### PR TITLE
Combine test and confirm

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1339,11 +1339,6 @@
       "count": 1
     }
   },
-  "packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx": {
     "local/no-alert-classname": {
       "count": 1

--- a/packages/front-end/components/Settings/BigQueryEventForwarderForm.tsx
+++ b/packages/front-end/components/Settings/BigQueryEventForwarderForm.tsx
@@ -1,65 +1,34 @@
 import { ChangeEventHandler, FC } from "react";
 import { Flex } from "@radix-ui/themes";
 import { DEFAULT_EVENT_FORWARDER_BIGQUERY_TABLE_NAME } from "shared/util";
-import { DataSourceParams } from "shared/types/datasource";
 import { BigQueryConnectionParams } from "shared/types/integrations/bigquery";
 import { EventForwarderConfigDraft } from "shared/types/event-forwarder";
 import Field from "@/components/Forms/Field";
-import Button from "@/components/Button";
-import Callout from "@/ui/Callout";
 import EventForwarderTableNameField from "./EventForwarderTableNameField";
-import { useEventForwarderAccessTest } from "./useEventForwarderAccessTest";
 
 const BigQueryEventForwarderForm: FC<{
   params: Partial<BigQueryConnectionParams>;
-  accessTestParams?: Partial<DataSourceParams>;
   eventForwarderConfig: EventForwarderConfigDraft;
-  existing: boolean;
   setParams?: (params: { [key: string]: string | boolean }) => void;
   setEventForwarderConfig: (
     eventForwarderConfig: EventForwarderConfigDraft | null,
   ) => void;
   onParamChange?: ChangeEventHandler<HTMLInputElement>;
-  datasourceId?: string;
-  projects?: string[];
-  eventForwarderAccessSignature: string;
-  setValidatedEventForwarderSignature?: (signature: string | null) => void;
   showDefaultDatasetField?: boolean;
   className?: string;
 }> = ({
   params,
-  accessTestParams,
   eventForwarderConfig,
-  existing,
   setParams,
   setEventForwarderConfig,
   onParamChange,
-  datasourceId,
-  projects,
-  eventForwarderAccessSignature,
-  setValidatedEventForwarderSignature,
   showDefaultDatasetField = false,
   className = "form-group col-md-12 mt-3 px-0",
 }) => {
   const bigQueryEventForwarderConfig =
     eventForwarderConfig.sinkType === "bigquery" ? eventForwarderConfig : null;
-  const { eventForwarderTestResult, testEventForwarderAccess } =
-    useEventForwarderAccessTest({
-      existing,
-      datasourceId,
-      type: "bigquery",
-      params: accessTestParams ?? params,
-      projects,
-      eventForwarderConfig: bigQueryEventForwarderConfig,
-      eventForwarderAccessSignature,
-      setValidatedEventForwarderSignature,
-    });
 
   if (!bigQueryEventForwarderConfig) return null;
-
-  const canTestEventForwarderAccess =
-    !!params.defaultDataset?.trim() &&
-    !!bigQueryEventForwarderConfig.config.tableName.trim();
 
   return (
     <Flex direction="column" gap="3" className={className}>
@@ -97,22 +66,6 @@ const BigQueryEventForwarderForm: FC<{
         tooltip="Defaults to gb_events. If that table already exists, GrowthBook will reuse it for the event forwarder."
         helpText="Letters, numbers, and underscores (Unicode allowed). Hyphens and spaces are normalized to underscores when saving."
       />
-      <div>
-        <Button
-          color="outline-primary"
-          disabled={!canTestEventForwarderAccess}
-          loadingClassName="btn-outline-primary disabled"
-          loadingCta="Testing access"
-          onClick={testEventForwarderAccess}
-        >
-          Test Write Access
-        </Button>
-      </div>
-      {eventForwarderTestResult ? (
-        <Callout status={eventForwarderTestResult.status} mt="0" mb="0">
-          {eventForwarderTestResult.message}
-        </Callout>
-      ) : null}
     </Flex>
   );
 };

--- a/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   DEFAULT_EVENT_FORWARDER_BIGQUERY_TABLE_NAME,
   DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME,
-  computeEventForwarderAccessSignature,
   stripLeadingUtf8ByteOrderMark,
 } from "shared/util";
 import {
@@ -17,15 +16,16 @@ import { BigQueryConnectionParams } from "shared/types/integrations/bigquery";
 import { SnowflakeConnectionParams } from "shared/types/integrations/snowflake";
 import { Box, Card, Flex } from "@radix-ui/themes";
 import { useAuth } from "@/services/auth";
-import Modal from "@/components/Modal";
 import BigQueryEventForwarderForm from "@/components/Settings/BigQueryEventForwarderForm";
 import SnowflakeEventForwarderForm from "@/components/Settings/SnowflakeEventForwarderForm";
+import { useEventForwarderAccessTest } from "@/components/Settings/useEventForwarderAccessTest";
 import Badge from "@/ui/Badge";
 import Button from "@/ui/Button";
 import Callout from "@/ui/Callout";
 import Checkbox from "@/ui/Checkbox";
 import Heading from "@/ui/Heading";
 import Text from "@/ui/Text";
+import Modal from "@/components/Modal";
 
 type Props = {
   dataSource: DataSourceInterfaceWithParams;
@@ -127,6 +127,35 @@ function getEventForwarderParamsForSubmit(
   } as Partial<DataSourceParams>;
 }
 
+function getCanConfirmEventForwarder(
+  draft: EventForwarderDatasourceDraft,
+): boolean {
+  const cfg = draft.eventForwarderConfig;
+  if (!cfg) return false;
+  const rawParams = draft.params || {};
+  if (cfg.sinkType === "bigquery") {
+    const p = rawParams as Partial<BigQueryConnectionParams>;
+    return !!p.defaultDataset?.trim() && !!cfg.config.tableName.trim();
+  }
+  if (cfg.sinkType === "snowflake") {
+    const p = rawParams as Partial<SnowflakeConnectionParams>;
+    const authMethod = p.authMethod ?? "password";
+    const hasSnowflakePrivateKey =
+      authMethod === "key-pair" || !!p.privateKey?.trim();
+    return (
+      !!cfg.config.tableName.trim() &&
+      !!cfg.config.accessUrl?.trim() &&
+      !!p.account?.trim() &&
+      !!p.username?.trim() &&
+      !!p.database?.trim() &&
+      !!p.schema?.trim() &&
+      authMethod === "key-pair" &&
+      hasSnowflakePrivateKey
+    );
+  }
+  return false;
+}
+
 function EventForwarderModal({
   dataSource,
   onCancel,
@@ -146,28 +175,8 @@ function EventForwarderModal({
       projects: dataSource.projects,
       eventForwarderConfig: getEventForwarderDraft(dataSource),
     }));
-  const [
-    validatedEventForwarderSignature,
-    setValidatedEventForwarderSignature,
-  ] = useState<string | null>(null);
   const [usEventForwarderFlowConsent, setUsEventForwarderFlowConsent] =
     useState(false);
-
-  const eventForwarderAccessSignature = computeEventForwarderAccessSignature(
-    datasourceDraft as Partial<DataSourceInterfaceWithParams>,
-  );
-  const eventForwarderSaveBlocked =
-    !!datasourceDraft.eventForwarderConfig &&
-    validatedEventForwarderSignature !== eventForwarderAccessSignature;
-
-  useEffect(() => {
-    if (
-      validatedEventForwarderSignature &&
-      validatedEventForwarderSignature !== eventForwarderAccessSignature
-    ) {
-      setValidatedEventForwarderSignature(null);
-    }
-  }, [eventForwarderAccessSignature, validatedEventForwarderSignature]);
 
   const setParams = (params: { [key: string]: string | boolean }) => {
     setDatasourceDraft((current) => ({
@@ -197,12 +206,27 @@ function EventForwarderModal({
     datasourceDraft,
   );
 
+  const accessTestParams =
+    eventForwarderParamsForSubmit ?? (params as Partial<DataSourceParams>);
+
+  const { testEventForwarderAccess } = useEventForwarderAccessTest({
+    existing: true,
+    datasourceId: dataSource.id,
+    type: datasourceDraft.type,
+    params: accessTestParams,
+    projects: dataSource.projects,
+    eventForwarderConfig,
+  });
+
+  const canConfirmEventForwarder = getCanConfirmEventForwarder(datasourceDraft);
+
   return (
     <Modal
       trackingEventModalType=""
       open={true}
       submit={async () => {
         if (!eventForwarderConfig) return;
+        await testEventForwarderAccess();
         await apiCall(`/datasource/${dataSource.id}/event-forwarder`, {
           method: "PUT",
           body: JSON.stringify({
@@ -218,34 +242,28 @@ function EventForwarderModal({
       header={modalTitle}
       cta="Confirm"
       size="md"
-      ctaEnabled={!eventForwarderSaveBlocked && usEventForwarderFlowConsent}
+      ctaEnabled={canConfirmEventForwarder && usEventForwarderFlowConsent}
       disabledMessage={
-        eventForwarderSaveBlocked
-          ? "Test Event Forwarder access before confirming."
+        !canConfirmEventForwarder
+          ? datasourceDraft.type === "bigquery"
+            ? "Enter a default dataset and table name before confirming."
+            : "Enter all required Snowflake fields before confirming."
           : !usEventForwarderFlowConsent
             ? "Acknowledge US data flow and authorization to use Confirm."
             : undefined
       }
     >
       <Callout status="info" mb="3">
-        Testing write access verifies GrowthBook can create tables in your
-        dataset. A temporary validation table is created and immediately
-        deleted.
+        Confirm runs a write test (create and delete a temporary validation
+        table), then saves your Event Forwarder configuration. If the test
+        fails, nothing is saved and the error is shown above.
       </Callout>
       {eventForwarderConfig?.sinkType === "bigquery" ? (
         <BigQueryEventForwarderForm
           params={params as Partial<BigQueryConnectionParams>}
-          accessTestParams={eventForwarderParamsForSubmit}
           eventForwarderConfig={eventForwarderConfig}
-          existing={true}
           setParams={setParams}
           setEventForwarderConfig={setEventForwarderConfig}
-          datasourceId={dataSource.id}
-          projects={dataSource.projects}
-          eventForwarderAccessSignature={eventForwarderAccessSignature}
-          setValidatedEventForwarderSignature={
-            setValidatedEventForwarderSignature
-          }
           showDefaultDatasetField
           className="form-group col-md-12 px-0"
         />
@@ -254,20 +272,7 @@ function EventForwarderModal({
         <SnowflakeEventForwarderForm
           params={params as Partial<SnowflakeConnectionParams>}
           eventForwarderConfig={eventForwarderConfig}
-          existing={true}
           setEventForwarderConfig={setEventForwarderConfig}
-          datasourceId={dataSource.id}
-          projects={dataSource.projects}
-          eventForwarderAccessSignature={eventForwarderAccessSignature}
-          setValidatedEventForwarderSignature={
-            setValidatedEventForwarderSignature
-          }
-          accessTestParams={undefined}
-          hasSnowflakePrivateKey={
-            (params as Partial<SnowflakeConnectionParams>).authMethod ===
-              "key-pair" ||
-            !!(params as Partial<SnowflakeConnectionParams>).privateKey?.trim()
-          }
         />
       ) : null}
       <Callout status="info" mx="2" mb="0" mt="3" icon={null}>

--- a/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
@@ -64,10 +64,7 @@ const statusColors: Record<
 };
 
 const EVENT_FORWARDER_MODAL_FAILURE_MESSAGE =
-  "Something went wrong. Update your settings and use Test write access to try again.";
-
-const EVENT_FORWARDER_STANDALONE_TEST_SUCCESS_MESSAGE =
-  "Write test succeeded. You can confirm to save.";
+  "Something went wrong. Update your settings and try again.";
 
 function getEventForwarderDraft(
   dataSource: DataSourceInterfaceWithParams,
@@ -217,9 +214,6 @@ function EventForwarderModal({
     }));
   const [usEventForwarderFlowConsent, setUsEventForwarderFlowConsent] =
     useState(false);
-  const [standaloneTestFeedback, setStandaloneTestFeedback] = useState<
-    null | "success" | "error"
-  >(null);
 
   const setParams = (params: { [key: string]: string | boolean }) => {
     setDatasourceDraft((current) => ({
@@ -263,17 +257,6 @@ function EventForwarderModal({
 
   const canConfirmEventForwarder = getCanConfirmEventForwarder(datasourceDraft);
 
-  const runStandaloneWriteTest = async () => {
-    if (!eventForwarderConfig || !canConfirmEventForwarder) return;
-    setStandaloneTestFeedback(null);
-    try {
-      await testEventForwarderAccess();
-      setStandaloneTestFeedback("success");
-    } catch {
-      setStandaloneTestFeedback("error");
-    }
-  };
-
   return (
     <Modal.Root
       open={true}
@@ -285,7 +268,6 @@ function EventForwarderModal({
     >
       <ModalForm
         onSubmit={async () => {
-          setStandaloneTestFeedback(null);
           if (!eventForwarderConfig) return;
           try {
             await testEventForwarderAccess();
@@ -309,23 +291,6 @@ function EventForwarderModal({
           <Modal.Title>{modalTitle}</Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          {standaloneTestFeedback === "success" ? (
-            <Callout status="success" mb="3">
-              {EVENT_FORWARDER_STANDALONE_TEST_SUCCESS_MESSAGE}
-            </Callout>
-          ) : null}
-          {standaloneTestFeedback === "error" ? (
-            <Callout status="error" mb="3">
-              {EVENT_FORWARDER_MODAL_FAILURE_MESSAGE}
-            </Callout>
-          ) : null}
-          <Callout status="info" mb="3">
-            Use <strong>Test write access</strong> to validate permissions
-            without saving. <strong>Confirm</strong> runs the same write test,
-            then saves your configuration. If something fails, nothing is saved
-            and a short message is shown above; adjust your settings and use
-            Test write access to try again.
-          </Callout>
           {eventForwarderConfig?.sinkType === "bigquery" ? (
             <BigQueryEventForwarderForm
               params={params as Partial<BigQueryConnectionParams>}
@@ -342,7 +307,7 @@ function EventForwarderModal({
               setEventForwarderConfig={setEventForwarderConfig}
             />
           ) : null}
-          <Callout status="info" mx="2" mb="0" mt="3" icon={null}>
+          <Callout status="info" mb="0" mt="3" icon={null}>
             <Checkbox
               value={usEventForwarderFlowConsent}
               setValue={setUsEventForwarderFlowConsent}
@@ -357,14 +322,6 @@ function EventForwarderModal({
               Cancel
             </Button>
           </Modal.Close>
-          <Button
-            type="button"
-            variant="outline"
-            disabled={!canConfirmEventForwarder}
-            onClick={runStandaloneWriteTest}
-          >
-            Test write access
-          </Button>
           <EventForwarderConfirmButton
             canConfirmEventForwarder={canConfirmEventForwarder}
             usEventForwarderFlowConsent={usEventForwarderFlowConsent}

--- a/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
@@ -25,7 +25,9 @@ import Callout from "@/ui/Callout";
 import Checkbox from "@/ui/Checkbox";
 import Heading from "@/ui/Heading";
 import Text from "@/ui/Text";
-import Modal from "@/components/Modal";
+import Tooltip from "@/components/Tooltip/Tooltip";
+import Modal from "@/ui/Modal";
+import ModalForm, { useModalForm } from "@/ui/Modal/ModalForm";
 
 type Props = {
   dataSource: DataSourceInterfaceWithParams;
@@ -60,6 +62,12 @@ const statusColors: Record<
   error: "red",
   schema_update_error: "red",
 };
+
+const EVENT_FORWARDER_MODAL_FAILURE_MESSAGE =
+  "Something went wrong. Update your settings and use Test write access to try again.";
+
+const EVENT_FORWARDER_STANDALONE_TEST_SUCCESS_MESSAGE =
+  "Write test succeeded. You can confirm to save.";
 
 function getEventForwarderDraft(
   dataSource: DataSourceInterfaceWithParams,
@@ -156,6 +164,38 @@ function getCanConfirmEventForwarder(
   return false;
 }
 
+function EventForwarderConfirmButton({
+  canConfirmEventForwarder,
+  usEventForwarderFlowConsent,
+  datasourceDraft,
+}: {
+  canConfirmEventForwarder: boolean;
+  usEventForwarderFlowConsent: boolean;
+  datasourceDraft: EventForwarderDatasourceDraft;
+}) {
+  const { loading } = useModalForm();
+  const ctaEnabled = canConfirmEventForwarder && usEventForwarderFlowConsent;
+  const disabledMessage = !canConfirmEventForwarder
+    ? datasourceDraft.type === "bigquery"
+      ? "Enter a default dataset and table name before confirming."
+      : "Enter all required Snowflake fields before confirming."
+    : !usEventForwarderFlowConsent
+      ? "Acknowledge US data flow and authorization to use Confirm."
+      : undefined;
+
+  return (
+    <Tooltip
+      body={disabledMessage || ""}
+      shouldDisplay={!ctaEnabled && !!disabledMessage}
+      tipPosition="top"
+    >
+      <Button type="submit" disabled={!ctaEnabled} loading={loading}>
+        Confirm
+      </Button>
+    </Tooltip>
+  );
+}
+
 function EventForwarderModal({
   dataSource,
   onCancel,
@@ -177,6 +217,9 @@ function EventForwarderModal({
     }));
   const [usEventForwarderFlowConsent, setUsEventForwarderFlowConsent] =
     useState(false);
+  const [standaloneTestFeedback, setStandaloneTestFeedback] = useState<
+    null | "success" | "error"
+  >(null);
 
   const setParams = (params: { [key: string]: string | boolean }) => {
     setDatasourceDraft((current) => ({
@@ -220,70 +263,116 @@ function EventForwarderModal({
 
   const canConfirmEventForwarder = getCanConfirmEventForwarder(datasourceDraft);
 
+  const runStandaloneWriteTest = async () => {
+    if (!eventForwarderConfig || !canConfirmEventForwarder) return;
+    setStandaloneTestFeedback(null);
+    try {
+      await testEventForwarderAccess();
+      setStandaloneTestFeedback("success");
+    } catch {
+      setStandaloneTestFeedback("error");
+    }
+  };
+
   return (
-    <Modal
-      trackingEventModalType=""
+    <Modal.Root
       open={true}
-      submit={async () => {
-        if (!eventForwarderConfig) return;
-        await testEventForwarderAccess();
-        await apiCall(`/datasource/${dataSource.id}/event-forwarder`, {
-          method: "PUT",
-          body: JSON.stringify({
-            eventForwarderConfig,
-            ...(eventForwarderParamsForSubmit
-              ? { params: eventForwarderParamsForSubmit }
-              : {}),
-          }),
-        });
-        await onRefresh();
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) onCancel();
       }}
-      close={onCancel}
-      header={modalTitle}
-      cta="Confirm"
       size="md"
-      ctaEnabled={canConfirmEventForwarder && usEventForwarderFlowConsent}
-      disabledMessage={
-        !canConfirmEventForwarder
-          ? datasourceDraft.type === "bigquery"
-            ? "Enter a default dataset and table name before confirming."
-            : "Enter all required Snowflake fields before confirming."
-          : !usEventForwarderFlowConsent
-            ? "Acknowledge US data flow and authorization to use Confirm."
-            : undefined
-      }
+      trackingEventModalType=""
     >
-      <Callout status="info" mb="3">
-        Confirm runs a write test (create and delete a temporary validation
-        table), then saves your Event Forwarder configuration. If the test
-        fails, nothing is saved and the error is shown above.
-      </Callout>
-      {eventForwarderConfig?.sinkType === "bigquery" ? (
-        <BigQueryEventForwarderForm
-          params={params as Partial<BigQueryConnectionParams>}
-          eventForwarderConfig={eventForwarderConfig}
-          setParams={setParams}
-          setEventForwarderConfig={setEventForwarderConfig}
-          showDefaultDatasetField
-          className="form-group col-md-12 px-0"
-        />
-      ) : null}
-      {eventForwarderConfig?.sinkType === "snowflake" ? (
-        <SnowflakeEventForwarderForm
-          params={params as Partial<SnowflakeConnectionParams>}
-          eventForwarderConfig={eventForwarderConfig}
-          setEventForwarderConfig={setEventForwarderConfig}
-        />
-      ) : null}
-      <Callout status="info" mx="2" mb="0" mt="3" icon={null}>
-        <Checkbox
-          value={usEventForwarderFlowConsent}
-          setValue={setUsEventForwarderFlowConsent}
-          label="I understand that event data will flow through GrowthBook's US servers and confirm I'm authorized to enable this for my organization."
-          weight="regular"
-        />
-      </Callout>
-    </Modal>
+      <ModalForm
+        onSubmit={async () => {
+          setStandaloneTestFeedback(null);
+          if (!eventForwarderConfig) return;
+          try {
+            await testEventForwarderAccess();
+            await apiCall(`/datasource/${dataSource.id}/event-forwarder`, {
+              method: "PUT",
+              body: JSON.stringify({
+                eventForwarderConfig,
+                ...(eventForwarderParamsForSubmit
+                  ? { params: eventForwarderParamsForSubmit }
+                  : {}),
+              }),
+            });
+            await onRefresh();
+            onCancel();
+          } catch {
+            throw new Error(EVENT_FORWARDER_MODAL_FAILURE_MESSAGE);
+          }
+        }}
+      >
+        <Modal.Header>
+          <Modal.Title>{modalTitle}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {standaloneTestFeedback === "success" ? (
+            <Callout status="success" mb="3">
+              {EVENT_FORWARDER_STANDALONE_TEST_SUCCESS_MESSAGE}
+            </Callout>
+          ) : null}
+          {standaloneTestFeedback === "error" ? (
+            <Callout status="error" mb="3">
+              {EVENT_FORWARDER_MODAL_FAILURE_MESSAGE}
+            </Callout>
+          ) : null}
+          <Callout status="info" mb="3">
+            Use <strong>Test write access</strong> to validate permissions
+            without saving. <strong>Confirm</strong> runs the same write test,
+            then saves your configuration. If something fails, nothing is saved
+            and a short message is shown above; adjust your settings and use
+            Test write access to try again.
+          </Callout>
+          {eventForwarderConfig?.sinkType === "bigquery" ? (
+            <BigQueryEventForwarderForm
+              params={params as Partial<BigQueryConnectionParams>}
+              eventForwarderConfig={eventForwarderConfig}
+              setParams={setParams}
+              setEventForwarderConfig={setEventForwarderConfig}
+              showDefaultDatasetField
+              className="form-group col-md-12 px-0"
+            />
+          ) : null}
+          {eventForwarderConfig?.sinkType === "snowflake" ? (
+            <SnowflakeEventForwarderForm
+              eventForwarderConfig={eventForwarderConfig}
+              setEventForwarderConfig={setEventForwarderConfig}
+            />
+          ) : null}
+          <Callout status="info" mx="2" mb="0" mt="3" icon={null}>
+            <Checkbox
+              value={usEventForwarderFlowConsent}
+              setValue={setUsEventForwarderFlowConsent}
+              label="I understand that event data will flow through GrowthBook's US servers and confirm I'm authorized to enable this for my organization."
+              weight="regular"
+            />
+          </Callout>
+        </Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button variant="ghost" onClick={onCancel}>
+              Cancel
+            </Button>
+          </Modal.Close>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={!canConfirmEventForwarder}
+            onClick={runStandaloneWriteTest}
+          >
+            Test write access
+          </Button>
+          <EventForwarderConfirmButton
+            canConfirmEventForwarder={canConfirmEventForwarder}
+            usEventForwarderFlowConsent={usEventForwarderFlowConsent}
+            datasourceDraft={datasourceDraft}
+          />
+        </Modal.Footer>
+      </ModalForm>
+    </Modal.Root>
   );
 }
 

--- a/packages/front-end/components/Settings/SnowflakeEventForwarderForm.tsx
+++ b/packages/front-end/components/Settings/SnowflakeEventForwarderForm.tsx
@@ -1,64 +1,18 @@
 import { FC } from "react";
 import { DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME } from "shared/util";
-import { DataSourceParams } from "shared/types/datasource";
-import { SnowflakeConnectionParams } from "shared/types/integrations/snowflake";
 import { EventForwarderConfigDraft } from "shared/types/event-forwarder";
-import Button from "@/components/Button";
-import Callout from "@/ui/Callout";
 import EventForwarderTableNameField from "./EventForwarderTableNameField";
-import { useEventForwarderAccessTest } from "./useEventForwarderAccessTest";
 
 const SnowflakeEventForwarderForm: FC<{
-  params: Partial<SnowflakeConnectionParams>;
-  accessTestParams?: Partial<DataSourceParams>;
   eventForwarderConfig: EventForwarderConfigDraft;
-  existing: boolean;
   setEventForwarderConfig: (
     eventForwarderConfig: EventForwarderConfigDraft | null,
   ) => void;
-  datasourceId?: string;
-  projects?: string[];
-  eventForwarderAccessSignature: string;
-  setValidatedEventForwarderSignature?: (signature: string | null) => void;
-  hasSnowflakePrivateKey: boolean;
-}> = ({
-  params,
-  accessTestParams,
-  eventForwarderConfig,
-  existing,
-  setEventForwarderConfig,
-  datasourceId,
-  projects,
-  eventForwarderAccessSignature,
-  setValidatedEventForwarderSignature,
-  hasSnowflakePrivateKey,
-}) => {
+}> = ({ eventForwarderConfig, setEventForwarderConfig }) => {
   const snowflakeEventForwarderConfig =
     eventForwarderConfig.sinkType === "snowflake" ? eventForwarderConfig : null;
-  const { eventForwarderTestResult, testEventForwarderAccess } =
-    useEventForwarderAccessTest({
-      existing,
-      datasourceId,
-      type: "snowflake",
-      params: accessTestParams ?? params,
-      projects,
-      eventForwarderConfig: snowflakeEventForwarderConfig,
-      eventForwarderAccessSignature,
-      setValidatedEventForwarderSignature,
-    });
 
   if (!snowflakeEventForwarderConfig) return null;
-
-  const authMethod = params.authMethod ?? "password";
-  const canTestEventForwarderAccess =
-    !!snowflakeEventForwarderConfig.config.tableName.trim() &&
-    !!snowflakeEventForwarderConfig.config.accessUrl?.trim() &&
-    !!params.account?.trim() &&
-    !!params.username?.trim() &&
-    !!params.database?.trim() &&
-    !!params.schema?.trim() &&
-    authMethod === "key-pair" &&
-    hasSnowflakePrivateKey;
 
   return (
     <>
@@ -97,24 +51,6 @@ const SnowflakeEventForwarderForm: FC<{
           subTitle="Letters, numbers, underscores, and dollar signs. Hyphens and spaces are normalized to underscores when saving."
         />
       </div>
-      <div className="form-group col-md-12">
-        <Button
-          color="outline-primary"
-          disabled={!canTestEventForwarderAccess}
-          loadingClassName="btn-outline-primary disabled"
-          loadingCta="Testing access"
-          onClick={testEventForwarderAccess}
-        >
-          Test Write Access
-        </Button>
-      </div>
-      {eventForwarderTestResult ? (
-        <div className="form-group col-md-12">
-          <Callout status={eventForwarderTestResult.status} mt="0" mb="0">
-            {eventForwarderTestResult.message}
-          </Callout>
-        </div>
-      ) : null}
     </>
   );
 };

--- a/packages/front-end/components/Settings/useEventForwarderAccessTest.ts
+++ b/packages/front-end/components/Settings/useEventForwarderAccessTest.ts
@@ -1,13 +1,7 @@
-import { useState } from "react";
 import { DataSourceParams, DataSourceType } from "shared/types/datasource";
 import { EventForwarderConfigDraft } from "shared/types/event-forwarder";
 import { EventForwarderAccessTestResponse } from "shared/validators";
 import { useAuth } from "@/services/auth";
-
-export type EventForwarderAccessTestResult = {
-  status: "success" | "error";
-  message: string;
-};
 
 export function useEventForwarderAccessTest({
   existing,
@@ -16,8 +10,6 @@ export function useEventForwarderAccessTest({
   params,
   projects,
   eventForwarderConfig,
-  eventForwarderAccessSignature,
-  setValidatedEventForwarderSignature,
 }: {
   existing: boolean;
   datasourceId?: string;
@@ -25,18 +17,12 @@ export function useEventForwarderAccessTest({
   params?: Partial<DataSourceParams>;
   projects?: string[];
   eventForwarderConfig: EventForwarderConfigDraft | null;
-  eventForwarderAccessSignature: string;
-  setValidatedEventForwarderSignature?: (signature: string | null) => void;
 }) {
   const { apiCall } = useAuth();
-  const [eventForwarderTestResult, setEventForwarderTestResult] =
-    useState<EventForwarderAccessTestResult | null>(null);
 
   async function testEventForwarderAccess() {
     if (!eventForwarderConfig) return;
 
-    setEventForwarderTestResult(null);
-    setValidatedEventForwarderSignature?.(null);
     const endpoint =
       existing && datasourceId
         ? `/datasource/${datasourceId}/event-forwarder/test-access`
@@ -60,24 +46,12 @@ export function useEventForwarderAccessTest({
     });
     const sinkWrite = response.results.sinkWrite;
     if (sinkWrite.result === "success") {
-      setValidatedEventForwarderSignature?.(eventForwarderAccessSignature);
-      setEventForwarderTestResult({
-        status: "success",
-        message:
-          "Event Forwarder table creation access verified. GrowthBook created and deleted a temporary validation table.",
-      });
-    } else {
-      setEventForwarderTestResult({
-        status: "error",
-        message:
-          sinkWrite.resultMessage ||
-          "Event Forwarder table creation access failed.",
-      });
+      return;
     }
+    throw new Error(sinkWrite.resultMessage || "Write test permission denied.");
   }
 
   return {
-    eventForwarderTestResult,
     testEventForwarderAccess,
   };
 }


### PR DESCRIPTION
### Features and Changes
- Test Write access and confirm should be the same button
- Unless the test failed, THEN we allow them to run the test independently

- Closes **[Combine Test Write access and confirm](https://www.notion.so/growthbook/Event-Forwarder-345a857e74a080a888c8de6d150a518d?source=copy_link#359a857e74a08003b2f5c1d59210ea71)**

### Testing
- Setup Data source
- Provide the information for the Event Forwarder
- Click Confirm. If it's accurate it will automatically connect
- If it failed, it will show an error with a retry button.

### Screenshots
<img width="561" height="689" alt="Screenshot 2026-05-10 at 4 44 34 PM" src="https://github.com/user-attachments/assets/24cd8449-7c6d-4b63-bc3b-49bbb48aea70" />

<img width="544" height="635" alt="Screenshot 2026-05-10 at 5 23 54 PM" src="https://github.com/user-attachments/assets/db468cf6-e7af-4e34-8e24-d4c80d2b620d" />
