### PR TITLE
Fix bugs in new top values queries

### DIFF
--- a/packages/back-end/src/integrations/dialects/clickhouse.ts
+++ b/packages/back-end/src/integrations/dialects/clickhouse.ts
@@ -67,15 +67,17 @@ if(
       metricTable,
       where,
     ),
+  // Use binding names distinct from the outer SELECT aliases (column_name,
+  // value) to avoid ClickHouse's "Duplicate alias in ARRAY JOIN" error.
   unpivotLabeledPairs: (pairs) => {
     const namesArr = pairs.map((p) => `'${p.keyLiteral}'`).join(", ");
     const valsArr = pairs.map((p) => p.valueSql).join(", ");
     return {
       fromContinuation: `ARRAY JOIN
-        [${namesArr}] AS column_name,
-        [${valsArr}] AS value`,
-      keyExpr: "column_name",
-      valueExpr: "value",
+        [${namesArr}] AS __col_name,
+        [${valsArr}] AS __col_value`,
+      keyExpr: "__col_name",
+      valueExpr: "__col_value",
     };
   },
 

--- a/packages/back-end/src/integrations/dialects/databricks.ts
+++ b/packages/back-end/src/integrations/dialects/databricks.ts
@@ -60,6 +60,9 @@ export const databricksDialect: SqlDialect = {
       where,
     ),
 
+  // Qualify the STACK outputs with the __col table alias so they don't become
+  // ambiguous if the fact table also projects a column named `column_name` or
+  // `value` (the latter is common for metric/event value columns).
   unpivotLabeledPairs: (pairs) => {
     const stackPairs = pairs
       .map((p) => `'${p.keyLiteral}', ${p.valueSql}`)
@@ -68,8 +71,8 @@ export const databricksDialect: SqlDialect = {
       fromContinuation: `LATERAL VIEW STACK(${pairs.length},
         ${stackPairs}
       ) __col AS column_name, value`,
-      keyExpr: "column_name",
-      valueExpr: "value",
+      keyExpr: "__col.column_name",
+      valueExpr: "__col.value",
     };
   },
 };

--- a/packages/back-end/src/integrations/dialects/redshift.ts
+++ b/packages/back-end/src/integrations/dialects/redshift.ts
@@ -43,15 +43,19 @@ export const redshiftDialect: SqlDialect = {
           .join(",\n        ")}
       `,
 
-  // Single-scan unpivot (Redshift 1.0.14631+ LATERAL + VALUES, PostgreSQL-style).
+  // Redshift LATERAL only supports SELECT subqueries (not VALUES), so we emit
+  // a UNION ALL chain.
   unpivotLabeledPairs: (pairs) => {
-    const valueRows = pairs
-      .map((p) => `('${p.keyLiteral}', ${p.valueSql})`)
-      .join(", ");
+    const first = `SELECT '${pairs[0].keyLiteral}' AS column_name, ${pairs[0].valueSql} AS value`;
+    const rest = pairs
+      .slice(1)
+      .map((p) => `UNION ALL SELECT '${p.keyLiteral}', ${p.valueSql}`)
+      .join(" ");
     return {
       fromContinuation: `CROSS JOIN LATERAL (
-        VALUES ${valueRows}
-      ) AS __col(column_name, value)`,
+        ${first}
+        ${pairs.length > 1 ? `\n${rest}` : ""}
+      ) AS __col`,
       keyExpr: "__col.column_name",
       valueExpr: "__col.value",
     };

--- a/packages/back-end/src/integrations/dialects/snowflake.ts
+++ b/packages/back-end/src/integrations/dialects/snowflake.ts
@@ -53,17 +53,23 @@ export const snowflakeDialect: SqlDialect = {
       where,
     ),
 
+  // LATERAL FLATTEN(input => ARRAY_CONSTRUCT(OBJECT_CONSTRUCT(...))) doesn't
+  // reliably correlate the column references back to the outer table in
+  // Snowflake, producing "invalid identifier" errors at runtime. Use a plain
+  // LATERAL inline view with a UNION ALL chain instead.
   unpivotLabeledPairs: (pairs) => {
-    const objects = pairs
-      .map(
-        (p) =>
-          `OBJECT_CONSTRUCT('column_name', '${p.keyLiteral}', 'value', ${p.valueSql})`,
-      )
-      .join(", ");
+    const first = `SELECT '${pairs[0].keyLiteral}' AS column_name, ${pairs[0].valueSql} AS value`;
+    const rest = pairs
+      .slice(1)
+      .map((p) => `UNION ALL SELECT '${p.keyLiteral}', ${p.valueSql}`)
+      .join(" ");
     return {
-      fromContinuation: `,\n LATERAL FLATTEN(input => ARRAY_CONSTRUCT(${objects})) __col`,
-      keyExpr: "__col.value:column_name::VARCHAR",
-      valueExpr: "__col.value:value::VARCHAR",
+      fromContinuation: `, LATERAL (
+        ${first}
+        ${pairs.length > 1 ? `\n${rest}` : ""}
+      ) __col`,
+      keyExpr: "__col.column_name",
+      valueExpr: "__col.value",
     };
   },
 };

--- a/packages/back-end/src/integrations/dialects/vertica.ts
+++ b/packages/back-end/src/integrations/dialects/vertica.ts
@@ -25,14 +25,19 @@ export const verticaDialect: SqlDialect = {
       where,
     ),
 
+  // Vertica's FROM clause only accepts relations and subqueries, not a bare
+  // VALUES list, so we emit a UNION ALL chain inside the LATERAL subquery.
   unpivotLabeledPairs: (pairs) => {
-    const valueRows = pairs
-      .map((p) => `('${p.keyLiteral}', ${p.valueSql})`)
-      .join(", ");
+    const first = `SELECT '${pairs[0].keyLiteral}' AS column_name, ${pairs[0].valueSql} AS value`;
+    const rest = pairs
+      .slice(1)
+      .map((p) => `UNION ALL SELECT '${p.keyLiteral}', ${p.valueSql}`)
+      .join(" ");
     return {
       fromContinuation: `CROSS JOIN LATERAL (
-        VALUES ${valueRows}
-      ) AS __col(column_name, value)`,
+        ${first}
+        ${pairs.length > 1 ? `\n${rest}` : ""}
+      ) AS __col`,
       keyExpr: "__col.column_name",
       valueExpr: "__col.value",
     };


### PR DESCRIPTION
### Features and Changes

After merging #5720 , several dialect-specific bugs were identified in production when run against real customer tables.  Testing these queries in real-life conditions is difficult, so this was not unexpected.

This PR fixes several dialect-specific bugs:
- ClickHouse and Databricks had ambiguous column references
- Redshift, Vertica, and Snowflake all had issues constructing objects during the lateral join. Switching to a simpler UNION ALL approach instead