### PR TITLE
Another fix for top value queries on Redshift, Snowflake, Vertica

### DIFF
--- a/packages/back-end/src/integrations/dialects/redshift.ts
+++ b/packages/back-end/src/integrations/dialects/redshift.ts
@@ -1,4 +1,5 @@
 import type { SqlDialect } from "shared/types/sql";
+import { indicesTableUnpivot } from "back-end/src/integrations/sql/clauses/indices-table-unpivot";
 import { baseDialect } from "./base";
 
 export const redshiftDialect: SqlDialect = {
@@ -43,21 +44,8 @@ export const redshiftDialect: SqlDialect = {
           .join(",\n        ")}
       `,
 
-  // Redshift LATERAL only supports SELECT subqueries (not VALUES), so we emit
-  // a UNION ALL chain.
-  unpivotLabeledPairs: (pairs) => {
-    const first = `SELECT '${pairs[0].keyLiteral}' AS column_name, ${pairs[0].valueSql} AS value`;
-    const rest = pairs
-      .slice(1)
-      .map((p) => `UNION ALL SELECT '${p.keyLiteral}', ${p.valueSql}`)
-      .join(" ");
-    return {
-      fromContinuation: `CROSS JOIN LATERAL (
-        ${first}
-        ${pairs.length > 1 ? `\n${rest}` : ""}
-      ) AS __col`,
-      keyExpr: "__col.column_name",
-      valueExpr: "__col.value",
-    };
-  },
+  // Redshift's LATERAL keyword only applies to nested SUPER data, not regular
+  // relational subqueries — both `CROSS JOIN LATERAL (VALUES ...)` and
+  // `CROSS JOIN LATERAL (SELECT ... UNION ALL ...)` are syntax errors.
+  unpivotLabeledPairs: indicesTableUnpivot,
 };

--- a/packages/back-end/src/integrations/dialects/snowflake.ts
+++ b/packages/back-end/src/integrations/dialects/snowflake.ts
@@ -1,6 +1,7 @@
 import type { DataType } from "shared/types/integrations";
 import type { SqlDialect } from "shared/types/sql";
 import { defaultPercentileCapSelectClause } from "back-end/src/integrations/sql/clauses/percentile-cap-select-clause";
+import { indicesTableUnpivot } from "back-end/src/integrations/sql/clauses/indices-table-unpivot";
 import { baseDialect } from "./base";
 
 export const snowflakeDialect: SqlDialect = {
@@ -53,23 +54,12 @@ export const snowflakeDialect: SqlDialect = {
       where,
     ),
 
-  // LATERAL FLATTEN(input => ARRAY_CONSTRUCT(OBJECT_CONSTRUCT(...))) doesn't
-  // reliably correlate the column references back to the outer table in
-  // Snowflake, producing "invalid identifier" errors at runtime. Use a plain
-  // LATERAL inline view with a UNION ALL chain instead.
-  unpivotLabeledPairs: (pairs) => {
-    const first = `SELECT '${pairs[0].keyLiteral}' AS column_name, ${pairs[0].valueSql} AS value`;
-    const rest = pairs
-      .slice(1)
-      .map((p) => `UNION ALL SELECT '${p.keyLiteral}', ${p.valueSql}`)
-      .join(" ");
-    return {
-      fromContinuation: `, LATERAL (
-        ${first}
-        ${pairs.length > 1 ? `\n${rest}` : ""}
-      ) __col`,
-      keyExpr: "__col.column_name",
-      valueExpr: "__col.value",
-    };
-  },
+  // Two LATERAL patterns have failed on Snowflake:
+  //   - LATERAL FLATTEN(input => ARRAY_CONSTRUCT(OBJECT_CONSTRUCT(...))) does
+  //     not reliably correlate column refs inside the constructed array
+  //     ("invalid identifier" at runtime).
+  //   - LATERAL (SELECT ... UNION ALL ...) is rejected as an "Unsupported
+  //     subquery type" because Snowflake's correlated subqueries can't contain
+  //     set operations.
+  unpivotLabeledPairs: indicesTableUnpivot,
 };

--- a/packages/back-end/src/integrations/dialects/vertica.ts
+++ b/packages/back-end/src/integrations/dialects/vertica.ts
@@ -1,5 +1,6 @@
 import type { SqlDialect } from "shared/types/sql";
 import { defaultPercentileCapSelectClause } from "back-end/src/integrations/sql/clauses/percentile-cap-select-clause";
+import { indicesTableUnpivot } from "back-end/src/integrations/sql/clauses/indices-table-unpivot";
 import { baseDialect } from "./base";
 
 export const verticaDialect: SqlDialect = {
@@ -25,21 +26,7 @@ export const verticaDialect: SqlDialect = {
       where,
     ),
 
-  // Vertica's FROM clause only accepts relations and subqueries, not a bare
-  // VALUES list, so we emit a UNION ALL chain inside the LATERAL subquery.
-  unpivotLabeledPairs: (pairs) => {
-    const first = `SELECT '${pairs[0].keyLiteral}' AS column_name, ${pairs[0].valueSql} AS value`;
-    const rest = pairs
-      .slice(1)
-      .map((p) => `UNION ALL SELECT '${p.keyLiteral}', ${p.valueSql}`)
-      .join(" ");
-    return {
-      fromContinuation: `CROSS JOIN LATERAL (
-        ${first}
-        ${pairs.length > 1 ? `\n${rest}` : ""}
-      ) AS __col`,
-      keyExpr: "__col.column_name",
-      valueExpr: "__col.value",
-    };
-  },
+  // Vertica's FROM clause rejects bare VALUES, and LATERAL derived tables are
+  // restricted to a single SELECT (no UNION).
+  unpivotLabeledPairs: indicesTableUnpivot,
 };

--- a/packages/back-end/src/integrations/sql/clauses/indices-table-unpivot.ts
+++ b/packages/back-end/src/integrations/sql/clauses/indices-table-unpivot.ts
@@ -1,0 +1,31 @@
+import type {
+  UnpivotLabeledPair,
+  UnpivotLabeledPairsResult,
+} from "shared/types/sql";
+
+// Builds an unpivot clause that uses a plain CROSS JOIN against a small inline
+// indices relation and resolves column_name/value through CASE on the index.
+// Used by dialects whose LATERAL implementation can't carry the standard
+// pattern (Redshift's LATERAL is SUPER-only, Snowflake rejects UNION ALL in
+// correlated subqueries, Vertica restricts LATERAL to a single SELECT).
+//
+// __factTable is still scanned once; each row is multiplied by the number of
+// columns being unpivoted.
+export function indicesTableUnpivot(
+  pairs: UnpivotLabeledPair[],
+): UnpivotLabeledPairsResult {
+  const indices = pairs
+    .map((_p, i) => (i === 0 ? `SELECT 1 AS __col_idx` : `SELECT ${i + 1}`))
+    .join(" UNION ALL ");
+  const keyCase = `CASE __col.__col_idx ${pairs
+    .map((p, i) => `WHEN ${i + 1} THEN '${p.keyLiteral}'`)
+    .join(" ")} END`;
+  const valueCase = `CASE __col.__col_idx ${pairs
+    .map((p, i) => `WHEN ${i + 1} THEN ${p.valueSql}`)
+    .join(" ")} END`;
+  return {
+    fromContinuation: `CROSS JOIN (${indices}) __col`,
+    keyExpr: keyCase,
+    valueExpr: valueCase,
+  };
+}

--- a/packages/back-end/src/integrations/sql/queries/columns-top-values-query.ts
+++ b/packages/back-end/src/integrations/sql/queries/columns-top-values-query.ts
@@ -73,17 +73,24 @@ function getTopValuesCTEBody(
 
   const lengthFilter =
     maxValueLength !== undefined
-      ? `AND ${dialect.stringLength(u.valueExpr)} <= ${maxValueLength}`
+      ? `AND ${dialect.stringLength("value")} <= ${maxValueLength}`
       : "";
 
+  // Materialize the unpivoted (column_name, value) once in an inner subquery so
+  // keyExpr/valueExpr are only embedded one time. Some dialects (Redshift,
+  // Snowflake) resolve these via large CASE expressions, and repeating those
+  // across SELECT/WHERE/GROUP BY would balloon the SQL.
   const aggQuery = `
-      SELECT ${u.keyExpr} AS column_name, ${u.valueExpr} AS value, COUNT(*) AS count
-      FROM __factTable
-      ${u.fromContinuation}
-      WHERE timestamp >= ${dialect.toTimestamp(start)}
-        AND ${u.valueExpr} IS NOT NULL
+      SELECT column_name, value, COUNT(*) AS count
+      FROM (
+        SELECT ${u.keyExpr} AS column_name, ${u.valueExpr} AS value
+        FROM __factTable
+        ${u.fromContinuation}
+        WHERE timestamp >= ${dialect.toTimestamp(start)}
+      ) __unpivot
+      WHERE value IS NOT NULL
         ${lengthFilter}
-      GROUP BY ${u.keyExpr}, ${u.valueExpr}`;
+      GROUP BY column_name, value`;
 
   // Wraps an aggregation query shaped like (column_name, value, count) and
   // returns the top `limit` values per column. Shared across all efficient


### PR DESCRIPTION
### Features and Changes

The new top values query was still throwing errors on a few SQL dialects.

Changes:

- New helper indices-table-unpivot.ts — emits a plain CROSS JOIN against a small inline SELECT 1 AS __col_idx UNION ALL SELECT 2 ... relation, then resolves column_name/value through CASE __col.__col_idx WHEN .... Uses only basic SQL — no LATERAL, no correlated set operations, no constructed-array correlation. Still a single scan of __factTable.
Redshift, Snowflake, Vertica now use this helper.
- columns-top-values-query restructured to materialize keyExpr/valueExpr once in an inner subquery, then aggregate. Previously they were embedded 5 times (SELECT, WHERE × 2, GROUP BY × 2) — with CASE expressions over 50 columns that would have bloated the SQL by ~9KB.