### PR TITLE
Fix metric drilldown modal not refreshing with dimension breakdowns in reports

### DIFF
--- a/packages/front-end/components/Experiment/ExperimentResultTooltipContent/ExperimentResultTooltipContent.tsx
+++ b/packages/front-end/components/Experiment/ExperimentResultTooltipContent/ExperimentResultTooltipContent.tsx
@@ -166,7 +166,8 @@ export default function ExperimentResultTooltipContent({
     if (resultsStatus !== "draw" || minPercentChange === undefined) return null;
     return (
       <Text as="div" size="1" style={{ color: "var(--color-text-mid)" }}>
-        <b>Draw:</b> this occurs when the % Change is smaller than the
+        <b>Draw:</b>
+        {" this occurs when the % Change is smaller than the "}
         metric&apos;s min change ({percentFormatter.format(minPercentChange)})
       </Text>
     );
@@ -176,7 +177,8 @@ export default function ExperimentResultTooltipContent({
     if (!suspiciousChange) return null;
     return (
       <Text as="div" size="1" style={{ color: "var(--color-text-mid)" }}>
-        <b>Suspicious:</b> this occurs when the % Change is above the
+        <b>Suspicious:</b>
+        {" this occurs when the % Change is above the "}
         metric&apos;s max change ({percentFormatter.format(suspiciousThreshold)}
         )
       </Text>

--- a/packages/front-end/components/Experiment/SnapshotProvider.tsx
+++ b/packages/front-end/components/Experiment/SnapshotProvider.tsx
@@ -182,22 +182,24 @@ export function LocalSnapshotProvider({
       validParentSettings ?? defaultAnalysisSettings,
     );
 
+  // Refresh by snapshot id (not by experiment+phase) so this works for both
+  // experiments and reports. Reports have their own specific snapshot which
+  // may differ from the experiment's current latest snapshot, and we want to
+  // pick up newly-added analyses on this exact snapshot.
+  const snapshotId = localSnapshot.id;
   const mutateSnapshot = useCallback(async () => {
     setLoading(true);
     try {
       const response = await apiCall<{
         snapshot: ExperimentSnapshotInterface;
-      }>(
-        `/experiment/${experiment.id}/snapshot/${phase}` +
-          (dimension ? "/" + dimension : ""),
-      );
+      }>(`/snapshot/${snapshotId}`);
       if (response.snapshot) {
         setLocalSnapshot(response.snapshot);
       }
     } finally {
       setLoading(false);
     }
-  }, [apiCall, experiment.id, phase, dimension]);
+  }, [apiCall, snapshotId]);
 
   // Compute analysis from local snapshot + local settings
   const analysis = localSnapshot

--- a/packages/front-end/components/Experiment/SnapshotProvider.tsx
+++ b/packages/front-end/components/Experiment/SnapshotProvider.tsx
@@ -140,7 +140,7 @@ export function useSnapshot() {
 }
 
 export interface LocalSnapshotProviderProps {
-  experiment: ExperimentInterfaceStringDates;
+  experiment?: ExperimentInterfaceStringDates;
   snapshot: ExperimentSnapshotInterface;
   phase: number;
   dimension: string;

--- a/packages/front-end/components/MetricDrilldown/MetricDrilldownContext.tsx
+++ b/packages/front-end/components/MetricDrilldown/MetricDrilldownContext.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useCallback, useMemo, FC, ReactNode } from "react";
 import {
-  ExperimentInterfaceStringDates,
   ExperimentStatus,
   LookbackOverride,
   MetricOverride,
@@ -81,11 +80,10 @@ export interface MetricDrilldownProviderProps {
   // When true, timeseries is unavailable and a message is shown instead
   isReportContext?: boolean;
 
-  // Optional snapshot and experiment for report context (no parent SnapshotProvider)
-  // These are used to create a LocalSnapshotProvider in the modal
+  // Snapshot for report context (no parent SnapshotProvider).
+  // When provided, a LocalSnapshotProvider is created in the modal so it can
+  // refresh when baseline/difference settings change.
   snapshot?: ExperimentSnapshotInterface;
-  experiment?: ExperimentInterfaceStringDates;
-  dimension?: string;
 }
 
 interface OpenModalInfo {
@@ -126,8 +124,6 @@ export const MetricDrilldownProvider: FC<MetricDrilldownProviderProps> = ({
   ssrPolyfills,
   isReportContext,
   snapshot,
-  experiment,
-  dimension,
 }) => {
   const [openModalInfo, setOpenModalInfo] = useState<OpenModalInfo | null>(
     null,
@@ -232,8 +228,6 @@ export const MetricDrilldownProvider: FC<MetricDrilldownProviderProps> = ({
           ssrPolyfills={ssrPolyfills}
           isReportContext={isReportContext}
           snapshot={snapshot}
-          experiment={experiment}
-          dimension={dimension}
         />
       )}
     </MetricDrilldownContext.Provider>

--- a/packages/front-end/components/MetricDrilldown/MetricDrilldownContext.tsx
+++ b/packages/front-end/components/MetricDrilldown/MetricDrilldownContext.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useMemo, FC, ReactNode } from "react";
 import {
+  ExperimentInterfaceStringDates,
   ExperimentStatus,
   LookbackOverride,
   MetricOverride,
@@ -8,7 +9,10 @@ import {
   ExperimentReportVariation,
   MetricSnapshotSettings,
 } from "shared/types/report";
-import { ExperimentSnapshotAnalysis } from "shared/types/experiment-snapshot";
+import {
+  ExperimentSnapshotAnalysis,
+  ExperimentSnapshotInterface,
+} from "shared/types/experiment-snapshot";
 import {
   DifferenceType,
   PValueCorrection,
@@ -76,6 +80,12 @@ export interface MetricDrilldownProviderProps {
 
   // When true, timeseries is unavailable and a message is shown instead
   isReportContext?: boolean;
+
+  // Optional snapshot and experiment for report context (no parent SnapshotProvider)
+  // These are used to create a LocalSnapshotProvider in the modal
+  snapshot?: ExperimentSnapshotInterface;
+  experiment?: ExperimentInterfaceStringDates;
+  dimension?: string;
 }
 
 interface OpenModalInfo {
@@ -115,6 +125,9 @@ export const MetricDrilldownProvider: FC<MetricDrilldownProviderProps> = ({
   sortDirection,
   ssrPolyfills,
   isReportContext,
+  snapshot,
+  experiment,
+  dimension,
 }) => {
   const [openModalInfo, setOpenModalInfo] = useState<OpenModalInfo | null>(
     null,
@@ -218,6 +231,9 @@ export const MetricDrilldownProvider: FC<MetricDrilldownProviderProps> = ({
           lookbackOverride={lookbackOverride}
           ssrPolyfills={ssrPolyfills}
           isReportContext={isReportContext}
+          snapshot={snapshot}
+          experiment={experiment}
+          dimension={dimension}
         />
       )}
     </MetricDrilldownContext.Provider>

--- a/packages/front-end/components/MetricDrilldown/MetricDrilldownModal.tsx
+++ b/packages/front-end/components/MetricDrilldown/MetricDrilldownModal.tsx
@@ -480,6 +480,8 @@ const MetricDrilldownModal = ({
   const effectiveSnapshot = parentSnapshot ?? snapshotProp;
   const effectiveExperiment = contextExperiment ?? experimentProp;
   const effectiveDimension = contextDimension ?? dimensionProp ?? "";
+  // Use contextPhase from snapshot context when available, otherwise use phase prop
+  const effectivePhase = parentSnapshot ? contextPhase : phase;
 
   const isReportContext = isReportContextProp ?? false;
 
@@ -621,7 +623,7 @@ const MetricDrilldownModal = ({
             <LocalSnapshotProvider
               experiment={effectiveExperiment}
               snapshot={effectiveSnapshot}
-              phase={contextPhase}
+              phase={effectivePhase}
               dimension={effectiveDimension}
               initialAnalysisSettings={parentAnalysisSettings}
             >

--- a/packages/front-end/components/MetricDrilldown/MetricDrilldownModal.tsx
+++ b/packages/front-end/components/MetricDrilldown/MetricDrilldownModal.tsx
@@ -14,7 +14,6 @@ import {
   StatsEngine,
 } from "shared/types/stats";
 import {
-  ExperimentInterfaceStringDates,
   ExperimentStatus,
   LookbackOverride,
   MetricOverride,
@@ -107,11 +106,10 @@ interface MetricDrilldownModalProps {
   // When true, timeseries is unavailable and a message is shown instead
   isReportContext?: boolean;
 
-  // Optional snapshot and experiment for report context (no parent SnapshotProvider)
-  // These are used to create a LocalSnapshotProvider when parent context is empty
+  // Snapshot for report context (no parent SnapshotProvider).
+  // When provided, a LocalSnapshotProvider is created so the modal can refresh
+  // when baseline/difference settings change.
   snapshot?: ExperimentSnapshotInterface;
-  experiment?: ExperimentInterfaceStringDates;
-  dimension?: string;
 }
 
 /**
@@ -453,10 +451,8 @@ const MetricDrilldownModal = ({
   dimensionInfo,
   // Report context
   isReportContext: isReportContextProp,
-  // Optional snapshot and experiment for report context
+  // Snapshot for report context (no parent SnapshotProvider)
   snapshot: snapshotProp,
-  experiment: experimentProp,
-  dimension: dimensionProp,
 }: MetricDrilldownModalProps) => {
   useBodyScrollLock(true);
   const { metric } = row;
@@ -470,7 +466,6 @@ const MetricDrilldownModal = ({
   // Get snapshot from global snapshot context, to initialize LocalSnapshotProvider
   const {
     snapshot: parentSnapshot,
-    experiment: contextExperiment,
     phase: contextPhase,
     dimension: contextDimension,
     analysisSettings: parentAnalysisSettings,
@@ -478,8 +473,9 @@ const MetricDrilldownModal = ({
 
   // Use prop values when parent context is empty (report context)
   const effectiveSnapshot = parentSnapshot ?? snapshotProp;
-  const effectiveExperiment = contextExperiment ?? experimentProp;
-  const effectiveDimension = contextDimension ?? dimensionProp ?? "";
+  // Prefer the context dimension, then fall back to the snapshot's own dimension
+  const effectiveDimension =
+    contextDimension || effectiveSnapshot?.dimension || "";
   // Use contextPhase from snapshot context when available, otherwise use phase prop
   const effectivePhase = parentSnapshot ? contextPhase : phase;
 
@@ -619,9 +615,8 @@ const MetricDrilldownModal = ({
         autoFocusSelector=""
       >
         <MetricDrilldownContext.Provider value={null}>
-          {effectiveSnapshot && effectiveExperiment ? (
+          {effectiveSnapshot ? (
             <LocalSnapshotProvider
-              experiment={effectiveExperiment}
               snapshot={effectiveSnapshot}
               phase={effectivePhase}
               dimension={effectiveDimension}

--- a/packages/front-end/components/MetricDrilldown/MetricDrilldownModal.tsx
+++ b/packages/front-end/components/MetricDrilldown/MetricDrilldownModal.tsx
@@ -466,6 +466,7 @@ const MetricDrilldownModal = ({
   // Get snapshot from global snapshot context, to initialize LocalSnapshotProvider
   const {
     snapshot: parentSnapshot,
+    experiment,
     phase: contextPhase,
     dimension: contextDimension,
     analysisSettings: parentAnalysisSettings,
@@ -617,6 +618,7 @@ const MetricDrilldownModal = ({
         <MetricDrilldownContext.Provider value={null}>
           {effectiveSnapshot ? (
             <LocalSnapshotProvider
+              experiment={experiment}
               snapshot={effectiveSnapshot}
               phase={effectivePhase}
               dimension={effectiveDimension}

--- a/packages/front-end/components/MetricDrilldown/MetricDrilldownModal.tsx
+++ b/packages/front-end/components/MetricDrilldown/MetricDrilldownModal.tsx
@@ -14,10 +14,12 @@ import {
   StatsEngine,
 } from "shared/types/stats";
 import {
+  ExperimentInterfaceStringDates,
   ExperimentStatus,
   LookbackOverride,
   MetricOverride,
 } from "shared/types/experiment";
+import { ExperimentSnapshotInterface } from "shared/types/experiment-snapshot";
 import {
   ExperimentReportResultDimension,
   ExperimentReportVariation,
@@ -104,6 +106,12 @@ interface MetricDrilldownModalProps {
 
   // When true, timeseries is unavailable and a message is shown instead
   isReportContext?: boolean;
+
+  // Optional snapshot and experiment for report context (no parent SnapshotProvider)
+  // These are used to create a LocalSnapshotProvider when parent context is empty
+  snapshot?: ExperimentSnapshotInterface;
+  experiment?: ExperimentInterfaceStringDates;
+  dimension?: string;
 }
 
 /**
@@ -445,6 +453,10 @@ const MetricDrilldownModal = ({
   dimensionInfo,
   // Report context
   isReportContext: isReportContextProp,
+  // Optional snapshot and experiment for report context
+  snapshot: snapshotProp,
+  experiment: experimentProp,
+  dimension: dimensionProp,
 }: MetricDrilldownModalProps) => {
   useBodyScrollLock(true);
   const { metric } = row;
@@ -458,11 +470,16 @@ const MetricDrilldownModal = ({
   // Get snapshot from global snapshot context, to initialize LocalSnapshotProvider
   const {
     snapshot: parentSnapshot,
-    experiment,
+    experiment: contextExperiment,
     phase: contextPhase,
-    dimension,
+    dimension: contextDimension,
     analysisSettings: parentAnalysisSettings,
   } = useSnapshot();
+
+  // Use prop values when parent context is empty (report context)
+  const effectiveSnapshot = parentSnapshot ?? snapshotProp;
+  const effectiveExperiment = contextExperiment ?? experimentProp;
+  const effectiveDimension = contextDimension ?? dimensionProp ?? "";
 
   const isReportContext = isReportContextProp ?? false;
 
@@ -600,12 +617,12 @@ const MetricDrilldownModal = ({
         autoFocusSelector=""
       >
         <MetricDrilldownContext.Provider value={null}>
-          {parentSnapshot && experiment ? (
+          {effectiveSnapshot && effectiveExperiment ? (
             <LocalSnapshotProvider
-              experiment={experiment}
-              snapshot={parentSnapshot}
+              experiment={effectiveExperiment}
+              snapshot={effectiveSnapshot}
               phase={contextPhase}
-              dimension={dimension}
+              dimension={effectiveDimension}
               initialAnalysisSettings={parentAnalysisSettings}
             >
               <MetricDrilldownContent {...contentProps} />

--- a/packages/front-end/components/Report/ReportResults.tsx
+++ b/packages/front-end/components/Report/ReportResults.tsx
@@ -216,12 +216,6 @@ export default function ReportResults({
             ssrPolyfills={ssrPolyfills}
             isReportContext
             snapshot={snapshot}
-            experiment={
-              experiment?.id
-                ? (experiment as ExperimentInterfaceStringDates)
-                : undefined
-            }
-            dimension={snapshot.dimension ?? undefined}
           >
             {showDateResults ? (
               <DateResults

--- a/packages/front-end/components/Report/ReportResults.tsx
+++ b/packages/front-end/components/Report/ReportResults.tsx
@@ -215,6 +215,13 @@ export default function ReportResults({
             differenceType={analysis?.settings.differenceType}
             ssrPolyfills={ssrPolyfills}
             isReportContext
+            snapshot={snapshot}
+            experiment={
+              experiment?.id
+                ? (experiment as ExperimentInterfaceStringDates)
+                : undefined
+            }
+            dimension={snapshot.dimension ?? undefined}
           >
             {showDateResults ? (
               <DateResults


### PR DESCRIPTION
### Features and Changes

Fixed the metric drilldown modal for **reports** where the difference type chooser and baseline variation selector would get stuck (appear to do nothing) when clicked.

**Root Cause:**

When the user clicks a different difference type inside the drilldown modal, `DifferenceTypeChooserChangeColumnLabel` does two things:

1. POSTs `/snapshot/${snapshot.id}/analysis` to add the new analysis to the snapshot — this works fine for reports, the backend already supports multiple analyses on a single snapshot.
2. Calls `mutate()` to refresh the local snapshot.

The bug was in step 2. `LocalSnapshotProvider.mutateSnapshot` was fetching `/experiment/${experiment.id}/snapshot/${phase}`, which returns the **experiment's current latest snapshot** — a different snapshot than the one the report is rendering. The local snapshot would be replaced with the wrong one (which doesn't contain the newly-added analysis), causing `getSnapshotAnalysis(localSnapshot, newSettings)` to return `undefined`, and leaving the UI stuck on the previous difference type.

**The Fix:**

Change `LocalSnapshotProvider.mutateSnapshot` to refresh by snapshot ID via `/snapshot/${snapshot.id}` instead of via experiment+phase. This is correct for both contexts:
- **Experiments:** same snapshot comes back, now containing the newly-added analysis.
- **Reports:** the report's specific snapshot comes back, now containing the newly-added analysis — allowing the report snapshot to accumulate multiple analyses over time.

Additionally, simplified the props threading: since the snapshot already carries its own `dimension`, and no drilldown child component reads `experiment` from `useSnapshot()`, only the `snapshot` prop needs to be passed down to `MetricDrilldownProvider`/`MetricDrilldownModal` for the report context (down from three props: `snapshot`, `experiment`, `dimension`).

- Related to: PR #5687 (original experiments drilldown fix)

### Dependencies

None

### Testing

1. Open a report (not an experiment) that has results
2. Open the metric drilldown modal by clicking a metric row
3. Click the difference type chooser (the "% Change" / "Absolute" / "Scaled" dropdown in the column header) and switch to a different type
4. Verify the results update — previously this would appear to do nothing or get stuck
5. Repeat with a report that has a dimension breakdown active and verify the modal still opens correctly

### Screenshots

Behavior fix — no visual UI changes.

[Slack Thread](https://growthbookapp.slack.com/archives/C07NK4F016Z/p1776459675227379?thread_ts=1776459675.227379&cid=C07NK4F016Z)