### PR TITLE
Fix: Do not copy seed when duplicating an experiment

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1061,6 +1061,7 @@ export async function postExperiments(
       allowDuplicateTrackingKey?: boolean;
       originalId?: string;
       autoRefreshResults?: boolean;
+      allowSameSeedAsOriginal?: boolean;
     }
   >,
   res: Response<
@@ -1212,7 +1213,7 @@ export async function postExperiments(
   // The NewExperimentForm should already have cleared the seed, but this
   // ensures that the seed is always removed when duplicating an
   // experiment.
-  if (req.query.originalId) {
+  if (req.query.originalId && !req.query.allowSameSeedAsOriginal) {
     obj.phases = obj.phases.map((phase) => {
       return {
         ...phase,

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1206,6 +1206,20 @@ export async function postExperiments(
     holdoutId: holdoutId || undefined,
     customMetricSlices: data.customMetricSlices,
   };
+
+  // When duplicating an experiment, always remove seed from phases so
+  // bucket assignment is independent from the source experiment.
+  // The NewExperimentForm should already have cleared the seed, but this
+  // ensures that the seed is always removed when duplicating an
+  // experiment.
+  if (req.query.originalId) {
+    obj.phases = obj.phases.map((phase) => {
+      return {
+        ...phase,
+        seed: undefined,
+      };
+    });
+  }
   const { settings } = getScopedSettings({
     organization: org,
   });

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -586,7 +586,7 @@ export async function createExperiment({
     uid: uuidv4().replace(/-/g, ""),
     // If this is a sample experiment, we'll override the id with data.id
     ...data,
-    //set the default phase seed to uuid
+    // set the default phase seed to uuid
     phases: data.phases
       ? data.phases.map(({ ...phase }) => {
           return {

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -337,6 +337,8 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                 variations:
                   initialValue.phases[lastPhase].variations ??
                   toPhaseVariations(initialExpVariations),
+                // Clear seed when duplicating to generate a fresh one on the backend
+                ...(duplicate ? { seed: undefined } : {}),
               },
             ]
           : [

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -202,6 +202,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
   const [allowDuplicateTrackingKey, setAllowDuplicateTrackingKey] =
     useState(false);
   const [autoRefreshResults, setAutoRefreshResults] = useState(true);
+  const [useSameSeedAsOriginal, setUseSameSeedAsOriginal] = useState(false);
 
   const { datasources, getDatasourceById, refreshTags, project, projects } =
     useDefinitions();
@@ -541,6 +542,12 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
       }
     }
 
+    if (duplicate && data.phases?.[0]) {
+      data.phases[0].seed = useSameSeedAsOriginal
+        ? initialValue?.phases?.[lastPhase]?.seed
+        : undefined;
+    }
+
     const body = JSON.stringify(data);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -550,6 +557,9 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
     }
     if (duplicate && initialValue?.id) {
       params.originalId = initialValue.id;
+      if (useSameSeedAsOriginal) {
+        params.allowSameSeedAsOriginal = true;
+      }
     }
 
     if (autoRefreshResults && isImport) {
@@ -943,6 +953,21 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                 setLinkNameWithTrackingKey(false);
               }}
             />
+            {duplicate && (
+              <Box mb="4">
+                <Checkbox
+                  label="Use same randomization seed as original experiment"
+                  value={useSameSeedAsOriginal}
+                  setValue={(v) => setUseSameSeedAsOriginal(v)}
+                  error={
+                    useSameSeedAsOriginal
+                      ? "Can introduce bias if the original experiment influenced user behavior."
+                      : undefined
+                  }
+                  errorLevel="warning"
+                />
+              </Box>
+            )}
             {!isBandit && (
               <Field
                 label="Hypothesis"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

When duplicating an experiment, seed behavior is now **explicitly user-controlled** instead of always forcing a new seed.

New duplicate flow behavior:

- A warning callout appears below **Tracking Key** with an unchecked-by-default checkbox:
  - **“Use same randomization seed as original experiment”**
- If unchecked (default), duplication uses a fresh phase seed (preserves statistical independence).
- If checked, duplication reuses the original seed (intentional carry-over).

This prevents accidental seed reuse while still allowing deliberate reuse when needed.

---

### Technical Details

- Updated `NewExperimentForm.tsx`:
  - Added `useSameSeedAsOriginal` state (default `false`).
  - Added duplicate-only callout + checkbox UI below Tracking Key.
  - Shows warning text only when checked:
    - `Can introduce bias if the original experiment influenced user behavior.`
  - On submit (duplicate flow), sets phase seed from original only when checked.
  - Sends `allowSameSeedAsOriginal=true` in the `/experiments` query params when checked.

- Updated `postExperiments` in `experiments.ts`:
  - Added typed query param: `allowSameSeedAsOriginal?: boolean`
  - Duplicate-seed clearing logic now runs only when:
    - `originalId` is present **and**
    - `allowSameSeedAsOriginal` is **not** true

So backend no longer overrides the seed when the user has explicitly opted in.

---

### Dependencies

None.

---

### Testing

Verified via duplicate flow behavior:

1. Start front-end + back-end + MongoDB.
2. Create an original experiment.
3. Duplicate with checkbox **unchecked** (default):
   - Confirm duplicate gets a different seed.
4. Duplicate with checkbox **checked**:
   - Confirm duplicate keeps the original seed.

This validates both safe default behavior and explicit opt-in reuse.

---

### Slack Thread

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C07NK4F016Z/p1778690995637389?thread_ts=1778690995.637389&cid=C07NK4F016Z)

<div><a href="https://cursor.com/agents/bc-1c08b44d-571d-5b14-b03c-68b2604624b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c08b44d-571d-5b14-b03c-68b2604624b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

