### PR TITLE
Add move to top and move to bottom actions to feature rule dropdown menu

### DIFF
--- a/packages/front-end/components/Features/Rule.tsx
+++ b/packages/front-end/components/Features/Rule.tsx
@@ -19,6 +19,8 @@ import {
   PiTrash,
   PiCaretUp,
   PiCaretDown,
+  PiCaretDoubleUp,
+  PiCaretDoubleDown,
 } from "react-icons/pi";
 import { BsThreeDotsVertical } from "react-icons/bs";
 import { format as formatTimeZone } from "date-fns-tz";
@@ -193,6 +195,8 @@ interface SortableProps {
   // rule cannot move in that direction.
   onMoveUp?: () => void;
   onMoveDown?: () => void;
+  onMoveToTop?: () => void;
+  onMoveToBottom?: () => void;
 }
 
 type RuleProps = SortableProps &
@@ -256,6 +260,8 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
       isAllEnvsView,
       onMoveUp,
       onMoveDown,
+      onMoveToTop,
+      onMoveToBottom,
       ...props
     },
     ref,
@@ -616,10 +622,20 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
                       {rule.enabled ? "Disable" : "Enable"}
                     </DropdownMenuItem>
                   </DropdownMenuGroup>
-                  {(onMoveUp || onMoveDown) && (
+                  {(onMoveUp || onMoveDown || onMoveToTop || onMoveToBottom) && (
                     <>
                       <DropdownMenuSeparator />
                       <DropdownMenuGroup>
+                        {onMoveToTop && (
+                          <DropdownMenuItem
+                            onClick={() => {
+                              onMoveToTop();
+                              setDropdownOpen(false);
+                            }}
+                          >
+                            <PiCaretDoubleUp /> Move to top
+                          </DropdownMenuItem>
+                        )}
                         <DropdownMenuItem
                           disabled={!onMoveUp}
                           onClick={() => {
@@ -642,6 +658,16 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
                         >
                           <PiCaretDown /> Move down
                         </DropdownMenuItem>
+                        {onMoveToBottom && (
+                          <DropdownMenuItem
+                            onClick={() => {
+                              onMoveToBottom();
+                              setDropdownOpen(false);
+                            }}
+                          >
+                            <PiCaretDoubleDown /> Move to bottom
+                          </DropdownMenuItem>
+                        )}
                       </DropdownMenuGroup>
                     </>
                   )}

--- a/packages/front-end/components/Features/Rule.tsx
+++ b/packages/front-end/components/Features/Rule.tsx
@@ -622,7 +622,10 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
                       {rule.enabled ? "Disable" : "Enable"}
                     </DropdownMenuItem>
                   </DropdownMenuGroup>
-                  {(onMoveUp || onMoveDown || onMoveToTop || onMoveToBottom) && (
+                  {(onMoveUp ||
+                    onMoveDown ||
+                    onMoveToTop ||
+                    onMoveToBottom) && (
                     <>
                       <DropdownMenuSeparator />
                       <DropdownMenuGroup>

--- a/packages/front-end/components/Features/RuleList.tsx
+++ b/packages/front-end/components/Features/RuleList.tsx
@@ -295,6 +295,12 @@ export default function RuleList(props: RuleListProps) {
           {items.map((rule, i) => {
             const prevId = i > 0 ? items[i - 1].id : null;
             const nextId = i < items.length - 1 ? items[i + 1].id : null;
+            const firstId = items.length > 0 ? items[0].id : null;
+            const lastId = items.length > 0 ? items[items.length - 1].id : null;
+            // Don't show "move to top" if already at top
+            const canMoveToTop = canEdit && i > 0;
+            // Don't show "move to bottom" if already at bottom
+            const canMoveToBottom = canEdit && i < items.length - 1;
             return (
               <SortableRule
                 key={rule.id || i}
@@ -324,6 +330,16 @@ export default function RuleList(props: RuleListProps) {
                 onMoveDown={
                   canEdit && nextId
                     ? () => reorderByRuleId(rule.id, nextId)
+                    : undefined
+                }
+                onMoveToTop={
+                  canMoveToTop && firstId
+                    ? () => reorderByRuleId(rule.id, firstId)
+                    : undefined
+                }
+                onMoveToBottom={
+                  canMoveToBottom && lastId
+                    ? () => reorderByRuleId(rule.id, lastId)
                     : undefined
                 }
               />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

Added "Move to top" and "Move to bottom" actions to the feature rule card dropdown menu, complementing the existing "Move up" and "Move down" options. This allows users to quickly reorder rules without clicking multiple times.

**Implementation details:**
- Added `PiCaretDoubleUp` and `PiCaretDoubleDown` Phosphor icons for the new actions
- Added `onMoveToTop` and `onMoveToBottom` callbacks to the `Rule` component props
- Implemented the callbacks in `RuleList.tsx` to use the existing `reorderByRuleId` function
- Actions are conditionally rendered:
  - "Move to top" only appears when the rule is NOT already at the top position
  - "Move to bottom" only appears when the rule is NOT already at the bottom position
- Respects locked-to-top rules like holdouts: rules can only move to the first regular rule position (after any holdout)

**Files changed:**
- `packages/front-end/components/Features/Rule.tsx` - Added icon imports, props, and menu items
- `packages/front-end/components/Features/RuleList.tsx` - Added callback implementations

**Menu structure:**
The dropdown menu for rules now shows (when applicable):
```
Edit
Duplicate rule
Enable/Disable
---
[Move to top]      ⇈  (conditionally shown)
Move up            ↑  (existing, may be disabled)
Move down          ↓  (existing, may be disabled)
[Move to bottom]   ⇊  (conditionally shown)
---
[Ramp-up schedule actions if applicable]
---
Delete
```

### Dependencies

None

### Testing

**Automated verification:**
- ✅ TypeScript type-checking passes (`pnpm --filter front-end type-check`)
- ✅ ESLint passes (`pnpm lint`)
- ✅ Verified `PiCaretDoubleUp` and `PiCaretDoubleDown` icons exist in react-icons/pi package
- ✅ Verified compiled JavaScript includes new menu items ("Move to top", "Move to bottom")
- ✅ Code review confirms implementation follows existing patterns

**Manual testing steps:**
1. Navigate to a feature with 3+ rules
2. Click the three-dot menu on a middle rule
3. Verify "Move to top" and "Move to bottom" options appear with double caret icons
4. Click "Move to top" and verify the rule moves to the first regular rule position (after any holdout)
5. Click "Move to bottom" and verify the rule moves to the last position
6. Verify the options don't appear when a rule is already at top/bottom
7. Test with a feature that has a holdout rule to ensure rules don't move above it

**Implementation notes:**
- The implementation reuses the existing `reorderByRuleId` function which already handles proper API calls and optimistic UI updates
- The holdout rule is rendered separately from the regular rules list, so "move to top" correctly moves to the first regular rule position
- Conditional rendering logic matches the existing pattern used for "Move up/down" actions

### Screenshots

The new menu items use Phosphor icons consistent with the existing UI:
- **Move to top**: `PiCaretDoubleUp` - Double up arrow (⇈)
- **Move up**: `PiCaretUp` - Single up arrow (↑) [existing]
- **Move down**: `PiCaretDown` - Single down arrow (↓) [existing]
- **Move to bottom**: `PiCaretDoubleDown` - Double down arrow (⇊)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C0A9B5W8LMN/p1778692031380299?thread_ts=1778692031.380299&cid=C0A9B5W8LMN)

<div><a href="https://cursor.com/agents/bc-2cf09365-a34b-5576-86ab-5e95e93cbef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cf09365-a34b-5576-86ab-5e95e93cbef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

