### PR TITLE
Add move to top and bottom feature rule actions

### DIFF
--- a/packages/front-end/components/Features/Rule.tsx
+++ b/packages/front-end/components/Features/Rule.tsx
@@ -19,6 +19,8 @@ import {
   PiTrash,
   PiCaretUp,
   PiCaretDown,
+  PiCaretDoubleUp,
+  PiCaretDoubleDown,
 } from "react-icons/pi";
 import { BsThreeDotsVertical } from "react-icons/bs";
 import { format as formatTimeZone } from "date-fns-tz";
@@ -188,11 +190,13 @@ interface SortableProps {
   // in the env-scope badges.
   isAllEnvsView?: boolean;
   // Provided by RuleList to support keyboard/menu reordering. Each callback
-  // moves the rule by one position in the current visible projection and
-  // posts the equivalent flat-index reorder to the API. Undefined when the
-  // rule cannot move in that direction.
+  // moves the rule in the current visible projection and posts the equivalent
+  // flat-index reorder to the API. Undefined when the rule cannot move in
+  // that direction.
+  onMoveToTop?: () => void;
   onMoveUp?: () => void;
   onMoveDown?: () => void;
+  onMoveToBottom?: () => void;
 }
 
 type RuleProps = SortableProps &
@@ -254,8 +258,10 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
       rampSchedule,
       draftRevision,
       isAllEnvsView,
+      onMoveToTop,
       onMoveUp,
       onMoveDown,
+      onMoveToBottom,
       ...props
     },
     ref,
@@ -616,10 +622,24 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
                       {rule.enabled ? "Disable" : "Enable"}
                     </DropdownMenuItem>
                   </DropdownMenuGroup>
-                  {(onMoveUp || onMoveDown) && (
+                  {(onMoveToTop ||
+                    onMoveUp ||
+                    onMoveDown ||
+                    onMoveToBottom) && (
                     <>
                       <DropdownMenuSeparator />
                       <DropdownMenuGroup>
+                        <DropdownMenuItem
+                          disabled={!onMoveToTop}
+                          onClick={() => {
+                            if (onMoveToTop) {
+                              onMoveToTop();
+                              setDropdownOpen(false);
+                            }
+                          }}
+                        >
+                          <PiCaretDoubleUp /> Move to top
+                        </DropdownMenuItem>
                         <DropdownMenuItem
                           disabled={!onMoveUp}
                           onClick={() => {
@@ -641,6 +661,17 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
                           }}
                         >
                           <PiCaretDown /> Move down
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          disabled={!onMoveToBottom}
+                          onClick={() => {
+                            if (onMoveToBottom) {
+                              onMoveToBottom();
+                              setDropdownOpen(false);
+                            }
+                          }}
+                        >
+                          <PiCaretDoubleDown /> Move to bottom
                         </DropdownMenuItem>
                       </DropdownMenuGroup>
                     </>

--- a/packages/front-end/components/Features/RuleList.tsx
+++ b/packages/front-end/components/Features/RuleList.tsx
@@ -293,8 +293,10 @@ export default function RuleList(props: RuleListProps) {
         )}
         <SortableContext items={items} strategy={verticalListSortingStrategy}>
           {items.map((rule, i) => {
+            const firstId = items[0].id;
             const prevId = i > 0 ? items[i - 1].id : null;
             const nextId = i < items.length - 1 ? items[i + 1].id : null;
+            const lastId = items[items.length - 1].id;
             return (
               <SortableRule
                 key={rule.id || i}
@@ -316,6 +318,11 @@ export default function RuleList(props: RuleListProps) {
                 rampSchedule={rampSchedulesMap.get(rule.id ?? "")}
                 draftRevision={draftRevision}
                 isAllEnvsView={allEnvsView}
+                onMoveToTop={
+                  canEdit && i > 0
+                    ? () => reorderByRuleId(rule.id, firstId)
+                    : undefined
+                }
                 onMoveUp={
                   canEdit && prevId
                     ? () => reorderByRuleId(rule.id, prevId)
@@ -324,6 +331,11 @@ export default function RuleList(props: RuleListProps) {
                 onMoveDown={
                   canEdit && nextId
                     ? () => reorderByRuleId(rule.id, nextId)
+                    : undefined
+                }
+                onMoveToBottom={
+                  canEdit && i < items.length - 1
+                    ? () => reorderByRuleId(rule.id, lastId)
                     : undefined
                 }
               />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

Adds "Move to top" and "Move to bottom" options to the per-rule dropdown menu in the feature rules list, alongside the existing "Move up" and "Move down" actions.

Request permalink: <a href="https://growthbookapp.slack&#46;com/archives/C0B492B9388/p1778720613197939">https://growthbookapp.slack&#46;com/archives/C0B492B9388/p1778720613197939</a>

- Closes **(customer request permalink above)**

### Dependencies

None.

### Testing

- `pnpm --filter front-end type-check`
- `pnpm eslint packages/front-end/components/Features/Rule.tsx packages/front-end/components/Features/RuleList.tsx --max-warnings 0 --cache --cache-strategy content`
- Manual browser walkthrough on a local feature with three rules: verified "Move to top"/"Move to bottom" appear in the rule dropdown, top/bottom disabled states are correct, "Move to bottom" moves the first rule to the bottom, and "Move to top" restores it.

### Screenshots

[feature_rule_move_top_bottom_walkthrough.mp4](https://cursor.com/agents/bc-96f523fc-d5e5-499b-8a12-0abe0e04d47c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffeature_rule_move_top_bottom_walkthrough.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96f523fc-d5e5-499b-8a12-0abe0e04d47c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96f523fc-d5e5-499b-8a12-0abe0e04d47c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

