### PR TITLE
Add feature configuration clipboard import MVP

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -872,6 +872,10 @@ app.get("/feature/:id/:version/log", featuresController.getRevisionLog);
 app.post("/feature/:id/archive", featuresController.postFeatureArchive);
 app.post("/feature/:id/toggle", featuresController.postFeatureToggle);
 app.post("/feature/:id/draft", featuresController.postFeatureCreateDraft);
+app.post(
+  "/feature/:id/import-draft",
+  featuresController.postFeatureImportDraft,
+);
 app.post("/feature/:id/:version/fork", featuresController.postFeatureFork);
 app.post("/feature/:id/:version/rebase", featuresController.postFeatureRebase);
 app.post("/feature/:id/:version/revert", featuresController.postFeatureRevert);

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -41,7 +41,7 @@ import {
   RevisionRampAction,
   RevisionRampCreateAction,
   RevisionRampDetachAction,
-  featureRule,
+  clipboardFeatureRule,
 } from "shared/validators";
 import { FeatureUsageLookback } from "shared/types/integrations";
 import {
@@ -3570,7 +3570,7 @@ export async function postFeatureCreateDraft(
 
 const featureImportDraftBodySchema = z
   .object({
-    rules: z.array(featureRule),
+    rules: z.array(clipboardFeatureRule),
     environmentsEnabled: z.record(z.string(), z.boolean()),
     title: z.string().optional(),
     comment: z.string().optional(),

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import { evaluateFeatures } from "@growthbook/proxy-eval";
 import { cloneDeep, isEqual, omit } from "lodash";
 import { v4 as uuidv4 } from "uuid";
+import { z } from "zod";
 import {
   SDKConnectionInterface,
   SDKLanguage,
@@ -40,6 +41,7 @@ import {
   RevisionRampAction,
   RevisionRampCreateAction,
   RevisionRampDetachAction,
+  featureRule,
 } from "shared/validators";
 import { FeatureUsageLookback } from "shared/types/integrations";
 import {
@@ -3546,6 +3548,107 @@ export async function postFeatureCreateDraft(
         version: newDraft.version,
         baseVersion: newDraft.baseVersion,
         comment: newDraft.comment,
+      }),
+    })
+    .catch((e) =>
+      logger.error(e, "Failed to write audit log for revision.create"),
+    );
+
+  await dispatchFeatureRevisionEvent(
+    context,
+    feature,
+    newDraft,
+    "revision.created",
+    {},
+  );
+
+  return res.status(200).json({
+    status: 200,
+    draftVersion: newDraft.version,
+  });
+}
+
+const featureImportDraftBodySchema = z
+  .object({
+    rules: z.array(featureRule),
+    environmentsEnabled: z.record(z.string(), z.boolean()),
+    title: z.string().optional(),
+    comment: z.string().optional(),
+  })
+  .strict();
+
+export async function postFeatureImportDraft(
+  req: AuthRequest<unknown, { id: string }>,
+  res: Response<
+    { status: 200; draftVersion: number },
+    EventUserForResponseLocals
+  >,
+) {
+  const { id } = req.params;
+  const context = getContextFromReq(req);
+  const { org } = context;
+  const result = featureImportDraftBodySchema.safeParse(req.body);
+
+  if (!result.success) {
+    throw new Error("Invalid feature import draft payload");
+  }
+
+  const { rules, environmentsEnabled, title, comment } = result.data;
+  const feature = await getFeature(context, id);
+
+  if (!feature) {
+    throw new Error("Could not find feature");
+  }
+
+  const allEnvironments = getEnvironments(org);
+  const environments = filterEnvironmentsByFeature(allEnvironments, feature);
+  const environmentIds = environments.map((e) => e.id);
+  const changedEnvironments = Object.keys(environmentsEnabled);
+
+  changedEnvironments.forEach((env) => {
+    if (!environmentIds.includes(env)) {
+      throw new Error(`Invalid environment: ${env}`);
+    }
+  });
+
+  if (
+    !context.permissions.canUpdateFeature(feature, {}) ||
+    !context.permissions.canManageFeatureDrafts(feature) ||
+    !context.permissions.canPublishFeature(feature, changedEnvironments)
+  ) {
+    context.permissions.throwPermissionError();
+  }
+
+  const importedRules = cloneDeep(rules);
+  addIdsToFlatRules(importedRules, feature.id);
+
+  const newDraft = await createRevision({
+    context,
+    feature,
+    user: context.auditUser,
+    baseVersion: feature.version,
+    comment: comment ?? "",
+    title,
+    environments: environmentIds,
+    publish: false,
+    changes: {
+      rules: importedRules,
+      environmentsEnabled,
+    },
+    org,
+    canBypassApprovalChecks: false,
+  });
+
+  void req
+    .audit({
+      event: "feature.revision.create",
+      entity: { object: "feature", id: feature.id },
+      details: auditDetailsCreate({
+        featureId: feature.id,
+        version: newDraft.version,
+        baseVersion: newDraft.baseVersion,
+        comment: newDraft.comment,
+        importedRules: importedRules.length,
       }),
     })
     .catch((e) =>

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -3633,6 +3633,26 @@ export async function postFeatureImportDraft(
   const importedRules = cloneDeep(rules);
   addIdsToFlatRules(importedRules, feature.id);
 
+  // Enforce the destination org's opt-in attribute-registration policy on
+  // every imported rule. Mirrors postFeatureRule's call so a clipboard
+  // import can't smuggle in attributes the single-rule add path would
+  // reject. Per-rule loop because each rule has its own hash/fallback/
+  // condition tuple.
+  for (const r of importedRules) {
+    assertRegisteredAttributes(
+      context,
+      {
+        hashAttribute: (r as { hashAttribute?: string }).hashAttribute,
+        fallbackAttribute: (r as { fallbackAttribute?: string })
+          .fallbackAttribute,
+        condition: r.condition,
+      },
+      "rule",
+      undefined,
+      feature.project,
+    );
+  }
+
   const newDraft = await createRevision({
     context,
     feature,
@@ -3649,6 +3669,27 @@ export async function postFeatureImportDraft(
     org,
     canBypassApprovalChecks: false,
   });
+
+  // Reconcile experiment linkage for any experiment-ref rules in the
+  // imported draft — mirrors the bookkeeping that postFeatureRule does on
+  // single-rule add. Without this, experiments don't list the feature as a
+  // linked implementation and the draft isn't queued for auto-publish.
+  const experimentRefIds = new Set<string>();
+  for (const r of importedRules) {
+    if (r.type === "experiment-ref" && r.experimentId) {
+      experimentRefIds.add(r.experimentId);
+    }
+  }
+  for (const experimentId of experimentRefIds) {
+    await addLinkedFeatureToExperiment(context, experimentId, feature.id);
+    await addLinkedExperiment(feature, experimentId);
+    await addPendingFeatureDraftToExperiment(
+      context,
+      experimentId,
+      feature.id,
+      newDraft.version,
+    );
+  }
 
   void req
     .audit({

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -3599,7 +3599,14 @@ export async function postFeatureImportDraft(
   const result = featureImportDraftBodySchema.safeParse(req.body);
 
   if (!result.success) {
-    throw new Error("Invalid feature import draft payload");
+    // Surface the first Zod issue so a structural mismatch (unknown rule
+    // shape, missing required field, etc.) is diagnosable from the client
+    // error and server logs instead of a bare "invalid payload".
+    const firstIssue = result.error.issues[0];
+    const issueDetail = firstIssue
+      ? `${firstIssue.path.join(".") || "<root>"}: ${firstIssue.message}`
+      : "unknown";
+    throw new Error(`Invalid feature import draft payload — ${issueDetail}`);
   }
 
   const { rules, environmentsEnabled, safeRolloutSettings, title, comment } =
@@ -3670,6 +3677,24 @@ export async function postFeatureImportDraft(
   // rule.safeRolloutId to point at them. Destination-specific refs
   // (datasource, exposure query, guardrails) are carried as-is and may need
   // user fix-up post-import.
+  //
+  // Gate on the destination org's safe-rollout entitlement (the same gate
+  // postFeatureRule enforces on single-rule add) so importing a feature
+  // with safe-rollout rules into a non-premium org fails cleanly instead
+  // of silently bypassing entitlement. We deliberately skip
+  // validateCreateSafeRolloutFields here: it asserts that datasourceId /
+  // exposureQueryId / guardrailMetricIds exist in the destination, which
+  // would always fail for cross-org imports. The user fixes those refs on
+  // the auto-created SafeRollout via the destination's safe-rollout UI
+  // post-import.
+  const hasAnySafeRolloutRule = importedRules.some(
+    (r) => r.type === "safe-rollout",
+  );
+  if (hasAnySafeRolloutRule && !context.hasPremiumFeature("safe-rollout")) {
+    throw new Error(
+      "This feature contains a Safe Rollout rule, which requires a paid plan in the destination organization.",
+    );
+  }
   const createdSafeRolloutIds: string[] = [];
   try {
     for (const r of importedRules) {
@@ -3683,15 +3708,27 @@ export async function postFeatureImportDraft(
           `Safe-rollout rule references safeRolloutId "${sourceId}" but no matching safeRolloutSettings were provided in the import payload. Re-export from the source instance.`,
         );
       }
-      // Safe rollouts are single-env. The rule's environments[] is the
-      // source of truth; allEnvironments doesn't translate.
-      const ruleEnv =
-        !r.allEnvironments && r.environments?.length === 1
-          ? r.environments[0]
-          : undefined;
-      if (!ruleEnv) {
+      // SafeRollout docs are single-env, but the rule itself can apply to
+      // all envs (allEnvironments: true) or a list. Pick the env the
+      // destination SafeRollout doc lives in:
+      //   - rule.environments.length === 1 → that env (faithful to source)
+      //   - allEnvironments: true → first applicable env (the rule still
+      //     evaluates in all envs at SDK runtime; only analysis is scoped)
+      // Anything else (multi-env list) is a configuration the standard
+      // create flow forbids; refuse import rather than silently picking.
+      let ruleEnv: string | undefined;
+      if (r.allEnvironments) {
+        ruleEnv = environmentIds[0];
+        if (!ruleEnv) {
+          throw new Error(
+            "Cannot import an allEnvironments safe-rollout rule because this feature's project has no environments.",
+          );
+        }
+      } else if (r.environments?.length === 1) {
+        ruleEnv = r.environments[0];
+      } else {
         throw new Error(
-          "Safe-rollout rules must be scoped to a single environment to be imported.",
+          "Safe-rollout rules must be scoped to all environments or to a single environment to be imported.",
         );
       }
       if (!environmentIds.includes(ruleEnv)) {
@@ -3798,13 +3835,12 @@ export async function postFeatureImportDraft(
   // already no-ops for missing experiments but `addLinkedExperiment` does
   // not, so they have to be gated together.
   //
-  // Linkage failures are caught per-experiment and logged rather than
-  // surfaced as a request error: the feature, draft, and SafeRollouts have
-  // all been persisted successfully at this point, and the frontend
-  // rollback path (archive + delete the feature) does NOT cascade to
-  // SafeRollouts — so throwing here would leave orphan SafeRollout docs in
-  // the DB. Broken linkage is recoverable (user can re-link from the
-  // experiment page); orphan rollouts are not.
+  // If linkage fails, we surface the failure as a hard error so the UI
+  // doesn't show "success" while bookkeeping is partly broken. We also
+  // delete any SafeRollouts we created here, because the frontend rollback
+  // (archive + delete the feature) cascades to revisions and audit but
+  // does NOT touch SafeRollouts — without manual cleanup they'd orphan in
+  // the DB. The frontend then handles feature/draft cleanup as usual.
   const experimentRefIds = new Set<string>();
   for (const r of importedRules) {
     if (r.type === "experiment-ref" && r.experimentId) {
@@ -3817,10 +3853,10 @@ export async function postFeatureImportDraft(
   const presentExperimentById = new Map(
     presentExperiments.map((e) => [e.id, e]),
   );
-  for (const experimentId of experimentRefIds) {
-    const experiment = presentExperimentById.get(experimentId);
-    if (!experiment) continue;
-    try {
+  try {
+    for (const experimentId of experimentRefIds) {
+      const experiment = presentExperimentById.get(experimentId);
+      if (!experiment) continue;
       await addLinkedFeatureToExperiment(
         context,
         experimentId,
@@ -3834,12 +3870,19 @@ export async function postFeatureImportDraft(
         feature.id,
         newDraft.version,
       );
-    } catch (linkErr) {
-      logger.warn(
-        linkErr,
-        `Failed to link experiment ${experimentId} to imported feature ${feature.id}; feature and draft were created successfully`,
-      );
     }
+  } catch (linkErr) {
+    for (const srId of createdSafeRolloutIds) {
+      try {
+        await context.models.safeRollout.deleteById(srId);
+      } catch (delErr) {
+        logger.warn(
+          delErr,
+          `Failed to clean up safe rollout ${srId} after linkage error`,
+        );
+      }
+    }
+    throw linkErr;
   }
 
   void req

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -3797,6 +3797,14 @@ export async function postFeatureImportDraft(
   // `linkedExperiments` with dangling ids — `addLinkedFeatureToExperiment`
   // already no-ops for missing experiments but `addLinkedExperiment` does
   // not, so they have to be gated together.
+  //
+  // Linkage failures are caught per-experiment and logged rather than
+  // surfaced as a request error: the feature, draft, and SafeRollouts have
+  // all been persisted successfully at this point, and the frontend
+  // rollback path (archive + delete the feature) does NOT cascade to
+  // SafeRollouts — so throwing here would leave orphan SafeRollout docs in
+  // the DB. Broken linkage is recoverable (user can re-link from the
+  // experiment page); orphan rollouts are not.
   const experimentRefIds = new Set<string>();
   for (const r of importedRules) {
     if (r.type === "experiment-ref" && r.experimentId) {
@@ -3812,19 +3820,26 @@ export async function postFeatureImportDraft(
   for (const experimentId of experimentRefIds) {
     const experiment = presentExperimentById.get(experimentId);
     if (!experiment) continue;
-    await addLinkedFeatureToExperiment(
-      context,
-      experimentId,
-      feature.id,
-      experiment,
-    );
-    await addLinkedExperiment(feature, experimentId);
-    await addPendingFeatureDraftToExperiment(
-      context,
-      experimentId,
-      feature.id,
-      newDraft.version,
-    );
+    try {
+      await addLinkedFeatureToExperiment(
+        context,
+        experimentId,
+        feature.id,
+        experiment,
+      );
+      await addLinkedExperiment(feature, experimentId);
+      await addPendingFeatureDraftToExperiment(
+        context,
+        experimentId,
+        feature.id,
+        newDraft.version,
+      );
+    } catch (linkErr) {
+      logger.warn(
+        linkErr,
+        `Failed to link experiment ${experimentId} to imported feature ${feature.id}; feature and draft were created successfully`,
+      );
+    }
   }
 
   void req

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -42,6 +42,7 @@ import {
   RevisionRampCreateAction,
   RevisionRampDetachAction,
   clipboardFeatureRule,
+  clipboardSafeRolloutSettings,
 } from "shared/validators";
 import { FeatureUsageLookback } from "shared/types/integrations";
 import {
@@ -3572,6 +3573,14 @@ const featureImportDraftBodySchema = z
   .object({
     rules: z.array(clipboardFeatureRule),
     environmentsEnabled: z.record(z.string(), z.boolean()),
+    // Keyed by the SOURCE safeRolloutId referenced from the rules. The
+    // backend creates a fresh SafeRollout per safe-rollout rule using these
+    // settings and rewrites rule.safeRolloutId. Optional for backward compat
+    // with older payloads, but safe-rollout rules will fail import without
+    // a matching entry.
+    safeRolloutSettings: z
+      .record(z.string(), clipboardSafeRolloutSettings)
+      .optional(),
     title: z.string().optional(),
     comment: z.string().optional(),
   })
@@ -3593,7 +3602,8 @@ export async function postFeatureImportDraft(
     throw new Error("Invalid feature import draft payload");
   }
 
-  const { rules, environmentsEnabled, title, comment } = result.data;
+  const { rules, environmentsEnabled, safeRolloutSettings, title, comment } =
+    result.data;
   const feature = await getFeature(context, id);
 
   if (!feature) {
@@ -3653,35 +3663,161 @@ export async function postFeatureImportDraft(
     );
   }
 
-  const newDraft = await createRevision({
-    context,
-    feature,
-    user: context.auditUser,
-    baseVersion: feature.version,
-    comment: comment ?? "",
-    title,
-    environments: environmentIds,
-    publish: false,
-    changes: {
-      rules: importedRules,
-      environmentsEnabled: filteredEnvironmentsEnabled,
-    },
-    org,
-    canBypassApprovalChecks: false,
-  });
+  // Auto-create destination SafeRollouts for each safe-rollout rule using
+  // the source settings carried in the envelope. Safe rollouts are
+  // per-feature, so cross-org id mapping doesn't make sense — instead we
+  // mint fresh SafeRollouts owned by the importing feature and rewrite
+  // rule.safeRolloutId to point at them. Destination-specific refs
+  // (datasource, exposure query, guardrails) are carried as-is and may need
+  // user fix-up post-import.
+  const createdSafeRolloutIds: string[] = [];
+  try {
+    for (const r of importedRules) {
+      if (r.type !== "safe-rollout") continue;
+      const sourceId = r.safeRolloutId;
+      const sourceSettings = sourceId
+        ? safeRolloutSettings?.[sourceId]
+        : undefined;
+      if (!sourceSettings) {
+        throw new Error(
+          `Safe-rollout rule references safeRolloutId "${sourceId}" but no matching safeRolloutSettings were provided in the import payload. Re-export from the source instance.`,
+        );
+      }
+      // Safe rollouts are single-env. The rule's environments[] is the
+      // source of truth; allEnvironments doesn't translate.
+      const ruleEnv =
+        !r.allEnvironments && r.environments?.length === 1
+          ? r.environments[0]
+          : undefined;
+      if (!ruleEnv) {
+        throw new Error(
+          "Safe-rollout rules must be scoped to a single environment to be imported.",
+        );
+      }
+      if (!environmentIds.includes(ruleEnv)) {
+        throw new Error(
+          `Safe-rollout rule references environment "${ruleEnv}" which is not available in this feature's project.`,
+        );
+      }
+      // Ramp schedule structure carries across; runtime step / completion
+      // state is reset so the destination starts fresh.
+      const rampSteps = sourceSettings.rampUpSchedule?.steps?.length
+        ? sourceSettings.rampUpSchedule.steps
+        : [
+            { percent: 0.1 },
+            { percent: 0.25 },
+            { percent: 0.5 },
+            { percent: 0.75 },
+            { percent: 1 },
+          ];
+      r.seed = r.seed || uuidv4();
+      r.trackingKey =
+        r.trackingKey || `${SAFE_ROLLOUT_TRACKING_KEY_PREFIX}${uuidv4()}`;
+      const created = await context.models.safeRollout.create({
+        datasourceId: sourceSettings.datasourceId,
+        exposureQueryId: sourceSettings.exposureQueryId,
+        guardrailMetricIds: sourceSettings.guardrailMetricIds,
+        maxDuration: sourceSettings.maxDuration,
+        autoRollback: sourceSettings.autoRollback,
+        autoSnapshots: sourceSettings.autoSnapshots,
+        environment: ruleEnv,
+        featureId: feature.id,
+        status: r.status ?? "running",
+        rampUpSchedule: {
+          enabled: sourceSettings.rampUpSchedule?.enabled ?? false,
+          step: 0,
+          steps: rampSteps,
+          rampUpCompleted: false,
+          nextUpdate: undefined,
+        },
+      });
+      if (!created) throw new Error("Failed to create safe rollout on import");
+      createdSafeRolloutIds.push(created.id);
+      r.safeRolloutId = created.id;
+    }
+  } catch (e) {
+    // Roll back any SafeRollouts we created before the failure so a
+    // partial import doesn't leave dangling docs in the destination.
+    for (const srId of createdSafeRolloutIds) {
+      try {
+        await context.models.safeRollout.deleteById(srId);
+      } catch (delErr) {
+        logger.warn(
+          delErr,
+          `Failed to clean up safe rollout ${srId} after import error`,
+        );
+      }
+    }
+    throw e;
+  }
+
+  let newDraft: Awaited<ReturnType<typeof createRevision>>;
+  try {
+    newDraft = await createRevision({
+      context,
+      feature,
+      user: context.auditUser,
+      baseVersion: feature.version,
+      comment: comment ?? "",
+      title,
+      environments: environmentIds,
+      publish: false,
+      changes: {
+        rules: importedRules,
+        environmentsEnabled: filteredEnvironmentsEnabled,
+      },
+      org,
+      canBypassApprovalChecks: false,
+    });
+  } catch (e) {
+    // If revision creation fails after we've created SafeRollouts, those
+    // SafeRollouts would otherwise orphan in the destination (the
+    // upstream feature gets archived+deleted by the frontend rollback,
+    // but unlinkFeatureFromAllExperiments doesn't touch safe rollouts).
+    for (const srId of createdSafeRolloutIds) {
+      try {
+        await context.models.safeRollout.deleteById(srId);
+      } catch (delErr) {
+        logger.warn(
+          delErr,
+          `Failed to clean up safe rollout ${srId} after revision-create error`,
+        );
+      }
+    }
+    throw e;
+  }
 
   // Reconcile experiment linkage for any experiment-ref rules in the
   // imported draft — mirrors the bookkeeping that postFeatureRule does on
   // single-rule add. Without this, experiments don't list the feature as a
   // linked implementation and the draft isn't queued for auto-publish.
+  //
+  // We resolve experiment existence up front so a missing experiment (an
+  // unmapped reference from the source org) doesn't pollute the feature's
+  // `linkedExperiments` with dangling ids — `addLinkedFeatureToExperiment`
+  // already no-ops for missing experiments but `addLinkedExperiment` does
+  // not, so they have to be gated together.
   const experimentRefIds = new Set<string>();
   for (const r of importedRules) {
     if (r.type === "experiment-ref" && r.experimentId) {
       experimentRefIds.add(r.experimentId);
     }
   }
+  const presentExperiments = await getExperimentsByIds(context, [
+    ...experimentRefIds,
+  ]);
+  const presentExperimentById = new Map(
+    presentExperiments.map((e) => [e.id, e]),
+  );
   for (const experimentId of experimentRefIds) {
-    await addLinkedFeatureToExperiment(context, experimentId, feature.id);
+    const experiment = presentExperimentById.get(experimentId);
+    if (!experiment) continue;
+    await addLinkedFeatureToExperiment(
+      context,
+      experimentId,
+      feature.id,
+      experiment,
+    );
     await addLinkedExperiment(feature, experimentId);
     await addPendingFeatureDraftToExperiment(
       context,

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -3603,18 +3603,28 @@ export async function postFeatureImportDraft(
   const allEnvironments = getEnvironments(org);
   const environments = filterEnvironmentsByFeature(allEnvironments, feature);
   const environmentIds = environments.map((e) => e.id);
-  const changedEnvironments = Object.keys(environmentsEnabled);
 
-  changedEnvironments.forEach((env) => {
+  Object.keys(environmentsEnabled).forEach((env) => {
     if (!environmentIds.includes(env)) {
       throw new Error(`Invalid environment: ${env}`);
     }
   });
 
+  // Publish permission is only required for environments whose enabled state
+  // differs from the live feature — those are the ones a future publish of
+  // this draft would actually flip.
+  const envsRequiringPublish = Object.entries(environmentsEnabled)
+    .filter(
+      ([env, enabled]) =>
+        (feature.environmentSettings?.[env]?.enabled ?? false) !== enabled,
+    )
+    .map(([env]) => env);
+
   if (
     !context.permissions.canUpdateFeature(feature, {}) ||
     !context.permissions.canManageFeatureDrafts(feature) ||
-    !context.permissions.canPublishFeature(feature, changedEnvironments)
+    (envsRequiringPublish.length > 0 &&
+      !context.permissions.canPublishFeature(feature, envsRequiringPublish))
   ) {
     context.permissions.throwPermissionError();
   }

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -3620,21 +3620,12 @@ export async function postFeatureImportDraft(
     ),
   );
 
-  // Publish permission is only required for environments whose enabled state
-  // differs from the live feature — those are the ones a future publish of
-  // this draft would actually flip.
-  const envsRequiringPublish = Object.entries(filteredEnvironmentsEnabled)
-    .filter(
-      ([env, enabled]) =>
-        (feature.environmentSettings?.[env]?.enabled ?? false) !== enabled,
-    )
-    .map(([env]) => env);
-
+  // Mirrors postFeatureCreateDraft — this endpoint only ever creates an
+  // unpublished draft. Publish-permission is enforced when the draft is
+  // actually published, not at draft-creation time.
   if (
     !context.permissions.canUpdateFeature(feature, {}) ||
-    !context.permissions.canManageFeatureDrafts(feature) ||
-    (envsRequiringPublish.length > 0 &&
-      !context.permissions.canPublishFeature(feature, envsRequiringPublish))
+    !context.permissions.canManageFeatureDrafts(feature)
   ) {
     context.permissions.throwPermissionError();
   }

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -3603,17 +3603,27 @@ export async function postFeatureImportDraft(
   const allEnvironments = getEnvironments(org);
   const environments = filterEnvironmentsByFeature(allEnvironments, feature);
   const environmentIds = environments.map((e) => e.id);
+  const orgEnvironmentIds = new Set(allEnvironments.map((e) => e.id));
 
+  // Drop env keys that aren't applicable to this feature's project — the
+  // client sends every org env, but project env-scoping may shrink the valid
+  // set. Anything outside the org entirely is a real error from a stale or
+  // hostile client.
   Object.keys(environmentsEnabled).forEach((env) => {
-    if (!environmentIds.includes(env)) {
+    if (!orgEnvironmentIds.has(env)) {
       throw new Error(`Invalid environment: ${env}`);
     }
   });
+  const filteredEnvironmentsEnabled = Object.fromEntries(
+    Object.entries(environmentsEnabled).filter(([env]) =>
+      environmentIds.includes(env),
+    ),
+  );
 
   // Publish permission is only required for environments whose enabled state
   // differs from the live feature — those are the ones a future publish of
   // this draft would actually flip.
-  const envsRequiringPublish = Object.entries(environmentsEnabled)
+  const envsRequiringPublish = Object.entries(filteredEnvironmentsEnabled)
     .filter(
       ([env, enabled]) =>
         (feature.environmentSettings?.[env]?.enabled ?? false) !== enabled,
@@ -3643,7 +3653,7 @@ export async function postFeatureImportDraft(
     publish: false,
     changes: {
       rules: importedRules,
-      environmentsEnabled,
+      environmentsEnabled: filteredEnvironmentsEnabled,
     },
     org,
     canBypassApprovalChecks: false,

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -145,6 +145,7 @@ import {
   getRevisionsByVersions,
   getFeaturePageRevisions,
   getRevisionsByStatus,
+  hardDeleteRevision,
   markRevisionAsReviewRequested,
   normalizeRulesInputToV2,
   ReviewSubmittedType,
@@ -3872,6 +3873,42 @@ export async function postFeatureImportDraft(
       );
     }
   } catch (linkErr) {
+    // Hard-delete the just-created draft so its rules — which reference
+    // the SafeRollouts we're about to remove — can't be applied even if
+    // the frontend's archive+delete rollback never runs (browser crash,
+    // lost connectivity, etc.). We use hard-delete (not discardRevision)
+    // because this revision was created seconds ago and has no audit
+    // history worth keeping, and a discarded revision would still carry
+    // the dangling safeRolloutId references the bot flagged.
+    //
+    // Order matters: drop the revision first so it can't reference the
+    // SafeRollouts at the moment we're deleting them. Then we explicitly
+    // clear any pendingFeatureDrafts that partial linkage may have
+    // written for this version, since hard-delete doesn't trigger
+    // syncFeatureExperimentLinkages the way discardRevision does.
+    try {
+      await hardDeleteRevision(context.org.id, feature.id, newDraft.version);
+    } catch (delErr) {
+      logger.warn(
+        delErr,
+        `Failed to delete import draft for ${feature.id} after linkage error`,
+      );
+    }
+    for (const experimentId of experimentRefIds) {
+      try {
+        await removePendingFeatureDraftFromExperiment(
+          context,
+          experimentId,
+          feature.id,
+          newDraft.version,
+        );
+      } catch (pdrErr) {
+        logger.warn(
+          pdrErr,
+          `Failed to clear pending draft link from experiment ${experimentId} after linkage error`,
+        );
+      }
+    }
     for (const srId of createdSafeRolloutIds) {
       try {
         await context.models.safeRollout.deleteById(srId);

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -1286,6 +1286,22 @@ export async function deleteAllRevisionsForFeature(
   });
 }
 
+// Hard-deletes a single revision. Use this only for rollback of a revision
+// that was just created (no published history, no external references).
+// Normal "remove this draft" flows should use `discardRevision` instead —
+// discarded revisions are kept for audit history.
+export async function hardDeleteRevision(
+  organization: string,
+  featureId: string,
+  version: number,
+) {
+  await FeatureRevisionModel.deleteOne({
+    organization,
+    featureId,
+    version,
+  });
+}
+
 export async function cleanUpPreviousRevisions(
   organization: string,
   featureId: string,

--- a/packages/front-end/components/Features/FeatureConfigurationClipboardImporter.tsx
+++ b/packages/front-end/components/Features/FeatureConfigurationClipboardImporter.tsx
@@ -109,6 +109,7 @@ export default function FeatureConfigurationClipboardImporter() {
         });
       }}
       featureToImport={payload.feature}
+      safeRolloutImportSettings={payload.safeRolloutSettings}
     />
   );
 }

--- a/packages/front-end/components/Features/FeatureConfigurationClipboardImporter.tsx
+++ b/packages/front-end/components/Features/FeatureConfigurationClipboardImporter.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { GrowthBookFeatureClipboardFeature } from "shared/validators";
+import FeatureModal from "@/components/Features/FeatureModal";
+import { parseFeatureConfigurationClipboardPayload } from "@/services/feature-configuration-clipboard";
+
+function getClipboardText(event: ClipboardEvent): string {
+  return event.clipboardData?.getData("text/plain") || "";
+}
+
+export default function FeatureConfigurationClipboardImporter() {
+  const router = useRouter();
+  const [featureToImport, setFeatureToImport] =
+    useState<GrowthBookFeatureClipboardFeature | null>(null);
+
+  useEffect(() => {
+    const handlePaste = (event: ClipboardEvent) => {
+      const payload = parseFeatureConfigurationClipboardPayload(
+        getClipboardText(event),
+      );
+      if (!payload) return;
+
+      event.preventDefault();
+      setFeatureToImport(payload.feature);
+    };
+
+    document.addEventListener("paste", handlePaste, true);
+    return () => document.removeEventListener("paste", handlePaste, true);
+  }, []);
+
+  if (!featureToImport) return null;
+
+  return (
+    <FeatureModal
+      cta="Import"
+      close={() => setFeatureToImport(null)}
+      onSuccess={async (feature, options) => {
+        setFeatureToImport(null);
+        await router.push({
+          pathname: `/features/${feature.id}`,
+          query: options?.draftVersion ? { v: options.draftVersion } : {},
+        });
+      }}
+      featureToImport={featureToImport}
+    />
+  );
+}

--- a/packages/front-end/components/Features/FeatureConfigurationClipboardImporter.tsx
+++ b/packages/front-end/components/Features/FeatureConfigurationClipboardImporter.tsx
@@ -1,47 +1,105 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
-import { GrowthBookFeatureClipboardFeature } from "shared/validators";
+import { GrowthBookFeatureClipboardPayload } from "shared/validators";
 import FeatureModal from "@/components/Features/FeatureModal";
+import FeatureConfigurationReferenceMappingModal, {
+  payloadHasReferences,
+} from "@/components/Features/FeatureConfigurationReferenceMappingModal";
 import { parseFeatureConfigurationClipboardPayload } from "@/services/feature-configuration-clipboard";
 
 function getClipboardText(event: ClipboardEvent): string {
   return event.clipboardData?.getData("text/plain") || "";
 }
 
+// Matches the envelope's `"source": "growthbook"` marker tolerating any JSON
+// whitespace between the key and value (covers minified and pretty-printed
+// forms). Far cheaper than JSON.parse on large non-import pastes.
+const GROWTHBOOK_ENVELOPE_MARKER = /"source"\s*:\s*"growthbook"/;
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!target || !(target instanceof HTMLElement)) return false;
+  if (target instanceof HTMLInputElement) {
+    // <input type="button|submit|checkbox|...> isn't a paste sink; only treat
+    // text-like inputs as editable.
+    const nonTextTypes = new Set([
+      "button",
+      "submit",
+      "reset",
+      "checkbox",
+      "radio",
+      "range",
+      "color",
+      "file",
+      "image",
+    ]);
+    return !nonTextTypes.has(target.type);
+  }
+  if (target instanceof HTMLTextAreaElement) return true;
+  if (target instanceof HTMLSelectElement) return false;
+  return target.isContentEditable;
+}
+
+// The import flow is a state machine:
+//   "mapping"  — show the reference-mapping modal (rules reference at least
+//                one cross-org object that the user must resolve)
+//   "creating" — references are resolved (or there were none); show the
+//                FeatureModal that actually creates the feature
+type ImportStep = "mapping" | "creating";
+
 export default function FeatureConfigurationClipboardImporter() {
   const router = useRouter();
-  const [featureToImport, setFeatureToImport] =
-    useState<GrowthBookFeatureClipboardFeature | null>(null);
+  const [payload, setPayload] =
+    useState<GrowthBookFeatureClipboardPayload | null>(null);
+  const [step, setStep] = useState<ImportStep>("creating");
 
   useEffect(() => {
     const handlePaste = (event: ClipboardEvent) => {
-      const payload = parseFeatureConfigurationClipboardPayload(
-        getClipboardText(event),
-      );
-      if (!payload) return;
+      // Never intercept pastes destined for an editable element — the user is
+      // trying to type, not import a feature.
+      if (isEditableTarget(event.target)) return;
+
+      const text = getClipboardText(event);
+      if (!text || !GROWTHBOOK_ENVELOPE_MARKER.test(text)) return;
+
+      const parsed = parseFeatureConfigurationClipboardPayload(text);
+      if (!parsed) return;
 
       event.preventDefault();
-      setFeatureToImport(payload.feature);
+      setPayload(parsed);
+      setStep(payloadHasReferences(parsed) ? "mapping" : "creating");
     };
 
-    document.addEventListener("paste", handlePaste, true);
-    return () => document.removeEventListener("paste", handlePaste, true);
+    document.addEventListener("paste", handlePaste);
+    return () => document.removeEventListener("paste", handlePaste);
   }, []);
 
-  if (!featureToImport) return null;
+  if (!payload) return null;
+
+  if (step === "mapping") {
+    return (
+      <FeatureConfigurationReferenceMappingModal
+        payload={payload}
+        close={() => setPayload(null)}
+        onConfirm={(mapped) => {
+          setPayload(mapped);
+          setStep("creating");
+        }}
+      />
+    );
+  }
 
   return (
     <FeatureModal
       cta="Import"
-      close={() => setFeatureToImport(null)}
+      close={() => setPayload(null)}
       onSuccess={async (feature, options) => {
-        setFeatureToImport(null);
+        setPayload(null);
         await router.push({
           pathname: `/features/${feature.id}`,
           query: options?.draftVersion ? { v: options.draftVersion } : {},
         });
       }}
-      featureToImport={featureToImport}
+      featureToImport={payload.feature}
     />
   );
 }

--- a/packages/front-end/components/Features/FeatureConfigurationClipboardImporter.tsx
+++ b/packages/front-end/components/Features/FeatureConfigurationClipboardImporter.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
-import { GrowthBookFeatureClipboardPayload } from "shared/validators";
+import { GrowthBookClipboardPayload } from "shared/validators";
 import FeatureModal from "@/components/Features/FeatureModal";
 import FeatureConfigurationReferenceMappingModal, {
   payloadHasReferences,
@@ -48,8 +48,9 @@ type ImportStep = "mapping" | "creating";
 
 export default function FeatureConfigurationClipboardImporter() {
   const router = useRouter();
-  const [payload, setPayload] =
-    useState<GrowthBookFeatureClipboardPayload | null>(null);
+  const [payload, setPayload] = useState<GrowthBookClipboardPayload | null>(
+    null,
+  );
   const [step, setStep] = useState<ImportStep>("creating");
 
   useEffect(() => {

--- a/packages/front-end/components/Features/FeatureConfigurationClipboardImporter.tsx
+++ b/packages/front-end/components/Features/FeatureConfigurationClipboardImporter.tsx
@@ -52,6 +52,12 @@ export default function FeatureConfigurationClipboardImporter() {
     null,
   );
   const [step, setStep] = useState<ImportStep>("creating");
+  // Bumped on every fresh paste. Used as the FeatureModal `key` so that a
+  // second paste while the modal is already open remounts the form — useForm
+  // only honors `defaultValues` at mount, so without a remount the second
+  // payload's id/rules/project would be ignored and the modal would submit
+  // the first payload's values.
+  const [pasteSequence, setPasteSequence] = useState(0);
 
   useEffect(() => {
     const handlePaste = (event: ClipboardEvent) => {
@@ -68,6 +74,7 @@ export default function FeatureConfigurationClipboardImporter() {
       event.preventDefault();
       setPayload(parsed);
       setStep(payloadHasReferences(parsed) ? "mapping" : "creating");
+      setPasteSequence((n) => n + 1);
     };
 
     document.addEventListener("paste", handlePaste);
@@ -91,6 +98,7 @@ export default function FeatureConfigurationClipboardImporter() {
 
   return (
     <FeatureModal
+      key={pasteSequence}
       cta="Import"
       close={() => setPayload(null)}
       onSuccess={async (feature, options) => {

--- a/packages/front-end/components/Features/FeatureConfigurationReferenceMappingModal.tsx
+++ b/packages/front-end/components/Features/FeatureConfigurationReferenceMappingModal.tsx
@@ -1,0 +1,326 @@
+import { useMemo, useState } from "react";
+import { Box, Flex } from "@radix-ui/themes";
+import { PiArrowRight } from "react-icons/pi";
+import {
+  GrowthBookClipboardReferenceContext,
+  GrowthBookFeatureClipboardPayload,
+  SafeRolloutInterface,
+} from "shared/validators";
+import { FeatureInterface } from "shared/types/feature";
+import { ExperimentInterfaceStringDates } from "shared/types/experiment";
+import Modal from "@/ui/Modal";
+import ModalForm from "@/ui/Modal/ModalForm";
+import Button from "@/ui/Button";
+import Text from "@/ui/Text";
+import SelectField from "@/components/Forms/SelectField";
+import Callout from "@/ui/Callout";
+import useApi from "@/hooks/useApi";
+import { useDefinitions } from "@/services/DefinitionsContext";
+import { useExperiments } from "@/hooks/useExperiments";
+import { useEnvironments, useFeaturesList } from "@/services/features";
+import {
+  applyFeatureReferenceMappings,
+  EMPTY_FEATURE_REFERENCE_MAPPINGS,
+  FeatureReferenceCategory,
+  FeatureReferenceMappings,
+} from "@/services/feature-configuration-clipboard";
+
+type CategoryDescriptor = {
+  category: FeatureReferenceCategory;
+  title: string;
+  emptyMessage: string;
+};
+
+const CATEGORIES: CategoryDescriptor[] = [
+  {
+    category: "experiments",
+    title: "Experiments",
+    emptyMessage:
+      "No experiments in this organization. Mapping not available — these rules will be created with their original (broken) reference.",
+  },
+  {
+    category: "savedGroups",
+    title: "Saved Groups",
+    emptyMessage:
+      "No saved groups in this organization. Mapping not available — these references will be left as-is.",
+  },
+  {
+    category: "safeRollouts",
+    title: "Safe Rollouts",
+    emptyMessage:
+      "No safe rollouts in this organization. Mapping not available — these rules will be created with their original (broken) reference.",
+  },
+  {
+    category: "features",
+    title: "Prerequisite Features",
+    emptyMessage:
+      "No other features in this organization. Mapping not available — these prerequisites will be left as-is.",
+  },
+  {
+    category: "environments",
+    title: "Environments",
+    emptyMessage:
+      "No environments configured in this organization. Mapping not available — env-scoped rules will keep their source ids.",
+  },
+];
+
+type Option = { label: string; value: string };
+
+// Returns the references manifest grouped by category. The manifest is the
+// source of truth for which references to show — it's produced by the
+// exporter, which knows which ids each rule referenced and enriches them with
+// source-org names + details.
+function buildReferenceRows(
+  payload: GrowthBookFeatureClipboardPayload,
+): Record<FeatureReferenceCategory, GrowthBookClipboardReferenceContext[]> {
+  return {
+    experiments: payload.references.experiments,
+    savedGroups: payload.references.savedGroups,
+    safeRollouts: payload.references.safeRollouts,
+    features: payload.references.features,
+    environments: payload.references.environments,
+  };
+}
+
+export default function FeatureConfigurationReferenceMappingModal({
+  payload,
+  close,
+  onConfirm,
+}: {
+  payload: GrowthBookFeatureClipboardPayload;
+  close: () => void;
+  onConfirm: (mappedPayload: GrowthBookFeatureClipboardPayload) => void;
+}) {
+  const rowsByCategory = useMemo(() => buildReferenceRows(payload), [payload]);
+
+  const totalRefs =
+    rowsByCategory.experiments.length +
+    rowsByCategory.savedGroups.length +
+    rowsByCategory.safeRollouts.length +
+    rowsByCategory.features.length +
+    rowsByCategory.environments.length;
+
+  const { experiments } = useExperiments(undefined, /* includeArchived */ true);
+  const { savedGroups } = useDefinitions();
+  const { data: safeRolloutsData } = useApi<{
+    status: 200;
+    safeRollouts: SafeRolloutInterface[];
+  }>("/safe-rollout");
+  const { features } = useFeaturesList({
+    useCurrentProject: false,
+    includeArchived: true,
+  });
+  const destinationEnvironments = useEnvironments();
+
+  const optionsByCategory: Record<FeatureReferenceCategory, Option[]> = useMemo(
+    () => ({
+      experiments: experiments.map(
+        (e: ExperimentInterfaceStringDates): Option => ({
+          label: e.name ? `${e.name} (${e.id})` : e.id,
+          value: e.id,
+        }),
+      ),
+      savedGroups: savedGroups.map(
+        (sg): Option => ({
+          label: sg.groupName ? `${sg.groupName} (${sg.id})` : sg.id,
+          value: sg.id,
+        }),
+      ),
+      safeRollouts: (safeRolloutsData?.safeRollouts ?? []).map(
+        (sr): Option => ({
+          label: sr.featureId
+            ? `${sr.featureId} / ${sr.environment} (${sr.id})`
+            : sr.id,
+          value: sr.id,
+        }),
+      ),
+      features: (features ?? []).map(
+        (f: FeatureInterface): Option => ({
+          label: f.description ? `${f.id} — ${f.description}` : f.id,
+          value: f.id,
+        }),
+      ),
+      environments: destinationEnvironments.map(
+        (env): Option => ({
+          label: env.description ? `${env.id} — ${env.description}` : env.id,
+          value: env.id,
+        }),
+      ),
+    }),
+    [
+      experiments,
+      savedGroups,
+      safeRolloutsData,
+      features,
+      destinationEnvironments,
+    ],
+  );
+
+  // Pre-populate any reference whose source id exists in the destination org.
+  // For those rows we leave the SelectField at that value so the user can
+  // confirm or override; everything else starts blank and must be chosen.
+  const [mappings, setMappings] = useState<FeatureReferenceMappings>(() => {
+    const next: FeatureReferenceMappings = {
+      experiments: { ...EMPTY_FEATURE_REFERENCE_MAPPINGS.experiments },
+      savedGroups: { ...EMPTY_FEATURE_REFERENCE_MAPPINGS.savedGroups },
+      safeRollouts: { ...EMPTY_FEATURE_REFERENCE_MAPPINGS.safeRollouts },
+      features: { ...EMPTY_FEATURE_REFERENCE_MAPPINGS.features },
+      environments: { ...EMPTY_FEATURE_REFERENCE_MAPPINGS.environments },
+    };
+    (Object.keys(rowsByCategory) as FeatureReferenceCategory[]).forEach(
+      (category) => {
+        const validIds = new Set(
+          optionsByCategory[category].map((o) => o.value),
+        );
+        rowsByCategory[category].forEach((row) => {
+          if (validIds.has(row.id)) next[category][row.id] = row.id;
+        });
+      },
+    );
+    return next;
+  });
+
+  // We treat the form as complete once every row either has an explicit
+  // mapping or is skipped because no options exist in the destination org.
+  const allMapped = (
+    Object.keys(rowsByCategory) as FeatureReferenceCategory[]
+  ).every((category) => {
+    const options = optionsByCategory[category];
+    if (!options.length) return true;
+    return rowsByCategory[category].every(
+      (row) => !!mappings[category][row.id],
+    );
+  });
+
+  if (totalRefs === 0) {
+    // Defensive: parent should have skipped opening this modal. Auto-confirm.
+    onConfirm(payload);
+    return null;
+  }
+
+  return (
+    <Modal.Root
+      open
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) close();
+      }}
+      size="lg"
+      trackingEventModalType="feature-import-reference-mapping"
+    >
+      <ModalForm
+        onSubmit={() => {
+          // Advance the state machine manually here. We deliberately avoid
+          // ModalStandard (which would call `close()` on submit success) —
+          // `close` is wired to clear the import payload, which would race
+          // the `onConfirm` update and drop us out of the flow with no UI.
+          const mappedFeature = applyFeatureReferenceMappings(
+            payload.feature,
+            mappings,
+          );
+          onConfirm({ ...payload, feature: mappedFeature });
+        }}
+      >
+        <Modal.Header>
+          <Modal.Title>Map References Before Importing</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Callout status="info" mb="3">
+            This feature was exported from another GrowthBook instance and
+            references objects that may not exist here. Pick the matching
+            experiment, saved group, safe rollout, or feature in this
+            organization for each reference below.
+          </Callout>
+
+          {CATEGORIES.map((cat) => {
+            const rows = rowsByCategory[cat.category];
+            if (!rows.length) return null;
+            const options = optionsByCategory[cat.category];
+            return (
+              <Box key={cat.category} mb="4">
+                <Text size="large" weight="semibold">
+                  {cat.title}
+                </Text>
+                {options.length === 0 ? (
+                  <Callout status="warning" mt="2">
+                    {cat.emptyMessage}
+                  </Callout>
+                ) : (
+                  <Box mt="2">
+                    {rows.map((row) => (
+                      <Flex
+                        key={row.id}
+                        align="center"
+                        gap="3"
+                        mb="3"
+                        style={{ width: "100%" }}
+                      >
+                        <Box style={{ flex: 1, minWidth: 0 }}>
+                          <Text weight="medium" as="div">
+                            {row.name || row.id}
+                          </Text>
+                          <Text size="small" as="div" color="text-low">
+                            {row.id}
+                          </Text>
+                          {row.details && (
+                            <Text size="small" as="div" color="text-low">
+                              {row.details}
+                            </Text>
+                          )}
+                        </Box>
+                        <Box style={{ flexShrink: 0 }}>
+                          <PiArrowRight size={18} />
+                        </Box>
+                        <Box style={{ flex: 1, minWidth: 0 }}>
+                          <SelectField
+                            value={mappings[cat.category][row.id] ?? ""}
+                            options={options}
+                            placeholder={`Select a ${cat.title.toLowerCase().slice(0, -1)}...`}
+                            onChange={(value) => {
+                              setMappings((prev) => ({
+                                ...prev,
+                                [cat.category]: {
+                                  ...prev[cat.category],
+                                  [row.id]: value,
+                                },
+                              }));
+                            }}
+                            sort
+                          />
+                        </Box>
+                      </Flex>
+                    ))}
+                  </Box>
+                )}
+              </Box>
+            );
+          })}
+        </Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button variant="ghost" onClick={close}>
+              Cancel
+            </Button>
+          </Modal.Close>
+          <Button type="submit" disabled={!allMapped}>
+            Continue
+          </Button>
+        </Modal.Footer>
+      </ModalForm>
+    </Modal.Root>
+  );
+}
+
+// Helper used by the parent to decide whether to render the modal at all.
+// Returns true if the payload's references manifest contains at least one
+// cross-org reference that the importer needs to resolve.
+export function payloadHasReferences(
+  payload: GrowthBookFeatureClipboardPayload,
+): boolean {
+  const r = payload.references;
+  return (
+    r.experiments.length > 0 ||
+    r.savedGroups.length > 0 ||
+    r.safeRollouts.length > 0 ||
+    r.features.length > 0
+  );
+}

--- a/packages/front-end/components/Features/FeatureConfigurationReferenceMappingModal.tsx
+++ b/packages/front-end/components/Features/FeatureConfigurationReferenceMappingModal.tsx
@@ -321,6 +321,7 @@ export function payloadHasReferences(
     r.experiments.length > 0 ||
     r.savedGroups.length > 0 ||
     r.safeRollouts.length > 0 ||
-    r.features.length > 0
+    r.features.length > 0 ||
+    r.environments.length > 0
   );
 }

--- a/packages/front-end/components/Features/FeatureConfigurationReferenceMappingModal.tsx
+++ b/packages/front-end/components/Features/FeatureConfigurationReferenceMappingModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Box, Flex } from "@radix-ui/themes";
 import { PiArrowRight } from "react-icons/pi";
 import {
@@ -100,17 +100,30 @@ export default function FeatureConfigurationReferenceMappingModal({
     rowsByCategory.features.length +
     rowsByCategory.environments.length;
 
-  const { experiments } = useExperiments(undefined, /* includeArchived */ true);
+  const { experiments, loading: experimentsLoading } = useExperiments(
+    undefined,
+    /* includeArchived */ true,
+  );
   const { savedGroups } = useDefinitions();
-  const { data: safeRolloutsData } = useApi<{
+  const { data: safeRolloutsData, error: safeRolloutsError } = useApi<{
     status: 200;
     safeRollouts: SafeRolloutInterface[];
   }>("/safe-rollout");
-  const { features } = useFeaturesList({
+  const { features, loading: featuresLoading } = useFeaturesList({
     useCurrentProject: false,
     includeArchived: true,
   });
   const destinationEnvironments = useEnvironments();
+
+  // We need to wait for every async source before we can pre-populate
+  // identity mappings or trust `allMapped`. Otherwise during the loading
+  // window options.length === 0 for not-yet-loaded categories, which would
+  // (a) make Continue look ready and (b) cause it to flip to disabled once
+  // data arrives — and the user's auto-populated rows would be missing.
+  const loading =
+    experimentsLoading ||
+    featuresLoading ||
+    (!safeRolloutsData && !safeRolloutsError);
 
   const optionsByCategory: Record<FeatureReferenceCategory, Option[]> = useMemo(
     () => ({
@@ -156,47 +169,69 @@ export default function FeatureConfigurationReferenceMappingModal({
     ],
   );
 
-  // Pre-populate any reference whose source id exists in the destination org.
-  // For those rows we leave the SelectField at that value so the user can
-  // confirm or override; everything else starts blank and must be chosen.
-  const [mappings, setMappings] = useState<FeatureReferenceMappings>(() => {
-    const next: FeatureReferenceMappings = {
-      experiments: { ...EMPTY_FEATURE_REFERENCE_MAPPINGS.experiments },
-      savedGroups: { ...EMPTY_FEATURE_REFERENCE_MAPPINGS.savedGroups },
-      safeRollouts: { ...EMPTY_FEATURE_REFERENCE_MAPPINGS.safeRollouts },
-      features: { ...EMPTY_FEATURE_REFERENCE_MAPPINGS.features },
-      environments: { ...EMPTY_FEATURE_REFERENCE_MAPPINGS.environments },
-    };
-    (Object.keys(rowsByCategory) as FeatureReferenceCategory[]).forEach(
+  // Mappings start empty and get pre-populated once the async option sources
+  // settle (see useEffect below). Pre-population identifies any reference id
+  // that exists verbatim in the destination org and seeds it as a default
+  // selection the user can confirm or override.
+  const [mappings, setMappings] = useState<FeatureReferenceMappings>(() => ({
+    experiments: { ...EMPTY_FEATURE_REFERENCE_MAPPINGS.experiments },
+    savedGroups: { ...EMPTY_FEATURE_REFERENCE_MAPPINGS.savedGroups },
+    safeRollouts: { ...EMPTY_FEATURE_REFERENCE_MAPPINGS.safeRollouts },
+    features: { ...EMPTY_FEATURE_REFERENCE_MAPPINGS.features },
+    environments: { ...EMPTY_FEATURE_REFERENCE_MAPPINGS.environments },
+  }));
+
+  const prepopulatedRef = useRef(false);
+  useEffect(() => {
+    if (loading || prepopulatedRef.current) return;
+    prepopulatedRef.current = true;
+    setMappings((prev) => {
+      const next: FeatureReferenceMappings = {
+        experiments: { ...prev.experiments },
+        savedGroups: { ...prev.savedGroups },
+        safeRollouts: { ...prev.safeRollouts },
+        features: { ...prev.features },
+        environments: { ...prev.environments },
+      };
+      (Object.keys(rowsByCategory) as FeatureReferenceCategory[]).forEach(
+        (category) => {
+          const validIds = new Set(
+            optionsByCategory[category].map((o) => o.value),
+          );
+          rowsByCategory[category].forEach((row) => {
+            // Don't clobber a value the user already touched.
+            if (next[category][row.id]) return;
+            if (validIds.has(row.id)) next[category][row.id] = row.id;
+          });
+        },
+      );
+      return next;
+    });
+  }, [loading, rowsByCategory, optionsByCategory]);
+
+  // Defensive: parent should have skipped opening this modal when there are
+  // no references. Auto-confirm in an effect so we don't set state on the
+  // parent during this component's render.
+  useEffect(() => {
+    if (totalRefs === 0) onConfirm(payload);
+  }, [totalRefs, onConfirm, payload]);
+
+  // The form is complete once every row in every category with available
+  // options has a mapping. We require !loading so a category whose options
+  // haven't arrived yet doesn't masquerade as "no options, skip".
+  const allMapped =
+    !loading &&
+    (Object.keys(rowsByCategory) as FeatureReferenceCategory[]).every(
       (category) => {
-        const validIds = new Set(
-          optionsByCategory[category].map((o) => o.value),
+        const options = optionsByCategory[category];
+        if (!options.length) return true;
+        return rowsByCategory[category].every(
+          (row) => !!mappings[category][row.id],
         );
-        rowsByCategory[category].forEach((row) => {
-          if (validIds.has(row.id)) next[category][row.id] = row.id;
-        });
       },
     );
-    return next;
-  });
 
-  // We treat the form as complete once every row either has an explicit
-  // mapping or is skipped because no options exist in the destination org.
-  const allMapped = (
-    Object.keys(rowsByCategory) as FeatureReferenceCategory[]
-  ).every((category) => {
-    const options = optionsByCategory[category];
-    if (!options.length) return true;
-    return rowsByCategory[category].every(
-      (row) => !!mappings[category][row.id],
-    );
-  });
-
-  if (totalRefs === 0) {
-    // Defensive: parent should have skipped opening this modal. Auto-confirm.
-    onConfirm(payload);
-    return null;
-  }
+  if (totalRefs === 0) return null;
 
   return (
     <Modal.Root
@@ -231,6 +266,12 @@ export default function FeatureConfigurationReferenceMappingModal({
             organization for each reference below.
           </Callout>
 
+          {loading && (
+            <Callout status="info" mb="3">
+              Loading destination options…
+            </Callout>
+          )}
+
           {CATEGORIES.map((cat) => {
             const rows = rowsByCategory[cat.category];
             if (!rows.length) return null;
@@ -240,7 +281,7 @@ export default function FeatureConfigurationReferenceMappingModal({
                 <Text size="large" weight="semibold">
                   {cat.title}
                 </Text>
-                {options.length === 0 ? (
+                {loading ? null : options.length === 0 ? (
                   <Callout status="warning" mt="2">
                     {cat.emptyMessage}
                   </Callout>

--- a/packages/front-end/components/Features/FeatureConfigurationReferenceMappingModal.tsx
+++ b/packages/front-end/components/Features/FeatureConfigurationReferenceMappingModal.tsx
@@ -182,6 +182,22 @@ export default function FeatureConfigurationReferenceMappingModal({
   }));
 
   const prepopulatedRef = useRef(false);
+  // If the user pastes a second envelope while the modal is still mounted,
+  // `payload` swaps under us. Clear the prepop guard and any selections from
+  // the previous payload so the prepop effect below re-runs against the new
+  // reference rows instead of leaving stale mappings pointing at ids the
+  // new payload doesn't contain.
+  useEffect(() => {
+    prepopulatedRef.current = false;
+    setMappings({
+      experiments: { ...EMPTY_FEATURE_REFERENCE_MAPPINGS.experiments },
+      savedGroups: { ...EMPTY_FEATURE_REFERENCE_MAPPINGS.savedGroups },
+      safeRollouts: { ...EMPTY_FEATURE_REFERENCE_MAPPINGS.safeRollouts },
+      features: { ...EMPTY_FEATURE_REFERENCE_MAPPINGS.features },
+      environments: { ...EMPTY_FEATURE_REFERENCE_MAPPINGS.environments },
+    });
+  }, [payload]);
+
   useEffect(() => {
     if (loading || prepopulatedRef.current) return;
     prepopulatedRef.current = true;

--- a/packages/front-end/components/Features/FeatureConfigurationReferenceMappingModal.tsx
+++ b/packages/front-end/components/Features/FeatureConfigurationReferenceMappingModal.tsx
@@ -3,7 +3,7 @@ import { Box, Flex } from "@radix-ui/themes";
 import { PiArrowRight } from "react-icons/pi";
 import {
   GrowthBookClipboardReferenceContext,
-  GrowthBookFeatureClipboardPayload,
+  GrowthBookClipboardPayload,
   SafeRolloutInterface,
 } from "shared/validators";
 import { FeatureInterface } from "shared/types/feature";
@@ -71,7 +71,7 @@ type Option = { label: string; value: string };
 // exporter, which knows which ids each rule referenced and enriches them with
 // source-org names + details.
 function buildReferenceRows(
-  payload: GrowthBookFeatureClipboardPayload,
+  payload: GrowthBookClipboardPayload,
 ): Record<FeatureReferenceCategory, GrowthBookClipboardReferenceContext[]> {
   return {
     experiments: payload.references.experiments,
@@ -87,9 +87,9 @@ export default function FeatureConfigurationReferenceMappingModal({
   close,
   onConfirm,
 }: {
-  payload: GrowthBookFeatureClipboardPayload;
+  payload: GrowthBookClipboardPayload;
   close: () => void;
-  onConfirm: (mappedPayload: GrowthBookFeatureClipboardPayload) => void;
+  onConfirm: (mappedPayload: GrowthBookClipboardPayload) => void;
 }) {
   const rowsByCategory = useMemo(() => buildReferenceRows(payload), [payload]);
 
@@ -193,21 +193,57 @@ export default function FeatureConfigurationReferenceMappingModal({
         features: { ...prev.features },
         environments: { ...prev.environments },
       };
+      // Name-fallback lookups for the categories where the entity has a real
+      // human-readable name distinct from its id. Only seed from name when
+      // exactly one destination shares that name — ambiguous matches are left
+      // for the user to disambiguate.
+      const nameToIds: Partial<
+        Record<FeatureReferenceCategory, Map<string, string[]>>
+      > = {};
+      const addName = (
+        category: FeatureReferenceCategory,
+        name: string | undefined,
+        id: string,
+      ) => {
+        if (!name) return;
+        const key = name.trim().toLowerCase();
+        if (!key) return;
+        const map = nameToIds[category] ?? new Map<string, string[]>();
+        const ids = map.get(key) ?? [];
+        ids.push(id);
+        map.set(key, ids);
+        nameToIds[category] = map;
+      };
+      experiments.forEach((e: ExperimentInterfaceStringDates) =>
+        addName("experiments", e.name, e.id),
+      );
+      savedGroups.forEach((sg) => addName("savedGroups", sg.groupName, sg.id));
+
       (Object.keys(rowsByCategory) as FeatureReferenceCategory[]).forEach(
         (category) => {
           const validIds = new Set(
             optionsByCategory[category].map((o) => o.value),
           );
+          const byName = nameToIds[category];
           rowsByCategory[category].forEach((row) => {
             // Don't clobber a value the user already touched.
             if (next[category][row.id]) return;
-            if (validIds.has(row.id)) next[category][row.id] = row.id;
+            if (validIds.has(row.id)) {
+              next[category][row.id] = row.id;
+              return;
+            }
+            if (byName && row.name) {
+              const candidates = byName.get(row.name.trim().toLowerCase());
+              if (candidates && candidates.length === 1) {
+                next[category][row.id] = candidates[0];
+              }
+            }
           });
         },
       );
       return next;
     });
-  }, [loading, rowsByCategory, optionsByCategory]);
+  }, [loading, rowsByCategory, optionsByCategory, experiments, savedGroups]);
 
   // Defensive: parent should have skipped opening this modal when there are
   // no references. Auto-confirm in an effect so we don't set state on the
@@ -355,7 +391,7 @@ export default function FeatureConfigurationReferenceMappingModal({
 // Returns true if the payload's references manifest contains at least one
 // cross-org reference that the importer needs to resolve.
 export function payloadHasReferences(
-  payload: GrowthBookFeatureClipboardPayload,
+  payload: GrowthBookClipboardPayload,
 ): boolean {
   const r = payload.references;
   return (

--- a/packages/front-end/components/Features/FeatureConfigurationReferenceMappingModal.tsx
+++ b/packages/front-end/components/Features/FeatureConfigurationReferenceMappingModal.tsx
@@ -4,7 +4,6 @@ import { PiArrowRight } from "react-icons/pi";
 import {
   GrowthBookClipboardReferenceContext,
   GrowthBookClipboardPayload,
-  SafeRolloutInterface,
 } from "shared/validators";
 import { FeatureInterface } from "shared/types/feature";
 import { ExperimentInterfaceStringDates } from "shared/types/experiment";
@@ -14,7 +13,6 @@ import Button from "@/ui/Button";
 import Text from "@/ui/Text";
 import SelectField from "@/components/Forms/SelectField";
 import Callout from "@/ui/Callout";
-import useApi from "@/hooks/useApi";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useExperiments } from "@/hooks/useExperiments";
 import { useEnvironments, useFeaturesList } from "@/services/features";
@@ -31,6 +29,11 @@ type CategoryDescriptor = {
   emptyMessage: string;
 };
 
+// Safe rollouts are intentionally NOT user-mappable: they're per-feature, so
+// pointing an imported rule at a destination safe rollout that belongs to a
+// different feature would be incoherent. The backend creates fresh
+// SafeRollouts during import using the source settings carried in the
+// envelope and rewrites rule.safeRolloutId.
 const CATEGORIES: CategoryDescriptor[] = [
   {
     category: "experiments",
@@ -43,12 +46,6 @@ const CATEGORIES: CategoryDescriptor[] = [
     title: "Saved Groups",
     emptyMessage:
       "No saved groups in this organization. Mapping not available — these references will be left as-is.",
-  },
-  {
-    category: "safeRollouts",
-    title: "Safe Rollouts",
-    emptyMessage:
-      "No safe rollouts in this organization. Mapping not available — these rules will be created with their original (broken) reference.",
   },
   {
     category: "features",
@@ -76,7 +73,9 @@ function buildReferenceRows(
   return {
     experiments: payload.references.experiments,
     savedGroups: payload.references.savedGroups,
-    safeRollouts: payload.references.safeRollouts,
+    // safeRollouts intentionally excluded — backend auto-creates these,
+    // they don't need (and can't sensibly receive) user mapping.
+    safeRollouts: [],
     features: payload.references.features,
     environments: payload.references.environments,
   };
@@ -105,10 +104,6 @@ export default function FeatureConfigurationReferenceMappingModal({
     /* includeArchived */ true,
   );
   const { savedGroups } = useDefinitions();
-  const { data: safeRolloutsData, error: safeRolloutsError } = useApi<{
-    status: 200;
-    safeRollouts: SafeRolloutInterface[];
-  }>("/safe-rollout");
   const { features, loading: featuresLoading } = useFeaturesList({
     useCurrentProject: false,
     includeArchived: true,
@@ -120,10 +115,7 @@ export default function FeatureConfigurationReferenceMappingModal({
   // window options.length === 0 for not-yet-loaded categories, which would
   // (a) make Continue look ready and (b) cause it to flip to disabled once
   // data arrives — and the user's auto-populated rows would be missing.
-  const loading =
-    experimentsLoading ||
-    featuresLoading ||
-    (!safeRolloutsData && !safeRolloutsError);
+  const loading = experimentsLoading || featuresLoading;
 
   const optionsByCategory: Record<FeatureReferenceCategory, Option[]> = useMemo(
     () => ({
@@ -139,14 +131,9 @@ export default function FeatureConfigurationReferenceMappingModal({
           value: sg.id,
         }),
       ),
-      safeRollouts: (safeRolloutsData?.safeRollouts ?? []).map(
-        (sr): Option => ({
-          label: sr.featureId
-            ? `${sr.featureId} / ${sr.environment} (${sr.id})`
-            : sr.id,
-          value: sr.id,
-        }),
-      ),
+      // No options — backend auto-creates SafeRollouts; rows for this
+      // category are always empty (see buildReferenceRows).
+      safeRollouts: [],
       features: (features ?? []).map(
         (f: FeatureInterface): Option => ({
           label: f.description ? `${f.id} — ${f.description}` : f.id,
@@ -160,13 +147,7 @@ export default function FeatureConfigurationReferenceMappingModal({
         }),
       ),
     }),
-    [
-      experiments,
-      savedGroups,
-      safeRolloutsData,
-      features,
-      destinationEnvironments,
-    ],
+    [experiments, savedGroups, features, destinationEnvironments],
   );
 
   // Mappings start empty and get pre-populated once the async option sources
@@ -405,7 +386,9 @@ export default function FeatureConfigurationReferenceMappingModal({
 
 // Helper used by the parent to decide whether to render the modal at all.
 // Returns true if the payload's references manifest contains at least one
-// cross-org reference that the importer needs to resolve.
+// USER-MAPPABLE cross-org reference. Safe rollouts are intentionally
+// excluded — the backend auto-creates them — so a payload whose only refs
+// are safe rollouts skips straight to the FeatureModal.
 export function payloadHasReferences(
   payload: GrowthBookClipboardPayload,
 ): boolean {
@@ -413,7 +396,6 @@ export function payloadHasReferences(
   return (
     r.experiments.length > 0 ||
     r.savedGroups.length > 0 ||
-    r.safeRollouts.length > 0 ||
     r.features.length > 0 ||
     r.environments.length > 0
   );

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -294,11 +294,15 @@ export default function FeatureModal({
           throw new Error("Please select a value type");
         }
 
-        // When duplicating, skip JSON schema validation since the value is
-        // copied verbatim from an existing feature and the user cannot edit it.
-        const featureForValidation = featureToDuplicate
-          ? { valueType: feature.valueType }
-          : feature;
+        // When duplicating or importing, skip JSON schema validation since
+        // the value is copied verbatim from an existing valid feature and the
+        // user cannot edit it in this modal. Running validateFeatureValue
+        // with the full feature can "fix" an already-valid value and force
+        // the confusing two-submit dance.
+        const featureForValidation =
+          featureToDuplicate || featureToImport
+            ? { valueType: feature.valueType }
+            : feature;
         const newDefaultValue = validateFeatureValue(
           featureForValidation,
           defaultValue,

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -348,7 +348,7 @@ export default function FeatureModal({
             }>(`/feature/${res.feature.id}/import-draft`, {
               method: "POST",
               body: JSON.stringify({
-                rules,
+                rules: feature.rules,
                 environmentsEnabled: Object.fromEntries(
                   Object.keys(createEnvironmentSettings).map((env) => [
                     env,
@@ -379,7 +379,8 @@ export default function FeatureModal({
         track("Feature Created", {
           valueType: values.valueType,
           hasDescription: !!values.description?.length,
-          initialRule: isImport && rules.length ? "imported-draft" : "none",
+          initialRule:
+            isImport && feature.rules?.length ? "imported-draft" : "none",
         });
         values.tags && refreshTags(values.tags);
         refreshWatching();

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -4,7 +4,10 @@ import {
   FeatureInterface,
   FeatureValueType,
 } from "shared/types/feature";
-import { GrowthBookClipboardFeature } from "shared/validators";
+import {
+  ClipboardSafeRolloutSettings,
+  GrowthBookClipboardFeature,
+} from "shared/validators";
 import React, { ReactElement } from "react";
 import { validateFeatureValue } from "shared/util";
 import { PiInfo } from "react-icons/pi";
@@ -52,6 +55,11 @@ export type Props = {
   secondaryCTA?: ReactElement;
   featureToDuplicate?: FeatureInterface;
   featureToImport?: GrowthBookClipboardFeature;
+  // Source-org safe-rollout settings indexed by source safeRolloutId — the
+  // backend needs these to mint fresh SafeRollouts in the destination during
+  // import. Lives one level up on the clipboard payload (not inside
+  // `featureToImport`), so the importer forwards it as a separate prop.
+  safeRolloutImportSettings?: Record<string, ClipboardSafeRolloutSettings>;
   features?: FeatureInterface[];
 };
 
@@ -199,6 +207,7 @@ export default function FeatureModal({
   secondaryCTA,
   featureToDuplicate,
   featureToImport,
+  safeRolloutImportSettings,
 }: Props) {
   const { project, refreshTags } = useDefinitions();
   const environments = useEnvironments();
@@ -364,6 +373,11 @@ export default function FeatureModal({
                     true,
                   ]),
                 ),
+                // Source-org SafeRollout settings; the backend mints fresh
+                // destination SafeRollouts from these and rewrites
+                // rule.safeRolloutId. Omitting this would cause the
+                // import-draft endpoint to throw for any safe-rollout rule.
+                safeRolloutSettings: safeRolloutImportSettings,
                 title: "Imported feature configuration",
                 comment:
                   "Imported from a copied GrowthBook feature configuration.",

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -4,6 +4,7 @@ import {
   FeatureInterface,
   FeatureValueType,
 } from "shared/types/feature";
+import { GrowthBookFeatureClipboardFeature } from "shared/validators";
 import React, { ReactElement } from "react";
 import { validateFeatureValue } from "shared/util";
 import { PiInfo } from "react-icons/pi";
@@ -42,22 +43,28 @@ import ValueTypeField from "./ValueTypeField";
 
 export type Props = {
   close?: () => void;
-  onSuccess: (feature: FeatureInterface) => Promise<void>;
+  onSuccess: (
+    feature: FeatureInterface,
+    options?: { draftVersion?: number },
+  ) => Promise<void>;
   inline?: boolean;
   cta?: string;
   secondaryCTA?: ReactElement;
   featureToDuplicate?: FeatureInterface;
+  featureToImport?: GrowthBookFeatureClipboardFeature;
   features?: FeatureInterface[];
 };
 
 const genEnvironmentSettings = ({
   environments,
   featureToDuplicate,
+  featureToImport,
   permissions,
   project,
 }: {
   environments: ReturnType<typeof useEnvironments>;
   featureToDuplicate?: FeatureInterface;
+  featureToImport?: GrowthBookFeatureClipboardFeature;
   permissions: ReturnType<typeof usePermissionsUtil>;
   project: string;
 }): Record<string, FeatureEnvironment> => {
@@ -66,10 +73,12 @@ const genEnvironmentSettings = ({
   environments.forEach((e) => {
     const canPublish = permissions.canPublishFeature({ project }, [e.id]);
     const defaultEnabled = canPublish ? (e.defaultState ?? true) : false;
-    const enabled = canPublish
-      ? (featureToDuplicate?.environmentSettings?.[e.id]?.enabled ??
-        defaultEnabled)
-      : false;
+    const enabled = featureToImport
+      ? false
+      : canPublish
+        ? (featureToDuplicate?.environmentSettings?.[e.id]?.enabled ??
+          defaultEnabled)
+        : false;
 
     envSettings[e.id] = { enabled };
   });
@@ -81,12 +90,14 @@ const genFormDefaultValues = ({
   environments,
   permissions: permissionsUtil,
   featureToDuplicate,
+  featureToImport,
   project,
   customFields,
 }: {
   environments: ReturnType<typeof useEnvironments>;
   permissions: ReturnType<typeof usePermissionsUtil>;
   featureToDuplicate?: FeatureInterface;
+  featureToImport?: GrowthBookFeatureClipboardFeature;
   project: string;
   customFields?: ReturnType<typeof useCustomFields>;
 }): Pick<
@@ -106,6 +117,7 @@ const genFormDefaultValues = ({
   const environmentSettings = genEnvironmentSettings({
     environments,
     featureToDuplicate,
+    featureToImport,
     permissions: permissionsUtil,
     project,
   });
@@ -117,6 +129,23 @@ const genFormDefaultValues = ({
         ]),
       )
     : {};
+
+  const importedCustomFieldValues =
+    customFields && featureToImport?.customFields
+      ? {
+          ...customFieldValues,
+          ...Object.fromEntries(
+            customFields
+              .filter(
+                (field) => field.id in (featureToImport.customFields ?? {}),
+              )
+              .map((field) => [
+                field.id,
+                featureToImport.customFields?.[field.id],
+              ]),
+          ),
+        }
+      : customFieldValues;
 
   return featureToDuplicate
     ? {
@@ -134,18 +163,32 @@ const genFormDefaultValues = ({
           : undefined,
         jsonSchema: featureToDuplicate.jsonSchema,
       }
-    : {
-        valueType: "" as FeatureValueType,
-        defaultValue: getDefaultValue("boolean"),
-        description: "",
-        id: "",
-        project,
-        tags: [],
-        environmentSettings,
-        rules: [],
-        customFields: customFieldValues,
-        holdout: undefined,
-      };
+    : featureToImport
+      ? {
+          valueType: featureToImport.valueType,
+          defaultValue: featureToImport.defaultValue,
+          description: featureToImport.description,
+          id: featureToImport.id,
+          project,
+          tags: featureToImport.tags,
+          environmentSettings,
+          rules: featureToImport.rules ?? [],
+          customFields: importedCustomFieldValues,
+          holdout: undefined,
+          jsonSchema: featureToImport.jsonSchema,
+        }
+      : {
+          valueType: "" as FeatureValueType,
+          defaultValue: getDefaultValue("boolean"),
+          description: "",
+          id: "",
+          project,
+          tags: [],
+          environmentSettings,
+          rules: [],
+          customFields: customFieldValues,
+          holdout: undefined,
+        };
 };
 
 export default function FeatureModal({
@@ -155,6 +198,7 @@ export default function FeatureModal({
   cta = "Create",
   secondaryCTA,
   featureToDuplicate,
+  featureToImport,
 }: Props) {
   const { project, refreshTags } = useDefinitions();
   const environments = useEnvironments();
@@ -174,6 +218,7 @@ export default function FeatureModal({
     environments,
     permissions: permissionsUtil,
     featureToDuplicate,
+    featureToImport,
     project,
     customFields: hasCommercialFeature("custom-metadata")
       ? initialCustomFields
@@ -201,10 +246,14 @@ export default function FeatureModal({
 
   const valueType = form.watch("valueType") as FeatureValueType;
   const environmentSettings = form.watch("environmentSettings");
+  const rules = form.watch("rules") ?? [];
+  const isImport = !!featureToImport;
 
-  const modalHeader = featureToDuplicate
-    ? `Duplicate Feature (${featureToDuplicate.id})`
-    : "Create Feature";
+  const modalHeader = isImport
+    ? "Import Feature Configuration"
+    : featureToDuplicate
+      ? `Duplicate Feature (${featureToDuplicate.id})`
+      : "Create Feature";
 
   let ctaEnabled = true;
   let disabledMessage: string | undefined;
@@ -267,8 +316,17 @@ export default function FeatureModal({
           );
         }
 
+        const createEnvironmentSettings = isImport
+          ? Object.fromEntries(
+              Object.entries(feature.environmentSettings).map(
+                ([env, settings]) => [env, { ...settings, enabled: false }],
+              ),
+            )
+          : feature.environmentSettings;
         const body = {
           ...feature,
+          rules: isImport ? [] : feature.rules,
+          environmentSettings: createEnvironmentSettings,
           defaultValue: parseDefaultValue(defaultValue, valueType),
           holdout: {
             id: holdout?.id ?? "",
@@ -281,18 +339,50 @@ export default function FeatureModal({
           body: JSON.stringify(body),
         });
 
+        let draftVersion: number | undefined;
+        if (isImport) {
+          const importDraftRes = await apiCall<{
+            status: 200;
+            draftVersion: number;
+          }>(`/feature/${res.feature.id}/import-draft`, {
+            method: "POST",
+            body: JSON.stringify({
+              rules,
+              environmentsEnabled: Object.fromEntries(
+                Object.keys(createEnvironmentSettings).map((env) => [
+                  env,
+                  true,
+                ]),
+              ),
+              title: "Imported feature configuration",
+              comment:
+                "Imported from a copied GrowthBook feature configuration.",
+            }),
+          });
+          draftVersion = importDraftRes.draftVersion;
+        }
+
         track("Feature Created", {
           valueType: values.valueType,
           hasDescription: !!values.description?.length,
-          initialRule: "none",
+          initialRule: isImport && rules.length ? "imported-draft" : "none",
         });
         values.tags && refreshTags(values.tags);
         refreshWatching();
 
-        await onSuccess(res.feature);
+        await onSuccess(res.feature, { draftVersion });
       })}
     >
       <FormProvider {...form}>
+        {isImport && (
+          <Callout status="info" mb="3">
+            This will create the live feature with all environments disabled,
+            then create a draft revision with {rules.length} imported{" "}
+            {rules.length === 1 ? "rule" : "rules"} and all environments
+            enabled. No rules will be published until you review and publish the
+            draft.
+          </Callout>
+        )}
         {currentProjectIsDemo && (
           <Callout status="warning" mb="3">
             You are creating a feature under the demo datasource project.
@@ -384,15 +474,22 @@ export default function FeatureModal({
           />
         )}
 
-        <EnvironmentSelect
-          environmentSettings={environmentSettings}
-          environments={environments}
-          project={selectedProject}
-          setValue={(env, on) => {
-            environmentSettings[env.id].enabled = on;
-            form.setValue("environmentSettings", environmentSettings);
-          }}
-        />
+        {isImport ? (
+          <Callout status="info" mb="4">
+            The draft created by this import will enable all environments. You
+            can review or change those environment toggles before publishing.
+          </Callout>
+        ) : (
+          <EnvironmentSelect
+            environmentSettings={environmentSettings}
+            environments={environments}
+            project={selectedProject}
+            setValue={(env, on) => {
+              environmentSettings[env.id].enabled = on;
+              form.setValue("environmentSettings", environmentSettings);
+            }}
+          />
+        )}
 
         <div className="mb-4">
           <label>Description</label>

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -167,10 +167,10 @@ const genFormDefaultValues = ({
       ? {
           valueType: featureToImport.valueType,
           defaultValue: featureToImport.defaultValue,
-          description: featureToImport.description,
+          description: featureToImport.description ?? "",
           id: featureToImport.id,
-          project,
-          tags: featureToImport.tags,
+          project: featureToImport.project ?? project,
+          tags: featureToImport.tags ?? [],
           environmentSettings,
           rules: featureToImport.rules ?? [],
           customFields: importedCustomFieldValues,
@@ -341,25 +341,39 @@ export default function FeatureModal({
 
         let draftVersion: number | undefined;
         if (isImport) {
-          const importDraftRes = await apiCall<{
-            status: 200;
-            draftVersion: number;
-          }>(`/feature/${res.feature.id}/import-draft`, {
-            method: "POST",
-            body: JSON.stringify({
-              rules,
-              environmentsEnabled: Object.fromEntries(
-                Object.keys(createEnvironmentSettings).map((env) => [
-                  env,
-                  true,
-                ]),
-              ),
-              title: "Imported feature configuration",
-              comment:
-                "Imported from a copied GrowthBook feature configuration.",
-            }),
-          });
-          draftVersion = importDraftRes.draftVersion;
+          try {
+            const importDraftRes = await apiCall<{
+              status: 200;
+              draftVersion: number;
+            }>(`/feature/${res.feature.id}/import-draft`, {
+              method: "POST",
+              body: JSON.stringify({
+                rules,
+                environmentsEnabled: Object.fromEntries(
+                  Object.keys(createEnvironmentSettings).map((env) => [
+                    env,
+                    true,
+                  ]),
+                ),
+                title: "Imported feature configuration",
+                comment:
+                  "Imported from a copied GrowthBook feature configuration.",
+              }),
+            });
+            draftVersion = importDraftRes.draftVersion;
+          } catch (e) {
+            // The live feature was created but the draft with the imported
+            // rules failed — clean up so the user isn't left with an empty,
+            // permanently-disabled feature. Surface the original error.
+            try {
+              await apiCall(`/feature/${res.feature.id}`, {
+                method: "DELETE",
+              });
+            } catch {
+              // If cleanup fails, fall through and surface the original error.
+            }
+            throw e;
+          }
         }
 
         track("Feature Created", {
@@ -497,7 +511,14 @@ export default function FeatureModal({
             <MarkdownInput
               value={form.watch("description") || ""}
               setValue={(value) => form.setValue("description", value)}
-              autofocus={!featureToDuplicate?.description?.length}
+              // Autofocus only when there's no preexisting description to
+              // read — pre-populated content (from duplicate or import) means
+              // the user is more likely reviewing than typing, and focusing
+              // the editor scrolls the modal past the informational callouts.
+              autofocus={
+                !featureToDuplicate?.description?.length &&
+                !featureToImport?.description?.length
+              }
             />
           </Box>
         </div>

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -368,13 +368,21 @@ export default function FeatureModal({
           } catch (e) {
             // The live feature was created but the draft with the imported
             // rules failed — clean up so the user isn't left with an empty,
-            // permanently-disabled feature. Surface the original error.
+            // permanently-disabled feature. DELETE /feature/:id only accepts
+            // archived features, so archive first.  Surface the original
+            // error regardless of cleanup outcome.
             try {
+              await apiCall(`/feature/${res.feature.id}/archive`, {
+                method: "POST",
+                body: JSON.stringify({ archived: true }),
+              });
               await apiCall(`/feature/${res.feature.id}`, {
                 method: "DELETE",
               });
             } catch {
-              // If cleanup fails, fall through and surface the original error.
+              // If cleanup fails (archive or delete), fall through and
+              // surface the original error. The orphan feature can be cleaned
+              // up manually from the Features list.
             }
             throw e;
           }

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -4,7 +4,7 @@ import {
   FeatureInterface,
   FeatureValueType,
 } from "shared/types/feature";
-import { GrowthBookFeatureClipboardFeature } from "shared/validators";
+import { GrowthBookClipboardFeature } from "shared/validators";
 import React, { ReactElement } from "react";
 import { validateFeatureValue } from "shared/util";
 import { PiInfo } from "react-icons/pi";
@@ -51,7 +51,7 @@ export type Props = {
   cta?: string;
   secondaryCTA?: ReactElement;
   featureToDuplicate?: FeatureInterface;
-  featureToImport?: GrowthBookFeatureClipboardFeature;
+  featureToImport?: GrowthBookClipboardFeature;
   features?: FeatureInterface[];
 };
 
@@ -64,7 +64,7 @@ const genEnvironmentSettings = ({
 }: {
   environments: ReturnType<typeof useEnvironments>;
   featureToDuplicate?: FeatureInterface;
-  featureToImport?: GrowthBookFeatureClipboardFeature;
+  featureToImport?: GrowthBookClipboardFeature;
   permissions: ReturnType<typeof usePermissionsUtil>;
   project: string;
 }): Record<string, FeatureEnvironment> => {
@@ -97,7 +97,7 @@ const genFormDefaultValues = ({
   environments: ReturnType<typeof useEnvironments>;
   permissions: ReturnType<typeof usePermissionsUtil>;
   featureToDuplicate?: FeatureInterface;
-  featureToImport?: GrowthBookFeatureClipboardFeature;
+  featureToImport?: GrowthBookClipboardFeature;
   project: string;
   customFields?: ReturnType<typeof useCustomFields>;
 }): Pick<

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -258,16 +258,21 @@ export default function FeatureModal({
   let ctaEnabled = true;
   let disabledMessage: string | undefined;
 
+  // Duplicate locks the project to the source feature; create / import follow
+  // whatever the user picked in the selector.
+  const projectForPermissionCheck =
+    featureToDuplicate?.project ?? selectedProject;
   if (
     !permissionsUtil.canManageFeatureDrafts({
-      project: featureToDuplicate?.project ?? selectedProject,
-    })
+      project: projectForPermissionCheck,
+    }) ||
+    !permissionsUtil.canCreateFeature({ project: projectForPermissionCheck })
   ) {
     ctaEnabled = false;
     disabledMessage =
       !selectedProject && projectOptions.length > 0
         ? "Select a project to continue."
-        : "You don't have permission to create feature flag drafts.";
+        : "You don't have permission to create features in this project.";
   }
 
   // We want to show a warning when someone tries to create a feature under the demo project
@@ -457,7 +462,7 @@ export default function FeatureModal({
           formType="feature"
         />
 
-        {!featureToDuplicate && (
+        {!featureToDuplicate && !featureToImport && (
           <ValueTypeField
             value={valueType}
             onChange={(val) => {

--- a/packages/front-end/components/Features/FeaturesHeader.tsx
+++ b/packages/front-end/components/Features/FeaturesHeader.tsx
@@ -96,7 +96,7 @@ export default function FeaturesHeader({
   const [archiveModal, setArchiveModal] = useState(false);
   const [deleteModal, setDeleteModal] = useState(false);
   const [copyFeatureConfigMessage, setCopyFeatureConfigMessage] = useState<
-    "success" | "error" | null
+    { kind: "success" } | { kind: "error"; message: string } | null
   >(null);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [staleStatusOpen, setStaleStatusOpen] = useState(false);
@@ -134,11 +134,13 @@ export default function FeaturesHeader({
   } = useDefinitions();
   const { holdouts } = useHoldouts(feature.project);
   const holdoutsEnabled = hasCommercialFeature("holdouts");
-  // Loaded so the "Copy feature configuration" action can attach descriptions
-  // for any prerequisite-feature references in the clipboard payload.
-  const { features: projectFeatures } = useFeatureMetaInfo({
-    project: feature.project,
-  });
+  // Loaded so the "Copy feature configuration" action can attach
+  // descriptions for any prerequisite-feature references in the clipboard
+  // payload. Deliberately unfiltered by project — prerequisites can be
+  // cross-project (see getPrerequisiteStates' JIT load comment in
+  // features.ts), and filtering here would silently drop those names from
+  // the import-side mapping context.
+  const { features: allFeaturesForCopy } = useFeatureMetaInfo();
 
   const staleHook = useFeatureStaleStates();
   const staleData = staleHook.getStaleState(feature.id);
@@ -256,7 +258,7 @@ export default function FeaturesHeader({
         ]),
       );
       const featuresLookup = new Map(
-        projectFeatures.map((f) => [f.id, { description: f.description }]),
+        allFeaturesForCopy.map((f) => [f.id, { description: f.description }]),
       );
 
       // Always serialize the LIVE feature (`baseFeature`) — when viewing a
@@ -272,9 +274,16 @@ export default function FeaturesHeader({
           environments: environmentsLookup,
         }),
       );
-      setCopyFeatureConfigMessage("success");
-    } catch {
-      setCopyFeatureConfigMessage("error");
+      setCopyFeatureConfigMessage({ kind: "success" });
+    } catch (err) {
+      // Surface the specific build error (e.g. missing safe-rollout
+      // settings) so the user knows whether to retry or report a bug,
+      // rather than the previous opaque "unable to copy" toast.
+      const message =
+        err instanceof Error && err.message
+          ? err.message
+          : "Unable to copy feature configuration to clipboard.";
+      setCopyFeatureConfigMessage({ kind: "error", message });
     }
   };
 
@@ -496,14 +505,14 @@ export default function FeaturesHeader({
               </Flex>
             </Callout>
           )}
-          {copyFeatureConfigMessage === "success" && (
+          {copyFeatureConfigMessage?.kind === "success" && (
             <Callout status="success" mb="3">
               Feature configuration copied to clipboard.
             </Callout>
           )}
-          {copyFeatureConfigMessage === "error" && (
+          {copyFeatureConfigMessage?.kind === "error" && (
             <Callout status="error" mb="3">
-              Unable to copy feature configuration to clipboard.
+              {copyFeatureConfigMessage.message}
             </Callout>
           )}
 

--- a/packages/front-end/components/Features/FeaturesHeader.tsx
+++ b/packages/front-end/components/Features/FeaturesHeader.tsx
@@ -46,6 +46,7 @@ import {
   DropdownSubMenu,
 } from "@/ui/DropdownMenu";
 import { useFeatureStaleStates } from "@/hooks/useFeatureStaleStates";
+import { useFeatureMetaInfo } from "@/hooks/useFeatureMetaInfo";
 import { useScrollPosition } from "@/hooks/useScrollPosition";
 import { buildFeatureConfigurationClipboardPayload } from "@/services/feature-configuration-clipboard";
 import FeatureArchiveModal from "./FeatureArchiveModal";
@@ -127,6 +128,11 @@ export default function FeaturesHeader({
   } = useDefinitions();
   const { holdouts } = useHoldouts(feature.project);
   const holdoutsEnabled = hasCommercialFeature("holdouts");
+  // Loaded so the "Copy feature configuration" action can attach descriptions
+  // for any prerequisite-feature references in the clipboard payload.
+  const { features: projectFeatures } = useFeatureMetaInfo({
+    project: feature.project,
+  });
 
   const staleHook = useFeatureStaleStates();
   const staleData = staleHook.getStaleState(feature.id);
@@ -241,12 +247,16 @@ export default function FeaturesHeader({
           { description: env.description },
         ]),
       );
+      const featuresLookup = new Map(
+        projectFeatures.map((f) => [f.id, { description: f.description }]),
+      );
 
       await navigator.clipboard.writeText(
         buildFeatureConfigurationClipboardPayload(feature, {
           experiments: experimentsLookup,
           savedGroups: savedGroupsLookup,
           safeRollouts: safeRolloutsLookup,
+          features: featuresLookup,
           environments: environmentsLookup,
         }),
       );

--- a/packages/front-end/components/Features/FeaturesHeader.tsx
+++ b/packages/front-end/components/Features/FeaturesHeader.tsx
@@ -54,6 +54,7 @@ import FeatureDeleteModal from "./FeatureDeleteModal";
 import AddToHoldoutModal from "./AddToHoldoutModal";
 export default function FeaturesHeader({
   feature,
+  baseFeature,
   mutate,
   setVersion,
   version,
@@ -67,6 +68,11 @@ export default function FeaturesHeader({
   safeRollouts,
 }: {
   feature: FeatureInterface;
+  // The live (published) feature, separate from `feature` which is the
+  // mergeRevision output for the currently-viewed revision. Used by "Copy
+  // feature configuration" so the clipboard always reflects the live config
+  // rather than whichever draft the user happens to be inspecting.
+  baseFeature: FeatureInterface;
   mutate: () => Promise<unknown>;
   setVersion: (version: number) => void;
   version: number | null;
@@ -235,11 +241,13 @@ export default function FeaturesHeader({
           },
         ]),
       );
+      // Pass the full SafeRolloutInterface so the importer has the source
+      // settings (datasource, exposure query, guardrails, max duration,
+      // rollback config, ramp schedule) to seed fresh destination
+      // SafeRollouts. Runtime state is dropped on the way out by the
+      // clipboard service.
       const safeRolloutsLookup = new Map(
-        (safeRollouts ?? []).map((sr) => [
-          sr.id,
-          { featureId: sr.featureId, environment: sr.environment },
-        ]),
+        (safeRollouts ?? []).map((sr) => [sr.id, sr]),
       );
       const environmentsLookup = new Map(
         allEnvironments.map((env) => [
@@ -251,8 +259,12 @@ export default function FeaturesHeader({
         projectFeatures.map((f) => [f.id, { description: f.description }]),
       );
 
+      // Always serialize the LIVE feature (`baseFeature`) — when viewing a
+      // non-live revision, the `feature` prop is `mergeRevision(baseFeature,
+      // revision)` output, which would export draft/historical rules instead
+      // of what's currently published.
       await navigator.clipboard.writeText(
-        buildFeatureConfigurationClipboardPayload(feature, {
+        buildFeatureConfigurationClipboardPayload(baseFeature, {
           experiments: experimentsLookup,
           savedGroups: savedGroupsLookup,
           safeRollouts: safeRolloutsLookup,
@@ -328,9 +340,11 @@ export default function FeaturesHeader({
           >
             Audit history
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={copyFeatureConfiguration}>
-            Copy feature configuration
-          </DropdownMenuItem>
+          {canEdit && (
+            <DropdownMenuItem onClick={copyFeatureConfiguration}>
+              Copy feature configuration
+            </DropdownMenuItem>
+          )}
           <DropdownSubMenu
             trigger={
               <Flex

--- a/packages/front-end/components/Features/FeaturesHeader.tsx
+++ b/packages/front-end/components/Features/FeaturesHeader.tsx
@@ -8,8 +8,9 @@ import { filterEnvironmentsByFeature, isDefined } from "shared/util";
 import { getDemoDatasourceProjectIdForOrganization } from "shared/demo-datasource";
 import { BsThreeDotsVertical } from "react-icons/bs";
 import { PiEye, PiWarning } from "react-icons/pi";
-import { HoldoutInterface } from "shared/validators";
+import { HoldoutInterface, SafeRolloutInterface } from "shared/validators";
 import { MinimalFeatureRevisionInterface } from "shared/types/feature-revision";
+import { ExperimentInterfaceStringDates } from "shared/types/experiment";
 import Text from "@/ui/Text";
 import Heading from "@/ui/Heading";
 import { useUser } from "@/services/UserContext";
@@ -61,6 +62,8 @@ export default function FeaturesHeader({
   setEditFeatureInfoModal,
   holdout,
   isReadOnly = false,
+  experiments,
+  safeRollouts,
 }: {
   feature: FeatureInterface;
   mutate: () => Promise<unknown>;
@@ -72,6 +75,8 @@ export default function FeaturesHeader({
   setEditFeatureInfoModal: (open: boolean) => void;
   holdout: HoldoutInterface | undefined;
   isReadOnly?: boolean;
+  experiments?: ExperimentInterfaceStringDates[];
+  safeRollouts?: SafeRolloutInterface[];
 }) {
   const router = useRouter();
   const projectId = feature?.project;
@@ -118,6 +123,7 @@ export default function FeaturesHeader({
     getProjectById,
     project: currentProject,
     projects,
+    savedGroups,
   } = useDefinitions();
   const { holdouts } = useHoldouts(feature.project);
   const holdoutsEnabled = hasCommercialFeature("holdouts");
@@ -204,8 +210,45 @@ export default function FeaturesHeader({
   const copyFeatureConfiguration = async () => {
     setDropdownOpen(false);
     try {
+      // Enrich the clipboard payload with the source org's names for any
+      // referenced experiments / saved groups / safe rollouts so the import-
+      // time mapping UI can show useful context to the destination user.
+      const experimentsLookup = new Map(
+        (experiments ?? []).map((e) => [
+          e.id,
+          { name: e.name, hypothesis: e.hypothesis },
+        ]),
+      );
+      const savedGroupsLookup = new Map(
+        savedGroups.map((sg) => [
+          sg.id,
+          {
+            groupName: sg.groupName,
+            type: sg.type,
+            attributeKey: sg.attributeKey,
+          },
+        ]),
+      );
+      const safeRolloutsLookup = new Map(
+        (safeRollouts ?? []).map((sr) => [
+          sr.id,
+          { featureId: sr.featureId, environment: sr.environment },
+        ]),
+      );
+      const environmentsLookup = new Map(
+        allEnvironments.map((env) => [
+          env.id,
+          { description: env.description },
+        ]),
+      );
+
       await navigator.clipboard.writeText(
-        buildFeatureConfigurationClipboardPayload(feature),
+        buildFeatureConfigurationClipboardPayload(feature, {
+          experiments: experimentsLookup,
+          savedGroups: savedGroupsLookup,
+          safeRollouts: safeRolloutsLookup,
+          environments: environmentsLookup,
+        }),
       );
       setCopyFeatureConfigMessage("success");
     } catch {

--- a/packages/front-end/components/Features/FeaturesHeader.tsx
+++ b/packages/front-end/components/Features/FeaturesHeader.tsx
@@ -46,6 +46,7 @@ import {
 } from "@/ui/DropdownMenu";
 import { useFeatureStaleStates } from "@/hooks/useFeatureStaleStates";
 import { useScrollPosition } from "@/hooks/useScrollPosition";
+import { buildFeatureConfigurationClipboardPayload } from "@/services/feature-configuration-clipboard";
 import FeatureArchiveModal from "./FeatureArchiveModal";
 import FeatureDeleteModal from "./FeatureDeleteModal";
 import AddToHoldoutModal from "./AddToHoldoutModal";
@@ -82,6 +83,9 @@ export default function FeaturesHeader({
   const [addToHoldoutModal, setAddToHoldoutModal] = useState(false);
   const [archiveModal, setArchiveModal] = useState(false);
   const [deleteModal, setDeleteModal] = useState(false);
+  const [copyFeatureConfigMessage, setCopyFeatureConfigMessage] = useState<
+    "success" | "error" | null
+  >(null);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [staleStatusOpen, setStaleStatusOpen] = useState(false);
   const [showImplementation, setShowImplementation] = useState(firstFeature);
@@ -187,6 +191,28 @@ export default function FeaturesHeader({
     await staleHook.fetchSome([feature.id]);
   };
 
+  useEffect(() => {
+    if (!copyFeatureConfigMessage) return;
+
+    const timer = window.setTimeout(() => {
+      setCopyFeatureConfigMessage(null);
+    }, 3000);
+
+    return () => window.clearTimeout(timer);
+  }, [copyFeatureConfigMessage]);
+
+  const copyFeatureConfiguration = async () => {
+    setDropdownOpen(false);
+    try {
+      await navigator.clipboard.writeText(
+        buildFeatureConfigurationClipboardPayload(feature),
+      );
+      setCopyFeatureConfigMessage("success");
+    } catch {
+      setCopyFeatureConfigMessage("error");
+    }
+  };
+
   const project = getProjectById(projectId || "");
   const projectName = project?.name || null;
   const projectIsDeReferenced = projectId && !projectName;
@@ -248,6 +274,9 @@ export default function FeaturesHeader({
             }}
           >
             Audit history
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={copyFeatureConfiguration}>
+            Copy feature configuration
           </DropdownMenuItem>
           <DropdownSubMenu
             trigger={
@@ -398,6 +427,16 @@ export default function FeaturesHeader({
                   />
                 </Flex>
               </Flex>
+            </Callout>
+          )}
+          {copyFeatureConfigMessage === "success" && (
+            <Callout status="success" mb="3">
+              Feature configuration copied to clipboard.
+            </Callout>
+          )}
+          {copyFeatureConfigMessage === "error" && (
+            <Callout status="error" mb="3">
+              Unable to copy feature configuration to clipboard.
             </Callout>
           )}
 

--- a/packages/front-end/pages/_app.tsx
+++ b/packages/front-end/pages/_app.tsx
@@ -41,6 +41,7 @@ import { SidebarOpenProvider } from "@/components/Layout/SidebarOpenProvider";
 import { HoverTooltipProvider } from "@/hooks/useHoverTooltip";
 import { FeatureStaleStatesProvider } from "@/hooks/useFeatureStaleStates";
 import { CommandPaletteLauncher } from "@/components/CommandPalette/CommandPalette";
+import FeatureConfigurationClipboardImporter from "@/components/Features/FeatureConfigurationClipboardImporter";
 import Callout from "@/ui/Callout";
 
 // Make useLayoutEffect isomorphic (for SSR)
@@ -199,6 +200,7 @@ function App({
                                 <FeatureStaleStatesProvider>
                                   {liteLayout ? <LayoutLite /> : <Layout />}
                                   <CommandPaletteLauncher />
+                                  <FeatureConfigurationClipboardImporter />
                                   <main className={`main ${parts[0]}`}>
                                     <GuidedGetStartedBar />
                                     <OrganizationMessagesContainer />

--- a/packages/front-end/pages/features/[fid].tsx
+++ b/packages/front-end/pages/features/[fid].tsx
@@ -157,6 +157,8 @@ export default function FeaturePage() {
             (revision.status === "published" &&
               revision.version !== feature.version)
           }
+          experiments={experiments}
+          safeRollouts={safeRollouts}
         />
 
         {tab === "overview" && (

--- a/packages/front-end/pages/features/[fid].tsx
+++ b/packages/front-end/pages/features/[fid].tsx
@@ -144,6 +144,7 @@ export default function FeaturePage() {
         />
         <FeaturesHeader
           feature={feature}
+          baseFeature={baseFeature}
           mutate={refreshData}
           setVersion={setVersion}
           version={version}

--- a/packages/front-end/services/feature-configuration-clipboard.ts
+++ b/packages/front-end/services/feature-configuration-clipboard.ts
@@ -117,15 +117,14 @@ export function extractFeatureReferenceIds(
       }
     }
     // Rule env scope — only meaningful when allEnvironments is false; with
-    // the wildcard set, environments[] is ignored at evaluation.
+    // the wildcard set, environments[] is ignored at evaluation. The keys of
+    // `feature.environmentSettings` are deliberately NOT collected: the
+    // importer rebuilds env settings from the destination org wholesale, so
+    // those keys aren't transferred and shouldn't trigger the mapping modal.
     if (!rule.allEnvironments && rule.environments?.length) {
       rule.environments.forEach((env) => ids.environments.add(env));
     }
   });
-
-  Object.keys(feature.environmentSettings ?? {}).forEach((env) =>
-    ids.environments.add(env),
-  );
 
   return ids;
 }
@@ -303,19 +302,12 @@ export function applyFeatureReferenceMappings(
   feature: GrowthBookFeatureClipboardFeature,
   mappings: FeatureReferenceMappings,
 ): GrowthBookFeatureClipboardFeature {
-  const envMap = mappings.environments;
-  const remappedEnvSettings = feature.environmentSettings
-    ? Object.fromEntries(
-        Object.entries(feature.environmentSettings).map(([env, settings]) => [
-          envMap[env] ?? env,
-          settings,
-        ]),
-      )
-    : feature.environmentSettings;
-
+  // `environmentSettings` is deliberately not remapped: the importer
+  // regenerates env settings from the destination org (see FeatureModal's
+  // `genEnvironmentSettings`), so any mapping applied here would be silently
+  // discarded downstream. Env mappings only matter for rule-level scoping.
   return {
     ...feature,
-    environmentSettings: remappedEnvSettings,
     rules: feature.rules.map((rule) => applyMappingsToRule(rule, mappings)),
   };
 }

--- a/packages/front-end/services/feature-configuration-clipboard.ts
+++ b/packages/front-end/services/feature-configuration-clipboard.ts
@@ -1,0 +1,56 @@
+import {
+  GrowthBookFeatureClipboardFeature,
+  GrowthBookFeatureClipboardPayload,
+  growthbookFeatureClipboardPayload,
+} from "shared/validators";
+import { FeatureInterface } from "shared/types/feature";
+
+export const FEATURE_CONFIGURATION_CLIPBOARD_VERSION = 1;
+
+export function featureToClipboardConfiguration(
+  feature: FeatureInterface,
+): GrowthBookFeatureClipboardFeature {
+  return {
+    id: feature.id,
+    description: feature.description,
+    project: feature.project,
+    valueType: feature.valueType,
+    defaultValue: feature.defaultValue,
+    tags: feature.tags,
+    environmentSettings: feature.environmentSettings,
+    rules: feature.rules ?? [],
+    customFields: feature.customFields,
+    jsonSchema: feature.jsonSchema,
+    neverStale: feature.neverStale,
+  };
+}
+
+export function buildFeatureConfigurationClipboardPayload(
+  feature: FeatureInterface,
+): string {
+  const payload: GrowthBookFeatureClipboardPayload = {
+    growthbook: {
+      source: "growthbook",
+      object: "feature",
+      version: FEATURE_CONFIGURATION_CLIPBOARD_VERSION,
+      exportedAt: new Date().toISOString(),
+    },
+    feature: featureToClipboardConfiguration(feature),
+  };
+
+  return JSON.stringify(payload, null, 2);
+}
+
+export function parseFeatureConfigurationClipboardPayload(
+  text: string,
+): GrowthBookFeatureClipboardPayload | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+
+  const result = growthbookFeatureClipboardPayload.safeParse(parsed);
+  return result.success ? result.data : null;
+}

--- a/packages/front-end/services/feature-configuration-clipboard.ts
+++ b/packages/front-end/services/feature-configuration-clipboard.ts
@@ -39,7 +39,7 @@ export type FeatureReferenceLookups = {
     { groupName?: string; type?: string; attributeKey?: string }
   >;
   safeRollouts?: Map<string, { featureId?: string; environment?: string }>;
-  features?: Map<string, { id: string; description?: string }>;
+  features?: Map<string, { description?: string }>;
   environments?: Map<string, { description?: string }>;
 };
 
@@ -53,7 +53,6 @@ export function featureToClipboardConfiguration(
     valueType: feature.valueType,
     defaultValue: feature.defaultValue,
     tags: feature.tags,
-    environmentSettings: feature.environmentSettings,
     rules: feature.rules ?? [],
     customFields: feature.customFields,
     jsonSchema: feature.jsonSchema,
@@ -176,7 +175,9 @@ function buildReferenceManifest(
   const features: GrowthBookClipboardReferenceContext[] = [];
   ids.features.forEach((id) => {
     const feat = lookups.features?.get(id);
-    features.push({ id, name: feat?.id, details: feat?.description });
+    // Features have no separate human-readable name distinct from their id;
+    // use the id itself so the mapping modal shows a consistent label.
+    features.push({ id, name: id, details: feat?.description });
   });
 
   const environments: GrowthBookClipboardReferenceContext[] = [];
@@ -302,10 +303,10 @@ export function applyFeatureReferenceMappings(
   feature: GrowthBookClipboardFeature,
   mappings: FeatureReferenceMappings,
 ): GrowthBookClipboardFeature {
-  // `environmentSettings` is deliberately not remapped: the importer
-  // regenerates env settings from the destination org (see FeatureModal's
-  // `genEnvironmentSettings`), so any mapping applied here would be silently
-  // discarded downstream. Env mappings only matter for rule-level scoping.
+  // Env mappings only matter for rule-level scoping; `environmentSettings`
+  // is not part of the clipboard payload because the importer regenerates
+  // those from the destination org (see FeatureModal's
+  // `genEnvironmentSettings`).
   return {
     ...feature,
     rules: feature.rules.map((rule) => applyMappingsToRule(rule, mappings)),

--- a/packages/front-end/services/feature-configuration-clipboard.ts
+++ b/packages/front-end/services/feature-configuration-clipboard.ts
@@ -1,11 +1,47 @@
 import {
+  GrowthBookClipboardReferenceContext,
   GrowthBookFeatureClipboardFeature,
   GrowthBookFeatureClipboardPayload,
+  GrowthBookFeatureClipboardReferences,
   growthbookFeatureClipboardPayload,
 } from "shared/validators";
-import { FeatureInterface } from "shared/types/feature";
+import { FeatureInterface, FeatureRule } from "shared/types/feature";
 
 export const FEATURE_CONFIGURATION_CLIPBOARD_VERSION = 1;
+
+export type FeatureReferenceCategory =
+  | "experiments"
+  | "savedGroups"
+  | "safeRollouts"
+  | "features"
+  | "environments";
+
+export type FeatureReferenceMappings = Record<
+  FeatureReferenceCategory,
+  Record<string, string>
+>;
+
+export const EMPTY_FEATURE_REFERENCE_MAPPINGS: FeatureReferenceMappings = {
+  experiments: {},
+  savedGroups: {},
+  safeRollouts: {},
+  features: {},
+  environments: {},
+};
+
+// Lookup context the exporter uses to enrich each referenced id with a
+// human-readable name. The caller passes whatever it has — anything missing
+// just leaves `name` undefined on that reference.
+export type FeatureReferenceLookups = {
+  experiments?: Map<string, { name?: string; hypothesis?: string }>;
+  savedGroups?: Map<
+    string,
+    { groupName?: string; type?: string; attributeKey?: string }
+  >;
+  safeRollouts?: Map<string, { featureId?: string; environment?: string }>;
+  features?: Map<string, { id: string; description?: string }>;
+  environments?: Map<string, { description?: string }>;
+};
 
 export function featureToClipboardConfiguration(
   feature: FeatureInterface,
@@ -25,9 +61,139 @@ export function featureToClipboardConfiguration(
   };
 }
 
+// Walks the feature config and pulls out every id that points at something
+// living in another collection — experiments, saved groups, safe rollouts,
+// prerequisite features, and environments (rule scoping + envSettings keys).
+export function extractFeatureReferenceIds(
+  feature: GrowthBookFeatureClipboardFeature,
+): Record<FeatureReferenceCategory, Set<string>> {
+  const ids: Record<FeatureReferenceCategory, Set<string>> = {
+    experiments: new Set(),
+    savedGroups: new Set(),
+    safeRollouts: new Set(),
+    features: new Set(),
+    environments: new Set(),
+  };
+
+  const walkConditionForSavedGroups = (node: unknown): void => {
+    if (!node || typeof node !== "object") return;
+    if (Array.isArray(node)) {
+      node.forEach(walkConditionForSavedGroups);
+      return;
+    }
+    for (const [key, value] of Object.entries(
+      node as Record<string, unknown>,
+    )) {
+      if (
+        (key === "$inGroup" || key === "$notInGroup") &&
+        typeof value === "string"
+      ) {
+        ids.savedGroups.add(value);
+      } else {
+        walkConditionForSavedGroups(value);
+      }
+    }
+  };
+
+  feature.rules.forEach((rule) => {
+    if (rule.type === "experiment-ref" && rule.experimentId) {
+      ids.experiments.add(rule.experimentId);
+    }
+    if (rule.type === "safe-rollout" && rule.safeRolloutId) {
+      ids.safeRollouts.add(rule.safeRolloutId);
+    }
+    (rule.savedGroups ?? []).forEach((sg) => {
+      (sg.ids ?? []).forEach((id) => ids.savedGroups.add(id));
+    });
+    (rule.prerequisites ?? []).forEach((prereq) => {
+      if (prereq.id) ids.features.add(prereq.id);
+    });
+    if (rule.condition) {
+      try {
+        walkConditionForSavedGroups(JSON.parse(rule.condition));
+      } catch {
+        // Conditions that aren't valid JSON have no saved group refs to
+        // extract — silently skip them.
+      }
+    }
+    // Rule env scope — only meaningful when allEnvironments is false; with
+    // the wildcard set, environments[] is ignored at evaluation.
+    if (!rule.allEnvironments && rule.environments?.length) {
+      rule.environments.forEach((env) => ids.environments.add(env));
+    }
+  });
+
+  Object.keys(feature.environmentSettings ?? {}).forEach((env) =>
+    ids.environments.add(env),
+  );
+
+  return ids;
+}
+
+function buildReferenceManifest(
+  feature: GrowthBookFeatureClipboardFeature,
+  lookups: FeatureReferenceLookups,
+): GrowthBookFeatureClipboardReferences {
+  const ids = extractFeatureReferenceIds(feature);
+
+  const experiments: GrowthBookClipboardReferenceContext[] = [];
+  ids.experiments.forEach((id) => {
+    const exp = lookups.experiments?.get(id);
+    experiments.push({ id, name: exp?.name, details: exp?.hypothesis });
+  });
+
+  const savedGroups: GrowthBookClipboardReferenceContext[] = [];
+  ids.savedGroups.forEach((id) => {
+    const sg = lookups.savedGroups?.get(id);
+    const detailsParts = [
+      sg?.type ? `type: ${sg.type}` : null,
+      sg?.attributeKey ? `attribute: ${sg.attributeKey}` : null,
+    ].filter(Boolean);
+    savedGroups.push({
+      id,
+      name: sg?.groupName,
+      details: detailsParts.length ? detailsParts.join(" • ") : undefined,
+    });
+  });
+
+  const safeRollouts: GrowthBookClipboardReferenceContext[] = [];
+  ids.safeRollouts.forEach((id) => {
+    const sr = lookups.safeRollouts?.get(id);
+    const detailsParts = [
+      sr?.featureId ? `feature: ${sr.featureId}` : null,
+      sr?.environment ? `env: ${sr.environment}` : null,
+    ].filter(Boolean);
+    safeRollouts.push({
+      id,
+      // Safe rollouts have no `name` field; use feature/env as a stand-in.
+      name:
+        sr?.featureId && sr?.environment
+          ? `${sr.featureId} (${sr.environment})`
+          : undefined,
+      details: detailsParts.length ? detailsParts.join(" • ") : undefined,
+    });
+  });
+
+  const features: GrowthBookClipboardReferenceContext[] = [];
+  ids.features.forEach((id) => {
+    const feat = lookups.features?.get(id);
+    features.push({ id, name: feat?.id, details: feat?.description });
+  });
+
+  const environments: GrowthBookClipboardReferenceContext[] = [];
+  ids.environments.forEach((id) => {
+    const env = lookups.environments?.get(id);
+    environments.push({ id, name: env?.description || undefined });
+  });
+
+  return { experiments, savedGroups, safeRollouts, features, environments };
+}
+
 export function buildFeatureConfigurationClipboardPayload(
   feature: FeatureInterface,
+  lookups: FeatureReferenceLookups = {},
 ): string {
+  const featureConfig = featureToClipboardConfiguration(feature);
   const payload: GrowthBookFeatureClipboardPayload = {
     growthbook: {
       source: "growthbook",
@@ -35,7 +201,8 @@ export function buildFeatureConfigurationClipboardPayload(
       version: FEATURE_CONFIGURATION_CLIPBOARD_VERSION,
       exportedAt: new Date().toISOString(),
     },
-    feature: featureToClipboardConfiguration(feature),
+    feature: featureConfig,
+    references: buildReferenceManifest(featureConfig, lookups),
   };
 
   return JSON.stringify(payload, null, 2);
@@ -53,4 +220,102 @@ export function parseFeatureConfigurationClipboardPayload(
 
   const result = growthbookFeatureClipboardPayload.safeParse(parsed);
   return result.success ? result.data : null;
+}
+
+// Rewrites every reference id in a rule to its mapped target. Conditions are
+// re-serialized through JSON.parse/stringify so embedded $inGroup ids get
+// swapped too. Refs that aren't in the mapping are left alone — callers
+// (i.e. the mapping modal) are responsible for ensuring full coverage.
+function applyMappingsToRule(
+  rule: FeatureRule,
+  mappings: FeatureReferenceMappings,
+): FeatureRule {
+  const next: FeatureRule = { ...rule };
+
+  if (next.type === "experiment-ref" && next.experimentId) {
+    const mapped = mappings.experiments[next.experimentId];
+    if (mapped) next.experimentId = mapped;
+  }
+  if (next.type === "safe-rollout" && next.safeRolloutId) {
+    const mapped = mappings.safeRollouts[next.safeRolloutId];
+    if (mapped) next.safeRolloutId = mapped;
+  }
+
+  if (next.savedGroups?.length) {
+    next.savedGroups = next.savedGroups.map((sg) => ({
+      ...sg,
+      ids: (sg.ids ?? []).map((id) => mappings.savedGroups[id] ?? id),
+    }));
+  }
+
+  if (next.prerequisites?.length) {
+    next.prerequisites = next.prerequisites.map((p) => ({
+      ...p,
+      id: mappings.features[p.id] ?? p.id,
+    }));
+  }
+
+  // Rule env scope: rewrite when the rule isn't a wildcard. Falls back to the
+  // original id so an unmapped env still passes the env-validity check on the
+  // back-end with whatever was on the clipboard.
+  if (!next.allEnvironments && next.environments?.length) {
+    next.environments = next.environments.map(
+      (env) => mappings.environments[env] ?? env,
+    );
+  }
+
+  if (next.condition) {
+    try {
+      const parsed = JSON.parse(next.condition);
+      const remapped = remapConditionSavedGroups(parsed, mappings.savedGroups);
+      next.condition = JSON.stringify(remapped);
+    } catch {
+      // Leave non-JSON conditions untouched.
+    }
+  }
+
+  return next;
+}
+
+function remapConditionSavedGroups(
+  node: unknown,
+  mapping: Record<string, string>,
+): unknown {
+  if (!node || typeof node !== "object") return node;
+  if (Array.isArray(node)) {
+    return node.map((item) => remapConditionSavedGroups(item, mapping));
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+    if (
+      (key === "$inGroup" || key === "$notInGroup") &&
+      typeof value === "string"
+    ) {
+      out[key] = mapping[value] ?? value;
+    } else {
+      out[key] = remapConditionSavedGroups(value, mapping);
+    }
+  }
+  return out;
+}
+
+export function applyFeatureReferenceMappings(
+  feature: GrowthBookFeatureClipboardFeature,
+  mappings: FeatureReferenceMappings,
+): GrowthBookFeatureClipboardFeature {
+  const envMap = mappings.environments;
+  const remappedEnvSettings = feature.environmentSettings
+    ? Object.fromEntries(
+        Object.entries(feature.environmentSettings).map(([env, settings]) => [
+          envMap[env] ?? env,
+          settings,
+        ]),
+      )
+    : feature.environmentSettings;
+
+  return {
+    ...feature,
+    environmentSettings: remappedEnvSettings,
+    rules: feature.rules.map((rule) => applyMappingsToRule(rule, mappings)),
+  };
 }

--- a/packages/front-end/services/feature-configuration-clipboard.ts
+++ b/packages/front-end/services/feature-configuration-clipboard.ts
@@ -1,9 +1,11 @@
 import {
+  ClipboardSafeRolloutSettings,
   GrowthBookClipboardReferenceContext,
   GrowthBookClipboardFeature,
   GrowthBookClipboardPayload,
   GrowthBookFeatureClipboardReferences,
   growthbookClipboardPayload,
+  SafeRolloutInterface,
 } from "shared/validators";
 import { FeatureInterface, FeatureRule } from "shared/types/feature";
 
@@ -32,13 +34,18 @@ export const EMPTY_FEATURE_REFERENCE_MAPPINGS: FeatureReferenceMappings = {
 // Lookup context the exporter uses to enrich each referenced id with a
 // human-readable name. The caller passes whatever it has — anything missing
 // just leaves `name` undefined on that reference.
+//
+// `safeRollouts` is a full SafeRolloutInterface map (not just display
+// context) because the importer auto-creates fresh SafeRollouts in the
+// destination and needs the source settings — datasource, exposure query,
+// guardrails, max duration, rollback, ramp schedule — to seed them.
 export type FeatureReferenceLookups = {
   experiments?: Map<string, { name?: string; hypothesis?: string }>;
   savedGroups?: Map<
     string,
     { groupName?: string; type?: string; attributeKey?: string }
   >;
-  safeRollouts?: Map<string, { featureId?: string; environment?: string }>;
+  safeRollouts?: Map<string, SafeRolloutInterface>;
   features?: Map<string, { description?: string }>;
   environments?: Map<string, { description?: string }>;
 };
@@ -172,6 +179,9 @@ function buildReferenceManifest(
     });
   });
 
+  // Kept in the manifest for inspection but no longer mapped by the user;
+  // see safeRolloutSettings below for the data the importer actually uses.
+
   const features: GrowthBookClipboardReferenceContext[] = [];
   ids.features.forEach((id) => {
     const feat = lookups.features?.get(id);
@@ -189,6 +199,44 @@ function buildReferenceManifest(
   return { experiments, savedGroups, safeRollouts, features, environments };
 }
 
+// Builds the per-source-id map of portable SafeRollout settings that the
+// importer uses to spin up fresh SafeRollouts in the destination. We only
+// emit entries for SafeRollouts that the feature's rules actually reference
+// — other safe rollouts in the lookup are ignored.
+function buildSafeRolloutSettings(
+  feature: GrowthBookClipboardFeature,
+  lookups: FeatureReferenceLookups,
+): Record<string, ClipboardSafeRolloutSettings> | undefined {
+  const ids = extractFeatureReferenceIds(feature).safeRollouts;
+  if (!ids.size) return undefined;
+
+  const out: Record<string, ClipboardSafeRolloutSettings> = {};
+  ids.forEach((id) => {
+    const sr = lookups.safeRollouts?.get(id);
+    if (!sr) return;
+    out[id] = {
+      datasourceId: sr.datasourceId,
+      exposureQueryId: sr.exposureQueryId,
+      guardrailMetricIds: sr.guardrailMetricIds,
+      maxDuration: sr.maxDuration,
+      autoRollback: sr.autoRollback,
+      autoSnapshots: sr.autoSnapshots,
+      // Preserve user-configured ramp structure (percentages + enabled flag);
+      // drop runtime progress fields (step / dateRampedUp / next-last update
+      // / rampUpCompleted) so the destination starts fresh.
+      rampUpSchedule: sr.rampUpSchedule
+        ? {
+            enabled: sr.rampUpSchedule.enabled,
+            steps: (sr.rampUpSchedule.steps ?? []).map((s) => ({
+              percent: s.percent,
+            })),
+          }
+        : undefined,
+    };
+  });
+  return Object.keys(out).length ? out : undefined;
+}
+
 export function buildFeatureConfigurationClipboardPayload(
   feature: FeatureInterface,
   lookups: FeatureReferenceLookups = {},
@@ -203,6 +251,7 @@ export function buildFeatureConfigurationClipboardPayload(
     },
     feature: featureConfig,
     references: buildReferenceManifest(featureConfig, lookups),
+    safeRolloutSettings: buildSafeRolloutSettings(featureConfig, lookups),
   };
 
   return JSON.stringify(payload, null, 2);
@@ -236,10 +285,10 @@ function applyMappingsToRule(
     const mapped = mappings.experiments[next.experimentId];
     if (mapped) next.experimentId = mapped;
   }
-  if (next.type === "safe-rollout" && next.safeRolloutId) {
-    const mapped = mappings.safeRollouts[next.safeRolloutId];
-    if (mapped) next.safeRolloutId = mapped;
-  }
+  // safe-rollout safeRolloutId is intentionally NOT mapped here. Safe
+  // rollouts are per-feature, so cross-org mapping doesn't make sense; the
+  // backend creates fresh SafeRollouts during import and rewrites the rule's
+  // safeRolloutId there. We carry the source id through unchanged.
 
   if (next.savedGroups?.length) {
     next.savedGroups = next.savedGroups.map((sg) => ({

--- a/packages/front-end/services/feature-configuration-clipboard.ts
+++ b/packages/front-end/services/feature-configuration-clipboard.ts
@@ -1,9 +1,9 @@
 import {
   GrowthBookClipboardReferenceContext,
-  GrowthBookFeatureClipboardFeature,
-  GrowthBookFeatureClipboardPayload,
+  GrowthBookClipboardFeature,
+  GrowthBookClipboardPayload,
   GrowthBookFeatureClipboardReferences,
-  growthbookFeatureClipboardPayload,
+  growthbookClipboardPayload,
 } from "shared/validators";
 import { FeatureInterface, FeatureRule } from "shared/types/feature";
 
@@ -45,7 +45,7 @@ export type FeatureReferenceLookups = {
 
 export function featureToClipboardConfiguration(
   feature: FeatureInterface,
-): GrowthBookFeatureClipboardFeature {
+): GrowthBookClipboardFeature {
   return {
     id: feature.id,
     description: feature.description,
@@ -65,7 +65,7 @@ export function featureToClipboardConfiguration(
 // living in another collection — experiments, saved groups, safe rollouts,
 // prerequisite features, and environments (rule scoping + envSettings keys).
 export function extractFeatureReferenceIds(
-  feature: GrowthBookFeatureClipboardFeature,
+  feature: GrowthBookClipboardFeature,
 ): Record<FeatureReferenceCategory, Set<string>> {
   const ids: Record<FeatureReferenceCategory, Set<string>> = {
     experiments: new Set(),
@@ -130,7 +130,7 @@ export function extractFeatureReferenceIds(
 }
 
 function buildReferenceManifest(
-  feature: GrowthBookFeatureClipboardFeature,
+  feature: GrowthBookClipboardFeature,
   lookups: FeatureReferenceLookups,
 ): GrowthBookFeatureClipboardReferences {
   const ids = extractFeatureReferenceIds(feature);
@@ -193,7 +193,7 @@ export function buildFeatureConfigurationClipboardPayload(
   lookups: FeatureReferenceLookups = {},
 ): string {
   const featureConfig = featureToClipboardConfiguration(feature);
-  const payload: GrowthBookFeatureClipboardPayload = {
+  const payload: GrowthBookClipboardPayload = {
     growthbook: {
       source: "growthbook",
       object: "feature",
@@ -209,7 +209,7 @@ export function buildFeatureConfigurationClipboardPayload(
 
 export function parseFeatureConfigurationClipboardPayload(
   text: string,
-): GrowthBookFeatureClipboardPayload | null {
+): GrowthBookClipboardPayload | null {
   let parsed: unknown;
   try {
     parsed = JSON.parse(text);
@@ -217,7 +217,7 @@ export function parseFeatureConfigurationClipboardPayload(
     return null;
   }
 
-  const result = growthbookFeatureClipboardPayload.safeParse(parsed);
+  const result = growthbookClipboardPayload.safeParse(parsed);
   return result.success ? result.data : null;
 }
 
@@ -299,9 +299,9 @@ function remapConditionSavedGroups(
 }
 
 export function applyFeatureReferenceMappings(
-  feature: GrowthBookFeatureClipboardFeature,
+  feature: GrowthBookClipboardFeature,
   mappings: FeatureReferenceMappings,
-): GrowthBookFeatureClipboardFeature {
+): GrowthBookClipboardFeature {
   // `environmentSettings` is deliberately not remapped: the importer
   // regenerates env settings from the destination org (see FeatureModal's
   // `genEnvironmentSettings`), so any mapping applied here would be silently

--- a/packages/front-end/services/feature-configuration-clipboard.ts
+++ b/packages/front-end/services/feature-configuration-clipboard.ts
@@ -201,8 +201,13 @@ function buildReferenceManifest(
 
 // Builds the per-source-id map of portable SafeRollout settings that the
 // importer uses to spin up fresh SafeRollouts in the destination. We only
-// emit entries for SafeRollouts that the feature's rules actually reference
-// — other safe rollouts in the lookup are ignored.
+// emit entries for SafeRollouts that the feature's rules actually reference.
+//
+// Throws if any referenced safe-rollout is missing from the lookup —
+// emitting an envelope without settings for a referenced id would cause
+// the destination's import-draft endpoint to fail AFTER the live feature is
+// created, leaving the user to clean up a broken orphan. Failing the copy
+// up front surfaces a clear error before any state is mutated anywhere.
 function buildSafeRolloutSettings(
   feature: GrowthBookClipboardFeature,
   lookups: FeatureReferenceLookups,
@@ -211,9 +216,13 @@ function buildSafeRolloutSettings(
   if (!ids.size) return undefined;
 
   const out: Record<string, ClipboardSafeRolloutSettings> = {};
+  const missing: string[] = [];
   ids.forEach((id) => {
     const sr = lookups.safeRollouts?.get(id);
-    if (!sr) return;
+    if (!sr) {
+      missing.push(id);
+      return;
+    }
     out[id] = {
       datasourceId: sr.datasourceId,
       exposureQueryId: sr.exposureQueryId,
@@ -234,7 +243,12 @@ function buildSafeRolloutSettings(
         : undefined,
     };
   });
-  return Object.keys(out).length ? out : undefined;
+  if (missing.length) {
+    throw new Error(
+      `Cannot copy feature configuration: missing safe rollout settings for ${missing.join(", ")}. Reload the feature page and try again.`,
+    );
+  }
+  return out;
 }
 
 export function buildFeatureConfigurationClipboardPayload(

--- a/packages/front-end/test/services/feature-configuration-clipboard.test.ts
+++ b/packages/front-end/test/services/feature-configuration-clipboard.test.ts
@@ -212,9 +212,12 @@ describe("feature reference extraction and mapping", () => {
     ).toBe("exp_new");
     expect(expRef?.prerequisites?.[0].id).toBe("feat_new");
 
+    // safe-rollout safeRolloutId is intentionally NOT remapped on the
+    // frontend; the backend mints a fresh SafeRollout during import and
+    // rewrites the id server-side. The source id should pass through here.
     const sr = mapped.rules.find((r) => r.type === "safe-rollout");
     expect(sr && "safeRolloutId" in sr ? sr.safeRolloutId : null).toBe(
-      "sr_new",
+      "sr_old",
     );
 
     const force = mapped.rules.find((r) => r.type === "force");

--- a/packages/front-end/test/services/feature-configuration-clipboard.test.ts
+++ b/packages/front-end/test/services/feature-configuration-clipboard.test.ts
@@ -1,0 +1,70 @@
+import { FeatureInterface } from "shared/types/feature";
+import {
+  buildFeatureConfigurationClipboardPayload,
+  parseFeatureConfigurationClipboardPayload,
+} from "@/services/feature-configuration-clipboard";
+
+const feature: FeatureInterface = {
+  id: "new-homepage",
+  organization: "org_123",
+  owner: "user_123",
+  dateCreated: new Date("2026-01-01T00:00:00.000Z"),
+  dateUpdated: new Date("2026-01-02T00:00:00.000Z"),
+  valueType: "boolean",
+  defaultValue: "false",
+  version: 3,
+  description: "Controls the new homepage",
+  project: "web",
+  tags: ["growth"],
+  environmentSettings: {
+    dev: { enabled: true },
+    production: { enabled: false },
+  },
+  rules: [
+    {
+      id: "fr_homepage",
+      type: "force",
+      description: "Enable for beta users",
+      condition: '{"id":{"$in":["beta-user"]}}',
+      allEnvironments: true,
+      value: "true",
+    },
+  ],
+  customFields: {
+    team: "growth",
+  },
+  archived: false,
+};
+
+describe("feature configuration clipboard payloads", () => {
+  it("builds and parses a GrowthBook feature clipboard envelope", () => {
+    const payload = parseFeatureConfigurationClipboardPayload(
+      buildFeatureConfigurationClipboardPayload(feature),
+    );
+
+    expect(payload).not.toBeNull();
+    expect(payload?.growthbook).toMatchObject({
+      source: "growthbook",
+      object: "feature",
+      version: 1,
+    });
+    expect(payload?.feature).toMatchObject({
+      id: "new-homepage",
+      valueType: "boolean",
+      defaultValue: "false",
+      rules: feature.rules,
+    });
+  });
+
+  it("ignores non-JSON clipboard text", () => {
+    expect(parseFeatureConfigurationClipboardPayload("not json")).toBeNull();
+  });
+
+  it("rejects JSON without the GrowthBook feature envelope", () => {
+    expect(
+      parseFeatureConfigurationClipboardPayload(
+        JSON.stringify({ feature: { id: "missing-metadata" } }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/packages/front-end/test/services/feature-configuration-clipboard.test.ts
+++ b/packages/front-end/test/services/feature-configuration-clipboard.test.ts
@@ -181,10 +181,6 @@ describe("feature reference extraction and mapping", () => {
     valueType: "boolean" as const,
     defaultValue: "false",
     rules,
-    environmentSettings: {
-      dev: { enabled: true },
-      staging: { enabled: false },
-    },
   };
 
   it("extracts every cross-org reference id by category", () => {
@@ -227,20 +223,12 @@ describe("feature reference extraction and mapping", () => {
     const parsedCondition = JSON.parse(force?.condition ?? "{}");
     expect(parsedCondition.$or[0].id.$inGroup).toBe("grp_A2");
     expect(parsedCondition.$or[1].id.$notInGroup).toBe("grp_B2");
-
-    // environmentSettings keys are NOT remapped — the importer regenerates
-    // env settings from the destination org, so any mapping here would be
-    // dropped downstream. Leaving them untouched keeps the source manifest
-    // free of phantom env references that would force the mapping modal.
-    expect(Object.keys(mapped.environmentSettings ?? {}).sort()).toEqual([
-      "dev",
-      "staging",
-    ]);
   });
 
   it("does not collect environmentSettings keys as references", () => {
     // A feature with only allEnvironments-true rules has no cross-org env
-    // refs — its envSettings keys must not pollute the reference manifest.
+    // refs — env-scoped rule fields are the only source of environment
+    // references in the clipboard manifest.
     const ids = extractFeatureReferenceIds({
       id: "f",
       valueType: "boolean",
@@ -254,10 +242,6 @@ describe("feature reference extraction and mapping", () => {
           value: "true",
         },
       ],
-      environmentSettings: {
-        dev: { enabled: true },
-        production: { enabled: false },
-      },
     });
     expect(Array.from(ids.environments)).toEqual([]);
   });

--- a/packages/front-end/test/services/feature-configuration-clipboard.test.ts
+++ b/packages/front-end/test/services/feature-configuration-clipboard.test.ts
@@ -136,6 +136,39 @@ describe("feature configuration clipboard payloads", () => {
       ),
     ).toBeNull();
   });
+
+  it("throws when a safe-rollout rule references a safeRolloutId missing from the lookup", () => {
+    // Building a clipboard envelope with safe-rollout rules but without the
+    // matching SafeRollout settings would produce a payload the destination
+    // import-draft endpoint can't satisfy. Failing the copy up front (with
+    // a descriptive error) is the only signal the user gets before the
+    // missing settings cause a partial import + cleanup downstream.
+    const featureWithSafeRollout: FeatureInterface = {
+      ...feature,
+      rules: [
+        {
+          id: "fr_sr",
+          type: "safe-rollout",
+          description: "",
+          allEnvironments: true,
+          safeRolloutId: "sr_missing",
+          controlValue: "false",
+          variationValue: "true",
+          status: "running",
+          hashAttribute: "id",
+          seed: "x",
+          trackingKey: "tk",
+        },
+      ],
+    };
+
+    expect(() =>
+      buildFeatureConfigurationClipboardPayload(featureWithSafeRollout, {
+        // Empty safeRollouts lookup — sr_missing isn't there.
+        safeRollouts: new Map(),
+      }),
+    ).toThrow(/sr_missing/);
+  });
 });
 
 describe("feature reference extraction and mapping", () => {

--- a/packages/front-end/test/services/feature-configuration-clipboard.test.ts
+++ b/packages/front-end/test/services/feature-configuration-clipboard.test.ts
@@ -195,9 +195,37 @@ describe("feature reference extraction and mapping", () => {
     expect(parsedCondition.$or[0].id.$inGroup).toBe("grp_A2");
     expect(parsedCondition.$or[1].id.$notInGroup).toBe("grp_B2");
 
+    // environmentSettings keys are NOT remapped — the importer regenerates
+    // env settings from the destination org, so any mapping here would be
+    // dropped downstream. Leaving them untouched keeps the source manifest
+    // free of phantom env references that would force the mapping modal.
     expect(Object.keys(mapped.environmentSettings ?? {}).sort()).toEqual([
-      "development",
-      "production",
+      "dev",
+      "staging",
     ]);
+  });
+
+  it("does not collect environmentSettings keys as references", () => {
+    // A feature with only allEnvironments-true rules has no cross-org env
+    // refs — its envSettings keys must not pollute the reference manifest.
+    const ids = extractFeatureReferenceIds({
+      id: "f",
+      valueType: "boolean",
+      defaultValue: "false",
+      rules: [
+        {
+          id: "fr_force",
+          type: "force",
+          description: "",
+          allEnvironments: true,
+          value: "true",
+        },
+      ],
+      environmentSettings: {
+        dev: { enabled: true },
+        production: { enabled: false },
+      },
+    });
+    expect(Array.from(ids.environments)).toEqual([]);
   });
 });

--- a/packages/front-end/test/services/feature-configuration-clipboard.test.ts
+++ b/packages/front-end/test/services/feature-configuration-clipboard.test.ts
@@ -92,6 +92,39 @@ describe("feature configuration clipboard payloads", () => {
     );
   });
 
+  it("accepts rules carrying stale fields from a prior rule type", () => {
+    // Real-world feature rules carry leftover fields when the user switches
+    // rule type in the UI — e.g., a rule that was a `rollout` (with
+    // `coverage`) and was changed to `force` may still persist `coverage` on
+    // disk. The clipboard schema must tolerate these so paste doesn't
+    // silently drop the entire payload.
+    const featureWithStaleField: FeatureInterface = {
+      ...feature,
+      rules: [
+        {
+          id: "fr_force_stale",
+          type: "force",
+          description: "",
+          allEnvironments: false,
+          environments: ["dev"],
+          value: "false",
+          // `coverage` is a `rollout`-rule field; forceRule schema is strict
+          // and would reject it without the clipboard validator's leniency.
+          coverage: 1,
+        } as unknown as FeatureRule,
+      ],
+    };
+
+    const payload = parseFeatureConfigurationClipboardPayload(
+      buildFeatureConfigurationClipboardPayload(featureWithStaleField),
+    );
+
+    expect(payload).not.toBeNull();
+    expect(payload?.feature.rules).toHaveLength(1);
+    expect(payload?.feature.rules[0]?.type).toBe("force");
+    expect(payload?.references.environments.map((r) => r.id)).toContain("dev");
+  });
+
   it("ignores non-JSON clipboard text", () => {
     expect(parseFeatureConfigurationClipboardPayload("not json")).toBeNull();
   });

--- a/packages/front-end/test/services/feature-configuration-clipboard.test.ts
+++ b/packages/front-end/test/services/feature-configuration-clipboard.test.ts
@@ -1,6 +1,9 @@
-import { FeatureInterface } from "shared/types/feature";
+import { FeatureInterface, FeatureRule } from "shared/types/feature";
 import {
+  applyFeatureReferenceMappings,
   buildFeatureConfigurationClipboardPayload,
+  EMPTY_FEATURE_REFERENCE_MAPPINGS,
+  extractFeatureReferenceIds,
   parseFeatureConfigurationClipboardPayload,
 } from "@/services/feature-configuration-clipboard";
 
@@ -66,5 +69,102 @@ describe("feature configuration clipboard payloads", () => {
         JSON.stringify({ feature: { id: "missing-metadata" } }),
       ),
     ).toBeNull();
+  });
+});
+
+describe("feature reference extraction and mapping", () => {
+  const rules: FeatureRule[] = [
+    {
+      id: "fr_ref",
+      type: "experiment-ref",
+      description: "",
+      allEnvironments: true,
+      experimentId: "exp_abc",
+      variations: [{ variationId: "v0", value: "true" }],
+      prerequisites: [{ id: "feat_prereq", condition: "" }],
+    },
+    {
+      id: "fr_sr",
+      type: "safe-rollout",
+      description: "",
+      allEnvironments: true,
+      safeRolloutId: "sr_old",
+      controlValue: "a",
+      variationValue: "b",
+      status: "running",
+      hashAttribute: "id",
+      seed: "x",
+      trackingKey: "tk",
+    },
+    {
+      id: "fr_force",
+      type: "force",
+      description: "",
+      allEnvironments: false,
+      environments: ["dev", "staging"],
+      value: "true",
+      condition: JSON.stringify({
+        $or: [{ id: { $inGroup: "grp_a" } }, { id: { $notInGroup: "grp_b" } }],
+      }),
+      savedGroups: [{ match: "all", ids: ["grp_a", "grp_c"] }],
+    },
+  ];
+
+  const clipboardFeature = {
+    id: "f",
+    valueType: "boolean" as const,
+    defaultValue: "false",
+    rules,
+    environmentSettings: {
+      dev: { enabled: true },
+      staging: { enabled: false },
+    },
+  };
+
+  it("extracts every cross-org reference id by category", () => {
+    const ids = extractFeatureReferenceIds(clipboardFeature);
+    expect(Array.from(ids.experiments)).toEqual(["exp_abc"]);
+    expect(Array.from(ids.safeRollouts)).toEqual(["sr_old"]);
+    expect(Array.from(ids.savedGroups).sort()).toEqual([
+      "grp_a",
+      "grp_b",
+      "grp_c",
+    ]);
+    expect(Array.from(ids.features)).toEqual(["feat_prereq"]);
+    expect(Array.from(ids.environments).sort()).toEqual(["dev", "staging"]);
+  });
+
+  it("rewrites referenced ids in rules, conditions, prereqs, and envs", () => {
+    const mapped = applyFeatureReferenceMappings(clipboardFeature, {
+      ...EMPTY_FEATURE_REFERENCE_MAPPINGS,
+      experiments: { exp_abc: "exp_new" },
+      safeRollouts: { sr_old: "sr_new" },
+      savedGroups: { grp_a: "grp_A2", grp_b: "grp_B2" },
+      features: { feat_prereq: "feat_new" },
+      environments: { dev: "development", staging: "production" },
+    });
+
+    const expRef = mapped.rules.find((r) => r.type === "experiment-ref");
+    expect(
+      expRef && "experimentId" in expRef ? expRef.experimentId : null,
+    ).toBe("exp_new");
+    expect(expRef?.prerequisites?.[0].id).toBe("feat_new");
+
+    const sr = mapped.rules.find((r) => r.type === "safe-rollout");
+    expect(sr && "safeRolloutId" in sr ? sr.safeRolloutId : null).toBe(
+      "sr_new",
+    );
+
+    const force = mapped.rules.find((r) => r.type === "force");
+    expect(force?.savedGroups?.[0].ids).toEqual(["grp_A2", "grp_c"]);
+    expect(force?.environments).toEqual(["development", "production"]);
+    const parsedCondition = JSON.parse(force?.condition ?? "{}");
+    expect(parsedCondition.$or[0].id.$inGroup).toBe("grp_A2");
+    expect(parsedCondition.$or[1].id.$notInGroup).toBe("grp_B2");
+
+    expect(Object.keys(mapped.environmentSettings ?? {}).sort()).toEqual([
+      "development",
+      "production",
+    ]);
   });
 });

--- a/packages/front-end/test/services/feature-configuration-clipboard.test.ts
+++ b/packages/front-end/test/services/feature-configuration-clipboard.test.ts
@@ -59,6 +59,39 @@ describe("feature configuration clipboard payloads", () => {
     });
   });
 
+  it("roundtrips experiment rule bandit start dates as Date instances", () => {
+    const banditDate = new Date("2026-02-15T10:30:00.000Z");
+    const banditFeature: FeatureInterface = {
+      ...feature,
+      rules: [
+        {
+          id: "fr_bandit",
+          type: "experiment",
+          description: "",
+          allEnvironments: true,
+          trackingKey: "tk",
+          hashAttribute: "id",
+          values: [{ value: "a", weight: 0.5 }],
+          banditStage: "explore",
+          banditStageDateStarted: banditDate,
+        },
+      ],
+    };
+
+    const payload = parseFeatureConfigurationClipboardPayload(
+      buildFeatureConfigurationClipboardPayload(banditFeature),
+    );
+
+    expect(payload).not.toBeNull();
+    const rule = payload?.feature.rules[0];
+    expect(rule?.type).toBe("experiment");
+    if (rule?.type !== "experiment") return;
+    expect(rule.banditStageDateStarted).toBeInstanceOf(Date);
+    expect(rule.banditStageDateStarted?.toISOString()).toBe(
+      banditDate.toISOString(),
+    );
+  });
+
   it("ignores non-JSON clipboard text", () => {
     expect(parseFeatureConfigurationClipboardPayload("not json")).toBeNull();
   });

--- a/packages/shared/src/validators/clipboard.ts
+++ b/packages/shared/src/validators/clipboard.ts
@@ -17,10 +17,42 @@ export const growthbookClipboardMetadata = z
   .object({
     source: z.literal("growthbook"),
     object: z.literal("feature"),
-    version: z.literal(1),
+    // Accept any positive integer version. Field-level validation below will
+    // catch any structural incompatibility from a future envelope rather than
+    // silently rejecting the entire paste with no feedback.
+    version: z.number().int().min(1),
     exportedAt: z.string().optional(),
   })
   .strict();
+
+// Source-org context for a single reference (experiment, saved group, etc.).
+// `name` (and `details` when present) are shown in the import-time reference
+// mapping UI so a user can identify what the original referred to.
+export const growthbookClipboardReferenceContext = z
+  .object({
+    id: z.string(),
+    name: z.string().optional(),
+    details: z.string().optional(),
+  })
+  .strict();
+
+export type GrowthBookClipboardReferenceContext = z.infer<
+  typeof growthbookClipboardReferenceContext
+>;
+
+export const growthbookFeatureClipboardReferences = z
+  .object({
+    experiments: z.array(growthbookClipboardReferenceContext),
+    savedGroups: z.array(growthbookClipboardReferenceContext),
+    safeRollouts: z.array(growthbookClipboardReferenceContext),
+    features: z.array(growthbookClipboardReferenceContext),
+    environments: z.array(growthbookClipboardReferenceContext),
+  })
+  .strict();
+
+export type GrowthBookFeatureClipboardReferences = z.infer<
+  typeof growthbookFeatureClipboardReferences
+>;
 
 export const growthbookFeatureClipboardFeature = z
   .object({
@@ -42,6 +74,7 @@ export const growthbookFeatureClipboardPayload = z
   .object({
     growthbook: growthbookClipboardMetadata,
     feature: growthbookFeatureClipboardFeature,
+    references: growthbookFeatureClipboardReferences,
   })
   .strict();
 

--- a/packages/shared/src/validators/clipboard.ts
+++ b/packages/shared/src/validators/clipboard.ts
@@ -18,6 +18,19 @@ const clipboardJSONSchemaDef = JSONSchemaDef.extend({
 // safeParse. Coerce any known date fields back to Date instances before the
 // rule union validator runs.
 const RULE_DATE_FIELDS = ["banditStageDateStarted"] as const;
+
+// Each rule variant in `featureRule` is `.strict()`, but real-world feature
+// rules in the DB often carry stale fields left over from earlier rule types
+// (e.g. a rule was a `rollout` with `coverage`, then switched to `force` —
+// the form drops `coverage` from the active UI but the value persists on
+// disk). Strict validation would reject those rules and silently drop the
+// entire paste. Rebuild the union with `.passthrough()` so unknown top-level
+// fields are kept, matching the back-end's accept-what-we-got posture for
+// imports.
+const lenientFeatureRule = z.union(
+  featureRule.options.map((member) => member.passthrough()),
+);
+
 export const clipboardFeatureRule = z.preprocess((value) => {
   if (!value || typeof value !== "object" || Array.isArray(value)) return value;
   const obj = value as Record<string, unknown>;
@@ -30,7 +43,7 @@ export const clipboardFeatureRule = z.preprocess((value) => {
     }
   }
   return next ?? value;
-}, featureRule);
+}, lenientFeatureRule);
 
 export const growthbookClipboardMetadata = z
   .object({

--- a/packages/shared/src/validators/clipboard.ts
+++ b/packages/shared/src/validators/clipboard.ts
@@ -13,6 +13,25 @@ const clipboardJSONSchemaDef = JSONSchemaDef.extend({
   ),
 });
 
+// JSON.stringify turns Date fields on `featureRule` (currently
+// `banditStageDateStarted`) into ISO strings, which `z.date()` rejects on
+// safeParse. Coerce any known date fields back to Date instances before the
+// rule union validator runs.
+const RULE_DATE_FIELDS = ["banditStageDateStarted"] as const;
+export const clipboardFeatureRule = z.preprocess((value) => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  const obj = value as Record<string, unknown>;
+  let next: Record<string, unknown> | null = null;
+  for (const field of RULE_DATE_FIELDS) {
+    const current = obj[field];
+    if (typeof current === "string") {
+      next = next ?? { ...obj };
+      next[field] = new Date(current);
+    }
+  }
+  return next ?? value;
+}, featureRule);
+
 export const growthbookClipboardMetadata = z
   .object({
     source: z.literal("growthbook"),
@@ -63,7 +82,7 @@ export const growthbookFeatureClipboardFeature = z
     defaultValue: z.string(),
     tags: z.array(z.string()).optional(),
     environmentSettings: z.record(z.string(), featureEnvironment).optional(),
-    rules: z.array(featureRule),
+    rules: z.array(clipboardFeatureRule),
     customFields: z.record(z.string(), z.any()).optional(),
     jsonSchema: clipboardJSONSchemaDef.optional(),
     neverStale: z.boolean().optional(),

--- a/packages/shared/src/validators/clipboard.ts
+++ b/packages/shared/src/validators/clipboard.ts
@@ -45,6 +45,11 @@ export const clipboardFeatureRule = z.preprocess((value) => {
   return next ?? value;
 }, lenientFeatureRule);
 
+// All clipboard schemas use `.passthrough()` rather than `.strict()` so that
+// a payload exported from a newer GrowthBook instance (with extra fields we
+// don't yet know about) still parses successfully. Field-level validation
+// will catch structural incompatibilities; unknown fields are ignored rather
+// than causing the entire paste to silently fail.
 export const growthbookClipboardMetadata = z
   .object({
     source: z.literal("growthbook"),
@@ -55,7 +60,7 @@ export const growthbookClipboardMetadata = z
     version: z.number().int().min(1),
     exportedAt: z.string().optional(),
   })
-  .strict();
+  .passthrough();
 
 // Source-org context for a single reference (experiment, saved group, etc.).
 // `name` (and `details` when present) are shown in the import-time reference
@@ -66,7 +71,7 @@ export const growthbookClipboardReferenceContext = z
     name: z.string().optional(),
     details: z.string().optional(),
   })
-  .strict();
+  .passthrough();
 
 export type GrowthBookClipboardReferenceContext = z.infer<
   typeof growthbookClipboardReferenceContext
@@ -80,7 +85,7 @@ export const growthbookFeatureClipboardReferences = z
     features: z.array(growthbookClipboardReferenceContext),
     environments: z.array(growthbookClipboardReferenceContext),
   })
-  .strict();
+  .passthrough();
 
 export type GrowthBookFeatureClipboardReferences = z.infer<
   typeof growthbookFeatureClipboardReferences
@@ -100,7 +105,7 @@ export const growthbookFeatureClipboardFeature = z
     jsonSchema: clipboardJSONSchemaDef.optional(),
     neverStale: z.boolean().optional(),
   })
-  .strict();
+  .passthrough();
 
 export const growthbookFeatureClipboardPayload = z
   .object({
@@ -108,7 +113,7 @@ export const growthbookFeatureClipboardPayload = z
     feature: growthbookFeatureClipboardFeature,
     references: growthbookFeatureClipboardReferences,
   })
-  .strict();
+  .passthrough();
 
 export const growthbookClipboardPayload = z.union([
   growthbookFeatureClipboardPayload,

--- a/packages/shared/src/validators/clipboard.ts
+++ b/packages/shared/src/validators/clipboard.ts
@@ -1,6 +1,37 @@
 import { z } from "zod";
 import { featureRule, featureValueType, JSONSchemaDef } from "./features";
 
+// Subset of SafeRolloutInterface that ports cleanly across orgs. Runtime
+// state (startedAt, snapshot timestamps, analysisSummary, pastNotifications,
+// rampUpSchedule step/completion timestamps) is intentionally excluded —
+// the destination starts fresh. Destination-specific refs (datasourceId,
+// exposureQueryId, guardrailMetricIds) are carried as-is and are likely to
+// be broken in the destination; the user fixes them post-import on the
+// auto-created safe rollout.
+export const clipboardSafeRolloutSettings = z
+  .object({
+    datasourceId: z.string(),
+    exposureQueryId: z.string(),
+    guardrailMetricIds: z.array(z.string()),
+    maxDuration: z.object({
+      amount: z.number(),
+      unit: z.enum(["weeks", "days", "hours", "minutes"]),
+    }),
+    autoRollback: z.boolean(),
+    autoSnapshots: z.boolean(),
+    rampUpSchedule: z
+      .object({
+        enabled: z.boolean(),
+        steps: z.array(z.object({ percent: z.number() }).loose()),
+      })
+      .loose()
+      .optional(),
+  })
+  .loose();
+export type ClipboardSafeRolloutSettings = z.infer<
+  typeof clipboardSafeRolloutSettings
+>;
+
 const clipboardJSONSchemaDef = JSONSchemaDef.extend({
   date: z.preprocess(
     (value) => (typeof value === "string" ? new Date(value) : value),
@@ -110,6 +141,16 @@ export const growthbookClipboardFeaturePayload = z
     growthbook: growthbookClipboardMetadata,
     feature: growthbookClipboardFeature,
     references: growthbookFeatureClipboardReferences,
+    // Source-org safe-rollout settings, keyed by the source safeRolloutId
+    // referenced from the rules. The importer creates a fresh SafeRollout
+    // per safe-rollout rule in the destination using these settings and
+    // rewrites rule.safeRolloutId accordingly; mapping by the user isn't
+    // required because safe rollouts are per-feature and cross-mapping
+    // would be incoherent. Optional for backward compat with older
+    // payloads (rules will fail import without it).
+    safeRolloutSettings: z
+      .record(z.string(), clipboardSafeRolloutSettings)
+      .optional(),
   })
   .loose();
 

--- a/packages/shared/src/validators/clipboard.ts
+++ b/packages/shared/src/validators/clipboard.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import {
+  featureEnvironment,
+  featureRule,
+  featureValueType,
+  JSONSchemaDef,
+} from "./features";
+
+const clipboardJSONSchemaDef = JSONSchemaDef.extend({
+  date: z.preprocess(
+    (value) => (typeof value === "string" ? new Date(value) : value),
+    z.date(),
+  ),
+});
+
+export const growthbookClipboardMetadata = z
+  .object({
+    source: z.literal("growthbook"),
+    object: z.literal("feature"),
+    version: z.literal(1),
+    exportedAt: z.string().optional(),
+  })
+  .strict();
+
+export const growthbookFeatureClipboardFeature = z
+  .object({
+    id: z.string(),
+    description: z.string().optional(),
+    project: z.string().optional(),
+    valueType: z.enum(featureValueType),
+    defaultValue: z.string(),
+    tags: z.array(z.string()).optional(),
+    environmentSettings: z.record(z.string(), featureEnvironment).optional(),
+    rules: z.array(featureRule),
+    customFields: z.record(z.string(), z.any()).optional(),
+    jsonSchema: clipboardJSONSchemaDef.optional(),
+    neverStale: z.boolean().optional(),
+  })
+  .strict();
+
+export const growthbookFeatureClipboardPayload = z
+  .object({
+    growthbook: growthbookClipboardMetadata,
+    feature: growthbookFeatureClipboardFeature,
+  })
+  .strict();
+
+export const growthbookClipboardPayload = z.union([
+  growthbookFeatureClipboardPayload,
+]);
+
+export type GrowthBookFeatureClipboardFeature = z.infer<
+  typeof growthbookFeatureClipboardFeature
+>;
+
+export type GrowthBookFeatureClipboardPayload = z.infer<
+  typeof growthbookFeatureClipboardPayload
+>;

--- a/packages/shared/src/validators/clipboard.ts
+++ b/packages/shared/src/validators/clipboard.ts
@@ -1,10 +1,5 @@
 import { z } from "zod";
-import {
-  featureEnvironment,
-  featureRule,
-  featureValueType,
-  JSONSchemaDef,
-} from "./features";
+import { featureRule, featureValueType, JSONSchemaDef } from "./features";
 
 const clipboardJSONSchemaDef = JSONSchemaDef.extend({
   date: z.preprocess(
@@ -99,7 +94,10 @@ export const growthbookClipboardFeature = z
     valueType: z.enum(featureValueType),
     defaultValue: z.string(),
     tags: z.array(z.string()).optional(),
-    environmentSettings: z.record(z.string(), featureEnvironment).optional(),
+    // environmentSettings is intentionally not part of the clipboard: the
+    // importer regenerates env settings from the destination org (see
+    // FeatureModal's `genEnvironmentSettings`), so any value carried here
+    // would be silently discarded downstream.
     rules: z.array(clipboardFeatureRule),
     customFields: z.record(z.string(), z.any()).optional(),
     jsonSchema: clipboardJSONSchemaDef.optional(),
@@ -115,6 +113,9 @@ export const growthbookClipboardFeaturePayload = z
   })
   .loose();
 
+// Single-member union today; modeled this way so additional clipboard object
+// types (e.g. experiments) can be added as new union members without
+// reshaping callers.
 export const growthbookClipboardPayload = z.union([
   growthbookClipboardFeaturePayload,
 ]);

--- a/packages/shared/src/validators/clipboard.ts
+++ b/packages/shared/src/validators/clipboard.ts
@@ -24,11 +24,11 @@ const RULE_DATE_FIELDS = ["banditStageDateStarted"] as const;
 // (e.g. a rule was a `rollout` with `coverage`, then switched to `force` —
 // the form drops `coverage` from the active UI but the value persists on
 // disk). Strict validation would reject those rules and silently drop the
-// entire paste. Rebuild the union with `.passthrough()` so unknown top-level
+// entire paste. Rebuild the union with `.loose()` so unknown top-level
 // fields are kept, matching the back-end's accept-what-we-got posture for
 // imports.
 const lenientFeatureRule = z.union(
-  featureRule.options.map((member) => member.passthrough()),
+  featureRule.options.map((member) => member.loose()),
 );
 
 export const clipboardFeatureRule = z.preprocess((value) => {
@@ -45,7 +45,7 @@ export const clipboardFeatureRule = z.preprocess((value) => {
   return next ?? value;
 }, lenientFeatureRule);
 
-// All clipboard schemas use `.passthrough()` rather than `.strict()` so that
+// All clipboard schemas use `.loose()` rather than `.strict()` so that
 // a payload exported from a newer GrowthBook instance (with extra fields we
 // don't yet know about) still parses successfully. Field-level validation
 // will catch structural incompatibilities; unknown fields are ignored rather
@@ -60,7 +60,7 @@ export const growthbookClipboardMetadata = z
     version: z.number().int().min(1),
     exportedAt: z.string().optional(),
   })
-  .passthrough();
+  .loose();
 
 // Source-org context for a single reference (experiment, saved group, etc.).
 // `name` (and `details` when present) are shown in the import-time reference
@@ -71,7 +71,7 @@ export const growthbookClipboardReferenceContext = z
     name: z.string().optional(),
     details: z.string().optional(),
   })
-  .passthrough();
+  .loose();
 
 export type GrowthBookClipboardReferenceContext = z.infer<
   typeof growthbookClipboardReferenceContext
@@ -85,13 +85,13 @@ export const growthbookFeatureClipboardReferences = z
     features: z.array(growthbookClipboardReferenceContext),
     environments: z.array(growthbookClipboardReferenceContext),
   })
-  .passthrough();
+  .loose();
 
 export type GrowthBookFeatureClipboardReferences = z.infer<
   typeof growthbookFeatureClipboardReferences
 >;
 
-export const growthbookFeatureClipboardFeature = z
+export const growthbookClipboardFeature = z
   .object({
     id: z.string(),
     description: z.string().optional(),
@@ -105,24 +105,24 @@ export const growthbookFeatureClipboardFeature = z
     jsonSchema: clipboardJSONSchemaDef.optional(),
     neverStale: z.boolean().optional(),
   })
-  .passthrough();
+  .loose();
 
-export const growthbookFeatureClipboardPayload = z
+export const growthbookClipboardFeaturePayload = z
   .object({
     growthbook: growthbookClipboardMetadata,
-    feature: growthbookFeatureClipboardFeature,
+    feature: growthbookClipboardFeature,
     references: growthbookFeatureClipboardReferences,
   })
-  .passthrough();
+  .loose();
 
 export const growthbookClipboardPayload = z.union([
-  growthbookFeatureClipboardPayload,
+  growthbookClipboardFeaturePayload,
 ]);
 
-export type GrowthBookFeatureClipboardFeature = z.infer<
-  typeof growthbookFeatureClipboardFeature
+export type GrowthBookClipboardFeature = z.infer<
+  typeof growthbookClipboardFeature
 >;
 
-export type GrowthBookFeatureClipboardPayload = z.infer<
-  typeof growthbookFeatureClipboardPayload
+export type GrowthBookClipboardPayload = z.infer<
+  typeof growthbookClipboardPayload
 >;

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -15,6 +15,7 @@ export * from "./members";
 export * from "./api-settings";
 export * from "./bulk-import";
 export * from "./code-refs";
+export * from "./clipboard";
 export * from "./information-schema-tables";
 export * from "./queries";
 export * from "./safe-rollout";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

Adds an MVP clipboard flow for copying feature configuration between GrowthBook instances:

- Adds a feature action to copy a typed GrowthBook JSON envelope to the clipboard.
- Adds a global app paste listener that detects valid GrowthBook feature JSON and opens the create/import modal from any page.
- Extends the feature modal with an import preview that explains imported rules are saved into a draft revision and not published immediately.
- Creates imported features with live environments disabled, then creates a draft revision containing imported rules and all environments enabled.
- Adds shared Zod validators and focused front-end utility coverage for the clipboard envelope.

- Closes **(add link to issue here)**

### Dependencies

None

### Testing

- `pnpm --filter front-end test test/services/feature-configuration-clipboard.test.ts`
- `pnpm --filter front-end type-check`
- `pnpm --filter shared type-check`
- `pnpm --filter back-end type-check`
- Browser walkthrough: created a source feature by pasting a valid GrowthBook feature envelope, verified the import modal showed 1 imported rule, created the draft revision, then copied that feature's configuration from the feature action menu and pasted it from the feature list to import a second feature.

### Screenshots

[feature_config_clipboard_copy_paste_import.mp4](https://cursor.com/agents/bc-7eaefd4e-beb3-5e84-97c7-1f43724e9510/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffeature_config_clipboard_copy_paste_import.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/D0B3JSAH6SY/p1778718320059729?thread_ts=1778718320.059729&cid=D0B3JSAH6SY)

<div><a href="https://cursor.com/agents/bc-7eaefd4e-beb3-5e84-97c7-1f43724e9510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eaefd4e-beb3-5e84-97c7-1f43724e9510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

