### PR TITLE
Enable owner filter search and sorting

### DIFF
--- a/packages/front-end/components/Search/ExperimentSearchFilters.tsx
+++ b/packages/front-end/components/Search/ExperimentSearchFilters.tsx
@@ -96,7 +96,9 @@ const ExperimentSearchFilters: FC<
         owners.add(getOwnerDisplay(e.owner));
       }
     });
-    return Array.from(owners);
+    return Array.from(owners).sort((a, b) =>
+      a.localeCompare(b, undefined, { sensitivity: "base" }),
+    );
   }, [experiments, getOwnerDisplay]);
 
   const availableExperimentTypes = useMemo(() => {

--- a/packages/front-end/components/Search/FeatureSearchFilters.tsx
+++ b/packages/front-end/components/Search/FeatureSearchFilters.tsx
@@ -110,7 +110,9 @@ const FeatureSearchFilters: FC<
     features.forEach((f) => {
       if (f.owner) set.add(getOwnerDisplay(f.owner));
     });
-    return Array.from(set);
+    return Array.from(set).sort((a, b) =>
+      a.localeCompare(b, undefined, { sensitivity: "base" }),
+    );
   }, [features, getOwnerDisplay]);
 
   const availableFeatureTypes = useMemo(() => {

--- a/packages/front-end/components/Search/MetricSearchFilters.tsx
+++ b/packages/front-end/components/Search/MetricSearchFilters.tsx
@@ -52,7 +52,9 @@ const MetricSearchFilters: FC<
         owners.add(getOwnerDisplay(m.owner));
       }
     });
-    return Array.from(owners);
+    return Array.from(owners).sort((a, b) =>
+      a.localeCompare(b, undefined, { sensitivity: "base" }),
+    );
   }, [combinedMetrics, getOwnerDisplay]);
 
   const hasArchivedMetrics = combinedMetrics.some((m) => m.archived);

--- a/packages/front-end/components/Search/SearchFilters.tsx
+++ b/packages/front-end/components/Search/SearchFilters.tsx
@@ -115,23 +115,14 @@ export const FilterDropdown: FC<{
     () => USE_SEARCH_BOX && items.length > 10,
     [items],
   );
-  const filteredItems = useMemo(
-    () =>
-      filterSearch
-        ? items.filter(
-            (i) =>
-              (typeof i.name === "string"
-                ? i.name.toLowerCase()
-                : i.searchValue.toLowerCase()
-              ).startsWith(filterSearch.toLowerCase()) ||
-              (typeof i.name === "string"
-                ? i.name.toLowerCase()
-                : i.searchValue.toLowerCase()
-              ).includes(filterSearch.toLowerCase()),
-          )
-        : items,
-    [items, filterSearch],
-  );
+  const filteredItems = useMemo(() => {
+    if (!filterSearch) return items;
+    const query = filterSearch.toLowerCase();
+    return items.filter((i) => {
+      const haystack = typeof i.name === "string" ? i.name : i.searchValue;
+      return haystack.toLowerCase().includes(query);
+    });
+  }, [items, filterSearch]);
 
   const inputRef = useRef<HTMLInputElement>(null);
   useEffect(() => {

--- a/packages/front-end/components/Search/SearchFilters.tsx
+++ b/packages/front-end/components/Search/SearchFilters.tsx
@@ -19,7 +19,7 @@ import { SearchTermFilterOperator, SyntaxFilter } from "@/services/search";
 import Field from "@/components/Forms/Field";
 import OverflowText from "@/components/Experiment/TabbedPage/OverflowText";
 
-const USE_SEARCH_BOX = false;
+const USE_SEARCH_BOX = true;
 
 // Common interfaces
 export interface SearchFiltersItem {

--- a/packages/front-end/components/Search/SearchFilters.tsx
+++ b/packages/front-end/components/Search/SearchFilters.tsx
@@ -140,9 +140,12 @@ export const FilterDropdown: FC<{
       return;
     }
 
-    if (showSearchFilter) {
+    if (!showSearchFilter) return;
+
+    const focusTimer = setTimeout(() => {
       inputRef.current?.focus();
-    }
+    }, 0);
+    return () => clearTimeout(focusTimer);
   }, [filter, open, showSearchFilter]);
 
   return (

--- a/packages/front-end/components/Search/SearchFilters.tsx
+++ b/packages/front-end/components/Search/SearchFilters.tsx
@@ -3,6 +3,7 @@ import {
   FC,
   Fragment,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -109,6 +110,7 @@ export const FilterDropdown: FC<{
   menuPlacement = "start",
 }) => {
   const [filterSearch, setFilterSearch] = useState<string>("");
+  const filterLabel = heading ?? filter;
   const showSearchFilter = useMemo(
     () => USE_SEARCH_BOX && items.length > 10,
     [items],
@@ -132,11 +134,21 @@ export const FilterDropdown: FC<{
   );
 
   const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (open !== filter) {
+      setFilterSearch("");
+      return;
+    }
+
+    if (showSearchFilter) {
+      inputRef.current?.focus();
+    }
+  }, [filter, open, showSearchFilter]);
 
   return (
     <DropdownMenu
       trigger={FilterHeading({
-        heading: heading ?? filter,
+        heading: filterLabel,
         open: open === filter,
       })}
       variant="soft"
@@ -146,7 +158,7 @@ export const FilterDropdown: FC<{
         setOpen(o ? filter : "");
       }}
     >
-      <DropdownMenuLabel>Filter by {heading ?? filter}</DropdownMenuLabel>
+      <DropdownMenuLabel>Filter by {filterLabel}</DropdownMenuLabel>
       {showSearchFilter && (
         <Box px="2" pb="1" style={{ maxWidth: "250px" }}>
           <Field
@@ -154,6 +166,8 @@ export const FilterDropdown: FC<{
             value={filterSearch}
             onChange={(e) => setFilterSearch(e.target.value)}
             type="search"
+            placeholder={`Search ${filterLabel}`}
+            aria-label={`Search ${filterLabel} filters`}
             onKeyDown={(e) => {
               if (e.key !== "ArrowUp" && e.key !== "ArrowDown") {
                 e.stopPropagation();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

- Enable the existing typeahead search box in shared search filter dropdowns when a menu has more than 10 items.
- Add a visible placeholder, focus the search input after large dropdowns open, and clear the search when they close.
- Sort owner filter values case-insensitively on Features, Experiments, and Metrics search filters.

Customer request permalink: growthbookapp.slack.com/archives/C0B492B9388/p1778807891430319

### Dependencies

None.

### Testing

- `pnpm --filter front-end type-check`
- Manual UI validation on `/features` with 12 seeded owner values: verified the owner dropdown shows the search input, owners are sorted alphabetically, typing `jul` immediately after opening filters to `juliet-owner@example.com`, clearing restores the full sorted list.

### Screenshots

[owner_filter_typeahead_demo.mp4](https://cursor.com/agents/bc-7aa00213-96d9-4452-9087-a047ddc7acaa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fowner_filter_typeahead_demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7aa00213-96d9-4452-9087-a047ddc7acaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7aa00213-96d9-4452-9087-a047ddc7acaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

