### PR TITLE
fix(incremental): harden refresh lock - add fencing + heartbeat

### DIFF
--- a/packages/back-end/src/models/IncrementalRefreshModel.ts
+++ b/packages/back-end/src/models/IncrementalRefreshModel.ts
@@ -8,8 +8,11 @@ import { MakeModelClass } from "./BaseModel";
 
 export const COLLECTION_NAME = "incrementalrefresh";
 
-// If a lock hasn't been updated in this long, consider it stale
-const STALE_LOCK_TIMEOUT_MS = 60 * 60 * 1000;
+// A lock is considered stale once its heartbeat is older than this. The
+// runner refreshes the heartbeat every ~30s while queries are executing, so
+// this only needs to cover slow polls / brief stalls — not the full runtime
+// of a refresh.
+export const INCREMENTAL_LOCK_STALE_MS = 10 * 60 * 1000;
 
 const BaseClass = MakeModelClass({
   schema: incrementalRefreshValidator,
@@ -53,7 +56,7 @@ export class IncrementalRefreshModel extends BaseClass {
     experimentId: string,
     snapshotId: string,
   ): Promise<boolean> {
-    const staleLockThreshold = new Date(Date.now() - STALE_LOCK_TIMEOUT_MS);
+    const staleThreshold = new Date(Date.now() - INCREMENTAL_LOCK_STALE_MS);
     try {
       const result = await this._dangerousGetCollection().updateOne(
         {
@@ -62,13 +65,16 @@ export class IncrementalRefreshModel extends BaseClass {
           $or: [
             // Unlocked
             { currentExecutionSnapshotId: null },
-            // Or lock is stale
-            { dateUpdated: { $lt: staleLockThreshold } },
+            // Heartbeat stale → holder crashed or stalled
+            { lockHeartbeatAt: { $lt: staleThreshold } },
+            // Legacy docs without a heartbeat: fall back to dateUpdated
+            { lockHeartbeatAt: null, dateUpdated: { $lt: staleThreshold } },
           ],
         },
         {
           $set: {
             currentExecutionSnapshotId: snapshotId,
+            lockHeartbeatAt: new Date(),
             dateUpdated: new Date(),
           },
           $setOnInsert: {
@@ -113,8 +119,23 @@ export class IncrementalRefreshModel extends BaseClass {
         currentExecutionSnapshotId: snapshotId,
       },
       {
-        $set: { currentExecutionSnapshotId: null, dateUpdated: new Date() },
+        $set: {
+          currentExecutionSnapshotId: null,
+          lockHeartbeatAt: null,
+          dateUpdated: new Date(),
+        },
       },
+    );
+  }
+
+  public async touchLockHeartbeat(experimentId: string, snapshotId: string) {
+    await this._dangerousGetCollection().updateOne(
+      {
+        organization: this.context.org.id,
+        experimentId,
+        currentExecutionSnapshotId: snapshotId,
+      },
+      { $set: { lockHeartbeatAt: new Date(), dateUpdated: new Date() } },
     );
   }
 

--- a/packages/back-end/src/models/IncrementalRefreshModel.ts
+++ b/packages/back-end/src/models/IncrementalRefreshModel.ts
@@ -65,8 +65,9 @@ export class IncrementalRefreshModel extends BaseClass {
           $or: [
             // Unlocked
             { currentExecutionSnapshotId: null },
-            // Heartbeat stale → holder crashed or stalled
-            { lockHeartbeatAt: { $lt: staleThreshold } },
+            // Heartbeat stale → holder crashed or stalled (non-null only;
+            // null/missing heartbeats use the dateUpdated fallback below)
+            { lockHeartbeatAt: { $lt: staleThreshold, $ne: null } },
             // Legacy docs without a heartbeat: fall back to dateUpdated
             { lockHeartbeatAt: null, dateUpdated: { $lt: staleThreshold } },
           ],

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
@@ -50,6 +50,7 @@ export type ExperimentIncrementalRefreshExploratoryQueryParams = {
   factTableMap: FactTableMap;
   experimentId: string;
   experimentQueryMetadata: ExperimentQueryMetadata | null;
+  queryParentId: string;
   // Incremental Refresh specific
   incrementalRefreshStartTime: Date;
 };
@@ -116,6 +117,31 @@ export const startExperimentIncrementalRefreshExploratoryQueries = async (
       "Units table not found in incremental refresh model; required for exploratory analysis.",
     );
   }
+
+  const executionId = params.queryParentId;
+
+  // Wraps a `run` callback with an execution-fence check. The exploratory
+  // runner only reads the shared per-experiment pipeline tables, but it holds
+  // the same lock the incremental runner uses to DROP/CREATE/RENAME them. If
+  // the lock is taken over by another snapshot mid-run (stale heartbeat,
+  // cancel + restart), continuing to SELECT from those tables would observe a
+  // missing or half-rebuilt table and return empty/malformed results. Checked
+  // at execute time (not enqueue time) because queries run sequentially via
+  // dependencies — the lock can be lost between dependent queries.
+  const fenced =
+    <A extends unknown[], R>(run: (...args: A) => Promise<R>) =>
+    async (...args: A): Promise<R> => {
+      const current =
+        await context.models.incrementalRefresh.getCurrentExecutionSnapshotId(
+          experimentId,
+        );
+      if (current !== executionId) {
+        throw new Error(
+          "Incremental refresh lock was lost to another snapshot; aborting exploratory analysis to avoid reading half-rebuilt pipeline tables.",
+        );
+      }
+      return run(...args);
+    };
 
   // Metric Queries
   const existingSources = incrementalRefreshModel?.metricSources;
@@ -186,12 +212,13 @@ export const startExperimentIncrementalRefreshExploratoryQueries = async (
       displayTitle: `Compute Statistics ${sourceName}`,
       query: integration.getIncrementalRefreshStatisticsQuery(metricParams),
       dependencies: [],
-      run: (query, setExternalId, queryMetadata) =>
+      run: fenced((query, setExternalId, queryMetadata) =>
         integration.runIncrementalRefreshStatisticsQuery(
           query,
           setExternalId,
           queryMetadata,
         ),
+      ),
       queryType: "experimentIncrementalRefreshStatistics",
     });
     queries.push(statisticsQuery);

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
@@ -213,6 +213,17 @@ export class ExperimentIncrementalRefreshExploratoryQueryRunner extends QueryRun
     );
   }
 
+  protected override onHeartbeat(): void {
+    this.context.models.incrementalRefresh
+      .touchLockHeartbeat(this.model.experiment, this.model.id)
+      .catch((e) =>
+        this.context.logger.warn(
+          e,
+          "Failed to refresh incremental refresh lock heartbeat",
+        ),
+      );
+  }
+
   async startQueries(
     params: ExperimentIncrementalRefreshExploratoryQueryParams,
   ): Promise<Queries> {

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
@@ -334,6 +334,21 @@ export class ExperimentIncrementalRefreshExploratoryQueryRunner extends QueryRun
         snapshot: this.model.id,
       });
     }
+
+    // Release the incremental refresh lock on any terminal status. This runner
+    // acquires the lock (see createSnapshotFromPlan) so that it does not read
+    // the shared pipeline tables while an incremental refresh is mutating them.
+    if (updates.status !== "running") {
+      await this.context.models.incrementalRefresh
+        .releaseLock(this.model.experiment, this.model.id)
+        .catch((e) =>
+          this.context.logger.warn(
+            e,
+            "Failed to release incremental refresh lock on terminal status",
+          ),
+        );
+    }
+
     return {
       ...this.model,
       ...updates,

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -881,6 +881,17 @@ export class ExperimentIncrementalRefreshQueryRunner extends QueryRunner<
     );
   }
 
+  protected override onHeartbeat(): void {
+    this.context.models.incrementalRefresh
+      .touchLockHeartbeat(this.model.experiment, this.model.id)
+      .catch((e) =>
+        this.context.logger.warn(
+          e,
+          "Failed to refresh incremental refresh lock heartbeat",
+        ),
+      );
+  }
+
   async startQueries(
     params: ExperimentIncrementalRefreshQueryParams,
   ): Promise<Queries> {

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -14,6 +14,7 @@ import {
 } from "shared/validators";
 import {
   ExperimentAggregateUnitsQueryResponseRows,
+  ExternalIdCallback,
   InsertMetricSourceDataQueryParams,
   UpdateExperimentIncrementalUnitsQueryParams,
 } from "shared/types/integrations";
@@ -25,6 +26,7 @@ import {
 import {
   ExperimentQueryMetadata,
   Queries,
+  QueryMetadata,
   QueryPointer,
   QueryStatus,
 } from "shared/types/query";
@@ -268,6 +270,38 @@ const startExperimentIncrementalRefreshQueries = async (
 
   const executionId = params.queryParentId;
 
+  // Wraps a `run` callback with an execution-fence check so that DDL on the
+  // shared per-experiment pipeline tables (units / metric-source) is skipped if
+  // another snapshot has taken over the lock since this run started. Checked at
+  // execute time (not enqueue time) because all queries are enqueued up-front
+  // but executed sequentially via dependencies — the lock can be lost between
+  // dependent queries. releaseLock() is fenced on snapshotId, so the eventual
+  // release on this run's terminal status is a safe no-op once the lock is lost.
+  const fenced =
+    <R>(
+      run: (
+        query: string,
+        setExternalId: ExternalIdCallback,
+        queryMetadata?: QueryMetadata,
+      ) => Promise<R>,
+    ) =>
+    async (
+      query: string,
+      setExternalId: ExternalIdCallback,
+      queryMetadata?: QueryMetadata,
+    ): Promise<R> => {
+      const current =
+        await context.models.incrementalRefresh.getCurrentExecutionSnapshotId(
+          experimentId,
+        );
+      if (current !== executionId) {
+        throw new Error(
+          "Incremental refresh lock was lost to another snapshot; aborting to avoid corrupting shared pipeline tables.",
+        );
+      }
+      return run(query, setExternalId, queryMetadata);
+    };
+
   // When adding new metrics to a fact table, we will need to scan the whole table.
   // So to simplify things we re-create the whole metric source.
   // When removing metrics this is not needed, we just don't insert updated data.
@@ -358,8 +392,9 @@ const startExperimentIncrementalRefreshQueries = async (
         unitsTableFullName: unitQueryParams.unitsTableFullName,
       }),
       dependencies: [],
-      run: (query, setExternalId, queryMetadata) =>
+      run: fenced((query, setExternalId, queryMetadata) =>
         integration.runDropTableQuery(query, setExternalId, queryMetadata),
+      ),
       queryType: "experimentIncrementalRefreshDropUnitsTable",
     });
     queries.push(dropOldUnitsTableQuery);
@@ -370,12 +405,13 @@ const startExperimentIncrementalRefreshQueries = async (
       query:
         integration.getCreateExperimentIncrementalUnitsQuery(unitQueryParams),
       dependencies: [dropOldUnitsTableQuery.query],
-      run: (query, setExternalId, queryMetadata) =>
+      run: fenced((query, setExternalId, queryMetadata) =>
         integration.runIncrementalWithNoOutputQuery(
           query,
           setExternalId,
           queryMetadata,
         ),
+      ),
       queryType: "experimentIncrementalRefreshCreateUnitsTable",
     });
     queries.push(createUnitsTableQuery);
@@ -405,8 +441,9 @@ const startExperimentIncrementalRefreshQueries = async (
     query: integration.getDropOldIncrementalUnitsQuery({
       unitsTableFullName: unitsTableFullName,
     }),
-    run: (query, setExternalId, queryMetadata) =>
+    run: fenced((query, setExternalId, queryMetadata) =>
       integration.runDropTableQuery(query, setExternalId, queryMetadata),
+    ),
     dependencies: [updateUnitsTableQuery.query],
     queryType: "experimentIncrementalRefreshDropUnitsTable",
   });
@@ -420,12 +457,13 @@ const startExperimentIncrementalRefreshQueries = async (
       unitsTempTableFullName: unitsTempTableFullName,
     }),
     dependencies: [dropUnitsTableQuery.query],
-    run: (query, setExternalId, queryMetadata) =>
+    run: fenced((query, setExternalId, queryMetadata) =>
       integration.runIncrementalWithNoOutputQuery(
         query,
         setExternalId,
         queryMetadata,
       ),
+    ),
     queryType: "experimentIncrementalRefreshAlterUnitsTable",
   });
   queries.push(alterUnitsTableQuery);
@@ -559,12 +597,13 @@ const startExperimentIncrementalRefreshQueries = async (
           metricSourceTableFullName,
         }),
         dependencies: [updateUnitsTableQuery.query],
-        run: (query, setExternalId, queryMetadata) =>
+        run: fenced((query, setExternalId, queryMetadata) =>
           integration.runIncrementalWithNoOutputQuery(
             query,
             setExternalId,
             queryMetadata,
           ),
+        ),
         queryType: "experimentIncrementalRefreshCreateMetricsSourceTable",
       });
       queries.push(createMetricsSourceQuery);

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -131,6 +131,7 @@ export abstract class QueryRunner<
   } = {};
   private useCache: boolean;
   private pendingTimers: Record<string, NodeJS.Timeout> = {};
+  private lockHeartbeatTimer: null | NodeJS.Timeout = null;
   private finishedQueryMapCache: QueryMap = new Map();
 
   public constructor(
@@ -188,10 +189,23 @@ export abstract class QueryRunner<
     return this.pendingTimers[id] !== undefined;
   }
 
-  // Called from the per-query heartbeat interval (~every 30s while any query
-  // is executing). Subclasses that hold an external lock can override this to
-  // refresh it; the default is a no-op.
+  // Called periodically while the runner is active. Override to refresh an
+  // external lock; default is a no-op.
   protected onHeartbeat(): void {}
+
+  private startLockHeartbeat(): void {
+    if (this.lockHeartbeatTimer) return;
+    this.lockHeartbeatTimer = setInterval(() => {
+      this.onHeartbeat();
+    }, 30000);
+  }
+
+  private stopLockHeartbeat(): void {
+    if (this.lockHeartbeatTimer) {
+      clearInterval(this.lockHeartbeatTimer);
+      this.lockHeartbeatTimer = null;
+    }
+  }
 
   async onQueryFinish() {
     if (!this.timer) {
@@ -351,7 +365,12 @@ export abstract class QueryRunner<
     this.error = error;
     this.result = result;
 
+    if (this.status === "running") {
+      this.startLockHeartbeat();
+    }
+
     if (this.status === "finished") {
+      this.stopLockHeartbeat();
       this.emitter.emit(FINISH_EVENT);
     }
   }
@@ -711,7 +730,6 @@ export abstract class QueryRunner<
       updateQuery(this.context, doc, { heartbeat: new Date() }).catch((e) => {
         logger.error(e);
       });
-      this.onHeartbeat();
     }, 30000);
 
     // Run the query in the background

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -188,6 +188,11 @@ export abstract class QueryRunner<
     return this.pendingTimers[id] !== undefined;
   }
 
+  // Called from the per-query heartbeat interval (~every 30s while any query
+  // is executing). Subclasses that hold an external lock can override this to
+  // refresh it; the default is a no-op.
+  protected onHeartbeat(): void {}
+
   async onQueryFinish() {
     if (!this.timer) {
       logger.debug(
@@ -623,6 +628,7 @@ export abstract class QueryRunner<
       updateQuery(this.context, doc, { heartbeat: new Date() }).catch((e) => {
         logger.error(e);
       });
+      this.onHeartbeat();
     }, 30000);
 
     // Run the query in the background

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -1450,8 +1450,19 @@ export async function createSnapshotFromPlan({
   }
   const integration = getSourceIntegrationObject(context, datasource, true);
 
+  // Both incremental runner kinds need exclusive access to the per-experiment
+  // pipeline tables: "incremental" mutates them (DROP/CREATE/RENAME on the
+  // units + metric-source tables), and "incremental-exploratory" reads them.
+  // Locking both prevents concurrent triggers (e.g. scheduled auto-refresh +
+  // manual Update) from racing on those tables and producing empty or
+  // malformed results. The "results" runner writes only to per-snapshot
+  // ephemeral tables, so it does not need this lock.
+  const needsIncrementalRefreshLock =
+    plan.runnerKind === "incremental" ||
+    plan.runnerKind === "incremental-exploratory";
+
   let hasIncrementalRefreshLock = false;
-  if (plan.runnerKind === "incremental") {
+  if (needsIncrementalRefreshLock) {
     hasIncrementalRefreshLock =
       await context.models.incrementalRefresh.acquireLock(
         experiment.id,

--- a/packages/back-end/test/queryRunners/QueryRunner.test.ts
+++ b/packages/back-end/test/queryRunners/QueryRunner.test.ts
@@ -575,4 +575,162 @@ describe("QueryRunner", () => {
       }
     });
   });
+
+  describe("onHeartbeat lifecycle", () => {
+    let mockContext: ReqContext;
+    let mockIntegration: SourceIntegrationInterface;
+
+    beforeEach(() => {
+      mockContext = createMockContext();
+      mockIntegration = createMockIntegration();
+      (getQueriesByIds as jest.Mock).mockResolvedValue([]);
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    // Drives the runner into the "running" state with a DAG that still has
+    // queued/running queries, but never actually executes any query (no
+    // executeQuery, no per-query timers). onQueryFinish is neutralized so the
+    // only timer in play is the runner-level heartbeat interval. This isolates
+    // the guarantee in question: the lock heartbeat must keep firing for the
+    // whole time the runner is "running" — including the gaps between
+    // sequentially-dependent queries when no single query is executing.
+    class HeartbeatTestQueryRunner extends QueryRunner<
+      InterfaceWithQueries,
+      { pointers: Queries },
+      { success: boolean }
+    > {
+      public onHeartbeatSpy = jest.fn();
+
+      checkPermissions() {
+        return true;
+      }
+
+      async startQueries(params: { pointers: Queries }) {
+        return params.pointers;
+      }
+
+      async runAnalysis() {
+        return { success: true };
+      }
+
+      async getLatestModel() {
+        return this.model;
+      }
+
+      async updateModel(params: {
+        status: QueryStatus;
+        queries: Queries;
+      }): Promise<InterfaceWithQueries> {
+        return { ...this.model, queries: params.queries };
+      }
+
+      // Neutralize the per-query follow-up timer so the heartbeat interval is
+      // the only thing the fake clock advances.
+      async onQueryFinish() {}
+
+      protected override onHeartbeat(): void {
+        this.onHeartbeatSpy();
+      }
+    }
+
+    const runningPointers: Queries = [
+      { name: "drop_old", query: "qry_drop", status: "running" },
+      { name: "create", query: "qry_create", status: "queued" },
+    ];
+
+    it("fires onHeartbeat every ~30s while running even when no query is executing", async () => {
+      jest.useFakeTimers();
+      try {
+        const runner = new HeartbeatTestQueryRunner(
+          mockContext,
+          {
+            id: "test-model",
+            organization: "test-org",
+            queries: [],
+            runStarted: new Date(),
+          },
+          mockIntegration,
+        );
+
+        await runner.startAnalysis({ pointers: runningPointers });
+
+        expect(runner.status).toBe("running");
+        // Not yet — interval hasn't elapsed.
+        expect(runner.onHeartbeatSpy).toHaveBeenCalledTimes(0);
+
+        jest.advanceTimersByTime(30000);
+        expect(runner.onHeartbeatSpy).toHaveBeenCalledTimes(1);
+
+        // Spans the inter-query gap: still firing with zero query activity.
+        jest.advanceTimersByTime(60000);
+        expect(runner.onHeartbeatSpy).toHaveBeenCalledTimes(3);
+      } finally {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+      }
+    });
+
+    it("stops firing onHeartbeat once the runner finishes", async () => {
+      jest.useFakeTimers();
+      try {
+        const runner = new HeartbeatTestQueryRunner(
+          mockContext,
+          {
+            id: "test-model",
+            organization: "test-org",
+            queries: [],
+            runStarted: new Date(),
+          },
+          mockIntegration,
+        );
+
+        await runner.startAnalysis({ pointers: runningPointers });
+        jest.advanceTimersByTime(30000);
+        expect(runner.onHeartbeatSpy).toHaveBeenCalledTimes(1);
+
+        await runner.cancelQueries();
+        expect(runner.status).toBe("finished");
+
+        // Interval must be cleared — no further beats no matter how long we wait.
+        jest.advanceTimersByTime(120000);
+        expect(runner.onHeartbeatSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+      }
+    });
+
+    it("never starts the heartbeat when the runner finishes immediately (cached)", async () => {
+      jest.useFakeTimers();
+      try {
+        const runner = new HeartbeatTestQueryRunner(
+          mockContext,
+          {
+            id: "test-model",
+            organization: "test-org",
+            queries: [],
+            runStarted: new Date(),
+          },
+          mockIntegration,
+        );
+
+        await runner.startAnalysis({
+          pointers: [
+            { name: "a", query: "qry_a", status: "succeeded" },
+            { name: "b", query: "qry_b", status: "succeeded" },
+          ],
+        });
+
+        expect(runner.status).toBe("finished");
+        jest.advanceTimersByTime(120000);
+        expect(runner.onHeartbeatSpy).toHaveBeenCalledTimes(0);
+      } finally {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+      }
+    });
+  });
 });

--- a/packages/shared/src/validators/incremental-refresh.ts
+++ b/packages/shared/src/validators/incremental-refresh.ts
@@ -42,6 +42,7 @@ const incrementalRefresh = z
 
     // Incremental refresh lock
     currentExecutionSnapshotId: z.string().nullable(),
+    lockHeartbeatAt: z.date().nullable().optional(),
   })
   .strict();
 


### PR DESCRIPTION
Builds on #5466, which added the per-experiment incremental-refresh lock. Three remaining gaps allowed concurrent runs to corrupt the shared `gb_units_<experimentId>` / `gb_metrics_<experimentId>_*` warehouse tables.

## Problem

1. **Exploratory reader unlocked.** `createSnapshotFromPlan` only acquires the lock for `runnerKind === "incremental"`. The `incremental-exploratory` runner reads the same per-experiment units / metric-source tables that the incremental runner DROP/CREATE/RENAMEs, so a scheduled auto-refresh overlapping with a dimension-slice analysis can observe a missing or empty units table and return empty results.
2. **Stale check is wall-clock, not liveness.** A lock was considered stale once `dateUpdated` was >1h old. Long-running refreshes legitimately exceed that, so a second trigger (auto-refresh cron + manual Update overlap) could steal the lock mid-run while the first holder was still issuing DDL on the shared tables.
3. **No fence at DDL time.** Even with a correct lock, if it *is* lost mid-run (stale takeover, cancel + restart), the original holder's already-queued DROP/RENAME on the shared tables would still execute and clobber the new holder's state.

## Fix

1. **Lock the exploratory reader.** Acquire the lock for both `incremental` and `incremental-exploratory` runner kinds; release it from the exploratory runner's `updateModel` on terminal status (mirroring the incremental runner). The `results` runner is unaffected — it writes only to per-snapshot ephemeral tables (`growthbook_tmp_units_<snapshotId>`) and shares no warehouse state across runs. This also serves as in-flight snapshot dedup for incremental pipeline mode: a second concurrent `createSnapshot` caller fails fast with `ConcurrentIncrementalRefreshError`, which the auto-refresh job already handles gracefully.
2. **Heartbeat-based staleness.** Add `lockHeartbeatAt` to `IncrementalRefresh`; `acquireLock` now treats a lock as stale only when the heartbeat (falling back to `dateUpdated` for legacy docs) is older than `INCREMENTAL_LOCK_STALE_MS` (10 min). Add `touchLockHeartbeat()` (fenced on `currentExecutionSnapshotId`) and call it from a new `QueryRunner.onHeartbeat()` hook driven by the existing 30s per-query heartbeat interval. Both incremental runner kinds override the hook.
3. **Execute-time fence on shared-table DDL.** Wrap the `run` callbacks for the units DROP/CREATE/RENAME and metric-source CREATE queries in a `fenced()` helper that re-reads `currentExecutionSnapshotId` immediately before executing the SQL and aborts with a clear error if this snapshot no longer holds the lock. Checked at execute time (not enqueue time) because all queries are enqueued up-front but run sequentially via dependencies. `releaseLock` is already fenced on `snapshotId`, so the terminal-status release is a safe no-op once the lock is lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
