### PR TITLE
Restore /api/v1/ index route lost in routing refactor (#5690 / #5804)

### DIFF
--- a/packages/back-end/src/api/api.router.ts
+++ b/packages/back-end/src/api/api.router.ts
@@ -123,14 +123,21 @@ router.use(
   }),
 );
 
-// Index health check route
-router.get("/", (req, res) => {
+// Index health check route. Registered at both `/` (mounted at `/api/`) and
+// `/v1/` (mounted at `/api/v1/`). Before #5690 the router was mounted at
+// `/api/v1` directly, so `router.get("/")` answered `/api/v1/`. #5690 moved
+// the mount to `/api` with the registration loop below self-prefixing `/v1/`
+// onto other routes, and #5804 hand-updated the openapi route similarly —
+// but this index handler was missed, leaving `/api/v1/` unrouted.
+const indexHandler: RequestHandler = (req, res) => {
   res.json({
     name: "GrowthBook API",
     apiVersion: 1,
     build: getBuild(),
   });
-});
+};
+router.get("/", indexHandler);
+router.get("/v1/", indexHandler);
 
 export const allRoutes = [
   ...featureRoutes,


### PR DESCRIPTION
## Summary

- `router.get("/", ...)` answered `/api/v1/` before #5690 because the router was mounted at `/api/v1`. #5690 moved the mount to `/api` with the registration loop self-prefixing `/v1/` onto `allRoutes` entries, and #5804 hand-updated the openapi route accordingly (`/v1/openapi.yaml`). The index health-check was missed — it still only answers `/api/`.
- This silently broke external pings against `/api/v1/` that worked for years. The endpoint now returns `404 {"message":"Unknown API endpoint"}` instead of the build-info JSON.
- Fix: register the same handler at both `/` and `/v1/`. Two lines.

## Repro

```
$ curl https://growthbook.example/api/v1/
{"message":"Unknown API endpoint"}        # 404, post-#5690

$ curl https://growthbook.example/api/
{"name":"GrowthBook API","apiVersion":1,...}    # 200, the index handler
```

The fact that one shape works and the other doesn't is the giveaway — pre-#5690 it was the inverse (`/api/v1/` worked, `/api/` didn't), so the routing refactor flipped which path the index handler answers on without anyone realizing.

## Test plan

- [x] Verified locally: `GET /api/v1/` returns the build-info JSON.
- [x] Verified `GET /api/` still returns the build-info JSON (unchanged behavior for the post-#5690 form).
- [x] No effect on the openapi spec — this only adds a non-versioned alias to an existing handler.

## Why this is worth merging

Our experiment-sync pipeline downstream pings `/api/v1/` at startup to log GrowthBook's build info, and started failing the moment we deployed the post-#5690 / post-#5804 stack to prod. The change is small, low-risk (no behavior change for any existing working path), and restores byte-identical behavior at `/api/v1/` to what shipped before the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)