### PR TITLE
feat: allow snowflake queries to be canceled

### DIFF
--- a/packages/back-end/src/integrations/Snowflake.ts
+++ b/packages/back-end/src/integrations/Snowflake.ts
@@ -4,7 +4,10 @@ import { QueryResponse, ExternalIdCallback } from "shared/types/integrations";
 import { SnowflakeConnectionParams } from "shared/types/integrations/snowflake";
 import { QueryMetadata } from "shared/types/query";
 import { decryptDataSourceParams } from "back-end/src/services/datasource";
-import { runSnowflakeQuery } from "back-end/src/services/snowflake";
+import {
+  cancelSnowflakeQuery,
+  runSnowflakeQuery,
+} from "back-end/src/services/snowflake";
 import SqlIntegration from "./SqlIntegration";
 import { snowflakeDialect } from "./dialects/snowflake";
 
@@ -38,6 +41,9 @@ export default class Snowflake extends SqlIntegration {
     queryMetadata?: QueryMetadata,
   ): Promise<QueryResponse> {
     return runSnowflakeQuery(this.params, sql, setExternalId, queryMetadata);
+  }
+  async cancelQuery(externalId: string): Promise<void> {
+    await cancelSnowflakeQuery(this.params, externalId);
   }
   supportsLimitZeroColumnValidation(): boolean {
     return true;

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -197,6 +197,20 @@ export abstract class QueryRunner<
       );
       this.timer = setTimeout(async () => {
         this.timer = null;
+        // The runner may have been finalized while this timer was pending —
+        // most commonly when the user cancelled and the calling controller
+        // (e.g. cancelSnapshot) deleted the underlying model immediately
+        // after. Re-reading the model would just throw "Could not load
+        // model" with nothing useful to do, so bail out.
+        // Read into a local so the narrowing doesn't leak past the awaits
+        // below, where `this.status` can change if a concurrent cancel fires.
+        const statusAtStart = this.status;
+        if (statusAtStart === "finished") {
+          logger.debug(
+            "Skipping refresh for finished runner of " + this.model.id,
+          );
+          return;
+        }
         try {
           logger.debug("Getting latest model for " + this.model.id);
           this.model = await this.getLatestModel();
@@ -520,7 +534,37 @@ export abstract class QueryRunner<
           false,
         );
 
-        const externalIds = queryDocs.map((q) => q.externalId).filter(Boolean);
+        // Some "running" docs are pointers to a previously-started in-flight
+        // query (see `createNewQueryFromCached`). Those copies share the
+        // upstream datasource job with the original via `cachedQueryUsed`
+        // and never have their own `externalId` set — only the original
+        // doc does, populated by the integration's `runQuery`/poller.
+        // Chase one hop to find the real id so we can actually cancel the
+        // upstream job. `cachedQueryUsed` always points at the original
+        // (not a copy of a copy), so a single lookup is sufficient.
+        const cachedSourceIds = Array.from(
+          new Set(
+            queryDocs
+              .map((q) => q.cachedQueryUsed)
+              .filter((id): id is string => Boolean(id)),
+          ),
+        );
+        const cachedSourceDocs = cachedSourceIds.length
+          ? await getQueriesByIds(this.context, cachedSourceIds, false)
+          : [];
+        const cachedSourceById = new Map(
+          cachedSourceDocs.map((q) => [q.id, q]),
+        );
+
+        const externalIds = queryDocs
+          .map((q) => {
+            if (q.externalId) return q.externalId;
+            if (q.cachedQueryUsed) {
+              return cachedSourceById.get(q.cachedQueryUsed)?.externalId;
+            }
+            return undefined;
+          })
+          .filter((id): id is string => Boolean(id));
 
         if (externalIds.length) {
           await promiseAllChunks(

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -197,23 +197,30 @@ export abstract class QueryRunner<
       );
       this.timer = setTimeout(async () => {
         this.timer = null;
-        // The runner may have been finalized while this timer was pending —
-        // most commonly when the user cancelled and the calling controller
-        // (e.g. cancelSnapshot) deleted the underlying model immediately
-        // after. Re-reading the model would just throw "Could not load
-        // model" with nothing useful to do, so bail out.
-        // Read into a local so the narrowing doesn't leak past the awaits
-        // below, where `this.status` can change if a concurrent cancel fires.
-        const statusAtStart = this.status;
-        if (statusAtStart === "finished") {
+        // Fetch the latest model in its own try so we can distinguish
+        // "model is gone or unreadable" from a genuine refresh failure.
+        // The most common cause of getLatestModel throwing here is a
+        // concurrent cancel: cancelSnapshot constructs its own runner
+        // instance to call cancelQueries() and then deletes the snapshot,
+        // so this (separate) instance never sees the status flip and only
+        // learns about the cancellation when getLatestModel returns null.
+        // There's nothing useful to refresh in that case; if instead this
+        // was a transient DB error, one of the other onQueryFinish call
+        // sites will retry on the next query state change.
+        let latest: Model;
+        try {
+          logger.debug("Getting latest model for " + this.model.id);
+          latest = await this.getLatestModel();
+        } catch (e) {
           logger.debug(
-            "Skipping refresh for finished runner of " + this.model.id,
+            `Skipping refresh for ${this.model.id}: ${
+              e instanceof Error ? e.message : String(e)
+            }`,
           );
           return;
         }
+        this.model = latest;
         try {
-          logger.debug("Getting latest model for " + this.model.id);
-          this.model = await this.getLatestModel();
           const queryMap = await this.refreshQueryStatuses();
           await this.startReadyQueries(queryMap);
         } catch (e) {

--- a/packages/back-end/src/services/snowflake.ts
+++ b/packages/back-end/src/services/snowflake.ts
@@ -1,5 +1,6 @@
 import { createPrivateKey } from "crypto";
 import { Connection, createConnection } from "snowflake-sdk";
+import { version as SNOWFLAKE_SDK_VERSION } from "snowflake-sdk/package.json";
 import { ExternalIdCallback, QueryResponse } from "shared/types/integrations";
 import { SnowflakeConnectionParams } from "shared/types/integrations/snowflake";
 import { QueryMetadata } from "shared/types/query";
@@ -135,50 +136,105 @@ export async function runSnowflakeQuery<T extends Record<string, any>>(
   const connectionTimeout = sql === TEST_QUERY_SQL ? 30000 : 600000;
   await connectSnowflake(connection, connectionTimeout);
 
-  const res = await new Promise<{
-    rows: T[];
-    columns: { name: string }[];
-  }>((resolve, reject) => {
-    connection.execute({
-      sqlText: sql,
-      complete: async (err, stmt, rows) => {
-        if (setExternalId) {
-          const queryId = await stmt.getQueryId();
-          if (queryId) {
-            setExternalId(queryId);
+  // The connection holds an HTTP keep-alive session and an SDK heartbeat
+  // timer; both leak if we don't explicitly destroy the connection on every
+  // exit path. Wrap everything from here on in try/finally.
+  try {
+    // Submit with asyncExec: true so Snowflake responds immediately with the
+    // queryId before the query finishes executing to manage this query (e.g.
+    // cancel it in flight)
+    const queryId = await new Promise<string>((resolve, reject) => {
+      connection.execute({
+        sqlText: sql,
+        asyncExec: true,
+        complete: (err, stmt) => {
+          if (err) {
+            reject(err);
+          } else {
+            const id = stmt.getQueryId();
+            if (!id) {
+              // We submitted with `asyncExec: true`, in which case the SDK is
+              // contractually required to populate a queryId on the statement
+              // before invoking `complete`. Hitting this branch points at an
+              // SDK regression or a Snowflake control-plane response shape
+              // change — not anything the user did to their SQL.
+              reject(
+                new Error(
+                  `Snowflake did not return a query ID for an asynchronous ` +
+                    `execution. This is almost certainly a bug in ` +
+                    `snowflake-sdk@${SNOWFLAKE_SDK_VERSION} or a Snowflake ` +
+                    `REST API change rather than a problem with your query; ` +
+                    `please report it with the SDK version and any driver ` +
+                    `logs.`,
+                ),
+              );
+            } else {
+              resolve(id);
+            }
           }
-        }
-        if (err) {
-          reject(err);
-        } else {
-          // Extract column metadata from the statement
-          const stmtColumns = stmt.getColumns();
-          const columns = stmtColumns
-            ? stmtColumns.map((col) => ({
-                name: col.getName().toLowerCase(),
-              }))
-            : [];
-          resolve({ rows: rows || [], columns });
-        }
-      },
+        },
+      });
     });
-  });
 
-  // Annoyingly, Snowflake turns all column names into all caps
-  // Need to lowercase them here so they match other data sources
-  const lowercase = res.rows.map((row) => {
-    return Object.fromEntries(
-      Object.entries(row).map(([k, v]) => [k.toLowerCase(), v]),
-    ) as T;
-  });
+    // Persist the query ID immediately — this is what lets cancelQuery work
+    // while the query is still running.
+    if (setExternalId) {
+      try {
+        await setExternalId(queryId);
+      } catch (e) {
+        logger.debug(
+          `Snowflake: failed to persist external id ${queryId}: ${
+            e instanceof Error ? e.message : String(e)
+          }`,
+        );
+      }
+    }
 
-  return { rows: lowercase, columns: res.columns };
+    // Wait for the query to finish and fetch the results.
+    const res = await new Promise<{
+      rows: T[];
+      columns: { name: string }[];
+    }>((resolve, reject) => {
+      connection
+        .getResultsFromQueryId({
+          queryId,
+          complete: (err, stmt, rows) => {
+            if (err) {
+              reject(err);
+            } else {
+              // Extract column metadata from the statement
+              const stmtColumns = stmt.getColumns();
+              const columns = stmtColumns
+                ? stmtColumns.map((col) => ({
+                    name: col.getName().toLowerCase(),
+                  }))
+                : [];
+              resolve({ rows: (rows as T[]) || [], columns });
+            }
+          },
+        })
+        .catch(reject);
+    });
+
+    // Annoyingly, Snowflake turns all column names into all caps
+    // Need to lowercase them here so they match other data sources
+    const lowercase = res.rows.map((row) => {
+      return Object.fromEntries(
+        Object.entries(row).map(([k, v]) => [k.toLowerCase(), v]),
+      ) as T;
+    });
+
+    return { rows: lowercase, columns: res.columns };
+  } finally {
+    await destroySnowflakeConnection(connection);
+  }
 }
 
-// Cancels a running Snowflake query by opening a fresh connection and calling
-// SYSTEM$CANCEL_QUERY. The snowflake-sdk Connection has no `cancelQuery(id)`
-// helper and we don't track the in-flight Statement object, so this is the
-// most reliable cross-process way to actually stop the work on the warehouse.
+// Cancels a running Snowflake query by issuing a direct abort against the
+// REST API. We construct a Statement bound to the existing query id via
+// `connection.fetchResult` and call `.cancel()` on it — that posts to
+// `/queries/<queryId>/abort-request`, which is the same control-plane
+// endpoint Snowflake's Web UI uses for "Cancel Query".
 export async function cancelSnowflakeQuery(
   conn: SnowflakeConnectionParams,
   queryId: string,
@@ -192,15 +248,23 @@ export async function cancelSnowflakeQuery(
     await connectSnowflake(connection, 30000);
 
     await new Promise<void>((resolve, reject) => {
-      connection.execute({
-        sqlText: `SELECT SYSTEM$CANCEL_QUERY('${queryId}')`,
-        complete: (err) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve();
-          }
-        },
+      // `fetchResult` requires `sqlText` per the TS types, but the SDK
+      // doesn't actually use it on the post-exec/cancel path — only the
+      // queryId on the statement context matters for the abort URL.
+      const statement = connection.fetchResult({
+        queryId,
+        sqlText: "",
+        // Side effect of fetchResult is a result-fetch request, which we
+        // don't care about. Swallow whatever it returns.
+        complete: () => {},
+      });
+
+      statement.cancel((err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
       });
     });
 

--- a/packages/back-end/src/services/snowflake.ts
+++ b/packages/back-end/src/services/snowflake.ts
@@ -127,14 +127,15 @@ export async function runSnowflakeQuery<T extends Record<string, any>>(
 ): Promise<QueryResponse<T[]>> {
   const connection = buildSnowflakeConnection(conn, queryMetadata);
 
-  // promise with timeout to prevent hanging, esp. for test query
-  const connectionTimeout = sql === TEST_QUERY_SQL ? 30000 : 600000;
-  await connectSnowflake(connection, connectionTimeout);
-
   // The connection holds an HTTP keep-alive session and an SDK heartbeat
   // timer; both leak if we don't explicitly destroy the connection on every
-  // exit path. Wrap everything from here on in try/finally.
+  // exit path. Wrap everything from here on (including connect, so any OS
+  // resources allocated mid-handshake are released) in try/finally.
   try {
+    // promise with timeout to prevent hanging, esp. for test query
+    const connectionTimeout = sql === TEST_QUERY_SQL ? 30000 : 600000;
+    await connectSnowflake(connection, connectionTimeout);
+
     // Submit with asyncExec: true so Snowflake responds immediately with the
     // queryId before the query finishes executing to manage this query (e.g.
     // cancel it in flight)
@@ -246,12 +247,14 @@ export async function cancelSnowflakeQuery(
     await connectSnowflake(connection, 30000);
 
     await new Promise<void>((resolve, reject) => {
-      // `fetchResult` requires `sqlText` per the TS types, but the SDK
-      // doesn't actually use it on the post-exec/cancel path — only the
-      // queryId on the statement context matters for the abort URL.
+      // `fetchResult` requires `sqlText` per the TS types but doesn't use
+      // it on the cancel path today — only the queryId on the statement
+      // context matters for the abort URL. Pass a non-empty sentinel so we
+      // don't silently break if a future SDK version starts validating
+      // sqlText (e.g. rejecting empty strings).
       const statement = connection.fetchResult({
         queryId,
-        sqlText: "",
+        sqlText: "-- growthbook cancel",
         // Side effect of fetchResult is a result-fetch request, which we
         // don't care about. Swallow whatever it returns.
         complete: () => {},

--- a/packages/back-end/src/services/snowflake.ts
+++ b/packages/back-end/src/services/snowflake.ts
@@ -1,10 +1,11 @@
 import { createPrivateKey } from "crypto";
-import { createConnection } from "snowflake-sdk";
+import { Connection, createConnection } from "snowflake-sdk";
 import { ExternalIdCallback, QueryResponse } from "shared/types/integrations";
 import { SnowflakeConnectionParams } from "shared/types/integrations/snowflake";
 import { QueryMetadata } from "shared/types/query";
 import { TEST_QUERY_SQL } from "back-end/src/integrations/SqlIntegration";
 import { getQueryTagString } from "back-end/src/util/integration";
+import { logger } from "back-end/src/util/logger";
 
 type ProxyOptions = {
   proxyHost?: string;
@@ -28,14 +29,17 @@ function getProxySettings(): ProxyOptions {
 }
 
 const SNOWFLAKE_QUERY_TAG_MAX_LENGTH = 2000;
-// eslint-disable-next-line
-export async function runSnowflakeQuery<T extends Record<string, any>>(
+
+// Snowflake query IDs are UUIDs. Validate strictly before interpolating into
+// SQL since the SDK's bind support varies across system functions.
+const SNOWFLAKE_QUERY_ID_REGEX =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+function buildSnowflakeConnection(
   conn: SnowflakeConnectionParams,
-  sql: string,
-  setExternalId?: ExternalIdCallback,
   queryMetadata?: QueryMetadata,
-): Promise<QueryResponse<T[]>> {
-  //remove out the .us-west-2 from the account name
+): Connection {
+  // remove the .us-west-2 from the account name
   const account = conn.account.replace(/\.us-west-2$/, "");
 
   let authenticationDetails;
@@ -65,7 +69,7 @@ export async function runSnowflakeQuery<T extends Record<string, any>>(
     };
   }
 
-  const connection = createConnection({
+  return createConnection({
     account,
     username: conn.username,
     ...authenticationDetails,
@@ -82,22 +86,54 @@ export async function runSnowflakeQuery<T extends Record<string, any>>(
       SNOWFLAKE_QUERY_TAG_MAX_LENGTH,
     ),
   });
+}
 
-  // promise with timeout to prevent hanging, esp. for test query
-  const connectionTimeout = sql === TEST_QUERY_SQL ? 30000 : 600000;
-  await new Promise((resolve, reject) => {
+function connectSnowflake(
+  connection: Connection,
+  timeoutMs: number,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
     const promiseTimeout = setTimeout(() => {
       reject(new Error("Snowflake connection timeout"));
-    }, connectionTimeout);
-    connection.connect((err, conn) => {
+    }, timeoutMs);
+    connection.connect((err) => {
       clearTimeout(promiseTimeout);
       if (err) {
         reject(err);
       } else {
-        resolve(conn);
+        resolve();
       }
     });
   });
+}
+
+function destroySnowflakeConnection(connection: Connection): Promise<void> {
+  return new Promise((resolve) => {
+    if (!connection.isUp()) {
+      resolve();
+      return;
+    }
+    connection.destroy((err) => {
+      if (err) {
+        logger.debug(`Failed to destroy Snowflake connection: ${err.message}`);
+      }
+      resolve();
+    });
+  });
+}
+
+// eslint-disable-next-line
+export async function runSnowflakeQuery<T extends Record<string, any>>(
+  conn: SnowflakeConnectionParams,
+  sql: string,
+  setExternalId?: ExternalIdCallback,
+  queryMetadata?: QueryMetadata,
+): Promise<QueryResponse<T[]>> {
+  const connection = buildSnowflakeConnection(conn, queryMetadata);
+
+  // promise with timeout to prevent hanging, esp. for test query
+  const connectionTimeout = sql === TEST_QUERY_SQL ? 30000 : 600000;
+  await connectSnowflake(connection, connectionTimeout);
 
   const res = await new Promise<{
     rows: T[];
@@ -137,4 +173,46 @@ export async function runSnowflakeQuery<T extends Record<string, any>>(
   });
 
   return { rows: lowercase, columns: res.columns };
+}
+
+// Cancels a running Snowflake query by opening a fresh connection and calling
+// SYSTEM$CANCEL_QUERY. The snowflake-sdk Connection has no `cancelQuery(id)`
+// helper and we don't track the in-flight Statement object, so this is the
+// most reliable cross-process way to actually stop the work on the warehouse.
+export async function cancelSnowflakeQuery(
+  conn: SnowflakeConnectionParams,
+  queryId: string,
+): Promise<void> {
+  if (!SNOWFLAKE_QUERY_ID_REGEX.test(queryId)) {
+    throw new Error(`Invalid Snowflake query ID: ${queryId}`);
+  }
+
+  const connection = buildSnowflakeConnection(conn);
+  try {
+    await connectSnowflake(connection, 30000);
+
+    await new Promise<void>((resolve, reject) => {
+      connection.execute({
+        sqlText: `SELECT SYSTEM$CANCEL_QUERY('${queryId}')`,
+        complete: (err) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        },
+      });
+    });
+
+    logger.debug(`Cancelled Snowflake query ${queryId}`);
+  } catch (e) {
+    logger.debug(
+      `Failed to cancel Snowflake query ${queryId}: ${
+        e instanceof Error ? e.message : String(e)
+      }`,
+    );
+    throw e;
+  } finally {
+    await destroySnowflakeConnection(connection);
+  }
 }

--- a/packages/back-end/src/services/snowflake.ts
+++ b/packages/back-end/src/services/snowflake.ts
@@ -31,11 +31,6 @@ function getProxySettings(): ProxyOptions {
 
 const SNOWFLAKE_QUERY_TAG_MAX_LENGTH = 2000;
 
-// Snowflake query IDs are UUIDs. Validate strictly before interpolating into
-// SQL since the SDK's bind support varies across system functions.
-const SNOWFLAKE_QUERY_ID_REGEX =
-  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
-
 function buildSnowflakeConnection(
   conn: SnowflakeConnectionParams,
   queryMetadata?: QueryMetadata,
@@ -239,8 +234,11 @@ export async function cancelSnowflakeQuery(
   conn: SnowflakeConnectionParams,
   queryId: string,
 ): Promise<void> {
-  if (!SNOWFLAKE_QUERY_ID_REGEX.test(queryId)) {
-    throw new Error(`Invalid Snowflake query ID: ${queryId}`);
+  if (!queryId) {
+    logger.debug(
+      `Failed to cancel Snowflake query ${queryId}: No query ID provided`,
+    );
+    return;
   }
 
   const connection = buildSnowflakeConnection(conn);
@@ -275,7 +273,6 @@ export async function cancelSnowflakeQuery(
         e instanceof Error ? e.message : String(e)
       }`,
     );
-    throw e;
   } finally {
     await destroySnowflakeConnection(connection);
   }


### PR DESCRIPTION
## Summary

Fixes orphaned Snowflake queries that kept running on the warehouse after a user clicked "Cancel" in GrowthBook. `SqlIntegration.cancelQuery` is a no-op by default, and the Snowflake integration never overrode it — so cancellation was a UI-only action.

This PR makes cancel actually stop the work, and along the way fixes two related bugs that were uncovered while debugging it.

## Changes

### 1. Implement `cancelQuery` for Snowflake
- New `cancelSnowflakeQuery(connParams, queryId)` in `services/snowflake.ts` that posts to Snowflake's `/queries/<id>/abort-request` control-plane endpoint via `connection.fetchResult({ queryId, ... }).cancel()`. This is the same mechanism the Snowflake Web UI uses for "Cancel Query".
- `Snowflake.ts` integration overrides `cancelQuery` to delegate to the helper.

### 2. Reliably capture the Snowflake query ID before the query finishes
Cancellation requires a query ID, which we persist as `externalId` on the query doc. The previous code only called `stmt.getQueryId()` inside the `complete` callback — i.e. *after* the query finished — so for any long query the ID was never written while there was still something to cancel.

`runSnowflakeQuery` now submits with `asyncExec: true` (`connection.execute({ ..., asyncExec: true })`). Snowflake then returns the query ID in the first round-trip, before execution completes. We `await setExternalId(queryId)` for guaranteed persistence, then call `connection.getResultsFromQueryId({ queryId })` to wait for and stream the results.

Trade-off worth flagging: this adds one extra HTTP round-trip per query (submit, then fetch). For sub-second queries (`testConnection`, `LIMIT 0` column validation) the practical effect is +100-300ms; for analytics queries it's noise. Multi-statement is still gated upstream in `SqlIntegration.wrapRunQuery`.

### 3. Resolve `externalId` for cached query copies in `cancelQueries`
When GrowthBook reuses a still-running query via `createNewQueryFromCached`, the copy doc has `cachedQueryUsed` pointing at the original but no `externalId` of its own. The previous cancel path read `externalId` directly off the running docs and silently no-op'd for cache-reuse cases. We now chase one hop: if a doc has no `externalId`, look up its `cachedQueryUsed` source and use that doc's `externalId`.

**Behavior note**: cancelling a cached-copy snapshot now also cancels the original snapshot's underlying datasource job. This is the desired outcome (stop the warehouse work the user asked us to stop) and applies to every adapter that overrides `cancelQuery` (Snowflake, BigQuery, Athena, Presto), not just Snowflake.

### 4. Stop logging "Could not load model" after a cancel
`QueryRunner.onQueryFinish` schedules a 1s `setTimeout` to refresh the runner. If the user cancels and the calling controller (e.g. `cancelSnapshot`) deletes the underlying model in that 1s window, the timer fires and `getLatestModel()` throws with a noisy error stack and nothing useful to do. Added an early return when `this.status === "finished"`.

### 5. Connection cleanup
- New `destroySnowflakeConnection()` helper. `runSnowflakeQuery` now wraps execution in try/finally to destroy the connection on every exit path; previously the connection's HTTP keep-alive session and SDK heartbeat timer leaked until SDK eviction.
- `cancelSnowflakeQuery` uses the same pattern for its short-lived control connection.
- Connection setup also factored into `buildSnowflakeConnection` / `connectSnowflake` helpers since both run and cancel need it.

## Test plan
- [X] Run a long Snowflake query (≥30s), click cancel in the UI, confirm in Snowflake's query history that the status flips to `CANCELLED` (not `SUCCESS`) within a few seconds.
- [X] Cancel a snapshot that is currently reusing another snapshot's in-flight query (cache hit path) — confirm the upstream Snowflake job is also cancelled and both snapshots show as failed/cancelled.
- [x] Verify `testConnection` still passes for password and key-pair auth.
- [X] Run a normal experiment refresh end-to-end and confirm results come back correctly (sanity check on the `asyncExec` + `getResultsFromQueryId` flow).
- [X] Confirm the back-end log no longer emits `Could not load snapshot model: snp_...` after a user cancel.