### PR TITLE
fix(incremental): degrade gracefully when some metrics are incompatible with the pipeline

### DIFF
--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -81,6 +81,7 @@ const experimentSnapshotSchema = new mongoose.Schema({
   dimension: String,
   unknownVariations: [String],
   multipleExposures: Number,
+  warnings: [String],
   hasCorrectedStats: Boolean,
   status: String,
   settings: {},

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
@@ -30,7 +30,10 @@ import { FactTableMap } from "back-end/src/models/FactTableModel";
 import { updateReport } from "back-end/src/models/ReportModel";
 import { parseDimension } from "back-end/src/services/experiments";
 import { analyzeExperimentResults } from "back-end/src/services/stats";
-import { validateIncrementalPipeline } from "back-end/src/services/dataPipeline";
+import {
+  formatIncompatibleMetricsWarning,
+  validateIncrementalPipeline,
+} from "back-end/src/services/dataPipeline";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
 import { applyMetricOverrides } from "back-end/src/util/integration";
 import {
@@ -237,7 +240,7 @@ export class ExperimentIncrementalRefreshExploratoryQueryRunner extends QueryRun
       throw new Error("Experiment not found");
     }
 
-    await validateIncrementalPipeline({
+    const { incompatibleMetrics } = await validateIncrementalPipeline({
       org: this.context.org,
       integration: this.integration,
       snapshotSettings: params.snapshotSettings,
@@ -248,9 +251,33 @@ export class ExperimentIncrementalRefreshExploratoryQueryRunner extends QueryRun
       analysisType: "exploratory",
     });
 
+    let runnerParams = params;
+    if (incompatibleMetrics.length) {
+      const incompatibleIds = new Set(incompatibleMetrics.map((m) => m.id));
+      runnerParams = {
+        ...params,
+        snapshotSettings: {
+          ...params.snapshotSettings,
+          metricSettings: params.snapshotSettings.metricSettings.filter(
+            (m) => !incompatibleIds.has(m.id),
+          ),
+        },
+      };
+      await updateSnapshot({
+        context: this.context,
+        id: this.model.id,
+        updates: {
+          warnings: [
+            ...(this.model.warnings ?? []),
+            formatIncompatibleMetricsWarning(incompatibleMetrics),
+          ],
+        },
+      });
+    }
+
     return startExperimentIncrementalRefreshExploratoryQueries(
       this.context,
-      params,
+      runnerParams,
       this.integration,
       this.startQuery.bind(this),
     );

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -45,7 +45,10 @@ import {
   getExperimentSettingsHashForIncrementalRefresh,
   getMetricSettingsHashForIncrementalRefresh,
 } from "back-end/src/services/experimentTimeSeries";
-import { validateIncrementalPipeline } from "back-end/src/services/dataPipeline";
+import {
+  formatIncompatibleMetricsWarning,
+  validateIncrementalPipeline,
+} from "back-end/src/services/dataPipeline";
 import { getExposureQueryEligibleDimensions } from "back-end/src/services/dimensions";
 import { chunkMetrics } from "back-end/src/services/experimentQueries/experimentQueries";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
@@ -906,8 +909,9 @@ export class ExperimentIncrementalRefreshQueryRunner extends QueryRunner<
       throw new Error("Experiment not found");
     }
 
-    // Throws if any settings/experiment is not supported
-    await validateIncrementalPipeline({
+    // Throws on experiment-wide incompatibilities; returns per-metric ones so
+    // we can run incremental refresh on the compatible subset.
+    const { incompatibleMetrics } = await validateIncrementalPipeline({
       org: this.context.org,
       integration: this.integration,
       snapshotSettings: params.snapshotSettings,
@@ -918,9 +922,33 @@ export class ExperimentIncrementalRefreshQueryRunner extends QueryRunner<
       analysisType: params.fullRefresh ? "main-fullRefresh" : "main-update",
     });
 
+    let runnerParams = params;
+    if (incompatibleMetrics.length) {
+      const incompatibleIds = new Set(incompatibleMetrics.map((m) => m.id));
+      runnerParams = {
+        ...params,
+        snapshotSettings: {
+          ...params.snapshotSettings,
+          metricSettings: params.snapshotSettings.metricSettings.filter(
+            (m) => !incompatibleIds.has(m.id),
+          ),
+        },
+      };
+      await updateSnapshot({
+        context: this.context,
+        id: this.model.id,
+        updates: {
+          warnings: [
+            ...(this.model.warnings ?? []),
+            formatIncompatibleMetricsWarning(incompatibleMetrics),
+          ],
+        },
+      });
+    }
+
     return await startExperimentIncrementalRefreshQueries(
       this.context,
-      params,
+      runnerParams,
       this.integration,
       this.startQuery.bind(this),
     );

--- a/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
@@ -68,6 +68,7 @@ export type SnapshotResult = {
   analyses: ExperimentSnapshotAnalysis[];
   banditResult?: BanditResult;
   health?: ExperimentSnapshotHealth;
+  warnings?: string[];
 };
 
 export type ExperimentResultsQueryParams = {

--- a/packages/back-end/src/services/dataPipeline.ts
+++ b/packages/back-end/src/services/dataPipeline.ts
@@ -16,8 +16,16 @@ import {
   getMetricSettingsHashForIncrementalRefresh,
 } from "./experimentTimeSeries";
 
-// If the given settings / experiment is not compatible with incremental refresh, throw an error.
-// Otherwise, return void.
+export type IncompatibleMetric = {
+  id: string;
+  name: string;
+  reason: string;
+};
+
+// Throws if the experiment as a whole cannot use incremental refresh
+// (experiment-wide gates). Per-metric incompatibilities are returned instead
+// of thrown so the runner can still process the compatible subset and surface
+// a non-fatal warning for the rest. Throws if no compatible metrics remain.
 export async function validateIncrementalPipeline({
   org,
   integration,
@@ -36,7 +44,7 @@ export async function validateIncrementalPipeline({
   experiment: ExperimentInterface;
   incrementalRefreshModel: IncrementalRefreshInterface | null;
   analysisType: "main-update" | "main-fullRefresh" | "exploratory";
-}): Promise<void> {
+}): Promise<{ incompatibleMetrics: IncompatibleMetric[] }> {
   if (snapshotSettings.skipPartialData) {
     throw new Error(
       "'Exclude In-Progress Conversions' is not supported for incremental refresh queries while in beta. Please select 'Include' in the Analysis Settings for Metric Conversion Windows.",
@@ -93,35 +101,50 @@ export async function validateIncrementalPipeline({
   if (!selectedMetrics.length) {
     throw new Error("Experiment must have at least 1 metric selected.");
   }
-  if (selectedMetrics.some((m) => !isFactMetric(m))) {
-    throw new Error(
-      "Only fact metrics are supported with incremental refresh.",
-    );
-  }
 
-  selectedMetrics.filter(isFactMetric).forEach((metric) => {
+  const incompatibleMetrics: IncompatibleMetric[] = [];
+  const hasQuantileKLL = integration.getSourceProperties().hasQuantileKLL;
+
+  selectedMetrics.forEach((metric) => {
+    if (!isFactMetric(metric)) {
+      incompatibleMetrics.push({
+        id: metric.id,
+        name: metric.name ?? metric.id,
+        reason: "only fact metrics are supported with incremental refresh",
+      });
+      return;
+    }
     if (
       isRatioMetric(metric) &&
       metric.numerator.factTableId !== metric.denominator?.factTableId
     ) {
-      throw new Error(
-        "Ratio metrics must have the same numerator and denominator fact table with incremental refresh.",
-      );
+      incompatibleMetrics.push({
+        id: metric.id,
+        name: metric.name ?? metric.id,
+        reason:
+          "ratio metric numerator and denominator must use the same fact table for incremental refresh",
+      });
+      return;
     }
-
     // Unit quantiles store a float and re-aggregate via SUM, so they work on
     // any incremental-capable warehouse. Only event quantiles need KLL (the
     // quantile must be computed over raw event values, which requires a
     // mergeable sketch for incremental aggregation).
-    if (
-      quantileMetricType(metric) === "event" &&
-      !integration.getSourceProperties().hasQuantileKLL
-    ) {
-      throw new Error(
-        "Event quantile metrics are not supported with incremental refresh on this data source.",
-      );
+    if (quantileMetricType(metric) === "event" && !hasQuantileKLL) {
+      incompatibleMetrics.push({
+        id: metric.id,
+        name: metric.name ?? metric.id,
+        reason:
+          "event quantile metrics require KLL sketch support, which this data source does not provide",
+      });
     }
   });
+
+  if (incompatibleMetrics.length === selectedMetrics.length) {
+    throw new Error(
+      `No metrics are compatible with incremental refresh: ${incompatibleMetrics[0].reason}.`,
+    );
+  }
 
   // If not forcing a full refresh and we have a previous run, ensure the
   // current configuration matches what the incremental pipeline was built with.
@@ -167,4 +190,15 @@ export async function validateIncrementalPipeline({
       });
     }
   }
+
+  return { incompatibleMetrics };
+}
+
+export function formatIncompatibleMetricsWarning(
+  incompatibleMetrics: IncompatibleMetric[],
+): string {
+  const list = incompatibleMetrics
+    .map((m) => `"${m.name}" (${m.reason})`)
+    .join(", ");
+  return `${incompatibleMetrics.length} metric(s) excluded from incremental refresh and not computed in this snapshot: ${list}. Remove or replace these metrics, or disable incremental pipeline mode for this experiment, to compute them.`;
 }

--- a/packages/shared/types/experiment-snapshot.d.ts
+++ b/packages/shared/types/experiment-snapshot.d.ts
@@ -240,6 +240,9 @@ export interface ExperimentSnapshotInterface {
   // Results
   unknownVariations: string[];
   multipleExposures: number;
+  // Non-fatal warnings surfaced to the user (e.g., metrics skipped because
+  // they are incompatible with incremental refresh).
+  warnings?: string[];
   analyses: ExperimentSnapshotAnalysis[];
   hasChunkedAnalyses?: boolean;
   // Keyed by `ExperimentSnapshotAnalysis.analysisKey`


### PR DESCRIPTION
## Problem

`validateIncrementalPipeline` throws on the first metric that fails any per-metric check (non-fact metric, ratio metric whose numerator/denominator span different fact tables, or event-quantile metric on a warehouse without KLL sketch support). `planSnapshotQueryRunner` catches that throw and routes the entire snapshot to the inline `"results"` runner. So a single incompatible metric — even one out of dozens — forfeits incremental refresh for *all* metrics on the experiment, with the reason only visible in an `info`-level server log.

## Fix

Partition instead of throw for per-metric checks:

- `validateIncrementalPipeline` now collects per-metric incompatibilities into a returned `incompatibleMetrics: {id, name, reason}[]` list. Experiment-wide gates (skipPartialData, activation metric, feature/datasource eligibility, settings-hash mismatch) still throw and fall back to inline as before. If *every* selected metric is incompatible it also still throws.
- Both incremental runners (`ExperimentIncrementalRefreshQueryRunner` and `ExperimentIncrementalRefreshExploratoryQueryRunner`) drop the incompatible metrics from `snapshotSettings.metricSettings` before building queries, and persist a non-fatal `warnings[]` entry on the snapshot listing the skipped metric names and reasons.
- Adds an optional `warnings?: string[]` field to `ExperimentSnapshotInterface` / mongoose schema / `SnapshotResult` to carry these messages. This is the same shape proposed in #5832 — whichever lands first, the other rebases trivially.

## Out of scope / follow-up

- **Hybrid mode** (compute the incompatible metrics via the inline path alongside the incremental run, so they still get results) — this PR only skips and warns; hybrid is the obvious next step.
- **UI surfacing** of `snapshot.warnings` — left for the front-end to render once the field exists (also needed by #5832).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
