### PR TITLE
[triage] Improve owner filter dropdown

### DIFF
--- a/packages/front-end/components/Search/FeatureSearchFilters.tsx
+++ b/packages/front-end/components/Search/FeatureSearchFilters.tsx
@@ -110,7 +110,9 @@ const FeatureSearchFilters: FC<
     features.forEach((f) => {
       if (f.owner) set.add(getOwnerDisplay(f.owner));
     });
-    return Array.from(set);
+    return Array.from(set).sort((a, b) =>
+      a.localeCompare(b, undefined, { sensitivity: "base" }),
+    );
   }, [features, getOwnerDisplay]);
 
   const availableFeatureTypes = useMemo(() => {

--- a/packages/front-end/components/Search/SearchFilters.tsx
+++ b/packages/front-end/components/Search/SearchFilters.tsx
@@ -3,6 +3,7 @@ import {
   FC,
   Fragment,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -133,6 +134,20 @@ export const FilterDropdown: FC<{
 
   const inputRef = useRef<HTMLInputElement>(null);
 
+  useEffect(() => {
+    if (open !== filter) {
+      setFilterSearch("");
+      return;
+    }
+    if (!showSearchFilter) return;
+
+    const timeout = window.setTimeout(() => {
+      inputRef.current?.focus();
+    }, 0);
+
+    return () => window.clearTimeout(timeout);
+  }, [filter, open, showSearchFilter]);
+
   return (
     <DropdownMenu
       trigger={FilterHeading({
@@ -154,6 +169,8 @@ export const FilterDropdown: FC<{
             value={filterSearch}
             onChange={(e) => setFilterSearch(e.target.value)}
             type="search"
+            placeholder="Search..."
+            aria-label={`Search ${heading ?? filter} filters`}
             onKeyDown={(e) => {
               if (e.key !== "ArrowUp" && e.key !== "ArrowDown") {
                 e.stopPropagation();

--- a/packages/front-end/components/Search/SearchFilters.tsx
+++ b/packages/front-end/components/Search/SearchFilters.tsx
@@ -19,7 +19,7 @@ import { SearchTermFilterOperator, SyntaxFilter } from "@/services/search";
 import Field from "@/components/Forms/Field";
 import OverflowText from "@/components/Experiment/TabbedPage/OverflowText";
 
-const USE_SEARCH_BOX = false;
+const USE_SEARCH_BOX = true;
 
 // Common interfaces
 export interface SearchFiltersItem {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

- Sort feature owner filter options alphabetically by display name, case-insensitively.
- Enable the existing search/typeahead field for larger filter dropdowns.
- Focus and label the dropdown search input so filtering is immediately usable when the menu opens.

Customer request permalink: growthbookapp[.]slack[.]com/archives/C0B492B9388/p1778892134922089

- Closes **(customer request)**

### Dependencies

None.

### Testing

- `pnpm --filter front-end type-check`
- Manual UI walkthrough on the Features page with 12 seeded owners: opened the owner dropdown, verified alphabetical ordering, typed `ju`, and verified the list filtered to Judy Example only.

### Screenshots

[owner_filter_search_sorted_walkthrough.mp4](https://cursor.com/agents/bc-5c6051c8-d94c-4731-8bb2-3607b6cc90b8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fowner_filter_search_sorted_walkthrough.mp4)

[Owner filter search filtered to Judy Example](https://cursor.com/agents/bc-5c6051c8-d94c-4731-8bb2-3607b6cc90b8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fowner_filter_search_filtered.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c6051c8-d94c-4731-8bb2-3607b6cc90b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c6051c8-d94c-4731-8bb2-3607b6cc90b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

