### PR TITLE
feat(auth): add DISABLE_REGISTRATION environment variable

### DIFF
--- a/packages/back-end/src/controllers/auth.ts
+++ b/packages/back-end/src/controllers/auth.ts
@@ -7,9 +7,14 @@ import {
 } from "back-end/src/models/ForgotPasswordModel";
 import {
   createOrganization,
+  findOrganizationByInviteKey,
   hasOrganization,
 } from "back-end/src/models/OrganizationModel";
-import { IS_CLOUD, IS_LOCALHOST } from "back-end/src/util/secrets";
+import {
+  DISABLE_REGISTRATION,
+  IS_CLOUD,
+  IS_LOCALHOST,
+} from "back-end/src/util/secrets";
 import {
   deleteAuthCookies,
   getAuthConnection,
@@ -221,11 +226,14 @@ export async function postLogin(
 }
 
 export async function postRegister(
-  // eslint-disable-next-line
-  req: Request<any, any, { email: unknown; name: unknown; password: unknown }>,
+  req: Request<
+    Record<string, never>,
+    unknown,
+    { email: unknown; name: unknown; password: unknown; inviteKey: unknown }
+  >,
   res: Response,
 ) {
-  const { email, name, password } = req.body;
+  const { email, name, password, inviteKey } = req.body;
 
   if (
     typeof email !== "string" ||
@@ -233,6 +241,26 @@ export async function postRegister(
     typeof password !== "string"
   ) {
     throw new Error("Invalid arguments");
+  }
+
+  if (DISABLE_REGISTRATION) {
+    const invitedOrganization =
+      typeof inviteKey === "string"
+        ? await findOrganizationByInviteKey(inviteKey)
+        : null;
+    const invite = invitedOrganization?.invites.find(
+      (invite) =>
+        invite.key === inviteKey &&
+        invite.email.toLowerCase() === email.toLowerCase(),
+    );
+
+    if (!invite) {
+      return res.status(403).json({
+        status: 403,
+        message:
+          "Registration is disabled. Please contact your administrator for an invitation.",
+      });
+    }
   }
 
   validatePasswordFormat(password);

--- a/packages/back-end/src/services/auth/LocalAuthConnection.ts
+++ b/packages/back-end/src/services/auth/LocalAuthConnection.ts
@@ -3,7 +3,7 @@ import { expressjwt } from "express-jwt";
 import jwt from "jsonwebtoken";
 import { UnauthenticatedResponse } from "shared/types/sso-connection";
 import { UserInterface } from "shared/types/user";
-import { JWT_SECRET } from "back-end/src/util/secrets";
+import { DISABLE_REGISTRATION, JWT_SECRET } from "back-end/src/util/secrets";
 import {
   AuthRefreshModel,
   createRefreshToken,
@@ -53,6 +53,7 @@ export class LocalAuthConnection implements AuthConnection {
     return {
       showLogin: true,
       newInstallation,
+      registrationDisabled: DISABLE_REGISTRATION,
     };
   }
   async processCallback(

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -19,6 +19,12 @@ export const ALLOW_SELF_ORG_CREATION = stringToBoolean(
   true,
 );
 
+// When true, prevents new users from registering via the UI.
+// Existing users can still log in, and admins can still invite users.
+export const DISABLE_REGISTRATION = stringToBoolean(
+  process.env.DISABLE_REGISTRATION,
+);
+
 export const UPLOAD_METHOD = (() => {
   const method = process.env.UPLOAD_METHOD;
   if (method && ["s3", "google-cloud"].includes(method)) {

--- a/packages/front-end/components/Auth/Welcome.tsx
+++ b/packages/front-end/components/Auth/Welcome.tsx
@@ -25,9 +25,11 @@ type LoginHeroContent = {
 export default function Welcome({
   onSuccess,
   firstTime = false,
+  registrationDisabled = false,
 }: {
   onSuccess: (token: string, projectId?: string) => void;
   firstTime?: boolean;
+  registrationDisabled?: boolean;
 }): ReactElement {
   const [state, setState] = useState<
     "login" | "register" | "forgot" | "forgotSuccess" | "firsttime"
@@ -43,17 +45,21 @@ export default function Welcome({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [welcomeMsgIndex] = useState(Math.floor(Math.random() * 4));
-  const { pathname } = useRouter();
+  const router = useRouter();
+  const { pathname } = router;
+  const isInvitation = pathname === "/invitation";
+  const invitationKey =
+    typeof router.query.key === "string" ? router.query.key : undefined;
   const hero = useFeatureValue<LoginHeroContent | null>(
     "login-page-content",
     null,
   );
 
   useEffect(() => {
-    if (pathname === "/invitation") {
+    if (isInvitation) {
       setState("register");
     }
-  }, [pathname]);
+  }, [isInvitation]);
 
   const welcomeMsg = [
     <>Welcome to GrowthBook!</>,
@@ -82,7 +88,13 @@ export default function Welcome({
               "Content-Type": "application/json",
             },
             credentials: "include",
-            body: JSON.stringify(data),
+            body: JSON.stringify({
+              ...data,
+              inviteKey:
+                state === "register" && isInvitation
+                  ? invitationKey
+                  : undefined,
+            }),
           });
           const json: {
             status: number;
@@ -201,6 +213,10 @@ export default function Welcome({
   );
 
   const email = form.watch("email");
+  const canRegister =
+    state === "register" && (!registrationDisabled || isInvitation);
+  const showRegistrationDisabled =
+    state === "register" && registrationDisabled && !isInvitation;
 
   return (
     <>
@@ -226,18 +242,34 @@ export default function Welcome({
           {state === "register" && (
             <div>
               <h3 className="h2">Register</h3>
-              <p>
-                Already have an account?{" "}
-                <a
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    setState("login");
-                  }}
-                >
-                  Log In
-                </a>
-              </p>
+              {showRegistrationDisabled ? (
+                <Callout status="warning" mb="3">
+                  Registration is disabled. Please contact your administrator
+                  for an invitation.{" "}
+                  <a
+                    href="#"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setState("login");
+                    }}
+                  >
+                    Log In
+                  </a>
+                </Callout>
+              ) : (
+                <p>
+                  Already have an account?{" "}
+                  <a
+                    href="#"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setState("login");
+                    }}
+                  >
+                    Log In
+                  </a>
+                </p>
+              )}
             </div>
           )}
           {state === "firsttime" && (
@@ -306,7 +338,7 @@ export default function Welcome({
               {...form.register("companyname")}
             />
           )}
-          {(state === "register" || state === "firsttime") && (
+          {(canRegister || state === "firsttime") && (
             <Field
               label="Name"
               required
@@ -317,7 +349,7 @@ export default function Welcome({
             />
           )}
           {(state === "login" ||
-            state === "register" ||
+            canRegister ||
             state === "forgot" ||
             state === "firsttime") && (
             <Field
@@ -329,9 +361,7 @@ export default function Welcome({
               autoComplete="username"
             />
           )}
-          {(state === "login" ||
-            state === "register" ||
-            state === "firsttime") && (
+          {(state === "login" || canRegister || state === "firsttime") && (
             <Field
               label="Password"
               required
@@ -361,29 +391,35 @@ export default function Welcome({
               {error}
             </Callout>
           )}
-          <Button
-            type="submit"
-            size="lg"
-            loading={loading}
-            style={{ width: "100%" }}
-            mt="5"
-            mb="5"
-          >
-            {cta}
-          </Button>
+          {!showRegistrationDisabled && (
+            <Button
+              type="submit"
+              size="lg"
+              loading={loading}
+              style={{ width: "100%" }}
+              mt="5"
+              mb="5"
+            >
+              {cta}
+            </Button>
+          )}
           {state === "login" && (
             <Flex justify="center" align="center">
               <Text color="text-mid" weight="regular" align="center">
-                Don&apos;t have an account yet?{" "}
-                <a
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    setState("register");
-                  }}
-                >
-                  Start for free
-                </a>
+                {!registrationDisabled && (
+                  <>
+                    Don&apos;t have an account yet?{" "}
+                    <a
+                      href="#"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setState("register");
+                      }}
+                    >
+                      Start for free
+                    </a>
+                  </>
+                )}
               </Text>
             </Flex>
           )}

--- a/packages/front-end/services/auth.tsx
+++ b/packages/front-end/services/auth.tsx
@@ -310,6 +310,7 @@ export const AuthProvider: React.FC<{
       setAuthComponent(
         <Welcome
           firstTime={resp.newInstallation}
+          registrationDisabled={resp.registrationDisabled}
           onSuccess={(t, pid) => {
             setToken(t);
             if (pid) {

--- a/packages/shared/types/sso-connection.d.ts
+++ b/packages/shared/types/sso-connection.d.ts
@@ -24,6 +24,10 @@ export interface SSOConnectionInterface {
 }
 
 export type RedirectResponse = { redirectURI: string; confirm?: boolean };
-export type ShowLoginResponse = { showLogin: true; newInstallation: boolean };
+export type ShowLoginResponse = {
+  showLogin: true;
+  newInstallation: boolean;
+  registrationDisabled?: boolean;
+};
 export type UnauthenticatedResponse = RedirectResponse | ShowLoginResponse;
 export type IdTokenResponse = { token: string; ssoConnectionId?: string };


### PR DESCRIPTION
When self-hosting GrowthBook, administrators sometimes need to restrict registration to prevent unauthorized accounts. Currently, anyone who can access the login page can create an account.

I added a `DISABLE_REGISTRATION` environment variable that, when set to `true`:

- Hides the "Register" link on the login page
- Shows an informational message if someone navigates directly to the register form
- Returns HTTP 403 from `POST /auth/register` with a clear error message
- Does not affect the first-time setup flow (`postFirstTimeRegister`)

Existing users can still log in normally, and admins can still send invitations to add new users.

**Files changed:**
- `packages/back-end/src/util/secrets.ts` - added `DISABLE_REGISTRATION` env var
- `packages/back-end/src/controllers/auth.ts` - reject registration when disabled
- `packages/back-end/src/services/auth/LocalAuthConnection.ts` - pass flag to frontend
- `packages/shared/types/sso-connection.d.ts` - added type for the flag
- `packages/front-end/services/auth.tsx` - pass flag to Welcome component
- `packages/front-end/components/Auth/Welcome.tsx` - hide registration UI when disabled

Closes #2644