### PR TITLE
feat: add exp filters to some insights pages + greatly impove performance

### DIFF
--- a/packages/front-end/components/MetricExperiments/MetricExperiments.tsx
+++ b/packages/front-end/components/MetricExperiments/MetricExperiments.tsx
@@ -186,6 +186,11 @@ function MetricExperimentResultTab({
     defaultSortDir: -1,
     undefinedLast: true,
     searchFields: [],
+    // This is a sort-only table embedded inside pages that own the URL `q`
+    // param (e.g. MetricEffects). Without this, the hook would latch onto
+    // the page's filter string at mount, which combined with an empty
+    // searchFields collapses the table to zero rows.
+    disableUrlSearchTerm: true,
   });
 
   const expRows = items.slice(start, end).map((e) => {
@@ -324,7 +329,9 @@ const MetricExperiments: FC<MetricAnalysisProps> = ({
   }>(`/metrics/${metric.id}/experiments`, {
     shouldRun: dataWithSnapshot ? () => false : undefined,
   });
-  const loading = !data;
+  // When the parent passes in `dataWithSnapshot`, it owns the loading state
+  // and we should never block on the (disabled) SWR fetch.
+  const loading = dataWithSnapshot === undefined && !data;
 
   const metricExperiments = (dataWithSnapshot ?? data?.data ?? []).filter(
     (e) =>

--- a/packages/front-end/enterprise/components/Insights/MetricCorrelations.tsx
+++ b/packages/front-end/enterprise/components/Insights/MetricCorrelations.tsx
@@ -5,10 +5,7 @@ import {
   getLatestPhaseVariations,
 } from "shared/experiments";
 import { MetricGroupInterface } from "shared/types/metric-groups";
-import {
-  ComputedExperimentInterface,
-  ExperimentInterfaceStringDates,
-} from "shared/types/experiment";
+import { ExperimentInterfaceStringDates } from "shared/types/experiment";
 import {
   ExperimentSnapshotInterface,
   ExperimentWithSnapshot,
@@ -159,18 +156,6 @@ const MetricCorrelations = (): React.ReactElement => {
     error: experimentsError,
   } = useExperiments("", true, "standard");
 
-  // Memoized once so every downstream consumer can share a stable reference,
-  // preventing the heavy correlation computation in MetricCorrelationCard from
-  // re-running on every parent render.
-  const allStandardExperiments = useMemo(
-    () => allExperiments.filter((e) => e.type !== "multi-armed-bandit"),
-    [allExperiments],
-  );
-
-  const filterResults = useCallback((items: ComputedExperimentInterface[]) => {
-    return items.filter((item) => item.type !== "multi-armed-bandit");
-  }, []);
-
   const {
     items: filteredExperiments,
     searchInputProps,
@@ -178,7 +163,6 @@ const MetricCorrelations = (): React.ReactElement => {
     setSearchValue,
   } = useExperimentSearch({
     allExperiments,
-    filterResults,
     localStorageKey: "metric-correlations-experiments",
   });
 
@@ -213,7 +197,7 @@ const MetricCorrelations = (): React.ReactElement => {
     );
   }
 
-  if (allStandardExperiments.length === 0) {
+  if (allExperiments.length === 0) {
     return (
       <Box mb="3">
         <PremiumEmptyState
@@ -260,7 +244,7 @@ const MetricCorrelations = (): React.ReactElement => {
       </Flex>
       <MetricCorrelationCard
         filteredExperiments={filteredExperiments}
-        allExperiments={allStandardExperiments}
+        allExperiments={allExperiments}
         params={params[0]}
       />
     </Box>

--- a/packages/front-end/enterprise/components/Insights/MetricCorrelations.tsx
+++ b/packages/front-end/enterprise/components/Insights/MetricCorrelations.tsx
@@ -5,7 +5,10 @@ import {
   getLatestPhaseVariations,
 } from "shared/experiments";
 import { MetricGroupInterface } from "shared/types/metric-groups";
-import { ExperimentInterfaceStringDates } from "shared/types/experiment";
+import {
+  ComputedExperimentInterface,
+  ExperimentInterfaceStringDates,
+} from "shared/types/experiment";
 import {
   ExperimentSnapshotInterface,
   ExperimentWithSnapshot,
@@ -21,7 +24,6 @@ import ScatterPlotGraph, {
 import { useExperiments } from "@/hooks/useExperiments";
 import MetricSelector from "@/components/Experiment/MetricSelector";
 import { useDefinitions } from "@/services/DefinitionsContext";
-import { useAuth } from "@/services/auth";
 import {
   formatPercent,
   getExperimentMetricFormatter,
@@ -35,6 +37,12 @@ import EmptyState from "@/components/EmptyState";
 import LinkButton from "@/ui/LinkButton";
 import MetricCorrelationsExperimentTable from "@/enterprise/components/Insights/MetricCorrelations/MetricCorrelationsExperimentTable";
 import { useCurrency } from "@/hooks/useCurrency";
+import useApi from "@/hooks/useApi";
+import { useExperimentSearch } from "@/services/experiments";
+import ExperimentSearchFilters from "@/components/Search/ExperimentSearchFilters";
+import Field from "@/components/Forms/Field";
+import Link from "@/ui/Link";
+import LoadingOverlay from "@/components/LoadingOverlay";
 
 export const filterExperimentsByMetrics = (
   experiments: ExperimentInterfaceStringDates[],
@@ -140,16 +148,39 @@ const parseQueryParams = (
 };
 
 const MetricCorrelations = (): React.ReactElement => {
-  const { experiments } = useExperiments();
   const router = useRouter();
   const qParams = router.query;
 
   const params = parseQueryParams(qParams);
 
-  const filteredExperiments = useMemo(
-    () => experiments.filter((e) => e.type !== "multi-armed-bandit"),
-    [experiments],
+  const {
+    experiments: allExperiments,
+    loading: experimentsLoading,
+    error: experimentsError,
+  } = useExperiments("", true, "standard");
+
+  // Memoized once so every downstream consumer can share a stable reference,
+  // preventing the heavy correlation computation in MetricCorrelationCard from
+  // re-running on every parent render.
+  const allStandardExperiments = useMemo(
+    () => allExperiments.filter((e) => e.type !== "multi-armed-bandit"),
+    [allExperiments],
   );
+
+  const filterResults = useCallback((items: ComputedExperimentInterface[]) => {
+    return items.filter((item) => item.type !== "multi-armed-bandit");
+  }, []);
+
+  const {
+    items: filteredExperiments,
+    searchInputProps,
+    syntaxFilters,
+    setSearchValue,
+  } = useExperimentSearch({
+    allExperiments,
+    filterResults,
+    localStorageKey: "metric-correlations-experiments",
+  });
 
   const { hasCommercialFeature } = useUser();
   const hasMetricCorrelationCommercialFeature = hasCommercialFeature(
@@ -169,7 +200,20 @@ const MetricCorrelations = (): React.ReactElement => {
       </Box>
     );
   }
-  if (filteredExperiments.length === 0) {
+
+  if (experimentsLoading) {
+    return <LoadingOverlay />;
+  }
+
+  if (experimentsError) {
+    return (
+      <Callout status="error">
+        An error occurred loading experiments: {experimentsError.message}
+      </Callout>
+    );
+  }
+
+  if (allStandardExperiments.length === 0) {
     return (
       <Box mb="3">
         <PremiumEmptyState
@@ -182,11 +226,44 @@ const MetricCorrelations = (): React.ReactElement => {
       </Box>
     );
   }
+
+  const showClearFilters = syntaxFilters.length > 0 || !!searchInputProps.value;
+
   return (
-    <MetricCorrelationCard
-      experiments={filteredExperiments}
-      params={params[0]}
-    />
+    <Box>
+      <Flex gap="4" align="start" justify="between" mb="4" wrap="wrap">
+        <Flex align="center" gap="3">
+          <Box flexBasis="300px" flexShrink="0">
+            <Field
+              placeholder="Search..."
+              type="search"
+              {...searchInputProps}
+            />
+          </Box>
+          {showClearFilters && (
+            <Link
+              size="1"
+              onClick={() => setSearchValue("")}
+              style={{ whiteSpace: "nowrap" }}
+            >
+              Clear filters
+            </Link>
+          )}
+        </Flex>
+        <ExperimentSearchFilters
+          searchInputProps={searchInputProps}
+          syntaxFilters={syntaxFilters}
+          setSearchValue={setSearchValue}
+          experiments={allExperiments}
+          showStatusFilter={false}
+        />
+      </Flex>
+      <MetricCorrelationCard
+        filteredExperiments={filteredExperiments}
+        allExperiments={allStandardExperiments}
+        params={params[0]}
+      />
+    </Box>
   );
 };
 
@@ -238,46 +315,35 @@ const formattedValueWithCI = (
 };
 
 const MetricCorrelationCard = ({
-  experiments,
+  filteredExperiments,
+  allExperiments,
   params,
 }: {
-  experiments: ExperimentInterfaceStringDates[];
+  filteredExperiments: ExperimentInterfaceStringDates[];
+  allExperiments: ExperimentInterfaceStringDates[];
   params?: MetricCorrelationParams;
 }): React.ReactElement => {
-  const { apiCall } = useAuth();
-
   const { project, getExperimentMetricById, getFactTableById, metricGroups } =
     useDefinitions();
   const { theme } = useAppearanceUITheme();
   const computedTheme = theme === "light" ? "light" : "dark";
   const displayCurrency = useCurrency();
 
-  const [loading, setLoading] = useState<boolean>(false);
-
   const [metric1, setMetric1] = useState<string>(params?.m1 || "");
   const [metric2, setMetric2] = useState<string>(params?.m2 || "");
-  const [metric1Name, setMetric1Name] = useState<string>("");
-  const [metric2Name, setMetric2Name] = useState<string>("");
-  const [searchParams, setSearchParams] = useState<Record<string, string>>({});
   const [differenceType, setDifferenceType] = useState<DifferenceType>(
     params?.diff || "relative",
   );
-  const [metricData, setMetricData] = useState<{
-    correlationData: ScatterPointData<MetricCorrelationTooltipData>[];
-  }>({
-    correlationData: [],
-  });
-  const [filteredExperiments, setFilteredExperiments] = useState<
-    ExperimentWithSnapshot[]
-  >([]);
   const [excludedExperimentVariations, setExcludedExperimentVariations] =
     useState<{ experimentId: string; variationIndex: number }[]>(
       params?.excludedExperimentVariations || [],
     );
 
+  // Counts driven off the full set of (non-bandit) experiments so the metric
+  // dropdowns stay stable while the user adjusts the experiment filter.
   const metric1OptionCounts = useMemo(() => {
     const counts: Record<string, number> = {};
-    experiments.forEach((experiment) => {
+    allExperiments.forEach((experiment) => {
       const metricIds = getAllMetricIdsFromExperiment(
         experiment,
         false,
@@ -288,13 +354,13 @@ const MetricCorrelationCard = ({
       });
     });
     return counts;
-  }, [experiments, metricGroups]);
+  }, [allExperiments, metricGroups]);
 
   const metric2OptionCounts = useMemo(() => {
     const counts: Record<string, number> = {};
     if (!metric1) return counts;
 
-    experiments.forEach((exp) => {
+    allExperiments.forEach((exp) => {
       const ids = getAllMetricIdsFromExperiment(exp, false, metricGroups);
       if (!ids.includes(metric1)) return;
       ids.forEach((id) => {
@@ -303,30 +369,35 @@ const MetricCorrelationCard = ({
       });
     });
     return counts;
-  }, [experiments, metricGroups, metric1]);
+  }, [allExperiments, metricGroups, metric1]);
 
+  // Sync URL params when user-controlled values change.
   useEffect(() => {
-    updateSearchParams(searchParams, false);
-  }, [searchParams]);
+    if (!metric1 || !metric2) return;
+    updateSearchParams(
+      {
+        m1_0: metric1,
+        m2_0: metric2,
+        diff_0: differenceType,
+        excludedExperimentVariations_0: excludedExperimentVariations
+          .map((ev) => `${ev.experimentId}-${ev.variationIndex}`)
+          .join(","),
+      },
+      false,
+    );
+  }, [metric1, metric2, differenceType, excludedExperimentVariations]);
 
   const metric1Obj = getExperimentMetricById(metric1);
   const metric2Obj = getExperimentMetricById(metric2);
 
-  useEffect(() => {
-    const title =
-      differenceType === "relative"
-        ? "(Lift %)"
-        : differenceType === "absolute"
-          ? "(Absolute Change)"
-          : "(Scaled Impact)";
-
-    if (metric1Obj) {
-      setMetric1Name(`${metric1Obj.name} ${title}`);
-    }
-    if (metric2Obj) {
-      setMetric2Name(`${metric2Obj.name} ${title}`);
-    }
-  }, [metric1Obj, metric2Obj, differenceType]);
+  const title =
+    differenceType === "relative"
+      ? "(Lift %)"
+      : differenceType === "absolute"
+        ? "(Absolute Change)"
+        : "(Scaled Impact)";
+  const metric1Name = metric1Obj ? `${metric1Obj.name} ${title}` : "";
+  const metric2Name = metric2Obj ? `${metric2Obj.name} ${title}` : "";
 
   const getLiftFormatter = useCallback(
     (
@@ -352,150 +423,154 @@ const MetricCorrelationCard = ({
   const formatterM1 = getLiftFormatter(metric1Obj, differenceType);
   const formatterM2 = getLiftFormatter(metric2Obj, differenceType);
 
-  const handleFetchCorrelations = useCallback(async () => {
-    if (!metric1 || !metric2) {
-      return;
-    }
-
-    setLoading(true);
-
-    const filteredExperiments = filterExperimentsByMetrics(
-      experiments,
+  // All experiments (regardless of user filter) that include both metrics.
+  // Drives the snapshot fetch so its cache key stays stable as the user
+  // adjusts the experiment filter.
+  const allExperimentsWithBothMetrics = useMemo(() => {
+    if (!metric1 || !metric2) return [];
+    return filterExperimentsByMetrics(
+      allExperiments,
       metric1,
       metric2,
       metricGroups,
     );
+  }, [allExperiments, metric1, metric2, metricGroups]);
 
-    const filteredExperimentsWithSnapshot: Record<
-      string,
-      ExperimentWithSnapshot
-    > = {};
+  // Set of experiment ids that pass the user's current search/filter — used
+  // to narrow the snapshot results in memory without invalidating the cache.
+  const filteredExperimentIds = useMemo(
+    () => new Set(filteredExperiments.map((e) => e.id)),
+    [filteredExperiments],
+  );
 
-    setSearchParams({
-      [`m1_0`]: metric1,
-      [`m2_0`]: metric2,
-      [`diff_0`]: differenceType,
-      [`excludedExperimentVariations_0`]: excludedExperimentVariations
-        .map((ev) => `${ev.experimentId}-${ev.variationIndex}`)
+  // Stable cache key for SWR.
+  const snapshotQueryIds = useMemo(
+    () =>
+      allExperimentsWithBothMetrics
+        .map((e) => e.id)
+        .sort()
+        .map(encodeURIComponent)
         .join(","),
+    [allExperimentsWithBothMetrics],
+  );
+
+  const snapshotsKey = snapshotQueryIds
+    ? `/experiments/snapshots/?experiments=${snapshotQueryIds}`
+    : "";
+  const { data: snapshotsData, error: snapshotsError } = useApi<{
+    snapshots: ExperimentSnapshotInterface[];
+  }>(snapshotsKey, {
+    shouldRun: () => !!snapshotsKey,
+    autoRevalidate: false,
+  });
+
+  const snapshotsLoading =
+    !!metric1 &&
+    !!metric2 &&
+    allExperimentsWithBothMetrics.length > 0 &&
+    !snapshotsData &&
+    !snapshotsError;
+
+  const { correlationData, filteredExperimentsWithSnapshot } = useMemo(() => {
+    const empty = {
+      correlationData: [] as ScatterPointData<MetricCorrelationTooltipData>[],
+      filteredExperimentsWithSnapshot: [] as ExperimentWithSnapshot[],
+    };
+
+    if (!metric1 || !metric2 || !snapshotsData?.snapshots?.length) return empty;
+
+    const snapshotsByExperiment = new Map<
+      string,
+      ExperimentSnapshotInterface
+    >();
+    snapshotsData.snapshots.forEach((s) => {
+      snapshotsByExperiment.set(s.experiment, s);
     });
 
-    const queryIds = filteredExperiments
-      .map((e) => encodeURIComponent(e.id))
-      .join(",");
-    try {
-      const { snapshots } = await apiCall<{
-        snapshots: ExperimentSnapshotInterface[];
-      }>(`/experiments/snapshots/?experiments=${queryIds}`, {
-        method: "GET",
+    const experimentsWithSnapshot: Record<string, ExperimentWithSnapshot> = {};
+    const correlationData: ScatterPointData<MetricCorrelationTooltipData>[] =
+      [];
+
+    allExperimentsWithBothMetrics.forEach((experiment) => {
+      // Apply the user's filter in memory.
+      if (!filteredExperimentIds.has(experiment.id)) return;
+
+      const snapshot = snapshotsByExperiment.get(experiment.id);
+      if (!snapshot) return;
+
+      const defaultAnalysis = getSnapshotAnalysis(snapshot);
+      if (!defaultAnalysis) return;
+
+      const analysis = getSnapshotAnalysis(snapshot, {
+        ...defaultAnalysis.settings,
+        differenceType,
       });
+      if (!analysis) return;
 
-      if (snapshots && snapshots.length > 0) {
-        const newCorrelationData: ScatterPointData<MetricCorrelationTooltipData>[] =
-          [];
-        snapshots.forEach((snapshot) => {
-          const experiment = filteredExperiments.find(
-            (exp) => exp.id === snapshot.experiment,
-          );
-          if (!experiment) return;
+      const result = analysis.results[0];
+      if (!result) return;
 
-          const defaultAnalysis = getSnapshotAnalysis(snapshot);
-          if (!defaultAnalysis) return;
+      result.variations.forEach((variation, variationIndex) => {
+        if (variationIndex === 0) return; // Skip baseline
 
-          const analysis = getSnapshotAnalysis(snapshot, {
-            ...defaultAnalysis.settings,
-            differenceType: differenceType,
-          });
-          // TODO keep track of experiments missing difference type analysis
+        const metric1Data = variation.metrics[metric1];
+        const metric2Data = variation.metrics[metric2];
 
-          if (!analysis) return;
+        if (metric1Data?.errorMessage || metric2Data?.errorMessage) {
+          return;
+        }
 
-          const result = analysis.results[0];
-          if (!result) return;
+        if (!metric1Data || !metric2Data) return;
 
-          result.variations.forEach((variation, variationIndex) => {
-            if (variationIndex === 0) return; // Skip baseline
+        if (!experimentsWithSnapshot[experiment.id]) {
+          experimentsWithSnapshot[experiment.id] = {
+            ...experiment,
+            snapshot,
+          };
+        }
 
-            const metric1Data = variation.metrics[metric1];
-            const metric2Data = variation.metrics[metric2];
+        const isExcluded = excludedExperimentVariations.some(
+          (ev) =>
+            ev.experimentId === experiment.id &&
+            ev.variationIndex === variationIndex,
+        );
+        if (isExcluded) return;
 
-            if (metric1Data?.errorMessage || metric2Data?.errorMessage) {
-              return;
-            }
-
-            if (metric1Data && metric2Data) {
-              // add to data for table
-              if (!filteredExperimentsWithSnapshot[experiment.id]) {
-                filteredExperimentsWithSnapshot[experiment.id] = {
-                  ...experiment,
-                  snapshot: snapshot,
-                };
-              }
-
-              if (
-                excludedExperimentVariations.some(
-                  (ev) =>
-                    ev.experimentId === experiment.id &&
-                    ev.variationIndex === variationIndex,
-                )
-              ) {
-                return;
-              }
-
-              newCorrelationData.push({
-                id: `${experiment.id}_var_${variationIndex}`,
-                x: metric1Data.uplift?.mean || 0,
-                y: metric2Data.uplift?.mean || 0,
-                xmin: metric1Data?.ci?.[0] || 0,
-                xmax: metric1Data?.ci?.[1] || 0,
-                ymin: metric2Data?.ci?.[0] || 0,
-                ymax: metric2Data?.ci?.[1] || 0,
-                units: variation.users,
-                otherData: {
-                  experimentName: experiment.name || experiment.id,
-                  variationName:
-                    getLatestPhaseVariations(experiment)[variationIndex]
-                      ?.name || "",
-                  xMetricName: metric1Name,
-                  yMetricName: metric2Name,
-                },
-              });
-            }
-          });
+        correlationData.push({
+          id: `${experiment.id}_var_${variationIndex}`,
+          x: metric1Data.uplift?.mean || 0,
+          y: metric2Data.uplift?.mean || 0,
+          xmin: metric1Data?.ci?.[0] || 0,
+          xmax: metric1Data?.ci?.[1] || 0,
+          ymin: metric2Data?.ci?.[0] || 0,
+          ymax: metric2Data?.ci?.[1] || 0,
+          units: variation.users,
+          otherData: {
+            experimentName: experiment.name || experiment.id,
+            variationName:
+              getLatestPhaseVariations(experiment)[variationIndex]?.name || "",
+            xMetricName: metric1Name,
+            yMetricName: metric2Name,
+          },
         });
-        setMetricData({
-          correlationData: newCorrelationData,
-        });
-        setFilteredExperiments(Object.values(filteredExperimentsWithSnapshot));
-      } else {
-        setMetricData({
-          correlationData: [],
-        });
-      }
-    } catch (error) {
-      console.error(`Error getting snapshots: ${(error as Error).message}`);
-      setMetricData({
-        correlationData: [],
       });
-    } finally {
-      setLoading(false);
-    }
+    });
+
+    return {
+      correlationData,
+      filteredExperimentsWithSnapshot: Object.values(experimentsWithSnapshot),
+    };
   }, [
+    snapshotsData,
+    allExperimentsWithBothMetrics,
+    filteredExperimentIds,
     metric1,
     metric2,
+    differenceType,
+    excludedExperimentVariations,
     metric1Name,
     metric2Name,
-    experiments,
-    differenceType,
-    setSearchParams,
-    apiCall,
-    excludedExperimentVariations,
-    metricGroups,
   ]);
-
-  useEffect(() => {
-    handleFetchCorrelations();
-  }, [handleFetchCorrelations]);
 
   if (Object.entries(metric1OptionCounts).length === 0) {
     return (
@@ -573,11 +648,6 @@ const MetricCorrelationCard = ({
                 ]}
               />
             </Box>
-            {loading && (
-              <Box>
-                <LoadingSpinner />
-              </Box>
-            )}
           </Flex>
         </Flex>
         {!metric1 || !metric2 ? (
@@ -590,19 +660,23 @@ const MetricCorrelationCard = ({
               />
             </Box>
           </Flex>
-        ) : loading ? (
-          <Flex align="center" justify="center" mt="3">
-            <Box>
-              <LoadingSpinner />
-            </Box>
+        ) : snapshotsError ? (
+          <Box mt="4">
+            <Callout status="error">
+              Error loading experiment results: {snapshotsError.message}
+            </Callout>
+          </Box>
+        ) : snapshotsLoading ? (
+          <Flex align="center" justify="center" mt="6" mb="6">
+            <LoadingSpinner />
           </Flex>
-        ) : metricData.correlationData.length > 0 ||
-          filteredExperiments.length > 0 ? (
+        ) : correlationData.length > 0 ||
+          filteredExperimentsWithSnapshot.length > 0 ? (
           <Flex direction="column" gap="4">
             <Box mt="4">
               <Flex mt="2" align="center" justify="center" p="3">
                 <ScatterPlotGraph
-                  data={metricData.correlationData}
+                  data={correlationData}
                   width={800}
                   height={500}
                   xFormatter={formatterM1}
@@ -650,7 +724,7 @@ const MetricCorrelationCard = ({
             </Box>
             {metric1Obj && metric2Obj ? (
               <MetricCorrelationsExperimentTable
-                experimentsWithSnapshot={filteredExperiments}
+                experimentsWithSnapshot={filteredExperimentsWithSnapshot}
                 metrics={[metric1Obj, metric2Obj]}
                 bandits={false}
                 numPerPage={50}
@@ -665,7 +739,8 @@ const MetricCorrelationCard = ({
         ) : (
           <Box mt="4">
             <Callout status="info">
-              No experiments found that both have these two metrics
+              No experiments found that match the current experiment filters and
+              have both selected metrics.
             </Callout>
           </Box>
         )}

--- a/packages/front-end/enterprise/components/Insights/MetricCorrelations/MetricCorrelationsExperimentTable.tsx
+++ b/packages/front-end/enterprise/components/Insights/MetricCorrelations/MetricCorrelationsExperimentTable.tsx
@@ -243,6 +243,11 @@ const ExperimentWithMetricsTable: FC<Props> = ({
     defaultSortDir: -1,
     undefinedLast: true,
     searchFields: [],
+    // This is a sort-only table embedded inside pages that own the URL `q`
+    // param (e.g. MetricCorrelations). Without this, the hook would latch
+    // onto the page's filter string at mount, which combined with an empty
+    // searchFields collapses the table to zero rows.
+    disableUrlSearchTerm: true,
   });
 
   const expRows = items.slice(start, end).map((e) => {

--- a/packages/front-end/enterprise/components/Insights/MetricEffects.tsx
+++ b/packages/front-end/enterprise/components/Insights/MetricEffects.tsx
@@ -5,7 +5,10 @@ import React, {
   useMemo,
   ReactNode,
 } from "react";
-import { ExperimentInterfaceStringDates } from "shared/types/experiment";
+import {
+  ComputedExperimentInterface,
+  ExperimentInterfaceStringDates,
+} from "shared/types/experiment";
 import {
   ExperimentSnapshotInterface,
   ExperimentWithSnapshot,
@@ -18,7 +21,6 @@ import { getAllMetricIdsFromExperiment } from "shared/experiments";
 import { useExperiments } from "@/hooks/useExperiments";
 import MetricSelector from "@/components/Experiment/MetricSelector";
 import { useDefinitions } from "@/services/DefinitionsContext";
-import { useAuth } from "@/services/auth";
 import {
   formatNumber,
   formatPercent,
@@ -39,6 +41,12 @@ import EmptyState from "@/components/EmptyState";
 import LinkButton from "@/ui/LinkButton";
 import Callout from "@/ui/Callout";
 import { useAppearanceUITheme } from "@/services/AppearanceUIThemeProvider";
+import useApi from "@/hooks/useApi";
+import { useExperimentSearch } from "@/services/experiments";
+import ExperimentSearchFilters from "@/components/Search/ExperimentSearchFilters";
+import Field from "@/components/Forms/Field";
+import Link from "@/ui/Link";
+import LoadingOverlay from "@/components/LoadingOverlay";
 
 interface HistogramDatapoint {
   start: number;
@@ -158,16 +166,31 @@ const parseQueryParams = (
 };
 
 const MetricEffects = (): React.ReactElement => {
-  const { experiments } = useExperiments();
   const router = useRouter();
   const qParams = router.query;
 
   const params = parseQueryParams(qParams);
 
-  const filteredExperiments = useMemo(
-    () => experiments.filter((e) => e.type !== "multi-armed-bandit"),
-    [experiments],
-  );
+  const {
+    experiments: allExperiments,
+    loading: experimentsLoading,
+    error: experimentsError,
+  } = useExperiments("", true, "standard");
+
+  const filterResults = useCallback((items: ComputedExperimentInterface[]) => {
+    return items.filter((item) => item.type !== "multi-armed-bandit");
+  }, []);
+
+  const {
+    items: filteredExperiments,
+    searchInputProps,
+    syntaxFilters,
+    setSearchValue,
+  } = useExperimentSearch({
+    allExperiments,
+    filterResults,
+    localStorageKey: "metric-effects-experiments",
+  });
 
   const { hasCommercialFeature } = useUser();
   const hasMetricEffectsCommercialFeature =
@@ -177,7 +200,18 @@ const MetricEffects = (): React.ReactElement => {
   const computedTheme = theme === "light" ? "light" : "dark";
   const { metrics, factMetrics, datasources } = useDefinitions();
 
-  const metricExpCounts = useMetricExpCounts(filteredExperiments);
+  // Non-bandit experiments memoized once so every downstream consumer can use
+  // a stable reference. Without this, each parent render produces a new array
+  // that cascades through MetricEffectCard's useMemos and forces the heavy
+  // histogram computation to re-run on every render.
+  const standardExperiments = useMemo(
+    () => allExperiments.filter((e) => e.type !== "multi-armed-bandit"),
+    [allExperiments],
+  );
+
+  // Counts include all non-bandit experiments (ignoring user filters) so the
+  // metric dropdown options stay stable as the user adjusts filters.
+  const metricExpCounts = useMetricExpCounts(standardExperiments);
 
   if (!hasMetricEffectsCommercialFeature) {
     return (
@@ -191,7 +225,21 @@ const MetricEffects = (): React.ReactElement => {
         />
       </Box>
     );
-  } else if (
+  }
+
+  if (experimentsLoading) {
+    return <LoadingOverlay />;
+  }
+
+  if (experimentsError) {
+    return (
+      <Callout status="error">
+        An error occurred loading experiments: {experimentsError.message}
+      </Callout>
+    );
+  }
+
+  if (
     !datasources.length ||
     (!metrics.length && !factMetrics.length) ||
     Object.keys(metricExpCounts).length === 0
@@ -217,11 +265,45 @@ const MetricEffects = (): React.ReactElement => {
       </Box>
     );
   }
+
+  const showClearFilters = syntaxFilters.length > 0 || !!searchInputProps.value;
+
   return (
-    <MetricEffectCard
-      experiments={filteredExperiments}
-      params={params[0] || undefined}
-    />
+    <Box>
+      <Flex gap="4" align="start" justify="between" mb="4" wrap="wrap">
+        <Flex align="center" gap="3">
+          <Box flexBasis="300px" flexShrink="0">
+            <Field
+              placeholder="Search..."
+              type="search"
+              {...searchInputProps}
+            />
+          </Box>
+          {showClearFilters && (
+            <Link
+              size="1"
+              onClick={() => setSearchValue("")}
+              style={{ whiteSpace: "nowrap" }}
+            >
+              Clear filters
+            </Link>
+          )}
+        </Flex>
+        <ExperimentSearchFilters
+          searchInputProps={searchInputProps}
+          syntaxFilters={syntaxFilters}
+          setSearchValue={setSearchValue}
+          experiments={allExperiments}
+          showStatusFilter={false}
+        />
+      </Flex>
+      <MetricEffectCard
+        filteredExperiments={filteredExperiments}
+        allExperiments={standardExperiments}
+        metricExpCounts={metricExpCounts}
+        params={params[0] || undefined}
+      />
+    </Box>
   );
 };
 
@@ -245,48 +327,39 @@ function useMetricExpCounts(experiments: ExperimentInterfaceStringDates[]) {
 }
 
 const MetricEffectCard = ({
-  experiments,
+  filteredExperiments,
+  allExperiments,
+  metricExpCounts,
   params,
 }: {
-  experiments: ExperimentInterfaceStringDates[];
+  filteredExperiments: ExperimentInterfaceStringDates[];
+  allExperiments: ExperimentInterfaceStringDates[];
+  metricExpCounts: Record<string, number>;
   params?: MetricEffectParams;
 }): React.ReactElement => {
-  const { apiCall } = useAuth();
-
   const { project, getExperimentMetricById, getFactTableById, metricGroups } =
     useDefinitions();
 
-  const metricExpCounts = useMetricExpCounts(experiments);
-
   const displayCurrency = useCurrency();
 
-  const [experimentsWithSnapshot, setExperimentsWithSnapshot] = useState<
-    ExperimentWithSnapshot[]
-  >([]);
-  const [loading, setLoading] = useState<boolean>(false);
   const [metric, setMetric] = useState<string>(params?.metric || "");
-  const [searchParams, setSearchParams] = useState<Record<string, string>>({});
   const [differenceType, setDifferenceType] = useState<DifferenceType>(
     params?.diff || "relative",
   );
-  const [metricData, setMetricData] = useState<{
-    histogramData: HistogramDatapoint[];
-    stats:
-      | {
-          numExperiments: number;
-          numVariations: number;
-          mean: number;
-          standardDeviation: number;
-        }
-      | undefined;
-  }>({
-    histogramData: [],
-    stats: undefined,
-  });
 
+  // Keep URL query params in sync with selected metric / diff type so a deep
+  // link reproduces the same view. Only run when user-controlled values change
+  // (not on filtered experiment list updates).
   useEffect(() => {
-    updateSearchParams(searchParams, false);
-  }, [searchParams]);
+    if (!metric) return;
+    updateSearchParams(
+      {
+        metric_0: metric,
+        diff_0: differenceType,
+      },
+      false,
+    );
+  }, [metric, differenceType]);
 
   const metricObj = getExperimentMetricById(metric);
 
@@ -306,164 +379,148 @@ const MetricEffectCard = ({
     ...(differenceType === "scaled" ? { notation: "compact" } : {}),
   };
 
-  const handleFetchMetric = useCallback(async () => {
-    if (!metric) {
-      return;
-    }
-
-    setLoading(true);
-    const filteredExperiments = filterExperimentsByMetrics(
-      experiments,
+  // All experiments (regardless of user filter) that include the selected
+  // metric. This drives the snapshot fetch so its cache key stays stable as
+  // the user adjusts the experiment filter.
+  const allExperimentsWithMetric = useMemo(() => {
+    if (!metric) return [];
+    return filterExperimentsByMetrics(
+      allExperiments,
       metric,
       undefined,
       metricGroups,
     );
-    const experimentsWithData = new Map<string, ExperimentWithSnapshot>();
+  }, [allExperiments, metric, metricGroups]);
 
-    setSearchParams({
-      [`metric_0`]: metric,
-      [`diff_0`]: differenceType,
+  // Set of experiment ids that pass the user's current search/filter — used
+  // to narrow the snapshot results in memory without invalidating the cache.
+  const filteredExperimentIds = useMemo(
+    () => new Set(filteredExperiments.map((e) => e.id)),
+    [filteredExperiments],
+  );
+
+  // Stable, comma-separated id list used both as the SWR cache key and the
+  // request payload. Sorting ensures the cache key doesn't churn when the
+  // input order changes.
+  const snapshotQueryIds = useMemo(
+    () =>
+      allExperimentsWithMetric
+        .map((e) => e.id)
+        .sort()
+        .map(encodeURIComponent)
+        .join(","),
+    [allExperimentsWithMetric],
+  );
+
+  const snapshotsKey = snapshotQueryIds
+    ? `/experiments/snapshots/?experiments=${snapshotQueryIds}`
+    : "";
+  const { data: snapshotsData, error: snapshotsError } = useApi<{
+    snapshots: ExperimentSnapshotInterface[];
+  }>(snapshotsKey, {
+    shouldRun: () => !!snapshotsKey,
+    autoRevalidate: false,
+  });
+
+  // Loading is "true" only while we have a metric selected and the snapshot
+  // fetch is still pending. We intentionally do not show a spinner when the
+  // user hasn't picked a metric yet.
+  const snapshotsLoading =
+    !!metric &&
+    allExperimentsWithMetric.length > 0 &&
+    !snapshotsData &&
+    !snapshotsError;
+
+  const { histogramData, stats, experimentsWithSnapshot } = useMemo(() => {
+    const empty = {
+      histogramData: [] as HistogramDatapoint[],
+      stats: undefined as
+        | {
+            numExperiments: number;
+            numVariations: number;
+            mean: number;
+            standardDeviation: number;
+          }
+        | undefined,
+      experimentsWithSnapshot: [] as ExperimentWithSnapshot[],
+    };
+
+    if (!metric || !snapshotsData?.snapshots?.length) return empty;
+
+    const snapshotsByExperiment = new Map<
+      string,
+      ExperimentSnapshotInterface
+    >();
+    snapshotsData.snapshots.forEach((s) => {
+      snapshotsByExperiment.set(s.experiment, s);
     });
 
-    const queryIds = filteredExperiments
-      .map((e) => encodeURIComponent(e.id))
-      .join(",");
+    const histogramValues: number[] = [];
+    const experimentsWithData = new Map<string, ExperimentWithSnapshot>();
 
-    try {
-      const { snapshots } = await apiCall<{
-        snapshots: ExperimentSnapshotInterface[];
-      }>(`/experiments/snapshots/?experiments=${queryIds}`, {
-        method: "GET",
+    allExperimentsWithMetric.forEach((experiment) => {
+      // Apply the user's filter in memory.
+      if (!filteredExperimentIds.has(experiment.id)) return;
+
+      const snapshot = snapshotsByExperiment.get(experiment.id);
+      if (!snapshot) return;
+
+      const defaultAnalysis = getSnapshotAnalysis(snapshot);
+      if (!defaultAnalysis) return;
+
+      const analysis = getSnapshotAnalysis(snapshot, {
+        ...defaultAnalysis.settings,
+        differenceType,
       });
+      if (!analysis) return;
 
-      setExperimentsWithSnapshot(
-        filteredExperiments.map((e) => ({
-          ...e,
-          snapshot: snapshots.find((s) => s.experiment === e.id) ?? undefined,
-        })),
-      );
+      const result = analysis.results[0];
+      if (!result) return;
 
-      if (snapshots && snapshots.length > 0) {
-        const histogramValues: number[] = [];
+      result.variations.forEach((variation, variationIndex) => {
+        if (variationIndex === 0) return; // Skip baseline
 
-        snapshots.forEach((snapshot) => {
-          const experiment = filteredExperiments.find(
-            (exp) => exp.id === snapshot.experiment,
-          );
-          if (!experiment) return;
+        const variationMetric = variation.metrics[metric];
+        if (!variationMetric || variationMetric.errorMessage) return;
 
-          const defaultAnalysis = getSnapshotAnalysis(snapshot);
-          if (!defaultAnalysis) return;
-
-          const analysis = getSnapshotAnalysis(snapshot, {
-            ...defaultAnalysis.settings,
-            differenceType: differenceType,
-          });
-
-          if (!analysis) return;
-
-          const result = analysis.results[0];
-          if (!result) return;
-
-          result.variations.forEach((variation, variationIndex) => {
-            if (variationIndex === 0) return; // Skip baseline
-
-            const metricData = variation.metrics[metric];
-
-            if (metricData && !metricData.errorMessage) {
-              experimentsWithData.set(experiment.id, {
-                ...experiment,
-                snapshot: snapshot,
-              });
-
-              histogramValues.push(metricData.uplift?.mean || 0);
-            }
-          });
+        experimentsWithData.set(experiment.id, {
+          ...experiment,
+          snapshot,
         });
-        const metricMean =
-          histogramValues.reduce((a, b) => a + b, 0) / histogramValues.length;
-        const metricStandardDeviation = Math.sqrt(
-          histogramValues.reduce((a, b) => a + Math.pow(b - metricMean, 2), 0) /
-            histogramValues.length,
-        );
-        setMetricData({
-          histogramData: createHistogramData(histogramValues),
-          stats: {
-            numExperiments: experimentsWithData.size,
-            numVariations: histogramValues.length,
-            mean: metricMean,
-            standardDeviation: metricStandardDeviation,
-          },
-        });
-      } else {
-        setMetricData({
-          histogramData: [],
-          stats: undefined,
-        });
-      }
-    } catch (error) {
-      console.error(`Error getting snapshots: ${(error as Error).message}`);
-      setMetricData({
-        histogramData: [],
-        stats: undefined,
+
+        histogramValues.push(variationMetric.uplift?.mean || 0);
       });
-    } finally {
-      setExperimentsWithSnapshot(Array.from(experimentsWithData.values()));
-      setLoading(false);
-    }
+    });
+
+    if (histogramValues.length === 0) return empty;
+
+    const mean =
+      histogramValues.reduce((a, b) => a + b, 0) / histogramValues.length;
+    const standardDeviation = Math.sqrt(
+      histogramValues.reduce((a, b) => a + Math.pow(b - mean, 2), 0) /
+        histogramValues.length,
+    );
+
+    return {
+      histogramData: createHistogramData(histogramValues),
+      stats: {
+        numExperiments: experimentsWithData.size,
+        numVariations: histogramValues.length,
+        mean,
+        standardDeviation,
+      },
+      experimentsWithSnapshot: Array.from(experimentsWithData.values()),
+    };
   }, [
+    snapshotsData,
+    allExperimentsWithMetric,
+    filteredExperimentIds,
     metric,
-    experiments,
     differenceType,
-    setSearchParams,
-    apiCall,
-    metricGroups,
   ]);
-
-  useEffect(() => {
-    handleFetchMetric();
-  }, [handleFetchMetric]);
 
   return (
     <Box className="" width="100%">
-      {/* TODO: add when experiment filter component lands */}
-      {/* <Flex align="center" gap="2" className="mb-3" justify="between">
-        {experimentFilter ? (
-          <>
-            <Box flexBasis="40%" flexShrink="1" flexGrow="0">
-              <Field
-                  placeholder="Search..."
-                  type="search"
-                  {...searchInputProps}
-                />
-            </Box>
-            <Box>
-              <ExperimentSearchFilters
-                  experiments={experiments}
-                  syntaxFilters={syntaxFilters}
-                  searchInputProps={searchInputProps}
-                  setSearchValue={setSearchValue}
-                />
-            </Box>
-            <Box>
-              <Button
-                variant="ghost"
-                onClick={() => {
-                  setExperimentFilter(false);
-                  // TODO remove params
-                  //setSearchParams({});
-                }}
-              >
-                Remove All Filters
-              </Button>
-            </Box>
-          </>
-        ) : (
-          <Button variant="ghost" onClick={() => setExperimentFilter(true)}>
-            <BiFilter /> Filter Eligible Experiments
-          </Button>
-        )}
-      </Flex> */}
       <Box className="appbox appbox-light p-3">
         <Flex direction="row" align="center" justify="between" width="100%">
           <Flex direction="row" gap="4" flexBasis="100%">
@@ -499,165 +556,161 @@ const MetricEffectCard = ({
                 ]}
               />
             </Box>
-            {loading && (
-              <Box>
-                <LoadingSpinner />
-              </Box>
-            )}
           </Flex>
         </Flex>
-        {metricObj && metricData.histogramData.length > 0 ? (
-          <Box mt="4" width="100%">
-            {metricData.histogramData.length > 0 ? (
-              <Flex direction="column" gap="2" width="100%">
-                <Box className="appbox" p="3">
-                  <Flex
-                    direction="row"
-                    gap="5"
-                    p="3"
-                    align="center"
-                    justify="center"
-                  >
-                    <Box flexBasis="60%">
-                      <HistogramGraph
-                        data={metricData.histogramData}
-                        formatter={(value) =>
-                          formatterM1(value, formatterOptions)
-                        }
-                        xAxisLabel="Lift"
-                        mean={metricData.stats?.mean || 0}
-                        height={300}
-                        highlightPositiveNegative={true}
-                        invertHighlightColors={metricObj.inverse}
-                      />
-                    </Box>
-                    <Box flexGrow="1" minWidth={"250px"}>
-                      <Box className="appbox p-3 bg-light">
-                        <Flex direction="column" align="start">
-                          <Text as="p" color="gray">
-                            <Text weight="medium">
-                              Number of Experiments with Results:
-                            </Text>{" "}
-                            {metricData.stats?.numExperiments}
-                          </Text>
-                          <Text as="p" color="gray">
-                            <Text weight="medium">
-                              Number of Variations with Results:
-                            </Text>{" "}
-                            {metricData.stats?.numVariations}
-                          </Text>
-                          <Text as="p" color="gray">
-                            <Text weight="medium">Mean:</Text>{" "}
-                            {differenceType === "relative"
-                              ? formatPercent(metricData.stats?.mean || 0)
-                              : formatNumber(metricData.stats?.mean || 0)}
-                          </Text>
-                          <Text as="p" color="gray">
-                            <Text weight="medium">Standard Deviation:</Text>{" "}
-                            {differenceType === "relative"
-                              ? formatPercent(
-                                  metricData.stats?.standardDeviation || 0,
-                                )
-                              : formatNumber(
-                                  metricData.stats?.standardDeviation || 0,
-                                )}
-                          </Text>
-                        </Flex>
-                      </Box>
-                    </Box>
-                  </Flex>
-                </Box>
-                <Box>
-                  <MetricExperiments
-                    metric={metricObj}
-                    dataWithSnapshot={experimentsWithSnapshot}
-                    includeOnlyResults={true}
-                    numPerPage={10}
-                    differenceType={differenceType}
-                    outerClassName=""
-                  />
-                </Box>
-              </Flex>
-            ) : (
-              <Text as="p" color="gray">
-                No lift data to display for histogram.
-              </Text>
-            )}
-          </Box>
-        ) : metric ? (
+        {!metric ? (
+          <DefaultEmptyState />
+        ) : snapshotsError ? (
           <Box mt="4">
-            <Callout status="info">No experiments with results found</Callout>
+            <Callout status="error">
+              Error loading experiment results: {snapshotsError.message}
+            </Callout>
           </Box>
-        ) : (
-          <>
-            {/* default empty state */}
-            <Flex gap="4" align="center" justify="between" mt="4">
-              <Box px="6" flexBasis="60%" flexShrink="0">
-                <Box>
-                  <Box
-                    style={{
-                      border: "1px solid var(--slate-a8)",
-                      borderTop: 0,
-                      borderRight: 0,
-                      width: "100%",
-                      height: "260px",
-                      position: "relative",
-                    }}
-                  >
-                    <Box
-                      style={{
-                        position: "absolute",
-                        transform: "rotate(-90deg)",
-                        color: "var(--slate-a8)",
-                        left: "-40px",
-                        top: "50%",
-                        transformOrigin: "center",
-                      }}
-                    >
-                      Count
+        ) : snapshotsLoading ? (
+          <Flex align="center" justify="center" mt="6" mb="6">
+            <LoadingSpinner />
+          </Flex>
+        ) : metricObj && histogramData.length > 0 ? (
+          <Box mt="4" width="100%">
+            <Flex direction="column" gap="2" width="100%">
+              <Box className="appbox" p="3">
+                <Flex
+                  direction="row"
+                  gap="5"
+                  p="3"
+                  align="center"
+                  justify="center"
+                >
+                  <Box flexBasis="60%">
+                    <HistogramGraph
+                      data={histogramData}
+                      formatter={(value) =>
+                        formatterM1(value, formatterOptions)
+                      }
+                      xAxisLabel="Lift"
+                      mean={stats?.mean || 0}
+                      height={300}
+                      highlightPositiveNegative={true}
+                      invertHighlightColors={metricObj.inverse}
+                    />
+                  </Box>
+                  <Box flexGrow="1" minWidth={"250px"}>
+                    <Box className="appbox p-3 bg-light">
+                      <Flex direction="column" align="start">
+                        <Text as="p" color="gray">
+                          <Text weight="medium">
+                            Number of Experiments with Results:
+                          </Text>{" "}
+                          {stats?.numExperiments}
+                        </Text>
+                        <Text as="p" color="gray">
+                          <Text weight="medium">
+                            Number of Variations with Results:
+                          </Text>{" "}
+                          {stats?.numVariations}
+                        </Text>
+                        <Text as="p" color="gray">
+                          <Text weight="medium">Mean:</Text>{" "}
+                          {differenceType === "relative"
+                            ? formatPercent(stats?.mean || 0)
+                            : formatNumber(stats?.mean || 0)}
+                        </Text>
+                        <Text as="p" color="gray">
+                          <Text weight="medium">Standard Deviation:</Text>{" "}
+                          {differenceType === "relative"
+                            ? formatPercent(stats?.standardDeviation || 0)
+                            : formatNumber(stats?.standardDeviation || 0)}
+                        </Text>
+                      </Flex>
                     </Box>
                   </Box>
-                  <Box
-                    p="3"
-                    style={{
-                      color: "var(--slate-a8)",
-                      textAlign: "center",
-                      transformOrigin: "center",
-                    }}
-                  >
-                    Lift
-                  </Box>
-                </Box>
+                </Flex>
               </Box>
-              <Box flexBasis="40%" style={{ opacity: 0.6 }}>
-                <Box className="appbox p-3 bg-light">
-                  <Flex direction="column" align="start">
-                    <Text as="p" color="gray">
-                      <Text weight="medium">
-                        Number of Experiments with Results:
-                      </Text>{" "}
-                      --
-                    </Text>
-                    <Text as="p" color="gray">
-                      <Text weight="medium">
-                        Number of Variations with Results:
-                      </Text>{" "}
-                      --
-                    </Text>
-                    <Text as="p" color="gray">
-                      <Text weight="medium">Mean:</Text> --
-                    </Text>
-                    <Text as="p" color="gray">
-                      <Text weight="medium">Standard Deviation:</Text> --
-                    </Text>
-                  </Flex>
-                </Box>
+              <Box>
+                <MetricExperiments
+                  metric={metricObj}
+                  dataWithSnapshot={experimentsWithSnapshot}
+                  includeOnlyResults={true}
+                  numPerPage={10}
+                  differenceType={differenceType}
+                  outerClassName=""
+                />
               </Box>
             </Flex>
-          </>
+          </Box>
+        ) : (
+          <Box mt="4">
+            <Callout status="info">
+              No experiments with results found for this metric and the current
+              experiment filters.
+            </Callout>
+          </Box>
         )}
       </Box>
     </Box>
+  );
+};
+
+const DefaultEmptyState = () => {
+  return (
+    <Flex gap="4" align="center" justify="between" mt="4">
+      <Box px="6" flexBasis="60%" flexShrink="0">
+        <Box>
+          <Box
+            style={{
+              border: "1px solid var(--slate-a8)",
+              borderTop: 0,
+              borderRight: 0,
+              width: "100%",
+              height: "260px",
+              position: "relative",
+            }}
+          >
+            <Box
+              style={{
+                position: "absolute",
+                transform: "rotate(-90deg)",
+                color: "var(--slate-a8)",
+                left: "-40px",
+                top: "50%",
+                transformOrigin: "center",
+              }}
+            >
+              Count
+            </Box>
+          </Box>
+          <Box
+            p="3"
+            style={{
+              color: "var(--slate-a8)",
+              textAlign: "center",
+              transformOrigin: "center",
+            }}
+          >
+            Lift
+          </Box>
+        </Box>
+      </Box>
+      <Box flexBasis="40%" style={{ opacity: 0.6 }}>
+        <Box className="appbox p-3 bg-light">
+          <Flex direction="column" align="start">
+            <Text as="p" color="gray">
+              <Text weight="medium">Number of Experiments with Results:</Text>{" "}
+              --
+            </Text>
+            <Text as="p" color="gray">
+              <Text weight="medium">Number of Variations with Results:</Text> --
+            </Text>
+            <Text as="p" color="gray">
+              <Text weight="medium">Mean:</Text> --
+            </Text>
+            <Text as="p" color="gray">
+              <Text weight="medium">Standard Deviation:</Text> --
+            </Text>
+          </Flex>
+        </Box>
+      </Box>
+    </Flex>
   );
 };
 

--- a/packages/front-end/enterprise/components/Insights/MetricEffects.tsx
+++ b/packages/front-end/enterprise/components/Insights/MetricEffects.tsx
@@ -1,14 +1,5 @@
-import React, {
-  useEffect,
-  useCallback,
-  useState,
-  useMemo,
-  ReactNode,
-} from "react";
-import {
-  ComputedExperimentInterface,
-  ExperimentInterfaceStringDates,
-} from "shared/types/experiment";
+import React, { useEffect, useState, useMemo, ReactNode } from "react";
+import { ExperimentInterfaceStringDates } from "shared/types/experiment";
 import {
   ExperimentSnapshotInterface,
   ExperimentWithSnapshot,
@@ -177,10 +168,6 @@ const MetricEffects = (): React.ReactElement => {
     error: experimentsError,
   } = useExperiments("", true, "standard");
 
-  const filterResults = useCallback((items: ComputedExperimentInterface[]) => {
-    return items.filter((item) => item.type !== "multi-armed-bandit");
-  }, []);
-
   const {
     items: filteredExperiments,
     searchInputProps,
@@ -188,7 +175,6 @@ const MetricEffects = (): React.ReactElement => {
     setSearchValue,
   } = useExperimentSearch({
     allExperiments,
-    filterResults,
     localStorageKey: "metric-effects-experiments",
   });
 
@@ -200,18 +186,9 @@ const MetricEffects = (): React.ReactElement => {
   const computedTheme = theme === "light" ? "light" : "dark";
   const { metrics, factMetrics, datasources } = useDefinitions();
 
-  // Non-bandit experiments memoized once so every downstream consumer can use
-  // a stable reference. Without this, each parent render produces a new array
-  // that cascades through MetricEffectCard's useMemos and forces the heavy
-  // histogram computation to re-run on every render.
-  const standardExperiments = useMemo(
-    () => allExperiments.filter((e) => e.type !== "multi-armed-bandit"),
-    [allExperiments],
-  );
-
-  // Counts include all non-bandit experiments (ignoring user filters) so the
-  // metric dropdown options stay stable as the user adjusts filters.
-  const metricExpCounts = useMetricExpCounts(standardExperiments);
+  // Counts use the full experiment list (ignoring user filters) so the metric
+  // dropdown options stay stable as the user adjusts filters.
+  const metricExpCounts = useMetricExpCounts(allExperiments);
 
   if (!hasMetricEffectsCommercialFeature) {
     return (
@@ -299,7 +276,7 @@ const MetricEffects = (): React.ReactElement => {
       </Flex>
       <MetricEffectCard
         filteredExperiments={filteredExperiments}
-        allExperiments={standardExperiments}
+        allExperiments={allExperiments}
         metricExpCounts={metricExpCounts}
         params={params[0] || undefined}
       />

--- a/packages/front-end/services/search.tsx
+++ b/packages/front-end/services/search.tsx
@@ -117,6 +117,11 @@ export interface SearchProps<T extends { id: string }> {
   };
   filterResults?: (items: T[]) => T[];
   updateSearchQueryOnChange?: boolean;
+  // When true, the hook will not initialize its search term from the URL `q`
+  // param. Use this when an enclosing useSearch instance owns the `q` param
+  // (e.g. a sort-only inner table inside a search-filtered page) so the inner
+  // hook doesn't latch onto the outer hook's filter string.
+  disableUrlSearchTerm?: boolean;
   pageSize?: number;
 }
 
@@ -155,6 +160,7 @@ export function useSearch<T extends { id: string }>({
   defaultMappings = {},
   searchTermFilters,
   updateSearchQueryOnChange,
+  disableUrlSearchTerm,
   pageSize,
 }: SearchProps<T>): SearchReturn<T> {
   const defaultSort = { field: defaultSortField, dir: defaultSortDir || 1 };
@@ -167,7 +173,11 @@ export function useSearch<T extends { id: string }>({
 
   const router = useRouter();
   const { q } = router.query;
-  const initialSearchTerm = Array.isArray(q) ? q.join(" ") : q;
+  const initialSearchTerm = disableUrlSearchTerm
+    ? ""
+    : Array.isArray(q)
+      ? q.join(" ")
+      : q;
   const [value, setValue] = useState(initialSearchTerm ?? "");
   const [disableRelevanceSort, setDisableRelevanceSort] = useState(false);
 


### PR DESCRIPTION
Adds the `useExperimentSearch` filter bar to the Metric Effects and Metric Correlations pages and fixes three loading bugs along the way.

**Changes**
- Add experiment search/filter UI (matches the new `ExecReport` pattern) to `MetricEffects` and `MetricCorrelations`.
- Decouple the snapshot fetch from the user filter: snapshots are fetched once via `useApi` for every experiment containing the selected metric(s) and the user's filter is then applied in-memory, keeping the SWR cache key stable and eliminating refetch churn.
- Replace ad-hoc `apiCall` + `useState` + `useEffect` plumbing with a single derived `useMemo`; consolidate to one centered loading spinner per page.
- Memoize `standardExperiments` / `allStandardExperiments` so the heavy histogram/correlation memo doesn't re-run on every parent render.

**Bug fixes**
- `MetricExperiments` no longer hangs on its loading spinner when the parent passes `dataWithSnapshot` (it was gating on a permanently-disabled SWR call).
- Clearing the experiment filter no longer leaves the results table empty. Root cause: the inner sort-only `useSearch` was reading the page-level `?q=` URL param and combining it with `searchFields: []`, collapsing the table to zero rows. Added an opt-in `disableUrlSearchTerm` flag on `useSearch` and set it on the two inner tables.