### PR TITLE
Support cross-fact-table ratio metrics in incremental refresh

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -2046,9 +2046,13 @@ export default abstract class SqlIntegration
       a.id.localeCompare(b.id),
     );
 
+    const factTableId =
+      params.factTableId ?? params.metrics[0].numerator?.factTableId;
+
     const columnDefinitions = this.getMetricSourceTableColumnDefinitions(
       baseIdType,
       sortedMetrics,
+      factTableId,
     );
 
     if (
@@ -2078,11 +2082,13 @@ export default abstract class SqlIntegration
   protected getMetricSourceTableColumnDefinitions(
     baseIdType: string,
     metrics: FactMetricInterface[],
+    factTableId?: string,
   ): string[] {
     const schema = getMetricSourceTableSchema(
       this.getSqlDialect(),
       baseIdType,
       metrics,
+      factTableId,
     );
     return Array.from(schema.entries()).map(
       ([columnName, dataType]) => `${columnName} ${dataType}`,
@@ -2092,11 +2098,13 @@ export default abstract class SqlIntegration
   protected getMetricSourceTableColumns(
     baseIdType: string,
     metrics: FactMetricInterface[],
+    factTableId?: string,
   ): string[] {
     const schema = getMetricSourceTableSchema(
       this.getSqlDialect(),
       baseIdType,
       metrics,
+      factTableId,
     );
     return Array.from(schema.keys());
   }
@@ -2171,9 +2179,9 @@ export default abstract class SqlIntegration
     );
 
     const factTableMap = params.factTableMap;
-    const factTable = factTableMap.get(
-      params.metrics[0].numerator?.factTableId,
-    );
+    const targetFactTableId =
+      params.factTableId ?? params.metrics[0].numerator?.factTableId;
+    const factTable = factTableMap.get(targetFactTableId);
     if (!factTable) {
       throw new Error("Could not find fact table");
     }
@@ -2210,19 +2218,34 @@ export default abstract class SqlIntegration
       },
     );
 
-    // TODO(incremental-refresh): ensure only one fact table with metric data
-    // at this part of the query; multi-fact table metrics should be split across
-    // their own getInsertMetricSourceDataQuery calls
-    if (factTablesWithMetricData.length !== 1) {
-      throw new Error("Expected exactly one fact table with metric data");
+    // Each getInsertMetricSourceDataQuery call scans exactly one fact table
+    // and writes to exactly one cache table. Metric source groups that span
+    // two fact tables (cross-fact-table ratio metrics) issue two calls, one
+    // per side of the ratio, so the denominator is cached from its own fact
+    // table with its own incremental max timestamp.
+    const factTableWithMetricData = factTablesWithMetricData.find(
+      (f) => f.factTable.id === targetFactTableId,
+    );
+    if (!factTableWithMetricData) {
+      throw new Error(
+        "Could not find metric data for the target fact table of the metric source insert query",
+      );
     }
-    const factTableWithMetricData = factTablesWithMetricData[0];
+    const ftIndex = factTableWithMetricData.index;
+    // metricData is the full list for the group; filter per-column below based
+    // on which side of each metric (numerator/denominator) lives in this fact
+    // table.
     const metricData = factTableWithMetricData.metricData;
+    const numeratorInThisTable = (d: (typeof metricData)[number]) =>
+      d.numeratorSourceIndex === ftIndex;
+    const denominatorInThisTable = (d: (typeof metricData)[number]) =>
+      d.ratioMetric && d.denominatorSourceIndex === ftIndex;
 
     // Get consistent column names using the helper
     const columnNames = this.getMetricSourceTableColumns(
       baseIdType,
       sortedMetrics,
+      targetFactTableId,
     );
 
     return format(
@@ -2263,22 +2286,29 @@ export default abstract class SqlIntegration
             ${metricData
               .map(
                 (data) =>
-                  `, ${addCaseWhenTimeFilter(this.getSqlDialect(), {
-                    col: `m.${data.alias}_value`,
-                    metric: data.metric,
-                    overrideConversionWindows: data.overrideConversionWindows,
-                    // The experiment end date, because this is used
-                    // to filter metrics that only capture data during
-                    // the experiment
-                    endDate: params.settings.endDate,
-                    metricQuantileSettings: data.quantileMetric
-                      ? data.metricQuantileSettings
-                      : undefined,
-                    metricTimestampColExpr: castToTimestamp("m.timestamp"),
-                    exposureTimestampColExpr: "d.first_exposure_timestamp",
-                  })} AS ${data.alias}_value
+                  `${
+                    numeratorInThisTable(data)
+                      ? `, ${addCaseWhenTimeFilter(this.getSqlDialect(), {
+                          col: `m.${data.alias}_value`,
+                          metric: data.metric,
+                          overrideConversionWindows:
+                            data.overrideConversionWindows,
+                          // The experiment end date, because this is used
+                          // to filter metrics that only capture data during
+                          // the experiment
+                          endDate: params.settings.endDate,
+                          metricQuantileSettings: data.quantileMetric
+                            ? data.metricQuantileSettings
+                            : undefined,
+                          metricTimestampColExpr:
+                            castToTimestamp("m.timestamp"),
+                          exposureTimestampColExpr:
+                            "d.first_exposure_timestamp",
+                        })} AS ${data.alias}_value`
+                      : ""
+                  }
                 ${
-                  data.ratioMetric
+                  denominatorInThisTable(data)
                     ? `, ${addCaseWhenTimeFilter(this.getSqlDialect(), {
                         col: `m.${data.alias}_denominator`,
                         metric: data.metric,
@@ -2291,7 +2321,8 @@ export default abstract class SqlIntegration
                     : ""
                 }
                 ${
-                  data.metric.numerator.aggregation === "kll merge"
+                  data.metric.numerator.aggregation === "kll merge" &&
+                  numeratorInThisTable(data)
                     ? `, ${addCaseWhenTimeFilter(this.getSqlDialect(), {
                         col: `m.${data.alias}_n_events`,
                         metric: data.metric,
@@ -2329,14 +2360,18 @@ export default abstract class SqlIntegration
                 const denomAggFunction =
                   m.denominatorAggFns.partialAggregationFunction;
                 return `
-                , ${aggfunction(`${m.alias}_value`)} AS ${encodeMetricIdForColumnName(m.id)}_value
                 ${
-                  !!denomAggFunction && isRatioMetric(m.metric)
+                  numeratorInThisTable(m)
+                    ? `, ${aggfunction(`${m.alias}_value`)} AS ${encodeMetricIdForColumnName(m.id)}_value`
+                    : ""
+                }
+                ${
+                  !!denomAggFunction && denominatorInThisTable(m)
                     ? `, ${denomAggFunction(`${m.alias}_denominator`)} AS ${encodeMetricIdForColumnName(m.id)}_denominator_value`
                     : ""
                 }
                 ${
-                  m.quantileMetric === "event"
+                  m.quantileMetric === "event" && numeratorInThisTable(m)
                     ? // For 'kll merge' metrics, each row in __newMetricRows
                       // is a pre-aggregated sketch covering many events, so
                       // COUNT(rows) does NOT equal events. SUM the paired
@@ -2359,12 +2394,16 @@ export default abstract class SqlIntegration
           ${metricData
             .map(
               (m) =>
-                `, ${encodeMetricIdForColumnName(m.id)}_value AS ${encodeMetricIdForColumnName(m.id)}_value${
-                  m.ratioMetric
+                `${
+                  numeratorInThisTable(m)
+                    ? `, ${encodeMetricIdForColumnName(m.id)}_value AS ${encodeMetricIdForColumnName(m.id)}_value`
+                    : ""
+                }${
+                  denominatorInThisTable(m)
                     ? `\n, ${encodeMetricIdForColumnName(m.id)}_denominator_value AS ${encodeMetricIdForColumnName(m.id)}_denominator_value`
                     : ""
                 }${
-                  m.quantileMetric === "event"
+                  m.quantileMetric === "event" && numeratorInThisTable(m)
                     ? `\n, ${encodeMetricIdForColumnName(m.id)}_n_events AS ${encodeMetricIdForColumnName(m.id)}_n_events`
                     : ""
                 }`,
@@ -2381,9 +2420,6 @@ export default abstract class SqlIntegration
     );
   }
 
-  // TODO(incremental-refresh): only need to run one per group, while the rest of the metrics pipeline
-  // needs to run once per fact table, once we allow metrics that cross
-  // fact tables to be added
   getIncrementalRefreshStatisticsQuery(
     params: IncrementalRefreshStatisticsQueryParams,
   ): string {
@@ -2399,14 +2435,34 @@ export default abstract class SqlIntegration
         ...params,
         // Covariate data joined to single table with `m` alias before columns are extracted
         covariateTableAlias: "m",
+        // All per-user cache values are joined into a single `m` alias in
+        // __joinedData below, so force a single source index regardless of
+        // how many fact tables back a cross-FT ratio metric group.
+        collapseSourceIndices: true,
       },
     );
 
-    // TODO(incremental-refresh): generalize to multiple sources
-    if (factTablesWithMetricData.length !== 1) {
-      throw new Error("Expected exactly one fact table with metric data");
+    if (factTablesWithMetricData.length > 2) {
+      throw new Error(
+        "Expected at most two fact tables with metric data for incremental refresh statistics",
+      );
     }
+    // When the group spans two fact tables (cross-fact-table ratio metrics),
+    // the denominator per-user aggregates live in a separate cache table and
+    // are joined into __joinedData below.
+    const hasDenominatorSource =
+      factTablesWithMetricData.length > 1 &&
+      !!params.metricSourceDenominatorTableFullName;
+    if (factTablesWithMetricData.length > 1 && !hasDenominatorSource) {
+      throw new Error(
+        "Metric source group spans two fact tables but no denominator cache table was provided",
+      );
+    }
+
     const factTableWithMetricData = factTablesWithMetricData[0];
+    // percentileData/eventQuantileData are already filtered to metrics that
+    // touch this fact table; since the numerator always lives in the first
+    // fact table of a cross-FT group these cover every metric in the group.
     const metricData = factTableWithMetricData.metricData;
     const percentileData = factTableWithMetricData.percentileData;
     const eventQuantileData = factTableWithMetricData.eventQuantileData;
@@ -2421,6 +2477,14 @@ export default abstract class SqlIntegration
     if (percentileData.length > 0) {
       percentileTableIndices.add(0);
     }
+
+    // For cross-fact-table ratio metrics, the denominator per-user aggregates
+    // come from the separate denominator cache table. Same-fact-table ratio
+    // metrics read both sides from the primary cache table.
+    const isCrossFtRatio = (data: (typeof metricData)[number]) =>
+      data.ratioMetric &&
+      data.metric.denominator?.factTableId !==
+        data.metric.numerator.factTableId;
 
     // exploratory dimensions
     const { experimentDimensions, unitDimensions, dateDimension } =
@@ -2487,11 +2551,18 @@ export default abstract class SqlIntegration
     // TODO(incremental-refresh): Validate with existing columns
     return format(
       `
-      WITH 
+      WITH
       ${idJoinSQL}
       __metricSourceData AS (
         SELECT * FROM ${params.metricSourceTableFullName}
       )
+      ${
+        hasDenominatorSource
+          ? `, __metricSourceDenominatorData AS (
+        SELECT * FROM ${params.metricSourceDenominatorTableFullName}
+      )`
+          : ""
+      }
       ${unitDimensions
         .map(
           (d) =>
@@ -2540,7 +2611,9 @@ export default abstract class SqlIntegration
                 data.denominatorAggFns.reAggregationFunction;
               return `, ${reAggFunction(`umj.${encodeMetricIdForColumnName(data.metric.id)}_value`)} AS ${encodeMetricIdForColumnName(data.metric.id)}_value
                 ${
-                  data.ratioMetric && denomReAggFunction
+                  !isCrossFtRatio(data) &&
+                  data.ratioMetric &&
+                  denomReAggFunction
                     ? `, ${denomReAggFunction(`umj.${encodeMetricIdForColumnName(data.metric.id)}_denominator_value`)} AS ${encodeMetricIdForColumnName(data.metric.id)}_denominator_value`
                     : ""
                 }
@@ -2555,6 +2628,25 @@ export default abstract class SqlIntegration
         GROUP BY
           ${baseIdType}
       )
+      ${
+        hasDenominatorSource
+          ? `, __metricDenominatorDataAggregated AS (
+        SELECT
+          ${baseIdType}
+          ${metricData
+            .filter((data) => isCrossFtRatio(data))
+            .map((data) => {
+              const denomReAggFunction =
+                data.denominatorAggFns.reAggregationFunction;
+              return `, ${denomReAggFunction(`umj.${encodeMetricIdForColumnName(data.metric.id)}_denominator_value`)} AS ${encodeMetricIdForColumnName(data.metric.id)}_denominator_value`;
+            })
+            .join("\n")}
+        FROM __metricSourceDenominatorData umj
+        GROUP BY
+          ${baseIdType}
+      )`
+          : ""
+      }
       ${
         // __eventQuantileSketch: pass 1 of two-pass KLL rank recovery — merge
         // per-user sketches by variation+dimension. __eventQuantileMetric
@@ -2642,7 +2734,19 @@ export default abstract class SqlIntegration
                 })} AS ${data.alias}_value ${
                   data.ratioMetric
                     ? `, ${data.aggregatedValueTransformation({
-                        column: `COALESCE(m.${encodeMetricIdForColumnName(data.metric.id)}_denominator_value, 0)`,
+                        // Cross-FT ratio denominators come from the joined
+                        // denominator cache table (md); same-FT ratios read
+                        // from the primary cache table (m). Both are LEFT
+                        // JOINed onto the units table, so COALESCE to 0 for
+                        // units with no events on that side — matching the
+                        // inline path, where __userMetricAgg{N} always
+                        // contains every experiment unit via
+                        // __distinctUsers LEFT JOIN __factTable{N}.
+                        column: `COALESCE(${
+                          hasDenominatorSource && isCrossFtRatio(data)
+                            ? "md"
+                            : "m"
+                        }.${encodeMetricIdForColumnName(data.metric.id)}_denominator_value, 0)`,
                         initialTimestampColumn: "u.first_exposure_timestamp",
                         analysisEndDate: params.settings.endDate,
                       })} AS ${data.alias}_denominator`
@@ -2667,6 +2771,11 @@ export default abstract class SqlIntegration
             }
           FROM __experimentUnits u
           LEFT JOIN __metricDataAggregated m ON u.${baseIdType} = m.${baseIdType}
+          ${
+            hasDenominatorSource
+              ? `LEFT JOIN __metricDenominatorDataAggregated md ON u.${baseIdType} = md.${baseIdType}`
+              : ""
+          }
           ${
             // TODO(incremental-refresh): GROUP BY is not necessary but is a failsafe
             // against bad insertions into covariate table

--- a/packages/back-end/src/integrations/sql/fact-metrics/metric-source-table-schema.ts
+++ b/packages/back-end/src/integrations/sql/fact-metrics/metric-source-table-schema.ts
@@ -9,22 +9,36 @@ export function getMetricSourceTableSchema(
   dialect: SqlDialect,
   baseIdType: string,
   metrics: FactMetricInterface[],
+  // Which fact table this cache table is built from. When a metric source
+  // group spans two fact tables (cross-fact-table ratio metrics), the
+  // numerator aggregates and denominator aggregates are stored in separate
+  // cache tables, one per fact table. When omitted, the schema includes every
+  // column (the default behavior when numerator and denominator always live in
+  // the same fact table).
+  factTableId?: string,
 ): Map<string, string> {
   const schema = new Map<string, string>();
 
   schema.set(baseIdType, dialect.getDataType("string"));
 
   metrics.forEach((metric) => {
-    const numeratorMetadata = getAggregationMetadata(dialect, {
-      metric,
-      useDenominator: false,
-    });
-    schema.set(
-      `${encodeMetricIdForColumnName(metric.id)}_value`,
-      dialect.getDataType(numeratorMetadata.intermediateDataType),
-    );
+    const numeratorInThisTable =
+      !factTableId || metric.numerator.factTableId === factTableId;
+    const denominatorInThisTable =
+      !factTableId || metric.denominator?.factTableId === factTableId;
 
-    if (isRatioMetric(metric)) {
+    if (numeratorInThisTable) {
+      const numeratorMetadata = getAggregationMetadata(dialect, {
+        metric,
+        useDenominator: false,
+      });
+      schema.set(
+        `${encodeMetricIdForColumnName(metric.id)}_value`,
+        dialect.getDataType(numeratorMetadata.intermediateDataType),
+      );
+    }
+
+    if (isRatioMetric(metric) && denominatorInThisTable) {
       const denominatorMetadata = getAggregationMetadata(dialect, {
         metric,
         useDenominator: true,
@@ -39,7 +53,7 @@ export function getMetricSourceTableSchema(
     // count per user-date. The count is needed to compute n_events and the
     // clustered-variance denominator at stats time (sketches cannot answer
     // rank queries).
-    if (quantileMetricType(metric) === "event") {
+    if (quantileMetricType(metric) === "event" && numeratorInThisTable) {
       schema.set(
         `${encodeMetricIdForColumnName(metric.id)}_n_events`,
         dialect.getDataType("integer"),

--- a/packages/back-end/src/integrations/sql/fact-metrics/parse-experiment-fact-metrics-params.ts
+++ b/packages/back-end/src/integrations/sql/fact-metrics/parse-experiment-fact-metrics-params.ts
@@ -26,6 +26,12 @@ export function parseExperimentFactMetricsParams(
     lastMaxTimestamp: Date | null;
     covariateTableAlias: string;
     forcedUserIdType?: string;
+    // When true, numerator/denominator source indices on the generated
+    // FactMetricData are forced to 0. Used by the incremental-refresh
+    // statistics query, which joins all per-user cache values into a single
+    // aliased CTE (`m`) before computing statistics regardless of which fact
+    // table they originated from.
+    collapseSourceIndices?: boolean;
   },
 ): {
   factTablesWithMetricData: FactMetricSourceData[];
@@ -53,13 +59,17 @@ export function parseExperimentFactMetricsParams(
     factTableMap,
   );
 
+  const factTablesForMetricData = params.collapseSourceIndices
+    ? factTablesWithMetrics.map((f) => ({ ...f, index: 0 }))
+    : factTablesWithMetrics;
+
   const metricData = metricsWithIndices.map((m) => {
     return getMetricData(
       dialect,
       { metric: m.metric, index: m.index },
       settings,
       activationMetric,
-      factTablesWithMetrics,
+      factTablesForMetricData,
       params.covariateTableAlias,
       `m${m.index}`,
     );

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
@@ -175,6 +175,8 @@ export const startExperimentIncrementalRefreshExploratoryQueries = async (
       dimensionsForAnalysis: dimensionObjs,
       factTableMap: params.factTableMap,
       metricSourceTableFullName: existingSource.tableFullName,
+      metricSourceDenominatorTableFullName:
+        existingSource.denominatorTableFullName ?? null,
       metricSourceCovariateTableFullName:
         existingCovariateSource?.tableFullName ?? null,
       unitsSourceTableFullName: unitsTableFullName,

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -2,6 +2,7 @@ import { tabulateCovariateImbalance } from "shared/health";
 import {
   ExperimentMetricInterface,
   isFactMetric,
+  isRatioMetric,
   isRegressionAdjusted,
   quantileMetricType,
 } from "shared/experiments";
@@ -88,6 +89,22 @@ export interface MetricSourceGroups {
   metrics: FactMetricInterface[];
 }
 
+// Returns the denominator fact table id for a metric whose numerator and
+// denominator live in different fact tables. Undefined for non-ratio metrics
+// and for ratio metrics where both sides share a fact table.
+export function getCrossFtDenominatorFactTableId(
+  metric: FactMetricInterface,
+): string | undefined {
+  if (
+    isRatioMetric(metric) &&
+    metric.denominator?.factTableId &&
+    metric.denominator.factTableId !== metric.numerator.factTableId
+  ) {
+    return metric.denominator.factTableId;
+  }
+  return undefined;
+}
+
 export function getIncrementalRefreshMetricSources({
   metrics,
   existingMetricSources,
@@ -102,14 +119,19 @@ export function getIncrementalRefreshMetricSources({
   metrics: FactMetricInterface[];
   groupId: string;
   factTableId: string;
+  denominatorFactTableId?: string;
 }[] {
   // TODO(incremental-refresh): skip partial data is currently ignored
   // TODO(incremental-refresh): error if no efficient percentiles
   // shouldn't be possible since we are unlikely to build incremental
   // refresh for mySQL
   const getMetricGroupKey = (metric: FactMetricInterface) => {
+    // Cross-fact-table ratio metrics get their own group keyed by the fact
+    // table pair so they can be cached in two tables (numerator + denominator)
+    // without expanding the schema of other groups' cache tables.
+    const crossFtDenominator = getCrossFtDenominatorFactTableId(metric);
     // Keep quantiles in their own source (similar to experimentQueries grouping)
-    return `${metric.numerator.factTableId}${quantileMetricType(metric) ? "_qtile" : ""}`;
+    return `${metric.numerator.factTableId}${crossFtDenominator ? `_${crossFtDenominator}` : ""}${quantileMetricType(metric) ? "_qtile" : ""}`;
   };
 
   const groups: Record<
@@ -117,6 +139,7 @@ export function getIncrementalRefreshMetricSources({
     {
       alreadyExists: boolean;
       factTableId: string;
+      denominatorFactTableId?: string;
       metrics: FactMetricInterface[];
     }
   > = {};
@@ -130,18 +153,20 @@ export function getIncrementalRefreshMetricSources({
       groups[existingGroup.groupId] = groups[existingGroup.groupId] || {
         alreadyExists: true,
         factTableId: existingGroup.factTableId,
+        denominatorFactTableId: existingGroup.denominatorFactTableId,
         metrics: [],
       };
       groups[existingGroup.groupId].metrics.push(metric);
       return;
     }
 
-    // TODO(incremental-refresh): handle cross-table metrics
     const factTableId = metric.numerator.factTableId;
+    const denominatorFactTableId = getCrossFtDenominatorFactTableId(metric);
     const groupKey = getMetricGroupKey(metric);
     groups[groupKey] = groups[groupKey] || {
       alreadyExists: false,
       factTableId,
+      denominatorFactTableId,
       metrics: [],
     };
     groups[groupKey].metrics.push(metric);
@@ -150,6 +175,7 @@ export function getIncrementalRefreshMetricSources({
   const finalGroups: {
     groupId: string;
     factTableId: string;
+    denominatorFactTableId?: string;
     metrics: FactMetricInterface[];
   }[] = [];
   Object.entries(groups).forEach(([groupId, group]) => {
@@ -157,6 +183,7 @@ export function getIncrementalRefreshMetricSources({
       finalGroups.push({
         groupId,
         factTableId: group.factTableId,
+        denominatorFactTableId: group.denominatorFactTableId,
         metrics: group.metrics,
       });
       return;
@@ -183,6 +210,7 @@ export function getIncrementalRefreshMetricSources({
       finalGroups.push({
         groupId: groupId + "_" + randomId + i,
         factTableId: group.factTableId,
+        denominatorFactTableId: group.denominatorFactTableId,
         metrics: chunk,
       });
     });
@@ -557,6 +585,7 @@ const startExperimentIncrementalRefreshQueries = async (
           metrics: group.metrics,
           factTableMap: params.factTableMap,
           metricSourceTableFullName,
+          factTableId: group.factTableId,
         }),
         dependencies: [updateUnitsTableQuery.query],
         run: (query, setExternalId, queryMetadata) =>
@@ -578,6 +607,7 @@ const startExperimentIncrementalRefreshQueries = async (
       unitsSourceTableFullName: unitsTableFullName,
       metrics: group.metrics,
       lastMaxTimestamp: existingSource?.maxTimestamp || null,
+      factTableId: group.factTableId,
     };
 
     const insertMetricsSourceDataQuery = await startQuery({
@@ -597,6 +627,109 @@ const startExperimentIncrementalRefreshQueries = async (
       queryType: "experimentIncrementalRefreshInsertMetricsSourceData",
     });
     queries.push(insertMetricsSourceDataQuery);
+
+    // Cross-fact-table ratio metric groups store the denominator per-user
+    // aggregates in a separate cache table built from the denominator fact
+    // table, so each side of the ratio tracks its own incremental max
+    // timestamp.
+    const denominatorFactTable = group.denominatorFactTableId
+      ? params.factTableMap.get(group.denominatorFactTableId)
+      : undefined;
+    const denominatorSourceName = denominatorFactTable
+      ? `(${denominatorFactTable.name})`
+      : "";
+
+    const metricSourceDenominatorTableFullName: string | undefined =
+      group.denominatorFactTableId
+        ? (existingSource?.denominatorTableFullName ??
+          (integration.generateTablePath &&
+            integration.generateTablePath(
+              `${INCREMENTAL_METRICS_TABLE_PREFIX}_${experimentId}_${group.groupId}_denom`,
+              settings.pipelineSettings?.writeDataset,
+              settings.pipelineSettings?.writeDatabase,
+              true,
+            )))
+        : undefined;
+    if (group.denominatorFactTableId && !metricSourceDenominatorTableFullName) {
+      throw new Error(
+        "Unable to generate table; table path generator not specified.",
+      );
+    }
+
+    let createMetricsDenominatorSourceQuery: QueryPointer | null = null;
+    let insertMetricsDenominatorSourceDataQuery: QueryPointer | null = null;
+    let maxTimestampMetricsDenominatorSourceQuery: QueryPointer | null = null;
+    // Captured by the numerator max-timestamp onSuccess below so both max
+    // timestamps can be persisted to the incremental refresh model in a single
+    // update without racing on the shared runningSourceData closure.
+    let denominatorMaxTimestamp: Date | null =
+      existingSource?.denominatorMaxTimestamp ?? null;
+    if (group.denominatorFactTableId && metricSourceDenominatorTableFullName) {
+      if (!existingSource) {
+        createMetricsDenominatorSourceQuery = await startQuery({
+          name: `create_metrics_denominator_source_${group.groupId}`,
+          displayTitle: `Create Metrics Denominator Source ${denominatorSourceName}`,
+          query: integration.getCreateMetricSourceTableQuery({
+            settings: snapshotSettings,
+            metrics: group.metrics,
+            factTableMap: params.factTableMap,
+            metricSourceTableFullName: metricSourceDenominatorTableFullName,
+            factTableId: group.denominatorFactTableId,
+          }),
+          dependencies: [updateUnitsTableQuery.query],
+          run: (query, setExternalId, queryMetadata) =>
+            integration.runIncrementalWithNoOutputQuery(
+              query,
+              setExternalId,
+              queryMetadata,
+            ),
+          queryType: "experimentIncrementalRefreshCreateMetricsSourceTable",
+        });
+        queries.push(createMetricsDenominatorSourceQuery);
+      }
+
+      insertMetricsDenominatorSourceDataQuery = await startQuery({
+        name: `insert_metrics_denominator_source_data_${group.groupId}`,
+        displayTitle: `Update Metrics Denominator Source ${denominatorSourceName}`,
+        query: integration.getInsertMetricSourceDataQuery({
+          ...metricParams,
+          metricSourceTableFullName: metricSourceDenominatorTableFullName,
+          lastMaxTimestamp: existingSource?.denominatorMaxTimestamp || null,
+          factTableId: group.denominatorFactTableId,
+        }),
+        dependencies: [
+          ...(createMetricsDenominatorSourceQuery
+            ? [createMetricsDenominatorSourceQuery.query]
+            : []),
+          alterUnitsTableQuery.query,
+        ],
+        run: (query, setExternalId, queryMetadata) =>
+          integration.runIncrementalWithNoOutputQuery(
+            query,
+            setExternalId,
+            queryMetadata,
+          ),
+        queryType: "experimentIncrementalRefreshInsertMetricsSourceData",
+      });
+      queries.push(insertMetricsDenominatorSourceDataQuery);
+
+      maxTimestampMetricsDenominatorSourceQuery = await startQuery({
+        name: `max_timestamp_metrics_denominator_source_${group.groupId}`,
+        displayTitle: `Find Latest Metrics Denominator Source Timestamp ${denominatorSourceName}`,
+        query: integration.getMaxTimestampMetricSourceQuery({
+          metricSourceTableFullName: metricSourceDenominatorTableFullName,
+          lastMaxTimestamp: existingSource?.denominatorMaxTimestamp || null,
+        }),
+        dependencies: [insertMetricsDenominatorSourceDataQuery.query],
+        run: (query, setExternalId, queryMetadata) =>
+          integration.runMaxTimestampQuery(query, setExternalId, queryMetadata),
+        onSuccess: async (rows) => {
+          denominatorMaxTimestamp = new Date(rows[0].max_timestamp as string);
+        },
+        queryType: "experimentIncrementalRefreshMaxTimestampMetricsSource",
+      });
+      queries.push(maxTimestampMetricsDenominatorSourceQuery);
+    }
 
     // CUPED tables
     const metricSourceCovariateTableFullName: string | undefined =
@@ -734,7 +867,14 @@ const startExperimentIncrementalRefreshQueries = async (
         metricSourceTableFullName,
         lastMaxTimestamp: existingSource?.maxTimestamp || null,
       }),
-      dependencies: [insertMetricsSourceDataQuery.query],
+      dependencies: [
+        insertMetricsSourceDataQuery.query,
+        // Sequenced after the denominator max timestamp query so both max
+        // timestamps are known when the onSuccess below persists the source.
+        ...(maxTimestampMetricsDenominatorSourceQuery
+          ? [maxTimestampMetricsDenominatorSourceQuery.query]
+          : []),
+      ],
       run: (query, setExternalId, queryMetadata) =>
         integration.runMaxTimestampQuery(query, setExternalId, queryMetadata),
       onFailure: async () => {
@@ -761,7 +901,13 @@ const startExperimentIncrementalRefreshQueries = async (
           // TODO(incremental-refresh): Clean up metadata handling in query runner
           const updatedSource: IncrementalRefreshMetricSourceInterface =
             existingSource
-              ? { ...existingSource, maxTimestamp }
+              ? {
+                  ...existingSource,
+                  maxTimestamp,
+                  ...(group.denominatorFactTableId
+                    ? { denominatorMaxTimestamp }
+                    : {}),
+                }
               : {
                   groupId: group.groupId,
                   factTableId: group.factTableId,
@@ -778,6 +924,15 @@ const startExperimentIncrementalRefreshQueries = async (
                     }),
                   })),
                   tableFullName: metricSourceTableFullName,
+                  ...(group.denominatorFactTableId &&
+                  metricSourceDenominatorTableFullName
+                    ? {
+                        denominatorFactTableId: group.denominatorFactTableId,
+                        denominatorTableFullName:
+                          metricSourceDenominatorTableFullName,
+                        denominatorMaxTimestamp,
+                      }
+                    : {}),
                 };
           if (!existingSource) {
             runningSourceData = runningSourceData.concat(updatedSource);
@@ -822,9 +977,14 @@ const startExperimentIncrementalRefreshQueries = async (
         dimensionsForPrecomputation,
         dimensionsForAnalysis: [],
         metricSourceCovariateTableFullName,
+        metricSourceDenominatorTableFullName:
+          metricSourceDenominatorTableFullName ?? null,
       }),
       dependencies: [
         insertMetricsSourceDataQuery.query,
+        ...(insertMetricsDenominatorSourceDataQuery
+          ? [insertMetricsDenominatorSourceDataQuery.query]
+          : []),
         ...(insertMetricCovariateDataQuery
           ? [insertMetricCovariateDataQuery.query]
           : []),

--- a/packages/back-end/src/services/dataPipeline.ts
+++ b/packages/back-end/src/services/dataPipeline.ts
@@ -1,7 +1,9 @@
+import cloneDeep from "lodash/cloneDeep";
 import {
   ExperimentMetricInterface,
   isFactMetric,
   isRatioMetric,
+  isRegressionAdjusted,
   quantileMetricType,
 } from "shared/experiments";
 import { IncrementalRefreshInterface } from "shared/validators";
@@ -11,6 +13,7 @@ import { ExperimentInterface } from "shared/types/experiment";
 import { FactTableMap } from "back-end/src/models/FactTableModel";
 import { orgHasPremiumFeature } from "back-end/src/enterprise";
 import { SourceIntegrationInterface } from "back-end/src/types/Integration";
+import { applyMetricOverrides } from "back-end/src/util/integration";
 import {
   getExperimentSettingsHashForIncrementalRefresh,
   getMetricSettingsHashForIncrementalRefresh,
@@ -100,13 +103,26 @@ export async function validateIncrementalPipeline({
   }
 
   selectedMetrics.filter(isFactMetric).forEach((metric) => {
+    // Cross-fact-table ratio metrics are supported by caching the numerator
+    // and denominator per-user aggregates in separate tables and joining them
+    // in the statistics query. CUPED (regression adjustment) on a cross-FT
+    // ratio metric would also require the pre-exposure covariate aggregates to
+    // span two fact tables, which is not implemented yet, so we only block the
+    // CUPED case.
     if (
       isRatioMetric(metric) &&
       metric.numerator.factTableId !== metric.denominator?.factTableId
     ) {
-      throw new Error(
-        "Ratio metrics must have the same numerator and denominator fact table with incremental refresh.",
-      );
+      const metricWithOverrides = cloneDeep(metric);
+      applyMetricOverrides(metricWithOverrides, snapshotSettings);
+      if (
+        snapshotSettings.regressionAdjustmentEnabled &&
+        isRegressionAdjusted(metricWithOverrides)
+      ) {
+        throw new Error(
+          "Ratio metrics with different numerator and denominator fact tables do not support regression adjustment (CUPED) with incremental refresh. Disable regression adjustment for this metric or use a full query to analyze it.",
+        );
+      }
     }
 
     // Unit quantiles store a float and re-aggregate via SUM, so they work on

--- a/packages/back-end/test/integrations/BigQuery.test.ts
+++ b/packages/back-end/test/integrations/BigQuery.test.ts
@@ -683,3 +683,266 @@ describe("BigQuery KLL incremental refresh SQL generation (E2E)", () => {
     expect(sql).not.toContain("__userMetricAggBase");
   });
 });
+
+describe("BigQuery cross-fact-table ratio metric incremental refresh SQL generation", () => {
+  let integration: BigQuery;
+
+  const exposureQuery: ExposureQuery = {
+    id: "exposure",
+    name: "Exposure",
+    description: "",
+    query: "*",
+    userIdType: "user_id",
+    dimensions: [],
+  };
+
+  const purchasesFactTable = factTableFactory.build({
+    id: "ft_purchases",
+    name: "Purchases",
+    sql: "SELECT * FROM purchases",
+    userIdTypes: ["user_id"],
+  });
+  const sessionsFactTable = factTableFactory.build({
+    id: "ft_sessions",
+    name: "Sessions",
+    sql: "SELECT * FROM sessions",
+    userIdTypes: ["user_id"],
+  });
+  const factTableMap = new Map([
+    ["ft_purchases", purchasesFactTable],
+    ["ft_sessions", sessionsFactTable],
+  ]);
+
+  // Ratio metric whose numerator and denominator live in different fact tables
+  const crossFtRatioMetric = factMetricFactory.build({
+    id: "fact_revenue_per_session",
+    metricType: "ratio",
+    numerator: {
+      factTableId: "ft_purchases",
+      column: "revenue",
+      aggregation: "sum",
+    },
+    denominator: {
+      factTableId: "ft_sessions",
+      column: "$$count",
+      aggregation: "sum",
+    },
+  });
+
+  // Same-fact-table ratio metric as a control
+  const sameFtRatioMetric = factMetricFactory.build({
+    id: "fact_revenue_per_order",
+    metricType: "ratio",
+    numerator: {
+      factTableId: "ft_purchases",
+      column: "revenue",
+      aggregation: "sum",
+    },
+    denominator: {
+      factTableId: "ft_purchases",
+      column: "$$count",
+      aggregation: "sum",
+    },
+  });
+
+  const settings: ExperimentSnapshotSettings = {
+    manual: false,
+    dimensions: [],
+    metricSettings: [],
+    goalMetrics: [],
+    secondaryMetrics: [],
+    guardrailMetrics: [],
+    activationMetric: null,
+    defaultMetricPriorSettings: {
+      override: false,
+      proper: false,
+      mean: 0,
+      stddev: 0,
+    },
+    regressionAdjustmentEnabled: false,
+    attributionModel: "firstExposure",
+    experimentId: "exp_1",
+    queryFilter: "",
+    segment: "",
+    skipPartialData: false,
+    datasourceId: "ds_1",
+    exposureQueryId: "exposure",
+    startDate: new Date("2024-01-01"),
+    endDate: new Date("2024-01-31"),
+    variations: [],
+  };
+
+  beforeEach(() => {
+    // @ts-expect-error -- context not needed for this unit test
+    integration = new BigQuery("", {
+      settings: {
+        queries: {
+          exposure: [exposureQuery],
+        },
+      },
+    });
+  });
+
+  it("getCreateMetricSourceTableQuery splits numerator and denominator columns across cache tables by factTableId", () => {
+    const numeratorSql = integration.getCreateMetricSourceTableQuery({
+      settings,
+      metrics: [crossFtRatioMetric],
+      factTableMap,
+      metricSourceTableFullName: "proj.ds.metric_source_num",
+      factTableId: "ft_purchases",
+    });
+    expect(numeratorSql).toContain("fact_revenue_per_session_value");
+    expect(numeratorSql).not.toContain(
+      "fact_revenue_per_session_denominator_value",
+    );
+
+    const denominatorSql = integration.getCreateMetricSourceTableQuery({
+      settings,
+      metrics: [crossFtRatioMetric],
+      factTableMap,
+      metricSourceTableFullName: "proj.ds.metric_source_denom",
+      factTableId: "ft_sessions",
+    });
+    expect(denominatorSql).toContain(
+      "fact_revenue_per_session_denominator_value",
+    );
+    // The denominator cache table must NOT carry the numerator column.
+    expect(denominatorSql).not.toMatch(/fact_revenue_per_session_value\b/);
+  });
+
+  it("getCreateMetricSourceTableQuery keeps both columns in one cache table for same-FT ratio metrics (unchanged behavior)", () => {
+    const sql = integration.getCreateMetricSourceTableQuery({
+      settings,
+      metrics: [sameFtRatioMetric],
+      factTableMap,
+      metricSourceTableFullName: "proj.ds.metric_source",
+    });
+    expect(sql).toContain("fact_revenue_per_order_value");
+    expect(sql).toContain("fact_revenue_per_order_denominator_value");
+  });
+
+  it("getInsertMetricSourceDataQuery scans only the requested fact table for cross-FT ratio metrics", () => {
+    const numeratorSql = integration.getInsertMetricSourceDataQuery({
+      settings,
+      activationMetric: null,
+      factTableMap,
+      metricSourceTableFullName: "proj.ds.metric_source_num",
+      unitsSourceTableFullName: "proj.ds.units",
+      metrics: [crossFtRatioMetric],
+      lastMaxTimestamp: null,
+      factTableId: "ft_purchases",
+    });
+    const flatNumerator = numeratorSql.replace(/\s+/g, " ");
+    expect(flatNumerator).toContain("FROM purchases");
+    expect(flatNumerator).not.toContain("FROM sessions");
+    expect(numeratorSql).toContain("fact_revenue_per_session_value");
+    expect(numeratorSql).not.toContain(
+      "fact_revenue_per_session_denominator_value",
+    );
+    expect(flatNumerator).toContain("INSERT INTO proj.ds.metric_source_num");
+
+    const denominatorSql = integration.getInsertMetricSourceDataQuery({
+      settings,
+      activationMetric: null,
+      factTableMap,
+      metricSourceTableFullName: "proj.ds.metric_source_denom",
+      unitsSourceTableFullName: "proj.ds.units",
+      metrics: [crossFtRatioMetric],
+      lastMaxTimestamp: null,
+      factTableId: "ft_sessions",
+    });
+    const flatDenominator = denominatorSql.replace(/\s+/g, " ");
+    expect(flatDenominator).toContain("FROM sessions");
+    expect(flatDenominator).not.toContain("FROM purchases");
+    expect(denominatorSql).toContain(
+      "fact_revenue_per_session_denominator_value",
+    );
+    expect(denominatorSql).not.toMatch(/fact_revenue_per_session_value\b/);
+    expect(flatDenominator).toContain(
+      "INSERT INTO proj.ds.metric_source_denom",
+    );
+  });
+
+  it("getIncrementalRefreshStatisticsQuery joins numerator and denominator cache tables on the unit id", () => {
+    const sql = integration.getIncrementalRefreshStatisticsQuery({
+      settings,
+      activationMetric: null,
+      dimensionsForPrecomputation: [],
+      dimensionsForAnalysis: [],
+      factTableMap,
+      metricSourceTableFullName: "proj.ds.metric_source_num",
+      metricSourceDenominatorTableFullName: "proj.ds.metric_source_denom",
+      metricSourceCovariateTableFullName: null,
+      unitsSourceTableFullName: "proj.ds.units",
+      metrics: [crossFtRatioMetric],
+      lastMaxTimestamp: null,
+    });
+
+    const flat = sql.replace(/\s+/g, " ");
+
+    // Both cache tables are read and aggregated per user
+    expect(sql).toContain("__metricSourceData");
+    expect(sql).toContain("__metricSourceDenominatorData");
+    expect(flat).toContain("FROM proj.ds.metric_source_num");
+    expect(flat).toContain("FROM proj.ds.metric_source_denom");
+    expect(sql).toContain("__metricDenominatorDataAggregated");
+
+    // Denominator is joined onto units on the unit id, and COALESCEd to 0 for
+    // units with no denominator events (same missing-user semantics as the
+    // inline path).
+    expect(flat).toMatch(
+      /LEFT JOIN __metricDenominatorDataAggregated md ON u\.user_id = md\.user_id/,
+    );
+    expect(flat).toContain(
+      "COALESCE(md.fact_revenue_per_session_denominator_value, 0)",
+    );
+    // The denominator must NOT be read from the numerator cache table.
+    expect(flat).not.toContain(
+      "COALESCE(m.fact_revenue_per_session_denominator_value, 0)",
+    );
+    // Statistics still fold numerator and denominator per-user into ratio sums
+    expect(sql).toContain("m0_main_sum");
+    expect(sql).toContain("m0_denominator_sum");
+    expect(sql).toContain("m0_main_denominator_sum_product");
+  });
+
+  it("getIncrementalRefreshStatisticsQuery reads same-FT ratio denominator from the primary cache table (unchanged behavior)", () => {
+    const sql = integration.getIncrementalRefreshStatisticsQuery({
+      settings,
+      activationMetric: null,
+      dimensionsForPrecomputation: [],
+      dimensionsForAnalysis: [],
+      factTableMap,
+      metricSourceTableFullName: "proj.ds.metric_source",
+      metricSourceDenominatorTableFullName: null,
+      metricSourceCovariateTableFullName: null,
+      unitsSourceTableFullName: "proj.ds.units",
+      metrics: [sameFtRatioMetric],
+      lastMaxTimestamp: null,
+    });
+
+    const flat = sql.replace(/\s+/g, " ");
+    expect(sql).not.toContain("__metricDenominatorDataAggregated");
+    expect(flat).toContain(
+      "COALESCE(m.fact_revenue_per_order_denominator_value, 0)",
+    );
+  });
+
+  it("getIncrementalRefreshStatisticsQuery throws when the group spans two fact tables but no denominator cache table is provided", () => {
+    expect(() =>
+      integration.getIncrementalRefreshStatisticsQuery({
+        settings,
+        activationMetric: null,
+        dimensionsForPrecomputation: [],
+        dimensionsForAnalysis: [],
+        factTableMap,
+        metricSourceTableFullName: "proj.ds.metric_source_num",
+        metricSourceDenominatorTableFullName: null,
+        metricSourceCovariateTableFullName: null,
+        unitsSourceTableFullName: "proj.ds.units",
+        metrics: [crossFtRatioMetric],
+        lastMaxTimestamp: null,
+      }),
+    ).toThrow(/denominator cache table/);
+  });
+});

--- a/packages/back-end/test/queryRunners/ExperimentIncrementalRefreshQueryRunner.test.ts
+++ b/packages/back-end/test/queryRunners/ExperimentIncrementalRefreshQueryRunner.test.ts
@@ -1,0 +1,109 @@
+import { ExperimentSnapshotSettings } from "shared/types/experiment-snapshot";
+import {
+  getCrossFtDenominatorFactTableId,
+  getIncrementalRefreshMetricSources,
+} from "back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner";
+import { SourceIntegrationInterface } from "back-end/src/types/Integration";
+import { factMetricFactory } from "../factories/FactMetric.factory";
+
+const integration = {
+  getSourceProperties: () => ({ maxColumns: 10000 }),
+} as SourceIntegrationInterface;
+
+const snapshotSettings = {
+  regressionAdjustmentEnabled: false,
+  banditSettings: undefined,
+  metricSettings: [],
+} as unknown as ExperimentSnapshotSettings;
+
+const sameFtMetric = factMetricFactory.build({
+  id: "fact_purchases_count",
+  metricType: "mean",
+  numerator: { factTableId: "ft_purchases", column: "$$count" },
+});
+
+const sameFtRatioMetric = factMetricFactory.build({
+  id: "fact_revenue_per_order",
+  metricType: "ratio",
+  numerator: { factTableId: "ft_purchases", column: "revenue" },
+  denominator: { factTableId: "ft_purchases", column: "$$count" },
+});
+
+const crossFtRatioMetric = factMetricFactory.build({
+  id: "fact_revenue_per_session",
+  metricType: "ratio",
+  numerator: { factTableId: "ft_purchases", column: "revenue" },
+  denominator: { factTableId: "ft_sessions", column: "$$count" },
+});
+
+describe("getCrossFtDenominatorFactTableId", () => {
+  it("returns undefined for non-ratio metrics", () => {
+    expect(getCrossFtDenominatorFactTableId(sameFtMetric)).toBeUndefined();
+  });
+  it("returns undefined for same-FT ratio metrics", () => {
+    expect(getCrossFtDenominatorFactTableId(sameFtRatioMetric)).toBeUndefined();
+  });
+  it("returns the denominator fact table id for cross-FT ratio metrics", () => {
+    expect(getCrossFtDenominatorFactTableId(crossFtRatioMetric)).toBe(
+      "ft_sessions",
+    );
+  });
+});
+
+describe("getIncrementalRefreshMetricSources cross-FT grouping", () => {
+  it("keeps cross-FT ratio metrics in their own group with a denominator fact table id", () => {
+    const groups = getIncrementalRefreshMetricSources({
+      metrics: [sameFtMetric, sameFtRatioMetric, crossFtRatioMetric],
+      existingMetricSources: [],
+      integration,
+      snapshotSettings,
+    });
+
+    // Same-FT metrics share a group; the cross-FT ratio metric gets its own.
+    expect(groups).toHaveLength(2);
+
+    const crossFtGroup = groups.find((g) =>
+      g.metrics.some((m) => m.id === crossFtRatioMetric.id),
+    );
+    expect(crossFtGroup).toBeDefined();
+    expect(crossFtGroup?.factTableId).toBe("ft_purchases");
+    expect(crossFtGroup?.denominatorFactTableId).toBe("ft_sessions");
+    expect(crossFtGroup?.metrics.map((m) => m.id)).toEqual([
+      crossFtRatioMetric.id,
+    ]);
+
+    const sameFtGroup = groups.find((g) =>
+      g.metrics.some((m) => m.id === sameFtMetric.id),
+    );
+    expect(sameFtGroup).toBeDefined();
+    expect(sameFtGroup?.factTableId).toBe("ft_purchases");
+    expect(sameFtGroup?.denominatorFactTableId).toBeUndefined();
+    expect(sameFtGroup?.metrics.map((m) => m.id).sort()).toEqual(
+      [sameFtMetric.id, sameFtRatioMetric.id].sort(),
+    );
+  });
+
+  it("preserves denominator fact table id when reusing an existing group", () => {
+    const groups = getIncrementalRefreshMetricSources({
+      metrics: [crossFtRatioMetric],
+      existingMetricSources: [
+        {
+          groupId: "ft_purchases_ft_sessions_abc0",
+          factTableId: "ft_purchases",
+          denominatorFactTableId: "ft_sessions",
+          denominatorTableFullName: "proj.ds.denom",
+          denominatorMaxTimestamp: null,
+          metrics: [{ id: crossFtRatioMetric.id, settingsHash: "h" }],
+          maxTimestamp: null,
+          tableFullName: "proj.ds.num",
+        },
+      ],
+      integration,
+      snapshotSettings,
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].groupId).toBe("ft_purchases_ft_sessions_abc0");
+    expect(groups[0].denominatorFactTableId).toBe("ft_sessions");
+  });
+});

--- a/packages/shared/src/validators/incremental-refresh.ts
+++ b/packages/shared/src/validators/incremental-refresh.ts
@@ -12,6 +12,13 @@ export const incrementalRefreshMetricSourceValidator = z.object({
   ),
   maxTimestamp: z.date().nullable(),
   tableFullName: z.string(),
+  // Cross-fact-table ratio metrics store their denominator aggregates in a
+  // separate cache table built from the denominator fact table. The two fact
+  // tables can have different data availability, so we track a separate max
+  // timestamp for each.
+  denominatorFactTableId: z.string().optional(),
+  denominatorMaxTimestamp: z.date().nullable().optional(),
+  denominatorTableFullName: z.string().optional(),
 });
 
 export const incrementalRefreshMetricCovariateSourceValidator = z.object({

--- a/packages/shared/types/integrations.d.ts
+++ b/packages/shared/types/integrations.d.ts
@@ -349,6 +349,10 @@ export interface CreateMetricSourceTableQueryParams {
   metrics: FactMetricInterface[];
   factTableMap: FactTableMap;
   metricSourceTableFullName: string;
+  // When a metric source group spans two fact tables (cross-fact-table ratio
+  // metrics), identifies which fact table this cache table is built from. If
+  // omitted, the numerator fact table of the first metric is used.
+  factTableId?: string;
 }
 
 export interface InsertMetricSourceDataQueryParams {
@@ -359,6 +363,8 @@ export interface InsertMetricSourceDataQueryParams {
   unitsSourceTableFullName: string;
   metrics: FactMetricInterface[];
   lastMaxTimestamp: Date | null;
+  // See CreateMetricSourceTableQueryParams.factTableId
+  factTableId?: string;
 }
 
 export interface DropMetricSourceCovariateTableQueryParams {
@@ -388,6 +394,10 @@ export interface IncrementalRefreshStatisticsQueryParams {
   dimensionsForAnalysis: Dimension[];
   factTableMap: FactTableMap;
   metricSourceTableFullName: string;
+  // For cross-fact-table ratio metric groups, the cache table holding the
+  // per-user denominator aggregates from the denominator fact table. Joined to
+  // metricSourceTableFullName on the unit id before computing statistics.
+  metricSourceDenominatorTableFullName?: string | null;
   metricSourceCovariateTableFullName: string | null;
   unitsSourceTableFullName: string;
   metrics: FactMetricInterface[];


### PR DESCRIPTION
### Features and Changes

**Support cross-fact-table ratio metrics in incremental refresh (pipeline mode).**

#### The problem

A ratio metric whose numerator and denominator live in different fact tables (e.g. `revenue` from a `purchases` fact table divided by `$$count` from a `sessions` fact table) currently causes `validateIncrementalPipeline()` to throw:

> Ratio metrics must have the same numerator and denominator fact table with incremental refresh.

Because the validation is experiment-wide, a single cross-fact-table ratio metric disqualifies the **entire experiment** from the incremental query runner and forces it back to the inline path. On the inline path, every refresh re-scans all the raw fact-table data from the start of the experiment. Pipeline mode exists precisely to avoid that: it materializes per-user aggregates into cache tables (`gb_metrics_exp_*`) and only scans new data on each refresh. On a long-running experiment with large fact tables, falling back can make every refresh orders of magnitude more expensive, and it happens silently.

#### Why the limitation existed

In pipeline mode, each metric source group has exactly one cache table, built from exactly one fact table. The cache table schema (`metric-source-table-schema.ts`) stores a ratio metric's `{metric}_value` and `{metric}_denominator_value` columns side by side, and `getInsertMetricSourceDataQuery()` scans a single `__factTable` CTE. That assumes both sides of the ratio are sourced from the same fact table. There are explicit `TODO(incremental-refresh)` markers acknowledging this in `ExperimentIncrementalRefreshQueryRunner.ts` ("handle cross-table metrics") and `SqlIntegration.ts` ("generalize to multiple sources").

#### Why it's solvable without a redesign

The inline path already handles cross-fact-table ratios: `getExperimentFactMetricsQuery()` builds one `__factTable{N}` / `__userMetricAgg{N}` chain per fact table and joins the per-user aggregates on the unit id before computing statistics. The pipeline path already materializes exactly those per-user aggregates into cache tables. The only missing piece is: cache the denominator side in its own table, and join two cache tables in the statistics query instead of reading one.

#### What this PR does

1. **`validateIncrementalPipeline` (dataPipeline.ts)** — narrow the guard. Cross-fact-table ratio metrics no longer disqualify the experiment. The guard is kept for the CUPED (regression adjustment) case — see "Scope limitations" below.

2. **Metric source grouping (`ExperimentIncrementalRefreshQueryRunner.ts`)** — cross-fact-table ratio metrics are grouped by their fact-table pair (`{numeratorFT}_{denominatorFT}`), separate from same-FT metrics. A group that spans two fact tables now carries `denominatorFactTableId` and, once built, persists a `denominatorTableFullName` and `denominatorMaxTimestamp` on the metric source. Each fact table feeding the group is scanned and tracked independently, so one source lagging the other cannot cause dropped or double-counted rows.

3. **Cache table schema + CREATE + INSERT (`metric-source-table-schema.ts`, `SqlIntegration.ts`)** — `getCreateMetricSourceTableQuery()` and `getInsertMetricSourceDataQuery()` take an optional `factTableId` that identifies which side of the ratio a cache table represents. The numerator cache table only carries `{metric}_value` columns, the denominator cache table only `{metric}_denominator_value`, and each insert scans only its own fact table with its own incremental `max_timestamp`.

4. **Statistics query (`SqlIntegration.ts`)** — `getIncrementalRefreshStatisticsQuery()` accepts an optional `metricSourceDenominatorTableFullName`. When present, it adds a `__metricSourceDenominatorData` / `__metricDenominatorDataAggregated` CTE and LEFT JOINs it onto `__experimentUnits` alongside the numerator cache table on the unit id. Both joins COALESCE missing per-user values to 0, which matches the inline path's missing-user semantics (where every unit in `__distinctUsers` appears in both `__userMetricAgg` and `__userMetricAgg1` via LEFT JOINs and then gets COALESCEd in the stats CTE).

5. **Cache invalidation / schema migration** — `getMetricSettingsHashForIncrementalRefresh()` already hashes `factMetric.denominator` and the denominator fact table's SQL/filters, and the new `denominator*` fields on the metric source model are optional. Editing a ratio from same-FT to cross-FT (or vice versa) changes the settings hash and triggers the existing "configuration is outdated, run a Full Refresh" path rather than silently reading a stale cache. No migration of existing incremental refresh documents is needed.

#### Before / After (generated SQL, BigQuery)

Before this change, a cross-FT ratio metric could not reach pipeline mode at all. After this change, a `revenue (purchases) / $$count (sessions)` ratio produces two cache tables and one joined statistics query:

```sql
-- numerator cache
CREATE TABLE proj.ds.gb_metrics_exp_1_ft_purchases_ft_sessions_abc (
  user_id STRING,
  fact_revenue_per_session_value FLOAT64,
  refresh_timestamp TIMESTAMP, max_timestamp TIMESTAMP, metric_date DATE
) ...

-- denominator cache
CREATE TABLE proj.ds.gb_metrics_exp_1_ft_purchases_ft_sessions_abc_denom (
  user_id STRING,
  fact_revenue_per_session_denominator_value INT64,
  refresh_timestamp TIMESTAMP, max_timestamp TIMESTAMP, metric_date DATE
) ...
```

```sql
-- statistics (abridged)
WITH
  __metricSourceData AS (SELECT * FROM proj.ds.gb_metrics_..._abc),
  __metricSourceDenominatorData AS (SELECT * FROM proj.ds.gb_metrics_..._abc_denom),
  __experimentUnits AS (SELECT ... FROM proj.ds.gb_units_exp_1 e),
  __metricDataAggregated AS (
    SELECT user_id, SUM(COALESCE(umj.fact_revenue_per_session_value, 0)) AS fact_revenue_per_session_value
    FROM __metricSourceData umj GROUP BY user_id
  ),
  __metricDenominatorDataAggregated AS (
    SELECT user_id, SUM(COALESCE(umj.fact_revenue_per_session_denominator_value, 0)) AS fact_revenue_per_session_denominator_value
    FROM __metricSourceDenominatorData umj GROUP BY user_id
  ),
  __joinedData AS (
    SELECT u.user_id, u.variation,
      COALESCE(m.fact_revenue_per_session_value, 0) AS m0_value,
      COALESCE(md.fact_revenue_per_session_denominator_value, 0) AS m0_denominator
    FROM __experimentUnits u
    LEFT JOIN __metricDataAggregated m ON u.user_id = m.user_id
    LEFT JOIN __metricDenominatorDataAggregated md ON u.user_id = md.user_id
  )
SELECT m.variation, COUNT(*) AS users,
  SUM(COALESCE(m.m0_value, 0)) AS m0_main_sum,
  SUM(POWER(COALESCE(m.m0_value, 0), 2)) AS m0_main_sum_squares,
  SUM(COALESCE(m.m0_denominator, 0)) AS m0_denominator_sum,
  SUM(POWER(COALESCE(m.m0_denominator, 0), 2)) AS m0_denominator_sum_squares,
  SUM(COALESCE(m.m0_denominator, 0) * COALESCE(m.m0_value, 0)) AS m0_main_denominator_sum_product
FROM __joinedData m GROUP BY m.variation
```

Same-fact-table ratio metrics, non-ratio metrics, and quantile metrics generate the same SQL as before — see the "unchanged behavior" tests.

#### Scope limitations

- **CUPED cross-fact-table ratios remain unsupported in pipeline mode.** The pre-exposure covariate cache (`gb_metrics_*_covariate`) would also need to span two fact tables, which adds another full create/insert/maxTimestamp/join lifecycle. Rather than double the surface area here, the CUPED case keeps the validation guard with a clearer error message (disable CUPED for that metric, or analyze via a full query). This can be a follow-up.
- The denominator fact table is scanned once per group it participates in. If a metric with numerator FT-A also exists alongside a cross-FT ratio with denominator FT-A, FT-A is scanned twice — once for the same-FT group's cache table and once for the cross-FT group's denominator cache table. Both scans are still incremental (only new rows since the last `max_timestamp`), so the cost is bounded by new data, not total data.

Touches the second priority item in #4917 (ratio metric support for incremental refresh).

- Closes the `TODO(incremental-refresh): handle cross-table metrics` and `TODO(incremental-refresh): generalize to multiple sources` markers.

### Dependencies

None. The three new fields on `incrementalRefreshMetricSourceValidator` are optional, so existing incremental refresh documents remain valid.

### Testing

- Added a `describe("BigQuery cross-fact-table ratio metric incremental refresh SQL generation")` block to `packages/back-end/test/integrations/BigQuery.test.ts` covering: cache table schema split by `factTableId`, per-fact-table insert queries, the joined statistics query (and its error path when a denominator cache is missing), and "unchanged behavior" assertions for same-fact-table ratios.
- Added `packages/back-end/test/queryRunners/ExperimentIncrementalRefreshQueryRunner.test.ts` covering `getCrossFtDenominatorFactTableId()` and the cross-FT grouping logic in `getIncrementalRefreshMetricSources()`, including reuse of an existing group from a persisted metric source.
- `cd packages/back-end && pnpm test` — 96 suites / 3995 tests pass, including the 2259-test SQL integration snapshot suite with no snapshot changes.
- `cd packages/shared && pnpm test` — 26 suites / 701 tests pass.
- `pnpm type-check` clean in `back-end` and `shared`; `eslint` and `prettier` clean on changed files.

### Screenshots

No UI changes.
