### PR TITLE
fix(incremental): Prevent deadlock when query finishes before DAG

### DIFF
--- a/packages/back-end/src/jobs/expireOldQueries.ts
+++ b/packages/back-end/src/jobs/expireOldQueries.ts
@@ -162,31 +162,57 @@ async function reapStalledSnapshots() {
       queryIds,
     );
     if (statuses.length !== queryIds.length) continue;
+
+    const running = statuses.filter((q) => q.status === "running");
+    const queued = statuses.filter((q) => q.status === "queued");
     const allTerminal = statuses.every(
       (q) => q.status === "succeeded" || q.status === "failed",
     );
-    if (!allTerminal) continue;
+
+    // An orphaned DAG: nothing is actually executing, but one or more
+    // queries are still "queued" and will never be started. This happens
+    // when the in-memory timer that drives the DAG forward was lost —
+    // e.g. the process restarted mid-run, or a fast first query finished
+    // and fired its follow-up timer before the full query DAG was
+    // persisted (the Full Refresh race). Queued queries have no heartbeat
+    // and are never "running", so neither getStaleQueries() nor the
+    // all-terminal reap path above will ever touch them. Without this
+    // branch the snapshot would show "Running" forever.
+    const orphanedDag = running.length === 0 && queued.length > 0;
+
+    if (!allTerminal && !orphanedDag) continue;
 
     const latestFinishedAt = Math.max(
+      0,
       ...statuses.map((s) => s.finishedAt?.getTime() ?? 0),
     );
-    if (Date.now() - latestFinishedAt < STALLED_FINALIZE_GRACE_MS) continue;
+    // For an orphaned DAG nothing may have finished yet (latestFinishedAt
+    // stays 0), in which case fall back to the snapshot's age — the
+    // STALLED_SNAPSHOT_THRESHOLD_MS check above has already guaranteed it.
+    const lastActivityAt =
+      latestFinishedAt > 0 ? latestFinishedAt : snapshot.dateCreated.getTime();
+    if (Date.now() - lastActivityAt < STALLED_FINALIZE_GRACE_MS) continue;
 
     const statusById = new Map(statuses.map((s) => [s.id, s.status]));
     snapshot.queries.forEach((q) => {
       q.status = statusById.get(q.query) ?? q.status;
     });
 
+    const error = orphanedDag
+      ? "Snapshot stalled: queries were never started. This can happen when the server restarts mid-refresh. Please try updating results again."
+      : "Snapshot stalled: queries finished but results were never finalized. This usually means the analysis step failed (check server logs) or the process was restarted.";
+
     const context = await getContextForAgendaJobByOrgId(snapshot.organization);
     const reaped = await errorSnapshotIfStillRunning(context, snapshot.id, {
       queries: snapshot.queries,
-      error:
-        "Snapshot stalled: queries finished but results were never finalized. This usually means the analysis step failed (check server logs) or the process was restarted.",
+      error,
     });
     if (!reaped) continue;
 
     logger.info(
-      `Reaped stalled snapshot ${snapshot.id} (experiment ${snapshot.experiment}): all ${queryIds.length} queries terminal but status still running`,
+      orphanedDag
+        ? `Reaped orphaned snapshot ${snapshot.id} (experiment ${snapshot.experiment}): ${queued.length} of ${queryIds.length} queries stuck in "queued" with nothing running`
+        : `Reaped stalled snapshot ${snapshot.id} (experiment ${snapshot.experiment}): all ${queryIds.length} queries terminal but status still running`,
     );
 
     await context.models.incrementalRefresh

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -311,6 +311,24 @@ export abstract class QueryRunner<
       this.setStatus("finished", error, result);
     } else {
       this.setStatus("running");
+      // Schedule one more pass through refreshQueryStatuses/startReadyQueries
+      // now that the full `queries` array has been persisted to the model.
+      //
+      // This closes a race: queries with no dependencies are executed
+      // fire-and-forget inside startQueries() (see startQuery's readyToRun
+      // branch). If one of them is very fast (e.g. a DROP TABLE during a
+      // Full Refresh), it can finish — and its onQueryFinish 1-second timer
+      // can fire — while startQueries() is still generating SQL for the
+      // remaining queries and before updateModel() above has written them.
+      // That early timer reloads the model, sees no running/queued queries,
+      // and gives up. Once startQueries() finally returns, nothing re-arms
+      // the timer, so every other query in the DAG stays "queued" forever.
+      //
+      // Calling onQueryFinish() here guarantees at least one refresh happens
+      // after the DAG is visible in the persisted model. If the timer from
+      // the early-finishing query is still pending this is a no-op; if it
+      // already fired and found nothing, this re-arms it with the real DAG.
+      this.onQueryFinish();
     }
 
     return newModel;
@@ -458,9 +476,23 @@ export abstract class QueryRunner<
         (q) => q.status === "running" || q.status === "queued",
       )
     ) {
-      logger.debug(
-        "No running or queued queries for " + this.model.id + ", return",
-      );
+      if (this.status !== "finished") {
+        // Being asked to refresh a non-terminal runner whose persisted model
+        // has no active queries is unexpected. It most likely means a query
+        // finished (and its onQueryFinish timer fired) before startAnalysis()
+        // persisted the full `queries` array. Historically this was only a
+        // debug log, which made the resulting "snapshot stuck running forever"
+        // failure mode invisible. Log at warn so it surfaces; the post-persist
+        // onQueryFinish() in startAnalysis() will re-drive the DAG.
+        logger.warn(
+          `No running or queued queries for ${this.model.id} but runner status is "${this.status}". ` +
+            `Likely a query finished before the full query DAG was persisted; a follow-up refresh is scheduled.`,
+        );
+      } else {
+        logger.debug(
+          "No running or queued queries for " + this.model.id + ", return",
+        );
+      }
       return new Map();
     }
 

--- a/packages/back-end/test/queryRunners/QueryRunner.test.ts
+++ b/packages/back-end/test/queryRunners/QueryRunner.test.ts
@@ -1,4 +1,4 @@
-import { QueryInterface, QueryStatus } from "shared/types/query";
+import { Queries, QueryInterface, QueryStatus } from "shared/types/query";
 import { ReqContext } from "back-end/types/request";
 import {
   QueryRunner,
@@ -6,7 +6,7 @@ import {
   InterfaceWithQueries,
 } from "back-end/src/queryRunners/QueryRunner";
 import { SourceIntegrationInterface } from "back-end/src/types/Integration";
-import { updateQuery } from "back-end/src/models/QueryModel";
+import { getQueriesByIds, updateQuery } from "back-end/src/models/QueryModel";
 
 jest.mock("back-end/src/models/QueryModel");
 
@@ -434,6 +434,145 @@ describe("QueryRunner", () => {
           onFailure: expect.any(Function),
         }),
       );
+    });
+  });
+
+  describe("startAnalysis", () => {
+    let mockContext: ReqContext;
+    let mockIntegration: SourceIntegrationInterface;
+
+    beforeEach(() => {
+      mockContext = createMockContext();
+      mockIntegration = createMockIntegration();
+      // getQueryMap() calls getQueriesByIds() to hydrate cached-query results.
+      // The auto-mock returns undefined; make it return an empty array so the
+      // cached path in startAnalysis() is exercisable without real DB access.
+      (getQueriesByIds as jest.Mock).mockResolvedValue([]);
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    // Simulates the Full Refresh race: a dependency-free query (e.g. a DROP
+    // TABLE) is executed fire-and-forget inside startQueries() and can finish
+    // — and fire its onQueryFinish follow-up timer — before startAnalysis()
+    // has persisted the full `queries` array to the model. The early timer
+    // reloads a model with no queued/running queries and gives up. Without a
+    // post-persist re-arm, nothing ever drives the rest of the DAG and every
+    // downstream query stays "queued" forever.
+    class RaceTestQueryRunner extends QueryRunner<
+      InterfaceWithQueries,
+      { pointers: Queries },
+      { success: boolean }
+    > {
+      public persistedQueries: Queries = [];
+      public updateModelSpy = jest.fn();
+      public onQueryFinishSpy = jest.fn();
+
+      checkPermissions() {
+        return true;
+      }
+
+      async startQueries(params: { pointers: Queries }) {
+        return params.pointers;
+      }
+
+      async runAnalysis() {
+        return { success: true };
+      }
+
+      // Simulates reading the model from the database: returns whatever has
+      // been persisted via updateModel(), not the in-memory copy.
+      async getLatestModel() {
+        return {
+          ...this.model,
+          queries: this.persistedQueries,
+        };
+      }
+
+      async updateModel(params: {
+        status: QueryStatus;
+        queries: Queries;
+      }): Promise<InterfaceWithQueries> {
+        this.updateModelSpy(params);
+        this.persistedQueries = params.queries;
+        return { ...this.model, queries: params.queries };
+      }
+
+      async onQueryFinish() {
+        this.onQueryFinishSpy(this.persistedQueries.length);
+        return super.onQueryFinish();
+      }
+    }
+
+    it("re-arms the follow-up timer after persisting the query DAG", async () => {
+      jest.useFakeTimers();
+      try {
+        const model: InterfaceWithQueries = {
+          id: "test-model",
+          organization: "test-org",
+          queries: [],
+          runStarted: new Date(),
+        };
+        const runner = new RaceTestQueryRunner(
+          mockContext,
+          model,
+          mockIntegration,
+        );
+
+        const pointers: Queries = [
+          { name: "drop_old", query: "qry_drop", status: "running" },
+          { name: "create", query: "qry_create", status: "queued" },
+        ];
+
+        await runner.startAnalysis({ pointers });
+
+        // updateModel must have been called with the full DAG...
+        expect(runner.updateModelSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ status: "running", queries: pointers }),
+        );
+        // ...and onQueryFinish must have been called AFTER that persist, i.e.
+        // with the full DAG visible in the "database". This is what re-drives
+        // the DAG if a fast dependency-free query already finished and its
+        // follow-up timer already fired before the DAG was persisted.
+        expect(runner.onQueryFinishSpy).toHaveBeenCalledWith(pointers.length);
+      } finally {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+      }
+    });
+
+    it("does not re-arm the timer when queries are already finished (cached)", async () => {
+      jest.useFakeTimers();
+      try {
+        const model: InterfaceWithQueries = {
+          id: "test-model",
+          organization: "test-org",
+          queries: [],
+          runStarted: new Date(),
+        };
+        const runner = new RaceTestQueryRunner(
+          mockContext,
+          model,
+          mockIntegration,
+        );
+
+        const pointers: Queries = [
+          { name: "a", query: "qry_a", status: "succeeded" },
+          { name: "b", query: "qry_b", status: "succeeded" },
+        ];
+
+        await runner.startAnalysis({ pointers });
+
+        // Runner should be finished (analysis ran synchronously on cached
+        // results) and no follow-up refresh should have been scheduled.
+        expect(runner.status).toBe("finished");
+        expect(runner.onQueryFinishSpy).not.toHaveBeenCalled();
+      } finally {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+      }
     });
   });
 });


### PR DESCRIPTION
## Problem

Triggering a **Full Refresh** on an experiment with many metrics (~100+) can silently deadlock the refresh and leave the experiment worse off than before:

- The `DROP TABLE` that begins the Full Refresh runs and completes. Nothing after it ever starts — no `CREATE TABLE`, no metric-source inserts, no stats query.
- The snapshot stays `status: "running"` indefinitely. The UI shows a spinner that never resolves.
- No error is raised. No `warn`/`error` log is emitted. The only trace in the warehouse's job history is the lone `DROP TABLE`.
- The user's only recourse is to manually cancel and retry — which hits the same condition again.

This is **deterministic, not intermittent**. Once an experiment crosses the metric-count threshold where SQL generation for the full query DAG takes longer than ~1 second, every Full Refresh attempt hits the same wall, every time.

**Reproduced:** on an experiment with ~120 fact metrics, three consecutive Full Refresh attempts all deadlocked identically after the `DROP TABLE` — including attempts where the metric set and fact table SQL were changed between tries, ruling out config as the cause. The same experiment config rebuilt its cache successfully via a regular auto-refresh that detected the missing cache table — that path's first query is a slow `CREATE TABLE AS SELECT`, which gives `startQueries()` time to finish before the callback timer fires.

And once the cache table has been dropped, the experiment can't self-heal: regular (non-full) incremental updates don't rebuild the cache — they either fail the settings-hash check (if the experiment config changed, which is usually why someone is doing a Full Refresh) or can't find the cache table to append to, and fall back to inline full-rescans. A single failed Full Refresh permanently downgrades the experiment from pipeline mode to inline mode until a Full Refresh succeeds — and because the race is deterministic, that never happens.

## Root cause: a timer race between query execution and DAG persistence

1. `startAnalysis()` calls `startQueries()`, which builds the full query DAG (for an incremental Full Refresh with many metrics this is ~50+ query docs: drop old cache → create cache → per-metric-source create/insert/timestamp queries → stats → traffic).
2. Inside `startQueries()`, `startQuery()` fires `executeQuery()` **immediately and fire-and-forget** for any query with no dependencies (the `readyToRun` branch). For a Full Refresh, the first such query is a `DROP TABLE IF EXISTS` on the old cache table.
3. `startAnalysis()` only persists the full `queries` array to the model **after** `startQueries()` returns.
4. The `DROP TABLE` is essentially instant. When it finishes, `onQueryFinish()` arms a 1-second `setTimeout` to check what runs next.
5. If SQL generation for the remaining queries takes longer than `drop_latency + 1000ms` — which it reliably does for experiments with many metrics — the timer fires *before* the `queries` array is persisted.
6. The timer callback calls `getLatestModel()` (reloads the snapshot — still `queries: []`) and then `refreshQueryStatuses()`, which finds no running or queued queries and returns `new Map()` with only a `logger.debug()`.
7. `startQueries()` eventually returns and `startAnalysis()` persists the queries array. But nothing processes it — the only thing that ever re-drives the DAG is `onQueryFinish()`, the DROP already fired its one shot, and the timer already came up empty.
8. Every downstream query stays `status: "queued"` forever. The snapshot stays `status: "running"` forever.

### Why it only affects Full Refresh

On a regular (incremental) refresh, the first `dependencies: []` query is an `UPDATE` or `CREATE TABLE AS SELECT` that scans raw data — it always takes far longer than SQL generation, so the timer always fires after the DAG is persisted. Full Refresh is the only DAG where the first query is an instant DDL statement, so it's the only DAG that can win this race.

### Why the safety nets don't catch it

Two cleanup mechanisms should in theory detect a stuck snapshot, and both miss this case by design:

- `getStaleQueries()` marks `running` queries with a stale heartbeat as failed. But the orphaned queries here are `queued`, not `running` — they never started, so they have no heartbeat to go stale.
- `reapStalledSnapshots()` (added in #5611) reaps snapshots stuck `running` after their queries finished. But it requires **all** queries to be in a terminal state (`succeeded`/`failed`) before reaping. The orphaned queries are `queued`, which is non-terminal, so the snapshot never qualifies.

There is therefore **no timeout, no error, no reaper, and no log** that surfaces the stuck state.

## Fix

Three small, independent changes. The first closes the race; the other two make the remaining surface area observable and recoverable.

### 1. Re-drive the DAG after it's persisted (`QueryRunner.startAnalysis()`)

After `updateModel()` has persisted the full `queries` array and the runner has been marked `running`, call `onQueryFinish()` one more time. This guarantees at least one pass through `refreshQueryStatuses()` / `startReadyQueries()` happens **after** the DAG is visible in the persisted model.

- If the timer from the early-finishing query is still pending, this is a no-op (the existing `this.timer` guard de-dupes).
- If the timer already fired and gave up, this re-arms it with the real DAG and the refresh proceeds.
- If nothing has finished yet (the normal incremental case), this is a cheap extra status poll that finds nothing to do.

**Timeline, before and after** (for a Full Refresh where SQL generation takes ~3s):

```
Before:
 t=0.0s  DROP fired (fire-and-forget)
 t=0.5s  DROP finishes → onQueryFinish → 1s timer armed
 t=1.5s  timer fires → reloads model → queries:[] → gives up
 t=3.0s  startQueries() returns → queries array persisted
         ...nothing ever looks at it again. Stuck forever.

After:
 t=0.0s  DROP fired (fire-and-forget)
 t=0.5s  DROP finishes → onQueryFinish → 1s timer armed
 t=1.5s  timer fires → reloads model → queries:[] → logs warn → gives up
 t=3.0s  startQueries() returns → queries array persisted
 t=3.0s  onQueryFinish() called → 1s timer armed
 t=4.0s  timer fires → reloads model → full DAG visible → DROP is succeeded
         → startReadyQueries() starts CREATE → refresh proceeds normally.
```

This was chosen over deferring `executeQuery()` for `readyToRun` queries until after persistence because (a) it's a one-line behavioral change that doesn't alter when queries start executing, and (b) the cached-query reuse path in `startQuery()` can also call `onQueryFinish()` before the DAG is persisted (when a cached query is already finished) — a post-persist pass covers that path too, whereas deferring execution would not.

### 2. Make the condition visible (`QueryRunner.refreshQueryStatuses()`)

When `refreshQueryStatuses()` finds no running/queued queries on a runner that is **not** in a terminal state, log at `warn` instead of `debug`. This exact condition is the signature of the race, and the fact that it was only ever a debug log is why this failure mode was invisible in production logs.

### 3. Reap orphaned DAGs (`expireOldQueries.reapStalledSnapshots()`)

Extend the stalled-snapshot reaper (from #5611) to also reap snapshots where **zero queries are running and one or more are queued**. That combination means nothing is executing and nothing ever will — the in-memory timers that drive a DAG forward are process-local, so once they're gone (server restart mid-run, or this race before the fix above), queued queries are stuck permanently. The reaper marks the snapshot `error` with a descriptive message so the UI stops spinning and the user can retry. It reuses the existing 60-minute stall threshold and 10-minute finalize grace period.

This is a safety net for snapshots stuck by older code, by a mid-run restart, or by any future regression in the DAG lifecycle — not just this specific race.

## Impact

- Experiments with enough metrics that SQL generation takes >1s can now reliably Full Refresh, restoring their pipeline-mode caches instead of being permanently downgraded to inline full-rescans.
- Snapshots that do get stuck (server restart mid-run, etc.) are reaped within ~70 minutes instead of showing "Running" forever.
- The previously-silent race condition is now logged at `warn` level when it fires.

## Scope / what this does not change

- The 1-second `onQueryFinish` polling interval is unchanged.
- The fire-and-forget execution of dependency-free queries inside `startQueries()` is unchanged.
- The `reapStalledSnapshots()` thresholds (60 min stall, 10 min grace) are unchanged; the new branch reuses them.
- `getStaleQueries()` (heartbeat-based query reaping) is unchanged — queued queries still have no heartbeat, but the DAG-level reaper now covers that gap.
- The all-terminal reap branch in `reapStalledSnapshots()` is behaviorally unchanged (the new `orphanedDag` branch is additive).

## Testing

- Added two tests to `packages/back-end/test/queryRunners/QueryRunner.test.ts`:
  - `re-arms the follow-up timer after persisting the query DAG` — asserts `onQueryFinish()` is called after `updateModel()` persists the queries array when the runner enters `running`.
  - `does not re-arm the timer when queries are already finished (cached)` — asserts no extra timer is armed for the fully-cached synchronous-finish path.
- Full `packages/back-end` jest suite passes (95 suites / 3986 tests / 2244 snapshots).
- `tsc --noEmit`, `eslint --max-warnings 0`, `prettier --check` all pass on changed files.

Manual repro for reviewers: on an experiment with enough metrics that `startExperimentIncrementalRefreshQueries()` takes >1s to generate SQL, trigger a Full Refresh. Before this change the DROP appears in the warehouse's job history and nothing follows; after it the full DAG proceeds.

## Related

- #5611 added `reapStalledSnapshots()` for the "all queries terminal but snapshot still running" case — this extends it to the "no queries running but some still queued" case.
- #5882 is part of the same series hardening incremental refresh.

