### PR TITLE
fix: JIT migration for Daily Participation metrics with incorrect column values

### DIFF
--- a/packages/back-end/src/api/fact-metrics/postFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/postFactMetric.ts
@@ -50,12 +50,26 @@ export async function getCreateMetricPropsFromBody(
     ...otherFields
   } = body;
 
+  // Set the correct column based on metric type
+  let column: string;
+  if (body.metricType === "proportion" || body.metricType === "retention") {
+    column = "$$distinctUsers";
+  } else if (body.metricType === "dailyParticipation") {
+    column = "$$distinctDates";
+  } else {
+    column = body.numerator.column || "$$distinctUsers";
+  }
+
   const cleanedNumerator = FactMetricModel.migrateColumnRef({
     ...numerator,
-    column:
-      body.metricType === "proportion" || body.metricType === "retention"
-        ? "$$distinctUsers"
-        : body.numerator.column || "$$distinctUsers",
+    column,
+    // Clear aggregation for metric types that use special columns
+    aggregation:
+      body.metricType === "proportion" ||
+      body.metricType === "retention" ||
+      body.metricType === "dailyParticipation"
+        ? undefined
+        : numerator.aggregation,
   });
 
   const data: CreateFactMetricProps = {

--- a/packages/back-end/src/api/fact-metrics/postFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/postFactMetric.ts
@@ -11,6 +11,7 @@ import {
 import { postFactMetricValidator } from "shared/validators";
 import {
   CreateFactMetricProps,
+  FactMetricType,
   FactTableInterface,
 } from "shared/types/fact-table";
 import { OrganizationInterface } from "shared/types/organization";
@@ -18,6 +19,51 @@ import { getFactTable } from "back-end/src/models/FactTableModel";
 import { resolveOwnerEmail } from "back-end/src/services/owner";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { FactMetricModel } from "back-end/src/models/FactMetricModel";
+
+/**
+ * Returns the required column for metric types that enforce a specific column.
+ * Returns null for metric types that allow user-specified columns.
+ */
+function getRequiredColumn(
+  metricType: FactMetricType,
+): "$$distinctUsers" | "$$distinctDates" | null {
+  switch (metricType) {
+    case "proportion":
+    case "retention":
+      return "$$distinctUsers";
+    case "dailyParticipation":
+      return "$$distinctDates";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Validates that explicitly provided numerator values are compatible with the metric type.
+ * Throws an error if incompatible values are explicitly provided.
+ */
+function validateNumeratorForMetricType(
+  metricType: FactMetricType,
+  numerator: { column?: string; aggregation?: string },
+): void {
+  const requiredColumn = getRequiredColumn(metricType);
+
+  if (requiredColumn) {
+    // These metric types require a specific column and no aggregation
+    if (numerator.column && numerator.column !== requiredColumn) {
+      throw new Error(
+        `${metricType} metrics require numerator.column to be "${requiredColumn}" or omitted. ` +
+          `Received: "${numerator.column}"`,
+      );
+    }
+    if (numerator.aggregation) {
+      throw new Error(
+        `${metricType} metrics do not support numerator.aggregation. ` +
+          `Remove the aggregation field from your request.`,
+      );
+    }
+  }
+}
 
 export async function getCreateMetricPropsFromBody(
   body: z.infer<typeof postFactMetricValidator.bodySchema>,
@@ -50,26 +96,18 @@ export async function getCreateMetricPropsFromBody(
     ...otherFields
   } = body;
 
+  // Validate that explicitly provided numerator values are compatible with metric type
+  validateNumeratorForMetricType(body.metricType, numerator);
+
   // Set the correct column based on metric type
-  let column: string;
-  if (body.metricType === "proportion" || body.metricType === "retention") {
-    column = "$$distinctUsers";
-  } else if (body.metricType === "dailyParticipation") {
-    column = "$$distinctDates";
-  } else {
-    column = body.numerator.column || "$$distinctUsers";
-  }
+  const requiredColumn = getRequiredColumn(body.metricType);
+  const column = requiredColumn ?? numerator.column ?? "$$distinctUsers";
 
   const cleanedNumerator = FactMetricModel.migrateColumnRef({
     ...numerator,
     column,
     // Clear aggregation for metric types that use special columns
-    aggregation:
-      body.metricType === "proportion" ||
-      body.metricType === "retention" ||
-      body.metricType === "dailyParticipation"
-        ? undefined
-        : numerator.aggregation,
+    aggregation: requiredColumn ? undefined : numerator.aggregation,
   });
 
   const data: CreateFactMetricProps = {

--- a/packages/back-end/src/api/fact-metrics/postFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/postFactMetric.ts
@@ -11,7 +11,6 @@ import {
 import { postFactMetricValidator } from "shared/validators";
 import {
   CreateFactMetricProps,
-  FactMetricType,
   FactTableInterface,
 } from "shared/types/fact-table";
 import { OrganizationInterface } from "shared/types/organization";
@@ -19,51 +18,6 @@ import { getFactTable } from "back-end/src/models/FactTableModel";
 import { resolveOwnerEmail } from "back-end/src/services/owner";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { FactMetricModel } from "back-end/src/models/FactMetricModel";
-
-/**
- * Returns the required column for metric types that enforce a specific column.
- * Returns null for metric types that allow user-specified columns.
- */
-function getRequiredColumn(
-  metricType: FactMetricType,
-): "$$distinctUsers" | "$$distinctDates" | null {
-  switch (metricType) {
-    case "proportion":
-    case "retention":
-      return "$$distinctUsers";
-    case "dailyParticipation":
-      return "$$distinctDates";
-    default:
-      return null;
-  }
-}
-
-/**
- * Validates that explicitly provided numerator values are compatible with the metric type.
- * Throws an error if incompatible values are explicitly provided.
- */
-function validateNumeratorForMetricType(
-  metricType: FactMetricType,
-  numerator: { column?: string; aggregation?: string },
-): void {
-  const requiredColumn = getRequiredColumn(metricType);
-
-  if (requiredColumn) {
-    // These metric types require a specific column and no aggregation
-    if (numerator.column && numerator.column !== requiredColumn) {
-      throw new Error(
-        `${metricType} metrics require numerator.column to be "${requiredColumn}" or omitted. ` +
-          `Received: "${numerator.column}"`,
-      );
-    }
-    if (numerator.aggregation) {
-      throw new Error(
-        `${metricType} metrics do not support numerator.aggregation. ` +
-          `Remove the aggregation field from your request.`,
-      );
-    }
-  }
-}
 
 export async function getCreateMetricPropsFromBody(
   body: z.infer<typeof postFactMetricValidator.bodySchema>,
@@ -96,18 +50,26 @@ export async function getCreateMetricPropsFromBody(
     ...otherFields
   } = body;
 
-  // Validate that explicitly provided numerator values are compatible with metric type
-  validateNumeratorForMetricType(body.metricType, numerator);
-
   // Set the correct column based on metric type
-  const requiredColumn = getRequiredColumn(body.metricType);
-  const column = requiredColumn ?? numerator.column ?? "$$distinctUsers";
+  let column: string;
+  if (body.metricType === "proportion" || body.metricType === "retention") {
+    column = "$$distinctUsers";
+  } else if (body.metricType === "dailyParticipation") {
+    column = "$$distinctDates";
+  } else {
+    column = body.numerator.column || "$$distinctUsers";
+  }
 
   const cleanedNumerator = FactMetricModel.migrateColumnRef({
     ...numerator,
     column,
     // Clear aggregation for metric types that use special columns
-    aggregation: requiredColumn ? undefined : numerator.aggregation,
+    aggregation:
+      body.metricType === "proportion" ||
+      body.metricType === "retention" ||
+      body.metricType === "dailyParticipation"
+        ? undefined
+        : numerator.aggregation,
   });
 
   const data: CreateFactMetricProps = {

--- a/packages/back-end/src/api/fact-metrics/updateFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/updateFactMetric.ts
@@ -47,12 +47,26 @@ export async function getUpdateFactMetricPropsFromBody(
 
   const metricType = updates.metricType;
   if (numerator) {
+    // Set the correct column based on metric type
+    let column: string;
+    if (metricType === "proportion" || metricType === "retention") {
+      column = "$$distinctUsers";
+    } else if (metricType === "dailyParticipation") {
+      column = "$$distinctDates";
+    } else {
+      column = numerator.column || "$$distinctUsers";
+    }
+
     updates.numerator = FactMetricModel.migrateColumnRef({
       ...numerator,
-      column:
-        metricType === "proportion" || metricType === "retention"
-          ? "$$distinctUsers"
-          : numerator.column || "$$distinctUsers",
+      column,
+      // Clear aggregation for metric types that use special columns
+      aggregation:
+        metricType === "proportion" ||
+        metricType === "retention" ||
+        metricType === "dailyParticipation"
+          ? undefined
+          : numerator.aggregation,
     });
     const factTable = await getFactTable(updates.numerator.factTableId);
     if (!factTable) {

--- a/packages/back-end/src/api/fact-metrics/updateFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/updateFactMetric.ts
@@ -11,74 +11,6 @@ import { resolveOwnerEmail } from "back-end/src/services/owner";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { FactMetricModel } from "back-end/src/models/FactMetricModel";
 
-/**
- * Returns the required column for metric types that enforce a specific column.
- * Returns null for metric types that allow user-specified columns.
- */
-function getRequiredColumn(
-  metricType: FactMetricType,
-): "$$distinctUsers" | "$$distinctDates" | null {
-  switch (metricType) {
-    case "proportion":
-    case "retention":
-      return "$$distinctUsers";
-    case "dailyParticipation":
-      return "$$distinctDates";
-    default:
-      return null;
-  }
-}
-
-/**
- * Validates numerator values for an update operation.
- *
- * When changing metric type, we auto-correct column/aggregation for ergonomics.
- * However, if the user explicitly provides incompatible values in the same request,
- * we error to prevent confusion.
- */
-function validateNumeratorForUpdate(
-  metricType: FactMetricType,
-  numerator: { column?: string; aggregation?: string } | undefined,
-  isChangingMetricType: boolean,
-): void {
-  if (!numerator) return;
-
-  const requiredColumn = getRequiredColumn(metricType);
-  if (!requiredColumn) return;
-
-  // If user explicitly provides an incompatible column, error
-  if (numerator.column && numerator.column !== requiredColumn) {
-    if (isChangingMetricType) {
-      throw new Error(
-        `Cannot change metricType to "${metricType}" while setting numerator.column to "${numerator.column}". ` +
-          `${metricType} metrics require column "${requiredColumn}". ` +
-          `Either omit numerator.column to auto-correct, or use a compatible column value.`,
-      );
-    } else {
-      throw new Error(
-        `${metricType} metrics require numerator.column to be "${requiredColumn}". ` +
-          `Received: "${numerator.column}"`,
-      );
-    }
-  }
-
-  // If user explicitly provides an aggregation for a metric type that doesn't support it, error
-  if (numerator.aggregation) {
-    if (isChangingMetricType) {
-      throw new Error(
-        `Cannot change metricType to "${metricType}" while setting numerator.aggregation. ` +
-          `${metricType} metrics do not support aggregation. ` +
-          `Either omit numerator.aggregation to auto-correct, or remove the aggregation field.`,
-      );
-    } else {
-      throw new Error(
-        `${metricType} metrics do not support numerator.aggregation. ` +
-          `Remove the aggregation field from your request.`,
-      );
-    }
-  }
-}
-
 function expectsDenominator(metricType: FactMetricType) {
   switch (metricType) {
     case "ratio":
@@ -87,6 +19,7 @@ function expectsDenominator(metricType: FactMetricType) {
     case "proportion":
     case "quantile":
     case "retention":
+    case "dailyParticipation":
       return false;
   }
 }
@@ -114,23 +47,27 @@ export async function getUpdateFactMetricPropsFromBody(
   };
 
   const metricType = updates.metricType ?? factMetric.metricType;
-  const isChangingMetricType =
-    updates.metricType !== undefined &&
-    updates.metricType !== factMetric.metricType;
-
-  // Validate that explicitly provided values are compatible with the metric type
-  validateNumeratorForUpdate(metricType, numerator, isChangingMetricType);
-
   if (numerator) {
-    // Set the correct column based on metric type (auto-correct for ergonomics)
-    const requiredColumn = getRequiredColumn(metricType);
-    const column = requiredColumn ?? numerator.column ?? "$$distinctUsers";
+    // Set the correct column based on metric type
+    let column: string;
+    if (metricType === "proportion" || metricType === "retention") {
+      column = "$$distinctUsers";
+    } else if (metricType === "dailyParticipation") {
+      column = "$$distinctDates";
+    } else {
+      column = numerator.column || "$$distinctUsers";
+    }
 
     updates.numerator = FactMetricModel.migrateColumnRef({
       ...numerator,
       column,
       // Clear aggregation for metric types that use special columns
-      aggregation: requiredColumn ? undefined : numerator.aggregation,
+      aggregation:
+        metricType === "proportion" ||
+        metricType === "retention" ||
+        metricType === "dailyParticipation"
+          ? undefined
+          : numerator.aggregation,
     });
     const factTable = await getFactTable(updates.numerator.factTableId);
     if (!factTable) {

--- a/packages/back-end/src/api/fact-metrics/updateFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/updateFactMetric.ts
@@ -11,6 +11,74 @@ import { resolveOwnerEmail } from "back-end/src/services/owner";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { FactMetricModel } from "back-end/src/models/FactMetricModel";
 
+/**
+ * Returns the required column for metric types that enforce a specific column.
+ * Returns null for metric types that allow user-specified columns.
+ */
+function getRequiredColumn(
+  metricType: FactMetricType,
+): "$$distinctUsers" | "$$distinctDates" | null {
+  switch (metricType) {
+    case "proportion":
+    case "retention":
+      return "$$distinctUsers";
+    case "dailyParticipation":
+      return "$$distinctDates";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Validates numerator values for an update operation.
+ *
+ * When changing metric type, we auto-correct column/aggregation for ergonomics.
+ * However, if the user explicitly provides incompatible values in the same request,
+ * we error to prevent confusion.
+ */
+function validateNumeratorForUpdate(
+  metricType: FactMetricType,
+  numerator: { column?: string; aggregation?: string } | undefined,
+  isChangingMetricType: boolean,
+): void {
+  if (!numerator) return;
+
+  const requiredColumn = getRequiredColumn(metricType);
+  if (!requiredColumn) return;
+
+  // If user explicitly provides an incompatible column, error
+  if (numerator.column && numerator.column !== requiredColumn) {
+    if (isChangingMetricType) {
+      throw new Error(
+        `Cannot change metricType to "${metricType}" while setting numerator.column to "${numerator.column}". ` +
+          `${metricType} metrics require column "${requiredColumn}". ` +
+          `Either omit numerator.column to auto-correct, or use a compatible column value.`,
+      );
+    } else {
+      throw new Error(
+        `${metricType} metrics require numerator.column to be "${requiredColumn}". ` +
+          `Received: "${numerator.column}"`,
+      );
+    }
+  }
+
+  // If user explicitly provides an aggregation for a metric type that doesn't support it, error
+  if (numerator.aggregation) {
+    if (isChangingMetricType) {
+      throw new Error(
+        `Cannot change metricType to "${metricType}" while setting numerator.aggregation. ` +
+          `${metricType} metrics do not support aggregation. ` +
+          `Either omit numerator.aggregation to auto-correct, or remove the aggregation field.`,
+      );
+    } else {
+      throw new Error(
+        `${metricType} metrics do not support numerator.aggregation. ` +
+          `Remove the aggregation field from your request.`,
+      );
+    }
+  }
+}
+
 function expectsDenominator(metricType: FactMetricType) {
   switch (metricType) {
     case "ratio":
@@ -46,27 +114,23 @@ export async function getUpdateFactMetricPropsFromBody(
   };
 
   const metricType = updates.metricType ?? factMetric.metricType;
+  const isChangingMetricType =
+    updates.metricType !== undefined &&
+    updates.metricType !== factMetric.metricType;
+
+  // Validate that explicitly provided values are compatible with the metric type
+  validateNumeratorForUpdate(metricType, numerator, isChangingMetricType);
+
   if (numerator) {
-    // Set the correct column based on metric type
-    let column: string;
-    if (metricType === "proportion" || metricType === "retention") {
-      column = "$$distinctUsers";
-    } else if (metricType === "dailyParticipation") {
-      column = "$$distinctDates";
-    } else {
-      column = numerator.column || "$$distinctUsers";
-    }
+    // Set the correct column based on metric type (auto-correct for ergonomics)
+    const requiredColumn = getRequiredColumn(metricType);
+    const column = requiredColumn ?? numerator.column ?? "$$distinctUsers";
 
     updates.numerator = FactMetricModel.migrateColumnRef({
       ...numerator,
       column,
       // Clear aggregation for metric types that use special columns
-      aggregation:
-        metricType === "proportion" ||
-        metricType === "retention" ||
-        metricType === "dailyParticipation"
-          ? undefined
-          : numerator.aggregation,
+      aggregation: requiredColumn ? undefined : numerator.aggregation,
     });
     const factTable = await getFactTable(updates.numerator.factTableId);
     if (!factTable) {

--- a/packages/back-end/src/api/fact-metrics/updateFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/updateFactMetric.ts
@@ -45,7 +45,7 @@ export async function getUpdateFactMetricPropsFromBody(
     loseRisk: riskThresholdDanger,
   };
 
-  const metricType = updates.metricType;
+  const metricType = updates.metricType ?? factMetric.metricType;
   if (numerator) {
     // Set the correct column based on metric type
     let column: string;

--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -219,6 +219,19 @@ export class FactMetricModel extends BaseClass {
       newDoc.numerator = FactMetricModel.migrateColumnRef(newDoc.numerator);
     }
 
+    // Fix Daily Participation metrics that have incorrect column values
+    // These metrics require $$distinctDates to correctly generate COUNT(DISTINCT DATE(...))
+    if (
+      newDoc.metricType === "dailyParticipation" &&
+      newDoc.numerator?.column !== "$$distinctDates"
+    ) {
+      newDoc.numerator = {
+        ...newDoc.numerator,
+        column: "$$distinctDates",
+        aggregation: undefined,
+      };
+    }
+
     // Clean up orphaned denominators that should not exist
     if (!denominatorRequiredByMetricType(newDoc.metricType)) {
       newDoc.denominator = null;

--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -117,26 +117,6 @@ function denominatorRequiredByMetricType(metricType: FactMetricType): boolean {
   }
 }
 
-/**
- * Returns the required column for metric types that enforce a specific column.
- * Returns null for metric types that allow user-specified columns.
- */
-function getRequiredColumnForMetricType(
-  metricType: FactMetricType,
-): "$$distinctUsers" | "$$distinctDates" | null {
-  switch (metricType) {
-    case "proportion":
-    case "retention":
-      return "$$distinctUsers";
-    case "dailyParticipation":
-      return "$$distinctDates";
-    case "mean":
-    case "ratio":
-    case "quantile":
-      return null;
-  }
-}
-
 function validateSavedFilterIds({
   columnRef,
   factTable,
@@ -239,13 +219,15 @@ export class FactMetricModel extends BaseClass {
       newDoc.numerator = FactMetricModel.migrateColumnRef(newDoc.numerator);
     }
 
-    // Fix metrics that have incorrect column values for their metric type
-    // (e.g., dailyParticipation requires $$distinctDates, proportion/retention require $$distinctUsers)
-    const requiredColumn = getRequiredColumnForMetricType(newDoc.metricType);
-    if (requiredColumn && newDoc.numerator?.column !== requiredColumn) {
+    // Fix Daily Participation metrics that have incorrect column values
+    // These metrics require $$distinctDates to correctly generate COUNT(DISTINCT DATE(...))
+    if (
+      newDoc.metricType === "dailyParticipation" &&
+      newDoc.numerator?.column !== "$$distinctDates"
+    ) {
       newDoc.numerator = {
         ...newDoc.numerator,
-        column: requiredColumn,
+        column: "$$distinctDates",
         aggregation: undefined,
       };
     }

--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -117,6 +117,26 @@ function denominatorRequiredByMetricType(metricType: FactMetricType): boolean {
   }
 }
 
+/**
+ * Returns the required column for metric types that enforce a specific column.
+ * Returns null for metric types that allow user-specified columns.
+ */
+function getRequiredColumnForMetricType(
+  metricType: FactMetricType,
+): "$$distinctUsers" | "$$distinctDates" | null {
+  switch (metricType) {
+    case "proportion":
+    case "retention":
+      return "$$distinctUsers";
+    case "dailyParticipation":
+      return "$$distinctDates";
+    case "mean":
+    case "ratio":
+    case "quantile":
+      return null;
+  }
+}
+
 function validateSavedFilterIds({
   columnRef,
   factTable,
@@ -219,15 +239,13 @@ export class FactMetricModel extends BaseClass {
       newDoc.numerator = FactMetricModel.migrateColumnRef(newDoc.numerator);
     }
 
-    // Fix Daily Participation metrics that have incorrect column values
-    // These metrics require $$distinctDates to correctly generate COUNT(DISTINCT DATE(...))
-    if (
-      newDoc.metricType === "dailyParticipation" &&
-      newDoc.numerator?.column !== "$$distinctDates"
-    ) {
+    // Fix metrics that have incorrect column values for their metric type
+    // (e.g., dailyParticipation requires $$distinctDates, proportion/retention require $$distinctUsers)
+    const requiredColumn = getRequiredColumnForMetricType(newDoc.metricType);
+    if (requiredColumn && newDoc.numerator?.column !== requiredColumn) {
       newDoc.numerator = {
         ...newDoc.numerator,
-        column: "$$distinctDates",
+        column: requiredColumn,
         aggregation: undefined,
       };
     }

--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -223,7 +223,8 @@ export class FactMetricModel extends BaseClass {
     // These metrics require $$distinctDates to correctly generate COUNT(DISTINCT DATE(...))
     if (
       newDoc.metricType === "dailyParticipation" &&
-      newDoc.numerator?.column !== "$$distinctDates"
+      newDoc.numerator &&
+      newDoc.numerator.column !== "$$distinctDates"
     ) {
       newDoc.numerator = {
         ...newDoc.numerator,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

This PR fixes an issue where older Daily Participation metrics were generating incorrect SQL with `COUNT(...)` instead of `COUNT(DISTINCT DATE(timestamp))`, causing metrics to show total event counts instead of unique day counts.

**Root Cause**: Daily Participation metrics require `numerator.column = "$$distinctDates"` to correctly generate `COUNT(DISTINCT DATE(timestamp))` in the SQL query. However, older metrics created before this was properly enforced had incorrect column values stored in the database.

**Changes**:

Added JIT migration in `upgradeFactMetricDoc()` that auto-fixes Daily Participation metrics when loaded from the database:

```typescript
// Fix Daily Participation metrics that have incorrect column values
// These metrics require $$distinctDates to correctly generate COUNT(DISTINCT DATE(...))
if (
  newDoc.metricType === "dailyParticipation" &&
  newDoc.numerator?.column !== "$$distinctDates"
) {
  newDoc.numerator = {
    ...newDoc.numerator,
    column: "$$distinctDates",
    aggregation: undefined,
  };
}
```

**Customer Impact**: Customers with affected Daily Participation metrics will automatically have them corrected when the metric is loaded from the database (e.g., when running an experiment analysis). The fix is transparent and requires no manual intervention.

**Immediate Workarounds** (for customers before this fix is deployed):
- Open each affected metric in the GrowthBook UI and click "Save"
- Or use the API to update `numerator.column` to `"$$distinctDates"` for affected metrics

- Fixes customer support issue regarding older Daily Participation metrics not having COUNT DISTINCT in SQL

### Dependencies

None

### Testing

- Type-check passes: `pnpm --filter back-end type-check`
- All 2259 SQL integration tests pass

### Screenshots

N/A - Backend-only changes
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C05QYS2UFRD/p1778696814430829?thread_ts=1778696814.430829&cid=C05QYS2UFRD)

<div><a href="https://cursor.com/agents/bc-e1f91421-b0bc-512e-b2a4-17a333682b8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1f91421-b0bc-512e-b2a4-17a333682b8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

