### PR TITLE
Update approval flow settings headings

### DIFF
--- a/packages/front-end/components/GeneralSettings/ApprovalFlowSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/ApprovalFlowSettings.tsx
@@ -87,7 +87,7 @@ export default function ApprovalFlowSettings() {
         <Box mb="6" width="100%">
           <Frame p="3" mb="0">
             <Heading as="h4" size="small" weight="semibold" mb="4">
-              Drafts and Approvals
+              Features
             </Heading>
 
             <Text as="p" size="medium" mb="4" color="text-low">
@@ -294,6 +294,11 @@ export default function ApprovalFlowSettings() {
             <Heading as="h4" size="small" weight="semibold" mb="4">
               Saved Groups
             </Heading>
+
+            <Text as="p" size="medium" mb="4" color="text-low">
+              All changes to saved groups are tracked as revisions. Requiring
+              approvals adds a review step before any change goes live.
+            </Text>
 
             <Checkbox
               id="toggle-require-approvals-saved-groups"

--- a/packages/front-end/components/GeneralSettings/ApprovalFlowSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/ApprovalFlowSettings.tsx
@@ -83,8 +83,8 @@ export default function ApprovalFlowSettings() {
         </Box>
       </Flex>
 
-      <Flex align="start" direction="column" gap="5" mt="7">
-        <Box mb="6" width="100%">
+      <Flex align="start" direction="column" gap="4" mt="7">
+        <Box width="100%">
           <Frame p="3" mb="0">
             <Heading as="h4" size="small" weight="semibold" mb="4">
               Features
@@ -289,7 +289,7 @@ export default function ApprovalFlowSettings() {
           </Frame>
         </Box>
 
-        <Box mb="6" width="100%">
+        <Box width="100%">
           <Frame p="3" mb="0">
             <Heading as="h4" size="small" weight="semibold" mb="4">
               Saved Groups


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

- Renamed the feature approval-flow card heading from "Drafts and Approvals" to "Features".
- Added matching helper copy under the Saved Groups approval-flow card so both sections share the same heading/description structure.
- Tightened the spacing between the Features and Saved Groups approval-flow cards by removing the stacked card margins and using the standard settings gap scale.

### Dependencies

None.

### Testing

- `pnpm --filter front-end type-check`
- Manual browser verification at `http://localhost:3000/settings?tab=approval-flow#approval-flow` confirmed:
  - The first card heading says "Features".
  - The Saved Groups heading uses the same visual heading size/style.
  - The Saved Groups card includes the muted explanatory description below its heading.
  - The gap between the Features and Saved Groups cards is tightened to the standard settings spacing.

### Screenshots

[Approval flow settings tightened spacing](https://cursor.com/agents/bc-42927f5e-af2e-57fa-b5fe-ab849156f71e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapproval_flow_settings_tightened_spacing.webp)

[approval_flow_settings_tightened_spacing.mp4](https://cursor.com/agents/bc-42927f5e-af2e-57fa-b5fe-ab849156f71e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapproval_flow_settings_tightened_spacing.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/D0AM50FCKA4/p1773353152078359?thread_ts=1773353152.078359&cid=D0AM50FCKA4)

<div><a href="https://cursor.com/agents/bc-42927f5e-af2e-57fa-b5fe-ab849156f71e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42927f5e-af2e-57fa-b5fe-ab849156f71e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

