### PR TITLE
Gate saved group approvals by entitlement

### DIFF
--- a/packages/back-end/src/models/RevisionModel.ts
+++ b/packages/back-end/src/models/RevisionModel.ts
@@ -133,6 +133,8 @@ export class RevisionModel extends BaseClass {
     userId: string,
   ): { status?: Revision["status"]; resetEntry?: ActivityLogEntry } {
     if (existing.status !== "approved") return {};
+    if (!this.context.hasPremiumFeature("require-approvals")) return {};
+
     const settings = getApprovalFlowSettings(
       this.context.org.settings?.approvalFlows,
       existing.target.type,

--- a/packages/back-end/src/revisions/adapters/saved-group.adapter.ts
+++ b/packages/back-end/src/revisions/adapters/saved-group.adapter.ts
@@ -52,6 +52,13 @@ function canEditSavedGroup(
   return context.permissions.canUpdateSavedGroup(snapshot, {});
 }
 
+function isSavedGroupApprovalRequired(context: Context): boolean {
+  return (
+    context.hasPremiumFeature("require-approvals") &&
+    !!context.org.settings?.approvalFlows?.savedGroups?.[0]?.required
+  );
+}
+
 export const savedGroupAdapter: EntityRevisionAdapter<SavedGroupInterface> = {
   getModel(context: Context) {
     return context.models.savedGroups as {
@@ -74,9 +81,7 @@ export const savedGroupAdapter: EntityRevisionAdapter<SavedGroupInterface> = {
   },
 
   isRevisionRequired(context: Context): boolean {
-    return (
-      context.org.settings?.approvalFlows?.savedGroups?.[0]?.required || false
-    );
+    return isSavedGroupApprovalRequired(context);
   },
 
   getUpdatableFields(): ReadonlySet<string> {
@@ -104,9 +109,7 @@ export const savedGroupAdapter: EntityRevisionAdapter<SavedGroupInterface> = {
   },
 
   isApprovalRequired(context: Context): boolean {
-    return (
-      context.org.settings?.approvalFlows?.savedGroups?.[0]?.required || false
-    );
+    return isSavedGroupApprovalRequired(context);
   },
 
   // Per-revision gate: when the org has approval enabled but disabled the
@@ -115,6 +118,8 @@ export const savedGroupAdapter: EntityRevisionAdapter<SavedGroupInterface> = {
   // metadata-only autoPublish shortcut in PUT /saved-groups/:id so the
   // generic /revision/:id/merge endpoint reaches the same conclusion.
   isApprovalRequiredForRevision(context: Context, revision: Revision): boolean {
+    if (!context.hasPremiumFeature("require-approvals")) return false;
+
     const settings = getApprovalFlowSettings(
       context.org.settings?.approvalFlows,
       "saved-group",

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1603,24 +1603,13 @@ export async function putOrganization(
     const updates: Partial<OrganizationInterface> = {};
 
     const orig: Partial<OrganizationInterface> = {};
-    let sanitizedSettings = settings;
     if (
-      sanitizedSettings?.approvalFlows?.savedGroups?.[0]?.required &&
+      settings?.approvalFlows?.savedGroups?.[0]?.required &&
       !context.hasPremiumFeature("require-approvals")
     ) {
-      sanitizedSettings = {
-        ...sanitizedSettings,
-        approvalFlows: {
-          ...sanitizedSettings.approvalFlows,
-          savedGroups: [
-            {
-              ...sanitizedSettings.approvalFlows.savedGroups[0],
-              required: false,
-            },
-            ...sanitizedSettings.approvalFlows.savedGroups.slice(1),
-          ],
-        },
-      };
+      throw new Error(
+        "Saved Groups approval flows require the Require Approvals enterprise feature.",
+      );
     }
 
     if (name) {
@@ -1670,10 +1659,10 @@ export async function putOrganization(
       updates.externalId = externalId;
       orig.externalId = org.externalId;
     }
-    if (sanitizedSettings) {
+    if (settings) {
       updates.settings = {
         ...org.settings,
-        ...sanitizedSettings,
+        ...settings,
       };
       orig.settings = org.settings;
     }

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1543,6 +1543,16 @@ export async function signup(
   }
 }
 
+function settingsEnableFeatureApprovals(
+  settings: Partial<OrganizationSettings> | undefined,
+): boolean {
+  const requireReviews = settings?.requireReviews;
+  if (requireReviews === true) return true;
+  if (!Array.isArray(requireReviews)) return false;
+
+  return requireReviews.some((reviewSetting) => !!reviewSetting.requireReviewOn);
+}
+
 export async function putOrganization(
   req: AuthRequest<Partial<OrganizationInterface>>,
   res: Response,
@@ -1603,13 +1613,18 @@ export async function putOrganization(
     const updates: Partial<OrganizationInterface> = {};
 
     const orig: Partial<OrganizationInterface> = {};
-    if (
-      settings?.approvalFlows?.savedGroups?.[0]?.required &&
-      !context.hasPremiumFeature("require-approvals")
-    ) {
-      throw new Error(
-        "Saved Groups approval flows require the Require Approvals enterprise feature.",
-      );
+    if (!context.hasPremiumFeature("require-approvals")) {
+      if (settingsEnableFeatureApprovals(settings)) {
+        throw new Error(
+          "Feature approval flows require the Require Approvals enterprise feature.",
+        );
+      }
+
+      if (settings?.approvalFlows?.savedGroups?.[0]?.required) {
+        throw new Error(
+          "Saved Groups approval flows require the Require Approvals enterprise feature.",
+        );
+      }
     }
 
     if (name) {

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1603,6 +1603,25 @@ export async function putOrganization(
     const updates: Partial<OrganizationInterface> = {};
 
     const orig: Partial<OrganizationInterface> = {};
+    let sanitizedSettings = settings;
+    if (
+      sanitizedSettings?.approvalFlows?.savedGroups?.[0]?.required &&
+      !context.hasPremiumFeature("require-approvals")
+    ) {
+      sanitizedSettings = {
+        ...sanitizedSettings,
+        approvalFlows: {
+          ...sanitizedSettings.approvalFlows,
+          savedGroups: [
+            {
+              ...sanitizedSettings.approvalFlows.savedGroups[0],
+              required: false,
+            },
+            ...sanitizedSettings.approvalFlows.savedGroups.slice(1),
+          ],
+        },
+      };
+    }
 
     if (name) {
       updates.name = name;
@@ -1651,10 +1670,10 @@ export async function putOrganization(
       updates.externalId = externalId;
       orig.externalId = org.externalId;
     }
-    if (settings) {
+    if (sanitizedSettings) {
       updates.settings = {
         ...org.settings,
-        ...settings,
+        ...sanitizedSettings,
       };
       orig.settings = org.settings;
     }

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1550,7 +1550,9 @@ function settingsEnableFeatureApprovals(
   if (requireReviews === true) return true;
   if (!Array.isArray(requireReviews)) return false;
 
-  return requireReviews.some((reviewSetting) => !!reviewSetting.requireReviewOn);
+  return requireReviews.some(
+    (reviewSetting) => !!reviewSetting.requireReviewOn,
+  );
 }
 
 export async function putOrganization(

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1543,18 +1543,6 @@ export async function signup(
   }
 }
 
-function settingsEnableFeatureApprovals(
-  settings: Partial<OrganizationSettings> | undefined,
-): boolean {
-  const requireReviews = settings?.requireReviews;
-  if (requireReviews === true) return true;
-  if (!Array.isArray(requireReviews)) return false;
-
-  return requireReviews.some(
-    (reviewSetting) => !!reviewSetting.requireReviewOn,
-  );
-}
-
 export async function putOrganization(
   req: AuthRequest<Partial<OrganizationInterface>>,
   res: Response,
@@ -1616,13 +1604,7 @@ export async function putOrganization(
 
     const orig: Partial<OrganizationInterface> = {};
     if (!context.hasPremiumFeature("require-approvals")) {
-      if (settingsEnableFeatureApprovals(settings)) {
-        throw new Error(
-          "Feature approval flows require the Require Approvals enterprise feature.",
-        );
-      }
-
-      if (settings?.approvalFlows?.savedGroups?.[0]?.required) {
+      if (settings?.approvalFlows?.savedGroups?.some((sg) => sg?.required)) {
         throw new Error(
           "Saved Groups approval flows require the Require Approvals enterprise feature.",
         );

--- a/packages/back-end/src/routers/revision/revision.controller.ts
+++ b/packages/back-end/src/routers/revision/revision.controller.ts
@@ -486,6 +486,7 @@ export const postReview = async (
   // which means the existing author check above is the only effective guard.
   if (
     decision === "approve" &&
+    context.hasPremiumFeature("require-approvals") &&
     isUserBlockedFromApproving({
       approvalFlows: context.org.settings?.approvalFlows,
       entityType: existingRevision.target.type,

--- a/packages/back-end/test/revisions/saved-group.adapter.test.ts
+++ b/packages/back-end/test/revisions/saved-group.adapter.test.ts
@@ -43,6 +43,7 @@ const baseGroup: SavedGroupInterface = {
 // to avoid pulling the entire context surface into a unit test.
 function makeContext(overrides: {
   approvalRequired?: boolean;
+  hasRequireApprovals?: boolean;
   // When provided, controls the `requireMetadataReview` org setting. Defaults
   // to `undefined` (which behaves like the historical "true" default).
   requireMetadataReview?: boolean;
@@ -73,6 +74,10 @@ function makeContext(overrides: {
       },
     },
     permissions,
+    hasPremiumFeature: (feature: string) =>
+      feature === "require-approvals"
+        ? (overrides.hasRequireApprovals ?? true)
+        : false,
     models: {
       savedGroups: overrides.savedGroupsModel ?? {
         getById: jest.fn(),
@@ -180,10 +185,20 @@ describe("savedGroupAdapter", () => {
       expect(savedGroupAdapter.isApprovalRequired(ctx)).toBe(false);
     });
 
+    it("returns false when the org does not have the require-approvals feature", () => {
+      const ctx = makeContext({
+        approvalRequired: true,
+        hasRequireApprovals: false,
+      });
+      expect(savedGroupAdapter.isRevisionRequired(ctx)).toBe(false);
+      expect(savedGroupAdapter.isApprovalRequired(ctx)).toBe(false);
+    });
+
     it("returns false when settings are missing entirely", () => {
       const ctx = {
         org: { settings: undefined },
         permissions: {},
+        hasPremiumFeature: () => true,
         models: {},
       } as unknown as Context;
       expect(savedGroupAdapter.isRevisionRequired(ctx)).toBe(false);
@@ -212,6 +227,19 @@ describe("savedGroupAdapter", () => {
           buildRevision(metadataOnlyChanges),
         ),
       ).toBe(false);
+      expect(
+        savedGroupAdapter.isApprovalRequiredForRevision!(
+          ctx,
+          buildRevision(contentChanges),
+        ),
+      ).toBe(false);
+    });
+
+    it("returns false when approval settings are enabled but not licensed", () => {
+      const ctx = makeContext({
+        approvalRequired: true,
+        hasRequireApprovals: false,
+      });
       expect(
         savedGroupAdapter.isApprovalRequiredForRevision!(
           ctx,

--- a/packages/front-end/components/GeneralSettings/ApprovalFlowSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/ApprovalFlowSettings.tsx
@@ -11,7 +11,6 @@ import { OrganizationSettingsWithMetricDefaults } from "@/hooks/useOrganizationM
 import Frame from "@/ui/Frame";
 import Checkbox from "@/ui/Checkbox";
 import MultiSelectField from "@/components/Forms/MultiSelectField";
-import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
 import Link from "@/ui/Link";
 import PaidFeatureBadge from "@/components/GetStarted/PaidFeatureBadge";
 
@@ -82,9 +81,7 @@ export default function ApprovalFlowSettings() {
       <Flex gap="4">
         <Box width="220px" flexShrink="0">
           <Heading size="medium" as="h4">
-            <PremiumTooltip commercialFeature="require-approvals">
-              Approval Flows
-            </PremiumTooltip>
+            Approval Flows
           </Heading>
         </Box>
       </Flex>

--- a/packages/front-end/components/GeneralSettings/ApprovalFlowSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/ApprovalFlowSettings.tsx
@@ -12,7 +12,6 @@ import Frame from "@/ui/Frame";
 import Checkbox from "@/ui/Checkbox";
 import MultiSelectField from "@/components/Forms/MultiSelectField";
 import Link from "@/ui/Link";
-import PaidFeatureBadge from "@/components/GetStarted/PaidFeatureBadge";
 
 export default function ApprovalFlowSettings() {
   const form = useFormContext<OrganizationSettingsWithMetricDefaults>();
@@ -21,8 +20,6 @@ export default function ApprovalFlowSettings() {
   const { projects } = useDefinitions();
 
   const hasRequireApprovals = hasCommercialFeature("require-approvals");
-  const savedGroupApprovalRequired =
-    hasRequireApprovals && !!form.watch("approvalFlows.savedGroups.0.required");
 
   const rawRequireReviews = form.watch("requireReviews");
   const featureRequireReviews = Array.isArray(rawRequireReviews)
@@ -300,90 +297,83 @@ export default function ApprovalFlowSettings() {
               approvals adds a review step before any change goes live.
             </Text>
 
-            <Checkbox
-              id="toggle-require-approvals-saved-groups"
-              label={
-                <>
-                  Require approval to modify Saved Groups
-                  <PaidFeatureBadge
-                    commercialFeature="require-approvals"
-                    useTip={false}
-                    ml="2"
-                  />
-                </>
-              }
-              description="When enabled, all changes to Saved Groups must be reviewed and approved by another person before going live."
-              value={savedGroupApprovalRequired}
-              setValue={(v) => {
-                if (!hasRequireApprovals) return;
-                form.setValue("approvalFlows.savedGroups.0.required", v);
-              }}
-              disabled={!hasRequireApprovals}
-            />
-            {savedGroupApprovalRequired && (
-              <Flex direction="column" gap="3" mt="2" ml="5">
-                <Box mt="2">
-                  <Text as="label" size="medium" weight="semibold" mb="2">
-                    Require approval for
-                  </Text>
-                  <Flex direction="column" gap="2" align="start">
+            {hasRequireApprovals && (
+              <>
+                <Checkbox
+                  id="toggle-require-approvals-saved-groups"
+                  label="Require approval to modify Saved Groups"
+                  description="When enabled, all changes to Saved Groups must be reviewed and approved by another person before going live."
+                  value={!!form.watch("approvalFlows.savedGroups.0.required")}
+                  setValue={(v) =>
+                    form.setValue("approvalFlows.savedGroups.0.required", v)
+                  }
+                />
+                {!!form.watch("approvalFlows.savedGroups.0.required") && (
+                  <Flex direction="column" gap="3" mt="2" ml="5">
+                    <Box mt="2">
+                      <Text as="label" size="medium" weight="semibold" mb="2">
+                        Require approval for
+                      </Text>
+                      <Flex direction="column" gap="2" align="start">
+                        <Checkbox
+                          id="toggle-saved-group-values-conditions"
+                          label="Values and conditions"
+                          value={true}
+                          disabled={true}
+                          setValue={() => undefined}
+                        />
+                        <Checkbox
+                          id="toggle-saved-group-metadata-review"
+                          label="Metadata changes (description, owner, project, tags, etc.)"
+                          value={
+                            form.watch(
+                              `approvalFlows.savedGroups.0.requireMetadataReview`,
+                            ) !== false
+                          }
+                          setValue={(v) =>
+                            form.setValue(
+                              `approvalFlows.savedGroups.0.requireMetadataReview`,
+                              v,
+                            )
+                          }
+                        />
+                      </Flex>
+                    </Box>
                     <Checkbox
-                      id="toggle-saved-group-values-conditions"
-                      label="Values and conditions"
-                      value={true}
-                      disabled={true}
-                      setValue={() => undefined}
-                    />
-                    <Checkbox
-                      id="toggle-saved-group-metadata-review"
-                      label="Metadata changes (description, owner, project, tags, etc.)"
+                      id="toggle-saved-group-reset-review-on-change"
+                      label="Reset review on changes"
+                      description="If a draft is modified after being approved, the approval is revoked and a new review is required before publishing."
                       value={
-                        form.watch(
-                          `approvalFlows.savedGroups.0.requireMetadataReview`,
-                        ) !== false
+                        !!form.watch(
+                          `approvalFlows.savedGroups.0.resetReviewOnChange`,
+                        )
                       }
                       setValue={(v) =>
                         form.setValue(
-                          `approvalFlows.savedGroups.0.requireMetadataReview`,
+                          `approvalFlows.savedGroups.0.resetReviewOnChange`,
+                          v,
+                        )
+                      }
+                    />
+                    <Checkbox
+                      id="toggle-saved-group-block-self-approval"
+                      label="Require approval from a non-editor"
+                      description="Anyone who edited the draft is blocked from approving it. A separate reviewer must approve before publishing."
+                      value={
+                        !!form.watch(
+                          `approvalFlows.savedGroups.0.blockSelfApproval`,
+                        )
+                      }
+                      setValue={(v) =>
+                        form.setValue(
+                          `approvalFlows.savedGroups.0.blockSelfApproval`,
                           v,
                         )
                       }
                     />
                   </Flex>
-                </Box>
-                <Checkbox
-                  id="toggle-saved-group-reset-review-on-change"
-                  label="Reset review on changes"
-                  description="If a draft is modified after being approved, the approval is revoked and a new review is required before publishing."
-                  value={
-                    !!form.watch(
-                      `approvalFlows.savedGroups.0.resetReviewOnChange`,
-                    )
-                  }
-                  setValue={(v) =>
-                    form.setValue(
-                      `approvalFlows.savedGroups.0.resetReviewOnChange`,
-                      v,
-                    )
-                  }
-                />
-                <Checkbox
-                  id="toggle-saved-group-block-self-approval"
-                  label="Require approval from a non-editor"
-                  description="Anyone who edited the draft is blocked from approving it. A separate reviewer must approve before publishing."
-                  value={
-                    !!form.watch(
-                      `approvalFlows.savedGroups.0.blockSelfApproval`,
-                    )
-                  }
-                  setValue={(v) =>
-                    form.setValue(
-                      `approvalFlows.savedGroups.0.blockSelfApproval`,
-                      v,
-                    )
-                  }
-                />
-              </Flex>
+                )}
+              </>
             )}
           </Frame>
         </Box>

--- a/packages/front-end/components/GeneralSettings/ApprovalFlowSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/ApprovalFlowSettings.tsx
@@ -21,6 +21,9 @@ export default function ApprovalFlowSettings() {
   const { projects } = useDefinitions();
 
   const hasRequireApprovals = hasCommercialFeature("require-approvals");
+  const savedGroupApprovalRequired =
+    hasRequireApprovals &&
+    !!form.watch("approvalFlows.savedGroups.0.required");
 
   const rawRequireReviews = form.watch("requireReviews");
   const featureRequireReviews = Array.isArray(rawRequireReviews)
@@ -302,15 +305,20 @@ export default function ApprovalFlowSettings() {
 
             <Checkbox
               id="toggle-require-approvals-saved-groups"
-              label="Require approval to modify Saved Groups"
-              description="When enabled, all changes to Saved Groups must be reviewed and approved by another person before going live."
-              value={!!form.watch("approvalFlows.savedGroups.0.required")}
-              setValue={(v) =>
-                form.setValue("approvalFlows.savedGroups.0.required", v)
+              label={
+                <PremiumTooltip commercialFeature="require-approvals">
+                  Require approval to modify Saved Groups
+                </PremiumTooltip>
               }
+              description="When enabled, all changes to Saved Groups must be reviewed and approved by another person before going live."
+              value={savedGroupApprovalRequired}
+              setValue={(v) => {
+                if (!hasRequireApprovals) return;
+                form.setValue("approvalFlows.savedGroups.0.required", v);
+              }}
               disabled={!hasRequireApprovals}
             />
-            {!!form.watch("approvalFlows.savedGroups.0.required") && (
+            {savedGroupApprovalRequired && (
               <Flex direction="column" gap="3" mt="2" ml="5">
                 <Box mt="2">
                   <Text as="label" size="medium" weight="semibold" mb="2">

--- a/packages/front-end/components/GeneralSettings/ApprovalFlowSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/ApprovalFlowSettings.tsx
@@ -28,9 +28,6 @@ export default function ApprovalFlowSettings() {
   const featureRequireReviews = Array.isArray(rawRequireReviews)
     ? rawRequireReviews
     : [];
-  const displayedFeatureRequireReviews = featureRequireReviews.length
-    ? featureRequireReviews
-    : [{}];
 
   const [showProjectScope, setShowProjectScope] = useState<
     Record<number, boolean>
@@ -100,36 +97,24 @@ export default function ApprovalFlowSettings() {
               settings.
             </Text>
 
-            <>
-              {displayedFeatureRequireReviews.map((_, i) => {
-                const featureApprovalRequired =
-                  hasRequireApprovals &&
-                  !!form.watch(`requireReviews.${i}.requireReviewOn`);
-                return (
+            {hasRequireApprovals && (
+              <>
+                {featureRequireReviews.map((_, i) => (
                   <Box key={`approval-flow-${i}`}>
                     <Checkbox
                       id={`toggle-require-reviews-${i}`}
-                      label={
-                        <>
-                          Require approval to publish changes
-                          <PaidFeatureBadge
-                            commercialFeature="require-approvals"
-                            useTip={false}
-                            ml="2"
-                          />
-                        </>
+                      label="Require approval to publish changes"
+                      value={
+                        !!form.watch(`requireReviews.${i}.requireReviewOn`)
                       }
-                      value={featureApprovalRequired}
-                      setValue={(value) => {
-                        if (!hasRequireApprovals) return;
+                      setValue={(value) =>
                         form.setValue(
                           `requireReviews.${i}.requireReviewOn`,
                           value,
-                        );
-                      }}
-                      disabled={!hasRequireApprovals}
+                        )
+                      }
                     />
-                    {featureApprovalRequired && (
+                    {!!form.watch(`requireReviews.${i}.requireReviewOn`) && (
                       <Flex direction="column" gap="3" mt="2" ml="5">
                         <Flex direction="column" gap="3" mb="3">
                           {showProjectScope[i] ? (
@@ -298,9 +283,9 @@ export default function ApprovalFlowSettings() {
                       </Flex>
                     )}
                   </Box>
-                );
-              })}
-            </>
+                ))}
+              </>
+            )}
           </Frame>
         </Box>
 

--- a/packages/front-end/components/GeneralSettings/ApprovalFlowSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/ApprovalFlowSettings.tsx
@@ -29,6 +29,9 @@ export default function ApprovalFlowSettings() {
   const featureRequireReviews = Array.isArray(rawRequireReviews)
     ? rawRequireReviews
     : [];
+  const displayedFeatureRequireReviews = featureRequireReviews.length
+    ? featureRequireReviews
+    : [{}];
 
   const [showProjectScope, setShowProjectScope] = useState<
     Record<number, boolean>
@@ -100,24 +103,31 @@ export default function ApprovalFlowSettings() {
               settings.
             </Text>
 
-            {hasRequireApprovals && (
-              <>
-                {featureRequireReviews.map((_, i) => (
+            <>
+              {displayedFeatureRequireReviews.map((_, i) => {
+                const featureApprovalRequired =
+                  hasRequireApprovals &&
+                  !!form.watch(`requireReviews.${i}.requireReviewOn`);
+                return (
                   <Box key={`approval-flow-${i}`}>
                     <Checkbox
                       id={`toggle-require-reviews-${i}`}
-                      label="Require approval to publish changes"
-                      value={
-                        !!form.watch(`requireReviews.${i}.requireReviewOn`)
+                      label={
+                        <PremiumTooltip commercialFeature="require-approvals">
+                          Require approval to publish changes
+                        </PremiumTooltip>
                       }
-                      setValue={(value) =>
+                      value={featureApprovalRequired}
+                      setValue={(value) => {
+                        if (!hasRequireApprovals) return;
                         form.setValue(
                           `requireReviews.${i}.requireReviewOn`,
                           value,
-                        )
-                      }
+                        );
+                      }}
+                      disabled={!hasRequireApprovals}
                     />
-                    {!!form.watch(`requireReviews.${i}.requireReviewOn`) && (
+                    {featureApprovalRequired && (
                       <Flex direction="column" gap="3" mt="2" ml="5">
                         <Flex direction="column" gap="3" mb="3">
                           {showProjectScope[i] ? (
@@ -286,9 +296,9 @@ export default function ApprovalFlowSettings() {
                       </Flex>
                     )}
                   </Box>
-                ))}
-              </>
-            )}
+                );
+              })}
+            </>
           </Frame>
         </Box>
 

--- a/packages/front-end/components/GeneralSettings/ApprovalFlowSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/ApprovalFlowSettings.tsx
@@ -111,11 +111,7 @@ export default function ApprovalFlowSettings() {
                   <Box key={`approval-flow-${i}`}>
                     <Checkbox
                       id={`toggle-require-reviews-${i}`}
-                      label={
-                        <PremiumTooltip commercialFeature="require-approvals">
-                          Require approval to publish changes
-                        </PremiumTooltip>
-                      }
+                      label="Require approval to publish changes"
                       value={featureApprovalRequired}
                       setValue={(value) => {
                         if (!hasRequireApprovals) return;
@@ -314,11 +310,7 @@ export default function ApprovalFlowSettings() {
 
             <Checkbox
               id="toggle-require-approvals-saved-groups"
-              label={
-                <PremiumTooltip commercialFeature="require-approvals">
-                  Require approval to modify Saved Groups
-                </PremiumTooltip>
-              }
+              label="Require approval to modify Saved Groups"
               description="When enabled, all changes to Saved Groups must be reviewed and approved by another person before going live."
               value={savedGroupApprovalRequired}
               setValue={(v) => {

--- a/packages/front-end/components/GeneralSettings/ApprovalFlowSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/ApprovalFlowSettings.tsx
@@ -22,8 +22,7 @@ export default function ApprovalFlowSettings() {
 
   const hasRequireApprovals = hasCommercialFeature("require-approvals");
   const savedGroupApprovalRequired =
-    hasRequireApprovals &&
-    !!form.watch("approvalFlows.savedGroups.0.required");
+    hasRequireApprovals && !!form.watch("approvalFlows.savedGroups.0.required");
 
   const rawRequireReviews = form.watch("requireReviews");
   const featureRequireReviews = Array.isArray(rawRequireReviews)

--- a/packages/front-end/components/GeneralSettings/ApprovalFlowSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/ApprovalFlowSettings.tsx
@@ -13,6 +13,7 @@ import Checkbox from "@/ui/Checkbox";
 import MultiSelectField from "@/components/Forms/MultiSelectField";
 import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
 import Link from "@/ui/Link";
+import PaidFeatureBadge from "@/components/GetStarted/PaidFeatureBadge";
 
 export default function ApprovalFlowSettings() {
   const form = useFormContext<OrganizationSettingsWithMetricDefaults>();
@@ -111,7 +112,16 @@ export default function ApprovalFlowSettings() {
                   <Box key={`approval-flow-${i}`}>
                     <Checkbox
                       id={`toggle-require-reviews-${i}`}
-                      label="Require approval to publish changes"
+                      label={
+                        <>
+                          Require approval to publish changes
+                          <PaidFeatureBadge
+                            commercialFeature="require-approvals"
+                            useTip={false}
+                            ml="2"
+                          />
+                        </>
+                      }
                       value={featureApprovalRequired}
                       setValue={(value) => {
                         if (!hasRequireApprovals) return;
@@ -310,7 +320,16 @@ export default function ApprovalFlowSettings() {
 
             <Checkbox
               id="toggle-require-approvals-saved-groups"
-              label="Require approval to modify Saved Groups"
+              label={
+                <>
+                  Require approval to modify Saved Groups
+                  <PaidFeatureBadge
+                    commercialFeature="require-approvals"
+                    useTip={false}
+                    ml="2"
+                  />
+                </>
+              }
               description="When enabled, all changes to Saved Groups must be reviewed and approved by another person before going live."
               value={savedGroupApprovalRequired}
               setValue={(v) => {

--- a/packages/front-end/components/Revision/RevisionDetail.tsx
+++ b/packages/front-end/components/Revision/RevisionDetail.tsx
@@ -55,7 +55,13 @@ function RevisionDetail<T>({
   requiresApproval = true,
   closeModal,
 }: RevisionDetailProps<T>) {
-  const { getUserDisplay, userId, user, organization } = useUser();
+  const {
+    getUserDisplay,
+    userId,
+    user,
+    organization,
+    hasCommercialFeature,
+  } = useUser();
   const { apiCall } = useAuth();
   const [bypassApproval, setBypassApproval] = useState(false);
   const [confirmReopen, setConfirmReopen] = useState(false);
@@ -168,6 +174,7 @@ function RevisionDetail<T>({
   const isRevisionAuthor = !!userId && revision.authorId === userId;
   const isBlockedContributor =
     !!userId &&
+    hasCommercialFeature("require-approvals") &&
     isUserBlockedFromApproving({
       approvalFlows: organization?.settings?.approvalFlows,
       entityType: revision.target.type,

--- a/packages/front-end/components/Revision/RevisionDetail.tsx
+++ b/packages/front-end/components/Revision/RevisionDetail.tsx
@@ -55,13 +55,8 @@ function RevisionDetail<T>({
   requiresApproval = true,
   closeModal,
 }: RevisionDetailProps<T>) {
-  const {
-    getUserDisplay,
-    userId,
-    user,
-    organization,
-    hasCommercialFeature,
-  } = useUser();
+  const { getUserDisplay, userId, user, organization, hasCommercialFeature } =
+    useUser();
   const { apiCall } = useAuth();
   const [bypassApproval, setBypassApproval] = useState(false);
   const [confirmReopen, setConfirmReopen] = useState(false);

--- a/packages/front-end/hooks/useOrgSettings.ts
+++ b/packages/front-end/hooks/useOrgSettings.ts
@@ -1,11 +1,30 @@
 import { AGREEMENT_TYPE_AI } from "shared/validators";
+import { DEFAULT_REVISION_CONFIGURATION } from "shared/constants";
 import { useUser } from "@/services/UserContext";
 import { isCloud, hasAnyAIKey } from "@/services/env";
 
 export default function useOrgSettings() {
   const { settings, hasCommercialFeature } = useUser();
   if (!hasCommercialFeature("require-approvals") && settings) {
-    return { ...settings, requireReviews: [] };
+    if (!settings.approvalFlows) return { ...settings, requireReviews: [] };
+
+    const savedGroupApprovalFlow =
+      settings.approvalFlows.savedGroups?.[0] ??
+      DEFAULT_REVISION_CONFIGURATION.savedGroups[0];
+    return {
+      ...settings,
+      requireReviews: [],
+      approvalFlows: {
+        ...settings.approvalFlows,
+        savedGroups: [
+          {
+            ...savedGroupApprovalFlow,
+            required: false,
+          },
+          ...(settings.approvalFlows.savedGroups?.slice(1) ?? []),
+        ],
+      },
+    };
   }
   return settings;
 }

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -15,6 +15,7 @@ import {
   DEFAULT_DECISION_FRAMEWORK_ENABLED,
   DEFAULT_REQUIRE_PROJECT_FOR_FEATURES,
   DEFAULT_POST_STRATIFICATION_ENABLED,
+  DEFAULT_REVISION_CONFIGURATION,
 } from "shared/constants";
 import { DEFAULT_MAX_METRIC_SLICE_LEVELS } from "shared/settings";
 import { OrganizationSettings } from "shared/types/organization";
@@ -63,6 +64,28 @@ function hasChanges(
   return !isEqual(value, existing);
 }
 
+function applyApprovalFlowEntitlements(
+  approvalFlows: OrganizationSettings["approvalFlows"],
+  hasRequireApprovals: boolean,
+): OrganizationSettings["approvalFlows"] {
+  if (hasRequireApprovals || !approvalFlows) return approvalFlows;
+
+  const savedGroupApprovalFlow =
+    approvalFlows?.savedGroups?.[0] ??
+    DEFAULT_REVISION_CONFIGURATION.savedGroups[0];
+
+  return {
+    ...approvalFlows,
+    savedGroups: [
+      {
+        ...savedGroupApprovalFlow,
+        required: false,
+      },
+      ...(approvalFlows.savedGroups?.slice(1) ?? []),
+    ],
+  };
+}
+
 const GeneralSettingsPage = (): React.ReactElement => {
   const { refreshOrganization, settings, organization, hasCommercialFeature } =
     useUser();
@@ -75,6 +98,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
   const displayCurrency = useCurrency();
 
   const hasStickyBucketFeature = hasCommercialFeature("sticky-bucketing");
+  const hasRequireApprovals = hasCommercialFeature("require-approvals");
 
   const promptForm = useForm();
 
@@ -187,7 +211,10 @@ const GeneralSettingsPage = (): React.ReactElement => {
       postStratificationEnabled:
         settings.postStratificationEnabled ??
         DEFAULT_POST_STRATIFICATION_ENABLED,
-      approvalFlows: settings.approvalFlows,
+      approvalFlows: applyApprovalFlowEntitlements(
+        settings.approvalFlows,
+        hasRequireApprovals,
+      ),
     },
   });
   const { apiCall } = useAuth();
@@ -287,6 +314,11 @@ const GeneralSettingsPage = (): React.ReactElement => {
                 }
               : {}),
           };
+        } else if (k === "approvalFlows") {
+          newVal.approvalFlows = applyApprovalFlowEntitlements(
+            settings?.approvalFlows,
+            hasRequireApprovals,
+          );
         } else {
           newVal[k] = settings?.[k] || newVal[k];
         }
@@ -358,6 +390,10 @@ const GeneralSettingsPage = (): React.ReactElement => {
       multipleExposureMinPercent:
         (value.multipleExposureMinPercent ?? 0.01) / 100,
       preferredEnvironment: value.preferredEnvironment || null,
+      approvalFlows: applyApprovalFlowEntitlements(
+        value.approvalFlows,
+        hasRequireApprovals,
+      ),
     };
 
     // Make sure the feature key example is valid

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -86,13 +86,6 @@ function applyApprovalFlowEntitlements(
   };
 }
 
-function applyRequireReviewEntitlements(
-  requireReviews: OrganizationSettings["requireReviews"],
-  hasRequireApprovals: boolean,
-): OrganizationSettings["requireReviews"] {
-  return hasRequireApprovals ? requireReviews : [];
-}
-
 const GeneralSettingsPage = (): React.ReactElement => {
   const { refreshOrganization, settings, organization, hasCommercialFeature } =
     useUser();
@@ -157,19 +150,16 @@ const GeneralSettingsPage = (): React.ReactElement => {
       displayCurrency,
       secureAttributeSalt: "",
       killswitchConfirmation: false,
-      requireReviews: applyRequireReviewEntitlements(
-        [
-          {
-            requireReviewOn: false,
-            resetReviewOnChange: false,
-            environments: [],
-            projects: [],
-            featureRequireEnvironmentReview: true,
-            featureRequireMetadataReview: true,
-          },
-        ],
-        hasRequireApprovals,
-      ),
+      requireReviews: [
+        {
+          requireReviewOn: false,
+          resetReviewOnChange: false,
+          environments: [],
+          projects: [],
+          featureRequireEnvironmentReview: true,
+          featureRequireMetadataReview: true,
+        },
+      ],
       restApiBypassesReviews: settings.restApiBypassesReviews ?? false,
       defaultDataSource: settings.defaultDataSource || "",
       testQueryDays: DEFAULT_TEST_QUERY_DAYS,
@@ -324,11 +314,6 @@ const GeneralSettingsPage = (): React.ReactElement => {
                 }
               : {}),
           };
-        } else if (k === "requireReviews") {
-          newVal.requireReviews = applyRequireReviewEntitlements(
-            settings?.requireReviews,
-            hasRequireApprovals,
-          );
         } else if (k === "approvalFlows") {
           newVal.approvalFlows = applyApprovalFlowEntitlements(
             settings?.approvalFlows,
@@ -364,7 +349,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
         );
       }
     }
-  }, [settings]);
+  }, [settings, hasRequireApprovals]);
 
   useEffect(() => {
     form.setValue(
@@ -407,10 +392,6 @@ const GeneralSettingsPage = (): React.ReactElement => {
       preferredEnvironment: value.preferredEnvironment || null,
       approvalFlows: applyApprovalFlowEntitlements(
         value.approvalFlows,
-        hasRequireApprovals,
-      ),
-      requireReviews: applyRequireReviewEntitlements(
-        value.requireReviews,
         hasRequireApprovals,
       ),
     };

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -86,6 +86,13 @@ function applyApprovalFlowEntitlements(
   };
 }
 
+function applyRequireReviewEntitlements(
+  requireReviews: OrganizationSettings["requireReviews"],
+  hasRequireApprovals: boolean,
+): OrganizationSettings["requireReviews"] {
+  return hasRequireApprovals ? requireReviews : [];
+}
+
 const GeneralSettingsPage = (): React.ReactElement => {
   const { refreshOrganization, settings, organization, hasCommercialFeature } =
     useUser();
@@ -150,16 +157,19 @@ const GeneralSettingsPage = (): React.ReactElement => {
       displayCurrency,
       secureAttributeSalt: "",
       killswitchConfirmation: false,
-      requireReviews: [
-        {
-          requireReviewOn: false,
-          resetReviewOnChange: false,
-          environments: [],
-          projects: [],
-          featureRequireEnvironmentReview: true,
-          featureRequireMetadataReview: true,
-        },
-      ],
+      requireReviews: applyRequireReviewEntitlements(
+        [
+          {
+            requireReviewOn: false,
+            resetReviewOnChange: false,
+            environments: [],
+            projects: [],
+            featureRequireEnvironmentReview: true,
+            featureRequireMetadataReview: true,
+          },
+        ],
+        hasRequireApprovals,
+      ),
       restApiBypassesReviews: settings.restApiBypassesReviews ?? false,
       defaultDataSource: settings.defaultDataSource || "",
       testQueryDays: DEFAULT_TEST_QUERY_DAYS,
@@ -314,6 +324,11 @@ const GeneralSettingsPage = (): React.ReactElement => {
                 }
               : {}),
           };
+        } else if (k === "requireReviews") {
+          newVal.requireReviews = applyRequireReviewEntitlements(
+            settings?.requireReviews,
+            hasRequireApprovals,
+          );
         } else if (k === "approvalFlows") {
           newVal.approvalFlows = applyApprovalFlowEntitlements(
             settings?.approvalFlows,
@@ -392,6 +407,10 @@ const GeneralSettingsPage = (): React.ReactElement => {
       preferredEnvironment: value.preferredEnvironment || null,
       approvalFlows: applyApprovalFlowEntitlements(
         value.approvalFlows,
+        hasRequireApprovals,
+      ),
+      requireReviews: applyRequireReviewEntitlements(
+        value.requireReviews,
         hasRequireApprovals,
       ),
     };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

- Show disabled checkbox controls with Enterprise badges beside the labels for non-entitled orgs in both approval-flow cards:
  - Features: `Require approval to publish changes`
  - Saved Groups: `Require approval to modify Saved Groups`
- Prevent those disabled controls from mutating form state or revealing nested approval options when the org lacks `require-approvals`.
- Sanitize feature and saved-group approval-flow settings on settings load/save for orgs without the `require-approvals` entitlement so the UI cannot submit enabled approval values.
- Gate direct backend settings updates: attempts to enable either Feature approval flows or Saved Groups approval flows without the `require-approvals` entitlement now return an error.
- Keep Saved Groups revision tracking/auto-merge behavior intact when approval flows are not entitled.
- Keep contributor approval/reset behavior gated behind the same entitlement.

### Dependencies

None.

### Testing

- `pnpm lint:ci`
- `pnpm --filter front-end type-check`
- `pnpm --filter back-end type-check`
- `pnpm --filter back-end test test/revisions/saved-group.adapter.test.ts`
- Direct backend verification with authenticated `PUT /organization` requests on a non-enterprise/local org confirmed:
  - `requireReviews[0].requireReviewOn: true` returns `400` with `Feature approval flows require the Require Approvals enterprise feature.`
  - `approvalFlows.savedGroups[0].required: true` returns `400` with `Saved Groups approval flows require the Require Approvals enterprise feature.`
- Manual browser verification at `http://localhost:3000/settings?tab=approval-flow#approval-flow` confirmed both the Feature and Saved Groups approval toggles render as actual disabled checkbox controls with Enterprise badges beside their label text, clicking either checkbox does not enable it, and nested approval options are not revealed.

### Screenshots

[Disabled approval checkboxes with Enterprise badges](https://cursor.com/agents/bc-42927f5e-af2e-57fa-b5fe-ab849156f71e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdisabled_approval_checkboxes_with_badges.webp)

[disabled_approval_checkboxes_with_badges.mp4](https://cursor.com/agents/bc-42927f5e-af2e-57fa-b5fe-ab849156f71e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdisabled_approval_checkboxes_with_badges.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/D0AM50FCKA4/p1773353152078359?thread_ts=1773353152.078359&cid=D0AM50FCKA4)

<div><a href="https://cursor.com/agents/bc-42927f5e-af2e-57fa-b5fe-ab849156f71e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42927f5e-af2e-57fa-b5fe-ab849156f71e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

