### PR TITLE
Fix dropdown not closing when clicking menu item with onClick handler

### DIFF
--- a/packages/front-end/ui/DropdownMenu.tsx
+++ b/packages/front-end/ui/DropdownMenu.tsx
@@ -278,11 +278,13 @@ export function DropdownMenuItem({
           setLoading(true);
           try {
             await onClick(event);
+            setLoading(false);
+            closeDropdown?.();
           } catch (e) {
             setError(e.message);
             console.error(e);
+            setLoading(false);
           }
-          setLoading(false);
         }
       }}
       color={color}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

Fixed an issue where clicking "Import Existing Experiment" (and other dropdown menu items with onClick handlers) from the experiments list dropdown would not close the dropdown when opening the modal.

**Root cause:** The `DropdownMenuItem` component in `packages/front-end/ui/DropdownMenu.tsx` was calling `event.preventDefault()` to prevent the Radix dropdown from auto-closing, but it wasn't explicitly closing the dropdown after the onClick handler completed. Items with `confirmation` modals correctly called `closeDropdown()` when the modal closed, but regular onClick handlers did not.

**Fix:** After a successful `onClick` execution, the component now calls `closeDropdown?.()` to close the dropdown. On error, the dropdown stays open so the error state can be displayed to the user.

### Dependencies

None

### Testing

1. Navigate to the Experiments list page (`/experiments`)
2. Click the "Add" button to open the dropdown
3. Click "Import Existing Experiment"
4. Verify the dropdown closes when the Import modal opens

The fix applies to all `DropdownMenuItem` components with onClick handlers throughout the application.

### Screenshots

**Dropdown open (before clicking):**

[Dropdown menu open showing both Create New Experiment and Import Existing Experiment options](https://cursor.com/agents/bc-c1ce07bf-c6b6-53a0-a3f5-5fbb366fee22/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdropdown_open.webp)

**After clicking "Import Existing Experiment" - dropdown closes:**

[Dropdown closed after clicking Import Existing Experiment](https://cursor.com/agents/bc-c1ce07bf-c6b6-53a0-a3f5-5fbb366fee22/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdropdown_closed_after_click.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C07NK4F016Z/p1779141108801139?thread_ts=1779141108.801139&cid=C07NK4F016Z)

<div><a href="https://cursor.com/agents/bc-c1ce07bf-c6b6-53a0-a3f5-5fbb366fee22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1ce07bf-c6b6-53a0-a3f5-5fbb366fee22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

