### PR TITLE
Add GrowthBook error tracking plugin to sdk-js

### DIFF
--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -9,6 +9,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./dist/index.d.ts",
       "import": {
         "types": "./dist/index.d.ts",
         "default": "./dist/esm/index.mjs"
@@ -19,6 +20,7 @@
       }
     },
     "./plugins": {
+      "types": "./dist/plugins/index.d.ts",
       "import": {
         "types": "./dist/plugins/index.d.ts",
         "default": "./dist/esm/plugins/index.mjs"
@@ -26,6 +28,17 @@
       "require": {
         "types": "./dist/plugins/index.d.ts",
         "default": "./dist/cjs/plugins/index.js"
+      }
+    },
+    "./plugins/growthbook-error-tracking": {
+      "types": "./dist/plugins/growthbook-error-tracking.d.ts",
+      "import": {
+        "types": "./dist/plugins/growthbook-error-tracking.d.ts",
+        "default": "./dist/esm/plugins/growthbook-error-tracking.mjs"
+      },
+      "require": {
+        "types": "./dist/plugins/growthbook-error-tracking.d.ts",
+        "default": "./dist/cjs/plugins/growthbook-error-tracking.js"
       }
     }
   },

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -9,7 +9,6 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "types": "./dist/index.d.ts",
       "import": {
         "types": "./dist/index.d.ts",
         "default": "./dist/esm/index.mjs"
@@ -28,17 +27,6 @@
       "require": {
         "types": "./dist/plugins/index.d.ts",
         "default": "./dist/cjs/plugins/index.js"
-      }
-    },
-    "./plugins/growthbook-error-tracking": {
-      "types": "./dist/plugins/growthbook-error-tracking.d.ts",
-      "import": {
-        "types": "./dist/plugins/growthbook-error-tracking.d.ts",
-        "default": "./dist/esm/plugins/growthbook-error-tracking.mjs"
-      },
-      "require": {
-        "types": "./dist/plugins/growthbook-error-tracking.d.ts",
-        "default": "./dist/cjs/plugins/growthbook-error-tracking.js"
       }
     }
   },

--- a/packages/sdk-js/src/GrowthBookClient.ts
+++ b/packages/sdk-js/src/GrowthBookClient.ts
@@ -379,6 +379,8 @@ export class UserScopedGrowthBook<
 > {
   private _gb: GrowthBookClient;
   private _userContext: UserContext;
+  private _destroyed?: boolean;
+  private _destroyCallbacks: Array<() => void>;
   public logs: Array<LogUnion>;
 
   constructor(
@@ -388,6 +390,7 @@ export class UserScopedGrowthBook<
   ) {
     this._gb = gb;
     this._userContext = userContext;
+    this._destroyCallbacks = [];
     this.logs = [];
 
     this._userContext.trackedExperiments =
@@ -401,6 +404,26 @@ export class UserScopedGrowthBook<
         plugin(this);
       }
     }
+  }
+
+  public onDestroy(cb: () => void) {
+    this._destroyCallbacks.push(cb);
+  }
+
+  public isDestroyed() {
+    return !!this._destroyed;
+  }
+
+  public destroy() {
+    this._destroyed = true;
+    this._destroyCallbacks.forEach((cb) => {
+      try {
+        cb();
+      } catch (e) {
+        console.error(e);
+      }
+    });
+    this._destroyCallbacks = [];
   }
 
   public runInlineExperiment<T>(experiment: Experiment<T>): Result<T> {

--- a/packages/sdk-js/src/core.ts
+++ b/packages/sdk-js/src/core.ts
@@ -35,6 +35,8 @@ import { StickyBucketService } from "./sticky-bucket-service";
 
 export const EVENT_FEATURE_EVALUATED = "Feature Evaluated";
 export const EVENT_EXPERIMENT_VIEWED = "Experiment Viewed";
+/** Managed warehouse / ClickHouse `errors` table — requires `growthbookTrackingPlugin`. */
+export const EVENT_GROWTHBOOK_ERROR = "GrowthBook Error";
 
 function getForcedFeatureValues(ctx: EvalContext) {
   // Merge user and global values

--- a/packages/sdk-js/src/index.ts
+++ b/packages/sdk-js/src/index.ts
@@ -99,4 +99,14 @@ export {
   paddedVersionString,
 } from "./util";
 
-export { EVENT_EXPERIMENT_VIEWED, EVENT_FEATURE_EVALUATED } from "./core";
+export {
+  EVENT_EXPERIMENT_VIEWED,
+  EVENT_FEATURE_EVALUATED,
+  EVENT_GROWTHBOOK_ERROR,
+} from "./core";
+
+export {
+  buildErrorEventProperties,
+  captureGrowthBookError,
+  growthbookErrorTrackingPlugin,
+} from "./plugins/growthbook-error-tracking";

--- a/packages/sdk-js/src/index.ts
+++ b/packages/sdk-js/src/index.ts
@@ -104,9 +104,3 @@ export {
   EVENT_FEATURE_EVALUATED,
   EVENT_GROWTHBOOK_ERROR,
 } from "./core";
-
-export {
-  buildErrorEventProperties,
-  captureGrowthBookError,
-  growthbookErrorTrackingPlugin,
-} from "./plugins/growthbook-error-tracking";

--- a/packages/sdk-js/src/plugins/growthbook-error-tracking.ts
+++ b/packages/sdk-js/src/plugins/growthbook-error-tracking.ts
@@ -125,7 +125,7 @@ export function growthbookComposedError(
 export function normalizeErrorMessageForFingerprint(message: string): string {
   let normalized = message.trim();
   normalized = normalized.replace(
-    /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi,
+    /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
     "{uuid}",
   );
   normalized = normalized.replace(/\b0x[0-9a-f]+\b/gi, "{hex}");
@@ -229,10 +229,12 @@ export type BuiltErrorEventProps = {
   handled?: boolean;
 };
 
-export function buildErrorEventProperties(
-  error: unknown,
-  extras?: Record<string, unknown>,
-): BuiltErrorEventProps & Record<string, unknown> {
+type ParsedErrorCore = Pick<
+  BuiltErrorEventProps,
+  "fingerprint" | "title" | "message" | "stack" | "stackFrames"
+>;
+
+function parseErrorCore(error: unknown): ParsedErrorCore {
   const { message, stack, name } = stringifyUnknown(error);
   const stackFrames = parseStackFrames(stack);
   const composedPattern = getComposedErrorPattern(error);
@@ -242,6 +244,27 @@ export function buildErrorEventProperties(
     name,
     composedPattern,
   );
+  const displayMessage =
+    message.length > 500 ? `${message.slice(0, 497)}...` : message;
+
+  return {
+    fingerprint,
+    title: displayMessage,
+    message: displayMessage,
+    stack: stack?.slice(0, 50_000),
+    stackFrames,
+  };
+}
+
+function mergeErrorEventExtras(
+  core: ParsedErrorCore,
+  extras?: Record<string, unknown>,
+): BuiltErrorEventProps & Record<string, unknown> {
+  const { title, fingerprint, message, ...extrasWithoutCoreFields } =
+    extras || {};
+  void title;
+  void fingerprint;
+  void message;
 
   const {
     errorType,
@@ -252,23 +275,13 @@ export function buildErrorEventProperties(
     contexts,
     breadcrumbs,
     handled,
-    title: _extrasTitle,
-    fingerprint: _extrasFingerprint,
-    message: _extrasMessage,
     ...rest
-  } = extras || {};
-
-  const displayMessage =
-    message.length > 500 ? `${message.slice(0, 497)}...` : message;
+  } = extrasWithoutCoreFields;
 
   return {
     ...rest,
-    fingerprint,
-    title: displayMessage,
-    message: displayMessage,
+    ...core,
     errorType: typeof errorType === "string" ? errorType : "unknown",
-    stack: stack?.slice(0, 50_000),
-    stackFrames,
     transaction: typeof transaction === "string" ? transaction : undefined,
     release: typeof release === "string" ? release : undefined,
     runtime:
@@ -290,12 +303,22 @@ export function buildErrorEventProperties(
   };
 }
 
+export function buildErrorEventProperties(
+  error: unknown,
+  extras?: Record<string, unknown>,
+): BuiltErrorEventProps & Record<string, unknown> {
+  return mergeErrorEventExtras(parseErrorCore(error), extras);
+}
+
 async function logError(
   gb: GrowthBook | UserScopedGrowthBook | GrowthBookClient,
   error: unknown,
   extras?: Record<string, unknown>,
+  parsedCore?: ParsedErrorCore,
 ) {
-  const props = buildErrorEventProperties(error, extras);
+  const props = parsedCore
+    ? mergeErrorEventExtras(parsedCore, extras)
+    : buildErrorEventProperties(error, extras);
   if (gb instanceof GrowthBook || gb instanceof UserScopedGrowthBook) {
     await gb.logEvent(EVENT_GROWTHBOOK_ERROR, props);
     return;
@@ -403,8 +426,8 @@ export function growthbookErrorTrackingPlugin({
         }
       });
 
-      const propsPreview = buildErrorEventProperties(error, extras);
-      const fp = propsPreview.fingerprint;
+      const parsedCore = parseErrorCore(error);
+      const fp = parsedCore.fingerprint;
       const last = recentFingerprints.get(fp);
       if (last !== undefined && now - last < dedupeWindowMs) {
         return;
@@ -425,17 +448,22 @@ export function growthbookErrorTrackingPlugin({
         ...(envTag ? { environment: envTag } : {}),
       };
 
-      await logError(gb, error, {
-        ...extras,
-        release: resolvedRelease,
-        runtime:
-          extras?.runtime ?? runtime ?? (browser ? "browser" : "javascript"),
-        tags: { ...tags, ...(extras?.tags as Record<string, string>) },
-        contexts: {
-          ...defaultBrowserContexts(),
-          ...(typeof extras?.contexts === "object" ? extras.contexts : {}),
+      await logError(
+        gb,
+        error,
+        {
+          ...extras,
+          release: resolvedRelease,
+          runtime:
+            extras?.runtime ?? runtime ?? (browser ? "browser" : "javascript"),
+          tags: { ...tags, ...(extras?.tags as Record<string, string>) },
+          contexts: {
+            ...defaultBrowserContexts(),
+            ...(typeof extras?.contexts === "object" ? extras.contexts : {}),
+          },
         },
-      });
+        parsedCore,
+      );
     };
 
     if (!browser || (!captureUnhandled && !captureUnhandledRejections)) {

--- a/packages/sdk-js/src/plugins/growthbook-error-tracking.ts
+++ b/packages/sdk-js/src/plugins/growthbook-error-tracking.ts
@@ -17,18 +17,11 @@ export type CaptureGrowthBookErrorOptions = {
   gb: GrowthBook | UserScopedGrowthBook | GrowthBookClient;
   error: unknown;
   props?: GrowthBookErrorEventProps;
+  /** Override issue grouping for this error. A string is used as-is; an array is hashed server-side. */
+  fingerprint?: string | readonly string[];
   /** Required when `gb` is a {@link GrowthBookClient}. */
   userContext?: UserContext;
 };
-
-type PendingFingerprint =
-  | { type: "value"; value: string }
-  | { type: "parts"; parts: string[] };
-
-const pendingFingerprints = new WeakMap<
-  GrowthBook | UserScopedGrowthBook,
-  PendingFingerprint
->();
 
 function stringifyUnknown(err: unknown): {
   message: string;
@@ -79,59 +72,18 @@ export function parseStackFrames(stack?: string): ErrorTrackingStackFrame[] {
   return frames;
 }
 
-function consumePendingFingerprint(
-  gb: GrowthBook | UserScopedGrowthBook | GrowthBookClient,
-): PendingFingerprint | undefined {
-  if (gb instanceof GrowthBook || gb instanceof UserScopedGrowthBook) {
-    const pending = pendingFingerprints.get(gb);
-    if (pending) {
-      pendingFingerprints.delete(gb);
-    }
-    return pending;
-  }
-  return undefined;
-}
-
-/**
- * Override issue grouping for the next error reported on this GrowthBook
- * instance. The ingestor uses `fingerprint` as-is; `fingerprintParts` is hashed
- * server-side (similar to Sentry's `setFingerprint` array form).
- *
- * @example
- * setFingerprint({ gb, fingerprint: ["checkout", "payment-failed"] });
- * await captureGrowthBookError({ gb, error: err });
- */
-export function setFingerprint({
-  gb,
-  fingerprint,
-}: {
-  gb: GrowthBook | UserScopedGrowthBook;
-  fingerprint: string | readonly string[];
-}): void {
-  if (typeof fingerprint === "string") {
-    const value = fingerprint.trim();
-    if (!value) return;
-    pendingFingerprints.set(gb, { type: "value", value });
-    return;
-  }
-  const parts = fingerprint.map((part) => String(part)).filter(Boolean);
-  if (!parts.length) return;
-  pendingFingerprints.set(gb, { type: "parts", parts });
-}
-
 function dedupeKeyForError(
   error: unknown,
   props?: GrowthBookErrorEventProps,
 ): string {
-  const pending =
-    props && "_pendingFingerprint" in props
-      ? (props._pendingFingerprint as PendingFingerprint | undefined)
-      : undefined;
-  if (pending?.type === "value") {
-    return pending.value;
+  if (typeof props?.fingerprint === "string" && props.fingerprint.trim()) {
+    return props.fingerprint.trim();
   }
-  if (pending?.type === "parts") {
-    return pending.parts.join("\n");
+  if (
+    Array.isArray(props?.fingerprintParts) &&
+    (props.fingerprintParts as string[]).length > 0
+  ) {
+    return (props.fingerprintParts as string[]).join("\n");
   }
   const { message, stack } = stringifyUnknown(error);
   const frame = stack
@@ -142,7 +94,7 @@ function dedupeKeyForError(
 }
 
 export type BuiltErrorEventProps = {
-  /** Set via {@link setFingerprint}; otherwise computed in the ingestor. */
+  /** Override issue grouping; otherwise computed in the ingestor. */
   fingerprint?: string;
   fingerprintParts?: string[];
   /** Human-readable issue line; same as {@link BuiltErrorEventProps.message}. */
@@ -164,11 +116,9 @@ export type BuiltErrorEventProps = {
 export function buildErrorEventProperties({
   error,
   props,
-  gb,
 }: {
   error: unknown;
   props?: GrowthBookErrorEventProps;
-  gb?: GrowthBook | UserScopedGrowthBook | GrowthBookClient;
 }): BuiltErrorEventProps & Record<string, unknown> {
   const { message, stack, name } = stringifyUnknown(error);
   const stackFrames = parseStackFrames(stack);
@@ -188,8 +138,6 @@ export function buildErrorEventProperties({
     message: _propsMessage,
     ...rest
   } = props || {};
-
-  const pending = gb ? consumePendingFingerprint(gb) : undefined;
 
   const displayMessage =
     message.length > 500 ? `${message.slice(0, 497)}...` : message;
@@ -221,11 +169,7 @@ export function buildErrorEventProperties({
     handled: typeof handled === "boolean" ? handled : undefined,
   };
 
-  if (pending?.type === "value") {
-    built.fingerprint = pending.value;
-  } else if (pending?.type === "parts") {
-    built.fingerprintParts = pending.parts;
-  } else if (typeof propsFingerprint === "string" && propsFingerprint.trim()) {
+  if (typeof propsFingerprint === "string" && propsFingerprint.trim()) {
     built.fingerprint = propsFingerprint.trim();
   } else if (
     Array.isArray(propsFingerprintParts) &&
@@ -241,9 +185,19 @@ async function logError({
   gb,
   error,
   props,
+  fingerprint,
   userContext,
 }: CaptureGrowthBookErrorOptions): Promise<void> {
-  const eventProps = buildErrorEventProperties({ error, props, gb });
+  const fingerprintProps: GrowthBookErrorEventProps =
+    fingerprint !== undefined
+      ? typeof fingerprint === "string"
+        ? { fingerprint }
+        : { fingerprintParts: [...fingerprint] }
+      : {};
+  const eventProps = buildErrorEventProperties({
+    error,
+    props: { ...fingerprintProps, ...props },
+  });
 
   if (gb instanceof GrowthBook || gb instanceof UserScopedGrowthBook) {
     await gb.logEvent(EVENT_GROWTHBOOK_ERROR, eventProps);
@@ -359,14 +313,7 @@ export function growthbookErrorTrackingPlugin({
     const run = async (error: unknown, props?: GrowthBookErrorEventProps) => {
       if (!enable) return;
 
-      const pending =
-        gb instanceof GrowthBook || gb instanceof UserScopedGrowthBook
-          ? pendingFingerprints.get(gb)
-          : undefined;
-      const dedupeKey = dedupeKeyForError(error, {
-        ...props,
-        _pendingFingerprint: pending,
-      });
+      const dedupeKey = dedupeKeyForError(error, props);
       const now = Date.now();
       const last = recentDedupeKeys.get(dedupeKey);
       if (last !== undefined && now - last < dedupeWindowMs) {

--- a/packages/sdk-js/src/plugins/growthbook-error-tracking.ts
+++ b/packages/sdk-js/src/plugins/growthbook-error-tracking.ts
@@ -1,16 +1,24 @@
 import { EVENT_GROWTHBOOK_ERROR } from "../core";
-import type { Attributes } from "../types/growthbook";
+import type { Attributes, UserContext } from "../types/growthbook";
 import { GrowthBook } from "../GrowthBook";
-import {
-  GrowthBookClient,
-  UserScopedGrowthBook,
-} from "../GrowthBookClient";
+import { GrowthBookClient, UserScopedGrowthBook } from "../GrowthBookClient";
 
 export type ErrorTrackingStackFrame = {
   filename?: string;
   function?: string;
   lineno?: number;
   colno?: number;
+};
+
+/** Optional metadata passed to {@link captureGrowthBookError} as `props` (like `logEvent`). */
+export type GrowthBookErrorEventProps = Record<string, unknown>;
+
+export type CaptureGrowthBookErrorOptions = {
+  gb: GrowthBook | UserScopedGrowthBook | GrowthBookClient;
+  error: unknown;
+  props?: GrowthBookErrorEventProps;
+  /** Required when `gb` is a {@link GrowthBookClient}. */
+  userContext?: UserContext;
 };
 
 type PendingFingerprint =
@@ -90,13 +98,16 @@ function consumePendingFingerprint(
  * server-side (similar to Sentry's `setFingerprint` array form).
  *
  * @example
- * setFingerprint(gb, ["checkout", "payment-failed"]);
- * await captureGrowthBookError(gb, err);
+ * setFingerprint({ gb, fingerprint: ["checkout", "payment-failed"] });
+ * await captureGrowthBookError({ gb, error: err });
  */
-export function setFingerprint(
-  gb: GrowthBook | UserScopedGrowthBook,
-  fingerprint: string | readonly string[],
-): void {
+export function setFingerprint({
+  gb,
+  fingerprint,
+}: {
+  gb: GrowthBook | UserScopedGrowthBook;
+  fingerprint: string | readonly string[];
+}): void {
   if (typeof fingerprint === "string") {
     const value = fingerprint.trim();
     if (!value) return;
@@ -108,10 +119,13 @@ export function setFingerprint(
   pendingFingerprints.set(gb, { type: "parts", parts });
 }
 
-function dedupeKeyForError(error: unknown, extras?: Record<string, unknown>): string {
+function dedupeKeyForError(
+  error: unknown,
+  props?: GrowthBookErrorEventProps,
+): string {
   const pending =
-    extras && "_pendingFingerprint" in extras
-      ? (extras._pendingFingerprint as PendingFingerprint | undefined)
+    props && "_pendingFingerprint" in props
+      ? (props._pendingFingerprint as PendingFingerprint | undefined)
       : undefined;
   if (pending?.type === "value") {
     return pending.value;
@@ -120,7 +134,10 @@ function dedupeKeyForError(error: unknown, extras?: Record<string, unknown>): st
     return pending.parts.join("\n");
   }
   const { message, stack } = stringifyUnknown(error);
-  const frame = stack?.split("\n").map((line) => line.trim()).find(Boolean);
+  const frame = stack
+    ?.split("\n")
+    .map((line) => line.trim())
+    .find(Boolean);
   return `${message}\n${frame || ""}`;
 }
 
@@ -144,13 +161,15 @@ export type BuiltErrorEventProps = {
   handled?: boolean;
 };
 
-export function buildErrorEventProperties(
-  error: unknown,
-  extras?: Record<string, unknown>,
-  options?: {
-    gb?: GrowthBook | UserScopedGrowthBook | GrowthBookClient;
-  },
-): BuiltErrorEventProps & Record<string, unknown> {
+export function buildErrorEventProperties({
+  error,
+  props,
+  gb,
+}: {
+  error: unknown;
+  props?: GrowthBookErrorEventProps;
+  gb?: GrowthBook | UserScopedGrowthBook | GrowthBookClient;
+}): BuiltErrorEventProps & Record<string, unknown> {
   const { message, stack, name } = stringifyUnknown(error);
   const stackFrames = parseStackFrames(stack);
 
@@ -163,27 +182,26 @@ export function buildErrorEventProperties(
     contexts,
     breadcrumbs,
     handled,
-    fingerprint: extrasFingerprint,
-    fingerprintParts: extrasFingerprintParts,
-    title: _extrasTitle,
-    message: _extrasMessage,
+    fingerprint: propsFingerprint,
+    fingerprintParts: propsFingerprintParts,
+    title: _propsTitle,
+    message: _propsMessage,
     ...rest
-  } = extras || {};
+  } = props || {};
 
-  const pending = options?.gb ? consumePendingFingerprint(options.gb) : undefined;
+  const pending = gb ? consumePendingFingerprint(gb) : undefined;
 
   const displayMessage =
     message.length > 500 ? `${message.slice(0, 497)}...` : message;
 
-  const props: BuiltErrorEventProps & Record<string, unknown> = {
+  const built: BuiltErrorEventProps & Record<string, unknown> = {
     ...rest,
     title: displayMessage,
     message: displayMessage,
     errorType: typeof errorType === "string" ? errorType : name || "unknown",
     stack: stack?.slice(0, 50_000),
     stackFrames,
-    transaction:
-      typeof transaction === "string" ? transaction : undefined,
+    transaction: typeof transaction === "string" ? transaction : undefined,
     release: typeof release === "string" ? release : undefined,
     runtime:
       typeof runtime === "string"
@@ -191,56 +209,62 @@ export function buildErrorEventProperties(
         : typeof navigator !== "undefined"
           ? "browser"
           : "javascript",
-    tags: tags && typeof tags === "object" ? (tags as Record<string, string>) : undefined,
+    tags:
+      tags && typeof tags === "object"
+        ? (tags as Record<string, string>)
+        : undefined,
     contexts:
       contexts && typeof contexts === "object"
         ? (contexts as Record<string, unknown>)
         : undefined,
-    breadcrumbs: Array.isArray(breadcrumbs)
-      ? breadcrumbs
-      : undefined,
+    breadcrumbs: Array.isArray(breadcrumbs) ? breadcrumbs : undefined,
     handled: typeof handled === "boolean" ? handled : undefined,
   };
 
   if (pending?.type === "value") {
-    props.fingerprint = pending.value;
+    built.fingerprint = pending.value;
   } else if (pending?.type === "parts") {
-    props.fingerprintParts = pending.parts;
-  } else if (typeof extrasFingerprint === "string" && extrasFingerprint.trim()) {
-    props.fingerprint = extrasFingerprint.trim();
+    built.fingerprintParts = pending.parts;
+  } else if (typeof propsFingerprint === "string" && propsFingerprint.trim()) {
+    built.fingerprint = propsFingerprint.trim();
   } else if (
-    Array.isArray(extrasFingerprintParts) &&
-    extrasFingerprintParts.length > 0
+    Array.isArray(propsFingerprintParts) &&
+    propsFingerprintParts.length > 0
   ) {
-    props.fingerprintParts = extrasFingerprintParts.map((part) => String(part));
+    built.fingerprintParts = propsFingerprintParts.map((part) => String(part));
   }
 
-  return props;
+  return built;
 }
 
-async function logError(
-  gb: GrowthBook | UserScopedGrowthBook | GrowthBookClient,
-  error: unknown,
-  extras?: Record<string, unknown>,
-) {
-  const props = buildErrorEventProperties(error, extras, { gb });
+async function logError({
+  gb,
+  error,
+  props,
+  userContext,
+}: CaptureGrowthBookErrorOptions): Promise<void> {
+  const eventProps = buildErrorEventProperties({ error, props, gb });
+
   if (gb instanceof GrowthBook || gb instanceof UserScopedGrowthBook) {
-    await gb.logEvent(EVENT_GROWTHBOOK_ERROR, props);
+    await gb.logEvent(EVENT_GROWTHBOOK_ERROR, eventProps);
     return;
   }
+
   if (gb instanceof GrowthBookClient) {
-    console.warn(
-      "growthbookErrorTrackingPlugin: use GrowthBook or a scoped UserScopedGrowthBook instance (not the root GrowthBookClient).",
-    );
+    if (!userContext) {
+      console.warn(
+        "captureGrowthBookError: pass userContext when gb is a GrowthBookClient.",
+      );
+      return;
+    }
+    gb.logEvent(EVENT_GROWTHBOOK_ERROR, eventProps, userContext);
   }
 }
 
 export async function captureGrowthBookError(
-  gb: GrowthBook | UserScopedGrowthBook | GrowthBookClient,
-  error: unknown,
-  extras?: Record<string, unknown>,
+  options: CaptureGrowthBookErrorOptions,
 ): Promise<void> {
-  await logError(gb, error, extras);
+  await logError(options);
 }
 
 function defaultBrowserContexts(): Record<string, unknown> {
@@ -252,7 +276,8 @@ function defaultBrowserContexts(): Record<string, unknown> {
       cookieEnabled: navigator.cookieEnabled,
     },
     device: {
-      screen: typeof screen !== "undefined" ? `${screen.width}x${screen.height}` : "",
+      screen:
+        typeof screen !== "undefined" ? `${screen.width}x${screen.height}` : "",
       pixelRatio:
         typeof window !== "undefined" ? window.devicePixelRatio : undefined,
     },
@@ -261,10 +286,21 @@ function defaultBrowserContexts(): Record<string, unknown> {
 
 function readGrowthBookAttributes(
   gb: GrowthBook | UserScopedGrowthBook | GrowthBookClient,
+  userContext?: UserContext,
 ): Attributes {
+  if (userContext?.attributes) {
+    return userContext.attributes;
+  }
+
   try {
+    if (gb instanceof UserScopedGrowthBook) {
+      return gb.getUserContext().attributes || {};
+    }
     if ("getAttributes" in gb && typeof gb.getAttributes === "function") {
       return gb.getAttributes() || {};
+    }
+    if (gb instanceof GrowthBookClient) {
+      return gb.getGlobalAttributes();
     }
   } catch {
     /* ignore */
@@ -306,9 +342,9 @@ export function growthbookErrorTrackingPlugin({
     }
 
     const recentDedupeKeys = new Map<string, number>();
-    const resolveRelease = (extras?: Record<string, unknown>) => {
-      if (typeof extras?.release === "string" && extras.release) {
-        return extras.release;
+    const resolveRelease = (props?: GrowthBookErrorEventProps) => {
+      if (typeof props?.release === "string" && props.release) {
+        return props.release;
       }
       const dynamicRelease = getRelease?.();
       if (typeof dynamicRelease === "string" && dynamicRelease) {
@@ -317,7 +353,10 @@ export function growthbookErrorTrackingPlugin({
       return typeof release === "string" ? release : undefined;
     };
 
-    const run = async (error: unknown, extras?: Record<string, unknown>) => {
+    const pluginUserContext =
+      gb instanceof UserScopedGrowthBook ? gb.getUserContext() : undefined;
+
+    const run = async (error: unknown, props?: GrowthBookErrorEventProps) => {
       if (!enable) return;
 
       const pending =
@@ -325,7 +364,7 @@ export function growthbookErrorTrackingPlugin({
           ? pendingFingerprints.get(gb)
           : undefined;
       const dedupeKey = dedupeKeyForError(error, {
-        ...extras,
+        ...props,
         _pendingFingerprint: pending,
       });
       const now = Date.now();
@@ -335,33 +374,43 @@ export function growthbookErrorTrackingPlugin({
       }
       recentDedupeKeys.set(dedupeKey, now);
 
-      const attrs = readGrowthBookAttributes(gb);
+      const attrs = readGrowthBookAttributes(gb, pluginUserContext);
       const envTag =
         typeof attrs.environment === "string"
           ? attrs.environment
           : typeof attrs.gbEnvironment === "string"
             ? attrs.gbEnvironment
             : undefined;
-      const resolvedRelease = resolveRelease(extras);
+      const resolvedRelease = resolveRelease(props);
 
       const tags: Record<string, string> = {
         ...(resolvedRelease ? { release: resolvedRelease } : {}),
         ...(envTag ? { environment: envTag } : {}),
       };
 
-      await logError(gb, error, {
-        ...extras,
-        release: resolvedRelease,
-        runtime: extras?.runtime ?? runtime ?? (browser ? "browser" : "javascript"),
-        tags: { ...tags, ...(extras?.tags as Record<string, string>) },
-        contexts: {
-          ...defaultBrowserContexts(),
-          ...(typeof extras?.contexts === "object" ? extras.contexts : {}),
+      await logError({
+        gb,
+        error,
+        userContext: pluginUserContext,
+        props: {
+          ...props,
+          release: resolvedRelease,
+          runtime:
+            props?.runtime ?? runtime ?? (browser ? "browser" : "javascript"),
+          tags: { ...tags, ...(props?.tags as Record<string, string>) },
+          contexts: {
+            ...defaultBrowserContexts(),
+            ...(typeof props?.contexts === "object" ? props.contexts : {}),
+          },
         },
       });
     };
 
     if (!browser || (!captureUnhandled && !captureUnhandledRejections)) {
+      return;
+    }
+
+    if (gb instanceof GrowthBookClient) {
       return;
     }
 

--- a/packages/sdk-js/src/plugins/growthbook-error-tracking.ts
+++ b/packages/sdk-js/src/plugins/growthbook-error-tracking.ts
@@ -1,7 +1,10 @@
 import { EVENT_GROWTHBOOK_ERROR } from "../core";
 import type { Attributes } from "../types/growthbook";
 import { GrowthBook } from "../GrowthBook";
-import { GrowthBookClient, UserScopedGrowthBook } from "../GrowthBookClient";
+import {
+  GrowthBookClient,
+  UserScopedGrowthBook,
+} from "../GrowthBookClient";
 
 export type ErrorTrackingStackFrame = {
   filename?: string;
@@ -9,6 +12,15 @@ export type ErrorTrackingStackFrame = {
   lineno?: number;
   colno?: number;
 };
+
+type PendingFingerprint =
+  | { type: "value"; value: string }
+  | { type: "parts"; parts: string[] };
+
+const pendingFingerprints = new WeakMap<
+  GrowthBook | UserScopedGrowthBook,
+  PendingFingerprint
+>();
 
 function stringifyUnknown(err: unknown): {
   message: string;
@@ -59,263 +71,66 @@ export function parseStackFrames(stack?: string): ErrorTrackingStackFrame[] {
   return frames;
 }
 
-const FINGERPRINT_FRAME_LIMIT = 3;
-const NOISE_FRAME_PATH_RE =
-  /(?:^|[/\\])(?:node_modules|next[/\\]dist|react-dom|webpack)(?:[/\\]|$)/i;
-
-function hashFingerprintParts(parts: string[]): string {
-  const raw = parts.filter(Boolean).join("\n");
-  let h = 2166136261;
-  for (let i = 0; i < raw.length; i++) {
-    h ^= raw.charCodeAt(i);
-    h = Math.imul(h, 16777619);
+function consumePendingFingerprint(
+  gb: GrowthBook | UserScopedGrowthBook | GrowthBookClient,
+): PendingFingerprint | undefined {
+  if (gb instanceof GrowthBook || gb instanceof UserScopedGrowthBook) {
+    const pending = pendingFingerprints.get(gb);
+    if (pending) {
+      pendingFingerprints.delete(gb);
+    }
+    return pending;
   }
-  return (h >>> 0).toString(16);
+  return undefined;
 }
 
 /**
- * Tagged-template errors: fingerprints use the literal source pattern with `{}`
- * for each `${...}` hole, so interpolated values do not split issues.
- *
- * JavaScript does not expose template segments on `Error.message`; use
- * `growthbookComposedError` (or set this symbol on your own `Error` subclass).
- */
-export const GROWTHBOOK_COMPOSED_ERROR_PATTERN = Symbol.for(
-  "growthbook.composedErrorPattern",
-);
-
-function getComposedErrorPattern(error: unknown): string | undefined {
-  if (!error || typeof error !== "object") return undefined;
-  const pattern = Reflect.get(error, GROWTHBOOK_COMPOSED_ERROR_PATTERN);
-  return typeof pattern === "string" && pattern.trim().length
-    ? pattern.trim()
-    : undefined;
-}
-
-/**
- * Create an `Error` thrown from a template literal such that fingerprinting uses
- * the static text and `{}` placeholders instead of runtime interpolation.
+ * Override issue grouping for the next error reported on this GrowthBook
+ * instance. The ingestor uses `fingerprint` as-is; `fingerprintParts` is hashed
+ * server-side (similar to Sentry's `setFingerprint` array form).
  *
  * @example
- * throw growthbookComposedError`Checkout failed (trace ${crypto.randomUUID()})`;
+ * setFingerprint(gb, ["checkout", "payment-failed"]);
+ * await captureGrowthBookError(gb, err);
  */
-export function growthbookComposedError(
-  strings: TemplateStringsArray,
-  ...values: unknown[]
-): Error {
-  let message = "";
-  for (let i = 0; i < strings.length; i++) {
-    message += strings[i];
-    if (i < values.length) {
-      message += String(values[i]);
-    }
+export function setFingerprint(
+  gb: GrowthBook | UserScopedGrowthBook,
+  fingerprint: string | readonly string[],
+): void {
+  if (typeof fingerprint === "string") {
+    const value = fingerprint.trim();
+    if (!value) return;
+    pendingFingerprints.set(gb, { type: "value", value });
+    return;
   }
-
-  const pattern = strings.reduce((acc, segment, index) => {
-    const hole = index < values.length ? "{}" : "";
-    return acc + segment + hole;
-  }, "");
-
-  const err = new Error(message.trim());
-  Reflect.set(err, GROWTHBOOK_COMPOSED_ERROR_PATTERN, pattern);
-  return err;
+  const parts = fingerprint.map((part) => String(part)).filter(Boolean);
+  if (!parts.length) return;
+  pendingFingerprints.set(gb, { type: "parts", parts });
 }
 
-/**
- * Collapse `{...}` segments (e.g. JSON payloads) innermost-first so dynamic
- * object bodies do not split fingerprints. No-op when braces are absent.
- */
-export function collapseBraceSegments(message: string): string {
-  if (!message.includes("{") || !message.includes("}")) {
-    return message;
+function dedupeKeyForError(error: unknown, extras?: Record<string, unknown>): string {
+  const pending =
+    extras && "_pendingFingerprint" in extras
+      ? (extras._pendingFingerprint as PendingFingerprint | undefined)
+      : undefined;
+  if (pending?.type === "value") {
+    return pending.value;
   }
-  let normalized = message;
-  for (let pass = 0; pass < 64; pass++) {
-    const start = normalized.indexOf("{");
-    if (start < 0) {
-      break;
-    }
-    let depth = 0;
-    let end = -1;
-    for (let i = start; i < normalized.length; i++) {
-      const ch = normalized[i];
-      if (ch === "{") {
-        depth++;
-      } else if (ch === "}") {
-        depth--;
-        if (depth === 0) {
-          end = i;
-          break;
-        }
-      }
-    }
-    if (end < 0) {
-      break;
-    }
-    const inner = normalized.slice(start + 1, end);
-    if (!inner.length) {
-      break;
-    }
-    normalized = normalized.slice(0, start) + "{}" + normalized.slice(end + 1);
+  if (pending?.type === "parts") {
+    return pending.parts.join("\n");
   }
-  return normalized;
-}
-
-/**
- * Normalize volatile fragments in error messages for stable issue grouping.
- *
- * Inspired by Sentry's server-side message parameterization (see
- * `sentry/grouping/parameterization.py`): replace emails, URLs, IDs, dates,
- * etc. with placeholders. Unlike Sentry, we also fold stack frames into the
- * fingerprint client-side; Sentry primarily groups on stack when available.
- */
-export function normalizeErrorMessageForFingerprint(message: string): string {
-  let normalized = message.trim();
-  normalized = collapseBraceSegments(normalized);
-
-  // W3C traceparent / AWS ALB trace ids
-  normalized = normalized.replace(
-    /\b00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]\b/gi,
-    "{trace}",
-  );
-  normalized = normalized.replace(
-    /\b1-[0-9a-f]{8}-[0-9a-f]{24}\b/gi,
-    "{trace}",
-  );
-
-  normalized = normalized.replace(
-    /[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+/g,
-    "{email}",
-  );
-  normalized = normalized.replace(/https?:\/\/\S+/gi, "{url}");
-  normalized = normalized.replace(/\bwww\.\S+/gi, "{url}");
-
-  normalized = normalized.replace(
-    /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi,
-    "{uuid}",
-  );
-
-  // Distinct hash lengths before generic hex (Sentry: sha1 / md5)
-  normalized = normalized.replace(/\b[0-9a-f]{40}\b/gi, "{sha1}");
-  normalized = normalized.replace(/\b[0-9a-f]{32}\b/gi, "{md5}");
-
-  normalized = normalized.replace(/\b(?:\d{1,3}\.){3}\d{1,3}\b/g, "{ip}");
-
-  normalized = normalized.replace(
-    /\d{4}-[01]\d-[0-3]\d(?:[T\s][0-2]\d:[0-5]\d(?::[0-5]\d)?(?:\.\d+)?(?:Z|[+-][0-2]\d:?[0-5]\d)?)?/g,
-    "{datetime}",
-  );
-
-  normalized = normalized.replace(/"[^"]{3,}"/g, "{str}");
-  normalized = normalized.replace(/'[^']{3,}'/g, "{str}");
-
-  normalized = normalized.replace(
-    /(?:\/?[\w.-]+)+\.(?:tsx?|jsx?|mjs|cjs|vue|py|go|rb|java|cs|php|rs)\b/gi,
-    "{path}",
-  );
-
-  normalized = normalized.replace(/\b0x[0-9a-f]+\b/gi, "{hex}");
-  normalized = normalized.replace(
-    /\b(?=[0-9a-f]*[a-f])(?=[0-9a-f]*[0-9])[0-9a-f]{8,}\b/gi,
-    "{hex}",
-  );
-
-  normalized = normalized.replace(/\btx[0-9a-f]{21}-[0-9a-f]{10}\S*/gi, "{id}");
-
-  // Mixed alphanumeric tokens (request ids, base64-ish chunks, etc.)
-  normalized = normalized.replace(
-    /\b(?=[\w-]*[a-zA-Z])(?=[\w-]*[0-9])[\w-]{8,}\b/g,
-    "{id}",
-  );
-
-  normalized = normalized.replace(/\b\d+(\.\d+)?ms\b/gi, "{duration}");
-  normalized = normalized.replace(/\b-?\d{1,3}(?:,\d{3})+(?:\.\d+)?\b/g, "{n}");
-  normalized = normalized.replace(/\b-?\d+\.\d+\b/g, "{n}");
-  normalized = normalized.replace(/\b-?\d+\b/g, "{n}");
-  normalized = normalized.replace(/\s+/g, " ");
-  return normalized;
-}
-
-/** Reduce bundled or absolute paths to a stable app-relative label. */
-export function normalizeFilenameForFingerprint(filename: string): string {
-  let normalized = filename.trim();
-  normalized = normalized.replace(/^webpack-internal:\/\/\/+/, "");
-  normalized = normalized.replace(/^\(app-pages-browser\)\/+/, "");
-  normalized = normalized.replace(/^https?:\/\/[^/]+\/+/, "");
-  normalized = normalized.replace(/\?.*$/, "");
-  normalized = normalized.replace(/:\d+(?::\d+)?$/, "");
-
-  const parts = normalized.split(/[/\\]/).filter(Boolean);
-  if (parts.length >= 2) {
-    return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`;
-  }
-  return parts[parts.length - 1] || normalized;
-}
-
-function isNoiseFrame(frame: ErrorTrackingStackFrame): boolean {
-  const file = frame.filename || "";
-  return NOISE_FRAME_PATH_RE.test(file) || /^webpack/i.test(file);
-}
-
-function formatFrameForFingerprint(frame: ErrorTrackingStackFrame): string {
-  const file = frame.filename
-    ? normalizeFilenameForFingerprint(frame.filename)
-    : "?";
-  const fn = frame.function?.trim();
-  const fnLabel = fn && !/^(?:anonymous|unknown)$/i.test(fn) ? fn : "?";
-  return `${fnLabel}@${file}`;
-}
-
-function selectFingerprintFrames(
-  frames: ErrorTrackingStackFrame[],
-): ErrorTrackingStackFrame[] {
-  const appFrames = frames.filter((frame) => !isNoiseFrame(frame));
-  const candidates = appFrames.length ? appFrames : frames;
-  const selected: ErrorTrackingStackFrame[] = [];
-  const seen = new Set<string>();
-
-  for (const frame of candidates) {
-    const label = formatFrameForFingerprint(frame);
-    if (seen.has(label)) {
-      continue;
-    }
-    seen.add(label);
-    selected.push(frame);
-    if (selected.length >= FINGERPRINT_FRAME_LIMIT) {
-      break;
-    }
-  }
-
-  return selected;
-}
-
-/**
- * Stable issue grouping key from error type, normalized message, and
- * application stack frames (without line/column numbers).
- */
-export function fingerprintForError(
-  message: string,
-  stack?: string,
-  errorName?: string,
-  messageForFingerprint?: string,
-): string {
-  const frames = parseStackFrames(stack);
-  const selectedFrames = selectFingerprintFrames(frames);
-  const fingerprintMessage = messageForFingerprint ?? message;
-  const parts = [
-    errorName?.trim() || "Error",
-    normalizeErrorMessageForFingerprint(fingerprintMessage),
-    ...selectedFrames.map(formatFrameForFingerprint),
-  ];
-
-  return hashFingerprintParts(parts);
+  const { message, stack } = stringifyUnknown(error);
+  const frame = stack?.split("\n").map((line) => line.trim()).find(Boolean);
+  return `${message}\n${frame || ""}`;
 }
 
 export type BuiltErrorEventProps = {
-  fingerprint: string;
+  /** Set via {@link setFingerprint}; otherwise computed in the ingestor. */
+  fingerprint?: string;
+  fingerprintParts?: string[];
   /** Human-readable issue line; same as {@link BuiltErrorEventProps.message}. */
   title: string;
-  /** Full interpolated `Error.message` (for UI / warehouse; fingerprint may use a static pattern). */
+  /** Full `Error.message` for display and search in the warehouse. */
   message: string;
   errorType: string;
   stack?: string;
@@ -332,16 +147,12 @@ export type BuiltErrorEventProps = {
 export function buildErrorEventProperties(
   error: unknown,
   extras?: Record<string, unknown>,
+  options?: {
+    gb?: GrowthBook | UserScopedGrowthBook | GrowthBookClient;
+  },
 ): BuiltErrorEventProps & Record<string, unknown> {
   const { message, stack, name } = stringifyUnknown(error);
   const stackFrames = parseStackFrames(stack);
-  const composedPattern = getComposedErrorPattern(error);
-  const fingerprint = fingerprintForError(
-    message,
-    stack,
-    name,
-    composedPattern,
-  );
 
   const {
     errorType,
@@ -352,24 +163,27 @@ export function buildErrorEventProperties(
     contexts,
     breadcrumbs,
     handled,
+    fingerprint: extrasFingerprint,
+    fingerprintParts: extrasFingerprintParts,
     title: _extrasTitle,
-    fingerprint: _extrasFingerprint,
     message: _extrasMessage,
     ...rest
   } = extras || {};
 
+  const pending = options?.gb ? consumePendingFingerprint(options.gb) : undefined;
+
   const displayMessage =
     message.length > 500 ? `${message.slice(0, 497)}...` : message;
 
-  return {
+  const props: BuiltErrorEventProps & Record<string, unknown> = {
     ...rest,
-    fingerprint,
     title: displayMessage,
     message: displayMessage,
-    errorType: typeof errorType === "string" ? errorType : "unknown",
+    errorType: typeof errorType === "string" ? errorType : name || "unknown",
     stack: stack?.slice(0, 50_000),
     stackFrames,
-    transaction: typeof transaction === "string" ? transaction : undefined,
+    transaction:
+      typeof transaction === "string" ? transaction : undefined,
     release: typeof release === "string" ? release : undefined,
     runtime:
       typeof runtime === "string"
@@ -377,17 +191,31 @@ export function buildErrorEventProperties(
         : typeof navigator !== "undefined"
           ? "browser"
           : "javascript",
-    tags:
-      tags && typeof tags === "object"
-        ? (tags as Record<string, string>)
-        : undefined,
+    tags: tags && typeof tags === "object" ? (tags as Record<string, string>) : undefined,
     contexts:
       contexts && typeof contexts === "object"
         ? (contexts as Record<string, unknown>)
         : undefined,
-    breadcrumbs: Array.isArray(breadcrumbs) ? breadcrumbs : undefined,
+    breadcrumbs: Array.isArray(breadcrumbs)
+      ? breadcrumbs
+      : undefined,
     handled: typeof handled === "boolean" ? handled : undefined,
   };
+
+  if (pending?.type === "value") {
+    props.fingerprint = pending.value;
+  } else if (pending?.type === "parts") {
+    props.fingerprintParts = pending.parts;
+  } else if (typeof extrasFingerprint === "string" && extrasFingerprint.trim()) {
+    props.fingerprint = extrasFingerprint.trim();
+  } else if (
+    Array.isArray(extrasFingerprintParts) &&
+    extrasFingerprintParts.length > 0
+  ) {
+    props.fingerprintParts = extrasFingerprintParts.map((part) => String(part));
+  }
+
+  return props;
 }
 
 async function logError(
@@ -395,7 +223,7 @@ async function logError(
   error: unknown,
   extras?: Record<string, unknown>,
 ) {
-  const props = buildErrorEventProperties(error, extras);
+  const props = buildErrorEventProperties(error, extras, { gb });
   if (gb instanceof GrowthBook || gb instanceof UserScopedGrowthBook) {
     await gb.logEvent(EVENT_GROWTHBOOK_ERROR, props);
     return;
@@ -424,8 +252,7 @@ function defaultBrowserContexts(): Record<string, unknown> {
       cookieEnabled: navigator.cookieEnabled,
     },
     device: {
-      screen:
-        typeof screen !== "undefined" ? `${screen.width}x${screen.height}` : "",
+      screen: typeof screen !== "undefined" ? `${screen.width}x${screen.height}` : "",
       pixelRatio:
         typeof window !== "undefined" ? window.devicePixelRatio : undefined,
     },
@@ -458,14 +285,11 @@ export function growthbookErrorTrackingPlugin({
   enable?: boolean;
   captureUnhandled?: boolean;
   captureUnhandledRejections?: boolean;
-  /** Skip logging when the same fingerprint was reported very recently. */
+  /** Suppress duplicate reports within a short window (by message/stack or custom fingerprint). */
   dedupeWindowMs?: number;
-  /** e.g. git SHA or app version — also appears in event tags. */
   release?: string;
-  /** Resolve release at capture time (overrides static `release`). */
   getRelease?: () => string | undefined;
   runtime?: string;
-  /** Optional transaction name (e.g. React route). */
   getTransaction?: () => string | undefined;
 } = {}) {
   return (gb: GrowthBook | UserScopedGrowthBook | GrowthBookClient) => {
@@ -481,7 +305,7 @@ export function growthbookErrorTrackingPlugin({
       );
     }
 
-    const recentFingerprints = new Map<string, number>();
+    const recentDedupeKeys = new Map<string, number>();
     const resolveRelease = (extras?: Record<string, unknown>) => {
       if (typeof extras?.release === "string" && extras.release) {
         return extras.release;
@@ -496,14 +320,20 @@ export function growthbookErrorTrackingPlugin({
     const run = async (error: unknown, extras?: Record<string, unknown>) => {
       if (!enable) return;
 
-      const propsPreview = buildErrorEventProperties(error, extras);
-      const fp = propsPreview.fingerprint;
+      const pending =
+        gb instanceof GrowthBook || gb instanceof UserScopedGrowthBook
+          ? pendingFingerprints.get(gb)
+          : undefined;
+      const dedupeKey = dedupeKeyForError(error, {
+        ...extras,
+        _pendingFingerprint: pending,
+      });
       const now = Date.now();
-      const last = recentFingerprints.get(fp);
+      const last = recentDedupeKeys.get(dedupeKey);
       if (last !== undefined && now - last < dedupeWindowMs) {
         return;
       }
-      recentFingerprints.set(fp, now);
+      recentDedupeKeys.set(dedupeKey, now);
 
       const attrs = readGrowthBookAttributes(gb);
       const envTag =
@@ -522,8 +352,7 @@ export function growthbookErrorTrackingPlugin({
       await logError(gb, error, {
         ...extras,
         release: resolvedRelease,
-        runtime:
-          extras?.runtime ?? runtime ?? (browser ? "browser" : "javascript"),
+        runtime: extras?.runtime ?? runtime ?? (browser ? "browser" : "javascript"),
         tags: { ...tags, ...(extras?.tags as Record<string, string>) },
         contexts: {
           ...defaultBrowserContexts(),

--- a/packages/sdk-js/src/plugins/growthbook-error-tracking.ts
+++ b/packages/sdk-js/src/plugins/growthbook-error-tracking.ts
@@ -1,0 +1,478 @@
+import { EVENT_GROWTHBOOK_ERROR } from "../core";
+import type { Attributes } from "../types/growthbook";
+import { GrowthBook } from "../GrowthBook";
+import { GrowthBookClient, UserScopedGrowthBook } from "../GrowthBookClient";
+
+export type ErrorTrackingStackFrame = {
+  filename?: string;
+  function?: string;
+  lineno?: number;
+  colno?: number;
+};
+
+function stringifyUnknown(err: unknown): {
+  message: string;
+  stack?: string;
+  name?: string;
+} {
+  if (err instanceof Error) {
+    return {
+      message: err.message || err.name || "Error",
+      stack: err.stack,
+      name: err.name || "Error",
+    };
+  }
+  if (typeof err === "string") {
+    return { message: err };
+  }
+  try {
+    return { message: JSON.stringify(err) };
+  } catch {
+    return { message: String(err) };
+  }
+}
+
+/** Best-effort stack frame parsing (Chrome / Safari / Firefox-ish lines). */
+export function parseStackFrames(stack?: string): ErrorTrackingStackFrame[] {
+  if (!stack) return [];
+  const frames: ErrorTrackingStackFrame[] = [];
+  const lines = stack.split("\n");
+  const chromeRe =
+    /^\s*at (?:(?:async\s+)?([^()]+?)\s+)?\(?(.+?):(\d+):(\d+)\)?$/;
+  const firefoxRe = /^(.*?)@(.+?):(\d+):(\d+)$/;
+
+  for (const raw of lines) {
+    const line = raw.trim();
+    let m = chromeRe.exec(line);
+    if (!m) {
+      m = firefoxRe.exec(line) as RegExpExecArray | null;
+    }
+    if (m) {
+      frames.push({
+        function: (m[1] || "").trim() || undefined,
+        filename: m[2],
+        lineno: parseInt(m[3] || "0", 10) || undefined,
+        colno: parseInt(m[4] || "0", 10) || undefined,
+      });
+    }
+  }
+  return frames;
+}
+
+const FINGERPRINT_FRAME_LIMIT = 3;
+const NOISE_FRAME_PATH_RE =
+  /(?:^|[/\\])(?:node_modules|next[/\\]dist|react-dom|webpack)(?:[/\\]|$)/i;
+
+function hashFingerprintParts(parts: string[]): string {
+  const raw = parts.filter(Boolean).join("\n");
+  let h = 2166136261;
+  for (let i = 0; i < raw.length; i++) {
+    h ^= raw.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return (h >>> 0).toString(16);
+}
+
+/**
+ * Tagged-template errors: fingerprints use the literal source pattern with `{}`
+ * for each `${...}` hole, so interpolated values do not split issues.
+ *
+ * JavaScript does not expose template segments on `Error.message`; use
+ * `growthbookComposedError` (or set this symbol on your own `Error` subclass).
+ */
+export const GROWTHBOOK_COMPOSED_ERROR_PATTERN = Symbol.for(
+  "growthbook.composedErrorPattern",
+);
+
+function getComposedErrorPattern(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const pattern = Reflect.get(error, GROWTHBOOK_COMPOSED_ERROR_PATTERN);
+  return typeof pattern === "string" && pattern.trim().length
+    ? pattern.trim()
+    : undefined;
+}
+
+/**
+ * Create an `Error` thrown from a template literal such that fingerprinting uses
+ * the static text and `{}` placeholders instead of runtime interpolation.
+ *
+ * @example
+ * throw growthbookComposedError`Checkout failed (trace ${crypto.randomUUID()})`;
+ */
+export function growthbookComposedError(
+  strings: TemplateStringsArray,
+  ...values: unknown[]
+): Error {
+  let message = "";
+  for (let i = 0; i < strings.length; i++) {
+    message += strings[i];
+    if (i < values.length) {
+      message += String(values[i]);
+    }
+  }
+
+  const pattern = strings.reduce((acc, segment, index) => {
+    const hole = index < values.length ? "{}" : "";
+    return acc + segment + hole;
+  }, "");
+
+  const err = new Error(message.trim());
+  Reflect.set(err, GROWTHBOOK_COMPOSED_ERROR_PATTERN, pattern);
+  return err;
+}
+
+/** Collapse volatile message values while keeping static wording. */
+export function normalizeErrorMessageForFingerprint(message: string): string {
+  let normalized = message.trim();
+  normalized = normalized.replace(
+    /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi,
+    "{uuid}",
+  );
+  normalized = normalized.replace(/\b0x[0-9a-f]+\b/gi, "{hex}");
+  normalized = normalized.replace(/\b[0-9a-f]{16,}\b/gi, "{hex}");
+  normalized = normalized.replace(/https?:\/\/\S+/gi, "{url}");
+  normalized = normalized.replace(/\b\d+\b/g, "{n}");
+  normalized = normalized.replace(/\s+/g, " ");
+  return normalized;
+}
+
+/** Reduce bundled or absolute paths to a stable app-relative label. */
+export function normalizeFilenameForFingerprint(filename: string): string {
+  let normalized = filename.trim();
+  normalized = normalized.replace(/^webpack-internal:\/\/\/+/, "");
+  normalized = normalized.replace(/^\(app-pages-browser\)\/+/, "");
+  normalized = normalized.replace(/^https?:\/\/[^/]+\/+/, "");
+  normalized = normalized.replace(/\?.*$/, "");
+  normalized = normalized.replace(/:\d+(?::\d+)?$/, "");
+
+  const parts = normalized.split(/[/\\]/).filter(Boolean);
+  if (parts.length >= 2) {
+    return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`;
+  }
+  return parts[parts.length - 1] || normalized;
+}
+
+function isNoiseFrame(frame: ErrorTrackingStackFrame): boolean {
+  const file = frame.filename || "";
+  return NOISE_FRAME_PATH_RE.test(file) || /^webpack/i.test(file);
+}
+
+function formatFrameForFingerprint(frame: ErrorTrackingStackFrame): string {
+  const file = frame.filename
+    ? normalizeFilenameForFingerprint(frame.filename)
+    : "?";
+  const fn = frame.function?.trim();
+  const fnLabel = fn && !/^(?:anonymous|unknown)$/i.test(fn) ? fn : "?";
+  return `${fnLabel}@${file}`;
+}
+
+function selectFingerprintFrames(
+  frames: ErrorTrackingStackFrame[],
+): ErrorTrackingStackFrame[] {
+  const appFrames = frames.filter((frame) => !isNoiseFrame(frame));
+  const candidates = appFrames.length ? appFrames : frames;
+  const selected: ErrorTrackingStackFrame[] = [];
+  const seen = new Set<string>();
+
+  for (const frame of candidates) {
+    const label = formatFrameForFingerprint(frame);
+    if (seen.has(label)) {
+      continue;
+    }
+    seen.add(label);
+    selected.push(frame);
+    if (selected.length >= FINGERPRINT_FRAME_LIMIT) {
+      break;
+    }
+  }
+
+  return selected;
+}
+
+/**
+ * Stable issue grouping key from error type, normalized message, and
+ * application stack frames (without line/column numbers).
+ */
+export function fingerprintForError(
+  message: string,
+  stack?: string,
+  errorName?: string,
+  messageForFingerprint?: string,
+): string {
+  const frames = parseStackFrames(stack);
+  const selectedFrames = selectFingerprintFrames(frames);
+  const fingerprintMessage = messageForFingerprint ?? message;
+  const parts = [
+    errorName?.trim() || "Error",
+    normalizeErrorMessageForFingerprint(fingerprintMessage),
+    ...selectedFrames.map(formatFrameForFingerprint),
+  ];
+
+  return hashFingerprintParts(parts);
+}
+
+export type BuiltErrorEventProps = {
+  fingerprint: string;
+  /** Human-readable issue line; same as {@link BuiltErrorEventProps.message}. */
+  title: string;
+  /** Full interpolated `Error.message` (for UI / warehouse; fingerprint may use a static pattern). */
+  message: string;
+  errorType: string;
+  stack?: string;
+  stackFrames: ErrorTrackingStackFrame[];
+  transaction?: string;
+  release?: string;
+  runtime?: string;
+  tags?: Record<string, string>;
+  contexts?: Record<string, unknown>;
+  breadcrumbs?: { ts: number; type: string; message: string }[];
+  handled?: boolean;
+};
+
+export function buildErrorEventProperties(
+  error: unknown,
+  extras?: Record<string, unknown>,
+): BuiltErrorEventProps & Record<string, unknown> {
+  const { message, stack, name } = stringifyUnknown(error);
+  const stackFrames = parseStackFrames(stack);
+  const composedPattern = getComposedErrorPattern(error);
+  const fingerprint = fingerprintForError(
+    message,
+    stack,
+    name,
+    composedPattern,
+  );
+
+  const {
+    errorType,
+    transaction,
+    release,
+    runtime,
+    tags,
+    contexts,
+    breadcrumbs,
+    handled,
+    title: _extrasTitle,
+    fingerprint: _extrasFingerprint,
+    message: _extrasMessage,
+    ...rest
+  } = extras || {};
+
+  const displayMessage =
+    message.length > 500 ? `${message.slice(0, 497)}...` : message;
+
+  return {
+    ...rest,
+    fingerprint,
+    title: displayMessage,
+    message: displayMessage,
+    errorType: typeof errorType === "string" ? errorType : "unknown",
+    stack: stack?.slice(0, 50_000),
+    stackFrames,
+    transaction: typeof transaction === "string" ? transaction : undefined,
+    release: typeof release === "string" ? release : undefined,
+    runtime:
+      typeof runtime === "string"
+        ? runtime
+        : typeof navigator !== "undefined"
+          ? "browser"
+          : "javascript",
+    tags:
+      tags && typeof tags === "object"
+        ? (tags as Record<string, string>)
+        : undefined,
+    contexts:
+      contexts && typeof contexts === "object"
+        ? (contexts as Record<string, unknown>)
+        : undefined,
+    breadcrumbs: Array.isArray(breadcrumbs) ? breadcrumbs : undefined,
+    handled: typeof handled === "boolean" ? handled : undefined,
+  };
+}
+
+async function logError(
+  gb: GrowthBook | UserScopedGrowthBook | GrowthBookClient,
+  error: unknown,
+  extras?: Record<string, unknown>,
+) {
+  const props = buildErrorEventProperties(error, extras);
+  if (gb instanceof GrowthBook || gb instanceof UserScopedGrowthBook) {
+    await gb.logEvent(EVENT_GROWTHBOOK_ERROR, props);
+    return;
+  }
+  if (gb instanceof GrowthBookClient) {
+    console.warn(
+      "growthbookErrorTrackingPlugin: use GrowthBook or a scoped UserScopedGrowthBook instance (not the root GrowthBookClient).",
+    );
+  }
+}
+
+export async function captureGrowthBookError(
+  gb: GrowthBook | UserScopedGrowthBook | GrowthBookClient,
+  error: unknown,
+  extras?: Record<string, unknown>,
+): Promise<void> {
+  await logError(gb, error, extras);
+}
+
+function defaultBrowserContexts(): Record<string, unknown> {
+  if (typeof navigator === "undefined") return {};
+  return {
+    browser: {
+      name: navigator.userAgent,
+      language: navigator.language,
+      cookieEnabled: navigator.cookieEnabled,
+    },
+    device: {
+      screen:
+        typeof screen !== "undefined" ? `${screen.width}x${screen.height}` : "",
+      pixelRatio:
+        typeof window !== "undefined" ? window.devicePixelRatio : undefined,
+    },
+  };
+}
+
+function readGrowthBookAttributes(
+  gb: GrowthBook | UserScopedGrowthBook | GrowthBookClient,
+): Attributes {
+  try {
+    if ("getAttributes" in gb && typeof gb.getAttributes === "function") {
+      return gb.getAttributes() || {};
+    }
+  } catch {
+    /* ignore */
+  }
+  return {};
+}
+
+export function growthbookErrorTrackingPlugin({
+  enable = true,
+  captureUnhandled = true,
+  captureUnhandledRejections = true,
+  dedupeWindowMs = 2000,
+  release,
+  getRelease,
+  runtime,
+  getTransaction,
+}: {
+  enable?: boolean;
+  captureUnhandled?: boolean;
+  captureUnhandledRejections?: boolean;
+  /** Skip logging when the same fingerprint was reported very recently. */
+  dedupeWindowMs?: number;
+  /** e.g. git SHA or app version — also appears in event tags. */
+  release?: string;
+  /** Resolve release at capture time (overrides static `release`). */
+  getRelease?: () => string | undefined;
+  runtime?: string;
+  /** Optional transaction name (e.g. React route). */
+  getTransaction?: () => string | undefined;
+} = {}) {
+  return (gb: GrowthBook | UserScopedGrowthBook | GrowthBookClient) => {
+    const browser = typeof window !== "undefined";
+
+    const clientKey =
+      "getClientKey" in gb && typeof gb.getClientKey === "function"
+        ? gb.getClientKey()
+        : null;
+    if (!clientKey) {
+      throw new Error(
+        "clientKey must be specified to use GrowthBook error tracking",
+      );
+    }
+
+    const recentFingerprints = new Map<string, number>();
+    const resolveRelease = (extras?: Record<string, unknown>) => {
+      if (typeof extras?.release === "string" && extras.release) {
+        return extras.release;
+      }
+      const dynamicRelease = getRelease?.();
+      if (typeof dynamicRelease === "string" && dynamicRelease) {
+        return dynamicRelease;
+      }
+      return typeof release === "string" ? release : undefined;
+    };
+
+    const run = async (error: unknown, extras?: Record<string, unknown>) => {
+      if (!enable) return;
+
+      const now = Date.now();
+      recentFingerprints.forEach((ts, fp) => {
+        if (now - ts >= dedupeWindowMs) {
+          recentFingerprints.delete(fp);
+        }
+      });
+
+      const propsPreview = buildErrorEventProperties(error, extras);
+      const fp = propsPreview.fingerprint;
+      const last = recentFingerprints.get(fp);
+      if (last !== undefined && now - last < dedupeWindowMs) {
+        return;
+      }
+      recentFingerprints.set(fp, now);
+
+      const attrs = readGrowthBookAttributes(gb);
+      const envTag =
+        typeof attrs.environment === "string"
+          ? attrs.environment
+          : typeof attrs.gbEnvironment === "string"
+            ? attrs.gbEnvironment
+            : undefined;
+      const resolvedRelease = resolveRelease(extras);
+
+      const tags: Record<string, string> = {
+        ...(resolvedRelease ? { release: resolvedRelease } : {}),
+        ...(envTag ? { environment: envTag } : {}),
+      };
+
+      await logError(gb, error, {
+        ...extras,
+        release: resolvedRelease,
+        runtime:
+          extras?.runtime ?? runtime ?? (browser ? "browser" : "javascript"),
+        tags: { ...tags, ...(extras?.tags as Record<string, string>) },
+        contexts: {
+          ...defaultBrowserContexts(),
+          ...(typeof extras?.contexts === "object" ? extras.contexts : {}),
+        },
+      });
+    };
+
+    if (!browser || (!captureUnhandled && !captureUnhandledRejections)) {
+      return;
+    }
+
+    const onError = (event: ErrorEvent) => {
+      const err = event.error;
+      void run(err ?? event.message, {
+        errorType: "uncaught",
+        handled: false,
+        transaction: getTransaction?.(),
+      });
+    };
+
+    const onRejection = (event: PromiseRejectionEvent) => {
+      void run(event.reason, {
+        errorType: "unhandledrejection",
+        handled: false,
+        transaction: getTransaction?.(),
+      });
+    };
+
+    if (captureUnhandled) {
+      window.addEventListener("error", onError);
+    }
+    if (captureUnhandledRejections) {
+      window.addEventListener("unhandledrejection", onRejection);
+    }
+
+    const cleanup = () => {
+      window.removeEventListener("error", onError);
+      window.removeEventListener("unhandledrejection", onRejection);
+    };
+
+    if ("onDestroy" in gb && typeof gb.onDestroy === "function") {
+      gb.onDestroy(cleanup);
+    }
+  };
+}

--- a/packages/sdk-js/src/plugins/growthbook-error-tracking.ts
+++ b/packages/sdk-js/src/plugins/growthbook-error-tracking.ts
@@ -121,17 +121,117 @@ export function growthbookComposedError(
   return err;
 }
 
-/** Collapse volatile message values while keeping static wording. */
+/**
+ * Collapse `{...}` segments (e.g. JSON payloads) innermost-first so dynamic
+ * object bodies do not split fingerprints. No-op when braces are absent.
+ */
+export function collapseBraceSegments(message: string): string {
+  if (!message.includes("{") || !message.includes("}")) {
+    return message;
+  }
+  let normalized = message;
+  for (let pass = 0; pass < 64; pass++) {
+    const start = normalized.indexOf("{");
+    if (start < 0) {
+      break;
+    }
+    let depth = 0;
+    let end = -1;
+    for (let i = start; i < normalized.length; i++) {
+      const ch = normalized[i];
+      if (ch === "{") {
+        depth++;
+      } else if (ch === "}") {
+        depth--;
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+    if (end < 0) {
+      break;
+    }
+    const inner = normalized.slice(start + 1, end);
+    if (!inner.length) {
+      break;
+    }
+    normalized = normalized.slice(0, start) + "{}" + normalized.slice(end + 1);
+  }
+  return normalized;
+}
+
+/**
+ * Normalize volatile fragments in error messages for stable issue grouping.
+ *
+ * Inspired by Sentry's server-side message parameterization (see
+ * `sentry/grouping/parameterization.py`): replace emails, URLs, IDs, dates,
+ * etc. with placeholders. Unlike Sentry, we also fold stack frames into the
+ * fingerprint client-side; Sentry primarily groups on stack when available.
+ */
 export function normalizeErrorMessageForFingerprint(message: string): string {
   let normalized = message.trim();
+  normalized = collapseBraceSegments(normalized);
+
+  // W3C traceparent / AWS ALB trace ids
   normalized = normalized.replace(
-    /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
+    /\b00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]\b/gi,
+    "{trace}",
+  );
+  normalized = normalized.replace(
+    /\b1-[0-9a-f]{8}-[0-9a-f]{24}\b/gi,
+    "{trace}",
+  );
+
+  normalized = normalized.replace(
+    /[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)+/g,
+    "{email}",
+  );
+  normalized = normalized.replace(/https?:\/\/\S+/gi, "{url}");
+  normalized = normalized.replace(/\bwww\.\S+/gi, "{url}");
+
+  normalized = normalized.replace(
+    /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi,
     "{uuid}",
   );
+
+  // Distinct hash lengths before generic hex (Sentry: sha1 / md5)
+  normalized = normalized.replace(/\b[0-9a-f]{40}\b/gi, "{sha1}");
+  normalized = normalized.replace(/\b[0-9a-f]{32}\b/gi, "{md5}");
+
+  normalized = normalized.replace(/\b(?:\d{1,3}\.){3}\d{1,3}\b/g, "{ip}");
+
+  normalized = normalized.replace(
+    /\d{4}-[01]\d-[0-3]\d(?:[T\s][0-2]\d:[0-5]\d(?::[0-5]\d)?(?:\.\d+)?(?:Z|[+-][0-2]\d:?[0-5]\d)?)?/g,
+    "{datetime}",
+  );
+
+  normalized = normalized.replace(/"[^"]{3,}"/g, "{str}");
+  normalized = normalized.replace(/'[^']{3,}'/g, "{str}");
+
+  normalized = normalized.replace(
+    /(?:\/?[\w.-]+)+\.(?:tsx?|jsx?|mjs|cjs|vue|py|go|rb|java|cs|php|rs)\b/gi,
+    "{path}",
+  );
+
   normalized = normalized.replace(/\b0x[0-9a-f]+\b/gi, "{hex}");
-  normalized = normalized.replace(/\b[0-9a-f]{16,}\b/gi, "{hex}");
-  normalized = normalized.replace(/https?:\/\/\S+/gi, "{url}");
-  normalized = normalized.replace(/\b\d+\b/g, "{n}");
+  normalized = normalized.replace(
+    /\b(?=[0-9a-f]*[a-f])(?=[0-9a-f]*[0-9])[0-9a-f]{8,}\b/gi,
+    "{hex}",
+  );
+
+  normalized = normalized.replace(/\btx[0-9a-f]{21}-[0-9a-f]{10}\S*/gi, "{id}");
+
+  // Mixed alphanumeric tokens (request ids, base64-ish chunks, etc.)
+  normalized = normalized.replace(
+    /\b(?=[\w-]*[a-zA-Z])(?=[\w-]*[0-9])[\w-]{8,}\b/g,
+    "{id}",
+  );
+
+  normalized = normalized.replace(/\b\d+(\.\d+)?ms\b/gi, "{duration}");
+  normalized = normalized.replace(/\b-?\d{1,3}(?:,\d{3})+(?:\.\d+)?\b/g, "{n}");
+  normalized = normalized.replace(/\b-?\d+\.\d+\b/g, "{n}");
+  normalized = normalized.replace(/\b-?\d+\b/g, "{n}");
   normalized = normalized.replace(/\s+/g, " ");
   return normalized;
 }
@@ -229,12 +329,10 @@ export type BuiltErrorEventProps = {
   handled?: boolean;
 };
 
-type ParsedErrorCore = Pick<
-  BuiltErrorEventProps,
-  "fingerprint" | "title" | "message" | "stack" | "stackFrames"
->;
-
-function parseErrorCore(error: unknown): ParsedErrorCore {
+export function buildErrorEventProperties(
+  error: unknown,
+  extras?: Record<string, unknown>,
+): BuiltErrorEventProps & Record<string, unknown> {
   const { message, stack, name } = stringifyUnknown(error);
   const stackFrames = parseStackFrames(stack);
   const composedPattern = getComposedErrorPattern(error);
@@ -244,27 +342,6 @@ function parseErrorCore(error: unknown): ParsedErrorCore {
     name,
     composedPattern,
   );
-  const displayMessage =
-    message.length > 500 ? `${message.slice(0, 497)}...` : message;
-
-  return {
-    fingerprint,
-    title: displayMessage,
-    message: displayMessage,
-    stack: stack?.slice(0, 50_000),
-    stackFrames,
-  };
-}
-
-function mergeErrorEventExtras(
-  core: ParsedErrorCore,
-  extras?: Record<string, unknown>,
-): BuiltErrorEventProps & Record<string, unknown> {
-  const { title, fingerprint, message, ...extrasWithoutCoreFields } =
-    extras || {};
-  void title;
-  void fingerprint;
-  void message;
 
   const {
     errorType,
@@ -275,13 +352,23 @@ function mergeErrorEventExtras(
     contexts,
     breadcrumbs,
     handled,
+    title: _extrasTitle,
+    fingerprint: _extrasFingerprint,
+    message: _extrasMessage,
     ...rest
-  } = extrasWithoutCoreFields;
+  } = extras || {};
+
+  const displayMessage =
+    message.length > 500 ? `${message.slice(0, 497)}...` : message;
 
   return {
     ...rest,
-    ...core,
+    fingerprint,
+    title: displayMessage,
+    message: displayMessage,
     errorType: typeof errorType === "string" ? errorType : "unknown",
+    stack: stack?.slice(0, 50_000),
+    stackFrames,
     transaction: typeof transaction === "string" ? transaction : undefined,
     release: typeof release === "string" ? release : undefined,
     runtime:
@@ -303,22 +390,12 @@ function mergeErrorEventExtras(
   };
 }
 
-export function buildErrorEventProperties(
-  error: unknown,
-  extras?: Record<string, unknown>,
-): BuiltErrorEventProps & Record<string, unknown> {
-  return mergeErrorEventExtras(parseErrorCore(error), extras);
-}
-
 async function logError(
   gb: GrowthBook | UserScopedGrowthBook | GrowthBookClient,
   error: unknown,
   extras?: Record<string, unknown>,
-  parsedCore?: ParsedErrorCore,
 ) {
-  const props = parsedCore
-    ? mergeErrorEventExtras(parsedCore, extras)
-    : buildErrorEventProperties(error, extras);
+  const props = buildErrorEventProperties(error, extras);
   if (gb instanceof GrowthBook || gb instanceof UserScopedGrowthBook) {
     await gb.logEvent(EVENT_GROWTHBOOK_ERROR, props);
     return;
@@ -419,15 +496,9 @@ export function growthbookErrorTrackingPlugin({
     const run = async (error: unknown, extras?: Record<string, unknown>) => {
       if (!enable) return;
 
+      const propsPreview = buildErrorEventProperties(error, extras);
+      const fp = propsPreview.fingerprint;
       const now = Date.now();
-      recentFingerprints.forEach((ts, fp) => {
-        if (now - ts >= dedupeWindowMs) {
-          recentFingerprints.delete(fp);
-        }
-      });
-
-      const parsedCore = parseErrorCore(error);
-      const fp = parsedCore.fingerprint;
       const last = recentFingerprints.get(fp);
       if (last !== undefined && now - last < dedupeWindowMs) {
         return;
@@ -448,30 +519,20 @@ export function growthbookErrorTrackingPlugin({
         ...(envTag ? { environment: envTag } : {}),
       };
 
-      await logError(
-        gb,
-        error,
-        {
-          ...extras,
-          release: resolvedRelease,
-          runtime:
-            extras?.runtime ?? runtime ?? (browser ? "browser" : "javascript"),
-          tags: { ...tags, ...(extras?.tags as Record<string, string>) },
-          contexts: {
-            ...defaultBrowserContexts(),
-            ...(typeof extras?.contexts === "object" ? extras.contexts : {}),
-          },
+      await logError(gb, error, {
+        ...extras,
+        release: resolvedRelease,
+        runtime:
+          extras?.runtime ?? runtime ?? (browser ? "browser" : "javascript"),
+        tags: { ...tags, ...(extras?.tags as Record<string, string>) },
+        contexts: {
+          ...defaultBrowserContexts(),
+          ...(typeof extras?.contexts === "object" ? extras.contexts : {}),
         },
-        parsedCore,
-      );
+      });
     };
 
-    if (
-      !enable ||
-      !browser ||
-      (!captureUnhandled && !captureUnhandledRejections) ||
-      gb instanceof GrowthBookClient
-    ) {
+    if (!browser || (!captureUnhandled && !captureUnhandledRejections)) {
       return;
     }
 

--- a/packages/sdk-js/src/plugins/growthbook-error-tracking.ts
+++ b/packages/sdk-js/src/plugins/growthbook-error-tracking.ts
@@ -466,7 +466,12 @@ export function growthbookErrorTrackingPlugin({
       );
     };
 
-    if (!browser || (!captureUnhandled && !captureUnhandledRejections)) {
+    if (
+      !enable ||
+      !browser ||
+      (!captureUnhandled && !captureUnhandledRejections) ||
+      gb instanceof GrowthBookClient
+    ) {
       return;
     }
 

--- a/packages/sdk-js/src/plugins/index.ts
+++ b/packages/sdk-js/src/plugins/index.ts
@@ -4,10 +4,8 @@ export {
   growthbookErrorTrackingPlugin,
   captureGrowthBookError,
   buildErrorEventProperties,
-  fingerprintForError,
+  setFingerprint,
   parseStackFrames,
-  growthbookComposedError,
-  GROWTHBOOK_COMPOSED_ERROR_PATTERN,
 } from "./growthbook-error-tracking";
 export { thirdPartyTrackingPlugin } from "./third-party-tracking";
 export {

--- a/packages/sdk-js/src/plugins/index.ts
+++ b/packages/sdk-js/src/plugins/index.ts
@@ -1,5 +1,14 @@
 export { autoAttributesPlugin } from "./auto-attributes";
 export { growthbookTrackingPlugin } from "./growthbook-tracking";
+export {
+  growthbookErrorTrackingPlugin,
+  captureGrowthBookError,
+  buildErrorEventProperties,
+  fingerprintForError,
+  parseStackFrames,
+  growthbookComposedError,
+  GROWTHBOOK_COMPOSED_ERROR_PATTERN,
+} from "./growthbook-error-tracking";
 export { thirdPartyTrackingPlugin } from "./third-party-tracking";
 export {
   devtoolsPlugin,

--- a/packages/sdk-js/src/plugins/index.ts
+++ b/packages/sdk-js/src/plugins/index.ts
@@ -4,7 +4,6 @@ export {
   growthbookErrorTrackingPlugin,
   captureGrowthBookError,
   buildErrorEventProperties,
-  setFingerprint,
   parseStackFrames,
 } from "./growthbook-error-tracking";
 export type {

--- a/packages/sdk-js/src/plugins/index.ts
+++ b/packages/sdk-js/src/plugins/index.ts
@@ -7,6 +7,12 @@ export {
   setFingerprint,
   parseStackFrames,
 } from "./growthbook-error-tracking";
+export type {
+  BuiltErrorEventProps,
+  CaptureGrowthBookErrorOptions,
+  ErrorTrackingStackFrame,
+  GrowthBookErrorEventProps,
+} from "./growthbook-error-tracking";
 export { thirdPartyTrackingPlugin } from "./third-party-tracking";
 export {
   devtoolsPlugin,

--- a/packages/sdk-js/test/plugins/growthbook-error-tracking.test.ts
+++ b/packages/sdk-js/test/plugins/growthbook-error-tracking.test.ts
@@ -186,6 +186,8 @@ describe("growthbookErrorTracking helpers", () => {
   });
 
   it("captures scoped unhandled errors until the scoped instance is destroyed", async () => {
+    const addSpy = jest.spyOn(window, "addEventListener");
+    const removeSpy = jest.spyOn(window, "removeEventListener");
     const eventLogger = jest.fn();
     const client = new GrowthBookClient({
       clientKey: "test",
@@ -195,6 +197,12 @@ describe("growthbookErrorTracking helpers", () => {
       { attributes: { id: "123" } },
       [growthbookErrorTrackingPlugin()],
     );
+    const errorListener = addSpy.mock.calls.find(
+      ([eventName]) => eventName === "error",
+    )?.[1];
+    const rejectionListener = addSpy.mock.calls.find(
+      ([eventName]) => eventName === "unhandledrejection",
+    )?.[1];
 
     window.dispatchEvent(
       new ErrorEvent("error", {
@@ -216,15 +224,11 @@ describe("growthbookErrorTracking helpers", () => {
     );
 
     scoped.destroy();
-    window.dispatchEvent(
-      new ErrorEvent("error", {
-        error: new Error("second"),
-        message: "second",
-      }),
+    expect(removeSpy).toHaveBeenCalledWith("error", errorListener);
+    expect(removeSpy).toHaveBeenCalledWith(
+      "unhandledrejection",
+      rejectionListener,
     );
-    await Promise.resolve();
-
-    expect(eventLogger).toHaveBeenCalledTimes(1);
     client.destroy();
   });
 });

--- a/packages/sdk-js/test/plugins/growthbook-error-tracking.test.ts
+++ b/packages/sdk-js/test/plugins/growthbook-error-tracking.test.ts
@@ -2,12 +2,17 @@ import {
   buildErrorEventProperties,
   fingerprintForError,
   growthbookComposedError,
+  growthbookErrorTrackingPlugin,
   normalizeErrorMessageForFingerprint,
   normalizeFilenameForFingerprint,
 } from "../../src/plugins/growthbook-error-tracking";
-import { EVENT_GROWTHBOOK_ERROR } from "../../src/core";
+import { EVENT_GROWTHBOOK_ERROR, GrowthBook, GrowthBookClient } from "../../src";
 
 describe("growthbookErrorTracking helpers", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("uses stable fingerprint for same message and stack", () => {
     const err = new Error("boom");
     err.stack = "Error: boom\n  at foo (file.js:1:2)";
@@ -148,5 +153,78 @@ describe("growthbookErrorTracking helpers", () => {
 
   it("EVENT_GROWTHBOOK_ERROR matches warehouse filter string", () => {
     expect(EVENT_GROWTHBOOK_ERROR).toEqual("GrowthBook Error");
+  });
+
+  it("does not register unhandled listeners when disabled", () => {
+    const addSpy = jest.spyOn(window, "addEventListener");
+
+    growthbookErrorTrackingPlugin({ enable: false })(
+      new GrowthBook({ clientKey: "test" }),
+    );
+
+    expect(addSpy).not.toHaveBeenCalledWith("error", expect.any(Function));
+    expect(addSpy).not.toHaveBeenCalledWith(
+      "unhandledrejection",
+      expect.any(Function),
+    );
+  });
+
+  it("does not register unhandled listeners on the root multi-user client", () => {
+    const addSpy = jest.spyOn(window, "addEventListener");
+
+    const client = new GrowthBookClient({
+      clientKey: "test",
+      plugins: [growthbookErrorTrackingPlugin()],
+    });
+
+    expect(addSpy).not.toHaveBeenCalledWith("error", expect.any(Function));
+    expect(addSpy).not.toHaveBeenCalledWith(
+      "unhandledrejection",
+      expect.any(Function),
+    );
+    client.destroy();
+  });
+
+  it("captures scoped unhandled errors until the scoped instance is destroyed", async () => {
+    const eventLogger = jest.fn();
+    const client = new GrowthBookClient({
+      clientKey: "test",
+      eventLogger,
+    });
+    const scoped = client.createScopedInstance(
+      { attributes: { id: "123" } },
+      [growthbookErrorTrackingPlugin()],
+    );
+
+    window.dispatchEvent(
+      new ErrorEvent("error", {
+        error: new Error("first"),
+        message: "first",
+      }),
+    );
+    await Promise.resolve();
+
+    expect(eventLogger).toHaveBeenCalledTimes(1);
+    expect(eventLogger).toHaveBeenCalledWith(
+      EVENT_GROWTHBOOK_ERROR,
+      expect.objectContaining({
+        errorType: "uncaught",
+        handled: false,
+        message: "first",
+      }),
+      expect.any(Object),
+    );
+
+    scoped.destroy();
+    window.dispatchEvent(
+      new ErrorEvent("error", {
+        error: new Error("second"),
+        message: "second",
+      }),
+    );
+    await Promise.resolve();
+
+    expect(eventLogger).toHaveBeenCalledTimes(1);
+    client.destroy();
   });
 });

--- a/packages/sdk-js/test/plugins/growthbook-error-tracking.test.ts
+++ b/packages/sdk-js/test/plugins/growthbook-error-tracking.test.ts
@@ -1,182 +1,72 @@
 import {
   buildErrorEventProperties,
-  collapseBraceSegments,
-  fingerprintForError,
-  growthbookComposedError,
-  normalizeErrorMessageForFingerprint,
-  normalizeFilenameForFingerprint,
+  captureGrowthBookError,
+  setFingerprint,
 } from "../../src/plugins/growthbook-error-tracking";
+import { GrowthBook } from "../../src/GrowthBook";
 import { EVENT_GROWTHBOOK_ERROR } from "../../src/core";
 
 describe("growthbookErrorTracking helpers", () => {
-  it("uses stable fingerprint for same message and stack", () => {
-    const err = new Error("boom");
-    err.stack = "Error: boom\n  at foo (file.js:1:2)";
-    const a = fingerprintForError(err.message, err.stack, err.name);
-    const b = fingerprintForError(err.message, err.stack, err.name);
-    expect(a).toEqual(b);
-    expect(a.length).toBeGreaterThan(4);
-  });
-
-  it("ignores line and column changes in the same frame", () => {
-    const stackA =
-      "Error: boom\n  at onClick (src/app/errors-demo/page.tsx:120:11)";
-    const stackB =
-      "Error: boom\n  at onClick (src/app/errors-demo/page.tsx:188:7)";
-    expect(fingerprintForError("boom", stackA, "Error")).toEqual(
-      fingerprintForError("boom", stackB, "Error"),
-    );
-  });
-
-  it("ignores bundled path prefixes for the same source file", () => {
-    const stackA =
-      "Error: boom\n  at onClick (src/app/errors-demo/page.tsx:10:1)";
-    const stackB =
-      "Error: boom\n  at onClick (webpack-internal:///(app-pages-browser)/./src/app/errors-demo/page.tsx:10:1)";
-    expect(fingerprintForError("boom", stackA, "Error")).toEqual(
-      fingerprintForError("boom", stackB, "Error"),
-    );
-  });
-
-  it("groups dynamic message values with the same template", () => {
-    const stack = "Error: boom\n  at loadUser (src/services/users.ts:40:5)";
-    expect(fingerprintForError("User 123 not found", stack, "Error")).toEqual(
-      fingerprintForError("User 456 not found", stack, "Error"),
-    );
-  });
-
-  it("separates different static messages at the same stack location", () => {
-    const stack = "Error: boom\n  at loadUser (src/services/users.ts:40:5)";
-    expect(fingerprintForError("User not found", stack, "Error")).not.toEqual(
-      fingerprintForError("Order not found", stack, "Error"),
-    );
-  });
-
-  it("separates different error types with the same message and stack", () => {
-    const stack = "Error: boom\n  at loadUser (src/services/users.ts:40:5)";
-    expect(fingerprintForError("boom", stack, "Error")).not.toEqual(
-      fingerprintForError("boom", stack, "TypeError"),
-    );
-  });
-
-  it("normalizes volatile message values", () => {
-    expect(normalizeErrorMessageForFingerprint("User 123 failed")).toEqual(
-      "User {n} failed",
-    );
-    expect(
-      normalizeErrorMessageForFingerprint(
-        "Request failed for https://example.com/a",
-      ),
-    ).toEqual("Request failed for {url}");
-  });
-
-  it("collapses JSON and nested brace segments", () => {
-    expect(
-      collapseBraceSegments('API failed {"code":404,"user":"alice"}'),
-    ).toEqual("API failed {}");
-    expect(collapseBraceSegments("outer { a: { b: 1 } } tail")).toEqual(
-      "outer {} tail",
-    );
-  });
-
-  it("normalizes emails, hashes, and quoted strings", () => {
-    const sha1 = "a".repeat(40);
-    expect(
-      normalizeErrorMessageForFingerprint(
-        `Notify admin@example.com about ${sha1}`,
-      ),
-    ).toEqual("Notify {email} about {sha1}");
-    expect(
-      normalizeErrorMessageForFingerprint('Validation: "field x is invalid"'),
-    ).toEqual("Validation: {str}");
-  });
-
-  it("groups errors whose messages differ only by JSON payloads", () => {
-    const stack = "Error: boom\n  at save (src/api/client.ts:40:5)";
-    expect(
-      fingerprintForError('Save failed {"id":1,"name":"a"}', stack, "Error"),
-    ).toEqual(
-      fingerprintForError('Save failed {"id":99,"name":"zzz"}', stack, "Error"),
-    );
-  });
-
-  it("groups errors with different opaque alphanumeric ids", () => {
-    const stack = "Error: boom\n  at run (src/job.ts:10:1)";
-    expect(
-      fingerprintForError("Job abc12xyz99 failed", stack, "Error"),
-    ).toEqual(fingerprintForError("Job qwerty9999 failed", stack, "Error"));
-  });
-
-  it("normalizes bundled filenames to app-relative labels", () => {
-    expect(
-      normalizeFilenameForFingerprint(
-        "webpack-internal:///(app-pages-browser)/./src/app/errors-demo/page.tsx:10:1",
-      ),
-    ).toEqual("errors-demo/page.tsx");
-  });
-
-  it("builds GrowthBook Error payload shape", () => {
-    const props = buildErrorEventProperties(new Error("x"), {
+  it("builds GrowthBook Error payload without client fingerprint", () => {
+    const err = new Error("something broke");
+    err.stack = "Error: something broke\n  at foo (file.js:1:2)";
+    const props = buildErrorEventProperties(err, {
       errorType: "manual",
     });
-    expect(props.title).toContain("x");
+    expect(props.title).toContain("something broke");
     expect(props.message).toEqual(props.title);
-    expect(props.fingerprint).toBeTruthy();
+    expect(props.fingerprint).toBeUndefined();
     expect(props.errorType).toEqual("manual");
     expect(Array.isArray(props.stackFrames)).toBe(true);
   });
 
-  it("groups composed / template-literal tails when tagged with growthbookComposedError", () => {
-    const stack = "Error: x\n  at demo (src/app/errors-demo/page.tsx:99:11)";
-    const a = fingerprintForError(
-      "Demo: hello abc12xyz suffix",
-      stack,
-      "Error",
-      "Demo: hello {} suffix",
+  it("setFingerprint applies a string fingerprint on the next capture", async () => {
+    const gb = new GrowthBook({ clientKey: "sdk-test" });
+    const logEvent = jest.fn();
+    gb.logEvent = logEvent;
+
+    setFingerprint(gb, "my-custom-group");
+    await captureGrowthBookError(gb, new Error("volatile 123"), {
+      errorType: "manual",
+    });
+
+    expect(logEvent).toHaveBeenCalledWith(
+      EVENT_GROWTHBOOK_ERROR,
+      expect.objectContaining({
+        fingerprint: "my-custom-group",
+        message: "volatile 123",
+      }),
     );
-    const b = fingerprintForError(
-      "Demo: hello def99zzz suffix",
-      stack,
-      "Error",
-      "Demo: hello {} suffix",
-    );
-    expect(a).toEqual(b);
-    expect(
-      fingerprintForError(
-        "Demo: hello abc12xyz suffix",
-        stack,
-        "Error",
-        "Different static {} suffix",
-      ),
-    ).not.toEqual(a);
   });
 
-  it("growthbookComposedError fingerprints ignore interpolated random segments", () => {
-    const errA = growthbookComposedError`Demo test (${"rand-a-9x2z"}) tail`;
-    errA.stack = "Error\n  at t (demo.tsx:1:2)";
-    const errB = growthbookComposedError`Demo test (${"DIFFERENT-ID"}) tail`;
-    errB.stack = errA.stack;
-    expect(buildErrorEventProperties(errA).fingerprint).toEqual(
-      buildErrorEventProperties(errB).fingerprint,
+  it("setFingerprint applies fingerprintParts on the next capture", async () => {
+    const gb = new GrowthBook({ clientKey: "sdk-test" });
+    const logEvent = jest.fn();
+    gb.logEvent = logEvent;
+
+    setFingerprint(gb, ["checkout", "failed"]);
+    await captureGrowthBookError(gb, new Error("order 999"), {
+      errorType: "manual",
+    });
+
+    expect(logEvent).toHaveBeenCalledWith(
+      EVENT_GROWTHBOOK_ERROR,
+      expect.objectContaining({
+        fingerprintParts: ["checkout", "failed"],
+      }),
     );
-    const propsA = buildErrorEventProperties(errA);
-    expect(propsA.title).toContain("rand-a-9x2z");
-    expect(propsA.message).toContain("rand-a-9x2z");
-    expect(propsA.title).not.toContain("{}");
+    const props = logEvent.mock.calls[0][1];
+    expect(props.fingerprint).toBeUndefined();
   });
 
-  it("extras cannot override fingerprint, title, or message", () => {
+  it("extras cannot override title or message", () => {
     const err = new Error("real message");
     const props = buildErrorEventProperties(err, {
       title: "wrong title",
-      fingerprint: "deadbeef",
       message: "wrong message",
     } as Record<string, unknown>);
     expect(props.title).toEqual("real message");
     expect(props.message).toEqual("real message");
-    expect(props.fingerprint).toEqual(
-      buildErrorEventProperties(err).fingerprint,
-    );
   });
 
   it("EVENT_GROWTHBOOK_ERROR matches warehouse filter string", () => {

--- a/packages/sdk-js/test/plugins/growthbook-error-tracking.test.ts
+++ b/packages/sdk-js/test/plugins/growthbook-error-tracking.test.ts
@@ -1,22 +1,14 @@
 import {
   buildErrorEventProperties,
+  collapseBraceSegments,
   fingerprintForError,
   growthbookComposedError,
-  growthbookErrorTrackingPlugin,
   normalizeErrorMessageForFingerprint,
   normalizeFilenameForFingerprint,
 } from "../../src/plugins/growthbook-error-tracking";
-import {
-  EVENT_GROWTHBOOK_ERROR,
-  GrowthBook,
-  GrowthBookClient,
-} from "../../src";
+import { EVENT_GROWTHBOOK_ERROR } from "../../src/core";
 
 describe("growthbookErrorTracking helpers", () => {
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
   it("uses stable fingerprint for same message and stack", () => {
     const err = new Error("boom");
     err.stack = "Error: boom\n  at foo (file.js:1:2)";
@@ -76,11 +68,43 @@ describe("growthbookErrorTracking helpers", () => {
         "Request failed for https://example.com/a",
       ),
     ).toEqual("Request failed for {url}");
+  });
+
+  it("collapses JSON and nested brace segments", () => {
+    expect(
+      collapseBraceSegments('API failed {"code":404,"user":"alice"}'),
+    ).toEqual("API failed {}");
+    expect(collapseBraceSegments("outer { a: { b: 1 } } tail")).toEqual(
+      "outer {} tail",
+    );
+  });
+
+  it("normalizes emails, hashes, and quoted strings", () => {
+    const sha1 = "a".repeat(40);
     expect(
       normalizeErrorMessageForFingerprint(
-        "Checkout failed 018f4e2a-7b3c-7def-8a2b-9c3d4e5f6789",
+        `Notify admin@example.com about ${sha1}`,
       ),
-    ).toEqual("Checkout failed {uuid}");
+    ).toEqual("Notify {email} about {sha1}");
+    expect(
+      normalizeErrorMessageForFingerprint('Validation: "field x is invalid"'),
+    ).toEqual("Validation: {str}");
+  });
+
+  it("groups errors whose messages differ only by JSON payloads", () => {
+    const stack = "Error: boom\n  at save (src/api/client.ts:40:5)";
+    expect(
+      fingerprintForError('Save failed {"id":1,"name":"a"}', stack, "Error"),
+    ).toEqual(
+      fingerprintForError('Save failed {"id":99,"name":"zzz"}', stack, "Error"),
+    );
+  });
+
+  it("groups errors with different opaque alphanumeric ids", () => {
+    const stack = "Error: boom\n  at run (src/job.ts:10:1)";
+    expect(
+      fingerprintForError("Job abc12xyz99 failed", stack, "Error"),
+    ).toEqual(fingerprintForError("Job qwerty9999 failed", stack, "Error"));
   });
 
   it("normalizes bundled filenames to app-relative labels", () => {
@@ -157,81 +181,5 @@ describe("growthbookErrorTracking helpers", () => {
 
   it("EVENT_GROWTHBOOK_ERROR matches warehouse filter string", () => {
     expect(EVENT_GROWTHBOOK_ERROR).toEqual("GrowthBook Error");
-  });
-
-  it("does not register unhandled listeners when disabled", () => {
-    const addSpy = jest.spyOn(window, "addEventListener");
-
-    growthbookErrorTrackingPlugin({ enable: false })(
-      new GrowthBook({ clientKey: "test" }),
-    );
-
-    expect(addSpy).not.toHaveBeenCalledWith("error", expect.any(Function));
-    expect(addSpy).not.toHaveBeenCalledWith(
-      "unhandledrejection",
-      expect.any(Function),
-    );
-  });
-
-  it("does not register unhandled listeners on the root multi-user client", () => {
-    const addSpy = jest.spyOn(window, "addEventListener");
-
-    const client = new GrowthBookClient({
-      clientKey: "test",
-      plugins: [growthbookErrorTrackingPlugin()],
-    });
-
-    expect(addSpy).not.toHaveBeenCalledWith("error", expect.any(Function));
-    expect(addSpy).not.toHaveBeenCalledWith(
-      "unhandledrejection",
-      expect.any(Function),
-    );
-    client.destroy();
-  });
-
-  it("captures scoped unhandled errors until the scoped instance is destroyed", async () => {
-    const addSpy = jest.spyOn(window, "addEventListener");
-    const removeSpy = jest.spyOn(window, "removeEventListener");
-    const eventLogger = jest.fn();
-    const client = new GrowthBookClient({
-      clientKey: "test",
-      eventLogger,
-    });
-    const scoped = client.createScopedInstance({ attributes: { id: "123" } }, [
-      growthbookErrorTrackingPlugin(),
-    ]);
-    const errorListener = addSpy.mock.calls.find(
-      ([eventName]) => eventName === "error",
-    )?.[1];
-    const rejectionListener = addSpy.mock.calls.find(
-      ([eventName]) => eventName === "unhandledrejection",
-    )?.[1];
-
-    window.dispatchEvent(
-      new ErrorEvent("error", {
-        error: new Error("first"),
-        message: "first",
-      }),
-    );
-    await Promise.resolve();
-
-    expect(eventLogger).toHaveBeenCalledTimes(1);
-    expect(eventLogger).toHaveBeenCalledWith(
-      EVENT_GROWTHBOOK_ERROR,
-      expect.objectContaining({
-        errorType: "uncaught",
-        handled: false,
-        message: "first",
-      }),
-      expect.any(Object),
-    );
-
-    scoped.destroy();
-    expect(removeSpy).toHaveBeenCalledWith("error", errorListener);
-    expect(removeSpy).toHaveBeenCalledWith(
-      "unhandledrejection",
-      rejectionListener,
-    );
-    client.destroy();
   });
 });

--- a/packages/sdk-js/test/plugins/growthbook-error-tracking.test.ts
+++ b/packages/sdk-js/test/plugins/growthbook-error-tracking.test.ts
@@ -6,7 +6,11 @@ import {
   normalizeErrorMessageForFingerprint,
   normalizeFilenameForFingerprint,
 } from "../../src/plugins/growthbook-error-tracking";
-import { EVENT_GROWTHBOOK_ERROR, GrowthBook, GrowthBookClient } from "../../src";
+import {
+  EVENT_GROWTHBOOK_ERROR,
+  GrowthBook,
+  GrowthBookClient,
+} from "../../src";
 
 describe("growthbookErrorTracking helpers", () => {
   afterEach(() => {
@@ -193,10 +197,9 @@ describe("growthbookErrorTracking helpers", () => {
       clientKey: "test",
       eventLogger,
     });
-    const scoped = client.createScopedInstance(
-      { attributes: { id: "123" } },
-      [growthbookErrorTrackingPlugin()],
-    );
+    const scoped = client.createScopedInstance({ attributes: { id: "123" } }, [
+      growthbookErrorTrackingPlugin(),
+    ]);
     const errorListener = addSpy.mock.calls.find(
       ([eventName]) => eventName === "error",
     )?.[1];

--- a/packages/sdk-js/test/plugins/growthbook-error-tracking.test.ts
+++ b/packages/sdk-js/test/plugins/growthbook-error-tracking.test.ts
@@ -67,6 +67,11 @@ describe("growthbookErrorTracking helpers", () => {
         "Request failed for https://example.com/a",
       ),
     ).toEqual("Request failed for {url}");
+    expect(
+      normalizeErrorMessageForFingerprint(
+        "Checkout failed 018f4e2a-7b3c-7def-8a2b-9c3d4e5f6789",
+      ),
+    ).toEqual("Checkout failed {uuid}");
   });
 
   it("normalizes bundled filenames to app-relative labels", () => {

--- a/packages/sdk-js/test/plugins/growthbook-error-tracking.test.ts
+++ b/packages/sdk-js/test/plugins/growthbook-error-tracking.test.ts
@@ -1,0 +1,147 @@
+import {
+  buildErrorEventProperties,
+  fingerprintForError,
+  growthbookComposedError,
+  normalizeErrorMessageForFingerprint,
+  normalizeFilenameForFingerprint,
+} from "../../src/plugins/growthbook-error-tracking";
+import { EVENT_GROWTHBOOK_ERROR } from "../../src/core";
+
+describe("growthbookErrorTracking helpers", () => {
+  it("uses stable fingerprint for same message and stack", () => {
+    const err = new Error("boom");
+    err.stack = "Error: boom\n  at foo (file.js:1:2)";
+    const a = fingerprintForError(err.message, err.stack, err.name);
+    const b = fingerprintForError(err.message, err.stack, err.name);
+    expect(a).toEqual(b);
+    expect(a.length).toBeGreaterThan(4);
+  });
+
+  it("ignores line and column changes in the same frame", () => {
+    const stackA =
+      "Error: boom\n  at onClick (src/app/errors-demo/page.tsx:120:11)";
+    const stackB =
+      "Error: boom\n  at onClick (src/app/errors-demo/page.tsx:188:7)";
+    expect(fingerprintForError("boom", stackA, "Error")).toEqual(
+      fingerprintForError("boom", stackB, "Error"),
+    );
+  });
+
+  it("ignores bundled path prefixes for the same source file", () => {
+    const stackA =
+      "Error: boom\n  at onClick (src/app/errors-demo/page.tsx:10:1)";
+    const stackB =
+      "Error: boom\n  at onClick (webpack-internal:///(app-pages-browser)/./src/app/errors-demo/page.tsx:10:1)";
+    expect(fingerprintForError("boom", stackA, "Error")).toEqual(
+      fingerprintForError("boom", stackB, "Error"),
+    );
+  });
+
+  it("groups dynamic message values with the same template", () => {
+    const stack = "Error: boom\n  at loadUser (src/services/users.ts:40:5)";
+    expect(fingerprintForError("User 123 not found", stack, "Error")).toEqual(
+      fingerprintForError("User 456 not found", stack, "Error"),
+    );
+  });
+
+  it("separates different static messages at the same stack location", () => {
+    const stack = "Error: boom\n  at loadUser (src/services/users.ts:40:5)";
+    expect(fingerprintForError("User not found", stack, "Error")).not.toEqual(
+      fingerprintForError("Order not found", stack, "Error"),
+    );
+  });
+
+  it("separates different error types with the same message and stack", () => {
+    const stack = "Error: boom\n  at loadUser (src/services/users.ts:40:5)";
+    expect(fingerprintForError("boom", stack, "Error")).not.toEqual(
+      fingerprintForError("boom", stack, "TypeError"),
+    );
+  });
+
+  it("normalizes volatile message values", () => {
+    expect(normalizeErrorMessageForFingerprint("User 123 failed")).toEqual(
+      "User {n} failed",
+    );
+    expect(
+      normalizeErrorMessageForFingerprint(
+        "Request failed for https://example.com/a",
+      ),
+    ).toEqual("Request failed for {url}");
+  });
+
+  it("normalizes bundled filenames to app-relative labels", () => {
+    expect(
+      normalizeFilenameForFingerprint(
+        "webpack-internal:///(app-pages-browser)/./src/app/errors-demo/page.tsx:10:1",
+      ),
+    ).toEqual("errors-demo/page.tsx");
+  });
+
+  it("builds GrowthBook Error payload shape", () => {
+    const props = buildErrorEventProperties(new Error("x"), {
+      errorType: "manual",
+    });
+    expect(props.title).toContain("x");
+    expect(props.message).toEqual(props.title);
+    expect(props.fingerprint).toBeTruthy();
+    expect(props.errorType).toEqual("manual");
+    expect(Array.isArray(props.stackFrames)).toBe(true);
+  });
+
+  it("groups composed / template-literal tails when tagged with growthbookComposedError", () => {
+    const stack = "Error: x\n  at demo (src/app/errors-demo/page.tsx:99:11)";
+    const a = fingerprintForError(
+      "Demo: hello abc12xyz suffix",
+      stack,
+      "Error",
+      "Demo: hello {} suffix",
+    );
+    const b = fingerprintForError(
+      "Demo: hello def99zzz suffix",
+      stack,
+      "Error",
+      "Demo: hello {} suffix",
+    );
+    expect(a).toEqual(b);
+    expect(
+      fingerprintForError(
+        "Demo: hello abc12xyz suffix",
+        stack,
+        "Error",
+        "Different static {} suffix",
+      ),
+    ).not.toEqual(a);
+  });
+
+  it("growthbookComposedError fingerprints ignore interpolated random segments", () => {
+    const errA = growthbookComposedError`Demo test (${"rand-a-9x2z"}) tail`;
+    errA.stack = "Error\n  at t (demo.tsx:1:2)";
+    const errB = growthbookComposedError`Demo test (${"DIFFERENT-ID"}) tail`;
+    errB.stack = errA.stack;
+    expect(buildErrorEventProperties(errA).fingerprint).toEqual(
+      buildErrorEventProperties(errB).fingerprint,
+    );
+    const propsA = buildErrorEventProperties(errA);
+    expect(propsA.title).toContain("rand-a-9x2z");
+    expect(propsA.message).toContain("rand-a-9x2z");
+    expect(propsA.title).not.toContain("{}");
+  });
+
+  it("extras cannot override fingerprint, title, or message", () => {
+    const err = new Error("real message");
+    const props = buildErrorEventProperties(err, {
+      title: "wrong title",
+      fingerprint: "deadbeef",
+      message: "wrong message",
+    } as Record<string, unknown>);
+    expect(props.title).toEqual("real message");
+    expect(props.message).toEqual("real message");
+    expect(props.fingerprint).toEqual(
+      buildErrorEventProperties(err).fingerprint,
+    );
+  });
+
+  it("EVENT_GROWTHBOOK_ERROR matches warehouse filter string", () => {
+    expect(EVENT_GROWTHBOOK_ERROR).toEqual("GrowthBook Error");
+  });
+});

--- a/packages/sdk-js/test/plugins/growthbook-error-tracking.test.ts
+++ b/packages/sdk-js/test/plugins/growthbook-error-tracking.test.ts
@@ -4,14 +4,16 @@ import {
   setFingerprint,
 } from "../../src/plugins/growthbook-error-tracking";
 import { GrowthBook } from "../../src/GrowthBook";
+import { GrowthBookClient } from "../../src/GrowthBookClient";
 import { EVENT_GROWTHBOOK_ERROR } from "../../src/core";
 
 describe("growthbookErrorTracking helpers", () => {
   it("builds GrowthBook Error payload without client fingerprint", () => {
     const err = new Error("something broke");
     err.stack = "Error: something broke\n  at foo (file.js:1:2)";
-    const props = buildErrorEventProperties(err, {
-      errorType: "manual",
+    const props = buildErrorEventProperties({
+      error: err,
+      props: { errorType: "manual" },
     });
     expect(props.title).toContain("something broke");
     expect(props.message).toEqual(props.title);
@@ -25,9 +27,11 @@ describe("growthbookErrorTracking helpers", () => {
     const logEvent = jest.fn();
     gb.logEvent = logEvent;
 
-    setFingerprint(gb, "my-custom-group");
-    await captureGrowthBookError(gb, new Error("volatile 123"), {
-      errorType: "manual",
+    setFingerprint({ gb, fingerprint: "my-custom-group" });
+    await captureGrowthBookError({
+      gb,
+      error: new Error("volatile 123"),
+      props: { errorType: "manual" },
     });
 
     expect(logEvent).toHaveBeenCalledWith(
@@ -44,9 +48,11 @@ describe("growthbookErrorTracking helpers", () => {
     const logEvent = jest.fn();
     gb.logEvent = logEvent;
 
-    setFingerprint(gb, ["checkout", "failed"]);
-    await captureGrowthBookError(gb, new Error("order 999"), {
-      errorType: "manual",
+    setFingerprint({ gb, fingerprint: ["checkout", "failed"] });
+    await captureGrowthBookError({
+      gb,
+      error: new Error("order 999"),
+      props: { errorType: "manual" },
     });
 
     expect(logEvent).toHaveBeenCalledWith(
@@ -59,14 +65,54 @@ describe("growthbookErrorTracking helpers", () => {
     expect(props.fingerprint).toBeUndefined();
   });
 
-  it("extras cannot override title or message", () => {
+  it("props cannot override title or message", () => {
     const err = new Error("real message");
-    const props = buildErrorEventProperties(err, {
-      title: "wrong title",
-      message: "wrong message",
-    } as Record<string, unknown>);
+    const props = buildErrorEventProperties({
+      error: err,
+      props: {
+        title: "wrong title",
+        message: "wrong message",
+      },
+    });
     expect(props.title).toEqual("real message");
     expect(props.message).toEqual("real message");
+  });
+
+  it("logs via GrowthBookClient when userContext is provided", async () => {
+    const client = new GrowthBookClient({ clientKey: "sdk-test" });
+    const logEvent = jest.fn();
+    client.logEvent = logEvent;
+
+    await captureGrowthBookError({
+      gb: client,
+      error: new Error("server error"),
+      userContext: { attributes: { id: "user-1" } },
+      props: { errorType: "manual" },
+    });
+
+    expect(logEvent).toHaveBeenCalledWith(
+      EVENT_GROWTHBOOK_ERROR,
+      expect.objectContaining({
+        message: "server error",
+        errorType: "manual",
+      }),
+      { attributes: { id: "user-1" } },
+    );
+  });
+
+  it("warns when GrowthBookClient is used without userContext", async () => {
+    const client = new GrowthBookClient({ clientKey: "sdk-test" });
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    await captureGrowthBookError({
+      gb: client,
+      error: new Error("orphan"),
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      "captureGrowthBookError: pass userContext when gb is a GrowthBookClient.",
+    );
+    warn.mockRestore();
   });
 
   it("EVENT_GROWTHBOOK_ERROR matches warehouse filter string", () => {

--- a/packages/sdk-js/test/plugins/growthbook-tracking.test.ts
+++ b/packages/sdk-js/test/plugins/growthbook-tracking.test.ts
@@ -159,6 +159,43 @@ describe("growthbookTrackingPlugin", () => {
     gb.destroy();
   });
 
+  it("maps anonymous_id to device_id and user_id separately", async () => {
+    const plugin = growthbookTrackingPlugin({
+      debug: true,
+      enable: false,
+    });
+
+    const gb = new GrowthBook({
+      clientKey: "test",
+      plugins: [plugin],
+      url: "http://localhost:3000",
+      attributes: {
+        anonymous_id: "anon-123",
+        user_id: "user-456",
+        id: "legacy-id",
+      },
+    });
+
+    const log = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    gb.logEvent("test");
+
+    expect(log).toHaveBeenCalledWith("Logging event to GrowthBook", {
+      context_json: {},
+      device_id: "anon-123",
+      event_name: "test",
+      page_id: null,
+      properties_json: {},
+      sdk_language: "js",
+      sdk_version: "",
+      session_id: null,
+      url: "http://localhost:3000",
+      user_id: "user-456",
+    });
+
+    gb.destroy();
+  });
+
   it("Skips logging duplicate Feature Evaluted events", async () => {
     const plugin = growthbookTrackingPlugin();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1085,7 +1085,7 @@ importers:
         version: 7.0.2(rollup@4.59.0)
       ts-jest:
         specifier: ^27.0.5
-        version: 27.1.5(@babel/core@7.28.5)(@types/jest@27.0.1)(babel-jest@27.5.1(@babel/core@7.28.5))(jest@27.5.1)(typescript@5.7.3)
+        version: 27.1.5(@babel/core@7.28.5)(@types/jest@27.0.1)(babel-jest@27.5.1(@babel/core@7.28.5))(jest@27.5.1(ts-node@10.9.1(@swc/core@1.3.4)(@swc/wasm@1.2.130)(@types/node@22.8.6)(typescript@5.7.3)))(typescript@5.7.3)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -1093,8 +1093,8 @@ importers:
   packages/sdk-react:
     dependencies:
       '@growthbook/growthbook':
-        specifier: 1.6.5
-        version: 1.6.5
+        specifier: workspace:*
+        version: link:../sdk-js
     devDependencies:
       '@babel/cli':
         specifier: ^7.28.3
@@ -1155,7 +1155,7 @@ importers:
         version: 4.59.0
       ts-jest:
         specifier: ^27.0.5
-        version: 27.1.5(@babel/core@7.28.5)(@types/jest@27.0.1)(babel-jest@27.5.1(@babel/core@7.28.5))(jest@27.5.1)(typescript@5.7.3)
+        version: 27.1.5(@babel/core@7.28.5)(@types/jest@27.0.1)(babel-jest@27.5.1(@babel/core@7.28.5))(jest@27.5.1(ts-node@10.9.1(@swc/core@1.3.4)(@swc/wasm@1.2.130)(@types/node@22.8.6)(typescript@5.7.3)))(typescript@5.7.3)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -21270,7 +21270,7 @@ snapshots:
 
   axios@1.15.0:
     dependencies:
-      follow-redirects: 1.16.0(debug@4.3.4)
+      follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -26614,7 +26614,7 @@ snapshots:
 
   presto-client@1.1.0(patch_hash=9fd1f0ac9c8a83e477d0fbea5a3b9c67665121c24b78fa4d5af0cf112c3d1efb):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.3.4)
+      follow-redirects: 1.16.0(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -28308,7 +28308,7 @@ snapshots:
     dependencies:
       typescript: 5.7.3
 
-  ts-jest@27.1.5(@babel/core@7.28.5)(@types/jest@27.0.1)(babel-jest@27.5.1(@babel/core@7.28.5))(jest@27.5.1)(typescript@5.7.3):
+  ts-jest@27.1.5(@babel/core@7.28.5)(@types/jest@27.0.1)(babel-jest@27.5.1(@babel/core@7.28.5))(jest@27.5.1(ts-node@10.9.1(@swc/core@1.3.4)(@swc/wasm@1.2.130)(@types/node@22.8.6)(typescript@5.7.3)))(typescript@5.7.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1085,7 +1085,7 @@ importers:
         version: 7.0.2(rollup@4.59.0)
       ts-jest:
         specifier: ^27.0.5
-        version: 27.1.5(@babel/core@7.28.5)(@types/jest@27.0.1)(babel-jest@27.5.1(@babel/core@7.28.5))(jest@27.5.1(ts-node@10.9.1(@swc/core@1.3.4)(@swc/wasm@1.2.130)(@types/node@22.8.6)(typescript@5.7.3)))(typescript@5.7.3)
+        version: 27.1.5(@babel/core@7.28.5)(@types/jest@27.0.1)(babel-jest@27.5.1(@babel/core@7.28.5))(jest@27.5.1)(typescript@5.7.3)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -1093,8 +1093,8 @@ importers:
   packages/sdk-react:
     dependencies:
       '@growthbook/growthbook':
-        specifier: workspace:*
-        version: link:../sdk-js
+        specifier: 1.6.5
+        version: 1.6.5
     devDependencies:
       '@babel/cli':
         specifier: ^7.28.3
@@ -1155,7 +1155,7 @@ importers:
         version: 4.59.0
       ts-jest:
         specifier: ^27.0.5
-        version: 27.1.5(@babel/core@7.28.5)(@types/jest@27.0.1)(babel-jest@27.5.1(@babel/core@7.28.5))(jest@27.5.1(ts-node@10.9.1(@swc/core@1.3.4)(@swc/wasm@1.2.130)(@types/node@22.8.6)(typescript@5.7.3)))(typescript@5.7.3)
+        version: 27.1.5(@babel/core@7.28.5)(@types/jest@27.0.1)(babel-jest@27.5.1(@babel/core@7.28.5))(jest@27.5.1)(typescript@5.7.3)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -21270,7 +21270,7 @@ snapshots:
 
   axios@1.15.0:
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
+      follow-redirects: 1.16.0(debug@4.3.4)
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -26614,7 +26614,7 @@ snapshots:
 
   presto-client@1.1.0(patch_hash=9fd1f0ac9c8a83e477d0fbea5a3b9c67665121c24b78fa4d5af0cf112c3d1efb):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
+      follow-redirects: 1.16.0(debug@4.3.4)
     transitivePeerDependencies:
       - debug
 
@@ -28308,7 +28308,7 @@ snapshots:
     dependencies:
       typescript: 5.7.3
 
-  ts-jest@27.1.5(@babel/core@7.28.5)(@types/jest@27.0.1)(babel-jest@27.5.1(@babel/core@7.28.5))(jest@27.5.1(ts-node@10.9.1(@swc/core@1.3.4)(@swc/wasm@1.2.130)(@types/node@22.8.6)(typescript@5.7.3)))(typescript@5.7.3):
+  ts-jest@27.1.5(@babel/core@7.28.5)(@types/jest@27.0.1)(babel-jest@27.5.1(@babel/core@7.28.5))(jest@27.5.1)(typescript@5.7.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0


### PR DESCRIPTION
### Features and Changes
Adds changes to the sdk-js package to allow for error-tracking.

### Dependencies
Errors will not be properly handled in clickhouse until the errors table and MV is created (they will go into the main events table).  https://github.com/growthbook/central-license-server/pull/120/changes will need to land, and then we will need to drop and recreate tables in the admin for the orgs that want to use this (or eventually create a script to update the tables and MV for all orgs).

After this lands we can land https://github.com/growthbook/growthbook/pull/5886 which needs @growthbook/growthbook to be published.

### Testing
See the testing in https://github.com/growthbook/growthbook/pull/5886.
