### PR TITLE
fix(metric-drilldown): Ensure Modal can be closed via Esc/backdrop click

### DIFF
--- a/packages/front-end/components/MetricDrilldown/MetricDrilldownModal.tsx
+++ b/packages/front-end/components/MetricDrilldown/MetricDrilldownModal.tsx
@@ -534,10 +534,13 @@ const MetricDrilldownModal = ({
     <Tabs defaultValue={initialTab}>
       <Modal
         open={true}
+        close={close}
         borderlessHeader={true}
         backgroundlessHeader={true}
         headerClassName={styles.metricDrilldownModalHeader}
         bodyClassName={styles.metricDrilldownModalBody}
+        showHeaderCloseButton={false}
+        includeCloseCta={false}
         dismissible
         header={
           <Flex align="center" gap="0">
@@ -613,6 +616,7 @@ const MetricDrilldownModal = ({
         trackingEventModalSource="results-table"
         cta="Close"
         submit={close}
+        autoCloseOnSubmit={false}
         autoFocusSelector=""
       >
         <MetricDrilldownContext.Provider value={null}>

--- a/packages/front-end/components/MetricDrilldown/MetricDrilldownModal.tsx
+++ b/packages/front-end/components/MetricDrilldown/MetricDrilldownModal.tsx
@@ -616,7 +616,6 @@ const MetricDrilldownModal = ({
         trackingEventModalSource="results-table"
         cta="Close"
         submit={close}
-        autoCloseOnSubmit={false}
         autoFocusSelector=""
       >
         <MetricDrilldownContext.Provider value={null}>


### PR DESCRIPTION
### Features and Changes
- Reinstate Escape and backdrop dismissal for the Metric Drilldown modal

### Testing
- open Metric Drilldown from the Revenue per User row
- press Escape to close it
- reopen Metric Drilldown
- click the backdrop to close it