### PR TITLE
Add revision selector to feature rule delete modal

### DIFF
--- a/packages/front-end/components/Features/Rule.tsx
+++ b/packages/front-end/components/Features/Rule.tsx
@@ -1029,7 +1029,9 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
                     <DropdownMenuItem
                       color="red"
                       onClick={() => {
-                        setDeleteMode(defaultDraft != null ? "existing" : "new");
+                        setDeleteMode(
+                          defaultDraft != null ? "existing" : "new",
+                        );
                         setDeleteSelectedDraft(defaultDraft);
                         setShowDeleteRuleModal(true);
                         setDropdownOpen(false);

--- a/packages/front-end/components/Features/Rule.tsx
+++ b/packages/front-end/components/Features/Rule.tsx
@@ -511,7 +511,7 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
         {showDeleteRuleModal && (
           <ModalStandard
             trackingEventModalType="delete-feature-rule"
-            header="Delete rule from a revision"
+            header="Delete rule"
             size="lg"
             close={() => setShowDeleteRuleModal(false)}
             open={true}
@@ -551,12 +551,8 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
                 triggerPrefix="Rule deletion will be"
               />
               <Text as="p" mb="2">
-                This will add a rule deletion to the selected revision. The live
-                feature will not change until that revision is published.
-              </Text>
-              <Text as="p" mb="0" color="text-low">
-                To delete the rule in a different draft, choose it above before
-                saving.
+                This rule will be removed when the revision is published. The
+                live feature will not change until then.
               </Text>
             </Box>
           </ModalStandard>

--- a/packages/front-end/components/Features/Rule.tsx
+++ b/packages/front-end/components/Features/Rule.tsx
@@ -1,10 +1,13 @@
 import { FeatureInterface, FeatureRule } from "shared/types/feature";
-import { FeatureRevisionInterface } from "shared/types/feature-revision";
+import {
+  FeatureRevisionInterface,
+  MinimalFeatureRevisionInterface,
+} from "shared/types/feature-revision";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import React, { forwardRef, ReactElement, useState } from "react";
+import React, { forwardRef, ReactElement, useMemo, useState } from "react";
 import { ExperimentInterfaceStringDates } from "shared/types/experiment";
-import { filterEnvironmentsByFeature } from "shared/util";
+import { filterEnvironmentsByFeature, getReviewSetting } from "shared/util";
 import { Box, Flex, IconButton } from "@radix-ui/themes";
 import { RiAlertLine } from "react-icons/ri";
 import { RxCircleBackslash } from "react-icons/rx";
@@ -46,10 +49,16 @@ import {
 import { getUpcomingScheduleRule } from "@/services/scheduleRules";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import useOrgSettings from "@/hooks/useOrgSettings";
+import { useDefaultDraft } from "@/hooks/useDefaultDraft";
 import HelperText from "@/ui/HelperText";
 import Badge from "@/ui/Badge";
+import ModalStandard from "@/ui/Modal/Patterns/ModalStandard";
 import RuleEnvScopeBadges from "@/components/Features/RuleEnvScopeBadges";
 import RuleCard from "@/components/Features/RuleCard";
+import DraftSelectorForChanges, {
+  DraftMode,
+} from "@/components/Features/DraftSelectorForChanges";
 import ExperimentStatusIndicator from "@/components/Experiment/TabbedPage/ExperimentStatusIndicator";
 import Callout from "@/ui/Callout";
 import SafeRolloutSummary from "@/components/Features/SafeRolloutSummary";
@@ -181,6 +190,7 @@ interface SortableProps {
   hideInactive?: boolean;
   isDraft: boolean;
   holdout: HoldoutInterface | undefined;
+  revisionList: MinimalFeatureRevisionInterface[];
   rampSchedule?: RampScheduleInterface;
   draftRevision?: FeatureRevisionInterface | null;
   // True when rendered under the all-environments view. The `environment`
@@ -251,6 +261,7 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
       hideInactive,
       isDraft,
       holdout,
+      revisionList,
       rampSchedule,
       draftRevision,
       isAllEnvsView,
@@ -267,8 +278,17 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
     const [safeRolloutStatusModalOpen, setSafeRolloutStatusModalOpen] =
       useState(false);
     const [dropdownOpen, setDropdownOpen] = useState(false);
+    const [showDeleteRuleModal, setShowDeleteRuleModal] = useState(false);
     const [rampApproveLoading, setRampApproveLoading] = useState(false);
     const [rampApproveError, setRampApproveError] = useState("");
+    const defaultDraft = useDefaultDraft(revisionList);
+    const [deleteMode, setDeleteMode] = useState<DraftMode>(
+      defaultDraft != null ? "existing" : "new",
+    );
+    const [deleteSelectedDraft, setDeleteSelectedDraft] = useState<
+      number | null
+    >(defaultDraft);
+    const settings = useOrgSettings();
 
     const toggleRuleEnabled = async () => {
       setDropdownOpen(false);
@@ -336,6 +356,16 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
     const canEdit =
       permissionsUtil.canViewFeatureModal(feature.project) &&
       permissionsUtil.canManageFeatureDrafts(feature);
+
+    const gatedEnvSet: Set<string> | "all" | "none" = useMemo(() => {
+      const raw = settings?.requireReviews;
+      if (raw === true) return "all";
+      if (!Array.isArray(raw)) return "none";
+      const reviewSetting = getReviewSetting(raw, feature);
+      if (!reviewSetting?.requireReviewOn) return "none";
+      const envList = reviewSetting.environments ?? [];
+      return envList.length === 0 ? "all" : new Set(envList);
+    }, [settings?.requireReviews, feature]);
 
     const isInactive = isRuleInactive(rule, experimentsMap);
 
@@ -478,6 +508,59 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
 
     const contents = (
       <Box {...props} ref={ref}>
+        {showDeleteRuleModal && (
+          <ModalStandard
+            trackingEventModalType="delete-feature-rule"
+            header="Delete rule from a revision"
+            size="lg"
+            close={() => setShowDeleteRuleModal(false)}
+            open={true}
+            cta="Save deletion"
+            ctaColor="red"
+            submit={async () => {
+              track("Delete Feature Rule", {
+                ruleIndex: i,
+                environment,
+                type: rule.type,
+              });
+              const targetVersion =
+                deleteMode === "existing" && deleteSelectedDraft != null
+                  ? deleteSelectedDraft
+                  : feature.version;
+              const res = await apiCall<{ version: number }>(
+                `/feature/${feature.id}/${targetVersion}/rule`,
+                {
+                  method: "DELETE",
+                  body: JSON.stringify({ ruleId: rule.id }),
+                },
+              );
+              await mutate();
+              res.version && setVersion(res.version);
+            }}
+          >
+            <Box style={{ minHeight: 300 }}>
+              <DraftSelectorForChanges
+                feature={feature}
+                revisionList={revisionList}
+                mode={deleteMode}
+                setMode={setDeleteMode}
+                selectedDraft={deleteSelectedDraft}
+                setSelectedDraft={setDeleteSelectedDraft}
+                canAutoPublish={false}
+                gatedEnvSet={gatedEnvSet}
+                triggerPrefix="Rule deletion will be"
+              />
+              <Text as="p" mb="2">
+                This will add a rule deletion to the selected revision. The live
+                feature will not change until that revision is published.
+              </Text>
+              <Text as="p" mb="0" color="text-low">
+                To delete the rule in a different draft, choose it above before
+                saving.
+              </Text>
+            </Box>
+          </ModalStandard>
+        )}
         <RuleCard
           index={holdout ? globalRuleIdx + 2 : globalRuleIdx + 1}
           sideColor={info.sideColor}
@@ -949,28 +1032,14 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
                     <DropdownMenuSeparator />
                     <DropdownMenuItem
                       color="red"
-                      confirmation={{
-                        confirmationTitle: "Delete Rule",
-                        cta: "Delete",
-                        submit: async () => {
-                          track("Delete Feature Rule", {
-                            ruleIndex: i,
-                            environment,
-                            type: rule.type,
-                          });
-                          const res = await apiCall<{ version: number }>(
-                            `/feature/${feature.id}/${version}/rule`,
-                            {
-                              method: "DELETE",
-                              body: JSON.stringify({ ruleId: rule.id }),
-                            },
-                          );
-                          await mutate();
-                          res.version && setVersion(res.version);
-                        },
+                      onClick={() => {
+                        setDeleteMode(defaultDraft != null ? "existing" : "new");
+                        setDeleteSelectedDraft(defaultDraft);
+                        setShowDeleteRuleModal(true);
+                        setDropdownOpen(false);
                       }}
                     >
-                      Delete
+                      Delete rule
                     </DropdownMenuItem>
                   </DropdownMenuGroup>
                 </DropdownMenu>

--- a/packages/front-end/components/Features/RuleList.tsx
+++ b/packages/front-end/components/Features/RuleList.tsx
@@ -313,6 +313,7 @@ export default function RuleList(props: RuleListProps) {
                 isDraft={isDraft}
                 safeRolloutsMap={safeRolloutsMap}
                 holdout={holdout}
+                revisionList={revisionList}
                 rampSchedule={rampSchedulesMap.get(rule.id ?? "")}
                 draftRevision={draftRevision}
                 isAllEnvsView={allEnvsView}
@@ -354,6 +355,7 @@ export default function RuleList(props: RuleListProps) {
               isDraft={isDraft}
               safeRolloutsMap={safeRolloutsMap}
               holdout={holdout}
+              revisionList={revisionList}
               rampSchedule={rampSchedulesMap.get(activeRule.id ?? "")}
               draftRevision={draftRevision}
               isAllEnvsView={allEnvsView}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

- Replaced the generic feature rule delete confirmation with a dedicated modal.
- Added the existing revision/draft selector to the delete flow so users can see and choose where the rule deletion is saved.
- Updated modal copy and CTA to clarify that the deletion is saved to a revision and does not affect live behavior until published.

- Closes **(add link to issue here)**

### Dependencies

None.

### Testing

- `pnpm lint:ci`
- `pnpm --filter front-end type-check`

### Screenshots

Manual UI verification pending.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/D0AM50FCKA4/p1773353152078359?thread_ts=1773353152.078359&cid=D0AM50FCKA4)

<div><a href="https://cursor.com/agents/bc-79a2b4e4-9203-5937-8bf1-af7857abfff4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79a2b4e4-9203-5937-8bf1-af7857abfff4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

