### PR TITLE
fix(experiments): complete pre-flight permission gate and skip checklist for scheduled experiment approval

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -1437,6 +1437,21 @@ export async function postFeaturePublish(
       if (!context.permissions.canUpdateExperiment(experiment, {})) {
         context.permissions.throwPermissionError();
       }
+      const linkedFeatures = await getFeaturesByIds(
+        context,
+        experiment.linkedFeatures || [],
+      );
+      const schedEnvs = getAffectedEnvsForExperiment({
+        experiment,
+        orgEnvironments: allEnvironments,
+        linkedFeatures,
+      });
+      if (
+        schedEnvs.length > 0 &&
+        !context.permissions.canRunExperiment(experiment, schedEnvs)
+      ) {
+        context.permissions.throwPermissionError();
+      }
     }
 
     // Pre-flight: check for merge conflicts in OTHER pending feature drafts
@@ -1565,6 +1580,7 @@ export async function postFeaturePublish(
     const { updated } = await approveScheduledExperimentStart({
       context,
       experimentId: experiment.id,
+      skipChecklist: true,
     });
 
     await req.audit({

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -1443,7 +1443,7 @@ export async function postFeaturePublish(
       );
       const schedEnvs = getAffectedEnvsForExperiment({
         experiment,
-        orgEnvironments: allEnvironments,
+        orgEnvironments: context.org.settings?.environments || [],
         linkedFeatures,
       });
       if (


### PR DESCRIPTION
## Summary

- **Issue 1**: The pre-flight permission loop for scheduled-approval experiments only checked `canUpdateExperiment`, but `approveScheduledExperimentStart` (via `loadAndValidateExperimentForStatusChange`) also enforces `canRunExperiment` against the affected environments. If the second check failed, the feature revision was already committed — leaving the feature draft published and the experiment unscheduled. The fix adds a `canRunExperiment` check (with linked features, exactly mirroring `loadAndValidateExperimentForStatusChange`) to the pre-flight loop so the full permission gate fires before any writes.

- **Issue 2**: `approveScheduledExperimentStart` was called without `skipChecklist: true`, so an incomplete checklist would throw after the feature revision was committed. The immediate-start path does not enforce the checklist in this context, making the behavior inconsistent. Passing `skipChecklist: true` aligns both paths.

## Test plan

- [x] Publish a feature revision that includes a scheduled experiment where the current user lacks `runExperiments` in the target environment — request should fail with a permission error before any revision is saved
- [x] Publish a feature revision with a scheduled experiment that has an incomplete checklist — should succeed without error
- [x] Publish a feature revision with a scheduled experiment where the user has all required permissions — happy path still works end-to-end
- [x] `pnpm --filter back-end type-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)