### PR TITLE
Add experimentId to ExperimentQueryMetadata

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -1150,6 +1150,7 @@ export function getExperimentQueryMetadata(
   experiment: ExperimentInterface,
 ): ExperimentQueryMetadata {
   return {
+    experimentId: experiment.id,
     experimentOwner: experiment.owner || undefined,
     experimentProject: experiment.project || undefined,
     experimentTags: experiment.tags.length > 0 ? experiment.tags : undefined,

--- a/packages/shared/types/query.d.ts
+++ b/packages/shared/types/query.d.ts
@@ -104,6 +104,7 @@ export type QueryType =
   | "experimentResults";
 
 export type ExperimentQueryMetadata = {
+  experimentId?: string;
   experimentProject?: string;
   experimentOwner?: string;
   experimentTags?: string[];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

Adds `experimentId` to the `ExperimentQueryMetadata` type so that experiment queries include the experiment ID in their metadata. This complements the existing BQ label metadata (experimentProject, experimentOwner, experimentTags) that was recently merged.

**Changes:**
- Added `experimentId?: string` field to `ExperimentQueryMetadata` type in `packages/shared/types/query.d.ts`
- Updated `getExperimentQueryMetadata()` function in `packages/back-end/src/services/experiments.ts` to include `experiment.id`

### Dependencies

None

### Testing

- TypeScript type-check passes
- ESLint passes
- This is a straightforward type and function change that adds metadata to existing query infrastructure
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C07NK4F016Z/p1779284061007439?thread_ts=1779284061.007439&cid=C07NK4F016Z)

<div><a href="https://cursor.com/agents/bc-d6302f50-421c-5f0d-ba3f-20bac64d9053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6302f50-421c-5f0d-ba3f-20bac64d9053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

