### PR TITLE
Copy hashAttribute from SDK into event forwarder datasource

### DIFF
--- a/packages/back-end/src/api/attributes/postAttribute.ts
+++ b/packages/back-end/src/api/attributes/postAttribute.ts
@@ -6,6 +6,7 @@ import { auditDetailsCreate } from "back-end/src/services/audit";
 import { addTags } from "back-end/src/models/TagModel";
 import { syncEventForwarderSchemasAfterAttributeSchemaChange } from "back-end/src/services/eventForwarderProvisioning";
 import { hasAnyEventForwarderConfig } from "back-end/src/services/eventForwarderConfig";
+import { syncAllEventForwarderDatasourceUserIdTypesFromAttributeSchema } from "back-end/src/services/eventForwarderUserIdTypes";
 import { validatePayload } from "./validations";
 
 export const postAttribute = createApiRequestHandler(postAttributeValidator)(
@@ -50,6 +51,12 @@ export const postAttribute = createApiRequestHandler(postAttributeValidator)(
     await updateOrganization(org.id, updates);
 
     if (await hasAnyEventForwarderConfig(req.context)) {
+      if (attribute.hashAttribute) {
+        await syncAllEventForwarderDatasourceUserIdTypesFromAttributeSchema(
+          req.context,
+          updatedAttributeSchema,
+        );
+      }
       await syncEventForwarderSchemasAfterAttributeSchemaChange(
         req.context,
         updatedAttributeSchema,

--- a/packages/back-end/src/api/attributes/putAttribute.ts
+++ b/packages/back-end/src/api/attributes/putAttribute.ts
@@ -5,6 +5,7 @@ import { updateOrganization } from "back-end/src/models/OrganizationModel";
 import { auditDetailsUpdate } from "back-end/src/services/audit";
 import { addTagsDiff } from "back-end/src/models/TagModel";
 import { hasAnyEventForwarderConfig } from "back-end/src/services/eventForwarderConfig";
+import { syncAllEventForwarderDatasourceUserIdTypesFromAttributeSchema } from "back-end/src/services/eventForwarderUserIdTypes";
 import { validatePayload } from "./validations";
 
 export const putAttribute = createApiRequestHandler(putAttributeValidator)(
@@ -55,6 +56,18 @@ export const putAttribute = createApiRequestHandler(putAttributeValidator)(
     };
 
     await updateOrganization(org.id, updates);
+
+    const updatedAttributeSchema = updates.settings?.attributeSchema ?? [];
+    if (
+      hasEventForwarder &&
+      req.body.hashAttribute === true &&
+      !attribute.hashAttribute
+    ) {
+      await syncAllEventForwarderDatasourceUserIdTypesFromAttributeSchema(
+        req.context,
+        updatedAttributeSchema,
+      );
+    }
 
     await req.audit({
       event: "attribute.update",

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -1,5 +1,6 @@
 import { Response } from "express";
 import cloneDeep from "lodash/cloneDeep";
+import isEqual from "lodash/isEqual";
 import * as bq from "@google-cloud/bigquery";
 import { SQL_ROW_LIMIT } from "shared/sql";
 import {
@@ -591,6 +592,22 @@ export async function putDataSource(
     }
 
     if (settings) {
+      const eventForwarderConfig = await getEventForwarderConfigForDatasource(
+        context,
+        datasource.id,
+      );
+      if (
+        eventForwarderConfig &&
+        settings.userIdTypes !== undefined &&
+        !isEqual(settings.userIdTypes, datasource.settings?.userIdTypes)
+      ) {
+        res.status(400).json({
+          status: 400,
+          message:
+            "Identifier types cannot be changed while an Event Forwarder is configured for this data source.",
+        });
+        return;
+      }
       updates.settings = settings;
     }
 

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -3,6 +3,7 @@ import cloneDeep from "lodash/cloneDeep";
 import isEqual from "lodash/isEqual";
 import * as bq from "@google-cloud/bigquery";
 import { SQL_ROW_LIMIT } from "shared/sql";
+import { isEventForwarderAllowedUserIdTypesChange } from "shared/util";
 import {
   PIPELINE_MODE_SUPPORTED_DATA_SOURCE_TYPES,
   getPipelineValidationCreateTableQuery,
@@ -90,6 +91,7 @@ import {
   createDataSource,
   getDataSourcesByOrganization,
   getDataSourceById,
+  getRawDataSourceById,
   deleteDatasource,
   updateDataSource,
 } from "back-end/src/models/DataSourceModel";
@@ -596,17 +598,25 @@ export async function putDataSource(
         context,
         datasource.id,
       );
-      if (
-        eventForwarderConfig &&
-        settings.userIdTypes !== undefined &&
-        !isEqual(settings.userIdTypes, datasource.settings?.userIdTypes)
-      ) {
-        res.status(400).json({
-          status: 400,
-          message:
-            "Identifier types cannot be changed while an Event Forwarder is configured for this data source.",
-        });
-        return;
+      if (eventForwarderConfig && settings.userIdTypes !== undefined) {
+        const rawDatasource = await getRawDataSourceById(context, id);
+        const existingUserIdTypes = rawDatasource?.settings?.userIdTypes ?? [];
+        if (
+          !isEqual(settings.userIdTypes, existingUserIdTypes) &&
+          !isEventForwarderAllowedUserIdTypesChange(
+            existingUserIdTypes,
+            settings.userIdTypes,
+            org.settings?.attributeSchema ?? [],
+            datasource.projects,
+          )
+        ) {
+          res.status(400).json({
+            status: 400,
+            message:
+              "Identifier types cannot be changed while an Event Forwarder is configured for this data source.",
+          });
+          return;
+        }
       }
       updates.settings = settings;
     }

--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -143,11 +143,11 @@ export async function getGrowthbookDatasource(context: ReqContext) {
     : null;
 }
 
-export async function getDataSourceById(
+/** Returns persisted datasource fields without upgradeDatasourceObject defaults. */
+export async function getRawDataSourceById(
   context: ReqContext | ApiReqContext,
   id: string,
-) {
-  // If using config.yml, immediately return the from there
+): Promise<DataSourceInterface | null> {
   if (usingFileConfig()) {
     return (
       getConfigDatasources(context.org.id).filter((d) => d.id === id)[0] || null
@@ -161,11 +161,20 @@ export async function getDataSourceById(
 
   if (!doc) return null;
 
-  const datasource = toInterface(doc);
+  const datasource = doc.toJSON() as DataSourceInterface;
 
   return context.permissions.canReadMultiProjectResource(datasource.projects)
     ? datasource
     : null;
+}
+
+export async function getDataSourceById(
+  context: ReqContext | ApiReqContext,
+  id: string,
+) {
+  const datasource = await getRawDataSourceById(context, id);
+  if (!datasource) return null;
+  return upgradeDatasourceObject(datasource);
 }
 
 export async function getDataSourcesByIds(

--- a/packages/back-end/src/routers/attributes/attributes.controller.ts
+++ b/packages/back-end/src/routers/attributes/attributes.controller.ts
@@ -10,6 +10,7 @@ import { getAllFeatures } from "back-end/src/models/FeatureModel";
 import { getAllExperiments } from "back-end/src/models/ExperimentModel";
 import { syncEventForwarderSchemasAfterAttributeSchemaChange } from "back-end/src/services/eventForwarderProvisioning";
 import { hasAnyEventForwarderConfig } from "back-end/src/services/eventForwarderConfig";
+import { syncAllEventForwarderDatasourceUserIdTypesFromAttributeSchema } from "back-end/src/services/eventForwarderUserIdTypes";
 
 export const postAttribute = async (
   req: AuthRequest<SDKAttribute>,
@@ -51,6 +52,12 @@ export const postAttribute = async (
   // Uses the updated schema so the new attribute is included in the registration.
   // Errors are recorded on the EventForwarderConfig record and do not fail this request.
   if (await hasAnyEventForwarderConfig(context)) {
+    if (newAttribute.hashAttribute) {
+      await syncAllEventForwarderDatasourceUserIdTypesFromAttributeSchema(
+        context,
+        updatedAttributeSchema,
+      );
+    }
     await syncEventForwarderSchemasAfterAttributeSchemaChange(
       context,
       updatedAttributeSchema,
@@ -148,6 +155,17 @@ export const putAttribute = async (
       attributeSchema,
     },
   });
+
+  if (
+    hasEventForwarder &&
+    attributeFields.hashAttribute === true &&
+    !existing.hashAttribute
+  ) {
+    await syncAllEventForwarderDatasourceUserIdTypesFromAttributeSchema(
+      context,
+      attributeSchema,
+    );
+  }
 
   await req.audit({
     event: "attribute.update",

--- a/packages/back-end/src/services/eventForwarderProvisioning.ts
+++ b/packages/back-end/src/services/eventForwarderProvisioning.ts
@@ -19,6 +19,7 @@ import {
 import { decryptEventForwarderConfigModel } from "back-end/src/services/eventForwarderConfig";
 import { resolveBigQueryEventForwarderTableName } from "back-end/src/services/eventForwarderBqTableResolution";
 import { testEventForwarderWriteAccess } from "back-end/src/services/eventForwarderWriteAccessValidation";
+import { initializeDatasourceUserIdTypesFromOrgAttributeSchema } from "back-end/src/services/eventForwarderUserIdTypes";
 import { logger } from "back-end/src/util/logger";
 import { ReqContext } from "back-end/types/request";
 
@@ -150,6 +151,11 @@ export async function provisionEventForwarderThroughLicenseServer(
       connectorId: result.connectorId,
       lastProvisioningError: "",
     });
+
+    await initializeDatasourceUserIdTypesFromOrgAttributeSchema(
+      context,
+      eventForwarderConfig.datasourceId,
+    );
 
     if (options?.restartAfterProvision && result.connectorName.trim()) {
       await postRestartEventForwarderToLicenseServer({

--- a/packages/back-end/src/services/eventForwarderProvisioning.ts
+++ b/packages/back-end/src/services/eventForwarderProvisioning.ts
@@ -152,10 +152,22 @@ export async function provisionEventForwarderThroughLicenseServer(
       lastProvisioningError: "",
     });
 
-    await initializeDatasourceUserIdTypesFromOrgAttributeSchema(
-      context,
-      eventForwarderConfig.datasourceId,
-    );
+    try {
+      await initializeDatasourceUserIdTypesFromOrgAttributeSchema(
+        context,
+        eventForwarderConfig.datasourceId,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      logger.error(
+        {
+          datasourceId: eventForwarderConfig.datasourceId,
+          organizationId: context.org.id,
+          error: message,
+        },
+        "Failed to sync userIdTypes after event forwarder provisioning",
+      );
+    }
 
     if (options?.restartAfterProvision && result.connectorName.trim()) {
       await postRestartEventForwarderToLicenseServer({

--- a/packages/back-end/src/services/eventForwarderUserIdTypes.ts
+++ b/packages/back-end/src/services/eventForwarderUserIdTypes.ts
@@ -20,16 +20,15 @@ export async function initializeDatasourceUserIdTypesFromOrgAttributeSchema(
     return;
   }
 
-  if ((raw.settings?.userIdTypes?.length ?? 0) > 0) {
-    return;
-  }
-
-  const userIdTypes = buildUserIdTypesFromAttributeSchema(
+  const built = buildUserIdTypesFromAttributeSchema(
     context.org.settings?.attributeSchema ?? [],
     raw.projects,
   );
 
-  if (userIdTypes.length === 0) {
+  const existing = raw.settings?.userIdTypes ?? [];
+  const merged = mergeUserIdTypes(existing, built);
+
+  if (merged.length === existing.length) {
     return;
   }
 
@@ -41,7 +40,7 @@ export async function initializeDatasourceUserIdTypesFromOrgAttributeSchema(
   await updateDataSource(context, datasource, {
     settings: {
       ...raw.settings,
-      userIdTypes,
+      userIdTypes: merged,
     },
   });
 }

--- a/packages/back-end/src/services/eventForwarderUserIdTypes.ts
+++ b/packages/back-end/src/services/eventForwarderUserIdTypes.ts
@@ -1,0 +1,105 @@
+import {
+  buildUserIdTypesFromAttributeSchema,
+  mergeUserIdTypes,
+} from "shared/util";
+import { SDKAttributeSchema } from "shared/types/organization";
+import {
+  getDataSourceById,
+  getRawDataSourceById,
+  updateDataSource,
+} from "back-end/src/models/DataSourceModel";
+import { logger } from "back-end/src/util/logger";
+import { ReqContext } from "back-end/types/request";
+
+export async function initializeDatasourceUserIdTypesFromOrgAttributeSchema(
+  context: ReqContext,
+  datasourceId: string,
+): Promise<void> {
+  const raw = await getRawDataSourceById(context, datasourceId);
+  if (!raw) {
+    return;
+  }
+
+  if ((raw.settings?.userIdTypes?.length ?? 0) > 0) {
+    return;
+  }
+
+  const userIdTypes = buildUserIdTypesFromAttributeSchema(
+    context.org.settings?.attributeSchema ?? [],
+    raw.projects,
+  );
+
+  if (userIdTypes.length === 0) {
+    return;
+  }
+
+  const datasource = await getDataSourceById(context, datasourceId);
+  if (!datasource) {
+    return;
+  }
+
+  await updateDataSource(context, datasource, {
+    settings: {
+      ...raw.settings,
+      userIdTypes,
+    },
+  });
+}
+
+export async function syncAllEventForwarderDatasourceUserIdTypesFromAttributeSchema(
+  context: ReqContext,
+  attributeSchema: SDKAttributeSchema,
+): Promise<void> {
+  const configs = await context.models.eventForwarderConfigs.getAll();
+  if (configs.length === 0) {
+    return;
+  }
+
+  await Promise.all(
+    configs.map(async (config) => {
+      try {
+        const raw = await getRawDataSourceById(context, config.datasourceId);
+        if (!raw) {
+          return;
+        }
+
+        const built = buildUserIdTypesFromAttributeSchema(
+          attributeSchema,
+          raw.projects,
+        );
+        const existing = raw.settings?.userIdTypes ?? [];
+        const merged = mergeUserIdTypes(existing, built);
+
+        if (merged.length === existing.length) {
+          return;
+        }
+
+        const datasource = await getDataSourceById(
+          context,
+          config.datasourceId,
+        );
+        if (!datasource) {
+          return;
+        }
+
+        await updateDataSource(context, datasource, {
+          settings: {
+            ...raw.settings,
+            userIdTypes: merged,
+          },
+        });
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Unknown error";
+        logger.error(
+          {
+            datasourceId: config.datasourceId,
+            organizationId: context.org.id,
+            error: message,
+          },
+          "Failed to sync userIdTypes for event forwarder datasource",
+        );
+      }
+    }),
+  );
+}

--- a/packages/back-end/test/services/eventForwarderUserIdTypes.test.ts
+++ b/packages/back-end/test/services/eventForwarderUserIdTypes.test.ts
@@ -1,0 +1,202 @@
+import type { DataSourceInterface } from "shared/types/datasource";
+import {
+  initializeDatasourceUserIdTypesFromOrgAttributeSchema,
+  syncAllEventForwarderDatasourceUserIdTypesFromAttributeSchema,
+} from "back-end/src/services/eventForwarderUserIdTypes";
+import * as DataSourceModel from "back-end/src/models/DataSourceModel";
+
+jest.mock("back-end/src/models/DataSourceModel");
+
+const mockedGetRaw =
+  DataSourceModel.getRawDataSourceById as jest.MockedFunction<
+    typeof DataSourceModel.getRawDataSourceById
+  >;
+const mockedGetById = DataSourceModel.getDataSourceById as jest.MockedFunction<
+  typeof DataSourceModel.getDataSourceById
+>;
+const mockedUpdate = DataSourceModel.updateDataSource as jest.MockedFunction<
+  typeof DataSourceModel.updateDataSource
+>;
+
+function ds(
+  id: string,
+  settings: DataSourceInterface["settings"] = {},
+): DataSourceInterface {
+  return {
+    id,
+    organization: "org1",
+    name: "ds",
+    type: "bigquery",
+    description: "",
+    params: {} as DataSourceInterface["params"],
+    settings,
+    projects: [],
+    dateCreated: new Date(),
+    dateUpdated: new Date(),
+  };
+}
+
+function contextWithSchema(
+  schema: { property: string; datatype: "string"; hashAttribute?: boolean }[],
+) {
+  return {
+    org: {
+      id: "org1",
+      settings: { attributeSchema: schema },
+    },
+    models: {
+      eventForwarderConfigs: {
+        getAll: jest.fn(),
+      },
+    },
+  };
+}
+
+describe("initializeDatasourceUserIdTypesFromOrgAttributeSchema", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("skips when raw Mongo already has userIdTypes", async () => {
+    mockedGetRaw.mockResolvedValue(
+      ds("ds_1", {
+        userIdTypes: [{ userIdType: "user_id", description: "" }],
+      }),
+    );
+
+    await initializeDatasourceUserIdTypesFromOrgAttributeSchema(
+      contextWithSchema([
+        { property: "id", datatype: "string", hashAttribute: true },
+      ]) as never,
+      "ds_1",
+    );
+
+    expect(mockedUpdate).not.toHaveBeenCalled();
+  });
+
+  it("writes userIdTypes when raw Mongo has none", async () => {
+    const raw = ds("ds_1", {});
+    mockedGetRaw.mockResolvedValue(raw);
+    mockedGetById.mockResolvedValue({ ...raw, settings: {} });
+
+    await initializeDatasourceUserIdTypesFromOrgAttributeSchema(
+      contextWithSchema([
+        { property: "id", datatype: "string", hashAttribute: true },
+        { property: "country", datatype: "string" },
+      ]) as never,
+      "ds_1",
+    );
+
+    expect(mockedUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      {
+        settings: {
+          userIdTypes: [
+            {
+              userIdType: "id",
+              description: "",
+              attributes: ["id"],
+            },
+          ],
+        },
+      },
+    );
+  });
+});
+
+describe("syncAllEventForwarderDatasourceUserIdTypesFromAttributeSchema", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("merges new hash attributes into all event forwarder datasources", async () => {
+    const getAll = jest
+      .fn()
+      .mockResolvedValue([{ datasourceId: "ds_a" }, { datasourceId: "ds_b" }]);
+
+    mockedGetRaw
+      .mockResolvedValueOnce(
+        ds("ds_a", {
+          userIdTypes: [
+            { userIdType: "id", description: "", attributes: ["id"] },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(ds("ds_b", { userIdTypes: [] }));
+
+    mockedGetById
+      .mockResolvedValueOnce(ds("ds_a"))
+      .mockResolvedValueOnce(ds("ds_b"));
+
+    const attributeSchema = [
+      { property: "id", datatype: "string" as const, hashAttribute: true },
+      {
+        property: "device_id",
+        datatype: "string" as const,
+        hashAttribute: true,
+      },
+    ];
+
+    await syncAllEventForwarderDatasourceUserIdTypesFromAttributeSchema(
+      {
+        org: { id: "org1" },
+        models: { eventForwarderConfigs: { getAll } },
+      } as never,
+      attributeSchema,
+    );
+
+    expect(mockedUpdate).toHaveBeenCalledTimes(2);
+    expect(mockedUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: "ds_a" }),
+      {
+        settings: {
+          userIdTypes: [
+            { userIdType: "id", description: "", attributes: ["id"] },
+            {
+              userIdType: "device_id",
+              description: "",
+              attributes: ["device_id"],
+            },
+          ],
+        },
+      },
+    );
+    expect(mockedUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: "ds_b" }),
+      {
+        settings: {
+          userIdTypes: [
+            {
+              userIdType: "id",
+              description: "",
+              attributes: ["id"],
+            },
+            {
+              userIdType: "device_id",
+              description: "",
+              attributes: ["device_id"],
+            },
+          ],
+        },
+      },
+    );
+  });
+
+  it("does nothing when no event forwarder configs exist", async () => {
+    const getAll = jest.fn().mockResolvedValue([]);
+
+    await syncAllEventForwarderDatasourceUserIdTypesFromAttributeSchema(
+      {
+        org: { id: "org1" },
+        models: { eventForwarderConfigs: { getAll } },
+      } as never,
+      [{ property: "id", datatype: "string", hashAttribute: true }],
+    );
+
+    expect(mockedGetRaw).not.toHaveBeenCalled();
+    expect(mockedUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/back-end/test/services/eventForwarderUserIdTypes.test.ts
+++ b/packages/back-end/test/services/eventForwarderUserIdTypes.test.ts
@@ -57,21 +57,37 @@ describe("initializeDatasourceUserIdTypesFromOrgAttributeSchema", () => {
     jest.clearAllMocks();
   });
 
-  it("skips when raw Mongo already has userIdTypes", async () => {
-    mockedGetRaw.mockResolvedValue(
-      ds("ds_1", {
-        userIdTypes: [{ userIdType: "user_id", description: "" }],
-      }),
-    );
+  it("merges hash attributes without overriding existing names (case insensitive)", async () => {
+    const raw = ds("ds_1", {
+      userIdTypes: [{ userIdType: "user_id", description: "Existing" }],
+    });
+    mockedGetRaw.mockResolvedValue(raw);
+    mockedGetById.mockResolvedValue(raw);
 
     await initializeDatasourceUserIdTypesFromOrgAttributeSchema(
       contextWithSchema([
+        { property: "USER_ID", datatype: "string", hashAttribute: true },
         { property: "id", datatype: "string", hashAttribute: true },
       ]) as never,
       "ds_1",
     );
 
-    expect(mockedUpdate).not.toHaveBeenCalled();
+    expect(mockedUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      {
+        settings: {
+          userIdTypes: [
+            { userIdType: "user_id", description: "Existing" },
+            {
+              userIdType: "id",
+              description: "",
+              attributes: ["id"],
+            },
+          ],
+        },
+      },
+    );
   });
 
   it("writes userIdTypes when raw Mongo has none", async () => {

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/DataSourceInlineEditIdentifierTypes.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/DataSourceInlineEditIdentifierTypes.tsx
@@ -4,17 +4,23 @@ import {
   DataSourceInterfaceWithParams,
   UserIdType,
 } from "shared/types/datasource";
+import { isHashAttributeUserIdType } from "shared/util";
 import { FaPlus } from "react-icons/fa";
 import { Box, Card, Flex } from "@radix-ui/themes";
 import { DataSourceQueryEditingModalBaseProps } from "@/components/Settings/EditDataSource/types";
 import { EditIdentifierType } from "@/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/EditIdentifierType";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import useOrgSettings from "@/hooks/useOrgSettings";
 import Badge from "@/ui/Badge";
 import Button from "@/ui/Button";
 import Metadata from "@/ui/Metadata";
 import Text from "@/ui/Text";
 import Heading from "@/ui/Heading";
+import Tooltip from "@/ui/Tooltip";
+
+const EVENT_FORWARDER_HASH_IDENTIFIER_DELETE_MESSAGE =
+  "Identifier types linked to hash attributes cannot be deleted while an Event Forwarder is configured for this data source.";
 
 type DataSourceInlineEditIdentifierTypesProps =
   DataSourceQueryEditingModalBaseProps;
@@ -26,16 +32,38 @@ export const DataSourceInlineEditIdentifierTypes: FC<
   const [editingIndex, setEditingIndex] = useState<number>(-1);
 
   const permissionsUtil = usePermissionsUtil();
+  const { attributeSchema } = useOrgSettings();
   canEdit = canEdit && permissionsUtil.canUpdateDataSourceSettings(dataSource);
+
+  const eventForwarderActive = Boolean(dataSource.eventForwarderConfig);
 
   const userIdTypes = useMemo(
     () => dataSource.settings?.userIdTypes || [],
     [dataSource.settings?.userIdTypes],
   );
 
+  const isLockedHashAttributeType = useCallback(
+    (userIdType: string) =>
+      eventForwarderActive &&
+      isHashAttributeUserIdType(
+        userIdType,
+        attributeSchema ?? [],
+        dataSource.projects,
+      ),
+    [attributeSchema, dataSource.projects, eventForwarderActive],
+  );
+
   const recordEditing = useMemo((): null | UserIdType => {
     return userIdTypes[editingIndex] || null;
   }, [editingIndex, userIdTypes]);
+
+  const editingDescriptionOnly = useMemo(
+    () =>
+      recordEditing
+        ? isLockedHashAttributeType(recordEditing.userIdType)
+        : false,
+    [isLockedHashAttributeType, recordEditing],
+  );
 
   const handleCancel = useCallback(() => {
     setUiMode("view");
@@ -66,16 +94,34 @@ export const DataSourceInlineEditIdentifierTypes: FC<
     (idx: number) =>
       async (userIdType: string, description: string, attributes: string[]) => {
         const copy = cloneDeep<DataSourceInterfaceWithParams>(dataSource);
-        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-        copy.settings.userIdTypes[idx] = {
-          userIdType,
-          description,
-          attributes,
-        };
+        const types = copy.settings?.userIdTypes ?? [];
+        const descriptionOnly =
+          uiMode === "edit" && isLockedHashAttributeType(userIdType);
+
+        if (idx >= types.length) {
+          types.push({ userIdType, description, attributes });
+        } else {
+          const existing = types[idx];
+          if (!existing) {
+            return;
+          }
+          types[idx] = descriptionOnly
+            ? { ...existing, description }
+            : {
+                userIdType,
+                description,
+                attributes,
+              };
+        }
+
+        if (!copy.settings) {
+          copy.settings = {};
+        }
+        copy.settings.userIdTypes = types;
 
         await onSave(copy);
       },
-    [dataSource, onSave],
+    [dataSource, isLockedHashAttributeType, onSave, uiMode],
   );
 
   const handleAdd = useCallback(() => {
@@ -114,46 +160,67 @@ export const DataSourceInlineEditIdentifierTypes: FC<
       </Flex>
       <p>The different units you use to split traffic in an experiment.</p>
 
-      {userIdTypes.map(({ userIdType, description, attributes }, idx) => (
-        <Card key={userIdType} mt="3">
-          <Flex align="start" justify="between" py="2" px="3" gap="3">
-            {/* region Identity Type text */}
-            <Box>
-              <Heading size="small" as="h3" mb="1">
-                {userIdType}
-              </Heading>
-              <Box mb="2">
-                <Metadata
-                  label="Linked Hash Attributes"
-                  value={attributes?.join(", ") || "None"}
-                />
-              </Box>
-              <Text color="text-mid">{description || "(no description)"}</Text>
-            </Box>
-            {/* endregion Identity Type text */}
+      {userIdTypes.map(({ userIdType, description, attributes }, idx) => {
+        const deleteDisabled = isLockedHashAttributeType(userIdType);
 
-            {/* region Identity Type actions */}
-            {canEdit && (
-              <Flex gap="3">
-                <DeleteButton
-                  onClick={handleActionDeleteClicked(idx)}
-                  useRadix={true}
-                  useIcon={false}
-                  displayName={userIdTypes[idx]?.userIdType}
-                  deleteMessage={`Are you sure you want to delete identifier type ${userIdTypes[idx]?.userIdType}?`}
-                  title="Delete"
-                  text="Delete"
-                  outline={false}
-                />
-                <Button variant="ghost" onClick={handleActionEditClicked(idx)}>
-                  Edit
-                </Button>
-              </Flex>
-            )}
-            {/* endregion Identity Type actions */}
-          </Flex>
-        </Card>
-      ))}
+        return (
+          <Card key={userIdType} mt="3">
+            <Flex align="start" justify="between" py="2" px="3" gap="3">
+              {/* region Identity Type text */}
+              <Box>
+                <Heading size="small" as="h3" mb="1">
+                  {userIdType}
+                </Heading>
+                <Box mb="2">
+                  <Metadata
+                    label="Linked Hash Attributes"
+                    value={attributes?.join(", ") || "None"}
+                  />
+                </Box>
+                <Text color="text-mid">
+                  {description || "(no description)"}
+                </Text>
+              </Box>
+              {/* endregion Identity Type text */}
+
+              {/* region Identity Type actions */}
+              {canEdit && (
+                <Flex gap="3">
+                  <Tooltip
+                    enabled={deleteDisabled}
+                    content={EVENT_FORWARDER_HASH_IDENTIFIER_DELETE_MESSAGE}
+                  >
+                    <span
+                      style={
+                        deleteDisabled ? { cursor: "not-allowed" } : undefined
+                      }
+                    >
+                      <DeleteButton
+                        onClick={handleActionDeleteClicked(idx)}
+                        useRadix={true}
+                        useIcon={false}
+                        displayName={userIdTypes[idx]?.userIdType}
+                        deleteMessage={`Are you sure you want to delete identifier type ${userIdTypes[idx]?.userIdType}?`}
+                        title="Delete"
+                        text="Delete"
+                        outline={false}
+                        disabled={deleteDisabled}
+                      />
+                    </span>
+                  </Tooltip>
+                  <Button
+                    variant="ghost"
+                    onClick={handleActionEditClicked(idx)}
+                  >
+                    Edit
+                  </Button>
+                </Flex>
+              )}
+              {/* endregion Identity Type actions */}
+            </Flex>
+          </Card>
+        );
+      })}
 
       {/* region Identity Type empty state */}
       {userIdTypes.length === 0 ? (
@@ -171,6 +238,7 @@ export const DataSourceInlineEditIdentifierTypes: FC<
           attributes={recordEditing?.attributes}
           onSave={handleSave(editingIndex)}
           dataSource={dataSource}
+          descriptionOnly={editingDescriptionOnly}
         />
       ) : null}
       {/* endregion Add/Edit modal */}

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/EditIdentifierType.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/EditIdentifierType.tsx
@@ -13,6 +13,7 @@ type EditIdentifierTypeProps = {
   userIdType: string;
   description?: string;
   attributes?: string[];
+  descriptionOnly?: boolean;
   onSave: (
     name: string,
     description: string,
@@ -26,6 +27,7 @@ export const EditIdentifierType: FC<EditIdentifierTypeProps> = ({
   userIdType,
   description,
   attributes,
+  descriptionOnly = false,
   onSave,
   onCancel,
 }) => {
@@ -109,7 +111,7 @@ export const EditIdentifierType: FC<EditIdentifierTypeProps> = ({
           label="Identifier Type"
           {...form.register("idType")}
           pattern="^[a-z_]+$"
-          readOnly={mode === "edit"}
+          readOnly={mode === "edit" || descriptionOnly}
           required
           error={fieldError}
           helpText="Only lowercase letters and underscores allowed. For example, 'user_id' or 'device_cookie'."
@@ -121,7 +123,7 @@ export const EditIdentifierType: FC<EditIdentifierTypeProps> = ({
           maxRows={5}
           textarea
         />
-        {hashAttributes && (
+        {hashAttributes && !descriptionOnly && (
           <MultiSelectField
             label="Hash Attributes"
             value={form.watch("attributes")}

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -484,9 +484,7 @@ mixpanel.init('YOUR PROJECT TOKEN', {
                     onSave={updateDataSourceSettings}
                     onCancel={() => undefined}
                     dataSource={d}
-                    canEdit={
-                      canUpdateDataSourceSettings && !d.eventForwarderConfig
-                    }
+                    canEdit={canUpdateDataSourceSettings}
                   />
                 </Frame>
 

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -480,11 +480,19 @@ mixpanel.init('YOUR PROJECT TOKEN', {
                   )}
 
                 <Frame>
+                  {d.eventForwarderConfig ? (
+                    <Callout status="info" mb="3">
+                      Identifier types are set from your organization attributes
+                      and cannot be edited while Event Forwarder is enabled.
+                    </Callout>
+                  ) : null}
                   <DataSourceInlineEditIdentifierTypes
                     onSave={updateDataSourceSettings}
                     onCancel={() => undefined}
                     dataSource={d}
-                    canEdit={canUpdateDataSourceSettings}
+                    canEdit={
+                      canUpdateDataSourceSettings && !d.eventForwarderConfig
+                    }
                   />
                 </Frame>
 

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -480,12 +480,6 @@ mixpanel.init('YOUR PROJECT TOKEN', {
                   )}
 
                 <Frame>
-                  {d.eventForwarderConfig ? (
-                    <Callout status="info" mb="3">
-                      Identifier types are set from your organization attributes
-                      and cannot be edited while Event Forwarder is enabled.
-                    </Callout>
-                  ) : null}
                   <DataSourceInlineEditIdentifierTypes
                     onSave={updateDataSourceSettings}
                     onCancel={() => undefined}

--- a/packages/shared/src/util/datasource.ts
+++ b/packages/shared/src/util/datasource.ts
@@ -5,6 +5,9 @@ export function attributeMatchesDatasourceProjects(
   attribute: SDKAttribute,
   datasourceProjects: string[] | undefined,
 ): boolean {
+  // A project-scoped attribute only matches a project-scoped datasource when
+  // they share at least one project. A global datasource (no projects) or a
+  // global attribute (no projects) always matches.
   if (datasourceProjects?.length && attribute.projects?.length) {
     return attribute.projects.some((project) =>
       datasourceProjects.includes(project),
@@ -25,6 +28,54 @@ export function buildUserIdTypesFromAttributeSchema(
       description: a.description ?? "",
       attributes: [a.property],
     }));
+}
+
+export function isHashAttributeUserIdType(
+  userIdType: string,
+  attributeSchema: SDKAttributeSchema,
+  datasourceProjects?: string[],
+): boolean {
+  return attributeSchema.some(
+    (attribute) =>
+      attribute.hashAttribute &&
+      !attribute.archived &&
+      attribute.property.toLowerCase() === userIdType.toLowerCase() &&
+      attributeMatchesDatasourceProjects(attribute, datasourceProjects),
+  );
+}
+
+export function isEventForwarderAllowedUserIdTypesChange(
+  existing: UserIdType[],
+  updated: UserIdType[],
+  attributeSchema: SDKAttributeSchema,
+  datasourceProjects?: string[],
+): boolean {
+  const lockedExisting = existing.filter((item) =>
+    isHashAttributeUserIdType(
+      item.userIdType,
+      attributeSchema,
+      datasourceProjects,
+    ),
+  );
+
+  return lockedExisting.every((locked) => {
+    const match = updated.find(
+      (item) =>
+        item.userIdType.toLowerCase() === locked.userIdType.toLowerCase(),
+    );
+    if (!match || match.userIdType !== locked.userIdType) {
+      return false;
+    }
+
+    const lockedAttributes = locked.attributes ?? [];
+    const updatedAttributes = match.attributes ?? [];
+    return (
+      lockedAttributes.length === updatedAttributes.length &&
+      lockedAttributes.every(
+        (attribute, index) => attribute === updatedAttributes[index],
+      )
+    );
+  });
 }
 
 export function mergeUserIdTypes(

--- a/packages/shared/src/util/datasource.ts
+++ b/packages/shared/src/util/datasource.ts
@@ -31,8 +31,10 @@ export function mergeUserIdTypes(
   existing: UserIdType[],
   built: UserIdType[],
 ): UserIdType[] {
-  const existingIds = new Set(existing.map((u) => u.userIdType));
-  const toAdd = built.filter((u) => !existingIds.has(u.userIdType));
+  const existingIds = new Set(existing.map((u) => u.userIdType.toLowerCase()));
+  const toAdd = built.filter(
+    (u) => !existingIds.has(u.userIdType.toLowerCase()),
+  );
   if (toAdd.length === 0) {
     return existing;
   }

--- a/packages/shared/src/util/datasource.ts
+++ b/packages/shared/src/util/datasource.ts
@@ -1,0 +1,40 @@
+import { UserIdType } from "shared/types/datasource";
+import { SDKAttribute, SDKAttributeSchema } from "shared/types/organization";
+
+export function attributeMatchesDatasourceProjects(
+  attribute: SDKAttribute,
+  datasourceProjects: string[] | undefined,
+): boolean {
+  if (datasourceProjects?.length && attribute.projects?.length) {
+    return attribute.projects.some((project) =>
+      datasourceProjects.includes(project),
+    );
+  }
+  return true;
+}
+
+export function buildUserIdTypesFromAttributeSchema(
+  attributeSchema: SDKAttributeSchema,
+  datasourceProjects?: string[],
+): UserIdType[] {
+  return attributeSchema
+    .filter((a) => a.hashAttribute && !a.archived)
+    .filter((a) => attributeMatchesDatasourceProjects(a, datasourceProjects))
+    .map((a) => ({
+      userIdType: a.property,
+      description: a.description ?? "",
+      attributes: [a.property],
+    }));
+}
+
+export function mergeUserIdTypes(
+  existing: UserIdType[],
+  built: UserIdType[],
+): UserIdType[] {
+  const existingIds = new Set(existing.map((u) => u.userIdType));
+  const toAdd = built.filter((u) => !existingIds.has(u.userIdType));
+  if (toAdd.length === 0) {
+    return existing;
+  }
+  return [...existing, ...toAdd];
+}

--- a/packages/shared/src/util/index.ts
+++ b/packages/shared/src/util/index.ts
@@ -41,6 +41,7 @@ export * from "./types";
 export * from "./errors";
 export * from "./namespaces";
 export * from "./custom-fields";
+export * from "./datasource";
 
 export const DEFAULT_ENVIRONMENT_IDS = ["production", "dev", "staging", "test"];
 

--- a/packages/shared/test/util/datasource.test.ts
+++ b/packages/shared/test/util/datasource.test.ts
@@ -1,0 +1,127 @@
+import {
+  attributeMatchesDatasourceProjects,
+  buildUserIdTypesFromAttributeSchema,
+  mergeUserIdTypes,
+} from "../../src/util/datasource";
+
+describe("attributeMatchesDatasourceProjects", () => {
+  it("returns true when neither has projects", () => {
+    expect(
+      attributeMatchesDatasourceProjects(
+        { property: "id", datatype: "string" },
+        [],
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when attribute has no projects", () => {
+    expect(
+      attributeMatchesDatasourceProjects(
+        { property: "id", datatype: "string" },
+        ["proj_a"],
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when projects overlap", () => {
+    expect(
+      attributeMatchesDatasourceProjects(
+        { property: "id", datatype: "string", projects: ["proj_a", "proj_b"] },
+        ["proj_b"],
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when projects do not overlap", () => {
+    expect(
+      attributeMatchesDatasourceProjects(
+        { property: "id", datatype: "string", projects: ["proj_a"] },
+        ["proj_b"],
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("buildUserIdTypesFromAttributeSchema", () => {
+  it("includes only hash attributes that are not archived", () => {
+    const result = buildUserIdTypesFromAttributeSchema([
+      { property: "id", datatype: "string", hashAttribute: true },
+      {
+        property: "company",
+        datatype: "string",
+        hashAttribute: true,
+        archived: true,
+      },
+      { property: "country", datatype: "string" },
+    ]);
+
+    expect(result).toEqual([
+      {
+        userIdType: "id",
+        description: "",
+        attributes: ["id"],
+      },
+    ]);
+  });
+
+  it("filters by datasource projects", () => {
+    const result = buildUserIdTypesFromAttributeSchema(
+      [
+        { property: "id", datatype: "string", hashAttribute: true },
+        {
+          property: "device_id",
+          datatype: "string",
+          hashAttribute: true,
+          projects: ["proj_a"],
+        },
+      ],
+      ["proj_b"],
+    );
+
+    expect(result).toEqual([
+      {
+        userIdType: "id",
+        description: "",
+        attributes: ["id"],
+      },
+    ]);
+  });
+
+  it("uses attribute description when present", () => {
+    const result = buildUserIdTypesFromAttributeSchema([
+      {
+        property: "user_id",
+        datatype: "string",
+        hashAttribute: true,
+        description: "Logged-in user",
+      },
+    ]);
+
+    expect(result[0]?.description).toBe("Logged-in user");
+  });
+});
+
+describe("mergeUserIdTypes", () => {
+  it("appends only missing userIdType values", () => {
+    const existing = [
+      { userIdType: "user_id", description: "Existing", attributes: ["id"] },
+    ];
+    const built = [
+      { userIdType: "user_id", description: "Dup", attributes: ["id"] },
+      { userIdType: "device_id", description: "", attributes: ["device_id"] },
+    ];
+
+    expect(mergeUserIdTypes(existing, built)).toEqual([
+      { userIdType: "user_id", description: "Existing", attributes: ["id"] },
+      { userIdType: "device_id", description: "", attributes: ["device_id"] },
+    ]);
+  });
+
+  it("returns existing unchanged when nothing to add", () => {
+    const existing = [{ userIdType: "id", description: "" }];
+    expect(mergeUserIdTypes(existing, [])).toBe(existing);
+    expect(
+      mergeUserIdTypes(existing, [{ userIdType: "id", description: "x" }]),
+    ).toBe(existing);
+  });
+});

--- a/packages/shared/test/util/datasource.test.ts
+++ b/packages/shared/test/util/datasource.test.ts
@@ -1,6 +1,8 @@
 import {
   attributeMatchesDatasourceProjects,
   buildUserIdTypesFromAttributeSchema,
+  isEventForwarderAllowedUserIdTypesChange,
+  isHashAttributeUserIdType,
   mergeUserIdTypes,
 } from "../../src/util/datasource";
 
@@ -19,6 +21,15 @@ describe("attributeMatchesDatasourceProjects", () => {
       attributeMatchesDatasourceProjects(
         { property: "id", datatype: "string" },
         ["proj_a"],
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when datasource has no projects", () => {
+    expect(
+      attributeMatchesDatasourceProjects(
+        { property: "id", datatype: "string", projects: ["proj_a"] },
+        [],
       ),
     ).toBe(true);
   });
@@ -98,6 +109,137 @@ describe("buildUserIdTypesFromAttributeSchema", () => {
     ]);
 
     expect(result[0]?.description).toBe("Logged-in user");
+  });
+});
+
+describe("isHashAttributeUserIdType", () => {
+  const schema = [
+    { property: "user_id", datatype: "string" as const, hashAttribute: true },
+    { property: "id", datatype: "string" as const, hashAttribute: true },
+  ];
+
+  it("returns true when userIdType matches a hash attribute", () => {
+    expect(isHashAttributeUserIdType("user_id", schema)).toBe(true);
+    expect(isHashAttributeUserIdType("USER_ID", schema)).toBe(true);
+  });
+
+  it("returns false for non-hash or unknown identifier types", () => {
+    expect(isHashAttributeUserIdType("device_id", schema)).toBe(false);
+    expect(isHashAttributeUserIdType("session_id", schema)).toBe(false);
+  });
+});
+
+describe("isEventForwarderAllowedUserIdTypesChange", () => {
+  const schema = [
+    { property: "user_id", datatype: "string" as const, hashAttribute: true },
+  ];
+  const existing = [
+    {
+      userIdType: "user_id",
+      description: "Logged-in user",
+      attributes: ["user_id"],
+    },
+    {
+      userIdType: "device_id",
+      description: "",
+      attributes: ["device_id", "session_id"],
+    },
+  ];
+
+  it("allows description-only changes to hash-attribute identifier types", () => {
+    expect(
+      isEventForwarderAllowedUserIdTypesChange(
+        existing,
+        [
+          {
+            userIdType: "user_id",
+            description: "Updated description",
+            attributes: ["user_id"],
+          },
+          existing[1],
+        ],
+        schema,
+      ),
+    ).toBe(true);
+  });
+
+  it("allows editing non-hash-attribute identifier types", () => {
+    expect(
+      isEventForwarderAllowedUserIdTypesChange(
+        existing,
+        [
+          {
+            userIdType: "user_id",
+            description: "Logged-in user",
+            attributes: ["user_id"],
+          },
+          {
+            userIdType: "account_id",
+            description: "Renamed",
+            attributes: ["account_id"],
+          },
+        ],
+        schema,
+      ),
+    ).toBe(true);
+  });
+
+  it("allows deleting non-hash-attribute identifier types", () => {
+    expect(
+      isEventForwarderAllowedUserIdTypesChange(existing, [existing[0]], schema),
+    ).toBe(true);
+  });
+
+  it("rejects deleting hash-attribute identifier types", () => {
+    expect(
+      isEventForwarderAllowedUserIdTypesChange(existing, [existing[1]], schema),
+    ).toBe(false);
+  });
+
+  it("allows adding new identifier types", () => {
+    expect(
+      isEventForwarderAllowedUserIdTypesChange(
+        existing,
+        [...existing, { userIdType: "session_id", description: "Session" }],
+        schema,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects structural changes to hash-attribute identifier types", () => {
+    expect(
+      isEventForwarderAllowedUserIdTypesChange(
+        existing,
+        [
+          {
+            userIdType: "account_id",
+            description: "Logged-in user",
+            attributes: ["user_id"],
+          },
+          existing[1],
+        ],
+        schema,
+      ),
+    ).toBe(false);
+
+    expect(
+      isEventForwarderAllowedUserIdTypesChange(
+        existing,
+        [
+          {
+            userIdType: "user_id",
+            description: "",
+            attributes: ["device_id"],
+          },
+          existing[1],
+        ],
+        schema,
+      ),
+    ).toBe(false);
+
+    expect(
+      isEventForwarderAllowedUserIdTypesChange(existing, [existing[1]], schema),
+    ).toBe(false);
   });
 });
 

--- a/packages/shared/test/util/datasource.test.ts
+++ b/packages/shared/test/util/datasource.test.ts
@@ -124,4 +124,19 @@ describe("mergeUserIdTypes", () => {
       mergeUserIdTypes(existing, [{ userIdType: "id", description: "x" }]),
     ).toBe(existing);
   });
+
+  it("treats userIdType names as case insensitive when merging", () => {
+    const existing = [
+      { userIdType: "User_ID", description: "Existing", attributes: ["id"] },
+    ];
+    const built = [
+      { userIdType: "user_id", description: "Dup", attributes: ["id"] },
+      { userIdType: "device_id", description: "", attributes: ["device_id"] },
+    ];
+
+    expect(mergeUserIdTypes(existing, built)).toEqual([
+      { userIdType: "User_ID", description: "Existing", attributes: ["id"] },
+      { userIdType: "device_id", description: "", attributes: ["device_id"] },
+    ]);
+  });
 });


### PR DESCRIPTION
### Features and Changes
- When users setup a new event forwarder, we want to automatically copy over the SDK HashAttribute over as Identifier Types
- We also want to automatically copy new HashAttribute going forward into event forwarder datasource if they exist
- We want to keep them as readOnly if there's an event forwarder setup
- Closes **[Copy hash attribute to data source](https://www.notion.so/growthbook/Event-Forwarder-345a857e74a080a888c8de6d150a518d?source=copy_link#359a857e74a0806392a6f099fa837ad9)**


### Testing

1. Create an event forwarder with some default SDK attributes. Verify that `id` is copied over
2. After the event forwarder is connected, go into SDK attributes and create some Hashed attributes, and some NON-hash. Verify that the Hashed ones are created in datasource too
3. Make sure Identifier types are readonly

### Screenshots
<img width="1705" height="1174" alt="Screenshot 2026-05-21 at 08 10 20" src="https://github.com/user-attachments/assets/568d1c16-e5eb-4e25-892d-606e81dc5f3a" />

