### PR TITLE
perf: skip analysis chunk decoding for the snapshot status lookup

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -882,6 +882,7 @@ async function _getSnapshot({
   phase,
   dimension,
   withResults = true,
+  populateResults = true,
   type,
 }: {
   context: ReqContext | ApiReqContext;
@@ -889,6 +890,7 @@ async function _getSnapshot({
   phase?: string;
   dimension?: string;
   withResults?: boolean;
+  populateResults?: boolean;
   type?: SnapshotType;
 }) {
   const experimentObj = await getExperimentById(context, experiment);
@@ -912,6 +914,7 @@ async function _getSnapshot({
     phase: parseInt(phase),
     dimension,
     withResults,
+    populateResults,
     type,
   });
 }
@@ -935,12 +938,18 @@ export async function getSnapshotWithDimension(
     dimension,
     type,
   });
+  // The `latest` field is only used by the UI for refresh status and
+  // metadata (queries, status, error, dateCreated, id, health) — never for
+  // metric results. Skip the per-metric chunk load + decode, which for large
+  // experiments dominates the cost of this endpoint and would otherwise run
+  // twice per request.
   const latest = await _getSnapshot({
     context,
     experiment: id,
     phase,
     dimension,
     withResults: false,
+    populateResults: false,
     type,
   });
   const dimensionless =
@@ -973,11 +982,17 @@ export async function getSnapshot(
   const type = req.query?.type || undefined;
 
   const snapshot = await _getSnapshot({ context, experiment: id, phase, type });
+  // The `latest` field is only used by the UI for refresh status and
+  // metadata (queries, status, error, dateCreated, id, health) — never for
+  // metric results. Skip the per-metric chunk load + decode, which for large
+  // experiments dominates the cost of this endpoint and would otherwise run
+  // twice per request.
   const latest = await _getSnapshot({
     context,
     experiment: id,
     phase,
     withResults: false,
+    populateResults: false,
     type,
   });
 

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -924,6 +924,7 @@ export async function getLatestSnapshot({
   dimension,
   beforeSnapshot,
   withResults = true,
+  populateResults = true,
   type,
 }: {
   context: Context;
@@ -932,6 +933,16 @@ export async function getLatestSnapshot({
   dimension?: string;
   beforeSnapshot?: Pick<ExperimentSnapshotInterface, "dateCreated">;
   withResults?: boolean;
+  /**
+   * When false, skip loading and decoding the per-metric analysis chunk
+   * documents. For chunked snapshots the returned analyses keep their
+   * stored (stripped) form with empty `results`; legacy non-chunked
+   * snapshots are unaffected either way (their results are inline on the
+   * document). Use for callers that only need snapshot metadata (status,
+   * queries, error, health) — for large experiments the chunk decode is by
+   * far the most expensive part of this function.
+   */
+  populateResults?: boolean;
   type?: SnapshotType;
 }): Promise<ExperimentSnapshotInterface | null> {
   const query: FilterQuery<ExperimentSnapshotDocument> = {
@@ -1001,11 +1012,15 @@ export async function getLatestSnapshot({
       ).exec();
 
       if (runningSnapshot) {
-        return populateSnapshotAnalyses(context, toInterface(runningSnapshot));
+        const result = toInterface(runningSnapshot);
+        return populateResults
+          ? populateSnapshotAnalyses(context, result)
+          : result;
       }
     }
 
-    return populateSnapshotAnalyses(context, toInterface(mostRecentSnapshot));
+    const result = toInterface(mostRecentSnapshot);
+    return populateResults ? populateSnapshotAnalyses(context, result) : result;
   }
 
   // Otherwise, try getting old snapshot records
@@ -1018,7 +1033,9 @@ export async function getLatestSnapshot({
     limit: 1,
   }).exec();
 
-  return all[0] ? populateSnapshotAnalyses(context, toInterface(all[0])) : null;
+  if (!all[0]) return null;
+  const result = toInterface(all[0]);
+  return populateResults ? populateSnapshotAnalyses(context, result) : result;
 }
 
 // Gets latest snapshots per experiment-phase pair

--- a/packages/front-end/components/Experiment/SnapshotProvider.tsx
+++ b/packages/front-end/components/Experiment/SnapshotProvider.tsx
@@ -14,7 +14,6 @@ const snapshotContext = React.createContext<{
   experiment?: ExperimentInterfaceStringDates;
   snapshot?: ExperimentSnapshotInterface;
   analysis?: ExperimentSnapshotAnalysis | undefined;
-  latestAnalysis?: ExperimentSnapshotAnalysis | undefined;
   latest?: ExperimentSnapshotInterface;
   dimensionless?: ExperimentSnapshotInterface;
   mutateSnapshot: () => Promise<unknown>;
@@ -105,12 +104,6 @@ export default function SnapshotProvider({
         analysis: data?.snapshot
           ? ((getSnapshotAnalysis(
               data?.snapshot,
-              analysisSettings,
-            ) as ExperimentSnapshotAnalysis) ?? undefined)
-          : undefined,
-        latestAnalysis: data?.latest
-          ? ((getSnapshotAnalysis(
-              data?.latest,
               analysisSettings,
             ) as ExperimentSnapshotAnalysis) ?? undefined)
           : undefined,
@@ -214,7 +207,6 @@ export function LocalSnapshotProvider({
         dimensionless: localSnapshot,
         latest: localSnapshot,
         analysis,
-        latestAnalysis: analysis,
         mutateSnapshot,
         phase,
         dimension,

--- a/packages/front-end/components/SafeRollout/SnapshotProvider.tsx
+++ b/packages/front-end/components/SafeRollout/SnapshotProvider.tsx
@@ -13,7 +13,6 @@ const snapshotContext = React.createContext<{
   feature?: FeatureInterface;
   snapshot?: SafeRolloutSnapshotInterface;
   analysis?: SafeRolloutSnapshotAnalysis | undefined;
-  latestAnalysis?: SafeRolloutSnapshotAnalysis | undefined;
   latest?: SafeRolloutSnapshotInterface;
   mutateSnapshot: () => void;
   analysisSettings?: SafeRolloutSnapshotAnalysisSettings | null;
@@ -64,12 +63,6 @@ export default function SafeRolloutSnapshotProvider({
         analysis: data?.snapshot
           ? (getSafeRolloutSnapshotAnalysis(
               data?.snapshot,
-              defaultAnalysisSettings,
-            ) ?? undefined)
-          : undefined,
-        latestAnalysis: data?.latest
-          ? (getSafeRolloutSnapshotAnalysis(
-              data?.latest,
               defaultAnalysisSettings,
             ) ?? undefined)
           : undefined,


### PR DESCRIPTION
### Features and Changes

`GET /experiment/:id/snapshot/:phase` (and the `/:dimension` variant) returns two snapshot objects: `snapshot` (the latest successful snapshot, used to render results) and `latest` (the latest snapshot of any status, used by the UI to show refresh status). Both lookups currently go through `populateSnapshotAnalyses`, which loads and decodes every per-metric analysis chunk document for the snapshot.

The `latest` field's consumers only read `queries`, `error`, `status`, `dateCreated`, `multipleExposures`, `health`, and `banditResult` — never `analyses[].results`. For experiments with many metrics (and especially many metric slices, each of which gets its own chunk document), the chunk load + decode dominates the cost of this endpoint — and it runs twice per results-page load, with the second copy's results never being used.

This PR adds a `populateResults` option to `getLatestSnapshot` (default `true`, so no other call site changes behavior) and passes `false` for the two `latest` lookups in `getSnapshot` / `getSnapshotWithDimension`. For chunked snapshots the `latest` field's `analyses[].results` is now `[]`; legacy non-chunked snapshots are unaffected either way (their results are inline on the document).

Verification that this is safe: I checked every consumer of the `latest` field — every component that reads `latest` or `latestAnalysis` from the snapshot context, the dashboard snapshot provider, the public/SSR pages, and the REST API handlers. None read `latest.analyses[].results`. (`latestAnalysis` in the snapshot context is currently not consumed by any component at all.) The closest case is `getSRMValue`, which can fall back to `analyses[0].results[0].srm` for standard experiments, but the only call site that passes `latest` uses the multi-armed-bandit branch, which reads `banditResult`/`health` instead.

### Dependencies

None

### Testing

- Load the results page for an experiment with a large number of metrics: results render unchanged (the `snapshot` field is not affected), and the page load does roughly half the chunk-document reads and decoding.
- Refresh-status UI still works: the update button state, the running/error indicator, and the queries modal all read from `latest` (`queries`/`status`/`error`), which are unchanged.
- Bandit experiments: the SRM/health display reads `latest.banditResult` and `latest.health`, both unchanged.

### Screenshots

N/A — no UI changes.