### PR TITLE
Setup fact table for Event Forwarders

### DIFF
--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -31,6 +31,7 @@ import { logger } from "back-end/src/util/logger";
 import { deleteClickhouseUser } from "back-end/src/services/licenseServerManagedClickhouse";
 import { createModelAuditLogger } from "back-end/src/services/audit";
 import { syncEventForwarderAfterDatasourceDeleted } from "back-end/src/services/eventForwarderDatasourceLifecycle";
+import { deleteEventForwarderEventsFactTableForDatasource } from "back-end/src/services/eventForwarderFactTable";
 import { deleteFactTable, getFactTable } from "./FactTableModel";
 
 const dataSourceAuditConfig = {
@@ -217,6 +218,12 @@ export async function deleteDatasource(
     throw new Error("Cannot delete. Data sources managed by config.yml");
   }
   await syncEventForwarderAfterDatasourceDeleted(context, datasource);
+
+  try {
+    await deleteEventForwarderEventsFactTableForDatasource(context, datasource);
+  } catch (e) {
+    logger.error(e, "Error deleting event forwarder Events fact table");
+  }
 
   if (datasource.type === "growthbook_clickhouse") {
     if (!isManagedWarehouseAwaitingProvisioning(datasource)) {

--- a/packages/back-end/src/services/eventForwarderFactTable.ts
+++ b/packages/back-end/src/services/eventForwarderFactTable.ts
@@ -1,0 +1,198 @@
+import { BigQueryConnectionParams } from "shared/types/integrations/bigquery";
+import { SnowflakeConnectionParams } from "shared/types/integrations/snowflake";
+import {
+  BigQueryEventForwarderStoredConfig,
+  SnowflakeEventForwarderStoredConfig,
+} from "shared/types/event-forwarder";
+import { EventForwarderConfigInterface } from "shared/validators";
+import {
+  buildEventForwarderEventsFactTableColumns,
+  buildEventForwarderEventsFactTableSql,
+  getEventForwarderEventsFactTableId,
+  getEventForwarderEventsFactTableIdWithCollisionSuffix,
+  getEventForwarderEventsFactTableName,
+  isEventForwarderEventsFactTableCandidate,
+} from "shared/util";
+import type { FactTableInterface } from "shared/types/fact-table";
+import type { DataSourceInterface } from "shared/types/datasource";
+import {
+  createFactTable,
+  getFactTable,
+  getFactTablesForDatasource,
+  deleteFactTable,
+} from "back-end/src/models/FactTableModel";
+import { getDataSourceById } from "back-end/src/models/DataSourceModel";
+import {
+  decryptEventForwarderConfigModel,
+  getEventForwarderSinkTypeForDatasource,
+} from "back-end/src/services/eventForwarderConfig";
+import { logger } from "back-end/src/util/logger";
+import { ReqContext } from "back-end/types/request";
+
+export function findEventForwarderEventsFactTableForDatasource(
+  factTables: FactTableInterface[],
+  datasourceName: string,
+): FactTableInterface | null {
+  return (
+    factTables.find((ft) =>
+      isEventForwarderEventsFactTableCandidate(ft, datasourceName),
+    ) ?? null
+  );
+}
+
+async function resolveEventForwarderEventsFactTableId(
+  context: ReqContext,
+  datasource: DataSourceInterface,
+): Promise<string> {
+  const baseId = getEventForwarderEventsFactTableId(datasource.name);
+  const existing = await getFactTable(context, baseId);
+  if (!existing || existing.datasource === datasource.id) {
+    return baseId;
+  }
+
+  return getEventForwarderEventsFactTableIdWithCollisionSuffix(
+    datasource.name,
+    datasource.id,
+  );
+}
+
+export async function ensureEventForwarderEventsFactTable(
+  context: ReqContext,
+  eventForwarderConfig: EventForwarderConfigInterface,
+  datasourceParams?: BigQueryConnectionParams | SnowflakeConnectionParams,
+): Promise<void> {
+  if (eventForwarderConfig.sinkType === "databricks") {
+    return;
+  }
+
+  const datasource = await getDataSourceById(
+    context,
+    eventForwarderConfig.datasourceId,
+  );
+  if (!datasource) {
+    return;
+  }
+
+  const factTableId = await resolveEventForwarderEventsFactTableId(
+    context,
+    datasource,
+  );
+  const existing = await getFactTable(context, factTableId);
+  if (existing?.datasource === datasource.id) {
+    return;
+  }
+
+  const userIdTypes =
+    datasource.settings?.userIdTypes?.map((u) => u.userIdType) ?? [];
+  if (userIdTypes.length === 0) {
+    logger.warn(
+      {
+        datasourceId: datasource.id,
+        organizationId: context.org.id,
+      },
+      "Skipping event forwarder Events fact table: no userIdTypes on datasource",
+    );
+    return;
+  }
+
+  const attributeSchema = context.org.settings?.attributeSchema ?? [];
+
+  let sql: string;
+  if (eventForwarderConfig.sinkType === "bigquery") {
+    const bigqueryParams = datasourceParams as
+      | BigQueryConnectionParams
+      | undefined;
+    const projectId =
+      bigqueryParams?.defaultProject?.trim() ||
+      bigqueryParams?.projectId?.trim() ||
+      "";
+    if (!projectId) {
+      logger.warn(
+        {
+          datasourceId: datasource.id,
+          organizationId: context.org.id,
+        },
+        "Skipping event forwarder Events fact table: missing BigQuery project id",
+      );
+      return;
+    }
+
+    const decrypted =
+      decryptEventForwarderConfigModel<BigQueryEventForwarderStoredConfig>(
+        eventForwarderConfig,
+      );
+
+    sql = buildEventForwarderEventsFactTableSql({
+      sinkType: "bigquery",
+      projectId,
+      dataset: decrypted.dataset.trim(),
+      tableName: decrypted.tableName.trim(),
+    });
+  } else if (eventForwarderConfig.sinkType === "snowflake") {
+    const decrypted =
+      decryptEventForwarderConfigModel<SnowflakeEventForwarderStoredConfig>(
+        eventForwarderConfig,
+      );
+
+    sql = buildEventForwarderEventsFactTableSql({
+      sinkType: "snowflake",
+      database: decrypted.database.trim(),
+      schema: decrypted.schema.trim(),
+      tableName: decrypted.tableName.trim(),
+      userIdTypes,
+    });
+  } else {
+    return;
+  }
+
+  const columns = buildEventForwarderEventsFactTableColumns(
+    userIdTypes,
+    attributeSchema,
+    datasource.projects,
+  );
+
+  await createFactTable(context, {
+    id: factTableId,
+    name: getEventForwarderEventsFactTableName(datasource.name),
+    description: "",
+    owner: "",
+    tags: [],
+    projects: datasource.projects ?? [],
+    datasource: datasource.id,
+    userIdTypes,
+    sql,
+    eventName: "",
+    columns,
+    managedBy: "api",
+  });
+}
+
+export async function deleteEventForwarderEventsFactTableForDatasource(
+  context: ReqContext,
+  datasource: DataSourceInterface,
+): Promise<void> {
+  const sinkType = getEventForwarderSinkTypeForDatasource(datasource);
+  if (sinkType !== "bigquery" && sinkType !== "snowflake") {
+    return;
+  }
+
+  const factTables = await getFactTablesForDatasource(context, datasource.id);
+  let factTable = findEventForwarderEventsFactTableForDatasource(
+    factTables,
+    datasource.name,
+  );
+
+  if (!factTable) {
+    const fallbackId = getEventForwarderEventsFactTableId(datasource.name);
+    factTable = await getFactTable(context, fallbackId);
+    if (factTable?.datasource !== datasource.id) {
+      factTable = null;
+    }
+  }
+
+  if (!factTable) {
+    return;
+  }
+
+  await deleteFactTable(context, factTable, { bypassManagedByCheck: true });
+}

--- a/packages/back-end/src/services/eventForwarderFactTable.ts
+++ b/packages/back-end/src/services/eventForwarderFactTable.ts
@@ -43,17 +43,21 @@ export function findEventForwarderEventsFactTableForDatasource(
 async function resolveEventForwarderEventsFactTableId(
   context: ReqContext,
   datasource: DataSourceInterface,
-): Promise<string> {
+): Promise<{ factTableId: string; existing: FactTableInterface | null }> {
   const baseId = getEventForwarderEventsFactTableId(datasource.name);
   const existing = await getFactTable(context, baseId);
   if (!existing || existing.datasource === datasource.id) {
-    return baseId;
+    return { factTableId: baseId, existing };
   }
 
-  return getEventForwarderEventsFactTableIdWithCollisionSuffix(
+  const factTableId = getEventForwarderEventsFactTableIdWithCollisionSuffix(
     datasource.name,
     datasource.id,
   );
+  return {
+    factTableId,
+    existing: await getFactTable(context, factTableId),
+  };
 }
 
 export async function ensureEventForwarderEventsFactTable(
@@ -73,11 +77,8 @@ export async function ensureEventForwarderEventsFactTable(
     return;
   }
 
-  const factTableId = await resolveEventForwarderEventsFactTableId(
-    context,
-    datasource,
-  );
-  const existing = await getFactTable(context, factTableId);
+  const { factTableId, existing } =
+    await resolveEventForwarderEventsFactTableId(context, datasource);
   if (existing?.datasource === datasource.id) {
     return;
   }

--- a/packages/back-end/src/services/eventForwarderProvisioning.ts
+++ b/packages/back-end/src/services/eventForwarderProvisioning.ts
@@ -20,6 +20,7 @@ import { decryptEventForwarderConfigModel } from "back-end/src/services/eventFor
 import { resolveBigQueryEventForwarderTableName } from "back-end/src/services/eventForwarderBqTableResolution";
 import { testEventForwarderWriteAccess } from "back-end/src/services/eventForwarderWriteAccessValidation";
 import { initializeDatasourceUserIdTypesFromOrgAttributeSchema } from "back-end/src/services/eventForwarderUserIdTypes";
+import { ensureEventForwarderEventsFactTable } from "back-end/src/services/eventForwarderFactTable";
 import { logger } from "back-end/src/util/logger";
 import { ReqContext } from "back-end/types/request";
 
@@ -166,6 +167,24 @@ export async function provisionEventForwarderThroughLicenseServer(
           error: message,
         },
         "Failed to sync userIdTypes after event forwarder provisioning",
+      );
+    }
+
+    try {
+      await ensureEventForwarderEventsFactTable(
+        context,
+        eventForwarderConfig,
+        datasourceParams,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      logger.error(
+        {
+          datasourceId: eventForwarderConfig.datasourceId,
+          organizationId: context.org.id,
+          error: message,
+        },
+        "Failed to create Events fact table after event forwarder provisioning",
       );
     }
 

--- a/packages/back-end/test/services/eventForwarderFactTable.test.ts
+++ b/packages/back-end/test/services/eventForwarderFactTable.test.ts
@@ -1,0 +1,255 @@
+import type { DataSourceInterface } from "shared/types/datasource";
+import type { FactTableInterface } from "shared/types/fact-table";
+import {
+  ensureEventForwarderEventsFactTable,
+  findEventForwarderEventsFactTableForDatasource,
+  deleteEventForwarderEventsFactTableForDatasource,
+} from "back-end/src/services/eventForwarderFactTable";
+import * as DataSourceModel from "back-end/src/models/DataSourceModel";
+import * as FactTableModel from "back-end/src/models/FactTableModel";
+import * as EventForwarderConfig from "back-end/src/services/eventForwarderConfig";
+
+jest.mock("back-end/src/models/DataSourceModel");
+jest.mock("back-end/src/models/FactTableModel");
+jest.mock("back-end/src/services/eventForwarderConfig");
+
+const mockedGetDataSourceById =
+  DataSourceModel.getDataSourceById as jest.MockedFunction<
+    typeof DataSourceModel.getDataSourceById
+  >;
+const mockedGetFactTable = FactTableModel.getFactTable as jest.MockedFunction<
+  typeof FactTableModel.getFactTable
+>;
+const mockedCreateFactTable =
+  FactTableModel.createFactTable as jest.MockedFunction<
+    typeof FactTableModel.createFactTable
+  >;
+const mockedGetFactTablesForDatasource =
+  FactTableModel.getFactTablesForDatasource as jest.MockedFunction<
+    typeof FactTableModel.getFactTablesForDatasource
+  >;
+const mockedDeleteFactTable =
+  FactTableModel.deleteFactTable as jest.MockedFunction<
+    typeof FactTableModel.deleteFactTable
+  >;
+const mockedDecrypt =
+  EventForwarderConfig.decryptEventForwarderConfigModel as jest.MockedFunction<
+    typeof EventForwarderConfig.decryptEventForwarderConfigModel
+  >;
+const mockedGetSinkType =
+  EventForwarderConfig.getEventForwarderSinkTypeForDatasource as jest.MockedFunction<
+    typeof EventForwarderConfig.getEventForwarderSinkTypeForDatasource
+  >;
+
+function datasource(
+  overrides: Partial<DataSourceInterface> = {},
+): DataSourceInterface {
+  return {
+    id: "ds_1",
+    organization: "org1",
+    name: "Production Analytics",
+    type: "bigquery",
+    description: "",
+    params: {} as DataSourceInterface["params"],
+    settings: {
+      userIdTypes: [{ userIdType: "user_id", description: "" }],
+    },
+    projects: ["proj_1"],
+    dateCreated: new Date(),
+    dateUpdated: new Date(),
+    ...overrides,
+  };
+}
+
+function context() {
+  return {
+    org: {
+      id: "org1",
+      settings: { attributeSchema: [] },
+    },
+    userId: "user_1",
+  };
+}
+
+describe("findEventForwarderEventsFactTableForDatasource", () => {
+  it("finds api-managed Events fact table by name", () => {
+    const ft: FactTableInterface = {
+      id: "production_analytics_events",
+      name: "Production Analytics Events",
+      managedBy: "api",
+      organization: "org1",
+      dateCreated: new Date(),
+      dateUpdated: new Date(),
+      description: "",
+      owner: "",
+      projects: [],
+      tags: [],
+      datasource: "ds_1",
+      userIdTypes: ["user_id"],
+      sql: "",
+      eventName: "",
+      columns: [],
+      filters: [],
+    };
+
+    expect(
+      findEventForwarderEventsFactTableForDatasource(
+        [ft],
+        "Production Analytics",
+      ),
+    ).toBe(ft);
+  });
+});
+
+describe("ensureEventForwarderEventsFactTable", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates fact table with per-datasource id and name", async () => {
+    mockedGetDataSourceById.mockResolvedValue(datasource());
+    mockedGetFactTable.mockResolvedValue(null);
+    mockedDecrypt.mockReturnValue({
+      dataset: "analytics_123",
+      tableName: "gb_events",
+      serviceAccountKey: "{}",
+    });
+    mockedCreateFactTable.mockResolvedValue({} as never);
+
+    await ensureEventForwarderEventsFactTable(
+      context() as never,
+      {
+        id: "efc_1",
+        datasourceId: "ds_1",
+        sinkType: "bigquery",
+        config: "encrypted",
+        status: "pending",
+        organization: "org1",
+        projects: [],
+        topic: "topic",
+      },
+      {
+        defaultProject: "my-project",
+        defaultDataset: "analytics_123",
+      } as never,
+    );
+
+    expect(mockedCreateFactTable).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        id: "production_analytics_events",
+        name: "Production Analytics Events",
+        managedBy: "api",
+        datasource: "ds_1",
+        userIdTypes: ["user_id"],
+      }),
+    );
+
+    const createArgs = mockedCreateFactTable.mock.calls[0][1];
+    expect(createArgs.sql).toContain(
+      "`my-project`.`analytics_123`.`gb_events`",
+    );
+    expect(createArgs.sql).toContain("received_at BETWEEN");
+  });
+
+  it("skips when fact table already exists for datasource", async () => {
+    mockedGetDataSourceById.mockResolvedValue(datasource());
+    mockedGetFactTable.mockResolvedValue({
+      id: "production_analytics_events",
+      datasource: "ds_1",
+    } as never);
+
+    await ensureEventForwarderEventsFactTable(
+      context() as never,
+      {
+        id: "efc_1",
+        datasourceId: "ds_1",
+        sinkType: "bigquery",
+        config: "encrypted",
+        status: "pending",
+        organization: "org1",
+        projects: [],
+        topic: "topic",
+      },
+      { defaultProject: "my-project" } as never,
+    );
+
+    expect(mockedCreateFactTable).not.toHaveBeenCalled();
+  });
+
+  it("uses collision suffix when base id is taken by another datasource", async () => {
+    mockedGetDataSourceById.mockResolvedValue(datasource({ id: "ds_2" }));
+    mockedGetFactTable.mockResolvedValue({
+      id: "production_analytics_events",
+      datasource: "ds_other",
+    } as never);
+    mockedDecrypt.mockReturnValue({
+      dataset: "analytics_123",
+      tableName: "gb_events",
+      serviceAccountKey: "{}",
+    });
+    mockedCreateFactTable.mockResolvedValue({} as never);
+
+    await ensureEventForwarderEventsFactTable(
+      context() as never,
+      {
+        id: "efc_1",
+        datasourceId: "ds_2",
+        sinkType: "bigquery",
+        config: "encrypted",
+        status: "pending",
+        organization: "org1",
+        projects: [],
+        topic: "topic",
+      },
+      { defaultProject: "my-project" } as never,
+    );
+
+    expect(mockedCreateFactTable).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        id: "production_analytics_ds2_events",
+      }),
+    );
+  });
+});
+
+describe("deleteEventForwarderEventsFactTableForDatasource", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("deletes api-managed Events fact table for datasource", async () => {
+    const ft: FactTableInterface = {
+      id: "production_analytics_events",
+      name: "Production Analytics Events",
+      managedBy: "api",
+      organization: "org1",
+      dateCreated: new Date(),
+      dateUpdated: new Date(),
+      description: "",
+      owner: "",
+      projects: [],
+      tags: [],
+      datasource: "ds_1",
+      userIdTypes: ["user_id"],
+      sql: "",
+      eventName: "",
+      columns: [],
+      filters: [],
+    };
+
+    mockedGetSinkType.mockReturnValue("bigquery");
+    mockedGetFactTablesForDatasource.mockResolvedValue([ft]);
+    mockedDeleteFactTable.mockResolvedValue(undefined as never);
+
+    await deleteEventForwarderEventsFactTableForDatasource(
+      context() as never,
+      datasource(),
+    );
+
+    expect(mockedDeleteFactTable).toHaveBeenCalledWith(expect.anything(), ft, {
+      bypassManagedByCheck: true,
+    });
+  });
+});

--- a/packages/shared/src/event-forwarder-avro.ts
+++ b/packages/shared/src/event-forwarder-avro.ts
@@ -8,6 +8,8 @@ import type {
 export const EVENT_FORWARDER_AVRO_RECORD_NAME =
   "GrowthBookForwardedEvent" as const;
 export const EVENT_FORWARDER_AVRO_NAMESPACE = "io.growthbook.events" as const;
+/** BigQuery daily partition column for BigQueryStorageSink (timestamp-millis). */
+export const EVENT_FORWARDER_AVRO_PARTITION_FIELD = "received_at" as const;
 
 /** Avro field definitions matching the ingestor payload in kafka.ts (minus dynamic org columns). */
 export const EVENT_FORWARDER_AVRO_DEFAULT_FIELDS = [

--- a/packages/shared/src/util/event-forwarder-fact-table.ts
+++ b/packages/shared/src/util/event-forwarder-fact-table.ts
@@ -145,7 +145,7 @@ export function buildEventForwarderEventsFactTableSql(
   ];
   const selectCols = standardCols.map((col) => `${col}`).join(",\n  ");
 
-  return `SELECT\n  ${selectCols}\nFROM\n  ${tableRef}\nWHERE ${partitionFilter}`;
+  return `SELECT\n  ${selectCols}\nFROM\n  ${tableRef}`;
 }
 
 function defaultAvroFieldDatatype(fieldName: string): FactTableColumnType {

--- a/packages/shared/src/util/event-forwarder-fact-table.ts
+++ b/packages/shared/src/util/event-forwarder-fact-table.ts
@@ -1,0 +1,235 @@
+import type { SDKAttributeSchema } from "shared/types/organization";
+import type {
+  CreateColumnProps,
+  FactTableColumnType,
+} from "shared/types/fact-table";
+import {
+  EVENT_FORWARDER_AVRO_DEFAULT_FIELDS,
+  EVENT_FORWARDER_AVRO_PARTITION_FIELD,
+  sanitizeAvroFieldName,
+} from "../event-forwarder-avro";
+import { attributeMatchesDatasourceProjects } from "./datasource";
+
+export { EVENT_FORWARDER_AVRO_PARTITION_FIELD };
+
+export const EVENT_FORWARDER_EVENTS_FACT_TABLE_ID_SUFFIX = "_events";
+export const EVENT_FORWARDER_EVENTS_FACT_TABLE_NAME_SUFFIX = " Events";
+
+const DEFAULT_FIELD_NAMES: Set<string> = new Set(
+  EVENT_FORWARDER_AVRO_DEFAULT_FIELDS.map((f) => f.name),
+);
+
+export function sanitizeDatasourceNameForFactTableId(name: string): string {
+  const sanitized = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "");
+
+  if (!sanitized) {
+    return "datasource";
+  }
+
+  if (!/^[a-z_]/.test(sanitized)) {
+    return `_${sanitized}`;
+  }
+
+  return sanitized;
+}
+
+export function getEventForwarderEventsFactTableId(
+  datasourceName: string,
+): string {
+  return `${sanitizeDatasourceNameForFactTableId(datasourceName)}${EVENT_FORWARDER_EVENTS_FACT_TABLE_ID_SUFFIX}`;
+}
+
+export function getEventForwarderEventsFactTableIdWithCollisionSuffix(
+  datasourceName: string,
+  datasourceId: string,
+): string {
+  const prefix = sanitizeDatasourceNameForFactTableId(datasourceName);
+  const idSuffix = datasourceId
+    .replace(/[^a-zA-Z0-9]/g, "")
+    .slice(-6)
+    .toLowerCase();
+  if (!idSuffix) {
+    return `${prefix}${EVENT_FORWARDER_EVENTS_FACT_TABLE_ID_SUFFIX}`;
+  }
+  return `${prefix}_${idSuffix}${EVENT_FORWARDER_EVENTS_FACT_TABLE_ID_SUFFIX}`;
+}
+
+export function getEventForwarderEventsFactTableName(
+  datasourceName: string,
+): string {
+  return `${datasourceName.trim()}${EVENT_FORWARDER_EVENTS_FACT_TABLE_NAME_SUFFIX}`;
+}
+
+export function isEventForwarderEventsFactTableCandidate(
+  factTable: { id: string; name: string; managedBy?: string },
+  datasourceName: string,
+): boolean {
+  if (factTable.managedBy !== "api") {
+    return false;
+  }
+
+  const expectedName = getEventForwarderEventsFactTableName(datasourceName);
+  if (factTable.name === expectedName) {
+    return true;
+  }
+
+  const prefix = sanitizeDatasourceNameForFactTableId(datasourceName);
+  return (
+    factTable.id === getEventForwarderEventsFactTableId(datasourceName) ||
+    (factTable.id.startsWith(`${prefix}_`) &&
+      factTable.id.endsWith(EVENT_FORWARDER_EVENTS_FACT_TABLE_ID_SUFFIX))
+  );
+}
+
+export function buildBigQueryEventForwarderTableReference(
+  projectId: string,
+  dataset: string,
+  tableName: string,
+): string {
+  return `\`${projectId.trim()}\`.\`${dataset.trim()}\`.\`${tableName.trim()}\``;
+}
+
+export function buildSnowflakeEventForwarderTableReference(
+  database: string,
+  schema: string,
+  tableName: string,
+): string {
+  return `${database.trim()}.${schema.trim()}.${tableName.trim()}`;
+}
+
+export type BuildEventForwarderEventsFactTableSqlParams =
+  | {
+      sinkType: "bigquery";
+      projectId: string;
+      dataset: string;
+      tableName: string;
+    }
+  | {
+      sinkType: "snowflake";
+      database: string;
+      schema: string;
+      tableName: string;
+      userIdTypes: string[];
+    };
+
+export function buildEventForwarderEventsFactTableSql(
+  params: BuildEventForwarderEventsFactTableSqlParams,
+): string {
+  const partitionFilter = `${EVENT_FORWARDER_AVRO_PARTITION_FIELD} BETWEEN '{{startDate}}' AND '{{endDate}}'`;
+
+  if (params.sinkType === "bigquery") {
+    const tableRef = buildBigQueryEventForwarderTableReference(
+      params.projectId,
+      params.dataset,
+      params.tableName,
+    );
+    return `SELECT *\nFROM ${tableRef}\nWHERE ${partitionFilter}`;
+  }
+
+  const tableRef = buildSnowflakeEventForwarderTableReference(
+    params.database,
+    params.schema,
+    params.tableName,
+  );
+
+  const standardCols = [
+    ...params.userIdTypes,
+    "event_name",
+    "timestamp",
+    EVENT_FORWARDER_AVRO_PARTITION_FIELD,
+  ];
+  const selectCols = standardCols.map((col) => `${col}`).join(",\n  ");
+
+  return `SELECT\n  ${selectCols}\nFROM\n  ${tableRef}\nWHERE ${partitionFilter}`;
+}
+
+function defaultAvroFieldDatatype(fieldName: string): FactTableColumnType {
+  if (
+    fieldName === "timestamp" ||
+    fieldName === EVENT_FORWARDER_AVRO_PARTITION_FIELD
+  ) {
+    return "date";
+  }
+  if (fieldName === "properties" || fieldName === "additional_attributes") {
+    return "json";
+  }
+  if (fieldName === "geo_lat" || fieldName === "geo_lon") {
+    return "number";
+  }
+  return "string";
+}
+
+function hashAttributeDatatype(datatype: string): FactTableColumnType {
+  if (datatype === "number" || datatype === "number[]") {
+    return "number";
+  }
+  if (datatype === "boolean") {
+    return "boolean";
+  }
+  return "string";
+}
+
+export function buildEventForwarderEventsFactTableColumns(
+  userIdTypes: string[],
+  attributeSchema: SDKAttributeSchema = [],
+  datasourceProjects?: string[],
+): CreateColumnProps[] {
+  const columns: CreateColumnProps[] = [];
+  const seen = new Set<string>();
+
+  const pushColumn = (column: CreateColumnProps) => {
+    const key = column.column.toLowerCase();
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    columns.push({
+      ...column,
+      name: column.name ?? column.column,
+      description: column.description ?? "",
+      numberFormat: column.numberFormat ?? "",
+    });
+  };
+
+  for (const userIdType of userIdTypes) {
+    pushColumn({
+      column: userIdType,
+      datatype: "string",
+    });
+  }
+
+  for (const field of EVENT_FORWARDER_AVRO_DEFAULT_FIELDS) {
+    pushColumn({
+      column: field.name,
+      datatype: defaultAvroFieldDatatype(field.name),
+      alwaysInlineFilter: field.name === "event_name" ? true : undefined,
+    });
+  }
+
+  for (const attr of attributeSchema) {
+    if (!attr.hashAttribute || attr.archived) {
+      continue;
+    }
+    if (!attributeMatchesDatasourceProjects(attr, datasourceProjects)) {
+      continue;
+    }
+
+    const column = sanitizeAvroFieldName(attr.property);
+    if (DEFAULT_FIELD_NAMES.has(column)) {
+      continue;
+    }
+
+    pushColumn({
+      column,
+      datatype: hashAttributeDatatype(attr.datatype),
+      description: attr.description ?? "",
+    });
+  }
+
+  return columns;
+}

--- a/packages/shared/src/util/index.ts
+++ b/packages/shared/src/util/index.ts
@@ -42,6 +42,7 @@ export * from "./errors";
 export * from "./namespaces";
 export * from "./custom-fields";
 export * from "./datasource";
+export * from "./event-forwarder-fact-table";
 
 export const DEFAULT_ENVIRONMENT_IDS = ["production", "dev", "staging", "test"];
 

--- a/packages/shared/test/util/event-forwarder-fact-table.test.ts
+++ b/packages/shared/test/util/event-forwarder-fact-table.test.ts
@@ -1,0 +1,160 @@
+import {
+  buildBigQueryEventForwarderTableReference,
+  buildEventForwarderEventsFactTableColumns,
+  buildEventForwarderEventsFactTableSql,
+  buildSnowflakeEventForwarderTableReference,
+  EVENT_FORWARDER_AVRO_PARTITION_FIELD,
+  getEventForwarderEventsFactTableId,
+  getEventForwarderEventsFactTableIdWithCollisionSuffix,
+  getEventForwarderEventsFactTableName,
+  isEventForwarderEventsFactTableCandidate,
+  sanitizeDatasourceNameForFactTableId,
+} from "../../src/util/event-forwarder-fact-table";
+
+describe("event-forwarder-fact-table identity", () => {
+  it("sanitizes datasource names for fact table ids", () => {
+    expect(sanitizeDatasourceNameForFactTableId("Production Analytics")).toBe(
+      "production_analytics",
+    );
+    expect(sanitizeDatasourceNameForFactTableId("  ")).toBe("datasource");
+    expect(sanitizeDatasourceNameForFactTableId("123-abc")).toBe("_123-abc");
+  });
+
+  it("derives id and display name from datasource name", () => {
+    expect(getEventForwarderEventsFactTableId("Production Analytics")).toBe(
+      "production_analytics_events",
+    );
+    expect(getEventForwarderEventsFactTableName("Production Analytics")).toBe(
+      "Production Analytics Events",
+    );
+  });
+
+  it("appends collision suffix from datasource id", () => {
+    expect(
+      getEventForwarderEventsFactTableIdWithCollisionSuffix(
+        "Analytics",
+        "ds_abc123xyz",
+      ),
+    ).toBe("analytics_123xyz_events");
+  });
+
+  it("matches event forwarder fact table candidates", () => {
+    expect(
+      isEventForwarderEventsFactTableCandidate(
+        {
+          id: "production_analytics_events",
+          name: "Production Analytics Events",
+          managedBy: "api",
+        },
+        "Production Analytics",
+      ),
+    ).toBe(true);
+
+    expect(
+      isEventForwarderEventsFactTableCandidate(
+        {
+          id: "production_analytics_a1b2c3_events",
+          name: "Old Name Events",
+          managedBy: "api",
+        },
+        "Production Analytics",
+      ),
+    ).toBe(true);
+
+    expect(
+      isEventForwarderEventsFactTableCandidate(
+        {
+          id: "other_events",
+          name: "Other Events",
+          managedBy: "",
+        },
+        "Production Analytics",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("event-forwarder-fact-table SQL", () => {
+  it("builds BigQuery table reference", () => {
+    expect(
+      buildBigQueryEventForwarderTableReference(
+        "my-project",
+        "analytics_123",
+        "gb_events",
+      ),
+    ).toBe("`my-project`.`analytics_123`.`gb_events`");
+  });
+
+  it("builds BigQuery fact table SQL with received_at partition filter", () => {
+    const sql = buildEventForwarderEventsFactTableSql({
+      sinkType: "bigquery",
+      projectId: "my-project",
+      dataset: "analytics_123",
+      tableName: "gb_events",
+    });
+
+    expect(sql).toContain("SELECT *");
+    expect(sql).toContain("`my-project`.`analytics_123`.`gb_events`");
+    expect(sql).toContain(
+      `${EVENT_FORWARDER_AVRO_PARTITION_FIELD} BETWEEN '{{startDate}}' AND '{{endDate}}'`,
+    );
+  });
+
+  it("builds Snowflake table reference", () => {
+    expect(
+      buildSnowflakeEventForwarderTableReference(
+        "MY_DB",
+        "PUBLIC",
+        "GB_EVENTS",
+      ),
+    ).toBe("MY_DB.PUBLIC.GB_EVENTS");
+  });
+
+  it("builds Snowflake fact table SQL with dynamic userIdTypes", () => {
+    const sql = buildEventForwarderEventsFactTableSql({
+      sinkType: "snowflake",
+      database: "MY_DB",
+      schema: "PUBLIC",
+      tableName: "GB_EVENTS",
+      userIdTypes: ["user_id", "device_id"],
+    });
+
+    expect(sql).toContain("user_id");
+    expect(sql).toContain("device_id");
+    expect(sql).toContain("event_name");
+    expect(sql).toContain("FROM\n  MY_DB.PUBLIC.GB_EVENTS");
+    expect(sql).toContain(
+      `${EVENT_FORWARDER_AVRO_PARTITION_FIELD} BETWEEN '{{startDate}}' AND '{{endDate}}'`,
+    );
+  });
+});
+
+describe("buildEventForwarderEventsFactTableColumns", () => {
+  it("includes user id types, default avro fields, and hash attributes", () => {
+    const columns = buildEventForwarderEventsFactTableColumns(
+      ["user_id"],
+      [
+        {
+          property: "device_id",
+          datatype: "string",
+          hashAttribute: true,
+        },
+        {
+          property: "event_name",
+          datatype: "string",
+          hashAttribute: true,
+        },
+      ],
+    );
+
+    const columnNames = columns.map((c) => c.column);
+    expect(columnNames).toContain("user_id");
+    expect(columnNames).toContain("device_id");
+    expect(columnNames).toContain("event_name");
+    expect(columnNames).toContain("received_at");
+    expect(columnNames).toContain("properties");
+
+    const eventNameCol = columns.find((c) => c.column === "event_name");
+    expect(eventNameCol?.alwaysInlineFilter).toBe(true);
+  });
+});

--- a/packages/shared/test/util/event-forwarder-fact-table.test.ts
+++ b/packages/shared/test/util/event-forwarder-fact-table.test.ts
@@ -123,9 +123,7 @@ describe("event-forwarder-fact-table SQL", () => {
     expect(sql).toContain("device_id");
     expect(sql).toContain("event_name");
     expect(sql).toContain("FROM\n  MY_DB.PUBLIC.GB_EVENTS");
-    expect(sql).toContain(
-      `${EVENT_FORWARDER_AVRO_PARTITION_FIELD} BETWEEN '{{startDate}}' AND '{{endDate}}'`,
-    );
+    expect(sql).not.toContain("WHERE");
   });
 });
 


### PR DESCRIPTION
### Features and Changes
- Create fact table for Data source with Event forwarders table
- Clean up this fact table if data source is removed

- Closes **[Add fact table](https://www.notion.so/growthbook/Event-Forwarder-345a857e74a080a888c8de6d150a518d?source=copy_link#359a857e74a08029b9ddf3e89de62f28)**


### Testing

- Set up an event forwarder for both BigQuery and SnowFlake
- Verify a new fact table is created for each and point to the events tables
- Make sure BigQuery fact table has a received_at where clause, but not Snowflake due to partitioning

### Screenshots
<img width="1724" height="932" alt="Screenshot 2026-05-21 at 15 18 23" src="https://github.com/user-attachments/assets/05c7921e-5e18-4059-9706-553e8eaca05a" />
<img width="1722" height="1292" alt="Screenshot 2026-05-21 at 15 41 56" src="https://github.com/user-attachments/assets/33b51519-6a1c-46b9-b910-64ad46fdb6ff" />


