### PR TITLE
Select everything for Snowflake EF Fact table

### DIFF
--- a/packages/back-end/src/services/eventForwarderFactTable.ts
+++ b/packages/back-end/src/services/eventForwarderFactTable.ts
@@ -140,7 +140,6 @@ export async function ensureEventForwarderEventsFactTable(
       database: decrypted.database.trim(),
       schema: decrypted.schema.trim(),
       tableName: decrypted.tableName.trim(),
-      userIdTypes,
     });
   } else {
     return;

--- a/packages/shared/src/util/event-forwarder-fact-table.ts
+++ b/packages/shared/src/util/event-forwarder-fact-table.ts
@@ -114,7 +114,6 @@ export type BuildEventForwarderEventsFactTableSqlParams =
       database: string;
       schema: string;
       tableName: string;
-      userIdTypes: string[];
     };
 
 export function buildEventForwarderEventsFactTableSql(
@@ -137,15 +136,7 @@ export function buildEventForwarderEventsFactTableSql(
     params.tableName,
   );
 
-  const standardCols = [
-    ...params.userIdTypes,
-    "event_name",
-    "timestamp",
-    EVENT_FORWARDER_AVRO_PARTITION_FIELD,
-  ];
-  const selectCols = standardCols.map((col) => `${col}`).join(",\n  ");
-
-  return `SELECT\n  ${selectCols}\nFROM\n  ${tableRef}`;
+  return `SELECT *\nFROM ${tableRef}`;
 }
 
 function defaultAvroFieldDatatype(fieldName: string): FactTableColumnType {

--- a/packages/shared/test/util/event-forwarder-fact-table.test.ts
+++ b/packages/shared/test/util/event-forwarder-fact-table.test.ts
@@ -110,20 +110,15 @@ describe("event-forwarder-fact-table SQL", () => {
     ).toBe("MY_DB.PUBLIC.GB_EVENTS");
   });
 
-  it("builds Snowflake fact table SQL with dynamic userIdTypes", () => {
+  it("builds Snowflake fact table SQL with select all", () => {
     const sql = buildEventForwarderEventsFactTableSql({
       sinkType: "snowflake",
       database: "MY_DB",
       schema: "PUBLIC",
       tableName: "GB_EVENTS",
-      userIdTypes: ["user_id", "device_id"],
     });
 
-    expect(sql).toContain("user_id");
-    expect(sql).toContain("device_id");
-    expect(sql).toContain("event_name");
-    expect(sql).toContain("FROM\n  MY_DB.PUBLIC.GB_EVENTS");
-    expect(sql).not.toContain("WHERE");
+    expect(sql).toBe("SELECT *\nFROM MY_DB.PUBLIC.GB_EVENTS");
   });
 });
 


### PR DESCRIPTION
### Features and Changes
- Select * for EF Fact table in Snowflake instead of just the basic ones

- Closes **[Fact Table for Snowflake](https://www.notion.so/growthbook/Event-Forwarder-345a857e74a080a888c8de6d150a518d?source=copy_link#359a857e74a08029b9ddf3e89de62f28)**

### Testing
- Create Snowflake datasource and then add Event Forwarder

### Screenshots
<img width="1708" height="1265" alt="Screenshot 2026-05-21 at 16 36 30" src="https://github.com/user-attachments/assets/4b4d5510-73eb-491e-b7dd-17668a7e2204" />


