### PR TITLE
Remove unused trafficSplit and targetingCondition from experiment API request schemas

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -9228,19 +9228,6 @@ paths:
                         type: string
                       coverage:
                         type: number
-                      trafficSplit:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            variationId:
-                              type: string
-                            weight:
-                              type: number
-                          required:
-                            - variationId
-                            - weight
-                          additionalProperties: false
                       namespace:
                         type: object
                         properties:
@@ -9264,8 +9251,6 @@ paths:
                         required:
                           - namespaceId
                         additionalProperties: false
-                      targetingCondition:
-                        type: string
                       prerequisites:
                         type: array
                         items:
@@ -9825,21 +9810,6 @@ paths:
                         type: string
                       coverage:
                         type: number
-                      trafficSplit:
-                        deprecated: true
-                        description: Deprecated and unused. Use variationWeights instead.
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            variationId:
-                              type: string
-                            weight:
-                              type: number
-                          required:
-                            - variationId
-                            - weight
-                          additionalProperties: false
                       namespace:
                         type: object
                         properties:
@@ -9857,8 +9827,6 @@ paths:
                           - namespaceId
                           - range
                         additionalProperties: false
-                      targetingCondition:
-                        type: string
                       prerequisites:
                         type: array
                         items:

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -973,14 +973,6 @@ const apiPhaseInput = z.object({
   reasonForStopping: z.string().optional(),
   seed: z.string().optional(),
   coverage: z.number().optional(),
-  trafficSplit: z
-    .array(
-      z.object({
-        variationId: z.string(),
-        weight: z.number(),
-      }),
-    )
-    .optional(),
   namespace: z
     .object({
       namespaceId: z.string(),
@@ -990,7 +982,6 @@ const apiPhaseInput = z.object({
       ranges: z.array(z.tuple([z.number(), z.number()])).optional(),
     })
     .optional(),
-  targetingCondition: z.string().optional(),
   prerequisites: z
     .array(
       z.object({
@@ -1234,16 +1225,6 @@ const updateExperimentBody = z
           reasonForStopping: z.string().optional(),
           seed: z.string().optional(),
           coverage: z.number().optional(),
-          trafficSplit: z
-            .array(
-              z.object({
-                variationId: z.string(),
-                weight: z.number(),
-              }),
-            )
-            .describe("Deprecated and unused. Use variationWeights instead.")
-            .optional()
-            .meta({ deprecated: true }),
           namespace: z
             .object({
               namespaceId: z.string(),
@@ -1251,7 +1232,6 @@ const updateExperimentBody = z
               enabled: z.boolean().optional(),
             })
             .optional(),
-          targetingCondition: z.string().optional(),
           prerequisites: z
             .array(
               z.object({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

Removes unused fields from the public API experiment create and update request schemas:

- **`trafficSplit`** - Was accepted in phase definitions for both create (`POST /api/v1/experiments`) and update (`POST /api/v1/experiments/:id`) endpoints, but was never processed by the handlers. Users should use `variationWeights` instead.
- **`targetingCondition`** - Was accepted in phase definitions for both endpoints, but was never processed by the handlers. Users should use `condition` instead.

These fields were added during a recent API refactor but only apply to response schemas (where they map from internal model fields `variationWeights` → `trafficSplit` and `condition` → `targetingCondition`). The request schemas should only accept the internal field names.

**Note:** The response schemas still include `trafficSplit` and `targetingCondition` as these are correctly populated when returning experiment data.

### Dependencies

None

### Testing

- All existing tests pass (4049 back-end tests, 314 front-end tests)
- Type checking passes
- ESLint passes
- OpenAPI spec regenerated to reflect the schema changes

### Screenshots

N/A - This is an API schema cleanup with no UI changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C07NK4F016Z/p1779407494533059?thread_ts=1779407494.533059&cid=C07NK4F016Z)

<div><a href="https://cursor.com/agents/bc-7e261ad2-0137-5a17-b72e-2a391b6becd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e261ad2-0137-5a17-b72e-2a391b6becd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

