### PR TITLE
Add EAQ for each identifier type

### DIFF
--- a/packages/back-end/src/services/eventForwarderExposureQueries.ts
+++ b/packages/back-end/src/services/eventForwarderExposureQueries.ts
@@ -4,7 +4,6 @@ import {
   BigQueryEventForwarderStoredConfig,
   SnowflakeEventForwarderStoredConfig,
 } from "shared/types/event-forwarder";
-import type { DataSourceInterface } from "shared/types/datasource";
 import { EventForwarderConfigInterface } from "shared/validators";
 import {
   GenerateEventForwarderExposureQueriesParams,
@@ -16,28 +15,15 @@ import {
   updateDataSource,
 } from "back-end/src/models/DataSourceModel";
 import { decryptEventForwarderConfigModel } from "back-end/src/services/eventForwarderConfig";
+import { getSourceIntegrationObject } from "back-end/src/services/datasource";
 import { logger } from "back-end/src/util/logger";
 import { ReqContext } from "back-end/types/request";
 
-function resolveDatasourceParams(
-  datasourceParams?: BigQueryConnectionParams | SnowflakeConnectionParams,
-  integrationParams?: DataSourceInterface["params"],
-): BigQueryConnectionParams | SnowflakeConnectionParams | undefined {
-  if (datasourceParams) {
-    return datasourceParams;
-  }
-  return integrationParams as
-    | BigQueryConnectionParams
-    | SnowflakeConnectionParams
-    | undefined;
-}
-
 function buildExposureQueryParams(
   eventForwarderConfig: EventForwarderConfigInterface,
-  integrationParams?: DataSourceInterface["params"],
-  datasourceParams?: BigQueryConnectionParams | SnowflakeConnectionParams,
+  connectionParams?: BigQueryConnectionParams | SnowflakeConnectionParams,
 ): GenerateEventForwarderExposureQueriesParams | null {
-  const params = resolveDatasourceParams(datasourceParams, integrationParams);
+  const params = connectionParams;
 
   if (eventForwarderConfig.sinkType === "bigquery") {
     const bigqueryParams = params as BigQueryConnectionParams | undefined;
@@ -111,10 +97,17 @@ export async function ensureEventForwarderExposureQueries(
     eventForwarderConfig.datasourceId,
   );
 
+  const connectionParams =
+    datasourceParams ??
+    (datasource
+      ? (getSourceIntegrationObject(context, datasource).params as
+          | BigQueryConnectionParams
+          | SnowflakeConnectionParams)
+      : undefined);
+
   const sqlParams = buildExposureQueryParams(
     eventForwarderConfig,
-    datasource?.params,
-    datasourceParams,
+    connectionParams,
   );
   if (!sqlParams) {
     logger.warn(

--- a/packages/back-end/src/services/eventForwarderExposureQueries.ts
+++ b/packages/back-end/src/services/eventForwarderExposureQueries.ts
@@ -1,0 +1,155 @@
+import { BigQueryConnectionParams } from "shared/types/integrations/bigquery";
+import { SnowflakeConnectionParams } from "shared/types/integrations/snowflake";
+import {
+  BigQueryEventForwarderStoredConfig,
+  SnowflakeEventForwarderStoredConfig,
+} from "shared/types/event-forwarder";
+import type { DataSourceInterface } from "shared/types/datasource";
+import { EventForwarderConfigInterface } from "shared/validators";
+import {
+  GenerateEventForwarderExposureQueriesParams,
+  mergeEventForwarderExposureQueries,
+} from "shared/util";
+import {
+  getDataSourceById,
+  getRawDataSourceById,
+  updateDataSource,
+} from "back-end/src/models/DataSourceModel";
+import { decryptEventForwarderConfigModel } from "back-end/src/services/eventForwarderConfig";
+import { logger } from "back-end/src/util/logger";
+import { ReqContext } from "back-end/types/request";
+
+function resolveDatasourceParams(
+  datasourceParams?: BigQueryConnectionParams | SnowflakeConnectionParams,
+  integrationParams?: DataSourceInterface["params"],
+): BigQueryConnectionParams | SnowflakeConnectionParams | undefined {
+  if (datasourceParams) {
+    return datasourceParams;
+  }
+  return integrationParams as
+    | BigQueryConnectionParams
+    | SnowflakeConnectionParams
+    | undefined;
+}
+
+function buildExposureQueryParams(
+  eventForwarderConfig: EventForwarderConfigInterface,
+  integrationParams?: DataSourceInterface["params"],
+  datasourceParams?: BigQueryConnectionParams | SnowflakeConnectionParams,
+): GenerateEventForwarderExposureQueriesParams | null {
+  const params = resolveDatasourceParams(datasourceParams, integrationParams);
+
+  if (eventForwarderConfig.sinkType === "bigquery") {
+    const bigqueryParams = params as BigQueryConnectionParams | undefined;
+    const projectId =
+      bigqueryParams?.defaultProject?.trim() ||
+      bigqueryParams?.projectId?.trim() ||
+      "";
+    if (!projectId) {
+      return null;
+    }
+
+    const decrypted =
+      decryptEventForwarderConfigModel<BigQueryEventForwarderStoredConfig>(
+        eventForwarderConfig,
+      );
+
+    return {
+      sinkType: "bigquery",
+      projectId,
+      dataset: decrypted.dataset.trim(),
+    };
+  }
+
+  if (eventForwarderConfig.sinkType === "snowflake") {
+    const decrypted =
+      decryptEventForwarderConfigModel<SnowflakeEventForwarderStoredConfig>(
+        eventForwarderConfig,
+      );
+
+    return {
+      sinkType: "snowflake",
+      database: decrypted.database.trim(),
+      schema: decrypted.schema.trim(),
+    };
+  }
+
+  return null;
+}
+
+export async function ensureEventForwarderExposureQueries(
+  context: ReqContext,
+  eventForwarderConfig: EventForwarderConfigInterface,
+  datasourceParams?: BigQueryConnectionParams | SnowflakeConnectionParams,
+): Promise<void> {
+  if (eventForwarderConfig.sinkType === "databricks") {
+    return;
+  }
+
+  const raw = await getRawDataSourceById(
+    context,
+    eventForwarderConfig.datasourceId,
+  );
+  if (!raw) {
+    return;
+  }
+
+  const userIdTypes = raw.settings?.userIdTypes?.map((u) => u.userIdType) ?? [];
+  if (userIdTypes.length === 0) {
+    logger.warn(
+      {
+        datasourceId: raw.id,
+        organizationId: context.org.id,
+      },
+      "Skipping event forwarder exposure queries: no userIdTypes on datasource",
+    );
+    return;
+  }
+
+  const datasource = await getDataSourceById(
+    context,
+    eventForwarderConfig.datasourceId,
+  );
+
+  const sqlParams = buildExposureQueryParams(
+    eventForwarderConfig,
+    datasource?.params,
+    datasourceParams,
+  );
+  if (!sqlParams) {
+    logger.warn(
+      {
+        datasourceId: raw.id,
+        organizationId: context.org.id,
+        sinkType: eventForwarderConfig.sinkType,
+      },
+      "Skipping event forwarder exposure queries: missing sink connection params",
+    );
+    return;
+  }
+
+  const existing = raw.settings?.queries?.exposure ?? [];
+  const merged = mergeEventForwarderExposureQueries(
+    existing,
+    userIdTypes,
+    sqlParams,
+  );
+
+  if (merged.length === existing.length) {
+    return;
+  }
+
+  if (!datasource) {
+    return;
+  }
+
+  await updateDataSource(context, datasource, {
+    settings: {
+      ...raw.settings,
+      queries: {
+        ...raw.settings?.queries,
+        exposure: merged,
+      },
+    },
+  });
+}

--- a/packages/back-end/src/services/eventForwarderExposureQueries.ts
+++ b/packages/back-end/src/services/eventForwarderExposureQueries.ts
@@ -133,6 +133,14 @@ export async function ensureEventForwarderExposureQueries(
   }
 
   if (!datasource) {
+    logger.warn(
+      {
+        datasourceId: raw.id,
+        organizationId: context.org.id,
+        sinkType: eventForwarderConfig.sinkType,
+      },
+      "Skipping event forwarder exposure queries: datasource unavailable for update",
+    );
     return;
   }
 

--- a/packages/back-end/src/services/eventForwarderProvisioning.ts
+++ b/packages/back-end/src/services/eventForwarderProvisioning.ts
@@ -21,6 +21,7 @@ import { resolveBigQueryEventForwarderTableName } from "back-end/src/services/ev
 import { testEventForwarderWriteAccess } from "back-end/src/services/eventForwarderWriteAccessValidation";
 import { initializeDatasourceUserIdTypesFromOrgAttributeSchema } from "back-end/src/services/eventForwarderUserIdTypes";
 import { ensureEventForwarderEventsFactTable } from "back-end/src/services/eventForwarderFactTable";
+import { ensureEventForwarderExposureQueries } from "back-end/src/services/eventForwarderExposureQueries";
 import { logger } from "back-end/src/util/logger";
 import { ReqContext } from "back-end/types/request";
 
@@ -157,6 +158,7 @@ export async function provisionEventForwarderThroughLicenseServer(
       await initializeDatasourceUserIdTypesFromOrgAttributeSchema(
         context,
         eventForwarderConfig.datasourceId,
+        eventForwarderConfig,
       );
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";
@@ -167,6 +169,24 @@ export async function provisionEventForwarderThroughLicenseServer(
           error: message,
         },
         "Failed to sync userIdTypes after event forwarder provisioning",
+      );
+    }
+
+    try {
+      await ensureEventForwarderExposureQueries(
+        context,
+        eventForwarderConfig,
+        datasourceParams,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      logger.error(
+        {
+          datasourceId: eventForwarderConfig.datasourceId,
+          organizationId: context.org.id,
+          error: message,
+        },
+        "Failed to create exposure queries after event forwarder provisioning",
       );
     }
 

--- a/packages/back-end/src/services/eventForwarderUserIdTypes.ts
+++ b/packages/back-end/src/services/eventForwarderUserIdTypes.ts
@@ -3,17 +3,39 @@ import {
   mergeUserIdTypes,
 } from "shared/util";
 import { SDKAttributeSchema } from "shared/types/organization";
+import { EventForwarderConfigInterface } from "shared/validators";
 import {
   getDataSourceById,
   getRawDataSourceById,
   updateDataSource,
 } from "back-end/src/models/DataSourceModel";
+import { ensureEventForwarderExposureQueries } from "back-end/src/services/eventForwarderExposureQueries";
 import { logger } from "back-end/src/util/logger";
 import { ReqContext } from "back-end/types/request";
+
+async function ensureExposureQueriesAfterUserIdTypesSync(
+  context: ReqContext,
+  eventForwarderConfig: EventForwarderConfigInterface,
+): Promise<void> {
+  try {
+    await ensureEventForwarderExposureQueries(context, eventForwarderConfig);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    logger.error(
+      {
+        datasourceId: eventForwarderConfig.datasourceId,
+        organizationId: context.org.id,
+        error: message,
+      },
+      "Failed to create exposure queries after event forwarder userIdTypes sync",
+    );
+  }
+}
 
 export async function initializeDatasourceUserIdTypesFromOrgAttributeSchema(
   context: ReqContext,
   datasourceId: string,
+  eventForwarderConfig?: EventForwarderConfigInterface,
 ): Promise<void> {
   const raw = await getRawDataSourceById(context, datasourceId);
   if (!raw) {
@@ -43,6 +65,13 @@ export async function initializeDatasourceUserIdTypesFromOrgAttributeSchema(
       userIdTypes: merged,
     },
   });
+
+  if (eventForwarderConfig) {
+    await ensureExposureQueriesAfterUserIdTypesSync(
+      context,
+      eventForwarderConfig,
+    );
+  }
 }
 
 export async function syncAllEventForwarderDatasourceUserIdTypesFromAttributeSchema(
@@ -87,6 +116,8 @@ export async function syncAllEventForwarderDatasourceUserIdTypesFromAttributeSch
             userIdTypes: merged,
           },
         });
+
+        await ensureExposureQueriesAfterUserIdTypesSync(context, config);
       } catch (error) {
         const message =
           error instanceof Error ? error.message : "Unknown error";

--- a/packages/back-end/test/services/eventForwarderExposureQueries.test.ts
+++ b/packages/back-end/test/services/eventForwarderExposureQueries.test.ts
@@ -1,7 +1,9 @@
 import type { DataSourceInterface } from "shared/types/datasource";
+import { BigQueryConnectionParams } from "shared/types/integrations/bigquery";
 import { ensureEventForwarderExposureQueries } from "back-end/src/services/eventForwarderExposureQueries";
 import * as DataSourceModel from "back-end/src/models/DataSourceModel";
 import * as EventForwarderConfig from "back-end/src/services/eventForwarderConfig";
+import { encryptParams } from "back-end/src/services/datasource";
 
 jest.mock("back-end/src/models/DataSourceModel");
 jest.mock("back-end/src/services/eventForwarderConfig");
@@ -64,6 +66,49 @@ function context() {
 describe("ensureEventForwarderExposureQueries", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  it("creates BigQuery exposure queries using decrypted params when datasourceParams is omitted", async () => {
+    const bigqueryParams: BigQueryConnectionParams = {
+      projectId: "my-project",
+      clientEmail: "test@example.com",
+      privateKey: "key",
+    };
+    const raw = ds({
+      userIdTypes: [{ userIdType: "device_id", description: "" }],
+      queries: { exposure: [] },
+    });
+    raw.params = encryptParams(bigqueryParams);
+    mockedGetRaw.mockResolvedValue(raw);
+    mockedGetById.mockResolvedValue(raw);
+    mockedDecrypt.mockReturnValue({
+      dataset: "analytics_123",
+      tableName: "gb_events",
+      serviceAccountKey: "{}",
+    });
+
+    await ensureEventForwarderExposureQueries(
+      context() as never,
+      efConfig("bigquery"),
+    );
+
+    expect(mockedUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      {
+        settings: expect.objectContaining({
+          queries: {
+            exposure: [
+              expect.objectContaining({
+                userIdType: "device_id",
+                id: "device_id",
+                managedBy: "api",
+              }),
+            ],
+          },
+        }),
+      },
+    );
   });
 
   it("creates one exposure query per userIdType for BigQuery", async () => {

--- a/packages/back-end/test/services/eventForwarderExposureQueries.test.ts
+++ b/packages/back-end/test/services/eventForwarderExposureQueries.test.ts
@@ -1,0 +1,252 @@
+import type { DataSourceInterface } from "shared/types/datasource";
+import { ensureEventForwarderExposureQueries } from "back-end/src/services/eventForwarderExposureQueries";
+import * as DataSourceModel from "back-end/src/models/DataSourceModel";
+import * as EventForwarderConfig from "back-end/src/services/eventForwarderConfig";
+
+jest.mock("back-end/src/models/DataSourceModel");
+jest.mock("back-end/src/services/eventForwarderConfig");
+
+const mockedGetRaw =
+  DataSourceModel.getRawDataSourceById as jest.MockedFunction<
+    typeof DataSourceModel.getRawDataSourceById
+  >;
+const mockedGetById = DataSourceModel.getDataSourceById as jest.MockedFunction<
+  typeof DataSourceModel.getDataSourceById
+>;
+const mockedUpdate = DataSourceModel.updateDataSource as jest.MockedFunction<
+  typeof DataSourceModel.updateDataSource
+>;
+const mockedDecrypt =
+  EventForwarderConfig.decryptEventForwarderConfigModel as jest.MockedFunction<
+    typeof EventForwarderConfig.decryptEventForwarderConfigModel
+  >;
+
+function ds(
+  settings: DataSourceInterface["settings"] = {},
+): DataSourceInterface {
+  return {
+    id: "ds_1",
+    organization: "org1",
+    name: "Production Analytics",
+    type: "bigquery",
+    description: "",
+    params: {
+      defaultProject: "my-project",
+      defaultDataset: "analytics_123",
+    } as DataSourceInterface["params"],
+    settings,
+    projects: [],
+    dateCreated: new Date(),
+    dateUpdated: new Date(),
+  };
+}
+
+function efConfig(sinkType: "bigquery" | "snowflake" = "bigquery") {
+  return {
+    id: "efc_1",
+    datasourceId: "ds_1",
+    sinkType,
+    config: "encrypted",
+    status: "pending" as const,
+    organization: "org1",
+    projects: [],
+    topic: "topic",
+  };
+}
+
+function context() {
+  return {
+    org: { id: "org1", settings: { attributeSchema: [] } },
+    userId: "user_1",
+  };
+}
+
+describe("ensureEventForwarderExposureQueries", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates one exposure query per userIdType for BigQuery", async () => {
+    const raw = ds({
+      userIdTypes: [
+        { userIdType: "user_id", description: "" },
+        { userIdType: "device_id", description: "" },
+      ],
+      queries: { exposure: [] },
+    });
+    mockedGetRaw.mockResolvedValue(raw);
+    mockedGetById.mockResolvedValue(raw);
+    mockedDecrypt.mockReturnValue({
+      dataset: "analytics_123",
+      tableName: "gb_events",
+      serviceAccountKey: "{}",
+    });
+
+    await ensureEventForwarderExposureQueries(
+      context() as never,
+      efConfig("bigquery"),
+      { defaultProject: "my-project" } as never,
+    );
+
+    expect(mockedUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      {
+        settings: expect.objectContaining({
+          queries: {
+            exposure: expect.arrayContaining([
+              expect.objectContaining({
+                userIdType: "user_id",
+                id: "user_id",
+                managedBy: "api",
+              }),
+              expect.objectContaining({
+                userIdType: "device_id",
+                id: "device_id",
+              }),
+            ]),
+          },
+        }),
+      },
+    );
+
+    const exposure =
+      mockedUpdate.mock.calls[0][2].settings?.queries?.exposure ?? [];
+    expect(exposure).toHaveLength(2);
+    expect(exposure[0].query).toContain("experiment_viewed");
+    expect(exposure[0].query).toContain("received_at BETWEEN");
+    expect(exposure[0].query).not.toContain("experiment_id LIKE");
+  });
+
+  it("creates Snowflake exposure queries without WHERE clause", async () => {
+    const raw = ds({
+      userIdTypes: [{ userIdType: "user_id", description: "" }],
+      queries: { exposure: [] },
+    });
+    mockedGetRaw.mockResolvedValue(raw);
+    mockedGetById.mockResolvedValue({
+      ...raw,
+      type: "snowflake",
+      params: {} as DataSourceInterface["params"],
+    });
+    mockedDecrypt.mockReturnValue({
+      database: "MY_DB",
+      schema: "PUBLIC",
+      tableName: "gb_events",
+      account: "acct",
+      username: "user",
+      privateKey: "key",
+    });
+
+    await ensureEventForwarderExposureQueries(
+      context() as never,
+      efConfig("snowflake"),
+    );
+
+    const exposure =
+      mockedUpdate.mock.calls[0][2].settings?.queries?.exposure ?? [];
+    expect(exposure).toHaveLength(1);
+    expect(exposure[0].query).toContain("MY_DB.PUBLIC.experiment_viewed");
+    expect(exposure[0].query).not.toContain("WHERE");
+  });
+
+  it("is idempotent when exposure queries already exist", async () => {
+    const raw = ds({
+      userIdTypes: [{ userIdType: "user_id", description: "" }],
+      queries: {
+        exposure: [
+          {
+            id: "user_id",
+            name: "user_id",
+            userIdType: "user_id",
+            dimensions: [],
+            query: "SELECT 1",
+          },
+        ],
+      },
+    });
+    mockedGetRaw.mockResolvedValue(raw);
+    mockedGetById.mockResolvedValue(raw);
+    mockedDecrypt.mockReturnValue({
+      dataset: "analytics_123",
+      tableName: "gb_events",
+      serviceAccountKey: "{}",
+    });
+
+    await ensureEventForwarderExposureQueries(
+      context() as never,
+      efConfig("bigquery"),
+      { defaultProject: "my-project" } as never,
+    );
+
+    expect(mockedUpdate).not.toHaveBeenCalled();
+  });
+
+  it("appends only missing identifier types without overwriting existing", async () => {
+    const raw = ds({
+      userIdTypes: [
+        { userIdType: "user_id", description: "" },
+        { userIdType: "device_id", description: "" },
+      ],
+      queries: {
+        exposure: [
+          {
+            id: "user_id",
+            name: "Custom",
+            userIdType: "user_id",
+            dimensions: [],
+            query: "SELECT custom",
+          },
+        ],
+      },
+    });
+    mockedGetRaw.mockResolvedValue(raw);
+    mockedGetById.mockResolvedValue(raw);
+    mockedDecrypt.mockReturnValue({
+      dataset: "analytics_123",
+      tableName: "gb_events",
+      serviceAccountKey: "{}",
+    });
+
+    await ensureEventForwarderExposureQueries(
+      context() as never,
+      efConfig("bigquery"),
+      { defaultProject: "my-project" } as never,
+    );
+
+    const exposure =
+      mockedUpdate.mock.calls[0][2].settings?.queries?.exposure ?? [];
+    expect(exposure).toHaveLength(2);
+    expect(exposure[0].query).toBe("SELECT custom");
+    expect(exposure[1].userIdType).toBe("device_id");
+  });
+
+  it("skips when no userIdTypes on datasource", async () => {
+    mockedGetRaw.mockResolvedValue(ds({ userIdTypes: [], queries: {} }));
+
+    await ensureEventForwarderExposureQueries(
+      context() as never,
+      efConfig("bigquery"),
+      { defaultProject: "my-project" } as never,
+    );
+
+    expect(mockedUpdate).not.toHaveBeenCalled();
+    expect(mockedGetById).not.toHaveBeenCalled();
+  });
+
+  it("skips databricks sink", async () => {
+    mockedGetRaw.mockResolvedValue(
+      ds({
+        userIdTypes: [{ userIdType: "user_id", description: "" }],
+      }),
+    );
+
+    await ensureEventForwarderExposureQueries(context() as never, {
+      ...efConfig("bigquery"),
+      sinkType: "databricks",
+    });
+
+    expect(mockedUpdate).not.toHaveBeenCalled();
+    expect(mockedGetRaw).not.toHaveBeenCalled();
+  });
+});

--- a/packages/back-end/test/services/eventForwarderUserIdTypes.test.ts
+++ b/packages/back-end/test/services/eventForwarderUserIdTypes.test.ts
@@ -4,8 +4,15 @@ import {
   syncAllEventForwarderDatasourceUserIdTypesFromAttributeSchema,
 } from "back-end/src/services/eventForwarderUserIdTypes";
 import * as DataSourceModel from "back-end/src/models/DataSourceModel";
+import * as EventForwarderExposureQueries from "back-end/src/services/eventForwarderExposureQueries";
 
 jest.mock("back-end/src/models/DataSourceModel");
+jest.mock("back-end/src/services/eventForwarderExposureQueries");
+
+const mockedEnsureExposure =
+  EventForwarderExposureQueries.ensureEventForwarderExposureQueries as jest.MockedFunction<
+    typeof EventForwarderExposureQueries.ensureEventForwarderExposureQueries
+  >;
 
 const mockedGetRaw =
   DataSourceModel.getRawDataSourceById as jest.MockedFunction<
@@ -55,6 +62,7 @@ function contextWithSchema(
 describe("initializeDatasourceUserIdTypesFromOrgAttributeSchema", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockedEnsureExposure.mockResolvedValue(undefined);
   });
 
   it("merges hash attributes without overriding existing names (case insensitive)", async () => {
@@ -119,11 +127,42 @@ describe("initializeDatasourceUserIdTypesFromOrgAttributeSchema", () => {
       },
     );
   });
+
+  it("ensures exposure queries when event forwarder config is provided", async () => {
+    const raw = ds("ds_1", {});
+    mockedGetRaw.mockResolvedValue(raw);
+    mockedGetById.mockResolvedValue(raw);
+
+    const config = {
+      id: "efc_1",
+      datasourceId: "ds_1",
+      sinkType: "bigquery" as const,
+      config: "encrypted",
+      status: "pending" as const,
+      organization: "org1",
+      projects: [],
+      topic: "topic",
+    };
+
+    await initializeDatasourceUserIdTypesFromOrgAttributeSchema(
+      contextWithSchema([
+        { property: "id", datatype: "string", hashAttribute: true },
+      ]) as never,
+      "ds_1",
+      config,
+    );
+
+    expect(mockedEnsureExposure).toHaveBeenCalledWith(
+      expect.anything(),
+      config,
+    );
+  });
 });
 
 describe("syncAllEventForwarderDatasourceUserIdTypesFromAttributeSchema", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockedEnsureExposure.mockResolvedValue(undefined);
   });
 
   it("merges new hash attributes into all event forwarder datasources", async () => {
@@ -163,6 +202,7 @@ describe("syncAllEventForwarderDatasourceUserIdTypesFromAttributeSchema", () => 
     );
 
     expect(mockedUpdate).toHaveBeenCalledTimes(2);
+    expect(mockedEnsureExposure).toHaveBeenCalledTimes(2);
     expect(mockedUpdate).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ id: "ds_a" }),

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
@@ -8,6 +8,7 @@ import { useForm } from "react-hook-form";
 import cloneDeep from "lodash/cloneDeep";
 import uniqId from "uniqid";
 import { FaExclamationTriangle, FaExternalLinkAlt } from "react-icons/fa";
+import { isEventForwarderManagedExposureQuery } from "shared/util";
 import { TestQueryRow } from "shared/types/integrations";
 import Code from "@/components/SyntaxHighlighting/Code";
 import StringArrayField from "@/components/Forms/StringArrayField";
@@ -36,6 +37,11 @@ export const AddEditExperimentAssignmentQueryModal: FC<
       : `Edit ${
           exposureQuery ? exposureQuery.name : "Experiment Assignment"
         } query`;
+
+  const isManaged =
+    mode === "edit" &&
+    !!exposureQuery &&
+    isEventForwarderManagedExposureQuery(exposureQuery);
 
   const userIdTypeOptions = dataSource?.settings?.userIdTypes?.map(
     ({ userIdType }) => ({
@@ -70,6 +76,10 @@ export const AddEditExperimentAssignmentQueryModal: FC<
   const userEnteredHasNameCol = form.watch("hasNameCol");
 
   const handleSubmit = form.handleSubmit(async (value) => {
+    if (isManaged && exposureQuery) {
+      value.userIdType = exposureQuery.userIdType;
+      value.managedBy = exposureQuery.managedBy;
+    }
     await onSave(value);
 
     form.reset({
@@ -251,9 +261,22 @@ export const AddEditExperimentAssignmentQueryModal: FC<
                 {...form.register("description")}
               />
               <Field
-                label="Identifier Type"
+                label={
+                  <>
+                    Identifier Type
+                    {isManaged ? (
+                      <Tooltip body="Identifier type is fixed for queries created by Event Forwarder and cannot be changed." />
+                    ) : null}
+                  </>
+                }
                 options={identityTypes.map((i) => i.userIdType)}
                 required
+                disabled={isManaged}
+                helpText={
+                  isManaged
+                    ? "Managed by Event Forwarder for this identifier."
+                    : undefined
+                }
                 {...form.register("userIdType")}
               />
               <div className="form-group">

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
@@ -5,6 +5,7 @@ import {
 } from "shared/types/datasource";
 import cloneDeep from "lodash/cloneDeep";
 import { FaChevronRight, FaPlus } from "react-icons/fa";
+import { isEventForwarderManagedExposureQuery } from "shared/util";
 import { Box, Card, Flex, Heading } from "@radix-ui/themes";
 import { DimensionSlicesInterface } from "shared/types/dimension";
 import { DataSourceQueryEditingModalBaseProps } from "@/components/Settings/EditDataSource/types";
@@ -17,6 +18,7 @@ import { UpdateDimensionMetadataModal } from "@/components/Settings/EditDataSour
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import Badge from "@/ui/Badge";
 import Callout from "@/ui/Callout";
+import Tooltip from "@/components/Tooltip/Tooltip";
 import { CustomDimensionMetadata } from "@/components/Settings/EditDataSource/DimensionMetadata/DimensionSlicesRunner";
 
 type ExperimentAssignmentQueriesProps = DataSourceQueryEditingModalBaseProps;
@@ -73,6 +75,11 @@ export const ExperimentAssignmentQueries: FC<
 
   const handleActionDeleteClicked = useCallback(
     (idx: number) => async () => {
+      const query = dataSource.settings?.queries?.exposure?.[idx];
+      if (query && isEventForwarderManagedExposureQuery(query)) {
+        return;
+      }
+
       const copy = cloneDeep<DataSourceInterfaceWithParams>(dataSource);
 
       // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
@@ -152,20 +159,34 @@ export const ExperimentAssignmentQueries: FC<
 
       {experimentExposureQueries.map((query, idx) => {
         const isOpen = openIndexes[idx] || false;
+        const isManaged = isEventForwarderManagedExposureQuery(query);
+        const deleteButton = (
+          <DeleteButton
+            onClick={handleActionDeleteClicked(idx)}
+            className="dropdown-item text-danger py-2"
+            iconClassName="mr-2"
+            style={{ borderRadius: 0 }}
+            useIcon={false}
+            displayName={query.name}
+            deleteMessage={`Are you sure you want to delete experiment assignment query ${query.name}?`}
+            title="Delete"
+            text="Delete"
+            outline={false}
+            disabled={isManaged}
+          />
+        );
 
         return (
           <Card mt="3" key={query.id}>
             <Flex align="start" justify="between" py="2" px="3" gap="3">
               {/* region Title Bar */}
               <Box width="100%">
-                <Flex>
-                  <Heading as="h4" size="3" mb="1">
-                    {query.name}
-                  </Heading>
-                  {query.description && (
-                    <p className="ml-3 text-muted">{query.description}</p>
-                  )}
-                </Flex>
+                <Heading as="h4" size="3" mb="0">
+                  {query.name}
+                </Heading>
+                {query.description && (
+                  <p className="text-muted mb-0 mt-1">{query.description}</p>
+                )}
 
                 <Flex gap="4">
                   <Box>
@@ -238,20 +259,17 @@ export const ExperimentAssignmentQueries: FC<
                         Edit Dimensions
                       </button>
                     ) : null}
-
                     <hr className="dropdown-divider" />
-                    <DeleteButton
-                      onClick={handleActionDeleteClicked(idx)}
-                      className="dropdown-item text-danger py-2"
-                      iconClassName="mr-2"
-                      style={{ borderRadius: 0 }}
-                      useIcon={false}
-                      displayName={query.name}
-                      deleteMessage={`Are you sure you want to delete experiment assignment query ${query.name}?`}
-                      title="Delete"
-                      text="Delete"
-                      outline={false}
-                    />
+                    {isManaged ? (
+                      <Tooltip
+                        body="This query was created automatically when Event Forwarder was connected. It cannot be deleted; it is removed when the linked identifier type is no longer used."
+                        usePortal
+                      >
+                        <span className="d-block">{deleteButton}</span>
+                      </Tooltip>
+                    ) : (
+                      deleteButton
+                    )}
                   </MoreMenu>
                 )}
 

--- a/packages/shared/src/util/event-forwarder-exposure-queries.ts
+++ b/packages/shared/src/util/event-forwarder-exposure-queries.ts
@@ -40,12 +40,14 @@ export function buildEventForwarderExperimentViewedTableReference(
 export function buildEventForwarderExposureQuerySql({
   sinkType,
   tableRef,
+  userIdType,
 }: {
   sinkType: "bigquery" | "snowflake";
   tableRef: string;
+  userIdType: string;
 }): string {
   const select = `SELECT
-  event_uuid AS id,
+  event_uuid AS ${userIdType},
   timestamp AS timestamp,
   experiment_id AS experiment_id,
   variation_id AS variation_id
@@ -78,6 +80,7 @@ export function generateEventForwarderExposureQueries(
     query: buildEventForwarderExposureQuerySql({
       sinkType: params.sinkType,
       tableRef,
+      userIdType,
     }),
   }));
 }

--- a/packages/shared/src/util/event-forwarder-exposure-queries.ts
+++ b/packages/shared/src/util/event-forwarder-exposure-queries.ts
@@ -1,0 +1,116 @@
+import type { ExposureQuery } from "shared/types/datasource";
+import { EVENT_FORWARDER_AVRO_PARTITION_FIELD } from "../event-forwarder-avro";
+import {
+  buildBigQueryEventForwarderTableReference,
+  buildSnowflakeEventForwarderTableReference,
+} from "./event-forwarder-fact-table";
+
+export const EVENT_FORWARDER_EXPERIMENT_VIEWED_TABLE = "experiment_viewed";
+
+export type BuildEventForwarderExperimentViewedTableRefParams =
+  | {
+      sinkType: "bigquery";
+      projectId: string;
+      dataset: string;
+    }
+  | {
+      sinkType: "snowflake";
+      database: string;
+      schema: string;
+    };
+
+export function buildEventForwarderExperimentViewedTableReference(
+  params: BuildEventForwarderExperimentViewedTableRefParams,
+): string {
+  if (params.sinkType === "bigquery") {
+    return buildBigQueryEventForwarderTableReference(
+      params.projectId,
+      params.dataset,
+      EVENT_FORWARDER_EXPERIMENT_VIEWED_TABLE,
+    );
+  }
+
+  return buildSnowflakeEventForwarderTableReference(
+    params.database,
+    params.schema,
+    EVENT_FORWARDER_EXPERIMENT_VIEWED_TABLE,
+  );
+}
+
+export function buildEventForwarderExposureQuerySql({
+  sinkType,
+  tableRef,
+}: {
+  sinkType: "bigquery" | "snowflake";
+  tableRef: string;
+}): string {
+  const select = `SELECT
+  event_uuid AS id,
+  timestamp AS timestamp,
+  experiment_id AS experiment_id,
+  variation_id AS variation_id
+FROM ${tableRef}`;
+
+  if (sinkType === "bigquery") {
+    return `${select}
+WHERE ${EVENT_FORWARDER_AVRO_PARTITION_FIELD} BETWEEN '{{startDate}}' AND '{{endDate}}'`;
+  }
+
+  return select;
+}
+
+export type GenerateEventForwarderExposureQueriesParams =
+  BuildEventForwarderExperimentViewedTableRefParams;
+
+export function generateEventForwarderExposureQueries(
+  userIdTypes: string[],
+  params: GenerateEventForwarderExposureQueriesParams,
+): ExposureQuery[] {
+  const tableRef = buildEventForwarderExperimentViewedTableReference(params);
+
+  return userIdTypes.map((userIdType) => ({
+    id: userIdType,
+    userIdType,
+    name: userIdType,
+    description: "",
+    dimensions: [],
+    managedBy: "api" as const,
+    query: buildEventForwarderExposureQuerySql({
+      sinkType: params.sinkType,
+      tableRef,
+    }),
+  }));
+}
+
+export function isEventForwarderManagedExposureQuery(
+  query: ExposureQuery,
+): boolean {
+  return query.managedBy === "api";
+}
+
+export function exposureQueryExistsForUserIdType(
+  exposureQueries: ExposureQuery[],
+  userIdType: string,
+): boolean {
+  const normalized = userIdType.toLowerCase();
+  return exposureQueries.some((q) => q.userIdType.toLowerCase() === normalized);
+}
+
+export function mergeEventForwarderExposureQueries(
+  existing: ExposureQuery[],
+  userIdTypes: string[],
+  params: GenerateEventForwarderExposureQueriesParams,
+): ExposureQuery[] {
+  const missing = userIdTypes.filter(
+    (userIdType) => !exposureQueryExistsForUserIdType(existing, userIdType),
+  );
+
+  if (missing.length === 0) {
+    return existing;
+  }
+
+  return [
+    ...existing,
+    ...generateEventForwarderExposureQueries(missing, params),
+  ];
+}

--- a/packages/shared/src/util/index.ts
+++ b/packages/shared/src/util/index.ts
@@ -43,6 +43,7 @@ export * from "./namespaces";
 export * from "./custom-fields";
 export * from "./datasource";
 export * from "./event-forwarder-fact-table";
+export * from "./event-forwarder-exposure-queries";
 
 export const DEFAULT_ENVIRONMENT_IDS = ["production", "dev", "staging", "test"];
 

--- a/packages/shared/test/util/event-forwarder-exposure-queries.test.ts
+++ b/packages/shared/test/util/event-forwarder-exposure-queries.test.ts
@@ -1,0 +1,130 @@
+import {
+  buildEventForwarderExperimentViewedTableReference,
+  buildEventForwarderExposureQuerySql,
+  EVENT_FORWARDER_EXPERIMENT_VIEWED_TABLE,
+  exposureQueryExistsForUserIdType,
+  generateEventForwarderExposureQueries,
+  isEventForwarderManagedExposureQuery,
+  mergeEventForwarderExposureQueries,
+} from "../../src/util/event-forwarder-exposure-queries";
+import { EVENT_FORWARDER_AVRO_PARTITION_FIELD } from "../../src/event-forwarder-avro";
+
+describe("event-forwarder-exposure-queries table reference", () => {
+  it("builds BigQuery experiment_viewed table reference", () => {
+    expect(
+      buildEventForwarderExperimentViewedTableReference({
+        sinkType: "bigquery",
+        projectId: "my-project",
+        dataset: "analytics_123",
+      }),
+    ).toBe(
+      `\`my-project\`.\`analytics_123\`.\`${EVENT_FORWARDER_EXPERIMENT_VIEWED_TABLE}\``,
+    );
+  });
+
+  it("builds Snowflake experiment_viewed table reference", () => {
+    expect(
+      buildEventForwarderExperimentViewedTableReference({
+        sinkType: "snowflake",
+        database: "MY_DB",
+        schema: "PUBLIC",
+      }),
+    ).toBe(`MY_DB.PUBLIC.${EVENT_FORWARDER_EXPERIMENT_VIEWED_TABLE}`);
+  });
+});
+
+describe("buildEventForwarderExposureQuerySql", () => {
+  const tableRef = "`proj`.`ds`.`experiment_viewed`";
+
+  it("includes received_at partition filter for BigQuery only", () => {
+    const sql = buildEventForwarderExposureQuerySql({
+      sinkType: "bigquery",
+      tableRef,
+      userIdType: "user_id",
+    });
+
+    expect(sql).toContain("user_id AS user_id");
+    expect(sql).toContain("experiment_id AS experiment_id");
+    expect(sql).toContain(`FROM ${tableRef}`);
+    expect(sql).toContain(
+      `WHERE ${EVENT_FORWARDER_AVRO_PARTITION_FIELD} BETWEEN '{{startDate}}' AND '{{endDate}}'`,
+    );
+    expect(sql).not.toContain("experiment_id LIKE");
+    expect(sql).not.toContain("timestamp BETWEEN");
+  });
+
+  it("has no WHERE clause for Snowflake", () => {
+    const sql = buildEventForwarderExposureQuerySql({
+      sinkType: "snowflake",
+      tableRef: "MY_DB.PUBLIC.experiment_viewed",
+      userIdType: "device_id",
+    });
+
+    expect(sql).toContain("device_id AS device_id");
+    expect(sql).toContain("FROM MY_DB.PUBLIC.experiment_viewed");
+    expect(sql).not.toContain("WHERE");
+  });
+});
+
+describe("generateEventForwarderExposureQueries", () => {
+  it("creates one exposure query per identifier type", () => {
+    const queries = generateEventForwarderExposureQueries(
+      ["user_id", "anonymous_id"],
+      {
+        sinkType: "bigquery",
+        projectId: "proj",
+        dataset: "ds",
+      },
+    );
+
+    expect(queries).toHaveLength(2);
+    expect(queries[0].id).toBe("user_id");
+    expect(queries[0].userIdType).toBe("user_id");
+    expect(queries[1].userIdType).toBe("anonymous_id");
+    expect(queries[0].dimensions).toEqual([]);
+    expect(queries[0].managedBy).toBe("api");
+    expect(isEventForwarderManagedExposureQuery(queries[0])).toBe(true);
+  });
+});
+
+describe("mergeEventForwarderExposureQueries", () => {
+  it("appends only missing identifier types", () => {
+    const existing = generateEventForwarderExposureQueries(["user_id"], {
+      sinkType: "snowflake",
+      database: "DB",
+      schema: "PUBLIC",
+    });
+
+    const merged = mergeEventForwarderExposureQueries(
+      existing,
+      ["user_id", "device_id"],
+      {
+        sinkType: "snowflake",
+        database: "DB",
+        schema: "PUBLIC",
+      },
+    );
+
+    expect(merged).toHaveLength(2);
+    expect(merged[0].userIdType).toBe("user_id");
+    expect(merged[1].userIdType).toBe("device_id");
+  });
+
+  it("is case-insensitive when checking existing queries", () => {
+    const existing = generateEventForwarderExposureQueries(["USER_ID"], {
+      sinkType: "snowflake",
+      database: "DB",
+      schema: "PUBLIC",
+    });
+
+    expect(exposureQueryExistsForUserIdType(existing, "user_id")).toBe(true);
+
+    const merged = mergeEventForwarderExposureQueries(existing, ["user_id"], {
+      sinkType: "snowflake",
+      database: "DB",
+      schema: "PUBLIC",
+    });
+
+    expect(merged).toHaveLength(1);
+  });
+});

--- a/packages/shared/test/util/event-forwarder-exposure-queries.test.ts
+++ b/packages/shared/test/util/event-forwarder-exposure-queries.test.ts
@@ -43,7 +43,7 @@ describe("buildEventForwarderExposureQuerySql", () => {
       userIdType: "user_id",
     });
 
-    expect(sql).toContain("user_id AS user_id");
+    expect(sql).toContain("event_uuid AS user_id");
     expect(sql).toContain("experiment_id AS experiment_id");
     expect(sql).toContain(`FROM ${tableRef}`);
     expect(sql).toContain(
@@ -60,7 +60,7 @@ describe("buildEventForwarderExposureQuerySql", () => {
       userIdType: "device_id",
     });
 
-    expect(sql).toContain("device_id AS device_id");
+    expect(sql).toContain("event_uuid AS device_id");
     expect(sql).toContain("FROM MY_DB.PUBLIC.experiment_viewed");
     expect(sql).not.toContain("WHERE");
   });

--- a/packages/shared/types/datasource.d.ts
+++ b/packages/shared/types/datasource.d.ts
@@ -179,6 +179,8 @@ export interface ExposureQuery {
   dimensionSlicesId?: string;
   dimensionMetadata?: ExperimentDimensionMetadata[];
   error?: string;
+  /** Set to "api" for queries auto-created by Event Forwarder (not deletable in UI). */
+  managedBy?: "" | "api";
 }
 
 export interface FeatureUsageQuery {


### PR DESCRIPTION
### Features and Changes
- Add Experiment Assignment Query for each new identifier type
- Readonly, they can't edit the type nor delete them
- When a new HashAttribute is created, they will be migrated over WITH a new EAQ
- Closes **[Add new EAQ](https://www.notion.so/growthbook/Event-Forwarder-345a857e74a080a888c8de6d150a518d?source=copy_link#359a857e74a08056946efa7519953207)**


### Screenshots
<img width="1667" height="1514" alt="Screenshot 2026-05-21 at 23 43 16" src="https://github.com/user-attachments/assets/6f2a1427-1fd8-4468-bfc8-e7bfa84fb93f" />
<img width="751" height="387" alt="Screenshot 2026-05-21 at 23 43 20" src="https://github.com/user-attachments/assets/46edb406-8348-4ea2-80e4-425c7a89b00d" />

