### PR TITLE
Features: clean up UI issues with user/API attribution, and DX issues with some REST feature/revision endpoints

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -262,7 +262,7 @@ tags:
     x-displayName: Ramp Schedule Templates
     description: Reusable step configurations for ramp schedules.
   - name: AnalyticsExploration_model
-    x-displayName: AnalyticsExploration
+    x-displayName: Analytics Exploration
     description: <SchemaDefinition schemaRef="#/components/schemas/AnalyticsExploration" />
   - name: Archetype_model
     x-displayName: Archetype
@@ -271,16 +271,16 @@ tags:
     x-displayName: Attribute
     description: <SchemaDefinition schemaRef="#/components/schemas/Attribute" />
   - name: CodeRef_model
-    x-displayName: CodeRef
+    x-displayName: Code Ref
     description: <SchemaDefinition schemaRef="#/components/schemas/CodeRef" />
   - name: CustomField_model
-    x-displayName: CustomField
+    x-displayName: Custom Field
     description: <SchemaDefinition schemaRef="#/components/schemas/CustomField" />
   - name: Dashboard_model
     x-displayName: Dashboard
     description: <SchemaDefinition schemaRef="#/components/schemas/Dashboard" />
   - name: DataSource_model
-    x-displayName: DataSource
+    x-displayName: Data Source
     description: <SchemaDefinition schemaRef="#/components/schemas/DataSource" />
   - name: Dimension_model
     x-displayName: Dimension
@@ -291,119 +291,122 @@ tags:
   - name: Experiment_model
     x-displayName: Experiment
     description: <SchemaDefinition schemaRef="#/components/schemas/Experiment" />
+  - name: Experiment Rule_model
+    x-displayName: Experiment Rule
+    description: <SchemaDefinition schemaRef="#/components/schemas/Experiment Rule" />
   - name: ExperimentAnalysisSettings_model
-    x-displayName: ExperimentAnalysisSettings
+    x-displayName: Experiment Analysis Settings
     description: >-
       <SchemaDefinition
       schemaRef="#/components/schemas/ExperimentAnalysisSettings" />
   - name: ExperimentDecisionFrameworkSettings_model
-    x-displayName: ExperimentDecisionFrameworkSettings
+    x-displayName: Experiment Decision Framework Settings
     description: >-
       <SchemaDefinition
       schemaRef="#/components/schemas/ExperimentDecisionFrameworkSettings" />
   - name: ExperimentMetric_model
-    x-displayName: ExperimentMetric
+    x-displayName: Experiment Metric
     description: <SchemaDefinition schemaRef="#/components/schemas/ExperimentMetric" />
   - name: ExperimentMetricOverrideEntry_model
-    x-displayName: ExperimentMetricOverrideEntry
+    x-displayName: Experiment Metric Override Entry
     description: >-
       <SchemaDefinition
       schemaRef="#/components/schemas/ExperimentMetricOverrideEntry" />
   - name: ExperimentResults_model
-    x-displayName: ExperimentResults
+    x-displayName: Experiment Results
     description: <SchemaDefinition schemaRef="#/components/schemas/ExperimentResults" />
   - name: ExperimentSnapshot_model
-    x-displayName: ExperimentSnapshot
+    x-displayName: Experiment Snapshot
     description: <SchemaDefinition schemaRef="#/components/schemas/ExperimentSnapshot" />
   - name: ExperimentTemplate_model
-    x-displayName: ExperimentTemplate
+    x-displayName: Experiment Template
     description: <SchemaDefinition schemaRef="#/components/schemas/ExperimentTemplate" />
   - name: ExperimentWithEnhancedStatus_model
-    x-displayName: ExperimentWithEnhancedStatus
+    x-displayName: Experiment With Enhanced Status
     description: >-
       <SchemaDefinition
       schemaRef="#/components/schemas/ExperimentWithEnhancedStatus" />
   - name: FactMetric_model
-    x-displayName: FactMetric
+    x-displayName: Fact Metric
     description: <SchemaDefinition schemaRef="#/components/schemas/FactMetric" />
   - name: FactTable_model
-    x-displayName: FactTable
+    x-displayName: Fact Table
     description: <SchemaDefinition schemaRef="#/components/schemas/FactTable" />
   - name: FactTableColumn_model
-    x-displayName: FactTableColumn
+    x-displayName: Fact Table Column
     description: <SchemaDefinition schemaRef="#/components/schemas/FactTableColumn" />
   - name: FactTableFilter_model
-    x-displayName: FactTableFilter
+    x-displayName: Fact Table Filter
     description: <SchemaDefinition schemaRef="#/components/schemas/FactTableFilter" />
   - name: Feature_model
     x-displayName: Feature
     description: <SchemaDefinition schemaRef="#/components/schemas/Feature" />
   - name: FeatureBaseRule_model
-    x-displayName: FeatureBaseRule
+    x-displayName: Feature Base Rule
     description: <SchemaDefinition schemaRef="#/components/schemas/FeatureBaseRule" />
   - name: FeatureDefinition_model
-    x-displayName: FeatureDefinition
+    x-displayName: Feature Definition
     description: <SchemaDefinition schemaRef="#/components/schemas/FeatureDefinition" />
   - name: FeatureEnvironment_model
-    x-displayName: FeatureEnvironment
+    x-displayName: Feature Environment
     description: <SchemaDefinition schemaRef="#/components/schemas/FeatureEnvironment" />
   - name: FeatureEnvironmentV2_model
-    x-displayName: FeatureEnvironmentV2
+    x-displayName: Feature Environment V2
     description: <SchemaDefinition schemaRef="#/components/schemas/FeatureEnvironmentV2" />
   - name: FeatureExperimentRefRule_model
-    x-displayName: FeatureExperimentRefRule
+    x-displayName: Feature Experiment Ref Rule
     description: >-
       <SchemaDefinition
       schemaRef="#/components/schemas/FeatureExperimentRefRule" />
   - name: FeatureExperimentRule_model
-    x-displayName: FeatureExperimentRule
+    x-displayName: Feature Experiment Rule
     description: >-
       <SchemaDefinition schemaRef="#/components/schemas/FeatureExperimentRule"
       />
   - name: FeatureForceRule_model
-    x-displayName: FeatureForceRule
+    x-displayName: Feature Force Rule
     description: <SchemaDefinition schemaRef="#/components/schemas/FeatureForceRule" />
   - name: FeatureRevision_model
-    x-displayName: FeatureRevision
+    x-displayName: Feature Revision
     description: <SchemaDefinition schemaRef="#/components/schemas/FeatureRevision" />
   - name: FeatureRevisionV2_model
-    x-displayName: FeatureRevisionV2
+    x-displayName: Feature Revision V2
     description: <SchemaDefinition schemaRef="#/components/schemas/FeatureRevisionV2" />
   - name: FeatureRolloutRule_model
-    x-displayName: FeatureRolloutRule
+    x-displayName: Feature Rollout Rule
     description: <SchemaDefinition schemaRef="#/components/schemas/FeatureRolloutRule" />
   - name: FeatureRule_model
-    x-displayName: FeatureRule
+    x-displayName: Feature Rule
     description: <SchemaDefinition schemaRef="#/components/schemas/FeatureRule" />
   - name: FeatureRuleV2_model
-    x-displayName: FeatureRuleV2
+    x-displayName: Feature Rule V2
     description: <SchemaDefinition schemaRef="#/components/schemas/FeatureRuleV2" />
   - name: FeatureSafeRolloutRule_model
-    x-displayName: FeatureSafeRolloutRule
+    x-displayName: Feature Safe Rollout Rule
     description: >-
       <SchemaDefinition schemaRef="#/components/schemas/FeatureSafeRolloutRule"
       />
   - name: FeatureV2_model
-    x-displayName: FeatureV2
+    x-displayName: Feature V2
     description: <SchemaDefinition schemaRef="#/components/schemas/FeatureV2" />
   - name: FeatureWithRevisions_model
-    x-displayName: FeatureWithRevisions
+    x-displayName: Feature With Revisions
     description: <SchemaDefinition schemaRef="#/components/schemas/FeatureWithRevisions" />
   - name: FeatureWithRevisionsV2_model
-    x-displayName: FeatureWithRevisionsV2
+    x-displayName: Feature With Revisions V2
     description: >-
       <SchemaDefinition schemaRef="#/components/schemas/FeatureWithRevisionsV2"
       />
   - name: InformationSchema_model
-    x-displayName: InformationSchema
+    x-displayName: Information Schema
     description: <SchemaDefinition schemaRef="#/components/schemas/InformationSchema" />
   - name: InformationSchemaTable_model
-    x-displayName: InformationSchemaTable
+    x-displayName: Information Schema Table
     description: >-
       <SchemaDefinition schemaRef="#/components/schemas/InformationSchemaTable"
       />
   - name: LookbackOverride_model
-    x-displayName: LookbackOverride
+    x-displayName: Lookback Override
     description: <SchemaDefinition schemaRef="#/components/schemas/LookbackOverride" />
   - name: Member_model
     x-displayName: Member
@@ -412,19 +415,19 @@ tags:
     x-displayName: Metric
     description: <SchemaDefinition schemaRef="#/components/schemas/Metric" />
   - name: MetricAnalysis_model
-    x-displayName: MetricAnalysis
+    x-displayName: Metric Analysis
     description: <SchemaDefinition schemaRef="#/components/schemas/MetricAnalysis" />
   - name: MetricGroup_model
-    x-displayName: MetricGroup
+    x-displayName: Metric Group
     description: <SchemaDefinition schemaRef="#/components/schemas/MetricGroup" />
   - name: MetricUsage_model
-    x-displayName: MetricUsage
+    x-displayName: Metric Usage
     description: <SchemaDefinition schemaRef="#/components/schemas/MetricUsage" />
   - name: Namespace_model
     x-displayName: Namespace
     description: <SchemaDefinition schemaRef="#/components/schemas/Namespace" />
   - name: NamespaceExperimentMember_model
-    x-displayName: NamespaceExperimentMember
+    x-displayName: Namespace Experiment Member
     description: >-
       <SchemaDefinition
       schemaRef="#/components/schemas/NamespaceExperimentMember" />
@@ -432,7 +435,7 @@ tags:
     x-displayName: Organization
     description: <SchemaDefinition schemaRef="#/components/schemas/Organization" />
   - name: PaginationFields_model
-    x-displayName: PaginationFields
+    x-displayName: Pagination Fields
     description: <SchemaDefinition schemaRef="#/components/schemas/PaginationFields" />
   - name: Project_model
     x-displayName: Project
@@ -441,22 +444,25 @@ tags:
     x-displayName: Query
     description: <SchemaDefinition schemaRef="#/components/schemas/Query" />
   - name: RampSchedule_model
-    x-displayName: RampSchedule
+    x-displayName: Ramp Schedule
     description: <SchemaDefinition schemaRef="#/components/schemas/RampSchedule" />
   - name: RampScheduleTemplate_model
-    x-displayName: RampScheduleTemplate
+    x-displayName: Ramp Schedule Template
     description: <SchemaDefinition schemaRef="#/components/schemas/RampScheduleTemplate" />
   - name: Report_model
     x-displayName: Report
     description: <SchemaDefinition schemaRef="#/components/schemas/Report" />
+  - name: Safe Rollout Rule_model
+    x-displayName: Safe Rollout Rule
+    description: <SchemaDefinition schemaRef="#/components/schemas/Safe Rollout Rule" />
   - name: SavedGroup_model
-    x-displayName: SavedGroup
+    x-displayName: Saved Group
     description: <SchemaDefinition schemaRef="#/components/schemas/SavedGroup" />
   - name: ScheduleRule_model
-    x-displayName: ScheduleRule
+    x-displayName: Schedule Rule
     description: <SchemaDefinition schemaRef="#/components/schemas/ScheduleRule" />
   - name: SdkConnection_model
-    x-displayName: SdkConnection
+    x-displayName: Sdk Connection
     description: <SchemaDefinition schemaRef="#/components/schemas/SdkConnection" />
   - name: Segment_model
     x-displayName: Segment
@@ -464,14 +470,17 @@ tags:
   - name: Settings_model
     x-displayName: Settings
     description: <SchemaDefinition schemaRef="#/components/schemas/Settings" />
+  - name: Targeting Rule_model
+    x-displayName: Targeting Rule
+    description: <SchemaDefinition schemaRef="#/components/schemas/Targeting Rule" />
   - name: Team_model
     x-displayName: Team
     description: <SchemaDefinition schemaRef="#/components/schemas/Team" />
   - name: VisualChange_model
-    x-displayName: VisualChange
+    x-displayName: Visual Change
     description: <SchemaDefinition schemaRef="#/components/schemas/VisualChange" />
   - name: VisualChangeset_model
-    x-displayName: VisualChangeset
+    x-displayName: Visual Changeset
     description: <SchemaDefinition schemaRef="#/components/schemas/VisualChangeset" />
 security:
   - bearerAuth: []
@@ -3430,19 +3439,22 @@ paths:
                         properties:
                           trigger:
                             anyOf:
-                              - type: object
+                              - description: Fires automatically after a fixed delay.
+                                type: object
                                 properties:
                                   type:
                                     type: string
                                     const: interval
                                   seconds:
+                                    description: Seconds to wait before this step fires.
                                     type: number
                                     exclusiveMinimum: 0
                                 required:
                                   - type
                                   - seconds
                                 additionalProperties: false
-                              - type: object
+                              - description: Pauses the ramp until manually approved.
+                                type: object
                                 properties:
                                   type:
                                     type: string
@@ -3450,12 +3462,18 @@ paths:
                                 required:
                                   - type
                                 additionalProperties: false
-                              - type: object
+                              - description: Fires at a specific date and time.
+                                type: object
                                 properties:
                                   type:
                                     type: string
                                     const: scheduled
-                                  at: {}
+                                  at:
+                                    description: >-
+                                      ISO 8601 date-time, e.g.
+                                      "2025-06-01T00:00:00Z".
+                                    type: string
+                                    format: date-time
                                 required:
                                   - type
                                   - at
@@ -3610,20 +3628,30 @@ paths:
                           - patch
                         additionalProperties: false
                     startDate:
+                      description: >-
+                        ISO 8601 date-time, e.g. "2025-06-01T00:00:00Z". Absent
+                        or null means start immediately on publish.
                       anyOf:
                         - type: string
+                          format: date-time
                         - type: 'null'
                     endCondition:
                       type: object
                       properties:
                         trigger:
                           anyOf:
-                            - type: object
+                            - description: End the ramp at a specific date and time.
+                              type: object
                               properties:
                                 type:
                                   type: string
                                   const: scheduled
-                                at: {}
+                                at:
+                                  description: >-
+                                    ISO 8601 date-time, e.g.
+                                    "2025-07-01T00:00:00Z".
+                                  type: string
+                                  format: date-time
                               required:
                                 - type
                                 - at
@@ -3829,19 +3857,22 @@ paths:
                         properties:
                           trigger:
                             anyOf:
-                              - type: object
+                              - description: Fires automatically after a fixed delay.
+                                type: object
                                 properties:
                                   type:
                                     type: string
                                     const: interval
                                   seconds:
+                                    description: Seconds to wait before this step fires.
                                     type: number
                                     exclusiveMinimum: 0
                                 required:
                                   - type
                                   - seconds
                                 additionalProperties: false
-                              - type: object
+                              - description: Pauses the ramp until manually approved.
+                                type: object
                                 properties:
                                   type:
                                     type: string
@@ -3849,12 +3880,18 @@ paths:
                                 required:
                                   - type
                                 additionalProperties: false
-                              - type: object
+                              - description: Fires at a specific date and time.
+                                type: object
                                 properties:
                                   type:
                                     type: string
                                     const: scheduled
-                                  at: {}
+                                  at:
+                                    description: >-
+                                      ISO 8601 date-time, e.g.
+                                      "2025-06-01T00:00:00Z".
+                                    type: string
+                                    format: date-time
                                 required:
                                   - type
                                   - at
@@ -4009,20 +4046,30 @@ paths:
                           - patch
                         additionalProperties: false
                     startDate:
+                      description: >-
+                        ISO 8601 date-time, e.g. "2025-06-01T00:00:00Z". Absent
+                        or null means start immediately on publish.
                       anyOf:
                         - type: string
+                          format: date-time
                         - type: 'null'
                     endCondition:
                       type: object
                       properties:
                         trigger:
                           anyOf:
-                            - type: object
+                            - description: End the ramp at a specific date and time.
+                              type: object
                               properties:
                                 type:
                                   type: string
                                   const: scheduled
-                                at: {}
+                                at:
+                                  description: >-
+                                    ISO 8601 date-time, e.g.
+                                    "2025-07-01T00:00:00Z".
+                                  type: string
+                                  format: date-time
                               required:
                                 - type
                                 - at
@@ -4259,19 +4306,22 @@ paths:
                     properties:
                       trigger:
                         anyOf:
-                          - type: object
+                          - description: Fires automatically after a fixed delay.
+                            type: object
                             properties:
                               type:
                                 type: string
                                 const: interval
                               seconds:
+                                description: Seconds to wait before this step fires.
                                 type: number
                                 exclusiveMinimum: 0
                             required:
                               - type
                               - seconds
                             additionalProperties: false
-                          - type: object
+                          - description: Pauses the ramp until manually approved.
+                            type: object
                             properties:
                               type:
                                 type: string
@@ -4279,12 +4329,18 @@ paths:
                             required:
                               - type
                             additionalProperties: false
-                          - type: object
+                          - description: Fires at a specific date and time.
+                            type: object
                             properties:
                               type:
                                 type: string
                                 const: scheduled
-                              at: {}
+                              at:
+                                description: >-
+                                  ISO 8601 date-time, e.g.
+                                  "2025-06-01T00:00:00Z".
+                                type: string
+                                format: date-time
                             required:
                               - type
                               - at
@@ -4439,20 +4495,28 @@ paths:
                       - patch
                     additionalProperties: false
                 startDate:
+                  description: >-
+                    ISO 8601 date-time, e.g. "2025-06-01T00:00:00Z". Absent or
+                    null means start immediately on publish.
                   anyOf:
                     - type: string
+                      format: date-time
                     - type: 'null'
                 endCondition:
                   type: object
                   properties:
                     trigger:
                       anyOf:
-                        - type: object
+                        - description: End the ramp at a specific date and time.
+                          type: object
                           properties:
                             type:
                               type: string
                               const: scheduled
-                            at: {}
+                            at:
+                              description: ISO 8601 date-time, e.g. "2025-07-01T00:00:00Z".
+                              type: string
+                              format: date-time
                           required:
                             - type
                             - at
@@ -5083,8 +5147,12 @@ paths:
                               type: object
                               properties:
                                 timestamp:
+                                  description: >-
+                                    ISO 8601 date-time, e.g.
+                                    "2025-06-01T00:00:00Z".
                                   anyOf:
                                     - type: string
+                                      format: date-time
                                     - type: 'null'
                                 enabled:
                                   type: boolean
@@ -5162,8 +5230,12 @@ paths:
                               type: object
                               properties:
                                 timestamp:
+                                  description: >-
+                                    ISO 8601 date-time, e.g.
+                                    "2025-06-01T00:00:00Z".
                                   anyOf:
                                     - type: string
+                                      format: date-time
                                     - type: 'null'
                                 enabled:
                                   type: boolean
@@ -5254,8 +5326,12 @@ paths:
                               type: object
                               properties:
                                 timestamp:
+                                  description: >-
+                                    ISO 8601 date-time, e.g.
+                                    "2025-06-01T00:00:00Z".
                                   anyOf:
                                     - type: string
+                                      format: date-time
                                     - type: 'null'
                                 enabled:
                                   type: boolean
@@ -5347,8 +5423,12 @@ paths:
                               type: object
                               properties:
                                 timestamp:
+                                  description: >-
+                                    ISO 8601 date-time, e.g.
+                                    "2025-06-01T00:00:00Z".
                                   anyOf:
                                     - type: string
+                                      format: date-time
                                     - type: 'null'
                                 enabled:
                                   type: boolean
@@ -5585,8 +5665,12 @@ paths:
                               type: object
                               properties:
                                 timestamp:
+                                  description: >-
+                                    ISO 8601 date-time, e.g.
+                                    "2025-06-01T00:00:00Z".
                                   anyOf:
                                     - type: string
+                                      format: date-time
                                     - type: 'null'
                                 enabled:
                                   type: boolean
@@ -5664,8 +5748,12 @@ paths:
                               type: object
                               properties:
                                 timestamp:
+                                  description: >-
+                                    ISO 8601 date-time, e.g.
+                                    "2025-06-01T00:00:00Z".
                                   anyOf:
                                     - type: string
+                                      format: date-time
                                     - type: 'null'
                                 enabled:
                                   type: boolean
@@ -5756,8 +5844,12 @@ paths:
                               type: object
                               properties:
                                 timestamp:
+                                  description: >-
+                                    ISO 8601 date-time, e.g.
+                                    "2025-06-01T00:00:00Z".
                                   anyOf:
                                     - type: string
+                                      format: date-time
                                     - type: 'null'
                                 enabled:
                                   type: boolean
@@ -5849,8 +5941,12 @@ paths:
                               type: object
                               properties:
                                 timestamp:
+                                  description: >-
+                                    ISO 8601 date-time, e.g.
+                                    "2025-06-01T00:00:00Z".
                                   anyOf:
                                     - type: string
+                                      format: date-time
                                     - type: 'null'
                                 enabled:
                                   type: boolean
@@ -6217,13 +6313,14 @@ paths:
           source: |-
             curl -X GET 'https://api.growthbook.io/api/v2/stale-features' \
               -H 'Authorization: Bearer YOUR_API_KEY'
-  /v2/revisions:
+  /v2/feature-revisions:
     get:
       operationId: listRevisionsV2
-      summary: List feature revisions
+      summary: List revisions across all features
       description: >-
         Returns a paginated list of feature revisions across all features in the
-        organization. Revision `rules` is a flat array with per-rule scope.
+        organization. Use the `featureId` query parameter to filter to a single
+        feature. Revision `rules` is a flat array with per-rule scope.
       tags:
         - feature-revisions-v2
       parameters:
@@ -6289,7 +6386,7 @@ paths:
       x-codeSamples:
         - lang: cURL
           source: |-
-            curl -X GET 'https://api.growthbook.io/api/v2/revisions' \
+            curl -X GET 'https://api.growthbook.io/api/v2/feature-revisions' \
               -H 'Authorization: Bearer YOUR_API_KEY'
   /v2/features/{id}/revisions:
     get:
@@ -6663,8 +6760,14 @@ paths:
                 defaultValue:
                   type: string
                 revisionTitle:
+                  description: >-
+                    Title for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
                 revisionComment:
+                  description: >-
+                    Comment for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
               required:
                 - defaultValue
@@ -6731,8 +6834,14 @@ paths:
                       - condition
                     additionalProperties: false
                 revisionTitle:
+                  description: >-
+                    Title for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
                 revisionComment:
+                  description: >-
+                    Comment for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
               required:
                 - prerequisites
@@ -6799,8 +6908,14 @@ paths:
                       additionalProperties: false
                     - type: 'null'
                 revisionTitle:
+                  description: >-
+                    Title for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
                 revisionComment:
+                  description: >-
+                    Comment for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
               required:
                 - holdout
@@ -6856,8 +6971,14 @@ paths:
                 archived:
                   type: boolean
                 revisionTitle:
+                  description: >-
+                    Title for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
                 revisionComment:
+                  description: >-
+                    Comment for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
               required:
                 - archived
@@ -6915,8 +7036,14 @@ paths:
                 enabled:
                   type: boolean
                 revisionTitle:
+                  description: >-
+                    Title for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
                 revisionComment:
+                  description: >-
+                    Comment for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
               required:
                 - environment
@@ -6947,9 +7074,16 @@ paths:
       summary: Add a rule to a draft revision
       description: >-
         Appends a new rule to the revision's rule list. Supply `allEnvironments:
-        true` to target all environments, or `environments: [...]` to scope to
-        specific ones. Use `rampSchedule` for ramp configuration or `schedule`
-        for a simple start/end window.
+        true` on the rule to target all environments, or `environments: [...]`
+        to scope to specific ones.
+
+
+        **Scheduling:** For `force` and `rollout` rules, attach a schedule via
+        `rampSchedule` (multi-step ramp) or `schedule` (simple start/end window)
+        — these create standalone ramp actions and set `pendingRamp: "create"`
+        on the rule. For `experiment-ref` and `safe-rollout` rules, only
+        `schedule` is supported and is stored as legacy schedule fields on the
+        rule itself (`rampSchedule` is not available for these rule types).
       tags:
         - feature-revisions-v2
       parameters:
@@ -6977,343 +7111,14 @@ paths:
               properties:
                 rule:
                   anyOf:
-                    - type: object
-                      properties:
-                        description:
-                          type: string
-                        enabled:
-                          type: boolean
-                        condition:
-                          type: string
-                        savedGroups:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              match:
-                                type: string
-                                enum:
-                                  - all
-                                  - none
-                                  - any
-                              ids:
-                                type: array
-                                items:
-                                  type: string
-                            required:
-                              - match
-                              - ids
-                            additionalProperties: false
-                        prerequisites:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              id:
-                                type: string
-                              condition:
-                                type: string
-                            required:
-                              - id
-                              - condition
-                            additionalProperties: false
-                        scheduleRules:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              timestamp:
-                                anyOf:
-                                  - type: string
-                                  - type: 'null'
-                              enabled:
-                                type: boolean
-                            required:
-                              - timestamp
-                              - enabled
-                            additionalProperties: false
-                        scheduleType:
-                          type: string
-                          enum:
-                            - none
-                            - schedule
-                            - ramp
-                        allEnvironments:
-                          description: >-
-                            When true the rule applies to all environments.
-                            Defaults to false.
-                          type: boolean
-                        environments:
-                          description: >-
-                            Specific environment IDs this rule applies to. Used
-                            when allEnvironments is false.
-                          type: array
-                          items:
-                            type: string
-                        type:
-                          type: string
-                          const: experiment-ref
-                        experimentId:
-                          type: string
-                        variations:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              variationId:
-                                type: string
-                              value:
-                                type: string
-                            required:
-                              - value
-                            additionalProperties: false
-                      required:
-                        - type
-                        - experimentId
-                        - variations
-                      additionalProperties: false
-                    - type: object
-                      properties:
-                        description:
-                          type: string
-                        enabled:
-                          type: boolean
-                        condition:
-                          type: string
-                        savedGroups:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              match:
-                                type: string
-                                enum:
-                                  - all
-                                  - none
-                                  - any
-                              ids:
-                                type: array
-                                items:
-                                  type: string
-                            required:
-                              - match
-                              - ids
-                            additionalProperties: false
-                        prerequisites:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              id:
-                                type: string
-                              condition:
-                                type: string
-                            required:
-                              - id
-                              - condition
-                            additionalProperties: false
-                        scheduleRules:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              timestamp:
-                                anyOf:
-                                  - type: string
-                                  - type: 'null'
-                              enabled:
-                                type: boolean
-                            required:
-                              - timestamp
-                              - enabled
-                            additionalProperties: false
-                        scheduleType:
-                          type: string
-                          enum:
-                            - none
-                            - schedule
-                            - ramp
-                        allEnvironments:
-                          description: >-
-                            When true the rule applies to all environments.
-                            Defaults to false.
-                          type: boolean
-                        environments:
-                          description: >-
-                            Specific environment IDs this rule applies to. Used
-                            when allEnvironments is false.
-                          type: array
-                          items:
-                            type: string
-                        type:
-                          type: string
-                          const: safe-rollout
-                        controlValue:
-                          type: string
-                        variationValue:
-                          type: string
-                        hashAttribute:
-                          type: string
-                        trackingKey:
-                          type: string
-                        seed:
-                          type: string
-                        safeRolloutFields:
-                          type: object
-                          properties:
-                            datasourceId:
-                              type: string
-                            exposureQueryId:
-                              type: string
-                            guardrailMetricIds:
-                              type: array
-                              items:
-                                type: string
-                            maxDuration:
-                              type: object
-                              properties:
-                                amount:
-                                  type: number
-                                  exclusiveMinimum: 0
-                                unit:
-                                  type: string
-                                  enum:
-                                    - weeks
-                                    - days
-                                    - hours
-                                    - minutes
-                              required:
-                                - amount
-                                - unit
-                              additionalProperties: false
-                            autoRollback:
-                              type: boolean
-                            rampUpSchedule:
-                              type: object
-                              properties:
-                                enabled:
-                                  type: boolean
-                                steps:
-                                  minItems: 1
-                                  type: array
-                                  items:
-                                    type: object
-                                    properties:
-                                      percent:
-                                        type: number
-                                        minimum: 0
-                                        maximum: 1
-                                    required:
-                                      - percent
-                                    additionalProperties: false
-                              required:
-                                - enabled
-                              additionalProperties: false
-                          required:
-                            - datasourceId
-                            - exposureQueryId
-                            - guardrailMetricIds
-                            - maxDuration
-                          additionalProperties: false
-                      required:
-                        - type
-                        - controlValue
-                        - variationValue
-                        - hashAttribute
-                        - safeRolloutFields
-                      additionalProperties: false
-                    - type: object
-                      properties:
-                        description:
-                          type: string
-                        enabled:
-                          type: boolean
-                        condition:
-                          type: string
-                        savedGroups:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              match:
-                                type: string
-                                enum:
-                                  - all
-                                  - none
-                                  - any
-                              ids:
-                                type: array
-                                items:
-                                  type: string
-                            required:
-                              - match
-                              - ids
-                            additionalProperties: false
-                        prerequisites:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              id:
-                                type: string
-                              condition:
-                                type: string
-                            required:
-                              - id
-                              - condition
-                            additionalProperties: false
-                        scheduleRules:
-                          type: array
-                          items:
-                            type: object
-                            properties:
-                              timestamp:
-                                anyOf:
-                                  - type: string
-                                  - type: 'null'
-                              enabled:
-                                type: boolean
-                            required:
-                              - timestamp
-                              - enabled
-                            additionalProperties: false
-                        scheduleType:
-                          type: string
-                          enum:
-                            - none
-                            - schedule
-                            - ramp
-                        allEnvironments:
-                          description: >-
-                            When true the rule applies to all environments.
-                            Defaults to false.
-                          type: boolean
-                        environments:
-                          description: >-
-                            Specific environment IDs this rule applies to. Used
-                            when allEnvironments is false.
-                          type: array
-                          items:
-                            type: string
-                        type:
-                          type: string
-                          enum:
-                            - force
-                            - rollout
-                        value:
-                          type: string
-                        coverage:
-                          type: number
-                          minimum: 0
-                          maximum: 1
-                        hashAttribute:
-                          type: string
-                        seed:
-                          type: string
-                      required:
-                        - value
-                      additionalProperties: false
+                    - $ref: '#/components/schemas/Targeting Rule'
+                    - $ref: '#/components/schemas/Experiment Rule'
+                    - $ref: '#/components/schemas/Safe Rollout Rule'
                 rampSchedule:
+                  description: >-
+                    Multi-step ramp schedule for force/rollout rules. Not
+                    supported for experiment-ref or safe-rollout rules. Mutually
+                    exclusive with `schedule`.
                   type: object
                   properties:
                     name:
@@ -7327,19 +7132,22 @@ paths:
                         properties:
                           trigger:
                             anyOf:
-                              - type: object
+                              - description: Fires automatically after a fixed delay.
+                                type: object
                                 properties:
                                   type:
                                     type: string
                                     const: interval
                                   seconds:
+                                    description: Seconds to wait before this step fires.
                                     type: number
                                     exclusiveMinimum: 0
                                 required:
                                   - type
                                   - seconds
                                 additionalProperties: false
-                              - type: object
+                              - description: Pauses the ramp until manually approved.
+                                type: object
                                 properties:
                                   type:
                                     type: string
@@ -7347,12 +7155,18 @@ paths:
                                 required:
                                   - type
                                 additionalProperties: false
-                              - type: object
+                              - description: Fires at a specific date and time.
+                                type: object
                                 properties:
                                   type:
                                     type: string
                                     const: scheduled
-                                  at: {}
+                                  at:
+                                    description: >-
+                                      ISO 8601 date-time, e.g.
+                                      "2025-06-01T00:00:00Z".
+                                    type: string
+                                    format: date-time
                                 required:
                                   - type
                                   - at
@@ -7507,20 +7321,30 @@ paths:
                           - patch
                         additionalProperties: false
                     startDate:
+                      description: >-
+                        ISO 8601 date-time, e.g. "2025-06-01T00:00:00Z". Absent
+                        or null means start immediately on publish.
                       anyOf:
                         - type: string
+                          format: date-time
                         - type: 'null'
                     endCondition:
                       type: object
                       properties:
                         trigger:
                           anyOf:
-                            - type: object
+                            - description: End the ramp at a specific date and time.
+                              type: object
                               properties:
                                 type:
                                   type: string
                                   const: scheduled
-                                at: {}
+                                at:
+                                  description: >-
+                                    ISO 8601 date-time, e.g.
+                                    "2025-07-01T00:00:00Z".
+                                  type: string
+                                  format: date-time
                               required:
                                 - type
                                 - at
@@ -7528,20 +7352,39 @@ paths:
                       additionalProperties: false
                   additionalProperties: false
                 schedule:
+                  description: >-
+                    Simple start/end date window. For force/rollout rules this
+                    creates a standalone ramp action; for
+                    experiment-ref/safe-rollout rules this sets legacy schedule
+                    fields on the rule. Mutually exclusive with `rampSchedule`.
                   type: object
                   properties:
                     startDate:
+                      description: >-
+                        ISO 8601 date-time, e.g. "2025-06-01T00:00:00Z". Rule is
+                        enabled at this time.
                       anyOf:
                         - type: string
+                          format: date-time
                         - type: 'null'
                     endDate:
+                      description: >-
+                        ISO 8601 date-time, e.g. "2025-07-01T00:00:00Z". Rule is
+                        disabled at this time.
                       anyOf:
                         - type: string
+                          format: date-time
                         - type: 'null'
                   additionalProperties: false
                 revisionTitle:
+                  description: >-
+                    Title for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
                 revisionComment:
+                  description: >-
+                    Comment for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
               required:
                 - rule
@@ -7573,6 +7416,14 @@ paths:
         Patches fields on an existing rule (identified by `ruleId`). The rule
         `type` cannot be changed. Scope can be updated via `allEnvironments` /
         `environments` patch fields.
+
+
+        **Scheduling:** For `force` and `rollout` rules, update the schedule via
+        `rampSchedule` (multi-step ramp) or `schedule` (simple start/end window)
+        — these manage standalone ramp actions and set `pendingRamp: "create"`
+        on the rule. For `experiment-ref` and `safe-rollout` rules, only
+        `schedule` is supported and updates legacy schedule fields on the rule
+        itself (`rampSchedule` is not available for these rule types).
       tags:
         - feature-revisions-v2
       parameters:
@@ -7640,31 +7491,6 @@ paths:
                           - id
                           - condition
                         additionalProperties: false
-                    scheduleRules:
-                      anyOf:
-                        - type: array
-                          items:
-                            type: object
-                            properties:
-                              timestamp:
-                                anyOf:
-                                  - type: string
-                                  - type: 'null'
-                              enabled:
-                                type: boolean
-                            required:
-                              - timestamp
-                              - enabled
-                            additionalProperties: false
-                        - type: 'null'
-                    scheduleType:
-                      anyOf:
-                        - type: string
-                          enum:
-                            - none
-                            - schedule
-                            - ramp
-                        - type: 'null'
                     type:
                       type: string
                       enum:
@@ -7709,6 +7535,10 @@ paths:
                         type: string
                   additionalProperties: false
                 rampSchedule:
+                  description: >-
+                    Multi-step ramp schedule for force/rollout rules. Not
+                    supported for experiment-ref or safe-rollout rules. Mutually
+                    exclusive with `schedule`.
                   type: object
                   properties:
                     name:
@@ -7722,19 +7552,22 @@ paths:
                         properties:
                           trigger:
                             anyOf:
-                              - type: object
+                              - description: Fires automatically after a fixed delay.
+                                type: object
                                 properties:
                                   type:
                                     type: string
                                     const: interval
                                   seconds:
+                                    description: Seconds to wait before this step fires.
                                     type: number
                                     exclusiveMinimum: 0
                                 required:
                                   - type
                                   - seconds
                                 additionalProperties: false
-                              - type: object
+                              - description: Pauses the ramp until manually approved.
+                                type: object
                                 properties:
                                   type:
                                     type: string
@@ -7742,12 +7575,18 @@ paths:
                                 required:
                                   - type
                                 additionalProperties: false
-                              - type: object
+                              - description: Fires at a specific date and time.
+                                type: object
                                 properties:
                                   type:
                                     type: string
                                     const: scheduled
-                                  at: {}
+                                  at:
+                                    description: >-
+                                      ISO 8601 date-time, e.g.
+                                      "2025-06-01T00:00:00Z".
+                                    type: string
+                                    format: date-time
                                 required:
                                   - type
                                   - at
@@ -7902,20 +7741,30 @@ paths:
                           - patch
                         additionalProperties: false
                     startDate:
+                      description: >-
+                        ISO 8601 date-time, e.g. "2025-06-01T00:00:00Z". Absent
+                        or null means start immediately on publish.
                       anyOf:
                         - type: string
+                          format: date-time
                         - type: 'null'
                     endCondition:
                       type: object
                       properties:
                         trigger:
                           anyOf:
-                            - type: object
+                            - description: End the ramp at a specific date and time.
+                              type: object
                               properties:
                                 type:
                                   type: string
                                   const: scheduled
-                                at: {}
+                                at:
+                                  description: >-
+                                    ISO 8601 date-time, e.g.
+                                    "2025-07-01T00:00:00Z".
+                                  type: string
+                                  format: date-time
                               required:
                                 - type
                                 - at
@@ -7923,20 +7772,40 @@ paths:
                       additionalProperties: false
                   additionalProperties: false
                 schedule:
+                  description: >-
+                    Simple start/end date window. For force/rollout rules this
+                    manages a standalone ramp action; for
+                    experiment-ref/safe-rollout rules this updates legacy
+                    schedule fields on the rule. Mutually exclusive with
+                    `rampSchedule`.
                   type: object
                   properties:
                     startDate:
+                      description: >-
+                        ISO 8601 date-time, e.g. "2025-06-01T00:00:00Z". Rule is
+                        enabled at this time.
                       anyOf:
                         - type: string
+                          format: date-time
                         - type: 'null'
                     endDate:
+                      description: >-
+                        ISO 8601 date-time, e.g. "2025-07-01T00:00:00Z". Rule is
+                        disabled at this time.
                       anyOf:
                         - type: string
+                          format: date-time
                         - type: 'null'
                   additionalProperties: false
                 revisionTitle:
+                  description: >-
+                    Title for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
                 revisionComment:
+                  description: >-
+                    Comment for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
               required:
                 - rule
@@ -7993,8 +7862,14 @@ paths:
               type: object
               properties:
                 revisionTitle:
+                  description: >-
+                    Title for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
                 revisionComment:
+                  description: >-
+                    Comment for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
               additionalProperties: false
       responses:
@@ -8054,8 +7929,14 @@ paths:
                   items:
                     type: string
                 revisionTitle:
+                  description: >-
+                    Title for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
                 revisionComment:
+                  description: >-
+                    Comment for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
               required:
                 - ruleIds
@@ -8083,6 +7964,12 @@ paths:
     put:
       operationId: putFeatureRevisionRuleRampScheduleV2
       summary: Set ramp schedule for a rule
+      description: >-
+        Creates or replaces the pending ramp schedule for a rule. The rule will
+        show `pendingRamp: "create"` in subsequent GET responses. The ramp is
+        created when the revision is published. If the rule already has a live
+        ramp schedule, this endpoint returns an error — update the live schedule
+        via `PUT /api/v1/ramp-schedules/{id}` instead.
       tags:
         - feature-revisions-v2
       parameters:
@@ -8120,19 +8007,22 @@ paths:
                     properties:
                       trigger:
                         anyOf:
-                          - type: object
+                          - description: Fires automatically after a fixed delay.
+                            type: object
                             properties:
                               type:
                                 type: string
                                 const: interval
                               seconds:
+                                description: Seconds to wait before this step fires.
                                 type: number
                                 exclusiveMinimum: 0
                             required:
                               - type
                               - seconds
                             additionalProperties: false
-                          - type: object
+                          - description: Pauses the ramp until manually approved.
+                            type: object
                             properties:
                               type:
                                 type: string
@@ -8140,12 +8030,18 @@ paths:
                             required:
                               - type
                             additionalProperties: false
-                          - type: object
+                          - description: Fires at a specific date and time.
+                            type: object
                             properties:
                               type:
                                 type: string
                                 const: scheduled
-                              at: {}
+                              at:
+                                description: >-
+                                  ISO 8601 date-time, e.g.
+                                  "2025-06-01T00:00:00Z".
+                                type: string
+                                format: date-time
                             required:
                               - type
                               - at
@@ -8300,20 +8196,28 @@ paths:
                       - patch
                     additionalProperties: false
                 startDate:
+                  description: >-
+                    ISO 8601 date-time, e.g. "2025-06-01T00:00:00Z". Absent or
+                    null means start immediately on publish.
                   anyOf:
                     - type: string
+                      format: date-time
                     - type: 'null'
                 endCondition:
                   type: object
                   properties:
                     trigger:
                       anyOf:
-                        - type: object
+                        - description: End the ramp at a specific date and time.
+                          type: object
                           properties:
                             type:
                               type: string
                               const: scheduled
-                            at: {}
+                            at:
+                              description: ISO 8601 date-time, e.g. "2025-07-01T00:00:00Z".
+                              type: string
+                              format: date-time
                           required:
                             - type
                             - at
@@ -8323,8 +8227,14 @@ paths:
                   deprecated: true
                   type: string
                 revisionTitle:
+                  description: >-
+                    Title for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
                 revisionComment:
+                  description: >-
+                    Comment for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
               additionalProperties: false
       responses:
@@ -8349,6 +8259,11 @@ paths:
     delete:
       operationId: deleteFeatureRevisionRuleRampScheduleV2
       summary: Remove ramp schedule from a rule
+      description: >-
+        Clears any pending ramp action for this rule. If a live ramp schedule
+        exists, queues a detach that removes it on publish — the rule will show
+        `pendingRamp: "detach"`. If only a pending create exists, it is removed
+        and `pendingRamp` is cleared.
       tags:
         - feature-revisions-v2
       parameters:
@@ -8376,8 +8291,14 @@ paths:
               type: object
               properties:
                 revisionTitle:
+                  description: >-
+                    Title for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
                 revisionComment:
+                  description: >-
+                    Comment for a newly created draft. Only used when version is
+                    "new"; ignored for existing revisions.
                   type: string
               additionalProperties: false
       responses:
@@ -8642,7 +8563,8 @@ paths:
       summary: Publish a draft revision
       description: >-
         Immediately publishes a draft revision, making it the live version of
-        the feature.
+        the feature. Any pending ramp actions (`pendingRamp` on rules) are
+        executed atomically — ramp schedules are created or detached as queued.
       tags:
         - feature-revisions-v2
       parameters:
@@ -16807,8 +16729,6 @@ paths:
                   anyOf:
                     - type: string
                       format: date-time
-                      pattern: >-
-                        ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                     - type: 'null'
                 endCondition:
                   description: Optional hard deadline
@@ -16823,8 +16743,6 @@ paths:
                         at:
                           type: string
                           format: date-time
-                          pattern: >-
-                            ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                       required:
                         - type
                         - at
@@ -20764,8 +20682,6 @@ paths:
                     - type: boolean
                     - type: string
                       format: date-time
-                      pattern: >-
-                        ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                     - type: string
                       format: date
                       pattern: >-
@@ -20783,8 +20699,6 @@ paths:
                       items:
                         type: string
                         format: date-time
-                        pattern: >-
-                          ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                     - type: array
                       items:
                         type: string
@@ -20965,8 +20879,6 @@ paths:
                     - type: boolean
                     - type: string
                       format: date-time
-                      pattern: >-
-                        ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                     - type: string
                       format: date
                       pattern: >-
@@ -20984,8 +20896,6 @@ paths:
                       items:
                         type: string
                         format: date-time
-                        pattern: >-
-                          ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                     - type: array
                       items:
                         type: string
@@ -22499,13 +22409,9 @@ paths:
                           dateCreated:
                             type: string
                             format: date-time
-                            pattern: >-
-                              ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                           dateUpdated:
                             type: string
                             format: date-time
-                            pattern: >-
-                              ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                           datasource:
                             type: string
                           status:
@@ -23151,13 +23057,9 @@ paths:
                           dateCreated:
                             type: string
                             format: date-time
-                            pattern: >-
-                              ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                           dateUpdated:
                             type: string
                             format: date-time
-                            pattern: >-
-                              ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                           datasource:
                             type: string
                           status:
@@ -23829,13 +23731,9 @@ paths:
                           dateCreated:
                             type: string
                             format: date-time
-                            pattern: >-
-                              ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                           dateUpdated:
                             type: string
                             format: date-time
-                            pattern: >-
-                              ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                           datasource:
                             type: string
                           status:
@@ -24302,19 +24200,22 @@ paths:
                     properties:
                       trigger:
                         anyOf:
-                          - type: object
+                          - description: Fires automatically after a fixed delay.
+                            type: object
                             properties:
                               type:
                                 type: string
                                 const: interval
                               seconds:
+                                description: Seconds to wait before this step fires.
                                 type: number
                                 exclusiveMinimum: 0
                             required:
                               - type
                               - seconds
                             additionalProperties: false
-                          - type: object
+                          - description: Pauses the ramp until manually approved.
+                            type: object
                             properties:
                               type:
                                 type: string
@@ -24322,16 +24223,18 @@ paths:
                             required:
                               - type
                             additionalProperties: false
-                          - type: object
+                          - description: Fires at a specific date and time.
+                            type: object
                             properties:
                               type:
                                 type: string
                                 const: scheduled
                               at:
+                                description: >-
+                                  ISO 8601 date-time, e.g.
+                                  "2025-06-01T00:00:00Z".
                                 type: string
                                 format: date-time
-                                pattern: >-
-                                  ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                             required:
                               - type
                               - at
@@ -24502,19 +24405,22 @@ paths:
                     properties:
                       trigger:
                         anyOf:
-                          - type: object
+                          - description: Fires automatically after a fixed delay.
+                            type: object
                             properties:
                               type:
                                 type: string
                                 const: interval
                               seconds:
+                                description: Seconds to wait before this step fires.
                                 type: number
                                 exclusiveMinimum: 0
                             required:
                               - type
                               - seconds
                             additionalProperties: false
-                          - type: object
+                          - description: Pauses the ramp until manually approved.
+                            type: object
                             properties:
                               type:
                                 type: string
@@ -24522,16 +24428,18 @@ paths:
                             required:
                               - type
                             additionalProperties: false
-                          - type: object
+                          - description: Fires at a specific date and time.
+                            type: object
                             properties:
                               type:
                                 type: string
                                 const: scheduled
                               at:
+                                description: >-
+                                  ISO 8601 date-time, e.g.
+                                  "2025-06-01T00:00:00Z".
                                 type: string
                                 format: date-time
-                                pattern: >-
-                                  ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                             required:
                               - type
                               - at
@@ -25008,8 +24916,6 @@ paths:
                   anyOf:
                     - type: string
                       format: date-time
-                      pattern: >-
-                        ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                     - type: 'null'
                 endCondition:
                   anyOf:
@@ -25024,8 +24930,6 @@ paths:
                             at:
                               type: string
                               format: date-time
-                              pattern: >-
-                                ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                           required:
                             - type
                             - at
@@ -26426,6 +26330,16 @@ components:
               type: array
               items:
                 type: string
+            pendingRamp:
+              description: >-
+                Present on draft revisions only. "create" means a ramp schedule
+                will be created for this rule on publish. "detach" means an
+                existing live ramp schedule will be removed on publish. Use
+                PUT/DELETE .../rules/{ruleId}/ramp-schedule to modify.
+              type: string
+              enum:
+                - create
+                - detach
           required:
             - allEnvironments
           additionalProperties: false
@@ -26598,6 +26512,298 @@ components:
         - date
         - status
         - rules
+      additionalProperties: false
+    Targeting Rule:
+      description: >-
+        A targeting rule that serves a specific value to users matching the
+        conditions. Set coverage < 1 for a percentage rollout.
+      type: object
+      properties:
+        description:
+          type: string
+        enabled:
+          type: boolean
+        condition:
+          type: string
+        savedGroups:
+          type: array
+          items:
+            type: object
+            properties:
+              match:
+                type: string
+                enum:
+                  - all
+                  - none
+                  - any
+              ids:
+                type: array
+                items:
+                  type: string
+            required:
+              - match
+              - ids
+            additionalProperties: false
+        prerequisites:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              condition:
+                type: string
+            required:
+              - id
+              - condition
+            additionalProperties: false
+        allEnvironments:
+          description: When true the rule applies to all environments. Defaults to false.
+          type: boolean
+        environments:
+          description: >-
+            Specific environment IDs this rule applies to. Used when
+            allEnvironments is false.
+          type: array
+          items:
+            type: string
+        type:
+          description: >-
+            Use "force" for a standard targeting rule, or "rollout" for a
+            percentage rollout (coverage < 1). Both are functionally equivalent;
+            a force rule with coverage < 1 behaves as a rollout.
+          type: string
+          enum:
+            - force
+            - rollout
+        value:
+          description: The value to serve when this rule matches.
+          type: string
+        coverage:
+          description: >-
+            Percentage of users to include (0–1). Defaults to 1. When less than
+            1, hashAttribute is required.
+          type: number
+          minimum: 0
+          maximum: 1
+        hashAttribute:
+          description: >-
+            Attribute to hash on for consistent assignment. Required when
+            coverage < 1.
+          type: string
+        seed:
+          type: string
+      required:
+        - type
+        - value
+      additionalProperties: false
+    Experiment Rule:
+      description: An experiment rule that links a feature value to an existing experiment.
+      type: object
+      properties:
+        description:
+          type: string
+        enabled:
+          type: boolean
+        condition:
+          type: string
+        savedGroups:
+          type: array
+          items:
+            type: object
+            properties:
+              match:
+                type: string
+                enum:
+                  - all
+                  - none
+                  - any
+              ids:
+                type: array
+                items:
+                  type: string
+            required:
+              - match
+              - ids
+            additionalProperties: false
+        prerequisites:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              condition:
+                type: string
+            required:
+              - id
+              - condition
+            additionalProperties: false
+        allEnvironments:
+          description: When true the rule applies to all environments. Defaults to false.
+          type: boolean
+        environments:
+          description: >-
+            Specific environment IDs this rule applies to. Used when
+            allEnvironments is false.
+          type: array
+          items:
+            type: string
+        type:
+          description: Must be "experiment-ref" for an experiment rule.
+          type: string
+          const: experiment-ref
+        experimentId:
+          description: ID of the linked experiment.
+          type: string
+        variations:
+          type: array
+          items:
+            type: object
+            properties:
+              variationId:
+                type: string
+              value:
+                type: string
+            required:
+              - value
+            additionalProperties: false
+      required:
+        - type
+        - experimentId
+        - variations
+      additionalProperties: false
+    Safe Rollout Rule:
+      description: >-
+        A safe rollout rule with automated guardrail monitoring and optional
+        auto-rollback.
+      type: object
+      properties:
+        description:
+          type: string
+        enabled:
+          type: boolean
+        condition:
+          type: string
+        savedGroups:
+          type: array
+          items:
+            type: object
+            properties:
+              match:
+                type: string
+                enum:
+                  - all
+                  - none
+                  - any
+              ids:
+                type: array
+                items:
+                  type: string
+            required:
+              - match
+              - ids
+            additionalProperties: false
+        prerequisites:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              condition:
+                type: string
+            required:
+              - id
+              - condition
+            additionalProperties: false
+        allEnvironments:
+          description: When true the rule applies to all environments. Defaults to false.
+          type: boolean
+        environments:
+          description: >-
+            Specific environment IDs this rule applies to. Used when
+            allEnvironments is false.
+          type: array
+          items:
+            type: string
+        type:
+          description: Must be "safe-rollout" for a safe rollout rule.
+          type: string
+          const: safe-rollout
+        controlValue:
+          type: string
+        variationValue:
+          type: string
+        hashAttribute:
+          type: string
+        trackingKey:
+          type: string
+        seed:
+          type: string
+        safeRolloutFields:
+          type: object
+          properties:
+            datasourceId:
+              type: string
+            exposureQueryId:
+              type: string
+            guardrailMetricIds:
+              type: array
+              items:
+                type: string
+            maxDuration:
+              type: object
+              properties:
+                amount:
+                  type: number
+                  exclusiveMinimum: 0
+                unit:
+                  type: string
+                  enum:
+                    - weeks
+                    - days
+                    - hours
+                    - minutes
+              required:
+                - amount
+                - unit
+              additionalProperties: false
+            autoRollback:
+              type: boolean
+            rampUpSchedule:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                steps:
+                  minItems: 1
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      percent:
+                        type: number
+                        minimum: 0
+                        maximum: 1
+                    required:
+                      - percent
+                    additionalProperties: false
+              required:
+                - enabled
+              additionalProperties: false
+          required:
+            - datasourceId
+            - exposureQueryId
+            - guardrailMetricIds
+            - maxDuration
+          additionalProperties: false
+      required:
+        - type
+        - controlValue
+        - variationValue
+        - hashAttribute
+        - safeRolloutFields
       additionalProperties: false
     Archetype:
       type: object
@@ -29763,13 +29969,9 @@ components:
         dateCreated:
           type: string
           format: date-time
-          pattern: >-
-            ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
         dateUpdated:
           type: string
           format: date-time
-          pattern: >-
-            ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
         name:
           type: string
         entityType:
@@ -29830,19 +30032,22 @@ components:
             properties:
               trigger:
                 anyOf:
-                  - type: object
+                  - description: Fires automatically after a fixed delay.
+                    type: object
                     properties:
                       type:
                         type: string
                         const: interval
                       seconds:
+                        description: Seconds to wait before this step fires.
                         type: number
                         exclusiveMinimum: 0
                     required:
                       - type
                       - seconds
                     additionalProperties: false
-                  - type: object
+                  - description: Pauses the ramp until manually approved.
+                    type: object
                     properties:
                       type:
                         type: string
@@ -29850,16 +30055,16 @@ components:
                     required:
                       - type
                     additionalProperties: false
-                  - type: object
+                  - description: Fires at a specific date and time.
+                    type: object
                     properties:
                       type:
                         type: string
                         const: scheduled
                       at:
+                        description: ISO 8601 date-time, e.g. "2025-06-01T00:00:00Z".
                         type: string
                         format: date-time
-                        pattern: >-
-                          ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                     required:
                       - type
                       - at
@@ -30033,8 +30238,6 @@ components:
           anyOf:
             - type: string
               format: date-time
-              pattern: >-
-                ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
             - type: 'null'
         endCondition:
           description: Optional hard deadline for standard (no-step) schedules
@@ -30043,16 +30246,16 @@ components:
               properties:
                 trigger:
                   anyOf:
-                    - type: object
+                    - description: End the ramp at a specific date and time.
+                      type: object
                       properties:
                         type:
                           type: string
                           const: scheduled
                         at:
+                          description: ISO 8601 date-time, e.g. "2025-07-01T00:00:00Z".
                           type: string
                           format: date-time
-                          pattern: >-
-                            ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                       required:
                         - type
                         - at
@@ -30077,8 +30280,6 @@ components:
           anyOf:
             - type: string
               format: date-time
-              pattern: >-
-                ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
             - type: 'null'
         phaseStartedAt:
           description: >-
@@ -30087,15 +30288,11 @@ components:
           anyOf:
             - type: string
               format: date-time
-              pattern: >-
-                ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
             - type: 'null'
         pausedAt:
           anyOf:
             - type: string
               format: date-time
-              pattern: >-
-                ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
             - type: 'null'
         nextStepAt:
           description: >-
@@ -30104,15 +30301,11 @@ components:
           anyOf:
             - type: string
               format: date-time
-              pattern: >-
-                ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
             - type: 'null'
         nextProcessAt:
           anyOf:
             - type: string
               format: date-time
-              pattern: >-
-                ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
             - type: 'null'
         elapsedMs:
           description: Milliseconds since startedAt (computed at response time, not stored)
@@ -30567,23 +30760,15 @@ components:
         nextUpdate:
           type: string
           format: date-time
-          pattern: >-
-            ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
         lastUpdated:
           type: string
           format: date-time
-          pattern: >-
-            ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
         dateCreated:
           type: string
           format: date-time
-          pattern: >-
-            ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
         dateUpdated:
           type: string
           format: date-time
-          pattern: >-
-            ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
         blocks:
           type: array
           items:
@@ -31983,13 +32168,9 @@ components:
         dateCreated:
           type: string
           format: date-time
-          pattern: >-
-            ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
         dateUpdated:
           type: string
           format: date-time
-          pattern: >-
-            ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
         name:
           type: string
         description:
@@ -32003,8 +32184,6 @@ components:
             - type: boolean
             - type: string
               format: date-time
-              pattern: >-
-                ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
             - type: string
               format: date
               pattern: >-
@@ -32022,8 +32201,6 @@ components:
               items:
                 type: string
                 format: date-time
-                pattern: >-
-                  ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
             - type: array
               items:
                 type: string
@@ -32079,13 +32256,9 @@ components:
         dateCreated:
           type: string
           format: date-time
-          pattern: >-
-            ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
         dateUpdated:
           type: string
           format: date-time
-          pattern: >-
-            ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
         owner:
           description: The userId of the owner (or raw owner name/email for legacy records)
           type: string
@@ -32135,13 +32308,9 @@ components:
         dateCreated:
           type: string
           format: date-time
-          pattern: >-
-            ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
         dateUpdated:
           type: string
           format: date-time
-          pattern: >-
-            ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
         name:
           type: string
         createdBy:
@@ -32224,13 +32393,9 @@ components:
         dateCreated:
           type: string
           format: date-time
-          pattern: >-
-            ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
         dateUpdated:
           type: string
           format: date-time
-          pattern: >-
-            ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
         project:
           type: string
         owner:
@@ -32388,13 +32553,9 @@ components:
         dateCreated:
           type: string
           format: date-time
-          pattern: >-
-            ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
         dateUpdated:
           type: string
           format: date-time
-          pattern: >-
-            ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
         name:
           type: string
         steps:
@@ -32404,19 +32565,22 @@ components:
             properties:
               trigger:
                 anyOf:
-                  - type: object
+                  - description: Fires automatically after a fixed delay.
+                    type: object
                     properties:
                       type:
                         type: string
                         const: interval
                       seconds:
+                        description: Seconds to wait before this step fires.
                         type: number
                         exclusiveMinimum: 0
                     required:
                       - type
                       - seconds
                     additionalProperties: false
-                  - type: object
+                  - description: Pauses the ramp until manually approved.
+                    type: object
                     properties:
                       type:
                         type: string
@@ -32424,16 +32588,16 @@ components:
                     required:
                       - type
                     additionalProperties: false
-                  - type: object
+                  - description: Fires at a specific date and time.
+                    type: object
                     properties:
                       type:
                         type: string
                         const: scheduled
                       at:
+                        description: ISO 8601 date-time, e.g. "2025-06-01T00:00:00Z".
                         type: string
                         format: date-time
-                        pattern: >-
-                          ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
                     required:
                       - type
                       - at
@@ -34622,6 +34786,7 @@ x-tagGroups:
       - Dimension_model
       - Environment_model
       - Experiment_model
+      - Experiment Rule_model
       - ExperimentAnalysisSettings_model
       - ExperimentDecisionFrameworkSettings_model
       - ExperimentMetric_model
@@ -34668,11 +34833,13 @@ x-tagGroups:
       - RampSchedule_model
       - RampScheduleTemplate_model
       - Report_model
+      - Safe Rollout Rule_model
       - SavedGroup_model
       - ScheduleRule_model
       - SdkConnection_model
       - Segment_model
       - Settings_model
+      - Targeting Rule_model
       - Team_model
       - VisualChange_model
       - VisualChangeset_model

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -26570,8 +26570,9 @@ components:
         type:
           description: >-
             Use "force" for a standard targeting rule, or "rollout" for a
-            percentage rollout (coverage < 1). Both are functionally equivalent;
-            a force rule with coverage < 1 behaves as a rollout.
+            percentage rollout (coverage < 1). Defaults to "force". Both are
+            functionally equivalent; a force rule with coverage < 1 behaves as a
+            rollout.
           type: string
           enum:
             - force
@@ -26594,7 +26595,6 @@ components:
         seed:
           type: string
       required:
-        - type
         - value
       additionalProperties: false
     Experiment Rule:

--- a/packages/back-end/src/api/api.router.ts
+++ b/packages/back-end/src/api/api.router.ts
@@ -66,7 +66,6 @@ const router = Router();
 router.use(bodyParser.json({ limit: "2mb" }));
 router.use(bodyParser.urlencoded({ limit: "2mb", extended: true }));
 
-
 // Public route for OpenAPI spec - must be registered BEFORE authentication middleware
 let openapiSpec: string;
 router.get("/v1/openapi.yaml", (req, res) => {

--- a/packages/back-end/src/api/api.router.ts
+++ b/packages/back-end/src/api/api.router.ts
@@ -66,6 +66,7 @@ const router = Router();
 router.use(bodyParser.json({ limit: "2mb" }));
 router.use(bodyParser.urlencoded({ limit: "2mb", extended: true }));
 
+
 // Public route for OpenAPI spec - must be registered BEFORE authentication middleware
 let openapiSpec: string;
 router.get("/v1/openapi.yaml", (req, res) => {

--- a/packages/back-end/src/api/features/deleteFeatureRevisionRuleRampSchedule.ts
+++ b/packages/back-end/src/api/features/deleteFeatureRevisionRuleRampSchedule.ts
@@ -111,6 +111,7 @@ export async function clearRuleRampSchedule(
         mode: "detach",
         ruleId: canonicalRuleId,
         rampScheduleId: liveSchedules[0].id,
+        deleteScheduleWhenEmpty: true,
       };
       newRampActions = [...filtered, detach];
     }

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
@@ -199,18 +199,32 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
         }
 
         if (needsHoldoutCheck && feature.holdout?.id) {
+          if (experiment.status !== "draft") {
+            throw new BadRequestError(
+              `Cannot add experiment rule: this feature uses a holdout, so the experiment must be in "draft" status (currently "${experiment.status}").`,
+            );
+          }
           const expHasLinkedChanges =
             (experiment.linkedFeatures?.length ?? 0) > 0 ||
             experiment.hasURLRedirects ||
             experiment.hasVisualChangesets;
-          if (
-            experiment.status !== "draft" ||
-            (experiment.holdoutId &&
-              experiment.holdoutId !== feature.holdout.id) ||
-            expHasLinkedChanges
-          ) {
+          if (expHasLinkedChanges) {
             throw new BadRequestError(
-              "Failed to create experiment rule. Experiment has linked changes, is not in draft status, or is not linked to the same holdout as the feature.",
+              `Cannot add experiment rule: this feature uses a holdout, but the experiment already has linked features, URL redirects, or visual changesets. Unlink them first.`,
+            );
+          }
+          if (
+            experiment.holdoutId &&
+            experiment.holdoutId !== feature.holdout.id
+          ) {
+            const featureHoldout = await req.context.models.holdout.getById(
+              feature.holdout.id,
+            );
+            const expHoldout = experiment.holdoutId
+              ? await req.context.models.holdout.getById(experiment.holdoutId)
+              : null;
+            throw new BadRequestError(
+              `Cannot add experiment rule: experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}" but this feature uses holdout "${featureHoldout?.name || feature.holdout.id}".`,
             );
           }
 

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
@@ -116,18 +116,32 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
         }
 
         if (needsHoldoutCheck && feature.holdout?.id) {
+          if (experiment.status !== "draft") {
+            throw new BadRequestError(
+              `Cannot add experiment rule: this feature uses a holdout, so the experiment must be in "draft" status (currently "${experiment.status}").`,
+            );
+          }
           const expHasLinkedChanges =
             (experiment.linkedFeatures?.length ?? 0) > 0 ||
             experiment.hasURLRedirects ||
             experiment.hasVisualChangesets;
-          if (
-            experiment.status !== "draft" ||
-            (experiment.holdoutId &&
-              experiment.holdoutId !== feature.holdout.id) ||
-            expHasLinkedChanges
-          ) {
+          if (expHasLinkedChanges) {
             throw new BadRequestError(
-              "Failed to create experiment rule. Experiment has linked changes, is not in draft status, or is not linked to the same holdout as the feature.",
+              `Cannot add experiment rule: this feature uses a holdout, but the experiment already has linked features, URL redirects, or visual changesets. Unlink them first.`,
+            );
+          }
+          if (
+            experiment.holdoutId &&
+            experiment.holdoutId !== feature.holdout.id
+          ) {
+            const featureHoldout = await req.context.models.holdout.getById(
+              feature.holdout.id,
+            );
+            const expHoldout = experiment.holdoutId
+              ? await req.context.models.holdout.getById(experiment.holdoutId)
+              : null;
+            throw new BadRequestError(
+              `Cannot add experiment rule: experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}" but this feature uses holdout "${featureHoldout?.name || feature.holdout.id}".`,
             );
           }
           if (!experiment.holdoutId) {

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
@@ -215,16 +215,33 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
       (rule as SafeRolloutRule).safeRolloutId = safeRollout.id;
     }
 
+    const usesLegacyScheduling =
+      ruleInput.type === "experiment-ref" || ruleInput.type === "safe-rollout";
+
+    if (usesLegacyScheduling && inlineRampSchedule) {
+      throw new BadRequestError(
+        `rampSchedule is not supported for ${ruleInput.type} rules. Use "schedule" instead.`,
+      );
+    }
+
     let resolvedRampAction = inlineRampSchedule
       ? normalizeInlineRampSchedule(inlineRampSchedule, rule.id)
       : undefined;
     if (!resolvedRampAction && (schedule?.startDate || schedule?.endDate)) {
-      if (schedule.startDate) rule.enabled = false;
-      resolvedRampAction = buildScheduleRampAction(
-        rule.id,
-        schedule.startDate,
-        schedule.endDate,
-      );
+      if (usesLegacyScheduling) {
+        rule.scheduleRules = [
+          { enabled: true, timestamp: schedule.startDate ?? null },
+          { enabled: false, timestamp: schedule.endDate ?? null },
+        ];
+        rule.scheduleType = "schedule";
+      } else {
+        if (schedule.startDate) rule.enabled = false;
+        resolvedRampAction = buildScheduleRampAction(
+          rule.id,
+          schedule.startDate,
+          schedule.endDate,
+        );
+      }
     }
 
     // V2: stamp scope from the rule's own allEnvironments/environments fields.

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
@@ -59,6 +59,12 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
   const inlineRampSchedule = req.body.rampSchedule;
   const ruleInput = req.body.rule as RuleCreateInputV2;
 
+  if (inlineRampSchedule && (schedule?.startDate || schedule?.endDate)) {
+    throw new BadRequestError(
+      "rampSchedule and schedule are mutually exclusive. Provide one or the other, not both.",
+    );
+  }
+
   const { revision, created } = await resolveOrCreateRevision(
     req.context,
     req.organization.id,

--- a/packages/back-end/src/api/features/postFeatureRevisionSubmitReview.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionSubmitReview.ts
@@ -65,7 +65,7 @@ export async function submitRevisionReview(
       : undefined;
     if (reviewSetting?.blockSelfApproval) {
       const isSelfApproval = (revision.contributors ?? []).some(
-        (c) => c != null && "id" in c && c.id === req.context.userId,
+        (id) => id === req.context.userId,
       );
       if (isSelfApproval) {
         throw new BadRequestError(

--- a/packages/back-end/src/api/features/putFeatureRevisionRuleRampSchedule.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionRuleRampSchedule.ts
@@ -36,7 +36,6 @@ export async function setRuleRampSchedule(
     // All remaining fields are forwarded as the inline schedule definition.
     [k: string]: unknown;
   },
-  docLinkVersion: "v1" | "v2",
 ) {
   const feature = await getFeature(context, params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
@@ -100,7 +99,7 @@ export async function setRuleRampSchedule(
     if (liveSchedules.length > 0) {
       throw new BadRequestError(
         `Rule "${canonicalRuleId}" already has a live ramp schedule.` +
-          ` Update it via PUT /api/${docLinkVersion}/ramp-schedules/${liveSchedules[0].id}.`,
+          ` Update it via PUT /api/v1/ramp-schedules/${liveSchedules[0].id}.`,
       );
     }
 
@@ -181,7 +180,6 @@ export const putFeatureRevisionRuleRampSchedule = createApiRequestHandler(
     req.organization,
     req.params,
     req.body,
-    "v1",
   );
   return { revision: toApiRevision(revision, req.context, feature) };
 });

--- a/packages/back-end/src/api/features/putFeatureRevisionRuleRampScheduleV2.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionRuleRampScheduleV2.ts
@@ -11,7 +11,6 @@ export const putFeatureRevisionRuleRampScheduleV2 = createApiRequestHandler(
     req.organization,
     req.params,
     req.body,
-    "v2",
   );
   return { revision: toApiRevisionV2(revision) };
 });

--- a/packages/back-end/src/api/features/putFeatureRevisionRuleV2.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionRuleV2.ts
@@ -208,9 +208,17 @@ export const putFeatureRevisionRuleV2 = createApiRequestHandler(
       );
     }
 
-    let resolvedRampAction = inlineRampSchedule
-      ? normalizeInlineRampSchedule(inlineRampSchedule, updatedRule.id)
-      : undefined;
+    let resolvedRampAction:
+      | ReturnType<typeof normalizeInlineRampSchedule>
+      | undefined;
+    if (inlineRampSchedule) {
+      resolvedRampAction = normalizeInlineRampSchedule(
+        inlineRampSchedule,
+        updatedRule.id,
+      );
+      updatedRule.scheduleRules = [];
+      updatedRule.scheduleType = "none";
+    }
     if (!resolvedRampAction && (schedule?.startDate || schedule?.endDate)) {
       if (usesLegacyScheduling) {
         updatedRule.scheduleRules = [
@@ -220,6 +228,8 @@ export const putFeatureRevisionRuleV2 = createApiRequestHandler(
         updatedRule.scheduleType = "schedule";
       } else {
         if (schedule.startDate) updatedRule.enabled = false;
+        updatedRule.scheduleRules = [];
+        updatedRule.scheduleType = "none";
         resolvedRampAction = buildScheduleRampAction(
           updatedRule.id,
           schedule.startDate,

--- a/packages/back-end/src/api/features/putFeatureRevisionRuleV2.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionRuleV2.ts
@@ -125,7 +125,7 @@ export const putFeatureRevisionRuleV2 = createApiRequestHandler(
       if (liveSchedules.length > 0) {
         throw new BadRequestError(
           `Rule "${req.params.ruleId}" already has a live ramp schedule.` +
-            ` Update it via PUT /api/v2/ramp-schedules/${liveSchedules[0].id}.`,
+            ` Update it via PUT /api/v1/ramp-schedules/${liveSchedules[0].id}.`,
         );
       }
     }
@@ -199,15 +199,20 @@ export const putFeatureRevisionRuleV2 = createApiRequestHandler(
     const newRules = flatRules.map((r, i) => (i === idx ? updatedRule : r));
     const changes: RevisionChanges = { rules: newRules };
 
+    const usesLegacyScheduling =
+      oldRule.type === "experiment-ref" || oldRule.type === "safe-rollout";
+
+    if (usesLegacyScheduling && inlineRampSchedule) {
+      throw new BadRequestError(
+        `rampSchedule is not supported for ${oldRule.type} rules. Use "schedule" instead.`,
+      );
+    }
+
     let resolvedRampAction = inlineRampSchedule
       ? normalizeInlineRampSchedule(inlineRampSchedule, updatedRule.id)
       : undefined;
     if (!resolvedRampAction && (schedule?.startDate || schedule?.endDate)) {
-      const hasLegacySchedule =
-        oldRule.scheduleType === "schedule" ||
-        (oldRule.scheduleRules?.some((r) => r.timestamp) &&
-          oldRule.scheduleType !== "ramp");
-      if (hasLegacySchedule) {
+      if (usesLegacyScheduling) {
         updatedRule.scheduleRules = [
           { enabled: true, timestamp: schedule.startDate ?? null },
           { enabled: false, timestamp: schedule.endDate ?? null },

--- a/packages/back-end/src/api/features/putFeatureRevisionRuleV2.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionRuleV2.ts
@@ -48,6 +48,12 @@ export const putFeatureRevisionRuleV2 = createApiRequestHandler(
   const inlineRampSchedule = req.body.rampSchedule;
   const patch = req.body.rule as RulePatchInputV2;
 
+  if (inlineRampSchedule && (schedule?.startDate || schedule?.endDate)) {
+    throw new BadRequestError(
+      "rampSchedule and schedule are mutually exclusive. Provide one or the other, not both.",
+    );
+  }
+
   const { revision, created } = await resolveOrCreateRevision(
     req.context,
     req.organization.id,

--- a/packages/back-end/src/api/features/putFeatureRevisionRuleV2.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionRuleV2.ts
@@ -122,7 +122,11 @@ export const putFeatureRevisionRuleV2 = createApiRequestHandler(
       Boolean(inlineRampSchedule) ||
       (!inlineRampSchedule &&
         (Boolean(schedule?.startDate) || Boolean(schedule?.endDate)));
-    if (wantsNewSchedule) {
+    if (
+      wantsNewSchedule &&
+      oldRule.type !== "experiment-ref" &&
+      oldRule.type !== "safe-rollout"
+    ) {
       const liveSchedules =
         await req.context.models.rampSchedules.findByTargetRule(
           req.params.ruleId,

--- a/packages/back-end/src/api/features/v2Shared.ts
+++ b/packages/back-end/src/api/features/v2Shared.ts
@@ -56,7 +56,6 @@ export function mapV2ApiRuleToFeatureRule(
       match: s.matchType,
       ids: s.savedGroups,
     })),
-    scheduleRules: ruleInput.scheduleRules,
     allEnvironments: resolvedAllEnvs,
     environments: resolvedEnvs,
   };

--- a/packages/back-end/src/api/features/validations.ts
+++ b/packages/back-end/src/api/features/validations.ts
@@ -31,17 +31,17 @@ type InlineRampScheduleInput = z.infer<typeof inlineRampScheduleInput>;
 function normalizeRevisionRampCreateAction(
   input: z.infer<typeof apiRevisionRampCreateAction>,
 ): RevisionRampCreateAction {
-  const endCondition: RevisionRampCreateAction["endCondition"] =
-    input.endCondition?.trigger
-      ? {
-          trigger: {
-            ...input.endCondition.trigger,
-            at: new Date(input.endCondition.trigger.at),
-          },
-        }
-      : input.endCondition
-        ? { trigger: undefined }
-        : undefined;
+  const endCondition: RevisionRampCreateAction["endCondition"] = input
+    .endCondition?.trigger
+    ? {
+        trigger: {
+          ...input.endCondition.trigger,
+          at: new Date(input.endCondition.trigger.at),
+        },
+      }
+    : input.endCondition
+      ? { trigger: undefined }
+      : undefined;
 
   return {
     ...input,

--- a/packages/back-end/src/api/features/validations.ts
+++ b/packages/back-end/src/api/features/validations.ts
@@ -31,10 +31,25 @@ type InlineRampScheduleInput = z.infer<typeof inlineRampScheduleInput>;
 function normalizeRevisionRampCreateAction(
   input: z.infer<typeof apiRevisionRampCreateAction>,
 ): RevisionRampCreateAction {
+  const endCondition: RevisionRampCreateAction["endCondition"] =
+    input.endCondition?.trigger
+      ? {
+          trigger: {
+            ...input.endCondition.trigger,
+            at: new Date(input.endCondition.trigger.at),
+          },
+        }
+      : input.endCondition
+        ? { trigger: undefined }
+        : undefined;
+
   return {
     ...input,
     steps: (input.steps ?? []).map((s) => ({
-      trigger: s.trigger,
+      trigger:
+        s.trigger.type === "scheduled"
+          ? { ...s.trigger, at: new Date(s.trigger.at) }
+          : s.trigger,
       actions: (s.actions ?? []).map((a) => ({
         targetType: a.targetType ?? ("feature-rule" as const),
         targetId: a.targetId ?? "",
@@ -49,6 +64,7 @@ function normalizeRevisionRampCreateAction(
       patch:
         a.patch as RevisionRampCreateAction["steps"][number]["actions"][number]["patch"],
     })),
+    endCondition,
   };
 }
 

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -2184,18 +2184,30 @@ export async function postFeatureRule(
   // experiment-ref rules
   if (rule.type === "experiment-ref" && feature.holdout?.id) {
     const experiment = await getExperimentById(context, rule.experimentId);
-    const expHasLinkedChanges =
-      (experiment?.linkedFeatures?.length ?? 0) > 0 ||
-      experiment?.hasURLRedirects ||
-      experiment?.hasVisualChangesets;
 
-    if (
-      experiment?.status !== "draft" ||
-      (experiment?.holdoutId && experiment.holdoutId !== feature.holdout.id) ||
-      expHasLinkedChanges
-    ) {
+    if (experiment?.status !== "draft") {
       throw new Error(
-        "Failed to create experiment rule. Experiment has linked changes, is not in draft status, or is not linked to the same holdout as the feature.",
+        `Cannot add experiment rule: this feature uses a holdout, so the experiment must be in "draft" status (currently "${experiment?.status ?? "unknown"}").`,
+      );
+    }
+    const expHasLinkedChanges =
+      (experiment.linkedFeatures?.length ?? 0) > 0 ||
+      experiment.hasURLRedirects ||
+      experiment.hasVisualChangesets;
+    if (expHasLinkedChanges) {
+      throw new Error(
+        `Cannot add experiment rule: this feature uses a holdout, but the experiment already has linked features, URL redirects, or visual changesets. Unlink them first.`,
+      );
+    }
+    if (experiment.holdoutId && experiment.holdoutId !== feature.holdout.id) {
+      const featureHoldout = await context.models.holdout.getById(
+        feature.holdout.id,
+      );
+      const expHoldout = experiment.holdoutId
+        ? await context.models.holdout.getById(experiment.holdoutId)
+        : null;
+      throw new Error(
+        `Cannot add experiment rule: experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}" but this feature uses holdout "${featureHoldout?.name || feature.holdout.id}".`,
       );
     }
 

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -1119,7 +1119,7 @@ export async function postFeatureReviewOrComment(
       : undefined;
     if (reviewSetting?.blockSelfApproval) {
       const isSelfApproval = (revision.contributors ?? []).some(
-        (c) => c != null && "id" in c && c.id === context.userId,
+        (id) => id === context.userId,
       );
       if (isSelfApproval) {
         throw new Error("You cannot approve a draft you contributed to.");

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -45,6 +45,27 @@ import { runValidateFeatureRevisionHooks } from "back-end/src/enterprise/sandbox
 
 export type ReviewSubmittedType = "Comment" | "Approved" | "Requested Changes";
 
+// Read-time migration: old docs stored contributors as EventUser objects;
+// new docs store plain user-ID strings. Normalize to string[] so callers
+// always see the current schema.
+function migrateContributors(
+  raw: unknown[] | undefined,
+): string[] | undefined {
+  if (!raw?.length) return raw as undefined;
+
+  const ids = new Set<string>();
+  for (const entry of raw) {
+    if (entry == null) continue;
+    if (typeof entry === "string") {
+      if (entry) ids.add(entry);
+    } else if (typeof entry === "object" && "id" in entry) {
+      const id = (entry as { id?: string }).id;
+      if (id) ids.add(id);
+    }
+  }
+  return ids.size > 0 ? [...ids] : undefined;
+}
+
 const featureRevisionSchema = new mongoose.Schema({
   organization: String,
   featureId: String,
@@ -183,6 +204,11 @@ export function buildFeatureRevisionInterface(
       applicableEnvs,
     });
   }
+
+  revision.contributors = migrateContributors(
+    revision.contributors as unknown as unknown[],
+  );
+
   return revision;
 }
 
@@ -279,7 +305,13 @@ export async function getMinimalRevisions(
     status: m.status,
     comment: m.comment || "",
     ...(m.title ? { title: m.title } : {}),
-    ...(m.contributors?.length ? { contributors: m.contributors } : {}),
+    ...(m.contributors?.length
+      ? {
+          contributors: migrateContributors(
+            m.contributors as unknown as unknown[],
+          ),
+        }
+      : {}),
   }));
 }
 
@@ -930,11 +962,13 @@ export async function updateRevision(
     original: revision,
   });
 
-  // Track contributors atomically using $addToSet (deep equality dedup).
-  // Using a separate operator from $set avoids the race condition where two
-  // concurrent edits both read the same stale contributors array.
+  // Track contributors as user ID strings via atomic $addToSet.
+  const contributorId =
+    log.user != null && "id" in log.user && log.user.id
+      ? log.user.id
+      : null;
   const contributorUpdate =
-    log.user != null ? { $addToSet: { contributors: log.user } } : {};
+    contributorId != null ? { $addToSet: { contributors: contributorId } } : {};
 
   const doc = await FeatureRevisionModel.findOneAndUpdate(
     {

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -48,9 +48,7 @@ export type ReviewSubmittedType = "Comment" | "Approved" | "Requested Changes";
 // Read-time migration: old docs stored contributors as EventUser objects;
 // new docs store plain user-ID strings. Normalize to string[] so callers
 // always see the current schema.
-function migrateContributors(
-  raw: unknown[] | undefined,
-): string[] | undefined {
+function migrateContributors(raw: unknown[] | undefined): string[] | undefined {
   if (!raw?.length) return raw as undefined;
 
   const ids = new Set<string>();
@@ -257,6 +255,7 @@ export async function countDocuments(
   if (involvedUserId) {
     filter.$or = [
       { "createdBy.id": involvedUserId },
+      { contributors: involvedUserId },
       { "contributors.id": involvedUserId },
     ];
   }
@@ -444,6 +443,7 @@ export async function getFeatureRevisionsByStatus({
   if (involvedUserId) {
     filter.$or = [
       { "createdBy.id": involvedUserId },
+      { contributors: involvedUserId },
       { "contributors.id": involvedUserId },
     ];
   }
@@ -476,6 +476,7 @@ export async function getLatestActiveDraftForFeature(
   if (involvedUserId) {
     filter.$or = [
       { "createdBy.id": involvedUserId },
+      { contributors: involvedUserId },
       { "contributors.id": involvedUserId },
     ];
   }
@@ -964,9 +965,7 @@ export async function updateRevision(
 
   // Track contributors as user ID strings via atomic $addToSet.
   const contributorId =
-    log.user != null && "id" in log.user && log.user.id
-      ? log.user.id
-      : null;
+    log.user != null && "id" in log.user && log.user.id ? log.user.id : null;
   const contributorUpdate =
     contributorId != null ? { $addToSet: { contributors: contributorId } } : {};
 

--- a/packages/back-end/src/scripts/generate-openapi.ts
+++ b/packages/back-end/src/scripts/generate-openapi.ts
@@ -220,6 +220,13 @@ function toOpenApiSchema(schema: z.ZodType): z.core.JSONSchema.BaseSchema {
       if (jsonSchema.maximum === 9007199254740991) {
         delete jsonSchema.maximum;
       }
+      // format: "date-time" is sufficient for docs; strip the verbose regex pattern
+      if (
+        (jsonSchema as Record<string, unknown>).format === "date-time" &&
+        (jsonSchema as Record<string, unknown>).pattern
+      ) {
+        delete (jsonSchema as Record<string, unknown>).pattern;
+      }
     },
   }) as Record<string, unknown>;
   if ($defs && typeof $defs === "object") {
@@ -753,9 +760,10 @@ curl https://api.growthbook.io/api/v1/features \
   for (const name of Object.keys(componentSchemas).sort()) {
     const tagName = `${name}_model`;
     modelTags.push(tagName);
+    const modelDisplayName = name.replace(/([a-z])([A-Z])/g, "$1 $2");
     openapiSpec.tags.push({
       name: tagName,
-      "x-displayName": name,
+      "x-displayName": modelDisplayName,
       description: `<SchemaDefinition schemaRef="#/components/schemas/${name}" />`,
     });
   }

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -1846,8 +1846,19 @@ export function normalizeRuleForApiV2(rule: FeatureRule): ApiFeatureRuleV2 {
 export function revisionToApiInterfaceV2(
   rev: FeatureRevisionInterface,
 ): z.infer<typeof apiFeatureRevisionV2Validator> {
+  const rampActionsByRuleId = new Map<string, "create" | "detach">();
+  for (const a of rev.rampActions ?? []) {
+    if (a.mode === "create" || a.mode === "detach") {
+      rampActionsByRuleId.set(a.ruleId, a.mode);
+    }
+  }
+
   const rules: ApiFeatureRuleV2[] = Array.isArray(rev.rules)
-    ? rev.rules.map(normalizeRuleForApiV2)
+    ? rev.rules.map((rule) => {
+        const base = normalizeRuleForApiV2(rule);
+        const pendingRamp = rampActionsByRuleId.get(rule.id);
+        return pendingRamp ? { ...base, pendingRamp } : base;
+      })
     : [];
 
   return {

--- a/packages/front-end/components/Features/CoAuthors.tsx
+++ b/packages/front-end/components/Features/CoAuthors.tsx
@@ -6,6 +6,7 @@ import {
   FeatureRevisionInterface,
   RevisionLog,
 } from "shared/types/feature-revision";
+import { useUser } from "@/services/UserContext";
 import EventUser from "@/components/Avatar/EventUser";
 
 // Actions that carry no content change — excluded when deriving co-authors from logs.
@@ -29,38 +30,31 @@ interface Props extends MarginProps {
 
 export default function CoAuthors({ rev, logs, ...marginProps }: Props) {
   const [open, setOpen] = useState(false);
+  const { users } = useUser();
 
   const createdById =
     rev.createdBy?.type === "dashboard" ? rev.createdBy.id : null;
 
-  const storedContributors = (rev.contributors ?? []).filter(
-    (c): c is NonNullable<typeof c> => c != null,
-  );
+  // contributors is now string[] (user IDs). For older revisions that lack
+  // the field, fall back to deriving from content-bearing log entries.
+  const storedIds = (rev.contributors ?? []).filter(Boolean);
 
-  const derivedContributors =
-    storedContributors.length === 0 && logs
+  const coAuthorIds =
+    storedIds.length === 0 && logs
       ? logs
           .filter(
             (l) =>
               !NON_CONTENT_ACTIONS.has(l.action) &&
-              l.user?.type === "dashboard",
+              l.user?.type === "dashboard" &&
+              l.user.id !== createdById,
           )
-          .map((l) => l.user!)
-          .filter(
-            (u, i, arr) =>
-              u.type === "dashboard" &&
-              arr.findIndex((x) => x.type === "dashboard" && x.id === u.id) ===
-                i,
-          )
-      : storedContributors;
+          .map((l) => (l.user as { id: string }).id)
+          .filter((id, i, arr) => arr.indexOf(id) === i)
+      : storedIds.filter((id) => id !== createdById);
 
-  const coAuthors = derivedContributors.filter(
-    (c) => !(c.type === "dashboard" && c.id === createdById),
-  );
+  if (coAuthorIds.length === 0) return null;
 
-  if (coAuthors.length === 0) return null;
-
-  const label = `Co-author${coAuthors.length > 1 ? "s" : ""} (${coAuthors.length})`;
+  const label = `Co-author${coAuthorIds.length > 1 ? "s" : ""} (${coAuthorIds.length})`;
 
   return (
     <Box {...marginProps}>
@@ -85,17 +79,23 @@ export default function CoAuthors({ rev, logs, ...marginProps }: Props) {
       </div>
       {open && (
         <Flex direction="column" gap="2" mt="2" ml="3">
-          {coAuthors.map((c) =>
-            c.type === "dashboard" || c.type === "api_key" ? (
+          {coAuthorIds.map((id) => {
+            const u = users.get(id);
+            return (
               <EventUser
-                user={c}
+                user={{
+                  type: "dashboard",
+                  id,
+                  name: u?.name || "",
+                  email: u?.email || "",
+                }}
                 display="avatar-name-email"
                 size="sm"
                 wrap={true}
-                key={c.type === "dashboard" ? c.id : c.apiKey}
+                key={id}
               />
-            ) : null,
-          )}
+            );
+          })}
         </Flex>
       )}
     </Box>

--- a/packages/front-end/components/Features/RequestReviewModal.tsx
+++ b/packages/front-end/components/Features/RequestReviewModal.tsx
@@ -86,7 +86,7 @@ export default function RequestReviewModal({
 
   const { apiCall } = useAuth();
   const user = getCurrentUser();
-  const { organization } = useUser();
+  const { organization, users } = useUser();
   const permissionsUtil = usePermissionsUtil();
   const canAdminPublish = permissionsUtil.canBypassApprovalChecks(feature);
   const revision = revisions.find((r) => r.version === version);
@@ -103,9 +103,7 @@ export default function RequestReviewModal({
     : undefined;
   const isBlockedContributor =
     reviewSetting?.blockSelfApproval &&
-    (revision?.contributors ?? []).some(
-      (c) => c != null && "id" in c && c.id === user?.id,
-    );
+    (revision?.contributors ?? []).some((id) => id === user?.id);
   const canReview =
     isPendingReview &&
     createdBy?.id !== user?.id &&
@@ -496,34 +494,23 @@ export default function RequestReviewModal({
               <div className="mb-3">
                 <strong style={{ fontSize: "0.85rem" }}>Contributors</strong>
                 <Flex align="center" gap="2" wrap="wrap" mt="1">
-                  {[revision.createdBy, ...revision.contributors]
-                    .filter(
-                      (u): u is EventUserLoggedIn | EventUserApiKey =>
-                        u != null &&
-                        (u.type === "dashboard" || u.type === "api_key"),
-                    )
-                    .filter(
-                      (u, idx, arr) =>
-                        arr.findIndex(
-                          (x) => "id" in x && "id" in u && x.id === u.id,
-                        ) === idx,
-                    )
-                    .map((lu) => {
-                      return (
-                        <Flex
-                          key={"id" in lu ? lu.id : lu.apiKey}
-                          align="center"
-                          gap="1"
-                          wrap="wrap"
-                        >
-                          <EventUser
-                            user={lu}
-                            display="avatar-name-email"
-                            size="sm"
-                          />
-                        </Flex>
-                      );
-                    })}
+                  {revision.contributors.map((id) => {
+                    const u = users.get(id);
+                    return (
+                      <Flex key={id} align="center" gap="1" wrap="wrap">
+                        <EventUser
+                          user={{
+                            type: "dashboard",
+                            id,
+                            name: u?.name || "",
+                            email: u?.email || "",
+                          }}
+                          display="avatar-name-email"
+                          size="sm"
+                        />
+                      </Flex>
+                    );
+                  })}
                 </Flex>
               </div>
             )}

--- a/packages/front-end/components/Features/RequestReviewModal.tsx
+++ b/packages/front-end/components/Features/RequestReviewModal.tsx
@@ -490,30 +490,47 @@ export default function RequestReviewModal({
         {mergeResult.success && hasChanges && (
           <div>
             <div className="mb-2">{showRevisionStatus()}</div>
-            {revision.contributors && revision.contributors.length > 0 && (
-              <div className="mb-3">
-                <strong style={{ fontSize: "0.85rem" }}>Contributors</strong>
-                <Flex align="center" gap="2" wrap="wrap" mt="1">
-                  {revision.contributors.map((id) => {
-                    const u = users.get(id);
-                    return (
-                      <Flex key={id} align="center" gap="1" wrap="wrap">
-                        <EventUser
-                          user={{
-                            type: "dashboard",
-                            id,
-                            name: u?.name || "",
-                            email: u?.email || "",
-                          }}
-                          display="avatar-name-email"
-                          size="sm"
-                        />
-                      </Flex>
-                    );
-                  })}
-                </Flex>
-              </div>
-            )}
+            {(() => {
+              const authorId =
+                revision.createdBy &&
+                "id" in revision.createdBy &&
+                revision.createdBy.id
+                  ? revision.createdBy.id
+                  : undefined;
+              const contribIds = revision.contributors ?? [];
+              const allIds =
+                authorId && !contribIds.includes(authorId)
+                  ? [authorId, ...contribIds]
+                  : contribIds;
+              return (
+                allIds.length > 0 && (
+                  <div className="mb-3">
+                    <strong style={{ fontSize: "0.85rem" }}>
+                      Contributors
+                    </strong>
+                    <Flex align="center" gap="2" wrap="wrap" mt="1">
+                      {allIds.map((id) => {
+                        const u = users.get(id);
+                        return (
+                          <Flex key={id} align="center" gap="1" wrap="wrap">
+                            <EventUser
+                              user={{
+                                type: "dashboard",
+                                id,
+                                name: u?.name || "",
+                                email: u?.email || "",
+                              }}
+                              display="avatar-name-email"
+                              size="sm"
+                            />
+                          </Flex>
+                        );
+                      })}
+                    </Flex>
+                  </div>
+                )
+              );
+            })()}
             {canAdminPublish && (
               <div className="mt-3 mb-4 ml-1">
                 <Checkbox

--- a/packages/front-end/components/Features/Rule.tsx
+++ b/packages/front-end/components/Features/Rule.tsx
@@ -143,7 +143,7 @@ function computeRemainingTime(
 
   const currentIsApproval =
     rs.currentStepIndex >= 0 &&
-    rs.steps[rs.currentStepIndex]?.trigger.type === "approval";
+    rs.steps[rs.currentStepIndex]?.trigger?.type === "approval";
   const nextIdx =
     rs.status === "pending-approval" ||
     (rs.status === "paused" && currentIsApproval)
@@ -151,11 +151,11 @@ function computeRemainingTime(
       : rs.currentStepIndex + 1; // works for -1 → 0
   for (let i = nextIdx; i < rs.steps.length; i++) {
     const trigger = rs.steps[i].trigger;
-    if (trigger.type === "interval") {
+    if (trigger?.type === "interval") {
       seconds += trigger.seconds;
-    } else if (trigger.type === "approval") {
+    } else if (trigger?.type === "approval") {
       manualApprovals++;
-    } else if (trigger.type === "scheduled") {
+    } else if (trigger?.type === "scheduled") {
       seconds += Math.max(0, (new Date(trigger.at).getTime() - now) / 1000);
     }
   }

--- a/packages/front-end/components/RampSchedule/RampTimeline.tsx
+++ b/packages/front-end/components/RampSchedule/RampTimeline.tsx
@@ -21,9 +21,10 @@ import styles from "./RampTimeline.module.scss";
 // ─── helpers ────────────────────────────────────────────────────────────────
 
 export function formatTrigger(trigger: RampTrigger): ReactNode {
-  if (trigger.type === "approval") return <Text size="small">approval</Text>;
-  if (trigger.type === "scheduled") return formatScheduledDate(trigger.at);
-  const s = trigger.seconds;
+  if (trigger?.type === "approval") return <Text size="small">approval</Text>;
+  if (trigger?.type === "scheduled") return formatScheduledDate(trigger?.at);
+  const s = trigger?.seconds;
+  if (!s) return null;
   let duration: string;
   if (s < 60) duration = `${s}s`;
   else {

--- a/packages/front-end/hooks/useFeaturePageData.ts
+++ b/packages/front-end/hooks/useFeaturePageData.ts
@@ -306,7 +306,7 @@ export function useFeaturePageData(
     const isMine = (r: MinimalFeatureRevisionInterface) =>
       !!userId &&
       (r.createdBy?.id === userId ||
-        r.contributors?.some((c) => c?.id === userId));
+        r.contributors?.some((id) => id === userId));
 
     const drafts = data?.revisionList?.filter(isActiveDraft) ?? [];
     const myDraft = drafts.find(isMine) ?? null;

--- a/packages/shared/src/validators/feature-revisions-v2.ts
+++ b/packages/shared/src/validators/feature-revisions-v2.ts
@@ -33,13 +33,13 @@ const newDraftMetadataFields = {
     .string()
     .optional()
     .describe(
-      "Title for a newly created draft. Only used when version is \"new\"; ignored for existing revisions.",
+      'Title for a newly created draft. Only used when version is "new"; ignored for existing revisions.',
     ),
   revisionComment: z
     .string()
     .optional()
     .describe(
-      "Comment for a newly created draft. Only used when version is \"new\"; ignored for existing revisions.",
+      'Comment for a newly created draft. Only used when version is "new"; ignored for existing revisions.',
     ),
 };
 
@@ -99,13 +99,17 @@ const scheduleShorthand = z
       .datetime({ offset: true })
       .optional()
       .nullable()
-      .describe('ISO 8601 date-time, e.g. "2025-06-01T00:00:00Z". Rule is enabled at this time.'),
+      .describe(
+        'ISO 8601 date-time, e.g. "2025-06-01T00:00:00Z". Rule is enabled at this time.',
+      ),
     endDate: z
       .string()
       .datetime({ offset: true })
       .optional()
       .nullable()
-      .describe('ISO 8601 date-time, e.g. "2025-07-01T00:00:00Z". Rule is disabled at this time.'),
+      .describe(
+        'ISO 8601 date-time, e.g. "2025-07-01T00:00:00Z". Rule is disabled at this time.',
+      ),
   })
   .strict();
 
@@ -141,8 +145,9 @@ const targetingRuleCreateInputV2 = namedSchema(
       ...ruleScopeInput,
       type: z
         .enum(["force", "rollout"])
+        .optional()
         .describe(
-          "Use \"force\" for a standard targeting rule, or \"rollout\" for a percentage rollout (coverage < 1). Both are functionally equivalent; a force rule with coverage < 1 behaves as a rollout.",
+          'Use "force" for a standard targeting rule, or "rollout" for a percentage rollout (coverage < 1). Defaults to "force". Both are functionally equivalent; a force rule with coverage < 1 behaves as a rollout.',
         ),
       value: z.string().describe("The value to serve when this rule matches."),
       coverage: z
@@ -156,7 +161,9 @@ const targetingRuleCreateInputV2 = namedSchema(
       hashAttribute: z
         .string()
         .optional()
-        .describe("Attribute to hash on for consistent assignment. Required when coverage < 1."),
+        .describe(
+          "Attribute to hash on for consistent assignment. Required when coverage < 1.",
+        ),
       seed: z.string().optional(),
     })
     .strict()
@@ -173,7 +180,7 @@ const experimentRefCreateInputV2 = namedSchema(
       ...ruleScopeInput,
       type: z
         .literal("experiment-ref")
-        .describe("Must be \"experiment-ref\" for an experiment rule."),
+        .describe('Must be "experiment-ref" for an experiment rule.'),
       experimentId: z.string().describe("ID of the linked experiment."),
       variations: z.array(
         z
@@ -195,7 +202,7 @@ const safeRolloutCreateInputV2 = namedSchema(
       ...ruleScopeInput,
       type: z
         .literal("safe-rollout")
-        .describe("Must be \"safe-rollout\" for a safe rollout rule."),
+        .describe('Must be "safe-rollout" for a safe rollout rule.'),
       controlValue: z.string(),
       variationValue: z.string(),
       hashAttribute: z.string(),
@@ -217,9 +224,7 @@ const safeRolloutCreateInputV2 = namedSchema(
             .object({
               enabled: z.boolean(),
               steps: z
-                .array(
-                  z.object({ percent: z.number().min(0).max(1) }).strict(),
-                )
+                .array(z.object({ percent: z.number().min(0).max(1) }).strict())
                 .min(1)
                 .optional(),
             })
@@ -564,7 +569,7 @@ export const postFeatureRevisionRuleAddV2Validator = {
   operationId: "postFeatureRevisionRuleAddV2",
   summary: "Add a rule to a draft revision",
   description:
-    "Appends a new rule to the revision's rule list. Supply `allEnvironments: true` on the rule to target all environments, or `environments: [...]` to scope to specific ones.\n\n**Scheduling:** For `force` and `rollout` rules, attach a schedule via `rampSchedule` (multi-step ramp) or `schedule` (simple start/end window) — these create standalone ramp actions and set `pendingRamp: \"create\"` on the rule. For `experiment-ref` and `safe-rollout` rules, only `schedule` is supported and is stored as legacy schedule fields on the rule itself (`rampSchedule` is not available for these rule types).",
+    'Appends a new rule to the revision\'s rule list. Supply `allEnvironments: true` on the rule to target all environments, or `environments: [...]` to scope to specific ones.\n\n**Scheduling:** For `force` and `rollout` rules, attach a schedule via `rampSchedule` (multi-step ramp) or `schedule` (simple start/end window) — these create standalone ramp actions and set `pendingRamp: "create"` on the rule. For `experiment-ref` and `safe-rollout` rules, only `schedule` is supported and is stored as legacy schedule fields on the rule itself (`rampSchedule` is not available for these rule types).',
   tags: ["feature-revisions-v2"],
   paramsSchema: revisionParams,
   bodySchema: z
@@ -614,7 +619,7 @@ export const putFeatureRevisionRuleV2Validator = {
   operationId: "putFeatureRevisionRuleV2",
   summary: "Update a rule in a draft revision",
   description:
-    "Patches fields on an existing rule (identified by `ruleId`). The rule `type` cannot be changed. Scope can be updated via `allEnvironments` / `environments` patch fields.\n\n**Scheduling:** For `force` and `rollout` rules, update the schedule via `rampSchedule` (multi-step ramp) or `schedule` (simple start/end window) — these manage standalone ramp actions and set `pendingRamp: \"create\"` on the rule. For `experiment-ref` and `safe-rollout` rules, only `schedule` is supported and updates legacy schedule fields on the rule itself (`rampSchedule` is not available for these rule types).",
+    'Patches fields on an existing rule (identified by `ruleId`). The rule `type` cannot be changed. Scope can be updated via `allEnvironments` / `environments` patch fields.\n\n**Scheduling:** For `force` and `rollout` rules, update the schedule via `rampSchedule` (multi-step ramp) or `schedule` (simple start/end window) — these manage standalone ramp actions and set `pendingRamp: "create"` on the rule. For `experiment-ref` and `safe-rollout` rules, only `schedule` is supported and updates legacy schedule fields on the rule itself (`rampSchedule` is not available for these rule types).',
   tags: ["feature-revisions-v2"],
   paramsSchema: ruleParams,
   bodySchema: z
@@ -659,7 +664,7 @@ export const putFeatureRevisionRuleRampScheduleV2Validator = {
   operationId: "putFeatureRevisionRuleRampScheduleV2",
   summary: "Set ramp schedule for a rule",
   description:
-    "Creates or replaces the pending ramp schedule for a rule. The rule will show `pendingRamp: \"create\"` in subsequent GET responses. The ramp is created when the revision is published. If the rule already has a live ramp schedule, this endpoint returns an error — update the live schedule via `PUT /api/v1/ramp-schedules/{id}` instead.",
+    'Creates or replaces the pending ramp schedule for a rule. The rule will show `pendingRamp: "create"` in subsequent GET responses. The ramp is created when the revision is published. If the rule already has a live ramp schedule, this endpoint returns an error — update the live schedule via `PUT /api/v1/ramp-schedules/{id}` instead.',
   tags: ["feature-revisions-v2"],
   paramsSchema: ruleParams,
   bodySchema: standaloneRampScheduleInput.extend(newDraftMetadataFields),
@@ -674,7 +679,7 @@ export const deleteFeatureRevisionRuleRampScheduleV2Validator = {
   operationId: "deleteFeatureRevisionRuleRampScheduleV2",
   summary: "Remove ramp schedule from a rule",
   description:
-    "Clears any pending ramp action for this rule. If a live ramp schedule exists, queues a detach that removes it on publish — the rule will show `pendingRamp: \"detach\"`. If only a pending create exists, it is removed and `pendingRamp` is cleared.",
+    'Clears any pending ramp action for this rule. If a live ramp schedule exists, queues a detach that removes it on publish — the rule will show `pendingRamp: "detach"`. If only a pending create exists, it is removed and `pendingRamp` is cleared.',
   tags: ["feature-revisions-v2"],
   paramsSchema: ruleParams,
   bodySchema: z

--- a/packages/shared/src/validators/feature-revisions-v2.ts
+++ b/packages/shared/src/validators/feature-revisions-v2.ts
@@ -14,6 +14,7 @@ import {
 import { apiFeatureRevisionV2Validator } from "./features-v2";
 import { JSONSchemaDef, revisionStatusSchema } from "./features";
 import { ownerInputField } from "./owner-field";
+import { namedSchema } from "./openapi-helpers";
 
 // ---- Shared param schemas ----
 
@@ -28,8 +29,18 @@ const ruleParams = revisionParams.extend({ ruleId: z.string() });
 // Optional metadata applied when an endpoint auto-creates a draft via
 // `version: "new"`. Ignored when editing an existing revision.
 const newDraftMetadataFields = {
-  revisionTitle: z.string().optional(),
-  revisionComment: z.string().optional(),
+  revisionTitle: z
+    .string()
+    .optional()
+    .describe(
+      "Title for a newly created draft. Only used when version is \"new\"; ignored for existing revisions.",
+    ),
+  revisionComment: z
+    .string()
+    .optional()
+    .describe(
+      "Comment for a newly created draft. Only used when version is \"new\"; ignored for existing revisions.",
+    ),
 };
 
 // ---- Shared response schemas ----
@@ -81,14 +92,20 @@ const mergeResultChangesSchema = z
 
 // ---- V2 Rule input schemas ----
 
-const scheduleRuleInput = z
-  .object({ timestamp: z.string().nullable(), enabled: z.boolean() })
-  .strict();
-
 const scheduleShorthand = z
   .object({
-    startDate: z.string().optional().nullable(),
-    endDate: z.string().optional().nullable(),
+    startDate: z
+      .string()
+      .datetime({ offset: true })
+      .optional()
+      .nullable()
+      .describe('ISO 8601 date-time, e.g. "2025-06-01T00:00:00Z". Rule is enabled at this time.'),
+    endDate: z
+      .string()
+      .datetime({ offset: true })
+      .optional()
+      .nullable()
+      .describe('ISO 8601 date-time, e.g. "2025-07-01T00:00:00Z". Rule is disabled at this time.'),
   })
   .strict();
 
@@ -98,8 +115,6 @@ const commonRuleFields = {
   condition: z.string().optional(),
   savedGroups: z.array(savedGroupTargeting).optional(),
   prerequisites: z.array(featurePrerequisite).optional(),
-  scheduleRules: z.array(scheduleRuleInput).optional(),
-  scheduleType: z.enum(["none", "schedule", "ramp"]).optional(),
 };
 
 // Scope fields for v2 — no `environment` needed; each rule carries its own.
@@ -118,73 +133,111 @@ const ruleScopeInput = {
     ),
 };
 
-const forceRolloutCreateInputV2 = z
-  .object({
-    ...commonRuleFields,
-    ...ruleScopeInput,
-    type: z.enum(["force", "rollout"]).optional(),
-    value: z.string(),
-    coverage: z.number().min(0).max(1).optional(),
-    hashAttribute: z.string().optional(),
-    seed: z.string().optional(),
-  })
-  .strict();
-
-const experimentRefCreateInputV2 = z
-  .object({
-    ...commonRuleFields,
-    ...ruleScopeInput,
-    type: z.literal("experiment-ref"),
-    experimentId: z.string(),
-    variations: z.array(
-      z
-        .object({ variationId: z.string().optional(), value: z.string() })
-        .strict(),
+const targetingRuleCreateInputV2 = namedSchema(
+  "Targeting Rule",
+  z
+    .object({
+      ...commonRuleFields,
+      ...ruleScopeInput,
+      type: z
+        .enum(["force", "rollout"])
+        .describe(
+          "Use \"force\" for a standard targeting rule, or \"rollout\" for a percentage rollout (coverage < 1). Both are functionally equivalent; a force rule with coverage < 1 behaves as a rollout.",
+        ),
+      value: z.string().describe("The value to serve when this rule matches."),
+      coverage: z
+        .number()
+        .min(0)
+        .max(1)
+        .optional()
+        .describe(
+          "Percentage of users to include (0–1). Defaults to 1. When less than 1, hashAttribute is required.",
+        ),
+      hashAttribute: z
+        .string()
+        .optional()
+        .describe("Attribute to hash on for consistent assignment. Required when coverage < 1."),
+      seed: z.string().optional(),
+    })
+    .strict()
+    .describe(
+      "A targeting rule that serves a specific value to users matching the conditions. Set coverage < 1 for a percentage rollout.",
     ),
-  })
-  .strict();
+);
 
-const safeRolloutCreateInputV2 = z
-  .object({
-    ...commonRuleFields,
-    ...ruleScopeInput,
-    type: z.literal("safe-rollout"),
-    controlValue: z.string(),
-    variationValue: z.string(),
-    hashAttribute: z.string(),
-    trackingKey: z.string().optional(),
-    seed: z.string().optional(),
-    safeRolloutFields: z
-      .object({
-        datasourceId: z.string(),
-        exposureQueryId: z.string(),
-        guardrailMetricIds: z.array(z.string()),
-        maxDuration: z
-          .object({
-            amount: z.number().positive(),
-            unit: z.enum(["weeks", "days", "hours", "minutes"]),
-          })
+const experimentRefCreateInputV2 = namedSchema(
+  "Experiment Rule",
+  z
+    .object({
+      ...commonRuleFields,
+      ...ruleScopeInput,
+      type: z
+        .literal("experiment-ref")
+        .describe("Must be \"experiment-ref\" for an experiment rule."),
+      experimentId: z.string().describe("ID of the linked experiment."),
+      variations: z.array(
+        z
+          .object({ variationId: z.string().optional(), value: z.string() })
           .strict(),
-        autoRollback: z.boolean().optional(),
-        rampUpSchedule: z
-          .object({
-            enabled: z.boolean(),
-            steps: z
-              .array(z.object({ percent: z.number().min(0).max(1) }).strict())
-              .min(1)
-              .optional(),
-          })
-          .strict()
-          .optional(),
-      })
-      .strict(),
-  })
-  .strict();
+      ),
+    })
+    .strict()
+    .describe(
+      "An experiment rule that links a feature value to an existing experiment.",
+    ),
+);
+
+const safeRolloutCreateInputV2 = namedSchema(
+  "Safe Rollout Rule",
+  z
+    .object({
+      ...commonRuleFields,
+      ...ruleScopeInput,
+      type: z
+        .literal("safe-rollout")
+        .describe("Must be \"safe-rollout\" for a safe rollout rule."),
+      controlValue: z.string(),
+      variationValue: z.string(),
+      hashAttribute: z.string(),
+      trackingKey: z.string().optional(),
+      seed: z.string().optional(),
+      safeRolloutFields: z
+        .object({
+          datasourceId: z.string(),
+          exposureQueryId: z.string(),
+          guardrailMetricIds: z.array(z.string()),
+          maxDuration: z
+            .object({
+              amount: z.number().positive(),
+              unit: z.enum(["weeks", "days", "hours", "minutes"]),
+            })
+            .strict(),
+          autoRollback: z.boolean().optional(),
+          rampUpSchedule: z
+            .object({
+              enabled: z.boolean(),
+              steps: z
+                .array(
+                  z.object({ percent: z.number().min(0).max(1) }).strict(),
+                )
+                .min(1)
+                .optional(),
+            })
+            .strict()
+            .optional(),
+        })
+        .strict(),
+    })
+    .strict()
+    .describe(
+      "A safe rollout rule with automated guardrail monitoring and optional auto-rollback.",
+    ),
+);
 
 const ruleCreateInputV2 = z.union([
+  targetingRuleCreateInputV2,
   experimentRefCreateInputV2,
   safeRolloutCreateInputV2,
-  forceRolloutCreateInputV2,
 ]);
 
 export type RuleCreateInputV2 = z.infer<typeof ruleCreateInputV2>;
@@ -196,8 +249,6 @@ const rulePatchSchemaV2 = z
     condition: z.string().optional(),
     savedGroups: z.array(savedGroupTargeting).optional(),
     prerequisites: z.array(featurePrerequisite).optional(),
-    scheduleRules: z.array(scheduleRuleInput).nullable().optional(),
-    scheduleType: z.enum(["none", "schedule", "ramp"]).nullable().optional(),
     type: z
       .enum(["force", "rollout", "experiment-ref", "safe-rollout"])
       .optional(),
@@ -293,7 +344,7 @@ export const postFeatureRevisionPublishV2Validator = {
   operationId: "postFeatureRevisionPublishV2",
   summary: "Publish a draft revision",
   description:
-    "Immediately publishes a draft revision, making it the live version of the feature.",
+    "Immediately publishes a draft revision, making it the live version of the feature. Any pending ramp actions (`pendingRamp` on rules) are executed atomically — ramp schedules are created or detached as queued.",
   tags: ["feature-revisions-v2"],
   paramsSchema: revisionParamsStrict,
   bodySchema: z.object({ comment: z.string().optional() }).strict(),
@@ -513,14 +564,22 @@ export const postFeatureRevisionRuleAddV2Validator = {
   operationId: "postFeatureRevisionRuleAddV2",
   summary: "Add a rule to a draft revision",
   description:
-    "Appends a new rule to the revision's rule list. Supply `allEnvironments: true` to target all environments, or `environments: [...]` to scope to specific ones. Use `rampSchedule` for ramp configuration or `schedule` for a simple start/end window.",
+    "Appends a new rule to the revision's rule list. Supply `allEnvironments: true` on the rule to target all environments, or `environments: [...]` to scope to specific ones.\n\n**Scheduling:** For `force` and `rollout` rules, attach a schedule via `rampSchedule` (multi-step ramp) or `schedule` (simple start/end window) — these create standalone ramp actions and set `pendingRamp: \"create\"` on the rule. For `experiment-ref` and `safe-rollout` rules, only `schedule` is supported and is stored as legacy schedule fields on the rule itself (`rampSchedule` is not available for these rule types).",
   tags: ["feature-revisions-v2"],
   paramsSchema: revisionParams,
   bodySchema: z
     .object({
       rule: ruleCreateInputV2,
-      rampSchedule: inlineRampScheduleInput.optional(),
-      schedule: scheduleShorthand.optional(),
+      rampSchedule: inlineRampScheduleInput
+        .optional()
+        .describe(
+          "Multi-step ramp schedule for force/rollout rules. Not supported for experiment-ref or safe-rollout rules. Mutually exclusive with `schedule`.",
+        ),
+      schedule: scheduleShorthand
+        .optional()
+        .describe(
+          "Simple start/end date window. For force/rollout rules this creates a standalone ramp action; for experiment-ref/safe-rollout rules this sets legacy schedule fields on the rule. Mutually exclusive with `rampSchedule`.",
+        ),
       ...newDraftMetadataFields,
     })
     .strict(),
@@ -555,14 +614,22 @@ export const putFeatureRevisionRuleV2Validator = {
   operationId: "putFeatureRevisionRuleV2",
   summary: "Update a rule in a draft revision",
   description:
-    "Patches fields on an existing rule (identified by `ruleId`). The rule `type` cannot be changed. Scope can be updated via `allEnvironments` / `environments` patch fields.",
+    "Patches fields on an existing rule (identified by `ruleId`). The rule `type` cannot be changed. Scope can be updated via `allEnvironments` / `environments` patch fields.\n\n**Scheduling:** For `force` and `rollout` rules, update the schedule via `rampSchedule` (multi-step ramp) or `schedule` (simple start/end window) — these manage standalone ramp actions and set `pendingRamp: \"create\"` on the rule. For `experiment-ref` and `safe-rollout` rules, only `schedule` is supported and updates legacy schedule fields on the rule itself (`rampSchedule` is not available for these rule types).",
   tags: ["feature-revisions-v2"],
   paramsSchema: ruleParams,
   bodySchema: z
     .object({
       rule: rulePatchSchemaV2,
-      rampSchedule: inlineRampScheduleInput.optional(),
-      schedule: scheduleShorthand.optional(),
+      rampSchedule: inlineRampScheduleInput
+        .optional()
+        .describe(
+          "Multi-step ramp schedule for force/rollout rules. Not supported for experiment-ref or safe-rollout rules. Mutually exclusive with `schedule`.",
+        ),
+      schedule: scheduleShorthand
+        .optional()
+        .describe(
+          "Simple start/end date window. For force/rollout rules this manages a standalone ramp action; for experiment-ref/safe-rollout rules this updates legacy schedule fields on the rule. Mutually exclusive with `rampSchedule`.",
+        ),
       ...newDraftMetadataFields,
     })
     .strict(),
@@ -591,6 +658,8 @@ export const putFeatureRevisionRuleRampScheduleV2Validator = {
   path: "/features/:id/revisions/:version/rules/:ruleId/ramp-schedule",
   operationId: "putFeatureRevisionRuleRampScheduleV2",
   summary: "Set ramp schedule for a rule",
+  description:
+    "Creates or replaces the pending ramp schedule for a rule. The rule will show `pendingRamp: \"create\"` in subsequent GET responses. The ramp is created when the revision is published. If the rule already has a live ramp schedule, this endpoint returns an error — update the live schedule via `PUT /api/v1/ramp-schedules/{id}` instead.",
   tags: ["feature-revisions-v2"],
   paramsSchema: ruleParams,
   bodySchema: standaloneRampScheduleInput.extend(newDraftMetadataFields),
@@ -604,6 +673,8 @@ export const deleteFeatureRevisionRuleRampScheduleV2Validator = {
   path: "/features/:id/revisions/:version/rules/:ruleId/ramp-schedule",
   operationId: "deleteFeatureRevisionRuleRampScheduleV2",
   summary: "Remove ramp schedule from a rule",
+  description:
+    "Clears any pending ramp action for this rule. If a live ramp schedule exists, queues a detach that removes it on publish — the rule will show `pendingRamp: \"detach\"`. If only a pending create exists, it is removed and `pendingRamp` is cleared.",
   tags: ["feature-revisions-v2"],
   paramsSchema: ruleParams,
   bodySchema: z
@@ -618,11 +689,11 @@ export const deleteFeatureRevisionRuleRampScheduleV2Validator = {
 
 export const listRevisionsV2Validator = {
   method: "get" as const,
-  path: "/revisions",
+  path: "/feature-revisions",
   operationId: "listRevisionsV2",
-  summary: "List feature revisions",
+  summary: "List revisions across all features",
   description:
-    "Returns a paginated list of feature revisions across all features in the organization. Revision `rules` is a flat array with per-rule scope.",
+    "Returns a paginated list of feature revisions across all features in the organization. Use the `featureId` query parameter to filter to a single feature. Revision `rules` is a flat array with per-rule scope.",
   tags: ["feature-revisions-v2"],
   paramsSchema: z.never(),
   bodySchema: z.never(),

--- a/packages/shared/src/validators/features-v2.ts
+++ b/packages/shared/src/validators/features-v2.ts
@@ -29,6 +29,12 @@ const apiRuleScopeExtension = z
       .describe(
         "The environment IDs this rule is active in. Populated when `allEnvironments` is false.",
       ),
+    pendingRamp: z
+      .enum(["create", "detach"])
+      .optional()
+      .describe(
+        'Present on draft revisions only. "create" means a ramp schedule will be created for this rule on publish. "detach" means an existing live ramp schedule will be removed on publish. Use PUT/DELETE .../rules/{ruleId}/ramp-schedule to modify.',
+      ),
   })
   .strict();
 
@@ -236,7 +242,11 @@ const postFeaturePrerequisite = z.object({
 });
 
 const apiScheduleRule = z.object({
-  timestamp: z.string().nullable(),
+  timestamp: z
+    .string()
+    .datetime({ offset: true })
+    .nullable()
+    .describe('ISO 8601 date-time, e.g. "2025-06-01T00:00:00Z".'),
   enabled: z.boolean(),
 });
 

--- a/packages/shared/src/validators/features.ts
+++ b/packages/shared/src/validators/features.ts
@@ -13,10 +13,11 @@ import { safeRolloutStatusArray } from "./safe-rollout";
 import { ownerEmailField, ownerField, ownerInputField } from "./owner-field";
 import {
   featureRulePatch,
-  rampTrigger,
   rampStep,
   rampStepAction,
   rampEndTrigger,
+  apiRampTrigger,
+  apiRampEndTrigger,
 } from "./ramp-schedule";
 
 import { namedSchema } from "./openapi-helpers";
@@ -297,7 +298,7 @@ const minimalFeatureRevisionInterface = z
     status: revisionStatusSchema,
     comment: z.string(),
     title: z.string().optional(),
-    contributors: z.array(eventUser).optional(),
+    contributors: z.array(z.string()).optional(),
   })
   .strict();
 
@@ -334,7 +335,7 @@ const revisionApiRampStepAction = z.object({
 });
 
 const revisionApiRampStep = z.object({
-  trigger: rampTrigger,
+  trigger: apiRampTrigger,
   actions: z.array(revisionApiRampStepAction).optional(),
   approvalNotes: z.string().nullish(),
 });
@@ -365,6 +366,15 @@ export const revisionRampCreateAction = z.object({
 export const apiRevisionRampCreateAction = revisionRampCreateAction.extend({
   steps: z.array(revisionApiRampStep).optional(),
   endActions: z.array(revisionApiRampStepAction).optional(),
+  startDate: z
+    .string()
+    .datetime({ offset: true })
+    .optional()
+    .nullable()
+    .describe(
+      'ISO 8601 date-time, e.g. "2025-06-01T00:00:00Z". Absent or null means start immediately on publish.',
+    ),
+  endCondition: z.object({ trigger: apiRampEndTrigger.optional() }).optional(),
 });
 
 export const revisionRampDetachAction = z.object({
@@ -413,9 +423,9 @@ const featureRevisionInterface = minimalFeatureRevisionInterface
     // are NOT stored here — they operate directly on live ramp schedule documents.
     rampActions: z.array(revisionRampAction).optional(),
     log: z.array(revisionLog).optional(), // This is deprecated in favor of using FeatureRevisionLog due to it being too large
-    // Users (beyond the original author) who have made edits to this draft.
+    // User IDs who have made edits to this draft (always includes the author).
     // Populated incrementally via updateRevision; used for the self-approval block.
-    contributors: z.array(eventUser).optional(),
+    contributors: z.array(z.string()).optional(),
   })
   .strict();
 

--- a/packages/shared/src/validators/features.ts
+++ b/packages/shared/src/validators/features.ts
@@ -423,8 +423,9 @@ const featureRevisionInterface = minimalFeatureRevisionInterface
     // are NOT stored here — they operate directly on live ramp schedule documents.
     rampActions: z.array(revisionRampAction).optional(),
     log: z.array(revisionLog).optional(), // This is deprecated in favor of using FeatureRevisionLog due to it being too large
-    // User IDs who have made edits to this draft (always includes the author).
-    // Populated incrementally via updateRevision; used for the self-approval block.
+    // User IDs who have made edits to this draft. Populated incrementally via
+    // updateRevision's $addToSet; may be empty if no content edits have been made.
+    // Note: the revision author (createdBy) is NOT automatically seeded here.
     contributors: z.array(z.string()).optional(),
   })
   .strict();

--- a/packages/shared/src/validators/ramp-schedule.ts
+++ b/packages/shared/src/validators/ramp-schedule.ts
@@ -190,12 +190,28 @@ export type RampScheduleTemplateInterface = z.infer<
   typeof rampScheduleTemplateValidator
 >;
 
-// API-facing step schema — identical to the DB variant except scheduled trigger uses
-// an ISO string instead of a Date object (the API serializes dates as strings).
-const apiRampTrigger = z.union([
-  z.object({ type: z.literal("interval"), seconds: z.number().positive() }),
-  z.object({ type: z.literal("approval") }),
-  z.object({ type: z.literal("scheduled"), at: z.iso.datetime() }),
+// API-facing trigger schemas — use ISO strings instead of Date objects.
+export const apiRampTrigger = z.discriminatedUnion("type", [
+  z
+    .object({
+      type: z.literal("interval"),
+      seconds: z
+        .number()
+        .positive()
+        .describe("Seconds to wait before this step fires."),
+    })
+    .describe("Fires automatically after a fixed delay."),
+  z
+    .object({ type: z.literal("approval") })
+    .describe("Pauses the ramp until manually approved."),
+  z
+    .object({
+      type: z.literal("scheduled"),
+      at: z.iso
+        .datetime()
+        .describe('ISO 8601 date-time, e.g. "2025-06-01T00:00:00Z".'),
+    })
+    .describe("Fires at a specific date and time."),
 ]);
 
 // Template step action for the API — same as the DB variant (no date fields in actions).
@@ -218,8 +234,15 @@ export const apiRampScheduleTemplateValidator = namedSchema(
 );
 
 // API-facing ramp end trigger — uses ISO string instead of Date.
-const apiRampEndTrigger = z.discriminatedUnion("type", [
-  z.object({ type: z.literal("scheduled"), at: z.iso.datetime() }),
+export const apiRampEndTrigger = z.discriminatedUnion("type", [
+  z
+    .object({
+      type: z.literal("scheduled"),
+      at: z.iso
+        .datetime()
+        .describe('ISO 8601 date-time, e.g. "2025-07-01T00:00:00Z".'),
+    })
+    .describe("End the ramp at a specific date and time."),
 ]);
 
 // API-facing ramp step — uses ISO strings for scheduled trigger dates.


### PR DESCRIPTION
- More expressive v2 endpoints for feature revisions. Better docs, better schema. More metadata about pending schedules and their lifecycle.
- Move the v2 list all features' revisions endpoint to be better namespaced with features.
- Fix/migrate dual attribution when the same user modifies a revision (a) within the app, and (b) via PAT REST API access. Fixes this issue:
<img width="639" height="184" alt="image" src="https://github.com/user-attachments/assets/4440a00b-5861-4f97-ba52-8c292d5a7e1e" />
