### PR TITLE
Fix up experiment queries

### DIFF
--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
@@ -210,7 +210,7 @@ export const ExperimentAssignmentQueries: FC<
                     )}
                   </Box>
                 </Flex>
-                {query.error && (
+                {query.error && !isManaged && (
                   <Callout status="error" mt="3">
                     <Box>
                       This query had an error with it the last time it ran:{" "}

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
@@ -210,7 +210,7 @@ export const ExperimentAssignmentQueries: FC<
                     )}
                   </Box>
                 </Flex>
-                {query.error && !isManaged && (
+                {query.error && (
                   <Callout status="error" mt="3">
                     <Box>
                       This query had an error with it the last time it ran:{" "}

--- a/packages/shared/src/util/event-forwarder-exposure-queries.ts
+++ b/packages/shared/src/util/event-forwarder-exposure-queries.ts
@@ -47,7 +47,7 @@ export function buildEventForwarderExposureQuerySql({
   userIdType: string;
 }): string {
   const select = `SELECT
-  event_uuid AS ${userIdType},
+  ${userIdType} AS ${userIdType},
   timestamp AS timestamp,
   experiment_id AS experiment_id,
   variation_id AS variation_id

--- a/packages/shared/src/util/event-forwarder-exposure-queries.ts
+++ b/packages/shared/src/util/event-forwarder-exposure-queries.ts
@@ -46,8 +46,10 @@ export function buildEventForwarderExposureQuerySql({
   tableRef: string;
   userIdType: string;
 }): string {
+  const quotedId =
+    sinkType === "bigquery" ? `\`${userIdType}\`` : `"${userIdType}"`;
   const select = `SELECT
-  ${userIdType} AS ${userIdType},
+  ${quotedId} AS ${quotedId},
   timestamp AS timestamp,
   experiment_id AS experiment_id,
   variation_id AS variation_id

--- a/packages/shared/test/util/event-forwarder-exposure-queries.test.ts
+++ b/packages/shared/test/util/event-forwarder-exposure-queries.test.ts
@@ -43,7 +43,7 @@ describe("buildEventForwarderExposureQuerySql", () => {
       userIdType: "user_id",
     });
 
-    expect(sql).toContain("event_uuid AS user_id");
+    expect(sql).toContain("`user_id` AS `user_id`");
     expect(sql).toContain("experiment_id AS experiment_id");
     expect(sql).toContain(`FROM ${tableRef}`);
     expect(sql).toContain(
@@ -53,6 +53,16 @@ describe("buildEventForwarderExposureQuerySql", () => {
     expect(sql).not.toContain("timestamp BETWEEN");
   });
 
+  it("quotes reserved-word identifiers for BigQuery", () => {
+    const sql = buildEventForwarderExposureQuerySql({
+      sinkType: "bigquery",
+      tableRef,
+      userIdType: "user",
+    });
+
+    expect(sql).toContain("`user` AS `user`");
+  });
+
   it("has no WHERE clause for Snowflake", () => {
     const sql = buildEventForwarderExposureQuerySql({
       sinkType: "snowflake",
@@ -60,7 +70,7 @@ describe("buildEventForwarderExposureQuerySql", () => {
       userIdType: "device_id",
     });
 
-    expect(sql).toContain("event_uuid AS device_id");
+    expect(sql).toContain('"device_id" AS "device_id"');
     expect(sql).toContain("FROM MY_DB.PUBLIC.experiment_viewed");
     expect(sql).not.toContain("WHERE");
   });


### PR DESCRIPTION
### Features and Changes
- Use the actual column name instead of event_uuid

- Closes **(https://www.notion.so/growthbook/Event-Forwarder-345a857e74a080a888c8de6d150a518d?source=copy_link#359a857e74a08056946efa7519953207)**

### Testing

Create new hashAttribute with event forwarder connected
Check ExperiementQueries for SQL

