### PR TITLE
feat: add PowerCalculation BaseModel and internal API

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -113,6 +113,7 @@ import { eventWebHooksRouter } from "./routers/event-webhooks/event-webhooks.rou
 import { tagRouter } from "./routers/tag/tag.router";
 import { savedGroupRouter } from "./routers/saved-group/saved-group.router";
 import { ArchetypeRouter } from "./routers/archetype/archetype.router";
+import { powerCalculationsRouter } from "./routers/power-calculations/power-calculations.router";
 import { AttributeRouter } from "./routers/attributes/attributes.router";
 import { customFieldsRouter } from "./routers/custom-fields/custom-fields.router";
 import { segmentRouter } from "./routers/segment/segment.router";
@@ -576,6 +577,8 @@ app.use("/tag", tagRouter);
 app.use("/saved-groups", savedGroupRouter);
 
 app.use("/archetype", ArchetypeRouter);
+
+app.use("/power-calculations", powerCalculationsRouter);
 
 app.use("/attribute", AttributeRouter);
 

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -361,6 +361,7 @@ const experimentSchema = new mongoose.Schema({
   dismissedWarnings: [String],
   holdoutId: String,
   defaultDashboardId: String,
+  powerCalculationId: String,
   customMetricSlices: [
     {
       _id: false,

--- a/packages/back-end/src/models/PowerCalculationModel.ts
+++ b/packages/back-end/src/models/PowerCalculationModel.ts
@@ -1,0 +1,128 @@
+import { isEqual } from "lodash";
+import {
+  PowerCalculationInterface,
+  powerCalculationValidator,
+} from "shared/validators";
+import { powerMetricWeeks } from "shared/power";
+import { UpdateProps } from "shared/types/base-model";
+import { logger } from "back-end/src/util/logger";
+import { ExperimentModel } from "back-end/src/models/ExperimentModel";
+import { MakeModelClass } from "./BaseModel";
+
+const BaseClass = MakeModelClass({
+  schema: powerCalculationValidator,
+  collectionName: "powercalculations",
+  idPrefix: "pwr_",
+  auditLog: {
+    entity: "powerCalculation",
+    createEvent: "powerCalculation.create",
+    updateEvent: "powerCalculation.update",
+    deleteEvent: "powerCalculation.delete",
+  },
+  globallyUniquePrimaryKeys: false,
+});
+
+export class PowerCalculationModel extends BaseClass {
+  protected canRead(doc: PowerCalculationInterface): boolean {
+    return this.context.permissions.canReadSingleProjectResource(doc.project);
+  }
+
+  protected canCreate(doc: PowerCalculationInterface): boolean {
+    return this.context.permissions.canCreatePowerCalculation({
+      project: doc.project,
+    });
+  }
+
+  protected canUpdate(
+    existing: PowerCalculationInterface,
+    _updates: UpdateProps<PowerCalculationInterface>,
+    newDoc: PowerCalculationInterface,
+  ): boolean {
+    return this.context.permissions.canUpdatePowerCalculation(
+      { project: existing.project },
+      { project: newDoc.project },
+    );
+  }
+
+  protected canDelete(doc: PowerCalculationInterface): boolean {
+    return this.context.permissions.canDeletePowerCalculation({
+      project: doc.project,
+    });
+  }
+
+  // `results` is server-computed. Populate it before the document is inserted.
+  protected async beforeCreate(doc: PowerCalculationInterface): Promise<void> {
+    doc.results = {
+      data: powerMetricWeeks(doc.inputs),
+      computedAt: new Date(),
+    };
+  }
+
+  /**
+   * `beforeUpdate` runs AFTER BaseModel has built the `$set` payload from
+   * `updates`, so mutating `updates` here would NOT persist. Recomputation of
+   * `results` is therefore handled by overriding `update` / `updateById` below
+   * to inject the new `results` into `updates` before delegating to the base
+   * implementation.
+   */
+
+  // Override `update` so we can inject a recomputed `results` into `updates`
+  // whenever `inputs` is changing. Delegating to the base call preserves all of
+  // BaseModel's validation, permission checks, audit logging, and date handling.
+  public override update(
+    existing: PowerCalculationInterface,
+    updates: UpdateProps<PowerCalculationInterface>,
+  ): Promise<PowerCalculationInterface> {
+    const merged = this.withRecomputedResults(existing, updates);
+    return super.update(existing, merged);
+  }
+
+  public override async updateById(
+    id: string,
+    updates: UpdateProps<PowerCalculationInterface>,
+  ): Promise<PowerCalculationInterface> {
+    const existing = await this.getById(id);
+    if (!existing) {
+      throw new Error("Could not find power calculation to update");
+    }
+    const merged = this.withRecomputedResults(existing, updates);
+    return super.update(existing, merged);
+  }
+
+  private withRecomputedResults(
+    existing: PowerCalculationInterface,
+    updates: UpdateProps<PowerCalculationInterface>,
+  ): UpdateProps<PowerCalculationInterface> {
+    if (!("inputs" in updates) || updates.inputs === undefined) {
+      return updates;
+    }
+    if (isEqual(updates.inputs, existing.inputs)) {
+      return updates;
+    }
+    return {
+      ...updates,
+      results: {
+        data: powerMetricWeeks(updates.inputs),
+        computedAt: new Date(),
+      },
+    };
+  }
+
+  // When a power calculation is deleted, null out the back-pointer on any
+  // experiment that referenced it. Failures here are logged but not rethrown:
+  // deletion has already succeeded and we don't want to leave the system in
+  // an inconsistent state where the doc is gone but the call also threw.
+  protected async afterDelete(doc: PowerCalculationInterface): Promise<void> {
+    try {
+      await ExperimentModel.updateMany(
+        { organization: this.context.org.id, powerCalculationId: doc.id },
+        { $unset: { powerCalculationId: "" } },
+      );
+    } catch (err) {
+      logger.error(
+        { err, powerCalculationId: doc.id, organization: this.context.org.id },
+        "Failed to clear powerCalculationId on experiments after delete",
+      );
+    }
+  }
+}

--- a/packages/back-end/src/routers/power-calculations/power-calculations.controller.ts
+++ b/packages/back-end/src/routers/power-calculations/power-calculations.controller.ts
@@ -1,0 +1,105 @@
+import type { Response } from "express";
+import {
+  CreatePowerCalculationBody,
+  PowerCalculationInterface,
+  UpdatePowerCalculationBody,
+} from "shared/validators";
+import { AuthRequest } from "back-end/src/types/AuthRequest";
+import { getContextFromReq } from "back-end/src/services/organizations";
+
+type GetPowerCalculationResponse = {
+  status: 200;
+  powerCalculation: PowerCalculationInterface;
+};
+
+export const getPowerCalculation = async (
+  req: AuthRequest<unknown, { id: string }>,
+  res: Response<GetPowerCalculationResponse>,
+) => {
+  const context = getContextFromReq(req);
+  const doc = await context.models.powerCalculations.getById(req.params.id);
+  if (!doc) {
+    return context.throwNotFoundError(
+      "Could not find power calculation with that id",
+    );
+  }
+  return res.status(200).json({
+    status: 200,
+    powerCalculation: doc,
+  });
+};
+
+type PostPowerCalculationResponse = {
+  status: 200;
+  powerCalculation: PowerCalculationInterface;
+};
+
+export const postPowerCalculation = async (
+  req: AuthRequest<CreatePowerCalculationBody>,
+  res: Response<PostPowerCalculationResponse>,
+) => {
+  const context = getContextFromReq(req);
+  const { name, description, owner, project, inputs } = req.body;
+
+  const doc = await context.models.powerCalculations.create({
+    name,
+    description,
+    owner,
+    project,
+    inputs,
+  });
+
+  return res.status(200).json({
+    status: 200,
+    powerCalculation: doc,
+  });
+};
+
+type PutPowerCalculationResponse = {
+  status: 200;
+  powerCalculation: PowerCalculationInterface;
+};
+
+export const putPowerCalculation = async (
+  req: AuthRequest<UpdatePowerCalculationBody, { id: string }>,
+  res: Response<PutPowerCalculationResponse>,
+) => {
+  const context = getContextFromReq(req);
+  const existing = await context.models.powerCalculations.getById(
+    req.params.id,
+  );
+  if (!existing) {
+    return context.throwNotFoundError(
+      "Could not find power calculation with that id",
+    );
+  }
+
+  const updated = await context.models.powerCalculations.update(
+    existing,
+    req.body,
+  );
+
+  return res.status(200).json({
+    status: 200,
+    powerCalculation: updated,
+  });
+};
+
+type DeletePowerCalculationResponse = { status: 200 };
+
+export const deletePowerCalculation = async (
+  req: AuthRequest<unknown, { id: string }>,
+  res: Response<DeletePowerCalculationResponse>,
+) => {
+  const context = getContextFromReq(req);
+  const existing = await context.models.powerCalculations.getById(
+    req.params.id,
+  );
+  if (!existing) {
+    return context.throwNotFoundError(
+      "Could not find power calculation with that id",
+    );
+  }
+  await context.models.powerCalculations.delete(existing);
+  return res.status(200).json({ status: 200 });
+};

--- a/packages/back-end/src/routers/power-calculations/power-calculations.router.ts
+++ b/packages/back-end/src/routers/power-calculations/power-calculations.router.ts
@@ -1,0 +1,50 @@
+import express from "express";
+import { z } from "zod";
+import {
+  createPowerCalculationBodySchema,
+  updatePowerCalculationBodySchema,
+} from "shared/validators";
+import { wrapController } from "back-end/src/routers/wrapController";
+import { validateRequestMiddleware } from "back-end/src/routers/utils/validateRequestMiddleware";
+import * as rawPowerCalculationsController from "./power-calculations.controller";
+
+const router = express.Router();
+
+const PowerCalculationsController = wrapController(
+  rawPowerCalculationsController,
+);
+
+router.get(
+  "/:id",
+  validateRequestMiddleware({
+    params: z.object({ id: z.string() }).strict(),
+  }),
+  PowerCalculationsController.getPowerCalculation,
+);
+
+router.post(
+  "/",
+  validateRequestMiddleware({
+    body: createPowerCalculationBodySchema,
+  }),
+  PowerCalculationsController.postPowerCalculation,
+);
+
+router.put(
+  "/:id",
+  validateRequestMiddleware({
+    params: z.object({ id: z.string() }).strict(),
+    body: updatePowerCalculationBodySchema,
+  }),
+  PowerCalculationsController.putPowerCalculation,
+);
+
+router.delete(
+  "/:id",
+  validateRequestMiddleware({
+    params: z.object({ id: z.string() }).strict(),
+  }),
+  PowerCalculationsController.deletePowerCalculation,
+);
+
+export { router as powerCalculationsRouter };

--- a/packages/back-end/src/services/context.ts
+++ b/packages/back-end/src/services/context.ts
@@ -54,6 +54,7 @@ import { DecisionCriteriaModel } from "back-end/src/enterprise/models/DecisionCr
 import { MetricTimeSeriesModel } from "back-end/src/models/MetricTimeSeriesModel";
 import { WebhookSecretDataModel } from "back-end/src/models/WebhookSecretModel";
 import { HoldoutModel } from "back-end/src/models/HoldoutModel";
+import { PowerCalculationModel } from "back-end/src/models/PowerCalculationModel";
 import { SavedQueryDataModel } from "back-end/src/models/SavedQueryDataModel";
 import { SavedGroupModel } from "back-end/src/models/SavedGroupModel";
 import { FeatureRevisionLogModel } from "back-end/src/models/FeatureRevisionLogModel";
@@ -94,6 +95,7 @@ export type ModelName =
   | "urlRedirects"
   | "metricAnalysis"
   | "populationData"
+  | "powerCalculations"
   | "savedQueries"
   | "metricGroups"
   | "segments"
@@ -133,6 +135,7 @@ export const modelClasses = {
   urlRedirects: UrlRedirectModel,
   metricAnalysis: MetricAnalysisModel,
   populationData: PopulationDataModel,
+  powerCalculations: PowerCalculationModel,
   savedQueries: SavedQueryDataModel,
   metricGroups: MetricGroupModel,
   segments: SegmentModel,
@@ -181,6 +184,7 @@ export class ReqContextClass {
       urlRedirects: new UrlRedirectModel(this),
       metricAnalysis: new MetricAnalysisModel(this),
       populationData: new PopulationDataModel(this),
+      powerCalculations: new PowerCalculationModel(this),
       savedQueries: new SavedQueryDataModel(this),
       metricGroups: new MetricGroupModel(this),
       segments: new SegmentModel(this),

--- a/packages/front-end/components/Experiment/CompareExperimentEventsModal.tsx
+++ b/packages/front-end/components/Experiment/CompareExperimentEventsModal.tsx
@@ -246,6 +246,7 @@ const EXPERIMENT_SECTION_KEYS: Record<
   dismissedWarnings: false,
   holdoutId: false,
   defaultDashboardId: false,
+  powerCalculationId: false,
 };
 
 function sectionKeys(

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -244,6 +244,7 @@ export const entityEvents = {
   decisionCriteria: ["create", "update", "delete"],
   execReport: ["create", "update", "delete"],
   holdout: ["create", "update", "delete"],
+  powerCalculation: ["create", "update", "delete"],
   savedQuery: ["create", "update", "delete"],
   dashboard: ["create", "update", "delete"],
   dashboardTemplate: ["create", "update", "delete"],

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -456,6 +456,38 @@ export class Permissions {
     );
   };
 
+  // Power calculations are single-project resources. We wrap the single project
+  // into a one-element array so we can reuse the existing project-filter
+  // permission helpers, mirroring how `canCreateHoldout` etc. work.
+  public canCreatePowerCalculation = (powerCalculation: {
+    project: string;
+  }): boolean => {
+    return this.checkProjectFilterPermission(
+      { projects: [powerCalculation.project] },
+      "createAnalyses",
+    );
+  };
+
+  public canUpdatePowerCalculation = (
+    existing: { project: string },
+    updated: { project: string },
+  ): boolean => {
+    return this.checkProjectFilterUpdatePermission(
+      { projects: [existing.project] },
+      { projects: [updated.project] },
+      "createAnalyses",
+    );
+  };
+
+  public canDeletePowerCalculation = (powerCalculation: {
+    project: string;
+  }): boolean => {
+    return this.checkProjectFilterPermission(
+      { projects: [powerCalculation.project] },
+      "createAnalyses",
+    );
+  };
+
   // Frontend helper to gate "Create Experiment Template" UI.
   // Pass allProjects on list pages where "All Projects" may be selected;
   // omit it when checking a specific resource's project or global-only access.

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -425,6 +425,7 @@ export const experimentInterface = z
     dismissedWarnings: z.array(z.enum(["low-power"])).optional(),
     holdoutId: z.string().optional(),
     defaultDashboardId: z.string().optional(),
+    powerCalculationId: z.string().optional(),
     customMetricSlices: z.array(customMetricSlice).optional(),
     statusUpdateSchedule: statusUpdateScheduleValidator.optional().nullable(),
     nextScheduledStatusUpdate: nextScheduledStatusUpdateValidator

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -54,6 +54,7 @@ export * from "./exec-report";
 export * from "./experiment-template";
 export * from "./metric-analysis";
 export * from "./population-data";
+export * from "./power-calculations";
 export * from "./presentation-theme";
 export * from "./url-redirects";
 export * from "./sdk-connection-cache";

--- a/packages/shared/src/validators/power-calculations.ts
+++ b/packages/shared/src/validators/power-calculations.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+import {
+  powerCalculationParamsSchema,
+  powerCalculationResultsSchema,
+} from "../power/power";
+import { baseSchema } from "./base-model";
+import { ownerField, ownerInputField } from "./owner-field";
+
+export const powerCalculationResultsWithComputedAtSchema = z
+  .object({
+    data: powerCalculationResultsSchema,
+    computedAt: z.date(),
+  })
+  .strict();
+
+export type PowerCalculationResultsWithComputedAt = z.infer<
+  typeof powerCalculationResultsWithComputedAtSchema
+>;
+
+export const powerCalculationValidator = baseSchema
+  .extend({
+    name: z.string(),
+    description: z.string().optional(),
+    owner: ownerField.optional(),
+    project: z.string(),
+    inputs: powerCalculationParamsSchema,
+    // `results` is computed server-side. It is optional in the schema so that
+    // creates can omit it; the model populates it in `beforeCreate` before
+    // inserting the document.
+    results: powerCalculationResultsWithComputedAtSchema.optional(),
+  })
+  .strict();
+
+export type PowerCalculationInterface = z.infer<
+  typeof powerCalculationValidator
+>;
+
+export const createPowerCalculationBodySchema = z
+  .object({
+    name: z.string(),
+    description: z.string().optional(),
+    owner: ownerInputField.optional(),
+    project: z.string(),
+    inputs: powerCalculationParamsSchema,
+  })
+  .strict();
+
+export type CreatePowerCalculationBody = z.infer<
+  typeof createPowerCalculationBodySchema
+>;
+
+export const updatePowerCalculationBodySchema = z
+  .object({
+    name: z.string().optional(),
+    description: z.string().optional(),
+    owner: ownerInputField.optional(),
+    project: z.string().optional(),
+    inputs: powerCalculationParamsSchema.optional(),
+  })
+  .strict();
+
+export type UpdatePowerCalculationBody = z.infer<
+  typeof updatePowerCalculationBodySchema
+>;


### PR DESCRIPTION
## Summary

- PR 2 of a series migrating the standalone power calculator to a BaseModel-backed `PowerCalculation` collection. **Stacked on top of #5935** — the base of this PR will retarget to `main` automatically once #5935 merges.
- Adds a persisted `PowerCalculation` document with `inputs` (user-supplied) and `results` (server-computed, with `computedAt`) as separate sub-documents.
- Adds internal CRUD endpoints under `/power-calculations`.
- Linkage is **one-way**: `experiment.powerCalculationId?: string`. The power calc itself has no back-reference. When a power calc is deleted, the pointer is nulled out on any referencing experiments.
- Permissions: `createAnalyses` policy via new `canCreate/Update/DeletePowerCalculation` helpers (single project wrapped as a one-element array for reuse).
- Free feature, no commercial gate.

## Implementation notes worth a look

1. **`results` recomputation on update.** `BaseModel._updateOne` builds the MongoDB `$set` payload from `updates` _before_ `beforeUpdate` runs, so mutating `updates`/`newDoc` in `beforeUpdate` does not persist new fields. The model therefore overrides `update`/`updateById` to inject a recomputed `results` into `updates` ahead of the base call. The trade-off is documented inline. `dangerousUpdate*BypassPermission` paths are intentionally not covered — system code that bypasses permissions also bypasses recomputation.
2. **Experiment mongoose schema** required an explicit `powerCalculationId: String` field next to `defaultDashboardId` so the field persists on the legacy mongoose-backed `experiments` collection.
3. **`CompareExperimentEventsModal`** maintains a `Record<keyof ExperimentInterface, SectionAssignment>` and needs an entry for every experiment field — added `powerCalculationId: false` next to `defaultDashboardId: false`.

## Out of scope (later PRs)

- Front-end UI for summoning a power calc from an experiment page.
- Rewiring the standalone `/power-calculator` page to read/write via this API.

## Test plan

- [x] `pnpm --filter shared type-check`
- [x] `pnpm --filter back-end type-check`
- [x] `pnpm --filter front-end type-check`
- [x] `eslint` on all changed files
- [x] `prettier --check` on all changed files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)