### PR TITLE
Improve validation and safety of Test Webhook endpoint

### DIFF
--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -123,7 +123,6 @@
     "scim2-parse-filter": "^0.2.8",
     "shared": "workspace:*",
     "snowflake-sdk": "2.3.3",
-    "ssrf-req-filter": "^1.1.1",
     "string-env-interpolation": "^1.0.1",
     "stripe": "^17.4.0",
     "tiktoken": "1.0.21",

--- a/packages/back-end/src/routers/event-webhooks/event-webhooks.controller.ts
+++ b/packages/back-end/src/routers/event-webhooks/event-webhooks.controller.ts
@@ -26,6 +26,7 @@ import * as EventWebHookLog from "back-end/src/models/EventWebHookLogModel";
 
 import { AuthRequest } from "back-end/src/types/AuthRequest";
 import { getContextFromReq } from "back-end/src/services/organizations";
+import { cancellableFetch } from "back-end/src/util/http.util";
 
 // region GET /event-webhooks
 
@@ -333,18 +334,31 @@ export const testWebHookParams = async (
   req: PostTestWebHooksParamsRequest,
   res: Response<{ success: boolean } | PrivateApiErrorResponse>,
 ) => {
-  try {
-    const response = await fetch(req.body.url, {
-      method: req.body.method,
-      body: JSON.stringify(testParamsPayload(req.body.name)),
-      headers: { "Content-Type": "application/json" },
-    });
+  const context = getContextFromReq(req);
 
-    if (response.ok) return res.json({ success: true });
+  if (!context.permissions.canCreateEventWebhook()) {
+    context.permissions.throwPermissionError();
+  }
+
+  try {
+    const { responseWithoutBody } = await cancellableFetch(
+      req.body.url,
+      {
+        method: req.body.method,
+        body: JSON.stringify(testParamsPayload(req.body.name)),
+        headers: { "Content-Type": "application/json" },
+      },
+      {
+        maxTimeMs: 30000,
+        maxContentSize: 1000,
+      },
+    );
+
+    if (responseWithoutBody.ok) return res.json({ success: true });
 
     return res.status(403).json({
       status: 403,
-      message: `Request failed: ${response.status} - ${response.statusText}`,
+      message: `Request failed: ${responseWithoutBody.status} - ${responseWithoutBody.statusText}`,
     });
   } catch (e) {
     return res

--- a/packages/back-end/src/routers/event-webhooks/event-webhooks.router.ts
+++ b/packages/back-end/src/routers/event-webhooks/event-webhooks.router.ts
@@ -139,7 +139,7 @@ router.post(
       .object({
         name: z.string().trim().min(1),
         method: z.enum(eventWebHookMethods),
-        url: z.string().trim().min(1),
+        url: z.string().url(),
       })
       .strict(),
   }),

--- a/packages/back-end/src/util/http.util.ts
+++ b/packages/back-end/src/util/http.util.ts
@@ -23,21 +23,7 @@ export function fetch(url: string, init?: RequestInit) {
   });
 }
 
-export function getHttpOptions(url?: string) {
-  // if there is a ?proxy argument in the url, use that as the proxy
-  if (url) {
-    // parse the url and extract the proxy argument
-    const urlObj = new URL(url);
-    const proxy = urlObj.searchParams.get("proxy_test");
-    if (proxy) {
-      return {
-        agent: new ProxyAgent({
-          getProxyForUrl: () => proxy,
-        }),
-      };
-    }
-  }
-
+export function getHttpOptions() {
   if (useWebhookProxy && WEBHOOK_PROXY) {
     logger.debug("using webhook proxy");
     return {
@@ -89,7 +75,7 @@ export const cancellableFetch = async (
   try {
     response = await fetch(url, {
       signal: abortController.signal as RequestInit["signal"],
-      ...getHttpOptions(url),
+      ...getHttpOptions(),
       ...fetchOptions,
     });
 

--- a/packages/back-end/typings/ssrf-req-filter/index.d.ts
+++ b/packages/back-end/typings/ssrf-req-filter/index.d.ts
@@ -1,5 +1,0 @@
-import { Agent } from "http";
-
-declare module "ssrf-req-filter" {
-  export default function ssrfReqFilter(url: string): Agent;
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -424,9 +424,6 @@ importers:
       snowflake-sdk:
         specifier: 2.3.3
         version: 2.3.3(asn1.js@5.4.1)(encoding@0.1.13)
-      ssrf-req-filter:
-        specifier: ^1.1.1
-        version: 1.1.1
       string-env-interpolation:
         specifier: ^1.0.1
         version: 1.0.1
@@ -9283,10 +9280,6 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
-  ipaddr.js@2.2.0:
-    resolution: {integrity: sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==}
-    engines: {node: '>= 10'}
-
   is-absolute@1.0.0:
     resolution: {integrity: sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==}
     engines: {node: '>=0.10.0'}
@@ -12180,9 +12173,6 @@ packages:
   sqlstring@2.3.3:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
     engines: {node: '>= 0.6'}
-
-  ssrf-req-filter@1.1.1:
-    resolution: {integrity: sha512-z0duj5tuvr5YetayhTdQWHf5gEncHvY6nL1HoqiFaF0gfK8Gc3VpTlxvAf4DaOVwcoczfqsL97H5TJRfYFtEYg==}
 
   ssri@13.0.1:
     resolution: {integrity: sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==}
@@ -23871,8 +23861,6 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
-  ipaddr.js@2.2.0: {}
-
   is-absolute@1.0.0:
     dependencies:
       is-relative: 1.0.0
@@ -27569,10 +27557,6 @@ snapshots:
       nearley: 2.20.1
 
   sqlstring@2.3.3: {}
-
-  ssrf-req-filter@1.1.1:
-    dependencies:
-      ipaddr.js: 2.2.0
 
   ssri@13.0.1:
     dependencies:


### PR DESCRIPTION
### Features and Changes

* Remove unused `ssrf-req-filter` library.  SSRF protection is handled by a smokescreen server proxy instead in production, which is more robust.
* Remove unused `proxy_test` url param.  Was originally added to test the Smokescreen server in production, but now that it is enabled for everyone it is no longer needed and a potential security vulnerability to leave in the code.
* Add permission check to the "test webhook" endpoint - no reason for someone to test a new webhook unless they have permission to actually create it.  Not a security issue, just unnecessarily broad permissions.
* Stricter validation on URLs in the test endpoint - now validate it's an actual URL and not an arbitrary string.  Also not a security issue, but should provide better error messages.
* Route test webhook requests through the `cancellableFetch` helper, which lets us enforce max response size, set a timeout, and route through our smokescreen server. This does fix a potential security issue where an attacker could perform a resource exhaustion attack or attempt an SSRF attack (although multiple layers of protection are in place for this already so not a huge concern).