### PR TITLE
Product Analytics group by fixes

### DIFF
--- a/packages/back-end/src/routers/demo-datasource-project/demo-datasource-project.controller.ts
+++ b/packages/back-end/src/routers/demo-datasource-project/demo-datasource-project.controller.ts
@@ -36,6 +36,7 @@ import {
   createFactTable,
   getFactTableMap,
 } from "back-end/src/models/FactTableModel";
+import { queueFactTableColumnsRefresh } from "back-end/src/jobs/refreshFactTableColumns";
 
 // region Constants for Demo Datasource
 
@@ -235,14 +236,14 @@ export const postDemoDatasourceProject = async (
     );
 
     // Create fact table
-    await createFactTable(context, {
+    const demoFactTable = await createFactTable(context, {
       id: demoFactTableId,
       name: "purchases",
       description: "",
       owner: ASSET_OWNER,
       tags: DEMO_TAGS,
       userIdTypes: ["user_id"],
-      sql: "SELECT\nuserId AS user_id,\ntimestamp AS timestamp,\namount AS value\nFROM purchases",
+      sql: "SELECT\nuserId AS user_id,\ntimestamp AS timestamp,\namount AS value,\nbrowser,\ncountry\nFROM purchases",
       eventName: "purchases",
       datasource: datasource.id,
       projects: [project.id],
@@ -260,8 +261,21 @@ export const postDemoDatasourceProject = async (
           datatype: "number",
           numberFormat: "currency",
         },
+        {
+          column: "browser",
+          datatype: "string",
+        },
+        {
+          column: "country",
+          datatype: "string",
+        },
       ],
+      columnRefreshPending: true,
     });
+
+    // Kick off a column refresh so string columns get topValues populated
+    // for autocomplete dropdowns in filters and Group By.
+    await queueFactTableColumnsRefresh(demoFactTable);
 
     // Create metrics
     const metrics = await Promise.all(

--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/GroupBySection.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/GroupBySection.tsx
@@ -6,6 +6,7 @@ import Button from "@/ui/Button";
 import { getMaxDimensions } from "@/enterprise/components/ProductAnalytics/util";
 import { useExplorerContext } from "@/enterprise/components/ProductAnalytics/ExplorerContext";
 import Text from "@/ui/Text";
+import Tooltip from "@/ui/Tooltip";
 import SelectField from "@/components/Forms/SelectField";
 import Field from "@/components/Forms/Field";
 
@@ -131,21 +132,26 @@ export default function GroupBySection() {
     >
       <Flex justify="between" align="center">
         <Text weight="medium">Group By</Text>
-        <Button
-          size="xs"
-          variant="ghost"
-          disabled={
-            getMaxDimensions(draftExploreState.dataset) <=
-              draftExploreState.dimensions.length ||
-            availableColumns.length === 0 ||
-            draftExploreState.chartType === "bigNumber"
-          }
-          onClick={handleAddDimension}
+        <Tooltip
+          enabled={commonColumns.length === 0}
+          content="No group by columns are available."
         >
-          <Flex align="center" gap="2">
-            <PiPlus size={14} /> Add
-          </Flex>
-        </Button>
+          <Button
+            size="xs"
+            variant="ghost"
+            disabled={
+              getMaxDimensions(draftExploreState.dataset) <=
+                draftExploreState.dimensions.length ||
+              availableColumns.length === 0 ||
+              draftExploreState.chartType === "bigNumber"
+            }
+            onClick={handleAddDimension}
+          >
+            <Flex align="center" gap="2">
+              <PiPlus size={14} /> Add
+            </Flex>
+          </Button>
+        </Tooltip>
       </Flex>
       {/* Display existing dimensions */}
       {draftExploreState.dimensions.map((dim, i) => {

--- a/packages/front-end/enterprise/components/ProductAnalytics/util.ts
+++ b/packages/front-end/enterprise/components/ProductAnalytics/util.ts
@@ -161,12 +161,17 @@ export function getCommonColumns(
 ): Pick<ColumnInterface, "column" | "name">[] {
   if (!dataset || !dataset.values || dataset.values.length === 0) return [];
 
-  type SimpleColumn = Pick<ColumnInterface, "column" | "name" | "deleted">;
+  type SimpleColumn = Pick<
+    ColumnInterface,
+    "column" | "name" | "deleted" | "datatype"
+  >;
   let columns: SimpleColumn[] | null = null;
+  const userIdTypes = new Set<string>();
 
   if (dataset.type === "fact_table") {
     const ft = getFactTableById(dataset.factTableId || "");
     columns = ft?.columns || [];
+    ft?.userIdTypes?.forEach((u) => userIdTypes.add(u));
   } else if (dataset.type === "metric") {
     for (const value of dataset.values) {
       const metricId = value.metricId;
@@ -176,6 +181,7 @@ export function getCommonColumns(
       if (factMetric) {
         const ft = getFactTableById(factMetric.numerator.factTableId);
         valueColumns = ft?.columns || [];
+        ft?.userIdTypes?.forEach((u) => userIdTypes.add(u));
       }
 
       if (columns === null) {
@@ -187,15 +193,18 @@ export function getCommonColumns(
       }
     }
   } else if (dataset.type === "data_source") {
-    columns = Object.keys(dataset.columnTypes).map((name) => ({
+    columns = Object.entries(dataset.columnTypes).map(([name, datatype]) => ({
       column: name,
       name,
       deleted: false,
+      datatype,
     }));
   }
 
   return (columns || [])
     .filter((c) => !c.deleted)
+    .filter((c) => c.datatype === "string")
+    .filter((c) => !userIdTypes.has(c.column))
     .sort((a, b) => (a.name || a.column).localeCompare(b.name || b.column))
     .map((c) => ({ column: c.column, name: c.name }));
 }


### PR DESCRIPTION
### Features and Changes

* Restrict the columns that can be used to "Group By" in product analytics.  Only string columns (excluding identifier columns) are allowed now.  We may add support for numeric columns in the future with automatic histogram buckets, but right now the SQL just throws an error if you try to use them.
* Select a few dimension columns (`browser` and `country`) in the sample data fact table so users can easily test out filtering and group by before connecting to their own data.