### PR TITLE
Strip incompatible metrics at submit when duplicating an experiment

### DIFF
--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -206,8 +206,14 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
   const [autoRefreshResults, setAutoRefreshResults] = useState(true);
   const [useSameSeedAsOriginal, setUseSameSeedAsOriginal] = useState(false);
 
-  const { datasources, getDatasourceById, refreshTags, project, projects } =
-    useDefinitions();
+  const {
+    datasources,
+    getDatasourceById,
+    getExperimentMetricById,
+    refreshTags,
+    project,
+    projects,
+  } = useDefinitions();
   const { aiEnabled } = useAISettings();
   const [similarExperiments, setSimilarExperiments] = useState<
     { experiment: ExperimentInterfaceStringDates; similarity: number }[]
@@ -493,6 +499,24 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
     }
 
     const data = { ...value };
+
+    // Strip out any selected metrics that belong to a different data source.
+    // The Metrics step hides chips for IDs whose metric isn't in the current
+    // data source's options, but the IDs stay in form state so they re-appear
+    // if the user switches back. Filter here so submit doesn't fail with
+    // "Metrics must be tied to the same datasource as the experiment".
+    if (data.datasource) {
+      const datasourceId = data.datasource;
+      const isValidMetric = (id: string) =>
+        getExperimentMetricById(id)?.datasource === datasourceId;
+      data.goalMetrics = (data.goalMetrics ?? []).filter(isValidMetric);
+      data.secondaryMetrics = (data.secondaryMetrics ?? []).filter(
+        isValidMetric,
+      );
+      data.guardrailMetrics = (data.guardrailMetrics ?? []).filter(
+        isValidMetric,
+      );
+    }
 
     if (data.status !== "stopped" && data.phases?.[0]) {
       data.phases[0].dateEnded = "";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

When duplicating (or creating) an experiment, switching the **Data Source** on the Metrics step hid the previously selected metric chips from the UI but left the stale metric IDs in form state. Clicking **Submit** then failed with:

> Metrics must be tied to the same datasource as the experiment

This fix filters `goalMetrics`, `secondaryMetrics`, and `guardrailMetrics` inside `NewExperimentForm`'s `onSubmit` handler so only IDs whose metric belongs to the chosen data source are sent to the backend.

The filter only mutates the outgoing payload, not form state, so two nice behaviors come for free without any extra code:

- **Restore on switch-back:** if the user switches data source then switches back to the original, the chips reappear because the original IDs were never wiped from form state.
- **Picking a new metric drops the stale IDs:** react-select's `value` prop in `MultiSelectField` is bound to the *visible* selection (`selected = value.map(map.get).filter(isDefined)`), so the moment the user picks any new metric, react-select fires `onChange` with the visible selection + the new pick, leaving stale hidden IDs out of the new form state.

For bandits, putting the filter before the existing `data.goalMetrics?.length !== 1` guard means a user who switched data sources without picking a new decision metric now sees the friendlier *"You must select 1 decision metric"* error instead of the backend's same-datasource error.

- Closes the duplication/create bug where the Metrics step shows no chips but submit errors with *"Metrics must be tied to the same datasource as the experiment"*.

### Dependencies

None.

### Testing

Manual verification on a local dev environment (front-end at `http://localhost:3000`, back-end at `http://localhost:3100`, MongoDB seeded with two data sources — `Sample Data Source` and `Sample Data Source 2` — each with the same four fact metrics).

Three end-to-end scenarios on the standard new-experiment flow, all passing:

- **A. Switch data source then submit** — pick metric in DS1, switch to DS2 (chip hides), click Save → submit succeeds, lands on the new experiment's detail page (this was the failing scenario before the fix).
- **B. Switch back restores chips** — pick metric in DS1, switch to DS2, switch back to DS1 → chip reappears, Save succeeds.
- **C. Pick a new metric after switching** — pick metric in DS1, switch to DS2, pick a new metric for DS2 → only the DS2 chip shows, Save succeeds.

Programmatic:

- ✅ `pnpm --filter front-end type-check`
- ⚠️ `pnpm --filter front-end exec eslint components/Experiment/NewExperimentForm.tsx` — 3 pre-existing errors on `main` (Heading import + 2 Bootstrap alert classNames at unrelated lines), not introduced by this PR.

### Screenshots

End-to-end demo of scenario A:

[metric_filter_bugfix_demo.mp4](https://cursor.com/agents/bc-20c438f5-7a29-451b-8dc0-0201ed9abcc6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmetric_filter_bugfix_demo.mp4)

Scenario A — submit success after switching data source:

[Test A - submit succeeded after switching data source](https://cursor.com/agents/bc-20c438f5-7a29-451b-8dc0-0201ed9abcc6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmetric_filter_submit_success.png)

Scenario B — chip restored when switching back to the original data source:

[Test B - chip restored after switching back](https://cursor.com/agents/bc-20c438f5-7a29-451b-8dc0-0201ed9abcc6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmetric_filter_chip_restored.png)

Scenario C — only the newly picked DS2 chip remains visible after switching:

[Test C - new metric picked on second data source](https://cursor.com/agents/bc-20c438f5-7a29-451b-8dc0-0201ed9abcc6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmetric_filter_new_pick.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20c438f5-7a29-451b-8dc0-0201ed9abcc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20c438f5-7a29-451b-8dc0-0201ed9abcc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

