### PR TITLE
fast-follow(experiment-scheduling): Add ability to schedule from postExperiment + render schedule timezone in UI

### DIFF
--- a/docs/src/partials/event-webhook/_event-webhook-list.md
+++ b/docs/src/partials/event-webhook/_event-webhook-list.md
@@ -1685,7 +1685,8 @@ Triggered when an experiment is created
             defaultDashboardId?: string | undefined;
             templateId?: string | undefined;
             statusUpdateSchedule?: ({
-                startAt?: string | undefined;
+                /** ISO datetime when the experiment should start. Must be in the future. Setting or clearing this field invalidates any existing staged start (`nextScheduledStatusUpdate`); call POST /experiments/{id}/start to stage the new schedule. */
+                startAt: string;
             } | null) | undefined;
             nextScheduledStatusUpdate?: ({
                 type: "start";
@@ -1940,7 +1941,8 @@ Triggered when an experiment is updated
             defaultDashboardId?: string | undefined;
             templateId?: string | undefined;
             statusUpdateSchedule?: ({
-                startAt?: string | undefined;
+                /** ISO datetime when the experiment should start. Must be in the future. Setting or clearing this field invalidates any existing staged start (`nextScheduledStatusUpdate`); call POST /experiments/{id}/start to stage the new schedule. */
+                startAt: string;
             } | null) | undefined;
             nextScheduledStatusUpdate?: ({
                 type: "start";
@@ -2156,7 +2158,8 @@ Triggered when an experiment is updated
             defaultDashboardId?: string | undefined;
             templateId?: string | undefined;
             statusUpdateSchedule?: ({
-                startAt?: string | undefined;
+                /** ISO datetime when the experiment should start. Must be in the future. Setting or clearing this field invalidates any existing staged start (`nextScheduledStatusUpdate`); call POST /experiments/{id}/start to stage the new schedule. */
+                startAt: string;
             } | null) | undefined;
             nextScheduledStatusUpdate?: ({
                 type: "start";
@@ -2416,7 +2419,8 @@ Triggered when an experiment is deleted
             defaultDashboardId?: string | undefined;
             templateId?: string | undefined;
             statusUpdateSchedule?: ({
-                startAt?: string | undefined;
+                /** ISO datetime when the experiment should start. Must be in the future. Setting or clearing this field invalidates any existing staged start (`nextScheduledStatusUpdate`); call POST /experiments/{id}/start to stage the new schedule. */
+                startAt: string;
             } | null) | undefined;
             nextScheduledStatusUpdate?: ({
                 type: "start";

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -9383,7 +9383,10 @@ paths:
                       format: date-time
                       description: >-
                         ISO datetime when the experiment should start. Must be
-                        in the future.
+                        in the future. Setting or clearing this field
+                        invalidates any existing staged start
+                        (`nextScheduledStatusUpdate`); call POST
+                        /experiments/{id}/start to stage the new schedule.
                       type: string
                   required:
                     - startAt
@@ -27111,11 +27114,21 @@ components:
           type: string
         statusUpdateSchedule:
           anyOf:
-            - type: object
+            - description: >-
+                Schedule a future start for a draft experiment. Only `startAt`
+                is currently supported.
+              type: object
               properties:
                 startAt:
                   format: date-time
+                  description: >-
+                    ISO datetime when the experiment should start. Must be in
+                    the future. Setting or clearing this field invalidates any
+                    existing staged start (`nextScheduledStatusUpdate`); call
+                    POST /experiments/{id}/start to stage the new schedule.
                   type: string
+              required:
+                - startAt
               additionalProperties: false
             - type: 'null'
         nextScheduledStatusUpdate:
@@ -27806,11 +27819,22 @@ components:
               type: string
             statusUpdateSchedule:
               anyOf:
-                - type: object
+                - description: >-
+                    Schedule a future start for a draft experiment. Only
+                    `startAt` is currently supported.
+                  type: object
                   properties:
                     startAt:
                       format: date-time
+                      description: >-
+                        ISO datetime when the experiment should start. Must be
+                        in the future. Setting or clearing this field
+                        invalidates any existing staged start
+                        (`nextScheduledStatusUpdate`); call POST
+                        /experiments/{id}/start to stage the new schedule.
                       type: string
+                  required:
+                    - startAt
                   additionalProperties: false
                 - type: 'null'
             nextScheduledStatusUpdate:

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -9385,6 +9385,8 @@ paths:
                         ISO datetime when the experiment should start. Must be
                         in the future.
                       type: string
+                  required:
+                    - startAt
                   additionalProperties: false
               required:
                 - trackingKey
@@ -9979,6 +9981,8 @@ paths:
                             (`nextScheduledStatusUpdate`); call POST
                             /experiments/{id}/start to stage the new schedule.
                           type: string
+                      required:
+                        - startAt
                       additionalProperties: false
                     - type: 'null'
               additionalProperties: false

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -9373,6 +9373,19 @@ paths:
                     required:
                       - slices
                     additionalProperties: false
+                statusUpdateSchedule:
+                  description: >-
+                    Schedule a future start for a draft experiment. Only
+                    `startAt` is currently supported.
+                  type: object
+                  properties:
+                    startAt:
+                      format: date-time
+                      description: >-
+                        ISO datetime when the experiment should start. Must be
+                        in the future.
+                      type: string
+                  additionalProperties: false
               required:
                 - trackingKey
                 - name
@@ -9960,11 +9973,11 @@ paths:
                         startAt:
                           format: date-time
                           description: >-
-                            ISO datetime when the experiment should start.
-                            Setting or clearing this field invalidates any
-                            existing staged start (`nextScheduledStatusUpdate`);
-                            call POST /experiments/{id}/start to stage the new
-                            schedule.
+                            ISO datetime when the experiment should start. Must
+                            be in the future. Setting or clearing this field
+                            invalidates any existing staged start
+                            (`nextScheduledStatusUpdate`); call POST
+                            /experiments/{id}/start to stage the new schedule.
                           type: string
                       additionalProperties: false
                     - type: 'null'
@@ -10055,7 +10068,10 @@ paths:
   /v1/experiments/{id}/start:
     post:
       operationId: postExperimentStart
-      summary: Start an experiment
+      summary: Start/Stage an experiment
+      description: >-
+        Starts an experiment or stages it for a future start if a
+        `statusUpdateSchedule` is set on the experiment.
       tags:
         - experiments
       parameters:

--- a/packages/back-end/src/api/experiments/postExperiment.ts
+++ b/packages/back-end/src/api/experiments/postExperiment.ts
@@ -14,6 +14,7 @@ import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 import {
   postExperimentApiPayloadToInterface,
   toExperimentApiInterface,
+  validateStatusUpdateSchedule,
   validateVariationIds,
 } from "back-end/src/services/experiments";
 import { assertRegisteredAttributes } from "back-end/src/services/attributes";
@@ -264,6 +265,13 @@ export const postExperiment = createApiRequestHandler(postExperimentValidator)(
     ) {
       throw new Error(
         "lookbackOverride is only allowed when attributionModel is 'lookbackOverride'",
+      );
+    }
+
+    if (payload.statusUpdateSchedule) {
+      validateStatusUpdateSchedule(
+        payload.type ?? "standard",
+        payload.statusUpdateSchedule,
       );
     }
 

--- a/packages/back-end/src/api/experiments/updateExperiment.ts
+++ b/packages/back-end/src/api/experiments/updateExperiment.ts
@@ -262,6 +262,11 @@ export const updateExperiment = createApiRequestHandler(
     );
   }
 
+  if (req.body.statusUpdateSchedule) {
+    const effectiveType = req.body.type ?? experiment.type ?? "standard";
+    validateStatusUpdateSchedule(effectiveType, req.body.statusUpdateSchedule);
+  }
+
   const resolvedOwner = await resolveOwnerToUserId(req.body.owner, req.context);
   const changes = updateExperimentApiPayloadToInterface(
     {
@@ -273,11 +278,7 @@ export const updateExperiment = createApiRequestHandler(
     req.organization,
   );
 
-  if (req.body.statusUpdateSchedule) {
-    const effectiveType = req.body.type ?? experiment.type ?? "standard";
-    validateStatusUpdateSchedule(effectiveType, req.body.statusUpdateSchedule);
-    normalizeStatusUpdateScheduleChanges(experiment, changes);
-  }
+  normalizeStatusUpdateScheduleChanges(experiment, changes);
 
   const isStartingFromDraft =
     experiment.status === "draft" && changes.status === "running";

--- a/packages/back-end/src/api/experiments/updateExperiment.ts
+++ b/packages/back-end/src/api/experiments/updateExperiment.ts
@@ -14,6 +14,7 @@ import {
   normalizeStatusUpdateScheduleChanges,
   toExperimentApiInterface,
   updateExperimentApiPayloadToInterface,
+  validateStatusUpdateSchedule,
   validateVariationIds,
 } from "back-end/src/services/experiments";
 import { assertRegisteredAttributes } from "back-end/src/services/attributes";
@@ -272,7 +273,11 @@ export const updateExperiment = createApiRequestHandler(
     req.organization,
   );
 
-  normalizeStatusUpdateScheduleChanges(experiment, changes);
+  if (req.body.statusUpdateSchedule) {
+    const effectiveType = req.body.type ?? experiment.type ?? "standard";
+    validateStatusUpdateSchedule(effectiveType, req.body.statusUpdateSchedule);
+    normalizeStatusUpdateScheduleChanges(experiment, changes);
+  }
 
   const isStartingFromDraft =
     experiment.status === "draft" && changes.status === "running";

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -61,6 +61,7 @@ import {
   updateExperimentAndSync,
   validateVariationIds,
   validateExperimentData,
+  validateStatusUpdateSchedule,
 } from "back-end/src/services/experiments";
 import { assertRegisteredAttributes } from "back-end/src/services/attributes";
 import {
@@ -1687,6 +1688,11 @@ export async function postExperiment(
       });
       return;
     }
+  }
+
+  if (data.statusUpdateSchedule) {
+    const effectiveType = data.type ?? experiment.type ?? "standard";
+    validateStatusUpdateSchedule(effectiveType, data.statusUpdateSchedule);
   }
 
   const keys: (keyof ExperimentInterface)[] = [

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2484,11 +2484,7 @@ export async function toExperimentApiInterface(
     templateId: experiment.templateId || undefined,
     statusUpdateSchedule: experiment.statusUpdateSchedule
       ? {
-          ...(experiment.statusUpdateSchedule.startAt
-            ? {
-                startAt: experiment.statusUpdateSchedule.startAt.toISOString(),
-              }
-            : {}),
+          startAt: experiment.statusUpdateSchedule.startAt.toISOString(),
         }
       : experiment.statusUpdateSchedule,
     // Only "start" is produced for experiments; updateExperimentStatus.ts

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -82,6 +82,7 @@ import {
   ApiExperimentMetric,
   ApiExperimentResults,
   ApiMetric,
+  ExperimentType,
 } from "shared/validators";
 import { Dimension } from "shared/types/integrations";
 import {
@@ -3720,6 +3721,10 @@ export function postExperimentApiPayloadToInterface(
     ...(payload.defaultDashboardId !== undefined
       ? { defaultDashboardId: payload.defaultDashboardId }
       : {}),
+    statusUpdateSchedule:
+      payload.statusUpdateSchedule && payload.statusUpdateSchedule.startAt
+        ? { startAt: getValidDate(payload.statusUpdateSchedule.startAt) }
+        : undefined,
   };
 
   const { settings } = getScopedSettings({
@@ -3890,6 +3895,22 @@ function resolveExperimentUpdateVariationsAndPhases(
   };
 }
 
+export function validateStatusUpdateSchedule(
+  experimentType: ExperimentType,
+  statusUpdateSchedule: ExperimentInterfaceStringDates["statusUpdateSchedule"],
+): void {
+  if (experimentType === "multi-armed-bandit" && statusUpdateSchedule) {
+    throw new Error("Bandit experiments do not support scheduled starts.");
+  }
+  if (
+    statusUpdateSchedule &&
+    statusUpdateSchedule.startAt &&
+    getValidDate(statusUpdateSchedule.startAt) <= new Date()
+  ) {
+    throw new Error("statusUpdateSchedule.startAt must be in the future");
+  }
+}
+
 /**
  * Normalize `statusUpdateSchedule` / `nextScheduledStatusUpdate` on an in-progress
  * Changeset:
@@ -3905,13 +3926,6 @@ export function normalizeStatusUpdateScheduleChanges(
   changes: Changeset,
 ): void {
   if ("statusUpdateSchedule" in changes) {
-    const effectiveType = changes.type ?? experiment.type;
-    if (
-      effectiveType === "multi-armed-bandit" &&
-      !!changes.statusUpdateSchedule
-    ) {
-      throw new Error("Bandit experiments do not support scheduled starts.");
-    }
     const incoming = changes.statusUpdateSchedule;
     if (incoming === null) {
       changes.statusUpdateSchedule = null;

--- a/packages/back-end/test/services/experiments.test.ts
+++ b/packages/back-end/test/services/experiments.test.ts
@@ -1616,42 +1616,6 @@ describe("normalizeStatusUpdateScheduleChanges", () => {
     expect(changes.nextScheduledStatusUpdate).toBeNull();
   });
 
-  it("throws for bandit experiments when a schedule is provided", () => {
-    const experiment = makeExperiment({ type: "multi-armed-bandit" });
-    const changes: Partial<ExperimentInterface> = {
-      statusUpdateSchedule: { startAt: new Date("2099-01-01") },
-    };
-
-    expect(() =>
-      normalizeStatusUpdateScheduleChanges(experiment, changes),
-    ).toThrow("Bandit experiments do not support scheduled starts.");
-  });
-
-  it("does not throw for bandit experiments when schedule is explicitly cleared", () => {
-    const experiment = makeExperiment({ type: "multi-armed-bandit" });
-    const changes: Partial<ExperimentInterface> = {
-      statusUpdateSchedule: null,
-    };
-
-    expect(() =>
-      normalizeStatusUpdateScheduleChanges(experiment, changes),
-    ).not.toThrow();
-    expect(changes.statusUpdateSchedule).toBeNull();
-    expect(changes.nextScheduledStatusUpdate).toBeNull();
-  });
-
-  it("type changing to bandit with a schedule throws", () => {
-    const experiment = makeExperiment({ type: "standard" });
-    const changes: Partial<ExperimentInterface> = {
-      type: "multi-armed-bandit",
-      statusUpdateSchedule: { startAt: new Date("2099-01-01") },
-    };
-
-    expect(() =>
-      normalizeStatusUpdateScheduleChanges(experiment, changes),
-    ).toThrow("Bandit experiments do not support scheduled starts.");
-  });
-
   it("status moving out of draft clears a pending staged start when no schedule key is present", () => {
     const experiment = makeExperiment({
       status: "draft",

--- a/packages/back-end/test/services/experiments.test.ts
+++ b/packages/back-end/test/services/experiments.test.ts
@@ -17,6 +17,7 @@ import {
   putMetricApiPayloadIsValid,
   putMetricApiPayloadToMetricInterface,
   updateExperimentApiPayloadToInterface,
+  validateStatusUpdateSchedule,
 } from "back-end/src/services/experiments";
 
 describe("experiments utils", () => {
@@ -1658,5 +1659,40 @@ describe("normalizeStatusUpdateScheduleChanges", () => {
     normalizeStatusUpdateScheduleChanges(experiment, changes);
 
     expect(changes.nextScheduledStatusUpdate).toBeUndefined();
+  });
+});
+
+describe("validateStatusUpdateSchedule", () => {
+  it("throws when experiment type is bandit and a schedule is provided", () => {
+    expect(() =>
+      validateStatusUpdateSchedule("multi-armed-bandit", {
+        startAt: "2099-01-01T00:00:00Z",
+      }),
+    ).toThrow("Bandit experiments do not support scheduled starts.");
+  });
+
+  it("throws when startAt is in the past", () => {
+    expect(() =>
+      validateStatusUpdateSchedule("standard", {
+        startAt: "2000-01-01T00:00:00Z",
+      }),
+    ).toThrow("statusUpdateSchedule.startAt must be in the future");
+  });
+
+  it("throws when effective type changes to bandit and a schedule exists", () => {
+    const effectiveType = "multi-armed-bandit";
+    expect(() =>
+      validateStatusUpdateSchedule(effectiveType, {
+        startAt: "2099-01-01T00:00:00Z",
+      }),
+    ).toThrow("Bandit experiments do not support scheduled starts.");
+  });
+
+  it("does not throw for a valid future startAt on a standard experiment", () => {
+    expect(() =>
+      validateStatusUpdateSchedule("standard", {
+        startAt: "2099-01-01T00:00:00Z",
+      }),
+    ).not.toThrow();
   });
 });

--- a/packages/front-end/components/Experiment/EditScheduleModal.tsx
+++ b/packages/front-end/components/Experiment/EditScheduleModal.tsx
@@ -1,6 +1,7 @@
 import { useForm } from "react-hook-form";
 import { ExperimentInterfaceStringDates } from "shared/types/experiment";
 import { Box } from "@radix-ui/themes";
+import { format as formatTimeZone } from "date-fns-tz";
 import ModalStandard from "@/ui/Modal/Patterns/ModalStandard";
 import DatePicker from "@/components/DatePicker";
 import { useAuth } from "@/services/auth";
@@ -81,7 +82,10 @@ export default function EditScheduleModal({
     >
       <Box>
         <Text as="label" color="text-high" mb={hasSchedule ? "1" : "2"}>
-          Start Date & Time
+          Start Date & Time{" "}
+          <Text as="span" color="text-mid">
+            ({formatTimeZone(new Date(), "z")})
+          </Text>
         </Text>
         {hasSchedule && (
           <Text as="div" color="text-mid" mb="2">

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -19,7 +19,7 @@ import {
   ReportInterface,
 } from "shared/types/report";
 import { HoldoutInterfaceStringDates } from "shared/validators";
-import { format } from "date-fns";
+import { format } from "date-fns-tz";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import { useAuth } from "@/services/auth";
 import { Tabs, TabsList, TabsTrigger } from "@/ui/Tabs";
@@ -813,7 +813,10 @@ export default function ExperimentHeader({
                     }}
                   >
                     Starts{" "}
-                    {format(nextScheduledStartDate, "MMM d, yyyy 'at' h:mm a")}{" "}
+                    {format(
+                      nextScheduledStartDate,
+                      "MMM d, yyyy 'at' h:mm a (z)",
+                    )}{" "}
                     {editSchedule && <PiPencilSimpleFill className="ml-1" />}
                   </Button>
                 ) : experiment.status === "draft" ? (

--- a/packages/front-end/components/Experiment/TabbedPage/SetupTabOverview.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/SetupTabOverview.tsx
@@ -14,7 +14,7 @@ import {
   PiPencilSimpleFill,
   PiWarningFill,
 } from "react-icons/pi";
-import { format } from "date-fns";
+import { format } from "date-fns-tz";
 import { PreLaunchChecklist } from "@/components/Experiment/PreLaunchChecklist";
 import CustomFieldDisplay from "@/components/CustomFields/CustomFieldDisplay";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
@@ -194,7 +194,7 @@ export default function SetupTabOverview({
                 {experiment.statusUpdateSchedule?.startAt
                   ? format(
                       new Date(experiment.statusUpdateSchedule.startAt),
-                      "MMM d, yyyy 'at' h:mm a",
+                      "MMM d, yyyy 'at' h:mm a (z)",
                     )
                   : ""}{" "}
                 <PiPencilSimpleFill className="ml-1" />

--- a/packages/front-end/components/Experiment/TabbedPage/StartExperimentModal.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/StartExperimentModal.tsx
@@ -1,5 +1,5 @@
 import { ExperimentInterfaceStringDates } from "shared/types/experiment";
-import { format } from "date-fns";
+import { format } from "date-fns-tz";
 import { useState } from "react";
 import { Flex } from "@radix-ui/themes";
 import Modal, { useModalContext } from "@/ui/Modal";
@@ -120,7 +120,7 @@ export default function StartExperimentModal({
 
   const subHeader =
     hasSchedule && parsedScheduledDate
-      ? `Scheduled to start ${format(parsedScheduledDate, "MMM d, yyyy 'at' h:mm a")}`
+      ? `Scheduled to start ${format(parsedScheduledDate, "MMM d, yyyy 'at' h:mm a (z)")}`
       : null;
 
   const primaryAction = useScheduledFlow
@@ -191,7 +191,7 @@ export default function StartExperimentModal({
             <Callout status="warning" mb="3">
               The scheduled start date{" "}
               <Text weight="semibold">
-                {format(parsedScheduledDate, "MMM d, yyyy 'at' h:mm a")}
+                {format(parsedScheduledDate, "MMM d, yyyy 'at' h:mm a (z)")}
               </Text>{" "}
               has passed. Click <Text weight="semibold">Start Now</Text> to
               start the experiment immediately, or close this modal and update

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -1126,8 +1126,7 @@ const postExperimentBody = z
           .meta({ format: "date-time" })
           .describe(
             "ISO datetime when the experiment should start. Must be in the future.",
-          )
-          .optional(),
+          ),
       })
       .describe(
         "Schedule a future start for a draft experiment. Only `startAt` is currently supported.",
@@ -1313,8 +1312,7 @@ const updateExperimentBody = z
           .meta({ format: "date-time" })
           .describe(
             "ISO datetime when the experiment should start. Must be in the future. Setting or clearing this field invalidates any existing staged start (`nextScheduledStatusUpdate`); call POST /experiments/{id}/start to stage the new schedule.",
-          )
-          .optional(),
+          ),
       })
       .describe(
         "Schedule a future start for a draft experiment. Set to `null` to remove the schedule. Provide `{ startAt }` to set or update it. Only `startAt` is currently supported.",

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -338,7 +338,7 @@ export type ExperimentAnalysisSummary = z.infer<
 
 // TODO(schedule-status-updates): add stopAt
 export const statusUpdateScheduleValidator = z.object({
-  startAt: z.date().optional(),
+  startAt: z.date(),
 });
 
 const nextScheduledStatusUpdateValidator = z.object({
@@ -725,6 +725,21 @@ const apiCustomMetricSlices = z
     "Custom slices that apply to ALL applicable metrics in the experiment",
   );
 
+const apiStatusUpdateSchedule = z
+  .object({
+    startAt: z
+      .string()
+      .meta({ format: "date-time" })
+      .describe(
+        "ISO datetime when the experiment should start. Must be in the future. " +
+          "Setting or clearing this field invalidates any existing staged start " +
+          "(`nextScheduledStatusUpdate`); call POST /experiments/{id}/start to stage the new schedule.",
+      ),
+  })
+  .describe(
+    "Schedule a future start for a draft experiment. Only `startAt` is currently supported.",
+  );
+
 // Corresponds to schemas/Experiment.yaml
 const apiExperimentShape = z.object({
   id: z.string(),
@@ -770,12 +785,7 @@ const apiExperimentShape = z.object({
     .describe("ID of the default dashboard for this experiment.")
     .optional(),
   templateId: z.string().optional(),
-  statusUpdateSchedule: z
-    .object({
-      startAt: z.string().meta({ format: "date-time" }).optional(),
-    })
-    .nullable()
-    .optional(),
+  statusUpdateSchedule: apiStatusUpdateSchedule.nullable().optional(),
   nextScheduledStatusUpdate: z
     .object({
       // Only "start" is supported for experiments today. The internal
@@ -1119,19 +1129,7 @@ const postExperimentBody = z
       .optional(),
     customFields: z.record(z.string(), z.string()).optional(),
     customMetricSlices: apiCustomMetricSlices.optional(),
-    statusUpdateSchedule: z
-      .object({
-        startAt: z
-          .string()
-          .meta({ format: "date-time" })
-          .describe(
-            "ISO datetime when the experiment should start. Must be in the future.",
-          ),
-      })
-      .describe(
-        "Schedule a future start for a draft experiment. Only `startAt` is currently supported.",
-      )
-      .optional(),
+    statusUpdateSchedule: apiStatusUpdateSchedule.optional(),
   })
   .strict();
 
@@ -1305,15 +1303,7 @@ const updateExperimentBody = z
       .optional(),
     customFields: z.record(z.string(), z.string()).optional(),
     customMetricSlices: apiCustomMetricSlices.optional(),
-    statusUpdateSchedule: z
-      .object({
-        startAt: z
-          .string()
-          .meta({ format: "date-time" })
-          .describe(
-            "ISO datetime when the experiment should start. Must be in the future. Setting or clearing this field invalidates any existing staged start (`nextScheduledStatusUpdate`); call POST /experiments/{id}/start to stage the new schedule.",
-          ),
-      })
+    statusUpdateSchedule: apiStatusUpdateSchedule
       .describe(
         "Schedule a future start for a draft experiment. Set to `null` to remove the schedule. Provide `{ startAt }` to set or update it. Only `startAt` is currently supported.",
       )

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -1119,6 +1119,20 @@ const postExperimentBody = z
       .optional(),
     customFields: z.record(z.string(), z.string()).optional(),
     customMetricSlices: apiCustomMetricSlices.optional(),
+    statusUpdateSchedule: z
+      .object({
+        startAt: z
+          .string()
+          .meta({ format: "date-time" })
+          .describe(
+            "ISO datetime when the experiment should start. Must be in the future.",
+          )
+          .optional(),
+      })
+      .describe(
+        "Schedule a future start for a draft experiment. Only `startAt` is currently supported.",
+      )
+      .optional(),
   })
   .strict();
 
@@ -1298,7 +1312,7 @@ const updateExperimentBody = z
           .string()
           .meta({ format: "date-time" })
           .describe(
-            "ISO datetime when the experiment should start. Setting or clearing this field invalidates any existing staged start (`nextScheduledStatusUpdate`); call POST /experiments/{id}/start to stage the new schedule.",
+            "ISO datetime when the experiment should start. Must be in the future. Setting or clearing this field invalidates any existing staged start (`nextScheduledStatusUpdate`); call POST /experiments/{id}/start to stage the new schedule.",
           )
           .optional(),
       })
@@ -1583,7 +1597,9 @@ export const postExperimentStartValidator = {
         .optional(),
     })
     .strict(),
-  summary: "Start an experiment",
+  summary: "Start/Stage an experiment",
+  description:
+    "Starts an experiment or stages it for a future start if a `statusUpdateSchedule` is set on the experiment.",
   operationId: "postExperimentStart",
   tags: ["experiments"],
   method: "post" as const,


### PR DESCRIPTION
### Features and Changes

Adds support for `statusUpdateSchedule` to the `postExperiment` REST API, adds more validation, updates the description for the start experiment REST API docs, and renders the timezone next to the schedule in the UI.

### Testing

  `POST /api/v1/experiments` — new `statusUpdateSchedule` field

  - [x] Standard experiment with a valid future `startAt` → 200, experiment created with `statusUpdateSchedule` persisted
  - [x] Multi-armed bandit with `statusUpdateSchedule` → 400, `"Bandit experiments do not support scheduled starts."`
  - [x] Standard experiment with a past `startAt` → 400, `"statusUpdateSchedule.startAt must be in the future"`

  `POST /api/v1/experiments/:id` — update `statusUpdateSchedule`

  - [x] Update `startAt` to a new valid future date → 200, `statusUpdateSchedule` updated
  - [x] Update `startAt` to a past date → 400, `"statusUpdateSchedule.startAt must be in the future"`
  - [x] Set `statusUpdateSchedule` on a bandit experiment → 400, `"Bandit experiments do not support scheduled starts."`

  `POST /api/v1/experiments/:id/start` — staging behavior

  - [x] Start a draft experiment with a future `statusUpdateSchedule` → 200, status remains `draft`, `enhancedStatus` becomes `"Scheduled"`,
  `nextScheduledStatusUpdate` populated, response includes a human-readable `message` (e.g. `"…staged to start on Jul 15, 2026 at 10:00 AM
  UTC"`)
  - [x] Call `/start` again on an already-staged experiment → 400, `"Experiment is already staged for a scheduled start. To start now, remove the schedule via the update experiment endpoint."`

### Screenshots

<img width="306" height="65" alt="Screenshot 2026-05-26 at 3 25 19 PM" src="https://github.com/user-attachments/assets/8bfe2ffb-144d-4ebf-b8e3-bac017dab65f" />
