### PR TITLE
chore(docker): apt-get -y upgrade to pull latest Debian patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ WORKDIR /usr/local/src/app
 ARG NODE_OPTIONS="--max-old-space-size=8192"
 ENV NODE_OPTIONS="${NODE_OPTIONS}"
 RUN apt-get update && \
+  apt-get -y upgrade && \
   apt-get install -y --no-install-recommends build-essential python3 ca-certificates libkrb5-dev && \
   npm install -g pnpm@10.33.4 node-gyp && \
   apt-get clean && \
@@ -83,6 +84,7 @@ FROM node:${NODE_MAJOR}-slim
 ARG PYTHON_MAJOR
 WORKDIR /usr/local/src/app
 RUN apt-get update && \
+  apt-get -y upgrade && \
   apt-get install -y --no-install-recommends python${PYTHON_MAJOR} ca-certificates libkrb5-3 && \
   npm install -g pnpm@10.33.4 && \
   rm -rf /usr/local/lib/node_modules/npm && \


### PR DESCRIPTION
## Summary

Add `apt-get -y upgrade` to both the build and runtime stages of the Dockerfile so security patches that Debian publishes between Node Docker base-image rebuilds get pulled in on every image rebuild.

## Motivation

Without this, the runtime image inherits whatever package versions `node:24-slim` was last published with — Debian patches that land between Node Docker rebuilds don't make it in.

Concrete case from today's Vanta report: `gnutls28 3.7.9-2+deb12u7` and `libgcrypt20 1.10.1-3+deb12u1` have been published in Debian bookworm and are already present in the latest `node:24-slim` image, but the most recent `growthbook` image rebuild (`git-eff608d`, pushed at 17:23 today) still shows Vanta findings for the unpatched versions. Reason: we never ran `apt-get upgrade`, so the rebuild reused whatever the base layer happened to contain.

## Pattern parity

`apt-get -y upgrade` is already the standard pattern across our other ECR-tracked services:

- `growthbook-proxy` (both stages)
- `growthbook-proxy-cloud` (both stages)
- `growthbook-ingestor` (ingestor stage)
- `central-license-server` (runtime stage)
- `internal-slackbot` (runtime stage)

This PR brings `growthbook` in line with that pattern.

## Reproducibility note

The standard objection to `apt-get upgrade` in Dockerfiles is reproducibility — same Dockerfile, different package versions a week later. For prod runtime images under an active Vanta vuln SLA, the trade-off flips: shipping known CVEs is a direct, recurring cost; nondeterminism is rare and debuggable. If we want belt-and-suspenders reproducibility we can pair this with a digest-pin on `node:24-slim` in a follow-up.

## Test plan

- [ ] CI build passes
- [ ] Pull the resulting image and `dpkg -l | grep -E "libgnutls30|libgcrypt20"` shows the `deb12u7` / `deb12u1` versions
- [ ] On next Vanta rescan after this is deployed, the 11 OS findings (gnutls28 ×10, libgcrypt20 ×1) drop off

🤖 Generated with [Claude Code](https://claude.com/claude-code)