### PR TITLE
Add new experiment.warning webhook event for no data

### DIFF
--- a/docs/src/partials/event-webhook/_event-webhook-list.md
+++ b/docs/src/partials/event-webhook/_event-webhook-list.md
@@ -2483,6 +2483,10 @@ Triggered when a warning condition is detected on an experiment
             experimentId: string;
             threshold: number;
         } | {
+            type: "no-data";
+            experimentName: string;
+            experimentId: string;
+        } | {
             type: "scheduled-status-update-failed";
             experimentName: string;
             experimentId: string;

--- a/packages/back-end/src/events/handlers/slack/slack-event-handler-utils.ts
+++ b/packages/back-end/src/events/handlers/slack/slack-event-handler-utils.ts
@@ -1052,6 +1052,26 @@ const buildSlackMessageForExperimentWarningEvent = (
       };
     }
 
+    case "no-data": {
+      const text = (experimentName: string) =>
+        `No data yet for experiment ${experimentName}. The most recent update ran successfully but returned no results. Make sure your experiment is tracking properly.`;
+
+      return {
+        text: text(data.experimentName),
+        blocks: [
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text:
+                text(`*${data.experimentName}*`) +
+                getExperimentUrlFormatted(data.experimentId),
+            },
+          },
+        ],
+      };
+    }
+
     case "scheduled-status-update-failed": {
       const action =
         data.scheduledStatusUpdateType === "start" ? "start" : "stop";

--- a/packages/back-end/src/services/experimentNotifications.ts
+++ b/packages/back-end/src/services/experimentNotifications.ts
@@ -255,6 +255,48 @@ export const notifySrm = async ({
   return triggered && !experiment.pastNotifications?.includes("srm");
 };
 
+export const notifyNoData = async ({
+  context,
+  experiment,
+  snapshot,
+}: {
+  context: Context;
+  experiment: ExperimentInterface;
+  snapshot: ExperimentSnapshotInterface;
+}) => {
+  // Mirror the front-end "No data yet" check: the snapshot ran successfully but
+  // the default analysis returned no variation rows.
+  const analysis = getSnapshotAnalysis(snapshot);
+  const triggered =
+    snapshot.status === "success" &&
+    (analysis?.results?.[0]?.variations?.length ?? 0) === 0;
+
+  await memoizeNotification({
+    context,
+    experiment,
+    type: "no-data",
+    triggered,
+    dispatch: async () => {
+      if (!triggered) return;
+
+      await dispatchEvent({
+        context,
+        experiment,
+        event: "warning",
+        data: {
+          object: {
+            type: "no-data",
+            experimentId: experiment.id,
+            experimentName: experiment.name,
+          },
+        },
+      });
+    },
+  });
+
+  return triggered && !experiment.pastNotifications?.includes("no-data");
+};
+
 type ExperimentSignificanceChange = {
   experimentId: string;
   experimentName: string;
@@ -600,6 +642,15 @@ export const notifyExperimentChange = async ({
     healthSettings,
     decisionCriteria,
   });
+
+  const triggeredNoData = await notifyNoData({
+    context,
+    experiment,
+    snapshot,
+  });
+  if (triggeredNoData) {
+    notificationsTriggered.push("no-data");
+  }
 
   if (currentStatus) {
     const triggeredMultipleExposures = await notifyMultipleExposures({

--- a/packages/back-end/test/events/experiment.test.ts
+++ b/packages/back-end/test/events/experiment.test.ts
@@ -1,3 +1,4 @@
+import { ExperimentSnapshotInterface } from "shared/types/experiment-snapshot";
 import {
   logExperimentCreated,
   logExperimentUpdated,
@@ -9,6 +10,7 @@ import { experimentSnapshot } from "back-end/test/snapshots/experiment.snapshot"
 import {
   notifyDecision,
   notifyMultipleExposures,
+  notifyNoData,
   notifySrm,
 } from "back-end/src/services/experimentNotifications";
 import { EventModel } from "back-end/src/models/EventModel";
@@ -995,6 +997,104 @@ describe("experiments events", () => {
         type: "dashboard",
       },
     });
+  });
+
+  it("dispatches experiment.warning event when a snapshot returns no data", async () => {
+    let rawPayload;
+
+    jest.spyOn(EventModel, "create").mockImplementation(({ data }) => {
+      if (data.event === "experiment.warning") rawPayload = data;
+      return { toJSON: () => "" };
+    });
+
+    jest
+      .spyOn(ExperimentModel, "updateOne")
+      .mockImplementation(() => undefined);
+
+    const noDataSnapshot = {
+      status: "success",
+      analyses: [{ results: [{ variations: [] }] }],
+    } as unknown as ExperimentSnapshotInterface;
+
+    await notifyNoData({
+      context: {
+        org,
+        userId: "user-aabb",
+        email: "user@email.com",
+        userName: "User Name",
+        auditUser: {
+          type: "dashboard",
+          id: "user-aabb",
+          email: "user@email.com",
+          name: "User Name",
+        },
+      },
+      experiment: experimentSnapshot,
+      snapshot: noDataSnapshot,
+    });
+
+    expect(rawPayload).toEqual(
+      expect.objectContaining({
+        api_version: expect.any(String),
+        containsSecrets: false,
+        created: expect.any(Number),
+        environments: [],
+        event: "experiment.warning",
+        object: "experiment",
+        projects: [],
+        tags: [],
+        data: {
+          object: {
+            experimentId: "exp_dd4gxd4lyel8bwi",
+            experimentName: "Add To Cart",
+            type: "no-data",
+          },
+        },
+        user: {
+          email: "user@email.com",
+          id: "user-aabb",
+          name: "User Name",
+          type: "dashboard",
+        },
+      }),
+    );
+  });
+
+  it("does not dispatch experiment.warning no-data event when the snapshot has data", async () => {
+    let rawPayload;
+
+    jest.spyOn(EventModel, "create").mockImplementation(({ data }) => {
+      if (data.event === "experiment.warning") rawPayload = data;
+      return { toJSON: () => "" };
+    });
+
+    jest
+      .spyOn(ExperimentModel, "updateOne")
+      .mockImplementation(() => undefined);
+
+    const hasDataSnapshot = {
+      status: "success",
+      analyses: [{ results: [{ variations: [{}, {}] }] }],
+    } as unknown as ExperimentSnapshotInterface;
+
+    await notifyNoData({
+      context: {
+        org,
+        userId: "user-aabb",
+        email: "user@email.com",
+        userName: "User Name",
+        auditUser: {
+          type: "dashboard",
+          id: "user-aabb",
+          email: "user@email.com",
+          name: "User Name",
+        },
+      },
+      experiment: experimentSnapshot,
+      snapshot: hasDataSnapshot,
+    });
+
+    expect(rawPayload).toEqual(undefined);
   });
 
   it("dispatches decision update when decision to ship", async () => {

--- a/packages/shared/src/validators/experiment-warnings.ts
+++ b/packages/shared/src/validators/experiment-warnings.ts
@@ -28,6 +28,14 @@ export const srm = z
   })
   .strict();
 
+export const noData = z
+  .object({
+    type: z.literal("no-data"),
+    experimentName: z.string(),
+    experimentId: z.string(),
+  })
+  .strict();
+
 export const scheduledStatusUpdateFailed = z
   .object({
     type: z.literal("scheduled-status-update-failed"),
@@ -47,6 +55,7 @@ export const experimentWarningNotificationPayload = z.union([
   autoUpdateFailed,
   multipleExposures,
   srm,
+  noData,
   scheduledStatusUpdateFailed,
 ]);
 

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -161,6 +161,7 @@ export const experimentNotification = [
   "auto-update",
   "multiple-exposures",
   "srm",
+  "no-data",
   "significance",
 ] as const;
 export type ExperimentNotification = (typeof experimentNotification)[number];


### PR DESCRIPTION
## Add `no-data` experiment health warning

### Summary
Adds a new `no-data` warning that fires as an `experiment.warning` event when a successful snapshot returns no results — the same condition the UI already surfaces as "No data yet" (`analysis.results[0].variations.length === 0`). This brings the no-data state in line with our other health warnings (`srm`, `multiple-exposures`) so it can be consumed via webhooks and Slack.

### Changes
- **shared/validators/experiment-warnings.ts**: Add `noData` payload schema (`type`, `experimentName`, `experimentId`) to the `experiment.warning` union.
- **shared/validators/experiments.ts**: Add `"no-data"` to the `experimentNotification` enum so the warning is memoized in `pastNotifications` and only re-fires when the state changes.
- **back-end/services/experimentNotifications.ts**: Add memoized `notifyNoData()` and wire it into `notifyExperimentChange()` (runs on every successful standard snapshot).
- **back-end/events/handlers/slack/slack-event-handler-utils.ts**: Add `no-data` case to the warning Slack message builder.
- **docs/.../_event-webhook-list.md**: Regenerated to document the new payload variant.
- **back-end/test/events/experiment.test.ts**: Add tests for the triggered (no data) and not-triggered (has data) cases.

### Notes
- Matches the front-end's exact no-data definition for consistency with the UI warning.
- Memoized like other health warnings to avoid spamming consumers on every refresh; resets once data appears.

### Test plan
- [x] `pnpm --filter shared type-check` / `pnpm --filter back-end type-check`
- [x] `pnpm --filter back-end test test/events/experiment.test.ts` (11 passing)
- [x] Lint clean on edited files