### PR TITLE
perf(view-queries): Use preview for sql + virtualize results

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1078,11 +1078,6 @@
       "count": 1
     }
   },
-  "packages/front-end/components/Queries/ExpandableQuery.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
   "packages/front-end/components/Queries/QueriesLastRun.tsx": {
     "no-restricted-imports": {
       "count": 1

--- a/packages/front-end/components/Queries/ExpandableQuery.tsx
+++ b/packages/front-end/components/Queries/ExpandableQuery.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, ReactNode, useCallback } from "react";
 import { QueryInterface } from "shared/types/query";
 import { formatDistanceStrict } from "date-fns";
 import {
@@ -17,6 +17,7 @@ import Callout from "@/ui/Callout";
 import HelperText from "@/ui/HelperText";
 import { useUser } from "@/services/UserContext";
 import QueryStatsRow from "./QueryStatsRow";
+import QueryResultTable from "./QueryResultTable";
 
 const ExpandableQuery: FC<{
   query: QueryInterface;
@@ -35,6 +36,42 @@ const ExpandableQuery: FC<{
 
   const { hasCommercialFeature } = useUser();
   const hasOptimizedQueries = hasCommercialFeature("multi-metric-queries");
+
+  const getResultCell = useCallback(
+    (value: unknown): { content: ReactNode; text: string } => {
+      if (typeof value === "string" && isFactMetricId(value)) {
+        const factMetric = getFactMetricById(value);
+        if (factMetric) {
+          const name = factMetric.name || value;
+          return {
+            content: (
+              <span className="badge badge-secondary" title={value}>
+                {name}
+              </span>
+            ),
+            text: name,
+          };
+        }
+      }
+
+      const json = JSON.stringify(value);
+      return {
+        content: json ?? <em className="text-muted">null</em>,
+        text: json ?? "null",
+      };
+    },
+    [getFactMetricById],
+  );
+
+  const renderResultValue = useCallback(
+    (value: unknown) => getResultCell(value).content,
+    [getResultCell],
+  );
+
+  const getResultCellText = useCallback(
+    (value: unknown) => getResultCell(value).text,
+    [getResultCell],
+  );
 
   return (
     <div className="mb-4">
@@ -79,68 +116,20 @@ const ExpandableQuery: FC<{
       </h4>
       <Code language={query.language} code={query.query} expandable={true} />
       {query.error && (
-        <div className="alert alert-danger">
+        <Callout status="error" my="3">
           <pre className="m-0 p-0" style={{ whiteSpace: "pre-wrap" }}>
             {query.error}
           </pre>
-        </div>
+        </Callout>
       )}
       {query.status === "succeeded" && (
         <>
           {query.rawResult?.[0] ? (
-            <div style={{ maxHeight: 300, overflowY: "auto" }}>
-              <table className="table table-bordered table-sm query-table">
-                <thead>
-                  <tr
-                    style={{
-                      position: "sticky",
-                      top: -1,
-                    }}
-                  >
-                    <th></th>
-                    {Object.keys(query.rawResult[0]).map((k) => (
-                      <th key={k}>{k}</th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {query.rawResult.map((row, i) => {
-                    return (
-                      <tr key={i}>
-                        <th>{i}</th>
-                        {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
-                        {Object.keys(query.rawResult[0]).map((k) => {
-                          const val = row[k];
-                          if (typeof val === "string" && isFactMetricId(val)) {
-                            const factMetric = getFactMetricById(val);
-                            if (factMetric) {
-                              return (
-                                <td key={k}>
-                                  <span
-                                    className="badge badge-secondary"
-                                    title={val}
-                                  >
-                                    {factMetric?.name || val}
-                                  </span>
-                                </td>
-                              );
-                            }
-                          }
-
-                          return (
-                            <td key={k}>
-                              {JSON.stringify(row[k]) ?? (
-                                <em className="text-muted">null</em>
-                              )}
-                            </td>
-                          );
-                        })}
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
+            <QueryResultTable
+              rows={query.rawResult}
+              renderValue={renderResultValue}
+              getCellText={getResultCellText}
+            />
           ) : query.query.startsWith("SELECT") ? (
             <Callout status="warning" my="3">
               No rows returned

--- a/packages/front-end/components/Queries/QueryResultTable/PlainQueryResultTable.tsx
+++ b/packages/front-end/components/Queries/QueryResultTable/PlainQueryResultTable.tsx
@@ -1,0 +1,37 @@
+import { ReactNode } from "react";
+import { RESULT_TABLE_MAX_HEIGHT } from "./constants";
+
+export default function PlainQueryResultTable({
+  rows,
+  columns,
+  renderValue,
+}: {
+  rows: Record<string, unknown>[];
+  columns: string[];
+  renderValue: (value: unknown) => ReactNode;
+}) {
+  return (
+    <div style={{ maxHeight: RESULT_TABLE_MAX_HEIGHT, overflow: "auto" }}>
+      <table className="table table-bordered table-sm query-table">
+        <thead>
+          <tr style={{ position: "sticky", top: -1 }}>
+            <th></th>
+            {columns.map((key) => (
+              <th key={key}>{key}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, rowIndex) => (
+            <tr key={rowIndex}>
+              <th>{rowIndex}</th>
+              {columns.map((key) => (
+                <td key={key}>{renderValue(row[key])}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/packages/front-end/components/Queries/QueryResultTable/QueryResultTable.module.scss
+++ b/packages/front-end/components/Queries/QueryResultTable/QueryResultTable.module.scss
@@ -1,0 +1,40 @@
+.headerRow {
+  background-color: var(--slate-2);
+}
+
+.cell {
+  box-sizing: border-box;
+  padding: var(--qrt-cell-padding);
+  line-height: var(--qrt-cell-line-height);
+  border-right: var(--qrt-cell-border) solid var(--slate-a4);
+  border-bottom: var(--qrt-cell-border) solid var(--slate-a4);
+  font-size: var(--qrt-cell-font-size);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.firstColumn {
+  border-left: var(--qrt-cell-border) solid var(--slate-a4);
+}
+
+.indexCell {
+  font-weight: 700;
+  background-color: var(--slate-2);
+}
+
+.headerCell {
+  font-weight: 700;
+  background-color: var(--slate-2);
+  border-top: var(--qrt-cell-border) solid var(--slate-a4);
+}
+
+:global(.dark-theme) {
+  .indexCell,
+  .headerCell,
+  .headerRow {
+    // we cannot use --slate-a2 here because it is transparent
+    // so we hard code the color of slate-a2 on top of background color
+    background-color: rgba(36, 43, 61, 1);
+  }
+}

--- a/packages/front-end/components/Queries/QueryResultTable/VirtualizedQueryResultTable.tsx
+++ b/packages/front-end/components/Queries/QueryResultTable/VirtualizedQueryResultTable.tsx
@@ -1,0 +1,173 @@
+import { CSSProperties, ReactNode, useMemo, useRef } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { ScrollArea } from "@radix-ui/themes";
+import clsx from "clsx";
+import styles from "./QueryResultTable.module.scss";
+import { computeColumnWidths, GetCellText } from "./columnWidths";
+import {
+  CELL_BORDER,
+  CELL_FONT_SIZE,
+  CELL_LINE_HEIGHT,
+  CELL_PADDING,
+  RESULT_TABLE_MAX_HEIGHT,
+  RESULT_TABLE_ROW_HEIGHT,
+  RESULT_TABLE_ROW_OVERSCAN,
+  RESULT_TABLE_COLUMN_OVERSCAN,
+} from "./constants";
+
+const CELL_STYLE_VARS = {
+  "--qrt-cell-font-size": `${CELL_FONT_SIZE}px`,
+  "--qrt-cell-line-height": `${CELL_LINE_HEIGHT}`,
+  "--qrt-cell-padding": `${CELL_PADDING}px`,
+  "--qrt-cell-border": `${CELL_BORDER}px`,
+};
+
+export default function VirtualizedQueryResultTable({
+  rows,
+  columns,
+  renderValue,
+  getCellText,
+}: {
+  rows: Record<string, unknown>[];
+  columns: string[];
+  renderValue: (value: unknown) => ReactNode;
+  getCellText: GetCellText;
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const columnWidths = useMemo(
+    () => computeColumnWidths(rows, columns, getCellText),
+    [rows, columns, getCellText],
+  );
+  const columnCount = columnWidths.length;
+
+  const rowVirtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => RESULT_TABLE_ROW_HEIGHT,
+    overscan: RESULT_TABLE_ROW_OVERSCAN,
+    // The sticky header occupies the first row-height of the scroll content, so
+    // the body list starts that far down. Setting scrollMargin to the header
+    // height keeps the visible-window math correct and makes each item's `start`
+    // already include the offset — so it doubles as the absolute top below.
+    scrollMargin: RESULT_TABLE_ROW_HEIGHT,
+  });
+
+  const columnVirtualizer = useVirtualizer({
+    horizontal: true,
+    count: columnCount,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: (index) => columnWidths[index],
+    overscan: RESULT_TABLE_COLUMN_OVERSCAN,
+  });
+
+  const totalWidth = columnVirtualizer.getTotalSize();
+  const bodyHeight = rowVirtualizer.getTotalSize();
+  const columnItems = columnVirtualizer.getVirtualItems();
+  const innerHeight = RESULT_TABLE_ROW_HEIGHT + bodyHeight;
+
+  // Make the vertical scrollbar show up below the sticky header
+  const scrollAreaStyle = {
+    ...CELL_STYLE_VARS,
+    maxWidth: `min(100%, ${totalWidth}px)`,
+    maxHeight: RESULT_TABLE_MAX_HEIGHT,
+    "--scrollarea-scrollbar-vertical-margin-top": `${
+      RESULT_TABLE_ROW_HEIGHT + 4
+    }px`,
+  };
+
+  return (
+    <ScrollArea
+      ref={scrollRef}
+      scrollbars="both"
+      type="auto"
+      style={scrollAreaStyle}
+    >
+      <div
+        style={{
+          position: "relative",
+          width: totalWidth,
+          height: innerHeight,
+        }}
+      >
+        <div
+          className={styles.headerRow}
+          style={{
+            position: "sticky",
+            top: 0,
+            zIndex: 1,
+            width: totalWidth,
+            height: RESULT_TABLE_ROW_HEIGHT,
+          }}
+        >
+          {columnItems.map((column) => {
+            // Column 0 is the index column header, intentionally blank.
+            const label = column.index === 0 ? "" : columns[column.index - 1];
+            return (
+              <div
+                key={column.index}
+                title={label || undefined}
+                className={clsx(
+                  styles.cell,
+                  styles.headerCell,
+                  column.index === 0 && styles.firstColumn,
+                )}
+                style={{
+                  position: "absolute",
+                  left: column.start,
+                  width: column.size,
+                  height: RESULT_TABLE_ROW_HEIGHT,
+                }}
+              >
+                {label}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Body cells are positioned absolutely below the header. row.start
+            already includes the header offset because scrollMargin equals the
+            header height, so it doubles as the absolute top within this box. */}
+        {rowVirtualizer.getVirtualItems().map((row) =>
+          columnItems.map((column) => {
+            const cellStyle: CSSProperties = {
+              position: "absolute",
+              top: row.start,
+              left: column.start,
+              width: column.size,
+              height: row.size,
+            };
+
+            if (column.index === 0) {
+              return (
+                <div
+                  key={`${row.index}:${column.index}`}
+                  className={clsx(
+                    styles.cell,
+                    styles.indexCell,
+                    styles.firstColumn,
+                  )}
+                  style={cellStyle}
+                >
+                  {row.index}
+                </div>
+              );
+            }
+
+            const value = rows[row.index][columns[column.index - 1]];
+            return (
+              <div
+                key={`${row.index}:${column.index}`}
+                title={getCellText(value)}
+                className={styles.cell}
+                style={cellStyle}
+              >
+                {renderValue(value)}
+              </div>
+            );
+          }),
+        )}
+      </div>
+    </ScrollArea>
+  );
+}

--- a/packages/front-end/components/Queries/QueryResultTable/VirtualizedQueryResultTable.tsx
+++ b/packages/front-end/components/Queries/QueryResultTable/VirtualizedQueryResultTable.tsx
@@ -1,6 +1,5 @@
 import { CSSProperties, ReactNode, useMemo, useRef } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { ScrollArea } from "@radix-ui/themes";
 import clsx from "clsx";
 import styles from "./QueryResultTable.module.scss";
 import { computeColumnWidths, GetCellText } from "./columnWidths";
@@ -66,23 +65,15 @@ export default function VirtualizedQueryResultTable({
   const columnItems = columnVirtualizer.getVirtualItems();
   const innerHeight = RESULT_TABLE_ROW_HEIGHT + bodyHeight;
 
-  // Make the vertical scrollbar show up below the sticky header
-  const scrollAreaStyle = {
+  const scrollAreaStyle: CSSProperties = {
     ...CELL_STYLE_VARS,
     maxWidth: `min(100%, ${totalWidth}px)`,
     maxHeight: RESULT_TABLE_MAX_HEIGHT,
-    "--scrollarea-scrollbar-vertical-margin-top": `${
-      RESULT_TABLE_ROW_HEIGHT + 4
-    }px`,
+    overflow: "auto",
   };
 
   return (
-    <ScrollArea
-      ref={scrollRef}
-      scrollbars="both"
-      type="auto"
-      style={scrollAreaStyle}
-    >
+    <div ref={scrollRef} style={scrollAreaStyle}>
       <div
         style={{
           position: "relative",
@@ -168,6 +159,6 @@ export default function VirtualizedQueryResultTable({
           }),
         )}
       </div>
-    </ScrollArea>
+    </div>
   );
 }

--- a/packages/front-end/components/Queries/QueryResultTable/columnWidths.ts
+++ b/packages/front-end/components/Queries/QueryResultTable/columnWidths.ts
@@ -1,0 +1,87 @@
+import {
+  CELL_BORDER,
+  CELL_FONT_SIZE,
+  CELL_PADDING,
+  COLUMN_WIDTH_BUFFER,
+  MAX_COLUMN_WIDTH,
+  MIN_COLUMN_WIDTH,
+  WIDTH_SAMPLE_ROWS,
+} from "./constants";
+
+// Used to calculate column widths for column virtualization
+export type GetCellText = (value: unknown) => string;
+
+// By default we get the size of the JSON stringified value
+export const cellText: GetCellText = (value) => JSON.stringify(value) ?? "null";
+
+export function computeColumnWidths(
+  rows: Record<string, unknown>[],
+  columns: string[],
+  getCellText: GetCellText = cellText,
+): number[] {
+  const widthOf = (textWidth: number) =>
+    Math.min(
+      MAX_COLUMN_WIDTH,
+      Math.max(
+        MIN_COLUMN_WIDTH,
+        Math.ceil(textWidth) +
+          CELL_PADDING * 2 +
+          CELL_BORDER +
+          COLUMN_WIDTH_BUFFER,
+      ),
+    );
+
+  // Sample rows evenly rather than scanning every cell, so width
+  // measurement stays cheap for very large result sets.
+  const sampleStep =
+    rows.length > WIDTH_SAMPLE_ROWS
+      ? Math.floor(rows.length / WIDTH_SAMPLE_ROWS)
+      : 1;
+
+  const widestText: string[] = new Array(columns.length).fill("");
+  const widestLength: number[] = new Array(columns.length).fill(-1);
+
+  for (let r = 0; r < rows.length; r += sampleStep) {
+    const row = rows[r];
+    for (let c = 0; c < columns.length; c++) {
+      const text = getCellText(row[columns[c]]);
+      if (text.length > widestLength[c]) {
+        widestLength[c] = text.length;
+        widestText[c] = text;
+      }
+    }
+  }
+
+  // The last row has the most digits, so it's the widest index label
+  const longestIndex = rows.length ? String(rows.length - 1) : "";
+
+  const measure = makeTextMeasurer();
+
+  return [
+    // Index header is blank, so the column is sized purely by the numbers.
+    widthOf(measure(longestIndex, true)),
+    ...columns.map((key, i) =>
+      widthOf(Math.max(measure(key, true), measure(widestText[i], false))),
+    ),
+  ];
+}
+
+// Does some magic via canvas to measure the width of text
+function makeTextMeasurer(): (text: string, bold: boolean) => number {
+  const ctx =
+    typeof document !== "undefined"
+      ? document.createElement("canvas").getContext("2d")
+      : null;
+
+  if (!ctx) {
+    return (text) => text.length * 7;
+  }
+
+  const fontFamily = getComputedStyle(document.body).fontFamily || "sans-serif";
+  const normalFont = `${CELL_FONT_SIZE}px ${fontFamily}`;
+  const boldFont = `700 ${CELL_FONT_SIZE}px ${fontFamily}`;
+  return (text, bold) => {
+    ctx.font = bold ? boldFont : normalFont;
+    return ctx.measureText(text).width;
+  };
+}

--- a/packages/front-end/components/Queries/QueryResultTable/constants.ts
+++ b/packages/front-end/components/Queries/QueryResultTable/constants.ts
@@ -1,0 +1,27 @@
+// Defines when the virtualization kicks in
+export const RESULT_TABLE_ROW_VIRTUALIZATION_THRESHOLD = 100;
+export const RESULT_TABLE_COLUMN_VIRTUALIZATION_THRESHOLD = 25;
+
+// Configuration for the tables
+export const RESULT_TABLE_MAX_HEIGHT = 300;
+export const RESULT_TABLE_ROW_OVERSCAN = 15;
+export const RESULT_TABLE_COLUMN_OVERSCAN = 5;
+export const COLUMN_WIDTH_BUFFER = 3;
+export const MIN_COLUMN_WIDTH = 24;
+export const MAX_COLUMN_WIDTH = 600;
+
+// For the virtualizaed table, defines how many rows
+// are sampled when sizing columns to content
+export const WIDTH_SAMPLE_ROWS = 30;
+
+// Copied from the styles that PlainQueryResultTable uses, from bootstrap's `table-sm`
+// if we modify the design on how these are rendered, we should update it here so
+// the virtualization has the proper values to match
+export const CELL_FONT_SIZE = 14;
+export const CELL_LINE_HEIGHT = 1.5;
+export const CELL_PADDING = 4.8;
+export const CELL_BORDER = 1;
+
+export const RESULT_TABLE_ROW_HEIGHT = Math.round(
+  CELL_FONT_SIZE * CELL_LINE_HEIGHT + CELL_PADDING * 2 + CELL_BORDER,
+);

--- a/packages/front-end/components/Queries/QueryResultTable/index.tsx
+++ b/packages/front-end/components/Queries/QueryResultTable/index.tsx
@@ -1,0 +1,46 @@
+import { ReactNode, useMemo } from "react";
+import { cellText, GetCellText } from "./columnWidths";
+import {
+  RESULT_TABLE_COLUMN_VIRTUALIZATION_THRESHOLD,
+  RESULT_TABLE_ROW_VIRTUALIZATION_THRESHOLD,
+} from "./constants";
+import PlainQueryResultTable from "./PlainQueryResultTable";
+import VirtualizedQueryResultTable from "./VirtualizedQueryResultTable";
+
+type RenderValue = (value: unknown) => ReactNode;
+
+export default function QueryResultTable({
+  rows,
+  renderValue,
+  // Used to calculate column widths for column virtualization
+  getCellText = cellText,
+}: {
+  rows: Record<string, unknown>[];
+  renderValue: RenderValue;
+  getCellText?: GetCellText;
+}) {
+  const columns = useMemo(() => Object.keys(rows[0] || {}), [rows]);
+
+  const shouldVirtualize =
+    rows.length > RESULT_TABLE_ROW_VIRTUALIZATION_THRESHOLD ||
+    columns.length > RESULT_TABLE_COLUMN_VIRTUALIZATION_THRESHOLD;
+
+  if (!shouldVirtualize) {
+    return (
+      <PlainQueryResultTable
+        rows={rows}
+        columns={columns}
+        renderValue={renderValue}
+      />
+    );
+  }
+
+  return (
+    <VirtualizedQueryResultTable
+      rows={rows}
+      columns={columns}
+      renderValue={renderValue}
+      getCellText={getCellText}
+    />
+  );
+}

--- a/packages/front-end/components/SyntaxHighlighting/Code.module.scss
+++ b/packages/front-end/components/SyntaxHighlighting/Code.module.scss
@@ -1,0 +1,44 @@
+@use "../../styles/colors.scss";
+
+.codeHolder {
+  margin: 0.5em 0;
+
+  &.collapsible pre {
+    transition: max-height 0.2s;
+    max-height: 60em;
+    overflow-y: scroll;
+  }
+
+  &.collapsed pre {
+    max-height: 10em;
+  }
+
+  pre {
+    margin: 0 !important;
+  }
+}
+
+.actionButtons {
+  border: 1px solid var(--slate-a4);
+  border-bottom: none;
+}
+
+.message {
+  padding: 2px 6px;
+  background: colors.$highlight-purple;
+  color: #fff;
+  position: relative;
+  margin-right: 10px;
+  display: inline-block;
+  border-radius: 3px;
+  margin-top: 2px;
+}
+
+.arrow {
+  position: absolute;
+  left: 100%;
+  top: 50%;
+  margin-top: -6px;
+  border: 6px solid transparent;
+  border-left: 6px solid colors.$highlight-purple;
+}

--- a/packages/front-end/components/SyntaxHighlighting/Code.tsx
+++ b/packages/front-end/components/SyntaxHighlighting/Code.tsx
@@ -4,7 +4,6 @@ import React, {
   ReactElement,
   Suspense,
   lazy,
-  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -86,11 +85,11 @@ export default function Code({
 
   const [isExpanded, setIsExpanded] = useState(!expandable);
   const [hasExpanded, setHasExpanded] = useState(!expandable);
-  useEffect(() => {
-    if (isExpanded) {
-      setHasExpanded(true);
-    }
-  }, [isExpanded]);
+
+  const expand = () => {
+    setIsExpanded(true);
+    setHasExpanded(true);
+  };
 
   const { theme } = useAppearanceUITheme();
 
@@ -188,7 +187,7 @@ export default function Code({
             style={{ cursor: "pointer" }}
             onClick={async (e) => {
               e.preventDefault();
-              setIsExpanded(!isExpanded);
+              isExpanded ? setIsExpanded(false) : expand();
             }}
           >
             {isExpanded ? <FaCompressAlt /> : <FaExpandAlt />}
@@ -206,7 +205,7 @@ export default function Code({
           showLineNumbers={showLineNumbers}
           startingLineNumber={startingLineNumber ?? 1}
           previewOnly
-          onPreviewExpand={() => setIsExpanded(true)}
+          onPreviewExpand={expand}
         />
       ) : (
         <Suspense

--- a/packages/front-end/components/SyntaxHighlighting/Code.tsx
+++ b/packages/front-end/components/SyntaxHighlighting/Code.tsx
@@ -4,6 +4,8 @@ import React, {
   ReactElement,
   Suspense,
   lazy,
+  useEffect,
+  useMemo,
   useState,
 } from "react";
 import { FaCompressAlt, FaExpandAlt } from "react-icons/fa";
@@ -16,6 +18,7 @@ import { HiOutlineClipboard, HiOutlineClipboardCheck } from "react-icons/hi";
 import { useAppearanceUITheme } from "@/services/AppearanceUIThemeProvider";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import PrismFallback from "./PrismFallback";
+import styles from "./Code.module.scss";
 
 // Lazy-load syntax highlighting to improve page load time
 const Prism = lazy(() => import("./Prism"));
@@ -81,27 +84,44 @@ export default function Code({
   language = language || "none";
   if (language === "sh") language = "bash";
 
-  const [expanded, setExpanded] = useState(!expandable);
+  const [isExpanded, setIsExpanded] = useState(!expandable);
+  const [hasExpanded, setHasExpanded] = useState(!expandable);
+  useEffect(() => {
+    if (isExpanded) {
+      setHasExpanded(true);
+    }
+  }, [isExpanded]);
 
   const { theme } = useAppearanceUITheme();
 
   const enoughLines = code.split("\n").length > 8;
 
-  const style = cloneDeep(theme === "dark" ? dark : light);
-  style['code[class*="language-"]'].fontSize = "0.85rem";
-  style['code[class*="language-"]'].lineHeight = 1.5;
-  style['code[class*="language-"]'].fontWeight = 600;
+  const style = useMemo(() => {
+    const style = cloneDeep(theme === "dark" ? dark : light);
+    style['code[class*="language-"]'].fontSize = "0.85rem";
+    style['code[class*="language-"]'].lineHeight = 1.5;
+    style['code[class*="language-"]'].fontWeight = 600;
 
-  const codeBackgrounds = {
-    dark: "transparent",
-    light: "#fff",
-  };
-  style['pre[class*="language-"]'].backgroundColor = codeBackgrounds[theme];
-  style['pre[class*="language-"]'].border = "1px solid var(--slate-a4)";
+    const codeBackgrounds = {
+      dark: "transparent",
+      light: "#fff",
+    };
+    style['pre[class*="language-"]'].backgroundColor = codeBackgrounds[theme];
+    style['pre[class*="language-"]'].border = "1px solid var(--slate-a4)";
 
-  if (maxHeight) {
-    style['pre[class*="language-"]'].maxHeight = maxHeight;
-  }
+    if (maxHeight) {
+      style['pre[class*="language-"]'].maxHeight = maxHeight;
+    }
+
+    return style;
+  }, [theme, maxHeight]);
+
+  const shouldRenderPrism =
+    hasExpanded ||
+    !enoughLines ||
+    errorLine !== undefined ||
+    highlightLine !== undefined ||
+    startingLineNumber !== undefined;
 
   const display =
     filename ||
@@ -115,27 +135,34 @@ export default function Code({
 
   return (
     <div
-      className={clsx(`code-holder d-flex flex-column`, containerClassName, {
-        collapsible: expandable && enoughLines,
-        collapsed: !expanded,
-      })}
+      className={clsx(
+        "d-flex flex-column",
+        styles.codeHolder,
+        containerClassName,
+        {
+          [styles.collapsible]: expandable && enoughLines,
+          [styles.collapsed]: !isExpanded,
+        },
+      )}
       style={{
         maxWidth: "100%",
         ..._style,
       }}
     >
       <div
-        className="action-buttons bg-light d-flex align-items-center rounded-top"
-        style={{ border: "1px solid var(--slate-a4)", borderBottom: "none" }}
+        className={clsx(
+          "bg-light d-flex align-items-center rounded-top",
+          styles.actionButtons,
+        )}
       >
         <div>
           <small className="text-muted px-2">{display}</small>
         </div>
         <div className="ml-auto"></div>
         {copySuccess && (
-          <div className="message">
+          <div className={styles.message}>
             copied!
-            <div className="arrow" />
+            <div className={styles.arrow} />
           </div>
         )}
         {copySupported && (
@@ -156,67 +183,84 @@ export default function Code({
         {expandable && enoughLines && (
           <div
             className="p-1 text-muted"
-            title={expanded ? "Collapse" : "Expand"}
+            title={isExpanded ? "Collapse" : "Expand"}
             role="button"
             style={{ cursor: "pointer" }}
             onClick={async (e) => {
               e.preventDefault();
-              setExpanded(!expanded);
+              setIsExpanded(!isExpanded);
             }}
           >
-            {expanded ? <FaCompressAlt /> : <FaExpandAlt />}
+            {isExpanded ? <FaCompressAlt /> : <FaExpandAlt />}
           </div>
         )}
       </div>
-      <Suspense
-        fallback={
-          <PrismFallback
-            language={language}
-            style={style}
-            className={clsx("rounded-bottom", className)}
-            code={code}
-          />
-        }
-      >
-        <Prism
+      {!shouldRenderPrism ? (
+        // Keep the fallback rendering until expanded
+        // this way it is more lightweight and does not block the UI
+        <PrismFallback
           language={language}
           style={style}
           className={clsx("rounded-bottom", className)}
+          code={code}
           showLineNumbers={showLineNumbers}
           startingLineNumber={startingLineNumber ?? 1}
-          {...(errorLine
-            ? {
-                wrapLines: true,
-                lineProps: (
-                  lineNumber: number,
-                ): React.HTMLProps<HTMLElement> => {
-                  const style: React.CSSProperties = {};
-                  if (errorLine && lineNumber === errorLine) {
-                    style.textDecoration = "underline wavy red";
-                    style.textUnderlineOffset = "0.2em";
-                  }
-                  return { style };
-                },
-              }
-            : {})}
-          {...(highlightLine
-            ? {
-                wrapLines: true,
-                lineProps: (
-                  lineNumber: number,
-                ): React.HTMLProps<HTMLElement> => {
-                  const style: React.CSSProperties = {};
-                  if (highlightLine && lineNumber === highlightLine) {
-                    style.backgroundColor = "rgba(255, 255, 0, 0.2)";
-                  }
-                  return { style };
-                },
-              }
-            : {})}
+          previewOnly
+          onPreviewExpand={() => setIsExpanded(true)}
+        />
+      ) : (
+        <Suspense
+          fallback={
+            <PrismFallback
+              language={language}
+              style={style}
+              className={clsx("rounded-bottom", className)}
+              code={code}
+              showLineNumbers={showLineNumbers}
+              startingLineNumber={startingLineNumber ?? 1}
+            />
+          }
         >
-          {code}
-        </Prism>
-      </Suspense>
+          <Prism
+            language={language}
+            style={style}
+            className={clsx("rounded-bottom", className)}
+            showLineNumbers={showLineNumbers}
+            startingLineNumber={startingLineNumber ?? 1}
+            {...(errorLine
+              ? {
+                  wrapLines: true,
+                  lineProps: (
+                    lineNumber: number,
+                  ): React.HTMLProps<HTMLElement> => {
+                    const style: React.CSSProperties = {};
+                    if (errorLine && lineNumber === errorLine) {
+                      style.textDecoration = "underline wavy red";
+                      style.textUnderlineOffset = "0.2em";
+                    }
+                    return { style };
+                  },
+                }
+              : {})}
+            {...(highlightLine
+              ? {
+                  wrapLines: true,
+                  lineProps: (
+                    lineNumber: number,
+                  ): React.HTMLProps<HTMLElement> => {
+                    const style: React.CSSProperties = {};
+                    if (highlightLine && lineNumber === highlightLine) {
+                      style.backgroundColor = "rgba(255, 255, 0, 0.2)";
+                    }
+                    return { style };
+                  },
+                }
+              : {})}
+          >
+            {code}
+          </Prism>
+        </Suspense>
+      )}
     </div>
   );
 }

--- a/packages/front-end/components/SyntaxHighlighting/PrismFallback.module.scss
+++ b/packages/front-end/components/SyntaxHighlighting/PrismFallback.module.scss
@@ -1,0 +1,47 @@
+.fallback {
+  &.withLineNumbers::before {
+    content: attr(data-line-numbers);
+    position: absolute;
+    top: 1em;
+    left: 1em;
+    width: var(--syntax-highlight-fallback-line-number-width);
+    text-align: right;
+    white-space: pre;
+    pointer-events: none;
+    user-select: none;
+    color: var(--syntax-highlight-fallback-line-number-color);
+    font-style: var(--syntax-highlight-fallback-line-number-font-style);
+    font-weight: var(--syntax-highlight-fallback-line-number-font-weight);
+  }
+}
+
+.previewCta {
+  appearance: none;
+  background: var(--violet-a3);
+  border: 1px solid var(--violet-a7);
+  border-radius: var(--radius-3);
+  box-shadow: 0 1px 0 var(--violet-a3);
+  color: var(--violet-11);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  font: inherit;
+  line-height: 1.25;
+  padding: 0.08em 0.55em;
+  text-align: left;
+
+  &:hover {
+    background: var(--violet-a4);
+    border-color: var(--violet-a8);
+    color: var(--violet-12);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--violet-8);
+    outline-offset: 2px;
+  }
+
+  &:active {
+    background: var(--violet-a5);
+  }
+}

--- a/packages/front-end/components/SyntaxHighlighting/PrismFallback.tsx
+++ b/packages/front-end/components/SyntaxHighlighting/PrismFallback.tsx
@@ -1,6 +1,8 @@
 import clsx from "clsx";
-import { CSSProperties } from "react";
-import { Language } from "./Code";
+import { CSSProperties, useMemo } from "react";
+import type { Language } from "./Code";
+import { tokenizeSql } from "./sqlTokenizer";
+import styles from "./PrismFallback.module.scss";
 
 export interface Props {
   code: string;
@@ -9,6 +11,112 @@ export interface Props {
   };
   language: Language;
   className?: string;
+  showLineNumbers?: boolean;
+  startingLineNumber?: number;
+  previewOnly?: boolean;
+  onPreviewExpand?: () => void;
+}
+
+const SQL_PREVIEW_LINES = 16;
+
+interface FallbackContent {
+  highlightedText: string | null;
+  plainText: string;
+  lineNumbers: string | undefined;
+  lineNumberWidth: string;
+  showExpandButton: boolean;
+}
+
+function renderHighlightedSQL(code: string, style: Props["style"]) {
+  // The token types we use match the Prism theme keys
+  // so we can use it to apply the proper css style
+  return tokenizeSql(code).map((segment, i) => {
+    if (segment.type === "text") return segment.value;
+
+    return (
+      <span style={style[segment.type]} key={i}>
+        {segment.value}
+      </span>
+    );
+  });
+}
+
+function computeLineNumberWidth(
+  totalLines: number,
+  startingLineNumber: number,
+): string {
+  const widestLineNumber = totalLines + startingLineNumber;
+  return `${widestLineNumber.toString().length}.25em`;
+}
+
+// Preview renders just the first chunk of lines with lightweight SQL
+// highlighting and an optional "view full query" button.
+function buildPreviewContent({
+  code,
+  language,
+  startingLineNumber,
+  showLineNumbers,
+  onPreviewExpand,
+}: {
+  code: string;
+  language: Language;
+  startingLineNumber: number;
+  showLineNumbers: boolean;
+  onPreviewExpand?: () => void;
+}): FallbackContent {
+  const lines = code.split("\n");
+  const visibleLines = lines.slice(0, SQL_PREVIEW_LINES);
+  const showExpandButton =
+    lines.length > visibleLines.length && !!onPreviewExpand;
+
+  const highlightedText = language === "sql" ? visibleLines.join("\n") : null;
+  const plainText = language === "sql" ? "" : visibleLines.join("\n");
+
+  let lineNumbers: string | undefined;
+  if (showLineNumbers) {
+    const numbers = visibleLines.map((_, i) => String(startingLineNumber + i));
+    if (showExpandButton) {
+      numbers.push(String(startingLineNumber + visibleLines.length));
+    }
+    lineNumbers = numbers.join("\n");
+  }
+
+  return {
+    highlightedText,
+    plainText,
+    lineNumbers,
+    lineNumberWidth: computeLineNumberWidth(lines.length, startingLineNumber),
+    showExpandButton,
+  };
+}
+
+// Full content renders the whole code as plain text (no highlighting)
+// while Prism loads
+function buildFullContent({
+  code,
+  startingLineNumber,
+  showLineNumbers,
+}: {
+  code: string;
+  startingLineNumber: number;
+  showLineNumbers: boolean;
+}): FallbackContent {
+  const lines = code.split("\n");
+
+  let lineNumbers: string | undefined;
+  if (showLineNumbers) {
+    lineNumbers = lines
+      .map((_, i) => String(startingLineNumber + i))
+      .join("\n");
+  }
+
+  return {
+    highlightedText: null,
+    plainText: code,
+    lineNumbers,
+    lineNumberWidth: computeLineNumberWidth(lines.length, startingLineNumber),
+    showExpandButton: false,
+  };
 }
 
 export default function PrismFallback({
@@ -16,19 +124,83 @@ export default function PrismFallback({
   style,
   language,
   code,
+  showLineNumbers = false,
+  startingLineNumber = 1,
+  previewOnly = false,
+  onPreviewExpand,
 }: Props) {
+  const {
+    highlightedText,
+    plainText,
+    lineNumbers,
+    lineNumberWidth,
+    showExpandButton,
+  } = previewOnly
+    ? buildPreviewContent({
+        code,
+        language,
+        startingLineNumber,
+        showLineNumbers,
+        onPreviewExpand,
+      })
+    : buildFullContent({ code, startingLineNumber, showLineNumbers });
+
+  const highlightedPreview = useMemo(() => {
+    if (!highlightedText) return null;
+    return renderHighlightedSQL(highlightedText, style);
+  }, [highlightedText, style]);
+
+  const preStyle = useMemo(() => {
+    const baseStyle = style['pre[class*="language-"]'];
+    if (!showLineNumbers) return baseStyle;
+
+    const codeStyle = style['code[class*="language-"]'];
+
+    return {
+      ...baseStyle,
+      fontSize: codeStyle?.fontSize,
+      lineHeight: codeStyle?.lineHeight,
+      "--syntax-highlight-fallback-line-number-color":
+        style.comment?.color ?? baseStyle?.color,
+      "--syntax-highlight-fallback-line-number-font-style":
+        style.comment?.fontStyle,
+      "--syntax-highlight-fallback-line-number-font-weight":
+        codeStyle?.fontWeight,
+      "--syntax-highlight-fallback-line-number-width": lineNumberWidth,
+      paddingLeft: `calc(1em + ${lineNumberWidth} + 1em)`,
+      position: "relative" as const,
+    };
+  }, [style, showLineNumbers, lineNumberWidth]);
+
   // This is a fallback while the full syntax highlighter loads
   // Since we have the exact same styles, it shouldn't cause any layout shifts.
   return (
     <pre
-      className={clsx(className, `language-${language}`)}
-      style={style['pre[class*="language-"]']}
+      className={clsx(className, `language-${language}`, styles.fallback, {
+        [styles.withLineNumbers]: showLineNumbers,
+      })}
+      data-line-numbers={lineNumbers}
+      style={preStyle}
     >
       <code
         className={`language-${language}`}
         style={style['code[class*="language-"]']}
       >
-        {code}
+        {highlightedPreview}
+        {highlightedText && plainText ? "\n" : null}
+        {plainText}
+        {showExpandButton ? (
+          <>
+            {"\n"}
+            <button
+              type="button"
+              className={styles.previewCta}
+              onClick={onPreviewExpand}
+            >
+              View full query
+            </button>
+          </>
+        ) : null}
       </code>
     </pre>
   );

--- a/packages/front-end/components/SyntaxHighlighting/sqlTokenizer.ts
+++ b/packages/front-end/components/SyntaxHighlighting/sqlTokenizer.ts
@@ -1,0 +1,44 @@
+// Simple SQL tokenizer used to approximate syntax highlighting
+// without having to load the full Prism highlighter.
+// This ensures the page does not crash when we render 60 queries with 4k+ lines each at once
+
+type SqlTokenType = "comment" | "string" | "number" | "keyword";
+
+type SqlSegment =
+  | { type: "text"; value: string }
+  | { type: SqlTokenType; value: string };
+
+const sqlTokenRegex =
+  /(--[^\n]*|'(?:''|[^'])*'|"(?:""|[^"])*"|`[^`]*`|\b(?:WITH|SELECT|FROM|WHERE|JOIN|LEFT|RIGHT|INNER|OUTER|FULL|CROSS|ON|AS|AND|OR|NOT|NULL|CASE|WHEN|THEN|ELSE|END|GROUP|BY|ORDER|HAVING|LIMIT|OFFSET|UNION|ALL|DISTINCT|COUNT|SUM|AVG|MIN|MAX|COALESCE|CAST|BETWEEN|IN|IS|LIKE|INTERVAL|TIMESTAMP|DATE)\b|\b\d+(?:\.\d+)?\b)/gi;
+
+export function getSqlTokenType(token: string): SqlTokenType {
+  if (token.startsWith("--")) return "comment";
+  if (token.startsWith("'") || token.startsWith('"') || token.startsWith("`")) {
+    return "string";
+  }
+  if (/^\d/.test(token)) return "number";
+  return "keyword";
+}
+
+export function tokenizeSql(code: string): SqlSegment[] {
+  const segments: SqlSegment[] = [];
+  let lastIndex = 0;
+
+  for (const match of code.matchAll(sqlTokenRegex)) {
+    const token = match[0];
+    const index = match.index ?? 0;
+
+    if (index > lastIndex) {
+      segments.push({ type: "text", value: code.slice(lastIndex, index) });
+    }
+
+    segments.push({ type: getSqlTokenType(token), value: token });
+    lastIndex = index + token.length;
+  }
+
+  if (lastIndex < code.length) {
+    segments.push({ type: "text", value: code.slice(lastIndex) });
+  }
+
+  return segments;
+}

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -34,6 +34,7 @@
     "@stdlib/stats": "^0.1.1",
     "@stripe/react-stripe-js": "^3.1.1",
     "@stripe/stripe-js": "^5.5.0",
+    "@tanstack/react-virtual": "^3.13.26",
     "@visx/axis": "^2.1.0",
     "@visx/curve": "^2.1.0",
     "@visx/event": "^2.6.0",

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -1461,46 +1461,6 @@ main.main {
   border: 0px !important;
 }
 
-.code-holder {
-  margin: 0.5em 0;
-
-  &.collapsible pre {
-    transition: max-height 0.2s;
-    max-height: 60em;
-    overflow-y: scroll;
-  }
-
-  &.collapsed pre {
-    max-height: 10em;
-  }
-
-  .action-buttons {
-    .message {
-      padding: 2px 6px;
-      background: colors.$highlight-purple;
-      color: #fff;
-      position: relative;
-      margin-right: 10px;
-      display: inline-block;
-      border-radius: 3px;
-      margin-top: 2px;
-
-      .arrow {
-        position: absolute;
-        left: 100%;
-        top: 50%;
-        margin-top: -6px;
-        border: 6px solid transparent;
-        border-left: 6px solid colors.$highlight-purple;
-      }
-    }
-  }
-
-  pre {
-    margin: 0 !important;
-  }
-}
-
 .gb-tooltip {
   border-radius: 5px;
   white-space: normal;

--- a/packages/front-end/test/components/Queries/QueryResultTable/columnWidths.test.ts
+++ b/packages/front-end/test/components/Queries/QueryResultTable/columnWidths.test.ts
@@ -1,0 +1,80 @@
+import {
+  cellText,
+  computeColumnWidths,
+} from "@/components/Queries/QueryResultTable/columnWidths";
+import {
+  CELL_BORDER,
+  CELL_PADDING,
+  COLUMN_WIDTH_BUFFER,
+  MAX_COLUMN_WIDTH,
+  MIN_COLUMN_WIDTH,
+} from "@/components/Queries/QueryResultTable/constants";
+
+describe("cellText", () => {
+  it("JSON-stringifies primitives the way a cell renders them", () => {
+    expect(cellText("hello")).toBe('"hello"');
+    expect(cellText(42)).toBe("42");
+    expect(cellText(true)).toBe("true");
+  });
+
+  it('renders null and undefined as the literal "null"', () => {
+    expect(cellText(null)).toBe("null");
+    expect(cellText(undefined)).toBe("null");
+  });
+});
+
+// jsdom has no canvas 2d context, so computeColumnWidths exercises its
+// no-canvas estimate branch here (len * 7 px per glyph).
+describe("computeColumnWidths (no-canvas estimate path)", () => {
+  const pad = CELL_PADDING * 2 + CELL_BORDER + COLUMN_WIDTH_BUFFER;
+  const estimateWidth = (len: number) =>
+    Math.min(
+      MAX_COLUMN_WIDTH,
+      Math.max(MIN_COLUMN_WIDTH, Math.ceil(len * 7) + pad),
+    );
+
+  it("returns one width per column plus the leading index column", () => {
+    const rows = [{ a: 1, b: 2 }];
+    expect(computeColumnWidths(rows, ["a", "b"])).toHaveLength(3);
+  });
+
+  it("sizes a data column to the wider of its header or its widest value", () => {
+    const rows = [{ name: "x" }, { name: "a-very-long-value" }];
+    const [, nameWidth] = computeColumnWidths(rows, ["name"]);
+    // widest value "a-very-long-value" (17 chars) + quotes = 19 beats header 4.
+    expect(nameWidth).toBe(estimateWidth(19));
+  });
+
+  it("clamps very wide content to MAX_COLUMN_WIDTH", () => {
+    const rows = [{ wide: "x".repeat(500) }];
+    const [, wideWidth] = computeColumnWidths(rows, ["wide"]);
+    expect(wideWidth).toBe(MAX_COLUMN_WIDTH);
+  });
+
+  it("never returns a column narrower than MIN_COLUMN_WIDTH", () => {
+    const rows = [{ a: 1 }];
+    for (const width of computeColumnWidths(rows, ["a"])) {
+      expect(width).toBeGreaterThanOrEqual(MIN_COLUMN_WIDTH);
+    }
+  });
+
+  it("sizes the index column from the largest row number", () => {
+    const rows = Array.from({ length: 1000 }, (_, i) => ({ a: i }));
+    const [indexWidth] = computeColumnWidths(rows, ["a"]);
+    // Largest index label is "999" (3 chars).
+    expect(indexWidth).toBe(estimateWidth(3));
+  });
+
+  it("handles an empty result set without throwing", () => {
+    expect(computeColumnWidths([], [])).toEqual([estimateWidth(0)]);
+  });
+
+  it("measures the projected text from a custom getCellText, not the raw value", () => {
+    // Raw JSON would be '"fact__abc"' (11 chars); the projection renders a
+    // longer display name, so the column must size to the name instead.
+    const rows = [{ id: "fact__abc" }];
+    const name = "A Friendly Metric Name";
+    const [, idWidth] = computeColumnWidths(rows, ["id"], () => name);
+    expect(idWidth).toBe(estimateWidth(name.length));
+  });
+});

--- a/packages/front-end/test/components/SyntaxHighlighting/sqlTokenizer.test.ts
+++ b/packages/front-end/test/components/SyntaxHighlighting/sqlTokenizer.test.ts
@@ -1,0 +1,123 @@
+import {
+  getSqlTokenType,
+  tokenizeSql,
+} from "@/components/SyntaxHighlighting/sqlTokenizer";
+
+describe("getSqlTokenType", () => {
+  it("classifies line comments", () => {
+    expect(getSqlTokenType("-- a comment")).toBe("comment");
+  });
+
+  it("classifies single-quoted strings, double-quoted and backtick identifiers", () => {
+    expect(getSqlTokenType("'hello'")).toBe("string");
+    expect(getSqlTokenType('"col"')).toBe("string");
+    expect(getSqlTokenType("`col`")).toBe("string");
+  });
+
+  it("classifies integers and decimals as numbers", () => {
+    expect(getSqlTokenType("42")).toBe("number");
+    expect(getSqlTokenType("3.14")).toBe("number");
+  });
+
+  it("treats everything else as a keyword", () => {
+    expect(getSqlTokenType("SELECT")).toBe("keyword");
+  });
+});
+
+describe("tokenizeSql", () => {
+  it("returns a single text segment when there is nothing to highlight", () => {
+    expect(tokenizeSql("foo bar baz")).toEqual([
+      { type: "text", value: "foo bar baz" },
+    ]);
+  });
+
+  it("returns an empty list for empty input", () => {
+    expect(tokenizeSql("")).toEqual([]);
+  });
+
+  it("highlights keywords case-insensitively", () => {
+    expect(tokenizeSql("select")).toEqual([
+      { type: "keyword", value: "select" },
+    ]);
+    expect(tokenizeSql("Select")).toEqual([
+      { type: "keyword", value: "Select" },
+    ]);
+    expect(tokenizeSql("SELECT")).toEqual([
+      { type: "keyword", value: "SELECT" },
+    ]);
+  });
+
+  it("respects word boundaries so keyword substrings stay text", () => {
+    // "SELECTED" contains "SELECT" but should not be tokenized as a keyword
+    expect(tokenizeSql("SELECTED")).toEqual([
+      { type: "text", value: "SELECTED" },
+    ]);
+    // "INTERVAL" must not be split into the "IN" keyword + "TERVAL"
+    expect(tokenizeSql("INTERVAL")).toEqual([
+      { type: "keyword", value: "INTERVAL" },
+    ]);
+  });
+
+  it("interleaves keywords with surrounding text", () => {
+    expect(tokenizeSql("SELECT x FROM t")).toEqual([
+      { type: "keyword", value: "SELECT" },
+      { type: "text", value: " x " },
+      { type: "keyword", value: "FROM" },
+      { type: "text", value: " t" },
+    ]);
+  });
+
+  it("captures line comments to the end of the line only", () => {
+    expect(tokenizeSql("SELECT 1 -- a note\nFROM t")).toEqual([
+      { type: "keyword", value: "SELECT" },
+      { type: "text", value: " " },
+      { type: "number", value: "1" },
+      { type: "text", value: " " },
+      { type: "comment", value: "-- a note" },
+      { type: "text", value: "\n" },
+      { type: "keyword", value: "FROM" },
+      { type: "text", value: " t" },
+    ]);
+  });
+
+  it("handles single-quoted strings including escaped quotes", () => {
+    expect(tokenizeSql("WHERE name = 'it''s ok'")).toEqual([
+      { type: "keyword", value: "WHERE" },
+      { type: "text", value: " name = " },
+      { type: "string", value: "'it''s ok'" },
+    ]);
+  });
+
+  it("does not treat keywords inside a string as keywords", () => {
+    expect(tokenizeSql("'SELECT FROM'")).toEqual([
+      { type: "string", value: "'SELECT FROM'" },
+    ]);
+  });
+
+  it("highlights decimals and integers", () => {
+    expect(tokenizeSql("LIMIT 100 OFFSET 2.5")).toEqual([
+      { type: "keyword", value: "LIMIT" },
+      { type: "text", value: " " },
+      { type: "number", value: "100" },
+      { type: "text", value: " " },
+      { type: "keyword", value: "OFFSET" },
+      { type: "text", value: " " },
+      { type: "number", value: "2.5" },
+    ]);
+  });
+
+  it("preserves the original input exactly when joining segments", () => {
+    const samples = [
+      "SELECT COUNT(*) AS n FROM users WHERE created > '2024-01-01' -- recent\nGROUP BY id",
+      "weird   spacing\tand\nnewlines",
+      "no_sql_here(just text)",
+      "",
+    ];
+    for (const sample of samples) {
+      const rebuilt = tokenizeSql(sample)
+        .map((s) => s.value)
+        .join("");
+      expect(rebuilt).toBe(sample);
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -669,6 +669,9 @@ importers:
       '@stripe/stripe-js':
         specifier: ^5.5.0
         version: 5.6.0
+      '@tanstack/react-virtual':
+        specifier: ^3.13.26
+        version: 3.13.26(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@visx/axis':
         specifier: ^2.1.0
         version: 2.1.0(react@18.2.0)
@@ -5848,6 +5851,15 @@ packages:
 
   '@swc/wasm@1.2.130':
     resolution: {integrity: sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==}
+
+  '@tanstack/react-virtual@3.13.26':
+    resolution: {integrity: sha512-DosdgjOxCLahkn0o+ilmZYwEjo1glfMGuRT/j3PQ18yr5XqA8N/BCaL9IJ3B5TRl+nnzyK2IOFgAILwzN3a9xQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.16.0':
+    resolution: {integrity: sha512-Er2N7q3WOiH6y2JLxsxNX+u2/sLqSsL0bxFgDjuiPiA7vKhZRm+IzcS17vRee3GNXr64UsesA5CAp9yTiIYw9A==}
 
   '@techteamer/ocsp@1.0.1':
     resolution: {integrity: sha512-q4pW5wAC6Pc3JI8UePwE37CkLQ5gDGZMgjSX4MEEm4D4Di59auDQ8UNIDzC4gRnPNmmcwjpPxozq8p5pjiOmOw==}
@@ -19726,6 +19738,14 @@ snapshots:
 
   '@swc/wasm@1.2.130':
     optional: true
+
+  '@tanstack/react-virtual@3.13.26(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tanstack/virtual-core': 3.16.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
+  '@tanstack/virtual-core@3.16.0': {}
 
   '@techteamer/ocsp@1.0.1':
     dependencies:


### PR DESCRIPTION
### Features and Changes

In the Experiment > View Queries modal we have 2 performance bottlenecks that are client-side.

1. For each query, we instantiate a full Prism Highlighter
	This is specially impactful if we have 20 queries and each has more than 4k lines. This would freeze the UI completely.
	
2. We would render the full results for each query using a native `<table>` component
	Meaning if we have many queries with many results, this would also generate a lot of DOM nodes and the browser would freeze.

We fixed this performance issue by:
- Rendering a cheaper SQL Highlighter when it is not expanded
- Virtualizing the results table

In a test scenario for a single query block with 4200 lines, 1000 columns and 1000 rows, we went from `10s` to `30ms` of render time. Increasing to 60 queries with the same configuration would crash the tab with the previous implementation and now it finishes in ~500ms.

### Testing

- Unit tests
- Perf page to compare before and after (removed from this PR)
