### PR TITLE
perf(bigquery): Pack quantile in a single array column 

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -260,6 +260,7 @@ export default abstract class SqlIntegration
       hasCountDistinctHLL: this.getSqlDialect().hasCountDistinctHLL(),
       hasQuantileSketch: this.hasQuantileSketch(),
       hasIncrementalRefresh: this.canRunIncrementalRefreshQueries(),
+      hasArrayQuantileGrid: this.getSqlDialect().hasArrayQuantileGrid(),
       maxColumns: 1000,
     };
   }

--- a/packages/back-end/src/integrations/dialects/base.ts
+++ b/packages/back-end/src/integrations/dialects/base.ts
@@ -131,5 +131,14 @@ export const baseDialect: Omit<SqlDialect, "unpivotLabeledPairs"> = {
     );
   },
 
+  hasArrayQuantileGrid: () => false,
+
+  arrayLiteral: () => {
+    throw new Error(
+      "Array literals are not supported by this data source. " +
+        "A dialect must implement arrayLiteral to set hasArrayQuantileGrid().",
+    );
+  },
+
   stringLength: (column: string) => `LENGTH(${column})`,
 };

--- a/packages/back-end/src/integrations/dialects/base.ts
+++ b/packages/back-end/src/integrations/dialects/base.ts
@@ -133,10 +133,10 @@ export const baseDialect: Omit<SqlDialect, "unpivotLabeledPairs"> = {
 
   hasArrayQuantileGrid: () => false,
 
-  arrayLiteral: () => {
+  quantileGridArrayLiteral: () => {
     throw new Error(
-      "Array literals are not supported by this data source. " +
-        "A dialect must implement arrayLiteral to set hasArrayQuantileGrid().",
+      "Quantile-grid array literals are not supported by this data source. " +
+        "A dialect must implement quantileGridArrayLiteral to set hasArrayQuantileGrid().",
     );
   },
 

--- a/packages/back-end/src/integrations/dialects/bigquery.ts
+++ b/packages/back-end/src/integrations/dialects/bigquery.ts
@@ -147,6 +147,8 @@ export const bigQueryDialect: SqlDialect = {
     const countBelow = `(SELECT COUNT(*) FROM UNNEST(${cdfArray}) AS p WHERE p < ${thresholdCol})`;
     return `COALESCE(${countBelow} * ${nEventsCol} / ${numQuantiles}.0, 0)`;
   },
+  hasArrayQuantileGrid: () => true,
+  arrayLiteral: (elements: string[]) => `[${elements.join(", ")}]`,
   percentileApprox: (value: string, quantile: string | number) => {
     const multiplier = APPROX_QUANTILES_MULTIPLIER;
     const quantileVal = Number(quantile)

--- a/packages/back-end/src/integrations/dialects/bigquery.ts
+++ b/packages/back-end/src/integrations/dialects/bigquery.ts
@@ -148,7 +148,13 @@ export const bigQueryDialect: SqlDialect = {
     return `COALESCE(${countBelow} * ${nEventsCol} / ${numQuantiles}.0, 0)`;
   },
   hasArrayQuantileGrid: () => true,
-  arrayLiteral: (elements: string[]) => `[${elements.join(", ")}]`,
+  // BigQuery rejects NULL containing arrays in a query result, so collapse the
+  // whole grid to NULL when an array would contain NULLs.
+  // The quantile-grid elements are all-or-nothing, so we can test the first element.
+  quantileGridArrayLiteral: (elements: string[]) =>
+    elements.length > 0
+      ? `IF(${elements[0]} IS NULL, NULL, [${elements.join(", ")}])`
+      : `[${elements.join(", ")}]`,
   percentileApprox: (value: string, quantile: string | number) => {
     const multiplier = APPROX_QUANTILES_MULTIPLIER;
     const quantileVal = Number(quantile)

--- a/packages/back-end/src/integrations/sql/columns/quantile-bounds-from-query-response.ts
+++ b/packages/back-end/src/integrations/sql/columns/quantile-bounds-from-query-response.ts
@@ -18,12 +18,29 @@ export function getQuantileBoundsFromQueryResponse(
 
     const smallestNStar = Math.min(...N_STAR_VALUES);
 
-    // process grid for quantile data
-    N_STAR_VALUES.forEach((n) => {
-      const lowerColumn = `${prefix}quantile_lower_${n}`;
-      const upperColumn = `${prefix}quantile_upper_${n}`;
-      if (row[lowerColumn] === undefined || row[upperColumn] === undefined)
-        return;
+    // For datasources that we can pack the values in a single array column
+    const gridArray = row[`${prefix}quantile_grid`];
+    const isArrayGrid = Array.isArray(gridArray);
+    const expectedGridLength = N_STAR_VALUES.length * 2;
+    if (isArrayGrid && gridArray.length !== expectedGridLength) {
+      throw new Error(
+        `Expected ${prefix}quantile_grid array of length ${expectedGridLength}, got ${gridArray.length}. ` +
+          `This indicates a mismatch between SQL generation (getQuantileGridColumns / getQuantileSketchGridColumns) ` +
+          `and N_STAR_VALUES on the read side.`,
+      );
+    }
+
+    const getLower = isArrayGrid
+      ? (k: number) => gridArray[2 * k]
+      : (k: number) => row[`${prefix}quantile_lower_${N_STAR_VALUES[k]}`];
+    const getUpper = isArrayGrid
+      ? (k: number) => gridArray[2 * k + 1]
+      : (k: number) => row[`${prefix}quantile_upper_${N_STAR_VALUES[k]}`];
+
+    N_STAR_VALUES.forEach((n, k) => {
+      const lowerVal = getLower(k);
+      const upperVal = getUpper(k);
+      if (lowerVal === undefined || upperVal === undefined) return;
 
       if (
         // if nstar is smaller, or if it's the smallest nstar, proceed
@@ -32,10 +49,8 @@ export function getQuantileBoundsFromQueryResponse(
         // this n is the largest n we've seen so far
         n > (Number(quantileData[`${prefix}quantile_nstar`]) || 0)
       ) {
-        quantileData[`${prefix}quantile_lower`] =
-          parseFloat(row[lowerColumn]) || 0;
-        quantileData[`${prefix}quantile_upper`] =
-          parseFloat(row[upperColumn]) || 0;
+        quantileData[`${prefix}quantile_lower`] = parseFloat(lowerVal) || 0;
+        quantileData[`${prefix}quantile_upper`] = parseFloat(upperVal) || 0;
         quantileData[`${prefix}quantile_nstar`] = n;
       }
     });

--- a/packages/back-end/src/integrations/sql/columns/quantile-bounds-from-query-response.ts
+++ b/packages/back-end/src/integrations/sql/columns/quantile-bounds-from-query-response.ts
@@ -40,7 +40,9 @@ export function getQuantileBoundsFromQueryResponse(
     N_STAR_VALUES.forEach((n, k) => {
       const lowerVal = getLower(k);
       const upperVal = getUpper(k);
-      if (lowerVal === undefined || upperVal === undefined) return;
+      // Covers both null (e.g. empty-group APPROX_QUANTILES array elements)
+      // and undefined (missing scalar columns)
+      if ((lowerVal ?? null) === null || (upperVal ?? null) === null) return;
 
       if (
         // if nstar is smaller, or if it's the smallest nstar, proceed

--- a/packages/back-end/src/integrations/sql/columns/quantile-bounds-from-query-response.ts
+++ b/packages/back-end/src/integrations/sql/columns/quantile-bounds-from-query-response.ts
@@ -11,8 +11,9 @@ export function getQuantileBoundsFromQueryResponse(
     [key: string]: number;
   } = {};
   if (row[`${prefix}quantile`] !== undefined) {
-    quantileData[`${prefix}quantile`] =
-      parseFloat(row[`${prefix}quantile`]) || 0;
+    const rawQuantile = row[`${prefix}quantile`];
+
+    quantileData[`${prefix}quantile`] = parseFloat(rawQuantile) || 0;
     quantileData[`${prefix}quantile_n`] =
       parseFloat(row[`${prefix}quantile_n`]) || 0;
 
@@ -22,7 +23,18 @@ export function getQuantileBoundsFromQueryResponse(
     const gridArray = row[`${prefix}quantile_grid`];
     const isArrayGrid = Array.isArray(gridArray);
     const expectedGridLength = N_STAR_VALUES.length * 2;
-    if (isArrayGrid && gridArray.length !== expectedGridLength) {
+    // BigQuery translates NULL arrays to empty arrays in query results, so
+    // the no-values grid can/will arrive as []
+    const emptyGridWithoutValues =
+      isArrayGrid &&
+      gridArray.length === 0 &&
+      (rawQuantile ?? null) === null &&
+      quantileData[`${prefix}quantile_n`] === 0;
+    if (
+      isArrayGrid &&
+      gridArray.length !== expectedGridLength &&
+      !emptyGridWithoutValues
+    ) {
       throw new Error(
         `Expected ${prefix}quantile_grid array of length ${expectedGridLength}, got ${gridArray.length}. ` +
           `This indicates a mismatch between SQL generation (getQuantileGridColumns / getQuantileSketchGridColumns) ` +

--- a/packages/back-end/src/integrations/sql/columns/quantile-grid-array-column.ts
+++ b/packages/back-end/src/integrations/sql/columns/quantile-grid-array-column.ts
@@ -1,0 +1,18 @@
+import type { SqlDialect } from "shared/types/sql";
+import { N_STAR_VALUES } from "back-end/src/services/experimentQueries/constants";
+import { getQuantileBoundValues } from "back-end/src/integrations/sql/columns/quantile-bound-values";
+
+// Packs the n_star confidence-interval grid into one array column instead of
+// N_STAR_VALUES.length * 2 scalar columns.
+export function getQuantileGridArrayColumn(
+  dialect: SqlDialect,
+  quantile: number,
+  prefix: string,
+  boundExpr: (bound: number) => string,
+): string {
+  const elements = N_STAR_VALUES.flatMap((nstar) => {
+    const { lower, upper } = getQuantileBoundValues(quantile, 0.05, nstar);
+    return [boundExpr(lower), boundExpr(upper)];
+  });
+  return `, ${dialect.arrayLiteral(elements)} AS ${prefix}quantile_grid`;
+}

--- a/packages/back-end/src/integrations/sql/columns/quantile-grid-array-column.ts
+++ b/packages/back-end/src/integrations/sql/columns/quantile-grid-array-column.ts
@@ -14,5 +14,7 @@ export function getQuantileGridArrayColumn(
     const { lower, upper } = getQuantileBoundValues(quantile, 0.05, nstar);
     return [boundExpr(lower), boundExpr(upper)];
   });
-  return `, ${dialect.arrayLiteral(elements)} AS ${prefix}quantile_grid`;
+  return `, ${dialect.quantileGridArrayLiteral(
+    elements,
+  )} AS ${prefix}quantile_grid`;
 }

--- a/packages/back-end/src/integrations/sql/columns/quantile-grid-columns.ts
+++ b/packages/back-end/src/integrations/sql/columns/quantile-grid-columns.ts
@@ -1,8 +1,8 @@
 import type { MetricQuantileSettings } from "shared/types/fact-table";
 import type { SqlDialect } from "shared/types/sql";
 import { N_STAR_VALUES } from "back-end/src/services/experimentQueries/constants";
-
 import { getQuantileBoundValues } from "back-end/src/integrations/sql/columns/quantile-bound-values";
+import { getQuantileGridArrayColumn } from "back-end/src/integrations/sql/columns/quantile-grid-array-column";
 import { quantileColumn } from "back-end/src/integrations/sql/columns/quantile-column";
 
 export function getQuantileGridColumns(
@@ -10,12 +10,26 @@ export function getQuantileGridColumns(
   metricQuantileSettings: MetricQuantileSettings,
   prefix: string,
 ): string {
-  return `, ${quantileColumn(
+  const asArray = dialect.hasArrayQuantileGrid();
+  const valueExpr = `m.${prefix}value`;
+  const centralCol = `, ${quantileColumn(
     dialect,
-    `m.${prefix}value`,
+    valueExpr,
     `${prefix}quantile`,
     metricQuantileSettings.quantile,
-  )}
+  )}`;
+
+  if (asArray) {
+    return `${centralCol}
+    ${getQuantileGridArrayColumn(
+      dialect,
+      metricQuantileSettings.quantile,
+      prefix,
+      (bound) => dialect.percentileApprox(valueExpr, bound),
+    )}`;
+  }
+
+  return `${centralCol}
     ${N_STAR_VALUES.map((nstar) => {
       const { lower, upper } = getQuantileBoundValues(
         metricQuantileSettings.quantile,
@@ -24,13 +38,13 @@ export function getQuantileGridColumns(
       );
       return `, ${quantileColumn(
         dialect,
-        `m.${prefix}value`,
+        valueExpr,
         `${prefix}quantile_lower_${nstar}`,
         lower,
       )}
           , ${quantileColumn(
             dialect,
-            `m.${prefix}value`,
+            valueExpr,
             `${prefix}quantile_upper_${nstar}`,
             upper,
           )}`;

--- a/packages/back-end/src/integrations/sql/columns/quantile-sketch-grid-columns.ts
+++ b/packages/back-end/src/integrations/sql/columns/quantile-sketch-grid-columns.ts
@@ -3,6 +3,7 @@ import type { SqlDialect } from "shared/types/sql";
 import { N_STAR_VALUES } from "back-end/src/services/experimentQueries/constants";
 
 import { getQuantileBoundValues } from "back-end/src/integrations/sql/columns/quantile-bound-values";
+import { getQuantileGridArrayColumn } from "back-end/src/integrations/sql/columns/quantile-grid-array-column";
 
 export function getQuantileSketchGridColumns(
   dialect: SqlDialect,
@@ -10,7 +11,20 @@ export function getQuantileSketchGridColumns(
   sketchCol: string,
   prefix: string,
 ): string {
-  return `, ${dialect.quantileSketchExtractPoint(sketchCol, metricQuantileSettings.quantile)} AS ${prefix}quantile
+  const asArray = dialect.hasArrayQuantileGrid();
+  const centralCol = `, ${dialect.quantileSketchExtractPoint(sketchCol, metricQuantileSettings.quantile)} AS ${prefix}quantile`;
+
+  if (asArray) {
+    return `${centralCol}
+    ${getQuantileGridArrayColumn(
+      dialect,
+      metricQuantileSettings.quantile,
+      prefix,
+      (bound) => dialect.quantileSketchExtractPoint(sketchCol, bound),
+    )}`;
+  }
+
+  return `${centralCol}
     ${N_STAR_VALUES.map((nstar) => {
       const { lower, upper } = getQuantileBoundValues(
         metricQuantileSettings.quantile,

--- a/packages/back-end/src/integrations/sql/ctes/experiment-fact-metric-statistics-cte.ts
+++ b/packages/back-end/src/integrations/sql/ctes/experiment-fact-metric-statistics-cte.ts
@@ -33,6 +33,7 @@ export function getExperimentFactMetricStatisticsCTE(
     percentileTableIndices: Set<number>;
   },
 ): string {
+  const useArrayQuantileGrid = dialect.hasArrayQuantileGrid();
   return `SELECT
         m.variation AS variation
         ${dimensionCols.map((c) => `, m.${c.alias} AS ${c.alias}`).join("")}
@@ -78,12 +79,16 @@ export function getExperimentFactMetricStatisticsCTE(
                 data.alias
               }_quantile_n
               , MAX(qm.${data.alias}_quantile) AS ${data.alias}_quantile
-                ${N_STAR_VALUES.map(
-                  (
-                    n,
-                  ) => `, MAX(qm.${data.alias}_quantile_lower_${n}) AS ${data.alias}_quantile_lower_${n}
+                ${
+                  useArrayQuantileGrid
+                    ? `, ANY_VALUE(qm.${data.alias}_quantile_grid) AS ${data.alias}_quantile_grid`
+                    : N_STAR_VALUES.map(
+                        (
+                          n,
+                        ) => `, MAX(qm.${data.alias}_quantile_lower_${n}) AS ${data.alias}_quantile_lower_${n}
                         , MAX(qm.${data.alias}_quantile_upper_${n}) AS ${data.alias}_quantile_upper_${n}`,
-                ).join("\n")}`
+                      ).join("\n")
+                }`
                 : ""
             }
             ${

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -177,6 +177,7 @@ export function getIncrementalRefreshMetricSources({
     });
   });
 
+  const sourceProps = integration.getSourceProperties();
   newBuckets.forEach((bucket, baseGroupId) => {
     const chunks = chunkMetrics({
       metrics: bucket.metrics.map((m) => {
@@ -190,8 +191,9 @@ export function getIncrementalRefreshMetricSources({
             snapshotSettings.regressionAdjustmentEnabled,
         };
       }),
-      maxColumnsPerQuery: integration.getSourceProperties().maxColumns,
+      maxColumnsPerQuery: sourceProps.maxColumns,
       isBandit: !!snapshotSettings.banditSettings,
+      efficientQuantileGrid: !!sourceProps.hasArrayQuantileGrid,
     });
     chunks.forEach((chunk, i) => {
       const randomId = Math.random().toString(36).substring(2, 15);

--- a/packages/back-end/src/services/experimentQueries/experimentQueries.ts
+++ b/packages/back-end/src/services/experimentQueries/experimentQueries.ts
@@ -142,10 +142,12 @@ export function maxColumnsNeededForMetric({
   metric,
   regressionAdjusted,
   isBandit,
+  efficientQuantileGrid = false,
 }: {
   metric: FactMetricInterface;
   regressionAdjusted: boolean;
   isBandit: boolean;
+  efficientQuantileGrid?: boolean;
 }) {
   // id column
   const boilerplateCols = 1;
@@ -169,7 +171,8 @@ export function maxColumnsNeededForMetric({
         // quantile_n and quantile
         2 +
         // quantile_lower and quantile_upper per n_star
-        N_STAR_VALUES.length * 2
+        // it is packed into a single ARRAY column when supported
+        (efficientQuantileGrid ? 1 : N_STAR_VALUES.length * 2)
       );
   }
 }
@@ -178,6 +181,7 @@ export function chunkMetrics({
   metrics,
   maxColumnsPerQuery,
   isBandit,
+  efficientQuantileGrid = false,
 }: {
   metrics: {
     metric: FactMetricInterface;
@@ -185,6 +189,7 @@ export function chunkMetrics({
   }[];
   maxColumnsPerQuery: number;
   isBandit: boolean;
+  efficientQuantileGrid?: boolean;
 }): FactMetricInterface[][] {
   // up to 100 dimensions (overkill, but also adds in buffer)
   // + 1 for variation + 2 for users and count
@@ -199,6 +204,7 @@ export function chunkMetrics({
       metric: m,
       regressionAdjusted,
       isBandit,
+      efficientQuantileGrid,
     });
     const updatedCols = runningCols + colsNeeded;
     if (
@@ -314,6 +320,7 @@ export function getFactMetricGroups(
   });
 
   const groupArrays: FactMetricInterface[][] = [];
+  const sourceProps = integration.getSourceProperties();
   Object.values(groups).forEach((group) => {
     // Split groups into chunks of MAX_METRICS_PER_QUERY
     const chunks = chunkMetrics({
@@ -328,8 +335,9 @@ export function getFactMetricGroups(
             settings.regressionAdjustmentEnabled,
         };
       }),
-      maxColumnsPerQuery: integration.getSourceProperties().maxColumns,
+      maxColumnsPerQuery: sourceProps.maxColumns,
       isBandit: !!settings.banditSettings,
+      efficientQuantileGrid: !!sourceProps.hasArrayQuantileGrid,
     });
     groupArrays.push(...chunks);
   });

--- a/packages/back-end/test/integrations/BigQuery.test.ts
+++ b/packages/back-end/test/integrations/BigQuery.test.ts
@@ -289,7 +289,9 @@ describe("BigQuery KLL quantile sketch methods", () => {
     const extractCount = (
       grid.match(/KLL_QUANTILES\.EXTRACT_POINT_FLOAT64\(m0_sketch,/g) || []
     ).length;
-    expect(extractCount).toBe(1 + N_STAR_VALUES.length * 2);
+    // 1 central point + 20 × 2 bounds, plus the first bound referenced once more
+    // in the IF(... IS NULL) guard that collapses the grid to NULL when empty.
+    expect(extractCount).toBe(1 + N_STAR_VALUES.length * 2 + 1);
   });
 
   it("returns kll intermediate data type for event quantile metrics", () => {
@@ -637,7 +639,9 @@ describe("BigQuery KLL incremental refresh SQL generation (E2E)", () => {
     const extractPointCount = (
       sql.match(/KLL_QUANTILES\.EXTRACT_POINT_FLOAT64/g) || []
     ).length;
-    expect(extractPointCount).toBe(1 + N_STAR_VALUES.length * 2);
+    // 1 central point + 20 × 2 bounds, plus the first bound referenced once more
+    // in the IF(... IS NULL) guard that collapses the grid to NULL when empty.
+    expect(extractPointCount).toBe(1 + N_STAR_VALUES.length * 2 + 1);
 
     // Pass 2: per-user rank recovery via CDF counting
     expect(sql).toContain("KLL_QUANTILES.EXTRACT_FLOAT64");

--- a/packages/back-end/test/integrations/BigQuery.test.ts
+++ b/packages/back-end/test/integrations/BigQuery.test.ts
@@ -2,6 +2,7 @@ import { ExperimentSnapshotSettings } from "shared/types/experiment-snapshot";
 import { ExposureQuery } from "shared/types/datasource";
 import BigQuery from "back-end/src/integrations/BigQuery";
 import { getAggregationMetadata } from "back-end/src/integrations/sql/fact-metrics/aggregation-metadata";
+import { getQuantileSketchGridColumns } from "back-end/src/integrations/sql/columns/quantile-sketch-grid-columns";
 import { N_STAR_VALUES } from "back-end/src/services/experimentQueries/constants";
 import { getFactTableTypeFromBigQueryType } from "back-end/src/services/bigquery";
 import { factTableFactory } from "../factories/FactTable.factory";
@@ -241,8 +242,16 @@ describe("BigQuery KLL quantile sketch methods", () => {
     expect(sql).toContain("COALESCE(");
   });
 
-  it("generates quantile grid columns from a quantile sketch", () => {
-    const grid = integration.getQuantileSketchGridColumns(
+  it("expands a quantile sketch into scalar grid columns when the dialect does not pack arrays", () => {
+    // Quantile sketches are BigQuery-only and the BigQuery dialect packs the
+    // grid into a single array, so exercise the scalar branch with a dialect
+    // that opts out.
+    const scalarDialect = {
+      ...integration.getSqlDialect(),
+      hasArrayQuantileGrid: () => false,
+    };
+    const grid = getQuantileSketchGridColumns(
+      scalarDialect,
       { type: "event", quantile: 0.9, ignoreZeros: false },
       "m0_sketch",
       "m0_",
@@ -257,6 +266,26 @@ describe("BigQuery KLL quantile sketch methods", () => {
       expect(grid).toContain(`m0_quantile_upper_${nstar}`);
     }
     // All grid columns come from EXTRACT_POINT on the same sketch
+    const extractCount = (
+      grid.match(/KLL_QUANTILES\.EXTRACT_POINT_FLOAT64\(m0_sketch,/g) || []
+    ).length;
+    expect(extractCount).toBe(1 + N_STAR_VALUES.length * 2);
+  });
+
+  it("packs quantile sketch grid columns into a single array (BigQuery dialect)", () => {
+    const grid = integration.getQuantileSketchGridColumns(
+      { type: "event", quantile: 0.9, ignoreZeros: false },
+      "m0_sketch",
+      "m0_",
+    );
+
+    expect(grid).toContain(
+      "KLL_QUANTILES.EXTRACT_POINT_FLOAT64(m0_sketch, 0.9) AS m0_quantile",
+    );
+    expect(grid).toContain("AS m0_quantile_grid");
+    expect(grid).not.toMatch(/m0_quantile_lower_\d+/);
+    expect(grid).not.toMatch(/m0_quantile_upper_\d+/);
+
     const extractCount = (
       grid.match(/KLL_QUANTILES\.EXTRACT_POINT_FLOAT64\(m0_sketch,/g) || []
     ).length;
@@ -599,8 +628,12 @@ describe("BigQuery KLL incremental refresh SQL generation (E2E)", () => {
     expect(sql).toContain("__eventQuantileSketch");
     expect(sql).toContain("KLL_QUANTILES.MERGE_PARTIAL");
 
-    // Grid extraction: 1 point estimate + 20 × 2 bounds = 41 EXTRACT_POINT calls
+    // Grid extraction still computes 1 point estimate + 20 × 2 bounds, but the
+    // bound grid is packed into one array column for BigQuery.
     expect(sql).toContain("__eventQuantileMetric");
+    expect(sql).toContain("_quantile_grid");
+    expect(sql).not.toMatch(/_quantile_lower_\d+/);
+    expect(sql).not.toMatch(/_quantile_upper_\d+/);
     const extractPointCount = (
       sql.match(/KLL_QUANTILES\.EXTRACT_POINT_FLOAT64/g) || []
     ).length;
@@ -659,6 +692,9 @@ describe("BigQuery KLL incremental refresh SQL generation (E2E)", () => {
     // tell-tale sign of kllRankApprox.
     expect(sql).toContain("__userMetricAggBase");
     expect(sql).toContain("KLL_QUANTILES.EXTRACT_FLOAT64");
+    expect(sql).toContain("_quantile_grid");
+    expect(sql).not.toMatch(/_quantile_lower_\d+/);
+    expect(sql).not.toMatch(/_quantile_upper_\d+/);
     expect(flat).toMatch(
       /FROM\s+__userMetricAggBase\s+base\s+LEFT\s+JOIN\s+__eventQuantileMetric/i,
     );
@@ -689,6 +725,9 @@ describe("BigQuery KLL incremental refresh SQL generation (E2E)", () => {
     // Raw event quantile uses APPROX_QUANTILES on the per-event values, no
     // KLL extraction or rank-recovery wrapper.
     expect(sql).toContain("APPROX_QUANTILES");
+    expect(sql).toContain("_quantile_grid");
+    expect(sql).not.toMatch(/_quantile_lower_\d+/);
+    expect(sql).not.toMatch(/_quantile_upper_\d+/);
     expect(sql).not.toContain("KLL_QUANTILES.EXTRACT_FLOAT64");
     // No KLL merge metrics → the per-user aggregation goes directly into
     // __userMetricAgg without the __userMetricAggBase wrapper.
@@ -1288,5 +1327,44 @@ describe("BigQuery KLL incremental refresh SQL generation (E2E)", () => {
       // No numerator columns for either metric land on the FT_subs cache.
       expect(subsInsertSql).not.toMatch(/fact_ratio_a_b_value[^_]/);
     });
+  });
+
+  it("getExperimentFactMetricsQuery packs the unit-quantile n_star grid into a single ARRAY column", () => {
+    // Unit quantiles previously emitted 1 + N_STAR_VALUES.length*2 = 41 scalar
+    // columns per metric, which capped chunkMetrics at ~18 metrics/query and
+    // caused the BQ job fan-out reported by customers. The array packing keeps
+    // the same statistical content (same percentile values, same selection in
+    // getQuantileBoundsFromQueryResponse) but emits 2 columns per metric, so
+    // many more quantile metrics fit per query.
+    const unitQuantileMetric = factMetricFactory.build({
+      id: "fact_uq1",
+      metricType: "quantile",
+      quantileSettings: { type: "unit", quantile: 0.9, ignoreZeros: false },
+      numerator: {
+        factTableId: "ft_events",
+        column: "amount",
+        aggregation: "sum",
+      },
+    });
+    const sql = integration.getExperimentFactMetricsQuery({
+      settings,
+      activationMetric: null,
+      dimensions: [],
+      segment: null,
+      factTableMap,
+      metrics: [unitQuantileMetric],
+      unitsSource: "exposureQuery",
+    });
+
+    const flat = sql.replace(/\s+/g, " ");
+    expect(flat).toMatch(/AS\s+m0_quantile_grid/);
+    // The legacy per-nstar scalar columns must not appear when the grid is
+    // packed into an array.
+    expect(sql).not.toMatch(/m0_quantile_lower_\d+/);
+    expect(sql).not.toMatch(/m0_quantile_upper_\d+/);
+    // Central quantile and quantile_n are still required by the read-side
+    // selection logic.
+    expect(sql).toContain("m0_quantile");
+    expect(sql).toContain("m0_quantile_n");
   });
 });

--- a/packages/back-end/test/integrations/sql/quantile-bounds-from-query-response.test.ts
+++ b/packages/back-end/test/integrations/sql/quantile-bounds-from-query-response.test.ts
@@ -73,6 +73,26 @@ describe("getQuantileBoundsFromQueryResponse — array vs scalar shape", () => {
     ).toEqual({});
   });
 
+  it("treats an empty grid array as no bounds when the quantile has no values", () => {
+    const array = getQuantileBoundsFromQueryResponse(
+      {
+        [`${prefix}quantile`]: null,
+        [`${prefix}quantile_n`]: 0,
+        [`${prefix}quantile_grid`]: [],
+      },
+      prefix,
+    );
+    const scalar = getQuantileBoundsFromQueryResponse(
+      {
+        [`${prefix}quantile`]: null,
+        [`${prefix}quantile_n`]: 0,
+      },
+      prefix,
+    );
+
+    expect(array).toEqual(scalar);
+  });
+
   it("throws when the grid array length does not match N_STAR_VALUES*2", () => {
     // Empty array — would silently drop all bounds without validation.
     expect(() =>

--- a/packages/back-end/test/integrations/sql/quantile-bounds-from-query-response.test.ts
+++ b/packages/back-end/test/integrations/sql/quantile-bounds-from-query-response.test.ts
@@ -1,0 +1,102 @@
+import { N_STAR_VALUES } from "back-end/src/services/experimentQueries/constants";
+import { getQuantileBoundsFromQueryResponse } from "back-end/src/integrations/sql/columns/quantile-bounds-from-query-response";
+
+// The array shape is the BigQuery-only optimization that packs the n_star CI
+// grid into one column instead of N_STAR_VALUES.length * 2 scalar columns.
+// It must be statistically equivalent to the legacy scalar shape — same
+// "largest nstar smaller than actual n" selection.
+describe("getQuantileBoundsFromQueryResponse — array vs scalar shape", () => {
+  const prefix = "m0_";
+  // Synthetic but realistic grid values: increasing CI width as nstar
+  // shrinks. The actual numbers don't matter as long as both shapes carry
+  // the same per-nstar lower/upper.
+  const lowerFor = (n: number) => 0.9 - 1 / Math.sqrt(n);
+  const upperFor = (n: number) => 0.9 + 1 / Math.sqrt(n);
+
+  const buildScalarRow = (quantileN: number) => {
+    const row: Record<string, number> = {
+      [`${prefix}quantile`]: 0.9,
+      [`${prefix}quantile_n`]: quantileN,
+    };
+    for (const nstar of N_STAR_VALUES) {
+      row[`${prefix}quantile_lower_${nstar}`] = lowerFor(nstar);
+      row[`${prefix}quantile_upper_${nstar}`] = upperFor(nstar);
+    }
+    return row;
+  };
+
+  const buildArrayRow = (quantileN: number) => {
+    const arr: number[] = [];
+    for (const nstar of N_STAR_VALUES) {
+      arr.push(lowerFor(nstar), upperFor(nstar));
+    }
+    return {
+      [`${prefix}quantile`]: 0.9,
+      [`${prefix}quantile_n`]: quantileN,
+      [`${prefix}quantile_grid`]: arr,
+    };
+  };
+
+  it.each([100, 250, 1000, 50_000, 1_000_000, 100_000_000])(
+    "picks identical bounds in array and scalar shape for quantile_n=%i",
+    (quantileN) => {
+      const scalar = getQuantileBoundsFromQueryResponse(
+        buildScalarRow(quantileN),
+        prefix,
+      );
+      const array = getQuantileBoundsFromQueryResponse(
+        buildArrayRow(quantileN),
+        prefix,
+      );
+
+      expect(array[`${prefix}quantile`]).toBe(scalar[`${prefix}quantile`]);
+      expect(array[`${prefix}quantile_n`]).toBe(scalar[`${prefix}quantile_n`]);
+      expect(array[`${prefix}quantile_nstar`]).toBe(
+        scalar[`${prefix}quantile_nstar`],
+      );
+      expect(array[`${prefix}quantile_lower`]).toBe(
+        scalar[`${prefix}quantile_lower`],
+      );
+      expect(array[`${prefix}quantile_upper`]).toBe(
+        scalar[`${prefix}quantile_upper`],
+      );
+    },
+  );
+
+  it("returns empty object when no quantile data is present (both shapes)", () => {
+    expect(getQuantileBoundsFromQueryResponse({}, prefix)).toEqual({});
+    expect(
+      getQuantileBoundsFromQueryResponse(
+        { [`${prefix}quantile_grid`]: [] },
+        prefix,
+      ),
+    ).toEqual({});
+  });
+
+  it("throws when the grid array length does not match N_STAR_VALUES*2", () => {
+    // Empty array — would silently drop all bounds without validation.
+    expect(() =>
+      getQuantileBoundsFromQueryResponse(
+        {
+          [`${prefix}quantile`]: 0.9,
+          [`${prefix}quantile_n`]: 1000,
+          [`${prefix}quantile_grid`]: [],
+        },
+        prefix,
+      ),
+    ).toThrow(/quantile_grid array of length/);
+
+    // One element short — also a contract violation.
+    const shortGrid = new Array(N_STAR_VALUES.length * 2 - 1).fill(0);
+    expect(() =>
+      getQuantileBoundsFromQueryResponse(
+        {
+          [`${prefix}quantile`]: 0.9,
+          [`${prefix}quantile_n`]: 1000,
+          [`${prefix}quantile_grid`]: shortGrid,
+        },
+        prefix,
+      ),
+    ).toThrow(/quantile_grid array of length/);
+  });
+});

--- a/packages/back-end/test/services/experimentQueries.test.ts
+++ b/packages/back-end/test/services/experimentQueries.test.ts
@@ -411,5 +411,92 @@ describe("experimentQueries", () => {
         });
       });
     });
+
+    describe("efficient quantile grid (array column packing)", () => {
+      // BigQuery emits the unit-quantile n_star confidence-interval grid as a
+      // single ARRAY column instead of N_STAR_VALUES.length*2 scalar columns,
+      // so each quantile metric costs far fewer output columns. chunkMetrics
+      // must honor this so it packs more metrics per query and reduces the
+      // BQ job fan-out per snapshot.
+      it("dramatically increases the quantile chunk size when set", () => {
+        const maxColumnsPerQuery = 1000;
+        const baseColumnsNeeded = 103;
+
+        const quantileColsLegacy = maxColumnsNeededForMetric({
+          metric: factMetricFactory.build({
+            metricType: "quantile",
+            numerator: { factTableId: "ft_1" },
+          }),
+          regressionAdjusted: false,
+          isBandit: false,
+        });
+        const quantileColsEfficient = maxColumnsNeededForMetric({
+          metric: factMetricFactory.build({
+            metricType: "quantile",
+            numerator: { factTableId: "ft_1" },
+          }),
+          regressionAdjusted: false,
+          isBandit: false,
+          efficientQuantileGrid: true,
+        });
+        // Efficient mode must reduce the per-metric column cost by at least 5×.
+        expect(quantileColsEfficient * 5).toBeLessThan(quantileColsLegacy);
+
+        const metrics: FactMetricInterface[] = Array.from({ length: 100 }, () =>
+          factMetricFactory.build({
+            metricType: "quantile",
+            numerator: { factTableId: "ft_1" },
+          }),
+        );
+        const wrap = metrics.map((m) => ({
+          metric: m,
+          regressionAdjusted: false,
+        }));
+
+        const legacyChunks = chunkMetrics({
+          metrics: wrap,
+          maxColumnsPerQuery,
+          isBandit: false,
+        });
+        const efficientChunks = chunkMetrics({
+          metrics: wrap,
+          maxColumnsPerQuery,
+          isBandit: false,
+          efficientQuantileGrid: true,
+        });
+
+        // All 100 metrics still present in both modes.
+        expect(legacyChunks.reduce((s, c) => s + c.length, 0)).toBe(100);
+        expect(efficientChunks.reduce((s, c) => s + c.length, 0)).toBe(100);
+
+        // Concrete expected packing for 100 unit-quantile metrics under a
+        // 1000-column / 103-base budget:
+        //   legacy quantile cost     = 1 + 5 + 2 + N_STAR_VALUES.length * 2 = 48
+        //   efficient quantile cost  = 1 + 5 + 2 + 1                       = 9
+        //   legacy chunks    = ceil(100 / floor(897/48))  = ceil(100/18) = 6
+        //   efficient chunks = ceil(100 / floor(897/9))   = ceil(100/99) = 2
+        expect(legacyChunks.length).toBe(6);
+        expect(efficientChunks.length).toBe(2);
+
+        // No chunk in efficient mode may exceed maxColumnsPerQuery.
+        efficientChunks.forEach((chunk) => {
+          const totalCols =
+            baseColumnsNeeded +
+            chunk.reduce(
+              (sum, m) =>
+                sum +
+                maxColumnsNeededForMetric({
+                  metric: m,
+                  regressionAdjusted: false,
+                  isBandit: false,
+                  efficientQuantileGrid: true,
+                }),
+              0,
+            );
+          expect(totalCols).toBeLessThanOrEqual(maxColumnsPerQuery);
+          expect(chunk.length).toBeLessThanOrEqual(MAX_METRICS_PER_QUERY);
+        });
+      });
+    });
   });
 });

--- a/packages/back-end/test/sqlintegration.test.ts
+++ b/packages/back-end/test/sqlintegration.test.ts
@@ -8,7 +8,9 @@ import {
   RowFilter,
 } from "shared/types/fact-table";
 import { ExposureQuery } from "shared/types/datasource";
+import { SqlDialect } from "shared/types/sql";
 import BigQuery from "back-end/src/integrations/BigQuery";
+import Snowflake from "back-end/src/integrations/Snowflake";
 import { bigQueryDialect } from "back-end/src/integrations/dialects/bigquery";
 import { mysqlDialect } from "back-end/src/integrations/dialects/mysql";
 import { clickHouseDialect } from "back-end/src/integrations/dialects/clickhouse";
@@ -18,6 +20,7 @@ import { getAggregateMetricColumnLegacyMetrics } from "back-end/src/integrations
 import { getMaxHoursToConvert } from "back-end/src/integrations/sql/dates/max-hours-to-convert";
 import { getFactMetricCTE } from "back-end/src/integrations/sql/ctes/fact-metric-cte";
 import { getExperimentFactMetricsQuery } from "back-end/src/integrations/sql/queries/experiment-fact-metrics-query";
+import { N_STAR_VALUES } from "back-end/src/services/experimentQueries/constants";
 import { getFeatureEvalDiagnosticsQuery } from "back-end/src/integrations/sql/queries/feature-eval-diagnostics-query";
 import { factMetricFactory } from "./factories/FactMetric.factory";
 import { factTableFactory } from "./factories/FactTable.factory";
@@ -1379,6 +1382,217 @@ describe("full fact metric experiment query - bigquery", () => {
       expect(format(normalizedSql, "bigquery")).toMatchSnapshot();
     },
   );
+});
+
+describe("quantile grid array packing is BigQuery-only", () => {
+  // The array-packed quantile grid is gated entirely on
+  // dialect.hasArrayQuantileGrid(). This drives two distinct behaviors:
+  //   1. SQL generation — getExperimentFactMetricsQuery emits ONE array column
+  //      (m0_quantile_grid) instead of N_STAR_VALUES.length * 2 scalar columns.
+  //   2. Column budgeting — getSourceProperties().hasArrayQuantileGrid (which
+  //      just forwards the dialect flag) flips chunkMetrics into efficient mode.
+  // These tests pin both behaviors to BigQuery so the optimization can't
+  // silently leak into another warehouse that doesn't actually support arrays.
+  const testExposureQuery: ExposureQuery = {
+    id: "anonymous_id",
+    name: "Exposure",
+    description: "Exposure",
+    query: "*",
+    userIdType: "user_id",
+    dimensions: [],
+  };
+
+  const ordersFactTable = factTableFactory.build({
+    id: "orders",
+    name: "Orders Fact Table",
+    sql: "*",
+  });
+  const factTableMap = new Map([[ordersFactTable.id, ordersFactTable]]);
+
+  // A single BigQuery instance only to source a valid (dialect-agnostic)
+  // datasource object — the SQL is generated from the dialect we pass in, not
+  // from the integration, so the same datasource feeds both branches and the
+  // ONLY difference between the two SQL strings is the dialect.
+  // @ts-expect-error -- context not needed for test
+  const datasourceIntegration = new BigQuery("", {
+    settings: { queries: { exposure: [testExposureQuery] } },
+  });
+
+  const buildQuantileSql = (
+    dialect: SqlDialect,
+    quantileSettings: FactMetricInterface["quantileSettings"],
+  ): string => {
+    const metric = factMetricFactory.build({
+      id: "fact_uq1",
+      metricType: "quantile",
+      quantileSettings,
+      numerator: {
+        factTableId: "orders",
+        column: "amount",
+        aggregation: "sum",
+      },
+    });
+    return getExperimentFactMetricsQuery(
+      dialect,
+      datasourceIntegration.datasource,
+      {
+        settings: {
+          manual: false,
+          dimensions: [],
+          metricSettings: [],
+          goalMetrics: [],
+          secondaryMetrics: [],
+          guardrailMetrics: [],
+          activationMetric: null,
+          defaultMetricPriorSettings: {
+            override: false,
+            proper: false,
+            mean: 0,
+            stddev: 0,
+          },
+          regressionAdjustmentEnabled: false,
+          attributionModel: "firstExposure",
+          experimentId: "",
+          queryFilter: "",
+          segment: "",
+          skipPartialData: false,
+          datasourceId: "",
+          exposureQueryId: "",
+          startDate: new Date("2023-01-01"),
+          endDate: new Date("2023-01-31"),
+          variations: [],
+        },
+        unitsSource: "exposureQuery",
+        activationMetric: null,
+        dimensions: [],
+        segment: null,
+        metrics: [metric],
+        factTableMap,
+      },
+    );
+  };
+
+  describe("dialect flag", () => {
+    it.each([
+      ["bigquery", bigQueryDialect, true],
+      ["snowflake", snowflakeDialect, false],
+      ["clickhouse", clickHouseDialect, false],
+      ["mysql", mysqlDialect, false],
+    ] as const)(
+      "%s reports hasArrayQuantileGrid() === %s",
+      (_name, dialect, expected) => {
+        expect(dialect.hasArrayQuantileGrid()).toBe(expected);
+      },
+    );
+
+    it("non-array dialects throw if arrayLiteral is ever called", () => {
+      // Defensive contract: a dialect must not advertise array support without
+      // implementing arrayLiteral, and must not have arrayLiteral silently
+      // no-op if it doesn't support arrays.
+      expect(() => snowflakeDialect.arrayLiteral(["1", "2"])).toThrow();
+      expect(bigQueryDialect.arrayLiteral(["1", "2"])).toBe("[1, 2]");
+    });
+  });
+
+  describe("column budgeting (source properties)", () => {
+    it("only BigQuery's source properties enable the efficient (array) grid", () => {
+      // @ts-expect-error -- context not needed for test
+      const bq = new BigQuery("", {
+        settings: { queries: { exposure: [testExposureQuery] } },
+      });
+      // @ts-expect-error -- context not needed for test
+      const sf = new Snowflake("", {
+        settings: { queries: { exposure: [testExposureQuery] } },
+      });
+
+      expect(bq.getSourceProperties().hasArrayQuantileGrid).toBe(true);
+      expect(sf.getSourceProperties().hasArrayQuantileGrid).toBe(false);
+    });
+  });
+
+  describe("SQL generation", () => {
+    it.each(["unit", "event"] as const)(
+      "%s quantile: BigQuery packs one array column; Snowflake keeps scalar columns",
+      (quantileType) => {
+        const quantileSettings = {
+          type: quantileType,
+          quantile: 0.9,
+          ignoreZeros: false,
+        };
+        const bqSql = buildQuantileSql(bigQueryDialect, quantileSettings);
+        const sfSql = buildQuantileSql(snowflakeDialect, quantileSettings);
+
+        // BigQuery: single array column, no per-nstar scalar columns.
+        expect(bqSql).toMatch(/AS\s+m0_quantile_grid/);
+        expect(bqSql).not.toMatch(/m0_quantile_lower_\d+/);
+        expect(bqSql).not.toMatch(/m0_quantile_upper_\d+/);
+
+        // Snowflake: per-nstar scalar columns, no packed array column.
+        expect(sfSql).not.toContain("m0_quantile_grid");
+        expect(sfSql).toMatch(/m0_quantile_lower_\d+/);
+        expect(sfSql).toMatch(/m0_quantile_upper_\d+/);
+
+        // The central point estimate and quantile_n are present in both shapes
+        // (the read side needs them regardless of the grid encoding).
+        expect(bqSql).toContain("m0_quantile_n");
+        expect(sfSql).toContain("m0_quantile_n");
+      },
+    );
+
+    it("Snowflake emits exactly N_STAR_VALUES*2 scalar bound columns (no array)", () => {
+      const sfSql = buildQuantileSql(snowflakeDialect, {
+        type: "unit",
+        quantile: 0.9,
+        ignoreZeros: false,
+      });
+
+      const lowerCount = (sfSql.match(/AS\s+m0_quantile_lower_\d+/g) || [])
+        .length;
+      const upperCount = (sfSql.match(/AS\s+m0_quantile_upper_\d+/g) || [])
+        .length;
+
+      expect(lowerCount).toBe(N_STAR_VALUES.length);
+      expect(upperCount).toBe(N_STAR_VALUES.length);
+    });
+  });
+
+  // Coverage transfer: the BigQuery snapshot suite above used to be the only
+  // thing pinning the exact scalar-column quantile SQL. Now that BigQuery emits
+  // an array, that path is exercised only by non-array warehouses — so we pin
+  // the exact scalar SQL here, under Snowflake, to keep the unchanged path
+  // guarded against unintended structural changes (offsets, CTE shape, etc.).
+  describe("exact scalar quantile SQL (Snowflake snapshots)", () => {
+    const quantileVariants: {
+      label: string;
+      settings: FactMetricInterface["quantileSettings"];
+    }[] = [
+      {
+        label: "unit_0.9_includeZeros",
+        settings: { type: "unit", quantile: 0.9, ignoreZeros: false },
+      },
+      {
+        label: "unit_0.9_ignoreZeros",
+        settings: { type: "unit", quantile: 0.9, ignoreZeros: true },
+      },
+      {
+        label: "event_0.9_includeZeros",
+        settings: { type: "event", quantile: 0.9, ignoreZeros: false },
+      },
+      {
+        label: "event_0.9_ignoreZeros",
+        settings: { type: "event", quantile: 0.9, ignoreZeros: true },
+      },
+    ];
+
+    it.each(quantileVariants)(
+      "snowflake scalar quantile SQL is correct for $label",
+      ({ settings }) => {
+        const sql = buildQuantileSql(snowflakeDialect, settings);
+        const normalizedSql = sql.replace(/\s+/g, " ").trim();
+        expect(format(normalizedSql, "snowflake")).toMatchSnapshot();
+      },
+    );
+  });
 });
 
 describe("getFeatureEvalDiagnosticsQuery", () => {

--- a/packages/back-end/test/sqlintegration.test.ts
+++ b/packages/back-end/test/sqlintegration.test.ts
@@ -1485,12 +1485,18 @@ describe("quantile grid array packing is BigQuery-only", () => {
       },
     );
 
-    it("non-array dialects throw if arrayLiteral is ever called", () => {
+    it("quantileGridArrayLiteral collapses to NULL when the grid has no data", () => {
       // Defensive contract: a dialect must not advertise array support without
-      // implementing arrayLiteral, and must not have arrayLiteral silently
+      // implementing quantileGridArrayLiteral, and must not have it silently
       // no-op if it doesn't support arrays.
-      expect(() => snowflakeDialect.arrayLiteral(["1", "2"])).toThrow();
-      expect(bigQueryDialect.arrayLiteral(["1", "2"])).toBe("[1, 2]");
+      expect(() =>
+        snowflakeDialect.quantileGridArrayLiteral(["1", "2"]),
+      ).toThrow();
+      // BigQuery rejects a NULL-containing array in a query result, so the grid
+      // must collapse to NULL (all-or-nothing) instead of emitting a partial array.
+      expect(bigQueryDialect.quantileGridArrayLiteral(["a", "b"])).toBe(
+        "IF(a IS NULL, NULL, [a, b])",
+      );
     });
   });
 

--- a/packages/shared/src/sql.ts
+++ b/packages/shared/src/sql.ts
@@ -209,7 +209,12 @@ export function encodeSQLResults(
     return [];
   }
 
-  const columns = Object.keys(results[0]);
+  const columns = Array.from(
+    results.reduce((acc, row) => {
+      Object.keys(row).forEach((column) => acc.add(column));
+      return acc;
+    }, new Set<string>()),
+  );
   const encodedResults: SqlResultChunkData[] = [];
 
   function createChunk(): SqlResultChunkData {
@@ -239,7 +244,7 @@ export function encodeSQLResults(
   for (const row of results) {
     currentChunk.numRows++;
     for (const col of columns) {
-      const value = row[col];
+      const value = row[col] ?? null;
       currentChunk.data[col].push(value);
       currentChunkSize += getSize(value);
     }

--- a/packages/shared/test/sql.test.ts
+++ b/packages/shared/test/sql.test.ts
@@ -588,4 +588,29 @@ describe("encodeSQLResults", () => {
     const decoded = decodeSQLResults(encoded);
     expect(decoded).toEqual(results);
   });
+
+  it("preserves columns that are missing from the first row", () => {
+    const results = [
+      { id: 1, name: "Alice" },
+      { id: 2, name: "Bob", grid: [1, 2, 3] },
+    ];
+
+    const encoded = encodeSQLResults(results);
+    expect(encoded).toEqual([
+      {
+        numRows: 2,
+        data: {
+          id: [1, 2],
+          name: ["Alice", "Bob"],
+          grid: [null, [1, 2, 3]],
+        },
+      },
+    ]);
+
+    const decoded = decodeSQLResults(encoded);
+    expect(decoded).toEqual([
+      { id: 1, name: "Alice", grid: null },
+      { id: 2, name: "Bob", grid: [1, 2, 3] },
+    ]);
+  });
 });

--- a/packages/shared/types/datasource.d.ts
+++ b/packages/shared/types/datasource.d.ts
@@ -146,6 +146,7 @@ export interface DataSourceProperties {
   hasCountDistinctHLL?: boolean;
   hasQuantileSketch?: boolean;
   hasIncrementalRefresh?: boolean;
+  hasArrayQuantileGrid?: boolean;
   maxColumns: number;
 }
 

--- a/packages/shared/types/sql.d.ts
+++ b/packages/shared/types/sql.d.ts
@@ -101,6 +101,8 @@ export interface SqlDialect {
     nEventsCol: string,
     numQuantiles: number,
   ) => string;
+  hasArrayQuantileGrid: () => boolean;
+  arrayLiteral: (elements: string[]) => string;
   unpivotLabeledPairs: (
     pairs: UnpivotLabeledPair[],
   ) => UnpivotLabeledPairsResult;

--- a/packages/shared/types/sql.d.ts
+++ b/packages/shared/types/sql.d.ts
@@ -102,7 +102,7 @@ export interface SqlDialect {
     numQuantiles: number,
   ) => string;
   hasArrayQuantileGrid: () => boolean;
-  arrayLiteral: (elements: string[]) => string;
+  quantileGridArrayLiteral: (elements: string[]) => string;
   unpivotLabeledPairs: (
     pairs: UnpivotLabeledPair[],
   ) => UnpivotLabeledPairsResult;


### PR DESCRIPTION
### Features and Changes

For quantile metrics we compute a confidence-interval grid — a lower/upper bound at each
of the 20 sample-size thresholds in `N_STAR_VALUES` — and previously emitted every bound as
its own SQL column (1 point estimate + `N_STAR_VALUES.length * 2` = 41 columns per metric).
On BigQuery we now pack the whole grid into a single `ARRAY` column instead, dropping a
quantile metric's column cost ~5×.

Since we chunk metrics into queries under a max-columns-per-query budget, this lets
many more quantile metrics fit per query, reducing
the number of queries and repeated fact-table scans per snapshot.

- **BigQuery-only, opt-in via dialect:** new `hasArrayQuantileGrid()` capability (default off);
  all other warehouses keep the existing scalar columns unchanged.
- **Statistically identical:** Just changes how the query is created and read