### PR TITLE
fix: align ResultsTable zero line by using flex instead of inline-flex

### DIFF
--- a/packages/front-end/components/Experiment/PercentGraph.tsx
+++ b/packages/front-end/components/Experiment/PercentGraph.tsx
@@ -141,7 +141,7 @@ export default function PercentGraph({
   });
 
   return (
-    <Trigger style={{ display: "inline-flex" }}>
+    <Trigger style={{ display: "flex" }}>
       <AlignedGraph
         ci={showGraph ? (stats?.ciAdjusted ?? stats.ci) : [0, 0]}
         id={id}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

Fixes the broken/fragmented vertical 0 line in the ResultsTable that was introduced in PR #5906.

**Root Cause:**  
PR #5906 changed the `PercentGraph` component to wrap `AlignedGraph` in a `<Trigger>` component with `style={{ display: "inline-flex" }}`. The `Trigger` renders a `<span>` element, and `inline-flex` causes it to be an inline-level element that doesn't take the full width of the table cell. This results in:
- Each row's graph potentially having different horizontal positioning
- The vertical 0 line (drawn by `AxisLeft` in `AlignedGraph`) appearing fragmented across rows

**Fix:**  
Changed `display: "inline-flex"` to `display: "flex"` (block-level flex container), ensuring the wrapper takes the full width of the table cell and graphs align properly across all rows.

- Fixes issue reported in Slack thread about broken 0 line in ResultsTable

### Dependencies

None

### Testing

- All 403 front-end tests pass
- TypeScript type-check passes
- ESLint check passes
- This is a minimal CSS-only change (single property value) with low risk

The fix follows the theory confirmed by Bryce in the Slack thread regarding `display: inline-flex` causing line-render behavior issues in the graph cell.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C07NK4F016Z/p1780090744645499?thread_ts=1780090744.645499&cid=C07NK4F016Z)

<div><a href="https://cursor.com/agents/bc-cdd424ad-12a1-5f1f-ab2c-d90a65d79511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cdd424ad-12a1-5f1f-ab2c-d90a65d79511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

