### PR TITLE
fix(time-series): keep time series data if at least one variation has real data

### DIFF
--- a/packages/shared/src/util/metric-time-series.ts
+++ b/packages/shared/src/util/metric-time-series.ts
@@ -24,17 +24,17 @@ export function isValidDataPoint(
     return false;
   }
 
-  // Check variations from index 1 onwards (skip control)
-  for (let i = 1; i < dataPoint.variations.length; i++) {
-    const variation = dataPoint.variations[i];
-    if (
-      variation.absolute?.ci &&
-      variation.absolute.ci[0] === 0 &&
-      variation.absolute.ci[1] === 0
-    ) {
-      return false;
-    }
-  }
+  // Only drop the point when EVERY treatment variation (index 1+) is degenerate
+  // (absolute CI of [0, 0]). A point with a real estimate for at least one
+  // variation is still useful and should be kept.
+  const allTreatmentsDegenerate = dataPoint.variations
+    .slice(1)
+    .every(
+      (variation) =>
+        variation.absolute?.ci &&
+        variation.absolute.ci[0] === 0 &&
+        variation.absolute.ci[1] === 0,
+    );
 
-  return true;
+  return !allTreatmentsDegenerate;
 }

--- a/packages/shared/test/metric-time-series.test.ts
+++ b/packages/shared/test/metric-time-series.test.ts
@@ -1,4 +1,29 @@
 import { metricTimeSeriesSchema } from "../src/validators/metric-time-series";
+import type { MetricTimeSeries } from "../src/validators/metric-time-series";
+import {
+  isValidDataPoint,
+  filterInvalidMetricTimeSeries,
+} from "../src/util/metric-time-series";
+
+type DataPoint = MetricTimeSeries["dataPoints"][number];
+type Variation = DataPoint["variations"][number];
+
+const control: Variation = { id: "0", name: "Control" };
+const realVariation: Variation = {
+  id: "1",
+  name: "Variation",
+  absolute: { value: 1, ci: [0.5, 1.5] },
+};
+const degenerateVariation: Variation = {
+  id: "1",
+  name: "Variation",
+  absolute: { value: 0, ci: [0, 0] },
+};
+const noAbsoluteVariation: Variation = { id: "1", name: "Variation" };
+
+function makeDataPoint(variations: Variation[]): DataPoint {
+  return { date: new Date("2025-01-01T00:00:00Z"), variations };
+}
 
 function makeMetricTimeSeries(overrides: Record<string, unknown> = {}) {
   return {
@@ -66,5 +91,77 @@ describe("metricTimeSeriesSchema", () => {
     expect(
       metricTimeSeriesSchema.safeParse(makeMetricTimeSeries(overrides)).success,
     ).toBe(false);
+  });
+});
+
+describe("isValidDataPoint", () => {
+  it("rejects a point with no variations or only control", () => {
+    expect(isValidDataPoint(makeDataPoint([]))).toBe(false);
+    expect(isValidDataPoint(makeDataPoint([control]))).toBe(false);
+  });
+
+  it("accepts a point with a non-degenerate treatment variation", () => {
+    expect(isValidDataPoint(makeDataPoint([control, realVariation]))).toBe(
+      true,
+    );
+  });
+
+  it("rejects a point only when ALL treatment variations are degenerate", () => {
+    expect(
+      isValidDataPoint(makeDataPoint([control, degenerateVariation])),
+    ).toBe(false);
+    expect(
+      isValidDataPoint(
+        makeDataPoint([control, degenerateVariation, degenerateVariation]),
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps a point when at least one treatment variation is non-degenerate", () => {
+    expect(
+      isValidDataPoint(
+        makeDataPoint([control, degenerateVariation, realVariation]),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat a missing absolute CI as degenerate", () => {
+    expect(
+      isValidDataPoint(makeDataPoint([control, noAbsoluteVariation])),
+    ).toBe(true);
+  });
+});
+
+describe("filterInvalidMetricTimeSeries", () => {
+  function makeSeries(dataPoints: DataPoint[]): MetricTimeSeries {
+    return {
+      id: "mts_1",
+      organization: "org_1",
+      dateCreated: new Date("2025-01-01T00:00:00Z"),
+      dateUpdated: new Date("2025-01-01T00:00:00Z"),
+      metricId: "met_1",
+      source: "experiment",
+      sourceId: "exp_1",
+      sourcePhase: 0,
+      lastExperimentSettingsHash: "experiment_hash",
+      lastMetricSettingsHash: "metric_hash",
+      dataPoints,
+    } as MetricTimeSeries;
+  }
+
+  it("drops invalid data points but keeps mixed-validity points", () => {
+    const series = makeSeries([
+      makeDataPoint([control, degenerateVariation]),
+      makeDataPoint([control, degenerateVariation, realVariation]),
+    ]);
+
+    const [filtered] = filterInvalidMetricTimeSeries([series]);
+    expect(filtered.dataPoints).toHaveLength(1);
+    expect(filtered.dataPoints[0].variations).toContain(realVariation);
+  });
+
+  it("removes a series whose data points are all invalid", () => {
+    const series = makeSeries([makeDataPoint([control, degenerateVariation])]);
+    expect(filterInvalidMetricTimeSeries([series])).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Keep partial metric time-series points instead of dropping them

`isValidDataPoint` now drops a data point only when **all** treatment variations are degenerate (absolute CI of `[0, 0]`), rather than as soon as any single variation is degenerate. This stops early-phase points (where one variation lacks data but others have real estimates) from being silently discarded on write and render.

- `packages/shared/src/util/metric-time-series.ts`: invert the per-variation check to require all treatments degenerate before invalidating a point.
- `packages/shared/test/metric-time-series.test.ts`: add `isValidDataPoint` and `filterInvalidMetricTimeSeries` coverage for all-degenerate, mixed-validity, and missing-CI cases.