### PR TITLE
Materialize assignment query into stable table for inactive pipeline

### DIFF
--- a/packages/back-end/src/integrations/sql/queries/drop-units-table-query.ts
+++ b/packages/back-end/src/integrations/sql/queries/drop-units-table-query.ts
@@ -1,10 +1,16 @@
 import { DropTableQueryParams } from "shared/types/integrations";
-import { UNITS_TABLE_PREFIX } from "back-end/src/queryRunners/ExperimentResultsQueryRunner";
+import {
+  UNITS_TABLE_PREFIX,
+  ASSIGNMENT_UNITS_TABLE_PREFIX,
+} from "back-end/src/queryRunners/ExperimentResultsQueryRunner";
 
 export function getDropUnitsTableQuery(params: DropTableQueryParams): string {
-  // valdidate units table query follows expected name to help
+  // validate units table query follows expected name to help
   // prevent dropping other tables
-  if (!params.fullTablePath.includes(UNITS_TABLE_PREFIX)) {
+  if (
+    !params.fullTablePath.includes(UNITS_TABLE_PREFIX) &&
+    !params.fullTablePath.includes(ASSIGNMENT_UNITS_TABLE_PREFIX)
+  ) {
     throw new Error("Unable to drop table that is not temporary units table.");
   }
   return `DROP TABLE IF EXISTS ${params.fullTablePath}`;

--- a/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
@@ -153,7 +153,10 @@ export const startExperimentResultQueries = async (
   // materialize the assignment/exposure query into its own table so it runs
   // once instead of being inlined as a CTE inside every metric query.
   const separateAssignmentQuery =
-    canWriteTable && settings.pipelineSettings?.allowWriting && !useUnitsTable;
+    canWriteTable &&
+    settings.pipelineSettings?.allowWriting &&
+    hasPipelineModeFeature &&
+    !useUnitsTable;
   const shouldCreateUnitsTable = useUnitsTable || separateAssignmentQuery;
 
   // Table name: use a per-snapshot name for full pipeline mode (ephemeral),

--- a/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
@@ -84,6 +84,7 @@ export type ExperimentResultsQueryParams = {
 export const TRAFFIC_QUERY_NAME = "traffic";
 
 export const UNITS_TABLE_PREFIX = "growthbook_tmp_units";
+export const ASSIGNMENT_UNITS_TABLE_PREFIX = "gb_units_assignment";
 
 export const startExperimentResultQueries = async (
   context: ApiReqContext,
@@ -137,13 +138,39 @@ export const startExperimentResultQueries = async (
   const queries: Queries = [];
 
   // Settings for units table
+  const canWriteTable =
+    integration.getSourceProperties().supportsWritingTables &&
+    !!settings.pipelineSettings?.writeDataset;
+
   const useUnitsTable =
-    (integration.getSourceProperties().supportsWritingTables &&
+    (canWriteTable &&
       settings.pipelineSettings?.allowWriting &&
       settings.pipelineSettings?.mode === "ephemeral" &&
-      !!settings.pipelineSettings?.writeDataset &&
       hasPipelineModeFeature) ??
     false;
+
+  // When we can write tables but full pipeline mode is not active, still
+  // materialize the assignment/exposure query into its own table so it runs
+  // once instead of being inlined as a CTE inside every metric query.
+  const separateAssignmentQuery =
+    canWriteTable && settings.pipelineSettings?.allowWriting && !useUnitsTable;
+  const shouldCreateUnitsTable = useUnitsTable || separateAssignmentQuery;
+
+  // Table name: use a per-snapshot name for full pipeline mode (ephemeral),
+  // and a stable per-experiment name for the separate-assignment path so the
+  // materialized results can be reused across refreshes.
+  const unitsTableName = useUnitsTable
+    ? `${UNITS_TABLE_PREFIX}_${queryParentId}`
+    : `${ASSIGNMENT_UNITS_TABLE_PREFIX}_${snapshotSettings.experimentId}`;
+  const unitsTableFullName =
+    shouldCreateUnitsTable && !!integration.generateTablePath
+      ? integration.generateTablePath(
+          unitsTableName,
+          settings.pipelineSettings?.writeDataset,
+          settings.pipelineSettings?.writeDatabase,
+          true,
+        )
+      : "";
 
   // Configured "always-computed" unit dimensions. These are materialized as
   // extra dim_unit_<id> columns on the shared units table and get isolated
@@ -160,15 +187,6 @@ export const startExperimentResultQueries = async (
     )
   ).filter((d): d is Dimension => d !== null);
   let unitQuery: QueryPointer | null = null;
-  const unitsTableFullName =
-    useUnitsTable && !!integration.generateTablePath
-      ? integration.generateTablePath(
-          `${UNITS_TABLE_PREFIX}_${queryParentId}`,
-          settings.pipelineSettings?.writeDataset,
-          settings.pipelineSettings?.writeDatabase,
-          true,
-        )
-      : "";
 
   // Settings for health query
   const runTrafficQuery = shouldRunHealthTrafficQuery({
@@ -199,7 +217,7 @@ export const startExperimentResultQueries = async (
     factTableMap: params.factTableMap,
   };
 
-  if (useUnitsTable) {
+  if (shouldCreateUnitsTable) {
     // The Mixpanel integration does not support writing tables
     if (!integration.generateTablePath) {
       throw new Error(
@@ -215,7 +233,7 @@ export const startExperimentResultQueries = async (
         ...unitQueryParams,
         dimensions: [
           ...unitQueryParams.dimensions,
-          ...unitDimensionsToPrecompute,
+          ...(useUnitsTable ? unitDimensionsToPrecompute : []),
         ],
       }),
       dependencies: [],
@@ -448,7 +466,7 @@ export const startExperimentResultQueries = async (
   const dropUnitsTable =
     integration.getSourceProperties().dropUnitsTable &&
     settings.pipelineSettings?.unitsTableDeletion;
-  if (useUnitsTable && dropUnitsTable) {
+  if (shouldCreateUnitsTable && dropUnitsTable) {
     const dropUnitsTableQuery = await startQuery({
       name: `drop_${queryParentId}`,
       query: integration.getDropUnitsTableQuery({


### PR DESCRIPTION
This update optimizes data processing when the full pipeline is inactive but table writing is enabled. Instead of inlining assignment/exposure queries as CTEs, queries are now materialized into stable per-experiment tables (gb_units_assignment_*), significantly reducing redundant computation during refreshes.

Key changes:
* Refactored units table logic into shouldCreateUnitsTable and canWriteTable
* Added ASSIGNMENT_UNITS_TABLE_PREFIX constant for consistent table naming
* Extended drop-units-table validation to support both prefix types
* Precomputation of unit dimensions now occurs only in full pipeline mode


Closes: https://github.com/growthbook/growthbook/issues/5925
