### PR TITLE
fix(features): treat missing environmentsEnabled on base revision as false

### DIFF
--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -2056,7 +2056,11 @@ export function getDraftAffectedEnvironments(
     if (!isEqual(revRules, baseRules)) {
       envs.add(env);
     }
-    const effectiveBaseEnvVal = baseRevision.environmentsEnabled?.[env];
+    // Base revisions that predate an environment have no key for it at all;
+    // treat missing as false so a freshly-snapshotted `false` on the draft side
+    // doesn't register as a kill-switch change.
+    const effectiveBaseEnvVal =
+      baseRevision.environmentsEnabled?.[env] ?? false;
     if (
       revision.environmentsEnabled?.[env] !== undefined &&
       revision.environmentsEnabled[env] !== effectiveBaseEnvVal
@@ -2174,7 +2178,7 @@ export function checkIfRevisionNeedsReview({
     (env) =>
       revision.environmentsEnabled?.[env] !== undefined &&
       revision.environmentsEnabled[env] !==
-        baseRevision.environmentsEnabled?.[env],
+        (baseRevision.environmentsEnabled?.[env] ?? false),
   );
 
   const gatedEnvs = reviewSetting.environments;

--- a/packages/shared/test/util/feature-revisions.test.ts
+++ b/packages/shared/test/util/feature-revisions.test.ts
@@ -1227,6 +1227,56 @@ describe("getDraftAffectedEnvironments", () => {
     ).toBe("all");
   });
 
+  it("does not flag an environment that is missing on the base (added after base was published)", () => {
+    // base predates the "vertex" env → no key at all
+    const oldBase: RevisionFields = {
+      version: 3,
+      defaultValue: "false",
+      rules: { production: [], staging: [] },
+      environmentsEnabled: { production: true, staging: false },
+      prerequisites: [],
+    };
+    // draft snapshots all current envs; the user only changed staging rules
+    const revision: RevisionFields = {
+      ...oldBase,
+      version: 4,
+      rules: {
+        ...oldBase.rules,
+        staging: [{ type: "force", id: "r1", description: "", value: "x" }],
+      },
+      environmentsEnabled: { production: true, staging: false, vertex: false },
+    };
+    expect(
+      getDraftAffectedEnvironments(revision, oldBase, [
+        "production",
+        "staging",
+        "vertex",
+      ]),
+    ).toEqual(["staging"]);
+  });
+
+  it("still flags an environment missing on the base when the draft enables it", () => {
+    const oldBase: RevisionFields = {
+      version: 3,
+      defaultValue: "false",
+      rules: { production: [], staging: [] },
+      environmentsEnabled: { production: true, staging: false },
+      prerequisites: [],
+    };
+    const revision: RevisionFields = {
+      ...oldBase,
+      version: 4,
+      environmentsEnabled: { production: true, staging: false, vertex: true },
+    };
+    expect(
+      getDraftAffectedEnvironments(revision, oldBase, [
+        "production",
+        "staging",
+        "vertex",
+      ]),
+    ).toEqual(["vertex"]);
+  });
+
   it('collapses to "all" when every environment is affected', () => {
     const revision: RevisionFields = {
       ...base,


### PR DESCRIPTION
### Features and Changes

Editing a feature that was last published before a new environment was added to the org spuriously demands approval for that new environment — even when the edit doesn't touch it.

**The bug.** `getDraftAffectedEnvironments` decides which environments a draft changed relative to its base revision by comparing `environmentsEnabled[env]` on both sides. When a draft is created, `createRevision` snapshots every environment the org currently has, writing `false` for any the feature doesn't yet have settings for. But the base revision was stored before the new environment existed, so it has no key for it at all. The comparison then sees `false !== undefined` and flags the new environment as a kill-switch change, which pulls in its approval requirement even though the user never touched it.

**The fix.** Treat a missing `environmentsEnabled` key on the base side as `false`, matching the default `createRevision` writes on the draft side. Applied at both comparison sites (`getDraftAffectedEnvironments` and the kill-switch filter inside `checkIfRevisionNeedsReview`). This follows the same `?? false` normalization already used in `draftDiffersFromLive`.

Adding an environment does not backfill `environmentSettings` on existing features, so the draft side always writes `false` for a newly-added env regardless of the env's `defaultState` — `?? false` on the base side is exact, not an approximation.

Without this fix the bug self-heals once any draft is published for the feature after the new environment exists (the published revision carries the full `environmentsEnabled` map, so the next edit's base has the key), but every feature last published before the env add hits it once.

Note: `autoMerge` carries the same un-normalized comparison (`revVal !== base.environmentsEnabled?.[env]`). It builds merge results rather than approval gates, so the symptom there is a no-op write or a spurious merge-conflict marker rather than a spurious approval demand. Left out of scope for this PR — happy to follow up.

### Dependencies

None

### Testing

- Two test cases added to `feature-revisions.test.ts`: base revision missing the key with draft `false` (not flagged as affected) and with draft `true` (still flagged).
- Behaviour is unchanged when the base revision already has the key for the environment.
