### PR TITLE
Optional owner in REST endpoints when using a PAT

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -588,10 +588,9 @@ paths:
                     The userId or email address of the owner. If an email
                     address is provided, it will be used to look up the userId
                     of the matching organization member. If an ID is provided,
-                    it will be validated as existing in the organization. Not
-                    required when authenticating with a Personal Access Token
-                    (PAT) — it will default to the user associated with the
-                    token.
+                    it will be validated as existing in the organization. When
+                    omitted, it defaults to the user associated with the
+                    request's Personal Access Token (PAT), if one is being used.
                   type: string
                 project:
                   description: An associated project ID
@@ -5678,10 +5677,9 @@ paths:
                     The userId or email address of the owner. If an email
                     address is provided, it will be used to look up the userId
                     of the matching organization member. If an ID is provided,
-                    it will be validated as existing in the organization. Not
-                    required when authenticating with a Personal Access Token
-                    (PAT) — it will default to the user associated with the
-                    token.
+                    it will be validated as existing in the organization. When
+                    omitted, it defaults to the user associated with the
+                    request's Personal Access Token (PAT), if one is being used.
                   type: string
                 project:
                   description: An associated project ID
@@ -10181,10 +10179,9 @@ paths:
                     The userId or email address of the owner. If an email
                     address is provided, it will be used to look up the userId
                     of the matching organization member. If an ID is provided,
-                    it will be validated as existing in the organization. Not
-                    required when authenticating with a Personal Access Token
-                    (PAT) — it will default to the user associated with the
-                    token.
+                    it will be validated as existing in the organization. When
+                    omitted, it defaults to the user associated with the
+                    request's Personal Access Token (PAT), if one is being used.
                   type: string
                 archived:
                   type: boolean
@@ -14538,10 +14535,9 @@ paths:
                     The userId or email address of the owner. If an email
                     address is provided, it will be used to look up the userId
                     of the matching organization member. If an ID is provided,
-                    it will be validated as existing in the organization. Not
-                    required when authenticating with a Personal Access Token
-                    (PAT) — it will default to the user associated with the
-                    token.
+                    it will be validated as existing in the organization. When
+                    omitted, it defaults to the user associated with the
+                    request's Personal Access Token (PAT), if one is being used.
                   type: string
                 projects:
                   type: array

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -588,7 +588,10 @@ paths:
                     The userId or email address of the owner. If an email
                     address is provided, it will be used to look up the userId
                     of the matching organization member. If an ID is provided,
-                    it will be validated as existing in the organization.
+                    it will be validated as existing in the organization. Not
+                    required when authenticating with a Personal Access Token
+                    (PAT) — it will default to the user associated with the
+                    token.
                   type: string
                 project:
                   description: An associated project ID
@@ -1298,7 +1301,6 @@ paths:
                     type: string
               required:
                 - id
-                - owner
                 - valueType
                 - defaultValue
               additionalProperties: false
@@ -5676,7 +5678,10 @@ paths:
                     The userId or email address of the owner. If an email
                     address is provided, it will be used to look up the userId
                     of the matching organization member. If an ID is provided,
-                    it will be validated as existing in the organization.
+                    it will be validated as existing in the organization. Not
+                    required when authenticating with a Personal Access Token
+                    (PAT) — it will default to the user associated with the
+                    token.
                   type: string
                 project:
                   description: An associated project ID
@@ -6120,7 +6125,6 @@ paths:
                     type: string
               required:
                 - id
-                - owner
                 - valueType
                 - defaultValue
               additionalProperties: false
@@ -10177,7 +10181,10 @@ paths:
                     The userId or email address of the owner. If an email
                     address is provided, it will be used to look up the userId
                     of the matching organization member. If an ID is provided,
-                    it will be validated as existing in the organization.
+                    it will be validated as existing in the organization. Not
+                    required when authenticating with a Personal Access Token
+                    (PAT) — it will default to the user associated with the
+                    token.
                   type: string
                 archived:
                   type: boolean
@@ -14531,7 +14538,10 @@ paths:
                     The userId or email address of the owner. If an email
                     address is provided, it will be used to look up the userId
                     of the matching organization member. If an ID is provided,
-                    it will be validated as existing in the organization.
+                    it will be validated as existing in the organization. Not
+                    required when authenticating with a Personal Access Token
+                    (PAT) — it will default to the user associated with the
+                    token.
                   type: string
                 projects:
                   type: array

--- a/packages/back-end/src/api/experiments/postExperiment.ts
+++ b/packages/back-end/src/api/experiments/postExperiment.ts
@@ -21,7 +21,7 @@ import { assertRegisteredAttributes } from "back-end/src/services/attributes";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { assertExperimentPrecomputedUnitDimensionIdsAreValid } from "back-end/src/services/dimensions";
 import {
-  resolveOwnerToUserId,
+  resolveOwnerForCreate,
   resolveOwnerEmail,
 } from "back-end/src/services/owner";
 import { getMetricMap } from "back-end/src/models/MetricModel";
@@ -193,9 +193,9 @@ export const postExperiment = createApiRequestHandler(postExperimentValidator)(
         throw new Error(`Invalid dashboard: ${payload.defaultDashboardId}`);
       }
     }
-    const ownerId =
-      (await resolveOwnerToUserId(ownerEmail, req.context, { strict: true })) ??
-      req.context.userId;
+    const ownerId = await resolveOwnerForCreate(ownerEmail, req.context, {
+      strict: true,
+    });
 
     // Validate that specified metrics exist and belong to the organization
     const metricGroups = await req.context.models.metricGroups.getAll();

--- a/packages/back-end/src/api/experiments/postExperiment.ts
+++ b/packages/back-end/src/api/experiments/postExperiment.ts
@@ -21,7 +21,7 @@ import { assertRegisteredAttributes } from "back-end/src/services/attributes";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { assertExperimentPrecomputedUnitDimensionIdsAreValid } from "back-end/src/services/dimensions";
 import {
-  resolveOwnerForCreate,
+  resolveOwnerToUserId,
   resolveOwnerEmail,
 } from "back-end/src/services/owner";
 import { getMetricMap } from "back-end/src/models/MetricModel";
@@ -193,9 +193,9 @@ export const postExperiment = createApiRequestHandler(postExperimentValidator)(
         throw new Error(`Invalid dashboard: ${payload.defaultDashboardId}`);
       }
     }
-    const ownerId = await resolveOwnerForCreate(ownerEmail, req.context, {
-      strict: true,
-    });
+    const ownerId =
+      (await resolveOwnerToUserId(ownerEmail, req.context, { strict: true })) ??
+      req.context.userId;
 
     // Validate that specified metrics exist and belong to the organization
     const metricGroups = await req.context.models.metricGroups.getAll();

--- a/packages/back-end/src/api/features/postFeature.ts
+++ b/packages/back-end/src/api/features/postFeature.ts
@@ -4,7 +4,7 @@ import { postFeatureValidator } from "shared/validators";
 import { FeatureInterface } from "shared/types/feature";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import {
-  resolveOwnerToUserId,
+  resolveOwnerForCreate,
   resolveOwnerEmail,
 } from "back-end/src/services/owner";
 import { createFeature, getFeature } from "back-end/src/models/FeatureModel";
@@ -103,7 +103,7 @@ export const postFeature = createApiRequestHandler(postFeatureValidator)(async (
   const feature: FeatureInterface = {
     defaultValue: req.body.defaultValue ?? "",
     valueType: req.body.valueType,
-    owner: (await resolveOwnerToUserId(req.body.owner, req.context)) ?? "",
+    owner: await resolveOwnerForCreate(req.body.owner, req.context),
     description: req.body.description || "",
     project: req.body.project || "",
     dateCreated: new Date(),

--- a/packages/back-end/src/api/features/postFeatureV2.ts
+++ b/packages/back-end/src/api/features/postFeatureV2.ts
@@ -4,7 +4,7 @@ import { FeatureInterface } from "shared/types/feature";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import {
   resolveOwnerEmail,
-  resolveOwnerToUserId,
+  resolveOwnerForCreate,
 } from "back-end/src/services/owner";
 import { createFeature, getFeature } from "back-end/src/models/FeatureModel";
 import { getExperimentMapForFeature } from "back-end/src/models/ExperimentModel";
@@ -72,7 +72,7 @@ export const postFeatureV2 = createApiRequestHandler(postFeatureV2Validator)(
     const feature: FeatureInterface = {
       defaultValue: req.body.defaultValue ?? "",
       valueType: req.body.valueType,
-      owner: (await resolveOwnerToUserId(req.body.owner, req.context)) ?? "",
+      owner: await resolveOwnerForCreate(req.body.owner, req.context),
       description: req.body.description || "",
       project: req.body.project || "",
       dateCreated: new Date(),

--- a/packages/back-end/src/api/saved-groups/postSavedGroup.ts
+++ b/packages/back-end/src/api/saved-groups/postSavedGroup.ts
@@ -1,6 +1,9 @@
 import { ID_LIST_DATATYPES, validateCondition } from "shared/util";
 import { postSavedGroupValidator } from "shared/validators";
-import { resolveOwnerEmail } from "back-end/src/services/owner";
+import {
+  resolveOwnerEmail,
+  resolveOwnerForCreate,
+} from "back-end/src/services/owner";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { validateListSize } from "back-end/src/routers/saved-group/saved-group.controller";
 import { BadRequestError } from "back-end/src/util/errors";
@@ -111,7 +114,7 @@ export const postSavedGroup = createApiRequestHandler(postSavedGroupValidator)(
       type: type,
       values: values || [],
       groupName: name,
-      owner: owner || "",
+      owner: await resolveOwnerForCreate(owner, req.context),
       condition: condition || "",
       attributeKey,
       projects,

--- a/packages/back-end/src/api/saved-groups/postSavedGroup.ts
+++ b/packages/back-end/src/api/saved-groups/postSavedGroup.ts
@@ -1,9 +1,6 @@
 import { ID_LIST_DATATYPES, validateCondition } from "shared/util";
 import { postSavedGroupValidator } from "shared/validators";
-import {
-  resolveOwnerEmail,
-  resolveOwnerForCreate,
-} from "back-end/src/services/owner";
+import { resolveOwnerEmail } from "back-end/src/services/owner";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { validateListSize } from "back-end/src/routers/saved-group/saved-group.controller";
 import { BadRequestError } from "back-end/src/util/errors";
@@ -114,7 +111,9 @@ export const postSavedGroup = createApiRequestHandler(postSavedGroupValidator)(
       type: type,
       values: values || [],
       groupName: name,
-      owner: await resolveOwnerForCreate(owner, req.context),
+      // Falls back to the authenticated user (only present for Personal Access
+      // Tokens) when no owner is provided, otherwise stays empty.
+      owner: owner || req.context.userId || "",
       condition: condition || "",
       attributeKey,
       projects,

--- a/packages/back-end/src/services/owner.ts
+++ b/packages/back-end/src/services/owner.ts
@@ -38,6 +38,29 @@ export async function resolveOwnerToUserId(
   return ownerInput;
 }
 
+/**
+ * Resolves the owner for a create request, falling back to the authenticated
+ * user when no owner is provided in the request body.
+ *
+ * The `owner` field is optional on create endpoints, but the created resource
+ * must always have an owner. When the body omits it we fall back to
+ * `context.userId`, which is only populated for Personal Access Tokens (PATs).
+ * Regular organization API keys have no associated user, so in that case the
+ * caller must provide an explicit owner — otherwise we throw.
+ */
+export async function resolveOwnerForCreate(
+  ownerInput: string | undefined,
+  context: ReqContext,
+  { strict = false }: { strict?: boolean } = {},
+): Promise<string> {
+  const resolved = await resolveOwnerToUserId(ownerInput, context, { strict });
+  if (resolved) return resolved;
+  if (context.userId) return context.userId;
+  throw new Error(
+    "Must specify an `owner` in the request body. The `owner` field is only optional when authenticating with a Personal Access Token (PAT).",
+  );
+}
+
 // In-memory userId → email cache. Safe to key by userId alone because
 // UserModel ids are globally unique (users live outside any single org).
 // Stale for up to TTL when a user changes their email — same trade-off

--- a/packages/back-end/test/services/ownerEmail.test.ts
+++ b/packages/back-end/test/services/ownerEmail.test.ts
@@ -4,6 +4,7 @@ import {
   clearOwnerEmailCache,
   resolveOwnerEmail,
   resolveOwnerEmails,
+  resolveOwnerForCreate,
 } from "back-end/src/services/owner";
 
 function makeContext(users: Partial<UserInterface>[]): ReqContext {
@@ -11,6 +12,23 @@ function makeContext(users: Partial<UserInterface>[]): ReqContext {
     users.filter((u) => u.id && ids.includes(u.id)),
   );
   return { getUsersByIds } as unknown as ReqContext;
+}
+
+function makeOwnerContext({
+  members = [],
+  userId = "",
+}: {
+  members?: Partial<UserInterface>[];
+  userId?: string;
+}): ReqContext {
+  const getUserByEmail = jest.fn(async (email: string) =>
+    members.find((m) => m.email === email),
+  );
+  return {
+    userId,
+    org: { members: members.map((m) => ({ id: m.id })) },
+    getUserByEmail,
+  } as unknown as ReqContext;
 }
 
 beforeEach(() => {
@@ -197,5 +215,52 @@ describe("resolveOwnerEmails", () => {
     const result = await resolveOwnerEmails(docs, context);
     expect(docs[0]).toEqual({ id: "x_1", owner: "u_1" });
     expect(result[0]).not.toBe(docs[0]);
+  });
+});
+
+describe("resolveOwnerForCreate", () => {
+  it("resolves an explicit u_ owner that is a valid org member", async () => {
+    const context = makeOwnerContext({
+      members: [{ id: "u_1", email: "alice@example.com" }],
+      userId: "u_2",
+    });
+    expect(await resolveOwnerForCreate("u_1", context)).toBe("u_1");
+  });
+
+  it("resolves an email owner to the matching member's userId", async () => {
+    const context = makeOwnerContext({
+      members: [{ id: "u_1", email: "alice@example.com" }],
+      userId: "",
+    });
+    expect(await resolveOwnerForCreate("alice@example.com", context)).toBe(
+      "u_1",
+    );
+  });
+
+  it("falls back to the authenticated user (PAT) when no owner is provided", async () => {
+    const context = makeOwnerContext({ members: [], userId: "u_pat" });
+    expect(await resolveOwnerForCreate(undefined, context)).toBe("u_pat");
+    expect(await resolveOwnerForCreate("", context)).toBe("u_pat");
+  });
+
+  it("throws when no owner is provided and there is no userId (org API key)", async () => {
+    const context = makeOwnerContext({ members: [], userId: "" });
+    await expect(resolveOwnerForCreate(undefined, context)).rejects.toThrow(
+      /Personal Access Token/,
+    );
+  });
+
+  it("returns an unresolvable owner unchanged in non-strict mode", async () => {
+    const context = makeOwnerContext({ members: [], userId: "" });
+    expect(await resolveOwnerForCreate("legacyname", context)).toBe(
+      "legacyname",
+    );
+  });
+
+  it("throws on an unresolvable owner email in strict mode", async () => {
+    const context = makeOwnerContext({ members: [], userId: "u_pat" });
+    await expect(
+      resolveOwnerForCreate("missing@example.com", context, { strict: true }),
+    ).rejects.toThrow(/Unable to find user/);
   });
 });

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -11,7 +11,12 @@ import {
   apiPaginationFieldsValidator,
 } from "./shared";
 import { windowTypeValidator } from "./fact-table";
-import { ownerEmailField, ownerField, ownerInputField } from "./owner-field";
+import {
+  ownerEmailField,
+  ownerField,
+  ownerInputField,
+  optionalOwnerInputField,
+} from "./owner-field";
 
 import { namedSchema } from "./openapi-helpers";
 
@@ -1082,7 +1087,7 @@ const postExperimentBody = z
       .string()
       .describe("WHERE clause to add to the default experiment query")
       .optional(),
-    owner: ownerInputField.optional(),
+    owner: optionalOwnerInputField,
     archived: z.boolean().optional(),
     status: z.enum(experimentStatus).optional(),
     autoRefresh: z.boolean().optional(),

--- a/packages/shared/src/validators/features-v2.ts
+++ b/packages/shared/src/validators/features-v2.ts
@@ -5,7 +5,7 @@ import {
   paginationQueryFields,
   skipPaginationQueryField,
 } from "./shared";
-import { ownerInputField } from "./owner-field";
+import { ownerInputField, optionalOwnerInputField } from "./owner-field";
 import {
   apiFeatureRuleValidator,
   apiRevisionPrerequisiteV2,
@@ -350,7 +350,7 @@ export const postFeatureBodyV2 = z
       ),
     archived: z.boolean().optional(),
     description: z.string().describe("Description of the feature").optional(),
-    owner: ownerInputField,
+    owner: optionalOwnerInputField,
     project: z.string().describe("An associated project ID").optional(),
     valueType: z
       .enum(["boolean", "string", "number", "json"])

--- a/packages/shared/src/validators/features.ts
+++ b/packages/shared/src/validators/features.ts
@@ -10,7 +10,12 @@ import {
   apiPaginationFieldsValidator,
 } from "./shared";
 import { safeRolloutStatusArray } from "./safe-rollout";
-import { ownerEmailField, ownerField, ownerInputField } from "./owner-field";
+import {
+  ownerEmailField,
+  ownerField,
+  ownerInputField,
+  optionalOwnerInputField,
+} from "./owner-field";
 import {
   featureRulePatch,
   lockdownConfigSchema,
@@ -1222,7 +1227,7 @@ const postFeatureBody = z
       ),
     archived: z.boolean().optional(),
     description: z.string().describe("Description of the feature").optional(),
-    owner: ownerInputField,
+    owner: optionalOwnerInputField,
     project: z.string().describe("An associated project ID").optional(),
     valueType: z
       .enum(["boolean", "string", "number", "json"])

--- a/packages/shared/src/validators/owner-field.ts
+++ b/packages/shared/src/validators/owner-field.ts
@@ -31,14 +31,13 @@ export const ownerInputField = z
   );
 
 /**
- * Optional owner input for create endpoints. The owner is not required when the
- * request is made with a Personal Access Token (PAT) — in that case it defaults
- * to the user associated with the token. When authenticating with a regular
- * organization API key (which has no associated user), an explicit owner must
- * be provided.
+ * Optional owner input for create endpoints. When omitted, the owner defaults to
+ * the user associated with the request's Personal Access Token (PAT), if one is
+ * being used. Endpoints that require an owner (e.g. create feature) will reject
+ * the request when the owner is omitted and no PAT user is available.
  */
 export const optionalOwnerInputField = ownerInputField
   .optional()
   .describe(
-    "The userId or email address of the owner. If an email address is provided, it will be used to look up the userId of the matching organization member. If an ID is provided, it will be validated as existing in the organization. Not required when authenticating with a Personal Access Token (PAT) — it will default to the user associated with the token.",
+    "The userId or email address of the owner. If an email address is provided, it will be used to look up the userId of the matching organization member. If an ID is provided, it will be validated as existing in the organization. When omitted, it defaults to the user associated with the request's Personal Access Token (PAT), if one is being used.",
   );

--- a/packages/shared/src/validators/owner-field.ts
+++ b/packages/shared/src/validators/owner-field.ts
@@ -29,3 +29,16 @@ export const ownerInputField = z
   .describe(
     "The userId or email address of the owner. If an email address is provided, it will be used to look up the userId of the matching organization member. If an ID is provided, it will be validated as existing in the organization.",
   );
+
+/**
+ * Optional owner input for create endpoints. The owner is not required when the
+ * request is made with a Personal Access Token (PAT) — in that case it defaults
+ * to the user associated with the token. When authenticating with a regular
+ * organization API key (which has no associated user), an explicit owner must
+ * be provided.
+ */
+export const optionalOwnerInputField = ownerInputField
+  .optional()
+  .describe(
+    "The userId or email address of the owner. If an email address is provided, it will be used to look up the userId of the matching organization member. If an ID is provided, it will be validated as existing in the organization. Not required when authenticating with a Personal Access Token (PAT) — it will default to the user associated with the token.",
+  );

--- a/packages/shared/src/validators/saved-group.ts
+++ b/packages/shared/src/validators/saved-group.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
-import { ownerEmailField, ownerField, ownerInputField } from "./owner-field";
+import {
+  ownerEmailField,
+  ownerField,
+  ownerInputField,
+  optionalOwnerInputField,
+} from "./owner-field";
 import { apiPaginationFieldsValidator, paginationQueryFields } from "./shared";
 
 import { namedSchema } from "./openapi-helpers";
@@ -131,7 +136,7 @@ const postSavedGroupBody = z
         "When type = 'list', this is the list of values for the attribute key",
       )
       .optional(),
-    owner: ownerInputField.optional(),
+    owner: optionalOwnerInputField,
     projects: z.array(z.string()).optional(),
     bypassApproval: z
       .boolean()


### PR DESCRIPTION
Update `postFeature`, and `postFeatureV2` to have an optional `owner` field when using a Personal Access Token (PAT).  Updated `postSavedGroup` endpoint to use the PAT to fill a missing `owner` field (it was already optional, just defaulting to `""` instead).