### PR TITLE
hotfix rule starting conditions when creating a new rule with a ramp-up

### DIFF
--- a/packages/back-end/src/services/rampSchedule.ts
+++ b/packages/back-end/src/services/rampSchedule.ts
@@ -271,10 +271,18 @@ export function remapTemplateActions(
 
 // Sparse step patches accumulate through the target step.
 export function computeEffectivePatch(
-  schedule: Pick<RampScheduleInterface, "steps" | "endActions">,
+  schedule: Pick<
+    RampScheduleInterface,
+    "steps" | "endActions" | "startActions"
+  >,
   stepIndex: number,
 ): Map<string, FeatureRulePatch> {
-  // Sparse step patches inherit absent fields from earlier steps.
+  // startActions represent the rule's initial state (targeting conditions,
+  // coverage, environments, etc.) captured at schedule creation time. They form
+  // the base layer — step patches are sparse overlays that only specify fields
+  // they change (typically just coverage). Without seeding from startActions,
+  // any field present only in startActions (e.g. condition, savedGroups) would
+  // never be applied when advancing into step 0.
   const byTarget = new Map<string, FeatureRulePatch>();
 
   const merge = (act: RampStepAction) => {
@@ -289,6 +297,10 @@ export function computeEffectivePatch(
       byTarget.set(act.targetId, { ruleId, ...fields } as FeatureRulePatch);
     }
   };
+
+  // Seed with startActions — the base-layer rule state (condition, savedGroups,
+  // coverage, etc.) that all steps inherit from unless explicitly overridden.
+  for (const a of schedule.startActions ?? []) merge(a);
 
   const lastStepIdx = Math.min(stepIndex, schedule.steps.length - 1);
   for (let i = 0; i <= lastStepIdx; i++) {

--- a/packages/back-end/test/services/rampSchedule.test.ts
+++ b/packages/back-end/test/services/rampSchedule.test.ts
@@ -627,6 +627,48 @@ describe("computeEffectivePatch", () => {
       force: "variant-b",
     });
   });
+
+  it("rollback to intermediate step still inherits startActions fields", () => {
+    const sched = {
+      ...sparseSchedule([
+        [action(TARGET_ID, { coverage: 0.3 })],
+        [action(TARGET_ID, { coverage: 0.6 })],
+        [action(TARGET_ID, { coverage: 1.0 })],
+      ]),
+      startActions: [
+        {
+          targetType: "feature-rule" as const,
+          targetId: TARGET_ID,
+          patch: {
+            ruleId: RULE_ID,
+            coverage: 0.0,
+            condition: '{"country":"US"}',
+            savedGroups: [{ ids: ["grp1"], match: "any" }],
+            prerequisites: [
+              { id: "feat_gate", condition: '{"$or":[{"value":true}]}' },
+            ],
+            allEnvironments: false,
+            environments: ["production", "staging"],
+            force: "variant-b",
+          },
+        },
+      ],
+    };
+    // Rolling back to step 1 — startActions fields persist through step 0 and 1
+    const result = computeEffectivePatch(sched, 1);
+    const patch = result.get(TARGET_ID);
+    expect(patch).toMatchObject({
+      coverage: 0.6,
+      condition: '{"country":"US"}',
+      savedGroups: [{ ids: ["grp1"], match: "any" }],
+      prerequisites: [
+        { id: "feat_gate", condition: '{"$or":[{"value":true}]}' },
+      ],
+      allEnvironments: false,
+      environments: ["production", "staging"],
+      force: "variant-b",
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/back-end/test/services/rampSchedule.test.ts
+++ b/packages/back-end/test/services/rampSchedule.test.ts
@@ -338,6 +338,8 @@ describe("getStartPatchForRule", () => {
       condition: '{"country":"US"}',
       savedGroups,
       prerequisites,
+      allEnvironments: false,
+      environments: ["production", "staging"],
     } as FeatureRule);
 
     expect(patch).toMatchObject({
@@ -345,8 +347,97 @@ describe("getStartPatchForRule", () => {
       condition: '{"country":"US"}',
       savedGroups,
       prerequisites,
+      allEnvironments: false,
+      environments: ["production", "staging"],
       enabled: false,
     });
+  });
+
+  it("captures force value (including null as a valid value)", () => {
+    const patch = getStartPatchForRule({
+      id: "r1",
+      type: "force",
+      hashAttribute: "id",
+      enabled: true,
+      value: "variant-b",
+    } as FeatureRule);
+
+    expect(patch.force).toBe("variant-b");
+
+    const nullPatch = getStartPatchForRule({
+      id: "r1",
+      type: "force",
+      hashAttribute: "id",
+      enabled: true,
+      value: null,
+    } as FeatureRule);
+
+    expect(nullPatch.force).toBeNull();
+  });
+
+  it("round-trips: capture → computeEffectivePatch → applyPatchToRule restores original rule", () => {
+    const originalRule = {
+      id: "r1",
+      type: "rollout" as const,
+      coverage: 0.75,
+      hashAttribute: "id",
+      enabled: true,
+      condition: '{"country":"US"}',
+      savedGroups: [{ match: "any" as const, ids: ["grp1"] }],
+      prerequisites: [{ id: "feat_gate", condition: '{"value":true}' }],
+      allEnvironments: false,
+      environments: ["production"],
+    } as FeatureRule;
+
+    // A. Capture into startActions
+    const startPatch = getStartPatchForRule(originalRule);
+    const startActions = [
+      {
+        targetType: "feature-rule" as const,
+        targetId: TARGET_ID,
+        patch: { ruleId: RULE_ID, ...startPatch },
+      },
+    ];
+
+    // B. Build a schedule at step 1 (ramp changed coverage to 0.5)
+    const sched = {
+      steps: [
+        {
+          interval: 300,
+          actions: [
+            {
+              targetType: "feature-rule" as const,
+              targetId: TARGET_ID,
+              patch: { ruleId: RULE_ID, coverage: 0.5 },
+            },
+          ],
+        },
+      ],
+      startActions,
+      endActions: [],
+    };
+
+    // C. computeEffectivePatch at step 0 merges startActions + step 0
+    const effective = computeEffectivePatch(sched, 0);
+    const merged = effective.get(TARGET_ID)!;
+    expect(merged.coverage).toBe(0.5); // step override
+    expect(merged.condition).toBe('{"country":"US"}'); // from startActions
+
+    // D. Apply the startActions patch directly (simulates rollbackToStep(-1))
+    const driftedRule = {
+      ...originalRule,
+      coverage: 0.5,
+      condition: "",
+    } as FeatureRule;
+    const restored = applyPatchToRule(driftedRule, startPatch);
+    expect((restored as { coverage?: number }).coverage).toBe(0.75);
+    expect(restored.condition).toBe('{"country":"US"}');
+    expect(restored.savedGroups).toEqual([{ match: "any", ids: ["grp1"] }]);
+    expect(restored.prerequisites).toEqual([
+      { id: "feat_gate", condition: '{"value":true}' },
+    ]);
+    expect(restored.allEnvironments).toBe(false);
+    expect(restored.environments).toEqual(["production"]);
   });
 });
 
@@ -499,7 +590,7 @@ describe("computeEffectivePatch", () => {
     expect(computeEffectivePatch(sched, -1).size).toBe(0);
   });
 
-  it("seeds from startActions so step 0 inherits condition/savedGroups/prerequisites", () => {
+  it("seeds from startActions so step 0 inherits the full initial rule state", () => {
     const sched = {
       ...sparseSchedule([[action(TARGET_ID, { coverage: 0.1 })]]),
       startActions: [
@@ -514,13 +605,16 @@ describe("computeEffectivePatch", () => {
             prerequisites: [
               { id: "feat_gate", condition: '{"$or":[{"value":true}]}' },
             ],
+            allEnvironments: false,
+            environments: ["production", "staging"],
+            force: "variant-b",
           },
         },
       ],
     };
     const result = computeEffectivePatch(sched, 0);
     const patch = result.get(TARGET_ID);
-    // Step 0's coverage override wins, but condition/savedGroups/prerequisites are inherited
+    // Step 0's coverage override wins; all other fields inherited from startActions
     expect(patch).toMatchObject({
       coverage: 0.1,
       condition: '{"country":"US"}',
@@ -528,6 +622,9 @@ describe("computeEffectivePatch", () => {
       prerequisites: [
         { id: "feat_gate", condition: '{"$or":[{"value":true}]}' },
       ],
+      allEnvironments: false,
+      environments: ["production", "staging"],
+      force: "variant-b",
     });
   });
 });

--- a/packages/back-end/test/services/rampSchedule.test.ts
+++ b/packages/back-end/test/services/rampSchedule.test.ts
@@ -499,7 +499,7 @@ describe("computeEffectivePatch", () => {
     expect(computeEffectivePatch(sched, -1).size).toBe(0);
   });
 
-  it("seeds from startActions so step 0 inherits condition/savedGroups", () => {
+  it("seeds from startActions so step 0 inherits condition/savedGroups/prerequisites", () => {
     const sched = {
       ...sparseSchedule([[action(TARGET_ID, { coverage: 0.1 })]]),
       startActions: [
@@ -511,17 +511,23 @@ describe("computeEffectivePatch", () => {
             coverage: 0.0,
             condition: '{"country":"US"}',
             savedGroups: [{ ids: ["grp1"], match: "any" }],
+            prerequisites: [
+              { id: "feat_gate", condition: '{"$or":[{"value":true}]}' },
+            ],
           },
         },
       ],
     };
     const result = computeEffectivePatch(sched, 0);
     const patch = result.get(TARGET_ID);
-    // Step 0's coverage override wins, but condition/savedGroups are inherited
+    // Step 0's coverage override wins, but condition/savedGroups/prerequisites are inherited
     expect(patch).toMatchObject({
       coverage: 0.1,
       condition: '{"country":"US"}',
       savedGroups: [{ ids: ["grp1"], match: "any" }],
+      prerequisites: [
+        { id: "feat_gate", condition: '{"$or":[{"value":true}]}' },
+      ],
     });
   });
 });

--- a/packages/back-end/test/services/rampSchedule.test.ts
+++ b/packages/back-end/test/services/rampSchedule.test.ts
@@ -498,6 +498,32 @@ describe("computeEffectivePatch", () => {
     const sched = sparseSchedule([]);
     expect(computeEffectivePatch(sched, -1).size).toBe(0);
   });
+
+  it("seeds from startActions so step 0 inherits condition/savedGroups", () => {
+    const sched = {
+      ...sparseSchedule([[action(TARGET_ID, { coverage: 0.1 })]]),
+      startActions: [
+        {
+          targetType: "feature-rule" as const,
+          targetId: TARGET_ID,
+          patch: {
+            ruleId: RULE_ID,
+            coverage: 0.0,
+            condition: '{"country":"US"}',
+            savedGroups: [{ ids: ["grp1"], match: "any" }],
+          },
+        },
+      ],
+    };
+    const result = computeEffectivePatch(sched, 0);
+    const patch = result.get(TARGET_ID);
+    // Step 0's coverage override wins, but condition/savedGroups are inherited
+    expect(patch).toMatchObject({
+      coverage: 0.1,
+      condition: '{"country":"US"}',
+      savedGroups: [{ ids: ["grp1"], match: "any" }],
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -415,6 +415,8 @@ export default function RuleModal({
         ruleRampSchedule?.startActions ??
         pendingCreateActionTyped?.startActions;
       if (!startActions?.length) return {};
+      // Safe to use .find() (first match): per-env entries always share the
+      // same targeting fields — only coverage differs across targets.
       const patch = startActions.find(
         (a) => a.targetType === "feature-rule",
       )?.patch;

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -398,6 +398,39 @@ export default function RuleModal({
           seed: "",
         }
       : {}),
+    // Backward-compat: rules saved before the stripping logic was removed may
+    // have empty targeting on the rule with the real values in startActions.
+    // For pre-start/terminal states, restore from startActions if the rule's
+    // own fields are empty. For running/paused, the rule's live values are
+    // managed by the engine and are always correct.
+    ...(() => {
+      const isPreStartOrTerminal =
+        ruleRampSchedule == null ||
+        ["pending", "ready", "rolled-back", "completed"].includes(
+          ruleRampSchedule.status,
+        );
+      if (!isPreStartOrTerminal && !pendingCreateActionTyped) return {};
+
+      const startActions =
+        ruleRampSchedule?.startActions ??
+        pendingCreateActionTyped?.startActions;
+      if (!startActions?.length) return {};
+      const patch = startActions.find(
+        (a) => a.targetType === "feature-rule",
+      )?.patch;
+      if (!patch) return {};
+      const restored: Record<string, unknown> = {};
+      if (patch.condition != null && !rule?.condition) {
+        restored.condition = patch.condition;
+      }
+      if (patch.savedGroups != null && !rule?.savedGroups?.length) {
+        restored.savedGroups = patch.savedGroups;
+      }
+      if (patch.prerequisites != null && !rule?.prerequisites?.length) {
+        restored.prerequisites = patch.prerequisites;
+      }
+      return restored;
+    })(),
   };
 
   // Overview Page
@@ -1379,22 +1412,15 @@ export default function RuleModal({
             values.enabled = true;
           }
 
-          // For real ramps that have not started yet, targeting widgets edit the
-          // ramp's start conditions instead of the immediately served rule.
-          if (
-            rampScheduleInline &&
-            "steps" in rampScheduleInline &&
-            rampScheduleInline.steps &&
-            rampScheduleInline.steps.length > 0 &&
-            (values.type === "rollout" || values.type === "force")
-          ) {
-            values = {
-              ...values,
-              condition: "",
-              savedGroups: [],
-              prerequisites: [],
-            };
-          }
+          // Targeting fields (condition, savedGroups, prerequisites) are always
+          // written directly to the rule — they must be live immediately. For
+          // pre-start ramps (pending/ready), they're ALSO captured into
+          // startActions by buildRampStartActionsFromRule above, so the ramp
+          // knows the initial state for rollback purposes. We no longer strip
+          // these fields from the rule: the ramp engine overlays them via
+          // computeEffectivePatch (which seeds from startActions) when it
+          // advances, but the rule must have them set immediately for the period
+          // between publish and ramp-start (or if the ramp never starts).
 
           // Future-dated schedule → publish the rule as disabled so it
           // remains hidden until the schedule activates.
@@ -1495,23 +1521,10 @@ export default function RuleModal({
           values = { ...values, enabled: false };
         }
 
-        // Ramp-up steps own targeting over time; clear rule-level targeting so
-        // they don't conflict. Standard schedules (no steps) don't control
-        // targeting, so preserve user-set values.
-        if (
-          rampScheduleInline &&
-          "steps" in rampScheduleInline &&
-          rampScheduleInline.steps &&
-          rampScheduleInline.steps.length > 0 &&
-          (values.type === "rollout" || values.type === "force")
-        ) {
-          values = {
-            ...values,
-            condition: "",
-            savedGroups: [],
-            prerequisites: [],
-          };
-        }
+        // Targeting is always written directly to the rule so it's live
+        // immediately. For pre-start ramps, buildRampStartActionsFromRule
+        // (above) also captures it into startActions for rollback purposes.
+        // We no longer strip condition/savedGroups/prerequisites from the rule.
 
         res = await apiCall<{ version: number }>(
           `/feature/${feature.id}/${targetVersion}/rule`,


### PR DESCRIPTION
Hotfix: For new rules with ramp-up schedules, apply rule targeting to rule immediately (in draft) and save it as the ramp's startCondition. We were previously only saving it to startCondition and then fast-forwarding past it on ramp start.