### PR TITLE
Enable fact table optimization for managed warehouse

### DIFF
--- a/packages/back-end/src/services/experimentQueries/experimentQueries.ts
+++ b/packages/back-end/src/services/experimentQueries/experimentQueries.ts
@@ -13,6 +13,7 @@ import { MetricInterface } from "shared/types/metric";
 import { ExperimentSnapshotSettings } from "shared/types/experiment-snapshot";
 import { OrganizationInterface } from "shared/types/organization";
 import cloneDeep from "lodash/cloneDeep";
+import { isManagedWarehouse } from "shared/util";
 import { SourceIntegrationInterface } from "back-end/src/types/Integration";
 import { orgHasPremiumFeature } from "back-end/src/enterprise";
 import { applyMetricOverrides } from "back-end/src/util/integration";
@@ -270,20 +271,19 @@ export function getFactMetricGroups(
     legacyMetricSingles: legacyMetrics,
   };
 
-  // Combining metrics in a single query is an Enterprise-only feature
-  if (!orgHasPremiumFeature(organization, "multi-metric-queries")) {
+  // Combining metrics in a single query is normally an Enterprise feature, but
+  // we also enable it for the Managed Warehouse since GrowthBook owns the
+  // compute and wants to run every optimization it can.
+  if (
+    !isManagedWarehouse(integration.datasource) &&
+    !orgHasPremiumFeature(organization, "multi-metric-queries")
+  ) {
     return defaultReturn;
   }
 
   // Metrics might have different conversion windows which makes the query complicated
   // TODO(sql): join together metrics with the same date windows for some added efficiency
   if (settings.skipPartialData) {
-    return defaultReturn;
-  }
-
-  // Org-level setting (in case the multi-metric query introduces bugs)
-  // TODO(sql): deprecate this setting and hide it for orgs that have not set it
-  if (organization.settings?.disableMultiMetricQueries) {
     return defaultReturn;
   }
 

--- a/packages/front-end/components/GeneralSettings/ExperimentSettings/index.tsx
+++ b/packages/front-end/components/GeneralSettings/ExperimentSettings/index.tsx
@@ -164,65 +164,6 @@ export default function ExperimentSettings({
               </Box>
             </Box>
 
-            {/* Fact table optimization */}
-            <Box mb="6">
-              <Flex align="start" justify="start" gap="3">
-                <Box>
-                  <Checkbox
-                    disabled={!hasCommercialFeature("multi-metric-queries")}
-                    value={
-                      hasCommercialFeature("multi-metric-queries") &&
-                      !form.watch("disableMultiMetricQueries")
-                    }
-                    setValue={(v) =>
-                      form.setValue("disableMultiMetricQueries", !v)
-                    }
-                    id="toggle-factoptimization"
-                    mt="1"
-                  />
-                </Box>
-                <Flex direction="column" justify="start">
-                  <Box>
-                    <label
-                      htmlFor="toggle-factTableQueryOptimization"
-                      className="mb-2"
-                    >
-                      <PremiumTooltip
-                        commercialFeature="multi-metric-queries"
-                        body={
-                          <>
-                            <p>
-                              If multiple metrics from the same Fact Table are
-                              added to an experiment, this will combine them
-                              into a single query, which is much faster and more
-                              efficient.
-                            </p>
-                            <p>
-                              For data sources with usage-based billing like
-                              BigQuery or SnowFlake, this can result in
-                              substantial cost savings.
-                            </p>
-                          </>
-                        }
-                      >
-                        <Text size="3" className="font-weight-semibold">
-                          Fact Table Query Optimization
-                        </Text>{" "}
-                        <GBInfo />
-                      </PremiumTooltip>
-                    </label>
-                  </Box>
-                  <Box>
-                    <Text>
-                      Combine multiple metrics from the same Fact Table into a
-                      single query to reduce fees on usage-based data sources,
-                      like BigQuery or Snowflake.
-                    </Text>
-                  </Box>
-                </Flex>
-              </Flex>
-            </Box>
-
             {/* Pre-computed dimension breakdowns */}
             <Box mb="6">
               <Flex align="start" justify="start" gap="3">

--- a/packages/front-end/components/Queries/ExpandableQuery.tsx
+++ b/packages/front-end/components/Queries/ExpandableQuery.tsx
@@ -15,8 +15,7 @@ import Code from "@/components/SyntaxHighlighting/Code";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import Callout from "@/ui/Callout";
 import HelperText from "@/ui/HelperText";
-import { useUser } from "@/services/UserContext";
-import QueryStatsRow from "./QueryStatsRow";
+import QueryStatsRow, { getNumberOfMetricsInQuery } from "./QueryStatsRow";
 import QueryResultTable from "./QueryResultTable";
 
 const ExpandableQuery: FC<{
@@ -33,9 +32,6 @@ const ExpandableQuery: FC<{
   }
 
   const { getFactMetricById } = useDefinitions();
-
-  const { hasCommercialFeature } = useUser();
-  const hasOptimizedQueries = hasCommercialFeature("multi-metric-queries");
 
   const getResultCell = useCallback(
     (value: unknown): { content: ReactNode; text: string } => {
@@ -73,6 +69,13 @@ const ExpandableQuery: FC<{
     [getResultCell],
   );
 
+  // A fact-metric query is only "optimized" when it actually combines more than
+  // one metric. Single-metric queries share the same query type/builder but
+  // weren't combined, so don't surface the badge for them.
+  const isCombinedMetricQuery =
+    query.queryType === "experimentMultiMetric" &&
+    getNumberOfMetricsInQuery(query) > 1;
+
   return (
     <div className="mb-4">
       <h4 className="d-flex align-items-top">
@@ -93,7 +96,7 @@ const ExpandableQuery: FC<{
           {title && " - "}
           Query {i + 1} of {total}
         </span>
-        {query.queryType === "experimentMultiMetric" && hasOptimizedQueries && (
+        {isCombinedMetricQuery && (
           <div className="ml-auto">
             <Tooltip
               body={

--- a/packages/front-end/components/Queries/QueryStatsRow.tsx
+++ b/packages/front-end/components/Queries/QueryStatsRow.tsx
@@ -1,12 +1,14 @@
 import { QueryInterface, QueryStatistics } from "shared/types/query";
 import { ReactElement } from "react";
+import { isManagedWarehouse } from "shared/util";
 import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
 import { GBInfo } from "@/components/Icons";
 import { useUser } from "@/services/UserContext";
+import { useDefinitions } from "@/services/DefinitionsContext";
 
 const numberFormatter = Intl.NumberFormat();
 
-function getNumberOfMetricsInQuery(q: QueryInterface) {
+export function getNumberOfMetricsInQuery(q: QueryInterface) {
   if (q.queryType === "experimentMetric") return 1;
   if (q.queryType === "experimentMultiMetric") {
     return (
@@ -26,7 +28,12 @@ export default function QueryStatsRow({
   showPipelineMode?: boolean;
 }) {
   const { hasCommercialFeature } = useUser();
-  const hasOptimizedQueries = hasCommercialFeature("multi-metric-queries");
+  const { datasources } = useDefinitions();
+  // Fact table optimization is an Enterprise feature, but the Managed Warehouse
+  // gets it for free since GrowthBook owns the compute.
+  const hasOptimizedQueries =
+    hasCommercialFeature("multi-metric-queries") ||
+    datasources.some((d) => isManagedWarehouse(d));
 
   const queryStats: QueryStatistics[] = queries
     .map((q) => q.statistics)
@@ -40,12 +47,14 @@ export default function QueryStatsRow({
     return false;
   });
 
-  const factTableOptimizedMetrics = !hasOptimizedQueries
-    ? 0
-    : queries
-        .filter((q) => q.queryType === "experimentMultiMetric")
-        .map((q) => getNumberOfMetricsInQuery(q))
-        .reduce((sum, n) => sum + n, 0);
+  // A fact-metric query is only "optimized" when it actually combines more than
+  // one metric. Single-metric queries share the same query type/builder but
+  // weren't combined, so exclude them from the optimized count.
+  const factTableOptimizedMetrics = queries
+    .filter((q) => q.queryType === "experimentMultiMetric")
+    .map((q) => getNumberOfMetricsInQuery(q))
+    .filter((n) => n > 1)
+    .reduce((sum, n) => sum + n, 0);
 
   const totalMetrics = queries
     .map((q) => getNumberOfMetricsInQuery(q))
@@ -89,7 +98,9 @@ export default function QueryStatsRow({
               </div>
             </>
           }
-          commercialFeature="multi-metric-queries"
+          commercialFeature={
+            hasOptimizedQueries ? undefined : "multi-metric-queries"
+          }
         >
           <div className="col-auto mb-2">
             <span className="uppercase-title">

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -167,7 +167,6 @@ const GeneralSettingsPage = (): React.ReactElement => {
       restApiBypassesReviews: settings.restApiBypassesReviews ?? false,
       defaultDataSource: settings.defaultDataSource || "",
       testQueryDays: DEFAULT_TEST_QUERY_DAYS,
-      disableMultiMetricQueries: false,
       disablePrecomputedDimensions:
         settings.disablePrecomputedDimensions ?? true,
       useStickyBucketing: false,

--- a/packages/shared/src/util/managedWarehouse.ts
+++ b/packages/shared/src/util/managedWarehouse.ts
@@ -58,13 +58,24 @@ export function formatQueryExecutionErrorForApi(e: unknown): string {
 }
 
 /**
+ * Managed Warehouse is backed by the growthbook_clickhouse datasource type.
+ * Because GrowthBook owns the warehouse compute, we enable query optimizations
+ * (e.g. multi-metric queries) for it even on non-enterprise plans.
+ */
+export function isManagedWarehouse(
+  datasource: Pick<DataSourceInterface, "type">,
+): boolean {
+  return datasource.type === "growthbook_clickhouse";
+}
+
+/**
  * Managed Warehouse rows created before provisioning was deferred will not
  * have this flag; treat them as provisioned.
  */
 export function isManagedWarehouseAwaitingProvisioning(
   datasource: Pick<DataSourceInterface, "type" | "settings">,
 ): boolean {
-  if (datasource.type !== "growthbook_clickhouse") {
+  if (!isManagedWarehouse(datasource)) {
     return false;
   }
   const settings = datasource.settings as {

--- a/packages/shared/test/util/managedWarehouse.test.ts
+++ b/packages/shared/test/util/managedWarehouse.test.ts
@@ -1,10 +1,23 @@
 import {
+  isManagedWarehouse,
   isManagedWarehouseNoEventsGuidanceMessage,
   isManagedWarehousePendingQueryError,
   MANAGED_WAREHOUSE_NO_EVENTS_MESSAGE,
   MANAGED_WAREHOUSE_PENDING_ERROR_CODE,
   MANAGED_WAREHOUSE_SENDING_EVENTS_DOC_URL,
 } from "../../src/util/managedWarehouse";
+
+describe("isManagedWarehouse", () => {
+  it("is true only for the growthbook_clickhouse datasource type", () => {
+    expect(isManagedWarehouse({ type: "growthbook_clickhouse" })).toBe(true);
+  });
+
+  it("is false for self-hosted ClickHouse and other warehouses", () => {
+    expect(isManagedWarehouse({ type: "clickhouse" })).toBe(false);
+    expect(isManagedWarehouse({ type: "bigquery" })).toBe(false);
+    expect(isManagedWarehouse({ type: "snowflake" })).toBe(false);
+  });
+});
 
 describe("isManagedWarehousePendingQueryError", () => {
   it("matches the bare error code", () => {

--- a/packages/shared/types/organization.d.ts
+++ b/packages/shared/types/organization.d.ts
@@ -260,7 +260,6 @@ export interface OrganizationSettings {
   restApiBypassesReviews?: boolean;
   defaultDataSource?: string;
   testQueryDays?: number;
-  disableMultiMetricQueries?: boolean;
   disablePrecomputedDimensions?: boolean;
   useStickyBucketing?: boolean;
   useFallbackAttributes?: boolean;


### PR DESCRIPTION
### Features and Changes

- Always enable fact table optimization for Managed Warehouse data sources, even for non-enterprise orgs
- Remove the setting to disable fact table optimization completely - it was originally built as a failsafe in case we broke something with the initial implementation. It is now fully battle tested and safe to enable for everyone.
- Fix the front-end `Optimized` badge to only show for queries that actually include 2+ metrics in them.  Currently, it also shows when there's only 1 metric included when the query isn't really "optimized".