### PR TITLE
fix(api): respect explicit regressionAdjustmentSettings.enabled=false on fact-metric create

### DIFF
--- a/packages/back-end/src/api/fact-metrics/postFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/postFactMetric.ts
@@ -164,10 +164,8 @@ export async function getCreateMetricPropsFromBody(
 
   if (regressionAdjustmentSettings?.override) {
     data.regressionAdjustmentOverride = true;
-    if (regressionAdjustmentSettings.enabled) {
-      data.regressionAdjustmentEnabled = true;
-    }
-    if (regressionAdjustmentSettings.days) {
+    data.regressionAdjustmentEnabled = !!regressionAdjustmentSettings.enabled;
+    if (regressionAdjustmentSettings.days != null) {
       data.regressionAdjustmentDays = regressionAdjustmentSettings.days;
     }
   }

--- a/packages/back-end/src/api/fact-metrics/updateFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/updateFactMetric.ts
@@ -125,7 +125,7 @@ export async function getUpdateFactMetricPropsFromBody(
     if (regressionAdjustmentSettings.override) {
       updates.regressionAdjustmentEnabled =
         !!regressionAdjustmentSettings.enabled;
-      if (regressionAdjustmentSettings.days) {
+      if (regressionAdjustmentSettings.days != null) {
         updates.regressionAdjustmentDays = regressionAdjustmentSettings.days;
       }
     }


### PR DESCRIPTION
## Problem

`getCreateMetricPropsFromBody` (used by `POST /api/v1/fact-metrics` and the **create** path of `POST /api/v1/bulk-import/facts`) applies the request's `regressionAdjustmentSettings` with a truthiness guard:

```ts
if (regressionAdjustmentSettings.enabled) {
  data.regressionAdjustmentEnabled = true;
}
```

When the caller sends `{ override: true, enabled: false }`, the condition is falsy and the assignment is skipped, so `regressionAdjustmentEnabled` stays at the org-default value set a few lines earlier (`!!scopedSettings.regressionAdjustmentEnabled`). For orgs with regression adjustment enabled by default, an explicit `enabled: false` is silently coerced to `true`.

The same pattern drops `days: 0`.

## Fix

Align with the already-correct logic in `updateFactMetric.ts` (`getUpdateFactMetricPropsFromBody`):

```ts
data.regressionAdjustmentEnabled = !!regressionAdjustmentSettings.enabled;
if (regressionAdjustmentSettings.days != null) {
  data.regressionAdjustmentDays = regressionAdjustmentSettings.days;
}
```

## Impact

- `POST /api/v1/fact-metrics` now honors `regressionAdjustmentSettings.enabled: false`.
- `POST /api/v1/bulk-import/facts` (create path) no longer requires a follow-up per-metric `PUT` to disable RA on newly-created metrics.