### PR TITLE
Updates SSO flow to respect autoApprove toggle

### DIFF
--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -1189,6 +1189,18 @@ export async function addMemberFromSSOConnection(
   }
   if (!organization) return null;
 
+  // If the org doesn't have autoApproveMembers enabled, add the user as a pending member
+  if (!organization.autoApproveMembers) {
+    await addPendingMemberToOrg({
+      organization,
+      name: req.name || "",
+      email: req.email || "",
+      userId: req.userId,
+      ...getDefaultRole(organization),
+    });
+    return null;
+  }
+
   await addMemberToOrg({
     organization,
     userId: req.userId,

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -90,7 +90,12 @@ import {
   mergeParams,
 } from "./datasource";
 import { createMetric } from "./experiments";
-import { isEmailEnabled, sendInviteEmail, sendNewMemberEmail } from "./email";
+import {
+  isEmailEnabled,
+  sendInviteEmail,
+  sendNewMemberEmail,
+  sendPendingMemberEmail,
+} from "./email";
 import { ReqContextClass } from "./context";
 
 export {
@@ -1198,6 +1203,18 @@ export async function addMemberFromSSOConnection(
       userId: req.userId,
       ...getDefaultRole(organization),
     });
+    try {
+      const teamUrl = APP_ORIGIN + "/settings/team/?org=" + organization.id;
+      await sendPendingMemberEmail(
+        req.name || "",
+        req.email || "",
+        organization.name,
+        organization.ownerEmail,
+        teamUrl,
+      );
+    } catch (e) {
+      req.log.error(e, "Failed to send pending member email");
+    }
     return null;
   }
 

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -1196,24 +1196,29 @@ export async function addMemberFromSSOConnection(
 
   // If the org has explicitly disabled autoApproveMembers, add the user as a pending member
   if (organization.autoApproveMembers === false) {
-    await addPendingMemberToOrg({
-      organization,
-      name: req.name || "",
-      email: req.email || "",
-      userId: req.userId,
-      ...getDefaultRole(organization),
-    });
-    try {
-      const teamUrl = APP_ORIGIN + "/settings/team/?org=" + organization.id;
-      await sendPendingMemberEmail(
-        req.name || "",
-        req.email || "",
-        organization.name,
-        organization.ownerEmail,
-        teamUrl,
-      );
-    } catch (e) {
-      req.log.error(e, "Failed to send pending member email");
+    const alreadyPending = organization.pendingMembers?.some(
+      (m) => m.id === req.userId,
+    );
+    if (!alreadyPending) {
+      await addPendingMemberToOrg({
+        organization,
+        name: req.name || "",
+        email: req.email || "",
+        userId: req.userId,
+        ...getDefaultRole(organization),
+      });
+      try {
+        const teamUrl = APP_ORIGIN + "/settings/team/?org=" + organization.id;
+        await sendPendingMemberEmail(
+          req.name || "",
+          req.email || "",
+          organization.name,
+          organization.ownerEmail,
+          teamUrl,
+        );
+      } catch (e) {
+        req.log.error(e, "Failed to send pending member email");
+      }
     }
     return null;
   }

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -1195,6 +1195,7 @@ export async function addMemberFromSSOConnection(
   if (!organization) return null;
 
   // If the org has explicitly disabled autoApproveMembers, add the user as a pending member
+  // This differs from the non-SSO path (`undefined` is auto-approved there) to preserve existing behavior
   if (organization.autoApproveMembers === false) {
     const alreadyPending = organization.pendingMembers?.some(
       (m) => m.id === req.userId,

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -1189,8 +1189,8 @@ export async function addMemberFromSSOConnection(
   }
   if (!organization) return null;
 
-  // If the org doesn't have autoApproveMembers enabled, add the user as a pending member
-  if (!organization.autoApproveMembers) {
+  // If the org has explicitly disabled autoApproveMembers, add the user as a pending member
+  if (organization.autoApproveMembers === false) {
     await addPendingMemberToOrg({
       organization,
       name: req.name || "",


### PR DESCRIPTION
### Features and Changes

Previously, `addMemberFromSSOConnection` unconditionally added SSO users as full members, ignoring the organization's `autoApproveMembers` setting. This meant orgs that required manual member approval had no way to enforce that gate for SSO-authenticated users.

This change makes SSO respect the `autoApproveMembers` flag:

- If `autoApproveMembers === false` (explicitly disabled), the SSO user is added to the pending queue instead of as a full member, and the org owner receives a `sendPendingMemberEmail` notification with a link to the team settings page to review the request.
- Orgs that have never set the flag (`undefined`) continue to auto-approve, preserving the existing behavior.

- Closes **(add link to issue here)**

### Dependencies

None

### Testing

- [ ] On an org with `autoApproveMembers` **explicitly set to `false`**: log in via SSO as a new user — confirm they are added as a **pending** member and that the org owner receives a pending member notification email
- [ ] On an org with `autoApproveMembers` **unset (`undefined`)**: log in via SSO as a new user — confirm they are added as a full member immediately (no regression)
- [ ] On an org with `autoApproveMembers` **set to `true`**: log in via SSO as a new user — confirm they are added as a full member immediately
- [ ] Approve a pending SSO member and confirm they gain normal access

### Screenshots

<!-- No UI changes -->