### PR TITLE
fix(back-end): register OTel observable gauge callback once

### DIFF
--- a/packages/back-end/src/tracing.opentelemetry.ts
+++ b/packages/back-end/src/tracing.opentelemetry.ts
@@ -90,10 +90,9 @@ const attributeKey = (attributes?: Attributes) => {
   if (!attributes) {
     return "";
   }
-  return Object.entries(attributes)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([k, v]) => `${k}=${v}`)
-    .join(",");
+  return JSON.stringify(
+    Object.entries(attributes).sort(([a], [b]) => a.localeCompare(b)),
+  );
 };
 
 const gaugeByName = new Map<
@@ -108,6 +107,7 @@ const getGauge = (name: string) => {
   }
 
   const gauge = otlMetrics.getMeter(name).createObservableGauge(name);
+  // Entries stay until removed via remove(); stale label combos are not dropped on their own.
   const series = new Map<string, { value: number; attributes?: Attributes }>();
   gauge.addCallback((observableResult) => {
     for (const { value, attributes } of series.values()) {
@@ -118,6 +118,9 @@ const getGauge = (name: string) => {
   const wrapper = {
     record: (value: number, attributes?: Attributes) => {
       series.set(attributeKey(attributes), { value, attributes });
+    },
+    remove: (attributes?: Attributes) => {
+      series.delete(attributeKey(attributes));
     },
   };
   gaugeByName.set(name, wrapper);

--- a/packages/back-end/src/tracing.opentelemetry.ts
+++ b/packages/back-end/src/tracing.opentelemetry.ts
@@ -88,12 +88,18 @@ const getCounter = (name: string) => {
 
 const getGauge = (name: string) => {
   const gauge = otlMetrics.getMeter(name).createObservableGauge(name);
+  // One callback per gauge; record() only updates latest. Multiple attribute sets
+  // overwrite each other. That beats unbounded callback accumulation on every record().
+  let latest: { value: number; attributes?: Attributes } | null = null;
+  gauge.addCallback((observableResult) => {
+    if (latest) {
+      observableResult.observe(latest.value, latest.attributes);
+    }
+  });
 
   return {
     record: (value: number, attributes?: Attributes) => {
-      gauge.addCallback((observableResult) => {
-        observableResult.observe(value, attributes);
-      });
+      latest = { value, attributes };
     },
   };
 };

--- a/packages/back-end/src/tracing.opentelemetry.ts
+++ b/packages/back-end/src/tracing.opentelemetry.ts
@@ -86,22 +86,42 @@ const getCounter = (name: string) => {
   };
 };
 
+const attributeKey = (attributes?: Attributes) => {
+  if (!attributes) {
+    return "";
+  }
+  return Object.entries(attributes)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}=${v}`)
+    .join(",");
+};
+
+const gaugeByName = new Map<
+  string,
+  { record: (value: number, attributes?: Attributes) => void }
+>();
+
 const getGauge = (name: string) => {
+  const existing = gaugeByName.get(name);
+  if (existing) {
+    return existing;
+  }
+
   const gauge = otlMetrics.getMeter(name).createObservableGauge(name);
-  // One callback per gauge; record() only updates latest. Multiple attribute sets
-  // overwrite each other. That beats unbounded callback accumulation on every record().
-  let latest: { value: number; attributes?: Attributes } | null = null;
+  const series = new Map<string, { value: number; attributes?: Attributes }>();
   gauge.addCallback((observableResult) => {
-    if (latest) {
-      observableResult.observe(latest.value, latest.attributes);
+    for (const { value, attributes } of series.values()) {
+      observableResult.observe(value, attributes);
     }
   });
 
-  return {
+  const wrapper = {
     record: (value: number, attributes?: Attributes) => {
-      latest = { value, attributes };
+      series.set(attributeKey(attributes), { value, attributes });
     },
   };
+  gaugeByName.set(name, wrapper);
+  return wrapper;
 };
 
 setMetrics({

--- a/packages/back-end/src/util/metrics.ts
+++ b/packages/back-end/src/util/metrics.ts
@@ -29,6 +29,7 @@ export const metrics: Metrics = {
   }),
   getGauge: (_: string) => ({
     record: () => undefined,
+    remove: () => undefined,
   }),
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a memory leak in OpenTelemetry observable gauge recording. `getGauge()` previously called `addCallback` on every `record()`, so callbacks accumulated without bound and stale values were re-exported each scrape interval.

## Change

Register one callback when the gauge is created and cache the gauge wrapper by name so repeated `getGauge(name)` calls share the same instrument.

`record()` upserts into a per-gauge series map keyed by attributes. On export, the callback observes every stored series. This matches Datadog gauge semantics (each distinct label set is its own time series) without unbounded callback accumulation.

## Verification

- `pnpm --filter back-end type-check`
- ESLint on `tracing.opentelemetry.ts`
- Code review: exactly one `addCallback` per gauge name

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f055ce4-de61-420c-add8-5ed9cc25fcfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f055ce4-de61-420c-add8-5ed9cc25fcfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>