### PR TITLE
fix: keep create CTAs enabled when sample-data is the only project

### DIFF
--- a/packages/front-end/pages/features/index.tsx
+++ b/packages/front-end/pages/features/index.tsx
@@ -613,19 +613,21 @@ export default function FeaturesPage() {
     if (project) {
       return permissionsUtil.canManageFeatureDrafts({ project });
     }
-    if (projects?.length) {
-      // If "All Projects" is selected, check if user has permissions for at least one project
-
-      return projects.some(
-        (p) =>
-          permissionsUtil.canCreateFeature({ project: p.id }) &&
-          permissionsUtil.canManageFeatureDrafts({ project: p.id }),
-      );
-    }
-    // No projects - fall back to global permission check (e.g. admin in new org)
-    return (
+    // "All Projects" selected. Check the global (no-project) permission first so
+    // a user who can create features at the org level (e.g. an admin) isn't
+    // blocked by a non-creatable project. Otherwise the read-only sample-data
+    // project would disable the button whenever it's the only project.
+    if (
       permissionsUtil.canCreateFeature({ project: "" }) &&
       permissionsUtil.canManageFeatureDrafts({ project: "" })
+    ) {
+      return true;
+    }
+    // Otherwise, allow if they can create in at least one specific project.
+    return (projects ?? []).some(
+      (p) =>
+        permissionsUtil.canCreateFeature({ project: p.id }) &&
+        permissionsUtil.canManageFeatureDrafts({ project: p.id }),
     );
   }, [project, projects, permissionsUtil]);
 

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -488,7 +488,10 @@ export class Permissions {
       // read-only sample-data project) can't gate the CTA when it's the only
       // project.
       return (
-        this.checkProjectFilterPermission({ projects: [] }, "manageTemplates") ||
+        this.checkProjectFilterPermission(
+          { projects: [] },
+          "manageTemplates",
+        ) ||
         allProjects.some((p) =>
           this.checkProjectFilterPermission(
             { projects: [p.id] },

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -314,11 +314,18 @@ export class Permissions {
     allProjects?: { id: string }[],
   ): boolean => {
     if (!project && allProjects?.length) {
-      return allProjects.some((p) =>
-        this.checkProjectFilterPermission(
-          { projects: [p.id] },
-          "manageFeatures",
-        ),
+      // Allow if the user has the permission with no project (e.g. a global
+      // admin). Checking that first means a non-creatable project (like the
+      // read-only sample-data project) can't gate the CTA when it's the only
+      // project.
+      return (
+        this.checkProjectFilterPermission({ projects: [] }, "manageFeatures") ||
+        allProjects.some((p) =>
+          this.checkProjectFilterPermission(
+            { projects: [p.id] },
+            "manageFeatures",
+          ),
+        )
       );
     }
     return this.checkProjectFilterPermission(
@@ -368,11 +375,18 @@ export class Permissions {
     allProjects?: { id: string }[],
   ): boolean => {
     if (!project && allProjects?.length) {
-      return allProjects.some((p) =>
-        this.checkProjectFilterPermission(
-          { projects: [p.id] },
-          "createAnalyses",
-        ),
+      // Allow if the user has the permission with no project (e.g. a global
+      // admin). Checking that first means a non-creatable project (like the
+      // read-only sample-data project) can't gate the CTA when it's the only
+      // project.
+      return (
+        this.checkProjectFilterPermission({ projects: [] }, "createAnalyses") ||
+        allProjects.some((p) =>
+          this.checkProjectFilterPermission(
+            { projects: [p.id] },
+            "createAnalyses",
+          ),
+        )
       );
     }
     return this.checkProjectFilterPermission(
@@ -469,11 +483,18 @@ export class Permissions {
     allProjects?: { id: string }[],
   ): boolean => {
     if (!project && allProjects?.length) {
-      return allProjects.some((p) =>
-        this.checkProjectFilterPermission(
-          { projects: [p.id] },
-          "manageTemplates",
-        ),
+      // Allow if the user has the permission with no project (e.g. a global
+      // admin). Checking that first means a non-creatable project (like the
+      // read-only sample-data project) can't gate the CTA when it's the only
+      // project.
+      return (
+        this.checkProjectFilterPermission({ projects: [] }, "manageTemplates") ||
+        allProjects.some((p) =>
+          this.checkProjectFilterPermission(
+            { projects: [p.id] },
+            "manageTemplates",
+          ),
+        )
       );
     }
     return this.checkProjectFilterPermission(

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -420,8 +420,13 @@ export class Permissions {
     allProjects?: { id: string }[],
   ): boolean => {
     if (!project && allProjects?.length) {
-      return allProjects.some((p) =>
-        this.canCreateHoldout({ projects: [p.id] }),
+      // Allow if the user can create a holdout with no project (e.g. a global
+      // admin). Checking that first means a non-creatable project (like the
+      // read-only sample-data project) can't gate the CTA when it's the only
+      // project.
+      return (
+        this.canCreateHoldout({ projects: [] }) ||
+        allProjects.some((p) => this.canCreateHoldout({ projects: [p.id] }))
       );
     }
     return this.canCreateHoldout({ projects: project ? [project] : [] });
@@ -661,8 +666,13 @@ export class Permissions {
     allProjects?: { id: string }[],
   ): boolean => {
     if (!project && allProjects?.length) {
-      return allProjects.some((p) =>
-        this.canCreateFactTable({ projects: [p.id] }),
+      // Allow if the user can create a fact table with no project (e.g. a
+      // global admin). Checking that first means a non-creatable project (like
+      // the read-only sample-data project) can't gate the CTA when it's the
+      // only project.
+      return (
+        this.canCreateFactTable({ projects: [] }) ||
+        allProjects.some((p) => this.canCreateFactTable({ projects: [p.id] }))
       );
     }
     return this.canCreateFactTable({ projects: project ? [project] : [] });

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -270,8 +270,13 @@ export class Permissions {
     allProjects?: { id: string }[],
   ): boolean => {
     if (!project && allProjects?.length) {
-      return allProjects.some((p) =>
-        this.canCreateAttribute({ projects: [p.id] }),
+      // Allow if the user can create an attribute with no project (e.g. a
+      // global admin). Checking that first means a non-creatable project (like
+      // the read-only sample-data project) can't gate the CTA when it's the
+      // only project.
+      return (
+        this.canCreateAttribute({ projects: [] }) ||
+        allProjects.some((p) => this.canCreateAttribute({ projects: [p.id] }))
       );
     }
     return this.canCreateAttribute({ projects: project ? [project] : [] });
@@ -620,7 +625,14 @@ export class Permissions {
     allProjects?: { id: string }[],
   ): boolean => {
     if (!project && allProjects?.length) {
-      return allProjects.some((p) => this.canCreateIdea({ project: p.id }));
+      // Allow if the user can create an idea with no project (e.g. a global
+      // admin). Checking that first means a non-creatable project (like the
+      // read-only sample-data project) can't gate the CTA when it's the only
+      // project.
+      return (
+        this.canCreateIdea({ project: "" }) ||
+        allProjects.some((p) => this.canCreateIdea({ project: p.id }))
+      );
     }
     return this.canCreateIdea({ project });
   };
@@ -937,8 +949,15 @@ export class Permissions {
     allProjects?: { id: string }[],
   ): boolean => {
     if (!project && allProjects?.length) {
-      return allProjects.some((p) =>
-        this.canCreateDataSource({ projects: [p.id], type: undefined }),
+      // Allow if the user can create a data source with no project (e.g. a
+      // global admin). Checking that first means a non-creatable project (like
+      // the read-only sample-data project) can't gate the CTA when it's the
+      // only project.
+      return (
+        this.canCreateDataSource({ projects: [], type: undefined }) ||
+        allProjects.some((p) =>
+          this.canCreateDataSource({ projects: [p.id], type: undefined }),
+        )
       );
     }
     return this.canCreateDataSource({
@@ -1219,8 +1238,13 @@ export class Permissions {
     allProjects?: { id: string }[],
   ): boolean => {
     if (!project && allProjects?.length) {
-      return allProjects.some((p) =>
-        this.canCreateSavedGroup({ projects: [p.id] }),
+      // Allow if the user can create a saved group with no project (e.g. a
+      // global admin). Checking that first means a non-creatable project (like
+      // the read-only sample-data project) can't gate the CTA when it's the
+      // only project.
+      return (
+        this.canCreateSavedGroup({ projects: [] }) ||
+        allProjects.some((p) => this.canCreateSavedGroup({ projects: [p.id] }))
       );
     }
     return this.canCreateSavedGroup({ projects: project ? [project] : [] });

--- a/packages/shared/test/permissions-demo-project.test.ts
+++ b/packages/shared/test/permissions-demo-project.test.ts
@@ -90,6 +90,12 @@ describe("demo (sample data) project does not lock out create CTAs", () => {
     permissions.canViewExperimentModal = wrapByProjectString(
       permissions.canViewExperimentModal,
     );
+    permissions.canCreateExperimentTemplate = wrapByProject(
+      permissions.canCreateExperimentTemplate,
+    );
+    permissions.canViewExperimentTemplateModal = wrapByProjectString(
+      permissions.canViewExperimentTemplateModal,
+    );
     permissions.canCreateHoldout = wrapByProjects(permissions.canCreateHoldout);
     permissions.canViewHoldoutModal = wrapByProjectString(
       permissions.canViewHoldoutModal,
@@ -114,6 +120,11 @@ describe("demo (sample data) project does not lock out create CTAs", () => {
   it("Add Fact Table stays enabled", () => {
     const p = getAdminPermissionsForDemoOnlyOrg();
     expect(p.canViewCreateFactTableModal("", allProjects)).toBe(true);
+  });
+
+  it("Add Template stays enabled", () => {
+    const p = getAdminPermissionsForDemoOnlyOrg();
+    expect(p.canViewExperimentTemplateModal("", allProjects)).toBe(true);
   });
 
   it("Add Feature stays enabled (canViewFeatureModal + global-first create check)", () => {

--- a/packages/shared/test/permissions-demo-project.test.ts
+++ b/packages/shared/test/permissions-demo-project.test.ts
@@ -1,0 +1,130 @@
+import { OrganizationInterface } from "shared/types/organization";
+import { Permissions, roleToPermissionMap } from "../permissions";
+
+// Regression test for the "Sample Data" (demo) project locking out create CTAs.
+//
+// In the front-end (services/UserContext.tsx) we inject a read-only-ish role
+// for the demo project and then wrap the create/view permission methods to
+// return false for that project (so its CTAs stay disabled). When the demo
+// project is the ONLY project in the org, the "All Projects" create CTAs must
+// still be enabled for a user who can create at the org level (e.g. an admin) —
+// a non-creatable project must not gate the button.
+describe("demo (sample data) project does not lock out create CTAs", () => {
+  const testOrg: OrganizationInterface = {
+    id: "org_demo_only",
+    name: "Test Org",
+    ownerEmail: "test@test.com",
+    url: "https://test.com",
+    dateCreated: new Date(),
+    invites: [],
+    members: [],
+    settings: {
+      environments: [{ id: "production", description: "" }],
+    },
+  };
+
+  // Same shape as getDemoDatasourceProjectIdForOrganization(org.id).
+  const demoProjectId = "prj_org_demo_only_demo-datasource-project";
+  const allProjects = [{ id: demoProjectId }];
+
+  // Build a global admin's Permissions instance exactly as UserContext does for
+  // an org whose only project is the demo project.
+  function getAdminPermissionsForDemoOnlyOrg(): Permissions {
+    const permissions = new Permissions({
+      global: {
+        permissions: roleToPermissionMap("admin", testOrg),
+        limitAccessByEnvironment: false,
+        environments: [],
+      },
+      projects: {
+        // Mirrors the injected demo-project role in UserContext.tsx.
+        [demoProjectId]: {
+          permissions: {
+            ...roleToPermissionMap("readonly", testOrg),
+            runQueries: true,
+            manageFeatures: true,
+            manageFeatureDrafts: true,
+            canReview: true,
+            createAnalyses: true,
+            manageFactMetrics: true,
+            publishFeatures: true,
+            runExperiments: true,
+          },
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+      },
+    });
+
+    // Mirror the create/delete CTA wrapping from UserContext.tsx.
+    const targetsDemoProject = (project?: string) => project === demoProjectId;
+    const projectsTargetDemoOnly = (projects?: string[]) =>
+      !!projects?.length && projects.every((p) => p === demoProjectId);
+
+    const wrapByProject =
+      <T extends { project?: string }, R extends boolean>(
+        original: (arg: T) => R,
+      ) =>
+      (arg: T) =>
+        (targetsDemoProject(arg.project) ? false : original(arg)) as R;
+    const wrapByProjects =
+      <T extends { projects?: string[] }, R extends boolean>(
+        original: (arg: T) => R,
+      ) =>
+      (arg: T) =>
+        (projectsTargetDemoOnly(arg.projects) ? false : original(arg)) as R;
+    const wrapByProjectString =
+      (
+        original: (project?: string, allProjects?: { id: string }[]) => boolean,
+      ) =>
+      (project?: string, allProjects?: { id: string }[]) =>
+        targetsDemoProject(project) ? false : original(project, allProjects);
+
+    permissions.canCreateFeature = wrapByProject(permissions.canCreateFeature);
+    permissions.canViewFeatureModal = wrapByProjectString(
+      permissions.canViewFeatureModal,
+    );
+    permissions.canCreateExperiment = wrapByProject(
+      permissions.canCreateExperiment,
+    );
+    permissions.canViewExperimentModal = wrapByProjectString(
+      permissions.canViewExperimentModal,
+    );
+    permissions.canCreateHoldout = wrapByProjects(permissions.canCreateHoldout);
+    permissions.canViewHoldoutModal = wrapByProjectString(
+      permissions.canViewHoldoutModal,
+    );
+    permissions.canCreateFactMetric = wrapByProjects(
+      permissions.canCreateFactMetric,
+    );
+
+    return permissions;
+  }
+
+  it("Add Experiment stays enabled (worked even before the fix)", () => {
+    const p = getAdminPermissionsForDemoOnlyOrg();
+    expect(p.canViewExperimentModal("", allProjects)).toBe(true);
+  });
+
+  it("Add Holdout stays enabled", () => {
+    const p = getAdminPermissionsForDemoOnlyOrg();
+    expect(p.canViewHoldoutModal("", allProjects)).toBe(true);
+  });
+
+  it("Add Fact Table stays enabled", () => {
+    const p = getAdminPermissionsForDemoOnlyOrg();
+    expect(p.canViewCreateFactTableModal("", allProjects)).toBe(true);
+  });
+
+  it("Add Feature stays enabled (canViewFeatureModal + global-first create check)", () => {
+    const p = getAdminPermissionsForDemoOnlyOrg();
+    // canViewFeatureModal is the first half of the features button gate.
+    expect(p.canViewFeatureModal("", allProjects)).toBe(true);
+    // The second half mirrors features/index.tsx canCreateFeatures "All
+    // Projects" global-first check.
+    expect(
+      p.canCreateFeature({ project: "" }) &&
+        p.canManageFeatureDrafts({ project: "" }),
+    ).toBe(true);
+  });
+});

--- a/packages/shared/test/permissions-demo-project.test.ts
+++ b/packages/shared/test/permissions-demo-project.test.ts
@@ -138,4 +138,24 @@ describe("demo (sample data) project does not lock out create CTAs", () => {
         p.canManageFeatureDrafts({ project: "" }),
     ).toBe(true);
   });
+
+  it("Add Attribute stays enabled", () => {
+    const p = getAdminPermissionsForDemoOnlyOrg();
+    expect(p.canViewAttributeModal("", allProjects)).toBe(true);
+  });
+
+  it("Add Idea stays enabled", () => {
+    const p = getAdminPermissionsForDemoOnlyOrg();
+    expect(p.canViewIdeaModal("", allProjects)).toBe(true);
+  });
+
+  it("Add Data Source stays enabled", () => {
+    const p = getAdminPermissionsForDemoOnlyOrg();
+    expect(p.canViewCreateDataSourceModal("", allProjects)).toBe(true);
+  });
+
+  it("Add Saved Group stays enabled", () => {
+    const p = getAdminPermissionsForDemoOnlyOrg();
+    expect(p.canViewSavedGroupModal("", allProjects)).toBe(true);
+  });
 });


### PR DESCRIPTION
The sample-data (demo) project is a real project that the front-end forces read-only by wrapping create permission checks to return false for it. On list pages with "All Projects" selected, the create CTA was gated by projects.some(p => canCreate(p)), so when the sample-data project was the only project in the org the button was disabled for everyone — admins included.

Check the global (no-project) create permission first so a user who can create at the org level isn't blocked by a non-creatable project. Fixes Add Feature, Add Holdout, and Add Fact Table; adds a regression test.

### Features and Changes

<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
