### PR TITLE
chore(logs): Add info log with timing data when Experiments are updated

### DIFF
--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -26,6 +26,7 @@ import { notifyExperimentChange } from "back-end/src/services/experimentNotifica
 import { updateExperimentAnalysisSummary } from "back-end/src/services/experiments";
 import { updateExperimentTimeSeries } from "back-end/src/services/experimentTimeSeries";
 import { runEagerExperimentAndUnitDimensionsAnalyses } from "back-end/src/services/experimentDimensionAnalyses";
+import { ExperimentUpdateExecutionLogger } from "back-end/src/services/experimentUpdateExecutionLogger";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import { queriesSchema } from "./QueryModel";
@@ -401,10 +402,12 @@ export async function updateSnapshot({
   context,
   id,
   updates,
+  experimentUpdateExecutionLogger,
 }: {
   context: Context;
   id: string;
   updates: Partial<ExperimentSnapshotInterface>;
+  experimentUpdateExecutionLogger?: ExperimentUpdateExecutionLogger | null;
 }) {
   const organization = context.org.id;
 
@@ -417,112 +420,130 @@ export async function updateSnapshot({
   }
 
   const existingInterface = toInterface(existingSnapshotModel);
-  const updatesForDb: Partial<ExperimentSnapshotInterface> = { ...updates };
-  let deleteExistingChunksAfterUpdate = false;
-  let chunkResult: Awaited<ReturnType<typeof chunkAndStripAnalyses>> = null;
   let experimentSnapshot: ExperimentSnapshotInterface = {
     ...existingInterface,
     ...updates,
   };
+  const hasAnalysisUpdates = updates.analyses !== undefined;
 
-  const analysisUpdates = updates.analyses;
-  const hasAnalysisUpdates = analysisUpdates !== undefined;
+  experimentUpdateExecutionLogger?.startPhase("persistSnapshot");
 
-  // Normalize analysis keys up front: preserve keys by settings-match against
-  // the existing on-disk analyses so in-place updates stay on the same
-  // sub-path, mint fresh ones for analyses that don't match.
-  const normalizedAnalyses = hasAnalysisUpdates
-    ? analysisUpdates.map((analysis) => {
-        const resolvedKey = resolveAnalysisKey(
-          existingInterface.analyses,
-          analysis,
-        );
-        return analysis.analysisKey === resolvedKey
-          ? analysis
-          : { ...analysis, analysisKey: resolvedKey };
-      })
-    : undefined;
+  let currentExperimentModel: Awaited<ReturnType<typeof getExperimentById>> =
+    null;
+  let updatedExperimentModel: Awaited<
+    ReturnType<typeof updateExperimentAnalysisSummary>
+  > | null = null;
+  let shouldRunEagerDimensionAnalyses = false;
 
-  // If analyses have results, chunk them into separate documents
-  if (normalizedAnalyses) {
-    chunkResult = await chunkAndStripAnalyses({
-      context,
-      snapshotId: id,
-      experimentId: experimentSnapshot.experiment,
-      analyses: normalizedAnalyses,
-      settings: experimentSnapshot.settings,
-    });
-  }
+  try {
+    const updatesForDb: Partial<ExperimentSnapshotInterface> = { ...updates };
+    let deleteExistingChunksAfterUpdate = false;
+    let chunkResult: Awaited<ReturnType<typeof chunkAndStripAnalyses>> = null;
 
-  if (chunkResult && normalizedAnalyses) {
-    deleteExistingChunksAfterUpdate = chunkResult.metricIds.length === 0;
-    // Clear results from the main document while keeping the logical snapshot
-    // populated for post-success side effects below.
-    updatesForDb.analyses = chunkResult.strippedAnalyses;
-    updatesForDb.hasChunkedAnalyses = chunkResult.hasChunkedAnalyses;
-    updatesForDb.chunkedAnalysesMeta = chunkResult.chunkedAnalysesMeta;
-    experimentSnapshot = {
-      ...experimentSnapshot,
-      analyses: normalizedAnalyses,
-      hasChunkedAnalyses: chunkResult.hasChunkedAnalyses,
-      chunkedAnalysesMeta: chunkResult.chunkedAnalysesMeta,
-    };
-  } else if (normalizedAnalyses) {
-    deleteExistingChunksAfterUpdate = true;
-    updatesForDb.analyses = normalizedAnalyses;
-    updatesForDb.hasChunkedAnalyses = false;
-    updatesForDb.chunkedAnalysesMeta = {};
-    experimentSnapshot = {
-      ...experimentSnapshot,
-      analyses: normalizedAnalyses,
-      hasChunkedAnalyses: false,
-      chunkedAnalysesMeta: {},
-    };
-  }
+    // Normalize analysis keys up front: preserve keys by settings-match against
+    // the existing on-disk analyses so in-place updates stay on the same
+    // sub-path, mint fresh ones for analyses that don't match.
+    const normalizedAnalyses = updates.analyses
+      ? updates.analyses.map((analysis) => {
+          const resolvedKey = resolveAnalysisKey(
+            existingInterface.analyses,
+            analysis,
+          );
+          return analysis.analysisKey === resolvedKey
+            ? analysis
+            : { ...analysis, analysisKey: resolvedKey };
+        })
+      : undefined;
 
-  await ExperimentSnapshotModel.updateOne(
-    {
-      organization,
-      id,
-    },
-    {
-      $set: updatesForDb,
-    },
-  );
-
-  if (deleteExistingChunksAfterUpdate) {
-    await context.models.experimentSnapshotAnalysisChunks.deleteBySnapshotId(
-      id,
-    );
-  }
-
-  if (experimentSnapshot.hasChunkedAnalyses && !chunkResult) {
-    await populateSnapshotAnalyses(context, experimentSnapshot);
-  }
-
-  const shouldUpdateExperimentAnalysisSummary =
-    experimentSnapshot.type === "standard" &&
-    experimentSnapshot.status === "success";
-
-  const shouldRunEagerDimensionAnalyses =
-    shouldUpdateExperimentAnalysisSummary && hasAnalysisUpdates;
-
-  const currentExperimentModel = shouldUpdateExperimentAnalysisSummary
-    ? await getExperimentById(context, experimentSnapshot.experiment)
-    : null;
-
-  const isLatestPhase = currentExperimentModel
-    ? experimentSnapshot.phase === currentExperimentModel.phases.length - 1
-    : false;
-
-  if (currentExperimentModel && isLatestPhase) {
-    if (shouldUpdateExperimentAnalysisSummary) {
-      const updatedExperimentModel = await updateExperimentAnalysisSummary({
+    // If analyses have results, chunk them into separate documents
+    if (normalizedAnalyses) {
+      chunkResult = await chunkAndStripAnalyses({
         context,
-        experiment: currentExperimentModel,
-        experimentSnapshot,
+        snapshotId: id,
+        experimentId: experimentSnapshot.experiment,
+        analyses: normalizedAnalyses,
+        settings: experimentSnapshot.settings,
       });
+    }
 
+    if (chunkResult && normalizedAnalyses) {
+      deleteExistingChunksAfterUpdate = chunkResult.metricIds.length === 0;
+      // Clear results from the main document while keeping the logical snapshot
+      // populated for post-success side effects below.
+      updatesForDb.analyses = chunkResult.strippedAnalyses;
+      updatesForDb.hasChunkedAnalyses = chunkResult.hasChunkedAnalyses;
+      updatesForDb.chunkedAnalysesMeta = chunkResult.chunkedAnalysesMeta;
+      experimentSnapshot = {
+        ...experimentSnapshot,
+        analyses: normalizedAnalyses,
+        hasChunkedAnalyses: chunkResult.hasChunkedAnalyses,
+        chunkedAnalysesMeta: chunkResult.chunkedAnalysesMeta,
+      };
+    } else if (normalizedAnalyses) {
+      deleteExistingChunksAfterUpdate = true;
+      updatesForDb.analyses = normalizedAnalyses;
+      updatesForDb.hasChunkedAnalyses = false;
+      updatesForDb.chunkedAnalysesMeta = {};
+      experimentSnapshot = {
+        ...experimentSnapshot,
+        analyses: normalizedAnalyses,
+        hasChunkedAnalyses: false,
+        chunkedAnalysesMeta: {},
+      };
+    }
+
+    await ExperimentSnapshotModel.updateOne(
+      {
+        organization,
+        id,
+      },
+      {
+        $set: updatesForDb,
+      },
+    );
+
+    if (deleteExistingChunksAfterUpdate) {
+      await context.models.experimentSnapshotAnalysisChunks.deleteBySnapshotId(
+        id,
+      );
+    }
+
+    if (experimentSnapshot.hasChunkedAnalyses && !chunkResult) {
+      await populateSnapshotAnalyses(context, experimentSnapshot);
+    }
+
+    const shouldUpdateExperimentAnalysisSummary =
+      experimentSnapshot.type === "standard" &&
+      experimentSnapshot.status === "success";
+
+    shouldRunEagerDimensionAnalyses =
+      shouldUpdateExperimentAnalysisSummary && hasAnalysisUpdates;
+
+    if (shouldUpdateExperimentAnalysisSummary) {
+      currentExperimentModel = await getExperimentById(
+        context,
+        experimentSnapshot.experiment,
+      );
+
+      const isLatestPhase = currentExperimentModel
+        ? experimentSnapshot.phase === currentExperimentModel.phases.length - 1
+        : false;
+
+      if (currentExperimentModel && isLatestPhase) {
+        updatedExperimentModel = await updateExperimentAnalysisSummary({
+          context,
+          experiment: currentExperimentModel,
+          experimentSnapshot,
+        });
+      }
+    }
+  } finally {
+    experimentUpdateExecutionLogger?.endPhase("persistSnapshot");
+  }
+
+  if (updatedExperimentModel && currentExperimentModel) {
+    experimentUpdateExecutionLogger?.startPhase("propagateSnapshot");
+    try {
       const notificationsTriggered = await notifyExperimentChange({
         context,
         experiment: updatedExperimentModel,
@@ -565,7 +586,19 @@ export async function updateSnapshot({
           );
         });
       }
+    } finally {
+      experimentUpdateExecutionLogger?.endPhase("propagateSnapshot");
     }
+  }
+
+  if (
+    experimentUpdateExecutionLogger &&
+    experimentSnapshot.status !== "running"
+  ) {
+    experimentUpdateExecutionLogger.logUpdateCompleted(context, {
+      snapshotStatus: experimentSnapshot.status,
+      error: experimentSnapshot.error,
+    });
   }
 
   const updateDashboardWithSnapshot = async (dashboard: DashboardInterface) => {

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
@@ -471,6 +471,7 @@ export class ExperimentIncrementalRefreshExploratoryQueryRunner extends QueryRun
       context: this.context,
       id: this.model.id,
       updates,
+      experimentUpdateExecutionLogger: this.experimentUpdateExecutionLogger,
     });
     if (
       this.model.report &&

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -1158,6 +1158,12 @@ export class ExperimentIncrementalRefreshQueryRunner extends QueryRunner<
       analysisType: params.fullRefresh ? "main-fullRefresh" : "main-update",
     });
 
+    if (this.experimentUpdateExecutionLogger) {
+      this.experimentUpdateExecutionLogger.execution = {
+        incrementalRefreshMode: params.fullRefresh ? "full" : "incremental",
+      };
+    }
+
     return await startExperimentIncrementalRefreshQueries(
       this.context,
       params,
@@ -1302,6 +1308,7 @@ export class ExperimentIncrementalRefreshQueryRunner extends QueryRunner<
       context: this.context,
       id: this.model.id,
       updates,
+      experimentUpdateExecutionLogger: this.experimentUpdateExecutionLogger,
     });
     if (
       this.model.report &&

--- a/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
@@ -634,6 +634,7 @@ export class ExperimentResultsQueryRunner extends QueryRunner<
       context: this.context,
       id: this.model.id,
       updates,
+      experimentUpdateExecutionLogger: this.experimentUpdateExecutionLogger,
     });
     if (
       this.model.report &&

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -25,6 +25,10 @@ import { logger } from "back-end/src/util/logger";
 import { promiseAllChunks } from "back-end/src/util/promise";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
+import {
+  ExperimentUpdateExecutionLogger,
+  ExperimentUpdateTimingPhase,
+} from "back-end/src/services/experimentUpdateExecutionLogger";
 
 export type QueryMap = Map<string, QueryInterface>;
 
@@ -135,6 +139,8 @@ export abstract class QueryRunner<
   private pendingTimers: Record<string, NodeJS.Timeout> = {};
   private lockHeartbeatTimer: null | NodeJS.Timeout = null;
   private finishedQueryMapCache: QueryMap = new Map();
+  protected experimentUpdateExecutionLogger: ExperimentUpdateExecutionLogger | null =
+    null;
 
   public constructor(
     context: ReqContext | ApiReqContext,
@@ -280,12 +286,32 @@ export abstract class QueryRunner<
     return getQueryMap(this.context, pointers, this.finishedQueryMapCache);
   }
 
+  setExperimentUpdateExecutionLogger(
+    logger: ExperimentUpdateExecutionLogger | null,
+  ): void {
+    this.experimentUpdateExecutionLogger = logger;
+  }
+
+  withExperimentUpdateTiming<T>(
+    phase: ExperimentUpdateTimingPhase,
+    fn: () => Promise<T> | T,
+  ): Promise<T> | T {
+    if (!this.experimentUpdateExecutionLogger) {
+      return fn();
+    }
+    return this.experimentUpdateExecutionLogger.withTiming(phase, fn);
+  }
+
   public async startAnalysis(params: Params): Promise<Model> {
     logger.debug(this.model.id + " runner: Starting queries");
-    const queries = await this.startQueries(params);
+    const queries = await this.withExperimentUpdateTiming("generateSql", () =>
+      this.startQueries(params),
+    );
+    this.experimentUpdateExecutionLogger?.startPhase("runQueries");
     this.model.queries = queries;
 
     if (queries.length === 0) {
+      this.experimentUpdateExecutionLogger?.endPhase("runQueries");
       const noQueriesError = "No queries were generated for this analysis";
       logger.debug(this.model.id + " runner: " + noQueriesError);
       const newModel = await this.updateModel({
@@ -308,13 +334,17 @@ export abstract class QueryRunner<
       logger.debug(this.model.id + " runner: Query already succeeded (cached)");
       const queryMap = await this.getQueryMap(queries);
       try {
-        result = await this.runAnalysis(queryMap);
+        this.experimentUpdateExecutionLogger?.endPhase("runQueries");
+        result = await this.withExperimentUpdateTiming("analyze", () =>
+          this.runAnalysis(queryMap),
+        );
         logger.debug(this.model.id + " runner: Ran analysis successfully");
       } catch (e) {
         logger.error(e, this.model.id + " runner: Error running analysis");
         error = "Error running analysis: " + e.message;
       }
     } else if (queryStatus === "failed") {
+      this.experimentUpdateExecutionLogger?.endPhase("runQueries");
       logger.debug(this.model.id + " runner: Query failed immediately");
       error = "Error running one or more database queries";
     }
@@ -548,6 +578,8 @@ export abstract class QueryRunner<
         error = query.error || error;
       }
 
+      this.experimentUpdateExecutionLogger?.endPhase("runQueries");
+
       logger.debug(
         "Query failed for " +
           this.model.id +
@@ -559,7 +591,10 @@ export abstract class QueryRunner<
       (newStatus === "succeeded" || newStatus === "partially-succeeded")
     ) {
       try {
-        result = await this.runAnalysis(queryMap);
+        this.experimentUpdateExecutionLogger?.endPhase("runQueries");
+        result = await this.withExperimentUpdateTiming("analyze", () =>
+          this.runAnalysis(queryMap),
+        );
         logger.debug(`Queries ${newStatus}, ran analysis successfully`);
       } catch (e) {
         error = "Error running analysis: " + e.message;

--- a/packages/back-end/src/services/experimentUpdateExecutionLogger.ts
+++ b/packages/back-end/src/services/experimentUpdateExecutionLogger.ts
@@ -1,0 +1,149 @@
+import { DataSourceInterface } from "shared/types/datasource";
+import {
+  SnapshotTriggeredBy,
+  SnapshotType,
+} from "shared/types/experiment-snapshot";
+import { ReqContext } from "back-end/types/request";
+import { ApiReqContext } from "back-end/types/api";
+import { SnapshotQueryRunnerKind } from "./experiments";
+
+type ExperimentUpdateLogMeta = {
+  experimentId: string;
+  snapshotId: string;
+  snapshotType: SnapshotType;
+  triggeredBy: SnapshotTriggeredBy;
+  datasource: DataSourceInterface;
+};
+
+export type ExperimentUpdateLogPlan = {
+  runnerKind: SnapshotQueryRunnerKind;
+  incrementalFallbackReason: string | null;
+  useCache: boolean | null;
+  fullRefresh: boolean | null;
+  fullRefreshReason: string | null;
+};
+
+type ExperimentUpdateExecutionLog = {
+  incrementalRefreshMode: "full" | "incremental" | null;
+};
+
+type ExperimentUpdateTimingMs = {
+  generateSql: number;
+  runQueries: number;
+  analyze: number;
+  persistSnapshot: number;
+  propagateSnapshot: number;
+  total: number;
+};
+
+export type ExperimentUpdateTimingPhase = Exclude<
+  keyof ExperimentUpdateTimingMs,
+  "total"
+>;
+
+export class ExperimentUpdateExecutionLogger {
+  public execution: ExperimentUpdateExecutionLog = {
+    incrementalRefreshMode: null,
+  };
+
+  private readonly startedAtMs = Date.now();
+  private totalMs: number | null = null;
+  private readonly phaseStartedAtMs: Partial<
+    Record<ExperimentUpdateTimingPhase, number>
+  > = {};
+  private readonly phaseMs = {
+    generateSql: 0,
+    runQueries: 0,
+    analyze: 0,
+    persistSnapshot: 0,
+    propagateSnapshot: 0,
+  };
+  private logged = false;
+
+  constructor(
+    public readonly plan: ExperimentUpdateLogPlan,
+    private readonly meta: ExperimentUpdateLogMeta,
+  ) {}
+
+  async withTiming<T>(
+    phase: ExperimentUpdateTimingPhase,
+    fn: () => Promise<T> | T,
+  ): Promise<T> {
+    this.startPhase(phase);
+    try {
+      return await fn();
+    } finally {
+      this.endPhase(phase);
+    }
+  }
+
+  startPhase(phase: ExperimentUpdateTimingPhase): void {
+    if (this.phaseStartedAtMs[phase] !== undefined) {
+      return;
+    }
+    this.phaseStartedAtMs[phase] = Date.now();
+  }
+
+  endPhase(phase: ExperimentUpdateTimingPhase): void {
+    const startedAt = this.phaseStartedAtMs[phase];
+    if (startedAt !== undefined) {
+      this.phaseMs[phase] += Date.now() - startedAt;
+      delete this.phaseStartedAtMs[phase];
+    }
+
+    if (phase === "propagateSnapshot") {
+      this.freezeTotal();
+    }
+  }
+
+  private freezeTotal(): void {
+    if (this.totalMs !== null) {
+      return;
+    }
+    this.totalMs = Date.now() - this.startedAtMs;
+  }
+
+  getTimings(): ExperimentUpdateTimingMs {
+    return {
+      ...this.phaseMs,
+      total: this.totalMs ?? 0,
+    };
+  }
+
+  logUpdateCompleted(
+    context: ReqContext | ApiReqContext,
+    {
+      snapshotStatus,
+      error,
+    }: {
+      snapshotStatus: "running" | "success" | "error";
+      error?: string;
+    },
+  ): void {
+    if (this.logged || snapshotStatus === "running") {
+      return;
+    }
+    this.logged = true;
+    this.freezeTotal();
+    context.logger.info(
+      {
+        event: "experiment_updated",
+        experimentId: this.meta.experimentId,
+        snapshotId: this.meta.snapshotId,
+        snapshotType: this.meta.snapshotType,
+        triggeredBy: this.meta.triggeredBy,
+        snapshotStatus,
+        error: error || null,
+        datasourceId: this.meta.datasource.id,
+        datasourceType: this.meta.datasource.type,
+        runnerKind: this.plan.runnerKind,
+        incrementalFallbackReason: this.plan.incrementalFallbackReason,
+        plannedFullRefresh: this.plan.fullRefresh,
+        fullRefreshReason: this.plan.fullRefreshReason,
+        incrementalRefreshMode: this.execution.incrementalRefreshMode,
+        timingsMs: this.getTimings(),
+      },
+      "Experiment update completed",
+    );
+  }
+}

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -1234,7 +1234,6 @@ function isIncrementalRefreshEnabledForSnapshot({
 }
 
 export function getSnapshotQueryRunnerKind({
-  allowIncrementalRefresh,
   isExperimentCompatibleWithIncrementalRefresh,
   datasource,
   experiment,
@@ -1242,7 +1241,6 @@ export function getSnapshotQueryRunnerKind({
   hasSnapshotDimensions,
   hasMaterializedUnitsTable,
 }: {
-  allowIncrementalRefresh: boolean;
   isExperimentCompatibleWithIncrementalRefresh: boolean;
   datasource: DataSourceInterface;
   experiment: ExperimentInterface;
@@ -1251,7 +1249,6 @@ export function getSnapshotQueryRunnerKind({
   hasMaterializedUnitsTable: boolean;
 }): SnapshotQueryRunnerKind {
   if (
-    allowIncrementalRefresh &&
     isIncrementalRefreshEnabledForSnapshot({ datasource, experiment }) &&
     (experiment.type === undefined || experiment.type === "standard") &&
     isExperimentCompatibleWithIncrementalRefresh
@@ -1273,7 +1270,6 @@ export function getSnapshotQueryRunnerKind({
 }
 
 async function planSnapshotQueryRunner({
-  allowIncrementalRefresh,
   organization,
   datasource,
   integration,
@@ -1285,7 +1281,6 @@ async function planSnapshotQueryRunner({
   snapshotType,
   fullRefresh,
 }: {
-  allowIncrementalRefresh: boolean;
   organization: OrganizationInterface;
   datasource: DataSourceInterface;
   integration: SourceIntegrationInterface;
@@ -1298,32 +1293,29 @@ async function planSnapshotQueryRunner({
   fullRefresh: boolean;
 }): Promise<SnapshotQueryRunnerKind> {
   let isExperimentCompatibleWithIncrementalRefresh = false;
-  if (allowIncrementalRefresh) {
-    try {
-      await validateIncrementalPipeline({
-        org: organization,
-        integration,
-        snapshotSettings,
-        metricMap,
-        factTableMap,
-        experiment,
-        incrementalRefreshModel,
-        analysisType: fullRefresh
-          ? "main-fullRefresh"
-          : snapshotType === "standard"
-            ? "main-update"
-            : "exploratory",
-      });
-      isExperimentCompatibleWithIncrementalRefresh = true;
-    } catch (error) {
-      logger.info(
-        `Experiment ${experiment.id} does not support incremental refresh: ${"message" in error ? error.message : error}`,
-      );
-    }
+  try {
+    await validateIncrementalPipeline({
+      org: organization,
+      integration,
+      snapshotSettings,
+      metricMap,
+      factTableMap,
+      experiment,
+      incrementalRefreshModel,
+      analysisType: fullRefresh
+        ? "main-fullRefresh"
+        : snapshotType === "standard"
+          ? "main-update"
+          : "exploratory",
+    });
+    isExperimentCompatibleWithIncrementalRefresh = true;
+  } catch (error) {
+    logger.info(
+      `Experiment ${experiment.id} does not support incremental refresh: ${"message" in error ? error.message : error}`,
+    );
   }
 
   return getSnapshotQueryRunnerKind({
-    allowIncrementalRefresh,
     isExperimentCompatibleWithIncrementalRefresh,
     datasource,
     experiment,
@@ -1354,7 +1346,6 @@ export async function planSnapshot({
   metricMap,
   factTableMap,
   reweight,
-  allowIncrementalRefresh = true,
 }: {
   experiment: ExperimentInterface;
   context: ReqContext | ApiReqContext;
@@ -1368,7 +1359,6 @@ export async function planSnapshot({
   metricMap: Map<string, ExperimentMetricInterface>;
   factTableMap: FactTableMap;
   reweight?: boolean;
-  allowIncrementalRefresh?: boolean;
 }): Promise<PlannedExperimentSnapshot> {
   const { org: organization } = context;
   const dimension = defaultAnalysisSettings.dimensions[0] || null;
@@ -1469,7 +1459,6 @@ export async function planSnapshot({
   const integration = getSourceIntegrationObject(context, datasource, true);
 
   const runnerKind = await planSnapshotQueryRunner({
-    allowIncrementalRefresh,
     organization,
     datasource,
     integration,
@@ -1710,7 +1699,6 @@ export async function createSnapshot({
   metricMap,
   factTableMap,
   reweight,
-  allowIncrementalRefresh = true,
 }: {
   experiment: ExperimentInterface;
   context: ReqContext | ApiReqContext;
@@ -1724,7 +1712,6 @@ export async function createSnapshot({
   metricMap: Map<string, ExperimentMetricInterface>;
   factTableMap: FactTableMap;
   reweight?: boolean;
-  allowIncrementalRefresh?: boolean;
 }): Promise<ExperimentSnapshotQueryRunner> {
   const plan = await planSnapshot({
     experiment,
@@ -1739,7 +1726,6 @@ export async function createSnapshot({
     metricMap,
     factTableMap,
     reweight,
-    allowIncrementalRefresh,
   });
 
   return createSnapshotFromPlan({
@@ -1831,7 +1817,6 @@ export async function createExperimentSnapshot({
   triggeredBy,
   type,
   reweight,
-  allowIncrementalRefresh = true,
 }: {
   context: ReqContext;
   experiment: ExperimentInterface;
@@ -1842,7 +1827,6 @@ export async function createExperimentSnapshot({
   triggeredBy?: SnapshotTriggeredBy;
   type?: SnapshotType;
   reweight?: boolean;
-  allowIncrementalRefresh?: boolean;
 }): Promise<{
   snapshot: ExperimentSnapshotInterface;
   queryRunner: ExperimentSnapshotQueryRunner;
@@ -1857,7 +1841,6 @@ export async function createExperimentSnapshot({
     triggeredBy,
     type,
     reweight,
-    allowIncrementalRefresh,
   });
 
   return createExperimentSnapshotFromPlan({
@@ -1910,7 +1893,6 @@ export async function planExperimentSnapshot({
   triggeredBy,
   type,
   reweight,
-  allowIncrementalRefresh = true,
 }: {
   context: ReqContext;
   experiment: ExperimentInterface;
@@ -1921,7 +1903,6 @@ export async function planExperimentSnapshot({
   triggeredBy?: SnapshotTriggeredBy;
   type?: SnapshotType;
   reweight?: boolean;
-  allowIncrementalRefresh?: boolean;
 }): Promise<PlannedExperimentSnapshot> {
   const snapshotType =
     type ??
@@ -2012,7 +1993,6 @@ export async function planExperimentSnapshot({
     reweight,
     type: snapshotType,
     triggeredBy: triggeredBy ?? "manual",
-    allowIncrementalRefresh,
   });
   return plan;
 }

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -190,6 +190,10 @@ import {
 } from "back-end/src/services/dimensions";
 import { ConcurrentIncrementalRefreshError } from "back-end/src/util/errors";
 import { validateIncrementalPipeline } from "back-end/src/enterprise/services/data-pipeline";
+import {
+  ExperimentUpdateLogPlan,
+  ExperimentUpdateExecutionLogger,
+} from "back-end/src/services/experimentUpdateExecutionLogger";
 import { getMetricForSnapshot } from "./reports";
 import {
   getIntegrationFromDatasourceId,
@@ -1233,40 +1237,93 @@ function isIncrementalRefreshEnabledForSnapshot({
   );
 }
 
-export function getSnapshotQueryRunnerKind({
-  isExperimentCompatibleWithIncrementalRefresh,
+export function resolveSnapshotRunner({
   datasource,
   experiment,
   snapshotType,
   hasSnapshotDimensions,
   hasMaterializedUnitsTable,
 }: {
-  isExperimentCompatibleWithIncrementalRefresh: boolean;
   datasource: DataSourceInterface;
   experiment: ExperimentInterface;
   snapshotType: SnapshotType;
   hasSnapshotDimensions: boolean;
   hasMaterializedUnitsTable: boolean;
-}): SnapshotQueryRunnerKind {
-  if (
-    isIncrementalRefreshEnabledForSnapshot({ datasource, experiment }) &&
-    (experiment.type === undefined || experiment.type === "standard") &&
-    isExperimentCompatibleWithIncrementalRefresh
-  ) {
-    if (snapshotType === "exploratory" && !hasSnapshotDimensions) {
-      // Dimension-less exploratory snapshots reuse the incremental runner in
-      // read-only mode (fullRefresh is clamped to false downstream). That only
-      // works if the warehouse units table has already been created by a prior
-      // standard snapshot — otherwise fall back to the non-pipeline runner.
-      return hasMaterializedUnitsTable ? "incremental" : "results";
-    }
-
-    return snapshotType === "exploratory"
-      ? "incremental-exploratory"
-      : "incremental";
+}): {
+  runnerKind: SnapshotQueryRunnerKind;
+  incrementalFallbackReason: string | null;
+} {
+  if (!isIncrementalRefreshEnabledForSnapshot({ datasource, experiment })) {
+    return { runnerKind: "results", incrementalFallbackReason: null };
   }
 
-  return "results";
+  if (experiment.type !== undefined && experiment.type !== "standard") {
+    return {
+      runnerKind: "results",
+      incrementalFallbackReason: `Experiment type "${experiment.type}" is not supported for incremental refresh.`,
+    };
+  }
+
+  if (snapshotType === "exploratory" && !hasSnapshotDimensions) {
+    // Dimension-less exploratory snapshots reuse the incremental runner in
+    // read-only mode (fullRefresh is always false on exploratory snapshots). That only
+    // works if the warehouse units table has already been created by a prior
+    // standard snapshot — otherwise fall back to the non-pipeline runner.
+    if (!hasMaterializedUnitsTable) {
+      return {
+        runnerKind: "results",
+        incrementalFallbackReason:
+          "No materialized units table yet for this dimension-less exploratory snapshot.",
+      };
+    }
+    return { runnerKind: "incremental", incrementalFallbackReason: null };
+  }
+
+  return {
+    runnerKind:
+      snapshotType === "exploratory"
+        ? "incremental-exploratory"
+        : "incremental",
+    incrementalFallbackReason: null,
+  };
+}
+
+/**
+ * Determines if a full refresh is needed for an incremental experiment snapshot.
+ *
+ * Returns true in the following cases:
+ * - A full refresh is explicitly requested (`useCache` is false).
+ * - There is no prior incremental state for this experiment.
+ * - The state document exists but has no `unitsTableFullName`, meaning
+ *   the warehouse units table was never created (e.g., the initial attempt failed).
+ */
+function resolveFullRefresh(
+  useCache: boolean,
+  incrementalRefreshModel: IncrementalRefreshInterface | null,
+): { fullRefresh: boolean; fullRefreshReason: string | null } {
+  if (!useCache) {
+    return {
+      fullRefresh: true,
+      fullRefreshReason: "Full refresh explicitly requested.",
+    };
+  }
+
+  if (!incrementalRefreshModel) {
+    return {
+      fullRefresh: true,
+      fullRefreshReason:
+        "No prior incremental refresh state for this experiment.",
+    };
+  }
+
+  if (!incrementalRefreshModel.unitsTableFullName) {
+    return {
+      fullRefresh: true,
+      fullRefreshReason: "Units table was never materialized by a prior run.",
+    };
+  }
+
+  return { fullRefresh: false, fullRefreshReason: null };
 }
 
 async function planSnapshotQueryRunner({
@@ -1291,8 +1348,24 @@ async function planSnapshotQueryRunner({
   incrementalRefreshModel: IncrementalRefreshInterface | null;
   snapshotType: SnapshotType;
   fullRefresh: boolean;
-}): Promise<SnapshotQueryRunnerKind> {
-  let isExperimentCompatibleWithIncrementalRefresh = false;
+}): Promise<{
+  runnerKind: SnapshotQueryRunnerKind;
+  incrementalFallbackReason: string | null;
+  fullRefresh?: boolean;
+  fullRefreshReason?: string | null;
+}> {
+  const decision = resolveSnapshotRunner({
+    datasource,
+    experiment,
+    snapshotType,
+    hasSnapshotDimensions: snapshotSettings.dimensions.length > 0,
+    hasMaterializedUnitsTable: !!incrementalRefreshModel?.unitsTableFullName,
+  });
+
+  if (decision.runnerKind === "results") {
+    return decision;
+  }
+
   try {
     await validateIncrementalPipeline({
       org: organization,
@@ -1308,21 +1381,18 @@ async function planSnapshotQueryRunner({
           ? "main-update"
           : "exploratory",
     });
-    isExperimentCompatibleWithIncrementalRefresh = true;
+    return decision;
   } catch (error) {
+    const validationError = "message" in error ? error.message : String(error);
     logger.info(
-      `Experiment ${experiment.id} does not support incremental refresh: ${"message" in error ? error.message : error}`,
+      `Experiment ${experiment.id} does not support incremental refresh: ${validationError}`,
     );
-  }
 
-  return getSnapshotQueryRunnerKind({
-    isExperimentCompatibleWithIncrementalRefresh,
-    datasource,
-    experiment,
-    snapshotType,
-    hasSnapshotDimensions: snapshotSettings.dimensions.length > 0,
-    hasMaterializedUnitsTable: !!incrementalRefreshModel?.unitsTableFullName,
-  });
+    return {
+      runnerKind: "results",
+      incrementalFallbackReason: validationError,
+    };
+  }
 }
 
 export type PlannedExperimentSnapshot = {
@@ -1331,6 +1401,8 @@ export type PlannedExperimentSnapshot = {
   useCache: boolean;
   fullRefresh: boolean;
   settingsForSnapshotMetrics: MetricSnapshotSettings[];
+  incrementalFallbackReason: string | null;
+  fullRefreshReason: string | null;
 };
 
 export async function planSnapshot({
@@ -1373,16 +1445,13 @@ export async function planSnapshot({
     ? await context.models.incrementalRefresh.getByExperimentId(experiment.id)
     : null;
 
-  // Full refresh when explicitly requested (!useCache), when no prior
-  // incremental state exists, or when the state doc exists but has no
-  // unitsTableFullName. The latter happens because acquireLock() upserts the
-  // doc before any warehouse table is created — unitsTableFullName is only
-  // populated after a successful CREATE, so a null value means the units
-  // table was never materialized (e.g. lock acquired but first run failed).
-  const fullRefresh =
-    !useCache ||
-    !incrementalRefreshModel ||
-    !incrementalRefreshModel.unitsTableFullName;
+  const {
+    fullRefresh: standardFullRefresh,
+    fullRefreshReason: standardFullRefreshReason,
+  } = resolveFullRefresh(useCache, incrementalRefreshModel);
+  const fullRefresh = type === "standard" ? standardFullRefresh : false;
+  const fullRefreshReason =
+    type === "standard" ? standardFullRefreshReason : null;
 
   const requestedPrecomputedUnitDimensionIds =
     experiment.precomputedUnitDimensionIds ?? [];
@@ -1458,7 +1527,7 @@ export async function planSnapshot({
   };
   const integration = getSourceIntegrationObject(context, datasource, true);
 
-  const runnerKind = await planSnapshotQueryRunner({
+  const runnerPlan = await planSnapshotQueryRunner({
     organization,
     datasource,
     integration,
@@ -1471,12 +1540,26 @@ export async function planSnapshot({
     fullRefresh,
   });
 
+  let resolvedFullRefresh = fullRefresh;
+  let resolvedFullRefreshReason = fullRefreshReason;
+  if (
+    runnerPlan.runnerKind === "incremental" ||
+    runnerPlan.runnerKind === "incremental-exploratory"
+  ) {
+    resolvedFullRefresh =
+      type === "standard" ? (runnerPlan.fullRefresh ?? false) : false;
+    resolvedFullRefreshReason =
+      type === "standard" ? (runnerPlan.fullRefreshReason ?? null) : null;
+  }
+
   return {
     snapshot: data,
-    runnerKind,
+    runnerKind: runnerPlan.runnerKind,
     useCache,
-    fullRefresh,
+    fullRefresh: resolvedFullRefresh,
     settingsForSnapshotMetrics,
+    incrementalFallbackReason: runnerPlan.incrementalFallbackReason,
+    fullRefreshReason: resolvedFullRefreshReason,
   };
 }
 
@@ -1525,6 +1608,8 @@ export async function createSnapshotFromPlan({
   }
 
   let createdSnapshotId: string | null = null;
+  let experimentUpdateExecutionLogger: ExperimentUpdateExecutionLogger | null =
+    null;
 
   try {
     let scheduleNextSnapshot = true;
@@ -1559,6 +1644,31 @@ export async function createSnapshotFromPlan({
     });
     createdSnapshotId = snapshot.id;
 
+    const experimentUpdateLog: ExperimentUpdateLogPlan = {
+      runnerKind: plan.runnerKind,
+      incrementalFallbackReason: plan.incrementalFallbackReason,
+      useCache: plan.useCache,
+      fullRefresh: plan.fullRefresh,
+      fullRefreshReason: plan.fullRefreshReason,
+    };
+
+    const snapshotType = plan.snapshot.type;
+    if (!snapshotType) {
+      throw new Error("Snapshot plan is missing a snapshot type");
+    }
+
+    experimentUpdateExecutionLogger = new ExperimentUpdateExecutionLogger(
+      experimentUpdateLog,
+      {
+        experimentId: experiment.id,
+        snapshotId: snapshot.id,
+        snapshotType,
+        triggeredBy:
+          snapshot.triggeredBy ?? plan.snapshot.triggeredBy ?? "manual",
+        datasource,
+      },
+    );
+
     let queryRunner: ExperimentSnapshotQueryRunner;
     switch (plan.runnerKind) {
       case "incremental-exploratory":
@@ -1590,10 +1700,9 @@ export async function createSnapshotFromPlan({
         throw new Error(`Unknown snapshot runner kind: ${plan.runnerKind}`);
     }
 
-    const snapshotType = plan.snapshot.type;
-    if (!snapshotType) {
-      throw new Error("Snapshot plan is missing a snapshot type");
-    }
+    queryRunner.setExperimentUpdateExecutionLogger(
+      experimentUpdateExecutionLogger,
+    );
 
     const analysisProps = {
       snapshotType,
@@ -1615,7 +1724,7 @@ export async function createSnapshotFromPlan({
         ...analysisProps,
         experimentId: experiment.id,
         incrementalRefreshStartTime: new Date(),
-        fullRefresh: plan.fullRefresh && plan.snapshot.type === "standard",
+        fullRefresh: plan.fullRefresh,
       });
     } else if (plan.runnerKind === "incremental-exploratory") {
       await (
@@ -1680,6 +1789,7 @@ export async function createSnapshotFromPlan({
           status: "error",
           error: e.message,
         },
+        experimentUpdateExecutionLogger,
       });
     }
     throw e;

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -1351,8 +1351,6 @@ async function planSnapshotQueryRunner({
 }): Promise<{
   runnerKind: SnapshotQueryRunnerKind;
   incrementalFallbackReason: string | null;
-  fullRefresh?: boolean;
-  fullRefreshReason?: string | null;
 }> {
   const decision = resolveSnapshotRunner({
     datasource,
@@ -1540,26 +1538,14 @@ export async function planSnapshot({
     fullRefresh,
   });
 
-  let resolvedFullRefresh = fullRefresh;
-  let resolvedFullRefreshReason = fullRefreshReason;
-  if (
-    runnerPlan.runnerKind === "incremental" ||
-    runnerPlan.runnerKind === "incremental-exploratory"
-  ) {
-    resolvedFullRefresh =
-      type === "standard" ? (runnerPlan.fullRefresh ?? false) : false;
-    resolvedFullRefreshReason =
-      type === "standard" ? (runnerPlan.fullRefreshReason ?? null) : null;
-  }
-
   return {
     snapshot: data,
     runnerKind: runnerPlan.runnerKind,
-    useCache,
-    fullRefresh: resolvedFullRefresh,
-    settingsForSnapshotMetrics,
     incrementalFallbackReason: runnerPlan.incrementalFallbackReason,
-    fullRefreshReason: resolvedFullRefreshReason,
+    useCache,
+    fullRefresh,
+    fullRefreshReason,
+    settingsForSnapshotMetrics,
   };
 }
 

--- a/packages/back-end/test/models/ExperimentSnapshotModel.test.ts
+++ b/packages/back-end/test/models/ExperimentSnapshotModel.test.ts
@@ -22,6 +22,7 @@ import { updateExperimentAnalysisSummary } from "back-end/src/services/experimen
 import { notifyExperimentChange } from "back-end/src/services/experimentNotifications";
 import { updateExperimentTimeSeries } from "back-end/src/services/experimentTimeSeries";
 import { runEagerExperimentAndUnitDimensionsAnalyses } from "back-end/src/services/experimentDimensionAnalyses";
+import { ExperimentUpdateExecutionLogger } from "back-end/src/services/experimentUpdateExecutionLogger";
 import { snapshotFactory } from "back-end/test/factories/Snapshot.factory";
 
 jest.mock("back-end/src/models/ExperimentModel", () => ({
@@ -759,6 +760,124 @@ describe("ExperimentSnapshotModel", () => {
           ]),
         }),
       });
+    });
+
+    it("logs experiment_updated for error snapshots without propagation side effects", async () => {
+      const info = jest.fn();
+      const context = getSnapshotUpdateContext();
+      context.logger = {
+        info,
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+      } as never;
+
+      const snapshot = makeSnapshotWithMetric("snp_error_log");
+      snapshot.type = "standard";
+      await createExperimentSnapshotModel({ data: snapshot, context });
+
+      const executionLogger = new ExperimentUpdateExecutionLogger(
+        {
+          runnerKind: "results",
+          incrementalFallbackReason: null,
+          useCache: true,
+          fullRefresh: false,
+          fullRefreshReason: null,
+        },
+        {
+          experimentId: snapshot.experiment,
+          snapshotId: snapshot.id,
+          snapshotType: "standard",
+          triggeredBy: "schedule",
+          datasource: { id: "ds_1", type: "bigquery" } as never,
+        },
+      );
+
+      await updateSnapshot({
+        context,
+        id: snapshot.id,
+        updates: {
+          status: "error",
+          error: "Failed to run queries",
+        },
+        experimentUpdateExecutionLogger: executionLogger,
+      });
+
+      expect(getExperimentById).not.toHaveBeenCalled();
+      expect(updateExperimentAnalysisSummary).not.toHaveBeenCalled();
+      expect(info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "experiment_updated",
+          snapshotStatus: "error",
+          error: "Failed to run queries",
+          timingsMs: expect.objectContaining({
+            persistSnapshot: expect.any(Number),
+            propagateSnapshot: 0,
+          }),
+        }),
+        "Experiment update completed",
+      );
+    });
+
+    it("logs experiment_updated for exploratory success without propagation", async () => {
+      const info = jest.fn();
+      const context = getSnapshotUpdateContext();
+      context.logger = {
+        info,
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+      } as never;
+
+      const snapshot = makeSnapshotWithMetric("snp_exploratory_log");
+      snapshot.type = "exploratory";
+      await createExperimentSnapshotModel({ data: snapshot, context });
+
+      const executionLogger = new ExperimentUpdateExecutionLogger(
+        {
+          runnerKind: "incremental-exploratory",
+          incrementalFallbackReason: null,
+          useCache: true,
+          fullRefresh: false,
+          fullRefreshReason: null,
+        },
+        {
+          experimentId: snapshot.experiment,
+          snapshotId: snapshot.id,
+          snapshotType: "exploratory",
+          triggeredBy: "manual",
+          datasource: { id: "ds_1", type: "bigquery" } as never,
+        },
+      );
+
+      await updateSnapshot({
+        context,
+        id: snapshot.id,
+        updates: {
+          status: "success",
+          analyses: [
+            makeAnalysis({
+              settings: makeAnalysisSettings(),
+              value: 10,
+            }),
+          ],
+        },
+        experimentUpdateExecutionLogger: executionLogger,
+      });
+
+      expect(updateExperimentAnalysisSummary).not.toHaveBeenCalled();
+      expect(info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "experiment_updated",
+          snapshotType: "exploratory",
+          snapshotStatus: "success",
+          timingsMs: expect.objectContaining({
+            persistSnapshot: expect.any(Number),
+            propagateSnapshot: 0,
+          }),
+        }),
+        "Experiment update completed",
+      );
     });
 
     it("passes populated chunked analyses to post-success side effects", async () => {

--- a/packages/back-end/test/services/experiment-update-log.test.ts
+++ b/packages/back-end/test/services/experiment-update-log.test.ts
@@ -1,0 +1,172 @@
+import { ExperimentUpdateExecutionLogger } from "back-end/src/services/experimentUpdateExecutionLogger";
+
+describe("ExperimentUpdateExecutionLogger", () => {
+  const plan = {
+    runnerKind: "incremental" as const,
+    useCache: false,
+    fullRefresh: true,
+    fullRefreshReason:
+      "No prior incremental refresh state for this experiment.",
+    incrementalFallbackReason: null,
+  };
+
+  const meta = {
+    experimentId: "exp_1",
+    snapshotId: "snap_1",
+    snapshotType: "standard" as const,
+    triggeredBy: "schedule" as const,
+    datasource: { id: "ds_1", type: "bigquery" } as const,
+  };
+
+  it("accumulates phase timings via withTiming and boundary marks", async () => {
+    const logger = new ExperimentUpdateExecutionLogger(plan, meta);
+    await logger.withTiming("generateSql", async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    logger.startPhase("runQueries");
+    logger.endPhase("runQueries");
+    await logger.withTiming("analyze", async () => {});
+    await logger.withTiming("persistSnapshot", async () => {});
+    logger.startPhase("propagateSnapshot");
+    logger.endPhase("propagateSnapshot");
+
+    expect(logger.getTimings()).toEqual({
+      generateSql: expect.any(Number),
+      runQueries: expect.any(Number),
+      analyze: expect.any(Number),
+      persistSnapshot: expect.any(Number),
+      propagateSnapshot: expect.any(Number),
+      total: expect.any(Number),
+    });
+    expect(logger.getTimings().generateSql).toBeGreaterThanOrEqual(10);
+  });
+
+  it("records phase timings via startPhase and endPhase", async () => {
+    const logger = new ExperimentUpdateExecutionLogger(plan, meta);
+    logger.startPhase("generateSql");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    logger.endPhase("generateSql");
+    logger.startPhase("runQueries");
+    logger.endPhase("runQueries");
+
+    expect(logger.getTimings().generateSql).toBeGreaterThanOrEqual(10);
+    expect(logger.getTimings().runQueries).toBeGreaterThanOrEqual(0);
+  });
+
+  it("starts a phase only once until ended", () => {
+    const logger = new ExperimentUpdateExecutionLogger(plan, meta);
+    logger.startPhase("analyze");
+    const timingsAfterFirstStart = logger.getTimings().analyze;
+
+    logger.startPhase("analyze");
+    expect(logger.getTimings().analyze).toBe(timingsAfterFirstStart);
+
+    logger.endPhase("analyze");
+    expect(logger.getTimings().analyze).toBeGreaterThanOrEqual(0);
+  });
+
+  it("records analyze timing even when the wrapped fn throws", async () => {
+    const logger = new ExperimentUpdateExecutionLogger(plan, meta);
+
+    await expect(
+      logger.withTiming("analyze", async () => {
+        throw new Error("analysis failed");
+      }),
+    ).rejects.toThrow("analysis failed");
+
+    expect(logger.getTimings().analyze).toBeGreaterThanOrEqual(0);
+  });
+
+  it("freezes total when propagateSnapshot ends", async () => {
+    const logger = new ExperimentUpdateExecutionLogger(plan, meta);
+    await logger.withTiming("generateSql", async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    logger.endPhase("propagateSnapshot");
+
+    const timingsAfterFreeze = logger.getTimings();
+    expect(timingsAfterFreeze.total).toBeGreaterThanOrEqual(10);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(logger.getTimings().total).toBe(timingsAfterFreeze.total);
+  });
+
+  it("freezes total when logUpdateCompleted runs without propagateSnapshot", async () => {
+    const logger = new ExperimentUpdateExecutionLogger(plan, meta);
+    await logger.withTiming("persistSnapshot", async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    const info = jest.fn();
+    logger.logUpdateCompleted({ logger: { info } } as never, {
+      snapshotStatus: "error",
+      error: "query failed",
+    });
+
+    expect(logger.getTimings().total).toBeGreaterThanOrEqual(10);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(logger.getTimings().total).toBeGreaterThanOrEqual(10);
+  });
+
+  it("logs only once on terminal snapshot status", () => {
+    const logger = new ExperimentUpdateExecutionLogger(plan, meta);
+    const info = jest.fn();
+    const context = { logger: { info } } as const;
+
+    logger.logUpdateCompleted(context, { snapshotStatus: "running" });
+    logger.logUpdateCompleted(context, { snapshotStatus: "success" });
+    logger.logUpdateCompleted(context, { snapshotStatus: "success" });
+
+    expect(info).toHaveBeenCalledTimes(1);
+    expect(info.mock.calls[0][0]).toMatchObject({
+      event: "experiment_updated",
+      snapshotStatus: "success",
+      timingsMs: expect.objectContaining({
+        generateSql: 0,
+        analyze: 0,
+      }),
+    });
+  });
+
+  it("emits structured fields including plan metadata and execution mode", () => {
+    const logger = new ExperimentUpdateExecutionLogger(
+      {
+        runnerKind: "results",
+        incrementalFallbackReason: "metric not compatible",
+        useCache: true,
+        fullRefresh: false,
+        fullRefreshReason: null,
+      },
+      {
+        ...meta,
+        snapshotType: "exploratory",
+        triggeredBy: "manual",
+      },
+    );
+    logger.execution.incrementalRefreshMode = "incremental";
+    const info = jest.fn();
+
+    logger.logUpdateCompleted({ logger: { info } } as never, {
+      snapshotStatus: "error",
+      error: "Failed to run queries",
+    });
+
+    expect(info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "experiment_updated",
+        experimentId: "exp_1",
+        snapshotId: "snap_1",
+        snapshotType: "exploratory",
+        triggeredBy: "manual",
+        snapshotStatus: "error",
+        error: "Failed to run queries",
+        runnerKind: "results",
+        incrementalFallbackReason: "metric not compatible",
+        plannedFullRefresh: false,
+        fullRefreshReason: null,
+        incrementalRefreshMode: "incremental",
+        timingsMs: expect.any(Object),
+      }),
+      "Experiment update completed",
+    );
+  });
+});

--- a/packages/back-end/test/services/snapshot-lifecycle.test.ts
+++ b/packages/back-end/test/services/snapshot-lifecycle.test.ts
@@ -51,6 +51,7 @@ jest.mock("back-end/src/queryRunners/ExperimentResultsQueryRunner", () => ({
     .mockImplementation((_context, snapshot) => ({
       model: snapshot,
       startAnalysis: jest.fn(),
+      setExperimentUpdateExecutionLogger: jest.fn(),
     })),
 }));
 
@@ -62,6 +63,7 @@ jest.mock(
       .mockImplementation((_context, snapshot) => ({
         model: snapshot,
         startAnalysis: jest.fn(),
+        setExperimentUpdateExecutionLogger: jest.fn(),
       })),
   }),
 );
@@ -74,6 +76,7 @@ jest.mock(
       .mockImplementation((_context, snapshot) => ({
         model: snapshot,
         startAnalysis: jest.fn(),
+        setExperimentUpdateExecutionLogger: jest.fn(),
       })),
   }),
 );
@@ -109,6 +112,12 @@ function makeContext(): ApiReqContext {
     org: {
       id: "org_123",
       settings: {},
+    },
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
     },
     models: {
       metricGroups: {
@@ -210,6 +219,8 @@ function makePlan(
     useCache: true,
     fullRefresh: false,
     settingsForSnapshotMetrics: [] as MetricSnapshotSettings[],
+    incrementalFallbackReason: null,
+    fullRefreshReason: null,
     ...overrides,
   };
 }
@@ -260,6 +271,11 @@ describe("snapshot lifecycle", () => {
     );
 
     const queryRunner = resultsQueryRunnerMock.mock.results[0].value;
+    expect(queryRunner.setExperimentUpdateExecutionLogger).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plan: expect.objectContaining({ runnerKind: "results" }),
+      }),
+    );
     expect(queryRunner.startAnalysis).toHaveBeenCalledWith(
       expect.objectContaining({
         snapshotType: "standard",

--- a/packages/back-end/test/services/snapshot-planning.test.ts
+++ b/packages/back-end/test/services/snapshot-planning.test.ts
@@ -137,28 +137,11 @@ describe("snapshot planning", () => {
     },
   } as unknown as DataSourceInterface;
 
-  it("forces the standard results runner when incremental refresh is disabled", () => {
-    const experiment = { type: "standard" } as unknown as ExperimentInterface;
-
-    expect(
-      getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: false,
-        isExperimentCompatibleWithIncrementalRefresh: true,
-        datasource: incrementalDatasource,
-        experiment,
-        snapshotType: "standard",
-        hasSnapshotDimensions: false,
-        hasMaterializedUnitsTable: true,
-      }),
-    ).toBe("results");
-  });
-
   it("uses the incremental runner for eligible standard snapshots", () => {
     const experiment = { type: "standard" } as unknown as ExperimentInterface;
 
     expect(
       getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: true,
         isExperimentCompatibleWithIncrementalRefresh: true,
         datasource: incrementalDatasource,
         experiment,
@@ -174,7 +157,6 @@ describe("snapshot planning", () => {
 
     expect(
       getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: true,
         isExperimentCompatibleWithIncrementalRefresh: true,
         datasource: incrementalDatasource,
         experiment,
@@ -190,7 +172,6 @@ describe("snapshot planning", () => {
 
     expect(
       getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: true,
         isExperimentCompatibleWithIncrementalRefresh: true,
         datasource: incrementalDatasource,
         experiment,
@@ -208,7 +189,6 @@ describe("snapshot planning", () => {
 
     expect(
       getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: true,
         isExperimentCompatibleWithIncrementalRefresh: true,
         datasource: incrementalDatasource,
         experiment,
@@ -232,7 +212,6 @@ describe("snapshot planning", () => {
       settingsForSnapshotMetrics: [],
       metricMap: new Map<string, ExperimentMetricInterface>(),
       factTableMap: new Map() as FactTableMap,
-      allowIncrementalRefresh: false,
     });
 
     expect(plan.runnerKind).toBe("results");

--- a/packages/back-end/test/services/snapshot-planning.test.ts
+++ b/packages/back-end/test/services/snapshot-planning.test.ts
@@ -3,10 +3,8 @@ import { ExperimentInterface } from "shared/types/experiment";
 import { DataSourceInterface } from "shared/types/datasource";
 import { ExperimentSnapshotAnalysisSettings } from "shared/types/experiment-snapshot";
 import { ApiReqContext } from "back-end/types/api";
-import {
-  getSnapshotQueryRunnerKind,
-  planSnapshot,
-} from "back-end/src/services/experiments";
+import { validateIncrementalPipeline } from "back-end/src/enterprise/services/data-pipeline";
+import { planSnapshot } from "back-end/src/services/experiments";
 import { updateExperiment } from "back-end/src/models/ExperimentModel";
 import { createExperimentSnapshotModel } from "back-end/src/models/ExperimentSnapshotModel";
 import { getDataSourceById } from "back-end/src/models/DataSourceModel";
@@ -35,6 +33,10 @@ jest.mock("back-end/src/enterprise/services/dashboards", () => ({
   updateExperimentDashboards: jest.fn(),
 }));
 
+jest.mock("back-end/src/enterprise/services/data-pipeline", () => ({
+  validateIncrementalPipeline: jest.fn(),
+}));
+
 const updateExperimentMock = updateExperiment as jest.MockedFunction<
   typeof updateExperiment
 >;
@@ -52,6 +54,10 @@ const getSourceIntegrationObjectMock =
 const updateExperimentDashboardsMock =
   updateExperimentDashboards as jest.MockedFunction<
     typeof updateExperimentDashboards
+  >;
+const validateIncrementalPipelineMock =
+  validateIncrementalPipeline as jest.MockedFunction<
+    typeof validateIncrementalPipeline
   >;
 
 function makeContext(): ApiReqContext {
@@ -128,77 +134,6 @@ describe("snapshot planning", () => {
     getSourceIntegrationObjectMock.mockReturnValue({} as never);
   });
 
-  const incrementalDatasource = {
-    settings: {
-      pipelineSettings: {
-        allowWriting: true,
-        mode: "incremental",
-      },
-    },
-  } as unknown as DataSourceInterface;
-
-  it("uses the incremental runner for eligible standard snapshots", () => {
-    const experiment = { type: "standard" } as unknown as ExperimentInterface;
-
-    expect(
-      getSnapshotQueryRunnerKind({
-        isExperimentCompatibleWithIncrementalRefresh: true,
-        datasource: incrementalDatasource,
-        experiment,
-        snapshotType: "standard",
-        hasSnapshotDimensions: false,
-        hasMaterializedUnitsTable: true,
-      }),
-    ).toBe("incremental");
-  });
-
-  it("uses the exploratory incremental runner for eligible exploratory snapshots", () => {
-    const experiment = { type: "standard" } as unknown as ExperimentInterface;
-
-    expect(
-      getSnapshotQueryRunnerKind({
-        isExperimentCompatibleWithIncrementalRefresh: true,
-        datasource: incrementalDatasource,
-        experiment,
-        snapshotType: "exploratory",
-        hasSnapshotDimensions: true,
-        hasMaterializedUnitsTable: true,
-      }),
-    ).toBe("incremental-exploratory");
-  });
-
-  it("uses the incremental runner for exploratory snapshots with no dimensions", () => {
-    const experiment = { type: "standard" } as unknown as ExperimentInterface;
-
-    expect(
-      getSnapshotQueryRunnerKind({
-        isExperimentCompatibleWithIncrementalRefresh: true,
-        datasource: incrementalDatasource,
-        experiment,
-        snapshotType: "exploratory",
-        hasSnapshotDimensions: false,
-        hasMaterializedUnitsTable: true,
-      }),
-    ).toBe("incremental");
-  });
-
-  it("falls back to the standard results runner for unsupported experiment types", () => {
-    const experiment = {
-      type: "multi-armed-bandit",
-    } as unknown as ExperimentInterface;
-
-    expect(
-      getSnapshotQueryRunnerKind({
-        isExperimentCompatibleWithIncrementalRefresh: true,
-        datasource: incrementalDatasource,
-        experiment,
-        snapshotType: "standard",
-        hasSnapshotDimensions: false,
-        hasMaterializedUnitsTable: true,
-      }),
-    ).toBe("results");
-  });
-
   it("plans a draft snapshot without persisting or mutating experiment state", async () => {
     const plan = await planSnapshot({
       experiment: makeExperiment(),
@@ -215,11 +150,106 @@ describe("snapshot planning", () => {
     });
 
     expect(plan.runnerKind).toBe("results");
+    // useCache: false → full refresh, with a free-form reason explaining why.
+    expect(plan.fullRefresh).toBe(true);
+    expect(plan.fullRefreshReason).toBe("Full refresh explicitly requested.");
     expect(plan.snapshot.status).toBe("running");
     expect(plan.snapshot.triggeredBy).toBe("manual-dashboard");
     expect(plan.snapshot.analyses).toHaveLength(1);
     expect(createExperimentSnapshotModelMock).not.toHaveBeenCalled();
     expect(updateExperimentMock).not.toHaveBeenCalled();
     expect(updateExperimentDashboardsMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces pipeline validation errors as incremental fallback reasons", async () => {
+    getDataSourceByIdMock.mockResolvedValue(
+      makeDatasource({
+        settings: {
+          queries: {},
+          pipelineSettings: {
+            allowWriting: true,
+            mode: "incremental",
+          },
+        },
+      }),
+    );
+    validateIncrementalPipelineMock.mockRejectedValue(
+      new Error("metric not compatible"),
+    );
+
+    const context = makeContext();
+    context.models.incrementalRefresh = {
+      getByExperimentId: jest.fn().mockResolvedValue({
+        unitsTableFullName: "db.schema.units_exp_123",
+      }),
+    } as never;
+
+    const plan = await planSnapshot({
+      experiment: makeExperiment(),
+      context,
+      type: "standard",
+      triggeredBy: "manual-dashboard",
+      phaseIndex: 0,
+      useCache: true,
+      defaultAnalysisSettings: makeAnalysisSettings(),
+      additionalAnalysisSettings: [],
+      settingsForSnapshotMetrics: [],
+      metricMap: new Map<string, ExperimentMetricInterface>(),
+      factTableMap: new Map() as FactTableMap,
+    });
+
+    expect(validateIncrementalPipelineMock).toHaveBeenCalled();
+    expect(plan.runnerKind).toBe("results");
+    expect(plan.incrementalFallbackReason).toBe("metric not compatible");
+  });
+
+  it("falls back to the results runner when incremental state is outdated", async () => {
+    getDataSourceByIdMock.mockResolvedValue(
+      makeDatasource({
+        settings: {
+          queries: {},
+          pipelineSettings: {
+            allowWriting: true,
+            mode: "incremental",
+          },
+        },
+      }),
+    );
+    const staleConfigMessage =
+      "The experiment configuration is outdated. Please run a Full Refresh.";
+    validateIncrementalPipelineMock.mockRejectedValue(
+      new Error(staleConfigMessage),
+    );
+
+    const context = makeContext();
+    context.models.incrementalRefresh = {
+      getByExperimentId: jest.fn().mockResolvedValue({
+        unitsTableFullName: "db.schema.units_exp_123",
+        experimentSettingsHash: "stale_hash",
+      }),
+    } as never;
+
+    const plan = await planSnapshot({
+      experiment: makeExperiment(),
+      context,
+      type: "standard",
+      triggeredBy: "manual-dashboard",
+      phaseIndex: 0,
+      useCache: true,
+      defaultAnalysisSettings: makeAnalysisSettings(),
+      additionalAnalysisSettings: [],
+      settingsForSnapshotMetrics: [],
+      metricMap: new Map<string, ExperimentMetricInterface>(),
+      factTableMap: new Map() as FactTableMap,
+    });
+
+    expect(validateIncrementalPipelineMock).toHaveBeenCalledWith(
+      expect.objectContaining({ analysisType: "main-update" }),
+    );
+    expect(validateIncrementalPipelineMock).toHaveBeenCalledTimes(1);
+    expect(plan.runnerKind).toBe("results");
+    expect(plan.incrementalFallbackReason).toBe(staleConfigMessage);
+    expect(plan.fullRefresh).toBe(false);
+    expect(plan.fullRefreshReason).toBeNull();
   });
 });

--- a/packages/back-end/test/services/snapshot-planning.test.ts
+++ b/packages/back-end/test/services/snapshot-planning.test.ts
@@ -203,6 +203,53 @@ describe("snapshot planning", () => {
     expect(plan.incrementalFallbackReason).toBe("metric not compatible");
   });
 
+  it("preserves the computed full refresh when using the incremental runner on a first run", async () => {
+    getDataSourceByIdMock.mockResolvedValue(
+      makeDatasource({
+        settings: {
+          queries: {},
+          pipelineSettings: {
+            allowWriting: true,
+            mode: "incremental",
+          },
+        },
+      }),
+    );
+    validateIncrementalPipelineMock.mockResolvedValue(undefined as never);
+
+    const context = makeContext();
+    // First run: no prior incremental state, so the warehouse units table
+    // does not exist yet and a full refresh is required.
+    context.models.incrementalRefresh = {
+      getByExperimentId: jest.fn().mockResolvedValue(null),
+    } as never;
+
+    const plan = await planSnapshot({
+      experiment: makeExperiment(),
+      context,
+      type: "standard",
+      triggeredBy: "manual-dashboard",
+      phaseIndex: 0,
+      useCache: true,
+      defaultAnalysisSettings: makeAnalysisSettings(),
+      additionalAnalysisSettings: [],
+      settingsForSnapshotMetrics: [],
+      metricMap: new Map<string, ExperimentMetricInterface>(),
+      factTableMap: new Map() as FactTableMap,
+    });
+
+    expect(plan.runnerKind).toBe("incremental");
+    // The incremental runner must not discard the computed full refresh, or it
+    // would attempt an incremental update against a non-existent units table.
+    expect(plan.fullRefresh).toBe(true);
+    expect(plan.fullRefreshReason).toBe(
+      "No prior incremental refresh state for this experiment.",
+    );
+    expect(validateIncrementalPipelineMock).toHaveBeenCalledWith(
+      expect.objectContaining({ analysisType: "main-fullRefresh" }),
+    );
+  });
+
   it("falls back to the results runner when incremental state is outdated", async () => {
     getDataSourceByIdMock.mockResolvedValue(
       makeDatasource({

--- a/packages/back-end/test/services/snapshot-query-runner-kind.test.ts
+++ b/packages/back-end/test/services/snapshot-query-runner-kind.test.ts
@@ -1,6 +1,6 @@
 import { DataSourceInterface } from "shared/types/datasource";
 import { ExperimentInterface } from "shared/types/experiment";
-import { getSnapshotQueryRunnerKind } from "back-end/src/services/experiments";
+import { resolveSnapshotRunner } from "back-end/src/services/experiments";
 
 function makeDatasource(
   pipelineOverrides: Partial<
@@ -32,129 +32,121 @@ function makeExperiment(
   } as unknown as ExperimentInterface;
 }
 
-describe("getSnapshotQueryRunnerKind", () => {
+describe("resolveSnapshotRunner", () => {
   it("returns 'incremental' for a standard snapshot when all conditions are met", () => {
     expect(
-      getSnapshotQueryRunnerKind({
-        isExperimentCompatibleWithIncrementalRefresh: true,
+      resolveSnapshotRunner({
         datasource: makeDatasource(),
         experiment: makeExperiment(),
         snapshotType: "standard",
         hasSnapshotDimensions: false,
         hasMaterializedUnitsTable: true,
-      }),
+      }).runnerKind,
     ).toBe("incremental");
   });
 
   it("returns 'incremental-exploratory' for an exploratory snapshot when all conditions are met", () => {
     expect(
-      getSnapshotQueryRunnerKind({
-        isExperimentCompatibleWithIncrementalRefresh: true,
+      resolveSnapshotRunner({
         datasource: makeDatasource(),
         experiment: makeExperiment(),
         snapshotType: "exploratory",
         hasSnapshotDimensions: true,
         hasMaterializedUnitsTable: true,
-      }),
+      }).runnerKind,
     ).toBe("incremental-exploratory");
   });
 
   it("returns 'incremental' for exploratory snapshots without dimensions when the units table has been materialized", () => {
     expect(
-      getSnapshotQueryRunnerKind({
-        isExperimentCompatibleWithIncrementalRefresh: true,
+      resolveSnapshotRunner({
         datasource: makeDatasource(),
         experiment: makeExperiment(),
         snapshotType: "exploratory",
         hasSnapshotDimensions: false,
         hasMaterializedUnitsTable: true,
-      }),
+      }).runnerKind,
     ).toBe("incremental");
   });
 
   it("returns 'results' for exploratory snapshots without dimensions when the units table has not been materialized", () => {
     expect(
-      getSnapshotQueryRunnerKind({
-        isExperimentCompatibleWithIncrementalRefresh: true,
+      resolveSnapshotRunner({
         datasource: makeDatasource(),
         experiment: makeExperiment(),
         snapshotType: "exploratory",
         hasSnapshotDimensions: false,
         hasMaterializedUnitsTable: false,
       }),
-    ).toBe("results");
+    ).toEqual({
+      runnerKind: "results",
+      incrementalFallbackReason:
+        "No materialized units table yet for this dimension-less exploratory snapshot.",
+    });
   });
 
   it("returns 'incremental' for standard snapshots even when the units table has not been materialized (full refresh will create it)", () => {
     expect(
-      getSnapshotQueryRunnerKind({
-        isExperimentCompatibleWithIncrementalRefresh: true,
+      resolveSnapshotRunner({
         datasource: makeDatasource(),
         experiment: makeExperiment(),
         snapshotType: "standard",
         hasSnapshotDimensions: false,
         hasMaterializedUnitsTable: false,
-      }),
+      }).runnerKind,
     ).toBe("incremental");
   });
 
-  it("returns 'results' when experiment is not compatible with incremental refresh", () => {
-    expect(
-      getSnapshotQueryRunnerKind({
-        isExperimentCompatibleWithIncrementalRefresh: false,
-        datasource: makeDatasource(),
-        experiment: makeExperiment(),
-        snapshotType: "standard",
-        hasSnapshotDimensions: false,
-        hasMaterializedUnitsTable: true,
-      }),
-    ).toBe("results");
-  });
-
-  it("returns 'results' when datasource pipeline mode is not incremental", () => {
+  it("returns 'results' with no fallback reason when datasource pipeline mode is not incremental", () => {
     const datasource = makeDatasource({ mode: "parallel" as never });
     expect(
-      getSnapshotQueryRunnerKind({
-        isExperimentCompatibleWithIncrementalRefresh: true,
+      resolveSnapshotRunner({
         datasource,
         experiment: makeExperiment(),
         snapshotType: "standard",
         hasSnapshotDimensions: false,
         hasMaterializedUnitsTable: true,
       }),
-    ).toBe("results");
+    ).toEqual({
+      runnerKind: "results",
+      incrementalFallbackReason: null,
+    });
   });
 
-  it("returns 'results' when experiment is excluded from incremental refresh", () => {
+  it("returns 'results' with no fallback reason when experiment is excluded from incremental refresh", () => {
     const datasource = makeDatasource({
       excludedExperimentIds: ["exp_123"],
     });
     expect(
-      getSnapshotQueryRunnerKind({
-        isExperimentCompatibleWithIncrementalRefresh: true,
+      resolveSnapshotRunner({
         datasource,
         experiment: makeExperiment(),
         snapshotType: "standard",
         hasSnapshotDimensions: false,
         hasMaterializedUnitsTable: true,
       }),
-    ).toBe("results");
+    ).toEqual({
+      runnerKind: "results",
+      incrementalFallbackReason: null,
+    });
   });
 
-  it("returns 'results' when includedExperimentIds is set but does not include the experiment", () => {
+  it("returns 'results' with no fallback reason when includedExperimentIds is set but does not include the experiment", () => {
     const datasource = makeDatasource({
       includedExperimentIds: ["exp_other"],
     });
     expect(
-      getSnapshotQueryRunnerKind({
-        isExperimentCompatibleWithIncrementalRefresh: true,
+      resolveSnapshotRunner({
         datasource,
         experiment: makeExperiment(),
         snapshotType: "standard",
         hasSnapshotDimensions: false,
         hasMaterializedUnitsTable: true,
       }),
-    ).toBe("results");
+    ).toEqual({
+      runnerKind: "results",
+      incrementalFallbackReason: null,
+    });
   });
 
   it("returns 'incremental' when includedExperimentIds includes the experiment", () => {
@@ -162,40 +154,41 @@ describe("getSnapshotQueryRunnerKind", () => {
       includedExperimentIds: ["exp_123"],
     });
     expect(
-      getSnapshotQueryRunnerKind({
-        isExperimentCompatibleWithIncrementalRefresh: true,
+      resolveSnapshotRunner({
         datasource,
         experiment: makeExperiment(),
         snapshotType: "standard",
         hasSnapshotDimensions: false,
         hasMaterializedUnitsTable: true,
-      }),
+      }).runnerKind,
     ).toBe("incremental");
   });
 
   it("returns 'results' for multi-armed-bandit experiments", () => {
     expect(
-      getSnapshotQueryRunnerKind({
-        isExperimentCompatibleWithIncrementalRefresh: true,
+      resolveSnapshotRunner({
         datasource: makeDatasource(),
         experiment: makeExperiment({ type: "multi-armed-bandit" }),
         snapshotType: "standard",
         hasSnapshotDimensions: false,
         hasMaterializedUnitsTable: true,
       }),
-    ).toBe("results");
+    ).toEqual({
+      runnerKind: "results",
+      incrementalFallbackReason:
+        'Experiment type "multi-armed-bandit" is not supported for incremental refresh.',
+    });
   });
 
   it("returns 'incremental' when experiment.type is undefined (legacy)", () => {
     expect(
-      getSnapshotQueryRunnerKind({
-        isExperimentCompatibleWithIncrementalRefresh: true,
+      resolveSnapshotRunner({
         datasource: makeDatasource(),
         experiment: makeExperiment({ type: undefined }),
         snapshotType: "standard",
         hasSnapshotDimensions: false,
         hasMaterializedUnitsTable: true,
-      }),
+      }).runnerKind,
     ).toBe("incremental");
   });
 
@@ -205,49 +198,33 @@ describe("getSnapshotQueryRunnerKind", () => {
       incrementalOptInExperimentIds: ["exp_123"],
     });
     expect(
-      getSnapshotQueryRunnerKind({
-        isExperimentCompatibleWithIncrementalRefresh: true,
+      resolveSnapshotRunner({
         datasource,
         experiment: makeExperiment(),
         snapshotType: "standard",
         hasSnapshotDimensions: false,
         hasMaterializedUnitsTable: true,
-      }),
+      }).runnerKind,
     ).toBe("incremental");
   });
 
-  it("returns 'results' (ephemeral fallback) for an opted-in experiment when incremental is not compatible", () => {
-    const datasource = makeDatasource({
-      mode: "ephemeral",
-      incrementalOptInExperimentIds: ["exp_123"],
-    });
-    expect(
-      getSnapshotQueryRunnerKind({
-        isExperimentCompatibleWithIncrementalRefresh: false,
-        datasource,
-        experiment: makeExperiment(),
-        snapshotType: "standard",
-        hasSnapshotDimensions: false,
-        hasMaterializedUnitsTable: false,
-      }),
-    ).toBe("results");
-  });
-
-  it("returns 'results' for an experiment that is not in the opt-in list when default mode is ephemeral", () => {
+  it("returns 'results' with no fallback reason for an experiment that is not in the opt-in list when default mode is ephemeral", () => {
     const datasource = makeDatasource({
       mode: "ephemeral",
       incrementalOptInExperimentIds: ["exp_other"],
     });
     expect(
-      getSnapshotQueryRunnerKind({
-        isExperimentCompatibleWithIncrementalRefresh: true,
+      resolveSnapshotRunner({
         datasource,
         experiment: makeExperiment(),
         snapshotType: "standard",
         hasSnapshotDimensions: false,
         hasMaterializedUnitsTable: true,
       }),
-    ).toBe("results");
+    ).toEqual({
+      runnerKind: "results",
+      incrementalFallbackReason: null,
+    });
   });
 
   it("ignores opt-in when mode is 'incremental' so excludedExperimentIds wins", () => {
@@ -257,32 +234,33 @@ describe("getSnapshotQueryRunnerKind", () => {
       incrementalOptInExperimentIds: ["exp_123"],
     });
     expect(
-      getSnapshotQueryRunnerKind({
-        isExperimentCompatibleWithIncrementalRefresh: true,
+      resolveSnapshotRunner({
         datasource,
         experiment: makeExperiment(),
         snapshotType: "standard",
         hasSnapshotDimensions: false,
         hasMaterializedUnitsTable: true,
-      }),
+      }).runnerKind,
     ).toBe("results");
   });
 
-  it("returns 'results' when allowWriting is false even with opt-in", () => {
+  it("returns 'results' with no fallback reason when allowWriting is false even with opt-in", () => {
     const datasource = makeDatasource({
       allowWriting: false,
       mode: "ephemeral",
       incrementalOptInExperimentIds: ["exp_123"],
     });
     expect(
-      getSnapshotQueryRunnerKind({
-        isExperimentCompatibleWithIncrementalRefresh: true,
+      resolveSnapshotRunner({
         datasource,
         experiment: makeExperiment(),
         snapshotType: "standard",
         hasSnapshotDimensions: false,
         hasMaterializedUnitsTable: true,
       }),
-    ).toBe("results");
+    ).toEqual({
+      runnerKind: "results",
+      incrementalFallbackReason: null,
+    });
   });
 });

--- a/packages/back-end/test/services/snapshot-query-runner-kind.test.ts
+++ b/packages/back-end/test/services/snapshot-query-runner-kind.test.ts
@@ -36,7 +36,6 @@ describe("getSnapshotQueryRunnerKind", () => {
   it("returns 'incremental' for a standard snapshot when all conditions are met", () => {
     expect(
       getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: true,
         isExperimentCompatibleWithIncrementalRefresh: true,
         datasource: makeDatasource(),
         experiment: makeExperiment(),
@@ -50,7 +49,6 @@ describe("getSnapshotQueryRunnerKind", () => {
   it("returns 'incremental-exploratory' for an exploratory snapshot when all conditions are met", () => {
     expect(
       getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: true,
         isExperimentCompatibleWithIncrementalRefresh: true,
         datasource: makeDatasource(),
         experiment: makeExperiment(),
@@ -64,7 +62,6 @@ describe("getSnapshotQueryRunnerKind", () => {
   it("returns 'incremental' for exploratory snapshots without dimensions when the units table has been materialized", () => {
     expect(
       getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: true,
         isExperimentCompatibleWithIncrementalRefresh: true,
         datasource: makeDatasource(),
         experiment: makeExperiment(),
@@ -78,7 +75,6 @@ describe("getSnapshotQueryRunnerKind", () => {
   it("returns 'results' for exploratory snapshots without dimensions when the units table has not been materialized", () => {
     expect(
       getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: true,
         isExperimentCompatibleWithIncrementalRefresh: true,
         datasource: makeDatasource(),
         experiment: makeExperiment(),
@@ -92,7 +88,6 @@ describe("getSnapshotQueryRunnerKind", () => {
   it("returns 'incremental' for standard snapshots even when the units table has not been materialized (full refresh will create it)", () => {
     expect(
       getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: true,
         isExperimentCompatibleWithIncrementalRefresh: true,
         datasource: makeDatasource(),
         experiment: makeExperiment(),
@@ -103,24 +98,9 @@ describe("getSnapshotQueryRunnerKind", () => {
     ).toBe("incremental");
   });
 
-  it("returns 'results' when allowIncrementalRefresh is false", () => {
-    expect(
-      getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: false,
-        isExperimentCompatibleWithIncrementalRefresh: true,
-        datasource: makeDatasource(),
-        experiment: makeExperiment(),
-        snapshotType: "standard",
-        hasSnapshotDimensions: false,
-        hasMaterializedUnitsTable: true,
-      }),
-    ).toBe("results");
-  });
-
   it("returns 'results' when experiment is not compatible with incremental refresh", () => {
     expect(
       getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: true,
         isExperimentCompatibleWithIncrementalRefresh: false,
         datasource: makeDatasource(),
         experiment: makeExperiment(),
@@ -135,7 +115,6 @@ describe("getSnapshotQueryRunnerKind", () => {
     const datasource = makeDatasource({ mode: "parallel" as never });
     expect(
       getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: true,
         isExperimentCompatibleWithIncrementalRefresh: true,
         datasource,
         experiment: makeExperiment(),
@@ -152,7 +131,6 @@ describe("getSnapshotQueryRunnerKind", () => {
     });
     expect(
       getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: true,
         isExperimentCompatibleWithIncrementalRefresh: true,
         datasource,
         experiment: makeExperiment(),
@@ -169,7 +147,6 @@ describe("getSnapshotQueryRunnerKind", () => {
     });
     expect(
       getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: true,
         isExperimentCompatibleWithIncrementalRefresh: true,
         datasource,
         experiment: makeExperiment(),
@@ -186,7 +163,6 @@ describe("getSnapshotQueryRunnerKind", () => {
     });
     expect(
       getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: true,
         isExperimentCompatibleWithIncrementalRefresh: true,
         datasource,
         experiment: makeExperiment(),
@@ -200,7 +176,6 @@ describe("getSnapshotQueryRunnerKind", () => {
   it("returns 'results' for multi-armed-bandit experiments", () => {
     expect(
       getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: true,
         isExperimentCompatibleWithIncrementalRefresh: true,
         datasource: makeDatasource(),
         experiment: makeExperiment({ type: "multi-armed-bandit" }),
@@ -214,7 +189,6 @@ describe("getSnapshotQueryRunnerKind", () => {
   it("returns 'incremental' when experiment.type is undefined (legacy)", () => {
     expect(
       getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: true,
         isExperimentCompatibleWithIncrementalRefresh: true,
         datasource: makeDatasource(),
         experiment: makeExperiment({ type: undefined }),
@@ -232,7 +206,6 @@ describe("getSnapshotQueryRunnerKind", () => {
     });
     expect(
       getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: true,
         isExperimentCompatibleWithIncrementalRefresh: true,
         datasource,
         experiment: makeExperiment(),
@@ -250,7 +223,6 @@ describe("getSnapshotQueryRunnerKind", () => {
     });
     expect(
       getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: true,
         isExperimentCompatibleWithIncrementalRefresh: false,
         datasource,
         experiment: makeExperiment(),
@@ -268,7 +240,6 @@ describe("getSnapshotQueryRunnerKind", () => {
     });
     expect(
       getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: true,
         isExperimentCompatibleWithIncrementalRefresh: true,
         datasource,
         experiment: makeExperiment(),
@@ -287,7 +258,6 @@ describe("getSnapshotQueryRunnerKind", () => {
     });
     expect(
       getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: true,
         isExperimentCompatibleWithIncrementalRefresh: true,
         datasource,
         experiment: makeExperiment(),
@@ -306,7 +276,6 @@ describe("getSnapshotQueryRunnerKind", () => {
     });
     expect(
       getSnapshotQueryRunnerKind({
-        allowIncrementalRefresh: true,
         isExperimentCompatibleWithIncrementalRefresh: true,
         datasource,
         experiment: makeExperiment(),


### PR DESCRIPTION
### Features and Changes

This provides a more convenient way of monitoring experiment update duration via a concrete log with distinct phases for Experiment update.

It also includes the reason on why we fallback to `results` query runner when we cannot honor incremental refresh, and within incremental we also include the reason why we might fall back to a `full refresh` instead of an incremental update.

Finally, we also clean up `allowIncrementalRefresh` flag that was leftover from the developing of this feature.

### Testing

- New unit tests
- Manual test
  - Refresh results for a given experiment
  - Observe the new log