### PR TITLE
Enable fact table optimization when skipPartialData is true

### DIFF
--- a/packages/back-end/src/services/experimentQueries/experimentQueries.ts
+++ b/packages/back-end/src/services/experimentQueries/experimentQueries.ts
@@ -17,6 +17,7 @@ import { isManagedWarehouse } from "shared/util";
 import { SourceIntegrationInterface } from "back-end/src/types/Integration";
 import { orgHasPremiumFeature } from "back-end/src/enterprise";
 import { applyMetricOverrides } from "back-end/src/util/integration";
+import { getMaxHoursToConvert } from "back-end/src/integrations/sql/dates/max-hours-to-convert";
 import {
   BANDIT_CUPED_FLOAT_COLS,
   BASE_METRIC_CUPED_FLOAT_COLS,
@@ -228,7 +229,17 @@ export function chunkMetrics({
   return chunks;
 }
 
-export function getFactMetricGroup(metric: FactMetricInterface) {
+export function getFactMetricGroup(
+  metric: FactMetricInterface,
+  { skipPartialData }: { skipPartialData: boolean },
+) {
+  // When `skipPartialData` is enabled, the experiment end date is pulled back to
+  // exclude users who haven't had a full conversion window to convert.
+  // Add the conversion window to the group key to keep same-window metrics grouped together
+  const conversionWindowKey = skipPartialData
+    ? `_cw${getMaxHoursToConvert(false, [metric], null)}`
+    : "";
+
   // Ratio metrics must have the same numerator and denominator fact table to be grouped
   if (isRatioMetric(metric)) {
     if (metric.numerator.factTableId !== metric.denominator?.factTableId) {
@@ -238,7 +249,7 @@ export function getFactMetricGroup(metric: FactMetricInterface) {
         metric.denominator?.factTableId,
       ].sort((a, b) => a?.localeCompare(b ?? "") ?? 0);
       return tableIds.length >= 2
-        ? `${tableIds[0]} ${tableIds[1]} (cross-table ratio metrics)`
+        ? `${tableIds[0]} ${tableIds[1]} (cross-table ratio metrics)${conversionWindowKey}`
         : metric.id;
     }
   }
@@ -247,10 +258,12 @@ export function getFactMetricGroup(metric: FactMetricInterface) {
   // and because they do not support re-aggregation across pre-computed dimensions
   if (quantileMetricType(metric)) {
     return metric.numerator.factTableId
-      ? `${metric.numerator.factTableId}_qtile`
+      ? `${metric.numerator.factTableId}_qtile${conversionWindowKey}`
       : "";
   }
-  return metric.numerator.factTableId || "";
+  return metric.numerator.factTableId
+    ? `${metric.numerator.factTableId}${conversionWindowKey}`
+    : "";
 }
 
 export interface GroupedMetrics {
@@ -287,12 +300,6 @@ export function getFactMetricGroups(
     return defaultReturn;
   }
 
-  // Metrics might have different conversion windows which makes the query complicated
-  // TODO(sql): join together metrics with the same date windows for some added efficiency
-  if (settings.skipPartialData) {
-    return defaultReturn;
-  }
-
   // Group fact metrics into efficient groups (primarily if they share a fact table)
   const groups: Record<string, FactMetricInterface[]> = {};
   factMetrics.forEach((m) => {
@@ -312,7 +319,9 @@ export function getFactMetricGroups(
       return;
     }
 
-    const group = getFactMetricGroup(m);
+    const group = getFactMetricGroup(m, {
+      skipPartialData: !!settings.skipPartialData,
+    });
     if (group) {
       groups[group] = groups[group] || [];
       groups[group].push(m);

--- a/packages/back-end/test/services/experimentQueries.test.ts
+++ b/packages/back-end/test/services/experimentQueries.test.ts
@@ -1,6 +1,7 @@
 import { FactMetricInterface } from "shared/types/fact-table";
 import {
   chunkMetrics,
+  getFactMetricGroup,
   maxColumnsNeededForMetric,
 } from "back-end/src/services/experimentQueries/experimentQueries";
 import { MAX_METRICS_PER_QUERY } from "back-end/src/services/experimentQueries/constants";
@@ -496,6 +497,196 @@ describe("experimentQueries", () => {
           expect(totalCols).toBeLessThanOrEqual(maxColumnsPerQuery);
           expect(chunk.length).toBeLessThanOrEqual(MAX_METRICS_PER_QUERY);
         });
+      });
+    });
+  });
+
+  describe("getFactMetricGroup", () => {
+    const conversionWindow = (
+      windowValue: number,
+      windowUnit: "minutes" | "hours" | "days" | "weeks",
+      delayValue = 0,
+      delayUnit: "minutes" | "hours" | "days" | "weeks" = "hours",
+    ) => ({
+      type: "conversion" as const,
+      delayValue,
+      delayUnit,
+      windowValue,
+      windowUnit,
+    });
+
+    const meanMetric = (
+      factTableId: string,
+      windowSettings: FactMetricInterface["windowSettings"],
+    ) =>
+      factMetricFactory.build({
+        metricType: "mean",
+        numerator: { factTableId },
+        windowSettings,
+      });
+
+    describe("when skipPartialData is false", () => {
+      it("keys on the fact table only, ignoring the conversion window", () => {
+        const a = meanMetric("ft_1", conversionWindow(3, "days"));
+        const b = meanMetric("ft_1", conversionWindow(7, "days"));
+
+        // Different conversion windows still share a group because the window
+        // does not affect the query when partial data is included.
+        expect(getFactMetricGroup(a, { skipPartialData: false })).toBe("ft_1");
+        expect(getFactMetricGroup(b, { skipPartialData: false })).toBe("ft_1");
+      });
+    });
+
+    describe("when skipPartialData is true", () => {
+      it("appends the conversion window (in hours) to the fact table key", () => {
+        // 3 days = 72 hours
+        const metric = meanMetric("ft_1", conversionWindow(3, "days"));
+        expect(getFactMetricGroup(metric, { skipPartialData: true })).toBe(
+          "ft_1_cw72",
+        );
+      });
+
+      it("groups metrics from the same fact table with the same conversion window", () => {
+        const a = meanMetric("ft_1", conversionWindow(3, "days"));
+        const b = meanMetric("ft_1", conversionWindow(3, "days"));
+
+        expect(getFactMetricGroup(a, { skipPartialData: true })).toBe(
+          getFactMetricGroup(b, { skipPartialData: true }),
+        );
+      });
+
+      it("separates metrics from the same fact table with different conversion windows", () => {
+        const a = meanMetric("ft_1", conversionWindow(3, "days"));
+        const b = meanMetric("ft_1", conversionWindow(7, "days"));
+
+        expect(getFactMetricGroup(a, { skipPartialData: true })).not.toBe(
+          getFactMetricGroup(b, { skipPartialData: true }),
+        );
+      });
+
+      it("groups equivalent conversion windows expressed in different units", () => {
+        const days = meanMetric("ft_1", conversionWindow(1, "days"));
+        const hours = meanMetric("ft_1", conversionWindow(24, "hours"));
+
+        // 1 day == 24 hours, so both contribute the same end-date cutoff.
+        expect(getFactMetricGroup(days, { skipPartialData: true })).toBe(
+          getFactMetricGroup(hours, { skipPartialData: true }),
+        );
+      });
+
+      it("includes the delay window when computing the conversion window key", () => {
+        // 3-day window, no delay = 72h total
+        const noDelay = meanMetric("ft_1", conversionWindow(3, "days"));
+        // 2-day window + 1-day delay = 72h total (should match noDelay)
+        const withDelay = meanMetric(
+          "ft_1",
+          conversionWindow(2, "days", 1, "days"),
+        );
+        // 3-day window + 1-day delay = 96h total (should differ)
+        const longerDelay = meanMetric(
+          "ft_1",
+          conversionWindow(3, "days", 1, "days"),
+        );
+
+        expect(getFactMetricGroup(noDelay, { skipPartialData: true })).toBe(
+          getFactMetricGroup(withDelay, { skipPartialData: true }),
+        );
+        expect(getFactMetricGroup(noDelay, { skipPartialData: true })).not.toBe(
+          getFactMetricGroup(longerDelay, { skipPartialData: true }),
+        );
+      });
+
+      it("treats lookback and no-window metrics as a single zero-window group, distinct from conversion windows", () => {
+        const noWindow = meanMetric("ft_1", {
+          type: "",
+          delayValue: 0,
+          delayUnit: "hours",
+          windowValue: 0,
+          windowUnit: "hours",
+        });
+        const lookback = meanMetric("ft_1", {
+          type: "lookback",
+          delayValue: 0,
+          delayUnit: "hours",
+          windowValue: 3,
+          windowUnit: "days",
+        });
+        const conversion = meanMetric("ft_1", conversionWindow(3, "days"));
+
+        // Neither lookback nor "no window" affects the skipPartialData cutoff,
+        // so they share a group with each other...
+        expect(getFactMetricGroup(noWindow, { skipPartialData: true })).toBe(
+          getFactMetricGroup(lookback, { skipPartialData: true }),
+        );
+        // ...but not with a conversion-window metric.
+        expect(
+          getFactMetricGroup(noWindow, { skipPartialData: true }),
+        ).not.toBe(getFactMetricGroup(conversion, { skipPartialData: true }));
+      });
+
+      it("keeps metrics on different fact tables separate even with the same window", () => {
+        const a = meanMetric("ft_1", conversionWindow(3, "days"));
+        const b = meanMetric("ft_2", conversionWindow(3, "days"));
+
+        expect(getFactMetricGroup(a, { skipPartialData: true })).not.toBe(
+          getFactMetricGroup(b, { skipPartialData: true }),
+        );
+      });
+
+      it("appends the conversion window to cross-table ratio metric groups", () => {
+        const crossTableRatio = (
+          windowSettings: FactMetricInterface["windowSettings"],
+        ) =>
+          factMetricFactory.build({
+            metricType: "ratio",
+            numerator: { factTableId: "ft_1" },
+            denominator: { factTableId: "ft_2" },
+            windowSettings,
+          });
+
+        const a = crossTableRatio(conversionWindow(3, "days"));
+        const b = crossTableRatio(conversionWindow(3, "days"));
+        const c = crossTableRatio(conversionWindow(7, "days"));
+
+        expect(getFactMetricGroup(a, { skipPartialData: true })).toBe(
+          getFactMetricGroup(b, { skipPartialData: true }),
+        );
+        expect(getFactMetricGroup(a, { skipPartialData: true })).not.toBe(
+          getFactMetricGroup(c, { skipPartialData: true }),
+        );
+        // The base cross-table grouping is preserved.
+        expect(getFactMetricGroup(a, { skipPartialData: true })).toContain(
+          "(cross-table ratio metrics)",
+        );
+      });
+
+      it("appends the conversion window to quantile metric groups", () => {
+        const quantileMetric = (
+          windowSettings: FactMetricInterface["windowSettings"],
+        ): FactMetricInterface => ({
+          ...factMetricFactory.build({
+            metricType: "quantile",
+            numerator: { factTableId: "ft_1" },
+            windowSettings,
+          }),
+          quantileSettings: {
+            type: "unit",
+            quantile: 0.5,
+            ignoreZeros: false,
+          },
+        });
+
+        const a = quantileMetric(conversionWindow(3, "days"));
+        const b = quantileMetric(conversionWindow(7, "days"));
+
+        // Quantile metrics keep their dedicated `_qtile` group, now further
+        // split by conversion window under skipPartialData.
+        expect(getFactMetricGroup(a, { skipPartialData: true })).toContain(
+          "ft_1_qtile",
+        );
+        expect(getFactMetricGroup(a, { skipPartialData: true })).not.toBe(
+          getFactMetricGroup(b, { skipPartialData: true }),
+        );
       });
     });
   });


### PR DESCRIPTION
### Features and Changes

When `skipPartialData` is true for an experiment, we were skipping Fact Table Optimization entirely.  Every metric would be run in a separate query.

We did this because with this setting, the experiment end date in the SQL is dynamically changed based on the metric's conversion window, so it wasn't safe to combine arbitrary metrics together which may have different conversion window settings.

In reality, there is a very small set of distinct conversion windows an organization typically uses, so there is still a big opportunity for performance improvements.

This PR enables Fact Table Optimization even when this setting is true and simply adds the conversion window to the group key.  So two metrics with the same conversion window will be grouped together.  This is fully safe and avoids needing to do any SQL refactor work.