### PR TITLE
warn when a rule targets a disabled environment

### DIFF
--- a/packages/front-end/components/Features/RuleModal/EnvironmentScopeField.tsx
+++ b/packages/front-end/components/Features/RuleModal/EnvironmentScopeField.tsx
@@ -15,6 +15,7 @@ export type EnvScopeProps = {
   setAllEnvironments: (v: boolean) => void;
   selectedEnvironments: string[];
   setSelectedEnvironments: (v: string[]) => void;
+  disabledEnvironmentIds?: string[];
   label?: string;
 } & MarginProps;
 
@@ -24,10 +25,44 @@ export default function RuleEnvironmentScopeField({
   setAllEnvironments,
   selectedEnvironments,
   setSelectedEnvironments,
+  disabledEnvironmentIds = [],
   label = "Rule Environments",
   ...marginProps
 }: EnvScopeProps) {
   const options = environments.map((e) => ({ label: e.id, value: e.id }));
+
+  const disabledSet = new Set(disabledEnvironmentIds);
+  const affectedEnvIds = allEnvironments
+    ? disabledEnvironmentIds
+    : selectedEnvironments.filter((e) => disabledSet.has(e));
+  // Only warn when *some but not all* selected environments are disabled — if
+  // every targeted env is off there's nothing specific to call out here.
+  const totalSelected = allEnvironments
+    ? environments.length
+    : selectedEnvironments.length;
+  const showDisabledWarning =
+    affectedEnvIds.length > 0 && affectedEnvIds.length < totalSelected;
+
+  const disabledWarning = showDisabledWarning ? (
+    <Callout status="warning" size="sm" mt="2">
+      {affectedEnvIds.length === 1 ? (
+        <>
+          <strong>{affectedEnvIds[0]}</strong> is not enabled for this feature.
+          This rule will have no effect there until the feature is enabled in
+          that environment.
+        </>
+      ) : (
+        <>
+          <strong>
+            {affectedEnvIds.slice(0, -1).join(", ")} and{" "}
+            {affectedEnvIds[affectedEnvIds.length - 1]}
+          </strong>{" "}
+          are not enabled for this feature. This rule will have no effect there
+          until the feature is enabled in those environments.
+        </>
+      )}
+    </Callout>
+  ) : null;
 
   return (
     <Box {...marginProps}>
@@ -49,6 +84,7 @@ export default function RuleEnvironmentScopeField({
           { value: "specific", label: "Specific Environments" },
         ]}
       />
+      {allEnvironments && disabledWarning}
       {!allEnvironments && (
         <Box pl="5">
           <MultiSelectField
@@ -66,6 +102,7 @@ export default function RuleEnvironmentScopeField({
               selected.
             </Callout>
           )}
+          {disabledWarning}
         </Box>
       )}
     </Box>

--- a/packages/front-end/components/Features/RuleModal/EnvironmentScopeField.tsx
+++ b/packages/front-end/components/Features/RuleModal/EnvironmentScopeField.tsx
@@ -52,12 +52,9 @@ export default function RuleEnvironmentScopeField({
         </>
       ) : (
         <>
-          <strong>
-            {affectedEnvIds.slice(0, -1).join(", ")} and{" "}
-            {affectedEnvIds[affectedEnvIds.length - 1]}
-          </strong>{" "}
-          are not enabled for this feature. This rule will have no effect there
-          until the feature is enabled in those environments.
+          <strong>{affectedEnvIds.join(", ")}</strong> are not enabled for this
+          feature. This rule will have no effect there until the feature is
+          enabled in those environments.
         </>
       )}
     </Callout>

--- a/packages/front-end/components/Features/RuleModal/EnvironmentScopeField.tsx
+++ b/packages/front-end/components/Features/RuleModal/EnvironmentScopeField.tsx
@@ -32,17 +32,23 @@ export default function RuleEnvironmentScopeField({
   const options = environments.map((e) => ({ label: e.id, value: e.id }));
 
   const disabledSet = new Set(disabledEnvironmentIds);
+  const allEnvsDisabled =
+    environments.length > 0 &&
+    disabledEnvironmentIds.length === environments.length;
   const affectedEnvIds = allEnvironments
     ? disabledEnvironmentIds
     : selectedEnvironments.filter((e) => disabledSet.has(e));
-  // Only warn when *some but not all* feature environments are disabled — if
-  // every environment is off the feature is entirely inactive and there's
-  // nothing specific to single out.
-  const showDisabledWarning =
+  const showPartialDisabledWarning =
+    !allEnvsDisabled &&
     affectedEnvIds.length > 0 &&
     disabledEnvironmentIds.length < environments.length;
 
-  const disabledWarning = showDisabledWarning ? (
+  const disabledWarning = allEnvsDisabled ? (
+    <Callout status="warning" size="sm" mt="2">
+      This feature is not enabled in any environment. This rule will have no
+      effect until at least one environment is enabled.
+    </Callout>
+  ) : showPartialDisabledWarning ? (
     <Callout status="warning" size="sm" mt="2">
       {affectedEnvIds.length === 1 ? (
         <>

--- a/packages/front-end/components/Features/RuleModal/EnvironmentScopeField.tsx
+++ b/packages/front-end/components/Features/RuleModal/EnvironmentScopeField.tsx
@@ -76,9 +76,7 @@ export default function RuleEnvironmentScopeField({
       <RadioGroup
         value={allEnvironments ? "all" : "specific"}
         setValue={(v) => {
-          const next = v === "all";
-          setAllEnvironments(next);
-          if (next) setSelectedEnvironments([]);
+          setAllEnvironments(v === "all");
         }}
         gap="0"
         options={[

--- a/packages/front-end/components/Features/RuleModal/EnvironmentScopeField.tsx
+++ b/packages/front-end/components/Features/RuleModal/EnvironmentScopeField.tsx
@@ -98,7 +98,7 @@ export default function RuleEnvironmentScopeField({
             showCopyButton={false}
             containerClassName="w-full"
           />
-          {selectedEnvironments.length === 0 && (
+          {selectedEnvironments.length === 0 && !disabledWarning && (
             <Callout status="warning" size="sm" mt="2">
               This rule will not apply in any environment until at least one is
               selected.

--- a/packages/front-end/components/Features/RuleModal/EnvironmentScopeField.tsx
+++ b/packages/front-end/components/Features/RuleModal/EnvironmentScopeField.tsx
@@ -35,13 +35,12 @@ export default function RuleEnvironmentScopeField({
   const affectedEnvIds = allEnvironments
     ? disabledEnvironmentIds
     : selectedEnvironments.filter((e) => disabledSet.has(e));
-  // Only warn when *some but not all* selected environments are disabled — if
-  // every targeted env is off there's nothing specific to call out here.
-  const totalSelected = allEnvironments
-    ? environments.length
-    : selectedEnvironments.length;
+  // Only warn when *some but not all* feature environments are disabled — if
+  // every environment is off the feature is entirely inactive and there's
+  // nothing specific to single out.
   const showDisabledWarning =
-    affectedEnvIds.length > 0 && affectedEnvIds.length < totalSelected;
+    affectedEnvIds.length > 0 &&
+    disabledEnvironmentIds.length < environments.length;
 
   const disabledWarning = showDisabledWarning ? (
     <Callout status="warning" size="sm" mt="2">

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -1476,7 +1476,7 @@ export default function RuleModal({
               // Single environment: scope patches to that env only.
               // Multiple environments: omit so the ramp applies to all matching ruleIds.
               environment:
-                selectedEnvironments.length === 1
+                !scopeAllEnvs && selectedEnvironments.length === 1
                   ? selectedEnvironments[0]
                   : undefined,
               ...(!isScheduleMode

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -298,7 +298,7 @@ export default function RuleModal({
   const allEnvironments = useEnvironments();
   const environments = filterEnvironmentsByFeature(allEnvironments, feature);
   const disabledEnvironmentIds = environments
-    .filter((e) => feature.environmentSettings[e.id]?.enabled === false)
+    .filter((e) => !feature.environmentSettings[e.id]?.enabled)
     .map((e) => e.id);
 
   const { data: sdkConnectionsData } = useSDKConnections();

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -297,6 +297,9 @@ export default function RuleModal({
   const { templates: allTemplates } = useTemplates();
   const allEnvironments = useEnvironments();
   const environments = filterEnvironmentsByFeature(allEnvironments, feature);
+  const disabledEnvironmentIds = environments
+    .filter((e) => feature.environmentSettings[e.id]?.enabled === false)
+    .map((e) => e.id);
 
   const { data: sdkConnectionsData } = useSDKConnections();
   const hasSDKWithNoBucketingV2 = !allConnectionsSupportBucketingV2(
@@ -1739,6 +1742,7 @@ export default function RuleModal({
     setAllEnvironments: setScopeAllEnvs,
     selectedEnvironments,
     setSelectedEnvironments,
+    disabledEnvironmentIds,
   };
 
   // Resolved env list used by child components that care about which envs the


### PR DESCRIPTION
Shows a callout in the rule modal when the selected environment(s) are not enabled for the feature, helping users avoid silently saving rules that will have no effect.

### Features and Changes

<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots
<img width="765" height="133" alt="image" src="https://github.com/user-attachments/assets/7f93d58d-0458-44b7-8f83-63029417e77a" />
<img width="776" height="190" alt="image" src="https://github.com/user-attachments/assets/20134ae2-222c-46ca-b48b-35e6c2d62b7a" />

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
