### PR TITLE
Support 'Exclude In-Progress Conversions' with incremental refresh

### DIFF
--- a/docs/docs/experimentation-analysis/query-optimization.mdx
+++ b/docs/docs/experimentation-analysis/query-optimization.mdx
@@ -48,7 +48,6 @@ If multiple metrics from the same Fact Table are added to an experiment, they wi
 There are some restrictions that limit when this optimization can be performed:
 
 - Ratio metrics where the numerator and denominator are part of different Fact Tables are always excluded from this optimization
-- If `Exclude In-Progress Conversions` is set for an experiment, optimization is disabled for all metrics
 - If you are using MySQL and a metric has percentile capping, it will be excluded from optimization
 
 In all other cases, this optimization is enabled by default. It can be disabled under **Settings → General → Experiment Settings**. When disabled, a separate SQL query will always be run for every individual metric.

--- a/packages/back-end/src/enterprise/services/data-pipeline.ts
+++ b/packages/back-end/src/enterprise/services/data-pipeline.ts
@@ -42,13 +42,8 @@ export async function validateIncrementalPipeline({
   incrementalRefreshModel: IncrementalRefreshInterface | null;
   analysisType: "main-update" | "main-fullRefresh" | "exploratory";
 }): Promise<void> {
-  // "Exclude In-Progress Conversions" (skipPartialData) is supported via a
-  // read-time exposure cutoff in the statistics query — the runners partition
-  // stats queries by conversion window and pass `maxFirstExposureTimestamp`
-  // (see getIncrementalRefreshStatisticsQuery). It never affects materialization,
-  // so it is excluded from the cache-invalidation hash (hard-coded `false` in
-  // getExperimentSettingsHashForIncrementalRefresh below) — toggling it needs
-  // no full refresh.
+  // skipPartialData no longer blocks incremental refresh — it's applied as a
+  // read-time cutoff in the stats query (see getIncrementalRefreshStatisticsQuery).
   if (!integration.getSourceProperties().hasIncrementalRefresh) {
     throw new Error("Integration does not support incremental refresh queries");
   }
@@ -165,13 +160,8 @@ export function getExperimentSettingsHashForIncrementalRefresh(
     attributionModel: snapshotSettings.attributionModel,
     queryFilter: snapshotSettings.queryFilter,
     segment: snapshotSettings.segment,
-    // skipPartialData ("Exclude In-Progress Conversions") only affects the
-    // read-time statistics query (the exposure cutoff in
-    // getIncrementalRefreshStatisticsQuery), never materialization — so it must
-    // not invalidate the cache. We hard-code `false` rather than dropping the
-    // key so the hash stays byte-identical to existing models (all built while
-    // skipPartialData was forced off): existing incremental experiments stay
-    // valid AND users can toggle the setting without forcing a full refresh.
+    // Hard-coded (not dropped) to keep the hash byte-identical to existing
+    // models — skipPartialData only affects read-time stats, never the cache.
     skipPartialData: false,
     datasourceId: snapshotSettings.datasourceId,
     exposureQueryId: snapshotSettings.exposureQueryId,

--- a/packages/back-end/src/enterprise/services/data-pipeline.ts
+++ b/packages/back-end/src/enterprise/services/data-pipeline.ts
@@ -42,12 +42,13 @@ export async function validateIncrementalPipeline({
   incrementalRefreshModel: IncrementalRefreshInterface | null;
   analysisType: "main-update" | "main-fullRefresh" | "exploratory";
 }): Promise<void> {
-  if (snapshotSettings.skipPartialData) {
-    throw new Error(
-      "'Exclude In-Progress Conversions' is not supported for incremental refresh queries while in beta. Please select 'Include' in the Analysis Settings for Metric Conversion Windows.",
-    );
-  }
-
+  // "Exclude In-Progress Conversions" (skipPartialData) is supported via a
+  // read-time exposure cutoff in the statistics query — the runners partition
+  // stats queries by conversion window and pass `maxFirstExposureTimestamp`
+  // (see getIncrementalRefreshStatisticsQuery). It never affects materialization,
+  // so it is excluded from the cache-invalidation hash (hard-coded `false` in
+  // getExperimentSettingsHashForIncrementalRefresh below) — toggling it needs
+  // no full refresh.
   if (!integration.getSourceProperties().hasIncrementalRefresh) {
     throw new Error("Integration does not support incremental refresh queries");
   }
@@ -164,7 +165,14 @@ export function getExperimentSettingsHashForIncrementalRefresh(
     attributionModel: snapshotSettings.attributionModel,
     queryFilter: snapshotSettings.queryFilter,
     segment: snapshotSettings.segment,
-    skipPartialData: snapshotSettings.skipPartialData,
+    // skipPartialData ("Exclude In-Progress Conversions") only affects the
+    // read-time statistics query (the exposure cutoff in
+    // getIncrementalRefreshStatisticsQuery), never materialization — so it must
+    // not invalidate the cache. We hard-code `false` rather than dropping the
+    // key so the hash stays byte-identical to existing models (all built while
+    // skipPartialData was forced off): existing incremental experiments stay
+    // valid AND users can toggle the setting without forcing a full refresh.
+    skipPartialData: false,
     datasourceId: snapshotSettings.datasourceId,
     exposureQueryId: snapshotSettings.exposureQueryId,
     startDate: snapshotSettings.startDate,

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -2715,13 +2715,8 @@ export default abstract class SqlIntegration
         })
         .join("\n");
 
-    // skipPartialData ("Exclude In-Progress Conversions"): restrict the analysis
-    // to units exposed early enough to have completed their conversion window.
-    // The runner partitions stats queries by conversion window, so every metric
-    // in this query shares one cutoff. Applied to `__experimentUnits` — the
-    // single source of users and per-variation N — so both N and metric values
-    // consistently exclude not-yet-mature units. Uses `toTimestamp` (no ms) to
-    // match the non-incremental skipPartialData filter in getExperimentFactMetricsQuery.
+    // skipPartialData cutoff on __experimentUnits (the single source of users +
+    // N), so both N and metric values exclude not-yet-mature units.
     const firstExposureWhere = params.maxFirstExposureTimestamp
       ? `WHERE e.first_exposure_timestamp <= ${this.getSqlDialect().toTimestamp(
           params.maxFirstExposureTimestamp,

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -2715,6 +2715,19 @@ export default abstract class SqlIntegration
         })
         .join("\n");
 
+    // skipPartialData ("Exclude In-Progress Conversions"): restrict the analysis
+    // to units exposed early enough to have completed their conversion window.
+    // The runner partitions stats queries by conversion window, so every metric
+    // in this query shares one cutoff. Applied to `__experimentUnits` — the
+    // single source of users and per-variation N — so both N and metric values
+    // consistently exclude not-yet-mature units. Uses `toTimestamp` (no ms) to
+    // match the non-incremental skipPartialData filter in getExperimentFactMetricsQuery.
+    const firstExposureWhere = params.maxFirstExposureTimestamp
+      ? `WHERE e.first_exposure_timestamp <= ${this.getSqlDialect().toTimestamp(
+          params.maxFirstExposureTimestamp,
+        )}`
+      : "";
+
     // TODO(incremental-refresh): Handle activation metric in dimensions
     // like in getExperimentFactMetricsQuery
     // TODO(incremental-refresh): Validate with existing columns
@@ -2758,6 +2771,7 @@ export default abstract class SqlIntegration
           )`,
             )
             .join("\n")}
+          ${firstExposureWhere}
           GROUP BY
             e.${baseIdType}
       `
@@ -2766,7 +2780,8 @@ export default abstract class SqlIntegration
           , e.variation AS variation
           , e.first_exposure_timestamp AS first_exposure_timestamp
           ${nonUnitDimensionCols.map((d) => `, ${d.value} AS ${d.alias}`).join("")}
-        FROM ${params.unitsSourceTableFullName} e`
+        FROM ${params.unitsSourceTableFullName} e
+        ${firstExposureWhere}`
       })
       ${sources
         .map(

--- a/packages/back-end/src/integrations/sql/dates/experiment-end-date.ts
+++ b/packages/back-end/src/integrations/sql/dates/experiment-end-date.ts
@@ -3,10 +3,8 @@ import { ExperimentSnapshotSettings } from "shared/types/experiment-snapshot";
 export function getExperimentEndDate(
   settings: ExperimentSnapshotSettings,
   conversionWindowHours: number,
-  // Reference "now" for the conversion-window cutoff. Defaults to the current
-  // time, but callers (e.g. incremental refresh) pass a pinned timestamp so the
-  // cutoff is deterministic across the many queries in a run and matches the
-  // freshness of materialized caches.
+  // Reference "now" for the cutoff; callers can pin it (e.g. incremental
+  // refresh) for determinism across a run.
   now: Date = new Date(),
 ): Date {
   // Only include users who entered the experiment before this timestamp

--- a/packages/back-end/src/integrations/sql/dates/experiment-end-date.ts
+++ b/packages/back-end/src/integrations/sql/dates/experiment-end-date.ts
@@ -3,12 +3,17 @@ import { ExperimentSnapshotSettings } from "shared/types/experiment-snapshot";
 export function getExperimentEndDate(
   settings: ExperimentSnapshotSettings,
   conversionWindowHours: number,
+  // Reference "now" for the conversion-window cutoff. Defaults to the current
+  // time, but callers (e.g. incremental refresh) pass a pinned timestamp so the
+  // cutoff is deterministic across the many queries in a run and matches the
+  // freshness of materialized caches.
+  now: Date = new Date(),
 ): Date {
   // Only include users who entered the experiment before this timestamp
   // If we need to wait until users have had a chance to fully convert
   if (settings.skipPartialData) {
     // The last date allowed to give enough time for users to convert
-    const conversionWindowEndDate = new Date();
+    const conversionWindowEndDate = new Date(now);
     conversionWindowEndDate.setHours(
       conversionWindowEndDate.getHours() - conversionWindowHours,
     );

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
@@ -22,8 +22,7 @@ import {
   updateSnapshot,
 } from "back-end/src/models/ExperimentSnapshotModel";
 import { getIncrementalRefreshMetricSources } from "back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner";
-import { groupMetricsByConversionWindowHours } from "back-end/src/services/experimentQueries/experimentQueries";
-import { getExperimentEndDate } from "back-end/src/integrations/sql/dates/experiment-end-date";
+import { getStatsQueryBuckets } from "back-end/src/services/experimentQueries/experimentQueries";
 import {
   hasAnyRegressionAdjustedMetric,
   planMetricFanOut,
@@ -235,26 +234,11 @@ export const startExperimentIncrementalRefreshExploratoryQueries = async (
     // in case same fact table is split across multiple sources
     const sourceName = factTable ? `(${factTable.name})` : "";
 
-    // skipPartialData: one stats query per conversion window (see main runner).
-    const statsBuckets = snapshotSettings.skipPartialData
-      ? Array.from(
-          groupMetricsByConversionWindowHours(sameFtMetrics).entries(),
-        ).map(([conversionWindowHours, bucketMetrics]) => ({
-          metrics: bucketMetrics,
-          maxFirstExposureTimestamp: getExperimentEndDate(
-            snapshotSettings,
-            conversionWindowHours,
-            skipPartialDataReferenceTime,
-          ),
-          nameSuffix: `_cw${conversionWindowHours}`,
-        }))
-      : [
-          {
-            metrics: sameFtMetrics,
-            maxFirstExposureTimestamp: null,
-            nameSuffix: "",
-          },
-        ];
+    const statsBuckets = getStatsQueryBuckets({
+      metrics: sameFtMetrics,
+      snapshotSettings,
+      referenceTime: skipPartialDataReferenceTime,
+    });
 
     for (const bucket of statsBuckets) {
       const statisticsQuery = await startQuery({
@@ -320,26 +304,11 @@ export const startExperimentIncrementalRefreshExploratoryQueries = async (
     const ftB = params.factTableMap.get(pipelineB.group.factTableId);
     const sourceName = ftA && ftB ? `(${ftA.name} x ${ftB.name})` : "";
 
-    const crossFtMetrics = subGroup.metrics.map((m) => m.metric);
-    const statsBuckets = snapshotSettings.skipPartialData
-      ? Array.from(
-          groupMetricsByConversionWindowHours(crossFtMetrics).entries(),
-        ).map(([conversionWindowHours, bucketMetrics]) => ({
-          metrics: bucketMetrics,
-          maxFirstExposureTimestamp: getExperimentEndDate(
-            snapshotSettings,
-            conversionWindowHours,
-            skipPartialDataReferenceTime,
-          ),
-          nameSuffix: `_cw${conversionWindowHours}`,
-        }))
-      : [
-          {
-            metrics: crossFtMetrics,
-            maxFirstExposureTimestamp: null,
-            nameSuffix: "",
-          },
-        ];
+    const statsBuckets = getStatsQueryBuckets({
+      metrics: subGroup.metrics.map((m) => m.metric),
+      snapshotSettings,
+      referenceTime: skipPartialDataReferenceTime,
+    });
 
     for (const bucket of statsBuckets) {
       const crossStatsQuery = await startQuery({

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
@@ -93,16 +93,8 @@ export const startExperimentIncrementalRefreshExploratoryQueries = async (
     );
   }
 
-  // Cutoff reference for skipPartialData ("Exclude In-Progress Conversions").
-  // Use the timestamp the caches were last refreshed at (persisted by the last
-  // main run), NOT this exploratory run's clock — the caches only contain data
-  // up to that point, so a fresher cutoff would surface not-yet-materialized
-  // partial data. For models built before lastRefreshTimestamp was tracked,
-  // fall back to the materialized units' max timestamp (a data-bounded, safe
-  // proxy for cache freshness), and only then to this run's clock. This value
-  // is only ever applied when skipPartialData is on; experiments predating the
-  // field always have it off, so it's computed but never used until the next
-  // main run backfills lastRefreshTimestamp.
+  // Cutoff reference = when the caches were last refreshed, NOT this run's clock
+  // (older models fall back to the units watermark, then this run's start).
   const skipPartialDataReferenceTime =
     incrementalRefreshModel.lastRefreshTimestamp ??
     incrementalRefreshModel.unitsMaxTimestamp ??
@@ -243,10 +235,7 @@ export const startExperimentIncrementalRefreshExploratoryQueries = async (
     // in case same fact table is split across multiple sources
     const sourceName = factTable ? `(${factTable.name})` : "";
 
-    // When skipPartialData is on, partition into one stats query per
-    // conversion window, each with its own first_exposure_timestamp cutoff
-    // (see main runner). Uses the persisted cache-freshness timestamp as the
-    // reference so the cutoff matches what the caches actually contain.
+    // skipPartialData: one stats query per conversion window (see main runner).
     const statsBuckets = snapshotSettings.skipPartialData
       ? Array.from(
           groupMetricsByConversionWindowHours(sameFtMetrics).entries(),

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
@@ -22,6 +22,8 @@ import {
   updateSnapshot,
 } from "back-end/src/models/ExperimentSnapshotModel";
 import { getIncrementalRefreshMetricSources } from "back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner";
+import { groupMetricsByConversionWindowHours } from "back-end/src/services/experimentQueries/experimentQueries";
+import { getExperimentEndDate } from "back-end/src/integrations/sql/dates/experiment-end-date";
 import {
   hasAnyRegressionAdjustedMetric,
   planMetricFanOut,
@@ -90,6 +92,21 @@ export const startExperimentIncrementalRefreshExploratoryQueries = async (
       "Incremental refresh model not found; the overall results must be created before exploratory analyses can be run.",
     );
   }
+
+  // Cutoff reference for skipPartialData ("Exclude In-Progress Conversions").
+  // Use the timestamp the caches were last refreshed at (persisted by the last
+  // main run), NOT this exploratory run's clock — the caches only contain data
+  // up to that point, so a fresher cutoff would surface not-yet-materialized
+  // partial data. For models built before lastRefreshTimestamp was tracked,
+  // fall back to the materialized units' max timestamp (a data-bounded, safe
+  // proxy for cache freshness), and only then to this run's clock. This value
+  // is only ever applied when skipPartialData is on; experiments predating the
+  // field always have it off, so it's computed but never used until the next
+  // main run backfills lastRefreshTimestamp.
+  const skipPartialDataReferenceTime =
+    incrementalRefreshModel.lastRefreshTimestamp ??
+    incrementalRefreshModel.unitsMaxTimestamp ??
+    params.incrementalRefreshStartTime;
 
   const dimensionObjs: Dimension[] = (
     await Promise.all(
@@ -226,44 +243,72 @@ export const startExperimentIncrementalRefreshExploratoryQueries = async (
     // in case same fact table is split across multiple sources
     const sourceName = factTable ? `(${factTable.name})` : "";
 
-    const statisticsQuery = await startQuery({
-      name: `statistics_${group.groupId}`,
-      displayTitle: `Compute Statistics ${sourceName}`,
-      query: integration.getIncrementalRefreshStatisticsQuery({
-        settings: snapshotSettings,
-        activationMetric: activationMetric,
-        // TODO(incremental-refresh): add post-stratification to exploratory
-        // analysis. Pre-computation is unused here; we lean on
-        // dimensionsForAnalysis to drive breakdowns instead.
-        dimensionsForPrecomputation: [],
-        dimensionsForAnalysis: dimensionObjs,
-        factTableMap: params.factTableMap,
-        metricSources: [
+    // When skipPartialData is on, partition into one stats query per
+    // conversion window, each with its own first_exposure_timestamp cutoff
+    // (see main runner). Uses the persisted cache-freshness timestamp as the
+    // reference so the cutoff matches what the caches actually contain.
+    const statsBuckets = snapshotSettings.skipPartialData
+      ? Array.from(
+          groupMetricsByConversionWindowHours(sameFtMetrics).entries(),
+        ).map(([conversionWindowHours, bucketMetrics]) => ({
+          metrics: bucketMetrics,
+          maxFirstExposureTimestamp: getExperimentEndDate(
+            snapshotSettings,
+            conversionWindowHours,
+            skipPartialDataReferenceTime,
+          ),
+          nameSuffix: `_cw${conversionWindowHours}`,
+        }))
+      : [
           {
-            factTableId: group.factTableId,
-            tableFullName: existingSource.tableFullName,
-            ...(anyMetricHasCuped && existingCovariateSource
-              ? {
-                  covariateTableFullName: existingCovariateSource.tableFullName,
-                }
-              : {}),
+            metrics: sameFtMetrics,
+            maxFirstExposureTimestamp: null,
+            nameSuffix: "",
           },
-        ],
-        unitsSourceTableFullName: unitsTableFullName,
-        metrics: sameFtMetrics,
-        lastMaxTimestamp: existingSource?.maxTimestamp || null,
-      }),
-      dependencies: [],
-      run: fenced((query, setExternalId, queryMetadata) =>
-        integration.runIncrementalRefreshStatisticsQuery(
-          query,
-          setExternalId,
-          queryMetadata,
+        ];
+
+    for (const bucket of statsBuckets) {
+      const statisticsQuery = await startQuery({
+        name: `statistics_${group.groupId}${bucket.nameSuffix}`,
+        displayTitle: `Compute Statistics ${sourceName}`,
+        query: integration.getIncrementalRefreshStatisticsQuery({
+          settings: snapshotSettings,
+          activationMetric: activationMetric,
+          // TODO(incremental-refresh): add post-stratification to exploratory
+          // analysis. Pre-computation is unused here; we lean on
+          // dimensionsForAnalysis to drive breakdowns instead.
+          dimensionsForPrecomputation: [],
+          dimensionsForAnalysis: dimensionObjs,
+          factTableMap: params.factTableMap,
+          metricSources: [
+            {
+              factTableId: group.factTableId,
+              tableFullName: existingSource.tableFullName,
+              ...(anyMetricHasCuped && existingCovariateSource
+                ? {
+                    covariateTableFullName:
+                      existingCovariateSource.tableFullName,
+                  }
+                : {}),
+            },
+          ],
+          unitsSourceTableFullName: unitsTableFullName,
+          metrics: bucket.metrics,
+          lastMaxTimestamp: existingSource?.maxTimestamp || null,
+          maxFirstExposureTimestamp: bucket.maxFirstExposureTimestamp,
+        }),
+        dependencies: [],
+        run: fenced((query, setExternalId, queryMetadata) =>
+          integration.runIncrementalRefreshStatisticsQuery(
+            query,
+            setExternalId,
+            queryMetadata,
+          ),
         ),
-      ),
-      queryType: "experimentIncrementalRefreshStatistics",
-    });
-    queries.push(statisticsQuery);
+        queryType: "experimentIncrementalRefreshStatistics",
+      });
+      queries.push(statisticsQuery);
+    }
   }
 
   // Cross-FT pair pass — mirrors the main runner. We re-derive the
@@ -286,49 +331,73 @@ export const startExperimentIncrementalRefreshExploratoryQueries = async (
     const ftB = params.factTableMap.get(pipelineB.group.factTableId);
     const sourceName = ftA && ftB ? `(${ftA.name} x ${ftB.name})` : "";
 
-    const crossStatsQuery = await startQuery({
-      name: `statistics_cross_${pipelineA.group.groupId}__${pipelineB.group.groupId}`,
-      displayTitle: `Compute Cross-Fact Statistics ${sourceName}`,
-      query: integration.getIncrementalRefreshStatisticsQuery({
-        settings: snapshotSettings,
-        activationMetric: activationMetric,
-        dimensionsForPrecomputation: [],
-        dimensionsForAnalysis: dimensionObjs,
-        factTableMap: params.factTableMap,
-        unitsSourceTableFullName: unitsTableFullName,
-        metrics: subGroup.metrics.map((m) => m.metric),
-        lastMaxTimestamp: null,
-        // Cross-FT CUPED reads each side's covariate cache. Either
-        // pipeline may have none (if its metrics aren't RA), and we omit
-        // `covariateTableFullName` in that case.
-        metricSources: [
+    const crossFtMetrics = subGroup.metrics.map((m) => m.metric);
+    const statsBuckets = snapshotSettings.skipPartialData
+      ? Array.from(
+          groupMetricsByConversionWindowHours(crossFtMetrics).entries(),
+        ).map(([conversionWindowHours, bucketMetrics]) => ({
+          metrics: bucketMetrics,
+          maxFirstExposureTimestamp: getExperimentEndDate(
+            snapshotSettings,
+            conversionWindowHours,
+            skipPartialDataReferenceTime,
+          ),
+          nameSuffix: `_cw${conversionWindowHours}`,
+        }))
+      : [
           {
-            factTableId: pipelineA.group.factTableId,
-            tableFullName: pipelineA.tableFullName,
-            ...(pipelineA.covariateTableFullName
-              ? { covariateTableFullName: pipelineA.covariateTableFullName }
-              : {}),
+            metrics: crossFtMetrics,
+            maxFirstExposureTimestamp: null,
+            nameSuffix: "",
           },
-          {
-            factTableId: pipelineB.group.factTableId,
-            tableFullName: pipelineB.tableFullName,
-            ...(pipelineB.covariateTableFullName
-              ? { covariateTableFullName: pipelineB.covariateTableFullName }
-              : {}),
-          },
-        ],
-      }),
-      dependencies: [],
-      run: fenced((query, setExternalId, queryMetadata) =>
-        integration.runIncrementalRefreshStatisticsQuery(
-          query,
-          setExternalId,
-          queryMetadata,
+        ];
+
+    for (const bucket of statsBuckets) {
+      const crossStatsQuery = await startQuery({
+        name: `statistics_cross_${pipelineA.group.groupId}__${pipelineB.group.groupId}${bucket.nameSuffix}`,
+        displayTitle: `Compute Cross-Fact Statistics ${sourceName}`,
+        query: integration.getIncrementalRefreshStatisticsQuery({
+          settings: snapshotSettings,
+          activationMetric: activationMetric,
+          dimensionsForPrecomputation: [],
+          dimensionsForAnalysis: dimensionObjs,
+          factTableMap: params.factTableMap,
+          unitsSourceTableFullName: unitsTableFullName,
+          metrics: bucket.metrics,
+          lastMaxTimestamp: null,
+          maxFirstExposureTimestamp: bucket.maxFirstExposureTimestamp,
+          // Cross-FT CUPED reads each side's covariate cache. Either
+          // pipeline may have none (if its metrics aren't RA), and we omit
+          // `covariateTableFullName` in that case.
+          metricSources: [
+            {
+              factTableId: pipelineA.group.factTableId,
+              tableFullName: pipelineA.tableFullName,
+              ...(pipelineA.covariateTableFullName
+                ? { covariateTableFullName: pipelineA.covariateTableFullName }
+                : {}),
+            },
+            {
+              factTableId: pipelineB.group.factTableId,
+              tableFullName: pipelineB.tableFullName,
+              ...(pipelineB.covariateTableFullName
+                ? { covariateTableFullName: pipelineB.covariateTableFullName }
+                : {}),
+            },
+          ],
+        }),
+        dependencies: [],
+        run: fenced((query, setExternalId, queryMetadata) =>
+          integration.runIncrementalRefreshStatisticsQuery(
+            query,
+            setExternalId,
+            queryMetadata,
+          ),
         ),
-      ),
-      queryType: "experimentIncrementalRefreshStatistics",
-    });
-    queries.push(crossStatsQuery);
+        queryType: "experimentIncrementalRefreshStatistics",
+      });
+      queries.push(crossStatsQuery);
+    }
   }
 
   return queries;

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -52,9 +52,8 @@ import {
 import { getExposureQueryEligibleDimensions } from "back-end/src/services/dimensions";
 import {
   chunkMetrics,
-  groupMetricsByConversionWindowHours,
+  getStatsQueryBuckets,
 } from "back-end/src/services/experimentQueries/experimentQueries";
-import { getExperimentEndDate } from "back-end/src/integrations/sql/dates/experiment-end-date";
 import {
   filterRegressionAdjustedMetrics,
   planMetricFanOut,
@@ -940,27 +939,11 @@ const startExperimentIncrementalRefreshQueries = async (
     // only host one half of a cross-FT ratio skip this — those metrics'
     // stats are computed in the cross-FT pair pass below.
     if (sameFtMetrics.length > 0) {
-      // skipPartialData: split into one stats query per conversion window (each
-      // needs its own cutoff, since per-variation N is shared within a query).
-      const statsBuckets = snapshotSettings.skipPartialData
-        ? Array.from(
-            groupMetricsByConversionWindowHours(sameFtMetrics).entries(),
-          ).map(([conversionWindowHours, bucketMetrics]) => ({
-            metrics: bucketMetrics,
-            maxFirstExposureTimestamp: getExperimentEndDate(
-              snapshotSettings,
-              conversionWindowHours,
-              params.incrementalRefreshStartTime,
-            ),
-            nameSuffix: `_cw${conversionWindowHours}`,
-          }))
-        : [
-            {
-              metrics: sameFtMetrics,
-              maxFirstExposureTimestamp: null,
-              nameSuffix: "",
-            },
-          ];
+      const statsBuckets = getStatsQueryBuckets({
+        metrics: sameFtMetrics,
+        snapshotSettings,
+        referenceTime: params.incrementalRefreshStartTime,
+      });
 
       for (const bucket of statsBuckets) {
         // Match standard query runner behavior: quantiles only run overall
@@ -1047,28 +1030,11 @@ const startExperimentIncrementalRefreshQueries = async (
       ? []
       : eligibleDimensionsWithSlicesUnderMaxCells;
 
-    const crossFtMetrics = subGroup.metrics.map((m) => m.metric);
-    // Window-partition like the same-FT pass (a pair can host metrics with
-    // different windows).
-    const statsBuckets = snapshotSettings.skipPartialData
-      ? Array.from(
-          groupMetricsByConversionWindowHours(crossFtMetrics).entries(),
-        ).map(([conversionWindowHours, bucketMetrics]) => ({
-          metrics: bucketMetrics,
-          maxFirstExposureTimestamp: getExperimentEndDate(
-            snapshotSettings,
-            conversionWindowHours,
-            params.incrementalRefreshStartTime,
-          ),
-          nameSuffix: `_cw${conversionWindowHours}`,
-        }))
-      : [
-          {
-            metrics: crossFtMetrics,
-            maxFirstExposureTimestamp: null,
-            nameSuffix: "",
-          },
-        ];
+    const statsBuckets = getStatsQueryBuckets({
+      metrics: subGroup.metrics.map((m) => m.metric),
+      snapshotSettings,
+      referenceTime: params.incrementalRefreshStartTime,
+    });
 
     for (const bucket of statsBuckets) {
       const crossStatsQuery = await startQuery({

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -523,10 +523,7 @@ const startExperimentIncrementalRefreshQueries = async (
             {
               unitsTableFullName: unitsTableFullName,
               unitsMaxTimestamp: maxTimestamp,
-              // Records how current the materialized caches are, so read-only
-              // exploratory runs apply the same skipPartialData maturity cutoff
-              // as this main run (see getExperimentEndDate usage in the stats
-              // query partitioning).
+              // Cache-freshness marker; exploratory runs use it as their cutoff reference.
               lastRefreshTimestamp: params.incrementalRefreshStartTime,
               experimentSettingsHash:
                 getExperimentSettingsHashForIncrementalRefresh(
@@ -943,13 +940,8 @@ const startExperimentIncrementalRefreshQueries = async (
     // only host one half of a cross-FT ratio skip this — those metrics'
     // stats are computed in the cross-FT pair pass below.
     if (sameFtMetrics.length > 0) {
-      // When skipPartialData ("Exclude In-Progress Conversions") is on,
-      // partition this cache's metrics into separate statistics queries by
-      // conversion window, each with its own first_exposure_timestamp cutoff.
-      // Every metric in a query must share one cutoff because per-variation N
-      // is shared across the query. The caches stay untouched (window-agnostic);
-      // only the cheap read-time stats queries split. When the setting is off,
-      // this is a single query over all metrics with no cutoff (unchanged).
+      // skipPartialData: split into one stats query per conversion window (each
+      // needs its own cutoff, since per-variation N is shared within a query).
       const statsBuckets = snapshotSettings.skipPartialData
         ? Array.from(
             groupMetricsByConversionWindowHours(sameFtMetrics).entries(),
@@ -1056,10 +1048,8 @@ const startExperimentIncrementalRefreshQueries = async (
       : eligibleDimensionsWithSlicesUnderMaxCells;
 
     const crossFtMetrics = subGroup.metrics.map((m) => m.metric);
-    // Same window-partitioning as the same-FT pass: when skipPartialData is on,
-    // emit one stats query per conversion window (a single cross-FT pair can
-    // host ratio metrics with different windows), each with its own
-    // first_exposure_timestamp cutoff. Off => a single query, unchanged.
+    // Window-partition like the same-FT pass (a pair can host metrics with
+    // different windows).
     const statsBuckets = snapshotSettings.skipPartialData
       ? Array.from(
           groupMetricsByConversionWindowHours(crossFtMetrics).entries(),

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -50,7 +50,11 @@ import {
   validateIncrementalPipeline,
 } from "back-end/src/enterprise/services/data-pipeline";
 import { getExposureQueryEligibleDimensions } from "back-end/src/services/dimensions";
-import { chunkMetrics } from "back-end/src/services/experimentQueries/experimentQueries";
+import {
+  chunkMetrics,
+  groupMetricsByConversionWindowHours,
+} from "back-end/src/services/experimentQueries/experimentQueries";
+import { getExperimentEndDate } from "back-end/src/integrations/sql/dates/experiment-end-date";
 import {
   filterRegressionAdjustedMetrics,
   planMetricFanOut,
@@ -519,6 +523,11 @@ const startExperimentIncrementalRefreshQueries = async (
             {
               unitsTableFullName: unitsTableFullName,
               unitsMaxTimestamp: maxTimestamp,
+              // Records how current the materialized caches are, so read-only
+              // exploratory runs apply the same skipPartialData maturity cutoff
+              // as this main run (see getExperimentEndDate usage in the stats
+              // query partitioning).
+              lastRefreshTimestamp: params.incrementalRefreshStartTime,
               experimentSettingsHash:
                 getExperimentSettingsHashForIncrementalRefresh(
                   snapshotSettings,
@@ -934,52 +943,87 @@ const startExperimentIncrementalRefreshQueries = async (
     // only host one half of a cross-FT ratio skip this — those metrics'
     // stats are computed in the cross-FT pair pass below.
     if (sameFtMetrics.length > 0) {
-      // Match standard query runner behavior: quantiles only run overall
-      // stats (no pre-computed dimensions), regardless of requested
-      // dimensions.
-      const runOverallQuantileAnalysis = sameFtMetrics.some(quantileMetricType);
-      const dimensionsForPrecomputation =
-        org.settings?.disablePrecomputedDimensions || runOverallQuantileAnalysis
-          ? []
-          : eligibleDimensionsWithSlicesUnderMaxCells;
-
-      const statisticsQuery = await startQuery({
-        name: `statistics_${group.groupId}`,
-        displayTitle: `Compute Statistics ${sourceName}`,
-        query: integration.getIncrementalRefreshStatisticsQuery({
-          settings: snapshotSettings,
-          activationMetric: activationMetric,
-          factTableMap: params.factTableMap,
-          unitsSourceTableFullName: unitsTableFullName,
-          metrics: sameFtMetrics,
-          lastMaxTimestamp: existingSource?.maxTimestamp || null,
-          dimensionsForPrecomputation,
-          dimensionsForAnalysis: [],
-          metricSources: [
+      // When skipPartialData ("Exclude In-Progress Conversions") is on,
+      // partition this cache's metrics into separate statistics queries by
+      // conversion window, each with its own first_exposure_timestamp cutoff.
+      // Every metric in a query must share one cutoff because per-variation N
+      // is shared across the query. The caches stay untouched (window-agnostic);
+      // only the cheap read-time stats queries split. When the setting is off,
+      // this is a single query over all metrics with no cutoff (unchanged).
+      const statsBuckets = snapshotSettings.skipPartialData
+        ? Array.from(
+            groupMetricsByConversionWindowHours(sameFtMetrics).entries(),
+          ).map(([conversionWindowHours, bucketMetrics]) => ({
+            metrics: bucketMetrics,
+            maxFirstExposureTimestamp: getExperimentEndDate(
+              snapshotSettings,
+              conversionWindowHours,
+              params.incrementalRefreshStartTime,
+            ),
+            nameSuffix: `_cw${conversionWindowHours}`,
+          }))
+        : [
             {
-              factTableId: group.factTableId,
-              tableFullName: metricSourceTableFullName,
-              ...(anyMetricHasCuped && metricSourceCovariateTableFullName
-                ? { covariateTableFullName: metricSourceCovariateTableFullName }
-                : {}),
+              metrics: sameFtMetrics,
+              maxFirstExposureTimestamp: null,
+              nameSuffix: "",
             },
+          ];
+
+      for (const bucket of statsBuckets) {
+        // Match standard query runner behavior: quantiles only run overall
+        // stats (no pre-computed dimensions), regardless of requested
+        // dimensions.
+        const runOverallQuantileAnalysis =
+          bucket.metrics.some(quantileMetricType);
+        const dimensionsForPrecomputation =
+          org.settings?.disablePrecomputedDimensions ||
+          runOverallQuantileAnalysis
+            ? []
+            : eligibleDimensionsWithSlicesUnderMaxCells;
+
+        const statisticsQuery = await startQuery({
+          name: `statistics_${group.groupId}${bucket.nameSuffix}`,
+          displayTitle: `Compute Statistics ${sourceName}`,
+          query: integration.getIncrementalRefreshStatisticsQuery({
+            settings: snapshotSettings,
+            activationMetric: activationMetric,
+            factTableMap: params.factTableMap,
+            unitsSourceTableFullName: unitsTableFullName,
+            metrics: bucket.metrics,
+            lastMaxTimestamp: existingSource?.maxTimestamp || null,
+            maxFirstExposureTimestamp: bucket.maxFirstExposureTimestamp,
+            dimensionsForPrecomputation,
+            dimensionsForAnalysis: [],
+            metricSources: [
+              {
+                factTableId: group.factTableId,
+                tableFullName: metricSourceTableFullName,
+                ...(anyMetricHasCuped && metricSourceCovariateTableFullName
+                  ? {
+                      covariateTableFullName:
+                        metricSourceCovariateTableFullName,
+                    }
+                  : {}),
+              },
+            ],
+          }),
+          dependencies: [
+            insertMetricsSourceDataQuery.query,
+            ...(insertMetricCovariateDataQuery
+              ? [insertMetricCovariateDataQuery.query]
+              : []),
           ],
-        }),
-        dependencies: [
-          insertMetricsSourceDataQuery.query,
-          ...(insertMetricCovariateDataQuery
-            ? [insertMetricCovariateDataQuery.query]
-            : []),
-        ],
-        run: (query, setExternalId, queryMetadata) =>
-          integration.runIncrementalRefreshStatisticsQuery(
-            query,
-            setExternalId,
-            queryMetadata,
-          ),
-        queryType: "experimentIncrementalRefreshStatistics",
-      });
-      queries.push(statisticsQuery);
+          run: (query, setExternalId, queryMetadata) =>
+            integration.runIncrementalRefreshStatisticsQuery(
+              query,
+              setExternalId,
+              queryMetadata,
+            ),
+          queryType: "experimentIncrementalRefreshStatistics",
+        });
+        queries.push(statisticsQuery);
+      }
     }
   }
 
@@ -1011,64 +1055,92 @@ const startExperimentIncrementalRefreshQueries = async (
       ? []
       : eligibleDimensionsWithSlicesUnderMaxCells;
 
-    const crossStatsQuery = await startQuery({
-      name: `statistics_cross_${pipelineA.group.groupId}__${pipelineB.group.groupId}`,
-      displayTitle: `Compute Cross-Fact Statistics ${sourceName}`,
-      query: integration.getIncrementalRefreshStatisticsQuery({
-        settings: snapshotSettings,
-        activationMetric: activationMetric,
-        factTableMap: params.factTableMap,
-        unitsSourceTableFullName: unitsTableFullName,
-        metrics: subGroup.metrics.map((m) => m.metric),
-        // The earliest of the two caches' max timestamps gates which rows
-        // we can trust as fully populated. For simplicity we just pass
-        // null; the stats query reads whatever each cache holds and the
-        // ratio aggregation works regardless of catch-up state.
-        lastMaxTimestamp: null,
-        dimensionsForPrecomputation,
-        dimensionsForAnalysis: [],
-        // Cross-FT CUPED uses one covariate cache per pipeline — the
-        // numerator FT's cache carries `_value` covariates, the
-        // denominator FT's cache carries `_denominator_value` covariates,
-        // and the per-source covariate LEFT JOIN inside each
-        // `__joinedData{i}` picks the right side from each side's cache.
-        // Pipelines with no RA metrics omit `covariateTableFullName`.
-        metricSources: [
+    const crossFtMetrics = subGroup.metrics.map((m) => m.metric);
+    // Same window-partitioning as the same-FT pass: when skipPartialData is on,
+    // emit one stats query per conversion window (a single cross-FT pair can
+    // host ratio metrics with different windows), each with its own
+    // first_exposure_timestamp cutoff. Off => a single query, unchanged.
+    const statsBuckets = snapshotSettings.skipPartialData
+      ? Array.from(
+          groupMetricsByConversionWindowHours(crossFtMetrics).entries(),
+        ).map(([conversionWindowHours, bucketMetrics]) => ({
+          metrics: bucketMetrics,
+          maxFirstExposureTimestamp: getExperimentEndDate(
+            snapshotSettings,
+            conversionWindowHours,
+            params.incrementalRefreshStartTime,
+          ),
+          nameSuffix: `_cw${conversionWindowHours}`,
+        }))
+      : [
           {
-            factTableId: pipelineA.group.factTableId,
-            tableFullName: pipelineA.tableFullName,
-            ...(pipelineA.covariateTableFullName
-              ? { covariateTableFullName: pipelineA.covariateTableFullName }
-              : {}),
+            metrics: crossFtMetrics,
+            maxFirstExposureTimestamp: null,
+            nameSuffix: "",
           },
-          {
-            factTableId: pipelineB.group.factTableId,
-            tableFullName: pipelineB.tableFullName,
-            ...(pipelineB.covariateTableFullName
-              ? { covariateTableFullName: pipelineB.covariateTableFullName }
-              : {}),
-          },
+        ];
+
+    for (const bucket of statsBuckets) {
+      const crossStatsQuery = await startQuery({
+        name: `statistics_cross_${pipelineA.group.groupId}__${pipelineB.group.groupId}${bucket.nameSuffix}`,
+        displayTitle: `Compute Cross-Fact Statistics ${sourceName}`,
+        query: integration.getIncrementalRefreshStatisticsQuery({
+          settings: snapshotSettings,
+          activationMetric: activationMetric,
+          factTableMap: params.factTableMap,
+          unitsSourceTableFullName: unitsTableFullName,
+          metrics: bucket.metrics,
+          // The earliest of the two caches' max timestamps gates which rows
+          // we can trust as fully populated. For simplicity we just pass
+          // null; the stats query reads whatever each cache holds and the
+          // ratio aggregation works regardless of catch-up state.
+          lastMaxTimestamp: null,
+          maxFirstExposureTimestamp: bucket.maxFirstExposureTimestamp,
+          dimensionsForPrecomputation,
+          dimensionsForAnalysis: [],
+          // Cross-FT CUPED uses one covariate cache per pipeline — the
+          // numerator FT's cache carries `_value` covariates, the
+          // denominator FT's cache carries `_denominator_value` covariates,
+          // and the per-source covariate LEFT JOIN inside each
+          // `__joinedData{i}` picks the right side from each side's cache.
+          // Pipelines with no RA metrics omit `covariateTableFullName`.
+          metricSources: [
+            {
+              factTableId: pipelineA.group.factTableId,
+              tableFullName: pipelineA.tableFullName,
+              ...(pipelineA.covariateTableFullName
+                ? { covariateTableFullName: pipelineA.covariateTableFullName }
+                : {}),
+            },
+            {
+              factTableId: pipelineB.group.factTableId,
+              tableFullName: pipelineB.tableFullName,
+              ...(pipelineB.covariateTableFullName
+                ? { covariateTableFullName: pipelineB.covariateTableFullName }
+                : {}),
+            },
+          ],
+        }),
+        dependencies: [
+          pipelineA.insertQuery.query,
+          pipelineB.insertQuery.query,
+          ...(pipelineA.covariateInsertQuery
+            ? [pipelineA.covariateInsertQuery.query]
+            : []),
+          ...(pipelineB.covariateInsertQuery
+            ? [pipelineB.covariateInsertQuery.query]
+            : []),
         ],
-      }),
-      dependencies: [
-        pipelineA.insertQuery.query,
-        pipelineB.insertQuery.query,
-        ...(pipelineA.covariateInsertQuery
-          ? [pipelineA.covariateInsertQuery.query]
-          : []),
-        ...(pipelineB.covariateInsertQuery
-          ? [pipelineB.covariateInsertQuery.query]
-          : []),
-      ],
-      run: (query, setExternalId, queryMetadata) =>
-        integration.runIncrementalRefreshStatisticsQuery(
-          query,
-          setExternalId,
-          queryMetadata,
-        ),
-      queryType: "experimentIncrementalRefreshStatistics",
-    });
-    queries.push(crossStatsQuery);
+        run: (query, setExternalId, queryMetadata) =>
+          integration.runIncrementalRefreshStatisticsQuery(
+            query,
+            setExternalId,
+            queryMetadata,
+          ),
+        queryType: "experimentIncrementalRefreshStatistics",
+      });
+      queries.push(crossStatsQuery);
+    }
   }
   const runTrafficQuery = shouldRunHealthTrafficQuery({
     snapshotType: params.snapshotType,

--- a/packages/back-end/src/services/experimentQueries/experimentQueries.ts
+++ b/packages/back-end/src/services/experimentQueries/experimentQueries.ts
@@ -266,6 +266,29 @@ export function getFactMetricGroup(
     : "";
 }
 
+// Group fact metrics by their conversion-window hours (delay + window; 0 for
+// non-conversion windows). Used to partition statistics queries when
+// `skipPartialData` is enabled: every metric in a bucket shares the same
+// experiment end-date cutoff, so they can be analyzed in one query with a
+// single user-maturity filter on `first_exposure_timestamp`. Keyed on the same
+// value `getFactMetricGroup` uses for its `_cw` group-key suffix, so the two
+// stay consistent. Insertion order of metrics is preserved within each bucket.
+export function groupMetricsByConversionWindowHours(
+  metrics: FactMetricInterface[],
+): Map<number, FactMetricInterface[]> {
+  const groups = new Map<number, FactMetricInterface[]>();
+  metrics.forEach((metric) => {
+    const hours = getMaxHoursToConvert(false, [metric], null);
+    const existing = groups.get(hours);
+    if (existing) {
+      existing.push(metric);
+    } else {
+      groups.set(hours, [metric]);
+    }
+  });
+  return groups;
+}
+
 export interface GroupedMetrics {
   // Fact metrics grouped together or alone
   factMetricGroups: FactMetricInterface[][];

--- a/packages/back-end/src/services/experimentQueries/experimentQueries.ts
+++ b/packages/back-end/src/services/experimentQueries/experimentQueries.ts
@@ -266,13 +266,8 @@ export function getFactMetricGroup(
     : "";
 }
 
-// Group fact metrics by their conversion-window hours (delay + window; 0 for
-// non-conversion windows). Used to partition statistics queries when
-// `skipPartialData` is enabled: every metric in a bucket shares the same
-// experiment end-date cutoff, so they can be analyzed in one query with a
-// single user-maturity filter on `first_exposure_timestamp`. Keyed on the same
-// value `getFactMetricGroup` uses for its `_cw` group-key suffix, so the two
-// stay consistent. Insertion order of metrics is preserved within each bucket.
+// Bucket fact metrics by conversion-window hours (delay + window; 0 for none),
+// so skipPartialData stats queries can apply one end-date cutoff per bucket.
 export function groupMetricsByConversionWindowHours(
   metrics: FactMetricInterface[],
 ): Map<number, FactMetricInterface[]> {

--- a/packages/back-end/src/services/experimentQueries/experimentQueries.ts
+++ b/packages/back-end/src/services/experimentQueries/experimentQueries.ts
@@ -18,6 +18,7 @@ import { SourceIntegrationInterface } from "back-end/src/types/Integration";
 import { orgHasPremiumFeature } from "back-end/src/enterprise";
 import { applyMetricOverrides } from "back-end/src/util/integration";
 import { getMaxHoursToConvert } from "back-end/src/integrations/sql/dates/max-hours-to-convert";
+import { getExperimentEndDate } from "back-end/src/integrations/sql/dates/experiment-end-date";
 import {
   BANDIT_CUPED_FLOAT_COLS,
   BASE_METRIC_CUPED_FLOAT_COLS,
@@ -282,6 +283,40 @@ export function groupMetricsByConversionWindowHours(
     }
   });
   return groups;
+}
+
+export interface StatsQueryBucket {
+  metrics: FactMetricInterface[];
+  // Exposure cutoff for skipPartialData, or null to include all users.
+  maxFirstExposureTimestamp: Date | null;
+  nameSuffix: string;
+}
+
+// One stats-query bucket per conversion window when skipPartialData is on (each
+// gets its own first_exposure_timestamp cutoff); otherwise a single bucket.
+export function getStatsQueryBuckets({
+  metrics,
+  snapshotSettings,
+  referenceTime,
+}: {
+  metrics: FactMetricInterface[];
+  snapshotSettings: ExperimentSnapshotSettings;
+  referenceTime: Date;
+}): StatsQueryBucket[] {
+  if (!snapshotSettings.skipPartialData) {
+    return [{ metrics, maxFirstExposureTimestamp: null, nameSuffix: "" }];
+  }
+  return Array.from(groupMetricsByConversionWindowHours(metrics).entries()).map(
+    ([conversionWindowHours, bucketMetrics]) => ({
+      metrics: bucketMetrics,
+      maxFirstExposureTimestamp: getExperimentEndDate(
+        snapshotSettings,
+        conversionWindowHours,
+        referenceTime,
+      ),
+      nameSuffix: `_cw${conversionWindowHours}`,
+    }),
+  );
 }
 
 export interface GroupedMetrics {

--- a/packages/back-end/test/integrations/BigQuery.test.ts
+++ b/packages/back-end/test/integrations/BigQuery.test.ts
@@ -657,6 +657,83 @@ describe("BigQuery KLL incremental refresh SQL generation (E2E)", () => {
     expect(joinedPos).toBeGreaterThan(gridPos);
   });
 
+  describe("getIncrementalRefreshStatisticsQuery skipPartialData cutoff", () => {
+    const meanMetric = factMetricFactory.build({
+      id: "fact_mean_cw",
+      metricType: "mean",
+      numerator: {
+        factTableId: "ft_events",
+        column: "amount",
+        aggregation: "sum",
+      },
+    });
+
+    const baseParams = {
+      settings,
+      activationMetric: null,
+      dimensionsForPrecomputation: [],
+      dimensionsForAnalysis: [],
+      factTableMap,
+      metricSources: [
+        { factTableId: "ft_events", tableFullName: "proj.ds.metric_source" },
+      ],
+      unitsSourceTableFullName: "proj.ds.units",
+      metrics: [meanMetric],
+      lastMaxTimestamp: null,
+    };
+
+    it("filters __experimentUnits by first_exposure_timestamp when maxFirstExposureTimestamp is set", () => {
+      const sql = integration.getIncrementalRefreshStatisticsQuery({
+        ...baseParams,
+        maxFirstExposureTimestamp: new Date("2024-01-20T00:00:00Z"),
+      });
+
+      // The cutoff is applied as a read-time WHERE on the units cache.
+      expect(sql).toContain("first_exposure_timestamp <=");
+
+      // ...and it lives inside the __experimentUnits CTE, before the metric
+      // aggregation CTE — so it filters both per-variation N and metric values.
+      const unitsPos = sql.indexOf("__experimentUnits");
+      const filterPos = sql.indexOf("first_exposure_timestamp <=");
+      const aggPos = sql.indexOf("__metricDataAggregated");
+      expect(unitsPos).toBeGreaterThan(-1);
+      expect(filterPos).toBeGreaterThan(unitsPos);
+      expect(aggPos).toBeGreaterThan(filterPos);
+    });
+
+    it("omits the cutoff filter when maxFirstExposureTimestamp is not set", () => {
+      const sql = integration.getIncrementalRefreshStatisticsQuery(baseParams);
+      expect(sql).not.toContain("first_exposure_timestamp <=");
+    });
+
+    it("renders the provided cutoff value (different cutoffs => different SQL)", () => {
+      const early = integration.getIncrementalRefreshStatisticsQuery({
+        ...baseParams,
+        maxFirstExposureTimestamp: new Date("2024-01-10T00:00:00Z"),
+      });
+      const late = integration.getIncrementalRefreshStatisticsQuery({
+        ...baseParams,
+        maxFirstExposureTimestamp: new Date("2024-01-25T00:00:00Z"),
+      });
+      expect(early).toContain("first_exposure_timestamp <=");
+      expect(late).toContain("first_exposure_timestamp <=");
+      expect(early).not.toBe(late);
+    });
+
+    it("is deterministic for a fixed cutoff (no wall-clock drift)", () => {
+      const cutoff = new Date("2024-01-20T12:34:56Z");
+      const a = integration.getIncrementalRefreshStatisticsQuery({
+        ...baseParams,
+        maxFirstExposureTimestamp: cutoff,
+      });
+      const b = integration.getIncrementalRefreshStatisticsQuery({
+        ...baseParams,
+        maxFirstExposureTimestamp: cutoff,
+      });
+      expect(a).toBe(b);
+    });
+  });
+
   it("getExperimentFactMetricsQuery uses kll grid extraction and post-aggregation rank recovery for 'kll merge' event quantiles", () => {
     const prebuiltSketchMetric = factMetricFactory.build({
       id: "fact_eq_sketch_xp",

--- a/packages/back-end/test/integrations/sql/dates/experiment-end-date.test.ts
+++ b/packages/back-end/test/integrations/sql/dates/experiment-end-date.test.ts
@@ -47,8 +47,7 @@ describe("getExperimentEndDate", () => {
   });
 
   it("returns the phase end date when the conversion-window cutoff is later than it", () => {
-    // now is months after endDate, so now - 1h is still well past endDate and
-    // min() keeps the phase end date.
+    // now is long after endDate, so min() keeps the phase end date.
     const endDate = new Date("2024-01-31T00:00:00Z");
     const now = new Date("2024-06-01T00:00:00Z");
     expect(getExperimentEndDate(settingsWith(true, endDate), 1, now)).toEqual(
@@ -57,9 +56,8 @@ describe("getExperimentEndDate", () => {
   });
 
   it("honors the explicit reference time instead of the wall clock", () => {
-    // Far-future end date + 0-hour window => cutoff is exactly `now`. If the
-    // function used the real wall clock instead of the passed-in time, the
-    // result would be today's date, not the pinned 2024-01-10.
+    // Far-future endDate + 0h window => cutoff is exactly the passed-in now
+    // (a wall-clock fallback would yield today, not 2024-01-10).
     const farEndDate = new Date("2025-01-01T00:00:00Z");
     const now = new Date("2024-01-10T00:00:00Z");
     expect(
@@ -80,8 +78,7 @@ describe("getExperimentEndDate", () => {
       48,
       now,
     );
-    // 0-hour window => cutoff is exactly now; a 48h window must be strictly
-    // earlier (and never reaches the far-future end date).
+    // 0h window => cutoff is exactly now; 48h must be strictly earlier.
     expect(noWindow).toEqual(now);
     expect(dayWindow.getTime()).toBeLessThan(now.getTime());
   });

--- a/packages/back-end/test/integrations/sql/dates/experiment-end-date.test.ts
+++ b/packages/back-end/test/integrations/sql/dates/experiment-end-date.test.ts
@@ -1,0 +1,88 @@
+import { ExperimentSnapshotSettings } from "shared/types/experiment-snapshot";
+import { getExperimentEndDate } from "back-end/src/integrations/sql/dates/experiment-end-date";
+
+describe("getExperimentEndDate", () => {
+  const baseSettings: ExperimentSnapshotSettings = {
+    manual: false,
+    dimensions: [],
+    metricSettings: [],
+    goalMetrics: [],
+    secondaryMetrics: [],
+    guardrailMetrics: [],
+    activationMetric: null,
+    defaultMetricPriorSettings: {
+      override: false,
+      proper: false,
+      mean: 0,
+      stddev: 0,
+    },
+    regressionAdjustmentEnabled: false,
+    attributionModel: "firstExposure",
+    experimentId: "exp_1",
+    queryFilter: "",
+    segment: "",
+    skipPartialData: false,
+    datasourceId: "ds_1",
+    exposureQueryId: "exposure",
+    startDate: new Date("2024-01-01T00:00:00Z"),
+    endDate: new Date("2024-01-31T00:00:00Z"),
+    variations: [],
+  };
+
+  const settingsWith = (
+    skipPartialData: boolean,
+    endDate: Date,
+  ): ExperimentSnapshotSettings => ({
+    ...baseSettings,
+    skipPartialData,
+    endDate,
+  });
+
+  it("returns the phase end date (ignoring now) when skipPartialData is false", () => {
+    const endDate = new Date("2024-01-31T00:00:00Z");
+    const now = new Date("2024-06-01T00:00:00Z");
+    expect(getExperimentEndDate(settingsWith(false, endDate), 1000, now)).toBe(
+      endDate,
+    );
+  });
+
+  it("returns the phase end date when the conversion-window cutoff is later than it", () => {
+    // now is months after endDate, so now - 1h is still well past endDate and
+    // min() keeps the phase end date.
+    const endDate = new Date("2024-01-31T00:00:00Z");
+    const now = new Date("2024-06-01T00:00:00Z");
+    expect(getExperimentEndDate(settingsWith(true, endDate), 1, now)).toEqual(
+      endDate,
+    );
+  });
+
+  it("honors the explicit reference time instead of the wall clock", () => {
+    // Far-future end date + 0-hour window => cutoff is exactly `now`. If the
+    // function used the real wall clock instead of the passed-in time, the
+    // result would be today's date, not the pinned 2024-01-10.
+    const farEndDate = new Date("2025-01-01T00:00:00Z");
+    const now = new Date("2024-01-10T00:00:00Z");
+    expect(
+      getExperimentEndDate(settingsWith(true, farEndDate), 0, now),
+    ).toEqual(now);
+  });
+
+  it("pulls the cutoff earlier as the conversion window grows", () => {
+    const farEndDate = new Date("2025-01-01T00:00:00Z");
+    const now = new Date("2024-06-15T00:00:00Z");
+    const noWindow = getExperimentEndDate(
+      settingsWith(true, farEndDate),
+      0,
+      now,
+    );
+    const dayWindow = getExperimentEndDate(
+      settingsWith(true, farEndDate),
+      48,
+      now,
+    );
+    // 0-hour window => cutoff is exactly now; a 48h window must be strictly
+    // earlier (and never reaches the far-future end date).
+    expect(noWindow).toEqual(now);
+    expect(dayWindow.getTime()).toBeLessThan(now.getTime());
+  });
+});

--- a/packages/back-end/test/services/experimentQueries.test.ts
+++ b/packages/back-end/test/services/experimentQueries.test.ts
@@ -1,7 +1,9 @@
 import { FactMetricInterface } from "shared/types/fact-table";
+import { ExperimentSnapshotSettings } from "shared/types/experiment-snapshot";
 import {
   chunkMetrics,
   getFactMetricGroup,
+  getStatsQueryBuckets,
   groupMetricsByConversionWindowHours,
   maxColumnsNeededForMetric,
 } from "back-end/src/services/experimentQueries/experimentQueries";
@@ -779,6 +781,105 @@ describe("experimentQueries", () => {
 
     it("returns an empty map for no metrics", () => {
       expect(groupMetricsByConversionWindowHours([]).size).toBe(0);
+    });
+  });
+
+  describe("getStatsQueryBuckets", () => {
+    const conversionWindow = (windowValue: number) => ({
+      type: "conversion" as const,
+      delayValue: 0,
+      delayUnit: "hours" as const,
+      windowValue,
+      windowUnit: "days" as const,
+    });
+
+    const metric = (
+      id: string,
+      windowSettings: FactMetricInterface["windowSettings"],
+    ) =>
+      factMetricFactory.build({
+        id,
+        metricType: "mean",
+        numerator: { factTableId: "ft_1" },
+        windowSettings,
+      });
+
+    const buildSettings = (
+      skipPartialData: boolean,
+      endDate: Date,
+    ): ExperimentSnapshotSettings => ({
+      manual: false,
+      dimensions: [],
+      metricSettings: [],
+      goalMetrics: [],
+      secondaryMetrics: [],
+      guardrailMetrics: [],
+      activationMetric: null,
+      defaultMetricPriorSettings: {
+        override: false,
+        proper: false,
+        mean: 0,
+        stddev: 0,
+      },
+      regressionAdjustmentEnabled: false,
+      attributionModel: "firstExposure",
+      experimentId: "exp_1",
+      queryFilter: "",
+      segment: "",
+      skipPartialData,
+      datasourceId: "ds_1",
+      exposureQueryId: "exposure",
+      startDate: new Date("2024-01-01T00:00:00Z"),
+      endDate,
+      variations: [],
+    });
+
+    const referenceTime = new Date("2024-06-15T00:00:00Z");
+
+    it("returns a single uncut bucket when skipPartialData is off", () => {
+      const a = metric("a", conversionWindow(3));
+      const b = metric("b", conversionWindow(7));
+
+      const buckets = getStatsQueryBuckets({
+        metrics: [a, b],
+        snapshotSettings: buildSettings(
+          false,
+          new Date("2024-06-30T00:00:00Z"),
+        ),
+        referenceTime,
+      });
+
+      expect(buckets).toEqual([
+        { metrics: [a, b], maxFirstExposureTimestamp: null, nameSuffix: "" },
+      ]);
+    });
+
+    it("returns one bucket per conversion window when skipPartialData is on", () => {
+      const a = metric("a", conversionWindow(3)); // 72h
+      const b = metric("b", conversionWindow(3)); // 72h
+      const c = metric("c", conversionWindow(7)); // 168h
+
+      const buckets = getStatsQueryBuckets({
+        // far-future endDate so the cutoff is referenceTime - window
+        metrics: [a, b, c],
+        snapshotSettings: buildSettings(true, new Date("2025-01-01T00:00:00Z")),
+        referenceTime,
+      });
+
+      expect(buckets).toHaveLength(2);
+      const cw72 = buckets.find((x) => x.nameSuffix === "_cw72");
+      const cw168 = buckets.find((x) => x.nameSuffix === "_cw168");
+      expect(cw72?.metrics.map((m) => m.id)).toEqual(["a", "b"]);
+      expect(cw168?.metrics.map((m) => m.id)).toEqual(["c"]);
+
+      // Cutoff is derived from referenceTime (not wall clock) and is earlier
+      // for the longer window.
+      expect(cw72?.maxFirstExposureTimestamp?.getTime()).toBeLessThan(
+        referenceTime.getTime(),
+      );
+      expect(cw168?.maxFirstExposureTimestamp?.getTime()).toBeLessThan(
+        cw72?.maxFirstExposureTimestamp?.getTime() ?? 0,
+      );
     });
   });
 });

--- a/packages/back-end/test/services/experimentQueries.test.ts
+++ b/packages/back-end/test/services/experimentQueries.test.ts
@@ -2,6 +2,7 @@ import { FactMetricInterface } from "shared/types/fact-table";
 import {
   chunkMetrics,
   getFactMetricGroup,
+  groupMetricsByConversionWindowHours,
   maxColumnsNeededForMetric,
 } from "back-end/src/services/experimentQueries/experimentQueries";
 import { MAX_METRICS_PER_QUERY } from "back-end/src/services/experimentQueries/constants";
@@ -688,6 +689,96 @@ describe("experimentQueries", () => {
           getFactMetricGroup(b, { skipPartialData: true }),
         );
       });
+    });
+  });
+
+  describe("groupMetricsByConversionWindowHours", () => {
+    const conversionWindow = (
+      windowValue: number,
+      windowUnit: "minutes" | "hours" | "days" | "weeks",
+      delayValue = 0,
+      delayUnit: "minutes" | "hours" | "days" | "weeks" = "hours",
+    ) => ({
+      type: "conversion" as const,
+      delayValue,
+      delayUnit,
+      windowValue,
+      windowUnit,
+    });
+
+    const metric = (
+      id: string,
+      windowSettings: FactMetricInterface["windowSettings"],
+    ) =>
+      factMetricFactory.build({
+        id,
+        metricType: "mean",
+        numerator: { factTableId: "ft_1" },
+        windowSettings,
+      });
+
+    it("groups metrics with the same conversion window into one bucket", () => {
+      const a = metric("a", conversionWindow(3, "days"));
+      const b = metric("b", conversionWindow(3, "days"));
+
+      const groups = groupMetricsByConversionWindowHours([a, b]);
+
+      expect(groups.size).toBe(1);
+      // 3 days = 72 hours
+      expect(groups.get(72)?.map((m) => m.id)).toEqual(["a", "b"]);
+    });
+
+    it("separates metrics with different conversion windows into different buckets", () => {
+      const a = metric("a", conversionWindow(3, "days")); // 72h
+      const b = metric("b", conversionWindow(7, "days")); // 168h
+
+      const groups = groupMetricsByConversionWindowHours([a, b]);
+
+      expect(groups.size).toBe(2);
+      expect(groups.get(72)?.map((m) => m.id)).toEqual(["a"]);
+      expect(groups.get(168)?.map((m) => m.id)).toEqual(["b"]);
+    });
+
+    it("groups equivalent windows expressed in different units together", () => {
+      const days = metric("days", conversionWindow(1, "days")); // 24h
+      const hours = metric("hours", conversionWindow(24, "hours")); // 24h
+
+      const groups = groupMetricsByConversionWindowHours([days, hours]);
+
+      expect(groups.size).toBe(1);
+      expect(groups.get(24)?.map((m) => m.id)).toEqual(["days", "hours"]);
+    });
+
+    it("buckets lookback and no-window metrics together under 0 hours", () => {
+      const noWindow = metric("none", {
+        type: "",
+        delayValue: 0,
+        delayUnit: "hours",
+        windowValue: 0,
+        windowUnit: "hours",
+      });
+      const lookback = metric("lookback", {
+        type: "lookback",
+        delayValue: 0,
+        delayUnit: "hours",
+        windowValue: 3,
+        windowUnit: "days",
+      });
+      const conversion = metric("conversion", conversionWindow(3, "days"));
+
+      const groups = groupMetricsByConversionWindowHours([
+        noWindow,
+        lookback,
+        conversion,
+      ]);
+
+      expect(groups.size).toBe(2);
+      expect(groups.get(0)?.map((m) => m.id)).toEqual(["none", "lookback"]);
+      expect(groups.get(72)?.map((m) => m.id)).toEqual(["conversion"]);
+    });
+
+    it("returns an empty map for no metrics", () => {
+      expect(groupMetricsByConversionWindowHours([]).size).toBe(0);
     });
   });
 });

--- a/packages/front-end/components/Experiment/AnalysisForm.tsx
+++ b/packages/front-end/components/Experiment/AnalysisForm.tsx
@@ -1083,37 +1083,25 @@ const AnalysisForm: FC<{
                       )}
                     {datasourceProperties?.separateExperimentResultQueries && (
                       <div className="form-group mb-2">
-                        <Tooltip
-                          shouldDisplay={
-                            isExperimentIncludedInIncrementalRefresh
+                        <SelectField
+                          label="Metric Conversion Windows"
+                          labelClassName="font-weight-bold"
+                          value={form.watch("skipPartialData")}
+                          onChange={(value) =>
+                            form.setValue("skipPartialData", value)
                           }
-                          body="In-progress Conversions is not supported with Incremental Refresh while in beta"
-                        >
-                          <SelectField
-                            label="Metric Conversion Windows"
-                            labelClassName="font-weight-bold"
-                            value={form.watch("skipPartialData")}
-                            onChange={(value) =>
-                              form.setValue("skipPartialData", value)
-                            }
-                            options={[
-                              {
-                                label: "Include In-Progress Conversions",
-                                value: "loose",
-                              },
-                              {
-                                label: "Exclude In-Progress Conversions",
-                                value: "strict",
-                              },
-                            ]}
-                            isOptionDisabled={(option) =>
-                              isExperimentIncludedInIncrementalRefresh &&
-                              "value" in option &&
-                              option.value === "strict"
-                            }
-                            helpText="How to treat users not enrolled in the experiment long enough to complete conversion window."
-                          />
-                        </Tooltip>
+                          options={[
+                            {
+                              label: "Include In-Progress Conversions",
+                              value: "loose",
+                            },
+                            {
+                              label: "Exclude In-Progress Conversions",
+                              value: "strict",
+                            },
+                          ]}
+                          helpText="How to treat users not enrolled in the experiment long enough to complete conversion window."
+                        />
                       </div>
                     )}
                     {datasourceProperties?.separateExperimentResultQueries && (

--- a/packages/shared/src/validators/incremental-refresh.ts
+++ b/packages/shared/src/validators/incremental-refresh.ts
@@ -34,12 +34,8 @@ const incrementalRefresh = z
     unitsMaxTimestamp: z.date().nullable(),
     unitsDimensions: z.array(z.string()),
 
-    // Wall-clock reference time of the last successful main refresh — i.e. how
-    // current the materialized caches are. The "Exclude In-Progress
-    // Conversions" (skipPartialData) cutoff is computed relative to this so
-    // that read-only exploratory runs, which don't refresh the caches, use the
-    // same maturity boundary as the main run that built them (rather than their
-    // own later clock, which would surface not-yet-materialized partial data).
+    // When the caches were last refreshed; exploratory runs use it as the
+    // skipPartialData cutoff reference so it matches what the caches contain.
     lastRefreshTimestamp: z.date().nullable().optional(),
 
     // Experiment Settings Hash

--- a/packages/shared/src/validators/incremental-refresh.ts
+++ b/packages/shared/src/validators/incremental-refresh.ts
@@ -34,6 +34,14 @@ const incrementalRefresh = z
     unitsMaxTimestamp: z.date().nullable(),
     unitsDimensions: z.array(z.string()),
 
+    // Wall-clock reference time of the last successful main refresh — i.e. how
+    // current the materialized caches are. The "Exclude In-Progress
+    // Conversions" (skipPartialData) cutoff is computed relative to this so
+    // that read-only exploratory runs, which don't refresh the caches, use the
+    // same maturity boundary as the main run that built them (rather than their
+    // own later clock, which would surface not-yet-materialized partial data).
+    lastRefreshTimestamp: z.date().nullable().optional(),
+
     // Experiment Settings Hash
     experimentSettingsHash: z.string().nullable(),
 

--- a/packages/shared/types/integrations.d.ts
+++ b/packages/shared/types/integrations.d.ts
@@ -432,13 +432,8 @@ export interface IncrementalRefreshStatisticsQueryParams {
   unitsSourceTableFullName: string;
   metrics: FactMetricInterface[];
   lastMaxTimestamp: Date | null;
-  // When set ("Exclude In-Progress Conversions" / skipPartialData), restricts
-  // the analysis to units exposed early enough to have completed their full
-  // conversion window: `__experimentUnits` is filtered to
-  // `first_exposure_timestamp <= maxFirstExposureTimestamp`. All metrics in a
-  // given query must share one conversion window (the runner partitions stats
-  // queries by window) so this single cutoff is correct. Undefined/null => no
-  // exposure cutoff (include in-progress conversions).
+  // skipPartialData cutoff: filters __experimentUnits to
+  // first_exposure_timestamp <= this. Unset => include in-progress conversions.
   maxFirstExposureTimestamp?: Date | null;
 }
 

--- a/packages/shared/types/integrations.d.ts
+++ b/packages/shared/types/integrations.d.ts
@@ -432,6 +432,14 @@ export interface IncrementalRefreshStatisticsQueryParams {
   unitsSourceTableFullName: string;
   metrics: FactMetricInterface[];
   lastMaxTimestamp: Date | null;
+  // When set ("Exclude In-Progress Conversions" / skipPartialData), restricts
+  // the analysis to units exposed early enough to have completed their full
+  // conversion window: `__experimentUnits` is filtered to
+  // `first_exposure_timestamp <= maxFirstExposureTimestamp`. All metrics in a
+  // given query must share one conversion window (the runner partitions stats
+  // queries by window) so this single cutoff is correct. Undefined/null => no
+  // exposure cutoff (include in-progress conversions).
+  maxFirstExposureTimestamp?: Date | null;
 }
 
 type UnitsSource = "exposureQuery" | "exposureTable" | "otherQuery";


### PR DESCRIPTION
## Summary

Turning on **Exclude In-Progress Conversions** (`skipPartialData`) blocked **incremental refresh** entirely, forcing a full re-scan of all fact data on every run — a big, recurring performance hit.

This PR makes incremental refresh work with the setting by excluding not-yet-matured users at **read time** rather than at materialization.

## Changes

- **Unblocked incremental refresh** for `skipPartialData`. Metric caches are left untouched — instead the statistics query is split per conversion window and filters the units table by `first_exposure_timestamp <= cutoff`. Toggling the setting needs **no full refresh** (it no longer affects the cache hash).
- **Exploratory queries** use a new persisted `lastRefreshTimestamp` as the cutoff reference, so the maturity cutoff matches what the caches actually contain — not the query's own clock.

## Tests

Unit tests for the new window-bucketing helper and `getExperimentEndDate`, plus SQL-generation tests for the read-time cutoff (present/absent, deterministic). All existing SQL snapshots unchanged.
