### PR TITLE
fix: include precomputedUnitDimensionIds in snapshotSatisfiesBlock check

### DIFF
--- a/packages/shared/src/enterprise/dashboards/utils.ts
+++ b/packages/shared/src/enterprise/dashboards/utils.ts
@@ -131,8 +131,13 @@ export function snapshotSatisfiesBlock(
   }
   if (!blockSettings.dimensionId) return true;
   // If snapshot doesn't have a dimension, check whether the requested dimension is precomputed
-  return snapshot.settings.dimensions.some(
-    ({ id }) => blockSettings.dimensionId === id,
+  // Check both regular precomputed dimensions and precomputed unit dimensions
+  const precomputedDimIds = snapshot.settings.dimensions.map(({ id }) => id);
+  const precomputedUnitDimIds =
+    snapshot.settings.precomputedUnitDimensionIds ?? [];
+  return (
+    precomputedDimIds.includes(blockSettings.dimensionId) ||
+    precomputedUnitDimIds.includes(blockSettings.dimensionId)
   );
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

When determining if a snapshot satisfies a dashboard block's dimension requirement, `snapshotSatisfiesBlock` was only checking regular precomputed dimensions (`snapshot.settings.dimensions`) but not precomputed unit dimensions (`snapshot.settings.precomputedUnitDimensionIds`).

This caused redundant exploratory snapshots to be created in `updateExperimentDashboards` for unit dimensions that were already queued to be pre-computed in the main snapshot.

**The Fix:**

The fix adds a check for `precomputedUnitDimensionIds` alongside the existing `dimensions` check, consistent with how `isAnalysisAllowed` already handles this case in `packages/shared/src/util/index.ts`:

```typescript
// Before:
return snapshot.settings.dimensions.some(
  ({ id }) => blockSettings.dimensionId === id,
);

// After:
const precomputedDimIds = snapshot.settings.dimensions.map(({ id }) => id);
const precomputedUnitDimIds =
  snapshot.settings.precomputedUnitDimensionIds ?? [];
return (
  precomputedDimIds.includes(blockSettings.dimensionId) ||
  precomputedUnitDimIds.includes(blockSettings.dimensionId)
);
```

### Dependencies

None

### Testing

- All existing tests pass (shared, back-end, front-end)
- Type checking passes across all packages

- [ ] Human testing of this logic

### Screenshots

N/A - No UI changes
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C07NK4F016Z/p1780596463761349?thread_ts=1780596463.761349&cid=C07NK4F016Z)

<div><a href="https://cursor.com/agents/bc-cd232d0f-1c34-526d-9e40-5bfa9cf335fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd232d0f-1c34-526d-9e40-5bfa9cf335fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

