### PR TITLE
more fixes for a variety of small bugs and UI annoyances for schedules/ramps

### DIFF
--- a/packages/back-end/src/api/ramp-schedules/rampScheduleActions.ts
+++ b/packages/back-end/src/api/ramp-schedules/rampScheduleActions.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { v4 as uuidv4 } from "uuid";
 import { PermissionError } from "shared/util";
+import type { RampScheduleInterface } from "shared/validators";
 import {
   apiRampScheduleInterface,
   DEFAULT_NO_TRAFFIC_GRACE_PERIOD_HOURS,
@@ -18,6 +19,7 @@ import { getSRMHealthData, getMultipleExposureHealthData } from "shared/health";
 import {
   advanceScheduleManually,
   approveAndPublishStep,
+  completeRampKeepCutoff,
   completeRollout,
   ensureSafeRolloutForMonitoredRamp,
   getEffectiveRampAutoUpdateState,
@@ -196,9 +198,18 @@ export const completeRampSchedule = createApiRequestHandler({
   }
 
   const isSimple = schedule.steps.length === 0 && !!schedule.cutoffDate;
-  const completed = await completeRollout(req.context, schedule, {
-    disableActiveTargets: req.body?.disableRule === true || isSimple,
-  });
+  const disableNow = req.body?.disableRule === true || isSimple;
+  const hasFutureCutoff =
+    schedule.cutoffDate && schedule.cutoffDate > new Date();
+
+  let completed: RampScheduleInterface;
+  if (!disableNow && hasFutureCutoff) {
+    completed = await completeRampKeepCutoff(req.context, schedule);
+  } else {
+    completed = await completeRollout(req.context, schedule, {
+      disableActiveTargets: disableNow,
+    });
+  }
 
   return { rampSchedule: rampScheduleToApiInterface(completed) };
 });

--- a/packages/back-end/src/routers/ramp-schedule/ramp-schedule.controller.ts
+++ b/packages/back-end/src/routers/ramp-schedule/ramp-schedule.controller.ts
@@ -7,6 +7,7 @@ import {
   appendRampEvent,
   assertCanUpdateLinkedSafeRolloutMonitoringConfig,
   approveAndPublishStep,
+  completeRampKeepCutoff,
   completeRollout,
   computeNextProcessAt,
   dispatchRampEvent,
@@ -364,9 +365,17 @@ export const postRampScheduleAction = async (
       }
       {
         const isSimple = schedule.steps.length === 0 && !!schedule.cutoffDate;
-        updated = await completeRollout(context, schedule, {
-          disableActiveTargets: req.body?.disableRule === true || isSimple,
-        });
+        const disableNow = req.body?.disableRule === true || isSimple;
+        const hasFutureCutoff =
+          schedule.cutoffDate && schedule.cutoffDate > new Date();
+
+        if (!disableNow && hasFutureCutoff) {
+          updated = await completeRampKeepCutoff(context, schedule);
+        } else {
+          updated = await completeRollout(context, schedule, {
+            disableActiveTargets: disableNow,
+          });
+        }
       }
       break;
 

--- a/packages/back-end/src/services/rampSchedule.ts
+++ b/packages/back-end/src/services/rampSchedule.ts
@@ -820,51 +820,9 @@ export async function advanceStep(
   const step = schedule.steps[nextStepIndex];
 
   if (!step) {
-    const now = new Date();
-    // All steps are done. If there's a future cutoffDate, apply end actions
-    // (so the rule reaches its final state, e.g. coverage 100%) but keep the
-    // schedule running so the cutoff-driven disable fires at the right time.
-    if (schedule.cutoffDate && schedule.cutoffDate > now) {
-      const effective = computeEffectivePatch(schedule, schedule.steps.length);
-
-      const actionsToApply: RampStepAction[] = [...effective.entries()].map(
-        ([targetId, patch]) => ({
-          targetType: "feature-rule" as const,
-          targetId,
-          patch,
-        }),
-      );
-      if (actionsToApply.length > 0) {
-        await executeStepActions(
-          ctx,
-          schedule,
-          schedule.steps.length,
-          actionsToApply,
-        );
-      }
-
-      const pastEndIndex = schedule.steps.length;
-      const updated = await ctx.models.rampSchedules.updateById(schedule.id, {
-        currentStepIndex: pastEndIndex,
-        currentStepEnteredAt: now,
-        nextStepAt: null,
-        nextSnapshotAt: null,
-        nextProcessAt: computeNextProcessAt({
-          status: "running",
-          cutoffDate: schedule.cutoffDate,
-        }),
-        eventHistory: appendRampEvent(schedule, "step-advanced", {
-          stepIndex: pastEndIndex,
-          previousStepIndex: schedule.currentStepIndex,
-          status: "running",
-          previousStatus: schedule.status,
-        }),
-      });
-
-      await syncLinkedSafeRolloutForRampState(ctx, updated);
-      return updated;
+    if (schedule.cutoffDate && schedule.cutoffDate > new Date()) {
+      return applyEndActionsAndAwaitCutoff(ctx, schedule);
     }
-
     return completeRollout(ctx, schedule);
   }
 
@@ -1588,11 +1546,12 @@ export async function jumpAheadToStep(
 }
 
 /**
- * Applies end-state patches (final coverage, etc.) but keeps the schedule
- * "running" so the cutoff-date-driven disable still fires on time.
- * Use when the user wants to skip remaining steps but honour the cutoff.
+ * Applies end-state patches (final coverage, etc.) and transitions the
+ * schedule to "running" so the cutoff-date-driven disable still fires.
+ *
+ * Shared by `advanceStep` (automatic) and `completeRampKeepCutoff` (manual).
  */
-export async function completeRampKeepCutoff(
+async function applyEndActionsAndAwaitCutoff(
   ctx: ReqContext | ApiReqContext,
   schedule: RampScheduleInterface,
 ): Promise<RampScheduleInterface> {
@@ -1617,6 +1576,7 @@ export async function completeRampKeepCutoff(
 
   const pastEndIndex = schedule.steps.length;
   const updated = await ctx.models.rampSchedules.updateById(schedule.id, {
+    status: "running",
     currentStepIndex: pastEndIndex,
     currentStepEnteredAt: now,
     nextStepAt: null,
@@ -1635,6 +1595,18 @@ export async function completeRampKeepCutoff(
 
   await syncLinkedSafeRolloutForRampState(ctx, updated);
   return updated;
+}
+
+/**
+ * Applies end-state patches but keeps the schedule "running" so the
+ * cutoff-date-driven disable still fires on time. Use when the user
+ * wants to skip remaining steps but honour the cutoff.
+ */
+export async function completeRampKeepCutoff(
+  ctx: ReqContext | ApiReqContext,
+  schedule: RampScheduleInterface,
+): Promise<RampScheduleInterface> {
+  return applyEndActionsAndAwaitCutoff(ctx, schedule);
 }
 
 export async function completeRollout(

--- a/packages/back-end/src/services/rampSchedule.ts
+++ b/packages/back-end/src/services/rampSchedule.ts
@@ -1171,11 +1171,26 @@ export async function resumeSchedule(
           now,
         );
       } else {
-        // Already at the last step (nextStepIndex >= steps.length) with no
-        // nextStepAt — set it to now so advanceUntilBlocked can drive
-        // advanceStep → completeRollout rather than returning immediately on
-        // the !nextStepAt guard and stranding the schedule in "running" forever.
-        resumeUpdates.nextStepAt = now;
+        // At the last step (nextStepIndex >= steps.length) with no nextStepAt.
+        // If the current step has an interval, honour it so the step actually
+        // runs its hold time before advancing to completion. Otherwise set
+        // nextStepAt = now so advanceUntilBlocked finishes the schedule.
+        if (currentStep?.interval) {
+          const currentStepIndex = schedule.currentStepIndex;
+          let sumBefore = 0;
+          for (let i = 0; i < currentStepIndex; i++) {
+            sumBefore += schedule.steps[i]?.interval ?? 0;
+          }
+          const freshPhaseStart = new Date(now.getTime() - sumBefore * 1000);
+          resumeUpdates.phaseStartedAt = freshPhaseStart;
+          resumeUpdates.nextStepAt = computeNextStepAt(
+            { ...schedule, phaseStartedAt: freshPhaseStart },
+            currentStepIndex,
+            now,
+          );
+        } else {
+          resumeUpdates.nextStepAt = now;
+        }
       }
     }
   }
@@ -1569,6 +1584,56 @@ export async function jumpAheadToStep(
 
   await syncLinkedSafeRolloutForRampState(ctx, updated, "stopped");
 
+  return updated;
+}
+
+/**
+ * Applies end-state patches (final coverage, etc.) but keeps the schedule
+ * "running" so the cutoff-date-driven disable still fires on time.
+ * Use when the user wants to skip remaining steps but honour the cutoff.
+ */
+export async function completeRampKeepCutoff(
+  ctx: ReqContext | ApiReqContext,
+  schedule: RampScheduleInterface,
+): Promise<RampScheduleInterface> {
+  const now = new Date();
+  const effective = computeEffectivePatch(schedule, schedule.steps.length);
+
+  const actionsToApply: RampStepAction[] = [...effective.entries()].map(
+    ([targetId, patch]) => ({
+      targetType: "feature-rule" as const,
+      targetId,
+      patch,
+    }),
+  );
+  if (actionsToApply.length > 0) {
+    await executeStepActions(
+      ctx,
+      schedule,
+      schedule.steps.length,
+      actionsToApply,
+    );
+  }
+
+  const pastEndIndex = schedule.steps.length;
+  const updated = await ctx.models.rampSchedules.updateById(schedule.id, {
+    currentStepIndex: pastEndIndex,
+    currentStepEnteredAt: now,
+    nextStepAt: null,
+    nextSnapshotAt: null,
+    nextProcessAt: computeNextProcessAt({
+      status: "running",
+      cutoffDate: schedule.cutoffDate,
+    }),
+    eventHistory: appendRampEvent(schedule, "step-advanced", {
+      stepIndex: pastEndIndex,
+      previousStepIndex: schedule.currentStepIndex,
+      status: "running",
+      previousStatus: schedule.status,
+    }),
+  });
+
+  await syncLinkedSafeRolloutForRampState(ctx, updated);
   return updated;
 }
 

--- a/packages/back-end/test/services/rampSchedule.test.ts
+++ b/packages/back-end/test/services/rampSchedule.test.ts
@@ -42,6 +42,8 @@ import {
   applyRampStartActions,
   startReadyScheduleNow,
   approveAndPublishStep,
+  computeNextProcessAt,
+  pauseSchedule,
 } from "back-end/src/services/rampSchedule";
 
 // ---------------------------------------------------------------------------
@@ -1762,11 +1764,11 @@ describe("resumeSchedule", () => {
     mockPublishRevision.mockResolvedValue(makeFeature() as never);
   });
 
-  it("resume after jump-to-last-step sets nextStepAt=now so advanceUntilBlocked can complete the schedule", async () => {
+  it("resume after jump-to-last-step honours the step interval before completing", async () => {
     // jumpAheadToStep stores nextStepAt:null and status:paused. The schedule
-    // has 3 steps; currentStepIndex=2 is the last one. Resuming should set
-    // nextStepAt to now so advanceUntilBlocked → advanceStep → completeRollout
-    // fires, rather than leaving the schedule stranded in "running" forever.
+    // has 3 steps; currentStepIndex=2 is the last one with interval=900s.
+    // Resuming should compute a future nextStepAt based on the step's interval
+    // so the step runs its hold time before advancing to completion.
     const schedule = makeSchedule({
       status: "paused",
       currentStepIndex: 2, // last step (steps.length - 1 = 2)
@@ -1800,16 +1802,19 @@ describe("resumeSchedule", () => {
 
     await resumeSchedule(ctx as never, schedule);
 
-    // The first updateById call is the resume update — nextStepAt must be set
-    // so advanceUntilBlocked can gate on it.
     const [, resumeUpdates] = updateById.mock.calls[0];
     expect(resumeUpdates.nextStepAt).not.toBeNull();
     expect(resumeUpdates.nextStepAt).toBeInstanceOf(Date);
 
-    // completeRollout (triggered by advanceUntilBlocked → advanceStep) calls
-    // publishRevision to apply endActions, confirming the schedule reached
-    // completion rather than stalling.
-    expect(mockPublishRevision).toHaveBeenCalled();
+    // nextStepAt should be in the future (step interval not yet elapsed),
+    // NOT set to now — the step needs to run its hold time first.
+    expect(resumeUpdates.nextStepAt.getTime()).toBeGreaterThan(
+      Date.now() - 1000,
+    );
+
+    // completeRollout should NOT fire immediately — the step interval must
+    // elapse first.
+    expect(mockPublishRevision).not.toHaveBeenCalled();
   });
 });
 
@@ -3776,5 +3781,231 @@ describe("isReadyForApproval", () => {
         steps: [{ interval: null, holdConditions: {} }],
       }),
     ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeNextProcessAt
+// ---------------------------------------------------------------------------
+
+describe("computeNextProcessAt", () => {
+  it("running: returns earliest of nextStepAt, nextSnapshotAt, cutoffDate", () => {
+    const step = new Date("2026-06-10T00:00:00Z");
+    const snapshot = new Date("2026-06-08T00:00:00Z");
+    const cutoff = new Date("2026-06-15T00:00:00Z");
+    const result = computeNextProcessAt({
+      status: "running",
+      nextStepAt: step,
+      nextSnapshotAt: snapshot,
+      cutoffDate: cutoff,
+    });
+    expect(result).toEqual(snapshot);
+  });
+
+  it("running: returns cutoffDate when no step or snapshot timers exist", () => {
+    const cutoff = new Date("2026-06-15T00:00:00Z");
+    const result = computeNextProcessAt({
+      status: "running",
+      nextStepAt: null,
+      nextSnapshotAt: null,
+      cutoffDate: cutoff,
+    });
+    expect(result).toEqual(cutoff);
+  });
+
+  it("running: returns null when no timers exist at all", () => {
+    const result = computeNextProcessAt({
+      status: "running",
+      nextStepAt: null,
+      nextSnapshotAt: null,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("ready: returns startDate", () => {
+    const start = new Date("2026-06-05T00:00:00Z");
+    const result = computeNextProcessAt({
+      status: "ready",
+      startDate: start,
+    });
+    expect(result).toEqual(start);
+  });
+
+  it("ready: returns null when no startDate", () => {
+    const result = computeNextProcessAt({ status: "ready" });
+    expect(result).toBeNull();
+  });
+
+  it("paused: returns cutoffDate so scheduler can enforce the cutoff", () => {
+    const cutoff = new Date("2026-06-15T00:00:00Z");
+    const result = computeNextProcessAt({
+      status: "paused",
+      cutoffDate: cutoff,
+    });
+    expect(result).toEqual(cutoff);
+  });
+
+  it("paused: returns null when no cutoffDate", () => {
+    const result = computeNextProcessAt({ status: "paused" });
+    expect(result).toBeNull();
+  });
+
+  it("completed: returns null (terminal state)", () => {
+    const result = computeNextProcessAt({
+      status: "completed",
+      cutoffDate: new Date("2026-06-15T00:00:00Z"),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("rolled-back: returns null (terminal state)", () => {
+    const result = computeNextProcessAt({
+      status: "rolled-back",
+      cutoffDate: new Date("2026-06-15T00:00:00Z"),
+    });
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// advanceStep — future cutoffDate keeps schedule running
+// ---------------------------------------------------------------------------
+
+describe("advanceStep — future cutoffDate keeps schedule running", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetFeature.mockResolvedValue(makeFeature() as never);
+    mockCreateRevision.mockResolvedValue(makeRevision() as never);
+    mockPublishRevision.mockResolvedValue(makeFeature() as never);
+  });
+
+  it("stays running with nextProcessAt=cutoffDate when all steps are done but cutoff is future", async () => {
+    const futureCutoff = new Date(Date.now() + 60 * 60_000);
+    const schedule = makeSchedule({
+      currentStepIndex: 2,
+      cutoffDate: futureCutoff,
+    });
+    const { ctx, updateById } = makeContext({
+      currentStepIndex: 2,
+      cutoffDate: futureCutoff,
+    });
+
+    await advanceStep(ctx as never, schedule);
+
+    expect(mockPublishRevision).toHaveBeenCalledTimes(1);
+
+    const [, updates] = updateById.mock.calls[0];
+    expect(updates.status).toBeUndefined();
+    expect(updates.currentStepIndex).toBe(3);
+    expect(updates.nextProcessAt).toEqual(futureCutoff);
+    expect(updates.nextStepAt).toBeNull();
+  });
+
+  it("completes normally when cutoffDate is in the past", async () => {
+    const pastCutoff = new Date(Date.now() - 60_000);
+    const schedule = makeSchedule({
+      currentStepIndex: 2,
+      cutoffDate: pastCutoff,
+    });
+    const { ctx, updateById } = makeContext({
+      currentStepIndex: 2,
+      cutoffDate: pastCutoff,
+    });
+
+    await advanceStep(ctx as never, schedule);
+
+    const [, updates] = updateById.mock.calls[0];
+    expect(updates.status).toBe("completed");
+  });
+
+  it("completes normally when no cutoffDate exists", async () => {
+    const schedule = makeSchedule({ currentStepIndex: 2 });
+    const { ctx, updateById } = makeContext({ currentStepIndex: 2 });
+
+    await advanceStep(ctx as never, schedule);
+
+    const [, updates] = updateById.mock.calls[0];
+    expect(updates.status).toBe("completed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pauseSchedule — nextProcessAt from cutoffDate
+// ---------------------------------------------------------------------------
+
+describe("pauseSchedule", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("sets nextProcessAt to cutoffDate when a cutoff exists", async () => {
+    const futureCutoff = new Date(Date.now() + 60 * 60_000);
+    const schedule = makeSchedule({
+      status: "running",
+      currentStepIndex: 1,
+      cutoffDate: futureCutoff,
+    });
+
+    const updateById = jest
+      .fn()
+      .mockImplementation(
+        (_id: string, updates: Partial<RampScheduleInterface>) => ({
+          ...schedule,
+          ...updates,
+        }),
+      );
+
+    const ctx = {
+      org: { id: ORG_ID, settings: {} },
+      auditUser: { type: "system" },
+      environments: [],
+      permissions: {
+        canUpdateFeature: jest.fn().mockReturnValue(true),
+      },
+      models: {
+        rampSchedules: { updateById, getById: jest.fn() },
+      },
+    };
+
+    await pauseSchedule(ctx as never, schedule);
+
+    const [, updates] = updateById.mock.calls[0];
+    expect(updates.status).toBe("paused");
+    expect(updates.nextProcessAt).toEqual(futureCutoff);
+    expect(updates.nextSnapshotAt).toBeNull();
+  });
+
+  it("sets nextProcessAt to null when no cutoffDate exists", async () => {
+    const schedule = makeSchedule({
+      status: "running",
+      currentStepIndex: 1,
+    });
+
+    const updateById = jest
+      .fn()
+      .mockImplementation(
+        (_id: string, updates: Partial<RampScheduleInterface>) => ({
+          ...schedule,
+          ...updates,
+        }),
+      );
+
+    const ctx = {
+      org: { id: ORG_ID, settings: {} },
+      auditUser: { type: "system" },
+      environments: [],
+      permissions: {
+        canUpdateFeature: jest.fn().mockReturnValue(true),
+      },
+      models: {
+        rampSchedules: { updateById, getById: jest.fn() },
+      },
+    };
+
+    await pauseSchedule(ctx as never, schedule);
+
+    const [, updates] = updateById.mock.calls[0];
+    expect(updates.status).toBe("paused");
+    expect(updates.nextProcessAt).toBeNull();
   });
 });

--- a/packages/back-end/test/services/rampSchedule.test.ts
+++ b/packages/back-end/test/services/rampSchedule.test.ts
@@ -3895,7 +3895,7 @@ describe("advanceStep — future cutoffDate keeps schedule running", () => {
     expect(mockPublishRevision).toHaveBeenCalledTimes(1);
 
     const [, updates] = updateById.mock.calls[0];
-    expect(updates.status).toBeUndefined();
+    expect(updates.status).toBe("running");
     expect(updates.currentStepIndex).toBe(3);
     expect(updates.nextProcessAt).toEqual(futureCutoff);
     expect(updates.nextStepAt).toBeNull();

--- a/packages/front-end/components/Features/Rule.tsx
+++ b/packages/front-end/components/Features/Rule.tsx
@@ -1179,22 +1179,27 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
                                 )}
                                 {(() => {
                                   const hasCutoff = !!rampSchedule.cutoffDate;
+                                  const allStepsDone =
+                                    rampSchedule.currentStepIndex >=
+                                    rampSchedule.steps.length;
                                   return (
                                     <>
-                                      <DropdownMenuItem
-                                        onClick={async () => {
-                                          await apiCall(
-                                            `/ramp-schedule/${rampSchedule.id}/actions/complete`,
-                                            { method: "POST" },
-                                          );
-                                          await mutate();
-                                          setDropdownOpen(false);
-                                        }}
-                                      >
-                                        <Flex align="center" gap="2">
-                                          <PiFastForward /> Complete ramp
-                                        </Flex>
-                                      </DropdownMenuItem>
+                                      {!allStepsDone && (
+                                        <DropdownMenuItem
+                                          onClick={async () => {
+                                            await apiCall(
+                                              `/ramp-schedule/${rampSchedule.id}/actions/complete`,
+                                              { method: "POST" },
+                                            );
+                                            await mutate();
+                                            setDropdownOpen(false);
+                                          }}
+                                        >
+                                          <Flex align="center" gap="2">
+                                            <PiFastForward /> Complete ramp
+                                          </Flex>
+                                        </DropdownMenuItem>
+                                      )}
                                       {hasCutoff && (
                                         <DropdownMenuItem
                                           onClick={async () => {

--- a/packages/front-end/components/Features/RuleModal/ScheduleInputs.tsx
+++ b/packages/front-end/components/Features/RuleModal/ScheduleInputs.tsx
@@ -13,6 +13,7 @@ import type { RampSectionState } from "@/components/Features/RuleModal/RampSched
 interface Props {
   state: RampSectionState;
   setState: (s: RampSectionState) => void;
+  disabled?: boolean;
 }
 
 /** Auto-generate a human-readable schedule name based on start/end dates. */
@@ -79,7 +80,7 @@ function formatOptionLabel(
   );
 }
 
-export default function ScheduleInputs({ state, setState }: Props) {
+export default function ScheduleInputs({ state, setState, disabled }: Props) {
   const endTriggerValue = state.endScheduleAt ? "specific-time" : "never";
 
   function patchState(patch: Partial<RampSectionState>) {
@@ -125,6 +126,7 @@ export default function ScheduleInputs({ state, setState }: Props) {
           value={state.startDate ? "specific-time" : "immediately"}
           options={START_OPTIONS}
           onChange={handleStartChange}
+          disabled={disabled}
           containerClassName="mb-0"
           containerStyle={{ minHeight: 38, width: 150 }}
           useMultilineLabels
@@ -137,6 +139,7 @@ export default function ScheduleInputs({ state, setState }: Props) {
             precision="datetime"
             containerClassName="mb-0"
             scheduleEndDate={state.endScheduleAt || undefined}
+            disabled={disabled}
           />
         )}
       </Flex>
@@ -152,6 +155,7 @@ export default function ScheduleInputs({ state, setState }: Props) {
           value={endTriggerValue}
           options={END_OPTIONS}
           onChange={handleEndChange}
+          disabled={disabled}
           containerClassName="mb-0"
           containerStyle={{ minHeight: 38, width: 150 }}
           useMultilineLabels
@@ -169,6 +173,7 @@ export default function ScheduleInputs({ state, setState }: Props) {
             disableBefore={
               state.startDate ? new Date(state.startDate) : new Date()
             }
+            disabled={disabled}
           />
         )}
       </Flex>

--- a/packages/front-end/components/Features/RuleModal/StandardRuleFields.tsx
+++ b/packages/front-end/components/Features/RuleModal/StandardRuleFields.tsx
@@ -26,6 +26,7 @@ import {
   defaultRampSectionState,
 } from "@/components/Features/RuleModal/RampScheduleSection";
 import HelperText from "@/ui/HelperText";
+import Button from "@/ui/Button";
 import Callout from "@/ui/Callout";
 import MonitoredIcon from "@/components/Features/RuleModal/MonitoredIcon";
 import RampScheduleBadge from "@/components/RampSchedule/RampScheduleBadge";
@@ -129,7 +130,9 @@ export default function StandardRuleFields({
     !!ruleRampSchedule &&
     ruleRampSchedule.status === "running" &&
     !isSimpleSchedule;
-  const releasePlanLocked = rampScheduleEditLocked;
+  const pendingScheduleRemoval =
+    !!ruleRampSchedule && isSimpleSchedule && rampSectionState.mode === "off";
+  const releasePlanLocked = rampScheduleEditLocked || pendingScheduleRemoval;
   const selectorScheduleType: ScheduleSelectorType =
     scheduleType === "ramp" && rampSectionState.steps.some((s) => s.monitored)
       ? "ramp-monitored"
@@ -268,12 +271,15 @@ export default function StandardRuleFields({
           <HelperText status="info" mb="2" icon={<PiLockSimple />}>
             <Box>
               <Text as="div">
-                Locked while {isSimpleSchedule ? "Schedule" : "Ramp-up"} is
-                running
+                {pendingScheduleRemoval
+                  ? "Locked while schedule removal is pending"
+                  : `Locked while ${isSimpleSchedule ? "Schedule" : "Ramp-up"} is running`}
               </Text>
-              <Text as="div" mt="1" size="small">
-                To change the release plan, pause or end the Ramp-up
-              </Text>
+              {!pendingScheduleRemoval && (
+                <Text as="div" mt="1" size="small">
+                  To change the release plan, pause or end the Ramp-up
+                </Text>
+              )}
             </Box>
           </HelperText>
         )}
@@ -362,10 +368,50 @@ export default function StandardRuleFields({
                 hideToggle={true}
               />
             ) : (
-              <ScheduleInputs
-                state={rampSectionState}
-                setState={setRampSectionState}
-              />
+              <>
+                {(() => {
+                  const isTerminal =
+                    !!ruleRampSchedule &&
+                    isSimpleSchedule &&
+                    ["completed", "rolled-back"].includes(
+                      ruleRampSchedule.status,
+                    );
+                  const isPendingRemoval = rampSectionState.mode === "off";
+                  return (
+                    <>
+                      <ScheduleInputs
+                        state={rampSectionState}
+                        setState={setRampSectionState}
+                        disabled={isTerminal || isPendingRemoval}
+                      />
+                      {isTerminal && !isPendingRemoval && (
+                        <Callout status="info" mt="3" size="sm">
+                          <Flex align="center" justify="between" gap="3">
+                            <Text>This schedule has finished.</Text>
+                            <Button
+                              size="xs"
+                              variant="outline"
+                              onClick={() =>
+                                setRampSectionState({
+                                  ...rampSectionState,
+                                  mode: "off",
+                                })
+                              }
+                            >
+                              Remove schedule
+                            </Button>
+                          </Flex>
+                        </Callout>
+                      )}
+                      {isPendingRemoval && (
+                        <Callout status="info" mt="3" size="sm">
+                          Schedule will be removed on save.
+                        </Callout>
+                      )}
+                    </>
+                  );
+                })()}
+              </>
             )}
             {isLiveRule &&
               form.watch("enabled") &&

--- a/packages/front-end/components/RampSchedule/RampScheduleBadge.tsx
+++ b/packages/front-end/components/RampSchedule/RampScheduleBadge.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from "react";
 import { isReadyForApproval, RampScheduleInterface } from "shared/validators";
-import { abbreviateAgo, datetime } from "shared/dates";
+import { abbreviateAgo, dateNoYear, datetime } from "shared/dates";
 import Badge from "@/ui/Badge";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import {
@@ -71,12 +71,15 @@ export default function RampScheduleBadge({
       : (statusLabels[rs.status] ??
         `Schedule ${getRampStatusLabel(rs).toLowerCase()}`);
 
+    const endAt = rs.cutoffDate ? new Date(rs.cutoffDate) : null;
+    const futureEnd = endAt && endAt > now;
+
     let timingLabel: string | null = null;
     if (preStart && futureStart) {
       timingLabel = `Starts ${abbreviateAgo(startAt)}`;
+    } else if (rs.status === "running" && futureEnd) {
+      timingLabel = `Disables ${dateNoYear(endAt)}`;
     }
-
-    const endAt = rs.cutoffDate ? new Date(rs.cutoffDate) : null;
     const tooltipRows: ReactNode[] = [];
     if (startAt) tooltipRows.push(dateRow("Starts", startAt));
     if (endAt) tooltipRows.push(dateRow("Disables", endAt));
@@ -108,11 +111,20 @@ export default function RampScheduleBadge({
   const pausedAt =
     rs.status === "paused" && rs.pausedAt ? new Date(rs.pausedAt) : null;
 
+  const endAt = rs.cutoffDate ? new Date(rs.cutoffDate) : null;
+  const futureEnd = endAt && endAt > now;
+  const allStepsDone =
+    rs.status === "running" &&
+    rs.steps.length > 0 &&
+    rs.currentStepIndex >= rs.steps.length;
+
   let timingLabel: string | null = null;
   const timingTooltipRows: ReactNode[] = [];
   if (preStart && futureStart) {
     timingLabel = `Starts ${abbreviateAgo(startAt)}`;
     timingTooltipRows.push(dateRow("Starts", startAt));
+  } else if (allStepsDone && futureEnd) {
+    timingLabel = `Disables ${dateNoYear(endAt)}`;
   }
   if (rs.cutoffDate) {
     timingTooltipRows.push(dateRow("Disables", new Date(rs.cutoffDate)));
@@ -131,9 +143,12 @@ export default function RampScheduleBadge({
     completed: "Ramp complete",
     "rolled-back": "Rolled back",
   };
-  const featureContextLabel = isReadyForApproval(rs)
+  let featureContextLabel = isReadyForApproval(rs)
     ? "Ramp needs approval"
     : (featureContextLabels[rs.status] ?? `Ramp ${baseLabel.toLowerCase()}`);
+  if (allStepsDone && futureEnd) {
+    featureContextLabel = "Ramp complete";
+  }
   const displayLabel = featureRuleContext ? featureContextLabel : baseLabel;
 
   const badge = (


### PR DESCRIPTION
Fix a broad variety of minor bugs and UI annoyances:

- Fix "resume after jump to last step" skipping the step's interval and immediately completing the ramp
- Add "complete ramp and disable rule" as a distinct action from "complete ramp" for schedules with a cutoff date
- Show ramp/schedule status and disable date prominently in badge (e.g. "Ramp complete · Disables Jun 15")
- Disable and grey out rule editor fields for terminal simple schedules, with a "Remove schedule" option
- Disable "Restart" when cutoff date has already passed