### PR TITLE
fix(incremental): Handle null packing from quantile grid properly for incremental

### DIFF
--- a/packages/back-end/src/integrations/sql/columns/quantile-bounds-from-query-response.ts
+++ b/packages/back-end/src/integrations/sql/columns/quantile-bounds-from-query-response.ts
@@ -68,6 +68,16 @@ export function getQuantileBoundsFromQueryResponse(
         quantileData[`${prefix}quantile_nstar`] = n;
       }
     });
+
+    // Sparse slices can have quantile columns present but no usable grid bounds.
+    // Chunked query storage unions column names across rows, so omitting these
+    // fields on some rows rehydrates as explicit nulls and breaks gbstats input
+    // validation. Default to zero like other parseFloat(... ) || 0 paths.
+    if (quantileData[`${prefix}quantile_nstar`] === undefined) {
+      quantileData[`${prefix}quantile_lower`] = 0;
+      quantileData[`${prefix}quantile_upper`] = 0;
+      quantileData[`${prefix}quantile_nstar`] = 0;
+    }
   }
   return quantileData;
 }

--- a/packages/back-end/test/integrations/sql/quantile-bounds-from-query-response.test.ts
+++ b/packages/back-end/test/integrations/sql/quantile-bounds-from-query-response.test.ts
@@ -1,5 +1,7 @@
+import { decodeSQLResults, encodeSQLResults } from "shared/sql";
 import { N_STAR_VALUES } from "back-end/src/services/experimentQueries/constants";
 import { getQuantileBoundsFromQueryResponse } from "back-end/src/integrations/sql/columns/quantile-bounds-from-query-response";
+import { processExperimentFactMetricsQueryRows } from "back-end/src/integrations/sql/processing/process-experiment-fact-metrics-query-rows";
 
 // The array shape is the BigQuery-only optimization that packs the n_star CI
 // grid into one column instead of N_STAR_VALUES.length * 2 scalar columns.
@@ -91,6 +93,58 @@ describe("getQuantileBoundsFromQueryResponse — array vs scalar shape", () => {
     );
 
     expect(array).toEqual(scalar);
+    expect(array[`${prefix}quantile_lower`]).toBe(0);
+    expect(array[`${prefix}quantile_upper`]).toBe(0);
+    expect(array[`${prefix}quantile_nstar`]).toBe(0);
+  });
+
+  it("defaults bounds to zero on sparse slices with a null packed grid", () => {
+    const bounds = getQuantileBoundsFromQueryResponse(
+      {
+        [`${prefix}quantile`]: null,
+        [`${prefix}quantile_n`]: 0,
+        [`${prefix}quantile_grid`]: null,
+      },
+      prefix,
+    );
+
+    expect(bounds[`${prefix}quantile_lower`]).toBe(0);
+    expect(bounds[`${prefix}quantile_upper`]).toBe(0);
+    expect(bounds[`${prefix}quantile_nstar`]).toBe(0);
+  });
+
+  it("keeps zero bounds after chunked SQL result roundtrip for sparse slices", () => {
+    const denseRow = {
+      variation: "0",
+      users: 100,
+      m0_id: "fact_q",
+      m0_quantile: 0.9,
+      m0_quantile_n: 1000,
+      m0_quantile_grid: N_STAR_VALUES.flatMap((nstar) => [
+        0.9 - 1 / Math.sqrt(nstar),
+        0.9 + 1 / Math.sqrt(nstar),
+      ]),
+    };
+    const sparseRow = {
+      variation: "1",
+      users: 50,
+      m0_id: "fact_q",
+      m0_quantile: null,
+      m0_quantile_n: 0,
+      m0_quantile_grid: null,
+    };
+
+    const processed = processExperimentFactMetricsQueryRows([
+      denseRow,
+      sparseRow,
+    ]);
+    const [decodedSparse] = decodeSQLResults(encodeSQLResults(processed)).slice(
+      1,
+    );
+
+    expect(decodedSparse.m0_quantile_lower).toBe(0);
+    expect(decodedSparse.m0_quantile_upper).toBe(0);
+    expect(decodedSparse.m0_quantile_nstar).toBe(0);
   });
 
   it("throws when the grid array length does not match N_STAR_VALUES*2", () => {


### PR DESCRIPTION
### Features and Changes

After #5976, BigQuery quantile metrics store confidence-interval bounds in one packed array column instead of many separate columns.

On some experiment slices (e.g. a variation or dimension with no data for that metric), those bounds were missing.

When results are saved in chunks, missing values show up as null. The stats engine rejects null and the experiment ends up with empty results and no clear error.

This change fills in 0 for those missing bounds on empty slices, same as we already do for other numeric fields that are not packed.

### Testing

- [x] New unit tests
- [x] Manual testing