### PR TITLE
fix(query-runner): Ensure snapshot is marked as failed if analysis failed

### DIFF
--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -362,7 +362,23 @@ export abstract class QueryRunner<
       this.setStatus("finished", error, result);
     } else {
       this.setStatus("running");
-      // Re-arm refresh now that the full query DAG has been persisted.
+      // Schedule one more pass through refreshQueryStatuses/startReadyQueries
+      // now that the full `queries` array has been persisted to the model.
+      //
+      // This closes a race: queries with no dependencies are executed
+      // fire-and-forget inside startQueries() (see startQuery's readyToRun
+      // branch). If one of them is very fast (e.g. a DROP TABLE during a
+      // Full Refresh), it can finish — and its onQueryFinish 1-second timer
+      // can fire — while startQueries() is still generating SQL for the
+      // remaining queries and before updateModel() above has written them.
+      // That early timer reloads the model, sees no running/queued queries,
+      // and gives up. Once startQueries() finally returns, nothing re-arms
+      // the timer, so every other query in the DAG stays "queued" forever.
+      //
+      // Calling onQueryFinish() here guarantees at least one refresh happens
+      // after the DAG is visible in the persisted model. If the timer from
+      // the early-finishing query is still pending this is a no-op; if it
+      // already fired and found nothing, this re-arms it with the real DAG.
       this.onQueryFinish();
     }
 

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -350,7 +350,7 @@ export abstract class QueryRunner<
     }
 
     const newModel = await this.updateModel({
-      status: queryStatus,
+      status: error ? "failed" : queryStatus,
       queries,
       runStarted: new Date(),
       result: result,
@@ -362,23 +362,7 @@ export abstract class QueryRunner<
       this.setStatus("finished", error, result);
     } else {
       this.setStatus("running");
-      // Schedule one more pass through refreshQueryStatuses/startReadyQueries
-      // now that the full `queries` array has been persisted to the model.
-      //
-      // This closes a race: queries with no dependencies are executed
-      // fire-and-forget inside startQueries() (see startQuery's readyToRun
-      // branch). If one of them is very fast (e.g. a DROP TABLE during a
-      // Full Refresh), it can finish — and its onQueryFinish 1-second timer
-      // can fire — while startQueries() is still generating SQL for the
-      // remaining queries and before updateModel() above has written them.
-      // That early timer reloads the model, sees no running/queued queries,
-      // and gives up. Once startQueries() finally returns, nothing re-arms
-      // the timer, so every other query in the DAG stays "queued" forever.
-      //
-      // Calling onQueryFinish() here guarantees at least one refresh happens
-      // after the DAG is visible in the persisted model. If the timer from
-      // the early-finishing query is still pending this is a no-op; if it
-      // already fired and found nothing, this re-arms it with the real DAG.
+      // Re-arm refresh now that the full query DAG has been persisted.
       this.onQueryFinish();
     }
 
@@ -603,7 +587,7 @@ export abstract class QueryRunner<
     }
 
     const newModel = await this.updateModel({
-      status: newStatus,
+      status: error ? "failed" : newStatus,
       queries: this.model.queries,
       result,
       error,

--- a/packages/back-end/test/queryRunners/QueryRunner.test.ts
+++ b/packages/back-end/test/queryRunners/QueryRunner.test.ts
@@ -574,6 +574,83 @@ describe("QueryRunner", () => {
         jest.useRealTimers();
       }
     });
+
+    class FailingAnalysisQueryRunner extends RaceTestQueryRunner {
+      async runAnalysis(): Promise<{ success: boolean }> {
+        throw new Error("stats engine blew up");
+      }
+
+      async onQueryFinish() {}
+    }
+
+    it("persists a failed status when analysis throws on cached results", async () => {
+      const model: InterfaceWithQueries = {
+        id: "test-model",
+        organization: "test-org",
+        queries: [],
+        runStarted: new Date(),
+      };
+      const runner = new FailingAnalysisQueryRunner(
+        mockContext,
+        model,
+        mockIntegration,
+      );
+
+      const pointers: Queries = [
+        { name: "a", query: "qry_a", status: "succeeded" },
+        { name: "b", query: "qry_b", status: "succeeded" },
+      ];
+
+      await runner.startAnalysis({ pointers });
+
+      expect(runner.updateModelSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: "failed",
+          error: expect.stringContaining("stats engine blew up"),
+        }),
+      );
+      expect(runner.status).toBe("finished");
+      await expect(runner.waitForResults()).rejects.toThrow(
+        "stats engine blew up",
+      );
+    });
+
+    it("persists a failed status when analysis throws after queries finish", async () => {
+      const pointers: Queries = [
+        { name: "a", query: "qry_a", status: "running" },
+      ];
+      const model: InterfaceWithQueries = {
+        id: "test-model",
+        organization: "test-org",
+        queries: [],
+        runStarted: new Date(),
+      };
+      const runner = new FailingAnalysisQueryRunner(
+        mockContext,
+        model,
+        mockIntegration,
+      );
+
+      await runner.startAnalysis({ pointers });
+      expect(runner.status).toBe("running");
+      runner.updateModelSpy.mockClear();
+
+      const succeededQuery = createMockQuery("qry_a", "succeeded");
+      (getQueriesByIds as jest.Mock).mockResolvedValue([succeededQuery]);
+
+      await runner.refreshQueryStatuses();
+
+      expect(runner.updateModelSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: "failed",
+          error: expect.stringContaining("stats engine blew up"),
+        }),
+      );
+      expect(runner.status).toBe("finished");
+      await expect(runner.waitForResults()).rejects.toThrow(
+        "stats engine blew up",
+      );
+    });
   });
 
   describe("onHeartbeat lifecycle", () => {


### PR DESCRIPTION
### Features and Changes

QueryRunner was being stored with `status: success` if all queries succeeded, even if the analysis failed.

Now we properly mark it as failed, given we need to run the analysis to have useful data.