### PR TITLE
fix: apply custom field default values when creating experiment from template

### DIFF
--- a/packages/front-end/components/CustomFields/CustomFieldInput.tsx
+++ b/packages/front-end/components/CustomFields/CustomFieldInput.tsx
@@ -1,7 +1,10 @@
 import { FC, useEffect, useMemo, useState } from "react";
 import { CustomField, CustomFieldSection } from "shared/types/custom-fields";
 import { Flex, Box } from "@radix-ui/themes";
-import { filterCustomFieldsForSectionAndProject } from "@/hooks/useCustomFields";
+import {
+  filterCustomFieldsForSectionAndProject,
+  applyCustomFieldDefaults,
+} from "@/hooks/useCustomFields";
 import Field from "@/components/Forms/Field";
 import SelectField from "@/components/Forms/SelectField";
 import MultiSelectField from "@/components/Forms/MultiSelectField";
@@ -49,36 +52,11 @@ const CustomFieldInput: FC<{
       // here we are setting the default values in the form, otherwise
       // boolean/toggles or inputs with default values will not be saved.
       if (availableFields) {
-        const nextCustomFields = { ...normalizedCustomFields };
-        availableFields.forEach((v) => {
-          const currentValue = nextCustomFields?.[v.id];
-          const missingCurrentValue =
-            currentValue === undefined ||
-            currentValue === null ||
-            currentValue === "";
-          const hasDefaultValue =
-            v.defaultValue !== undefined &&
-            v.defaultValue !== null &&
-            (Array.isArray(v.defaultValue)
-              ? v.defaultValue.length > 0
-              : v.defaultValue !== "");
-
-          if (missingCurrentValue && hasDefaultValue) {
-            if (v.type === "multiselect") {
-              nextCustomFields[v.id] = Array.isArray(v.defaultValue)
-                ? JSON.stringify(v.defaultValue)
-                : JSON.stringify([v.defaultValue]);
-            } else if (v.type === "boolean") {
-              const normalizedDefault =
-                typeof v.defaultValue === "boolean"
-                  ? v.defaultValue
-                  : String(v.defaultValue).toLowerCase() === "true";
-              nextCustomFields[v.id] = String(normalizedDefault);
-            } else {
-              nextCustomFields[v.id] = String(v.defaultValue);
-            }
-          }
-        });
+        const nextCustomFields = applyCustomFieldDefaults(
+          availableFields,
+          normalizedCustomFields,
+          true,
+        );
         setCustomFields(nextCustomFields);
         setLoadedDefaults(true);
       }

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -34,6 +34,7 @@ import { getExposureQuery } from "@/services/datasources";
 import {
   filterCustomFieldsForSectionAndProject,
   useCustomFields,
+  applyCustomFieldDefaults,
 } from "@/hooks/useCustomFields";
 import {
   generateVariationId,
@@ -671,6 +672,14 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
         templateAsExperiment.skipPartialData = "loose";
       }
 
+      if (customFields) {
+        templateAsExperiment.customFields = applyCustomFieldDefaults(
+          customFields,
+          templateAsExperiment.customFields || {},
+          true,
+        );
+      }
+
       form.reset(templateAsExperiment, {
         keepDefaultValues: true,
       });
@@ -885,6 +894,16 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
 
                       const templateAsExperiment =
                         convertTemplateToExperiment(template);
+
+                      if (customFields) {
+                        templateAsExperiment.customFields =
+                          applyCustomFieldDefaults(
+                            customFields,
+                            templateAsExperiment.customFields || {},
+                            true,
+                          );
+                      }
+
                       form.reset(templateAsExperiment, {
                         keepDefaultValues: true,
                       });

--- a/packages/front-end/hooks/useCustomFields.ts
+++ b/packages/front-end/hooks/useCustomFields.ts
@@ -40,3 +40,45 @@ export function filterCustomFieldsForSectionAndProject(
     return v.projects.length === 0 || v.projects.includes(normalizedProject);
   });
 }
+
+export function applyCustomFieldDefaults(
+  customFieldsDef: CustomField[] | undefined,
+  currentValues: Record<string, string> = {},
+  treatEmptyStringAsMissing: boolean = false,
+): Record<string, string> {
+  if (!customFieldsDef || customFieldsDef.length === 0) return currentValues;
+
+  const merged = { ...currentValues };
+  customFieldsDef.forEach((v) => {
+    const currentValue = merged[v.id];
+    const missingCurrentValue =
+      currentValue === undefined ||
+      currentValue === null ||
+      (treatEmptyStringAsMissing && currentValue === "");
+
+    const hasDefaultValue =
+      v.defaultValue !== undefined &&
+      v.defaultValue !== null &&
+      (Array.isArray(v.defaultValue)
+        ? v.defaultValue.length > 0
+        : v.defaultValue !== "");
+
+    if (missingCurrentValue && hasDefaultValue) {
+      if (v.type === "multiselect") {
+        merged[v.id] = Array.isArray(v.defaultValue)
+          ? JSON.stringify(v.defaultValue)
+          : JSON.stringify([v.defaultValue]);
+      } else if (v.type === "boolean") {
+        const normalizedDefault =
+          typeof v.defaultValue === "boolean"
+            ? v.defaultValue
+            : String(v.defaultValue).toLowerCase() === "true";
+        merged[v.id] = String(normalizedDefault);
+      } else {
+        merged[v.id] = String(v.defaultValue);
+      }
+    }
+  });
+
+  return merged;
+}


### PR DESCRIPTION
## Summary

Fixes a bug where custom field default values were not applied when creating
a new experiment from an experiment template.

**Reported issue:** When a custom field is configured with a default value,
the default is correctly populated when creating a plain new experiment.
However, when creating an experiment from a template (especially one saved
*before* the custom field was added), the default value is missing.
Users were required to manually re-save every existing template to pick up
new defaults.

## Root Cause

`CustomFieldInput` uses a one-shot `useEffect` (guarded by a `loadedDefaults`
flag) to inject default values into the form on mount. When a user selects
a template, `form.reset()` overwrites the entire `customFields` object with
whatever was stored in the template. Since older templates predate the new
custom field, they don't contain it — and because `loadedDefaults` is already
`true`, the defaults injection effect never re-runs, leaving the field blank.

## Fix

Introduced a pure helper `applyCustomFieldDefaults` in `useCustomFields.ts`
that merges the latest configured default values into any existing
`customFields` object, only filling in keys that are missing or empty.

This helper is called **before** `form.reset()` in both places where a
template is applied in `NewExperimentForm`:

1. On mount, when a `templateId` is passed via URL params
2. When the user selects a template from the dropdown

This ensures that the most up-to-date default values are always injected,
regardless of when the template was originally saved.

## Changes

- `packages/front-end/hooks/useCustomFields.ts` — added `applyCustomFieldDefaults` helper
- `packages/front-end/components/CustomFields/CustomFieldInput.tsx` — refactored to use the new helper (no behaviour change)
- `packages/front-end/components/Experiment/NewExperimentForm.tsx` — merge defaults before `form.reset()` in both template-loading paths

## Testing

1. Create a custom field with a default value (e.g. `Jira ticket` → `https://jira.mycompany.com`)
2. Create an experiment template and **clear** the custom field default (simulating an old template)
3. Open **Add New Experiment** → select the template
4. The custom field now shows the default value instead of being blank


##Related issue(s)/PR(s)

Closes #5872