### PR TITLE
fix(helm): update sub-chart appVersion to 4.4.0

### DIFF
--- a/charts/growthbook/charts/server/Chart.yaml
+++ b/charts/growthbook/charts/server/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.0.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.5.0"
+appVersion: "4.4.0"


### PR DESCRIPTION
### Features and Changes

Updated the `appVersion` in the `server` sub-chart (`charts/growthbook/charts/server/Chart.yaml`) from `3.5.0` to `4.4.0`. This ensures Helm deploys the correct version of the Docker image (4.4.0 instead of 3.5.0) when installing the main chart.

- Closes #6013

### Testing

Run a `helm template` against the local chart to verify the correct image tag is rendered:

```bash
helm template growthbook ./charts/growthbook | grep image
````
Expected output:
```bash
image: "growthbook/growthbook:4.4.0"
```