### PR TITLE
Invalidate cached experiment data when referenced definitions change

### DIFF
--- a/packages/back-end/src/enterprise/services/data-pipeline.ts
+++ b/packages/back-end/src/enterprise/services/data-pipeline.ts
@@ -10,8 +10,9 @@ import {
   ExperimentSnapshotSettings,
   MetricForSnapshot,
 } from "shared/types/experiment-snapshot";
-import { OrganizationInterface } from "shared/types/organization";
 import { ExperimentInterface } from "shared/types/experiment";
+import { ExposureQuery } from "shared/types/datasource";
+import { SegmentInterface } from "shared/types/segment";
 import {
   FactMetricInterface,
   FactTableInterface,
@@ -20,11 +21,13 @@ import { FactTableMap } from "back-end/src/models/FactTableModel";
 import { orgHasPremiumFeature } from "back-end/src/enterprise";
 import { SourceIntegrationInterface } from "back-end/src/types/Integration";
 import { getFiltersForHash } from "back-end/src/services/experimentTimeSeries";
+import { ReqContext } from "back-end/types/request";
+import { ApiReqContext } from "back-end/types/api";
 
 // If the given settings / experiment is not compatible with incremental refresh, throw an error.
 // Otherwise, return void.
 export async function validateIncrementalPipeline({
-  org,
+  context,
   integration,
   snapshotSettings,
   metricMap,
@@ -33,7 +36,7 @@ export async function validateIncrementalPipeline({
   incrementalRefreshModel,
   analysisType,
 }: {
-  org: OrganizationInterface;
+  context: ReqContext | ApiReqContext;
   integration: SourceIntegrationInterface;
   snapshotSettings: ExperimentSnapshotSettings;
   metricMap: Map<string, ExperimentMetricInterface>;
@@ -54,7 +57,7 @@ export async function validateIncrementalPipeline({
 
   // Check if organization has the incremental refresh feature
   const hasIncrementalRefreshFeature = orgHasPremiumFeature(
-    org,
+    context.org,
     "incremental-refresh",
   );
   if (!hasIncrementalRefreshFeature) {
@@ -110,15 +113,27 @@ export async function validateIncrementalPipeline({
   // If not forcing a full refresh and we have a previous run, ensure the
   // current configuration matches what the incremental pipeline was built with.
   if (analysisType === "main-update" && incrementalRefreshModel) {
-    const currentSettingsHash =
-      getExperimentSettingsHashForIncrementalRefresh(snapshotSettings);
-    if (
-      incrementalRefreshModel.experimentSettingsHash &&
-      currentSettingsHash !== incrementalRefreshModel.experimentSettingsHash
-    ) {
-      throw new Error(
-        "The experiment configuration is outdated. Please run a Full Refresh.",
-      );
+    if (incrementalRefreshModel.experimentSettingsHash) {
+      const exposureQuery =
+        (settings.queries?.exposure || []).find(
+          (q) => q.id === snapshotSettings.exposureQueryId,
+        ) ?? null;
+      const segment = snapshotSettings.segment
+        ? await context.models.segments.getById(snapshotSettings.segment)
+        : null;
+      if (
+        !experimentSettingsHashMatchesForIncrementalRefresh({
+          storedHash: incrementalRefreshModel.experimentSettingsHash,
+          snapshotSettings,
+          exposureQuery,
+          segment,
+          factTableMap,
+        })
+      ) {
+        throw new Error(
+          "The experiment configuration is outdated. Please run a Full Refresh.",
+        );
+      }
     }
 
     // Validate metric settings hashes for existing metric sources
@@ -155,7 +170,135 @@ export async function validateIncrementalPipeline({
 
 const hashObject = (obj: object) => md5(JSON.stringify(obj));
 
-export function getExperimentSettingsHashForIncrementalRefresh(
+// Version prefix for the experiment settings hash. Bump whenever the set of
+// hashed inputs changes so that hashes stored by older builds can still be
+// compared with the matching legacy function below — a raw input change would
+// otherwise read as "configuration outdated" for every existing pipeline and
+// silently drop them all out of incremental refresh on deploy.
+const EXPERIMENT_SETTINGS_HASH_VERSION_PREFIX = "v2:";
+
+// Fields of `ExperimentSnapshotSettings` whose values change the incremental
+// units table SQL or the data it accumulates. Any change to one of these MUST
+// invalidate the units table and force a full refresh.
+const HASHED_SNAPSHOT_SETTINGS_FIELDS_FOR_INCREMENTAL_REFRESH = [
+  "activationMetric",
+  "attributionModel",
+  "queryFilter",
+  "segment",
+  "skipPartialData",
+  "datasourceId",
+  "exposureQueryId",
+  "startDate",
+  "regressionAdjustmentEnabled",
+  "experimentId",
+  "lookbackOverride",
+  // Compiled into the exposure query and segment SQL as template variables
+  "phase",
+  "customFields",
+] as const satisfies readonly (keyof ExperimentSnapshotSettings)[];
+
+// Fields of `ExperimentSnapshotSettings` that are intentionally NOT part of
+// the incremental-refresh hash:
+// - endDate moves forward on every incremental update by design
+// - dimensions / precomputedUnitDimensionIds / variations / statistical
+//   settings only affect analysis-time queries, which are recomputed from the
+//   units and metric source tables on every run (unit dimension columns are
+//   additionally gated by `unitsDimensions` on the incremental refresh model)
+// - metricSettings and the metric id lists are covered per-metric by
+//   `getMetricSettingsHashForIncrementalRefresh`
+type IgnoredSnapshotSettingsFieldForIncrementalRefresh =
+  | "endDate"
+  | "dimensions"
+  | "precomputedUnitDimensionIds"
+  | "metricSettings"
+  | "goalMetrics"
+  | "secondaryMetrics"
+  | "guardrailMetrics"
+  | "defaultMetricPriorSettings"
+  | "variations"
+  | "coverage"
+  | "banditSettings"
+  | "manual";
+
+// Compile-time exhaustiveness guard, mirroring the one for metric computed
+// settings below. When a field is added to `ExperimentSnapshotSettings`, this
+// fails to compile until the new field is classified as hashed or ignored.
+type UnhandledSnapshotSettingsFieldForIncrementalRefresh = Exclude<
+  keyof ExperimentSnapshotSettings,
+  | (typeof HASHED_SNAPSHOT_SETTINGS_FIELDS_FOR_INCREMENTAL_REFRESH)[number]
+  | IgnoredSnapshotSettingsFieldForIncrementalRefresh
+>;
+export type SnapshotSettingsForIncrementalRefreshExhaustivenessCheck =
+  AssertNever<UnhandledSnapshotSettingsFieldForIncrementalRefresh>;
+
+// The units table SQL also depends on definitions that snapshotSettings only
+// references by id. The ids don't change when the underlying SQL is edited,
+// so the definitions themselves must be hashed — otherwise rows produced by
+// the new definition get appended to a table built with the old one and the
+// mixed data is analyzed as if it were consistent.
+function getSegmentSettingsForHash(
+  segment: SegmentInterface | null,
+  factTableMap: FactTableMap,
+) {
+  if (!segment) return null;
+  const factTable = segment.factTableId
+    ? factTableMap.get(segment.factTableId)
+    : undefined;
+  return {
+    type: segment.type,
+    sql: segment.sql ?? null,
+    userIdType: segment.userIdType ?? null,
+    factTableId: segment.factTableId ?? null,
+    factTableSql: factTable?.sql ?? null,
+    // Resolved filter SQL, not just filter ids
+    filters:
+      factTable && segment.filters?.length
+        ? factTable.filters
+            .filter((f) => segment.filters?.includes(f.id))
+            .map((f) => ({ id: f.id, value: f.value }))
+        : null,
+  };
+}
+
+export function getExperimentSettingsHashForIncrementalRefresh({
+  snapshotSettings,
+  exposureQuery,
+  segment,
+  factTableMap,
+}: {
+  snapshotSettings: ExperimentSnapshotSettings;
+  exposureQuery: ExposureQuery | null;
+  segment: SegmentInterface | null;
+  factTableMap: FactTableMap;
+}): string {
+  // Normalize undefined to null so optional fields hash deterministically
+  const snapshotSettingsFields = Object.fromEntries(
+    HASHED_SNAPSHOT_SETTINGS_FIELDS_FOR_INCREMENTAL_REFRESH.map((field) => [
+      field,
+      snapshotSettings[field] ?? null,
+    ]),
+  );
+
+  return (
+    EXPERIMENT_SETTINGS_HASH_VERSION_PREFIX +
+    hashObject({
+      ...snapshotSettingsFields,
+      exposureQuery: exposureQuery
+        ? {
+            query: exposureQuery.query,
+            userIdType: exposureQuery.userIdType,
+          }
+        : null,
+      segmentDefinition: getSegmentSettingsForHash(segment, factTableMap),
+    })
+  );
+}
+
+// The hash exactly as computed before the version prefix was introduced.
+// Stored hashes without a version prefix were written by this function; keep
+// it so those pipelines keep validating (and keep running incrementally)
+// until the runner rewrites the stored hash on their next successful update.
+function getLegacyExperimentSettingsHashForIncrementalRefresh(
   snapshotSettings: ExperimentSnapshotSettings,
 ): string {
   return hashObject({
@@ -171,6 +314,39 @@ export function getExperimentSettingsHashForIncrementalRefresh(
     regressionAdjustmentEnabled: snapshotSettings.regressionAdjustmentEnabled,
     experimentId: snapshotSettings.experimentId,
   });
+}
+
+export function experimentSettingsHashMatchesForIncrementalRefresh({
+  storedHash,
+  snapshotSettings,
+  exposureQuery,
+  segment,
+  factTableMap,
+}: {
+  storedHash: string;
+  snapshotSettings: ExperimentSnapshotSettings;
+  exposureQuery: ExposureQuery | null;
+  segment: SegmentInterface | null;
+  factTableMap: FactTableMap;
+}): boolean {
+  if (!storedHash.startsWith(EXPERIMENT_SETTINGS_HASH_VERSION_PREFIX)) {
+    // Hash written by an older build. The inputs added since then weren't
+    // captured at units-table build time, so they can't be validated
+    // retroactively; they're covered from the next successful update onward.
+    return (
+      storedHash ===
+      getLegacyExperimentSettingsHashForIncrementalRefresh(snapshotSettings)
+    );
+  }
+  return (
+    storedHash ===
+    getExperimentSettingsHashForIncrementalRefresh({
+      snapshotSettings,
+      exposureQuery,
+      segment,
+      factTableMap,
+    })
+  );
 }
 
 type ComputedSettingsForSnapshot = NonNullable<

--- a/packages/back-end/src/enterprise/services/data-pipeline.ts
+++ b/packages/back-end/src/enterprise/services/data-pipeline.ts
@@ -1,4 +1,3 @@
-import md5 from "md5";
 import {
   ExperimentMetricInterface,
   isFactMetric,
@@ -17,6 +16,7 @@ import {
   FactMetricInterface,
   FactTableInterface,
 } from "shared/types/fact-table";
+import { hashObject } from "back-end/src/util/hash.util";
 import { FactTableMap } from "back-end/src/models/FactTableModel";
 import { orgHasPremiumFeature } from "back-end/src/enterprise";
 import { SourceIntegrationInterface } from "back-end/src/types/Integration";
@@ -168,8 +168,6 @@ export async function validateIncrementalPipeline({
   }
 }
 
-const hashObject = (obj: object) => md5(JSON.stringify(obj));
-
 // Version prefix for the experiment settings hash. Bump whenever the set of
 // hashed inputs changes so that hashes stored by older builds can still be
 // compared with the matching legacy function below — a raw input change would
@@ -236,6 +234,48 @@ export type SnapshotSettingsForIncrementalRefreshExhaustivenessCheck =
 // so the definitions themselves must be hashed — otherwise rows produced by
 // the new definition get appended to a table built with the old one and the
 // mixed data is analyzed as if it were consistent.
+//
+// The same classification discipline applies to these definition objects:
+// when a field is added to ExposureQuery or SegmentInterface, the guards
+// below fail to compile until it's classified as hashed or ignored.
+type HashedExposureQueryField = "query" | "userIdType";
+type IgnoredExposureQueryField =
+  | "id" // hashed via snapshotSettings.exposureQueryId
+  | "name"
+  | "description" // cosmetic
+  | "hasNameCol" // display-only
+  | "dimensions"
+  | "dimensionSlicesId"
+  | "dimensionMetadata" // gated by unitsDimensions / recomputed at analysis time
+  | "error"; // transient status
+export type ExposureQueryForIncrementalRefreshExhaustivenessCheck = AssertNever<
+  Exclude<
+    keyof ExposureQuery,
+    HashedExposureQueryField | IgnoredExposureQueryField
+  >
+>;
+
+type HashedSegmentField =
+  | "type"
+  | "sql"
+  | "userIdType"
+  | "factTableId"
+  | "filters"; // resolved to filter SQL below
+type IgnoredSegmentField =
+  | "id" // hashed via snapshotSettings.segment
+  | "organization"
+  | "owner"
+  | "datasource" // hashed via snapshotSettings.datasourceId
+  | "dateCreated"
+  | "dateUpdated"
+  | "name"
+  | "description" // cosmetic
+  | "managedBy"
+  | "projects"; // access control, not SQL
+export type SegmentForIncrementalRefreshExhaustivenessCheck = AssertNever<
+  Exclude<keyof SegmentInterface, HashedSegmentField | IgnoredSegmentField>
+>;
+
 function getSegmentSettingsForHash(
   segment: SegmentInterface | null,
   factTableMap: FactTableMap,
@@ -389,6 +429,11 @@ type UnhandledComputedSettingsFieldForIncrementalRefresh = Exclude<
 export type ComputedSettingsForIncrementalRefreshExhaustivenessCheck =
   AssertNever<UnhandledComputedSettingsFieldForIncrementalRefresh>;
 
+// NOTE: like the experiment settings hash above, this hash is stored (on
+// each metric source) and compared across deploys. If the set of hashed
+// inputs here ever changes, apply the same version-prefix + legacy-comparison
+// treatment used for the experiment settings hash — a raw input change would
+// invalidate every stored metric source on deploy.
 export function getMetricSettingsHashForIncrementalRefresh({
   factMetric,
   factTableMap,

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
@@ -384,7 +384,7 @@ export class ExperimentIncrementalRefreshExploratoryQueryRunner extends QueryRun
     }
 
     await validateIncrementalPipeline({
-      org: this.context.org,
+      context: this.context,
       integration: this.integration,
       snapshotSettings: params.snapshotSettings,
       metricMap: params.metricMap,

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -520,9 +520,12 @@ const startExperimentIncrementalRefreshQueries = async (
               unitsTableFullName: unitsTableFullName,
               unitsMaxTimestamp: maxTimestamp,
               experimentSettingsHash:
-                getExperimentSettingsHashForIncrementalRefresh(
+                getExperimentSettingsHashForIncrementalRefresh({
                   snapshotSettings,
-                ),
+                  exposureQuery,
+                  segment: segmentObj,
+                  factTableMap: params.factTableMap,
+                }),
               unitsDimensions: eligibleDimensions.map((d) => d.id),
             },
           );
@@ -1150,7 +1153,7 @@ export class ExperimentIncrementalRefreshQueryRunner extends QueryRunner<
 
     // Throws if any settings/experiment is not supported
     await validateIncrementalPipeline({
-      org: this.context.org,
+      context: this.context,
       integration: this.integration,
       snapshotSettings: params.snapshotSettings,
       metricMap: params.metricMap,

--- a/packages/back-end/src/routers/population-data/population-data.controller.ts
+++ b/packages/back-end/src/routers/population-data/population-data.controller.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import md5 from "md5";
 import type { Response } from "express";
 import { ExperimentMetricInterface, isFactMetric } from "shared/experiments";
 import { ExperimentSnapshotSettings } from "shared/types/experiment-snapshot";
@@ -13,6 +12,7 @@ import {
   getIntegrationFromDatasourceId,
   getSourceIntegrationObject,
 } from "back-end/src/services/datasource";
+import { hashObject } from "back-end/src/util/hash.util";
 import { getContextFromReq } from "back-end/src/services/organizations";
 import { AuthRequest } from "back-end/src/types/AuthRequest";
 import { PopulationDataQueryRunner } from "back-end/src/queryRunners/PopulationDataQueryRunner";
@@ -27,8 +27,6 @@ import { PrivateApiErrorResponse } from "back-end/types/api";
 type CreatePopulationDataProps = z.infer<
   typeof createPopulationDataPropsValidator
 >;
-
-const hashObject = (obj: object) => md5(JSON.stringify(obj));
 
 // Cache-validation hashes for population data. These are version stamps
 // (id + dateUpdated of every definition the queries read), not field-by-field
@@ -65,10 +63,15 @@ function getPopulationSourceSettingsHash({
 
 function getPopulationMetricSettingsHash(
   metric: ExperimentMetricInterface,
+  metricMap: Map<string, ExperimentMetricInterface>,
   factTableMap: FactTableMap,
 ): string {
   // Fact table edits (sql, filters) don't bump the metric's own dateUpdated
   const factTableStamps: { id: string; dateUpdated: Date | null }[] = [];
+  // A classic ratio metric's denominator is another metric, resolved by id at
+  // query time — editing it doesn't bump this metric's dateUpdated either
+  let denominatorMetricStamp: { id: string; dateUpdated: Date | null } | null =
+    null;
   if (isFactMetric(metric)) {
     [metric.numerator.factTableId, metric.denominator?.factTableId].forEach(
       (factTableId) => {
@@ -79,11 +82,17 @@ function getPopulationMetricSettingsHash(
         });
       },
     );
+  } else if (metric.denominator) {
+    denominatorMetricStamp = {
+      id: metric.denominator,
+      dateUpdated: metricMap.get(metric.denominator)?.dateUpdated ?? null,
+    };
   }
   return hashObject({
     id: metric.id,
     dateUpdated: metric.dateUpdated ?? null,
     factTables: factTableStamps,
+    denominatorMetric: denominatorMetricStamp,
   });
 }
 
@@ -121,19 +130,17 @@ export const postPopulationData = async (
   }
 
   // see if one exists from the last 7 days
-  const populationData =
-    await context.models.populationData.getRecentUsingSettings(
+  const [populationData, metricMap, factTableMap, segment] = await Promise.all([
+    context.models.populationData.getRecentUsingSettings(
       data.sourceId,
       data.userIdType,
-    );
-
-  const metricMap = await getMetricMap(context);
-  const factTableMap = await getFactTableMap(context);
-
-  const segment =
+    ),
+    getMetricMap(context),
+    getFactTableMap(context),
     data.sourceType === "segment"
-      ? await context.models.segments.getById(data.sourceId)
-      : null;
+      ? context.models.segments.getById(data.sourceId)
+      : null,
+  ]);
   const sourceFactTable =
     data.sourceType === "factTable"
       ? (factTableMap.get(data.sourceId) ?? null)
@@ -154,6 +161,7 @@ export const postPopulationData = async (
     if (metric) {
       metricSettingsHashes[metricId] = getPopulationMetricSettingsHash(
         metric,
+        metricMap,
         factTableMap,
       );
     }
@@ -196,7 +204,7 @@ export const postPopulationData = async (
     populationData.sourceSettingsHash === sourceSettingsHash
   ) {
     // Only reuse a cached metric if it was computed from the current metric
-    // definition; re-query metrics whose definition changed since.
+    // definition; a metric is stale if its definition changed since.
     const cachedValidMetricIds = new Set(
       populationData.metrics
         .filter((m) => {
@@ -208,16 +216,16 @@ export const postPopulationData = async (
         })
         .map((m) => m.metricId),
     );
-    // only ask for new or stale metrics
-    snapshotSettings.goalMetrics = data.metricIds.filter(
-      (m) => !cachedValidMetricIds.has(m),
-    );
-    if (snapshotSettings.goalMetrics.length === 0) {
+    if (data.metricIds.every((m) => cachedValidMetricIds.has(m))) {
       return res.status(200).json({
         status: 200,
         populationData,
       });
     }
+    // Otherwise re-query ALL requested metrics, not just the new/stale ones:
+    // the document created below becomes the most recent cache entry and the
+    // front-end reads a single document, so a partial document would leave
+    // the omitted (still-valid) metrics looking like they have no data.
     // TODO: incrementally do an update
   }
 

--- a/packages/back-end/src/routers/population-data/population-data.controller.ts
+++ b/packages/back-end/src/routers/population-data/population-data.controller.ts
@@ -1,8 +1,13 @@
 import { z } from "zod";
+import md5 from "md5";
 import type { Response } from "express";
+import { ExperimentMetricInterface, isFactMetric } from "shared/experiments";
 import { ExperimentSnapshotSettings } from "shared/types/experiment-snapshot";
 import { PopulationDataInterface } from "shared/types/population-data";
 import type { PopulationDataQuerySettings } from "shared/types/query";
+import { DataSourceInterface } from "shared/types/datasource";
+import { SegmentInterface } from "shared/types/segment";
+import { FactTableInterface } from "shared/types/fact-table";
 import { createPopulationDataPropsValidator } from "shared/validators";
 import {
   getIntegrationFromDatasourceId,
@@ -13,12 +18,74 @@ import { AuthRequest } from "back-end/src/types/AuthRequest";
 import { PopulationDataQueryRunner } from "back-end/src/queryRunners/PopulationDataQueryRunner";
 import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 import { getMetricMap } from "back-end/src/models/MetricModel";
-import { getFactTableMap } from "back-end/src/models/FactTableModel";
+import {
+  getFactTableMap,
+  FactTableMap,
+} from "back-end/src/models/FactTableModel";
 import { PrivateApiErrorResponse } from "back-end/types/api";
 
 type CreatePopulationDataProps = z.infer<
   typeof createPopulationDataPropsValidator
 >;
+
+const hashObject = (obj: object) => md5(JSON.stringify(obj));
+
+// Cache-validation hashes for population data. These are version stamps
+// (id + dateUpdated of every definition the queries read), not field-by-field
+// hashes: any edit to a definition invalidates the cached data, including
+// edits the queries don't depend on. Over-invalidation just costs a re-query;
+// silently reusing data computed from an older definition skews the power
+// estimates without any signal to the user.
+function getPopulationSourceSettingsHash({
+  datasource,
+  sourceType,
+  sourceId,
+  userIdType,
+  segment,
+  factTable,
+}: {
+  datasource: DataSourceInterface;
+  sourceType: CreatePopulationDataProps["sourceType"];
+  sourceId: string;
+  userIdType: string;
+  segment: SegmentInterface | null;
+  factTable: FactTableInterface | null;
+}): string {
+  return hashObject({
+    datasourceId: datasource.id,
+    // Covers exposure/identity-join settings used to join id types
+    datasourceDateUpdated: datasource.dateUpdated ?? null,
+    sourceType,
+    sourceId,
+    userIdType,
+    segmentDateUpdated: segment?.dateUpdated ?? null,
+    factTableDateUpdated: factTable?.dateUpdated ?? null,
+  });
+}
+
+function getPopulationMetricSettingsHash(
+  metric: ExperimentMetricInterface,
+  factTableMap: FactTableMap,
+): string {
+  // Fact table edits (sql, filters) don't bump the metric's own dateUpdated
+  const factTableStamps: { id: string; dateUpdated: Date | null }[] = [];
+  if (isFactMetric(metric)) {
+    [metric.numerator.factTableId, metric.denominator?.factTableId].forEach(
+      (factTableId) => {
+        if (!factTableId) return;
+        factTableStamps.push({
+          id: factTableId,
+          dateUpdated: factTableMap.get(factTableId)?.dateUpdated ?? null,
+        });
+      },
+    );
+  }
+  return hashObject({
+    id: metric.id,
+    dateUpdated: metric.dateUpdated ?? null,
+    factTables: factTableStamps,
+  });
+}
 
 export const postPopulationData = async (
   req: AuthRequest<CreatePopulationDataProps>,
@@ -60,6 +127,38 @@ export const postPopulationData = async (
       data.userIdType,
     );
 
+  const metricMap = await getMetricMap(context);
+  const factTableMap = await getFactTableMap(context);
+
+  const segment =
+    data.sourceType === "segment"
+      ? await context.models.segments.getById(data.sourceId)
+      : null;
+  const sourceFactTable =
+    data.sourceType === "factTable"
+      ? (factTableMap.get(data.sourceId) ?? null)
+      : null;
+
+  const sourceSettingsHash = getPopulationSourceSettingsHash({
+    datasource: integration.datasource,
+    sourceType: data.sourceType,
+    sourceId: data.sourceId,
+    userIdType: data.userIdType,
+    segment,
+    factTable: sourceFactTable,
+  });
+
+  const metricSettingsHashes: Record<string, string> = {};
+  data.metricIds.forEach((metricId) => {
+    const metric = metricMap.get(metricId);
+    if (metric) {
+      metricSettingsHashes[metricId] = getPopulationMetricSettingsHash(
+        metric,
+        factTableMap,
+      );
+    }
+  });
+
   const snapshotSettings: ExperimentSnapshotSettings = {
     dimensions: [],
     metricSettings: [],
@@ -86,17 +185,32 @@ export const postPopulationData = async (
     variations: [],
   };
 
-  // TODO hash metric and datasource to validate cache and let force refresh override
   // TODO incrementally update metrics
   if (
     !data.force &&
     populationData &&
-    populationData.datasourceId === data.datasourceId
+    populationData.datasourceId === data.datasourceId &&
+    // The population (units) side must have been computed from the same
+    // datasource/segment/fact table definitions. Documents written before
+    // hashes existed have no sourceSettingsHash and are treated as stale.
+    populationData.sourceSettingsHash === sourceSettingsHash
   ) {
-    const populationMetrics = populationData.metrics.map((m) => m.metricId);
-    // only ask for new metrics
+    // Only reuse a cached metric if it was computed from the current metric
+    // definition; re-query metrics whose definition changed since.
+    const cachedValidMetricIds = new Set(
+      populationData.metrics
+        .filter((m) => {
+          const storedHash = populationData.metricSettingsHashes?.[m.metricId];
+          return (
+            storedHash !== undefined &&
+            storedHash === metricSettingsHashes[m.metricId]
+          );
+        })
+        .map((m) => m.metricId),
+    );
+    // only ask for new or stale metrics
     snapshotSettings.goalMetrics = data.metricIds.filter(
-      (m) => !populationMetrics.includes(m),
+      (m) => !cachedValidMetricIds.has(m),
     );
     if (snapshotSettings.goalMetrics.length === 0) {
       return res.status(200).json({
@@ -123,6 +237,14 @@ export const postPopulationData = async (
     runStarted: null,
     status: "running",
 
+    sourceSettingsHash,
+    // Only the metrics this document will actually contain data for
+    metricSettingsHashes: Object.fromEntries(
+      snapshotSettings.goalMetrics
+        .filter((metricId) => metricSettingsHashes[metricId] !== undefined)
+        .map((metricId) => [metricId, metricSettingsHashes[metricId]]),
+    ),
+
     units: [],
     metrics: [],
   });
@@ -132,9 +254,6 @@ export const postPopulationData = async (
     integration,
     true,
   );
-
-  const metricMap = await getMetricMap(context);
-  const factTableMap = await getFactTableMap(context);
 
   await queryRunner
     .startAnalysis({

--- a/packages/back-end/src/services/experimentTimeSeries.ts
+++ b/packages/back-end/src/services/experimentTimeSeries.ts
@@ -421,7 +421,10 @@ function getMetricSettingsHash(
       denominatorFactTable: {
         sql: denominatorFactTable?.sql,
         eventName: denominatorFactTable?.eventName,
-        // TODO: also include denominator filters?
+        filters: getFiltersForHash(
+          denominatorFactTable,
+          factMetric.denominator,
+        ),
       },
     });
   }

--- a/packages/back-end/src/services/experimentTimeSeries.ts
+++ b/packages/back-end/src/services/experimentTimeSeries.ts
@@ -1,4 +1,3 @@
-import md5 from "md5";
 import {
   getAllExpandedMetricIdsFromExperiment,
   isFactMetricId,
@@ -31,6 +30,7 @@ import {
   ColumnRef,
 } from "shared/types/fact-table";
 import { ReqContext } from "back-end/types/request";
+import { hashObject } from "back-end/src/util/hash.util";
 import { getFactTableMap } from "back-end/src/models/FactTableModel";
 import { getMetricMap } from "back-end/src/models/MetricModel";
 import { getTimeSeriesAnalyses } from "back-end/src/services/experimentDimensionTimeSeries";
@@ -331,8 +331,6 @@ function convertMetricToMetricValue(
     chanceToWin: metric.chanceToWin ?? undefined,
   };
 }
-
-const hashObject = (obj: object) => md5(JSON.stringify(obj));
 
 function getExperimentSettingsHash(
   snapshotSettings: ExperimentSnapshotSettings,

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -1327,7 +1327,7 @@ function resolveFullRefresh(
 }
 
 async function planSnapshotQueryRunner({
-  organization,
+  context,
   datasource,
   integration,
   snapshotSettings,
@@ -1338,7 +1338,7 @@ async function planSnapshotQueryRunner({
   snapshotType,
   fullRefresh,
 }: {
-  organization: OrganizationInterface;
+  context: ReqContext | ApiReqContext;
   datasource: DataSourceInterface;
   integration: SourceIntegrationInterface;
   snapshotSettings: ExperimentSnapshotSettings;
@@ -1366,7 +1366,7 @@ async function planSnapshotQueryRunner({
 
   try {
     await validateIncrementalPipeline({
-      org: organization,
+      context,
       integration,
       snapshotSettings,
       metricMap,
@@ -1526,7 +1526,7 @@ export async function planSnapshot({
   const integration = getSourceIntegrationObject(context, datasource, true);
 
   const runnerPlan = await planSnapshotQueryRunner({
-    organization,
+    context,
     datasource,
     integration,
     snapshotSettings: data.settings,

--- a/packages/back-end/src/services/safeRolloutTimeSeries.ts
+++ b/packages/back-end/src/services/safeRolloutTimeSeries.ts
@@ -1,4 +1,3 @@
-import md5 from "md5";
 import { isFactMetricId, expandMetricGroups } from "shared/experiments";
 import { SAFE_ROLLOUT_VARIATIONS } from "shared/constants";
 import {
@@ -17,6 +16,7 @@ import {
   FactTableInterface,
 } from "shared/types/fact-table";
 import { ReqContext } from "back-end/types/request";
+import { hashObject } from "back-end/src/util/hash.util";
 import { getFactTableMap } from "back-end/src/models/FactTableModel";
 import { logger } from "back-end/src/util/logger";
 import { getFiltersForHash } from "back-end/src/services/experimentTimeSeries";
@@ -138,8 +138,6 @@ function convertMetricToMetricValue(
     chanceToWin: metric.chanceToWin ?? undefined,
   };
 }
-
-const hashObject = (obj: object) => md5(JSON.stringify(obj));
 
 function getSafeRolloutSettingsHash(
   snapshotSettings: SafeRolloutSnapshotSettings,

--- a/packages/back-end/src/services/safeRolloutTimeSeries.ts
+++ b/packages/back-end/src/services/safeRolloutTimeSeries.ts
@@ -199,7 +199,10 @@ function getSafeRolloutMetricSettingsHash(
       denominatorFactTable: {
         sql: denominatorFactTable?.sql,
         eventName: denominatorFactTable?.eventName,
-        // TODO: include denominator filters?
+        filters: getFiltersForHash(
+          denominatorFactTable,
+          factMetric.denominator,
+        ),
       },
     });
   }

--- a/packages/back-end/src/util/hash.util.ts
+++ b/packages/back-end/src/util/hash.util.ts
@@ -1,0 +1,11 @@
+import md5 from "md5";
+
+// Single definition for the settings-hash scheme used by the incremental
+// refresh gate, the time-series settings-change markers, and the population
+// data cache. These hashes are persisted and compared across deploys, so any
+// change to the scheme (digest, key ordering, undefined handling) must be
+// made here for all of them at once — a one-sided change makes stored hashes
+// permanently mismatch in whichever subsystem was missed.
+// Note: JSON.stringify is key-order-sensitive; callers construct the hashed
+// object literally (or from a const field list) so key order is fixed.
+export const hashObject = (obj: object): string => md5(JSON.stringify(obj));

--- a/packages/back-end/test/enterprise/dataPipelineSettingsHash.test.ts
+++ b/packages/back-end/test/enterprise/dataPipelineSettingsHash.test.ts
@@ -1,0 +1,255 @@
+import md5 from "md5";
+import type { ExperimentSnapshotSettings } from "shared/types/experiment-snapshot";
+import type { ExposureQuery } from "shared/types/datasource";
+import type { SegmentInterface } from "shared/types/segment";
+import type { FactTableInterface } from "shared/types/fact-table";
+import {
+  experimentSettingsHashMatchesForIncrementalRefresh,
+  getExperimentSettingsHashForIncrementalRefresh,
+} from "back-end/src/enterprise/services/data-pipeline";
+
+const baseSnapshotSettings: ExperimentSnapshotSettings = {
+  manual: false,
+  dimensions: [],
+  metricSettings: [],
+  goalMetrics: [],
+  secondaryMetrics: [],
+  guardrailMetrics: [],
+  activationMetric: null,
+  defaultMetricPriorSettings: {
+    override: false,
+    proper: false,
+    mean: 0,
+    stddev: 0,
+  },
+  regressionAdjustmentEnabled: false,
+  attributionModel: "firstExposure",
+  experimentId: "exp_1",
+  queryFilter: "",
+  segment: "",
+  skipPartialData: false,
+  datasourceId: "ds_1",
+  exposureQueryId: "exposure",
+  startDate: new Date("2024-01-01"),
+  endDate: new Date("2024-01-31"),
+  variations: [],
+};
+
+const baseExposureQuery: ExposureQuery = {
+  id: "exposure",
+  name: "Logged-in Users",
+  query: "SELECT user_id, timestamp, experiment_id, variation_id FROM events",
+  userIdType: "user_id",
+  dimensions: [],
+};
+
+const sqlSegment: SegmentInterface = {
+  id: "seg_1",
+  organization: "org_1",
+  owner: "",
+  datasource: "ds_1",
+  userIdType: "user_id",
+  name: "US Users",
+  type: "SQL",
+  sql: "SELECT user_id, date FROM users WHERE country = 'US'",
+  dateCreated: new Date("2024-01-01"),
+  dateUpdated: new Date("2024-01-01"),
+};
+
+const factTable = {
+  id: "ft_1",
+  sql: "SELECT user_id, timestamp, country FROM signups",
+  eventName: "",
+  filters: [
+    {
+      id: "flt_1",
+      name: "US only",
+      description: "",
+      value: "country = 'US'",
+      dateCreated: new Date("2024-01-01"),
+      dateUpdated: new Date("2024-01-01"),
+    },
+  ],
+} as unknown as FactTableInterface;
+
+const factSegment: SegmentInterface = {
+  ...sqlSegment,
+  id: "seg_2",
+  type: "FACT",
+  sql: "",
+  factTableId: "ft_1",
+  filters: ["flt_1"],
+};
+
+// The hash exactly as it was computed before versioning was introduced —
+// kept verbatim so these tests fail if the legacy compatibility path drifts.
+function legacyHash(snapshotSettings: ExperimentSnapshotSettings): string {
+  return md5(
+    JSON.stringify({
+      activationMetric: snapshotSettings.activationMetric,
+      attributionModel: snapshotSettings.attributionModel,
+      queryFilter: snapshotSettings.queryFilter,
+      segment: snapshotSettings.segment,
+      skipPartialData: snapshotSettings.skipPartialData,
+      datasourceId: snapshotSettings.datasourceId,
+      exposureQueryId: snapshotSettings.exposureQueryId,
+      startDate: snapshotSettings.startDate,
+      regressionAdjustmentEnabled: snapshotSettings.regressionAdjustmentEnabled,
+      experimentId: snapshotSettings.experimentId,
+    }),
+  );
+}
+
+const currentHashInputs = {
+  snapshotSettings: baseSnapshotSettings,
+  exposureQuery: baseExposureQuery,
+  segment: null,
+  factTableMap: new Map(),
+};
+
+describe("getExperimentSettingsHashForIncrementalRefresh", () => {
+  it("is stable for identical inputs", () => {
+    expect(
+      getExperimentSettingsHashForIncrementalRefresh(currentHashInputs),
+    ).toEqual(
+      getExperimentSettingsHashForIncrementalRefresh(currentHashInputs),
+    );
+  });
+
+  it("is version-prefixed so older stored hashes are distinguishable", () => {
+    expect(
+      getExperimentSettingsHashForIncrementalRefresh(currentHashInputs),
+    ).toMatch(/^v2:/);
+  });
+
+  it("ignores endDate, which moves forward on every incremental update", () => {
+    const movedEndDate = getExperimentSettingsHashForIncrementalRefresh({
+      ...currentHashInputs,
+      snapshotSettings: {
+        ...baseSnapshotSettings,
+        endDate: new Date("2024-06-30"),
+      },
+    });
+    expect(movedEndDate).toEqual(
+      getExperimentSettingsHashForIncrementalRefresh(currentHashInputs),
+    );
+  });
+
+  it("changes when the exposure query SQL changes", () => {
+    const editedSql = getExperimentSettingsHashForIncrementalRefresh({
+      ...currentHashInputs,
+      exposureQuery: {
+        ...baseExposureQuery,
+        query: "SELECT user_id, timestamp, exp_id, var_id FROM events_v2",
+      },
+    });
+    expect(editedSql).not.toEqual(
+      getExperimentSettingsHashForIncrementalRefresh(currentHashInputs),
+    );
+  });
+
+  it("changes when the exposure query userIdType changes", () => {
+    const editedIdType = getExperimentSettingsHashForIncrementalRefresh({
+      ...currentHashInputs,
+      exposureQuery: { ...baseExposureQuery, userIdType: "anonymous_id" },
+    });
+    expect(editedIdType).not.toEqual(
+      getExperimentSettingsHashForIncrementalRefresh(currentHashInputs),
+    );
+  });
+
+  it("changes when a SQL segment's SQL changes", () => {
+    const withSegment = {
+      ...currentHashInputs,
+      snapshotSettings: { ...baseSnapshotSettings, segment: "seg_1" },
+      segment: sqlSegment,
+    };
+    const editedSegment = {
+      ...withSegment,
+      segment: {
+        ...sqlSegment,
+        sql: "SELECT user_id, date FROM users WHERE country = 'CA'",
+      },
+    };
+    expect(
+      getExperimentSettingsHashForIncrementalRefresh(editedSegment),
+    ).not.toEqual(getExperimentSettingsHashForIncrementalRefresh(withSegment));
+  });
+
+  it("changes when a FACT segment's fact table filter value changes", () => {
+    const factTableMap = new Map([["ft_1", factTable]]);
+    const withFactSegment = {
+      ...currentHashInputs,
+      snapshotSettings: { ...baseSnapshotSettings, segment: "seg_2" },
+      segment: factSegment,
+      factTableMap,
+    };
+    const editedFilter = {
+      ...withFactSegment,
+      factTableMap: new Map([
+        [
+          "ft_1",
+          {
+            ...factTable,
+            filters: [{ ...factTable.filters[0], value: "country = 'CA'" }],
+          } as FactTableInterface,
+        ],
+      ]),
+    };
+    expect(
+      getExperimentSettingsHashForIncrementalRefresh(editedFilter),
+    ).not.toEqual(
+      getExperimentSettingsHashForIncrementalRefresh(withFactSegment),
+    );
+  });
+});
+
+describe("experimentSettingsHashMatchesForIncrementalRefresh", () => {
+  it("matches a current-version stored hash for unchanged inputs", () => {
+    const storedHash =
+      getExperimentSettingsHashForIncrementalRefresh(currentHashInputs);
+    expect(
+      experimentSettingsHashMatchesForIncrementalRefresh({
+        storedHash,
+        ...currentHashInputs,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects a current-version stored hash when the exposure SQL changed", () => {
+    const storedHash =
+      getExperimentSettingsHashForIncrementalRefresh(currentHashInputs);
+    expect(
+      experimentSettingsHashMatchesForIncrementalRefresh({
+        storedHash,
+        ...currentHashInputs,
+        exposureQuery: { ...baseExposureQuery, query: "SELECT 1" },
+      }),
+    ).toBe(false);
+  });
+
+  it("still matches a legacy (unversioned) stored hash when settings are unchanged", () => {
+    // A stored hash written by an older build must not read as "outdated"
+    // just because this build hashes more inputs — that would silently drop
+    // every existing pipeline out of incremental refresh on deploy.
+    expect(
+      experimentSettingsHashMatchesForIncrementalRefresh({
+        storedHash: legacyHash(baseSnapshotSettings),
+        ...currentHashInputs,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects a legacy stored hash when a legacy-hashed setting changed", () => {
+    expect(
+      experimentSettingsHashMatchesForIncrementalRefresh({
+        storedHash: legacyHash(baseSnapshotSettings),
+        ...currentHashInputs,
+        snapshotSettings: {
+          ...baseSnapshotSettings,
+          queryFilter: "device = 'mobile'",
+        },
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/validators/population-data.ts
+++ b/packages/shared/src/validators/population-data.ts
@@ -65,6 +65,11 @@ export const populationDataInterfaceValidator = z
     sourceId: z.string(),
     userIdType: z.string(),
 
+    // Cache-validation hashes. Older documents don't have them and are
+    // treated as stale by the cache lookup.
+    sourceSettingsHash: z.string().optional(),
+    metricSettingsHashes: z.record(z.string(), z.string()).optional(),
+
     // data
     units: z.array(
       z.object({


### PR DESCRIPTION
## What this fixes

Several caching layers compare definition **ids** but not the **definitions behind them**. Editing an exposure query, segment, fact-table filter, or metric leaves the stored id unchanged, so data computed from the old definition is silently reused alongside data computed from the new one. Depending on the layer, that means wrong experiment results, wrong power estimates, or missing "settings changed" markers — all with no signal to the user.

This PR closes those gaps in three places, ordered by severity:

### 1. Incremental refresh: settings-hash gate misses the definitions behind the ids (wrong experiment results)

The incremental pipeline appends new rows to a persistent units table on every refresh. A settings hash (`getExperimentSettingsHashForIncrementalRefresh`) gates this: if the experiment configuration changed since the table was built, the refresh must not append.

The hash covered `exposureQueryId` and the segment **id** — but not the exposure query's SQL/userIdType, the segment's definition, or the `phase`/`customFields` SQL-template variables. Editing any of those passes the gate, so rows produced by the new definition get appended to a table built with the old one, and the mixed table is analyzed as if it were consistent.

**Fix:**
- Hash the exposure query SQL + userIdType, the segment definition (including resolved fact-table filter SQL for FACT segments), `phase`, `customFields`, and `lookbackOverride` alongside the existing fields. On mismatch, planning falls back to the standard non-incremental runner (results stay correct); a Full Refresh re-materializes the units table and resumes incremental updates.
- **Version the hash** (`v2:` prefix) and keep the legacy computation for comparing hashes stored by older builds. Without this, every existing pipeline would read as "configuration outdated" on deploy and silently drop out of incremental refresh permanently (the stored hash is only rewritten by the incremental runner itself). With it, existing pipelines keep validating against the legacy inputs and pick up the v2 hash on their next successful incremental update.
- Add compile-time exhaustiveness guards over `ExperimentSnapshotSettings` and over the `ExposureQuery`/`SegmentInterface` fields the hash reads, mirroring the existing guard for metric computed settings: adding a field to any of these types now fails compilation until the field is classified as hashed or intentionally ignored. This is the structural fix for the bug class — the gate can no longer silently fall behind the types it depends on.

`validateIncrementalPipeline` now takes the request context instead of just the org so the gate can load the segment definition; the three call sites are updated.

### 2. Population data: 7-day cache with no definition validation (wrong power estimates)

`postPopulationData` reuses cached population documents for up to 7 days, keyed only on `sourceId` + `userIdType` (there was a `TODO hash metric and datasource to validate cache` at the lookup). Editing a metric's definition, the segment/fact table SQL, or datasource settings within that window silently reused the old means/standard deviations, skewing power calculations.

**Fix:** store a source settings hash and per-metric settings hashes on the document — dateUpdated stamps of the datasource, segment/fact table, each metric, its fact table(s), and (for classic ratio metrics) the denominator metric. Over-invalidation just costs a re-query, so stamps are safer than field enumeration here. The cached document is only returned when the source hash and **every** requested metric's hash match; otherwise all requested metrics are re-queried into a fresh, complete document.

Re-querying everything (rather than just the stale metrics) is deliberate: the new document replaces the cached one as the most recent cache entry and the front-end reads a single document, so a partial document leaves the omitted, still-valid metrics looking like they have no data (`setMetricDataFromPopulationData` zeroes metrics missing from the response). That partial-document hazard predates this PR (it was reachable by adding a metric to a recent power calculation); this PR removes the partial path entirely. The `TODO: incrementally do an update` remains the eventual proper fix.

### 3. Time series: denominator fact-table filters not hashed (missing "settings changed" markers)

`getMetricSettingsHash` (experiment time series) and `getSafeRolloutMetricSettingsHash` both had a `TODO: also include denominator filters?`. Editing a denominator filter changed results without producing the settings-changed marker on the time series. Both TODOs are resolved by hashing the resolved filter SQL, the same way the numerator side already does.

## How to reproduce

**Incremental refresh (before this PR):**
1. On a datasource with pipeline mode set to `incremental`, start an experiment and run an update so the `gb_units_*` table is materialized.
2. Edit the datasource's exposure query SQL (same query id) — e.g. change the join or point it at a different events table. Editing the experiment's segment SQL works too.
3. Trigger a regular (non-full) refresh.
4. The gate passes (only the id was hashed), the update appends rows from the new SQL onto the table built with the old SQL, and results are computed from the mixed table with no warning. After this PR, the same refresh falls back to the standard runner and results are computed consistently; the UI's Full Refresh restores incremental operation.

**Population data (before this PR):**
1. Open the power calculator, select a population (segment or fact table) and metrics, and run it — this caches a population document for 7 days.
2. Edit one of the metrics (SQL, column, capping, …), the segment definition, or — for a classic ratio metric — its denominator metric.
3. Re-run the power calculation with the same population and metrics.
4. The cached values computed from the old definition are returned. After this PR, the cache is invalidated and the metrics are re-queried.

**Time series (before this PR):**
1. Create a ratio fact metric whose denominator applies a fact-table filter, use it in an experiment that has time series data points.
2. Edit the filter's SQL and refresh.
3. No settings-changed marker appears even though the metric's data changed. After this PR, the next data point is marked.

## Rollout notes

- Existing incremental pipelines are **not** invalidated on deploy (legacy hash comparison). The new inputs are enforced from each pipeline's next successful update onward. Corollary: a definition drift that happened entirely *before* this ships can't be detected retroactively — the old inputs were never captured.
- Cached population documents are re-queried once (they carry no hashes).
- Ratio metrics whose denominator references a fact table will show a one-time settings-changed marker on their next time-series data point after deploy, because the hash inputs grew (`getFiltersForHash` returns `undefined` when there's no denominator, so other metrics' hashes are unchanged). This seemed acceptable versus carrying versioned hashes in four more places — happy to add the same legacy-comparison treatment there if preferred.
- The gate loads the segment through the permission-scoped model. If the hash was written by a context that can read the segment and validated by one that can't (or vice versa), the comparison fails conservatively: the refresh falls back to the standard runner (correct results, not incremental) until a Full Refresh under a consistent context.

## Test plan

- New unit tests for the settings hash and matcher: stability, version prefix, endDate exclusion, exposure-SQL / userIdType / segment-SQL / fact-filter sensitivity, and the legacy-hash compatibility path (the legacy algorithm is pinned verbatim in the test so drift fails).
- Existing `snapshot-planning`, `snapshot-lifecycle`, `experimentTimeSeries`, and query-runner suites pass unchanged.
- `tsgo --noEmit` passes for `shared` and `back-end` (the new exhaustiveness guards compile, i.e. all fields of the hashed types are classified).
