### PR TITLE
Single feature custom hooks + JSON schemas for string/number flags

### DIFF
--- a/docs/docs/features/custom-hooks.mdx
+++ b/docs/docs/features/custom-hooks.mdx
@@ -13,13 +13,17 @@ Custom Hooks are JavaScript snippets that run on the server during validation. U
 
 ## Using Custom Hooks
 
-To manage Custom Hooks, navigate to **Settings → Custom Hooks** in the GrowthBook UI.
-
 :::note Custom Hooks are only available on self-hosted GrowthBook Enterprise.
 
 :::
 
-Custom Hooks can be global or scoped to specific projects, and you can create multiple hooks of the same type for flexible, granular validation rules.
+You can create multiple hooks of the same type for flexible, granular validation rules. Each hook has a **scope** that controls which features it runs for:
+
+- **Global** — runs for every feature.
+- **Project** — runs only for features in the selected projects.
+- **Feature** — runs only for a single feature.
+
+Global and project-scoped hooks are managed under **Settings → Custom Hooks**. Feature-scoped hooks are created and managed from a feature's **Validation** tab by anyone who can edit that feature; that tab also lists any global and project hooks that apply to the feature.
 
 ### Limits
 

--- a/docs/docs/features/custom-hooks.mdx
+++ b/docs/docs/features/custom-hooks.mdx
@@ -36,6 +36,10 @@ The following default limits are in place to prevent abuse and ensure performanc
 - `CUSTOM_HOOK_WALL_TIMEOUT_MS` - Maximum total run time (including async calls) (default: 5000ms)
 - `CUSTOM_HOOK_MAX_FETCH_RESP_SIZE` - Maximum response size from fetch calls in bytes (default: 500KB)
 
+### Execution Frequency
+
+A hook may execute **multiple times for a single save**. GrowthBook runs hooks early in a request (before related records are written) and again immediately before the final database write, and the Incremental Changes option adds additional runs against the previous state. Keep hooks fast and free of side effects — they should validate their inputs and either return, `throw`, or `addWarning()`, nothing else.
+
 ### Debugging
 
 If a Custom Hook throws an error during execution, the error message will be used as the validation error shown in the UI. This allows you to provide clear feedback to users about why their changes were rejected.

--- a/docs/docs/features/json-schema-validation.mdx
+++ b/docs/docs/features/json-schema-validation.mdx
@@ -1,6 +1,6 @@
 ---
 title: JSON Schema Validation
-description: Enforce the structure of JSON feature flag values with JSON Schema to prevent typos and costly mistakes.
+description: Validate JSON, string, and number feature flag values against a schema to prevent typos and costly mistakes.
 sidebar_label: JSON Schema Validation
 slug: /features/json-schema-validation
 ---
@@ -12,7 +12,9 @@ import MaxWidthImage from "@site/src/components/MaxWidthImage";
 
 <CommercialFeature feature="json-validation" />
 
-JSON feature flags are powerful, especially for remote configuration, letting you ship structured data like pricing rules, layout settings, or experiment parameters without a code deploy. That flexibility comes with a risk: a single typo or missing field in a JSON blob can break production. GrowthBook Enterprise lets you attach a JSON Schema to a JSON flag so every value is validated against the structure you define.
+JSON feature flags are powerful, especially for remote configuration, letting you ship structured data like pricing rules, layout settings, or experiment parameters without a code deploy. That flexibility comes with a risk: a single typo or missing field in a JSON blob can break production. GrowthBook Enterprise lets you attach a schema to a flag so every value is validated against the structure you define.
+
+Validation isn't limited to JSON flags. You can also add a schema to **string** and **number** flags — for example, to restrict a string flag to a set of allowed values or keep a number flag within a min/max range. (Boolean flags can't have a schema.)
 
 <MaxWidthImage border>
   ![JSON Schema Validation](/images/features/json-schema/validation-banner.png)
@@ -30,7 +32,7 @@ Adding a schema means:
 
 ## Enabling Validation
 
-Open a JSON feature flag and find the **JSON Validation** section on the feature details page. Click **Enable** to open the schema editor. You can switch validation on or off at any time, and edit the schema later from the same section.
+Open a JSON, string, or number feature flag, go to its **Validation** tab, and find the **Schema Validation** section. Click **Enable** to open the schema editor. You can switch validation on or off at any time, and edit the schema later from the same section.
 
 <MaxWidthImage border>
   ![JSON Schema Editor](/images/features/json-schema/validation-form.png)
@@ -51,6 +53,8 @@ Choose a root type:
 - **Primitive Value** - a single string, number, or boolean
 - **Array of Primitive Values** - a list of primitives
 
+(For **string** and **number** flags the value is always a single primitive, so the builder skips this choice and goes straight to configuring that value.)
+
 For each property you add, you can configure:
 
 - **Property Key** and **Description**
@@ -62,6 +66,8 @@ For each property you add, you can configure:
 ### Raw JSON Schema
 
 When you need more expressiveness than the Simple Builder offers - nested objects, conditional schemas, regex patterns, references, and so on - switch to raw JSON Schema mode and paste in a full [JSON Schema](https://json-schema.org/) document. Anything a standard JSON Schema validator accepts will work here.
+
+For string and number flags, the schema's top-level `type` must match the flag — `string` for string flags, `number` or `integer` for number flags.
 
 ## The Editing Experience
 
@@ -76,7 +82,7 @@ When validation is enabled with a Simple Schema, GrowthBook replaces the raw JSO
   ![Simplified editing UI for simple schemas](/images/features/json-schema/value-editor.png)
 </MaxWidthImage>
 
-This form-based editor appears everywhere you set a JSON value for the flag: the default value, forced-value rules, rollout rules, and experiment variations. If you ever want to bypass the form, click **Edit as JSON** to switch back to the raw editor.
+This form-based editor appears everywhere you set the flag's value: the default value, forced-value rules, rollout rules, and experiment variations. If you ever want to bypass the form, click **Edit as JSON** to switch back to the raw editor.
 
 For raw JSON Schemas that are too complex for the form view, editors continue to use the JSON editor, but values are still validated against the schema on save.
 
@@ -87,4 +93,5 @@ When you try to save a value that doesn't match the schema, GrowthBook shows an 
 ## Related
 
 - [Feature Flag Basics](/features/basics) — overview of the JSON flag type
+- [Custom Hooks](/features/custom-hooks) — when you need more validation control than a schema provides, run custom server-side validation logic (self-hosted Enterprise)
 - [Publishing & Approval Flows](/features/publishing-and-approval-flows) — combine schema validation with required approvals for an extra layer of safety

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -493,6 +493,11 @@
       "count": 1
     }
   },
+  "packages/front-end/components/Features/CustomHookModal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "packages/front-end/components/Features/DraftModal.tsx": {
     "no-restricted-imports": {
       "count": 1
@@ -1825,11 +1830,6 @@
   "packages/front-end/pages/sdks/index.tsx": {
     "local/no-alert-classname": {
       "count": 1
-    }
-  },
-  "packages/front-end/pages/settings/custom-hooks.tsx": {
-    "no-restricted-imports": {
-      "count": 2
     }
   },
   "packages/front-end/pages/settings/custom-markdown.tsx": {

--- a/packages/back-end/src/api/features/postFeature.ts
+++ b/packages/back-end/src/api/features/postFeature.ts
@@ -138,7 +138,11 @@ export const postFeature = createApiRequestHandler(postFeatureValidator)(async (
     req.body.environments ?? {},
   );
 
-  const jsonSchema = parseApiJsonSchema(req.context.org, req.body.jsonSchema);
+  const jsonSchema = parseApiJsonSchema(
+    req.context.org,
+    req.body.jsonSchema,
+    req.body.valueType,
+  );
 
   feature.jsonSchema = jsonSchema;
 

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
@@ -5,6 +5,7 @@ import {
   RevisionRampCreateAction,
   postFeatureRevisionRuleAddValidator,
   RuleCreateInput,
+  SafeRolloutInterface,
 } from "shared/validators";
 import type {
   ExperimentRefRule,
@@ -15,6 +16,8 @@ import type {
 } from "shared/validators";
 import { resetReviewOnChange } from "shared/util";
 import { RevisionChanges } from "shared/types/feature-revision";
+import { ExperimentInterface } from "shared/types/experiment";
+import { CreateProps } from "shared/types/base-model";
 import { getLatestPhaseVariations } from "shared/experiments";
 import { toApiRevision } from "back-end/src/services/features";
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
@@ -26,8 +29,10 @@ import {
 } from "back-end/src/models/ExperimentModel";
 import {
   getRevision,
+  prevalidateRevisionUpdate,
   updateRevision,
 } from "back-end/src/models/FeatureRevisionModel";
+import { generateId } from "back-end/src/util/uuid";
 import { validateCreateSafeRolloutFields } from "back-end/src/validators/safe-rollout";
 import {
   BadRequestError,
@@ -157,6 +162,7 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
   let createdSafeRolloutId: string | undefined;
   let linkedExperimentId: string | undefined;
   let linkedHoldoutId: string | undefined;
+  let holdoutExperimentToLink: ExperimentInterface | null = null;
   try {
     if (!isDraftStatus(revision.status)) {
       throw new BadRequestError(
@@ -230,25 +236,9 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
           }
 
           if (!experiment.holdoutId) {
-            await updateExperiment({
-              context: req.context,
-              experiment,
-              changes: { holdoutId: feature.holdout.id },
-            });
-            linkedExperimentId = experiment.id;
-            const holdout = await req.context.models.holdout.getById(
-              feature.holdout.id,
-            );
-            await req.context.models.holdout.updateById(feature.holdout.id, {
-              linkedExperiments: {
-                ...holdout?.linkedExperiments,
-                [experiment.id]: {
-                  id: experiment.id,
-                  dateAdded: new Date(),
-                },
-              },
-            });
-            linkedHoldoutId = feature.holdout.id;
+            // Linkage writes are deferred until after custom-hook
+            // prevalidation below so a hook rejection doesn't orphan them.
+            holdoutExperimentToLink = experiment;
           }
         }
       }
@@ -261,6 +251,10 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
     validateRuleAttributes(rule, req.context, feature.project);
     await validateRuleReferences(rule, req.context);
 
+    // Validate safe-rollout fields and pre-generate the safeRollout id so
+    // the rule can be prevalidated against custom hooks with its final
+    // shape. The doc itself is created after prevalidation below.
+    let safeRolloutCreateProps: CreateProps<SafeRolloutInterface> | null = null;
     if (ruleInput.type === "safe-rollout" && rule.type === "safe-rollout") {
       if (!req.context.hasPremiumFeature("safe-rollout")) {
         req.context.throwPlanDoesNotAllowError(
@@ -284,7 +278,9 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
         { percent: 0.75 },
         { percent: 1 },
       ];
-      const safeRollout = await req.context.models.safeRollout.create({
+      const safeRolloutId = generateId("sr_");
+      safeRolloutCreateProps = {
+        id: safeRolloutId,
         ...validatedFields,
         featureId: feature.id,
         status: "running",
@@ -296,12 +292,8 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
           rampUpCompleted: false,
           nextUpdate: undefined,
         },
-      });
-
-      if (!safeRollout)
-        throw new InternalServerError("Failed to create safe rollout");
-      createdSafeRolloutId = safeRollout.id;
-      (rule as SafeRolloutRule).safeRolloutId = safeRollout.id;
+      };
+      (rule as SafeRolloutRule).safeRolloutId = safeRolloutId;
     }
 
     // Priority: rampSchedule > schedule shorthand > inline scheduleRules (legacy).
@@ -340,6 +332,57 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
       changes.rampActions = [...filtered, resolvedRampAction];
     }
 
+    const resetReview = resetReviewOnChange({
+      feature,
+      changedEnvironments: [environment],
+      defaultValueChanged: false,
+      settings: req.organization.settings,
+    });
+
+    // Run custom hooks against the exact proposed revision BEFORE the
+    // side-effect writes below (safeRollout doc, holdout linkage) so a hook
+    // rejection — or a soft warning the caller hasn't acknowledged with
+    // ?ignoreWarnings=true — doesn't orphan them. updateRevision() re-fires
+    // the hooks as the authoritative gate.
+    await prevalidateRevisionUpdate(
+      req.context,
+      feature,
+      revision,
+      changes,
+      resetReview,
+    );
+
+    if (safeRolloutCreateProps) {
+      const safeRollout = await req.context.models.safeRollout.create(
+        safeRolloutCreateProps,
+      );
+      if (!safeRollout)
+        throw new InternalServerError("Failed to create safe rollout");
+      createdSafeRolloutId = safeRollout.id;
+    }
+
+    if (holdoutExperimentToLink && feature.holdout?.id) {
+      await updateExperiment({
+        context: req.context,
+        experiment: holdoutExperimentToLink,
+        changes: { holdoutId: feature.holdout.id },
+      });
+      linkedExperimentId = holdoutExperimentToLink.id;
+      const holdout = await req.context.models.holdout.getById(
+        feature.holdout.id,
+      );
+      await req.context.models.holdout.updateById(feature.holdout.id, {
+        linkedExperiments: {
+          ...holdout?.linkedExperiments,
+          [holdoutExperimentToLink.id]: {
+            id: holdoutExperimentToLink.id,
+            dateAdded: new Date(),
+          },
+        },
+      });
+      linkedHoldoutId = feature.holdout.id;
+    }
+
     await updateRevision(
       req.context,
       feature,
@@ -351,12 +394,7 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
         subject: `to ${environment}`,
         value: JSON.stringify(rule),
       },
-      resetReviewOnChange({
-        feature,
-        changedEnvironments: [environment],
-        defaultValueChanged: false,
-        settings: req.organization.settings,
-      }),
+      resetReview,
     );
 
     const updated = await getRevision({

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
@@ -236,8 +236,7 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
           }
 
           if (!experiment.holdoutId) {
-            // Linkage writes are deferred until after custom-hook
-            // prevalidation below so a hook rejection doesn't orphan them.
+            // Deferred until after custom-hook prevalidation below
             holdoutExperimentToLink = experiment;
           }
         }
@@ -251,9 +250,7 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
     validateRuleAttributes(rule, req.context, feature.project);
     await validateRuleReferences(rule, req.context);
 
-    // Validate safe-rollout fields and pre-generate the safeRollout id so
-    // the rule can be prevalidated against custom hooks with its final
-    // shape. The doc itself is created after prevalidation below.
+    // Pre-generate the safeRollout id so hooks see the rule's final shape; the doc is created after prevalidation
     let safeRolloutCreateProps: CreateProps<SafeRolloutInterface> | null = null;
     if (ruleInput.type === "safe-rollout" && rule.type === "safe-rollout") {
       if (!req.context.hasPremiumFeature("safe-rollout")) {
@@ -339,11 +336,7 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
       settings: req.organization.settings,
     });
 
-    // Run custom hooks against the exact proposed revision BEFORE the
-    // side-effect writes below (safeRollout doc, holdout linkage) so a hook
-    // rejection — or a soft warning the caller hasn't acknowledged with
-    // ?ignoreWarnings=true — doesn't orphan them. updateRevision() re-fires
-    // the hooks as the authoritative gate.
+    // Run custom hooks before the side-effect writes below so a rejection doesn't orphan them
     await prevalidateRevisionUpdate(
       req.context,
       feature,

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
@@ -154,8 +154,7 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
             );
           }
           if (!experiment.holdoutId) {
-            // Linkage writes are deferred until after custom-hook
-            // prevalidation below so a hook rejection doesn't orphan them.
+            // Deferred until after custom-hook prevalidation below
             holdoutExperimentToLink = experiment;
           }
         }
@@ -181,9 +180,7 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
     validateRuleAttributes(rule, req.context, feature.project);
     await validateRuleReferences(rule, req.context);
 
-    // Validate safe-rollout fields and pre-generate the safeRollout id so
-    // the rule can be prevalidated against custom hooks with its final
-    // shape. The doc itself is created after prevalidation below.
+    // Pre-generate the safeRollout id so hooks see the rule's final shape; the doc is created after prevalidation
     let safeRolloutCreateProps: CreateProps<SafeRolloutInterface> | null = null;
     if (ruleInput.type === "safe-rollout" && rule.type === "safe-rollout") {
       if (!req.context.hasPremiumFeature("safe-rollout")) {
@@ -291,11 +288,7 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
       settings: req.organization.settings,
     });
 
-    // Run custom hooks against the exact proposed revision BEFORE the
-    // side-effect writes below (safeRollout doc, holdout linkage) so a hook
-    // rejection — or a soft warning the caller hasn't acknowledged with
-    // ?ignoreWarnings=true — doesn't orphan them. updateRevision() re-fires
-    // the hooks as the authoritative gate.
+    // Run custom hooks before the side-effect writes below so a rejection doesn't orphan them
     await prevalidateRevisionUpdate(
       req.context,
       feature,

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
@@ -6,10 +6,13 @@ import {
   postFeatureRevisionRuleAddV2Validator,
   RuleCreateInput,
   RuleCreateInputV2,
+  SafeRolloutInterface,
 } from "shared/validators";
 import type { FeatureRule, SafeRolloutRule } from "shared/validators";
 import { resetReviewOnChange } from "shared/util";
 import { RevisionChanges } from "shared/types/feature-revision";
+import { ExperimentInterface } from "shared/types/experiment";
+import { CreateProps } from "shared/types/base-model";
 import { getLatestPhaseVariations } from "shared/experiments";
 import {
   toApiRevisionV2,
@@ -24,8 +27,10 @@ import {
 } from "back-end/src/models/ExperimentModel";
 import {
   getRevision,
+  prevalidateRevisionUpdate,
   updateRevision,
 } from "back-end/src/models/FeatureRevisionModel";
+import { generateId } from "back-end/src/util/uuid";
 import { validateCreateSafeRolloutFields } from "back-end/src/validators/safe-rollout";
 import {
   BadRequestError,
@@ -79,6 +84,7 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
   let createdSafeRolloutId: string | undefined;
   let linkedExperimentId: string | undefined;
   let linkedHoldoutId: string | undefined;
+  let holdoutExperimentToLink: ExperimentInterface | null = null;
   try {
     if (!isDraftStatus(revision.status)) {
       throw new BadRequestError(
@@ -148,22 +154,9 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
             );
           }
           if (!experiment.holdoutId) {
-            await updateExperiment({
-              context: req.context,
-              experiment,
-              changes: { holdoutId: feature.holdout.id },
-            });
-            linkedExperimentId = experiment.id;
-            const holdout = await req.context.models.holdout.getById(
-              feature.holdout.id,
-            );
-            await req.context.models.holdout.updateById(feature.holdout.id, {
-              linkedExperiments: {
-                ...holdout?.linkedExperiments,
-                [experiment.id]: { id: experiment.id, dateAdded: new Date() },
-              },
-            });
-            linkedHoldoutId = feature.holdout.id;
+            // Linkage writes are deferred until after custom-hook
+            // prevalidation below so a hook rejection doesn't orphan them.
+            holdoutExperimentToLink = experiment;
           }
         }
       }
@@ -188,6 +181,10 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
     validateRuleAttributes(rule, req.context, feature.project);
     await validateRuleReferences(rule, req.context);
 
+    // Validate safe-rollout fields and pre-generate the safeRollout id so
+    // the rule can be prevalidated against custom hooks with its final
+    // shape. The doc itself is created after prevalidation below.
+    let safeRolloutCreateProps: CreateProps<SafeRolloutInterface> | null = null;
     if (ruleInput.type === "safe-rollout" && rule.type === "safe-rollout") {
       if (!req.context.hasPremiumFeature("safe-rollout")) {
         req.context.throwPlanDoesNotAllowError(
@@ -213,7 +210,9 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
         { percent: 0.75 },
         { percent: 1 },
       ];
-      const safeRollout = await req.context.models.safeRollout.create({
+      const safeRolloutId = generateId("sr_");
+      safeRolloutCreateProps = {
+        id: safeRolloutId,
         ...validatedFields,
         featureId: feature.id,
         status: "running",
@@ -225,12 +224,8 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
           rampUpCompleted: false,
           nextUpdate: undefined,
         },
-      });
-
-      if (!safeRollout)
-        throw new InternalServerError("Failed to create safe rollout");
-      createdSafeRolloutId = safeRollout.id;
-      (rule as SafeRolloutRule).safeRolloutId = safeRollout.id;
+      };
+      (rule as SafeRolloutRule).safeRolloutId = safeRolloutId;
     }
 
     const usesLegacyScheduling =
@@ -289,6 +284,56 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
     const affectedEnvs = resolvedAllEnvs
       ? Object.keys(feature.environmentSettings ?? {})
       : (environments ?? []);
+    const resetReview = resetReviewOnChange({
+      feature,
+      changedEnvironments: affectedEnvs,
+      defaultValueChanged: false,
+      settings: req.organization.settings,
+    });
+
+    // Run custom hooks against the exact proposed revision BEFORE the
+    // side-effect writes below (safeRollout doc, holdout linkage) so a hook
+    // rejection — or a soft warning the caller hasn't acknowledged with
+    // ?ignoreWarnings=true — doesn't orphan them. updateRevision() re-fires
+    // the hooks as the authoritative gate.
+    await prevalidateRevisionUpdate(
+      req.context,
+      feature,
+      revision,
+      changes,
+      resetReview,
+    );
+
+    if (safeRolloutCreateProps) {
+      const safeRollout = await req.context.models.safeRollout.create(
+        safeRolloutCreateProps,
+      );
+      if (!safeRollout)
+        throw new InternalServerError("Failed to create safe rollout");
+      createdSafeRolloutId = safeRollout.id;
+    }
+
+    if (holdoutExperimentToLink && feature.holdout?.id) {
+      await updateExperiment({
+        context: req.context,
+        experiment: holdoutExperimentToLink,
+        changes: { holdoutId: feature.holdout.id },
+      });
+      linkedExperimentId = holdoutExperimentToLink.id;
+      const holdout = await req.context.models.holdout.getById(
+        feature.holdout.id,
+      );
+      await req.context.models.holdout.updateById(feature.holdout.id, {
+        linkedExperiments: {
+          ...holdout?.linkedExperiments,
+          [holdoutExperimentToLink.id]: {
+            id: holdoutExperimentToLink.id,
+            dateAdded: new Date(),
+          },
+        },
+      });
+      linkedHoldoutId = feature.holdout.id;
+    }
 
     await updateRevision(
       req.context,
@@ -303,12 +348,7 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
           : `to ${(environments ?? []).join(", ")}`,
         value: JSON.stringify(rule),
       },
-      resetReviewOnChange({
-        feature,
-        changedEnvironments: affectedEnvs,
-        defaultValueChanged: false,
-        settings: req.organization.settings,
-      }),
+      resetReview,
     );
 
     const updated = await getRevision({

--- a/packages/back-end/src/api/features/postFeatureV2.ts
+++ b/packages/back-end/src/api/features/postFeatureV2.ts
@@ -113,7 +113,11 @@ export const postFeatureV2 = createApiRequestHandler(postFeatureV2Validator)(
       mapV2ApiRuleToFeatureRule(rule),
     );
 
-    const jsonSchema = parseApiJsonSchema(req.context.org, req.body.jsonSchema);
+    const jsonSchema = parseApiJsonSchema(
+      req.context.org,
+      req.body.jsonSchema,
+      feature.valueType,
+    );
     feature.jsonSchema = jsonSchema;
     feature.defaultValue = validateFeatureValue(feature, feature.defaultValue);
 

--- a/packages/back-end/src/api/features/updateFeature.ts
+++ b/packages/back-end/src/api/features/updateFeature.ts
@@ -143,8 +143,12 @@ export const updateFeature = createApiRequestHandler(updateFeatureValidator)(
     await assertValidHoldout(req.body.holdout, req.context);
 
     const jsonSchema =
-      feature.valueType === "json" && req.body.jsonSchema != null
-        ? parseApiJsonSchema(req.organization, req.body.jsonSchema)
+      feature.valueType !== "boolean" && req.body.jsonSchema != null
+        ? parseApiJsonSchema(
+            req.organization,
+            req.body.jsonSchema,
+            feature.valueType,
+          )
         : null;
 
     let updates: Partial<FeatureInterface> = {

--- a/packages/back-end/src/api/features/updateFeatureV2.ts
+++ b/packages/back-end/src/api/features/updateFeatureV2.ts
@@ -125,8 +125,12 @@ export const updateFeatureV2 = createApiRequestHandler(
   await assertValidHoldout(req.body.holdout, req.context);
 
   const jsonSchema =
-    feature.valueType === "json" && req.body.jsonSchema != null
-      ? parseApiJsonSchema(req.organization, req.body.jsonSchema)
+    feature.valueType !== "boolean" && req.body.jsonSchema != null
+      ? parseApiJsonSchema(
+          req.organization,
+          req.body.jsonSchema,
+          feature.valueType,
+        )
       : null;
 
   let inboundFlatRules: FeatureRule[] | null = null;

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -1539,8 +1539,7 @@ export async function postFeaturePublish(
             `Feature "${otherFeature.id}" has a merge conflict in its pending draft. Resolve the conflict before starting experiment "${experiment.name}".`,
           );
         }
-        // Also prevalidate custom hooks for the other draft so a hook
-        // rejection surfaces BEFORE the current feature publishes below.
+        // Prevalidate custom hooks for the other draft before the current feature publishes below
         if (mergeResultHasChanges(otherMerge)) {
           await prevalidatePublishRevision({
             context,
@@ -1601,12 +1600,10 @@ export async function postFeaturePublish(
     //
     // Residual exposure: the current feature is already live by this point.
     // Phase-1 pre-flight above caught merge conflicts, approval gaps, and
-    // custom-hook rejections for the OTHER drafts before we published this
-    // one, so the only remaining failure modes here are transient infra
-    // errors during publishRevision and races with concurrent edits (a hook
-    // can also re-reject if state shifted since the pre-flight). Throwing
-    // aborts the experiment status transition; the already-published current
-    // feature stays live. Closing this gap fully would require cross-
+    // custom-hook rejections for the OTHER drafts, so the remaining failure
+    // modes here are transient infra errors and re-rejects after state shifts.
+    // Throwing aborts the experiment status transition; the already-published
+    // current feature stays live. Closing this gap fully would require cross-
     // collection transactions.
     const adminBypass =
       !!adminOverride && context.permissions.canBypassApprovalChecks(feature);
@@ -2183,10 +2180,7 @@ export async function postFeatureRule(
     feature.project,
   );
 
-  // Validate safe-rollout fields and pre-generate the safeRollout id so the
-  // rule can be prevalidated against custom hooks with its final shape. The
-  // doc itself is created AFTER prevalidation below, so a hook rejection
-  // doesn't leave an orphaned safeRollout behind.
+  // Pre-generate the safeRollout id so hooks see the rule's final shape; the doc is created after prevalidation
   let validatedSafeRolloutFields: Awaited<
     ReturnType<typeof validateCreateSafeRolloutFields>
   > | null = null;
@@ -2209,8 +2203,7 @@ export async function postFeatureRule(
 
   // Add holdout to existing experiment and experiment to holdout linkedExperiments
   // if the experiment is not running and has no linked implementations for
-  // experiment-ref rules. Guards run here; the actual linkage writes are
-  // deferred until after custom-hook prevalidation below.
+  // experiment-ref rules (writes deferred until after custom-hook prevalidation)
   let holdoutExperimentToLink: ExperimentInterface | null = null;
   if (rule.type === "experiment-ref" && feature.holdout?.id) {
     const experiment = await getExperimentById(context, rule.experimentId);
@@ -2355,10 +2348,7 @@ export async function postFeatureRule(
     combinedChanges.rampActions = [...filtered, rampActionsUpdate];
   }
 
-  // Run custom hooks against the exact proposed revision BEFORE the
-  // side-effect writes below (safeRollout doc, holdout linkage) so a hook
-  // rejection — or a soft warning the user hasn't acknowledged yet — doesn't
-  // orphan them. updateRevision() re-fires the hooks as the authoritative gate.
+  // Run custom hooks before the side-effect writes below so a rejection doesn't orphan them
   await prevalidateRevisionUpdate(
     context,
     feature,
@@ -3067,7 +3057,6 @@ export async function postFeatureSchema(
     context.permissions.throwPermissionError();
   }
 
-  // Reject schemas that don't make sense for the feature's value type.
   assertSchemaMatchesValueType(schemaDef, feature.valueType);
 
   const jsonSchema: JSONSchemaDef = {

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -26,6 +26,7 @@ import {
   fillRevisionFromFeature,
   getReviewSetting,
   namespacesToMap,
+  assertSchemaMatchesValueType,
 } from "shared/util";
 import { SAFE_ROLLOUT_TRACKING_KEY_PREFIX } from "shared/constants";
 import {
@@ -3020,6 +3021,10 @@ export async function postFeatureSchema(
   ) {
     context.permissions.throwPermissionError();
   }
+
+  // Reject schemas that don't make sense for the feature's value type
+  // (e.g. an object schema on a number flag).
+  assertSchemaMatchesValueType(schemaDef, feature.valueType);
 
   const jsonSchema: JSONSchemaDef = {
     ...schemaDef,

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -11,6 +11,7 @@ import {
   filterEnvironmentsByFeature,
   filterProjectsByEnvironmentWithNull,
   MergeResultChanges,
+  mergeResultHasChanges,
   MergeStrategy,
   checkIfRevisionNeedsReview,
   resetReviewOnChange,
@@ -92,12 +93,14 @@ import {
   getFeatureEnvStatus,
   hasArchivedFeatures,
   migrateDraft,
+  prevalidatePublishRevision,
   publishRevision,
   setDefaultValue,
   updateFeature,
 } from "back-end/src/models/FeatureModel";
 import { getRealtimeUsageByHour } from "back-end/src/models/RealtimeModel";
 import { dangerousLookupOrganizationByApiKey } from "back-end/src/util/api-key.util";
+import { generateId } from "back-end/src/util/uuid";
 import {
   addIdsToFlatRules,
   addIdsToRules,
@@ -149,6 +152,7 @@ import {
   getRevisionsByStatus,
   markRevisionAsReviewRequested,
   normalizeRulesInputToV2,
+  prevalidateRevisionUpdate,
   ReviewSubmittedType,
   submitReviewAndComments,
   updateRevision,
@@ -1535,6 +1539,17 @@ export async function postFeaturePublish(
             `Feature "${otherFeature.id}" has a merge conflict in its pending draft. Resolve the conflict before starting experiment "${experiment.name}".`,
           );
         }
+        // Also prevalidate custom hooks for the other draft so a hook
+        // rejection surfaces BEFORE the current feature publishes below.
+        if (mergeResultHasChanges(otherMerge)) {
+          await prevalidatePublishRevision({
+            context,
+            feature: otherFeature,
+            revision: otherRevision,
+            result: otherMerge.result,
+            comment: `Experiment "${experiment.name}" started`,
+          });
+        }
       }
     }
   }
@@ -1585,11 +1600,13 @@ export async function postFeaturePublish(
     // fail — mirrors the blocking behavior of postExperimentStatus.
     //
     // Residual exposure: the current feature is already live by this point.
-    // Phase-1 pre-flight above caught merge conflicts and approval gaps for
-    // the OTHER drafts before we published this one, so the only remaining
-    // failure modes here are transient infra errors during publishRevision.
-    // Throwing aborts the experiment status transition; the already-published
-    // current feature stays live. Closing this gap fully would require cross-
+    // Phase-1 pre-flight above caught merge conflicts, approval gaps, and
+    // custom-hook rejections for the OTHER drafts before we published this
+    // one, so the only remaining failure modes here are transient infra
+    // errors during publishRevision and races with concurrent edits (a hook
+    // can also re-reject if state shifted since the pre-flight). Throwing
+    // aborts the experiment status transition; the already-published current
+    // feature stays live. Closing this gap fully would require cross-
     // collection transactions.
     const adminBypass =
       !!adminOverride && context.permissions.canBypassApprovalChecks(feature);
@@ -2166,12 +2183,19 @@ export async function postFeatureRule(
     feature.project,
   );
 
+  // Validate safe-rollout fields and pre-generate the safeRollout id so the
+  // rule can be prevalidated against custom hooks with its final shape. The
+  // doc itself is created AFTER prevalidation below, so a hook rejection
+  // doesn't leave an orphaned safeRollout behind.
+  let validatedSafeRolloutFields: Awaited<
+    ReturnType<typeof validateCreateSafeRolloutFields>
+  > | null = null;
   if (rule.type === "safe-rollout") {
     if (!context.hasPremiumFeature("safe-rollout")) {
       throw new Error(`Safe Rollout rules is a premium feature.`);
     }
 
-    const validatedSafeRolloutFields = await validateCreateSafeRolloutFields(
+    validatedSafeRolloutFields = await validateCreateSafeRolloutFields(
       omit(safeRolloutFields, "rampUpSchedule"),
       context,
     );
@@ -2180,36 +2204,14 @@ export async function postFeatureRule(
     rule.seed = rule.seed || uuidv4();
     rule.trackingKey =
       rule.trackingKey || `${SAFE_ROLLOUT_TRACKING_KEY_PREFIX}${uuidv4()}`;
-
-    const safeRollout = await context.models.safeRollout.create({
-      ...validatedSafeRolloutFields,
-      featureId: feature.id,
-      status: rule.status,
-      autoSnapshots: true,
-      rampUpSchedule: {
-        enabled: safeRolloutFields?.rampUpSchedule?.enabled ?? false, // this is used so that we can disable the ramp up schedule using feature Flag
-        step: 0,
-        steps: [
-          { percent: 0.1 },
-          { percent: 0.25 },
-          { percent: 0.5 },
-          { percent: 0.75 },
-          { percent: 1 },
-        ],
-        rampUpCompleted: false,
-        nextUpdate: undefined, // this is set with the rule is enabled
-      },
-    });
-
-    if (!safeRollout) {
-      throw new Error("Failed to create safe rollout");
-    }
-    rule.safeRolloutId = safeRollout.id;
+    rule.safeRolloutId = generateId("sr_");
   }
 
   // Add holdout to existing experiment and experiment to holdout linkedExperiments
   // if the experiment is not running and has no linked implementations for
-  // experiment-ref rules
+  // experiment-ref rules. Guards run here; the actual linkage writes are
+  // deferred until after custom-hook prevalidation below.
+  let holdoutExperimentToLink: ExperimentInterface | null = null;
   if (rule.type === "experiment-ref" && feature.holdout?.id) {
     const experiment = await getExperimentById(context, rule.experimentId);
 
@@ -2240,23 +2242,7 @@ export async function postFeatureRule(
     }
 
     if (!experiment.holdoutId) {
-      await updateExperiment({
-        context,
-        experiment,
-        changes: {
-          holdoutId: feature.holdout.id,
-        },
-      });
-      const holdout = await context.models.holdout.getById(feature.holdout.id);
-      await context.models.holdout.updateById(feature.holdout.id, {
-        linkedExperiments: {
-          ...holdout?.linkedExperiments,
-          [experiment.id]: {
-            id: experiment.id,
-            dateAdded: new Date(),
-          },
-        },
-      });
+      holdoutExperimentToLink = experiment;
     }
   }
 
@@ -2367,6 +2353,65 @@ export async function postFeatureRule(
         ),
     );
     combinedChanges.rampActions = [...filtered, rampActionsUpdate];
+  }
+
+  // Run custom hooks against the exact proposed revision BEFORE the
+  // side-effect writes below (safeRollout doc, holdout linkage) so a hook
+  // rejection — or a soft warning the user hasn't acknowledged yet — doesn't
+  // orphan them. updateRevision() re-fires the hooks as the authoritative gate.
+  await prevalidateRevisionUpdate(
+    context,
+    feature,
+    revision,
+    combinedChanges,
+    resetReview,
+  );
+
+  if (rule.type === "safe-rollout" && validatedSafeRolloutFields) {
+    const safeRollout = await context.models.safeRollout.create({
+      id: rule.safeRolloutId,
+      ...validatedSafeRolloutFields,
+      featureId: feature.id,
+      status: rule.status,
+      autoSnapshots: true,
+      rampUpSchedule: {
+        enabled: safeRolloutFields?.rampUpSchedule?.enabled ?? false, // this is used so that we can disable the ramp up schedule using feature Flag
+        step: 0,
+        steps: [
+          { percent: 0.1 },
+          { percent: 0.25 },
+          { percent: 0.5 },
+          { percent: 0.75 },
+          { percent: 1 },
+        ],
+        rampUpCompleted: false,
+        nextUpdate: undefined, // this is set with the rule is enabled
+      },
+    });
+
+    if (!safeRollout) {
+      throw new Error("Failed to create safe rollout");
+    }
+  }
+
+  if (holdoutExperimentToLink && feature.holdout?.id) {
+    await updateExperiment({
+      context,
+      experiment: holdoutExperimentToLink,
+      changes: {
+        holdoutId: feature.holdout.id,
+      },
+    });
+    const holdout = await context.models.holdout.getById(feature.holdout.id);
+    await context.models.holdout.updateById(feature.holdout.id, {
+      linkedExperiments: {
+        ...holdout?.linkedExperiments,
+        [holdoutExperimentToLink.id]: {
+          id: holdoutExperimentToLink.id,
+          dateAdded: new Date(),
+        },
+      },
+    });
   }
 
   const auditSubject =

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -3022,8 +3022,7 @@ export async function postFeatureSchema(
     context.permissions.throwPermissionError();
   }
 
-  // Reject schemas that don't make sense for the feature's value type
-  // (e.g. an object schema on a number flag).
+  // Reject schemas that don't make sense for the feature's value type.
   assertSchemaMatchesValueType(schemaDef, feature.valueType);
 
   const jsonSchema: JSONSchemaDef = {

--- a/packages/back-end/src/enterprise/sandbox/sandbox-core.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-core.ts
@@ -1,0 +1,290 @@
+import { Isolate, Context, Reference, ExternalCopy } from "isolated-vm";
+import { RequestInit } from "node-fetch";
+import { parseEnvInt } from "shared/util";
+import { cancellableFetch } from "back-end/src/util/http.util";
+import { IS_CLOUD } from "back-end/src/util/secrets";
+
+// This module is the *pure* isolate runner. It is imported both by the main
+// process and by the forked sandbox worker, so it must stay light — do NOT
+// import the request context, models, mongoose, etc. here (that would balloon
+// every worker's boot footprint). Orchestration lives in sandbox-eval.ts.
+
+// Default memory limit in MB
+const MEMORY_MB = parseEnvInt(process.env.CUSTOM_HOOK_MEMORY_MB, 32, {
+  min: 1,
+  name: "CUSTOM_HOOK_MEMORY_MB",
+});
+// Max active CPU time (excluding fetch)
+const CPU_TIMEOUT_MS = parseEnvInt(
+  process.env.CUSTOM_HOOK_CPU_TIMEOUT_MS,
+  100,
+  {
+    min: 1,
+    name: "CUSTOM_HOOK_CPU_TIMEOUT_MS",
+  },
+);
+// Max total run time (including fetch)
+const WALL_TIMEOUT_MS = parseEnvInt(
+  process.env.CUSTOM_HOOK_WALL_TIMEOUT_MS,
+  5000,
+  { min: 1, name: "CUSTOM_HOOK_WALL_TIMEOUT_MS" },
+);
+// Max response size from fetch calls (default 500KB)
+const MAX_FETCH_RESP_SIZE = parseEnvInt(
+  process.env.CUSTOM_HOOK_MAX_FETCH_RESP_SIZE,
+  500 * 1024,
+  { min: 1, name: "CUSTOM_HOOK_MAX_FETCH_RESP_SIZE" },
+);
+// Max total size of captured console.log output, in characters (default 64KB).
+// The isolate memory limit only bounds memory *inside* the isolate; data copied
+// out to the host (logs/warnings) is unbounded without this cap.
+const MAX_LOG_CHARS = parseEnvInt(
+  process.env.CUSTOM_HOOK_MAX_LOG_CHARS,
+  64 * 1024,
+  { min: 1, name: "CUSTOM_HOOK_MAX_LOG_CHARS" },
+);
+// Max number of warnings raised via addWarning (default 100)
+const MAX_WARNINGS = parseEnvInt(process.env.CUSTOM_HOOK_MAX_WARNINGS, 100, {
+  min: 1,
+  name: "CUSTOM_HOOK_MAX_WARNINGS",
+});
+// Max total size of all warnings combined, in characters (default 64KB)
+const MAX_WARNING_CHARS = parseEnvInt(
+  process.env.CUSTOM_HOOK_MAX_WARNING_CHARS,
+  64 * 1024,
+  { min: 1, name: "CUSTOM_HOOK_MAX_WARNING_CHARS" },
+);
+
+export interface SandboxEvalResult {
+  ok: boolean;
+  error?: string;
+  returnVal?: unknown;
+  log?: string;
+  warnings: string[];
+}
+
+export interface SandboxEvalOptions {
+  memoryLimitMB?: number;
+  cpuTimeoutMS?: number;
+  wallTimeoutMS?: number;
+  maxFetchRespSize?: number;
+}
+
+export async function sandboxEval(
+  functionBody: string,
+  functionArgs: Record<string, unknown>,
+  {
+    memoryLimitMB,
+    cpuTimeoutMS,
+    wallTimeoutMS,
+    maxFetchRespSize,
+  }: SandboxEvalOptions = {},
+): Promise<SandboxEvalResult> {
+  // Sanity check. This should be handled by the caller already
+  // isolated-vm is not 100% safe in a multi-tenant environment, but should be fine when self-hosting
+  if (IS_CLOUD) {
+    return {
+      ok: false,
+      error: "Custom hooks are not supported in GrowthBook Cloud",
+      warnings: [],
+    };
+  }
+
+  const isolate = new Isolate({
+    memoryLimit: memoryLimitMB ?? MEMORY_MB,
+  });
+
+  const logs: string[] = [];
+  const warnings: string[] = [];
+  // Track how much we've captured so we can bound host-side memory (the isolate
+  // memory limit does not cover data copied out to these arrays).
+  let logChars = 0;
+  let warningChars = 0;
+
+  // Dispose state, so we can terminate a runaway isolate from the wall-clock
+  // timer (async code that yields with `await` escapes the per-run CPU timeout).
+  let disposed = false;
+  let wallTimer: ReturnType<typeof setTimeout> | undefined;
+  const safeDispose = () => {
+    if (disposed) return;
+    disposed = true;
+    try {
+      isolate.dispose();
+    } catch {
+      /* already disposed */
+    }
+  };
+
+  try {
+    const isolateCtx: Context = await isolate.createContext();
+    const jail = isolateCtx.global;
+    await jail.set("global", jail.derefInto());
+
+    // Same fetch function we use for webhooks (Smokescreen server, max size, timeout)
+    const hostFetch = async (url: string, opts: RequestInit = {}) => {
+      const res = await cancellableFetch(url, opts, {
+        maxContentSize: maxFetchRespSize ?? MAX_FETCH_RESP_SIZE,
+        maxTimeMs: wallTimeoutMS ?? WALL_TIMEOUT_MS,
+      });
+
+      return {
+        ok: res.responseWithoutBody.ok,
+        status: res.responseWithoutBody.status,
+        statusText: res.responseWithoutBody.statusText,
+        _body: res.stringBody,
+      };
+    };
+
+    // Host -> isolate bridge for fetch
+    const fetchRef = new Reference(
+      async (url: string, opts: RequestInit = {}) => {
+        try {
+          const resp = await hostFetch(String(url), opts || {});
+          return new ExternalCopy(resp).copyInto();
+        } catch (err) {
+          return new ExternalCopy({
+            _error: String(err.message || err),
+          }).copyInto();
+        }
+      },
+    );
+
+    // Host -> isolate bridge for logging.
+    // Bounds total captured output so a tight log loop can't exhaust host
+    // memory. Enforced here (not just in the shim) because user code can reach
+    // this Reference directly.
+    const logRef = new Reference((...args: unknown[]) => {
+      const remaining = MAX_LOG_CHARS - logChars;
+      if (remaining <= 0) return;
+      let line = args.map(String).join(" ");
+      if (line.length > remaining) {
+        line = line.slice(0, remaining) + "…[log truncated]";
+      }
+      logs.push(line);
+      logChars += line.length;
+    });
+
+    // Host -> isolate bridge for raising soft warnings.
+    // Bounds both the count and the total size of warnings.
+    const warnRef = new Reference((msg: unknown) => {
+      if (warnings.length >= MAX_WARNINGS) return;
+      const remaining = MAX_WARNING_CHARS - warningChars;
+      if (remaining <= 0) return;
+      let str = String(msg);
+      if (str.length > remaining) {
+        str = str.slice(0, remaining) + "…[warning truncated]";
+      }
+      warnings.push(str);
+      warningChars += str.length;
+    });
+
+    await jail.set("hostFetch", fetchRef);
+    await jail.set("hostLog", logRef);
+    await jail.set("hostWarn", warnRef);
+
+    // Inject shims for console.log and fetch
+    // We aren't aiming for a 100% complete implementation
+    // We just need something good enough so copy/pasted code works
+    const shimCode = `
+      (function() {
+        const stringifyLogArgs = (args) => args.map(arg => {
+          if (typeof arg === "string") return arg;
+          try {
+            return JSON.stringify(arg);
+          } catch {
+            return String(arg);
+          }
+        });
+
+        globalThis.console = {
+          log: (...args) => hostLog.applyIgnored(undefined, ["[log]", ...stringifyLogArgs(args)]),
+          error: (...args) => hostLog.applyIgnored(undefined, ["[error]", ...stringifyLogArgs(args)]),
+          debug: (...args) => hostLog.applyIgnored(undefined, ["[debug]", ...stringifyLogArgs(args)])
+        };
+        globalThis.fetch = async (...args) => {
+          const { _body, _error, ...rest } = await hostFetch.apply(undefined, args, {
+            arguments: { copy: true },
+            result: { copy: true, promise: true },
+          });
+          if (_error) {
+            throw new Error(_error);
+          }
+          return {
+            ...rest,
+            text: async () => _body,
+            json: async () => JSON.parse(_body),
+          };
+        };
+        globalThis.addWarning = (msg) => {
+          let str;
+          if (typeof msg === "string") {
+            str = msg;
+          } else {
+            try {
+              str = JSON.stringify(msg);
+            } catch {
+              str = String(msg);
+            }
+          }
+          hostWarn.applyIgnored(undefined, [str]);
+        };
+      })();
+    `;
+    await isolate.compileScript(shimCode).then((s) => s.run(isolateCtx));
+
+    // Wrap user body into a function and make individual arg keys available as variables
+    const wrapped = `
+      globalThis.__user_func = async function({${Object.keys(functionArgs).join(", ")}}) {
+        ${functionBody}
+      };
+      "__ready__";
+    `;
+    await isolate.compileScript(wrapped).then((s) => s.run(isolateCtx));
+
+    const funcRef = (await jail.get("__user_func", {
+      reference: true,
+    })) as Reference;
+
+    if (!funcRef) {
+      throw new Error("Compilation error");
+    }
+
+    const dataCopy = new ExternalCopy(functionArgs).copyInto();
+
+    // The `timeout` below only bounds a single *synchronous* run. Async code
+    // that yields with `await` resumes unbudgeted, so the wall-clock timer is
+    // the authoritative bound — and it must dispose the isolate to actually
+    // stop a runaway loop (rejecting the promise alone does not).
+    const resultPromise = funcRef.apply(undefined, [dataCopy], {
+      arguments: { copy: true },
+      result: { copy: true, promise: true },
+      timeout: cpuTimeoutMS ?? CPU_TIMEOUT_MS,
+    });
+    // If the wall timer fires first and disposes the isolate, this promise
+    // rejects after the race already settled; swallow the late rejection.
+    resultPromise.catch(() => {});
+
+    const wallTimeout = new Promise<never>((_, reject) => {
+      wallTimer = setTimeout(() => {
+        // Terminate any runaway execution (incl. async loops that evade the
+        // CPU timeout) instead of letting it run until `finally`.
+        safeDispose();
+        reject(new Error("Execution timed out"));
+      }, wallTimeoutMS ?? WALL_TIMEOUT_MS);
+    });
+
+    const returnVal = await Promise.race([resultPromise, wallTimeout]);
+    return { ok: true, returnVal, log: logs.join("\n"), warnings };
+  } catch (err) {
+    const message = err.message || err || "";
+    return {
+      ok: false,
+      error: message ? `Custom hook: ${message}` : "Custom hook error",
+      log: logs.join("\n"),
+      warnings,
+    };
+  } finally {
+    if (wallTimer) clearTimeout(wallTimer);
+    safeDispose();
+  }
+}

--- a/packages/back-end/src/enterprise/sandbox/sandbox-core.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-core.ts
@@ -4,10 +4,7 @@ import { parseEnvInt } from "shared/util";
 import { cancellableFetch } from "back-end/src/util/http.util";
 import { IS_CLOUD } from "back-end/src/util/secrets";
 
-// This module is the *pure* isolate runner. It is imported both by the main
-// process and by the forked sandbox worker, so it must stay light — do NOT
-// import the request context, models, mongoose, etc. here (that would balloon
-// every worker's boot footprint). Orchestration lives in sandbox-eval.ts.
+// Pure isolate runner — kept light (no context/models) so forked workers boot cheaply.
 
 // Default memory limit in MB
 const MEMORY_MB = parseEnvInt(process.env.CUSTOM_HOOK_MEMORY_MB, 32, {
@@ -35,9 +32,7 @@ const MAX_FETCH_RESP_SIZE = parseEnvInt(
   500 * 1024,
   { min: 1, name: "CUSTOM_HOOK_MAX_FETCH_RESP_SIZE" },
 );
-// Max total size of captured console.log output, in characters (default 64KB).
-// The isolate memory limit only bounds memory *inside* the isolate; data copied
-// out to the host (logs/warnings) is unbounded without this cap.
+// Cap captured console.log output; host arrays aren't bounded by the isolate limit.
 const MAX_LOG_CHARS = parseEnvInt(
   process.env.CUSTOM_HOOK_MAX_LOG_CHARS,
   64 * 1024,
@@ -80,8 +75,7 @@ export async function sandboxEval(
     maxFetchRespSize,
   }: SandboxEvalOptions = {},
 ): Promise<SandboxEvalResult> {
-  // Sanity check. This should be handled by the caller already
-  // isolated-vm is not 100% safe in a multi-tenant environment, but should be fine when self-hosting
+  // Caller already gates cloud; isolated-vm is acceptable for self-hosting, not multi-tenant.
   if (IS_CLOUD) {
     return {
       ok: false,
@@ -96,13 +90,11 @@ export async function sandboxEval(
 
   const logs: string[] = [];
   const warnings: string[] = [];
-  // Track how much we've captured so we can bound host-side memory (the isolate
-  // memory limit does not cover data copied out to these arrays).
+  // Bound host-side memory; the isolate limit doesn't cover data copied out.
   let logChars = 0;
   let warningChars = 0;
 
-  // Dispose state, so we can terminate a runaway isolate from the wall-clock
-  // timer (async code that yields with `await` escapes the per-run CPU timeout).
+  // Lets the wall timer terminate a runaway isolate (async escapes the CPU timeout).
   let disposed = false;
   let wallTimer: ReturnType<typeof setTimeout> | undefined;
   const safeDispose = () => {
@@ -149,10 +141,7 @@ export async function sandboxEval(
       },
     );
 
-    // Host -> isolate bridge for logging.
-    // Bounds total captured output so a tight log loop can't exhaust host
-    // memory. Enforced here (not just in the shim) because user code can reach
-    // this Reference directly.
+    // Bounds total log output; enforced here since user code can call this Reference directly.
     const logRef = new Reference((...args: unknown[]) => {
       const remaining = MAX_LOG_CHARS - logChars;
       if (remaining <= 0) return;
@@ -164,8 +153,7 @@ export async function sandboxEval(
       logChars += line.length;
     });
 
-    // Host -> isolate bridge for raising soft warnings.
-    // Bounds both the count and the total size of warnings.
+    // Bounds warning count and total size.
     const warnRef = new Reference((msg: unknown) => {
       if (warnings.length >= MAX_WARNINGS) return;
       const remaining = MAX_WARNING_CHARS - warningChars;
@@ -182,9 +170,7 @@ export async function sandboxEval(
     await jail.set("hostLog", logRef);
     await jail.set("hostWarn", warnRef);
 
-    // Inject shims for console.log and fetch
-    // We aren't aiming for a 100% complete implementation
-    // We just need something good enough so copy/pasted code works
+    // Minimal console/fetch/addWarning shims — good enough for copy/pasted code.
     const shimCode = `
       (function() {
         const stringifyLogArgs = (args) => args.map(arg => {
@@ -251,23 +237,18 @@ export async function sandboxEval(
 
     const dataCopy = new ExternalCopy(functionArgs).copyInto();
 
-    // The `timeout` below only bounds a single *synchronous* run. Async code
-    // that yields with `await` resumes unbudgeted, so the wall-clock timer is
-    // the authoritative bound — and it must dispose the isolate to actually
-    // stop a runaway loop (rejecting the promise alone does not).
+    // CPU timeout only bounds sync runs; the wall timer disposes the isolate for async runaways.
     const resultPromise = funcRef.apply(undefined, [dataCopy], {
       arguments: { copy: true },
       result: { copy: true, promise: true },
       timeout: cpuTimeoutMS ?? CPU_TIMEOUT_MS,
     });
-    // If the wall timer fires first and disposes the isolate, this promise
-    // rejects after the race already settled; swallow the late rejection.
+    // Swallow the late rejection if the wall timer disposed the isolate first.
     resultPromise.catch(() => {});
 
     const wallTimeout = new Promise<never>((_, reject) => {
       wallTimer = setTimeout(() => {
-        // Terminate any runaway execution (incl. async loops that evade the
-        // CPU timeout) instead of letting it run until `finally`.
+        // Terminate runaways (incl. async) now instead of waiting for finally.
         safeDispose();
         reject(new Error("Execution timed out"));
       }, wallTimeoutMS ?? WALL_TIMEOUT_MS);

--- a/packages/back-end/src/enterprise/sandbox/sandbox-core.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-core.ts
@@ -6,7 +6,6 @@ import { IS_CLOUD } from "back-end/src/util/secrets";
 
 // Pure isolate runner — kept light (no context/models) so forked workers boot cheaply.
 
-// Default memory limit in MB
 const MEMORY_MB = parseEnvInt(process.env.CUSTOM_HOOK_MEMORY_MB, 32, {
   min: 1,
   name: "CUSTOM_HOOK_MEMORY_MB",
@@ -26,7 +25,6 @@ const WALL_TIMEOUT_MS = parseEnvInt(
   5000,
   { min: 1, name: "CUSTOM_HOOK_WALL_TIMEOUT_MS" },
 );
-// Max response size from fetch calls (default 500KB)
 const MAX_FETCH_RESP_SIZE = parseEnvInt(
   process.env.CUSTOM_HOOK_MAX_FETCH_RESP_SIZE,
   500 * 1024,
@@ -38,12 +36,10 @@ const MAX_LOG_CHARS = parseEnvInt(
   64 * 1024,
   { min: 1, name: "CUSTOM_HOOK_MAX_LOG_CHARS" },
 );
-// Max number of warnings raised via addWarning (default 100)
 const MAX_WARNINGS = parseEnvInt(process.env.CUSTOM_HOOK_MAX_WARNINGS, 100, {
   min: 1,
   name: "CUSTOM_HOOK_MAX_WARNINGS",
 });
-// Max total size of all warnings combined, in characters (default 64KB)
 const MAX_WARNING_CHARS = parseEnvInt(
   process.env.CUSTOM_HOOK_MAX_WARNING_CHARS,
   64 * 1024,
@@ -127,7 +123,6 @@ export async function sandboxEval(
       };
     };
 
-    // Host -> isolate bridge for fetch
     const fetchRef = new Reference(
       async (url: string, opts: RequestInit = {}) => {
         try {
@@ -153,7 +148,6 @@ export async function sandboxEval(
       logChars += line.length;
     });
 
-    // Bounds warning count and total size.
     const warnRef = new Reference((msg: unknown) => {
       if (warnings.length >= MAX_WARNINGS) return;
       const remaining = MAX_WARNING_CHARS - warningChars;

--- a/packages/back-end/src/enterprise/sandbox/sandbox-eval.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-eval.ts
@@ -8,6 +8,29 @@ import { getContextForAgendaJobByOrgObject } from "back-end/src/services/organiz
 import { runInSandbox } from "./sandbox-pool";
 
 // Custom hook orchestration; sandboxed JS runs in the child-process pool (sandbox-pool.ts).
+//
+// ## Convention for `validateX` hooks on a resource X
+//
+// 1. The hook call inside the low-level model write function (createX/updateX,
+//    immediately before the Mongo write) is MANDATORY and authoritative —
+//    nothing may bypass it.
+// 2. The model module exports a pure function (`computeXUpdate`) that
+//    computes exactly the proposed state the write path passes to
+//    `runValidateXHooks`, and the write path consumes it — so a prevalidated
+//    state and the saved state stay identical by construction.
+// 3. The model module exports `prevalidateXUpdate(...)` =
+//    `runValidateXHooks(computeXUpdate(...))`. Any controller/service that
+//    performs side-effect writes to OTHER collections before the gated save
+//    must call it with the final intended changes BEFORE the first
+//    side-effect write, so a hook rejection (or unacknowledged soft warning)
+//    doesn't orphan those writes. Pre-generate referenced ids
+//    (`generateId(prefix)` + `CreateProps.id`) rather than validating
+//    placeholder values. See `prevalidateRevisionUpdate` /
+//    `prevalidatePublishRevision` for the pattern.
+// 4. Hooks therefore fire more than once per successful save. Never dedupe by
+//    hook id — the model-level run must stay authoritative even if state
+//    changed after prevalidation. Prevalidation is best-effort: a concurrent
+//    mutation or non-deterministic hook (fetch()) can still fail at save time.
 
 export async function runValidateFeatureHooks({
   context,

--- a/packages/back-end/src/enterprise/sandbox/sandbox-eval.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-eval.ts
@@ -8,29 +8,6 @@ import { getContextForAgendaJobByOrgObject } from "back-end/src/services/organiz
 import { runInSandbox } from "./sandbox-pool";
 
 // Custom hook orchestration; sandboxed JS runs in the child-process pool (sandbox-pool.ts).
-//
-// ## Convention for `validateX` hooks on a resource X
-//
-// 1. The hook call inside the low-level model write function (createX/updateX,
-//    immediately before the Mongo write) is MANDATORY and authoritative —
-//    nothing may bypass it.
-// 2. The model module exports a pure function (`computeXUpdate`) that
-//    computes exactly the proposed state the write path passes to
-//    `runValidateXHooks`, and the write path consumes it — so a prevalidated
-//    state and the saved state stay identical by construction.
-// 3. The model module exports `prevalidateXUpdate(...)` =
-//    `runValidateXHooks(computeXUpdate(...))`. Any controller/service that
-//    performs side-effect writes to OTHER collections before the gated save
-//    must call it with the final intended changes BEFORE the first
-//    side-effect write, so a hook rejection (or unacknowledged soft warning)
-//    doesn't orphan those writes. Pre-generate referenced ids
-//    (`generateId(prefix)` + `CreateProps.id`) rather than validating
-//    placeholder values. See `prevalidateRevisionUpdate` /
-//    `prevalidatePublishRevision` for the pattern.
-// 4. Hooks therefore fire more than once per successful save. Never dedupe by
-//    hook id — the model-level run must stay authoritative even if state
-//    changed after prevalidation. Prevalidation is best-effort: a concurrent
-//    mutation or non-deterministic hook (fetch()) can still fail at save time.
 
 export async function runValidateFeatureHooks({
   context,

--- a/packages/back-end/src/enterprise/sandbox/sandbox-eval.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-eval.ts
@@ -7,12 +7,8 @@ import { ReqContextClass } from "back-end/src/services/context";
 import { getContextForAgendaJobByOrgObject } from "back-end/src/services/organizations";
 import { runInSandbox } from "./sandbox-pool";
 
-// Orchestration for custom hooks. The sandboxed JavaScript itself runs in a
-// pool of disposable child processes (sandbox-pool.ts / sandbox-worker.ts), so
-// a crashing or runaway hook can only take down a worker, never the API server.
-// The pure isolate runner lives in sandbox-core.ts.
+// Custom hook orchestration; sandboxed JS runs in the child-process pool (sandbox-pool.ts).
 
-// Export wrapped calls for each hook type
 export async function runValidateFeatureHooks({
   context,
   feature,
@@ -123,8 +119,7 @@ async function _runCustomHook(
 
   // A thrown error is a hard block and always wins over any warnings.
   if (!res.ok) {
-    // Incremental: if the same error was already present before this change,
-    // ignore the hook entirely.
+    // Incremental: ignore the hook if this same error already existed before the change.
     if (originalFunctionArgs && hook.incrementalChangesOnly) {
       const originalRes = await runInSandbox(hook.code, originalFunctionArgs);
       if (!originalRes.ok && originalRes.error === res.error) {

--- a/packages/back-end/src/enterprise/sandbox/sandbox-eval.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-eval.ts
@@ -52,6 +52,7 @@ export async function runValidateFeatureHooks({
     "validateFeature",
     { feature },
     feature.project,
+    feature.id,
     original ? { feature: original } : undefined,
   );
 }
@@ -72,6 +73,7 @@ export async function runValidateFeatureRevisionHooks({
     "validateFeatureRevision",
     { feature, revision },
     feature.project,
+    feature.id,
     {
       feature,
       revision: original,
@@ -93,6 +95,7 @@ async function _runCustomHooks(
   hookType: CustomHookType,
   functionArgs: Record<string, unknown>,
   project: string = "",
+  featureId: string = "",
   originalFunctionArgs?: Record<string, unknown>,
 ) {
   // Skip on cloud
@@ -115,6 +118,7 @@ async function _runCustomHooks(
   const hooks = await adminContext.models.customHooks.getByHook(
     hookType,
     project,
+    featureId,
   );
 
   const allWarnings: string[] = [];

--- a/packages/back-end/src/enterprise/sandbox/sandbox-eval.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-eval.ts
@@ -1,41 +1,16 @@
-import { Isolate, Context, Reference, ExternalCopy } from "isolated-vm";
-import { RequestInit } from "node-fetch";
 import { CustomHookInterface, CustomHookType } from "shared/validators";
 import { FeatureInterface } from "shared/types/feature";
 import { FeatureRevisionInterface } from "shared/types/feature-revision";
-import { parseEnvInt } from "shared/util";
-import { cancellableFetch } from "back-end/src/util/http.util";
 import { SoftWarningError } from "back-end/src/util/errors";
 import { IS_CLOUD } from "back-end/src/util/secrets";
 import { ReqContextClass } from "back-end/src/services/context";
 import { getContextForAgendaJobByOrgObject } from "back-end/src/services/organizations";
+import { runInSandbox } from "./sandbox-pool";
 
-// Default memory limit in MB
-const MEMORY_MB = parseEnvInt(process.env.CUSTOM_HOOK_MEMORY_MB, 32, {
-  min: 1,
-  name: "CUSTOM_HOOK_MEMORY_MB",
-});
-// Max active CPU time (excluding fetch)
-const CPU_TIMEOUT_MS = parseEnvInt(
-  process.env.CUSTOM_HOOK_CPU_TIMEOUT_MS,
-  100,
-  {
-    min: 1,
-    name: "CUSTOM_HOOK_CPU_TIMEOUT_MS",
-  },
-);
-// Max total run time (including fetch)
-const WALL_TIMEOUT_MS = parseEnvInt(
-  process.env.CUSTOM_HOOK_WALL_TIMEOUT_MS,
-  5000,
-  { min: 1, name: "CUSTOM_HOOK_WALL_TIMEOUT_MS" },
-);
-// Max response size from fetch calls (default 500KB)
-const MAX_FETCH_RESP_SIZE = parseEnvInt(
-  process.env.CUSTOM_HOOK_MAX_FETCH_RESP_SIZE,
-  500 * 1024,
-  { min: 1, name: "CUSTOM_HOOK_MAX_FETCH_RESP_SIZE" },
-);
+// Orchestration for custom hooks. The sandboxed JavaScript itself runs in a
+// pool of disposable child processes (sandbox-pool.ts / sandbox-worker.ts), so
+// a crashing or runaway hook can only take down a worker, never the API server.
+// The pure isolate runner lives in sandbox-core.ts.
 
 // Export wrapped calls for each hook type
 export async function runValidateFeatureHooks({
@@ -79,14 +54,6 @@ export async function runValidateFeatureRevisionHooks({
       revision: original,
     },
   );
-}
-
-export interface SandboxEvalResult {
-  ok: boolean;
-  error?: string;
-  returnVal?: unknown;
-  log?: string;
-  warnings: string[];
 }
 
 // Private methods
@@ -146,7 +113,7 @@ async function _runCustomHook(
   functionArgs: Record<string, unknown>,
   originalFunctionArgs?: Record<string, unknown>,
 ): Promise<{ error?: string; warnings: string[] }> {
-  const res = await sandboxEval(hook.code, functionArgs);
+  const res = await runInSandbox(hook.code, functionArgs);
 
   if (res.ok) {
     context.models.customHooks.logSuccess(hook);
@@ -159,7 +126,7 @@ async function _runCustomHook(
     // Incremental: if the same error was already present before this change,
     // ignore the hook entirely.
     if (originalFunctionArgs && hook.incrementalChangesOnly) {
-      const originalRes = await sandboxEval(hook.code, originalFunctionArgs);
+      const originalRes = await runInSandbox(hook.code, originalFunctionArgs);
       if (!originalRes.ok && originalRes.error === res.error) {
         return { warnings: [] };
       }
@@ -174,193 +141,11 @@ async function _runCustomHook(
 
   // Incremental: drop warnings that were already present before this change.
   if (warnings.length && originalFunctionArgs && hook.incrementalChangesOnly) {
-    const originalRes = await sandboxEval(hook.code, originalFunctionArgs);
+    const originalRes = await runInSandbox(hook.code, originalFunctionArgs);
     if (originalRes.ok) {
       warnings = warnings.filter((w) => !originalRes.warnings.includes(w));
     }
   }
 
   return { warnings };
-}
-
-export async function sandboxEval(
-  functionBody: string,
-  functionArgs: Record<string, unknown>,
-  {
-    memoryLimitMB,
-    cpuTimeoutMS,
-    wallTimeoutMS,
-    maxFetchRespSize,
-  }: {
-    memoryLimitMB?: number;
-    cpuTimeoutMS?: number;
-    wallTimeoutMS?: number;
-    maxFetchRespSize?: number;
-  } = {},
-): Promise<SandboxEvalResult> {
-  // Sanity check. This should be handled by the caller already
-  // isolated-vm is not 100% safe in a multi-tenant environment, but should be fine when self-hosting
-  if (IS_CLOUD) {
-    return {
-      ok: false,
-      error: "Custom hooks are not supported in GrowthBook Cloud",
-      warnings: [],
-    };
-  }
-
-  const isolate = new Isolate({
-    memoryLimit: memoryLimitMB ?? MEMORY_MB,
-  });
-
-  const logs: string[] = [];
-  const warnings: string[] = [];
-
-  try {
-    const isolateCtx: Context = await isolate.createContext();
-    const jail = isolateCtx.global;
-    await jail.set("global", jail.derefInto());
-
-    // Same fetch function we use for webhooks (Smokescreen server, max size, timeout)
-    const hostFetch = async (url: string, opts: RequestInit = {}) => {
-      const res = await cancellableFetch(url, opts, {
-        maxContentSize: maxFetchRespSize ?? MAX_FETCH_RESP_SIZE,
-        maxTimeMs: wallTimeoutMS ?? WALL_TIMEOUT_MS,
-      });
-
-      return {
-        ok: res.responseWithoutBody.ok,
-        status: res.responseWithoutBody.status,
-        statusText: res.responseWithoutBody.statusText,
-        _body: res.stringBody,
-      };
-    };
-
-    // Host -> isolate bridge for fetch
-    const fetchRef = new Reference(
-      async (url: string, opts: RequestInit = {}) => {
-        try {
-          const resp = await hostFetch(String(url), opts || {});
-          return new ExternalCopy(resp).copyInto();
-        } catch (err) {
-          return new ExternalCopy({
-            _error: String(err.message || err),
-          }).copyInto();
-        }
-      },
-    );
-
-    // Host -> isolate bridge for logging
-    const logRef = new Reference((...args: unknown[]) => {
-      logs.push(args.map(String).join(" "));
-    });
-
-    // Host -> isolate bridge for raising soft warnings
-    const warnRef = new Reference((msg: unknown) => {
-      warnings.push(String(msg));
-    });
-
-    await jail.set("hostFetch", fetchRef);
-    await jail.set("hostLog", logRef);
-    await jail.set("hostWarn", warnRef);
-
-    // Inject shims for console.log and fetch
-    // We aren't aiming for a 100% complete implementation
-    // We just need something good enough so copy/pasted code works
-    const shimCode = `
-      (function() {
-        const stringifyLogArgs = (args) => args.map(arg => {
-          if (typeof arg === "string") return arg;
-          try {
-            return JSON.stringify(arg);
-          } catch {
-            return String(arg);
-          }
-        });
-
-        globalThis.console = {
-          log: (...args) => hostLog.applyIgnored(undefined, ["[log]", ...stringifyLogArgs(args)]),
-          error: (...args) => hostLog.applyIgnored(undefined, ["[error]", ...stringifyLogArgs(args)]),
-          debug: (...args) => hostLog.applyIgnored(undefined, ["[debug]", ...stringifyLogArgs(args)])
-        };
-        globalThis.fetch = async (...args) => {
-          const { _body, _error, ...rest } = await hostFetch.apply(undefined, args, {
-            arguments: { copy: true },
-            result: { copy: true, promise: true },
-          });
-          if (_error) {
-            throw new Error(_error);
-          }
-          return {
-            ...rest,
-            text: async () => _body,
-            json: async () => JSON.parse(_body),
-          };
-        };
-        globalThis.addWarning = (msg) => {
-          let str;
-          if (typeof msg === "string") {
-            str = msg;
-          } else {
-            try {
-              str = JSON.stringify(msg);
-            } catch {
-              str = String(msg);
-            }
-          }
-          hostWarn.applyIgnored(undefined, [str]);
-        };
-      })();
-    `;
-    await isolate.compileScript(shimCode).then((s) => s.run(isolateCtx));
-
-    // Wrap user body into a function and make individual arg keys available as variables
-    const wrapped = `
-      globalThis.__user_func = async function({${Object.keys(functionArgs).join(", ")}}) {
-        ${functionBody}
-      };
-      "__ready__";
-    `;
-    await isolate.compileScript(wrapped).then((s) => s.run(isolateCtx));
-
-    const funcRef = (await jail.get("__user_func", {
-      reference: true,
-    })) as Reference;
-
-    if (!funcRef) {
-      throw new Error("Compilation error");
-    }
-
-    const dataCopy = new ExternalCopy(functionArgs).copyInto();
-
-    // Race between CPU-limited call and wall-clock timeout
-    const resultPromise = funcRef.apply(undefined, [dataCopy], {
-      arguments: { copy: true },
-      result: { copy: true, promise: true },
-      timeout: cpuTimeoutMS ?? CPU_TIMEOUT_MS,
-    });
-
-    const wallTimeout = new Promise<never>((_, reject) =>
-      setTimeout(
-        () => reject(new Error("Execution timed out")),
-        wallTimeoutMS ?? WALL_TIMEOUT_MS,
-      ),
-    );
-
-    const returnVal = await Promise.race([resultPromise, wallTimeout]);
-    return { ok: true, returnVal, log: logs.join("\n"), warnings };
-  } catch (err) {
-    const message = err.message || err || "";
-    return {
-      ok: false,
-      error: message ? `Custom hook: ${message}` : "Custom hook error",
-      log: logs.join("\n"),
-      warnings,
-    };
-  } finally {
-    try {
-      isolate.dispose();
-    } catch {
-      /* ignore */
-    }
-  }
 }

--- a/packages/back-end/src/enterprise/sandbox/sandbox-pool.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-pool.ts
@@ -66,6 +66,7 @@ interface Worker {
   proc: ChildProcess;
   busy: boolean;
   jobsHandled: number;
+  generation: number;
   current?: { job: Job; killTimer: ReturnType<typeof setTimeout> };
 }
 
@@ -74,6 +75,10 @@ const queue: Job[] = [];
 let jobCounter = 0;
 let started = false;
 let shuttingDown = false;
+// Bumped each time the pool is (re)started. Workers capture the generation they
+// were spawned in so handleExit can tell a live worker from one belonging to a
+// pool that's already been torn down (see __shutdownSandboxPool).
+let generation = 0;
 
 function spawnWorker(): Worker {
   // Preserve the parent's runtime flags (source maps, snapshot settings) but
@@ -91,7 +96,7 @@ function spawnWorker(): Worker {
     stdio: ["ignore", "ignore", "inherit", "ipc"],
   });
 
-  const worker: Worker = { proc, busy: false, jobsHandled: 0 };
+  const worker: Worker = { proc, busy: false, jobsHandled: 0, generation };
 
   proc.on("message", (msg: { id: number; result: SandboxEvalResult }) => {
     const cur = worker.current;
@@ -138,6 +143,11 @@ function handleExit(
       warnings: [],
     });
   }
+
+  // Ignore exits from a torn-down generation: an async SIGKILL exit can arrive
+  // after the pool was shut down and restarted. The in-flight job, if any, was
+  // already failed above; we just must not grow or re-dispatch the new pool.
+  if (worker.generation !== generation) return;
 
   // Keep the pool warm and drain any backlog.
   if (!shuttingDown && started) {
@@ -222,6 +232,7 @@ function dispatch() {
 function ensureStarted() {
   if (started) return;
   started = true;
+  generation++;
   for (let i = 0; i < POOL_SIZE; i++) workers.push(spawnWorker());
   process.once("exit", shutdown);
 }

--- a/packages/back-end/src/enterprise/sandbox/sandbox-pool.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-pool.ts
@@ -4,11 +4,7 @@ import { parseEnvInt } from "shared/util";
 import { logger } from "back-end/src/util/logger";
 import type { SandboxEvalOptions, SandboxEvalResult } from "./sandbox-core";
 
-// Runs custom hook code in a pool of disposable child processes. Process-level
-// isolation means a hard crash (OOM abort, native fault) or a hung run takes
-// down only a worker, not the API server — the pool detects the exit, fails
-// just that job, and respawns. Workers also run with a hard memory cap so an
-// OOM is contained rather than competing with the main heap.
+// Pool of disposable child processes — a worker crash/OOM/hang takes down only that worker.
 
 const POOL_SIZE = parseEnvInt(process.env.CUSTOM_HOOK_POOL_SIZE, 2, {
   min: 1,
@@ -36,17 +32,13 @@ const WALL_TIMEOUT_MS = parseEnvInt(
   5000,
   { min: 1, name: "CUSTOM_HOOK_WALL_TIMEOUT_MS" },
 );
-// Extra time beyond the in-isolate wall timeout before we SIGKILL a worker that
-// hasn't responded (covers native hangs the in-process dispose can't stop).
+// Grace beyond the wall timeout before we SIGKILL an unresponsive worker.
 const KILL_GRACE_MS = parseEnvInt(process.env.CUSTOM_HOOK_KILL_GRACE_MS, 2000, {
   min: 1,
   name: "CUSTOM_HOOK_KILL_GRACE_MS",
 });
 
-// Resolve the worker as a sibling of this module, matching its own extension:
-// `.ts` when run directly via ts-node/tsx, `.js` once compiled. fork() inherits
-// the parent's execArgv (see spawnWorker) so any TS loader carries over to the
-// child. CUSTOM_HOOK_WORKER_PATH overrides for non-standard setups.
+// Worker sibling module, matching this file's extension (.ts dev / .js compiled).
 const WORKER_PATH =
   process.env.CUSTOM_HOOK_WORKER_PATH ||
   path.join(
@@ -75,14 +67,11 @@ const queue: Job[] = [];
 let jobCounter = 0;
 let started = false;
 let shuttingDown = false;
-// Bumped each time the pool is (re)started. Workers capture the generation they
-// were spawned in so handleExit can tell a live worker from one belonging to a
-// pool that's already been torn down (see __shutdownSandboxPool).
+// Bumped on (re)start so handleExit can ignore workers from a torn-down pool.
 let generation = 0;
 
 function spawnWorker(): Worker {
-  // Preserve the parent's runtime flags (source maps, snapshot settings) but
-  // override the heap cap so the worker is hard-bounded.
+  // Keep the parent's runtime flags but override the heap cap.
   const execArgv = [
     ...process.execArgv.filter((a) => !a.startsWith("--max-old-space-size")),
     `--max-old-space-size=${WORKER_HEAP_MB}`,
@@ -91,8 +80,7 @@ function spawnWorker(): Worker {
   const proc = fork(WORKER_PATH, [], {
     execArgv,
     serialization: "advanced",
-    // Discard stdin/stdout; keep stderr so a crash (e.g. "FATAL ERROR: heap out
-    // of memory") surfaces in the server logs. IPC channel for jobs/results.
+    // Discard stdin/stdout; keep stderr so crashes surface in logs. ipc for jobs/results.
     stdio: ["ignore", "ignore", "inherit", "ipc"],
   });
 
@@ -128,8 +116,7 @@ function handleExit(
 
   const cur = worker.current;
   if (cur) {
-    // A job was in flight: the worker crashed, OOM'd, or was killed for hanging.
-    // Contained here — fail only this job; the server keeps running.
+    // Worker died mid-job (crash/OOM/kill) — fail just this job; the server keeps running.
     clearTimeout(cur.killTimer);
     worker.current = undefined;
     logger.warn(
@@ -144,9 +131,7 @@ function handleExit(
     });
   }
 
-  // Ignore exits from a torn-down generation: an async SIGKILL exit can arrive
-  // after the pool was shut down and restarted. The in-flight job, if any, was
-  // already failed above; we just must not grow or re-dispatch the new pool.
+  // Ignore exits from a torn-down generation (the job, if any, was failed above).
   if (worker.generation !== generation) return;
 
   // Keep the pool warm and drain any backlog.
@@ -156,13 +141,10 @@ function handleExit(
   }
 }
 
-// Gracefully retire a worker (e.g. after MAX_JOBS_PER_WORKER); the exit handler
-// removes it and respawns a replacement.
+// Gracefully retire a worker; the exit handler removes and respawns it.
 function recycle(worker: Worker) {
   if (worker.current) return; // only when idle
-  // Remove from the pool immediately so dispatch() cannot select this worker
-  // after SIGTERM is sent but before the process has actually exited
-  // (proc.connected stays true until the IPC channel closes asynchronously).
+  // Remove now so dispatch() can't pick it between SIGTERM and the async exit.
   workers = workers.filter((w) => w !== worker);
   try {
     worker.proc.kill();
@@ -249,11 +231,7 @@ function shutdown() {
   workers = [];
 }
 
-/**
- * Run custom hook code in a sandboxed child process. Drop-in for the in-process
- * sandboxEval: never rejects — resolves with `{ ok: false, error }` on failure,
- * crash, timeout, or load-shedding.
- */
+// Drop-in for sandboxEval; never rejects (resolves { ok: false } on failure/crash/timeout).
 export function runInSandbox(
   code: string,
   args: Record<string, unknown>,

--- a/packages/back-end/src/enterprise/sandbox/sandbox-pool.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-pool.ts
@@ -208,6 +208,7 @@ function dispatch() {
       warnings: [],
     });
     recycle(worker);
+    dispatch();
   }
 }
 

--- a/packages/back-end/src/enterprise/sandbox/sandbox-pool.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-pool.ts
@@ -43,9 +43,16 @@ const KILL_GRACE_MS = parseEnvInt(process.env.CUSTOM_HOOK_KILL_GRACE_MS, 2000, {
   name: "CUSTOM_HOOK_KILL_GRACE_MS",
 });
 
+// Resolve the worker as a sibling of this module, matching its own extension:
+// `.ts` when run directly via ts-node/tsx, `.js` once compiled. fork() inherits
+// the parent's execArgv (see spawnWorker) so any TS loader carries over to the
+// child. CUSTOM_HOOK_WORKER_PATH overrides for non-standard setups.
 const WORKER_PATH =
   process.env.CUSTOM_HOOK_WORKER_PATH ||
-  path.join(__dirname, "sandbox-worker.js");
+  path.join(
+    __dirname,
+    `sandbox-worker${__filename.endsWith(".ts") ? ".ts" : ".js"}`,
+  );
 
 interface Job {
   id: number;
@@ -143,6 +150,10 @@ function handleExit(
 // removes it and respawns a replacement.
 function recycle(worker: Worker) {
   if (worker.current) return; // only when idle
+  // Remove from the pool immediately so dispatch() cannot select this worker
+  // after SIGTERM is sent but before the process has actually exited
+  // (proc.connected stays true until the IPC channel closes asynchronously).
+  workers = workers.filter((w) => w !== worker);
   try {
     worker.proc.kill();
   } catch {

--- a/packages/back-end/src/enterprise/sandbox/sandbox-pool.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-pool.ts
@@ -134,7 +134,6 @@ function handleExit(
   // Ignore exits from a torn-down generation (the job, if any, was failed above).
   if (worker.generation !== generation) return;
 
-  // Keep the pool warm and drain any backlog.
   if (!shuttingDown && started) {
     if (workers.length < POOL_SIZE) workers.push(spawnWorker());
     dispatch();

--- a/packages/back-end/src/enterprise/sandbox/sandbox-pool.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-pool.ts
@@ -1,0 +1,261 @@
+import { ChildProcess, fork } from "child_process";
+import * as path from "path";
+import { parseEnvInt } from "shared/util";
+import { logger } from "back-end/src/util/logger";
+import type { SandboxEvalOptions, SandboxEvalResult } from "./sandbox-core";
+
+// Runs custom hook code in a pool of disposable child processes. Process-level
+// isolation means a hard crash (OOM abort, native fault) or a hung run takes
+// down only a worker, not the API server — the pool detects the exit, fails
+// just that job, and respawns. Workers also run with a hard memory cap so an
+// OOM is contained rather than competing with the main heap.
+
+const POOL_SIZE = parseEnvInt(process.env.CUSTOM_HOOK_POOL_SIZE, 2, {
+  min: 1,
+  name: "CUSTOM_HOOK_POOL_SIZE",
+});
+// Hard per-worker heap cap (V8 old space). An OOM kills the worker, not the server.
+const WORKER_HEAP_MB = parseEnvInt(
+  process.env.CUSTOM_HOOK_WORKER_HEAP_MB,
+  256,
+  { min: 16, name: "CUSTOM_HOOK_WORKER_HEAP_MB" },
+);
+// Recycle a worker after this many jobs so any slow growth can't accumulate.
+const MAX_JOBS_PER_WORKER = parseEnvInt(
+  process.env.CUSTOM_HOOK_MAX_JOBS_PER_WORKER,
+  50,
+  { min: 1, name: "CUSTOM_HOOK_MAX_JOBS_PER_WORKER" },
+);
+// Max number of jobs waiting for a free worker before we shed load.
+const MAX_QUEUE = parseEnvInt(process.env.CUSTOM_HOOK_MAX_QUEUE, 100, {
+  min: 1,
+  name: "CUSTOM_HOOK_MAX_QUEUE",
+});
+const WALL_TIMEOUT_MS = parseEnvInt(
+  process.env.CUSTOM_HOOK_WALL_TIMEOUT_MS,
+  5000,
+  { min: 1, name: "CUSTOM_HOOK_WALL_TIMEOUT_MS" },
+);
+// Extra time beyond the in-isolate wall timeout before we SIGKILL a worker that
+// hasn't responded (covers native hangs the in-process dispose can't stop).
+const KILL_GRACE_MS = parseEnvInt(process.env.CUSTOM_HOOK_KILL_GRACE_MS, 2000, {
+  min: 1,
+  name: "CUSTOM_HOOK_KILL_GRACE_MS",
+});
+
+const WORKER_PATH =
+  process.env.CUSTOM_HOOK_WORKER_PATH ||
+  path.join(__dirname, "sandbox-worker.js");
+
+interface Job {
+  id: number;
+  code: string;
+  args: Record<string, unknown>;
+  opts?: SandboxEvalOptions;
+  resolve: (result: SandboxEvalResult) => void;
+}
+
+interface Worker {
+  proc: ChildProcess;
+  busy: boolean;
+  jobsHandled: number;
+  current?: { job: Job; killTimer: ReturnType<typeof setTimeout> };
+}
+
+let workers: Worker[] = [];
+const queue: Job[] = [];
+let jobCounter = 0;
+let started = false;
+let shuttingDown = false;
+
+function spawnWorker(): Worker {
+  // Preserve the parent's runtime flags (source maps, snapshot settings) but
+  // override the heap cap so the worker is hard-bounded.
+  const execArgv = [
+    ...process.execArgv.filter((a) => !a.startsWith("--max-old-space-size")),
+    `--max-old-space-size=${WORKER_HEAP_MB}`,
+  ];
+
+  const proc = fork(WORKER_PATH, [], {
+    execArgv,
+    serialization: "advanced",
+    // Discard stdin/stdout; keep stderr so a crash (e.g. "FATAL ERROR: heap out
+    // of memory") surfaces in the server logs. IPC channel for jobs/results.
+    stdio: ["ignore", "ignore", "inherit", "ipc"],
+  });
+
+  const worker: Worker = { proc, busy: false, jobsHandled: 0 };
+
+  proc.on("message", (msg: { id: number; result: SandboxEvalResult }) => {
+    const cur = worker.current;
+    if (!cur || cur.job.id !== msg.id) return; // stale/duplicate
+    clearTimeout(cur.killTimer);
+    worker.current = undefined;
+    worker.busy = false;
+    cur.job.resolve(msg.result);
+    if (worker.jobsHandled >= MAX_JOBS_PER_WORKER) {
+      recycle(worker);
+    }
+    dispatch();
+  });
+
+  proc.on("exit", (code, signal) => handleExit(worker, code, signal));
+  proc.on("error", (err) => {
+    logger.error(err, "Custom hook sandbox worker error");
+  });
+
+  return worker;
+}
+
+function handleExit(
+  worker: Worker,
+  code: number | null,
+  signal: NodeJS.Signals | null,
+) {
+  workers = workers.filter((w) => w !== worker);
+
+  const cur = worker.current;
+  if (cur) {
+    // A job was in flight: the worker crashed, OOM'd, or was killed for hanging.
+    // Contained here — fail only this job; the server keeps running.
+    clearTimeout(cur.killTimer);
+    worker.current = undefined;
+    logger.warn(
+      { code, signal, jobId: cur.job.id },
+      "Custom hook sandbox worker exited mid-job (crash, OOM, or timeout); failing the job",
+    );
+    cur.job.resolve({
+      ok: false,
+      error:
+        "Custom hook: sandbox terminated unexpectedly (possible crash, out-of-memory, or timeout)",
+      warnings: [],
+    });
+  }
+
+  // Keep the pool warm and drain any backlog.
+  if (!shuttingDown && started) {
+    if (workers.length < POOL_SIZE) workers.push(spawnWorker());
+    dispatch();
+  }
+}
+
+// Gracefully retire a worker (e.g. after MAX_JOBS_PER_WORKER); the exit handler
+// removes it and respawns a replacement.
+function recycle(worker: Worker) {
+  if (worker.current) return; // only when idle
+  try {
+    worker.proc.kill();
+  } catch {
+    /* already gone */
+  }
+}
+
+function dispatch() {
+  if (shuttingDown || !queue.length) return;
+
+  let worker = workers.find((w) => !w.busy && w.proc.connected);
+  if (!worker) {
+    if (workers.length < POOL_SIZE) {
+      worker = spawnWorker();
+      workers.push(worker);
+    } else {
+      return; // all busy; a freeing worker will re-dispatch
+    }
+  }
+
+  const job = queue.shift();
+  if (!job) return;
+
+  worker.busy = true;
+  worker.jobsHandled++;
+
+  const wallTimeout = job.opts?.wallTimeoutMS ?? WALL_TIMEOUT_MS;
+  const killTimer = setTimeout(() => {
+    logger.warn(
+      { jobId: job.id },
+      "Custom hook sandbox worker did not respond in time; killing it",
+    );
+    try {
+      worker?.proc.kill("SIGKILL");
+    } catch {
+      /* already gone */
+    }
+    // handleExit resolves the job and respawns.
+  }, wallTimeout + KILL_GRACE_MS);
+
+  worker.current = { job, killTimer };
+
+  try {
+    worker.proc.send({
+      id: job.id,
+      code: job.code,
+      args: job.args,
+      opts: job.opts,
+    });
+  } catch (e) {
+    // Couldn't hand off (e.g. non-cloneable args or dead channel).
+    clearTimeout(killTimer);
+    worker.current = undefined;
+    worker.busy = false;
+    job.resolve({
+      ok: false,
+      error: `Custom hook: failed to dispatch to sandbox (${
+        e instanceof Error ? e.message : String(e)
+      })`,
+      warnings: [],
+    });
+    recycle(worker);
+  }
+}
+
+function ensureStarted() {
+  if (started) return;
+  started = true;
+  for (let i = 0; i < POOL_SIZE; i++) workers.push(spawnWorker());
+  process.once("exit", shutdown);
+}
+
+function shutdown() {
+  shuttingDown = true;
+  for (const w of workers) {
+    try {
+      w.proc.kill("SIGKILL");
+    } catch {
+      /* ignore */
+    }
+  }
+  workers = [];
+}
+
+/**
+ * Run custom hook code in a sandboxed child process. Drop-in for the in-process
+ * sandboxEval: never rejects — resolves with `{ ok: false, error }` on failure,
+ * crash, timeout, or load-shedding.
+ */
+export function runInSandbox(
+  code: string,
+  args: Record<string, unknown>,
+  opts?: SandboxEvalOptions,
+): Promise<SandboxEvalResult> {
+  ensureStarted();
+  return new Promise<SandboxEvalResult>((resolve) => {
+    if (queue.length >= MAX_QUEUE) {
+      resolve({
+        ok: false,
+        error: "Custom hook: sandbox is overloaded, please try again",
+        warnings: [],
+      });
+      return;
+    }
+    queue.push({ id: ++jobCounter, code, args, opts, resolve });
+    dispatch();
+  });
+}
+
+// Exposed for tests/diagnostics.
+export function __shutdownSandboxPool() {
+  shutdown();
+  // Allow a fresh start afterwards (used by tests).
+  shuttingDown = false;
+  started = false;
+}

--- a/packages/back-end/src/enterprise/sandbox/sandbox-worker.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-worker.ts
@@ -1,0 +1,53 @@
+import {
+  sandboxEval,
+  SandboxEvalOptions,
+  SandboxEvalResult,
+} from "./sandbox-core";
+
+// Forked child process that runs custom hook code in an isolated-vm sandbox,
+// one job at a time, communicating with the parent over IPC. Running in a
+// separate OS process means a hard crash (OOM abort, native fault) or a hung
+// run kills only this worker — the parent (SandboxPool) detects the exit and
+// fails just that job, keeping the API server alive.
+//
+// This file imports only sandbox-core (which is intentionally light), so each
+// worker boots without the full back-end module graph.
+
+interface WorkerJob {
+  id: number;
+  code: string;
+  args: Record<string, unknown>;
+  opts?: SandboxEvalOptions;
+}
+
+interface WorkerResponse {
+  id: number;
+  result: SandboxEvalResult;
+}
+
+// If launched without an IPC channel there's nothing to do.
+if (!process.send) {
+  process.exit(0);
+}
+
+// Exit if the parent goes away, so we never become an orphan.
+process.on("disconnect", () => process.exit(0));
+
+process.on("message", async (job: WorkerJob) => {
+  let result: SandboxEvalResult;
+  try {
+    result = await sandboxEval(job.code, job.args, job.opts);
+  } catch (e) {
+    result = {
+      ok: false,
+      error: `Custom hook: ${e instanceof Error ? e.message : String(e)}`,
+      warnings: [],
+    };
+  }
+  const response: WorkerResponse = { id: job.id, result };
+  try {
+    process.send?.(response);
+  } catch {
+    // Parent is gone; nothing we can do.
+  }
+});

--- a/packages/back-end/src/enterprise/sandbox/sandbox-worker.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-worker.ts
@@ -1,17 +1,10 @@
+// eslint-disable-next-line no-restricted-imports
+import "../../init/aliases";
 import {
   sandboxEval,
   SandboxEvalOptions,
   SandboxEvalResult,
 } from "./sandbox-core";
-
-// Forked child process that runs custom hook code in an isolated-vm sandbox,
-// one job at a time, communicating with the parent over IPC. Running in a
-// separate OS process means a hard crash (OOM abort, native fault) or a hung
-// run kills only this worker — the parent (SandboxPool) detects the exit and
-// fails just that job, keeping the API server alive.
-//
-// This file imports only sandbox-core (which is intentionally light), so each
-// worker boots without the full back-end module graph.
 
 interface WorkerJob {
   id: number;

--- a/packages/back-end/src/models/CustomHookModel.ts
+++ b/packages/back-end/src/models/CustomHookModel.ts
@@ -25,10 +25,6 @@ const BaseClass = MakeModelClass({
 });
 
 export class CustomHookModel extends BaseClass {
-  private allowPerFeatureHooks(): boolean {
-    return !!this.context.org.settings?.allowPerFeatureCustomHooks;
-  }
-
   // For a feature-scoped hook, resolve the referenced feature synchronously
   // (BaseModel populates foreign refs before the permission hooks run).
   private featureRef(doc: CustomHookInterface): FeatureInterface | null {
@@ -39,10 +35,7 @@ export class CustomHookModel extends BaseClass {
   protected canCreate(doc: CustomHookInterface): boolean {
     const feature = this.featureRef(doc);
     return feature
-      ? this.context.permissions.canManageFeatureCustomHooks(
-          feature,
-          this.allowPerFeatureHooks(),
-        )
+      ? this.context.permissions.canManageFeatureCustomHooks(feature)
       : this.context.permissions.canCreateCustomHook(doc);
   }
   protected canRead(doc: CustomHookInterface): boolean {
@@ -59,19 +52,13 @@ export class CustomHookModel extends BaseClass {
     // entityType/entityId are readonly, so the scope can't change on update.
     const feature = this.featureRef(newDoc);
     return feature
-      ? this.context.permissions.canManageFeatureCustomHooks(
-          feature,
-          this.allowPerFeatureHooks(),
-        )
+      ? this.context.permissions.canManageFeatureCustomHooks(feature)
       : this.context.permissions.canUpdateCustomHook(existing, newDoc);
   }
   protected canDelete(doc: CustomHookInterface): boolean {
     const feature = this.featureRef(doc);
     return feature
-      ? this.context.permissions.canManageFeatureCustomHooks(
-          feature,
-          this.allowPerFeatureHooks(),
-        )
+      ? this.context.permissions.canManageFeatureCustomHooks(feature)
       : this.context.permissions.canDeleteCustomHook(doc);
   }
 

--- a/packages/back-end/src/models/CustomHookModel.ts
+++ b/packages/back-end/src/models/CustomHookModel.ts
@@ -2,8 +2,10 @@ import {
   CustomHookInterface,
   CustomHookType,
   customHookValidator,
+  hookEntityType,
 } from "shared/validators";
 import { UpdateProps } from "shared/types/base-model";
+import { FeatureInterface } from "shared/types/feature";
 import { MakeModelClass } from "./BaseModel";
 
 const BaseClass = MakeModelClass({
@@ -17,33 +19,85 @@ const BaseClass = MakeModelClass({
     deleteEvent: "customHook.delete",
   },
   globallyUniquePrimaryKeys: false,
+  // Scope is locked at creation. Retargeting a hook is not allowed — duplicate
+  // instead. This also keeps the permission checks below unambiguous.
+  readonlyFields: ["entityType", "entityId"],
 });
 
 export class CustomHookModel extends BaseClass {
+  private allowPerFeatureHooks(): boolean {
+    return !!this.context.org.settings?.allowPerFeatureCustomHooks;
+  }
+
+  // For a feature-scoped hook, resolve the referenced feature synchronously
+  // (BaseModel populates foreign refs before the permission hooks run).
+  private featureRef(doc: CustomHookInterface): FeatureInterface | null {
+    if (doc.entityType !== "feature" || !doc.entityId) return null;
+    return this.getForeignRefs(doc, false).feature ?? null;
+  }
+
   protected canCreate(doc: CustomHookInterface): boolean {
-    return this.context.permissions.canCreateCustomHook(doc);
+    const feature = this.featureRef(doc);
+    return feature
+      ? this.context.permissions.canManageFeatureCustomHooks(
+          feature,
+          this.allowPerFeatureHooks(),
+        )
+      : this.context.permissions.canCreateCustomHook(doc);
   }
   protected canRead(doc: CustomHookInterface): boolean {
-    return this.context.permissions.canReadMultiProjectResource(doc.projects);
+    const feature = this.featureRef(doc);
+    return feature
+      ? this.context.permissions.canReadSingleProjectResource(feature.project)
+      : this.context.permissions.canReadMultiProjectResource(doc.projects);
   }
   protected canUpdate(
     existing: CustomHookInterface,
     _updates: UpdateProps<CustomHookInterface>,
     newDoc: CustomHookInterface,
   ): boolean {
-    return this.context.permissions.canUpdateCustomHook(existing, newDoc);
+    // entityType/entityId are readonly, so the scope can't change on update.
+    const feature = this.featureRef(newDoc);
+    return feature
+      ? this.context.permissions.canManageFeatureCustomHooks(
+          feature,
+          this.allowPerFeatureHooks(),
+        )
+      : this.context.permissions.canUpdateCustomHook(existing, newDoc);
   }
   protected canDelete(doc: CustomHookInterface): boolean {
-    return this.context.permissions.canDeleteCustomHook(doc);
+    const feature = this.featureRef(doc);
+    return feature
+      ? this.context.permissions.canManageFeatureCustomHooks(
+          feature,
+          this.allowPerFeatureHooks(),
+        )
+      : this.context.permissions.canDeleteCustomHook(doc);
   }
 
-  public async getByHook(hook: CustomHookType, project: string = "") {
+  // Ensure a hook's entityType matches the resource its hook type operates on
+  // (e.g. a validateFeature hook can only be scoped to a feature).
+  protected async customValidation(doc: CustomHookInterface) {
+    if (doc.entityType && doc.entityType !== hookEntityType[doc.hook]) {
+      throw new Error(
+        `A ${doc.hook} hook cannot be scoped to a ${doc.entityType}`,
+      );
+    }
+  }
+
+  public async getByHook(
+    hook: CustomHookType,
+    project: string = "",
+    featureId: string = "",
+  ) {
     const hooks = await this._find({ hook, enabled: true });
 
-    // Filter by project
-    // Empty projects array = all projects
-    return hooks.filter(
-      (h) => !h.projects.length || h.projects.includes(project),
+    // Feature-scoped hooks (entityType/entityId set) only run for their target
+    // feature. Otherwise filter by project (empty projects array = all).
+    return hooks.filter((h) =>
+      h.entityType === "feature" && h.entityId
+        ? h.entityId === featureId
+        : !h.projects.length || h.projects.includes(project),
     );
   }
 

--- a/packages/back-end/src/models/CustomHookModel.ts
+++ b/packages/back-end/src/models/CustomHookModel.ts
@@ -19,14 +19,12 @@ const BaseClass = MakeModelClass({
     deleteEvent: "customHook.delete",
   },
   globallyUniquePrimaryKeys: false,
-  // Scope is locked at creation. Retargeting a hook is not allowed — duplicate
-  // instead. This also keeps the permission checks below unambiguous.
+  // Scope is locked at creation — retarget by duplicating instead.
   readonlyFields: ["entityType", "entityId"],
 });
 
 export class CustomHookModel extends BaseClass {
-  // For a feature-scoped hook, resolve the referenced feature synchronously
-  // (BaseModel populates foreign refs before the permission hooks run).
+  // Resolve the referenced feature synchronously (foreign refs are populated first).
   private featureRef(doc: CustomHookInterface): FeatureInterface | null {
     if (doc.entityType !== "feature" || !doc.entityId) return null;
     return this.getForeignRefs(doc, false).feature ?? null;
@@ -91,8 +89,7 @@ export class CustomHookModel extends BaseClass {
   ) {
     const hooks = await this._find({ hook, enabled: true });
 
-    // Feature-scoped hooks (entityType/entityId set) only run for their target
-    // feature. Otherwise filter by project (empty projects array = all).
+    // Feature-scoped hooks match by entityId; others match by project (empty = all).
     return hooks.filter((h) =>
       h.entityType === "feature" && h.entityId
         ? h.entityId === featureId

--- a/packages/back-end/src/models/CustomHookModel.ts
+++ b/packages/back-end/src/models/CustomHookModel.ts
@@ -62,13 +62,25 @@ export class CustomHookModel extends BaseClass {
       : this.context.permissions.canDeleteCustomHook(doc);
   }
 
-  // Ensure a hook's entityType matches the resource its hook type operates on
-  // (e.g. a validateFeature hook can only be scoped to a feature).
+  // Ensure scoped hooks are well-formed and point at a real resource.
   protected async customValidation(doc: CustomHookInterface) {
-    if (doc.entityType && doc.entityType !== hookEntityType[doc.hook]) {
+    const entityType = doc.entityType ?? null;
+    const entityId = doc.entityId ?? null;
+
+    if ((entityType === null) !== (entityId === null)) {
+      throw new Error(
+        "Custom hooks must specify both entityType and entityId, or neither",
+      );
+    }
+
+    if (entityType !== null && entityType !== hookEntityType[doc.hook]) {
       throw new Error(
         `A ${doc.hook} hook cannot be scoped to a ${doc.entityType}`,
       );
+    }
+
+    if (entityType === "feature" && this.featureRef(doc) === null) {
+      throw new Error(`Could not find feature for custom hook: ${entityId}`);
     }
   }
 

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -97,7 +97,10 @@ import {
   deleteVercelExperimentationItemFromFeature,
 } from "back-end/src/services/vercel-native-integration.service";
 import { getObjectDiff } from "back-end/src/events/handlers/webhooks/event-webhooks-utils";
-import { runValidateFeatureHooks } from "back-end/src/enterprise/sandbox/sandbox-eval";
+import {
+  runValidateFeatureHooks,
+  runValidateFeatureRevisionHooks,
+} from "back-end/src/enterprise/sandbox/sandbox-eval";
 import {
   createEvent,
   hasPreviousObject,
@@ -118,6 +121,7 @@ import {
   deleteAllRevisionsForFeature,
   getRevision,
   markRevisionAsPublished,
+  computeRevisionPublishChanges,
   updateRevision,
   createRevision,
 } from "./FeatureRevisionModel";
@@ -1463,13 +1467,19 @@ const updateSafeRolloutStatuses = async (
   });
 };
 
-// Apply a revision merge result to the feature document.
-export async function applyRevisionChanges(
+// Pure computation of the feature-doc changes a revision merge will produce.
+// Shared by applyRevisionChanges() (the write path) and publishRevision()'s
+// hook prevalidation so both see the identical proposed state. No writes.
+export function computeRevisionMergeChanges(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
   revision: FeatureRevisionInterface,
   result: MergeResultChanges,
-) {
+): {
+  changes: Partial<FeatureInterface>;
+  hasChanges: boolean;
+  removeHoldout: boolean;
+} {
   let hasChanges = false;
   const changes: Partial<FeatureInterface> = {};
   let removeHoldout = false;
@@ -1545,8 +1555,7 @@ export async function applyRevisionChanges(
   // revision behind a stale feature.version, which traps subsequent reverts.
   if (!hasChanges) {
     changes.version = revision.version;
-    changes.dateUpdated = new Date();
-    return await updateFeature(context, feature, changes);
+    return { changes, hasChanges, removeHoldout };
   }
 
   if (changes.rules !== undefined) {
@@ -1554,6 +1563,27 @@ export async function applyRevisionChanges(
   }
 
   changes.version = revision.version;
+
+  return { changes, hasChanges, removeHoldout };
+}
+
+// Apply a revision merge result to the feature document.
+export async function applyRevisionChanges(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  revision: FeatureRevisionInterface,
+  result: MergeResultChanges,
+) {
+  const { changes, hasChanges, removeHoldout } = computeRevisionMergeChanges(
+    context,
+    feature,
+    revision,
+    result,
+  );
+
+  if (!hasChanges) {
+    return await updateFeature(context, feature, changes);
+  }
 
   await updateSafeRolloutStatuses(context, feature, revision);
 
@@ -2184,6 +2214,56 @@ async function cleanupOrphanedRampSchedules(
   }
 }
 
+// Best-effort early run of both custom hook types against the proposed
+// post-publish state. publishRevision() calls this before any side-effect
+// writes; publish pre-flight loops (e.g. multi-feature experiment starts)
+// call it directly so a hook rejection fails the batch before anything
+// publishes. The authoritative hook runs still happen inside
+// updateFeature / markRevisionAsPublished.
+export async function prevalidatePublishRevision({
+  context,
+  feature,
+  revision,
+  result,
+  comment,
+}: {
+  context: ReqContext | ApiReqContext;
+  feature: FeatureInterface;
+  revision: FeatureRevisionInterface;
+  result: MergeResultChanges;
+  comment?: string;
+}) {
+  const { changes, removeHoldout } = computeRevisionMergeChanges(
+    context,
+    feature,
+    revision,
+    result,
+  );
+  const base = removeHoldout
+    ? (omit(feature, ["holdout"]) as FeatureInterface)
+    : feature;
+  const proposedFeature: FeatureInterface = {
+    ...base,
+    ...changes,
+    dateUpdated: new Date(),
+  };
+  proposedFeature.linkedExperiments = getLinkedExperiments(proposedFeature);
+  await runValidateFeatureHooks({
+    context,
+    feature: proposedFeature,
+    original: feature,
+  });
+  await runValidateFeatureRevisionHooks({
+    context,
+    feature,
+    revision: {
+      ...revision,
+      ...computeRevisionPublishChanges(revision, context.auditUser, comment),
+    },
+    original: revision,
+  });
+}
+
 export async function publishRevision({
   context,
   feature,
@@ -2206,6 +2286,22 @@ export async function publishRevision({
   if (!bypassLockdown) {
     await assertFeatureNotLockedByRamp(context, feature.id);
   }
+
+  // Prevalidate BOTH custom hook types against the proposed post-publish
+  // state BEFORE any side-effect writes (ramp schedule docs below, safe
+  // rollout status syncs inside applyRevisionChanges). The authoritative
+  // hook runs still happen inside updateFeature / markRevisionAsPublished;
+  // this early pass keeps a hook rejection from orphaning those writes and
+  // ensures the revision hook is checked before the feature doc goes live.
+  // A concurrent mutation or non-deterministic hook can still fail at save
+  // time — the rollback below remains as second-line defense for that.
+  await prevalidatePublishRevision({
+    context,
+    feature,
+    revision,
+    result,
+    comment,
+  });
 
   // Create ramp schedules BEFORE writing the feature so that a schedule
   // creation failure gates the publish (atomicity: no published feature without
@@ -2257,6 +2353,9 @@ export async function publishRevision({
     );
   } catch (err) {
     // Roll back pre-created ramp schedules so they don't linger as orphans.
+    // Second-line defense: hook rejections are normally caught by the
+    // prevalidation above, so this mostly covers infra failures and the
+    // concurrent-mutation race.
     for (const id of preCreatedScheduleIds) {
       try {
         await context.models.rampSchedules.deleteById(id);

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -1467,9 +1467,7 @@ const updateSafeRolloutStatuses = async (
   });
 };
 
-// Pure computation of the feature-doc changes a revision merge will produce.
-// Shared by applyRevisionChanges() (the write path) and publishRevision()'s
-// hook prevalidation so both see the identical proposed state. No writes.
+// Pure computation of the feature-doc changes a revision merge will produce; no writes
 export function computeRevisionMergeChanges(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
@@ -2214,12 +2212,7 @@ async function cleanupOrphanedRampSchedules(
   }
 }
 
-// Best-effort early run of both custom hook types against the proposed
-// post-publish state. publishRevision() calls this before any side-effect
-// writes; publish pre-flight loops (e.g. multi-feature experiment starts)
-// call it directly so a hook rejection fails the batch before anything
-// publishes. The authoritative hook runs still happen inside
-// updateFeature / markRevisionAsPublished.
+// Best-effort early hook run; updateFeature / markRevisionAsPublished re-run hooks authoritatively
 export async function prevalidatePublishRevision({
   context,
   feature,
@@ -2287,14 +2280,7 @@ export async function publishRevision({
     await assertFeatureNotLockedByRamp(context, feature.id);
   }
 
-  // Prevalidate BOTH custom hook types against the proposed post-publish
-  // state BEFORE any side-effect writes (ramp schedule docs below, safe
-  // rollout status syncs inside applyRevisionChanges). The authoritative
-  // hook runs still happen inside updateFeature / markRevisionAsPublished;
-  // this early pass keeps a hook rejection from orphaning those writes and
-  // ensures the revision hook is checked before the feature doc goes live.
-  // A concurrent mutation or non-deterministic hook can still fail at save
-  // time — the rollback below remains as second-line defense for that.
+  // Run custom hooks before the side-effect writes below so a rejection doesn't orphan them
   await prevalidatePublishRevision({
     context,
     feature,
@@ -2353,9 +2339,6 @@ export async function publishRevision({
     );
   } catch (err) {
     // Roll back pre-created ramp schedules so they don't linger as orphans.
-    // Second-line defense: hook rejections are normally caught by the
-    // prevalidation above, so this mostly covers infra failures and the
-    // concurrent-mutation race.
     for (const id of preCreatedScheduleIds) {
       try {
         await context.models.rampSchedules.deleteById(id);

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -937,10 +937,7 @@ export async function createRevision({
   return toInterface(doc, context, feature);
 }
 
-// Pure computation of what updateRevision() will validate and persist for the
-// given inputs: the draft-status guard, review-status transitions, and rules
-// normalization. updateRevision() consumes this directly, so the prevalidated
-// state and the saved state stay identical by construction.
+// Pure computation of what updateRevision() will validate and persist; no writes
 export function computeRevisionUpdate(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
@@ -1007,11 +1004,7 @@ export function computeRevisionUpdate(
   };
 }
 
-// Best-effort early run of the validateFeatureRevision hooks against the exact
-// state updateRevision() will validate. Call this from controllers/services
-// BEFORE any side-effect writes to other collections (e.g. safe rollout docs,
-// holdout linkage) so a hook rejection doesn't orphan them. The authoritative
-// hook run still happens inside updateRevision().
+// Best-effort early hook run before side-effect writes; updateRevision() re-runs hooks authoritatively
 export async function prevalidateRevisionUpdate(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
@@ -1122,9 +1115,7 @@ export async function updateRevision(
   return updatedRevision;
 }
 
-// Pure computation of the changes markRevisionAsPublished() will validate and
-// persist. Also used by publishRevision() to prevalidate the revision hook
-// before any side-effect writes.
+// Pure computation of the changes markRevisionAsPublished() will validate and persist
 export function computeRevisionPublishChanges(
   revision: FeatureRevisionInterface,
   user: EventUser,

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -937,14 +937,21 @@ export async function createRevision({
   return toInterface(doc, context, feature);
 }
 
-export async function updateRevision(
+// Pure computation of what updateRevision() will validate and persist for the
+// given inputs: the draft-status guard, review-status transitions, and rules
+// normalization. updateRevision() consumes this directly, so the prevalidated
+// state and the saved state stay identical by construction.
+export function computeRevisionUpdate(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
   revision: FeatureRevisionInterface,
   changes: RevisionChanges,
-  log: Omit<RevisionLog, "timestamp">,
   resetReview: boolean,
-) {
+): {
+  normalizedChanges: RevisionChanges;
+  status: FeatureRevisionInterface["status"];
+  proposedRevision: FeatureRevisionInterface;
+} {
   let status = revision.status;
 
   const MUTABLE_FIELDS = [
@@ -993,14 +1000,60 @@ export async function updateRevision(
         }
       : changes;
 
+  return {
+    normalizedChanges,
+    status,
+    proposedRevision: { ...revision, ...normalizedChanges, status },
+  };
+}
+
+// Best-effort early run of the validateFeatureRevision hooks against the exact
+// state updateRevision() will validate. Call this from controllers/services
+// BEFORE any side-effect writes to other collections (e.g. safe rollout docs,
+// holdout linkage) so a hook rejection doesn't orphan them. The authoritative
+// hook run still happens inside updateRevision().
+export async function prevalidateRevisionUpdate(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  revision: FeatureRevisionInterface,
+  changes: RevisionChanges,
+  resetReview: boolean,
+): Promise<void> {
+  const { proposedRevision } = computeRevisionUpdate(
+    context,
+    feature,
+    revision,
+    changes,
+    resetReview,
+  );
   await runValidateFeatureRevisionHooks({
     context,
     feature,
-    revision: {
-      ...revision,
-      ...normalizedChanges,
-      status,
-    },
+    revision: proposedRevision,
+    original: revision,
+  });
+}
+
+export async function updateRevision(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  revision: FeatureRevisionInterface,
+  changes: RevisionChanges,
+  log: Omit<RevisionLog, "timestamp">,
+  resetReview: boolean,
+) {
+  const { normalizedChanges, status, proposedRevision } = computeRevisionUpdate(
+    context,
+    feature,
+    revision,
+    changes,
+    resetReview,
+  );
+
+  await runValidateFeatureRevisionHooks({
+    context,
+    feature,
+    revision: proposedRevision,
     original: revision,
   });
 
@@ -1069,6 +1122,23 @@ export async function updateRevision(
   return updatedRevision;
 }
 
+// Pure computation of the changes markRevisionAsPublished() will validate and
+// persist. Also used by publishRevision() to prevalidate the revision hook
+// before any side-effect writes.
+export function computeRevisionPublishChanges(
+  revision: FeatureRevisionInterface,
+  user: EventUser,
+  comment?: string,
+): Partial<FeatureRevisionInterface> {
+  return {
+    status: "published",
+    publishedBy: user,
+    datePublished: new Date(),
+    dateUpdated: new Date(),
+    comment: revision.comment ? revision.comment : comment,
+  };
+}
+
 export async function markRevisionAsPublished(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
@@ -1078,15 +1148,7 @@ export async function markRevisionAsPublished(
 ) {
   const action = revision.status === "draft" ? "publish" : "re-publish";
 
-  const revisionComment = revision.comment ? revision.comment : comment;
-
-  const changes: Partial<FeatureRevisionInterface> = {
-    status: "published",
-    publishedBy: user,
-    datePublished: new Date(),
-    dateUpdated: new Date(),
-    comment: revisionComment,
-  };
+  const changes = computeRevisionPublishChanges(revision, user, comment);
 
   await runValidateFeatureRevisionHooks({
     context,

--- a/packages/back-end/src/routers/custom-hooks/custom-hooks.controller.ts
+++ b/packages/back-end/src/routers/custom-hooks/custom-hooks.controller.ts
@@ -1,10 +1,11 @@
 import type { Response } from "express";
 import { CreateProps, UpdateProps } from "shared/types/base-model";
-import { CustomHookInterface } from "shared/validators";
+import { CustomHookEntityType, CustomHookInterface } from "shared/validators";
 import { AuthRequest } from "back-end/src/types/AuthRequest";
 import { getContextFromReq } from "back-end/src/services/organizations";
 import { IS_CLOUD } from "back-end/src/util/secrets";
 import { sandboxEval } from "back-end/src/enterprise/sandbox/sandbox-eval";
+import { getFeature } from "back-end/src/models/FeatureModel";
 
 export const getCustomHooks = async (
   req: AuthRequest,
@@ -46,7 +47,14 @@ export const createCustomHook = async (
     throw new Error("Not allowed");
   }
 
-  const customHook = await context.models.customHooks.create(req.body);
+  const data = { ...req.body };
+  // Feature-scoped hooks derive their scope from the referenced feature, so
+  // `projects` is unused — keep it empty regardless of what the client sent.
+  if (data.entityType && data.entityId) {
+    data.projects = [];
+  }
+
+  const customHook = await context.models.customHooks.create(data);
 
   res.status(200).json({
     status: 200,
@@ -101,7 +109,12 @@ export const deleteCustomHook = async (
 
 export const testCustomHook = async (
   req: AuthRequest<
-    { functionBody: string; functionArgs: Record<string, unknown> },
+    {
+      functionBody: string;
+      functionArgs: Record<string, unknown>;
+      entityType?: CustomHookEntityType;
+      entityId?: string;
+    },
     null
   >,
   res: Response<{
@@ -120,7 +133,21 @@ export const testCustomHook = async (
   if (IS_CLOUD || !context.hasPremiumFeature("custom-hooks")) {
     throw new Error("Not allowed");
   }
-  if (!context.permissions.canCreateCustomHook({ projects: [] })) {
+
+  const { entityType, entityId } = req.body;
+  if (entityType === "feature" && entityId) {
+    // Feature-scoped test: authorize against the target feature
+    const feature = await getFeature(context, entityId);
+    if (
+      !feature ||
+      !context.permissions.canManageFeatureCustomHooks(
+        feature,
+        !!context.org.settings?.allowPerFeatureCustomHooks,
+      )
+    ) {
+      context.permissions.throwPermissionError();
+    }
+  } else if (!context.permissions.canCreateCustomHook({ projects: [] })) {
     context.permissions.throwPermissionError();
   }
 

--- a/packages/back-end/src/routers/custom-hooks/custom-hooks.controller.ts
+++ b/packages/back-end/src/routers/custom-hooks/custom-hooks.controller.ts
@@ -4,7 +4,7 @@ import { CustomHookEntityType, CustomHookInterface } from "shared/validators";
 import { AuthRequest } from "back-end/src/types/AuthRequest";
 import { getContextFromReq } from "back-end/src/services/organizations";
 import { IS_CLOUD } from "back-end/src/util/secrets";
-import { sandboxEval } from "back-end/src/enterprise/sandbox/sandbox-eval";
+import { runInSandbox } from "back-end/src/enterprise/sandbox/sandbox-pool";
 import { getFeature } from "back-end/src/models/FeatureModel";
 
 export const getCustomHooks = async (
@@ -138,20 +138,14 @@ export const testCustomHook = async (
   if (entityType === "feature" && entityId) {
     // Feature-scoped test: authorize against the target feature
     const feature = await getFeature(context, entityId);
-    if (
-      !feature ||
-      !context.permissions.canManageFeatureCustomHooks(
-        feature,
-        !!context.org.settings?.allowPerFeatureCustomHooks,
-      )
-    ) {
+    if (!feature || !context.permissions.canManageFeatureCustomHooks(feature)) {
       context.permissions.throwPermissionError();
     }
   } else if (!context.permissions.canCreateCustomHook({ projects: [] })) {
     context.permissions.throwPermissionError();
   }
 
-  const result = await sandboxEval(
+  const result = await runInSandbox(
     req.body.functionBody,
     req.body.functionArgs,
   );

--- a/packages/back-end/src/routers/custom-hooks/custom-hooks.controller.ts
+++ b/packages/back-end/src/routers/custom-hooks/custom-hooks.controller.ts
@@ -48,8 +48,7 @@ export const createCustomHook = async (
   }
 
   const data = { ...req.body };
-  // Feature-scoped hooks derive their scope from the referenced feature, so
-  // `projects` is unused — keep it empty regardless of what the client sent.
+  // Feature-scoped hooks derive scope from the feature; keep projects empty.
   if (data.entityType && data.entityId) {
     data.projects = [];
   }

--- a/packages/back-end/src/services/context.ts
+++ b/packages/back-end/src/services/context.ts
@@ -312,8 +312,7 @@ export class ReqContextClass {
     this.initModels();
   }
 
-  // Whether soft warnings should be ignored for this request
-  // Background jobs have no req and always ignore - users have no way to respond to the feedback.
+  // True to skip soft warnings; background jobs (no req) always ignore.
   public get ignoreWarnings(): boolean {
     if (!this.req) return true;
     const v = this.req.query?.ignoreWarnings;

--- a/packages/back-end/src/services/experiment-feature.ts
+++ b/packages/back-end/src/services/experiment-feature.ts
@@ -24,6 +24,7 @@ import { applyPartialFeatureRuleUpdatesToRevision } from "back-end/src/util/feat
 import {
   editFeatureRules,
   getFeature,
+  prevalidatePublishRevision,
   publishRevision,
 } from "back-end/src/models/FeatureModel";
 import {
@@ -410,6 +411,48 @@ export async function publishPendingFeatureDraftsForExperiment(
 
   if (failed.length > 0) {
     return { published: [], failed };
+  }
+
+  // ── Phase 1.5: prevalidate custom hooks for every ready draft ────────────
+  // Run the validateFeature/validateFeatureRevision hooks against each
+  // draft's proposed post-publish state BEFORE publishing anything, so a
+  // hook rejection fails the whole batch up front instead of after some
+  // features already published. Throws (including SoftWarningError) rather
+  // than returning a failure so the caller's 422/ignoreWarnings handling
+  // applies. Best-effort: state can still shift between this check and the
+  // sequential publishes below — publishRevision re-checks authoritatively.
+  for (const { featureId, revisionVersion } of ready) {
+    const feature = await getFeature(context, featureId);
+    if (!feature) continue;
+    const revision = await getRevision({
+      context,
+      organization: feature.organization,
+      featureId: feature.id,
+      feature,
+      version: revisionVersion,
+    });
+    if (
+      !revision ||
+      revision.status === "published" ||
+      revision.status === "discarded"
+    ) {
+      continue;
+    }
+    const { live, base } = await getLiveAndBaseRevisionsForFeature({
+      context,
+      feature,
+      revision,
+    });
+    const mergeResult = autoMerge(live, base, revision, orgEnvIds, {});
+    // Merge conflicts and no-op drafts are handled by phase 2.
+    if (!mergeResult.success || !mergeResultHasChanges(mergeResult)) continue;
+    await prevalidatePublishRevision({
+      context,
+      feature,
+      revision,
+      result: mergeResult.result,
+      comment: `Experiment "${experiment.name}" started`,
+    });
   }
 
   // ── Phase 2: sequential publish, re-merging each against fresh live ──────

--- a/packages/back-end/src/services/experiment-feature.ts
+++ b/packages/back-end/src/services/experiment-feature.ts
@@ -414,13 +414,7 @@ export async function publishPendingFeatureDraftsForExperiment(
   }
 
   // ── Phase 1.5: prevalidate custom hooks for every ready draft ────────────
-  // Run the validateFeature/validateFeatureRevision hooks against each
-  // draft's proposed post-publish state BEFORE publishing anything, so a
-  // hook rejection fails the whole batch up front instead of after some
-  // features already published. Throws (including SoftWarningError) rather
-  // than returning a failure so the caller's 422/ignoreWarnings handling
-  // applies. Best-effort: state can still shift between this check and the
-  // sequential publishes below — publishRevision re-checks authoritatively.
+  // A hook rejection fails the whole batch before anything publishes.
   for (const { featureId, revisionVersion } of ready) {
     const feature = await getFeature(context, featureId);
     if (!feature) continue;

--- a/packages/back-end/src/services/experiment-feature.ts
+++ b/packages/back-end/src/services/experiment-feature.ts
@@ -1,6 +1,7 @@
 import isEqual from "lodash/isEqual";
 import {
   autoMerge,
+  AutoMergeResult,
   getMatchingRules,
   MatchingRule,
   mergeResultHasChanges,
@@ -333,11 +334,19 @@ export function formatPendingDraftFailureMessage(
 
 type ResolvedDraft = { featureId: string; revisionVersion: number };
 
-// Auto-publishes pendingFeatureDrafts on experiment start. Phase 1 prunes
-// stale entries and gates on approval; Phase 2 publishes sequentially,
-// re-merging each draft against fresh live state since earlier publishes
-// may have advanced feature.version. Halts on the first merge conflict or
-// publish error so the caller can abort the experiment transition.
+type ReadyDraft = ResolvedDraft & {
+  feature: FeatureInterface;
+  revision: FeatureRevisionInterface;
+  mergeResult: AutoMergeResult;
+};
+
+// Auto-publishes pendingFeatureDrafts on experiment start. Phase 1 resolves
+// each draft once (prune stale, gate on approval, merge against live);
+// Phase 1.5 prevalidates custom hooks; Phase 2 publishes sequentially,
+// reusing the resolved state except when an earlier publish in this run
+// advanced the same feature's live version, which forces a re-merge.
+// Halts on the first merge conflict or publish error so the caller can
+// abort the experiment transition.
 export async function publishPendingFeatureDraftsForExperiment(
   context: ReqContext | ApiReqContext,
   experiment: ExperimentInterface,
@@ -348,11 +357,19 @@ export async function publishPendingFeatureDraftsForExperiment(
 
   const orgEnvIds = context.environments;
   const failed: PendingDraftFailure[] = [];
-  const ready: ResolvedDraft[] = [];
+  const ready: ReadyDraft[] = [];
+  // Multiple drafts can target the same feature — fetch each feature once.
+  const featureCache = new Map<string, FeatureInterface | null>();
+  const getCachedFeature = async (featureId: string) => {
+    if (!featureCache.has(featureId)) {
+      featureCache.set(featureId, await getFeature(context, featureId));
+    }
+    return featureCache.get(featureId) ?? null;
+  };
 
-  // ── Phase 1: prune stale + gate on approval ──────────────────────────────
+  // ── Phase 1: prune stale + gate on approval + merge against live ─────────
   for (const { featureId, revisionVersion } of drafts) {
-    const feature = await getFeature(context, featureId);
+    const feature = await getCachedFeature(featureId);
     if (!feature) {
       await removePendingFeatureDraftFromExperiment(
         context,
@@ -384,7 +401,7 @@ export async function publishPendingFeatureDraftsForExperiment(
       continue;
     }
 
-    const { base } = await getLiveAndBaseRevisionsForFeature({
+    const { live, base } = await getLiveAndBaseRevisionsForFeature({
       context,
       feature,
       revision,
@@ -406,7 +423,8 @@ export async function publishPendingFeatureDraftsForExperiment(
       continue;
     }
 
-    ready.push({ featureId, revisionVersion });
+    const mergeResult = autoMerge(live, base, revision, orgEnvIds, {});
+    ready.push({ featureId, revisionVersion, feature, revision, mergeResult });
   }
 
   if (failed.length > 0) {
@@ -415,29 +433,7 @@ export async function publishPendingFeatureDraftsForExperiment(
 
   // ── Phase 1.5: prevalidate custom hooks for every ready draft ────────────
   // A hook rejection fails the whole batch before anything publishes.
-  for (const { featureId, revisionVersion } of ready) {
-    const feature = await getFeature(context, featureId);
-    if (!feature) continue;
-    const revision = await getRevision({
-      context,
-      organization: feature.organization,
-      featureId: feature.id,
-      feature,
-      version: revisionVersion,
-    });
-    if (
-      !revision ||
-      revision.status === "published" ||
-      revision.status === "discarded"
-    ) {
-      continue;
-    }
-    const { live, base } = await getLiveAndBaseRevisionsForFeature({
-      context,
-      feature,
-      revision,
-    });
-    const mergeResult = autoMerge(live, base, revision, orgEnvIds, {});
+  for (const { feature, revision, mergeResult } of ready) {
     // Merge conflicts and no-op drafts are handled by phase 2.
     if (!mergeResult.success || !mergeResultHasChanges(mergeResult)) continue;
     await prevalidatePublishRevision({
@@ -449,7 +445,7 @@ export async function publishPendingFeatureDraftsForExperiment(
     });
   }
 
-  // ── Phase 2: sequential publish, re-merging each against fresh live ──────
+  // ── Phase 2: sequential publish ───────────────────────────────────────────
   // Ascending version per feature so each merge builds on the previous publish.
   ready.sort(
     (a, b) =>
@@ -458,31 +454,41 @@ export async function publishPendingFeatureDraftsForExperiment(
   );
 
   const published: ResolvedDraft[] = [];
+  // Features whose live version we advanced during this loop — later drafts
+  // of these features must re-merge against the fresh live state.
+  const publishedFeatureIds = new Set<string>();
 
-  for (const { featureId, revisionVersion } of ready) {
-    const feature = await getFeature(context, featureId);
-    if (!feature) continue;
-    const revision = await getRevision({
-      context,
-      organization: feature.organization,
-      featureId: feature.id,
-      feature,
-      version: revisionVersion,
-    });
-    if (
-      !revision ||
-      revision.status === "published" ||
-      revision.status === "discarded"
-    ) {
-      continue;
+  for (const entry of ready) {
+    const { featureId, revisionVersion } = entry;
+    let { feature, revision, mergeResult } = entry;
+
+    if (publishedFeatureIds.has(featureId)) {
+      const freshFeature = await getFeature(context, featureId);
+      if (!freshFeature) continue;
+      feature = freshFeature;
+      const freshRevision = await getRevision({
+        context,
+        organization: feature.organization,
+        featureId: feature.id,
+        feature,
+        version: revisionVersion,
+      });
+      if (
+        !freshRevision ||
+        freshRevision.status === "published" ||
+        freshRevision.status === "discarded"
+      ) {
+        continue;
+      }
+      revision = freshRevision;
+      const { live, base } = await getLiveAndBaseRevisionsForFeature({
+        context,
+        feature,
+        revision,
+      });
+      mergeResult = autoMerge(live, base, revision, orgEnvIds, {});
     }
 
-    const { live, base } = await getLiveAndBaseRevisionsForFeature({
-      context,
-      feature,
-      revision,
-    });
-    const mergeResult = autoMerge(live, base, revision, orgEnvIds, {});
     if (!mergeResult.success) {
       logger.warn(
         {
@@ -531,6 +537,7 @@ export async function publishPendingFeatureDraftsForExperiment(
         revisionVersion,
       );
       published.push({ featureId, revisionVersion });
+      publishedFeatureIds.add(featureId);
     } catch (err) {
       logger.error(
         { err, experimentId: experiment.id, featureId, revisionVersion },

--- a/packages/back-end/src/util/feature-json-schema.ts
+++ b/packages/back-end/src/util/feature-json-schema.ts
@@ -61,7 +61,6 @@ export function parseApiJsonSchema(
       `Invalid JSON schema: ${e instanceof Error ? e.message : String(e)}`,
     );
   }
-  // Reject schemas that don't make sense for the feature's value type.
   if (valueType) {
     assertSchemaMatchesValueType(jsonSchemaWrapper, valueType);
   }

--- a/packages/back-end/src/util/feature-json-schema.ts
+++ b/packages/back-end/src/util/feature-json-schema.ts
@@ -1,5 +1,10 @@
-import { FeatureInterface, JSONSchemaDef } from "shared/types/feature";
+import {
+  FeatureInterface,
+  FeatureValueType,
+  JSONSchemaDef,
+} from "shared/types/feature";
 import { OrganizationInterface } from "shared/types/organization";
+import { assertSchemaMatchesValueType } from "shared/util";
 import { orgHasPremiumFeature } from "back-end/src/enterprise";
 import { logger } from "back-end/src/util/logger";
 
@@ -43,6 +48,7 @@ export function getInitialFeatureJsonSchema(
 export function parseApiJsonSchema(
   org: OrganizationInterface,
   jsonSchema: string | undefined,
+  valueType?: FeatureValueType,
 ): JSONSchemaDef {
   const jsonSchemaWrapper = getDefaultJsonSchema(new Date());
   if (!jsonSchema) return jsonSchemaWrapper;
@@ -50,9 +56,14 @@ export function parseApiJsonSchema(
   try {
     jsonSchemaWrapper.schema = JSON.stringify(JSON.parse(jsonSchema));
     jsonSchemaWrapper.enabled = true;
-    return jsonSchemaWrapper;
   } catch (e) {
     logger.error(e, "Failed to parse feature json schema");
     return jsonSchemaWrapper;
   }
+  // Reject schemas that don't make sense for the feature's value type
+  // (e.g. an object schema on a number flag). Throws on mismatch.
+  if (valueType) {
+    assertSchemaMatchesValueType(jsonSchemaWrapper, valueType);
+  }
+  return jsonSchemaWrapper;
 }

--- a/packages/back-end/src/util/feature-json-schema.ts
+++ b/packages/back-end/src/util/feature-json-schema.ts
@@ -61,8 +61,7 @@ export function parseApiJsonSchema(
       `Invalid JSON schema: ${e instanceof Error ? e.message : String(e)}`,
     );
   }
-  // Reject schemas that don't make sense for the feature's value type
-  // (e.g. an object schema on a number flag). Throws on mismatch.
+  // Reject schemas that don't make sense for the feature's value type.
   if (valueType) {
     assertSchemaMatchesValueType(jsonSchemaWrapper, valueType);
   }

--- a/packages/back-end/src/util/feature-json-schema.ts
+++ b/packages/back-end/src/util/feature-json-schema.ts
@@ -6,7 +6,7 @@ import {
 import { OrganizationInterface } from "shared/types/organization";
 import { assertSchemaMatchesValueType } from "shared/util";
 import { orgHasPremiumFeature } from "back-end/src/enterprise";
-import { logger } from "back-end/src/util/logger";
+import { BadRequestError } from "back-end/src/util/errors";
 
 function getDefaultJsonSchema(date: Date): JSONSchemaDef {
   return {
@@ -57,8 +57,9 @@ export function parseApiJsonSchema(
     jsonSchemaWrapper.schema = JSON.stringify(JSON.parse(jsonSchema));
     jsonSchemaWrapper.enabled = true;
   } catch (e) {
-    logger.error(e, "Failed to parse feature json schema");
-    return jsonSchemaWrapper;
+    throw new BadRequestError(
+      `Invalid JSON schema: ${e instanceof Error ? e.message : String(e)}`,
+    );
   }
   // Reject schemas that don't make sense for the feature's value type
   // (e.g. an object schema on a number flag). Throws on mismatch.

--- a/packages/back-end/test/api/features/ruleAddCustomHooks.test.ts
+++ b/packages/back-end/test/api/features/ruleAddCustomHooks.test.ts
@@ -11,21 +11,13 @@ import {
 import { getFeature } from "back-end/src/models/FeatureModel";
 import { setupApp } from "../api.setup";
 
-// ---------------------------------------------------------------------------
-// Regression tests for custom-hook prevalidation ordering: a hook rejection
-// (or unacknowledged soft warning) on the rule-add endpoint must NOT leave an
-// orphaned SafeRollout document behind. Before prevalidation existed, the
-// safeRollout doc was created before updateRevision fired the hooks, so a
-// rejection — or a 422 warning followed by a "Save anyway" retry — orphaned
-// (or duplicated) the doc.
-// ---------------------------------------------------------------------------
+// Regression tests: a custom-hook rejection on the rule-add endpoint must not orphan a SafeRollout doc
 
 jest.mock("back-end/src/enterprise/sandbox/sandbox-pool", () => ({
   runInSandbox: jest.fn(),
 }));
 
-// Safe-rollout field validation requires a real datasource + metrics; that
-// plumbing is irrelevant here, so return a canned valid shape.
+// Field validation needs a real datasource + metrics; return a canned valid shape instead
 jest.mock("back-end/src/validators/safe-rollout", () => ({
   validateCreateSafeRolloutFields: jest.fn(async () => ({
     datasourceId: "ds_1",
@@ -62,8 +54,7 @@ function makeContext(query: Record<string, string> = {}) {
     org: ORG,
     auditUser: { type: "api_key", apiKey: "key_test" },
     role: "admin",
-    // context.ignoreWarnings reads req.query; in production the context is
-    // built from the live request, so the URL query flows through naturally.
+    // context.ignoreWarnings reads req.query
     req: { query, headers: {} } as unknown as Request,
   });
 }
@@ -184,12 +175,12 @@ describe("rule-add custom hook prevalidation", () => {
     expect(response.status).toBe(400);
     expect(response.body.message).toContain("Rejected by hook");
 
-    // The headline assertion: no orphaned safeRollout doc.
+    // No orphaned safeRollout doc
     expect(
       await mongoose.connection.collection("saferollout").countDocuments(),
     ).toBe(0);
 
-    // And the revision is untouched.
+    // Revision untouched
     const revisionDoc = await mongoose.connection
       .collection("featurerevisions")
       .findOne({ featureId: FEATURE_ID, version: revision.version });
@@ -216,8 +207,7 @@ describe("rule-add custom hook prevalidation", () => {
       await mongoose.connection.collection("saferollout").countDocuments(),
     ).toBe(0);
 
-    // Retry with ?ignoreWarnings=true — pre-fix this produced a SECOND
-    // safeRollout doc (the first was orphaned by the 422); now it's exactly one.
+    // Pre-fix, the ignoreWarnings retry produced a second safeRollout doc; now exactly one
     setReqContext(makeContext({ ignoreWarnings: "true" }));
     const retried = await request(app)
       .post(
@@ -244,7 +234,7 @@ describe("rule-add custom hook prevalidation", () => {
       .send(SAFE_ROLLOUT_RULE_BODY);
 
     expect(response.status).toBe(200);
-    // One execution from prevalidateRevisionUpdate, one from updateRevision.
+    // One from prevalidateRevisionUpdate, one from updateRevision
     expect(mockRunInSandbox).toHaveBeenCalledTimes(2);
     expect(
       await mongoose.connection.collection("saferollout").countDocuments(),

--- a/packages/back-end/test/api/features/ruleAddCustomHooks.test.ts
+++ b/packages/back-end/test/api/features/ruleAddCustomHooks.test.ts
@@ -1,0 +1,259 @@
+import request from "supertest";
+import mongoose from "mongoose";
+import type { Request } from "express";
+import type { OrganizationInterface } from "shared/types/organization";
+import { ReqContextClass } from "back-end/src/services/context";
+import { runInSandbox } from "back-end/src/enterprise/sandbox/sandbox-pool";
+import {
+  createInitialRevision,
+  createRevision,
+} from "back-end/src/models/FeatureRevisionModel";
+import { getFeature } from "back-end/src/models/FeatureModel";
+import { setupApp } from "../api.setup";
+
+// ---------------------------------------------------------------------------
+// Regression tests for custom-hook prevalidation ordering: a hook rejection
+// (or unacknowledged soft warning) on the rule-add endpoint must NOT leave an
+// orphaned SafeRollout document behind. Before prevalidation existed, the
+// safeRollout doc was created before updateRevision fired the hooks, so a
+// rejection — or a 422 warning followed by a "Save anyway" retry — orphaned
+// (or duplicated) the doc.
+// ---------------------------------------------------------------------------
+
+jest.mock("back-end/src/enterprise/sandbox/sandbox-pool", () => ({
+  runInSandbox: jest.fn(),
+}));
+
+// Safe-rollout field validation requires a real datasource + metrics; that
+// plumbing is irrelevant here, so return a canned valid shape.
+jest.mock("back-end/src/validators/safe-rollout", () => ({
+  validateCreateSafeRolloutFields: jest.fn(async () => ({
+    datasourceId: "ds_1",
+    exposureQueryId: "q_1",
+    guardrailMetricIds: ["met_1"],
+    maxDuration: { amount: 3, unit: "days" },
+    autoRollback: false,
+  })),
+}));
+
+const mockRunInSandbox = runInSandbox as jest.MockedFunction<
+  typeof runInSandbox
+>;
+
+const ORG = {
+  id: "org_hooks_test",
+  name: "Hooks Test",
+  ownerEmail: "test@test.com",
+  url: "",
+  dateCreated: new Date(),
+  members: [],
+  settings: {
+    environments: [
+      { id: "production", description: "" },
+      { id: "dev", description: "" },
+    ],
+  },
+} as unknown as OrganizationInterface;
+
+const FEATURE_ID = "feat_hooks_test";
+
+function makeContext(query: Record<string, string> = {}) {
+  return new ReqContextClass({
+    org: ORG,
+    auditUser: { type: "api_key", apiKey: "key_test" },
+    role: "admin",
+    // context.ignoreWarnings reads req.query; in production the context is
+    // built from the live request, so the URL query flows through naturally.
+    req: { query, headers: {} } as unknown as Request,
+  });
+}
+
+async function seedFeature() {
+  await mongoose.connection.collection("features").insertOne({
+    id: FEATURE_ID,
+    organization: ORG.id,
+    version: 1,
+    defaultValue: "false",
+    valueType: "boolean",
+    owner: "",
+    description: "",
+    project: "",
+    tags: [],
+    dateCreated: new Date(),
+    dateUpdated: new Date(),
+    rules: [],
+    environmentSettings: {
+      production: { enabled: true },
+      dev: { enabled: false },
+    },
+    archived: false,
+  });
+}
+
+async function seedDraftRevision(context: ReqContextClass) {
+  const feature = await getFeature(context, FEATURE_ID);
+  if (!feature) throw new Error("seed feature missing");
+  // createRevision requires a published base revision for feature.version.
+  await createInitialRevision(context, feature, context.auditUser, [
+    "production",
+    "dev",
+  ]);
+  return createRevision({
+    context,
+    feature,
+    user: context.auditUser,
+    baseVersion: feature.version,
+    environments: ["production", "dev"],
+    publish: false,
+    changes: {},
+    org: ORG,
+    canBypassApprovalChecks: false,
+  });
+}
+
+async function seedRevisionHook() {
+  await mongoose.connection.collection("customhooks").insertOne({
+    id: "hook_test_1",
+    organization: ORG.id,
+    dateCreated: new Date(),
+    dateUpdated: new Date(),
+    enabled: true,
+    projects: [],
+    name: "test revision hook",
+    hook: "validateFeatureRevision",
+    code: "// behavior comes from the runInSandbox mock",
+  });
+}
+
+const SAFE_ROLLOUT_RULE_BODY = {
+  environment: "production",
+  rule: {
+    type: "safe-rollout",
+    controlValue: "false",
+    variationValue: "true",
+    hashAttribute: "id",
+    safeRolloutFields: {
+      datasourceId: "ds_1",
+      exposureQueryId: "q_1",
+      guardrailMetricIds: ["met_1"],
+      maxDuration: { amount: 3, unit: "days" },
+    },
+  },
+};
+
+describe("rule-add custom hook prevalidation", () => {
+  const { app, setReqContext } = setupApp();
+
+  let premiumSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    premiumSpy = jest
+      .spyOn(ReqContextClass.prototype, "hasPremiumFeature")
+      .mockReturnValue(true);
+    mockRunInSandbox.mockResolvedValue({ ok: true, warnings: [] });
+  });
+
+  afterEach(() => {
+    premiumSpy.mockRestore();
+  });
+
+  async function setup() {
+    const context = makeContext();
+    setReqContext(context);
+    await seedFeature();
+    const revision = await seedDraftRevision(context);
+    await seedRevisionHook();
+    return { context, revision };
+  }
+
+  it("does not create a safeRollout doc when a hook rejects the revision", async () => {
+    const { revision } = await setup();
+    mockRunInSandbox.mockResolvedValue({
+      ok: false,
+      error: "Rejected by hook",
+      warnings: [],
+    });
+
+    const response = await request(app)
+      .post(
+        `/api/v1/features/${FEATURE_ID}/revisions/${revision.version}/rules`,
+      )
+      .set("Authorization", "Bearer foo")
+      .send(SAFE_ROLLOUT_RULE_BODY);
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toContain("Rejected by hook");
+
+    // The headline assertion: no orphaned safeRollout doc.
+    expect(
+      await mongoose.connection.collection("saferollout").countDocuments(),
+    ).toBe(0);
+
+    // And the revision is untouched.
+    const revisionDoc = await mongoose.connection
+      .collection("featurerevisions")
+      .findOne({ featureId: FEATURE_ID, version: revision.version });
+    expect(revisionDoc?.rules ?? []).toHaveLength(0);
+  });
+
+  it("does not create a safeRollout doc on an unacknowledged soft warning, and creates exactly one on the ignoreWarnings retry", async () => {
+    const { revision } = await setup();
+    mockRunInSandbox.mockResolvedValue({
+      ok: true,
+      warnings: ["check this"],
+    });
+
+    const warned = await request(app)
+      .post(
+        `/api/v1/features/${FEATURE_ID}/revisions/${revision.version}/rules`,
+      )
+      .set("Authorization", "Bearer foo")
+      .send(SAFE_ROLLOUT_RULE_BODY);
+
+    expect(warned.status).toBe(422);
+    expect(warned.body.warnings).toEqual(["check this"]);
+    expect(
+      await mongoose.connection.collection("saferollout").countDocuments(),
+    ).toBe(0);
+
+    // Retry with ?ignoreWarnings=true — pre-fix this produced a SECOND
+    // safeRollout doc (the first was orphaned by the 422); now it's exactly one.
+    setReqContext(makeContext({ ignoreWarnings: "true" }));
+    const retried = await request(app)
+      .post(
+        `/api/v1/features/${FEATURE_ID}/revisions/${revision.version}/rules?ignoreWarnings=true`,
+      )
+      .set("Authorization", "Bearer foo")
+      .send(SAFE_ROLLOUT_RULE_BODY);
+
+    expect(retried.status).toBe(200);
+    expect(
+      await mongoose.connection.collection("saferollout").countDocuments(),
+    ).toBe(1);
+  });
+
+  it("double-fires hooks on a successful save (prevalidate + authoritative)", async () => {
+    const { revision } = await setup();
+    mockRunInSandbox.mockResolvedValue({ ok: true, warnings: [] });
+
+    const response = await request(app)
+      .post(
+        `/api/v1/features/${FEATURE_ID}/revisions/${revision.version}/rules`,
+      )
+      .set("Authorization", "Bearer foo")
+      .send(SAFE_ROLLOUT_RULE_BODY);
+
+    expect(response.status).toBe(200);
+    // One execution from prevalidateRevisionUpdate, one from updateRevision.
+    expect(mockRunInSandbox).toHaveBeenCalledTimes(2);
+    expect(
+      await mongoose.connection.collection("saferollout").countDocuments(),
+    ).toBe(1);
+
+    const revisionDoc = await mongoose.connection
+      .collection("featurerevisions")
+      .findOne({ featureId: FEATURE_ID, version: revision.version });
+    expect(revisionDoc?.rules).toHaveLength(1);
+    expect(revisionDoc?.rules[0].type).toBe("safe-rollout");
+  });
+});

--- a/packages/back-end/test/models/computeRevisionMergeChanges.test.ts
+++ b/packages/back-end/test/models/computeRevisionMergeChanges.test.ts
@@ -1,0 +1,180 @@
+import { FeatureInterface, FeatureRule } from "shared/types/feature";
+import { FeatureRevisionInterface } from "shared/types/feature-revision";
+import { Environment } from "shared/types/organization";
+import { MergeResultChanges } from "shared/util";
+import { computeRevisionMergeChanges } from "back-end/src/models/FeatureModel";
+import { ReqContext } from "back-end/types/request";
+
+// ---------------------------------------------------------------------------
+// computeRevisionMergeChanges is the pure computation shared by
+// applyRevisionChanges() (the publish write path) and
+// prevalidatePublishRevision() (the custom-hook early gate). It must produce
+// exactly the feature-doc changes the publish will persist, with no writes.
+// ---------------------------------------------------------------------------
+
+const ORG_ENVS: Environment[] = [
+  { id: "dev", description: "" },
+  { id: "production", description: "" },
+];
+
+function mockContext(envs: Environment[] = ORG_ENVS): ReqContext {
+  return {
+    org: { settings: { environments: envs } },
+  } as unknown as ReqContext;
+}
+
+function makeFeature(
+  overrides: Partial<FeatureInterface> = {},
+): FeatureInterface {
+  return {
+    id: "feat_test",
+    organization: "org_test",
+    version: 3,
+    defaultValue: "true",
+    valueType: "boolean",
+    owner: "",
+    description: "",
+    project: "",
+    tags: [],
+    dateCreated: new Date("2024-01-01"),
+    dateUpdated: new Date("2024-01-01"),
+    rules: [],
+    environmentSettings: {
+      production: { enabled: true },
+      dev: { enabled: false },
+    },
+    ...overrides,
+  } as FeatureInterface;
+}
+
+const REVISION = { version: 4 } as FeatureRevisionInterface;
+
+describe("computeRevisionMergeChanges", () => {
+  it("bumps only the version for an empty merge result", () => {
+    const { changes, hasChanges, removeHoldout } = computeRevisionMergeChanges(
+      mockContext(),
+      makeFeature(),
+      REVISION,
+      {},
+    );
+
+    expect(hasChanges).toBe(false);
+    expect(removeHoldout).toBe(false);
+    expect(changes).toEqual({ version: 4 });
+  });
+
+  it("projects defaultValue changes with the revision version", () => {
+    const { changes, hasChanges } = computeRevisionMergeChanges(
+      mockContext(),
+      makeFeature(),
+      REVISION,
+      { defaultValue: "false" },
+    );
+
+    expect(hasChanges).toBe(true);
+    expect(changes.defaultValue).toBe("false");
+    expect(changes.version).toBe(4);
+  });
+
+  it("backfills rule ids/seeds and computes nextScheduledUpdate for rules", () => {
+    const rules = [
+      {
+        type: "rollout",
+        description: "",
+        value: "true",
+        coverage: 0.5,
+        hashAttribute: "id",
+        enabled: true,
+        allEnvironments: true,
+      },
+    ] as unknown as FeatureRule[];
+
+    const { changes, hasChanges } = computeRevisionMergeChanges(
+      mockContext(),
+      makeFeature(),
+      REVISION,
+      { rules } as MergeResultChanges,
+    );
+
+    expect(hasChanges).toBe(true);
+    expect(changes.rules?.[0].id).toBeTruthy();
+    // Rollout rules without an explicit seed default to their rule id.
+    expect((changes.rules?.[0] as { seed?: string }).seed).toBe(
+      changes.rules?.[0].id,
+    );
+    expect("nextScheduledUpdate" in changes).toBe(true);
+  });
+
+  it("skips no-op environment toggles so the SDK payload cache is preserved", () => {
+    const { changes, hasChanges } = computeRevisionMergeChanges(
+      mockContext(),
+      makeFeature(),
+      REVISION,
+      { environmentsEnabled: { production: true } },
+    );
+
+    // production is already enabled — no content change, version bump only.
+    expect(hasChanges).toBe(false);
+    expect(changes).toEqual({ version: 4 });
+  });
+
+  it("applies real environment toggles while preserving other env settings", () => {
+    const { changes, hasChanges } = computeRevisionMergeChanges(
+      mockContext(),
+      makeFeature(),
+      REVISION,
+      { environmentsEnabled: { dev: true } },
+    );
+
+    expect(hasChanges).toBe(true);
+    expect(changes.environmentSettings?.dev.enabled).toBe(true);
+    expect(changes.environmentSettings?.production.enabled).toBe(true);
+  });
+
+  it("flags holdout removal without setting changes.holdout", () => {
+    const { changes, hasChanges, removeHoldout } = computeRevisionMergeChanges(
+      mockContext(),
+      makeFeature({
+        holdout: { id: "hld_1" },
+      } as unknown as Partial<FeatureInterface>),
+      REVISION,
+      { holdout: null },
+    );
+
+    expect(hasChanges).toBe(true);
+    expect(removeHoldout).toBe(true);
+    expect("holdout" in changes).toBe(false);
+  });
+
+  it("maps metadata fields onto the feature changes", () => {
+    const { changes, hasChanges } = computeRevisionMergeChanges(
+      mockContext(),
+      makeFeature(),
+      REVISION,
+      {
+        metadata: {
+          description: "new description",
+          owner: "new owner",
+          tags: ["a"],
+        },
+      } as MergeResultChanges,
+    );
+
+    expect(hasChanges).toBe(true);
+    expect(changes.description).toBe("new description");
+    expect(changes.owner).toBe("new owner");
+    expect(changes.tags).toEqual(["a"]);
+  });
+
+  it("does not mutate the feature or write anything", () => {
+    const feature = makeFeature();
+    const before = JSON.stringify(feature);
+
+    computeRevisionMergeChanges(mockContext(), feature, REVISION, {
+      defaultValue: "false",
+      environmentsEnabled: { dev: true },
+    });
+
+    expect(JSON.stringify(feature)).toBe(before);
+  });
+});

--- a/packages/back-end/test/models/computeRevisionMergeChanges.test.ts
+++ b/packages/back-end/test/models/computeRevisionMergeChanges.test.ts
@@ -5,13 +5,6 @@ import { MergeResultChanges } from "shared/util";
 import { computeRevisionMergeChanges } from "back-end/src/models/FeatureModel";
 import { ReqContext } from "back-end/types/request";
 
-// ---------------------------------------------------------------------------
-// computeRevisionMergeChanges is the pure computation shared by
-// applyRevisionChanges() (the publish write path) and
-// prevalidatePublishRevision() (the custom-hook early gate). It must produce
-// exactly the feature-doc changes the publish will persist, with no writes.
-// ---------------------------------------------------------------------------
-
 const ORG_ENVS: Environment[] = [
   { id: "dev", description: "" },
   { id: "production", description: "" },

--- a/packages/back-end/test/models/computeRevisionUpdate.test.ts
+++ b/packages/back-end/test/models/computeRevisionUpdate.test.ts
@@ -10,15 +10,6 @@ import {
 } from "back-end/src/models/FeatureRevisionModel";
 import { ReqContext } from "back-end/types/request";
 
-// ---------------------------------------------------------------------------
-// computeRevisionUpdate is the pure computation consumed by both
-// updateRevision() (the write path) and prevalidateRevisionUpdate() (the
-// custom-hook early gate). The critical invariant: the proposed state a
-// caller prevalidates against must be exactly the state updateRevision()
-// validates and persists — status transitions and rules normalization
-// included.
-// ---------------------------------------------------------------------------
-
 const ORG_ENVS: Environment[] = [
   { id: "dev", description: "" },
   { id: "production", description: "" },

--- a/packages/back-end/test/models/computeRevisionUpdate.test.ts
+++ b/packages/back-end/test/models/computeRevisionUpdate.test.ts
@@ -1,0 +1,229 @@
+import { FeatureInterface } from "shared/types/feature";
+import {
+  FeatureRevisionInterface,
+  RevisionChanges,
+} from "shared/types/feature-revision";
+import { Environment } from "shared/types/organization";
+import {
+  computeRevisionUpdate,
+  computeRevisionPublishChanges,
+} from "back-end/src/models/FeatureRevisionModel";
+import { ReqContext } from "back-end/types/request";
+
+// ---------------------------------------------------------------------------
+// computeRevisionUpdate is the pure computation consumed by both
+// updateRevision() (the write path) and prevalidateRevisionUpdate() (the
+// custom-hook early gate). The critical invariant: the proposed state a
+// caller prevalidates against must be exactly the state updateRevision()
+// validates and persists — status transitions and rules normalization
+// included.
+// ---------------------------------------------------------------------------
+
+const ORG_ENVS: Environment[] = [
+  { id: "dev", description: "" },
+  { id: "production", description: "" },
+];
+
+function mockContext(envs: Environment[] = ORG_ENVS): ReqContext {
+  return {
+    org: { settings: { environments: envs } },
+  } as unknown as ReqContext;
+}
+
+const FEATURE = {
+  id: "feat_test",
+  organization: "org_test",
+  project: "",
+} as unknown as FeatureInterface;
+
+function makeRevision(
+  overrides: Partial<FeatureRevisionInterface> = {},
+): FeatureRevisionInterface {
+  return {
+    organization: "org_test",
+    featureId: "feat_test",
+    version: 2,
+    baseVersion: 1,
+    dateCreated: new Date("2024-01-01"),
+    dateUpdated: new Date("2024-01-01"),
+    datePublished: null,
+    createdBy: { type: "dashboard", id: "u", email: "", name: "" },
+    comment: "",
+    defaultValue: "true",
+    rules: [],
+    status: "draft",
+    log: [],
+    ...overrides,
+  } as FeatureRevisionInterface;
+}
+
+function v2Rule(id: string) {
+  return {
+    id,
+    type: "force" as const,
+    description: "",
+    value: "true",
+    enabled: true,
+    allEnvironments: true,
+  };
+}
+
+describe("computeRevisionUpdate", () => {
+  it("merges normalized changes and status into proposedRevision", () => {
+    const revision = makeRevision();
+    const changes: RevisionChanges = { defaultValue: "false" };
+
+    const { normalizedChanges, status, proposedRevision } =
+      computeRevisionUpdate(mockContext(), FEATURE, revision, changes, false);
+
+    expect(status).toBe("draft");
+    expect(normalizedChanges).toEqual(changes);
+    expect(proposedRevision).toEqual({
+      ...revision,
+      ...normalizedChanges,
+      status,
+    });
+  });
+
+  it("throws for mutable changes on a published revision", () => {
+    const revision = makeRevision({ status: "published" });
+
+    expect(() =>
+      computeRevisionUpdate(
+        mockContext(),
+        FEATURE,
+        revision,
+        { rules: [v2Rule("r1")] },
+        false,
+      ),
+    ).toThrow("Can only update draft revisions");
+  });
+
+  it("allows non-mutable changes on a published revision", () => {
+    const revision = makeRevision({ status: "published" });
+
+    const { status } = computeRevisionUpdate(
+      mockContext(),
+      FEATURE,
+      revision,
+      {},
+      false,
+    );
+
+    expect(status).toBe("published");
+  });
+
+  it("resets changes-requested to pending-review on content changes", () => {
+    const revision = makeRevision({ status: "changes-requested" });
+
+    const { status, proposedRevision } = computeRevisionUpdate(
+      mockContext(),
+      FEATURE,
+      revision,
+      { defaultValue: "false" },
+      false,
+    );
+
+    expect(status).toBe("pending-review");
+    expect(proposedRevision.status).toBe("pending-review");
+  });
+
+  it("resets approved to pending-review only when resetReview is set", () => {
+    const revision = makeRevision({ status: "approved" });
+
+    const kept = computeRevisionUpdate(
+      mockContext(),
+      FEATURE,
+      revision,
+      { defaultValue: "false" },
+      false,
+    );
+    expect(kept.status).toBe("approved");
+
+    const reset = computeRevisionUpdate(
+      mockContext(),
+      FEATURE,
+      revision,
+      { defaultValue: "false" },
+      true,
+    );
+    expect(reset.status).toBe("pending-review");
+  });
+
+  it("normalizes v1 env-keyed rules into a flat v2 array", () => {
+    const revision = makeRevision();
+    const changes = {
+      rules: {
+        production: [
+          {
+            id: "r1",
+            type: "force",
+            description: "",
+            value: "true",
+            enabled: true,
+          },
+        ],
+      },
+    } as unknown as RevisionChanges;
+
+    const { normalizedChanges, proposedRevision } = computeRevisionUpdate(
+      mockContext(),
+      FEATURE,
+      revision,
+      changes,
+      false,
+    );
+
+    expect(Array.isArray(normalizedChanges.rules)).toBe(true);
+    expect(proposedRevision.rules).toBe(normalizedChanges.rules);
+  });
+
+  it("is deterministic: identical inputs produce identical proposed states", () => {
+    const revision = makeRevision({ status: "changes-requested" });
+    const changes: RevisionChanges = { rules: [v2Rule("r1")] };
+
+    const a = computeRevisionUpdate(
+      mockContext(),
+      FEATURE,
+      revision,
+      changes,
+      false,
+    );
+    const b = computeRevisionUpdate(
+      mockContext(),
+      FEATURE,
+      revision,
+      changes,
+      false,
+    );
+
+    expect(a.proposedRevision).toEqual(b.proposedRevision);
+  });
+});
+
+describe("computeRevisionPublishChanges", () => {
+  const user = { type: "dashboard" as const, id: "u", email: "", name: "" };
+
+  it("computes the published status and publisher", () => {
+    const revision = makeRevision();
+
+    const changes = computeRevisionPublishChanges(
+      revision,
+      user,
+      "publish comment",
+    );
+
+    expect(changes.status).toBe("published");
+    expect(changes.publishedBy).toBe(user);
+    expect(changes.datePublished).toBeInstanceOf(Date);
+    expect(changes.comment).toBe("publish comment");
+  });
+
+  it("keeps the revision's own comment when present", () => {
+    const revision = makeRevision({ comment: "original" });
+
+    const changes = computeRevisionPublishChanges(revision, user, "ignored");
+
+    expect(changes.comment).toBe("original");
+  });
+});

--- a/packages/back-end/test/sandbox-eval.test.ts
+++ b/packages/back-end/test/sandbox-eval.test.ts
@@ -89,10 +89,7 @@ describe("sandboxEval", () => {
     expect(result).toEqual({ ok: true, returnVal: 1, log: "", warnings: [] });
   });
 
-  // Resource-exhaustion guards. Data copied out of the isolate (logs/warnings)
-  // is NOT bounded by the isolate memory limit, so without these caps a tight
-  // log/warning loop could exhaust host memory and crash the Node process.
-  // Defaults: MAX_LOG_CHARS = 64KB, MAX_WARNINGS = 100, MAX_WARNING_CHARS = 64KB.
+  // Caps on host-side log/warning output (the isolate limit doesn't cover copied-out data).
   describe("resource limits", () => {
     it("bounds total console.log output regardless of loop count", async () => {
       // Each iteration logs a 100KB string; without a cap this retains 100s of MB
@@ -116,10 +113,7 @@ describe("sandboxEval", () => {
     });
 
     it("terminates a long-running async log loop with bounded output", async () => {
-      // Microtask yields (`await null`) stay within the CPU budget; macrotask
-      // yields (e.g. `await fetch`) escape it and are stopped by the wall timer
-      // disposing the isolate. Either way the loop must terminate and the
-      // captured output must stay bounded (no unbounded host-memory growth).
+      // Either way the loop must terminate and captured output stay bounded.
       const result = await sandboxEval(
         `const s = "x".repeat(100000); while (true) { console.log(s); await null; }`,
         {},

--- a/packages/back-end/test/sandbox-eval.test.ts
+++ b/packages/back-end/test/sandbox-eval.test.ts
@@ -1,4 +1,4 @@
-import { sandboxEval } from "../src/enterprise/sandbox/sandbox-eval";
+import { sandboxEval } from "../src/enterprise/sandbox/sandbox-core";
 
 describe("sandboxEval", () => {
   it("should evaluate a function in a sandboxed environment", async () => {
@@ -87,5 +87,47 @@ describe("sandboxEval", () => {
   it("should return no warnings when addWarning is not called", async () => {
     const result = await sandboxEval("return 1", {});
     expect(result).toEqual({ ok: true, returnVal: 1, log: "", warnings: [] });
+  });
+
+  // Resource-exhaustion guards. Data copied out of the isolate (logs/warnings)
+  // is NOT bounded by the isolate memory limit, so without these caps a tight
+  // log/warning loop could exhaust host memory and crash the Node process.
+  // Defaults: MAX_LOG_CHARS = 64KB, MAX_WARNINGS = 100, MAX_WARNING_CHARS = 64KB.
+  describe("resource limits", () => {
+    it("bounds total console.log output regardless of loop count", async () => {
+      // Each iteration logs a 100KB string; without a cap this retains 100s of MB
+      const result = await sandboxEval(
+        `const s = "x".repeat(100000); for (let i = 0; i < 100000; i++) { console.log(s); } return 1;`,
+        {},
+      );
+      // ~64KB cap plus a short truncation marker
+      expect(result.log.length).toBeLessThanOrEqual(64 * 1024 + 64);
+    });
+
+    it("bounds the count and total size of warnings", async () => {
+      const result = await sandboxEval(
+        `const s = "x".repeat(5000); for (let i = 0; i < 100000; i++) { addWarning(s); } return 1;`,
+        {},
+      );
+      expect(result.warnings.length).toBeLessThanOrEqual(100);
+      expect(result.warnings.join("").length).toBeLessThanOrEqual(
+        64 * 1024 + 200,
+      );
+    });
+
+    it("terminates a long-running async log loop with bounded output", async () => {
+      // Microtask yields (`await null`) stay within the CPU budget; macrotask
+      // yields (e.g. `await fetch`) escape it and are stopped by the wall timer
+      // disposing the isolate. Either way the loop must terminate and the
+      // captured output must stay bounded (no unbounded host-memory growth).
+      const result = await sandboxEval(
+        `const s = "x".repeat(100000); while (true) { console.log(s); await null; }`,
+        {},
+        { cpuTimeoutMS: 100, wallTimeoutMS: 300 },
+      );
+      expect(result.ok).toBe(false);
+      expect(result.error).toEqual(expect.stringContaining("timed out"));
+      expect(result.log.length).toBeLessThanOrEqual(64 * 1024 + 64);
+    });
   });
 });

--- a/packages/back-end/test/sandbox-eval.test.ts
+++ b/packages/back-end/test/sandbox-eval.test.ts
@@ -113,7 +113,6 @@ describe("sandboxEval", () => {
     });
 
     it("terminates a long-running async log loop with bounded output", async () => {
-      // Either way the loop must terminate and captured output stay bounded.
       const result = await sandboxEval(
         `const s = "x".repeat(100000); while (true) { console.log(s); await null; }`,
         {},

--- a/packages/back-end/test/services/publishPendingFeatureDraftsForExperiment.test.ts
+++ b/packages/back-end/test/services/publishPendingFeatureDraftsForExperiment.test.ts
@@ -199,6 +199,55 @@ describe("publishPendingFeatureDraftsForExperiment", () => {
     expect(mockPublishRevision).toHaveBeenCalledTimes(1);
   });
 
+  it("fetches each feature/revision once instead of re-fetching per phase", async () => {
+    mockGetRevision.mockImplementation(async ({ version }) => {
+      return { version, status: "draft", rules: [] } as never;
+    });
+
+    const experiment = makeExperiment([
+      { featureId: "feat_a", revisionVersion: 5 },
+      { featureId: "feat_b", revisionVersion: 6 },
+    ]);
+
+    const result = await publishPendingFeatureDraftsForExperiment(
+      ctx,
+      experiment,
+    );
+
+    expect(result.published.length).toBe(2);
+    // One fetch per feature and one per draft revision across all phases.
+    expect(mockGetFeature).toHaveBeenCalledTimes(2);
+    expect(mockGetRevision).toHaveBeenCalledTimes(2);
+    expect(mockGetLiveAndBase).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-fetches fresh state only for later drafts of an already-published feature", async () => {
+    mockGetRevision.mockImplementation(async ({ version }) => {
+      return { version, status: "draft", rules: [] } as never;
+    });
+
+    const experiment = makeExperiment([
+      { featureId: "feat_a", revisionVersion: 5 },
+      { featureId: "feat_a", revisionVersion: 7 },
+    ]);
+
+    const result = await publishPendingFeatureDraftsForExperiment(
+      ctx,
+      experiment,
+    );
+
+    expect(result.published).toEqual([
+      { featureId: "feat_a", revisionVersion: 5 },
+      { featureId: "feat_a", revisionVersion: 7 },
+    ]);
+    // Phase 1 fetches the feature once (cached across drafts) and each
+    // revision once; publishing v5 advances live state, so v7 re-fetches
+    // everything before re-merging.
+    expect(mockGetFeature).toHaveBeenCalledTimes(2);
+    expect(mockGetRevision).toHaveBeenCalledTimes(3);
+    expect(mockGetLiveAndBase).toHaveBeenCalledTimes(3);
+  });
+
   it("publishes multiple drafts of the same feature in version order", async () => {
     mockGetRevision.mockImplementation(async ({ version }) => {
       return { version, status: "draft", rules: [] } as never;

--- a/packages/back-end/test/services/publishPendingFeatureDraftsForExperiment.test.ts
+++ b/packages/back-end/test/services/publishPendingFeatureDraftsForExperiment.test.ts
@@ -257,9 +257,7 @@ describe("publishPendingFeatureDraftsForExperiment", () => {
     mockGetRevision.mockImplementation(async ({ version }) => {
       return { version, status: "draft", rules: [] } as never;
     });
-    // feat_a's drafts (v5, v7) merge cleanly; feat_b's (v6) hits a conflict.
-    // Keyed by revision version (not call order) because the hook
-    // prevalidation pass also merges each draft before phase 2 runs.
+    // Keyed by revision version (not call order): feat_a's drafts (v5, v7) merge cleanly; feat_b's (v6) conflicts
     mockAutoMerge.mockImplementation(
       (live, base, revision) =>
         ((revision as { version: number }).version === 6

--- a/packages/back-end/test/services/publishPendingFeatureDraftsForExperiment.test.ts
+++ b/packages/back-end/test/services/publishPendingFeatureDraftsForExperiment.test.ts
@@ -5,6 +5,7 @@ import type { ReqContext } from "back-end/types/request";
 jest.mock("back-end/src/models/FeatureModel", () => ({
   getFeature: jest.fn(),
   publishRevision: jest.fn(),
+  prevalidatePublishRevision: jest.fn(),
   editFeatureRules: jest.fn(),
 }));
 
@@ -35,7 +36,11 @@ jest.mock("shared/util", () => ({
 }));
 
 import { publishPendingFeatureDraftsForExperiment } from "back-end/src/services/experiment-feature";
-import { getFeature, publishRevision } from "back-end/src/models/FeatureModel";
+import {
+  getFeature,
+  prevalidatePublishRevision,
+  publishRevision,
+} from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   discardRevision,
@@ -51,6 +56,10 @@ const mockDiscardRevision = discardRevision as jest.MockedFunction<
 const mockPublishRevision = publishRevision as jest.MockedFunction<
   typeof publishRevision
 >;
+const mockPrevalidatePublish =
+  prevalidatePublishRevision as jest.MockedFunction<
+    typeof prevalidatePublishRevision
+  >;
 const mockRemovePending =
   removePendingFeatureDraftFromExperiment as jest.MockedFunction<
     typeof removePendingFeatureDraftFromExperiment
@@ -146,6 +155,27 @@ describe("publishPendingFeatureDraftsForExperiment", () => {
     expect(mockPublishRevision).not.toHaveBeenCalled();
   });
 
+  it("fails the whole batch before publishing anything when hook prevalidation rejects", async () => {
+    mockGetRevision.mockImplementation(async ({ version }) => {
+      return { version, status: "draft", rules: [] } as never;
+    });
+    // First draft prevalidates fine, second is rejected by a custom hook.
+    mockPrevalidatePublish
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("Blocked by custom hook"));
+
+    const experiment = makeExperiment([
+      { featureId: "feat_a", revisionVersion: 5 },
+      { featureId: "feat_b", revisionVersion: 6 },
+    ]);
+
+    await expect(
+      publishPendingFeatureDraftsForExperiment(ctx, experiment),
+    ).rejects.toThrow("Blocked by custom hook");
+
+    expect(mockPublishRevision).not.toHaveBeenCalled();
+  });
+
   it("publishes a single draft cleanly", async () => {
     mockGetRevision.mockResolvedValue({
       version: 6,
@@ -227,22 +257,24 @@ describe("publishPendingFeatureDraftsForExperiment", () => {
     mockGetRevision.mockImplementation(async ({ version }) => {
       return { version, status: "draft", rules: [] } as never;
     });
-    // First two drafts merge cleanly, third hits a conflict.
-    mockAutoMerge
-      .mockReturnValueOnce({
-        success: true,
-        conflicts: [],
-        result: { rules: [] },
-      })
-      .mockReturnValueOnce({
-        success: true,
-        conflicts: [],
-        result: { rules: [] },
-      })
-      .mockReturnValueOnce({
-        success: false,
-        conflicts: [{ key: "rules", base: "x", live: "y", revision: "z" }],
-      } as never);
+    // feat_a's drafts (v5, v7) merge cleanly; feat_b's (v6) hits a conflict.
+    // Keyed by revision version (not call order) because the hook
+    // prevalidation pass also merges each draft before phase 2 runs.
+    mockAutoMerge.mockImplementation(
+      (live, base, revision) =>
+        ((revision as { version: number }).version === 6
+          ? {
+              success: false,
+              conflicts: [
+                { key: "rules", base: "x", live: "y", revision: "z" },
+              ],
+            }
+          : {
+              success: true,
+              conflicts: [],
+              result: { rules: [] },
+            }) as never,
+    );
 
     const experiment = makeExperiment([
       { featureId: "feat_a", revisionVersion: 5 },

--- a/packages/back-end/types/api.d.ts
+++ b/packages/back-end/types/api.d.ts
@@ -45,8 +45,7 @@ export interface ApiErrorResponse {
   // a structured conflict list (e.g. feature revision publish/rebase) so
   // clients can auto-resolve programmatically.
   conflicts?: unknown[];
-  // Populated on 422 SoftWarningError responses (e.g. a custom hook raised a soft
-  // warning). Re-submit with `?ignoreWarnings=true` to proceed anyway.
+  // Populated on 422 soft-warning responses; re-submit with ?ignoreWarnings=true to proceed.
   warnings?: string[];
 }
 

--- a/packages/front-end/components/ApiWarningModal.tsx
+++ b/packages/front-end/components/ApiWarningModal.tsx
@@ -3,9 +3,7 @@ import { Flex } from "@radix-ui/themes";
 import ModalStandard from "@/ui/Modal/Patterns/ModalStandard";
 import Callout from "@/ui/Callout";
 
-// Global dialog shown when an API request returns soft warnings (HTTP 422).
-// The user can acknowledge them and proceed, or cancel. Generic on purpose so
-// it can surface warnings from any feature, not just custom hooks.
+// Global dialog for API soft warnings (HTTP 422) — acknowledge to proceed, or cancel.
 export default function ApiWarningModal({
   warnings,
   onConfirm,
@@ -15,8 +13,7 @@ export default function ApiWarningModal({
   onConfirm: () => void;
   onCancel: () => void;
 }) {
-  // ModalStandard fires `submit` AND then `close` when the user confirms
-  // Report exactly one outcome to the caller — whichever fires first wins.
+  // ModalStandard fires submit then close on confirm; report exactly one outcome.
   const reported = useRef(false);
   const reportOnce = (report: () => void) => {
     if (reported.current) return;

--- a/packages/front-end/components/Dropdown/MoreMenu.tsx
+++ b/packages/front-end/components/Dropdown/MoreMenu.tsx
@@ -19,6 +19,7 @@ const MoreMenu: FC<{
   zIndex?: number;
   children: ReactNode;
   useRadix?: boolean;
+  iconButtonSize?: "1" | "2" | "3";
   size?: number;
 }> = ({
   children,
@@ -26,6 +27,7 @@ const MoreMenu: FC<{
   className = "",
   zIndex = 1020,
   useRadix,
+  iconButtonSize = "3",
   size = 18,
 }) => {
   const [open, setOpen] = useState(false);
@@ -63,7 +65,7 @@ const MoreMenu: FC<{
             variant="ghost"
             color="gray"
             radius="full"
-            size="3"
+            size={iconButtonSize}
             highContrast
             ref={refs.setReference}
             onClick={() => {

--- a/packages/front-end/components/Features/CustomHookModal.tsx
+++ b/packages/front-end/components/Features/CustomHookModal.tsx
@@ -1,0 +1,363 @@
+import React, { useState } from "react";
+import { useForm } from "react-hook-form";
+import { CustomHookInterface, CustomHookType } from "shared/validators";
+import { CreateProps } from "shared/types/base-model";
+import { Flex, Kbd, Separator } from "@radix-ui/themes";
+import stringify from "json-stringify-pretty-compact";
+import { FeatureInterface } from "shared/types/feature";
+import { FeatureRevisionInterface } from "shared/types/feature-revision";
+import { useAuth } from "@/services/auth";
+import Modal from "@/components/Modal";
+import Field from "@/components/Forms/Field";
+import SelectField from "@/components/Forms/SelectField";
+import useProjectOptions from "@/hooks/useProjectOptions";
+import MultiSelectField from "@/components/Forms/MultiSelectField";
+import CodeTextArea from "@/components/Forms/CodeTextArea";
+import Checkbox from "@/ui/Checkbox";
+import Button from "@/ui/Button";
+import Callout from "@/ui/Callout";
+import Text from "@/ui/Text";
+
+const dummyFeature: FeatureInterface = {
+  id: "new-feature",
+  organization: "org_abc123",
+  dateCreated: new Date(),
+  dateUpdated: new Date(),
+  description: "My new feature",
+  valueType: "boolean",
+  defaultValue: "false",
+  tags: [],
+  environmentSettings: {
+    production: {
+      enabled: true,
+    },
+  },
+  rules: [],
+  archived: false,
+  owner: "",
+  project: "",
+  version: 1,
+  prerequisites: [],
+  customFields: {},
+};
+const dummyRevision: FeatureRevisionInterface = {
+  organization: "org_abc123",
+  featureId: "new-feature",
+  dateCreated: new Date(),
+  dateUpdated: new Date(),
+  version: 2,
+  baseVersion: 1,
+  comment: "",
+  createdBy: {
+    type: "dashboard",
+    id: "user_123",
+    name: "User",
+    email: "user@example.com",
+  },
+  defaultValue: "false",
+  status: "draft",
+  rules: [],
+  datePublished: null,
+  publishedBy: null,
+};
+
+export const hookTypes: Record<
+  CustomHookType,
+  {
+    label: string;
+    availableArguments: Record<
+      string,
+      { description: string; testValue: string }
+    >;
+    example: string;
+  }
+> = {
+  validateFeature: {
+    label: "Validate Feature",
+    availableArguments: {
+      feature: {
+        description: "The feature object being validated",
+        testValue: stringify(dummyFeature),
+      },
+    },
+    example: `\n// Block the save (hard error):\nif (!feature.description) {\n  throw new Error("Feature must have a description");\n}\n\n// Or raise a soft warning the user can acknowledge:\nif (feature.tags.length === 0) {\n  addWarning("Consider adding at least one tag");\n}`,
+  },
+  validateFeatureRevision: {
+    label: "Validate Feature Revision",
+    availableArguments: {
+      feature: {
+        description: "The feature object the revision belongs to",
+        testValue: stringify(dummyFeature),
+      },
+      revision: {
+        description: "The feature revision being validated",
+        testValue: stringify(dummyRevision),
+      },
+    },
+    example: `\n// Block the save (hard error):\nif (!revision.rules.production || revision.rules.production.length === 0) {\n  throw new Error("At least one production rule is required");\n}\n\n// Or raise a soft warning the user can acknowledge:\nif (!revision.comment) {\n  addWarning("Consider adding a comment describing this change");\n}`,
+  },
+};
+
+export default function CustomHookModal({
+  close,
+  current,
+  onSave,
+  feature,
+}: {
+  close: () => void;
+  current?: CustomHookInterface;
+  onSave?: () => void;
+  // When set, the hook is scoped to this specific feature (entityType/entityId)
+  // and the Projects field is hidden.
+  feature?: FeatureInterface;
+}) {
+  const form = useForm<CreateProps<CustomHookInterface>>({
+    defaultValues: {
+      name: current?.name || "",
+      hook: current?.hook || "validateFeature",
+      code: current?.code || "",
+      projects: current?.projects || [],
+      enabled: current?.enabled ?? true,
+      incrementalChangesOnly: current?.incrementalChangesOnly || false,
+    },
+  });
+
+  const { apiCall } = useAuth();
+
+  const projectOptions = useProjectOptions(() => true, current?.projects || []);
+
+  const hookType = form.watch("hook");
+  const hookTypeData = hookTypes[hookType];
+
+  // For a feature-scoped hook, prefill the `feature` argument with the real
+  // feature so testing reflects the actual object being validated.
+  const initialTestValues = (h: CustomHookType): Record<string, string> =>
+    Object.fromEntries(
+      Object.entries(hookTypes[h].availableArguments).map(([k, v]) => [
+        k,
+        feature && k === "feature" ? stringify(feature) : v.testValue,
+      ]),
+    );
+
+  const [testValues, setTestValues] = useState<Record<string, string>>(
+    initialTestValues(current?.hook || "validateFeature"),
+  );
+  const [testResult, setTestResult] = useState<{
+    status: "" | "success" | "error";
+    returnVal?: string;
+    error?: string;
+    warnings?: string[];
+    log?: string;
+  }>({ status: "" });
+
+  const runTest = async () => {
+    const res = await apiCall<{
+      success: boolean;
+      returnVal?: string;
+      error?: string;
+      warnings?: string[];
+      log?: string;
+    }>("/custom-hooks/test", {
+      method: "POST",
+      body: JSON.stringify({
+        functionBody: form.getValues("code"),
+        functionArgs: Object.fromEntries(
+          Object.entries(testValues).map(([k, v]) => {
+            try {
+              return [k, JSON.parse(v)];
+            } catch (e) {
+              return [k, v];
+            }
+          }),
+        ),
+        ...(feature
+          ? { entityType: "feature" as const, entityId: feature.id }
+          : {}),
+      }),
+    });
+    setTestResult({
+      status: res.success ? "success" : "error",
+      returnVal: res.returnVal,
+      error: res.error,
+      warnings: res.warnings,
+      log: res.log,
+    });
+  };
+
+  const isMac =
+    typeof navigator !== "undefined" && navigator.userAgent.includes("Mac");
+  const modKey = isMac ? "⌘" : "Ctrl";
+
+  return (
+    <Modal
+      header={current?.id ? "Edit Custom Hook" : "Add Custom Hook"}
+      close={close}
+      open={true}
+      size="max"
+      trackingEventModalType="custom-hooks"
+      submit={form.handleSubmit(async (value) => {
+        const body = feature
+          ? {
+              ...value,
+              projects: [],
+              entityType: "feature" as const,
+              entityId: feature.id,
+            }
+          : value;
+        if (current?.id) {
+          await apiCall(`/custom-hooks/${current.id}`, {
+            method: "PUT",
+            body: JSON.stringify(body),
+          });
+        } else {
+          await apiCall("/custom-hooks", {
+            method: "POST",
+            body: JSON.stringify(body),
+          });
+        }
+
+        if (onSave) onSave();
+      })}
+    >
+      <Flex align="start" gap="5">
+        <div style={{ width: "50%" }} className="border-right pr-4">
+          <Field label="Name" required {...form.register("name")} />
+          <SelectField
+            label="Hook Type"
+            required
+            options={Object.entries(hookTypes).map(([value, { label }]) => ({
+              value,
+              label,
+            }))}
+            value={hookType}
+            onChange={(value) => {
+              form.setValue("hook", value as CustomHookType);
+              setTestValues(initialTestValues(value as CustomHookType));
+            }}
+          />
+          {!feature && (
+            <MultiSelectField
+              label={"Projects"}
+              placeholder="All projects"
+              value={form.watch("projects") || []}
+              options={projectOptions}
+              onChange={(v) => form.setValue("projects", v)}
+              customClassName="label-overflow-ellipsis"
+              helpText="Only run this hook for selected projects"
+            />
+          )}
+          <Checkbox
+            label="Enable this hook"
+            value={form.watch("enabled")}
+            setValue={(value) => form.setValue("enabled", value)}
+            description="Uncheck to disable this hook without deleting it"
+          />
+
+          <Separator size="4" mb="4" my="2" />
+
+          <strong>Available Variables</strong>
+          <ul>
+            {Object.entries(hookTypeData?.availableArguments).map(
+              ([arg, { description }]) => (
+                <li key={arg}>
+                  <code>{arg}</code>: {description}
+                </li>
+              ),
+            )}
+          </ul>
+
+          <Text as="p" size="small" color="text-low" mb="2">
+            Call <code>throw new Error(...)</code> to block the action, or{" "}
+            <code>addWarning(...)</code> for a soft warning the user can
+            acknowledge and override.
+          </Text>
+
+          <CodeTextArea
+            language="javascript"
+            label="Javascript Code"
+            required
+            value={form.watch("code")}
+            setValue={(value) => form.setValue("code", value)}
+            placeholder={hookTypeData?.example || ""}
+            onCtrlEnter={runTest}
+          />
+
+          <Checkbox
+            label="Incremental Changes Only"
+            value={form.watch("incrementalChangesOnly") || false}
+            setValue={(value) => form.setValue("incrementalChangesOnly", value)}
+            description="Ignore this hook if the same error was already present before attempting to save."
+          />
+        </div>
+        <div style={{ width: "50%" }}>
+          <h3>Test Your Hook</h3>
+          {Object.keys(hookTypeData?.availableArguments).map((arg) => (
+            <CodeTextArea
+              language="json"
+              key={arg}
+              label={arg}
+              required
+              value={testValues[arg] || ""}
+              setValue={(value) =>
+                setTestValues((existing) => ({
+                  ...existing,
+                  [arg]: value,
+                }))
+              }
+              onCtrlEnter={runTest}
+              maxLines={8}
+            />
+          ))}
+          <Button
+            onClick={runTest}
+            disabled={!form.watch("code")}
+            variant="outline"
+          >
+            <Flex align="center" gap="3">
+              <Text>Run Test</Text>
+              <Kbd size="1">{modKey} + Enter</Kbd>
+            </Flex>
+          </Button>
+          {testResult.status === "success" && !testResult.warnings?.length && (
+            <Callout mt="3" status="success">
+              Success!
+            </Callout>
+          )}
+          {testResult.status === "error" && (
+            <Callout mt="3" status="error">
+              Error!
+            </Callout>
+          )}
+          {testResult.warnings && testResult.warnings.length > 0 && (
+            <div className="mt-3">
+              <strong>Warnings:</strong>
+              {testResult.warnings.map((w, i) => (
+                <Callout key={i} status="warning" mt="2">
+                  {w}
+                </Callout>
+              ))}
+            </div>
+          )}
+          {testResult.returnVal && (
+            <div className="mt-3">
+              <strong>Return Value:</strong>
+              <pre className="p-3 bg-light">{testResult.returnVal}</pre>
+            </div>
+          )}
+          {testResult.error && (
+            <div className="mt-3">
+              <strong>Error:</strong>
+              <pre className="p-3 bg-light">{testResult.error}</pre>
+            </div>
+          )}
+          {testResult.log && (
+            <div className="mt-3">
+              <strong>Log:</strong>
+              <pre className="p-3 bg-light">{testResult.log}</pre>
+            </div>
+          )}
+        </div>
+      </Flex>
+    </Modal>
+  );
+}

--- a/packages/front-end/components/Features/CustomHookModal.tsx
+++ b/packages/front-end/components/Features/CustomHookModal.tsx
@@ -111,7 +111,7 @@ export default function CustomHookModal({
   onSave?: () => void;
   // When set, scopes the hook to this feature and hides the Projects field.
   feature?: FeatureInterface;
-  // Prefills the revision test argument so testing reflects the real object.
+  // Prefills the revision test argument
   revision?: FeatureRevisionInterface;
 }) {
   const form = useForm<CreateProps<CustomHookInterface>>({
@@ -131,7 +131,6 @@ export default function CustomHookModal({
   const hookType = form.watch("hook");
   const hookTypeData = hookTypes[hookType];
 
-  // Prefill test args with the real feature/revision so testing reflects actual objects.
   const initialTestValues = (h: CustomHookType): Record<string, string> =>
     Object.fromEntries(
       Object.entries(hookTypes[h].availableArguments).map(([k, v]) => [

--- a/packages/front-end/components/Features/CustomHookModal.tsx
+++ b/packages/front-end/components/Features/CustomHookModal.tsx
@@ -362,7 +362,16 @@ export default function CustomHookModal({
           {testResult.log && (
             <div className="mt-3">
               <strong>Log:</strong>
-              <pre className="p-3 bg-light">{testResult.log}</pre>
+              <pre
+                className="p-3 bg-light"
+                style={{
+                  whiteSpace: "pre-wrap",
+                  maxHeight: 200,
+                  overflowY: "auto",
+                }}
+              >
+                {testResult.log}
+              </pre>
             </div>
           )}
         </div>

--- a/packages/front-end/components/Features/CustomHookModal.tsx
+++ b/packages/front-end/components/Features/CustomHookModal.tsx
@@ -109,11 +109,9 @@ export default function CustomHookModal({
   close: () => void;
   current?: CustomHookInterface;
   onSave?: () => void;
-  // When set, the hook is scoped to this specific feature (entityType/entityId)
-  // and the Projects field is hidden.
+  // When set, scopes the hook to this feature and hides the Projects field.
   feature?: FeatureInterface;
-  // When set alongside `feature`, prefill the `revision` test argument with this
-  // revision so hook testing reflects the object being validated.
+  // Prefills the revision test argument so testing reflects the real object.
   revision?: FeatureRevisionInterface;
 }) {
   const form = useForm<CreateProps<CustomHookInterface>>({
@@ -133,8 +131,7 @@ export default function CustomHookModal({
   const hookType = form.watch("hook");
   const hookTypeData = hookTypes[hookType];
 
-  // For a feature-scoped hook, prefill test arguments with the real feature
-  // and revision so testing reflects the actual objects being validated.
+  // Prefill test args with the real feature/revision so testing reflects actual objects.
   const initialTestValues = (h: CustomHookType): Record<string, string> =>
     Object.fromEntries(
       Object.entries(hookTypes[h].availableArguments).map(([k, v]) => [

--- a/packages/front-end/components/Features/CustomHookModal.tsx
+++ b/packages/front-end/components/Features/CustomHookModal.tsx
@@ -17,6 +17,7 @@ import Checkbox from "@/ui/Checkbox";
 import Button from "@/ui/Button";
 import Callout from "@/ui/Callout";
 import Text from "@/ui/Text";
+import InlineCode from "@/components/SyntaxHighlighting/InlineCode";
 
 const dummyFeature: FeatureInterface = {
   id: "new-feature",
@@ -103,6 +104,7 @@ export default function CustomHookModal({
   current,
   onSave,
   feature,
+  revision,
 }: {
   close: () => void;
   current?: CustomHookInterface;
@@ -110,6 +112,9 @@ export default function CustomHookModal({
   // When set, the hook is scoped to this specific feature (entityType/entityId)
   // and the Projects field is hidden.
   feature?: FeatureInterface;
+  // When set alongside `feature`, prefill the `revision` test argument with this
+  // revision so hook testing reflects the object being validated.
+  revision?: FeatureRevisionInterface;
 }) {
   const form = useForm<CreateProps<CustomHookInterface>>({
     defaultValues: {
@@ -117,8 +122,7 @@ export default function CustomHookModal({
       hook: current?.hook || "validateFeature",
       code: current?.code || "",
       projects: current?.projects || [],
-      enabled: current?.enabled ?? true,
-      incrementalChangesOnly: current?.incrementalChangesOnly || false,
+      incrementalChangesOnly: current?.incrementalChangesOnly ?? true,
     },
   });
 
@@ -129,13 +133,17 @@ export default function CustomHookModal({
   const hookType = form.watch("hook");
   const hookTypeData = hookTypes[hookType];
 
-  // For a feature-scoped hook, prefill the `feature` argument with the real
-  // feature so testing reflects the actual object being validated.
+  // For a feature-scoped hook, prefill test arguments with the real feature
+  // and revision so testing reflects the actual objects being validated.
   const initialTestValues = (h: CustomHookType): Record<string, string> =>
     Object.fromEntries(
       Object.entries(hookTypes[h].availableArguments).map(([k, v]) => [
         k,
-        feature && k === "feature" ? stringify(feature) : v.testValue,
+        feature && k === "feature"
+          ? stringify(feature)
+          : revision && k === "revision"
+            ? stringify(revision)
+            : v.testValue,
       ]),
     );
 
@@ -196,14 +204,17 @@ export default function CustomHookModal({
       size="max"
       trackingEventModalType="custom-hooks"
       submit={form.handleSubmit(async (value) => {
-        const body = feature
-          ? {
-              ...value,
-              projects: [],
-              entityType: "feature" as const,
-              entityId: feature.id,
-            }
-          : value;
+        const body = {
+          ...value,
+          enabled: current?.enabled ?? true,
+          ...(feature
+            ? {
+                projects: [],
+                entityType: "feature" as const,
+                entityId: feature.id,
+              }
+            : {}),
+        };
         if (current?.id) {
           await apiCall(`/custom-hooks/${current.id}`, {
             method: "PUT",
@@ -246,13 +257,6 @@ export default function CustomHookModal({
               helpText="Only run this hook for selected projects"
             />
           )}
-          <Checkbox
-            label="Enable this hook"
-            value={form.watch("enabled")}
-            setValue={(value) => form.setValue("enabled", value)}
-            description="Uncheck to disable this hook without deleting it"
-          />
-
           <Separator size="4" mb="4" my="2" />
 
           <strong>Available Variables</strong>
@@ -260,17 +264,26 @@ export default function CustomHookModal({
             {Object.entries(hookTypeData?.availableArguments).map(
               ([arg, { description }]) => (
                 <li key={arg}>
-                  <code>{arg}</code>: {description}
+                  <strong>{arg}</strong>: {description}
                 </li>
               ),
             )}
           </ul>
 
-          <Text as="p" size="small" color="text-low" mb="2">
-            Call <code>throw new Error(...)</code> to block the action, or{" "}
-            <code>addWarning(...)</code> for a soft warning the user can
-            acknowledge and override.
-          </Text>
+          <Callout status="info" mb="4" contentsAs="div">
+            <Flex align="center" wrap={"wrap"} gapX={"2"}>
+              <Text as="span">Call</Text>
+              <InlineCode
+                language="javascript"
+                code="throw new Error('...')"
+              />{" "}
+              <Text>to block the action, or</Text>
+              <InlineCode language="javascript" code="addWarning('...')" />{" "}
+              <Text>
+                for a soft warning the user can acknowledge and override.
+              </Text>
+            </Flex>
+          </Callout>
 
           <CodeTextArea
             language="javascript"
@@ -284,7 +297,7 @@ export default function CustomHookModal({
 
           <Checkbox
             label="Incremental Changes Only"
-            value={form.watch("incrementalChangesOnly") || false}
+            value={form.watch("incrementalChangesOnly") ?? true}
             setValue={(value) => form.setValue("incrementalChangesOnly", value)}
             description="Ignore this hook if the same error was already present before attempting to save."
           />

--- a/packages/front-end/components/Features/EditSchemaModal.tsx
+++ b/packages/front-end/components/Features/EditSchemaModal.tsx
@@ -60,46 +60,50 @@ function EditSchemaField({
   onChange: (value: SchemaField) => void;
   valueType?: FeatureValueType;
 }) {
+  // String flags only allow a single type, so the Type selector is pointless.
+  // These flags are always single primitives, never in an object, so the
+  // entire row can be hidden. Number flags keep the selector to choose
+  // between Integer and Float.
+  const hideTypeSelector = valueType === "string";
   const allTypeOptions = [
     { value: "string", label: "Text String" },
     { value: "integer", label: "Integer" },
     { value: "float", label: "Float (Decimal)" },
     { value: "boolean", label: "Boolean (True/False)" },
   ];
-  // Restrict field type to match string/number flags.
   const typeOptions =
-    valueType === "string"
-      ? allTypeOptions.filter((o) => o.value === "string")
-      : valueType === "number"
-        ? allTypeOptions.filter((o) => ["integer", "float"].includes(o.value))
-        : allTypeOptions;
+    valueType === "number"
+      ? allTypeOptions.filter((o) => ["integer", "float"].includes(o.value))
+      : allTypeOptions;
   return (
     <div>
-      <div className="row">
-        {inObject && (
+      {!hideTypeSelector && (
+        <div className="row">
+          {inObject && (
+            <div className="col">
+              <Field
+                label="Property Key"
+                value={value.key}
+                onChange={(e) => onChange({ ...value, key: e.target.value })}
+                required
+                maxLength={64}
+              />
+            </div>
+          )}
           <div className="col">
-            <Field
-              label="Property Key"
-              value={value.key}
-              onChange={(e) => onChange({ ...value, key: e.target.value })}
+            <SelectField
+              label="Type"
+              value={value.type}
+              onChange={(type) =>
+                onChange({ ...value, type: type as SchemaField["type"] })
+              }
+              sort={false}
+              options={typeOptions}
               required
-              maxLength={64}
             />
           </div>
-        )}
-        <div className="col">
-          <SelectField
-            label="Type"
-            value={value.type}
-            onChange={(type) =>
-              onChange({ ...value, type: type as SchemaField["type"] })
-            }
-            sort={false}
-            options={typeOptions}
-            required
-          />
         </div>
-      </div>
+      )}
       <Field
         label="Description"
         value={value.description}
@@ -286,7 +290,7 @@ function EditSimpleSchema({
               value={
                 schema.fields[0] || {
                   key: "",
-                  type: "string",
+                  type: valueType === "number" ? "float" : "string",
                   required: false,
                   default: "",
                   description: "",

--- a/packages/front-end/components/Features/EditSchemaModal.tsx
+++ b/packages/front-end/components/Features/EditSchemaModal.tsx
@@ -66,8 +66,7 @@ function EditSchemaField({
     { value: "float", label: "Float (Decimal)" },
     { value: "boolean", label: "Boolean (True/False)" },
   ];
-  // For string/number flags, restrict the field type to match the flag so the
-  // schema stays compatible with the feature's value type.
+  // Restrict field type to match string/number flags.
   const typeOptions =
     valueType === "string"
       ? allTypeOptions.filter((o) => o.value === "string")
@@ -235,8 +234,7 @@ function EditSimpleSchema({
 }) {
   const [expandedFields, setExpandedFields] = useState(new Set<number>());
 
-  // String/number flags can only have a single primitive value, so lock the
-  // schema to "primitive" and hide the structure selector.
+  // String/number flags lock to a single primitive; hide the structure selector.
   const lockedPrimitive = valueType === "string" || valueType === "number";
 
   return (
@@ -566,8 +564,7 @@ export default function EditSchemaModal({
           }
         }
 
-        // Reject schemas that don't make sense for the feature's value type
-        // (e.g. an object schema on a number flag).
+        // Reject schemas that don't make sense for the feature's value type.
         assertSchemaMatchesValueType(value, feature.valueType);
 
         const body: Record<string, unknown> = {

--- a/packages/front-end/components/Features/EditSchemaModal.tsx
+++ b/packages/front-end/components/Features/EditSchemaModal.tsx
@@ -60,10 +60,7 @@ function EditSchemaField({
   onChange: (value: SchemaField) => void;
   valueType?: FeatureValueType;
 }) {
-  // String flags only allow a single type, so the Type selector is pointless.
-  // These flags are always single primitives, never in an object, so the
-  // entire row can be hidden. Number flags keep the selector to choose
-  // between Integer and Float.
+  // String features only have 1 type option, so hide the selector
   const hideTypeSelector = valueType === "string";
   const allTypeOptions = [
     { value: "string", label: "Text String" },
@@ -238,7 +235,6 @@ function EditSimpleSchema({
 }) {
   const [expandedFields, setExpandedFields] = useState(new Set<number>());
 
-  // String/number flags lock to a single primitive; hide the structure selector.
   const lockedPrimitive = valueType === "string" || valueType === "number";
 
   return (

--- a/packages/front-end/components/Features/EditSchemaModal.tsx
+++ b/packages/front-end/components/Features/EditSchemaModal.tsx
@@ -564,7 +564,6 @@ export default function EditSchemaModal({
           }
         }
 
-        // Reject schemas that don't make sense for the feature's value type.
         assertSchemaMatchesValueType(value, feature.valueType);
 
         const body: Record<string, unknown> = {

--- a/packages/front-end/components/Features/EditSchemaModal.tsx
+++ b/packages/front-end/components/Features/EditSchemaModal.tsx
@@ -1,6 +1,7 @@
 import { useForm } from "react-hook-form";
 import {
   FeatureInterface,
+  FeatureValueType,
   JSONSchemaDef,
   SchemaField,
   SimpleSchema,
@@ -13,6 +14,7 @@ import {
   inferSimpleSchemaFromValue,
   simpleToJSONSchema,
   getReviewSetting,
+  assertSchemaMatchesValueType,
 } from "shared/util";
 import { FaAngleDown, FaAngleRight, FaRegTrashAlt } from "react-icons/fa";
 import { MinimalFeatureRevisionInterface } from "shared/types/feature-revision";
@@ -50,12 +52,28 @@ function EditSchemaField({
   value,
   inObject,
   onChange,
+  valueType,
 }: {
   i: number;
   value: SchemaField;
   inObject: boolean;
   onChange: (value: SchemaField) => void;
+  valueType?: FeatureValueType;
 }) {
+  const allTypeOptions = [
+    { value: "string", label: "Text String" },
+    { value: "integer", label: "Integer" },
+    { value: "float", label: "Float (Decimal)" },
+    { value: "boolean", label: "Boolean (True/False)" },
+  ];
+  // For string/number flags, restrict the field type to match the flag so the
+  // schema stays compatible with the feature's value type.
+  const typeOptions =
+    valueType === "string"
+      ? allTypeOptions.filter((o) => o.value === "string")
+      : valueType === "number"
+        ? allTypeOptions.filter((o) => ["integer", "float"].includes(o.value))
+        : allTypeOptions;
   return (
     <div>
       <div className="row">
@@ -78,24 +96,7 @@ function EditSchemaField({
               onChange({ ...value, type: type as SchemaField["type"] })
             }
             sort={false}
-            options={[
-              {
-                value: "string",
-                label: "Text String",
-              },
-              {
-                value: "integer",
-                label: "Integer",
-              },
-              {
-                value: "float",
-                label: "Float (Decimal)",
-              },
-              {
-                value: "boolean",
-                label: "Boolean (True/False)",
-              },
-            ]}
+            options={typeOptions}
             required
           />
         </div>
@@ -226,53 +227,64 @@ function EditSchemaField({
 function EditSimpleSchema({
   schema,
   setSchema,
+  valueType,
 }: {
   schema: SimpleSchema;
   setSchema: (schema: SimpleSchema) => void;
+  valueType?: FeatureValueType;
 }) {
   const [expandedFields, setExpandedFields] = useState(new Set<number>());
 
+  // String/number flags can only have a single primitive value, so lock the
+  // schema to "primitive" and hide the structure selector.
+  const lockedPrimitive = valueType === "string" || valueType === "number";
+
   return (
     <div>
-      <SelectField
-        label="Type"
-        labelClassName="font-weight-bold text-dark"
-        value={schema.type}
-        sort={false}
-        onChange={(type) =>
-          setSchema({
-            ...schema,
-            type: type as SimpleSchema["type"],
-          })
-        }
-        options={[
-          {
-            value: "object",
-            label: "Object",
-          },
-          {
-            value: "object[]",
-            label: "Array of Objects",
-          },
-          {
-            value: "primitive",
-            label: "Primitive Value (string, number, boolean)",
-          },
-          {
-            value: "primitive[]",
-            label: "Array of Primitive Values",
-          },
-        ]}
-        required
-      />
-      {schema.type === "primitive[]" || schema.type === "primitive" ? (
+      {!lockedPrimitive && (
+        <SelectField
+          label="Type"
+          labelClassName="font-weight-bold text-dark"
+          value={schema.type}
+          sort={false}
+          onChange={(type) =>
+            setSchema({
+              ...schema,
+              type: type as SimpleSchema["type"],
+            })
+          }
+          options={[
+            {
+              value: "object",
+              label: "Object",
+            },
+            {
+              value: "object[]",
+              label: "Array of Objects",
+            },
+            {
+              value: "primitive",
+              label: "Primitive Value (string, number, boolean)",
+            },
+            {
+              value: "primitive[]",
+              label: "Array of Primitive Values",
+            },
+          ]}
+          required
+        />
+      )}
+      {lockedPrimitive ||
+      schema.type === "primitive[]" ||
+      schema.type === "primitive" ? (
         <div className="form-group">
           <label className="font-weight-bold text-dark">
-            {schema.type === "primitive" ? "Primitive Value" : "Array Items"}
+            {schema.type === "primitive[]" ? "Array Items" : "Primitive Value"}
           </label>
           <div className="appbox p-3 bg-light">
             <EditSchemaField
               i={0}
+              valueType={valueType}
               value={
                 schema.fields[0] || {
                   key: "",
@@ -443,9 +455,28 @@ export default function EditSchemaModal({
   defaultEnable,
   onEnable,
 }: Props) {
-  const defaultSimpleSchema = feature.jsonSchema?.simple?.fields?.length
+  const valueType = feature.valueType;
+  const defaultSimpleSchema: SimpleSchema = feature.jsonSchema?.simple?.fields
+    ?.length
     ? feature.jsonSchema.simple
-    : inferSimpleSchemaFromValue(feature.defaultValue);
+    : valueType === "string" || valueType === "number"
+      ? {
+          // String/number flags hold a single primitive value
+          type: "primitive",
+          fields: [
+            {
+              key: "",
+              type: valueType === "string" ? "string" : "float",
+              required: true,
+              default: "",
+              description: "",
+              enum: [],
+              min: 0,
+              max: valueType === "string" ? 256 : 100,
+            },
+          ],
+        }
+      : inferSimpleSchemaFromValue(feature.defaultValue);
 
   const defaultJSONSchema = feature.jsonSchema?.schema || "{}";
 
@@ -534,6 +565,10 @@ export default function EditSchemaModal({
             );
           }
         }
+
+        // Reject schemas that don't make sense for the feature's value type
+        // (e.g. an object schema on a number flag).
+        assertSchemaMatchesValueType(value, feature.valueType);
 
         const body: Record<string, unknown> = {
           ...value,
@@ -626,6 +661,7 @@ export default function EditSchemaModal({
             <EditSimpleSchema
               schema={form.watch("simple")}
               setSchema={(v) => form.setValue("simple", v)}
+              valueType={valueType}
             />
           ) : (
             <CodeTextArea

--- a/packages/front-end/components/Features/FeatureModal/FeatureKeyField.tsx
+++ b/packages/front-end/components/Features/FeatureModal/FeatureKeyField.tsx
@@ -9,7 +9,7 @@ const FeatureKeyField: FC<{
   <Field
     label="Feature Key"
     {...keyField}
-    pattern="^[a-zA-Z0-9_.:|-]+$"
+    pattern="^[a-zA-Z0-9_.:\|\-]+$"
     placeholder={useOrgSettings().featureKeyExample || "my-feature"}
     required
     title="Only letters, numbers, and the characters '_-.:|' allowed. No spaces."

--- a/packages/front-end/components/Features/FeatureValidationTab.tsx
+++ b/packages/front-end/components/Features/FeatureValidationTab.tsx
@@ -272,9 +272,9 @@ function CustomHooksTable({
         <TableHeader>
           <TableRow>
             <TableColumnHeader>Name</TableColumnHeader>
-            <TableColumnHeader>Type</TableColumnHeader>
-            <TableColumnHeader>Scope</TableColumnHeader>
-            <TableColumnHeader>Incremental</TableColumnHeader>
+            <TableColumnHeader width="200px">Type</TableColumnHeader>
+            <TableColumnHeader width="150px">Scope</TableColumnHeader>
+            <TableColumnHeader width="100px">Incremental</TableColumnHeader>
             <TableColumnHeader style={{ width: 50 }} />
           </TableRow>
         </TableHeader>

--- a/packages/front-end/components/Features/FeatureValidationTab.tsx
+++ b/packages/front-end/components/Features/FeatureValidationTab.tsx
@@ -1,0 +1,212 @@
+import { FeatureInterface } from "shared/types/feature";
+import { CustomHookInterface } from "shared/validators";
+import { MinimalFeatureRevisionInterface } from "shared/types/feature-revision";
+import { useState } from "react";
+import { Box, Flex } from "@radix-ui/themes";
+import { useAuth } from "@/services/auth";
+import { useUser } from "@/services/UserContext";
+import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import useApi from "@/hooks/useApi";
+import { isCloud } from "@/services/env";
+import Frame from "@/ui/Frame";
+import Heading from "@/ui/Heading";
+import Button from "@/ui/Button";
+import Callout from "@/ui/Callout";
+import MoreMenu from "@/components/Dropdown/MoreMenu";
+import DeleteButton from "@/components/DeleteButton/DeleteButton";
+import JSONValidation from "@/components/Features/JSONValidation";
+import CustomHookModal from "@/components/Features/CustomHookModal";
+
+export default function FeatureValidationTab({
+  feature,
+  mutate,
+  setVersion,
+  revisionList,
+}: {
+  feature: FeatureInterface;
+  mutate: () => void;
+  setVersion?: (version: number) => void;
+  revisionList?: MinimalFeatureRevisionInterface[];
+}) {
+  return (
+    <div className="contents container-fluid pagecontents">
+      {/* JSON / simple schema validation (not applicable to boolean flags) */}
+      {feature.valueType !== "boolean" && (
+        <Frame mb="4" px="6" py="4">
+          <JSONValidation
+            feature={feature}
+            mutate={mutate}
+            setVersion={setVersion}
+            revisionList={revisionList || []}
+          />
+        </Frame>
+      )}
+
+      {/* Custom Hooks are self-hosted only */}
+      {!isCloud() && (
+        <Frame mb="4" px="6" py="4">
+          <CustomHooksSection feature={feature} />
+        </Frame>
+      )}
+    </div>
+  );
+}
+
+function CustomHooksSection({ feature }: { feature: FeatureInterface }) {
+  const { hasCommercialFeature, settings } = useUser();
+  const permissionsUtil = usePermissionsUtil();
+  const { apiCall } = useAuth();
+  const [modalData, setModalData] = useState<null | true | CustomHookInterface>(
+    null,
+  );
+
+  const hasCustomHooks = hasCommercialFeature("custom-hooks");
+
+  const { data, mutate } = useApi<{ customHooks: CustomHookInterface[] }>(
+    "/custom-hooks",
+    { shouldRun: () => hasCustomHooks },
+  );
+
+  const canManage = permissionsUtil.canManageFeatureCustomHooks(
+    feature,
+    !!settings.allowPerFeatureCustomHooks,
+  );
+
+  const allHooks = data?.customHooks || [];
+  // Global/project hooks that also apply to this feature (read-only here)
+  const inheritedHooks = allHooks.filter(
+    (h) =>
+      !h.entityType &&
+      (!h.projects.length || h.projects.includes(feature.project || "")),
+  );
+  // Hooks scoped specifically to this feature
+  const featureHooks = allHooks.filter(
+    (h) => h.entityType === "feature" && h.entityId === feature.id,
+  );
+
+  return (
+    <Box>
+      {modalData && (
+        <CustomHookModal
+          current={modalData === true ? undefined : modalData}
+          feature={feature}
+          close={() => setModalData(null)}
+          onSave={() => mutate()}
+        />
+      )}
+      <Flex align="center" gap="1" mb="1">
+        <Heading as="h3" size="medium" mb="0">
+          Custom Hooks
+        </Heading>
+        {hasCustomHooks && canManage && (
+          <div className="ml-auto">
+            <Button onClick={() => setModalData(true)}>Add Custom Hook</Button>
+          </div>
+        )}
+      </Flex>
+      <Box mb="3">
+        <em className="text-muted">
+          Run sandboxed JavaScript validation before this feature is saved.
+        </em>
+      </Box>
+
+      {!hasCustomHooks ? (
+        <Callout status="info">
+          Custom Hooks require an Enterprise plan.
+        </Callout>
+      ) : (
+        <>
+          <Heading as="h4" size="small" mb="1">
+            Scoped to this feature
+          </Heading>
+          {featureHooks.length === 0 ? (
+            <p className="text-muted">No hooks scoped to this feature yet.</p>
+          ) : (
+            <table className="gbtable table appbox">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Enabled</th>
+                  {canManage && <th style={{ width: 50 }}></th>}
+                </tr>
+              </thead>
+              <tbody>
+                {featureHooks.map((hook) => (
+                  <tr key={hook.id}>
+                    <td data-title="Name">{hook.name}</td>
+                    <td data-title="Type">{hook.hook}</td>
+                    <td data-title="Enabled">{hook.enabled ? "Yes" : "No"}</td>
+                    {canManage && (
+                      <td>
+                        <MoreMenu>
+                          <a
+                            href="#"
+                            className="dropdown-item"
+                            onClick={() => setModalData(hook)}
+                          >
+                            Edit
+                          </a>
+                          <DeleteButton
+                            useIcon={false}
+                            text="Delete"
+                            displayName="custom hook"
+                            onClick={async () => {
+                              await apiCall(`/custom-hooks/${hook.id}`, {
+                                method: "DELETE",
+                              });
+                              await mutate();
+                            }}
+                            className="dropdown-item text-danger"
+                          />
+                        </MoreMenu>
+                      </td>
+                    )}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+
+          {inheritedHooks.length > 0 && (
+            <Box mt="4">
+              <Heading as="h4" size="small" mb="1">
+                Inherited (global &amp; project)
+              </Heading>
+              <p className="text-muted">
+                These hooks apply to this feature but are managed in Settings →
+                Custom Hooks.
+              </p>
+              <table className="gbtable table appbox">
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Type</th>
+                    <th>Scope</th>
+                    <th>Enabled</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {inheritedHooks.map((hook) => (
+                    <tr key={hook.id}>
+                      <td data-title="Name">{hook.name}</td>
+                      <td data-title="Type">{hook.hook}</td>
+                      <td data-title="Scope">
+                        {hook.projects.length
+                          ? "Specific projects"
+                          : "All projects"}
+                      </td>
+                      <td data-title="Enabled">
+                        {hook.enabled ? "Yes" : "No"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </Box>
+          )}
+        </>
+      )}
+    </Box>
+  );
+}

--- a/packages/front-end/components/Features/FeatureValidationTab.tsx
+++ b/packages/front-end/components/Features/FeatureValidationTab.tsx
@@ -5,8 +5,8 @@ import {
   MinimalFeatureRevisionInterface,
 } from "shared/types/feature-revision";
 import { useMemo, useState } from "react";
-import { Box, Flex, IconButton } from "@radix-ui/themes";
-import { PiCode } from "react-icons/pi";
+import { Box, Flex } from "@radix-ui/themes";
+import { PiArrowSquareOut } from "react-icons/pi";
 import { useAuth } from "@/services/auth";
 import { useUser } from "@/services/UserContext";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
@@ -15,7 +15,6 @@ import { isCloud } from "@/services/env";
 import Frame from "@/ui/Frame";
 import Heading from "@/ui/Heading";
 import Button from "@/ui/Button";
-import Callout from "@/ui/Callout";
 import Table, {
   TableHeader,
   TableBody,
@@ -31,7 +30,9 @@ import Code from "@/components/SyntaxHighlighting/Code";
 import JSONValidation from "@/components/Features/JSONValidation";
 import CustomHookModal from "@/components/Features/CustomHookModal";
 import Badge from "@/ui/Badge";
-import Link from "@/ui/Link";
+import PremiumCallout from "@/ui/PremiumCallout";
+import Text from "@/ui/Text";
+import LinkButton from "@/ui/LinkButton";
 
 export default function FeatureValidationTab({
   feature,
@@ -121,11 +122,7 @@ function CustomHooksSection({
 }) {
   const { hasCommercialFeature } = useUser();
   const permissionsUtil = usePermissionsUtil();
-  const { apiCall } = useAuth();
   const [modalData, setModalData] = useState<null | true | CustomHookInterface>(
-    null,
-  );
-  const [viewCodeHook, setViewCodeHook] = useState<CustomHookInterface | null>(
     null,
   );
 
@@ -168,27 +165,9 @@ function CustomHooksSection({
           onSave={() => mutate()}
         />
       )}
-      {viewCodeHook && (
-        <CustomHookCodeModal
-          hook={viewCodeHook}
-          close={() => setViewCodeHook(null)}
-        />
-      )}
-      <Flex align="center" gap="1" mb="1">
-        <Heading as="h3" size="medium" mb="0">
-          Custom Hooks
-        </Heading>
-        <div className="ml-auto">
-          <Tooltip body={disableReason} shouldDisplay={!!disableReason}>
-            <Button
-              onClick={() => setModalData(true)}
-              disabled={!hasAccessToCustomHooks || !canManage}
-            >
-              Add Custom Hook
-            </Button>
-          </Tooltip>
-        </div>
-      </Flex>
+      <Heading as="h3" size="medium" mb="1">
+        Custom Hooks
+      </Heading>
       <Box mb="3">
         <em className="text-muted">
           Run sandboxed JavaScript validation before this feature is saved.
@@ -196,108 +175,188 @@ function CustomHooksSection({
       </Box>
 
       {!hasAccessToCustomHooks ? (
-        <Callout status="info">
+        <PremiumCallout
+          commercialFeature="custom-hooks"
+          id="custom-hooks-validation-tab"
+        >
           Custom Hooks require an Enterprise plan.
-        </Callout>
-      ) : applicableHooks.length === 0 ? (
-        <p className="text-muted">No custom hooks apply to this feature yet.</p>
+        </PremiumCallout>
       ) : (
-        <Table variant="list" stickyHeader roundedCorners>
-          <TableHeader>
-            <TableRow>
-              <TableColumnHeader>Name</TableColumnHeader>
-              <TableColumnHeader>Type</TableColumnHeader>
-              <TableColumnHeader>Scope</TableColumnHeader>
-              <TableColumnHeader>Incremental</TableColumnHeader>
-              <TableColumnHeader style={{ width: canManage ? 80 : 40 }} />
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {applicableHooks.map((hook) => {
-              const featureScoped = isFeatureScopedHook(hook, feature);
-              return (
-                <TableRow key={hook.id}>
-                  <TableCell>
-                    {hook.name}
-                    {!hook.enabled ? (
-                      <Badge color="gray" label="Disabled" />
-                    ) : null}
-                  </TableCell>
-                  <TableCell>{hook.hook}</TableCell>
-                  <TableCell>{getHookScopeLabel(hook, feature)}</TableCell>
-                  <TableCell>
-                    {hook.incrementalChangesOnly ? "Yes" : "No"}
-                  </TableCell>
-                  <TableCell>
-                    <Flex align="center" justify="end" gap="1">
-                      <Tooltip body="View code" usePortal>
-                        <IconButton
-                          variant="ghost"
-                          color="gray"
-                          size="1"
-                          onClick={() => setViewCodeHook(hook)}
-                          aria-label="View hook code"
-                        >
-                          <PiCode />
-                        </IconButton>
-                      </Tooltip>
-                      {canManage && featureScoped && (
-                        <MoreMenu>
-                          <a
-                            href="#"
-                            className="dropdown-item"
-                            onClick={() => setModalData(hook)}
-                          >
-                            Edit
-                          </a>
-                          <a
-                            href="#"
-                            className="dropdown-item"
-                            onClick={async (e) => {
-                              e.preventDefault();
-                              await apiCall(`/custom-hooks/${hook.id}`, {
-                                method: "PUT",
-                                body: JSON.stringify({
-                                  enabled: !hook.enabled,
-                                }),
-                              });
-                              await mutate();
-                            }}
-                          >
-                            {hook.enabled ? "Disable" : "Enable"}
-                          </a>
-                          <DeleteButton
-                            useIcon={false}
-                            text="Delete"
-                            displayName="custom hook"
-                            onClick={async () => {
-                              await apiCall(`/custom-hooks/${hook.id}`, {
-                                method: "DELETE",
-                              });
-                              await mutate();
-                            }}
-                            className="dropdown-item text-danger"
-                          />
-                        </MoreMenu>
-                      )}
-                    </Flex>
-                  </TableCell>
-                </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
-      )}
-      {hasAccessToCustomHooks && (
-        <Box mt="3">
-          <Callout status="info">
-            Admins can manage global and project-scoped hooks in{" "}
-            <Link href="/settings/custom-hooks">
-              Settings &gt; Custom Hooks
-            </Link>
-          </Callout>
-        </Box>
+        <>
+          <Flex align="center" gap="1" mb="1">
+            <Heading as="h4" size="small" mb="0">
+              Feature-specific Hooks
+            </Heading>
+            <div className="ml-auto">
+              <Tooltip body={disableReason} shouldDisplay={!!disableReason}>
+                <Button
+                  onClick={() => setModalData(true)}
+                  disabled={!hasAccessToCustomHooks || !canManage}
+                >
+                  Add Feature Hook
+                </Button>
+              </Tooltip>
+            </div>
+          </Flex>
+          <CustomHooksTable
+            hooks={applicableHooks.filter((hook) => !!hook.entityId)}
+            feature={feature}
+            canManage={canManage}
+            setModalData={setModalData}
+            mutate={mutate}
+          />
+
+          <Flex align="center" gap="1" mb="1" mt="5" pt="5">
+            <Heading as="h4" size="small" mb="0">
+              Global/Project Hooks
+            </Heading>
+            <div className="ml-auto">
+              <LinkButton
+                href="/settings/custom-hooks"
+                variant="soft"
+                disabled={!hasAccessToCustomHooks || !canManage}
+              >
+                Manage in Settings <PiArrowSquareOut />
+              </LinkButton>
+            </div>
+          </Flex>
+
+          <CustomHooksTable
+            hooks={applicableHooks.filter((hook) => !hook.entityId)}
+            feature={feature}
+            canManage={canManage}
+            setModalData={setModalData}
+            mutate={mutate}
+          />
+        </>
       )}
     </Box>
+  );
+}
+
+function CustomHooksTable({
+  hooks,
+  feature,
+  canManage,
+  mutate,
+  setModalData,
+}: {
+  hooks: CustomHookInterface[];
+  feature: FeatureInterface;
+  canManage: boolean;
+  setModalData: (hook: CustomHookInterface) => void;
+  mutate: () => void;
+}) {
+  const { apiCall } = useAuth();
+  const [viewCodeHook, setViewCodeHook] = useState<CustomHookInterface | null>(
+    null,
+  );
+
+  if (!hooks.length) {
+    return (
+      <Text color="text-low">
+        <em>No custom hooks yet.</em>
+      </Text>
+    );
+  }
+
+  return (
+    <>
+      {viewCodeHook && (
+        <CustomHookCodeModal
+          hook={viewCodeHook}
+          close={() => setViewCodeHook(null)}
+        />
+      )}
+      <Table variant="list" stickyHeader roundedCorners>
+        <TableHeader>
+          <TableRow>
+            <TableColumnHeader>Name</TableColumnHeader>
+            <TableColumnHeader>Type</TableColumnHeader>
+            <TableColumnHeader>Scope</TableColumnHeader>
+            <TableColumnHeader>Incremental</TableColumnHeader>
+            <TableColumnHeader style={{ width: 50 }} />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {hooks.map((hook) => {
+            const featureScoped = isFeatureScopedHook(hook, feature);
+            return (
+              <TableRow key={hook.id}>
+                <TableCell>
+                  {hook.name}
+                  {!hook.enabled ? (
+                    <Badge color="gray" label="Disabled" />
+                  ) : null}
+                </TableCell>
+                <TableCell>{hook.hook}</TableCell>
+                <TableCell>{getHookScopeLabel(hook, feature)}</TableCell>
+                <TableCell>
+                  {hook.incrementalChangesOnly ? "Yes" : "No"}
+                </TableCell>
+                <TableCell>
+                  <MoreMenu>
+                    <a
+                      href="#"
+                      className="dropdown-item"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setViewCodeHook(hook);
+                      }}
+                    >
+                      Preview Code
+                    </a>
+                    {canManage && featureScoped && (
+                      <a
+                        href="#"
+                        className="dropdown-item"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          setModalData(hook);
+                        }}
+                      >
+                        Edit
+                      </a>
+                    )}
+                    {canManage && featureScoped && (
+                      <a
+                        href="#"
+                        className="dropdown-item"
+                        onClick={async (e) => {
+                          e.preventDefault();
+                          await apiCall(`/custom-hooks/${hook.id}`, {
+                            method: "PUT",
+                            body: JSON.stringify({
+                              enabled: !hook.enabled,
+                            }),
+                          });
+                          await mutate();
+                        }}
+                      >
+                        {hook.enabled ? "Disable" : "Enable"}
+                      </a>
+                    )}
+                    {canManage && featureScoped && (
+                      <DeleteButton
+                        useIcon={false}
+                        text="Delete"
+                        displayName="custom hook"
+                        onClick={async () => {
+                          await apiCall(`/custom-hooks/${hook.id}`, {
+                            method: "DELETE",
+                          });
+                          await mutate();
+                        }}
+                        className="dropdown-item text-danger"
+                      />
+                    )}
+                  </MoreMenu>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </>
   );
 }

--- a/packages/front-end/components/Features/FeatureValidationTab.tsx
+++ b/packages/front-end/components/Features/FeatureValidationTab.tsx
@@ -1,8 +1,12 @@
 import { FeatureInterface } from "shared/types/feature";
 import { CustomHookInterface } from "shared/validators";
-import { MinimalFeatureRevisionInterface } from "shared/types/feature-revision";
-import { useState } from "react";
-import { Box, Flex } from "@radix-ui/themes";
+import {
+  FeatureRevisionInterface,
+  MinimalFeatureRevisionInterface,
+} from "shared/types/feature-revision";
+import { useMemo, useState } from "react";
+import { Box, Flex, IconButton } from "@radix-ui/themes";
+import { PiCode } from "react-icons/pi";
 import { useAuth } from "@/services/auth";
 import { useUser } from "@/services/UserContext";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
@@ -12,18 +16,32 @@ import Frame from "@/ui/Frame";
 import Heading from "@/ui/Heading";
 import Button from "@/ui/Button";
 import Callout from "@/ui/Callout";
+import Table, {
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableColumnHeader,
+  TableCell,
+} from "@/ui/Table";
+import ModalStandard from "@/ui/Modal/Patterns/ModalStandard";
 import MoreMenu from "@/components/Dropdown/MoreMenu";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
+import Tooltip from "@/components/Tooltip/Tooltip";
+import Code from "@/components/SyntaxHighlighting/Code";
 import JSONValidation from "@/components/Features/JSONValidation";
 import CustomHookModal from "@/components/Features/CustomHookModal";
+import Badge from "@/ui/Badge";
+import Link from "@/ui/Link";
 
 export default function FeatureValidationTab({
   feature,
+  revision,
   mutate,
   setVersion,
   revisionList,
 }: {
   feature: FeatureInterface;
+  revision: FeatureRevisionInterface;
   mutate: () => void;
   setVersion?: (version: number) => void;
   revisionList?: MinimalFeatureRevisionInterface[];
@@ -45,44 +63,99 @@ export default function FeatureValidationTab({
       {/* Custom Hooks are self-hosted only */}
       {!isCloud() && (
         <Frame mb="4" px="6" py="4">
-          <CustomHooksSection feature={feature} />
+          <CustomHooksSection feature={feature} revision={revision} />
         </Frame>
       )}
     </div>
   );
 }
 
-function CustomHooksSection({ feature }: { feature: FeatureInterface }) {
-  const { hasCommercialFeature, settings } = useUser();
+function getHookScopeLabel(
+  hook: CustomHookInterface,
+  feature: FeatureInterface,
+): string {
+  if (hook.entityType === "feature" && hook.entityId === feature.id) {
+    return "Feature";
+  }
+  if (hook.projects.length) {
+    return "Project";
+  }
+  return "Global";
+}
+
+function isFeatureScopedHook(
+  hook: CustomHookInterface,
+  feature: FeatureInterface,
+): boolean {
+  return hook.entityType === "feature" && hook.entityId === feature.id;
+}
+
+function CustomHookCodeModal({
+  hook,
+  close,
+}: {
+  hook: CustomHookInterface;
+  close: () => void;
+}) {
+  return (
+    <ModalStandard
+      open
+      header={hook.name}
+      subheader={hook.hook}
+      close={close}
+      closeCta="Close"
+      size="lg"
+      trackingEventModalType=""
+    >
+      <Code language="javascript" code={hook.code} />
+    </ModalStandard>
+  );
+}
+
+function CustomHooksSection({
+  feature,
+  revision,
+}: {
+  feature: FeatureInterface;
+  revision: FeatureRevisionInterface;
+}) {
+  const { hasCommercialFeature } = useUser();
   const permissionsUtil = usePermissionsUtil();
   const { apiCall } = useAuth();
   const [modalData, setModalData] = useState<null | true | CustomHookInterface>(
     null,
   );
+  const [viewCodeHook, setViewCodeHook] = useState<CustomHookInterface | null>(
+    null,
+  );
 
-  const hasCustomHooks = hasCommercialFeature("custom-hooks");
+  const hasAccessToCustomHooks = hasCommercialFeature("custom-hooks");
 
   const { data, mutate } = useApi<{ customHooks: CustomHookInterface[] }>(
     "/custom-hooks",
-    { shouldRun: () => hasCustomHooks },
+    { shouldRun: () => hasAccessToCustomHooks },
   );
 
-  const canManage = permissionsUtil.canManageFeatureCustomHooks(
-    feature,
-    !!settings.allowPerFeatureCustomHooks,
+  const canManage = permissionsUtil.canManageFeatureCustomHooks(feature);
+
+  const applicableHooks = useMemo(
+    () =>
+      (data?.customHooks || []).filter(
+        (h) =>
+          (h.entityType === "feature" && h.entityId === feature.id) ||
+          (!h.entityType &&
+            (!h.projects.length || h.projects.includes(feature.project || ""))),
+      ),
+    [data, feature.id, feature.project],
   );
 
-  const allHooks = data?.customHooks || [];
-  // Global/project hooks that also apply to this feature (read-only here)
-  const inheritedHooks = allHooks.filter(
-    (h) =>
-      !h.entityType &&
-      (!h.projects.length || h.projects.includes(feature.project || "")),
-  );
-  // Hooks scoped specifically to this feature
-  const featureHooks = allHooks.filter(
-    (h) => h.entityType === "feature" && h.entityId === feature.id,
-  );
+  let disableReason = "";
+  if (!hasAccessToCustomHooks) {
+    disableReason = "Custom Hooks require an Enterprise plan.";
+  } else if (!canManage) {
+    disableReason =
+      "You don't have permission to manage custom hooks for this feature.";
+  }
 
   return (
     <Box>
@@ -90,19 +163,31 @@ function CustomHooksSection({ feature }: { feature: FeatureInterface }) {
         <CustomHookModal
           current={modalData === true ? undefined : modalData}
           feature={feature}
+          revision={revision}
           close={() => setModalData(null)}
           onSave={() => mutate()}
+        />
+      )}
+      {viewCodeHook && (
+        <CustomHookCodeModal
+          hook={viewCodeHook}
+          close={() => setViewCodeHook(null)}
         />
       )}
       <Flex align="center" gap="1" mb="1">
         <Heading as="h3" size="medium" mb="0">
           Custom Hooks
         </Heading>
-        {hasCustomHooks && canManage && (
-          <div className="ml-auto">
-            <Button onClick={() => setModalData(true)}>Add Custom Hook</Button>
-          </div>
-        )}
+        <div className="ml-auto">
+          <Tooltip body={disableReason} shouldDisplay={!!disableReason}>
+            <Button
+              onClick={() => setModalData(true)}
+              disabled={!hasAccessToCustomHooks || !canManage}
+            >
+              Add Custom Hook
+            </Button>
+          </Tooltip>
+        </div>
       </Flex>
       <Box mb="3">
         <em className="text-muted">
@@ -110,35 +195,53 @@ function CustomHooksSection({ feature }: { feature: FeatureInterface }) {
         </em>
       </Box>
 
-      {!hasCustomHooks ? (
+      {!hasAccessToCustomHooks ? (
         <Callout status="info">
           Custom Hooks require an Enterprise plan.
         </Callout>
+      ) : applicableHooks.length === 0 ? (
+        <p className="text-muted">No custom hooks apply to this feature yet.</p>
       ) : (
-        <>
-          <Heading as="h4" size="small" mb="1">
-            Scoped to this feature
-          </Heading>
-          {featureHooks.length === 0 ? (
-            <p className="text-muted">No hooks scoped to this feature yet.</p>
-          ) : (
-            <table className="gbtable table appbox">
-              <thead>
-                <tr>
-                  <th>Name</th>
-                  <th>Type</th>
-                  <th>Enabled</th>
-                  {canManage && <th style={{ width: 50 }}></th>}
-                </tr>
-              </thead>
-              <tbody>
-                {featureHooks.map((hook) => (
-                  <tr key={hook.id}>
-                    <td data-title="Name">{hook.name}</td>
-                    <td data-title="Type">{hook.hook}</td>
-                    <td data-title="Enabled">{hook.enabled ? "Yes" : "No"}</td>
-                    {canManage && (
-                      <td>
+        <Table variant="list" stickyHeader roundedCorners>
+          <TableHeader>
+            <TableRow>
+              <TableColumnHeader>Name</TableColumnHeader>
+              <TableColumnHeader>Type</TableColumnHeader>
+              <TableColumnHeader>Scope</TableColumnHeader>
+              <TableColumnHeader>Incremental</TableColumnHeader>
+              <TableColumnHeader style={{ width: canManage ? 80 : 40 }} />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {applicableHooks.map((hook) => {
+              const featureScoped = isFeatureScopedHook(hook, feature);
+              return (
+                <TableRow key={hook.id}>
+                  <TableCell>
+                    {hook.name}
+                    {!hook.enabled ? (
+                      <Badge color="gray" label="Disabled" />
+                    ) : null}
+                  </TableCell>
+                  <TableCell>{hook.hook}</TableCell>
+                  <TableCell>{getHookScopeLabel(hook, feature)}</TableCell>
+                  <TableCell>
+                    {hook.incrementalChangesOnly ? "Yes" : "No"}
+                  </TableCell>
+                  <TableCell>
+                    <Flex align="center" justify="end" gap="1">
+                      <Tooltip body="View code" usePortal>
+                        <IconButton
+                          variant="ghost"
+                          color="gray"
+                          size="1"
+                          onClick={() => setViewCodeHook(hook)}
+                          aria-label="View hook code"
+                        >
+                          <PiCode />
+                        </IconButton>
+                      </Tooltip>
+                      {canManage && featureScoped && (
                         <MoreMenu>
                           <a
                             href="#"
@@ -146,6 +249,22 @@ function CustomHooksSection({ feature }: { feature: FeatureInterface }) {
                             onClick={() => setModalData(hook)}
                           >
                             Edit
+                          </a>
+                          <a
+                            href="#"
+                            className="dropdown-item"
+                            onClick={async (e) => {
+                              e.preventDefault();
+                              await apiCall(`/custom-hooks/${hook.id}`, {
+                                method: "PUT",
+                                body: JSON.stringify({
+                                  enabled: !hook.enabled,
+                                }),
+                              });
+                              await mutate();
+                            }}
+                          >
+                            {hook.enabled ? "Disable" : "Enable"}
                           </a>
                           <DeleteButton
                             useIcon={false}
@@ -160,52 +279,24 @@ function CustomHooksSection({ feature }: { feature: FeatureInterface }) {
                             className="dropdown-item text-danger"
                           />
                         </MoreMenu>
-                      </td>
-                    )}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
-
-          {inheritedHooks.length > 0 && (
-            <Box mt="4">
-              <Heading as="h4" size="small" mb="1">
-                Inherited (global &amp; project)
-              </Heading>
-              <p className="text-muted">
-                These hooks apply to this feature but are managed in Settings →
-                Custom Hooks.
-              </p>
-              <table className="gbtable table appbox">
-                <thead>
-                  <tr>
-                    <th>Name</th>
-                    <th>Type</th>
-                    <th>Scope</th>
-                    <th>Enabled</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {inheritedHooks.map((hook) => (
-                    <tr key={hook.id}>
-                      <td data-title="Name">{hook.name}</td>
-                      <td data-title="Type">{hook.hook}</td>
-                      <td data-title="Scope">
-                        {hook.projects.length
-                          ? "Specific projects"
-                          : "All projects"}
-                      </td>
-                      <td data-title="Enabled">
-                        {hook.enabled ? "Yes" : "No"}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </Box>
-          )}
-        </>
+                      )}
+                    </Flex>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      )}
+      {hasAccessToCustomHooks && (
+        <Box mt="3">
+          <Callout status="info">
+            Admins can manage global and project-scoped hooks in{" "}
+            <Link href="/settings/custom-hooks">
+              Settings &gt; Custom Hooks
+            </Link>
+          </Callout>
+        </Box>
       )}
     </Box>
   );

--- a/packages/front-end/components/Features/FeatureValueField.tsx
+++ b/packages/front-end/components/Features/FeatureValueField.tsx
@@ -230,10 +230,7 @@ export default function FeatureValueField({
     );
   }
 
-  // Schema-aware input for string/number flags using a "primitive" simple
-  // schema (e.g. enum dropdown, min/max constraints). These flag values are
-  // stored as raw scalars (not JSON), so we use the primitive editor directly
-  // and bypass SimpleSchemaEditor's JSON encoding.
+  // Schema-aware input for string/number flags; values are raw scalars, so bypass JSON encoding.
   if (
     validationEnabled &&
     hasJsonValidator &&
@@ -527,12 +524,7 @@ function parseNumberInput(
     : { valid: false };
 }
 
-// Number input for a numeric schema field. Keeps the in-progress text the user
-// is typing in local state instead of deriving the displayed value from the
-// parsed number on every keystroke. Deriving it would reformat intermediate
-// values — e.g. typing "1.0" becomes parseFloat("1.0") -> 1 -> "1", clobbering
-// the input (via the controlled value) before the user can finish typing
-// "1.05".
+// Keeps in-progress text in local state so typing e.g. "1.05" isn't reformatted mid-keystroke.
 function NumberSchemaField<T = unknown>({
   field,
   value,

--- a/packages/front-end/components/Features/FeatureValueField.tsx
+++ b/packages/front-end/components/Features/FeatureValueField.tsx
@@ -230,6 +230,45 @@ export default function FeatureValueField({
     );
   }
 
+  // Schema-aware input for string/number flags using a "primitive" simple
+  // schema (e.g. enum dropdown, min/max constraints). These flag values are
+  // stored as raw scalars (not JSON), so we use the primitive editor directly
+  // and bypass SimpleSchemaEditor's JSON encoding.
+  if (
+    validationEnabled &&
+    hasJsonValidator &&
+    (valueType === "string" || valueType === "number") &&
+    simpleSchema?.type === "primitive"
+  ) {
+    const field = simpleSchema.fields[0];
+    const typeMatches =
+      !!field &&
+      (valueType === "string"
+        ? field.type === "string"
+        : field.type === "integer" || field.type === "float");
+    if (field && typeMatches) {
+      return (
+        <>
+          <SimpleSchemaPrimitiveEditor
+            field={field}
+            value={
+              valueType === "number"
+                ? value === ""
+                  ? undefined
+                  : parseFloat(value)
+                : value
+            }
+            setValue={(v) => setValue(v == null ? "" : String(v))}
+            label={label}
+            showDescription={true}
+            disabled={disabled}
+          />
+          {helpText && <small className="text-muted">{helpText}</small>}
+        </>
+      );
+    }
+  }
+
   const copyButton = (
     <Tooltip body={copySuccess ? "Copied" : "Copy to clipboard"}>
       <IconButton

--- a/packages/front-end/components/Features/FeatureValueField.tsx
+++ b/packages/front-end/components/Features/FeatureValueField.tsx
@@ -4,7 +4,7 @@ import {
   SchemaField,
   SimpleSchema,
 } from "shared/types/feature";
-import { ReactElement, ReactNode, useId, useState } from "react";
+import { ReactElement, ReactNode, useEffect, useId, useState } from "react";
 import { getValidation } from "shared/util";
 import { FaMagic, FaRegTrashAlt } from "react-icons/fa";
 import stringify from "json-stringify-pretty-compact";
@@ -500,29 +500,97 @@ function SimpleSchemaPrimitiveEditor<T = unknown>({
     case "integer":
     case "float":
       return (
-        <Field
-          containerClassName={containerClassName}
-          labelClassName={labelClassName}
+        <NumberSchemaField
+          field={field}
+          value={value}
+          setValue={setValue}
           label={label}
-          value={(value ?? "") + ""}
-          onChange={(e) => {
-            setValue(
-              (e.target.value === ""
-                ? undefined
-                : parseFloat(e.target.value)) as T,
-            );
-          }}
-          type="number"
-          step={field.type === "integer" ? "1" : "any"}
-          min={field.min}
-          max={field.max}
-          required={field.required}
-          style={{ minWidth: 80 }}
-          disabled={(!field.required && !isset) || disabled}
+          labelClassName={labelClassName}
+          containerClassName={containerClassName}
           helpText={helpText}
+          disabled={(!field.required && !isset) || disabled}
         />
       );
   }
+}
+
+function parseNumberInput(
+  value: string,
+): { valid: true; value: number | undefined } | { valid: false } {
+  if (value === "") {
+    return { valid: true, value: undefined };
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed)
+    ? { valid: true, value: parsed }
+    : { valid: false };
+}
+
+// Number input for a numeric schema field. Keeps the in-progress text the user
+// is typing in local state instead of deriving the displayed value from the
+// parsed number on every keystroke. Deriving it would reformat intermediate
+// values — e.g. typing "1.0" becomes parseFloat("1.0") -> 1 -> "1", clobbering
+// the input (via the controlled value) before the user can finish typing
+// "1.05".
+function NumberSchemaField<T = unknown>({
+  field,
+  value,
+  setValue,
+  label,
+  labelClassName,
+  containerClassName,
+  helpText,
+  disabled = false,
+}: {
+  field: SchemaField;
+  value: T;
+  setValue: (value: T) => void;
+  label?: ReactNode;
+  labelClassName?: string;
+  containerClassName?: string;
+  helpText?: ReactNode;
+  disabled?: boolean;
+}): ReactElement {
+  const numericValue =
+    (value ?? null) === null ? undefined : (value as unknown as number);
+
+  const [text, setText] = useState(
+    numericValue === undefined ? "" : String(numericValue),
+  );
+
+  useEffect(() => {
+    setText((currentText) => {
+      const parsed = parseNumberInput(currentText);
+      if (parsed.valid && parsed.value === numericValue) return currentText;
+      return numericValue === undefined ? "" : String(numericValue);
+    });
+  }, [numericValue]);
+
+  return (
+    <Field
+      containerClassName={containerClassName}
+      labelClassName={labelClassName}
+      label={label}
+      value={text}
+      onChange={(e) => {
+        const raw = e.target.value;
+        const parsed = parseNumberInput(raw);
+        setText(raw);
+        if (parsed.valid) {
+          setValue(parsed.value as T);
+        }
+      }}
+      type="number"
+      step={field.type === "integer" ? "1" : "any"}
+      min={field.min}
+      max={field.max}
+      required={field.required}
+      style={{ minWidth: 80 }}
+      disabled={disabled}
+      helpText={helpText}
+    />
+  );
 }
 
 function SimpleSchemaEditor({

--- a/packages/front-end/components/Features/FeaturesHeader.tsx
+++ b/packages/front-end/components/Features/FeaturesHeader.tsx
@@ -519,8 +519,7 @@ export default function FeaturesHeader({
                   <TabsTrigger value="test">Simulate</TabsTrigger>
                   <TabsTrigger value="stats">Code Refs</TabsTrigger>
                   <TabsTrigger value="diagnostics">Diagnostics</TabsTrigger>
-                  {/* Custom Hooks are self-hosted only, and boolean flags can't
-                  have a JSON schema, so there's nothing to validate on Cloud */}
+                  {/* Hooks are self-hosted only and boolean flags have no schema, so Cloud booleans have nothing to validate */}
                   {!(isCloud() && feature.valueType === "boolean") && (
                     <TabsTrigger value="validation">Validation</TabsTrigger>
                   )}

--- a/packages/front-end/components/Features/FeaturesHeader.tsx
+++ b/packages/front-end/components/Features/FeaturesHeader.tsx
@@ -17,6 +17,7 @@ import Modal from "@/components/Modal";
 import FeatureStatusBadge from "@/components/Features/FeatureStatusBadge";
 import { getEnabledEnvironments, useEnvironments } from "@/services/features";
 import { useAuth } from "@/services/auth";
+import { isCloud } from "@/services/env";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import SortedTags from "@/components/Tags/SortedTags";
@@ -518,6 +519,11 @@ export default function FeaturesHeader({
                   <TabsTrigger value="test">Simulate</TabsTrigger>
                   <TabsTrigger value="stats">Code Refs</TabsTrigger>
                   <TabsTrigger value="diagnostics">Diagnostics</TabsTrigger>
+                  {/* Custom Hooks are self-hosted only, and boolean flags can't
+                  have a JSON schema, so there's nothing to validate on Cloud */}
+                  {!(isCloud() && feature.valueType === "boolean") && (
+                    <TabsTrigger value="validation">Validation</TabsTrigger>
+                  )}
                   {/* Slot: revisionAndSettingsGroup portal mounts here when scrolled */}
                   <Box style={{ marginLeft: "auto", alignSelf: "center" }}>
                     <div ref={tabsSlotRef} />

--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -103,7 +103,6 @@ import Text from "@/ui/Text";
 import Heading from "@/ui/Heading";
 import Metadata from "@/ui/Metadata";
 import Link from "@/ui/Link";
-import JSONValidation from "@/components/Features/JSONValidation";
 import {
   PrerequisiteStateResult,
   usePrerequisiteStates,
@@ -1835,17 +1834,6 @@ export default function FeaturesOverview({
                 )}
               </>
             )}
-          </Frame>
-        )}
-
-        {feature.valueType === "json" && (
-          <Frame mb="4" px="6" py="4">
-            <JSONValidation
-              feature={feature}
-              mutate={mutate}
-              setVersion={setVersion}
-              revisionList={revisionList || []}
-            />
           </Frame>
         )}
 

--- a/packages/front-end/components/Features/JSONSchemaDescription.tsx
+++ b/packages/front-end/components/Features/JSONSchemaDescription.tsx
@@ -2,20 +2,70 @@ import Code from "@/components/SyntaxHighlighting/Code";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import { GBInfo } from "@/components/Icons";
 
+type FieldData = {
+  type: string;
+  description: string;
+  details: string;
+  enum?: string[];
+  lengthRange?: [number | undefined, number | undefined];
+  valueRange?: [number | undefined, number | undefined];
+};
+
+type FieldInfo = FieldData & {
+  key: string;
+  required?: boolean;
+};
+
+type SchemaSummary =
+  | { kind: "fields"; description: string; fields: FieldInfo[] }
+  | { kind: "primitive"; isArray: boolean; field: FieldData };
+
 export default function JSONSchemaDescription({
   jsonSchema,
 }: {
   jsonSchema: unknown;
 }) {
-  const { jsonSchemaDescription, jsonSchemaFields } =
-    getJSONSchemaSummary(jsonSchema);
+  const summary = getJSONSchemaSummary(jsonSchema);
+  if (!summary) return null;
+
+  if (summary.kind === "primitive") {
+    const { field, isArray } = summary;
+    const hasExtraDetails =
+      !!field.description || (field.details && field.details !== "{}");
+
+    return (
+      <div className="d-flex align-items-center">
+        <div className="mr-2">{getPrimitiveDescription(field, isArray)}</div>
+        {hasExtraDetails ? (
+          <Tooltip
+            body={
+              <div>
+                {field.description && (
+                  <div className="bg-light p-2 mb-1 border">
+                    {field.description}
+                  </div>
+                )}
+                {field.details && field.details !== "{}" && (
+                  <div>
+                    Other Settings:
+                    <Code language="json" code={field.details} />
+                  </div>
+                )}
+              </div>
+            }
+            tipMinWidth="300px"
+          >
+            <GBInfo />
+          </Tooltip>
+        ) : null}
+      </div>
+    );
+  }
 
   return (
     <div className="d-flex align-items-center">
-      {jsonSchemaDescription ? (
-        <div className="mr-2">{jsonSchemaDescription}</div>
-      ) : null}
-      {jsonSchemaFields.map((field) => (
+      <div className="mr-2">{summary.description}</div>
+      {summary.fields.map((field) => (
         <div key={field.key} className="mr-2 bg-light px-2 border rounded">
           <div>
             <Tooltip
@@ -39,14 +89,15 @@ export default function JSONSchemaDescription({
                   {field.valueRange && (
                     <div className="mb-1">
                       Value: Between{" "}
-                      <strong>{field.valueRange[0] || "-"}</strong> and{" "}
-                      <strong>{field.valueRange[1] || "-"}</strong>
+                      <strong>{field.valueRange[0] ?? "-"}</strong> and{" "}
+                      <strong>{field.valueRange[1] ?? "-"}</strong>
                     </div>
                   )}
                   {field.lengthRange && (
                     <div className="mb-1">
-                      Length: Between <strong>{field.lengthRange[0]}</strong>{" "}
-                      and <strong>{field.lengthRange[1]}</strong>
+                      Length: Between{" "}
+                      <strong>{field.lengthRange[0] ?? "-"}</strong> and{" "}
+                      <strong>{field.lengthRange[1] ?? "-"}</strong>
                     </div>
                   )}
                   {field.enum && field.enum.length > 0 && (
@@ -83,150 +134,186 @@ export default function JSONSchemaDescription({
   );
 }
 
-function getJSONSchemaSummary(jsonSchema: unknown) {
-  // Human-readable description of the JSON Schema validation
-  let jsonSchemaDescription = "";
-  const jsonSchemaFields: {
-    key: string;
-    required?: boolean;
-    type: string;
-    description: string;
-    details: string;
-    enum?: string[];
-    lengthRange?: [number, number];
-    valueRange?: [string, string];
-  }[] = [];
-  if (jsonSchema && typeof jsonSchema === "object") {
-    const getFieldData = (schema: unknown) => {
-      if (!schema || typeof schema !== "object") {
-        return {
-          type: "unknown",
-          description: "",
-          details: "",
-        };
-      }
+// "Value is one of "ON", "OFF"" / "Value is a float between 0 and 24"
+function getPrimitiveDescription(field: FieldData, isArray: boolean): string {
+  const noun = field.type === "number" ? "float" : field.type;
+  const constraint = getConstraintText(field);
 
-      const {
-        type,
-        description,
-        enum: values,
-        minimum,
-        maximum,
-        minLength,
-        maxLength,
-        multipleOf,
-        format,
-        ...otherDetails
-      } = schema as {
-        type?: string;
-        description?: string;
-        enum?: unknown[];
-        minimum?: unknown;
-        maxium?: unknown;
-        minLength?: number;
-        maxLength?: number;
-        multipleOf?: number;
-        format?: string;
-        [key: string]: unknown;
-      };
+  if (isArray) {
+    const itemNoun = noun === "unknown" ? "item" : noun;
+    return `Value is an array of ${itemNoun}s${
+      constraint ? `, each ${constraint}` : ""
+    }`;
+  }
 
-      let typeStr = type + "";
-      if (multipleOf) {
-        if (typeStr === "number" && multipleOf === 1) {
-          typeStr = "integer";
-        } else {
-          otherDetails["multipleOf"] = multipleOf;
-        }
-      }
+  if (field.enum && field.enum.length > 0) {
+    return `Value is ${constraint}`;
+  }
 
-      if (format && (format !== "number" || typeStr !== "integer")) {
-        otherDetails["format"] = format;
-      }
+  if (noun === "unknown") {
+    return "Value is an unknown type";
+  }
 
-      return {
-        type: typeStr || "unknown",
-        description: (description || "") + "",
-        details: JSON.stringify(otherDetails, null, 2),
-        enum: values?.length ? values.map((v) => v + "") : undefined,
-        valueRange:
-          minimum || maximum
-            ? ([minimum + "", maximum + ""] as [string, string])
-            : undefined,
-        lengthRange:
-          minLength || maxLength
-            ? ([minLength || 0, maxLength || 0] as [number, number])
-            : undefined,
-      };
+  const article = /^[aeiou]/i.test(noun) ? "an" : "a";
+  return `Value is ${article} ${noun}${constraint ? ` ${constraint}` : ""}`;
+}
+
+function getConstraintText(field: FieldData): string {
+  if (field.enum && field.enum.length > 0) {
+    return `one of ${field.enum.join(", ")}`;
+  }
+  if (field.valueRange) {
+    const [min, max] = field.valueRange;
+    if (min !== undefined && max !== undefined) {
+      return `between ${min} and ${max}`;
+    }
+    if (min !== undefined) return `of at least ${min}`;
+    if (max !== undefined) return `of at most ${max}`;
+  }
+  if (field.lengthRange) {
+    const [min, max] = field.lengthRange;
+    if (min !== undefined && max !== undefined) {
+      return `between ${min} and ${max} characters long`;
+    }
+    if (min !== undefined) return `at least ${min} characters long`;
+    if (max !== undefined) return `at most ${max} characters long`;
+  }
+  return "";
+}
+
+function getFieldData(schema: unknown): FieldData {
+  if (!schema || typeof schema !== "object") {
+    return {
+      type: "unknown",
+      description: "",
+      details: "",
     };
+  }
 
-    if (
-      "properties" in jsonSchema &&
-      jsonSchema.properties &&
-      typeof jsonSchema.properties === "object"
-    ) {
-      const required = new Set(
-        "required" in jsonSchema && Array.isArray(jsonSchema.required)
-          ? jsonSchema.required
-          : [],
-      );
-      Object.entries(jsonSchema.properties).forEach(([key, value]) => {
-        jsonSchemaFields.push({
-          key,
-          required: required.has(key),
-          ...getFieldData(value),
-        });
-      });
-      jsonSchemaDescription = "Value is an object with properties";
-    } else if (
-      "items" in jsonSchema &&
-      jsonSchema.items &&
-      typeof jsonSchema.items === "object" &&
-      !Array.isArray(jsonSchema.items)
-    ) {
-      if (
-        "properties" in jsonSchema.items &&
-        jsonSchema.items.properties &&
-        typeof jsonSchema.items.properties === "object"
-      ) {
-        const required = new Set(
-          "required" in jsonSchema.items &&
-          Array.isArray(jsonSchema.items.required)
-            ? jsonSchema.items.required
-            : [],
-        );
-        Object.entries(jsonSchema.items.properties).forEach(([key, value]) => {
-          jsonSchemaFields.push({
-            key,
-            required: required.has(key),
-            ...getFieldData(value),
-          });
-        });
-        jsonSchemaDescription = "Value is an array of objects with properties";
-      } else {
-        jsonSchemaDescription = "Value is an array of";
+  const {
+    type,
+    description,
+    enum: values,
+    minimum,
+    maximum,
+    minLength,
+    maxLength,
+    multipleOf,
+    format,
+    ...otherDetails
+  } = schema as {
+    type?: string;
+    description?: string;
+    enum?: unknown[];
+    minimum?: unknown;
+    maximum?: unknown;
+    minLength?: number;
+    maxLength?: number;
+    multipleOf?: number;
+    format?: string;
+    [key: string]: unknown;
+  };
 
-        const key =
-          "type" in jsonSchema.items ? jsonSchema.items.type + "s" : "items";
-
-        jsonSchemaFields.push({
-          key: key,
-          ...getFieldData(jsonSchema.items),
-        });
-      }
+  let typeStr = type + "";
+  if (multipleOf) {
+    if (typeStr === "number" && multipleOf === 1) {
+      typeStr = "integer";
     } else {
-      jsonSchemaDescription = "Value is a";
-
-      const key = "type" in jsonSchema ? jsonSchema.type + "" : "unknown type";
-
-      jsonSchemaFields.push({
-        key: key,
-        ...getFieldData(jsonSchema),
-      });
+      otherDetails["multipleOf"] = multipleOf;
     }
   }
 
+  if (format && (format !== "number" || typeStr !== "integer")) {
+    otherDetails["format"] = format;
+  }
+
+  const min = typeof minimum === "number" ? minimum : undefined;
+  const max = typeof maximum === "number" ? maximum : undefined;
+  if (minimum !== undefined && min === undefined) {
+    otherDetails["minimum"] = minimum;
+  }
+  if (maximum !== undefined && max === undefined) {
+    otherDetails["maximum"] = maximum;
+  }
+
   return {
-    jsonSchemaDescription,
-    jsonSchemaFields,
+    type: typeStr || "unknown",
+    description: (description || "") + "",
+    details: JSON.stringify(otherDetails, null, 2),
+    enum: values?.length
+      ? values.map((v) => (typeof v === "string" ? `"${v}"` : v + ""))
+      : undefined,
+    valueRange: min !== undefined || max !== undefined ? [min, max] : undefined,
+    lengthRange:
+      minLength !== undefined || maxLength !== undefined
+        ? [minLength, maxLength]
+        : undefined,
+  };
+}
+
+function getJSONSchemaSummary(jsonSchema: unknown): SchemaSummary | null {
+  if (!jsonSchema || typeof jsonSchema !== "object") return null;
+
+  if (
+    "properties" in jsonSchema &&
+    jsonSchema.properties &&
+    typeof jsonSchema.properties === "object"
+  ) {
+    const required = new Set(
+      "required" in jsonSchema && Array.isArray(jsonSchema.required)
+        ? jsonSchema.required
+        : [],
+    );
+    return {
+      kind: "fields",
+      description: "Value is an object with properties",
+      fields: Object.entries(jsonSchema.properties).map(([key, value]) => ({
+        key,
+        required: required.has(key),
+        ...getFieldData(value),
+      })),
+    };
+  }
+
+  if (
+    "items" in jsonSchema &&
+    jsonSchema.items &&
+    typeof jsonSchema.items === "object" &&
+    !Array.isArray(jsonSchema.items)
+  ) {
+    if (
+      "properties" in jsonSchema.items &&
+      jsonSchema.items.properties &&
+      typeof jsonSchema.items.properties === "object"
+    ) {
+      const required = new Set(
+        "required" in jsonSchema.items &&
+        Array.isArray(jsonSchema.items.required)
+          ? jsonSchema.items.required
+          : [],
+      );
+      return {
+        kind: "fields",
+        description: "Value is an array of objects with properties",
+        fields: Object.entries(jsonSchema.items.properties).map(
+          ([key, value]) => ({
+            key,
+            required: required.has(key),
+            ...getFieldData(value),
+          }),
+        ),
+      };
+    }
+    return {
+      kind: "primitive",
+      isArray: true,
+      field: getFieldData(jsonSchema.items),
+    };
+  }
+
+  return {
+    kind: "primitive",
+    isArray: false,
+    field: getFieldData(jsonSchema),
   };
 }

--- a/packages/front-end/components/Features/JSONValidation.tsx
+++ b/packages/front-end/components/Features/JSONValidation.tsx
@@ -46,8 +46,7 @@ export default function JSONValidation({
 
   const [edit, setEdit] = useState(false);
 
-  // Boolean flags can't have a validation schema. JSON, string, and number
-  // flags all can.
+  // Boolean flags can't have a validation schema; json/string/number can.
   if (feature.valueType === "boolean") return null;
 
   return (

--- a/packages/front-end/components/Features/JSONValidation.tsx
+++ b/packages/front-end/components/Features/JSONValidation.tsx
@@ -46,7 +46,9 @@ export default function JSONValidation({
 
   const [edit, setEdit] = useState(false);
 
-  if (feature.valueType !== "json") return null;
+  // Boolean flags can't have a validation schema. JSON, string, and number
+  // flags all can.
+  if (feature.valueType === "boolean") return null;
 
   return (
     <Box>
@@ -74,7 +76,7 @@ export default function JSONValidation({
       )}
       <Flex align="center" gap="1" mb="1">
         <Heading as="h3" size="medium" mb="0">
-          JSON Validation
+          Schema Validation
         </Heading>
         {hasJsonValidator && (
           <Badge

--- a/packages/front-end/components/GeneralSettings/FeatureSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/FeatureSettings.tsx
@@ -8,6 +8,7 @@ import Field from "@/components/Forms/Field";
 import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
 import SelectField from "@/components/Forms/SelectField";
 import { useEnvironments, FEATURE_RULES_ALL_ENVS } from "@/services/features";
+import { isCloud } from "@/services/env";
 import Checkbox from "@/ui/Checkbox";
 import Button from "@/ui/Button";
 import { GBInfo } from "@/components/Icons";
@@ -178,6 +179,23 @@ export default function FeatureSettings() {
               }
             />
           </Box>
+
+          {/* Custom Hooks are self-hosted only */}
+          {!isCloud() && hasCommercialFeature("custom-hooks") && (
+            <Box mb="6" width="100%">
+              <Checkbox
+                id="toggle-allowPerFeatureCustomHooks"
+                label="Allow feature editors to manage Custom Hooks for their own features"
+                description="If enabled, users who can edit a feature can create, edit, and delete Custom Hooks scoped to that feature. Global and project-scoped hooks still require the Custom Hooks admin permission."
+                value={!!form.watch("allowPerFeatureCustomHooks")}
+                setValue={(value) =>
+                  form.setValue("allowPerFeatureCustomHooks", value, {
+                    shouldDirty: true,
+                  })
+                }
+              />
+            </Box>
+          )}
 
           <Box mb="5">
             <SelectField

--- a/packages/front-end/components/GeneralSettings/FeatureSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/FeatureSettings.tsx
@@ -8,7 +8,6 @@ import Field from "@/components/Forms/Field";
 import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
 import SelectField from "@/components/Forms/SelectField";
 import { useEnvironments, FEATURE_RULES_ALL_ENVS } from "@/services/features";
-import { isCloud } from "@/services/env";
 import Checkbox from "@/ui/Checkbox";
 import Button from "@/ui/Button";
 import { GBInfo } from "@/components/Icons";
@@ -179,23 +178,6 @@ export default function FeatureSettings() {
               }
             />
           </Box>
-
-          {/* Custom Hooks are self-hosted only */}
-          {!isCloud() && hasCommercialFeature("custom-hooks") && (
-            <Box mb="6" width="100%">
-              <Checkbox
-                id="toggle-allowPerFeatureCustomHooks"
-                label="Allow feature editors to manage Custom Hooks for their own features"
-                description="If enabled, users who can edit a feature can create, edit, and delete Custom Hooks scoped to that feature. Global and project-scoped hooks still require the Custom Hooks admin permission."
-                value={!!form.watch("allowPerFeatureCustomHooks")}
-                setValue={(value) =>
-                  form.setValue("allowPerFeatureCustomHooks", value, {
-                    shouldDirty: true,
-                  })
-                }
-              />
-            </Box>
-          )}
 
           <Box mb="5">
             <SelectField

--- a/packages/front-end/pages/features/[fid].tsx
+++ b/packages/front-end/pages/features/[fid].tsx
@@ -15,12 +15,19 @@ import { useUser } from "@/services/UserContext";
 import EditTagsForm from "@/components/Tags/EditTagsForm";
 import EditFeatureInfoModal from "@/components/Features/EditFeatureInfoModal";
 import FeatureDiagnostics from "@/components/Features/FeatureDiagnostics";
+import FeatureValidationTab from "@/components/Features/FeatureValidationTab";
 import { useFeaturePageData } from "@/hooks/useFeaturePageData";
 import { useFeatureDependents } from "@/hooks/useFeatureDependents";
 import Callout from "@/ui/Callout";
 import { FeatureRevisionsContext } from "@/contexts/FeatureRevisionsContext";
 
-const featureTabs = ["overview", "stats", "test", "diagnostics"] as const;
+const featureTabs = [
+  "overview",
+  "stats",
+  "test",
+  "diagnostics",
+  "validation",
+] as const;
 export type FeatureTab = (typeof featureTabs)[number];
 
 export default function FeaturePage() {
@@ -196,6 +203,15 @@ export default function FeaturePage() {
             feature={feature}
             results={diagnosticsResults}
             setResults={setDiagnosticsResults}
+          />
+        )}
+
+        {tab === "validation" && (
+          <FeatureValidationTab
+            feature={feature}
+            mutate={refreshData}
+            setVersion={setVersion}
+            revisionList={data.revisionList}
           />
         )}
 

--- a/packages/front-end/pages/features/[fid].tsx
+++ b/packages/front-end/pages/features/[fid].tsx
@@ -209,6 +209,7 @@ export default function FeaturePage() {
         {tab === "validation" && (
           <FeatureValidationTab
             feature={feature}
+            revision={revision}
             mutate={refreshData}
             setVersion={setVersion}
             revisionList={data.revisionList}

--- a/packages/front-end/pages/settings/custom-hooks.tsx
+++ b/packages/front-end/pages/settings/custom-hooks.tsx
@@ -75,8 +75,7 @@ export default function CustomHooksPage() {
   }
 
   const allHooks = data.customHooks || [];
-  // Global/project hooks are managed here. Feature-scoped hooks are managed
-  // from each feature's Validation tab and shown read-only below.
+  // Global/project hooks managed here; feature-scoped ones on the feature's Validation tab.
   const hooks = allHooks.filter((h) => !h.entityType);
   const featureHooks = allHooks.filter((h) => h.entityType === "feature");
 

--- a/packages/front-end/pages/settings/custom-hooks.tsx
+++ b/packages/front-end/pages/settings/custom-hooks.tsx
@@ -1,19 +1,7 @@
 import React, { useState } from "react";
-import { useForm } from "react-hook-form";
-import { CustomHookInterface, CustomHookType } from "shared/validators";
-import { CreateProps } from "shared/types/base-model";
-import { Flex, Kbd, Separator, Text } from "@radix-ui/themes";
-import stringify from "json-stringify-pretty-compact";
-import { FeatureInterface } from "shared/types/feature";
-import { FeatureRevisionInterface } from "shared/types/feature-revision";
+import { CustomHookInterface } from "shared/validators";
+import { Flex } from "@radix-ui/themes";
 import { useAuth } from "@/services/auth";
-import Modal from "@/components/Modal";
-import Field from "@/components/Forms/Field";
-import SelectField from "@/components/Forms/SelectField";
-import useProjectOptions from "@/hooks/useProjectOptions";
-import MultiSelectField from "@/components/Forms/MultiSelectField";
-import CodeTextArea from "@/components/Forms/CodeTextArea";
-import Checkbox from "@/ui/Checkbox";
 import Button from "@/ui/Button";
 import useApi from "@/hooks/useApi";
 import Callout from "@/ui/Callout";
@@ -22,334 +10,7 @@ import EmptyState from "@/components/EmptyState";
 import MoreMenu from "@/components/Dropdown/MoreMenu";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
 import { isCloud } from "@/services/env";
-
-const dummyFeature: FeatureInterface = {
-  id: "new-feature",
-  organization: "org_abc123",
-  dateCreated: new Date(),
-  dateUpdated: new Date(),
-  description: "My new feature",
-  valueType: "boolean",
-  defaultValue: "false",
-  tags: [],
-  environmentSettings: {
-    production: {
-      enabled: true,
-    },
-  },
-  rules: [],
-  archived: false,
-  owner: "",
-  project: "",
-  version: 1,
-  prerequisites: [],
-  customFields: {},
-};
-const dummyRevision: FeatureRevisionInterface = {
-  organization: "org_abc123",
-  featureId: "new-feature",
-  dateCreated: new Date(),
-  dateUpdated: new Date(),
-  version: 2,
-  baseVersion: 1,
-  comment: "",
-  createdBy: {
-    type: "dashboard",
-    id: "user_123",
-    name: "User",
-    email: "user@example.com",
-  },
-  defaultValue: "false",
-  status: "draft",
-  rules: [],
-  datePublished: null,
-  publishedBy: null,
-};
-
-const hookTypes: Record<
-  CustomHookType,
-  {
-    label: string;
-    availableArguments: Record<
-      string,
-      { description: string; testValue: string }
-    >;
-    example: string;
-  }
-> = {
-  validateFeature: {
-    label: "Validate Feature",
-    availableArguments: {
-      feature: {
-        description: "The feature object being validated",
-        testValue: stringify(dummyFeature),
-      },
-    },
-    example: `\n// Block the save (hard error):\nif (!feature.description) {\n  throw new Error("Feature must have a description");\n}\n\n// Or raise a soft warning the user can acknowledge:\nif (feature.tags.length === 0) {\n  addWarning("Consider adding at least one tag");\n}`,
-  },
-  validateFeatureRevision: {
-    label: "Validate Feature Revision",
-    availableArguments: {
-      feature: {
-        description: "The feature object the revision belongs to",
-        testValue: stringify(dummyFeature),
-      },
-      revision: {
-        description: "The feature revision being validated",
-        testValue: stringify(dummyRevision),
-      },
-    },
-    example: `\n// Block the save (hard error):\nif (!revision.rules.production || revision.rules.production.length === 0) {\n  throw new Error("At least one production rule is required");\n}\n\n// Or raise a soft warning the user can acknowledge:\nif (!revision.comment) {\n  addWarning("Consider adding a comment describing this change");\n}`,
-  },
-};
-
-function CustomHooksModal({
-  close,
-  current,
-  onSave,
-}: {
-  close: () => void;
-  current?: CustomHookInterface;
-  onSave?: () => void;
-}) {
-  const form = useForm<CreateProps<CustomHookInterface>>({
-    defaultValues: {
-      name: current?.name || "",
-      hook: current?.hook || "validateFeature",
-      code: current?.code || "",
-      projects: current?.projects || [],
-      enabled: current?.enabled ?? true,
-      incrementalChangesOnly: current?.incrementalChangesOnly || false,
-    },
-  });
-
-  const { apiCall } = useAuth();
-
-  const projectOptions = useProjectOptions(() => true, current?.projects || []);
-
-  const hookType = form.watch("hook");
-  const hookTypeData = hookTypes[hookType];
-
-  const [testValues, setTestValues] = useState<Record<string, string>>(
-    Object.fromEntries(
-      Object.entries(hookTypeData.availableArguments).map(([k, v]) => [
-        k,
-        v.testValue,
-      ]),
-    ),
-  );
-  const [testResult, setTestResult] = useState<{
-    status: "" | "success" | "error";
-    returnVal?: string;
-    error?: string;
-    warnings?: string[];
-    log?: string;
-  }>({ status: "" });
-
-  const runTest = async () => {
-    const res = await apiCall<{
-      success: boolean;
-      returnVal?: string;
-      error?: string;
-      warnings?: string[];
-      log?: string;
-    }>("/custom-hooks/test", {
-      method: "POST",
-      body: JSON.stringify({
-        functionBody: form.getValues("code"),
-        functionArgs: Object.fromEntries(
-          Object.entries(testValues).map(([k, v]) => {
-            try {
-              return [k, JSON.parse(v)];
-            } catch (e) {
-              return [k, v];
-            }
-          }),
-        ),
-      }),
-    });
-    setTestResult({
-      status: res.success ? "success" : "error",
-      returnVal: res.returnVal,
-      error: res.error,
-      warnings: res.warnings,
-      log: res.log,
-    });
-  };
-
-  const isMac =
-    typeof navigator !== "undefined" && navigator.userAgent.includes("Mac");
-  const modKey = isMac ? "⌘" : "Ctrl";
-
-  return (
-    <Modal
-      header={current?.id ? "Edit Custom Hook" : "Add Custom Hook"}
-      close={close}
-      open={true}
-      size="max"
-      trackingEventModalType="custom-hooks"
-      submit={form.handleSubmit(async (value) => {
-        if (current?.id) {
-          await apiCall(`/custom-hooks/${current.id}`, {
-            method: "PUT",
-            body: JSON.stringify(value),
-          });
-        } else {
-          await apiCall("/custom-hooks", {
-            method: "POST",
-            body: JSON.stringify(value),
-          });
-        }
-
-        if (onSave) onSave();
-      })}
-    >
-      <Flex align="start" gap="5">
-        <div style={{ width: "50%" }} className="border-right pr-4">
-          <Field label="Name" required {...form.register("name")} />
-          <SelectField
-            label="Hook Type"
-            required
-            options={Object.entries(hookTypes).map(([value, { label }]) => ({
-              value,
-              label,
-            }))}
-            value={hookType}
-            onChange={(value) => {
-              form.setValue("hook", value as CustomHookType);
-              setTestValues(
-                Object.fromEntries(
-                  Object.entries(
-                    hookTypes[value as CustomHookType].availableArguments,
-                  ).map(([k, v]) => [k, v.testValue]),
-                ),
-              );
-            }}
-          />
-          <MultiSelectField
-            label={"Projects"}
-            placeholder="All projects"
-            value={form.watch("projects") || []}
-            options={projectOptions}
-            onChange={(v) => form.setValue("projects", v)}
-            customClassName="label-overflow-ellipsis"
-            helpText="Only run this hook for selected projects"
-          />
-          <Checkbox
-            label="Enable this hook"
-            value={form.watch("enabled")}
-            setValue={(value) => form.setValue("enabled", value)}
-            description="Uncheck to disable this hook without deleting it"
-          />
-
-          <Separator size="4" mb="4" my="2" />
-
-          <strong>Available Variables</strong>
-          <ul>
-            {Object.entries(hookTypeData?.availableArguments).map(
-              ([arg, { description }]) => (
-                <li key={arg}>
-                  <code>{arg}</code>: {description}
-                </li>
-              ),
-            )}
-          </ul>
-
-          <Text as="p" size="1" color="gray" mb="2">
-            Call <code>throw new Error(...)</code> to block the action, or{" "}
-            <code>addWarning(...)</code> for a soft warning the user can
-            acknowledge and override.
-          </Text>
-
-          <CodeTextArea
-            language="javascript"
-            label="Javascript Code"
-            required
-            value={form.watch("code")}
-            setValue={(value) => form.setValue("code", value)}
-            placeholder={hookTypeData?.example || ""}
-            onCtrlEnter={runTest}
-          />
-
-          <Checkbox
-            label="Incremental Changes Only"
-            value={form.watch("incrementalChangesOnly") || false}
-            setValue={(value) => form.setValue("incrementalChangesOnly", value)}
-            description="Ignore this hook if the same error was already present before attempting to save."
-          />
-        </div>
-        <div style={{ width: "50%" }}>
-          <h3>Test Your Hook</h3>
-          {Object.keys(hookTypeData?.availableArguments).map((arg) => (
-            <CodeTextArea
-              language="json"
-              key={arg}
-              label={arg}
-              required
-              value={testValues[arg] || ""}
-              setValue={(value) =>
-                setTestValues((existing) => ({
-                  ...existing,
-                  [arg]: value,
-                }))
-              }
-              onCtrlEnter={runTest}
-              maxLines={8}
-            />
-          ))}
-          <Button
-            onClick={runTest}
-            disabled={!form.watch("code")}
-            variant="outline"
-          >
-            <Flex align="center" gap="3">
-              <Text>Run Test</Text>
-              <Kbd size="1">{modKey} + Enter</Kbd>
-            </Flex>
-          </Button>
-          {testResult.status === "success" && !testResult.warnings?.length && (
-            <Callout mt="3" status="success">
-              Success!
-            </Callout>
-          )}
-          {testResult.status === "error" && (
-            <Callout mt="3" status="error">
-              Error!
-            </Callout>
-          )}
-          {testResult.warnings && testResult.warnings.length > 0 && (
-            <div className="mt-3">
-              <strong>Warnings:</strong>
-              {testResult.warnings.map((w, i) => (
-                <Callout key={i} status="warning" mt="2">
-                  {w}
-                </Callout>
-              ))}
-            </div>
-          )}
-          {testResult.returnVal && (
-            <div className="mt-3">
-              <strong>Return Value:</strong>
-              <pre className="p-3 bg-light">{testResult.returnVal}</pre>
-            </div>
-          )}
-          {testResult.error && (
-            <div className="mt-3">
-              <strong>Error:</strong>
-              <pre className="p-3 bg-light">{testResult.error}</pre>
-            </div>
-          )}
-          {testResult.log && (
-            <div className="mt-3">
-              <strong>Log:</strong>
-              <pre className="p-3 bg-light">{testResult.log}</pre>
-            </div>
-          )}
-        </div>
-      </Flex>
-    </Modal>
-  );
-}
+import CustomHookModal from "@/components/Features/CustomHookModal";
 
 export default function CustomHooksPage() {
   const [modalData, setModalData] = useState<null | true | CustomHookInterface>(
@@ -377,19 +38,23 @@ export default function CustomHooksPage() {
     return <LoadingOverlay />;
   }
 
-  const hooks = data.customHooks || [];
+  const allHooks = data.customHooks || [];
+  // Global/project hooks are managed here. Feature-scoped hooks are managed
+  // from each feature's Validation tab and shown read-only below.
+  const hooks = allHooks.filter((h) => !h.entityType);
+  const featureHooks = allHooks.filter((h) => h.entityType === "feature");
 
   return (
     <div className="container-fluid pagecontents">
       {modalData && (
-        <CustomHooksModal
+        <CustomHookModal
           current={modalData === true ? undefined : modalData}
           close={() => setModalData(null)}
           onSave={() => mutate()}
         />
       )}
 
-      {hooks.length === 0 ? (
+      {allHooks.length === 0 ? (
         <EmptyState
           description="Custom hooks allow you to extend the functionality of GrowthBook by
         writing custom javascript snippets that execute on certain events."
@@ -401,56 +66,104 @@ export default function CustomHooksPage() {
           }
         />
       ) : (
-        <div>
-          <Flex justify="between" align="center" mb="3">
-            <h1 className="mb-0">Custom Hooks</h1>
-            <Button onClick={() => setModalData(true)}>Add Custom Hook</Button>
-          </Flex>
-          <table className="gbtable table appbox">
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Type</th>
-                <th>Projects</th>
-                <th>Enabled</th>
-                <th style={{ width: 50 }}></th>
-              </tr>
-            </thead>
-            <tbody>
-              {hooks.map((hook) => (
-                <tr key={hook.id}>
-                  <td data-title="Name">{hook.name}</td>
-                  <td data-title="Type">{hook.hook}</td>
-                  <td data-title="Projects">{hook.projects.join(", ")}</td>
-                  <td data-title="Enabled">{hook.enabled ? "Yes" : "No"}</td>
-                  <td>
-                    <MoreMenu>
-                      <a
-                        href="#"
-                        className="dropdown-item"
-                        onClick={() => setModalData(hook)}
-                      >
-                        Edit
-                      </a>
-                      <DeleteButton
-                        useIcon={false}
-                        text="Delete"
-                        displayName="custom hook"
-                        onClick={async () => {
-                          await apiCall(`/custom-hooks/${hook.id}`, {
-                            method: "DELETE",
-                          });
-                          await mutate();
-                        }}
-                        className="dropdown-item text-danger"
-                      />
-                    </MoreMenu>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <>
+          <div>
+            <Flex justify="between" align="center" mb="3">
+              <h1 className="mb-0">Custom Hooks</h1>
+              <Button onClick={() => setModalData(true)}>
+                Add Custom Hook
+              </Button>
+            </Flex>
+            {hooks.length === 0 ? (
+              <Callout status="info">
+                No global or project-scoped hooks yet.
+              </Callout>
+            ) : (
+              <table className="gbtable table appbox">
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Type</th>
+                    <th>Projects</th>
+                    <th>Enabled</th>
+                    <th style={{ width: 50 }}></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {hooks.map((hook) => (
+                    <tr key={hook.id}>
+                      <td data-title="Name">{hook.name}</td>
+                      <td data-title="Type">{hook.hook}</td>
+                      <td data-title="Projects">{hook.projects.join(", ")}</td>
+                      <td data-title="Enabled">
+                        {hook.enabled ? "Yes" : "No"}
+                      </td>
+                      <td>
+                        <MoreMenu>
+                          <a
+                            href="#"
+                            className="dropdown-item"
+                            onClick={() => setModalData(hook)}
+                          >
+                            Edit
+                          </a>
+                          <DeleteButton
+                            useIcon={false}
+                            text="Delete"
+                            displayName="custom hook"
+                            onClick={async () => {
+                              await apiCall(`/custom-hooks/${hook.id}`, {
+                                method: "DELETE",
+                              });
+                              await mutate();
+                            }}
+                            className="dropdown-item text-danger"
+                          />
+                        </MoreMenu>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+
+          {featureHooks.length > 0 && (
+            <div className="mt-5">
+              <h2>Feature-specific Hooks</h2>
+              <p className="text-muted">
+                These hooks are scoped to a single feature and managed from that
+                feature&apos;s Validation tab.
+              </p>
+              <table className="gbtable table appbox">
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Type</th>
+                    <th>Feature</th>
+                    <th>Enabled</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {featureHooks.map((hook) => (
+                    <tr key={hook.id}>
+                      <td data-title="Name">{hook.name}</td>
+                      <td data-title="Type">{hook.hook}</td>
+                      <td data-title="Feature">
+                        <a href={`/features/${hook.entityId}#validation`}>
+                          {hook.entityId}
+                        </a>
+                      </td>
+                      <td data-title="Enabled">
+                        {hook.enabled ? "Yes" : "No"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/packages/front-end/pages/settings/custom-hooks.tsx
+++ b/packages/front-end/pages/settings/custom-hooks.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { CustomHookInterface } from "shared/validators";
-import { Flex } from "@radix-ui/themes";
+import { Box, Flex, IconButton } from "@radix-ui/themes";
+import { PiCode } from "react-icons/pi";
 import { useAuth } from "@/services/auth";
 import Button from "@/ui/Button";
 import useApi from "@/hooks/useApi";
@@ -9,11 +10,47 @@ import LoadingOverlay from "@/components/LoadingOverlay";
 import EmptyState from "@/components/EmptyState";
 import MoreMenu from "@/components/Dropdown/MoreMenu";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
+import Tooltip from "@/components/Tooltip/Tooltip";
+import Code from "@/components/SyntaxHighlighting/Code";
 import { isCloud } from "@/services/env";
 import CustomHookModal from "@/components/Features/CustomHookModal";
+import ModalStandard from "@/ui/Modal/Patterns/ModalStandard";
+import Table, {
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableColumnHeader,
+  TableCell,
+} from "@/ui/Table";
+import Badge from "@/ui/Badge";
+
+function CustomHookCodeModal({
+  hook,
+  close,
+}: {
+  hook: CustomHookInterface;
+  close: () => void;
+}) {
+  return (
+    <ModalStandard
+      open
+      header={hook.name}
+      subheader={hook.hook}
+      close={close}
+      closeCta="Close"
+      size="lg"
+      trackingEventModalType=""
+    >
+      <Code language="javascript" code={hook.code} />
+    </ModalStandard>
+  );
+}
 
 export default function CustomHooksPage() {
   const [modalData, setModalData] = useState<null | true | CustomHookInterface>(
+    null,
+  );
+  const [viewCodeHook, setViewCodeHook] = useState<CustomHookInterface | null>(
     null,
   );
 
@@ -53,6 +90,12 @@ export default function CustomHooksPage() {
           onSave={() => mutate()}
         />
       )}
+      {viewCodeHook && (
+        <CustomHookCodeModal
+          hook={viewCodeHook}
+          close={() => setViewCodeHook(null)}
+        />
+      )}
 
       {allHooks.length === 0 ? (
         <EmptyState
@@ -68,63 +111,116 @@ export default function CustomHooksPage() {
       ) : (
         <>
           <div>
-            <Flex justify="between" align="center" mb="3">
-              <h1 className="mb-0">Custom Hooks</h1>
+            <Box mb="5">
+              <h1>Custom Hooks</h1>
+              <p>
+                Custom hooks allow you to extend the functionality of GrowthBook
+                by writing custom javascript snippets that execute on certain
+                events.
+              </p>
+            </Box>
+            <Flex justify="between" align="center" mb="1">
+              <h2 className="mb-0">Global/Project Hooks</h2>
               <Button onClick={() => setModalData(true)}>
                 Add Custom Hook
               </Button>
             </Flex>
+
+            <p className="text-muted">
+              These hooks run for all resources in your organization.
+            </p>
+
             {hooks.length === 0 ? (
               <Callout status="info">
                 No global or project-scoped hooks yet.
               </Callout>
             ) : (
-              <table className="gbtable table appbox">
-                <thead>
-                  <tr>
-                    <th>Name</th>
-                    <th>Type</th>
-                    <th>Projects</th>
-                    <th>Enabled</th>
-                    <th style={{ width: 50 }}></th>
-                  </tr>
-                </thead>
-                <tbody>
+              <Table variant="list" stickyHeader roundedCorners>
+                <TableHeader>
+                  <TableRow>
+                    <TableColumnHeader>Name</TableColumnHeader>
+                    <TableColumnHeader>Type</TableColumnHeader>
+                    <TableColumnHeader>Projects</TableColumnHeader>
+                    <TableColumnHeader style={{ width: 80 }} />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
                   {hooks.map((hook) => (
-                    <tr key={hook.id}>
-                      <td data-title="Name">{hook.name}</td>
-                      <td data-title="Type">{hook.hook}</td>
-                      <td data-title="Projects">{hook.projects.join(", ")}</td>
-                      <td data-title="Enabled">
-                        {hook.enabled ? "Yes" : "No"}
-                      </td>
-                      <td>
-                        <MoreMenu>
-                          <a
-                            href="#"
-                            className="dropdown-item"
-                            onClick={() => setModalData(hook)}
+                    <TableRow key={hook.id}>
+                      <TableCell>
+                        {hook.name}
+                        {!hook.enabled ? (
+                          <Badge color="gray" label="Disabled" />
+                        ) : null}
+                      </TableCell>
+                      <TableCell>{hook.hook}</TableCell>
+                      <TableCell>
+                        {hook.projects.length ? (
+                          hook.projects.join(", ")
+                        ) : (
+                          <em>All projects</em>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Flex align="center" justify="end" gap="2">
+                          <Tooltip
+                            body="View code"
+                            usePortal
+                            className="d-inline-flex align-items-center"
                           >
-                            Edit
-                          </a>
-                          <DeleteButton
-                            useIcon={false}
-                            text="Delete"
-                            displayName="custom hook"
-                            onClick={async () => {
-                              await apiCall(`/custom-hooks/${hook.id}`, {
-                                method: "DELETE",
-                              });
-                              await mutate();
-                            }}
-                            className="dropdown-item text-danger"
-                          />
-                        </MoreMenu>
-                      </td>
-                    </tr>
+                            <IconButton
+                              variant="ghost"
+                              color="gray"
+                              size="1"
+                              onClick={() => setViewCodeHook(hook)}
+                              aria-label="View hook code"
+                            >
+                              <PiCode />
+                            </IconButton>
+                          </Tooltip>
+                          <MoreMenu useRadix iconButtonSize="1">
+                            <a
+                              href="#"
+                              className="dropdown-item"
+                              onClick={() => setModalData(hook)}
+                            >
+                              Edit
+                            </a>
+                            <a
+                              href="#"
+                              className="dropdown-item"
+                              onClick={async (e) => {
+                                e.preventDefault();
+                                await apiCall(`/custom-hooks/${hook.id}`, {
+                                  method: "PUT",
+                                  body: JSON.stringify({
+                                    enabled: !hook.enabled,
+                                  }),
+                                });
+                                await mutate();
+                              }}
+                            >
+                              {hook.enabled ? "Disable" : "Enable"}
+                            </a>
+                            <DeleteButton
+                              useIcon={false}
+                              text="Delete"
+                              displayName="custom hook"
+                              onClick={async () => {
+                                await apiCall(`/custom-hooks/${hook.id}`, {
+                                  method: "DELETE",
+                                });
+                                await mutate();
+                              }}
+                              className="dropdown-item text-danger"
+                            />
+                          </MoreMenu>
+                        </Flex>
+                      </TableCell>
+                    </TableRow>
                   ))}
-                </tbody>
-              </table>
+                </TableBody>
+              </Table>
             )}
           </div>
 
@@ -135,32 +231,53 @@ export default function CustomHooksPage() {
                 These hooks are scoped to a single feature and managed from that
                 feature&apos;s Validation tab.
               </p>
-              <table className="gbtable table appbox">
-                <thead>
-                  <tr>
-                    <th>Name</th>
-                    <th>Type</th>
-                    <th>Feature</th>
-                    <th>Enabled</th>
-                  </tr>
-                </thead>
-                <tbody>
+              <Table variant="list" stickyHeader roundedCorners>
+                <TableHeader>
+                  <TableRow>
+                    <TableColumnHeader>Name</TableColumnHeader>
+                    <TableColumnHeader>Type</TableColumnHeader>
+                    <TableColumnHeader>Feature</TableColumnHeader>
+                    <TableColumnHeader style={{ width: 40 }} />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
                   {featureHooks.map((hook) => (
-                    <tr key={hook.id}>
-                      <td data-title="Name">{hook.name}</td>
-                      <td data-title="Type">{hook.hook}</td>
-                      <td data-title="Feature">
+                    <TableRow key={hook.id}>
+                      <TableCell>
+                        {hook.name}
+                        {!hook.enabled ? (
+                          <Badge color="gray" label="Disabled" />
+                        ) : null}
+                      </TableCell>
+                      <TableCell>{hook.hook}</TableCell>
+                      <TableCell>
                         <a href={`/features/${hook.entityId}#validation`}>
                           {hook.entityId}
                         </a>
-                      </td>
-                      <td data-title="Enabled">
-                        {hook.enabled ? "Yes" : "No"}
-                      </td>
-                    </tr>
+                      </TableCell>
+                      <TableCell>
+                        <Flex align="center" justify="end">
+                          <Tooltip
+                            body="View code"
+                            usePortal
+                            className="d-inline-flex align-items-center"
+                          >
+                            <IconButton
+                              variant="ghost"
+                              color="gray"
+                              size="1"
+                              onClick={() => setViewCodeHook(hook)}
+                              aria-label="View hook code"
+                            >
+                              <PiCode />
+                            </IconButton>
+                          </Tooltip>
+                        </Flex>
+                      </TableCell>
+                    </TableRow>
                   ))}
-                </tbody>
-              </table>
+                </TableBody>
+              </Table>
             </div>
           )}
         </>

--- a/packages/front-end/pages/settings/custom-hooks.tsx
+++ b/packages/front-end/pages/settings/custom-hooks.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { CustomHookInterface } from "shared/validators";
-import { Box, Flex, IconButton } from "@radix-ui/themes";
-import { PiCode } from "react-icons/pi";
+import { Box, Flex } from "@radix-ui/themes";
 import { useAuth } from "@/services/auth";
 import Button from "@/ui/Button";
 import useApi from "@/hooks/useApi";
@@ -10,7 +9,6 @@ import LoadingOverlay from "@/components/LoadingOverlay";
 import EmptyState from "@/components/EmptyState";
 import MoreMenu from "@/components/Dropdown/MoreMenu";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
-import Tooltip from "@/components/Tooltip/Tooltip";
 import Code from "@/components/SyntaxHighlighting/Code";
 import { isCloud } from "@/services/env";
 import CustomHookModal from "@/components/Features/CustomHookModal";
@@ -23,6 +21,7 @@ import Table, {
   TableCell,
 } from "@/ui/Table";
 import Badge from "@/ui/Badge";
+import Link from "@/ui/Link";
 
 function CustomHookCodeModal({
   hook,
@@ -141,7 +140,7 @@ export default function CustomHooksPage() {
                     <TableColumnHeader>Name</TableColumnHeader>
                     <TableColumnHeader>Type</TableColumnHeader>
                     <TableColumnHeader>Projects</TableColumnHeader>
-                    <TableColumnHeader style={{ width: 80 }} />
+                    <TableColumnHeader style={{ width: 50 }} />
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -162,60 +161,56 @@ export default function CustomHooksPage() {
                         )}
                       </TableCell>
                       <TableCell>
-                        <Flex align="center" justify="end" gap="2">
-                          <Tooltip
-                            body="View code"
-                            usePortal
-                            className="d-inline-flex align-items-center"
+                        <MoreMenu useRadix iconButtonSize="1">
+                          <a
+                            href="#"
+                            className="dropdown-item"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              setViewCodeHook(hook);
+                            }}
                           >
-                            <IconButton
-                              variant="ghost"
-                              color="gray"
-                              size="1"
-                              onClick={() => setViewCodeHook(hook)}
-                              aria-label="View hook code"
-                            >
-                              <PiCode />
-                            </IconButton>
-                          </Tooltip>
-                          <MoreMenu useRadix iconButtonSize="1">
-                            <a
-                              href="#"
-                              className="dropdown-item"
-                              onClick={() => setModalData(hook)}
-                            >
-                              Edit
-                            </a>
-                            <a
-                              href="#"
-                              className="dropdown-item"
-                              onClick={async (e) => {
-                                e.preventDefault();
-                                await apiCall(`/custom-hooks/${hook.id}`, {
-                                  method: "PUT",
-                                  body: JSON.stringify({
-                                    enabled: !hook.enabled,
-                                  }),
-                                });
-                                await mutate();
-                              }}
-                            >
-                              {hook.enabled ? "Disable" : "Enable"}
-                            </a>
-                            <DeleteButton
-                              useIcon={false}
-                              text="Delete"
-                              displayName="custom hook"
-                              onClick={async () => {
-                                await apiCall(`/custom-hooks/${hook.id}`, {
-                                  method: "DELETE",
-                                });
-                                await mutate();
-                              }}
-                              className="dropdown-item text-danger"
-                            />
-                          </MoreMenu>
-                        </Flex>
+                            Preview Code
+                          </a>
+                          <a
+                            href="#"
+                            className="dropdown-item"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              setModalData(hook);
+                            }}
+                          >
+                            Edit
+                          </a>
+                          <a
+                            href="#"
+                            className="dropdown-item"
+                            onClick={async (e) => {
+                              e.preventDefault();
+                              await apiCall(`/custom-hooks/${hook.id}`, {
+                                method: "PUT",
+                                body: JSON.stringify({
+                                  enabled: !hook.enabled,
+                                }),
+                              });
+                              await mutate();
+                            }}
+                          >
+                            {hook.enabled ? "Disable" : "Enable"}
+                          </a>
+                          <DeleteButton
+                            useIcon={false}
+                            text="Delete"
+                            displayName="custom hook"
+                            onClick={async () => {
+                              await apiCall(`/custom-hooks/${hook.id}`, {
+                                method: "DELETE",
+                              });
+                              await mutate();
+                            }}
+                            className="dropdown-item text-danger"
+                          />
+                        </MoreMenu>
                       </TableCell>
                     </TableRow>
                   ))}
@@ -237,7 +232,7 @@ export default function CustomHooksPage() {
                     <TableColumnHeader>Name</TableColumnHeader>
                     <TableColumnHeader>Type</TableColumnHeader>
                     <TableColumnHeader>Feature</TableColumnHeader>
-                    <TableColumnHeader style={{ width: 40 }} />
+                    <TableColumnHeader style={{ width: 50 }} />
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -251,28 +246,23 @@ export default function CustomHooksPage() {
                       </TableCell>
                       <TableCell>{hook.hook}</TableCell>
                       <TableCell>
-                        <a href={`/features/${hook.entityId}#validation`}>
+                        <Link href={`/features/${hook.entityId}#validation`}>
                           {hook.entityId}
-                        </a>
+                        </Link>
                       </TableCell>
                       <TableCell>
-                        <Flex align="center" justify="end">
-                          <Tooltip
-                            body="View code"
-                            usePortal
-                            className="d-inline-flex align-items-center"
+                        <MoreMenu useRadix iconButtonSize="1">
+                          <a
+                            href="#"
+                            className="dropdown-item"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              setViewCodeHook(hook);
+                            }}
                           >
-                            <IconButton
-                              variant="ghost"
-                              color="gray"
-                              size="1"
-                              onClick={() => setViewCodeHook(hook)}
-                              aria-label="View hook code"
-                            >
-                              <PiCode />
-                            </IconButton>
-                          </Tooltip>
-                        </Flex>
+                            Preview Code
+                          </a>
+                        </MoreMenu>
                       </TableCell>
                     </TableRow>
                   ))}

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -221,6 +221,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
         settings.disableLegacyMetricCreation ?? false,
       defaultFeatureRulesInAllEnvs:
         settings.defaultFeatureRulesInAllEnvs ?? false,
+      allowPerFeatureCustomHooks: settings.allowPerFeatureCustomHooks ?? false,
       preferredEnvironment: settings.preferredEnvironment || "",
       maxMetricSliceLevels:
         settings.maxMetricSliceLevels ?? DEFAULT_MAX_METRIC_SLICE_LEVELS,
@@ -287,6 +288,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
     visualEditorAIContext: form.watch("visualEditorAIContext") || undefined,
     disableLegacyMetricCreation: form.watch("disableLegacyMetricCreation"),
     defaultFeatureRulesInAllEnvs: form.watch("defaultFeatureRulesInAllEnvs"),
+    allowPerFeatureCustomHooks: form.watch("allowPerFeatureCustomHooks"),
     preferredEnvironment: form.watch("preferredEnvironment") || "",
     maxMetricSliceLevels: form.watch("maxMetricSliceLevels"),
     savedGroupSizeLimit: form.watch("savedGroupSizeLimit"),

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -221,7 +221,6 @@ const GeneralSettingsPage = (): React.ReactElement => {
         settings.disableLegacyMetricCreation ?? false,
       defaultFeatureRulesInAllEnvs:
         settings.defaultFeatureRulesInAllEnvs ?? false,
-      allowPerFeatureCustomHooks: settings.allowPerFeatureCustomHooks ?? false,
       preferredEnvironment: settings.preferredEnvironment || "",
       maxMetricSliceLevels:
         settings.maxMetricSliceLevels ?? DEFAULT_MAX_METRIC_SLICE_LEVELS,
@@ -288,7 +287,6 @@ const GeneralSettingsPage = (): React.ReactElement => {
     visualEditorAIContext: form.watch("visualEditorAIContext") || undefined,
     disableLegacyMetricCreation: form.watch("disableLegacyMetricCreation"),
     defaultFeatureRulesInAllEnvs: form.watch("defaultFeatureRulesInAllEnvs"),
-    allowPerFeatureCustomHooks: form.watch("allowPerFeatureCustomHooks"),
     preferredEnvironment: form.watch("preferredEnvironment") || "",
     maxMetricSliceLevels: form.watch("maxMetricSliceLevels"),
     savedGroupSizeLimit: form.watch("savedGroupSizeLimit"),

--- a/packages/front-end/services/auth.tsx
+++ b/packages/front-end/services/auth.tsx
@@ -36,8 +36,7 @@ export type ApiCallType<T> = (
   errorHandler?: ErrorHandler,
 ) => Promise<T>;
 
-// Append the `ignoreWarnings` flag so the server skips soft warnings on retry.
-// Handles URLs that already carry a querystring.
+// Append the ignoreWarnings flag so the server skips soft warnings on retry.
 export function appendIgnoreWarnings(url: string): string {
   return url + (url.includes("?") ? "&" : "?") + "ignoreWarnings=true";
 }
@@ -52,8 +51,7 @@ export interface AuthContextValue {
     errorHandler?: ErrorHandler,
   ) => Promise<T>;
   fetchRaw: (url: string, options?: RequestInit) => Promise<Response>;
-  // Show the global "Save anyway?" dialog for soft warnings returned by the API.
-  // Resolves true if the user chooses to proceed, false if they cancel.
+  // Show the global "Save anyway?" dialog; resolves true if the user proceeds.
   confirmIgnoreWarnings: (warnings: string[]) => Promise<boolean>;
   ssoConnectionId: string;
   orgId: string | null;
@@ -234,8 +232,7 @@ export const AuthProvider: React.FC<{
   const [authComponent, setAuthComponent] = useState<ReactElement | null>(null);
   const [initError, setInitError] = useState("");
   const [sessionError, setSessionError] = useState(false);
-  // Soft warnings returned by the API, shown in a global "Save anyway?" dialog.
-  // Batch together multiple concurrent warnings (e.g. from Promise.all)
+  // Pending soft-warning requests, batched so concurrent ones share one dialog.
   const pendingWarnings = useRef<
     { warnings: string[]; resolve: (proceed: boolean) => void }[]
   >([]);
@@ -446,8 +443,7 @@ export const AuthProvider: React.FC<{
     [orgId, token],
   );
 
-  // Register a warning request and (re)render the combined dialog. All pending
-  // requests share one dialog; resolving it applies the same choice to each.
+  // Register a warning request; all pending requests share one dialog.
   const confirmIgnoreWarnings = useCallback((warnings: string[]) => {
     return new Promise<boolean>((resolve) => {
       pendingWarnings.current.push({ warnings, resolve });
@@ -510,8 +506,7 @@ export const AuthProvider: React.FC<{
           );
         }
 
-        // Soft warning from a server-side validation hook. Let the user
-        // acknowledge it, then re-submit the same request ignoring warnings.
+        // Soft warning: let the user acknowledge, then re-submit ignoring warnings.
         if (
           responseData.status === 422 &&
           Array.isArray(responseData.warnings)

--- a/packages/front-end/ui/Modal/Patterns/ModalStandard.tsx
+++ b/packages/front-end/ui/Modal/Patterns/ModalStandard.tsx
@@ -42,6 +42,7 @@ export type Props = TrackingEventModalProps & {
   // destructive or out-of-flow actions that shouldn't be the primary CTA.
   secondaryAction?: ReactNode;
   close: () => void;
+  closeCta?: string;
   children: ReactNode;
 };
 
@@ -61,6 +62,7 @@ export default function ModalStandard({
   submit,
   secondaryAction,
   close,
+  closeCta = "Cancel",
   children,
   trackingEventModalType,
   trackingEventModalSource,
@@ -81,7 +83,7 @@ export default function ModalStandard({
         <Flex gap="3" align="center">
           <Modal.Close>
             <Button variant="ghost" onClick={close}>
-              Cancel
+              {closeCta}
             </Button>
           </Modal.Close>
           {submit && (

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -1376,23 +1376,16 @@ export class Permissions {
     return this.checkProjectFilterPermission(customHook, "manageCustomHooks");
   };
 
-  // Manage a Custom Hook scoped to a single feature. Admins (manageCustomHooks)
-  // can always manage hooks. When the org opts in via allowPerFeatureHooks,
-  // anyone who can edit the feature (manageFeatures) can manage hooks for it.
-  // Add sibling methods (e.g. canManageExperimentCustomHooks) as more resource
-  // types gain hooks.
+  // Manage a Custom Hook scoped to a single feature. Currently a thin alias for
+  // the feature-edit permission (manageFeatures) — anyone who can edit a feature
+  // can manage hooks scoped to it. Kept as its own method so we can layer extra
+  // logic on later, and so future resource types get sibling methods (e.g.
+  // canManageExperimentCustomHooks). Global/project-scoped hooks still require
+  // manageCustomHooks (see canCreate/Update/DeleteCustomHook).
   public canManageFeatureCustomHooks = (
     feature: Pick<FeatureInterface, "project">,
-    allowPerFeatureHooks: boolean,
   ): boolean => {
-    const projects = feature.project ? [feature.project] : [];
-    if (this.checkProjectFilterPermission({ projects }, "manageCustomHooks")) {
-      return true;
-    }
-    return (
-      allowPerFeatureHooks &&
-      this.checkProjectFilterPermission({ projects }, "manageFeatures")
-    );
+    return this.canUpdateFeature(feature, {});
   };
 
   public throwPermissionError(message?: string): void {

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -1376,6 +1376,25 @@ export class Permissions {
     return this.checkProjectFilterPermission(customHook, "manageCustomHooks");
   };
 
+  // Manage a Custom Hook scoped to a single feature. Admins (manageCustomHooks)
+  // can always manage hooks. When the org opts in via allowPerFeatureHooks,
+  // anyone who can edit the feature (manageFeatures) can manage hooks for it.
+  // Add sibling methods (e.g. canManageExperimentCustomHooks) as more resource
+  // types gain hooks.
+  public canManageFeatureCustomHooks = (
+    feature: Pick<FeatureInterface, "project">,
+    allowPerFeatureHooks: boolean,
+  ): boolean => {
+    const projects = feature.project ? [feature.project] : [];
+    if (this.checkProjectFilterPermission({ projects }, "manageCustomHooks")) {
+      return true;
+    }
+    return (
+      allowPerFeatureHooks &&
+      this.checkProjectFilterPermission({ projects }, "manageFeatures")
+    );
+  };
+
   public throwPermissionError(message?: string): void {
     throw new PermissionError(
       message ?? "You do not have permission to perform this action",

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -1376,12 +1376,7 @@ export class Permissions {
     return this.checkProjectFilterPermission(customHook, "manageCustomHooks");
   };
 
-  // Manage a Custom Hook scoped to a single feature. Currently a thin alias for
-  // the feature-edit permission (manageFeatures) — anyone who can edit a feature
-  // can manage hooks scoped to it. Kept as its own method so we can layer extra
-  // logic on later, and so future resource types get sibling methods (e.g.
-  // canManageExperimentCustomHooks). Global/project-scoped hooks still require
-  // manageCustomHooks (see canCreate/Update/DeleteCustomHook).
+  // Alias for the feature-edit permission; its own method so we can add logic/resource types later.
   public canManageFeatureCustomHooks = (
     feature: Pick<FeatureInterface, "project">,
   ): boolean => {

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -19,6 +19,8 @@ import {
   SchemaField,
   SimpleSchema,
   ScheduleRule,
+  JSONSchemaDef,
+  FeatureValueType,
 } from "shared/types/feature";
 import { ExperimentInterfaceStringDates } from "shared/types/experiment";
 import { FeatureRevisionInterface } from "shared/types/feature-revision";
@@ -209,6 +211,10 @@ export function validateJSONFeatureValue(
   // eslint-disable-next-line
   value: any,
   feature: Pick<FeatureInterface, "jsonSchema">,
+  // For non-json flags, the stored value is a raw scalar (not a JSON document),
+  // so we coerce it to the right type before running the schema instead of
+  // JSON-parsing. Defaults to the json behavior to preserve existing callers.
+  valueType?: FeatureValueType,
 ) {
   const { jsonSchema, validationEnabled } = getValidation(feature);
   if (!validationEnabled) {
@@ -218,7 +224,12 @@ export function validateJSONFeatureValue(
     const ajv = getJSONValidator();
     const validate = ajv.compile(jsonSchema);
     let parsedValue;
-    if (typeof value === "string") {
+    if (valueType === "string") {
+      // String flags store the raw string value; validate it directly.
+      parsedValue = value;
+    } else if (valueType === "number") {
+      parsedValue = typeof value === "string" ? parseFloat(value) : value;
+    } else if (typeof value === "string") {
       try {
         parsedValue = JSON.parse(value);
       } catch (e) {
@@ -280,6 +291,25 @@ export function validateFeatureValue(
     if (!value.match(/^-?[0-9]+(\.[0-9]+)?$/)) {
       throw new Error(prefix + "Must be a valid number");
     }
+    // Apply JSON schema validation if set and enabled (e.g. min/max)
+    const { valid, errors } = validateJSONFeatureValue(
+      value,
+      feature,
+      "number",
+    );
+    if (!valid) {
+      throw new Error(prefix + errors.join(", "));
+    }
+  } else if (type === "string") {
+    // Apply JSON schema validation if set and enabled (e.g. maxLength/enum)
+    const { valid, errors } = validateJSONFeatureValue(
+      value,
+      feature,
+      "string",
+    );
+    if (!valid) {
+      throw new Error(prefix + errors.join(", "));
+    }
   } else if (type === "json") {
     let parsedValue;
     let validJSON = true;
@@ -306,6 +336,56 @@ export function validateFeatureValue(
   }
 
   return value;
+}
+
+// Ensure a feature's validation schema is compatible with its value type.
+// Prevents broken states like attaching a `type: object` schema to a number
+// flag. Only enforced when the schema is enabled.
+export function assertSchemaMatchesValueType(
+  jsonSchema: Pick<
+    JSONSchemaDef,
+    "schemaType" | "schema" | "simple" | "enabled"
+  >,
+  valueType: FeatureValueType,
+): void {
+  if (!jsonSchema.enabled) return;
+
+  // JSON flags accept any schema
+  if (valueType === "json") return;
+
+  if (valueType === "boolean") {
+    throw new Error("Boolean features cannot have a validation schema.");
+  }
+
+  // Determine the schema's top-level JSON type
+  let topType: unknown;
+  try {
+    const schemaString =
+      jsonSchema.schemaType === "simple"
+        ? simpleToJSONSchema(jsonSchema.simple)
+        : jsonSchema.schema;
+    topType = JSON.parse(schemaString)?.type;
+  } catch (e) {
+    throw new Error(
+      `Invalid validation schema: ${
+        e instanceof Error ? e.message : String(e)
+      }`,
+    );
+  }
+
+  if (valueType === "number") {
+    if (topType !== "number" && topType !== "integer") {
+      throw new Error(
+        'A number feature\'s validation schema must have a top-level type of "number" or "integer".',
+      );
+    }
+  } else if (valueType === "string") {
+    if (topType !== "string") {
+      throw new Error(
+        'A string feature\'s validation schema must have a top-level type of "string".',
+      );
+    }
+  }
 }
 
 // Helper function to validate ISO timestamp format

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -211,9 +211,7 @@ export function validateJSONFeatureValue(
   // eslint-disable-next-line
   value: any,
   feature: Pick<FeatureInterface, "jsonSchema">,
-  // For non-json flags, the stored value is a raw scalar (not a JSON document),
-  // so we coerce it to the right type before running the schema instead of
-  // JSON-parsing. Defaults to the json behavior to preserve existing callers.
+  // Non-json flags hold a raw scalar; coerce instead of JSON-parsing (default keeps json behavior).
   valueType?: FeatureValueType,
 ) {
   const { jsonSchema, validationEnabled } = getValidation(feature);
@@ -338,9 +336,7 @@ export function validateFeatureValue(
   return value;
 }
 
-// Ensure a feature's validation schema is compatible with its value type.
-// Prevents broken states like attaching a `type: object` schema to a number
-// flag. Only enforced when the schema is enabled.
+// Ensure a feature's enabled validation schema is compatible with its value type.
 export function assertSchemaMatchesValueType(
   jsonSchema: Pick<
     JSONSchemaDef,

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -223,7 +223,6 @@ export function validateJSONFeatureValue(
     const validate = ajv.compile(jsonSchema);
     let parsedValue;
     if (valueType === "string") {
-      // String flags store the raw string value; validate it directly.
       parsedValue = value;
     } else if (valueType === "number") {
       parsedValue = typeof value === "string" ? parseFloat(value) : value;
@@ -289,7 +288,6 @@ export function validateFeatureValue(
     if (!value.match(/^-?[0-9]+(\.[0-9]+)?$/)) {
       throw new Error(prefix + "Must be a valid number");
     }
-    // Apply JSON schema validation if set and enabled (e.g. min/max)
     const { valid, errors } = validateJSONFeatureValue(
       value,
       feature,
@@ -299,7 +297,6 @@ export function validateFeatureValue(
       throw new Error(prefix + errors.join(", "));
     }
   } else if (type === "string") {
-    // Apply JSON schema validation if set and enabled (e.g. maxLength/enum)
     const { valid, errors } = validateJSONFeatureValue(
       value,
       feature,
@@ -353,7 +350,6 @@ export function assertSchemaMatchesValueType(
     throw new Error("Boolean features cannot have a validation schema.");
   }
 
-  // Determine the schema's top-level JSON type
   let parsed: unknown;
   try {
     const schemaString =
@@ -374,9 +370,7 @@ export function assertSchemaMatchesValueType(
       : {};
   const topType = schemaObj.type;
 
-  // Schemas without an explicit top-level "type" are only allowed when they
-  // restrict values with an "enum" whose entries all match the feature's
-  // value type (e.g. {"enum": ["red", "green"]} for a string feature).
+  // No top-level "type" is only allowed with an "enum" whose entries all match the value type
   if (topType === undefined) {
     const enumValues = schemaObj.enum;
     if (!Array.isArray(enumValues)) {

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -354,19 +354,46 @@ export function assertSchemaMatchesValueType(
   }
 
   // Determine the schema's top-level JSON type
-  let topType: unknown;
+  let parsed: unknown;
   try {
     const schemaString =
       jsonSchema.schemaType === "simple"
         ? simpleToJSONSchema(jsonSchema.simple)
         : jsonSchema.schema;
-    topType = JSON.parse(schemaString)?.type;
+    parsed = JSON.parse(schemaString);
   } catch (e) {
     throw new Error(
       `Invalid validation schema: ${
         e instanceof Error ? e.message : String(e)
       }`,
     );
+  }
+  const schemaObj: Record<string, unknown> =
+    parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  const topType = schemaObj.type;
+
+  // Schemas without an explicit top-level "type" are only allowed when they
+  // restrict values with an "enum" whose entries all match the feature's
+  // value type (e.g. {"enum": ["red", "green"]} for a string feature).
+  if (topType === undefined) {
+    const enumValues = schemaObj.enum;
+    if (!Array.isArray(enumValues)) {
+      throw new Error(
+        `A ${valueType} feature's validation schema must have a top-level "type" or "enum".`,
+      );
+    }
+    if (
+      !enumValues.every((v) =>
+        valueType === "number" ? typeof v === "number" : typeof v === "string",
+      )
+    ) {
+      throw new Error(
+        `All "enum" values in a ${valueType} feature's validation schema must be of type "${valueType}".`,
+      );
+    }
+    return;
   }
 
   if (valueType === "number") {

--- a/packages/shared/src/validators/custom-hooks.ts
+++ b/packages/shared/src/validators/custom-hooks.ts
@@ -2,6 +2,10 @@ import { z } from "zod";
 
 export const hooks = ["validateFeature", "validateFeatureRevision"] as const;
 
+// The resource types a custom hook can be scoped to via entityType/entityId.
+// Add new resource types here as more hook types are introduced.
+export const customHookEntityTypes = ["feature"] as const;
+
 export const customHookValidator = z
   .object({
     id: z.string(),
@@ -13,6 +17,11 @@ export const customHookValidator = z
     name: z.string(),
     hook: z.enum(hooks),
     code: z.string(),
+    // Optional scoping to a single resource (e.g. one feature). When both are
+    // set the hook only runs for that resource; when absent it's global or
+    // project-scoped via `projects`.
+    entityType: z.enum(customHookEntityTypes).optional(),
+    entityId: z.string().optional(),
     lastSuccess: z.date().optional(),
     lastFailure: z.date().optional(),
     incrementalChangesOnly: z.boolean().optional(),
@@ -22,3 +31,12 @@ export const customHookValidator = z
 export type CustomHookInterface = z.infer<typeof customHookValidator>;
 
 export type CustomHookType = (typeof hooks)[number];
+
+export type CustomHookEntityType = (typeof customHookEntityTypes)[number];
+
+// Single source of truth for which resource type each hook operates on.
+// Used to validate that a hook's entityType matches its hook type.
+export const hookEntityType: Record<CustomHookType, CustomHookEntityType> = {
+  validateFeature: "feature",
+  validateFeatureRevision: "feature",
+};

--- a/packages/shared/src/validators/custom-hooks.ts
+++ b/packages/shared/src/validators/custom-hooks.ts
@@ -2,8 +2,7 @@ import { z } from "zod";
 
 export const hooks = ["validateFeature", "validateFeatureRevision"] as const;
 
-// The resource types a custom hook can be scoped to via entityType/entityId.
-// Add new resource types here as more hook types are introduced.
+// Resource types a hook can be scoped to via entityType/entityId.
 export const customHookEntityTypes = ["feature"] as const;
 
 export const customHookValidator = z
@@ -17,9 +16,7 @@ export const customHookValidator = z
     name: z.string(),
     hook: z.enum(hooks),
     code: z.string(),
-    // Optional scoping to a single resource (e.g. one feature). When both are
-    // set the hook only runs for that resource; when absent it's global or
-    // project-scoped via `projects`.
+    // Optional scope to a single resource; absent = global/project-scoped via projects.
     entityType: z.enum(customHookEntityTypes).optional(),
     entityId: z.string().optional(),
     lastSuccess: z.date().optional(),
@@ -34,8 +31,7 @@ export type CustomHookType = (typeof hooks)[number];
 
 export type CustomHookEntityType = (typeof customHookEntityTypes)[number];
 
-// Single source of truth for which resource type each hook operates on.
-// Used to validate that a hook's entityType matches its hook type.
+// Which resource type each hook operates on (validated against entityType).
 export const hookEntityType: Record<CustomHookType, CustomHookEntityType> = {
   validateFeature: "feature",
   validateFeatureRevision: "feature",

--- a/packages/shared/test/permissions.test.ts
+++ b/packages/shared/test/permissions.test.ts
@@ -956,3 +956,50 @@ describe("Role permissions", () => {
     expect(p.canDeleteOfficialResources(projectsResource)).toBe(true);
   });
 });
+
+describe("canManageFeatureCustomHooks", () => {
+  const testOrg: OrganizationInterface = {
+    id: "org_sktwi1id9l7z9xkjb",
+    name: "Test Org",
+    ownerEmail: "test@test.com",
+    url: "https://test.com",
+    dateCreated: new Date(),
+    invites: [],
+    members: [],
+    settings: {
+      environments: [{ id: "production", description: "" }],
+    },
+  };
+
+  function getPermissions(role: string) {
+    return new Permissions({
+      global: {
+        permissions: roleToPermissionMap(role, testOrg),
+        limitAccessByEnvironment: false,
+        environments: [],
+      },
+      projects: {},
+    });
+  }
+
+  const featureResource = { project: "" };
+
+  it("lets admins manage feature hooks regardless of the org setting", () => {
+    const p = getPermissions("admin");
+    expect(p.canManageFeatureCustomHooks(featureResource, false)).toBe(true);
+    expect(p.canManageFeatureCustomHooks(featureResource, true)).toBe(true);
+  });
+
+  it("lets feature editors manage only when the org opts in", () => {
+    // engineer has manageFeatures but not manageCustomHooks
+    const p = getPermissions("engineer");
+    expect(p.canManageFeatureCustomHooks(featureResource, false)).toBe(false);
+    expect(p.canManageFeatureCustomHooks(featureResource, true)).toBe(true);
+  });
+
+  it("never lets users without feature edit access manage hooks", () => {
+    const p = getPermissions("readonly");
+    expect(p.canManageFeatureCustomHooks(featureResource, false)).toBe(false);
+    expect(p.canManageFeatureCustomHooks(featureResource, true)).toBe(false);
+  });
+});

--- a/packages/shared/test/permissions.test.ts
+++ b/packages/shared/test/permissions.test.ts
@@ -984,22 +984,22 @@ describe("canManageFeatureCustomHooks", () => {
 
   const featureResource = { project: "" };
 
-  it("lets admins manage feature hooks regardless of the org setting", () => {
-    const p = getPermissions("admin");
-    expect(p.canManageFeatureCustomHooks(featureResource, false)).toBe(true);
-    expect(p.canManageFeatureCustomHooks(featureResource, true)).toBe(true);
+  it("lets admins manage feature hooks (they have manageFeatures)", () => {
+    expect(
+      getPermissions("admin").canManageFeatureCustomHooks(featureResource),
+    ).toBe(true);
   });
 
-  it("lets feature editors manage only when the org opts in", () => {
-    // engineer has manageFeatures but not manageCustomHooks
-    const p = getPermissions("engineer");
-    expect(p.canManageFeatureCustomHooks(featureResource, false)).toBe(false);
-    expect(p.canManageFeatureCustomHooks(featureResource, true)).toBe(true);
+  it("lets feature editors manage feature hooks", () => {
+    // engineer has manageFeatures
+    expect(
+      getPermissions("engineer").canManageFeatureCustomHooks(featureResource),
+    ).toBe(true);
   });
 
-  it("never lets users without feature edit access manage hooks", () => {
-    const p = getPermissions("readonly");
-    expect(p.canManageFeatureCustomHooks(featureResource, false)).toBe(false);
-    expect(p.canManageFeatureCustomHooks(featureResource, true)).toBe(false);
+  it("does not let users without feature edit access manage hooks", () => {
+    expect(
+      getPermissions("readonly").canManageFeatureCustomHooks(featureResource),
+    ).toBe(false);
   });
 });

--- a/packages/shared/test/util/features.test.ts
+++ b/packages/shared/test/util/features.test.ts
@@ -1480,6 +1480,51 @@ describe("assertSchemaMatchesValueType", () => {
     ).toThrow();
   });
 
+  it("allows type-less schemas with an enum matching the value type", () => {
+    expect(() =>
+      assertSchemaMatchesValueType(
+        rawSchema({ enum: ["red", "green", "blue"] }),
+        "string",
+      ),
+    ).not.toThrow();
+    expect(() =>
+      assertSchemaMatchesValueType(rawSchema({ enum: [1, 2, 3] }), "number"),
+    ).not.toThrow();
+  });
+
+  it("rejects type-less schemas whose enum values don't match the value type", () => {
+    expect(() =>
+      assertSchemaMatchesValueType(rawSchema({ enum: [1, 2, 3] }), "string"),
+    ).toThrow();
+    expect(() =>
+      assertSchemaMatchesValueType(rawSchema({ enum: ["red", 2] }), "string"),
+    ).toThrow();
+    expect(() =>
+      assertSchemaMatchesValueType(rawSchema({ enum: ["1", "2"] }), "number"),
+    ).toThrow();
+  });
+
+  it("rejects type-less schemas without an enum", () => {
+    expect(() =>
+      assertSchemaMatchesValueType(
+        rawSchema({ properties: { test: { type: "string" } } }),
+        "string",
+      ),
+    ).toThrow();
+    expect(() =>
+      assertSchemaMatchesValueType(
+        rawSchema({ items: { type: "number" } }),
+        "number",
+      ),
+    ).toThrow();
+    expect(() =>
+      assertSchemaMatchesValueType(
+        rawSchema({ anyOf: [{ const: "a" }, { const: "b" }] }),
+        "string",
+      ),
+    ).toThrow();
+  });
+
   it("does not enforce anything when the schema is disabled", () => {
     expect(() =>
       assertSchemaMatchesValueType(

--- a/packages/shared/test/util/features.test.ts
+++ b/packages/shared/test/util/features.test.ts
@@ -8,6 +8,7 @@ import { FeatureRevisionInterface } from "shared/types/feature-revision";
 import { OrganizationSettings, RequireReview } from "shared/types/organization";
 import {
   validateFeatureValue,
+  assertSchemaMatchesValueType,
   getValidation,
   validateJSONFeatureValue,
   autoMerge,
@@ -1378,6 +1379,143 @@ describe("validateFeatureValue", () => {
         validateFeatureValue(feature, value, "testVal"),
       ).toThrowError();
     });
+  });
+
+  describe("string values with a schema", () => {
+    const stringFeature = (
+      schema: object,
+    ): Pick<FeatureInterface, "valueType" | "jsonSchema"> => ({
+      valueType: "string",
+      jsonSchema: {
+        schemaType: "schema",
+        schema: JSON.stringify(schema),
+        simple: { type: "primitive", fields: [] },
+        date: new Date(),
+        enabled: true,
+      },
+    });
+
+    it("accepts a string within maxLength and rejects one over it", () => {
+      const f = stringFeature({ type: "string", maxLength: 5 });
+      expect(validateFeatureValue(f, "hello", "testVal")).toEqual("hello");
+      expect(() =>
+        validateFeatureValue(f, "toolong", "testVal"),
+      ).toThrowError();
+    });
+
+    it("enforces an enum", () => {
+      const f = stringFeature({ type: "string", enum: ["a", "b"] });
+      expect(validateFeatureValue(f, "a", "testVal")).toEqual("a");
+      expect(() => validateFeatureValue(f, "c", "testVal")).toThrowError();
+    });
+  });
+
+  describe("number values with a schema", () => {
+    const numberFeature = (
+      schema: object,
+    ): Pick<FeatureInterface, "valueType" | "jsonSchema"> => ({
+      valueType: "number",
+      jsonSchema: {
+        schemaType: "schema",
+        schema: JSON.stringify(schema),
+        simple: { type: "primitive", fields: [] },
+        date: new Date(),
+        enabled: true,
+      },
+    });
+
+    it("enforces minimum and maximum", () => {
+      const f = numberFeature({ type: "number", minimum: 1, maximum: 10 });
+      expect(validateFeatureValue(f, "5", "testVal")).toEqual("5");
+      expect(() => validateFeatureValue(f, "0", "testVal")).toThrowError();
+      expect(() => validateFeatureValue(f, "50", "testVal")).toThrowError();
+    });
+
+    it("enforces integer type", () => {
+      const f = numberFeature({ type: "integer" });
+      expect(validateFeatureValue(f, "5", "testVal")).toEqual("5");
+      expect(() => validateFeatureValue(f, "5.5", "testVal")).toThrowError();
+    });
+  });
+});
+
+describe("assertSchemaMatchesValueType", () => {
+  const rawSchema = (schema: object, enabled = true) => ({
+    schemaType: "schema" as const,
+    schema: JSON.stringify(schema),
+    simple: { type: "primitive" as const, fields: [] },
+    enabled,
+  });
+
+  it("allows any schema for json flags", () => {
+    expect(() =>
+      assertSchemaMatchesValueType(rawSchema({ type: "object" }), "json"),
+    ).not.toThrow();
+  });
+
+  it("rejects any schema for boolean flags", () => {
+    expect(() =>
+      assertSchemaMatchesValueType(rawSchema({ type: "string" }), "boolean"),
+    ).toThrow();
+  });
+
+  it("requires a number/integer top-level type for number flags", () => {
+    expect(() =>
+      assertSchemaMatchesValueType(rawSchema({ type: "number" }), "number"),
+    ).not.toThrow();
+    expect(() =>
+      assertSchemaMatchesValueType(rawSchema({ type: "integer" }), "number"),
+    ).not.toThrow();
+    expect(() =>
+      assertSchemaMatchesValueType(rawSchema({ type: "object" }), "number"),
+    ).toThrow();
+  });
+
+  it("requires a string top-level type for string flags", () => {
+    expect(() =>
+      assertSchemaMatchesValueType(rawSchema({ type: "string" }), "string"),
+    ).not.toThrow();
+    expect(() =>
+      assertSchemaMatchesValueType(rawSchema({ type: "number" }), "string"),
+    ).toThrow();
+  });
+
+  it("does not enforce anything when the schema is disabled", () => {
+    expect(() =>
+      assertSchemaMatchesValueType(
+        rawSchema({ type: "object" }, false),
+        "number",
+      ),
+    ).not.toThrow();
+  });
+
+  it("validates a simple primitive schema against the flag type", () => {
+    const simpleString = {
+      schemaType: "simple" as const,
+      schema: "",
+      simple: {
+        type: "primitive" as const,
+        fields: [
+          {
+            key: "",
+            type: "string" as const,
+            required: true,
+            default: "",
+            description: "",
+            enum: [],
+            min: 0,
+            max: 10,
+          },
+        ],
+      },
+      enabled: true,
+    };
+    expect(() =>
+      assertSchemaMatchesValueType(simpleString, "string"),
+    ).not.toThrow();
+    expect(() =>
+      assertSchemaMatchesValueType(simpleString, "number"),
+    ).toThrow();
   });
 });
 

--- a/packages/shared/types/organization.d.ts
+++ b/packages/shared/types/organization.d.ts
@@ -278,6 +278,10 @@ export interface OrganizationSettings {
   featureRegexValidator?: string; // Regex to validate feature flag name (e.g. ^.+-\d{8}-.+$)
   requireProjectForFeatures?: boolean;
   requireProjectForSdkConnections?: boolean;
+  // When true, users with edit permission for a feature can manage Custom Hooks
+  // scoped to that feature without the org-wide manageCustomHooks (admin)
+  // permission. Global/project-scoped hooks still require admin.
+  allowPerFeatureCustomHooks?: boolean;
   // When true, saving a feature rule or experiment rejects hashAttribute,
   // fallbackAttribute, or condition keys that don't appear (unarchived) in
   // attributeSchema. Prevents typo'd attributes silently never matching at

--- a/packages/shared/types/organization.d.ts
+++ b/packages/shared/types/organization.d.ts
@@ -278,10 +278,6 @@ export interface OrganizationSettings {
   featureRegexValidator?: string; // Regex to validate feature flag name (e.g. ^.+-\d{8}-.+$)
   requireProjectForFeatures?: boolean;
   requireProjectForSdkConnections?: boolean;
-  // When true, users with edit permission for a feature can manage Custom Hooks
-  // scoped to that feature without the org-wide manageCustomHooks (admin)
-  // permission. Global/project-scoped hooks still require admin.
-  allowPerFeatureCustomHooks?: boolean;
   // When true, saving a feature rule or experiment rejects hashAttribute,
   // fallbackAttribute, or condition keys that don't appear (unarchived) in
   // attributeSchema. Prevents typo'd attributes silently never matching at


### PR DESCRIPTION
## Background

There are 2 ways to add validation to features in GrowthBook.
- JSON feature flags can add a JSON schema that is used to validate values against
- Custom hooks run javascript snippets in a sandbox vm every time a feature is about to change and gives you an opportunity to throw an error

## Changes

This PR expands the validation options and improves the UX. Specifically:

1. JSON Schema validation can now be enabled for string/number flags in addition to JSON flags.  Use this to enforce things like min/max length or restrict the set of allowed values using an enum.
2. Allow custom hooks to be scoped to a single feature flag instead of applying to all features in a project. This lets you write one-off custom validation logic as part of your feature definition.
3. Add a new "Validation" tab on feature detail pages to manage both JSON Schema validation and Custom Hooks

This PR also hardens the sandbox eval code against both malicious and accidental abuse. This is necessary since custom hooks can now be created by non-admins.  Specifically, the following was done:
- Protect against log/warning flood by imposing a max size
- Fix to properly kill async code that extends beyond wall clock timeout
- Move all sandbox evaluation to separate child processes to protect the main server against segfaults or similar fatal errors

Lastly, this PR fixes a pre-existing bug with custom hooks. When performing certain feature actions, side effects were being saved before running custom hooks. If the hook were to throw, the feature could end up in an inconsistent or broken state. Now, to fix this, custom hooks are run twice in most cases - once at the start of the request to pre-validate everything, and again when actually doing the save in the database.

## Testing

- [x] Global custom hooks continue to run after hardening work
- [x] Per-feature custom hooks run properly
- [x] Simple schema validation works for string flags
- [x] JSON Schema validation works for string flags
- [x] Simple schema validation works for number flags
- [x] JSON Schema validation works for number flags
- [x] Test custom hooks in a production build

## Screenshots

New "Validation" tab for features.  JSON Schema validation enabled for a number flag.  One global hook + one feature-specific hook.

<img width="1345" height="662" alt="image" src="https://github.com/user-attachments/assets/bbc3238c-4fae-459a-b7a9-a6b2e91c145f" />

UI for adding a new feature-specific hook (test data pre-filled with the current feature state):

<img width="1398" height="762" alt="image" src="https://github.com/user-attachments/assets/bbdc8e33-f6ca-423c-8c5d-7c08817c06f9" />
