### PR TITLE
Add missing permission checks for Archetypes API

### DIFF
--- a/packages/back-end/src/api/archetypes/deleteArchetype.ts
+++ b/packages/back-end/src/api/archetypes/deleteArchetype.ts
@@ -9,6 +9,12 @@ import { auditDetailsDelete } from "back-end/src/services/audit";
 export const deleteArchetype = createApiRequestHandler(
   deleteArchetypeValidator,
 )(async (req) => {
+  if (!req.context.hasPremiumFeature("archetypes")) {
+    req.context.throwPlanDoesNotAllowError(
+      "Archetypes require a premium plan.",
+    );
+  }
+
   const { id } = req.params;
   const orgId = req.organization.id;
   const archetype = await getArchetypeById(id, orgId);

--- a/packages/back-end/src/api/archetypes/getArchetype.ts
+++ b/packages/back-end/src/api/archetypes/getArchetype.ts
@@ -8,6 +8,12 @@ import {
 
 export const getArchetype = createApiRequestHandler(getArchetypeValidator)(
   async (req) => {
+    if (!req.context.hasPremiumFeature("archetypes")) {
+      req.context.throwPlanDoesNotAllowError(
+        "Archetypes require a premium plan.",
+      );
+    }
+
     const { id } = req.params;
     const orgId = req.organization.id;
     const archetype = await getArchetypeById(id, orgId);

--- a/packages/back-end/src/api/archetypes/listArchetypes.ts
+++ b/packages/back-end/src/api/archetypes/listArchetypes.ts
@@ -8,6 +8,12 @@ import {
 
 export const listArchetypes = createApiRequestHandler(listArchetypesValidator)(
   async (req) => {
+    if (!req.context.hasPremiumFeature("archetypes")) {
+      req.context.throwPlanDoesNotAllowError(
+        "Archetypes require a premium plan.",
+      );
+    }
+
     const archetypes = await getAllArchetypes(
       req.context.org.id,
       req.context.userId,

--- a/packages/back-end/src/api/archetypes/postArchetype.ts
+++ b/packages/back-end/src/api/archetypes/postArchetype.ts
@@ -10,7 +10,17 @@ import { validatePayload } from "./validations";
 
 export const postArchetype = createApiRequestHandler(postArchetypeValidator)(
   async (req) => {
+    if (!req.context.hasPremiumFeature("archetypes")) {
+      req.context.throwPlanDoesNotAllowError(
+        "Archetypes require a premium plan.",
+      );
+    }
+
     const payload = await validatePayload(req.context, req.body);
+
+    if (!req.context.permissions.canCreateArchetype(payload))
+      req.context.permissions.throwPermissionError();
+
     const archetype = await createArchetype(payload);
 
     await req.audit({

--- a/packages/back-end/src/api/archetypes/putArchetype.ts
+++ b/packages/back-end/src/api/archetypes/putArchetype.ts
@@ -11,6 +11,12 @@ import { validatePayload } from "./validations";
 
 export const putArchetype = createApiRequestHandler(putArchetypeValidator)(
   async (req) => {
+    if (!req.context.hasPremiumFeature("archetypes")) {
+      req.context.throwPlanDoesNotAllowError(
+        "Archetypes require a premium plan.",
+      );
+    }
+
     const { id } = req.params;
     const orgId = req.organization.id;
     const archetype = await getArchetypeById(id, orgId);


### PR DESCRIPTION
### Features and Changes

Archetypes API endpoints were overly permissive for the premium flag and the POST endpoint was missing a canCreate check
