### PR TITLE
Add missing CodeRefs API permissions

### DIFF
--- a/packages/back-end/src/api/code-refs/getCodeRefs.ts
+++ b/packages/back-end/src/api/code-refs/getCodeRefs.ts
@@ -1,5 +1,6 @@
 import { getCodeRefsValidator } from "shared/validators";
 import { createApiRequestHandler } from "back-end/src/util/handler";
+import { NotFoundError } from "back-end/src/util/errors";
 import {
   getAllCodeRefsForFeature,
   toApiInterface,
@@ -10,10 +11,11 @@ export const getCodeRefs = createApiRequestHandler(getCodeRefsValidator)(async (
   req,
 ) => {
   // Code ref flag keys equal feature ids. getFeature returns null when the
-  // feature doesn't exist or the caller can't read its project.
+  // feature doesn't exist or the caller can't read its project. Return the same
+  // 404 in both cases so we don't leak the existence of inaccessible features.
   const feature = await getFeature(req.context, req.params.id);
   if (!feature) {
-    return { codeRefs: [] };
+    throw new NotFoundError("Feature not found");
   }
 
   const codeRefs = (

--- a/packages/back-end/src/api/code-refs/getCodeRefs.ts
+++ b/packages/back-end/src/api/code-refs/getCodeRefs.ts
@@ -4,10 +4,18 @@ import {
   getAllCodeRefsForFeature,
   toApiInterface,
 } from "back-end/src/models/FeatureCodeRefs";
+import { getFeature } from "back-end/src/models/FeatureModel";
 
 export const getCodeRefs = createApiRequestHandler(getCodeRefsValidator)(async (
   req,
 ) => {
+  // Code ref flag keys equal feature ids. getFeature returns null when the
+  // feature doesn't exist or the caller can't read its project.
+  const feature = await getFeature(req.context, req.params.id);
+  if (!feature) {
+    return { codeRefs: [] };
+  }
+
   const codeRefs = (
     await getAllCodeRefsForFeature({
       organization: req.context.org,

--- a/packages/back-end/src/api/code-refs/listCodeRefs.ts
+++ b/packages/back-end/src/api/code-refs/listCodeRefs.ts
@@ -8,12 +8,25 @@ import {
   toApiInterface,
   uniqueId,
 } from "back-end/src/models/FeatureCodeRefs";
+import { getFeaturesByIds } from "back-end/src/models/FeatureModel";
 
 export const listCodeRefs = createApiRequestHandler(listCodeRefsValidator)(
   async (req) => {
-    const allCodeRefs = await getAllCodeRefsForOrg({
-      context: req.context,
-    });
+    const orgCodeRefs = await getAllCodeRefsForOrg({ context: req.context });
+
+    // Code ref flag keys equal feature ids. getFeaturesByIds drops features the
+    // caller can't read, so only refs for readable features survive the filter.
+    const readableFeatures = new Set(
+      (
+        await getFeaturesByIds(
+          req.context,
+          orgCodeRefs.map((r) => r.feature),
+        )
+      ).map((f) => f.id),
+    );
+    const allCodeRefs = orgCodeRefs.filter((r) =>
+      readableFeatures.has(r.feature),
+    );
 
     const { filtered, returnFields } = applyPagination(
       allCodeRefs.sort((a, b) => uniqueId(a).localeCompare(uniqueId(b))),

--- a/packages/back-end/src/api/code-refs/postCodeRefs.ts
+++ b/packages/back-end/src/api/code-refs/postCodeRefs.ts
@@ -37,8 +37,7 @@ export const postCodeRefs = createApiRequestHandler(postCodeRefsValidator)(
     // touching the collection. Code ref flag keys equal feature ids. Resolve the
     // project of each existing feature (regardless of the caller's read access)
     // so a feature in a project the caller can't reach is still checked against
-    // that project — not silently treated as a non-existent key. Keys with no
-    // matching feature in the org fall back to a global manageFeatures check.
+    // that project — not silently treated as a non-existent key.
     const affectedFeatureIds = [
       ...new Set([...requestedFeatures, ...featuresToRemove]),
     ];
@@ -48,13 +47,21 @@ export const postCodeRefs = createApiRequestHandler(postCodeRefsValidator)(
     );
     const cannotWriteAll = affectedFeatureIds.some((featureId) => {
       if (featureProjects.has(featureId)) {
+        // Existing feature: require write access to its project.
         const project = featureProjects.get(featureId);
         return !req.context.permissions.canUpdateFeature(
           { project },
           { project },
         );
       }
-      return !req.context.permissions.canCreateFeature({});
+      // No matching feature in the org. When upserting, this is a flag key with
+      // no GrowthBook feature, gated on a global manageFeatures check. When only
+      // clearing (deleteMissing), the feature was deleted and we're just removing
+      // its dangling refs — there's no project to gate on, so allow it.
+      if (requestedFeatures.has(featureId)) {
+        return !req.context.permissions.canCreateFeature({});
+      }
+      return false;
     });
     if (cannotWriteAll) {
       req.context.permissions.throwPermissionError();

--- a/packages/back-end/src/api/code-refs/postCodeRefs.ts
+++ b/packages/back-end/src/api/code-refs/postCodeRefs.ts
@@ -7,7 +7,7 @@ import {
   getFeatureKeysForRepoBranch,
   upsertFeatureCodeRefs,
 } from "back-end/src/models/FeatureCodeRefs";
-import { getFeaturesByIds } from "back-end/src/models/FeatureModel";
+import { getFeatureProjectsByIds } from "back-end/src/models/FeatureModel";
 
 export const postCodeRefs = createApiRequestHandler(postCodeRefsValidator)(
   async (req) => {
@@ -34,22 +34,27 @@ export const postCodeRefs = createApiRequestHandler(postCodeRefsValidator)(
     }
 
     // Require write access to every feature being upserted or cleared before
-    // touching the collection. Code ref flag keys equal feature ids; keys with
-    // no matching feature require global manageFeatures.
+    // touching the collection. Code ref flag keys equal feature ids. Resolve the
+    // project of each existing feature (regardless of the caller's read access)
+    // so a feature in a project the caller can't reach is still checked against
+    // that project — not silently treated as a non-existent key. Keys with no
+    // matching feature in the org fall back to a global manageFeatures check.
     const affectedFeatureIds = [
       ...new Set([...requestedFeatures, ...featuresToRemove]),
     ];
-    const featuresMap = new Map(
-      (await getFeaturesByIds(req.context, affectedFeatureIds)).map((f) => [
-        f.id,
-        f,
-      ]),
+    const featureProjects = await getFeatureProjectsByIds(
+      req.context,
+      affectedFeatureIds,
     );
     const cannotWriteAll = affectedFeatureIds.some((featureId) => {
-      const feature = featuresMap.get(featureId);
-      return feature
-        ? !req.context.permissions.canUpdateFeature(feature, feature)
-        : !req.context.permissions.canCreateFeature({});
+      if (featureProjects.has(featureId)) {
+        const project = featureProjects.get(featureId);
+        return !req.context.permissions.canUpdateFeature(
+          { project },
+          { project },
+        );
+      }
+      return !req.context.permissions.canCreateFeature({});
     });
     if (cannotWriteAll) {
       req.context.permissions.throwPermissionError();

--- a/packages/back-end/src/api/code-refs/postCodeRefs.ts
+++ b/packages/back-end/src/api/code-refs/postCodeRefs.ts
@@ -7,6 +7,7 @@ import {
   getFeatureKeysForRepoBranch,
   upsertFeatureCodeRefs,
 } from "back-end/src/models/FeatureCodeRefs";
+import { getFeaturesByIds } from "back-end/src/models/FeatureModel";
 
 export const postCodeRefs = createApiRequestHandler(postCodeRefsValidator)(
   async (req) => {
@@ -30,7 +31,31 @@ export const postCodeRefs = createApiRequestHandler(postCodeRefsValidator)(
       featuresToRemove = existingFeatures.filter(
         (feature) => !requestedFeatures.has(feature),
       );
+    }
 
+    // Require write access to every feature being upserted or cleared before
+    // touching the collection. Code ref flag keys equal feature ids; keys with
+    // no matching feature require global manageFeatures.
+    const affectedFeatureIds = [
+      ...new Set([...requestedFeatures, ...featuresToRemove]),
+    ];
+    const featuresMap = new Map(
+      (await getFeaturesByIds(req.context, affectedFeatureIds)).map((f) => [
+        f.id,
+        f,
+      ]),
+    );
+    const cannotWriteAll = affectedFeatureIds.some((featureId) => {
+      const feature = featuresMap.get(featureId);
+      return feature
+        ? !req.context.permissions.canUpdateFeature(feature, feature)
+        : !req.context.permissions.canCreateFeature({});
+    });
+    if (cannotWriteAll) {
+      req.context.permissions.throwPermissionError();
+    }
+
+    if (deleteMissing) {
       // Remove references for features not in the request by setting empty refs
       await promiseAllChunks(
         featuresToRemove.map(

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -609,6 +609,22 @@ export async function getFeaturesByIds(
   );
 }
 
+// Returns id -> project for every feature that exists in the org, regardless of
+// the caller's read permission. Intended for permission decisions where missing
+// (inaccessible) and non-existent features must be distinguished — do not use it
+// to return feature data to the caller.
+export async function getFeatureProjectsByIds(
+  context: ReqContext | ApiReqContext,
+  ids: string[],
+): Promise<Map<string, string | undefined>> {
+  if (!ids.length) return new Map();
+  const features = await FeatureModel.find(
+    { organization: context.org.id, id: { $in: ids } },
+    { projection: { id: 1, project: 1, _id: 0 } },
+  );
+  return new Map(features.map((f) => [f.id, f.project || undefined]));
+}
+
 export async function createFeature(
   context: ReqContext | ApiReqContext,
   data: FeatureInterface,

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -620,7 +620,7 @@ export async function getFeatureProjectsByIds(
   if (!ids.length) return new Map();
   const features = await FeatureModel.find(
     { organization: context.org.id, id: { $in: ids } },
-    { projection: { id: 1, project: 1, _id: 0 } },
+    { id: 1, project: 1, _id: 0 },
   );
   return new Map(features.map((f) => [f.id, f.project || undefined]));
 }


### PR DESCRIPTION
### Features and Changes

The CodeRefs API endpoints weren't properly checking permissions against the linked features. This PR uses existing feature helpers to enforce permissions.

