### PR TITLE
Add extra hardening for proxy URL resolution

### DIFF
--- a/packages/back-end/src/routers/importing/importing.controller.ts
+++ b/packages/back-end/src/routers/importing/importing.controller.ts
@@ -16,17 +16,29 @@ function validateHttpMethod(method: string): AllowedHttpMethod {
 }
 
 // Resolve a user-supplied path/segment against a fixed base URL and ensure it
-// stays on the expected host. Using the URL constructor neutralizes authority
-// injection (e.g. a leading "@" or "//") that string concatenation would allow,
-// preventing SSRF to arbitrary hosts.
+// stays on the expected host and within the base path. Using the URL
+// constructor neutralizes authority injection (e.g. a leading "@" or "//") that
+// string concatenation would allow, preventing SSRF to arbitrary hosts.
 function resolveProxyUrl(pathOrSegment: string, baseUrl: string): string {
+  const base = new URL(baseUrl);
+
+  // Strip leading slashes so the input always resolves relative to the base
+  // path. Without this, "/foo" would resolve from the host root and drop the
+  // base path entirely (e.g. ".../console/v1/" + "/foo" -> "/foo").
+  const relative = pathOrSegment.replace(/^\/+/, "");
+
   let resolved: URL;
   try {
-    resolved = new URL(pathOrSegment, baseUrl);
+    resolved = new URL(relative, baseUrl);
   } catch {
     throw new UnrecoverableApiError("Invalid request URL.");
   }
-  if (resolved.origin !== new URL(baseUrl).origin) {
+  // Reject anything that changes the host (authority injection) or escapes the
+  // base path via "../" traversal.
+  if (
+    resolved.origin !== base.origin ||
+    !resolved.pathname.startsWith(base.pathname)
+  ) {
     throw new UnrecoverableApiError("Invalid request URL.");
   }
   return resolved.toString();

--- a/packages/back-end/src/routers/importing/importing.controller.ts
+++ b/packages/back-end/src/routers/importing/importing.controller.ts
@@ -3,6 +3,7 @@ import { AuthRequest } from "back-end/src/types/AuthRequest";
 import { fetch } from "back-end/src/util/http.util";
 import { IS_CLOUD } from "back-end/src/util/secrets";
 import { UnrecoverableApiError } from "back-end/src/util/errors";
+import { resolveProxyUrl } from "back-end/src/routers/importing/importing.util";
 
 // Allowed HTTP methods for proxy requests
 const ALLOWED_HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH"] as const;
@@ -13,35 +14,6 @@ function validateHttpMethod(method: string): AllowedHttpMethod {
     throw new UnrecoverableApiError(`Invalid HTTP method: ${method}.`);
   }
   return method as AllowedHttpMethod;
-}
-
-// Resolve a user-supplied path/segment against a fixed base URL and ensure it
-// stays on the expected host and within the base path. Using the URL
-// constructor neutralizes authority injection (e.g. a leading "@" or "//") that
-// string concatenation would allow, preventing SSRF to arbitrary hosts.
-function resolveProxyUrl(pathOrSegment: string, baseUrl: string): string {
-  const base = new URL(baseUrl);
-
-  // Strip leading slashes so the input always resolves relative to the base
-  // path. Without this, "/foo" would resolve from the host root and drop the
-  // base path entirely (e.g. ".../console/v1/" + "/foo" -> "/foo").
-  const relative = pathOrSegment.replace(/^\/+/, "");
-
-  let resolved: URL;
-  try {
-    resolved = new URL(relative, baseUrl);
-  } catch {
-    throw new UnrecoverableApiError("Invalid request URL.");
-  }
-  // Reject anything that changes the host (authority injection) or escapes the
-  // base path via "../" traversal.
-  if (
-    resolved.origin !== base.origin ||
-    !resolved.pathname.startsWith(base.pathname)
-  ) {
-    throw new UnrecoverableApiError("Invalid request URL.");
-  }
-  return resolved.toString();
 }
 
 export const proxyStatsigRequest = async (

--- a/packages/back-end/src/routers/importing/importing.controller.ts
+++ b/packages/back-end/src/routers/importing/importing.controller.ts
@@ -65,9 +65,11 @@ export const proxyStatsigRequest = async (
   // Validate HTTP method
   const validatedMethod = validateHttpMethod(method);
 
-  try {
-    const url = resolveProxyUrl(endpoint, "https://statsigapi.net/console/v1/");
+  // Resolve the URL before the try block so an invalid/origin-violating URL
+  // surfaces as a 4xx (via the global error handler) rather than a 500.
+  const url = resolveProxyUrl(endpoint, "https://statsigapi.net/console/v1/");
 
+  try {
     const response = await fetch(url, {
       method: validatedMethod,
       headers: {
@@ -118,9 +120,11 @@ export const proxyLaunchDarklyRequest = async (
     });
   }
 
-  try {
-    const fullUrl = resolveProxyUrl(url, "https://app.launchdarkly.com");
+  // Resolve the URL before the try block so an invalid/origin-violating URL
+  // surfaces as a 4xx (via the global error handler) rather than a 500.
+  const fullUrl = resolveProxyUrl(url, "https://app.launchdarkly.com");
 
+  try {
     const response = await fetch(fullUrl, {
       headers: {
         Authorization: apiToken,

--- a/packages/back-end/src/routers/importing/importing.controller.ts
+++ b/packages/back-end/src/routers/importing/importing.controller.ts
@@ -15,6 +15,23 @@ function validateHttpMethod(method: string): AllowedHttpMethod {
   return method as AllowedHttpMethod;
 }
 
+// Resolve a user-supplied path/segment against a fixed base URL and ensure it
+// stays on the expected host. Using the URL constructor neutralizes authority
+// injection (e.g. a leading "@" or "//") that string concatenation would allow,
+// preventing SSRF to arbitrary hosts.
+function resolveProxyUrl(pathOrSegment: string, baseUrl: string): string {
+  let resolved: URL;
+  try {
+    resolved = new URL(pathOrSegment, baseUrl);
+  } catch {
+    throw new UnrecoverableApiError("Invalid request URL.");
+  }
+  if (resolved.origin !== new URL(baseUrl).origin) {
+    throw new UnrecoverableApiError("Invalid request URL.");
+  }
+  return resolved.toString();
+}
+
 export const proxyStatsigRequest = async (
   req: AuthRequest<{
     endpoint: string;
@@ -49,7 +66,7 @@ export const proxyStatsigRequest = async (
   const validatedMethod = validateHttpMethod(method);
 
   try {
-    const url = `https://statsigapi.net/console/v1/${endpoint}`;
+    const url = resolveProxyUrl(endpoint, "https://statsigapi.net/console/v1/");
 
     const response = await fetch(url, {
       method: validatedMethod,
@@ -102,7 +119,7 @@ export const proxyLaunchDarklyRequest = async (
   }
 
   try {
-    const fullUrl = `https://app.launchdarkly.com${url}`;
+    const fullUrl = resolveProxyUrl(url, "https://app.launchdarkly.com");
 
     const response = await fetch(fullUrl, {
       headers: {

--- a/packages/back-end/src/routers/importing/importing.util.ts
+++ b/packages/back-end/src/routers/importing/importing.util.ts
@@ -1,0 +1,33 @@
+import { UnrecoverableApiError } from "back-end/src/util/errors";
+
+// Resolve a user-supplied path/segment against a fixed base URL and ensure it
+// stays on the expected host and within the base path. Using the URL
+// constructor neutralizes authority injection (e.g. a leading "@" or "//") that
+// string concatenation would allow, preventing SSRF to arbitrary hosts.
+export function resolveProxyUrl(
+  pathOrSegment: string,
+  baseUrl: string,
+): string {
+  const base = new URL(baseUrl);
+
+  // Strip leading slashes so the input always resolves relative to the base
+  // path. Without this, "/foo" would resolve from the host root and drop the
+  // base path entirely (e.g. ".../console/v1/" + "/foo" -> "/foo").
+  const relative = pathOrSegment.replace(/^\/+/, "");
+
+  let resolved: URL;
+  try {
+    resolved = new URL(relative, baseUrl);
+  } catch {
+    throw new UnrecoverableApiError("Invalid request URL.");
+  }
+  // Reject anything that changes the host (authority injection) or escapes the
+  // base path via "../" traversal.
+  if (
+    resolved.origin !== base.origin ||
+    !resolved.pathname.startsWith(base.pathname)
+  ) {
+    throw new UnrecoverableApiError("Invalid request URL.");
+  }
+  return resolved.toString();
+}

--- a/packages/back-end/test/routers/importing.util.test.ts
+++ b/packages/back-end/test/routers/importing.util.test.ts
@@ -1,0 +1,78 @@
+import { resolveProxyUrl } from "back-end/src/routers/importing/importing.util";
+
+const STATSIG_BASE = "https://statsigapi.net/console/v1/";
+const LAUNCHDARKLY_BASE = "https://app.launchdarkly.com";
+
+describe("resolveProxyUrl", () => {
+  describe("Statsig base (with path prefix)", () => {
+    it.each([
+      ["gates", "https://statsigapi.net/console/v1/gates"],
+      ["metrics/list", "https://statsigapi.net/console/v1/metrics/list"],
+      [
+        "metrics/metric_source/list",
+        "https://statsigapi.net/console/v1/metrics/metric_source/list",
+      ],
+      [
+        "experiments?page=2",
+        "https://statsigapi.net/console/v1/experiments?page=2",
+      ],
+    ])("resolves legitimate segment %p", (input, expected) => {
+      expect(resolveProxyUrl(input, STATSIG_BASE)).toBe(expected);
+    });
+
+    it.each([
+      // Leading slashes are stripped and treated as relative to the base path
+      ["/foo", "https://statsigapi.net/console/v1/foo"],
+      ["/metrics/list", "https://statsigapi.net/console/v1/metrics/list"],
+      // Protocol-relative authority injection is neutralized to a same-host path
+      ["//evil.com", "https://statsigapi.net/console/v1/evil.com"],
+      // "@" stays a path segment, not userinfo
+      ["@evil.com", "https://statsigapi.net/console/v1/@evil.com"],
+    ])("neutralizes %p to stay on host/path", (input, expected) => {
+      expect(resolveProxyUrl(input, STATSIG_BASE)).toBe(expected);
+    });
+
+    it.each([
+      ["../foo"], // escapes the base path
+      ["../../secrets"],
+      ["https://evil.com"], // absolute URL to another host
+      ["https://evil.com/console/v1/x"],
+    ])("rejects %p", (input) => {
+      expect(() => resolveProxyUrl(input, STATSIG_BASE)).toThrow(
+        "Invalid request URL.",
+      );
+    });
+  });
+
+  describe("LaunchDarkly base (no path prefix)", () => {
+    it.each([
+      [
+        "/api/v2/projects?limit=300",
+        "https://app.launchdarkly.com/api/v2/projects?limit=300",
+      ],
+      [
+        "/api/v2/flags/x?summary=true",
+        "https://app.launchdarkly.com/api/v2/flags/x?summary=true",
+      ],
+      ["api/v2/x", "https://app.launchdarkly.com/api/v2/x"],
+    ])("resolves legitimate path %p", (input, expected) => {
+      expect(resolveProxyUrl(input, LAUNCHDARKLY_BASE)).toBe(expected);
+    });
+
+    it.each([
+      ["//evil.com", "https://app.launchdarkly.com/evil.com"],
+      ["@evil.com/x", "https://app.launchdarkly.com/@evil.com/x"],
+    ])("neutralizes %p to stay on host", (input, expected) => {
+      expect(resolveProxyUrl(input, LAUNCHDARKLY_BASE)).toBe(expected);
+    });
+
+    it.each([["https://evil.com"], ["https://evil.com/api/v2/x"]])(
+      "rejects %p",
+      (input) => {
+        expect(() => resolveProxyUrl(input, LAUNCHDARKLY_BASE)).toThrow(
+          "Invalid request URL.",
+        );
+      },
+    );
+  });
+});


### PR DESCRIPTION
### Features and Changes

Replaces the url string interpolation with a helper that delegates to `new URL` to ensure that control characters like `@` are sanitized and enforces the origin hasn't changed.

### Testing

Added unit test covering the following cases
**Statsig** (base `https://statsigapi.net/console/v1/`)

| Input | Result |
|-------|--------|
| `gates` | ✅ `https://statsigapi.net/console/v1/gates` |
| `metrics/list` | ✅ `https://statsigapi.net/console/v1/metrics/list` |
| `metrics/metric_source/list` | ✅ `https://statsigapi.net/console/v1/metrics/metric_source/list` |
| `experiments?page=2` | ✅ `https://statsigapi.net/console/v1/experiments?page=2` |
| `/foo` | ✅ `https://statsigapi.net/console/v1/foo` (leading slash stripped) |
| `//evil.com` | ✅ `https://statsigapi.net/console/v1/evil.com` (authority injection neutralized to same-host path) |
| `@evil.com` | ✅ `https://statsigapi.net/console/v1/@evil.com` (stays on host as path segment) |
| `../foo` | 🚫 rejected — escapes base path |
| `https://evil.com` | 🚫 rejected — host mismatch |

**LaunchDarkly** (base `https://app.launchdarkly.com`)

| Input | Result |
|-------|--------|
| `/api/v2/projects?limit=300` | ✅ `https://app.launchdarkly.com/api/v2/projects?limit=300` |
| `/api/v2/flags/x?summary=true` | ✅ `https://app.launchdarkly.com/api/v2/flags/x?summary=true` |
| `api/v2/x` | ✅ `https://app.launchdarkly.com/api/v2/x` |
| `//evil.com` | ✅ `https://app.launchdarkly.com/evil.com` (neutralized to same-host path) |
| `@evil.com/x` | ✅ `https://app.launchdarkly.com/@evil.com/x` (stays on host as path segment) |
| `../etc` | ✅ `https://app.launchdarkly.com/etc` (base path is `/`, so no escape) |

