### PR TITLE
feat(cuped-aggregation): Update API permission to match UI + Add wide event log

### DIFF
--- a/packages/back-end/src/api/fact-tables/postFactTable.ts
+++ b/packages/back-end/src/api/fact-tables/postFactTable.ts
@@ -66,6 +66,9 @@ export const postFactTable = createApiRequestHandler(postFactTableValidator)(
           "Maintaining shared daily aggregated tables requires the data pipeline feature.",
         );
       }
+      if (!req.context.permissions.canUpdateDataSourceSettings(datasource)) {
+        req.context.permissions.throwPermissionError();
+      }
       validateAggregatedFactTableSettings(
         req.body.aggregatedFactTableSettings,
         req.body.userIdTypes,

--- a/packages/back-end/src/api/fact-tables/refreshAggregatedFactTable.ts
+++ b/packages/back-end/src/api/fact-tables/refreshAggregatedFactTable.ts
@@ -1,5 +1,6 @@
 import { refreshAggregatedFactTableValidator } from "shared/validators";
 import { getFactTable } from "back-end/src/models/FactTableModel";
+import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { runAggregatedFactTableUpdate } from "back-end/src/services/aggregatedFactTables";
 
@@ -17,7 +18,12 @@ export const refreshAggregatedFactTable = createApiRequestHandler(
     );
   }
 
-  if (!req.context.permissions.canUpdateFactTable(factTable, {})) {
+  const datasource = await getDataSourceById(req.context, factTable.datasource);
+  if (!datasource) {
+    throw new Error("Could not find datasource for this fact table");
+  }
+
+  if (!req.context.permissions.canUpdateDataSourceSettings(datasource)) {
     req.context.permissions.throwPermissionError();
   }
 

--- a/packages/back-end/src/api/fact-tables/updateFactTable.ts
+++ b/packages/back-end/src/api/fact-tables/updateFactTable.ts
@@ -41,12 +41,11 @@ export const updateFactTable = createApiRequestHandler(
     }
   }
 
+  let datasource: Awaited<ReturnType<typeof getDataSourceById>> | undefined;
+
   // Validate userIdTypes
   if (req.body.userIdTypes) {
-    const datasource = await getDataSourceById(
-      req.context,
-      factTable.datasource,
-    );
+    datasource ??= await getDataSourceById(req.context, factTable.datasource);
     if (!datasource) {
       throw new Error("Could not find datasource for this fact table");
     }
@@ -67,10 +66,7 @@ export const updateFactTable = createApiRequestHandler(
         "Maintaining shared daily aggregated tables requires the data pipeline feature.",
       );
     }
-    const datasource = await getDataSourceById(
-      req.context,
-      factTable.datasource,
-    );
+    datasource ??= await getDataSourceById(req.context, factTable.datasource);
     if (!datasource) {
       throw new Error("Could not find datasource for this fact table");
     }

--- a/packages/back-end/src/api/fact-tables/updateFactTable.ts
+++ b/packages/back-end/src/api/fact-tables/updateFactTable.ts
@@ -67,6 +67,16 @@ export const updateFactTable = createApiRequestHandler(
         "Maintaining shared daily aggregated tables requires the data pipeline feature.",
       );
     }
+    const datasource = await getDataSourceById(
+      req.context,
+      factTable.datasource,
+    );
+    if (!datasource) {
+      throw new Error("Could not find datasource for this fact table");
+    }
+    if (!req.context.permissions.canUpdateDataSourceSettings(datasource)) {
+      req.context.permissions.throwPermissionError();
+    }
     validateAggregatedFactTableSettings(
       req.body.aggregatedFactTableSettings,
       req.body.userIdTypes ?? factTable.userIdTypes,

--- a/packages/back-end/src/routers/fact-table/fact-table.controller.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.controller.ts
@@ -278,6 +278,9 @@ export const postFactTable = async (
         "Maintaining shared daily aggregated tables requires the data pipeline feature.",
       );
     }
+    if (!context.permissions.canUpdateDataSourceSettings(datasource)) {
+      context.permissions.throwPermissionError();
+    }
     validateAggregatedFactTableSettings(
       data.aggregatedFactTableSettings,
       data.userIdTypes,
@@ -357,6 +360,9 @@ export const putFactTable = async (
       throw new Error(
         "Maintaining shared daily aggregated tables requires the data pipeline feature.",
       );
+    }
+    if (!context.permissions.canUpdateDataSourceSettings(datasource)) {
+      context.permissions.throwPermissionError();
     }
     // Validate against the effective userIdTypes after any column refresh.
     const effectiveUserIdTypes =
@@ -604,7 +610,12 @@ export const refreshAggregatedFactTables = async (
     );
   }
 
-  if (!context.permissions.canUpdateFactTable(factTable, {})) {
+  const datasource = await getDataSourceById(context, factTable.datasource);
+  if (!datasource) {
+    throw new Error("Could not find datasource for this fact table");
+  }
+
+  if (!context.permissions.canUpdateDataSourceSettings(datasource)) {
     context.permissions.throwPermissionError();
   }
 
@@ -650,8 +661,15 @@ export const cancelAggregatedFactTableRun = async (
   if (!factTable) {
     throw new Error("Could not find fact table with that id");
   }
+  const factTableDatasource = await getDataSourceById(
+    context,
+    factTable.datasource,
+  );
+  if (!factTableDatasource) {
+    throw new Error("Could not find datasource for this fact table");
+  }
 
-  if (!context.permissions.canUpdateFactTable(factTable, {})) {
+  if (!context.permissions.canUpdateDataSourceSettings(factTableDatasource)) {
     context.permissions.throwPermissionError();
   }
 

--- a/packages/back-end/src/services/aggregatedFactTables.ts
+++ b/packages/back-end/src/services/aggregatedFactTables.ts
@@ -1,5 +1,6 @@
 import uniqid from "uniqid";
 import { getAutoSliceMetrics, isRatioMetric } from "shared/experiments";
+import { DataSourceInterface } from "shared/types/datasource";
 import {
   FactMetricInterface,
   FactTableInterface,
@@ -21,6 +22,81 @@ import {
   buildAggregatedFactTableSchemaState,
   getAggregatedFactTableRestateReason,
 } from "back-end/src/enterprise/services/data-pipeline";
+
+type AggregatedFactTableRestateLogReason =
+  | "forced"
+  | "no-existing-table"
+  | "incomplete-write"
+  | "schema-drift"
+  | null;
+
+function resolveAggregatedFactTableRestateLogReason({
+  mode,
+  forceRestate,
+  hasExistingTable,
+  restateReason,
+}: {
+  mode: AggregatedFactTableRunMode;
+  forceRestate: boolean;
+  hasExistingTable: boolean;
+  restateReason: AggregatedFactTableRestateReason;
+}): AggregatedFactTableRestateLogReason {
+  if (mode === "incremental") return null;
+  if (forceRestate) return "forced";
+  if (!hasExistingTable) return "no-existing-table";
+  return restateReason ?? "schema-drift";
+}
+
+function createAggregatedFactTableUpdateExecutionLogger(meta: {
+  organization: string;
+  datasource: Pick<DataSourceInterface, "id" | "type">;
+  aggregatedFactTableId: string;
+  factTableId: string;
+  idType: string;
+  runId: string;
+  executionId: string;
+  mode: AggregatedFactTableRunMode;
+  restateReason: AggregatedFactTableRestateLogReason;
+}) {
+  const startedAtMs = Date.now();
+  let logged = false;
+
+  return {
+    logUpdateCompleted(
+      context: ReqContext,
+      {
+        status,
+        error,
+      }: {
+        status: "success" | "error";
+        error?: string;
+      },
+    ): void {
+      if (logged) return;
+      logged = true;
+      context.logger.info(
+        {
+          event: "aggregated_fact_table_updated",
+          organization: meta.organization,
+          datasourceId: meta.datasource.id,
+          datasourceType: meta.datasource.type,
+          aggregatedFactTableId: meta.aggregatedFactTableId,
+          factTableId: meta.factTableId,
+          idType: meta.idType,
+          runId: meta.runId,
+          executionId: meta.executionId,
+          mode: meta.mode,
+          restate: meta.mode === "restate",
+          restateReason: meta.restateReason,
+          status,
+          error: error || null,
+          durationMs: Date.now() - startedAtMs,
+        },
+        "Aggregated fact table update completed",
+      );
+    },
+  };
+}
 
 export type AggregatedFactTableMaterializationStatus =
   | "running"
@@ -193,12 +269,6 @@ export async function runAggregatedFactTableUpdate(
     forceRestate || !registry.tableFullName || restateReason !== null
       ? "restate"
       : "incremental";
-  if (restateReason) {
-    logger.info(
-      { factTableId: factTable.id, idType, restateReason },
-      "[aggregated-fact-table] forcing restate",
-    );
-  }
 
   const run = await context.models.aggregatedFactTableRuns.create({
     aggregatedFactTableId: registry.id,
@@ -214,12 +284,33 @@ export async function runAggregatedFactTableUpdate(
     result: null,
   });
 
+  const executionLogger = createAggregatedFactTableUpdateExecutionLogger({
+    organization: context.org.id,
+    datasource: { id: datasource.id, type: datasource.type },
+    aggregatedFactTableId: registry.id,
+    factTableId: factTable.id,
+    idType,
+    runId: run.id,
+    executionId,
+    mode,
+    restateReason: resolveAggregatedFactTableRestateLogReason({
+      mode,
+      forceRestate,
+      hasExistingTable: !!registry.tableFullName,
+      restateReason,
+    }),
+  });
+
   const handleFailure = async (e: unknown) => {
     const message = e instanceof Error ? e.message : String(e);
     logger.error(
       e,
       `Failed to update aggregated fact table for ${factTable.id}/${idType}`,
     );
+    executionLogger.logUpdateCompleted(context, {
+      status: "error",
+      error: message,
+    });
     try {
       await context.models.aggregatedFactTableRuns.updateRunFields(run.id, {
         error: message,
@@ -267,6 +358,7 @@ export async function runAggregatedFactTableUpdate(
   const waitForCompletion = async () => {
     try {
       await runner.waitForResults();
+      executionLogger.logUpdateCompleted(context, { status: "success" });
       logger.debug(
         `Updated aggregated fact table ${factTable.id}/${idType} (${mode})`,
       );


### PR DESCRIPTION
### Features and Changes

Quick follow-up from https://github.com/growthbook/growthbook/pull/6036.

- We updated the UI to check for `updateDataSource` permission, now we updated API to match the same behavior
- Added wide event log when the table is updated

### Testing

- Unit tests pass
