### PR TITLE
Avoid cloneDeep in getFeatureDefinitionsResponse

### DIFF
--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -875,31 +875,44 @@ export async function getFeatureDefinitionsResponse({
   savedGroups?: SavedGroupsValues;
   encryptedSavedGroups?: string;
 }> {
-  features = cloneDeep(features);
-  let processedExperiments: AutoExperiment[] =
-    experiments !== undefined ? cloneDeep(experiments) : [];
-  usedSavedGroups = cloneDeep(usedSavedGroups);
+  const needsSavedGroupInlining =
+    (!capabilities.includes("savedGroupReferences") ||
+      !savedGroupReferencesEnabled) &&
+    (usedSavedGroups?.length ?? 0) > 0 &&
+    !!organization;
 
-  if (experiments !== undefined && !includeDraftExperiments) {
-    processedExperiments = processedExperiments.filter(
-      (e) => e.status !== "draft",
-    );
+  const hasSecureAttributes = attributes?.some((a) =>
+    ["secureString", "secureString[]"].includes(a.datatype),
+  );
+  const needsHashing =
+    !!attributes && !!hasSecureAttributes && secureAttributeSalt !== undefined;
+
+  // Fresh payloads from buildSDKPayloadForConnection are not reused; avoid
+  // cloning unless a downstream pass mutates rule conditions in place.
+  let processedFeatures = features;
+  if (needsSavedGroupInlining || needsHashing) {
+    processedFeatures = cloneDeep(features);
+  }
+
+  let processedExperiments: AutoExperiment[] | undefined;
+  if (experiments !== undefined) {
+    processedExperiments = includeDraftExperiments
+      ? experiments
+      : experiments.filter((e) => e.status !== "draft");
+    if (needsHashing) {
+      processedExperiments = cloneDeep(processedExperiments);
+    }
   }
 
   // Inline saved groups: expand $inGroup to $in when not using savedGroupReferences.
   // When called from buildSDKPayloadForConnection, getFeatureDefinition already expanded; this pass is a no-op.
-  if (
-    (!capabilities.includes("savedGroupReferences") ||
-      !savedGroupReferencesEnabled) &&
-    usedSavedGroups?.length > 0 &&
-    organization
-  ) {
+  if (needsSavedGroupInlining) {
     const savedGroupsMap = Object.fromEntries(
       usedSavedGroups.map((sg) => [sg.id, sg]),
     );
-    for (const k in features) {
-      if (features[k]?.rules) {
-        for (const rule of features[k].rules ?? []) {
+    for (const k in processedFeatures) {
+      if (processedFeatures[k]?.rules) {
+        for (const rule of processedFeatures[k].rules ?? []) {
           if (rule.condition) {
             recursiveWalk(
               rule.condition,
@@ -917,13 +930,14 @@ export async function getFeatureDefinitionsResponse({
     }
   }
 
-  const hasSecureAttributes = attributes?.some((a) =>
-    ["secureString", "secureString[]"].includes(a.datatype),
-  );
-  if (attributes && hasSecureAttributes && secureAttributeSalt !== undefined) {
-    features = applyFeatureHashing(features, attributes, secureAttributeSalt);
+  if (needsHashing) {
+    processedFeatures = applyFeatureHashing(
+      processedFeatures,
+      attributes,
+      secureAttributeSalt,
+    );
 
-    if (experiments !== undefined) {
+    if (processedExperiments !== undefined) {
       processedExperiments = applyExperimentHashing(
         processedExperiments,
         attributes,
@@ -950,7 +964,7 @@ export async function getFeatureDefinitionsResponse({
 
   if (!encryptPayload || !encryptionKey) {
     return {
-      features,
+      features: processedFeatures,
       ...(experiments !== undefined && { experiments: processedExperiments }),
       dateUpdated,
       savedGroups: savedGroupsForPayload,
@@ -958,11 +972,11 @@ export async function getFeatureDefinitionsResponse({
   }
 
   const encryptedFeatures = await encrypt(
-    JSON.stringify(features),
+    JSON.stringify(processedFeatures),
     encryptionKey,
   );
   const encryptedExperiments =
-    experiments !== undefined
+    processedExperiments !== undefined
       ? await encrypt(JSON.stringify(processedExperiments), encryptionKey)
       : undefined;
 

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -43,7 +43,6 @@ import {
   SavedGroupsValues,
   SavedGroupInterface,
 } from "shared/types/saved-group";
-import { clone } from "lodash";
 import { VisualChangesetInterface } from "shared/types/visual-changeset";
 import { ArchetypeAttributeValues } from "shared/types/archetype";
 import {
@@ -2334,7 +2333,7 @@ export function applySavedGroupHashing(
   attributes: SDKAttributeSchema,
   salt: string,
 ): SavedGroupInterface[] {
-  const clonedGroups = clone(savedGroups);
+  const clonedGroups = cloneDeep(savedGroups);
   clonedGroups.forEach((group) => {
     const attribute = attributes.find(
       (attr) => attr.property === group.attributeKey,


### PR DESCRIPTION
## Summary
- Skip unconditional `cloneDeep` in `getFeatureDefinitionsResponse` when building SDK cache payloads
- Deep-clone features only when saved-group inlining or secure-attribute hashing will mutate rule conditions; clone experiments only when hashing runs
- Draft experiment filtering uses a shallow `.filter()` instead of cloning the full experiments array up front

Follow-up to #6060 — on the typical refresh path (saved group references off after upstream expansion, no secure-attribute hashing), this removes another full-payload lodash clone per SDK connection rebuild.

## Test plan
- [ ] `pnpm --filter back-end test sdk-payload-generation.test.ts`
- [ ] Verify SDK payload refresh CPU drops for orgs without secure-attribute hashing (Datadog profiler)
- [ ] Confirm encrypted payloads and secure-attribute hashing still work for connections with `hashSecureAttributes` enabled


Made with [Cursor](https://cursor.com)