### PR TITLE
Fix stale-base draft publish silently reverting concurrent changes

### DIFF
--- a/packages/back-end/src/api/features/postFeatureRevisionPublish.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionPublish.ts
@@ -209,12 +209,14 @@ export async function publishFeatureRevision(
     }),
   });
 
+  // Use `revision.version`, not the request param — publishing a draft built
+  // on a stale base re-versions it to the head of the history.
   const updated = await getRevision({
     context: req.context,
     organization: req.organization.id,
     featureId: feature.id,
     feature,
-    version: req.params.version,
+    version: revision.version,
   });
   const finalRevision = updated ?? revision;
 

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -1557,12 +1557,14 @@ export async function postFeaturePublish(
     }),
   });
 
+  // Use `revision.version`, not the request param — publishing a draft built
+  // on a stale base re-versions it to the head of the history.
   const publishedRevision = await getRevision({
     context,
     organization: org.id,
     featureId: feature.id,
     feature,
-    version: parseInt(version),
+    version: revision.version,
   });
   await dispatchFeatureRevisionEvent(
     context,

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -1194,12 +1194,21 @@ export async function postFeatureReviewOrComment(
 //
 // Idempotent and converges in one round-trip. Mutates `feature` so callers in
 // the same request see the repaired state without re-reading.
+//
+// `reportOnly` (read paths): never mutate — log the drift and return. A GET
+// must not rewrite the feature (and rebuild SDK payloads) based on the live
+// revision; when the revision is the stale side, doing so silently reverts
+// live changes. Write paths (publish, revert) repair for real, and every
+// repair writes an audit entry so it's visible after the fact.
 async function repairFeatureDriftIfNeeded(
   context: ReqContext,
   feature: FeatureInterface,
   live: FeatureRevisionInterface | undefined,
   environmentIds: string[],
-  { throwOnFailure = false }: { throwOnFailure?: boolean } = {},
+  {
+    throwOnFailure = false,
+    reportOnly = false,
+  }: { throwOnFailure?: boolean; reportOnly?: boolean } = {},
 ): Promise<void> {
   if (!live) return;
 
@@ -1222,16 +1231,39 @@ async function repairFeatureDriftIfNeeded(
       orgId: context.org.id,
       defaultValueDrift,
       driftedEnvs,
+      reportOnly,
     },
-    "Repairing feature drift against live revision",
+    reportOnly
+      ? "Feature drift against live revision detected (report-only, not repairing)"
+      : "Repairing feature drift against live revision",
   );
 
+  if (reportOnly) return;
+
   try {
+    const before = { ...feature };
     const repaired = await updateFeature(context, feature, {
       ...(defaultValueDrift ? { defaultValue: live.defaultValue } : {}),
       rules: liveRulesFlat,
     });
     Object.assign(feature, repaired);
+
+    // Surface the repair in the audit log — it changes live feature content
+    // outside any explicit user action, so it must not be silent.
+    try {
+      await context.auditLog({
+        event: "feature.update",
+        entity: { object: "feature", id: feature.id },
+        reason:
+          "Automatic drift repair: feature content disagreed with its live revision",
+        details: auditDetailsUpdate(before, repaired),
+      });
+    } catch (auditErr) {
+      logger.error(
+        { err: auditErr, featureId: feature.id, orgId: context.org.id },
+        "Failed to write audit log for feature drift repair",
+      );
+    }
   } catch (e) {
     logger.error(
       { err: e, featureId: feature.id, orgId: context.org.id },
@@ -1240,8 +1272,7 @@ async function repairFeatureDriftIfNeeded(
     // Write callers (publish, revert) MUST abort if the repair fails —
     // otherwise the subsequent diff runs against the stale `feature.rules`
     // and the operation silently no-ops or produces an incorrect merge
-    // (the exact failure this helper exists to prevent). Read callers
-    // (e.g. getFeatureById) tolerate the stale response.
+    // (the exact failure this helper exists to prevent).
     if (throwOnFailure) {
       throw new Error(
         "Could not reconcile feature with its live revision. Please retry.",
@@ -4739,8 +4770,12 @@ export async function getFeatureById(
     }
   }
 
+  // Read path: report drift but never mutate the feature from a GET. Repair
+  // happens on the next write-path call (publish/revert).
   const live = fullRevisions.find((r) => r.version === feature.version);
-  await repairFeatureDriftIfNeeded(context, feature, live, environments);
+  await repairFeatureDriftIfNeeded(context, feature, live, environments, {
+    reportOnly: true,
+  });
 
   // find code references
   const codeRefs = await getAllCodeRefsForFeature({

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -118,6 +118,7 @@ import {
   deleteAllRevisionsForFeature,
   getRevision,
   markRevisionAsPublished,
+  reversionRevisionToHead,
   updateRevision,
   createRevision,
 } from "./FeatureRevisionModel";
@@ -973,6 +974,12 @@ export async function updateFeature(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
   updates: Partial<FeatureInterface>,
+  options?: {
+    // Optimistic lock: only apply the update if the live version pointer
+    // hasn't moved since the caller read the feature. Used by publish paths
+    // so two concurrent publishes can't silently overwrite each other.
+    expectedVersion?: number;
+  },
 ): Promise<FeatureInterface> {
   const allUpdates = {
     ...updates,
@@ -1037,12 +1044,28 @@ export async function updateFeature(
     }
   }
 
-  await FeatureModel.updateOne(
-    { organization: feature.organization, id: feature.id },
-    {
-      $set: normalizedUpdates,
-    },
-  );
+  const filter: FilterQuery<FeatureInterface> = {
+    organization: feature.organization,
+    id: feature.id,
+  };
+  if (options?.expectedVersion !== undefined) {
+    // `version: null` also matches legacy docs created before revision
+    // versioning that lack the field entirely (it is backfilled at read time).
+    filter.$or = [{ version: options.expectedVersion }, { version: null }];
+  }
+
+  const updateResult = await FeatureModel.updateOne(filter, {
+    $set: normalizedUpdates,
+  });
+
+  if (
+    options?.expectedVersion !== undefined &&
+    updateResult.matchedCount === 0
+  ) {
+    throw new Error(
+      "The feature was changed by someone else while publishing. Please refresh and try again.",
+    );
+  }
 
   if (experimentsAdded.size > 0) {
     await Promise.all(
@@ -1546,7 +1569,9 @@ export async function applyRevisionChanges(
   if (!hasChanges) {
     changes.version = revision.version;
     changes.dateUpdated = new Date();
-    return await updateFeature(context, feature, changes);
+    return await updateFeature(context, feature, changes, {
+      expectedVersion: feature.version,
+    });
   }
 
   if (changes.rules !== undefined) {
@@ -1566,10 +1591,13 @@ export async function applyRevisionChanges(
       context,
       featureWithoutHoldout as FeatureInterface,
       changes,
+      { expectedVersion: feature.version },
     );
   }
 
-  return await updateFeature(context, feature, changes);
+  return await updateFeature(context, feature, changes, {
+    expectedVersion: feature.version,
+  });
 }
 
 // Run HoldoutModel / Experiment side-effects when a feature's holdout
@@ -2207,6 +2235,16 @@ export async function publishRevision({
     await assertFeatureNotLockedByRamp(context, feature.id);
   }
 
+  // Draft version numbers are allocated when the draft is created, so a
+  // revision published while the draft was open can leave the draft numbered
+  // at or below the current live version. Move it to the head of the version
+  // history first so `feature.version` never moves backwards past a
+  // concurrently published revision. Mutates `revision.version`/`baseVersion`.
+  const preReversionVersion = revision.version;
+  if (feature.version >= revision.version) {
+    await reversionRevisionToHead(context, feature, revision);
+  }
+
   // Create ramp schedules BEFORE writing the feature so that a schedule
   // creation failure gates the publish (atomicity: no published feature without
   // its ramp schedule).
@@ -2241,20 +2279,34 @@ export async function publishRevision({
       await applyHoldoutSideEffects(context, feature, result.holdout);
     }
 
+    // Pass the POST-publish feature so the revision document captures the
+    // live state the publish actually produced (the merge result applied on
+    // top of live), not the draft's possibly-stale snapshot.
     await markRevisionAsPublished(
       context,
-      feature,
+      updatedFeature,
       revision,
       context.auditUser,
       comment,
     );
 
+    // Pending-draft entries on experiments were stored with the version the
+    // draft had when it was saved — use the pre-reversion number (and the
+    // current one, in case entries were added after a re-version).
     await clearPendingFeatureDraftsForRevision(
       context,
       revision.featureId,
-      revision.version,
+      preReversionVersion,
       revision.rules,
     );
+    if (revision.version !== preReversionVersion) {
+      await clearPendingFeatureDraftsForRevision(
+        context,
+        revision.featureId,
+        revision.version,
+        revision.rules,
+      );
+    }
   } catch (err) {
     // Roll back pre-created ramp schedules so they don't linger as orphans.
     for (const id of preCreatedScheduleIds) {

--- a/packages/back-end/src/models/FeatureRevisionLogModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionLogModel.ts
@@ -71,6 +71,32 @@ export class FeatureRevisionLogModel extends BaseClass {
     return await this._find({ featureId, version });
   }
 
+  /**
+   * System bookkeeping for publish-time re-versioning of a draft revision:
+   * when the revision document moves to the head of the version history its
+   * log entries must follow so the draft's history stays attached. This is
+   * not a user-facing update (canUpdate is intentionally false), so it writes
+   * through the raw collection.
+   */
+  public async reassignVersion({
+    featureId,
+    fromVersion,
+    toVersion,
+  }: {
+    featureId: string;
+    fromVersion: number;
+    toVersion: number;
+  }) {
+    await this._dangerousGetCollection().updateMany(
+      {
+        organization: this.context.org.id,
+        featureId,
+        version: fromVersion,
+      },
+      { $set: { version: toVersion } },
+    );
+  }
+
   public async deleteAllByFeature(feature: FeatureInterface) {
     // We should keep the log unless the feature itself is deleted.
     if (!this.context.permissions.canDeleteFeature(feature)) {

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -743,6 +743,92 @@ async function getLastRevision(
   return lastRevision ? toInterface(lastRevision, context, feature) : null;
 }
 
+export type RevisionContentSnapshot = Pick<
+  FeatureRevisionInterface,
+  | "defaultValue"
+  | "rules"
+  | "environmentsEnabled"
+  | "prerequisites"
+  | "archived"
+  | "metadata"
+  | "holdout"
+>;
+
+// Builds the complete content snapshot stored on a revision from the parent
+// feature, optionally overlaying explicit `changes`. All fields are always
+// written as a complete snapshot so revisions are self-contained and HEAD can
+// be set to any revision without base traversal. Legacy documents missing
+// these fields are handled defensively at read/apply time.
+//
+// Used at revision creation, and again at publish time (without `changes`) to
+// persist the post-merge live state back onto the published revision so
+// "published revision content == the live state it produced" holds even when
+// the publish merged against a diverged live version.
+export function buildRevisionContentSnapshot({
+  feature,
+  orgEnvs,
+  environments,
+  changes,
+}: {
+  feature: FeatureInterface;
+  orgEnvs: Environment[];
+  environments: string[];
+  changes?: Partial<FeatureRevisionInterface>;
+}): RevisionContentSnapshot {
+  const defaultValue = changes?.defaultValue ?? feature.defaultValue;
+
+  const rules: FeatureRule[] =
+    changes && "rules" in changes && changes.rules !== undefined
+      ? normalizeRulesInputToV2(changes.rules as unknown, {
+          orgEnvs,
+          featureProject: feature.project,
+        })
+      : (feature.rules ?? [])
+          .filter(isPlausibleFeatureRule)
+          .map((r) => upgradeFeatureRule(r));
+
+  const environmentsEnabled: Record<string, boolean> = Object.fromEntries(
+    environments.map((env) => [
+      env,
+      changes?.environmentsEnabled?.[env] ??
+        feature.environmentSettings?.[env]?.enabled ??
+        false,
+    ]),
+  );
+  const prerequisites = changes?.prerequisites ?? feature.prerequisites ?? [];
+  const archived = changes?.archived ?? feature.archived ?? false;
+  const featureMetadataSnapshot: RevisionMetadata = {
+    description: feature.description,
+    owner: feature.owner,
+    project: feature.project,
+    tags: feature.tags,
+    neverStale: feature.neverStale,
+    customFields: feature.customFields,
+    jsonSchema: feature.jsonSchema,
+    valueType: feature.valueType,
+  };
+  // Always store a complete snapshot. Partial changes (e.g. { neverStale: true })
+  // are merged on top so other metadata fields aren't silently dropped.
+  const metadata: RevisionMetadata = changes?.metadata
+    ? { ...featureMetadataSnapshot, ...changes.metadata }
+    : featureMetadataSnapshot;
+  // holdout: explicit null in changes = remove; undefined/absent = carry forward from live
+  const holdout =
+    "holdout" in (changes ?? {})
+      ? (changes!.holdout ?? null)
+      : (feature.holdout ?? null);
+
+  return {
+    defaultValue,
+    rules,
+    environmentsEnabled,
+    prerequisites,
+    archived,
+    metadata,
+    holdout,
+  };
+}
+
 export async function createRevision({
   context,
   feature,
@@ -776,54 +862,20 @@ export async function createRevision({
   const lastRevision = await getLastRevision(context, feature);
   const newVersion = lastRevision ? lastRevision.version + 1 : 1;
 
-  const defaultValue =
-    changes && "defaultValue" in changes
-      ? changes.defaultValue
-      : feature.defaultValue;
-
-  const rules: FeatureRule[] =
-    changes && "rules" in changes && changes.rules !== undefined
-      ? normalizeRulesInputToV2(changes.rules as unknown, {
-          orgEnvs: getEnvironments(context.org),
-          featureProject: feature.project,
-        })
-      : (feature.rules ?? [])
-          .filter(isPlausibleFeatureRule)
-          .map((r) => upgradeFeatureRule(r));
-
-  // All fields are always written as a complete snapshot so revisions are
-  // self-contained and HEAD can be set to any revision without base traversal.
-  // Legacy documents missing these fields are handled defensively at read/apply time.
-  const environmentsEnabled: Record<string, boolean> = Object.fromEntries(
-    environments.map((env) => [
-      env,
-      changes?.environmentsEnabled?.[env] ??
-        feature.environmentSettings?.[env]?.enabled ??
-        false,
-    ]),
-  );
-  const prerequisites = changes?.prerequisites ?? feature.prerequisites ?? [];
-  const archived = changes?.archived ?? feature.archived ?? false;
-  const featureMetadataSnapshot: RevisionMetadata = {
-    description: feature.description,
-    owner: feature.owner,
-    project: feature.project,
-    tags: feature.tags,
-    neverStale: feature.neverStale,
-    customFields: feature.customFields,
-    jsonSchema: feature.jsonSchema,
-    valueType: feature.valueType,
-  };
-  // Always store a complete snapshot. Partial changes (e.g. { neverStale: true })
-  // are merged on top so other metadata fields aren't silently dropped.
-  const metadata: RevisionMetadata = changes?.metadata
-    ? { ...featureMetadataSnapshot, ...changes.metadata }
-    : featureMetadataSnapshot;
-  // holdout: explicit null in changes = remove; undefined/absent = carry forward from live
-  const holdout =
-    "holdout" in (changes ?? {})
-      ? (changes!.holdout ?? null)
-      : (feature.holdout ?? null);
+  const {
+    defaultValue,
+    rules,
+    environmentsEnabled,
+    prerequisites,
+    archived,
+    metadata,
+    holdout,
+  } = buildRevisionContentSnapshot({
+    feature,
+    orgEnvs: getEnvironments(context.org),
+    environments,
+    changes,
+  });
 
   if (!baseVersion) baseVersion = lastRevision?.version;
   if (!baseVersion) {
@@ -1069,6 +1121,93 @@ export async function updateRevision(
   return updatedRevision;
 }
 
+/**
+ * Moves a draft revision to the head of the feature's version history just
+ * before it gets published.
+ *
+ * Draft version numbers are allocated at creation time, so when another
+ * revision is published while the draft is open, the draft's number ends up
+ * below the live `feature.version`. Publishing it as-is would move the live
+ * pointer BACKWARDS past the concurrently published revision: the stale-
+ * numbered revision would shadow it as the "live" revision and drift repair
+ * could silently revert the concurrent change.
+ *
+ * Mutates `revision` in place (`version` + `baseVersion`) and returns the new
+ * version number. Log entries in the revision-log collection are migrated to
+ * the new version so the draft's history stays attached. Embedded review/log
+ * entries live on the revision document itself and move with it.
+ */
+export async function reversionRevisionToHead(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  revision: FeatureRevisionInterface,
+): Promise<number> {
+  const fromVersion = revision.version;
+  let newVersion = fromVersion;
+
+  // Retried on duplicate-key collisions from the
+  // (organization, featureId, version) unique index, mirroring createRevision.
+  await createWithVersionRetry(async () => {
+    const latest = await getLastRevision(context, feature);
+    newVersion = Math.max(latest?.version ?? 0, feature.version) + 1;
+    const result = await FeatureRevisionModel.updateOne(
+      {
+        organization: revision.organization,
+        featureId: revision.featureId,
+        version: fromVersion,
+      },
+      {
+        $set: {
+          version: newVersion,
+          baseVersion: feature.version,
+          dateUpdated: new Date(),
+        },
+      },
+    );
+    if (result.matchedCount === 0) {
+      throw new Error(
+        "Could not re-version the draft revision — it may have been modified concurrently. Please retry.",
+      );
+    }
+  });
+
+  await context.models.featureRevisionLogs.reassignVersion({
+    featureId: revision.featureId,
+    fromVersion,
+    toVersion: newVersion,
+  });
+
+  // Fire and forget - mirrors the other revision-log writes in this file
+  context.models.featureRevisionLogs
+    .create({
+      featureId: revision.featureId,
+      version: newVersion,
+      action: "re-version",
+      subject: `from #${fromVersion} (live revision was #${feature.version} at publish)`,
+      user: context.auditUser ?? revision.createdBy,
+      value: JSON.stringify({ fromVersion, baseVersion: feature.version }),
+    })
+    .catch((e) => {
+      logger.error(e, "Error creating revisionlog");
+    });
+
+  revision.version = newVersion;
+  revision.baseVersion = feature.version;
+  return newVersion;
+}
+
+/**
+ * Marks a revision as published and persists the post-publish live state of
+ * the feature back onto the revision document.
+ *
+ * `feature` MUST be the feature as it stands AFTER the publish was applied
+ * (the return value of `applyRevisionChanges`). When a draft was built on a
+ * stale base, the publish applies a three-way merge result — not the draft's
+ * raw content — so without this write-back the "live" revision would disagree
+ * with the feature and downstream consumers that treat the live revision as
+ * the source of truth (e.g. drift repair) would silently revert the merged-in
+ * concurrent changes.
+ */
 export async function markRevisionAsPublished(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
@@ -1080,12 +1219,20 @@ export async function markRevisionAsPublished(
 
   const revisionComment = revision.comment ? revision.comment : comment;
 
+  const orgEnvs = getEnvironments(context.org);
+  const contentSnapshot = buildRevisionContentSnapshot({
+    feature,
+    orgEnvs,
+    environments: orgEnvs.map((e) => e.id),
+  });
+
   const changes: Partial<FeatureRevisionInterface> = {
     status: "published",
     publishedBy: user,
     datePublished: new Date(),
     dateUpdated: new Date(),
     comment: revisionComment,
+    ...contentSnapshot,
   };
 
   await runValidateFeatureRevisionHooks({

--- a/packages/back-end/test/models/FeatureRevisionModel.publish-race.test.ts
+++ b/packages/back-end/test/models/FeatureRevisionModel.publish-race.test.ts
@@ -1,0 +1,418 @@
+import mongoose from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import {
+  autoMerge,
+  fillRevisionFromFeature,
+  liveRevisionFromFeature,
+} from "shared/util";
+import { FeatureRule } from "shared/types/feature";
+import { EventUser } from "shared/types/events/event-types";
+import { OrganizationInterface } from "shared/types/organization";
+import { ReqContext } from "back-end/types/request";
+import {
+  createRevision,
+  getRevision,
+} from "back-end/src/models/FeatureRevisionModel";
+import { getFeature, publishRevision } from "back-end/src/models/FeatureModel";
+
+// ---------------------------------------------------------------------------
+// Regression test for the stale-base publish race:
+//
+//   1. A draft is created at live version 1 (snapshotting its content).
+//   2. A concurrent publish (e.g. a ramp step advancing a rollout) lands a
+//      NEWER revision and moves feature.version forward.
+//   3. The draft is published.
+//
+// Before the fix, step 3 moved feature.version BACKWARDS to the draft's
+// stale version number, and the published revision document kept its
+// pre-merge snapshot — so the "live" revision disagreed with the feature and
+// drift repair would silently revert the concurrent rollout change.
+//
+// The model functions run against a real in-memory Mongo; heavyweight
+// side-effect services (SDK payload refresh, events, ramp schedules, sandbox
+// hooks) are mocked, mirroring SafeRolloutSnapshotModel.ramp-integration.
+// ---------------------------------------------------------------------------
+
+jest.mock("back-end/src/services/features", () => ({
+  generateRuleId: jest.fn(() => "rule_generated"),
+  addIdsToFlatRules: jest.fn(),
+  getApiFeatureObj: jest.fn(),
+  getNextScheduledUpdate: jest.fn(() => null),
+  getSavedGroupMap: jest.fn(),
+  queueSDKPayloadRefresh: jest.fn(),
+  synthesizeRuleId: jest.fn(() => "rule_synthesized"),
+}));
+
+jest.mock("back-end/src/services/rampSchedule", () => ({
+  appendRampEvent: jest.fn(),
+  assertFeatureNotLockedByRamp: jest.fn(async () => undefined),
+  computeNextProcessAt: jest.fn(),
+  ensureSafeRolloutForMonitoredRamp: jest.fn(),
+  getStartActionsFromRules: jest.fn(() => []),
+  mergeStepsForRunningSchedule: jest.fn(),
+  remapTemplateActions: jest.fn(),
+  startReadyScheduleNow: jest.fn(),
+  syncLinkedSafeRolloutForRampState: jest.fn(),
+}));
+
+jest.mock("back-end/src/enterprise/sandbox/sandbox-eval", () => ({
+  runValidateFeatureHooks: jest.fn(async () => undefined),
+  runValidateFeatureRevisionHooks: jest.fn(async () => undefined),
+}));
+
+jest.mock("back-end/src/services/organizations", () => ({
+  getContextForAgendaJobByOrgId: jest.fn(),
+  getEnvironmentIdsFromOrg: jest.fn(
+    (org: { settings?: { environments?: { id: string }[] } }) =>
+      (org?.settings?.environments ?? []).map((e) => e.id),
+  ),
+}));
+
+jest.mock("back-end/src/services/vercel-native-integration.service", () => ({
+  createVercelExperimentationItemFromFeature: jest.fn(),
+  updateVercelExperimentationItemFromFeature: jest.fn(),
+  deleteVercelExperimentationItemFromFeature: jest.fn(),
+}));
+
+jest.mock("back-end/src/enterprise/saferollouts/safeRolloutUtils", () => ({
+  determineNextSafeRolloutSnapshotAttempt: jest.fn(),
+}));
+
+jest.mock("back-end/src/events/handlers/utils", () => ({
+  getChangedApiFeatureEnvironments: jest.fn(() => []),
+}));
+
+jest.mock("back-end/src/events/handlers/webhooks/event-webhooks-utils", () => ({
+  getObjectDiff: jest.fn(() => ({})),
+}));
+
+jest.mock("back-end/src/models/EventModel", () => ({
+  createEvent: jest.fn(),
+  hasPreviousObject: jest.fn(() => false),
+}));
+
+jest.mock("back-end/src/models/ExperimentModel", () => ({
+  addLinkedFeatureToExperiment: jest.fn(),
+  clearPendingFeatureDraftsForRevision: jest.fn(),
+  getExperimentById: jest.fn(),
+  getExperimentMapForFeature: jest.fn(async () => new Map()),
+  removeLinkedFeatureFromExperiment: jest.fn(),
+  updateExperiment: jest.fn(),
+}));
+
+const ORG_ID = "org_race";
+const FEATURE_ID = "feat_race";
+const ENVIRONMENTS = ["production", "dev"];
+
+const user: EventUser = {
+  type: "dashboard",
+  id: "u_1",
+  email: "u@example.com",
+  name: "Test User",
+};
+
+const org = {
+  id: ORG_ID,
+  settings: {
+    environments: [
+      { id: "production", description: "" },
+      { id: "dev", description: "" },
+    ],
+  },
+} as unknown as OrganizationInterface;
+
+const reassignVersionMock = jest.fn(async () => undefined);
+const revisionLogCreateMock = jest.fn(async () => undefined);
+
+const context = {
+  org,
+  auditUser: user,
+  hasPremiumFeature: jest.fn(() => false),
+  permissions: {
+    canReadSingleProjectResource: jest.fn(() => true),
+  },
+  models: {
+    featureRevisionLogs: {
+      create: revisionLogCreateMock,
+      reassignVersion: reassignVersionMock,
+    },
+    safeRollout: {
+      getByIds: jest.fn(async () => []),
+      getAllPayloadSafeRollouts: jest.fn(async () => new Map()),
+    },
+    rampSchedules: {
+      getAllByFeatureId: jest.fn(async () => []),
+      findByActivatingRevision: jest.fn(async () => []),
+    },
+  },
+} as unknown as ReqContext;
+
+function rolloutRule(coverage: number): FeatureRule {
+  return {
+    id: "r_rollout",
+    type: "rollout",
+    description: "",
+    value: "true",
+    coverage,
+    hashAttribute: "id",
+    enabled: true,
+    condition: "",
+    allEnvironments: false,
+    environments: ["production"],
+  } as FeatureRule;
+}
+
+const FORCE_RULE: FeatureRule = {
+  id: "r_force",
+  type: "force",
+  description: "",
+  value: "true",
+  enabled: true,
+  condition: "",
+  allEnvironments: true,
+} as FeatureRule;
+
+async function insertFixtures() {
+  const now = new Date();
+  await mongoose.connection.db!.collection("features").insertOne({
+    id: FEATURE_ID,
+    organization: ORG_ID,
+    version: 1,
+    dateCreated: now,
+    dateUpdated: now,
+    archived: false,
+    description: "",
+    owner: "",
+    project: "",
+    tags: [],
+    valueType: "boolean",
+    defaultValue: "false",
+    rules: [rolloutRule(0.2)],
+    environmentSettings: {
+      production: { enabled: true },
+      dev: { enabled: true },
+    },
+    prerequisites: [],
+  });
+  await mongoose.connection.db!.collection("featurerevisions").insertOne({
+    organization: ORG_ID,
+    featureId: FEATURE_ID,
+    version: 1,
+    baseVersion: 0,
+    dateCreated: now,
+    dateUpdated: now,
+    datePublished: now,
+    status: "published",
+    createdBy: user,
+    publishedBy: user,
+    comment: "",
+    defaultValue: "false",
+    rules: [rolloutRule(0.2)],
+    environmentsEnabled: { production: true, dev: true },
+    prerequisites: [],
+    archived: false,
+    metadata: {},
+    holdout: null,
+  });
+}
+
+describe("publishing a draft built on a stale base", () => {
+  let mongod: MongoMemoryServer;
+
+  beforeAll(async () => {
+    mongod = await MongoMemoryServer.create();
+    await mongoose.connect(mongod.getUri());
+  }, 60000);
+
+  afterAll(async () => {
+    await mongoose.connection.close();
+    await mongod.stop();
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const collections = mongoose.connection.collections;
+    for (const key in collections) {
+      await collections[key].deleteMany({});
+    }
+    await insertFixtures();
+  });
+
+  it("preserves a concurrently published rollout change and keeps the live revision consistent", async () => {
+    const feature = await getFeature(context, FEATURE_ID);
+    if (!feature) throw new Error("fixture feature missing");
+
+    // 1. A user opens a draft that adds a force rule (rollout untouched).
+    const draft = await createRevision({
+      context,
+      feature,
+      user,
+      environments: ENVIRONMENTS,
+      changes: { rules: [rolloutRule(0.2), FORCE_RULE] },
+      org,
+    });
+    expect(draft.version).toBe(2);
+    expect(draft.baseVersion).toBe(1);
+
+    // 2. A concurrent publish (e.g. ramp step) advances the rollout to 50%
+    //    and lands as a NEWER revision, mirroring featureEntityHandler.
+    const concurrent = await createRevision({
+      context,
+      feature,
+      user,
+      environments: ENVIRONMENTS,
+      changes: { rules: [rolloutRule(0.5)] },
+      org,
+    });
+    await publishRevision({
+      context,
+      feature,
+      revision: concurrent,
+      result: { rules: [rolloutRule(0.5)] },
+      bypassLockdown: true,
+    });
+
+    const featureAfterConcurrent = await getFeature(context, FEATURE_ID);
+    if (!featureAfterConcurrent) throw new Error("feature missing");
+    expect(featureAfterConcurrent.version).toBe(concurrent.version);
+
+    // 3. The user publishes the draft. The merge is computed the same way the
+    //    publish endpoints do.
+    const liveRevision = await getRevision({
+      context,
+      organization: ORG_ID,
+      featureId: FEATURE_ID,
+      feature: featureAfterConcurrent,
+      version: featureAfterConcurrent.version,
+    });
+    const baseRevision = await getRevision({
+      context,
+      organization: ORG_ID,
+      featureId: FEATURE_ID,
+      feature: featureAfterConcurrent,
+      version: draft.baseVersion,
+    });
+    if (!liveRevision || !baseRevision) throw new Error("revisions missing");
+
+    const mergeResult = autoMerge(
+      liveRevisionFromFeature(liveRevision, featureAfterConcurrent),
+      fillRevisionFromFeature(baseRevision, featureAfterConcurrent),
+      draft,
+      ENVIRONMENTS,
+      {},
+    );
+    expect(mergeResult.success).toBe(true);
+    if (!mergeResult.success) return;
+
+    const staleDraftVersion = draft.version;
+    const updatedFeature = await publishRevision({
+      context,
+      feature: featureAfterConcurrent,
+      revision: draft,
+      result: mergeResult.result,
+    });
+
+    // The draft was re-versioned to the head of the history instead of
+    // moving feature.version backwards past the concurrent publish.
+    expect(draft.version).toBeGreaterThan(concurrent.version);
+    expect(updatedFeature.version).toBe(draft.version);
+    expect(reassignVersionMock).toHaveBeenCalledWith({
+      featureId: FEATURE_ID,
+      fromVersion: staleDraftVersion,
+      toVersion: draft.version,
+    });
+
+    // The concurrent rollout change survived the draft publish.
+    const liveRolloutRule = updatedFeature.rules?.find(
+      (r) => r.id === "r_rollout",
+    );
+    expect(liveRolloutRule).toMatchObject({ coverage: 0.5 });
+    expect(updatedFeature.rules?.find((r) => r.id === "r_force")).toBeTruthy();
+
+    // The published revision document holds the post-merge live content —
+    // the invariant that makes drift repair safe. Before the fix it kept the
+    // draft's stale snapshot (rollout at 0.2).
+    const publishedRevision = await getRevision({
+      context,
+      organization: ORG_ID,
+      featureId: FEATURE_ID,
+      feature: updatedFeature,
+      version: updatedFeature.version,
+    });
+    expect(publishedRevision?.status).toBe("published");
+    expect(
+      publishedRevision?.rules?.find((r) => r.id === "r_rollout"),
+    ).toMatchObject({ coverage: 0.5 });
+    expect(
+      publishedRevision?.rules?.find((r) => r.id === "r_force"),
+    ).toBeTruthy();
+
+    // No revision is left behind under the stale number.
+    const staleDoc = await mongoose.connection
+      .db!.collection("featurerevisions")
+      .findOne({
+        organization: ORG_ID,
+        featureId: FEATURE_ID,
+        version: staleDraftVersion,
+      });
+    expect(staleDoc).toBeNull();
+  });
+
+  it("publishes a fresh draft without re-versioning", async () => {
+    const feature = await getFeature(context, FEATURE_ID);
+    if (!feature) throw new Error("fixture feature missing");
+
+    const draft = await createRevision({
+      context,
+      feature,
+      user,
+      environments: ENVIRONMENTS,
+      changes: { rules: [rolloutRule(0.2), FORCE_RULE] },
+      org,
+    });
+    expect(draft.version).toBe(2);
+
+    const updatedFeature = await publishRevision({
+      context,
+      feature,
+      revision: draft,
+      result: { rules: [rolloutRule(0.2), FORCE_RULE] },
+    });
+
+    expect(draft.version).toBe(2);
+    expect(updatedFeature.version).toBe(2);
+    expect(reassignVersionMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects the publish write when the feature changed after it was read", async () => {
+    const feature = await getFeature(context, FEATURE_ID);
+    if (!feature) throw new Error("fixture feature missing");
+
+    const draft = await createRevision({
+      context,
+      feature,
+      user,
+      environments: ENVIRONMENTS,
+      changes: { rules: [rolloutRule(0.2), FORCE_RULE] },
+      org,
+    });
+
+    // Simulate a publish landing between this request reading the feature
+    // and writing it.
+    await mongoose.connection
+      .db!.collection("features")
+      .updateOne(
+        { organization: ORG_ID, id: FEATURE_ID },
+        { $set: { version: 99 } },
+      );
+
+    await expect(
+      publishRevision({
+        context,
+        feature, // stale in-memory copy still at version 1
+        revision: draft,
+        result: { rules: [rolloutRule(0.2), FORCE_RULE] },
+      }),
+    ).rejects.toThrow(/changed by someone else/);
+  });
+});

--- a/packages/back-end/test/models/FeatureRevisionModel.test.ts
+++ b/packages/back-end/test/models/FeatureRevisionModel.test.ts
@@ -1,9 +1,11 @@
 import { FeatureRule } from "shared/validators";
+import { FeatureInterface } from "shared/types/feature";
 import { FeatureRevisionInterface } from "shared/types/feature-revision";
 import { Environment } from "shared/types/organization";
 import { naiveFlattenV1Rules, suffixRuleId } from "shared/util";
 import {
   buildFeatureRevisionInterface,
+  buildRevisionContentSnapshot,
   normalizeRulesInputToV2,
 } from "back-end/src/models/FeatureRevisionModel";
 import { ReqContext } from "back-end/types/request";
@@ -647,5 +649,172 @@ describe("normalizeRulesInputToV2", () => {
       expect(persisted).toHaveLength(2);
       expect(new Set(persisted.map((r) => r.id)).size).toBe(2);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRevisionContentSnapshot builds the complete content snapshot stored on
+// a revision from the parent feature, optionally overlaying explicit changes.
+// It runs at revision creation AND at publish time (without changes), where it
+// persists the post-merge live state back onto the published revision — the
+// invariant that keeps the live revision in agreement with the feature.
+// ---------------------------------------------------------------------------
+
+describe("buildRevisionContentSnapshot", () => {
+  const orgEnvs = ORG_ENVS;
+  const environments = ORG_ENVS.map((e) => e.id);
+
+  function makeFeature(overrides: Record<string, unknown> = {}) {
+    return {
+      id: FEATURE_ID,
+      organization: "org_test",
+      version: 3,
+      defaultValue: "live-default",
+      valueType: "string",
+      description: "live description",
+      owner: "live owner",
+      project: "prj_1",
+      tags: ["t1"],
+      neverStale: false,
+      rules: [
+        {
+          id: "r_live",
+          type: "rollout",
+          description: "",
+          value: "true",
+          coverage: 0.5,
+          hashAttribute: "id",
+          enabled: true,
+          allEnvironments: true,
+        },
+      ],
+      environmentSettings: {
+        dev: { enabled: true },
+        production: { enabled: false },
+      },
+      prerequisites: [{ id: "feat_parent", condition: "{}" }],
+      archived: false,
+      ...overrides,
+    } as unknown as FeatureInterface;
+  }
+
+  it("mirrors the live feature when no changes are supplied (publish-time write-back)", () => {
+    const snapshot = buildRevisionContentSnapshot({
+      feature: makeFeature(),
+      orgEnvs,
+      environments,
+    });
+
+    expect(snapshot.defaultValue).toBe("live-default");
+    expect(snapshot.rules).toHaveLength(1);
+    expect(snapshot.rules[0]).toMatchObject({ id: "r_live", coverage: 0.5 });
+    expect(snapshot.environmentsEnabled).toEqual({
+      dev: true,
+      production: false,
+    });
+    expect(snapshot.prerequisites).toEqual([
+      { id: "feat_parent", condition: "{}" },
+    ]);
+    expect(snapshot.archived).toBe(false);
+    expect(snapshot.metadata).toMatchObject({
+      description: "live description",
+      owner: "live owner",
+      project: "prj_1",
+      tags: ["t1"],
+      valueType: "string",
+    });
+    expect(snapshot.holdout).toBeNull();
+  });
+
+  it("defaults environmentsEnabled to false for envs missing from the feature", () => {
+    const snapshot = buildRevisionContentSnapshot({
+      feature: makeFeature({ environmentSettings: { dev: { enabled: true } } }),
+      orgEnvs,
+      environments,
+    });
+    expect(snapshot.environmentsEnabled).toEqual({
+      dev: true,
+      production: false,
+    });
+  });
+
+  it("overlays explicit changes on top of the feature snapshot", () => {
+    const snapshot = buildRevisionContentSnapshot({
+      feature: makeFeature(),
+      orgEnvs,
+      environments,
+      changes: {
+        defaultValue: "draft-default",
+        rules: [
+          {
+            id: "r_draft",
+            type: "force",
+            description: "",
+            value: "false",
+            enabled: true,
+            allEnvironments: true,
+          },
+        ] as unknown as FeatureRule[],
+        environmentsEnabled: { production: true },
+        metadata: { description: "draft description" },
+      },
+    });
+
+    expect(snapshot.defaultValue).toBe("draft-default");
+    expect(snapshot.rules.map((r) => r.id)).toEqual(["r_draft"]);
+    // Per-env overlay: untouched envs still come from the feature.
+    expect(snapshot.environmentsEnabled).toEqual({
+      dev: true,
+      production: true,
+    });
+    // Partial metadata changes merge over the full feature snapshot.
+    expect(snapshot.metadata).toMatchObject({
+      description: "draft description",
+      owner: "live owner",
+      project: "prj_1",
+    });
+  });
+
+  it("treats an explicit null holdout as removal while absent carries forward", () => {
+    const holdout = { id: "hld_1", value: "v" };
+    const withHoldout = makeFeature({ holdout });
+
+    expect(
+      buildRevisionContentSnapshot({
+        feature: withHoldout,
+        orgEnvs,
+        environments,
+      }).holdout,
+    ).toEqual(holdout);
+
+    expect(
+      buildRevisionContentSnapshot({
+        feature: withHoldout,
+        orgEnvs,
+        environments,
+        changes: { holdout: null },
+      }).holdout,
+    ).toBeNull();
+  });
+
+  it("filters implausible rule slots when snapshotting from the feature", () => {
+    const snapshot = buildRevisionContentSnapshot({
+      feature: makeFeature({
+        rules: [
+          null,
+          {
+            id: "r_ok",
+            type: "force",
+            description: "",
+            value: "true",
+            enabled: true,
+            allEnvironments: true,
+          },
+        ],
+      }),
+      orgEnvs,
+      environments,
+    });
+    expect(snapshot.rules.map((r) => r.id)).toEqual(["r_ok"]);
   });
 });

--- a/packages/front-end/components/Features/DraftModal.tsx
+++ b/packages/front-end/components/Features/DraftModal.tsx
@@ -1,6 +1,6 @@
 import { FeatureInterface } from "shared/types/feature";
 import ReactDiffViewer, { DiffMethod } from "react-diff-viewer";
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import { FaAngleDown, FaAngleRight, FaArrowLeft } from "react-icons/fa";
 import { PiLockSimple } from "react-icons/pi";
 import { FeatureRevisionInterface } from "shared/types/feature-revision";
@@ -131,6 +131,14 @@ export default function DraftModal({
   const permissionsUtil = usePermissionsUtil();
 
   const { apiCall } = useAuth();
+
+  // Revalidate on open so the merge preview is computed against the current
+  // live state — another revision may have been published since the page
+  // loaded. The server re-checks the serialized merge result at publish time,
+  // but refreshing here means the user reviews the right diff up front.
+  useEffect(() => {
+    mutate();
+  }, []);
 
   const revision = revisions.find((r) => r.version === version);
   const baseRevision = revisions.find(
@@ -519,6 +527,17 @@ export default function DraftModal({
           publishing this draft.
         </Callout>
       )}
+
+      {!mergeResult.conflicts.length &&
+        revision.baseVersion !== feature.version && (
+          <Callout status="warning" mb="3">
+            This draft was created from revision{" "}
+            <strong>#{revision.baseVersion}</strong>, but revision{" "}
+            <strong>#{feature.version}</strong> has been published since then.
+            Those newer changes are merged into the preview below and will be
+            preserved when you publish.
+          </Callout>
+        )}
 
       {linkedRamps.map(({ ramp }) => (
         <Callout key={ramp.id} status="info" mb="3">


### PR DESCRIPTION

Publishing a draft built on a stale base version silently reverted a concurrent live rollout for ~40 minutes, with no conflict warning at publish time.

## Root cause

The three-way merge (`autoMerge`) was not at fault — it correctly preserves concurrent changes when the draft didn't touch the same rule. The revert came from publish-time version bookkeeping plus drift repair trusting the wrong source:

1. Draft version numbers are allocated at creation. When a concurrent publish (e.g. a ramp step) landed while the draft was open, it got a **higher** number, and `applyRevisionChanges` then set `feature.version = revision.version` unconditionally — moving the live pointer **backwards** past the concurrent publish.
2. `markRevisionAsPublished` never wrote the merge result back to the revision doc, so the now-"live" revision held the draft's stale pre-merge snapshot and disagreed with the actual feature content.
3. `repairFeatureDriftIfNeeded` treated the live revision as the source of truth and overwrote `feature.rules` from it — **even on the feature GET path** — silently reverting the concurrent rollout in the SDK payload. Only a `logger.warn`, no audit, no UI signal. The next ramp step (~40 min later) re-applied the coverage, matching the incident duration.

## Tests

- New real-Mongo regression test (`FeatureRevisionModel.publish-race.test.ts`) reproducing the exact incident: draft at v1 → concurrent rollout publish (20%→50%) → draft publish. Asserts the draft is renumbered past the concurrent revision, the rollout survives, the published revision equals the live feature (drift condition gone), and no doc is left under the stale number. Plus no-renumber happy path and optimistic-lock rejection.
- Pure-function tests for the extracted `buildRevisionContentSnapshot` helper.
- Full back-end suite green: 111 suites, 4,322 tests.

## Behavior note

A draft published from a stale base now comes back with a **new version number** (e.g. publishing `/revisions/6/publish` may return revision 9). The dashboard already handles this (it refetches after publish); REST API consumers see the new version in the response body.