### PR TITLE
Surface incremental-refresh fallback to inline mode (coded reasons, API runner info, UI callout + intercept)

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -11604,8 +11604,59 @@ paths:
                 properties:
                   snapshot:
                     $ref: '#/components/schemas/snapshot'
+                  runnerInfo:
+                    anyOf:
+                      - type: object
+                        properties:
+                          runner:
+                            type: string
+                            enum:
+                              - incremental
+                              - incremental-exploratory
+                          fallback:
+                            type: 'null'
+                        required:
+                          - runner
+                          - fallback
+                        additionalProperties: false
+                      - type: object
+                        properties:
+                          runner:
+                            type: string
+                            const: inline
+                          fallback:
+                            anyOf:
+                              - type: object
+                                properties:
+                                  code:
+                                    type: string
+                                    enum:
+                                      - settings-outdated
+                                      - non-fact-metrics
+                                      - no-metrics-selected
+                                      - event-quantile-metric
+                                      - activation-metric
+                                      - skip-partial-data
+                                      - experiment-type
+                                      - no-materialized-units-table
+                                      - datasource-unsupported
+                                      - missing-premium-feature
+                                      - not-enabled
+                                      - unknown
+                                  message:
+                                    type: string
+                                required:
+                                  - code
+                                  - message
+                                additionalProperties: false
+                              - type: 'null'
+                        required:
+                          - runner
+                          - fallback
+                        additionalProperties: false
                 required:
                   - snapshot
+                  - runnerInfo
                 additionalProperties: false
       x-codeSamples:
         - lang: cURL

--- a/packages/back-end/src/api/experiments/postExperimentSnapshot.ts
+++ b/packages/back-end/src/api/experiments/postExperimentSnapshot.ts
@@ -63,7 +63,7 @@ export const postExperimentSnapshot = createApiRequestHandler(
     useCache: true,
   };
 
-  const snapshot = await createExperimentSnapshot({
+  const result = await createExperimentSnapshot({
     context,
     experiment,
     datasource,
@@ -84,9 +84,10 @@ export const postExperimentSnapshot = createApiRequestHandler(
   });
   return {
     snapshot: {
-      id: snapshot.snapshot.id,
-      experiment: snapshot.snapshot.experiment,
-      status: snapshot.snapshot.status,
+      id: result.snapshot.id,
+      experiment: result.snapshot.experiment,
+      status: result.snapshot.status,
     },
+    runnerInfo: result.runnerInfo,
   };
 });

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -50,6 +50,7 @@ import {
   applyVariationWeightsToLatestPhase,
   createSnapshotAnalyses,
   createSnapshotAnalysis,
+  computeNextUpdateRunnerInfo,
   determineNextBanditSchedule,
   getLinkedChangeEnvironmentStates,
   getLinkedFeatureInfo,
@@ -817,9 +818,15 @@ export async function getExperimentIncrementalRefresh(
   const incrementalRefresh =
     await context.models.incrementalRefresh.getByExperimentId(id);
 
+  const nextUpdatePlan = await computeNextUpdateRunnerInfo({
+    context,
+    experiment,
+  });
+
   return res.status(200).json({
     status: 200,
     incrementalRefresh: incrementalRefresh || null,
+    nextUpdatePlan: nextUpdatePlan ?? null,
   });
 }
 
@@ -3174,7 +3181,7 @@ export async function postSnapshot(
   const useCache = !req.query["force"];
 
   try {
-    const { snapshot } = await createExperimentSnapshot({
+    const { snapshot, runnerInfo } = await createExperimentSnapshot({
       context,
       experiment,
       datasource,
@@ -3201,6 +3208,7 @@ export async function postSnapshot(
     res.status(200).json({
       status: 200,
       snapshot,
+      runnerInfo,
     });
   } catch (e) {
     req.log.error(e, "Failed to create experiment snapshot");

--- a/packages/back-end/src/enterprise/services/data-pipeline.ts
+++ b/packages/back-end/src/enterprise/services/data-pipeline.ts
@@ -10,6 +10,8 @@ import { isExperimentIncrementalEnabled } from "shared/enterprise";
 import {
   AggregatedFactTableInterface,
   AggregatedFactTableMetricStateInterface,
+  IncrementalFallback,
+  IncrementalFallbackCode,
   IncrementalRefreshInterface,
 } from "shared/validators";
 import {
@@ -28,23 +30,20 @@ import { getFiltersForHash } from "back-end/src/services/experimentTimeSeries";
 import { getColumnsForMetric } from "back-end/src/integrations/sql/fact-metrics/columns-for-metric";
 import type { MetricFanOut } from "back-end/src/services/experimentQueries/planMetricFanOut";
 
-/**
- * Preconditions for running the incremental refresh query runner on a snapshot.
- * Throws when incremental refresh is unsupported for this configuration, or when
- * an incremental update would reuse a units table built under different
- * experiment-level settings.
- *
- * Does not validate metric-source cache drift. See getFactTablesNeedingRebuild.
- */
-export async function assertIncrementalRefreshPrerequisites({
-  org,
-  integration,
-  snapshotSettings,
-  metricMap,
-  experiment,
-  incrementalRefreshModel,
-  analysisType,
-}: {
+export class IncrementalRefreshFallbackError extends Error {
+  readonly code: IncrementalFallbackCode;
+  constructor(code: IncrementalFallbackCode, message: string) {
+    super(message);
+    this.name = "IncrementalRefreshFallbackError";
+    this.code = code;
+  }
+}
+
+export type EligibilityResult =
+  | { eligible: true }
+  | { eligible: false; fallback: IncrementalFallback };
+
+type IncrementalRefreshPrerequisiteArgs = {
   org: OrganizationInterface;
   integration: SourceIntegrationInterface;
   snapshotSettings: ExperimentSnapshotSettings;
@@ -52,41 +51,84 @@ export async function assertIncrementalRefreshPrerequisites({
   experiment: ExperimentInterface;
   incrementalRefreshModel: IncrementalRefreshInterface | null;
   analysisType: "main-update" | "main-fullRefresh" | "exploratory";
-}): Promise<void> {
+};
+
+/**
+ * Pure eligibility check — no side effects, no throws.
+ * Maps each precondition to a typed fallback code.
+ * The planner calls this directly. assertIncrementalRefreshPrerequisites wraps
+ * it for the two incremental query runners.
+ *
+ * Does not validate metric-source cache drift. See getFactTablesNeedingRebuild.
+ */
+export async function checkIncrementalRefreshEligibility({
+  org,
+  integration,
+  snapshotSettings,
+  metricMap,
+  experiment,
+  incrementalRefreshModel,
+  analysisType,
+}: IncrementalRefreshPrerequisiteArgs): Promise<EligibilityResult> {
   if (snapshotSettings.skipPartialData) {
-    throw new Error(
-      "'Exclude In-Progress Conversions' is not supported for incremental refresh queries while in beta. Please select 'Include' in the Analysis Settings for Metric Conversion Windows.",
-    );
+    return {
+      eligible: false,
+      fallback: {
+        code: "skip-partial-data",
+        message:
+          "'Exclude In-Progress Conversions' is not supported for incremental refresh queries while in beta. Please select 'Include' in the Analysis Settings for Metric Conversion Windows.",
+      },
+    };
   }
 
   if (!integration.getSourceProperties().hasIncrementalRefresh) {
-    throw new Error("Integration does not support incremental refresh queries");
+    return {
+      eligible: false,
+      fallback: {
+        code: "datasource-unsupported",
+        message: "Integration does not support incremental refresh queries",
+      },
+    };
   }
 
-  // Check if organization has the incremental refresh feature
   const hasIncrementalRefreshFeature = orgHasPremiumFeature(
     org,
     "incremental-refresh",
   );
   if (!hasIncrementalRefreshFeature) {
-    throw new Error(
-      "Organization does not have access to incremental refresh feature",
-    );
+    return {
+      eligible: false,
+      fallback: {
+        code: "missing-premium-feature",
+        message:
+          "Organization does not have access to incremental refresh feature",
+      },
+    };
   }
 
   const settings = integration.datasource.settings;
   if (
     !isExperimentIncrementalEnabled(settings.pipelineSettings, experiment.id)
   ) {
-    throw new Error(
-      "This experiment is not enabled for incremental refresh on this data source.",
-    );
+    return {
+      eligible: false,
+      fallback: {
+        code: "not-enabled",
+        message:
+          "This experiment is not enabled for incremental refresh on this data source.",
+      },
+    };
   }
 
   if (experiment.activationMetric) {
-    throw new Error(
-      "Activation metrics are not supported for incremental refresh while in beta.",
-    );
+    return {
+      eligible: false,
+      fallback: {
+        code: "activation-metric",
+        message:
+          "Activation metrics are not supported for incremental refresh while in beta.",
+      },
+    };
   }
 
   // Get selected metrics
@@ -95,15 +137,25 @@ export async function assertIncrementalRefreshPrerequisites({
     .filter((m) => m !== undefined);
 
   if (!selectedMetrics.length) {
-    throw new Error("Experiment must have at least 1 metric selected.");
+    return {
+      eligible: false,
+      fallback: {
+        code: "no-metrics-selected",
+        message: "Experiment must have at least 1 metric selected.",
+      },
+    };
   }
   if (selectedMetrics.some((m) => !isFactMetric(m))) {
-    throw new Error(
-      "Only fact metrics are supported with incremental refresh.",
-    );
+    return {
+      eligible: false,
+      fallback: {
+        code: "non-fact-metrics",
+        message: "Only fact metrics are supported with incremental refresh.",
+      },
+    };
   }
 
-  selectedMetrics.filter(isFactMetric).forEach((metric) => {
+  for (const metric of selectedMetrics.filter(isFactMetric)) {
     // Unit quantiles store a float and re-aggregate via SUM, so they work on
     // any incremental-capable warehouse. Only event quantiles need a quantile
     // sketch (the quantile must be computed over raw event values, which
@@ -112,11 +164,16 @@ export async function assertIncrementalRefreshPrerequisites({
       quantileMetricType(metric) === "event" &&
       !integration.getSourceProperties().hasQuantileSketch
     ) {
-      throw new Error(
-        "Event quantile metrics are not supported with incremental refresh on this data source.",
-      );
+      return {
+        eligible: false,
+        fallback: {
+          code: "event-quantile-metric",
+          message:
+            "Event quantile metrics are not supported with incremental refresh on this data source.",
+        },
+      };
     }
-  });
+  }
 
   // If not forcing a full refresh and we have a previous run, ensure the
   // experiment-level configuration matches what the incremental pipeline was
@@ -134,10 +191,34 @@ export async function assertIncrementalRefreshPrerequisites({
       getExperimentSettingsHashForIncrementalRefresh(snapshotSettings);
     const storedSettingsHash = incrementalRefreshModel.experimentSettingsHash;
     if (!storedSettingsHash || currentSettingsHash !== storedSettingsHash) {
-      throw new Error(
-        "The experiment configuration is outdated. Please run a Full Refresh.",
-      );
+      return {
+        eligible: false,
+        fallback: {
+          code: "settings-outdated",
+          message:
+            "The experiment configuration is outdated. Please run a Full Refresh.",
+        },
+      };
     }
+  }
+
+  return { eligible: true };
+}
+
+/**
+ * Preconditions for running the incremental refresh query runner on a snapshot.
+ * Thin wrapper over checkIncrementalRefreshEligibility that throws on failure.
+ * The two incremental query runners keep calling this unchanged.
+ */
+export async function assertIncrementalRefreshPrerequisites(
+  args: IncrementalRefreshPrerequisiteArgs,
+): Promise<void> {
+  const result = await checkIncrementalRefreshEligibility(args);
+  if (!result.eligible) {
+    throw new IncrementalRefreshFallbackError(
+      result.fallback.code,
+      result.fallback.message,
+    );
   }
 }
 

--- a/packages/back-end/src/services/experimentUpdateExecutionLogger.ts
+++ b/packages/back-end/src/services/experimentUpdateExecutionLogger.ts
@@ -3,6 +3,7 @@ import {
   SnapshotTriggeredBy,
   SnapshotType,
 } from "shared/types/experiment-snapshot";
+import { IncrementalFallback } from "shared/validators";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import type { CovariateInsertPathReason } from "back-end/src/integrations/sql/fact-metrics/resolve-covariate-insert-path";
@@ -18,7 +19,7 @@ type ExperimentUpdateLogMeta = {
 
 export type ExperimentUpdateLogPlan = {
   runnerKind: SnapshotQueryRunnerKind;
-  incrementalFallbackReason: string | null;
+  incrementalFallback: IncrementalFallback | null;
   useCache: boolean | null;
   fullRefresh: boolean | null;
   fullRefreshReason: string | null;
@@ -154,7 +155,9 @@ export class ExperimentUpdateExecutionLogger {
         datasourceId: this.meta.datasource.id,
         datasourceType: this.meta.datasource.type,
         runnerKind: this.plan.runnerKind,
-        incrementalFallbackReason: this.plan.incrementalFallbackReason,
+        incrementalFallbackCode: this.plan.incrementalFallback?.code ?? null,
+        incrementalFallbackMessage:
+          this.plan.incrementalFallback?.message ?? null,
         plannedFullRefresh: this.plan.fullRefresh,
         fullRefreshReason: this.plan.fullRefreshReason,
         incrementalRefreshMode: this.execution.incrementalRefreshMode,

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2155,17 +2155,26 @@ export async function computeNextUpdateRunnerInfo({
     return null;
   }
 
-  const plan = await planExperimentSnapshot({
-    context,
-    experiment,
-    datasource,
-    dimension: undefined,
-    phase: experiment.phases.length - 1,
-    useCache: true,
-    type: "standard",
-  });
-
-  return planToRunnerInfo(plan);
+  // This rides on a read endpoint; a planning failure (e.g. integration
+  // misconfiguration) must not break the response it is attached to.
+  try {
+    const plan = await planExperimentSnapshot({
+      context,
+      experiment,
+      datasource,
+      dimension: undefined,
+      phase: experiment.phases.length - 1,
+      useCache: true,
+      type: "standard",
+    });
+    return planToRunnerInfo(plan);
+  } catch (e) {
+    logger.warn(
+      e,
+      `Failed to compute next-update runner info for experiment ${experiment.id}`,
+    );
+    return null;
+  }
 }
 
 export type SnapshotAnalysisParams = {

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -78,6 +78,8 @@ import {
   updateExperimentValidator,
   SafeRolloutSnapshotAnalysis,
   IncrementalRefreshInterface,
+  IncrementalFallback,
+  SnapshotRunnerInfo,
   LookbackOverrideValueUnit,
   ApiExperiment,
   ApiExperimentMetric,
@@ -189,7 +191,7 @@ import {
   getExposureQueryEligibleDimensions,
 } from "back-end/src/services/dimensions";
 import { ConcurrentIncrementalRefreshError } from "back-end/src/util/errors";
-import { assertIncrementalRefreshPrerequisites } from "back-end/src/enterprise/services/data-pipeline";
+import { checkIncrementalRefreshEligibility } from "back-end/src/enterprise/services/data-pipeline";
 import {
   ExperimentUpdateLogPlan,
   ExperimentUpdateExecutionLogger,
@@ -1251,16 +1253,19 @@ export function resolveSnapshotRunner({
   hasMaterializedUnitsTable: boolean;
 }): {
   runnerKind: SnapshotQueryRunnerKind;
-  incrementalFallbackReason: string | null;
+  incrementalFallback: IncrementalFallback | null;
 } {
   if (!isIncrementalRefreshEnabledForSnapshot({ datasource, experiment })) {
-    return { runnerKind: "results", incrementalFallbackReason: null };
+    return { runnerKind: "results", incrementalFallback: null };
   }
 
   if (experiment.type !== undefined && experiment.type !== "standard") {
     return {
       runnerKind: "results",
-      incrementalFallbackReason: `Experiment type "${experiment.type}" is not supported for incremental refresh.`,
+      incrementalFallback: {
+        code: "experiment-type",
+        message: `Experiment type "${experiment.type}" is not supported for incremental refresh.`,
+      },
     };
   }
 
@@ -1272,11 +1277,14 @@ export function resolveSnapshotRunner({
     if (!hasMaterializedUnitsTable) {
       return {
         runnerKind: "results",
-        incrementalFallbackReason:
-          "No materialized units table yet for this dimension-less exploratory snapshot.",
+        incrementalFallback: {
+          code: "no-materialized-units-table",
+          message:
+            "No materialized units table yet for this dimension-less exploratory snapshot.",
+        },
       };
     }
-    return { runnerKind: "incremental", incrementalFallbackReason: null };
+    return { runnerKind: "incremental", incrementalFallback: null };
   }
 
   return {
@@ -1284,7 +1292,7 @@ export function resolveSnapshotRunner({
       snapshotType === "exploratory"
         ? "incremental-exploratory"
         : "incremental",
-    incrementalFallbackReason: null,
+    incrementalFallback: null,
   };
 }
 
@@ -1348,7 +1356,7 @@ async function planSnapshotQueryRunner({
   fullRefresh: boolean;
 }): Promise<{
   runnerKind: SnapshotQueryRunnerKind;
-  incrementalFallbackReason: string | null;
+  incrementalFallback: IncrementalFallback | null;
 }> {
   const decision = resolveSnapshotRunner({
     datasource,
@@ -1362,8 +1370,9 @@ async function planSnapshotQueryRunner({
     return decision;
   }
 
+  let eligibility;
   try {
-    await assertIncrementalRefreshPrerequisites({
+    eligibility = await checkIncrementalRefreshEligibility({
       org: organization,
       integration,
       snapshotSettings,
@@ -1376,18 +1385,28 @@ async function planSnapshotQueryRunner({
           ? "main-update"
           : "exploratory",
     });
-    return decision;
-  } catch (error) {
-    const validationError = "message" in error ? error.message : String(error);
+  } catch (e) {
+    const message = String(e);
     logger.info(
-      `Experiment ${experiment.id} does not support incremental refresh: ${validationError}`,
+      `Experiment ${experiment.id} incremental eligibility check threw unexpectedly: ${message}`,
     );
-
     return {
       runnerKind: "results",
-      incrementalFallbackReason: validationError,
+      incrementalFallback: { code: "unknown", message },
     };
   }
+
+  if (!eligibility.eligible) {
+    logger.info(
+      `Experiment ${experiment.id} does not support incremental refresh: ${eligibility.fallback.message}`,
+    );
+    return {
+      runnerKind: "results",
+      incrementalFallback: eligibility.fallback,
+    };
+  }
+
+  return { runnerKind: decision.runnerKind, incrementalFallback: null };
 }
 
 export type PlannedExperimentSnapshot = {
@@ -1396,7 +1415,7 @@ export type PlannedExperimentSnapshot = {
   useCache: boolean;
   fullRefresh: boolean;
   settingsForSnapshotMetrics: MetricSnapshotSettings[];
-  incrementalFallbackReason: string | null;
+  incrementalFallback: IncrementalFallback | null;
   fullRefreshReason: string | null;
 };
 
@@ -1537,7 +1556,7 @@ export async function planSnapshot({
   return {
     snapshot: data,
     runnerKind: runnerPlan.runnerKind,
-    incrementalFallbackReason: runnerPlan.incrementalFallbackReason,
+    incrementalFallback: runnerPlan.incrementalFallback,
     useCache,
     fullRefresh,
     fullRefreshReason,
@@ -1628,7 +1647,7 @@ export async function createSnapshotFromPlan({
 
     const experimentUpdateLog: ExperimentUpdateLogPlan = {
       runnerKind: plan.runnerKind,
-      incrementalFallbackReason: plan.incrementalFallbackReason,
+      incrementalFallback: plan.incrementalFallback,
       useCache: plan.useCache,
       fullRefresh: plan.fullRefresh,
       fullRefreshReason: plan.fullRefreshReason,
@@ -1922,6 +1941,7 @@ export async function createExperimentSnapshot({
 }): Promise<{
   snapshot: ExperimentSnapshotInterface;
   queryRunner: ExperimentSnapshotQueryRunner;
+  runnerInfo: SnapshotRunnerInfo;
 }> {
   const plan = await planExperimentSnapshot({
     context,
@@ -1953,6 +1973,7 @@ export async function createExperimentSnapshotFromPlan({
 }): Promise<{
   snapshot: ExperimentSnapshotInterface;
   queryRunner: ExperimentSnapshotQueryRunner;
+  runnerInfo: SnapshotRunnerInfo;
 }> {
   const metricMap = await getMetricMap(context);
   const factTableMap = await getFactTableMap(context);
@@ -1972,7 +1993,11 @@ export async function createExperimentSnapshotFromPlan({
     metricMap,
     factTableMap,
   });
-  return { snapshot: queryRunner.model, queryRunner };
+  return {
+    snapshot: queryRunner.model,
+    queryRunner,
+    runnerInfo: planToRunnerInfo(plan),
+  };
 }
 
 export async function planExperimentSnapshot({
@@ -2087,6 +2112,60 @@ export async function planExperimentSnapshot({
     triggeredBy: triggeredBy ?? "manual",
   });
   return plan;
+}
+
+/**
+ * Maps a PlannedExperimentSnapshot's runner fields into the SnapshotRunnerInfo
+ * shape included in snapshot-creation responses. The internal "results" runner
+ * kind becomes "inline" in the public vocabulary. Pure; no I/O.
+ */
+export function planToRunnerInfo(
+  plan: PlannedExperimentSnapshot,
+): SnapshotRunnerInfo {
+  if (
+    plan.runnerKind === "incremental" ||
+    plan.runnerKind === "incremental-exploratory"
+  ) {
+    return { runner: plan.runnerKind, fallback: null };
+  }
+  return { runner: "inline", fallback: plan.incrementalFallback };
+}
+
+/**
+ * Computes what the next standard (no-dimension, latest-phase, useCache=true)
+ * update would do for the given experiment. Returns null when the experiment
+ * has no datasource or no phases.
+ *
+ * Reuses the real planExperimentSnapshot so there is exactly one eligibility
+ * code path — no divergence possible.
+ */
+export async function computeNextUpdateRunnerInfo({
+  context,
+  experiment,
+}: {
+  context: ReqContext;
+  experiment: ExperimentInterface;
+}): Promise<SnapshotRunnerInfo | null> {
+  if (!experiment.datasource || !experiment.phases.length) {
+    return null;
+  }
+
+  const datasource = await getDataSourceById(context, experiment.datasource);
+  if (!datasource) {
+    return null;
+  }
+
+  const plan = await planExperimentSnapshot({
+    context,
+    experiment,
+    datasource,
+    dimension: undefined,
+    phase: experiment.phases.length - 1,
+    useCache: true,
+    type: "standard",
+  });
+
+  return planToRunnerInfo(plan);
 }
 
 export type SnapshotAnalysisParams = {

--- a/packages/back-end/test/services/experiment-update-log.test.ts
+++ b/packages/back-end/test/services/experiment-update-log.test.ts
@@ -16,7 +16,7 @@ describe("ExperimentUpdateExecutionLogger", () => {
     fullRefresh: true,
     fullRefreshReason:
       "No prior incremental refresh state for this experiment.",
-    incrementalFallbackReason: null,
+    incrementalFallback: null,
   };
 
   const meta = {
@@ -141,7 +141,10 @@ describe("ExperimentUpdateExecutionLogger", () => {
     const logger = new ExperimentUpdateExecutionLogger(
       {
         runnerKind: "results",
-        incrementalFallbackReason: "metric not compatible",
+        incrementalFallback: {
+          code: "non-fact-metrics",
+          message: "metric not compatible",
+        },
         useCache: true,
         fullRefresh: false,
         fullRefreshReason: null,
@@ -170,7 +173,8 @@ describe("ExperimentUpdateExecutionLogger", () => {
         snapshotStatus: "error",
         error: "Failed to run queries",
         runnerKind: "results",
-        incrementalFallbackReason: "metric not compatible",
+        incrementalFallbackCode: "non-fact-metrics",
+        incrementalFallbackMessage: "metric not compatible",
         plannedFullRefresh: false,
         fullRefreshReason: null,
         incrementalRefreshMode: "incremental",

--- a/packages/back-end/test/services/incremental-refresh-eligibility.test.ts
+++ b/packages/back-end/test/services/incremental-refresh-eligibility.test.ts
@@ -218,7 +218,6 @@ describe("checkIncrementalRefreshEligibility", () => {
       id: "m1",
       type: "mean",
     } as unknown as ExperimentMetricInterface;
-    // Verify our test assumption
     expect(isFactMetric(legacyMetric)).toBe(false);
 
     const result = await checkIncrementalRefreshEligibility({

--- a/packages/back-end/test/services/incremental-refresh-eligibility.test.ts
+++ b/packages/back-end/test/services/incremental-refresh-eligibility.test.ts
@@ -1,0 +1,339 @@
+import { OrganizationInterface } from "shared/types/organization";
+import { ExperimentInterface } from "shared/types/experiment";
+import { ExperimentSnapshotSettings } from "shared/types/experiment-snapshot";
+import { IncrementalRefreshInterface } from "shared/validators";
+import { ExperimentMetricInterface, isFactMetric } from "shared/experiments";
+import {
+  checkIncrementalRefreshEligibility,
+  getExperimentSettingsHashForIncrementalRefresh,
+} from "back-end/src/enterprise/services/data-pipeline";
+import { orgHasPremiumFeature } from "back-end/src/enterprise";
+import { SourceIntegrationInterface } from "back-end/src/types/Integration";
+
+jest.mock("back-end/src/enterprise", () => ({
+  orgHasPremiumFeature: jest.fn(),
+}));
+
+const orgHasPremiumFeatureMock = orgHasPremiumFeature as jest.MockedFunction<
+  typeof orgHasPremiumFeature
+>;
+
+function makeOrg(): OrganizationInterface {
+  return { id: "org_1" } as unknown as OrganizationInterface;
+}
+
+function makeIntegration(
+  overrides: Partial<{
+    hasIncrementalRefresh: boolean;
+    hasQuantileSketch: boolean;
+    pipelineEnabled: boolean;
+  }> = {},
+): SourceIntegrationInterface {
+  const {
+    hasIncrementalRefresh = true,
+    hasQuantileSketch = true,
+    pipelineEnabled = true,
+  } = overrides;
+  return {
+    datasource: {
+      settings: {
+        pipelineSettings: pipelineEnabled
+          ? { allowWriting: true, mode: "incremental" }
+          : {},
+      },
+    },
+    getSourceProperties: () => ({
+      hasIncrementalRefresh,
+      hasQuantileSketch,
+    }),
+  } as unknown as SourceIntegrationInterface;
+}
+
+function makeExperiment(
+  overrides: Partial<ExperimentInterface> = {},
+): ExperimentInterface {
+  return {
+    id: "exp_1",
+    activationMetric: null,
+    type: "standard",
+    ...overrides,
+  } as unknown as ExperimentInterface;
+}
+
+function makeSnapshotSettings(
+  overrides: Partial<ExperimentSnapshotSettings> = {},
+): ExperimentSnapshotSettings {
+  return {
+    skipPartialData: false,
+    metricSettings: [{ id: "m1" }],
+    dimensions: [],
+    datasourceId: "ds_1",
+    experimentId: "exp_1",
+    activationMetric: null,
+    attributionModel: "firstExposure",
+    queryFilter: "",
+    segment: "",
+    startDate: new Date("2024-01-01"),
+    regressionAdjustmentEnabled: false,
+    exposureQueryId: "eq_1",
+    ...overrides,
+  } as unknown as ExperimentSnapshotSettings;
+}
+
+function makeFactMetric(quantileType?: "event" | "unit") {
+  return {
+    id: "m1",
+    metricType: quantileType === "event" ? "quantile" : "mean",
+    numerator: { factTableId: "ft_1", column: "amount" },
+    quantileSettings: quantileType
+      ? { type: quantileType, quantile: 0.9, ignoreZeros: false }
+      : undefined,
+  } as unknown as ExperimentMetricInterface;
+}
+
+function makeMetricMap(
+  metric: ExperimentMetricInterface = makeFactMetric(),
+): Map<string, ExperimentMetricInterface> {
+  return new Map([["m1", metric]]);
+}
+
+describe("checkIncrementalRefreshEligibility", () => {
+  beforeEach(() => {
+    orgHasPremiumFeatureMock.mockReturnValue(true);
+  });
+
+  it("returns eligible when all conditions pass", async () => {
+    const result = await checkIncrementalRefreshEligibility({
+      org: makeOrg(),
+      integration: makeIntegration(),
+      snapshotSettings: makeSnapshotSettings(),
+      metricMap: makeMetricMap(),
+      experiment: makeExperiment(),
+      incrementalRefreshModel: null,
+      analysisType: "main-update",
+    });
+    expect(result.eligible).toBe(true);
+  });
+
+  it("returns skip-partial-data when skipPartialData is true", async () => {
+    const result = await checkIncrementalRefreshEligibility({
+      org: makeOrg(),
+      integration: makeIntegration(),
+      snapshotSettings: makeSnapshotSettings({ skipPartialData: true }),
+      metricMap: makeMetricMap(),
+      experiment: makeExperiment(),
+      incrementalRefreshModel: null,
+      analysisType: "main-update",
+    });
+    expect(result.eligible).toBe(false);
+    if (!result.eligible) {
+      expect(result.fallback.code).toBe("skip-partial-data");
+    }
+  });
+
+  it("returns datasource-unsupported when integration lacks hasIncrementalRefresh", async () => {
+    const result = await checkIncrementalRefreshEligibility({
+      org: makeOrg(),
+      integration: makeIntegration({ hasIncrementalRefresh: false }),
+      snapshotSettings: makeSnapshotSettings(),
+      metricMap: makeMetricMap(),
+      experiment: makeExperiment(),
+      incrementalRefreshModel: null,
+      analysisType: "main-update",
+    });
+    expect(result.eligible).toBe(false);
+    if (!result.eligible) {
+      expect(result.fallback.code).toBe("datasource-unsupported");
+    }
+  });
+
+  it("returns missing-premium-feature when org lacks incremental-refresh feature", async () => {
+    orgHasPremiumFeatureMock.mockReturnValue(false);
+    const result = await checkIncrementalRefreshEligibility({
+      org: makeOrg(),
+      integration: makeIntegration(),
+      snapshotSettings: makeSnapshotSettings(),
+      metricMap: makeMetricMap(),
+      experiment: makeExperiment(),
+      incrementalRefreshModel: null,
+      analysisType: "main-update",
+    });
+    expect(result.eligible).toBe(false);
+    if (!result.eligible) {
+      expect(result.fallback.code).toBe("missing-premium-feature");
+    }
+  });
+
+  it("returns not-enabled when pipeline is not enabled for the experiment", async () => {
+    const result = await checkIncrementalRefreshEligibility({
+      org: makeOrg(),
+      integration: makeIntegration({ pipelineEnabled: false }),
+      snapshotSettings: makeSnapshotSettings(),
+      metricMap: makeMetricMap(),
+      experiment: makeExperiment(),
+      incrementalRefreshModel: null,
+      analysisType: "main-update",
+    });
+    expect(result.eligible).toBe(false);
+    if (!result.eligible) {
+      expect(result.fallback.code).toBe("not-enabled");
+    }
+  });
+
+  it("returns activation-metric when experiment has an activation metric", async () => {
+    const result = await checkIncrementalRefreshEligibility({
+      org: makeOrg(),
+      integration: makeIntegration(),
+      snapshotSettings: makeSnapshotSettings(),
+      metricMap: makeMetricMap(),
+      experiment: makeExperiment({ activationMetric: "met_act" as never }),
+      incrementalRefreshModel: null,
+      analysisType: "main-update",
+    });
+    expect(result.eligible).toBe(false);
+    if (!result.eligible) {
+      expect(result.fallback.code).toBe("activation-metric");
+    }
+  });
+
+  it("returns no-metrics-selected when no metrics resolve in the metric map", async () => {
+    const result = await checkIncrementalRefreshEligibility({
+      org: makeOrg(),
+      integration: makeIntegration(),
+      snapshotSettings: makeSnapshotSettings(),
+      metricMap: new Map(), // m1 not in map
+      experiment: makeExperiment(),
+      incrementalRefreshModel: null,
+      analysisType: "main-update",
+    });
+    expect(result.eligible).toBe(false);
+    if (!result.eligible) {
+      expect(result.fallback.code).toBe("no-metrics-selected");
+    }
+  });
+
+  it("returns non-fact-metrics when a non-fact metric is selected", async () => {
+    // Legacy metrics do not have a metricType field — isFactMetric checks for "metricType" in m
+    const legacyMetric = {
+      id: "m1",
+      type: "mean",
+    } as unknown as ExperimentMetricInterface;
+    // Verify our test assumption
+    expect(isFactMetric(legacyMetric)).toBe(false);
+
+    const result = await checkIncrementalRefreshEligibility({
+      org: makeOrg(),
+      integration: makeIntegration(),
+      snapshotSettings: makeSnapshotSettings(),
+      metricMap: new Map([["m1", legacyMetric]]),
+      experiment: makeExperiment(),
+      incrementalRefreshModel: null,
+      analysisType: "main-update",
+    });
+    expect(result.eligible).toBe(false);
+    if (!result.eligible) {
+      expect(result.fallback.code).toBe("non-fact-metrics");
+    }
+  });
+
+  it("returns event-quantile-metric when an event quantile metric is used on a datasource without sketch support", async () => {
+    const result = await checkIncrementalRefreshEligibility({
+      org: makeOrg(),
+      integration: makeIntegration({ hasQuantileSketch: false }),
+      snapshotSettings: makeSnapshotSettings(),
+      metricMap: makeMetricMap(makeFactMetric("event")),
+      experiment: makeExperiment(),
+      incrementalRefreshModel: null,
+      analysisType: "main-update",
+    });
+    expect(result.eligible).toBe(false);
+    if (!result.eligible) {
+      expect(result.fallback.code).toBe("event-quantile-metric");
+    }
+  });
+
+  it("returns settings-outdated when analysisType is main-update and settings hash has changed", async () => {
+    const snapshotSettings = makeSnapshotSettings();
+    const storedHash =
+      getExperimentSettingsHashForIncrementalRefresh(snapshotSettings);
+    const staleModel = {
+      experimentSettingsHash: storedHash + "_stale",
+      unitsTableFullName: "db.schema.units",
+    } as unknown as IncrementalRefreshInterface;
+
+    const result = await checkIncrementalRefreshEligibility({
+      org: makeOrg(),
+      integration: makeIntegration(),
+      snapshotSettings,
+      metricMap: makeMetricMap(),
+      experiment: makeExperiment(),
+      incrementalRefreshModel: staleModel,
+      analysisType: "main-update",
+    });
+    expect(result.eligible).toBe(false);
+    if (!result.eligible) {
+      expect(result.fallback.code).toBe("settings-outdated");
+    }
+  });
+
+  it("returns eligible when analysisType is main-fullRefresh even when settings hash has changed", async () => {
+    const snapshotSettings = makeSnapshotSettings();
+    const staleModel = {
+      experimentSettingsHash: "stale_hash",
+      unitsTableFullName: "db.schema.units",
+    } as unknown as IncrementalRefreshInterface;
+
+    const result = await checkIncrementalRefreshEligibility({
+      org: makeOrg(),
+      integration: makeIntegration(),
+      snapshotSettings,
+      metricMap: makeMetricMap(),
+      experiment: makeExperiment(),
+      incrementalRefreshModel: staleModel,
+      analysisType: "main-fullRefresh",
+    });
+    expect(result.eligible).toBe(true);
+  });
+
+  it("message is verbatim for skip-partial-data", async () => {
+    const result = await checkIncrementalRefreshEligibility({
+      org: makeOrg(),
+      integration: makeIntegration(),
+      snapshotSettings: makeSnapshotSettings({ skipPartialData: true }),
+      metricMap: makeMetricMap(),
+      experiment: makeExperiment(),
+      incrementalRefreshModel: null,
+      analysisType: "main-update",
+    });
+    expect(result.eligible).toBe(false);
+    if (!result.eligible) {
+      expect(result.fallback.message).toContain(
+        "'Exclude In-Progress Conversions' is not supported",
+      );
+    }
+  });
+
+  it("message is verbatim for settings-outdated", async () => {
+    const snapshotSettings = makeSnapshotSettings();
+    const staleModel = {
+      experimentSettingsHash: "stale",
+      unitsTableFullName: "db.schema.units",
+    } as unknown as IncrementalRefreshInterface;
+
+    const result = await checkIncrementalRefreshEligibility({
+      org: makeOrg(),
+      integration: makeIntegration(),
+      snapshotSettings,
+      metricMap: makeMetricMap(),
+      experiment: makeExperiment(),
+      incrementalRefreshModel: staleModel,
+      analysisType: "main-update",
+    });
+    expect(result.eligible).toBe(false);
+    if (!result.eligible) {
+      expect(result.fallback.message).toBe(
+        "The experiment configuration is outdated. Please run a Full Refresh.",
+      );
+    }
+  });
+});

--- a/packages/back-end/test/services/snapshot-planning.test.ts
+++ b/packages/back-end/test/services/snapshot-planning.test.ts
@@ -186,7 +186,6 @@ describe("snapshot planning", () => {
     jest.clearAllMocks();
     getDataSourceByIdMock.mockResolvedValue(makeDatasource());
     getSourceIntegrationObjectMock.mockReturnValue({} as never);
-    // Default: eligible
     checkIncrementalRefreshEligibilityMock.mockResolvedValue({
       eligible: true,
     });

--- a/packages/back-end/test/services/snapshot-planning.test.ts
+++ b/packages/back-end/test/services/snapshot-planning.test.ts
@@ -10,7 +10,7 @@ import {
 } from "shared/types/experiment-snapshot";
 import { MetricSnapshotSettings } from "shared/types/report";
 import { ApiReqContext } from "back-end/types/api";
-import { assertIncrementalRefreshPrerequisites } from "back-end/src/enterprise/services/data-pipeline";
+import { checkIncrementalRefreshEligibility } from "back-end/src/enterprise/services/data-pipeline";
 import { orgHasPremiumFeature } from "back-end/src/enterprise";
 import {
   getSnapshotSettings,
@@ -52,7 +52,7 @@ jest.mock("back-end/src/enterprise", () => ({
 }));
 
 jest.mock("back-end/src/enterprise/services/data-pipeline", () => ({
-  assertIncrementalRefreshPrerequisites: jest.fn(),
+  checkIncrementalRefreshEligibility: jest.fn(),
 }));
 
 const {
@@ -83,9 +83,9 @@ const updateExperimentDashboardsMock =
   updateExperimentDashboards as jest.MockedFunction<
     typeof updateExperimentDashboards
   >;
-const assertIncrementalRefreshPrerequisitesMock =
-  assertIncrementalRefreshPrerequisites as jest.MockedFunction<
-    typeof assertIncrementalRefreshPrerequisites
+const checkIncrementalRefreshEligibilityMock =
+  checkIncrementalRefreshEligibility as jest.MockedFunction<
+    typeof checkIncrementalRefreshEligibility
   >;
 const orgHasPremiumFeatureMock = orgHasPremiumFeature as jest.MockedFunction<
   typeof orgHasPremiumFeature
@@ -186,6 +186,10 @@ describe("snapshot planning", () => {
     jest.clearAllMocks();
     getDataSourceByIdMock.mockResolvedValue(makeDatasource());
     getSourceIntegrationObjectMock.mockReturnValue({} as never);
+    // Default: eligible
+    checkIncrementalRefreshEligibilityMock.mockResolvedValue({
+      eligible: true,
+    });
   });
 
   it("plans a draft snapshot without persisting or mutating experiment state", async () => {
@@ -215,7 +219,7 @@ describe("snapshot planning", () => {
     expect(updateExperimentDashboardsMock).not.toHaveBeenCalled();
   });
 
-  it("surfaces pipeline validation errors as incremental fallback reasons", async () => {
+  it("surfaces pipeline validation errors as incremental fallback", async () => {
     getDataSourceByIdMock.mockResolvedValue(
       makeDatasource({
         settings: {
@@ -227,9 +231,10 @@ describe("snapshot planning", () => {
         },
       }),
     );
-    assertIncrementalRefreshPrerequisitesMock.mockRejectedValue(
-      new Error("metric not compatible"),
-    );
+    checkIncrementalRefreshEligibilityMock.mockResolvedValue({
+      eligible: false,
+      fallback: { code: "non-fact-metrics", message: "metric not compatible" },
+    });
 
     const context = makeContext();
     context.models.incrementalRefresh = {
@@ -252,9 +257,12 @@ describe("snapshot planning", () => {
       factTableMap: new Map() as FactTableMap,
     });
 
-    expect(assertIncrementalRefreshPrerequisitesMock).toHaveBeenCalled();
+    expect(checkIncrementalRefreshEligibilityMock).toHaveBeenCalled();
     expect(plan.runnerKind).toBe("results");
-    expect(plan.incrementalFallbackReason).toBe("metric not compatible");
+    expect(plan.incrementalFallback).toEqual({
+      code: "non-fact-metrics",
+      message: "metric not compatible",
+    });
   });
 
   it("preserves the computed full refresh when using the incremental runner on a first run", async () => {
@@ -269,9 +277,9 @@ describe("snapshot planning", () => {
         },
       }),
     );
-    assertIncrementalRefreshPrerequisitesMock.mockResolvedValue(
-      undefined as never,
-    );
+    checkIncrementalRefreshEligibilityMock.mockResolvedValue({
+      eligible: true,
+    });
 
     const context = makeContext();
     // First run: no prior incremental state, so the warehouse units table
@@ -301,18 +309,18 @@ describe("snapshot planning", () => {
     expect(plan.fullRefreshReason).toBe(
       "No prior incremental refresh state for this experiment.",
     );
-    expect(assertIncrementalRefreshPrerequisitesMock).toHaveBeenCalledWith(
+    expect(checkIncrementalRefreshEligibilityMock).toHaveBeenCalledWith(
       expect.objectContaining({ analysisType: "main-fullRefresh" }),
     );
   });
 
   it("keeps the incremental runner when only metric settings drift", async () => {
     orgHasPremiumFeatureMock.mockReturnValue(true);
-    assertIncrementalRefreshPrerequisitesMock.mockImplementation(
+    checkIncrementalRefreshEligibilityMock.mockImplementation(
       jest.requireActual<
         typeof import("back-end/src/enterprise/services/data-pipeline")
       >("back-end/src/enterprise/services/data-pipeline")
-        .assertIncrementalRefreshPrerequisites,
+        .checkIncrementalRefreshEligibility,
     );
 
     const datasource = makeIncrementalDatasource();
@@ -432,12 +440,12 @@ describe("snapshot planning", () => {
       factTableMap,
     });
 
-    expect(assertIncrementalRefreshPrerequisitesMock).toHaveBeenCalledWith(
+    expect(checkIncrementalRefreshEligibilityMock).toHaveBeenCalledWith(
       expect.objectContaining({ analysisType: "main-update" }),
     );
     expect(plan.runnerKind).toBe("incremental");
     expect(plan.fullRefresh).toBe(false);
-    expect(plan.incrementalFallbackReason).toBeNull();
+    expect(plan.incrementalFallback).toBeNull();
 
     const plannedMetric = plan.snapshot.settings.metricSettings.find(
       (m) => m.id === "m1",
@@ -476,9 +484,10 @@ describe("snapshot planning", () => {
     );
     const staleConfigMessage =
       "The experiment configuration is outdated. Please run a Full Refresh.";
-    assertIncrementalRefreshPrerequisitesMock.mockRejectedValue(
-      new Error(staleConfigMessage),
-    );
+    checkIncrementalRefreshEligibilityMock.mockResolvedValue({
+      eligible: false,
+      fallback: { code: "settings-outdated", message: staleConfigMessage },
+    });
 
     const context = makeContext();
     context.models.incrementalRefresh = {
@@ -502,12 +511,15 @@ describe("snapshot planning", () => {
       factTableMap: new Map() as FactTableMap,
     });
 
-    expect(assertIncrementalRefreshPrerequisitesMock).toHaveBeenCalledWith(
+    expect(checkIncrementalRefreshEligibilityMock).toHaveBeenCalledWith(
       expect.objectContaining({ analysisType: "main-update" }),
     );
-    expect(assertIncrementalRefreshPrerequisitesMock).toHaveBeenCalledTimes(1);
+    expect(checkIncrementalRefreshEligibilityMock).toHaveBeenCalledTimes(1);
     expect(plan.runnerKind).toBe("results");
-    expect(plan.incrementalFallbackReason).toBe(staleConfigMessage);
+    expect(plan.incrementalFallback).toEqual({
+      code: "settings-outdated",
+      message: staleConfigMessage,
+    });
     expect(plan.fullRefresh).toBe(false);
     expect(plan.fullRefreshReason).toBeNull();
   });

--- a/packages/back-end/test/services/snapshot-query-runner-kind.test.ts
+++ b/packages/back-end/test/services/snapshot-query-runner-kind.test.ts
@@ -80,8 +80,11 @@ describe("resolveSnapshotRunner", () => {
       }),
     ).toEqual({
       runnerKind: "results",
-      incrementalFallbackReason:
-        "No materialized units table yet for this dimension-less exploratory snapshot.",
+      incrementalFallback: {
+        code: "no-materialized-units-table",
+        message:
+          "No materialized units table yet for this dimension-less exploratory snapshot.",
+      },
     });
   });
 
@@ -97,7 +100,7 @@ describe("resolveSnapshotRunner", () => {
     ).toBe("incremental");
   });
 
-  it("returns 'results' with no fallback reason when datasource pipeline mode is not incremental", () => {
+  it("returns 'results' with no fallback when datasource pipeline mode is not incremental", () => {
     const datasource = makeDatasource({ mode: "parallel" as never });
     expect(
       resolveSnapshotRunner({
@@ -109,11 +112,11 @@ describe("resolveSnapshotRunner", () => {
       }),
     ).toEqual({
       runnerKind: "results",
-      incrementalFallbackReason: null,
+      incrementalFallback: null,
     });
   });
 
-  it("returns 'results' with no fallback reason when experiment is excluded from incremental refresh", () => {
+  it("returns 'results' with no fallback when experiment is excluded from incremental refresh", () => {
     const datasource = makeDatasource({
       excludedExperimentIds: ["exp_123"],
     });
@@ -127,11 +130,11 @@ describe("resolveSnapshotRunner", () => {
       }),
     ).toEqual({
       runnerKind: "results",
-      incrementalFallbackReason: null,
+      incrementalFallback: null,
     });
   });
 
-  it("returns 'results' with no fallback reason when includedExperimentIds is set but does not include the experiment", () => {
+  it("returns 'results' with no fallback when includedExperimentIds is set but does not include the experiment", () => {
     const datasource = makeDatasource({
       includedExperimentIds: ["exp_other"],
     });
@@ -145,7 +148,7 @@ describe("resolveSnapshotRunner", () => {
       }),
     ).toEqual({
       runnerKind: "results",
-      incrementalFallbackReason: null,
+      incrementalFallback: null,
     });
   });
 
@@ -175,8 +178,11 @@ describe("resolveSnapshotRunner", () => {
       }),
     ).toEqual({
       runnerKind: "results",
-      incrementalFallbackReason:
-        'Experiment type "multi-armed-bandit" is not supported for incremental refresh.',
+      incrementalFallback: {
+        code: "experiment-type",
+        message:
+          'Experiment type "multi-armed-bandit" is not supported for incremental refresh.',
+      },
     });
   });
 
@@ -208,7 +214,7 @@ describe("resolveSnapshotRunner", () => {
     ).toBe("incremental");
   });
 
-  it("returns 'results' with no fallback reason for an experiment that is not in the opt-in list when default mode is ephemeral", () => {
+  it("returns 'results' with no fallback for an experiment that is not in the opt-in list when default mode is ephemeral", () => {
     const datasource = makeDatasource({
       mode: "ephemeral",
       incrementalOptInExperimentIds: ["exp_other"],
@@ -223,7 +229,7 @@ describe("resolveSnapshotRunner", () => {
       }),
     ).toEqual({
       runnerKind: "results",
-      incrementalFallbackReason: null,
+      incrementalFallback: null,
     });
   });
 
@@ -244,7 +250,7 @@ describe("resolveSnapshotRunner", () => {
     ).toBe("results");
   });
 
-  it("returns 'results' with no fallback reason when allowWriting is false even with opt-in", () => {
+  it("returns 'results' with no fallback when allowWriting is false even with opt-in", () => {
     const datasource = makeDatasource({
       allowWriting: false,
       mode: "ephemeral",
@@ -260,7 +266,7 @@ describe("resolveSnapshotRunner", () => {
       }),
     ).toEqual({
       runnerKind: "results",
-      incrementalFallbackReason: null,
+      incrementalFallback: null,
     });
   });
 });

--- a/packages/front-end/components/Experiment/IncrementalRefreshFallbackCallout.tsx
+++ b/packages/front-end/components/Experiment/IncrementalRefreshFallbackCallout.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { SnapshotRunnerInfo } from "shared/validators";
+import Callout from "@/ui/Callout";
+import { getFallbackCopy } from "./incrementalFallbackCopy";
+
+export default function IncrementalRefreshFallbackCallout({
+  nextUpdatePlan,
+  dimension,
+}: {
+  nextUpdatePlan: SnapshotRunnerInfo | null;
+  dimension?: string;
+}): React.ReactElement | null {
+  if (!nextUpdatePlan) return null;
+  if (dimension) return null;
+  if (nextUpdatePlan.runner !== "inline") return null;
+  if (!nextUpdatePlan.fallback) return null;
+
+  const copy = getFallbackCopy(nextUpdatePlan.fallback.code);
+
+  if (copy.visibility === "none") return null;
+
+  if (copy.visibility === "muted") {
+    return (
+      <span style={{ fontSize: "12px", color: "var(--gray-11)" }}>
+        {copy.summary}
+      </span>
+    );
+  }
+
+  return (
+    <Callout status="warning" size="sm" contentsAs="div">
+      <div>
+        <div style={{ fontWeight: 500 }}>{copy.summary}</div>
+        <div>{copy.detail}</div>
+      </div>
+    </Callout>
+  );
+}

--- a/packages/front-end/components/Experiment/RefreshResultsButton.tsx
+++ b/packages/front-end/components/Experiment/RefreshResultsButton.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Queries } from "shared/types/query";
 import { ExperimentInterfaceStringDates } from "shared/types/experiment";
 import { isDimensionPrecomputed } from "shared/experiments";
@@ -18,6 +18,8 @@ import { trackSnapshot } from "@/services/track";
 import RunQueriesButton from "@/components/Queries/RunQueriesButton";
 import ExperimentRefreshSnapshotButton from "@/components/Experiment/RefreshSnapshotButton";
 import SafeRolloutRefreshSnapshotButton from "@/components/SafeRollout/RefreshSnapshotButton";
+import ConfirmDialog from "@/ui/ConfirmDialog";
+import { useIncrementalRefresh } from "@/hooks/useIncrementalRefresh";
 
 export type EntityType = "experiment" | "holdout" | "safe-rollout";
 
@@ -76,6 +78,14 @@ export default function RefreshResultsButton<
   const { getDatasourceById } = useDefinitions();
   const { hasCommercialFeature } = useUser();
 
+  const { nextUpdatePlan, mutate: mutateIncrementalRefresh } =
+    useIncrementalRefresh(
+      entityType === "experiment" || entityType === "holdout" ? entityId : "",
+    );
+
+  const [settingsOutdatedModalOpen, setSettingsOutdatedModalOpen] =
+    useState(false);
+
   const hasQueries = latest?.queries && latest.queries.length > 0;
 
   // Determine which button to render
@@ -104,8 +114,111 @@ export default function RefreshResultsButton<
       ? `/safe-rollout/${entityId}/snapshot`
       : `/experiment/${entityId}/snapshot`;
 
+  const isSettingsOutdated =
+    nextUpdatePlan?.runner === "inline" &&
+    nextUpdatePlan.fallback?.code === "settings-outdated";
+
+  const runNormalUpdate = async () => {
+    const snapshotDimension = isDimensionPrecomputed(
+      dimension,
+      getHonoredPrecomputedUnitDimensionIds(
+        experiment?.precomputedUnitDimensionIds,
+        experiment?.datasource
+          ? getDatasourceById(experiment.datasource)
+          : undefined,
+        hasCommercialFeature("pipeline-mode"),
+      ),
+    )
+      ? ""
+      : (dimension ?? "");
+    const body =
+      entityType === "experiment" || entityType === "holdout"
+        ? JSON.stringify({
+            phase: phase ?? 0,
+            dimension: snapshotDimension,
+          })
+        : undefined;
+
+    try {
+      if (entityType === "safe-rollout") {
+        await apiCall<{ snapshot: SafeRolloutSnapshotInterface }>(
+          snapshotEndpoint,
+          { method: "POST" },
+        );
+      } else {
+        const res = await apiCall<{
+          snapshot: ExperimentSnapshotInterface;
+        }>(snapshotEndpoint, {
+          method: "POST",
+          ...(body && { body }),
+        });
+        if (experimentSnapshotTrackingProps) {
+          trackSnapshot(
+            "create",
+            experimentSnapshotTrackingProps.trackingSource,
+            experimentSnapshotTrackingProps.datasourceType,
+            res.snapshot,
+          );
+        }
+      }
+      onSuccess?.();
+      setRefreshError("");
+    } catch (e) {
+      setRefreshError(e.message);
+    } finally {
+      mutate();
+      mutateAdditional?.();
+    }
+  };
+
+  const runForceRefresh = async () => {
+    try {
+      await apiCall<{ snapshot: ExperimentSnapshotInterface }>(
+        `${snapshotEndpoint}?force=true`,
+        {
+          method: "POST",
+          body: JSON.stringify({ phase: phase ?? 0, dimension: "" }),
+        },
+      );
+      onSuccess?.();
+      setRefreshError("");
+    } catch (e) {
+      setRefreshError(e.message);
+    } finally {
+      mutate();
+      mutateAdditional?.();
+      mutateIncrementalRefresh();
+    }
+  };
+
   return (
     <>
+      {settingsOutdatedModalOpen ? (
+        <ConfirmDialog
+          title="Rebuild incremental pipeline?"
+          content={
+            <div>
+              The experiment settings have changed since the incremental
+              pipeline was built. Updates will run as full queries and pipeline
+              tables will stop advancing until you run a Full Refresh.
+              <br />
+              <br />
+              Running a Full Refresh rebuilds the pipeline tables with the
+              current settings and resumes incremental updates going forward.
+            </div>
+          }
+          yesText="Run Full Refresh"
+          noText="Update anyway"
+          onConfirm={async () => {
+            setSettingsOutdatedModalOpen(false);
+            await runForceRefresh();
+          }}
+          onCancel={async () => {
+            setSettingsOutdatedModalOpen(false);
+            await runNormalUpdate();
+          }}
+        />
+      ) : null}
       {shouldUseRunQueriesButton ? (
         <RunQueriesButton
           cta="Update"
@@ -122,60 +235,11 @@ export default function RefreshResultsButton<
           useRadixButton={true}
           radixVariant="outline"
           onSubmit={async () => {
-            // Precomputed dimensions are computed as part of a standard snapshot,
-            // so we don't need to pass them to the backend for a new snapshot query
-            const snapshotDimension = isDimensionPrecomputed(
-              dimension,
-              getHonoredPrecomputedUnitDimensionIds(
-                experiment?.precomputedUnitDimensionIds,
-                experiment?.datasource
-                  ? getDatasourceById(experiment.datasource)
-                  : undefined,
-                hasCommercialFeature("pipeline-mode"),
-              ),
-            )
-              ? ""
-              : (dimension ?? "");
-            const body =
-              entityType === "experiment" || entityType === "holdout"
-                ? JSON.stringify({
-                    phase: phase ?? 0,
-                    dimension: snapshotDimension,
-                  })
-                : undefined;
-
-            try {
-              if (entityType === "safe-rollout") {
-                await apiCall<{ snapshot: SafeRolloutSnapshotInterface }>(
-                  snapshotEndpoint,
-                  { method: "POST" },
-                );
-              } else {
-                const res = await apiCall<{
-                  snapshot: ExperimentSnapshotInterface;
-                }>(snapshotEndpoint, {
-                  method: "POST",
-                  ...(body && { body }),
-                });
-                if (experimentSnapshotTrackingProps) {
-                  trackSnapshot(
-                    "create",
-                    experimentSnapshotTrackingProps.trackingSource,
-                    experimentSnapshotTrackingProps.datasourceType,
-                    res.snapshot,
-                  );
-                }
-              }
-              onSuccess?.();
-              setRefreshError("");
-            } catch (e) {
-              setRefreshError(e.message);
-            } finally {
-              // Always refresh, regardless of success or failure
-              // to give the UI a chance to catch up
-              mutate();
-              mutateAdditional?.();
+            if (isSettingsOutdated && !dimension) {
+              setSettingsOutdatedModalOpen(true);
+              return;
             }
+            await runNormalUpdate();
           }}
         />
       ) : shouldRenderExperimentButton ? (

--- a/packages/front-end/components/Experiment/RefreshResultsButton.tsx
+++ b/packages/front-end/components/Experiment/RefreshResultsButton.tsx
@@ -18,7 +18,8 @@ import { trackSnapshot } from "@/services/track";
 import RunQueriesButton from "@/components/Queries/RunQueriesButton";
 import ExperimentRefreshSnapshotButton from "@/components/Experiment/RefreshSnapshotButton";
 import SafeRolloutRefreshSnapshotButton from "@/components/SafeRollout/RefreshSnapshotButton";
-import ConfirmDialog from "@/ui/ConfirmDialog";
+import Button from "@/ui/Button";
+import ModalStandard from "@/ui/Modal/Patterns/ModalStandard";
 import { useIncrementalRefresh } from "@/hooks/useIncrementalRefresh";
 
 export type EntityType = "experiment" | "holdout" | "safe-rollout";
@@ -193,32 +194,35 @@ export default function RefreshResultsButton<
 
   return (
     <>
-      {settingsOutdatedModalOpen ? (
-        <ConfirmDialog
-          title="Rebuild incremental pipeline?"
-          content={
-            <div>
-              The experiment settings have changed since the incremental
-              pipeline was built. Updates will run as full queries and pipeline
-              tables will stop advancing until you run a Full Refresh.
-              <br />
-              <br />
-              Running a Full Refresh rebuilds the pipeline tables with the
-              current settings and resumes incremental updates going forward.
-            </div>
-          }
-          yesText="Run Full Refresh"
-          noText="Update anyway"
-          onConfirm={async () => {
-            setSettingsOutdatedModalOpen(false);
-            await runForceRefresh();
-          }}
-          onCancel={async () => {
-            setSettingsOutdatedModalOpen(false);
-            await runNormalUpdate();
-          }}
-        />
-      ) : null}
+      <ModalStandard
+        trackingEventModalType="incremental-refresh-settings-outdated"
+        open={settingsOutdatedModalOpen}
+        header="Rebuild incremental pipeline?"
+        close={() => setSettingsOutdatedModalOpen(false)}
+        cta="Run Full Refresh"
+        submit={runForceRefresh}
+        secondaryAction={
+          <Button
+            variant="outline"
+            onClick={async () => {
+              setSettingsOutdatedModalOpen(false);
+              await runNormalUpdate();
+            }}
+          >
+            Update anyway
+          </Button>
+        }
+      >
+        <p>
+          The experiment settings have changed since the incremental pipeline
+          was built. Updates will run as full queries and pipeline tables will
+          stop advancing until you run a Full Refresh.
+        </p>
+        <p className="mb-0">
+          Running a Full Refresh rebuilds the pipeline tables with the current
+          settings and resumes incremental updates going forward.
+        </p>
+      </ModalStandard>
       {shouldUseRunQueriesButton ? (
         <RunQueriesButton
           cta="Update"

--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
@@ -50,6 +50,8 @@ import { filterMetricsByTags } from "@/hooks/useExperimentTableRows";
 import DimensionChooser from "@/components/Dimensions/DimensionChooser";
 import Link from "@/ui/Link";
 import MigrateResultsToDashboardModal from "@/components/Experiment/ResultsFilter/MigrateResultsToDashboardModal";
+import IncrementalRefreshFallbackCallout from "@/components/Experiment/IncrementalRefreshFallbackCallout";
+import { useIncrementalRefresh } from "@/hooks/useIncrementalRefresh";
 
 export interface Props {
   experiment: ExperimentInterfaceStringDates;
@@ -169,6 +171,8 @@ export default function AnalysisSettingsSummary({
   const hasValidStatsEngine =
     !analysis?.settings ||
     (analysis?.settings?.statsEngine || DEFAULT_STATS_ENGINE) === statsEngine;
+
+  const { nextUpdatePlan } = useIncrementalRefresh(experiment.id);
 
   const [refreshError, setRefreshError] = useState("");
   const [queriesModalOpen, setQueriesModalOpen] = useState(false);
@@ -685,6 +689,13 @@ export default function AnalysisSettingsSummary({
                 />
               ) : null}
             </Flex>
+
+            {experiment.type !== "holdout" ? (
+              <IncrementalRefreshFallbackCallout
+                nextUpdatePlan={nextUpdatePlan}
+                dimension={dimension}
+              />
+            ) : null}
 
             {ds &&
             permissionsUtil.canRunExperimentQueries(ds) &&

--- a/packages/front-end/components/Experiment/incrementalFallbackCopy.ts
+++ b/packages/front-end/components/Experiment/incrementalFallbackCopy.ts
@@ -1,0 +1,86 @@
+import { IncrementalFallbackCode } from "shared/validators";
+
+export type FallbackVisibility = "callout" | "muted" | "none";
+
+export type FallbackCopy = {
+  summary: string;
+  detail: string;
+  visibility: FallbackVisibility;
+};
+
+const COPY: Record<IncrementalFallbackCode, FallbackCopy> = {
+  "settings-outdated": {
+    summary: "Experiment settings have changed",
+    detail:
+      "The incremental pipeline was built with different analysis settings. Updates will run as full queries and pipeline tables will stop advancing until a Full Refresh is performed. Run a Full Refresh to rebuild the pipeline and resume incremental updates.",
+    visibility: "callout",
+  },
+  "non-fact-metrics": {
+    summary: "Non-fact metrics detected",
+    detail:
+      "Only fact metrics are supported with incremental refresh. Switch to fact metrics to re-enable incremental updates.",
+    visibility: "callout",
+  },
+  "no-metrics-selected": {
+    summary: "No metrics selected",
+    detail:
+      "At least one metric must be selected to use incremental refresh. Add metrics to re-enable incremental updates.",
+    visibility: "callout",
+  },
+  "event-quantile-metric": {
+    summary: "Event quantile metric not supported",
+    detail:
+      "This datasource does not support event quantile metrics with incremental refresh. Remove event quantile metrics or switch to a supported datasource.",
+    visibility: "callout",
+  },
+  "activation-metric": {
+    summary: "Activation metric not supported",
+    detail:
+      "Activation metrics are not supported with incremental refresh while in beta. Remove the activation metric to re-enable incremental updates.",
+    visibility: "callout",
+  },
+  "skip-partial-data": {
+    summary: '"Exclude In-Progress Conversions" not supported',
+    detail:
+      'Incremental refresh does not support "Exclude In-Progress Conversions". Change the conversion window setting to "Include" to re-enable incremental updates.',
+    visibility: "callout",
+  },
+  "experiment-type": {
+    summary: "Experiment type not supported",
+    detail: "Incremental refresh is only supported for standard experiments.",
+    visibility: "none",
+  },
+  "no-materialized-units-table": {
+    summary: "No incremental data available yet",
+    detail:
+      "Run a standard update first to initialize the incremental pipeline.",
+    visibility: "none",
+  },
+  "datasource-unsupported": {
+    summary: "Datasource does not support incremental refresh",
+    detail:
+      "This datasource integration does not support incremental queries. Contact support or switch to a supported datasource.",
+    visibility: "muted",
+  },
+  "missing-premium-feature": {
+    summary: "Incremental refresh requires a Pro plan",
+    detail: "Upgrade to a Pro plan or higher to use incremental refresh.",
+    visibility: "muted",
+  },
+  "not-enabled": {
+    summary: "Incremental refresh not enabled",
+    detail:
+      "Incremental refresh is not enabled for this experiment on this datasource.",
+    visibility: "none",
+  },
+  unknown: {
+    summary: "Incremental refresh unavailable",
+    detail:
+      "An unexpected error occurred while checking incremental refresh eligibility.",
+    visibility: "muted",
+  },
+};
+
+export function getFallbackCopy(code: IncrementalFallbackCode): FallbackCopy {
+  return COPY[code];
+}

--- a/packages/front-end/hooks/useIncrementalRefresh.ts
+++ b/packages/front-end/hooks/useIncrementalRefresh.ts
@@ -1,16 +1,21 @@
-import { IncrementalRefreshInterface } from "shared/validators";
+import {
+  IncrementalRefreshInterface,
+  SnapshotRunnerInfo,
+} from "shared/validators";
 import useApi from "./useApi";
 
 export function useIncrementalRefresh(experimentId: string) {
   const { data, error, mutate } = useApi<{
     incrementalRefresh: IncrementalRefreshInterface | null;
+    nextUpdatePlan: SnapshotRunnerInfo | null;
   }>(`/experiment/${experimentId}/incremental-refresh`, {
     shouldRun: () => !!experimentId,
   });
 
   return {
     loading: !error && !data,
-    incrementalRefresh: data?.incrementalRefresh || null,
+    incrementalRefresh: data?.incrementalRefresh ?? null,
+    nextUpdatePlan: data?.nextUpdatePlan ?? null,
     error: error,
     mutate,
   };

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -20,6 +20,7 @@ import {
 } from "./owner-field";
 
 import { namedSchema } from "./openapi-helpers";
+import { snapshotRunnerInfoValidator } from "./incremental-refresh";
 
 export const customMetricSlice = z.object({
   slices: z.array(
@@ -1735,6 +1736,7 @@ export const postExperimentSnapshotValidator = {
   responseSchema: z
     .object({
       snapshot: apiExperimentSnapshotShape,
+      runnerInfo: snapshotRunnerInfoValidator,
     })
     .strict(),
   summary: "Create Experiment Snapshot",

--- a/packages/shared/src/validators/incremental-refresh.ts
+++ b/packages/shared/src/validators/incremental-refresh.ts
@@ -1,6 +1,45 @@
 import { z } from "zod";
 import { baseSchema } from "./base-model";
 
+export const incrementalFallbackCodeValidator = z.enum([
+  "settings-outdated",
+  "non-fact-metrics",
+  "no-metrics-selected",
+  "event-quantile-metric",
+  "activation-metric",
+  "skip-partial-data",
+  "experiment-type",
+  "no-materialized-units-table",
+  "datasource-unsupported",
+  "missing-premium-feature",
+  "not-enabled",
+  "unknown",
+]);
+export type IncrementalFallbackCode = z.infer<
+  typeof incrementalFallbackCodeValidator
+>;
+
+export const incrementalFallbackValidator = z
+  .object({ code: incrementalFallbackCodeValidator, message: z.string() })
+  .strict();
+export type IncrementalFallback = z.infer<typeof incrementalFallbackValidator>;
+
+export const snapshotRunnerInfoValidator = z.discriminatedUnion("runner", [
+  z
+    .object({
+      runner: z.enum(["incremental", "incremental-exploratory"]),
+      fallback: z.null(),
+    })
+    .strict(),
+  z
+    .object({
+      runner: z.literal("inline"),
+      fallback: incrementalFallbackValidator.nullable(),
+    })
+    .strict(),
+]);
+export type SnapshotRunnerInfo = z.infer<typeof snapshotRunnerInfoValidator>;
+
 // Identity for each metric a cache materializes. Which side(s) of the metric
 // this cache actually holds (numerator, denominator, or both) is derivable
 // from the metric's column refs and the source's `factTableId`, so we don't


### PR DESCRIPTION
When pipeline mode cannot be honored, snapshot updates silently fall back to the standard full re-query runner. The reason is a free-text string that dies in a telemetry log. Users keep paying for full scans without knowing; API consumers cannot tell which runner produced a snapshot.

### What changes

**For experimenters.** The results page warns when the next update will run as a full query, with copy naming the cause and the fix. For the one case recoverable by a Full Refresh (experiment settings hash drift), clicking Update opens a modal offering Run Full Refresh (primary), Update anyway, or Cancel. Healthy incremental, pipeline-off, and first-run states render nothing.

**For API consumers.** `POST /api/v1/experiments/:id/snapshot` (and the internal snapshot endpoint) now returns a required `runnerInfo` sibling: `runner: "inline" | "incremental" | "incremental-exploratory"` plus `fallback: {code, message} | null`. Requests are never blocked by a fallback. `GET /experiment/:id/incremental-refresh` additionally returns `nextUpdatePlan`, the prospective answer for a standard update.

### Design notes

- Fallback reasons are a closed Zod enum (`shared/src/validators/incremental-refresh.ts`); a discriminated union makes `incremental` + non-null fallback unrepresentable. `fallback: null` on the `inline` arm means inline was the expected mode (pipeline off/excluded), distinguishing "never expected" from "fell back".
- `assertIncrementalRefreshPrerequisites` is now a thin throwing wrapper over a pure `checkIncrementalRefreshEligibility`; the planner and the prospective check consume the result form, the two incremental query runners keep the throw contract. Single eligibility path; messages unchanged.
- `nextUpdatePlan` is computed by reusing the real `planExperimentSnapshot` (standard, no dimension, latest phase, useCache), so the preview cannot diverge from what Update actually does. Planning failures degrade to `null` rather than breaking the GET.
- Nothing new is persisted on the snapshot document. Runner info is plan-time metadata and rides only creation responses.
- The FE copy map is `Record<IncrementalFallbackCode, FallbackCopy>`, so an unclassified new code fails to compile. `RunQueriesButton` (28 call sites) and `ResultMoreMenu` are untouched; the intercept lives in `RefreshResultsButton`.

### Verification

Type-checks pass on shared, back-end, front-end. 43 backend tests pass across the four affected suites, including a new unit suite covering every eligibility code. OpenAPI spec regenerated and committed. Not yet verified against a live warehouse with pipeline mode enabled; the callout/modal surfaces are exercised by types and lint only, hence the draft state.