### PR TITLE
Add validateFeaturePublish custom hook type

### DIFF
--- a/docs/docs/features/custom-hooks.mdx
+++ b/docs/docs/features/custom-hooks.mdx
@@ -187,3 +187,26 @@ if (
     }
 }
 ```
+
+### validateFeaturePublish
+
+Called when a draft revision is about to be published, before any changes are written. Receives the `feature`, the `revision`, and `approvers` — an array of users who submitted an Approved review on this revision. Each approver is an event user object, e.g. `{type: "dashboard", id: "...", email: "...", name: "..."}` for a logged-in user or `{type: "api_key", apiKey: "key_..."}` for an API request. Throwing blocks the publish.
+
+Example: Require approval from a specific service account plus at least one human before publishing.
+
+```js
+if (
+  !approvers.some(
+    (a) => a?.type === "api_key" && a.apiKey === "key_abc123"
+  )
+) {
+  throw new Error(
+    "Publishing requires approval from the release-bot service account."
+  );
+}
+if (!approvers.some((a) => a?.type === "dashboard")) {
+  throw new Error(
+    "Publishing requires at least one human approval."
+  );
+}
+```

--- a/docs/docs/features/custom-hooks.mdx
+++ b/docs/docs/features/custom-hooks.mdx
@@ -190,7 +190,7 @@ if (
 
 ### validateFeaturePublish
 
-Called when a draft revision is about to be published, before any changes are written. Receives the `feature`, the `revision`, and `approvers` — an array of users who submitted an Approved review on this revision. Each approver is an event user object, e.g. `{type: "dashboard", id: "...", email: "...", name: "..."}` for a logged-in user or `{type: "api_key", apiKey: "key_..."}` for an API request. Throwing blocks the publish.
+Called when a draft revision is about to be published, before any changes are written. Receives the `feature`, the `revision`, and `approvers` — an array of users whose most recent review decision on this revision is an approval (a user who approves and later requests changes is not counted). Each approver is an event user object, e.g. `{type: "dashboard", id: "...", email: "...", name: "..."}` for a logged-in user or `{type: "api_key", apiKey: "key_..."}` for an API request. Throwing blocks the publish.
 
 Example: Require approval from a specific service account plus at least one human before publishing.
 

--- a/packages/back-end/src/enterprise/sandbox/sandbox-eval.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-eval.ts
@@ -1,6 +1,10 @@
 import { Isolate, Context, Reference, ExternalCopy } from "isolated-vm";
 import { RequestInit } from "node-fetch";
-import { CustomHookInterface, CustomHookType } from "shared/validators";
+import {
+  CustomHookInterface,
+  CustomHookType,
+  EventUser,
+} from "shared/validators";
 import { FeatureInterface } from "shared/types/feature";
 import { FeatureRevisionInterface } from "shared/types/feature-revision";
 import { parseEnvInt } from "shared/util";
@@ -76,6 +80,27 @@ export async function runValidateFeatureRevisionHooks({
       feature,
       revision: original,
     },
+  );
+}
+
+export async function runValidateFeaturePublishHooks({
+  context,
+  feature,
+  revision,
+  approvers,
+}: {
+  context: ReqContextClass;
+  feature: FeatureInterface;
+  revision: FeatureRevisionInterface;
+  approvers: EventUser[];
+}): Promise<void> {
+  // No originalFunctionArgs: publishing is not an incremental edit, so
+  // `incrementalChangesOnly` does not apply to this hook type.
+  return _runCustomHooks(
+    context,
+    "validateFeaturePublish",
+    { feature, revision, approvers },
+    feature.project,
   );
 }
 

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -97,7 +97,10 @@ import {
   deleteVercelExperimentationItemFromFeature,
 } from "back-end/src/services/vercel-native-integration.service";
 import { getObjectDiff } from "back-end/src/events/handlers/webhooks/event-webhooks-utils";
-import { runValidateFeatureHooks } from "back-end/src/enterprise/sandbox/sandbox-eval";
+import {
+  runValidateFeatureHooks,
+  runValidateFeaturePublishHooks,
+} from "back-end/src/enterprise/sandbox/sandbox-eval";
 import {
   createEvent,
   hasPreviousObject,
@@ -2222,6 +2225,23 @@ export async function publishRevision({
   if (!bypassLockdown) {
     await assertFeatureNotLockedByRamp(context, feature.id);
   }
+
+  // Run publish validation hooks before any writes (feature doc, ramp
+  // schedules, SDK refresh) so a throwing hook blocks the publish cleanly.
+  const revisionLogs =
+    await context.models.featureRevisionLogs.getAllByFeatureIdAndVersion({
+      featureId: revision.featureId,
+      version: revision.version,
+    });
+  const approvers = revisionLogs
+    .filter((l) => l.action === "Approved")
+    .map((l) => l.user);
+  await runValidateFeaturePublishHooks({
+    context,
+    feature,
+    revision,
+    approvers,
+  });
 
   // Create ramp schedules BEFORE writing the feature so that a schedule
   // creation failure gates the publish (atomicity: no published feature without

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -2233,7 +2233,25 @@ export async function publishRevision({
       featureId: revision.featureId,
       version: revision.version,
     });
-  const approvers = revisionLogs
+  // Only count a user as an approver if their most recent review decision is
+  // an approval — an approval followed by "Requested Changes" is withdrawn.
+  const latestReviewByUser = new Map<string, (typeof revisionLogs)[number]>();
+  for (const log of revisionLogs) {
+    if (log.action !== "Approved" && log.action !== "Requested Changes") {
+      continue;
+    }
+    const u = log.user;
+    const key = !u
+      ? "null"
+      : u.type === "api_key"
+        ? `api_key:${u.apiKey}`
+        : `${u.type}:${u.id ?? ""}`;
+    const prev = latestReviewByUser.get(key);
+    if (!prev || log.dateCreated >= prev.dateCreated) {
+      latestReviewByUser.set(key, log);
+    }
+  }
+  const approvers = [...latestReviewByUser.values()]
     .filter((l) => l.action === "Approved")
     .map((l) => l.user);
   await runValidateFeaturePublishHooks({

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -1201,19 +1201,22 @@ export async function submitReviewAndComments(
     },
   );
 
-  // Fire and forget - no route that submits the review and comments expects the log to be there immediately
-  context.models.featureRevisionLogs
-    .create({
+  // Await the log write: `publishRevision` reads these logs to determine
+  // approvers for validateFeaturePublish hooks, so an Approved entry must be
+  // persisted before the review request returns. Failures still don't block
+  // the review itself.
+  try {
+    await context.models.featureRevisionLogs.create({
       featureId: revision.featureId,
       version: revision.version,
       action,
       subject: "",
       user,
       value: JSON.stringify(comment ? { comment } : {}),
-    })
-    .catch((e) => {
-      logger.error(e, "Error creating revisionlog");
     });
+  } catch (e) {
+    logger.error(e, "Error creating revisionlog");
+  }
 }
 
 export async function discardRevision(

--- a/packages/back-end/test/sandbox-eval.test.ts
+++ b/packages/back-end/test/sandbox-eval.test.ts
@@ -88,4 +88,76 @@ describe("sandboxEval", () => {
     const result = await sandboxEval("return 1", {});
     expect(result).toEqual({ ok: true, returnVal: 1, log: "", warnings: [] });
   });
+
+  describe("validateFeaturePublish args", () => {
+    const requireApproversBody = `
+      if (!approvers.length) {
+        throw new Error("Publishing requires at least one approval");
+      }
+      if (!approvers.some((a) => a?.type === "dashboard")) {
+        throw new Error("Publishing requires at least one human approval");
+      }
+    `;
+
+    const feature = { id: "my-feature", project: "" };
+    const revision = {
+      featureId: "my-feature",
+      version: 2,
+      status: "approved",
+    };
+
+    it("should block when there are no approvers", async () => {
+      const result = await sandboxEval(requireApproversBody, {
+        feature,
+        revision,
+        approvers: [],
+      });
+      expect(result).toEqual({
+        ok: false,
+        error: expect.stringContaining(
+          "Publishing requires at least one approval",
+        ),
+        log: "",
+        warnings: [],
+      });
+    });
+
+    it("should block when only an api_key approver is present", async () => {
+      const result = await sandboxEval(requireApproversBody, {
+        feature,
+        revision,
+        approvers: [{ type: "api_key", apiKey: "key_abc123" }],
+      });
+      expect(result).toEqual({
+        ok: false,
+        error: expect.stringContaining(
+          "Publishing requires at least one human approval",
+        ),
+        log: "",
+        warnings: [],
+      });
+    });
+
+    it("should pass when a dashboard approver is present", async () => {
+      const result = await sandboxEval(requireApproversBody, {
+        feature,
+        revision,
+        approvers: [
+          { type: "api_key", apiKey: "key_abc123" },
+          {
+            type: "dashboard",
+            id: "user_123",
+            email: "user@example.com",
+            name: "User",
+          },
+        ],
+      });
+      expect(result).toEqual({
+        ok: true,
+        returnVal: undefined,
+        log: "",
+        warnings: [],
+      });
+    });
+  });
 });

--- a/packages/front-end/pages/settings/custom-hooks.tsx
+++ b/packages/front-end/pages/settings/custom-hooks.tsx
@@ -101,6 +101,32 @@ const hookTypes: Record<
     },
     example: `\n// Block the save (hard error):\nif (!revision.rules.production || revision.rules.production.length === 0) {\n  throw new Error("At least one production rule is required");\n}\n\n// Or raise a soft warning the user can acknowledge:\nif (!revision.comment) {\n  addWarning("Consider adding a comment describing this change");\n}`,
   },
+  validateFeaturePublish: {
+    label: "Validate Feature Publish",
+    availableArguments: {
+      feature: {
+        description: "The feature object being published",
+        testValue: stringify(dummyFeature),
+      },
+      revision: {
+        description: "The feature revision being published",
+        testValue: stringify(dummyRevision),
+      },
+      approvers: {
+        description: "Users who submitted an Approved review for this revision",
+        testValue: stringify([
+          {
+            type: "dashboard",
+            id: "user_123",
+            name: "User",
+            email: "user@example.com",
+          },
+          { type: "api_key", apiKey: "key_abc123" },
+        ]),
+      },
+    },
+    example: `\n// Block the publish (hard error):\nif (approvers.length === 0) {\n  throw new Error("Publishing requires at least one approval");\n}\n\n// Or raise a soft warning the user can acknowledge:\nif (!approvers.some((a) => a?.type === "dashboard")) {\n  addWarning("Consider getting a human approval before publishing");\n}`,
+  },
 };
 
 function CustomHooksModal({

--- a/packages/front-end/pages/settings/custom-hooks.tsx
+++ b/packages/front-end/pages/settings/custom-hooks.tsx
@@ -113,7 +113,8 @@ const hookTypes: Record<
         testValue: stringify(dummyRevision),
       },
       approvers: {
-        description: "Users who submitted an Approved review for this revision",
+        description:
+          "Users whose most recent review decision on this revision is an approval",
         testValue: stringify([
           {
             type: "dashboard",

--- a/packages/shared/src/validators/custom-hooks.ts
+++ b/packages/shared/src/validators/custom-hooks.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 
-export const hooks = ["validateFeature", "validateFeatureRevision"] as const;
+export const hooks = [
+  "validateFeature",
+  "validateFeatureRevision",
+  "validateFeaturePublish",
+] as const;
 
 export const customHookValidator = z
   .object({


### PR DESCRIPTION
## Motivation

Custom hooks currently cover feature saves (`validateFeature`) and revision edits (`validateFeatureRevision`), but there is no synchronous gate at **publish** time. Organizations that require specific approval policies — e.g. "a particular service account *and* at least one human must approve before a revision goes live" — have no way to enforce them without forking or wrapping the API.

This adds a third hook type, `validateFeaturePublish`, that fires in `publishRevision` **before any feature-doc write, ramp-schedule creation, or SDK refresh**. Throwing from the hook blocks the publish cleanly.

## Behavior

* Hook receives `{ feature, revision, approvers }`, where `approvers` is the array of event-user objects whose most recent review decision on the revision is an approval (an approval followed by "Requested Changes" is withdrawn) — so approval policies need no external fetches.
* Every publish path funnels through `publishRevision` (UI publish, REST `createAndPublishRevision`, experiment features, ramp schedules, safe rollouts), so the single call site covers all of them.
* `incrementalChangesOnly` does not apply (publishing is not an incremental edit), mirroring how the wrapper omits `originalFunctionArgs`.
* `submitReviewAndComments` now awaits the revision-log write (still non-fatal on failure) so an Approved entry is persisted before the review request returns, closing the race where a publish could read logs before the approval landed.

Example hook:

```js
if (!approvers.some((a) => a?.type === "api_key" && a.apiKey === "key_abc123")) {
  throw new Error("Publishing requires approval from the release-bot service account.");
}
if (!approvers.some((a) => a?.type === "dashboard")) {
  throw new Error("Publishing requires at least one human approval.");
}
```

## Changes

* `packages/shared/src/validators/custom-hooks.ts` — add `validateFeaturePublish` to the hook enum.
* `packages/back-end/src/enterprise/sandbox/sandbox-eval.ts` — add `runValidateFeaturePublishHooks` wrapper.
* `packages/back-end/src/models/FeatureModel.ts` — invoke the hook in `publishRevision` before any writes.
* `packages/back-end/src/models/FeatureRevisionModel.ts` — await the Approved revision-log write.
* `packages/front-end/pages/settings/custom-hooks.tsx` — new hook type in the settings UI with sample test inputs.
* `docs/docs/features/custom-hooks.mdx` — document the new hook type.
* `packages/back-end/test/sandbox-eval.test.ts` — tests covering approver-based blocking/passing.

## Testing

* New jest cases in `sandbox-eval.test.ts` exercising a hook body over `approvers` (blocks with no approvers, blocks with only an API-key approver, passes with a human approver).
* Type-checks pass for `back-end`, `front-end`, and `shared`.

Purely additive; mirrors the existing hook pattern.
