### PR TITLE
Fix: Stop draft experiments trapping the browser navigation and breaking the back button

### DIFF
--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -283,14 +283,8 @@ export default function ExperimentHeader({
   }, [shouldHideTabs]);
 
   // When the tab strip is hidden (e.g. an unstarted draft), the only
-  // reachable view is the overview, so force the active tab there. Guard
-  // on the current tab: `setTab` is `setTabAndScroll`, which does a
-  // `router.push("#overview")`, and it's recreated every render — without
-  // this guard the effect re-ran on every render and, crucially, re-pushed
-  // "#overview" right after the user pressed Back to strip the hash,
-  // trapping the Back button so it could never return to the experiments
-  // list. Once `tab` is already "overview" this is a no-op, so Back exits
-  // cleanly.
+  // reachable view is the overview, so force the active tab there. Once `tab`
+  // is already "overview" this is a no-op, so Back exits cleanly.
   useEffect(() => {
     if (shouldHideTabs && tab !== "overview") {
       setTab("overview");

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -282,11 +282,20 @@ export default function ExperimentHeader({
     return () => observer.disconnect();
   }, [shouldHideTabs]);
 
+  // When the tab strip is hidden (e.g. an unstarted draft), the only
+  // reachable view is the overview, so force the active tab there. Guard
+  // on the current tab: `setTab` is `setTabAndScroll`, which does a
+  // `router.push("#overview")`, and it's recreated every render — without
+  // this guard the effect re-ran on every render and, crucially, re-pushed
+  // "#overview" right after the user pressed Back to strip the hash,
+  // trapping the Back button so it could never return to the experiments
+  // list. Once `tab` is already "overview" this is a no-op, so Back exits
+  // cleanly.
   useEffect(() => {
-    if (shouldHideTabs) {
+    if (shouldHideTabs && tab !== "overview") {
       setTab("overview");
     }
-  }, [shouldHideTabs, setTab]);
+  }, [shouldHideTabs, tab, setTab]);
 
   async function handleWatchUpdates(watch: boolean) {
     await apiCall(

--- a/packages/front-end/components/Experiment/TabbedPage/index.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/index.tsx
@@ -205,20 +205,28 @@ export default function TabbedPage({
         setTab(tabName);
         setTabPath(tabPath);
       } else if (!hash) {
-        // If no hash in URL, add the current tab from state to the URL
-        const newUrl =
-          window.location.href.replace(/#.*/, "") + "#" + tabRef.current;
-        router.replace(newUrl, undefined, { shallow: true }).catch((e) => {
-          if (!e.cancelled) {
-            throw e;
-          }
-        });
+        if (experiment.status === "draft") {
+          // Draft experiments only have one tab, and show the default "overview" tab WITHOUT
+          // rewriting the URL to include the hash string.
+          setTab("overview");
+          setTabPath("");
+        } else {
+          // Non-draft experiments: re-add the remembered tab from state to the
+          // URL so navigating back to the experiment restores the last tab.
+          const newUrl =
+            window.location.href.replace(/#.*/, "") + "#" + tabRef.current;
+          router.replace(newUrl, undefined, { shallow: true }).catch((e) => {
+            if (!e.cancelled) {
+              throw e;
+            }
+          });
+        }
       }
     };
     handler();
     window.addEventListener("hashchange", handler, false);
     return () => window.removeEventListener("hashchange", handler, false);
-  }, [setTab, router]);
+  }, [setTab, router, experiment.status]);
 
   const { dashboards } = useExperimentDashboards(experiment.id);
 

--- a/packages/front-end/components/Experiment/TabbedPage/index.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/index.tsx
@@ -205,28 +205,20 @@ export default function TabbedPage({
         setTab(tabName);
         setTabPath(tabPath);
       } else if (!hash) {
-        if (experiment.status === "draft") {
-          // Draft experiments only have one tab, and show the default "overview" tab WITHOUT
-          // rewriting the URL to include the hash string.
-          setTab("overview");
-          setTabPath("");
-        } else {
-          // Non-draft experiments: re-add the remembered tab from state to the
-          // URL so navigating back to the experiment restores the last tab.
-          const newUrl =
-            window.location.href.replace(/#.*/, "") + "#" + tabRef.current;
-          router.replace(newUrl, undefined, { shallow: true }).catch((e) => {
-            if (!e.cancelled) {
-              throw e;
-            }
-          });
-        }
+        // If no hash in URL, add the current tab from state to the URL
+        const newUrl =
+          window.location.href.replace(/#.*/, "") + "#" + tabRef.current;
+        router.replace(newUrl, undefined, { shallow: true }).catch((e) => {
+          if (!e.cancelled) {
+            throw e;
+          }
+        });
       }
     };
     handler();
     window.addEventListener("hashchange", handler, false);
     return () => window.removeEventListener("hashchange", handler, false);
-  }, [setTab, router, experiment.status]);
+  }, [setTab, router]);
 
   const { dashboards } = useExperimentDashboards(experiment.id);
 


### PR DESCRIPTION
Navigating to a draft experiment messes up the urls and breaks the back button. 