### PR TITLE
Fix various bugs from production error logs

### DIFF
--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -3,7 +3,6 @@ import { DEFAULT_STATS_ENGINE } from "shared/constants";
 import { getValidDate } from "shared/dates";
 import { getSnapshotAnalysis } from "shared/util";
 import { pick, omit } from "lodash";
-import uniqid from "uniqid";
 import { experimentAnalysisSettings } from "shared/validators";
 import {
   ExperimentReportAnalysisSettings,
@@ -13,6 +12,7 @@ import {
   ReportInterface,
 } from "shared/types/report";
 import { getAllVariations } from "shared/experiments";
+import { generateId } from "back-end/src/util/uuid";
 import {
   getExperimentById,
   getExperimentsByIds,
@@ -62,7 +62,7 @@ export async function postReportFromSnapshot(
     throw new Error("Invalid snapshot id");
   }
   // Prepare a new report-specific snapshot
-  snapshot.id = uniqid("snp_");
+  snapshot.id = generateId("snp_");
   snapshot.type = "report";
   snapshot.triggeredBy = "manual";
   if (snapshot?.health?.traffic && !snapshot?.health?.traffic?.dimension) {

--- a/packages/back-end/src/jobs/updateExperimentResults.ts
+++ b/packages/back-end/src/jobs/updateExperimentResults.ts
@@ -14,7 +14,10 @@ import {
   getSettingsForSnapshotMetrics,
   updateExperimentBanditSettings,
 } from "back-end/src/services/experiments";
-import { ConcurrentIncrementalRefreshError } from "back-end/src/util/errors";
+import {
+  ConcurrentIncrementalRefreshError,
+  UnrecoverableSnapshotError,
+} from "back-end/src/util/errors";
 import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizations";
 import { getMetricMap } from "back-end/src/models/MetricModel";
 import { notifyAutoUpdate } from "back-end/src/services/experimentNotifications";
@@ -225,8 +228,13 @@ const updateSingleExperiment = async (job: UpdateSingleExpJob) => {
     }
 
     logger.error(e, "Failed to update experiment: " + experimentId);
-    // If we failed to update the experiment, turn off auto-updating for the future (non-bandits only)
-    if (experiment.type === "multi-armed-bandit") return;
+    // Turn off auto-updating for the future (bandits keep retrying unless the failure is deterministic)
+    if (
+      experiment.type === "multi-armed-bandit" &&
+      !(e instanceof UnrecoverableSnapshotError)
+    ) {
+      return;
+    }
     try {
       await updateExperiment({
         context,

--- a/packages/back-end/src/models/AuditModel.ts
+++ b/packages/back-end/src/models/AuditModel.ts
@@ -44,7 +44,12 @@ type AuditDocument = mongoose.Document & AuditInterface;
 const AuditModel = mongoose.model<AuditInterface>("Audit", auditSchema);
 
 const toInterface: ToInterface<AuditInterface> = (doc) => {
-  return removeMongooseFields(doc);
+  const audit = removeMongooseFields(doc);
+  // Legacy audit docs may be missing the user field entirely
+  if (!audit.user) {
+    audit.user = { id: "", email: "", name: "Unknown" };
+  }
+  return audit;
 };
 
 export async function insertAudit(

--- a/packages/back-end/src/models/AuditModel.ts
+++ b/packages/back-end/src/models/AuditModel.ts
@@ -1,10 +1,10 @@
 import mongoose, { FilterQuery, QueryOptions } from "mongoose";
-import uniqid from "uniqid";
 import { AuditInterface, EntityType } from "shared/types/audit";
 import {
   removeMongooseFields,
   ToInterface,
 } from "back-end/src/util/mongo.util";
+import { generateId } from "back-end/src/util/uuid";
 
 const auditSchema = new mongoose.Schema({
   id: {
@@ -52,7 +52,7 @@ export async function insertAudit(
 ): Promise<AuditInterface> {
   const auditDoc = await AuditModel.create({
     ...data,
-    id: uniqid("aud_"),
+    id: generateId("aud_"),
   });
   return toInterface(auditDoc);
 }

--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -248,6 +248,11 @@ export class FactMetricModel extends BaseClass {
   public static migrateColumnRef(columnRef: LegacyColumnRef): ColumnRef {
     const { filters, inlineFilters, ...newColumnRef } = columnRef;
 
+    // The Mongo driver stores explicit `undefined` as null, which fails validation on later updates
+    if ((newColumnRef.aggregation ?? null) === null) {
+      delete newColumnRef.aggregation;
+    }
+
     // If row filters are already defined, do nothing
     if (newColumnRef.rowFilters !== undefined) {
       return newColumnRef;

--- a/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
@@ -36,6 +36,7 @@ import {
   QueryStatus,
 } from "shared/types/query";
 import { BanditResult } from "shared/types/experiment";
+import { UnrecoverableSnapshotError } from "back-end/src/util/errors";
 import { orgHasPremiumFeature } from "back-end/src/enterprise";
 import { ApiReqContext } from "back-end/types/api";
 import {
@@ -110,7 +111,9 @@ export const startExperimentResultQueries = async (
     .map((m) => metricMap.get(m.id))
     .filter((m) => m) as ExperimentMetricInterface[];
   if (!selectedMetrics.length) {
-    throw new Error("Experiment must have at least 1 metric selected.");
+    throw new UnrecoverableSnapshotError(
+      "Experiment must have at least 1 metric selected.",
+    );
   }
 
   let segmentObj: SegmentInterface | null = null;
@@ -670,7 +673,9 @@ export class ExperimentResultsQueryRunner extends QueryRunner<
       .map((m) => metricMap.get(m))
       .filter((m) => m) as ExperimentMetricInterface[];
     if (!selectedMetrics.length) {
-      throw new Error("Experiment must have at least 1 metric selected.");
+      throw new UnrecoverableSnapshotError(
+        "Experiment must have at least 1 metric selected.",
+      );
     }
 
     const dimensionObj = await parseDimension(

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -131,6 +131,7 @@ import { ProjectInterface } from "shared/types/project";
 import { MetricGroupInterface } from "shared/types/metric-groups";
 import { ExperimentQueryMetadata } from "shared/types/query";
 import { isExperimentIncrementalEnabled } from "shared/enterprise";
+import { generateId } from "back-end/src/util/uuid";
 import { orgHasPremiumFeature } from "back-end/src/enterprise";
 import { updateExperiment } from "back-end/src/models/ExperimentModel";
 import {
@@ -1483,7 +1484,7 @@ export async function planSnapshot({
   });
 
   const data: ExperimentSnapshotInterface = {
-    id: uniqid("snp_"),
+    id: generateId("snp_"),
     organization: experiment.organization,
     experiment: experiment.id,
     runStarted: new Date(),

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -23,7 +23,6 @@ import {
   getLatestPhaseVariations,
 } from "shared/experiments";
 import { isDefined } from "shared/util";
-import uniqid from "uniqid";
 import { differenceInMinutes } from "date-fns";
 import { getScopedSettings } from "shared/settings";
 import uniq from "lodash/uniq";
@@ -61,6 +60,7 @@ import { DataSourceInterface } from "shared/types/datasource";
 import { ProjectInterface } from "shared/types/project";
 import { accountFeatures, CommercialFeature } from "shared/enterprise";
 import { buildAnalysisKey } from "shared/snapshot-analysis-chunks";
+import { generateId } from "back-end/src/util/uuid";
 import { getMetricsByIds } from "back-end/src/models/MetricModel";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
@@ -567,7 +567,7 @@ export async function createReportSnapshot({
   // Fill in and sanitize the model
   snapshotData = {
     ...snapshotData,
-    id: uniqid("snp_"),
+    id: generateId("snp_"),
     type: snapshotType,
     report: report.id,
     triggeredBy: "manual",

--- a/packages/back-end/src/util/errors.ts
+++ b/packages/back-end/src/util/errors.ts
@@ -107,6 +107,14 @@ export class ConcurrentIncrementalRefreshError extends Error {
   }
 }
 
+// Snapshot failures that repeat on every retry; auto-updates get disabled, even for bandits
+export class UnrecoverableSnapshotError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnrecoverableSnapshotError";
+  }
+}
+
 // Some errors are part of normal operation and shouldn't pollute
 // error-level logs or Sentry. Add cases here as we identify them.
 export function shouldSkipErrorLog(err: unknown): boolean {

--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -73,6 +73,11 @@ function adjustWeights(weights: number[]): number[] {
 export function upgradeMetricDoc(doc: LegacyMetricInterface): MetricInterface {
   const newDoc = { ...doc };
 
+  // Raw-driver reads skip Mongoose date casting; legacy docs may store strings
+  if (typeof newDoc.runStarted === "string") {
+    newDoc.runStarted = new Date(newDoc.runStarted);
+  }
+
   if (doc.windowSettings === undefined) {
     if (doc.conversionDelayHours == null && doc.earlyStart) {
       newDoc.windowSettings = {

--- a/packages/back-end/test/migrations.test.ts
+++ b/packages/back-end/test/migrations.test.ts
@@ -553,6 +553,53 @@ describe("Metric Migration", () => {
     });
   });
 
+  it("casts string runStarted values to Dates", () => {
+    const baseMetric: LegacyMetricInterface = {
+      datasource: "",
+      dateCreated: new Date(),
+      dateUpdated: new Date(),
+      description: "",
+      id: "",
+      ignoreNulls: false,
+      inverse: false,
+      name: "",
+      organization: "",
+      owner: "",
+      queries: [],
+      runStarted: null,
+      type: "binomial",
+      userIdColumns: {
+        user_id: "user_id",
+        anonymous_id: "anonymous_id",
+      },
+      cappingSettings: {
+        type: "",
+        value: 0,
+      },
+      priorSettings: {
+        override: false,
+        proper: false,
+        mean: 0,
+        stddev: DEFAULT_PROPER_PRIOR_STDDEV,
+      },
+      userIdTypes: ["anonymous_id", "user_id"],
+    };
+
+    expect(
+      upgradeMetricDoc({
+        ...baseMetric,
+        runStarted: "2026-05-20T01:23:45.678Z" as unknown as Date,
+      }).runStarted,
+    ).toEqual(new Date("2026-05-20T01:23:45.678Z"));
+
+    // Dates and nulls pass through unchanged
+    const date = new Date();
+    expect(
+      upgradeMetricDoc({ ...baseMetric, runStarted: date }).runStarted,
+    ).toBe(date);
+    expect(upgradeMetricDoc(baseMetric).runStarted).toBe(null);
+  });
+
   it("updates old metric objects - cap and capping", () => {
     const baseMetric: LegacyMetricInterface = {
       datasource: "",

--- a/packages/front-end/components/HistoryTable.tsx
+++ b/packages/front-end/components/HistoryTable.tsx
@@ -100,8 +100,7 @@ export function HistoryTableRow({
   itemName?: string;
   url?: string;
 }) {
-  // Legacy audit docs may be missing the user field entirely
-  const user = event.user ?? { name: "Unknown" };
+  const user = event.user;
   const userDisplay =
     ("name" in user && user.name) ||
     ("email" in user && user.email) ||

--- a/packages/front-end/components/HistoryTable.tsx
+++ b/packages/front-end/components/HistoryTable.tsx
@@ -100,7 +100,8 @@ export function HistoryTableRow({
   itemName?: string;
   url?: string;
 }) {
-  const user = event.user;
+  // Legacy audit docs may be missing the user field entirely
+  const user = event.user ?? { name: "Unknown" };
   const userDisplay =
     ("name" in user && user.name) ||
     ("email" in user && user.email) ||


### PR DESCRIPTION
### Features and Changes

Fixes 5 bugs discovered in Sentry:
1. Mongo unique index collisions for audit logs and snapshots.  Switched from `uniqid` to `generateId`
2. Bandits with no metrics would attempt to refresh every 10 minutes and immediately fail (just to be requeued 10 minutes later). Fixed by differentiating unrecoverable errors from other errors and disabling automatic updates.
3. Some fact metrics were persisted with `numerator.aggregation === null`, which fails Zod validation (the field is optional, but not nullable).  Added a JIT migration to fix this.
4. Some legacy metrics were persisted with `runStarted` as a string instead of a date.  Added a JIT migration to fix this (plus some tests to verify the fix).
5. Some old audit log events in Mongo are missing a user which crashed the audit history table on the front-end. Added a fallback on the front-end to make this more lenient.