### PR TITLE
Use Docker Hardened Image (dev variant) for the runtime base

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -30,7 +30,7 @@ jobs:
       # Required to pull the hardened base image (FROM dhi.io/...) in the Dockerfile.
       # Depot forwards these credentials to its remote builder.
       - name: Login to Docker Hardened Images
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: dhi.io
           username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -22,8 +22,17 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      # Required to pull the hardened base image (FROM dhi.io/...) in the Dockerfile.
+      # Depot forwards these credentials to its remote builder.
+      - name: Login to Docker Hardened Images
+        uses: docker/login-action@v3
+        with:
+          registry: dhi.io
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
       # Required to pull the hardened base image (FROM dhi.io/...) in the Dockerfile.
       # Depot forwards these credentials to its remote builder.
       - name: Login to Docker Hardened Images
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: dhi.io
           username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,15 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
+      # Required to pull the hardened base image (FROM dhi.io/...) in the Dockerfile.
+      # Depot forwards these credentials to its remote builder.
+      - name: Login to Docker Hardened Images
+        uses: docker/login-action@v3
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
       - name: Configure AWS credentials for ECR
         uses: aws-actions/configure-aws-credentials@v5
         with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -45,7 +45,7 @@ jobs:
       # so we build on CI via Depot (which can) and deploy the prebuilt image.
       - name: Login to Docker Hardened Images
         if: ${{ github.event.action != 'closed' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: dhi.io
           username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,6 +16,9 @@ jobs:
   preview:
     if: ${{ github.repository == 'growthbook/growthbook' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       url: ${{ steps.deploy.outputs.url }}
     concurrency:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -38,12 +38,45 @@ jobs:
       - name: Setup fly cli
         uses: superfly/flyctl-actions/setup-flyctl@master
 
+      # Fly's remote builder can't authenticate to the private dhi.io base image,
+      # so we build on CI via Depot (which can) and deploy the prebuilt image.
+      - name: Login to Docker Hardened Images
+        if: ${{ github.event.action != 'closed' }}
+        uses: docker/login-action@v3
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Install Depot CLI
+        if: ${{ github.event.action != 'closed' }}
+        uses: depot/setup-action@v1
+
+      - name: Login to Fly registry
+        if: ${{ github.event.action != 'closed' }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl auth docker
+
+      - name: Build and push preview image
+        if: ${{ github.event.action != 'closed' }}
+        uses: depot/build-push-action@v1
+        with:
+          push: true
+          context: .
+          file: preview/Dockerfile.generated
+          project: vmp2ssvj9r
+          build-args: |
+            NODE_OPTIONS=--max-old-space-size=14336
+          tags: registry.fly.io/${{ env.APP_NAME }}:${{ github.sha }}
+
       - name: Deploy PR preview
         id: deploy
         uses: superfly/fly-pr-review-apps@1.3.0
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         with:
+          image: registry.fly.io/${{ env.APP_NAME }}:${{ github.sha }}
           config: preview-pr-fly.toml
           name: ${{ env.APP_NAME }}
           org: growthbook

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,9 @@ RUN pnpm postinstall
 # Package the full app together on a hardened, continuously-patched base
 # (Docker Hardened Images). The dev variant keeps apt/shell/root, so the
 # apt-install + pm2 + pnpm flow below is unchanged from a stock node base.
+# Building this image from source requires `docker login dhi.io` (free Docker
+# Hub account, DHI Community tier). Pulling the published growthbook/growthbook
+# image needs no such login.
 FROM dhi.io/node:${NODE_MAJOR}-debian12-dev
 ARG PYTHON_MAJOR
 WORKDIR /usr/local/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,14 +84,16 @@ RUN \
   && rm -f packages/stats/poetry.lock
 RUN pnpm postinstall
 
-# Package the full app together
-FROM node:${NODE_MAJOR}-slim
+# Package the full app together on a hardened, continuously-patched base
+# (Docker Hardened Images). The dev variant keeps apt/shell/root, so the
+# apt-install + pm2 + pnpm flow below is unchanged from a stock node base.
+FROM dhi.io/node:${NODE_MAJOR}-debian12-dev
 ARG PYTHON_MAJOR
 WORKDIR /usr/local/src/app
+# The hardened node image already bundles pnpm, so (unlike a stock node base) we
+# don't reinstall it; the stock-path npm removal is likewise unneeded here.
 RUN apt-get update && \
   apt-get install -y --no-install-recommends python${PYTHON_MAJOR} ca-certificates libkrb5-3 && \
-  npm install -g pnpm@10.33.4 && \
-  rm -rf /usr/local/lib/node_modules/npm && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
   ln -sf /usr/bin/python${PYTHON_MAJOR} /usr/local/bin/python3 && \


### PR DESCRIPTION
### Features and Changes

Swaps the final-stage runtime base from `node:24-slim` to the Docker Hardened Image dev variant (`dhi.io/node:24-debian12-dev`) — a continuously-patched, near-zero-CVE base. This eliminates the recurring class of OS-package findings (e.g. `gnutls28`, `libgcrypt20`) that never clear on a rebuild, because the stock base freezes those packages and our Dockerfile never runs `apt-get upgrade`.

The `dev` variant keeps `apt`/shell/root, so the existing `apt-get install` + `pm2` + `pnpm` flow is unchanged. It already bundles `pnpm`, so the `npm install -g pnpm` and npm-removal lines are dropped (they'd collide / no-op otherwise). Build stages stay on the official slim images since they don't ship.

Pulling `dhi.io/*` requires authentication, so this also wires up Docker auth across every build path that compiles the Dockerfile from source:

- **`deploy.yml` (production) and `deploy-branch.yml` (manual).** Add a `docker login dhi.io` step before the Depot build. Depot forwards the runner's registry credentials to its remote builder, so `FROM dhi.io/...` resolves. Both reuse the existing `DOCKER_HUB_*` secrets.
- **`preview.yml` (Fly PR previews).** Fly's remote builder can't authenticate to a private base registry, so previews no longer build on Fly. Instead CI builds `preview/Dockerfile.generated` via Depot (which can auth to `dhi.io`), pushes to `registry.fly.io`, and hands the prebuilt image to `fly-pr-review-apps` via its `image:` input. The build steps are gated on `github.event.action != 'closed'` so teardown is unaffected, and the job gains `id-token: write` for Depot's OIDC auth.
- **`release.yml` / `rollback.yml` are untouched** — they only retag an already-built image (`imagetools create`), so they never pull the base.

Note: only building the image **from source** now requires `docker login dhi.io`. Pulling the published `growthbook/growthbook` image (including existing self-host `docker compose` setups) needs no login — they get the hardened base automatically on their next pull.

:warning: This changes the production runtime base image and the preview build pipeline. Building from source now needs `docker login dhi.io` (DHI Community tier — free, no subscription).

Scan delta vs the current `main` build (`docker scout quickview`):
```
            stock     this branch
Critical      1    ->      0
High         21    ->      8
Medium       13    ->      9
Low          43    ->     54
```
Low rises because the dev variant bundles build tooling (`curl`/`git`/`gcc`/`perl`) carrying won't-fix low CVEs, which aren't removable on the free tier. The distroless runtime variant reaches `0C/6H/5M/11L` but needs a substantially more complex Dockerfile (multi-stage copy-assembly + a custom process supervisor); deferred in favor of this minimal change.

### Testing

- [x] `docker build` completes on the hardened base; container boots (`pm2` starts back-end + front-end), serves on `:3000`/`:3100`; Mongo connects (SCRAM) and an experiment results refresh runs the `gbstats` engine
- [x] `docker scout quickview` shows 0 Critical / 8 High
- [x] **Preview pipeline, end-to-end green** ([run 27664206015](https://github.com/growthbook/growthbook/actions/runs/27664206015)) — Depot pulls the `dhi.io` base, pushes to `registry.fly.io`, `fly-pr-review-apps` deploys by image, healthcheck passes
- [x] **Preview server functionality verified** - login, navigation, and refreshing experiment results works
- [x] **Production build path proven via `deploy-branch`** ([run 27664951467](https://github.com/growthbook/growthbook/actions/runs/27664951467)) — Depot pulls the `dhi.io` base and pushes `growthbook/growthbook:branch-kc_harden-dockerfile-base` (same Depot + `dhi.io`-login pattern as `deploy.yml`)
