### PR TITLE
fix(back-end): mock Python stats pool in Jest

### DIFF
--- a/packages/back-end/test/jest.setup.ts
+++ b/packages/back-end/test/jest.setup.ts
@@ -15,3 +15,10 @@ jest.mock("snowflake-sdk", () => ({
   createConnection: jest.fn(),
   configure: jest.fn(),
 }));
+
+jest.mock("back-end/src/services/python", () => ({
+  statsServerPool: {
+    acquire: jest.fn(),
+    release: jest.fn(),
+  },
+}));


### PR DESCRIPTION
### Features and Changes

Mock the Python stats service in the back-end Jest setup to prevent its process pool and monitor interval from creating open handles.

The agent sometimes run `jest` directly instead of using `pnpm test` and that would hang the terminal. So we can also fix this via the mock just for extra safety.

### Testing

- `node_modules/.bin/jest test/sqlintegration.test.ts --watchman=false --runInBand --detectOpenHandles`
- Confirmed 2,272 tests pass and Jest exits normally.
- Confirmed removing the mock leaves an open `Timeout` handle and hangs until externally terminated.