### PR TITLE
feat(agg-tables): add dedicated run endpoints + fix to surface query errors

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -37879,15 +37879,18 @@ components:
           description: The id type this refresh targets
           type: string
         runId:
-          description: The id of the run that was started, or null when status is skipped.
+          description: >-
+            The id of the run, set when status is started or failed and null
+            when skipped.
           anyOf:
             - type: string
             - type: 'null'
         status:
-          description: Whether a refresh was started for this id type
+          description: Whether a refresh was started, failed to be created, or was skipped
           type: string
           enum:
             - started
+            - failed
             - skipped
         reason:
           description: Why the refresh was skipped, when status is skipped.
@@ -37900,11 +37903,17 @@ components:
                 - unsupported-datasource
                 - no-eligible-metrics
             - type: 'null'
+        error:
+          description: The error message when status is failed; null otherwise.
+          anyOf:
+            - type: string
+            - type: 'null'
       required:
         - idType
         - runId
         - status
         - reason
+        - error
       additionalProperties: false
     AggregatedTableRunSummary:
       type: object

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -16777,13 +16777,13 @@ paths:
               schema:
                 type: object
                 properties:
-                  queued:
-                    description: The id types for which a materialization run was queued
+                  runs:
+                    description: One entry per id type refreshed
                     type: array
                     items:
-                      type: string
+                      $ref: '#/components/schemas/AggregatedTableRefreshTrigger'
                 required:
-                  - queued
+                  - runs
                 additionalProperties: false
       x-codeSamples:
         - lang: cURL
@@ -16794,6 +16794,75 @@ paths:
               -H 'Authorization: Bearer YOUR_API_KEY' \
               -H 'Content-Type: application/json' \
               -d '{"fullRestate":false}'
+  /v1/fact-tables/{id}/aggregated-tables/runs:
+    get:
+      operationId: listAggregatedTableRuns
+      summary: List aggregated table runs
+      tags:
+        - fact-tables
+      parameters:
+        - $ref: '#/components/parameters/id'
+        - $ref: '#/components/parameters/idType'
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - type: object
+                    properties:
+                      runs:
+                        description: A list of the aggregated table runs for the fact table
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/AggregatedTableRunSummary'
+                    required:
+                      - runs
+                    additionalProperties: false
+                  - $ref: '#/components/schemas/PaginationFields'
+      x-codeSamples:
+        - lang: cURL
+          source: >-
+            curl -X GET
+            'https://api.growthbook.io/api/v1/fact-tables/ftb_123/aggregated-tables/runs?idType=user_id'
+            \
+              -H 'Authorization: Bearer YOUR_API_KEY'
+  /v1/fact-tables/{id}/aggregated-tables/runs/{runId}:
+    get:
+      operationId: getAggregatedTableRun
+      summary: Get a single aggregated table run
+      tags:
+        - fact-tables
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the fact table
+          schema:
+            description: The id of the fact table
+            type: string
+        - $ref: '#/components/parameters/runId'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  run:
+                    $ref: '#/components/schemas/AggregatedTableRun'
+                required:
+                  - run
+                additionalProperties: false
+      x-codeSamples:
+        - lang: cURL
+          source: >-
+            curl -X GET
+            'https://api.growthbook.io/api/v1/fact-tables/abc123/aggregated-tables/runs/aftr_abc123'
+            \
+              -H 'Authorization: Bearer YOUR_API_KEY'
   /v1/fact-metrics:
     get:
       operationId: listFactMetrics
@@ -31663,6 +31732,25 @@ components:
       schema:
         description: Specify a specific fact table
         type: string
+    idType:
+      name: idType
+      in: query
+      description: >-
+        Only return runs for this id type. When omitted, runs for all id types
+        are returned.
+      schema:
+        description: >-
+          Only return runs for this id type. When omitted, runs for all id types
+          are returned.
+        type: string
+    runId:
+      name: runId
+      in: path
+      required: true
+      description: The id of the aggregated table run (e.g. aftr_...)
+      schema:
+        description: The id of the aggregated table run (e.g. aftr_...)
+        type: string
     deleteMissing:
       name: deleteMissing
       in: query
@@ -37783,6 +37871,199 @@ components:
         - dateUpdated
         - pendingRestate
         - pendingRestateReason
+      additionalProperties: false
+    AggregatedTableRefreshTrigger:
+      type: object
+      properties:
+        idType:
+          description: The id type this refresh targets
+          type: string
+        runId:
+          description: The id of the run that was started, or null when status is skipped.
+          anyOf:
+            - type: string
+            - type: 'null'
+        status:
+          description: Whether a refresh was started for this id type
+          type: string
+          enum:
+            - started
+            - skipped
+        reason:
+          description: Why the refresh was skipped, when status is skipped.
+          anyOf:
+            - type: string
+              enum:
+                - already-in-progress
+                - datasource-not-found
+                - pipeline-not-configured
+                - unsupported-datasource
+                - no-eligible-metrics
+            - type: 'null'
+      required:
+        - idType
+        - runId
+        - status
+        - reason
+      additionalProperties: false
+    AggregatedTableRunSummary:
+      type: object
+      properties:
+        id:
+          description: The run id (e.g. aftr_...)
+          type: string
+        idType:
+          description: The id type this run materialized
+          type: string
+        mode:
+          description: Whether this run appended new data or rebuilt the table
+          type: string
+          enum:
+            - incremental
+            - restate
+        status:
+          description: Overall run status derived from its warehouse queries
+          type: string
+          enum:
+            - queued
+            - running
+            - failed
+            - partially-succeeded
+            - succeeded
+        runStarted:
+          description: When query execution began
+          anyOf:
+            - format: date-time
+              type: string
+            - type: 'null'
+        dateCreated:
+          format: date-time
+          description: When the run record was created
+          type: string
+        finishedAt:
+          description: When the run finished, or null if still in progress
+          anyOf:
+            - format: date-time
+              type: string
+            - type: 'null'
+        error:
+          description: Error message when the run failed
+          anyOf:
+            - type: string
+            - type: 'null'
+        queryIds:
+          description: >-
+            Warehouse query ids for this run; poll each via GET /queries/{id}
+            for per-query status
+          type: array
+          items:
+            type: string
+      required:
+        - id
+        - idType
+        - mode
+        - status
+        - runStarted
+        - dateCreated
+        - finishedAt
+        - error
+        - queryIds
+      additionalProperties: false
+    AggregatedTableRun:
+      type: object
+      properties:
+        id:
+          description: The run id (e.g. aftr_...)
+          type: string
+        idType:
+          description: The id type this run materialized
+          type: string
+        mode:
+          description: Whether this run appended new data or rebuilt the table
+          type: string
+          enum:
+            - incremental
+            - restate
+        status:
+          description: Overall run status derived from its warehouse queries
+          type: string
+          enum:
+            - queued
+            - running
+            - failed
+            - partially-succeeded
+            - succeeded
+        runStarted:
+          description: When query execution began
+          anyOf:
+            - format: date-time
+              type: string
+            - type: 'null'
+        dateCreated:
+          format: date-time
+          description: When the run record was created
+          type: string
+        finishedAt:
+          description: When the run finished, or null if still in progress
+          anyOf:
+            - format: date-time
+              type: string
+            - type: 'null'
+        error:
+          description: Error message when the run failed
+          anyOf:
+            - type: string
+            - type: 'null'
+        queryIds:
+          description: >-
+            Warehouse query ids for this run; poll each via GET /queries/{id}
+            for per-query status
+          type: array
+          items:
+            type: string
+        factTableId:
+          type: string
+        datasourceId:
+          type: string
+        result:
+          description: Coverage written on success, or null while running/failed
+          anyOf:
+            - type: object
+              properties:
+                lastMaxTimestamp:
+                  anyOf:
+                    - format: date-time
+                      type: string
+                    - type: 'null'
+                firstEventDate:
+                  anyOf:
+                    - format: date-time
+                      type: string
+                    - type: 'null'
+                lastEventDate:
+                  anyOf:
+                    - format: date-time
+                      type: string
+                    - type: 'null'
+              required:
+                - lastMaxTimestamp
+                - firstEventDate
+                - lastEventDate
+              additionalProperties: false
+            - type: 'null'
+      required:
+        - id
+        - idType
+        - mode
+        - status
+        - runStarted
+        - dateCreated
+        - finishedAt
+        - error
+        - queryIds
+        - factTableId
+        - datasourceId
+        - result
       additionalProperties: false
     FactMetric:
       type: object

--- a/packages/back-end/src/api/fact-tables/fact-tables.router.ts
+++ b/packages/back-end/src/api/fact-tables/fact-tables.router.ts
@@ -11,6 +11,8 @@ import { updateFactTableFilter } from "./updateFactTableFilter";
 import { deleteFactTableFilter } from "./deleteFactTableFilter";
 import { getAggregatedFactTables } from "./getAggregatedFactTables";
 import { refreshAggregatedFactTable } from "./refreshAggregatedFactTable";
+import { listAggregatedTableRuns } from "./listAggregatedTableRuns";
+import { getAggregatedTableRun } from "./getAggregatedTableRun";
 
 export const factTablesRoutes: OpenApiRoute[] = [
   listFactTables,
@@ -25,4 +27,6 @@ export const factTablesRoutes: OpenApiRoute[] = [
   deleteFactTableFilter,
   getAggregatedFactTables,
   refreshAggregatedFactTable,
+  listAggregatedTableRuns,
+  getAggregatedTableRun,
 ];

--- a/packages/back-end/src/api/fact-tables/getAggregatedTableRun.ts
+++ b/packages/back-end/src/api/fact-tables/getAggregatedTableRun.ts
@@ -1,0 +1,27 @@
+import { getAggregatedTableRunValidator } from "shared/validators";
+import { getFactTable } from "back-end/src/models/FactTableModel";
+import { createApiRequestHandler } from "back-end/src/util/handler";
+import { NotFoundError } from "back-end/src/util/errors";
+import { toAggregatedTableRunApiInterface } from "back-end/src/services/aggregatedFactTables";
+
+export const getAggregatedTableRun = createApiRequestHandler(
+  getAggregatedTableRunValidator,
+)(async (req) => {
+  const factTable = await getFactTable(req.context, req.params.id);
+  if (!factTable) {
+    throw new NotFoundError("Could not find factTable with that id");
+  }
+
+  const run = await req.context.models.aggregatedFactTableRuns.getById(
+    req.params.runId,
+  );
+  if (!run || run.factTableId !== factTable.id) {
+    throw new NotFoundError(
+      `An aggregated table run with id ${req.params.runId} does not exist for this fact table`,
+    );
+  }
+
+  return {
+    run: toAggregatedTableRunApiInterface(run),
+  };
+});

--- a/packages/back-end/src/api/fact-tables/listAggregatedTableRuns.ts
+++ b/packages/back-end/src/api/fact-tables/listAggregatedTableRuns.ts
@@ -1,0 +1,48 @@
+import { listAggregatedTableRunsValidator } from "shared/validators";
+import { getFactTable } from "back-end/src/models/FactTableModel";
+import {
+  createApiRequestHandler,
+  validatePagination,
+} from "back-end/src/util/handler";
+import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
+import { toAggregatedTableRunSummaryApiInterface } from "back-end/src/services/aggregatedFactTables";
+
+export const listAggregatedTableRuns = createApiRequestHandler(
+  listAggregatedTableRunsValidator,
+)(async (req) => {
+  const factTable = await getFactTable(req.context, req.params.id);
+  if (!factTable) {
+    throw new NotFoundError("Could not find factTable with that id");
+  }
+
+  const { idType } = req.query;
+  if (
+    idType &&
+    !(factTable.aggregatedFactTableSettings?.idTypes ?? []).includes(idType)
+  ) {
+    throw new BadRequestError(
+      `id type '${idType}' is not enabled for shared daily aggregated tables on this fact table.`,
+    );
+  }
+
+  const { limit, offset } = validatePagination(req.query);
+  const { runs, total } =
+    await req.context.models.aggregatedFactTableRuns.getByFactTableAndIdType(
+      factTable.id,
+      idType,
+      { limit, skip: offset },
+    );
+
+  const nextOffset = offset + limit;
+  const hasMore = nextOffset < total;
+
+  return {
+    runs: runs.map(toAggregatedTableRunSummaryApiInterface),
+    limit,
+    offset,
+    count: runs.length,
+    total,
+    hasMore,
+    nextOffset: hasMore ? nextOffset : null,
+  };
+});

--- a/packages/back-end/src/api/fact-tables/listAggregatedTableRuns.ts
+++ b/packages/back-end/src/api/fact-tables/listAggregatedTableRuns.ts
@@ -4,7 +4,7 @@ import {
   createApiRequestHandler,
   validatePagination,
 } from "back-end/src/util/handler";
-import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
+import { NotFoundError } from "back-end/src/util/errors";
 import { toAggregatedTableRunSummaryApiInterface } from "back-end/src/services/aggregatedFactTables";
 
 export const listAggregatedTableRuns = createApiRequestHandler(
@@ -15,15 +15,9 @@ export const listAggregatedTableRuns = createApiRequestHandler(
     throw new NotFoundError("Could not find factTable with that id");
   }
 
+  // NB: We intentionally don't validate idType against the fact table's
+  // currently-enabled id types to allow historical querying of the runs.
   const { idType } = req.query;
-  if (
-    idType &&
-    !(factTable.aggregatedFactTableSettings?.idTypes ?? []).includes(idType)
-  ) {
-    throw new BadRequestError(
-      `id type '${idType}' is not enabled for shared daily aggregated tables on this fact table.`,
-    );
-  }
 
   const { limit, offset } = validatePagination(req.query);
   const { runs, total } =

--- a/packages/back-end/src/api/fact-tables/refreshAggregatedFactTable.ts
+++ b/packages/back-end/src/api/fact-tables/refreshAggregatedFactTable.ts
@@ -2,25 +2,29 @@ import { refreshAggregatedFactTableValidator } from "shared/validators";
 import { getFactTable } from "back-end/src/models/FactTableModel";
 import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { runAggregatedFactTableUpdate } from "back-end/src/services/aggregatedFactTables";
+import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
+import {
+  runAggregatedFactTableUpdate,
+  toAggregatedTableRefreshTriggerResult,
+} from "back-end/src/services/aggregatedFactTables";
 
 export const refreshAggregatedFactTable = createApiRequestHandler(
   refreshAggregatedFactTableValidator,
 )(async (req) => {
   const factTable = await getFactTable(req.context, req.params.id);
   if (!factTable) {
-    throw new Error("Could not find factTable with that id");
+    throw new NotFoundError("Could not find factTable with that id");
   }
 
   if (!req.context.hasPremiumFeature("pipeline-mode")) {
-    throw new Error(
+    req.context.throwPlanDoesNotAllowError(
       "Maintaining shared daily aggregated tables requires the data pipeline feature.",
     );
   }
 
   const datasource = await getDataSourceById(req.context, factTable.datasource);
   if (!datasource) {
-    throw new Error("Could not find datasource for this fact table");
+    throw new BadRequestError("Could not find datasource for this fact table");
   }
 
   if (!req.context.permissions.canUpdateDataSourceSettings(datasource)) {
@@ -29,7 +33,7 @@ export const refreshAggregatedFactTable = createApiRequestHandler(
 
   const enabledIdTypes = factTable.aggregatedFactTableSettings?.idTypes ?? [];
   if (!enabledIdTypes.length) {
-    throw new Error(
+    throw new BadRequestError(
       "This fact table does not have any id types enabled for shared daily aggregated tables.",
     );
   }
@@ -37,19 +41,26 @@ export const refreshAggregatedFactTable = createApiRequestHandler(
   let idTypes = enabledIdTypes;
   if (req.body.idType) {
     if (!enabledIdTypes.includes(req.body.idType)) {
-      throw new Error(
+      throw new BadRequestError(
         `id type '${req.body.idType}' is not enabled for shared daily aggregated tables on this fact table.`,
       );
     }
     idTypes = [req.body.idType];
   }
 
+  const runs = [];
   for (const idType of idTypes) {
-    await runAggregatedFactTableUpdate(req.context, factTable, idType, {
-      forceRestate: !!req.body.fullRestate,
-      awaitResults: false,
-    });
+    const outcome = await runAggregatedFactTableUpdate(
+      req.context,
+      factTable,
+      idType,
+      {
+        forceRestate: !!req.body.fullRestate,
+        awaitResults: false,
+      },
+    );
+    runs.push(toAggregatedTableRefreshTriggerResult(idType, outcome));
   }
 
-  return { queued: idTypes };
+  return { runs };
 });

--- a/packages/back-end/src/models/AggregatedFactTableRunModel.ts
+++ b/packages/back-end/src/models/AggregatedFactTableRunModel.ts
@@ -39,15 +39,17 @@ export class AggregatedFactTableRunModel extends BaseClass {
     );
   }
 
-  public async getRecentByFactTableAndIdType(
+  public async getByFactTableAndIdType(
     factTableId: string,
-    idType: string,
-    limit = 20,
-  ) {
-    return this._find(
-      { factTableId, idType },
-      { sort: { dateCreated: -1 }, limit },
-    );
+    idType: string | undefined,
+    { limit, skip }: { limit: number; skip: number },
+  ): Promise<{ runs: AggregatedFactTableRunInterface[]; total: number }> {
+    const filter = { factTableId, ...(idType ? { idType } : {}) };
+    const [runs, total] = await Promise.all([
+      this._find(filter, { sort: { dateCreated: -1 }, limit, skip }),
+      this._countDocuments(filter),
+    ]);
+    return { runs, total };
   }
 
   protected canRead(_doc: AggregatedFactTableRunInterface) {

--- a/packages/back-end/src/queryRunners/AggregatedFactTableQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/AggregatedFactTableQueryRunner.ts
@@ -127,6 +127,14 @@ export class AggregatedFactTableQueryRunner extends QueryRunner<
     );
   }
 
+  protected override getOverallQueryStatus(): QueryStatus {
+    const queries = this.model.queries;
+    if (queries.some((q) => q.status === "running" || q.status === "queued")) {
+      return "running";
+    }
+    return queries.some((q) => q.status === "failed") ? "failed" : "succeeded";
+  }
+
   private getKey(): AggregatedFactTableKey {
     return {
       datasourceId: this.model.datasourceId,

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -80,6 +80,24 @@ const FINISH_EVENT = "finish";
 const INITIAL_CONCURRENCY_TIMEOUT = 250;
 const MAX_CONCURRENCY_TIMEOUT = 4000;
 
+const GENERIC_QUERY_FAILURE_ERROR =
+  "Failed to run a majority of the database queries";
+
+// Pick the most useful error to surface for a failed runner. Prefer a real
+// failing query's error (e.g. the warehouse's invalid-SQL message) over the
+// "Dependencies failed: ..." cascade messages the runner writes onto queries
+// whose upstream failed, and fall back to a generic message when no query
+// carries a usable error.
+export function getQueryFailureError(queryMap: QueryMap): string {
+  const failed = Array.from(queryMap.values()).filter(
+    (q) => q.status === "failed" && q.error,
+  );
+  const rootCause = failed.find(
+    (q) => !q.error?.startsWith("Dependencies failed"),
+  );
+  return (rootCause ?? failed[0])?.error || GENERIC_QUERY_FAILURE_ERROR;
+}
+
 export async function getQueryMap(
   context: ReqContext,
   queries: Queries,
@@ -569,22 +587,18 @@ export abstract class QueryRunner<
     let error: string | undefined = undefined;
     let result: Result | undefined = undefined;
 
-    if (oldStatus === "running" && newStatus === "failed") {
-      error = "Failed to run a majority of the database queries";
+    if (newStatus === "failed") {
+      error = getQueryFailureError(queryMap);
 
-      // If there's just a single query, use the error from the query itself
-      if (queryMap.size === 1) {
-        const query = Array.from(queryMap.values())[0];
-        error = query.error || error;
+      if (oldStatus === "running") {
+        this.experimentUpdateExecutionLogger?.endPhase("runQueries");
+
+        logger.debug(
+          "Query failed for " +
+            this.model.id +
+            " runner, transitioning to error state",
+        );
       }
-
-      this.experimentUpdateExecutionLogger?.endPhase("runQueries");
-
-      logger.debug(
-        "Query failed for " +
-          this.model.id +
-          " runner, transitioning to error state",
-      );
     }
     if (
       oldStatus === "running" &&
@@ -1032,7 +1046,7 @@ export abstract class QueryRunner<
     return numRunningQueries >= numericConcurrencyLimit;
   }
 
-  private getOverallQueryStatus(): QueryStatus {
+  protected getOverallQueryStatus(): QueryStatus {
     const failedQueries = this.model.queries.filter(
       (q) => q.status === "failed",
     );

--- a/packages/back-end/src/routers/fact-table/fact-table.controller.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.controller.ts
@@ -52,8 +52,10 @@ import { needsColumnRefresh } from "back-end/src/api/fact-tables/updateFactTable
 import {
   AggregatedFactTableStatus,
   buildAggregatedFactTableStatus,
+  deriveAggregatedFactTableRunStatus,
   getAggregatedFactTableMetrics,
   runAggregatedFactTableUpdate,
+  toAggregatedTableRefreshTriggerResult,
 } from "back-end/src/services/aggregatedFactTables";
 import { buildAggregatedFactTableSchemaState } from "back-end/src/enterprise/services/data-pipeline";
 import { AggregatedFactTableQueryRunner } from "back-end/src/queryRunners/AggregatedFactTableQueryRunner";
@@ -527,26 +529,6 @@ type AggregatedFactTableRunSummary = {
   queryIds: string[];
 };
 
-function deriveRunStatus(
-  queries: { status: QueryStatus }[],
-  error: string | null,
-): QueryStatus {
-  // A recorded error is terminal; surface as failed even if query pointers are
-  // stale (e.g. a run finalized out-of-process by the expireOldQueries reaper).
-  if (error) return "failed";
-
-  const total = queries.length;
-  if (!total) return "queued";
-
-  const failed = queries.filter((q) => q.status === "failed").length;
-  const running = queries.filter((q) => q.status === "running").length;
-  const queued = queries.filter((q) => q.status === "queued").length;
-
-  if (queued + running > 0) return "running";
-  if (failed > 0) return "failed";
-  return "succeeded";
-}
-
 export const getAggregatedFactTableRuns = async (
   req: AuthRequest<null, { id: string; idType: string }>,
   res: Response<{
@@ -570,22 +552,25 @@ export const getAggregatedFactTableRuns = async (
     );
   }
 
-  const runDocs =
-    await context.models.aggregatedFactTableRuns.getRecentByFactTableAndIdType(
+  const aggregatedTableRuns =
+    await context.models.aggregatedFactTableRuns.getByFactTableAndIdType(
       factTable.id,
       idType,
+      { limit: 20, skip: 0 },
     );
 
-  const runs: AggregatedFactTableRunSummary[] = runDocs.map((run) => ({
-    id: run.id,
-    mode: run.mode,
-    status: deriveRunStatus(run.queries, run.error),
-    runStarted: run.runStarted,
-    dateCreated: run.dateCreated,
-    finishedAt: run.finishedAt,
-    error: run.error,
-    queryIds: run.queries.map((q) => q.query),
-  }));
+  const runs: AggregatedFactTableRunSummary[] = aggregatedTableRuns.runs.map(
+    (run) => ({
+      id: run.id,
+      mode: run.mode,
+      status: deriveAggregatedFactTableRunStatus(run.queries, run.error),
+      runStarted: run.runStarted,
+      dateCreated: run.dateCreated,
+      finishedAt: run.finishedAt,
+      error: run.error,
+      queryIds: run.queries.map((q) => q.query),
+    }),
+  );
 
   res.status(200).json({
     status: 200,
@@ -595,7 +580,10 @@ export const getAggregatedFactTableRuns = async (
 
 export const refreshAggregatedFactTables = async (
   req: AuthRequest<{ idType?: string; fullRestate?: boolean }, { id: string }>,
-  res: Response<{ status: 200; queued: string[] }>,
+  res: Response<{
+    status: 200;
+    runs: ReturnType<typeof toAggregatedTableRefreshTriggerResult>[];
+  }>,
 ) => {
   const context = getContextFromReq(req);
 
@@ -638,16 +626,23 @@ export const refreshAggregatedFactTables = async (
 
   // Kick off directly (not via the nightly agenda queue); each call returns
   // once the run doc + queries exist and finishes in the background.
+  const runs = [];
   for (const idType of idTypes) {
-    await runAggregatedFactTableUpdate(context, factTable, idType, {
-      forceRestate: !!req.body.fullRestate,
-      awaitResults: false,
-    });
+    const outcome = await runAggregatedFactTableUpdate(
+      context,
+      factTable,
+      idType,
+      {
+        forceRestate: !!req.body.fullRestate,
+        awaitResults: false,
+      },
+    );
+    runs.push(toAggregatedTableRefreshTriggerResult(idType, outcome));
   }
 
   res.status(200).json({
     status: 200,
-    queued: idTypes,
+    runs,
   });
 };
 
@@ -682,14 +677,15 @@ export const cancelAggregatedFactTableRun = async (
     );
   }
 
-  const runDocs =
-    await context.models.aggregatedFactTableRuns.getRecentByFactTableAndIdType(
+  const aggregatedTableRuns =
+    await context.models.aggregatedFactTableRuns.getByFactTableAndIdType(
       factTable.id,
       idType,
+      { limit: 20, skip: 0 },
     );
 
-  const run = runDocs.find(
-    (r) => deriveRunStatus(r.queries, r.error) === "running",
+  const run = aggregatedTableRuns.runs.find(
+    (r) => deriveAggregatedFactTableRunStatus(r.queries, r.error) === "running",
   );
   if (!run) {
     res.status(200).json({ status: 200 });

--- a/packages/back-end/src/scripts/generate-openapi.ts
+++ b/packages/back-end/src/scripts/generate-openapi.ts
@@ -870,9 +870,11 @@ curl https://api.growthbook.io/api/v1/features \
     openapiSpec.components.schemas[name] = schema;
   });
 
-  // Generate _model tags for each named component schema (powers the "Models" section in docs)
+  // Generate _model tags for registered API resource models (powers the "Models"
+  // section in docs). Hoisted $defs from `componentSchema()` are omitted.
   const modelTags: string[] = [];
-  for (const name of Object.keys(componentSchemas).sort()) {
+  for (const name of [...namedSchemaRegistry.keys()].sort()) {
+    if (!componentSchemas[name]) continue;
     const tagName = `${name}_model`;
     modelTags.push(tagName);
     const modelDisplayName = name.replace(/([a-z])([A-Z])/g, "$1 $2");

--- a/packages/back-end/src/services/aggregatedFactTables.ts
+++ b/packages/back-end/src/services/aggregatedFactTables.ts
@@ -251,6 +251,7 @@ export function toAggregatedTableRunApiInterface(
 
 export type AggregatedFactTableUpdateOutcome =
   | { status: "started"; runId: string }
+  | { status: "failed"; runId: string; error: string }
   | { status: "skipped"; reason: AggregatedTableRefreshSkipReason };
 
 export function toAggregatedTableRefreshTriggerResult(
@@ -259,9 +260,13 @@ export function toAggregatedTableRefreshTriggerResult(
 ) {
   return {
     idType,
-    runId: outcome.status === "started" ? outcome.runId : null,
+    runId:
+      outcome.status === "started" || outcome.status === "failed"
+        ? outcome.runId
+        : null,
     status: outcome.status,
     reason: outcome.status === "skipped" ? outcome.reason : null,
+    error: outcome.status === "failed" ? outcome.error : null,
   };
 }
 
@@ -402,6 +407,7 @@ export async function runAggregatedFactTableUpdate(
         `Failed to record error for aggregated fact table ${factTable.id}/${idType}`,
       );
     }
+    return message;
   };
 
   const runner = new AggregatedFactTableQueryRunner(
@@ -425,8 +431,8 @@ export async function runAggregatedFactTableUpdate(
         factTable.aggregatedFactTableSettings?.lookbackWindow ?? 60,
     });
   } catch (e) {
-    await handleFailure(e);
-    return { status: "started", runId: run.id };
+    const error = await handleFailure(e);
+    return { status: "failed", runId: run.id, error };
   }
 
   const waitForCompletion = async () => {

--- a/packages/back-end/src/services/aggregatedFactTables.ts
+++ b/packages/back-end/src/services/aggregatedFactTables.ts
@@ -8,7 +8,10 @@ import {
 import {
   AggregatedFactTableInterface,
   AggregatedFactTableMetricStateInterface,
+  AggregatedFactTableRunInterface,
+  AggregatedTableRefreshSkipReason,
 } from "shared/validators";
+import { QueryStatus } from "shared/types/query";
 import { ReqContext } from "back-end/types/request";
 import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 import { getSourceIntegrationObject } from "back-end/src/services/datasource";
@@ -193,6 +196,75 @@ export function buildAggregatedFactTableStatus({
   };
 }
 
+export function deriveAggregatedFactTableRunStatus(
+  queries: { status: QueryStatus }[],
+  error: string | null,
+): QueryStatus {
+  // A recorded error is terminal; surface as failed even if query pointers are
+  // stale (e.g. a run finalized out-of-process by the expireOldQueries reaper).
+  if (error) return "failed";
+
+  const total = queries.length;
+  if (!total) return "queued";
+
+  const failed = queries.filter((q) => q.status === "failed").length;
+  const running = queries.filter((q) => q.status === "running").length;
+  const queued = queries.filter((q) => q.status === "queued").length;
+
+  if (queued + running > 0) return "running";
+  if (failed > 0) return "failed";
+  return "succeeded";
+}
+
+export function toAggregatedTableRunSummaryApiInterface(
+  run: AggregatedFactTableRunInterface,
+) {
+  return {
+    id: run.id,
+    idType: run.idType,
+    mode: run.mode,
+    status: deriveAggregatedFactTableRunStatus(run.queries, run.error),
+    runStarted: run.runStarted?.toISOString() ?? null,
+    dateCreated: run.dateCreated.toISOString(),
+    finishedAt: run.finishedAt?.toISOString() ?? null,
+    error: run.error,
+    queryIds: run.queries.map((q) => q.query),
+  };
+}
+
+export function toAggregatedTableRunApiInterface(
+  run: AggregatedFactTableRunInterface,
+) {
+  return {
+    ...toAggregatedTableRunSummaryApiInterface(run),
+    factTableId: run.factTableId,
+    datasourceId: run.datasourceId,
+    result: run.result
+      ? {
+          lastMaxTimestamp: run.result.lastMaxTimestamp?.toISOString() ?? null,
+          firstEventDate: run.result.firstEventDate?.toISOString() ?? null,
+          lastEventDate: run.result.lastEventDate?.toISOString() ?? null,
+        }
+      : null,
+  };
+}
+
+export type AggregatedFactTableUpdateOutcome =
+  | { status: "started"; runId: string }
+  | { status: "skipped"; reason: AggregatedTableRefreshSkipReason };
+
+export function toAggregatedTableRefreshTriggerResult(
+  idType: string,
+  outcome: AggregatedFactTableUpdateOutcome,
+) {
+  return {
+    idType,
+    runId: outcome.status === "started" ? outcome.runId : null,
+    status: outcome.status,
+    reason: outcome.status === "skipped" ? outcome.reason : null,
+  };
+}
+
 export async function runAggregatedFactTableUpdate(
   context: ReqContext,
   factTable: FactTableInterface,
@@ -202,16 +274,18 @@ export async function runAggregatedFactTableUpdate(
     // true (nightly worker): block until queries finish. false (manual UI trigger): return after creating the run and finish in the background.
     awaitResults = false,
   }: { forceRestate: boolean; awaitResults?: boolean },
-): Promise<void> {
+): Promise<AggregatedFactTableUpdateOutcome> {
   const datasource = await getDataSourceById(context, factTable.datasource);
-  if (!datasource) return;
+  if (!datasource) {
+    return { status: "skipped", reason: "datasource-not-found" };
+  }
 
   const pipelineSettings = datasource.settings.pipelineSettings;
   if (!pipelineSettings?.writeDataset) {
     logger.warn(
       `Skipping aggregated fact table update for ${factTable.id}/${idType}: data source ${datasource.id} has no pipeline write dataset configured`,
     );
-    return;
+    return { status: "skipped", reason: "pipeline-not-configured" };
   }
 
   const integration = getSourceIntegrationObject(context, datasource, true);
@@ -219,7 +293,7 @@ export async function runAggregatedFactTableUpdate(
     logger.warn(
       `Skipping aggregated fact table update for ${factTable.id}/${idType}: data source ${datasource.id} does not support writing tables`,
     );
-    return;
+    return { status: "skipped", reason: "unsupported-datasource" };
   }
 
   const factMetrics = await context.models.factMetrics.getAll();
@@ -228,7 +302,7 @@ export async function runAggregatedFactTableUpdate(
     logger.debug(
       `Skipping aggregated fact table update for ${factTable.id}/${idType}: no regression-adjusted fact metrics reference this fact table`,
     );
-    return;
+    return { status: "skipped", reason: "no-eligible-metrics" };
   }
 
   const key = {
@@ -246,7 +320,7 @@ export async function runAggregatedFactTableUpdate(
     logger.debug(
       `Aggregated fact table update for ${factTable.id}/${idType} already in progress; skipping`,
     );
-    return;
+    return { status: "skipped", reason: "already-in-progress" };
   }
 
   const registry = await context.models.aggregatedFactTables.getByKey(key);
@@ -352,7 +426,7 @@ export async function runAggregatedFactTableUpdate(
     });
   } catch (e) {
     await handleFailure(e);
-    return;
+    return { status: "started", runId: run.id };
   }
 
   const waitForCompletion = async () => {
@@ -372,4 +446,6 @@ export async function runAggregatedFactTableUpdate(
   } else {
     void waitForCompletion();
   }
+
+  return { status: "started", runId: run.id };
 }

--- a/packages/back-end/test/queryRunners/AggregatedFactTableQueryRunner.test.ts
+++ b/packages/back-end/test/queryRunners/AggregatedFactTableQueryRunner.test.ts
@@ -1,0 +1,216 @@
+import { QueryInterface, QueryStatus, Queries } from "shared/types/query";
+import { ReqContext } from "back-end/types/request";
+import { SourceIntegrationInterface } from "back-end/src/types/Integration";
+import { AggregatedFactTableQueryRunner } from "back-end/src/queryRunners/AggregatedFactTableQueryRunner";
+import { getQueriesByIds } from "back-end/src/models/QueryModel";
+
+jest.mock("back-end/src/models/QueryModel");
+
+const createMockQuery = (
+  id: string,
+  status: QueryStatus,
+  error?: string,
+): QueryInterface => ({
+  id,
+  organization: "test-org",
+  datasource: "test-ds",
+  language: "sql",
+  query: "SELECT 1",
+  status,
+  dependencies: [],
+  createdAt: new Date(),
+  heartbeat: new Date(),
+  queryType: "",
+  ...(error ? { error } : {}),
+});
+
+const buildContext = () => {
+  const updateByKeyIfCurrentExecution = jest.fn().mockResolvedValue(true);
+  const updateRunFields = jest.fn().mockResolvedValue(undefined);
+  const releaseLock = jest.fn().mockResolvedValue(undefined);
+  const context = {
+    org: { id: "test-org" },
+    permissions: { canRunExperimentQueries: () => true },
+    logger: { warn: jest.fn(), debug: jest.fn(), error: jest.fn() },
+    models: {
+      aggregatedFactTableRuns: { updateRunFields },
+      aggregatedFactTables: { updateByKeyIfCurrentExecution, releaseLock },
+    },
+  } as unknown as ReqContext;
+  return { context, updateByKeyIfCurrentExecution, updateRunFields };
+};
+
+const integration = {
+  datasource: { id: "test-ds", type: "postgres", settings: {} },
+  context: { org: { id: "test-org" } },
+} as unknown as SourceIntegrationInterface;
+
+// Sets the private `params` the runner would normally capture in startQueries,
+// so the terminal-failure branch of updateModel runs without a full warehouse
+// round-trip.
+class TestableRunner extends AggregatedFactTableQueryRunner {
+  public primeParams(executionId: string) {
+    // @ts-expect-error assigning the private field for the test
+    this.params = {
+      executionId,
+      aggregatedFactTable: { currentExecutionId: executionId },
+    };
+  }
+}
+
+describe("AggregatedFactTableQueryRunner error surfacing", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  // The reported bug: an invalid-SQL INSERT failure left the registry
+  // `lastError` null, so the UI/API showed no error. The insert fails first,
+  // then the dependent coverage query cascades to failed a refresh later.
+  // Under the any-failure status policy the run stays running until the
+  // cascade lands, and the terminal write must carry the real INSERT error.
+  it("persists the real INSERT error to the registry and never clobbers it with null", async () => {
+    const { context, updateByKeyIfCurrentExecution, updateRunFields } =
+      buildContext();
+    const queries: Queries = [
+      {
+        name: "insert_aggregated_fact_table_data",
+        query: "qry_insert",
+        status: "running",
+      },
+      {
+        name: "aggregated_fact_table_max_timestamp",
+        query: "qry_coverage",
+        status: "queued",
+      },
+    ];
+    const model = {
+      id: "aftr_1",
+      organization: "test-org",
+      datasourceId: "test-ds",
+      factTableId: "ft_1",
+      idType: "user_id",
+      queries,
+      runStarted: new Date(),
+    };
+
+    const runner = new TestableRunner(
+      context,
+      model as never,
+      integration,
+      false,
+    );
+    runner.primeParams("aftexec_1");
+
+    const insertFailed = createMockQuery(
+      "qry_insert",
+      "failed",
+      "Syntax error: unexpected keyword INSERT at [1:1]",
+    );
+
+    (getQueriesByIds as jest.Mock).mockResolvedValue([
+      insertFailed,
+      createMockQuery("qry_coverage", "queued"),
+    ]);
+    await runner.refreshQueryStatuses();
+
+    // Not terminal yet: the dependent coverage query is still queued, so no
+    // registry write happens until the cascade marks it failed.
+    expect(updateByKeyIfCurrentExecution).not.toHaveBeenCalled();
+
+    (getQueriesByIds as jest.Mock).mockResolvedValue([
+      insertFailed,
+      createMockQuery(
+        "qry_coverage",
+        "failed",
+        "Dependencies failed: qry_insert",
+      ),
+    ]);
+    await runner.refreshQueryStatuses();
+
+    expect(updateByKeyIfCurrentExecution).toHaveBeenCalledWith(
+      expect.objectContaining({
+        datasourceId: "test-ds",
+        factTableId: "ft_1",
+        idType: "user_id",
+      }),
+      "aftexec_1",
+      expect.objectContaining({
+        lastError: expect.stringContaining("unexpected keyword INSERT"),
+      }),
+    );
+    expect(updateRunFields).toHaveBeenLastCalledWith(
+      "aftr_1",
+      expect.objectContaining({
+        error: expect.stringContaining("unexpected keyword INSERT"),
+      }),
+    );
+
+    const registryLastErrors = updateByKeyIfCurrentExecution.mock.calls.map(
+      (c) => c[2].lastError,
+    );
+    expect(registryLastErrors).not.toContain(null);
+  });
+
+  it("fails a restate run when only the coverage query fails", async () => {
+    const { context, updateRunFields } = buildContext();
+    const queries: Queries = [
+      {
+        name: "drop_aggregated_fact_table",
+        query: "qry_drop",
+        status: "succeeded",
+      },
+      {
+        name: "create_aggregated_fact_table",
+        query: "qry_create",
+        status: "succeeded",
+      },
+      {
+        name: "insert_aggregated_fact_table_data",
+        query: "qry_insert",
+        status: "succeeded",
+      },
+      {
+        name: "aggregated_fact_table_max_timestamp",
+        query: "qry_coverage",
+        status: "running",
+      },
+    ];
+    const model = {
+      id: "aftr_1",
+      organization: "test-org",
+      datasourceId: "test-ds",
+      factTableId: "ft_1",
+      idType: "user_id",
+      queries,
+      runStarted: new Date(),
+    };
+
+    const runner = new TestableRunner(
+      context,
+      model as never,
+      integration,
+      false,
+    );
+    runner.primeParams("aftexec_1");
+
+    (getQueriesByIds as jest.Mock).mockResolvedValue([
+      createMockQuery("qry_drop", "succeeded"),
+      createMockQuery("qry_create", "succeeded"),
+      createMockQuery("qry_insert", "succeeded"),
+      createMockQuery(
+        "qry_coverage",
+        "failed",
+        "Syntax error: invalid column max_timestamp",
+      ),
+    ]);
+    await runner.refreshQueryStatuses();
+
+    expect(updateRunFields).toHaveBeenCalledWith(
+      "aftr_1",
+      expect.objectContaining({
+        error: expect.stringContaining("invalid column max_timestamp"),
+      }),
+    );
+    for (const [, payload] of updateRunFields.mock.calls) {
+      expect(payload.result).toBeUndefined();
+    }
+  });
+});

--- a/packages/back-end/test/queryRunners/QueryRunner.test.ts
+++ b/packages/back-end/test/queryRunners/QueryRunner.test.ts
@@ -4,6 +4,7 @@ import {
   QueryRunner,
   QueryMap,
   InterfaceWithQueries,
+  getQueryFailureError,
 } from "back-end/src/queryRunners/QueryRunner";
 import { SourceIntegrationInterface } from "back-end/src/types/Integration";
 import { getQueriesByIds, updateQuery } from "back-end/src/models/QueryModel";
@@ -105,6 +106,46 @@ const createMockContext = (): ReqContext => {
     },
   } as unknown as ReqContext;
 };
+
+const makeFailedQueryMap = (
+  ...entries: [string, { id: string; error?: string }][]
+): QueryMap => {
+  const map: QueryMap = new Map();
+  for (const [name, { id, error }] of entries) {
+    map.set(name, {
+      ...createMockQuery(id, "failed"),
+      ...(error ? { error } : {}),
+    });
+  }
+  return map;
+};
+
+describe("getQueryFailureError", () => {
+  it("prefers a root-cause error over a dependency cascade", () => {
+    const error = getQueryFailureError(
+      makeFailedQueryMap(
+        ["insert", { id: "q1", error: "Syntax error: bad SQL" }],
+        ["coverage", { id: "q2", error: "Dependencies failed: q1" }],
+      ),
+    );
+    expect(error).toBe("Syntax error: bad SQL");
+  });
+
+  it("falls back to the first failed query when all errors are cascades", () => {
+    const error = getQueryFailureError(
+      makeFailedQueryMap(
+        ["b", { id: "q2", error: "Dependencies failed: q1" }],
+        ["a", { id: "q1", error: "Dependencies failed: q0" }],
+      ),
+    );
+    expect(error).toBe("Dependencies failed: q1");
+  });
+
+  it("returns the generic message when no failed query has an error", () => {
+    const error = getQueryFailureError(makeFailedQueryMap(["a", { id: "q1" }]));
+    expect(error).toBe("Failed to run a majority of the database queries");
+  });
+});
 
 describe("QueryRunner", () => {
   describe("startReadyQueries", () => {
@@ -650,6 +691,68 @@ describe("QueryRunner", () => {
       await expect(runner.waitForResults()).rejects.toThrow(
         "stats engine blew up",
       );
+    });
+
+    class CascadeFailureQueryRunner extends RaceTestQueryRunner {
+      async onQueryFinish() {}
+    }
+
+    // Reproduces the swallowed-error bug in the aggregated fact table pipeline.
+    // A multi-query DAG (insert + a dependent coverage query) fails when the
+    // insert hits invalid SQL. The first refresh flips the runner to failed; a
+    // later refresh observes the dependent query cascading to failed while the
+    // runner is ALREADY failed. The error must be reported on every failed
+    // refresh — and must be the real query error — otherwise a model that
+    // persists `error ?? null` writes null over the recorded failure.
+    it("reports the real failing query error on every failed refresh, even a cascade", async () => {
+      const model: InterfaceWithQueries = {
+        id: "test-model",
+        organization: "test-org",
+        queries: [],
+        runStarted: new Date(),
+      };
+      const runner = new CascadeFailureQueryRunner(
+        mockContext,
+        model,
+        mockIntegration,
+      );
+
+      await runner.startAnalysis({
+        pointers: [
+          { name: "insert", query: "qry_insert", status: "running" },
+          { name: "coverage", query: "qry_coverage", status: "queued" },
+        ],
+      });
+      expect(runner.status).toBe("running");
+      runner.updateModelSpy.mockClear();
+
+      const insertFailed: QueryInterface = {
+        ...createMockQuery("qry_insert", "failed"),
+        error: "Syntax error: unexpected keyword INSERT",
+      };
+
+      (getQueriesByIds as jest.Mock).mockResolvedValue([
+        insertFailed,
+        createMockQuery("qry_coverage", "queued", ["qry_insert"]),
+      ]);
+      await runner.refreshQueryStatuses();
+
+      (getQueriesByIds as jest.Mock).mockResolvedValue([
+        insertFailed,
+        {
+          ...createMockQuery("qry_coverage", "failed", ["qry_insert"]),
+          error: "Dependencies failed: qry_insert",
+        },
+      ]);
+      await runner.refreshQueryStatuses();
+
+      const failedCalls = runner.updateModelSpy.mock.calls
+        .map((c) => c[0])
+        .filter((p) => p.status === "failed");
+      expect(failedCalls.length).toBeGreaterThanOrEqual(2);
+      for (const call of failedCalls) {
+        expect(call.error).toContain("unexpected keyword INSERT");
+      }
     });
   });
 

--- a/packages/front-end/components/FactTables/AggregatedFactTablesCard.tsx
+++ b/packages/front-end/components/FactTables/AggregatedFactTablesCard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import type { ApiAggregatedTableRefreshTrigger } from "shared/validators";
 import { FactTableInterface } from "shared/types/fact-table";
 import { QueryStatus } from "shared/types/query";
 import { dateOnly, timestamp } from "shared/dates";
@@ -30,9 +31,7 @@ export interface Props {
   factTable: FactTableInterface;
 }
 
-type RefreshResponse = {
-  queued: string[];
-};
+type RefreshResponse = { runs: ApiAggregatedTableRefreshTrigger[] };
 
 type AggregatedFactTableMaterializationStatus =
   | "running"

--- a/packages/shared/src/validators/aggregated-fact-table-run.ts
+++ b/packages/shared/src/validators/aggregated-fact-table-run.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { baseSchema } from "./base-model";
-import { queryPointerValidator } from "./queries";
+import { queryPointerValidator, queryStatusValidator } from "./queries";
+import { componentSchema } from "./openapi-helpers";
 
 // One materialization run per (organization, datasourceId, factTableId,
 // idType). Fed to the QueryRunner (satisfies `InterfaceWithQueries`); durable
@@ -42,4 +43,109 @@ export const aggregatedFactTableRunValidator = baseSchema
 
 export type AggregatedFactTableRunInterface = z.infer<
   typeof aggregatedFactTableRunValidator
+>;
+
+export const aggregatedTableRefreshTriggerStatusValidator = z.enum([
+  "started",
+  "skipped",
+]);
+
+export const aggregatedTableRefreshSkipReasonValidator = z.enum([
+  "already-in-progress",
+  "datasource-not-found",
+  "pipeline-not-configured",
+  "unsupported-datasource",
+  "no-eligible-metrics",
+]);
+
+export type AggregatedTableRefreshSkipReason = z.infer<
+  typeof aggregatedTableRefreshSkipReasonValidator
+>;
+
+const apiAggregatedTableRunSummaryFields = {
+  id: z.string().describe("The run id (e.g. aftr_...)"),
+  idType: z.string().describe("The id type this run materialized"),
+  mode: z
+    .enum(["incremental", "restate"])
+    .describe("Whether this run appended new data or rebuilt the table"),
+  status: queryStatusValidator.describe(
+    "Overall run status derived from its warehouse queries",
+  ),
+  runStarted: z
+    .string()
+    .meta({ format: "date-time" })
+    .nullable()
+    .describe("When query execution began"),
+  dateCreated: z
+    .string()
+    .meta({ format: "date-time" })
+    .describe("When the run record was created"),
+  finishedAt: z
+    .string()
+    .meta({ format: "date-time" })
+    .nullable()
+    .describe("When the run finished, or null if still in progress"),
+  error: z.string().nullable().describe("Error message when the run failed"),
+  queryIds: z
+    .array(z.string())
+    .describe(
+      "Warehouse query ids for this run; poll each via GET /queries/{id} for per-query status",
+    ),
+};
+
+export const apiAggregatedTableRunSummaryValidator = componentSchema(
+  "AggregatedTableRunSummary",
+  z.object(apiAggregatedTableRunSummaryFields).strict(),
+);
+
+export type ApiAggregatedTableRunSummary = z.infer<
+  typeof apiAggregatedTableRunSummaryValidator
+>;
+
+export const apiAggregatedTableRunValidator = componentSchema(
+  "AggregatedTableRun",
+  z
+    .object({
+      ...apiAggregatedTableRunSummaryFields,
+      factTableId: z.string(),
+      datasourceId: z.string(),
+      result: z
+        .object({
+          lastMaxTimestamp: z.string().meta({ format: "date-time" }).nullable(),
+          firstEventDate: z.string().meta({ format: "date-time" }).nullable(),
+          lastEventDate: z.string().meta({ format: "date-time" }).nullable(),
+        })
+        .nullable()
+        .describe("Coverage written on success, or null while running/failed"),
+    })
+    .strict(),
+);
+
+export type ApiAggregatedTableRun = z.infer<
+  typeof apiAggregatedTableRunValidator
+>;
+
+export const apiAggregatedTableRefreshTriggerValidator = componentSchema(
+  "AggregatedTableRefreshTrigger",
+  z
+    .object({
+      idType: z.string().describe("The id type this refresh targets"),
+      runId: z
+        .string()
+        .nullable()
+        .describe(
+          "The id of the run that was started, or null when status is skipped.",
+        ),
+      status: aggregatedTableRefreshTriggerStatusValidator.describe(
+        "Whether a refresh was started for this id type",
+      ),
+      reason: aggregatedTableRefreshSkipReasonValidator
+        .nullable()
+        .describe("Why the refresh was skipped, when status is skipped."),
+    })
+    .strict(),
+);
+
+export type ApiAggregatedTableRefreshTrigger = z.infer<
+  typeof apiAggregatedTableRefreshTriggerValidator
 >;

--- a/packages/shared/src/validators/aggregated-fact-table-run.ts
+++ b/packages/shared/src/validators/aggregated-fact-table-run.ts
@@ -47,6 +47,7 @@ export type AggregatedFactTableRunInterface = z.infer<
 
 export const aggregatedTableRefreshTriggerStatusValidator = z.enum([
   "started",
+  "failed",
   "skipped",
 ]);
 
@@ -134,14 +135,18 @@ export const apiAggregatedTableRefreshTriggerValidator = componentSchema(
         .string()
         .nullable()
         .describe(
-          "The id of the run that was started, or null when status is skipped.",
+          "The id of the run, set when status is started or failed and null when skipped.",
         ),
       status: aggregatedTableRefreshTriggerStatusValidator.describe(
-        "Whether a refresh was started for this id type",
+        "Whether a refresh was started, failed to be created, or was skipped",
       ),
       reason: aggregatedTableRefreshSkipReasonValidator
         .nullable()
         .describe("Why the refresh was skipped, when status is skipped."),
+      error: z
+        .string()
+        .nullable()
+        .describe("The error message when status is failed; null otherwise."),
     })
     .strict(),
 );

--- a/packages/shared/src/validators/fact-table.ts
+++ b/packages/shared/src/validators/fact-table.ts
@@ -4,6 +4,11 @@ import { ownerEmailField, ownerField, ownerInputField } from "./owner-field";
 import { apiPaginationFieldsValidator, paginationQueryFields } from "./shared";
 
 import { namedSchema } from "./openapi-helpers";
+import {
+  apiAggregatedTableRefreshTriggerValidator,
+  apiAggregatedTableRunSummaryValidator,
+  apiAggregatedTableRunValidator,
+} from "./aggregated-fact-table-run";
 
 // If you change these types, also update the factTableColumnTypeValidator to match
 export const factTableColumnTypes = [
@@ -946,9 +951,9 @@ export const refreshAggregatedFactTableValidator = {
   paramsSchema: idParams,
   responseSchema: z
     .object({
-      queued: z
-        .array(z.string())
-        .describe("The id types for which a materialization run was queued"),
+      runs: z
+        .array(apiAggregatedTableRefreshTriggerValidator)
+        .describe("One entry per id type refreshed"),
     })
     .strict(),
   summary:
@@ -960,5 +965,64 @@ export const refreshAggregatedFactTableValidator = {
   exampleRequest: {
     params: { id: "abc123" },
     body: { fullRestate: false },
+  },
+};
+
+const aggregatedTableRunParams = z
+  .object({
+    id: z.string().describe("The id of the fact table"),
+    runId: z
+      .string()
+      .describe("The id of the aggregated table run (e.g. aftr_...)"),
+  })
+  .strict();
+
+export const getAggregatedTableRunValidator = {
+  bodySchema: z.never(),
+  querySchema: z.never(),
+  paramsSchema: aggregatedTableRunParams,
+  responseSchema: z
+    .object({
+      run: apiAggregatedTableRunValidator,
+    })
+    .strict(),
+  summary: "Get a single aggregated table run",
+  operationId: "getAggregatedTableRun",
+  tags: ["fact-tables"],
+  method: "get" as const,
+  path: "/fact-tables/:id/aggregated-tables/runs/:runId",
+  exampleRequest: { params: { id: "abc123", runId: "aftr_abc123" } },
+};
+
+export const listAggregatedTableRunsValidator = {
+  bodySchema: z.never(),
+  querySchema: z
+    .object({
+      idType: z
+        .string()
+        .describe(
+          "Only return runs for this id type. When omitted, runs for all id types are returned.",
+        )
+        .optional(),
+      ...paginationQueryFields,
+    })
+    .strict(),
+  paramsSchema: idParams,
+  responseSchema: z.intersection(
+    z.object({
+      runs: z
+        .array(apiAggregatedTableRunSummaryValidator)
+        .describe("A list of the aggregated table runs for the fact table"),
+    }),
+    apiPaginationFieldsValidator,
+  ),
+  summary: "List aggregated table runs",
+  operationId: "listAggregatedTableRuns",
+  tags: ["fact-tables"],
+  method: "get" as const,
+  path: "/fact-tables/:id/aggregated-tables/runs",
+  exampleRequest: {
+    params: { id: "ftb_123" },
+    query: { idType: "user_id" },
   },
 };

--- a/packages/shared/src/validators/openapi-helpers.ts
+++ b/packages/shared/src/validators/openapi-helpers.ts
@@ -22,3 +22,18 @@ export function namedSchema<T extends z.ZodType>(name: string, schema: T): T {
   namedSchemaRegistry.set(name, tagged);
   return tagged;
 }
+
+/**
+ * Named OpenAPI component for a response/request sub-schema (not a top-level
+ * API resource). Gets a stable `$ref` in `components/schemas/` but is omitted
+ * from the docs "Models" section — use `namedSchema` for resource models.
+ */
+export function componentSchema<T extends z.ZodType>(
+  name: string,
+  schema: T,
+): T {
+  if (!process.env.ENABLE_ZOD_SCHEMA_REGISTRATION) {
+    return schema;
+  }
+  return schema.meta({ id: name }) as T;
+}


### PR DESCRIPTION
### Features and Changes

Two related improvements to the aggregated fact table (data pipeline) feature.

**Surface the real query error on failures.** When a multi-query run failed, the runner recorded the generic "Failed to run a majority of the database queries" message instead of the actual warehouse error, and a later dependency cascade could overwrite a recorded error with `null`. `getQueryFailureError` now prefers the root-cause query error over "Dependencies failed" cascade messages, and the error is re-asserted on every failed refresh so it is never clobbered. This path is shared by all query runners, so experiment query failures now surface the real warehouse message too.

`AggregatedFactTableQueryRunner` overrides `getOverallQueryStatus` with an any-failure policy. A run is failed if any single query fails, since a partially built table is unusable.

**Aggregated table run API.** Adds two REST endpoints. `GET /fact-tables/{id}/aggregated-tables/runs` returns a paginated list with an optional `idType` filter. `GET /fact-tables/{id}/aggregated-tables/runs/{runId}` returns a single run. The refresh endpoint now returns a structured `runs` array with a per-id-type `status` (`started` or `skipped`) and a skip `reason`, replacing the old `queued: string[]`.


### Testing

- Unit tests
- Manual testing
