### PR TITLE
Validate timestamp column type in exposure queries on save

### DIFF
--- a/packages/back-end/src/services/datasource.ts
+++ b/packages/back-end/src/services/datasource.ts
@@ -417,6 +417,20 @@ export async function testQueryValidity(
       )}`;
     }
 
+    // Validate column data types
+    const typeMap = new Map<string, FactTableColumnType>();
+    results.columns?.forEach((col) => {
+      if (col.dataType) typeMap.set(col.name, col.dataType);
+    });
+    determineColumnTypes(results.results, typeMap).forEach((col) => {
+      if (col.datatype) typeMap.set(col.column, col.datatype);
+    });
+
+    const timestampType = typeMap.get("timestamp");
+    if (timestampType && timestampType !== "date") {
+      return `Column "timestamp" must be date, but is ${timestampType} in experiment assignment query${query.name ? ` "${query.name}"` : ""}`;
+    }
+
     return undefined;
   } catch (e) {
     return e.message;

--- a/packages/back-end/test/services/datasource.test.ts
+++ b/packages/back-end/test/services/datasource.test.ts
@@ -262,4 +262,124 @@ describe("testQueryValidity", () => {
       "testQuery",
     );
   });
+
+  describe("column type validation", () => {
+    it("should return error when timestamp column value is a non-date string — row-based inference", async () => {
+      const query = {
+        id: "u",
+        name: "Test Query",
+        userIdType: "user_id",
+        dimensions: [],
+        hasNameCol: false,
+        query: "SELECT * FROM t",
+      };
+
+      mockDataSourceIntegration.getTestValidityQuery = jest
+        .fn()
+        .mockReturnValue("SELECT * FROM t LIMIT 1");
+      mockDataSourceIntegration.runTestQuery = jest.fn().mockResolvedValue({
+        results: [
+          {
+            user_id: "1",
+            experiment_id: "e1",
+            variation_id: "v1",
+            timestamp: "not-a-date",
+          },
+        ],
+      });
+
+      const result = await testQueryValidity(mockDataSourceIntegration, query);
+
+      expect(result).toBe(
+        'Column "timestamp" must be date, but is string in experiment assignment query "Test Query"',
+      );
+    });
+
+    it("should return error when timestamp type is string in engine metadata — BigQuery LIMIT 0", async () => {
+      const query = {
+        id: "u",
+        name: "BigQuery Test",
+        userIdType: "user_id",
+        dimensions: [],
+        hasNameCol: false,
+        query: "SELECT * FROM t",
+      };
+
+      mockLimitZeroIntegration.getTestValidityQuery = jest
+        .fn()
+        .mockReturnValue("SELECT * FROM t LIMIT 0");
+      mockLimitZeroIntegration.runTestQuery = jest.fn().mockResolvedValue({
+        results: [],
+        columns: [
+          { name: "user_id", dataType: "string" },
+          { name: "experiment_id", dataType: "string" },
+          { name: "variation_id", dataType: "string" },
+          { name: "timestamp", dataType: "string" },
+        ],
+      });
+
+      const result = await testQueryValidity(mockLimitZeroIntegration, query);
+
+      expect(result).toBe(
+        'Column "timestamp" must be date, but is string in experiment assignment query "BigQuery Test"',
+      );
+    });
+
+    it("should pass validation when timestamp is an ISO date string in row data", async () => {
+      const query = {
+        id: "u",
+        name: "Valid Test",
+        userIdType: "user_id",
+        dimensions: [],
+        hasNameCol: false,
+        query: "SELECT * FROM t",
+      };
+
+      mockDataSourceIntegration.getTestValidityQuery = jest
+        .fn()
+        .mockReturnValue("SELECT * FROM t LIMIT 1");
+      mockDataSourceIntegration.runTestQuery = jest.fn().mockResolvedValue({
+        results: [
+          {
+            user_id: "1",
+            experiment_id: "e1",
+            variation_id: "v1",
+            timestamp: "2024-01-01T00:00:00Z",
+          },
+        ],
+      });
+
+      const result = await testQueryValidity(mockDataSourceIntegration, query);
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should pass validation when timestamp type is date in engine metadata — BigQuery LIMIT 0", async () => {
+      const query = {
+        id: "u",
+        name: "BigQuery Date Test",
+        userIdType: "user_id",
+        dimensions: [],
+        hasNameCol: false,
+        query: "SELECT * FROM t",
+      };
+
+      mockLimitZeroIntegration.getTestValidityQuery = jest
+        .fn()
+        .mockReturnValue("SELECT * FROM t LIMIT 0");
+      mockLimitZeroIntegration.runTestQuery = jest.fn().mockResolvedValue({
+        results: [],
+        columns: [
+          { name: "user_id", dataType: "string" },
+          { name: "experiment_id", dataType: "string" },
+          { name: "variation_id", dataType: "string" },
+          { name: "timestamp", dataType: "date" },
+        ],
+      });
+
+      const result = await testQueryValidity(mockLimitZeroIntegration, query);
+
+      expect(result).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds timestamp type validation to experiment assignment query validation.

Previously, GrowthBook validated that required columns existed but did not validate their data types. This could allow queries with incorrectly typed timestamp columns (e.g. string/varchar) to be saved successfully and only fail later when generated analysis SQL executed.

This change extends `testQueryValidity()` to:

* Build a type map using datasource metadata when available
* Fall back to `determineColumnTypes()` inference when metadata is unavailable
* Validate that the required `timestamp` column resolves to the `date` type
* Return a clear validation error when the type is invalid

Example:

```text
Column "timestamp" must be date, but is string in experiment assignment query "Logged In Users"
```

## Tests

Added coverage for:

* Invalid timestamp type via row inference
* Invalid timestamp type via metadata
* Valid timestamp via row inference
* Valid timestamp via metadata

## Notes

Some datasources (e.g. Snowflake LIMIT 0 validation path) currently do not return column type metadata, so validation may be skipped in those cases. This is an existing limitation and can be addressed separately.
