### PR TITLE
fix(experiments): distinguish rebase-needed from true merge conflicts when auto-publishing drafts on experiment start

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -44101,6 +44101,7 @@ components:
                 type: string
                 enum:
                   - merge-conflict
+                  - needs-rebase
                   - needs-approval
                   - publish-error
             required:

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -104,7 +104,7 @@ import { isEmailEnabled } from "./services/email";
 import { init } from "./init";
 import { aiRouter } from "./routers/ai/ai.router";
 import { getCustomLogProps, httpLogger, logger } from "./util/logger";
-import { shouldSkipErrorLog, SoftWarningError } from "./util/errors";
+import { ApiError, shouldSkipErrorLog, SoftWarningError } from "./util/errors";
 import { usersRouter } from "./routers/users/users.router";
 import { organizationsRouter } from "./routers/organizations/organizations.router";
 import { uploadRouter } from "./routers/upload/upload.router";
@@ -1212,6 +1212,8 @@ const errorHandler: ErrorRequestHandler = (
     message: string;
     errorId?: string;
     warnings?: string[];
+    code?: string;
+    details?: unknown;
   } = {
     status: status,
     message: err.message || "An error occurred",
@@ -1220,6 +1222,12 @@ const errorHandler: ErrorRequestHandler = (
   // Picked up by front-end (when combined with 422 status code) to show a "Save anyway" dialog
   if (err instanceof SoftWarningError) {
     body.warnings = err.warnings;
+  }
+  // Structured errors carry a machine-readable code + details (same contract
+  // the REST API exposes) so the front-end can render richer error states.
+  if (err instanceof ApiError) {
+    body.code = err.code;
+    body.details = err.details;
   }
   res.status(status).json(body);
 };

--- a/packages/back-end/src/services/experiment-feature.ts
+++ b/packages/back-end/src/services/experiment-feature.ts
@@ -2,7 +2,10 @@ import isEqual from "lodash/isEqual";
 import {
   autoMerge,
   AutoMergeResult,
+  evaluatePublishGovernance,
+  fillRevisionFromFeature,
   getMatchingRules,
+  liveRevisionFromFeature,
   MatchingRule,
   mergeResultHasChanges,
   resetReviewOnChange,
@@ -284,6 +287,7 @@ export async function validateExperimentFeatureUpdates({
 
 export type PendingDraftFailureReason =
   | "merge-conflict"
+  | "needs-rebase"
   | "needs-approval"
   | "publish-error";
 
@@ -311,6 +315,7 @@ export function formatPendingDraftFailureMessage(
       ),
     );
   const conflictIds = ids("merge-conflict");
+  const rebaseIds = ids("needs-rebase");
   const approvalIds = ids("needs-approval");
   const errorIds = ids("publish-error");
 
@@ -319,6 +324,11 @@ export function formatPendingDraftFailureMessage(
   if (conflictIds.length) {
     parts.push(
       `merge conflict${conflictIds.length > 1 ? "s" : ""} in: ${conflictIds.join(", ")}`,
+    );
+  }
+  if (rebaseIds.length) {
+    parts.push(
+      `draft${rebaseIds.length > 1 ? "s" : ""} behind live (rebase needed, no conflicts) on: ${rebaseIds.join(", ")}`,
     );
   }
   if (approvalIds.length) {
@@ -334,6 +344,42 @@ export function formatPendingDraftFailureMessage(
 
 type ResolvedDraft = { featureId: string; revisionVersion: number };
 
+// Merges a draft against live exactly like the manual publish flow does:
+// the same fillRevisionFromFeature/liveRevisionFromFeature normalization the
+// FF detail page applies (raw sparse revisions produce phantom conflicts),
+// followed by the same publish governance. `rebaseRequired` is only set for
+// the mergeable-but-blocked case (org requires rebase-before-publish or the
+// approval went stale) — true conflicts are reported via `mergeResult`.
+function mergeDraftForAutoPublish(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  revision: FeatureRevisionInterface,
+  live: FeatureRevisionInterface,
+  base: FeatureRevisionInterface,
+): { mergeResult: AutoMergeResult; rebaseRequired: boolean } {
+  const mergeResult = autoMerge(
+    liveRevisionFromFeature(live, feature),
+    fillRevisionFromFeature(base, feature),
+    revision,
+    context.environments,
+    {},
+  );
+  const governance = evaluatePublishGovernance({
+    revisionStatus: revision.status,
+    baseVersion: revision.baseVersion,
+    liveVersion: live.version,
+    mergeSuccess: mergeResult.success,
+    liveChanges: [],
+    approvedBaseVersion: revision.approvedBaseVersion ?? null,
+    requireRebaseBeforePublish:
+      !!context.org.settings?.requireRebaseBeforePublish,
+  });
+  return {
+    mergeResult,
+    rebaseRequired: mergeResult.success && governance.rebaseRequired,
+  };
+}
+
 type ReadyDraft = ResolvedDraft & {
   feature: FeatureInterface;
   revision: FeatureRevisionInterface;
@@ -341,7 +387,8 @@ type ReadyDraft = ResolvedDraft & {
 };
 
 // Auto-publishes pendingFeatureDrafts on experiment start. Phase 1 resolves
-// each draft once (prune stale, gate on approval, merge against live);
+// each draft once (prune stale, gate on approval, merge against live with
+// the same normalization + governance as the manual publish flow);
 // Phase 1.5 prevalidates custom hooks; Phase 2 publishes sequentially,
 // reusing the resolved state except when an earlier publish in this run
 // advanced the same feature's live version, which forces a re-merge.
@@ -355,7 +402,6 @@ export async function publishPendingFeatureDraftsForExperiment(
   const drafts = experiment.pendingFeatureDrafts ?? [];
   if (!drafts.length) return { published: [], failed: [] };
 
-  const orgEnvIds = context.environments;
   const failed: PendingDraftFailure[] = [];
   const ready: ReadyDraft[] = [];
   // Multiple drafts can target the same feature — fetch each feature once.
@@ -423,7 +469,21 @@ export async function publishPendingFeatureDraftsForExperiment(
       continue;
     }
 
-    const mergeResult = autoMerge(live, base, revision, orgEnvIds, {});
+    const { mergeResult, rebaseRequired } = mergeDraftForAutoPublish(
+      context,
+      feature,
+      revision,
+      live,
+      base,
+    );
+    if (rebaseRequired) {
+      logger.warn(
+        { experimentId: experiment.id, featureId, revisionVersion },
+        "Cannot auto-publish pending feature draft: rebase with live required before publishing",
+      );
+      failed.push({ featureId, revisionVersion, reason: "needs-rebase" });
+      continue;
+    }
     ready.push({ featureId, revisionVersion, feature, revision, mergeResult });
   }
 
@@ -486,7 +546,22 @@ export async function publishPendingFeatureDraftsForExperiment(
         feature,
         revision,
       });
-      mergeResult = autoMerge(live, base, revision, orgEnvIds, {});
+      const remerged = mergeDraftForAutoPublish(
+        context,
+        feature,
+        revision,
+        live,
+        base,
+      );
+      mergeResult = remerged.mergeResult;
+      if (remerged.rebaseRequired) {
+        logger.warn(
+          { experimentId: experiment.id, featureId, revisionVersion },
+          "Cannot auto-publish pending feature draft: rebase with live required after an earlier publish advanced the feature",
+        );
+        failed.push({ featureId, revisionVersion, reason: "needs-rebase" });
+        break;
+      }
     }
 
     if (!mergeResult.success) {

--- a/packages/back-end/test/services/publishPendingFeatureDraftsForExperiment.test.ts
+++ b/packages/back-end/test/services/publishPendingFeatureDraftsForExperiment.test.ts
@@ -35,7 +35,10 @@ jest.mock("shared/util", () => ({
   checkIfRevisionNeedsReview: jest.fn(),
 }));
 
-import { publishPendingFeatureDraftsForExperiment } from "back-end/src/services/experiment-feature";
+import {
+  formatPendingDraftFailureMessage,
+  publishPendingFeatureDraftsForExperiment,
+} from "back-end/src/services/experiment-feature";
 import {
   getFeature,
   prevalidatePublishRevision,
@@ -338,5 +341,96 @@ describe("publishPendingFeatureDraftsForExperiment", () => {
     expect(result.failed.map((f) => f.featureId)).toEqual(["feat_b"]);
     expect(result.failed[0].reason).toBe("merge-conflict");
     expect(mockPublishRevision).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails with needs-rebase (not merge-conflict) for a mergeable diverged draft when the org requires rebase before publish", async () => {
+    const rebaseCtx = {
+      ...ctx,
+      org: { id: "org_1", settings: { requireRebaseBeforePublish: true } },
+    } as unknown as ReqContext;
+    mockGetRevision.mockResolvedValue({
+      version: 6,
+      status: "draft",
+      baseVersion: 4,
+      rules: [],
+    } as never);
+    // Live advanced past the draft's base, but the merge itself is clean.
+    mockGetLiveAndBase.mockResolvedValue({
+      live: { version: 5, rules: [] },
+      base: { version: 4, rules: [] },
+    } as never);
+
+    const experiment = makeExperiment([
+      { featureId: "j2-test", revisionVersion: 6 },
+    ]);
+
+    const result = await publishPendingFeatureDraftsForExperiment(
+      rebaseCtx,
+      experiment,
+    );
+
+    expect(result.published).toEqual([]);
+    expect(result.failed).toEqual([
+      { featureId: "j2-test", revisionVersion: 6, reason: "needs-rebase" },
+    ]);
+    expect(mockPublishRevision).not.toHaveBeenCalled();
+  });
+
+  it("auto-merges and publishes a mergeable diverged draft when the org does not require rebase before publish", async () => {
+    mockGetRevision.mockResolvedValue({
+      version: 6,
+      status: "draft",
+      baseVersion: 4,
+      rules: [],
+    } as never);
+    mockGetLiveAndBase.mockResolvedValue({
+      live: { version: 5, rules: [] },
+      base: { version: 4, rules: [] },
+    } as never);
+
+    const experiment = makeExperiment([
+      { featureId: "j2-test", revisionVersion: 6 },
+    ]);
+
+    const result = await publishPendingFeatureDraftsForExperiment(
+      ctx,
+      experiment,
+    );
+
+    expect(result.published).toEqual([
+      { featureId: "j2-test", revisionVersion: 6 },
+    ]);
+    expect(result.failed).toEqual([]);
+  });
+});
+
+describe("formatPendingDraftFailureMessage", () => {
+  it("distinguishes a rebase-only failure from a true merge conflict", () => {
+    expect(
+      formatPendingDraftFailureMessage([
+        { featureId: "feat_a", revisionVersion: 6, reason: "needs-rebase" },
+      ]),
+    ).toBe(
+      "Cannot start experiment: feature flag draft could not be published (draft behind live (rebase needed, no conflicts) on: feat_a). Resolve the issue and try again.",
+    );
+    expect(
+      formatPendingDraftFailureMessage([
+        { featureId: "feat_a", revisionVersion: 6, reason: "merge-conflict" },
+      ]),
+    ).toBe(
+      "Cannot start experiment: feature flag draft could not be published (merge conflict in: feat_a). Resolve the issue and try again.",
+    );
+  });
+
+  it("combines reasons and dedupes feature ids", () => {
+    expect(
+      formatPendingDraftFailureMessage([
+        { featureId: "feat_a", revisionVersion: 5, reason: "merge-conflict" },
+        { featureId: "feat_a", revisionVersion: 7, reason: "merge-conflict" },
+        { featureId: "feat_b", revisionVersion: 2, reason: "needs-rebase" },
+      ]),
+    ).toBe(
+      "Cannot start experiment: feature flag drafts could not be published (merge conflict in: feat_a; draft behind live (rebase needed, no conflicts) on: feat_b). Resolve the issues and try again.",
+    );
   });
 });

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -54,7 +54,9 @@ import LoadingSpinner from "@/components/LoadingSpinner";
 import HelperText from "@/ui/HelperText";
 import { useRunningExperimentStatus } from "@/hooks/useExperimentStatusIndicator";
 import RunningExperimentDecisionBanner from "@/components/Experiment/TabbedPage/RunningExperimentDecisionBanner";
-import StartExperimentModal from "@/components/Experiment/TabbedPage/StartExperimentModal";
+import StartExperimentModal, {
+  PendingDraftFailure,
+} from "@/components/Experiment/TabbedPage/StartExperimentModal";
 import { usePreLaunchChecklist } from "@/components/PreLaunchChecklist/PreLaunchChecklistProvider";
 import { useHoldouts } from "@/hooks/useHoldouts";
 import PhaseSelector from "@/components/Experiment/PhaseSelector";
@@ -224,6 +226,12 @@ export default function ExperimentHeader({
 
   const [showStartExperiment, setShowStartExperiment] = useState(false);
   const [showScheduleModal, setShowScheduleModal] = useState(false);
+  // Structured per-feature failures from the last failed start attempt
+  // (pending_draft_publish_failed) — lets the start modal link each blocked
+  // feature draft instead of only showing the error string.
+  const [pendingDraftFailures, setPendingDraftFailures] = useState<
+    PendingDraftFailure[]
+  >([]);
 
   const hasMultiArmedBanditFeature = hasCommercialFeature(
     "multi-armed-bandits",
@@ -321,6 +329,7 @@ export default function ExperimentHeader({
       }
     }
 
+    setPendingDraftFailures([]);
     if (isHoldout) {
       await apiCall(`/holdout/${holdout?.id}/edit-status`, {
         method: "POST",
@@ -330,12 +339,23 @@ export default function ExperimentHeader({
         }),
       });
     } else {
-      await apiCall(`/experiment/${experiment.id}/status`, {
-        method: "POST",
-        body: JSON.stringify({
-          status: "running",
-        }),
-      });
+      await apiCall(
+        `/experiment/${experiment.id}/status`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            status: "running",
+          }),
+        },
+        (responseData) => {
+          if (
+            responseData?.code === "pending_draft_publish_failed" &&
+            Array.isArray(responseData?.details?.failedFeatureDrafts)
+          ) {
+            setPendingDraftFailures(responseData.details.failedFeatureDrafts);
+          }
+        },
+      );
     }
     await mutate();
     startCelebration();
@@ -678,8 +698,12 @@ export default function ExperimentHeader({
       {showStartExperiment && experiment.status === "draft" && (
         <StartExperimentModal
           experiment={experiment}
-          close={() => setShowStartExperiment(false)}
+          close={() => {
+            setShowStartExperiment(false);
+            setPendingDraftFailures([]);
+          }}
           startExperiment={startExperiment}
+          pendingDraftFailures={pendingDraftFailures}
           scheduleExperiment={approveScheduledExperimentStart}
           checklistItemsRemaining={checklistItemsRemaining || 0}
           checklistHardBlockerCount={checklistHardBlockerCount}

--- a/packages/front-end/components/Experiment/TabbedPage/StartExperimentModal.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/StartExperimentModal.tsx
@@ -2,6 +2,7 @@ import {
   ExperimentInterfaceStringDates,
   LinkedFeatureInfo,
 } from "shared/types/experiment";
+import { ApiErrorDetails } from "shared/validators";
 import { URLRedirectInterface } from "shared/types/url-redirect";
 import { VisualChangesetInterface } from "shared/types/visual-changeset";
 import { format } from "date-fns-tz";
@@ -36,6 +37,9 @@ import {
 } from "@/components/Experiment/LinkedChanges/constants";
 import { CheckListItem } from "@/components/PreLaunchChecklist/PreLaunchChecklistItems";
 
+export type PendingDraftFailure =
+  ApiErrorDetails<"pending_draft_publish_failed">["failedFeatureDrafts"][number];
+
 export interface Props {
   experiment: ExperimentInterfaceStringDates;
   close: () => void;
@@ -48,7 +52,25 @@ export interface Props {
   visualChangesets?: VisualChangesetInterface[];
   urlRedirects?: URLRedirectInterface[];
   incompleteChecklistItems?: CheckListItem[];
+  // Per-feature failures from the last start attempt (structured details of
+  // the pending_draft_publish_failed error) — rendered as actionable links
+  // below the generic error message.
+  pendingDraftFailures?: PendingDraftFailure[];
 }
+
+// Short, action-oriented label per failure reason. "needs-rebase" is the
+// no-conflict case — the draft is merely behind live — and is deliberately
+// distinguished from a true merge conflict.
+const PENDING_DRAFT_FAILURE_LABELS: Record<
+  PendingDraftFailure["reason"],
+  string
+> = {
+  "merge-conflict":
+    "Merge conflict with live — open the draft to fix conflicts",
+  "needs-rebase": "Behind live, no conflicts — open the draft and rebase",
+  "needs-approval": "Awaiting approval",
+  "publish-error": "Publish failed unexpectedly",
+};
 
 function SubmitButton({ cta, disabled }: { cta: string; disabled: boolean }) {
   const { loading } = useModalForm();
@@ -153,6 +175,7 @@ export default function StartExperimentModal({
   visualChangesets = [],
   urlRedirects = [],
   incompleteChecklistItems = [],
+  pendingDraftFailures = [],
 }: Props) {
   const checklistIncomplete = checklistItemsRemaining > 0;
   const latestPhase = experiment.phases?.[experiment.phases.length - 1];
@@ -287,6 +310,41 @@ export default function StartExperimentModal({
         </Modal.Header>
         {subHeader && <Modal.Description>{subHeader}</Modal.Description>}
         <Modal.Body>
+          {pendingDraftFailures.length > 0 && (
+            <Box
+              mb="3"
+              p="3"
+              style={{
+                border: "1px solid var(--red-a6)",
+                borderRadius: "var(--radius-3)",
+              }}
+            >
+              <Text size="small" weight="semibold" color="text-high">
+                Linked feature drafts that could not be published
+              </Text>
+              <Flex direction="column" gap="2" mt="2">
+                {pendingDraftFailures.map((failure) => (
+                  <Flex
+                    key={`${failure.featureId}-${failure.revisionVersion}`}
+                    gap="2"
+                    align="baseline"
+                    wrap="wrap"
+                  >
+                    <Link
+                      href={`/features/${failure.featureId}?v=${failure.revisionVersion}`}
+                      target="_blank"
+                    >
+                      <Text weight="semibold">{failure.featureId}</Text>
+                      <PiArrowSquareOut className="ml-1" />
+                    </Link>
+                    <Text size="small" color="text-mid">
+                      {PENDING_DRAFT_FAILURE_LABELS[failure.reason]}
+                    </Text>
+                  </Flex>
+                ))}
+              </Flex>
+            </Box>
+          )}
           {scheduledStartDateIsInThePast && parsedScheduledDate && (
             <Callout status="warning" mb="3">
               The scheduled start date{" "}

--- a/packages/shared/src/validators/api-errors.ts
+++ b/packages/shared/src/validators/api-errors.ts
@@ -15,7 +15,12 @@ const checklistItemSchema = z.object({
 const pendingDraftFailureSchema = z.object({
   featureId: z.string(),
   revisionVersion: z.number(),
-  reason: z.enum(["merge-conflict", "needs-approval", "publish-error"]),
+  reason: z.enum([
+    "merge-conflict",
+    "needs-rebase",
+    "needs-approval",
+    "publish-error",
+  ]),
 });
 
 export const apiErrorRegistry = {


### PR DESCRIPTION
### Features and Changes

When starting an experiment with pending linked feature drafts, the "merge conflict" error could fire for drafts that were merely behind live (no conflicting edits), because the auto-publish path ran `autoMerge` on raw revision documents instead of normalizing them like the feature publish flow does.

- Experiment draft auto-publish now merges with the same `liveRevisionFromFeature`/`fillRevisionFromFeature` normalization and `evaluatePublishGovernance` governance as the manual publish flow, eliminating phantom conflicts.
- Diverged-but-mergeable drafts now block only when the org's **Require rebase before publish** setting is on, failing with a new `needs-rebase` reason ("draft behind live (rebase needed, no conflicts) on: ...") instead of being reported as a merge conflict. True conflicts still always block.
- `needs-rebase` added to the `pending_draft_publish_failed` error contract (`shared/validators/api-errors.ts`, OpenAPI spec regenerated), and the internal API error handler now serializes `code`/`details` for structured errors like the REST API does.
- The Start Experiment modal renders a per-feature breakdown under the error, deep-linking each blocked feature draft (`/features/{id}?v={version}`) with a short action label per reason.

### Dependencies

None

### Testing

- `pnpm --filter back-end test test/services/publishPendingFeatureDraftsForExperiment.test.ts` — added coverage for the needs-rebase failure (setting on), silent auto-merge of diverged drafts (setting off), and message formatting.
- Manual: link a feature draft to a draft experiment, publish another change to the feature so the draft is behind live, then start the experiment. With "Require rebase before publish" off it should start cleanly; with it on, the modal shows the rebase-needed error with a link to the draft. A genuine conflicting edit still reports a merge conflict.

### Screenshots

The start modal error now includes per-feature links below the message, e.g. `green-tomato-with-cheese ↗ Behind live, no conflicts — open the draft and rebase`.