### PR TITLE
fix(back-end): enforce prior stddev > 0

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -10557,6 +10557,7 @@ paths:
                         type: number
                       properPriorStdDev:
                         type: number
+                        exclusiveMinimum: 0
                       regressionAdjustmentOverride:
                         description: >-
                           Must be true for the override to take effect. If true,
@@ -11159,6 +11160,7 @@ paths:
                         type: number
                       properPriorStdDev:
                         type: number
+                        exclusiveMinimum: 0
                       regressionAdjustmentOverride:
                         description: >-
                           Must be true for the override to take effect. If true,
@@ -22061,6 +22063,7 @@ paths:
                         type: number
                       properPriorStdDev:
                         type: number
+                        exclusiveMinimum: 0
                       regressionAdjustmentOverride:
                         type: boolean
                       regressionAdjustmentEnabled:
@@ -22328,6 +22331,7 @@ paths:
                         type: number
                       properPriorStdDev:
                         type: number
+                        exclusiveMinimum: 0
                       regressionAdjustmentOverride:
                         type: boolean
                       regressionAdjustmentEnabled:
@@ -36370,6 +36374,7 @@ components:
                     Must be > 0. The standard deviation of the prior
                     distribution of relative effects in proportion terms.
                   type: number
+                  exclusiveMinimum: 0
               required:
                 - override
                 - proper
@@ -39423,6 +39428,7 @@ components:
                     type: number
                   properPriorStdDev:
                     type: number
+                    exclusiveMinimum: 0
                   regressionAdjustmentOverride:
                     type: boolean
                   regressionAdjustmentEnabled:

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -30,6 +30,7 @@ import {
 } from "back-end/src/services/experiments";
 import { logger } from "back-end/src/util/logger";
 import { upgradeExperimentDoc } from "back-end/src/util/migrations";
+import { validateMetricOverrides } from "back-end/src/util/priors";
 import {
   queueSDKPayloadRefresh,
   URLRedirectExperiment,
@@ -603,6 +604,8 @@ export async function createExperiment({
     context.org.settings?.updateSchedule || null,
   );
 
+  validateMetricOverrides(data.metricOverrides);
+
   const exp = await ExperimentModel.create({
     id: uniqid("exp_"),
     uid: uuidv4().replace(/-/g, ""),
@@ -671,6 +674,8 @@ export async function updateExperiment({
   };
   if (allChanges.name === "")
     throw new Error("Cannot set empty name for experiment!");
+
+  validateMetricOverrides(allChanges.metricOverrides);
 
   await ExperimentModel.updateOne(
     {

--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -27,6 +27,7 @@ import {
 } from "back-end/src/services/factMetricRowFilterValidation";
 import { projectFilterQuery } from "back-end/src/util/mongo.util";
 import { validateAggregationSpecification } from "back-end/src/services/factMetricAggregationValidation";
+import { healPriorSettings } from "back-end/src/util/priors";
 import { MakeModelClass } from "./BaseModel";
 import { getDataSourceById } from "./DataSourceModel";
 import { getFactTableMap } from "./FactTableModel";
@@ -214,6 +215,7 @@ export class FactMetricModel extends BaseClass {
         stddev: DEFAULT_PROPER_PRIOR_STDDEV,
       };
     }
+    healPriorSettings(newDoc.priorSettings);
 
     if (newDoc.numerator) {
       newDoc.numerator = FactMetricModel.migrateColumnRef(newDoc.numerator);

--- a/packages/back-end/src/models/MetricModel.ts
+++ b/packages/back-end/src/models/MetricModel.ts
@@ -8,6 +8,7 @@ import {
 } from "shared/types/metric";
 import { getConfigMetrics, usingFileConfig } from "back-end/src/init/config";
 import { upgradeMetricDoc } from "back-end/src/util/migrations";
+import { validatePriorSettings } from "back-end/src/util/priors";
 import { ALLOW_CREATE_METRICS } from "back-end/src/util/secrets";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
@@ -190,6 +191,8 @@ export async function insertMetric(
   if (!context.permissions.canCreateMetric(metricWithOrganization)) {
     context.permissions.throwPermissionError();
   }
+
+  validatePriorSettings(metricWithOrganization.priorSettings);
 
   const created = toInterface(await MetricModel.create(metricWithOrganization));
   await audit.logCreate(context, created);
@@ -583,6 +586,8 @@ export async function updateMetric(
       context.permissions.throwPermissionError();
     }
   }
+
+  validatePriorSettings(updates.priorSettings);
 
   // If using config.yml, need to do an `upsert` since it might not exist in mongo yet
   if (metric.managedBy === "config") {

--- a/packages/back-end/src/models/ReportModel.ts
+++ b/packages/back-end/src/models/ReportModel.ts
@@ -11,6 +11,7 @@ import { migrateExperimentReport } from "back-end/src/util/migrations";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import { logger } from "back-end/src/util/logger";
+import { validateMetricOverrides } from "back-end/src/util/priors";
 import { getAllExperiments } from "./ExperimentModel";
 import { queriesSchema } from "./QueryModel";
 
@@ -76,6 +77,10 @@ export async function createReport(
   organization: string,
   initialValue: Partial<ExperimentSnapshotReportInterface>,
 ): Promise<ExperimentSnapshotReportInterface> {
+  validateMetricOverrides(
+    initialValue.experimentAnalysisSettings?.metricOverrides,
+  );
+
   const report = await ReportModel.create({
     status: "private",
     ...initialValue,
@@ -160,6 +165,15 @@ export async function updateReport(
   id: string,
   updates: Partial<ReportInterface>,
 ) {
+  if ("experimentAnalysisSettings" in updates) {
+    validateMetricOverrides(
+      updates.experimentAnalysisSettings?.metricOverrides,
+    );
+  }
+  if ("args" in updates) {
+    validateMetricOverrides(updates.args?.metricOverrides);
+  }
+
   await ReportModel.updateOne(
     {
       organization,

--- a/packages/back-end/src/models/ReportModel.ts
+++ b/packages/back-end/src/models/ReportModel.ts
@@ -11,7 +11,10 @@ import { migrateExperimentReport } from "back-end/src/util/migrations";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import { logger } from "back-end/src/util/logger";
-import { validateMetricOverrides } from "back-end/src/util/priors";
+import {
+  healMetricOverrides,
+  validateMetricOverrides,
+} from "back-end/src/util/priors";
 import { getAllExperiments } from "./ExperimentModel";
 import { queriesSchema } from "./QueryModel";
 
@@ -53,11 +56,16 @@ const toInterface = (doc: ReportDocument): ReportInterface => {
       return migrateExperimentReport(
         omit(doc.toJSON<ExperimentReportDocument>(), ["__v", "_id"]),
       );
-    case "experiment-snapshot":
-      return omit(doc.toJSON<ExperimentSnapshotReportDocument>(), [
-        "__v",
-        "_id",
-      ]);
+    case "experiment-snapshot": {
+      const snapshotReport = omit(
+        doc.toJSON<ExperimentSnapshotReportDocument>(),
+        ["__v", "_id"],
+      );
+      healMetricOverrides(
+        snapshotReport.experimentAnalysisSettings?.metricOverrides,
+      );
+      return snapshotReport;
+    }
     default:
       logger.error(
         `Invalid report type: [${

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -146,6 +146,7 @@ import {
 } from "back-end/src/enterprise";
 import { getUsageFromCache } from "back-end/src/enterprise/billing";
 import { logger } from "back-end/src/util/logger";
+import { validatePriorSettings } from "back-end/src/util/priors";
 import {
   getInstallation,
   setInstallationName,
@@ -1673,6 +1674,8 @@ export async function putOrganization(
       orig.licenseKey = org.licenseKey;
       await setLicenseKey(org, updates.licenseKey);
     }
+
+    validatePriorSettings(updates.settings?.metricDefaults?.priorSettings);
 
     await updateOrganization(org.id, updates);
 

--- a/packages/back-end/src/routers/population-data/population-data.controller.ts
+++ b/packages/back-end/src/routers/population-data/population-data.controller.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { Response } from "express";
+import { DEFAULT_PROPER_PRIOR_STDDEV } from "shared/constants";
 import { ExperimentSnapshotSettings } from "shared/types/experiment-snapshot";
 import { PopulationDataInterface } from "shared/types/population-data";
 import type { PopulationDataQuerySettings } from "shared/types/query";
@@ -70,7 +71,7 @@ export const postPopulationData = async (
     defaultMetricPriorSettings: {
       proper: false,
       mean: 0,
-      stddev: 0,
+      stddev: DEFAULT_PROPER_PRIOR_STDDEV,
       override: false,
     },
     regressionAdjustmentEnabled: false,

--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -48,6 +48,10 @@ import { decryptDataSourceParams } from "back-end/src/services/datasource";
 import { SdkWebHookLogDocument } from "back-end/src/models/SdkWebhookLogModel";
 import { getAccountPlan } from "back-end/src/enterprise";
 import { logger } from "back-end/src/util/logger";
+import {
+  healPriorSettings,
+  healMetricOverrides,
+} from "back-end/src/util/priors";
 import { DEFAULT_CONVERSION_WINDOW_HOURS } from "./secrets";
 
 function roundVariationWeight(num: number): number {
@@ -118,6 +122,7 @@ export function upgradeMetricDoc(doc: LegacyMetricInterface): MetricInterface {
       stddev: DEFAULT_PROPER_PRIOR_STDDEV,
     };
   }
+  healPriorSettings(newDoc.priorSettings);
 
   if (!doc.userIdTypes?.length) {
     if (doc.userIdType === "user") {
@@ -605,6 +610,8 @@ export function upgradeOrganizationDoc(
     delete org.settings.postStratificationDisabled;
   }
 
+  healPriorSettings(org.settings?.metricDefaults?.priorSettings);
+
   return org;
 }
 
@@ -726,6 +733,7 @@ export function upgradeExperimentDoc(
       }
     });
   }
+  healMetricOverrides(experiment.metricOverrides);
 
   if (experiment.decisionFrameworkSettings === undefined) {
     experiment.decisionFrameworkSettings = {};
@@ -807,6 +815,8 @@ export function migrateExperimentReport(
       }),
     );
   }
+
+  healMetricOverrides(newArgs.metricOverrides);
 
   return {
     ...report,

--- a/packages/back-end/src/util/priors.ts
+++ b/packages/back-end/src/util/priors.ts
@@ -4,7 +4,10 @@ import type { MetricPriorSettings } from "shared/types/fact-table";
 export function validatePriorSettings(
   priorSettings: Partial<Pick<MetricPriorSettings, "stddev">> | undefined,
 ): void {
-  if (priorSettings?.stddev !== undefined && priorSettings.stddev <= 0) {
+  if (
+    priorSettings?.stddev !== undefined &&
+    (Number.isNaN(priorSettings.stddev) || priorSettings.stddev <= 0)
+  ) {
     throw new Error("Prior standard deviation must be greater than 0");
   }
 }
@@ -17,7 +20,8 @@ export function validateMetricOverrides(
   for (const override of overrides) {
     if (
       override.properPriorStdDev !== undefined &&
-      override.properPriorStdDev <= 0
+      (Number.isNaN(override.properPriorStdDev) ||
+        override.properPriorStdDev <= 0)
     ) {
       throw new Error(
         `Prior standard deviation must be greater than 0 for metric ${override.id}`,

--- a/packages/back-end/src/util/priors.ts
+++ b/packages/back-end/src/util/priors.ts
@@ -1,12 +1,42 @@
+import { DEFAULT_PROPER_PRIOR_STDDEV } from "shared/constants";
 import type { MetricOverride } from "shared/types/experiment";
 import type { MetricPriorSettings } from "shared/types/fact-table";
+
+// A proper prior needs a positive standard deviation. 0, a negative, or NaN
+// divides by zero in the Bayesian engine; `stddev > 0` rejects all three.
+function isValidPriorStdDev(stddev: number): boolean {
+  return stddev > 0;
+}
+
+export function healPriorSettings(
+  priorSettings: Pick<MetricPriorSettings, "stddev"> | undefined,
+): void {
+  if (priorSettings && !isValidPriorStdDev(priorSettings.stddev)) {
+    priorSettings.stddev = DEFAULT_PROPER_PRIOR_STDDEV;
+  }
+}
+
+export function healMetricOverrides(
+  overrides: MetricOverride[] | undefined,
+): void {
+  if (!overrides) return;
+
+  for (const override of overrides) {
+    if (
+      override.properPriorStdDev !== undefined &&
+      !isValidPriorStdDev(override.properPriorStdDev)
+    ) {
+      override.properPriorStdDev = DEFAULT_PROPER_PRIOR_STDDEV;
+    }
+  }
+}
 
 export function validatePriorSettings(
   priorSettings: Partial<Pick<MetricPriorSettings, "stddev">> | undefined,
 ): void {
   if (
     priorSettings?.stddev !== undefined &&
-    (Number.isNaN(priorSettings.stddev) || priorSettings.stddev <= 0)
+    !isValidPriorStdDev(priorSettings.stddev)
   ) {
     throw new Error("Prior standard deviation must be greater than 0");
   }
@@ -20,8 +50,7 @@ export function validateMetricOverrides(
   for (const override of overrides) {
     if (
       override.properPriorStdDev !== undefined &&
-      (Number.isNaN(override.properPriorStdDev) ||
-        override.properPriorStdDev <= 0)
+      !isValidPriorStdDev(override.properPriorStdDev)
     ) {
       throw new Error(
         `Prior standard deviation must be greater than 0 for metric ${override.id}`,

--- a/packages/back-end/src/util/priors.ts
+++ b/packages/back-end/src/util/priors.ts
@@ -1,0 +1,27 @@
+import type { MetricOverride } from "shared/types/experiment";
+import type { MetricPriorSettings } from "shared/types/fact-table";
+
+export function validatePriorSettings(
+  priorSettings: Partial<Pick<MetricPriorSettings, "stddev">> | undefined,
+): void {
+  if (priorSettings?.stddev !== undefined && priorSettings.stddev <= 0) {
+    throw new Error("Prior standard deviation must be greater than 0");
+  }
+}
+
+export function validateMetricOverrides(
+  overrides: MetricOverride[] | undefined,
+): void {
+  if (!overrides) return;
+
+  for (const override of overrides) {
+    if (
+      override.properPriorStdDev !== undefined &&
+      override.properPriorStdDev <= 0
+    ) {
+      throw new Error(
+        `Prior standard deviation must be greater than 0 for metric ${override.id}`,
+      );
+    }
+  }
+}

--- a/packages/back-end/test/services/snapshot-planning.test.ts
+++ b/packages/back-end/test/services/snapshot-planning.test.ts
@@ -2,7 +2,6 @@ import {
   ExperimentMetricInterface,
   getMetricSnapshotSettings,
 } from "shared/experiments";
-import { DEFAULT_PROPER_PRIOR_STDDEV } from "shared/constants";
 import { ExperimentInterface } from "shared/types/experiment";
 import { DataSourceInterface } from "shared/types/datasource";
 import {
@@ -685,61 +684,6 @@ describe("snapshot planning", () => {
         ],
       });
       expect(metricSnapshotSettings.properPriorStdDev).toBe(0.5);
-    });
-
-    it("corrects a legacy zero override stddev before analysis", () => {
-      const { metricSnapshotSettings } = getMetricSnapshotSettings({
-        metric: factMetricFactory.build({ id: "m1" }),
-        denominatorMetrics: [],
-        experimentRegressionAdjustmentEnabled: false,
-        metricOverrides: [
-          {
-            id: "m1",
-            properPriorOverride: true,
-            properPriorEnabled: true,
-            properPriorStdDev: 0,
-          },
-        ],
-      });
-      expect(metricSnapshotSettings.properPrior).toBe(true);
-      expect(metricSnapshotSettings.properPriorStdDev).toBe(
-        DEFAULT_PROPER_PRIOR_STDDEV,
-      );
-    });
-
-    it("corrects a legacy zero metric-level stddev before analysis", () => {
-      const { metricSnapshotSettings } = getMetricSnapshotSettings({
-        metric: factMetricFactory.build({
-          id: "m1",
-          priorSettings: { override: true, proper: true, mean: 0, stddev: 0 },
-        }),
-        denominatorMetrics: [],
-        experimentRegressionAdjustmentEnabled: false,
-      });
-      expect(metricSnapshotSettings.properPrior).toBe(true);
-      expect(metricSnapshotSettings.properPriorStdDev).toBe(
-        DEFAULT_PROPER_PRIOR_STDDEV,
-      );
-    });
-
-    it("corrects a legacy zero org-default stddev before analysis", () => {
-      const { metricSnapshotSettings } = getMetricSnapshotSettings({
-        metric: factMetricFactory.build({
-          id: "m1",
-          priorSettings: { override: false, proper: false, mean: 0, stddev: 1 },
-        }),
-        denominatorMetrics: [],
-        experimentRegressionAdjustmentEnabled: false,
-        organizationSettings: {
-          metricDefaults: {
-            priorSettings: { override: true, proper: true, mean: 0, stddev: 0 },
-          },
-        },
-      });
-      expect(metricSnapshotSettings.properPrior).toBe(true);
-      expect(metricSnapshotSettings.properPriorStdDev).toBe(
-        DEFAULT_PROPER_PRIOR_STDDEV,
-      );
     });
   });
 });

--- a/packages/back-end/test/services/snapshot-planning.test.ts
+++ b/packages/back-end/test/services/snapshot-planning.test.ts
@@ -672,4 +672,59 @@ describe("snapshot planning", () => {
     expect(plan.fullRefresh).toBe(false);
     expect(plan.fullRefreshReason).toBeNull();
   });
+
+  describe("getMetricSnapshotSettings read contract", () => {
+    it("applies a positive override stddev", () => {
+      const { metricSnapshotSettings } = getMetricSnapshotSettings({
+        metric: factMetricFactory.build({ id: "m1" }),
+        denominatorMetrics: [],
+        experimentRegressionAdjustmentEnabled: false,
+        metricOverrides: [
+          { id: "m1", properPriorOverride: true, properPriorStdDev: 0.5 },
+        ],
+      });
+      expect(metricSnapshotSettings.properPriorStdDev).toBe(0.5);
+    });
+
+    it("returns stored zero override stddev unchanged", () => {
+      const { metricSnapshotSettings } = getMetricSnapshotSettings({
+        metric: factMetricFactory.build({ id: "m1" }),
+        denominatorMetrics: [],
+        experimentRegressionAdjustmentEnabled: false,
+        metricOverrides: [
+          { id: "m1", properPriorOverride: true, properPriorStdDev: 0 },
+        ],
+      });
+      expect(metricSnapshotSettings.properPriorStdDev).toBe(0);
+    });
+
+    it("returns stored zero metric-level stddev unchanged", () => {
+      const { metricSnapshotSettings } = getMetricSnapshotSettings({
+        metric: factMetricFactory.build({
+          id: "m1",
+          priorSettings: { override: true, proper: true, mean: 0, stddev: 0 },
+        }),
+        denominatorMetrics: [],
+        experimentRegressionAdjustmentEnabled: false,
+      });
+      expect(metricSnapshotSettings.properPriorStdDev).toBe(0);
+    });
+
+    it("returns stored zero org-default stddev unchanged", () => {
+      const { metricSnapshotSettings } = getMetricSnapshotSettings({
+        metric: factMetricFactory.build({
+          id: "m1",
+          priorSettings: { override: false, proper: false, mean: 0, stddev: 1 },
+        }),
+        denominatorMetrics: [],
+        experimentRegressionAdjustmentEnabled: false,
+        organizationSettings: {
+          metricDefaults: {
+            priorSettings: { override: true, proper: true, mean: 0, stddev: 0 },
+          },
+        },
+      });
+      expect(metricSnapshotSettings.properPriorStdDev).toBe(0);
+    });
+  });
 });

--- a/packages/back-end/test/services/snapshot-planning.test.ts
+++ b/packages/back-end/test/services/snapshot-planning.test.ts
@@ -2,6 +2,7 @@ import {
   ExperimentMetricInterface,
   getMetricSnapshotSettings,
 } from "shared/experiments";
+import { DEFAULT_PROPER_PRIOR_STDDEV } from "shared/constants";
 import { ExperimentInterface } from "shared/types/experiment";
 import { DataSourceInterface } from "shared/types/datasource";
 import {
@@ -686,19 +687,27 @@ describe("snapshot planning", () => {
       expect(metricSnapshotSettings.properPriorStdDev).toBe(0.5);
     });
 
-    it("returns stored zero override stddev unchanged", () => {
+    it("corrects a legacy zero override stddev before analysis", () => {
       const { metricSnapshotSettings } = getMetricSnapshotSettings({
         metric: factMetricFactory.build({ id: "m1" }),
         denominatorMetrics: [],
         experimentRegressionAdjustmentEnabled: false,
         metricOverrides: [
-          { id: "m1", properPriorOverride: true, properPriorStdDev: 0 },
+          {
+            id: "m1",
+            properPriorOverride: true,
+            properPriorEnabled: true,
+            properPriorStdDev: 0,
+          },
         ],
       });
-      expect(metricSnapshotSettings.properPriorStdDev).toBe(0);
+      expect(metricSnapshotSettings.properPrior).toBe(true);
+      expect(metricSnapshotSettings.properPriorStdDev).toBe(
+        DEFAULT_PROPER_PRIOR_STDDEV,
+      );
     });
 
-    it("returns stored zero metric-level stddev unchanged", () => {
+    it("corrects a legacy zero metric-level stddev before analysis", () => {
       const { metricSnapshotSettings } = getMetricSnapshotSettings({
         metric: factMetricFactory.build({
           id: "m1",
@@ -707,10 +716,13 @@ describe("snapshot planning", () => {
         denominatorMetrics: [],
         experimentRegressionAdjustmentEnabled: false,
       });
-      expect(metricSnapshotSettings.properPriorStdDev).toBe(0);
+      expect(metricSnapshotSettings.properPrior).toBe(true);
+      expect(metricSnapshotSettings.properPriorStdDev).toBe(
+        DEFAULT_PROPER_PRIOR_STDDEV,
+      );
     });
 
-    it("returns stored zero org-default stddev unchanged", () => {
+    it("corrects a legacy zero org-default stddev before analysis", () => {
       const { metricSnapshotSettings } = getMetricSnapshotSettings({
         metric: factMetricFactory.build({
           id: "m1",
@@ -724,7 +736,10 @@ describe("snapshot planning", () => {
           },
         },
       });
-      expect(metricSnapshotSettings.properPriorStdDev).toBe(0);
+      expect(metricSnapshotSettings.properPrior).toBe(true);
+      expect(metricSnapshotSettings.properPriorStdDev).toBe(
+        DEFAULT_PROPER_PRIOR_STDDEV,
+      );
     });
   });
 });

--- a/packages/back-end/test/util/priors.test.ts
+++ b/packages/back-end/test/util/priors.test.ts
@@ -28,6 +28,12 @@ describe("priors util", () => {
         "Prior standard deviation must be greater than 0",
       );
     });
+
+    it("rejects NaN stddev", () => {
+      expect(() => validatePriorSettings({ stddev: NaN })).toThrow(
+        "Prior standard deviation must be greater than 0",
+      );
+    });
   });
 
   describe("validateMetricOverrides", () => {
@@ -70,6 +76,14 @@ describe("priors util", () => {
         validateMetricOverrides([{ id: "m1", properPriorStdDev: -0.5 }]),
       ).toThrow(
         "Prior standard deviation must be greater than 0 for metric m1",
+      );
+    });
+
+    it("rejects NaN stddev and names the metric", () => {
+      expect(() =>
+        validateMetricOverrides([{ id: "bad_metric", properPriorStdDev: NaN }]),
+      ).toThrow(
+        "Prior standard deviation must be greater than 0 for metric bad_metric",
       );
     });
   });

--- a/packages/back-end/test/util/priors.test.ts
+++ b/packages/back-end/test/util/priors.test.ts
@@ -1,0 +1,76 @@
+import {
+  validateMetricOverrides,
+  validatePriorSettings,
+} from "back-end/src/util/priors";
+
+describe("priors util", () => {
+  describe("validatePriorSettings", () => {
+    it("allows positive stddev", () => {
+      expect(() => validatePriorSettings({ stddev: 0.5 })).not.toThrow();
+    });
+
+    it("allows undefined stddev", () => {
+      expect(() => validatePriorSettings({ stddev: undefined })).not.toThrow();
+    });
+
+    it("allows undefined priorSettings", () => {
+      expect(() => validatePriorSettings(undefined)).not.toThrow();
+    });
+
+    it("rejects stddev = 0", () => {
+      expect(() => validatePriorSettings({ stddev: 0 })).toThrow(
+        "Prior standard deviation must be greater than 0",
+      );
+    });
+
+    it("rejects negative stddev", () => {
+      expect(() => validatePriorSettings({ stddev: -1 })).toThrow(
+        "Prior standard deviation must be greater than 0",
+      );
+    });
+  });
+
+  describe("validateMetricOverrides", () => {
+    it("allows positive properPriorStdDev", () => {
+      expect(() =>
+        validateMetricOverrides([
+          { id: "m1", properPriorStdDev: 0.3 },
+          { id: "m2", properPriorStdDev: 0.5 },
+        ]),
+      ).not.toThrow();
+    });
+
+    it("allows undefined properPriorStdDev", () => {
+      expect(() =>
+        validateMetricOverrides([{ id: "m1", properPriorStdDev: undefined }]),
+      ).not.toThrow();
+    });
+
+    it("allows empty overrides", () => {
+      expect(() => validateMetricOverrides([])).not.toThrow();
+    });
+
+    it("allows undefined overrides", () => {
+      expect(() => validateMetricOverrides(undefined)).not.toThrow();
+    });
+
+    it("rejects stddev = 0 and names the metric", () => {
+      expect(() =>
+        validateMetricOverrides([
+          { id: "m1", properPriorStdDev: 0.3 },
+          { id: "bad_metric", properPriorStdDev: 0 },
+        ]),
+      ).toThrow(
+        "Prior standard deviation must be greater than 0 for metric bad_metric",
+      );
+    });
+
+    it("rejects negative stddev and names the metric", () => {
+      expect(() =>
+        validateMetricOverrides([{ id: "m1", properPriorStdDev: -0.5 }]),
+      ).toThrow(
+        "Prior standard deviation must be greater than 0 for metric m1",
+      );
+    });
+  });
+});

--- a/packages/back-end/test/util/priors.test.ts
+++ b/packages/back-end/test/util/priors.test.ts
@@ -1,6 +1,9 @@
+import { DEFAULT_PROPER_PRIOR_STDDEV } from "shared/constants";
 import {
   validateMetricOverrides,
   validatePriorSettings,
+  healPriorSettings,
+  healMetricOverrides,
 } from "back-end/src/util/priors";
 
 describe("priors util", () => {
@@ -85,6 +88,89 @@ describe("priors util", () => {
       ).toThrow(
         "Prior standard deviation must be greater than 0 for metric bad_metric",
       );
+    });
+  });
+
+  describe("healPriorSettings", () => {
+    it("heals stddev=0 to DEFAULT", () => {
+      const settings = {
+        override: false,
+        proper: true,
+        mean: 0,
+        stddev: 0,
+      };
+      healPriorSettings(settings);
+      expect(settings.stddev).toBe(DEFAULT_PROPER_PRIOR_STDDEV);
+    });
+
+    it("heals a negative stddev to DEFAULT", () => {
+      const settings = { override: false, proper: true, mean: 0, stddev: -1 };
+      healPriorSettings(settings);
+      expect(settings.stddev).toBe(DEFAULT_PROPER_PRIOR_STDDEV);
+    });
+
+    it("heals a NaN stddev to DEFAULT", () => {
+      const settings = { override: false, proper: true, mean: 0, stddev: NaN };
+      healPriorSettings(settings);
+      expect(settings.stddev).toBe(DEFAULT_PROPER_PRIOR_STDDEV);
+    });
+
+    it("is idempotent on an already-default stddev", () => {
+      const settings = {
+        override: false,
+        proper: true,
+        mean: 0,
+        stddev: DEFAULT_PROPER_PRIOR_STDDEV,
+      };
+      healPriorSettings(settings);
+      expect(settings.stddev).toBe(DEFAULT_PROPER_PRIOR_STDDEV);
+    });
+
+    it("leaves a positive stddev unchanged", () => {
+      const settings = {
+        override: false,
+        proper: true,
+        mean: 0,
+        stddev: 0.5,
+      };
+      healPriorSettings(settings);
+      expect(settings.stddev).toBe(0.5);
+    });
+
+    it("is a no-op on undefined", () => {
+      expect(() => healPriorSettings(undefined)).not.toThrow();
+    });
+  });
+
+  describe("healMetricOverrides", () => {
+    it("heals properPriorStdDev=0 to DEFAULT for the right override", () => {
+      const overrides = [
+        { id: "m1", properPriorStdDev: 0.5 },
+        { id: "m2", properPriorStdDev: 0 },
+      ];
+      healMetricOverrides(overrides);
+      expect(overrides[0].properPriorStdDev).toBe(0.5);
+      expect(overrides[1].properPriorStdDev).toBe(DEFAULT_PROPER_PRIOR_STDDEV);
+    });
+
+    it("leaves a positive value unchanged", () => {
+      const overrides = [{ id: "m1", properPriorStdDev: 0.3 }];
+      healMetricOverrides(overrides);
+      expect(overrides[0].properPriorStdDev).toBe(0.3);
+    });
+
+    it("leaves an undefined properPriorStdDev as undefined", () => {
+      const overrides = [{ id: "m1", properPriorStdDev: undefined }];
+      healMetricOverrides(overrides);
+      expect(overrides[0].properPriorStdDev).toBeUndefined();
+    });
+
+    it("is a no-op on undefined overrides", () => {
+      expect(() => healMetricOverrides(undefined)).not.toThrow();
+    });
+
+    it("is a no-op on empty overrides array", () => {
+      expect(() => healMetricOverrides([])).not.toThrow();
     });
   });
 });

--- a/packages/shared/src/experiments/experiments.ts
+++ b/packages/shared/src/experiments/experiments.ts
@@ -839,6 +839,16 @@ export function getMetricSnapshotSettings<T extends ExperimentMetricInterface>({
     }
   }
 
+  // Legacy data may carry a non-positive (or NaN) prior stddev which is invalid
+  // A proper prior with stddev <= 0 divides by zero in the Bayesian engine, so
+  // fall back to the default strength while keeping the prior the user enabled.
+  if (
+    metricPriorSettings.properPrior &&
+    !(metricPriorSettings.properPriorStdDev > 0)
+  ) {
+    metricPriorSettings.properPriorStdDev = DEFAULT_PROPER_PRIOR_STDDEV;
+  }
+
   // final gatekeeping for RA
   if (regressionAdjustmentEnabled) {
     if (metric && isFactMetric(metric) && quantileMetricType(metric)) {

--- a/packages/shared/src/experiments/experiments.ts
+++ b/packages/shared/src/experiments/experiments.ts
@@ -839,16 +839,6 @@ export function getMetricSnapshotSettings<T extends ExperimentMetricInterface>({
     }
   }
 
-  // Legacy data may carry a non-positive (or NaN) prior stddev which is invalid
-  // A proper prior with stddev <= 0 divides by zero in the Bayesian engine, so
-  // fall back to the default strength while keeping the prior the user enabled.
-  if (
-    metricPriorSettings.properPrior &&
-    !(metricPriorSettings.properPriorStdDev > 0)
-  ) {
-    metricPriorSettings.properPriorStdDev = DEFAULT_PROPER_PRIOR_STDDEV;
-  }
-
   // final gatekeeping for RA
   if (regressionAdjustmentEnabled) {
     if (metric && isFactMetric(metric) && quantileMetricType(metric)) {

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -188,7 +188,7 @@ export const metricOverride = z
     properPriorOverride: z.boolean().optional(),
     properPriorEnabled: z.boolean().optional(),
     properPriorMean: z.number().optional(),
-    properPriorStdDev: z.number().optional(),
+    properPriorStdDev: z.number().gt(0).optional(),
     regressionAdjustmentOverride: z.boolean().optional(),
     regressionAdjustmentEnabled: z.boolean().optional(),
     regressionAdjustmentDays: z.number().optional(),
@@ -963,7 +963,7 @@ const apiMetricOverrideEntryInput = z
       .optional(),
     properPriorEnabled: z.boolean().optional(),
     properPriorMean: z.number().optional(),
-    properPriorStdDev: z.number().optional(),
+    properPriorStdDev: z.number().gt(0).optional(),
     regressionAdjustmentOverride: z
       .boolean()
       .describe(

--- a/packages/shared/src/validators/fact-table.ts
+++ b/packages/shared/src/validators/fact-table.ts
@@ -271,7 +271,9 @@ export const factMetricValidator = z
 
     cappingSettings: cappingSettingsValidator,
     windowSettings: windowSettingsValidator,
-    priorSettings: priorSettingsValidator,
+    priorSettings: priorSettingsValidator.extend({
+      stddev: z.number().gt(0),
+    }),
 
     maxPercentChange: z.number(),
     minPercentChange: z.number(),

--- a/packages/shared/src/validators/fact-table.ts
+++ b/packages/shared/src/validators/fact-table.ts
@@ -237,7 +237,7 @@ export const priorSettingsValidator = z.object({
   override: z.boolean(),
   proper: z.boolean(),
   mean: z.number(),
-  stddev: z.number(),
+  stddev: z.number().gt(0),
 });
 
 export const metricTypeValidator = z.enum([
@@ -271,9 +271,7 @@ export const factMetricValidator = z
 
     cappingSettings: cappingSettingsValidator,
     windowSettings: windowSettingsValidator,
-    priorSettings: priorSettingsValidator.extend({
-      stddev: z.number().gt(0),
-    }),
+    priorSettings: priorSettingsValidator,
 
     maxPercentChange: z.number(),
     minPercentChange: z.number(),

--- a/packages/shared/src/validators/metrics.ts
+++ b/packages/shared/src/validators/metrics.ts
@@ -89,6 +89,7 @@ export const apiMetricValidator = namedSchema(
               ),
             stddev: z.coerce
               .number()
+              .gt(0)
               .describe(
                 "Must be > 0. The standard deviation of the prior distribution of relative effects in proportion terms.",
               ),


### PR DESCRIPTION
### Features and Changes

Enforce `stddev > 0` (the prior standard deviation) consistently

Previously the constraint was only loosely enforced, so a prior stddev of `0` or negative could slip into metrics, experiments, and reports. A non-positive prior stddev is statistically invalid and breaks Bayesian analysis downstream.

So we now are both validating before write and also healing invalid documents by setting the field back to the default value.

### Testing

- Unit tests
