### PR TITLE
Allow quantile/percentile metrics as guardrails in Safe Rollouts

### DIFF
--- a/packages/front-end/components/Features/RuleModal/RampScheduleSection.tsx
+++ b/packages/front-end/components/Features/RuleModal/RampScheduleSection.tsx
@@ -2977,7 +2977,6 @@ export default function RampScheduleSection({
             project={feature.project ?? ""}
             includeFacts
             includeGroups
-            excludeQuantiles
             selected={state.monitoring.guardrailMetricIds}
             disabled={!state.monitoring.exposureQueryId}
             onChange={(v) => patchMonitoring({ guardrailMetricIds: v })}
@@ -2999,7 +2998,6 @@ export default function RampScheduleSection({
             project={feature.project ?? ""}
             includeFacts
             includeGroups
-            excludeQuantiles
             selected={state.monitoring.signalMetricIds}
             disabled={!state.monitoring.exposureQueryId}
             onChange={(v) => patchMonitoring({ signalMetricIds: v })}

--- a/packages/front-end/components/Features/RuleModal/SafeRolloutFields.tsx
+++ b/packages/front-end/components/Features/RuleModal/SafeRolloutFields.tsx
@@ -301,7 +301,6 @@ export default function SafeRolloutFields({
               includeFacts={true}
               forceSingleMetric={false}
               includeGroups={true}
-              excludeQuantiles={true}
               selected={
                 form.watch("safeRolloutFields.guardrailMetricIds") || []
               }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

Removes the UI-only restriction that blocked quantile/percentile metrics (e.g., P99 latency, median response time) from being selected as guardrail metrics in Safe Rollouts.

**Changes:**
- `SafeRolloutFields.tsx`: Removed `excludeQuantiles={true}` from the guardrail metrics selector
- `RampScheduleSection.tsx`: Removed `excludeQuantiles` from guardrail and signal metrics selectors for monitored ramps

**Why:**
Quantile metrics are often important guardrail metrics for monitoring performance regressions (e.g., P99 latency). There was no backend validation blocking these metrics - this was a UI-only restriction that is now lifted.

- Closes **N/A** (internal request from @lukesonnet)

### Dependencies

None

### Testing

- TypeScript type-check passes
- ESLint passes
- Code review verified the `excludeQuantiles` prop has been correctly removed from all relevant MetricsSelector instances
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C07NK4F016Z/p1781539083934429?thread_ts=1781539083.934429&cid=C07NK4F016Z)

<div><a href="https://cursor.com/agents/bc-a1f62007-afb5-5be3-b9ed-81835b9a1825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1f62007-afb5-5be3-b9ed-81835b9a1825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

