### PR TITLE
Add EF Prefix to managed IDs

### DIFF
--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -537,8 +537,6 @@ export async function putDataSource(
           !isEventForwarderAllowedUserIdTypesChange(
             existingUserIdTypes,
             settings.userIdTypes,
-            org.settings?.attributeSchema ?? [],
-            datasource.projects,
           )
         ) {
           res.status(400).json({

--- a/packages/back-end/test/services/eventForwarderExposureQueries.test.ts
+++ b/packages/back-end/test/services/eventForwarderExposureQueries.test.ts
@@ -140,7 +140,7 @@ describe("ensureEventForwarderExposureQueries", () => {
             exposure: [
               expect.objectContaining({
                 userIdType: "device_id",
-                id: "device_id",
+                id: "ef_device_id",
                 managedBy: "api",
               }),
             ],
@@ -183,12 +183,12 @@ describe("ensureEventForwarderExposureQueries", () => {
             exposure: expect.arrayContaining([
               expect.objectContaining({
                 userIdType: "user_id",
-                id: "user_id",
+                id: "ef_user_id",
                 managedBy: "api",
               }),
               expect.objectContaining({
                 userIdType: "device_id",
-                id: "device_id",
+                id: "ef_device_id",
               }),
             ]),
           },
@@ -248,10 +248,11 @@ describe("ensureEventForwarderExposureQueries", () => {
       queries: {
         exposure: [
           {
-            id: "user_id",
-            name: "user_id",
+            id: "ef_user_id",
+            name: "Event Forwarder: user_id",
             userIdType: "user_id",
             dimensions: [],
+            managedBy: "api",
             query: "SELECT 1",
           },
         ],
@@ -416,7 +417,7 @@ describe("ensureEventForwarderExposureQueries", () => {
             exposure: [
               expect.objectContaining({
                 userIdType: "device_id",
-                id: "device_id",
+                id: "ef_device_id",
                 managedBy: "api",
               }),
             ],

--- a/packages/back-end/test/services/eventForwarderExposureQueries.test.ts
+++ b/packages/back-end/test/services/eventForwarderExposureQueries.test.ts
@@ -113,7 +113,7 @@ describe("ensureEventForwarderExposureQueries", () => {
       privateKey: "key",
     };
     const raw = ds({
-      userIdTypes: [{ userIdType: "device_id", description: "" }],
+      userIdTypes: [{ userIdType: "ef_device_id", description: "" }],
       queries: { exposure: [] },
     });
     raw.params = encryptParams(bigqueryParams);
@@ -128,7 +128,7 @@ describe("ensureEventForwarderExposureQueries", () => {
     await ensureEventForwarderExposureQueries(
       context() as never,
       efConfig("bigquery"),
-      ["device_id"],
+      ["ef_device_id"],
     );
 
     expect(mockedUpdate).toHaveBeenCalledWith(
@@ -139,7 +139,7 @@ describe("ensureEventForwarderExposureQueries", () => {
           queries: {
             exposure: [
               expect.objectContaining({
-                userIdType: "device_id",
+                userIdType: "ef_device_id",
                 id: "ef_device_id",
                 managedBy: "api",
               }),
@@ -154,8 +154,8 @@ describe("ensureEventForwarderExposureQueries", () => {
   it("creates one exposure query per synced userIdType for BigQuery", async () => {
     const raw = ds({
       userIdTypes: [
-        { userIdType: "user_id", description: "" },
-        { userIdType: "device_id", description: "" },
+        { userIdType: "ef_user_id", description: "" },
+        { userIdType: "ef_device_id", description: "" },
       ],
       queries: { exposure: [] },
     });
@@ -170,7 +170,7 @@ describe("ensureEventForwarderExposureQueries", () => {
     await ensureEventForwarderExposureQueries(
       context() as never,
       efConfig("bigquery"),
-      ["user_id", "device_id"],
+      ["ef_user_id", "ef_device_id"],
       { defaultProject: "my-project" } as never,
     );
 
@@ -182,12 +182,12 @@ describe("ensureEventForwarderExposureQueries", () => {
           queries: {
             exposure: expect.arrayContaining([
               expect.objectContaining({
-                userIdType: "user_id",
+                userIdType: "ef_user_id",
                 id: "ef_user_id",
                 managedBy: "api",
               }),
               expect.objectContaining({
-                userIdType: "device_id",
+                userIdType: "ef_device_id",
                 id: "ef_device_id",
               }),
             ]),
@@ -249,7 +249,7 @@ describe("ensureEventForwarderExposureQueries", () => {
         exposure: [
           {
             id: "ef_user_id",
-            name: "Event Forwarder: user_id",
+            name: "ef_user_id",
             userIdType: "user_id",
             dimensions: [],
             managedBy: "api",
@@ -381,7 +381,7 @@ describe("ensureEventForwarderExposureQueries", () => {
 
   it("uses passed attributeSchema when context org schema is stale", async () => {
     const raw = ds({
-      userIdTypes: [{ userIdType: "device_id", description: "" }],
+      userIdTypes: [{ userIdType: "ef_device_id", description: "" }],
       queries: { exposure: [] },
     });
     mockedGetRaw.mockResolvedValue(raw);
@@ -403,7 +403,7 @@ describe("ensureEventForwarderExposureQueries", () => {
     await ensureEventForwarderExposureQueries(
       context([]) as never,
       efConfig("bigquery"),
-      ["device_id"],
+      ["ef_device_id"],
       { defaultProject: "my-project" } as never,
       updatedAttributeSchema,
     );
@@ -416,7 +416,7 @@ describe("ensureEventForwarderExposureQueries", () => {
           queries: {
             exposure: [
               expect.objectContaining({
-                userIdType: "device_id",
+                userIdType: "ef_device_id",
                 id: "ef_device_id",
                 managedBy: "api",
               }),

--- a/packages/back-end/test/services/eventForwarderUserIdTypes.test.ts
+++ b/packages/back-end/test/services/eventForwarderUserIdTypes.test.ts
@@ -252,7 +252,7 @@ describe("reconcileEventForwarderDatasourceUserIdTypesAndExposureQueries", () =>
         query: "SELECT custom_id",
       },
       expect.objectContaining({
-        id: "device_id",
+        id: "ef_device_id",
         userIdType: "device_id",
         managedBy: "api",
       }),
@@ -294,7 +294,7 @@ describe("reconcileEventForwarderDatasourceUserIdTypesAndExposureQueries", () =>
     ]);
     expect(settings?.queries?.exposure).toEqual([
       expect.objectContaining({
-        id: "id",
+        id: "ef_id",
         userIdType: "id",
         managedBy: "api",
       }),
@@ -335,7 +335,7 @@ describe("reconcileEventForwarderDatasourceUserIdTypesAndExposureQueries", () =>
     const exposure = mockedUpdate.mock.calls[0][2].settings?.queries?.exposure;
     expect(exposure?.[0]).toEqual(
       expect.objectContaining({
-        id: "user_id",
+        id: "ef_user_id",
         userIdType: "user_id",
         query: expect.stringContaining("AS FLOAT64"),
       }),
@@ -424,7 +424,7 @@ describe("reconcileEventForwarderDatasourceUserIdTypesAndExposureQueries", () =>
     ]);
     expect(mockedUpdate.mock.calls[0][2].settings?.queries?.exposure).toEqual([
       expect.objectContaining({
-        id: "id",
+        id: "ef_id",
         userIdType: "id",
         managedBy: "api",
       }),

--- a/packages/back-end/test/services/eventForwarderUserIdTypes.test.ts
+++ b/packages/back-end/test/services/eventForwarderUserIdTypes.test.ts
@@ -111,7 +111,7 @@ describe("initializeDatasourceUserIdTypesFromOrgAttributeSchema without event fo
     setupDataSourceMocks();
   });
 
-  it("merges hash attributes without overriding existing names (case insensitive)", async () => {
+  it("adds prefixed managed identifiers alongside existing user identifier types", async () => {
     const raw = ds("ds_1", {
       userIdTypes: [{ userIdType: "user_id", description: "Existing" }],
     });
@@ -132,9 +132,16 @@ describe("initializeDatasourceUserIdTypesFromOrgAttributeSchema without event fo
       {
         settings: {
           userIdTypes: [
+            // The user's own identifier type is preserved untouched; the managed
+            // ones are prefixed so they coexist instead of overriding it.
             { userIdType: "user_id", description: "Existing" },
             {
-              userIdType: "id",
+              userIdType: "ef_USER_ID",
+              description: EVENT_FORWARDER_MANAGED_IDENTIFIER_TYPE_DESCRIPTION,
+              attributes: ["USER_ID"],
+            },
+            {
+              userIdType: "ef_id",
               description: EVENT_FORWARDER_MANAGED_IDENTIFIER_TYPE_DESCRIPTION,
               attributes: ["id"],
             },
@@ -164,7 +171,7 @@ describe("initializeDatasourceUserIdTypesFromOrgAttributeSchema without event fo
         settings: {
           userIdTypes: [
             {
-              userIdType: "id",
+              userIdType: "ef_id",
               description: EVENT_FORWARDER_MANAGED_IDENTIFIER_TYPE_DESCRIPTION,
               attributes: ["id"],
             },
@@ -238,7 +245,7 @@ describe("reconcileEventForwarderDatasourceUserIdTypesAndExposureQueries", () =>
     expect(settings?.userIdTypes).toEqual([
       { userIdType: "custom_id", description: "Custom" },
       {
-        userIdType: "device_id",
+        userIdType: "ef_device_id",
         description: EVENT_FORWARDER_MANAGED_IDENTIFIER_TYPE_DESCRIPTION,
         attributes: ["device_id"],
       },
@@ -253,7 +260,7 @@ describe("reconcileEventForwarderDatasourceUserIdTypesAndExposureQueries", () =>
       },
       expect.objectContaining({
         id: "ef_device_id",
-        userIdType: "device_id",
+        userIdType: "ef_device_id",
         managedBy: "api",
       }),
     ]);
@@ -287,7 +294,7 @@ describe("reconcileEventForwarderDatasourceUserIdTypesAndExposureQueries", () =>
     const settings = mockedUpdate.mock.calls[0][2].settings;
     expect(settings?.userIdTypes).toEqual([
       {
-        userIdType: "id",
+        userIdType: "ef_id",
         description: EVENT_FORWARDER_MANAGED_IDENTIFIER_TYPE_DESCRIPTION,
         attributes: ["id"],
       },
@@ -295,7 +302,7 @@ describe("reconcileEventForwarderDatasourceUserIdTypesAndExposureQueries", () =>
     expect(settings?.queries?.exposure).toEqual([
       expect.objectContaining({
         id: "ef_id",
-        userIdType: "id",
+        userIdType: "ef_id",
         managedBy: "api",
       }),
     ]);
@@ -304,18 +311,18 @@ describe("reconcileEventForwarderDatasourceUserIdTypesAndExposureQueries", () =>
   it("regenerates managed exposure SQL when the hash attribute datatype changes", async () => {
     const raw = ds("ds_1", {
       userIdTypes: [
-        { userIdType: "user_id", description: "", attributes: ["user_id"] },
+        { userIdType: "ef_user_id", description: "", attributes: ["user_id"] },
       ],
       queries: {
         exposure: [
           {
-            id: "user_id",
-            userIdType: "user_id",
-            name: "user_id",
+            id: "ef_user_id",
+            userIdType: "ef_user_id",
+            name: "ef_user_id",
             dimensions: [],
             managedBy: "api",
             query:
-              "SELECT CAST(JSON_VALUE(`attributes`, '$.\"user_id\"') AS STRING) AS `user_id`",
+              "SELECT CAST(JSON_VALUE(`attributes`, '$.\"user_id\"') AS STRING) AS `ef_user_id`",
           },
         ],
       },
@@ -336,7 +343,7 @@ describe("reconcileEventForwarderDatasourceUserIdTypesAndExposureQueries", () =>
     expect(exposure?.[0]).toEqual(
       expect.objectContaining({
         id: "ef_user_id",
-        userIdType: "user_id",
+        userIdType: "ef_user_id",
         query: expect.stringContaining("AS FLOAT64"),
       }),
     );
@@ -417,7 +424,7 @@ describe("reconcileEventForwarderDatasourceUserIdTypesAndExposureQueries", () =>
 
     expect(mockedUpdate.mock.calls[0][2].settings?.userIdTypes).toEqual([
       {
-        userIdType: "id",
+        userIdType: "ef_id",
         description: EVENT_FORWARDER_MANAGED_IDENTIFIER_TYPE_DESCRIPTION,
         attributes: ["id"],
       },
@@ -425,7 +432,7 @@ describe("reconcileEventForwarderDatasourceUserIdTypesAndExposureQueries", () =>
     expect(mockedUpdate.mock.calls[0][2].settings?.queries?.exposure).toEqual([
       expect.objectContaining({
         id: "ef_id",
-        userIdType: "id",
+        userIdType: "ef_id",
         managedBy: "api",
       }),
     ]);

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/DataSourceInlineEditIdentifierTypes.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/DataSourceInlineEditIdentifierTypes.tsx
@@ -4,14 +4,13 @@ import {
   DataSourceInterfaceWithParams,
   UserIdType,
 } from "shared/types/datasource";
-import { isHashAttributeUserIdType } from "shared/util";
+import { isEventForwarderManagedIdentifierId } from "shared/util";
 import { FaPlus } from "react-icons/fa";
 import { Box, Card, Flex } from "@radix-ui/themes";
 import { DataSourceQueryEditingModalBaseProps } from "@/components/Settings/EditDataSource/types";
 import { EditIdentifierType } from "@/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/EditIdentifierType";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
-import useOrgSettings from "@/hooks/useOrgSettings";
 import Badge from "@/ui/Badge";
 import Button from "@/ui/Button";
 import Metadata from "@/ui/Metadata";
@@ -28,7 +27,6 @@ export const DataSourceInlineEditIdentifierTypes: FC<
   const [editingIndex, setEditingIndex] = useState<number>(-1);
 
   const permissionsUtil = usePermissionsUtil();
-  const { attributeSchema } = useOrgSettings();
   canEdit = canEdit && permissionsUtil.canUpdateDataSourceSettings(dataSource);
 
   const eventForwarderActive = Boolean(dataSource.eventForwarderConfig);
@@ -38,15 +36,13 @@ export const DataSourceInlineEditIdentifierTypes: FC<
     [dataSource.settings?.userIdTypes],
   );
 
-  const isLockedHashAttributeType = useCallback(
+  // Only Event Forwarder managed identifier types (prefixed with `ef_`) are
+  // locked. User-created identifier types that happen to use the same hash
+  // attribute remain editable / deletable.
+  const isEventForwarderManagedType = useCallback(
     (userIdType: string) =>
-      eventForwarderActive &&
-      isHashAttributeUserIdType(
-        userIdType,
-        attributeSchema ?? [],
-        dataSource.projects,
-      ),
-    [attributeSchema, dataSource.projects, eventForwarderActive],
+      eventForwarderActive && isEventForwarderManagedIdentifierId(userIdType),
+    [eventForwarderActive],
   );
 
   const recordEditing = useMemo((): null | UserIdType => {
@@ -56,9 +52,9 @@ export const DataSourceInlineEditIdentifierTypes: FC<
   const isEditingEventForwarderManagedType = useMemo(
     () =>
       recordEditing
-        ? isLockedHashAttributeType(recordEditing.userIdType)
+        ? isEventForwarderManagedType(recordEditing.userIdType)
         : false,
-    [isLockedHashAttributeType, recordEditing],
+    [isEventForwarderManagedType, recordEditing],
   );
 
   const handleCancel = useCallback(() => {
@@ -91,8 +87,8 @@ export const DataSourceInlineEditIdentifierTypes: FC<
       async (userIdType: string, description: string, attributes: string[]) => {
         const copy = cloneDeep<DataSourceInterfaceWithParams>(dataSource);
         const types = copy.settings?.userIdTypes ?? [];
-        const isEventForwarderManagedType =
-          uiMode === "edit" && isLockedHashAttributeType(userIdType);
+        const editingManagedType =
+          uiMode === "edit" && isEventForwarderManagedType(userIdType);
 
         if (idx >= types.length) {
           types.push({ userIdType, description, attributes });
@@ -101,7 +97,7 @@ export const DataSourceInlineEditIdentifierTypes: FC<
           if (!existing) {
             return;
           }
-          types[idx] = isEventForwarderManagedType
+          types[idx] = editingManagedType
             ? { ...existing, description }
             : {
                 userIdType,
@@ -117,7 +113,7 @@ export const DataSourceInlineEditIdentifierTypes: FC<
 
         await onSave(copy);
       },
-    [dataSource, isLockedHashAttributeType, onSave, uiMode],
+    [dataSource, isEventForwarderManagedType, onSave, uiMode],
   );
 
   const handleAdd = useCallback(() => {
@@ -148,7 +144,7 @@ export const DataSourceInlineEditIdentifierTypes: FC<
       <p>The different units you use to split traffic in an experiment.</p>
 
       {userIdTypes.map(({ userIdType, description, attributes }, idx) => {
-        const deleteDisabled = isLockedHashAttributeType(userIdType);
+        const deleteDisabled = isEventForwarderManagedType(userIdType);
 
         return (
           <Card key={userIdType} mt="3">

--- a/packages/shared/src/util/datasource.ts
+++ b/packages/shared/src/util/datasource.ts
@@ -6,6 +6,7 @@ export {
   getEventForwarderSinkTypeForDatasource,
   getUserIdTypesToAdd,
   isEventForwarderAllowedUserIdTypesChange,
+  isEventForwarderManagedIdentifierId,
   isHashAttributeUserIdType,
   mergeUserIdTypes,
   supportsEventForwarder,

--- a/packages/shared/src/util/event-forwarder-datasource.ts
+++ b/packages/shared/src/util/event-forwarder-datasource.ts
@@ -19,6 +19,36 @@ export type EventForwarderDatasourceParams =
 export const EVENT_FORWARDER_MANAGED_IDENTIFIER_TYPE_DESCRIPTION =
   "Managed by Event Forwarder.";
 
+// Event Forwarder managed identifier types (and the exposure queries that feed
+// them) are prefixed so they never collide with identifier types / queries a
+// user already created for the same hash attribute. The prefix is applied once,
+// here, when building the identifier type from the attribute. The underlying
+// source attribute is recoverable by stripping the prefix, which the SQL
+// generators use so extraction still reads the real attribute.
+export const EVENT_FORWARDER_MANAGED_IDENTIFIER_ID_PREFIX = "ef_";
+
+export function buildEventForwarderManagedIdentifierId(
+  attributeProperty: string,
+): string {
+  return `${EVENT_FORWARDER_MANAGED_IDENTIFIER_ID_PREFIX}${attributeProperty}`;
+}
+
+export function isEventForwarderManagedIdentifierId(
+  userIdType: string,
+): boolean {
+  return userIdType.startsWith(EVENT_FORWARDER_MANAGED_IDENTIFIER_ID_PREFIX);
+}
+
+// Resolves the source SDK attribute for a managed identifier id (e.g.
+// "ef_user_id" -> "user_id"). Non-managed identifier types are returned as-is.
+export function getEventForwarderManagedIdentifierSourceAttribute(
+  userIdType: string,
+): string {
+  return isEventForwarderManagedIdentifierId(userIdType)
+    ? userIdType.slice(EVENT_FORWARDER_MANAGED_IDENTIFIER_ID_PREFIX.length)
+    : userIdType;
+}
+
 export function getEventForwarderSinkTypeForDatasource(datasource: {
   type: DataSourceType;
 }): EventForwarderSinkType | null {
@@ -73,7 +103,7 @@ export function buildUserIdTypesFromAttributeSchema(
     .filter((a) => a.hashAttribute && !a.archived)
     .filter((a) => attributeMatchesDatasourceProjects(a, datasourceProjects))
     .map((a) => ({
-      userIdType: a.property,
+      userIdType: buildEventForwarderManagedIdentifierId(a.property),
       description: EVENT_FORWARDER_MANAGED_IDENTIFIER_TYPE_DESCRIPTION,
       attributes: [a.property],
     }));
@@ -84,11 +114,15 @@ export function isHashAttributeUserIdType(
   attributeSchema: SDKAttributeSchema,
   datasourceProjects?: string[],
 ): boolean {
+  // Managed identifier types are prefixed (e.g. "ef_user_id"); resolve back to
+  // the source attribute so the hash-attribute lookup still matches.
+  const sourceAttribute =
+    getEventForwarderManagedIdentifierSourceAttribute(userIdType).toLowerCase();
   return attributeSchema.some(
     (attribute) =>
       attribute.hashAttribute &&
       !attribute.archived &&
-      attribute.property.toLowerCase() === userIdType.toLowerCase() &&
+      attribute.property.toLowerCase() === sourceAttribute &&
       attributeMatchesDatasourceProjects(attribute, datasourceProjects),
   );
 }

--- a/packages/shared/src/util/event-forwarder-datasource.ts
+++ b/packages/shared/src/util/event-forwarder-datasource.ts
@@ -130,15 +130,12 @@ export function isHashAttributeUserIdType(
 export function isEventForwarderAllowedUserIdTypesChange(
   existing: UserIdType[],
   updated: UserIdType[],
-  attributeSchema: SDKAttributeSchema,
-  datasourceProjects?: string[],
 ): boolean {
+  // Only Event Forwarder managed identifier types (prefixed with `ef_`) are
+  // locked. User-created identifier types that happen to use the same hash
+  // attribute remain editable / deletable.
   const lockedExisting = existing.filter((item) =>
-    isHashAttributeUserIdType(
-      item.userIdType,
-      attributeSchema,
-      datasourceProjects,
-    ),
+    isEventForwarderManagedIdentifierId(item.userIdType),
   );
 
   return lockedExisting.every((locked) => {

--- a/packages/shared/src/util/event-forwarder-datasource.ts
+++ b/packages/shared/src/util/event-forwarder-datasource.ts
@@ -30,6 +30,12 @@ export const EVENT_FORWARDER_MANAGED_IDENTIFIER_ID_PREFIX = "ef_";
 export function buildEventForwarderManagedIdentifierId(
   attributeProperty: string,
 ): string {
+  // The prefix is applied unconditionally — even when the source attribute
+  // already starts with "ef_". This is intentional: an attribute literally
+  // named "ef_userId" must not collapse into the same managed id a user could
+  // have created themselves, and the source attribute is recovered by stripping
+  // exactly one prefix (see getEventForwarderManagedIdentifierSourceAttribute),
+  // so "ef_userId" -> "ef_ef_userId" -> "ef_userId" round-trips correctly.
   return `${EVENT_FORWARDER_MANAGED_IDENTIFIER_ID_PREFIX}${attributeProperty}`;
 }
 

--- a/packages/shared/src/util/event-forwarder-fact-table.ts
+++ b/packages/shared/src/util/event-forwarder-fact-table.ts
@@ -4,7 +4,10 @@ import type {
   SDKAttributeSchema,
   SDKAttributeType,
 } from "shared/types/organization";
-import { attributeMatchesDatasourceProjects } from "./event-forwarder-datasource";
+import {
+  attributeMatchesDatasourceProjects,
+  getEventForwarderManagedIdentifierSourceAttribute,
+} from "./event-forwarder-datasource";
 import {
   resolveBigQueryEventForwarderTableNames,
   resolveSnowflakeEventForwarderTableNames,
@@ -336,19 +339,24 @@ function buildEventForwarderEventsFactTableSelect({
   const attributeColumns: string[] = [];
 
   for (const userIdType of userIdTypes) {
+    // The projected column (alias / join key) keeps the managed identifier id
+    // (e.g. "ef_user_id"), but the value is extracted from the real source
+    // attribute ("user_id"). Non-managed identifier types resolve to themselves.
     const fieldName = sanitizeEventForwarderAvroFieldName(userIdType);
     const key = fieldName.toLowerCase();
     if (projectedFieldKeys.has(key)) {
       continue;
     }
     projectedFieldKeys.add(key);
+    const sourceAttribute =
+      getEventForwarderManagedIdentifierSourceAttribute(userIdType);
     const matchingAttribute = findEventForwarderEventsFactTableAttribute(
       attributes,
-      userIdType,
+      sourceAttribute,
     );
     const valueSql = buildEventForwarderNestedAttributeValueSql({
       sinkType,
-      attributeName: matchingAttribute?.property ?? userIdType,
+      attributeName: matchingAttribute?.property ?? sourceAttribute,
       valueDatatype: matchingAttribute
         ? getEventForwarderFactTableColumnDatatype(matchingAttribute)
         : "string",
@@ -449,11 +457,12 @@ export function buildEventForwarderEventsFactTableColumns(
 
   const seen = new Set<string>();
   const jsonFields: CreateColumnProps["jsonFields"] = {};
-
-  for (const attribute of getEventForwarderEventsFactTableAttributes(
+  const attributes = getEventForwarderEventsFactTableAttributes(
     attributeSchema,
     datasourceProjects,
-  )) {
+  );
+
+  for (const attribute of attributes) {
     const fieldName = sanitizeEventForwarderAvroFieldName(attribute.property);
     const key = fieldName.toLowerCase();
     if (seen.has(key)) {
@@ -472,7 +481,19 @@ export function buildEventForwarderEventsFactTableColumns(
       continue;
     }
     seen.add(key);
-    jsonFields[fieldName] = { datatype: "string" };
+    // Keep the column datatype aligned with the SELECT: a managed identifier id
+    // (e.g. "ef_user_id") inherits the datatype of its source attribute.
+    const sourceAttribute =
+      getEventForwarderManagedIdentifierSourceAttribute(userIdType);
+    const matchingAttribute = findEventForwarderEventsFactTableAttribute(
+      attributes,
+      sourceAttribute,
+    );
+    jsonFields[fieldName] = {
+      datatype: matchingAttribute
+        ? getEventForwarderFactTableColumnDatatype(matchingAttribute)
+        : "string",
+    };
   }
 
   return [

--- a/packages/shared/src/util/event-forwarder-warehouse-queries.ts
+++ b/packages/shared/src/util/event-forwarder-warehouse-queries.ts
@@ -17,6 +17,10 @@ import {
   EVENT_FORWARDER_AVRO_PARTITION_FIELD,
   quoteBigQueryIdentifier,
 } from "./event-forwarder-fact-table";
+import {
+  buildEventForwarderManagedIdentifierId,
+  getEventForwarderManagedIdentifierSourceAttribute,
+} from "./event-forwarder-datasource";
 
 export const EVENT_FORWARDER_EXPERIMENT_VIEWED_TABLE =
   EVENT_FORWARDER_EXPERIMENT_VIEWED_TABLE_SUFFIX;
@@ -26,24 +30,6 @@ export const EVENT_FORWARDER_MANAGED_EXPOSURE_QUERY_DESCRIPTION =
   "Managed by Event Forwarder and updated when the linked Identifier type changes.";
 export const EVENT_FORWARDER_MANAGED_FEATURE_USAGE_QUERY_DESCRIPTION =
   "Managed by Event Forwarder for feature usage events.";
-
-// Prefix the id/name of Event Forwarder managed exposure queries so they never
-// collide with queries a user already created for the same identifier. The
-// userIdType is left untouched so the managed query still resolves against the
-// same identifier type and attributes.
-export const EVENT_FORWARDER_MANAGED_EXPOSURE_QUERY_ID_PREFIX = "ef_";
-
-export function buildEventForwarderManagedExposureQueryId(
-  userIdType: string,
-): string {
-  return `${EVENT_FORWARDER_MANAGED_EXPOSURE_QUERY_ID_PREFIX}${userIdType}`;
-}
-
-export function buildEventForwarderManagedExposureQueryName(
-  userIdType: string,
-): string {
-  return `Event Forwarder: ${userIdType}`;
-}
 
 export type BuildEventForwarderExperimentViewedTableRefParams =
   | {
@@ -114,7 +100,10 @@ function findHashAttributeForUserIdType(
   userIdType: string,
   attributeSchema?: SDKAttributeSchema,
 ): SDKAttribute | undefined {
-  const normalized = userIdType.toLowerCase();
+  // userIdType is the managed identifier id (e.g. "ef_user_id"); resolve back to
+  // the source attribute before matching the schema.
+  const normalized =
+    getEventForwarderManagedIdentifierSourceAttribute(userIdType).toLowerCase();
   return attributeSchema?.find(
     (attribute) =>
       attribute.hashAttribute &&
@@ -157,9 +146,14 @@ export function buildEventForwarderExposureQuerySql({
   userIdType: string;
   attributeDatatype?: SDKAttributeType;
 }): string {
+  // The column alias / join key is the (prefixed) managed identifier id, but the
+  // value is extracted from the real source attribute (e.g. "ef_user_id" reads
+  // the "user_id" attribute).
+  const sourceAttribute =
+    getEventForwarderManagedIdentifierSourceAttribute(userIdType);
   const attributeValueSql = buildEventForwarderAttributeValueSql({
     sinkType,
-    userIdType,
+    userIdType: sourceAttribute,
     attributeDatatype,
   });
 
@@ -198,10 +192,12 @@ export function generateEventForwarderExposureQueries(
       attributeSchema,
     );
 
+    // userIdType is already the (prefixed) managed identifier id, so the
+    // exposure query id/name mirror it directly.
     return {
-      id: buildEventForwarderManagedExposureQueryId(userIdType),
+      id: userIdType,
       userIdType,
-      name: buildEventForwarderManagedExposureQueryName(userIdType),
+      name: userIdType,
       description: EVENT_FORWARDER_MANAGED_EXPOSURE_QUERY_DESCRIPTION,
       dimensions: [],
       managedBy: "api" as const,
@@ -279,13 +275,16 @@ export function refreshEventForwarderManagedExposureQuery(
     }
 
     found = true;
-    const userIdType = attribute.property;
+    // Re-derive the managed identifier id from the (possibly renamed) attribute.
+    const userIdType = buildEventForwarderManagedIdentifierId(
+      attribute.property,
+    );
 
     return {
       ...query,
-      id: buildEventForwarderManagedExposureQueryId(userIdType),
+      id: userIdType,
       userIdType,
-      name: buildEventForwarderManagedExposureQueryName(userIdType),
+      name: userIdType,
       query: buildEventForwarderExposureQuerySql({
         sinkType: params.sinkType,
         tableRef,

--- a/packages/shared/src/util/event-forwarder-warehouse-queries.ts
+++ b/packages/shared/src/util/event-forwarder-warehouse-queries.ts
@@ -27,6 +27,24 @@ export const EVENT_FORWARDER_MANAGED_EXPOSURE_QUERY_DESCRIPTION =
 export const EVENT_FORWARDER_MANAGED_FEATURE_USAGE_QUERY_DESCRIPTION =
   "Managed by Event Forwarder for feature usage events.";
 
+// Prefix the id/name of Event Forwarder managed exposure queries so they never
+// collide with queries a user already created for the same identifier. The
+// userIdType is left untouched so the managed query still resolves against the
+// same identifier type and attributes.
+export const EVENT_FORWARDER_MANAGED_EXPOSURE_QUERY_ID_PREFIX = "ef_";
+
+export function buildEventForwarderManagedExposureQueryId(
+  userIdType: string,
+): string {
+  return `${EVENT_FORWARDER_MANAGED_EXPOSURE_QUERY_ID_PREFIX}${userIdType}`;
+}
+
+export function buildEventForwarderManagedExposureQueryName(
+  userIdType: string,
+): string {
+  return `Event Forwarder: ${userIdType}`;
+}
+
 export type BuildEventForwarderExperimentViewedTableRefParams =
   | {
       sinkType: "bigquery";
@@ -181,9 +199,9 @@ export function generateEventForwarderExposureQueries(
     );
 
     return {
-      id: userIdType,
+      id: buildEventForwarderManagedExposureQueryId(userIdType),
       userIdType,
-      name: userIdType,
+      name: buildEventForwarderManagedExposureQueryName(userIdType),
       description: EVENT_FORWARDER_MANAGED_EXPOSURE_QUERY_DESCRIPTION,
       dimensions: [],
       managedBy: "api" as const,
@@ -203,12 +221,16 @@ export function isEventForwarderManagedExposureQuery(
   return query.managedBy === "api";
 }
 
-export function exposureQueryExistsForUserIdType(
+export function eventForwarderManagedExposureQueryExistsForUserIdType(
   exposureQueries: ExposureQuery[],
   userIdType: string,
 ): boolean {
   const normalized = userIdType.toLowerCase();
-  return exposureQueries.some((q) => q.userIdType.toLowerCase() === normalized);
+  return exposureQueries.some(
+    (q) =>
+      isEventForwarderManagedExposureQuery(q) &&
+      q.userIdType.toLowerCase() === normalized,
+  );
 }
 
 export function mergeEventForwarderExposureQueries(
@@ -217,8 +239,15 @@ export function mergeEventForwarderExposureQueries(
   params: GenerateEventForwarderExposureQueriesParams,
   attributeSchema?: SDKAttributeSchema,
 ): ExposureQuery[] {
+  // Only skip identifiers that already have a managed query. A user's own
+  // (non-managed) query for the same identifier no longer blocks us, since the
+  // prefixed id keeps the managed query from colliding with theirs.
   const missing = userIdTypes.filter(
-    (userIdType) => !exposureQueryExistsForUserIdType(existing, userIdType),
+    (userIdType) =>
+      !eventForwarderManagedExposureQueryExistsForUserIdType(
+        existing,
+        userIdType,
+      ),
   );
 
   if (missing.length === 0) {
@@ -254,9 +283,9 @@ export function refreshEventForwarderManagedExposureQuery(
 
     return {
       ...query,
-      id: userIdType,
+      id: buildEventForwarderManagedExposureQueryId(userIdType),
       userIdType,
-      name: userIdType,
+      name: buildEventForwarderManagedExposureQueryName(userIdType),
       query: buildEventForwarderExposureQuerySql({
         sinkType: params.sinkType,
         tableRef,

--- a/packages/shared/test/util/event-forwarder-datasource.test.ts
+++ b/packages/shared/test/util/event-forwarder-datasource.test.ts
@@ -115,7 +115,7 @@ describe("buildUserIdTypesFromAttributeSchema", () => {
 
     expect(result).toEqual([
       {
-        userIdType: "id",
+        userIdType: "ef_id",
         description: EVENT_FORWARDER_MANAGED_IDENTIFIER_TYPE_DESCRIPTION,
         attributes: ["id"],
       },
@@ -138,7 +138,7 @@ describe("buildUserIdTypesFromAttributeSchema", () => {
 
     expect(result).toEqual([
       {
-        userIdType: "id",
+        userIdType: "ef_id",
         description: EVENT_FORWARDER_MANAGED_IDENTIFIER_TYPE_DESCRIPTION,
         attributes: ["id"],
       },

--- a/packages/shared/test/util/event-forwarder-datasource.test.ts
+++ b/packages/shared/test/util/event-forwarder-datasource.test.ts
@@ -179,13 +179,18 @@ describe("isHashAttributeUserIdType", () => {
 });
 
 describe("isEventForwarderAllowedUserIdTypesChange", () => {
-  const schema = [
-    { property: "user_id", datatype: "string" as const, hashAttribute: true },
-  ];
   const existing = [
     {
+      // User-created identifier type that uses the same hash attribute as the
+      // managed one. This must stay editable / deletable.
       userIdType: "user_id",
       description: "Logged-in user",
+      attributes: ["user_id"],
+    },
+    {
+      // Event Forwarder managed identifier type (prefixed with `ef_`).
+      userIdType: "ef_user_id",
+      description: "Managed by Event Forwarder.",
       attributes: ["user_id"],
     },
     {
@@ -195,99 +200,93 @@ describe("isEventForwarderAllowedUserIdTypesChange", () => {
     },
   ];
 
-  it("allows description-only changes to hash-attribute identifier types", () => {
+  it("allows description-only changes to managed identifier types", () => {
     expect(
-      isEventForwarderAllowedUserIdTypesChange(
-        existing,
-        [
-          {
-            userIdType: "user_id",
-            description: "Updated description",
-            attributes: ["user_id"],
-          },
-          existing[1],
-        ],
-        schema,
-      ),
+      isEventForwarderAllowedUserIdTypesChange(existing, [
+        existing[0],
+        {
+          userIdType: "ef_user_id",
+          description: "Updated description",
+          attributes: ["user_id"],
+        },
+        existing[2],
+      ]),
     ).toBe(true);
   });
 
-  it("allows editing non-hash-attribute identifier types", () => {
+  it("allows editing user-created identifier types that use a hash attribute", () => {
     expect(
-      isEventForwarderAllowedUserIdTypesChange(
-        existing,
-        [
-          {
-            userIdType: "user_id",
-            description: "Logged-in user",
-            attributes: ["user_id"],
-          },
-          {
-            userIdType: "account_id",
-            description: "Renamed",
-            attributes: ["account_id"],
-          },
-        ],
-        schema,
-      ),
+      isEventForwarderAllowedUserIdTypesChange(existing, [
+        {
+          userIdType: "account_id",
+          description: "Renamed",
+          attributes: ["account_id"],
+        },
+        existing[1],
+        existing[2],
+      ]),
     ).toBe(true);
   });
 
-  it("allows deleting non-hash-attribute identifier types", () => {
+  it("allows deleting user-created identifier types", () => {
     expect(
-      isEventForwarderAllowedUserIdTypesChange(existing, [existing[0]], schema),
+      isEventForwarderAllowedUserIdTypesChange(existing, [
+        existing[1],
+        existing[2],
+      ]),
     ).toBe(true);
   });
 
-  it("rejects deleting hash-attribute identifier types", () => {
+  it("allows deleting non-managed identifier types", () => {
     expect(
-      isEventForwarderAllowedUserIdTypesChange(existing, [existing[1]], schema),
+      isEventForwarderAllowedUserIdTypesChange(existing, [
+        existing[0],
+        existing[1],
+      ]),
+    ).toBe(true);
+  });
+
+  it("rejects deleting managed identifier types", () => {
+    expect(
+      isEventForwarderAllowedUserIdTypesChange(existing, [
+        existing[0],
+        existing[2],
+      ]),
     ).toBe(false);
   });
 
   it("allows adding new identifier types", () => {
     expect(
-      isEventForwarderAllowedUserIdTypesChange(
-        existing,
-        [...existing, { userIdType: "session_id", description: "Session" }],
-        schema,
-      ),
+      isEventForwarderAllowedUserIdTypesChange(existing, [
+        ...existing,
+        { userIdType: "session_id", description: "Session" },
+      ]),
     ).toBe(true);
   });
 
-  it("rejects structural changes to hash-attribute identifier types", () => {
+  it("rejects structural changes to managed identifier types", () => {
     expect(
-      isEventForwarderAllowedUserIdTypesChange(
-        existing,
-        [
-          {
-            userIdType: "account_id",
-            description: "Logged-in user",
-            attributes: ["user_id"],
-          },
-          existing[1],
-        ],
-        schema,
-      ),
+      isEventForwarderAllowedUserIdTypesChange(existing, [
+        existing[0],
+        {
+          userIdType: "ef_account_id",
+          description: "Managed by Event Forwarder.",
+          attributes: ["user_id"],
+        },
+        existing[2],
+      ]),
     ).toBe(false);
 
     expect(
-      isEventForwarderAllowedUserIdTypesChange(
-        existing,
-        [
-          {
-            userIdType: "user_id",
-            description: "",
-            attributes: ["device_id"],
-          },
-          existing[1],
-        ],
-        schema,
-      ),
-    ).toBe(false);
-
-    expect(
-      isEventForwarderAllowedUserIdTypesChange(existing, [existing[1]], schema),
+      isEventForwarderAllowedUserIdTypesChange(existing, [
+        existing[0],
+        {
+          userIdType: "ef_user_id",
+          description: "Managed by Event Forwarder.",
+          attributes: ["device_id"],
+        },
+        existing[2],
+      ]),
     ).toBe(false);
   });
 });

--- a/packages/shared/test/util/event-forwarder-datasource.test.ts
+++ b/packages/shared/test/util/event-forwarder-datasource.test.ts
@@ -1,7 +1,9 @@
 import {
   EVENT_FORWARDER_MANAGED_IDENTIFIER_TYPE_DESCRIPTION,
   attributeMatchesDatasourceProjects,
+  buildEventForwarderManagedIdentifierId,
   buildUserIdTypesFromAttributeSchema,
+  getEventForwarderManagedIdentifierSourceAttribute,
   getEventForwarderDatasourceParams,
   getEventForwarderSinkTypeForDatasource,
   getUserIdTypesToAdd,
@@ -157,6 +159,27 @@ describe("buildUserIdTypesFromAttributeSchema", () => {
 
     expect(result[0]?.description).toBe(
       EVENT_FORWARDER_MANAGED_IDENTIFIER_TYPE_DESCRIPTION,
+    );
+  });
+});
+
+describe("buildEventForwarderManagedIdentifierId", () => {
+  it("prefixes the source attribute", () => {
+    expect(buildEventForwarderManagedIdentifierId("user_id")).toBe(
+      "ef_user_id",
+    );
+  });
+
+  it("double-prefixes an attribute that already starts with the prefix so it stays distinct from a user-created identifier", () => {
+    expect(buildEventForwarderManagedIdentifierId("ef_userId")).toBe(
+      "ef_ef_userId",
+    );
+  });
+
+  it("round-trips back to the source attribute by stripping exactly one prefix", () => {
+    const managedId = buildEventForwarderManagedIdentifierId("ef_userId");
+    expect(getEventForwarderManagedIdentifierSourceAttribute(managedId)).toBe(
+      "ef_userId",
     );
   });
 });

--- a/packages/shared/test/util/event-forwarder-fact-table.test.ts
+++ b/packages/shared/test/util/event-forwarder-fact-table.test.ts
@@ -182,6 +182,25 @@ WHERE ${EVENT_FORWARDER_AVRO_PARTITION_FIELD} BETWEEN '{{startDate}}' AND '{{end
     );
   });
 
+  it("projects a prefixed managed identifier id, extracting its source attribute", () => {
+    const sql = buildEventForwarderEventsFactTableSql({
+      sinkType: "bigquery",
+      projectId: "my-project",
+      dataset: "analytics_123",
+      tablePrefix: "gb",
+      // Managed identifier id is prefixed; the column alias keeps the id while the
+      // value is read from the underlying "employee_id" attribute.
+      userIdTypes: ["ef_employee_id"],
+      attributeSchema: [
+        { property: "employee_id", datatype: "number", hashAttribute: true },
+      ],
+    });
+
+    expect(sql).toContain(
+      `SAFE_CAST(JSON_VALUE(\`attributes\`, '$."employee_id"') AS FLOAT64) AS ef_employee_id`,
+    );
+  });
+
   it("builds Snowflake table reference", () => {
     expect(
       buildSnowflakeEventForwarderTableReference(

--- a/packages/shared/test/util/event-forwarder-warehouse-queries.test.ts
+++ b/packages/shared/test/util/event-forwarder-warehouse-queries.test.ts
@@ -1,3 +1,4 @@
+import type { ExposureQuery } from "shared/types/datasource";
 import {
   buildEventForwarderAttributeValueSql,
   buildEventForwarderExperimentViewedTableReference,
@@ -7,8 +8,8 @@ import {
   buildEventForwarderFeatureUsageTableReference,
   EVENT_FORWARDER_MANAGED_EXPOSURE_QUERY_DESCRIPTION,
   EVENT_FORWARDER_MANAGED_FEATURE_USAGE_QUERY_DESCRIPTION,
+  eventForwarderManagedExposureQueryExistsForUserIdType,
   eventForwarderManagedFeatureUsageQueryExists,
-  exposureQueryExistsForUserIdType,
   generateEventForwarderExposureQueries,
   getActiveFeatureUsageQuery,
   isEventForwarderManagedExposureQuery,
@@ -165,8 +166,10 @@ describe("generateEventForwarderExposureQueries", () => {
     );
 
     expect(queries).toHaveLength(2);
-    expect(queries[0].id).toBe("user_id");
+    expect(queries[0].id).toBe("ef_user_id");
     expect(queries[0].userIdType).toBe("user_id");
+    expect(queries[0].name).toBe("Event Forwarder: user_id");
+    expect(queries[1].id).toBe("ef_anonymous_id");
     expect(queries[1].userIdType).toBe("anonymous_id");
     expect(queries[0].description).toBe(
       EVENT_FORWARDER_MANAGED_EXPOSURE_QUERY_DESCRIPTION,
@@ -210,7 +213,12 @@ describe("mergeEventForwarderExposureQueries", () => {
       tablePrefix: "GB",
     });
 
-    expect(exposureQueryExistsForUserIdType(existing, "user_id")).toBe(true);
+    expect(
+      eventForwarderManagedExposureQueryExistsForUserIdType(
+        existing,
+        "user_id",
+      ),
+    ).toBe(true);
 
     const merged = mergeEventForwarderExposureQueries(existing, ["user_id"], {
       sinkType: "snowflake",
@@ -220,6 +228,33 @@ describe("mergeEventForwarderExposureQueries", () => {
     });
 
     expect(merged).toHaveLength(1);
+  });
+
+  it("adds a managed query alongside a user's own query for the same identifier", () => {
+    const existing: ExposureQuery[] = [
+      {
+        id: "user_id",
+        name: "My custom query",
+        userIdType: "user_id",
+        dimensions: [],
+        query: "SELECT custom",
+      },
+    ];
+
+    const merged = mergeEventForwarderExposureQueries(existing, ["user_id"], {
+      sinkType: "snowflake",
+      database: "DB",
+      schema: "PUBLIC",
+      tablePrefix: "GB",
+    });
+
+    expect(merged).toHaveLength(2);
+    // The user's own query is preserved untouched...
+    expect(merged[0]).toEqual(existing[0]);
+    // ...and the managed query is added with a prefixed id so it doesn't collide.
+    expect(merged[1].id).toBe("ef_user_id");
+    expect(merged[1].userIdType).toBe("user_id");
+    expect(merged[1].managedBy).toBe("api");
   });
 });
 
@@ -248,8 +283,9 @@ describe("refreshEventForwarderManagedExposureQuery", () => {
       },
     );
 
-    expect(refreshed[0].id).toBe("account_id");
+    expect(refreshed[0].id).toBe("ef_account_id");
     expect(refreshed[0].userIdType).toBe("account_id");
+    expect(refreshed[0].name).toBe("Event Forwarder: account_id");
     expect(refreshed[0].query).toContain("account_id");
     expect(refreshed[0].query).toContain("AS FLOAT64");
   });

--- a/packages/shared/test/util/event-forwarder-warehouse-queries.test.ts
+++ b/packages/shared/test/util/event-forwarder-warehouse-queries.test.ts
@@ -154,9 +154,11 @@ describe("buildEventForwarderExposureQuerySql", () => {
 });
 
 describe("generateEventForwarderExposureQueries", () => {
-  it("creates one exposure query per identifier type", () => {
+  it("creates one exposure query per managed identifier id", () => {
+    // Callers pass the prefixed managed identifier ids; id/userIdType/name mirror
+    // them, while the SQL extracts the real source attribute.
     const queries = generateEventForwarderExposureQueries(
-      ["user_id", "anonymous_id"],
+      ["ef_user_id", "ef_anonymous_id"],
       {
         sinkType: "bigquery",
         projectId: "proj",
@@ -167,10 +169,13 @@ describe("generateEventForwarderExposureQueries", () => {
 
     expect(queries).toHaveLength(2);
     expect(queries[0].id).toBe("ef_user_id");
-    expect(queries[0].userIdType).toBe("user_id");
-    expect(queries[0].name).toBe("Event Forwarder: user_id");
+    expect(queries[0].userIdType).toBe("ef_user_id");
+    expect(queries[0].name).toBe("ef_user_id");
     expect(queries[1].id).toBe("ef_anonymous_id");
-    expect(queries[1].userIdType).toBe("anonymous_id");
+    expect(queries[1].userIdType).toBe("ef_anonymous_id");
+    // Alias is the managed id; extraction reads the real attribute.
+    expect(queries[0].query).toContain("AS `ef_user_id`");
+    expect(queries[0].query).toContain('$."user_id"');
     expect(queries[0].description).toBe(
       EVENT_FORWARDER_MANAGED_EXPOSURE_QUERY_DESCRIPTION,
     );
@@ -241,26 +246,30 @@ describe("mergeEventForwarderExposureQueries", () => {
       },
     ];
 
-    const merged = mergeEventForwarderExposureQueries(existing, ["user_id"], {
-      sinkType: "snowflake",
-      database: "DB",
-      schema: "PUBLIC",
-      tablePrefix: "GB",
-    });
+    const merged = mergeEventForwarderExposureQueries(
+      existing,
+      ["ef_user_id"],
+      {
+        sinkType: "snowflake",
+        database: "DB",
+        schema: "PUBLIC",
+        tablePrefix: "GB",
+      },
+    );
 
     expect(merged).toHaveLength(2);
     // The user's own query is preserved untouched...
     expect(merged[0]).toEqual(existing[0]);
-    // ...and the managed query is added with a prefixed id so it doesn't collide.
+    // ...and the managed query is added with the prefixed id so it doesn't collide.
     expect(merged[1].id).toBe("ef_user_id");
-    expect(merged[1].userIdType).toBe("user_id");
+    expect(merged[1].userIdType).toBe("ef_user_id");
     expect(merged[1].managedBy).toBe("api");
   });
 });
 
 describe("refreshEventForwarderManagedExposureQuery", () => {
   it("renames managed exposure query and regenerates typed SQL", () => {
-    const existing = generateEventForwarderExposureQueries(["user_id"], {
+    const existing = generateEventForwarderExposureQueries(["ef_user_id"], {
       sinkType: "bigquery",
       projectId: "proj",
       dataset: "ds",
@@ -269,7 +278,7 @@ describe("refreshEventForwarderManagedExposureQuery", () => {
 
     const refreshed = refreshEventForwarderManagedExposureQuery(
       existing,
-      "user_id",
+      "ef_user_id",
       {
         property: "account_id",
         datatype: "number",
@@ -284,9 +293,11 @@ describe("refreshEventForwarderManagedExposureQuery", () => {
     );
 
     expect(refreshed[0].id).toBe("ef_account_id");
-    expect(refreshed[0].userIdType).toBe("account_id");
-    expect(refreshed[0].name).toBe("Event Forwarder: account_id");
-    expect(refreshed[0].query).toContain("account_id");
+    expect(refreshed[0].userIdType).toBe("ef_account_id");
+    expect(refreshed[0].name).toBe("ef_account_id");
+    // Alias is the managed id; extraction reads the real account_id attribute.
+    expect(refreshed[0].query).toContain("AS `ef_account_id`");
+    expect(refreshed[0].query).toContain('$."account_id"');
     expect(refreshed[0].query).toContain("AS FLOAT64");
   });
 });
@@ -294,7 +305,7 @@ describe("refreshEventForwarderManagedExposureQuery", () => {
 describe("reconcileEventForwarderManagedExposureQueries", () => {
   it("rebuilds managed queries from desired hash attributes", () => {
     const existing = [
-      ...generateEventForwarderExposureQueries(["user_id", "legacy_id"], {
+      ...generateEventForwarderExposureQueries(["ef_user_id", "ef_legacy_id"], {
         sinkType: "bigquery",
         projectId: "proj",
         dataset: "ds",
@@ -311,7 +322,7 @@ describe("reconcileEventForwarderManagedExposureQueries", () => {
 
     const reconciled = reconcileEventForwarderManagedExposureQueries({
       existing,
-      userIdTypes: ["account_id", "device_id"],
+      userIdTypes: ["ef_account_id", "ef_device_id"],
       params: {
         sinkType: "bigquery",
         projectId: "proj",
@@ -336,14 +347,15 @@ describe("reconcileEventForwarderManagedExposureQueries", () => {
     expect(reconciled[0].id).toBe("custom_query");
     expect(reconciled.map((query) => query.userIdType)).toEqual([
       "custom_id",
-      "account_id",
-      "device_id",
+      "ef_account_id",
+      "ef_device_id",
     ]);
     expect(reconciled[1].managedBy).toBe("api");
+    // account_id is a number attribute, resolved by stripping the ef_ prefix.
     expect(reconciled[1].query).toContain("AS FLOAT64");
-    expect(reconciled.some((query) => query.userIdType === "legacy_id")).toBe(
-      false,
-    );
+    expect(
+      reconciled.some((query) => query.userIdType === "ef_legacy_id"),
+    ).toBe(false);
   });
 
   it("preserves queries without the managed marker", () => {


### PR DESCRIPTION
### Features and Changes
- Add prefix to EF managed Identifier Types
- This is to avoid duplicated 

### Screenshots

<img width="1685" height="961" alt="Screenshot 2026-06-15 at 13 47 42" src="https://github.com/user-attachments/assets/288d0625-6725-4fe9-81be-96511cda9ee2" />

