### PR TITLE
feat(experiments): flag and confirm stale dimension breakdown refreshes

### DIFF
--- a/packages/front-end/components/Experiment/RefreshResultsButton.tsx
+++ b/packages/front-end/components/Experiment/RefreshResultsButton.tsx
@@ -204,11 +204,13 @@ export default function RefreshResultsButton<
           setError={(error) => setRefreshError(error ?? "")}
           useRadixButton={true}
           radixVariant="outline"
+          customValidation={customValidation}
         />
       ) : shouldRenderSafeRolloutButton ? (
         <SafeRolloutRefreshSnapshotButton
           mutate={mutate}
           safeRollout={safeRollout}
+          customValidation={customValidation}
         />
       ) : null}
     </>

--- a/packages/front-end/components/Experiment/RefreshResultsButton.tsx
+++ b/packages/front-end/components/Experiment/RefreshResultsButton.tsx
@@ -40,6 +40,9 @@ export interface RefreshResultsButtonProps<
     datasourceType: string | null;
   };
   onSuccess?: () => void;
+  // Return false to abort the refresh (e.g. to open a confirmation modal
+  // instead). Mirrors Modal's customValidation. Side effects are allowed.
+  customValidation?: () => boolean | Promise<boolean>;
   // Experiment/holdout-specific props
   experiment?: ExperimentInterfaceStringDates;
   phase?: number;
@@ -67,6 +70,7 @@ export default function RefreshResultsButton<
   setRefreshError,
   experimentSnapshotTrackingProps,
   onSuccess,
+  customValidation,
   experiment,
   phase,
   dimension,
@@ -104,6 +108,65 @@ export default function RefreshResultsButton<
       ? `/safe-rollout/${entityId}/snapshot`
       : `/experiment/${entityId}/snapshot`;
 
+  // Precomputed dimensions are computed as part of a standard snapshot, so we
+  // don't need to pass them to the backend for a new snapshot query
+  const snapshotDimension = isDimensionPrecomputed(
+    dimension,
+    getHonoredPrecomputedUnitDimensionIds(
+      experiment?.precomputedUnitDimensionIds,
+      experiment?.datasource
+        ? getDatasourceById(experiment.datasource)
+        : undefined,
+      hasCommercialFeature("pipeline-mode"),
+    ),
+  )
+    ? ""
+    : (dimension ?? "");
+
+  // Kicks off a new snapshot query for the given dimension ("" = main results).
+  const runSnapshot = async (dimensionToUse: string) => {
+    const body =
+      entityType === "experiment" || entityType === "holdout"
+        ? JSON.stringify({
+            phase: phase ?? 0,
+            dimension: dimensionToUse,
+          })
+        : undefined;
+
+    try {
+      if (entityType === "safe-rollout") {
+        await apiCall<{ snapshot: SafeRolloutSnapshotInterface }>(
+          snapshotEndpoint,
+          { method: "POST" },
+        );
+      } else {
+        const res = await apiCall<{
+          snapshot: ExperimentSnapshotInterface;
+        }>(snapshotEndpoint, {
+          method: "POST",
+          ...(body && { body }),
+        });
+        if (experimentSnapshotTrackingProps) {
+          trackSnapshot(
+            "create",
+            experimentSnapshotTrackingProps.trackingSource,
+            experimentSnapshotTrackingProps.datasourceType,
+            res.snapshot,
+          );
+        }
+      }
+      onSuccess?.();
+      setRefreshError("");
+    } catch (e) {
+      setRefreshError(e.message);
+    } finally {
+      // Always refresh, regardless of success or failure
+      // to give the UI a chance to catch up
+      mutate();
+      mutateAdditional?.();
+    }
+  };
+
   return (
     <>
       {shouldUseRunQueriesButton ? (
@@ -122,60 +185,11 @@ export default function RefreshResultsButton<
           useRadixButton={true}
           radixVariant="outline"
           onSubmit={async () => {
-            // Precomputed dimensions are computed as part of a standard snapshot,
-            // so we don't need to pass them to the backend for a new snapshot query
-            const snapshotDimension = isDimensionPrecomputed(
-              dimension,
-              getHonoredPrecomputedUnitDimensionIds(
-                experiment?.precomputedUnitDimensionIds,
-                experiment?.datasource
-                  ? getDatasourceById(experiment.datasource)
-                  : undefined,
-                hasCommercialFeature("pipeline-mode"),
-              ),
-            )
-              ? ""
-              : (dimension ?? "");
-            const body =
-              entityType === "experiment" || entityType === "holdout"
-                ? JSON.stringify({
-                    phase: phase ?? 0,
-                    dimension: snapshotDimension,
-                  })
-                : undefined;
-
-            try {
-              if (entityType === "safe-rollout") {
-                await apiCall<{ snapshot: SafeRolloutSnapshotInterface }>(
-                  snapshotEndpoint,
-                  { method: "POST" },
-                );
-              } else {
-                const res = await apiCall<{
-                  snapshot: ExperimentSnapshotInterface;
-                }>(snapshotEndpoint, {
-                  method: "POST",
-                  ...(body && { body }),
-                });
-                if (experimentSnapshotTrackingProps) {
-                  trackSnapshot(
-                    "create",
-                    experimentSnapshotTrackingProps.trackingSource,
-                    experimentSnapshotTrackingProps.datasourceType,
-                    res.snapshot,
-                  );
-                }
-              }
-              onSuccess?.();
-              setRefreshError("");
-            } catch (e) {
-              setRefreshError(e.message);
-            } finally {
-              // Always refresh, regardless of success or failure
-              // to give the UI a chance to catch up
-              mutate();
-              mutateAdditional?.();
+            if (customValidation && !(await customValidation())) {
+              return;
             }
+
+            await runSnapshot(snapshotDimension);
           }}
         />
       ) : shouldRenderExperimentButton ? (

--- a/packages/front-end/components/Experiment/RefreshSnapshotButton.tsx
+++ b/packages/front-end/components/Experiment/RefreshSnapshotButton.tsx
@@ -21,6 +21,8 @@ const RefreshSnapshotButton: FC<{
   useRadixButton?: boolean;
   radixVariant?: "outline" | "solid" | "soft";
   setError: (e: string | undefined) => void;
+  // Return false to abort the refresh
+  customValidation?: () => boolean | Promise<boolean>;
 }> = ({
   mutate,
   experiment,
@@ -29,6 +31,7 @@ const RefreshSnapshotButton: FC<{
   useRadixButton = false,
   radixVariant = "outline",
   setError,
+  customValidation,
 }) => {
   const [loading, setLoading] = useState(false);
   const [longResult, setLongResult] = useState(false);
@@ -38,6 +41,9 @@ const RefreshSnapshotButton: FC<{
   const { apiCall } = useAuth();
 
   const refreshSnapshot = async () => {
+    if (customValidation && !(await customValidation())) {
+      return;
+    }
     // Precomputed dimensions are computed as part of a standard snapshot,
     // so we don't need to pass them to the backend for a new snapshot query
     const snapshotDimension = isDimensionPrecomputed(

--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
@@ -946,9 +946,9 @@ export default function AnalysisSettingsSummary({
               trackingSource: "UpdateDimensionBreakdownModal",
             });
           }}
-          handleGoToOverallResultsClick={async () => {
-            // Kick-off overall results refresh
-            runSnapshot("", {
+          handleGoToOverallResultsClick={() => {
+            // Kick-off overall results refresh.
+            void runSnapshot("", {
               trackingSource: "UpdateDimensionBreakdownModal",
             });
 

--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
@@ -15,6 +15,7 @@ import {
   ExperimentMetricInterface,
   getLatestPhaseVariations,
 } from "shared/experiments";
+import { isNewerOverallResultsDataAvailable } from "shared/enterprise";
 import { getSnapshotAnalysis } from "shared/util";
 import { MetricGroupInterface } from "shared/types/metric-groups";
 import { getValidDate } from "shared/dates";
@@ -50,6 +51,7 @@ import { filterMetricsByTags } from "@/hooks/useExperimentTableRows";
 import DimensionChooser from "@/components/Dimensions/DimensionChooser";
 import Link from "@/ui/Link";
 import MigrateResultsToDashboardModal from "@/components/Experiment/ResultsFilter/MigrateResultsToDashboardModal";
+import UpdateDimensionBreakdownModal from "@/components/Experiment/UpdateDimensionBreakdownModal";
 
 export interface Props {
   experiment: ExperimentInterfaceStringDates;
@@ -140,6 +142,7 @@ export default function AnalysisSettingsSummary({
 
   const {
     snapshot,
+    dimensionless,
     latestSummary: latest,
     analysis,
     dimension: _snapshotDimension,
@@ -175,6 +178,10 @@ export default function AnalysisSettingsSummary({
   const [queriesModalOpen, setQueriesModalOpen] = useState(false);
   const [migrateToDashboardModalOpen, setMigrateToDashboardModalOpen] =
     useState(false);
+  const [
+    updateDimensionBreakdownModalOpen,
+    setUpdateDimensionBreakdownModalOpen,
+  ] = useState(false);
 
   const datasource = experiment
     ? getDatasourceById(experiment.datasource)
@@ -216,6 +223,40 @@ export default function AnalysisSettingsSummary({
       datasource ?? undefined,
       experiment.id,
     );
+
+  const newerOverallResultsAvailable = isNewerOverallResultsDataAvailable(
+    sourceSnapshot,
+    dimensionless,
+  );
+
+  const runSnapshot = async (
+    dimensionToRun: string,
+    opts?: { force?: boolean; trackingSource?: string },
+  ) => {
+    const force = opts?.force ?? false;
+    const trackingSource = opts?.trackingSource ?? "RunQueriesButton";
+    try {
+      const res = await apiCall<{ snapshot: ExperimentSnapshotInterface }>(
+        `/experiment/${experiment.id}/snapshot${force ? "?force=true" : ""}`,
+        {
+          method: "POST",
+          body: JSON.stringify({ phase, dimension: dimensionToRun }),
+        },
+      );
+      trackSnapshot(
+        "create",
+        trackingSource,
+        datasource?.type || null,
+        res.snapshot,
+      );
+      setRefreshError("");
+    } catch (e) {
+      setRefreshError(e.message);
+    } finally {
+      mutate();
+      mutateExperiment();
+    }
+  };
 
   const handleDisableIncrementalRefresh = async () => {
     if (!datasource || !isExperimentIncludedInIncrementalRefresh) return;
@@ -298,7 +339,15 @@ export default function AnalysisSettingsSummary({
     phase,
     unjoinableMetrics,
     conversionWindowMetrics,
+    newerOverallResultsAvailable,
   });
+
+  // For Incremental Pipeline mode, dimension results are built on top
+  // of overall results (dimensionless snapshot)
+  // So if the user is clicking 'Update' on a scenario that we know there's no
+  // newer overall results available, we show a confirmation modal explaining why.
+  const needsDimensionRefreshConfirm =
+    !!sourceSnapshot && !newerOverallResultsAvailable;
 
   const ds = getDatasourceById(experiment.datasource);
 
@@ -446,6 +495,7 @@ export default function AnalysisSettingsSummary({
     phase: currentPhase,
     unjoinableMetrics: unjoinable,
     conversionWindowMetrics: conversion,
+    newerOverallResultsAvailable,
   }: {
     experiment?: ExperimentInterfaceStringDates;
     snapshot?: ExperimentSnapshotInterface;
@@ -459,6 +509,7 @@ export default function AnalysisSettingsSummary({
     phase?: number;
     unjoinableMetrics?: Set<string>;
     conversionWindowMetrics?: Set<string>;
+    newerOverallResultsAvailable?: boolean;
   }): { outdated: boolean; reasons: string[] } {
     const snapshotSettings = snap?.settings;
     const analysisSettings = snap ? getSnapshotAnalysis(snap)?.settings : null;
@@ -600,6 +651,12 @@ export default function AnalysisSettingsSummary({
       reasons.push("Sequential testing settings changed");
     }
 
+    // For incremental-refresh dimension breakdowns: the breakdown reads from
+    // the overall results, so newer overall data makes it outdated too.
+    if (newerOverallResultsAvailable) {
+      reasons.push("Newer Overall Results are available");
+    }
+
     return { outdated: reasons.length > 0, reasons };
   }
 
@@ -681,7 +738,7 @@ export default function AnalysisSettingsSummary({
               />
               {hasData && outdated && status !== "running" ? (
                 <OutdatedBadge
-                  label={`Analysis settings have changed since last run. Click "Update" to re-run the analysis.`}
+                  label={`These results are outdated. Click "Update" to re-run the analysis.`}
                   reasons={reasons}
                   hasData={hasData && hasValidStatsEngine}
                 />
@@ -720,6 +777,13 @@ export default function AnalysisSettingsSummary({
                 phase={phase}
                 dimension={dimension}
                 setAnalysisSettings={setAnalysisSettings}
+                customValidation={() => {
+                  if (needsDimensionRefreshConfirm) {
+                    setUpdateDimensionBreakdownModalOpen(true);
+                    return false;
+                  }
+                  return true;
+                }}
               />
             ) : null}
 
@@ -729,34 +793,10 @@ export default function AnalysisSettingsSummary({
               forceRefresh={
                 allMetrics.length > 0
                   ? async () => {
-                      await apiCall<{
-                        snapshot: ExperimentSnapshotInterface;
-                      }>(`/experiment/${experiment.id}/snapshot?force=true`, {
-                        method: "POST",
-                        body: JSON.stringify({
-                          phase,
-                          dimension,
-                        }),
-                      })
-                        .then((res) => {
-                          trackSnapshot(
-                            "create",
-                            "ForceRerunQueriesButton",
-                            datasource?.type || null,
-                            res.snapshot,
-                          );
-                          // POST creates a brand-new snapshot id, so the
-                          // provider will auto-upgrade the heavy fetch once
-                          // status reports the new successful id — the
-                          // default cheap mutate is sufficient here.
-                          mutate();
-                          mutateExperiment();
-                          setRefreshError("");
-                        })
-                        .catch((e) => {
-                          console.error(e);
-                          setRefreshError(e.message);
-                        });
+                      await runSnapshot(dimension ?? "", {
+                        force: true,
+                        trackingSource: "ForceRerunQueriesButton",
+                      });
                     }
                   : undefined
               }
@@ -897,6 +937,31 @@ export default function AnalysisSettingsSummary({
         sortDirection={sortDirection ?? null}
         differenceType={differenceType}
       />
+      {updateDimensionBreakdownModalOpen && sourceSnapshot && (
+        <UpdateDimensionBreakdownModal
+          sourceSnapshot={sourceSnapshot}
+          close={() => setUpdateDimensionBreakdownModalOpen(false)}
+          handleUpdateDimensionOnlyClick={async () => {
+            await runSnapshot(dimension ?? "", {
+              trackingSource: "UpdateDimensionBreakdownModal",
+            });
+          }}
+          handleGoToOverallResultsClick={async () => {
+            // Kick-off overall results refresh
+            runSnapshot("", {
+              trackingSource: "UpdateDimensionBreakdownModal",
+            });
+
+            setUpdateDimensionBreakdownModalOpen(false);
+
+            // Show the overall results
+            // FIXME: this feels fragile, it should be only 1 state call
+            setSnapshotDimension("");
+            setAnalysisSettings(null);
+            setDimension?.("", true);
+          }}
+        />
+      )}
     </Box>
   );
 }

--- a/packages/front-end/components/Experiment/UpdateDimensionBreakdownModal.tsx
+++ b/packages/front-end/components/Experiment/UpdateDimensionBreakdownModal.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { datetime } from "shared/dates";
+import { SourceSnapshotRef } from "shared/enterprise";
+import Modal from "@/ui/Modal";
+import Button from "@/ui/Button";
+
+interface Props {
+  sourceSnapshot: SourceSnapshotRef;
+  close: () => void;
+  handleUpdateDimensionOnlyClick: () => void;
+  handleGoToOverallResultsClick: () => void;
+}
+
+export default function UpdateDimensionBreakdownModal({
+  sourceSnapshot,
+  close,
+  handleUpdateDimensionOnlyClick,
+  handleGoToOverallResultsClick,
+}: Props) {
+  const dateLabel = datetime(sourceSnapshot.dateCreated);
+
+  return (
+    <Modal.Root
+      trackingEventModalType="update-dimension-breakdown"
+      open={true}
+      onOpenChange={(open) => {
+        if (!open) close();
+      }}
+    >
+      <Modal.Header>
+        <Modal.Title>Update Dimension Results?</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <p>
+          Dimension Results are built from your Overall Results, which already
+          hold the latest data available from <b>{dateLabel}</b>.
+        </p>
+        <p>
+          Updating Dimension Results now re-runs on top of that same data. To
+          fetch newer data, update your Overall Results first.
+        </p>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="ghost" onClick={close}>
+          Cancel
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => {
+            handleUpdateDimensionOnlyClick();
+            close();
+          }}
+        >
+          Update dimension only
+        </Button>
+        <Button onClick={handleGoToOverallResultsClick}>
+          Update overall results
+        </Button>
+      </Modal.Footer>
+    </Modal.Root>
+  );
+}

--- a/packages/front-end/components/SafeRollout/RefreshSnapshotButton.tsx
+++ b/packages/front-end/components/SafeRollout/RefreshSnapshotButton.tsx
@@ -8,13 +8,17 @@ import Button from "@/components/Button";
 const RefreshSnapshotButton: FC<{
   mutate: () => void;
   safeRollout: SafeRolloutInterface;
-}> = ({ mutate, safeRollout }) => {
+  customValidation?: () => boolean | Promise<boolean>;
+}> = ({ mutate, safeRollout, customValidation }) => {
   const [loading, setLoading] = useState(false);
   const [longResult, setLongResult] = useState(false);
 
   const { apiCall } = useAuth();
 
   const refreshSnapshot = async () => {
+    if (customValidation && !(await customValidation())) {
+      return;
+    }
     await apiCall<{
       status: number;
       message: string;

--- a/packages/shared/src/enterprise/pipeline.ts
+++ b/packages/shared/src/enterprise/pipeline.ts
@@ -202,3 +202,19 @@ export function getExperimentSourceSnapshotRef(
     dateCreated: getValidDate(snapshot.sourceSnapshotDateCreated),
   };
 }
+
+export function isNewerOverallResultsDataAvailable(
+  sourceSnapshot: SourceSnapshotRef | undefined,
+  latestSuccessfulOverallResultsSnapshot:
+    | Pick<ExperimentSnapshotInterface, "dateCreated">
+    | undefined,
+): boolean {
+  if (!sourceSnapshot || !latestSuccessfulOverallResultsSnapshot) {
+    return false;
+  }
+
+  return (
+    getValidDate(latestSuccessfulOverallResultsSnapshot.dateCreated).getTime() >
+    getValidDate(sourceSnapshot.dateCreated).getTime()
+  );
+}

--- a/packages/shared/test/enterprise/pipeline.test.ts
+++ b/packages/shared/test/enterprise/pipeline.test.ts
@@ -1,6 +1,7 @@
 import {
   getExperimentSourceSnapshotRef,
   isExperimentIncrementalEnabled,
+  isNewerOverallResultsDataAvailable,
 } from "shared/enterprise";
 import type { DataSourcePipelineSettings } from "shared/types/datasource";
 
@@ -176,5 +177,56 @@ describe("getExperimentSourceSnapshotRef", () => {
         sourceSnapshotDateCreated: mainDate,
       }),
     ).toEqual({ id: "main", dateCreated: mainDate });
+  });
+});
+
+describe("isNewerOverallResultsDataAvailable", () => {
+  const source = {
+    id: "main_old",
+    dateCreated: new Date("2024-06-01T12:00:00Z"),
+  };
+
+  it("returns false when there is no source snapshot", () => {
+    expect(
+      isNewerOverallResultsDataAvailable(undefined, {
+        dateCreated: new Date("2024-06-02T12:00:00Z"),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when there is no latest main snapshot", () => {
+    expect(isNewerOverallResultsDataAvailable(source, undefined)).toBe(false);
+  });
+
+  it("returns false when the latest main snapshot is the same age", () => {
+    expect(
+      isNewerOverallResultsDataAvailable(source, {
+        dateCreated: source.dateCreated,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when the latest main snapshot is older", () => {
+    expect(
+      isNewerOverallResultsDataAvailable(source, {
+        dateCreated: new Date("2024-05-01T12:00:00Z"),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when a newer main snapshot exists", () => {
+    expect(
+      isNewerOverallResultsDataAvailable(source, {
+        dateCreated: new Date("2024-06-02T12:00:00Z"),
+      }),
+    ).toBe(true);
+  });
+
+  it("handles string dates from the API", () => {
+    expect(
+      isNewerOverallResultsDataAvailable(source, {
+        dateCreated: "2024-06-02T12:00:00Z" as unknown as Date,
+      }),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
### Features and Changes

In incremental pipeline mode, dimension breakdowns are computed on top of the overall (dimensionless) results. So refreshing a dimension breakdown never fetches newer data than the overall snapshot it reads from. Users had no way to know this and would re-run a dimension breakdown expecting fresh data.

This adds two interventions:

- An outdated badge reason. When newer overall results exist than the source snapshot a dimension breakdown was built from, the breakdown is now flagged as outdated with "Newer Overall Results are available".
- A confirmation modal. When a user clicks "Update" on a dimension breakdown and no newer overall data is available, a modal explains that dimension results read from the overall snapshot and offers two paths: re-run the dimension only, or update the overall results first.

`isNewerOverallResultsDataAvailable` in `shared/enterprise/pipeline.ts` is the new comparison helper backing both. `RefreshResultsButton` gains a `customValidation` hook (mirroring `Modal`'s) so the page can intercept the refresh and open the modal instead. The snapshot-refresh logic in both components was consolidated into single `runSnapshot` helpers along the way.

### Dependencies

Stacked on `av/dimension-timestamp-improvement` (https://github.com/growthbook/growthbook/pull/6114)

### Screenshots

<img width="535" height="357" alt="Screenshot 2026-06-15 at 2 15 58 PM" src="https://github.com/user-attachments/assets/1bf42858-d642-4734-ab72-56440c1b4959" />

<img width="1074" height="183" alt="Screenshot 2026-06-15 at 2 15 28 PM" src="https://github.com/user-attachments/assets/3868c59e-5e79-4221-aa53-e14719339873" />

### Testing

Unit tests for `isNewerOverallResultsDataAvailable` cover the no-source, no-overall, equal-age, older, newer, and string-date cases.
