### PR TITLE
improve sandbox worker stability, remove otel from workers

### DIFF
--- a/packages/back-end/src/enterprise/sandbox/sandbox-pool.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-pool.ts
@@ -123,9 +123,8 @@ const TRACING_MODULE_RE = /tracing\.(?:opentelemetry|datadog)/;
 // child (duplicate exporters/timers, child_process instrumentation nesting, slow
 // or failing boots). We want tracing only in the parent — the meaningful span is
 // the runInSandbox call there — so strip the tracing preload from the worker.
-function workerExecArgv(): string[] {
+export function workerExecArgv(parent: string[] = process.execArgv): string[] {
   const out: string[] = [];
-  const parent = process.execArgv;
   for (let i = 0; i < parent.length; i++) {
     const arg = parent[i];
     // Re-added below with the worker's own heap cap.
@@ -154,9 +153,11 @@ function workerExecArgv(): string[] {
 
 // Strip any tracing preload that came in via NODE_OPTIONS and hard-disable the
 // SDKs, so the worker can't bootstrap tracing by any path.
-function workerEnv(): NodeJS.ProcessEnv {
+export function workerEnv(
+  parentEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {
-    ...process.env,
+    ...parentEnv,
     OTEL_SDK_DISABLED: "true",
     DD_TRACE_ENABLED: "false",
   };

--- a/packages/back-end/src/enterprise/sandbox/sandbox-pool.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-pool.ts
@@ -117,7 +117,7 @@ let generation = 0;
 // Crash-loop breaker state.
 let consecutiveBootFailures = 0;
 let circuitOpenUntil = 0;
-let replenishScheduled = false;
+let replenishTimer: ReturnType<typeof setTimeout> | null = null;
 
 // Matches the `--require`/`-r` preload that bootstraps a tracing SDK
 // (tracing.opentelemetry / tracing.datadog), in either spelling:
@@ -232,6 +232,12 @@ function spawnWorker(): Worker {
 // Mark a worker as having booted successfully. Since the boot path works, also reset
 // the crash-loop breaker and resume normal respawning.
 function confirmBoot(worker: Worker) {
+  // Clear the uptime fallback so it can't fire later and reset the breaker a second
+  // time (mid-streak) while other workers are crash-looping.
+  if (worker.bootTimer) {
+    clearTimeout(worker.bootTimer);
+    worker.bootTimer = undefined;
+  }
   worker.bootConfirmed = true;
   if (consecutiveBootFailures === 0 && circuitOpenUntil === 0) return;
   consecutiveBootFailures = 0;
@@ -310,7 +316,7 @@ function handleExit(
 // happening: back off between attempts and, once the breaker is open, wait out the
 // cooldown before a single half-open trial worker.
 function ensureCapacity() {
-  if (shuttingDown || !started || replenishScheduled) return;
+  if (shuttingDown || !started || replenishTimer) return;
   if (workers.length >= POOL_SIZE) return;
 
   const now = Date.now();
@@ -324,9 +330,8 @@ function ensureCapacity() {
     );
   }
 
-  replenishScheduled = true;
-  const timer = setTimeout(() => {
-    replenishScheduled = false;
+  replenishTimer = setTimeout(() => {
+    replenishTimer = null;
     if (shuttingDown || !started) return;
     if (workers.length < POOL_SIZE) {
       workers.push(spawnWorker());
@@ -338,7 +343,7 @@ function ensureCapacity() {
       ensureCapacity();
     }
   }, delay);
-  timer.unref();
+  replenishTimer.unref();
 }
 
 // Gracefully retire a worker; the exit handler removes and respawns it.
@@ -436,6 +441,10 @@ function ensureStarted() {
 
 function shutdown() {
   shuttingDown = true;
+  if (replenishTimer) {
+    clearTimeout(replenishTimer);
+    replenishTimer = null;
+  }
   for (const w of workers) {
     if (w.bootTimer) clearTimeout(w.bootTimer);
     if (w.current) clearTimeout(w.current.killTimer);
@@ -487,5 +496,4 @@ export function __shutdownSandboxPool() {
   started = false;
   consecutiveBootFailures = 0;
   circuitOpenUntil = 0;
-  replenishScheduled = false;
 }

--- a/packages/back-end/src/enterprise/sandbox/sandbox-pool.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-pool.ts
@@ -37,6 +37,39 @@ const KILL_GRACE_MS = parseEnvInt(process.env.CUSTOM_HOOK_KILL_GRACE_MS, 2000, {
   min: 1,
   name: "CUSTOM_HOOK_KILL_GRACE_MS",
 });
+// A worker that exits before handling a job and before this uptime is treated as a
+// boot failure (bad worker path, missing native module, OOM-on-load). Set above the
+// real boot time so a healthy-but-slow boot isn't misclassified.
+const MIN_HEALTHY_UPTIME_MS = parseEnvInt(
+  process.env.CUSTOM_HOOK_MIN_HEALTHY_UPTIME_MS,
+  2000,
+  { min: 1, name: "CUSTOM_HOOK_MIN_HEALTHY_UPTIME_MS" },
+);
+// Backoff between respawns after boot failures, to avoid a fork→crash→fork storm
+// that pegs CPU and starves the event loop (tripping liveness probes).
+const RESPAWN_BACKOFF_BASE_MS = parseEnvInt(
+  process.env.CUSTOM_HOOK_RESPAWN_BACKOFF_MS,
+  250,
+  { min: 1, name: "CUSTOM_HOOK_RESPAWN_BACKOFF_MS" },
+);
+const RESPAWN_BACKOFF_MAX_MS = parseEnvInt(
+  process.env.CUSTOM_HOOK_RESPAWN_BACKOFF_MAX_MS,
+  30000,
+  { min: 1, name: "CUSTOM_HOOK_RESPAWN_BACKOFF_MAX_MS" },
+);
+// Consecutive boot failures that trip the crash-loop breaker.
+const CRASH_LOOP_THRESHOLD = parseEnvInt(
+  process.env.CUSTOM_HOOK_CRASH_LOOP_THRESHOLD,
+  5,
+  { min: 1, name: "CUSTOM_HOOK_CRASH_LOOP_THRESHOLD" },
+);
+// While the breaker is open we stop respawning and fail jobs fast; after this cooldown
+// we allow a single half-open trial worker to test whether the issue has cleared.
+const CIRCUIT_COOLDOWN_MS = parseEnvInt(
+  process.env.CUSTOM_HOOK_CIRCUIT_COOLDOWN_MS,
+  30000,
+  { min: 1, name: "CUSTOM_HOOK_CIRCUIT_COOLDOWN_MS" },
+);
 
 // Worker sibling module, matching this file's extension (.ts dev / .js compiled).
 const WORKER_PATH =
@@ -59,6 +92,10 @@ interface Worker {
   busy: boolean;
   jobsHandled: number;
   generation: number;
+  spawnedAt: number;
+  // Fires once the worker has stayed up long enough to count as a healthy boot,
+  // which clears the crash-loop breaker.
+  bootTimer?: ReturnType<typeof setTimeout>;
   current?: { job: Job; killTimer: ReturnType<typeof setTimeout> };
 }
 
@@ -69,24 +106,95 @@ let started = false;
 let shuttingDown = false;
 // Bumped on (re)start so handleExit can ignore workers from a torn-down pool.
 let generation = 0;
+// Crash-loop breaker state.
+let consecutiveBootFailures = 0;
+let circuitOpenUntil = 0;
+let replenishScheduled = false;
+
+// Matches the `--require`/`-r` preload that bootstraps a tracing SDK
+// (tracing.opentelemetry / tracing.datadog), in either spelling:
+//   "--require <module>"  ->  the value is the module path
+//   "--require=<module>"  ->  flag and value combined
+const TRACING_MODULE_RE = /tracing\.(?:opentelemetry|datadog)/;
+
+// The parent boots a tracing SDK via `node --require .../tracing.*.js`. A forked
+// worker inherits that flag through process.execArgv, so without this it would
+// re-bootstrap a full OpenTelemetry/Datadog SDK + auto-instrumentation in every
+// child (duplicate exporters/timers, child_process instrumentation nesting, slow
+// or failing boots). We want tracing only in the parent — the meaningful span is
+// the runInSandbox call there — so strip the tracing preload from the worker.
+function workerExecArgv(): string[] {
+  const out: string[] = [];
+  const parent = process.execArgv;
+  for (let i = 0; i < parent.length; i++) {
+    const arg = parent[i];
+    // Re-added below with the worker's own heap cap.
+    if (arg.startsWith("--max-old-space-size")) continue;
+    if (arg === "--require" || arg === "-r") {
+      // Drop the flag and its value when the value is a tracing module; keep
+      // any other preload (e.g. a TS loader in dev).
+      if (TRACING_MODULE_RE.test(parent[i + 1] ?? "")) {
+        i++;
+        continue;
+      }
+      out.push(arg);
+      continue;
+    }
+    if (
+      (arg.startsWith("--require=") || arg.startsWith("-r=")) &&
+      TRACING_MODULE_RE.test(arg)
+    ) {
+      continue;
+    }
+    out.push(arg);
+  }
+  out.push(`--max-old-space-size=${WORKER_HEAP_MB}`);
+  return out;
+}
+
+// Strip any tracing preload that came in via NODE_OPTIONS and hard-disable the
+// SDKs, so the worker can't bootstrap tracing by any path.
+function workerEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    OTEL_SDK_DISABLED: "true",
+    DD_TRACE_ENABLED: "false",
+  };
+  if (env.NODE_OPTIONS) {
+    const scrubbed = env.NODE_OPTIONS.replace(
+      /(?:--require|-r)(?:=|\s+)\S*tracing\.(?:opentelemetry|datadog)\S*/g,
+      "",
+    ).trim();
+    if (scrubbed) env.NODE_OPTIONS = scrubbed;
+    else delete env.NODE_OPTIONS;
+  }
+  return env;
+}
 
 function spawnWorker(): Worker {
-  // Keep the parent's runtime flags but override the heap cap.
-  const execArgv = [
-    ...process.execArgv.filter((a) => !a.startsWith("--max-old-space-size")),
-    `--max-old-space-size=${WORKER_HEAP_MB}`,
-  ];
-
   const proc = fork(WORKER_PATH, [], {
-    execArgv,
+    execArgv: workerExecArgv(),
+    env: workerEnv(),
     serialization: "advanced",
     // Discard stdin/stdout; keep stderr so crashes surface in logs. ipc for jobs/results.
     stdio: ["ignore", "ignore", "inherit", "ipc"],
   });
 
-  const worker: Worker = { proc, busy: false, jobsHandled: 0, generation };
+  const worker: Worker = {
+    proc,
+    busy: false,
+    jobsHandled: 0,
+    generation,
+    spawnedAt: Date.now(),
+  };
+
+  // Surviving a short uptime means the worker booted fine, so clear the breaker.
+  worker.bootTimer = setTimeout(markBootHealthy, MIN_HEALTHY_UPTIME_MS);
+  worker.bootTimer.unref();
 
   proc.on("message", (msg: { id: number; result: SandboxEvalResult }) => {
+    // Any response proves the worker is healthy, so clear the breaker.
+    markBootHealthy();
     const cur = worker.current;
     if (!cur || cur.job.id !== msg.id) return; // stale/duplicate
     clearTimeout(cur.killTimer);
@@ -107,12 +215,31 @@ function spawnWorker(): Worker {
   return worker;
 }
 
+// A worker stayed up long enough (or answered a job): the boot path works, so reset
+// the crash-loop breaker and resume normal respawning.
+function markBootHealthy() {
+  if (consecutiveBootFailures === 0 && circuitOpenUntil === 0) return;
+  consecutiveBootFailures = 0;
+  circuitOpenUntil = 0;
+  ensureCapacity();
+}
+
+function failAllQueued(error: string) {
+  while (queue.length) {
+    queue.shift()?.resolve({ ok: false, error, warnings: [] });
+  }
+}
+
 function handleExit(
   worker: Worker,
   code: number | null,
   signal: NodeJS.Signals | null,
 ) {
   workers = workers.filter((w) => w !== worker);
+  if (worker.bootTimer) {
+    clearTimeout(worker.bootTimer);
+    worker.bootTimer = undefined;
+  }
 
   const cur = worker.current;
   if (cur) {
@@ -129,15 +256,74 @@ function handleExit(
         "Custom hook: sandbox terminated unexpectedly (possible crash, out-of-memory, or timeout)",
       warnings: [],
     });
+  } else if (
+    worker.jobsHandled === 0 &&
+    Date.now() - worker.spawnedAt < MIN_HEALTHY_UPTIME_MS
+  ) {
+    // Worker died during startup before doing any work — likely a boot failure that
+    // would repeat on respawn. Count it; respawns back off (see ensureCapacity).
+    consecutiveBootFailures++;
+    logger.error(
+      { code, signal, consecutiveBootFailures },
+      "Custom hook sandbox worker failed to boot",
+    );
+    if (
+      consecutiveBootFailures >= CRASH_LOOP_THRESHOLD &&
+      circuitOpenUntil <= Date.now()
+    ) {
+      circuitOpenUntil = Date.now() + CIRCUIT_COOLDOWN_MS;
+      logger.error(
+        { cooldownMs: CIRCUIT_COOLDOWN_MS },
+        "Custom hook sandbox crash-loop detected; pausing respawns and failing jobs fast",
+      );
+      failAllQueued(
+        "Custom hook: sandbox temporarily unavailable (worker keeps crashing)",
+      );
+    }
   }
 
   // Ignore exits from a torn-down generation (the job, if any, was failed above).
   if (worker.generation !== generation) return;
 
   if (!shuttingDown && started) {
-    if (workers.length < POOL_SIZE) workers.push(spawnWorker());
+    ensureCapacity();
     dispatch();
   }
+}
+
+// Refill the pool toward POOL_SIZE, but throttle respawns while boot failures are
+// happening: back off between attempts and, once the breaker is open, wait out the
+// cooldown before a single half-open trial worker.
+function ensureCapacity() {
+  if (shuttingDown || !started || replenishScheduled) return;
+  if (workers.length >= POOL_SIZE) return;
+
+  const now = Date.now();
+  let delay = 0;
+  if (circuitOpenUntil > now) {
+    delay = circuitOpenUntil - now;
+  } else if (consecutiveBootFailures > 0) {
+    delay = Math.min(
+      RESPAWN_BACKOFF_BASE_MS * 2 ** (consecutiveBootFailures - 1),
+      RESPAWN_BACKOFF_MAX_MS,
+    );
+  }
+
+  replenishScheduled = true;
+  const timer = setTimeout(() => {
+    replenishScheduled = false;
+    if (shuttingDown || !started) return;
+    if (workers.length < POOL_SIZE) {
+      workers.push(spawnWorker());
+      dispatch();
+    }
+    // While healthy, fill the rest of the pool immediately; while degraded, spawn one
+    // at a time and let each worker's outcome drive the next attempt.
+    if (workers.length < POOL_SIZE && consecutiveBootFailures === 0) {
+      ensureCapacity();
+    }
+  }, delay);
+  timer.unref();
 }
 
 // Gracefully retire a worker; the exit handler removes and respawns it.
@@ -157,11 +343,13 @@ function dispatch() {
 
   let worker = workers.find((w) => !w.busy && w.proc.connected);
   if (!worker) {
-    if (workers.length < POOL_SIZE) {
+    // Don't spawn on demand while the breaker is open; respawns are throttled via
+    // ensureCapacity so we don't add to a fork→crash storm.
+    if (workers.length < POOL_SIZE && circuitOpenUntil <= Date.now()) {
       worker = spawnWorker();
       workers.push(worker);
     } else {
-      return; // all busy; a freeing worker will re-dispatch
+      return; // all busy / breaker open; a freeing or respawned worker re-dispatches
     }
   }
 
@@ -222,6 +410,8 @@ function ensureStarted() {
 function shutdown() {
   shuttingDown = true;
   for (const w of workers) {
+    if (w.bootTimer) clearTimeout(w.bootTimer);
+    if (w.current) clearTimeout(w.current.killTimer);
     try {
       w.proc.kill("SIGKILL");
     } catch {
@@ -239,6 +429,16 @@ export function runInSandbox(
 ): Promise<SandboxEvalResult> {
   ensureStarted();
   return new Promise<SandboxEvalResult>((resolve) => {
+    // Breaker open: workers keep failing to boot, so fail fast instead of queueing.
+    if (circuitOpenUntil > Date.now()) {
+      resolve({
+        ok: false,
+        error:
+          "Custom hook: sandbox temporarily unavailable (worker keeps crashing), please try again shortly",
+        warnings: [],
+      });
+      return;
+    }
     if (queue.length >= MAX_QUEUE) {
       resolve({
         ok: false,
@@ -258,4 +458,7 @@ export function __shutdownSandboxPool() {
   // Allow a fresh start afterwards (used by tests).
   shuttingDown = false;
   started = false;
+  consecutiveBootFailures = 0;
+  circuitOpenUntil = 0;
+  replenishScheduled = false;
 }

--- a/packages/back-end/src/enterprise/sandbox/sandbox-pool.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-pool.ts
@@ -37,9 +37,9 @@ const KILL_GRACE_MS = parseEnvInt(process.env.CUSTOM_HOOK_KILL_GRACE_MS, 2000, {
   min: 1,
   name: "CUSTOM_HOOK_KILL_GRACE_MS",
 });
-// A worker that exits before handling a job and before this uptime is treated as a
-// boot failure (bad worker path, missing native module, OOM-on-load). Set above the
-// real boot time so a healthy-but-slow boot isn't misclassified.
+// Fallback boot confirmation: a worker that survives this long without sending its
+// "ready" handshake (e.g. an older worker build mid-deploy) is still treated as
+// booted. Set above the real boot time so a slow boot isn't misclassified.
 const MIN_HEALTHY_UPTIME_MS = parseEnvInt(
   process.env.CUSTOM_HOOK_MIN_HEALTHY_UPTIME_MS,
   2000,
@@ -87,14 +87,22 @@ interface Job {
   resolve: (result: SandboxEvalResult) => void;
 }
 
+// Messages a worker sends to the pool: a one-time boot handshake, then job results.
+type WorkerMessage =
+  | { ready: true }
+  | { id: number; result: SandboxEvalResult };
+
 interface Worker {
   proc: ChildProcess;
   busy: boolean;
   jobsHandled: number;
   generation: number;
-  spawnedAt: number;
-  // Fires once the worker has stayed up long enough to count as a healthy boot,
-  // which clears the crash-loop breaker.
+  // Set once the worker proves it booted (sent its "ready" signal, answered a job,
+  // or survived the uptime fallback). An exit before this is a boot failure, even
+  // if a job was in flight; an exit after it is a normal mid-job crash.
+  bootConfirmed: boolean;
+  // Uptime fallback that confirms boot if no "ready"/result arrives (e.g. an older
+  // worker build during a rolling deploy).
   bootTimer?: ReturnType<typeof setTimeout>;
   current?: { job: Job; killTimer: ReturnType<typeof setTimeout> };
 }
@@ -186,16 +194,21 @@ function spawnWorker(): Worker {
     busy: false,
     jobsHandled: 0,
     generation,
-    spawnedAt: Date.now(),
+    bootConfirmed: false,
   };
 
-  // Surviving a short uptime means the worker booted fine, so clear the breaker.
-  worker.bootTimer = setTimeout(markBootHealthy, MIN_HEALTHY_UPTIME_MS);
+  // Fallback in case "ready" never arrives: surviving the uptime window also counts
+  // as a healthy boot.
+  worker.bootTimer = setTimeout(
+    () => confirmBoot(worker),
+    MIN_HEALTHY_UPTIME_MS,
+  );
   worker.bootTimer.unref();
 
-  proc.on("message", (msg: { id: number; result: SandboxEvalResult }) => {
-    // Any response proves the worker is healthy, so clear the breaker.
-    markBootHealthy();
+  proc.on("message", (msg: WorkerMessage) => {
+    // The worker's "ready" handshake (or any job result) proves it booted.
+    confirmBoot(worker);
+    if ("ready" in msg) return;
     const cur = worker.current;
     if (!cur || cur.job.id !== msg.id) return; // stale/duplicate
     clearTimeout(cur.killTimer);
@@ -216,9 +229,10 @@ function spawnWorker(): Worker {
   return worker;
 }
 
-// A worker stayed up long enough (or answered a job): the boot path works, so reset
+// Mark a worker as having booted successfully. Since the boot path works, also reset
 // the crash-loop breaker and resume normal respawning.
-function markBootHealthy() {
+function confirmBoot(worker: Worker) {
+  worker.bootConfirmed = true;
   if (consecutiveBootFailures === 0 && circuitOpenUntil === 0) return;
   consecutiveBootFailures = 0;
   circuitOpenUntil = 0;
@@ -257,12 +271,12 @@ function handleExit(
         "Custom hook: sandbox terminated unexpectedly (possible crash, out-of-memory, or timeout)",
       warnings: [],
     });
-  } else if (
-    worker.jobsHandled === 0 &&
-    Date.now() - worker.spawnedAt < MIN_HEALTHY_UPTIME_MS
-  ) {
-    // Worker died during startup before doing any work — likely a boot failure that
-    // would repeat on respawn. Count it; respawns back off (see ensureCapacity).
+  }
+
+  if (!worker.bootConfirmed) {
+    // Worker exited before confirming boot — likely a boot failure that repeats on
+    // respawn (bad worker path, missing native module, OOM-on-load). Counting it even
+    // when a job was in flight means the breaker still opens under sustained load.
     consecutiveBootFailures++;
     logger.error(
       { code, signal, consecutiveBootFailures },
@@ -332,6 +346,10 @@ function recycle(worker: Worker) {
   if (worker.current) return; // only when idle
   // Remove now so dispatch() can't pick it between SIGTERM and the async exit.
   workers = workers.filter((w) => w !== worker);
+  if (worker.bootTimer) {
+    clearTimeout(worker.bootTimer);
+    worker.bootTimer = undefined;
+  }
   try {
     worker.proc.kill();
   } catch {
@@ -344,13 +362,21 @@ function dispatch() {
 
   let worker = workers.find((w) => !w.busy && w.proc.connected);
   if (!worker) {
-    // Don't spawn on demand while the breaker is open; respawns are throttled via
-    // ensureCapacity so we don't add to a fork→crash storm.
-    if (workers.length < POOL_SIZE && circuitOpenUntil <= Date.now()) {
+    // Only spawn on demand when healthy. While boot failures are happening (breaker
+    // open, or backing off before it opens) respawns go through ensureCapacity's
+    // throttle so we don't add to a fork→crash storm.
+    if (
+      workers.length < POOL_SIZE &&
+      circuitOpenUntil <= Date.now() &&
+      consecutiveBootFailures === 0
+    ) {
       worker = spawnWorker();
       workers.push(worker);
     } else {
-      return; // all busy / breaker open; a freeing or respawned worker re-dispatches
+      // All busy, or respawns are throttled; a freeing or respawned worker
+      // re-dispatches. Make sure a refill is scheduled so the queue drains.
+      ensureCapacity();
+      return;
     }
   }
 

--- a/packages/back-end/src/enterprise/sandbox/sandbox-worker.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-worker.ts
@@ -26,6 +26,11 @@ if (!process.send) {
 // Exit if the parent goes away, so we never become an orphan.
 process.on("disconnect", () => process.exit(0));
 
+// Reaching here means all imports (incl. isolated-vm) loaded, so the boot
+// succeeded. Tell the pool so it can tell a boot failure (crash before ready)
+// apart from a user-code crash (after ready) and gate its crash-loop breaker.
+process.send?.({ ready: true });
+
 process.on("message", async (job: WorkerJob) => {
   let result: SandboxEvalResult;
   try {

--- a/packages/back-end/test/fixtures/sandbox/boot-crash-worker.js
+++ b/packages/back-end/test/fixtures/sandbox/boot-crash-worker.js
@@ -1,0 +1,3 @@
+// Stand-in worker that fails on boot before sending its "ready" handshake, to
+// exercise the pool's crash-loop breaker. Exits immediately on every spawn.
+process.exit(1);

--- a/packages/back-end/test/fixtures/sandbox/healthy-worker.js
+++ b/packages/back-end/test/fixtures/sandbox/healthy-worker.js
@@ -1,0 +1,14 @@
+// Minimal stand-in for sandbox-worker.js used by sandbox-pool integration tests.
+// Implements the same IPC protocol: send a "ready" handshake on boot, then reply
+// to each job with { id, result }, echoing args.n so the round-trip is verifiable.
+if (!process.send) process.exit(0);
+process.on("disconnect", () => process.exit(0));
+
+process.send({ ready: true });
+
+process.on("message", (job) => {
+  process.send({
+    id: job.id,
+    result: { ok: true, returnVal: job.args ? job.args.n : null, log: "", warnings: [] },
+  });
+});

--- a/packages/back-end/test/fixtures/sandbox/healthy-worker.js
+++ b/packages/back-end/test/fixtures/sandbox/healthy-worker.js
@@ -9,6 +9,11 @@ process.send({ ready: true });
 process.on("message", (job) => {
   process.send({
     id: job.id,
-    result: { ok: true, returnVal: job.args ? job.args.n : null, log: "", warnings: [] },
+    result: {
+      ok: true,
+      returnVal: job.args ? job.args.n : null,
+      log: "",
+      warnings: [],
+    },
   });
 });

--- a/packages/back-end/test/sandbox-pool-runtime.test.ts
+++ b/packages/back-end/test/sandbox-pool-runtime.test.ts
@@ -1,0 +1,105 @@
+import * as path from "path";
+
+// Integration tests for the worker pool's runtime behavior (boot handshake,
+// job round-trip, crash-loop breaker). These fork real child processes, so they
+// use plain-.js fixture workers (the real worker is .ts and can't be forked under
+// ts-jest). The pool reads its config from env at module load, so each test sets
+// env then loads a fresh module instance.
+
+const FIXTURES = path.join(__dirname, "fixtures", "sandbox");
+const HEALTHY_WORKER = path.join(FIXTURES, "healthy-worker.js");
+const CRASH_WORKER = path.join(FIXTURES, "boot-crash-worker.js");
+
+type Pool = typeof import("../src/enterprise/sandbox/sandbox-pool");
+
+const POOL_ENV_KEYS = [
+  "CUSTOM_HOOK_WORKER_PATH",
+  "CUSTOM_HOOK_POOL_SIZE",
+  "CUSTOM_HOOK_CRASH_LOOP_THRESHOLD",
+  "CUSTOM_HOOK_RESPAWN_BACKOFF_MS",
+  "CUSTOM_HOOK_RESPAWN_BACKOFF_MAX_MS",
+  "CUSTOM_HOOK_CIRCUIT_COOLDOWN_MS",
+  "CUSTOM_HOOK_MIN_HEALTHY_UPTIME_MS",
+];
+
+async function loadPool(env: Record<string, string>): Promise<Pool> {
+  jest.resetModules();
+  for (const k of POOL_ENV_KEYS) delete process.env[k];
+  Object.assign(process.env, env);
+  return import("../src/enterprise/sandbox/sandbox-pool");
+}
+
+describe("sandbox pool runtime", () => {
+  let pool: Pool | null = null;
+
+  afterEach(() => {
+    pool?.__shutdownSandboxPool();
+    pool = null;
+    for (const k of POOL_ENV_KEYS) delete process.env[k];
+  });
+
+  it("boots a worker, completes a job, and returns its result", async () => {
+    pool = await loadPool({
+      CUSTOM_HOOK_WORKER_PATH: HEALTHY_WORKER,
+      CUSTOM_HOOK_POOL_SIZE: "1",
+    });
+
+    const result = await pool.runInSandbox("unused", { n: 41 });
+
+    expect(result).toEqual({
+      ok: true,
+      returnVal: 41,
+      log: "",
+      warnings: [],
+    });
+  });
+
+  it("serves multiple sequential jobs from the pool", async () => {
+    pool = await loadPool({
+      CUSTOM_HOOK_WORKER_PATH: HEALTHY_WORKER,
+      CUSTOM_HOOK_POOL_SIZE: "2",
+    });
+
+    const results = await Promise.all([
+      pool.runInSandbox("unused", { n: 1 }),
+      pool.runInSandbox("unused", { n: 2 }),
+      pool.runInSandbox("unused", { n: 3 }),
+    ]);
+
+    expect(results.map((r) => (r.ok ? r.returnVal : null))).toEqual([1, 2, 3]);
+  });
+
+  it("opens the crash-loop breaker and fails fast after repeated boot failures", async () => {
+    pool = await loadPool({
+      CUSTOM_HOOK_WORKER_PATH: CRASH_WORKER,
+      CUSTOM_HOOK_POOL_SIZE: "1",
+      CUSTOM_HOOK_CRASH_LOOP_THRESHOLD: "3",
+      CUSTOM_HOOK_RESPAWN_BACKOFF_MS: "1",
+      CUSTOM_HOOK_RESPAWN_BACKOFF_MAX_MS: "5",
+      // Keep the breaker open long enough to assert against once tripped.
+      CUSTOM_HOOK_CIRCUIT_COOLDOWN_MS: "5000",
+      // High, so the uptime fallback never confirms a (crashing) worker as booted.
+      CUSTOM_HOOK_MIN_HEALTHY_UPTIME_MS: "100000",
+    });
+
+    // Workers crash on boot; jobs fail (terminated mid-job or, once the breaker is
+    // open, fast-failed). Poll until we observe the breaker's fast-fail.
+    const deadline = Date.now() + 10000;
+    let breakerError: string | undefined;
+    while (Date.now() < deadline) {
+      const r = await pool.runInSandbox("unused", {});
+      expect(r.ok).toBe(false);
+      if (!r.ok && r.error.includes("temporarily unavailable")) {
+        breakerError = r.error;
+        break;
+      }
+    }
+
+    expect(breakerError).toContain("temporarily unavailable");
+
+    // While open, a subsequent call fast-fails immediately with the same error.
+    const fast = await pool.runInSandbox("unused", {});
+    expect(fast.ok).toBe(false);
+    expect(fast.ok ? "" : fast.error).toContain("temporarily unavailable");
+  }, 15000);
+});

--- a/packages/back-end/test/sandbox-pool.test.ts
+++ b/packages/back-end/test/sandbox-pool.test.ts
@@ -1,0 +1,135 @@
+import {
+  workerExecArgv,
+  workerEnv,
+} from "../src/enterprise/sandbox/sandbox-pool";
+
+// The sandbox worker is a forked child. It must NOT inherit the parent's tracing
+// (APM) preload: a relative `--require .../tracing.*.js` fails to resolve from the
+// worker and crash-loops the boot, and even when it resolves it re-bootstraps a
+// full OpenTelemetry/Datadog SDK in every child. These tests pin that stripping.
+
+const heapArg = (argv: string[]) =>
+  argv.filter((a) => a.startsWith("--max-old-space-size="));
+
+describe("workerExecArgv", () => {
+  it("strips a separate-form tracing --require (OpenTelemetry)", () => {
+    const argv = workerExecArgv([
+      "--require",
+      "./packages/back-end/dist/tracing.opentelemetry.js",
+    ]);
+    expect(argv).not.toContain("--require");
+    expect(argv.some((a) => a.includes("tracing.opentelemetry"))).toBe(false);
+  });
+
+  it("strips a separate-form tracing -r (Datadog)", () => {
+    const argv = workerExecArgv([
+      "-r",
+      "./packages/back-end/dist/tracing.datadog.js",
+    ]);
+    expect(argv).not.toContain("-r");
+    expect(argv.some((a) => a.includes("tracing.datadog"))).toBe(false);
+  });
+
+  it("strips a combined-form tracing --require=<module>", () => {
+    const argv = workerExecArgv(["--require=./dist/tracing.opentelemetry.js"]);
+    expect(argv.some((a) => a.includes("tracing.opentelemetry"))).toBe(false);
+  });
+
+  it("keeps a non-tracing --require preload", () => {
+    const argv = workerExecArgv(["--require", "ts-node/register"]);
+    expect(argv).toEqual([
+      "--require",
+      "ts-node/register",
+      expect.stringMatching(/^--max-old-space-size=\d+$/),
+    ]);
+  });
+
+  it("keeps unrelated runtime flags", () => {
+    const argv = workerExecArgv(["--enable-source-maps", "--no-node-snapshot"]);
+    expect(argv).toContain("--enable-source-maps");
+    expect(argv).toContain("--no-node-snapshot");
+  });
+
+  it("replaces the parent's heap cap with the worker's own", () => {
+    const argv = workerExecArgv(["--max-old-space-size=8192"]);
+    expect(argv).not.toContain("--max-old-space-size=8192");
+    expect(heapArg(argv)).toHaveLength(1);
+  });
+
+  it("always appends exactly one heap cap, even with no parent flags", () => {
+    expect(heapArg(workerExecArgv([]))).toHaveLength(1);
+  });
+
+  it("strips tracing while keeping a sibling preload and runtime flag", () => {
+    const argv = workerExecArgv([
+      "--enable-source-maps",
+      "--require",
+      "ts-node/register",
+      "--require",
+      "/opt/app/dist/tracing.opentelemetry.js",
+    ]);
+    expect(argv.some((a) => a.includes("tracing.opentelemetry"))).toBe(false);
+    expect(argv).toContain("ts-node/register");
+    expect(argv).toContain("--enable-source-maps");
+    // The kept --require still pairs with its value (one require remains).
+    expect(argv.filter((a) => a === "--require")).toHaveLength(1);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = ["--require", "./dist/tracing.opentelemetry.js"];
+    workerExecArgv(input);
+    expect(input).toEqual(["--require", "./dist/tracing.opentelemetry.js"]);
+  });
+});
+
+describe("workerEnv", () => {
+  it("hard-disables the tracing SDKs", () => {
+    const env = workerEnv({});
+    expect(env.OTEL_SDK_DISABLED).toBe("true");
+    expect(env.DD_TRACE_ENABLED).toBe("false");
+  });
+
+  it("preserves unrelated env vars", () => {
+    const env = workerEnv({ FOO: "bar", PATH: "/usr/bin" });
+    expect(env.FOO).toBe("bar");
+    expect(env.PATH).toBe("/usr/bin");
+  });
+
+  it("scrubs a tracing --require from NODE_OPTIONS, keeping other options", () => {
+    const env = workerEnv({
+      NODE_OPTIONS:
+        "--require ./dist/tracing.opentelemetry.js --max-http-header-size=16384",
+    });
+    expect(env.NODE_OPTIONS).toBe("--max-http-header-size=16384");
+  });
+
+  it("deletes NODE_OPTIONS when only the tracing require was present", () => {
+    const env = workerEnv({
+      NODE_OPTIONS: "--require ./dist/tracing.datadog.js",
+    });
+    expect("NODE_OPTIONS" in env).toBe(false);
+  });
+
+  it("scrubs the combined-form --require=<tracing> from NODE_OPTIONS", () => {
+    const env = workerEnv({
+      NODE_OPTIONS: "--require=/opt/app/dist/tracing.opentelemetry.js",
+    });
+    expect("NODE_OPTIONS" in env).toBe(false);
+  });
+
+  it("keeps a non-tracing NODE_OPTIONS require untouched", () => {
+    const env = workerEnv({ NODE_OPTIONS: "--require ts-node/register" });
+    expect(env.NODE_OPTIONS).toBe("--require ts-node/register");
+  });
+
+  it("does not mutate the input env object", () => {
+    const input: NodeJS.ProcessEnv = {
+      NODE_OPTIONS: "--require ./dist/tracing.opentelemetry.js",
+    };
+    workerEnv(input);
+    expect(input.NODE_OPTIONS).toBe(
+      "--require ./dist/tracing.opentelemetry.js",
+    );
+    expect("OTEL_SDK_DISABLED" in input).toBe(false);
+  });
+});


### PR DESCRIPTION
Sandboxed hooks + otel crashing. Fix by improving hook stability and removing otel from sandbox.