### PR TITLE
Log sdk refreshes

### DIFF
--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -111,6 +111,7 @@ import { bucketRulesByEnv } from "back-end/src/util/toLegacy";
 import { ReqContext } from "back-end/types/request";
 import { getSDKPayloadCacheLocation } from "back-end/src/models/SdkConnectionCacheModel";
 import { logger } from "back-end/src/util/logger";
+import { Counter, Histogram, metrics } from "back-end/src/util/metrics";
 import { getEnvironments } from "back-end/src/util/organization.util";
 import { promiseAllChunks } from "back-end/src/util/promise";
 import { SDKPayloadKey } from "back-end/types/sdk-payload";
@@ -612,6 +613,34 @@ export function isSDKConnectionAffectedByPayloadKey(
   return connection.projects.includes(payloadKey.project);
 }
 
+let sdkPayloadRefreshesCounter: Counter | null = null;
+let sdkPayloadRefreshDurationHistogram: Histogram | null = null;
+
+function getSdkPayloadRefreshesCounter() {
+  if (!sdkPayloadRefreshesCounter) {
+    sdkPayloadRefreshesCounter = metrics.getCounter("sdk_payload.refreshes");
+  }
+  return sdkPayloadRefreshesCounter;
+}
+
+function getSdkPayloadRefreshDurationHistogram() {
+  if (!sdkPayloadRefreshDurationHistogram) {
+    sdkPayloadRefreshDurationHistogram = metrics.getHistogram(
+      "sdk_payload.refresh_duration_ms",
+    );
+  }
+  return sdkPayloadRefreshDurationHistogram;
+}
+
+function recordSdkPayloadRefreshMetrics(durationMs: number) {
+  try {
+    getSdkPayloadRefreshesCounter().increment();
+    getSdkPayloadRefreshDurationHistogram().record(durationMs);
+  } catch (e) {
+    logger.error({ err: e }, "Error recording sdk_payload refresh metrics");
+  }
+}
+
 // This is a synchronous wrapper around refreshSDKPayloadCache
 // We shouldn't need to await the refresh in most cases
 export function queueSDKPayloadRefresh(data: {
@@ -670,9 +699,15 @@ export async function refreshSDKPayloadCache({
 
   // If no environments are affected, we don't need to update anything
   if (!payloadKeys.length && !sdkConnectionsToUpdate.length) {
-    logger.debug("Skipping SDK Payload refresh - no environments affected");
+    logger.debug(
+      { orgId: context.org.id, auditContext: initialAuditContext },
+      "[sdk-payload] refresh skipped — no environments affected",
+    );
     return;
   }
+
+  const storageLocation = getSDKPayloadCacheLocation();
+  const refreshStartedAt = performance.now();
 
   // Clear any cache entries for legacy API keys since they can't be tracked individually
   try {
@@ -811,7 +846,6 @@ export async function refreshSDKPayloadCache({
               }
             : undefined;
 
-        const storageLocation = getSDKPayloadCacheLocation();
         if (storageLocation !== "none") {
           await context.models.sdkConnectionCache.upsert(
             connection.key,
@@ -826,11 +860,39 @@ export async function refreshSDKPayloadCache({
   });
 
   // If there are no changes, we don't need to do anything
-  if (!promises.length) return;
+  if (!promises.length) {
+    const durationMs = Math.round(performance.now() - refreshStartedAt);
+    recordSdkPayloadRefreshMetrics(durationMs);
+    logger.info(
+      {
+        orgId: context.org.id,
+        payloadKeys,
+        auditContext: initialAuditContext,
+        durationMs,
+      },
+      "[sdk-payload] refresh skipped — no matching SDK connections",
+    );
+    return;
+  }
 
   // There may be many SDK connection caches to update
   // Batch the promises in chunks of 4 at a time to avoid overloading Mongo
   await promiseAllChunks(promises, 4);
+
+  const durationMs = Math.round(performance.now() - refreshStartedAt);
+  recordSdkPayloadRefreshMetrics(durationMs);
+  logger.info(
+    {
+      orgId: context.org.id,
+      connectionKeys: connectionsUpdated.map((c) => c.key),
+      connectionCount: connectionsUpdated.length,
+      payloadKeys,
+      cacheLocation: storageLocation,
+      auditContext: initialAuditContext,
+      durationMs,
+    },
+    "[sdk-payload] refresh completed",
+  );
 
   triggerWebhookJobs(context, payloadKeys, connectionsUpdated, true).catch(
     (e) => {


### PR DESCRIPTION
### Features and Changes
Since SDK refreshes run in the background and they can be CPU intensive it would be good to get more visibility as to when they are occurring, for whom, and how long they take.  This PR adds logging with context and open telemetry metrics, which will help us to determine when CPU spikes are caused by sdk refreshes.  See [slack](https://growthbookapp.slack.com/archives/C055GKYGT26/p1781514513274499) for more detail.

### Testing
run datadog agent locally
pnpm build
pnpm start:with-datadog
Publish a new feature.
See the log line in the terminal output.
See the metrics [show up on datadog](https://us5.datadoghq.com/metric/explorer?fromUser=true&graph_layout=multi&start=1781563151394&end=1781563733530&paused=true#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGABuMMgaUADWTvLYaDgYUAB0RoJ2bBrAAFQ87RgaTpn4IggAFACUIHygkdG5sVgATInJCKnpeFk5eYiFxSCr5VU19Y3NrR1dPU5Qe56SIk6qGsNVAzzzALpUVzuPCYULhIGqEEYGKleLzCigCFQmE6db-KgaORoHKgJrYhAIA5QHAwMagjQQTKJNwCbROABGNFyFQwaDMJzQojgTjkimU6U5UESnJE3PoTGUIjcHjQ8KSEHsmCwPIUBxFSh4fx4fBAivEAGEpMIYCgRCC0DwgA)

