### PR TITLE
Monitored ramp-ups: fix UI issues for inverse metrics, 1-sided displays, signal metrics

### DIFF
--- a/packages/front-end/components/Experiment/AlignedGraph.tsx
+++ b/packages/front-end/components/Experiment/AlignedGraph.tsx
@@ -36,6 +36,9 @@ interface Props
   rowStatus?: string;
   isHovered?: boolean;
   percent?: boolean;
+  // When true the CI is one-sided: render a pill from the finite bound out to
+  // the open plot edge (never the two-sided violin), regardless of `uplift`.
+  oneSided?: boolean;
   onMouseMove?: (e: React.MouseEvent<SVGPathElement>) => void;
   onMouseLeave?: (e: React.MouseEvent<SVGPathElement>) => void;
   onMouseEnter?: (e: React.MouseEvent<SVGPathElement>) => void;
@@ -75,6 +78,7 @@ const AlignedGraph: FC<Props> = ({
   rowStatus,
   isHovered = false,
   percent = true,
+  oneSided = false,
   onMouseMove,
   onMouseLeave,
   onMouseEnter,
@@ -118,6 +122,13 @@ const AlignedGraph: FC<Props> = ({
   }
 
   if (barType == "violin" && !uplift) {
+    barType = "pill";
+  }
+
+  // One-sided intervals have a fake (±Infinity) bound, so the symmetric violin
+  // drawn from the uplift distribution would misrepresent them. Force a pill,
+  // which renders from the finite bound out to the open plot edge.
+  if (oneSided) {
     barType = "pill";
   }
 

--- a/packages/front-end/components/Experiment/ExperimentMetricTimeSeriesGraphWrapper.tsx
+++ b/packages/front-end/components/Experiment/ExperimentMetricTimeSeriesGraphWrapper.tsx
@@ -135,6 +135,7 @@ interface ExperimentMetricTimeSeriesGraphWrapperProps {
   preloadedTimeSeries?: MetricTimeSeries;
   dimensionId?: string;
   dimensionValue?: string;
+  oneSided?: boolean;
 }
 
 export default function ExperimentMetricTimeSeriesGraphWrapperWithErrorBoundary(
@@ -171,6 +172,7 @@ function ExperimentMetricTimeSeriesGraphWrapper({
   preloadedTimeSeries,
   dimensionId,
   dimensionValue,
+  oneSided = false,
 }: ExperimentMetricTimeSeriesGraphWrapperProps) {
   const { getFactTableById } = useDefinitions();
 
@@ -361,6 +363,7 @@ function ExperimentMetricTimeSeriesGraphWrapper({
       }
       statsEngine={statsEngine}
       usesPValueAdjustment={pValueAdjustmentEnabled}
+      oneSided={oneSided}
     />
   );
 }

--- a/packages/front-end/components/Experiment/ExperimentTimeSeriesGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentTimeSeriesGraph.tsx
@@ -64,6 +64,10 @@ export interface ExperimentTimeSeriesGraphProps {
   maxGapHours?: number;
   cumulative?: boolean;
   showVariations: boolean[];
+  // When true the CI is one-sided (one bound is ±Infinity). The y-range is
+  // anchored at 0 + padding around the finite bound/point estimates instead of
+  // expanding off the fake bound, and the ribbon fills out to the plot edge.
+  oneSided?: boolean;
 }
 
 const percentFormatter = new Intl.NumberFormat(undefined, {
@@ -384,6 +388,7 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
   hasStats = true,
   maxGapHours = 36,
   cumulative = false,
+  oneSided = false,
 }) => {
   const { containerRef, containerBounds, TooltipInPortal } = useTooltipInPortal(
     {
@@ -446,6 +451,40 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
 
   // Get y-axis domain
   const yDomain = useMemo<[number, number]>(() => {
+    if (oneSided) {
+      // One-sided CI: build the range from the *real* values only — finite CI
+      // bounds and point estimates — plus 0 as a reference. The fake
+      // (±Infinity) bound is ignored; the ribbon is filled out to the plot
+      // edge by ciLowerForArea/ciUpperForArea. Because we take min/max, 0 only
+      // widens the range when it is the extreme; a CI that straddles 0 keeps
+      // its real bounds.
+      const vals: number[] = [0];
+      datapoints.forEach((d) => {
+        d?.variations?.forEach((variation, i) => {
+          if (!showVariations[i]) return;
+          const pt = getYVal(variation ?? undefined, yaxis);
+          if (pt !== undefined) vals.push(pt);
+          const lo = variation?.ci?.[0];
+          const hi = variation?.ci?.[1];
+          if (lo !== undefined && Number.isFinite(lo)) vals.push(lo);
+          if (hi !== undefined && Number.isFinite(hi)) vals.push(hi);
+        });
+      });
+      const rawMin = Math.min(...vals);
+      const rawMax = Math.max(...vals);
+      const range = Math.max(rawMax - rawMin, 0.001);
+      const buffer = range * 0.05;
+      const paddedMin = rawMin - buffer;
+      const paddedMax = rawMax + buffer;
+      const minHalfWidthAboutZero = Math.max(
+        0.001,
+        ((paddedMax - paddedMin) / 2) * 0.02,
+      );
+      return [
+        Math.min(paddedMin, -minHalfWidthAboutZero),
+        Math.max(paddedMax, minHalfWidthAboutZero),
+      ];
+    }
     const minValue = Math.min(
       ...datapoints.map((d) =>
         d?.variations
@@ -564,7 +603,7 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
       Math.min(paddedMin, -minHalfWidthAboutZero),
       Math.max(paddedMax, minHalfWidthAboutZero),
     ];
-  }, [datapoints, yaxis, showVariations, sortedDatesWithData]);
+  }, [datapoints, yaxis, showVariations, sortedDatesWithData, oneSided]);
 
   // Get x-axis domain
   const min = Math.min(...datapoints.map((d) => d.d.getTime()));

--- a/packages/front-end/components/Experiment/PercentGraph.tsx
+++ b/packages/front-end/components/Experiment/PercentGraph.tsx
@@ -51,6 +51,7 @@ interface Props
   currentMetricTotal?: number;
   pValueAdjustmentEnabled?: boolean;
   statusLabels?: StatusLabels;
+  oneSided?: boolean;
 }
 
 export default function PercentGraph({
@@ -86,6 +87,7 @@ export default function PercentGraph({
   currentMetricTotal = 0,
   pValueAdjustmentEnabled,
   statusLabels,
+  oneSided = false,
 }: Props) {
   const { metricDefaults: _metricDefaults } = useOrganizationMetricDefaults();
 
@@ -160,6 +162,7 @@ export default function PercentGraph({
         className={className}
         isHovered={isHovered}
         percent={percent}
+        oneSided={oneSided}
         onMouseMove={onMouseMove}
         onMouseLeave={onMouseLeave}
         onClick={onClick}

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -137,6 +137,10 @@ export type ResultsTableProps = {
   dimensionValue?: string;
   valueColumnWidth?: number;
   labelMaxWidth?: number;
+  // When the underlying analysis uses one-sided intervals (e.g. safe
+  // rollouts), render CIs as one-sided: a single bound + open side, with the
+  // domain/range anchored at 0 rather than the fake (±Infinity) bound.
+  oneSided?: boolean;
 };
 
 const ROW_HEIGHT = 46;
@@ -211,6 +215,7 @@ export default function ResultsTable({
   dimensionValue,
   valueColumnWidth = 130,
   labelMaxWidth = 75,
+  oneSided = false,
 }: ResultsTableProps) {
   if (variationFilter?.includes(baselineRow)) {
     variationFilter = variationFilter.filter((v) => v !== baselineRow);
@@ -419,7 +424,7 @@ export default function ResultsTable({
   );
   const compactResults = filteredVariations.length <= 2;
 
-  const domain = useDomain(filteredVariations, rows, differenceType);
+  const domain = useDomain(filteredVariations, rows, differenceType, oneSided);
 
   const rowsResults: (RowResults | "query error" | RowError | null)[][] =
     useMemo(() => {
@@ -1177,6 +1182,7 @@ export default function ResultsTable({
                                             significant={rowResults.significant}
                                             baseline={baseline}
                                             domain={domain}
+                                            oneSided={oneSided}
                                             metric={row.metric}
                                             stats={stats}
                                             id={`${id}_violin_row${i}_var${j}_${
@@ -1324,6 +1330,7 @@ export default function ResultsTable({
                                           }
                                           dimensionId={dimensionId}
                                           dimensionValue={dimensionValue}
+                                          oneSided={oneSided}
                                         />
                                       </div>
                                     </div>

--- a/packages/front-end/components/Experiment/SafeRolloutTimeSeriesGraph.tsx
+++ b/packages/front-end/components/Experiment/SafeRolloutTimeSeriesGraph.tsx
@@ -32,7 +32,6 @@ export type TimeSeriesEventMarker = {
 type SafeRolloutTimeSeriesGraphProps = {
   data: MetricTimeSeries;
   xDateRange?: [undefined, undefined] | [Date, Date];
-  inverse?: boolean;
   eventMarkers?: TimeSeriesEventMarker[];
   ssrPolyfills?: SSRPolyfills;
 };
@@ -40,7 +39,6 @@ type SafeRolloutTimeSeriesGraphProps = {
 export default function SafeRolloutTimeSeriesGraph({
   data,
   xDateRange,
-  inverse,
   eventMarkers,
   ssrPolyfills,
 }: SafeRolloutTimeSeriesGraphProps) {
@@ -50,7 +48,6 @@ export default function SafeRolloutTimeSeriesGraph({
         <SafeRolloutTimeSeriesGraphContent
           data={data}
           xDateRange={xDateRange}
-          inverse={inverse}
           eventMarkers={eventMarkers}
           width={width}
           height={height}
@@ -75,7 +72,6 @@ type DataPoint = {
 const SafeRolloutTimeSeriesGraphContent = ({
   data,
   xDateRange,
-  inverse = false,
   eventMarkers,
   width,
   height,
@@ -176,15 +172,15 @@ const SafeRolloutTimeSeriesGraphContent = ({
     .flatMap((d) => {
       const ciResult = getNonInfiniteSideOfCI(d.variations[1]);
 
-      // Determine if this CI value is on the "wrong" side of zero.
-      // For inverse metrics, the "bad" direction is flipped.
+      // Determine if this CI value is on the "wrong" side of zero. Safe
+      // rollouts use one-sided intervals and the back-end already picks the
+      // direction from the metric's `inverse` flag (a "greater" test for
+      // inverse metrics, a "lesser" test otherwise). The finite bound is
+      // therefore always the boundary pointing toward harm, so a regression is
+      // simply that bound crossing zero — no extra `inverse` adjustment here.
       const isNegative =
         ciResult.value !== null &&
-        (inverse
-          ? (ciResult.isUpperBound && ciResult.value > 0) ||
-            (!ciResult.isUpperBound && ciResult.value < 0)
-          : (ciResult.isUpperBound && ciResult.value < 0) ||
-            (!ciResult.isUpperBound && ciResult.value > 0));
+        (ciResult.isUpperBound ? ciResult.value < 0 : ciResult.value > 0);
 
       return {
         x: xScale(d.date),
@@ -419,7 +415,6 @@ const SafeRolloutTimeSeriesGraphContent = ({
                   tooltipData,
                   formatter,
                   formatterOptions,
-                  inverse,
                   metric?.name,
                 )}
               </div>
@@ -434,7 +429,6 @@ function getTooltipContent(
   tooltipData: { datum: DataPoint; index: number },
   formatter: (value: number, options?: Intl.NumberFormatOptions) => string,
   formatterOptions: Intl.NumberFormatOptions,
-  inverse = false,
   metricName?: string,
 ) {
   const rolloutVariation = tooltipData.datum.variations?.find(
@@ -447,11 +441,12 @@ function getTooltipContent(
 
   const ci = getNonInfiniteSideOfCI(rolloutVariation);
 
-  const isRegression = inverse
-    ? (ci.isUpperBound && (ci.value ?? 0) > 0) ||
-      (!ci.isUpperBound && (ci.value ?? 0) < 0)
-    : (ci.isUpperBound && (ci.value ?? 0) < 0) ||
-      (!ci.isUpperBound && (ci.value ?? 0) > 0);
+  // The finite bound of the one-sided CI is the boundary toward harm (the
+  // back-end already orients it via the metric's `inverse` flag), so a
+  // regression is that bound crossing zero into the harmful side.
+  const isRegression = ci.isUpperBound
+    ? (ci.value ?? 0) < 0
+    : (ci.value ?? 0) > 0;
 
   const getStatusInfo = () => {
     if (isRegression) {

--- a/packages/front-end/components/MetricDrilldown/MetricDrilldownOverview.tsx
+++ b/packages/front-end/components/MetricDrilldown/MetricDrilldownOverview.tsx
@@ -49,6 +49,7 @@ interface MetricDrilldownOverviewProps {
   dimensionInfo?: DrilldownDimensionInfo;
   valueColumnWidth?: number;
   labelMaxWidth?: number;
+  oneSided?: boolean;
 }
 
 function MetricDrilldownOverview({
@@ -79,6 +80,7 @@ function MetricDrilldownOverview({
   localBaselineRow = 0,
   valueColumnWidth,
   labelMaxWidth,
+  oneSided = false,
 }: MetricDrilldownOverviewProps) {
   const [statsExpanded, setStatsExpanded] = useState(false);
   const { isAuthenticated } = useAuth();
@@ -157,6 +159,7 @@ function MetricDrilldownOverview({
         dimensionValue={dimensionInfo?.rawValue}
         valueColumnWidth={valueColumnWidth}
         labelMaxWidth={labelMaxWidth}
+        oneSided={oneSided}
         snapshot={snapshot}
         analysis={analysis}
         setAnalysisSettings={setAnalysisSettings}

--- a/packages/front-end/components/RampSchedule/SafeRolloutRuleDashboard/MetricSection.tsx
+++ b/packages/front-end/components/RampSchedule/SafeRolloutRuleDashboard/MetricSection.tsx
@@ -455,6 +455,7 @@ function SafeRolloutMetricDrilldownModal({
         preloadedTimeSeries={timeSeries}
         valueColumnWidth={170}
         labelMaxWidth={120}
+        oneSided
       />
     </Modal>
   );
@@ -624,7 +625,6 @@ export function MetricSection({
               const stats = row.variations[1] || { value: 0, cr: 0, users: 0 };
               const rr = allRowResults[i];
               const metricTs = timeSeries[row.metric.id];
-              const isInverse = !!row.metric.inverse;
 
               const hasData = rr.enoughData || (stats.users ?? 0) > 0;
 
@@ -671,7 +671,6 @@ export function MetricSection({
                         <SafeRolloutTimeSeriesGraph
                           data={metricTs ?? emptyTimeSeries(row.metric.id)}
                           xDateRange={dateExtent}
-                          inverse={isInverse}
                           eventMarkers={eventMarkers}
                         />
                       </div>

--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -211,6 +211,11 @@ export function useDomain(
   variations: ExperimentReportVariation[], // must be ordered, baseline first
   rows: ExperimentTableRow[],
   differenceType: DifferenceType,
+  // When the analysis uses one-sided intervals (e.g. safe rollouts), one CI
+  // bound is "fake" (±Infinity). In that case we anchor the open side at 0
+  // rather than inferring a finite extent from it, so the domain is "0 +
+  // padding around the real bound" instead of "[ci, ci]".
+  oneSided = false,
 ): [number, number] {
   const { metricDefaults } = useOrganizationMetricDefaults();
 
@@ -282,7 +287,19 @@ export function useDomain(
       const loFinite = Number.isFinite(ci0);
       const hiFinite = Number.isFinite(ci1);
 
-      if (loFinite && hiFinite) {
+      if (oneSided) {
+        // One bound is fake (±Infinity). Build the extent from the *real*
+        // values only — the finite bound and the point estimate — plus 0 as a
+        // reference. Because we take min/max, 0 only widens the domain when it
+        // is actually the extreme (the real CI sits entirely on one side of
+        // it); a "proper" CI that has drifted across 0 keeps its real bounds
+        // and 0 simply sits interior. The open side is drawn out to the plot
+        // edge by the consuming graph.
+        const realValues = [expected, 0];
+        if (loFinite) realValues.push(ci0);
+        if (hiFinite) realValues.push(ci1);
+        addBounds(Math.min(...realValues), Math.max(...realValues));
+      } else if (loFinite && hiFinite) {
         addBounds(ci0, ci1);
       } else if (!loFinite && hiFinite) {
         // One-sided [-Infinity, X]: infer a symmetric-ish finite left extent.


### PR DESCRIPTION
Several display fixes for monitored ramp-ups.
- signal metrics were being rendered as secondary metrics in the drilldown
- 1-sided CI graphs / timeseries were being drawn as if they were 2-sided
- UI was inversing an already-inversed result, making it look like the UI was wrong. Analysis remained correct, just presented wrong.

<img width="1424" height="666" alt="image" src="https://github.com/user-attachments/assets/0a0b2fa0-6e74-4008-9f96-76215ceb9c1b" />
