### PR TITLE
Reconcile update fact table function

### DIFF
--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -89,7 +89,6 @@ import {
   createDataSource,
   getDataSourcesByOrganization,
   getDataSourceById,
-  getRawDataSourceById,
   deleteDatasource,
   updateDataSource,
 } from "back-end/src/models/DataSourceModel";
@@ -530,8 +529,7 @@ export async function putDataSource(
         datasource.id,
       );
       if (existingEventForwarder && settings.userIdTypes !== undefined) {
-        const rawDatasource = await getRawDataSourceById(context, id);
-        const existingUserIdTypes = rawDatasource?.settings?.userIdTypes ?? [];
+        const existingUserIdTypes = datasource.settings?.userIdTypes ?? [];
         if (
           !isEqual(settings.userIdTypes, existingUserIdTypes) &&
           !isEventForwarderAllowedUserIdTypesChange(

--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -150,11 +150,11 @@ export async function getGrowthbookDatasource(context: ReqContext) {
     : null;
 }
 
-/** Returns persisted datasource fields without upgradeDatasourceObject defaults. */
-export async function getRawDataSourceById(
+export async function getDataSourceById(
   context: ReqContext | ApiReqContext,
   id: string,
-): Promise<DataSourceInterface | null> {
+) {
+  // If using config.yml, immediately return the from there
   if (usingFileConfig()) {
     return (
       getConfigDatasources(context.org.id).filter((d) => d.id === id)[0] || null
@@ -168,20 +168,11 @@ export async function getRawDataSourceById(
 
   if (!doc) return null;
 
-  const datasource = doc.toJSON() as DataSourceInterface;
+  const datasource = toInterface(doc);
 
   return context.permissions.canReadMultiProjectResource(datasource.projects)
     ? datasource
     : null;
-}
-
-export async function getDataSourceById(
-  context: ReqContext | ApiReqContext,
-  id: string,
-) {
-  const datasource = await getRawDataSourceById(context, id);
-  if (!datasource) return null;
-  return upgradeDatasourceObject(datasource);
 }
 
 export async function getDataSourcesByIds(

--- a/packages/back-end/src/models/EventForwarderConfigModel.ts
+++ b/packages/back-end/src/models/EventForwarderConfigModel.ts
@@ -33,6 +33,10 @@ const BaseClass = MakeModelClass({
 });
 
 export class EventForwarderConfigModel extends BaseClass {
+  protected hasPremiumFeature(): boolean {
+    return this.context.hasPremiumFeature("events-forwarder");
+  }
+
   protected canCreate(doc: EventForwarderConfigInterface): boolean {
     return this.context.permissions.canCreateEventForwarderConfig(doc);
   }

--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -300,17 +300,13 @@ export async function updateFactTable(
   context: ReqContext | ApiReqContext,
   factTable: FactTableInterface,
   changes: UpdateFactTableProps,
-  {
-    bypassManagedByCheck,
-  }: {
-    bypassManagedByCheck?: boolean;
-  } = {},
 ) {
-  // Allow changing columns even for API-managed fact tables
+  // Allow changing columns even for API-managed fact tables. Also allow
+  // system-initiated updates (e.g. the event forwarder sync) through.
   if (
-    !bypassManagedByCheck &&
     factTable.managedBy === "api" &&
     context.auditUser?.type !== "api_key" &&
+    context.auditUser?.type !== "system" &&
     Object.keys(changes).some((k) => k !== "columns")
   ) {
     throw new Error(

--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -302,11 +302,12 @@ export async function updateFactTable(
   changes: UpdateFactTableProps,
 ) {
   // Allow changing columns even for API-managed fact tables. Also allow
-  // system-initiated updates (e.g. the event forwarder sync) through.
+  // system/background contexts (which have no audit user) through, e.g. the
+  // event forwarder sync.
   if (
     factTable.managedBy === "api" &&
     context.auditUser?.type !== "api_key" &&
-    context.auditUser?.type !== "system" &&
+    context.auditUser !== null &&
     Object.keys(changes).some((k) => k !== "columns")
   ) {
     throw new Error(

--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -300,9 +300,15 @@ export async function updateFactTable(
   context: ReqContext | ApiReqContext,
   factTable: FactTableInterface,
   changes: UpdateFactTableProps,
+  {
+    bypassManagedByCheck,
+  }: {
+    bypassManagedByCheck?: boolean;
+  } = {},
 ) {
   // Allow changing columns even for API-managed fact tables
   if (
+    !bypassManagedByCheck &&
     factTable.managedBy === "api" &&
     context.auditUser?.type !== "api_key" &&
     Object.keys(changes).some((k) => k !== "columns")
@@ -355,12 +361,6 @@ const ALLOWED_COLUMN_UPDATE_FIELDS = [
   "userIdTypes",
 ] as const;
 
-const ALLOWED_EVENT_FORWARDER_METADATA_UPDATE_FIELDS = [
-  "columns",
-  "sql",
-  "columnRefreshPending",
-] as const;
-
 // This is called from a background cronjob to re-sync all of the columns
 // It doesn't need to check for 'managedBy' and doesn't need to set 'dateUpdated'
 export async function updateFactTableColumns(
@@ -403,40 +403,6 @@ export async function updateFactTableColumns(
       });
     }
   }
-}
-
-export async function updateEventForwarderFactTableMetadata(
-  factTable: FactTableInterface,
-  changes: Partial<
-    Pick<
-      FactTableInterface,
-      (typeof ALLOWED_EVENT_FORWARDER_METADATA_UPDATE_FIELDS)[number]
-    >
-  >,
-  context: ReqContext | ApiReqContext,
-) {
-  const safeChanges = Object.fromEntries(
-    Object.entries(changes).filter(([key]) =>
-      ALLOWED_EVENT_FORWARDER_METADATA_UPDATE_FIELDS.includes(
-        key as (typeof ALLOWED_EVENT_FORWARDER_METADATA_UPDATE_FIELDS)[number],
-      ),
-    ),
-  );
-
-  await FactTableModel.updateOne(
-    {
-      id: factTable.id,
-      organization: factTable.organization,
-    },
-    {
-      $set: {
-        ...safeChanges,
-        dateUpdated: new Date(),
-      },
-    },
-  );
-
-  await audit.logUpdate(context, factTable, { ...factTable, ...safeChanges });
 }
 
 // Detect columns that were removed or had auto slice disabled

--- a/packages/back-end/src/services/eventForwarder/datasourceQueries.ts
+++ b/packages/back-end/src/services/eventForwarder/datasourceQueries.ts
@@ -11,7 +11,6 @@ import {
 import uniqid from "uniqid";
 import {
   getDataSourceById,
-  getRawDataSourceById,
   updateDataSource,
 } from "back-end/src/models/DataSourceModel";
 import {
@@ -35,11 +34,11 @@ export async function ensureEventForwarderExposureQueries(
     return;
   }
 
-  const raw = await getRawDataSourceById(
+  const datasource = await getDataSourceById(
     context,
     eventForwarderConfig.datasourceId,
   );
-  if (!raw) {
+  if (!datasource) {
     return;
   }
 
@@ -49,25 +48,18 @@ export async function ensureEventForwarderExposureQueries(
     isHashAttributeUserIdType(
       userIdType,
       resolvedAttributeSchema,
-      raw.projects,
+      datasource.projects,
     ),
   );
   if (syncedUserIdTypes.length === 0) {
     return;
   }
 
-  const datasource = await getDataSourceById(
-    context,
-    eventForwarderConfig.datasourceId,
-  );
-
   const connectionParams =
     datasourceParams ??
-    (datasource
-      ? (getSourceIntegrationObject(context, datasource).params as
-          | BigQueryConnectionParams
-          | SnowflakeConnectionParams)
-      : undefined);
+    (getSourceIntegrationObject(context, datasource).params as
+      | BigQueryConnectionParams
+      | SnowflakeConnectionParams);
 
   const sqlParams = buildExposureQueryParams(
     eventForwarderConfig,
@@ -76,7 +68,7 @@ export async function ensureEventForwarderExposureQueries(
   if (!sqlParams) {
     logger.warn(
       {
-        datasourceId: raw.id,
+        datasourceId: datasource.id,
         organizationId: context.org.id,
         sinkType: eventForwarderConfig.sinkType,
       },
@@ -85,7 +77,7 @@ export async function ensureEventForwarderExposureQueries(
     return;
   }
 
-  const existing = raw.settings?.queries?.exposure ?? [];
+  const existing = datasource.settings?.queries?.exposure ?? [];
   const merged = mergeEventForwarderExposureQueries(
     existing,
     syncedUserIdTypes,
@@ -97,26 +89,14 @@ export async function ensureEventForwarderExposureQueries(
     return;
   }
 
-  if (!datasource) {
-    logger.warn(
-      {
-        datasourceId: raw.id,
-        organizationId: context.org.id,
-        sinkType: eventForwarderConfig.sinkType,
-      },
-      "Skipping event forwarder exposure queries: datasource unavailable for update",
-    );
-    return;
-  }
-
   await updateDataSource(
     context,
     datasource,
     {
       settings: {
-        ...raw.settings,
+        ...datasource.settings,
         queries: {
-          ...raw.settings?.queries,
+          ...datasource.settings?.queries,
           exposure: merged,
         },
       },
@@ -137,15 +117,15 @@ export async function ensureEventForwarderFeatureUsageQuery(
   eventForwarderConfig: EventForwarderConfigInterface,
   datasourceParams?: BigQueryConnectionParams | SnowflakeConnectionParams,
 ): Promise<string[]> {
-  const raw = await getRawDataSourceById(
+  const datasource = await getDataSourceById(
     context,
     eventForwarderConfig.datasourceId,
   );
-  if (!raw) {
+  if (!datasource) {
     return [];
   }
 
-  const existing = raw.settings?.queries?.featureUsage ?? [];
+  const existing = datasource.settings?.queries?.featureUsage ?? [];
   const existingManaged = existing.filter(
     isEventForwarderManagedFeatureUsageQuery,
   );
@@ -153,18 +133,11 @@ export async function ensureEventForwarderFeatureUsageQuery(
     return existingManaged.map((query) => query.id);
   }
 
-  const datasource = await getDataSourceById(
-    context,
-    eventForwarderConfig.datasourceId,
-  );
-
   const connectionParams =
     datasourceParams ??
-    (datasource
-      ? (getSourceIntegrationObject(context, datasource).params as
-          | BigQueryConnectionParams
-          | SnowflakeConnectionParams)
-      : undefined);
+    (getSourceIntegrationObject(context, datasource).params as
+      | BigQueryConnectionParams
+      | SnowflakeConnectionParams);
 
   const sqlParams = buildFeatureUsageQueryParams(
     eventForwarderConfig,
@@ -173,23 +146,11 @@ export async function ensureEventForwarderFeatureUsageQuery(
   if (!sqlParams) {
     logger.warn(
       {
-        datasourceId: raw.id,
+        datasourceId: datasource.id,
         organizationId: context.org.id,
         sinkType: eventForwarderConfig.sinkType,
       },
       "Skipping event forwarder feature usage query: missing sink connection params",
-    );
-    return [];
-  }
-
-  if (!datasource) {
-    logger.warn(
-      {
-        datasourceId: raw.id,
-        organizationId: context.org.id,
-        sinkType: eventForwarderConfig.sinkType,
-      },
-      "Skipping event forwarder feature usage query: datasource unavailable for update",
     );
     return [];
   }
@@ -204,9 +165,9 @@ export async function ensureEventForwarderFeatureUsageQuery(
     datasource,
     {
       settings: {
-        ...raw.settings,
+        ...datasource.settings,
         queries: {
-          ...raw.settings?.queries,
+          ...datasource.settings?.queries,
           featureUsage: [...existing, managedQuery],
         },
       },

--- a/packages/back-end/src/services/eventForwarder/datasourceSync.ts
+++ b/packages/back-end/src/services/eventForwarder/datasourceSync.ts
@@ -11,7 +11,6 @@ import { SnowflakeConnectionParams } from "shared/types/integrations/snowflake";
 import { EventForwarderConfigInterface } from "shared/validators";
 import {
   getDataSourceById,
-  getRawDataSourceById,
   updateDataSource,
 } from "back-end/src/models/DataSourceModel";
 import { buildExposureQueryParams } from "back-end/src/services/eventForwarder/sinkParams";
@@ -70,31 +69,26 @@ export async function initializeDatasourceUserIdTypesFromOrgAttributeSchema(
     return;
   }
 
-  const raw = await getRawDataSourceById(context, datasourceId);
-  if (!raw) {
+  const datasource = await getDataSourceById(context, datasourceId);
+  if (!datasource) {
     return;
   }
 
   const built = buildUserIdTypesFromAttributeSchema(
     context.org.settings?.attributeSchema ?? [],
-    raw.projects,
+    datasource.projects,
   );
 
-  const existing = raw.settings?.userIdTypes ?? [];
+  const existing = datasource.settings?.userIdTypes ?? [];
   const merged = mergeUserIdTypes(existing, built);
 
   if (merged.length === existing.length) {
     return;
   }
 
-  const datasource = await getDataSourceById(context, datasourceId);
-  if (!datasource) {
-    return;
-  }
-
   await updateDataSource(context, datasource, {
     settings: {
-      ...raw.settings,
+      ...datasource.settings,
       userIdTypes: merged,
     },
   });
@@ -105,11 +99,6 @@ export async function reconcileEventForwarderDatasourceUserIdTypesAndExposureQue
   config: EventForwarderConfigInterface,
   attributeSchema: SDKAttributeSchema,
 ): Promise<void> {
-  const raw = await getRawDataSourceById(context, config.datasourceId);
-  if (!raw) {
-    return;
-  }
-
   const datasource = await getDataSourceById(context, config.datasourceId);
   if (!datasource) {
     logger.warn(
@@ -124,13 +113,13 @@ export async function reconcileEventForwarderDatasourceUserIdTypesAndExposureQue
 
   const desiredUserIdTypes = buildUserIdTypesFromAttributeSchema(
     attributeSchema,
-    raw.projects,
+    datasource.projects,
   );
   const desiredUserIdTypeIds = desiredUserIdTypes.map(
     (userIdType) => userIdType.userIdType,
   );
-  const existingUserIdTypes = raw.settings?.userIdTypes ?? [];
-  const existingExposure = raw.settings?.queries?.exposure ?? [];
+  const existingUserIdTypes = datasource.settings?.userIdTypes ?? [];
+  const existingExposure = datasource.settings?.queries?.exposure ?? [];
   const managedExposure = getManagedExposureOwnership(existingExposure);
   const ownedUserIdTypes = [
     ...desiredUserIdTypeIds,
@@ -174,10 +163,10 @@ export async function reconcileEventForwarderDatasourceUserIdTypesAndExposureQue
       datasource,
       {
         settings: {
-          ...raw.settings,
+          ...datasource.settings,
           userIdTypes: updatedUserIdTypes,
           queries: {
-            ...raw.settings?.queries,
+            ...datasource.settings?.queries,
             exposure: updatedExposure,
           },
         },

--- a/packages/back-end/src/services/eventForwarder/factTable.ts
+++ b/packages/back-end/src/services/eventForwarder/factTable.ts
@@ -36,6 +36,7 @@ import {
   queueFactTableColumnsRefresh,
   queueFactTableColumnsRefreshAt,
 } from "back-end/src/jobs/refreshFactTableColumns";
+import { getSystemContextForOrgObject } from "back-end/src/services/organizations";
 import { logger } from "back-end/src/util/logger";
 import { ReqContext } from "back-end/types/request";
 
@@ -233,7 +234,7 @@ export async function syncEventForwarderEventsFactTableMetadataAfterAttributeSch
         );
       });
       await updateFactTable(
-        context,
+        getSystemContextForOrgObject(context.org, "event-forwarder"),
         factTable,
         {
           ...(hasMetadataChanges && {
@@ -244,7 +245,6 @@ export async function syncEventForwarderEventsFactTableMetadataAfterAttributeSch
             columnRefreshPending: true,
           }),
         },
-        { bypassManagedByCheck: true },
       );
     }
 

--- a/packages/back-end/src/services/eventForwarder/factTable.ts
+++ b/packages/back-end/src/services/eventForwarder/factTable.ts
@@ -23,7 +23,7 @@ import {
   createFactTable,
   getFactTable,
   deleteFactTable,
-  updateEventForwarderFactTableMetadata,
+  updateFactTable,
 } from "back-end/src/models/FactTableModel";
 import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 import {
@@ -232,7 +232,8 @@ export async function syncEventForwarderEventsFactTableMetadataAfterAttributeSch
           now,
         );
       });
-      await updateEventForwarderFactTableMetadata(
+      await updateFactTable(
+        context,
         factTable,
         {
           ...(hasMetadataChanges && {
@@ -243,7 +244,7 @@ export async function syncEventForwarderEventsFactTableMetadataAfterAttributeSch
             columnRefreshPending: true,
           }),
         },
-        context,
+        { bypassManagedByCheck: true },
       );
     }
 

--- a/packages/back-end/src/services/eventForwarder/factTable.ts
+++ b/packages/back-end/src/services/eventForwarder/factTable.ts
@@ -36,7 +36,7 @@ import {
   queueFactTableColumnsRefresh,
   queueFactTableColumnsRefreshAt,
 } from "back-end/src/jobs/refreshFactTableColumns";
-import { getSystemContextForOrgObject } from "back-end/src/services/organizations";
+import { getContextForAgendaJobByOrgObject } from "back-end/src/services/organizations";
 import { logger } from "back-end/src/util/logger";
 import { ReqContext } from "back-end/types/request";
 
@@ -234,7 +234,7 @@ export async function syncEventForwarderEventsFactTableMetadataAfterAttributeSch
         );
       });
       await updateFactTable(
-        getSystemContextForOrgObject(context.org, "event-forwarder"),
+        getContextForAgendaJobByOrgObject(context.org),
         factTable,
         {
           ...(hasMetadataChanges && {

--- a/packages/back-end/src/services/eventForwarder/warehouseSync.ts
+++ b/packages/back-end/src/services/eventForwarder/warehouseSync.ts
@@ -5,7 +5,6 @@ import {
 import { ReqContext } from "back-end/types/request";
 import {
   getDataSourceById,
-  getRawDataSourceById,
   updateDataSource,
   validateExposureQueriesAndAddMissingIds,
 } from "back-end/src/models/DataSourceModel";
@@ -19,18 +18,13 @@ export async function revalidateManagedEventForwarderDataSourceQueries(
   context: ReqContext,
   datasourceId: string,
 ): Promise<void> {
-  const raw = await getRawDataSourceById(context, datasourceId);
-  if (!raw) {
-    return;
-  }
-
   const datasource = await getDataSourceById(context, datasourceId);
   if (!datasource) {
     return;
   }
 
-  const exposure = raw.settings?.queries?.exposure ?? [];
-  const featureUsage = raw.settings?.queries?.featureUsage ?? [];
+  const exposure = datasource.settings?.queries?.exposure ?? [];
+  const featureUsage = datasource.settings?.queries?.featureUsage ?? [];
   const hasManagedExposure = exposure.some(
     isEventForwarderManagedExposureQuery,
   );
@@ -46,9 +40,9 @@ export async function revalidateManagedEventForwarderDataSourceQueries(
     context,
     datasource,
     {
-      ...raw.settings,
+      ...datasource.settings,
       queries: {
-        ...raw.settings?.queries,
+        ...datasource.settings?.queries,
         exposure,
         featureUsage,
       },

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -1370,6 +1370,25 @@ export function getContextForAgendaJobByOrgObject(
   });
 }
 
+// Admin context that acts as the system actor. Use for system-initiated
+// updates to API-managed resources (e.g. event forwarder fact tables) so they
+// pass both the permission check (admin role) and the `managedBy === "api"`
+// guard (which lets the `system` audit user type through). Audit logs attribute
+// the change to SYSTEM.
+export function getSystemContextForOrgObject(
+  organization: OrganizationInterface,
+  subtype?: string,
+): ApiReqContext {
+  return new ReqContextClass({
+    org: organization,
+    auditUser: {
+      type: "system",
+      ...(subtype ? { subtype } : {}),
+    },
+    role: "admin",
+  });
+}
+
 export async function getContextForAgendaJobByOrgId(
   orgId: string,
 ): Promise<ApiReqContext> {

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -1370,25 +1370,6 @@ export function getContextForAgendaJobByOrgObject(
   });
 }
 
-// Admin context that acts as the system actor. Use for system-initiated
-// updates to API-managed resources (e.g. event forwarder fact tables) so they
-// pass both the permission check (admin role) and the `managedBy === "api"`
-// guard (which lets the `system` audit user type through). Audit logs attribute
-// the change to SYSTEM.
-export function getSystemContextForOrgObject(
-  organization: OrganizationInterface,
-  subtype?: string,
-): ApiReqContext {
-  return new ReqContextClass({
-    org: organization,
-    auditUser: {
-      type: "system",
-      ...(subtype ? { subtype } : {}),
-    },
-    role: "admin",
-  });
-}
-
 export async function getContextForAgendaJobByOrgId(
   orgId: string,
 ): Promise<ApiReqContext> {

--- a/packages/back-end/test/services/eventForwarderDatasourceLifecycle.test.ts
+++ b/packages/back-end/test/services/eventForwarderDatasourceLifecycle.test.ts
@@ -126,67 +126,6 @@ describe("syncEventForwarderAfterDatasourceDeleted", () => {
     expect(deleteForDatasourceCascade).not.toHaveBeenCalled();
   });
 
-  it("tears down Confluent before cascade-deleting the row for Snowflake", async () => {
-    const existing: EventForwarderConfigInterface = {
-      id: "efc_s",
-      organization: "org1",
-      datasourceId: "ds_s",
-      projects: ["p1"],
-      topic: "topic-s",
-      schemaId: 1,
-      sinkType: "snowflake",
-      config: "{}",
-      status: "ready",
-      dateCreated: new Date(),
-      dateUpdated: new Date(),
-    };
-
-    const callOrder: string[] = [];
-    const deleteForDatasourceCascade = jest
-      .fn()
-      .mockImplementation(async () => {
-        callOrder.push("delete");
-      });
-    mockedTeardownRemote.mockImplementation(async () => {
-      callOrder.push("teardown");
-    });
-    const getByDatasourceIdForDatasourceCascade = jest
-      .fn()
-      .mockResolvedValue(existing);
-
-    const context = {
-      org: { id: "org1" },
-      auditLog: jest.fn(),
-      models: {
-        eventForwarderConfigs: {
-          getByDatasourceIdForDatasourceCascade,
-          deleteForDatasourceCascade,
-        },
-      },
-    };
-
-    const snowflakeDs: DataSourceInterface = {
-      ...bqDatasource("ds_s"),
-      type: "snowflake",
-    };
-
-    await syncEventForwarderAfterDatasourceDeleted(
-      context as never,
-      snowflakeDs,
-    );
-
-    expect(deleteForDatasourceCascade).toHaveBeenCalledWith(existing);
-    expect(mockedTeardownRemote).toHaveBeenCalledWith({
-      organizationId: "org1",
-      datasourceId: "ds_s",
-      sinkType: "snowflake",
-      topic: "topic-s",
-      connectorName: undefined,
-      connectorId: undefined,
-    });
-    expect(callOrder).toEqual(["teardown", "delete"]);
-  });
-
   it("invokes teardown only for the forwarder tied to the deleted datasource id", async () => {
     const existingA: EventForwarderConfigInterface = {
       id: "efc_a",

--- a/packages/back-end/test/services/eventForwarderDatasourceLifecycle.test.ts
+++ b/packages/back-end/test/services/eventForwarderDatasourceLifecycle.test.ts
@@ -100,6 +100,67 @@ describe("syncEventForwarderAfterDatasourceDeleted", () => {
     expect(callOrder).toEqual(["teardown", "delete"]);
   });
 
+  it("tears down Confluent before cascade-deleting the row for Snowflake", async () => {
+    const existing: EventForwarderConfigInterface = {
+      id: "efc_s",
+      organization: "org1",
+      datasourceId: "ds_s",
+      projects: ["p1"],
+      topic: "topic-s",
+      schemaId: 1,
+      sinkType: "snowflake",
+      config: "{}",
+      status: "ready",
+      dateCreated: new Date(),
+      dateUpdated: new Date(),
+    };
+
+    const callOrder: string[] = [];
+    const deleteForDatasourceCascade = jest
+      .fn()
+      .mockImplementation(async () => {
+        callOrder.push("delete");
+      });
+    mockedTeardownRemote.mockImplementation(async () => {
+      callOrder.push("teardown");
+    });
+    const getByDatasourceIdForDatasourceCascade = jest
+      .fn()
+      .mockResolvedValue(existing);
+
+    const context = {
+      org: { id: "org1" },
+      auditLog: jest.fn(),
+      models: {
+        eventForwarderConfigs: {
+          getByDatasourceIdForDatasourceCascade,
+          deleteForDatasourceCascade,
+        },
+      },
+    };
+
+    const snowflakeDs: DataSourceInterface = {
+      ...bqDatasource("ds_s"),
+      type: "snowflake",
+    };
+
+    await syncEventForwarderAfterDatasourceDeleted(
+      context as never,
+      snowflakeDs,
+    );
+
+    expect(deleteForDatasourceCascade).toHaveBeenCalledWith(existing);
+    expect(mockedTeardownRemote).toHaveBeenCalledWith({
+      organizationId: "org1",
+      datasourceId: "ds_s",
+      sinkType: "snowflake",
+      topic: "topic-s",
+      connectorName: undefined,
+      connectorId: undefined,
+    });
+    expect(callOrder).toEqual(["teardown", "delete"]);
+  });
+
   it("does nothing when no event forwarder exists for that datasource", async () => {
     const getByDatasourceIdForDatasourceCascade = jest
       .fn()

--- a/packages/back-end/test/services/eventForwarderExposureQueries.test.ts
+++ b/packages/back-end/test/services/eventForwarderExposureQueries.test.ts
@@ -427,27 +427,4 @@ describe("ensureEventForwarderExposureQueries", () => {
       { skipEventForwarderManagedValidation: true },
     );
   });
-
-  it("skips hash attributes missing from stale context when attributeSchema is omitted", async () => {
-    const raw = ds({
-      userIdTypes: [{ userIdType: "device_id", description: "" }],
-      queries: { exposure: [] },
-    });
-    mockedGetRaw.mockResolvedValue(raw);
-    mockedGetById.mockResolvedValue(raw);
-    mockedDecrypt.mockReturnValue({
-      dataset: "analytics_123",
-      tablePrefix: "gb",
-      serviceAccountKey: "{}",
-    });
-
-    await ensureEventForwarderExposureQueries(
-      context([]) as never,
-      efConfig("bigquery"),
-      ["device_id"],
-      { defaultProject: "my-project" } as never,
-    );
-
-    expect(mockedUpdate).not.toHaveBeenCalled();
-  });
 });

--- a/packages/back-end/test/services/eventForwarderExposureQueries.test.ts
+++ b/packages/back-end/test/services/eventForwarderExposureQueries.test.ts
@@ -12,10 +12,6 @@ jest.mock("back-end/src/services/eventForwarder/warehouseSync", () => ({
   queueDelayedEventForwarderWarehouseSyncForDatasource: jest.fn(),
 }));
 
-const mockedGetRaw =
-  DataSourceModel.getRawDataSourceById as jest.MockedFunction<
-    typeof DataSourceModel.getRawDataSourceById
-  >;
 const mockedGetById = DataSourceModel.getDataSourceById as jest.MockedFunction<
   typeof DataSourceModel.getDataSourceById
 >;
@@ -117,7 +113,6 @@ describe("ensureEventForwarderExposureQueries", () => {
       queries: { exposure: [] },
     });
     raw.params = encryptParams(bigqueryParams);
-    mockedGetRaw.mockResolvedValue(raw);
     mockedGetById.mockResolvedValue(raw);
     mockedDecrypt.mockReturnValue({
       dataset: "analytics_123",
@@ -159,7 +154,6 @@ describe("ensureEventForwarderExposureQueries", () => {
       ],
       queries: { exposure: [] },
     });
-    mockedGetRaw.mockResolvedValue(raw);
     mockedGetById.mockResolvedValue(raw);
     mockedDecrypt.mockReturnValue({
       dataset: "analytics_123",
@@ -214,7 +208,6 @@ describe("ensureEventForwarderExposureQueries", () => {
       userIdTypes: [{ userIdType: "user_id", description: "" }],
       queries: { exposure: [] },
     });
-    mockedGetRaw.mockResolvedValue(raw);
     mockedGetById.mockResolvedValue({
       ...raw,
       type: "snowflake",
@@ -258,7 +251,6 @@ describe("ensureEventForwarderExposureQueries", () => {
         ],
       },
     });
-    mockedGetRaw.mockResolvedValue(raw);
     mockedGetById.mockResolvedValue(raw);
     mockedDecrypt.mockReturnValue({
       dataset: "analytics_123",
@@ -295,7 +287,6 @@ describe("ensureEventForwarderExposureQueries", () => {
         ],
       },
     });
-    mockedGetRaw.mockResolvedValue(raw);
     mockedGetById.mockResolvedValue(raw);
     mockedDecrypt.mockReturnValue({
       dataset: "analytics_123",
@@ -318,7 +309,7 @@ describe("ensureEventForwarderExposureQueries", () => {
   });
 
   it("skips when synced userIdTypes is empty", async () => {
-    mockedGetRaw.mockResolvedValue(ds({ userIdTypes: [], queries: {} }));
+    mockedGetById.mockResolvedValue(ds({ userIdTypes: [], queries: {} }));
 
     await ensureEventForwarderExposureQueries(
       context() as never,
@@ -339,7 +330,6 @@ describe("ensureEventForwarderExposureQueries", () => {
       ],
       queries: { exposure: [] },
     });
-    mockedGetRaw.mockResolvedValue(raw);
     mockedGetById.mockResolvedValue(raw);
     mockedDecrypt.mockReturnValue({
       dataset: "analytics_123",
@@ -384,7 +374,6 @@ describe("ensureEventForwarderExposureQueries", () => {
       userIdTypes: [{ userIdType: "ef_device_id", description: "" }],
       queries: { exposure: [] },
     });
-    mockedGetRaw.mockResolvedValue(raw);
     mockedGetById.mockResolvedValue(raw);
     mockedDecrypt.mockReturnValue({
       dataset: "analytics_123",

--- a/packages/back-end/test/services/eventForwarderFactTable.test.ts
+++ b/packages/back-end/test/services/eventForwarderFactTable.test.ts
@@ -13,6 +13,7 @@ import * as FactTableModel from "back-end/src/models/FactTableModel";
 import * as EventForwarderConfig from "back-end/src/services/eventForwarder/config";
 import * as DataSourceService from "back-end/src/services/datasource";
 import * as RefreshFactTableColumns from "back-end/src/jobs/refreshFactTableColumns";
+import * as Organizations from "back-end/src/services/organizations";
 
 jest.mock("back-end/src/models/DataSourceModel");
 jest.mock("back-end/src/models/FactTableModel");
@@ -23,6 +24,9 @@ jest.mock("shared/util", () => ({
 }));
 jest.mock("back-end/src/services/datasource");
 jest.mock("back-end/src/jobs/refreshFactTableColumns");
+jest.mock("back-end/src/services/organizations", () => ({
+  getSystemContextForOrgObject: jest.fn(),
+}));
 
 const mockedGetDataSourceById =
   DataSourceModel.getDataSourceById as jest.MockedFunction<
@@ -39,10 +43,21 @@ const mockedDeleteFactTable =
   FactTableModel.deleteFactTable as jest.MockedFunction<
     typeof FactTableModel.deleteFactTable
   >;
-const mockedUpdateEventForwarderFactTableMetadata =
-  FactTableModel.updateEventForwarderFactTableMetadata as jest.MockedFunction<
-    typeof FactTableModel.updateEventForwarderFactTableMetadata
+const mockedUpdateFactTable =
+  FactTableModel.updateFactTable as jest.MockedFunction<
+    typeof FactTableModel.updateFactTable
   >;
+const mockedGetSystemContextForOrgObject =
+  Organizations.getSystemContextForOrgObject as jest.MockedFunction<
+    typeof Organizations.getSystemContextForOrgObject
+  >;
+// Sentinel returned by the mocked system-context factory. The event forwarder
+// sync passes this to updateFactTable so it can bypass the managedBy === "api"
+// guard; the tests assert it is threaded through unchanged.
+const systemContext = {
+  org: { id: "org1" },
+  auditUser: { type: "system", subtype: "event-forwarder" },
+} as never;
 const mockedDecrypt =
   EventForwarderConfig.decryptEventForwarderConfigModel as jest.MockedFunction<
     typeof EventForwarderConfig.decryptEventForwarderConfigModel
@@ -304,6 +319,7 @@ describe("syncEventForwarderEventsFactTableMetadataAfterAttributeSchemaChange", 
     jest.clearAllMocks();
     mockedGetBigQueryTablePrefix.mockReturnValue("gb");
     mockedGetSnowflakeTablePrefix.mockReturnValue("GB");
+    mockedGetSystemContextForOrgObject.mockReturnValue(systemContext);
   });
 
   it("updates managed fact table attribute jsonFields and queues delayed refresh", async () => {
@@ -361,29 +377,29 @@ describe("syncEventForwarderEventsFactTableMetadataAfterAttributeSchemaChange", 
       ],
     );
 
-    expect(mockedUpdateEventForwarderFactTableMetadata).toHaveBeenCalledWith(
-      ft,
-      {
-        columns: [
-          expect.objectContaining({
-            column: "attributes",
-            name: "attributes",
-            description: "",
-            numberFormat: "",
-            datatype: "json",
-            jsonFields: {
-              user_id: { datatype: "string" },
-              age: { datatype: "number" },
-            },
-          }),
-        ],
-        columnRefreshPending: true,
-        sql: expect.stringContaining(
-          "SAFE_CAST(JSON_VALUE(`attributes`, '$.\"age\"') AS FLOAT64) AS age",
-        ),
-      },
-      ctx,
+    expect(mockedGetSystemContextForOrgObject).toHaveBeenCalledWith(
+      ctx.org,
+      "event-forwarder",
     );
+    expect(mockedUpdateFactTable).toHaveBeenCalledWith(systemContext, ft, {
+      columns: [
+        expect.objectContaining({
+          column: "attributes",
+          name: "attributes",
+          description: "",
+          numberFormat: "",
+          datatype: "json",
+          jsonFields: {
+            user_id: { datatype: "string" },
+            age: { datatype: "number" },
+          },
+        }),
+      ],
+      columnRefreshPending: true,
+      sql: expect.stringContaining(
+        "SAFE_CAST(JSON_VALUE(`attributes`, '$.\"age\"') AS FLOAT64) AS age",
+      ),
+    });
     expect(mockedQueueFactTableColumnsRefreshAt).toHaveBeenCalledWith(
       ft,
       expect.any(Date),
@@ -450,84 +466,12 @@ WHERE received_at BETWEEN '{{startDate}}' AND '{{endDate}}'`;
       [{ property: "user_id", datatype: "string", hashAttribute: true }],
     );
 
-    expect(mockedUpdateEventForwarderFactTableMetadata).toHaveBeenCalledWith(
-      ft,
-      {
-        columnRefreshPending: true,
-      },
-      ctx,
-    );
+    expect(mockedUpdateFactTable).toHaveBeenCalledWith(systemContext, ft, {
+      columnRefreshPending: true,
+    });
     expect(mockedQueueFactTableColumnsRefreshAt).toHaveBeenCalledWith(
       ft,
       expect.any(Date),
-    );
-  });
-
-  it("clears deleted flag when rebuilding managed attributes column metadata", async () => {
-    const ctx = context();
-    ctx.models.eventForwarderConfigs.getAll.mockResolvedValue([
-      {
-        datasourceId: "ds_1",
-        sinkType: "bigquery",
-      },
-    ]);
-
-    const ds = datasource({
-      settings: {
-        userIdTypes: [{ userIdType: "user_id", description: "" }],
-      },
-      projects: [],
-    });
-    const ft = eventsFactTable({
-      columns: [
-        {
-          column: "attributes",
-          name: "attributes",
-          description: "",
-          numberFormat: "",
-          datatype: "json",
-          jsonFields: {
-            user_id: { datatype: "string" },
-          },
-          dateCreated: new Date(),
-          dateUpdated: new Date(),
-          deleted: true,
-          topValues: [],
-          autoSlices: [],
-          lockedAutoSlices: [],
-        },
-      ],
-    });
-
-    mockedGetDataSourceById.mockResolvedValue(ds);
-    mockedGetFactTable.mockResolvedValue(ft);
-    mockedGetSourceIntegrationObject.mockReturnValue({
-      params: {
-        defaultProject: "my-project",
-      },
-    } as never);
-    mockedDecrypt.mockReturnValue({
-      dataset: "analytics_123",
-      tablePrefix: "gb",
-      serviceAccountKey: "{}",
-    });
-
-    await syncEventForwarderEventsFactTableMetadataAfterAttributeSchemaChange(
-      ctx as never,
-      [{ property: "user_id", datatype: "string", hashAttribute: true }],
-    );
-
-    expect(mockedUpdateEventForwarderFactTableMetadata).toHaveBeenCalledWith(
-      ft,
-      expect.objectContaining({
-        columns: [
-          expect.objectContaining({
-            column: "attributes",
-            deleted: false,
-          }),
-        ],
-      }),
-      ctx,
     );
   });
 });

--- a/packages/back-end/test/services/eventForwarderFactTable.test.ts
+++ b/packages/back-end/test/services/eventForwarderFactTable.test.ts
@@ -25,7 +25,7 @@ jest.mock("shared/util", () => ({
 jest.mock("back-end/src/services/datasource");
 jest.mock("back-end/src/jobs/refreshFactTableColumns");
 jest.mock("back-end/src/services/organizations", () => ({
-  getSystemContextForOrgObject: jest.fn(),
+  getContextForAgendaJobByOrgObject: jest.fn(),
 }));
 
 const mockedGetDataSourceById =
@@ -47,16 +47,16 @@ const mockedUpdateFactTable =
   FactTableModel.updateFactTable as jest.MockedFunction<
     typeof FactTableModel.updateFactTable
   >;
-const mockedGetSystemContextForOrgObject =
-  Organizations.getSystemContextForOrgObject as jest.MockedFunction<
-    typeof Organizations.getSystemContextForOrgObject
+const mockedGetContextForAgendaJobByOrgObject =
+  Organizations.getContextForAgendaJobByOrgObject as jest.MockedFunction<
+    typeof Organizations.getContextForAgendaJobByOrgObject
   >;
-// Sentinel returned by the mocked system-context factory. The event forwarder
-// sync passes this to updateFactTable so it can bypass the managedBy === "api"
-// guard; the tests assert it is threaded through unchanged.
-const systemContext = {
+// Sentinel returned by the mocked background-job context factory. The event
+// forwarder sync passes this to updateFactTable so it can bypass the
+// managedBy === "api" guard; the tests assert it is threaded through unchanged.
+const agendaContext = {
   org: { id: "org1" },
-  auditUser: { type: "system", subtype: "event-forwarder" },
+  auditUser: null,
 } as never;
 const mockedDecrypt =
   EventForwarderConfig.decryptEventForwarderConfigModel as jest.MockedFunction<
@@ -319,7 +319,7 @@ describe("syncEventForwarderEventsFactTableMetadataAfterAttributeSchemaChange", 
     jest.clearAllMocks();
     mockedGetBigQueryTablePrefix.mockReturnValue("gb");
     mockedGetSnowflakeTablePrefix.mockReturnValue("GB");
-    mockedGetSystemContextForOrgObject.mockReturnValue(systemContext);
+    mockedGetContextForAgendaJobByOrgObject.mockReturnValue(agendaContext);
   });
 
   it("updates managed fact table attribute jsonFields and queues delayed refresh", async () => {
@@ -377,11 +377,10 @@ describe("syncEventForwarderEventsFactTableMetadataAfterAttributeSchemaChange", 
       ],
     );
 
-    expect(mockedGetSystemContextForOrgObject).toHaveBeenCalledWith(
+    expect(mockedGetContextForAgendaJobByOrgObject).toHaveBeenCalledWith(
       ctx.org,
-      "event-forwarder",
     );
-    expect(mockedUpdateFactTable).toHaveBeenCalledWith(systemContext, ft, {
+    expect(mockedUpdateFactTable).toHaveBeenCalledWith(agendaContext, ft, {
       columns: [
         expect.objectContaining({
           column: "attributes",
@@ -466,7 +465,7 @@ WHERE received_at BETWEEN '{{startDate}}' AND '{{endDate}}'`;
       [{ property: "user_id", datatype: "string", hashAttribute: true }],
     );
 
-    expect(mockedUpdateFactTable).toHaveBeenCalledWith(systemContext, ft, {
+    expect(mockedUpdateFactTable).toHaveBeenCalledWith(agendaContext, ft, {
       columnRefreshPending: true,
     });
     expect(mockedQueueFactTableColumnsRefreshAt).toHaveBeenCalledWith(

--- a/packages/back-end/test/services/eventForwarderFeatureUsageQueries.test.ts
+++ b/packages/back-end/test/services/eventForwarderFeatureUsageQueries.test.ts
@@ -1,9 +1,7 @@
 import type { DataSourceInterface } from "shared/types/datasource";
-import { BigQueryConnectionParams } from "shared/types/integrations/bigquery";
 import { ensureEventForwarderFeatureUsageQuery } from "back-end/src/services/eventForwarder/datasourceQueries";
 import * as DataSourceModel from "back-end/src/models/DataSourceModel";
 import * as EventForwarderConfig from "back-end/src/services/eventForwarder/config";
-import { encryptParams } from "back-end/src/services/datasource";
 
 jest.mock("back-end/src/models/DataSourceModel");
 jest.mock("back-end/src/services/eventForwarder/config");
@@ -199,29 +197,5 @@ describe("ensureEventForwarderFeatureUsageQuery", () => {
       mockedUpdate.mock.calls[0][2].settings?.queries?.featureUsage ?? [];
     expect(featureUsage[0].query).toContain("MY_DB.PUBLIC.GB_FEATURE_USAGE");
     expect(featureUsage[0].query).not.toContain("WHERE");
-  });
-
-  it("uses decrypted params when datasourceParams is omitted", async () => {
-    const bigqueryParams: BigQueryConnectionParams = {
-      projectId: "my-project",
-      clientEmail: "test@example.com",
-      privateKey: "key",
-    };
-    const raw = ds({ queries: { featureUsage: [] } });
-    raw.params = encryptParams(bigqueryParams);
-    mockedGetRaw.mockResolvedValue(raw);
-    mockedGetById.mockResolvedValue(raw);
-    mockedDecrypt.mockReturnValue({
-      dataset: "analytics_123",
-      tablePrefix: "gb",
-      serviceAccountKey: "{}",
-    });
-
-    await ensureEventForwarderFeatureUsageQuery(
-      context() as never,
-      efConfig("bigquery"),
-    );
-
-    expect(mockedUpdate).toHaveBeenCalled();
   });
 });

--- a/packages/back-end/test/services/eventForwarderFeatureUsageQueries.test.ts
+++ b/packages/back-end/test/services/eventForwarderFeatureUsageQueries.test.ts
@@ -6,10 +6,6 @@ import * as EventForwarderConfig from "back-end/src/services/eventForwarder/conf
 jest.mock("back-end/src/models/DataSourceModel");
 jest.mock("back-end/src/services/eventForwarder/config");
 
-const mockedGetRaw =
-  DataSourceModel.getRawDataSourceById as jest.MockedFunction<
-    typeof DataSourceModel.getRawDataSourceById
-  >;
 const mockedGetById = DataSourceModel.getDataSourceById as jest.MockedFunction<
   typeof DataSourceModel.getDataSourceById
 >;
@@ -89,7 +85,6 @@ describe("ensureEventForwarderFeatureUsageQuery", () => {
 
   it("creates a managed feature usage query for BigQuery", async () => {
     const raw = ds({ queries: { featureUsage: [] } });
-    mockedGetRaw.mockResolvedValue(raw);
     mockedGetById.mockResolvedValue(raw);
     mockedDecrypt.mockReturnValue({
       dataset: "analytics_123",
@@ -135,7 +130,6 @@ describe("ensureEventForwarderFeatureUsageQuery", () => {
         featureUsage: [{ id: "manual", query: "SELECT 1" }],
       },
     });
-    mockedGetRaw.mockResolvedValue(raw);
     mockedGetById.mockResolvedValue(raw);
     mockedDecrypt.mockReturnValue({
       dataset: "analytics_123",
@@ -163,7 +157,7 @@ describe("ensureEventForwarderFeatureUsageQuery", () => {
         featureUsage: [{ id: "managed", query: "SELECT 2", managedBy: "api" }],
       },
     });
-    mockedGetRaw.mockResolvedValue(raw);
+    mockedGetById.mockResolvedValue(raw);
 
     const ids = await ensureEventForwarderFeatureUsageQuery(
       context() as never,
@@ -176,7 +170,6 @@ describe("ensureEventForwarderFeatureUsageQuery", () => {
 
   it("creates Snowflake feature usage query without WHERE clause", async () => {
     const raw = ds({ queries: { featureUsage: [] } });
-    mockedGetRaw.mockResolvedValue(raw);
     mockedGetById.mockResolvedValue({ ...raw, type: "snowflake" });
     mockedDecrypt.mockReturnValue({
       database: "MY_DB",

--- a/packages/back-end/test/services/eventForwarderUserIdTypes.test.ts
+++ b/packages/back-end/test/services/eventForwarderUserIdTypes.test.ts
@@ -12,17 +12,12 @@ const EVENT_FORWARDER_MANAGED_IDENTIFIER_TYPE_DESCRIPTION =
   "Managed by Event Forwarder.";
 
 jest.mock("back-end/src/models/DataSourceModel", () => ({
-  getRawDataSourceById: jest.fn(),
   getDataSourceById: jest.fn(),
   updateDataSource: jest.fn(),
 }));
 jest.mock("back-end/src/services/eventForwarder/sinkParams");
 jest.mock("back-end/src/services/datasource");
 
-const mockedGetRaw =
-  DataSourceModel.getRawDataSourceById as jest.MockedFunction<
-    typeof DataSourceModel.getRawDataSourceById
-  >;
 const mockedGetById = DataSourceModel.getDataSourceById as jest.MockedFunction<
   typeof DataSourceModel.getDataSourceById
 >;
@@ -115,7 +110,6 @@ describe("initializeDatasourceUserIdTypesFromOrgAttributeSchema without event fo
     const raw = ds("ds_1", {
       userIdTypes: [{ userIdType: "user_id", description: "Existing" }],
     });
-    mockedGetRaw.mockResolvedValue(raw);
     setupDataSourceMocks(raw);
 
     await initializeDatasourceUserIdTypesFromOrgAttributeSchema(
@@ -153,7 +147,6 @@ describe("initializeDatasourceUserIdTypesFromOrgAttributeSchema without event fo
 
   it("writes userIdTypes when raw Mongo has none", async () => {
     const raw = ds("ds_1", {});
-    mockedGetRaw.mockResolvedValue(raw);
     setupDataSourceMocks(raw);
 
     await initializeDatasourceUserIdTypesFromOrgAttributeSchema(
@@ -223,7 +216,6 @@ describe("reconcileEventForwarderDatasourceUserIdTypesAndExposureQueries", () =>
         ],
       },
     });
-    mockedGetRaw.mockResolvedValue(raw);
     setupDataSourceMocks(raw);
     const attributeSchema = [
       {
@@ -279,7 +271,6 @@ describe("reconcileEventForwarderDatasourceUserIdTypesAndExposureQueries", () =>
       userIdTypes: [],
       queries: { exposure: [] },
     });
-    mockedGetRaw.mockResolvedValue(raw);
     setupDataSourceMocks(raw);
     const attributeSchema = [
       { property: "id", datatype: "string" as const, hashAttribute: true },
@@ -327,7 +318,6 @@ describe("reconcileEventForwarderDatasourceUserIdTypesAndExposureQueries", () =>
         ],
       },
     });
-    mockedGetRaw.mockResolvedValue(raw);
     setupDataSourceMocks(raw);
     const attributeSchema = [
       { property: "user_id", datatype: "number" as const, hashAttribute: true },
@@ -367,7 +357,6 @@ describe("reconcileEventForwarderDatasourceUserIdTypesAndExposureQueries", () =>
         ],
       },
     });
-    mockedGetRaw.mockResolvedValue(raw);
     setupDataSourceMocks(raw);
     const updateConfig = jest.fn();
 
@@ -399,7 +388,7 @@ describe("reconcileEventForwarderDatasourceUserIdTypesAndExposureQueries", () =>
       [{ property: "id", datatype: "string", hashAttribute: true }],
     );
 
-    expect(mockedGetRaw).not.toHaveBeenCalled();
+    expect(mockedGetById).not.toHaveBeenCalled();
     expect(mockedUpdate).not.toHaveBeenCalled();
   });
 
@@ -408,7 +397,6 @@ describe("reconcileEventForwarderDatasourceUserIdTypesAndExposureQueries", () =>
       userIdTypes: [],
       queries: { exposure: [] },
     });
-    mockedGetRaw.mockResolvedValue(raw);
     setupDataSourceMocks(raw);
     const updateConfig = jest.fn();
     const attributeSchema = [


### PR DESCRIPTION
### Features and Changes
- Move to a single updateFactTable function (use existing one and use admin context rather than user context)
- Don’t bypass data source model migrations (need more info, Nhat has more context here)
- Make sure we’re checking for the `events-forwarder` commercialFeature for EventForwarderConfigModel on create
