### PR TITLE
Ty/update table design

### DIFF
--- a/packages/front-end/styles/global-radix-overrides.scss
+++ b/packages/front-end/styles/global-radix-overrides.scss
@@ -446,6 +446,10 @@ p.rt-TooltipText {
 }
 
 // Table
+.rt-TableRow {
+  color: var(--color-text-high);
+}
+
 .rt-TableRootTable {
   .rt-TableBody > .rt-TableRow:last-child > .rt-TableCell {
     box-shadow: none;

--- a/packages/front-end/ui/Table.module.scss
+++ b/packages/front-end/ui/Table.module.scss
@@ -1,3 +1,7 @@
+:global(.rt-TableRootTable .rt-TableColumnHeaderCell) {
+  font-weight: 500;
+}
+
 // List table variant: sticky header, row hover (use same solid surface as surface variant)
 .wrapper[data-table-list] {
   max-width: 100%;

--- a/packages/front-end/ui/Table.module.scss
+++ b/packages/front-end/ui/Table.module.scss
@@ -31,6 +31,7 @@
   }
 
   :global(.rt-TableHeader) {
+    --table-row-background-color: var(--color-panel-solid);
     background-color: var(--color-panel-solid);
     border-top-left-radius: var(--radius-4);
     border-top-right-radius: var(--radius-4);
@@ -45,6 +46,7 @@
     white-space: nowrap;
     box-sizing: border-box;
     padding: var(--space-3);
+    box-shadow: inset 0 1px 0 0 var(--slate-a5, rgba(0, 9, 50, 0.12));
   }
 
   :global(.rt-TableRootTable) {
@@ -101,6 +103,7 @@
   }
 
   :global(.rt-TableCell .rt-TableHeader) {
+    --table-row-background-color: transparent;
     background-color: unset;
     border-top-left-radius: unset;
     border-top-right-radius: unset;


### PR DESCRIPTION
### Features and Changes

Design tweaks to the shared list table (`ui/Table`) and global Radix table styles:

- **Header text weight:** Column header cells now use `font-weight: 500`.
- **Header background:** The list-table header now reliably renders with `--color-panel-solid`. Radix's `surface` variant paints the header background through the header cells via `--table-row-background-color`, so that variable is now overridden (in addition to `background-color`) to win over the Radix default (`--gray-a2`).
- **Header top border:** The header's inset top border is now drawn on each header cell, since the opaque cell backgrounds were covering the original inset shadow on the `.rt-TableHeader` group.
- **Nested tables:** Nested ghost-table headers (e.g. a table inside an expanded row) reset `--table-row-background-color` to `transparent` so they don't inherit the panel color.
- **Row text color:** `.rt-TableRow` text now uses `--color-text-high` for better contrast.

### Dependencies

None

### Testing

1. Run the front-end (`pnpm dev:apps`).
2. Open a page that uses the list table variant (`Table` with `data-table-list`) and verify:
   - The header background is the solid panel color (not the gray surface tint).
   - The top border of the header is visible.
   - Header text is medium weight (500) and row text has high-contrast color.
3. Verify a table with expandable rows containing a nested table: the nested table's header should be transparent (no panel-colored background).
4. Check both light and dark themes.
