### PR TITLE
Fix search tokenization

### DIFF
--- a/packages/front-end/services/search.tsx
+++ b/packages/front-end/services/search.tsx
@@ -80,6 +80,10 @@ export function tagFilterOnClick(
   };
 }
 
+// Whitespace + punctuation (incl. underscores), matching MiniSearch's default
+// tokenizer. Used to split indexed fields into searchable parts.
+const wordSeparators = /[\n\r\p{Z}\p{P}]+/u;
+
 const searchTermOperators = [">", "<", "^", "=", "~", ""] as const;
 
 export type SyntaxFilter = {
@@ -227,10 +231,21 @@ export function useSearch<T extends { id: string }>({
     const miniSearchInstance = new MiniSearch({
       idField: internalSearchIdField,
       fields,
+      // Index each field as its punctuation-split parts AND its whole
+      // whitespace-delimited form. The parts let a query like "bar" find
+      // "foo_bar_baz"; the whole form lets an underscore-containing query
+      // ("foo_bar") prefix-match the full key instead of being split into
+      // separate tokens that would each OR-match (so "foo_bar" would wrongly
+      // match a feature named "foo").
+      tokenize: (text) => [
+        ...new Set([...text.split(/\s+/), ...text.split(wordSeparators)]),
+      ],
       searchOptions: {
         boost: keys,
         fuzzy: true,
         prefix: true,
+        // Split the query on whitespace only so "foo_bar" stays a single term.
+        tokenize: (text) => text.split(/\s+/),
       },
     });
 

--- a/packages/front-end/services/search.tsx
+++ b/packages/front-end/services/search.tsx
@@ -238,14 +238,16 @@ export function useSearch<T extends { id: string }>({
       // separate tokens that would each OR-match (so "foo_bar" would wrongly
       // match a feature named "foo").
       tokenize: (text) => [
-        ...new Set([...text.split(/\s+/), ...text.split(wordSeparators)]),
+        ...new Set(
+          [...text.split(/\s+/), ...text.split(wordSeparators)].filter(Boolean),
+        ),
       ],
       searchOptions: {
         boost: keys,
         fuzzy: true,
         prefix: true,
         // Split the query on whitespace only so "foo_bar" stays a single term.
-        tokenize: (text) => text.split(/\s+/),
+        tokenize: (text) => text.split(/\s+/).filter(Boolean),
       },
     });
 

--- a/packages/front-end/test/services/search.test.ts
+++ b/packages/front-end/test/services/search.test.ts
@@ -602,6 +602,48 @@ describe("useSearch", () => {
     });
   });
 
+  describe("underscore tokenization", () => {
+    type SearchItem = {
+      id: string;
+      name: string;
+    };
+
+    const items: SearchItem[] = [
+      { id: "1", name: "foo" },
+      { id: "2", name: "foo_bar_baz" },
+    ];
+
+    const setup = () =>
+      renderHook(() =>
+        useSearch<SearchItem>({
+          items,
+          searchFields: ["name"],
+          localStorageKey: "search-service-test-underscore",
+          defaultSortField: "name",
+        }),
+      );
+
+    it("matches a feature on an inner token", () => {
+      const { result } = setup();
+      act(() => {
+        result.current.setSearchValue("bar");
+      });
+      expect(result.current.filteredItems.map((i) => i.name)).toContain(
+        "foo_bar_baz",
+      );
+    });
+
+    it("requires the full multi-token query, not a partial subset", () => {
+      const { result } = setup();
+      act(() => {
+        result.current.setSearchValue("foo_bar");
+      });
+      const names = result.current.filteredItems.map((i) => i.name);
+      expect(names).toContain("foo_bar_baz");
+      expect(names).not.toContain("foo");
+    });
+  });
+
   describe("filterSearchTerm", () => {
     it("should filter with default operator", () => {
       // Strings (exact default)


### PR DESCRIPTION
### Features and Changes

Fixes feature search treating multi-token queries too permissively. MiniSearch's default tokenizer splits on punctuation — including underscores and hyphens — and that same tokenizer was applied to the search query, so `foo_bar` was split into `foo` OR `bar` and matched a feature named just `foo`.

The index still splits keys into parts (so `bar` finds `foo_bar_baz`), but now also indexes the whole key, and the query is split on whitespace only. So `foo_bar` stays a single term that prefix-matches the full key rather than OR-matching its parts.

- Closes #6117

### Testing

Verified against the reported cases (`foo` = a feature named `foo`):

```
"bar"            => foo_bar_baz                  (inner-token search still works)
"foo_bar"        => foo_bar_baz                  (no longer matches "foo")
"multi_account"  => multi_account                (not foo_account_bar)
"comms_foo"     => comms_foo_bar             (not content_foo)
"comms"          => comms_foo_bar             (prefix still works)
"checkout-new"   => checkout-new-flow            (hyphens treated like underscores)
```

Added regression tests in `search.test.ts`; existing search tests still pass.
