### PR TITLE
Fix cross-tenant path traversal in local upload endpoint

### DIFF
--- a/packages/back-end/src/routers/upload/upload.controller.ts
+++ b/packages/back-end/src/routers/upload/upload.controller.ts
@@ -23,6 +23,7 @@ import {
   getReportByUid,
   getReportsByExperimentId,
 } from "back-end/src/models/ReportModel";
+import { getOrgScopedPath } from "back-end/src/routers/upload/upload.util";
 
 const SIGNED_IMAGE_EXPIRY_MINUTES = 15;
 
@@ -98,11 +99,9 @@ export function getImage(req: AuthRequest<{ path: string }>, res: Response) {
     );
   }
 
-  const path = req.path[0] === "/" ? req.path.substr(1) : req.path;
-
-  const orgFromPath = path.split("/")[0];
-  if (orgFromPath !== org.id) {
-    context.throwBadRequestError("Invalid organization");
+  const path = getOrgScopedPath(req.path, org.id);
+  if (!path) {
+    return context.throwBadRequestError("Invalid organization");
   }
 
   const ext = path.split(".")?.pop()?.toLowerCase() ?? "";
@@ -131,11 +130,12 @@ export async function getSignedImageToken(
     );
   }
 
-  const fullPath = req.path.substring("/signed-url/".length);
-
-  const orgFromPath = fullPath.split("/")[0];
-  if (orgFromPath !== org.id) {
-    context.throwBadRequestError("Invalid organization");
+  const fullPath = getOrgScopedPath(
+    req.path.substring("/signed-url/".length),
+    org.id,
+  );
+  if (!fullPath) {
+    return context.throwBadRequestError("Invalid organization");
   }
 
   const signedUrl = await getSignedImageUrl(
@@ -302,11 +302,11 @@ export async function getSignedPublicImageToken(
   // Extract the image path from the request
   // The route is /upload/public-signed-url/:path* so req.path will be like:
   // /upload/public-signed-url/org_xxx/2025-10/img_xxx.jpeg
-  const fullPath = req.path.substring("/upload/public-signed-url/".length);
-
-  // Verify the org in the path matches the organization
-  const orgFromPath = fullPath.split("/")[0];
-  if (orgFromPath !== organizationId) {
+  const fullPath = getOrgScopedPath(
+    req.path.substring("/upload/public-signed-url/".length),
+    organizationId,
+  );
+  if (!fullPath) {
     res.status(403).json({
       status: 403,
       message: "Invalid organization",

--- a/packages/back-end/src/routers/upload/upload.util.ts
+++ b/packages/back-end/src/routers/upload/upload.util.ts
@@ -8,9 +8,7 @@ export function getOrgScopedPath(
   rawPath: string,
   orgId: string,
 ): string | null {
-  const normalized = posix.normalize(
-    rawPath[0] === "/" ? rawPath.slice(1) : rawPath,
-  );
+  const normalized = posix.normalize(rawPath.replace(/^\/+/, ""));
   if (normalized !== orgId && !normalized.startsWith(`${orgId}/`)) {
     return null;
   }

--- a/packages/back-end/src/routers/upload/upload.util.ts
+++ b/packages/back-end/src/routers/upload/upload.util.ts
@@ -1,0 +1,18 @@
+import { posix } from "path";
+
+// Normalize a user-supplied upload path and confirm it stays within the org's
+// own folder. Collapsing ".." before the check is what blocks cross-tenant
+// traversal like "org_A/../org_B/..." from slipping past a first-segment check.
+// Returns the normalized path, or null if it escapes the org's folder.
+export function getOrgScopedPath(
+  rawPath: string,
+  orgId: string,
+): string | null {
+  const normalized = posix.normalize(
+    rawPath[0] === "/" ? rawPath.slice(1) : rawPath,
+  );
+  if (normalized !== orgId && !normalized.startsWith(`${orgId}/`)) {
+    return null;
+  }
+  return normalized;
+}

--- a/packages/back-end/src/services/files.ts
+++ b/packages/back-end/src/services/files.ts
@@ -98,7 +98,7 @@ export function getUploadsDir() {
 // Join an upload key onto the uploads dir, rejecting anything that escapes it.
 // The separator-aware boundary check (vs. a bare prefix match) is what stops a
 // sibling like "uploads-evil" or a "../" traversal from slipping through.
-function resolveUploadPath(key: string): string {
+export function resolveUploadPath(key: string): string {
   const rootDirectory = getUploadsDir();
   const fullPath = path.join(rootDirectory, key);
   if (

--- a/packages/back-end/src/services/files.ts
+++ b/packages/back-end/src/services/files.ts
@@ -95,6 +95,23 @@ export function getUploadsDir() {
   return path.join(__dirname, "..", "..", "uploads");
 }
 
+// Join an upload key onto the uploads dir, rejecting anything that escapes it.
+// The separator-aware boundary check (vs. a bare prefix match) is what stops a
+// sibling like "uploads-evil" or a "../" traversal from slipping through.
+function resolveUploadPath(key: string): string {
+  const rootDirectory = getUploadsDir();
+  const fullPath = path.join(rootDirectory, key);
+  if (
+    fullPath !== rootDirectory &&
+    !fullPath.startsWith(rootDirectory + path.sep)
+  ) {
+    throw new Error(
+      "Error: Path must not escape out of the 'uploads' directory.",
+    );
+  }
+  return fullPath;
+}
+
 export async function uploadFile(
   filePath: string,
   contentType: string,
@@ -177,16 +194,7 @@ export async function uploadFile(
     fileURL =
       cfg.gcsDomain + (cfg.gcsDomain.endsWith("/") ? "" : "/") + filePath;
   } else {
-    const rootDirectory = getUploadsDir();
-    const fullPath = path.join(rootDirectory, filePath);
-
-    // Prevent directory traversal
-    if (fullPath.indexOf(rootDirectory) !== 0) {
-      throw new Error(
-        "Error: Path must not escape out of the 'uploads' directory.",
-      );
-    }
-
+    const fullPath = resolveUploadPath(filePath);
     const dir = path.dirname(fullPath);
     await fs.promises.mkdir(dir, { recursive: true });
     await fs.promises.writeFile(fullPath, contents);
@@ -201,15 +209,7 @@ export function getImageData(filePath: string) {
     throw new Error("Error: Filename must not contain null bytes");
   }
 
-  const rootDirectory = getUploadsDir();
-  const fullPath = path.join(rootDirectory, filePath);
-
-  // Prevent directory traversal
-  if (fullPath.indexOf(rootDirectory) !== 0) {
-    throw new Error(
-      "Error: Path must not escape out of the 'uploads' directory.",
-    );
-  }
+  const fullPath = resolveUploadPath(filePath);
 
   if (!fs.existsSync(fullPath)) {
     throw new Error("File not found");
@@ -444,17 +444,8 @@ export async function promoteFile(
     return cfg.gcsDomain + (cfg.gcsDomain.endsWith("/") ? "" : "/") + destKey;
   } else {
     // Local filesystem (dev): just rename.
-    const rootDirectory = getUploadsDir();
-    const srcPath = path.join(rootDirectory, srcKey);
-    const destPath = path.join(rootDirectory, destKey);
-    if (
-      srcPath.indexOf(rootDirectory) !== 0 ||
-      destPath.indexOf(rootDirectory) !== 0
-    ) {
-      throw new Error(
-        "Error: Path must not escape out of the 'uploads' directory.",
-      );
-    }
+    const srcPath = resolveUploadPath(srcKey);
+    const destPath = resolveUploadPath(destKey);
     await fs.promises.mkdir(path.dirname(destPath), { recursive: true });
     await fs.promises.rename(srcPath, destPath);
     return `/upload/${destKey}`;
@@ -514,11 +505,7 @@ export async function listFiles(
     }));
   } else {
     // Local filesystem (dev).
-    const rootDirectory = getUploadsDir();
-    const dir = path.join(rootDirectory, prefix);
-    if (dir.indexOf(rootDirectory) !== 0) {
-      throw new Error("Error: Prefix must not escape the uploads directory.");
-    }
+    const dir = resolveUploadPath(prefix);
     let entries: import("fs").Dirent[];
     try {
       entries = await fs.promises.readdir(dir, { withFileTypes: true });

--- a/packages/back-end/test/routers/upload.util.test.ts
+++ b/packages/back-end/test/routers/upload.util.test.ts
@@ -7,6 +7,8 @@ describe("getOrgScopedPath", () => {
     // Legitimate paths resolve unchanged
     [`${ORG}/2025-06/img_uuid.jpeg`, `${ORG}/2025-06/img_uuid.jpeg`],
     [`/${ORG}/2025-06/img_uuid.jpeg`, `${ORG}/2025-06/img_uuid.jpeg`],
+    // Multiple leading slashes are all stripped (else normalize stays absolute)
+    [`//${ORG}/2025-06/img.jpeg`, `${ORG}/2025-06/img.jpeg`],
     // Harmless "." segments collapse but stay in-org
     [`${ORG}/./2025-06/img.jpeg`, `${ORG}/2025-06/img.jpeg`],
   ])("accepts %p", (input, expected) => {

--- a/packages/back-end/test/routers/upload.util.test.ts
+++ b/packages/back-end/test/routers/upload.util.test.ts
@@ -1,0 +1,29 @@
+import { getOrgScopedPath } from "back-end/src/routers/upload/upload.util";
+
+const ORG = "org_abc123";
+
+describe("getOrgScopedPath", () => {
+  it.each([
+    // Legitimate paths resolve unchanged
+    [`${ORG}/2025-06/img_uuid.jpeg`, `${ORG}/2025-06/img_uuid.jpeg`],
+    [`/${ORG}/2025-06/img_uuid.jpeg`, `${ORG}/2025-06/img_uuid.jpeg`],
+    // Harmless "." segments collapse but stay in-org
+    [`${ORG}/./2025-06/img.jpeg`, `${ORG}/2025-06/img.jpeg`],
+  ])("accepts %p", (input, expected) => {
+    expect(getOrgScopedPath(input, ORG)).toBe(expected);
+  });
+
+  it.each([
+    // The reported cross-tenant traversal attack
+    [`${ORG}/../org_other/2025-06/img.jpeg`],
+    [`/${ORG}/../org_other/2025-06/img.jpeg`],
+    // Escaping the uploads dir entirely
+    [`${ORG}/../../etc/passwd`],
+    // A different org outright
+    ["org_other/2025-06/img.jpeg"],
+    // Prefix-collision: another org whose id starts with ours
+    [`${ORG}_evil/2025-06/img.jpeg`],
+  ])("rejects %p", (input) => {
+    expect(getOrgScopedPath(input, ORG)).toBeNull();
+  });
+});

--- a/packages/back-end/test/services/files.test.ts
+++ b/packages/back-end/test/services/files.test.ts
@@ -1,0 +1,33 @@
+import path from "path";
+import { getUploadsDir, resolveUploadPath } from "back-end/src/services/files";
+
+describe("resolveUploadPath", () => {
+  const root = getUploadsDir();
+
+  it("resolves a normal key under the uploads dir", () => {
+    const key = "org_abc/2025-06/img_uuid.jpeg";
+    expect(resolveUploadPath(key)).toBe(path.join(root, key));
+  });
+
+  it("returns the root dir for an empty key", () => {
+    expect(resolveUploadPath("")).toBe(root);
+  });
+
+  it("allows in-bounds traversal that stays under the uploads dir", () => {
+    // Cross-org containment is enforced at the controller layer, not here —
+    // this only guarantees the path doesn't escape the uploads dir.
+    expect(resolveUploadPath("org_a/../org_b/x")).toBe(
+      path.join(root, "org_b/x"),
+    );
+  });
+
+  it.each([
+    ["../../etc/passwd"],
+    ["../uploads-evil/key"], // sibling-prefix: must not pass a bare prefix match
+    ["org_a/../../secrets"],
+  ])("throws when %p escapes the uploads dir", (key) => {
+    expect(() => resolveUploadPath(key)).toThrow(
+      "Path must not escape out of the 'uploads' directory.",
+    );
+  });
+});


### PR DESCRIPTION
### Features and Changes

The image read handlers validated the requesting org by inspecting only the first path segment (`path.split("/")[0]`). Because `path.join()` collapses `..` afterwards, a path like `org_A/../org_B/2025-06/img.jpeg` passed the org check (first segment `org_A`) but resolved to another org's directory — letting any authenticated user read other orgs' uploaded images on local storage (`UPLOAD_METHOD="local"`).

- Adds `getOrgScopedPath()`, which normalizes the path (collapsing `..`) **before** the org check and requires the result to stay within the org's own folder. Applied to `getImage`, `getSignedImageToken`, and `getSignedPublicImageToken`. The `startsWith(`${orgId}/`)` form also closes a prefix-collision (an org `org_abc_evil` can no longer pass as `org_abc`).
- Hardens `files.ts`: routes all local-storage path joins through a new `resolveUploadPath()` helper that uses a separator-aware boundary check, so a sibling directory like `uploads-evil` can no longer satisfy the previous `indexOf(root) !== 0` prefix match. Replaces four copies of the old check.

:warning: Requests whose normalized path contains `..` (or otherwise leaves the org folder) now return `400`/`403` instead of being served. Legitimate paths (`org_xxx/YYYY-MM/img_*.jpeg`) are unaffected — only S3/GCS-keyed cloud storage was never vulnerable (keys are literal).

### Testing

- [x] Unit tests for `getOrgScopedPath` (`upload.util.test.ts`) — accepts legit/leading-slash/`.` paths; rejects the `../` cross-tenant attack, dir-escape, wrong-org, and prefix-collision cases
- [x] `pnpm --filter back-end type-check` and `eslint` clean
- [ ] Manual (local storage): `GET /upload/<yourOrg>/<month>/<img>` still serves your image
- [ ] Manual (local storage): `curl --path-as-is /upload/<yourOrg>/../<otherOrg>/<month>/<img>` now returns `400` instead of the other org's file