### PR TITLE
Enforce datasource read permission on GET /api/v1/queries/:id

### DIFF
--- a/packages/back-end/src/api/queries/getQuery.ts
+++ b/packages/back-end/src/api/queries/getQuery.ts
@@ -15,11 +15,10 @@ export const getQuery = createApiRequestHandler(getQueryValidator)(async (
     throw new Error(`A query with id ${id} does not exist`);
   }
 
+  // getDataSourceById enforces readData on the datasource's projects and
+  // returns null if the caller lacks access, so this gates query reads too.
   const datasource = await getDataSourceById(req.context, query.datasource);
-  if (
-    !datasource ||
-    !req.context.permissions.canReadMultiProjectResource(datasource.projects)
-  ) {
+  if (!datasource) {
     req.context.permissions.throwPermissionError();
   }
 

--- a/packages/back-end/src/api/queries/getQuery.ts
+++ b/packages/back-end/src/api/queries/getQuery.ts
@@ -4,6 +4,7 @@ import {
   getQueryById,
   toQueryApiInterface,
 } from "back-end/src/models/QueryModel";
+import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 
 export const getQuery = createApiRequestHandler(getQueryValidator)(async (
   req,
@@ -12,6 +13,14 @@ export const getQuery = createApiRequestHandler(getQueryValidator)(async (
   const query = await getQueryById(req.context, id);
   if (!query) {
     throw new Error(`A query with id ${id} does not exist`);
+  }
+
+  const datasource = await getDataSourceById(req.context, query.datasource);
+  if (
+    !datasource ||
+    !req.context.permissions.canReadMultiProjectResource(datasource.projects)
+  ) {
+    req.context.permissions.throwPermissionError();
   }
 
   return {


### PR DESCRIPTION
### Features and Changes

The external query API (`GET /api/v1/queries/:id`) returned a query — including its raw SQL text — scoped only by organization, skipping the project-level `readData` check that the internal route enforces through the query's datasource. A project-restricted API key could previously read queries belonging to datasources in other projects within the same org.

Now loads the query's datasource and requires `canReadMultiProjectResource` on its projects before returning, matching the internal `getDataSourceQueries` controller and the existing `getArchetype` API pattern. Returns a permission error if the datasource is missing or unreadable.

### Testing

- [ ] As an API key with `readData` on the query's datasource projects → returns the query
- [ ] As a project-restricted API key without `readData` on those projects → returns a permission error (previously leaked the SQL)