### PR TITLE
Add optional shared-secret auth to PYTHON_SERVER_MODE /stats endpoint

### DIFF
--- a/docs/docs/self-host/production.mdx
+++ b/docs/docs/self-host/production.mdx
@@ -109,6 +109,8 @@ GrowthBook container instances are stateless and can be horizontally scaled behi
 
 The most intensive part of GrowthBook is the stats engine and background jobs. If you are running a high volume of experiments, processing those experiments may impact other requests to growthbook. If you notice this, you can separate concerns by starting one "Jobs Server" with increased resourced as needed and the env vars `PYTHON_SERVER_MODE=true`, `GB_STATS_ENGINE_POOL_SIZE=<number of vCPUs>` on the "Jobs Server" and the others with `GB_STATS_ENGINE_MIN_POOL_SIZE=0`, `EXTERNAL_PYTHON_SERVER_URL=<url of jobs server>`, and `CRON_DISABLED=true`.
 
+The "Jobs Server" `/stats` endpoint has no built-in authentication, so it should only be reachable on a private network. As defense-in-depth, set a shared secret with `PYTHON_SERVER_AUTH_TOKEN=<random secret>` on both the "Jobs Server" and the main instances — when set, the "Jobs Server" rejects any request to `/stats` that doesn't present it as a `Bearer` token.
+
 ### MongoDB
 
 All application state is stored in MongoDB. A small GrowthBook deployment can run with shared CPU/RAM and under 512MB of storage. A very large deployment with 1,000 feature flags and experiments will take up around 5GB of storage and require at least 2GB of RAM and 2vCPUs.

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import crypto from "crypto";
 import { existsSync, readFileSync } from "fs";
 import bodyParser from "body-parser";
 import cookieParser from "cookie-parser";
@@ -180,6 +181,22 @@ if (stringToBoolean(process.env.PYTHON_SERVER_MODE)) {
   app.use(httpLogger);
   app.post(
     "/stats",
+    // When a shared secret is configured, require it before parsing the (large) body
+    (req, res, next) => {
+      const expected = process.env.PYTHON_SERVER_AUTH_TOKEN;
+      if (expected) {
+        const provided = (req.get("authorization") || "").replace(
+          /^Bearer\s+/i,
+          "",
+        );
+        const a = Buffer.from(provided);
+        const b = Buffer.from(expected);
+        if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
+          return res.status(401).json({ error: "Unauthorized" });
+        }
+      }
+      next();
+    },
     // increase max payload json size to 50mb as a single query can return up to 3000 rows
     // and we pass the results of all queries at once into python
     bodyParser.json({

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -189,9 +189,10 @@ if (stringToBoolean(process.env.PYTHON_SERVER_MODE)) {
           /^Bearer\s+/i,
           "",
         );
-        const a = Buffer.from(provided);
-        const b = Buffer.from(expected);
-        if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) {
+        // Hash both to fixed-length digests so the compare leaks no length info
+        const hash = (s: string) =>
+          crypto.createHash("sha256").update(s).digest();
+        if (!crypto.timingSafeEqual(hash(provided), hash(expected))) {
           return res.status(401).json({ error: "Unauthorized" });
         }
       }

--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -151,6 +151,11 @@ export async function runStatsEngine(
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          ...(process.env.PYTHON_SERVER_AUTH_TOKEN
+            ? {
+                Authorization: `Bearer ${process.env.PYTHON_SERVER_AUTH_TOKEN}`,
+              }
+            : {}),
         },
         body: JSON.stringify(statsData),
       },


### PR DESCRIPTION
### Features and Changes

When `PYTHON_SERVER_MODE` is enabled, the back-end registers `POST /stats` before all auth middleware (JWT, cookie parsing, CORS), so the endpoint is unauthenticated and accepts payloads up to 50MB. This is fine when the "Jobs Server" is correctly network-isolated, but provides no application-layer protection if it's ever exposed.

This adds an opt-in shared secret:

- If `PYTHON_SERVER_AUTH_TOKEN` is set, the `/stats` endpoint requires it as a `Bearer` token — checked with a constant-time compare **before** the body is parsed, so unauthorized callers can't even push a 50MB payload through `bodyParser`.
- The main back-end sends the same token as an `Authorization` header when proxying to `EXTERNAL_PYTHON_SERVER_URL`.
- Opt-in: when the env var is unset, behavior is unchanged, so existing network-isolated deployments are unaffected.

Documented the new env var in the self-host production guide.

Note: this is the necessary core of an old security-scan finding. Per-IP rate limiting and Zod body validation were also suggested but deliberately skipped — rate limiting has little value for a single trusted internal caller, and a valid-shaped 50MB payload would still pass a Zod check (the Python engine validates its own input). The auth gate is what closes the "unauthenticated endpoint" vector.

### Testing

- [ ] With `PYTHON_SERVER_MODE=true` and no `PYTHON_SERVER_AUTH_TOKEN`: `POST /stats` works as before.
- [ ] With `PYTHON_SERVER_AUTH_TOKEN=secret` set: `POST /stats` with no/incorrect `Authorization` returns `401`; with `Authorization: Bearer secret` it succeeds.
- [ ] With `EXTERNAL_PYTHON_SERVER_URL` + `PYTHON_SERVER_AUTH_TOKEN` set on the main instance: proxied requests carry the bearer token and the jobs server accepts them.