### PR TITLE
Generate SDK webhook signing keys with a CSPRNG

### DIFF
--- a/packages/back-end/src/models/WebhookModel.ts
+++ b/packages/back-end/src/models/WebhookModel.ts
@@ -1,6 +1,4 @@
 import { omit } from "lodash";
-import uniqid from "uniqid";
-import md5 from "md5";
 import { WEBHOOK_CONSECUTIVE_FAILURES_THRESHOLD } from "shared/constants";
 import { WebhookInterface } from "shared/types/webhook";
 import { UpdateProps } from "shared/types/base-model";
@@ -9,6 +7,7 @@ import {
   getCollection,
   removeMongooseFields,
 } from "back-end/src/util/mongo.util";
+import { generateSigningKey } from "back-end/src/util/api-key.util";
 import { MakeModelClass } from "./BaseModel";
 
 const COLLECTION_NAME = "webhooks";
@@ -147,7 +146,7 @@ export class SdkWebhookModel extends BaseClass {
       project: "",
       error: "",
       lastSuccess: null,
-      signingKey: "wk_" + md5(uniqid()).slice(0, 16),
+      signingKey: generateSigningKey("wk_"),
       useSdkMode: true,
       featuresOnly: true,
       sdks: [sdkConnectionId],


### PR DESCRIPTION
### Features and Changes

SDK webhook signing keys were generated as `"wk_" + md5(uniqid()).slice(0, 16)`. `uniqid` is composed of the host MAC address, PID, and a millisecond timestamp — all predictable or low-entropy — so the HMAC-SHA256 signing secret had far less effective entropy than its 16 hex chars suggested, making forged `X-GrowthBook-Signature` payloads plausibly brute-forceable.

Switches to the existing `generateSigningKey("wk_")` helper (backed by `crypto.randomBytes`), matching the entropy standard already used for SDK connection signing keys and event webhook (`ewhk_`) keys. Only affects newly created SDK webhooks; existing stored keys are unchanged.

### Testing

Create a new SDK webhook and confirm its `signingKey` is a long random `wk_`-prefixed value, and that payload delivery + signature verification still succeed.