### PR TITLE
Fix search to match multi-token substrings within keys

### DIFF
--- a/packages/front-end/services/search.tsx
+++ b/packages/front-end/services/search.tsx
@@ -80,9 +80,28 @@ export function tagFilterOnClick(
   };
 }
 
-// Whitespace + punctuation (incl. underscores), matching MiniSearch's default
-// tokenizer. Used to split indexed fields into searchable parts.
-const wordSeparators = /[\n\r\p{Z}\p{P}]+/u;
+// Whitespace separates distinct words; punctuation (incl. _ and -) separates
+// sub-tokens within a word.
+const wordBoundary = /[\n\r\p{Z}]+/u;
+const tokenSeparators = /\p{P}+/u;
+
+// Split a string into normalized words. MiniSearch can only match terms by
+// prefix/fuzzy (no substring search), so for indexing we emit every
+// "boundary suffix" of each word — e.g. "search_test_key" -> ["search_test_key",
+// "test_key", "key"] — which turns a prefix query into a substring-at-word-
+// boundary match. For queries we keep each word whole (one normalized term), so
+// "test_key" / "test-key" both prefix-match the "test_key" suffix of
+// "search_test_key" but never match "test-my-key".
+function tokenizeFields(text: string, expandSuffixes: boolean): string[] {
+  return text.split(wordBoundary).flatMap((word) => {
+    const parts = word.split(tokenSeparators).filter(Boolean);
+    return expandSuffixes
+      ? parts.map((_, i) => parts.slice(i).join("_"))
+      : parts.length
+        ? [parts.join("_")]
+        : [];
+  });
+}
 
 const searchTermOperators = [">", "<", "^", "=", "~", ""] as const;
 
@@ -231,23 +250,12 @@ export function useSearch<T extends { id: string }>({
     const miniSearchInstance = new MiniSearch({
       idField: internalSearchIdField,
       fields,
-      // Index each field as its punctuation-split parts AND its whole
-      // whitespace-delimited form. The parts let a query like "bar" find
-      // "foo_bar_baz"; the whole form lets an underscore-containing query
-      // ("foo_bar") prefix-match the full key instead of being split into
-      // separate tokens that would each OR-match (so "foo_bar" would wrongly
-      // match a feature named "foo").
-      tokenize: (text) => [
-        ...new Set(
-          [...text.split(/\s+/), ...text.split(wordSeparators)].filter(Boolean),
-        ),
-      ],
+      tokenize: (text) => tokenizeFields(text, true),
       searchOptions: {
         boost: keys,
         fuzzy: true,
         prefix: true,
-        // Split the query on whitespace only so "foo_bar" stays a single term.
-        tokenize: (text) => text.split(/\s+/).filter(Boolean),
+        tokenize: (text) => tokenizeFields(text, false),
       },
     });
 

--- a/packages/front-end/test/services/search.test.ts
+++ b/packages/front-end/test/services/search.test.ts
@@ -602,7 +602,7 @@ describe("useSearch", () => {
     });
   });
 
-  describe("underscore tokenization", () => {
+  describe("underscore/hyphen tokenization", () => {
     type SearchItem = {
       id: string;
       name: string;
@@ -611,6 +611,10 @@ describe("useSearch", () => {
     const items: SearchItem[] = [
       { id: "1", name: "foo" },
       { id: "2", name: "foo_bar_baz" },
+      { id: "3", name: "other_search_key" },
+      { id: "4", name: "search_test_key" },
+      { id: "5", name: "search-test-key" },
+      { id: "6", name: "test-my-key" },
     ];
 
     const setup = () =>
@@ -623,24 +627,38 @@ describe("useSearch", () => {
         }),
       );
 
-    it("matches a feature on an inner token", () => {
+    const search = (value: string): string[] => {
       const { result } = setup();
       act(() => {
-        result.current.setSearchValue("bar");
+        result.current.setSearchValue(value);
       });
-      expect(result.current.filteredItems.map((i) => i.name)).toContain(
-        "foo_bar_baz",
-      );
+      return result.current.filteredItems.map((i) => i.name);
+    };
+
+    it("matches a feature on an inner token", () => {
+      expect(search("bar")).toContain("foo_bar_baz");
     });
 
     it("requires the full multi-token query, not a partial subset", () => {
-      const { result } = setup();
-      act(() => {
-        result.current.setSearchValue("foo_bar");
-      });
-      const names = result.current.filteredItems.map((i) => i.name);
+      const names = search("foo_bar");
       expect(names).toContain("foo_bar_baz");
       expect(names).not.toContain("foo");
+    });
+
+    it("matches a multi-token substring in the middle of a key", () => {
+      const names = search("test_key");
+      expect(names).toEqual(
+        expect.arrayContaining(["search_test_key", "search-test-key"]),
+      );
+      // tokens must be contiguous: test-my-key has "test" and "key" but not "test_key"
+      expect(names).not.toContain("test-my-key");
+      expect(names).not.toContain("other_search_key");
+    });
+
+    it("treats hyphens and underscores interchangeably", () => {
+      expect(search("test-key")).toEqual(
+        expect.arrayContaining(["search_test_key", "search-test-key"]),
+      );
     });
   });
 


### PR DESCRIPTION
### Features and Changes

Follow-up to #6127. That fix kept a typed query as one whole token and prefix-matched the full key, so an *infix* query like `test_key` found nothing in `search_test_key` (it's a substring in the middle, not a prefix).

MiniSearch has no substring/contains query — it only matches terms by prefix/fuzzy. So instead we index every **word-boundary suffix** of each key (`search_test_key` → `["search_test_key", "test_key", "key"]`), which turns a prefix query into a substring-at-word-boundary match. Punctuation is normalized so `-` and `_` are interchangeable, and matches stay contiguous.

### Testing

Given features `other_search_key`, `search_test_key`, `search-test-key`, `test-my-key`, `foo`, `foo_bar_baz`, `multi_account`:

```
"test_key" / "test-key" => search_test_key, search-test-key   (excludes test-my-key, other_search_key)
"bar"                    => foo_bar_baz
"foo_bar"               => foo_bar_baz                          (not "foo")
"multi_account"         => multi_account                        (not ...sub_account... infix)
"account"               => multi_account, ...sub_account...     (single word still broad)
```

Covered by new hook tests in `search.test.ts` (substring-in-the-middle + hyphen/underscore interchangeability); all 40 search tests pass and `search.tsx` type-checks clean.