### PR TITLE
feat(incremental): warn before falling back from Incremental Pipeline mode

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -318,11 +318,6 @@
       "count": 3
     }
   },
-  "packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "packages/front-end/components/Experiment/TabbedPage/BanditUpdateStatus.tsx": {
     "local/no-alert-classname": {
       "count": 1

--- a/packages/back-end/src/enterprise/services/data-pipeline.ts
+++ b/packages/back-end/src/enterprise/services/data-pipeline.ts
@@ -2,11 +2,9 @@ import md5 from "md5";
 import {
   ExperimentMetricInterface,
   getAutoSliceMetrics,
-  isFactMetric,
   isSliceMetric,
-  quantileMetricType,
 } from "shared/experiments";
-import { isExperimentIncrementalEnabled } from "shared/enterprise";
+import { getIncrementalPipelineUnsupportedReason } from "shared/enterprise";
 import {
   AggregatedFactTableInterface,
   AggregatedFactTableMetricStateInterface,
@@ -54,70 +52,27 @@ export async function assertIncrementalRefreshPrerequisites({
   incrementalRefreshModel: IncrementalRefreshInterface | null;
   analysisType: "main-update" | "main-fullRefresh" | "exploratory";
 }): Promise<void> {
-  if (snapshotSettings.skipPartialData) {
-    throw new Error(
-      "'Exclude In-Progress Conversions' is not supported for incremental refresh queries while in beta. Please select 'Include' in the Analysis Settings for Metric Conversion Windows.",
-    );
-  }
-
-  if (!integration.getSourceProperties().hasIncrementalRefresh) {
-    throw new Error("Integration does not support incremental refresh queries");
-  }
-
-  // Check if organization has the incremental refresh feature
-  const hasIncrementalRefreshFeature = orgHasPremiumFeature(
-    org,
-    "incremental-refresh",
-  );
-  if (!hasIncrementalRefreshFeature) {
-    throw new Error(
-      "Organization does not have access to incremental refresh feature",
-    );
-  }
-
-  const settings = integration.datasource.settings;
-  if (
-    !isExperimentIncrementalEnabled(settings.pipelineSettings, experiment.id)
-  ) {
-    throw new Error(
-      "This experiment is not enabled for incremental refresh on this data source.",
-    );
-  }
-
-  if (experiment.activationMetric) {
-    throw new Error(
-      "Activation metrics are not supported for incremental refresh while in beta.",
-    );
-  }
-
-  // Get selected metrics
   const selectedMetrics = snapshotSettings.metricSettings
     .map((m) => metricMap.get(m.id))
     .filter((m) => m !== undefined);
 
-  if (!selectedMetrics.length) {
-    throw new Error("Experiment must have at least 1 metric selected.");
-  }
-  if (selectedMetrics.some((m) => !isFactMetric(m))) {
-    throw new Error(
-      "Only fact metrics are supported with incremental refresh.",
-    );
-  }
-
-  selectedMetrics.filter(isFactMetric).forEach((metric) => {
-    // Unit quantiles store a float and re-aggregate via SUM, so they work on
-    // any incremental-capable warehouse. Only event quantiles need a quantile
-    // sketch (the quantile must be computed over raw event values, which
-    // requires a mergeable sketch for incremental aggregation).
-    if (
-      quantileMetricType(metric) === "event" &&
-      !integration.getSourceProperties().hasQuantileSketch
-    ) {
-      throw new Error(
-        "Event quantile metrics are not supported with incremental refresh on this data source.",
-      );
-    }
+  const unsupportedReason = getIncrementalPipelineUnsupportedReason({
+    datasourceProperties: integration.getSourceProperties(),
+    pipelineSettings: integration.datasource.settings.pipelineSettings,
+    experimentId: experiment.id,
+    orgHasIncrementalPipelineFeature: orgHasPremiumFeature(
+      org,
+      "incremental-refresh",
+    ),
+    skipPartialData: snapshotSettings.skipPartialData,
+    activationMetric: experiment.activationMetric,
+    metrics: selectedMetrics,
+    experimentType: experiment.type,
   });
+
+  if (unsupportedReason) {
+    throw new Error(unsupportedReason);
+  }
 
   // If not forcing a full refresh and we have a previous run, ensure the
   // experiment-level configuration matches what the incremental pipeline was

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -1237,9 +1237,13 @@ function isIncrementalRefreshEnabledForSnapshot({
   datasource: DataSourceInterface;
   experiment: ExperimentInterface;
 }): boolean {
+  // Pass undefined for the type so the type gate is skipped here:
+  // resolveSnapshotRunner checks it separately to surface a descriptive
+  // fallback reason for unsupported types.
   return isExperimentIncrementalEnabled(
     datasource.settings.pipelineSettings,
     experiment.id,
+    undefined,
   );
 }
 

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -130,7 +130,10 @@ import { ExperimentRefRule, FeatureRule } from "shared/types/feature";
 import { ProjectInterface } from "shared/types/project";
 import { MetricGroupInterface } from "shared/types/metric-groups";
 import { ExperimentQueryMetadata } from "shared/types/query";
-import { isExperimentIncrementalEnabled } from "shared/enterprise";
+import {
+  isExperimentCoveredByIncrementalPipeline,
+  getUnsupportedIncrementalExperimentTypeReason,
+} from "shared/enterprise";
 import { generateId } from "back-end/src/util/uuid";
 import { orgHasPremiumFeature } from "back-end/src/enterprise";
 import { updateExperiment } from "back-end/src/models/ExperimentModel";
@@ -1230,23 +1233,6 @@ export type SnapshotQueryRunnerKind =
   | "incremental"
   | "incremental-exploratory";
 
-function isIncrementalRefreshEnabledForSnapshot({
-  datasource,
-  experiment,
-}: {
-  datasource: DataSourceInterface;
-  experiment: ExperimentInterface;
-}): boolean {
-  // Pass undefined for the type so the type gate is skipped here:
-  // resolveSnapshotRunner checks it separately to surface a descriptive
-  // fallback reason for unsupported types.
-  return isExperimentIncrementalEnabled(
-    datasource.settings.pipelineSettings,
-    experiment.id,
-    undefined,
-  );
-}
-
 export function resolveSnapshotRunner({
   datasource,
   experiment,
@@ -1263,14 +1249,22 @@ export function resolveSnapshotRunner({
   runnerKind: SnapshotQueryRunnerKind;
   incrementalFallbackReason: string | null;
 } {
-  if (!isIncrementalRefreshEnabledForSnapshot({ datasource, experiment })) {
+  if (
+    !isExperimentCoveredByIncrementalPipeline(
+      datasource.settings.pipelineSettings,
+      experiment.id,
+    )
+  ) {
     return { runnerKind: "results", incrementalFallbackReason: null };
   }
 
-  if (experiment.type !== undefined && experiment.type !== "standard") {
+  const unsupportedTypeReason = getUnsupportedIncrementalExperimentTypeReason(
+    experiment.type,
+  );
+  if (unsupportedTypeReason) {
     return {
       runnerKind: "results",
-      incrementalFallbackReason: `Experiment type "${experiment.type}" is not supported for incremental refresh.`,
+      incrementalFallbackReason: unsupportedTypeReason,
     };
   }
 

--- a/packages/back-end/test/services/snapshot-query-runner-kind.test.ts
+++ b/packages/back-end/test/services/snapshot-query-runner-kind.test.ts
@@ -164,7 +164,7 @@ describe("resolveSnapshotRunner", () => {
     ).toBe("incremental");
   });
 
-  it("returns 'results' for multi-armed-bandit experiments", () => {
+  it("returns 'results' with a descriptive fallback reason for multi-armed-bandit experiments", () => {
     expect(
       resolveSnapshotRunner({
         datasource: makeDatasource(),
@@ -177,6 +177,38 @@ describe("resolveSnapshotRunner", () => {
       runnerKind: "results",
       incrementalFallbackReason:
         'Experiment type "multi-armed-bandit" is not supported for incremental refresh.',
+    });
+  });
+
+  it("returns 'results' with a descriptive fallback reason for holdout experiments", () => {
+    expect(
+      resolveSnapshotRunner({
+        datasource: makeDatasource(),
+        experiment: makeExperiment({ type: "holdout" }),
+        snapshotType: "standard",
+        hasSnapshotDimensions: false,
+        hasMaterializedUnitsTable: true,
+      }),
+    ).toEqual({
+      runnerKind: "results",
+      incrementalFallbackReason:
+        'Experiment type "holdout" is not supported for incremental refresh.',
+    });
+  });
+
+  it("returns 'results' with no fallback reason for non-standard types not enabled by data source settings", () => {
+    const datasource = makeDatasource({ mode: "ephemeral" });
+    expect(
+      resolveSnapshotRunner({
+        datasource,
+        experiment: makeExperiment({ type: "multi-armed-bandit" }),
+        snapshotType: "standard",
+        hasSnapshotDimensions: false,
+        hasMaterializedUnitsTable: true,
+      }),
+    ).toEqual({
+      runnerKind: "results",
+      incrementalFallbackReason: null,
     });
   });
 

--- a/packages/front-end/components/Experiment/AnalysisForm.tsx
+++ b/packages/front-end/components/Experiment/AnalysisForm.tsx
@@ -287,6 +287,7 @@ const AnalysisForm: FC<{
     getIsExperimentIncludedInIncrementalRefresh(
       datasource ?? undefined,
       experiment.id,
+      experiment.type,
     );
 
   const datasourceField = form.watch("datasource");
@@ -951,6 +952,7 @@ const AnalysisForm: FC<{
               filterConversionWindowMetrics={isHoldout}
               goalDisabled={isBandit && experiment.status !== "draft"}
               experimentId={experiment.id}
+              experimentType={experiment.type}
             />
 
             {!!datasource && !isBandit && !isHoldout && (

--- a/packages/front-end/components/Experiment/BanditDecisionMetricSettings.tsx
+++ b/packages/front-end/components/Experiment/BanditDecisionMetricSettings.tsx
@@ -111,6 +111,7 @@ export default function BanditDecisionMetricSettings({
   return (
     <>
       <ExperimentMetricsSelector
+        experimentType="multi-armed-bandit"
         datasource={datasource?.id}
         exposureQueryId={exposureQueryId}
         project={project}

--- a/packages/front-end/components/Experiment/EditMetricsForm.tsx
+++ b/packages/front-end/components/Experiment/EditMetricsForm.tsx
@@ -159,6 +159,7 @@ const EditMetricsForm: FC<{
     getIsExperimentIncludedInIncrementalRefresh(
       datasource ?? undefined,
       experiment.id,
+      experiment.type,
     );
 
   const form = useForm<EditMetricsFormInterface>({
@@ -227,6 +228,7 @@ const EditMetricsForm: FC<{
         }
         filterConversionWindowMetrics={isHoldout}
         experimentId={experiment.id}
+        experimentType={experiment.type}
       />
       {/* If the org has the feature, we render a callout within MetricsSelector */}
       {!hasCommercialFeature("metric-groups") ? (

--- a/packages/front-end/components/Experiment/ExperimentMetricsSelector.tsx
+++ b/packages/front-end/components/Experiment/ExperimentMetricsSelector.tsx
@@ -8,6 +8,7 @@ import {
   getUserIdTypes,
 } from "shared/experiments";
 import { FactTableMap } from "shared/types/fact-table";
+import { ExperimentType } from "shared/validators";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { getIsExperimentIncludedInIncrementalRefresh } from "@/services/experiments";
 import { getExposureQuery } from "@/services/datasources";
@@ -36,6 +37,7 @@ export interface Props {
   filterConversionWindowMetrics?: boolean;
   excludeQuantiles?: boolean;
   experimentId?: string;
+  experimentType: ExperimentType | undefined;
 }
 
 export default function ExperimentMetricsSelector({
@@ -60,6 +62,7 @@ export default function ExperimentMetricsSelector({
   filterConversionWindowMetrics,
   excludeQuantiles = false,
   experimentId,
+  experimentType,
 }: Props) {
   const {
     getExperimentMetricById,
@@ -75,6 +78,7 @@ export default function ExperimentMetricsSelector({
         getIsExperimentIncludedInIncrementalRefresh(
           datasourceObj ?? undefined,
           experimentId,
+          experimentType,
         );
 
       if (!isExperimentIncludedInIncrementalRefresh) {
@@ -151,6 +155,7 @@ export default function ExperimentMetricsSelector({
     [
       datasource,
       experimentId,
+      experimentType,
       getExperimentMetricById,
       getDatasourceById,
       metricGroups,

--- a/packages/front-end/components/Experiment/IncrementalPipelineFallbackDialog.tsx
+++ b/packages/front-end/components/Experiment/IncrementalPipelineFallbackDialog.tsx
@@ -1,6 +1,5 @@
-import { Flex } from "@radix-ui/themes";
-import ConfirmDialog from "@/ui/ConfirmDialog";
 import Text from "@/ui/Text";
+import ModalStandard from "@/ui/Modal/Patterns/ModalStandard";
 
 export default function IncrementalPipelineFallbackDialog({
   reason,
@@ -12,27 +11,22 @@ export default function IncrementalPipelineFallbackDialog({
   onCancel: () => void;
 }) {
   return (
-    <ConfirmDialog
-      title="Update without Incremental Pipeline mode"
-      yesText="Update anyway"
-      noText="Cancel"
-      onConfirm={onConfirm}
-      onCancel={onCancel}
-      content={
-        <Flex direction="column" gap="3">
-          <div>
-            This update will rescan all the experiment data, from start to
-            today, which is potentially slower and more costly than an
-            incremental update.
-          </div>
-          <div>
-            <Text weight="semibold">
-              Current reason preventing the use of Incremental Pipeline:
-            </Text>
-            <div>{reason}</div>
-          </div>
-        </Flex>
-      }
-    />
+    <ModalStandard
+      open={true}
+      header="Update without Incremental Pipeline"
+      subheader="This re-scans all experiment data from the start instead of only new data, so it may take longer and cost more."
+      cta="Update anyway"
+      trackingEventModalType="incremental-pipeline-fallback"
+      submit={onConfirm}
+      close={onCancel}
+    >
+      <Text size="medium" color="text-high" as="p">
+        <Text size="medium" weight="semibold" color="text-high">
+          Why incremental updates are unavailable:
+        </Text>
+        <br />
+        {reason}
+      </Text>
+    </ModalStandard>
   );
 }

--- a/packages/front-end/components/Experiment/IncrementalPipelineFallbackDialog.tsx
+++ b/packages/front-end/components/Experiment/IncrementalPipelineFallbackDialog.tsx
@@ -1,0 +1,38 @@
+import { Flex } from "@radix-ui/themes";
+import ConfirmDialog from "@/ui/ConfirmDialog";
+import Text from "@/ui/Text";
+
+export default function IncrementalPipelineFallbackDialog({
+  reason,
+  onConfirm,
+  onCancel,
+}: {
+  reason: string;
+  onConfirm: () => void | Promise<void>;
+  onCancel: () => void;
+}) {
+  return (
+    <ConfirmDialog
+      title="Update without Incremental Pipeline mode"
+      yesText="Update anyway"
+      noText="Cancel"
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+      content={
+        <Flex direction="column" gap="3">
+          <div>
+            This update will rescan all the experiment data, from start to
+            today, which is potentially slower and more costly than an
+            incremental update.
+          </div>
+          <div>
+            <Text weight="semibold">
+              Current reason preventing the use of Incremental Pipeline:
+            </Text>
+            <div>{reason}</div>
+          </div>
+        </Flex>
+      }
+    />
+  );
+}

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -1569,6 +1569,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                   form.setValue("guardrailMetrics", guardrailMetrics)
                 }
                 experimentId={initialValue?.id}
+                experimentType={type}
               />
             </div>
 

--- a/packages/front-end/components/Experiment/RefreshResultsButton.tsx
+++ b/packages/front-end/components/Experiment/RefreshResultsButton.tsx
@@ -1,23 +1,16 @@
 import React from "react";
 import { Queries } from "shared/types/query";
 import { ExperimentInterfaceStringDates } from "shared/types/experiment";
-import { isDimensionPrecomputed } from "shared/experiments";
-import {
-  ExperimentSnapshotAnalysisSettings,
-  ExperimentSnapshotInterface,
-} from "shared/types/experiment-snapshot";
+import { ExperimentSnapshotAnalysisSettings } from "shared/types/experiment-snapshot";
 import {
   SafeRolloutInterface,
   SafeRolloutSnapshotInterface,
 } from "shared/validators";
 import { useAuth } from "@/services/auth";
-import { useDefinitions } from "@/services/DefinitionsContext";
-import { useUser } from "@/services/UserContext";
-import { getHonoredPrecomputedUnitDimensionIds } from "@/services/experiments";
-import { trackSnapshot } from "@/services/track";
 import RunQueriesButton from "@/components/Queries/RunQueriesButton";
 import ExperimentRefreshSnapshotButton from "@/components/Experiment/RefreshSnapshotButton";
 import SafeRolloutRefreshSnapshotButton from "@/components/SafeRollout/RefreshSnapshotButton";
+import { useExperimentSnapshotUpdate } from "@/hooks/useExperimentSnapshotUpdate";
 
 export type EntityType = "experiment" | "holdout" | "safe-rollout";
 
@@ -40,7 +33,7 @@ export interface RefreshResultsButtonProps<
     datasourceType: string | null;
   };
   onSuccess?: () => void;
-  // Return false to abort the refresh (e.g. to open a confirmation modal
+  // Return false to abort the refresh (e.g. to open a confirmation dialog
   // instead). Mirrors Modal's customValidation. Side effects are allowed.
   customValidation?: () => boolean | Promise<boolean>;
   // Experiment/holdout-specific props
@@ -50,7 +43,6 @@ export interface RefreshResultsButtonProps<
   setAnalysisSettings?: (
     settings: ExperimentSnapshotAnalysisSettings | null,
   ) => void;
-  // SafeRollout-specific props
   safeRollout?: SafeRolloutInterface;
 }
 
@@ -77,27 +69,32 @@ export default function RefreshResultsButton<
   safeRollout,
 }: RefreshResultsButtonProps<T>) {
   const { apiCall } = useAuth();
-  const { getDatasourceById } = useDefinitions();
-  const { hasCommercialFeature } = useUser();
+
+  const { submitUpdate } = useExperimentSnapshotUpdate({
+    experiment,
+    phase: phase ?? 0,
+    dimension,
+    mutate,
+    mutateAdditional,
+    setRefreshError,
+    onSuccess,
+    customValidation,
+    experimentSnapshotTrackingProps,
+  });
 
   const hasQueries = latest?.queries && latest.queries.length > 0;
-
-  // Determine which button to render
   const shouldUseRunQueriesButton = datasourceId && latest && hasQueries;
-
   const shouldRenderExperimentButton =
     !shouldUseRunQueriesButton &&
     (entityType === "experiment" || entityType === "holdout") &&
     experiment &&
     phase !== undefined;
-
   const shouldRenderSafeRolloutButton =
     !shouldUseRunQueriesButton &&
     !shouldRenderExperimentButton &&
     entityType === "safe-rollout" &&
     safeRollout;
 
-  // Endpoints for the various buttons
   const cancelEndpoint =
     entityType === "safe-rollout"
       ? `/safe-rollout/snapshot/${latest?.id}/cancel`
@@ -108,60 +105,18 @@ export default function RefreshResultsButton<
       ? `/safe-rollout/${entityId}/snapshot`
       : `/experiment/${entityId}/snapshot`;
 
-  // Precomputed dimensions are computed as part of a standard snapshot, so we
-  // don't need to pass them to the backend for a new snapshot query
-  const snapshotDimension = isDimensionPrecomputed(
-    dimension,
-    getHonoredPrecomputedUnitDimensionIds(
-      experiment?.precomputedUnitDimensionIds,
-      experiment?.datasource
-        ? getDatasourceById(experiment.datasource)
-        : undefined,
-      hasCommercialFeature("pipeline-mode"),
-    ),
-  )
-    ? ""
-    : (dimension ?? "");
-
-  // Kicks off a new snapshot query for the given dimension ("" = main results).
-  const runSnapshot = async (dimensionToUse: string) => {
-    const body =
-      entityType === "experiment" || entityType === "holdout"
-        ? JSON.stringify({
-            phase: phase ?? 0,
-            dimension: dimensionToUse,
-          })
-        : undefined;
-
+  const runSafeRolloutUpdate = async () => {
+    if (!latest) return;
     try {
-      if (entityType === "safe-rollout") {
-        await apiCall<{ snapshot: SafeRolloutSnapshotInterface }>(
-          snapshotEndpoint,
-          { method: "POST" },
-        );
-      } else {
-        const res = await apiCall<{
-          snapshot: ExperimentSnapshotInterface;
-        }>(snapshotEndpoint, {
-          method: "POST",
-          ...(body && { body }),
-        });
-        if (experimentSnapshotTrackingProps) {
-          trackSnapshot(
-            "create",
-            experimentSnapshotTrackingProps.trackingSource,
-            experimentSnapshotTrackingProps.datasourceType,
-            res.snapshot,
-          );
-        }
-      }
+      await apiCall<{ snapshot: SafeRolloutSnapshotInterface }>(
+        snapshotEndpoint,
+        { method: "POST" },
+      );
       onSuccess?.();
       setRefreshError("");
     } catch (e) {
       setRefreshError(e.message);
     } finally {
-      // Always refresh, regardless of success or failure
-      // to give the UI a chance to catch up
       mutate();
       mutateAdditional?.();
     }
@@ -184,13 +139,9 @@ export default function RefreshResultsButton<
           icon="refresh"
           useRadixButton={true}
           radixVariant="outline"
-          onSubmit={async () => {
-            if (customValidation && !(await customValidation())) {
-              return;
-            }
-
-            await runSnapshot(snapshotDimension);
-          }}
+          onSubmit={
+            entityType === "safe-rollout" ? runSafeRolloutUpdate : submitUpdate
+          }
         />
       ) : shouldRenderExperimentButton ? (
         <ExperimentRefreshSnapshotButton
@@ -205,6 +156,8 @@ export default function RefreshResultsButton<
           useRadixButton={true}
           radixVariant="outline"
           customValidation={customValidation}
+          onSuccess={onSuccess}
+          experimentSnapshotTrackingProps={experimentSnapshotTrackingProps}
         />
       ) : shouldRenderSafeRolloutButton ? (
         <SafeRolloutRefreshSnapshotButton

--- a/packages/front-end/components/Experiment/RefreshSnapshotButton.tsx
+++ b/packages/front-end/components/Experiment/RefreshSnapshotButton.tsx
@@ -1,17 +1,12 @@
-import { FC, useState } from "react";
+import { FC } from "react";
 import { BsArrowRepeat } from "react-icons/bs";
 import { ExperimentInterfaceStringDates } from "shared/types/experiment";
-import { ExperimentSnapshotInterface } from "shared/types/experiment-snapshot";
 import { Text } from "@radix-ui/themes";
 import { PiArrowClockwise } from "react-icons/pi";
-import { isDimensionPrecomputed } from "shared/experiments";
-import { useAuth } from "@/services/auth";
 import { useDefinitions } from "@/services/DefinitionsContext";
-import { useUser } from "@/services/UserContext";
-import { getHonoredPrecomputedUnitDimensionIds } from "@/services/experiments";
-import { trackSnapshot } from "@/services/track";
 import Button from "@/components/Button";
 import RadixButton from "@/ui/Button";
+import { useExperimentSnapshotUpdate } from "@/hooks/useExperimentSnapshotUpdate";
 
 const RefreshSnapshotButton: FC<{
   mutate: () => void;
@@ -23,6 +18,11 @@ const RefreshSnapshotButton: FC<{
   setError: (e: string | undefined) => void;
   // Return false to abort the refresh
   customValidation?: () => boolean | Promise<boolean>;
+  onSuccess?: () => void;
+  experimentSnapshotTrackingProps?: {
+    trackingSource: string;
+    datasourceType: string | null;
+  };
 }> = ({
   mutate,
   experiment,
@@ -32,118 +32,60 @@ const RefreshSnapshotButton: FC<{
   radixVariant = "outline",
   setError,
   customValidation,
+  onSuccess,
+  experimentSnapshotTrackingProps,
 }) => {
-  const [loading, setLoading] = useState(false);
-  const [longResult, setLongResult] = useState(false);
   const { getDatasourceById } = useDefinitions();
-  const { hasCommercialFeature } = useUser();
 
-  const { apiCall } = useAuth();
-
-  const refreshSnapshot = async () => {
-    if (customValidation && !(await customValidation())) {
-      return;
-    }
-    // Precomputed dimensions are computed as part of a standard snapshot,
-    // so we don't need to pass them to the backend for a new snapshot query
-    const snapshotDimension = isDimensionPrecomputed(
-      dimension,
-      getHonoredPrecomputedUnitDimensionIds(
-        experiment.precomputedUnitDimensionIds,
-        getDatasourceById(experiment.datasource),
-        hasCommercialFeature("pipeline-mode"),
-      ),
-    )
-      ? undefined
-      : dimension;
-    const res = await apiCall<{
-      status: number;
-      message: string;
-      snapshot: ExperimentSnapshotInterface;
-    }>(`/experiment/${experiment.id}/snapshot`, {
-      method: "POST",
-      body: JSON.stringify({
-        phase,
-        dimension: snapshotDimension,
-      }),
-    });
-    trackSnapshot(
-      "create",
-      "RefreshSnapshotButton",
-      getDatasourceById(experiment.datasource)?.type || null,
-      res.snapshot,
-    );
+  const trackingProps = experimentSnapshotTrackingProps ?? {
+    trackingSource: "RefreshSnapshotButton",
+    datasourceType: getDatasourceById(experiment.datasource)?.type || null,
   };
 
-  return (
+  const { submitUpdate, loading, longResult } = useExperimentSnapshotUpdate({
+    experiment,
+    phase,
+    dimension,
+    mutate,
+    setRefreshError: (error) => setError(error),
+    onSuccess,
+    customValidation,
+    experimentSnapshotTrackingProps: trackingProps,
+  });
+
+  return useRadixButton ? (
     <>
-      {useRadixButton ? (
-        <>
-          {loading && longResult && (
-            <Text size="1" color="gray" mr="3">
-              this may take several minutes
-            </Text>
-          )}
-          <RadixButton
-            variant={radixVariant}
-            size="sm"
-            disabled={loading}
-            setError={(error) => setError(error ?? undefined)}
-            onClick={async () => {
-              setLoading(true);
-              setLongResult(false);
-
-              const timer = setTimeout(() => {
-                setLongResult(true);
-              }, 5000);
-
-              try {
-                await refreshSnapshot();
-              } finally {
-                setLoading(false);
-                clearTimeout(timer);
-                mutate();
-              }
-            }}
-            style={{
-              minWidth: 110,
-            }}
-            icon={<PiArrowClockwise />}
-          >
-            Update
-          </RadixButton>
-        </>
-      ) : (
-        <>
-          {loading && longResult && (
-            <small className="text-muted mr-3">
-              this may take several minutes
-            </small>
-          )}
-          <Button
-            color="outline-primary"
-            setErrorText={setError}
-            onClick={async () => {
-              setLoading(true);
-              setLongResult(false);
-
-              const timer = setTimeout(() => {
-                setLongResult(true);
-              }, 5000);
-
-              try {
-                await refreshSnapshot();
-              } finally {
-                setLoading(false);
-                clearTimeout(timer);
-                mutate();
-              }
-            }}
-          >
-            <BsArrowRepeat /> Update
-          </Button>
-        </>
+      {loading && longResult && (
+        <Text size="1" color="gray" mr="3">
+          this may take several minutes
+        </Text>
       )}
+      <RadixButton
+        variant={radixVariant}
+        size="sm"
+        disabled={loading}
+        setError={(error) => setError(error ?? undefined)}
+        onClick={submitUpdate}
+        style={{
+          minWidth: 110,
+        }}
+        icon={<PiArrowClockwise />}
+      >
+        Update
+      </RadixButton>
+    </>
+  ) : (
+    <>
+      {loading && longResult && (
+        <small className="text-muted mr-3">this may take several minutes</small>
+      )}
+      <Button
+        color="outline-primary"
+        setErrorText={setError}
+        onClick={submitUpdate}
+      >
+        <BsArrowRepeat /> Update
+      </Button>
     </>
   );
 };

--- a/packages/front-end/components/Experiment/ResultMoreMenu.tsx
+++ b/packages/front-end/components/Experiment/ResultMoreMenu.tsx
@@ -140,6 +140,7 @@ export default function ResultMoreMenu({
     ? getIsExperimentIncludedInIncrementalRefresh(
         datasource ?? undefined,
         experiment.id,
+        experiment.type,
       )
     : false;
 
@@ -314,7 +315,7 @@ export default function ResultMoreMenu({
 
   // Re-enable Incremental Refresh: drops the experiment from the exclusion
   // list and (if the datasource defaults to ephemeral) adds it to the
-  // opt-in list. Mirror of handleDisableIncrementalRefresh.
+  // opt-in list.
   const handleReenableIncrementalRefresh = useCallback(async () => {
     if (!datasource || !experiment) return;
 

--- a/packages/front-end/components/Experiment/ResultMoreMenu.tsx
+++ b/packages/front-end/components/Experiment/ResultMoreMenu.tsx
@@ -145,12 +145,9 @@ export default function ResultMoreMenu({
       )
     : false;
 
-  // An experiment can be covered by the data source's incremental config yet
-  // still be unable to run incrementally (e.g. it has an activation metric).
-  // Such an experiment always does a full rescan, so the "Full refresh"
-  // treatment doesn't apply — present it as a plain re-run instead. The reason
-  // it can't run incrementally is surfaced separately by the analysis summary
-  // warning callout.
+  // An experiment that is unsupported by Incremental Pipeline mode
+  // will always do a full rescan.
+  // So Full Refresh does not apply.
   const incrementalPipelineUnsupportedReason =
     useIncrementalPipelineUnsupportedReason(experiment);
   const runsIncrementalRefresh =

--- a/packages/front-end/components/Experiment/ResultMoreMenu.tsx
+++ b/packages/front-end/components/Experiment/ResultMoreMenu.tsx
@@ -25,6 +25,7 @@ import {
 import { useDefinitions } from "@/services/DefinitionsContext";
 import Badge from "@/ui/Badge";
 import { useUser } from "@/services/UserContext";
+import { useIncrementalPipelineUnsupportedReason } from "@/hooks/useIncrementalPipelineUnsupportedReason";
 import { useSnapshot } from "./SnapshotProvider";
 
 export function canShowRefreshMenuItem({
@@ -144,6 +145,18 @@ export default function ResultMoreMenu({
       )
     : false;
 
+  // An experiment can be covered by the data source's incremental config yet
+  // still be unable to run incrementally (e.g. it has an activation metric).
+  // Such an experiment always does a full rescan, so the "Full refresh"
+  // treatment doesn't apply — present it as a plain re-run instead. The reason
+  // it can't run incrementally is surfaced separately by the analysis summary
+  // warning callout.
+  const incrementalPipelineUnsupportedReason =
+    useIncrementalPipelineUnsupportedReason(experiment);
+  const runsIncrementalRefresh =
+    isExperimentIncludedInIncrementalRefresh &&
+    !incrementalPipelineUnsupportedReason;
+
   const experimentExcludedFromIncrementalRefresh =
     isExperimentExcludedFromIncrementalRefresh({
       datasource,
@@ -155,7 +168,7 @@ export default function ResultMoreMenu({
 
   const { getExperimentMetricById, getDimensionById, ready } = useDefinitions();
 
-  const rerunAllQueriesText = isExperimentIncludedInIncrementalRefresh
+  const rerunAllQueriesText = runsIncrementalRefresh
     ? "Full refresh"
     : !hasData
       ? "Force update"
@@ -401,13 +414,13 @@ export default function ResultMoreMenu({
               (datasource &&
                 permissionsUtil.canRunExperimentQueries(datasource)) ??
               false,
-            isExperimentIncludedInIncrementalRefresh,
+            isExperimentIncludedInIncrementalRefresh: runsIncrementalRefresh,
             dimension,
           }) && (
             <DropdownMenuItem
               onClick={handleForceRefresh}
               confirmation={
-                isExperimentIncludedInIncrementalRefresh
+                runsIncrementalRefresh
                   ? {
                       confirmationTitle: "Full Refresh",
                       cta: "I understand",

--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
@@ -1,6 +1,12 @@
 import { ExperimentInterfaceStringDates } from "shared/types/experiment";
 import { FactTableColumnType } from "shared/types/fact-table";
-import React, { useMemo, useState, useEffect, useRef } from "react";
+import React, {
+  useCallback,
+  useMemo,
+  useState,
+  useEffect,
+  useRef,
+} from "react";
 import { OrganizationSettings } from "shared/types/organization";
 import { ExperimentSnapshotInterface } from "shared/types/experiment-snapshot";
 import { DifferenceType, StatsEngine } from "shared/types/stats";
@@ -360,13 +366,13 @@ export default function AnalysisSettingsSummary({
   // available, and the fallback confirm only fires when they are not. Sequencing
   // them in one gate keeps them from competing over the button's single
   // customValidation slot.
-  const confirmRefresh = async (): Promise<boolean> => {
+  const confirmRefresh = useCallback(async (): Promise<boolean> => {
     if (needsDimensionRefreshConfirm) {
       setUpdateDimensionBreakdownModalOpen(true);
       return false;
     }
     return confirmIncrementalPipelineFallback();
-  };
+  }, [needsDimensionRefreshConfirm, confirmIncrementalPipelineFallback]);
 
   const ds = getDatasourceById(experiment.datasource);
 

--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
@@ -812,9 +812,6 @@ export default function AnalysisSettingsSummary({
               forceRefresh={
                 allMetrics.length > 0
                   ? async () => {
-                      // Gate through the same fallback confirm as the main
-                      // Update button: a covered-but-unsupported experiment
-                      // would rescan all data, so warn before forcing it.
                       if (!(await confirmIncrementalPipelineFallback())) return;
                       await runSnapshot(dimension ?? "", {
                         force: true,

--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
@@ -806,6 +806,10 @@ export default function AnalysisSettingsSummary({
               forceRefresh={
                 allMetrics.length > 0
                   ? async () => {
+                      // Gate through the same fallback confirm as the main
+                      // Update button: a covered-but-unsupported experiment
+                      // would rescan all data, so warn before forcing it.
+                      if (!(await confirmIncrementalPipelineFallback())) return;
                       await runSnapshot(dimension ?? "", {
                         force: true,
                         trackingSource: "ForceRerunQueriesButton",

--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
@@ -914,7 +914,7 @@ export default function AnalysisSettingsSummary({
         </Box>
       )}
 
-      {latest?.status !== "running" && incrementalUpdatesUnavailable && (
+      {incrementalUpdatesUnavailable && (
         <Callout status="warning" mt="2">
           <Text weight="semibold" size="medium">
             Updates will rescan full experiment data.

--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
@@ -4,7 +4,7 @@ import React, { useMemo, useState, useEffect, useRef } from "react";
 import { OrganizationSettings } from "shared/types/organization";
 import { ExperimentSnapshotInterface } from "shared/types/experiment-snapshot";
 import { DifferenceType, StatsEngine } from "shared/types/stats";
-import { Box, Flex, Text, Separator } from "@radix-ui/themes";
+import { Box, Flex, Separator } from "@radix-ui/themes";
 import {
   expandMetricGroups,
   getAllMetricIdsFromExperiment,
@@ -28,14 +28,16 @@ import {
 import { startCase } from "lodash";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import ResultMoreMenu from "@/components/Experiment/ResultMoreMenu";
-import { trackSnapshot } from "@/services/track";
+import { useExperimentSnapshotUpdate } from "@/hooks/useExperimentSnapshotUpdate";
 import { useSnapshot } from "@/components/Experiment/SnapshotProvider";
 import { useAuth } from "@/services/auth";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import usePValueThreshold from "@/hooks/usePValueThreshold";
+import { useIncrementalPipelineFallbackConfirm } from "@/hooks/useIncrementalPipelineFallbackConfirm";
 import { useUser } from "@/services/UserContext";
 import { getQueryStatus } from "@/components/Queries/RunQueriesButton";
 import RefreshResultsButton from "@/components/Experiment/RefreshResultsButton";
+import IncrementalPipelineFallbackDialog from "@/components/Experiment/IncrementalPipelineFallbackDialog";
 import QueriesLastRun from "@/components/Queries/QueriesLastRun";
 import AsyncQueriesModal from "@/components/Queries/AsyncQueriesModal";
 import OutdatedBadge from "@/components/OutdatedBadge";
@@ -50,6 +52,7 @@ import ResultsFilter from "@/components/Experiment/ResultsFilter/ResultsFilter";
 import { filterMetricsByTags } from "@/hooks/useExperimentTableRows";
 import DimensionChooser from "@/components/Dimensions/DimensionChooser";
 import Link from "@/ui/Link";
+import Text from "@/ui/Text";
 import MigrateResultsToDashboardModal from "@/components/Experiment/ResultsFilter/MigrateResultsToDashboardModal";
 import UpdateDimensionBreakdownModal from "@/components/Experiment/UpdateDimensionBreakdownModal";
 
@@ -218,10 +221,27 @@ export default function AnalysisSettingsSummary({
   const { apiCall } = useAuth();
   const { status } = getQueryStatus(latest?.queries || [], latest?.error);
 
+  const {
+    customValidation: confirmIncrementalPipelineFallback,
+    reason: incrementalPipelineUnsupportedReason,
+    isConfirmOpen: incrementalPipelineConfirmOpen,
+    onConfirm: onConfirmIncrementalPipelineFallback,
+    onCancel: onCancelIncrementalPipelineFallback,
+  } = useIncrementalPipelineFallbackConfirm({
+    experiment,
+    latestStatus: latest?.status,
+  });
+  // When the next update would fall back to a full (non-incremental) rescan, the
+  // incremental "dimension results are built on overall results" model no longer
+  // holds. The stale-dimension modal and the "newer overall results" outdated
+  // reason are both incremental-only concerns, so they don't apply here.
+  const incrementalUpdatesUnavailable = !!incrementalPipelineUnsupportedReason;
+
   const isExperimentIncludedInIncrementalRefresh =
     getIsExperimentIncludedInIncrementalRefresh(
       datasource ?? undefined,
       experiment.id,
+      experiment.type,
     );
 
   const newerOverallResultsAvailable = isNewerOverallResultsDataAvailable(
@@ -229,34 +249,14 @@ export default function AnalysisSettingsSummary({
     dimensionless,
   );
 
-  const runSnapshot = async (
-    dimensionToRun: string,
-    opts?: { force?: boolean; trackingSource?: string },
-  ) => {
-    const force = opts?.force ?? false;
-    const trackingSource = opts?.trackingSource ?? "RunQueriesButton";
-    try {
-      const res = await apiCall<{ snapshot: ExperimentSnapshotInterface }>(
-        `/experiment/${experiment.id}/snapshot${force ? "?force=true" : ""}`,
-        {
-          method: "POST",
-          body: JSON.stringify({ phase, dimension: dimensionToRun }),
-        },
-      );
-      trackSnapshot(
-        "create",
-        trackingSource,
-        datasource?.type || null,
-        res.snapshot,
-      );
-      setRefreshError("");
-    } catch (e) {
-      setRefreshError(e.message);
-    } finally {
-      mutate();
-      mutateExperiment();
-    }
-  };
+  const { runSnapshot } = useExperimentSnapshotUpdate({
+    experiment,
+    phase,
+    dimension,
+    mutate,
+    mutateAdditional: mutateExperiment,
+    setRefreshError,
+  });
 
   const handleDisableIncrementalRefresh = async () => {
     if (!datasource || !isExperimentIncludedInIncrementalRefresh) return;
@@ -339,15 +339,34 @@ export default function AnalysisSettingsSummary({
     phase,
     unjoinableMetrics,
     conversionWindowMetrics,
-    newerOverallResultsAvailable,
+    newerOverallResultsAvailable:
+      newerOverallResultsAvailable && !incrementalUpdatesUnavailable,
   });
 
-  // For Incremental Pipeline mode, dimension results are built on top
-  // of overall results (dimensionless snapshot)
-  // So if the user is clicking 'Update' on a scenario that we know there's no
-  // newer overall results available, we show a confirmation modal explaining why.
+  // In Incremental Pipeline mode, dimension results are built on top of overall
+  // results (the dimensionless snapshot). When the user clicks 'Update' while
+  // viewing a dimension breakdown that already covers the latest overall results
+  // (no newer overall data available), re-running won't fetch anything new, so we
+  // confirm and point them at updating overall results instead. This only applies
+  // when incremental updates are available — under a full-rescan fallback there is
+  // no overall/dimension split to reconcile.
   const needsDimensionRefreshConfirm =
-    !!sourceSnapshot && !newerOverallResultsAvailable;
+    !!sourceSnapshot &&
+    !newerOverallResultsAvailable &&
+    !incrementalUpdatesUnavailable;
+
+  // Single gate for the "Update" button. The two confirms are mutually exclusive
+  // by construction: the dimension modal only fires when incremental updates are
+  // available, and the fallback confirm only fires when they are not. Sequencing
+  // them in one gate keeps them from competing over the button's single
+  // customValidation slot.
+  const confirmRefresh = async (): Promise<boolean> => {
+    if (needsDimensionRefreshConfirm) {
+      setUpdateDimensionBreakdownModalOpen(true);
+      return false;
+    }
+    return confirmIncrementalPipelineFallback();
+  };
 
   const ds = getDatasourceById(experiment.datasource);
 
@@ -777,13 +796,7 @@ export default function AnalysisSettingsSummary({
                 phase={phase}
                 dimension={dimension}
                 setAnalysisSettings={setAnalysisSettings}
-                customValidation={() => {
-                  if (needsDimensionRefreshConfirm) {
-                    setUpdateDimensionBreakdownModalOpen(true);
-                    return false;
-                  }
-                  return true;
-                }}
+                customValidation={confirmRefresh}
               />
             ) : null}
 
@@ -894,14 +907,32 @@ export default function AnalysisSettingsSummary({
         </Box>
       )}
 
+      {latest?.status !== "running" && incrementalUpdatesUnavailable && (
+        <Callout status="warning" mt="2">
+          <Text weight="semibold" size="medium">
+            Updates will rescan full experiment data.
+          </Text>{" "}
+          {incrementalPipelineUnsupportedReason}
+        </Callout>
+      )}
+
+      {incrementalPipelineConfirmOpen &&
+      incrementalPipelineUnsupportedReason ? (
+        <IncrementalPipelineFallbackDialog
+          reason={incrementalPipelineUnsupportedReason}
+          onConfirm={onConfirmIncrementalPipelineFallback}
+          onCancel={onCancelIncrementalPipelineFallback}
+        />
+      ) : null}
+
       {refreshError && (
         <>
           <Callout status="error" mt="2">
             <strong>Error updating data: </strong> {refreshError}
           </Callout>
           {isExperimentIncludedInIncrementalRefresh && (
-            <Box mt="2" mb="2" style={{ color: "var(--color-text-low)" }}>
-              <Text size="1">
+            <Box mt="2" mb="2">
+              <Text size="small" color="text-low">
                 If this error persists, you can try disabling Incremental
                 Refresh for this experiment by{" "}
                 <Link onClick={handleDisableIncrementalRefresh}>

--- a/packages/front-end/components/Features/RuleModal/BanditRefNewFields.tsx
+++ b/packages/front-end/components/Features/RuleModal/BanditRefNewFields.tsx
@@ -365,6 +365,7 @@ export default function BanditRefNewFields({
           />
 
           <ExperimentMetricsSelector
+            experimentType="multi-armed-bandit"
             datasource={datasource?.id}
             exposureQueryId={exposureQueryId}
             project={project}

--- a/packages/front-end/components/Features/RuleModal/ExperimentRefNewFields.tsx
+++ b/packages/front-end/components/Features/RuleModal/ExperimentRefNewFields.tsx
@@ -633,6 +633,7 @@ export default function ExperimentRefNewFields({
             }
             collapseSecondary={true}
             collapseGuardrail={true}
+            experimentType="standard"
           />
 
           <CustomMetricSlicesSelector

--- a/packages/front-end/components/Holdout/NewHoldoutForm.tsx
+++ b/packages/front-end/components/Holdout/NewHoldoutForm.tsx
@@ -701,6 +701,7 @@ const NewHoldoutForm: FC<NewHoldoutFormProps> = ({
               collapseSecondary={true}
               goalMetricsDescription="The primary metrics you are trying to improve within this holdout. "
               filterConversionWindowMetrics={true}
+              experimentType="holdout"
             />
 
             <hr className="mt-4" />

--- a/packages/front-end/components/Report/ConfigureLegacyReport.tsx
+++ b/packages/front-end/components/Report/ConfigureLegacyReport.tsx
@@ -355,6 +355,7 @@ export default function ConfigureLegacyReport({
       </div>
 
       <ExperimentMetricsSelector
+        experimentType={experiment?.type}
         datasource={report.args.datasource}
         exposureQueryId={exposureQueryId}
         project={project?.id}

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -455,6 +455,7 @@ export default function ConfigureReport({
                   guardrailMetrics,
                 )
               }
+              experimentType={experiment?.type}
             />
 
             <div className="mt-4">

--- a/packages/front-end/hooks/useExperimentPipelineMode.ts
+++ b/packages/front-end/hooks/useExperimentPipelineMode.ts
@@ -11,6 +11,7 @@ export default function useExperimentPipelineMode(
   const isIncrementalRefresh = getIsExperimentIncludedInIncrementalRefresh(
     datasource ?? undefined,
     experiment?.id,
+    experiment?.type,
   );
   if (isIncrementalRefresh) {
     return "incremental-refresh";

--- a/packages/front-end/hooks/useExperimentSnapshotUpdate.ts
+++ b/packages/front-end/hooks/useExperimentSnapshotUpdate.ts
@@ -1,0 +1,166 @@
+import { useCallback, useState } from "react";
+import { ExperimentInterfaceStringDates } from "shared/types/experiment";
+import { ExperimentSnapshotInterface } from "shared/types/experiment-snapshot";
+import { isDimensionPrecomputed } from "shared/experiments";
+import { DataSourceInterfaceWithParams } from "shared/types/datasource";
+import { useAuth } from "@/services/auth";
+import { useDefinitions } from "@/services/DefinitionsContext";
+import { useUser } from "@/services/UserContext";
+import { getHonoredPrecomputedUnitDimensionIds } from "@/services/experiments";
+import { trackSnapshot } from "@/services/track";
+
+function getSnapshotDimensionForPostRequest({
+  dimension,
+  experiment,
+  datasource,
+  hasPipelineModeFeature,
+}: {
+  dimension?: string;
+  experiment: ExperimentInterfaceStringDates;
+  datasource?: DataSourceInterfaceWithParams;
+  hasPipelineModeFeature: boolean;
+}): string {
+  return isDimensionPrecomputed(
+    dimension,
+    getHonoredPrecomputedUnitDimensionIds(
+      experiment.precomputedUnitDimensionIds,
+      datasource,
+      hasPipelineModeFeature,
+    ),
+  )
+    ? ""
+    : (dimension ?? "");
+}
+
+export function useExperimentSnapshotUpdate({
+  experiment,
+  phase,
+  dimension,
+  mutate,
+  mutateAdditional,
+  setRefreshError,
+  onSuccess,
+  customValidation,
+  experimentSnapshotTrackingProps,
+}: {
+  // Optional so a host component that also serves non-experiment entities (e.g.
+  // safe rollouts) can call the hook unconditionally; the update functions
+  // no-op until an experiment is present.
+  experiment: ExperimentInterfaceStringDates | undefined;
+  phase: number;
+  dimension?: string;
+  mutate: () => void;
+  mutateAdditional?: () => void;
+  setRefreshError: (error: string) => void;
+  onSuccess?: () => void;
+  // Return false to abort the refresh (e.g. to open a confirmation dialog
+  // instead). Mirrors Modal's customValidation. Side effects are allowed.
+  customValidation?: () => boolean | Promise<boolean>;
+  experimentSnapshotTrackingProps?: {
+    trackingSource: string;
+    datasourceType: string | null;
+  };
+}) {
+  const { apiCall } = useAuth();
+  const { getDatasourceById } = useDefinitions();
+  const { hasCommercialFeature } = useUser();
+
+  const [loading, setLoading] = useState(false);
+  const [longResult, setLongResult] = useState(false);
+
+  // Low-level primitive: POST a snapshot for an explicit dimension. Callers that
+  // already know the dimension to run (force re-run, "go to overall results",
+  // dimension-only breakdown) use this directly. `submitUpdate` resolves the
+  // dimension from props and gates on `customValidation` before delegating here.
+  const runSnapshot = useCallback(
+    async (
+      dimensionToRun: string,
+      opts?: { force?: boolean; trackingSource?: string },
+    ): Promise<void> => {
+      if (!experiment) return;
+      setLoading(true);
+      setLongResult(false);
+      setRefreshError("");
+      const timer = setTimeout(() => setLongResult(true), 5000);
+      try {
+        const force = opts?.force ?? false;
+        const datasource = experiment.datasource
+          ? (getDatasourceById(experiment.datasource) ?? undefined)
+          : undefined;
+        const { snapshot } = await apiCall<{
+          snapshot: ExperimentSnapshotInterface;
+        }>(
+          `/experiment/${experiment.id}/snapshot${force ? "?force=true" : ""}`,
+          {
+            method: "POST",
+            body: JSON.stringify({ phase, dimension: dimensionToRun }),
+          },
+        );
+        const trackingSource =
+          opts?.trackingSource ??
+          experimentSnapshotTrackingProps?.trackingSource;
+        if (trackingSource) {
+          trackSnapshot(
+            "create",
+            trackingSource,
+            experimentSnapshotTrackingProps?.datasourceType ??
+              datasource?.type ??
+              null,
+            snapshot,
+          );
+        }
+        onSuccess?.();
+      } catch (e) {
+        setRefreshError(e.message);
+      } finally {
+        clearTimeout(timer);
+        setLoading(false);
+        mutate();
+        mutateAdditional?.();
+      }
+    },
+    [
+      apiCall,
+      experiment,
+      getDatasourceById,
+      phase,
+      experimentSnapshotTrackingProps,
+      onSuccess,
+      setRefreshError,
+      mutate,
+      mutateAdditional,
+    ],
+  );
+
+  const submitUpdate = useCallback(async () => {
+    if (!experiment) return;
+    if (customValidation && !(await customValidation())) {
+      return;
+    }
+    const datasource = experiment.datasource
+      ? (getDatasourceById(experiment.datasource) ?? undefined)
+      : undefined;
+    await runSnapshot(
+      getSnapshotDimensionForPostRequest({
+        dimension,
+        experiment,
+        datasource,
+        hasPipelineModeFeature: hasCommercialFeature("pipeline-mode"),
+      }),
+    );
+  }, [
+    customValidation,
+    runSnapshot,
+    dimension,
+    experiment,
+    getDatasourceById,
+    hasCommercialFeature,
+  ]);
+
+  return {
+    submitUpdate,
+    runSnapshot,
+    loading,
+    longResult,
+  };
+}

--- a/packages/front-end/hooks/useIncrementalPipelineFallbackConfirm.ts
+++ b/packages/front-end/hooks/useIncrementalPipelineFallbackConfirm.ts
@@ -1,0 +1,41 @@
+import { useCallback, useRef, useState } from "react";
+import { ExperimentInterfaceStringDates } from "shared/types/experiment";
+import { useIncrementalPipelineUnsupportedReason } from "@/hooks/useIncrementalPipelineUnsupportedReason";
+
+export function useIncrementalPipelineFallbackConfirm({
+  experiment,
+  latestStatus,
+}: {
+  experiment: ExperimentInterfaceStringDates | undefined;
+  latestStatus?: string;
+}) {
+  const reason = useIncrementalPipelineUnsupportedReason(experiment);
+
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const resolveRef = useRef<((proceed: boolean) => void) | null>(null);
+
+  // Passed to RefreshResultsButton as customValidation: returns true to let the
+  // refresh proceed, false to abort. When a structural reason blocks incremental
+  // refresh (and we're not mid-run), open the confirmation dialog and resolve
+  // based on the user's choice. Mid-run updates skip the gate.
+  const customValidation = useCallback((): boolean | Promise<boolean> => {
+    if (!reason || latestStatus === "running") {
+      return true;
+    }
+    setIsConfirmOpen(true);
+    return new Promise<boolean>((resolve) => {
+      resolveRef.current = resolve;
+    });
+  }, [reason, latestStatus]);
+
+  const resolve = useCallback((proceed: boolean) => {
+    setIsConfirmOpen(false);
+    resolveRef.current?.(proceed);
+    resolveRef.current = null;
+  }, []);
+
+  const onConfirm = useCallback(() => resolve(true), [resolve]);
+  const onCancel = useCallback(() => resolve(false), [resolve]);
+
+  return { customValidation, reason, isConfirmOpen, onConfirm, onCancel };
+}

--- a/packages/front-end/hooks/useIncrementalPipelineFallbackConfirm.ts
+++ b/packages/front-end/hooks/useIncrementalPipelineFallbackConfirm.ts
@@ -22,6 +22,8 @@ export function useIncrementalPipelineFallbackConfirm({
     if (!reason || latestStatus === "running") {
       return true;
     }
+    // Ensure any pending requests resolve to false to avoid hanging
+    resolveRef.current?.(false);
     setIsConfirmOpen(true);
     return new Promise<boolean>((resolve) => {
       resolveRef.current = resolve;

--- a/packages/front-end/hooks/useIncrementalPipelineUnsupportedReason.ts
+++ b/packages/front-end/hooks/useIncrementalPipelineUnsupportedReason.ts
@@ -1,0 +1,62 @@
+import { useMemo } from "react";
+import { getAllMetricIdsFromExperiment } from "shared/experiments";
+import { getIncrementalPipelineUnsupportedReason } from "shared/enterprise";
+import { ExperimentInterfaceStringDates } from "shared/types/experiment";
+import { useDefinitions } from "@/services/DefinitionsContext";
+import { useUser } from "@/services/UserContext";
+import { getIsExperimentIncludedInIncrementalRefresh } from "@/services/experiments";
+
+export function useIncrementalPipelineUnsupportedReason(
+  experiment: ExperimentInterfaceStringDates | undefined,
+): string | undefined {
+  const { ready, getDatasourceById, getExperimentMetricById, metricGroups } =
+    useDefinitions();
+  const { hasCommercialFeature } = useUser();
+
+  return useMemo(() => {
+    if (!ready || !experiment) return undefined;
+
+    const datasource = getDatasourceById(experiment.datasource);
+    if (!datasource) return undefined;
+
+    if (
+      !getIsExperimentIncludedInIncrementalRefresh(
+        datasource,
+        experiment.id,
+        experiment.type,
+      )
+    ) {
+      return undefined;
+    }
+
+    const metrics = getAllMetricIdsFromExperiment(
+      experiment,
+      false,
+      metricGroups,
+    )
+      .map((id) => getExperimentMetricById(id))
+      .filter((m): m is NonNullable<typeof m> => m !== null);
+
+    return (
+      getIncrementalPipelineUnsupportedReason({
+        datasourceProperties: datasource.properties,
+        pipelineSettings: datasource.settings?.pipelineSettings,
+        experimentId: experiment.id,
+        orgHasIncrementalPipelineFeature: hasCommercialFeature(
+          "incremental-refresh",
+        ),
+        skipPartialData: !!experiment.skipPartialData,
+        activationMetric: experiment.activationMetric,
+        metrics,
+        experimentType: experiment.type,
+      }) ?? undefined
+    );
+  }, [
+    ready,
+    experiment,
+    getDatasourceById,
+    getExperimentMetricById,
+    metricGroups,
+    hasCommercialFeature,
+  ]);
+}

--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -959,6 +959,7 @@ export function getHonoredPrecomputedUnitDimensionIds(
 export function getIsExperimentIncludedInIncrementalRefresh(
   datasource: DataSourceInterfaceWithParams | undefined,
   experimentId: string | undefined,
+  experimentType: ExperimentInterfaceStringDates["type"],
 ): boolean {
   const pipelineSettings = datasource?.settings.pipelineSettings;
   if (!pipelineSettings) return false;
@@ -976,7 +977,11 @@ export function getIsExperimentIncludedInIncrementalRefresh(
     );
   }
 
-  return isExperimentIncrementalEnabled(pipelineSettings, experimentId);
+  return isExperimentIncrementalEnabled(
+    pipelineSettings,
+    experimentId,
+    experimentType,
+  );
 }
 
 // Returns updated pipeline settings that disable incremental refresh for the

--- a/packages/front-end/test/hooks/useExperimentSnapshotUpdate.test.ts
+++ b/packages/front-end/test/hooks/useExperimentSnapshotUpdate.test.ts
@@ -1,0 +1,106 @@
+import { act, renderHook } from "@testing-library/react";
+import { ExperimentInterfaceStringDates } from "shared/types/experiment";
+import { useExperimentSnapshotUpdate } from "@/hooks/useExperimentSnapshotUpdate";
+import { useAuth } from "@/services/auth";
+import { useDefinitions } from "@/services/DefinitionsContext";
+import { useUser } from "@/services/UserContext";
+
+vi.mock("@/services/auth");
+vi.mock("@/services/DefinitionsContext");
+vi.mock("@/services/UserContext");
+vi.mock("@/services/track");
+
+const experiment = {
+  id: "exp_1",
+  datasource: "ds_1",
+  precomputedUnitDimensionIds: [],
+} as unknown as ExperimentInterfaceStringDates;
+
+describe("useExperimentSnapshotUpdate", () => {
+  const apiCall = vi.fn();
+
+  beforeEach(() => {
+    apiCall.mockReset();
+    vi.mocked(useAuth).mockReturnValue({
+      apiCall,
+    } as unknown as ReturnType<typeof useAuth>);
+    vi.mocked(useDefinitions).mockReturnValue({
+      getDatasourceById: () => null,
+    } as unknown as ReturnType<typeof useDefinitions>);
+    vi.mocked(useUser).mockReturnValue({
+      hasCommercialFeature: () => false,
+    } as unknown as ReturnType<typeof useUser>);
+  });
+
+  function render(
+    overrides: Partial<Parameters<typeof useExperimentSnapshotUpdate>[0]> = {},
+  ) {
+    return renderHook(() =>
+      useExperimentSnapshotUpdate({
+        experiment,
+        phase: 0,
+        mutate: vi.fn(),
+        setRefreshError: vi.fn(),
+        ...overrides,
+      }),
+    );
+  }
+
+  it("posts immediately when there is no customValidation", async () => {
+    apiCall.mockResolvedValue({ status: 200, snapshot: { id: "snap_1" } });
+    const { result } = render();
+
+    await act(() => result.current.submitUpdate());
+
+    expect(apiCall).toHaveBeenCalledTimes(1);
+    expect(apiCall.mock.calls[0][0]).toBe("/experiment/exp_1/snapshot");
+  });
+
+  it("posts when customValidation resolves true", async () => {
+    apiCall.mockResolvedValue({ status: 200, snapshot: { id: "snap_1" } });
+    const customValidation = vi.fn().mockResolvedValue(true);
+    const { result } = render({ customValidation });
+
+    await act(() => result.current.submitUpdate());
+
+    expect(customValidation).toHaveBeenCalledTimes(1);
+    expect(apiCall).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts without posting when customValidation resolves false", async () => {
+    const customValidation = vi.fn().mockResolvedValue(false);
+    const { result } = render({ customValidation });
+
+    await act(() => result.current.submitUpdate());
+
+    expect(customValidation).toHaveBeenCalledTimes(1);
+    expect(apiCall).not.toHaveBeenCalled();
+  });
+
+  it("runSnapshot posts the explicit dimension without customValidation", async () => {
+    apiCall.mockResolvedValue({ status: 200, snapshot: { id: "snap_1" } });
+    const customValidation = vi.fn().mockResolvedValue(false);
+    const { result } = render({ customValidation });
+
+    await act(() => result.current.runSnapshot("country"));
+
+    expect(customValidation).not.toHaveBeenCalled();
+    expect(apiCall).toHaveBeenCalledTimes(1);
+    expect(apiCall.mock.calls[0][0]).toBe("/experiment/exp_1/snapshot");
+    expect(JSON.parse(apiCall.mock.calls[0][1].body)).toEqual({
+      phase: 0,
+      dimension: "country",
+    });
+  });
+
+  it("runSnapshot appends ?force=true when force is set", async () => {
+    apiCall.mockResolvedValue({ status: 200, snapshot: { id: "snap_1" } });
+    const { result } = render();
+
+    await act(() => result.current.runSnapshot("", { force: true }));
+
+    expect(apiCall.mock.calls[0][0]).toBe(
+      "/experiment/exp_1/snapshot?force=true",
+    );
+  });
+});

--- a/packages/front-end/test/hooks/useIncrementalPipelineFallbackConfirm.test.ts
+++ b/packages/front-end/test/hooks/useIncrementalPipelineFallbackConfirm.test.ts
@@ -1,0 +1,88 @@
+import { act, renderHook } from "@testing-library/react";
+import { ExperimentInterfaceStringDates } from "shared/types/experiment";
+import { useIncrementalPipelineFallbackConfirm } from "@/hooks/useIncrementalPipelineFallbackConfirm";
+import { useIncrementalPipelineUnsupportedReason } from "@/hooks/useIncrementalPipelineUnsupportedReason";
+
+vi.mock("@/hooks/useIncrementalPipelineUnsupportedReason");
+
+const experiment = { id: "exp_1" } as unknown as ExperimentInterfaceStringDates;
+const reason = "Activation metrics are not supported.";
+
+describe("useIncrementalPipelineFallbackConfirm", () => {
+  beforeEach(() => {
+    vi.mocked(useIncrementalPipelineUnsupportedReason).mockReset();
+  });
+
+  it("proceeds without opening the dialog when there is no unsupported reason", async () => {
+    vi.mocked(useIncrementalPipelineUnsupportedReason).mockReturnValue(
+      undefined,
+    );
+    const { result } = renderHook(() =>
+      useIncrementalPipelineFallbackConfirm({ experiment }),
+    );
+
+    let proceed: boolean | undefined;
+    await act(async () => {
+      proceed = await result.current.customValidation();
+    });
+
+    expect(proceed).toBe(true);
+    expect(result.current.isConfirmOpen).toBe(false);
+  });
+
+  it("skips the gate while queries are running", async () => {
+    vi.mocked(useIncrementalPipelineUnsupportedReason).mockReturnValue(reason);
+    const { result } = renderHook(() =>
+      useIncrementalPipelineFallbackConfirm({
+        experiment,
+        latestStatus: "running",
+      }),
+    );
+
+    let proceed: boolean | undefined;
+    await act(async () => {
+      proceed = await result.current.customValidation();
+    });
+
+    expect(proceed).toBe(true);
+    expect(result.current.isConfirmOpen).toBe(false);
+  });
+
+  it("opens the dialog and proceeds when confirmed", async () => {
+    vi.mocked(useIncrementalPipelineUnsupportedReason).mockReturnValue(reason);
+    const { result } = renderHook(() =>
+      useIncrementalPipelineFallbackConfirm({ experiment }),
+    );
+
+    let validation: boolean | Promise<boolean>;
+    act(() => {
+      validation = result.current.customValidation();
+    });
+    expect(result.current.isConfirmOpen).toBe(true);
+
+    act(() => {
+      result.current.onConfirm();
+    });
+    expect(result.current.isConfirmOpen).toBe(false);
+    await expect(validation!).resolves.toBe(true);
+  });
+
+  it("opens the dialog and aborts when cancelled", async () => {
+    vi.mocked(useIncrementalPipelineUnsupportedReason).mockReturnValue(reason);
+    const { result } = renderHook(() =>
+      useIncrementalPipelineFallbackConfirm({ experiment }),
+    );
+
+    let validation: boolean | Promise<boolean>;
+    act(() => {
+      validation = result.current.customValidation();
+    });
+    expect(result.current.isConfirmOpen).toBe(true);
+
+    act(() => {
+      result.current.onCancel();
+    });
+    expect(result.current.isConfirmOpen).toBe(false);
+    await expect(validation!).resolves.toBe(false);
+  });
+});

--- a/packages/front-end/test/hooks/useIncrementalPipelineFallbackConfirm.test.ts
+++ b/packages/front-end/test/hooks/useIncrementalPipelineFallbackConfirm.test.ts
@@ -116,4 +116,33 @@ describe("useIncrementalPipelineFallbackConfirm", () => {
     await expect(secondValidation!).resolves.toBe(true);
     expect(result.current.isConfirmOpen).toBe(false);
   });
+
+  // Both the Update button and the More Menu's "Re-run all queries" call this
+  // gate, so a second invocation can arrive while the first dialog is still
+  // open. The superseded attempt must settle (aborted) rather than hang.
+  it("aborts the earlier attempt instead of hanging when invocations overlap", async () => {
+    vi.mocked(useIncrementalPipelineUnsupportedReason).mockReturnValue(reason);
+    const { result } = renderHook(() =>
+      useIncrementalPipelineFallbackConfirm({ experiment }),
+    );
+
+    let firstValidation: boolean | Promise<boolean>;
+    act(() => {
+      firstValidation = result.current.customValidation();
+    });
+    expect(result.current.isConfirmOpen).toBe(true);
+
+    let secondValidation: boolean | Promise<boolean>;
+    act(() => {
+      secondValidation = result.current.customValidation();
+    });
+    await expect(firstValidation!).resolves.toBe(false);
+
+    expect(result.current.isConfirmOpen).toBe(true);
+    act(() => {
+      result.current.onConfirm();
+    });
+    await expect(secondValidation!).resolves.toBe(true);
+    expect(result.current.isConfirmOpen).toBe(false);
+  });
 });

--- a/packages/front-end/test/hooks/useIncrementalPipelineFallbackConfirm.test.ts
+++ b/packages/front-end/test/hooks/useIncrementalPipelineFallbackConfirm.test.ts
@@ -85,4 +85,35 @@ describe("useIncrementalPipelineFallbackConfirm", () => {
     expect(result.current.isConfirmOpen).toBe(false);
     await expect(validation!).resolves.toBe(false);
   });
+
+  // The main Update button and the results More Menu's "Re-run all queries"
+  // share one gate instance, so it must resolve each invocation independently.
+  it("re-opens and resolves independently across repeated invocations", async () => {
+    vi.mocked(useIncrementalPipelineUnsupportedReason).mockReturnValue(reason);
+    const { result } = renderHook(() =>
+      useIncrementalPipelineFallbackConfirm({ experiment }),
+    );
+
+    let firstValidation: boolean | Promise<boolean>;
+    act(() => {
+      firstValidation = result.current.customValidation();
+    });
+    expect(result.current.isConfirmOpen).toBe(true);
+    act(() => {
+      result.current.onCancel();
+    });
+    await expect(firstValidation!).resolves.toBe(false);
+    expect(result.current.isConfirmOpen).toBe(false);
+
+    let secondValidation: boolean | Promise<boolean>;
+    act(() => {
+      secondValidation = result.current.customValidation();
+    });
+    expect(result.current.isConfirmOpen).toBe(true);
+    act(() => {
+      result.current.onConfirm();
+    });
+    await expect(secondValidation!).resolves.toBe(true);
+    expect(result.current.isConfirmOpen).toBe(false);
+  });
 });

--- a/packages/shared/src/enterprise/pipeline.ts
+++ b/packages/shared/src/enterprise/pipeline.ts
@@ -1,47 +1,129 @@
 import { getValidDate } from "shared/dates";
+import {
+  isFactMetric,
+  quantileMetricType,
+  ExperimentMetricInterface,
+} from "shared/experiments";
 import type {
   DataSourceType,
   DataSourcePipelineMode,
   DataSourcePipelineSettings,
 } from "shared/types/datasource";
 import type { ExperimentSnapshotInterface } from "shared/types/experiment-snapshot";
+import type { ExperimentInterface } from "shared/types/experiment";
 import type { PipelineIntegration } from "shared/types/integrations";
 
 /**
- * Single source of truth for whether an experiment runs with incremental
- * refresh on a given data source. Used at snapshot planning time
- * (`isIncrementalRefreshEnabledForSnapshot`) and validation time
- * (`assertIncrementalRefreshPrerequisites`).
+ * Whether an experiment is *covered* by a data source's Incremental Pipeline
+ * configuration: incremental writing is enabled, the experiment is in scope,
+ * and its type is supported. Coverage is the first stage of incremental
+ * resolution.
  *
- * Resolution order:
- * 1. If `mode === "incremental"`, apply include/exclude semantics. Opt-in is
- *    ignored here — every experiment is already incremental by default, so
- *    `excludedExperimentIds` is the only meaningful per-experiment override.
- * 2. Else if the experiment is in `incrementalOptInExperimentIds`, it runs
- *    incremental (e.g. opting specific experiments into incremental while
- *    the default mode stays ephemeral).
- * 3. Otherwise, not incremental.
+ * The later stages live elsewhere: per-experiment *support*
+ * (`getIncrementalPipelineUnsupportedReason`) checks whether the experiment's
+ * own configuration works with incremental, and a supported experiment may
+ * still need a full (non-incremental) rescan to rebuild its units table.
+ *
+ * Used at snapshot planning time (`resolveSnapshotRunner`) and validation time
+ * (`assertIncrementalRefreshPrerequisites`).
  */
 export function isExperimentIncrementalEnabled(
   settings: DataSourcePipelineSettings | undefined,
   experimentId: string,
+  experimentType: ExperimentInterface["type"],
 ): boolean {
   if (!settings || !settings.allowWriting) return false;
 
-  if (settings.mode === "incremental") {
-    if (settings.excludedExperimentIds?.includes(experimentId)) return false;
-    if (
-      settings.includedExperimentIds !== undefined &&
-      !settings.includedExperimentIds.includes(experimentId)
-    ) {
-      return false;
-    }
-    return true;
+  const coveredByDataSource =
+    settings.mode === "incremental"
+      ? !settings.excludedExperimentIds?.includes(experimentId) &&
+        (settings.includedExperimentIds === undefined ||
+          settings.includedExperimentIds.includes(experimentId))
+      : (settings.incrementalOptInExperimentIds?.includes(experimentId) ??
+        false);
+
+  if (!coveredByDataSource) return false;
+
+  // Bandit and holdout experiments aren't supported yet.
+  if (experimentType !== undefined && experimentType !== "standard") {
+    return false;
   }
 
-  return (
-    settings.incrementalOptInExperimentIds?.includes(experimentId) ?? false
-  );
+  return true;
+}
+
+/**
+ * The highest-priority reason this experiment can't run in Incremental Pipeline
+ * mode, or null when it can. Combines coverage (delegated to
+ * `isExperimentIncrementalEnabled`) with the per-experiment support checks
+ * (in-progress conversions, activation metric, metrics, quantile sketches),
+ * returning the first reason that applies.
+ */
+export function getIncrementalPipelineUnsupportedReason(params: {
+  datasourceProperties:
+    | {
+        hasIncrementalRefresh?: boolean;
+        hasQuantileSketch?: boolean;
+      }
+    | undefined;
+  pipelineSettings: DataSourcePipelineSettings | undefined;
+  experimentId: string;
+  orgHasIncrementalPipelineFeature: boolean;
+  skipPartialData: boolean;
+  activationMetric: string | null | undefined;
+  metrics: ExperimentMetricInterface[];
+  experimentType: ExperimentInterface["type"];
+}): string | null {
+  if (!params.orgHasIncrementalPipelineFeature) {
+    return "Organization does not have access to Incremental Pipeline mode.";
+  }
+
+  if (!params.datasourceProperties?.hasIncrementalRefresh) {
+    return "The data source does not support Incremental Pipeline mode.";
+  }
+
+  if (
+    !isExperimentIncrementalEnabled(
+      params.pipelineSettings,
+      params.experimentId,
+      params.experimentType,
+    )
+  ) {
+    return "Incremental Pipeline mode is not enabled for this experiment.";
+  }
+
+  if (params.skipPartialData) {
+    return "'Exclude In-Progress Conversions' is not supported with Incremental Pipeline mode while in beta. Please select 'Include' in the Analysis Settings for Metric Conversion Windows.";
+  }
+
+  if (params.activationMetric) {
+    return "Activation metrics are not supported with Incremental Pipeline mode while in beta. Please remove the Activation Metric in the Analysis Settings.";
+  }
+
+  if (params.metrics.length === 0) {
+    return "Experiment must have at least 1 metric.";
+  }
+
+  if (params.metrics.some((m) => !isFactMetric(m))) {
+    return "Legacy metrics aren't supported with Incremental Pipeline mode. Convert or remove non-Fact Metrics.";
+  }
+
+  // Unit quantiles store a float and re-aggregate via SUM, so they work on
+  // any incremental-capable warehouse. Only event quantiles need a quantile
+  // sketch (the quantile must be computed over raw event values, which
+  // requires a mergeable sketch for incremental aggregation).
+  if (
+    params.metrics.some(
+      (metric) =>
+        isFactMetric(metric) &&
+        quantileMetricType(metric) === "event" &&
+        !params.datasourceProperties?.hasQuantileSketch,
+    )
+  ) {
+    return "Event quantile metrics are not supported with Incremental Pipeline mode on this data source.";
+  }
+
+  return null;
 }
 
 export type PipelineValidationResult = {

--- a/packages/shared/src/enterprise/pipeline.ts
+++ b/packages/shared/src/enterprise/pipeline.ts
@@ -14,15 +14,46 @@ import type { ExperimentInterface } from "shared/types/experiment";
 import type { PipelineIntegration } from "shared/types/integrations";
 
 /**
+ * Whether a data source's Incremental Pipeline configuration *covers* this
+ * experiment: incremental writing is enabled and the experiment is in scope.
+ * Datasource-level only; the experiment's type and per-config support are
+ * checked separately. A `false` here means "not an incremental experiment",
+ * which callers treat as silent (no fallback warning).
+ */
+export function isExperimentCoveredByIncrementalPipeline(
+  settings: DataSourcePipelineSettings | undefined,
+  experimentId: string,
+): boolean {
+  if (!settings || !settings.allowWriting) return false;
+
+  return settings.mode === "incremental"
+    ? !settings.excludedExperimentIds?.includes(experimentId) &&
+        (settings.includedExperimentIds === undefined ||
+          settings.includedExperimentIds.includes(experimentId))
+    : (settings.incrementalOptInExperimentIds?.includes(experimentId) ?? false);
+}
+
+/**
+ * The reason an experiment's *type* is unsupported by Incremental Pipeline
+ * mode, or null when the type is supported. Bandit and holdout experiments
+ * aren't supported yet.
+ */
+export function getUnsupportedIncrementalExperimentTypeReason(
+  experimentType: ExperimentInterface["type"],
+): string | null {
+  if (experimentType !== undefined && experimentType !== "standard") {
+    return `Experiment type "${experimentType}" is not supported for incremental refresh.`;
+  }
+  return null;
+}
+
+/**
  * Whether an experiment is *covered* by a data source's Incremental Pipeline
- * configuration: incremental writing is enabled, the experiment is in scope,
- * and its type is supported. Coverage is the first stage of incremental
- * resolution.
- *
- * The later stages live elsewhere: per-experiment *support*
- * (`getIncrementalPipelineUnsupportedReason`) checks whether the experiment's
- * own configuration works with incremental, and a supported experiment may
- * still need a full (non-incremental) rescan to rebuild its units table.
+ * configuration and has a supported type. Coverage is the first stage of
+ * incremental resolution; per-experiment *support*
+ * (`getIncrementalPipelineUnsupportedReason`) checks the rest, and a supported
+ * experiment may still need a full (non-incremental) rescan to rebuild its
+ * units table.
  *
  * Used at snapshot planning time (`resolveSnapshotRunner`) and validation time
  * (`assertIncrementalRefreshPrerequisites`).
@@ -32,24 +63,10 @@ export function isExperimentIncrementalEnabled(
   experimentId: string,
   experimentType: ExperimentInterface["type"],
 ): boolean {
-  if (!settings || !settings.allowWriting) return false;
-
-  const coveredByDataSource =
-    settings.mode === "incremental"
-      ? !settings.excludedExperimentIds?.includes(experimentId) &&
-        (settings.includedExperimentIds === undefined ||
-          settings.includedExperimentIds.includes(experimentId))
-      : (settings.incrementalOptInExperimentIds?.includes(experimentId) ??
-        false);
-
-  if (!coveredByDataSource) return false;
-
-  // Bandit and holdout experiments aren't supported yet.
-  if (experimentType !== undefined && experimentType !== "standard") {
-    return false;
-  }
-
-  return true;
+  return (
+    isExperimentCoveredByIncrementalPipeline(settings, experimentId) &&
+    getUnsupportedIncrementalExperimentTypeReason(experimentType) === null
+  );
 }
 
 /**

--- a/packages/shared/src/enterprise/pipeline.ts
+++ b/packages/shared/src/enterprise/pipeline.ts
@@ -105,7 +105,7 @@ export function getIncrementalPipelineUnsupportedReason(params: {
   }
 
   if (params.metrics.some((m) => !isFactMetric(m))) {
-    return "Legacy metrics aren't supported with Incremental Pipeline mode. Convert or remove non-Fact Metrics.";
+    return "Legacy metrics aren't supported with Incremental Pipeline mode. Convert them or remove non-Fact Metrics.";
   }
 
   // Unit quantiles store a float and re-aggregate via SUM, so they work on

--- a/packages/shared/test/enterprise/pipeline.test.ts
+++ b/packages/shared/test/enterprise/pipeline.test.ts
@@ -1,9 +1,12 @@
 import {
   getExperimentSourceSnapshotRef,
+  getIncrementalPipelineUnsupportedReason,
   isExperimentIncrementalEnabled,
   isNewerOverallResultsDataAvailable,
 } from "shared/enterprise";
+import type { ExperimentMetricInterface } from "shared/experiments";
 import type { DataSourcePipelineSettings } from "shared/types/datasource";
+import type { FactMetricInterface } from "shared/types/fact-table";
 
 const makeSettings = (
   overrides: Partial<DataSourcePipelineSettings> = {},
@@ -16,7 +19,9 @@ const makeSettings = (
 describe("isExperimentIncrementalEnabled", () => {
   describe("guards", () => {
     it("returns false when settings is undefined", () => {
-      expect(isExperimentIncrementalEnabled(undefined, "exp_1")).toBe(false);
+      expect(
+        isExperimentIncrementalEnabled(undefined, "exp_1", undefined),
+      ).toBe(false);
     });
 
     it("returns false when allowWriting is false, even with opt-in", () => {
@@ -28,6 +33,7 @@ describe("isExperimentIncrementalEnabled", () => {
             incrementalOptInExperimentIds: ["exp_1"],
           }),
           "exp_1",
+          undefined,
         ),
       ).toBe(false);
     });
@@ -37,16 +43,39 @@ describe("isExperimentIncrementalEnabled", () => {
         isExperimentIncrementalEnabled(
           makeSettings({ allowWriting: false }),
           "exp_1",
+          undefined,
         ),
       ).toBe(false);
+    });
+
+    it("returns false for non-standard experiment types", () => {
+      expect(
+        isExperimentIncrementalEnabled(
+          makeSettings(),
+          "exp_1",
+          "multi-armed-bandit",
+        ),
+      ).toBe(false);
+      expect(
+        isExperimentIncrementalEnabled(makeSettings(), "exp_1", "holdout"),
+      ).toBe(false);
+    });
+
+    it("allows standard and undefined (legacy) experiment types", () => {
+      expect(
+        isExperimentIncrementalEnabled(makeSettings(), "exp_1", "standard"),
+      ).toBe(true);
+      expect(
+        isExperimentIncrementalEnabled(makeSettings(), "exp_1", undefined),
+      ).toBe(true);
     });
   });
 
   describe("mode: 'incremental'", () => {
     it("returns true by default (no scoping lists)", () => {
-      expect(isExperimentIncrementalEnabled(makeSettings(), "exp_1")).toBe(
-        true,
-      );
+      expect(
+        isExperimentIncrementalEnabled(makeSettings(), "exp_1", undefined),
+      ).toBe(true);
     });
 
     it("returns false when experiment is in excludedExperimentIds", () => {
@@ -54,6 +83,7 @@ describe("isExperimentIncrementalEnabled", () => {
         isExperimentIncrementalEnabled(
           makeSettings({ excludedExperimentIds: ["exp_1"] }),
           "exp_1",
+          undefined,
         ),
       ).toBe(false);
     });
@@ -63,6 +93,7 @@ describe("isExperimentIncrementalEnabled", () => {
         isExperimentIncrementalEnabled(
           makeSettings({ includedExperimentIds: ["exp_1"] }),
           "exp_1",
+          undefined,
         ),
       ).toBe(true);
     });
@@ -72,6 +103,7 @@ describe("isExperimentIncrementalEnabled", () => {
         isExperimentIncrementalEnabled(
           makeSettings({ includedExperimentIds: ["exp_other"] }),
           "exp_1",
+          undefined,
         ),
       ).toBe(false);
     });
@@ -84,6 +116,7 @@ describe("isExperimentIncrementalEnabled", () => {
             incrementalOptInExperimentIds: ["exp_1"],
           }),
           "exp_1",
+          undefined,
         ),
       ).toBe(false);
     });
@@ -96,6 +129,7 @@ describe("isExperimentIncrementalEnabled", () => {
             incrementalOptInExperimentIds: ["exp_1"],
           }),
           "exp_1",
+          undefined,
         ),
       ).toBe(false);
     });
@@ -110,6 +144,7 @@ describe("isExperimentIncrementalEnabled", () => {
             incrementalOptInExperimentIds: ["exp_1"],
           }),
           "exp_1",
+          undefined,
         ),
       ).toBe(true);
     });
@@ -122,6 +157,7 @@ describe("isExperimentIncrementalEnabled", () => {
             incrementalOptInExperimentIds: ["exp_other"],
           }),
           "exp_1",
+          undefined,
         ),
       ).toBe(false);
     });
@@ -131,6 +167,7 @@ describe("isExperimentIncrementalEnabled", () => {
         isExperimentIncrementalEnabled(
           makeSettings({ mode: "ephemeral" }),
           "exp_1",
+          undefined,
         ),
       ).toBe(false);
     });
@@ -145,6 +182,7 @@ describe("isExperimentIncrementalEnabled", () => {
             excludedExperimentIds: ["exp_1"],
           }),
           "exp_1",
+          undefined,
         ),
       ).toBe(false);
     });
@@ -228,5 +266,257 @@ describe("isNewerOverallResultsDataAvailable", () => {
         dateCreated: "2024-06-02T12:00:00Z" as unknown as Date,
       }),
     ).toBe(true);
+  });
+});
+
+const experimentId = "exp_1";
+
+const makePipelineSettings = (
+  overrides: Partial<DataSourcePipelineSettings> = {},
+): DataSourcePipelineSettings => ({
+  allowWriting: true,
+  mode: "incremental",
+  ...overrides,
+});
+
+const makeFactMetric = (
+  overrides: Partial<FactMetricInterface> = {},
+): FactMetricInterface =>
+  ({
+    id: "fact_m1",
+    organization: "org_1",
+    datasource: "ds_1",
+    dateCreated: new Date(),
+    dateUpdated: new Date(),
+    name: "Test Fact Metric",
+    description: "",
+    owner: "owner",
+    projects: [],
+    tags: [],
+    inverse: false,
+    metricType: "mean",
+    numerator: {
+      factTableId: "ft_1",
+      column: "value",
+      aggregation: "sum",
+      rowFilters: [],
+    },
+    denominator: null,
+    cappingSettings: { type: "", value: 1000, ignoreZeros: false },
+    windowSettings: {
+      type: "",
+      delayValue: 1,
+      delayUnit: "days",
+      windowValue: 1,
+      windowUnit: "days",
+    },
+    priorSettings: {
+      override: false,
+      proper: false,
+      mean: 0,
+      stddev: 1,
+    },
+    quantileSettings: null,
+    maxPercentChange: 100,
+    minPercentChange: 0.1,
+    minSampleSize: 100,
+    targetMDE: 0.1,
+    displayAsPercentage: false,
+    winRisk: 0.1,
+    loseRisk: 0.05,
+    regressionAdjustmentOverride: true,
+    regressionAdjustmentEnabled: false,
+    regressionAdjustmentDays: 10,
+    ...overrides,
+  }) as FactMetricInterface;
+
+const makeLegacyMetric = (): ExperimentMetricInterface =>
+  ({
+    id: "legacy_m1",
+    organization: "org_1",
+    datasource: "ds_1",
+    name: "Legacy Metric",
+    type: "binomial",
+    sql: "SELECT 1",
+  }) as ExperimentMetricInterface;
+
+const makeEventQuantileMetric = (): FactMetricInterface =>
+  makeFactMetric({
+    id: "fact_quantile",
+    metricType: "quantile",
+    quantileSettings: {
+      type: "event",
+      quantile: 0.5,
+      ignoreZeros: false,
+    },
+  });
+
+const unsupportedReasonBaseParams = {
+  datasourceProperties: {
+    hasIncrementalRefresh: true,
+    hasQuantileSketch: true,
+  },
+  pipelineSettings: makePipelineSettings(),
+  experimentId,
+  orgHasIncrementalPipelineFeature: true,
+  skipPartialData: false,
+  activationMetric: null,
+  metrics: [makeFactMetric()],
+  experimentType: "standard",
+};
+
+describe("getIncrementalPipelineUnsupportedReason", () => {
+  it("returns null when all prerequisites are met", () => {
+    expect(
+      getIncrementalPipelineUnsupportedReason(unsupportedReasonBaseParams),
+    ).toBeNull();
+  });
+
+  it("flags a data source without Incremental Pipeline support", () => {
+    expect(
+      getIncrementalPipelineUnsupportedReason({
+        ...unsupportedReasonBaseParams,
+        datasourceProperties: { hasIncrementalRefresh: false },
+      }),
+    ).toBe("The data source does not support Incremental Pipeline mode.");
+  });
+
+  it("flags an experiment excluded from incremental mode", () => {
+    expect(
+      getIncrementalPipelineUnsupportedReason({
+        ...unsupportedReasonBaseParams,
+        pipelineSettings: makePipelineSettings({
+          excludedExperimentIds: [experimentId],
+        }),
+      }),
+    ).toBe("Incremental Pipeline mode is not enabled for this experiment.");
+  });
+
+  it("flags orgs without the premium feature", () => {
+    expect(
+      getIncrementalPipelineUnsupportedReason({
+        ...unsupportedReasonBaseParams,
+        orgHasIncrementalPipelineFeature: false,
+      }),
+    ).toBe("Organization does not have access to Incremental Pipeline mode.");
+  });
+
+  it("flags exclude in-progress conversions", () => {
+    expect(
+      getIncrementalPipelineUnsupportedReason({
+        ...unsupportedReasonBaseParams,
+        skipPartialData: true,
+      }),
+    ).toBe(
+      "'Exclude In-Progress Conversions' is not supported with Incremental Pipeline mode while in beta. Please select 'Include' in the Analysis Settings for Metric Conversion Windows.",
+    );
+  });
+
+  it("flags a configured activation metric", () => {
+    expect(
+      getIncrementalPipelineUnsupportedReason({
+        ...unsupportedReasonBaseParams,
+        activationMetric: "fact_m1",
+      }),
+    ).toBe(
+      "Activation metrics are not supported with Incremental Pipeline mode while in beta. Please remove the Activation Metric in the Analysis Settings.",
+    );
+  });
+
+  it("flags an experiment with no metrics", () => {
+    expect(
+      getIncrementalPipelineUnsupportedReason({
+        ...unsupportedReasonBaseParams,
+        metrics: [],
+      }),
+    ).toBe("Experiment must have at least 1 metric.");
+  });
+
+  it("flags legacy metrics", () => {
+    expect(
+      getIncrementalPipelineUnsupportedReason({
+        ...unsupportedReasonBaseParams,
+        metrics: [makeLegacyMetric()],
+      }),
+    ).toBe(
+      "Legacy metrics aren't supported with Incremental Pipeline mode. Convert or remove non-Fact Metrics.",
+    );
+  });
+
+  it("flags event quantile metrics on a data source without quantile sketches", () => {
+    expect(
+      getIncrementalPipelineUnsupportedReason({
+        ...unsupportedReasonBaseParams,
+        datasourceProperties: {
+          hasIncrementalRefresh: true,
+          hasQuantileSketch: false,
+        },
+        metrics: [makeEventQuantileMetric()],
+      }),
+    ).toBe(
+      "Event quantile metrics are not supported with Incremental Pipeline mode on this data source.",
+    );
+  });
+
+  it("allows event quantile metrics when the data source supports quantile sketches", () => {
+    expect(
+      getIncrementalPipelineUnsupportedReason({
+        ...unsupportedReasonBaseParams,
+        metrics: [makeEventQuantileMetric()],
+      }),
+    ).toBeNull();
+  });
+
+  it("returns the highest-priority reason when several apply", () => {
+    expect(
+      getIncrementalPipelineUnsupportedReason({
+        datasourceProperties: { hasIncrementalRefresh: false },
+        pipelineSettings: makePipelineSettings({
+          excludedExperimentIds: [experimentId],
+        }),
+        experimentId,
+        orgHasIncrementalPipelineFeature: false,
+        skipPartialData: true,
+        activationMetric: "fact_m1",
+        metrics: [],
+      }),
+    ).toBe("Organization does not have access to Incremental Pipeline mode.");
+  });
+
+  it("treats non-standard experiment types as not covered, coverage-first", () => {
+    // Coverage prerequisites still outrank the type rejection.
+    expect(
+      getIncrementalPipelineUnsupportedReason({
+        ...unsupportedReasonBaseParams,
+        orgHasIncrementalPipelineFeature: false,
+        experimentType: "multi-armed-bandit",
+      }),
+    ).toBe("Organization does not have access to Incremental Pipeline mode.");
+
+    // Once the prerequisites pass, an unsupported type reads as not enabled.
+    expect(
+      getIncrementalPipelineUnsupportedReason({
+        ...unsupportedReasonBaseParams,
+        experimentType: "multi-armed-bandit",
+      }),
+    ).toBe("Incremental Pipeline mode is not enabled for this experiment.");
+    expect(
+      getIncrementalPipelineUnsupportedReason({
+        ...unsupportedReasonBaseParams,
+        experimentType: "holdout",
+      }),
+    ).toBe("Incremental Pipeline mode is not enabled for this experiment.");
+  });
+
+  it("still evaluates reasons for standard experiments", () => {
+    expect(
+      getIncrementalPipelineUnsupportedReason({
+        ...unsupportedReasonBaseParams,
+        experimentType: "standard",
+        metrics: [makeLegacyMetric()],
+      }),
+    ).toBe(
+      "Legacy metrics aren't supported with Incremental Pipeline mode. Convert or remove non-Fact Metrics.",
+    );
   });
 });

--- a/packages/shared/test/enterprise/pipeline.test.ts
+++ b/packages/shared/test/enterprise/pipeline.test.ts
@@ -439,7 +439,7 @@ describe("getIncrementalPipelineUnsupportedReason", () => {
         metrics: [makeLegacyMetric()],
       }),
     ).toBe(
-      "Legacy metrics aren't supported with Incremental Pipeline mode. Convert or remove non-Fact Metrics.",
+      "Legacy metrics aren't supported with Incremental Pipeline mode. Convert them or remove non-Fact Metrics.",
     );
   });
 
@@ -479,6 +479,7 @@ describe("getIncrementalPipelineUnsupportedReason", () => {
         skipPartialData: true,
         activationMetric: "fact_m1",
         metrics: [],
+        experimentType: undefined,
       }),
     ).toBe("Organization does not have access to Incremental Pipeline mode.");
   });
@@ -516,7 +517,7 @@ describe("getIncrementalPipelineUnsupportedReason", () => {
         metrics: [makeLegacyMetric()],
       }),
     ).toBe(
-      "Legacy metrics aren't supported with Incremental Pipeline mode. Convert or remove non-Fact Metrics.",
+      "Legacy metrics aren't supported with Incremental Pipeline mode. Convert them or remove non-Fact Metrics.",
     );
   });
 });


### PR DESCRIPTION
### Features and Changes

For Incremental Pipeline we have 2 concepts:
- Is this experiment covered by it? Meaning is `pipeline mode` enabled in the datasource and is this experiment not excluded
- Is this experiment supported? Meaning, is there any setting/configuration on this experiment that we cannot honor in Pipeline Mode at the moment? (note: some gaps we already closed, and we will close more, and some we will not)

When the answer to the second question is `no` is where we are making the changes:

**Before**: we would silently fallback to the `non-incremental` refresh and scan the whole experiment data without any information in the UI on how the user can fix it

**Now**: We have 2 interventions, 1 Callout explaining why it is not supported and 1 Confirmation when `Refresh` is clicked, to ensure users understand that the cost of this update will potentially be orders of magnitude different.

This also provides an opportunity for the user to fix the problem if they want, which will make the Callout go away and they can update using the Incremental Pipeline again.

### Screenshots

<img width="1275" height="534" alt="Screenshot 2026-06-16 at 4 42 53 PM" src="https://github.com/user-attachments/assets/41f42e8c-7d35-4fa0-b378-96e009f5de23" />

<img width="562" height="360" alt="Screenshot 2026-06-16 at 4 42 36 PM" src="https://github.com/user-attachments/assets/c5cd2c96-aac3-4489-a82f-9ea83948fc91" />

### Testing

- Unit tests
- Manual testing
