### PR TITLE
Scheduled publishes for feature drafts

### DIFF
--- a/docs/src/data/commercialFeatures.ts
+++ b/docs/src/data/commercialFeatures.ts
@@ -225,6 +225,10 @@ export default {
     plan: "pro",
     displayName: "Schedule Feature Flag",
   },
+  "scheduled-revisions": {
+    plan: "enterprise",
+    displayName: "Scheduled Revisions",
+  },
   scim: {
     plan: "enterprise",
     displayName: "SCIM",

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -35736,6 +35736,36 @@ components:
                   - rampScheduleId
                   - ruleId
                 additionalProperties: false
+        autoPublishOnApproval:
+          description: >-
+            When true, the revision is armed to publish automatically once
+            governance allows (immediately on approval, or on
+            `scheduledPublishAt` if set).
+          type: boolean
+        scheduledPublishAt:
+          description: >-
+            Target date for a deferred (scheduled) publish. Null/absent means
+            publish as soon as approved.
+          anyOf:
+            - format: date-time
+              type: string
+            - type: 'null'
+        scheduledPublishLockEdits:
+          description: >-
+            When true, content edits to this draft are frozen while the schedule
+            is pending (rebasing is still allowed).
+          type: boolean
+        scheduledPublishLockOthers:
+          description: >-
+            When true, publishing other drafts of this feature is blocked while
+            the schedule is pending.
+          type: boolean
+        scheduledPublishLastError:
+          description: >-
+            Set when a due scheduled publish keeps failing (e.g. still awaiting
+            approval, merge conflict). Indicates the schedule is stuck and
+            retrying.
+          type: string
         reviews:
           description: >-
             Reviewer verdicts for the current review cycle (one entry per

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -9851,7 +9851,9 @@ paths:
         publishing other drafts of this feature until the schedule fires or is
         canceled. Requires publish permission; the publish executes with the
         caller's authority. An admin with bypass-approval permission can
-        schedule even without approval.
+        schedule even without approval — pass `bypassApproval: true` to mark it
+        as an admin override, which locks the schedule to cancel-and-re-arm
+        only.
       tags:
         - feature-revisions-v2
       parameters:
@@ -9877,6 +9879,8 @@ paths:
                 lockEdits:
                   type: boolean
                 lockOthers:
+                  type: boolean
+                bypassApproval:
                   type: boolean
               required:
                 - scheduledPublishAt
@@ -35763,6 +35767,12 @@ components:
           description: >-
             When true, publishing other drafts of this feature is blocked while
             the schedule is pending.
+          type: boolean
+        scheduledPublishBypassApproval:
+          description: >-
+            When true, this schedule was armed by an admin via the
+            bypass-approval override. It cannot be edited inline (only canceled
+            and re-armed) and anyone with publish authority may cancel it.
           type: boolean
         scheduledPublishLastError:
           description: >-

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -9778,6 +9778,14 @@ paths:
         requires the org to have auto-publish-on-approval enabled for the
         feature and the caller to have publish permission; the auto-publish then
         executes with the caller's authority.
+
+
+        Set `scheduledPublishAt` to a future ISO date-time to defer the
+        auto-publish until that date (it still also requires approval when
+        review is required). Use `scheduledPublishLockEdits` to freeze edits to
+        this draft while the schedule is pending, and
+        `scheduledPublishLockOthers` to block publishing other drafts of this
+        feature in the meantime.
       tags:
         - feature-revisions-v2
       parameters:
@@ -9799,6 +9807,15 @@ paths:
                   type: string
                 autoPublishOnApproval:
                   type: boolean
+                scheduledPublishAt:
+                  anyOf:
+                    - format: date-time
+                      type: string
+                    - type: 'null'
+                scheduledPublishLockEdits:
+                  type: boolean
+                scheduledPublishLockOthers:
+                  type: boolean
               additionalProperties: false
       responses:
         '200':
@@ -9817,6 +9834,70 @@ paths:
           source: >-
             curl -X POST
             'https://api.growthbook.io/api/v2/features/{id}/revisions/{version}/request-review'
+            \
+              -H 'Authorization: Bearer YOUR_API_KEY'
+  /v2/features/{id}/revisions/{version}/schedule-publish:
+    post:
+      operationId: postFeatureRevisionSchedulePublishV2
+      summary: Schedule (or cancel) a deferred publish for a draft revision
+      description: >-
+        Arms a deferred publish: the revision publishes automatically on/after
+        `scheduledPublishAt` (and, when review is required, only once also
+        approved). Send `scheduledPublishAt: null` to cancel the schedule.
+
+
+        Use `lockEdits` to freeze content edits to this draft while the schedule
+        is pending (rebasing is still allowed), and `lockOthers` to block
+        publishing other drafts of this feature until the schedule fires or is
+        canceled. Requires publish permission; the publish executes with the
+        caller's authority. An admin with bypass-approval permission can
+        schedule even without approval.
+      tags:
+        - feature-revisions-v2
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ''
+          schema:
+            type: string
+        - $ref: '#/components/parameters/version'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                scheduledPublishAt:
+                  anyOf:
+                    - format: date-time
+                      type: string
+                    - type: 'null'
+                lockEdits:
+                  type: boolean
+                lockOthers:
+                  type: boolean
+              required:
+                - scheduledPublishAt
+              additionalProperties: false
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  revision:
+                    $ref: '#/components/schemas/FeatureRevisionV2'
+                required:
+                  - revision
+                additionalProperties: false
+      x-codeSamples:
+        - lang: cURL
+          source: >-
+            curl -X POST
+            'https://api.growthbook.io/api/v2/features/{id}/revisions/{version}/schedule-publish'
             \
               -H 'Authorization: Bearer YOUR_API_KEY'
   /v2/features/{id}/revisions/{version}/submit-review:

--- a/packages/back-end/src/api/features/autoPublishOnApproval.ts
+++ b/packages/back-end/src/api/features/autoPublishOnApproval.ts
@@ -7,12 +7,15 @@ import {
   getFeatureAutopublishOnApproval,
   getMatchingRules,
   getNewDraftExperimentsToPublish,
+  isScheduledPublishDue,
+  isScheduledPublishPending,
 } from "shared/util";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import { getEnvironments } from "back-end/src/util/organization.util";
 import { getContextForUserIdInOrg } from "back-end/src/services/organizations";
 import { getExperimentsByIds } from "back-end/src/models/ExperimentModel";
+import { BadRequestError } from "back-end/src/util/errors";
 import { logger } from "back-end/src/util/logger";
 import { publishFeatureRevision } from "./postFeatureRevisionPublish";
 
@@ -36,6 +39,51 @@ export function canEnableFeatureAutoPublishOnApproval(
     feature,
   ).map((e) => e.id);
   return context.permissions.canPublishFeature(feature, environmentIds);
+}
+
+// Parse + validate a client-supplied schedule date. `null`/`undefined` means "no
+// schedule"; a value must be a valid, future date. Shared by the internal and
+// REST schedule entry points.
+export function parseScheduledPublishDate(
+  value: string | null | undefined,
+): Date | null {
+  if (value === null || value === undefined) return null;
+  const date = new Date(value);
+  if (isNaN(date.getTime())) {
+    throw new BadRequestError("Invalid scheduledPublishAt date");
+  }
+  if (date.getTime() <= Date.now()) {
+    throw new BadRequestError("scheduledPublishAt must be in the future");
+  }
+  return date;
+}
+
+// Publish authority over every environment this feature applies to. This is the
+// permission to cancel a pending schedule — anyone who could publish the feature
+// can call off (or take over) a deferred publish.
+export function canPublishFeatureRevision(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+): boolean {
+  const allEnvironments = getEnvironments(context.org);
+  const environmentIds = filterEnvironmentsByFeature(
+    allEnvironments,
+    feature,
+  ).map((e) => e.id);
+  return context.permissions.canPublishFeature(feature, environmentIds);
+}
+
+// Whether the caller may arm a deferred (date-based) publish on this feature.
+// Unlike auto-publish-on-approval, scheduling isn't gated on the org's
+// auto-publish setting — it only needs publish authority (the date is just a
+// deferral) — but it's a premium feature in its own right. Cancelling needs no
+// premium (see canPublishFeatureRevision) so a lapsed license can still disarm.
+export function canScheduleFeaturePublish(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+): boolean {
+  if (!context.hasPremiumFeature("scheduled-revisions")) return false;
+  return canPublishFeatureRevision(context, feature);
 }
 
 async function revisionRequiresPreLaunchChecklist(
@@ -75,6 +123,59 @@ async function revisionRequiresPreLaunchChecklist(
   );
 }
 
+// Resolve the context an armed publish runs with: the authority of whoever armed
+// it (`autoPublishEnabledBy`), falling back to the draft author for revisions
+// armed by actors without a user ID (API keys) or before the field existed.
+async function getArmedPublishContext(
+  context: ReqContext | ApiReqContext,
+  revision: FeatureRevisionInterface,
+): Promise<ReqContext | ApiReqContext | null> {
+  const enablerId =
+    revision.autoPublishEnabledBy ??
+    (revision.createdBy && "id" in revision.createdBy
+      ? revision.createdBy.id
+      : null);
+  if (!enablerId) return null;
+  try {
+    return await getContextForUserIdInOrg(context.org, enablerId);
+  } catch {
+    return null;
+  }
+}
+
+// Run the pre-launch checklist gate with the armer's authority, then publish.
+// Throws on a failed checklist / governance / permission / merge-conflict so the
+// caller can decide whether to hold (scheduled) or leave approved (on-approval).
+async function publishArmedRevision(
+  enablerContext: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  revision: FeatureRevisionInterface,
+  mergeNow: boolean,
+): Promise<FeatureRevisionInterface> {
+  // Checklist gate runs with the armer's context (the authority we publish with),
+  // not the caller's. A reviewer scoped out of a linked experiment's project
+  // would otherwise see no experiments and let a draft-experiment feature publish.
+  if (
+    await revisionRequiresPreLaunchChecklist(enablerContext, feature, revision)
+  ) {
+    throw new Error("pre-launch checklist required");
+  }
+
+  const { revision: published } = await publishFeatureRevision(
+    {
+      context: enablerContext,
+      organization: enablerContext.org,
+      audit: enablerContext.auditLog.bind(enablerContext),
+      params: { id: feature.id, version: revision.version },
+      // mergeNow only takes effect for armers with bypass-approval permission;
+      // it lets an admin-armed schedule force-merge a stale draft at fire time.
+      body: { comment: "", mergeNow },
+    },
+    false,
+  );
+  return published;
+}
+
 export async function maybeAutoPublishFeatureRevision(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
@@ -83,68 +184,69 @@ export async function maybeAutoPublishFeatureRevision(
   if (!revision.autoPublishOnApproval) return revision;
   if (revision.status !== "approved") return revision;
 
-  // Publish with the authority of whoever armed auto-publish. Fall back to
-  // the draft author for revisions armed by actors without a user ID (API
-  // keys) or before `autoPublishEnabledBy` existed.
-  const enablerId =
-    revision.autoPublishEnabledBy ??
-    (revision.createdBy && "id" in revision.createdBy
-      ? revision.createdBy.id
-      : null);
-  if (!enablerId) {
+  // A future-dated schedule defers to the Agenda poller; only publish on the
+  // approval event itself when there's no date (or the date has already passed).
+  if (isScheduledPublishPending(revision) && !isScheduledPublishDue(revision)) {
+    return revision;
+  }
+
+  const enablerContext = await getArmedPublishContext(context, revision);
+  if (!enablerContext) {
     logger.warn(
       { featureId: feature.id, version: revision.version },
-      "auto-publish-on-approval skipped: enabling user has no id; revision left approved",
+      "auto-publish-on-approval skipped: enabling user could not be resolved; revision left approved",
     );
     return revision;
   }
 
   try {
-    const enablerContext = await getContextForUserIdInOrg(
-      context.org,
-      enablerId,
+    return await publishArmedRevision(
+      enablerContext,
+      feature,
+      revision,
+      enablerContext.permissions.canBypassApprovalChecks(feature),
     );
-    if (!enablerContext) {
-      logger.warn(
-        { featureId: feature.id, version: revision.version, enablerId },
-        "auto-publish-on-approval skipped: enabling user could not be resolved; revision left approved",
-      );
-      return revision;
-    }
-
-    // Run the checklist gate with the armer's context (the authority we publish
-    // with), not the caller's. A reviewer scoped out of a linked experiment's
-    // project would otherwise see no experiments and let a draft-experiment
-    // feature auto-publish.
-    if (
-      await revisionRequiresPreLaunchChecklist(
-        enablerContext,
-        feature,
-        revision,
-      )
-    ) {
-      logger.info(
-        { featureId: feature.id, version: revision.version },
-        "auto-publish-on-approval skipped: pre-launch checklist required",
-      );
-      return revision;
-    }
-
-    const { revision: published } = await publishFeatureRevision(
-      {
-        context: enablerContext,
-        organization: enablerContext.org,
-        audit: enablerContext.auditLog.bind(enablerContext),
-        params: { id: feature.id, version: revision.version },
-        body: { comment: "" },
-      },
-      false,
-    );
-    return published;
   } catch (e) {
     logger.error(
       e,
       `auto-publish-on-approval failed for feature ${feature.id} revision ${revision.version}; left approved for manual publish`,
+    );
+    return revision;
+  }
+}
+
+// Date-driven counterpart invoked by the scheduled-publish Agenda poller. Fires
+// only once the target date has arrived; if the draft can't publish yet (review
+// required but not approved, stale approval, merge conflict) it holds — the next
+// tick retries — until conditions are met or the schedule is canceled. An admin
+// armer with bypass authority force-merges and skips the approval requirement.
+export async function maybePublishScheduledRevision(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  revision: FeatureRevisionInterface,
+): Promise<FeatureRevisionInterface> {
+  if (!isScheduledPublishDue(revision)) return revision;
+
+  const enablerContext = await getArmedPublishContext(context, revision);
+  if (!enablerContext) {
+    logger.warn(
+      { featureId: feature.id, version: revision.version },
+      "scheduled-publish skipped: enabling user could not be resolved; schedule left pending",
+    );
+    return revision;
+  }
+
+  try {
+    return await publishArmedRevision(
+      enablerContext,
+      feature,
+      revision,
+      enablerContext.permissions.canBypassApprovalChecks(feature),
+    );
+  } catch (e) {
+    logger.info(
+      { featureId: feature.id, version: revision.version },
+      `scheduled-publish held (will retry next tick): ${e instanceof Error ? e.message : String(e)}`,
     );
     return revision;
   }

--- a/packages/back-end/src/api/features/autoPublishOnApproval.ts
+++ b/packages/back-end/src/api/features/autoPublishOnApproval.ts
@@ -156,6 +156,13 @@ async function publishArmedRevision(
     throw new Error("pre-launch checklist required");
   }
 
+  // Concurrency note: this shared path can be entered by the poller, by
+  // auto-on-approval, and by a manual publish at nearly the same instant.
+  // publishFeatureRevision re-fetches and rejects an already-published revision,
+  // so in practice the loser throws and is caught upstream. Accepted residual: a
+  // sub-second cross-path overlap before either commits could double-fire publish
+  // side effects; not guarded with an atomic claim to avoid reworking the shared
+  // publish core, and the window requires a coincident trigger at the exact tick.
   const { revision: published } = await publishFeatureRevision(
     {
       context: enablerContext,

--- a/packages/back-end/src/api/features/autoPublishOnApproval.ts
+++ b/packages/back-end/src/api/features/autoPublishOnApproval.ts
@@ -119,18 +119,32 @@ async function revisionRequiresPreLaunchChecklist(
   );
 }
 
+// The dashboard user id an armed publish will run as: the explicit arming user
+// (autoPublishEnabledBy at fire time, or the current actor at arm time), else
+// the draft's author — but only when that author is a dashboard user. API-key
+// and system event users can carry an `id` that is NOT a resolvable user, so
+// they return null (the publish can't run with their authority).
+export function resolveArmedPublishUserId(
+  revision: Pick<
+    FeatureRevisionInterface,
+    "autoPublishEnabledBy" | "createdBy"
+  >,
+  armingUserId: string | null,
+): string | null {
+  const candidate = armingUserId ?? revision.autoPublishEnabledBy ?? null;
+  if (candidate) return candidate;
+  return revision.createdBy?.type === "dashboard"
+    ? revision.createdBy.id
+    : null;
+}
+
 // Resolve the context an armed publish runs with: whoever armed it
-// (autoPublishEnabledBy), falling back to the draft author when that's absent
-// (API keys, or revisions predating the field).
+// (autoPublishEnabledBy), falling back to the draft author when that's absent.
 async function getArmedPublishContext(
   context: ReqContext | ApiReqContext,
   revision: FeatureRevisionInterface,
 ): Promise<ReqContext | ApiReqContext | null> {
-  const enablerId =
-    revision.autoPublishEnabledBy ??
-    (revision.createdBy && "id" in revision.createdBy
-      ? revision.createdBy.id
-      : null);
+  const enablerId = resolveArmedPublishUserId(revision, null);
   if (!enablerId) return null;
   try {
     return await getContextForUserIdInOrg(context.org, enablerId);

--- a/packages/back-end/src/api/features/autoPublishOnApproval.ts
+++ b/packages/back-end/src/api/features/autoPublishOnApproval.ts
@@ -15,6 +15,7 @@ import { ApiReqContext } from "back-end/types/api";
 import { getEnvironments } from "back-end/src/util/organization.util";
 import { getContextForUserIdInOrg } from "back-end/src/services/organizations";
 import { getExperimentsByIds } from "back-end/src/models/ExperimentModel";
+import { recordScheduledPublishFailure } from "back-end/src/models/FeatureRevisionModel";
 import { BadRequestError } from "back-end/src/util/errors";
 import { logger } from "back-end/src/util/logger";
 import { publishFeatureRevision } from "./postFeatureRevisionPublish";
@@ -41,9 +42,8 @@ export function canEnableFeatureAutoPublishOnApproval(
   return context.permissions.canPublishFeature(feature, environmentIds);
 }
 
-// Parse + validate a client-supplied schedule date. `null`/`undefined` means "no
-// schedule"; a value must be a valid, future date. Shared by the internal and
-// REST schedule entry points.
+// Validate a client-supplied schedule date. null/undefined means "no schedule";
+// any value must be a valid future date.
 export function parseScheduledPublishDate(
   value: string | null | undefined,
 ): Date | null {
@@ -58,9 +58,8 @@ export function parseScheduledPublishDate(
   return date;
 }
 
-// Publish authority over every environment this feature applies to. This is the
-// permission to cancel a pending schedule — anyone who could publish the feature
-// can call off (or take over) a deferred publish.
+// Publish authority over every environment the feature applies to. Anyone with
+// it can cancel (or take over) a pending schedule.
 export function canPublishFeatureRevision(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
@@ -73,11 +72,8 @@ export function canPublishFeatureRevision(
   return context.permissions.canPublishFeature(feature, environmentIds);
 }
 
-// Whether the caller may arm a deferred (date-based) publish on this feature.
-// Unlike auto-publish-on-approval, scheduling isn't gated on the org's
-// auto-publish setting — it only needs publish authority (the date is just a
-// deferral) — but it's a premium feature in its own right. Cancelling needs no
-// premium (see canPublishFeatureRevision) so a lapsed license can still disarm.
+// Whether the caller may arm a date-based publish. Needs publish authority plus
+// the premium feature (canceling needs neither, so a lapsed license can disarm).
 export function canScheduleFeaturePublish(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
@@ -123,9 +119,9 @@ async function revisionRequiresPreLaunchChecklist(
   );
 }
 
-// Resolve the context an armed publish runs with: the authority of whoever armed
-// it (`autoPublishEnabledBy`), falling back to the draft author for revisions
-// armed by actors without a user ID (API keys) or before the field existed.
+// Resolve the context an armed publish runs with: whoever armed it
+// (autoPublishEnabledBy), falling back to the draft author when that's absent
+// (API keys, or revisions predating the field).
 async function getArmedPublishContext(
   context: ReqContext | ApiReqContext,
   revision: FeatureRevisionInterface,
@@ -144,17 +140,16 @@ async function getArmedPublishContext(
 }
 
 // Run the pre-launch checklist gate with the armer's authority, then publish.
-// Throws on a failed checklist / governance / permission / merge-conflict so the
-// caller can decide whether to hold (scheduled) or leave approved (on-approval).
+// Throws on a failed gate so the caller can decide whether to hold or leave
+// approved.
 async function publishArmedRevision(
   enablerContext: ReqContext | ApiReqContext,
   feature: FeatureInterface,
   revision: FeatureRevisionInterface,
   mergeNow: boolean,
 ): Promise<FeatureRevisionInterface> {
-  // Checklist gate runs with the armer's context (the authority we publish with),
-  // not the caller's. A reviewer scoped out of a linked experiment's project
-  // would otherwise see no experiments and let a draft-experiment feature publish.
+  // Use the armer's context, not the caller's: a reviewer scoped out of a linked
+  // experiment's project would see no experiments and skip the checklist.
   if (
     await revisionRequiresPreLaunchChecklist(enablerContext, feature, revision)
   ) {
@@ -167,8 +162,7 @@ async function publishArmedRevision(
       organization: enablerContext.org,
       audit: enablerContext.auditLog.bind(enablerContext),
       params: { id: feature.id, version: revision.version },
-      // mergeNow only takes effect for armers with bypass-approval permission;
-      // it lets an admin-armed schedule force-merge a stale draft at fire time.
+      // Only honored for armers who can bypass approvals (force-merge a stale draft).
       body: { comment: "", mergeNow },
     },
     false,
@@ -184,8 +178,8 @@ export async function maybeAutoPublishFeatureRevision(
   if (!revision.autoPublishOnApproval) return revision;
   if (revision.status !== "approved") return revision;
 
-  // A future-dated schedule defers to the Agenda poller; only publish on the
-  // approval event itself when there's no date (or the date has already passed).
+  // A future-dated schedule defers to the Agenda poller; publish on approval only
+  // when there's no date (or it's already due).
   if (isScheduledPublishPending(revision) && !isScheduledPublishDue(revision)) {
     return revision;
   }
@@ -215,11 +209,14 @@ export async function maybeAutoPublishFeatureRevision(
   }
 }
 
-// Date-driven counterpart invoked by the scheduled-publish Agenda poller. Fires
-// only once the target date has arrived; if the draft can't publish yet (review
-// required but not approved, stale approval, merge conflict) it holds — the next
-// tick retries — until conditions are met or the schedule is canceled. An admin
-// armer with bypass authority force-merges and skips the approval requirement.
+// Date-driven counterpart invoked by the Agenda poller once the target date has
+// arrived. If the draft can't publish yet (not approved, stale, conflict) it
+// holds and the next tick retries. Admin armers force-merge and skip approval.
+// Past this many failed poller attempts (~1/min) a held schedule is treated as
+// stuck: we log at error level so it surfaces in monitoring rather than retrying
+// silently forever.
+const SCHEDULED_PUBLISH_STUCK_AFTER_ATTEMPTS = 10;
+
 export async function maybePublishScheduledRevision(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
@@ -227,12 +224,21 @@ export async function maybePublishScheduledRevision(
 ): Promise<FeatureRevisionInterface> {
   if (!isScheduledPublishDue(revision)) return revision;
 
+  const recordFailure = async (message: string) => {
+    const attempts = await recordScheduledPublishFailure(revision, message);
+    const log =
+      attempts >= SCHEDULED_PUBLISH_STUCK_AFTER_ATTEMPTS
+        ? logger.error
+        : logger.info;
+    log(
+      { featureId: feature.id, version: revision.version, attempts },
+      `scheduled-publish held (will retry next tick): ${message}`,
+    );
+  };
+
   const enablerContext = await getArmedPublishContext(context, revision);
   if (!enablerContext) {
-    logger.warn(
-      { featureId: feature.id, version: revision.version },
-      "scheduled-publish skipped: enabling user could not be resolved; schedule left pending",
-    );
+    await recordFailure("enabling user could not be resolved");
     return revision;
   }
 
@@ -244,10 +250,7 @@ export async function maybePublishScheduledRevision(
       enablerContext.permissions.canBypassApprovalChecks(feature),
     );
   } catch (e) {
-    logger.info(
-      { featureId: feature.id, version: revision.version },
-      `scheduled-publish held (will retry next tick): ${e instanceof Error ? e.message : String(e)}`,
-    );
+    await recordFailure(e instanceof Error ? e.message : String(e));
     return revision;
   }
 }

--- a/packages/back-end/src/api/features/autoPublishOnApproval.ts
+++ b/packages/back-end/src/api/features/autoPublishOnApproval.ts
@@ -177,6 +177,23 @@ async function publishArmedRevision(
   return published;
 }
 
+// Whether an armed publish may force-merge past rebase governance at fire time.
+// Requires BOTH the persisted admin-bypass intent on the schedule AND that the
+// armer still holds bypass permission. Gating on the armer's role alone would
+// force-publish a stale approval for an ordinary (non-bypass) schedule whenever
+// the armer happens to be an admin — see governance handling in
+// publishFeatureRevision.
+function scheduledPublishMayForceMerge(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  revision: FeatureRevisionInterface,
+): boolean {
+  return (
+    !!revision.scheduledPublishBypassApproval &&
+    context.permissions.canBypassApprovalChecks(feature)
+  );
+}
+
 export async function maybeAutoPublishFeatureRevision(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
@@ -205,7 +222,7 @@ export async function maybeAutoPublishFeatureRevision(
       enablerContext,
       feature,
       revision,
-      enablerContext.permissions.canBypassApprovalChecks(feature),
+      scheduledPublishMayForceMerge(enablerContext, feature, revision),
     );
   } catch (e) {
     logger.error(
@@ -254,7 +271,7 @@ export async function maybePublishScheduledRevision(
       enablerContext,
       feature,
       revision,
-      enablerContext.permissions.canBypassApprovalChecks(feature),
+      scheduledPublishMayForceMerge(enablerContext, feature, revision),
     );
   } catch (e) {
     await recordFailure(e instanceof Error ? e.message : String(e));

--- a/packages/back-end/src/api/features/features.v2.router.ts
+++ b/packages/back-end/src/api/features/features.v2.router.ts
@@ -21,6 +21,7 @@ import { getFeatureRevisionMergeStatusV2 } from "./getFeatureRevisionMergeStatus
 import { postFeatureRevisionRebasePreviewV2 } from "./postFeatureRevisionRebasePreviewV2";
 import { postFeatureRevisionRebaseV2 } from "./postFeatureRevisionRebaseV2";
 import { postFeatureRevisionRequestReviewV2 } from "./postFeatureRevisionRequestReviewV2";
+import { postFeatureRevisionSchedulePublishV2 } from "./postFeatureRevisionSchedulePublishV2";
 import { postFeatureRevisionSubmitReviewV2 } from "./postFeatureRevisionSubmitReviewV2";
 import { postFeatureRevisionRecallReviewV2 } from "./postFeatureRevisionRecallReviewV2";
 import { postFeatureRevisionUndoReviewV2 } from "./postFeatureRevisionUndoReviewV2";
@@ -83,6 +84,7 @@ export const featureV2Routes: OpenApiRoute[] = [
 
   // Review & lifecycle
   postFeatureRevisionRequestReviewV2,
+  postFeatureRevisionSchedulePublishV2,
   postFeatureRevisionSubmitReviewV2,
   postFeatureRevisionRecallReviewV2,
   postFeatureRevisionUndoReviewV2,

--- a/packages/back-end/src/api/features/postFeatureRevisionRebase.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRebase.ts
@@ -230,6 +230,8 @@ export async function rebaseFeatureRevision(
       ),
     },
     resetReview,
+    // Rebase is permitted while a "lock edits" schedule is active.
+    { bypassScheduleLock: true },
   );
 
   const updated = await getRevision({

--- a/packages/back-end/src/api/features/postFeatureRevisionRequestReview.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRequestReview.ts
@@ -15,12 +15,22 @@ import {
   markRevisionAsReviewRequested,
 } from "back-end/src/models/FeatureRevisionModel";
 import { getEnvironments } from "back-end/src/util/organization.util";
-import { canEnableFeatureAutoPublishOnApproval } from "./autoPublishOnApproval";
+import {
+  canEnableFeatureAutoPublishOnApproval,
+  canScheduleFeaturePublish,
+  parseScheduledPublishDate,
+} from "./autoPublishOnApproval";
 
 export async function requestReview(
   req: Pick<ApiRequestLocals, "context" | "organization" | "audit"> & {
     params: { id: string; version: number };
-    body: { comment?: string; autoPublishOnApproval?: boolean };
+    body: {
+      comment?: string;
+      autoPublishOnApproval?: boolean;
+      scheduledPublishAt?: string | null;
+      scheduledPublishLockEdits?: boolean;
+      scheduledPublishLockOthers?: boolean;
+    };
   },
 ) {
   const feature = await getFeature(req.context, req.params.id);
@@ -75,12 +85,25 @@ export async function requestReview(
     req.body.autoPublishOnApproval &&
     canEnableFeatureAutoPublishOnApproval(req.context, feature);
 
+  const scheduledDate = parseScheduledPublishDate(req.body.scheduledPublishAt);
+  if (
+    scheduledDate !== null &&
+    !canScheduleFeaturePublish(req.context, feature)
+  ) {
+    req.context.permissions.throwPermissionError();
+  }
+
   await markRevisionAsReviewRequested(
     req.context,
     revision,
     req.context.auditUser,
     req.body.comment ?? "",
-    { autoPublishOnApproval: enableAutoPublish },
+    {
+      autoPublishOnApproval: enableAutoPublish,
+      scheduledPublishAt: scheduledDate,
+      scheduledPublishLockEdits: req.body.scheduledPublishLockEdits,
+      scheduledPublishLockOthers: req.body.scheduledPublishLockOthers,
+    },
   );
 
   const updated = await getRevision({

--- a/packages/back-end/src/api/features/postFeatureRevisionRequestReview.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRequestReview.ts
@@ -19,6 +19,7 @@ import {
   canEnableFeatureAutoPublishOnApproval,
   canScheduleFeaturePublish,
   parseScheduledPublishDate,
+  resolveArmedPublishUserId,
 } from "./autoPublishOnApproval";
 
 export async function requestReview(
@@ -91,6 +92,20 @@ export async function requestReview(
     !canScheduleFeaturePublish(req.context, feature)
   ) {
     req.context.permissions.throwPermissionError();
+  }
+
+  // A scheduled publish runs as a resolvable dashboard user at fire time. Reject
+  // arming when there is none (e.g. an API key requesting review with a schedule
+  // on a draft authored by an API key) so the poller doesn't loop forever on
+  // "enabling user could not be resolved". Mirrors the schedule-publish endpoint.
+  if (
+    scheduledDate !== null &&
+    !resolveArmedPublishUserId(revision, req.context.userId ?? null)
+  ) {
+    throw new BadRequestError(
+      "Scheduled publishes must run as a user, but this request has no resolvable user actor " +
+        "(e.g. an API key scheduling a draft authored by an API key). Arm the schedule from a user session.",
+    );
   }
 
   await markRevisionAsReviewRequested(

--- a/packages/back-end/src/api/features/postFeatureRevisionSchedulePublish.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionSchedulePublish.ts
@@ -5,6 +5,7 @@ import {
   getRevision,
   setRevisionScheduledPublish,
 } from "back-end/src/models/FeatureRevisionModel";
+import { revisionRequiresReview } from "back-end/src/services/features";
 import {
   canPublishFeatureRevision,
   canScheduleFeaturePublish,
@@ -18,8 +19,7 @@ const SCHEDULABLE_STATUSES = [
   "approved",
 ];
 
-// Arm or cancel a deferred publish on a revision. Send scheduledPublishAt: null
-// to cancel. Shared core for the REST handler.
+// Arm or cancel a deferred publish on a revision (scheduledPublishAt: null cancels).
 export async function schedulePublish(
   req: Pick<ApiRequestLocals, "context" | "organization"> & {
     params: { id: string; version: number };
@@ -49,15 +49,34 @@ export async function schedulePublish(
   }
 
   const date = parseScheduledPublishDate(req.body.scheduledPublishAt);
-  // Arming requires the premium feature + publish authority. Cancelling a
-  // pending schedule needs only publish authority — anyone who can publish the
-  // feature can call off (or take over) the deferred publish, leaving the
-  // revision at its current (approved) status.
+  // Arming needs the premium feature + publish authority; canceling needs only
+  // publish authority.
   const allowed = date
     ? canScheduleFeaturePublish(req.context, feature)
     : canPublishFeatureRevision(req.context, feature);
   if (!allowed) {
     req.context.permissions.throwPermissionError();
+  }
+
+  // Committing a schedule on a draft is the no-approval path (fires without a
+  // review cycle). Only allow it when the change doesn't require review, failing
+  // closed if the base can't be resolved. Review-required drafts arm via
+  // request-review instead.
+  if (date && revision.status === "draft") {
+    const requiresReview = await revisionRequiresReview(
+      req.context,
+      feature,
+      revision,
+      { treatUnresolvedBaseAsReview: true },
+    );
+    if (
+      requiresReview &&
+      !req.context.permissions.canBypassApprovalChecks(feature)
+    ) {
+      throw new BadRequestError(
+        "This change requires approval — request review to schedule its publish.",
+      );
+    }
   }
 
   await setRevisionScheduledPublish(

--- a/packages/back-end/src/api/features/postFeatureRevisionSchedulePublish.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionSchedulePublish.ts
@@ -27,6 +27,7 @@ export async function schedulePublish(
       scheduledPublishAt: string | null;
       lockEdits?: boolean;
       lockOthers?: boolean;
+      bypassApproval?: boolean;
     };
   },
 ) {
@@ -58,6 +59,12 @@ export async function schedulePublish(
     req.context.permissions.throwPermissionError();
   }
 
+  // Persist the admin bypass-approval intent only when the caller actually has
+  // that permission — a requested bypass from a non-admin is silently ignored.
+  const bypassApproval =
+    !!req.body.bypassApproval &&
+    req.context.permissions.canBypassApprovalChecks(feature);
+
   // Committing a schedule on a draft is the no-approval path (fires without a
   // review cycle). Only allow it when the change doesn't require review, failing
   // closed if the base can't be resolved. Review-required drafts arm via
@@ -86,6 +93,7 @@ export async function schedulePublish(
       scheduledPublishAt: date,
       lockEdits: req.body.lockEdits,
       lockOthers: req.body.lockOthers,
+      bypassApproval,
     },
     req.context.userId || null,
   );

--- a/packages/back-end/src/api/features/postFeatureRevisionSchedulePublish.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionSchedulePublish.ts
@@ -1,0 +1,83 @@
+import type { ApiRequestLocals } from "back-end/types/api";
+import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
+import { getFeature } from "back-end/src/models/FeatureModel";
+import {
+  getRevision,
+  setRevisionScheduledPublish,
+} from "back-end/src/models/FeatureRevisionModel";
+import {
+  canPublishFeatureRevision,
+  canScheduleFeaturePublish,
+  parseScheduledPublishDate,
+} from "./autoPublishOnApproval";
+
+const SCHEDULABLE_STATUSES = [
+  "draft",
+  "pending-review",
+  "changes-requested",
+  "approved",
+];
+
+// Arm or cancel a deferred publish on a revision. Send scheduledPublishAt: null
+// to cancel. Shared core for the REST handler.
+export async function schedulePublish(
+  req: Pick<ApiRequestLocals, "context" | "organization"> & {
+    params: { id: string; version: number };
+    body: {
+      scheduledPublishAt: string | null;
+      lockEdits?: boolean;
+      lockOthers?: boolean;
+    };
+  },
+) {
+  const feature = await getFeature(req.context, req.params.id);
+  if (!feature) throw new NotFoundError("Could not find feature");
+
+  const revision = await getRevision({
+    context: req.context,
+    organization: req.organization.id,
+    featureId: feature.id,
+    feature,
+    version: req.params.version,
+  });
+  if (!revision) throw new NotFoundError("Could not find feature revision");
+
+  if (!SCHEDULABLE_STATUSES.includes(revision.status)) {
+    throw new BadRequestError(
+      `Cannot schedule publish on a revision with status "${revision.status}"`,
+    );
+  }
+
+  const date = parseScheduledPublishDate(req.body.scheduledPublishAt);
+  // Arming requires the premium feature + publish authority. Cancelling a
+  // pending schedule needs only publish authority — anyone who can publish the
+  // feature can call off (or take over) the deferred publish, leaving the
+  // revision at its current (approved) status.
+  const allowed = date
+    ? canScheduleFeaturePublish(req.context, feature)
+    : canPublishFeatureRevision(req.context, feature);
+  if (!allowed) {
+    req.context.permissions.throwPermissionError();
+  }
+
+  await setRevisionScheduledPublish(
+    req.context,
+    revision,
+    {
+      scheduledPublishAt: date,
+      lockEdits: req.body.lockEdits,
+      lockOthers: req.body.lockOthers,
+    },
+    req.context.userId || null,
+  );
+
+  const updated = await getRevision({
+    context: req.context,
+    organization: req.organization.id,
+    featureId: feature.id,
+    feature,
+    version: req.params.version,
+  });
+
+  return { feature, revision: updated ?? revision };
+}

--- a/packages/back-end/src/api/features/postFeatureRevisionSchedulePublish.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionSchedulePublish.ts
@@ -10,6 +10,7 @@ import {
   canPublishFeatureRevision,
   canScheduleFeaturePublish,
   parseScheduledPublishDate,
+  resolveArmedPublishUserId,
 } from "./autoPublishOnApproval";
 
 const SCHEDULABLE_STATUSES = [
@@ -57,6 +58,20 @@ export async function schedulePublish(
     : canPublishFeatureRevision(req.context, feature);
   if (!allowed) {
     req.context.permissions.throwPermissionError();
+  }
+
+  // A scheduled publish runs as a resolvable dashboard user at fire time. Reject
+  // arming when there is none — e.g. an API key arming a draft also authored by
+  // an API key — instead of accepting a schedule the poller can never publish
+  // (it would loop on "enabling user could not be resolved").
+  if (
+    date &&
+    !resolveArmedPublishUserId(revision, req.context.userId ?? null)
+  ) {
+    throw new BadRequestError(
+      "Scheduled publishes must run as a user, but this request has no resolvable user actor " +
+        "(e.g. an API key scheduling a draft authored by an API key). Arm the schedule from a user session.",
+    );
   }
 
   // Persist the admin bypass-approval intent only when the caller actually has

--- a/packages/back-end/src/api/features/postFeatureRevisionSchedulePublishV2.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionSchedulePublishV2.ts
@@ -1,0 +1,11 @@
+import { postFeatureRevisionSchedulePublishV2Validator } from "shared/validators";
+import { toApiRevisionV2 } from "back-end/src/services/features";
+import { createApiRequestHandler } from "back-end/src/util/handler";
+import { schedulePublish } from "./postFeatureRevisionSchedulePublish";
+
+export const postFeatureRevisionSchedulePublishV2 = createApiRequestHandler(
+  postFeatureRevisionSchedulePublishV2Validator,
+)(async (req) => {
+  const { revision } = await schedulePublish(req);
+  return { revision: toApiRevisionV2(revision) };
+});

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -888,6 +888,10 @@ app.post(
   featuresController.postFeatureToggleAutoPublish,
 );
 app.post(
+  "/feature/:id/:version/schedule-publish",
+  featuresController.postFeatureScheduledPublish,
+);
+app.post(
   "/feature/:id/:version/recall-review",
   featuresController.postFeatureRecallReview,
 );

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -118,6 +118,7 @@ import {
   getLiveRevisionForFeature,
   getDraftRevision,
   assertCanAutoPublish,
+  revisionRequiresReview,
 } from "back-end/src/services/features";
 import { assertRegisteredAttributes } from "back-end/src/services/attributes";
 import {
@@ -163,6 +164,7 @@ import {
   submitReviewAndComments,
   updateRevision,
   setAutoPublishOnApproval,
+  setRevisionScheduledPublish,
 } from "back-end/src/models/FeatureRevisionModel";
 import {
   buildFeatureLookups,
@@ -217,7 +219,10 @@ import {
 } from "back-end/src/util/errors";
 import {
   canEnableFeatureAutoPublishOnApproval,
+  canPublishFeatureRevision,
+  canScheduleFeaturePublish,
   maybeAutoPublishFeatureRevision,
+  parseScheduledPublishDate,
 } from "back-end/src/api/features/autoPublishOnApproval";
 import {
   shouldValidateCustomFieldsOnUpdate,
@@ -1020,6 +1025,8 @@ export async function postFeatureRebase(
       ),
     },
     resetReview,
+    // Rebase is permitted while a "lock edits" schedule is active.
+    { bypassScheduleLock: true },
   );
 
   const rebased = await getRevision({
@@ -1061,11 +1068,15 @@ export async function postFeatureRebase(
     status: 200,
   });
 }
-export async function postFeatureRequestReview(
+// Arm or cancel a deferred publish on an existing draft. Cancel by sending
+// scheduledPublishAt: null. The Agenda poller (updateScheduledPublishes) fires
+// the publish once the date arrives and governance allows.
+export async function postFeatureScheduledPublish(
   req: AuthRequest<
     {
-      comment: string;
-      autoPublishOnApproval?: boolean;
+      scheduledPublishAt: string | null;
+      lockEdits?: boolean;
+      lockOthers?: boolean;
     },
     { id: string; version: string }
   >,
@@ -1073,7 +1084,96 @@ export async function postFeatureRequestReview(
 ) {
   const context = getContextFromReq(req);
   const { id, version } = req.params;
-  const { comment, autoPublishOnApproval } = req.body;
+  const { scheduledPublishAt, lockEdits, lockOthers } = req.body;
+
+  const feature = await getFeature(context, id);
+  if (!feature) throw new Error("Could not find feature");
+
+  const revision = await getRevision({
+    context,
+    organization: context.org.id,
+    featureId: feature.id,
+    feature,
+    version: parseInt(version),
+  });
+  if (!revision) throw new Error("Could not find feature revision");
+
+  if (
+    !["draft", "pending-review", "changes-requested", "approved"].includes(
+      revision.status,
+    )
+  ) {
+    throw new Error(
+      "Cannot schedule publish on a published or discarded revision",
+    );
+  }
+
+  const date = parseScheduledPublishDate(scheduledPublishAt);
+  // Arming requires the premium feature + publish authority. Cancelling a
+  // pending schedule needs only publish authority — anyone who can publish the
+  // feature can call off (or take over) the deferred publish, leaving the
+  // revision at its current (approved) status.
+  const allowed = date
+    ? canScheduleFeaturePublish(context, feature)
+    : canPublishFeatureRevision(context, feature);
+  if (!allowed) {
+    context.permissions.throwPermissionError();
+  }
+
+  // Committing a schedule directly on a draft is the no-approval path: the draft
+  // is locked in and fires on its date without a review cycle. Only allow it
+  // when the change doesn't actually require review (or the caller can bypass
+  // approvals). Review-required drafts must arm the schedule through the
+  // request-review flow instead, so they stay gated on approval.
+  if (date && revision.status === "draft") {
+    const requiresReview = await revisionRequiresReview(
+      context,
+      feature,
+      revision,
+    );
+    if (
+      requiresReview &&
+      !context.permissions.canBypassApprovalChecks(feature)
+    ) {
+      throw new Error(
+        "This change requires approval — request review to schedule its publish.",
+      );
+    }
+  }
+
+  await setRevisionScheduledPublish(
+    context,
+    revision,
+    { scheduledPublishAt: date, lockEdits, lockOthers },
+    context.userId || null,
+  );
+
+  res.status(200).json({ status: 200 });
+}
+
+export async function postFeatureRequestReview(
+  req: AuthRequest<
+    {
+      comment: string;
+      autoPublishOnApproval?: boolean;
+      // Optional deferred-publish schedule armed alongside the review request.
+      scheduledPublishAt?: string | null;
+      scheduledPublishLockEdits?: boolean;
+      scheduledPublishLockOthers?: boolean;
+    },
+    { id: string; version: string }
+  >,
+  res: Response,
+) {
+  const context = getContextFromReq(req);
+  const { id, version } = req.params;
+  const {
+    comment,
+    autoPublishOnApproval,
+    scheduledPublishAt,
+    scheduledPublishLockEdits,
+    scheduledPublishLockOthers,
+  } = req.body;
   const feature = await getFeature(context, id);
   if (!feature) {
     throw new Error("Could not find feature");
@@ -1099,12 +1199,22 @@ export async function postFeatureRequestReview(
     autoPublishOnApproval &&
     canEnableFeatureAutoPublishOnApproval(context, feature);
 
+  const scheduledDate = parseScheduledPublishDate(scheduledPublishAt);
+  if (scheduledDate !== null && !canScheduleFeaturePublish(context, feature)) {
+    context.permissions.throwPermissionError();
+  }
+
   await markRevisionAsReviewRequested(
     context,
     revision,
     res.locals.eventAudit,
     comment,
-    { autoPublishOnApproval: enableAutoPublish },
+    {
+      autoPublishOnApproval: enableAutoPublish,
+      scheduledPublishAt: scheduledDate,
+      scheduledPublishLockEdits,
+      scheduledPublishLockOthers,
+    },
   );
 
   const updatedRevision = await getRevision({

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -1068,9 +1068,8 @@ export async function postFeatureRebase(
     status: 200,
   });
 }
-// Arm or cancel a deferred publish on an existing draft. Cancel by sending
-// scheduledPublishAt: null. The Agenda poller (updateScheduledPublishes) fires
-// the publish once the date arrives and governance allows.
+// Arm or cancel a deferred publish on a draft (scheduledPublishAt: null cancels).
+// The Agenda poller fires it once the date arrives and governance allows.
 export async function postFeatureScheduledPublish(
   req: AuthRequest<
     {
@@ -1109,10 +1108,8 @@ export async function postFeatureScheduledPublish(
   }
 
   const date = parseScheduledPublishDate(scheduledPublishAt);
-  // Arming requires the premium feature + publish authority. Cancelling a
-  // pending schedule needs only publish authority — anyone who can publish the
-  // feature can call off (or take over) the deferred publish, leaving the
-  // revision at its current (approved) status.
+  // Arming needs the premium feature + publish authority; canceling needs only
+  // publish authority.
   const allowed = date
     ? canScheduleFeaturePublish(context, feature)
     : canPublishFeatureRevision(context, feature);
@@ -1120,16 +1117,17 @@ export async function postFeatureScheduledPublish(
     context.permissions.throwPermissionError();
   }
 
-  // Committing a schedule directly on a draft is the no-approval path: the draft
-  // is locked in and fires on its date without a review cycle. Only allow it
-  // when the change doesn't actually require review (or the caller can bypass
-  // approvals). Review-required drafts must arm the schedule through the
-  // request-review flow instead, so they stay gated on approval.
+  // Committing a schedule on a draft is the no-approval path (fires without a
+  // review cycle), so only allow it when the change doesn't require review (or
+  // the caller can bypass). Review-required drafts arm via request-review instead.
   if (date && revision.status === "draft") {
+    // Fail closed when the base can't be resolved: don't engage locks/schedule
+    // on a draft we can't confirm is review-exempt.
     const requiresReview = await revisionRequiresReview(
       context,
       feature,
       revision,
+      { treatUnresolvedBaseAsReview: true },
     );
     if (
       requiresReview &&

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -1077,6 +1077,7 @@ export async function postFeatureScheduledPublish(
       scheduledPublishAt: string | null;
       lockEdits?: boolean;
       lockOthers?: boolean;
+      bypassApproval?: boolean;
     },
     { id: string; version: string }
   >,
@@ -1140,10 +1141,16 @@ export async function postFeatureScheduledPublish(
     }
   }
 
+  // Persist the admin bypass-approval intent only when the caller actually has
+  // that permission — a requested bypass from a non-admin is silently ignored.
+  const bypassApproval =
+    !!req.body.bypassApproval &&
+    context.permissions.canBypassApprovalChecks(feature);
+
   await setRevisionScheduledPublish(
     context,
     revision,
-    { scheduledPublishAt: date, lockEdits, lockOthers },
+    { scheduledPublishAt: date, lockEdits, lockOthers, bypassApproval },
     context.userId || null,
   );
 

--- a/packages/back-end/src/init/queue.ts
+++ b/packages/back-end/src/init/queue.ts
@@ -25,6 +25,7 @@ import addExperimentStatusUpdateJob from "back-end/src/jobs/updateExperimentStat
 import updateAutoSlicesJob from "back-end/src/jobs/updateAutoSlices";
 import updateAggregatedFactTablesJob from "back-end/src/jobs/updateAggregatedFactTables";
 import addRampScheduleJob from "back-end/src/jobs/updateRampSchedules";
+import addScheduledPublishJob from "back-end/src/jobs/updateScheduledPublishes";
 import { initRampScheduleHooks } from "back-end/src/services/rampSchedule";
 
 export async function queueInit() {
@@ -51,6 +52,7 @@ export async function queueInit() {
   updateAutoSlicesJob(agenda);
   updateAggregatedFactTablesJob(agenda);
   addRampScheduleJob(agenda);
+  addScheduledPublishJob(agenda);
   initRampScheduleHooks();
   // Make sure we have index needed to delete efficiently
   agenda._collection

--- a/packages/back-end/src/jobs/updateScheduledPublishes.ts
+++ b/packages/back-end/src/jobs/updateScheduledPublishes.ts
@@ -79,11 +79,10 @@ export const publishScheduledRevision = async (
   const feature = await getFeature(context, featureId);
   if (!feature) return;
 
-  // Archived features must not auto-publish. archiveFeature already cancels
-  // schedules; this is a belt-and-suspenders guard against a race so we stop
-  // retrying instead of resurrecting an archived feature's draft.
+  // archiveFeature already cancels schedules; this guards against a race so we
+  // don't resurrect an archived feature's draft.
   if (feature.archived) {
-    await cancelScheduledPublishesForFeature(organization, featureId);
+    await cancelScheduledPublishesForFeature(context, organization, featureId);
     return;
   }
 
@@ -96,7 +95,6 @@ export const publishScheduledRevision = async (
   });
   if (!revision) return;
 
-  // maybePublishScheduledRevision re-checks the due gate and governance; if the
-  // draft can't publish yet it holds and the next 1-minute tick retries.
+  // Re-checks the due gate and governance; holds and retries next tick if not ready.
   await maybePublishScheduledRevision(context, feature, revision);
 };

--- a/packages/back-end/src/jobs/updateScheduledPublishes.ts
+++ b/packages/back-end/src/jobs/updateScheduledPublishes.ts
@@ -28,6 +28,9 @@ async function queueScheduledPublish(
     PUBLISH_SCHEDULED_REVISION,
     item,
   ) as PublishScheduledRevisionJob;
+  // Dedup per revision: overlapping poll ticks (and multiple back-end instances)
+  // can't queue two concurrent publishes for the same revision. The publish also
+  // re-fetches and re-checks status, so a stale re-run after a success no-ops.
   job.unique({
     organization: item.organization,
     featureId: item.featureId,

--- a/packages/back-end/src/jobs/updateScheduledPublishes.ts
+++ b/packages/back-end/src/jobs/updateScheduledPublishes.ts
@@ -1,0 +1,102 @@
+import Agenda, { Job } from "agenda";
+import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizations";
+import { logger } from "back-end/src/util/logger";
+import { getFeature } from "back-end/src/models/FeatureModel";
+import {
+  cancelScheduledPublishesForFeature,
+  dangerouslyFindRevisionsDueToPublish,
+  getRevision,
+} from "back-end/src/models/FeatureRevisionModel";
+import { maybePublishScheduledRevision } from "back-end/src/api/features/autoPublishOnApproval";
+
+type PublishScheduledRevisionJob = Job<{
+  organization: string;
+  featureId: string;
+  version: number;
+}>;
+
+const QUEUE_SCHEDULED_PUBLISHES = "queueScheduledPublishes";
+const PUBLISH_SCHEDULED_REVISION = "publishScheduledRevision";
+
+const POLL_INTERVAL_MINUTES = 1;
+
+async function queueScheduledPublish(
+  agenda: Agenda,
+  item: { organization: string; featureId: string; version: number },
+) {
+  const job = agenda.create(
+    PUBLISH_SCHEDULED_REVISION,
+    item,
+  ) as PublishScheduledRevisionJob;
+  job.unique({
+    organization: item.organization,
+    featureId: item.featureId,
+    version: item.version,
+  });
+  job.schedule(new Date());
+  await job.save();
+}
+
+export default async function addScheduledPublishJob(agenda: Agenda) {
+  agenda.define(QUEUE_SCHEDULED_PUBLISHES, async () => {
+    const due = await dangerouslyFindRevisionsDueToPublish(new Date());
+    for (const item of due) {
+      try {
+        await queueScheduledPublish(agenda, item);
+      } catch (e) {
+        logger.error(
+          e,
+          `Error queuing scheduled publish for feature ${item.featureId} v${item.version} (org ${item.organization})`,
+        );
+      }
+    }
+  });
+
+  agenda.define(PUBLISH_SCHEDULED_REVISION, publishScheduledRevision);
+
+  const job = agenda.create(QUEUE_SCHEDULED_PUBLISHES, {});
+  job.unique({});
+  job.repeatEvery(`${POLL_INTERVAL_MINUTES} minutes`);
+  await job.save();
+}
+
+export const publishScheduledRevision = async (
+  job: PublishScheduledRevisionJob,
+) => {
+  const organization = job.attrs.data?.organization;
+  const featureId = job.attrs.data?.featureId;
+  const version = job.attrs.data?.version;
+  if (
+    !organization ||
+    !featureId ||
+    version === undefined ||
+    version === null
+  ) {
+    return;
+  }
+
+  const context = await getContextForAgendaJobByOrgId(organization);
+  const feature = await getFeature(context, featureId);
+  if (!feature) return;
+
+  // Archived features must not auto-publish. archiveFeature already cancels
+  // schedules; this is a belt-and-suspenders guard against a race so we stop
+  // retrying instead of resurrecting an archived feature's draft.
+  if (feature.archived) {
+    await cancelScheduledPublishesForFeature(organization, featureId);
+    return;
+  }
+
+  const revision = await getRevision({
+    context,
+    organization,
+    featureId,
+    feature,
+    version,
+  });
+  if (!revision) return;
+
+  // maybePublishScheduledRevision re-checks the due gate and governance; if the
+  // draft can't publish yet it holds and the next 1-minute tick retries.
+  await maybePublishScheduledRevision(context, feature, revision);
+};

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -1149,10 +1149,13 @@ export async function archiveFeature(
   const updated = await updateFeature(context, feature, {
     archived: isArchived,
   });
-  // An archived feature shouldn't auto-publish a draft out from under the
-  // archive — cancel any pending deferred publishes on its revisions.
+  // Cancel pending schedules so an archived feature can't auto-publish a draft.
   if (isArchived) {
-    await cancelScheduledPublishesForFeature(context.org.id, feature.id);
+    await cancelScheduledPublishesForFeature(
+      context,
+      context.org.id,
+      feature.id,
+    );
   }
   return updated;
 }
@@ -2303,8 +2306,7 @@ export async function publishRevision({
   if (!bypassLockdown) {
     await assertFeatureNotLockedByRamp(context, feature.id);
 
-    // Another draft with a pending "lock other drafts" schedule freezes sibling
-    // publishes so live can't advance out from under the scheduled change.
+    // A sibling draft's "lock other drafts" schedule freezes other publishes.
     if (
       revision.version !== undefined &&
       (await hasPublishLockingScheduledSibling(

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -114,10 +114,12 @@ import {
   updateExperiment,
 } from "./ExperimentModel";
 import {
+  cancelScheduledPublishesForFeature,
   createInitialRevision,
   createRevisionFromLegacyDraft,
   deleteAllRevisionsForFeature,
   getRevision,
+  hasPublishLockingScheduledSibling,
   markRevisionAsPublished,
   computeRevisionPublishChanges,
   updateRevision,
@@ -1144,7 +1146,15 @@ export async function archiveFeature(
   feature: FeatureInterface,
   isArchived: boolean,
 ) {
-  return await updateFeature(context, feature, { archived: isArchived });
+  const updated = await updateFeature(context, feature, {
+    archived: isArchived,
+  });
+  // An archived feature shouldn't auto-publish a draft out from under the
+  // archive — cancel any pending deferred publishes on its revisions.
+  if (isArchived) {
+    await cancelScheduledPublishesForFeature(context.org.id, feature.id);
+  }
+  return updated;
 }
 
 function setEnvironmentSettings(
@@ -2292,6 +2302,21 @@ export async function publishRevision({
 
   if (!bypassLockdown) {
     await assertFeatureNotLockedByRamp(context, feature.id);
+
+    // Another draft with a pending "lock other drafts" schedule freezes sibling
+    // publishes so live can't advance out from under the scheduled change.
+    if (
+      revision.version !== undefined &&
+      (await hasPublishLockingScheduledSibling(
+        context.org.id,
+        feature.id,
+        revision.version,
+      ))
+    ) {
+      throw new Error(
+        "Another draft of this feature is scheduled to publish and has locked publishing of other drafts. Cancel that schedule to publish this revision.",
+      );
+    }
   }
 
   // Run custom hooks before the side-effect writes below so a rejection doesn't orphan them

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -1,6 +1,9 @@
 import mongoose from "mongoose";
 import omit from "lodash/omit";
-import { checkIfRevisionNeedsReview } from "shared/util";
+import {
+  checkIfRevisionNeedsReview,
+  isRevisionEditLockedBySchedule,
+} from "shared/util";
 import {
   FeatureInterface,
   FeatureRule,
@@ -111,6 +114,9 @@ const featureRevisionSchema = new mongoose.Schema({
   requiresReview: Boolean,
   autoPublishOnApproval: Boolean,
   autoPublishEnabledBy: String,
+  scheduledPublishAt: Date,
+  scheduledPublishLockEdits: Boolean,
+  scheduledPublishLockOthers: Boolean,
   log: [
     {
       _id: false,
@@ -128,6 +134,9 @@ featureRevisionSchema.index(
   { unique: true },
 );
 featureRevisionSchema.index({ organization: 1, status: 1 });
+// Sparse: only armed, deferred-publish revisions carry scheduledPublishAt, so the
+// cross-org due-poller (dangerouslyFindRevisionsDueToPublish) scans a tiny set.
+featureRevisionSchema.index({ scheduledPublishAt: 1 }, { sparse: true });
 
 type FeatureRevisionDocument = mongoose.Document & FeatureRevisionInterface;
 
@@ -335,7 +344,7 @@ export async function getMinimalRevisions(
     featureId,
   })
     .select(
-      "version datePublished dateUpdated createdBy status comment title contributors",
+      "version datePublished dateUpdated createdBy status comment title contributors autoPublishOnApproval scheduledPublishAt scheduledPublishLockEdits scheduledPublishLockOthers",
     )
     .sort({ version: -1 })
     .limit(200);
@@ -354,6 +363,18 @@ export async function getMinimalRevisions(
             m.contributors as unknown as unknown[],
           ),
         }
+      : {}),
+    ...(m.autoPublishOnApproval
+      ? { autoPublishOnApproval: m.autoPublishOnApproval }
+      : {}),
+    ...(m.scheduledPublishAt
+      ? { scheduledPublishAt: m.scheduledPublishAt }
+      : {}),
+    ...(m.scheduledPublishLockEdits
+      ? { scheduledPublishLockEdits: m.scheduledPublishLockEdits }
+      : {}),
+    ...(m.scheduledPublishLockOthers
+      ? { scheduledPublishLockOthers: m.scheduledPublishLockOthers }
       : {}),
   }));
 }
@@ -1081,7 +1102,17 @@ export async function updateRevision(
   changes: RevisionChanges,
   log: Omit<RevisionLog, "timestamp">,
   resetReview: boolean,
+  // Rebase is the one content-mutating path allowed while a schedule's
+  // "lock edits" is active (it keeps the scheduled draft mergeable). All other
+  // edits are frozen until the schedule is canceled.
+  { bypassScheduleLock = false }: { bypassScheduleLock?: boolean } = {},
 ) {
+  if (!bypassScheduleLock && isRevisionEditLockedBySchedule(revision)) {
+    throw new Error(
+      "This draft is locked for a scheduled publish. Cancel the schedule before editing.",
+    );
+  }
+
   const {
     normalizedChanges,
     status,
@@ -1219,6 +1250,9 @@ export async function markRevisionAsPublished(
     },
     {
       $set: changes,
+      // A published revision's schedule is spent — drop it (also keeps it out of
+      // the scheduledPublishAt sparse index).
+      $unset: { ...SCHEDULED_PUBLISH_UNSET },
     },
   );
 
@@ -1247,15 +1281,34 @@ export async function markRevisionAsReviewRequested(
   revision: FeatureRevisionInterface,
   user: EventUser,
   comment?: string,
-  { autoPublishOnApproval }: { autoPublishOnApproval?: boolean } = {},
+  {
+    autoPublishOnApproval,
+    scheduledPublishAt = null,
+    scheduledPublishLockEdits,
+    scheduledPublishLockOthers,
+  }: {
+    autoPublishOnApproval?: boolean;
+    // When set, arm a deferred publish for this date (implies auto-publish).
+    scheduledPublishAt?: Date | null;
+    scheduledPublishLockEdits?: boolean;
+    scheduledPublishLockOthers?: boolean;
+  } = {},
 ) {
   const action = "Review Requested";
+
+  // A target date implies the unified "armed" auto-publish flag.
+  const scheduled = scheduledPublishAt !== null;
+  const armed = !!autoPublishOnApproval || scheduled;
 
   // The auto-publish later runs with the arming user's authority, so record
   // who that was. Actors without a user ID (e.g. API keys) can still arm —
   // the publish then falls back to `createdBy`.
-  const enabledBy =
-    autoPublishOnApproval && user && "id" in user ? user.id : null;
+  const enabledBy = armed && user && "id" in user ? user.id : null;
+
+  const unset: Record<string, 1> = {};
+  if (enabledBy === null) unset.autoPublishEnabledBy = 1;
+  // Re-requesting review without a (new) schedule clears any stale one.
+  if (!scheduled) Object.assign(unset, SCHEDULED_PUBLISH_UNSET);
 
   await FeatureRevisionModel.updateOne(
     {
@@ -1269,13 +1322,20 @@ export async function markRevisionAsReviewRequested(
         datePublished: null,
         dateUpdated: new Date(),
         comment: comment,
-        autoPublishOnApproval: !!autoPublishOnApproval,
+        autoPublishOnApproval: armed,
+        ...(scheduled
+          ? {
+              scheduledPublishAt,
+              scheduledPublishLockEdits: !!scheduledPublishLockEdits,
+              scheduledPublishLockOthers: !!scheduledPublishLockOthers,
+            }
+          : {}),
         ...(enabledBy !== null ? { autoPublishEnabledBy: enabledBy } : {}),
         // Requesting review starts a new review cycle — prior verdicts no
         // longer stand (mirrors the revision-log replay semantics).
         reviews: [],
       },
-      ...(enabledBy === null ? { $unset: { autoPublishEnabledBy: 1 } } : {}),
+      ...(Object.keys(unset).length > 0 ? { $unset: unset } : {}),
     },
   );
 
@@ -1292,6 +1352,17 @@ export async function markRevisionAsReviewRequested(
     .catch((e) => {
       logger.error(e, "Error creating revisionlog");
     });
+
+  // A schedule armed alongside the review request is a separate, inspectable
+  // event in the timeline (carries the date + lock details).
+  if (scheduled) {
+    logScheduledPublishChange(context, revision, {
+      action: "schedule publish",
+      scheduledPublishAt: scheduledPublishAt as Date,
+      lockEdits: !!scheduledPublishLockEdits,
+      lockOthers: !!scheduledPublishLockOthers,
+    });
+  }
 }
 
 export async function setAutoPublishOnApproval(
@@ -1314,11 +1385,193 @@ export async function setAutoPublishOnApproval(
             autoPublishOnApproval: true,
             autoPublishEnabledBy: enabledBy,
           },
+          // Arming the "publish when approved" mode is mutually exclusive with a
+          // deferred date — clear any existing schedule so the two modes can't
+          // both be set at once.
+          $unset: { ...SCHEDULED_PUBLISH_UNSET },
         }
       : {
           $set: { autoPublishOnApproval: enabled },
-          $unset: { autoPublishEnabledBy: 1 },
+          // Disarming also drops any pending schedule so a dangling
+          // scheduledPublishAt can't linger (the unified armed flag is off).
+          $unset: { autoPublishEnabledBy: 1, ...SCHEDULED_PUBLISH_UNSET },
         },
+  );
+}
+
+// Fields that make up a deferred-publish schedule. Cleared together when the
+// schedule is canceled or the revision leaves the active review cycle.
+const SCHEDULED_PUBLISH_UNSET = {
+  scheduledPublishAt: 1,
+  scheduledPublishLockEdits: 1,
+  scheduledPublishLockOthers: 1,
+} as const;
+
+export type ScheduledPublishInput = {
+  // Target publish date, or null to cancel the schedule (also disarms auto-publish).
+  scheduledPublishAt: Date | null;
+  lockEdits?: boolean;
+  lockOthers?: boolean;
+};
+
+// Arm (or cancel) a deferred publish on a revision. Scheduling implies the
+// unified "armed" auto-publish flag; canceling disarms it. The publish later
+// runs with `enabledBy`'s authority (falls back to the draft author when null).
+// Append a revision-log entry for a deferred-publish change so additions,
+// changes, and cancellations show up in the review tab's timeline (and the
+// revision audit trail). Fire-and-forget, matching the other log writers here.
+export function logScheduledPublishChange(
+  context: ReqContext | ApiReqContext,
+  revision: Pick<FeatureRevisionInterface, "featureId" | "version">,
+  {
+    action,
+    scheduledPublishAt,
+    lockEdits,
+    lockOthers,
+  }: {
+    action:
+      | "schedule publish"
+      | "update scheduled publish"
+      | "cancel scheduled publish";
+    scheduledPublishAt?: Date;
+    lockEdits?: boolean;
+    lockOthers?: boolean;
+  },
+) {
+  context.models.featureRevisionLogs
+    .create({
+      featureId: revision.featureId,
+      version: revision.version,
+      action,
+      subject: "",
+      user: context.auditUser,
+      value: JSON.stringify(
+        action === "cancel scheduled publish"
+          ? {}
+          : {
+              scheduledPublishAt,
+              lockEdits: !!lockEdits,
+              lockOthers: !!lockOthers,
+            },
+      ),
+    })
+    .catch((e) => {
+      logger.error(e, "Error creating revisionlog for schedule change");
+    });
+}
+
+export async function setRevisionScheduledPublish(
+  context: ReqContext | ApiReqContext,
+  revision: FeatureRevisionInterface,
+  { scheduledPublishAt, lockEdits, lockOthers }: ScheduledPublishInput,
+  enabledBy: string | null,
+) {
+  const filter = {
+    organization: revision.organization,
+    featureId: revision.featureId,
+    version: revision.version,
+  };
+
+  if (scheduledPublishAt === null) {
+    await FeatureRevisionModel.updateOne(filter, {
+      $set: { autoPublishOnApproval: false, dateUpdated: new Date() },
+      $unset: { ...SCHEDULED_PUBLISH_UNSET, autoPublishEnabledBy: 1 },
+    });
+    logScheduledPublishChange(context, revision, {
+      action: "cancel scheduled publish",
+    });
+    return;
+  }
+
+  await FeatureRevisionModel.updateOne(filter, {
+    $set: {
+      autoPublishOnApproval: true,
+      scheduledPublishAt,
+      scheduledPublishLockEdits: !!lockEdits,
+      scheduledPublishLockOthers: !!lockOthers,
+      dateUpdated: new Date(),
+      ...(enabledBy !== null ? { autoPublishEnabledBy: enabledBy } : {}),
+    },
+    ...(enabledBy === null ? { $unset: { autoPublishEnabledBy: 1 } } : {}),
+  });
+
+  logScheduledPublishChange(context, revision, {
+    // Distinguish a first-time arm from an edit to an already-armed schedule.
+    action: revision.scheduledPublishAt
+      ? "update scheduled publish"
+      : "schedule publish",
+    scheduledPublishAt,
+    lockEdits: !!lockEdits,
+    lockOthers: !!lockOthers,
+  });
+}
+
+// Cross-org poller query for the scheduled-publish Agenda job. Returns the
+// identifying tuple for every armed revision whose target date has arrived and
+// is still in an active review cycle. Deliberately org-agnostic — the job
+// resolves per-org context downstream — so the projection stays tiny.
+export async function dangerouslyFindRevisionsDueToPublish(
+  now: Date,
+): Promise<{ organization: string; featureId: string; version: number }[]> {
+  const docs = await FeatureRevisionModel.find(
+    {
+      autoPublishOnApproval: true,
+      scheduledPublishAt: { $lte: now },
+      status: { $in: [...ACTIVE_DRAFT_STATUSES] },
+    },
+    { organization: 1, featureId: 1, version: 1 },
+  ).lean();
+  return docs
+    .filter((d) => d.version !== undefined && d.version !== null)
+    .map((d) => ({
+      organization: d.organization,
+      featureId: d.featureId,
+      version: d.version as number,
+    }));
+}
+
+// True if another active revision of this feature has a pending schedule that
+// blocks publishing sibling drafts (scheduledPublishLockOthers). Used to enforce
+// the lock at the publish choke point. The lock only applies once the scheduled
+// sibling is committed and no longer awaiting approval — i.e. "approved" (the
+// approval flow finished) or "draft" (the no-approval flow, where a schedule is
+// only committed on a draft when the change doesn't require review). An armed
+// schedule still in "pending-review"/"changes-requested" doesn't freeze others.
+export async function hasPublishLockingScheduledSibling(
+  organization: string,
+  featureId: string,
+  excludeVersion: number,
+): Promise<boolean> {
+  const doc = await FeatureRevisionModel.findOne({
+    organization,
+    featureId,
+    version: { $ne: excludeVersion },
+    autoPublishOnApproval: true,
+    scheduledPublishLockOthers: true,
+    status: { $in: ["approved", "draft"] },
+  }).select("_id");
+  return !!doc;
+}
+
+// Cancel every pending deferred publish across a feature's revisions. Used by
+// feature lifecycle events (e.g. archive) where a scheduled publish must no
+// longer fire. Disarms and clears the schedule/locks; safe to call when none
+// are pending. (Deletion drops the revisions outright, so it needs no call.)
+export async function cancelScheduledPublishesForFeature(
+  organization: string,
+  featureId: string,
+) {
+  await FeatureRevisionModel.updateMany(
+    {
+      organization,
+      featureId,
+      autoPublishOnApproval: true,
+      scheduledPublishAt: { $exists: true },
+    },
+    {
+      $set: { autoPublishOnApproval: false, dateUpdated: new Date() },
+      $unset: { ...SCHEDULED_PUBLISH_UNSET, autoPublishEnabledBy: 1 },
+    },
   );
 }
 
@@ -1491,6 +1744,19 @@ export async function submitReviewAndComments(
   // its own entry below; bumping `dateUpdated` would falsely signal a content
   // change to the rebase guard (expectedDraftDateUpdated) and "last modified" UI.
 
+  // A changes-requested verdict invalidates any pending deferred publish — the
+  // revision is no longer on track to publish, so cancel the schedule (and its
+  // edit/feature locks) and disarm so it can't fire on a stale approval.
+  if (
+    verdict === "changes-requested" &&
+    (revision.scheduledPublishAt ?? null)
+  ) {
+    await FeatureRevisionModel.updateOne(filter, {
+      $set: { autoPublishOnApproval: false, dateUpdated: new Date() },
+      $unset: { ...SCHEDULED_PUBLISH_UNSET, autoPublishEnabledBy: 1 },
+    });
+  }
+
   // Fire and forget - no route that submits the review and comments expects the log to be there immediately
   context.models.featureRevisionLogs
     .create({
@@ -1529,9 +1795,20 @@ export async function recallReview(
     },
     {
       // Recalling starts the review lifecycle over — clear baked verdicts
-      // (mirrors the revision-log replay semantics).
-      $set: { status: "draft", dateUpdated: new Date(), reviews: [] },
-      $unset: { approvedBaseVersion: 1 },
+      // (mirrors the revision-log replay semantics) and disarm any auto/deferred
+      // publish: arming is re-specified on the next Request Review, and a pending
+      // schedule must not fire on a draft that's no longer up for review.
+      $set: {
+        status: "draft",
+        dateUpdated: new Date(),
+        reviews: [],
+        autoPublishOnApproval: false,
+      },
+      $unset: {
+        approvedBaseVersion: 1,
+        autoPublishEnabledBy: 1,
+        ...SCHEDULED_PUBLISH_UNSET,
+      },
     },
   );
 
@@ -1748,7 +2025,11 @@ export async function reopenRevision(
         reviews: [],
         autoPublishOnApproval: false,
       },
-      $unset: { approvedBaseVersion: 1, autoPublishEnabledBy: 1 },
+      $unset: {
+        approvedBaseVersion: 1,
+        autoPublishEnabledBy: 1,
+        ...SCHEDULED_PUBLISH_UNSET,
+      },
     },
   );
 
@@ -1805,6 +2086,7 @@ export async function discardRevision(
     },
     {
       $set: { status: "discarded", dateUpdated: new Date() },
+      $unset: { ...SCHEDULED_PUBLISH_UNSET },
     },
   );
 

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -117,6 +117,8 @@ const featureRevisionSchema = new mongoose.Schema({
   scheduledPublishAt: Date,
   scheduledPublishLockEdits: Boolean,
   scheduledPublishLockOthers: Boolean,
+  scheduledPublishAttempts: Number,
+  scheduledPublishLastError: String,
   log: [
     {
       _id: false,
@@ -134,8 +136,8 @@ featureRevisionSchema.index(
   { unique: true },
 );
 featureRevisionSchema.index({ organization: 1, status: 1 });
-// Sparse: only armed, deferred-publish revisions carry scheduledPublishAt, so the
-// cross-org due-poller (dangerouslyFindRevisionsDueToPublish) scans a tiny set.
+// Sparse: only scheduled revisions carry scheduledPublishAt, so the cross-org
+// due-poller scans a tiny set.
 featureRevisionSchema.index({ scheduledPublishAt: 1 }, { sparse: true });
 
 type FeatureRevisionDocument = mongoose.Document & FeatureRevisionInterface;
@@ -1102,9 +1104,8 @@ export async function updateRevision(
   changes: RevisionChanges,
   log: Omit<RevisionLog, "timestamp">,
   resetReview: boolean,
-  // Rebase is the one content-mutating path allowed while a schedule's
-  // "lock edits" is active (it keeps the scheduled draft mergeable). All other
-  // edits are frozen until the schedule is canceled.
+  // Rebase is the only content-mutating path allowed while "lock edits" is
+  // active (keeps the scheduled draft mergeable); all other edits are frozen.
   { bypassScheduleLock = false }: { bypassScheduleLock?: boolean } = {},
 ) {
   if (!bypassScheduleLock && isRevisionEditLockedBySchedule(revision)) {
@@ -1250,8 +1251,7 @@ export async function markRevisionAsPublished(
     },
     {
       $set: changes,
-      // A published revision's schedule is spent — drop it (also keeps it out of
-      // the scheduledPublishAt sparse index).
+      // A published revision's schedule is spent — drop it.
       $unset: { ...SCHEDULED_PUBLISH_UNSET },
     },
   );
@@ -1299,6 +1299,14 @@ export async function markRevisionAsReviewRequested(
   // A target date implies the unified "armed" auto-publish flag.
   const scheduled = scheduledPublishAt !== null;
   const armed = !!autoPublishOnApproval || scheduled;
+
+  if (scheduled && scheduledPublishLockOthers) {
+    await assertNoConflictingPublishLock(
+      revision.organization,
+      revision.featureId,
+      revision.version,
+    );
+  }
 
   // The auto-publish later runs with the arming user's authority, so record
   // who that was. Actors without a user ID (e.g. API keys) can still arm —
@@ -1353,8 +1361,7 @@ export async function markRevisionAsReviewRequested(
       logger.error(e, "Error creating revisionlog");
     });
 
-  // A schedule armed alongside the review request is a separate, inspectable
-  // event in the timeline (carries the date + lock details).
+  // Log the schedule armed with the review request as its own timeline event.
   if (scheduled) {
     logScheduledPublishChange(context, revision, {
       action: "schedule publish",
@@ -1385,26 +1392,25 @@ export async function setAutoPublishOnApproval(
             autoPublishOnApproval: true,
             autoPublishEnabledBy: enabledBy,
           },
-          // Arming the "publish when approved" mode is mutually exclusive with a
-          // deferred date — clear any existing schedule so the two modes can't
-          // both be set at once.
+          // "publish when approved" is mutually exclusive with a date — clear any
+          // existing schedule.
           $unset: { ...SCHEDULED_PUBLISH_UNSET },
         }
       : {
           $set: { autoPublishOnApproval: enabled },
-          // Disarming also drops any pending schedule so a dangling
-          // scheduledPublishAt can't linger (the unified armed flag is off).
+          // Disarming drops any pending schedule too.
           $unset: { autoPublishEnabledBy: 1, ...SCHEDULED_PUBLISH_UNSET },
         },
   );
 }
 
-// Fields that make up a deferred-publish schedule. Cleared together when the
-// schedule is canceled or the revision leaves the active review cycle.
+// Schedule fields cleared together on cancel or when leaving the review cycle.
 const SCHEDULED_PUBLISH_UNSET = {
   scheduledPublishAt: 1,
   scheduledPublishLockEdits: 1,
   scheduledPublishLockOthers: 1,
+  scheduledPublishAttempts: 1,
+  scheduledPublishLastError: 1,
 } as const;
 
 export type ScheduledPublishInput = {
@@ -1414,12 +1420,8 @@ export type ScheduledPublishInput = {
   lockOthers?: boolean;
 };
 
-// Arm (or cancel) a deferred publish on a revision. Scheduling implies the
-// unified "armed" auto-publish flag; canceling disarms it. The publish later
-// runs with `enabledBy`'s authority (falls back to the draft author when null).
-// Append a revision-log entry for a deferred-publish change so additions,
-// changes, and cancellations show up in the review tab's timeline (and the
-// revision audit trail). Fire-and-forget, matching the other log writers here.
+// Log a schedule change so additions/changes/cancellations show in the review
+// timeline. Fire-and-forget, like the other log writers here.
 export function logScheduledPublishChange(
   context: ReqContext | ApiReqContext,
   revision: Pick<FeatureRevisionInterface, "featureId" | "version">,
@@ -1460,6 +1462,9 @@ export function logScheduledPublishChange(
     });
 }
 
+// Arm (or cancel) a deferred publish on a revision. Scheduling implies the armed
+// auto-publish flag; canceling disarms it. The publish later runs with
+// `enabledBy`'s authority (falls back to the draft author when null).
 export async function setRevisionScheduledPublish(
   context: ReqContext | ApiReqContext,
   revision: FeatureRevisionInterface,
@@ -1481,6 +1486,14 @@ export async function setRevisionScheduledPublish(
       action: "cancel scheduled publish",
     });
     return;
+  }
+
+  if (lockOthers) {
+    await assertNoConflictingPublishLock(
+      revision.organization,
+      revision.featureId,
+      revision.version,
+    );
   }
 
   await FeatureRevisionModel.updateOne(filter, {
@@ -1506,10 +1519,34 @@ export async function setRevisionScheduledPublish(
   });
 }
 
-// Cross-org poller query for the scheduled-publish Agenda job. Returns the
-// identifying tuple for every armed revision whose target date has arrived and
-// is still in an active review cycle. Deliberately org-agnostic — the job
-// resolves per-org context downstream — so the projection stays tiny.
+// Record a failed attempt by the scheduled-publish poller so a stuck schedule is
+// visible (UI + REST) instead of silently retrying. Cleared on the next
+// successful publish or when the schedule is canceled.
+export async function recordScheduledPublishFailure(
+  revision: Pick<
+    FeatureRevisionInterface,
+    "organization" | "featureId" | "version"
+  >,
+  message: string,
+): Promise<number> {
+  const doc = await FeatureRevisionModel.findOneAndUpdate(
+    {
+      organization: revision.organization,
+      featureId: revision.featureId,
+      version: revision.version,
+    },
+    {
+      $set: { scheduledPublishLastError: message },
+      $inc: { scheduledPublishAttempts: 1 },
+    },
+    { new: true },
+  ).select("scheduledPublishAttempts");
+  return doc?.scheduledPublishAttempts ?? 0;
+}
+
+// Cross-org poller query for the Agenda job: every armed revision whose date has
+// arrived and is still in an active review cycle. Org-agnostic by design (context
+// is resolved per-org downstream).
 export async function dangerouslyFindRevisionsDueToPublish(
   now: Date,
 ): Promise<{ organization: string; featureId: string; version: number }[]> {
@@ -1530,13 +1567,10 @@ export async function dangerouslyFindRevisionsDueToPublish(
     }));
 }
 
-// True if another active revision of this feature has a pending schedule that
-// blocks publishing sibling drafts (scheduledPublishLockOthers). Used to enforce
-// the lock at the publish choke point. The lock only applies once the scheduled
-// sibling is committed and no longer awaiting approval — i.e. "approved" (the
-// approval flow finished) or "draft" (the no-approval flow, where a schedule is
-// only committed on a draft when the change doesn't require review). An armed
-// schedule still in "pending-review"/"changes-requested" doesn't freeze others.
+// True if another revision has a committed "lock other drafts" schedule blocking
+// sibling publishes. Only applies once the schedule is committed and no longer
+// awaiting approval — status "approved" (approval flow) or "draft" (no-approval
+// flow); "pending-review"/"changes-requested" don't freeze others.
 export async function hasPublishLockingScheduledSibling(
   organization: string,
   featureId: string,
@@ -1553,14 +1587,47 @@ export async function hasPublishLockingScheduledSibling(
   return !!doc;
 }
 
-// Cancel every pending deferred publish across a feature's revisions. Used by
-// feature lifecycle events (e.g. archive) where a scheduled publish must no
-// longer fire. Disarms and clears the schedule/locks; safe to call when none
-// are pending. (Deletion drops the revisions outright, so it needs no call.)
+// Reject arming a second "lock other drafts" schedule while one is already
+// pending on the feature. Two such schedules would mutually block each other at
+// fire time (each is a publish-locking sibling of the other) and hold forever.
+async function assertNoConflictingPublishLock(
+  organization: string,
+  featureId: string,
+  version: number,
+) {
+  const conflict = await FeatureRevisionModel.findOne({
+    organization,
+    featureId,
+    version: { $ne: version },
+    autoPublishOnApproval: true,
+    scheduledPublishLockOthers: true,
+    scheduledPublishAt: { $ne: null },
+    status: { $in: [...ACTIVE_DRAFT_STATUSES] },
+  }).select("version");
+  if (conflict) {
+    throw new Error(
+      `Revision ${conflict.version} already has a scheduled publish that locks other drafts. Cancel it before scheduling another.`,
+    );
+  }
+}
+
+// Cancel pending schedules across a feature's revisions (e.g. on archive).
+// Disarms and clears schedule/locks; safe to call when none are pending.
+// Logs a cancellation against each affected revision so the timeline reflects it.
 export async function cancelScheduledPublishesForFeature(
+  context: ReqContext | ApiReqContext,
   organization: string,
   featureId: string,
 ) {
+  const affected = await FeatureRevisionModel.find({
+    organization,
+    featureId,
+    autoPublishOnApproval: true,
+    scheduledPublishAt: { $exists: true, $ne: null },
+  }).select("version");
+
+  if (!affected.length) return;
+
   await FeatureRevisionModel.updateMany(
     {
       organization,
@@ -1573,6 +1640,14 @@ export async function cancelScheduledPublishesForFeature(
       $unset: { ...SCHEDULED_PUBLISH_UNSET, autoPublishEnabledBy: 1 },
     },
   );
+
+  for (const doc of affected) {
+    logScheduledPublishChange(
+      context,
+      { featureId, version: doc.version },
+      { action: "cancel scheduled publish" },
+    );
+  }
 }
 
 // Compare-and-swap update: read `guardFields`, derive an update from the
@@ -1744,16 +1819,18 @@ export async function submitReviewAndComments(
   // its own entry below; bumping `dateUpdated` would falsely signal a content
   // change to the rebase guard (expectedDraftDateUpdated) and "last modified" UI.
 
-  // A changes-requested verdict invalidates any pending deferred publish — the
-  // revision is no longer on track to publish, so cancel the schedule (and its
-  // edit/feature locks) and disarm so it can't fire on a stale approval.
+  // A changes-requested verdict cancels any pending schedule so it can't fire on
+  // a stale approval.
   if (
     verdict === "changes-requested" &&
-    (revision.scheduledPublishAt ?? null)
+    (revision.scheduledPublishAt ?? null) !== null
   ) {
     await FeatureRevisionModel.updateOne(filter, {
       $set: { autoPublishOnApproval: false, dateUpdated: new Date() },
       $unset: { ...SCHEDULED_PUBLISH_UNSET, autoPublishEnabledBy: 1 },
+    });
+    logScheduledPublishChange(context, revision, {
+      action: "cancel scheduled publish",
     });
   }
 
@@ -1794,10 +1871,8 @@ export async function recallReview(
       version: revision.version,
     },
     {
-      // Recalling starts the review lifecycle over — clear baked verdicts
-      // (mirrors the revision-log replay semantics) and disarm any auto/deferred
-      // publish: arming is re-specified on the next Request Review, and a pending
-      // schedule must not fire on a draft that's no longer up for review.
+      // Recalling restarts the review lifecycle: clear verdicts and disarm any
+      // auto/deferred publish (re-specified on the next Request Review).
       $set: {
         status: "draft",
         dateUpdated: new Date(),
@@ -1824,6 +1899,13 @@ export async function recallReview(
     .catch((e) => {
       logger.error(e, "Error creating revisionlog for recallReview");
     });
+
+  // Recall disarms any pending schedule — record the cancellation in the timeline.
+  if ((revision.scheduledPublishAt ?? null) !== null) {
+    logScheduledPublishChange(context, revision, {
+      action: "cancel scheduled publish",
+    });
+  }
 }
 
 // Replay the review lifecycle from the merged log to find each reviewer's

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -1332,8 +1332,10 @@ export async function markRevisionAsReviewRequested(
 
   const unset: Record<string, 1> = {};
   if (enabledBy === null) unset.autoPublishEnabledBy = 1;
-  // Re-requesting review without a (new) schedule clears any stale one.
+  // Re-requesting review without a (new) schedule clears any stale one. With a
+  // new schedule, keep the schedule but still reset prior poller-failure state.
   if (!scheduled) Object.assign(unset, SCHEDULED_PUBLISH_UNSET);
+  else Object.assign(unset, SCHEDULED_PUBLISH_FAILURE_UNSET);
 
   try {
     await FeatureRevisionModel.updateOne(
@@ -1428,13 +1430,19 @@ export async function setAutoPublishOnApproval(
   );
 }
 
+// Poller-failure bookkeeping. Cleared on cancel and on every (re)arm so a fresh
+// schedule never inherits a prior schedule's "stuck" state or attempt count.
+const SCHEDULED_PUBLISH_FAILURE_UNSET = {
+  scheduledPublishAttempts: 1,
+  scheduledPublishLastError: 1,
+} as const;
+
 // Schedule fields cleared together on cancel or when leaving the review cycle.
 const SCHEDULED_PUBLISH_UNSET = {
   scheduledPublishAt: 1,
   scheduledPublishLockEdits: 1,
   scheduledPublishLockOthers: 1,
-  scheduledPublishAttempts: 1,
-  scheduledPublishLastError: 1,
+  ...SCHEDULED_PUBLISH_FAILURE_UNSET,
 } as const;
 
 export type ScheduledPublishInput = {
@@ -1530,7 +1538,12 @@ export async function setRevisionScheduledPublish(
         dateUpdated: new Date(),
         ...(enabledBy !== null ? { autoPublishEnabledBy: enabledBy } : {}),
       },
-      ...(enabledBy === null ? { $unset: { autoPublishEnabledBy: 1 } } : {}),
+      // Clear any prior poller-failure state so a reschedule doesn't keep the
+      // "stuck" UI or prematurely escalate logging on the next fire.
+      $unset: {
+        ...SCHEDULED_PUBLISH_FAILURE_UNSET,
+        ...(enabledBy === null ? { autoPublishEnabledBy: 1 } : {}),
+      },
     });
   } catch (e) {
     if (isPublishLockIndexConflict(e)) {

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -1339,8 +1339,14 @@ export async function markRevisionAsReviewRequested(
   if (enabledBy === null) unset.autoPublishEnabledBy = 1;
   // Re-requesting review without a (new) schedule clears any stale one. With a
   // new schedule, keep the schedule but still reset prior poller-failure state.
+  // Either way clear scheduledPublishBypassApproval — request-review never arms
+  // an admin-bypass schedule, so a stale flag from a prior schedule-publish arm
+  // must not carry over.
   if (!scheduled) Object.assign(unset, SCHEDULED_PUBLISH_UNSET);
-  else Object.assign(unset, SCHEDULED_PUBLISH_FAILURE_UNSET);
+  else
+    Object.assign(unset, SCHEDULED_PUBLISH_FAILURE_UNSET, {
+      scheduledPublishBypassApproval: 1,
+    });
 
   try {
     await FeatureRevisionModel.updateOne(

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -1543,24 +1543,37 @@ export async function setRevisionScheduledPublish(
   }
 
   try {
-    await FeatureRevisionModel.updateOne(filter, {
-      $set: {
-        autoPublishOnApproval: true,
-        scheduledPublishAt,
-        scheduledPublishLockEdits: !!lockEdits,
-        scheduledPublishLockOthers: !!lockOthers,
-        dateUpdated: new Date(),
-        ...(bypassApproval ? { scheduledPublishBypassApproval: true } : {}),
-        ...(enabledBy !== null ? { autoPublishEnabledBy: enabledBy } : {}),
+    // Guard against a TOCTOU race: only arm a revision that's still active.
+    // Without the status predicate, a revision published/discarded between the
+    // caller's read and this write would get schedule/lock fields stamped back
+    // onto it — and a stale lock-others doc would keep occupying the partial
+    // unique index, blocking future schedules for the feature.
+    const { matchedCount } = await FeatureRevisionModel.updateOne(
+      { ...filter, status: { $in: [...ACTIVE_DRAFT_STATUSES] } },
+      {
+        $set: {
+          autoPublishOnApproval: true,
+          scheduledPublishAt,
+          scheduledPublishLockEdits: !!lockEdits,
+          scheduledPublishLockOthers: !!lockOthers,
+          dateUpdated: new Date(),
+          ...(bypassApproval ? { scheduledPublishBypassApproval: true } : {}),
+          ...(enabledBy !== null ? { autoPublishEnabledBy: enabledBy } : {}),
+        },
+        // Clear any prior poller-failure state so a reschedule doesn't keep the
+        // "stuck" UI or prematurely escalate logging on the next fire.
+        $unset: {
+          ...SCHEDULED_PUBLISH_FAILURE_UNSET,
+          ...(bypassApproval ? {} : { scheduledPublishBypassApproval: 1 }),
+          ...(enabledBy === null ? { autoPublishEnabledBy: 1 } : {}),
+        },
       },
-      // Clear any prior poller-failure state so a reschedule doesn't keep the
-      // "stuck" UI or prematurely escalate logging on the next fire.
-      $unset: {
-        ...SCHEDULED_PUBLISH_FAILURE_UNSET,
-        ...(bypassApproval ? {} : { scheduledPublishBypassApproval: 1 }),
-        ...(enabledBy === null ? { autoPublishEnabledBy: 1 } : {}),
-      },
-    });
+    );
+    if (!matchedCount) {
+      throw new Error(
+        "This revision can no longer be scheduled — it was published or discarded.",
+      );
+    }
   } catch (e) {
     if (isPublishLockIndexConflict(e)) {
       throw new Error(PUBLISH_LOCK_CONFLICT_MESSAGE);

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -1271,9 +1271,10 @@ export async function markRevisionAsPublished(
       version: revision.version,
     },
     {
-      $set: changes,
-      // A published revision's schedule is spent — drop it.
-      $unset: { ...SCHEDULED_PUBLISH_UNSET },
+      // A published revision's schedule and auto-publish arming are spent —
+      // disarm so consumers don't see a published revision still "armed".
+      $set: { ...changes, autoPublishOnApproval: false },
+      $unset: { ...SCHEDULED_PUBLISH_UNSET, autoPublishEnabledBy: 1 },
     },
   );
 

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -1870,18 +1870,22 @@ export async function submitReviewAndComments(
   // change to the rebase guard (expectedDraftDateUpdated) and "last modified" UI.
 
   // A changes-requested verdict cancels any pending schedule so it can't fire on
-  // a stale approval.
-  if (
-    verdict === "changes-requested" &&
-    (revision.scheduledPublishAt ?? null) !== null
-  ) {
-    await FeatureRevisionModel.updateOne(filter, {
-      $set: { autoPublishOnApproval: false, dateUpdated: new Date() },
-      $unset: { ...SCHEDULED_PUBLISH_UNSET, autoPublishEnabledBy: 1 },
-    });
-    logScheduledPublishChange(context, revision, {
-      action: "cancel scheduled publish",
-    });
+  // a stale approval. Gate the clear on the schedule still being set so concurrent
+  // changes-requested verdicts don't each log a duplicate cancellation — only the
+  // writer that actually clears it (modifiedCount > 0) logs.
+  if (verdict === "changes-requested") {
+    const res = await FeatureRevisionModel.updateOne(
+      { ...filter, scheduledPublishAt: { $exists: true, $ne: null } },
+      {
+        $set: { autoPublishOnApproval: false, dateUpdated: new Date() },
+        $unset: { ...SCHEDULED_PUBLISH_UNSET, autoPublishEnabledBy: 1 },
+      },
+    );
+    if (res.modifiedCount > 0) {
+      logScheduledPublishChange(context, revision, {
+        action: "cancel scheduled publish",
+      });
+    }
   }
 
   // Fire and forget - no route that submits the review and comments expects the log to be there immediately

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -2234,8 +2234,14 @@ export async function discardRevision(
       version: revision.version,
     },
     {
-      $set: { status: "discarded", dateUpdated: new Date() },
-      $unset: { ...SCHEDULED_PUBLISH_UNSET },
+      // Discarding a revision also disarms auto-publish so the dead revision
+      // doesn't surface as armed via the API (mirrors recallReview/reopenRevision).
+      $set: {
+        status: "discarded",
+        dateUpdated: new Date(),
+        autoPublishOnApproval: false,
+      },
+      $unset: { ...SCHEDULED_PUBLISH_UNSET, autoPublishEnabledBy: 1 },
     },
   );
 

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -117,6 +117,7 @@ const featureRevisionSchema = new mongoose.Schema({
   scheduledPublishAt: Date,
   scheduledPublishLockEdits: Boolean,
   scheduledPublishLockOthers: Boolean,
+  scheduledPublishBypassApproval: Boolean,
   scheduledPublishAttempts: Number,
   scheduledPublishLastError: String,
   log: [
@@ -363,7 +364,7 @@ export async function getMinimalRevisions(
     featureId,
   })
     .select(
-      "version datePublished dateUpdated createdBy status comment title contributors autoPublishOnApproval scheduledPublishAt scheduledPublishLockEdits scheduledPublishLockOthers",
+      "version datePublished dateUpdated createdBy status comment title contributors autoPublishOnApproval scheduledPublishAt scheduledPublishLockEdits scheduledPublishLockOthers scheduledPublishBypassApproval",
     )
     .sort({ version: -1 })
     .limit(200);
@@ -394,6 +395,9 @@ export async function getMinimalRevisions(
       : {}),
     ...(m.scheduledPublishLockOthers
       ? { scheduledPublishLockOthers: m.scheduledPublishLockOthers }
+      : {}),
+    ...(m.scheduledPublishBypassApproval
+      ? { scheduledPublishBypassApproval: m.scheduledPublishBypassApproval }
       : {}),
   }));
 }
@@ -1442,6 +1446,7 @@ const SCHEDULED_PUBLISH_UNSET = {
   scheduledPublishAt: 1,
   scheduledPublishLockEdits: 1,
   scheduledPublishLockOthers: 1,
+  scheduledPublishBypassApproval: 1,
   ...SCHEDULED_PUBLISH_FAILURE_UNSET,
 } as const;
 
@@ -1450,6 +1455,10 @@ export type ScheduledPublishInput = {
   scheduledPublishAt: Date | null;
   lockEdits?: boolean;
   lockOthers?: boolean;
+  // Mark the schedule as an admin bypass-approval override. Callers must only
+  // pass true after confirming canBypassApprovalChecks. Persisted so the UI can
+  // lock the schedule to cancel-and-re-arm; ignored when canceling.
+  bypassApproval?: boolean;
 };
 
 // Log a schedule change so additions/changes/cancellations show in the review
@@ -1500,7 +1509,12 @@ export function logScheduledPublishChange(
 export async function setRevisionScheduledPublish(
   context: ReqContext | ApiReqContext,
   revision: FeatureRevisionInterface,
-  { scheduledPublishAt, lockEdits, lockOthers }: ScheduledPublishInput,
+  {
+    scheduledPublishAt,
+    lockEdits,
+    lockOthers,
+    bypassApproval,
+  }: ScheduledPublishInput,
   enabledBy: string | null,
 ) {
   const filter = {
@@ -1536,12 +1550,14 @@ export async function setRevisionScheduledPublish(
         scheduledPublishLockEdits: !!lockEdits,
         scheduledPublishLockOthers: !!lockOthers,
         dateUpdated: new Date(),
+        ...(bypassApproval ? { scheduledPublishBypassApproval: true } : {}),
         ...(enabledBy !== null ? { autoPublishEnabledBy: enabledBy } : {}),
       },
       // Clear any prior poller-failure state so a reschedule doesn't keep the
       // "stuck" UI or prematurely escalate logging on the next fire.
       $unset: {
         ...SCHEDULED_PUBLISH_FAILURE_UNSET,
+        ...(bypassApproval ? {} : { scheduledPublishBypassApproval: 1 }),
         ...(enabledBy === null ? { autoPublishEnabledBy: 1 } : {}),
       },
     });

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -131,6 +131,9 @@ const featureRevisionSchema = new mongoose.Schema({
   ],
 });
 
+// Named so we can recognize its duplicate-key errors and translate them.
+const PUBLISH_LOCK_OTHERS_INDEX = "uniqueArmedPublishLockOthers";
+
 featureRevisionSchema.index(
   { organization: 1, featureId: 1, version: 1 },
   { unique: true },
@@ -139,6 +142,20 @@ featureRevisionSchema.index({ organization: 1, status: 1 });
 // Sparse: only scheduled revisions carry scheduledPublishAt, so the cross-org
 // due-poller scans a tiny set.
 featureRevisionSchema.index({ scheduledPublishAt: 1 }, { sparse: true });
+// At most one armed "lock other drafts" schedule per feature — the atomic
+// backstop for assertNoConflictingPublishLock against concurrent arming. Partial
+// so canceling/publishing (which unsets the fields) drops the doc automatically.
+featureRevisionSchema.index(
+  { organization: 1, featureId: 1 },
+  {
+    name: PUBLISH_LOCK_OTHERS_INDEX,
+    unique: true,
+    partialFilterExpression: {
+      autoPublishOnApproval: true,
+      scheduledPublishLockOthers: true,
+    },
+  },
+);
 
 type FeatureRevisionDocument = mongoose.Document & FeatureRevisionInterface;
 
@@ -1318,34 +1335,41 @@ export async function markRevisionAsReviewRequested(
   // Re-requesting review without a (new) schedule clears any stale one.
   if (!scheduled) Object.assign(unset, SCHEDULED_PUBLISH_UNSET);
 
-  await FeatureRevisionModel.updateOne(
-    {
-      organization: revision.organization,
-      featureId: revision.featureId,
-      version: revision.version,
-    },
-    {
-      $set: {
-        status: "pending-review",
-        datePublished: null,
-        dateUpdated: new Date(),
-        comment: comment,
-        autoPublishOnApproval: armed,
-        ...(scheduled
-          ? {
-              scheduledPublishAt,
-              scheduledPublishLockEdits: !!scheduledPublishLockEdits,
-              scheduledPublishLockOthers: !!scheduledPublishLockOthers,
-            }
-          : {}),
-        ...(enabledBy !== null ? { autoPublishEnabledBy: enabledBy } : {}),
-        // Requesting review starts a new review cycle — prior verdicts no
-        // longer stand (mirrors the revision-log replay semantics).
-        reviews: [],
+  try {
+    await FeatureRevisionModel.updateOne(
+      {
+        organization: revision.organization,
+        featureId: revision.featureId,
+        version: revision.version,
       },
-      ...(Object.keys(unset).length > 0 ? { $unset: unset } : {}),
-    },
-  );
+      {
+        $set: {
+          status: "pending-review",
+          datePublished: null,
+          dateUpdated: new Date(),
+          comment: comment,
+          autoPublishOnApproval: armed,
+          ...(scheduled
+            ? {
+                scheduledPublishAt,
+                scheduledPublishLockEdits: !!scheduledPublishLockEdits,
+                scheduledPublishLockOthers: !!scheduledPublishLockOthers,
+              }
+            : {}),
+          ...(enabledBy !== null ? { autoPublishEnabledBy: enabledBy } : {}),
+          // Requesting review starts a new review cycle — prior verdicts no
+          // longer stand (mirrors the revision-log replay semantics).
+          reviews: [],
+        },
+        ...(Object.keys(unset).length > 0 ? { $unset: unset } : {}),
+      },
+    );
+  } catch (e) {
+    if (isPublishLockIndexConflict(e)) {
+      throw new Error(PUBLISH_LOCK_CONFLICT_MESSAGE);
+    }
+    throw e;
+  }
 
   // Fire and forget - no route that marks the revision as Review Requested expects the log to be there immediately
   context.models.featureRevisionLogs
@@ -1496,17 +1520,24 @@ export async function setRevisionScheduledPublish(
     );
   }
 
-  await FeatureRevisionModel.updateOne(filter, {
-    $set: {
-      autoPublishOnApproval: true,
-      scheduledPublishAt,
-      scheduledPublishLockEdits: !!lockEdits,
-      scheduledPublishLockOthers: !!lockOthers,
-      dateUpdated: new Date(),
-      ...(enabledBy !== null ? { autoPublishEnabledBy: enabledBy } : {}),
-    },
-    ...(enabledBy === null ? { $unset: { autoPublishEnabledBy: 1 } } : {}),
-  });
+  try {
+    await FeatureRevisionModel.updateOne(filter, {
+      $set: {
+        autoPublishOnApproval: true,
+        scheduledPublishAt,
+        scheduledPublishLockEdits: !!lockEdits,
+        scheduledPublishLockOthers: !!lockOthers,
+        dateUpdated: new Date(),
+        ...(enabledBy !== null ? { autoPublishEnabledBy: enabledBy } : {}),
+      },
+      ...(enabledBy === null ? { $unset: { autoPublishEnabledBy: 1 } } : {}),
+    });
+  } catch (e) {
+    if (isPublishLockIndexConflict(e)) {
+      throw new Error(PUBLISH_LOCK_CONFLICT_MESSAGE);
+    }
+    throw e;
+  }
 
   logScheduledPublishChange(context, revision, {
     // Distinguish a first-time arm from an edit to an already-armed schedule.
@@ -1519,9 +1550,10 @@ export async function setRevisionScheduledPublish(
   });
 }
 
-// Record a failed attempt by the scheduled-publish poller so a stuck schedule is
-// visible (UI + REST) instead of silently retrying. Cleared on the next
-// successful publish or when the schedule is canceled.
+// Record a failed poller attempt so a stuck schedule is visible (UI + REST)
+// instead of silently retrying; cleared on the next publish or cancel.
+// Intentionally a raw write — no dateUpdated bump, audit, timeline, or webhook —
+// so per-tick retries don't generate notification noise. Keep it that way.
 export async function recordScheduledPublishFailure(
   revision: Pick<
     FeatureRevisionInterface,
@@ -1587,9 +1619,12 @@ export async function hasPublishLockingScheduledSibling(
   return !!doc;
 }
 
-// Reject arming a second "lock other drafts" schedule while one is already
-// pending on the feature. Two such schedules would mutually block each other at
-// fire time (each is a publish-locking sibling of the other) and hold forever.
+const PUBLISH_LOCK_CONFLICT_MESSAGE =
+  "Another draft of this feature already has a scheduled publish that locks other drafts. Cancel it before scheduling another.";
+
+// Reject arming a second "lock other drafts" schedule on a feature — two would
+// mutually block each other at fire time and hold forever. Fast pre-check for a
+// clear error; the partial unique index is the atomic guard against the race.
 async function assertNoConflictingPublishLock(
   organization: string,
   featureId: string,
@@ -1611,9 +1646,24 @@ async function assertNoConflictingPublishLock(
   }
 }
 
+// True for the duplicate-key error from the lock-others partial unique index —
+// i.e. a concurrent arming request won the race for this feature's lock.
+function isPublishLockIndexConflict(e: unknown): boolean {
+  return (
+    !!e &&
+    typeof e === "object" &&
+    (e as { code?: number }).code === 11000 &&
+    String((e as { message?: string }).message ?? "").includes(
+      PUBLISH_LOCK_OTHERS_INDEX,
+    )
+  );
+}
+
 // Cancel pending schedules across a feature's revisions (e.g. on archive).
 // Disarms and clears schedule/locks; safe to call when none are pending.
 // Logs a cancellation against each affected revision so the timeline reflects it.
+// find→updateMany isn't atomic: a schedule armed between the two is still cleared
+// (same filter) but won't get a timeline entry. Accepted — log completeness only.
 export async function cancelScheduledPublishesForFeature(
   context: ReqContext | ApiReqContext,
   organization: string,
@@ -1633,7 +1683,7 @@ export async function cancelScheduledPublishesForFeature(
       organization,
       featureId,
       autoPublishOnApproval: true,
-      scheduledPublishAt: { $exists: true },
+      scheduledPublishAt: { $exists: true, $ne: null },
     },
     {
       $set: { autoPublishOnApproval: false, dateUpdated: new Date() },

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -1963,6 +1963,23 @@ export function revisionToApiInterfaceV2(
     ...(rev.rampActions !== undefined && {
       rampActions: rev.rampActions,
     }),
+    ...(rev.autoPublishOnApproval !== undefined && {
+      autoPublishOnApproval: rev.autoPublishOnApproval,
+    }),
+    ...((rev.scheduledPublishAt ?? null) !== null && {
+      scheduledPublishAt: new Date(
+        rev.scheduledPublishAt as Date,
+      ).toISOString(),
+    }),
+    ...(rev.scheduledPublishLockEdits !== undefined && {
+      scheduledPublishLockEdits: rev.scheduledPublishLockEdits,
+    }),
+    ...(rev.scheduledPublishLockOthers !== undefined && {
+      scheduledPublishLockOthers: rev.scheduledPublishLockOthers,
+    }),
+    ...(rev.scheduledPublishLastError !== undefined && {
+      scheduledPublishLastError: rev.scheduledPublishLastError,
+    }),
     ...(rev.reviews !== undefined && {
       reviews: rev.reviews.map((r) => {
         const user = eventUserToApiEventUser(r.user);
@@ -3105,14 +3122,18 @@ async function collectHoldoutAffectedEnvs(
   return [...envs];
 }
 
-// Whether a draft requires approval before it can be published (accounts for
-// the org's review settings, environment scoping, and the require-approvals
-// license). Returns false when the base can't be resolved (legacy/missing base)
-// so callers treat it as a no-approval change.
+// Whether a draft requires approval before publishing (org review settings, env
+// scoping, license). When the base can't be resolved the answer is ambiguous:
+// the default treats it as a no-approval change (false), but pass
+// `treatUnresolvedBaseAsReview` to fail closed (true) for flows that commit
+// locks/schedules and must not engage them on a draft that can't be evaluated.
 export async function revisionRequiresReview(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
   draft: FeatureRevisionInterface,
+  {
+    treatUnresolvedBaseAsReview = false,
+  }: { treatUnresolvedBaseAsReview?: boolean } = {},
 ): Promise<boolean> {
   const allEnvironments = getEnvironmentIdsFromOrg(context.org);
 
@@ -3123,7 +3144,7 @@ export async function revisionRequiresReview(
     feature,
     version: draft.baseVersion,
   });
-  if (!baseRevision) return false;
+  if (!baseRevision) return treatUnresolvedBaseAsReview;
 
   return checkIfRevisionNeedsReview({
     feature,

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -2039,6 +2039,9 @@ export function revisionToApiInterfaceV2(
     ...(rev.scheduledPublishLockOthers !== undefined && {
       scheduledPublishLockOthers: rev.scheduledPublishLockOthers,
     }),
+    ...(rev.scheduledPublishBypassApproval !== undefined && {
+      scheduledPublishBypassApproval: rev.scheduledPublishBypassApproval,
+    }),
     ...(rev.scheduledPublishLastError !== undefined && {
       scheduledPublishLastError: rev.scheduledPublishLastError,
     }),

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -3105,14 +3105,16 @@ async function collectHoldoutAffectedEnvs(
   return [...envs];
 }
 
-// Throws if the draft requires approval and the caller cannot bypass.
-export async function assertCanAutoPublish(
-  context: ReqContext,
+// Whether a draft requires approval before it can be published (accounts for
+// the org's review settings, environment scoping, and the require-approvals
+// license). Returns false when the base can't be resolved (legacy/missing base)
+// so callers treat it as a no-approval change.
+export async function revisionRequiresReview(
+  context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
   draft: FeatureRevisionInterface,
-): Promise<void> {
-  const { org } = context;
-  const allEnvironments = getEnvironmentIdsFromOrg(org);
+): Promise<boolean> {
+  const allEnvironments = getEnvironmentIdsFromOrg(context.org);
 
   const baseRevision = await getRevision({
     context,
@@ -3121,16 +3123,25 @@ export async function assertCanAutoPublish(
     feature,
     version: draft.baseVersion,
   });
-  if (!baseRevision) return; // can't determine — allow (legacy/missing base)
+  if (!baseRevision) return false;
 
-  const requiresReview = checkIfRevisionNeedsReview({
+  return checkIfRevisionNeedsReview({
     feature,
     baseRevision,
     revision: draft,
     allEnvironments,
-    settings: org.settings,
+    settings: context.org.settings,
     requireApprovalsLicensed: context.hasPremiumFeature("require-approvals"),
   });
+}
+
+// Throws if the draft requires approval and the caller cannot bypass.
+export async function assertCanAutoPublish(
+  context: ReqContext,
+  feature: FeatureInterface,
+  draft: FeatureRevisionInterface,
+): Promise<void> {
+  const requiresReview = await revisionRequiresReview(context, feature, draft);
 
   if (requiresReview && !context.permissions.canBypassApprovalChecks(feature)) {
     context.permissions.throwPermissionError();

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -2079,6 +2079,14 @@ export function revisionToDiffableV2(
     "publishedBy",
     "definitions",
     "reviews",
+    // Scheduling/auto-publish state isn't feature content — excluded so arming,
+    // canceling, or a poller failure doesn't surface as a false diff.
+    "autoPublishOnApproval",
+    "scheduledPublishAt",
+    "scheduledPublishLockEdits",
+    "scheduledPublishLockOthers",
+    "scheduledPublishBypassApproval",
+    "scheduledPublishLastError",
   ]);
   const content: Record<string, unknown> = {};
   for (const [key, val] of Object.entries(api)) {

--- a/packages/front-end/components/Features/FeatureRules.tsx
+++ b/packages/front-end/components/Features/FeatureRules.tsx
@@ -60,9 +60,7 @@ export default function FeatureRules({
   feature: FeatureInterface;
   baseFeature: FeatureInterface;
   isLocked: boolean;
-  // True when isLocked is caused specifically by a pending scheduled publish.
-  // Ramp runtime controls stay interactive in this case (they act on live
-  // runtime state, not the frozen draft content).
+  // `isLocked` is due to a pending scheduled publish; ramp controls stay interactive.
   lockedBySchedule?: boolean;
   canEditDrafts: boolean;
   experimentsMap: Map<string, ExperimentInterfaceStringDates>;

--- a/packages/front-end/components/Features/FeatureRules.tsx
+++ b/packages/front-end/components/Features/FeatureRules.tsx
@@ -40,6 +40,7 @@ export default function FeatureRules({
   environments,
   feature,
   isLocked,
+  lockedBySchedule,
   canEditDrafts,
   experimentsMap,
   mutate,
@@ -59,6 +60,10 @@ export default function FeatureRules({
   feature: FeatureInterface;
   baseFeature: FeatureInterface;
   isLocked: boolean;
+  // True when isLocked is caused specifically by a pending scheduled publish.
+  // Ramp runtime controls stay interactive in this case (they act on live
+  // runtime state, not the frozen draft content).
+  lockedBySchedule?: boolean;
   canEditDrafts: boolean;
   experimentsMap: Map<string, ExperimentInterfaceStringDates>;
   mutate: () => Promise<unknown>;
@@ -485,6 +490,7 @@ export default function FeatureRules({
                 version={currentVersion}
                 setVersion={setVersion}
                 locked={isLocked}
+                lockedBySchedule={lockedBySchedule}
                 experimentsMap={experimentsMap}
                 hideInactive={hideInactive}
                 isDraft={isDraft}
@@ -537,6 +543,7 @@ export default function FeatureRules({
                 version={currentVersion}
                 setVersion={setVersion}
                 locked={isLocked}
+                lockedBySchedule={lockedBySchedule}
                 experimentsMap={experimentsMap}
                 hideInactive={hideInactive}
                 isDraft={isDraft}

--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -480,14 +480,11 @@ export default function FeaturesOverview({
   const projectId = feature.project;
 
   const isDiscarded = revision.status === "discarded";
-  // This draft's content is frozen because it has a pending scheduled publish
-  // with "lock edits" armed (parallel to a ramp-schedule lockdown). Cancel the
-  // schedule to edit. Rebase is still allowed (handled in the publish modal).
+  // Draft frozen by a pending scheduled publish with "lock edits" (parallel to a
+  // ramp lockdown). Rebase is still allowed via the publish modal.
   const editLockedBySchedule =
     isDraft && isRevisionEditLockedBySchedule(revision);
   const scheduledPublishPending = isScheduledPublishPending(revision);
-  // True when the revision's content can't be edited here: an old published
-  // revision, a discarded one, or a draft frozen for a scheduled publish.
   const isReadOnly =
     isDiscarded ||
     (revision.status === "published" && !isLive) ||
@@ -711,10 +708,8 @@ export default function FeaturesOverview({
             isDraft || isPendingReview
               ? scheduledPublishPending
                 ? (() => {
-                    // Scheduled-publish state mirrors a ramp lockdown: amber
-                    // chrome, naming the target date. Locks (and the publish)
-                    // only take effect once the schedule is committed and no
-                    // longer awaiting approval. While in review we say "once
+                    // Mirrors a ramp lockdown, naming the target date. Locks
+                    // engage only once approved; while in review we say "once
                     // approved" and omit the lock clauses (editing stays open).
                     const lockActive = isScheduledPublishLockActive(revision);
                     const awaitingApproval =

--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -20,9 +20,16 @@ import {
   PiPencil,
   PiLockSimple,
   PiProhibit,
+  PiClockFill,
 } from "react-icons/pi";
 import { ago, datetime } from "shared/dates";
-import { filterEnvironmentsByFeature, getReviewSetting } from "shared/util";
+import {
+  filterEnvironmentsByFeature,
+  getReviewSetting,
+  isScheduledPublishPending,
+  isScheduledPublishLockActive,
+  isRevisionEditLockedBySchedule,
+} from "shared/util";
 import { BiHide, BiShow } from "react-icons/bi";
 import Collapsible from "react-collapsible";
 import { ExperimentInterfaceStringDates } from "shared/types/experiment";
@@ -473,9 +480,18 @@ export default function FeaturesOverview({
   const projectId = feature.project;
 
   const isDiscarded = revision.status === "discarded";
-  // True when browsing a read-only historical snapshot: an old published revision or a discarded one.
+  // This draft's content is frozen because it has a pending scheduled publish
+  // with "lock edits" armed (parallel to a ramp-schedule lockdown). Cancel the
+  // schedule to edit. Rebase is still allowed (handled in the publish modal).
+  const editLockedBySchedule =
+    isDraft && isRevisionEditLockedBySchedule(revision);
+  const scheduledPublishPending = isScheduledPublishPending(revision);
+  // True when the revision's content can't be edited here: an old published
+  // revision, a discarded one, or a draft frozen for a scheduled publish.
   const isReadOnly =
-    isDiscarded || (revision.status === "published" && !isLive);
+    isDiscarded ||
+    (revision.status === "published" && !isLive) ||
+    editLockedBySchedule;
 
   const envAndSummaryTooltipNonLiveDisclaimer = !isLive
     ? isDraft
@@ -693,19 +709,60 @@ export default function FeaturesOverview({
         {(() => {
           const bannerProps =
             isDraft || isPendingReview
-              ? {
-                  icon: <PiPencil size={18} />,
-                  color: "var(--amber-11)",
-                  bgColor: "var(--amber-a3)",
-                  message: (
-                    <>
-                      Viewing a <strong>draft</strong> —{" "}
-                      {isPendingReview
-                        ? "changes will not go live until approved and published"
-                        : "changes will not go live until published"}
-                    </>
-                  ),
-                }
+              ? scheduledPublishPending
+                ? (() => {
+                    // Scheduled-publish state mirrors a ramp lockdown: amber
+                    // chrome, naming the target date. Locks (and the publish)
+                    // only take effect once the schedule is committed and no
+                    // longer awaiting approval. While in review we say "once
+                    // approved" and omit the lock clauses (editing stays open).
+                    const lockActive = isScheduledPublishLockActive(revision);
+                    const awaitingApproval =
+                      revision.status === "pending-review" ||
+                      revision.status === "changes-requested";
+                    const lockOthersActive =
+                      lockActive && !!revision.scheduledPublishLockOthers;
+                    const lockClauses = [
+                      editLockedBySchedule ? "edits are locked" : null,
+                      lockOthersActive
+                        ? "publishing other drafts is locked"
+                        : null,
+                    ].filter((c): c is string => c !== null);
+                    return {
+                      icon: lockClauses.length ? (
+                        <PiLockSimple size={18} />
+                      ) : (
+                        <PiClockFill size={18} />
+                      ),
+                      color: "var(--amber-11)",
+                      bgColor: "var(--amber-a3)",
+                      message: (
+                        <>
+                          This <strong>draft</strong> is scheduled to publish on{" "}
+                          <strong>
+                            {datetime(revision.scheduledPublishAt as Date)}
+                          </strong>
+                          {awaitingApproval ? " once approved" : ""}
+                          {lockClauses.length
+                            ? ` — ${lockClauses.join(" and ")}`
+                            : ""}
+                        </>
+                      ),
+                    };
+                  })()
+                : {
+                    icon: <PiPencil size={18} />,
+                    color: "var(--amber-11)",
+                    bgColor: "var(--amber-a3)",
+                    message: (
+                      <>
+                        Viewing a <strong>draft</strong> —{" "}
+                        {isPendingReview
+                          ? "changes will not go live until approved and published"
+                          : "changes will not go live until published"}
+                      </>
+                    ),
+                  }
               : isDiscarded
                 ? {
                     icon: <PiProhibit size={18} />,
@@ -824,7 +881,15 @@ export default function FeaturesOverview({
                       gap="2"
                       style={{ gridColumn: 2 }}
                     >
-                      {bannerProps.icon}
+                      <span
+                        style={{
+                          display: "flex",
+                          flexGrow: 0,
+                          flexShrink: 0,
+                        }}
+                      >
+                        {bannerProps.icon}
+                      </span>
                       <span style={{ fontSize: "var(--font-size-2)" }}>
                         {bannerProps.message}
                       </span>
@@ -1583,6 +1648,7 @@ export default function FeaturesOverview({
                       feature={feature}
                       baseFeature={baseFeature}
                       isLocked={isReadOnly}
+                      lockedBySchedule={editLockedBySchedule}
                       canEditDrafts={canEditDrafts}
                       experimentsMap={experimentsMap}
                       mutate={mutate}

--- a/packages/front-end/components/Features/RevisionDropdown.tsx
+++ b/packages/front-end/components/Features/RevisionDropdown.tsx
@@ -87,9 +87,9 @@ function RevisionRow({
             )}
       </Box>
       {!publishedOnly && (
-        <Box flexShrink="0">
+        <Flex flexShrink="0" align="center" gap="2">
           <RevisionStatusBadge revision={r} liveVersion={liveVersion} />
-        </Box>
+        </Flex>
       )}
     </Flex>
   );
@@ -246,12 +246,12 @@ export default function RevisionDropdown({
         </Text>
       </Box>
       {!publishedOnly && (selectedRevision || !draftsOnly) && (
-        <Box flexShrink="0">
+        <Flex flexShrink="0" align="center" gap="2">
           <RevisionStatusBadge
             revision={selectedRevision}
             liveVersion={liveVersion}
           />
-        </Box>
+        </Flex>
       )}
       <PiCaretDownBold style={{ flexShrink: 0 }} />
     </Flex>

--- a/packages/front-end/components/Features/Rule.tsx
+++ b/packages/front-end/components/Features/Rule.tsx
@@ -208,6 +208,10 @@ interface SortableProps {
   version: number;
   setVersion: (version: number) => void;
   locked: boolean;
+  // True when `locked` is caused specifically by a pending scheduled publish.
+  // Ramp runtime controls (start/pause/resume/advance/rollback/complete) act on
+  // live runtime state, not the frozen draft content, so they stay interactive.
+  lockedBySchedule?: boolean;
   experimentsMap: Map<string, ExperimentInterfaceStringDates>;
   safeRolloutsMap: Map<string, SafeRolloutInterface>;
   hideInactive?: boolean;
@@ -284,6 +288,7 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
       version,
       setVersion,
       locked,
+      lockedBySchedule,
       experimentsMap,
       safeRolloutsMap,
       hideInactive,
@@ -303,6 +308,11 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
     ref,
   ) => {
     const { apiCall } = useAuth();
+
+    // Ramp runtime controls act on live runtime state (the ramp schedule), not
+    // the draft's rule config, so a scheduled-publish edit lock must not disable
+    // them. Other read-only reasons (old/discarded revisions) still do.
+    const rampControlsLocked = locked && !lockedBySchedule;
 
     const allEnvironments = useEnvironments();
     const environments = filterEnvironmentsByFeature(allEnvironments, feature);
@@ -482,7 +492,7 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
 
     if (
       rampSchedule &&
-      !locked &&
+      !rampControlsLocked &&
       !rampIsTerminal &&
       !hasPendingDetach &&
       !isSimpleSchedule &&
@@ -526,7 +536,7 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
       // RampMonitoringCTAs owns the "Approve Step" CTA when the current step is
       // monitored — skip adding it here to avoid a duplicate button.
       const approvalHandledByMonitoringCTAs =
-        !!safeRollout && !locked && isOnMonitoredStep(rampSchedule);
+        !!safeRollout && !rampControlsLocked && isOnMonitoredStep(rampSchedule);
       // Only surface the approval CTA once the step's interval has elapsed —
       // approval is the final gate, so we don't prompt while the timer counts.
       if (
@@ -566,7 +576,7 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
     // dropdown menu. The "Start" CTA above will pick up once it's `ready`.
     if (
       rampSchedule &&
-      !locked &&
+      !rampControlsLocked &&
       !hasPendingDetach &&
       !isSimpleSchedule &&
       !isSyntheticRamp &&
@@ -604,7 +614,11 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
       );
     }
 
-    if (rule.type === "safe-rollout" && !locked && rule.enabled !== false) {
+    if (
+      rule.type === "safe-rollout" &&
+      !rampControlsLocked &&
+      rule.enabled !== false
+    ) {
       ruleCtas.push(
         <DecisionCTA
           key="safe-rollout-decision"
@@ -736,7 +750,7 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
             <Flex align="center" gap="3" flexShrink="0">
               {rampSchedule &&
                 safeRollout &&
-                !locked &&
+                !rampControlsLocked &&
                 isOnMonitoredStep(rampSchedule) && (
                   <RampMonitoringCTAs
                     rampSchedule={rampSchedule}
@@ -770,246 +784,238 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
 
               {info.pill}
 
-              {/* Dropdown Menu */}
-              {canEdit && !locked && (
-                <DropdownMenu
-                  trigger={
-                    <IconButton
-                      variant="ghost"
-                      color="gray"
-                      radius="full"
-                      size="2"
-                      highContrast
-                      style={{ margin: 0 }}
-                    >
-                      <BsThreeDotsVertical size={16} />
-                    </IconButton>
-                  }
-                  open={dropdownOpen}
-                  onOpenChange={setDropdownOpen}
-                  menuPlacement="end"
-                  variant="soft"
-                >
-                  <DropdownMenuGroup>
-                    <DropdownMenuItem
-                      onClick={() => {
-                        setRuleModal({
-                          environment,
-                          i,
-                          ruleId: rule.id,
-                          mode: "edit",
-                        });
-                        setDropdownOpen(false);
-                      }}
-                    >
-                      Edit
-                    </DropdownMenuItem>
-                    {rule.type !== "experiment-ref" && (
-                      <DropdownMenuItem
-                        onClick={() => {
-                          setRuleModal({
-                            environment,
-                            i,
-                            ruleId: rule.id,
-                            mode: "duplicate",
-                          });
-                          setDropdownOpen(false);
-                        }}
+              {/* Dropdown Menu. Shown whenever rule-edit actions OR ramp runtime
+                actions are available. Under a scheduled-publish lock the
+                rule-edit group is hidden, but the ramp/schedule actions (which
+                act on live runtime state) remain. */}
+              {canEdit &&
+                !rampControlsLocked &&
+                (!locked || !!rampSchedule) && (
+                  <DropdownMenu
+                    trigger={
+                      <IconButton
+                        variant="ghost"
+                        color="gray"
+                        radius="full"
+                        size="2"
+                        highContrast
+                        style={{ margin: 0 }}
                       >
-                        Duplicate rule
-                      </DropdownMenuItem>
-                    )}
-                    <DropdownMenuItem
-                      onClick={
-                        !rule.enabled && getRampEnableDate(rampSchedule)
-                          ? undefined
-                          : toggleRuleEnabled
-                      }
-                      confirmation={(() => {
-                        const d = !rule.enabled
-                          ? getRampEnableDate(rampSchedule)
-                          : null;
-                        if (!d) return undefined;
-                        return {
-                          confirmationTitle: "Enable rule now?",
-                          getConfirmationContent: async () =>
-                            `This rule is scheduled to go live on ${fmtScheduleDate(d)}. Enabling now bypasses the schedule and will set the rule live immediately.`,
-                          cta: "Enable now",
-                          ctaColor: "violet",
-                          submit: toggleRuleEnabled,
-                        };
-                      })()}
-                    >
-                      {rule.enabled ? "Disable" : "Enable"}
-                    </DropdownMenuItem>
-                  </DropdownMenuGroup>
-                  {(onMoveUp ||
-                    onMoveDown ||
-                    onMoveToTop ||
-                    onMoveToBottom) && (
-                    <>
-                      <DropdownMenuSeparator />
+                        <BsThreeDotsVertical size={16} />
+                      </IconButton>
+                    }
+                    open={dropdownOpen}
+                    onOpenChange={setDropdownOpen}
+                    menuPlacement="end"
+                    variant="soft"
+                  >
+                    {!locked && (
                       <DropdownMenuGroup>
-                        {onMoveToTop && (
+                        <DropdownMenuItem
+                          onClick={() => {
+                            setRuleModal({
+                              environment,
+                              i,
+                              ruleId: rule.id,
+                              mode: "edit",
+                            });
+                            setDropdownOpen(false);
+                          }}
+                        >
+                          Edit
+                        </DropdownMenuItem>
+                        {rule.type !== "experiment-ref" && (
                           <DropdownMenuItem
                             onClick={() => {
-                              onMoveToTop();
+                              setRuleModal({
+                                environment,
+                                i,
+                                ruleId: rule.id,
+                                mode: "duplicate",
+                              });
                               setDropdownOpen(false);
                             }}
                           >
-                            <PiCaretDoubleUp /> Move to top
+                            Duplicate rule
                           </DropdownMenuItem>
                         )}
                         <DropdownMenuItem
-                          disabled={!onMoveUp}
-                          onClick={() => {
-                            if (onMoveUp) {
-                              onMoveUp();
-                              setDropdownOpen(false);
-                            }
-                          }}
+                          onClick={
+                            !rule.enabled && getRampEnableDate(rampSchedule)
+                              ? undefined
+                              : toggleRuleEnabled
+                          }
+                          confirmation={(() => {
+                            const d = !rule.enabled
+                              ? getRampEnableDate(rampSchedule)
+                              : null;
+                            if (!d) return undefined;
+                            return {
+                              confirmationTitle: "Enable rule now?",
+                              getConfirmationContent: async () =>
+                                `This rule is scheduled to go live on ${fmtScheduleDate(d)}. Enabling now bypasses the schedule and will set the rule live immediately.`,
+                              cta: "Enable now",
+                              ctaColor: "violet",
+                              submit: toggleRuleEnabled,
+                            };
+                          })()}
                         >
-                          <PiCaretUp /> Move up
+                          {rule.enabled ? "Disable" : "Enable"}
                         </DropdownMenuItem>
-                        <DropdownMenuItem
-                          disabled={!onMoveDown}
-                          onClick={() => {
-                            if (onMoveDown) {
-                              onMoveDown();
-                              setDropdownOpen(false);
-                            }
-                          }}
-                        >
-                          <PiCaretDown /> Move down
-                        </DropdownMenuItem>
-                        {onMoveToBottom && (
-                          <DropdownMenuItem
-                            onClick={() => {
-                              onMoveToBottom();
-                              setDropdownOpen(false);
-                            }}
-                          >
-                            <PiCaretDoubleDown /> Move to bottom
-                          </DropdownMenuItem>
-                        )}
                       </DropdownMenuGroup>
-                    </>
-                  )}
-                  {rampSchedule &&
-                    isSimpleSchedule &&
-                    !!rampSchedule.cutoffDate &&
-                    ["running", "paused"].includes(rampSchedule.status) && (
-                      <>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuGroup label="Schedule">
-                          <DropdownMenuItem
-                            onClick={async () => {
-                              await apiCall(
-                                `/ramp-schedule/${rampSchedule.id}/actions/complete`,
-                                { method: "POST" },
-                              );
-                              await mutate();
-                              setDropdownOpen(false);
-                            }}
-                          >
-                            <Flex align="center" gap="2">
-                              <PiFastForward /> Complete schedule and disable
-                            </Flex>
-                          </DropdownMenuItem>
-                        </DropdownMenuGroup>
-                      </>
                     )}
-                  {rampSchedule &&
-                    isSimpleSchedule &&
-                    !!rampSchedule.cutoffDate &&
-                    ["completed", "rolled-back"].includes(
-                      rampSchedule.status,
-                    ) && (
-                      <>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuGroup label="Schedule">
-                          <DropdownMenuItem
-                            onClick={async () => {
-                              const res = await apiCall<{
-                                version: number;
-                              }>(`/feature/${feature.id}/${version}/rule`, {
-                                method: "PUT",
-                                body: JSON.stringify({
-                                  ruleId: rule.id,
-                                  rule,
-                                  rampSchedule: {
-                                    mode: "detach",
-                                    rampScheduleId: rampSchedule.id,
-                                    deleteScheduleWhenEmpty: true,
-                                  },
-                                }),
-                              });
-                              if (res.version) setVersion(res.version);
-                              await mutate();
-                              setDropdownOpen(false);
-                            }}
-                          >
-                            <Flex align="center" gap="2">
-                              <PiTrash /> Remove schedule
-                            </Flex>
-                          </DropdownMenuItem>
-                        </DropdownMenuGroup>
-                      </>
-                    )}
-                  {rampSchedule && !isSimpleSchedule && !isSyntheticRamp && (
-                    <>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuGroup label="Ramp-up schedule">
-                        {hasPendingDetach ? (
-                          /* When removal is pending: cancel it directly via API (no modal) */
-                          <DropdownMenuItem
-                            onClick={async () => {
-                              const res = await apiCall<{
-                                version: number;
-                              }>(`/feature/${feature.id}/${version}/rule`, {
-                                method: "PUT",
-                                body: JSON.stringify({
-                                  ruleId: rule.id,
-                                  rule,
-                                  rampSchedule: { mode: "clear" },
-                                }),
-                              });
-                              if (res.version) setVersion(res.version);
-                              await mutate();
-                              setDropdownOpen(false);
-                            }}
-                          >
-                            Cancel removal of schedule
-                          </DropdownMenuItem>
-                        ) : (
-                          <>
-                            {/* pending: blocked Start */}
-                            {rampSchedule.status === "pending" && (
-                              <Tooltip
-                                tipPosition="left"
-                                body={`Cannot start while ramp is pending.${
-                                  rampSchedule.targets.find(
-                                    (t) => !!t.activatingRevisionVersion,
-                                  )?.activatingRevisionVersion
-                                    ? ` Publish Revision ${rampSchedule.targets.find((t) => !!t.activatingRevisionVersion)?.activatingRevisionVersion} first.`
-                                    : ""
-                                }`}
+                    {!locked &&
+                      (onMoveUp ||
+                        onMoveDown ||
+                        onMoveToTop ||
+                        onMoveToBottom) && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuGroup>
+                            {onMoveToTop && (
+                              <DropdownMenuItem
+                                onClick={() => {
+                                  onMoveToTop();
+                                  setDropdownOpen(false);
+                                }}
                               >
-                                <div style={{ cursor: "not-allowed" }}>
-                                  <DropdownMenuItem disabled>
-                                    <Flex align="center" gap="2">
-                                      <PiPlayFill /> Start now
-                                    </Flex>
-                                  </DropdownMenuItem>
-                                </div>
-                              </Tooltip>
+                                <PiCaretDoubleUp /> Move to top
+                              </DropdownMenuItem>
                             )}
-                            {/* ready: Start now */}
-                            {rampSchedule.status === "ready" &&
-                              (rampSchedule.targets.length === 0 ? (
+                            <DropdownMenuItem
+                              disabled={!onMoveUp}
+                              onClick={() => {
+                                if (onMoveUp) {
+                                  onMoveUp();
+                                  setDropdownOpen(false);
+                                }
+                              }}
+                            >
+                              <PiCaretUp /> Move up
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              disabled={!onMoveDown}
+                              onClick={() => {
+                                if (onMoveDown) {
+                                  onMoveDown();
+                                  setDropdownOpen(false);
+                                }
+                              }}
+                            >
+                              <PiCaretDown /> Move down
+                            </DropdownMenuItem>
+                            {onMoveToBottom && (
+                              <DropdownMenuItem
+                                onClick={() => {
+                                  onMoveToBottom();
+                                  setDropdownOpen(false);
+                                }}
+                              >
+                                <PiCaretDoubleDown /> Move to bottom
+                              </DropdownMenuItem>
+                            )}
+                          </DropdownMenuGroup>
+                        </>
+                      )}
+                    {rampSchedule &&
+                      isSimpleSchedule &&
+                      !!rampSchedule.cutoffDate &&
+                      ["running", "paused"].includes(rampSchedule.status) && (
+                        <>
+                          {!locked && <DropdownMenuSeparator />}
+                          <DropdownMenuGroup label="Schedule">
+                            <DropdownMenuItem
+                              onClick={async () => {
+                                await apiCall(
+                                  `/ramp-schedule/${rampSchedule.id}/actions/complete`,
+                                  { method: "POST" },
+                                );
+                                await mutate();
+                                setDropdownOpen(false);
+                              }}
+                            >
+                              <Flex align="center" gap="2">
+                                <PiFastForward /> Complete schedule and disable
+                              </Flex>
+                            </DropdownMenuItem>
+                          </DropdownMenuGroup>
+                        </>
+                      )}
+                    {rampSchedule &&
+                      isSimpleSchedule &&
+                      !!rampSchedule.cutoffDate &&
+                      ["completed", "rolled-back"].includes(
+                        rampSchedule.status,
+                      ) && (
+                        <>
+                          {!locked && <DropdownMenuSeparator />}
+                          <DropdownMenuGroup label="Schedule">
+                            <DropdownMenuItem
+                              onClick={async () => {
+                                const res = await apiCall<{
+                                  version: number;
+                                }>(`/feature/${feature.id}/${version}/rule`, {
+                                  method: "PUT",
+                                  body: JSON.stringify({
+                                    ruleId: rule.id,
+                                    rule,
+                                    rampSchedule: {
+                                      mode: "detach",
+                                      rampScheduleId: rampSchedule.id,
+                                      deleteScheduleWhenEmpty: true,
+                                    },
+                                  }),
+                                });
+                                if (res.version) setVersion(res.version);
+                                await mutate();
+                                setDropdownOpen(false);
+                              }}
+                            >
+                              <Flex align="center" gap="2">
+                                <PiTrash /> Remove schedule
+                              </Flex>
+                            </DropdownMenuItem>
+                          </DropdownMenuGroup>
+                        </>
+                      )}
+                    {rampSchedule && !isSimpleSchedule && !isSyntheticRamp && (
+                      <>
+                        {!locked && <DropdownMenuSeparator />}
+                        <DropdownMenuGroup label="Ramp-up schedule">
+                          {hasPendingDetach ? (
+                            /* When removal is pending: cancel it directly via API (no modal) */
+                            <DropdownMenuItem
+                              onClick={async () => {
+                                const res = await apiCall<{
+                                  version: number;
+                                }>(`/feature/${feature.id}/${version}/rule`, {
+                                  method: "PUT",
+                                  body: JSON.stringify({
+                                    ruleId: rule.id,
+                                    rule,
+                                    rampSchedule: { mode: "clear" },
+                                  }),
+                                });
+                                if (res.version) setVersion(res.version);
+                                await mutate();
+                                setDropdownOpen(false);
+                              }}
+                            >
+                              Cancel removal of schedule
+                            </DropdownMenuItem>
+                          ) : (
+                            <>
+                              {/* pending: blocked Start */}
+                              {rampSchedule.status === "pending" && (
                                 <Tooltip
-                                  body="No implementations linked"
                                   tipPosition="left"
+                                  body={`Cannot start while ramp is pending.${
+                                    rampSchedule.targets.find(
+                                      (t) => !!t.activatingRevisionVersion,
+                                    )?.activatingRevisionVersion
+                                      ? ` Publish Revision ${rampSchedule.targets.find((t) => !!t.activatingRevisionVersion)?.activatingRevisionVersion} first.`
+                                      : ""
+                                  }`}
                                 >
                                   <div style={{ cursor: "not-allowed" }}>
                                     <DropdownMenuItem disabled>
@@ -1019,105 +1025,159 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
                                     </DropdownMenuItem>
                                   </div>
                                 </Tooltip>
-                              ) : (
-                                <DropdownMenuItem
-                                  onClick={async () => {
-                                    await apiCall(
-                                      `/ramp-schedule/${rampSchedule.id}/actions/start`,
-                                      { method: "POST" },
-                                    );
-                                    await mutate();
-                                    setDropdownOpen(false);
-                                  }}
-                                >
-                                  <Flex align="center" gap="2">
-                                    <PiPlayFill /> Start now
-                                  </Flex>
-                                </DropdownMenuItem>
-                              ))}
-                            {/* Pause */}
-                            {rampSchedule.status === "running" && (
-                              <DropdownMenuItem
-                                onClick={async () => {
-                                  await apiCall(
-                                    `/ramp-schedule/${rampSchedule.id}/actions/pause`,
-                                    { method: "POST" },
-                                  );
-                                  await mutate();
-                                  setDropdownOpen(false);
-                                }}
-                              >
-                                <Flex align="center" gap="2">
-                                  <PiPauseFill /> Pause
-                                </Flex>
-                              </DropdownMenuItem>
-                            )}
-                            {/* Resume */}
-                            {rampSchedule.status === "paused" &&
-                              (rampSchedule.targets.length === 0 ? (
-                                <Tooltip
-                                  body="No implementations linked"
-                                  tipPosition="left"
-                                >
-                                  <div style={{ cursor: "not-allowed" }}>
-                                    <DropdownMenuItem disabled>
-                                      <Flex align="center" gap="2">
-                                        <PiPlayFill /> Resume
-                                      </Flex>
-                                    </DropdownMenuItem>
-                                  </div>
-                                </Tooltip>
-                              ) : (
-                                <DropdownMenuItem
-                                  onClick={async () => {
-                                    await apiCall(
-                                      `/ramp-schedule/${rampSchedule.id}/actions/resume`,
-                                      { method: "POST" },
-                                    );
-                                    await mutate();
-                                    setDropdownOpen(false);
-                                  }}
-                                >
-                                  <Flex align="center" gap="2">
-                                    <PiPlayFill /> Resume
-                                  </Flex>
-                                </DropdownMenuItem>
-                              ))}
-                            {/* Roll back / Jump ahead / Complete — active ramps */}
-                            {["running", "paused"].includes(
-                              rampSchedule.status,
-                            ) && (
-                              <>
-                                {rampSchedule.currentStepIndex >= 0 &&
-                                  (() => {
-                                    const backSteps = rampSchedule.steps
-                                      .map((_, idx) => idx)
-                                      .filter(
-                                        (idx) =>
-                                          idx < rampSchedule.currentStepIndex,
+                              )}
+                              {/* ready: Start now */}
+                              {rampSchedule.status === "ready" &&
+                                (rampSchedule.targets.length === 0 ? (
+                                  <Tooltip
+                                    body="No implementations linked"
+                                    tipPosition="left"
+                                  >
+                                    <div style={{ cursor: "not-allowed" }}>
+                                      <DropdownMenuItem disabled>
+                                        <Flex align="center" gap="2">
+                                          <PiPlayFill /> Start now
+                                        </Flex>
+                                      </DropdownMenuItem>
+                                    </div>
+                                  </Tooltip>
+                                ) : (
+                                  <DropdownMenuItem
+                                    onClick={async () => {
+                                      await apiCall(
+                                        `/ramp-schedule/${rampSchedule.id}/actions/start`,
+                                        { method: "POST" },
                                       );
-                                    return (
-                                      <DropdownSubMenu
-                                        trigger={
-                                          <Flex align="center" gap="2">
-                                            <PiArrowUUpLeft /> Roll back to
-                                          </Flex>
-                                        }
-                                      >
-                                        <DropdownMenuItem
-                                          onClick={async () => {
-                                            await rollbackToStart();
-                                            setDropdownOpen(false);
-                                          }}
+                                      await mutate();
+                                      setDropdownOpen(false);
+                                    }}
+                                  >
+                                    <Flex align="center" gap="2">
+                                      <PiPlayFill /> Start now
+                                    </Flex>
+                                  </DropdownMenuItem>
+                                ))}
+                              {/* Pause */}
+                              {rampSchedule.status === "running" && (
+                                <DropdownMenuItem
+                                  onClick={async () => {
+                                    await apiCall(
+                                      `/ramp-schedule/${rampSchedule.id}/actions/pause`,
+                                      { method: "POST" },
+                                    );
+                                    await mutate();
+                                    setDropdownOpen(false);
+                                  }}
+                                >
+                                  <Flex align="center" gap="2">
+                                    <PiPauseFill /> Pause
+                                  </Flex>
+                                </DropdownMenuItem>
+                              )}
+                              {/* Resume */}
+                              {rampSchedule.status === "paused" &&
+                                (rampSchedule.targets.length === 0 ? (
+                                  <Tooltip
+                                    body="No implementations linked"
+                                    tipPosition="left"
+                                  >
+                                    <div style={{ cursor: "not-allowed" }}>
+                                      <DropdownMenuItem disabled>
+                                        <Flex align="center" gap="2">
+                                          <PiPlayFill /> Resume
+                                        </Flex>
+                                      </DropdownMenuItem>
+                                    </div>
+                                  </Tooltip>
+                                ) : (
+                                  <DropdownMenuItem
+                                    onClick={async () => {
+                                      await apiCall(
+                                        `/ramp-schedule/${rampSchedule.id}/actions/resume`,
+                                        { method: "POST" },
+                                      );
+                                      await mutate();
+                                      setDropdownOpen(false);
+                                    }}
+                                  >
+                                    <Flex align="center" gap="2">
+                                      <PiPlayFill /> Resume
+                                    </Flex>
+                                  </DropdownMenuItem>
+                                ))}
+                              {/* Roll back / Jump ahead / Complete — active ramps */}
+                              {["running", "paused"].includes(
+                                rampSchedule.status,
+                              ) && (
+                                <>
+                                  {rampSchedule.currentStepIndex >= 0 &&
+                                    (() => {
+                                      const backSteps = rampSchedule.steps
+                                        .map((_, idx) => idx)
+                                        .filter(
+                                          (idx) =>
+                                            idx < rampSchedule.currentStepIndex,
+                                        );
+                                      return (
+                                        <DropdownSubMenu
+                                          trigger={
+                                            <Flex align="center" gap="2">
+                                              <PiArrowUUpLeft /> Roll back to
+                                            </Flex>
+                                          }
                                         >
-                                          <Flex align="center" gap="2">
-                                            <PiRewind /> Start
-                                          </Flex>
-                                        </DropdownMenuItem>
-                                        {backSteps.length > 0 && (
-                                          <DropdownMenuSeparator />
-                                        )}
-                                        {backSteps.map((stepIdx) => (
+                                          <DropdownMenuItem
+                                            onClick={async () => {
+                                              await rollbackToStart();
+                                              setDropdownOpen(false);
+                                            }}
+                                          >
+                                            <Flex align="center" gap="2">
+                                              <PiRewind /> Start
+                                            </Flex>
+                                          </DropdownMenuItem>
+                                          {backSteps.length > 0 && (
+                                            <DropdownMenuSeparator />
+                                          )}
+                                          {backSteps.map((stepIdx) => (
+                                            <DropdownMenuItem
+                                              key={stepIdx}
+                                              onClick={async () => {
+                                                await apiCall(
+                                                  `/ramp-schedule/${rampSchedule.id}/actions/jump`,
+                                                  {
+                                                    method: "POST",
+                                                    body: JSON.stringify({
+                                                      targetStepIndex: stepIdx,
+                                                    }),
+                                                  },
+                                                );
+                                                await mutate();
+                                                setDropdownOpen(false);
+                                              }}
+                                            >
+                                              Step {stepIdx + 1}
+                                            </DropdownMenuItem>
+                                          ))}
+                                        </DropdownSubMenu>
+                                      );
+                                    })()}
+                                  {rampSchedule.currentStepIndex <
+                                    rampSchedule.steps.length - 1 && (
+                                    <DropdownSubMenu
+                                      trigger={
+                                        <Flex align="center" gap="2">
+                                          <PiArrowUUpRight /> Jump ahead to
+                                        </Flex>
+                                      }
+                                    >
+                                      {rampSchedule.steps
+                                        .map((_, idx) => idx)
+                                        .filter(
+                                          (idx) =>
+                                            idx > rampSchedule.currentStepIndex,
+                                        )
+                                        .map((stepIdx) => (
                                           <DropdownMenuItem
                                             key={stepIdx}
                                             onClick={async () => {
@@ -1137,183 +1197,147 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
                                             Step {stepIdx + 1}
                                           </DropdownMenuItem>
                                         ))}
-                                      </DropdownSubMenu>
+                                    </DropdownSubMenu>
+                                  )}
+                                  {(() => {
+                                    const hasCutoff = !!rampSchedule.cutoffDate;
+                                    const allStepsDone =
+                                      rampSchedule.currentStepIndex >=
+                                      rampSchedule.steps.length;
+                                    return (
+                                      <>
+                                        {!allStepsDone && (
+                                          <DropdownMenuItem
+                                            onClick={async () => {
+                                              await apiCall(
+                                                `/ramp-schedule/${rampSchedule.id}/actions/complete`,
+                                                { method: "POST" },
+                                              );
+                                              await mutate();
+                                              setDropdownOpen(false);
+                                            }}
+                                          >
+                                            <Flex align="center" gap="2">
+                                              <PiFastForward /> Complete ramp
+                                            </Flex>
+                                          </DropdownMenuItem>
+                                        )}
+                                        {hasCutoff && (
+                                          <DropdownMenuItem
+                                            onClick={async () => {
+                                              await apiCall(
+                                                `/ramp-schedule/${rampSchedule.id}/actions/complete`,
+                                                {
+                                                  method: "POST",
+                                                  body: JSON.stringify({
+                                                    disableRule: true,
+                                                  }),
+                                                },
+                                              );
+                                              await mutate();
+                                              setDropdownOpen(false);
+                                            }}
+                                          >
+                                            <Flex align="center" gap="2">
+                                              <PiFastForward /> Complete ramp
+                                              and disable rule
+                                            </Flex>
+                                          </DropdownMenuItem>
+                                        )}
+                                      </>
                                     );
                                   })()}
-                                {rampSchedule.currentStepIndex <
-                                  rampSchedule.steps.length - 1 && (
-                                  <DropdownSubMenu
-                                    trigger={
+                                </>
+                              )}
+                              {/* Restart / Remove — terminal states */}
+                              {rampIsTerminal && (
+                                <>
+                                  {rampSchedule.cutoffDate &&
+                                  new Date(rampSchedule.cutoffDate) <=
+                                    new Date() ? (
+                                    <Tooltip
+                                      tipPosition="left"
+                                      body="The scheduled end date has already passed. Edit the schedule to remove or update the end date before restarting."
+                                    >
+                                      <div style={{ cursor: "not-allowed" }}>
+                                        <DropdownMenuItem disabled>
+                                          <Flex align="center" gap="2">
+                                            <PiRewind /> Restart ramp
+                                          </Flex>
+                                        </DropdownMenuItem>
+                                      </div>
+                                    </Tooltip>
+                                  ) : (
+                                    <DropdownMenuItem
+                                      onClick={async () => {
+                                        await apiCall(
+                                          `/ramp-schedule/${rampSchedule.id}/actions/restart`,
+                                          { method: "POST" },
+                                        );
+                                        await mutate();
+                                        setDropdownOpen(false);
+                                      }}
+                                    >
                                       <Flex align="center" gap="2">
-                                        <PiArrowUUpRight /> Jump ahead to
+                                        <PiRewind /> Restart ramp
                                       </Flex>
-                                    }
-                                  >
-                                    {rampSchedule.steps
-                                      .map((_, idx) => idx)
-                                      .filter(
-                                        (idx) =>
-                                          idx > rampSchedule.currentStepIndex,
-                                      )
-                                      .map((stepIdx) => (
-                                        <DropdownMenuItem
-                                          key={stepIdx}
-                                          onClick={async () => {
-                                            await apiCall(
-                                              `/ramp-schedule/${rampSchedule.id}/actions/jump`,
-                                              {
-                                                method: "POST",
-                                                body: JSON.stringify({
-                                                  targetStepIndex: stepIdx,
-                                                }),
-                                              },
-                                            );
-                                            await mutate();
-                                            setDropdownOpen(false);
-                                          }}
-                                        >
-                                          Step {stepIdx + 1}
-                                        </DropdownMenuItem>
-                                      ))}
-                                  </DropdownSubMenu>
-                                )}
-                                {(() => {
-                                  const hasCutoff = !!rampSchedule.cutoffDate;
-                                  const allStepsDone =
-                                    rampSchedule.currentStepIndex >=
-                                    rampSchedule.steps.length;
-                                  return (
-                                    <>
-                                      {!allStepsDone && (
-                                        <DropdownMenuItem
-                                          onClick={async () => {
-                                            await apiCall(
-                                              `/ramp-schedule/${rampSchedule.id}/actions/complete`,
-                                              { method: "POST" },
-                                            );
-                                            await mutate();
-                                            setDropdownOpen(false);
-                                          }}
-                                        >
-                                          <Flex align="center" gap="2">
-                                            <PiFastForward /> Complete ramp
-                                          </Flex>
-                                        </DropdownMenuItem>
-                                      )}
-                                      {hasCutoff && (
-                                        <DropdownMenuItem
-                                          onClick={async () => {
-                                            await apiCall(
-                                              `/ramp-schedule/${rampSchedule.id}/actions/complete`,
-                                              {
-                                                method: "POST",
-                                                body: JSON.stringify({
-                                                  disableRule: true,
-                                                }),
-                                              },
-                                            );
-                                            await mutate();
-                                            setDropdownOpen(false);
-                                          }}
-                                        >
-                                          <Flex align="center" gap="2">
-                                            <PiFastForward /> Complete ramp and
-                                            disable rule
-                                          </Flex>
-                                        </DropdownMenuItem>
-                                      )}
-                                    </>
-                                  );
-                                })()}
-                              </>
-                            )}
-                            {/* Restart / Remove — terminal states */}
-                            {rampIsTerminal && (
-                              <>
-                                {rampSchedule.cutoffDate &&
-                                new Date(rampSchedule.cutoffDate) <=
-                                  new Date() ? (
-                                  <Tooltip
-                                    tipPosition="left"
-                                    body="The scheduled end date has already passed. Edit the schedule to remove or update the end date before restarting."
-                                  >
-                                    <div style={{ cursor: "not-allowed" }}>
-                                      <DropdownMenuItem disabled>
-                                        <Flex align="center" gap="2">
-                                          <PiRewind /> Restart ramp
-                                        </Flex>
-                                      </DropdownMenuItem>
-                                    </div>
-                                  </Tooltip>
-                                ) : (
+                                    </DropdownMenuItem>
+                                  )}
                                   <DropdownMenuItem
                                     onClick={async () => {
-                                      await apiCall(
-                                        `/ramp-schedule/${rampSchedule.id}/actions/restart`,
-                                        { method: "POST" },
+                                      const res = await apiCall<{
+                                        version: number;
+                                      }>(
+                                        `/feature/${feature.id}/${version}/rule`,
+                                        {
+                                          method: "PUT",
+                                          body: JSON.stringify({
+                                            ruleId: rule.id,
+                                            rule,
+                                            rampSchedule: {
+                                              mode: "detach",
+                                              rampScheduleId: rampSchedule.id,
+                                              deleteScheduleWhenEmpty: true,
+                                            },
+                                          }),
+                                        },
                                       );
+                                      if (res.version) setVersion(res.version);
                                       await mutate();
                                       setDropdownOpen(false);
                                     }}
                                   >
                                     <Flex align="center" gap="2">
-                                      <PiRewind /> Restart ramp
+                                      <PiTrash /> Remove schedule
                                     </Flex>
                                   </DropdownMenuItem>
-                                )}
-                                <DropdownMenuItem
-                                  onClick={async () => {
-                                    const res = await apiCall<{
-                                      version: number;
-                                    }>(
-                                      `/feature/${feature.id}/${version}/rule`,
-                                      {
-                                        method: "PUT",
-                                        body: JSON.stringify({
-                                          ruleId: rule.id,
-                                          rule,
-                                          rampSchedule: {
-                                            mode: "detach",
-                                            rampScheduleId: rampSchedule.id,
-                                            deleteScheduleWhenEmpty: true,
-                                          },
-                                        }),
-                                      },
-                                    );
-                                    if (res.version) setVersion(res.version);
-                                    await mutate();
-                                    setDropdownOpen(false);
-                                  }}
-                                >
-                                  <Flex align="center" gap="2">
-                                    <PiTrash /> Remove schedule
-                                  </Flex>
-                                </DropdownMenuItem>
-                              </>
-                            )}
-                          </>
-                        )}
+                                </>
+                              )}
+                            </>
+                          )}
+                        </DropdownMenuGroup>
+                      </>
+                    )}
+                    {!locked && (
+                      <DropdownMenuGroup>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          color="red"
+                          onClick={() => {
+                            setDeleteMode(
+                              defaultDraft !== null ? "existing" : "new",
+                            );
+                            setDeleteSelectedDraft(defaultDraft);
+                            setShowDeleteRuleModal(true);
+                            setDropdownOpen(false);
+                          }}
+                        >
+                          Delete rule
+                        </DropdownMenuItem>
                       </DropdownMenuGroup>
-                    </>
-                  )}
-                  <DropdownMenuGroup>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      color="red"
-                      onClick={() => {
-                        setDeleteMode(
-                          defaultDraft !== null ? "existing" : "new",
-                        );
-                        setDeleteSelectedDraft(defaultDraft);
-                        setShowDeleteRuleModal(true);
-                        setDropdownOpen(false);
-                      }}
-                    >
-                      Delete rule
-                    </DropdownMenuItem>
-                  </DropdownMenuGroup>
-                </DropdownMenu>
-              )}
+                    )}
+                  </DropdownMenu>
+                )}
             </Flex>
           </Flex>
           <Box>{info.callout}</Box>

--- a/packages/front-end/components/Features/Rule.tsx
+++ b/packages/front-end/components/Features/Rule.tsx
@@ -208,9 +208,8 @@ interface SortableProps {
   version: number;
   setVersion: (version: number) => void;
   locked: boolean;
-  // True when `locked` is caused specifically by a pending scheduled publish.
-  // Ramp runtime controls (start/pause/resume/advance/rollback/complete) act on
-  // live runtime state, not the frozen draft content, so they stay interactive.
+  // `locked` is caused by a pending scheduled publish. Ramp runtime controls act
+  // on live state, not draft content, so they stay interactive.
   lockedBySchedule?: boolean;
   experimentsMap: Map<string, ExperimentInterfaceStringDates>;
   safeRolloutsMap: Map<string, SafeRolloutInterface>;
@@ -309,9 +308,8 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
   ) => {
     const { apiCall } = useAuth();
 
-    // Ramp runtime controls act on live runtime state (the ramp schedule), not
-    // the draft's rule config, so a scheduled-publish edit lock must not disable
-    // them. Other read-only reasons (old/discarded revisions) still do.
+    // A scheduled-publish edit lock leaves ramp runtime controls interactive;
+    // other lock reasons (old/discarded revisions) still disable them.
     const rampControlsLocked = locked && !lockedBySchedule;
 
     const allEnvironments = useEnvironments();
@@ -784,10 +782,9 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
 
               {info.pill}
 
-              {/* Dropdown Menu. Shown whenever rule-edit actions OR ramp runtime
-                actions are available. Under a scheduled-publish lock the
-                rule-edit group is hidden, but the ramp/schedule actions (which
-                act on live runtime state) remain. */}
+              {/* Shown when rule-edit OR ramp runtime actions are available.
+                Under a scheduled-publish lock the rule-edit group is hidden but
+                ramp/schedule actions remain. */}
               {canEdit &&
                 !rampControlsLocked &&
                 (!locked || !!rampSchedule) && (
@@ -941,14 +938,15 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
                           </DropdownMenuGroup>
                         </>
                       )}
-                    {rampSchedule &&
+                    {!locked &&
+                      rampSchedule &&
                       isSimpleSchedule &&
                       !!rampSchedule.cutoffDate &&
                       ["completed", "rolled-back"].includes(
                         rampSchedule.status,
                       ) && (
                         <>
-                          {!locked && <DropdownMenuSeparator />}
+                          <DropdownMenuSeparator />
                           <DropdownMenuGroup label="Schedule">
                             <DropdownMenuItem
                               onClick={async () => {
@@ -983,26 +981,29 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
                         {!locked && <DropdownMenuSeparator />}
                         <DropdownMenuGroup label="Ramp-up schedule">
                           {hasPendingDetach ? (
-                            /* When removal is pending: cancel it directly via API (no modal) */
-                            <DropdownMenuItem
-                              onClick={async () => {
-                                const res = await apiCall<{
-                                  version: number;
-                                }>(`/feature/${feature.id}/${version}/rule`, {
-                                  method: "PUT",
-                                  body: JSON.stringify({
-                                    ruleId: rule.id,
-                                    rule,
-                                    rampSchedule: { mode: "clear" },
-                                  }),
-                                });
-                                if (res.version) setVersion(res.version);
-                                await mutate();
-                                setDropdownOpen(false);
-                              }}
-                            >
-                              Cancel removal of schedule
-                            </DropdownMenuItem>
+                            // Canceling a pending removal edits the draft, so it's
+                            // gated by the edit-lock; runtime actions below are not.
+                            !locked && (
+                              <DropdownMenuItem
+                                onClick={async () => {
+                                  const res = await apiCall<{
+                                    version: number;
+                                  }>(`/feature/${feature.id}/${version}/rule`, {
+                                    method: "PUT",
+                                    body: JSON.stringify({
+                                      ruleId: rule.id,
+                                      rule,
+                                      rampSchedule: { mode: "clear" },
+                                    }),
+                                  });
+                                  if (res.version) setVersion(res.version);
+                                  await mutate();
+                                  setDropdownOpen(false);
+                                }}
+                              >
+                                Cancel removal of schedule
+                              </DropdownMenuItem>
+                            )
                           ) : (
                             <>
                               {/* pending: blocked Start */}
@@ -1283,34 +1284,37 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
                                       </Flex>
                                     </DropdownMenuItem>
                                   )}
-                                  <DropdownMenuItem
-                                    onClick={async () => {
-                                      const res = await apiCall<{
-                                        version: number;
-                                      }>(
-                                        `/feature/${feature.id}/${version}/rule`,
-                                        {
-                                          method: "PUT",
-                                          body: JSON.stringify({
-                                            ruleId: rule.id,
-                                            rule,
-                                            rampSchedule: {
-                                              mode: "detach",
-                                              rampScheduleId: rampSchedule.id,
-                                              deleteScheduleWhenEmpty: true,
-                                            },
-                                          }),
-                                        },
-                                      );
-                                      if (res.version) setVersion(res.version);
-                                      await mutate();
-                                      setDropdownOpen(false);
-                                    }}
-                                  >
-                                    <Flex align="center" gap="2">
-                                      <PiTrash /> Remove schedule
-                                    </Flex>
-                                  </DropdownMenuItem>
+                                  {!locked && (
+                                    <DropdownMenuItem
+                                      onClick={async () => {
+                                        const res = await apiCall<{
+                                          version: number;
+                                        }>(
+                                          `/feature/${feature.id}/${version}/rule`,
+                                          {
+                                            method: "PUT",
+                                            body: JSON.stringify({
+                                              ruleId: rule.id,
+                                              rule,
+                                              rampSchedule: {
+                                                mode: "detach",
+                                                rampScheduleId: rampSchedule.id,
+                                                deleteScheduleWhenEmpty: true,
+                                              },
+                                            }),
+                                          },
+                                        );
+                                        if (res.version)
+                                          setVersion(res.version);
+                                        await mutate();
+                                        setDropdownOpen(false);
+                                      }}
+                                    >
+                                      <Flex align="center" gap="2">
+                                        <PiTrash /> Remove schedule
+                                      </Flex>
+                                    </DropdownMenuItem>
+                                  )}
                                 </>
                               )}
                             </>

--- a/packages/front-end/components/Features/RuleList.tsx
+++ b/packages/front-end/components/Features/RuleList.tsx
@@ -54,8 +54,7 @@ type CommonProps = {
   version: number;
   setVersion: (version: number) => void;
   locked: boolean;
-  // True when `locked` is caused specifically by a pending scheduled publish.
-  // Ramp runtime controls remain interactive in this case.
+  // `locked` is due to a pending scheduled publish; ramp controls stay interactive.
   lockedBySchedule?: boolean;
   experimentsMap: Map<string, ExperimentInterfaceStringDates>;
   hideInactive?: boolean;

--- a/packages/front-end/components/Features/RuleList.tsx
+++ b/packages/front-end/components/Features/RuleList.tsx
@@ -54,6 +54,9 @@ type CommonProps = {
   version: number;
   setVersion: (version: number) => void;
   locked: boolean;
+  // True when `locked` is caused specifically by a pending scheduled publish.
+  // Ramp runtime controls remain interactive in this case.
+  lockedBySchedule?: boolean;
   experimentsMap: Map<string, ExperimentInterfaceStringDates>;
   hideInactive?: boolean;
   isDraft: boolean;
@@ -91,6 +94,7 @@ export default function RuleList(props: RuleListProps) {
     version,
     setVersion,
     locked,
+    lockedBySchedule,
     experimentsMap,
     hideInactive,
     isDraft,
@@ -326,6 +330,7 @@ export default function RuleList(props: RuleListProps) {
                 version={version}
                 setVersion={setVersion}
                 locked={locked}
+                lockedBySchedule={lockedBySchedule}
                 experimentsMap={experimentsMap}
                 hideInactive={hideInactive}
                 isDraft={isDraft}
@@ -375,6 +380,7 @@ export default function RuleList(props: RuleListProps) {
               version={version}
               setVersion={setVersion}
               locked={locked}
+              lockedBySchedule={lockedBySchedule}
               experimentsMap={experimentsMap}
               hideInactive={hideInactive}
               unreachable={isUnreachable(

--- a/packages/front-end/components/Reviews/DivergenceNotice.tsx
+++ b/packages/front-end/components/Reviews/DivergenceNotice.tsx
@@ -1,10 +1,8 @@
-import { Box, Flex } from "@radix-ui/themes";
-import { ReactNode } from "react";
 import { formatDistanceToNow } from "date-fns";
 import { PiGitMergeBold, PiWarningOctagonBold } from "react-icons/pi";
 import type { PublishGovernanceResult } from "shared/util";
 import Button from "@/ui/Button";
-import Text from "@/ui/Text";
+import NoticeBanner from "@/components/Reviews/NoticeBanner";
 
 export interface DivergenceNoticeProps {
   governance: PublishGovernanceResult;
@@ -25,63 +23,6 @@ export interface DivergenceNoticeProps {
   // legacy approvals that predate the tracking.
   approvedAt?: string | Date | null;
   revisionsSinceApproval?: number | null;
-}
-
-// GitHub-style banner ("This branch is out-of-date with the base branch"):
-// neutral panel, tinted icon disk, bold title with a muted one-line body,
-// and a right-aligned secondary action that wraps below in narrow columns.
-function NoticeBanner({
-  icon,
-  iconColor,
-  title,
-  body,
-  action,
-}: {
-  icon: ReactNode;
-  iconColor: string;
-  title: string;
-  body: string;
-  action?: ReactNode;
-}) {
-  return (
-    <Flex
-      gap="3"
-      align="start"
-      wrap="wrap"
-      p="3"
-      mb="3"
-      style={{
-        background: "var(--color-panel-solid)",
-        border: "1px solid var(--gray-a6)",
-        borderRadius: "var(--radius-3)",
-      }}
-    >
-      <Flex
-        align="center"
-        justify="center"
-        flexShrink="0"
-        style={{
-          width: 28,
-          height: 28,
-          borderRadius: "50%",
-          background: `var(--${iconColor}-a3)`,
-          color: `var(--${iconColor}-11)`,
-          fontSize: 15,
-        }}
-      >
-        {icon}
-      </Flex>
-      <Box flexGrow="1" style={{ minWidth: 0, flexBasis: 180 }}>
-        <Text as="div" size="medium" weight="semibold">
-          {title}
-        </Text>
-        <Text as="div" size="small" color="text-low">
-          {body}
-        </Text>
-      </Box>
-      {action && <Box ml="auto">{action}</Box>}
-    </Flex>
-  );
 }
 
 // Surfaces governance signals in the publish/review flow. Three distinct

--- a/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
+++ b/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
@@ -632,12 +632,13 @@ export default function ReviewAndPublish({
 
   // The revision loads asynchronously and changes on every mutation, so re-sync
   // the unified arming UI whenever the persisted arming changes. Keyed on the
-  // persisted values (not object identity) so an in-progress, not-yet-saved edit
-  // isn't clobbered by an unrelated revision mutation.
+  // persisted field VALUES (not the revision object identity) so an in-progress,
+  // not-yet-saved edit isn't clobbered when an auto-save's mutate() returns a new
+  // revision object whose values match what we already have. Depending on object
+  // identity here caused every checkbox to flicker on each toggle.
   useEffect(() => {
-    const scheduled = !!revision && isScheduledPublishPending(revision);
     setAutoPublishArmed(!!revision?.autoPublishOnApproval);
-    setPublishMode(scheduled ? "date" : "approve");
+    setPublishMode(scheduledPending ? "date" : "approve");
     setScheduleDate(
       revision?.scheduledPublishAt
         ? new Date(revision.scheduledPublishAt).toISOString()
@@ -646,12 +647,11 @@ export default function ReviewAndPublish({
     setScheduleLockEdits(!!revision?.scheduledPublishLockEdits);
     setScheduleLockOthers(!!revision?.scheduledPublishLockOthers);
   }, [
-    revision,
     revision?.autoPublishOnApproval,
     revision?.scheduledPublishAt,
     revision?.scheduledPublishLockEdits,
     revision?.scheduledPublishLockOthers,
-    revision?.version,
+    scheduledPending,
   ]);
 
   // Collapse back to the read-only schedule summary when switching revisions.
@@ -801,53 +801,42 @@ export default function ReviewAndPublish({
   const isReviewRequester =
     !!userId && !!reviewRequesterId && userId === reviewRequesterId;
 
-  // The arming control (auto-publish checkbox + mode dropdown) is only editable
-  // by whoever owns the draft / review request — the same rule main uses for the
-  // auto-publish-on-approval toggle. Reviewers and other viewers see a read-only
-  // summary of what's armed (and nothing when it isn't).
+  // Only the draft / review-request owner can edit the arming; others see a
+  // read-only summary when armed (matching main's auto-publish-on-approval rule).
   const isArmingOwner =
     permissionsUtil.canPublishFeature(feature, envIds) &&
     (revision?.status === "draft" || isReviewRequester);
   const hasScheduledRevisions = hasCommercialFeature("scheduled-revisions");
-  // "when approved" mode additionally needs the org's auto-publish setting and
-  // only makes sense before approval — once approved there's no future approval
-  // event to wait for, so arming "when approved" would just publish now (which
-  // the Publish button already does). Approved revisions only offer "on a date".
+  // "when approved" only makes sense before approval — once approved it would
+  // just publish now (which Publish already does), so approved revisions only
+  // offer "on a date".
   const canArmWhenApproved =
     autopublishOnApproval && isArmingOwner && revision?.status !== "approved";
   const canArmOnDate = isArmingOwner;
-  // The "when approved" mode requires that capability; otherwise force "date".
   const effectivePublishMode: "approve" | "date" = canArmWhenApproved
     ? publishMode
     : "date";
 
   const canManageAutoPublish = canArmWhenApproved || canArmOnDate;
-  // Reviewers / non-managers always see the read-only summary when armed.
   const showAutoPublishReadonly =
     revisionAutoPublishArmed && !canManageAutoPublish;
-  // Owners/admins get the editable controls only while configuring a fresh
-  // schedule or after explicitly hitting "Change". Once a schedule is armed they
-  // default to the same read-only summary (with Cancel + Change), guarding
-  // against accidental edits to a committed schedule.
+  // The read-only card (with Cancel + Change) is reserved for a dated schedule,
+  // guarding against accidental edits. "Auto-publish when approved" is just a
+  // toggle, so owners keep the plain editable checkbox.
   const showAutoPublishEditable =
-    canManageAutoPublish && (!revisionAutoPublishArmed || editingSchedule);
+    canManageAutoPublish && (!scheduledPending || editingSchedule);
   const showManagerScheduleReadonly =
-    canManageAutoPublish && revisionAutoPublishArmed && !editingSchedule;
-  // A schedule that has "started" (armed on an approved revision) can be
-  // canceled by anyone with publish authority, sending it back to plain
-  // approved — even if they aren't the arming owner.
+    canManageAutoPublish && scheduledPending && !editingSchedule;
+  // A schedule on an approved revision can be canceled by anyone with publish
+  // authority, even if they aren't the arming owner.
   const canCancelStartedSchedule =
     scheduledPending &&
     revision?.status === "approved" &&
     !canManageAutoPublish &&
     permissionsUtil.canPublishFeature(feature, envIds);
 
-  // A single, self-contained status card for an armed publish. Used by both the
-  // reviewer view and the owner/admin "armed" view so they read identically.
-  // Replaces the old disabled-checkbox-as-status presentation (and the now-
-  // redundant disabled "Publish scheduled" button) with one cohesive block:
-  // status icon + headline + date/lock detail, then optional Change / Cancel
-  // actions. `onChange`/`onCancel` are omitted for viewers without authority.
+  // Status card for a dated schedule. Used by both reviewer and owner views so
+  // they read identically; onChange/onCancel are omitted for viewers.
   const renderScheduleCard = ({
     onChange,
     onCancel,
@@ -855,14 +844,13 @@ export default function ReviewAndPublish({
     onChange?: () => void;
     onCancel?: () => void;
   }) => {
-    if (!revision) return null;
-    const hasDate = scheduledPending && !!revision.scheduledPublishAt;
-    // Locks (and the publish) only take effect once approved; until then the
-    // schedule is armed but its effects are pending.
+    if (!revision || !scheduledPending || !revision.scheduledPublishAt)
+      return null;
+    // Locks take effect only once approved; until then they're pending.
     const lockActive = isScheduledPublishLockActive(revision);
     const lockEdits = !!revision.scheduledPublishLockEdits;
     const lockOthers = !!revision.scheduledPublishLockOthers;
-    const hasLocks = hasDate && (lockEdits || lockOthers);
+    const hasLocks = lockEdits || lockOthers;
     const lockTargets =
       lockOthers && lockEdits
         ? "feature and draft"
@@ -873,24 +861,28 @@ export default function ReviewAndPublish({
       <NoticeBanner
         icon={<PiClockFill />}
         iconColor="violet"
-        title={
-          hasDate ? "Scheduled to publish" : "Auto-publishes when approved"
-        }
+        title="Scheduled to publish"
         body={
-          hasDate ? (
-            <>
-              {format(new Date(revision.scheduledPublishAt as Date), "PPp")}
-              {lockActive ? "" : " · pending approval"}
-            </>
-          ) : undefined
+          <>
+            {format(new Date(revision.scheduledPublishAt as Date), "PPp")}
+            {lockActive ? "" : " · pending approval"}
+          </>
         }
         footer={
-          hasLocks ? (
-            <HelperText status="warning" size="sm" icon={<PiLock />} mt="2">
-              {lockActive ? "Locks " : "Will lock "}
-              {lockTargets}
-            </HelperText>
-          ) : undefined
+          <>
+            {hasLocks && (
+              <HelperText status="warning" size="sm" icon={<PiLock />} mt="2">
+                {lockActive ? "Locks " : "Will lock "}
+                {lockTargets}
+              </HelperText>
+            )}
+            {revision.scheduledPublishLastError && (
+              <HelperText status="error" size="sm" mt="2">
+                Publish is stuck and keeps retrying:{" "}
+                {revision.scheduledPublishLastError}
+              </HelperText>
+            )}
+          </>
         }
         action={
           onChange || onCancel ? (
@@ -1820,10 +1812,8 @@ export default function ReviewAndPublish({
     }
   };
 
-  // Persist the deferred-publish schedule. Called automatically whenever the
-  // author changes the date or a lock toggle, so the full armed state is always
-  // saved to the revision (and thus visible read-only to reviewers) — no
-  // separate "save" step that could be skipped.
+  // Persist the schedule. Called on every date/lock change (no separate save
+  // step), so the full armed state is always saved and visible to reviewers.
   const persistSchedule = async (
     date: string,
     lockEdits: boolean,
@@ -1852,11 +1842,9 @@ export default function ReviewAndPublish({
     }
   };
 
-  // While a review-required draft is still a draft we only stage the schedule
-  // locally and arm it when the author clicks "Request Review" (matching how
-  // main stages auto-publish). Once review is pending (or later), edits persist
-  // instantly. For no-approval changes there's no review step, so committing the
-  // schedule on the draft is the arming action — persist it immediately.
+  // A review-required draft stages the schedule locally and arms it on "Request
+  // Review". Otherwise (review pending/later, or no-approval changes) it persists
+  // immediately.
   const schedulePersistsImmediately =
     revision?.status !== "draft" || !requireReviews;
 
@@ -1902,8 +1890,7 @@ export default function ReviewAndPublish({
     }
   };
 
-  // Unified "Automatically publish" checkbox. Arming uses the mode currently
-  // chosen in the always-visible dropdown.
+  // Arming uses the mode currently chosen in the dropdown.
   const doSetAutoPublishArmed = async (armed: boolean) => {
     setScheduleError(null);
     if (!armed) {
@@ -1916,14 +1903,11 @@ export default function ReviewAndPublish({
       }
       return;
     }
-    // Keep the editable controls open while the owner configures a freshly armed
-    // schedule (otherwise immediate-persist flows would collapse mid-edit).
+    // Keep the editable controls open while configuring a freshly armed schedule.
     setEditingSchedule(true);
     if (effectivePublishMode === "approve") {
       await doToggleAutoPublish(true);
     } else {
-      // Date mode: persist immediately if a date is already chosen (and we're
-      // past the draft stage). Drafts stage locally and arm on Request Review.
       setPublishMode("date");
       setAutoPublishArmed(true);
       if (scheduleDate && schedulePersistsImmediately) {
@@ -1936,18 +1920,15 @@ export default function ReviewAndPublish({
     }
   };
 
-  // Switch between the two mutually exclusive arming modes. When the revision
-  // isn't armed yet this only records the preference; it persists once armed.
+  // Switch arming modes. When not yet armed this only records the preference.
   const doSetPublishMode = async (mode: "approve" | "date") => {
     setScheduleError(null);
     setPublishMode(mode);
     if (!autoPublishArmed) return;
     if (mode === "approve") {
-      // Converting to "when approved" clears any pending date and arms approve.
       if (scheduledPending) await doClearSchedule();
       await doToggleAutoPublish(true);
     } else if (scheduleDate && schedulePersistsImmediately) {
-      // Converting to "date" with a date already chosen persists it now.
       await persistSchedule(
         scheduleDate,
         scheduleLockEdits,
@@ -2478,14 +2459,27 @@ export default function ReviewAndPublish({
           renderExperimentSelection()}
 
         <Box mt="6">
-          {/* Read-only arming summary for reviewers / non-managers. Shows what
-              the arming will do (nothing when unarmed). A started schedule on an
-              approved revision can still be canceled by any publisher. */}
+          {/* Read-only arming summary for reviewers / non-managers. A started
+              schedule on an approved revision can still be canceled by any
+              publisher. */}
           {showAutoPublishReadonly &&
             revision &&
-            renderScheduleCard({
-              onCancel: canCancelStartedSchedule ? doClearSchedule : undefined,
-            })}
+            (scheduledPending ? (
+              renderScheduleCard({
+                onCancel: canCancelStartedSchedule
+                  ? doClearSchedule
+                  : undefined,
+              })
+            ) : (
+              // "When approved" is just a toggle — show a disabled checkbox.
+              <Checkbox
+                label="Automatically publish when approved"
+                weight="regular"
+                disabled
+                value={true}
+                setValue={() => {}}
+              />
+            ))}
 
           {/* Submit review — reviewer action, opens the comment/decision popover */}
           {canReview && isPendingReview && !approved && (
@@ -2542,11 +2536,9 @@ export default function ReviewAndPublish({
 
             const continueLabel = "Continue to Publish →";
 
-            // What's blocking publish right now (raw, ignoring adminPublish so
-            // the block is still visible while the checkbox is unchecked). The
-            // button label never changes — the surrounding context (status
-            // header, divergence notice, conflict callout) explains why it's
-            // disabled. `overridable` gates the admin-bypass checkbox.
+            // What's blocking publish (ignoring adminPublish so it stays visible
+            // while the checkbox is unchecked). `overridable` gates the
+            // admin-bypass checkbox.
             type BlockInfo = { overridable: boolean } | null;
             const blockInfo: BlockInfo = (() => {
               if (!mergeResult.success) return { overridable: false };
@@ -2569,10 +2561,8 @@ export default function ReviewAndPublish({
               return null;
             })();
 
-            // A live schedule blocks publishing now — the schedule must be
-            // canceled first so there's a single, explicit path back to
-            // "approved" before a manual publish. Admin bypass overrides this:
-            // it force-publishes now regardless of the pending schedule.
+            // A pending schedule must be canceled before a manual publish (one
+            // explicit path back to "approved"). Admin bypass overrides this.
             const scheduleBlocksPublish = scheduledPending && !adminPublish;
             const publishEnabled =
               state.submitAction === "publish" &&
@@ -2611,11 +2601,9 @@ export default function ReviewAndPublish({
               adminCanBypassNow;
 
             {
-              /* Unified auto-publish arming: one checkbox + a mode selector.
-                 "when approved" and "on a specific date" are the two values of
-                 the same armed state (autoPublishOnApproval + scheduledPublishAt),
-                 so they're mutually exclusive. Rendered just above the primary CTA
-                 (Publish, or Request Review for drafts) so it reads as related. */
+              /* Unified auto-publish arming: one checkbox + a mode selector
+                 ("when approved" vs "on a specific date" are mutually exclusive),
+                 rendered just above the primary CTA so it reads as related. */
             }
             const autoPublishArming = showAutoPublishEditable ? (
               <Box mb="3">
@@ -2704,17 +2692,14 @@ export default function ReviewAndPublish({
                         {scheduleError}
                       </Callout>
                     )}
-                    {/* No "Cancel schedule" button here — unchecking
-                      "Automatically publish" above cancels the schedule (and
-                      resets the checkbox). When not editing, the read-only
-                      summary below carries the Cancel + Change actions. */}
+                    {/* Unchecking "Automatically publish" cancels the schedule;
+                      the read-only card below carries Cancel + Change. */}
                   </Box>
                 )}
               </Box>
             ) : showManagerScheduleReadonly && revision ? (
-              // Armed + not editing: owners/admins see the same status card
-              // reviewers do, plus actions to cancel or re-open the editor
-              // (guards against accidental edits to a committed schedule).
+              // Armed + not editing: owners see the read-only card with Cancel
+              // and Change (guards against accidental edits).
               renderScheduleCard({
                 onChange: () => setEditingSchedule(true),
                 onCancel: () => doSetAutoPublishArmed(false),

--- a/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
+++ b/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
@@ -2625,6 +2625,7 @@ export default function ReviewAndPublish({
                     <SelectField
                       containerClassName="select-dropdown-underline mb-0"
                       value={effectivePublishMode}
+                      disabled={savingSchedule}
                       isSearchable={false}
                       sort={false}
                       containerStyles={{

--- a/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
+++ b/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
@@ -1818,8 +1818,8 @@ export default function ReviewAndPublish({
     date: string,
     lockEdits: boolean,
     lockOthers: boolean,
-  ) => {
-    if (!date || !revision) return;
+  ): Promise<boolean> => {
+    if (!date || !revision) return false;
     setScheduleError(null);
     setSavingSchedule(true);
     try {
@@ -1835,8 +1835,10 @@ export default function ReviewAndPublish({
         },
       );
       await mutate();
+      return true;
     } catch (e) {
       setScheduleError(e.message || "Could not schedule publish");
+      return false;
     } finally {
       setSavingSchedule(false);
     }
@@ -1910,12 +1912,18 @@ export default function ReviewAndPublish({
     } else {
       setPublishMode("date");
       setAutoPublishArmed(true);
+      // Revert the optimistic check if the immediate save fails, so the box
+      // doesn't read as armed when nothing was persisted.
       if (scheduleDate && schedulePersistsImmediately) {
-        await persistSchedule(
+        const ok = await persistSchedule(
           scheduleDate,
           scheduleLockEdits,
           scheduleLockOthers,
         );
+        if (!ok) {
+          setAutoPublishArmed(false);
+          setEditingSchedule(false);
+        }
       }
     }
   };
@@ -2162,6 +2170,50 @@ export default function ReviewAndPublish({
       Are you sure you want to discard this draft? This action cannot be undone.
     </ModalStandard>
   ) : null;
+
+  // Hoisted out of the footer render so the read-only schedule card (shown to
+  // reviewers/non-managers) can tell whether the arming control will already
+  // render it below the rebase/divergence notice — and avoid showing it twice.
+  // Step actions precede publish (Request Review / Submit Review / Next).
+  const isStepAction =
+    state.hasSubmit &&
+    state.submitAction !== "publish" &&
+    state.submitAction !== "none" &&
+    state.submitAction !== "next-experiments";
+  const continueToPublish =
+    state.submitAction === "next-experiments" && !experimentsStep;
+
+  // What's blocking publish (ignoring adminPublish so it stays visible while the
+  // checkbox is unchecked). `overridable` gates the admin-bypass checkbox.
+  type BlockInfo = { overridable: boolean } | null;
+  const blockInfo: BlockInfo = (() => {
+    if (!mergeResult.success) return { overridable: false };
+    if (!hasChanges) return { overridable: false };
+    if (!hasPublishPermission) return { overridable: false };
+    if (
+      requireReviews &&
+      !adminPublish &&
+      ["draft", "pending-review", "changes-requested"].includes(revision.status)
+    )
+      return { overridable: true };
+    if (!adminPublish && !governance?.canPublish) return { overridable: true };
+    if (!adminPublish && featureLockedByRamp) return { overridable: true };
+    if (!adminPublish && featureLockedBySchedule) return { overridable: true };
+    return null;
+  })();
+
+  // Publish section (divider, admin-bypass, Publish button) is hidden for
+  // not-yet-approved drafts unless an admin can bypass.
+  const adminCanBypassNow =
+    canAdminPublish &&
+    mergeResult.success &&
+    (blockInfo?.overridable || adminPublish);
+  const showPublishSection =
+    state.submitAction === "publish" || continueToPublish || adminCanBypassNow;
+  // The arming control (and thus a dated schedule card) renders in either the
+  // step block or the publish section. When neither shows, the read-only card
+  // falls back to the summary block above.
+  const armingRendersBelow = isStepAction || showPublishSection;
 
   // Hard merge conflicts no longer short-circuit the page: keep the
   // two-column layout so reviewers can still see draft-vs-live changes
@@ -2459,12 +2511,14 @@ export default function ReviewAndPublish({
           renderExperimentSelection()}
 
         <Box mt="6">
-          {/* Read-only arming summary for reviewers / non-managers. A started
-              schedule on an approved revision can still be canceled by any
-              publisher. */}
+          {/* Read-only arming summary for reviewers / non-managers. The dated
+              schedule card renders with the arming control below the rebase
+              notice when a publish/step section exists; here it's only a
+              fallback for when neither section is shown (e.g. pending review). */}
           {showAutoPublishReadonly &&
             revision &&
             (scheduledPending ? (
+              !armingRendersBelow &&
               renderScheduleCard({
                 onCancel: canCancelStartedSchedule
                   ? doClearSchedule
@@ -2527,45 +2581,7 @@ export default function ReviewAndPublish({
           )}
 
           {(() => {
-            // Step actions that come before publish (Request Review, Submit
-            // Review, Next). Not gated on conflict state — requesting a review
-            // is allowed while conflicts exist; only publishing is blocked.
-            const isStepAction =
-              state.hasSubmit &&
-              state.submitAction !== "publish" &&
-              state.submitAction !== "none" &&
-              // Pre-launch checklist uses the publish footer CTA instead.
-              state.submitAction !== "next-experiments";
-
-            const continueToPublish =
-              state.submitAction === "next-experiments" && !experimentsStep;
-
             const continueLabel = "Continue to Publish →";
-
-            // What's blocking publish (ignoring adminPublish so it stays visible
-            // while the checkbox is unchecked). `overridable` gates the
-            // admin-bypass checkbox.
-            type BlockInfo = { overridable: boolean } | null;
-            const blockInfo: BlockInfo = (() => {
-              if (!mergeResult.success) return { overridable: false };
-              if (!hasChanges) return { overridable: false };
-              if (!hasPublishPermission) return { overridable: false };
-              if (
-                requireReviews &&
-                !adminPublish &&
-                ["draft", "pending-review", "changes-requested"].includes(
-                  revision.status,
-                )
-              )
-                return { overridable: true };
-              if (!adminPublish && !governance?.canPublish)
-                return { overridable: true };
-              if (!adminPublish && featureLockedByRamp)
-                return { overridable: true };
-              if (!adminPublish && featureLockedBySchedule)
-                return { overridable: true };
-              return null;
-            })();
 
             // A pending schedule must be canceled before a manual publish (one
             // explicit path back to "approved"). Admin bypass overrides this.
@@ -2593,18 +2609,6 @@ export default function ReviewAndPublish({
                 : onlyScheduledSelected
                   ? "Schedule to Start"
                   : "Publish";
-
-            // Hide the publish section (divider, admin-bypass checkbox, Publish
-            // button) for not-yet-approved drafts — unless an admin can bypass
-            // checks. There, Request Review is the only relevant action.
-            const adminCanBypassNow =
-              canAdminPublish &&
-              mergeResult.success &&
-              (blockInfo?.overridable || adminPublish);
-            const showPublishSection =
-              state.submitAction === "publish" ||
-              continueToPublish ||
-              adminCanBypassNow;
 
             {
               /* Unified auto-publish arming: one checkbox + a mode selector
@@ -2710,6 +2714,15 @@ export default function ReviewAndPublish({
               renderScheduleCard({
                 onChange: () => setEditingSchedule(true),
                 onCancel: () => doSetAutoPublishArmed(false),
+              })
+            ) : showAutoPublishReadonly && revision && scheduledPending ? (
+              // Reviewers / non-managers: read-only card in the same spot as the
+              // owner's (below the rebase notice), cancelable only on a started
+              // schedule by anyone with publish authority.
+              renderScheduleCard({
+                onCancel: canCancelStartedSchedule
+                  ? doClearSchedule
+                  : undefined,
               })
             ) : null;
 

--- a/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
+++ b/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
@@ -40,7 +40,6 @@ import {
   PiGitMergeBold,
   PiCaretDownBold,
   PiHourglassHighFill,
-  PiInfo,
 } from "react-icons/pi";
 import { BsThreeDotsVertical } from "react-icons/bs";
 import { Box, Flex, IconButton } from "@radix-ui/themes";
@@ -617,12 +616,21 @@ export default function ReviewAndPublish({
       ? new Date(revision.scheduledPublishAt).toISOString()
       : "",
   );
-  const [scheduleLockEdits, setScheduleLockEdits] = useState(
-    !!revision?.scheduledPublishLockEdits,
+  // The two underlying locks are surfaced as one checkbox + a scope selector
+  // (mirrors the "Automatically publish [mode]" control). The scope is its own
+  // state so the selector works even while the checkbox is off — picking a
+  // scope then only records the preference. lockEdits = enabled; lockOthers =
+  // enabled && scope === "feature" (feature scope is the superset).
+  const [scheduleLockEnabled, setScheduleLockEnabled] = useState(
+    !!revision?.scheduledPublishLockEdits ||
+      !!revision?.scheduledPublishLockOthers,
   );
-  const [scheduleLockOthers, setScheduleLockOthers] = useState(
-    !!revision?.scheduledPublishLockOthers,
-  );
+  const [scheduleLockScope, setScheduleLockScope] = useState<
+    "draft" | "feature"
+  >(revision?.scheduledPublishLockOthers ? "feature" : "draft");
+  const scheduleLockEdits = scheduleLockEnabled;
+  const scheduleLockOthers =
+    scheduleLockEnabled && scheduleLockScope === "feature";
   // Admin-only: dangerously arm the scheduled publish so it fires without the
   // normal approval. Distinct from the "publish now" admin bypass — this one
   // belongs to the schedule and is what gets persisted as scheduledPublishBypassApproval.
@@ -650,8 +658,13 @@ export default function ReviewAndPublish({
         ? new Date(revision.scheduledPublishAt).toISOString()
         : "",
     );
-    setScheduleLockEdits(!!revision?.scheduledPublishLockEdits);
-    setScheduleLockOthers(!!revision?.scheduledPublishLockOthers);
+    setScheduleLockEnabled(
+      !!revision?.scheduledPublishLockEdits ||
+        !!revision?.scheduledPublishLockOthers,
+    );
+    setScheduleLockScope(
+      revision?.scheduledPublishLockOthers ? "feature" : "draft",
+    );
     setScheduleBypassApproval(!!revision?.scheduledPublishBypassApproval);
   }, [
     revision?.autoPublishOnApproval,
@@ -1911,26 +1924,23 @@ export default function ReviewAndPublish({
     }
   };
 
-  // The two underlying locks are surfaced as one checkbox + a scope selector:
-  // off → no locks; "this draft" → freeze this draft's edits; "this feature" →
-  // freeze this draft's edits AND block publishing other drafts (superset).
-  const scheduleLocked = scheduleLockEdits || scheduleLockOthers;
-  const scheduleLockScope: "draft" | "feature" = scheduleLockOthers
-    ? "feature"
-    : "draft";
-
-  const applyScheduleLock = (lockEdits: boolean, lockOthers: boolean) => {
-    setScheduleLockEdits(lockEdits);
-    setScheduleLockOthers(lockOthers);
-    persistCurrentSchedule(lockEdits, lockOthers, scheduleBypassApproval);
+  const onScheduleLockToggle = (value: boolean) => {
+    setScheduleLockEnabled(value);
+    persistCurrentSchedule(
+      value,
+      value && scheduleLockScope === "feature",
+      scheduleBypassApproval,
+    );
   };
 
-  const onScheduleLockToggle = (value: boolean) =>
-    // Enabling defaults to draft scope; toggling off clears both.
-    applyScheduleLock(value, value ? scheduleLockOthers : false);
-
-  const onScheduleLockScopeChange = (scope: "draft" | "feature") =>
-    applyScheduleLock(true, scope === "feature");
+  const onScheduleLockScopeChange = (scope: "draft" | "feature") => {
+    setScheduleLockScope(scope);
+    // Mirror the publish-mode selector: changing scope while the lock is off
+    // only records the preference; it doesn't enable the lock.
+    if (scheduleLockEnabled) {
+      persistCurrentSchedule(true, scope === "feature", scheduleBypassApproval);
+    }
+  };
 
   const onScheduleBypassChange = (value: boolean) => {
     setScheduleBypassApproval(value);
@@ -2759,13 +2769,13 @@ export default function ReviewAndPublish({
                           <Checkbox
                             label="Lock edits to"
                             weight="regular"
-                            value={scheduleLocked}
+                            value={scheduleLockEnabled}
                             setValue={(v) => onScheduleLockToggle(!!v)}
                           />
                           <SelectField
                             containerClassName="select-dropdown-underline mb-0"
                             value={scheduleLockScope}
-                            disabled={!scheduleLocked || savingSchedule}
+                            disabled={savingSchedule}
                             isSearchable={false}
                             sort={false}
                             containerStyles={{
@@ -2773,8 +2783,8 @@ export default function ReviewAndPublish({
                               singleValue: (s) => ({ ...s, fontSize: 14 }),
                             }}
                             options={[
-                              { label: "this draft", value: "draft" },
                               { label: "this feature", value: "feature" },
+                              { label: "this draft", value: "draft" },
                             ]}
                             onChange={(v) =>
                               onScheduleLockScopeChange(
@@ -2782,13 +2792,6 @@ export default function ReviewAndPublish({
                               )
                             }
                           />
-                          <Text size="medium">while running</Text>
-                          <Tooltip content='"this draft" freezes content edits to the scheduled draft. "this feature" also blocks publishing other drafts of this feature until the schedule fires or is canceled.'>
-                            <PiInfo
-                              color="var(--color-text-low)"
-                              className="ml-1"
-                            />
-                          </Tooltip>
                         </Flex>
                         {canBypassScheduleApproval && (
                           <Box mt="2">

--- a/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
+++ b/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
@@ -812,7 +812,11 @@ export default function ReviewAndPublish({
   // offer "on a date".
   const canArmWhenApproved =
     autopublishOnApproval && isArmingOwner && revision?.status !== "approved";
-  const canArmOnDate = isArmingOwner;
+  // Arming/editing a dated schedule needs only publish authority — not draft /
+  // review-request ownership — matching the backend `canScheduleFeaturePublish`
+  // gate, so a reviewer with publish permission can manage the schedule from the
+  // UI. The premium (`scheduled-revisions`) gate is applied at render.
+  const canArmOnDate = permissionsUtil.canPublishFeature(feature, envIds);
   const effectivePublishMode: "approve" | "date" = canArmWhenApproved
     ? publishMode
     : "date";
@@ -827,13 +831,6 @@ export default function ReviewAndPublish({
     canManageAutoPublish && (!scheduledPending || editingSchedule);
   const showManagerScheduleReadonly =
     canManageAutoPublish && scheduledPending && !editingSchedule;
-  // A schedule on an approved revision can be canceled by anyone with publish
-  // authority, even if they aren't the arming owner.
-  const canCancelStartedSchedule =
-    scheduledPending &&
-    revision?.status === "approved" &&
-    !canManageAutoPublish &&
-    permissionsUtil.canPublishFeature(feature, envIds);
 
   // Status card for a dated schedule. Used by both reviewer and owner views so
   // they read identically; onChange/onCancel are omitted for viewers.
@@ -2518,12 +2515,7 @@ export default function ReviewAndPublish({
           {showAutoPublishReadonly &&
             revision &&
             (scheduledPending ? (
-              !armingRendersBelow &&
-              renderScheduleCard({
-                onCancel: canCancelStartedSchedule
-                  ? doClearSchedule
-                  : undefined,
-              })
+              !armingRendersBelow && renderScheduleCard({})
             ) : (
               // "When approved" is just a toggle — show a disabled checkbox.
               <Checkbox
@@ -2716,14 +2708,9 @@ export default function ReviewAndPublish({
                 onCancel: () => doSetAutoPublishArmed(false),
               })
             ) : showAutoPublishReadonly && revision && scheduledPending ? (
-              // Reviewers / non-managers: read-only card in the same spot as the
-              // owner's (below the rebase notice), cancelable only on a started
-              // schedule by anyone with publish authority.
-              renderScheduleCard({
-                onCancel: canCancelStartedSchedule
-                  ? doClearSchedule
-                  : undefined,
-              })
+              // Viewers without publish authority: read-only card in the same
+              // spot as the owner's (below the rebase notice), no Cancel/Change.
+              renderScheduleCard({})
             ) : null;
 
             return (

--- a/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
+++ b/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
@@ -21,6 +21,9 @@ import {
   checkIfRevisionNeedsReview,
   evaluatePublishGovernance,
   getLiveChangesSinceBase,
+  isScheduledPublishPending,
+  isScheduledPublishLockActive,
+  findPublishLockingScheduledRevision,
   MergeStrategy,
 } from "shared/util";
 import {
@@ -31,10 +34,13 @@ import { ExperimentInterfaceStringDates } from "shared/types/experiment";
 import { FaArrowLeft } from "react-icons/fa";
 import {
   PiLockSimple,
+  PiLock,
+  PiClockFill,
   PiGitDiff,
   PiGitMergeBold,
   PiCaretDownBold,
   PiHourglassHighFill,
+  PiInfo,
 } from "react-icons/pi";
 import { BsThreeDotsVertical } from "react-icons/bs";
 import { Box, Flex, IconButton } from "@radix-ui/themes";
@@ -72,6 +78,8 @@ import {
 import ModalStandard from "@/ui/Modal/Patterns/ModalStandard";
 import Button from "@/ui/Button";
 import Text from "@/ui/Text";
+import DatePicker from "@/components/DatePicker";
+import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
 import Tooltip from "@/ui/Tooltip";
 import Heading from "@/ui/Heading";
 import Avatar from "@/ui/Avatar";
@@ -85,6 +93,7 @@ import RevisionStatusBadge, {
 } from "@/components/Reviews/RevisionStatusBadge";
 import Callout from "@/ui/Callout";
 import Checkbox from "@/ui/Checkbox";
+import SelectField from "@/components/Forms/SelectField";
 import { useHoldouts } from "@/hooks/useHoldouts";
 import { PreLaunchChecklistForDraftFeature } from "@/components/PreLaunchChecklist/PreLaunchChecklist";
 import { COMPACT_DIFF_STYLES } from "@/components/AuditHistoryExplorer/CompareAuditEventsUtils";
@@ -109,6 +118,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/ui/Tabs";
 // view (JSON diffs, full edit timeline, inline diff comments).
 type ReviewSubTab = "overview" | "changes";
 import DivergenceNotice from "@/components/Reviews/DivergenceNotice";
+import NoticeBanner from "@/components/Reviews/NoticeBanner";
 import HelperText from "@/ui/HelperText";
 import Metadata from "@/ui/Metadata";
 import ReviewCommentPopover from "@/components/Reviews/ReviewCommentPopover";
@@ -576,8 +586,15 @@ export default function ReviewAndPublish({
   // persists directly to the API and mutates the revision.
   const comment = revision?.comment || "";
   const [adminPublish, setAdminPublish] = useState(false);
-  const [requestAutoPublish, setRequestAutoPublish] = useState(
+  // ── Unified auto-publish arming ──
+  // A revision is "armed" (autoPublishOnApproval) in one of two mutually
+  // exclusive modes: publish "when approved" (no date) or "on a specific date"
+  // (scheduledPublishAt). The UI is a single checkbox plus a mode selector.
+  const [autoPublishArmed, setAutoPublishArmed] = useState(
     !!revision?.autoPublishOnApproval,
+  );
+  const [publishMode, setPublishMode] = useState<"approve" | "date">(
+    revision && isScheduledPublishPending(revision) ? "date" : "approve",
   );
   const [rebasing, setRebasing] = useState(false);
   const [experimentsStep, setExperimentsStep] = useState(false);
@@ -593,14 +610,56 @@ export default function ReviewAndPublish({
   const doSubmitRef = useRef<() => void>(() => {});
   const revisionLogRef = useRef<MutateLog>(null);
 
-  // The revision loads asynchronously, so the initial useState above can be
-  // stale (e.g. unchecked on reload of an armed draft). Re-sync whenever the
-  // persisted value or version changes. Keyed on the persisted boolean (not
-  // object identity) so it won't clobber an unsaved draft toggle, which doesn't
-  // change revision.autoPublishOnApproval.
+  // ── Scheduled (deferred) publish ──
+  const scheduledPending = !!revision && isScheduledPublishPending(revision);
+  const [scheduleDate, setScheduleDate] = useState<string>(
+    revision?.scheduledPublishAt
+      ? new Date(revision.scheduledPublishAt).toISOString()
+      : "",
+  );
+  const [scheduleLockEdits, setScheduleLockEdits] = useState(
+    !!revision?.scheduledPublishLockEdits,
+  );
+  const [scheduleLockOthers, setScheduleLockOthers] = useState(
+    !!revision?.scheduledPublishLockOthers,
+  );
+  const [savingSchedule, setSavingSchedule] = useState(false);
+  const [scheduleError, setScheduleError] = useState<string | null>(null);
+  // Once a schedule is armed (persisted), owners/admins see a read-only summary
+  // (parity with reviewers) to avoid accidental edits. "Change" flips this on to
+  // reveal the editable controls; canceling/unarming flips it back off.
+  const [editingSchedule, setEditingSchedule] = useState(false);
+
+  // The revision loads asynchronously and changes on every mutation, so re-sync
+  // the unified arming UI whenever the persisted arming changes. Keyed on the
+  // persisted values (not object identity) so an in-progress, not-yet-saved edit
+  // isn't clobbered by an unrelated revision mutation.
   useEffect(() => {
-    setRequestAutoPublish(!!revision?.autoPublishOnApproval);
-  }, [revision?.autoPublishOnApproval, revision?.version]);
+    const scheduled = !!revision && isScheduledPublishPending(revision);
+    setAutoPublishArmed(!!revision?.autoPublishOnApproval);
+    setPublishMode(scheduled ? "date" : "approve");
+    setScheduleDate(
+      revision?.scheduledPublishAt
+        ? new Date(revision.scheduledPublishAt).toISOString()
+        : "",
+    );
+    setScheduleLockEdits(!!revision?.scheduledPublishLockEdits);
+    setScheduleLockOthers(!!revision?.scheduledPublishLockOthers);
+  }, [
+    revision,
+    revision?.autoPublishOnApproval,
+    revision?.scheduledPublishAt,
+    revision?.scheduledPublishLockEdits,
+    revision?.scheduledPublishLockOthers,
+    revision?.version,
+  ]);
+
+  // Collapse back to the read-only schedule summary when switching revisions.
+  // Keyed on version only (not every mutation) so an in-progress edit isn't
+  // collapsed when an auto-saved schedule change re-fetches the revision.
+  useEffect(() => {
+    setEditingSchedule(false);
+  }, [revision?.version]);
 
   // ── Sub-tabs ──
   // "Overview" (human-readable changes + review activity) vs "Changes" (JSON
@@ -705,6 +764,14 @@ export default function ReviewAndPublish({
     rampSchedules?.some(
       (rs) => rs.lockdownConfig?.mode === "locked" && rs.status === "running",
     ) ?? false;
+  // Parallel to the ramp lock: another draft of this feature has a pending
+  // scheduled publish that locks publishing of other drafts. Blocks publishing
+  // THIS revision (the scheduled sibling is excluded so it can still publish).
+  const lockingScheduledSibling = findPublishLockingScheduledRevision(
+    revisions,
+    revision?.version,
+  );
+  const featureLockedBySchedule = !!lockingScheduledSibling;
 
   const isPendingReview =
     revision?.status === "pending-review" ||
@@ -733,12 +800,126 @@ export default function ReviewAndPublish({
 
   const isReviewRequester =
     !!userId && !!reviewRequesterId && userId === reviewRequesterId;
-  const canToggleAutoPublish =
-    autopublishOnApproval &&
+
+  // The arming control (auto-publish checkbox + mode dropdown) is only editable
+  // by whoever owns the draft / review request — the same rule main uses for the
+  // auto-publish-on-approval toggle. Reviewers and other viewers see a read-only
+  // summary of what's armed (and nothing when it isn't).
+  const isArmingOwner =
     permissionsUtil.canPublishFeature(feature, envIds) &&
     (revision?.status === "draft" || isReviewRequester);
+  const hasScheduledRevisions = hasCommercialFeature("scheduled-revisions");
+  // "when approved" mode additionally needs the org's auto-publish setting and
+  // only makes sense before approval — once approved there's no future approval
+  // event to wait for, so arming "when approved" would just publish now (which
+  // the Publish button already does). Approved revisions only offer "on a date".
+  const canArmWhenApproved =
+    autopublishOnApproval && isArmingOwner && revision?.status !== "approved";
+  const canArmOnDate = isArmingOwner;
+  // The "when approved" mode requires that capability; otherwise force "date".
+  const effectivePublishMode: "approve" | "date" = canArmWhenApproved
+    ? publishMode
+    : "date";
+
+  const canManageAutoPublish = canArmWhenApproved || canArmOnDate;
+  // Reviewers / non-managers always see the read-only summary when armed.
   const showAutoPublishReadonly =
-    autopublishOnApproval && revisionAutoPublishArmed && !canToggleAutoPublish;
+    revisionAutoPublishArmed && !canManageAutoPublish;
+  // Owners/admins get the editable controls only while configuring a fresh
+  // schedule or after explicitly hitting "Change". Once a schedule is armed they
+  // default to the same read-only summary (with Cancel + Change), guarding
+  // against accidental edits to a committed schedule.
+  const showAutoPublishEditable =
+    canManageAutoPublish && (!revisionAutoPublishArmed || editingSchedule);
+  const showManagerScheduleReadonly =
+    canManageAutoPublish && revisionAutoPublishArmed && !editingSchedule;
+  // A schedule that has "started" (armed on an approved revision) can be
+  // canceled by anyone with publish authority, sending it back to plain
+  // approved — even if they aren't the arming owner.
+  const canCancelStartedSchedule =
+    scheduledPending &&
+    revision?.status === "approved" &&
+    !canManageAutoPublish &&
+    permissionsUtil.canPublishFeature(feature, envIds);
+
+  // A single, self-contained status card for an armed publish. Used by both the
+  // reviewer view and the owner/admin "armed" view so they read identically.
+  // Replaces the old disabled-checkbox-as-status presentation (and the now-
+  // redundant disabled "Publish scheduled" button) with one cohesive block:
+  // status icon + headline + date/lock detail, then optional Change / Cancel
+  // actions. `onChange`/`onCancel` are omitted for viewers without authority.
+  const renderScheduleCard = ({
+    onChange,
+    onCancel,
+  }: {
+    onChange?: () => void;
+    onCancel?: () => void;
+  }) => {
+    if (!revision) return null;
+    const hasDate = scheduledPending && !!revision.scheduledPublishAt;
+    // Locks (and the publish) only take effect once approved; until then the
+    // schedule is armed but its effects are pending.
+    const lockActive = isScheduledPublishLockActive(revision);
+    const lockEdits = !!revision.scheduledPublishLockEdits;
+    const lockOthers = !!revision.scheduledPublishLockOthers;
+    const hasLocks = hasDate && (lockEdits || lockOthers);
+    const lockTargets =
+      lockOthers && lockEdits
+        ? "feature and draft"
+        : lockOthers
+          ? "feature"
+          : "draft";
+    return (
+      <NoticeBanner
+        icon={<PiClockFill />}
+        iconColor="violet"
+        title={
+          hasDate ? "Scheduled to publish" : "Auto-publishes when approved"
+        }
+        body={
+          hasDate ? (
+            <>
+              {format(new Date(revision.scheduledPublishAt as Date), "PPp")}
+              {lockActive ? "" : " · pending approval"}
+            </>
+          ) : undefined
+        }
+        footer={
+          hasLocks ? (
+            <HelperText status="warning" size="sm" icon={<PiLock />} mt="2">
+              {lockActive ? "Locks " : "Will lock "}
+              {lockTargets}
+            </HelperText>
+          ) : undefined
+        }
+        action={
+          onChange || onCancel ? (
+            <Flex gap="3" align="center">
+              {onCancel && (
+                <Button
+                  variant="ghost"
+                  color="red"
+                  disabled={savingSchedule}
+                  onClick={onCancel}
+                >
+                  Cancel schedule
+                </Button>
+              )}
+              {onChange && (
+                <Button
+                  variant="outline"
+                  disabled={savingSchedule}
+                  onClick={onChange}
+                >
+                  Change
+                </Button>
+              )}
+            </Flex>
+          ) : undefined
+        }
+      />
+    );
+  };
 
   const liveChanges = useMemo(() => {
     if (!liveRevision || !baseRevision) return [];
@@ -1488,7 +1669,8 @@ export default function ReviewAndPublish({
     !mergeResult.success ||
     !hasChanges ||
     !(governance ? governance.canPublish : true) ||
-    featureLockedByRamp;
+    featureLockedByRamp ||
+    featureLockedBySchedule;
 
   // Determine whether approvals are required by diffing the merged result
   // against live (mirrors the feature overview's gating calculation).
@@ -1558,6 +1740,7 @@ export default function ReviewAndPublish({
     onlyScheduledSelected,
     experimentsStep,
     featureLockedByRamp,
+    featureLockedBySchedule,
     checklistBlocked,
     governanceCanPublish: governance ? governance.canPublish : true,
   });
@@ -1569,20 +1752,29 @@ export default function ReviewAndPublish({
         case "next-experiments":
           openChecklistStep();
           return;
-        case "request-review":
+        case "request-review": {
           setSubmitting(true);
+          const dateArmed =
+            autoPublishArmed &&
+            effectivePublishMode === "date" &&
+            !!scheduleDate;
           await apiCall(`/feature/${feature.id}/${revision.version}/request`, {
             method: "POST",
             body: JSON.stringify({
               mergeResultSerialized: JSON.stringify(mergeResult),
               comment,
-              autoPublishOnApproval: requestAutoPublish,
+              autoPublishOnApproval:
+                autoPublishArmed && effectivePublishMode === "approve",
+              scheduledPublishAt: dateArmed ? scheduleDate : null,
+              scheduledPublishLockEdits: scheduleLockEdits,
+              scheduledPublishLockOthers: scheduleLockOthers,
             }),
           });
           // The review log drives reviewRequesterId (and thus the "Retract
           // review request" affordance) — refresh it alongside the revision.
           await Promise.all([mutate(), mutateReviewLog()]);
           return;
+        }
         case "publish":
           setSubmitting(true);
           await apiCall(`/feature/${feature.id}/${revision.version}/publish`, {
@@ -1609,8 +1801,9 @@ export default function ReviewAndPublish({
   };
   doSubmitRef.current = doSubmit;
 
+  // Persist (or, for drafts, stage) the "publish when approved" arming.
   const doToggleAutoPublish = async (enabled: boolean) => {
-    setRequestAutoPublish(enabled);
+    setAutoPublishArmed(enabled);
     if (revision.status !== "draft") {
       try {
         await apiCall(
@@ -1622,8 +1815,144 @@ export default function ReviewAndPublish({
         );
         await mutate();
       } catch (e) {
-        setRequestAutoPublish(!enabled);
+        setAutoPublishArmed(!enabled);
       }
+    }
+  };
+
+  // Persist the deferred-publish schedule. Called automatically whenever the
+  // author changes the date or a lock toggle, so the full armed state is always
+  // saved to the revision (and thus visible read-only to reviewers) — no
+  // separate "save" step that could be skipped.
+  const persistSchedule = async (
+    date: string,
+    lockEdits: boolean,
+    lockOthers: boolean,
+  ) => {
+    if (!date || !revision) return;
+    setScheduleError(null);
+    setSavingSchedule(true);
+    try {
+      await apiCall(
+        `/feature/${feature.id}/${revision.version}/schedule-publish`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            scheduledPublishAt: date,
+            lockEdits,
+            lockOthers,
+          }),
+        },
+      );
+      await mutate();
+    } catch (e) {
+      setScheduleError(e.message || "Could not schedule publish");
+    } finally {
+      setSavingSchedule(false);
+    }
+  };
+
+  // While a review-required draft is still a draft we only stage the schedule
+  // locally and arm it when the author clicks "Request Review" (matching how
+  // main stages auto-publish). Once review is pending (or later), edits persist
+  // instantly. For no-approval changes there's no review step, so committing the
+  // schedule on the draft is the arming action — persist it immediately.
+  const schedulePersistsImmediately =
+    revision?.status !== "draft" || !requireReviews;
+
+  const onScheduleDateChange = (date: string) => {
+    setScheduleDate(date);
+    if (autoPublishArmed && date && schedulePersistsImmediately) {
+      persistSchedule(date, scheduleLockEdits, scheduleLockOthers);
+    }
+  };
+
+  const onScheduleLockEditsChange = (value: boolean) => {
+    setScheduleLockEdits(value);
+    if (autoPublishArmed && scheduleDate && schedulePersistsImmediately) {
+      persistSchedule(scheduleDate, value, scheduleLockOthers);
+    }
+  };
+
+  const onScheduleLockOthersChange = (value: boolean) => {
+    setScheduleLockOthers(value);
+    if (autoPublishArmed && scheduleDate && schedulePersistsImmediately) {
+      persistSchedule(scheduleDate, scheduleLockEdits, value);
+    }
+  };
+
+  const doClearSchedule = async () => {
+    if (!revision) return;
+    setScheduleError(null);
+    setSavingSchedule(true);
+    try {
+      await apiCall(
+        `/feature/${feature.id}/${revision.version}/schedule-publish`,
+        {
+          method: "POST",
+          body: JSON.stringify({ scheduledPublishAt: null }),
+        },
+      );
+      await mutate();
+      setScheduleDate("");
+    } catch (e) {
+      setScheduleError(e.message || "Could not cancel schedule");
+    } finally {
+      setSavingSchedule(false);
+    }
+  };
+
+  // Unified "Automatically publish" checkbox. Arming uses the mode currently
+  // chosen in the always-visible dropdown.
+  const doSetAutoPublishArmed = async (armed: boolean) => {
+    setScheduleError(null);
+    if (!armed) {
+      setAutoPublishArmed(false);
+      setEditingSchedule(false);
+      if (scheduledPending) {
+        await doClearSchedule();
+      } else {
+        await doToggleAutoPublish(false);
+      }
+      return;
+    }
+    // Keep the editable controls open while the owner configures a freshly armed
+    // schedule (otherwise immediate-persist flows would collapse mid-edit).
+    setEditingSchedule(true);
+    if (effectivePublishMode === "approve") {
+      await doToggleAutoPublish(true);
+    } else {
+      // Date mode: persist immediately if a date is already chosen (and we're
+      // past the draft stage). Drafts stage locally and arm on Request Review.
+      setPublishMode("date");
+      setAutoPublishArmed(true);
+      if (scheduleDate && schedulePersistsImmediately) {
+        await persistSchedule(
+          scheduleDate,
+          scheduleLockEdits,
+          scheduleLockOthers,
+        );
+      }
+    }
+  };
+
+  // Switch between the two mutually exclusive arming modes. When the revision
+  // isn't armed yet this only records the preference; it persists once armed.
+  const doSetPublishMode = async (mode: "approve" | "date") => {
+    setScheduleError(null);
+    setPublishMode(mode);
+    if (!autoPublishArmed) return;
+    if (mode === "approve") {
+      // Converting to "when approved" clears any pending date and arms approve.
+      if (scheduledPending) await doClearSchedule();
+      await doToggleAutoPublish(true);
+    } else if (scheduleDate && schedulePersistsImmediately) {
+      // Converting to "date" with a date already chosen persists it now.
+      await persistSchedule(
+        scheduleDate,
+        scheduleLockEdits,
+        scheduleLockOthers,
+      );
     }
   };
 
@@ -2149,26 +2478,24 @@ export default function ReviewAndPublish({
           renderExperimentSelection()}
 
         <Box mt="6">
-          {/* Read-only auto-publish indicator for reviewers */}
-          {showAutoPublishReadonly && (
-            <Box mb="3">
-              <Checkbox
-                label="Automatically publish when approved"
-                weight="regular"
-                value={revisionAutoPublishArmed}
-                setValue={() => {}}
-                disabled
-              />
-            </Box>
-          )}
+          {/* Read-only arming summary for reviewers / non-managers. Shows what
+              the arming will do (nothing when unarmed). A started schedule on an
+              approved revision can still be canceled by any publisher. */}
+          {showAutoPublishReadonly &&
+            revision &&
+            renderScheduleCard({
+              onCancel: canCancelStartedSchedule ? doClearSchedule : undefined,
+            })}
 
           {/* Submit review — reviewer action, opens the comment/decision popover */}
           {canReview && isPendingReview && !approved && (
             <Flex direction="column" gap="3">
               <ReviewCommentPopover
                 submitUrl={`/feature/${feature.id}/${revision.version}/submit-review`}
+                storageKey={`review-comment:${feature.id}:${revision.version}`}
                 allowPublishOnApprove={autopublishOnApproval}
                 autoPublishArmed={revisionAutoPublishArmed}
+                autoPublishScheduled={scheduledPending}
                 canReviewerPublish={hasPublishPermission}
                 publishBlocked={reviewerPublishBlocked}
                 publishHasMoreSteps={hasChecklistStep}
@@ -2237,16 +2564,27 @@ export default function ReviewAndPublish({
                 return { overridable: true };
               if (!adminPublish && featureLockedByRamp)
                 return { overridable: true };
+              if (!adminPublish && featureLockedBySchedule)
+                return { overridable: true };
               return null;
             })();
 
+            // A live schedule blocks publishing now — the schedule must be
+            // canceled first so there's a single, explicit path back to
+            // "approved" before a manual publish. Admin bypass overrides this:
+            // it force-publishes now regardless of the pending schedule.
+            const scheduleBlocksPublish = scheduledPending && !adminPublish;
             const publishEnabled =
               state.submitAction === "publish" &&
               state.ctaEnabled &&
-              canDoPrimary;
+              canDoPrimary &&
+              !scheduleBlocksPublish;
 
             const continueEnabled =
-              continueToPublish && state.ctaEnabled && canDoPrimary;
+              continueToPublish &&
+              state.ctaEnabled &&
+              canDoPrimary &&
+              !scheduleBlocksPublish;
 
             const primaryFooterEnabled = continueToPublish
               ? continueEnabled
@@ -2254,9 +2592,11 @@ export default function ReviewAndPublish({
 
             const primaryFooterLabel = continueToPublish
               ? continueLabel
-              : onlyScheduledSelected
-                ? "Schedule to Start"
-                : "Publish";
+              : scheduleBlocksPublish
+                ? "Publish scheduled"
+                : onlyScheduledSelected
+                  ? "Schedule to Start"
+                  : "Publish";
 
             // Hide the publish section (divider, admin-bypass checkbox, Publish
             // button) for not-yet-approved drafts — unless an admin can bypass
@@ -2270,23 +2610,124 @@ export default function ReviewAndPublish({
               continueToPublish ||
               adminCanBypassNow;
 
-            return (
-              <>
-                {/* Auto-publish toggle (editable by requestor) */}
-                {canToggleAutoPublish && (
-                  <Box mb="3">
-                    <Checkbox
-                      label="Automatically publish when approved"
-                      weight="regular"
-                      value={requestAutoPublish}
-                      setValue={(val) => doToggleAutoPublish(!!val)}
+            {
+              /* Unified auto-publish arming: one checkbox + a mode selector.
+                 "when approved" and "on a specific date" are the two values of
+                 the same armed state (autoPublishOnApproval + scheduledPublishAt),
+                 so they're mutually exclusive. Rendered just above the primary CTA
+                 (Publish, or Request Review for drafts) so it reads as related. */
+            }
+            const autoPublishArming = showAutoPublishEditable ? (
+              <Box mb="3">
+                <Flex align="center" gap="1">
+                  <Checkbox
+                    label="Automatically publish"
+                    weight="regular"
+                    disabled={savingSchedule}
+                    value={autoPublishArmed}
+                    setValue={(val) => doSetAutoPublishArmed(!!val)}
+                  />
+                  {canArmWhenApproved ? (
+                    <SelectField
+                      containerClassName="select-dropdown-underline mb-0"
+                      value={effectivePublishMode}
+                      isSearchable={false}
+                      sort={false}
+                      containerStyles={{
+                        control: (s) => ({ ...s, fontSize: 14 }),
+                        singleValue: (s) => ({ ...s, fontSize: 14 }),
+                      }}
+                      options={[
+                        {
+                          label: "when approved",
+                          value: "approve",
+                        },
+                        {
+                          label: "on a specific date",
+                          value: "date",
+                        },
+                      ]}
+                      onChange={(v) =>
+                        doSetPublishMode(v as "approve" | "date")
+                      }
                     />
+                  ) : (
+                    // Approved revisions can only defer to a date — "when
+                    // approved" would just publish now, so show it as text.
+                    <Text size="medium">on a specific date</Text>
+                  )}
+                </Flex>
+                {autoPublishArmed && effectivePublishMode === "date" && (
+                  <Box mt="2" ml="4">
+                    {hasScheduledRevisions ? (
+                      <>
+                        <DatePicker
+                          date={scheduleDate || undefined}
+                          setDate={(d) =>
+                            onScheduleDateChange(d ? d.toISOString() : "")
+                          }
+                          precision="datetime"
+                          disableBefore={new Date().toISOString()}
+                        />
+                        <Box mt="2">
+                          <Checkbox
+                            label="Lock edits to this draft while scheduled"
+                            weight="regular"
+                            value={scheduleLockEdits}
+                            setValue={(v) => onScheduleLockEditsChange(!!v)}
+                          />
+                        </Box>
+                        <Flex align="center" mt="2">
+                          <Checkbox
+                            label="Lock feature while scheduled"
+                            weight="regular"
+                            value={scheduleLockOthers}
+                            setValue={(v) => onScheduleLockOthersChange(!!v)}
+                          />
+                          <Tooltip content="Blocks publishing draft changes to this feature while a publish is scheduled.">
+                            <PiInfo
+                              color="var(--color-text-low)"
+                              className="ml-1"
+                            />
+                          </Tooltip>
+                        </Flex>
+                      </>
+                    ) : (
+                      <PremiumTooltip commercialFeature="scheduled-revisions">
+                        <Text size="small" as="div">
+                          Upgrade to publish on a specific date.
+                        </Text>
+                      </PremiumTooltip>
+                    )}
+                    {scheduleError && (
+                      <Callout status="error" mt="2">
+                        {scheduleError}
+                      </Callout>
+                    )}
+                    {/* No "Cancel schedule" button here — unchecking
+                      "Automatically publish" above cancels the schedule (and
+                      resets the checkbox). When not editing, the read-only
+                      summary below carries the Cancel + Change actions. */}
                   </Box>
                 )}
+              </Box>
+            ) : showManagerScheduleReadonly && revision ? (
+              // Armed + not editing: owners/admins see the same status card
+              // reviewers do, plus actions to cancel or re-open the editor
+              // (guards against accidental edits to a committed schedule).
+              renderScheduleCard({
+                onChange: () => setEditingSchedule(true),
+                onCancel: () => doSetAutoPublishArmed(false),
+              })
+            ) : null;
 
-                {/* Step CTA: Request Review / Submit Review / Next */}
+            return (
+              <>
+                {/* Step CTA: Request Review / Submit Review / Next. The arming
+                  control renders here for drafts (no publish section yet). */}
                 {isStepAction && (
                   <Box mt="4">
+                    {!showPublishSection && autoPublishArming}
                     <Button
                       variant="soft"
                       onClick={doSubmit}
@@ -2326,6 +2767,10 @@ export default function ReviewAndPublish({
                       />
                     )}
 
+                    {/* Arming control sits below the separator so it reads as
+                    related to the Publish button. */}
+                    {autoPublishArming}
+
                     {/* Merge conflicts are never admin-overridable — hide the
                     bypass checkbox entirely while one exists. */}
                     {canAdminPublish &&
@@ -2333,7 +2778,11 @@ export default function ReviewAndPublish({
                       (blockInfo?.overridable || adminPublish) && (
                         <Box mb="3">
                           <Checkbox
-                            label="Admin: bypass checks and publish now"
+                            label={
+                              <span style={{ color: "var(--red-11)" }}>
+                                Admin: bypass checks and publish now
+                              </span>
+                            }
                             weight="regular"
                             value={adminPublish}
                             setValue={(val) => {
@@ -2348,18 +2797,26 @@ export default function ReviewAndPublish({
                         </Box>
                       )}
 
-                    <Button
-                      onClick={primaryFooterEnabled ? doSubmit : undefined}
-                      loading={
-                        submitting &&
-                        (state.submitAction === "publish" || continueToPublish)
-                      }
-                      disabled={!primaryFooterEnabled}
-                      icon={state.ctaLocked ? <PiLockSimple /> : undefined}
-                      style={{ width: "100%" }}
-                    >
-                      {primaryFooterLabel}
-                    </Button>
+                    {/* A live schedule blocks "publish now"; the scheduled
+                    status card above already explains this and offers
+                    Cancel/Change, so we hide the otherwise-dead disabled
+                    button. It reappears the moment the block clears (e.g. admin
+                    bypass toggled, or the experiments "continue" flow). */}
+                    {!(scheduleBlocksPublish && !continueToPublish) && (
+                      <Button
+                        onClick={primaryFooterEnabled ? doSubmit : undefined}
+                        loading={
+                          submitting &&
+                          (state.submitAction === "publish" ||
+                            continueToPublish)
+                        }
+                        disabled={!primaryFooterEnabled}
+                        icon={state.ctaLocked ? <PiLockSimple /> : undefined}
+                        style={{ width: "100%" }}
+                      >
+                        {primaryFooterLabel}
+                      </Button>
+                    )}
 
                     {/* ── Uniform status displays for the publish state ──
                     All callouts use the same size, spacing, and chrome so
@@ -2379,6 +2836,18 @@ export default function ReviewAndPublish({
                         <Callout status="info" size="sm">
                           No changes to publish. Discard the draft or add
                           changes first.
+                        </Callout>
+                      )}
+
+                      {featureLockedBySchedule && !adminPublish && (
+                        <Callout status="warning" size="sm">
+                          Another draft
+                          {lockingScheduledSibling?.version
+                            ? ` (revision ${lockingScheduledSibling.version})`
+                            : ""}{" "}
+                          is scheduled to publish and has locked publishing of
+                          other drafts. Cancel that schedule to publish this
+                          revision.
                         </Callout>
                       )}
 

--- a/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
+++ b/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
@@ -623,6 +623,12 @@ export default function ReviewAndPublish({
   const [scheduleLockOthers, setScheduleLockOthers] = useState(
     !!revision?.scheduledPublishLockOthers,
   );
+  // Admin-only: dangerously arm the scheduled publish so it fires without the
+  // normal approval. Distinct from the "publish now" admin bypass — this one
+  // belongs to the schedule and is what gets persisted as scheduledPublishBypassApproval.
+  const [scheduleBypassApproval, setScheduleBypassApproval] = useState(
+    !!revision?.scheduledPublishBypassApproval,
+  );
   const [savingSchedule, setSavingSchedule] = useState(false);
   const [scheduleError, setScheduleError] = useState<string | null>(null);
   // Once a schedule is armed (persisted), owners/admins see a read-only summary
@@ -646,11 +652,13 @@ export default function ReviewAndPublish({
     );
     setScheduleLockEdits(!!revision?.scheduledPublishLockEdits);
     setScheduleLockOthers(!!revision?.scheduledPublishLockOthers);
+    setScheduleBypassApproval(!!revision?.scheduledPublishBypassApproval);
   }, [
     revision?.autoPublishOnApproval,
     revision?.scheduledPublishAt,
     revision?.scheduledPublishLockEdits,
     revision?.scheduledPublishLockOthers,
+    revision?.scheduledPublishBypassApproval,
     scheduledPending,
   ]);
 
@@ -821,25 +829,44 @@ export default function ReviewAndPublish({
     ? publishMode
     : "date";
 
+  // A schedule armed by an admin via the bypass-approval override is locked:
+  // nobody (not even the arming admin) can edit it inline — it can only be
+  // canceled and re-armed. Anyone with publish authority may cancel it, which
+  // clears the bypass flag (reverts the admin override).
+  const scheduleArmedByAdmin =
+    scheduledPending && !!revision?.scheduledPublishBypassApproval;
+  const canCancelAdminSchedule =
+    scheduleArmedByAdmin && permissionsUtil.canPublishFeature(feature, envIds);
+
   const canManageAutoPublish = canArmWhenApproved || canArmOnDate;
+  // Admin-armed schedules render read-only for everyone, so route them through
+  // the read-only card (with an optional Cancel) rather than the editable/owner
+  // controls.
   const showAutoPublishReadonly =
-    revisionAutoPublishArmed && !canManageAutoPublish;
+    (revisionAutoPublishArmed && !canManageAutoPublish) || scheduleArmedByAdmin;
   // The read-only card (with Cancel + Change) is reserved for a dated schedule,
   // guarding against accidental edits. "Auto-publish when approved" is just a
   // toggle, so owners keep the plain editable checkbox.
   const showAutoPublishEditable =
-    canManageAutoPublish && (!scheduledPending || editingSchedule);
+    canManageAutoPublish &&
+    !scheduleArmedByAdmin &&
+    (!scheduledPending || editingSchedule);
   const showManagerScheduleReadonly =
-    canManageAutoPublish && scheduledPending && !editingSchedule;
+    canManageAutoPublish &&
+    scheduledPending &&
+    !editingSchedule &&
+    !scheduleArmedByAdmin;
 
   // Status card for a dated schedule. Used by both reviewer and owner views so
   // they read identically; onChange/onCancel are omitted for viewers.
   const renderScheduleCard = ({
     onChange,
     onCancel,
+    note,
   }: {
     onChange?: () => void;
     onCancel?: () => void;
+    note?: string;
   }) => {
     if (!revision || !scheduledPending || !revision.scheduledPublishAt)
       return null;
@@ -877,6 +904,11 @@ export default function ReviewAndPublish({
               <HelperText status="error" size="sm" mt="2">
                 Publish is stuck and keeps retrying:{" "}
                 {revision.scheduledPublishLastError}
+              </HelperText>
+            )}
+            {note && (
+              <HelperText status="info" size="sm" mt="2">
+                {note}
               </HelperText>
             )}
           </>
@@ -1815,6 +1847,7 @@ export default function ReviewAndPublish({
     date: string,
     lockEdits: boolean,
     lockOthers: boolean,
+    bypassApproval = false,
   ): Promise<boolean> => {
     if (!date || !revision) return false;
     setScheduleError(null);
@@ -1828,6 +1861,7 @@ export default function ReviewAndPublish({
             scheduledPublishAt: date,
             lockEdits,
             lockOthers,
+            bypassApproval,
           }),
         },
       );
@@ -1843,29 +1877,72 @@ export default function ReviewAndPublish({
 
   // A review-required draft stages the schedule locally and arms it on "Request
   // Review". Otherwise (review pending/later, or no-approval changes) it persists
-  // immediately.
+  // immediately. An admin engaging the bypass override also persists immediately
+  // — they're dangerously arming a schedule rather than entering the review flow.
   const schedulePersistsImmediately =
-    revision?.status !== "draft" || !requireReviews;
+    revision?.status !== "draft" || !requireReviews || scheduleBypassApproval;
+
+  // The admin bypass toggle is only meaningful when this revision would
+  // otherwise need approval to publish (review required and not yet approved).
+  const canBypassScheduleApproval =
+    canAdminPublish && requireReviews && revision?.status !== "approved";
+
+  // Single source of truth for persisting the current schedule config.
+  const persistCurrentSchedule = (
+    lockEdits: boolean,
+    lockOthers: boolean,
+    bypassApproval: boolean,
+    persists = schedulePersistsImmediately,
+  ) => {
+    if (autoPublishArmed && scheduleDate && (persists || scheduledPending)) {
+      persistSchedule(scheduleDate, lockEdits, lockOthers, bypassApproval);
+    }
+  };
 
   const onScheduleDateChange = (date: string) => {
     setScheduleDate(date);
     if (autoPublishArmed && date && schedulePersistsImmediately) {
-      persistSchedule(date, scheduleLockEdits, scheduleLockOthers);
+      persistSchedule(
+        date,
+        scheduleLockEdits,
+        scheduleLockOthers,
+        scheduleBypassApproval,
+      );
     }
   };
 
-  const onScheduleLockEditsChange = (value: boolean) => {
-    setScheduleLockEdits(value);
-    if (autoPublishArmed && scheduleDate && schedulePersistsImmediately) {
-      persistSchedule(scheduleDate, value, scheduleLockOthers);
-    }
+  // The two underlying locks are surfaced as one checkbox + a scope selector:
+  // off → no locks; "this draft" → freeze this draft's edits; "this feature" →
+  // freeze this draft's edits AND block publishing other drafts (superset).
+  const scheduleLocked = scheduleLockEdits || scheduleLockOthers;
+  const scheduleLockScope: "draft" | "feature" = scheduleLockOthers
+    ? "feature"
+    : "draft";
+
+  const applyScheduleLock = (lockEdits: boolean, lockOthers: boolean) => {
+    setScheduleLockEdits(lockEdits);
+    setScheduleLockOthers(lockOthers);
+    persistCurrentSchedule(lockEdits, lockOthers, scheduleBypassApproval);
   };
 
-  const onScheduleLockOthersChange = (value: boolean) => {
-    setScheduleLockOthers(value);
-    if (autoPublishArmed && scheduleDate && schedulePersistsImmediately) {
-      persistSchedule(scheduleDate, scheduleLockEdits, value);
-    }
+  const onScheduleLockToggle = (value: boolean) =>
+    // Enabling defaults to draft scope; toggling off clears both.
+    applyScheduleLock(value, value ? scheduleLockOthers : false);
+
+  const onScheduleLockScopeChange = (scope: "draft" | "feature") =>
+    applyScheduleLock(true, scope === "feature");
+
+  const onScheduleBypassChange = (value: boolean) => {
+    setScheduleBypassApproval(value);
+    // Enabling bypass also flips schedulePersistsImmediately true for a
+    // review-required draft, so recompute persistence with the new value.
+    const persists = revision?.status !== "draft" || !requireReviews || value;
+    persistCurrentSchedule(
+      scheduleLockEdits,
+      scheduleLockOthers,
+      value,
+      persists,
+    );
   };
 
   const doClearSchedule = async () => {
@@ -1916,6 +1993,7 @@ export default function ReviewAndPublish({
           scheduleDate,
           scheduleLockEdits,
           scheduleLockOthers,
+          scheduleBypassApproval,
         );
         if (!ok) {
           setAutoPublishArmed(false);
@@ -1938,6 +2016,7 @@ export default function ReviewAndPublish({
         scheduleDate,
         scheduleLockEdits,
         scheduleLockOthers,
+        scheduleBypassApproval,
       );
     }
   };
@@ -2515,7 +2594,17 @@ export default function ReviewAndPublish({
           {showAutoPublishReadonly &&
             revision &&
             (scheduledPending ? (
-              !armingRendersBelow && renderScheduleCard({})
+              !armingRendersBelow &&
+              renderScheduleCard(
+                scheduleArmedByAdmin
+                  ? {
+                      onCancel: canCancelAdminSchedule
+                        ? () => doSetAutoPublishArmed(false)
+                        : undefined,
+                      note: "Armed by an admin (approval bypassed). Cancel and re-arm to change it.",
+                    }
+                  : {},
+              )
             ) : (
               // "When approved" is just a toggle — show a disabled checkbox.
               <Checkbox
@@ -2576,8 +2665,12 @@ export default function ReviewAndPublish({
             const continueLabel = "Continue to Publish →";
 
             // A pending schedule must be canceled before a manual publish (one
-            // explicit path back to "approved"). Admin bypass overrides this.
-            const scheduleBlocksPublish = scheduledPending && !adminPublish;
+            // explicit path back to "approved"). An admin bypass override lets an
+            // admin publish now over someone else's pending schedule — but not
+            // over a schedule that was itself admin-armed (that reads as the
+            // intentional deferral, so it still blocks publish-now).
+            const scheduleBlocksPublish =
+              scheduledPending && (!adminPublish || scheduleArmedByAdmin);
             const publishEnabled =
               state.submitAction === "publish" &&
               state.ctaEnabled &&
@@ -2608,7 +2701,9 @@ export default function ReviewAndPublish({
                  rendered just above the primary CTA so it reads as related. */
             }
             const autoPublishArming = showAutoPublishEditable ? (
-              <Box mb="3">
+              // Extra bottom margin separates the schedule widget from the admin
+              // bypass checkbox + Publish CTA group that follows.
+              <Box mb="5">
                 <Flex align="center" gap="1">
                   <Checkbox
                     label="Automatically publish"
@@ -2660,28 +2755,71 @@ export default function ReviewAndPublish({
                           precision="datetime"
                           disableBefore={new Date().toISOString()}
                         />
-                        <Box mt="2">
+                        <Flex align="center" gap="1" mt="2">
                           <Checkbox
-                            label="Lock edits to this draft while scheduled"
+                            label="Lock edits to"
                             weight="regular"
-                            value={scheduleLockEdits}
-                            setValue={(v) => onScheduleLockEditsChange(!!v)}
+                            value={scheduleLocked}
+                            setValue={(v) => onScheduleLockToggle(!!v)}
                           />
-                        </Box>
-                        <Flex align="center" mt="2">
-                          <Checkbox
-                            label="Lock feature while scheduled"
-                            weight="regular"
-                            value={scheduleLockOthers}
-                            setValue={(v) => onScheduleLockOthersChange(!!v)}
+                          <SelectField
+                            containerClassName="select-dropdown-underline mb-0"
+                            value={scheduleLockScope}
+                            disabled={!scheduleLocked || savingSchedule}
+                            isSearchable={false}
+                            sort={false}
+                            containerStyles={{
+                              control: (s) => ({ ...s, fontSize: 14 }),
+                              singleValue: (s) => ({ ...s, fontSize: 14 }),
+                            }}
+                            options={[
+                              { label: "this draft", value: "draft" },
+                              { label: "this feature", value: "feature" },
+                            ]}
+                            onChange={(v) =>
+                              onScheduleLockScopeChange(
+                                v as "draft" | "feature",
+                              )
+                            }
                           />
-                          <Tooltip content="Blocks publishing draft changes to this feature while a publish is scheduled.">
+                          <Text size="medium">while running</Text>
+                          <Tooltip content='"this draft" freezes content edits to the scheduled draft. "this feature" also blocks publishing other drafts of this feature until the schedule fires or is canceled.'>
                             <PiInfo
                               color="var(--color-text-low)"
                               className="ml-1"
                             />
                           </Tooltip>
                         </Flex>
+                        {canBypassScheduleApproval && (
+                          <Box mt="2">
+                            <Checkbox
+                              label={
+                                <span style={{ color: "var(--red-11)" }}>
+                                  Admin: allow scheduled publish to bypass
+                                  checks
+                                </span>
+                              }
+                              weight="regular"
+                              value={scheduleBypassApproval}
+                              setValue={(v) => onScheduleBypassChange(!!v)}
+                            />
+                          </Box>
+                        )}
+                        {experiments.length > 0 && (
+                          <Callout status="warning" mt="2">
+                            This draft would start{" "}
+                            {experiments.length === 1
+                              ? "a linked draft experiment"
+                              : `${experiments.length} linked draft experiments`}
+                            . A scheduled publish won&apos;t start{" "}
+                            {experiments.length === 1 ? "it" : "them"} — it will
+                            be held at the scheduled time until{" "}
+                            {experiments.length === 1 ? "it is" : "they are"}{" "}
+                            started (or removed from this draft). Start{" "}
+                            {experiments.length === 1 ? "it" : "them"} before
+                            the scheduled time to avoid a stuck publish.
+                          </Callout>
+                        )}
                       </>
                     ) : (
                       <PremiumTooltip commercialFeature="scheduled-revisions">
@@ -2708,9 +2846,19 @@ export default function ReviewAndPublish({
                 onCancel: () => doSetAutoPublishArmed(false),
               })
             ) : showAutoPublishReadonly && revision && scheduledPending ? (
-              // Viewers without publish authority: read-only card in the same
-              // spot as the owner's (below the rebase notice), no Cancel/Change.
-              renderScheduleCard({})
+              // Read-only card: viewers without publish authority see no controls;
+              // an admin-armed schedule offers Cancel (to publishers) but never an
+              // inline Change — it must be canceled and re-armed.
+              renderScheduleCard(
+                scheduleArmedByAdmin
+                  ? {
+                      onCancel: canCancelAdminSchedule
+                        ? () => doSetAutoPublishArmed(false)
+                        : undefined,
+                      note: "Armed by an admin (approval bypassed). Cancel and re-arm to change it.",
+                    }
+                  : {},
+              )
             ) : null;
 
             return (

--- a/packages/front-end/components/Reviews/Feature/RevisionLog.tsx
+++ b/packages/front-end/components/Reviews/Feature/RevisionLog.tsx
@@ -17,6 +17,7 @@ import {
   PiPlusMinusBold,
   PiProhibitFill,
   PiRocketLaunch,
+  PiSpinnerGap,
 } from "react-icons/pi";
 import { date, datetime } from "shared/dates";
 import React, {
@@ -81,6 +82,10 @@ export const REVIEW_ACTIVITY_ACTIONS = new Set([
   "revert",
   "discard",
   "reopen",
+  // Deferred (scheduled) publish lifecycle
+  "schedule publish",
+  "update scheduled publish",
+  "cancel scheduled publish",
 ]);
 
 // Action sets must mirror EDITABLE_AUTHOR_ACTIONS / DELETABLE_AUTHOR_ACTIONS
@@ -138,6 +143,9 @@ const AUDIT_ACTION_VERBS: Record<string, string> = {
   "edit metadata": "edited the revision metadata",
   "set ramp schedule": "set a ramp schedule",
   "clear ramp schedule": "cleared a ramp schedule",
+  "schedule publish": "scheduled this revision to publish",
+  "update scheduled publish": "updated the publish schedule",
+  "cancel scheduled publish": "canceled the publish schedule",
   "Recall Review": "recalled their review request",
   "Undo Review": "withdrew their review",
 };
@@ -186,7 +194,10 @@ function rowVisual(action: string): RowVisual {
       return {
         color: "orange",
         verb: "requested a review",
-        icon: <PiClockFill />,
+        // Spinner glyph (not a clock) to read as "awaiting review" and stay
+        // distinct from the scheduled-publish clock. Not animated here since
+        // this is a historical timeline entry.
+        icon: <PiSpinnerGap />,
         showCommentBody: false,
         showAuditDetails: false,
       };
@@ -244,6 +255,24 @@ function rowVisual(action: string): RowVisual {
         color: "indigo",
         verb: "reopened this revision as a draft",
         icon: <PiArrowCounterClockwiseFill />,
+        showCommentBody: false,
+        showAuditDetails: false,
+      };
+    case "schedule publish":
+    case "update scheduled publish":
+      return {
+        color: "amber",
+        verb: auditVerb(action),
+        icon: <PiClockFill />,
+        showCommentBody: false,
+        // Keep the Details disclosure so the date + lock payload is inspectable.
+        showAuditDetails: true,
+      };
+    case "cancel scheduled publish":
+      return {
+        color: "gray",
+        verb: auditVerb(action),
+        icon: <PiProhibitFill />,
         showCommentBody: false,
         showAuditDetails: false,
       };

--- a/packages/front-end/components/Reviews/Feature/RevisionLog.tsx
+++ b/packages/front-end/components/Reviews/Feature/RevisionLog.tsx
@@ -156,12 +156,8 @@ function auditVerb(action: string): string {
   );
 }
 
-// Icons and colors mirror the revision status presentation in
-// RevisionStatusBadge (`revisionStatusIcon` / `revisionStatusColor`) so the
-// timeline and the actions-column header speak the same visual language:
-// approved = grass check, changes requested = red chat bubble,
-// review requested (→ pending-review) = orange clock,
-// discard = gray prohibit (matches the Discarded badge's gray).
+// Icons and colors mirror RevisionStatusBadge so the timeline and the
+// actions-column header speak the same visual language.
 function rowVisual(action: string): RowVisual {
   switch (action) {
     case "Comment":
@@ -194,9 +190,7 @@ function rowVisual(action: string): RowVisual {
       return {
         color: "orange",
         verb: "requested a review",
-        // Spinner glyph (not a clock) to read as "awaiting review" and stay
-        // distinct from the scheduled-publish clock. Not animated here since
-        // this is a historical timeline entry.
+        // Spinner glyph (not a clock) — distinct from the scheduled-publish clock.
         icon: <PiSpinnerGap />,
         showCommentBody: false,
         showAuditDetails: false,

--- a/packages/front-end/components/Reviews/NoticeBanner.tsx
+++ b/packages/front-end/components/Reviews/NoticeBanner.tsx
@@ -2,11 +2,8 @@ import { Box, Flex } from "@radix-ui/themes";
 import { ReactNode } from "react";
 import Text from "@/ui/Text";
 
-// GitHub-style banner ("This branch is out-of-date with the base branch"):
-// neutral panel, tinted icon disk, bold title with a muted body, and a
-// right-aligned secondary action that wraps below in narrow columns. Shared by
-// the publish-flow status blocks (divergence/rebase/conflict notices and the
-// scheduled-publish status card) so they all read identically.
+// Shared status banner for the publish flow (divergence/rebase/conflict notices
+// and the scheduled-publish card) so they all read identically.
 export default function NoticeBanner({
   icon,
   iconColor,
@@ -16,12 +13,11 @@ export default function NoticeBanner({
   action,
 }: {
   icon: ReactNode;
-  // Radix color scale name (e.g. "red", "amber", "violet", "gray").
+  // Radix color scale name (e.g. "red", "amber", "violet").
   iconColor: string;
   title: ReactNode;
   body?: ReactNode;
-  // Rendered below the muted body, unwrapped, for content that styles itself
-  // (e.g. a HelperText callout).
+  // Rendered below the body, unwrapped, for self-styled content (e.g. HelperText).
   footer?: ReactNode;
   action?: ReactNode;
 }) {

--- a/packages/front-end/components/Reviews/NoticeBanner.tsx
+++ b/packages/front-end/components/Reviews/NoticeBanner.tsx
@@ -1,0 +1,70 @@
+import { Box, Flex } from "@radix-ui/themes";
+import { ReactNode } from "react";
+import Text from "@/ui/Text";
+
+// GitHub-style banner ("This branch is out-of-date with the base branch"):
+// neutral panel, tinted icon disk, bold title with a muted body, and a
+// right-aligned secondary action that wraps below in narrow columns. Shared by
+// the publish-flow status blocks (divergence/rebase/conflict notices and the
+// scheduled-publish status card) so they all read identically.
+export default function NoticeBanner({
+  icon,
+  iconColor,
+  title,
+  body,
+  footer,
+  action,
+}: {
+  icon: ReactNode;
+  // Radix color scale name (e.g. "red", "amber", "violet", "gray").
+  iconColor: string;
+  title: ReactNode;
+  body?: ReactNode;
+  // Rendered below the muted body, unwrapped, for content that styles itself
+  // (e.g. a HelperText callout).
+  footer?: ReactNode;
+  action?: ReactNode;
+}) {
+  return (
+    <Flex
+      gap="3"
+      align="start"
+      wrap="wrap"
+      p="3"
+      mb="3"
+      style={{
+        background: "var(--color-panel-solid)",
+        border: "1px solid var(--gray-a6)",
+        borderRadius: "var(--radius-3)",
+      }}
+    >
+      <Flex
+        align="center"
+        justify="center"
+        flexShrink="0"
+        style={{
+          width: 28,
+          height: 28,
+          borderRadius: "50%",
+          background: `var(--${iconColor}-a3)`,
+          color: `var(--${iconColor}-11)`,
+          fontSize: 15,
+        }}
+      >
+        {icon}
+      </Flex>
+      <Box flexGrow="1" style={{ minWidth: 0, flexBasis: 180 }}>
+        <Text as="div" size="medium" weight="semibold">
+          {title}
+        </Text>
+        {body && (
+          <Text as="div" size="small" color="text-low">
+            {body}
+          </Text>
+        )}
+        {footer}
+      </Box>
+      {action && <Box ml="auto">{action}</Box>}
+    </Flex>
+  );
+}

--- a/packages/front-end/components/Reviews/ReviewCommentPopover.tsx
+++ b/packages/front-end/components/Reviews/ReviewCommentPopover.tsx
@@ -56,9 +56,8 @@ interface Props {
   allowPublishOnApprove?: boolean;
   // Whether the auto-publish checkbox is checked on the revision.
   autoPublishArmed?: boolean;
-  // Whether the armed publish is deferred to a future date. When true, approving
-  // doesn't publish now — it just approves and the schedule fires on its date —
-  // so the CTA stays "Submit" instead of "Submit and Publish".
+  // Armed publish is deferred to a date, so approving doesn't publish now — the
+  // CTA stays "Submit" instead of "Submit and Publish".
   autoPublishScheduled?: boolean;
   // Whether the current reviewer can publish under their own authority. Gates
   // the non-armed "Submit and Publish" option, which publishes as the reviewer.
@@ -143,8 +142,7 @@ export default function ReviewCommentPopover({
   const canSubmit = decision !== "Comment" || comment.trim().length > 0;
 
   const isApproval = decision === "Approved";
-  // A future-dated schedule is already armed; approving just approves and lets
-  // the schedule fire later, so it isn't an immediate publish.
+  // A future-dated schedule fires later, so approving it isn't an immediate publish.
   const willPublish =
     isApproval &&
     autoPublishArmed &&

--- a/packages/front-end/components/Reviews/ReviewCommentPopover.tsx
+++ b/packages/front-end/components/Reviews/ReviewCommentPopover.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Box, Flex } from "@radix-ui/themes";
 import { Popover } from "@/ui/Popover";
 import Button from "@/ui/Button";
@@ -11,6 +11,43 @@ import { useAuth } from "@/services/auth";
 
 type ReviewDecision = "Comment" | "Requested Changes" | "Approved";
 
+const REVIEW_DECISIONS: ReviewDecision[] = [
+  "Comment",
+  "Requested Changes",
+  "Approved",
+];
+
+type PersistedReviewDraft = { comment: string; decision: ReviewDecision };
+
+// In-progress review drafts persist in sessionStorage (keyed by feature +
+// revision) so closing the popover doesn't lose work. Cleared on submit/cancel.
+function readReviewDraft(key: string): PersistedReviewDraft | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.sessionStorage.getItem(key);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<PersistedReviewDraft>;
+    return {
+      comment: typeof parsed.comment === "string" ? parsed.comment : "",
+      decision:
+        parsed.decision && REVIEW_DECISIONS.includes(parsed.decision)
+          ? parsed.decision
+          : "Comment",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function clearReviewDraft(key: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.removeItem(key);
+  } catch {
+    // ignore storage failures (private mode, quota, etc.)
+  }
+}
+
 interface Props {
   submitUrl: string;
   // When true, a "Submit and Publish" option appears when "Approve" is
@@ -19,6 +56,10 @@ interface Props {
   allowPublishOnApprove?: boolean;
   // Whether the auto-publish checkbox is checked on the revision.
   autoPublishArmed?: boolean;
+  // Whether the armed publish is deferred to a future date. When true, approving
+  // doesn't publish now — it just approves and the schedule fires on its date —
+  // so the CTA stays "Submit" instead of "Submit and Publish".
+  autoPublishScheduled?: boolean;
   // Whether the current reviewer can publish under their own authority. Gates
   // the non-armed "Submit and Publish" option, which publishes as the reviewer.
   // Irrelevant to armed drafts (those publish under the arming user's authority).
@@ -33,6 +74,9 @@ interface Props {
   trigger: React.ReactNode | ((state: { open: boolean }) => React.ReactNode);
   /** Prevents self-approval when blockSelfApproval is set. */
   isBlockedContributor?: boolean;
+  // sessionStorage key for persisting the in-progress draft (comment +
+  // decision). When omitted, the draft isn't persisted across popover closes.
+  storageKey?: string;
   // Called after a successful submit-review. `publish` is true when the user
   // chose "Submit and Publish" so the parent can proceed with its publish flow.
   onSuccess: (opts?: { publish?: boolean }) => void;
@@ -44,6 +88,7 @@ export default function ReviewCommentPopover({
   submitUrl,
   allowPublishOnApprove = false,
   autoPublishArmed = false,
+  autoPublishScheduled = false,
   canReviewerPublish = false,
   publishBlocked = false,
   publishHasMoreSteps = false,
@@ -52,18 +97,45 @@ export default function ReviewCommentPopover({
   onSuccess,
   side = "bottom",
   align = "end",
+  storageKey,
 }: Props) {
   const { apiCall } = useAuth();
   const [open, setOpen] = useState(false);
-  const [comment, setComment] = useState("");
-  const [decision, setDecision] = useState<ReviewDecision>("Comment");
+  const [comment, setComment] = useState<string>(
+    () => (storageKey ? readReviewDraft(storageKey)?.comment : "") ?? "",
+  );
+  const [decision, setDecision] = useState<ReviewDecision>(
+    () =>
+      (storageKey ? readReviewDraft(storageKey)?.decision : "Comment") ??
+      "Comment",
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const reset = () => {
+  // Persist the in-progress draft as it changes. An empty/default draft is
+  // removed so we don't leave stale keys around.
+  useEffect(() => {
+    if (!storageKey || typeof window === "undefined") return;
+    try {
+      if (comment.trim().length === 0 && decision === "Comment") {
+        window.sessionStorage.removeItem(storageKey);
+      } else {
+        window.sessionStorage.setItem(
+          storageKey,
+          JSON.stringify({ comment, decision }),
+        );
+      }
+    } catch {
+      // ignore storage failures (private mode, quota, etc.)
+    }
+  }, [comment, decision, storageKey]);
+
+  // Reset everything and drop the persisted draft (submit / cancel).
+  const clearDraft = () => {
     setComment("");
     setDecision("Comment");
     setError(null);
+    if (storageKey) clearReviewDraft(storageKey);
   };
 
   // Verdicts (Approve / Request changes) may stand alone, but a plain
@@ -71,8 +143,14 @@ export default function ReviewCommentPopover({
   const canSubmit = decision !== "Comment" || comment.trim().length > 0;
 
   const isApproval = decision === "Approved";
+  // A future-dated schedule is already armed; approving just approves and lets
+  // the schedule fire later, so it isn't an immediate publish.
   const willPublish =
-    isApproval && autoPublishArmed && allowPublishOnApprove && !publishBlocked;
+    isApproval &&
+    autoPublishArmed &&
+    !autoPublishScheduled &&
+    allowPublishOnApprove &&
+    !publishBlocked;
   // Non-armed publish-on-approve runs under the reviewer's own authority, so
   // only offer it when they can actually publish — otherwise the approval lands
   // but the follow-on publish is rejected by the backend. Also suppressed when
@@ -96,7 +174,7 @@ export default function ReviewCommentPopover({
         method: "POST",
         body: JSON.stringify({ comment, review: decision }),
       });
-      reset();
+      clearDraft();
       setOpen(false);
       onSuccess({ publish });
     } catch (e) {
@@ -156,7 +234,7 @@ export default function ReviewCommentPopover({
         <LinkButton
           color="link"
           onClick={() => {
-            reset();
+            clearDraft();
             setOpen(false);
           }}
         >
@@ -190,7 +268,9 @@ export default function ReviewCommentPopover({
     <Popover
       open={open}
       onOpenChange={(o) => {
-        if (!o) reset();
+        // Closing the popover keeps the in-progress draft (persisted in
+        // sessionStorage); only clear the transient error.
+        if (!o) setError(null);
         setOpen(o);
       }}
       trigger={resolvedTrigger}

--- a/packages/front-end/components/Reviews/RevisionStatusBadge.tsx
+++ b/packages/front-end/components/Reviews/RevisionStatusBadge.tsx
@@ -11,7 +11,6 @@ import type { RevisionStatus, ActiveDraftStatus } from "shared/validators";
 import type { EventUser } from "shared/types/events/event-types";
 import Badge from "@/ui/Badge";
 import { RadixColor } from "@/ui/HelperText";
-import spinnerStyles from "@/components/LoadingSpinner.module.scss";
 
 // Entity-agnostic revision identity — enough to render status badges, labels,
 // and icons without depending on FeatureRevisionInterface.
@@ -77,9 +76,8 @@ export function revisionStatusIcon(
       // surrounding chip/band provides the container.
       return <PiCheckBold />;
     case "pending-review":
-      // Spinner (not a clock) reads as "in progress / awaiting review" and
-      // keeps it visually distinct from the scheduled-publish clock.
-      return <PiSpinnerGap className={spinnerStyles.spin} />;
+      // Spinner glyph (not animated) — distinct from the scheduled-publish clock.
+      return <PiSpinnerGap />;
     case "changes-requested":
       return <PiPlusMinusBold />;
     case "discarded":

--- a/packages/front-end/components/Reviews/RevisionStatusBadge.tsx
+++ b/packages/front-end/components/Reviews/RevisionStatusBadge.tsx
@@ -1,16 +1,17 @@
 import React from "react";
 import {
   PiCheckBold,
-  PiClockFill,
   PiLockSimpleFill,
   PiPencil,
   PiPlusMinusBold,
+  PiSpinnerGap,
   PiXCircleFill,
 } from "react-icons/pi";
 import type { RevisionStatus, ActiveDraftStatus } from "shared/validators";
 import type { EventUser } from "shared/types/events/event-types";
 import Badge from "@/ui/Badge";
 import { RadixColor } from "@/ui/HelperText";
+import spinnerStyles from "@/components/LoadingSpinner.module.scss";
 
 // Entity-agnostic revision identity — enough to render status badges, labels,
 // and icons without depending on FeatureRevisionInterface.
@@ -76,7 +77,9 @@ export function revisionStatusIcon(
       // surrounding chip/band provides the container.
       return <PiCheckBold />;
     case "pending-review":
-      return <PiClockFill />;
+      // Spinner (not a clock) reads as "in progress / awaiting review" and
+      // keeps it visually distinct from the scheduled-publish clock.
+      return <PiSpinnerGap className={spinnerStyles.spin} />;
     case "changes-requested":
       return <PiPlusMinusBold />;
     case "discarded":

--- a/packages/front-end/components/Reviews/reviewAndPublishState.ts
+++ b/packages/front-end/components/Reviews/reviewAndPublishState.ts
@@ -51,7 +51,12 @@ export interface RnPStateInput {
   onlyScheduledSelected: boolean;
   // Currently on the pre-launch checklist step.
   experimentsStep: boolean;
+  // Publishing is frozen by an active ramp-schedule lockdown on this feature.
   featureLockedByRamp: boolean;
+  // Publishing is frozen because another draft of this feature has a pending
+  // scheduled publish that locks publishing of other drafts. Treated identically
+  // to the ramp lock (same lock glyph, admin-bypassable).
+  featureLockedBySchedule: boolean;
   // A selected experiment's required checklist is incomplete/loading.
   checklistBlocked: boolean;
   // Governance allows publishing (false when a stale draft must be rebased).
@@ -62,7 +67,8 @@ export interface RnPState {
   mode: RnPMode;
   ctaLabel: string;
   ctaEnabled: boolean;
-  // Show a lock glyph on the CTA (publishing through a ramp lockdown).
+  // Show a lock glyph on the CTA (publishing is frozen by a ramp lockdown or a
+  // sibling draft's scheduled-publish lock).
   ctaLocked: boolean;
   submitAction: RnPSubmitAction;
   // Whether the main modal wires up a submit handler at all.
@@ -76,10 +82,10 @@ export interface RnPState {
 }
 
 function publishLabel(
-  featureLockedByRamp: boolean,
+  publishLocked: boolean,
   onlyScheduledSelected: boolean,
 ): string {
-  if (featureLockedByRamp) return "Publish";
+  if (publishLocked) return "Publish";
   if (onlyScheduledSelected) return "Schedule to Start";
   return "Publish";
 }
@@ -100,9 +106,15 @@ export function getReviewAndPublishState(input: RnPStateInput): RnPState {
     onlyScheduledSelected,
     experimentsStep,
     featureLockedByRamp,
+    featureLockedBySchedule,
     checklistBlocked,
     governanceCanPublish,
   } = input;
+
+  // A ramp lockdown and a sibling draft's "lock other publishes" schedule both
+  // freeze publishing identically: the CTA shows a lock glyph and is disabled
+  // unless an admin bypasses. Collapse them into one concept everywhere below.
+  const publishLocked = featureLockedByRamp || featureLockedBySchedule;
 
   // recall-review ("Return to draft"): the requester or anyone with skin in
   // the draft (author/contributor) can pull it back, provided they have
@@ -145,15 +157,15 @@ export function getReviewAndPublishState(input: RnPStateInput): RnPState {
     const ctaEnabled =
       mergeSuccess &&
       hasChanges &&
-      (!featureLockedByRamp || adminPublish) &&
+      (!publishLocked || adminPublish) &&
       (governanceCanPublish || adminPublish);
     return {
       mode,
       ctaLabel: hasNextStep
         ? "Next"
-        : publishLabel(featureLockedByRamp, onlyScheduledSelected),
+        : publishLabel(publishLocked, onlyScheduledSelected),
       ctaEnabled,
-      ctaLocked: !hasNextStep && featureLockedByRamp,
+      ctaLocked: !hasNextStep && publishLocked,
       submitAction: hasNextStep ? "next-experiments" : "publish",
       hasSubmit: true,
       canRecallReview,
@@ -168,8 +180,8 @@ export function getReviewAndPublishState(input: RnPStateInput): RnPState {
   let ctaLabel = "Request Review";
   let ctaLocked = false;
   if (approved && !hasNextStep) {
-    ctaLabel = publishLabel(featureLockedByRamp, onlyScheduledSelected);
-    ctaLocked = featureLockedByRamp;
+    ctaLabel = publishLabel(publishLocked, onlyScheduledSelected);
+    ctaLocked = publishLocked;
   } else if (hasNextStep) {
     ctaLabel = "Next";
   }
@@ -191,7 +203,7 @@ export function getReviewAndPublishState(input: RnPStateInput): RnPState {
 
   const ctaEnabled =
     !(experimentsStep && checklistBlocked && !adminPublish) &&
-    (!featureLockedByRamp || adminPublish) &&
+    (!publishLocked || adminPublish) &&
     !(approved && !governanceCanPublish && !adminPublish) &&
     // Publishing is the only action a conflict blocks — request-review
     // remains enabled so the review cycle can start regardless.

--- a/packages/front-end/components/Reviews/reviewAndPublishState.ts
+++ b/packages/front-end/components/Reviews/reviewAndPublishState.ts
@@ -53,9 +53,8 @@ export interface RnPStateInput {
   experimentsStep: boolean;
   // Publishing is frozen by an active ramp-schedule lockdown on this feature.
   featureLockedByRamp: boolean;
-  // Publishing is frozen because another draft of this feature has a pending
-  // scheduled publish that locks publishing of other drafts. Treated identically
-  // to the ramp lock (same lock glyph, admin-bypassable).
+  // Publishing is frozen by a sibling draft's scheduled publish that locks other
+  // drafts. Treated identically to the ramp lock.
   featureLockedBySchedule: boolean;
   // A selected experiment's required checklist is incomplete/loading.
   checklistBlocked: boolean;
@@ -67,8 +66,7 @@ export interface RnPState {
   mode: RnPMode;
   ctaLabel: string;
   ctaEnabled: boolean;
-  // Show a lock glyph on the CTA (publishing is frozen by a ramp lockdown or a
-  // sibling draft's scheduled-publish lock).
+  // Show a lock glyph on the CTA (frozen by a ramp or scheduled-publish lock).
   ctaLocked: boolean;
   submitAction: RnPSubmitAction;
   // Whether the main modal wires up a submit handler at all.
@@ -111,9 +109,8 @@ export function getReviewAndPublishState(input: RnPStateInput): RnPState {
     governanceCanPublish,
   } = input;
 
-  // A ramp lockdown and a sibling draft's "lock other publishes" schedule both
-  // freeze publishing identically: the CTA shows a lock glyph and is disabled
-  // unless an admin bypasses. Collapse them into one concept everywhere below.
+  // Ramp and scheduled-publish locks freeze publishing identically (lock glyph,
+  // admin-bypassable), so collapse them into one concept below.
   const publishLocked = featureLockedByRamp || featureLockedBySchedule;
 
   // recall-review ("Return to draft"): the requester or anyone with skin in

--- a/packages/front-end/pages/saved-groups/[sgid].tsx
+++ b/packages/front-end/pages/saved-groups/[sgid].tsx
@@ -1449,7 +1449,15 @@ export default function EditSavedGroupPage() {
                         backgroundColor: bannerProps.bgColor,
                       }}
                     >
-                      {bannerProps.icon}
+                      <span
+                        style={{
+                          display: "flex",
+                          flexGrow: 0,
+                          flexShrink: 0,
+                        }}
+                      >
+                        {bannerProps.icon}
+                      </span>
                       <span style={{ fontSize: "var(--font-size-2)" }}>
                         {bannerProps.message}
                       </span>

--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -263,6 +263,16 @@ export function useFeatureSearch({
     syntaxFilterPassthrough,
     updateSearchQueryOnChange: true,
     localStorageKey: localStorageKey,
+    // These back the `has`/`is`/`on`/`off` filters below and load asynchronously;
+    // listing them keeps results from going stale when the data arrives.
+    searchTermFilterDeps: [
+      environmentStatus,
+      draftStates,
+      staleStates,
+      rampStates,
+      dependencyIndex,
+      experimentStates,
+    ],
     searchTermFilters: {
       is: (item) => {
         const is: string[] = [item.valueType];

--- a/packages/front-end/services/search.tsx
+++ b/packages/front-end/services/search.tsx
@@ -159,6 +159,11 @@ export interface SearchProps<T extends { id: string }> {
   // hook doesn't latch onto the outer hook's filter string.
   disableUrlSearchTerm?: boolean;
   pageSize?: number;
+  // Extra values that `searchTermFilters` closes over but that change
+  // asynchronously (e.g. lazily-fetched indexes). Including them here lets the
+  // filtered-results memo recompute when that data arrives instead of going
+  // stale. Must be a fixed-length array across renders.
+  searchTermFilterDeps?: unknown[];
 }
 
 export interface SearchReturn<T> {
@@ -206,6 +211,7 @@ export function useSearch<T extends { id: string }>({
   updateSearchQueryOnChange,
   disableUrlSearchTerm,
   pageSize,
+  searchTermFilterDeps = [],
 }: SearchProps<T>): SearchReturn<T> {
   const defaultSort = { field: defaultSortField, dir: defaultSortDir || 1 };
   const persistedSort = useLocalStorage(
@@ -347,6 +353,8 @@ export function useSearch<T extends { id: string }>({
     filterResults,
     syntaxFilterPassthrough,
     transformQuery,
+    // Recompute when async filter data (e.g. the dependents index) loads.
+    ...searchTermFilterDeps,
   ]);
 
   const previousSearchTerm = useRef(searchTerm);

--- a/packages/front-end/test/components/Reviews/reviewAndPublishState.test.ts
+++ b/packages/front-end/test/components/Reviews/reviewAndPublishState.test.ts
@@ -20,6 +20,7 @@ function base(overrides: Partial<RnPStateInput> = {}): RnPStateInput {
     onlyScheduledSelected: false,
     experimentsStep: false,
     featureLockedByRamp: false,
+    featureLockedBySchedule: false,
     checklistBlocked: false,
     governanceCanPublish: true,
     ...overrides,
@@ -136,6 +137,19 @@ describe("getReviewAndPublishState", () => {
 
       const bypassed = getReviewAndPublishState(
         base({ featureLockedByRamp: true, adminPublish: true }),
+      );
+      expect(bypassed.ctaEnabled).toBe(true);
+    });
+
+    it("locks publish when a sibling draft's scheduled publish locks others", () => {
+      const locked = getReviewAndPublishState(
+        base({ featureLockedBySchedule: true }),
+      );
+      expect(locked.ctaEnabled).toBe(false);
+      expect(locked.ctaLocked).toBe(true);
+
+      const bypassed = getReviewAndPublishState(
+        base({ featureLockedBySchedule: true, adminPublish: true }),
       );
       expect(bypassed.ctaEnabled).toBe(true);
     });

--- a/packages/shared/src/enterprise/license-consts.ts
+++ b/packages/shared/src/enterprise/license-consts.ts
@@ -77,7 +77,8 @@ export type CommercialFeature =
   | "manage-official-resources"
   | "incremental-refresh"
   | "adv-presentations"
-  | "ramp-schedules";
+  | "ramp-schedules"
+  | "scheduled-revisions";
 
 export type CommercialFeaturesMap = Record<AccountPlan, Set<CommercialFeature>>;
 
@@ -264,6 +265,7 @@ const commercialFeaturesEnterpriseOnly: CommercialFeature[] = [
   "share-product-analytics-dashboards",
   "incremental-refresh",
   "adv-presentations",
+  "scheduled-revisions",
 ];
 
 const commercialFeaturesEnterprise: CommercialFeature[] = [

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -1248,9 +1248,8 @@ export function evaluatePublishGovernance({
 
 // ── Scheduled / deferred publish ────────────────────────────────────────────
 // A revision is "armed" (autoPublishOnApproval) when it should publish itself as
-// soon as governance allows. `scheduledPublishAt` defers that auto-publish to a
-// target date. These helpers are pure so they're shared by the publish UI, the
-// edit/publish lockdown gates, and the Agenda poller's due-predicate.
+// soon as governance allows; `scheduledPublishAt` defers that to a target date.
+// These pure helpers are shared by the UI, the lockdown gates, and the poller.
 
 const SCHEDULE_PENDING_STATUSES = new Set<FeatureRevisionInterface["status"]>([
   "draft",
@@ -1269,8 +1268,8 @@ type ScheduledRevisionFields = Pick<
   | "scheduledPublishLockOthers"
 >;
 
-// A deferred-publish schedule is "pending" when the revision is armed, carries a
-// target date, and is still an active draft (not yet published/discarded).
+// A schedule is "pending" when the revision is armed, has a date, and is still
+// an active draft.
 export function isScheduledPublishPending(
   revision: Pick<
     ScheduledRevisionFields,
@@ -1284,8 +1283,8 @@ export function isScheduledPublishPending(
   );
 }
 
-// True once a pending schedule's target date has arrived. Coerces the date so it
-// works on both Date (back-end) and ISO-string (front-end JSON) shapes.
+// True once a pending schedule's date has arrived. Coerces the date so it works
+// on both Date (back-end) and ISO-string (front-end) shapes.
 export function isScheduledPublishDue(
   revision: Pick<
     ScheduledRevisionFields,
@@ -1298,16 +1297,9 @@ export function isScheduledPublishDue(
   return at.getTime() <= now.getTime();
 }
 
-// A scheduled publish's locks (and the publish itself) only take effect once the
-// schedule is committed AND no longer awaiting approval:
-//  - "approved": the approval flow finished.
-//  - "draft": the no-approval flow. The schedule-publish endpoint only commits a
-//    schedule on a draft when the change doesn't require review (or an admin
-//    bypassed), so a draft carrying a pending schedule is locked in and will
-//    fire on its date.
-// "pending-review" / "changes-requested" mean the schedule is armed but still
-// awaiting approval, so edits stay open and sibling publishes aren't blocked —
-// the author can keep iterating and address feedback until it's approved.
+// Locks (and the publish) take effect once the schedule is committed and no
+// longer awaiting approval: status "approved" (approval flow) or "draft"
+// (no-approval flow). "pending-review"/"changes-requested" stay editable.
 export function isScheduledPublishLockActive(
   revision: Pick<
     ScheduledRevisionFields,

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -1246,6 +1246,113 @@ export function evaluatePublishGovernance({
   };
 }
 
+// ── Scheduled / deferred publish ────────────────────────────────────────────
+// A revision is "armed" (autoPublishOnApproval) when it should publish itself as
+// soon as governance allows. `scheduledPublishAt` defers that auto-publish to a
+// target date. These helpers are pure so they're shared by the publish UI, the
+// edit/publish lockdown gates, and the Agenda poller's due-predicate.
+
+const SCHEDULE_PENDING_STATUSES = new Set<FeatureRevisionInterface["status"]>([
+  "draft",
+  "pending-review",
+  "approved",
+  "changes-requested",
+]);
+
+type ScheduledRevisionFields = Pick<
+  FeatureRevisionInterface,
+  | "version"
+  | "status"
+  | "autoPublishOnApproval"
+  | "scheduledPublishAt"
+  | "scheduledPublishLockEdits"
+  | "scheduledPublishLockOthers"
+>;
+
+// A deferred-publish schedule is "pending" when the revision is armed, carries a
+// target date, and is still an active draft (not yet published/discarded).
+export function isScheduledPublishPending(
+  revision: Pick<
+    ScheduledRevisionFields,
+    "status" | "autoPublishOnApproval" | "scheduledPublishAt"
+  >,
+): boolean {
+  return (
+    !!revision.autoPublishOnApproval &&
+    (revision.scheduledPublishAt ?? null) !== null &&
+    SCHEDULE_PENDING_STATUSES.has(revision.status)
+  );
+}
+
+// True once a pending schedule's target date has arrived. Coerces the date so it
+// works on both Date (back-end) and ISO-string (front-end JSON) shapes.
+export function isScheduledPublishDue(
+  revision: Pick<
+    ScheduledRevisionFields,
+    "status" | "autoPublishOnApproval" | "scheduledPublishAt"
+  >,
+  now: Date = new Date(),
+): boolean {
+  if (!isScheduledPublishPending(revision)) return false;
+  const at = new Date(revision.scheduledPublishAt as Date | string);
+  return at.getTime() <= now.getTime();
+}
+
+// A scheduled publish's locks (and the publish itself) only take effect once the
+// schedule is committed AND no longer awaiting approval:
+//  - "approved": the approval flow finished.
+//  - "draft": the no-approval flow. The schedule-publish endpoint only commits a
+//    schedule on a draft when the change doesn't require review (or an admin
+//    bypassed), so a draft carrying a pending schedule is locked in and will
+//    fire on its date.
+// "pending-review" / "changes-requested" mean the schedule is armed but still
+// awaiting approval, so edits stay open and sibling publishes aren't blocked —
+// the author can keep iterating and address feedback until it's approved.
+export function isScheduledPublishLockActive(
+  revision: Pick<
+    ScheduledRevisionFields,
+    "status" | "autoPublishOnApproval" | "scheduledPublishAt"
+  >,
+): boolean {
+  return (
+    isScheduledPublishPending(revision) &&
+    revision.status !== "pending-review" &&
+    revision.status !== "changes-requested"
+  );
+}
+
+// Content edits to this draft are frozen while a lock-edits schedule is active
+// (armed AND approved). Pending-approval drafts remain editable.
+export function isRevisionEditLockedBySchedule(
+  revision: Pick<
+    ScheduledRevisionFields,
+    | "status"
+    | "autoPublishOnApproval"
+    | "scheduledPublishAt"
+    | "scheduledPublishLockEdits"
+  >,
+): boolean {
+  return (
+    !!revision.scheduledPublishLockEdits &&
+    isScheduledPublishLockActive(revision)
+  );
+}
+
+// Among a feature's revisions, find one (other than `excludeVersion`) whose
+// active (armed AND approved) schedule blocks publishing sibling drafts.
+export function findPublishLockingScheduledRevision<
+  T extends ScheduledRevisionFields,
+>(revisions: T[], excludeVersion?: number): T | null {
+  return (
+    revisions.find(
+      (r) =>
+        r.version !== excludeVersion &&
+        !!r.scheduledPublishLockOthers &&
+        isScheduledPublishLockActive(r),
+    ) ?? null
+  );
+}
+
 // True if publishing the draft would change anything outside the target
 // experiment's experiment-ref rule(s). Compares effective post-publish state
 // (live overlaid with draft-set fields) vs live, sidestepping autoMerge's

--- a/packages/shared/src/validators/feature-revisions-v2.ts
+++ b/packages/shared/src/validators/feature-revisions-v2.ts
@@ -632,7 +632,7 @@ export const postFeatureRevisionSchedulePublishV2Validator = {
   operationId: "postFeatureRevisionSchedulePublishV2",
   summary: "Schedule (or cancel) a deferred publish for a draft revision",
   description:
-    "Arms a deferred publish: the revision publishes automatically on/after `scheduledPublishAt` (and, when review is required, only once also approved). Send `scheduledPublishAt: null` to cancel the schedule.\n\nUse `lockEdits` to freeze content edits to this draft while the schedule is pending (rebasing is still allowed), and `lockOthers` to block publishing other drafts of this feature until the schedule fires or is canceled. Requires publish permission; the publish executes with the caller's authority. An admin with bypass-approval permission can schedule even without approval.",
+    "Arms a deferred publish: the revision publishes automatically on/after `scheduledPublishAt` (and, when review is required, only once also approved). Send `scheduledPublishAt: null` to cancel the schedule.\n\nUse `lockEdits` to freeze content edits to this draft while the schedule is pending (rebasing is still allowed), and `lockOthers` to block publishing other drafts of this feature until the schedule fires or is canceled. Requires publish permission; the publish executes with the caller's authority. An admin with bypass-approval permission can schedule even without approval — pass `bypassApproval: true` to mark it as an admin override, which locks the schedule to cancel-and-re-arm only.",
   tags: ["feature-revisions-v2"],
   paramsSchema: revisionParamsStrict,
   bodySchema: z
@@ -643,6 +643,7 @@ export const postFeatureRevisionSchedulePublishV2Validator = {
       ]),
       lockEdits: z.boolean().optional(),
       lockOthers: z.boolean().optional(),
+      bypassApproval: z.boolean().optional(),
     })
     .strict(),
   querySchema: z.never(),

--- a/packages/shared/src/validators/feature-revisions-v2.ts
+++ b/packages/shared/src/validators/feature-revisions-v2.ts
@@ -607,13 +607,42 @@ export const postFeatureRevisionRequestReviewV2Validator = {
   operationId: "postFeatureRevisionRequestReviewV2",
   summary: "Request review for a draft revision",
   description:
-    "Moves the draft into the `pending-review` state and notifies reviewers.\n\nSet `autoPublishOnApproval` to `true` to publish the revision automatically the moment it is approved (GitHub auto-merge model). This requires the org to have auto-publish-on-approval enabled for the feature and the caller to have publish permission; the auto-publish then executes with the caller's authority.",
+    "Moves the draft into the `pending-review` state and notifies reviewers.\n\nSet `autoPublishOnApproval` to `true` to publish the revision automatically the moment it is approved (GitHub auto-merge model). This requires the org to have auto-publish-on-approval enabled for the feature and the caller to have publish permission; the auto-publish then executes with the caller's authority.\n\nSet `scheduledPublishAt` to a future ISO date-time to defer the auto-publish until that date (it still also requires approval when review is required). Use `scheduledPublishLockEdits` to freeze edits to this draft while the schedule is pending, and `scheduledPublishLockOthers` to block publishing other drafts of this feature in the meantime.",
   tags: ["feature-revisions-v2"],
   paramsSchema: revisionParamsStrict,
   bodySchema: z
     .object({
       comment: z.string().optional(),
       autoPublishOnApproval: z.boolean().optional(),
+      scheduledPublishAt: z
+        .union([z.string().meta({ format: "date-time" }), z.null()])
+        .optional(),
+      scheduledPublishLockEdits: z.boolean().optional(),
+      scheduledPublishLockOthers: z.boolean().optional(),
+    })
+    .strict(),
+  querySchema: z.never(),
+  responseSchema: revisionResponse,
+  version: "v2" as const,
+};
+
+export const postFeatureRevisionSchedulePublishV2Validator = {
+  method: "post" as const,
+  path: "/features/:id/revisions/:version/schedule-publish",
+  operationId: "postFeatureRevisionSchedulePublishV2",
+  summary: "Schedule (or cancel) a deferred publish for a draft revision",
+  description:
+    "Arms a deferred publish: the revision publishes automatically on/after `scheduledPublishAt` (and, when review is required, only once also approved). Send `scheduledPublishAt: null` to cancel the schedule.\n\nUse `lockEdits` to freeze content edits to this draft while the schedule is pending (rebasing is still allowed), and `lockOthers` to block publishing other drafts of this feature until the schedule fires or is canceled. Requires publish permission; the publish executes with the caller's authority. An admin with bypass-approval permission can schedule even without approval.",
+  tags: ["feature-revisions-v2"],
+  paramsSchema: revisionParamsStrict,
+  bodySchema: z
+    .object({
+      scheduledPublishAt: z.union([
+        z.string().meta({ format: "date-time" }),
+        z.null(),
+      ]),
+      lockEdits: z.boolean().optional(),
+      lockOthers: z.boolean().optional(),
     })
     .strict(),
   querySchema: z.never(),

--- a/packages/shared/src/validators/features-v2.ts
+++ b/packages/shared/src/validators/features-v2.ts
@@ -134,6 +134,36 @@ export const apiFeatureRevisionV2Validator = namedSchema(
           "Pending ramp schedule actions that will be applied when this draft is published",
         )
         .optional(),
+      autoPublishOnApproval: z
+        .boolean()
+        .describe(
+          "When true, the revision is armed to publish automatically once governance allows (immediately on approval, or on `scheduledPublishAt` if set).",
+        )
+        .optional(),
+      scheduledPublishAt: z
+        .union([z.string().meta({ format: "date-time" }), z.null()])
+        .describe(
+          "Target date for a deferred (scheduled) publish. Null/absent means publish as soon as approved.",
+        )
+        .optional(),
+      scheduledPublishLockEdits: z
+        .boolean()
+        .describe(
+          "When true, content edits to this draft are frozen while the schedule is pending (rebasing is still allowed).",
+        )
+        .optional(),
+      scheduledPublishLockOthers: z
+        .boolean()
+        .describe(
+          "When true, publishing other drafts of this feature is blocked while the schedule is pending.",
+        )
+        .optional(),
+      scheduledPublishLastError: z
+        .string()
+        .describe(
+          "Set when a due scheduled publish keeps failing (e.g. still awaiting approval, merge conflict). Indicates the schedule is stuck and retrying.",
+        )
+        .optional(),
       reviews: z
         .array(
           z

--- a/packages/shared/src/validators/features-v2.ts
+++ b/packages/shared/src/validators/features-v2.ts
@@ -158,6 +158,12 @@ export const apiFeatureRevisionV2Validator = namedSchema(
           "When true, publishing other drafts of this feature is blocked while the schedule is pending.",
         )
         .optional(),
+      scheduledPublishBypassApproval: z
+        .boolean()
+        .describe(
+          "When true, this schedule was armed by an admin via the bypass-approval override. It cannot be edited inline (only canceled and re-armed) and anyone with publish authority may cancel it.",
+        )
+        .optional(),
       scheduledPublishLastError: z
         .string()
         .describe(

--- a/packages/shared/src/validators/features.ts
+++ b/packages/shared/src/validators/features.ts
@@ -379,6 +379,12 @@ const minimalFeatureRevisionInterface = z
     comment: z.string(),
     title: z.string().optional(),
     contributors: z.array(z.string()).optional(),
+    // Scheduled-publish state — surfaced so revision lists/dropdowns can show a
+    // "Scheduled" status + lock indicators without fetching full revisions.
+    autoPublishOnApproval: z.boolean().optional(),
+    scheduledPublishAt: z.union([z.null(), z.date()]).optional(),
+    scheduledPublishLockEdits: z.boolean().optional(),
+    scheduledPublishLockOthers: z.boolean().optional(),
   })
   .strict();
 
@@ -584,6 +590,18 @@ const featureRevisionInterface = minimalFeatureRevisionInterface
     // an actor without a user ID (e.g. an API key), in which case the
     // publish falls back to `createdBy`.
     autoPublishEnabledBy: z.string().optional(),
+    // Deferred publish: when set, an armed revision (autoPublishOnApproval) does
+    // not publish until on/after this date — and, if review is required, only once
+    // also approved. `null`/absent keeps today's "publish as soon as approved"
+    // behavior. The Agenda poller (updateScheduledPublishes) fires it.
+    scheduledPublishAt: z.union([z.null(), z.date()]).optional(),
+    // While a schedule is pending, freeze content edits to this draft. Rebase is
+    // still permitted (to keep it mergeable) unless it would invalidate a required
+    // approval. Lets authors "set and forget" without drift.
+    scheduledPublishLockEdits: z.boolean().optional(),
+    // While a schedule is pending, block publishing OTHER drafts of this feature so
+    // the live version can't advance out from under the scheduled change.
+    scheduledPublishLockOthers: z.boolean().optional(),
     // Active reviewer verdicts for the current review cycle (one entry per
     // reviewer). Kept in sync by the review lifecycle mutations:
     // submit review upserts, undo review removes, request/recall review

--- a/packages/shared/src/validators/features.ts
+++ b/packages/shared/src/validators/features.ts
@@ -385,6 +385,7 @@ const minimalFeatureRevisionInterface = z
     scheduledPublishAt: z.union([z.null(), z.date()]).optional(),
     scheduledPublishLockEdits: z.boolean().optional(),
     scheduledPublishLockOthers: z.boolean().optional(),
+    scheduledPublishBypassApproval: z.boolean().optional(),
   })
   .strict();
 
@@ -597,6 +598,13 @@ const featureRevisionInterface = minimalFeatureRevisionInterface
     scheduledPublishLockEdits: z.boolean().optional(),
     // While pending, block publishing other drafts of this feature.
     scheduledPublishLockOthers: z.boolean().optional(),
+    // True when an admin armed this schedule via the bypass-approval override.
+    // The schedule is then treated as "dangerous": it can't be edited inline
+    // (only canceled and re-armed) and anyone with publish authority may cancel
+    // it. Fire-time bypass still derives from the armer's live role, not this
+    // flag. Cleared whenever the schedule is canceled or the revision leaves the
+    // review cycle (part of SCHEDULED_PUBLISH_UNSET).
+    scheduledPublishBypassApproval: z.boolean().optional(),
     // Set by the scheduled-publish poller when a due publish can't go through
     // (e.g. still awaiting approval, merge conflict). Lets the UI surface a
     // stuck schedule instead of it silently retrying forever. Cleared on a

--- a/packages/shared/src/validators/features.ts
+++ b/packages/shared/src/validators/features.ts
@@ -379,8 +379,8 @@ const minimalFeatureRevisionInterface = z
     comment: z.string(),
     title: z.string().optional(),
     contributors: z.array(z.string()).optional(),
-    // Scheduled-publish state — surfaced so revision lists/dropdowns can show a
-    // "Scheduled" status + lock indicators without fetching full revisions.
+    // Surfaced so revision lists/dropdowns can show schedule status + lock
+    // indicators without fetching full revisions.
     autoPublishOnApproval: z.boolean().optional(),
     scheduledPublishAt: z.union([z.null(), z.date()]).optional(),
     scheduledPublishLockEdits: z.boolean().optional(),
@@ -590,18 +590,19 @@ const featureRevisionInterface = minimalFeatureRevisionInterface
     // an actor without a user ID (e.g. an API key), in which case the
     // publish falls back to `createdBy`.
     autoPublishEnabledBy: z.string().optional(),
-    // Deferred publish: when set, an armed revision (autoPublishOnApproval) does
-    // not publish until on/after this date — and, if review is required, only once
-    // also approved. `null`/absent keeps today's "publish as soon as approved"
-    // behavior. The Agenda poller (updateScheduledPublishes) fires it.
+    // Defers an armed revision's auto-publish until on/after this date (and, if
+    // required, approved). null/absent = publish as soon as approved.
     scheduledPublishAt: z.union([z.null(), z.date()]).optional(),
-    // While a schedule is pending, freeze content edits to this draft. Rebase is
-    // still permitted (to keep it mergeable) unless it would invalidate a required
-    // approval. Lets authors "set and forget" without drift.
+    // While pending, freeze content edits to this draft (rebase still allowed).
     scheduledPublishLockEdits: z.boolean().optional(),
-    // While a schedule is pending, block publishing OTHER drafts of this feature so
-    // the live version can't advance out from under the scheduled change.
+    // While pending, block publishing other drafts of this feature.
     scheduledPublishLockOthers: z.boolean().optional(),
+    // Set by the scheduled-publish poller when a due publish can't go through
+    // (e.g. still awaiting approval, merge conflict). Lets the UI surface a
+    // stuck schedule instead of it silently retrying forever. Cleared on a
+    // successful publish or when the schedule is canceled.
+    scheduledPublishAttempts: z.number().optional(),
+    scheduledPublishLastError: z.string().optional(),
     // Active reviewer verdicts for the current review cycle (one entry per
     // reviewer). Kept in sync by the review lifecycle mutations:
     // submit review upserts, undo review removes, request/recall review

--- a/packages/shared/test/util/features.test.ts
+++ b/packages/shared/test/util/features.test.ts
@@ -14,6 +14,11 @@ import {
   autoMerge,
   getLiveChangesSinceBase,
   evaluatePublishGovernance,
+  isScheduledPublishPending,
+  isScheduledPublishDue,
+  isScheduledPublishLockActive,
+  isRevisionEditLockedBySchedule,
+  findPublishLockingScheduledRevision,
   RevisionFields,
   MergeConflict,
   validateCondition,
@@ -1020,6 +1025,170 @@ describe("evaluatePublishGovernance", () => {
     expect(r.rebaseRequired).toBe(true);
     expect(r.canPublish).toBe(false);
     expect(r.blockReason).toMatch(/approved/i);
+  });
+});
+
+describe("scheduled / deferred publish helpers", () => {
+  const future = new Date(Date.now() + 60 * 60 * 1000);
+  const past = new Date(Date.now() - 60 * 60 * 1000);
+
+  type SchedRev = Parameters<typeof isScheduledPublishPending>[0] &
+    Partial<Parameters<typeof isRevisionEditLockedBySchedule>[0]>;
+
+  const rev = (over: Partial<SchedRev> = {}): SchedRev => ({
+    status: "approved",
+    autoPublishOnApproval: true,
+    scheduledPublishAt: future,
+    ...over,
+  });
+
+  describe("isScheduledPublishPending", () => {
+    it("true for an armed, dated, active draft", () => {
+      expect(isScheduledPublishPending(rev())).toBe(true);
+    });
+    it("false when not armed", () => {
+      expect(
+        isScheduledPublishPending(rev({ autoPublishOnApproval: false })),
+      ).toBe(false);
+    });
+    it("false when no date (on-approval, not deferred)", () => {
+      expect(isScheduledPublishPending(rev({ scheduledPublishAt: null }))).toBe(
+        false,
+      );
+    });
+    it("false once published or discarded", () => {
+      expect(isScheduledPublishPending(rev({ status: "published" }))).toBe(
+        false,
+      );
+      expect(isScheduledPublishPending(rev({ status: "discarded" }))).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("isScheduledPublishDue", () => {
+    it("false while the target date is in the future", () => {
+      expect(isScheduledPublishDue(rev())).toBe(false);
+    });
+    it("true once the target date has passed", () => {
+      expect(isScheduledPublishDue(rev({ scheduledPublishAt: past }))).toBe(
+        true,
+      );
+    });
+    it("coerces ISO-string dates (front-end JSON shape)", () => {
+      expect(
+        isScheduledPublishDue(
+          rev({ scheduledPublishAt: past.toISOString() as unknown as Date }),
+        ),
+      ).toBe(true);
+    });
+    it("false when not pending even if date passed", () => {
+      expect(
+        isScheduledPublishDue(
+          rev({ scheduledPublishAt: past, status: "published" }),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("isScheduledPublishLockActive", () => {
+    it("true for an armed, dated, approved revision", () => {
+      expect(isScheduledPublishLockActive(rev())).toBe(true);
+    });
+    it("true for an armed draft (no-approval committed schedule)", () => {
+      // The schedule-publish endpoint only commits a schedule on a draft when
+      // the change doesn't require review, so a pending draft schedule is
+      // locked in and its locks engage.
+      expect(isScheduledPublishLockActive(rev({ status: "draft" }))).toBe(true);
+    });
+    it("false while still awaiting approval (locks don't apply yet)", () => {
+      expect(
+        isScheduledPublishLockActive(rev({ status: "pending-review" })),
+      ).toBe(false);
+      expect(
+        isScheduledPublishLockActive(rev({ status: "changes-requested" })),
+      ).toBe(false);
+    });
+  });
+
+  describe("isRevisionEditLockedBySchedule", () => {
+    it("true when an active (approved) schedule locks edits", () => {
+      expect(
+        isRevisionEditLockedBySchedule(
+          rev({ scheduledPublishLockEdits: true }),
+        ),
+      ).toBe(true);
+    });
+    it("true when a committed draft (no-approval) schedule locks edits", () => {
+      expect(
+        isRevisionEditLockedBySchedule(
+          rev({ scheduledPublishLockEdits: true, status: "draft" }),
+        ),
+      ).toBe(true);
+    });
+    it("false while still pending approval — edits stay open", () => {
+      expect(
+        isRevisionEditLockedBySchedule(
+          rev({ scheduledPublishLockEdits: true, status: "pending-review" }),
+        ),
+      ).toBe(false);
+      expect(
+        isRevisionEditLockedBySchedule(
+          rev({ scheduledPublishLockEdits: true, status: "changes-requested" }),
+        ),
+      ).toBe(false);
+    });
+    it("false when lock flag is off", () => {
+      expect(
+        isRevisionEditLockedBySchedule(
+          rev({ scheduledPublishLockEdits: false }),
+        ),
+      ).toBe(false);
+    });
+    it("false when the schedule isn't pending", () => {
+      expect(
+        isRevisionEditLockedBySchedule(
+          rev({ scheduledPublishLockEdits: true, scheduledPublishAt: null }),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("findPublishLockingScheduledRevision", () => {
+    const list = [
+      { version: 1, ...rev({ scheduledPublishLockOthers: true }) },
+      { version: 2, ...rev({ scheduledPublishLockOthers: false }) },
+    ];
+    it("finds a sibling whose pending schedule locks others", () => {
+      expect(findPublishLockingScheduledRevision(list, 2)?.version).toBe(1);
+    });
+    it("excludes the revision being published itself", () => {
+      expect(findPublishLockingScheduledRevision(list, 1)).toBe(null);
+    });
+    it("ignores schedules without the lock-others flag", () => {
+      expect(
+        findPublishLockingScheduledRevision(
+          [{ version: 2, ...rev({ scheduledPublishLockOthers: false }) }],
+          99,
+        ),
+      ).toBe(null);
+    });
+    it("ignores a sibling still pending approval (lock not active yet)", () => {
+      expect(
+        findPublishLockingScheduledRevision(
+          [
+            {
+              version: 1,
+              ...rev({
+                scheduledPublishLockOthers: true,
+                status: "pending-review",
+              }),
+            },
+          ],
+          99,
+        ),
+      ).toBe(null);
+    });
   });
 });
 


### PR DESCRIPTION
Defer a draft's publish to a specific date instead of publishing manually.

- Schedule a publish for later — arm a draft to go live automatically on a future date. Works whether or not approvals are required: if review is needed it fires once approved on/after the date; if not, it commits and waits.
- Either side can arm it — the requester or a reviewer can set, change, or cancel a schedule. Once it's active, anyone with publish authority can cancel it (which sends it back to "approved").
- Optional safety locks — while a schedule is pending you can freeze edits to the draft and/or block other drafts of the feature from publishing, so nothing drifts before the scheduled time. Live ramp controls stay usable.
- Clear status everywhere — a "Scheduled to publish" card in the review panel, plus badges/banners on the feature overview, all showing the date and any pending locks. Stuck schedules surface a reason instead of failing silently.
- Timeline + audit — scheduling, changes, and cancellations (including automatic ones from request-changes, recall, or archive) show up in the revision timeline and audit log.
- REST API — schedule state is readable over the v2 API, and you can arm/cancel schedules and request review with a schedule programmatically.


<img width="1260" height="666" alt="image" src="https://github.com/user-attachments/assets/3299a21a-18e9-45c9-bd75-12062f61710a" />
