### PR TITLE
Bump docker/login-action to v4 across all workflows

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -29,7 +29,7 @@ jobs:
         run: helm package .
       - name: Login to OCI registry
         if: ${{ startsWith(github.ref, 'refs/tags/') || inputs.publish }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -22,7 +22,7 @@ jobs:
           ref: ${{ inputs.branch }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.repository == 'growthbook/growthbook' }}
     steps:
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -16,7 +16,7 @@ jobs:
       id-token: write
     steps:
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}


### PR DESCRIPTION
### Features and Changes

Standardizes every `docker/login-action` usage on the latest major (`v4.2.0`), bumping `release.yml`, `rollback.yml`, and `deploy-branch.yml` from `@v1` and `chart.yaml` / `deploy.yml` from `@v3`. This also clears the Node 20 runtime deprecation warning GitHub now emits for `@v3` and earlier.

No behavior change — only the action version. Split out from #6092 to keep that PR focused.

Note: #6092 also touches `deploy.yml` and `deploy-branch.yml` (adding a `dhi.io` login step), so a small merge conflict on the version line is expected depending on merge order — trivial to resolve either way.

### Testing

- [x] YAML validates for all five workflows
- These workflows only run on merge-to-`main` / tag / manual dispatch, so there's no PR-time CI to exercise them; the change is a version-string bump only.