### PR TITLE
Prepare OpenAPI spec for Speakeasy

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -262,8 +262,10 @@ tags:
     x-displayName: Usage
     description: Usage information for metrics in experiments.
   - name: meta
-    x-displayName: meta
-    description: ''
+    x-displayName: Meta
+    description: >-
+      Server metadata, including the running build's version and commit for
+      version-skew checks.
   - name: Dashboards
     x-displayName: Dashboards
     description: ''

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -370,18 +370,15 @@ tags:
   - name: FactTableFilter_model
     x-displayName: Fact Table Filter
     description: <SchemaDefinition schemaRef="#/components/schemas/FactTableFilter" />
-  - name: Feature_model
-    x-displayName: Feature
-    description: <SchemaDefinition schemaRef="#/components/schemas/Feature" />
   - name: FeatureBaseRule_model
     x-displayName: Feature Base Rule
     description: <SchemaDefinition schemaRef="#/components/schemas/FeatureBaseRule" />
   - name: FeatureDefinition_model
     x-displayName: Feature Definition
     description: <SchemaDefinition schemaRef="#/components/schemas/FeatureDefinition" />
-  - name: FeatureEnvironment_model
-    x-displayName: Feature Environment
-    description: <SchemaDefinition schemaRef="#/components/schemas/FeatureEnvironment" />
+  - name: FeatureEnvironmentV1_model
+    x-displayName: Feature Environment V1
+    description: <SchemaDefinition schemaRef="#/components/schemas/FeatureEnvironmentV1" />
   - name: FeatureEnvironmentV2_model
     x-displayName: Feature Environment V2
     description: <SchemaDefinition schemaRef="#/components/schemas/FeatureEnvironmentV2" />
@@ -398,18 +395,23 @@ tags:
   - name: FeatureForceRule_model
     x-displayName: Feature Force Rule
     description: <SchemaDefinition schemaRef="#/components/schemas/FeatureForceRule" />
-  - name: FeatureRevision_model
-    x-displayName: Feature Revision
-    description: <SchemaDefinition schemaRef="#/components/schemas/FeatureRevision" />
+  - name: FeatureRevisionSummary_model
+    x-displayName: Feature Revision Summary
+    description: >-
+      <SchemaDefinition schemaRef="#/components/schemas/FeatureRevisionSummary"
+      />
+  - name: FeatureRevisionV1_model
+    x-displayName: Feature Revision V1
+    description: <SchemaDefinition schemaRef="#/components/schemas/FeatureRevisionV1" />
   - name: FeatureRevisionV2_model
     x-displayName: Feature Revision V2
     description: <SchemaDefinition schemaRef="#/components/schemas/FeatureRevisionV2" />
   - name: FeatureRolloutRule_model
     x-displayName: Feature Rollout Rule
     description: <SchemaDefinition schemaRef="#/components/schemas/FeatureRolloutRule" />
-  - name: FeatureRule_model
-    x-displayName: Feature Rule
-    description: <SchemaDefinition schemaRef="#/components/schemas/FeatureRule" />
+  - name: FeatureRuleV1_model
+    x-displayName: Feature Rule V1
+    description: <SchemaDefinition schemaRef="#/components/schemas/FeatureRuleV1" />
   - name: FeatureRuleV2_model
     x-displayName: Feature Rule V2
     description: <SchemaDefinition schemaRef="#/components/schemas/FeatureRuleV2" />
@@ -418,12 +420,17 @@ tags:
     description: >-
       <SchemaDefinition schemaRef="#/components/schemas/FeatureSafeRolloutRule"
       />
+  - name: FeatureV1_model
+    x-displayName: Feature V1
+    description: <SchemaDefinition schemaRef="#/components/schemas/FeatureV1" />
   - name: FeatureV2_model
     x-displayName: Feature V2
     description: <SchemaDefinition schemaRef="#/components/schemas/FeatureV2" />
-  - name: FeatureWithRevisions_model
-    x-displayName: Feature With Revisions
-    description: <SchemaDefinition schemaRef="#/components/schemas/FeatureWithRevisions" />
+  - name: FeatureWithRevisionsV1_model
+    x-displayName: Feature With Revisions V1
+    description: >-
+      <SchemaDefinition schemaRef="#/components/schemas/FeatureWithRevisionsV1"
+      />
   - name: FeatureWithRevisionsV2_model
     x-displayName: Feature With Revisions V2
     description: >-
@@ -565,7 +572,7 @@ paths:
                       features:
                         type: array
                         items:
-                          $ref: '#/components/schemas/Feature'
+                          $ref: '#/components/schemas/FeatureV1'
                     required:
                       - features
                     additionalProperties: false
@@ -1340,7 +1347,7 @@ paths:
                 type: object
                 properties:
                   feature:
-                    $ref: '#/components/schemas/Feature'
+                    $ref: '#/components/schemas/FeatureV1'
                 required:
                   - feature
                 additionalProperties: false
@@ -1371,7 +1378,7 @@ paths:
                 type: object
                 properties:
                   feature:
-                    $ref: '#/components/schemas/FeatureWithRevisions'
+                    $ref: '#/components/schemas/FeatureWithRevisionsV1'
                 required:
                   - feature
                 additionalProperties: false
@@ -2154,7 +2161,7 @@ paths:
                 type: object
                 properties:
                   feature:
-                    $ref: '#/components/schemas/Feature'
+                    $ref: '#/components/schemas/FeatureV1'
                 required:
                   - feature
                 additionalProperties: false
@@ -2270,7 +2277,7 @@ paths:
                 type: object
                 properties:
                   feature:
-                    $ref: '#/components/schemas/Feature'
+                    $ref: '#/components/schemas/FeatureV1'
                 required:
                   - feature
                 additionalProperties: false
@@ -2333,7 +2340,7 @@ paths:
                 type: object
                 properties:
                   feature:
-                    $ref: '#/components/schemas/Feature'
+                    $ref: '#/components/schemas/FeatureV1'
                 required:
                   - feature
                 additionalProperties: false
@@ -2435,7 +2442,7 @@ paths:
                   revisions:
                     type: array
                     items:
-                      $ref: '#/components/schemas/FeatureRevision'
+                      $ref: '#/components/schemas/FeatureRevisionV1'
                   limit:
                     type: integer
                   offset:
@@ -2496,7 +2503,7 @@ paths:
                   revisions:
                     type: array
                     items:
-                      $ref: '#/components/schemas/FeatureRevision'
+                      $ref: '#/components/schemas/FeatureRevisionV1'
                   limit:
                     type: integer
                   offset:
@@ -2569,7 +2576,7 @@ paths:
                 type: object
                 properties:
                   revision:
-                    $ref: '#/components/schemas/FeatureRevision'
+                    $ref: '#/components/schemas/FeatureRevisionV1'
                 required:
                   - revision
                 additionalProperties: false
@@ -2632,7 +2639,7 @@ paths:
                 type: object
                 properties:
                   revision:
-                    $ref: '#/components/schemas/FeatureRevision'
+                    $ref: '#/components/schemas/FeatureRevisionV1'
                 required:
                   - revision
                 additionalProperties: false
@@ -2674,7 +2681,7 @@ paths:
                 type: object
                 properties:
                   revision:
-                    $ref: '#/components/schemas/FeatureRevision'
+                    $ref: '#/components/schemas/FeatureRevisionV1'
                 required:
                   - revision
                 additionalProperties: false
@@ -2841,7 +2848,7 @@ paths:
                 type: object
                 properties:
                   revision:
-                    $ref: '#/components/schemas/FeatureRevision'
+                    $ref: '#/components/schemas/FeatureRevisionV1'
                 required:
                   - revision
                 additionalProperties: false
@@ -2910,7 +2917,7 @@ paths:
                 type: object
                 properties:
                   revision:
-                    $ref: '#/components/schemas/FeatureRevision'
+                    $ref: '#/components/schemas/FeatureRevisionV1'
                 required:
                   - revision
                 additionalProperties: false
@@ -2990,7 +2997,7 @@ paths:
                 type: object
                 properties:
                   revision:
-                    $ref: '#/components/schemas/FeatureRevision'
+                    $ref: '#/components/schemas/FeatureRevisionV1'
                 required:
                   - revision
                 additionalProperties: false
@@ -3069,7 +3076,7 @@ paths:
                 type: object
                 properties:
                   revision:
-                    $ref: '#/components/schemas/FeatureRevision'
+                    $ref: '#/components/schemas/FeatureRevisionV1'
                 required:
                   - revision
                 additionalProperties: false
@@ -3136,7 +3143,7 @@ paths:
                 type: object
                 properties:
                   revision:
-                    $ref: '#/components/schemas/FeatureRevision'
+                    $ref: '#/components/schemas/FeatureRevisionV1'
                 required:
                   - revision
                 additionalProperties: false
@@ -3206,7 +3213,7 @@ paths:
                 type: object
                 properties:
                   revision:
-                    $ref: '#/components/schemas/FeatureRevision'
+                    $ref: '#/components/schemas/FeatureRevisionV1'
                 required:
                   - revision
                 additionalProperties: false
@@ -4004,7 +4011,7 @@ paths:
                 type: object
                 properties:
                   revision:
-                    $ref: '#/components/schemas/FeatureRevision'
+                    $ref: '#/components/schemas/FeatureRevisionV1'
                 required:
                   - revision
                 additionalProperties: false
@@ -4600,7 +4607,7 @@ paths:
                 type: object
                 properties:
                   revision:
-                    $ref: '#/components/schemas/FeatureRevision'
+                    $ref: '#/components/schemas/FeatureRevisionV1'
                 required:
                   - revision
                 additionalProperties: false
@@ -4668,7 +4675,7 @@ paths:
                 type: object
                 properties:
                   revision:
-                    $ref: '#/components/schemas/FeatureRevision'
+                    $ref: '#/components/schemas/FeatureRevisionV1'
                 required:
                   - revision
                 additionalProperties: false
@@ -4742,7 +4749,7 @@ paths:
                 type: object
                 properties:
                   revision:
-                    $ref: '#/components/schemas/FeatureRevision'
+                    $ref: '#/components/schemas/FeatureRevisionV1'
                 required:
                   - revision
                 additionalProperties: false
@@ -5210,7 +5217,7 @@ paths:
                 type: object
                 properties:
                   revision:
-                    $ref: '#/components/schemas/FeatureRevision'
+                    $ref: '#/components/schemas/FeatureRevisionV1'
                 required:
                   - revision
                 additionalProperties: false
@@ -5277,7 +5284,7 @@ paths:
                 type: object
                 properties:
                   revision:
-                    $ref: '#/components/schemas/FeatureRevision'
+                    $ref: '#/components/schemas/FeatureRevisionV1'
                 required:
                   - revision
                 additionalProperties: false
@@ -5331,7 +5338,7 @@ paths:
                 type: object
                 properties:
                   revision:
-                    $ref: '#/components/schemas/FeatureRevision'
+                    $ref: '#/components/schemas/FeatureRevisionV1'
                 required:
                   - revision
                 additionalProperties: false
@@ -5398,7 +5405,7 @@ paths:
                 type: object
                 properties:
                   revision:
-                    $ref: '#/components/schemas/FeatureRevision'
+                    $ref: '#/components/schemas/FeatureRevisionV1'
                   autoPublished:
                     type: boolean
                 required:
@@ -5541,7 +5548,7 @@ paths:
                 type: object
                 properties:
                   revision:
-                    $ref: '#/components/schemas/FeatureRevision'
+                    $ref: '#/components/schemas/FeatureRevisionV1'
                 required:
                   - revision
                 additionalProperties: false
@@ -5603,7 +5610,7 @@ paths:
                 type: object
                 properties:
                   revision:
-                    $ref: '#/components/schemas/FeatureRevision'
+                    $ref: '#/components/schemas/FeatureRevisionV1'
                 required:
                   - revision
                 additionalProperties: false
@@ -5655,7 +5662,7 @@ paths:
                 type: object
                 properties:
                   revision:
-                    $ref: '#/components/schemas/FeatureRevision'
+                    $ref: '#/components/schemas/FeatureRevisionV1'
                 required:
                   - revision
                 additionalProperties: false
@@ -5715,7 +5722,7 @@ paths:
                 type: object
                 properties:
                   revision:
-                    $ref: '#/components/schemas/FeatureRevision'
+                    $ref: '#/components/schemas/FeatureRevisionV1'
                 required:
                   - revision
                 additionalProperties: false
@@ -33017,7 +33024,7 @@ components:
           - required
           - never
   schemas:
-    Feature:
+    FeatureV1:
       type: object
       properties:
         id:
@@ -33061,7 +33068,7 @@ components:
           propertyNames:
             type: string
           additionalProperties:
-            $ref: '#/components/schemas/FeatureEnvironment'
+            $ref: '#/components/schemas/FeatureEnvironmentV1'
         prerequisites:
           description: Feature IDs. Each feature must evaluate to `true`
           type: array
@@ -33124,7 +33131,7 @@ components:
         - environments
         - revision
       additionalProperties: false
-    FeatureEnvironment:
+    FeatureEnvironmentV1:
       type: object
       properties:
         enabled:
@@ -33134,7 +33141,7 @@ components:
         rules:
           type: array
           items:
-            $ref: '#/components/schemas/FeatureRule'
+            $ref: '#/components/schemas/FeatureRuleV1'
         definition:
           description: A JSON stringified [FeatureDefinition](#tag/FeatureDefinition_model)
           type: string
@@ -33148,7 +33155,7 @@ components:
             rules:
               type: array
               items:
-                $ref: '#/components/schemas/FeatureRule'
+                $ref: '#/components/schemas/FeatureRuleV1'
             definition:
               description: >-
                 A JSON stringified
@@ -33164,7 +33171,7 @@ components:
         - defaultValue
         - rules
       additionalProperties: false
-    FeatureRule:
+    FeatureRuleV1:
       anyOf:
         - $ref: '#/components/schemas/FeatureForceRule'
         - $ref: '#/components/schemas/FeatureRolloutRule'
@@ -33788,17 +33795,17 @@ components:
         - hasMore
         - nextOffset
       additionalProperties: false
-    FeatureWithRevisions:
+    FeatureWithRevisionsV1:
       allOf:
-        - $ref: '#/components/schemas/Feature'
+        - $ref: '#/components/schemas/FeatureV1'
         - type: object
           properties:
             revisions:
               type: array
               items:
-                $ref: '#/components/schemas/FeatureRevision'
+                $ref: '#/components/schemas/FeatureRevisionV1'
           additionalProperties: false
-    FeatureRevision:
+    FeatureRevisionV1:
       type: object
       properties:
         featureId:
@@ -33829,7 +33836,7 @@ components:
           additionalProperties:
             type: array
             items:
-              $ref: '#/components/schemas/FeatureRule'
+              $ref: '#/components/schemas/FeatureRuleV1'
         definitions:
           type: object
           propertyNames:
@@ -34862,24 +34869,7 @@ components:
           items:
             type: string
         revision:
-          type: object
-          properties:
-            version:
-              type: integer
-            comment:
-              type: string
-            date:
-              format: date-time
-              type: string
-            createdBy:
-              $ref: '#/components/schemas/EventUser'
-            publishedBy:
-              $ref: '#/components/schemas/EventUser'
-          required:
-            - version
-            - comment
-            - date
-          additionalProperties: false
+          $ref: '#/components/schemas/FeatureRevisionSummary'
         customFields:
           type: object
           propertyNames:
@@ -34919,7 +34909,7 @@ components:
       additionalProperties: false
     FeatureRuleV2:
       allOf:
-        - $ref: '#/components/schemas/FeatureRule'
+        - $ref: '#/components/schemas/FeatureRuleV1'
         - type: object
           properties:
             allEnvironments:
@@ -34960,6 +34950,25 @@ components:
       required:
         - enabled
         - defaultValue
+      additionalProperties: false
+    FeatureRevisionSummary:
+      type: object
+      properties:
+        version:
+          type: integer
+        comment:
+          type: string
+        date:
+          format: date-time
+          type: string
+        createdBy:
+          $ref: '#/components/schemas/EventUser'
+        publishedBy:
+          $ref: '#/components/schemas/EventUser'
+      required:
+        - version
+        - comment
+        - date
       additionalProperties: false
     EventUser:
       description: The user (or automated actor) responsible for an action
@@ -46325,22 +46334,23 @@ x-tagGroups:
       - FactTable_model
       - FactTableColumn_model
       - FactTableFilter_model
-      - Feature_model
       - FeatureBaseRule_model
       - FeatureDefinition_model
-      - FeatureEnvironment_model
+      - FeatureEnvironmentV1_model
       - FeatureEnvironmentV2_model
       - FeatureExperimentRefRule_model
       - FeatureExperimentRule_model
       - FeatureForceRule_model
-      - FeatureRevision_model
+      - FeatureRevisionSummary_model
+      - FeatureRevisionV1_model
       - FeatureRevisionV2_model
       - FeatureRolloutRule_model
-      - FeatureRule_model
+      - FeatureRuleV1_model
       - FeatureRuleV2_model
       - FeatureSafeRolloutRule_model
+      - FeatureV1_model
       - FeatureV2_model
-      - FeatureWithRevisions_model
+      - FeatureWithRevisionsV1_model
       - FeatureWithRevisionsV2_model
       - InformationSchema_model
       - InformationSchemaTable_model

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -261,6 +261,9 @@ tags:
   - name: usage
     x-displayName: Usage
     description: Usage information for metrics in experiments.
+  - name: meta
+    x-displayName: meta
+    description: ''
   - name: Dashboards
     x-displayName: Dashboards
     description: ''
@@ -19814,6 +19817,35 @@ paths:
         - lang: cURL
           source: |-
             curl -X GET 'https://api.growthbook.io/api/v1/settings' \
+              -H 'Authorization: Bearer YOUR_API_KEY'
+  /v1/version:
+    get:
+      operationId: getVersion
+      summary: Get the GrowthBook server version and build info
+      tags:
+        - meta
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  version:
+                    type: string
+                  commit:
+                    type: string
+                  date:
+                    type: string
+                required:
+                  - version
+                  - commit
+                  - date
+                additionalProperties: false
+      x-codeSamples:
+        - lang: cURL
+          source: |-
+            curl -X GET 'https://api.growthbook.io/api/v1/version' \
               -H 'Authorization: Bearer YOUR_API_KEY'
   /v1/information-schema-tables/{tableId}:
     get:
@@ -45974,6 +46006,7 @@ x-tagGroups:
       - settings
       - attributes
       - usage
+      - meta
       - Dashboards
       - CustomFields
       - MetricGroups

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -1,8 +1,4 @@
 openapi: 3.1.0
-x-growthbook-build:
-  version: 4.4.0
-  commit: f246588ea
-  date: '2026-06-17'
 info:
   version: 4.4.0
   title: GrowthBook REST API

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -15365,8 +15365,6 @@ paths:
             schema:
               type: object
               properties:
-                id:
-                  type: string
                 description:
                   type: string
                 css:

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -112,6 +112,10 @@ servers:
     description: GrowthBook Cloud
   - url: https://{domain}/api
     description: Self-hosted GrowthBook
+    variables:
+      domain:
+        default: localhost:3100
+        description: Your self-hosted GrowthBook host (and port)
 tags:
   - name: projects
     x-displayName: Projects

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -1,6 +1,10 @@
 openapi: 3.1.0
+x-growthbook-build:
+  version: 4.4.0
+  commit: f246588ea
+  date: '2026-06-17'
 info:
-  version: 1.0.0
+  version: 4.4.0
   title: GrowthBook REST API
   description: >
     GrowthBook offers a full REST API for interacting with the application.

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -555,6 +555,7 @@ paths:
         - $ref: '#/components/parameters/skipPagination'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -1332,6 +1333,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -1362,6 +1364,7 @@ paths:
         - $ref: '#/components/parameters/withRevisions'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -2144,6 +2147,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -2181,6 +2185,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -2258,6 +2263,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -2320,6 +2326,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -2352,6 +2359,7 @@ paths:
         - $ref: '#/components/parameters/projectId'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -2377,6 +2385,7 @@ paths:
         - $ref: '#/components/parameters/ids'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -2417,6 +2426,7 @@ paths:
         - $ref: '#/components/parameters/mine'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -2477,6 +2487,7 @@ paths:
         - $ref: '#/components/parameters/author'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -2551,6 +2562,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -2613,6 +2625,7 @@ paths:
               - type: boolean
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -2654,6 +2667,7 @@ paths:
         - $ref: '#/components/parameters/version'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -2820,6 +2834,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -2888,6 +2903,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -2967,6 +2983,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -3045,6 +3062,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -3111,6 +3129,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -3180,6 +3199,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -3977,6 +3997,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -4572,6 +4593,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -4639,6 +4661,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -4712,6 +4735,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -5179,6 +5203,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -5245,6 +5270,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -5298,6 +5324,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -5364,6 +5391,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -5409,6 +5437,7 @@ paths:
         - $ref: '#/components/parameters/version'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -5505,6 +5534,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -5566,6 +5596,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -5617,6 +5648,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -5676,6 +5708,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -5711,6 +5744,7 @@ paths:
         - $ref: '#/components/parameters/skipPagination'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -6217,6 +6251,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -6243,6 +6278,7 @@ paths:
         - $ref: '#/components/parameters/withRevisions'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -6762,6 +6798,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -6793,6 +6830,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -6859,6 +6897,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -6915,6 +6954,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -6941,6 +6981,7 @@ paths:
         - $ref: '#/components/parameters/projectId'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -6962,6 +7003,7 @@ paths:
         - $ref: '#/components/parameters/ids'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -7100,6 +7142,7 @@ paths:
               - type: boolean
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -7156,6 +7199,7 @@ paths:
         - $ref: '#/components/parameters/mine'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -7222,6 +7266,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -7283,6 +7328,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -7318,6 +7364,7 @@ paths:
         - $ref: '#/components/parameters/version'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -7364,6 +7411,7 @@ paths:
         - $ref: '#/components/parameters/base'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -7639,6 +7687,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -7702,6 +7751,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -7783,6 +7833,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -7857,6 +7908,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -7920,6 +7972,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -7986,6 +8039,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -8497,6 +8551,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -9095,6 +9150,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -9157,6 +9213,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -9226,6 +9283,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -9693,6 +9751,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -9757,6 +9816,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -9811,6 +9871,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -9872,6 +9933,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -9924,6 +9986,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -9973,6 +10036,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -10011,6 +10075,7 @@ paths:
         - $ref: '#/components/parameters/version'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -10065,6 +10130,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -10112,6 +10178,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -10154,6 +10221,7 @@ paths:
         - $ref: '#/components/parameters/version'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -10315,6 +10383,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -10468,6 +10537,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -10523,6 +10593,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -10564,6 +10635,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -10609,6 +10681,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -10659,6 +10732,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -10684,6 +10758,7 @@ paths:
         - archetypes
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -10746,6 +10821,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -10771,6 +10847,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -10830,6 +10907,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -10856,6 +10934,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -10896,6 +10975,7 @@ paths:
               - stopped
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -11406,6 +11486,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -11465,6 +11546,7 @@ paths:
               - stopped
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -11494,6 +11576,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -12008,6 +12091,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -12054,6 +12138,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -12091,6 +12176,7 @@ paths:
         - $ref: '#/components/parameters/dimension'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -12136,6 +12222,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -12238,6 +12325,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -12328,6 +12416,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -12398,6 +12487,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -12486,6 +12576,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -12545,6 +12636,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -12615,6 +12707,7 @@ paths:
         - $ref: '#/components/parameters/projectId'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -12648,6 +12741,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -12713,6 +12807,7 @@ paths:
               additionalProperties: {}
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -12750,6 +12845,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -12778,6 +12874,7 @@ paths:
         - $ref: '#/components/parameters/datasourceId'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -13181,6 +13278,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -13206,6 +13304,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -13593,6 +13692,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -13619,6 +13719,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -13668,6 +13769,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -13697,6 +13799,7 @@ paths:
         - $ref: '#/components/parameters/datasourceId'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -13797,6 +13900,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -13824,6 +13928,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -13917,6 +14022,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -13943,6 +14049,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -13972,6 +14079,7 @@ paths:
         - $ref: '#/components/parameters/datasourceId'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -14042,6 +14150,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -14069,6 +14178,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -14132,6 +14242,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -14158,6 +14269,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -14187,6 +14299,7 @@ paths:
         - $ref: '#/components/parameters/offset'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -14274,6 +14387,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -14301,6 +14415,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -14361,6 +14476,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -14387,6 +14503,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -14412,6 +14529,7 @@ paths:
         - environments
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -14467,6 +14585,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -14515,6 +14634,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -14541,6 +14661,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -14578,6 +14699,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -14655,6 +14777,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -14729,6 +14852,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -14755,6 +14879,7 @@ paths:
         - $ref: '#/components/parameters/property'
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -14785,6 +14910,7 @@ paths:
         - $ref: '#/components/parameters/multiOrg'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -14872,6 +14998,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -14897,6 +15024,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -14979,6 +15107,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -15004,6 +15133,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -15030,6 +15160,7 @@ paths:
         - $ref: '#/components/parameters/key'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -15058,6 +15189,7 @@ paths:
         - $ref: '#/components/parameters/projectId'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -15087,6 +15219,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -15117,6 +15250,7 @@ paths:
         - $ref: '#/components/parameters/dataSourceId'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -15145,6 +15279,7 @@ paths:
         - $ref: '#/components/parameters/includeExperiment'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -15250,6 +15385,7 @@ paths:
               additionalProperties: {}
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -15327,6 +15463,7 @@ paths:
               additionalProperties: {}
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -15402,6 +15539,7 @@ paths:
               additionalProperties: {}
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -15432,6 +15570,7 @@ paths:
         - $ref: '#/components/parameters/offset'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -15517,6 +15656,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -15581,6 +15721,7 @@ paths:
               - type: boolean
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -15629,6 +15770,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -15695,6 +15837,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -15722,6 +15865,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -15748,6 +15892,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -15774,6 +15919,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -15842,6 +15988,7 @@ paths:
               - type: boolean
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -15911,6 +16058,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -15967,6 +16115,7 @@ paths:
               - type: boolean
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -16004,6 +16153,7 @@ paths:
         - $ref: '#/components/parameters/version'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -16076,6 +16226,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -16137,6 +16288,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -16201,6 +16353,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -16262,6 +16415,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -16326,6 +16480,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -16388,6 +16543,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -16441,6 +16597,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -16505,6 +16662,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -16544,6 +16702,7 @@ paths:
         - $ref: '#/components/parameters/version'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -16635,6 +16794,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -16689,6 +16849,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -16735,6 +16896,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -16790,6 +16952,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -16821,6 +16984,7 @@ paths:
         - $ref: '#/components/parameters/offset'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -16890,6 +17054,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -16935,6 +17100,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -16966,6 +17132,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema: {}
@@ -16987,6 +17154,7 @@ paths:
         - $ref: '#/components/parameters/projectId'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -17103,6 +17271,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -17130,6 +17299,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -17254,6 +17424,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -17280,6 +17451,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -17310,6 +17482,7 @@ paths:
         - $ref: '#/components/parameters/offset'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -17369,6 +17542,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -17398,6 +17572,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -17452,6 +17627,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -17481,6 +17657,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -17512,6 +17689,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -17573,6 +17751,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -17608,6 +17787,7 @@ paths:
         - $ref: '#/components/parameters/offset'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -17647,6 +17827,7 @@ paths:
         - $ref: '#/components/parameters/runId'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -17687,6 +17868,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -18191,6 +18373,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -18218,6 +18401,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -18713,6 +18897,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -18740,6 +18925,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -18834,6 +19020,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -19488,6 +19675,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -19571,6 +19759,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -19598,6 +19787,7 @@ paths:
         - $ref: '#/components/parameters/offset'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -19627,6 +19817,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -19658,6 +19849,7 @@ paths:
         - $ref: '#/components/parameters/globalRole'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -19730,6 +19922,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -19755,6 +19948,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -19780,6 +19974,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -19803,6 +19998,7 @@ paths:
         - settings
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -19826,6 +20022,7 @@ paths:
         - meta
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -19861,6 +20058,7 @@ paths:
         - $ref: '#/components/parameters/tableId'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -19905,6 +20103,7 @@ paths:
               - rolled-back
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -20359,6 +20558,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -20409,6 +20609,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -20455,6 +20656,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -20503,6 +20705,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -20567,6 +20770,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -20620,6 +20824,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -20686,6 +20891,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -20741,6 +20947,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -20829,6 +21036,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -20891,6 +21099,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -20954,6 +21163,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -21061,6 +21271,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -21098,6 +21309,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -21180,6 +21392,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -21531,6 +21744,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -21944,6 +22158,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -22298,6 +22513,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -22700,6 +22916,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -22755,6 +22972,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -22789,6 +23007,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -23024,6 +23243,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -23049,6 +23269,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -23074,6 +23295,7 @@ paths:
         - $ref: '#/components/parameters/id'
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -23140,6 +23362,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -23379,6 +23602,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -23406,6 +23630,7 @@ paths:
         - $ref: '#/components/parameters/offset'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -23469,6 +23694,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -23502,6 +23728,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -23558,6 +23785,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -23595,6 +23823,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -23631,6 +23860,7 @@ paths:
         - $ref: '#/components/parameters/offset'
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -23688,6 +23918,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -23731,6 +23962,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema: {}
@@ -23939,6 +24171,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema: {}
@@ -23974,6 +24207,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema: {}
@@ -24015,6 +24249,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema: {}
@@ -24070,6 +24305,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema: {}
@@ -24099,6 +24335,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema: {}
@@ -24133,6 +24370,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema: {}
@@ -24164,6 +24402,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema: {}
@@ -24239,6 +24478,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema: {}
@@ -24293,6 +24533,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema: {}
@@ -24324,6 +24565,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema: {}
@@ -24338,6 +24580,7 @@ paths:
       operationId: getVisualEditorBootstrap
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema: {}
@@ -24360,6 +24603,7 @@ paths:
             maximum: 1000
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema: {}
@@ -24384,6 +24628,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -24413,6 +24658,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -26769,6 +27015,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -27481,6 +27728,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -27503,6 +27751,7 @@ paths:
         - Dashboards
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -27535,6 +27784,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -27649,6 +27899,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -27677,6 +27928,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -27704,6 +27956,7 @@ paths:
         - $ref: '#/components/parameters/index'
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -27734,6 +27987,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -27828,6 +28082,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -27858,6 +28113,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -27887,6 +28143,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -27953,6 +28210,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -28018,6 +28276,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -28040,6 +28299,7 @@ paths:
         - MetricGroups
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -28072,6 +28332,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -28165,6 +28426,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -28195,6 +28457,7 @@ paths:
         - $ref: '#/components/parameters/deleteMembers'
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -28286,6 +28549,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -28308,6 +28572,7 @@ paths:
         - Teams
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -28354,6 +28619,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -28397,6 +28663,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -28428,6 +28695,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -28458,6 +28726,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -28627,6 +28896,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -28797,6 +29067,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -28826,6 +29097,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -29015,6 +29287,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -29306,6 +29579,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -29954,6 +30228,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -30628,6 +30903,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -31037,6 +31313,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -31067,6 +31344,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -31368,6 +31646,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:
@@ -31666,6 +31945,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:
@@ -31689,6 +31969,7 @@ paths:
         - RampScheduleTemplates
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -31722,6 +32003,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Successful response
           content:
             application/json:
               schema:
@@ -31756,6 +32038,7 @@ paths:
             type: string
       responses:
         '200':
+          description: Resource deleted
           content:
             application/json:
               schema:
@@ -32236,6 +32519,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource updated
           content:
             application/json:
               schema:

--- a/packages/back-end/src/api/api.router.ts
+++ b/packages/back-end/src/api/api.router.ts
@@ -45,6 +45,7 @@ import { visualEditorAiRoutes } from "./visual-editor-ai/visualEditorAi.router";
 import { archetypesRoutes } from "./archetypes/archetypes.router";
 import { queriesRoutes } from "./queries/queries.router";
 import { settingsRoutes } from "./settings/settings.router";
+import { metaRoutes } from "./meta/meta.router";
 import { informationSchemaTablesRoutes } from "./information-schema-tables/information-schema-tables.router";
 import { rampSchedulesRoutes } from "./ramp-schedules/ramp-schedules.router";
 import { reportRoutes } from "./reports/reports.router";
@@ -170,6 +171,7 @@ export const allRoutes = [
   ...membersRoutes,
   ...queriesRoutes,
   ...settingsRoutes,
+  ...metaRoutes,
   ...informationSchemaTablesRoutes,
   ...rampSchedulesRoutes,
   ...reportRoutes,

--- a/packages/back-end/src/api/meta/getVersion.ts
+++ b/packages/back-end/src/api/meta/getVersion.ts
@@ -1,0 +1,14 @@
+import { getVersionValidator } from "shared/validators";
+import { createApiRequestHandler } from "back-end/src/util/handler";
+import { getBuild } from "back-end/src/util/build";
+
+export const getVersion = createApiRequestHandler(getVersionValidator)(
+  async () => {
+    const build = getBuild();
+    return {
+      version: build.lastVersion,
+      commit: build.sha,
+      date: build.date,
+    };
+  },
+);

--- a/packages/back-end/src/api/meta/meta.router.ts
+++ b/packages/back-end/src/api/meta/meta.router.ts
@@ -1,0 +1,4 @@
+import { OpenApiRoute } from "back-end/src/util/handler";
+import { getVersion } from "./getVersion";
+
+export const metaRoutes: OpenApiRoute[] = [getVersion];

--- a/packages/back-end/src/scripts/generate-openapi.ts
+++ b/packages/back-end/src/scripts/generate-openapi.ts
@@ -40,6 +40,7 @@ const openApiTags = [
   "settings",
   "attributes",
   "usage",
+  "meta",
 ] as const;
 
 export type OpenApiTag = (typeof openApiTags)[number];
@@ -179,6 +180,11 @@ const tags: Record<OpenApiTag, { display: string; description: string }> = {
   usage: {
     display: "Usage",
     description: "Usage information for metrics in experiments.",
+  },
+  meta: {
+    display: "Meta",
+    description:
+      "Server metadata, including the running build's version and commit for version-skew checks.",
   },
 };
 

--- a/packages/back-end/src/scripts/generate-openapi.ts
+++ b/packages/back-end/src/scripts/generate-openapi.ts
@@ -1,5 +1,6 @@
 import path from "path";
 import fs from "fs";
+import { execSync } from "child_process";
 import { z, ZodNever } from "zod";
 import yaml from "js-yaml";
 import {
@@ -8,6 +9,27 @@ import {
   ApiErrorCode,
 } from "shared/validators";
 import { allRoutes, apiModelTagMeta } from "back-end/src/api/api.router";
+import { getBuild } from "back-end/src/util/build";
+
+// Build identity stamped into the spec so a generated client can tell which
+// server build it was generated against (used for version-skew checks). The
+// orderable field is `date`. version comes from package.json; commit/date from
+// git (buildinfo files are usually absent when the spec is generated).
+function getServerBuild(): { version: string; commit: string; date: string } {
+  const build = getBuild();
+  let { sha: commit, date } = build;
+  if (!commit || !date) {
+    try {
+      commit =
+        commit || execSync("git rev-parse --short HEAD").toString().trim();
+      date =
+        date || execSync("git show -s --format=%cs HEAD").toString().trim();
+    } catch {
+      // git unavailable (e.g. tarball build) — leave whatever we have.
+    }
+  }
+  return { version: build.lastVersion, commit, date };
+}
 
 const openApiTags = [
   "projects",
@@ -378,6 +400,7 @@ type CodeSample = { lang: string; source: string };
 
 async function run() {
   // TODO: add security, etc.
+  const serverBuild = getServerBuild();
   const openapiSpec: {
     openapi: string;
     info: {
@@ -385,6 +408,7 @@ async function run() {
       title: string;
       description: string;
     };
+    "x-growthbook-build": { version: string; commit: string; date: string };
     servers: {
       url: string;
       description: string;
@@ -410,8 +434,9 @@ async function run() {
     };
   } = {
     openapi: "3.1.0",
+    "x-growthbook-build": serverBuild,
     info: {
-      version: "1.0.0",
+      version: serverBuild.version || "1.0.0",
       title: "GrowthBook REST API",
       description: `GrowthBook offers a full REST API for interacting with the application.
 

--- a/packages/back-end/src/scripts/generate-openapi.ts
+++ b/packages/back-end/src/scripts/generate-openapi.ts
@@ -361,13 +361,27 @@ type RequestBody = {
 };
 
 type Response = {
-  description?: string;
+  description: string;
   content: {
     "application/json": {
       schema: z.core.JSONSchema.BaseSchema;
     };
   };
 };
+
+function defaultResponseDescription(method: string): string {
+  switch (method.toLowerCase()) {
+    case "post":
+      return "Resource created";
+    case "put":
+    case "patch":
+      return "Resource updated";
+    case "delete":
+      return "Resource deleted";
+    default:
+      return "Successful response";
+  }
+}
 
 type Path = {
   operationId: string;
@@ -765,7 +779,7 @@ curl https://api.growthbook.io/api/v1/features \
 
     const responses: Record<string, Response> = {
       "200": {
-        ...(responseDescription && { description: responseDescription }),
+        description: responseDescription || defaultResponseDescription(method),
         content: {
           "application/json": {
             schema: responseSchema,

--- a/packages/back-end/src/scripts/generate-openapi.ts
+++ b/packages/back-end/src/scripts/generate-openapi.ts
@@ -1,6 +1,5 @@
 import path from "path";
 import fs from "fs";
-import { execSync } from "child_process";
 import { z, ZodNever } from "zod";
 import yaml from "js-yaml";
 import {
@@ -10,26 +9,6 @@ import {
 } from "shared/validators";
 import { allRoutes, apiModelTagMeta } from "back-end/src/api/api.router";
 import { getBuild } from "back-end/src/util/build";
-
-// Build identity stamped into the spec so a generated client can tell which
-// server build it was generated against (used for version-skew checks). The
-// orderable field is `date`. version comes from package.json; commit/date from
-// git (buildinfo files are usually absent when the spec is generated).
-function getServerBuild(): { version: string; commit: string; date: string } {
-  const build = getBuild();
-  let { sha: commit, date } = build;
-  if (!commit || !date) {
-    try {
-      commit =
-        commit || execSync("git rev-parse --short HEAD").toString().trim();
-      date =
-        date || execSync("git show -s --format=%cs HEAD").toString().trim();
-    } catch {
-      // git unavailable (e.g. tarball build) — leave whatever we have.
-    }
-  }
-  return { version: build.lastVersion, commit, date };
-}
 
 const openApiTags = [
   "projects",
@@ -400,7 +379,7 @@ type CodeSample = { lang: string; source: string };
 
 async function run() {
   // TODO: add security, etc.
-  const serverBuild = getServerBuild();
+  const version = getBuild().lastVersion || "1.0.0";
   const openapiSpec: {
     openapi: string;
     info: {
@@ -408,10 +387,13 @@ async function run() {
       title: string;
       description: string;
     };
-    "x-growthbook-build": { version: string; commit: string; date: string };
     servers: {
       url: string;
       description: string;
+      variables?: Record<
+        string,
+        { default: string; description?: string; enum?: string[] }
+      >;
     }[];
     tags: {
       name: string;
@@ -434,9 +416,8 @@ async function run() {
     };
   } = {
     openapi: "3.1.0",
-    "x-growthbook-build": serverBuild,
     info: {
-      version: serverBuild.version || "1.0.0",
+      version,
       title: "GrowthBook REST API",
       description: `GrowthBook offers a full REST API for interacting with the application.
 

--- a/packages/back-end/src/scripts/generate-openapi.ts
+++ b/packages/back-end/src/scripts/generate-openapi.ts
@@ -477,6 +477,12 @@ The response body will be a JSON object with the following properties:
       {
         url: "https://{domain}/api",
         description: "Self-hosted GrowthBook",
+        variables: {
+          domain: {
+            default: "localhost:3100",
+            description: "Your self-hosted GrowthBook host (and port)",
+          },
+        },
       },
     ],
     tags: openApiTags.map((id) => ({

--- a/packages/shared/src/validators/api-meta.ts
+++ b/packages/shared/src/validators/api-meta.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+// Server metadata endpoints. Tagged "meta" (not "version") so the generated
+// CLI command group doesn't collide with the CLI's built-in `version` command.
+export const getVersionValidator = {
+  bodySchema: z.never(),
+  querySchema: z.never(),
+  paramsSchema: z.never(),
+  responseSchema: z
+    .object({
+      // Semver release version, e.g. "4.4.0".
+      version: z.string(),
+      // Short git commit SHA of the build; "" when build info is unavailable (dev).
+      commit: z.string(),
+      // Build date (YYYY-MM-DD); "" when build info is unavailable (dev). This is
+      // the orderable field clients use for skew/compatibility checks.
+      date: z.string(),
+    })
+    .strict(),
+  summary: "Get the GrowthBook server version and build info",
+  operationId: "getVersion",
+  tags: ["meta"],
+  method: "get" as const,
+  path: "/version",
+};

--- a/packages/shared/src/validators/features-v2.ts
+++ b/packages/shared/src/validators/features-v2.ts
@@ -168,6 +168,23 @@ export type ApiFeatureRevisionV2 = z.infer<
 
 // ---- FeatureV2 (schemas/FeatureV2.yaml) ----
 
+// Slim summary of the current published revision returned inline on Feature
+// responses. Named explicitly so SDK code generators don't auto-name it
+// `FeatureRevision` (which would collide with FeatureRevisionV2 after
+// V2-suffix stripping).
+export const apiFeatureRevisionSummaryValidator = namedSchema(
+  "FeatureRevisionSummary",
+  z
+    .object({
+      version: z.coerce.number().int(),
+      comment: z.string(),
+      date: z.string().meta({ format: "date-time" }),
+      createdBy: apiEventUserValidator.optional(),
+      publishedBy: apiEventUserValidator.optional(),
+    })
+    .strict(),
+);
+
 export const apiFeatureV2Validator = namedSchema(
   "FeatureV2",
   z
@@ -196,13 +213,7 @@ export const apiFeatureV2Validator = namedSchema(
         .array(z.string())
         .describe("Feature IDs. Each feature must evaluate to `true`")
         .optional(),
-      revision: z.object({
-        version: z.coerce.number().int(),
-        comment: z.string(),
-        date: z.string().meta({ format: "date-time" }),
-        createdBy: apiEventUserValidator.optional(),
-        publishedBy: apiEventUserValidator.optional(),
-      }),
+      revision: apiFeatureRevisionSummaryValidator,
       customFields: z.record(z.string(), z.any()).optional(),
       holdout: apiFeatureHoldout,
     })

--- a/packages/shared/src/validators/features.ts
+++ b/packages/shared/src/validators/features.ts
@@ -873,9 +873,9 @@ export const apiFeatureSafeRolloutRuleValidator = namedSchema(
   ),
 );
 
-// ---- FeatureRule (schemas/FeatureRule.yaml) - anyOf / discriminated by type ----
+// ---- FeatureRuleV1 (schemas/FeatureRuleV1.yaml) - anyOf / discriminated by type ----
 export const apiFeatureRuleValidator = namedSchema(
-  "FeatureRule",
+  "FeatureRuleV1",
   z.union([
     apiFeatureForceRuleValidator,
     apiFeatureRolloutRuleValidator,
@@ -940,9 +940,9 @@ export const apiFeatureDefinitionValidator = namedSchema(
     .strict(),
 );
 
-// ---- FeatureEnvironment (schemas/FeatureEnvironment.yaml) ----
+// ---- FeatureEnvironmentV1 (schemas/FeatureEnvironmentV1.yaml) ----
 export const apiFeatureEnvironmentValidator = namedSchema(
-  "FeatureEnvironment",
+  "FeatureEnvironmentV1",
   z
     .object({
       enabled: z.boolean(),
@@ -1045,9 +1045,9 @@ export const apiEventUserValidator = namedSchema(
 
 export type ApiEventUser = z.infer<typeof apiEventUserValidator>;
 
-// ---- FeatureRevision (schemas/FeatureRevision.yaml) ----
+// ---- FeatureRevisionV1 (schemas/FeatureRevisionV1.yaml) ----
 export const apiFeatureRevisionValidator = namedSchema(
-  "FeatureRevision",
+  "FeatureRevisionV1",
   z
     .object({
       featureId: z.string().describe("The feature this revision belongs to"),
@@ -1102,9 +1102,9 @@ export const apiFeatureRevisionValidator = namedSchema(
     .strict(),
 );
 
-// ---- Feature (schemas/Feature.yaml) ----
+// ---- FeatureV1 (schemas/FeatureV1.yaml) ----
 export const apiFeatureValidator = namedSchema(
-  "Feature",
+  "FeatureV1",
   z
     .object({
       id: z.string(),
@@ -1136,9 +1136,9 @@ export const apiFeatureValidator = namedSchema(
     .strict(),
 );
 
-// ---- FeatureWithRevisions (schemas/FeatureWithRevisions.yaml) ----
+// ---- FeatureWithRevisionsV1 (schemas/FeatureWithRevisionsV1.yaml) ----
 export const apiFeatureWithRevisionsValidator = namedSchema(
-  "FeatureWithRevisions",
+  "FeatureWithRevisionsV1",
   z.intersection(
     apiFeatureValidator,
     z.object({

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -15,6 +15,7 @@ export * from "./attributes";
 export * from "./dimensions";
 export * from "./members";
 export * from "./api-settings";
+export * from "./api-meta";
 export * from "./bulk-import";
 export * from "./code-refs";
 export * from "./information-schema-tables";

--- a/packages/shared/src/validators/visual-changesets.ts
+++ b/packages/shared/src/validators/visual-changesets.ts
@@ -293,7 +293,10 @@ export const postVisualChangeValidator = {
 };
 
 export const putVisualChangeValidator = {
-  bodySchema: visualChangeBody.partial(),
+  // The body `id` field is intentionally omitted: the server strips it from
+  // the payload (a client can't rename a visual change via PUT), and keeping
+  // it would collide with the path `id` param in SDK code generation.
+  bodySchema: visualChangeBody.omit({ id: true }).partial(),
   querySchema: z.never(),
   paramsSchema: z
     .object({


### PR DESCRIPTION
### Features and Changes

Prepares the generated OpenAPI spec to drive Speakeasy CLI generation (consumed in a separate repo). Two groups of changes: runtime/versioning wiring for the CLI, and a set of spec-correctness fixes that block SDK/CLI codegen (ported from #5883).

**Runtime & versioning**

- **Fix invalid self-hosted server block.** The `https://{domain}/api` server declared a `{domain}` template variable with no matching `variables` entry — invalid OpenAPI 3.1 that strict parsers/generators reject. Adds a `variables.domain` block defaulting to `localhost:3100`.
- **Add `GET /v1/version`.** Returns `{ version, commit, date }` from `getBuild()`, tagged `meta` (not `version`, to avoid colliding with the generated CLI's built-in `version` command). This is the runtime source of the connected server's build for skew checks.
- **Track the app version in the spec.** `info.version` changes from a static `1.0.0` to the app version (e.g. `4.4.0`), giving the CLI a deterministic "generated-against" version straight from the standard OpenAPI field.

**Spec-correctness fixes for codegen (ported from #5883)**

- **Add a description to every 200 response.** OpenAPI generators/linters expect a `description` on each response. Defaults one by HTTP method (`Resource created`/`updated`/`deleted`, else `Successful response`) when a route doesn't supply its own, and makes the field required on the internal `Response` type.
- **Drop `id` from the `putVisualChange` PUT body.** The field is stripped server-side (a client can't rename a visual change via PUT) and keeping it collides with the path `id` param during SDK code generation. Omitted from the validator.
- **Suffix the v1 `Feature*` schemas with `V1`.** `Feature`, `FeatureRule`, `FeatureRevision`, `FeatureEnvironment`, and `FeatureWithRevisions` collide with their V2 counterparts once generators strip the `V2` suffix. Names them explicitly with a `V1` suffix, and extracts the inline `FeatureV2` revision into a named `FeatureRevisionSummary` so it isn't auto-named `FeatureRevision`.

Note: the committed spec deliberately carries **no** git commit/date. Baking those in made `spec.yaml` a moving target — every commit changed the file, so the `generate-openapi` CI check could never pass (writing the commit hash changes the hash). Generation now depends only on `package.json`, so it's deterministic. Live commit/date are available at runtime via `GET /v1/version`; the CLI sources its own generated-against date from the commit date of `spec.yaml` at build time.

Note: the three ported fixes supersede the relevant parts of #5883 (which is stale and conflicting). The deprecated-route-stripping and broader schema rework from that PR are intentionally **not** included here — the CLI keeps deprecated routes as `-vN` commands.

### Testing

- [x] `pnpm generate-openapi` regenerates `packages/back-end/generated/spec.yaml` cleanly, and re-running it produces no diff regardless of the checked-out commit (CI check passes).
- [x] Spec top shows `info.version` = app version and no `x-growthbook-build`; the self-hosted server entry has a `variables.domain` block.
- [x] `curl -H "Authorization: Bearer <key>" http://localhost:3100/api/v1/version` -> `{"version":"4.4.0","commit":"...","date":"..."}` (commit/date empty in dev without `buildinfo`).
- [x] After the `V1` renames, no dangling `$ref`s to the old un-suffixed schema names and no orphaned definitions remain in the spec.
- [x] Every 200 response in the generated spec has a `description`; `putVisualChange` PUT body no longer carries `id`.
- [x] (Optional) Run an OpenAPI validator to confirm the server block is now valid.
