### PR TITLE
fix(sql): qualify timestamp in user exposures query for Redshift

### DIFF
--- a/packages/back-end/src/integrations/sql/queries/user-experiment-exposures-query.ts
+++ b/packages/back-end/src/integrations/sql/queries/user-experiment-exposures-query.ts
@@ -39,7 +39,7 @@ export function getUserExperimentExposuresQuery(
             const dimensionSelectString = dimensionSelects.join(", ");
 
             return `
-              SELECT timestamp, experiment_id, variation_id, ${dimensionSelectString} FROM (
+              SELECT ${tableAlias}.timestamp, ${tableAlias}.experiment_id, ${tableAlias}.variation_id, ${dimensionSelectString} FROM (
                 ${compileSqlTemplate(
                   exposureQuery.query,
                   {
@@ -48,13 +48,13 @@ export function getUserExperimentExposuresQuery(
                   dialect,
                 )}
               ) ${tableAlias}
-              WHERE ${dialect.castToString(exposureQuery.userIdType)} = '${params.unitId}' AND timestamp >= ${dialect.toTimestamp(startDate)}
+              WHERE ${dialect.castToString(`${tableAlias}.${exposureQuery.userIdType}`)} = '${params.unitId}' AND ${tableAlias}.timestamp >= ${dialect.toTimestamp(startDate)}
             `;
           })
           .join("\nUNION ALL\n")}
       )
       SELECT * FROM __userExposures 
-      ORDER BY timestamp DESC 
+      ORDER BY __userExposures.timestamp DESC 
       LIMIT ${SQL_ROW_LIMIT}
       `,
     dialect.formatDialect,


### PR DESCRIPTION
## Summary

Fixes a Redshift syntax error in the **User Exposures** debugger (`POST /query/user-exposures`) by qualifying `timestamp` (and related columns) with table/CTE aliases in the generated SQL wrapper.


## Problem

When using the **User Exposures** lookup tool (Exposure Debugger) against an **Amazon Redshift** datasource, the query fails with:

```
syntax error at or near "," in context "SELECT timestamp,", at line 4, column 31
```

Example API response:

```json
{
  "status": 200,
  "experimentMap": {},
  "error": "syntax error at or near \",\" in context \"(\n        \n              SELECT timestamp,\", at line 4, column 31",
  "sql": "-- User Exposures Query\n      WITH __userExposures AS (\n        \n              SELECT timestamp, experiment_id, variation_id, ..."
}
```


## Root cause

GrowthBook generates a wrapper query in `user-experiment-exposures-query.ts` that unions all exposure sources for a given `userIdType`:

```sql
WITH __userExposures AS (
  SELECT timestamp, experiment_id, variation_id, ...
  FROM ( <user exposure SQL> ) t0
  WHERE ... AND timestamp >= '...'
  UNION ALL
  ...
)
SELECT * FROM __userExposures
ORDER BY timestamp DESC
LIMIT 1000
```

On **Redshift**, `TIMESTAMP` is a [reserved keyword](https://docs.aws.amazon.com/redshift/latest/dg/r_pg_keywords.html). When the parser sees **bare** `timestamp` immediately after `SELECT`, it interprets it as the type keyword, not a column name. The next token is `,`, which is invalid in that context — hence the error at the comma (position 17 in a minimal repro, column 31 in the full generated query).

This can be reproduced directly in Redshift:

```sql
-- Fails
SELECT timestamp, experiment_id
FROM (SELECT now() AS timestamp, 'exp1' AS experiment_id) t0;

-- Works
SELECT t0.timestamp, experiment_id
FROM (SELECT now() AS timestamp, 'exp1' AS experiment_id) t0;
```

The issue is **not** in user-defined exposure SQL. Inner queries correctly alias e.g. `collector_tstamp AS timestamp`. The bug is in GrowthBook's **outer wrapper** using unqualified `timestamp`.
