### PR TITLE
Wraps event track call in try/catch

### DIFF
--- a/packages/back-end/src/enterprise/licenseUtil.ts
+++ b/packages/back-end/src/enterprise/licenseUtil.ts
@@ -607,7 +607,7 @@ export function shouldNotifyLicenseServer(
 
 /**
  * Notifies the license server of a billable product event, forwarded to Orb
- * for usage-based billing.
+ * for usage-based billing. Errors are swallowed and logged. Fire and forget.
  *
  * @param eventName         - Event name (must be on the license server's allowlist).
  * @param uniqueId          - Natural identifier for the entity this event is about
@@ -634,18 +634,23 @@ export async function notifyLicenseServerEvent({
   uniqueId: string;
   metadata: Record<string, unknown>;
   timestampOverride?: string;
-}) {
+}): Promise<void> {
   const url = `${LICENSE_SERVER_URL}events/track`;
-  await callLicenseServer({
-    url,
-    body: JSON.stringify({
-      licenseKey,
-      eventName,
-      uniqueId,
-      metadata,
-      timestamp: timestampOverride ?? new Date().toISOString(),
-    }),
-  });
+
+  try {
+    await callLicenseServer({
+      url,
+      body: JSON.stringify({
+        licenseKey,
+        eventName,
+        uniqueId,
+        metadata,
+        timestamp: timestampOverride ?? new Date().toISOString(),
+      }),
+    });
+  } catch (e) {
+    logger.error(e, "Error posting license server event");
+  }
 }
 
 export async function postResendEmailVerificationEmailToLicenseServer(

--- a/packages/back-end/src/enterprise/licenseUtil.ts
+++ b/packages/back-end/src/enterprise/licenseUtil.ts
@@ -649,7 +649,10 @@ export async function notifyLicenseServerEvent({
       }),
     });
   } catch (e) {
-    logger.error(e, "Error posting license server event");
+    logger.error(
+      { err: e, eventName, uniqueId },
+      "Error posting license server event",
+    );
   }
 }
 

--- a/packages/back-end/src/enterprise/licenseUtil.ts
+++ b/packages/back-end/src/enterprise/licenseUtil.ts
@@ -622,7 +622,7 @@ export function shouldNotifyLicenseServer(
  * @param timestampOverride - ISO 8601 event timestamp. Defaults to now. Pass this
  *                            only when backdating historical events.
  */
-export async function notifyLicenseServerEvent({
+export function notifyLicenseServerEvent({
   licenseKey,
   eventName,
   uniqueId,
@@ -634,26 +634,24 @@ export async function notifyLicenseServerEvent({
   uniqueId: string;
   metadata: Record<string, unknown>;
   timestampOverride?: string;
-}): Promise<void> {
+}): void {
   const url = `${LICENSE_SERVER_URL}events/track`;
 
-  try {
-    await callLicenseServer({
-      url,
-      body: JSON.stringify({
-        licenseKey,
-        eventName,
-        uniqueId,
-        metadata,
-        timestamp: timestampOverride ?? new Date().toISOString(),
-      }),
-    });
-  } catch (e) {
+  callLicenseServer({
+    url,
+    body: JSON.stringify({
+      licenseKey,
+      eventName,
+      uniqueId,
+      metadata,
+      timestamp: timestampOverride ?? new Date().toISOString(),
+    }),
+  }).catch((e) => {
     logger.error(
       { err: e, eventName, uniqueId },
       "Error posting license server event",
     );
-  }
+  });
 }
 
 export async function postResendEmailVerificationEmailToLicenseServer(

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -2101,8 +2101,6 @@ const onExperimentUpdate = async ({
       eventName: "experiment_started",
       uniqueId: newExperiment.id,
       metadata: { experiment_id: newExperiment.id },
-    }).catch((e) => {
-      logger.error(e, "Failed to notify license server of experiment start");
     });
   }
 };


### PR DESCRIPTION
### Features and Changes

- Makes license server event tracking best-effort by catching and logging failures inside `notifyLicenseServerEvent`.
- Prevents license server/network errors from blocking experiment status updates when an experiment is started.
- Simplifies the experiment tracking call site now that the notification helper owns its fire-and-forget error handling.

### Dependencies

None.

### Testing

- [x] Verify that you can still send an experiment tracking event to the license server
- [x] Verify if the license server returns an error when tracking an experiment start, it doesn't block starting the experiment

### Screenshots

N/A