### PR TITLE
feat: directly inject custom markdown with expandable content

### DIFF
--- a/packages/front-end/components/Experiment/CompletedExperimentList.tsx
+++ b/packages/front-end/components/Experiment/CompletedExperimentList.tsx
@@ -7,7 +7,6 @@ import React, { useState } from "react";
 import { isFactMetricId, getAllVariations } from "shared/experiments";
 import { date } from "shared/dates";
 import { ExperimentInterfaceStringDates } from "shared/types/experiment";
-import CustomMarkdown from "@/components/Markdown/CustomMarkdown";
 import EmptyState from "@/components/EmptyState";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import ExperimentStatusIndicator from "@/components/Experiment/TabbedPage/ExperimentStatusIndicator";
@@ -59,7 +58,6 @@ const CompletedExperimentList = ({
           restrictVariation={false}
         />
       )}
-      <CustomMarkdown page={"learnings"} />
       <Box>
         {experiments.length === 0 ? (
           <EmptyState

--- a/packages/front-end/components/Experiment/TabbedPage/index.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/index.tsx
@@ -14,7 +14,7 @@ import { URLRedirectInterface } from "shared/types/url-redirect";
 import { FaChartBar } from "react-icons/fa";
 import { HoldoutInterfaceStringDates } from "shared/validators";
 import { FeatureInterface } from "shared/types/feature";
-import { Text } from "@radix-ui/themes";
+import { Box, Text } from "@radix-ui/themes";
 import {
   getAvailableMetricsFilters,
   getAvailableMetricTags,
@@ -544,7 +544,9 @@ export default function TabbedPage({
         {experiment.type !== "holdout" &&
           tab !== "dashboards" &&
           !showDashboardView && (
-            <CustomMarkdown page={"experiment"} variables={variables} />
+            <Box mt="3">
+              <CustomMarkdown page={"experiment"} variables={variables} />
+            </Box>
           )}
         {showStoppedBanner && (
           <div className="pt-3">

--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -844,6 +844,9 @@ export default function FeaturesOverview({
             </>
           );
         })()}
+        <Box mt="3">
+          <CustomMarkdown page={"feature"} variables={variables} />
+        </Box>
         {revision && (
           <Frame mt="2" mb="4" px="6" py="4">
             <Flex align="start" justify="between" mb="2" wrap="wrap" gap="2">
@@ -1068,9 +1071,6 @@ export default function FeaturesOverview({
           </Collapsible>
         </Frame>
 
-        <Box mt="3">
-          <CustomMarkdown page={"feature"} variables={variables} />
-        </Box>
         <Frame mb="4" px="6" py="4">
           <Flex align="center" justify="between" gap="2" mb="2">
             <Heading as="h4" size="small" mb="0">

--- a/packages/front-end/components/Markdown/CustomMarkdown.module.scss
+++ b/packages/front-end/components/Markdown/CustomMarkdown.module.scss
@@ -1,14 +1,3 @@
 .customMarkdown {
   border-color: var(--custom-markdown-border);
-  color: var(--text-color-primary);
-
-  .header {
-    display: flex;
-    align-items: center;
-    margin-bottom: 12px;
-  }
-
-  .content {
-    padding-left: 28px;
-  }
 }

--- a/packages/front-end/components/Markdown/CustomMarkdown.module.scss
+++ b/packages/front-end/components/Markdown/CustomMarkdown.module.scss
@@ -2,11 +2,13 @@
   border-color: var(--custom-markdown-border);
   color: var(--text-color-primary);
 
-  a {
-    vertical-align: middle;
+  .header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 12px;
+  }
 
-    &:hover {
-      text-decoration: underline !important;
-    }
+  .content {
+    padding-left: 28px;
   }
 }

--- a/packages/front-end/components/Markdown/CustomMarkdown.tsx
+++ b/packages/front-end/components/Markdown/CustomMarkdown.tsx
@@ -1,7 +1,6 @@
-import React from "react";
 import Handlebars from "handlebars";
-import { PiNote } from "react-icons/pi";
 import clsx from "clsx";
+import { useMemo } from "react";
 import { useUser } from "@/services/UserContext";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import ExpandableContent from "@/ui/ExpandableContent";
@@ -15,65 +14,46 @@ const PAGE_TO_SETTING_NAME = {
   featureList: "featureListMarkdown",
   metric: "metricPageMarkdown",
   metricList: "metricListMarkdown",
-};
+} as const;
 
-const PAGE_TO_CTA = {
-  experiment: "How to run an experiment at ",
-  experimentList: "How to prepare an experiment at ",
-  feature: "How to configure a feature flag at ",
-  featureList: "How to create a feature flag at ",
-  metric: "How to create a metric at ",
-  metricList: "How to create a metric at ",
-};
+export type CustomMarkdownPage = keyof typeof PAGE_TO_SETTING_NAME;
 
-const DEFAULT_MAX_HEIGHT = 150;
+const DEFAULT_MAX_HEIGHT = 100;
 
 interface Props {
-  page:
-    | "experiment"
-    | "experimentList"
-    | "feature"
-    | "featureList"
-    | "metric"
-    | "metricList"
-    | "learnings";
+  page: CustomMarkdownPage;
   variables?: Record<string, unknown>;
   maxHeight?: number;
 }
 
-const CustomMarkdown: React.FC<Props> = ({
+export default function CustomMarkdown({
   page,
   variables,
   maxHeight = DEFAULT_MAX_HEIGHT,
-}) => {
+}: Props) {
   const { name, organization, hasCommercialFeature } = useUser();
   const settings = useOrgSettings();
-  const settingName = PAGE_TO_SETTING_NAME[page];
-  const markdown = settings[settingName];
+  const markdown = settings[PAGE_TO_SETTING_NAME[page]];
 
-  if (!markdown || !hasCommercialFeature("custom-markdown")) return null;
+  const renderedMarkdown = useMemo(() => {
+    if (!markdown) return null;
+    const template = Handlebars.compile(markdown);
+    return template({
+      user: name,
+      orgName: organization.name,
+      ...variables,
+    });
+  }, [markdown, name, organization.name, variables]);
 
-  const baseVariables = {
-    user: name,
-    orgName: organization.name,
-  };
-
-  const template = Handlebars.compile(markdown);
-  const renderedMarkdown = template({ ...baseVariables, ...variables });
+  if (!renderedMarkdown || !hasCommercialFeature("custom-markdown")) {
+    return null;
+  }
 
   return (
-    <div className={clsx(styles.customMarkdown, "appbox p-4")}>
-      <div className={styles.header}>
-        <PiNote className="mr-2" style={{ height: "20px", width: "20px" }} />
-        <strong>{PAGE_TO_CTA[page] + organization.name}</strong>
-      </div>
-      <div className={styles.content}>
-        <ExpandableContent maxHeight={maxHeight}>
-          <Markdown>{renderedMarkdown}</Markdown>
-        </ExpandableContent>
-      </div>
+    <div className={clsx("appbox p-4", styles.customMarkdown)}>
+      <ExpandableContent maxHeight={maxHeight}>
+        <Markdown>{renderedMarkdown}</Markdown>
+      </ExpandableContent>
     </div>
   );
-};
-
-export default CustomMarkdown;
+}

--- a/packages/front-end/components/Markdown/CustomMarkdown.tsx
+++ b/packages/front-end/components/Markdown/CustomMarkdown.tsx
@@ -1,10 +1,10 @@
-import React, { useState } from "react";
+import React from "react";
 import Handlebars from "handlebars";
 import { PiNote } from "react-icons/pi";
 import clsx from "clsx";
 import { useUser } from "@/services/UserContext";
 import useOrgSettings from "@/hooks/useOrgSettings";
-import ModalStandard from "@/ui/Modal/Patterns/ModalStandard";
+import ExpandableContent from "@/ui/ExpandableContent";
 import Markdown from "./Markdown";
 import styles from "./CustomMarkdown.module.scss";
 
@@ -26,6 +26,8 @@ const PAGE_TO_CTA = {
   metricList: "How to create a metric at ",
 };
 
+const DEFAULT_MAX_HEIGHT = 150;
+
 interface Props {
   page:
     | "experiment"
@@ -36,14 +38,18 @@ interface Props {
     | "metricList"
     | "learnings";
   variables?: Record<string, unknown>;
+  maxHeight?: number;
 }
 
-const CustomMarkdown: React.FC<Props> = ({ page, variables }) => {
+const CustomMarkdown: React.FC<Props> = ({
+  page,
+  variables,
+  maxHeight = DEFAULT_MAX_HEIGHT,
+}) => {
   const { name, organization, hasCommercialFeature } = useUser();
   const settings = useOrgSettings();
   const settingName = PAGE_TO_SETTING_NAME[page];
   const markdown = settings[settingName];
-  const [showModal, setShowModal] = useState(false);
 
   if (!markdown || !hasCommercialFeature("custom-markdown")) return null;
 
@@ -56,26 +62,17 @@ const CustomMarkdown: React.FC<Props> = ({ page, variables }) => {
   const renderedMarkdown = template({ ...baseVariables, ...variables });
 
   return (
-    <>
-      {showModal && (
-        <ModalStandard
-          trackingEventModalType=""
-          open={true}
-          header={PAGE_TO_CTA[page] + organization.name}
-          close={() => setShowModal(false)}
-          size="lg"
-        >
-          <Markdown>{renderedMarkdown}</Markdown>
-        </ModalStandard>
-      )}
-
-      <div className={clsx(styles.customMarkdown, "appbox p-4")}>
+    <div className={clsx(styles.customMarkdown, "appbox p-4")}>
+      <div className={styles.header}>
         <PiNote className="mr-2" style={{ height: "20px", width: "20px" }} />
-        <a role="button" onClick={() => setShowModal(true)}>
-          <strong>{PAGE_TO_CTA[page] + organization.name}</strong>
-        </a>
+        <strong>{PAGE_TO_CTA[page] + organization.name}</strong>
       </div>
-    </>
+      <div className={styles.content}>
+        <ExpandableContent maxHeight={maxHeight}>
+          <Markdown>{renderedMarkdown}</Markdown>
+        </ExpandableContent>
+      </div>
+    </div>
   );
 };
 

--- a/packages/front-end/components/Reviews/Feature/RevisionDiffUtils.tsx
+++ b/packages/front-end/components/Reviews/Feature/RevisionDiffUtils.tsx
@@ -28,6 +28,7 @@ import {
   RevisionLog,
 } from "shared/types/feature-revision";
 import { RampScheduleInterface, HoldoutInterface } from "shared/validators";
+import ExpandableContent from "@/ui/ExpandableContent";
 import Text from "@/ui/Text";
 import Button from "@/ui/Button";
 import SplitButton from "@/ui/SplitButton";
@@ -173,65 +174,6 @@ export function DiffFormatToggle({
         {visible.map(segment)}
       </SplitButton>
     </Box>
-  );
-}
-
-// Height-capped wrapper with a fade-out and a "Show more"/"Show less" toggle
-// (same affordance as the Notes panel). Only collapses when the content
-// actually overflows; a ResizeObserver re-checks as content reflows.
-function CollapsedSection({
-  maxHeight,
-  children,
-}: {
-  maxHeight: number;
-  children: React.ReactNode;
-}) {
-  const [expanded, setExpanded] = useState(false);
-  const [overflowing, setOverflowing] = useState(false);
-  const contentRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    const el = contentRef.current;
-    if (!el) return;
-    const check = () => setOverflowing(el.scrollHeight > maxHeight + 1);
-    check();
-    const ro = new ResizeObserver(check);
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [maxHeight]);
-
-  return (
-    <>
-      <Box
-        style={
-          !expanded && overflowing
-            ? { position: "relative", maxHeight, overflow: "hidden" }
-            : { position: "relative" }
-        }
-      >
-        <Box ref={contentRef}>{children}</Box>
-        {!expanded && overflowing && (
-          <Box
-            style={{
-              position: "absolute",
-              bottom: 0,
-              left: 0,
-              right: 0,
-              height: 64,
-              background:
-                "linear-gradient(transparent, var(--color-panel-solid))",
-              pointerEvents: "none",
-            }}
-          />
-        )}
-      </Box>
-      {overflowing && (
-        <Box mt="2">
-          <Link onClick={() => setExpanded((v) => !v)}>
-            {expanded ? "Show less" : "Show more"}
-          </Link>
-        </Box>
-      )}
-    </>
   );
 }
 
@@ -1860,9 +1802,9 @@ export function DiffContent({
                   </Flex>
                 );
               return collapsedMaxHeight ? (
-                <CollapsedSection maxHeight={collapsedMaxHeight}>
+                <ExpandableContent maxHeight={collapsedMaxHeight}>
                   {view}
-                </CollapsedSection>
+                </ExpandableContent>
               ) : (
                 view
               );

--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -188,7 +188,9 @@ const ExperimentsPage = (): React.ReactElement => {
             {showViewSampleButton && <ViewSampleDataButton />}
             <div className="col-auto">{addExperimentDropdownButton}</div>
           </div>
-          <CustomMarkdown page={"experimentList"} />
+          <div className="mt-3">
+            <CustomMarkdown page={"experimentList"} />
+          </div>
           {!hasExperiments && analyzeExisting ? (
             <EmptyState
               title="Analyze Experiment Results"

--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -74,6 +74,7 @@ import {
   isMergeAggregationMetric,
   REST_API_ONLY_EDIT_MESSAGE,
 } from "@/services/factMetrics";
+import CustomMarkdown from "@/components/Markdown/CustomMarkdown";
 
 function FactTableLink({ id }: { id?: string }) {
   const { getFactTableById } = useDefinitions();
@@ -266,6 +267,13 @@ export default function FactMetricPage() {
   const datasource = factMetric.datasource
     ? getDatasourceById(factMetric.datasource)
     : null;
+
+  const variables = {
+    metricName: factMetric.name,
+    tags: factMetric.tags || [],
+    metricType: factMetric.metricType,
+    metricDatasource: datasource?.name || "",
+  };
 
   const userFilters = getAggregateFilters({
     columnRef: factMetric.numerator,
@@ -701,6 +709,10 @@ export default function FactMetricPage() {
             </span>
           )}
         </Flex>
+      </Box>
+
+      <Box mt="3">
+        <CustomMarkdown page={"metric"} variables={variables} />
       </Box>
 
       <div className="row">

--- a/packages/front-end/ui/ExpandableContent.module.scss
+++ b/packages/front-end/ui/ExpandableContent.module.scss
@@ -1,0 +1,8 @@
+.fadeOverlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 64px;
+  pointer-events: none;
+}

--- a/packages/front-end/ui/ExpandableContent.tsx
+++ b/packages/front-end/ui/ExpandableContent.tsx
@@ -1,0 +1,68 @@
+import { Box } from "@radix-ui/themes";
+import React, { useEffect, useRef, useState } from "react";
+import Link from "@/ui/Link";
+import styles from "./ExpandableContent.module.scss";
+
+export interface ExpandableContentProps {
+  maxHeight: number;
+  children: React.ReactNode;
+  expandLabel?: string;
+  collapseLabel?: string;
+  fadeColor?: string;
+}
+
+/**
+ * Height-capped wrapper with a fade-out and a "Show more"/"Show less" toggle.
+ * Only collapses when the content actually overflows; a ResizeObserver re-checks
+ * as content reflows.
+ */
+export default function ExpandableContent({
+  maxHeight,
+  children,
+  expandLabel = "Show more",
+  collapseLabel = "Show less",
+  fadeColor = "var(--color-panel-solid)",
+}: ExpandableContentProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [overflowing, setOverflowing] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = contentRef.current;
+    if (!el) return;
+    const check = () => setOverflowing(el.scrollHeight > maxHeight + 1);
+    check();
+    const ro = new ResizeObserver(check);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [maxHeight]);
+
+  return (
+    <>
+      <Box
+        style={
+          !expanded && overflowing
+            ? { position: "relative", maxHeight, overflow: "hidden" }
+            : { position: "relative" }
+        }
+      >
+        <Box ref={contentRef}>{children}</Box>
+        {!expanded && overflowing && (
+          <div
+            className={styles.fadeOverlay}
+            style={{
+              background: `linear-gradient(transparent, ${fadeColor})`,
+            }}
+          />
+        )}
+      </Box>
+      {overflowing && (
+        <Box mt="2">
+          <Link onClick={() => setExpanded((v) => !v)}>
+            {expanded ? collapseLabel : expandLabel}
+          </Link>
+        </Box>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

Custom markdown now renders inline on the page instead of behind a modal link.

**Core changes:**
- Added reusable `ExpandableContent` UI component (`packages/front-end/ui/ExpandableContent.tsx`) with max-height, fade-out gradient, and "Show more"/"Show less" toggle (only when content overflows, via `ResizeObserver`)
- Updated `CustomMarkdown` to render markdown directly inside an `appbox`, wrapped in `ExpandableContent` (default `maxHeight` of 100px, configurable per usage)
- Extracted duplicate collapse logic from `RevisionDiffUtils.tsx` (`CollapsedSection`) into `ExpandableContent`
- Removed modal, CTA link, and note icon from `CustomMarkdown`
- Dropped purple link styling from `CustomMarkdown.module.scss` so markdown uses normal text colors
- Tightened `CustomMarkdown` types (`CustomMarkdownPage`) and memoized Handlebars rendering
- Removed dead `learnings` page usage (no org setting existed, so it never rendered)

**Page placement & coverage:**
- Individual feature page: moved custom markdown above revision and description sections
- Individual experiment page: added consistent top spacing (`Box mt="3"`)
- Experiments list: wrapped in `mt-3` spacing container
- Fact metric page (`/fact-metrics/[fmid]`): added custom markdown support (previously only on legacy metric pages)

### Dependencies

None

### Testing

- [x] Verify custom markdown renders inline on experiment, feature, and metric pages (list + detail)
- [x] Verify fact metric page shows custom markdown above description
- [x] Verify long markdown shows fade + expand/collapse; short markdown does not
- [x] Verify feature page placement is above revision/description
- [x] Verify markdown text color matches normal markdown rendering (not purple)
- [x] Verify feature revision diff collapsed sections still expand/collapse correctly

### Screenshots (manual)

**Before**
Always links out to a modal
<img width="1482" height="312" alt="Screenshot 2026-06-17 at 12 40 57 PM" src="https://github.com/user-attachments/assets/4abdcd28-8db6-457e-a21e-38d5fd0b0c4c" />

Modal
<img width="1336" height="839" alt="Screenshot 2026-06-17 at 12 41 01 PM" src="https://github.com/user-attachments/assets/eac2b0fa-6095-4907-b00b-d6520a72846c" />

Weird location on feature page
<img width="1506" height="501" alt="Screenshot 2026-06-17 at 12 41 25 PM" src="https://github.com/user-attachments/assets/470ae6c1-8a7c-4224-9361-05d8ae6653c2" />


**After**

Short content
<img width="1409" height="269" alt="Screenshot 2026-06-17 at 12 18 36 PM" src="https://github.com/user-attachments/assets/73751744-2bdb-4aa8-9643-1b9367ee89c9" />

Longer, expandable content
<img width="1484" height="788" alt="Screenshot 2026-06-17 at 12 22 34 PM" src="https://github.com/user-attachments/assets/52f29491-c35b-4717-a880-466ae925f4e2" />
<img width="1535" height="808" alt="Screenshot 2026-06-17 at 12 23 34 PM" src="https://github.com/user-attachments/assets/8baaaf11-29bd-4c62-9d2c-7c1622a94e81" />

Fixed location on features page
<img width="1473" height="512" alt="Screenshot 2026-06-17 at 12 22 25 PM" src="https://github.com/user-attachments/assets/98a9ab6d-4a15-4b2a-84ad-2866801d51fe" />


### Screenshots (robot)

Front-end rendering successfully after changes:
[Front-end rendering verification](https://cursor.com/agents/bc-9ed2535c-bebb-5911-a1d7-d6e64da68130/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffrontend_rendering.webp)

Browser console showing no compilation errors:
[Console showing no JS errors](https://cursor.com/agents/bc-9ed2535c-bebb-5911-a1d7-d6e64da68130/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconsole_no_errors.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C046L8DQD6F/p1781712740810419?thread_ts=1781712740.810419&cid=C046L8DQD6F)

<div><a href="https://cursor.com/agents/bc-9ed2535c-bebb-5911-a1d7-d6e64da68130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ed2535c-bebb-5911-a1d7-d6e64da68130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>