### PR TITLE
perf(back-end): use readline for gbstats stdout to avoid event-loop stalls on large analyses

### DIFF
--- a/packages/back-end/src/services/python.ts
+++ b/packages/back-end/src/services/python.ts
@@ -64,6 +64,7 @@ if (IS_CLOUD) {
 
 class PythonStatsServer<Input, Output> {
   private python: ChildProcess;
+  private rl?: readline.Interface;
   private pid = -1;
   private promises: Map<
     string,
@@ -87,7 +88,7 @@ class PythonStatsServer<Input, Output> {
     this.promises = new Map();
 
     if (this.python.stdout) {
-      readline
+      this.rl = readline
         .createInterface({ input: this.python.stdout, crlfDelay: Infinity })
         .on("line", (line) => {
           const output = line.trim();
@@ -162,6 +163,8 @@ class PythonStatsServer<Input, Output> {
   }
 
   destroy() {
+    this.rl?.removeAllListeners("line");
+    this.rl?.close();
     if (this.isRunning()) {
       this.python.kill();
     }

--- a/packages/back-end/src/services/python.ts
+++ b/packages/back-end/src/services/python.ts
@@ -88,7 +88,7 @@ class PythonStatsServer<Input, Output> {
 
     if (this.python.stdout) {
       readline
-        .createInterface({ input: this.python.stdout })
+        .createInterface({ input: this.python.stdout, crlfDelay: Infinity })
         .on("line", (line) => {
           const output = line.trim();
           if (!output) return;

--- a/packages/back-end/src/services/python.ts
+++ b/packages/back-end/src/services/python.ts
@@ -1,6 +1,7 @@
 import { ChildProcess, spawn } from "child_process";
 import os from "os";
 import path from "path";
+import readline from "readline";
 import { randomUUID } from "crypto";
 import {
   CloudWatchClient,
@@ -44,6 +45,16 @@ const STATS_ENGINE_TIMEOUT_MS = parseEnvInt(
   { min: 1, name: "GB_STATS_ENGINE_TIMEOUT_MS" },
 );
 
+// stats_server.py writes via json.dumps(allow_nan=True), so output is strict
+// JSON unless it contains NaN/Infinity literals — fall back to JSON5 for those.
+function parsePythonOutput<T>(line: string): T {
+  try {
+    return JSON.parse(line);
+  } catch {
+    return JSON5.parse(line);
+  }
+}
+
 let cloudWatchClient: CloudWatchClient | null = null;
 if (IS_CLOUD) {
   cloudWatchClient = new CloudWatchClient({
@@ -75,61 +86,56 @@ class PythonStatsServer<Input, Output> {
     logger.debug(`Python stats server (pid: ${this.pid}) started`);
     this.promises = new Map();
 
-    let buffer = "";
-    this.python.stdout?.on("data", (rawData) => {
-      buffer += rawData.toString();
+    if (this.python.stdout) {
+      readline
+        .createInterface({ input: this.python.stdout })
+        .on("line", (line) => {
+          const output = line.trim();
+          if (!output) return;
+          try {
+            const parsed:
+              | PythonServerResponse<Output>
+              | { id: string; error: string; stack_trace?: string } =
+              parsePythonOutput(output);
 
-      // Once we have a complete line, process it
-      const lines = buffer.split("\n");
-      buffer = lines.pop() || ""; // Keep the last incomplete line in the buffer
-
-      lines.forEach((line) => {
-        const output = line.trim();
-        if (!output) return; // Skip empty lines
-        try {
-          const parsed:
-            | PythonServerResponse<Output>
-            | { id: string; error: string; stack_trace?: string } =
-            JSON5.parse(output);
-
-          if (!parsed.id) {
-            logger.error(
-              `Python stats server (pid: ${this.pid}) stdout missing 'id': ${parsed}`,
-            );
-            return;
-          }
-
-          const promise = this.promises.get(parsed.id);
-          if (!promise) {
-            logger.warn(
-              `Python stats server (pid: ${this.pid}) stdout has unknown id: ${parsed.id}`,
-              parsed,
-            );
-            return;
-          }
-
-          if ("error" in parsed) {
-            // Add stack trace to error message so we can show it on the front-end
-            const error = new Error(parsed.error || "Unknown error");
-            if (parsed.stack_trace) {
-              error.message += `\n\n${parsed.stack_trace}`;
+            if (!parsed.id) {
+              logger.error(
+                `Python stats server (pid: ${this.pid}) stdout missing 'id': ${parsed}`,
+              );
+              return;
             }
-            promise.reject(error);
-          } else {
-            promise.resolve(parsed);
-          }
 
-          // Delete promise
-          this.promises.delete(parsed.id);
-        } catch (e) {
-          logger.error(
-            `Python stats server (pid: ${this.pid}) failed to parse stdout: ${output}`,
-            e,
-          );
-          return;
-        }
-      });
-    });
+            const promise = this.promises.get(parsed.id);
+            if (!promise) {
+              logger.warn(
+                `Python stats server (pid: ${this.pid}) stdout has unknown id: ${parsed.id}`,
+                parsed,
+              );
+              return;
+            }
+
+            if ("error" in parsed) {
+              // Add stack trace to error message so we can show it on the front-end
+              const error = new Error(parsed.error || "Unknown error");
+              if (parsed.stack_trace) {
+                error.message += `\n\n${parsed.stack_trace}`;
+              }
+              promise.reject(error);
+            } else {
+              promise.resolve(parsed);
+            }
+
+            // Delete promise
+            this.promises.delete(parsed.id);
+          } catch (e) {
+            logger.error(
+              `Python stats server (pid: ${this.pid}) failed to parse stdout: ${output}`,
+              e,
+            );
+            return;
+          }
+        });
+    }
 
     this.python.stderr?.on("data", (data) => {
       const err = data.toString().trim();


### PR DESCRIPTION
### Features and Changes

The in-process Python stats server (`services/python.ts`) writes each analysis result as a single JSON line on stdout. For large experiments (many variations × metrics × dimension slices) this line can reach tens of megabytes.

The current stdout handler does:

```js
buffer += rawData.toString();
const lines = buffer.split("\n");
```

on every `data` event. Node delivers stdout in ~64KB chunks, so for a 20MB line this re-scans the growing buffer ~300 times — quadratic in the total payload size — and then parses with `JSON5.parse`, which is substantially slower than the native parser. All of this runs synchronously on the main event loop, so while a large result is being assembled the process cannot serve HTTP requests (including health-check probes).

This change:

- Replaces the manual buffer/split with `readline.createInterface`, which assembles lines incrementally in linear time.
- Parses with native `JSON.parse` as the fast path, falling back to `JSON5.parse` only when the line is not strict JSON. `stats_server.py` writes via `json.dumps(allow_nan=True)`, so the only case that needs the fallback is a result containing `NaN` / `Infinity` literals; everything else takes the fast path.

The per-line handling logic (id lookup, resolve/reject, error logging) is unchanged.

### Dependencies

None.

### Testing

Local benchmark with an ~18MB single-line JSON payload streamed through a `PassThrough` in 64KB chunks:

| Path | Time |
|---|---|
| current (`buffer += / split` + `JSON5.parse`) | ~3.4s |
| `readline` + `JSON5.parse` | ~2.0s |
| `readline` + `JSON.parse` (this PR, fast path) | ~0.14s |

Also ran `pnpm --filter back-end type-check` and `eslint` on the changed file.

To reproduce manually, run an analysis on an experiment with a large number of metric/variation/dimension combinations (no `EXTERNAL_PYTHON_SERVER_URL` set) and observe backend responsiveness while the result is being read.

### Screenshots

N/A — back-end only.