### PR TITLE
feat(experiment-results): add stable data-* attributes to the results table for programmatic extraction

### DIFF
--- a/packages/front-end/components/Experiment/ChangeColumn.tsx
+++ b/packages/front-end/components/Experiment/ChangeColumn.tsx
@@ -129,9 +129,13 @@ export default function ChangeColumn({
         ) : null}
       </span>{" "}
       {expected === 0 && stats.errorMessage ? (
-        <span className="expected">n/a</span>
+        // Stable field name for programmatic value extraction
+        <span className="expected" data-field="lift_percent">
+          n/a
+        </span>
       ) : (
-        <span className="expected">
+        // Stable field name for programmatic value extraction
+        <span className="expected" data-field="lift_percent">
           {formatter(expected, formatterOptions)}{" "}
         </span>
       )}
@@ -139,16 +143,27 @@ export default function ChangeColumn({
         <span className="plusminus font-weight-normal text-gray ml-1">
           ±
           {Math.abs(ci0) === Infinity || Math.abs(ci1) === Infinity ? (
-            <span style={{ fontSize: "18px", verticalAlign: "-2px" }}>∞</span>
+            // Field name on the value leaf only (exclude the ± glyph)
+            <span
+              data-field="lift_moe"
+              style={{ fontSize: "18px", verticalAlign: "-2px" }}
+            >
+              ∞
+            </span>
           ) : (
-            formatter(expected - ci0, formatterOptions)
+            // Field name on the value leaf only (exclude the ± glyph)
+            <span data-field="lift_moe">
+              {formatter(expected - ci0, formatterOptions)}
+            </span>
           )}
         </span>
       ) : null}
       {showCI ? (
         <span className="ml-2 ci font-weight-normal text-gray">
-          [{formatter(ci0, formatterOptions)},{" "}
-          {formatter(ci1, formatterOptions)}]
+          [{/* Separate leaves so each CI bound can be read independently */}
+          <span data-field="ci_low">{formatter(ci0, formatterOptions)}</span>
+          {", "}
+          <span data-field="ci_high">{formatter(ci1, formatterOptions)}</span>]
         </span>
       ) : null}
     </div>

--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -356,6 +356,26 @@ const CompactResults: FC<{
               experimentType={experimentType}
             />
           </Flex>
+          {/* Always-present, hidden summary block exposing top-level health */}
+          {/* signals (SRM p-value, multiple exposures, per-variation user */}
+          {/* counts) for programmatic extraction. These are otherwise only */}
+          {/* rendered inside conditional warning tooltips. Hidden via */}
+          {/* display:none + aria-hidden; not shown to users. */}
+          <div
+            data-results-health-summary="true"
+            style={{ display: "none" }}
+            aria-hidden="true"
+          >
+            {typeof results?.srm === "number" ? (
+              <span data-field="srm_p_value">{results.srm}</span>
+            ) : null}
+            <span data-field="multiple_exposures">{multipleExposures}</span>
+            {(results?.variations ?? []).map((v, i) => (
+              <span key={i} data-variation={i} data-field="total_users">
+                {v.users ?? 0}
+              </span>
+            ))}
+          </div>
         </>
       )}
 

--- a/packages/front-end/components/Experiment/MetricValueColumn.tsx
+++ b/packages/front-end/components/Experiment/MetricValueColumn.tsx
@@ -74,6 +74,10 @@ interface Props
   getExperimentMetricById: (id: string) => null | ExperimentMetricInterface;
   getFactTableById: (id: string) => null | FactTableInterface;
   asTd?: boolean;
+  // Differentiates the same component rendered as the baseline vs. the
+  // treatment column. Drives the data-field name so both values can be
+  // extracted without one overwriting the other under a single key.
+  cellRole?: "baseline" | "treatment";
 }
 
 export default function MetricValueColumn({
@@ -89,6 +93,7 @@ export default function MetricValueColumn({
   getExperimentMetricById,
   getFactTableById,
   asTd = true,
+  cellRole = "treatment",
   ...otherProps
 }: Props) {
   const formatterOptions = { currency: displayCurrency };
@@ -135,6 +140,12 @@ export default function MetricValueColumn({
     )(numeratorValue, formatterOptions);
   }
 
+  // Field names for programmatic value extraction. Baseline cells are prefixed
+  // so they don't collide with the treatment cell's values under one key.
+  const fieldPrefix = cellRole === "baseline" ? "baseline_" : "";
+  const metricValueField = `${fieldPrefix}metric_value`;
+  const userCountField = `${fieldPrefix}user_count`;
+
   return (
     <ConditionalWrapper
       condition={asTd}
@@ -149,7 +160,10 @@ export default function MetricValueColumn({
     >
       {metric && stats.users ? (
         <>
-          <div className="result-number">{overall}</div>
+          {/* Stable field name for programmatic value extraction */}
+          <div className="result-number" data-field={metricValueField}>
+            {overall}
+          </div>
           {showRatio && numerator ? (
             <div className="result-number-sub text-muted">
               <em>
@@ -164,7 +178,8 @@ export default function MetricValueColumn({
                   <>
                     {" "}
                     /&nbsp;
-                    {denominator}
+                    {/* Stable field name for programmatic value extraction */}
+                    <span data-field={userCountField}>{denominator}</span>
                   </>
                 ) : null}
               </em>

--- a/packages/front-end/components/Experiment/PValueColumn.tsx
+++ b/packages/front-end/components/Experiment/PValueColumn.tsx
@@ -59,17 +59,24 @@ export default function PValueColumn({
   pValueAdjustmentEnabled,
   ...otherProps
 }: Props) {
+  // Stable field names for programmatic value extraction
   let pValText = (
-    <>{stats?.pValue !== undefined ? pValueFormatter(stats.pValue) : ""}</>
+    <span data-field="p_value_raw">
+      {stats?.pValue !== undefined ? pValueFormatter(stats.pValue) : ""}
+    </span>
   );
   if (stats?.pValueAdjusted !== undefined && pValueCorrection) {
     pValText = showUnadjustedPValue ? (
       <>
-        <div>{pValueFormatter(stats.pValueAdjusted)}</div>
+        <div data-field="p_value_adjusted">
+          {pValueFormatter(stats.pValueAdjusted)}
+        </div>
         <div className="text-muted">(unadj.:&nbsp;{pValText})</div>
       </>
     ) : (
-      <>{pValueFormatter(stats.pValueAdjusted)}</>
+      <span data-field="p_value_adjusted">
+        {pValueFormatter(stats.pValueAdjusted)}
+      </span>
     );
   }
 
@@ -138,6 +145,10 @@ export default function PValueColumn({
       {...otherProps}
     >
       {renderContent()}
+      {/* Hidden significance flag (1/0) exposed for programmatic extraction */}
+      <span data-field="significant" style={{ display: "none" }}>
+        {rowResults?.significant ? "1" : "0"}
+      </span>
     </td>
   );
 }

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -520,6 +520,12 @@ export default function ResultsTable({
   const noRows = rows.length === 0;
   const hasUnfilteredMetrics = (totalMetricsCount ?? 0) > 0;
 
+  // Render-complete signal for programmatic consumers (automated UI tests,
+  // snapshot diffing, scraping): the table is only populated after the snapshot
+  // fetch resolves. Derived (not state) so the attribute never briefly renders
+  // "false" before rows arrive.
+  const renderComplete = rows.length > 0;
+
   const changeTitle = getEffectLabel(differenceType);
 
   const hasGoalMetrics = rows.some((r) => r.resultGroup === "goal");
@@ -537,7 +543,16 @@ export default function ResultsTable({
         onClick: onRowClick_,
       }) => (
         <div className="position-relative">
-          <div ref={tableContainerRef} className="experiment-results-wrapper">
+          <div
+            ref={tableContainerRef}
+            // Render gate: programmatic consumers should read values only once
+            // this is "true".
+            data-render-complete={renderComplete ? "true" : "false"}
+            // Snapshot id backing the rendered values, so two captures can be
+            // confirmed to come from the same snapshot. Omitted when absent.
+            {...(snapshot?.id ? { "data-snapshot-id": snapshot.id } : {})}
+            className="experiment-results-wrapper"
+          >
             <div className="w-100" style={{ minWidth: 700 }}>
               <table id="main-results" className="experiment-results table-sm">
                 <thead>
@@ -795,6 +810,17 @@ export default function ResultsTable({
                         <>
                           {/* Render the main results tbody */}
                           <tbody
+                            // Stable metric identifier for programmatic row
+                            // alignment (rows can reorder, so positional matching
+                            // is unsafe).
+                            data-metric-id={row.metric.id}
+                            // Dimension-slice identifier on slice rows. Omitted
+                            // entirely when absent (rather than rendered as the
+                            // literal string "null") so getAttribute() === null
+                            // reliably means "not a slice row".
+                            {...(row.sliceId
+                              ? { "data-slice-id": row.sliceId }
+                              : {})}
                             className={clsx("results-group-row", {
                               "slice-row": row.isSliceRow,
                               [styles.clickableRow]: !!effectiveOnRowClick,
@@ -956,6 +982,11 @@ export default function ResultsTable({
                                       id,
                                       domain,
                                       ssrPolyfills,
+                                      // Variation index for programmatic
+                                      // alignment (kept on the error/empty row
+                                      // too, so the row aligns even when no
+                                      // value cells render).
+                                      dataVariation: v.index,
                                     });
                                   } else {
                                     return null;
@@ -975,6 +1006,9 @@ export default function ResultsTable({
 
                                 return (
                                   <tr
+                                    // Variation index for programmatic alignment
+                                    // of this row.
+                                    data-variation={v.index}
                                     className={clsx(
                                       "results-variation-row align-items-center",
                                       {
@@ -1057,6 +1091,11 @@ export default function ResultsTable({
                                             stats={baseline}
                                             users={baseline?.users || 0}
                                             className="value baseline"
+                                            // Mark this render as the baseline
+                                            // column; drives the baseline_ field
+                                            // name prefix so the baseline and
+                                            // treatment values are keyed distinctly.
+                                            cellRole="baseline"
                                             showRatio={!isBandit}
                                             displayCurrency={displayCurrency}
                                             getExperimentMetricById={
@@ -1433,6 +1472,7 @@ function drawEmptyRow({
   labelColSpan,
   renderGraph,
   renderLastColumn,
+  dataVariation,
 }: {
   key?: number | string;
   className?: string;
@@ -1448,9 +1488,20 @@ function drawEmptyRow({
   labelColSpan: number;
   renderGraph: boolean;
   renderLastColumn: boolean;
+  // Optional variation index for programmatic alignment.
+  dataVariation?: number;
 }) {
   return (
-    <tr key={key} style={{ height: rowHeight, ...style }} className={className}>
+    <tr
+      key={key}
+      style={{ height: rowHeight, ...style }}
+      className={className}
+      // Variation index for programmatic alignment (only set on variation
+      // error/empty rows).
+      {...(dataVariation !== undefined
+        ? { "data-variation": dataVariation }
+        : {})}
+    >
       {renderLabel && (
         <td colSpan={labelColSpan} className="position-relative">
           {label}


### PR DESCRIPTION
## Motivation

The experiment results table can today only be located in the DOM by positional selectors (`nth-child`) or by matching internal classNames. Both are brittle: the component is refactored often, rows reorder by sort, and the same value-rendering component (`MetricValueColumn`) appears more than once per row.

That makes it hard to (a) write durable end-to-end / UI tests that assert on a specific statistic, (b) diff the *rendered* results of two versions of the table to catch regressions in result orchestration, and (c) scrape the values shown to a user for external verification or snapshot comparison.

This adds a small set of **semantic, value-bearing `data-*` attributes** so each statistic can be located by a stable key (metric id + variation index + field name) regardless of layout, sort order, or refactors. **There is no user-visible change** — the attributes are inert metadata, and the one new hidden element is `display:none` + `aria-hidden`.

These complement the existing CSV / Jupyter exports in `ResultMoreMenu` (which serialize the underlying numbers to a file) by exposing the *rendered* DOM values in place for live selection and positional alignment.

> Note: opening this as a **draft** purely to share an approach we've found useful when validating a deployment of our fork after rebasing from upstream.

## The attribute contract

**Invariant:** an attribute is omitted entirely when its value is absent (conditional spread) rather than serialized as the string `"null"`, so consumers can rely on `getAttribute() === null` meaning "not present".

**Sync / identity** (on `.experiment-results-wrapper`):
- `data-render-complete` — `"true"` once the table is mounted with snapshot data.
- `data-snapshot-id` — id of the snapshot backing the numbers (optional).

**Row alignment keys:**
- `data-metric-id` — on each per-metric `<tbody class="results-group-row">`.
- `data-slice-id` — on dimension-slice `<tbody>` rows (optional).
- `data-variation` — variation index (`0` = baseline) on each `<tr class="results-variation-row">`, the empty/error row, and the per-variation health spans.

**Value leaves** (`data-field="<snake_case>"`, value = element `textContent`):
- `MetricValueColumn`: `metric_value`, `user_count` (baseline column emits `baseline_metric_value` / `baseline_user_count` so the two renders don't collide under one key).
- `ChangeColumn`: `lift_percent`, `lift_moe`, `ci_low`, `ci_high`.
- `PValueColumn`: `p_value_raw`, `p_value_adjusted`, hidden `significant`
  (`"1"`/`"0"`).

**Top-level health signals** (otherwise only rendered inside a conditional warning tooltip): a hidden `<div data-results-health-summary="true">` with `data-field` spans for `srm_p_value`, `multiple_exposures`, and per-variation `total_users`.

## How to use it

Walk the table by stable keys — independent of row order or layout:

```ts
// 1. Wait until the table has rendered the snapshot data.
await page.waitForSelector('[data-render-complete="true"]');

// 2. (optional) confirm two captures came from the same snapshot.
const snapshotId = document
  .querySelector("[data-render-complete]")
  ?.getAttribute("data-snapshot-id");

// 3. Read each statistic by metric x variation x field.
const records = [];
for (const tbody of document.querySelectorAll(
  "tbody.results-group-row[data-metric-id]"
)) {
  const metricId = tbody.getAttribute("data-metric-id");
  const sliceId = tbody.getAttribute("data-slice-id"); // null on non-slice rows
  for (const tr of tbody.querySelectorAll(
    "tr.results-variation-row[data-variation]"
  )) {
    const variation = Number(tr.getAttribute("data-variation"));
    const fields = {};
    for (const el of tr.querySelectorAll("[data-field]")) {
      fields[el.getAttribute("data-field")] = el.textContent?.trim();
    }
    records.push({ metricId, sliceId, variation, fields });
    // fields => { metric_value, lift_percent, ci_low, ci_high, p_value_raw, significant, ... }
  }
}

// 4. Top-level health signals from the hidden summary block.
const health = document.querySelector('[data-results-health-summary="true"]');
const srm = health?.querySelector('[data-field="srm_p_value"]')?.textContent;
```

## What changed

`ResultsTable.tsx`, `MetricValueColumn.tsx`, `ChangeColumn.tsx`, `PValueColumn.tsx`, `CompactResults.tsx` — attributes / one hidden element only. No behavior, styling, or layout changes for end users.
