### PR TITLE
feat(experiment-results): pin a snapshot as an experiment's "Official results"

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -36367,6 +36367,19 @@ components:
                 - date
               additionalProperties: false
             - type: 'null'
+        pinnedReportId:
+          description: ID of the report pinned as this experiment's official results, if any.
+          type: string
+        pinnedSnapshotId:
+          description: ID of the snapshot frozen at pin time. Independent of the report's current snapshot so the official view stays stable. Server-derived.
+          type: string
+        pinnedReportBy:
+          description: User ID of whoever pinned the current official results. Server-derived.
+          type: string
+        pinnedReportAt:
+          description: Timestamp when the current official results were pinned. Server-derived.
+          format: date-time
+          type: string
       required:
         - id
         - trackingKey
@@ -37080,6 +37093,19 @@ components:
                     - date
                   additionalProperties: false
                 - type: 'null'
+            pinnedReportId:
+              description: ID of the report pinned as this experiment's official results, if any.
+              type: string
+            pinnedSnapshotId:
+              description: ID of the snapshot frozen at pin time. Independent of the report's current snapshot so the official view stays stable. Server-derived.
+              type: string
+            pinnedReportBy:
+              description: User ID of whoever pinned the current official results. Server-derived.
+              type: string
+            pinnedReportAt:
+              description: Timestamp when the current official results were pinned. Server-derived.
+              format: date-time
+              type: string
           required:
             - id
             - trackingKey

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -680,6 +680,11 @@ app.get(
   "/experiment/:id/snapshot-summary/:phase",
   experimentsController.getSnapshotSummary,
 );
+// Lists past snapshots for the "view a past snapshot" official-results picker
+app.get(
+  "/experiment/:id/snapshot-history/:phase",
+  experimentsController.getSnapshotHistory,
+);
 app.post("/experiment/:id/snapshot", experimentsController.postSnapshot);
 app.post(
   "/experiment/:id/banditSnapshot",

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -41,6 +41,8 @@ import { EventUserForResponseLocals } from "shared/types/events/event-types";
 import { CreateURLRedirectProps } from "shared/types/url-redirect";
 import isEqual from "lodash/isEqual";
 import { getMetricMap } from "back-end/src/models/MetricModel";
+// Used to derive the pinned snapshot id when pinning a report
+import { getReportById } from "back-end/src/models/ReportModel";
 import {
   AuthRequest,
   ResponseWithStatusAndError,
@@ -95,6 +97,7 @@ import {
 import {
   deleteSnapshotById,
   findSnapshotById,
+  findSnapshotHistory,
   getLatestSuccessfulSnapshot,
   getLatestSnapshotStatus,
   updateSnapshot,
@@ -1019,6 +1022,41 @@ export async function getSnapshotSummary(
   });
 }
 
+// Lists past successful snapshots for an experiment+phase so the UI can offer
+// "view a past snapshot" as an official-results source. Returns the lean
+// SnapshotHistoryEntry rows (window dates + status), never analysis blobs.
+// Mirrors getSnapshotSummary's access pattern.
+export async function getSnapshotHistory(
+  req: AuthRequest<null, { id: string; phase: string }, { dimension?: string }>,
+  res: Response,
+) {
+  const context = getContextFromReq(req);
+  const { id, phase } = req.params;
+  const dimension = req.query?.dimension || undefined;
+
+  const experimentObj = await getExperimentById(context, id);
+  if (!experimentObj) {
+    throw new Error("Experiment not found");
+  }
+  if (experimentObj.organization !== context.org.id) {
+    throw new Error("You do not have access to view this experiment");
+  }
+
+  const phaseNum = phase ? parseInt(phase) : experimentObj.phases.length - 1;
+
+  const snapshots = await findSnapshotHistory({
+    context,
+    experiment: experimentObj.id,
+    phase: phaseNum,
+    dimension,
+  });
+
+  res.status(200).json({
+    status: 200,
+    snapshots,
+  });
+}
+
 export async function getSnapshotById(
   req: AuthRequest<null, { id: string }>,
   res: Response,
@@ -1773,6 +1811,8 @@ export async function postExperiment(
     "defaultDashboardId",
     "customMetricSlices",
     "precomputedUnitDimensionIds",
+    // pinned "official results" report id
+    "pinnedReportId",
   ];
   let changes: Changeset = {};
 
@@ -1806,6 +1846,19 @@ export async function postExperiment(
   });
 
   normalizeStatusUpdateScheduleChanges(experiment, changes);
+
+  // Server-derive pinnedReportBy/pinnedReportAt/pinnedSnapshotId when
+  // pinnedReportId is set. Client can't supply these directly, and they stick to
+  // the pin event so the official view stays frozen even if the report is later
+  // edited or refreshed.
+  if ("pinnedReportId" in changes && changes.pinnedReportId) {
+    changes.pinnedReportBy = userId;
+    changes.pinnedReportAt = new Date();
+    const pinnedReport = await getReportById(org.id, changes.pinnedReportId);
+    if (pinnedReport?.type === "experiment-snapshot" && pinnedReport.snapshot) {
+      changes.pinnedSnapshotId = pinnedReport.snapshot;
+    }
+  }
 
   // Coerce lookbackOverride date value when type is "date"
   if (changes.lookbackOverride?.type === "date") {

--- a/packages/back-end/src/controllers/metrics.ts
+++ b/packages/back-end/src/controllers/metrics.ts
@@ -544,6 +544,8 @@ export const getMetricExperimentResults = async (
     ...e,
     dateCreated: e.dateCreated.toISOString(),
     dateUpdated: e.dateUpdated.toISOString(),
+    // stringify pinnedReportAt (official-results field) like other dates
+    pinnedReportAt: e.pinnedReportAt?.toISOString(),
     phases: e.phases.map((p) => ({
       ...p,
       dateStarted: p.dateStarted.toISOString(),
@@ -661,6 +663,8 @@ export const getMetricNorthstarData = async (
     ...e,
     dateCreated: e.dateCreated.toISOString(),
     dateUpdated: e.dateUpdated.toISOString(),
+    // stringify pinnedReportAt (official-results field) like other dates
+    pinnedReportAt: e.pinnedReportAt?.toISOString(),
     phases: e.phases.map((p) => ({
       ...p,
       dateStarted: p.dateStarted.toISOString(),

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -379,6 +379,15 @@ const experimentSchema = new mongoose.Schema({
     },
   ],
   precomputedUnitDimensionIds: [String],
+  // ID of a custom report pinned as the "official results" for this experiment
+  pinnedReportId: String,
+  // Frozen snapshot id at pin time so the official view stays stable
+  // even if the report is later edited/refreshed (server-derived)
+  pinnedSnapshotId: String,
+  // userId of whoever pinned the current official results (server-derived)
+  pinnedReportBy: String,
+  // Timestamp when the current official results were pinned (server-derived)
+  pinnedReportAt: Date,
 });
 
 // Compound indexes for API list filtering
@@ -701,6 +710,18 @@ export async function updateExperiment({
   });
 
   return updated;
+}
+
+// Only updates the snapshot — pinnedReportBy/At keep the original pinner.
+export async function updatePinnedSnapshotIdForReport(
+  organization: string,
+  reportId: string,
+  newSnapshotId: string,
+): Promise<void> {
+  await ExperimentModel.updateMany(
+    { organization, pinnedReportId: reportId },
+    { $set: { pinnedSnapshotId: newSnapshotId, dateUpdated: new Date() } },
+  );
 }
 
 export async function getExperimentsByMetric(

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -14,6 +14,7 @@ import {
   LegacyExperimentSnapshotInterface,
   ExperimentSnapshotSettings,
   SnapshotStatusSummary,
+  SnapshotHistoryEntry,
 } from "shared/types/experiment-snapshot";
 import {
   AnalysisKeyType,
@@ -1125,6 +1126,66 @@ export async function getLatestSnapshotStatus({
     return toSnapshotStatusSummary(mostRecent);
   }
   return null;
+}
+
+// Projection for the snapshot-history picker (pin a past snapshot).
+// Reads only the window dates + status fields — never the analysis blobs.
+const snapshotHistoryProjection = {
+  id: 1,
+  dateCreated: 1,
+  status: 1,
+  triggeredBy: 1,
+  type: 1,
+  dimension: 1,
+  "settings.startDate": 1,
+  "settings.endDate": 1,
+} as const;
+
+// Lists past successful snapshots for an experiment+phase+dimension, newest
+// first, for the "pin a past snapshot as official results" picker. Mirrors
+// getLatestSnapshotStatus's lean read but returns the full list (sans
+// report-type clones) instead of just the most recent row.
+export async function findSnapshotHistory({
+  context,
+  experiment,
+  phase,
+  dimension,
+  // ~daily refresh cadence, so 100 covers >3 months of snapshots — longer than
+  // any real experiment. Lean rows (dates + status, no analysis blobs) anyway.
+  limit = 100,
+}: {
+  context: Context;
+  experiment: string;
+  phase: number;
+  dimension?: string;
+  limit?: number;
+}): Promise<SnapshotHistoryEntry[]> {
+  const docs = await ExperimentSnapshotModel.find(
+    {
+      organization: context.org.id,
+      experiment,
+      phase,
+      dimension: dimension || null,
+      status: "success",
+      // never surface report-type snapshots (prior pinned-report clones)
+      type: { $ne: "report" },
+    },
+    snapshotHistoryProjection,
+    { sort: { dateCreated: -1 }, limit },
+  )
+    .lean<Partial<ExperimentSnapshotInterface>[]>()
+    .exec();
+
+  return docs.map((raw) => ({
+    id: raw.id ?? "",
+    dateCreated: raw.dateCreated ?? new Date(0),
+    status: raw.status ?? "success",
+    triggeredBy: raw.triggeredBy,
+    type: raw.type,
+    dimension: raw.dimension ?? null,
+    windowStartDate: raw.settings?.startDate ?? raw.dateCreated ?? new Date(0),
+    windowEndDate: raw.settings?.endDate ?? raw.dateCreated ?? new Date(0),
+  }));
 }
 
 // Gets latest snapshots per experiment-phase pair

--- a/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
@@ -55,6 +55,7 @@ import { expandDenominatorMetrics } from "back-end/src/util/sql";
 import { FactTableMap } from "back-end/src/models/FactTableModel";
 import SqlIntegration from "back-end/src/integrations/SqlIntegration";
 import { updateReport } from "back-end/src/models/ReportModel";
+import { updatePinnedSnapshotIdForReport } from "back-end/src/models/ExperimentModel";
 import {
   QueryRunner,
   QueryMap,
@@ -646,6 +647,14 @@ export class ExperimentResultsQueryRunner extends QueryRunner<
       await updateReport(this.model.organization, this.model.report, {
         snapshot: this.model.id,
       });
+      // Don't promote a failed snapshot to be the official view.
+      if (["partially-succeeded", "succeeded"].includes(status)) {
+        await updatePinnedSnapshotIdForReport(
+          this.model.organization,
+          this.model.report,
+          this.model.id,
+        );
+      }
     }
     return {
       ...this.model,

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2806,6 +2806,11 @@ export async function toExperimentApiInterface(
         : experiment.nextScheduledStatusUpdate === undefined
           ? undefined
           : null,
+    // expose official-results pin state to external API consumers
+    pinnedReportId: experiment.pinnedReportId || undefined,
+    pinnedSnapshotId: experiment.pinnedSnapshotId || undefined,
+    pinnedReportBy: experiment.pinnedReportBy || undefined,
+    pinnedReportAt: experiment.pinnedReportAt?.toISOString(),
   };
   return apiExperiment;
 }

--- a/packages/front-end/components/Experiment/CompareExperimentEventsModal.tsx
+++ b/packages/front-end/components/Experiment/CompareExperimentEventsModal.tsx
@@ -247,6 +247,11 @@ const EXPERIMENT_SECTION_KEYS: Record<
   dismissedWarnings: false,
   holdoutId: false,
   defaultDashboardId: false,
+  // pinning an official readout is a UI bookmark, not part of event diffs
+  pinnedReportId: false,
+  pinnedSnapshotId: false,
+  pinnedReportBy: false,
+  pinnedReportAt: false,
 };
 
 function sectionKeys(

--- a/packages/front-end/components/Experiment/TabbedPage/ResultsTab.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ResultsTab.tsx
@@ -5,34 +5,48 @@ import {
   isDimensionPrecomputed,
   getEffectiveLookbackOverride,
 } from "shared/experiments";
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect, useMemo } from "react";
 import {
   ExperimentSnapshotReportArgs,
+  ExperimentSnapshotReportInterface,
   ReportInterface,
 } from "shared/types/report";
+import {
+  ExperimentSnapshotInterface,
+  SnapshotHistoryEntry,
+} from "shared/types/experiment-snapshot";
 import { VisualChangesetInterface } from "shared/types/visual-changeset";
 import { SDKConnectionInterface } from "shared/types/sdk-connection";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
 import { DEFAULT_STATS_ENGINE } from "shared/constants";
 import { Box, Flex, Text } from "@radix-ui/themes";
-import { date } from "shared/dates";
+import { date, datetime } from "shared/dates";
 import { getDemoDatasourceProjectIdForOrganization } from "shared/demo-datasource";
+import { PiLink, PiCheck } from "react-icons/pi";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useUser } from "@/services/UserContext";
 import { useAuth } from "@/services/auth";
 import Results, { AnalysisBarSettings } from "@/components/Experiment/Results";
 import AnalysisForm from "@/components/Experiment/AnalysisForm";
 import ExperimentReportsList from "@/components/Experiment/ExperimentReportsList";
-import { useSnapshot } from "@/components/Experiment/SnapshotProvider";
+import {
+  LocalSnapshotProvider,
+  useSnapshot,
+} from "@/components/Experiment/SnapshotProvider";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import useApi from "@/hooks/useApi";
 import Callout from "@/ui/Callout";
 import Button from "@/ui/Button";
+import { Select, SelectItem } from "@/ui/Select";
 import { getHonoredPrecomputedUnitDimensionIds } from "@/services/experiments";
+import LinkButton from "@/ui/LinkButton";
+import { Tabs, TabsList, TabsTrigger } from "@/ui/Tabs";
 import track from "@/services/track";
 import Metadata from "@/ui/Metadata";
 import Link from "@/ui/Link";
 import Tooltip from "@/components/Tooltip/Tooltip";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import AnalysisSettingsSummary from "./AnalysisSettingsSummary";
 import { ExperimentTab } from ".";
 
@@ -76,7 +90,371 @@ export interface Props {
   setSortDirection: (d: "asc" | "desc" | null) => void;
 }
 
-export default function ResultsTab({
+// map URL hash → view. Defaults to "official" with a pin, "latest" otherwise.
+// Uses #results/<sub-view> so the parent TabbedPage routes to the Results tab on cold load.
+function viewFromHash(hash: string, hasPin: boolean): "official" | "latest" {
+  if (hash === "#results/latest-results") return "latest";
+  if (hash === "#results/official-results" && hasPin) return "official";
+  return hasPin ? "official" : "latest";
+}
+
+// outer wrapper for Official readout pinning. Fetches the pinned report
+// and its snapshot, then wraps the body in LocalSnapshotProvider when the user
+// is on the "Official readout" tab. The default SnapshotProvider from the parent
+// page still serves the latest snapshot when on "Latest results".
+export default function ResultsTab(props: Props) {
+  const { experiment } = props;
+  const pinnedReportId = experiment.pinnedReportId;
+  const hasPin = !!pinnedReportId;
+  const router = useRouter();
+
+  // seed view from URL hash for deep linking
+  const [view, setViewState] = useState<"official" | "latest">(() =>
+    viewFromHash(
+      typeof window !== "undefined" ? window.location.hash : "",
+      hasPin,
+    ),
+  );
+
+  // sync view on back/forward navigation
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handler = () =>
+      setViewState(viewFromHash(window.location.hash, hasPin));
+    window.addEventListener("hashchange", handler);
+    return () => window.removeEventListener("hashchange", handler);
+  }, [hasPin]);
+
+  // if the hash asks for official but there's no pin, drop the sub-path
+  // so the URL matches what's actually rendered (Latest results)
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!hasPin && window.location.hash === "#results/official-results") {
+      router.replace(
+        `${window.location.pathname}${window.location.search}#results`,
+        undefined,
+        { shallow: true },
+      );
+    }
+  }, [hasPin, router]);
+
+  // setView also writes the hash so the URL stays shareable
+  const setView = useCallback(
+    (newView: "official" | "latest") => {
+      setViewState(newView);
+      if (typeof window === "undefined") return;
+      const targetHash =
+        newView === "official"
+          ? "#results/official-results"
+          : "#results/latest-results";
+      if (window.location.hash !== targetHash) {
+        const newUrl = `${window.location.pathname}${window.location.search}${targetHash}`;
+        router.replace(newUrl, undefined, { shallow: true });
+      }
+    },
+    [router],
+  );
+
+  const { data: pinnedReportData } = useApi<{ report: ReportInterface }>(
+    `/report/${pinnedReportId}`,
+    { shouldRun: () => hasPin },
+  );
+  const pinnedReport =
+    pinnedReportData?.report?.type === "experiment-snapshot"
+      ? pinnedReportData.report
+      : undefined;
+
+  // load the snapshot from experiment.pinnedSnapshotId — frozen at pin
+  // time — so the official view doesn't follow report edits/refreshes. Fall back
+  // to the report's current snapshot for legacy pins that pre-date the field.
+  const pinnedSnapshotId =
+    experiment.pinnedSnapshotId || pinnedReport?.snapshot;
+  const { data: pinnedSnapshotData } = useApi<{
+    snapshot: ExperimentSnapshotInterface;
+  }>(`/snapshot/${pinnedSnapshotId}`, {
+    shouldRun: () => !!pinnedSnapshotId,
+  });
+  const pinnedSnapshot = pinnedSnapshotData?.snapshot;
+
+  // "view a past snapshot" (decoupled from pinning). Reads the parent
+  // provider's current phase/dimension + latest snapshot, lists past snapshots,
+  // and — when the user browses to an older one — loads it into a
+  // LocalSnapshotProvider so the whole results view reflects that snapshot
+  // (without committing). Only active when nothing is pinned; once pinned, the
+  // existing Official/Latest toggle takes over.
+  const parentSnapshotCtx = useSnapshot();
+  const currentPhase = parentSnapshotCtx.phase;
+  const currentDimension = parentSnapshotCtx.dimension;
+  const latestSnapshotId = parentSnapshotCtx.snapshot?.id;
+
+  const { data: historyData, mutate: mutateHistory } = useApi<{
+    snapshots: SnapshotHistoryEntry[];
+  }>(
+    `/experiment/${experiment.id}/snapshot-history/${currentPhase}` +
+      (currentDimension ? `?dimension=${currentDimension}` : ""),
+    { shouldRun: () => !hasPin },
+  );
+  const snapshotHistory = useMemo(
+    () => historyData?.snapshots ?? [],
+    [historyData],
+  );
+
+  // refetch the history when a new snapshot becomes the latest, so the
+  // dropdown's value always has a matching option. Otherwise it renders blank
+  // until the cached list reloads on its own, which can take 30-45s+ after a refresh.
+  useEffect(() => {
+    if (latestSnapshotId) mutateHistory();
+  }, [latestSnapshotId, mutateHistory]);
+
+  const [previewSnapshotId, setPreviewSnapshotId] = useState<string | null>(
+    null,
+  );
+  const { data: previewSnapshotData } = useApi<{
+    snapshot: ExperimentSnapshotInterface;
+  }>(`/snapshot/${previewSnapshotId}`, {
+    shouldRun: () => !!previewSnapshotId,
+  });
+  const previewSnapshot = previewSnapshotData?.snapshot;
+  const previewActive = !hasPin && !!previewSnapshotId && !!previewSnapshot;
+
+  // Select a specific snapshot to preview by id. The latest snapshot maps to
+  // null so we fall back to the live view rather than a frozen copy of it.
+  const selectPreviewSnapshot = useCallback(
+    (snapshotId: string) => {
+      setPreviewSnapshotId(snapshotId === latestSnapshotId ? null : snapshotId);
+    },
+    [latestSnapshotId],
+  );
+  const clearPreview = useCallback(() => setPreviewSnapshotId(null), []);
+
+  // a previewed snapshot is specific to a phase+dimension, so drop it
+  // when the user switches either — otherwise the view would keep rendering a
+  // snapshot from a different slice than the one now selected.
+  useEffect(() => {
+    setPreviewSnapshotId(null);
+  }, [currentPhase, currentDimension]);
+
+  const isOfficialView = hasPin && view === "official";
+
+  // The snapshot whose frozen metric arrays the view should reflect: the pinned
+  // one on the Official view, or the previewed one while browsing a past date.
+  const frozenSnapshot =
+    isOfficialView && pinnedSnapshot
+      ? pinnedSnapshot
+      : previewActive && previewSnapshot
+        ? previewSnapshot
+        : null;
+
+  // Swap the experiment's current metric arrays for the frozen snapshot's so the
+  // row list matches the data. Without this, an out-of-band metric sync that
+  // adds/removes metrics on the experiment after the snapshot ran can leave the
+  // view rendering "No data" rows or silently dropping metrics.
+  const effectiveExperiment = frozenSnapshot
+    ? {
+        ...experiment,
+        goalMetrics: frozenSnapshot.settings.goalMetrics,
+        secondaryMetrics: frozenSnapshot.settings.secondaryMetrics,
+        guardrailMetrics: frozenSnapshot.settings.guardrailMetrics,
+      }
+    : experiment;
+
+  const body = (
+    <ResultsTabBody
+      {...props}
+      experiment={effectiveExperiment}
+      hasPin={hasPin}
+      view={view}
+      setView={setView}
+      pinnedReport={pinnedReport}
+      pinnedSnapshotLoading={hasPin && !!pinnedSnapshotId && !pinnedSnapshot}
+      snapshotHistory={snapshotHistory}
+      previewActive={previewActive}
+      selectPreviewSnapshot={selectPreviewSnapshot}
+      clearPreview={clearPreview}
+    />
+  );
+
+  // Render the chosen snapshot (pinned or previewed) via LocalSnapshotProvider.
+  if (frozenSnapshot) {
+    const phase =
+      typeof frozenSnapshot.phase === "number"
+        ? frozenSnapshot.phase
+        : Math.max(0, (experiment.phases?.length ?? 1) - 1);
+    return (
+      <LocalSnapshotProvider
+        experiment={effectiveExperiment}
+        snapshot={frozenSnapshot}
+        phase={phase}
+        dimension={frozenSnapshot.dimension || ""}
+      >
+        {body}
+      </LocalSnapshotProvider>
+    );
+  }
+
+  return body;
+}
+
+// tabbed toggle between the pinned official results and latest results
+function OfficialReadoutToggle({
+  view,
+  setView,
+}: {
+  view: "official" | "latest";
+  setView: (v: "official" | "latest") => void;
+}) {
+  return (
+    <Tabs
+      value={view}
+      onValueChange={(v) => setView(v as "official" | "latest")}
+    >
+      <TabsList mb="3">
+        <TabsTrigger value="official">
+          <Tooltip body="A frozen snapshot of the experiment's results. The numbers and analysis settings don't change when the experiment refreshes.">
+            <span>
+              <span role="img" aria-label="pinned" style={{ marginRight: 6 }}>
+                📌
+              </span>
+              Official results
+            </span>
+          </Tooltip>
+        </TabsTrigger>
+        <TabsTrigger value="latest">
+          <Tooltip body="Live experiment results that get updated with each refresh.">
+            <span>Latest results</span>
+          </Tooltip>
+        </TabsTrigger>
+      </TabsList>
+    </Tabs>
+  );
+}
+
+// green "pinned" banner with provenance + actions for the official readout
+function OfficialReadoutBanner({
+  pinnedReport,
+  pinnedSnapshot,
+  experimentId,
+  pinnedBy,
+  pinnedAt,
+  onUnpin,
+  canManage,
+}: {
+  pinnedReport: ExperimentSnapshotReportInterface;
+  pinnedSnapshot?: ExperimentSnapshotInterface;
+  experimentId: string;
+  pinnedBy?: string;
+  pinnedAt?: string | Date;
+  onUnpin: () => Promise<void> | void;
+  canManage: boolean;
+}) {
+  const { getUserDisplay } = useUser();
+  const resolvedPinnedById = pinnedBy || pinnedReport.userId;
+  const pinnedByName = resolvedPinnedById
+    ? getUserDisplay(resolvedPinnedById, false)
+    : null;
+  const resolvedPinnedAt = pinnedAt || pinnedReport.dateUpdated;
+
+  // prefer the snapshot's actual analysis window over the experiment
+  // phase dates.
+  const snapshotStart = pinnedSnapshot?.settings?.startDate;
+  const snapshotEnd = pinnedSnapshot?.settings?.endDate;
+  const phaseStart = pinnedReport.experimentMetadata?.phases?.[0]?.dateStarted;
+  const phaseEnd =
+    pinnedReport.experimentMetadata?.phases?.[
+      (pinnedReport.experimentMetadata?.phases?.length ?? 1) - 1
+    ]?.dateEnded;
+  const rangeStart = snapshotStart ?? phaseStart;
+  const rangeEnd = snapshotEnd ?? phaseEnd;
+  const dateRange = rangeStart
+    ? rangeEnd
+      ? `${date(rangeStart)} – ${date(rangeEnd)}`
+      : `Since ${date(rangeStart)}`
+    : "";
+
+  const { performCopy, copySuccess } = useCopyToClipboard({ timeout: 1500 });
+  const copyShareableLink = () => {
+    if (typeof window === "undefined") return;
+    performCopy(
+      `${window.location.origin}/experiment/${experimentId}#results/official-results`,
+    );
+  };
+
+  return (
+    <Callout status="success" mb="3" contentsAs="div">
+      <Flex justify="between" align="start" gap="3">
+        <Box>
+          <Text as="div" weight="bold">
+            Official results
+          </Text>
+          {dateRange ? (
+            <Text as="div" size="2" color="gray">
+              Analysis window:{" "}
+              <Text
+                as="span"
+                weight="medium"
+                style={{ color: "var(--gray-12)" }}
+              >
+                {dateRange}
+              </Text>
+            </Text>
+          ) : null}
+          <Text
+            as="div"
+            size="1"
+            color="gray"
+            style={{ fontSize: 11, marginTop: 2 }}
+          >
+            {pinnedByName ? `Pinned by ${pinnedByName} on ` : "Pinned on "}
+            {date(resolvedPinnedAt)}
+          </Text>
+        </Box>
+        <Flex gap="3" align="center" style={{ alignSelf: "center" }}>
+          <Tooltip body="Open the underlying report page for editing, sharing, or seeing the full report metadata.">
+            <LinkButton variant="outline" href={`/report/${pinnedReport.id}`}>
+              Open report
+            </LinkButton>
+          </Tooltip>
+          <Tooltip
+            body={
+              copySuccess
+                ? "Copied"
+                : "Copy a shareable link that opens this experiment on the Official results view."
+            }
+          >
+            <Button
+              variant="ghost"
+              onClick={copyShareableLink}
+              icon={copySuccess ? <PiCheck /> : <PiLink />}
+            >
+              {copySuccess ? "Copied" : "Copy link"}
+            </Button>
+          </Tooltip>
+          {canManage ? (
+            <Button variant="ghost" color="gray" onClick={onUnpin}>
+              Remove official results
+            </Button>
+          ) : null}
+        </Flex>
+      </Flex>
+    </Callout>
+  );
+}
+
+type ResultsTabBodyProps = Props & {
+  // props threaded from the outer wrapper for the pinning feature
+  hasPin: boolean;
+  view: "official" | "latest";
+  setView: (v: "official" | "latest") => void;
+  pinnedReport?: ExperimentSnapshotReportInterface;
+  pinnedSnapshotLoading: boolean;
+  // "view a past snapshot" controls
+  snapshotHistory: SnapshotHistoryEntry[];
+  previewActive: boolean;
+  selectPreviewSnapshot: (snapshotId: string) => void;
+  clearPreview: () => void;
+};
+
+function ResultsTabBody({
   experiment,
   envs,
   mutate,
@@ -99,11 +477,21 @@ export default function ResultsTab({
   setSortBy,
   sortDirection,
   setSortDirection,
-}: Props) {
+  hasPin,
+  view,
+  setView,
+  pinnedReport,
+  pinnedSnapshotLoading,
+  snapshotHistory,
+  previewActive,
+  selectPreviewSnapshot,
+  clearPreview,
+}: ResultsTabBodyProps) {
   const {
     getDatasourceById,
     getExperimentMetricById,
     getProjectById,
+    metrics: _metrics,
     datasources,
     getSegmentById,
   } = useDefinitions();
@@ -168,11 +556,88 @@ export default function ResultsTab({
     (e) => e.id === experiment.exposureQueryId,
   )?.userIdType;
 
-  const reportArgs: ExperimentSnapshotReportArgs = {
-    userIdType: userIdType as "user" | "anonymous" | undefined,
-    differenceType: analysisBarSettings.differenceType,
-    dimension: analysisBarSettings.dimension,
-  };
+  const reportArgs: ExperimentSnapshotReportArgs = useMemo(
+    () => ({
+      userIdType: userIdType as "user" | "anonymous" | undefined,
+      differenceType: analysisBarSettings.differenceType,
+      dimension: analysisBarSettings.dimension,
+    }),
+    [
+      userIdType,
+      analysisBarSettings.differenceType,
+      analysisBarSettings.dimension,
+    ],
+  );
+
+  // derived state + callbacks for the official-readout pin feature
+  const isOfficialView = hasPin && view === "official";
+  const canManagePin = permissionsUtil.canUpdateExperiment(experiment, {});
+
+  // pins whatever snapshot is currently being viewed as the official
+  // readout. `isPast` = the view is a previewed past snapshot (not the latest).
+  const saveAsOfficialReadout = useCallback(
+    async (isPast: boolean) => {
+      const targetSnapshotId = snapshot?.id;
+      if (!targetSnapshotId) return;
+      // self-describing title — a past pin is dated by its window end,
+      // a live pin by today.
+      const windowEnd = snapshot?.settings?.endDate;
+      const officialTitle =
+        isPast && windowEnd
+          ? `Official results — ${date(windowEnd)}`
+          : `Official results — ${date(new Date())}`;
+      // for a *past* snapshot, the live analysis bar's differenceType
+      // may not have been computed back then. Omit it so postReportFromSnapshot
+      // falls back to the snapshot's default analysis (no upstream change
+      // needed). The live-snapshot path keeps its differenceType as before.
+      const body = isPast
+        ? { ...reportArgs, differenceType: undefined, title: officialTitle }
+        : { ...reportArgs, title: officialTitle };
+      const res = await apiCall<{ report: ReportInterface }>(
+        `/experiments/report/${targetSnapshotId}`,
+        {
+          method: "POST",
+          body: JSON.stringify(body),
+        },
+      );
+      if (!res.report) throw new Error("Failed to create report");
+      await apiCall(`/experiment/${experiment.id}`, {
+        method: "POST",
+        body: JSON.stringify({ pinnedReportId: res.report.id }),
+      });
+      track("Experiment Official Readout: Save", {
+        source: isPast
+          ? "experiment results tab (past snapshot)"
+          : "experiment results tab",
+      });
+      clearPreview();
+      mutate();
+      setView("official");
+    },
+    [
+      apiCall,
+      experiment.id,
+      mutate,
+      reportArgs,
+      setView,
+      snapshot,
+      clearPreview,
+    ],
+  );
+
+  const unpinOfficialReadout = useCallback(async () => {
+    await apiCall(`/experiment/${experiment.id}`, {
+      method: "POST",
+      body: JSON.stringify({ pinnedReportId: "" }),
+    });
+    track("Experiment Official Readout: Unpin", {
+      source: "experiment results tab",
+    });
+    mutate();
+    setView("latest");
+  }, [apiCall, experiment.id, mutate, setView]);
+  // error from the save-as-official button, rendered as a Callout
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   const onSnapshotSuccessfulUpdate = useCallback(() => {
     // Reset analysis settings to default
@@ -197,6 +662,7 @@ export default function ResultsTab({
 
   const endDate =
     experiment.status !== "running" ? snapshot?.settings?.endDate : undefined;
+
   return (
     <div>
       {isBandit && hasResults ? (
@@ -206,135 +672,216 @@ export default function ResultsTab({
         </Callout>
       ) : null}
 
-      <Box>
-        <Flex direction="row" align="start" gap="3" mx="1" mb="4">
-          {!(
-            experiment.type === "multi-armed-bandit" &&
-            experiment.status === "running"
-          ) && permissionsUtil.canUpdateExperiment(experiment, {}) ? (
-            <Link
-              type="button"
-              onClick={() => setAnalysisSettingsOpen(true)}
-              mr="2"
-            >
-              Edit Settings
-            </Link>
-          ) : null}
-          {hasData && (
-            <>
-              <Metadata
-                label="Engine"
-                value={
-                  analysis?.settings?.statsEngine === "frequentist"
-                    ? "Frequentist"
-                    : "Bayesian"
-                }
-              />
-              <Metadata
-                label="CUPED"
-                value={
-                  analysis?.settings?.regressionAdjusted
-                    ? "Enabled"
-                    : "Disabled"
-                }
-              />
-              {!organization?.settings?.disablePrecomputedDimensions ? (
+      {/* toggle + pinned banner + loading state for official readout */}
+      {saveError ? (
+        <Callout status="error" mb="3">
+          Failed to set as official results: {saveError}
+        </Callout>
+      ) : null}
+      {hasPin && <OfficialReadoutToggle view={view} setView={setView} />}
+      {isOfficialView && pinnedReport ? (
+        <OfficialReadoutBanner
+          pinnedReport={pinnedReport}
+          pinnedSnapshot={snapshot ?? undefined}
+          experimentId={experiment.id}
+          pinnedBy={experiment.pinnedReportBy}
+          pinnedAt={experiment.pinnedReportAt}
+          onUnpin={unpinOfficialReadout}
+          canManage={canManagePin}
+        />
+      ) : null}
+      {isOfficialView && pinnedSnapshotLoading ? (
+        <Callout status="info" mb="3">
+          Loading official results…
+        </Callout>
+      ) : null}
+
+      {/* hide the regular settings header while viewing the pinned readout */}
+      {!isOfficialView && (
+        <Box>
+          <Flex direction="row" align="start" gap="3" mx="1" mb="4">
+            {!(
+              experiment.type === "multi-armed-bandit" &&
+              experiment.status === "running"
+            ) && permissionsUtil.canUpdateExperiment(experiment, {}) ? (
+              <Link
+                type="button"
+                onClick={() => setAnalysisSettingsOpen(true)}
+                mr="2"
+              >
+                Edit Settings
+              </Link>
+            ) : null}
+            {hasData && (
+              <>
                 <Metadata
-                  label="Post-Stratification"
+                  label="Engine"
                   value={
-                    analysis?.settings?.postStratificationEnabled
+                    analysis?.settings?.statsEngine === "frequentist"
+                      ? "Frequentist"
+                      : "Bayesian"
+                  }
+                />
+                <Metadata
+                  label="CUPED"
+                  value={
+                    analysis?.settings?.regressionAdjusted
                       ? "Enabled"
                       : "Disabled"
                   }
                 />
-              ) : null}
-              {analysis?.settings?.statsEngine === "frequentist" ? (
-                <Metadata
-                  label="Sequential"
-                  value={
-                    analysis?.settings?.sequentialTesting
-                      ? "Enabled"
-                      : "Disabled"
-                  }
-                />
-              ) : null}
-              {segment ? (
-                <Metadata label="Segment" value={segment.name} />
-              ) : null}
-              {activationMetric ? (
-                <Metadata
-                  label="Activation Metric"
-                  value={activationMetric.name}
-                />
-              ) : null}
-              {getEffectiveLookbackOverride(
-                experiment.attributionModel,
-                experiment.lookbackOverride,
-              ) && experiment.lookbackOverride ? (
-                <Metadata
-                  label="Lookback Enforced"
-                  value={
-                    experiment.lookbackOverride.type === "date"
-                      ? `${date(experiment.lookbackOverride.value, "UTC")} - ${endDate ? date(endDate, "UTC") : "now"}`
-                      : `${experiment.lookbackOverride.value} ${experiment.lookbackOverride.valueUnit}`
-                  }
-                />
-              ) : null}
-              {isBandit && snapshot ? (
-                <>
-                  <Flex style={{ flex: 1 }} />
-                  <Flex direction="column" align="end">
-                    <Metadata
-                      label="Analysis type"
-                      value={
-                        snapshot?.type === "exploratory" ? (
-                          <Tooltip
-                            body={
-                              <div className="text-left">
-                                <p>This is an exploratory analysis.</p>
-                                <p>
-                                  Exploratory analyses do not cause bandit
-                                  variation weights to change.
-                                </p>
-                              </div>
-                            }
+                {!organization?.settings?.disablePrecomputedDimensions ? (
+                  <Metadata
+                    label="Post-Stratification"
+                    value={
+                      analysis?.settings?.postStratificationEnabled
+                        ? "Enabled"
+                        : "Disabled"
+                    }
+                  />
+                ) : null}
+                {analysis?.settings?.statsEngine === "frequentist" ? (
+                  <Metadata
+                    label="Sequential"
+                    value={
+                      analysis?.settings?.sequentialTesting
+                        ? "Enabled"
+                        : "Disabled"
+                    }
+                  />
+                ) : null}
+                {segment ? (
+                  <Metadata label="Segment" value={segment.name} />
+                ) : null}
+                {activationMetric ? (
+                  <Metadata
+                    label="Activation Metric"
+                    value={activationMetric.name}
+                  />
+                ) : null}
+                {getEffectiveLookbackOverride(
+                  experiment.attributionModel,
+                  experiment.lookbackOverride,
+                ) && experiment.lookbackOverride ? (
+                  <Metadata
+                    label="Lookback Enforced"
+                    value={
+                      experiment.lookbackOverride.type === "date"
+                        ? `${date(experiment.lookbackOverride.value, "UTC")} - ${endDate ? date(endDate, "UTC") : "now"}`
+                        : `${experiment.lookbackOverride.value} ${experiment.lookbackOverride.valueUnit}`
+                    }
+                  />
+                ) : null}
+                {/* view-a-past-snapshot control + pin, when nothing is pinned */}
+                {!hasPin &&
+                canManagePin &&
+                hasResults &&
+                experiment.status !== "draft" ? (
+                  <>
+                    <Flex style={{ flex: 1 }} />
+                    {/* browse to a past snapshot (snaps to nearest that ran) */}
+                    {snapshotHistory.length > 0 ? (
+                      <Tooltip body="View a previously computed snapshot (e.g. the day-14 readout). Snaps to the nearest snapshot that actually ran; only changes what you see until you pin.">
+                        <Flex
+                          align="center"
+                          gap="2"
+                          style={{
+                            fontSize: 13,
+                            color: "var(--color-text-mid)",
+                          }}
+                        >
+                          View results as of
+                          <Select
+                            value={snapshot?.id ?? ""}
+                            setValue={selectPreviewSnapshot}
+                            size="2"
+                            placeholder="Select a snapshot"
                           >
-                            Exploratory
-                          </Tooltip>
-                        ) : snapshot?.type === "standard" ? (
-                          <Tooltip
-                            body={
-                              <div className="text-left">
-                                <p>This is a standard analysis.</p>
-                                <p>
-                                  Bandit variation weights may have changed in
-                                  response to this analysis.
-                                </p>
-                              </div>
-                            }
-                          >
-                            Standard
-                          </Tooltip>
-                        ) : (
-                          <span>{snapshot?.type || `unknown`}</span>
-                        )
+                            {snapshotHistory.map((s) => (
+                              <SelectItem key={s.id} value={s.id}>
+                                {datetime(s.windowEndDate)}
+                              </SelectItem>
+                            ))}
+                          </Select>
+                        </Flex>
+                      </Tooltip>
+                    ) : null}
+                    <Tooltip
+                      body={
+                        previewActive
+                          ? "Pins the snapshot you're previewing as this experiment's official results."
+                          : "Creates a new custom report from the current snapshot and marks it as this experiment's official results. Visible to anyone who can view the experiment."
                       }
-                    />
-                    {snapshot?.type !== "standard" && (
-                      <Link
-                        onClick={() => setSnapshotType("standard")}
-                        style={{ marginBottom: -8 }}
+                    >
+                      <Button
+                        variant="outline"
+                        setError={setSaveError}
+                        onClick={() => saveAsOfficialReadout(previewActive)}
                       >
-                        <Text size="1">View standard analysis</Text>
-                      </Link>
-                    )}
-                  </Flex>
-                </>
-              ) : null}
-            </>
-          )}
-        </Flex>
-      </Box>
+                        📌{" "}
+                        {previewActive
+                          ? "Pin these results"
+                          : "Pin as official results"}
+                      </Button>
+                    </Tooltip>
+                  </>
+                ) : null}
+                {isBandit && snapshot ? (
+                  <>
+                    <Flex style={{ flex: 1 }} />
+                    <Flex direction="column" align="end">
+                      <Metadata
+                        label="Analysis type"
+                        value={
+                          snapshot?.type === "exploratory" ? (
+                            <Tooltip
+                              body={
+                                <div className="text-left">
+                                  <p>This is an exploratory analysis.</p>
+                                  <p>
+                                    Exploratory analyses do not cause bandit
+                                    variation weights to change.
+                                  </p>
+                                </div>
+                              }
+                            >
+                              Exploratory
+                            </Tooltip>
+                          ) : snapshot?.type === "standard" ? (
+                            <Tooltip
+                              body={
+                                <div className="text-left">
+                                  <p>This is a standard analysis.</p>
+                                  <p>
+                                    Bandit variation weights may have changed in
+                                    response to this analysis.
+                                  </p>
+                                </div>
+                              }
+                            >
+                              Standard
+                            </Tooltip>
+                          ) : (
+                            <span>{snapshot?.type || `unknown`}</span>
+                          )
+                        }
+                      />
+                      {snapshot?.type !== "standard" && (
+                        <Link
+                          onClick={() => setSnapshotType("standard")}
+                          style={{ marginBottom: -8 }}
+                        >
+                          <Text size="1">View standard analysis</Text>
+                        </Link>
+                      )}
+                    </Flex>
+                  </>
+                ) : null}
+              </>
+            )}
+          </Flex>
+        </Box>
+      )}
 
       <div className="appbox">
         {analysisSettingsOpen ? (
@@ -351,41 +898,45 @@ export default function ResultsTab({
           />
         ) : null}
         <div className="mb-2" style={{ overflowX: "initial" }}>
-          <AnalysisSettingsSummary
-            experiment={experiment}
-            mutate={mutate}
-            statsEngine={statsEngine}
-            editMetrics={editMetrics ?? undefined}
-            variationFilter={analysisBarSettings.variationFilter}
-            baselineRow={analysisBarSettings.baselineRow}
-            differenceType={analysisBarSettings.differenceType}
-            dimension={analysisBarSettings.dimension}
-            setDimension={(d: string, resetOtherSettings?: boolean) =>
-              setAnalysisBarSettings({
-                ...analysisBarSettings,
-                dimension: d,
-                ...(resetOtherSettings
-                  ? {
-                      baselineRow: 0,
-                      differenceType: "relative",
-                      variationFilter: [],
-                    }
-                  : {}),
-              })
-            }
-            metricTagFilter={metricTagFilter}
-            setMetricTagFilter={setMetricTagFilter}
-            metricsFilter={metricsFilter}
-            setMetricsFilter={setMetricsFilter}
-            availableMetricsFilters={availableMetricsFilters}
-            availableMetricTags={availableMetricTags}
-            availableSliceTags={availableSliceTags}
-            sliceTagsFilter={sliceTagsFilter}
-            setSliceTagsFilter={setSliceTagsFilter}
-            sortBy={sortBy}
-            sortDirection={sortDirection}
-            onSnapshotSuccessfulUpdate={onSnapshotSuccessfulUpdate}
-          />
+          {/* skip AnalysisSettingsSummary on the pinned readout. Its
+              Run Queries / date controls would mutate the snapshot. */}
+          {!isOfficialView && (
+            <AnalysisSettingsSummary
+              experiment={experiment}
+              mutate={mutate}
+              statsEngine={statsEngine}
+              editMetrics={editMetrics ?? undefined}
+              variationFilter={analysisBarSettings.variationFilter}
+              baselineRow={analysisBarSettings.baselineRow}
+              differenceType={analysisBarSettings.differenceType}
+              dimension={analysisBarSettings.dimension}
+              setDimension={(d: string, resetOtherSettings?: boolean) =>
+                setAnalysisBarSettings({
+                  ...analysisBarSettings,
+                  dimension: d,
+                  ...(resetOtherSettings
+                    ? {
+                        baselineRow: 0,
+                        differenceType: "relative",
+                        variationFilter: [],
+                      }
+                    : {}),
+                })
+              }
+              metricTagFilter={metricTagFilter}
+              setMetricTagFilter={setMetricTagFilter}
+              metricsFilter={metricsFilter}
+              setMetricsFilter={setMetricsFilter}
+              availableMetricsFilters={availableMetricsFilters}
+              availableMetricTags={availableMetricTags}
+              availableSliceTags={availableSliceTags}
+              sliceTagsFilter={sliceTagsFilter}
+              setSliceTagsFilter={setSliceTagsFilter}
+              sortBy={sortBy}
+              sortDirection={sortDirection}
+              onSnapshotSuccessfulUpdate={onSnapshotSuccessfulUpdate}
+            />
+          )}
           {experiment.status === "draft" ? (
             <Callout status="info" mx="3" my="4">
               Your experiment is still in a <strong>draft</strong> state. You
@@ -453,7 +1004,8 @@ export default function ResultsTab({
           )}
         </div>
       </div>
-      {snapshot && !isDemoExperiment && (
+      {/* also hide the Custom Reports section while viewing the pinned readout */}
+      {snapshot && !isDemoExperiment && !isOfficialView && (
         <div className="appbox mt-4">
           <div className="row mx-2 py-3 d-flex align-items-center">
             <div className="col ml-2">
@@ -492,6 +1044,18 @@ export default function ResultsTab({
           </div>
           <ExperimentReportsList experiment={experiment} />
         </div>
+      )}
+      {/* bottom-of-page nav so users on the Official view know how to
+          find the Custom Reports section. */}
+      {isOfficialView && (
+        <Box mt="4" mb="2" style={{ textAlign: "center" }}>
+          <Text as="div" size="2" color="gray">
+            <Link type="button" onClick={() => setView("latest")}>
+              View other custom reports →
+            </Link>{" "}
+            Switch to Latest results
+          </Text>
+        </Box>
       )}
     </div>
   );

--- a/packages/front-end/components/Report/ReportMetaInfo.tsx
+++ b/packages/front-end/components/Report/ReportMetaInfo.tsx
@@ -12,6 +12,7 @@ import { ExperimentInterfaceStringDates } from "shared/types/experiment";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import Button from "@/ui/Button";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import { useAuth } from "@/services/auth";
 import LinkButton from "@/ui/LinkButton";
 import SplitButton from "@/ui/SplitButton";
@@ -42,6 +43,7 @@ export default function ReportMetaInfo({
   experiment,
   datasource,
   mutate,
+  mutateExperiment,
   isOwner,
   isAdmin,
   canEdit,
@@ -55,6 +57,8 @@ export default function ReportMetaInfo({
   experiment?: Partial<ExperimentInterfaceStringDates>;
   datasource?: DataSourceInterfaceWithParams;
   mutate?: () => Promise<unknown> | unknown;
+  // lets the Pin / Unpin button refresh the underlying experiment
+  mutateExperiment?: () => Promise<unknown> | unknown;
   isOwner?: boolean;
   isAdmin?: boolean;
   canEdit?: boolean;
@@ -76,6 +80,18 @@ export default function ReportMetaInfo({
 
   const [generalModalOpen, setGeneralModalOpen] = useState(false);
   const [shareModalOpen, setShareModalOpen] = useState(false);
+
+  // track pin-as-official in-flight state
+  const [pinning, setPinning] = useState(false);
+  // the Pin button mutates the experiment, so gate it on canUpdateExperiment
+  // (not report-level canEdit). Server enforces this too; UI match prevents a 403 click.
+  const permissionsUtil = usePermissionsUtil();
+  const canPin = experiment?.id
+    ? permissionsUtil.canUpdateExperiment(
+        experiment as ExperimentInterfaceStringDates,
+        {},
+      )
+    : false;
 
   const [shareLevel, setShareLevel] = useState<ShareLevel>(
     report.shareLevel || "organization",
@@ -346,6 +362,53 @@ export default function ReportMetaInfo({
                   Edit Report
                 </LinkButton>
               )}
+              {/* Pin-as-official-readout button. Shown when the report
+                  is attached to an experiment the current user can edit. */}
+              {showEditControls && experiment?.id && canEdit && canPin
+                ? (() => {
+                    const isPinned = experiment?.pinnedReportId === report.id;
+                    const tooltipBody = isPinned
+                      ? "Removes this report as the experiment's official results. The experiment results view will revert to the live snapshot."
+                      : "Marks this report as the experiment's official results. Anyone viewing the experiment will see this report's results by default. Refreshes or edits to this report will update the official view.";
+                    return (
+                      <Tooltip body={tooltipBody}>
+                        <Button
+                          variant="outline"
+                          mr="2"
+                          loading={pinning}
+                          onClick={async () => {
+                            if (!experiment?.id) return;
+                            setPinning(true);
+                            try {
+                              await apiCall(`/experiment/${experiment.id}`, {
+                                method: "POST",
+                                body: JSON.stringify({
+                                  pinnedReportId: isPinned ? "" : report.id,
+                                }),
+                              });
+                              track(
+                                isPinned
+                                  ? "Experiment Official Readout: Unpin"
+                                  : "Experiment Official Readout: Pin",
+                                { source: "report page" },
+                              );
+                              await Promise.all([
+                                mutate?.(),
+                                mutateExperiment?.(),
+                              ]);
+                            } finally {
+                              setPinning(false);
+                            }
+                          }}
+                        >
+                          {isPinned
+                            ? "Remove official results"
+                            : "📌 Set as official results"}
+                        </Button>
+                      </Tooltip>
+                    );
+                  })()
+                : null}
               {showEditControls ? (
                 <div className="d-flex flex-column align-items-end">
                   {shareLevel === "public" ? (

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -15,6 +15,8 @@ import ReportMetaInfo from "@/components/Report/ReportMetaInfo";
 import LegacyReportPage from "@/components/Report/LegacyReportPage";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import ConfigureReport from "@/components/Report/ConfigureReport";
+import Callout from "@/ui/Callout";
+import Link from "@/ui/Link";
 
 export default function ReportPage() {
   const router = useRouter();
@@ -31,7 +33,9 @@ export default function ReportPage() {
   const report = data?.report;
   const loading = !data;
 
-  const { data: experimentData } = useApi<{
+  // mutateExperiment is exposed so the Pin-as-official-readout button in
+  // ReportMetaInfo can refresh experiment state after toggling pinnedReportId.
+  const { data: experimentData, mutate: mutateExperiment } = useApi<{
     experiment: ExperimentInterfaceStringDates;
     idea?: IdeaInterface;
     visualChangesets: VisualChangesetInterface[];
@@ -127,12 +131,26 @@ export default function ReportPage() {
         ]}
       />
 
+      {/* heads-up when this report is pinned as official results */}
+      {experiment?.pinnedReportId === report.id ? (
+        <Callout status="info" mb="3">
+          📌 Changes made to this report will update the{" "}
+          <Link href={`/experiment/${experiment.id}#results/official-results`}>
+            official experiment results
+          </Link>
+          . Please create a new custom report if you do not want to affect the
+          official results.
+        </Callout>
+      ) : null}
+
       <ReportMetaInfo
         report={report}
         snapshot={snapshot ?? undefined}
         experiment={experiment}
         datasource={datasource}
         mutate={mutate}
+        // lets Pin/Unpin official readout refresh the experiment state
+        mutateExperiment={mutateExperiment}
         isOwner={isOwner}
         isAdmin={isAdmin}
         canEdit={canEdit}

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -446,6 +446,15 @@ export const experimentInterface = z
       .array(z.string())
       .max(MAX_PRECOMPUTED_UNIT_DIMENSIONS, maxPrecomputedUnitDimensionsError)
       .optional(),
+    // ID of a custom report pinned as the "official results" for this experiment
+    pinnedReportId: z.string().optional(),
+    // frozen snapshot id at pin time so the official view stays stable
+    // even if the report is later edited/refreshed (server-derived)
+    pinnedSnapshotId: z.string().optional(),
+    // userId of whoever pinned the current official results (server-derived)
+    pinnedReportBy: z.string().optional(),
+    // timestamp when the current official results were pinned (server-derived)
+    pinnedReportAt: z.date().optional(),
   })
   .strict()
   .merge(experimentAnalysisSettings);
@@ -816,6 +825,32 @@ const apiExperimentShape = z.object({
       date: z.string().meta({ format: "date-time" }),
     })
     .nullable()
+    .optional(),
+  // official-results pin state on the external API
+  pinnedReportId: z
+    .string()
+    .describe(
+      "ID of the report pinned as this experiment's official results, if any.",
+    )
+    .optional(),
+  pinnedSnapshotId: z
+    .string()
+    .describe(
+      "ID of the snapshot frozen at pin time. Independent of the report's current snapshot so the official view stays stable. Server-derived.",
+    )
+    .optional(),
+  pinnedReportBy: z
+    .string()
+    .describe(
+      "User ID of whoever pinned the current official results. Server-derived.",
+    )
+    .optional(),
+  pinnedReportAt: z
+    .string()
+    .meta({ format: "date-time" })
+    .describe(
+      "Timestamp when the current official results were pinned. Server-derived.",
+    )
     .optional(),
 });
 export const apiExperimentValidator = namedSchema(

--- a/packages/shared/types/experiment-snapshot.d.ts
+++ b/packages/shared/types/experiment-snapshot.d.ts
@@ -287,6 +287,18 @@ export type SnapshotStatusSummary = Pick<
   | "triggeredBy"
 >;
 
+// Lightweight row for the "view a past snapshot" history picker. Carries the
+// analysis window (from settings) on top of a few status fields so the picker
+// can label each snapshot by its covered date range / "Day N" without reading
+// the heavy per-metric analysis blobs.
+export type SnapshotHistoryEntry = Pick<
+  ExperimentSnapshotInterface,
+  "id" | "dateCreated" | "status" | "triggeredBy" | "type" | "dimension"
+> & {
+  windowStartDate: Date;
+  windowEndDate: Date;
+};
+
 export interface ExperimentSnapshotHealth {
   traffic: ExperimentSnapshotTraffic;
   power?: MidExperimentPowerCalculationResult;

--- a/packages/shared/types/experiment.d.ts
+++ b/packages/shared/types/experiment.d.ts
@@ -196,12 +196,15 @@ export type ExperimentInterfaceStringDates = Omit<
   | "phases"
   | "nextScheduledStatusUpdate"
   | "statusUpdateSchedule"
+  | "pinnedReportAt"
 > & {
   dateCreated: string;
   dateUpdated: string;
   phases: ExperimentPhaseStringDates[];
   nextScheduledStatusUpdate?: NextScheduledStatusUpdateStringDates | null;
   statusUpdateSchedule?: StatusUpdateScheduleStringDates | null;
+  // pinnedReportAt is z.date() on the back-end but an ISO string on the wire
+  pinnedReportAt?: string;
 };
 
 export type HoldoutExperimentInterface = ExperimentInterfaceStringDates &


### PR DESCRIPTION
## Summary

Opening this as a **draft to share an approach**, in the same spirit as #6151 — not necessarily a merge request. We built this on our fork and thought the design might be useful upstream or to others; happy to adapt it (naming, UX, scope) if there's interest in taking it further.

It adds the ability to pin a specific results snapshot as an experiment's canonical **"Official results"**, so a shared readout link stays stable instead of changing every time the experiment auto-refreshes.

## Problem

The experiment results view always shows the *latest* snapshot. There's no way to say "this is the readout we're standing behind." When you share a results link in a doc or a review, the numbers can shift under it on the next refresh, and there's no stable, attributable "this is the official call" view.

## Approach

Pin state lives on the **experiment** (four optional fields):

- `pinnedReportId` — the report a user pinned (the only client-settable field)
- `pinnedSnapshotId` — the snapshot **frozen at pin time**, server-derived
- `pinnedReportBy` / `pinnedReportAt` — who pinned it and when, server-derived

The key decision is freezing `pinnedSnapshotId` at pin time rather than always following the report's live snapshot. That keeps the official view stable even if the experiment's metric list later drifts (e.g. an external sync adds/removes metrics after the snapshot ran). The Results tab renders the frozen snapshot by reusing the existing `LocalSnapshotProvider`, and overrides the experiment's metric arrays with the snapshot's frozen ones so the row list always matches the data.

**Three ways to pin** — all converge on the same state:

1. **Current snapshot** — "Pin as official results" on the Results tab
2. **A custom report** — "Set as official results" on the report page
3. **A past snapshot** — a "View results as of" dropdown previews an earlier snapshot, then pins the one you're viewing

Once pinned, the Results tab shows an **Official / Latest** toggle (deep-linkable via `#results/official-results`) with a provenance banner (pinned-by/at, open-report, copy-link, remove). A deliberate refresh/edit of the pinned report auto-advances `pinnedSnapshotId` to the new snapshot — but only on success, so a failed refresh never replaces a good official readout.

## Notable design points

- **No new controller for past-snapshot pinning.** It reuses the existing `POST /experiments/report/:snapshot`; the front end just omits `differenceType` so `postReportFromSnapshot` falls back to the snapshot's default analysis.
- **Cheap history endpoint.** `GET /experiment/:id/snapshot-history/:phase` projects only window dates + status (never the per-metric analysis blobs) and excludes report-type snapshots. It mirrors the access pattern of the existing `getSnapshotSummary` handler.
- **Read-only on the REST API.** The four fields are exposed on the `Experiment` API model but are server-derived and absent from the create/update bodies, so they can't be set via the external write API.
- **Pin changes are excluded from the experiment audit/compare diff** (treated as a UI bookmark).

## Files

Back-end: `models/ExperimentModel`, `models/ExperimentSnapshotModel`, `controllers/experiments`, `controllers/metrics`, `services/experiments`, `queryRunners/ExperimentResultsQueryRunner`, `app.ts`.
Shared: `validators/experiments`, `types/experiment.d.ts`, `types/experiment-snapshot.d.ts` (+ regenerated `generated/spec.yaml`).
Front-end: `Experiment/TabbedPage/ResultsTab` (the bulk), `Report/ReportMetaInfo`, `pages/report/[rid]`, `Experiment/CompareExperimentEventsModal`.

## Notes for reviewers

- `pinnedReportAt` is a `Date` internally and an ISO string on the wire, handled the same way as `dateCreated`/`dateUpdated`.
- There are a couple of bespoke `track(...)` analytics events ("Experiment Official Readout: …") that may not match upstream's conventions — easy to drop or rename.
- The front-end work is concentrated in `ResultsTab.tsx`, which is split into a thin wrapper (resolves the frozen snapshot + view state) around the existing body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
