### PR TITLE
fix(aggregated-tables): exclude archived fact-metrics from build query

### DIFF
--- a/packages/back-end/src/services/aggregatedFactTables.ts
+++ b/packages/back-end/src/services/aggregatedFactTables.ts
@@ -125,6 +125,7 @@ export function getMetricsForAggregatedFactTable(
   factTableId: string,
 ): FactMetricInterface[] {
   return factMetrics.filter((metric) => {
+    if (metric.archived) return false;
     const referencesFactTable =
       metric.numerator.factTableId === factTableId ||
       (isRatioMetric(metric) &&

--- a/packages/back-end/test/aggregatedFactTable.test.ts
+++ b/packages/back-end/test/aggregatedFactTable.test.ts
@@ -13,6 +13,7 @@ import {
   parseAggregatedFactTableCoverage,
   foldAggregatedFactTableCoverage,
 } from "back-end/src/queryRunners/AggregatedFactTableQueryRunner";
+import { getAggregatedFactTableMetrics } from "back-end/src/services/aggregatedFactTables";
 import { bigQueryDialect } from "back-end/src/integrations/dialects/bigquery";
 import { factMetricFactory } from "./factories/FactMetric.factory";
 import { factTableFactory } from "./factories/FactTable.factory";
@@ -197,6 +198,24 @@ describe("getFactTableSettingsHashForAggregatedFactTable", () => {
     expect(getFactTableSettingsHashForAggregatedFactTable(a)).not.toEqual(
       getFactTableSettingsHashForAggregatedFactTable(b),
     );
+  });
+});
+
+describe("getAggregatedFactTableMetrics", () => {
+  it("excludes archived fact-metrics", () => {
+    const factTable = factTableFactory.build({ id: FT_ID });
+    const active = factMetricFactory.build({
+      numerator: { factTableId: FT_ID, column: "value", aggregation: "sum" },
+    });
+    const archived = factMetricFactory.build({
+      archived: true,
+      numerator: { factTableId: FT_ID, column: "gone", aggregation: "sum" },
+    });
+    const metrics = getAggregatedFactTableMetrics({
+      factMetrics: [active, archived],
+      factTable,
+    });
+    expect(metrics.map((m) => m.id)).toEqual([active.id]);
   });
 });
 


### PR DESCRIPTION
## Problem

The Shared Daily Aggregated Tables build (#6036) compiles every fact-metric on the factTable into one INSERT query — including **archived** metrics. If an archived metric references a column that's been removed from the FT, the entire build fails at parse, even though the metric is archived and unused.

## Repro

1. FT with column `foo`, metric M referencing `foo`
2. Remove `foo` from FT SQL, archive M
3. Enable `aggregatedFactTableSettings`, trigger build
4. Build fails: `Unrecognized name: foo`

## Fix

Filter `!m.archived` when gathering metrics for the agg INSERT. Archived metrics don't need pre-aggregation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
