### PR TITLE
fix(front-end): cap search tokenizer suffix expansion to avoid O(N²) memory on /saved-groups

### DIFF
--- a/packages/front-end/services/search.tsx
+++ b/packages/front-end/services/search.tsx
@@ -85,6 +85,14 @@ export function tagFilterOnClick(
 const wordBoundary = /[\n\r\p{Z}]+/u;
 const tokenSeparators = /\p{P}+/u;
 
+// Suffix expansion is O(parts²) in string data, so it's only safe for
+// identifier-like words (a handful of underscore/hyphen-separated parts).
+// Above this threshold a "word" is almost certainly free text or JSON without
+// whitespace (e.g. a saved-group condition), where joining suffixes is both
+// meaningless and can produce hundreds of MB of strings — index the individual
+// parts instead.
+const maxPartsForSuffixExpansion = 16;
+
 // Split a string into normalized words. MiniSearch can only match terms by
 // prefix/fuzzy (no substring search), so for indexing we emit every
 // "boundary suffix" of each word — e.g. "search_test_key" -> ["search_test_key",
@@ -95,11 +103,10 @@ const tokenSeparators = /\p{P}+/u;
 function tokenizeFields(text: string, expandSuffixes: boolean): string[] {
   return text.split(wordBoundary).flatMap((word) => {
     const parts = word.split(tokenSeparators).filter(Boolean);
-    return expandSuffixes
-      ? parts.map((_, i) => parts.slice(i).join("_"))
-      : parts.length
-        ? [parts.join("_")]
-        : [];
+    if (!expandSuffixes) return parts.length ? [parts.join("_")] : [];
+    return parts.length > maxPartsForSuffixExpansion
+      ? parts
+      : parts.map((_, i) => parts.slice(i).join("_"));
   });
 }
 

--- a/packages/front-end/test/services/search.test.ts
+++ b/packages/front-end/test/services/search.test.ts
@@ -660,6 +660,32 @@ describe("useSearch", () => {
         expect.arrayContaining(["search_test_key", "search-test-key"]),
       );
     });
+
+    it("handles long punctuation-dense fields without quadratic suffix blowup", () => {
+      // A saved-group condition can be a single whitespace-free JSON string
+      // with thousands of punctuation-separated parts. Suffix expansion on
+      // that is O(parts²) and OOMs the tab; the tokenizer must cap it while
+      // still indexing individual parts so single-word search keeps working.
+      const values = Array.from({ length: 5000 }, (_, i) => `"v${i}"`).join(
+        ",",
+      );
+      const longItems = [
+        { id: "1", name: "small", condition: `{"x":1}` },
+        { id: "2", name: "big", condition: `{"attr":{"$in":[${values}]}}` },
+      ];
+      const { result } = renderHook(() =>
+        useSearch<{ id: string; name: string; condition: string }>({
+          items: longItems,
+          searchFields: ["name", "condition"],
+          localStorageKey: "search-service-test-long-condition",
+          defaultSortField: "name",
+        }),
+      );
+      act(() => {
+        result.current.setSearchValue("v4321");
+      });
+      expect(result.current.filteredItems.map((i) => i.name)).toEqual(["big"]);
+    });
   });
 
   describe("filterSearchTerm", () => {


### PR DESCRIPTION
## Problem

Since #6132, opening **/saved-groups** with a large Condition Group crashes the browser tab ("Aw, Snap!" / out-of-memory in Chrome).

## Root cause

#6132 changed the `useSearch` index tokenizer to emit every word-boundary suffix of each word, so a query like `test_key` can match `search_test_key`. For identifier-like words with a handful of `_`/`-` parts that's cheap.

But the Condition Groups tab indexes the `condition` field, which is a single whitespace-free JSON string. Splitting it on punctuation yields N parts, and the N suffixes total O(N²) characters of string data:

| values in one `$in` condition | total suffix chars |
| --- | --- |
| 1,000 | ~3.5M |
| 3,000 | ~36M |
| 5,000 | ~100M |

A condition with a few thousand IDs (especially if the IDs themselves contain underscores, doubling the part count) allocates several hundred MB just in tokenizer output, before MiniSearch even indexes it — enough to OOM the tab on page load.

## Fix

Cap suffix expansion at 16 parts per word. Above that threshold a single whitespace-free run is almost certainly serialized data (JSON, etc.) rather than an identifier, and joining suffixes is both meaningless and explosive — so index the individual parts instead.

- Words with ≤16 parts (every realistic feature key / metric name) keep the exact #6132 behavior.
- Words with >16 parts are indexed part-by-part, so single-token search inside a large condition still works (e.g. searching for a specific ID finds the group). Multi-token contiguous queries against such fields won't match, but the previous behavior there was to OOM, so nothing is lost.

This bounds the tokenizer to O(N) for all inputs and fixes the crash for any caller of `useSearch`, not just the saved-groups page.

## Testing

- Added a test that indexes a 5000-value condition JSON and verifies a single-token search still matches.
- All existing `underscore/hyphen tokenization` tests (the #6132 cases) still pass.