### PR TITLE
fix(data-pipeline): filter NULL idType rows from aggregated fact table INSERT

### DIFF
--- a/packages/back-end/src/integrations/sql/queries/insert-aggregated-fact-table-data-query.ts
+++ b/packages/back-end/src/integrations/sql/queries/insert-aggregated-fact-table-data-query.ts
@@ -129,6 +129,13 @@ export function getInsertAggregatedFactTableDataQuery(
           , ${dialect.castToDate("timestamp")} AS event_date
           ${dailyAggregations}
         FROM __factTable
+        -- NULL idType rows can never join to experiment exposures, so they
+        -- contribute nothing to any analysis read path. Dropping them here is
+        -- zero data loss and avoids a single mega-partition in the GROUP BY
+        -- when the source has high-volume unauthenticated/anonymous traffic.
+        -- __maxTimestamp intentionally still scans the unfiltered slice so the
+        -- watermark advances past these rows and they are never re-scanned.
+        WHERE ${idType} IS NOT NULL
         GROUP BY
           ${idType}
           , ${dialect.castToDate("timestamp")}

--- a/packages/back-end/test/aggregatedFactTable.test.ts
+++ b/packages/back-end/test/aggregatedFactTable.test.ts
@@ -14,6 +14,7 @@ import {
   foldAggregatedFactTableCoverage,
 } from "back-end/src/queryRunners/AggregatedFactTableQueryRunner";
 import { bigQueryDialect } from "back-end/src/integrations/dialects/bigquery";
+import { getInsertAggregatedFactTableDataQuery } from "back-end/src/integrations/sql/queries/insert-aggregated-fact-table-data-query";
 import { factMetricFactory } from "./factories/FactMetric.factory";
 import { factTableFactory } from "./factories/FactTable.factory";
 
@@ -197,6 +198,31 @@ describe("getFactTableSettingsHashForAggregatedFactTable", () => {
     expect(getFactTableSettingsHashForAggregatedFactTable(a)).not.toEqual(
       getFactTableSettingsHashForAggregatedFactTable(b),
     );
+  });
+});
+
+describe("getInsertAggregatedFactTableDataQuery", () => {
+  it("filters NULL idType rows out of the daily GROUP BY", () => {
+    const factTable = factTableFactory.build({
+      id: FT_ID,
+      userIdTypes: ["user_id", "anonymous_id"],
+      sql: "SELECT user_id, anonymous_id, timestamp, value FROM events",
+    });
+    const metric = factMetricFactory.build({
+      metricType: "mean",
+      numerator: { factTableId: FT_ID, column: "value", aggregation: "sum" },
+    });
+    const sql = getInsertAggregatedFactTableDataQuery(bigQueryDialect, {
+      factTable,
+      idType: "user_id",
+      tableFullName: "proj.ds.agg",
+      metrics: [metric],
+      windowStartDate: new Date("2024-01-01T00:00:00Z"),
+      exclusiveStart: false,
+    });
+    // The __dailyValues CTE must drop NULL-idType rows to avoid key skew;
+    // they can never join to experiment exposures.
+    expect(sql).toMatch(/WHERE\s+user_id\s+IS\s+NOT\s+NULL/i);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds `WHERE <idType> IS NOT NULL` to the `__dailyValues` GROUP BY in the aggregated-fact-table INSERT query.

## Why

The aggregated table's grain is `(idType, event_date)`. When the source fact table contains rows with a NULL idType, every one of them lands in a single GROUP BY partition per event_date. On warehouses that hash-partition the aggregation (BigQuery in particular), this produces extreme key skew — one worker gets the entire NULL slice — and on large telemetry-style fact tables the INSERT can stall or livelock on speculative re-execution.

This is a real-world pattern: high-volume telemetry/event tables often carry a meaningful share (10%+) of rows with NULL idType from headless SDK calls, unauthenticated clients, or pre-auth events.

## Why this is safe

- NULL-idType rows can **never join to experiment exposures** (the exposure table is keyed on idType), so they contribute nothing to any analysis read path that consumes the aggregated table. Dropping them is zero data loss for CUPED / covariate purposes.
- The filter is applied at the `__dailyValues` CTE, **not** at `__factTable`, so `__maxTimestamp` still scans the unfiltered slice. The watermark advances past NULL-idType events and they are never re-scanned on the next incremental run.
- No schema change, no read-path change — strictly fewer rows written.

## Testing

Added a unit test in `aggregatedFactTable.test.ts` asserting the generated SQL contains the filter for the configured idType.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QB3YeVKoESRoMBwttDT1cC