### PR TITLE
feat(front-end): add AI Visual Editor early-access callout to home page

### DIFF
--- a/packages/front-end/components/GetStarted/DocumentationSidebar.tsx
+++ b/packages/front-end/components/GetStarted/DocumentationSidebar.tsx
@@ -1,7 +1,10 @@
-import { PiSealQuestion } from "react-icons/pi";
-import { Card, Flex, Heading, Separator, Text } from "@radix-ui/themes";
+import { PiCaretRight, PiSealQuestion } from "react-icons/pi";
+import { Box, Card, Flex, Heading, Separator, Text } from "@radix-ui/themes";
+import { useFeatureIsOn } from "@growthbook/growthbook-react";
 import { useUser } from "@/services/UserContext";
+import Badge from "@/ui/Badge";
 import Button from "@/ui/Button";
+import Callout from "@/ui/Callout";
 import Link from "@/ui/Link";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import PaidFeatureBadge from "./PaidFeatureBadge";
@@ -27,6 +30,7 @@ const DocumentationSidebar = ({
     <Card style={{ padding: "var(--space-5)" }}>
       <SidebarHeading>WHAT&apos;S NEW</SidebarHeading>
       <Flex direction="column" gapY="3">
+        <AIVisualEditorCallout />
         <LinkItem href="https://www.growthbook.io/blog/growthbook-version-4-4">
           GrowthBook 4.4
         </LinkItem>
@@ -73,6 +77,59 @@ const DocumentationSidebar = ({
     </Card>
   );
 };
+
+function AIVisualEditorCallout(): React.ReactElement | null {
+  const enabled = useFeatureIsOn("ai-visual-editor-callout");
+
+  if (!enabled) {
+    return null;
+  }
+
+  return (
+    <Link
+      href="https://www.growthbook.io/events/visual-editor-early-access?utm_source=users&utm_medium=platform&utm_campaign=enablement-session-visual-editor"
+      target="_blank"
+      rel="noreferrer"
+      underline="none"
+      style={{ display: "block" }}
+    >
+      <Callout status="info" icon={null} contentsAs="div">
+        <Flex justify="start" mb="2">
+          <Badge
+            label="Early access"
+            color="violet"
+            variant="soft"
+            radius="full"
+            size="sm"
+          />
+        </Flex>
+        <Flex align="center" gap="3">
+          <Box flexGrow="1" style={{ minWidth: 0, lineHeight: 1.45 }}>
+            <Heading
+              as="h6"
+              size="2"
+              mb="1"
+              style={{ color: "var(--gray-12)", whiteSpace: "nowrap" }}
+            >
+              AI Visual Editor
+            </Heading>
+            <Text
+              as="div"
+              size="1"
+              style={{ color: "var(--gray-11)", whiteSpace: "nowrap" }}
+            >
+              Get early access June 22
+            </Text>
+          </Box>
+          <PiCaretRight
+            size={16}
+            style={{ color: "var(--gray-9)", flexShrink: 0 }}
+          />
+        </Flex>
+      </Callout>
+    </Link>
+  );
+}
 
 function SidebarHeading({ children }: { children: string }) {
   return (


### PR DESCRIPTION
## AI Visual Editor — Get Early Access

Adds a **What's New** callout on the Home page to promote the **AI Visual Editor**: build and ship experiments just by describing what you want — no code, no manual DOM editing.

Tapping it takes users straight to the [early-access signup](https://www.growthbook.io/events/visual-editor-early-access) (opens **June 22**). Gated behind the `ai-visual-editor-callout` feature flag for a controlled rollout.

### Screenshot

<img width="266" height="507" alt="image" src="https://github.com/user-attachments/assets/bcd3827d-594c-44e3-b311-865410cfc3c0" />
