### PR TITLE
fix(sdk-js): default refreshFeatures() timeout to the init timeout

### DIFF
--- a/packages/sdk-js/src/GrowthBook.ts
+++ b/packages/sdk-js/src/GrowthBook.ts
@@ -108,6 +108,7 @@ export class GrowthBook<
 
   private _autoExperimentsAllowed: boolean;
   private _destroyed?: boolean;
+  private _initTimeout?: number;
 
   constructor(options?: Options) {
     options = options || {};
@@ -270,6 +271,9 @@ export class GrowthBook<
     this._initialized = true;
     options = options || {};
 
+    // Remember the timeout so later refreshFeatures() calls can fall back to it
+    this._initTimeout = options.timeout;
+
     if (options.cacheSettings) {
       configureCache(options.cacheSettings);
     }
@@ -360,7 +364,7 @@ export class GrowthBook<
     // Trigger refresh in feature repository
     return refreshFeatures({
       instance: this,
-      timeout,
+      timeout: timeout ?? this._initTimeout,
       skipCache: skipCache || this._options.disableCache,
       allowStale,
       backgroundSync: streaming ?? this._options.backgroundSync ?? true,

--- a/packages/sdk-js/src/GrowthBookClient.ts
+++ b/packages/sdk-js/src/GrowthBookClient.ts
@@ -61,6 +61,7 @@ export class GrowthBookClient<
   private _payload: FeatureApiResponse | undefined;
   private _decryptedPayload: FeatureApiResponse | undefined;
   private _destroyed?: boolean;
+  private _initTimeout?: number;
 
   constructor(options?: ClientOptions) {
     options = options || {};
@@ -123,6 +124,9 @@ export class GrowthBookClient<
 
   public async init(options?: InitOptions): Promise<InitResponse> {
     options = options || {};
+
+    // Remember the timeout so later refreshFeatures() calls can fall back to it
+    this._initTimeout = options.timeout;
 
     if (options.cacheSettings) {
       configureCache(options.cacheSettings);
@@ -194,7 +198,7 @@ export class GrowthBookClient<
     // Trigger refresh in feature repository
     return refreshFeatures({
       instance: this,
-      timeout,
+      timeout: timeout ?? this._initTimeout,
       skipCache: skipCache || this._options.disableCache,
       allowStale,
       backgroundSync: streaming ?? true,

--- a/packages/sdk-js/test/feature-repo.test.ts
+++ b/packages/sdk-js/test/feature-repo.test.ts
@@ -966,6 +966,46 @@ describe("feature-repo", () => {
     cleanup();
   });
 
+  it("defaults refreshFeatures timeout to the one passed in init", async () => {
+    const payload = {
+      features: {
+        foo: {
+          defaultValue: "api",
+        },
+      },
+    };
+    // API always takes longer than the init timeout
+    const [f, cleanup] = mockApi(payload, false, 100);
+
+    const growthbook = new GrowthBook({
+      apiHost: "https://fakeapi.sample.io",
+      clientKey: "qwerty1234",
+    });
+
+    // Init times out (20ms) before the 100ms network response
+    const res = await growthbook.init({ timeout: 20 });
+    expect(res.source).toEqual("timeout");
+    expect(growthbook.getFeatures()).toEqual({});
+    expect(f.mock.calls.length).toEqual(1);
+
+    // Make the cached payload stale so refreshFeatures hits the network again
+    await clearCache();
+
+    // refreshFeatures with no explicit timeout should fall back to the
+    // init timeout (20ms) and resolve before the 100ms network response
+    const start = Date.now();
+    await growthbook.refreshFeatures();
+    const elapsed = Date.now() - start;
+
+    // Without the fallback, timeout is undefined and this would block for the
+    // full ~100ms network call instead of timing out at ~20ms
+    expect(elapsed).toBeLessThan(80);
+    expect(f.mock.calls.length).toEqual(2);
+
+    growthbook.destroy();
+    cleanup();
+  });
+
   it("handles errors with init", async () => {
     const [f, cleanup] = mockApi(null);
 


### PR DESCRIPTION
### Features and Changes

The `timeout` passed to `init()` is forwarded to the initial refresh call, but it was never stored on the instance. Later calls to `refreshFeatures()` made without an explicit `timeout` ended up passing `undefined`, so they silently ignored the timeout configured at init time.

This is inconsistent with the other refresh settings: `disableCache` and `backgroundSync` already fall back to values stored in the SDK options, but `timeout` did not.

This PR persists the init timeout on the instance and falls back to it in the private `_refresh` method, so `refreshFeatures()` honors the init timeout when no explicit one is given. An explicit timeout passed to `refreshFeatures()` still takes precedence. The same change is applied to both `GrowthBook` and `GrowthBookClient`.

- Fixes #5897

### Dependencies

None.

### Testing

Added a regression test in `packages/sdk-js/test/feature-repo.test.ts` (`defaults refreshFeatures timeout to the one passed in init`):

- `init({ timeout: 20 })` against an API that responds in ~100ms, so init times out as expected.
- After clearing the cache, `refreshFeatures()` is called with no explicit timeout.
- It now resolves in well under the ~100ms network time (asserted `< 80ms`), confirming it fell back to the 20ms init timeout. Before the fix this test fails because the refresh blocks for the full network call (~101ms).

Verified locally for the `sdk-js` package:

- `pnpm --filter @growthbook/growthbook test` — 677 passed (15 suites)
- `pnpm --filter @growthbook/growthbook type-check` — clean
- `eslint` + `prettier --check` on the changed files — clean

### Screenshots

N/A (no UI changes).
