### PR TITLE
fix(snapshot): prevent query-DAG persistence race causing phantom 'queued' queries

### DIFF
--- a/packages/back-end/src/jobs/expireOldQueries.ts
+++ b/packages/back-end/src/jobs/expireOldQueries.ts
@@ -22,7 +22,12 @@ import {
 import {
   getQueryStatusesByIds,
   getStaleQueries,
+  markPendingQueriesAsFailed,
 } from "back-end/src/models/QueryModel";
+import {
+  getExperimentById,
+  updateExperiment,
+} from "back-end/src/models/ExperimentModel";
 import {
   findReportsByQueryId,
   updateReport,
@@ -251,7 +256,7 @@ async function reapStalledSnapshots() {
     });
 
     const error = orphanedDag
-      ? "Snapshot stalled: queries were never started. This can happen when the server restarts mid-refresh. Please try updating results again."
+      ? "Snapshot stalled: queries were never started. This can happen when the server restarts mid-refresh. A retry has been scheduled."
       : "Snapshot stalled: queries finished but results were never finalized. This usually means the analysis step failed (check server logs) or the process was restarted.";
 
     const context = await getContextForAgendaJobByOrgId(snapshot.organization);
@@ -266,6 +271,53 @@ async function reapStalledSnapshots() {
         ? `Reaped orphaned snapshot ${snapshot.id} (experiment ${snapshot.experiment}): ${queued.length} of ${queryIds.length} queries stuck in "queued" with nothing running`
         : `Reaped stalled snapshot ${snapshot.id} (experiment ${snapshot.experiment}): all ${queryIds.length} queries terminal but status still running`,
     );
+
+    if (orphanedDag) {
+      // Fail the underlying queued Query docs so they don't linger forever
+      // (queued queries have no heartbeat, so getStaleQueries() will never
+      // touch them) and so any other runner reusing them via the query cache
+      // sees a terminal state.
+      await markPendingQueriesAsFailed(
+        context,
+        queued.map((q) => q.id),
+        "Query was never started: the snapshot driving it was reaped as stalled.",
+      ).catch((e) =>
+        logger.warn(e, "Failed to mark orphaned queued queries as failed"),
+      );
+
+      // Defense-in-depth retry: an orphaned DAG is almost always a lost
+      // in-memory driver (process restart / event-loop kill), not a
+      // deterministic data problem, so a fresh snapshot should succeed.
+      // Pull nextSnapshotAttempt forward so the 10-minute
+      // queueExperimentUpdates poll picks it up on its next pass instead of
+      // waiting up to EXPERIMENT_REFRESH_FREQUENCY hours. Re-enable
+      // autoSnapshots in case the original failing run already flipped it
+      // off. Reports reuse the snapshot model but have no schedule to bump.
+      if (snapshot.experiment && !snapshot.report) {
+        try {
+          const experiment = await getExperimentById(
+            context,
+            snapshot.experiment,
+          );
+          if (experiment) {
+            await updateExperiment({
+              context,
+              experiment,
+              changes: {
+                nextSnapshotAttempt: new Date(),
+                autoSnapshots: true,
+              },
+              bypassWebhooks: true,
+            });
+          }
+        } catch (e) {
+          logger.warn(
+            e,
+            "Failed to schedule retry snapshot after orphaned-DAG reap",
+          );
+        }
+      }
+    }
 
     await context.models.incrementalRefresh
       .releaseLock(snapshot.experiment, snapshot.id)

--- a/packages/back-end/src/jobs/expireOldQueries.ts
+++ b/packages/back-end/src/jobs/expireOldQueries.ts
@@ -226,15 +226,8 @@ async function reapStalledSnapshots() {
       (q) => q.status === "succeeded" || q.status === "failed",
     );
 
-    // An orphaned DAG: nothing is actually executing, but one or more
-    // queries are still "queued" and will never be started. This happens
-    // when the in-memory timer that drives the DAG forward was lost —
-    // e.g. the process restarted mid-run, or a fast first query finished
-    // and fired its follow-up timer before the full query DAG was
-    // persisted (the Full Refresh race). Queued queries have no heartbeat
-    // and are never "running", so neither getStaleQueries() nor the
-    // all-terminal reap path above will ever touch them. Without this
-    // branch the snapshot would show "Running" forever.
+    // Queued queries have no heartbeat. If the in-memory runner disappears
+    // before starting them, the normal stale-query path will never see them.
     const orphanedDag = running.length === 0 && queued.length > 0;
 
     if (!allTerminal && !orphanedDag) continue;
@@ -243,9 +236,7 @@ async function reapStalledSnapshots() {
       0,
       ...statuses.map((s) => s.finishedAt?.getTime() ?? 0),
     );
-    // For an orphaned DAG nothing may have finished yet (latestFinishedAt
-    // stays 0), in which case fall back to the snapshot's age — the
-    // STALLED_SNAPSHOT_THRESHOLD_MS check above has already guaranteed it.
+    // Orphaned DAGs may have no finished queries, so fall back to snapshot age.
     const lastActivityAt =
       latestFinishedAt > 0 ? latestFinishedAt : snapshot.dateCreated.getTime();
     if (Date.now() - lastActivityAt < STALLED_FINALIZE_GRACE_MS) continue;
@@ -255,8 +246,16 @@ async function reapStalledSnapshots() {
       q.status = statusById.get(q.query) ?? q.status;
     });
 
+    const shouldScheduleSnapshotRetry =
+      orphanedDag &&
+      !snapshot.report &&
+      snapshot.type === "standard" &&
+      snapshot.triggeredBy === "schedule";
+
     const error = orphanedDag
-      ? "Snapshot stalled: queries were never started. This can happen when the server restarts mid-refresh. A retry has been scheduled."
+      ? shouldScheduleSnapshotRetry
+        ? "Snapshot stalled: queries were never started. This can happen when the server restarts mid-refresh. A retry has been scheduled."
+        : "Snapshot stalled: queries were never started. This can happen when the server restarts mid-refresh. Please try updating results again."
       : "Snapshot stalled: queries finished but results were never finalized. This usually means the analysis step failed (check server logs) or the process was restarted.";
 
     const context = await getContextForAgendaJobByOrgId(snapshot.organization);
@@ -273,10 +272,6 @@ async function reapStalledSnapshots() {
     );
 
     if (orphanedDag) {
-      // Fail the underlying queued Query docs so they don't linger forever
-      // (queued queries have no heartbeat, so getStaleQueries() will never
-      // touch them) and so any other runner reusing them via the query cache
-      // sees a terminal state.
       await markPendingQueriesAsFailed(
         context,
         queued.map((q) => q.id),
@@ -285,15 +280,9 @@ async function reapStalledSnapshots() {
         logger.warn(e, "Failed to mark orphaned queued queries as failed"),
       );
 
-      // Defense-in-depth retry: an orphaned DAG is almost always a lost
-      // in-memory driver (process restart / event-loop kill), not a
-      // deterministic data problem, so a fresh snapshot should succeed.
-      // Pull nextSnapshotAttempt forward so the 10-minute
-      // queueExperimentUpdates poll picks it up on its next pass instead of
-      // waiting up to EXPERIMENT_REFRESH_FREQUENCY hours. Re-enable
-      // autoSnapshots in case the original failing run already flipped it
-      // off. Reports reuse the snapshot model but have no schedule to bump.
-      if (snapshot.experiment && !snapshot.report) {
+      // Only scheduled standard snapshots can be retried by bumping the
+      // generic experiment refresh schedule.
+      if (shouldScheduleSnapshotRetry) {
         try {
           const experiment = await getExperimentById(
             context,

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -153,11 +153,7 @@ export abstract class QueryRunner<
       onFailure: () => void;
     };
   } = {};
-  // True once startAnalysis() has written the full `queries` array to the
-  // model document. Gates onQueryFinish(): a refresh issued before this point
-  // would re-read a model with no (or partial) queries and accomplish nothing
-  // — and worse, can swallow the post-persist refresh via the `this.timer`
-  // debounce. See onQueryFinish() for the full race description.
+  // Prevent early query completions from refreshing against a partial DAG.
   private dagPersisted = false;
   private useCache: boolean;
   private pendingTimers: Record<string, NodeJS.Timeout> = {};
@@ -240,29 +236,9 @@ export abstract class QueryRunner<
   }
 
   async onQueryFinish() {
-    // Queries with no dependencies are dispatched fire-and-forget inside
-    // startQueries() (see startQuery's readyToRun branch), so a fast one
-    // (e.g. a DROP TABLE during an Incremental Pipeline full refresh) can
-    // finish — and call here — while startQueries() is still generating SQL
-    // for the remaining queries and before startAnalysis() has persisted the
-    // full `queries` array via updateModel().
-    //
-    // If we armed `this.timer` now, the callback's getLatestModel() would
-    // read a model with an empty `queries` array and do nothing useful. The
-    // previous mitigation (#5885) tolerated that and relied on a second
-    // post-persist onQueryFinish() in startAnalysis() to re-drive — but the
-    // `if (!this.timer)` debounce below means that post-persist call is a
-    // no-op whenever an early-finish timer is still pending, and the pending
-    // timer's getLatestModel() read can race the updateModel() write (no
-    // read-your-writes guarantee across pooled Mongo connections / replica
-    // reads). When that stale read lands *and* it was the last query to
-    // finish before persist, the refresh chain dies and every dependent
-    // query stays "queued" forever.
-    //
-    // Gating on dagPersisted removes the race entirely: early finishes are
-    // recorded as no-ops, `this.timer` stays null, and the post-persist
-    // onQueryFinish() in startAnalysis() is guaranteed to arm a timer whose
-    // getLatestModel() observes the committed DAG.
+    // Dependency-free queries can finish while startAnalysis() is still
+    // persisting the query DAG. Wait until the DAG is durable so the debounced
+    // refresh cannot read an empty query list and swallow the real refresh.
     if (!this.dagPersisted) {
       logger.debug(
         "Query finished for " +
@@ -412,21 +388,13 @@ export abstract class QueryRunner<
       error: error,
     });
     this.model = newModel;
-    // The full `queries` array is now durable. Unblocks onQueryFinish() —
-    // any query that finished while we were generating/persisting the DAG
-    // had its onQueryFinish() call short-circuited; the call below picks
-    // those up. Because every earlier call was gated, `this.timer` is null
-    // here, so the call below is guaranteed to actually arm the timer (the
-    // debounce can no longer swallow it).
     this.dagPersisted = true;
 
     if (error || result) {
       this.setStatus("finished", error, result);
     } else {
       this.setStatus("running");
-      // Drive the first refresh now that the DAG is persisted. This is the
-      // sole entry point for the refresh chain; see the dagPersisted gate in
-      // onQueryFinish() for why earlier calls were deferred to here.
+      // Pick up any query completions that happened before the DAG write.
       this.onQueryFinish();
     }
 
@@ -544,11 +512,7 @@ export abstract class QueryRunner<
           logger.debug(
             `${query.id}: "Run at end query" waiting for other queries to finish...`,
           );
-          // `continue`, not `return`: a runAtEnd query iterated before a
-          // ready non-runAtEnd queued query must not stop the whole pass —
-          // otherwise the two block on each other forever and the DAG stalls
-          // with nothing running. Map iteration order is insertion order,
-          // which is Mongo fetch order, so this is not hypothetical.
+          // Keep scanning. A later non-runAtEnd query may be ready.
           continue;
         }
       }
@@ -586,14 +550,6 @@ export abstract class QueryRunner<
       )
     ) {
       if (this.status !== "finished") {
-        // Being asked to refresh a non-terminal runner whose persisted model
-        // has no active queries is unexpected. The original cause — a fast
-        // query finishing before startAnalysis() persisted the DAG — is now
-        // prevented by the dagPersisted gate in onQueryFinish(), so this path
-        // should only be reachable from external callers (e.g. a controller
-        // polling refreshQueryStatuses() on a freshly-loaded model) or if a
-        // concurrent write truncated the queries array. Keep the warn so any
-        // recurrence is visible.
         logger.warn(
           `No running or queued queries for ${this.model.id} but runner status is "${this.status}". ` +
             `The persisted query DAG is empty or fully terminal; nothing to refresh.`,

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -153,6 +153,12 @@ export abstract class QueryRunner<
       onFailure: () => void;
     };
   } = {};
+  // True once startAnalysis() has written the full `queries` array to the
+  // model document. Gates onQueryFinish(): a refresh issued before this point
+  // would re-read a model with no (or partial) queries and accomplish nothing
+  // — and worse, can swallow the post-persist refresh via the `this.timer`
+  // debounce. See onQueryFinish() for the full race description.
+  private dagPersisted = false;
   private useCache: boolean;
   private pendingTimers: Record<string, NodeJS.Timeout> = {};
   private lockHeartbeatTimer: null | NodeJS.Timeout = null;
@@ -234,6 +240,37 @@ export abstract class QueryRunner<
   }
 
   async onQueryFinish() {
+    // Queries with no dependencies are dispatched fire-and-forget inside
+    // startQueries() (see startQuery's readyToRun branch), so a fast one
+    // (e.g. a DROP TABLE during an Incremental Pipeline full refresh) can
+    // finish — and call here — while startQueries() is still generating SQL
+    // for the remaining queries and before startAnalysis() has persisted the
+    // full `queries` array via updateModel().
+    //
+    // If we armed `this.timer` now, the callback's getLatestModel() would
+    // read a model with an empty `queries` array and do nothing useful. The
+    // previous mitigation (#5885) tolerated that and relied on a second
+    // post-persist onQueryFinish() in startAnalysis() to re-drive — but the
+    // `if (!this.timer)` debounce below means that post-persist call is a
+    // no-op whenever an early-finish timer is still pending, and the pending
+    // timer's getLatestModel() read can race the updateModel() write (no
+    // read-your-writes guarantee across pooled Mongo connections / replica
+    // reads). When that stale read lands *and* it was the last query to
+    // finish before persist, the refresh chain dies and every dependent
+    // query stays "queued" forever.
+    //
+    // Gating on dagPersisted removes the race entirely: early finishes are
+    // recorded as no-ops, `this.timer` stays null, and the post-persist
+    // onQueryFinish() in startAnalysis() is guaranteed to arm a timer whose
+    // getLatestModel() observes the committed DAG.
+    if (!this.dagPersisted) {
+      logger.debug(
+        "Query finished for " +
+          this.model.id +
+          " runner before DAG was persisted; deferring refresh",
+      );
+      return;
+    }
     if (!this.timer) {
       logger.debug(
         "Query finished for " +
@@ -375,28 +412,21 @@ export abstract class QueryRunner<
       error: error,
     });
     this.model = newModel;
+    // The full `queries` array is now durable. Unblocks onQueryFinish() —
+    // any query that finished while we were generating/persisting the DAG
+    // had its onQueryFinish() call short-circuited; the call below picks
+    // those up. Because every earlier call was gated, `this.timer` is null
+    // here, so the call below is guaranteed to actually arm the timer (the
+    // debounce can no longer swallow it).
+    this.dagPersisted = true;
 
     if (error || result) {
       this.setStatus("finished", error, result);
     } else {
       this.setStatus("running");
-      // Schedule one more pass through refreshQueryStatuses/startReadyQueries
-      // now that the full `queries` array has been persisted to the model.
-      //
-      // This closes a race: queries with no dependencies are executed
-      // fire-and-forget inside startQueries() (see startQuery's readyToRun
-      // branch). If one of them is very fast (e.g. a DROP TABLE during a
-      // Full Refresh), it can finish — and its onQueryFinish 1-second timer
-      // can fire — while startQueries() is still generating SQL for the
-      // remaining queries and before updateModel() above has written them.
-      // That early timer reloads the model, sees no running/queued queries,
-      // and gives up. Once startQueries() finally returns, nothing re-arms
-      // the timer, so every other query in the DAG stays "queued" forever.
-      //
-      // Calling onQueryFinish() here guarantees at least one refresh happens
-      // after the DAG is visible in the persisted model. If the timer from
-      // the early-finishing query is still pending this is a no-op; if it
-      // already fired and found nothing, this re-arms it with the real DAG.
+      // Drive the first refresh now that the DAG is persisted. This is the
+      // sole entry point for the refresh chain; see the dagPersisted gate in
+      // onQueryFinish() for why earlier calls were deferred to here.
       this.onQueryFinish();
     }
 
@@ -514,7 +544,12 @@ export abstract class QueryRunner<
           logger.debug(
             `${query.id}: "Run at end query" waiting for other queries to finish...`,
           );
-          return;
+          // `continue`, not `return`: a runAtEnd query iterated before a
+          // ready non-runAtEnd queued query must not stop the whole pass —
+          // otherwise the two block on each other forever and the DAG stalls
+          // with nothing running. Map iteration order is insertion order,
+          // which is Mongo fetch order, so this is not hypothetical.
+          continue;
         }
       }
 
@@ -552,15 +587,16 @@ export abstract class QueryRunner<
     ) {
       if (this.status !== "finished") {
         // Being asked to refresh a non-terminal runner whose persisted model
-        // has no active queries is unexpected. It most likely means a query
-        // finished (and its onQueryFinish timer fired) before startAnalysis()
-        // persisted the full `queries` array. Historically this was only a
-        // debug log, which made the resulting "snapshot stuck running forever"
-        // failure mode invisible. Log at warn so it surfaces; the post-persist
-        // onQueryFinish() in startAnalysis() will re-drive the DAG.
+        // has no active queries is unexpected. The original cause — a fast
+        // query finishing before startAnalysis() persisted the DAG — is now
+        // prevented by the dagPersisted gate in onQueryFinish(), so this path
+        // should only be reachable from external callers (e.g. a controller
+        // polling refreshQueryStatuses() on a freshly-loaded model) or if a
+        // concurrent write truncated the queries array. Keep the warn so any
+        // recurrence is visible.
         logger.warn(
           `No running or queued queries for ${this.model.id} but runner status is "${this.status}". ` +
-            `Likely a query finished before the full query DAG was persisted; a follow-up refresh is scheduled.`,
+            `The persisted query DAG is empty or fully terminal; nothing to refresh.`,
         );
       } else {
         logger.debug(

--- a/packages/back-end/test/jobs/expireOldQueries.test.ts
+++ b/packages/back-end/test/jobs/expireOldQueries.test.ts
@@ -1,0 +1,209 @@
+import type Agenda from "agenda";
+import type {
+  SnapshotTriggeredBy,
+  SnapshotType,
+} from "shared/types/experiment-snapshot";
+import expireOldQueries from "back-end/src/jobs/expireOldQueries";
+import {
+  dangerousFindStalledRunningSnapshotsFromAllOrgs,
+  errorSnapshotIfStillRunning,
+} from "back-end/src/models/ExperimentSnapshotModel";
+import {
+  getQueryStatusesByIds,
+  getStaleQueries,
+  markPendingQueriesAsFailed,
+} from "back-end/src/models/QueryModel";
+import {
+  getExperimentById,
+  updateExperiment,
+} from "back-end/src/models/ExperimentModel";
+import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizations";
+
+jest.mock("back-end/src/models/ExperimentSnapshotModel", () => ({
+  dangerousFindStalledRunningSnapshotsFromAllOrgs: jest.fn(),
+  errorSnapshotIfStillRunning: jest.fn(),
+  findRunningSnapshotsByQueryId: jest.fn().mockResolvedValue([]),
+  updateSnapshot: jest.fn(),
+}));
+
+jest.mock("back-end/src/models/QueryModel", () => ({
+  getQueryStatusesByIds: jest.fn(),
+  getStaleQueries: jest.fn(),
+  markPendingQueriesAsFailed: jest.fn(),
+}));
+
+jest.mock("back-end/src/models/ExperimentModel", () => ({
+  getExperimentById: jest.fn(),
+  updateExperiment: jest.fn(),
+}));
+
+jest.mock("back-end/src/models/MetricModel", () => ({
+  findRunningMetricsByQueryId: jest.fn().mockResolvedValue([]),
+  updateMetricQueriesAndStatus: jest.fn(),
+}));
+
+jest.mock("back-end/src/models/PastExperimentsModel", () => ({
+  findRunningPastExperimentsByQueryId: jest.fn().mockResolvedValue([]),
+  updatePastExperiments: jest.fn(),
+}));
+
+jest.mock("back-end/src/models/ReportModel", () => ({
+  findReportsByQueryId: jest.fn().mockResolvedValue([]),
+  updateReport: jest.fn(),
+}));
+
+jest.mock("back-end/src/services/organizations", () => ({
+  getContextForAgendaJobByOrgId: jest.fn(),
+}));
+
+jest.mock("back-end/src/models/MetricAnalysisModel", () => ({
+  MetricAnalysisModel: {
+    findByQueryIds: jest.fn().mockResolvedValue([]),
+  },
+}));
+
+jest.mock("back-end/src/util/mongo.util", () => ({
+  getCollection: jest.fn(() => {
+    const cursor = {
+      limit: jest.fn().mockReturnThis(),
+      toArray: jest.fn().mockResolvedValue([]),
+    };
+    return {
+      find: jest.fn().mockReturnValue(cursor),
+      updateOne: jest.fn().mockResolvedValue({ modifiedCount: 0 }),
+    };
+  }),
+}));
+
+jest.mock("back-end/src/util/logger", () => ({
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe("expireOldQueries stalled snapshot reaper", () => {
+  const releaseLock = jest.fn().mockResolvedValue(undefined);
+  const context = {
+    org: { id: "org_1" },
+    models: {
+      incrementalRefresh: { releaseLock },
+      metricAnalysis: { update: jest.fn() },
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getStaleQueries as jest.Mock).mockResolvedValue([]);
+    (
+      dangerousFindStalledRunningSnapshotsFromAllOrgs as jest.Mock
+    ).mockResolvedValue([]);
+    (getQueryStatusesByIds as jest.Mock).mockResolvedValue([]);
+    (errorSnapshotIfStillRunning as jest.Mock).mockResolvedValue(true);
+    (markPendingQueriesAsFailed as jest.Mock).mockResolvedValue(1);
+    (getExperimentById as jest.Mock).mockResolvedValue({
+      id: "exp_1",
+      organization: "org_1",
+    });
+    (updateExperiment as jest.Mock).mockResolvedValue({});
+    (getContextForAgendaJobByOrgId as jest.Mock).mockResolvedValue(context);
+  });
+
+  async function runJob() {
+    const definitions: Record<string, () => Promise<void>> = {};
+    const agenda = {
+      define: jest.fn((name: string, fn: () => Promise<void>) => {
+        definitions[name] = fn;
+      }),
+      create: jest.fn(() => ({
+        unique: jest.fn(),
+        repeatEvery: jest.fn(),
+        save: jest.fn().mockResolvedValue(undefined),
+      })),
+    };
+
+    await expireOldQueries(agenda as unknown as Agenda);
+    await definitions.expireOldQueries();
+  }
+
+  function mockOrphanedSnapshot(snapshot: {
+    type?: SnapshotType;
+    triggeredBy?: SnapshotTriggeredBy;
+    report?: string;
+  }) {
+    const dateCreated = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    (
+      dangerousFindStalledRunningSnapshotsFromAllOrgs as jest.Mock
+    ).mockResolvedValue([
+      {
+        id: "snp_1",
+        organization: "org_1",
+        experiment: "exp_1",
+        phase: 0,
+        dimension: null,
+        type: snapshot.type,
+        triggeredBy: snapshot.triggeredBy,
+        report: snapshot.report,
+        dateCreated,
+        runStarted: dateCreated,
+        status: "running",
+        settings: {},
+        queries: [{ name: "main", query: "qry_1", status: "queued" }],
+        unknownVariations: [],
+        multipleExposures: 0,
+        analyses: [],
+      },
+    ]);
+    (getQueryStatusesByIds as jest.Mock).mockResolvedValue([
+      { id: "qry_1", status: "queued" },
+    ]);
+  }
+
+  it("schedules a retry for orphaned scheduled standard snapshots", async () => {
+    mockOrphanedSnapshot({ type: "standard", triggeredBy: "schedule" });
+
+    await runJob();
+
+    expect(updateExperiment).toHaveBeenCalledWith({
+      context,
+      experiment: expect.objectContaining({ id: "exp_1" }),
+      changes: {
+        nextSnapshotAttempt: expect.any(Date),
+        autoSnapshots: true,
+      },
+      bypassWebhooks: true,
+    });
+    expect(errorSnapshotIfStillRunning).toHaveBeenCalledWith(
+      context,
+      "snp_1",
+      expect.objectContaining({
+        error: expect.stringContaining("A retry has been scheduled."),
+      }),
+    );
+  });
+
+  it("does not enable auto-refresh for orphaned manual snapshots", async () => {
+    mockOrphanedSnapshot({ type: "standard", triggeredBy: "manual" });
+
+    await runJob();
+
+    expect(updateExperiment).not.toHaveBeenCalled();
+    expect(errorSnapshotIfStillRunning).toHaveBeenCalledWith(
+      context,
+      "snp_1",
+      expect.objectContaining({
+        error: expect.stringContaining("Please try updating results again."),
+      }),
+    );
+  });
+
+  it("does not schedule the generic standard retry for exploratory snapshots", async () => {
+    mockOrphanedSnapshot({ type: "exploratory", triggeredBy: "schedule" });
+
+    await runJob();
+
+    expect(updateExperiment).not.toHaveBeenCalled();
+  });
+});

--- a/packages/back-end/test/queryRunners/QueryRunner.test.ts
+++ b/packages/back-end/test/queryRunners/QueryRunner.test.ts
@@ -245,10 +245,6 @@ describe("QueryRunner", () => {
     });
 
     it("processes ready non-runAtEnd queries even when a runAtEnd query is iterated first", async () => {
-      // Regression: the runAtEnd "still pending, wait" branch used to `return`
-      // out of startReadyQueries entirely. If Map iteration order put a
-      // runAtEnd query before a ready non-runAtEnd queued query, the two
-      // would deadlock — runAtEnd waits for B, but B was never reached.
       const queryEnd = createMockQuery("qry_end", "queued", []);
       queryEnd.runAtEnd = true;
       const queryB = createMockQuery("qry_B", "queued", []);
@@ -273,7 +269,6 @@ describe("QueryRunner", () => {
       runner.runCallbacks["qry_end"] = cb;
       runner.runCallbacks["qry_B"] = cb;
 
-      // Iteration order: runAtEnd query first, ready non-runAtEnd second.
       const queryMap: QueryMap = new Map([
         ["end", queryEnd],
         ["B", queryB],
@@ -281,12 +276,10 @@ describe("QueryRunner", () => {
 
       await runner.startReadyQueries(queryMap);
 
-      // runAtEnd query must NOT execute (B is still queued/non-terminal)
       expect(runner.executeQuerySpy).not.toHaveBeenCalledWith(
         expect.objectContaining({ id: "qry_end" }),
         expect.anything(),
       );
-      // B MUST execute despite being iterated after the runAtEnd query.
       expect(runner.executeQuerySpy).toHaveBeenCalledWith(
         expect.objectContaining({ id: "qry_B" }),
         expect.anything(),
@@ -544,13 +537,6 @@ describe("QueryRunner", () => {
       jest.clearAllMocks();
     });
 
-    // Simulates the Full Refresh race: a dependency-free query (e.g. a DROP
-    // TABLE) is executed fire-and-forget inside startQueries() and can finish
-    // — and fire its onQueryFinish follow-up timer — before startAnalysis()
-    // has persisted the full `queries` array to the model. The early timer
-    // reloads a model with no queued/running queries and gives up. Without a
-    // post-persist re-arm, nothing ever drives the rest of the DAG and every
-    // downstream query stays "queued" forever.
     class RaceTestQueryRunner extends QueryRunner<
       InterfaceWithQueries,
       { pointers: Queries },
@@ -611,16 +597,8 @@ describe("QueryRunner", () => {
           mockIntegration,
         );
 
-        // Simulate a fast dependency-free query finishing while
-        // startQueries() is still running (i.e. before startAnalysis() has
-        // called updateModel()). This must NOT arm the refresh timer — if it
-        // did, that timer's getLatestModel() could read the pre-persist
-        // model and the post-persist onQueryFinish() in startAnalysis()
-        // would be swallowed by the debounce.
         await runner.onQueryFinish();
-        // @ts-expect-error reading private prop for assertion
-        expect(runner.timer).toBeNull();
-        // The early call was recorded against an empty persisted DAG.
+        expect(jest.getTimerCount()).toBe(0);
         expect(runner.onQueryFinishSpy).toHaveBeenLastCalledWith(0);
 
         const pointers: Queries = [
@@ -630,19 +608,13 @@ describe("QueryRunner", () => {
 
         await runner.startAnalysis({ pointers });
 
-        // updateModel must have been called with the full DAG...
         expect(runner.updateModelSpy).toHaveBeenCalledWith(
           expect.objectContaining({ status: "running", queries: pointers }),
         );
-        // ...and onQueryFinish must have been called AFTER that persist, i.e.
-        // with the full DAG visible in the "database". Because the early call
-        // above was gated, the post-persist call is guaranteed to actually
-        // arm the refresh timer.
         expect(runner.onQueryFinishSpy).toHaveBeenLastCalledWith(
           pointers.length,
         );
-        // @ts-expect-error reading private prop for assertion
-        expect(runner.timer).not.toBeNull();
+        expect(jest.getTimerCount()).toBeGreaterThan(0);
       } finally {
         jest.clearAllTimers();
         jest.useRealTimers();

--- a/packages/back-end/test/queryRunners/QueryRunner.test.ts
+++ b/packages/back-end/test/queryRunners/QueryRunner.test.ts
@@ -244,6 +244,55 @@ describe("QueryRunner", () => {
       clearTimeout(timerA);
     });
 
+    it("processes ready non-runAtEnd queries even when a runAtEnd query is iterated first", async () => {
+      // Regression: the runAtEnd "still pending, wait" branch used to `return`
+      // out of startReadyQueries entirely. If Map iteration order put a
+      // runAtEnd query before a ready non-runAtEnd queued query, the two
+      // would deadlock — runAtEnd waits for B, but B was never reached.
+      const queryEnd = createMockQuery("qry_end", "queued", []);
+      queryEnd.runAtEnd = true;
+      const queryB = createMockQuery("qry_B", "queued", []);
+
+      const model: InterfaceWithQueries = {
+        id: "test-model",
+        organization: "test-org",
+        queries: [
+          { name: "end", query: "qry_end", status: "queued" },
+          { name: "B", query: "qry_B", status: "queued" },
+        ],
+        runStarted: new Date(),
+      };
+
+      const runner = new TestQueryRunner(mockContext, model, mockIntegration);
+
+      const cb = {
+        run: jest.fn().mockResolvedValue({ rows: [], statistics: {} }),
+        process: jest.fn((rows) => rows),
+        onFailure: jest.fn(),
+      };
+      runner.runCallbacks["qry_end"] = cb;
+      runner.runCallbacks["qry_B"] = cb;
+
+      // Iteration order: runAtEnd query first, ready non-runAtEnd second.
+      const queryMap: QueryMap = new Map([
+        ["end", queryEnd],
+        ["B", queryB],
+      ]);
+
+      await runner.startReadyQueries(queryMap);
+
+      // runAtEnd query must NOT execute (B is still queued/non-terminal)
+      expect(runner.executeQuerySpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ id: "qry_end" }),
+        expect.anything(),
+      );
+      // B MUST execute despite being iterated after the runAtEnd query.
+      expect(runner.executeQuerySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "qry_B" }),
+        expect.anything(),
+      );
+    });
+
     it("should not execute queries with pending dependencies", async () => {
       const depPending = createMockQuery("qry_dep_pending", "running", []);
       const queryA = createMockQuery("qry_A", "queued", ["qry_dep_pending"]);
@@ -547,7 +596,7 @@ describe("QueryRunner", () => {
       }
     }
 
-    it("re-arms the follow-up timer after persisting the query DAG", async () => {
+    it("gates onQueryFinish until the query DAG is persisted, then drives once", async () => {
       jest.useFakeTimers();
       try {
         const model: InterfaceWithQueries = {
@@ -562,6 +611,18 @@ describe("QueryRunner", () => {
           mockIntegration,
         );
 
+        // Simulate a fast dependency-free query finishing while
+        // startQueries() is still running (i.e. before startAnalysis() has
+        // called updateModel()). This must NOT arm the refresh timer — if it
+        // did, that timer's getLatestModel() could read the pre-persist
+        // model and the post-persist onQueryFinish() in startAnalysis()
+        // would be swallowed by the debounce.
+        await runner.onQueryFinish();
+        // @ts-expect-error reading private prop for assertion
+        expect(runner.timer).toBeNull();
+        // The early call was recorded against an empty persisted DAG.
+        expect(runner.onQueryFinishSpy).toHaveBeenLastCalledWith(0);
+
         const pointers: Queries = [
           { name: "drop_old", query: "qry_drop", status: "running" },
           { name: "create", query: "qry_create", status: "queued" },
@@ -574,10 +635,14 @@ describe("QueryRunner", () => {
           expect.objectContaining({ status: "running", queries: pointers }),
         );
         // ...and onQueryFinish must have been called AFTER that persist, i.e.
-        // with the full DAG visible in the "database". This is what re-drives
-        // the DAG if a fast dependency-free query already finished and its
-        // follow-up timer already fired before the DAG was persisted.
-        expect(runner.onQueryFinishSpy).toHaveBeenCalledWith(pointers.length);
+        // with the full DAG visible in the "database". Because the early call
+        // above was gated, the post-persist call is guaranteed to actually
+        // arm the refresh timer.
+        expect(runner.onQueryFinishSpy).toHaveBeenLastCalledWith(
+          pointers.length,
+        );
+        // @ts-expect-error reading private prop for assertion
+        expect(runner.timer).not.toBeNull();
       } finally {
         jest.clearAllTimers();
         jest.useRealTimers();


### PR DESCRIPTION
## Problem

Snapshots can stick at "running" forever with a handful of queries showing "queued" but nothing actually executing. The orphan reaper (added in #5885) eventually marks them errored after an hour, but does not retry.

Observed on a self-hosted deployment (Agenda split into a dedicated jobrunner pod):

```
23:20:38 backend  WARN: No running or queued queries for snp_2Cc9... but runner status is "pending".
                        Likely a query finished before the full query DAG was persisted; a follow-up refresh is scheduled.
00:20:37 jobrunner INFO: Reaped orphaned snapshot snp_2Cc9... 6 of 122 queries stuck in "queued" with nothing running
```

Hit 6 experiments in one night.

## Root cause

`startQuery()` dispatches dependency-free queries fire-and-forget *before* `startAnalysis()` has written the full `queries` array to the snapshot doc (`QueryRunner.ts` `startAnalysis()` → `updateModel()`). A fast query (e.g. an Incremental Pipeline `DROP TABLE`) can finish — and call `onQueryFinish()` — while `startQueries()` is still generating SQL for the remaining 100+ queries.

#5885 added a post-persist `onQueryFinish()` in `startAnalysis()` to re-drive the DAG after the write commits. But `onQueryFinish()` is debounced (`if (!this.timer)`), so when an early-finish timer is still pending the post-persist call is a **no-op**. The pending timer's `getLatestModel()` then races the `updateModel()` write — there is no read-your-writes guarantee across pooled Mongo connections / replica reads — and can return the pre-write `{queries: []}` doc. If that stale read lands and it was the last ready-to-run query to finish before persist, the refresh chain dies and every dependent query stays `"queued"` forever.

A second, independent stall: `startReadyQueries()` `return`s (instead of `continue`s) when a `runAtEnd` query is iterated while non-runAtEnd queries are still pending. If Map iteration order puts the `runAtEnd` query before a *ready* non-runAtEnd queued query, the two deadlock.

## Fix

**`QueryRunner.ts`**
- New `private dagPersisted = false`, set `true` immediately after `updateModel()` in `startAnalysis()`.
- `onQueryFinish()` returns early while `!dagPersisted`. Early finishes are deferred; `this.timer` stays null; the post-persist `onQueryFinish()` is guaranteed to actually arm a timer whose `getLatestModel()` observes the committed DAG.
- `startReadyQueries()`: `runAtEnd` "still pending" branch now `continue`s instead of `return`ing.
- WARN message updated (the original cause is now prevented; the warn stays for visibility on any other path).

**`expireOldQueries.ts` — `reapStalledSnapshots()` (defense-in-depth)**
- When reaping an orphaned-DAG snapshot, also fail the underlying queued `Query` docs (they have no heartbeat so `getStaleQueries()` never touches them; without this they linger forever and can be picked up by the query cache as eternally-running).
- Pull `nextSnapshotAttempt` forward and re-enable `autoSnapshots` so the experiment is retried on the next 10-minute `queueExperimentUpdates` poll instead of waiting `EXPERIMENT_REFRESH_FREQUENCY` hours. An orphaned DAG is almost always a lost in-memory driver (process restart / event-loop kill), not a deterministic data problem, so a fresh run should succeed.

## Tests

- `gates onQueryFinish until the query DAG is persisted, then drives once` — early `onQueryFinish()` does not arm `this.timer`; post-persist call does.
- `processes ready non-runAtEnd queries even when a runAtEnd query is iterated first` — regression for the `return`→`continue` fix.
- Existing `startAnalysis` / `startReadyQueries` / heartbeat tests unchanged.

## Related-race audit (multi-pod deployments)

Surveyed for other state writes that assume the QueryRunner is the only writer / single-process:

| Area | Finding |
|---|---|
| `runCallbacks` (in-memory closures) | Architectural: the DAG can only be driven by the process that called `startAnalysis()`. Any process death strands queued queries. The reaper auto-retry in this PR is the mitigation; making the DAG resumable from another process would need `run`/`process` callbacks to be reconstructible from persisted state. |
| `incrementalRefresh` lock | Mongo-backed, fenced on snapshot id, heartbeated; reaper releases. Multi-pod safe. |
| Agenda job locks | Mongo `lockedAt`/`lockLifetime`; multi-worker safe. Default 10-min `lockLifetime` is shorter than long snapshot runs — with a single jobrunner replica that's harmless, but worth a `lockLifetime` bump on `updateSingleExperiment` if jobrunner scales out. |
| Query cache reuse of a `running` query | `createNewQueryFromCached` copies `status: "running"` and the 3s poll only triggers `onQueryFinish()` (a refresh), never updates the *copy's* doc. The copy's heartbeat goes stale and `getStaleQueries()` fails it within ~2 min — so it self-heals to `error`, but the snapshot is wasted. Separate from this PR; noting for follow-up. |
| `expireOldQueries` vs live runner | `errorSnapshotIfStillRunning` is guarded on `status: "running"`; a live runner that just wrote `success` wins. Multi-pod safe. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
