### PR TITLE
Ramp schedule: template defaults, reordering, and REST rollback-to-0%

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -9671,6 +9671,91 @@ paths:
                 environment:
                   deprecated: true
                   type: string
+                startState:
+                  description: >-
+                    The rule state to roll back to (the rollback/jump-to-start
+                    anchor). Merged onto the rule's current state, so `{
+                    "coverage": 0 }` keeps existing targeting but rolls back to
+                    0%. This affects rollbacks only — it is NOT applied when the
+                    ramp starts. On create, omitting it infers the anchor from
+                    the rule's current coverage (and returns a warning if that
+                    isn't 0%); on update of a live schedule, omitting it leaves
+                    the existing anchor unchanged.
+                  type: object
+                  properties:
+                    coverage:
+                      description: >-
+                        Traffic fraction (0–1). For monitored steps the rollout
+                        rule is promoted to an experiment: treatment = [0,
+                        coverage), control = [0.5, 0.5+coverage). Both arms are
+                        equal-sized and non-adjacent, so a step-up only adds new
+                        users to each arm — no existing user changes group. The
+                        REST API enforces coverage ≤ 0.5 on monitored steps so
+                        control end never exceeds 1.0. The SDK uses explicit
+                        hash ranges on bucketingV2 clients to keep bucketing
+                        stable across monitored/unmonitored transitions.
+                      anyOf:
+                        - type: number
+                          minimum: 0
+                          maximum: 1
+                        - type: 'null'
+                    condition:
+                      anyOf:
+                        - type: string
+                        - type: 'null'
+                    savedGroups:
+                      anyOf:
+                        - type: array
+                          items:
+                            type: object
+                            properties:
+                              match:
+                                type: string
+                                enum:
+                                  - all
+                                  - none
+                                  - any
+                              ids:
+                                type: array
+                                items:
+                                  type: string
+                            required:
+                              - match
+                              - ids
+                            additionalProperties: false
+                        - type: 'null'
+                    prerequisites:
+                      anyOf:
+                        - type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                              condition:
+                                type: string
+                            required:
+                              - id
+                              - condition
+                            additionalProperties: false
+                        - type: 'null'
+                    allEnvironments:
+                      anyOf:
+                        - type: boolean
+                        - type: 'null'
+                    environments:
+                      anyOf:
+                        - type: array
+                          items:
+                            type: string
+                        - type: 'null'
+                    force:
+                      description: Force value (any JSON type)
+                    enabled:
+                      anyOf:
+                        - type: boolean
+                        - type: 'null'
+                  additionalProperties: false
                 revisionTitle:
                   description: >-
                     Title for a newly created draft. Only used when version is
@@ -9691,6 +9776,13 @@ paths:
                 properties:
                   revision:
                     $ref: '#/components/schemas/FeatureRevisionV2'
+                  warnings:
+                    description: >-
+                      Non-fatal advisories about how the request was
+                      interpreted.
+                    type: array
+                    items:
+                      type: string
                 required:
                   - revision
                 additionalProperties: false

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -31427,6 +31427,9 @@ paths:
                   required:
                     - mode
                   additionalProperties: false
+                order:
+                  description: Display order within the org (lower sorts first).
+                  type: number
               additionalProperties: false
       responses:
         '200':
@@ -31722,6 +31725,11 @@ paths:
                   required:
                     - mode
                   additionalProperties: false
+                order:
+                  description: >-
+                    Display order within the org (lower sorts first). Omit to
+                    append to the end.
+                  type: number
               required:
                 - name
                 - steps

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -43287,12 +43287,18 @@ components:
                 - mode
               additionalProperties: false
             - type: 'null'
+        order:
+          description: >-
+            Manual display order within the org (read-only; managed via the
+            app).
+          type: number
       required:
         - id
         - dateCreated
         - dateUpdated
         - name
         - steps
+        - order
       additionalProperties: false
     ExperimentSnapshot:
       type: object

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -9243,6 +9243,12 @@ paths:
         already has a live ramp schedule, this stores an `update` action applied
         on publish; otherwise it stores a `create` action. No live schedule
         config changes are applied immediately by this endpoint.
+
+
+        You can build the ramp from a template (`templateId`) and set the
+        rollback anchor (`startState`) in the same request — e.g. pull in a
+        template and pass `startState: { "coverage": 0 }` so a rollback returns
+        the rule to 0%.
       tags:
         - feature-revisions-v2
       parameters:

--- a/packages/back-end/src/api/features/putFeatureRevisionRuleRampSchedule.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionRuleRampSchedule.ts
@@ -109,6 +109,7 @@ export async function setRuleRampSchedule(
     // startActions (merged onto the rule's current state); when omitted, the
     // anchor is derived at publish from the rule's coverage — and we warn if
     // that isn't 0% on create.
+    const startStateProvided = scheduleInput.startState !== undefined;
     const { startActions: resolvedStartActions, warning: startStateWarning } =
       resolveRampStartState({
         rule: match,
@@ -120,6 +121,22 @@ export async function setRuleRampSchedule(
       scheduleInput.startActions = resolvedStartActions;
     }
     delete scheduleInput.startState;
+
+    const warnings: string[] = [];
+    if (startStateWarning) warnings.push(startStateWarning);
+    // The rollback anchor is only persisted while a schedule is pending/ready
+    // (see FeatureModel). Updating an already-active schedule's startState is a
+    // no-op, so tell the caller rather than returning a misleading success.
+    if (
+      startStateProvided &&
+      existingLiveSchedule &&
+      existingLiveSchedule.status !== "pending" &&
+      existingLiveSchedule.status !== "ready"
+    ) {
+      warnings.push(
+        `startState was ignored: ramp schedule "${existingLiveSchedule.id}" is "${existingLiveSchedule.status}", and the rollback anchor can only be changed while a schedule is pending or ready.`,
+      );
+    }
 
     const action = normalizeInlineRampSchedule(
       scheduleInput as Parameters<typeof normalizeInlineRampSchedule>[0],
@@ -195,7 +212,7 @@ export async function setRuleRampSchedule(
     return {
       feature,
       revision: finalRevision,
-      warnings: startStateWarning ? [startStateWarning] : undefined,
+      warnings: warnings.length ? warnings : undefined,
     };
   } catch (err) {
     await discardIfJustCreated(context, revision, created);

--- a/packages/back-end/src/api/features/putFeatureRevisionRuleRampSchedule.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionRuleRampSchedule.ts
@@ -1,9 +1,11 @@
 import type { OrganizationInterface } from "shared/types/organization";
 import {
   RevisionRampUpdateAction,
+  RampStartState,
   putFeatureRevisionRuleRampScheduleValidator,
 } from "shared/validators";
 import { resetReviewOnChange } from "shared/util";
+import { resolveRampStartState } from "back-end/src/services/rampSchedule";
 import type { ApiReqContext } from "back-end/types/api";
 import { toApiRevision } from "back-end/src/services/features";
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
@@ -101,11 +103,28 @@ export async function setRuleRampSchedule(
       canonicalRuleId,
       environment ?? undefined,
     );
+    const existingLiveSchedule = liveSchedules[0];
+
+    // Resolve the rollback anchor. An explicit `startState` is converted to
+    // startActions (merged onto the rule's current state); when omitted, the
+    // anchor is derived at publish from the rule's coverage — and we warn if
+    // that isn't 0% on create.
+    const { startActions: resolvedStartActions, warning: startStateWarning } =
+      resolveRampStartState({
+        rule: match,
+        ruleId: canonicalRuleId,
+        startState: scheduleInput.startState as RampStartState | undefined,
+        isCreate: !existingLiveSchedule,
+      });
+    if (resolvedStartActions) {
+      scheduleInput.startActions = resolvedStartActions;
+    }
+    delete scheduleInput.startState;
+
     const action = normalizeInlineRampSchedule(
       scheduleInput as Parameters<typeof normalizeInlineRampSchedule>[0],
       canonicalRuleId,
     );
-    const existingLiveSchedule = liveSchedules[0];
 
     // Replace any existing pending ramp action for this rule. Filter tolerant
     // to both the canonical id AND the caller-provided id, so stale entries
@@ -173,7 +192,11 @@ export async function setRuleRampSchedule(
       },
     );
 
-    return { feature, revision: finalRevision };
+    return {
+      feature,
+      revision: finalRevision,
+      warnings: startStateWarning ? [startStateWarning] : undefined,
+    };
   } catch (err) {
     await discardIfJustCreated(context, revision, created);
     throw err;

--- a/packages/back-end/src/api/features/putFeatureRevisionRuleRampScheduleV2.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionRuleRampScheduleV2.ts
@@ -6,11 +6,11 @@ import { setRuleRampSchedule } from "./putFeatureRevisionRuleRampSchedule";
 export const putFeatureRevisionRuleRampScheduleV2 = createApiRequestHandler(
   putFeatureRevisionRuleRampScheduleV2Validator,
 )(async (req) => {
-  const { revision } = await setRuleRampSchedule(
+  const { revision, warnings } = await setRuleRampSchedule(
     req.context,
     req.organization,
     req.params,
     req.body,
   );
-  return { revision: toApiRevisionV2(revision) };
+  return { revision: toApiRevisionV2(revision), warnings };
 });

--- a/packages/back-end/src/api/specs/ramp-schedule-template.spec.ts
+++ b/packages/back-end/src/api/specs/ramp-schedule-template.spec.ts
@@ -21,6 +21,12 @@ export const rampScheduleTemplateApiSpec = {
       official: z.boolean().optional(),
       monitoringConfig: rampMonitoringConfig.nullish(),
       lockdownConfig: lockdownConfigSchema.optional(),
+      order: z
+        .number()
+        .optional()
+        .describe(
+          "Display order within the org (lower sorts first). Omit to append to the end.",
+        ),
     }),
     updateBody: z.object({
       name: z.string().optional(),
@@ -29,6 +35,10 @@ export const rampScheduleTemplateApiSpec = {
       official: z.boolean().optional(),
       monitoringConfig: rampMonitoringConfig.nullish(),
       lockdownConfig: lockdownConfigSchema.optional(),
+      order: z
+        .number()
+        .optional()
+        .describe("Display order within the org (lower sorts first)."),
     }),
   },
   includeDefaultCrud: true,

--- a/packages/back-end/src/models/RampScheduleTemplateModel.ts
+++ b/packages/back-end/src/models/RampScheduleTemplateModel.ts
@@ -1,4 +1,4 @@
-import { UpdateProps } from "shared/types/base-model";
+import { CreateProps, UpdateProps } from "shared/types/base-model";
 import {
   RampScheduleTemplateInterface,
   rampScheduleTemplateValidator,
@@ -77,6 +77,18 @@ export class RampScheduleTemplateModel extends BaseClass {
   public async getNextOrder(): Promise<number> {
     const all = await this.getAll();
     return all.reduce((max, t) => Math.max(max, t.order), -1) + 1;
+  }
+
+  // REST create: append to the end unless the caller pins an explicit order, so
+  // API-created templates behave like app-created ones instead of defaulting to
+  // order 0 and jumping to the top.
+  protected async processApiCreateBody(
+    rawBody: unknown,
+  ): Promise<CreateProps<RampScheduleTemplateInterface>> {
+    const body = rawBody as CreateProps<RampScheduleTemplateInterface> & {
+      order?: number;
+    };
+    return { ...body, order: body.order ?? (await this.getNextOrder()) };
   }
 
   // Move `oldId` into the slot held by `newId`, then renumber so `order`

--- a/packages/back-end/src/models/RampScheduleTemplateModel.ts
+++ b/packages/back-end/src/models/RampScheduleTemplateModel.ts
@@ -18,6 +18,12 @@ const BaseClass = MakeModelClass({
     deleteEvent: "rampScheduleTemplate.delete",
   },
   globallyUniquePrimaryKeys: false,
+  defaultValues: {
+    order: 0,
+  },
+  // Reordering only touches `order`; don't bump dateUpdated or emit audit logs.
+  skipDateUpdatedFields: ["order"],
+  skipAuditLogFields: ["order"],
   apiConfig: {
     modelKey: "rampScheduleTemplates",
     openApiSpec: rampScheduleTemplateApiSpec,
@@ -27,9 +33,12 @@ const BaseClass = MakeModelClass({
 export class RampScheduleTemplateModel extends BaseClass {
   protected migrate(legacyDoc: unknown): RampScheduleTemplateInterface {
     const doc = legacyDoc as RampScheduleTemplateInterface;
-    return migrateRampStepTriggers(
+    const migrated = migrateRampStepTriggers(
       doc as unknown as Parameters<typeof migrateRampStepTriggers>[0],
     ) as unknown as RampScheduleTemplateInterface;
+    // Legacy templates predate the `order` field — default them to 0 so they
+    // keep a stable (date-created) order until the first manual reorder.
+    return { ...migrated, order: migrated.order ?? 0 };
   }
 
   protected canRead() {
@@ -49,5 +58,47 @@ export class RampScheduleTemplateModel extends BaseClass {
   }
   protected canDelete(_existing: RampScheduleTemplateInterface) {
     return this.context.permissions.canDeleteFeature({ project: undefined });
+  }
+
+  // Templates in manual order. Ties (e.g. legacy order=0) fall back to
+  // creation time so ordering stays deterministic before any reorder.
+  private sortByOrder(templates: RampScheduleTemplateInterface[]) {
+    return [...templates].sort(
+      (a, b) =>
+        a.order - b.order || a.dateCreated.getTime() - b.dateCreated.getTime(),
+    );
+  }
+
+  public async getAllSorted(): Promise<RampScheduleTemplateInterface[]> {
+    return this.sortByOrder(await this.getAll());
+  }
+
+  // Order to assign a newly created template so it lands at the end.
+  public async getNextOrder(): Promise<number> {
+    const all = await this.getAll();
+    return all.reduce((max, t) => Math.max(max, t.order), -1) + 1;
+  }
+
+  // Move `oldId` into the slot held by `newId`, then renumber so `order`
+  // matches array position. Returns the full reordered list, or null if either
+  // id is missing.
+  public async reorder(
+    oldId: string,
+    newId: string,
+  ): Promise<RampScheduleTemplateInterface[] | null> {
+    const sorted = await this.getAllSorted();
+    const oldIndex = sorted.findIndex((t) => t.id === oldId);
+    const newIndex = sorted.findIndex((t) => t.id === newId);
+    if (oldIndex === -1 || newIndex === -1) return null;
+
+    sorted.splice(newIndex, 0, sorted.splice(oldIndex, 1)[0]);
+
+    for (let i = 0; i < sorted.length; i++) {
+      if (sorted[i].order !== i) {
+        await this.updateById(sorted[i].id, { order: i });
+        sorted[i] = { ...sorted[i], order: i };
+      }
+    }
+    return sorted;
   }
 }

--- a/packages/back-end/src/routers/ramp-schedule-template/ramp-schedule-template.controller.ts
+++ b/packages/back-end/src/routers/ramp-schedule-template/ramp-schedule-template.controller.ts
@@ -10,7 +10,7 @@ export const getRampScheduleTemplates = async (
   res: Response,
 ) => {
   const context = getContextFromReq(req);
-  const templates = await context.models.rampScheduleTemplates.getAll();
+  const templates = await context.models.rampScheduleTemplates.getAllSorted();
   res.status(200).json({ status: 200, rampScheduleTemplates: templates });
 };
 
@@ -59,8 +59,33 @@ export const postRampScheduleTemplate = async (
     official,
     monitoringConfig,
     lockdownConfig,
+    order: await context.models.rampScheduleTemplates.getNextOrder(),
   });
   res.status(201).json({ status: 201, rampScheduleTemplate: created });
+};
+
+// POST /ramp-schedule-templates/reorder
+export const reorderRampScheduleTemplates = async (
+  req: AuthRequest<{ oldId: string; newId: string }>,
+  res: Response,
+) => {
+  const context = getContextFromReq(req);
+
+  if (!context.hasPremiumFeature("ramp-schedules")) {
+    context.throwPlanDoesNotAllowError(
+      "Ramp schedule templates require an Enterprise plan.",
+    );
+  }
+
+  const { oldId, newId } = req.body;
+  const reordered = await context.models.rampScheduleTemplates.reorder(
+    oldId,
+    newId,
+  );
+  if (!reordered) {
+    return res.status(404).json({ status: 404, message: "Template not found" });
+  }
+  res.status(200).json({ status: 200, rampScheduleTemplates: reordered });
 };
 
 // PUT /ramp-schedule-templates/:id

--- a/packages/back-end/src/routers/ramp-schedule-template/ramp-schedule-template.controller.ts
+++ b/packages/back-end/src/routers/ramp-schedule-template/ramp-schedule-template.controller.ts
@@ -132,6 +132,13 @@ export const deleteRampScheduleTemplate = async (
   res: Response,
 ) => {
   const context = getContextFromReq(req);
+
+  if (!context.hasPremiumFeature("ramp-schedules")) {
+    context.throwPlanDoesNotAllowError(
+      "Ramp schedule templates require an Enterprise plan.",
+    );
+  }
+
   const template = await context.models.rampScheduleTemplates.getById(
     req.params.id,
   );

--- a/packages/back-end/src/routers/ramp-schedule-template/ramp-schedule-template.router.ts
+++ b/packages/back-end/src/routers/ramp-schedule-template/ramp-schedule-template.router.ts
@@ -1,5 +1,7 @@
 import express from "express";
+import { reorderRampScheduleTemplatesValidator } from "shared/validators";
 import { wrapController } from "back-end/src/routers/wrapController";
+import { validateRequestMiddleware } from "back-end/src/routers/utils/validateRequestMiddleware";
 import * as rawController from "./ramp-schedule-template.controller";
 
 const router = express.Router();
@@ -7,6 +9,13 @@ const ctrl = wrapController(rawController);
 
 router.get("/", ctrl.getRampScheduleTemplates);
 router.post("/", ctrl.postRampScheduleTemplate);
+router.post(
+  "/reorder",
+  validateRequestMiddleware({
+    body: reorderRampScheduleTemplatesValidator,
+  }),
+  ctrl.reorderRampScheduleTemplates,
+);
 router.get("/:id", ctrl.getRampScheduleTemplate);
 router.put("/:id", ctrl.putRampScheduleTemplate);
 router.delete("/:id", ctrl.deleteRampScheduleTemplate);

--- a/packages/back-end/src/services/rampSchedule.ts
+++ b/packages/back-end/src/services/rampSchedule.ts
@@ -406,6 +406,57 @@ export function getStartActionsFromRules({
   }));
 }
 
+// Resolves the rollback anchor (startActions) and an optional advisory for the
+// REST ramp-schedule create/update flow. Pure given the rule + input.
+//
+// - Explicit `startState`: merged onto the rule's current state and returned as
+//   startActions, so partial input like `{ coverage: 0 }` restores full
+//   targeting while anchoring rollback at 0%.
+// - Omitted on create: no startActions (the anchor is derived from the rule's
+//   current coverage at publish). Returns a warning if that coverage isn't 0%,
+//   since rollback would then return there rather than to 0%.
+// - Omitted on update: no-op (leave the existing anchor alone).
+export function resolveRampStartState({
+  rule,
+  ruleId,
+  startState,
+  isCreate,
+}: {
+  rule: FeatureRule;
+  ruleId: string;
+  startState?: Partial<Omit<FeatureRulePatch, "ruleId">>;
+  isCreate: boolean;
+}): { startActions?: RampStepAction[]; warning?: string } {
+  if (startState !== undefined) {
+    const patch = { ...getStartPatchForRule(rule), ...startState };
+    return {
+      startActions: [
+        // targetId is a placeholder — the deferred create re-injects the real
+        // target id (see normalizeAction in FeatureModel).
+        {
+          targetType: "feature-rule",
+          targetId: "",
+          patch: { ruleId, ...patch },
+        },
+      ],
+    };
+  }
+
+  if (isCreate) {
+    const coverage = (rule as { coverage?: number }).coverage;
+    if (typeof coverage === "number" && coverage !== 0) {
+      return {
+        warning:
+          `Ramp start state was inferred from rule "${ruleId}"'s current coverage ` +
+          `(${Math.round(coverage * 100)}%); a rollback will return the rule there, ` +
+          `not to 0%. Pass startState: { "coverage": 0 } to anchor rollbacks at 0%.`,
+      };
+    }
+  }
+
+  return {};
+}
+
 export const featureEntityHandler: EntityHandler = {
   async applyActions(ctx, entityId, actions, opts) {
     const { stepLabel, user, environment } = opts;

--- a/packages/back-end/test/services/rampSchedule.test.ts
+++ b/packages/back-end/test/services/rampSchedule.test.ts
@@ -39,6 +39,7 @@ import {
   advanceScheduleManually,
   completeRollout,
   getStartPatchForRule,
+  resolveRampStartState,
   applyRampStartActions,
   startReadyScheduleNow,
   approveAndPublishStep,
@@ -474,6 +475,87 @@ function sparseSchedule(
     })),
   };
 }
+
+describe("resolveRampStartState", () => {
+  const rolloutRule = (coverage?: number) =>
+    ({
+      id: RULE_ID,
+      type: "rollout",
+      hashAttribute: "id",
+      enabled: true,
+      ...(coverage !== undefined ? { coverage } : {}),
+    }) as FeatureRule;
+
+  it("converts an explicit startState into startActions merged onto the rule state", () => {
+    const { startActions, warning } = resolveRampStartState({
+      rule: rolloutRule(0.1),
+      ruleId: RULE_ID,
+      startState: { coverage: 0 },
+      isCreate: true,
+    });
+
+    expect(warning).toBeUndefined();
+    expect(startActions).toHaveLength(1);
+    // Explicit coverage override wins; other targeting comes from the rule.
+    expect(startActions![0].patch).toMatchObject({
+      ruleId: RULE_ID,
+      coverage: 0,
+    });
+  });
+
+  it("warns on create when the anchor is inferred from a non-zero coverage", () => {
+    const { startActions, warning } = resolveRampStartState({
+      rule: rolloutRule(0.1),
+      ruleId: RULE_ID,
+      startState: undefined,
+      isCreate: true,
+    });
+
+    expect(startActions).toBeUndefined();
+    expect(warning).toContain("10%");
+  });
+
+  it("does not warn when the inferred coverage is already 0%", () => {
+    const { startActions, warning } = resolveRampStartState({
+      rule: rolloutRule(0),
+      ruleId: RULE_ID,
+      startState: undefined,
+      isCreate: true,
+    });
+
+    expect(startActions).toBeUndefined();
+    expect(warning).toBeUndefined();
+  });
+
+  it("does not warn for a rule with no coverage (e.g. a force rule)", () => {
+    const { warning } = resolveRampStartState({
+      rule: {
+        id: RULE_ID,
+        type: "force",
+        hashAttribute: "id",
+        enabled: true,
+        value: "x",
+      } as FeatureRule,
+      ruleId: RULE_ID,
+      startState: undefined,
+      isCreate: true,
+    });
+
+    expect(warning).toBeUndefined();
+  });
+
+  it("leaves the anchor alone (no warning) on update when startState is omitted", () => {
+    const { startActions, warning } = resolveRampStartState({
+      rule: rolloutRule(0.1),
+      ruleId: RULE_ID,
+      startState: undefined,
+      isCreate: false,
+    });
+
+    expect(startActions).toBeUndefined();
+    expect(warning).toBeUndefined();
+  });
+});
 
 describe("computeEffectivePatch", () => {
   // Returns the accumulated patch for TARGET_ID at the given stepIndex, as a plain object.

--- a/packages/front-end/components/Features/RuleModal/RampScheduleSection.tsx
+++ b/packages/front-end/components/Features/RuleModal/RampScheduleSection.tsx
@@ -964,31 +964,43 @@ export default function RampScheduleSection({
 
   const [selectedTemplateId, setSelectedTemplateId] = useState("");
   const [presetOpen, setPresetOpen] = useState(false);
-  const hasAutoSelected = useRef(false);
+  // Tracks the monitored-ness we last auto-selected a default for. Re-runs when
+  // it flips (e.g. switching between Ramp-up and Monitored Ramp-up) so the
+  // matching official default is applied for the new strategy — not just on the
+  // first template load.
+  const autoSelectedMonitored = useRef<boolean | null>(null);
 
-  // Keep the local display string in sync when simpleDurationDays is changed
-  // On first template load, match the existing state or apply the first default.
+  // On template load, and whenever the ramp's monitored-ness changes, adopt a
+  // matching template or apply the first official default for that strategy.
   useEffect(() => {
-    if (hasAutoSelected.current || templates.length === 0) return;
-    hasAutoSelected.current = true;
+    if (templates.length === 0) return;
+    const stateMonitored = state.steps.some((s) => s.monitored);
+    if (autoSelectedMonitored.current === stateMonitored) return;
+
     const matchId = findMatchingTemplate(state, templates);
     if (matchId) {
       setSelectedTemplateId(matchId);
+      autoSelectedMonitored.current = stateMonitored;
       return;
     }
-    // For a new ramp, pre-apply the first official template — but only one whose
-    // monitored-ness matches the release strategy already chosen on the rule
-    // (encoded in the seeded steps). This avoids forcing a monitored config onto
-    // a plain ramp, or a plain template onto a Monitored Ramp-up.
-    if (!ruleRampSchedule && !hideTemplateSave) {
-      const stateMonitored = state.steps.some((s) => s.monitored);
+    // For a new ramp, pre-apply the first official template whose monitored-ness
+    // matches the chosen release strategy — avoiding a monitored config on a
+    // plain ramp, or a plain template on a Monitored Ramp-up. Skip if the user
+    // already has a template pinned for this same strategy (a deliberate pick),
+    // but not if it's stale from before a strategy switch.
+    const currentSelection = templates.find((t) => t.id === selectedTemplateId);
+    const selectionIsForThisStrategy =
+      !!currentSelection &&
+      isMonitoredTemplate(currentSelection) === stateMonitored;
+    if (!ruleRampSchedule && !hideTemplateSave && !selectionIsForThisStrategy) {
       const defaultTemplate = templates.find(
         (t) => t.official && isMonitoredTemplate(t) === stateMonitored,
       );
       if (defaultTemplate) applyTemplate(defaultTemplate);
     }
+    autoSelectedMonitored.current = stateMonitored;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [templates]);
+  }, [templates, state.steps]);
 
   // Auto-derive monitoring cadence from step durations on initial mount,
   // but only if no explicit cadence override was already saved.

--- a/packages/front-end/components/Features/RuleModal/RampScheduleSection.tsx
+++ b/packages/front-end/components/Features/RuleModal/RampScheduleSection.tsx
@@ -378,6 +378,15 @@ export function formatRampStepSummary(
   return parts.join(", ");
 }
 
+// A template is "monitored" if it carries monitoring config or any monitored
+// step. Used to keep auto-selected defaults aligned with the rule's release
+// strategy (plain Ramp-up vs Monitored Ramp-up).
+export function isMonitoredTemplate(
+  t: Pick<RampScheduleTemplateInterface, "monitoringConfig" | "steps">,
+): boolean {
+  return !!t.monitoringConfig || t.steps.some((s) => s.monitored);
+}
+
 const COL = {
   num: 30, // "1" / "2" / "start" / "end"
   trigger: 175, // trigger type select
@@ -967,11 +976,16 @@ export default function RampScheduleSection({
       setSelectedTemplateId(matchId);
       return;
     }
-    if (!ruleRampSchedule && !hideTemplateSave && selectedTemplateId) {
-      const first = [...templates].sort(
-        (a, b) => (b.official ? 1 : 0) - (a.official ? 1 : 0),
-      )[0];
-      if (first) applyTemplate(first);
+    // For a new ramp, pre-apply the first official template — but only one whose
+    // monitored-ness matches the release strategy already chosen on the rule
+    // (encoded in the seeded steps). This avoids forcing a monitored config onto
+    // a plain ramp, or a plain template onto a Monitored Ramp-up.
+    if (!ruleRampSchedule && !hideTemplateSave) {
+      const stateMonitored = state.steps.some((s) => s.monitored);
+      const defaultTemplate = templates.find(
+        (t) => t.official && isMonitoredTemplate(t) === stateMonitored,
+      );
+      if (defaultTemplate) applyTemplate(defaultTemplate);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [templates]);
@@ -2646,19 +2660,31 @@ export default function RampScheduleSection({
       gap="2"
       style={{ width: 430, overflow: "hidden" }}
     >
-      <span
-        style={{
-          flex: 1,
-          minWidth: 0,
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-          whiteSpace: "nowrap",
-          color: selectedTemplate ? undefined : "var(--gray-a9)",
-        }}
-      >
-        {selectedTemplate?.name ??
-          (templates.length === 0 ? "No templates" : "None")}
-      </span>
+      <Flex align="center" gap="1" style={{ flex: 1, minWidth: 0 }}>
+        {selectedTemplate?.official && (
+          <HiBadgeCheck
+            style={{
+              fontSize: "1.2em",
+              lineHeight: "1em",
+              color: "var(--blue-11)",
+              flexShrink: 0,
+              display: "block",
+            }}
+          />
+        )}
+        <span
+          style={{
+            minWidth: 0,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            color: selectedTemplate ? undefined : "var(--gray-a9)",
+          }}
+        >
+          {selectedTemplate?.name ??
+            (templates.length === 0 ? "No templates" : "None")}
+        </span>
+      </Flex>
       <PiCaretDownBold style={{ flexShrink: 0 }} />
     </Flex>
   );
@@ -3360,7 +3386,7 @@ export default function RampScheduleSection({
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           {[...templates]
-            .sort((a, b) => (b.official ? 1 : 0) - (a.official ? 1 : 0))
+            .sort((a, b) => a.order - b.order)
             .map((t) => (
               <React.Fragment key={t.id}>
                 <DropdownMenuItem
@@ -3399,9 +3425,23 @@ export default function RampScheduleSection({
                         {t.name}
                       </span>
                     </Flex>
-                    <Text as="span" size="small" color="text-low">
-                      {formatRampStepSummary(t.steps)}
-                    </Text>
+                    <Flex align="center" gap="2" style={{ flexShrink: 0 }}>
+                      <Text as="span" size="small" color="text-low">
+                        {formatRampStepSummary(t.steps)}
+                      </Text>
+                      {/* Fixed-width slot keeps the icon column aligned across
+                          rows (empty for non-monitored templates). */}
+                      <Box
+                        style={{
+                          width: 16,
+                          flexShrink: 0,
+                          display: "flex",
+                          justifyContent: "center",
+                        }}
+                      >
+                        {isMonitoredTemplate(t) && <MonitoredIcon size={16} />}
+                      </Box>
+                    </Flex>
                   </Flex>
                 </DropdownMenuItem>
               </React.Fragment>
@@ -4374,7 +4414,7 @@ export function buildTemplatePayload(
   state: RampSectionState,
 ): Omit<
   RampScheduleTemplateInterface,
-  "id" | "organization" | "dateCreated" | "dateUpdated"
+  "id" | "organization" | "dateCreated" | "dateUpdated" | "order"
 > {
   const PLACEHOLDER_TARGET = "template-target";
   const PLACEHOLDER_RULE = "template-rule";

--- a/packages/front-end/components/Features/RuleModal/RampScheduleSection.tsx
+++ b/packages/front-end/components/Features/RuleModal/RampScheduleSection.tsx
@@ -964,41 +964,41 @@ export default function RampScheduleSection({
 
   const [selectedTemplateId, setSelectedTemplateId] = useState("");
   const [presetOpen, setPresetOpen] = useState(false);
-  // Tracks the monitored-ness we last auto-selected a default for. Re-runs when
-  // it flips (e.g. switching between Ramp-up and Monitored Ramp-up) so the
-  // matching official default is applied for the new strategy — not just on the
-  // first template load.
-  const autoSelectedMonitored = useRef<boolean | null>(null);
+  const hasAutoSelected = useRef(false);
+  // The monitored-ness reflected by the last selection sync, so we can detect a
+  // strategy flip that bypassed `patchState` (e.g. a page-1 release-strategy
+  // switch reseeds the parent state directly).
+  const lastSyncedMonitored = useRef<boolean | null>(null);
 
-  // On template load, and whenever the ramp's monitored-ness changes, adopt a
-  // matching template or apply the first official default for that strategy.
   useEffect(() => {
     if (templates.length === 0) return;
     const stateMonitored = state.steps.some((s) => s.monitored);
-    if (autoSelectedMonitored.current === stateMonitored) return;
 
-    const matchId = findMatchingTemplate(state, templates);
-    if (matchId) {
-      setSelectedTemplateId(matchId);
-      autoSelectedMonitored.current = stateMonitored;
+    // Initial load: adopt an exact match, or pre-apply the first official
+    // template matching the chosen release strategy for a brand-new ramp.
+    if (!hasAutoSelected.current) {
+      hasAutoSelected.current = true;
+      lastSyncedMonitored.current = stateMonitored;
+      const matchId = findMatchingTemplate(state, templates);
+      if (matchId) {
+        setSelectedTemplateId(matchId);
+      } else if (!ruleRampSchedule && !hideTemplateSave) {
+        const defaultTemplate = templates.find(
+          (t) => t.official && isMonitoredTemplate(t) === stateMonitored,
+        );
+        if (defaultTemplate) applyTemplate(defaultTemplate);
+      }
       return;
     }
-    // For a new ramp, pre-apply the first official template whose monitored-ness
-    // matches the chosen release strategy — avoiding a monitored config on a
-    // plain ramp, or a plain template on a Monitored Ramp-up. Skip if the user
-    // already has a template pinned for this same strategy (a deliberate pick),
-    // but not if it's stale from before a strategy switch.
-    const currentSelection = templates.find((t) => t.id === selectedTemplateId);
-    const selectionIsForThisStrategy =
-      !!currentSelection &&
-      isMonitoredTemplate(currentSelection) === stateMonitored;
-    if (!ruleRampSchedule && !hideTemplateSave && !selectionIsForThisStrategy) {
-      const defaultTemplate = templates.find(
-        (t) => t.official && isMonitoredTemplate(t) === stateMonitored,
-      );
-      if (defaultTemplate) applyTemplate(defaultTemplate);
+
+    // After init, a strategy flip that didn't go through `patchState` (a page-1
+    // switch reseeds steps directly) re-syncs the selection to an exact match or
+    // none/custom — never re-applies a default, so a customized ramp is never
+    // clobbered. In-editor edits/toggles are handled by `patchState`.
+    if (lastSyncedMonitored.current !== stateMonitored) {
+      lastSyncedMonitored.current = stateMonitored;
+      setSelectedTemplateId(findMatchingTemplate(state, templates));
     }
-    autoSelectedMonitored.current = stateMonitored;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [templates, state.steps]);
 
@@ -1025,11 +1025,13 @@ export default function RampScheduleSection({
 
   function patchState(partial: Partial<RampSectionState>) {
     const newState = { ...state, ...partial };
-    if (
-      selectedTemplateId &&
-      findMatchingTemplate(newState, templates) !== selectedTemplateId
-    ) {
-      setSelectedTemplateId("");
+    // Any edit that ejects from the selected template re-syncs the selection to
+    // an exact template match or none/custom — it never pulls in a default, so a
+    // customized ramp (e.g. after toggling monitored) is preserved.
+    const match = findMatchingTemplate(newState, templates);
+    if (match !== selectedTemplateId) {
+      setSelectedTemplateId(match);
+      lastSyncedMonitored.current = newState.steps.some((s) => s.monitored);
     }
     setState(newState);
   }

--- a/packages/front-end/components/GeneralSettings/RampScheduleTemplates.tsx
+++ b/packages/front-end/components/GeneralSettings/RampScheduleTemplates.tsx
@@ -451,12 +451,24 @@ export default function RampScheduleTemplates() {
     [activeId, items],
   );
 
-  const reorderTemplates = async (oldId: string, newId: string) => {
-    await apiCall(`/ramp-schedule-templates/reorder`, {
-      method: "POST",
-      body: JSON.stringify({ oldId, newId }),
-    });
-    await mutate();
+  // Move `oldId` into `newId`'s slot. Shared by drag-and-drop and the Move
+  // up/down menu so both update the list immediately, then revert if the persist
+  // fails — the table never shows an order the server didn't accept.
+  const moveTemplate = async (oldId: string, newId: string) => {
+    const oldIndex = items.findIndex((t) => t.id === oldId);
+    const newIndex = items.findIndex((t) => t.id === newId);
+    if (oldIndex < 0 || newIndex < 0) return;
+    const previous = items;
+    setItems(arrayMove(items, oldIndex, newIndex));
+    try {
+      await apiCall(`/ramp-schedule-templates/reorder`, {
+        method: "POST",
+        body: JSON.stringify({ oldId, newId }),
+      });
+      await mutate();
+    } catch {
+      setItems(previous);
+    }
   };
 
   async function handleDragEnd(event: {
@@ -466,18 +478,7 @@ export default function RampScheduleTemplates() {
     const { active, over } = event;
     setActiveId(undefined);
     if (!over || active.id === over.id) return;
-    const oldIndex = items.findIndex((t) => t.id === active.id);
-    const newIndex = items.findIndex((t) => t.id === over.id);
-    if (oldIndex < 0 || newIndex < 0) return;
-    // Optimistically reorder, then revert if the persist fails so the list
-    // never shows an order the server didn't accept.
-    const previous = items;
-    setItems(arrayMove(items, oldIndex, newIndex));
-    try {
-      await reorderTemplates(String(active.id), String(over.id));
-    } catch {
-      setItems(previous);
-    }
+    await moveTemplate(String(active.id), String(over.id));
   }
 
   const deleteTemplate = async (template: RampScheduleTemplateInterface) => {
@@ -548,10 +549,8 @@ export default function RampScheduleTemplates() {
                     canMoveDown={i < items.length - 1}
                     onEdit={() => setEditingTemplate(tmpl)}
                     onDelete={() => deleteTemplate(tmpl)}
-                    onMoveUp={() => reorderTemplates(tmpl.id, items[i - 1]!.id)}
-                    onMoveDown={() =>
-                      reorderTemplates(tmpl.id, items[i + 1]!.id)
-                    }
+                    onMoveUp={() => moveTemplate(tmpl.id, items[i - 1]!.id)}
+                    onMoveDown={() => moveTemplate(tmpl.id, items[i + 1]!.id)}
                   />
                 ))}
               </SortableContext>

--- a/packages/front-end/components/GeneralSettings/RampScheduleTemplates.tsx
+++ b/packages/front-end/components/GeneralSettings/RampScheduleTemplates.tsx
@@ -464,15 +464,20 @@ export default function RampScheduleTemplates() {
     over: { id: string } | null;
   }) {
     const { active, over } = event;
-    if (over && active.id !== over.id) {
-      const oldIndex = items.findIndex((t) => t.id === active.id);
-      const newIndex = items.findIndex((t) => t.id === over.id);
-      if (oldIndex >= 0 && newIndex >= 0) {
-        setItems(arrayMove(items, oldIndex, newIndex));
-        await reorderTemplates(String(active.id), String(over.id));
-      }
-    }
     setActiveId(undefined);
+    if (!over || active.id === over.id) return;
+    const oldIndex = items.findIndex((t) => t.id === active.id);
+    const newIndex = items.findIndex((t) => t.id === over.id);
+    if (oldIndex < 0 || newIndex < 0) return;
+    // Optimistically reorder, then revert if the persist fails so the list
+    // never shows an order the server didn't accept.
+    const previous = items;
+    setItems(arrayMove(items, oldIndex, newIndex));
+    try {
+      await reorderTemplates(String(active.id), String(over.id));
+    } catch {
+      setItems(previous);
+    }
   }
 
   const deleteTemplate = async (template: RampScheduleTemplateInterface) => {

--- a/packages/front-end/components/GeneralSettings/RampScheduleTemplates.tsx
+++ b/packages/front-end/components/GeneralSettings/RampScheduleTemplates.tsx
@@ -424,7 +424,8 @@ export default function RampScheduleTemplates() {
       { project: undefined },
       { project: undefined },
     );
-  const canDelete = permissionsUtil.canDeleteFeature({ project: undefined });
+  const canDelete =
+    hasFeature && permissionsUtil.canDeleteFeature({ project: undefined });
 
   const [editingTemplate, setEditingTemplate] = useState<
     RampScheduleTemplateInterface | null | false

--- a/packages/front-end/components/GeneralSettings/RampScheduleTemplates.tsx
+++ b/packages/front-end/components/GeneralSettings/RampScheduleTemplates.tsx
@@ -1,7 +1,26 @@
-import React, { useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Box, Flex, IconButton } from "@radix-ui/themes";
-import { PiPlusBold, PiTrash } from "react-icons/pi";
+import { PiPlusBold, PiCaretDown, PiCaretUp } from "react-icons/pi";
+import { BsThreeDotsVertical } from "react-icons/bs";
+import { RiDraggable } from "react-icons/ri";
 import { HiBadgeCheck } from "react-icons/hi";
+import {
+  closestCenter,
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import type { FeatureInterface } from "shared/types/feature";
 import { RampScheduleTemplateInterface } from "shared/validators";
 import Link from "@/ui/Link";
@@ -16,14 +35,28 @@ import Button from "@/ui/Button";
 import Checkbox from "@/ui/Checkbox";
 import Modal from "@/components/Modal";
 import Field from "@/components/Forms/Field";
-import ConfirmButton from "@/components/Modal/ConfirmButton";
 import Frame from "@/ui/Frame";
+import Table, {
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableColumnHeader,
+  TableCell,
+} from "@/ui/Table";
 import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
+import MonitoredIcon from "@/components/Features/RuleModal/MonitoredIcon";
+import {
+  DropdownMenu,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/ui/DropdownMenu";
 import RampScheduleSection, {
   defaultRampSectionState,
   buildTemplatePayload,
   templateToSectionState,
   formatRampStepSummary,
+  isMonitoredTemplate,
   type RampSectionState,
 } from "@/components/Features/RuleModal/RampScheduleSection";
 
@@ -34,6 +67,10 @@ const GENERIC_FEATURE: Pick<FeatureInterface, "id" | "valueType" | "project"> =
     valueType: "json",
     project: "",
   };
+
+const DRAG_HANDLE_WIDTH = 40;
+const MONITORED_WIDTH = 110;
+const MENU_WIDTH = 50;
 
 interface EditModalProps {
   template?: RampScheduleTemplateInterface;
@@ -103,7 +140,7 @@ function EditModal({ template, onClose, onSave }: EditModalProps) {
           label="Official template"
           value={official}
           setValue={setOfficial}
-          description="Appears at the top of the preset list"
+          description="Eligible to be used as the editor default for new ramps"
         />
       </Box>
       <RampScheduleSection
@@ -120,11 +157,260 @@ function EditModal({ template, onClose, onSave }: EditModalProps) {
   );
 }
 
+interface TemplateRowMenuProps {
+  canEdit: boolean;
+  canDelete: boolean;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onEdit: () => void;
+  onDelete: () => Promise<void>;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+}
+
+function TemplateRowMenu({
+  canEdit,
+  canDelete,
+  canMoveUp,
+  canMoveDown,
+  onEdit,
+  onDelete,
+  onMoveUp,
+  onMoveDown,
+}: TemplateRowMenuProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <DropdownMenu
+      trigger={
+        <IconButton
+          variant="ghost"
+          color="gray"
+          radius="full"
+          size="2"
+          highContrast
+          style={{ margin: 0 }}
+        >
+          <BsThreeDotsVertical size={18} />
+        </IconButton>
+      }
+      open={open}
+      onOpenChange={setOpen}
+      menuPlacement="end"
+      variant="soft"
+    >
+      <DropdownMenuGroup>
+        {canEdit && (
+          <DropdownMenuItem
+            onClick={() => {
+              onEdit();
+              setOpen(false);
+            }}
+          >
+            Edit
+          </DropdownMenuItem>
+        )}
+        {canDelete && (
+          <DropdownMenuItem
+            color="red"
+            confirmation={{
+              submit: onDelete,
+              confirmationTitle: "Delete Template",
+              cta: "Delete",
+              getConfirmationContent: async () =>
+                "Are you sure? This action cannot be undone.",
+            }}
+          >
+            Delete
+          </DropdownMenuItem>
+        )}
+        {(canMoveUp || canMoveDown) && <DropdownMenuSeparator />}
+        {(canMoveUp || canMoveDown) && (
+          <>
+            <DropdownMenuItem
+              disabled={!canMoveUp}
+              onClick={() => {
+                if (canMoveUp) {
+                  onMoveUp();
+                  setOpen(false);
+                }
+              }}
+            >
+              <PiCaretUp /> Move up
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={!canMoveDown}
+              onClick={() => {
+                if (canMoveDown) {
+                  onMoveDown();
+                  setOpen(false);
+                }
+              }}
+            >
+              <PiCaretDown /> Move down
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuGroup>
+    </DropdownMenu>
+  );
+}
+
+function TemplateRowCells({
+  template,
+  canUpdate,
+  onEdit,
+}: {
+  template: RampScheduleTemplateInterface;
+  canUpdate: boolean;
+  onEdit: () => void;
+}) {
+  return (
+    <>
+      <TableCell>
+        <Flex justify="between" align="center" gap="3">
+          <Flex align="center" gap="1" style={{ minWidth: 0 }}>
+            {template.official && (
+              <HiBadgeCheck
+                style={{
+                  fontSize: "1.2em",
+                  lineHeight: "1em",
+                  marginTop: "-2px",
+                  color: "var(--blue-11)",
+                  flexShrink: 0,
+                }}
+              />
+            )}
+            {canUpdate ? (
+              <Link onClick={onEdit} weight="medium">
+                {template.name}
+              </Link>
+            ) : (
+              <Text weight="medium" size="medium">
+                {template.name}
+              </Text>
+            )}
+          </Flex>
+          <Text color="text-low" size="small">
+            {formatRampStepSummary(template.steps)}
+          </Text>
+        </Flex>
+      </TableCell>
+      <TableCell style={{ width: MONITORED_WIDTH }}>
+        {isMonitoredTemplate(template) && (
+          <Flex justify="center">
+            <MonitoredIcon size={16} />
+          </Flex>
+        )}
+      </TableCell>
+    </>
+  );
+}
+
+interface SortableTemplateRowProps {
+  template: RampScheduleTemplateInterface;
+  canUpdate: boolean;
+  canDelete: boolean;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onEdit: () => void;
+  onDelete: () => Promise<void>;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+}
+
+function SortableTemplateRow({
+  template,
+  canUpdate,
+  canDelete,
+  canMoveUp,
+  canMoveDown,
+  onEdit,
+  onDelete,
+  onMoveUp,
+  onMoveDown,
+}: SortableTemplateRowProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: template.id });
+  const style: React.CSSProperties = {
+    transition,
+    ...(isDragging
+      ? { opacity: 0, pointerEvents: "none" as const }
+      : { transform: CSS.Transform.toString(transform), opacity: 1 }),
+  };
+
+  return (
+    <TableRow ref={setNodeRef} style={style}>
+      <TableCell style={{ width: DRAG_HANDLE_WIDTH }}>
+        {canUpdate && (
+          <Flex
+            justify="center"
+            style={{
+              color: "var(--slate-a8)",
+              cursor: isDragging ? "grabbing" : "grab",
+            }}
+            {...attributes}
+            {...listeners}
+          >
+            <RiDraggable size={16} />
+          </Flex>
+        )}
+      </TableCell>
+      <TemplateRowCells
+        template={template}
+        canUpdate={canUpdate}
+        onEdit={onEdit}
+      />
+      <TableCell style={{ width: MENU_WIDTH }}>
+        <Flex justify="center">
+          <TemplateRowMenu
+            canEdit={canUpdate}
+            canDelete={canDelete}
+            canMoveUp={canUpdate && canMoveUp}
+            canMoveDown={canUpdate && canMoveDown}
+            onEdit={onEdit}
+            onDelete={onDelete}
+            onMoveUp={onMoveUp}
+            onMoveDown={onMoveDown}
+          />
+        </Flex>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function StaticTemplateRow({
+  template,
+}: {
+  template: RampScheduleTemplateInterface;
+}) {
+  return (
+    <TableRow style={{ opacity: 0.85 }}>
+      <TableCell style={{ width: DRAG_HANDLE_WIDTH }}>
+        <Flex justify="center" style={{ color: "var(--slate-a8)" }}>
+          <RiDraggable size={16} />
+        </Flex>
+      </TableCell>
+      <TemplateRowCells
+        template={template}
+        canUpdate={false}
+        onEdit={() => undefined}
+      />
+      <TableCell style={{ width: MENU_WIDTH }} />
+    </TableRow>
+  );
+}
+
 export default function RampScheduleTemplates() {
   const { data, mutate } = useApi<{
     rampScheduleTemplates: RampScheduleTemplateInterface[];
   }>("/ramp-schedule-templates");
-  const templates = data?.rampScheduleTemplates ?? [];
   const { apiCall } = useAuth();
   const { hasCommercialFeature } = useUser();
   const permissionsUtil = usePermissionsUtil();
@@ -143,6 +429,57 @@ export default function RampScheduleTemplates() {
   const [editingTemplate, setEditingTemplate] = useState<
     RampScheduleTemplateInterface | null | false
   >(false);
+  const [activeId, setActiveId] = useState<string | undefined>();
+  // Local mirror of the server list so reorders feel instant before refetch.
+  const [items, setItems] = useState<RampScheduleTemplateInterface[]>(
+    data?.rampScheduleTemplates ?? [],
+  );
+
+  useEffect(() => {
+    setItems(data?.rampScheduleTemplates ?? []);
+  }, [data]);
+
+  const sensors = useSensors(
+    useSensor(MouseSensor, {}),
+    useSensor(TouchSensor, {}),
+    useSensor(KeyboardSensor, {}),
+  );
+
+  const activeTemplate = useMemo(
+    () => items.find((t) => t.id === activeId) ?? null,
+    [activeId, items],
+  );
+
+  const reorderTemplates = async (oldId: string, newId: string) => {
+    await apiCall(`/ramp-schedule-templates/reorder`, {
+      method: "POST",
+      body: JSON.stringify({ oldId, newId }),
+    });
+    await mutate();
+  };
+
+  async function handleDragEnd(event: {
+    active: { id: string };
+    over: { id: string } | null;
+  }) {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      const oldIndex = items.findIndex((t) => t.id === active.id);
+      const newIndex = items.findIndex((t) => t.id === over.id);
+      if (oldIndex >= 0 && newIndex >= 0) {
+        setItems(arrayMove(items, oldIndex, newIndex));
+        await reorderTemplates(String(active.id), String(over.id));
+      }
+    }
+    setActiveId(undefined);
+  }
+
+  const deleteTemplate = async (template: RampScheduleTemplateInterface) => {
+    await apiCall(`/ramp-schedule-templates/${template.id}`, {
+      method: "DELETE",
+    });
+    await mutate();
+  };
 
   return (
     <Frame>
@@ -162,7 +499,7 @@ export default function RampScheduleTemplates() {
         </PremiumTooltip>
       </Flex>
 
-      {templates.length === 0 ? (
+      {items.length === 0 ? (
         <Text color="text-low" size="medium">
           No templates yet.{" "}
           {hasFeature
@@ -170,75 +507,60 @@ export default function RampScheduleTemplates() {
             : "Upgrade to Enterprise to create and manage ramp schedule templates."}
         </Text>
       ) : (
-        <Box>
-          {[...templates]
-            .sort((a, b) => (b.official ? 1 : 0) - (a.official ? 1 : 0))
-            .map((tmpl) => (
-              <Flex
-                key={tmpl.id}
-                align="center"
-                gap="3"
-                py="2"
-                style={{ borderBottom: "1px solid var(--gray-a4)" }}
+        <DndContext
+          sensors={sensors}
+          onDragStart={(e) => setActiveId(String(e.active.id))}
+          onDragEnd={handleDragEnd}
+          onDragCancel={() => setActiveId(undefined)}
+          collisionDetection={closestCenter}
+        >
+          <Table variant="ghost">
+            <TableHeader>
+              <TableRow>
+                <TableColumnHeader style={{ width: DRAG_HANDLE_WIDTH }} />
+                <TableColumnHeader>Name</TableColumnHeader>
+                <TableColumnHeader
+                  style={{ width: MONITORED_WIDTH, textAlign: "center" }}
+                >
+                  Monitored
+                </TableColumnHeader>
+                <TableColumnHeader style={{ width: MENU_WIDTH }} />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <SortableContext
+                items={items}
+                strategy={verticalListSortingStrategy}
               >
-                <Box style={{ flex: 1, minWidth: 0 }}>
-                  <Flex align="center" gap="1">
-                    {tmpl.official && (
-                      <HiBadgeCheck
-                        style={{
-                          fontSize: "1.2em",
-                          lineHeight: "1em",
-                          marginTop: "-2px",
-                          color: "var(--blue-11)",
-                          flexShrink: 0,
-                        }}
-                      />
-                    )}
-                    {canUpdate ? (
-                      <Link
-                        onClick={() => setEditingTemplate(tmpl)}
-                        weight="medium"
-                      >
-                        {tmpl.name}
-                      </Link>
-                    ) : (
-                      <Text weight="medium" size="medium">
-                        {tmpl.name}
-                      </Text>
-                    )}
-                  </Flex>
-                  <Text color="text-low" size="small" as="div">
-                    {formatRampStepSummary(tmpl.steps)}
-                  </Text>
-                </Box>
-                {canDelete && (
-                  <ConfirmButton
-                    isDestructive
-                    onClick={async () => {
-                      await apiCall(`/ramp-schedule-templates/${tmpl.id}`, {
-                        method: "DELETE",
-                      });
-                      await mutate();
-                    }}
-                    modalHeader="Delete Template"
-                    confirmationText={`Delete "${tmpl.name}"? This cannot be undone.`}
-                    cta="Delete"
-                  >
-                    <IconButton
-                      type="button"
-                      variant="ghost"
-                      color="red"
-                      radius="full"
-                      size="2"
-                      aria-label="Delete template"
-                    >
-                      <PiTrash size={16} />
-                    </IconButton>
-                  </ConfirmButton>
-                )}
-              </Flex>
-            ))}
-        </Box>
+                {items.map((tmpl, i) => (
+                  <SortableTemplateRow
+                    key={tmpl.id}
+                    template={tmpl}
+                    canUpdate={canUpdate}
+                    canDelete={canDelete}
+                    canMoveUp={i > 0}
+                    canMoveDown={i < items.length - 1}
+                    onEdit={() => setEditingTemplate(tmpl)}
+                    onDelete={() => deleteTemplate(tmpl)}
+                    onMoveUp={() => reorderTemplates(tmpl.id, items[i - 1]!.id)}
+                    onMoveDown={() =>
+                      reorderTemplates(tmpl.id, items[i + 1]!.id)
+                    }
+                  />
+                ))}
+              </SortableContext>
+            </TableBody>
+          </Table>
+          <DragOverlay>
+            {activeId && activeTemplate ? (
+              <Table variant="ghost">
+                <TableBody>
+                  <StaticTemplateRow template={activeTemplate} />
+                </TableBody>
+              </Table>
+            ) : null}
+          </DragOverlay>
+        </DndContext>
       )}
 
       {editingTemplate !== false && (

--- a/packages/front-end/test/components/RampScheduleSection.test.ts
+++ b/packages/front-end/test/components/RampScheduleSection.test.ts
@@ -16,6 +16,7 @@ vi.mock("@/services/UserContext", () => ({ useUser: vi.fn() }));
 import type { RampScheduleTemplateInterface } from "shared/validators";
 import {
   formatRampStepSummary,
+  isMonitoredTemplate,
   buildTemplatePayload,
   findMatchingTemplate,
   templateToSectionState,
@@ -43,6 +44,7 @@ function makeTemplate(
     dateCreated: new Date(),
     dateUpdated: new Date(),
     official: false,
+    order: 0,
     ...buildTemplatePayload(state),
     ...overrides,
   } as RampScheduleTemplateInterface;
@@ -89,6 +91,38 @@ describe("formatRampStepSummary", () => {
 
   it("'0 steps' for empty array", () => {
     expect(formatRampStepSummary([])).toBe("0 steps");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isMonitoredTemplate
+// ---------------------------------------------------------------------------
+
+describe("isMonitoredTemplate", () => {
+  it("is false for a plain ramp template (no monitoring config, no monitored steps)", () => {
+    expect(isMonitoredTemplate(makeTemplate(freshState()))).toBe(false);
+  });
+
+  it("is true when any step is monitored", () => {
+    const s = freshState();
+    const monitored = {
+      ...s,
+      steps: s.steps.map((st) => ({ ...st, monitored: true })),
+    };
+    expect(isMonitoredTemplate(makeTemplate(monitored))).toBe(true);
+  });
+
+  it("is true when a monitoring config is present even with no monitored steps", () => {
+    expect(
+      isMonitoredTemplate({
+        monitoringConfig: {
+          datasourceId: "ds_1",
+          exposureQueryId: "eq_1",
+          guardrailMetricIds: ["met_1"],
+        },
+        steps: [],
+      } as Pick<RampScheduleTemplateInterface, "monitoringConfig" | "steps">),
+    ).toBe(true);
   });
 });
 

--- a/packages/shared/src/validators/feature-revisions-v2.ts
+++ b/packages/shared/src/validators/feature-revisions-v2.ts
@@ -1013,7 +1013,7 @@ export const putFeatureRevisionRuleRampScheduleV2Validator = {
   operationId: "putFeatureRevisionRuleRampScheduleV2",
   summary: "Set ramp schedule for a rule",
   description:
-    "Queues a revision-controlled ramp action for this rule. If the rule already has a live ramp schedule, this stores an `update` action applied on publish; otherwise it stores a `create` action. No live schedule config changes are applied immediately by this endpoint.",
+    'Queues a revision-controlled ramp action for this rule. If the rule already has a live ramp schedule, this stores an `update` action applied on publish; otherwise it stores a `create` action. No live schedule config changes are applied immediately by this endpoint.\n\nYou can build the ramp from a template (`templateId`) and set the rollback anchor (`startState`) in the same request — e.g. pull in a template and pass `startState: { "coverage": 0 }` so a rollback returns the rule to 0%.',
   tags: ["feature-revisions-v2"],
   paramsSchema: ruleParams,
   bodySchema: rampScheduleInputV2.extend(newDraftMetadataFields),

--- a/packages/shared/src/validators/feature-revisions-v2.ts
+++ b/packages/shared/src/validators/feature-revisions-v2.ts
@@ -12,6 +12,7 @@ import {
   standaloneRampScheduleInput,
   revisionVersionParam,
 } from "./feature-revisions";
+import { rampStartState } from "./ramp-schedule";
 import { apiFeatureRevisionV2Validator } from "./features-v2";
 import { JSONSchemaDef, revisionStatusFilterSchema } from "./features";
 import { ownerInputField } from "./owner-field";
@@ -47,6 +48,30 @@ const newDraftMetadataFields = {
 // ---- Shared response schemas ----
 
 const revisionResponse = z.object({ revision: apiFeatureRevisionV2Validator });
+
+// Ramp-schedule body accepting an optional `startState` (the rollback anchor).
+const rampScheduleInputV2 = standaloneRampScheduleInput.extend({
+  startState: rampStartState
+    .optional()
+    .describe(
+      "The rule state to roll back to (the rollback/jump-to-start anchor). " +
+        'Merged onto the rule\'s current state, so `{ "coverage": 0 }` keeps ' +
+        "existing targeting but rolls back to 0%. This affects rollbacks only — " +
+        "it is NOT applied when the ramp starts. On create, omitting it infers " +
+        "the anchor from the rule's current coverage (and returns a warning if " +
+        "that isn't 0%); on update of a live schedule, omitting it leaves the " +
+        "existing anchor unchanged.",
+    ),
+});
+
+// Response variant that can carry non-fatal advisories (e.g. an inferred
+// rollback anchor that isn't 0%).
+const revisionResponseWithWarnings = revisionResponse.extend({
+  warnings: z
+    .array(z.string())
+    .optional()
+    .describe("Non-fatal advisories about how the request was interpreted."),
+});
 
 // Mirrors MergeConflict in shared/util/features.ts.
 const mergeConflictSchema = z
@@ -991,9 +1016,9 @@ export const putFeatureRevisionRuleRampScheduleV2Validator = {
     "Queues a revision-controlled ramp action for this rule. If the rule already has a live ramp schedule, this stores an `update` action applied on publish; otherwise it stores a `create` action. No live schedule config changes are applied immediately by this endpoint.",
   tags: ["feature-revisions-v2"],
   paramsSchema: ruleParams,
-  bodySchema: standaloneRampScheduleInput.extend(newDraftMetadataFields),
+  bodySchema: rampScheduleInputV2.extend(newDraftMetadataFields),
   querySchema: z.never(),
-  responseSchema: revisionResponse,
+  responseSchema: revisionResponseWithWarnings,
   version: "v2" as const,
 };
 

--- a/packages/shared/src/validators/ramp-schedule.ts
+++ b/packages/shared/src/validators/ramp-schedule.ts
@@ -377,10 +377,22 @@ export const rampScheduleTemplateValidator = baseSchema.extend({
   official: z.boolean().optional(),
   lockdownConfig: lockdownConfigSchema.optional(),
   monitoringConfig: rampMonitoringConfig.nullish(),
+  // Manual display/priority order within the org. Lower sorts first; the first
+  // official template in this order is used as the editor default.
+  order: z.number(),
 });
 export type RampScheduleTemplateInterface = z.infer<
   typeof rampScheduleTemplateValidator
 >;
+
+// Body for reordering templates: move `oldId` to the slot currently held by
+// `newId` (mirrors the custom-fields reorder contract).
+export const reorderRampScheduleTemplatesValidator = z
+  .object({
+    oldId: z.string(),
+    newId: z.string(),
+  })
+  .strict();
 
 // Public API step shape. `interval` is the hold duration in seconds; `null`
 // means no time gate. Pure approval steps use
@@ -418,6 +430,11 @@ export const apiRampScheduleTemplateValidator = namedSchema(
     official: z.boolean().optional(),
     monitoringConfig: rampMonitoringConfig.nullish(),
     lockdownConfig: lockdownConfigSchema.nullish(),
+    order: z
+      .number()
+      .describe(
+        "Manual display order within the org (read-only; managed via the app).",
+      ),
   }),
 );
 

--- a/packages/shared/src/validators/ramp-schedule.ts
+++ b/packages/shared/src/validators/ramp-schedule.ts
@@ -27,6 +27,13 @@ export const featureRulePatch = z.object({
 });
 export type FeatureRulePatch = z.infer<typeof featureRulePatch>;
 
+// The rule's pre-ramp state, used purely as the rollback/jump-to-start anchor.
+// It is NOT applied when the ramp starts — step 0's coverage takes over
+// immediately on start. A partial patch is merged onto the rule's current
+// state, so `{ coverage: 0 }` keeps existing targeting but rolls back to 0%.
+export const rampStartState = featureRulePatch.omit({ ruleId: true });
+export type RampStartState = z.infer<typeof rampStartState>;
+
 export const lockdownModeArray = ["none", "locked"] as const;
 export type LockdownMode = (typeof lockdownModeArray)[number];
 


### PR DESCRIPTION


**Default template in the rule editor.** Creating a ramp on a feature rule now pre-selects a default template (the first official one) matching the rule's release strategy — a plain template for a standard Ramp-up, a monitored template for a Monitored Ramp-up. Previously it always defaulted to "None", even when official templates existed.

**Reorderable templates.** Org Settings → Features → Ramp Schedule Templates now supports drag-and-drop and a move up/down menu. The order is persisted and determines which official template becomes the editor default.

**Rollback to 0% over REST.** Attaching a ramp via the v2 feature-revision endpoint now accepts an optional `startState` (the rollback anchor), so callers can pin rollbacks to 0% with `{ "coverage": 0 }` regardless of the rule's current coverage — mirroring the UI. When it's omitted on create, the anchor is still inferred from the rule's current coverage, but the response now returns a warning if that isn't 0% so the behavior is visible instead of silent. Works on create and update; affects rollbacks only, not ramp start.

## Notes
- Adds an `order` field to ramp schedule templates (back-filled to 0 on read; the first manual reorder assigns explicit values).
- `startState` is added to the v2 endpoint only; v1 is unchanged. OpenAPI spec regenerated.

<img width="1319" height="536" alt="image" src="https://github.com/user-attachments/assets/cc9ab65a-fe64-41ea-a061-dc6c21253c83" />

<img width="823" height="947" alt="image" src="https://github.com/user-attachments/assets/e07dd3d8-90b6-424f-95da-754a13373c38" />
