### PR TITLE
perf(api): avoid loading all saved-group values on list pagination

### DIFF
--- a/packages/back-end/src/api/saved-groups/listSavedGroups.ts
+++ b/packages/back-end/src/api/saved-groups/listSavedGroups.ts
@@ -8,19 +8,29 @@ import {
 export const listSavedGroups = createApiRequestHandler(
   listSavedGroupsValidator,
 )(async (req) => {
-  const savedGroups = await req.context.models.savedGroups.getAll();
+  // `values` arrays are unbounded, so fetch the full list without them for
+  // pagination/total/read-permission filtering, then hydrate just the page.
+  const allWithoutValues =
+    await req.context.models.savedGroups.getAllWithoutValues();
 
-  // TODO: Move sorting/limiting to the database query for better performance
   const { filtered, returnFields } = applyPagination(
-    savedGroups.sort((a, b) => a.id.localeCompare(b.id)),
+    allWithoutValues.sort((a, b) => a.id.localeCompare(b.id)),
     req.query,
   );
 
+  const page = await req.context.models.savedGroups.getByIds(
+    filtered.map((g) => g.id),
+  );
+  const byId = new Map(page.map((g) => [g.id, g]));
+
   return {
     savedGroups: await resolveOwnerEmails(
-      filtered.map((savedGroup) =>
-        req.context.models.savedGroups.toApiInterface(savedGroup),
-      ),
+      filtered.flatMap((g) => {
+        const full = byId.get(g.id);
+        return full
+          ? [req.context.models.savedGroups.toApiInterface(full)]
+          : [];
+      }),
       req.context,
     ),
     ...returnFields,


### PR DESCRIPTION
### Features and Changes

`GET /api/v1/saved-groups` currently loads every saved group — including the full `values` array — on each page request, then sorts and paginates in memory. For organizations with many saved groups and large ID-list groups, a client paging through the list triggers one full-collection read per page.

This change fetches the list without `values` (via the existing `getAllWithoutValues()`) for sorting, read-permission filtering, and computing `total`, then re-fetches full docs for just the returned page (≤ `limit` docs) via `getByIds()`. The response shape is unchanged.

DB-level skip/limit is not used because `BaseModel._find` applies `filterByReadPermissions` after the fetch, so cursor-level pagination would give incorrect page boundaries for project-restricted users.

### Dependencies

None.

### Testing

- `pnpm --filter back-end type-check`
- ESLint on the changed file
- Manual: started a local back-end against a fresh MongoDB, seeded saved groups (mix of `list` and `condition` types), and verified `GET /api/v1/saved-groups` with `?limit=2&offset=0/2/4/10` returns the same shape as before — `values` and `condition` populated, `ownerEmail` resolved, `count`/`total`/`hasMore`/`nextOffset` correct, empty page past the end returns `[]`.