### PR TITLE
perf(back-end): scope snapshot chunk hydration to the requested metric in /metrics/:id/experiments

### DIFF
--- a/packages/back-end/src/controllers/metrics.ts
+++ b/packages/back-end/src/controllers/metrics.ts
@@ -537,7 +537,9 @@ export const getMetricExperimentResults = async (
     limit: 500,
   });
 
-  const snapshots = await _getSnapshots(context, experiments);
+  const snapshots = await _getSnapshots(context, experiments, undefined, true, [
+    req.params.id,
+  ]);
 
   // TODO simplify data for front-end?
   const data = experiments.map((e) => ({

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -294,16 +294,19 @@ function getAnalysisIndexBySettings(
 async function populateSnapshotAnalyses(
   context: Context,
   snapshot: ExperimentSnapshotInterface,
+  metricIds?: string[],
 ): Promise<ExperimentSnapshotInterface>;
 async function populateSnapshotAnalyses(
   context: Context,
   snapshots: ExperimentSnapshotInterface[],
+  metricIds?: string[],
 ): Promise<ExperimentSnapshotInterface[]>;
 async function populateSnapshotAnalyses(
   context: Context,
   snapshotOrSnapshots:
     | ExperimentSnapshotInterface
     | ExperimentSnapshotInterface[],
+  metricIds?: string[],
 ): Promise<ExperimentSnapshotInterface | ExperimentSnapshotInterface[]> {
   const snapshots = Array.isArray(snapshotOrSnapshots)
     ? snapshotOrSnapshots
@@ -311,6 +314,7 @@ async function populateSnapshotAnalyses(
 
   await context.models.experimentSnapshotAnalysisChunks.populateChunkedAnalyses(
     snapshots,
+    metricIds,
   );
   return snapshotOrSnapshots;
 }
@@ -1133,6 +1137,7 @@ export async function getLatestSnapshotMultipleExperiments(
   experimentPhaseMap: Map<string, number>,
   dimension?: string,
   withResults: boolean = true,
+  metricIds?: string[],
 ): Promise<ExperimentSnapshotInterface[]> {
   const experimentPhasesToGet = new Map(experimentPhaseMap);
   const query: FilterQuery<ExperimentSnapshotDocument> = {
@@ -1187,7 +1192,7 @@ export async function getLatestSnapshotMultipleExperiments(
     });
   }
 
-  return populateSnapshotAnalyses(context, snapshots);
+  return populateSnapshotAnalyses(context, snapshots, metricIds);
 }
 
 export async function createExperimentSnapshotModel({

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -1137,7 +1137,7 @@ export async function getLatestSnapshotMultipleExperiments(
   experimentPhaseMap: Map<string, number>,
   dimension?: string,
   withResults: boolean = true,
-  metricIds?: string[],
+  hydrateMetricIds?: string[],
 ): Promise<ExperimentSnapshotInterface[]> {
   const experimentPhasesToGet = new Map(experimentPhaseMap);
   const query: FilterQuery<ExperimentSnapshotDocument> = {
@@ -1192,7 +1192,7 @@ export async function getLatestSnapshotMultipleExperiments(
     });
   }
 
-  return populateSnapshotAnalyses(context, snapshots, metricIds);
+  return populateSnapshotAnalyses(context, snapshots, hydrateMetricIds);
 }
 
 export async function createExperimentSnapshotModel({

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2235,7 +2235,7 @@ export async function _getSnapshots(
   experimentObjs: ExperimentInterface[],
   dimension?: string,
   withResults: boolean = true,
-  metricIds?: string[],
+  hydrateMetricIds?: string[],
 ): Promise<ExperimentSnapshotInterface[]> {
   const experimentPhaseMap: Map<string, number> = new Map();
   experimentObjs.forEach((e) => {
@@ -2250,7 +2250,7 @@ export async function _getSnapshots(
     experimentPhaseMap,
     dimension,
     withResults,
-    metricIds,
+    hydrateMetricIds,
   );
 }
 

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2235,6 +2235,7 @@ export async function _getSnapshots(
   experimentObjs: ExperimentInterface[],
   dimension?: string,
   withResults: boolean = true,
+  metricIds?: string[],
 ): Promise<ExperimentSnapshotInterface[]> {
   const experimentPhaseMap: Map<string, number> = new Map();
   experimentObjs.forEach((e) => {
@@ -2249,6 +2250,7 @@ export async function _getSnapshots(
     experimentPhaseMap,
     dimension,
     withResults,
+    metricIds,
   );
 }
 


### PR DESCRIPTION
### Features and Changes

`GET /metrics/:id/experiments` (`getMetricExperimentResults`) loads the latest snapshot for every experiment that uses the metric, then hydrates analysis-result chunks for **every metric** in each of those snapshots via `populateSnapshotAnalyses`. The only front-end consumer (`MetricExperiments.tsx`) reads `snapshot.analyses[0].results[0].variations[*].metrics[<requested metric id>]` — results for other metrics are never used.

`populateChunkedAnalyses` already accepts an optional `metricIds` filter (backed by the `{snapshotId, metricId}` compound index). This change threads that filter through `_getSnapshots` → `getLatestSnapshotMultipleExperiments` → `populateSnapshotAnalyses` and passes `[req.params.id]` from the controller. For organizations where a popular metric is used across many experiments with many metrics each, this loads one chunk per snapshot instead of N.

Other callers of `_getSnapshots` / `getLatestSnapshotMultipleExperiments` / `populateSnapshotAnalyses` omit the new optional parameter and keep current behavior. Snapshots with inline (non-chunked) analyses are unaffected — `populateChunkedAnalyses` skips them and the inline results are returned as-is.

### Dependencies

None.

### Testing

- `pnpm --filter back-end type-check`
- ESLint on the changed files
- Manual: started a local back-end against a fresh MongoDB, seeded experiments referencing a test metric via `goalMetrics`/`guardrailMetrics` plus an unrelated experiment, and an inline snapshot. Verified `GET /metrics/<id>/experiments` returns the matching experiments with the snapshot attached, the unrelated experiment is excluded, and an unknown metric returns `data: []`.

### Notes

The `_getSnapshots(context, experiments, undefined, true, [...])` call site adds a fifth positional optional. Folding the trailing optionals into an options object would be a natural follow-up but is kept out of this change to keep the diff minimal.