### PR TITLE
Regenerate openapi spec

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -10062,6 +10062,7 @@ paths:
               additionalProperties: false
       responses:
         '200':
+          description: Resource created
           content:
             application/json:
               schema:


### PR DESCRIPTION
### Features and Changes

Regenerates the api spec as #6141 was out of date with `main` and missed adding a description to one new route