### PR TITLE
fix(sdk-js): resolve nested attribute keys as experiment hash attributes

### DIFF
--- a/packages/sdk-js/src/core.ts
+++ b/packages/sdk-js/src/core.ts
@@ -941,7 +941,10 @@ function resolveAttribute(
   attributes: Record<string, any>,
   key: string,
 ) {
-  if (attributes[key]) return attributes[key];
+  // Prefer a literal key (so a key that itself contains a dot still works), checking presence
+  // rather than truthiness so a literal falsy value is honored and not overridden by a nested path.
+  if (Object.prototype.hasOwnProperty.call(attributes, key))
+    return attributes[key];
   return getPath(attributes, key) ?? "";
 }
 

--- a/packages/sdk-js/src/core.ts
+++ b/packages/sdk-js/src/core.ts
@@ -16,7 +16,7 @@ import {
   Options,
   ClientOptions,
 } from "./types/growthbook";
-import { evalCondition } from "./mongrule";
+import { evalCondition, getPath } from "./mongrule";
 import { ConditionInterface } from "./types/mongrule";
 import {
   chooseVariation,
@@ -933,6 +933,18 @@ function mergeOverrides<T>(
   return experiment;
 }
 
+// Resolve an attribute by its literal key, falling back to dot-notation so
+// nested attributes (e.g. "user.id" -> { user: { id } }) can be used as the
+// hash attribute. A literal key containing a dot keeps taking precedence.
+function resolveAttribute(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  attributes: Record<string, any>,
+  key: string,
+) {
+  if (attributes[key]) return attributes[key];
+  return getPath(attributes, key) ?? "";
+}
+
 export function getHashAttribute(
   ctx: EvalContext,
   attr?: string,
@@ -944,15 +956,13 @@ export function getHashAttribute(
 
   const attributes = getAttributes(ctx);
 
-  if (attributes[hashAttribute]) {
-    hashValue = attributes[hashAttribute];
-  }
+  // Try the literal key first (so a key that contains a dot still works), then
+  // fall back to dot-notation to resolve nested attributes (e.g. "user.id")
+  hashValue = resolveAttribute(attributes, hashAttribute);
 
   // if no match, try fallback
   if (!hashValue && fallback) {
-    if (attributes[fallback]) {
-      hashValue = attributes[fallback];
-    }
+    hashValue = resolveAttribute(attributes, fallback);
     if (hashValue) {
       hashAttribute = fallback;
     }

--- a/packages/sdk-js/src/mongrule.ts
+++ b/packages/sdk-js/src/mongrule.ts
@@ -46,7 +46,7 @@ export function evalCondition(
 }
 
 // Return value at dot-separated path of an object
-function getPath(obj: TestedObj, path: string) {
+export function getPath(obj: TestedObj, path: string) {
   const parts = path.split(".");
   let current: any = obj;
   for (let i = 0; i < parts.length; i++) {

--- a/packages/sdk-js/test/experiments.test.ts
+++ b/packages/sdk-js/test/experiments.test.ts
@@ -879,4 +879,69 @@ describe("experiments", () => {
 
     gb2.destroy();
   });
+
+  it("resolves a nested attribute used as the hash attribute (#4432)", () => {
+    const exp: Experiment<number> = {
+      key: "my-test",
+      hashAttribute: "user.id",
+      variations: [0, 1],
+    };
+
+    // Nested attribute should resolve via dot notation
+    const nested = new GrowthBook({
+      attributes: { user: { id: "1" } },
+    });
+    const nestedRes = nested.run(exp);
+
+    // A flat attribute of the same name should produce the same assignment
+    const flat = new GrowthBook({
+      attributes: { "user.id": "1" },
+    });
+    const flatRes = flat.run({ ...exp });
+
+    expect(nestedRes.inExperiment).toEqual(true);
+    expect(nestedRes.hashUsed).toEqual(true);
+    expect(nestedRes.hashValue).toEqual("1");
+    expect(nestedRes.variationId).toEqual(flatRes.variationId);
+
+    nested.destroy();
+    flat.destroy();
+  });
+
+  it("prefers a literal dotted key over the nested path", () => {
+    // A real attribute key that literally contains a dot must still win
+    const gb = new GrowthBook({
+      attributes: {
+        "user.id": "literal",
+        user: { id: "nested" },
+      },
+    });
+
+    const res = gb.run({
+      key: "my-test",
+      hashAttribute: "user.id",
+      variations: [0, 1],
+    });
+
+    expect(res.hashValue).toEqual("literal");
+
+    gb.destroy();
+  });
+
+  it("does not hash when a nested hash attribute is missing", () => {
+    const gb = new GrowthBook({
+      attributes: { user: { email: "test@example.com" } },
+    });
+
+    const res = gb.run({
+      key: "my-test",
+      hashAttribute: "user.id",
+      variations: [0, 1],
+    });
+
+    expect(res.inExperiment).toEqual(false);
+    expect(res.hashUsed).toEqual(false);
+
+    gb.destroy();
+  });
 });

--- a/packages/sdk-js/test/experiments.test.ts
+++ b/packages/sdk-js/test/experiments.test.ts
@@ -928,6 +928,28 @@ describe("experiments", () => {
     gb.destroy();
   });
 
+  it("honors a falsy literal dotted key instead of falling through to the nested path", () => {
+    // A literal key that is present but falsy means "no value", and must not be
+    // silently overridden by a same-named nested path.
+    const gb = new GrowthBook({
+      attributes: {
+        "user.id": 0,
+        user: { id: "nested" },
+      },
+    });
+
+    const res = gb.run({
+      key: "my-test",
+      hashAttribute: "user.id",
+      variations: [0, 1],
+    });
+
+    expect(res.inExperiment).toEqual(false);
+    expect(res.hashUsed).toEqual(false);
+
+    gb.destroy();
+  });
+
   it("does not hash when a nested hash attribute is missing", () => {
     const gb = new GrowthBook({
       attributes: { user: { email: "test@example.com" } },


### PR DESCRIPTION
## What

Lets a nested attribute be used as the experiment hash attribute via dot notation, e.g. `hashAttribute: "user.id"` against `{ user: { id: "..." } }`.

Closes #4432

## Why

The SDK already supports nested attributes and you can target them with dot notation in conditions:

```json
{ "user.email": { "$eq": "test@example.com" } }
```

But `getHashAttribute` in `packages/sdk-js/src/core.ts` did a flat `attributes[hashAttribute]` lookup, so a dotted key like `user.id` never resolved when the attributes were nested. The value fell through to the empty-hash path and the experiment was skipped.

## How

The repo already has the right primitive: `getPath()` in `packages/sdk-js/src/mongrule.ts` resolves dot-separated paths, and targeting conditions use it. Rather than write a second resolver, I exported `getPath` and reused it.

`getHashAttribute` now resolves the hash attribute (and the fallback attribute) with a small `resolveAttribute` helper that:

1. tries the literal key first, so an attribute key that literally contains a dot keeps working (backward compatible),
2. then falls back to dot notation to resolve a nested attribute,
3. still yields an empty hash value when the attribute is missing (unchanged behavior, so missing-attribute experiments are still skipped).

No new dependency, and the zero-dependency SDK boundary is respected.

## How tested

Added regression tests in `packages/sdk-js/test/experiments.test.ts`:

- a nested attribute (`user.id`) resolves and produces the same assignment as the equivalent flat `"user.id"` key,
- a literal dotted key still takes precedence over the nested path,
- a missing nested hash attribute still skips the experiment.

The nested-resolution test fails on `main` and passes with this change. The existing fallback-attribute coverage in `sticky-buckets.test.ts` exercises the same `resolveAttribute` path and still passes.

```
Test Suites: 15 passed, 15 total
Tests:       679 passed, 679 total
```

Also ran type-check (`tsgo`), ESLint, and Prettier on the changed files, all clean. Verified on Node v24.16.0 (repo requires Node >=24).
