### PR TITLE
fix(preview): create Fly app before pushing preview image

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -67,7 +67,9 @@ jobs:
         if: ${{ github.event.action != 'closed' }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-        run: flyctl apps create "${{ env.APP_NAME }}" --org growthbook || true
+        run: |
+          flyctl apps create "${{ env.APP_NAME }}" --org growthbook || \
+            flyctl apps list | grep -qw "${{ env.APP_NAME }}"
 
       - name: Build and push preview image
         if: ${{ github.event.action != 'closed' }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -61,6 +61,14 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: flyctl auth docker
 
+      # The image push below targets registry.fly.io/<app>, which 404s if the
+      # app doesn't exist yet. Pre-create it so the first push on a new PR works.
+      - name: Ensure Fly app exists
+        if: ${{ github.event.action != 'closed' }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl apps create "${{ env.APP_NAME }}" --org growthbook || true
+
       - name: Build and push preview image
         if: ${{ github.event.action != 'closed' }}
         uses: depot/build-push-action@v1


### PR DESCRIPTION
### Features and Changes

The PR preview workflow has been broken for every newly-opened PR since #6092 merged.

#6092 split the preview build into a CI-side Depot build that pushes the image to `registry.fly.io/<app>` *before* the `superfly/fly-pr-review-apps` deploy step runs. But that deploy step is what creates the Fly app — and pushing to `registry.fly.io/<app>` returns `404 Not Found` on `blobs/uploads/` when the app doesn't exist yet:

```
Error: failed to solve: failed to push registry.fly.io/pr-<n>-growthbook:<sha>:
unexpected status from POST request to .../v2/pr-<n>-growthbook/blobs/uploads/: 404 Not Found
```

Existing PRs kept working because their app was created under the old workflow (where `fly-pr-review-apps` built on Fly's remote builder and created the app first). Any PR opened *after* #6092 has no app yet, so the very first push 404s and the deploy step never runs to create it.

This adds an idempotent `flyctl apps create` step before the push so the registry repo exists. `fly-pr-review-apps` then deploys into the existing app as normal.

Surfaced by #6171, the first PR opened after #6092 merged.
