### PR TITLE
Fix: use Mixpanel's current /api/query/jql endpoint

### DIFF
--- a/packages/back-end/src/services/mixpanel.ts
+++ b/packages/back-end/src/services/mixpanel.ts
@@ -57,7 +57,7 @@ export async function runQuery<T extends MixpanelResultRow>(
   const apiBase =
     conn.server === "eu" ? "eu.mixpanel.com/api" : "mixpanel.com/api";
 
-  const url = `https://${apiBase}/2.0/jql`;
+  const url = `https://${apiBase}/query/jql`;
 
   const options = {
     method: "POST",

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -313,6 +313,16 @@ const DataSourcePage: FC = () => {
           </Flex>
         )}
       </Flex>
+      {d.type === "mixpanel" && (
+        <Callout status="warning" mt="3">
+          Using Mixpanel as a direct data source is deprecated and no longer
+          supported, because Mixpanel has placed their query language (JQL) in
+          maintenance mode. To keep using Mixpanel data in GrowthBook, export it
+          to a data warehouse (e.g. BigQuery or Snowflake) and connect that
+          warehouse instead.{" "}
+          <DocLink docSection="mixpanel">View migration guide</DocLink>
+        </Callout>
+      )}
       <Flex align="center" gap="4" my="2">
         <Text color="text-mid">
           <Text weight="medium">Type:</Text>{" "}

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -320,7 +320,9 @@ const DataSourcePage: FC = () => {
           maintenance mode. To keep using Mixpanel data in GrowthBook, export it
           to a data warehouse (e.g. BigQuery or Snowflake) and connect that
           warehouse instead.{" "}
-          <DocLink docSection="mixpanel">View migration guide</DocLink>
+          <DocLink docSection="mixpanel" useRadix>
+            View migration guide
+          </DocLink>
         </Callout>
       )}
       <Flex align="center" gap="4" my="2">


### PR DESCRIPTION
### Features and Changes

Customers using Mixpanel as a direct data source are seeing `Error Processing Query Results: Invalid response body... Premature close` on JQL queries (Sentry: intermittent since ~Jan 2026, climbing sharply around Apr 12, 2026).

- **Align the JQL endpoint to Mixpanel's documented path.** The integration POSTs to the legacy `https://{domain}/api/2.0/jql`; Mixpanel's docs have specified `/api/query/jql` since their Sept 2023 docs sync ([`b35f6ab9`](https://github.com/mixpanel/docs/commit/b35f6ab9)). This switches to the documented path. Region domain logic, auth, headers, and body are unchanged.
- **Surface the deprecation in-app.** Using Mixpanel as a direct data source is [already deprecated in our docs](https://docs.growthbook.io/guide/mixpanel) (JQL is in maintenance mode at Mixpanel), but the warning lived only in the docs. This adds a warning `Callout` on Mixpanel data source pages linking to the warehouse-export migration guide.

:warning: **This endpoint change is documentation-alignment / future-proofing, not a confirmed fix for "Premature close."** Probing both paths with `curl` (EU + US) shows they return identical responses with byte-for-byte identical infra headers (`HTTP/2`, `server: nginx`, `via: 1.1 google`, matching `x-server-elapsed`) — i.e. `/api/2.0/jql` is a live alias hitting the same backend as `/api/query/jql`, not a retired route. "Premature close" is a *post-authentication, mid-response* truncation that only occurs on a real authenticated query returning data. The most likely root cause is degradation of Mixpanel's JQL backend itself (consistent with maintenance mode and the gradual error ramp), which would affect both paths equally — meaning this path swap may not resolve the incident.

**The real remediation for affected orgs is migrating to a warehouse export** (the in-app callout above), not a client-side endpoint change. We keep the endpoint alignment regardless because it matches the vendor docs and gets us ahead of any future hard-retirement of the legacy alias.

### Testing

- [x] Authenticated smoke test against a Mixpanel project (US), both paths. Service-account credentials are accepted on both `/api/2.0/jql` and `/api/query/jql`, returning identical responses — endpoint alignment is confirmed safe (new path authenticates and routes correctly; US auth not broken). Query execution could not be exercised: the test org's free plan returns `402 "Your plan does not allow API calls"` before any query runs, so the post-execution "Premature close" failure can't be reproduced without a paid plan. Efficacy of the path change for the reported error therefore remains unverified by design — see the warning above.
- [ ] Open a Mixpanel data source page and confirm the deprecation callout renders with a working (styled) link to the migration guide.
