### PR TITLE
Fix: project-level role takes precedence over global role when merging team permissions

### DIFF
--- a/docs/docs/account/user-permissions.mdx
+++ b/docs/docs/account/user-permissions.mdx
@@ -108,7 +108,12 @@ In the event you want a user to have access to a subset of projects, you can giv
 
 If, however, you only want to hide a certain project from a user, you can assign their project-level role of `No Access` which will make it so the user isn't able to view the project.
 
-If you need to apply these rules to many users as once, you can create a Team with the permissions needed, and then add users to that team. But, keep in mind, the user's permissions will be a combination of their user permissions, and the permissions of any team they are on, so after adding the user to a team, you may want to reduce their user-level permissions to ensure their previous user-level permissions don't override the permissions inherited by the team(s) they are on.
+If you need to apply these rules to many users at once, you can create a Team with the permissions needed, and then add users to that team. Keep in mind how project-level and global roles combine when a user is on one or more teams:
+
+- For a project where the user (or any team they are on) has an **explicit** project-level role, their access to that project is the union of those explicit project-level roles. Global roles are **not** used for that project.
+- For a project where no explicit project-level role applies, the user's global role (merged with their teams' global roles) is used instead.
+
+So to hide a specific project from a user, make sure no explicit project-level role grants them access to it: set their own project-level role for that project to `No Access`, and do the same for any team they are on that would otherwise grant access to it.
 
 ### How does the Project Admin role work?
 

--- a/packages/back-end/src/util/organization.util.ts
+++ b/packages/back-end/src/util/organization.util.ts
@@ -160,21 +160,19 @@ function mergeUserAndTeamPermissions(
     ...Object.keys(teamPermissions.projects),
   ]);
 
-  // Loop through that list of projects and merge the user and team permissions
+  // Loop through that list of projects and merge the user and team permissions.
+  // An explicitly-set project role takes precedence over a global role, so a
+  // principal with no project role contributes nothing (not its global role)
+  // rather than letting its global permissions leak into the project.
+  const noProjectRole = (): UserPermission => ({
+    limitAccessByEnvironment: false,
+    environments: [],
+    permissions: {},
+  });
   allProjects.forEach((project) => {
     userPermissions.projects[project] = mergeUserPermissionObj(
-      userPermissions.projects[project] || {
-        limitAccessByEnvironment:
-          userPermissions.global.limitAccessByEnvironment,
-        environments: userPermissions.global.environments,
-        permissions: userPermissions.global.permissions,
-      },
-      teamPermissions.projects[project] || {
-        limitAccessByEnvironment:
-          teamPermissions.global.limitAccessByEnvironment,
-        environments: teamPermissions.global.environments,
-        permissions: teamPermissions.global.permissions,
-      },
+      userPermissions.projects[project] || noProjectRole(),
+      teamPermissions.projects[project] || noProjectRole(),
       org,
     );
   });

--- a/packages/back-end/test/permissions.test.ts
+++ b/packages/back-end/test/permissions.test.ts
@@ -533,6 +533,199 @@ describe("Build base user permissions", () => {
     });
   });
 
+  it("should let an explicit project-level noaccess role take precedence over a team's global role (project role isn't widened by team global)", async () => {
+    const teams: TeamInterface[] = [
+      {
+        id: "team_123",
+        name: "SCIM Group",
+        organization: "org_id_1234",
+        description: "",
+        dateCreated: new Date(),
+        dateUpdated: new Date(),
+        createdBy: "idp",
+        role: "readonly",
+        limitAccessByEnvironment: false,
+        environments: [],
+        projectRoles: [],
+        managedByIdp: true,
+      },
+    ];
+
+    const userPermissions = getUserPermissions(
+      { id: "base_user_123" },
+      {
+        ...testOrg,
+        members: [
+          {
+            ...testOrg.members[0],
+            role: "readonly",
+            projectRoles: [
+              {
+                project: "prj_hidden",
+                role: "noaccess",
+                limitAccessByEnvironment: false,
+                environments: [],
+              },
+            ],
+            teams: ["team_123"],
+          },
+        ],
+      },
+      teams,
+    );
+
+    expect(userPermissions).toEqual({
+      global: {
+        environments: [],
+        limitAccessByEnvironment: false,
+        permissions: roleToPermissionMap("readonly", testOrg),
+      },
+      projects: {
+        prj_hidden: {
+          environments: [],
+          limitAccessByEnvironment: false,
+          permissions: roleToPermissionMap("noaccess", testOrg),
+        },
+      },
+    });
+
+    const permissions = new Permissions(userPermissions);
+    expect(permissions.canReadSingleProjectResource("prj_hidden")).toEqual(
+      false,
+    );
+  });
+
+  it("should let an explicit team project role take precedence over the user's global role", async () => {
+    const teams: TeamInterface[] = [
+      {
+        id: "team_123",
+        name: "Restricted Project Team",
+        organization: "org_id_1234",
+        description: "",
+        dateCreated: new Date(),
+        dateUpdated: new Date(),
+        createdBy: "Demo User",
+        role: "noaccess",
+        limitAccessByEnvironment: false,
+        environments: [],
+        projectRoles: [
+          {
+            project: "prj_restricted",
+            role: "noaccess",
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        ],
+        managedByIdp: false,
+      },
+    ];
+
+    const userPermissions = getUserPermissions(
+      { id: "base_user_123" },
+      {
+        ...testOrg,
+        members: [
+          {
+            ...testOrg.members[0],
+            role: "engineer",
+            projectRoles: [],
+            teams: ["team_123"],
+          },
+        ],
+      },
+      teams,
+    );
+
+    expect(userPermissions).toEqual({
+      global: {
+        environments: [],
+        limitAccessByEnvironment: false,
+        permissions: roleToPermissionMap("engineer", testOrg),
+      },
+      projects: {
+        prj_restricted: {
+          environments: [],
+          limitAccessByEnvironment: false,
+          permissions: roleToPermissionMap("noaccess", testOrg),
+        },
+      },
+    });
+
+    const permissions = new Permissions(userPermissions);
+    expect(permissions.canReadSingleProjectResource("prj_restricted")).toEqual(
+      false,
+    );
+  });
+
+  it("should union a user's explicit project role with a team's explicit project role (a user-level noaccess does not block a team's explicit grant on the same project)", async () => {
+    const teams: TeamInterface[] = [
+      {
+        id: "team_123",
+        name: "Project Engineers",
+        organization: "org_id_1234",
+        description: "",
+        dateCreated: new Date(),
+        dateUpdated: new Date(),
+        createdBy: "Demo User",
+        role: "noaccess",
+        limitAccessByEnvironment: false,
+        environments: [],
+        projectRoles: [
+          {
+            project: "prj_shared",
+            role: "engineer",
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        ],
+        managedByIdp: false,
+      },
+    ];
+
+    const userPermissions = getUserPermissions(
+      { id: "base_user_123" },
+      {
+        ...testOrg,
+        members: [
+          {
+            ...testOrg.members[0],
+            role: "readonly",
+            projectRoles: [
+              {
+                project: "prj_shared",
+                role: "noaccess",
+                limitAccessByEnvironment: false,
+                environments: [],
+              },
+            ],
+            teams: ["team_123"],
+          },
+        ],
+      },
+      teams,
+    );
+
+    expect(userPermissions).toEqual({
+      global: {
+        environments: [],
+        limitAccessByEnvironment: false,
+        permissions: roleToPermissionMap("readonly", testOrg),
+      },
+      projects: {
+        prj_shared: {
+          environments: [],
+          limitAccessByEnvironment: false,
+          permissions: roleToPermissionMap("engineer", testOrg),
+        },
+      },
+    });
+
+    const permissions = new Permissions(userPermissions);
+    expect(permissions.canReadSingleProjectResource("prj_shared")).toEqual(
+      true,
+    );
+  });
+
   it("should not override a user's global permissions with a team's permissions if the user has a more permissive role (e.g. don't override admin permissions with collaborator permissions", async () => {
     const teams: TeamInterface[] = [
       {


### PR DESCRIPTION
### Features and Changes

When building a member's effective permissions, `mergeUserAndTeamPermissions` merged each project across the user and every team they're on. For a project where a principal (the user, or one of their teams) had **no explicit project role**, that principal fell back to its **global** role. Since permissions merge as a union, this let a global role leak into a project where another principal had set an explicit project-scoped role — defeating the documented "project role overrides global" behavior.

The most visible symptom: a user given a project-scoped `No Access` could still see the project if they were on any team whose global role granted read. This is common with SCIM, where groups provision users onto teams, which is why it reproduced for customers on SSO/SCIM but not in local single-user testing.

The fix changes only the fallback used when an explicit project-scoped role is missing — from the principal's global role to nothing:

```
// before
merge(user.projects[p] || user.global, team.projects[p] || team.global)
// after
merge(user.projects[p] || undefined, team.projects[p] || undefined)
```

So a project's effective permissions are now the union of the **explicit** project-scoped roles that apply (the user's own + any team's), and global roles are only consulted for projects where no explicit project-scoped role exists.

:warning: This is a behavior change that can **reduce** access. Anyone who currently reaches a project *only* because a global role (their own or a team's) leaked past an explicit project role will lose that access once this ships. Worth understanding precisely, since it's easy to get wrong:

- A user's project-scoped `No Access` is **no longer widened by a team's global role** — so it now actually hides the project in that case.
- But project-scoped roles still **union across the user and all their teams**. A user-level `No Access` on a project does **not** block access if the same user has an explicit grant on that project from their own settings or from a team. To hide a project from a user, ensure no explicit project-scoped role grants them access to it (set it to `No Access` for the user and for any team that would otherwise grant it).
- Conversely, a team that sets an explicit project `No Access` no longer has that overridden by the user's global role.

Docs updated in `account/user-permissions.mdx` to describe the new merge precisely (the previous wording described the old additive-global behavior).

Cloud impact has been audited; a small number of organizations relying on the previous fallback behavior are being identified and contacted directly so they can adjust project roles before this ships. Self-hosted: call out in release notes.

### Testing

- [x] `pnpm --filter back-end test test/permissions.test.ts` — 242 pass, incl. new regression tests
- [x] User with global `readonly` + project-scoped `No Access` + on a team with global `readonly` and no project roles -> cannot read the project
- [x] User with global `engineer` + on a team that sets an explicit project `No Access` -> cannot read that project
- [x] User with project-scoped `No Access` + on a team with an explicit `engineer` role on that same project -> **can** read it (project roles union)
- [x] Existing team/project merge cases (project role more permissive than team global) -> unchanged
