### PR TITLE
fix(sql): stop misflagging backslash string literals as multi-statement queries

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -21,6 +21,7 @@ import {
   format,
   isMultiStatementSQL,
   SQL_ROW_LIMIT,
+  usesBackslashStringEscapes,
 } from "shared/sql";
 import { TemplateVariables, SqlDialect } from "shared/types/sql";
 import {
@@ -228,7 +229,12 @@ export default abstract class SqlIntegration
       setExternalId?: ExternalIdCallback,
       metadata?: QueryMetadata,
     ) => {
-      if (isMultiStatementSQL(sql)) {
+      if (
+        isMultiStatementSQL(
+          sql,
+          usesBackslashStringEscapes(this.getSqlDialect()),
+        )
+      ) {
         throw new Error("Multi-statement queries are not supported");
       }
       metadata = {

--- a/packages/shared/src/sql.ts
+++ b/packages/shared/src/sql.ts
@@ -135,17 +135,14 @@ export function isMultiStatementSQL(sql: string, backslashEscapes: boolean) {
     backslashEscapes,
   );
   if (parseError) {
-    // Ignore a final trailing semicolon to avoid a common false positive
-    return stripSQLComments(sql).replace(/;\s*$/, "").includes(";");
+    // Parse failed, so string boundaries are unknown. Stay conservative and
+    // treat any non-trailing semicolon as a statement separator.
+    return sql.replace(/;\s*$/, "").includes(";");
   }
   // Otherwise, search the stripped SQL for semicolons
   else {
     return strippedSql.includes(";");
   }
-}
-
-function stripSQLComments(sql: string): string {
-  return sql.replace(/\/\*[\s\S]*?\*\//g, "").replace(/--.*$/gm, "");
 }
 
 function stripCommentsAndStrings(

--- a/packages/shared/src/sql.ts
+++ b/packages/shared/src/sql.ts
@@ -1,6 +1,6 @@
 import { format as sqlFormat } from "sql-formatter";
 import { SqlResultChunkInterface } from "../types/query";
-import { FormatDialect, StringMatchFn } from "../types/sql";
+import { FormatDialect, SqlDialect, StringMatchFn } from "../types/sql";
 import { FormatError } from "../types/error";
 import { parseEnvInt } from "./util/numbers";
 
@@ -117,19 +117,26 @@ export function ensureLimit(sql: string, limit: number): string {
 }
 
 export function isReadOnlySQL(sql: string) {
-  const { strippedSql } = stripCommentsAndStrings(sql);
+  const { strippedSql } = stripCommentsAndStrings(sql, true);
 
   // Check the first keyword (e.g. "select", "with", etc.)
   return !!strippedSql.match(/^\s*(with|select|explain|show|describe|desc)\b/i);
 }
 
-export function isMultiStatementSQL(sql: string) {
-  const { strippedSql, parseError } = stripCommentsAndStrings(sql);
+export function usesBackslashStringEscapes(
+  dialect: Pick<SqlDialect, "escapeStringLiteral">,
+): boolean {
+  return dialect.escapeStringLiteral("\\") !== "\\";
+}
 
-  // If there was a parse error, search the original string for semicolons
+export function isMultiStatementSQL(sql: string, backslashEscapes: boolean) {
+  const { strippedSql, parseError } = stripCommentsAndStrings(
+    sql,
+    backslashEscapes,
+  );
   if (parseError) {
-    // Ignore final trailing semicolon when searching to avoid common false positive
-    return sql.replace(/;\s*$/, "").includes(";");
+    // Ignore a final trailing semicolon to avoid a common false positive
+    return stripSQLComments(sql).replace(/;\s*$/, "").includes(";");
   }
   // Otherwise, search the stripped SQL for semicolons
   else {
@@ -137,7 +144,14 @@ export function isMultiStatementSQL(sql: string) {
   }
 }
 
-function stripCommentsAndStrings(sql: string): {
+function stripSQLComments(sql: string): string {
+  return sql.replace(/\/\*[\s\S]*?\*\//g, "").replace(/--.*$/gm, "");
+}
+
+function stripCommentsAndStrings(
+  sql: string,
+  backslashEscapes: boolean,
+): {
   strippedSql: string;
   parseError: boolean;
 } {
@@ -158,7 +172,7 @@ function stripCommentsAndStrings(sql: string): {
     const nextChar = i + 1 < n ? sql[i + 1] : null;
 
     if (state === "singleQuote") {
-      if (char === "\\") {
+      if (backslashEscapes && char === "\\") {
         // Skip escaped character (e.g. \' or \\)
         i++;
       } else if (char === "'") {
@@ -166,7 +180,7 @@ function stripCommentsAndStrings(sql: string): {
         state = null;
       }
     } else if (state === "doubleQuote") {
-      if (char === "\\") {
+      if (backslashEscapes && char === "\\") {
         // Skip escaped character (e.g. \" or \\)
         i++;
       } else if (char === '"') {

--- a/packages/shared/test/sql.test.ts
+++ b/packages/shared/test/sql.test.ts
@@ -377,8 +377,15 @@ describe("isMultiStatementSQL — dialect-aware backslash escaping", () => {
     const sql = `SELECT * FROM t WHERE id LIKE 'a\\_b' ESCAPE '\\'`;
     expect(isMultiStatementSQL(sql, false)).toBe(false);
   });
-  it("allows a dimension query whose comment header contains a ';' plus ESCAPE", () => {
-    const sql = `-- Dimension: Platform; Fact Table: Sessions (trino)\nSELECT id FROM t WHERE x LIKE 'ab' ESCAPE '\\'`;
+  it("allows multi-line  query with a ';' in a comment and a backslash ESCAPE literal", () => {
+    const sql = `-- Dimension: Country (by user_id); Fact Table: Sessions (by user_id)
+WITH __rawExperiment AS (
+  SELECT timestamp, experiment_id, user_id
+  FROM "fake-database".sessions
+  WHERE timestamp >= timestamp '2026-05-26 19:00:00'
+    AND experiment_id LIKE replace('my-experiment-id-here', '_', '\\_') ESCAPE '\\'
+)
+SELECT timestamp, user_id FROM __rawExperiment;`;
     expect(isMultiStatementSQL(sql, false)).toBe(false);
   });
   it("still blocks a real statement separator on a non-backslash dialect", () => {
@@ -388,9 +395,9 @@ describe("isMultiStatementSQL — dialect-aware backslash escaping", () => {
     const sql = `SELECT 1 WHERE x = '\\'; DROP TABLE t; --'`;
     expect(isMultiStatementSQL(sql, false)).toBe(true);
   });
-  it("does not flag a comment semicolon when a parse error forces the fallback", () => {
-    const sql = `-- header with ; inside\nSELECT * FROM t WHERE x = 'unterminated`;
-    expect(isMultiStatementSQL(sql, false)).toBe(false);
+  it("blocks a real statement separator when a -- sits inside a string and the query ends mid-string", () => {
+    const sql = `SELECT '--'; DROP TABLE users; SELECT 'unterminated`;
+    expect(isMultiStatementSQL(sql, false)).toBe(true);
   });
   it("blocks a backslash-escaped-quote injection on a backslash dialect", () => {
     const sql = `SELECT 'It\\'s a test'; DROP TABLE users`;

--- a/packages/shared/test/sql.test.ts
+++ b/packages/shared/test/sql.test.ts
@@ -5,6 +5,7 @@ import {
   ensureLimit,
   isMultiStatementSQL,
   isReadOnlySQL,
+  usesBackslashStringEscapes,
 } from "../src/sql";
 
 describe("ensureLimit", () => {
@@ -265,12 +266,12 @@ describe("isReadOnlySQL", () => {
 describe("isMultiStatementSQL", () => {
   it("should return true for multiple statements", () => {
     const sql = "SELECT * FROM users; SELECT * FROM orders;";
-    expect(isMultiStatementSQL(sql)).toBe(true);
+    expect(isMultiStatementSQL(sql, true)).toBe(true);
   });
 
   it("should return false for single statement", () => {
     const sql = "SELECT * FROM users;";
-    expect(isMultiStatementSQL(sql)).toBe(false);
+    expect(isMultiStatementSQL(sql, true)).toBe(false);
   });
 
   it("should ignore comments when counting statements", () => {
@@ -278,12 +279,12 @@ describe("isMultiStatementSQL", () => {
       -- This is a comment; Select 1;
       SELECT * FROM users; /* Another comment; SELECT 1; */
     `;
-    expect(isMultiStatementSQL(sql)).toBe(false);
+    expect(isMultiStatementSQL(sql, true)).toBe(false);
   });
 
   it("should handle statements without semicolons", () => {
     const sql = "SELECT * FROM users";
-    expect(isMultiStatementSQL(sql)).toBe(false);
+    expect(isMultiStatementSQL(sql, true)).toBe(false);
   });
 
   it("should handle complex multi-statement SQL", () => {
@@ -293,81 +294,127 @@ describe("isMultiStatementSQL", () => {
       )
       SELECT * FROM recent_orders WHERE amount > 100;
     `;
-    expect(isMultiStatementSQL(sql)).toBe(false);
+    expect(isMultiStatementSQL(sql, true)).toBe(false);
   });
   it("should ignore semicolons within simple strings", () => {
     const sql = "SELECT 'This is a test; still in string' AS test_col;";
-    expect(isMultiStatementSQL(sql)).toBe(false);
+    expect(isMultiStatementSQL(sql, true)).toBe(false);
   });
   it("should handle CTAS statements", () => {
     const sql = "CREATE TABLE new_table AS SELECT * FROM users";
-    expect(isMultiStatementSQL(sql)).toBe(false);
+    expect(isMultiStatementSQL(sql, true)).toBe(false);
   });
   it("is not tricked by quotes and block comments", () => {
     const sql = `SELECT '/*'; DROP TABLE users; SELECT '*/';`;
-    expect(isMultiStatementSQL(sql)).toBe(true);
+    expect(isMultiStatementSQL(sql, true)).toBe(true);
   });
   it("is not tricked by quotes and line comments", () => {
     const sql = `SELECT '--'; DROP TABLE users`;
-    expect(isMultiStatementSQL(sql)).toBe(true);
+    expect(isMultiStatementSQL(sql, true)).toBe(true);
   });
   it("is not tricked by backslash escaped strings", () => {
     const sql = `SELECT 'It\\'s a test'; DROP TABLE users; SELECT '1';`;
-    expect(isMultiStatementSQL(sql)).toBe(true);
+    expect(isMultiStatementSQL(sql, true)).toBe(true);
   });
   it("is not tricked by fake escaped backslashes", () => {
     const sql = `SELECT 'This is a backslash: \\\\'; DROP TABLE users; SELECT '1';`;
-    expect(isMultiStatementSQL(sql)).toBe(true);
+    expect(isMultiStatementSQL(sql, true)).toBe(true);
   });
   it("is not tricked by single quotes that are escaped by doubling the quotes", () => {
     const sql = `SELECT 'It''s a test'; DROP TABLE users; SELECT '1';`;
-    expect(isMultiStatementSQL(sql)).toBe(true);
+    expect(isMultiStatementSQL(sql, true)).toBe(true);
   });
 
   it("is not tricked by double quotes and block comments", () => {
     const sql = `SELECT "/*"; DROP TABLE users; SELECT "*/";`;
-    expect(isMultiStatementSQL(sql)).toBe(true);
+    expect(isMultiStatementSQL(sql, true)).toBe(true);
   });
   it("is not tricked by double quotes and line comments", () => {
     const sql = `SELECT "--"; DROP TABLE users`;
-    expect(isMultiStatementSQL(sql)).toBe(true);
+    expect(isMultiStatementSQL(sql, true)).toBe(true);
   });
   it("is not tricked by backslash escaped double quoted strings", () => {
     const sql = `SELECT "It\\'s a test"; DROP TABLE users; SELECT "1";`;
-    expect(isMultiStatementSQL(sql)).toBe(true);
+    expect(isMultiStatementSQL(sql, true)).toBe(true);
   });
   it("is not tricked by fake escaped backslashes in double quoted strings", () => {
     const sql = `SELECT "This is a backslash: \\\\"; DROP TABLE users; SELECT "1";`;
-    expect(isMultiStatementSQL(sql)).toBe(true);
+    expect(isMultiStatementSQL(sql, true)).toBe(true);
   });
   it("is not tricked by single quotes that are escaped by doubling the double quotes", () => {
     const sql = `SELECT "It''s a test"; DROP TABLE users; SELECT "1";`;
-    expect(isMultiStatementSQL(sql)).toBe(true);
+    expect(isMultiStatementSQL(sql, true)).toBe(true);
   });
 
   it("is not tricked by backtick quotes and block comments", () => {
     const sql = `SELECT \`/*\`; DROP TABLE users; SELECT \`*/\`;`;
-    expect(isMultiStatementSQL(sql)).toBe(true);
+    expect(isMultiStatementSQL(sql, true)).toBe(true);
   });
   it("is not tricked by backtick quotes and line comments", () => {
     const sql = `SELECT \`--\`; DROP TABLE users`;
-    expect(isMultiStatementSQL(sql)).toBe(true);
+    expect(isMultiStatementSQL(sql, true)).toBe(true);
   });
   it("is not tricked by doubled backticks", () => {
     const sql = `SELECT \`It\`\`s a test\`; DROP TABLE users; SELECT \`1\`;`;
-    expect(isMultiStatementSQL(sql)).toBe(true);
+    expect(isMultiStatementSQL(sql, true)).toBe(true);
   });
   it("allows parse errors as long as there are no semicolons", () => {
     const sql = `SELECT 'It\\'`;
-    expect(isMultiStatementSQL(sql)).toBe(false);
+    expect(isMultiStatementSQL(sql, true)).toBe(false);
   });
   it("allows parse errors as long as there is only a trailing semicolon", () => {
     const sql = `SELECT 'It\\'; `;
-    expect(isMultiStatementSQL(sql)).toBe(false);
+    expect(isMultiStatementSQL(sql, true)).toBe(false);
   });
   it("blocks all internal semicolons when there is a parse error", () => {
     const sql = `SELECT 'It\\'; DROP TABLE users`;
-    expect(isMultiStatementSQL(sql)).toBe(true);
+    expect(isMultiStatementSQL(sql, true)).toBe(true);
+  });
+});
+
+describe("isMultiStatementSQL — dialect-aware backslash escaping", () => {
+  it("allows a backslash string literal on a non-backslash dialect (the reported bug)", () => {
+    const sql = `SELECT * FROM t WHERE id LIKE 'a\\_b' ESCAPE '\\'`;
+    expect(isMultiStatementSQL(sql, false)).toBe(false);
+  });
+  it("allows a dimension query whose comment header contains a ';' plus ESCAPE", () => {
+    const sql = `-- Dimension: Platform; Fact Table: Sessions (trino)\nSELECT id FROM t WHERE x LIKE 'ab' ESCAPE '\\'`;
+    expect(isMultiStatementSQL(sql, false)).toBe(false);
+  });
+  it("still blocks a real statement separator on a non-backslash dialect", () => {
+    expect(isMultiStatementSQL(`SELECT 1; DROP TABLE users`, false)).toBe(true);
+  });
+  it("blocks an injection hidden behind a backslash literal on a non-backslash dialect", () => {
+    const sql = `SELECT 1 WHERE x = '\\'; DROP TABLE t; --'`;
+    expect(isMultiStatementSQL(sql, false)).toBe(true);
+  });
+  it("does not flag a comment semicolon when a parse error forces the fallback", () => {
+    const sql = `-- header with ; inside\nSELECT * FROM t WHERE x = 'unterminated`;
+    expect(isMultiStatementSQL(sql, false)).toBe(false);
+  });
+  it("blocks a backslash-escaped-quote injection on a backslash dialect", () => {
+    const sql = `SELECT 'It\\'s a test'; DROP TABLE users`;
+    expect(isMultiStatementSQL(sql, true)).toBe(true);
+  });
+  it("allows a benign single statement with a backslash escape on a backslash dialect", () => {
+    const sql = `SELECT 'a\\nb' AS c`;
+    expect(isMultiStatementSQL(sql, true)).toBe(false);
+  });
+});
+
+describe("usesBackslashStringEscapes", () => {
+  it("is false for ANSI doubled-quote escaping (Trino, Athena, Postgres, MSSQL, Vertica)", () => {
+    const escapeStringLiteral = (v: string) => v.replace(/'/g, "''");
+    expect(usesBackslashStringEscapes({ escapeStringLiteral })).toBe(false);
+  });
+  it("is true when backslashes are doubled (MySQL, Snowflake, Redshift, ClickHouse)", () => {
+    const escapeStringLiteral = (v: string) =>
+      v.replace(/\\/g, "\\\\").replace(/'/g, "''");
+    expect(usesBackslashStringEscapes({ escapeStringLiteral })).toBe(true);
+  });
+  it("is true when quotes/backslashes are backslash-prefixed (BigQuery, Databricks)", () => {
+    const escapeStringLiteral = (v: string) => v.replace(/(['\\])/g, "\\$1");
+    expect(usesBackslashStringEscapes({ escapeStringLiteral })).toBe(true);
   });
 });
 

--- a/packages/shared/types/sql.d.ts
+++ b/packages/shared/types/sql.d.ts
@@ -1,5 +1,5 @@
 import type { SqlLanguage } from "sql-formatter";
-import { DataType } from "./integrations";
+import type { DataType } from "./integrations";
 
 export type StringMatchOperator =
   | "starts_with"
@@ -54,10 +54,6 @@ export type DateTruncGranularity = "hour" | "day" | "week" | "month" | "year";
 
 export interface SqlDialect {
   escapeStringLiteral: (s: string) => string;
-  // Builds a string-match condition (LIKE or a warehouse-native equivalent).
-  // Owns LIKE wildcard escaping and any ESCAPE clause. Build it with
-  // createLikeStringMatchFn from shared/sql, passing this dialect's own
-  // escapeStringLiteral — the two must always agree or patterns break.
   stringMatch: StringMatchFn;
   jsonExtract: (jsonCol: string, path: string, isNumeric: boolean) => string;
   evalBoolean: (col: string, value: boolean) => string;


### PR DESCRIPTION
### Features and Changes

Before sending any query to a warehouse, GrowthBook checks it for multiple statements and blocks anything that looks like more than one. That check assumed every warehouse treats a backslash inside a string literal the same way. On warehouses where a backslash is an ordinary character (Trino/Presto, Athena, Redshift, Postgres, SQL Server, Vertica), a valid single-statement query containing a backslash literal such as `ESCAPE '\'` was misread and wrongly rejected with "Multi-statement queries are not supported." It showed up most often on experiment queries that break down by a dimension, because those include a generated comment that contains a semicolon.

The check now interprets backslashes using each warehouse's own string rules instead of one shared assumption, so these queries run again. The guard still blocks genuine multi-statement input, and on these warehouses it is now more accurate, because it no longer lets a second statement hide behind a backslash.

### Testing

Unit tests cover multi-statement detection across each dialect's string-escaping rules, including the reported `ESCAPE '\'` case and real multi-statement input that must stay blocked.
