### PR TITLE
fix(front-end): use credentials: "include" in useRestApiCall to match apiCall

### DIFF
--- a/packages/front-end/services/restApi.ts
+++ b/packages/front-end/services/restApi.ts
@@ -94,8 +94,7 @@ export function useRestApiCall() {
           method: spec.method.toUpperCase(),
           body: body ? JSON.stringify(body) : undefined,
           headers,
-          // We aren't using cookies, only auth headers
-          credentials: "omit",
+          credentials: "include",
         });
 
       let response = await issue(url);


### PR DESCRIPTION
## Problem

`useRestApiCall` sets `credentials: "omit"` on its fetch, while the existing
`apiCall` / `fetchRaw` helpers in `services/auth.tsx` use `credentials: "include"`.

On self-hosted deployments that rely on cookies being sent with API requests,
this means calls routed through `useRestApiCall` fail where the equivalent
`apiCall` path works. The visible symptom is **Create Project** / **Edit Project**
(via `ProjectModal.tsx`) failing with a generic "There was an error" toast,
since #5692 moved those to `useRestApiCall`.

## Change

Switch `credentials: "omit"` → `credentials: "include"` so `useRestApiCall`
matches the behavior of `apiCall`. `fetchRaw` already defaults to `"include"`;
this just stops overriding it.

## Testing

Verified Create/Edit Project now succeed on a self-hosted deployment where
they previously failed; no change in behavior on a stock local dev setup.