### PR TITLE
Allow removing API-added legacy metrics from incremental experiments

### DIFF
--- a/packages/front-end/components/Experiment/MetricsSelector.tsx
+++ b/packages/front-end/components/Experiment/MetricsSelector.tsx
@@ -133,6 +133,7 @@ const MetricsSelector: FC<{
     factMetrics,
     factTables,
     getExperimentMetricById,
+    getMetricById,
     getDatasourceById,
     mutateDefinitions,
   } = useDefinitions();
@@ -245,7 +246,7 @@ const MetricsSelector: FC<{
         : []),
     ];
 
-    return options
+    const filtered = options
       .filter((m) => (datasource ? m.datasource === datasource : true))
       .filter((m) =>
         datasourceSettings && userIdType && m.userIdTypes.length
@@ -253,6 +254,32 @@ const MetricsSelector: FC<{
           : true,
       )
       .filter((m) => isProjectListValidForProject(m.projects, project));
+
+    if (noLegacyMetrics) {
+      const includedIds = new Set(filtered.map((m) => m.id));
+      const selectedSet = new Set(selected);
+      for (const id of selectedSet) {
+        if (includedIds.has(id)) continue;
+        const metric = getMetricById(id);
+        if (!metric) continue;
+        filtered.push({
+          id: metric.id,
+          name: metric.name,
+          description: metric.description || "",
+          datasource: metric.datasource || "",
+          tags: metric.tags || [],
+          projects: metric.projects || [],
+          factTables: [],
+          userIdTypes: metric.userIdTypes || [],
+          isGroup: false,
+          managedBy: metric.managedBy,
+          disabled: true,
+          disabledReason: "Legacy metric (remove to use Incremental Refresh)",
+        });
+      }
+    }
+
+    return filtered;
   }, [
     metrics,
     factMetrics,
@@ -269,6 +296,8 @@ const MetricsSelector: FC<{
     excludeQuantiles,
     filterConversionWindowMetrics,
     getMetricDisabledInfo,
+    selected,
+    getMetricById,
   ]);
 
   // O(1) lookup map for filteredOptions by id


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

When legacy metrics are added via API to an experiment that uses Incremental Refresh (incremental pipeline), they become impossible to remove through the UI. This happens because:

1. The `MetricsSelector` component filters out legacy metrics when `noLegacyMetrics={true}` (set for incremental refresh experiments)
2. The `MultiSelectField` component only displays selected items that exist in the options map
3. As a result, API-added legacy metrics persist in form state but disappear from the UI with no remove button

This fix adds selected legacy metrics back to the options list when `noLegacyMetrics` is true, marking them as disabled with the reason "Legacy metric (remove to use Incremental Refresh)". This allows the metrics to appear as selected chips in the selector UI so users can click the X to remove them.

The solution is minimal and targeted:
- Only affects the case where `noLegacyMetrics` is true (incremental refresh experiments)
- Only adds back legacy metrics that are already selected (not all legacy metrics)
- Marks them as disabled so they cannot be re-added from the dropdown
- Provides a clear reason explaining why they should be removed

### Dependencies

None

### Testing

1. Create an experiment on a datasource with Incremental Pipeline enabled
2. Add a legacy metric via API (e.g., `POST /api/v2/experiments/{id}` with `goalMetrics` containing a legacy metric ID)
3. Open the Edit Metrics modal in the UI
4. Before fix: Legacy metric is invisible in the selector
5. After fix: Legacy metric appears as a selected chip with an X button to remove it
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C07NK4F016Z/p1781913932311969?thread_ts=1781913932.311969&cid=C07NK4F016Z)

<div><a href="https://cursor.com/agents/bc-eb2f9166-934d-59d3-8ba3-d69a112f92d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb2f9166-934d-59d3-8ba3-d69a112f92d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

