### PR TITLE
Adds support for supporting visual editor early access

### DIFF
--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -399,6 +399,8 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
     const features = new Set<CommercialFeature>(
       currentOrg?.commercialFeatures || [],
     );
+    // This is a temporary override to give some users access to the visual editor
+    // If we decide to keep this, we should add a getEffectiveCommercialFeatures that expands this functionality
     if (hasVisualEditorPromo) features.add("visual-editor");
     return features;
   }, [currentOrg?.commercialFeatures, hasVisualEditorPromo]);

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -29,6 +29,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import { useFeatureIsOn } from "@growthbook/growthbook-react";
 import {
   setUser as sentrySetUser,
   setTag as sentrySetTag,
@@ -392,9 +393,15 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
     }
   }, [currentOrg?.organization?.id]);
 
+  const hasVisualEditorPromo = useFeatureIsOn("visual-editor-free-access");
+
   const commercialFeatures = useMemo(() => {
-    return new Set(currentOrg?.commercialFeatures || []);
-  }, [currentOrg?.commercialFeatures]);
+    const features = new Set<CommercialFeature>(
+      currentOrg?.commercialFeatures || [],
+    );
+    if (hasVisualEditorPromo) features.add("visual-editor");
+    return features;
+  }, [currentOrg?.commercialFeatures, hasVisualEditorPromo]);
 
   const permissionsCheck = useCallback(
     (
@@ -651,7 +658,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
         effectiveAccountPlan: currentOrg?.effectiveAccountPlan,
         commercialFeatureLowestPlan: currentOrg?.commercialFeatureLowestPlan,
         licenseError: currentOrg?.licenseError || "",
-        commercialFeatures: currentOrg?.commercialFeatures || [],
+        commercialFeatures: [...commercialFeatures],
         agreements: currentOrg?.agreements || [],
         organization: organization || {},
         seatsInUse: currentOrg?.seatsInUse || 0,


### PR DESCRIPTION
### Features and Changes

Adds support for granting temporary Visual Editor access through the `visual-editor-free-access` GrowthBook feature flag.

When the flag is enabled, the front-end treats `visual-editor` as an available commercial feature for the current user/org context, allowing early access without requiring the feature to be present in the org’s persisted commercial feature list.

- Closes **(add link to issue here)**

### Dependencies

- None

### Testing

- [x] Enable `visual-editor-free-access` for a test user/org and verify Visual Editor access is available.
- [x] Disable the flag and verify access falls back to the org’s existing commercial features.
- [x] Verify existing commercial feature checks continue to work as expected.

### Screenshots

<!-- Add screenshots manually if there are visible UI changes. -->