### PR TITLE
Disable keep-alive on the Mixpanel JQL request (fixes "Premature close" on Node ≥24.17.0)

### DIFF
--- a/packages/back-end/src/services/mixpanel.ts
+++ b/packages/back-end/src/services/mixpanel.ts
@@ -1,8 +1,17 @@
+import { Agent } from "node:https";
 import { URLSearchParams } from "url";
 import { MixpanelConnectionParams } from "shared/types/integrations/mixpanel";
 import { fetch } from "back-end/src/util/http.util";
 
 const encodedParams = new URLSearchParams();
+
+// node-fetch v2 reuses keep-alive sockets via Node's global Agent. Node 24.17.0's
+// http.Agent change (CVE-2026-48931) makes it read a pooled socket the server has
+// already closed, surfacing as "FetchError: ... Premature close"
+// (ERR_STREAM_PREMATURE_CLOSE). JQL requests are infrequent, so disabling
+// keep-alive here sidesteps the stale-socket reuse with no meaningful cost.
+// Ref: https://github.com/nodejs/node/issues/63989
+const jqlAgent = new Agent({ keepAlive: false });
 
 // eslint-disable-next-line
 type MixpanelResultRow = any;
@@ -70,6 +79,7 @@ export async function runQuery<T extends MixpanelResultRow>(
       ).toString("base64")}`,
     },
     body: encodedParams,
+    agent: jqlAgent,
   };
 
   const res = await fetch(url, options);


### PR DESCRIPTION
### Features and Changes

Mixpanel datasource queries fail with:

```
Invalid response body while trying to fetch https://mixpanel.com/api/2.0/jql: Premature close
```

surfaced in the UI as **Error Processing Query Results**.

**Root cause** — not Mixpanel, not auth. `runQuery` in `services/mixpanel.ts` uses node-fetch v2 (via the `http.util` `fetch` wrapper), which reuses keep-alive sockets from Node's global agent. Node **24.17.0** shipped a security fix — _"http: fix response queue poisoning in `http.Agent`"_ (CVE-2026-48931) — that changed keep-alive socket reuse so node-fetch reads a pooled socket the server has already closed, throwing `FetchError: … Premature close` (`ERR_STREAM_PREMATURE_CLOSE`). This is a known, broad node-fetch v2 regression (see nodejs/node#63989) that hit many libraries riding `gaxios`/`node-fetch`.

The runtime base bump in #6092 (continuously-patched hardened image) pulls Node 24.17.0 into the published `growthbook/growthbook` image, so self-hosted instances began hitting this on their next pull.

**Fix** — pass a `keepAlive: false` agent to the JQL request so it doesn't reuse pooled sockets. JQL calls are infrequent, so there is no meaningful cost. `runQuery` is the single chokepoint for all JQL traffic, so this covers both `Events` and `People` queries.

### Dependencies

None.

### Testing

Reproduced and verified in Docker against the **live** `mixpanel.com/api/2.0/jql` endpoint, isolating both variables (client library × Node version), 8 requests per cell:

| client | Node | result |
| --- | --- | --- |
| node-fetch (default keep-alive) | 24.17.0 | **8/8 `Premature close`** |
| node-fetch (default keep-alive) | 24.16.0 | 8/8 OK |
| native fetch (undici) | 24.17.0 | 8/8 OK |
| node-fetch + `agent: new Agent({ keepAlive: false })` | 24.17.0 | **8/8 OK** ← this fix |

- Confirms node-fetch + Node 24.17.0 is the broken pairing, and that disabling keep-alive (this PR) resolves it.
- `node --version` inside the current published `growthbook/growthbook` image: `v24.17.0`.

### Notes / alternatives considered

- Pinning Node back to 24.16.0 would reintroduce the CVE that #6092 closed — rejected.
- The same Node regression can affect other node-fetch keep-alive call sites (e.g. webhooks); this PR scopes to the reported Mixpanel JQL failure. A systemic fix (shared non-pooling agent / retry, or moving off the now-unmaintained node-fetch v2) could be a follow-up.
- Mixpanel is a deprecated datasource, but existing instances still depend on it; this keeps them working with a minimal, low-risk change.
