### PR TITLE
feat(back-end): enforce a queryType label on every warehouse query

### DIFF
--- a/eslint-rules/restricted-query-types.mjs
+++ b/eslint-rules/restricted-query-types.mjs
@@ -1,0 +1,69 @@
+const BANNED_VALUES = new Set(["freeFormQuery", "unknown", ""]);
+
+const MESSAGE =
+  'queryType "{{value}}" is not allowed here. ' +
+  "`freeFormQuery` is reserved for user-provided SQL (services/datasource.ts); " +
+  "`unknown`/empty is an internal fallback only. " +
+  "Create a new specific QueryType in packages/shared/types/query.d.ts.";
+
+function isBannedLiteral(node) {
+  return (
+    node.type === "Literal" &&
+    typeof node.value === "string" &&
+    BANNED_VALUES.has(node.value)
+  );
+}
+
+function isQueryTypeKey(node) {
+  if (node.computed) return false;
+  if (node.key.type === "Identifier") return node.key.name === "queryType";
+  if (node.key.type === "Literal") return node.key.value === "queryType";
+  return false;
+}
+
+function isRunTestQueryCallee(node) {
+  if (node.type === "Identifier") return node.name === "runTestQuery";
+  if (node.type === "MemberExpression" && !node.computed) {
+    return (
+      node.property.type === "Identifier" &&
+      node.property.name === "runTestQuery"
+    );
+  }
+  return false;
+}
+
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow reserved queryType literals on generated queries.",
+    },
+    schema: [],
+    messages: {
+      restrictedQueryType: MESSAGE,
+    },
+  },
+  create(context) {
+    return {
+      Property(node) {
+        if (!isQueryTypeKey(node)) return;
+        if (!isBannedLiteral(node.value)) return;
+        context.report({
+          node: node.value,
+          messageId: "restrictedQueryType",
+          data: { value: node.value.value },
+        });
+      },
+      CallExpression(node) {
+        if (!isRunTestQueryCallee(node.callee)) return;
+        const third = node.arguments[2];
+        if (!third || !isBannedLiteral(third)) return;
+        context.report({
+          node: third,
+          messageId: "restrictedQueryType",
+          data: { value: third.value },
+        });
+      },
+    };
+  },
+};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,7 @@ import * as tsParser from "@typescript-eslint/parser";
 import js from "@eslint/js";
 import { FlatCompat } from "@eslint/eslintrc";
 import noAlertClassname from "./eslint-rules/no-alert-classname.mjs";
+import restrictedQueryTypes from "./eslint-rules/restricted-query-types.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -366,6 +367,18 @@ export default defineConfig([
           ],
         },
       ],
+    },
+  },
+  {
+    files: ["./packages/back-end/**/*.ts"],
+    ignores: ["./packages/back-end/**/*.test.{ts,tsx,js,jsx}"],
+    plugins: {
+      localBackend: {
+        rules: { "restricted-query-types": restrictedQueryTypes },
+      },
+    },
+    rules: {
+      "localBackend/restricted-query-types": "error",
     },
   },
   {

--- a/packages/back-end/src/integrations/BigQuery.ts
+++ b/packages/back-end/src/integrations/BigQuery.ts
@@ -16,7 +16,7 @@ import {
   MaxTimestampIncrementalUnitsQueryParams,
 } from "shared/types/integrations";
 import { BigQueryConnectionParams } from "shared/types/integrations/bigquery";
-import { QueryMetadata } from "shared/types/query";
+import { RunQueryMetadata } from "shared/types/query";
 import { decryptDataSourceParams } from "back-end/src/services/datasource";
 import { IS_CLOUD } from "back-end/src/util/secrets";
 import { formatInformationSchema } from "back-end/src/util/informationSchemas";
@@ -86,8 +86,8 @@ export default class BigQuery extends SqlIntegration {
 
   async runQuery(
     sql: string,
-    setExternalId?: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    setExternalId: ExternalIdCallback | undefined,
+    queryMetadata: RunQueryMetadata,
   ): Promise<QueryResponse> {
     const client = this.getClient();
 
@@ -226,6 +226,8 @@ export default class BigQuery extends SqlIntegration {
       try {
         const { rows: datasetResults } = await this.runQuery(
           format(query, this.getSqlDialect().formatDialect),
+          undefined,
+          { queryType: "informationSchema" },
         );
 
         if (datasetResults.length > 0) {

--- a/packages/back-end/src/integrations/Presto.ts
+++ b/packages/back-end/src/integrations/Presto.ts
@@ -9,7 +9,7 @@ import {
   MaxTimestampMetricSourceQueryParams,
   ExternalIdCallback,
 } from "shared/types/integrations";
-import { QueryMetadata, QueryStatistics } from "shared/types/query";
+import { QueryStatistics, RunQueryMetadata } from "shared/types/query";
 import { PrestoConnectionParams } from "shared/types/integrations/presto";
 import { decryptDataSourceParams } from "back-end/src/services/datasource";
 import { getKerberosHeader } from "back-end/src/util/kerberos.util";
@@ -121,8 +121,8 @@ export default class Presto extends SqlIntegration {
 
   runQuery(
     sql: string,
-    setExternalId?: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    setExternalId: ExternalIdCallback | undefined,
+    queryMetadata: RunQueryMetadata,
   ): Promise<QueryResponse> {
     const engineHeaderName =
       this.params.engine === "presto" ? "Presto" : "Trino";
@@ -139,7 +139,7 @@ export default class Presto extends SqlIntegration {
         schema: this.params.schema,
         headers: {
           [`X-${engineHeaderName}-Client-Info`]: getQueryTagString(
-            queryMetadata ?? {},
+            queryMetadata,
             PRESTO_QUERY_TAG_MAX_LENGTH,
           ),
         },

--- a/packages/back-end/src/integrations/Snowflake.ts
+++ b/packages/back-end/src/integrations/Snowflake.ts
@@ -2,7 +2,7 @@ import { snowflakeCreateTableOptions } from "shared/enterprise";
 import { SqlDialect } from "shared/types/sql";
 import { QueryResponse, ExternalIdCallback } from "shared/types/integrations";
 import { SnowflakeConnectionParams } from "shared/types/integrations/snowflake";
-import { QueryMetadata } from "shared/types/query";
+import { RunQueryMetadata } from "shared/types/query";
 import { decryptDataSourceParams } from "back-end/src/services/datasource";
 import {
   cancelSnowflakeQuery,
@@ -37,8 +37,8 @@ export default class Snowflake extends SqlIntegration {
   }
   runQuery(
     sql: string,
-    setExternalId?: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    setExternalId: ExternalIdCallback | undefined,
+    queryMetadata: RunQueryMetadata,
   ): Promise<QueryResponse> {
     return runSnowflakeQuery(this.params, sql, setExternalId, queryMetadata);
   }

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -113,8 +113,8 @@ import {
 import { ExplorationConfig } from "shared/validators";
 import {
   AdditionalQueryMetadata,
-  QueryMetadata,
   QueryType,
+  RunQueryMetadata,
 } from "shared/types/query";
 import { MissingDatasourceParamsError } from "back-end/src/util/errors";
 import { ReqContext } from "back-end/types/request";
@@ -198,8 +198,8 @@ export default abstract class SqlIntegration
   abstract setParams(encryptedParams: string): void;
   abstract runQuery(
     sql: string,
-    setExternalId?: ExternalIdCallback,
-    metadata?: QueryMetadata,
+    setExternalId: ExternalIdCallback | undefined,
+    metadata: RunQueryMetadata,
   ): Promise<QueryResponse>;
   async cancelQuery(externalId: string): Promise<void> {
     // No-op default; warehouses with remote job control override.
@@ -226,8 +226,8 @@ export default abstract class SqlIntegration
     const originalRunQuery = this.runQuery;
     this.runQuery = async (
       sql: string,
-      setExternalId?: ExternalIdCallback,
-      metadata?: QueryMetadata,
+      setExternalId: ExternalIdCallback | undefined,
+      metadata: RunQueryMetadata,
     ) => {
       if (
         isMultiStatementSQL(
@@ -286,7 +286,9 @@ export default abstract class SqlIntegration
   }
 
   async testConnection(): Promise<boolean> {
-    await this.runQuery(TEST_QUERY_SQL);
+    await this.runQuery(TEST_QUERY_SQL, undefined, {
+      queryType: "connectionTest",
+    });
     return true;
   }
 
@@ -366,7 +368,7 @@ export default abstract class SqlIntegration
   async runPastExperimentQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<PastExperimentQueryResponse> {
     const { rows, statistics } = await this.runQuery(
       query,
@@ -415,7 +417,7 @@ export default abstract class SqlIntegration
   async runMetricAnalysisQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<MetricAnalysisQueryResponse> {
     const { rows, statistics } = await this.runQuery(
       query,
@@ -484,7 +486,7 @@ export default abstract class SqlIntegration
   async runPopulationFactMetricsQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<ExperimentFactMetricsQueryResponse> {
     return this.runExperimentFactMetricsQuery(
       query,
@@ -503,7 +505,7 @@ export default abstract class SqlIntegration
   async runExperimentFactMetricsQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<ExperimentFactMetricsQueryResponse> {
     const { rows, statistics } = await this.runQuery(
       query,
@@ -520,7 +522,7 @@ export default abstract class SqlIntegration
   async runPopulationMetricQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<ExperimentMetricQueryResponse> {
     return this.runExperimentMetricQuery(query, setExternalId, queryMetadata);
   }
@@ -528,7 +530,7 @@ export default abstract class SqlIntegration
   async runExperimentMetricQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<ExperimentMetricQueryResponse> {
     const { rows, statistics } = await this.runQuery(
       query,
@@ -638,7 +640,7 @@ export default abstract class SqlIntegration
   async runExperimentAggregateUnitsQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<ExperimentAggregateUnitsQueryResponse> {
     const { rows, statistics } = await this.runQuery(
       query,
@@ -661,7 +663,7 @@ export default abstract class SqlIntegration
   async runExperimentUnitsQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<ExperimentUnitsQueryResponse> {
     return await this.runQuery(query, setExternalId, queryMetadata);
   }
@@ -669,7 +671,7 @@ export default abstract class SqlIntegration
   async runMetricValueQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<MetricValueQueryResponse> {
     const { rows, statistics } = await this.runQuery(
       query,
@@ -748,24 +750,22 @@ export default abstract class SqlIntegration
 
   async runTestQuery(
     sql: string,
-    timestampCols?: string[],
-    queryType?: QueryType,
+    timestampCols: string[] | undefined,
+    queryType: QueryType,
   ): Promise<TestQueryResult> {
     const queryStartTime = Date.now();
-    const results = await this.runQuery(
-      sql,
-      undefined,
-      queryType ? { queryType } : undefined,
-    ).catch((e) => {
-      // If the user forgets to include a timestamp column in their SQL
-      // The error message from the db will be confusing, so make it more clear.
-      for (const col of timestampCols ?? []) {
-        if (e.message.includes(col)) {
-          throw new Error(`The column '${col}' is required. ${e.message}`);
+    const results = await this.runQuery(sql, undefined, { queryType }).catch(
+      (e) => {
+        // If the user forgets to include a timestamp column in their SQL
+        // The error message from the db will be confusing, so make it more clear.
+        for (const col of timestampCols ?? []) {
+          if (e.message.includes(col)) {
+            throw new Error(`The column '${col}' is required. ${e.message}`);
+          }
         }
-      }
-      throw e;
-    });
+        throw e;
+      },
+    );
     const queryEndTime = Date.now();
     const duration = queryEndTime - queryStartTime;
 
@@ -789,7 +789,7 @@ export default abstract class SqlIntegration
   async runDropTableQuery(
     sql: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<DropTableQueryResponse> {
     const results = await this.runQuery(sql, setExternalId, queryMetadata);
     return results;
@@ -907,7 +907,7 @@ export default abstract class SqlIntegration
   async runDimensionSlicesQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<DimensionSlicesQueryResponse> {
     const { rows, statistics } = await this.runQuery(
       query,
@@ -1071,11 +1071,11 @@ export default abstract class SqlIntegration
   }
   async getInformationSchema(): Promise<InformationSchema[]> {
     const sql = `
-  SELECT 
+  SELECT
     table_name as table_name,
     table_catalog as table_catalog,
     table_schema as table_schema,
-    count(column_name) as column_count 
+    count(column_name) as column_count
   FROM
     ${this.getInformationSchemaTable()}
     WHERE ${this.getInformationSchemaWhereClause()}
@@ -1083,6 +1083,8 @@ export default abstract class SqlIntegration
 
     const results = await this.runQuery(
       format(sql, this.getSqlDialect().formatDialect),
+      undefined,
+      { queryType: "informationSchema" },
     );
 
     if (!results.rows.length) {
@@ -1097,18 +1099,20 @@ export default abstract class SqlIntegration
     tableName: string,
   ): Promise<{ tableData: null | unknown[] }> {
     const sql = `
-  SELECT 
+  SELECT
     data_type as data_type,
-    column_name as column_name 
+    column_name as column_name
   FROM
     ${this.getInformationSchemaTable(tableSchema, databaseName)}
-  WHERE 
+  WHERE
     table_name = '${tableName}'
     AND table_schema = '${tableSchema}'
     AND table_catalog = '${databaseName}'`;
 
     const results = await this.runQuery(
       format(sql, this.getSqlDialect().formatDialect),
+      undefined,
+      { queryType: "tableColumns" },
     );
 
     return { tableData: results.rows };
@@ -1418,6 +1422,8 @@ export default abstract class SqlIntegration
 
     const { rows: resultRows } = await this.runQuery(
       format(sql, this.getSqlDialect().formatDialect),
+      undefined,
+      { queryType: "trackedEvents" },
     );
 
     const additionalEvents = getAdditionalEvents();
@@ -1437,6 +1443,8 @@ export default abstract class SqlIntegration
       try {
         const { rows: additionalEventResults } = await this.runQuery(
           format(sql, this.getSqlDialect().formatDialect),
+          undefined,
+          { queryType: "trackedEvents" },
         );
 
         additionalEventResults.forEach((result) => {
@@ -1494,7 +1502,9 @@ export default abstract class SqlIntegration
   public async runColumnsTopValuesQuery(
     sql: string,
   ): Promise<ColumnTopValuesResponse> {
-    const { rows, statistics } = await this.runQuery(sql);
+    const { rows, statistics } = await this.runQuery(sql, undefined, {
+      queryType: "columnTopValues",
+    });
 
     return {
       statistics,
@@ -1777,7 +1787,7 @@ export default abstract class SqlIntegration
   async runMaxTimestampQuery(
     sql: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<MaxTimestampQueryResponse> {
     const { rows, statistics } = await this.runQuery(
       sql,
@@ -1803,7 +1813,7 @@ export default abstract class SqlIntegration
   async runIncrementalWithNoOutputQuery(
     sql: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<IncrementalWithNoOutputQueryResponse> {
     const results = await this.runQuery(sql, setExternalId, queryMetadata);
     return results;
@@ -2813,7 +2823,7 @@ export default abstract class SqlIntegration
   async runIncrementalRefreshStatisticsQuery(
     sql: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<ExperimentFactMetricsQueryResponse> {
     const { rows, statistics } = await this.runQuery(
       sql,
@@ -2898,7 +2908,7 @@ export default abstract class SqlIntegration
   async runProductAnalyticsQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ) {
     return this.runQuery(query, setExternalId, queryMetadata);
   }

--- a/packages/back-end/src/models/ImpactEstimateModel.ts
+++ b/packages/back-end/src/models/ImpactEstimateModel.ts
@@ -108,6 +108,7 @@ export async function getImpactEstimate(
     async () => {
       // Ignore calls to setExternalId
     },
+    { queryType: "impactEstimate" },
   );
   const value = processMetricValueQueryResponse(queryResponse.rows);
 

--- a/packages/back-end/src/models/QueryModel.ts
+++ b/packages/back-end/src/models/QueryModel.ts
@@ -333,7 +333,7 @@ export async function createNewQuery({
   displayTitle,
   dependencies = [],
   running = false,
-  queryType = "",
+  queryType = "unknown",
   runAtEnd = false,
 }: {
   organization: string;

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -27,9 +27,9 @@ import {
 import {
   ExperimentQueryMetadata,
   Queries,
-  QueryMetadata,
   QueryPointer,
   QueryStatus,
+  RunQueryMetadata,
 } from "shared/types/query";
 import { FactMetricInterface } from "shared/types/fact-table";
 import { ApiReqContext } from "back-end/types/api";
@@ -304,13 +304,13 @@ const startExperimentIncrementalRefreshQueries = async (
       run: (
         query: string,
         setExternalId: ExternalIdCallback,
-        queryMetadata?: QueryMetadata,
+        queryMetadata: RunQueryMetadata,
       ) => Promise<R>,
     ) =>
     async (
       query: string,
       setExternalId: ExternalIdCallback,
-      queryMetadata?: QueryMetadata,
+      queryMetadata: RunQueryMetadata,
     ): Promise<R> => {
       const current =
         await context.models.incrementalRefresh.getCurrentExecutionSnapshotId(
@@ -790,7 +790,7 @@ const startExperimentIncrementalRefreshQueries = async (
         run: (
           query: string,
           setExternalId: ExternalIdCallback,
-          queryMetadata?: QueryMetadata,
+          queryMetadata: RunQueryMetadata,
         ) =>
           integration.runIncrementalWithNoOutputQuery(
             query,

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -3,10 +3,10 @@ import { ExternalIdCallback, QueryResponse } from "shared/types/integrations";
 import {
   Queries,
   QueryInterface,
-  QueryMetadata,
   QueryPointer,
   QueryStatus,
   QueryType,
+  RunQueryMetadata,
 } from "shared/types/query";
 import { parseIntWithDefault, parseOptionalInt } from "shared/util";
 import {
@@ -64,7 +64,7 @@ export type StartQueryParams<Rows, ProcessedRows> = {
   run: (
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ) => Promise<QueryResponse<Rows>>;
   /** @deprecated */
   process?: (rows: Rows) => ProcessedRows;
@@ -146,7 +146,7 @@ export abstract class QueryRunner<
       run: (
         query: string,
         setExternalId: ExternalIdCallback,
-        queryMetadata?: QueryMetadata,
+        queryMetadata: RunQueryMetadata,
       ) => Promise<QueryResponse<RowsType>>;
       process?: (rows: RowsType) => ProcessedRowsType;
       onSuccess?: (rows: RowsType) => void | Promise<void>;
@@ -797,7 +797,7 @@ export abstract class QueryRunner<
       run: (
         query: string,
         setExternalId: ExternalIdCallback,
-        queryMetadata?: QueryMetadata,
+        queryMetadata: RunQueryMetadata,
       ) => Promise<QueryResponse<Rows>>;
       process?: (rows: Rows) => ProcessedRows;
       onFailure: () => void;
@@ -842,7 +842,7 @@ export abstract class QueryRunner<
       });
     };
 
-    run(doc.query, setExternalId, { queryType: doc.queryType })
+    run(doc.query, setExternalId, { queryType: doc.queryType || "unknown" })
       .then(async ({ rows, statistics }) => {
         clearInterval(timer);
         logger.debug("Query succeeded: " + doc.id);

--- a/packages/back-end/src/services/datasource.ts
+++ b/packages/back-end/src/services/datasource.ts
@@ -14,7 +14,7 @@ import {
   FeatureUsageQuery,
 } from "shared/types/datasource";
 import { FactTableColumnType } from "shared/types/fact-table";
-import { QueryStatistics } from "shared/types/query";
+import { QueryStatistics, QueryType } from "shared/types/query";
 import { formatQueryExecutionErrorForApi } from "shared/util";
 import { SQLExecutionError } from "back-end/src/util/errors";
 import { determineColumnTypes } from "back-end/src/util/sql";
@@ -36,6 +36,9 @@ import Mssql from "back-end/src/integrations/Mssql";
 import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
+
+// freeFormQuery runs user-authored SQL; we should only use it for this scenario
+const FREE_FORM_QUERY_TYPE: QueryType = "freeFormQuery";
 
 export function decryptDataSourceParams<T = DataSourceParams>(
   encrypted: string,
@@ -183,7 +186,7 @@ export async function runFreeFormQuery(
     const { results, duration, columns } = await integration.runTestQuery(
       sql,
       ["timestamp"],
-      "freeFormQuery",
+      FREE_FORM_QUERY_TYPE,
     );
 
     // Build a type map from SQL engine metadata

--- a/packages/back-end/src/types/Integration.ts
+++ b/packages/back-end/src/types/Integration.ts
@@ -64,8 +64,8 @@ import {
 } from "shared/types/datasource";
 import {
   AdditionalQueryMetadata,
-  QueryMetadata,
   QueryType,
+  RunQueryMetadata,
 } from "shared/types/query";
 import { ExperimentSnapshotSettings } from "shared/types/experiment-snapshot";
 import { DimensionInterface } from "shared/types/dimension";
@@ -117,8 +117,8 @@ export interface SourceIntegrationInterface {
   getFreeFormQuery?(query: string, limit?: number): string;
   runTestQuery?(
     sql: string,
-    timestampCols?: string[],
-    queryType?: QueryType,
+    timestampCols: string[] | undefined,
+    queryType: QueryType,
   ): Promise<TestQueryResult>;
   getMetricAnalysisQuery(
     metric: FactMetricInterface,
@@ -127,13 +127,13 @@ export interface SourceIntegrationInterface {
   runMetricAnalysisQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<MetricAnalysisQueryResponse>;
   getDropUnitsTableQuery(params: DropTableQueryParams): string;
   runDropTableQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<DropTableQueryResponse>;
   getMetricValueQuery(params: MetricValueParams): string;
   getPopulationMetricQuery?(params: PopulationMetricQueryParams): string;
@@ -202,17 +202,17 @@ export interface SourceIntegrationInterface {
   runIncrementalWithNoOutputQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<IncrementalWithNoOutputQueryResponse>;
   runMaxTimestampQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<MaxTimestampQueryResponse>;
   runIncrementalRefreshStatisticsQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<ExperimentFactMetricsQueryResponse>;
   // Pipeline validation helpers
   getPipelineValidationInsertQuery?(params: { tableFullName: string }): string;
@@ -234,47 +234,47 @@ export interface SourceIntegrationInterface {
   runDimensionSlicesQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<DimensionSlicesQueryResponse>;
   runMetricValueQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<MetricValueQueryResponse>;
   runPopulationMetricQuery?(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<ExperimentMetricQueryResponse>;
   runPopulationFactMetricsQuery?(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<ExperimentFactMetricsQueryResponse>;
   runExperimentMetricQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<ExperimentMetricQueryResponse>;
   runExperimentFactMetricsQuery?(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<ExperimentFactMetricsQueryResponse>;
   runExperimentAggregateUnitsQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<ExperimentAggregateUnitsQueryResponse>;
   runExperimentUnitsQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<ExperimentUnitsQueryResponse>;
   runPastExperimentQuery(
     query: string,
     setExternalId: ExternalIdCallback,
-    queryMetadata?: QueryMetadata,
+    queryMetadata: RunQueryMetadata,
   ): Promise<PastExperimentQueryResponse>;
   runColumnsTopValuesQuery?(sql: string): Promise<ColumnTopValuesResponse>;
   getColumnsTopValuesQuery?: (params: ColumnTopValuesParams) => string;

--- a/packages/shared/types/query.d.ts
+++ b/packages/shared/types/query.d.ts
@@ -29,7 +29,8 @@ export type QueryStatistics = {
 };
 
 export type QueryType =
-  | ""
+  // Internal fallback. Do not use this value.
+  | "unknown"
 
   // ---
   // Metadata queries used to power various GrowthBook features
@@ -86,16 +87,24 @@ export type QueryType =
   // ---
   // Standalone metric analysis query on legacy of fact metric page
   | "metricAnalysis"
+  // Metric impact / idea estimation
+  | "impactEstimate"
   // Query used by the product analytics tool
   | "productAnalyticsExploration"
 
   // ---
   // Non-persisted / utility queries (for cost attribution tracking)
   // ---
-  // SQL explorer ad-hoc queries
+  // User-provided SQL (SQL explorer ad-hoc queries)
   | "freeFormQuery"
-  // Connection tests and validation queries
+  // User-initiated datasource test / validation queries
   | "testQuery"
+  // Datasource connectivity probe (SELECT 1)
+  | "connectionTest"
+  // Schema introspection: list tables + column counts
+  | "informationSchema"
+  // Schema introspection: a single table's column data types
+  | "tableColumns"
   // Fact table column/SQL validation
   | "factTableValidation"
   // Pipeline write permission tests
@@ -104,6 +113,10 @@ export type QueryType =
   | "userExposure"
   // Feature evaluation diagnostics
   | "featureEvalDiagnostics"
+  // Fact table column top-values scan (auto-slices + column refresh)
+  | "columnTopValues"
+  // Auto fact table tracked-event discovery scan
+  | "trackedEvents"
 
   // ---
   // Legacy, should be deprecated
@@ -130,6 +143,9 @@ export type QueryMetadata = AdditionalQueryMetadata &
     userName?: string;
     userId?: string;
   };
+
+// queryType is required to ensure visibility into query costs at the data warehouse
+export type RunQueryMetadata = QueryMetadata & { queryType: QueryType };
 
 export interface QueryInterface {
   id: string;


### PR DESCRIPTION
### Features and Changes

Enforce that we have a `queryType` for every query we execute, bringing more visibility into the data warehouse costs and performance.

- Added `queryTypes` to queries that were missing them
- Added `eslint` rule to prevent certain queryTypes from being used
- Make `queryType` a required param

### Testing

- `pnpm --filter back-end type-check`
- `pnpm lint`
