### PR TITLE
Reorganize Dashboard Block edits

### DIFF
--- a/packages/front-end/components/DatePicker/index.tsx
+++ b/packages/front-end/components/DatePicker/index.tsx
@@ -41,12 +41,6 @@ type Props = {
   clearButton?: boolean;
   wrapRangeInputs?: boolean;
   compact?: boolean;
-  /**
-   * Let the field shrink to fill a constrained container (drops the range
-   * input's 220px min-width) and truncate its text with an ellipsis instead of
-   * forcing width. Use when the picker sits in a narrow/flexible layout cell.
-   */
-  fluid?: boolean;
   disabled?: boolean;
   fixedSpanMode?: {
     phase: "committed" | "choosing";
@@ -121,7 +115,6 @@ export default function DatePicker({
   clearButton = false,
   wrapRangeInputs = false,
   compact = false,
-  fluid = false,
   disabled,
   fixedSpanMode,
 }: Props) {
@@ -356,7 +349,7 @@ export default function DatePicker({
                 width:
                   inputWidth ||
                   (wrapRangeInputs && isRange ? undefined : "100%"),
-                minWidth: fluid ? 0 : isRange ? 220 : undefined,
+                minWidth: isRange ? 220 : undefined,
                 height: compact ? inputHeight : undefined,
                 minHeight: inputHeight,
                 flex: wrapRangeInputs && isRange ? "1 1 220px" : undefined,
@@ -394,17 +387,10 @@ export default function DatePicker({
                     readOnly={!!fixedSpanMode}
                     style={{
                       border: 0,
-                      marginRight: fluid ? 0 : -20,
-                      width: fluid ? "100%" : "calc(100% + 30px)",
+                      marginRight: -20,
+                      width: "calc(100% + 30px)",
                       minHeight: inputHeight,
                       cursor: "pointer",
-                      ...(fluid
-                        ? {
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
-                            whiteSpace: "nowrap",
-                          }
-                        : {}),
                       ...compactFieldStyle,
                     }}
                     className={clsx("date-picker-field", {

--- a/packages/front-end/components/DatePicker/index.tsx
+++ b/packages/front-end/components/DatePicker/index.tsx
@@ -41,6 +41,12 @@ type Props = {
   clearButton?: boolean;
   wrapRangeInputs?: boolean;
   compact?: boolean;
+  /**
+   * Let the field shrink to fill a constrained container (drops the range
+   * input's 220px min-width) and truncate its text with an ellipsis instead of
+   * forcing width. Use when the picker sits in a narrow/flexible layout cell.
+   */
+  fluid?: boolean;
   disabled?: boolean;
   fixedSpanMode?: {
     phase: "committed" | "choosing";
@@ -115,6 +121,7 @@ export default function DatePicker({
   clearButton = false,
   wrapRangeInputs = false,
   compact = false,
+  fluid = false,
   disabled,
   fixedSpanMode,
 }: Props) {
@@ -349,7 +356,7 @@ export default function DatePicker({
                 width:
                   inputWidth ||
                   (wrapRangeInputs && isRange ? undefined : "100%"),
-                minWidth: isRange ? 220 : undefined,
+                minWidth: fluid ? 0 : isRange ? 220 : undefined,
                 height: compact ? inputHeight : undefined,
                 minHeight: inputHeight,
                 flex: wrapRangeInputs && isRange ? "1 1 220px" : undefined,
@@ -387,10 +394,17 @@ export default function DatePicker({
                     readOnly={!!fixedSpanMode}
                     style={{
                       border: 0,
-                      marginRight: -20,
-                      width: "calc(100% + 30px)",
+                      marginRight: fluid ? 0 : -20,
+                      width: fluid ? "100%" : "calc(100% + 30px)",
                       minHeight: inputHeight,
                       cursor: "pointer",
+                      ...(fluid
+                        ? {
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                          }
+                        : {}),
                       ...compactFieldStyle,
                     }}
                     className={clsx("date-picker-field", {

--- a/packages/front-end/enterprise/components/ProductAnalytics/MainSection/Toolbar/DateRangePicker.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/MainSection/Toolbar/DateRangePicker.tsx
@@ -213,7 +213,6 @@ function CurrentCustomRangeField({
     <DatePicker
       containerClassName="mb-0"
       compact
-      fluid={fullWidth}
       wrapRangeInputs={fullWidth ? false : shouldWrap}
       date={
         dateRange.startDate
@@ -329,7 +328,6 @@ function ComparisonPreviousRangePicker({
     <DatePicker
       containerClassName="mb-0"
       compact
-      fluid={fullWidth}
       wrapRangeInputs={fullWidth ? false : shouldWrap}
       date={getValidDateOffsetByUTC(previousTimeFrame.startDate)}
       date2={getValidDateOffsetByUTC(previousTimeFrame.endDate)}

--- a/packages/front-end/enterprise/components/ProductAnalytics/MainSection/Toolbar/DateRangePicker.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/MainSection/Toolbar/DateRangePicker.tsx
@@ -28,7 +28,12 @@ function MicroLabel({ children }: { children: ReactNode }) {
 }
 
 /** Preset dropdown ("Custom Date Range" etc.) plus the custom-lookback inputs. */
-function DateRangePresetSelect() {
+function DateRangePresetSelect({
+  fullWidth = false,
+}: {
+  /** Stretch the preset dropdown to 100% and lay the lookback # + unit in a row. */
+  fullWidth?: boolean;
+}) {
   const { draftExploreState, setDraftExploreState } = useExplorerContext();
   const { dateRange } = draftExploreState;
 
@@ -63,10 +68,80 @@ function DateRangePresetSelect() {
     latestLookbackRef.current = "";
   };
 
+  const lookbackNumberField = (
+    <Field
+      style={{
+        width: "55px",
+        paddingTop: "0px",
+        paddingBottom: "0px",
+        height: "32px",
+      }}
+      placeholder="#"
+      min="1"
+      value={
+        localLookbackValue !== null
+          ? localLookbackValue
+          : dateRange.lookbackValue?.toString() || ""
+      }
+      onFocus={() => {
+        latestLookbackRef.current = dateRange.lookbackValue?.toString() || "";
+      }}
+      onChange={(e) => {
+        const v = e.target.value;
+        latestLookbackRef.current = v;
+        setLocalLookbackValue(v);
+      }}
+      onBlur={() => {
+        if (skipBlurCommitRef.current) {
+          skipBlurCommitRef.current = false;
+          return;
+        }
+        const toCommit = latestLookbackRef.current;
+        commitLookbackValue(toCommit);
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          const toCommit =
+            latestLookbackRef.current ||
+            dateRange.lookbackValue?.toString() ||
+            "";
+          commitLookbackValue(toCommit);
+          skipBlurCommitRef.current = true;
+          (e.target as HTMLInputElement).blur();
+        }
+      }}
+    />
+  );
+
+  const lookbackUnitSelect = (
+    <Select
+      size="2"
+      style={fullWidth ? { width: "100%" } : undefined}
+      value={dateRange.lookbackUnit || "day"}
+      setValue={(v) => {
+        setDraftExploreState((prev) => ({
+          ...prev,
+          dateRange: {
+            ...prev.dateRange,
+            lookbackUnit: v as (typeof lookbackUnit)[number],
+          },
+        }));
+      }}
+    >
+      {lookbackUnit.map((u) => (
+        <SelectItem key={u} value={u}>
+          {u}(s)
+        </SelectItem>
+      ))}
+    </Select>
+  );
+
   return (
     <>
       <Select
         size="2"
+        style={fullWidth ? { width: "100%" } : undefined}
         value={dateRange.predefined}
         placeholder="Select range"
         setValue={(v) => {
@@ -86,73 +161,18 @@ function DateRangePresetSelect() {
         ))}
       </Select>
 
-      {dateRange.predefined === "customLookback" && (
-        <>
-          <Field
-            style={{
-              width: "55px",
-              paddingTop: "0px",
-              paddingBottom: "0px",
-              height: "32px",
-            }}
-            placeholder="#"
-            min="1"
-            value={
-              localLookbackValue !== null
-                ? localLookbackValue
-                : dateRange.lookbackValue?.toString() || ""
-            }
-            onFocus={() => {
-              latestLookbackRef.current =
-                dateRange.lookbackValue?.toString() || "";
-            }}
-            onChange={(e) => {
-              const v = e.target.value;
-              latestLookbackRef.current = v;
-              setLocalLookbackValue(v);
-            }}
-            onBlur={() => {
-              if (skipBlurCommitRef.current) {
-                skipBlurCommitRef.current = false;
-                return;
-              }
-              const toCommit = latestLookbackRef.current;
-              commitLookbackValue(toCommit);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                const toCommit =
-                  latestLookbackRef.current ||
-                  dateRange.lookbackValue?.toString() ||
-                  "";
-                commitLookbackValue(toCommit);
-                skipBlurCommitRef.current = true;
-                (e.target as HTMLInputElement).blur();
-              }
-            }}
-          />
-          <Select
-            size="2"
-            value={dateRange.lookbackUnit || "day"}
-            setValue={(v) => {
-              setDraftExploreState((prev) => ({
-                ...prev,
-                dateRange: {
-                  ...prev.dateRange,
-                  lookbackUnit: v as (typeof lookbackUnit)[number],
-                },
-              }));
-            }}
-          >
-            {lookbackUnit.map((u) => (
-              <SelectItem key={u} value={u}>
-                {u}(s)
-              </SelectItem>
-            ))}
-          </Select>
-        </>
-      )}
+      {dateRange.predefined === "customLookback" &&
+        (fullWidth ? (
+          <Flex gap="2" align="center" width="100%">
+            {lookbackNumberField}
+            <Box style={{ flex: 1, minWidth: 0 }}>{lookbackUnitSelect}</Box>
+          </Flex>
+        ) : (
+          <>
+            {lookbackNumberField}
+            {lookbackUnitSelect}
+          </>
+        ))}
     </>
   );
 }
@@ -161,53 +181,68 @@ function DateRangePresetSelect() {
 function CurrentCustomRangeField({
   shouldWrap = false,
   label,
+  fullWidth = false,
 }: {
   shouldWrap?: boolean;
   /** Micro-label shown before the custom date range field (e.g. "Current"). */
   label?: ReactNode;
+  /** Render as a single full-width range field (no label) that fills its cell. */
+  fullWidth?: boolean;
 }) {
   const { draftExploreState, setDraftExploreState } = useExplorerContext();
   const { dateRange } = draftExploreState;
 
   if (dateRange.predefined !== "customDateRange") return null;
 
+  const picker = (
+    <DatePicker
+      containerClassName="mb-0"
+      compact
+      wrapRangeInputs={fullWidth ? false : shouldWrap}
+      date={
+        dateRange.startDate
+          ? getValidDateOffsetByUTC(dateRange.startDate)
+          : undefined
+      }
+      date2={
+        dateRange.endDate
+          ? getValidDateOffsetByUTC(dateRange.endDate)
+          : undefined
+      }
+      setDate={(d) => {
+        setDraftExploreState((prev) => ({
+          ...prev,
+          dateRange: {
+            ...prev.dateRange,
+            startDate: d ? format(d, "yyyy-MM-dd") : null,
+          },
+        }));
+      }}
+      setDate2={(d) => {
+        setDraftExploreState((prev) => ({
+          ...prev,
+          dateRange: {
+            ...prev.dateRange,
+            endDate: d ? format(d, "yyyy-MM-dd") : null,
+          },
+        }));
+      }}
+      precision="date"
+    />
+  );
+
+  if (fullWidth) {
+    return (
+      <Box width="100%" style={{ minWidth: 0 }}>
+        {picker}
+      </Box>
+    );
+  }
+
   return (
     <>
       {label && <MicroLabel>{label}</MicroLabel>}
-      <DatePicker
-        containerClassName="mb-0"
-        compact
-        wrapRangeInputs={shouldWrap}
-        date={
-          dateRange.startDate
-            ? getValidDateOffsetByUTC(dateRange.startDate)
-            : undefined
-        }
-        date2={
-          dateRange.endDate
-            ? getValidDateOffsetByUTC(dateRange.endDate)
-            : undefined
-        }
-        setDate={(d) => {
-          setDraftExploreState((prev) => ({
-            ...prev,
-            dateRange: {
-              ...prev.dateRange,
-              startDate: d ? format(d, "yyyy-MM-dd") : null,
-            },
-          }));
-        }}
-        setDate2={(d) => {
-          setDraftExploreState((prev) => ({
-            ...prev,
-            dateRange: {
-              ...prev.dateRange,
-              endDate: d ? format(d, "yyyy-MM-dd") : null,
-            },
-          }));
-        }}
-        precision="date"
-      />
+      {picker}
     </>
   );
 }
@@ -215,11 +250,22 @@ function CurrentCustomRangeField({
 function DefaultDateRangePickerContent({
   shouldWrap = false,
   label,
+  fullWidth = false,
 }: {
   shouldWrap?: boolean;
   /** Micro-label shown before the custom date range field (e.g. "Current"). */
   label?: ReactNode;
+  /** Stack the preset dropdown and date field vertically, each spanning 100%. */
+  fullWidth?: boolean;
 }) {
+  if (fullWidth) {
+    return (
+      <Flex direction="column" gap="2" width="100%" style={{ minWidth: 0 }}>
+        <DateRangePresetSelect fullWidth />
+        <CurrentCustomRangeField fullWidth />
+      </Flex>
+    );
+  }
   return (
     <Flex
       align="center"
@@ -237,10 +283,13 @@ function DefaultDateRangePickerContent({
 function ComparisonPreviousRangePicker({
   shouldWrap = false,
   label,
+  fullWidth = false,
 }: {
   shouldWrap?: boolean;
   /** Micro-label shown before the prior date range field (e.g. "Prior"). */
   label?: ReactNode;
+  /** Render as a single full-width range field (no label) that fills its cell. */
+  fullWidth?: boolean;
 }) {
   const { draftExploreState, setDraftExploreState, compareEnabled } =
     useExplorerContext();
@@ -260,6 +309,49 @@ function ComparisonPreviousRangePicker({
     return null;
   }
 
+  const picker = (
+    <DatePicker
+      containerClassName="mb-0"
+      compact
+      wrapRangeInputs={fullWidth ? false : shouldWrap}
+      date={getValidDateOffsetByUTC(previousTimeFrame.startDate)}
+      date2={getValidDateOffsetByUTC(previousTimeFrame.endDate)}
+      setDate={(d) => {
+        setDraftExploreState((prev) => ({
+          ...prev,
+          previousTimeFrame: prev.previousTimeFrame
+            ? {
+                ...prev.previousTimeFrame,
+                predefined: "customDateRange" as const,
+                startDate: d ? format(d, "yyyy-MM-dd") : null,
+              }
+            : prev.previousTimeFrame,
+        }));
+      }}
+      setDate2={(d) => {
+        setDraftExploreState((prev) => ({
+          ...prev,
+          previousTimeFrame: prev.previousTimeFrame
+            ? {
+                ...prev.previousTimeFrame,
+                predefined: "customDateRange" as const,
+                endDate: d ? format(d, "yyyy-MM-dd") : null,
+              }
+            : prev.previousTimeFrame,
+        }));
+      }}
+      precision="date"
+    />
+  );
+
+  if (fullWidth) {
+    return (
+      <Box width="100%" style={{ minWidth: 0 }}>
+        {picker}
+      </Box>
+    );
+  }
+
   return (
     <Flex
       align="center"
@@ -269,38 +361,7 @@ function ComparisonPreviousRangePicker({
       style={{ minWidth: 0 }}
     >
       {label && <MicroLabel>{label}</MicroLabel>}
-      <DatePicker
-        containerClassName="mb-0"
-        compact
-        wrapRangeInputs={shouldWrap}
-        date={getValidDateOffsetByUTC(previousTimeFrame.startDate)}
-        date2={getValidDateOffsetByUTC(previousTimeFrame.endDate)}
-        setDate={(d) => {
-          setDraftExploreState((prev) => ({
-            ...prev,
-            previousTimeFrame: prev.previousTimeFrame
-              ? {
-                  ...prev.previousTimeFrame,
-                  predefined: "customDateRange" as const,
-                  startDate: d ? format(d, "yyyy-MM-dd") : null,
-                }
-              : prev.previousTimeFrame,
-          }));
-        }}
-        setDate2={(d) => {
-          setDraftExploreState((prev) => ({
-            ...prev,
-            previousTimeFrame: prev.previousTimeFrame
-              ? {
-                  ...prev.previousTimeFrame,
-                  predefined: "customDateRange" as const,
-                  endDate: d ? format(d, "yyyy-MM-dd") : null,
-                }
-              : prev.previousTimeFrame,
-          }));
-        }}
-        precision="date"
-      />
+      {picker}
     </Flex>
   );
 }
@@ -309,14 +370,21 @@ export interface DateRangePickerProps {
   shouldWrap?: boolean;
   /** Micro-label shown before the date range field (e.g. "Current" / "Prior"). */
   label?: ReactNode;
+  /** Stack the preset dropdown and date field vertically, each spanning 100%. */
+  fullWidth?: boolean;
 }
 
 export default function DateRangePicker({
   shouldWrap = false,
   label,
+  fullWidth = false,
 }: DateRangePickerProps = {}) {
   return (
-    <DefaultDateRangePickerContent shouldWrap={shouldWrap} label={label} />
+    <DefaultDateRangePickerContent
+      shouldWrap={shouldWrap}
+      label={label}
+      fullWidth={fullWidth}
+    />
   );
 }
 
@@ -343,10 +411,43 @@ function CompareFieldLabel({ children }: { children: ReactNode }) {
  */
 export function ComparisonDateControls({
   groupBySlot,
+  fullWidth = false,
 }: {
   /** Optional group-by control rendered alongside the prior picker. */
   groupBySlot?: ReactNode;
+  /**
+   * Stack vertically at full width: the preset dropdown spans 100%, and
+   * Prior / Current become `100px 1fr` rows (fixed label column + picker),
+   * laid out Prior above Current.
+   */
+  fullWidth?: boolean;
 }) {
+  if (fullWidth) {
+    const labeledRow = (label: string, field: ReactNode) => (
+      <Box
+        style={{
+          display: "grid",
+          gridTemplateColumns: "100px 1fr",
+          alignItems: "center",
+          columnGap: "var(--space-2)",
+        }}
+      >
+        <MicroLabel>{label}</MicroLabel>
+        {field}
+      </Box>
+    );
+    return (
+      <Flex direction="column" gap="2" width="100%" style={{ minWidth: 0 }}>
+        <DateRangePresetSelect fullWidth />
+        {labeledRow("Prior", <ComparisonPreviousRangePicker fullWidth />)}
+        <Text size="small" weight="medium">
+          vs
+        </Text>
+        {labeledRow("Current", <CurrentCustomRangeField fullWidth />)}
+        {groupBySlot}
+      </Flex>
+    );
+  }
   return (
     <>
       <DateRangePresetSelect />

--- a/packages/front-end/enterprise/components/ProductAnalytics/MainSection/Toolbar/DateRangePicker.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/MainSection/Toolbar/DateRangePicker.tsx
@@ -21,7 +21,7 @@ const PREDEFINED_LABELS: Record<(typeof dateRangePredefined)[number], string> =
 
 function MicroLabel({ children }: { children: ReactNode }) {
   return (
-    <Text size="small" color="text-low" weight="medium">
+    <Text size="small" color="text-low" weight="regular">
       {children}
     </Text>
   );
@@ -137,42 +137,57 @@ function DateRangePresetSelect({
     </Select>
   );
 
+  const presetSelect = (
+    <Select
+      size="2"
+      style={fullWidth ? { width: "100%" } : undefined}
+      value={dateRange.predefined}
+      placeholder="Select range"
+      setValue={(v) => {
+        setDraftExploreState((prev) => ({
+          ...prev,
+          dateRange: {
+            ...prev.dateRange,
+            predefined: v as (typeof dateRangePredefined)[number],
+          },
+        }));
+      }}
+    >
+      {dateRangePredefined.map((option) => (
+        <SelectItem key={option} value={option}>
+          {PREDEFINED_LABELS[option] || option}
+        </SelectItem>
+      ))}
+    </Select>
+  );
+
+  const isCustomLookback = dateRange.predefined === "customLookback";
+
+  if (fullWidth) {
+    // Custom Lookback keeps the preset dropdown, number, and unit on one row
+    // (preset widest, number compact, unit moderate); other presets are just
+    // the full-width dropdown.
+    if (isCustomLookback) {
+      return (
+        <Flex gap="2" align="center" width="100%">
+          <Box style={{ flex: 2, minWidth: 0 }}>{presetSelect}</Box>
+          {lookbackNumberField}
+          <Box style={{ flex: 1, minWidth: 0 }}>{lookbackUnitSelect}</Box>
+        </Flex>
+      );
+    }
+    return presetSelect;
+  }
+
   return (
     <>
-      <Select
-        size="2"
-        style={fullWidth ? { width: "100%" } : undefined}
-        value={dateRange.predefined}
-        placeholder="Select range"
-        setValue={(v) => {
-          setDraftExploreState((prev) => ({
-            ...prev,
-            dateRange: {
-              ...prev.dateRange,
-              predefined: v as (typeof dateRangePredefined)[number],
-            },
-          }));
-        }}
-      >
-        {dateRangePredefined.map((option) => (
-          <SelectItem key={option} value={option}>
-            {PREDEFINED_LABELS[option] || option}
-          </SelectItem>
-        ))}
-      </Select>
-
-      {dateRange.predefined === "customLookback" &&
-        (fullWidth ? (
-          <Flex gap="2" align="center" width="100%">
-            {lookbackNumberField}
-            <Box style={{ flex: 1, minWidth: 0 }}>{lookbackUnitSelect}</Box>
-          </Flex>
-        ) : (
-          <>
-            {lookbackNumberField}
-            {lookbackUnitSelect}
-          </>
-        ))}
+      {presetSelect}
+      {isCustomLookback && (
+        <>
+          {lookbackNumberField}
+          {lookbackUnitSelect}
+        </>
+      )}
     </>
   );
 }
@@ -198,6 +213,7 @@ function CurrentCustomRangeField({
     <DatePicker
       containerClassName="mb-0"
       compact
+      fluid={fullWidth}
       wrapRangeInputs={fullWidth ? false : shouldWrap}
       date={
         dateRange.startDate
@@ -313,6 +329,7 @@ function ComparisonPreviousRangePicker({
     <DatePicker
       containerClassName="mb-0"
       compact
+      fluid={fullWidth}
       wrapRangeInputs={fullWidth ? false : shouldWrap}
       date={getValidDateOffsetByUTC(previousTimeFrame.startDate)}
       date2={getValidDateOffsetByUTC(previousTimeFrame.endDate)}
@@ -416,18 +433,20 @@ export function ComparisonDateControls({
   /** Optional group-by control rendered alongside the prior picker. */
   groupBySlot?: ReactNode;
   /**
-   * Stack vertically at full width: the preset dropdown spans 100%, and
-   * Prior / Current become `100px 1fr` rows (fixed label column + picker),
-   * laid out Prior above Current.
+   * Full-width layout: the preset dropdown spans 100%, then Prior and Current
+   * stack as `100px 1fr` rows (fixed label column + single-line range field
+   * that truncates to fit), with `vs` between them. Prior sits above Current.
    */
   fullWidth?: boolean;
 }) {
   if (fullWidth) {
+    // Fixed 100px label column; the field column shrinks/truncates rather than
+    // forcing width (minmax(0, …) overrides the grid item's min-content floor).
     const labeledRow = (label: string, field: ReactNode) => (
       <Box
         style={{
           display: "grid",
-          gridTemplateColumns: "100px 1fr",
+          gridTemplateColumns: "100px minmax(0, 1fr)",
           alignItems: "center",
           columnGap: "var(--space-2)",
         }}
@@ -439,11 +458,16 @@ export function ComparisonDateControls({
     return (
       <Flex direction="column" gap="2" width="100%" style={{ minWidth: 0 }}>
         <DateRangePresetSelect fullWidth />
-        {labeledRow("Prior", <ComparisonPreviousRangePicker fullWidth />)}
-        <Text size="small" weight="medium">
-          vs
-        </Text>
-        {labeledRow("Current", <CurrentCustomRangeField fullWidth />)}
+        <Flex direction="column" gap="1" width="100%" style={{ minWidth: 0 }}>
+          {labeledRow("Prior", <ComparisonPreviousRangePicker fullWidth />)}
+          {labeledRow(
+            "",
+            <Text size="small" weight="semibold">
+              vs
+            </Text>,
+          )}
+          {labeledRow("Current", <CurrentCustomRangeField fullWidth />)}
+        </Flex>
         {groupBySlot}
       </Flex>
     );

--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ExplorerSideBar.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ExplorerSideBar.tsx
@@ -249,26 +249,20 @@ export default function ExplorerSideBar({
             </Flex>
             <GraphTypeSelector />
           </Flex>
-          <Flex gap="2" wrap="wrap">
-            <Flex direction="column" gap="2" style={{ minWidth: 0 }}>
-              <Text weight="medium">Date Range</Text>
-              {showComparisonDateControls ? (
-                <ComparisonDateControls
-                  groupBySlot={
-                    isTimeSeriesChart ? <GranularitySelector /> : null
-                  }
-                />
-              ) : (
-                <DateRangePicker shouldWrap />
-              )}
-            </Flex>
-            {!showComparisonDateControls && isTimeSeriesChart && (
-              <Flex direction="column" gap="2">
-                <Text weight="medium">Date Granularity</Text>
-                <GranularitySelector />
-              </Flex>
+          <Flex direction="column" gap="2" width="100%" style={{ minWidth: 0 }}>
+            <Text weight="medium">Date Range</Text>
+            {showComparisonDateControls ? (
+              <ComparisonDateControls fullWidth />
+            ) : (
+              <DateRangePicker fullWidth />
             )}
           </Flex>
+          {isTimeSeriesChart && (
+            <Flex direction="column" gap="2" width="100%">
+              <Text weight="medium">Date Granularity</Text>
+              <GranularitySelector />
+            </Flex>
+          )}
         </Flex>
       )}
 


### PR DESCRIPTION
### Features and Changes
Update the Dashboard filter

### Screenshots
Before
<img width="518" height="388" alt="Screenshot 2026-06-23 at 12 40 40" src="https://github.com/user-attachments/assets/2137267b-b144-4c4b-9023-c6cecda65b44" />
<img width="543" height="358" alt="Screenshot 2026-06-23 at 14 16 56" src="https://github.com/user-attachments/assets/6dfd5fa1-5b7d-49a5-95a6-baa1a77a7447" />
<img width="511" height="232" alt="Screenshot 2026-06-23 at 14 17 26" src="https://github.com/user-attachments/assets/8392c39a-d53e-4117-907d-2beaac0497a7" />
<img width="529" height="311" alt="Screenshot 2026-06-23 at 14 17 31" src="https://github.com/user-attachments/assets/118c3cc4-3bd8-4b54-a76e-594f0b688946" />
After
<img width="436" height="351" alt="Screenshot 2026-06-23 at 22 33 10" src="https://github.com/user-attachments/assets/49d337b2-1e52-4317-9d0b-87828ef36cfc" />
<img width="449" height="307" alt="Screenshot 2026-06-23 at 22 33 18" src="https://github.com/user-attachments/assets/0d8e4076-ae38-4750-8824-a54a8e8dcf5e" />
<img width="441" height="267" alt="Screenshot 2026-06-23 at 22 33 24" src="https://github.com/user-attachments/assets/78371120-d4d6-459e-aeb1-634eb1bd4c42" />
<img width="419" height="254" alt="Screenshot 2026-06-23 at 22 33 28" src="https://github.com/user-attachments/assets/e44ba159-d71c-4951-bc54-dca6ffd3e9e1" />

