### PR TITLE
feat: add Rules column to features list

### DIFF
--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -2656,6 +2656,7 @@ export async function getFeatureMetaInfoById(
     prerequisites: 1,
     "rules.prerequisites": 1,
     "rules.savedGroups": 1,
+    "rules.type": 1,
     environmentSettings: 1,
   };
   if (includeDefaultValue) {
@@ -2669,10 +2670,17 @@ export async function getFeatureMetaInfoById(
     .map((f) => {
       const doc = f as unknown as Record<string, unknown>;
       const rules = doc.rules as
-        | { prerequisites?: unknown[]; savedGroups?: unknown[] }[]
+        | {
+            prerequisites?: unknown[];
+            savedGroups?: unknown[];
+            type?: string;
+          }[]
         | undefined;
       const envSettings = doc.environmentSettings as
-        | Record<string, { prerequisites?: unknown[] }>
+        | Record<
+            string,
+            { prerequisites?: unknown[]; rules?: { type?: string }[] }
+          >
         | undefined;
       const topPrereqs = doc.prerequisites as unknown[] | undefined;
 
@@ -2686,6 +2694,30 @@ export async function getFeatureMetaInfoById(
       const hasSavedGroups = (rules ?? []).some(
         (r) => (r.savedGroups?.length ?? 0) > 0,
       );
+
+      const ruleTypesSet = new Set<string>();
+      if (rules) {
+        rules.forEach((r) => r.type && ruleTypesSet.add(r.type));
+      }
+      if (envSettings) {
+        Object.values(envSettings).forEach((env) => {
+          if (env.rules) {
+            env.rules.forEach((r) => r.type && ruleTypesSet.add(r.type));
+          }
+        });
+      }
+      const RULE_ORDER = [
+        "experiment",
+        "experiment-ref",
+        "safe-rollout",
+        "rollout",
+        "force",
+      ];
+      const ruleTypes = Array.from(ruleTypesSet).sort((a, b) => {
+        const indexA = RULE_ORDER.indexOf(a);
+        const indexB = RULE_ORDER.indexOf(b);
+        return (indexA === -1 ? 99 : indexA) - (indexB === -1 ? 99 : indexB);
+      }) as FeatureMetaInfo["ruleTypes"];
 
       return {
         id: f.id,
@@ -2702,6 +2734,7 @@ export async function getFeatureMetaInfoById(
         neverStale: f.neverStale,
         hasPrerequisites,
         hasSavedGroups,
+        ruleTypes,
         revision: f.revision as FeatureMetaInfo["revision"],
         ...(includeDefaultValue && { defaultValue: f.defaultValue ?? "" }),
       };
@@ -2731,26 +2764,61 @@ export async function getFeatureMetaInfoByIds(
       neverStale: 1,
       "jsonSchema.enabled": 1,
       revision: 1,
+      "rules.type": 1,
+      "environmentSettings.rules.type": 1,
     },
   );
 
   return features
     .filter((f) => context.permissions.canReadSingleProjectResource(f.project))
-    .map((f) => ({
-      id: f.id,
-      project: f.project,
-      archived: f.archived,
-      description: f.description,
-      dateCreated: f.dateCreated,
-      dateUpdated: f.dateUpdated,
-      tags: f.tags,
-      owner: f.owner,
-      valueType: f.valueType,
-      version: f.version,
-      linkedExperiments: f.linkedExperiments,
-      neverStale: f.neverStale,
-      revision: f.revision as FeatureMetaInfo["revision"],
-    }));
+    .map((f) => {
+      const doc = f as unknown as Record<string, unknown>;
+      const rules = doc.rules as { type?: string }[] | undefined;
+      const envSettings = doc.environmentSettings as
+        | Record<string, { rules?: { type?: string }[] }>
+        | undefined;
+
+      const ruleTypesSet = new Set<string>();
+      if (rules) {
+        rules.forEach((r) => r.type && ruleTypesSet.add(r.type));
+      }
+      if (envSettings) {
+        Object.values(envSettings).forEach((env) => {
+          if (env.rules) {
+            env.rules.forEach((r) => r.type && ruleTypesSet.add(r.type));
+          }
+        });
+      }
+      const RULE_ORDER = [
+        "experiment",
+        "experiment-ref",
+        "safe-rollout",
+        "rollout",
+        "force",
+      ];
+      const ruleTypes = Array.from(ruleTypesSet).sort((a, b) => {
+        const indexA = RULE_ORDER.indexOf(a);
+        const indexB = RULE_ORDER.indexOf(b);
+        return (indexA === -1 ? 99 : indexA) - (indexB === -1 ? 99 : indexB);
+      }) as FeatureMetaInfo["ruleTypes"];
+
+      return {
+        id: f.id,
+        project: f.project,
+        archived: f.archived,
+        description: f.description,
+        dateCreated: f.dateCreated,
+        dateUpdated: f.dateUpdated,
+        tags: f.tags,
+        owner: f.owner,
+        valueType: f.valueType,
+        version: f.version,
+        linkedExperiments: f.linkedExperiments,
+        neverStale: f.neverStale,
+        ruleTypes,
+        revision: f.revision as FeatureMetaInfo["revision"],
+      };
+    });
 }
 
 export async function getFeatureEnvStatus(

--- a/packages/back-end/test/models/FeatureModel.test.ts
+++ b/packages/back-end/test/models/FeatureModel.test.ts
@@ -7,6 +7,7 @@ import {
   migrateRawFeatureToV2,
   buildFeatureUpdate,
   toInterface,
+  getFeatureMetaInfoById,
 } from "back-end/src/models/FeatureModel";
 import { ReqContext } from "back-end/types/request";
 
@@ -1649,5 +1650,104 @@ describe("toInterface round-trip", () => {
     const result = toInterface(doc, mockContext());
     expect((result as unknown as { _id?: unknown })._id).toBeUndefined();
     expect((result as unknown as { __v?: unknown }).__v).toBeUndefined();
+  });
+});
+
+describe("getFeatureMetaInfoById ruleTypes extraction", () => {
+  let findSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    findSpy = jest.spyOn(FeatureModel, "find");
+  });
+
+  afterEach(() => {
+    findSpy.mockRestore();
+  });
+
+  const mockContextWithPerms = {
+    org: { id: "test_org" },
+    permissions: {
+      canReadSingleProjectResource: () => true,
+    },
+  } as unknown as ReqContext;
+
+  it("extracts v2 top-level rules correctly with sorting", async () => {
+    findSpy.mockResolvedValue([
+      {
+        id: "feat1",
+        project: "test",
+        rules: [
+          { type: "force" },
+          { type: "experiment" },
+          { type: "experiment-ref" },
+        ],
+      },
+    ]);
+
+    const res = await getFeatureMetaInfoById(mockContextWithPerms);
+    expect(res).toHaveLength(1);
+    expect(res[0].ruleTypes).toEqual(["experiment", "experiment-ref", "force"]);
+  });
+
+  it("extracts v1 environment rules correctly", async () => {
+    findSpy.mockResolvedValue([
+      {
+        id: "feat1",
+        project: "test",
+        environmentSettings: {
+          dev: {
+            rules: [{ type: "rollout" }],
+          },
+          production: {
+            rules: [{ type: "safe-rollout" }, { type: "force" }],
+          },
+        },
+      },
+    ]);
+
+    const res = await getFeatureMetaInfoById(mockContextWithPerms);
+    expect(res).toHaveLength(1);
+    expect(res[0].ruleTypes).toEqual(["safe-rollout", "rollout", "force"]);
+  });
+
+  it("deduplicates duplicate rule types", async () => {
+    findSpy.mockResolvedValue([
+      {
+        id: "feat1",
+        project: "test",
+        rules: [{ type: "force" }, { type: "force" }],
+        environmentSettings: {
+          dev: {
+            rules: [{ type: "force" }, { type: "experiment" }],
+          },
+        },
+      },
+    ]);
+
+    const res = await getFeatureMetaInfoById(mockContextWithPerms);
+    expect(res).toHaveLength(1);
+    expect(res[0].ruleTypes).toEqual(["experiment", "force"]);
+  });
+
+  it("returns empty array for features with no rules", async () => {
+    findSpy.mockResolvedValue([
+      {
+        id: "feat1",
+        project: "test",
+        rules: [],
+        environmentSettings: {
+          dev: { rules: [] },
+        },
+      },
+      {
+        id: "feat2",
+        project: "test",
+      },
+    ]);
+
+    const res = await getFeatureMetaInfoById(mockContextWithPerms);
+    expect(res).toHaveLength(2);
+    expect(res[0].ruleTypes).toEqual([]);
+    expect(res[1].ruleTypes).toEqual([]);
   });
 });

--- a/packages/front-end/pages/features/index.tsx
+++ b/packages/front-end/pages/features/index.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/router";
 import { useFeature } from "@growthbook/growthbook-react";
 import { Box, Flex } from "@radix-ui/themes";
 import { FaRegCircleCheck, FaRegCircleXmark } from "react-icons/fa6";
-import { FeatureInterface } from "shared/types/feature";
+import { FeatureInterface, FeatureMetaInfo } from "shared/types/feature";
 import { date, datetime } from "shared/dates";
 import { featureHasEnvironment } from "shared/util";
 import { getDemoDatasourceProjectIdForOrganization } from "shared/demo-datasource";
@@ -45,6 +45,7 @@ import {
   draftStatusDots,
   draftStatusTooltip,
 } from "@/components/Reviews/RevisionStatusBadge";
+import Badge from "@/ui/Badge";
 import { useFeatureContentSearch } from "@/hooks/useFeatureContentSearch";
 import type { ContentSearchParams } from "@/hooks/useFeatureContentSearch";
 import { useFeatureRampStates } from "@/hooks/useFeatureRampStates";
@@ -154,7 +155,7 @@ export default function FeaturesPage() {
     () =>
       showArchived
         ? undefined
-        : (items: FeatureInterface[]) => items.filter((f) => !f.archived),
+        : (items: FeatureMetaInfo[]) => items.filter((f) => !f.archived),
     [showArchived],
   );
 
@@ -165,7 +166,7 @@ export default function FeaturesPage() {
     setSearchValue,
     syntaxFilters,
   } = useFeatureSearch({
-    allFeatures: allFeatures as unknown as FeatureInterface[],
+    allFeatures,
     environments,
     environmentStatus: statusHook.environmentStatus,
     draftStates: draftHook.draftStates,
@@ -349,6 +350,7 @@ export default function FeaturesPage() {
                 >
                   Tags
                 </TableColumnHeader>
+                <TableColumnHeader>Rules</TableColumnHeader>
                 {toggleEnvs.map((en) => (
                   <TableColumnHeader
                     key={en.id}
@@ -449,6 +451,33 @@ export default function FeaturesPage() {
                           )}
                         />
                       </div>
+                    </TableCell>
+                    <TableCell>
+                      {feature.ruleTypes && feature.ruleTypes.length > 0 ? (
+                        <div
+                          style={{
+                            display: "flex",
+                            gap: "4px",
+                            flexWrap: "wrap",
+                          }}
+                        >
+                          {feature.ruleTypes.map((type) => {
+                            let label =
+                              type.charAt(0).toUpperCase() + type.slice(1);
+                            if (type === "experiment-ref")
+                              label = "Experiment Ref";
+                            else if (type === "safe-rollout")
+                              label = "Safe Rollout";
+                            return (
+                              <Badge key={type} color="gray">
+                                {label}
+                              </Badge>
+                            );
+                          })}
+                        </div>
+                      ) : (
+                        "—"
+                      )}
                     </TableCell>
                     {toggleEnvs.map((en) => (
                       <TableCell key={en.id}>

--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -189,7 +189,19 @@ export function useEnvironments() {
   return environments;
 }
 
-export function useFeatureSearch({
+type SearchableFeature = Pick<
+  FeatureInterface,
+  | "id"
+  | "description"
+  | "tags"
+  | "project"
+  | "archived"
+  | "valueType"
+  | "owner"
+  | "neverStale"
+>;
+
+export function useFeatureSearch<T extends SearchableFeature>({
   allFeatures,
   defaultSortField = "id",
   filterResults,
@@ -203,7 +215,7 @@ export function useFeatureSearch({
   experimentStates,
   contentSearchPrefixes = [],
 }: {
-  allFeatures: FeatureInterface[];
+  allFeatures: T[];
   defaultSortField?:
     | "id"
     | "description"
@@ -211,7 +223,7 @@ export function useFeatureSearch({
     | "defaultValue"
     | "dateCreated"
     | "dateUpdated";
-  filterResults?: (items: FeatureInterface[]) => FeatureInterface[];
+  filterResults?: (items: T[]) => T[];
   environments: Environment[];
   localStorageKey?: string;
   environmentStatus?: Record<string, Record<string, boolean>>;

--- a/packages/shared/types/feature.d.ts
+++ b/packages/shared/types/feature.d.ts
@@ -161,6 +161,9 @@ export type FeatureMetaInfo = Pick<
   defaultValue?: string;
   hasPrerequisites?: boolean;
   hasSavedGroups?: boolean;
+  ruleTypes?: Array<
+    "force" | "rollout" | "safe-rollout" | "experiment" | "experiment-ref"
+  >;
   revision?: {
     version: number;
     comment: string;


### PR DESCRIPTION
Closes #6190

## Summary

Adds a new **Rules** column to the Features list, allowing users to quickly see which rule types are assigned to each feature (e.g. Experiment, Experiment Ref, Safe Rollout, Rollout, Force).

## Changes

### Backend

* Added rule type fields to the feature metadata projection.
* Extracted unique rule types from both v2 top-level rules and legacy v1 environment-specific rules.
* Added deterministic sorting for rule type display.

### Shared Types

* Added a strongly typed `ruleTypes` field to `FeatureMetaInfo`.

### Frontend

* Added a new **Rules** column after **Tags** in the Features table.
* Rendered rule types as badges using existing UI patterns.
* Added an empty-state fallback (`—`) for features without rules.
* Preserved distinct display values for **Experiment** and **Experiment Ref**.

### Tests

* Added backend unit tests covering:

  * v1 environment rules
  * v2 top-level rules
  * duplicate rule types
  * features with no rules

## Verification

* Build and type-check the application.
* Navigate to `/features`.
* Confirm features display the expected rule type badges.
* Verify features without rules show an empty-state indicator.
* Verify duplicate rule types are not displayed multiple times.
