### PR TITLE
feat(agg-fact-table): defer first aggregation to next scheduled slot on creation

### DIFF
--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -17,6 +17,7 @@ import { ApiReqContext } from "back-end/types/api";
 import { promiseAllChunks } from "back-end/src/util/promise";
 import { projectFilterQuery } from "back-end/src/util/mongo.util";
 import { createModelAuditLogger } from "back-end/src/services/audit";
+import { deferAggregatedFactTableToNextSlot } from "back-end/src/services/aggregatedFactTables";
 
 const audit = createModelAuditLogger({
   entity: "factTable",
@@ -303,6 +304,8 @@ export async function createFactTable(
   const factTable = toInterface(doc);
 
   await audit.logCreate(context, factTable);
+
+  await deferAggregatedFactTableToNextSlot(context, factTable);
 
   return factTable;
 }

--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -297,15 +297,17 @@ export async function createFactTable(
     context.permissions.throwPermissionError();
   }
 
-  const doc = await FactTableModel.create(
-    createPropsToInterface(context, data),
-  );
+  const factTableProps = createPropsToInterface(context, data);
+
+  // We claim this slot first to avoid a potential race condition when the FactTable is created at
+  // the same time the background job is scheduling the aggregated table update
+  await deferAggregatedFactTableToNextSlot(context, factTableProps);
+
+  const doc = await FactTableModel.create(factTableProps);
 
   const factTable = toInterface(doc);
 
   await audit.logCreate(context, factTable);
-
-  await deferAggregatedFactTableToNextSlot(context, factTable);
 
   return factTable;
 }

--- a/packages/back-end/src/services/aggregatedFactTables.ts
+++ b/packages/back-end/src/services/aggregatedFactTables.ts
@@ -13,9 +13,11 @@ import {
 } from "shared/validators";
 import { QueryStatus } from "shared/types/query";
 import { ReqContext } from "back-end/types/request";
+import { ApiReqContext } from "back-end/types/api";
 import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 import { getSourceIntegrationObject } from "back-end/src/services/datasource";
 import { logger } from "back-end/src/util/logger";
+import { getMostRecentUpdateOccurrence } from "back-end/src/util/factTable";
 import {
   AggregatedFactTableQueryRunner,
   AggregatedFactTableRunMode,
@@ -149,6 +151,54 @@ export function getAggregatedFactTableMetrics({
     metric,
     ...getAutoSliceMetrics({ metric, factTable }),
   ]);
+}
+
+/**
+ * Claims the current slot for each enabled id type on a new fact table so the
+ * first aggregation waits for the next updateTime instead of restating right
+ * after creation.
+ *
+ * No-op unless aggregation is already enabled.
+ */
+export async function deferAggregatedFactTableToNextSlot(
+  context: ReqContext | ApiReqContext,
+  factTable: Pick<
+    FactTableInterface,
+    "id" | "datasource" | "aggregatedFactTableSettings"
+  >,
+) {
+  const settings = factTable.aggregatedFactTableSettings;
+  if (!settings?.idTypes?.length) return;
+  if (!context.hasPremiumFeature("pipeline-mode")) return;
+
+  let fireTime: Date;
+  try {
+    fireTime = getMostRecentUpdateOccurrence(settings.updateTime);
+  } catch (e) {
+    logger.error(
+      e,
+      `Invalid aggregatedFactTableSettings.updateTime for fact table ${factTable.id}; skipping schedule seed`,
+    );
+    return;
+  }
+
+  for (const idType of settings.idTypes) {
+    try {
+      await context.models.aggregatedFactTables.claimScheduledSlot(
+        {
+          datasourceId: factTable.datasource,
+          factTableId: factTable.id,
+          idType,
+        },
+        fireTime,
+      );
+    } catch (e) {
+      logger.error(
+        e,
+        `Failed to seed aggregated fact table slot for ${factTable.id}/${idType}`,
+      );
+    }
+  }
 }
 
 export function getAggregatedFactTableMaterializationStatus(

--- a/packages/back-end/src/services/aggregatedFactTables.ts
+++ b/packages/back-end/src/services/aggregatedFactTables.ts
@@ -184,14 +184,20 @@ export async function deferAggregatedFactTableToNextSlot(
 
   for (const idType of settings.idTypes) {
     try {
-      await context.models.aggregatedFactTables.claimScheduledSlot(
-        {
-          datasourceId: factTable.datasource,
-          factTableId: factTable.id,
-          idType,
-        },
-        fireTime,
-      );
+      const claimed =
+        await context.models.aggregatedFactTables.claimScheduledSlot(
+          {
+            datasourceId: factTable.datasource,
+            factTableId: factTable.id,
+            idType,
+          },
+          fireTime,
+        );
+      if (!claimed) {
+        logger.debug(
+          `Aggregated fact table slot for ${factTable.id}/${idType} was already claimed for ${fireTime.toISOString()}; deferral had no effect`,
+        );
+      }
     } catch (e) {
       logger.error(
         e,

--- a/packages/back-end/test/util/factTable.test.ts
+++ b/packages/back-end/test/util/factTable.test.ts
@@ -3,7 +3,10 @@ import {
   DataSourceInterface,
   GrowthbookClickhouseDataSource,
 } from "shared/types/datasource";
-import { deriveUserIdTypesFromColumns } from "back-end/src/util/factTable";
+import {
+  deriveUserIdTypesFromColumns,
+  getMostRecentUpdateOccurrence,
+} from "back-end/src/util/factTable";
 
 function makeColumn(column: string, deleted = false): ColumnInterface {
   return {
@@ -36,6 +39,59 @@ function makeStandardDatasource(
     settings: { userIdTypes },
   } as unknown as DataSourceInterface;
 }
+
+describe("getMostRecentUpdateOccurrence", () => {
+  const updateTime = { time: "02:00", timezone: "UTC" };
+
+  it("returns today's slot once now is past it", () => {
+    expect(
+      getMostRecentUpdateOccurrence(
+        updateTime,
+        new Date("2024-01-10T10:00:00Z"),
+      ),
+    ).toEqual(new Date("2024-01-10T02:00:00Z"));
+  });
+
+  it("is stable across the rest of the day (keeps the poller from re-claiming)", () => {
+    const morning = getMostRecentUpdateOccurrence(
+      updateTime,
+      new Date("2024-01-10T02:30:00Z"),
+    );
+    const night = getMostRecentUpdateOccurrence(
+      updateTime,
+      new Date("2024-01-10T23:59:00Z"),
+    );
+    expect(morning).toEqual(night);
+    expect(morning).toEqual(new Date("2024-01-10T02:00:00Z"));
+  });
+
+  it("rolls back to the previous day when now is before today's slot", () => {
+    expect(
+      getMostRecentUpdateOccurrence(
+        updateTime,
+        new Date("2024-01-10T01:00:00Z"),
+      ),
+    ).toEqual(new Date("2024-01-09T02:00:00Z"));
+  });
+
+  it("advances to the next day's slot once it passes (poller fires then)", () => {
+    expect(
+      getMostRecentUpdateOccurrence(
+        updateTime,
+        new Date("2024-01-11T02:30:00Z"),
+      ),
+    ).toEqual(new Date("2024-01-11T02:00:00Z"));
+  });
+
+  it("resolves the slot in the table's timezone", () => {
+    expect(
+      getMostRecentUpdateOccurrence(
+        { time: "02:00", timezone: "America/New_York" },
+        new Date("2024-01-10T12:00:00Z"),
+      ),
+    ).toEqual(new Date("2024-01-10T07:00:00Z"));
+  });
+});
 
 describe("deriveUserIdTypesFromColumns", () => {
   describe("growthbook_clickhouse datasource", () => {


### PR DESCRIPTION
### Features and Changes

When a fact table is created with aggregation already enabled, the scheduling poller would pick it up on its next pass and immediately run a full restate if a metric existed, even though the table was created moments ago. That first run is redundant and expensive.

This seeds the schedule on creation so the first aggregation waits for the next scheduled `updateTime` slot instead of firing right away. 

### Testing

- Unit tests
