### PR TITLE
Show effective (user + team) project role in member tables

### DIFF
--- a/packages/front-end/components/Settings/Team/MemberList.tsx
+++ b/packages/front-end/components/Settings/Team/MemberList.tsx
@@ -5,7 +5,10 @@ import { date, datetime } from "shared/dates";
 import { RxIdCard } from "react-icons/rx";
 import router from "next/router";
 import { Flex } from "@radix-ui/themes";
-import { getRoleDisplayName } from "shared/permissions";
+import {
+  getEffectiveRolesForProject,
+  getRoleDisplayName,
+} from "shared/permissions";
 import { roleHasAccessToEnv, useAuth } from "@/services/auth";
 import { useUser } from "@/services/UserContext";
 import ProjectBadges from "@/components/ProjectBadges";
@@ -42,7 +45,7 @@ const MemberList: FC<{
 }) => {
   const [inviting, setInviting] = useState(!!router.query["just-subscribed"]);
   const { apiCall } = useAuth();
-  const { userId, users, organization } = useUser();
+  const { userId, users, organization, teams } = useUser();
   const [roleModal, setRoleModal] = useState<string>("");
   const [projectRoleModal, setProjectRoleModal] = useState<string>("");
   const [passwordResetModal, setPasswordResetModal] =
@@ -171,6 +174,13 @@ const MemberList: FC<{
                 <SortableTH field="dateCreated">Date Joined</SortableTH>
                 <SortableTH field="lastLoginDate">Last Login</SortableTH>
                 <th>{project ? "Project Role" : "Global Role"}</th>
+                <th>
+                  <Tooltip body="The role(s) that actually apply after combining this member's own role with any teams they're on. Hover a value to see each source.">
+                    {project
+                      ? "Effective Project Role"
+                      : "Effective Global Role"}
+                  </Tooltip>
+                </th>
                 {!project && <th>Project Roles</th>}
                 {environments.map((env) => (
                   <th key={env.id}>{env.id}</th>
@@ -185,6 +195,30 @@ const MemberList: FC<{
                   (project &&
                     member.projectRoles?.find((r) => r.project === project)) ||
                   member;
+                const effectiveRoles = getEffectiveRolesForProject(
+                  member,
+                  project || null,
+                  teams || [],
+                );
+                const effectiveByRole: { role: string; sources: string[] }[] =
+                  [];
+                effectiveRoles.forEach((er) => {
+                  const src =
+                    er.sourceType === "user"
+                      ? "Direct"
+                      : `Team: ${er.sourceName}`;
+                  const existing = effectiveByRole.find(
+                    (e) => e.role === er.role,
+                  );
+                  if (existing) existing.sources.push(src);
+                  else effectiveByRole.push({ role: er.role, sources: [src] });
+                });
+                const effectiveLabel = effectiveByRole
+                  .map((e) => getRoleDisplayName(e.role, organization))
+                  .join(", ");
+                const effectiveFromTeam = effectiveRoles.some(
+                  (er) => er.sourceType === "team",
+                );
                 return (
                   <tr key={member.id}>
                     <td>{member.name}</td>
@@ -208,6 +242,28 @@ const MemberList: FC<{
                       {member.lastLoginDate && date(member.lastLoginDate)}
                     </td>
                     <td>{getRoleDisplayName(roleInfo.role, organization)}</td>
+                    <td>
+                      {effectiveFromTeam || effectiveByRole.length > 1 ? (
+                        <Tooltip
+                          body={
+                            <>
+                              {effectiveByRole.map((e) => (
+                                <div key={e.role}>
+                                  {getRoleDisplayName(e.role, organization)} —{" "}
+                                  {e.sources.join(", ")}
+                                </div>
+                              ))}
+                            </>
+                          }
+                        >
+                          <span style={{ textDecoration: "underline dotted" }}>
+                            {effectiveLabel}
+                          </span>
+                        </Tooltip>
+                      ) : (
+                        effectiveLabel
+                      )}
+                    </td>
                     {!project && (
                       <td className="col-2">
                         {member.projectRoles?.map((pr) => {

--- a/packages/shared/src/permissions/permissions.utils.ts
+++ b/packages/shared/src/permissions/permissions.utils.ts
@@ -190,3 +190,77 @@ export function roleToPermissionMap(
   const policies = role?.policies || [];
   return getPermissionsObjectByPolicies(policies);
 }
+
+export type EffectiveRoleSource = {
+  role: string;
+  sourceType: "user" | "team";
+  sourceName: string;
+};
+
+/**
+ * Resolve the roles that actually apply to a member, combining their own role
+ * with any teams they're on, using the same precedence as the back-end
+ * permission merge (mergeUserAndTeamPermissions): an explicit project-scoped
+ * role — from the member or any team — takes precedence over global roles for
+ * that project, and only when no explicit project role applies do global roles
+ * contribute. The result is the set of contributing roles (a union, which may
+ * be more than one role). Pass `project = null` to resolve global roles.
+ */
+export function getEffectiveRolesForProject(
+  member: Pick<MemberRoleInfo, "role"> & {
+    projectRoles?: ProjectMemberRole[];
+    teams?: string[];
+  },
+  project: string | null,
+  teams: {
+    id: string;
+    name: string;
+    role: string;
+    projectRoles?: ProjectMemberRole[];
+  }[],
+): EffectiveRoleSource[] {
+  const teamsById = new Map(teams.map((t) => [t.id, t]));
+
+  const principals: {
+    sourceType: "user" | "team";
+    sourceName: string;
+    role: string;
+    projectRoles?: ProjectMemberRole[];
+  }[] = [
+    {
+      sourceType: "user",
+      sourceName: "user",
+      role: member.role,
+      projectRoles: member.projectRoles,
+    },
+  ];
+  (member.teams || []).forEach((teamId) => {
+    const team = teamsById.get(teamId);
+    if (team) {
+      principals.push({
+        sourceType: "team",
+        sourceName: team.name,
+        role: team.role,
+        projectRoles: team.projectRoles,
+      });
+    }
+  });
+
+  const explicit: EffectiveRoleSource[] = [];
+  const globals: EffectiveRoleSource[] = [];
+  principals.forEach((p) => {
+    const projectRole = project
+      ? p.projectRoles?.find((r) => r.project === project)
+      : undefined;
+    const { sourceType, sourceName } = p;
+    if (projectRole) {
+      explicit.push({ role: projectRole.role, sourceType, sourceName });
+    } else {
+      globals.push({ role: p.role, sourceType, sourceName });
+    }
+  });
+
+  // An explicit project role takes precedence over global roles, so only fall
+  // back to global roles when no explicit project role applies.
+  return explicit.length ? explicit : globals;
+}

--- a/packages/shared/test/permissions.test.ts
+++ b/packages/shared/test/permissions.test.ts
@@ -1114,6 +1114,26 @@ describe("getEffectiveRolesForProject", () => {
     ]);
   });
 
+  it("drops the member's global role when only a team has an explicit project role", () => {
+    const result = getEffectiveRolesForProject(
+      { role: "admin", teams: ["team_1"] },
+      "prj_1",
+      [
+        team("team_1", "Restricted", "readonly", [
+          {
+            project: "prj_1",
+            role: "noaccess",
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        ]),
+      ],
+    );
+    expect(result).toEqual([
+      { role: "noaccess", sourceType: "team", sourceName: "Restricted" },
+    ]);
+  });
+
   it("resolves global roles (user + teams) when project is null", () => {
     const result = getEffectiveRolesForProject(
       {

--- a/packages/shared/test/permissions.test.ts
+++ b/packages/shared/test/permissions.test.ts
@@ -1,5 +1,9 @@
 import { OrganizationInterface } from "shared/types/organization";
-import { roleToPermissionMap, Permissions } from "../permissions";
+import {
+  roleToPermissionMap,
+  Permissions,
+  getEffectiveRolesForProject,
+} from "../permissions";
 
 describe("Role permissions", () => {
   const testOrg: OrganizationInterface = {
@@ -1001,5 +1005,135 @@ describe("canManageFeatureCustomHooks", () => {
     expect(
       getPermissions("readonly").canManageFeatureCustomHooks(featureResource),
     ).toBe(false);
+  });
+});
+
+describe("getEffectiveRolesForProject", () => {
+  const team = (
+    id: string,
+    name: string,
+    role: string,
+    projectRoles: {
+      project: string;
+      role: string;
+      limitAccessByEnvironment: boolean;
+      environments: string[];
+    }[] = [],
+  ) => ({ id, name, role, projectRoles });
+
+  it("returns just the member's global role when they have no project role and no teams", () => {
+    expect(
+      getEffectiveRolesForProject({ role: "engineer" }, "prj_1", []),
+    ).toEqual([{ role: "engineer", sourceType: "user", sourceName: "user" }]);
+  });
+
+  it("uses the member's own project role over their global role", () => {
+    expect(
+      getEffectiveRolesForProject(
+        {
+          role: "engineer",
+          projectRoles: [
+            {
+              project: "prj_1",
+              role: "analyst",
+              limitAccessByEnvironment: false,
+              environments: [],
+            },
+          ],
+        },
+        "prj_1",
+        [],
+      ),
+    ).toEqual([{ role: "analyst", sourceType: "user", sourceName: "user" }]);
+  });
+
+  it("does not let a team's global role leak past the member's explicit project role", () => {
+    const result = getEffectiveRolesForProject(
+      {
+        role: "readonly",
+        projectRoles: [
+          {
+            project: "prj_1",
+            role: "noaccess",
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        ],
+        teams: ["team_1"],
+      },
+      "prj_1",
+      [team("team_1", "Readers", "readonly")],
+    );
+    // The team has no explicit project role, so only the explicit project role applies.
+    expect(result).toEqual([
+      { role: "noaccess", sourceType: "user", sourceName: "user" },
+    ]);
+  });
+
+  it("unions explicit project roles from the member and their teams", () => {
+    const result = getEffectiveRolesForProject(
+      {
+        role: "readonly",
+        projectRoles: [
+          {
+            project: "prj_1",
+            role: "noaccess",
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        ],
+        teams: ["team_1"],
+      },
+      "prj_1",
+      [
+        team("team_1", "Engineers", "noaccess", [
+          {
+            project: "prj_1",
+            role: "engineer",
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        ]),
+      ],
+    );
+    expect(result).toEqual([
+      { role: "noaccess", sourceType: "user", sourceName: "user" },
+      { role: "engineer", sourceType: "team", sourceName: "Engineers" },
+    ]);
+  });
+
+  it("falls back to global roles (user + teams) when no explicit project role applies", () => {
+    const result = getEffectiveRolesForProject(
+      { role: "readonly", teams: ["team_1"] },
+      "prj_1",
+      [team("team_1", "Engineers", "engineer")],
+    );
+    expect(result).toEqual([
+      { role: "readonly", sourceType: "user", sourceName: "user" },
+      { role: "engineer", sourceType: "team", sourceName: "Engineers" },
+    ]);
+  });
+
+  it("resolves global roles (user + teams) when project is null", () => {
+    const result = getEffectiveRolesForProject(
+      {
+        role: "readonly",
+        projectRoles: [
+          {
+            project: "prj_1",
+            role: "engineer",
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        ],
+        teams: ["team_1"],
+      },
+      null,
+      [team("team_1", "Admins", "admin")],
+    );
+    expect(result).toEqual([
+      { role: "readonly", sourceType: "user", sourceName: "user" },
+      { role: "admin", sourceType: "team", sourceName: "Admins" },
+    ]);
   });
 });


### PR DESCRIPTION
### Features and Changes

The member tables on the **Members** page ("View roles and permissions for [PROJECT]") and the **Project** page (Project Members) only showed each member's *user-level* role for the selected project. They didn't reflect the role that actually applies once team memberships are combined in — so a member who is, say, `No Access` directly but `Engineer` via a team appeared as `No Access`.

- Adds a shared util `getEffectiveRolesForProject(member, project, teams)` that resolves the roles actually in effect for a member on a project, combining their own role with any teams they're on. It uses the same precedence as the back-end permission merge (#6179): an explicit project-scoped role — from the member or any team — takes precedence over global roles for that project, and global roles only contribute when no explicit project role applies. The result is the set of contributing roles (a union, which can be more than one). Pass `project = null` for the global/"All Projects" view.
- Adds an **Effective Role** column to `MemberList` (shared by both views). It renders the resulting role(s), and when teams contribute (or more than one role applies) shows a tooltip naming each source (`Direct` / `Team: <name>`). The existing user-level role column is kept for comparison, per the request.

Both views pick this up automatically since they share `MemberList`. No back-end changes — all the needed data (member `teams`, team `projectRoles`) is already on the client via `useUser()`.

Note: the per-environment access columns still reflect the user-level role; extending those to the effective role would be a reasonable follow-up but is out of scope here.

### Testing

- [x] Unit tests for `getEffectiveRolesForProject` in `packages/shared/test/permissions.test.ts` (own-project-role over global; team global not leaking past an explicit project role; union of explicit user + team project roles; global fallback when no project role applies; `project = null` global resolution)
- [x] Visual check of both the Members page and Project page member tables

### Screenshots

<img width="1648" height="627" alt="image" src="https://github.com/user-attachments/assets/9d5c271d-9e88-45ee-9721-a72b13690b6b" />

<img width="1680" height="920" alt="image" src="https://github.com/user-attachments/assets/6926d215-eae6-4dd2-afa3-982d6ac63093" />
