### PR TITLE
feat(back-end): use native approximate top-k aggregates for fact table column top values

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -1511,7 +1511,6 @@ export default abstract class SqlIntegration
       rows: rows.map((r) => ({
         column: r.column_name + "",
         value: r.value + "",
-        count: parseFloat(r.count),
       })),
     };
   }

--- a/packages/back-end/src/integrations/dialects/athena.ts
+++ b/packages/back-end/src/integrations/dialects/athena.ts
@@ -1,6 +1,5 @@
 import type { SqlDialect } from "shared/types/sql";
 import { defaultPercentileCapSelectClause } from "back-end/src/integrations/sql/clauses/percentile-cap-select-clause";
-import { approxMostFrequentTopValuesCTEBody } from "back-end/src/integrations/sql/clauses/approx-top-values";
 import { baseDialect } from "./base";
 
 export const athenaDialect: SqlDialect = {
@@ -46,7 +45,4 @@ export const athenaDialect: SqlDialect = {
       valueExpr: "__col.value",
     };
   },
-
-  approxTopValuesCTEBody: (params) =>
-    approxMostFrequentTopValuesCTEBody(athenaDialect, params),
 };

--- a/packages/back-end/src/integrations/dialects/athena.ts
+++ b/packages/back-end/src/integrations/dialects/athena.ts
@@ -1,5 +1,6 @@
 import type { SqlDialect } from "shared/types/sql";
 import { defaultPercentileCapSelectClause } from "back-end/src/integrations/sql/clauses/percentile-cap-select-clause";
+import { approxMostFrequentTopValuesCTEBody } from "back-end/src/integrations/sql/clauses/approx-top-values";
 import { baseDialect } from "./base";
 
 export const athenaDialect: SqlDialect = {
@@ -45,4 +46,7 @@ export const athenaDialect: SqlDialect = {
       valueExpr: "__col.value",
     };
   },
+
+  approxTopValuesCTEBody: (params) =>
+    approxMostFrequentTopValuesCTEBody(athenaDialect, params),
 };

--- a/packages/back-end/src/integrations/dialects/bigquery.ts
+++ b/packages/back-end/src/integrations/dialects/bigquery.ts
@@ -5,6 +5,7 @@ import {
   defaultPercentileCapSelectClause,
   PercentileCapSelectClauseValue,
 } from "back-end/src/integrations/sql/clauses/percentile-cap-select-clause";
+import { eligibleTopValueExpr } from "back-end/src/integrations/sql/clauses/approx-top-values";
 import { baseDialect } from "./base";
 
 const APPROX_QUANTILES_MULTIPLIER = 10000;
@@ -213,5 +214,40 @@ export const bigQueryDialect: SqlDialect = {
       keyExpr: "col.column_name",
       valueExpr: "col.value",
     };
+  },
+
+  // APPROX_TOP_COUNT(expr, k) returns ARRAY<STRUCT<value, count>> per column;
+  // pack the per-column structs into one array and double-UNNEST back to long
+  // form. It counts NULLs, so disqualified values map to NULL and the NULL
+  // bucket is dropped via `item.value IS NOT NULL`.
+  approxTopValuesCTEBody: ({
+    pairs,
+    fromTable,
+    whereClause,
+    limit,
+    maxValueLength,
+  }) => {
+    const structs = pairs
+      .map(
+        (p) =>
+          `STRUCT('${p.keyLiteral}' AS column_name, APPROX_TOP_COUNT(${eligibleTopValueExpr(
+            bigQueryDialect,
+            p.valueSql,
+            maxValueLength,
+          )}, ${limit}) AS items)`,
+      )
+      .join(",\n      ");
+    return `
+  SELECT __col.column_name AS column_name, __item.value AS value, __item.count AS count
+  FROM (
+    SELECT [
+      ${structs}
+    ] AS cols
+    FROM ${fromTable}
+    WHERE ${whereClause}
+  ) __agg
+  CROSS JOIN UNNEST(__agg.cols) AS __col
+  CROSS JOIN UNNEST(__col.items) AS __item
+  WHERE __item.value IS NOT NULL`;
   },
 };

--- a/packages/back-end/src/integrations/dialects/clickhouse.ts
+++ b/packages/back-end/src/integrations/dialects/clickhouse.ts
@@ -1,6 +1,7 @@
 import { createLikeStringMatchFn } from "shared/sql";
 import type { DateTruncGranularity, SqlDialect } from "shared/types/sql";
 import { defaultPercentileCapSelectClause } from "back-end/src/integrations/sql/clauses/percentile-cap-select-clause";
+import { eligibleTopValueExpr } from "back-end/src/integrations/sql/clauses/approx-top-values";
 import { baseDialect } from "./base";
 
 const clickHouseEscapeStringLiteral = (value: string) =>
@@ -108,4 +109,56 @@ if(
   // ClickHouse's LENGTH returns bytes (not characters); that's stricter
   // than JS .length but fine for the document-size guard.
   stringLength: (column: string) => `length(${column})`,
+
+  // topK(k)(expr) returns the k most frequent values in descending-frequency
+  // order with NO counts. Since the outer query sorts by `count DESC`, we
+  // synthesize a `count` from the inverse array position (`limit - i + 1`) to
+  // preserve topK's ordering; it's an internal sort key, never projected out.
+  //
+  // One aggregation row holds an array of (column_name, topK-array) tuples;
+  // aggregation and ARRAY JOIN live in separate query levels so the aggregate
+  // runs once before unnesting. topK skips NULLs.
+  approxTopValuesCTEBody: ({
+    pairs,
+    fromTable,
+    whereClause,
+    limit,
+    maxValueLength,
+  }) => {
+    const tuples = pairs
+      .map(
+        (p) =>
+          `('${p.keyLiteral}', topK(${limit})(${eligibleTopValueExpr(
+            clickHouseDialect,
+            p.valueSql,
+            maxValueLength,
+          )}))`,
+      )
+      .join(",\n        ");
+    return `
+  SELECT
+    column_name,
+    tupleElement(__valueCount, 1) AS value,
+    tupleElement(__valueCount, 2) AS count
+  FROM (
+    SELECT
+      tupleElement(__col, 1) AS column_name,
+      tupleElement(__col, 2) AS __values
+    FROM (
+      SELECT [
+        ${tuples}
+      ] AS __cols
+      FROM ${fromTable}
+      WHERE ${whereClause}
+    )
+    ARRAY JOIN __cols AS __col
+  )
+  ARRAY JOIN arrayMap(
+    -- (value, synthetic count): inverse array position, NOT a real frequency
+    (v, i) -> (v, toInt64(${limit}) - i + 1),
+    __values,
+    arrayEnumerate(__values)
+  ) AS __valueCount
+  WHERE value IS NOT NULL`;
+  },
 };

--- a/packages/back-end/src/integrations/dialects/databricks.ts
+++ b/packages/back-end/src/integrations/dialects/databricks.ts
@@ -2,6 +2,10 @@ import type { DataType } from "shared/types/integrations";
 import { createLikeStringMatchFn } from "shared/sql";
 import type { SqlDialect } from "shared/types/sql";
 import { defaultPercentileCapSelectClause } from "back-end/src/integrations/sql/clauses/percentile-cap-select-clause";
+import {
+  approxTopKCapacity,
+  eligibleTopValueExpr,
+} from "back-end/src/integrations/sql/clauses/approx-top-values";
 import { baseDialect } from "./base";
 
 const databricksEscapeStringLiteral = (value: string) =>
@@ -82,5 +86,40 @@ export const databricksDialect: SqlDialect = {
       keyExpr: "__col.column_name",
       valueExpr: "__col.value",
     };
+  },
+
+  // approx_top_k(expr, k, maxItemsTracked) returns ARRAY<STRUCT<item, count>>
+  // per column; explode the array of per-column named_structs, then inline each
+  // column's items.
+  approxTopValuesCTEBody: ({
+    pairs,
+    fromTable,
+    whereClause,
+    limit,
+    maxValueLength,
+  }) => {
+    const maxItemsTracked = approxTopKCapacity(limit);
+    const structs = pairs
+      .map(
+        (p) =>
+          `named_struct('column_name', '${p.keyLiteral}', 'items', approx_top_k(${eligibleTopValueExpr(
+            databricksDialect,
+            p.valueSql,
+            maxValueLength,
+          )}, ${limit}, ${maxItemsTracked}))`,
+      )
+      .join(",\n      ");
+    return `
+  SELECT __col.column_name AS column_name, __item.item AS value, __item.cnt AS count
+  FROM (
+    SELECT array(
+      ${structs}
+    ) AS cols
+    FROM ${fromTable}
+    WHERE ${whereClause}
+  ) __agg
+  LATERAL VIEW explode(__agg.cols) __t AS __col
+  LATERAL VIEW inline(__col.items) __item AS item, cnt
+  WHERE __item.item IS NOT NULL`;
   },
 };

--- a/packages/back-end/src/integrations/dialects/presto.ts
+++ b/packages/back-end/src/integrations/dialects/presto.ts
@@ -1,6 +1,9 @@
 import type { SqlDialect } from "shared/types/sql";
 import { defaultPercentileCapSelectClause } from "back-end/src/integrations/sql/clauses/percentile-cap-select-clause";
-import { approxMostFrequentTopValuesCTEBody } from "back-end/src/integrations/sql/clauses/approx-top-values";
+import {
+  approxTopKCapacity,
+  eligibleTopValueExpr,
+} from "back-end/src/integrations/sql/clauses/approx-top-values";
 import { baseDialect } from "./base";
 
 export const prestoDialect: SqlDialect = {
@@ -46,6 +49,39 @@ export const prestoDialect: SqlDialect = {
     };
   },
 
-  approxTopValuesCTEBody: (params) =>
-    approxMostFrequentTopValuesCTEBody(prestoDialect, params),
+  approxTopValuesCTEBody: ({
+    pairs,
+    fromTable,
+    whereClause,
+    limit,
+    maxValueLength,
+  }) => {
+    const capacity = approxTopKCapacity(limit);
+    const names = pairs.map((p) => `'${p.keyLiteral}'`).join(", ");
+    const maps = pairs
+      .map(
+        (p) =>
+          `approx_most_frequent(${limit}, ${eligibleTopValueExpr(
+            prestoDialect,
+            p.valueSql,
+            maxValueLength,
+          )}, ${capacity})`,
+      )
+      .join(",\n        ");
+
+    return `
+    SELECT __col.column_name AS column_name, __item.value AS value, __item.count AS count
+    FROM (
+      SELECT
+        ARRAY[${names}] AS col_names,
+        ARRAY[
+          ${maps}
+        ] AS col_maps
+      FROM ${fromTable}
+      WHERE ${whereClause}
+    ) __agg
+    CROSS JOIN UNNEST(__agg.col_names, __agg.col_maps) AS __col (column_name, items)
+    CROSS JOIN UNNEST(__col.items) AS __item (value, count)
+    WHERE __item.value IS NOT NULL`;
+  },
 };

--- a/packages/back-end/src/integrations/dialects/presto.ts
+++ b/packages/back-end/src/integrations/dialects/presto.ts
@@ -1,5 +1,6 @@
 import type { SqlDialect } from "shared/types/sql";
 import { defaultPercentileCapSelectClause } from "back-end/src/integrations/sql/clauses/percentile-cap-select-clause";
+import { approxMostFrequentTopValuesCTEBody } from "back-end/src/integrations/sql/clauses/approx-top-values";
 import { baseDialect } from "./base";
 
 export const prestoDialect: SqlDialect = {
@@ -44,4 +45,7 @@ export const prestoDialect: SqlDialect = {
       valueExpr: "__col.value",
     };
   },
+
+  approxTopValuesCTEBody: (params) =>
+    approxMostFrequentTopValuesCTEBody(prestoDialect, params),
 };

--- a/packages/back-end/src/integrations/dialects/snowflake.ts
+++ b/packages/back-end/src/integrations/dialects/snowflake.ts
@@ -3,6 +3,10 @@ import type { SqlDialect } from "shared/types/sql";
 import { createLikeStringMatchFn } from "shared/sql";
 import { defaultPercentileCapSelectClause } from "back-end/src/integrations/sql/clauses/percentile-cap-select-clause";
 import { indicesTableUnpivot } from "back-end/src/integrations/sql/clauses/indices-table-unpivot";
+import {
+  approxTopKCapacity,
+  eligibleTopValueExpr,
+} from "back-end/src/integrations/sql/clauses/approx-top-values";
 import { baseDialect } from "./base";
 
 const snowflakeEscapeStringLiteral = (value: string) =>
@@ -115,4 +119,46 @@ export const snowflakeDialect: SqlDialect = {
   //     subquery type" because Snowflake's correlated subqueries can't contain
   //     set operations.
   unpivotLabeledPairs: indicesTableUnpivot,
+
+  // APPROX_TOP_K(expr, k, counters) returns an ARRAY of [value, count] pairs per
+  // column; pack the per-column results into OBJECTs, then FLATTEN the outer
+  // array and each column's items.
+  //
+  // The first FLATTEN runs over a materialized subquery column (__agg.cols), not
+  // an inline ARRAY_CONSTRUCT, to avoid the correlated-construct failures noted
+  // on unpivotLabeledPairs above.
+  approxTopValuesCTEBody: ({
+    pairs,
+    fromTable,
+    whereClause,
+    limit,
+    maxValueLength,
+  }) => {
+    const counters = approxTopKCapacity(limit);
+    const objects = pairs
+      .map(
+        (p) =>
+          `OBJECT_CONSTRUCT('column_name', '${p.keyLiteral}', 'items', APPROX_TOP_K(${eligibleTopValueExpr(
+            snowflakeDialect,
+            p.valueSql,
+            maxValueLength,
+          )}, ${limit}, ${counters}))`,
+      )
+      .join(",\n      ");
+    return `
+  SELECT
+    __col.value:column_name::string AS column_name,
+    __item.value[0]::string AS value,
+    __item.value[1]::number AS count
+  FROM (
+    SELECT ARRAY_CONSTRUCT(
+      ${objects}
+    ) AS cols
+    FROM ${fromTable}
+    WHERE ${whereClause}
+  ) __agg,
+  LATERAL FLATTEN(input => __agg.cols) __col,
+  LATERAL FLATTEN(input => __col.value:items) __item
+  WHERE __item.value[0] IS NOT NULL`;
+  },
 };

--- a/packages/back-end/src/integrations/sql/clauses/approx-top-values.ts
+++ b/packages/back-end/src/integrations/sql/clauses/approx-top-values.ts
@@ -1,0 +1,78 @@
+import type { ApproxTopValuesParams, SqlDialect } from "shared/types/sql";
+
+/**
+ * Map NULL or over-length values to NULL so the approximate aggregates (which
+ * ignore NULLs) exclude them, mirroring the exact path's
+ * `value IS NOT NULL AND LENGTH(value) <= maxValueLength` filter. With no
+ * `maxValueLength`, the expression is returned unchanged.
+ */
+export function eligibleTopValueExpr(
+  dialect: SqlDialect,
+  valueSql: string,
+  maxValueLength?: number,
+): string {
+  if (maxValueLength === undefined) return valueSql;
+  return dialect.ifElse(
+    `${valueSql} IS NOT NULL AND ${dialect.stringLength(
+      valueSql,
+    )} <= ${maxValueLength}`,
+    valueSql,
+    "NULL",
+  );
+}
+
+/**
+ * Tracking capacity for the Space-Saving top-k family, sized well above `k` so
+ * counts stay accurate for the low-cardinality columns this runs on. Maps to
+ * Snowflake `counters`, Databricks `maxItemsTracked`, and Trino/Presto/Athena
+ * `capacity`; BigQuery's APPROX_TOP_COUNT and ClickHouse's topK take no such
+ * argument.
+ */
+export function approxTopKCapacity(limit: number): number {
+  return Math.min(100000, Math.max(limit * 10, 1000));
+}
+
+/**
+ * Trino / Presto / Athena single-pass approximate top-k using
+ * `approx_most_frequent(buckets, value, capacity)`, which returns a
+ * `MAP(value, count)` per column. One aggregation row holds parallel arrays of
+ * the column names and their maps; we expand both with UNNEST.
+ */
+export function approxMostFrequentTopValuesCTEBody(
+  dialect: SqlDialect,
+  {
+    pairs,
+    fromTable,
+    whereClause,
+    limit,
+    maxValueLength,
+  }: ApproxTopValuesParams,
+): string {
+  const capacity = approxTopKCapacity(limit);
+  const names = pairs.map((p) => `'${p.keyLiteral}'`).join(", ");
+  const maps = pairs
+    .map(
+      (p) =>
+        `approx_most_frequent(${limit}, ${eligibleTopValueExpr(
+          dialect,
+          p.valueSql,
+          maxValueLength,
+        )}, ${capacity})`,
+    )
+    .join(",\n        ");
+
+  return `
+  SELECT __col.column_name AS column_name, __item.value AS value, __item.count AS count
+  FROM (
+    SELECT
+      ARRAY[${names}] AS col_names,
+      ARRAY[
+        ${maps}
+      ] AS col_maps
+    FROM ${fromTable}
+    WHERE ${whereClause}
+  ) __agg
+  CROSS JOIN UNNEST(__agg.col_names, __agg.col_maps) AS __col (column_name, items)
+  CROSS JOIN UNNEST(__col.items) AS __item (value, count)
+  WHERE __item.value IS NOT NULL`;
+}

--- a/packages/back-end/src/integrations/sql/clauses/approx-top-values.ts
+++ b/packages/back-end/src/integrations/sql/clauses/approx-top-values.ts
@@ -1,4 +1,4 @@
-import type { ApproxTopValuesParams, SqlDialect } from "shared/types/sql";
+import type { SqlDialect } from "shared/types/sql";
 
 /**
  * Map NULL or over-length values to NULL so the approximate aggregates (which
@@ -24,55 +24,10 @@ export function eligibleTopValueExpr(
 /**
  * Tracking capacity for the Space-Saving top-k family, sized well above `k` so
  * counts stay accurate for the low-cardinality columns this runs on. Maps to
- * Snowflake `counters`, Databricks `maxItemsTracked`, and Trino/Presto/Athena
+ * Snowflake `counters`, Databricks `maxItemsTracked`, and Trino/Presto
  * `capacity`; BigQuery's APPROX_TOP_COUNT and ClickHouse's topK take no such
  * argument.
  */
 export function approxTopKCapacity(limit: number): number {
   return Math.min(100000, Math.max(limit * 10, 1000));
-}
-
-/**
- * Trino / Presto / Athena single-pass approximate top-k using
- * `approx_most_frequent(buckets, value, capacity)`, which returns a
- * `MAP(value, count)` per column. One aggregation row holds parallel arrays of
- * the column names and their maps; we expand both with UNNEST.
- */
-export function approxMostFrequentTopValuesCTEBody(
-  dialect: SqlDialect,
-  {
-    pairs,
-    fromTable,
-    whereClause,
-    limit,
-    maxValueLength,
-  }: ApproxTopValuesParams,
-): string {
-  const capacity = approxTopKCapacity(limit);
-  const names = pairs.map((p) => `'${p.keyLiteral}'`).join(", ");
-  const maps = pairs
-    .map(
-      (p) =>
-        `approx_most_frequent(${limit}, ${eligibleTopValueExpr(
-          dialect,
-          p.valueSql,
-          maxValueLength,
-        )}, ${capacity})`,
-    )
-    .join(",\n        ");
-
-  return `
-  SELECT __col.column_name AS column_name, __item.value AS value, __item.count AS count
-  FROM (
-    SELECT
-      ARRAY[${names}] AS col_names,
-      ARRAY[
-        ${maps}
-      ] AS col_maps
-    FROM ${fromTable}
-    WHERE ${whereClause}
-  ) __agg
-  CROSS JOIN UNNEST(__agg.col_names, __agg.col_maps) AS __col (column_name, items)
-  CROSS JOIN UNNEST(__col.items) AS __item (value, count)
-  WHERE __item.value IS NOT NULL`;
 }

--- a/packages/back-end/src/integrations/sql/queries/columns-top-values-query.ts
+++ b/packages/back-end/src/integrations/sql/queries/columns-top-values-query.ts
@@ -46,7 +46,7 @@ __factTable AS (
 __topValues AS (
   ${getTopValuesCTEBody(dialect, { columns, start, limit, maxValueLength })}
 )
-SELECT * FROM __topValues
+SELECT column_name, value FROM __topValues
 ORDER BY column_name, count DESC
   `,
     dialect.formatDialect,
@@ -68,6 +68,18 @@ function getTopValuesCTEBody(
     keyLiteral: c.column.replace(/'/g, "''"),
     valueSql: dialect.castToString(c.column),
   }));
+
+  // When the dialect has a native approximate top-k aggregate use it
+  // for better performance.
+  if (dialect.approxTopValuesCTEBody) {
+    return dialect.approxTopValuesCTEBody({
+      pairs,
+      fromTable: "__factTable",
+      whereClause: `timestamp >= ${dialect.toTimestamp(start)}`,
+      limit,
+      maxValueLength,
+    });
+  }
 
   const u = dialect.unpivotLabeledPairs(pairs);
 

--- a/packages/back-end/test/integrations/sql/queries/columns-top-values-query.test.ts
+++ b/packages/back-end/test/integrations/sql/queries/columns-top-values-query.test.ts
@@ -1,0 +1,144 @@
+import type { SqlDialect } from "shared/types/sql";
+import type { ColumnInterface } from "shared/types/fact-table";
+import { getColumnsTopValuesQuery } from "back-end/src/integrations/sql/queries/columns-top-values-query";
+import { bigQueryDialect } from "back-end/src/integrations/dialects/bigquery";
+import { snowflakeDialect } from "back-end/src/integrations/dialects/snowflake";
+import { databricksDialect } from "back-end/src/integrations/dialects/databricks";
+import { prestoDialect } from "back-end/src/integrations/dialects/presto";
+import { athenaDialect } from "back-end/src/integrations/dialects/athena";
+import { clickHouseDialect } from "back-end/src/integrations/dialects/clickhouse";
+import { postgresDialect } from "back-end/src/integrations/dialects/postgres";
+import { redshiftDialect } from "back-end/src/integrations/dialects/redshift";
+import { mysqlDialect } from "back-end/src/integrations/dialects/mysql";
+
+function makeColumn(column: string): ColumnInterface {
+  return {
+    dateCreated: new Date(),
+    dateUpdated: new Date(),
+    name: column,
+    description: "",
+    column,
+    datatype: "string",
+    numberFormat: "",
+    deleted: false,
+  };
+}
+
+const factTable = {
+  sql: "SELECT country, plan, timestamp FROM events WHERE timestamp >= {{startDate}}",
+  eventName: "",
+};
+
+const columns = [makeColumn("country"), makeColumn("plan")];
+
+function buildSql(
+  dialect: SqlDialect,
+  overrides: Record<string, unknown> = {},
+) {
+  return getColumnsTopValuesQuery(dialect, {
+    factTable,
+    columns,
+    limit: 100,
+    lookbackDays: 14,
+    maxValueLength: 100,
+    ...overrides,
+  });
+}
+
+function registerSharedTopValuesTests(dialect: SqlDialect) {
+  it("defines __factTable once and references it once (single source scan)", () => {
+    const sql = buildSql(dialect);
+    const factTableRefs = sql.match(/\b__factTable\b/g) ?? [];
+    expect(factTableRefs).toHaveLength(2);
+    expect(sql.match(/\b__factTable\s+AS\b/gi)?.length).toBe(1);
+    expect(sql.match(/FROM\s+__factTable\b/gi)?.length).toBe(1);
+  });
+
+  it("produces the (column_name, value, count) contract ordered for the consumer", () => {
+    const sql = buildSql(dialect);
+    expect(sql).toMatch(/column_name/i);
+    expect(sql).toMatch(/\bvalue\b/i);
+    expect(sql).toMatch(/\bcount\b/i);
+    expect(sql).toMatch(/ORDER BY\s+column_name,\s*count DESC/i);
+  });
+
+  it("applies the max-value-length gate", () => {
+    const sql = buildSql(dialect);
+    expect(sql).toMatch(/<=\s*100/);
+  });
+
+  it("respects the lookback window in the timestamp filter", () => {
+    const sql = buildSql(dialect);
+    const sql7 = buildSql(dialect, { lookbackDays: 7 });
+    expect(sql7).not.toEqual(sql);
+    expect(sql7).toMatch(/timestamp\s*>=/i);
+  });
+}
+
+// Dialects whose single-pass approximate top-k path replaces the exact
+// UNPIVOT + GROUP BY + ROW_NUMBER form.
+const approxDialects: {
+  name: string;
+  dialect: SqlDialect;
+  aggFn: RegExp;
+}[] = [
+  { name: "BigQuery", dialect: bigQueryDialect, aggFn: /APPROX_TOP_COUNT/i },
+  { name: "Snowflake", dialect: snowflakeDialect, aggFn: /APPROX_TOP_K/i },
+  { name: "Databricks", dialect: databricksDialect, aggFn: /approx_top_k/i },
+  { name: "Presto", dialect: prestoDialect, aggFn: /approx_most_frequent/i },
+  { name: "Athena", dialect: athenaDialect, aggFn: /approx_most_frequent/i },
+  { name: "ClickHouse", dialect: clickHouseDialect, aggFn: /topK/ },
+];
+
+describe("getColumnsTopValuesQuery — approximate top-k path", () => {
+  approxDialects.forEach(({ name, dialect, aggFn }) => {
+    describe(name, () => {
+      const sql = buildSql(dialect);
+
+      registerSharedTopValuesTests(dialect);
+
+      it("uses the approximate top-k aggregate, one call per column", () => {
+        expect(sql).toMatch(aggFn);
+        expect(sql.match(aggFn)?.length).toBeGreaterThanOrEqual(1);
+        // One aggregate per string column.
+        const calls = sql.match(new RegExp(aggFn.source, "gi"));
+        expect(calls?.length).toBe(columns.length);
+      });
+
+      it("drops the exact-path machinery (no row explosion / window)", () => {
+        expect(sql).not.toMatch(/ROW_NUMBER/i);
+        expect(sql).not.toMatch(/GROUP BY/i);
+      });
+    });
+  });
+});
+
+describe("getColumnsTopValuesQuery — exact fallback path", () => {
+  const exactDialects: { name: string; dialect: SqlDialect }[] = [
+    { name: "Postgres", dialect: postgresDialect },
+    { name: "Redshift", dialect: redshiftDialect },
+    { name: "MySQL", dialect: mysqlDialect },
+  ];
+
+  exactDialects.forEach(({ name, dialect }) => {
+    describe(name, () => {
+      registerSharedTopValuesTests(dialect);
+
+      it("keeps the exact ROW_NUMBER path with no approximate aggregate", () => {
+        const sql = buildSql(dialect);
+        expect(sql).toMatch(/ROW_NUMBER/i);
+        expect(sql).toMatch(/GROUP BY/i);
+        expect(sql).not.toMatch(
+          /APPROX_TOP_COUNT|APPROX_TOP_K|approx_most_frequent/i,
+        );
+      });
+    });
+  });
+
+  it("only the approximate dialects expose approxTopValuesCTEBody", () => {
+    expect(typeof bigQueryDialect.approxTopValuesCTEBody).toBe("function");
+    expect(postgresDialect.approxTopValuesCTEBody).toBeUndefined();
+    expect(redshiftDialect.approxTopValuesCTEBody).toBeUndefined();
+    expect(mysqlDialect.approxTopValuesCTEBody).toBeUndefined();
+  });
+});

--- a/packages/back-end/test/integrations/sql/queries/columns-top-values-query.test.ts
+++ b/packages/back-end/test/integrations/sql/queries/columns-top-values-query.test.ts
@@ -86,7 +86,6 @@ const approxDialects: {
   { name: "Snowflake", dialect: snowflakeDialect, aggFn: /APPROX_TOP_K/i },
   { name: "Databricks", dialect: databricksDialect, aggFn: /approx_top_k/i },
   { name: "Presto", dialect: prestoDialect, aggFn: /approx_most_frequent/i },
-  { name: "Athena", dialect: athenaDialect, aggFn: /approx_most_frequent/i },
   { name: "ClickHouse", dialect: clickHouseDialect, aggFn: /topK/ },
 ];
 
@@ -118,6 +117,9 @@ describe("getColumnsTopValuesQuery — exact fallback path", () => {
     { name: "Postgres", dialect: postgresDialect },
     { name: "Redshift", dialect: redshiftDialect },
     { name: "MySQL", dialect: mysqlDialect },
+    // Athena v3 should support it, but v2 does not (I think)
+    // so taking the safe route for now until we can add engine version detection.
+    { name: "Athena", dialect: athenaDialect },
   ];
 
   exactDialects.forEach(({ name, dialect }) => {
@@ -140,5 +142,6 @@ describe("getColumnsTopValuesQuery — exact fallback path", () => {
     expect(postgresDialect.approxTopValuesCTEBody).toBeUndefined();
     expect(redshiftDialect.approxTopValuesCTEBody).toBeUndefined();
     expect(mysqlDialect.approxTopValuesCTEBody).toBeUndefined();
+    expect(athenaDialect.approxTopValuesCTEBody).toBeUndefined();
   });
 });

--- a/packages/shared/types/integrations.d.ts
+++ b/packages/shared/types/integrations.d.ts
@@ -296,10 +296,11 @@ export type ColumnTopValuesParams = {
   lookbackDays?: number;
   maxValueLength?: number;
 };
+
+/** Rows are returned most-frequent-first per column. */
 export type ColumnTopValuesResponseRow = {
   column: string;
   value: string;
-  count: number;
 };
 
 interface ExperimentBaseQueryParams {

--- a/packages/shared/types/sql.d.ts
+++ b/packages/shared/types/sql.d.ts
@@ -29,6 +29,19 @@ export type UnpivotLabeledPairsResult = {
   valueExpr: string;
 };
 
+export type ApproxTopValuesParams = {
+  /** One entry per string column: logical name + the value SQL expression (cast to string). */
+  pairs: UnpivotLabeledPair[];
+  /** CTE/table the aggregate scans (e.g. `__factTable`). */
+  fromTable: string;
+  /** Boolean predicate for the WHERE clause, without the `WHERE` keyword (e.g. `timestamp >= '...'`). */
+  whereClause: string;
+  /** Number of top values to return per column (k). */
+  limit: number;
+  /** Drop values longer than this many characters before counting. */
+  maxValueLength?: number;
+};
+
 export type TemplateVariables = {
   eventName?: string;
   valueColumn?: string;
@@ -120,4 +133,5 @@ export interface SqlDialect {
     pairs: UnpivotLabeledPair[],
   ) => UnpivotLabeledPairsResult;
   stringLength: (column: string) => string;
+  approxTopValuesCTEBody?: (params: ApproxTopValuesParams) => string;
 }


### PR DESCRIPTION
### Features and Changes

The fact-table column "top values" scan previously unpivoted every string column and grouped/counted exact values across the lookback window. On large tables this is an expensive full scan with a wide GROUP BY.

Most of our supported warehouses ship a native single-pass approximate top-k aggregate. This PR uses them when available, falling back to the existing exact path on dialects that don't.

- Per-dialect implementations:
  - **BigQuery** — `APPROX_TOP_COUNT`
  - **Snowflake** — `APPROX_TOP_K`
  - **Databricks** — `approx_top_k`
  - **Presto / Athena** — `approx_most_frequent`
  - **ClickHouse** — `topK`
- Dropped the `count` field from `ColumnTopValuesResponseRow`. It was never used by consumers, and the engines disagree on whether/how they expose counts (ClickHouse's `topK` returns none, so we synthesize an ordering-only sort key). Rows are still ordered most-frequent-first per column.

### Testing

- New unit tests in `columns-top-values-query.test.ts`
- Manually validated against live BigQuery, Snowflake, Databricks, ClickHouse, and Presto warehouses
