### PR TITLE
feat(settings): deep-link to a section within a settings tab

### DIFF
--- a/packages/front-end/components/GeneralSettings/DatasourceSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/DatasourceSettings.tsx
@@ -12,7 +12,7 @@ export default function DatasourceSettings() {
   const { datasources } = useDefinitions();
 
   return (
-    <Frame>
+    <Frame id="data-source-settings" style={{ scrollMarginTop: 100 }}>
       <Flex gap="4">
         <Box width="220px" flexShrink="0">
           <Heading size="4" as="h4">

--- a/packages/front-end/components/GeneralSettings/settingsSections.ts
+++ b/packages/front-end/components/GeneralSettings/settingsSections.ts
@@ -32,11 +32,16 @@ export function parseSettingsHash(hash: string | undefined): {
   section: SettingsSectionId | null;
 } {
   const [tabSegment, sectionSegment] = (hash ?? "").split("/");
+  const section =
+    sectionSegment && isSettingsSectionId(sectionSegment)
+      ? sectionSegment
+      : null;
   return {
-    tab: isSettingsTab(tabSegment) ? tabSegment : DEFAULT_SETTINGS_TAB,
-    section:
-      sectionSegment && isSettingsSectionId(sectionSegment)
-        ? sectionSegment
-        : null,
+    tab: section
+      ? SETTINGS_SECTIONS[section]
+      : isSettingsTab(tabSegment)
+        ? tabSegment
+        : DEFAULT_SETTINGS_TAB,
+    section,
   };
 }

--- a/packages/front-end/components/GeneralSettings/settingsSections.ts
+++ b/packages/front-end/components/GeneralSettings/settingsSections.ts
@@ -1,0 +1,42 @@
+export const SETTINGS_TAB = {
+  experiment: "experiment",
+  feature: "feature",
+  metrics: "metrics",
+  "approval-flow": "approval-flow",
+  sdk: "sdk",
+  import: "import",
+  custom: "custom",
+  ai: "ai",
+} as const;
+
+type SettingsTabValue = (typeof SETTINGS_TAB)[keyof typeof SETTINGS_TAB];
+
+const DEFAULT_SETTINGS_TAB = SETTINGS_TAB.experiment;
+
+function isSettingsTab(value: string | undefined): value is SettingsTabValue {
+  return value !== undefined && value in SETTINGS_TAB;
+}
+
+const SETTINGS_SECTIONS = {
+  "data-source-settings": SETTINGS_TAB.metrics,
+} as const satisfies Record<string, SettingsTabValue>;
+
+type SettingsSectionId = keyof typeof SETTINGS_SECTIONS;
+
+export function isSettingsSectionId(value: string): value is SettingsSectionId {
+  return value in SETTINGS_SECTIONS;
+}
+
+export function parseSettingsHash(hash: string | undefined): {
+  tab: SettingsTabValue;
+  section: SettingsSectionId | null;
+} {
+  const [tabSegment, sectionSegment] = (hash ?? "").split("/");
+  return {
+    tab: isSettingsTab(tabSegment) ? tabSegment : DEFAULT_SETTINGS_TAB,
+    section:
+      sectionSegment && isSettingsSectionId(sectionSegment)
+        ? sectionSegment
+        : null,
+  };
+}

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -411,10 +411,9 @@ const GeneralSettingsPage = (): React.ReactElement => {
       document
         .getElementById(deepLinkSection)
         ?.scrollIntoView({ behavior: "smooth", block: "start" });
-      setUrlHash(activeTab);
     });
     return () => window.cancelAnimationFrame(frame);
-  }, [deepLinkSection, activeTab, setUrlHash]);
+  }, [deepLinkSection]);
 
   // I Don't think this works as intended - the hasChanges(value, originalValue) always seems to return true.
   const ctaEnabled =

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/hooks/useOrganizationMetricDefaults";
 import { useUser } from "@/services/UserContext";
 import { useCurrency } from "@/hooks/useCurrency";
+import useURLHash from "@/hooks/useURLHash";
 import OrganizationAndLicenseSettings from "@/components/GeneralSettings/OrganizationAndLicenseSettings";
 import ImportSettings from "@/components/GeneralSettings/ImportSettings";
 import NorthStarMetricSettings from "@/components/GeneralSettings/NorthStarMetricSettings";
@@ -46,6 +47,10 @@ import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
 import DatasourceSettings from "@/components/GeneralSettings/DatasourceSettings";
 import BanditSettings from "@/components/GeneralSettings/BanditSettings";
 import AISettings from "@/components/GeneralSettings/AISettings";
+import {
+  SETTINGS_TAB,
+  parseSettingsHash,
+} from "@/components/GeneralSettings/settingsSections";
 import HelperText from "@/ui/HelperText";
 import { StickyTabsList, Tabs, TabsContent, TabsTrigger } from "@/ui/Tabs";
 import Frame from "@/ui/Frame";
@@ -106,6 +111,9 @@ const GeneralSettingsPage = (): React.ReactElement => {
 
   const promptForm = useForm();
 
+  const [urlHash, setUrlHash] = useURLHash();
+  const { tab: activeTab, section: deepLinkSection } =
+    parseSettingsHash(urlHash);
   const { metricDefaults } = useOrganizationMetricDefaults();
   const form = useForm<OrganizationSettingsWithMetricDefaults>({
     defaultValues: {
@@ -397,6 +405,17 @@ const GeneralSettingsPage = (): React.ReactElement => {
     );
   }, [codeRefsBranchesToFilterStr]);
 
+  useEffect(() => {
+    if (!deepLinkSection) return;
+    const frame = window.requestAnimationFrame(() => {
+      document
+        .getElementById(deepLinkSection)
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+      setUrlHash(activeTab);
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [deepLinkSection, activeTab, setUrlHash]);
+
   // I Don't think this works as intended - the hasChanges(value, originalValue) always seems to return true.
   const ctaEnabled =
     hasChanges(value, originalValue) || promptForm.formState.isDirty;
@@ -492,32 +511,42 @@ const GeneralSettingsPage = (): React.ReactElement => {
           />
         </Box>
 
-        <Tabs defaultValue="experiment" persistInURL={true}>
+        <Tabs value={activeTab} onValueChange={setUrlHash}>
           <StickyTabsList>
-            <TabsTrigger value="experiment">Experiment Settings</TabsTrigger>
-            <TabsTrigger value="feature">Feature Settings</TabsTrigger>
-            <TabsTrigger value="metrics">Metrics &amp; Data</TabsTrigger>
-            <TabsTrigger value="approval-flow">
+            <TabsTrigger value={SETTINGS_TAB.experiment}>
+              Experiment Settings
+            </TabsTrigger>
+            <TabsTrigger value={SETTINGS_TAB.feature}>
+              Feature Settings
+            </TabsTrigger>
+            <TabsTrigger value={SETTINGS_TAB.metrics}>
+              Metrics &amp; Data
+            </TabsTrigger>
+            <TabsTrigger value={SETTINGS_TAB["approval-flow"]}>
               {/* TODO: Check if we want to reuse this feature flag or not */}
               <PremiumTooltip commercialFeature="require-approvals">
                 Approval Flows
               </PremiumTooltip>
             </TabsTrigger>
-            <TabsTrigger value="sdk">SDK Configuration</TabsTrigger>
-            <TabsTrigger value="import">Import &amp; Export</TabsTrigger>
-            <TabsTrigger value="custom">
+            <TabsTrigger value={SETTINGS_TAB.sdk}>
+              SDK Configuration
+            </TabsTrigger>
+            <TabsTrigger value={SETTINGS_TAB.import}>
+              Import &amp; Export
+            </TabsTrigger>
+            <TabsTrigger value={SETTINGS_TAB.custom}>
               <PremiumTooltip commercialFeature="custom-markdown">
                 Custom Markdown
               </PremiumTooltip>
             </TabsTrigger>
-            <TabsTrigger value="ai">
+            <TabsTrigger value={SETTINGS_TAB.ai}>
               <PremiumTooltip commercialFeature="ai-suggestions">
                 AI Settings
               </PremiumTooltip>
             </TabsTrigger>
           </StickyTabsList>
           <Box mt="4">
-            <TabsContent value="experiment">
+            <TabsContent value={SETTINGS_TAB.experiment}>
               <ExperimentSettings
                 cronString={cronString}
                 updateCronString={updateCronString}
@@ -527,12 +556,12 @@ const GeneralSettingsPage = (): React.ReactElement => {
               </Frame>
             </TabsContent>
 
-            <TabsContent value="feature">
+            <TabsContent value={SETTINGS_TAB.feature}>
               <FeatureSettings />
               <RampScheduleTemplates />
             </TabsContent>
 
-            <TabsContent value="metrics">
+            <TabsContent value={SETTINGS_TAB.metrics}>
               <>
                 <MetricsSettings />
                 <DatasourceSettings />
@@ -540,7 +569,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
               </>
             </TabsContent>
 
-            <TabsContent value="import">
+            <TabsContent value={SETTINGS_TAB.import}>
               <ImportSettings
                 hasFileConfig={hasFileConfig()}
                 isCloud={isCloud()}
@@ -549,7 +578,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
               />
             </TabsContent>
 
-            <TabsContent value="custom">
+            <TabsContent value={SETTINGS_TAB.custom}>
               <Frame>
                 <Flex>
                   <Box width="300px">
@@ -571,17 +600,17 @@ const GeneralSettingsPage = (): React.ReactElement => {
                 </Flex>
               </Frame>
             </TabsContent>
-            <TabsContent value="ai">
+            <TabsContent value={SETTINGS_TAB.ai}>
               <AISettings promptForm={promptForm} />
             </TabsContent>
-            <TabsContent value="sdk">
+            <TabsContent value={SETTINGS_TAB.sdk}>
               <>
                 <SDKConnectionSettings />
                 <SavedGroupSettings />
                 <TargetingAttributesSettings />
               </>
             </TabsContent>
-            <TabsContent value="approval-flow">
+            <TabsContent value={SETTINGS_TAB["approval-flow"]}>
               <ApprovalFlowSettings />
             </TabsContent>
           </Box>

--- a/packages/front-end/test/components/settingsSections.test.ts
+++ b/packages/front-end/test/components/settingsSections.test.ts
@@ -1,0 +1,50 @@
+import {
+  isSettingsSectionId,
+  parseSettingsHash,
+} from "@/components/GeneralSettings/settingsSections";
+
+describe("parseSettingsHash", () => {
+  it("parses a tab and section from a composite hash", () => {
+    expect(parseSettingsHash("metrics/data-source-settings")).toEqual({
+      tab: "metrics",
+      section: "data-source-settings",
+    });
+  });
+
+  it("parses a tab-only hash", () => {
+    expect(parseSettingsHash("feature")).toEqual({
+      tab: "feature",
+      section: null,
+    });
+  });
+
+  it("falls back to the default tab for an empty or unknown hash", () => {
+    expect(parseSettingsHash(undefined)).toEqual({
+      tab: "experiment",
+      section: null,
+    });
+    expect(parseSettingsHash("")).toEqual({ tab: "experiment", section: null });
+    expect(parseSettingsHash("not-a-tab")).toEqual({
+      tab: "experiment",
+      section: null,
+    });
+  });
+
+  it("ignores an unknown section segment", () => {
+    expect(parseSettingsHash("metrics/not-a-section")).toEqual({
+      tab: "metrics",
+      section: null,
+    });
+  });
+});
+
+describe("isSettingsSectionId", () => {
+  it("accepts registered section ids", () => {
+    expect(isSettingsSectionId("data-source-settings")).toBe(true);
+  });
+
+  it("rejects unregistered values", () => {
+    expect(isSettingsSectionId("not-a-section")).toBe(false);
+    expect(isSettingsSectionId("")).toBe(false);
+  });
+});


### PR DESCRIPTION
### Features and Changes

The settings page tabs persisted the active tab in the URL hash, but there was no way to link directly to a specific section *within* a tab. This adds support for a composite `tab/section` hash so other parts of the app can deep-link users to the exact setting they need.

For example, `/settings#metrics/data-source-settings` switches to the "Metrics & Data" tab and smooth-scrolls to the Data Source Settings section.

- `settingsSections.ts` is a small, typed registry mapping section ids to their owning tab, plus a `parseSettingsHash` helper that resolves a hash into `{ tab, section }` with safe fallbacks for unknown values.
- The settings page now drives the active tab from the parsed hash and runs the scroll-into-view on the targeted section.
- The Data Source Settings `Frame` gets an `id` (and `scrollMarginTop`) so it can be targeted.

### Testing

Unit tests for `parseSettingsHash` and `isSettingsSectionId` cover composite hashes, tab-only hashes, empty/unknown hashes, and unknown section segments.
