### PR TITLE
feat(agg-tables): per-slice fallback — uncovered slices don't force full legacy covariate scan

### DIFF
--- a/packages/back-end/src/integrations/sql/fact-metrics/resolve-covariate-insert-path.ts
+++ b/packages/back-end/src/integrations/sql/fact-metrics/resolve-covariate-insert-path.ts
@@ -28,6 +28,7 @@ export const AGGREGATED_FACT_TABLE_COVARIATE_FRESHNESS_MS = 1000 * 60 * 60 * 36;
 
 export type CovariateInsertPathReason =
   | "aggregated"
+  | "mixed"
   | "no-fact-table"
   | "id-type-not-materialized"
   | "no-materialized-table"
@@ -39,13 +40,21 @@ export type CovariateInsertPathReason =
 export type CovariateInsertPath =
   | {
       path: "legacy";
-      reason: Exclude<CovariateInsertPathReason, "aggregated">;
+      reason: Exclude<CovariateInsertPathReason, "aggregated" | "mixed">;
     }
   | {
       path: "aggregated";
       aggregatedTableFullName: string;
       idType: string;
       reason: "aggregated";
+    }
+  | {
+      path: "mixed";
+      aggregatedTableFullName: string;
+      idType: string;
+      coveredMetricIds: string[];
+      uncoveredMetricIds: string[];
+      reason: "mixed";
     };
 
 type ResolveCovariateInsertPathArgs = {
@@ -59,10 +68,12 @@ type ResolveCovariateInsertPathArgs = {
 };
 
 // Decides whether a fact-table group's covariate insert reads from the
-// pre-aggregated daily table or falls back to the legacy raw scan. All-or-nothing
-// per group: one covariate INSERT writes a row per unit with every metric column,
-// so it can't mix aggregated and raw columns. Any error falls back to legacy
-// (always correct) rather than failing the refresh.
+// pre-aggregated daily table, falls back to the legacy raw scan, or splits the
+// group across both ("mixed"). The mixed path emits two INSERTs into the same
+// destination table (covered metric columns from the aggregated table, uncovered
+// ones from the raw scan); the downstream stats read collapses multiple rows per
+// unit with `MAX(...) GROUP BY unit`, so the split is transparent. Any error
+// falls back to legacy (always correct) rather than failing the refresh.
 export async function resolveCovariateInsertPath(
   args: ResolveCovariateInsertPathArgs,
 ): Promise<CovariateInsertPath> {
@@ -180,33 +191,46 @@ async function resolveCovariateInsertPathInner({
     return { path: "legacy", reason: "window-not-covered" };
   }
 
-  const uncoveredMetricIds = regressionAdjustedMetrics
-    .filter(
-      (metric) =>
-        !isMetricCoveredByRegistry(
-          metric,
-          factTable.id,
-          registry.metricState,
-          log,
-        ),
-    )
-    .map((m) => m.id);
-  if (uncoveredMetricIds.length > 0) {
-    log("legacy: one or more RA metrics not covered by registry", {
-      uncoveredMetricIds,
-    });
+  const { coveredMetricIds, uncoveredMetricIds, uncoveredSliceMetricIds } =
+    partitionMetricsByRegistryCoverage(
+      regressionAdjustedMetrics,
+      factTable.id,
+      registry.metricState,
+      log,
+    );
+
+  if (coveredMetricIds.length === 0) {
+    log("legacy: no RA metrics covered by registry", { uncoveredMetricIds });
     return { path: "legacy", reason: "metrics-not-covered" };
   }
 
-  log("aggregated: all gates passed", {
+  if (uncoveredMetricIds.length === 0) {
+    log("aggregated: all gates passed", {
+      aggregatedTableFullName: registry.tableFullName,
+      idType: exposureUserIdType,
+    });
+    return {
+      path: "aggregated",
+      aggregatedTableFullName: registry.tableFullName,
+      idType: exposureUserIdType,
+      reason: "aggregated",
+    };
+  }
+
+  log("mixed: some RA metrics not covered by registry", {
     aggregatedTableFullName: registry.tableFullName,
     idType: exposureUserIdType,
+    coveredMetricCount: coveredMetricIds.length,
+    uncoveredMetricIds,
+    uncoveredSliceMetricIds,
   });
   return {
-    path: "aggregated",
+    path: "mixed",
     aggregatedTableFullName: registry.tableFullName,
     idType: exposureUserIdType,
-    reason: "aggregated",
+    coveredMetricIds,
+    uncoveredMetricIds,
+    reason: "mixed",
   };
 }
 
@@ -247,17 +271,57 @@ function getCovariateWindowBounds(
   return { firstCovariateDate, lastCovariateDate };
 }
 
-function isMetricCoveredByRegistry(
-  metric: FactMetricInterface,
+type MetricCoverage = "covered" | "uncovered-slice" | "uncovered-base";
+
+// Partitions a group's RA metrics into those the aggregated table can serve and
+// those it can't. Exported for unit testing; the runner consumes the partition
+// via resolveCovariateInsertPath.
+export function partitionMetricsByRegistryCoverage(
+  metrics: FactMetricInterface[],
   factTableId: string,
   metricState: AggregatedFactTableMetricStateInterface[],
   log: (msg: string, data?: Record<string, unknown>) => void = () => {},
-): boolean {
+): {
+  coveredMetricIds: string[];
+  uncoveredMetricIds: string[];
+  // Subset of uncoveredMetricIds whose base metric IS covered but whose slice
+  // columns aren't materialized (e.g., compound customMetricSlices). Tracked
+  // separately for logging — these are the cases the mixed path is designed for.
+  uncoveredSliceMetricIds: string[];
+} {
+  const coveredMetricIds: string[] = [];
+  const uncoveredMetricIds: string[] = [];
+  const uncoveredSliceMetricIds: string[] = [];
+  for (const metric of metrics) {
+    const coverage = classifyMetricCoverage(
+      metric,
+      factTableId,
+      metricState,
+      log,
+    );
+    if (coverage === "covered") {
+      coveredMetricIds.push(metric.id);
+    } else {
+      uncoveredMetricIds.push(metric.id);
+      if (coverage === "uncovered-slice") {
+        uncoveredSliceMetricIds.push(metric.id);
+      }
+    }
+  }
+  return { coveredMetricIds, uncoveredMetricIds, uncoveredSliceMetricIds };
+}
+
+function classifyMetricCoverage(
+  metric: FactMetricInterface,
+  factTableId: string,
+  metricState: AggregatedFactTableMetricStateInterface[],
+  log: (msg: string, data?: Record<string, unknown>) => void,
+): MetricCoverage {
   if (!canReAggregateDailyPartialsForCovariate(metric)) {
     log("metric not covered: unsafe to re-aggregate daily partials", {
       metricId: metric.id,
     });
-    return false;
+    return "uncovered-base";
   }
 
   const { baseMetricId, isSliceMetric } = parseSliceMetricId(metric.id);
@@ -267,7 +331,7 @@ function isMetricCoveredByRegistry(
       metricId: metric.id,
       baseMetricId,
     });
-    return false;
+    return "uncovered-base";
   }
 
   // Slice clones share the base metric's hash-affecting settings.
@@ -281,7 +345,7 @@ function isMetricCoveredByRegistry(
       computedHash: settingsHash,
       storedHash: baseState.settingsHash,
     });
-    return false;
+    return "uncovered-base";
   }
 
   const storedColumns = isSliceMetric
@@ -292,7 +356,7 @@ function isMetricCoveredByRegistry(
       metricId: metric.id,
       isSliceMetric,
     });
-    return false;
+    return isSliceMetric ? "uncovered-slice" : "uncovered-base";
   }
 
   const requiredColumns = getColumnsForMetric(metric, factTableId);
@@ -303,6 +367,7 @@ function isMetricCoveredByRegistry(
       requiredColumns,
       storedColumns,
     });
+    return isSliceMetric ? "uncovered-slice" : "uncovered-base";
   }
-  return covered;
+  return "covered";
 }

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -772,15 +772,17 @@ const startExperimentIncrementalRefreshQueries = async (
         factTableId: group.factTableId ?? null,
         path: covariatePath.path,
         aggregatedTableFullName:
-          covariatePath.path === "aggregated"
-            ? covariatePath.aggregatedTableFullName
-            : null,
+          covariatePath.path === "legacy"
+            ? null
+            : covariatePath.aggregatedTableFullName,
         reason: covariatePath.reason,
+        uncoveredMetricCount:
+          covariatePath.path === "mixed"
+            ? covariatePath.uncoveredMetricIds.length
+            : undefined,
       });
 
       const covariateInsertBaseParams = {
-        name: `insert_metrics_covariate_data_${group.groupId}`,
-        displayTitle: `Update Metric Covariate Data ${sourceName}`,
         dependencies: [
           maxTimestampUnitsTableQuery.query,
           ...(createMetricCovariateTableQuery
@@ -797,48 +799,51 @@ const startExperimentIncrementalRefreshQueries = async (
             setExternalId,
             queryMetadata,
           ),
-        onSuccess: async () => {
-          const incrementalRefresh =
-            await context.models.incrementalRefresh.getByExperimentId(
+      };
+
+      // Advances lastSuccessfulMaxTimestamp; attached only to the LAST insert
+      // in the chain so a partial mixed-path write can't skip units on retry.
+      const covariateInsertOnSuccess = async () => {
+        const incrementalRefresh =
+          await context.models.incrementalRefresh.getByExperimentId(
+            experimentId,
+          );
+        const lastSuccessfulMaxTimestamp =
+          incrementalRefresh?.unitsMaxTimestamp ?? null;
+        const updatedCovariateSource: IncrementalRefreshMetricCovariateSourceInterface =
+          existingCovariateSource
+            ? {
+                ...existingCovariateSource,
+                lastSuccessfulMaxTimestamp,
+              }
+            : {
+                groupId: group.groupId,
+                lastSuccessfulMaxTimestamp,
+                tableFullName: metricSourceCovariateTableFullName,
+              };
+        if (!existingCovariateSource) {
+          runningCovariateSourceData = runningCovariateSourceData.concat(
+            updatedCovariateSource,
+          );
+        } else {
+          runningCovariateSourceData = runningCovariateSourceData.map((s) =>
+            s.groupId === group.groupId ? updatedCovariateSource : s,
+          );
+        }
+        const lockHeld =
+          await context.models.incrementalRefresh.updateByExperimentIdIfCurrentExecution(
+            experimentId,
+            executionId,
+            {
+              metricCovariateSources: runningCovariateSourceData,
+            },
+          );
+        if (lockHeld !== true) {
+          context.logger.warn(
+            "Incremental refresh execution lock lost for experiment: " +
               experimentId,
-            );
-          const lastSuccessfulMaxTimestamp =
-            incrementalRefresh?.unitsMaxTimestamp ?? null;
-          const updatedCovariateSource: IncrementalRefreshMetricCovariateSourceInterface =
-            existingCovariateSource
-              ? {
-                  ...existingCovariateSource,
-                  lastSuccessfulMaxTimestamp,
-                }
-              : {
-                  groupId: group.groupId,
-                  lastSuccessfulMaxTimestamp,
-                  tableFullName: metricSourceCovariateTableFullName,
-                };
-          if (!existingCovariateSource) {
-            runningCovariateSourceData = runningCovariateSourceData.concat(
-              updatedCovariateSource,
-            );
-          } else {
-            runningCovariateSourceData = runningCovariateSourceData.map((s) =>
-              s.groupId === group.groupId ? updatedCovariateSource : s,
-            );
-          }
-          const lockHeld =
-            await context.models.incrementalRefresh.updateByExperimentIdIfCurrentExecution(
-              experimentId,
-              executionId,
-              {
-                metricCovariateSources: runningCovariateSourceData,
-              },
-            );
-          if (lockHeld !== true) {
-            context.logger.warn(
-              "Incremental refresh execution lock lost for experiment: " +
-                experimentId,
-            );
-          }
-        },
+          );
+        }
       };
 
       const commonCovariateQueryParams = {
@@ -848,18 +853,61 @@ const startExperimentIncrementalRefreshQueries = async (
         factTableId: group.factTableId,
         metricSourceCovariateTableFullName,
         unitsSourceTableFullName: unitsTableFullName,
-        metrics: regressionAdjustedMetrics,
         lastCovariateSuccessfulMaxTimestamp:
           existingCovariateSource?.lastSuccessfulMaxTimestamp || null,
       };
 
+      // Align to daily grain whenever the exposure id type is materialized,
+      // so the legacy scan computes the same covariate window as the
+      // pre-aggregated path.
+      const alignLegacyScanToDailyGrain = (
+        factTable?.aggregatedFactTableSettings?.idTypes ?? []
+      ).includes(exposureQuery.userIdType);
+
       if (covariatePath.path === "aggregated") {
         insertMetricCovariateDataQuery = await startQuery({
           ...covariateInsertBaseParams,
+          name: `insert_metrics_covariate_data_${group.groupId}`,
+          displayTitle: `Update Metric Covariate Data ${sourceName}`,
           query:
             integration.getInsertMetricSourceCovariateFromAggregatedFactTableQuery(
               {
                 ...commonCovariateQueryParams,
+                metrics: regressionAdjustedMetrics,
+                aggregatedTableFullName: covariatePath.aggregatedTableFullName,
+                idType: covariatePath.idType,
+              },
+            ),
+          onSuccess: covariateInsertOnSuccess,
+          queryType:
+            "experimentIncrementalRefreshInsertMetricsCovariateDataFromAggregated",
+        });
+        queries.push(insertMetricCovariateDataQuery);
+      } else if (covariatePath.path === "mixed") {
+        // Per-slice fallback: covered metric columns from the aggregated
+        // table, uncovered ones (typically compound customMetricSlices) from
+        // a legacy raw scan over only those metrics. Both INSERTs target the
+        // same destination table; the downstream stats read collapses the two
+        // rows per unit with `MAX(...) GROUP BY unit`, so the split is
+        // transparent. The legacy residual depends on the aggregated insert
+        // and is the only one to advance lastSuccessfulMaxTimestamp.
+        const coveredSet = new Set(covariatePath.coveredMetricIds);
+        const coveredMetrics = regressionAdjustedMetrics.filter((m) =>
+          coveredSet.has(m.id),
+        );
+        const uncoveredMetrics = regressionAdjustedMetrics.filter(
+          (m) => !coveredSet.has(m.id),
+        );
+
+        const aggregatedInsertQuery = await startQuery({
+          ...covariateInsertBaseParams,
+          name: `insert_metrics_covariate_data_${group.groupId}`,
+          displayTitle: `Update Metric Covariate Data ${sourceName}`,
+          query:
+            integration.getInsertMetricSourceCovariateFromAggregatedFactTableQuery(
+              {
+                ...commonCovariateQueryParams,
+                metrics: coveredMetrics,
                 aggregatedTableFullName: covariatePath.aggregatedTableFullName,
                 idType: covariatePath.idType,
               },
@@ -867,21 +915,40 @@ const startExperimentIncrementalRefreshQueries = async (
           queryType:
             "experimentIncrementalRefreshInsertMetricsCovariateDataFromAggregated",
         });
+        queries.push(aggregatedInsertQuery);
+
+        insertMetricCovariateDataQuery = await startQuery({
+          ...covariateInsertBaseParams,
+          name: `insert_metrics_covariate_data_legacy_residual_${group.groupId}`,
+          displayTitle: `Update Metric Covariate Data (Uncovered Slices) ${sourceName}`,
+          dependencies: [
+            ...covariateInsertBaseParams.dependencies,
+            aggregatedInsertQuery.query,
+          ],
+          query: integration.getInsertMetricSourceCovariateDataQuery({
+            ...commonCovariateQueryParams,
+            metrics: uncoveredMetrics,
+            alignLegacyScanToDailyGrain,
+          }),
+          onSuccess: covariateInsertOnSuccess,
+          queryType: "experimentIncrementalRefreshInsertMetricsCovariateData",
+        });
+        queries.push(insertMetricCovariateDataQuery);
       } else {
         insertMetricCovariateDataQuery = await startQuery({
           ...covariateInsertBaseParams,
+          name: `insert_metrics_covariate_data_${group.groupId}`,
+          displayTitle: `Update Metric Covariate Data ${sourceName}`,
           query: integration.getInsertMetricSourceCovariateDataQuery({
             ...commonCovariateQueryParams,
-            // Align to daily grain whenever the exposure id type is materialized,
-            // so the fallback window always matches the pre-aggregated path.
-            alignLegacyScanToDailyGrain: (
-              factTable?.aggregatedFactTableSettings?.idTypes ?? []
-            ).includes(exposureQuery.userIdType),
+            metrics: regressionAdjustedMetrics,
+            alignLegacyScanToDailyGrain,
           }),
+          onSuccess: covariateInsertOnSuccess,
           queryType: "experimentIncrementalRefreshInsertMetricsCovariateData",
         });
+        queries.push(insertMetricCovariateDataQuery);
       }
-      queries.push(insertMetricCovariateDataQuery);
     }
 
     const maxTimestampMetricsSourceQuery = await startQuery({

--- a/packages/back-end/src/services/experimentUpdateExecutionLogger.ts
+++ b/packages/back-end/src/services/experimentUpdateExecutionLogger.ts
@@ -27,9 +27,11 @@ export type ExperimentUpdateLogPlan = {
 export type ExperimentUpdateCovariateSourceLog = {
   groupId: string;
   factTableId: string | null;
-  path: "aggregated" | "legacy";
+  path: "aggregated" | "legacy" | "mixed";
   aggregatedTableFullName: string | null;
   reason: CovariateInsertPathReason;
+  // For path === "mixed": how many RA metrics fell back to the legacy raw scan.
+  uncoveredMetricCount?: number;
 };
 
 type ExperimentUpdateExecutionLog = {

--- a/packages/back-end/test/aggregatedFactTable.test.ts
+++ b/packages/back-end/test/aggregatedFactTable.test.ts
@@ -14,6 +14,7 @@ import {
   foldAggregatedFactTableCoverage,
 } from "back-end/src/queryRunners/AggregatedFactTableQueryRunner";
 import { getAggregatedFactTableMetrics } from "back-end/src/services/aggregatedFactTables";
+import { partitionMetricsByRegistryCoverage } from "back-end/src/integrations/sql/fact-metrics/resolve-covariate-insert-path";
 import { bigQueryDialect } from "back-end/src/integrations/dialects/bigquery";
 import { factMetricFactory } from "./factories/FactMetric.factory";
 import { factTableFactory } from "./factories/FactTable.factory";
@@ -565,6 +566,95 @@ describe("buildAggregatedFactTableSchemaState", () => {
       const entry = metricState.find((m) => m.metricId === metric.id);
       expect(entry?.slices).toEqual([]);
     }
+  });
+});
+
+describe("partitionMetricsByRegistryCoverage", () => {
+  const factTable = factTableFactory.build({
+    id: FT_ID,
+    sql: "SELECT * FROM events",
+    eventName: "purchase",
+    columns: [
+      {
+        column: "country",
+        name: "Country",
+        description: "",
+        datatype: "string",
+        numberFormat: "",
+        deleted: false,
+        dateCreated: new Date(),
+        dateUpdated: new Date(),
+        isAutoSliceColumn: true,
+        autoSlices: ["US", "UK"],
+      },
+    ],
+  });
+  const baseMetric = factMetricFactory.build({
+    id: "m1",
+    metricType: "mean",
+    numerator: { factTableId: FT_ID, column: "value", aggregation: "sum" },
+    metricAutoSlices: ["country"],
+  });
+  const singleDimSlices = getAutoSliceMetrics({
+    metric: baseMetric,
+    factTable,
+  });
+  // Registry materializes base + single-dim auto-slices only.
+  const { metricState } = buildAggregatedFactTableSchemaState({
+    factTable,
+    metrics: [baseMetric, ...singleDimSlices],
+  });
+
+  it("classifies a compound customMetricSlice as uncovered-slice without forcing legacy for the rest", () => {
+    // Compound slice (two dims) — never in baseState.slices since the agg
+    // builder only materializes single-dim metricAutoSlices.
+    const compoundSlice = {
+      ...baseMetric,
+      id: `${baseMetric.id}?dim:country=US&dim:platform=ios`,
+    };
+
+    const result = partitionMetricsByRegistryCoverage(
+      [baseMetric, ...singleDimSlices, compoundSlice],
+      FT_ID,
+      metricState,
+    );
+
+    expect(result.coveredMetricIds).toEqual(
+      expect.arrayContaining([
+        baseMetric.id,
+        ...singleDimSlices.map((m) => m.id),
+      ]),
+    );
+    expect(result.uncoveredMetricIds).toEqual([compoundSlice.id]);
+    expect(result.uncoveredSliceMetricIds).toEqual([compoundSlice.id]);
+  });
+
+  it("classifies a metric whose base is absent from the registry as uncovered-base", () => {
+    const otherBase = factMetricFactory.build({
+      id: "m2",
+      metricType: "mean",
+      numerator: { factTableId: FT_ID, column: "count", aggregation: "sum" },
+    });
+
+    const result = partitionMetricsByRegistryCoverage(
+      [baseMetric, otherBase],
+      FT_ID,
+      metricState,
+    );
+
+    expect(result.coveredMetricIds).toEqual([baseMetric.id]);
+    expect(result.uncoveredMetricIds).toEqual([otherBase.id]);
+    expect(result.uncoveredSliceMetricIds).toEqual([]);
+  });
+
+  it("returns all-covered when every metric is in the registry", () => {
+    const result = partitionMetricsByRegistryCoverage(
+      [baseMetric, ...singleDimSlices],
+      FT_ID,
+      metricState,
+    );
+    expect(result.uncoveredMetricIds).toEqual([]);
+    expect(result.coveredMetricIds.length).toBe(1 + singleDimSlices.length);
   });
 });
 


### PR DESCRIPTION
## Problem

`resolveCovariateInsertPath` returns `legacy` if **any** metric/slice column is missing from the agg table's `metricState`. Experiments with compound `customMetricSlices` (e.g. `{effort_level=high, model_class_pooled=Sonnet}`) always miss — the agg builder only materializes single-dim `metricAutoSlices`. So one compound slice → the entire FT group falls back to the raw scan and the agg table provides zero benefit.

## Fix

The gate now partitions the group's RA metrics into covered / uncovered and returns a third path `"mixed"` when at least one metric is covered but not all. The runner emits **two INSERTs into the same destination covariate table**:

- aggregated INSERT for the covered metric columns (reads `gb_aggregated_*`)
- legacy INSERT for only the uncovered metric columns (reads the raw `__factTable` CTE)

Each INSERT writes one row per unit with its column subset; the other columns stay NULL. The downstream stats read already collapses the covariate cache with `SELECT id, MAX(<col>) ... GROUP BY id` (`SqlIntegration.ts` `covariateInnerColumns`), so two rows per unit are transparent.

`onSuccess` (which advances `lastSuccessfulMaxTimestamp`) is attached only to the legacy-residual INSERT, which depends on the aggregated INSERT — a partial mixed-path write can't skip units on retry.

Same all-or-nothing-relaxation pattern as #6153 (archived metrics).

## Impact

For experiments with compound slices: the covered metrics (typically the vast majority of the group) keep reading the agg table; only the uncovered slice columns scan raw. For experiments without compound slices: no change — `aggregated` / `legacy` paths are byte-identical to before.

## Logging

`recordCovariateSource` now records `path: "mixed"` and `uncoveredMetricCount` so the per-group fallback is visible in execution logs.

## Test

`partitionMetricsByRegistryCoverage` is exported and unit-tested in `aggregatedFactTable.test.ts`: given a registry with base + single-dim auto-slices and a metric set including one compound slice, the compound slice lands in `uncoveredSliceMetricIds` while base + single-dim slices stay in `coveredMetricIds` (i.e. the gate would return `mixed`, not `legacy`). Also covers the absent-base and all-covered cases.