### PR TITLE
Make Big Numbers big enough

### DIFF
--- a/packages/front-end/components/SqlExplorer/BigValueChart.tsx
+++ b/packages/front-end/components/SqlExplorer/BigValueChart.tsx
@@ -20,14 +20,15 @@ type Props = {
   fillContainer?: boolean;
 };
 
-// Font sizes for `fillContainer` mode, relative to the smaller container
-// dimension (cqmin) per the design spec, but additionally capped by a
-// fraction of the container width (cqw) so longer strings can't overflow a
-// wide card, and clamped to a sane min/max.
+// Font sizes for `fillContainer` mode. The number scales to ~50% of the
+// smaller container dimension (cqmin), capped by a fraction of the width
+// (cqw) so it can't overflow a wide card. The label/comparison are captions:
+// they scale gently with the width and stay small so they never wrap into or
+// collide with the number.
 const FILL_FONT_SIZE = {
-  value: "clamp(2rem, min(50cqmin, 32cqw), 16rem)",
-  label: "clamp(0.75rem, min(15cqmin, 9cqw), 4rem)",
-  compare: "clamp(0.7rem, min(25cqmin, 9cqw), 5rem)",
+  value: "clamp(2rem, min(40cqmin, 26cqw), 13rem)",
+  label: "clamp(0.85rem, 5cqw, 1.5rem)",
+  compare: "clamp(0.8rem, 4.5cqw, 1.25rem)",
 } as const;
 
 function formatValue(value: number, format: BigValueFormat, currency: string) {
@@ -105,11 +106,12 @@ export default function BigValueChart({
           <Text
             as="div"
             color="gray"
+            truncate
+            align="center"
             style={{
               fontSize: FILL_FONT_SIZE.label,
               lineHeight: 1.2,
-              whiteSpace: "nowrap",
-              maxWidth: "100%",
+              width: "100%",
             }}
           >
             {label}

--- a/packages/front-end/components/SqlExplorer/BigValueChart.tsx
+++ b/packages/front-end/components/SqlExplorer/BigValueChart.tsx
@@ -1,4 +1,4 @@
-import { Flex, Heading, Text } from "@radix-ui/themes";
+import { Box, Flex, Heading, Text } from "@radix-ui/themes";
 import React, { type ReactNode } from "react";
 import { BigValueFormat } from "shared/validators";
 import { useCurrency } from "@/hooks/useCurrency";
@@ -12,7 +12,23 @@ type Props = {
   compareSlot?: ReactNode;
   /** Smaller heading for dense layouts (e.g. multi-metric grid). */
   compact?: boolean;
+  /**
+   * Scale the number/label/comparison to fill the surrounding container
+   * (the number targets ~50% of the smaller container dimension, the
+   * comparison ~25%). Only use inside a container with a determinate size.
+   */
+  fillContainer?: boolean;
 };
+
+// Font sizes for `fillContainer` mode, relative to the smaller container
+// dimension (cqmin) per the design spec, but additionally capped by a
+// fraction of the container width (cqw) so longer strings can't overflow a
+// wide card, and clamped to a sane min/max.
+const FILL_FONT_SIZE = {
+  value: "clamp(2rem, min(50cqmin, 32cqw), 16rem)",
+  label: "clamp(0.75rem, min(15cqmin, 9cqw), 4rem)",
+  compare: "clamp(0.7rem, min(25cqmin, 9cqw), 5rem)",
+} as const;
 
 function formatValue(value: number, format: BigValueFormat, currency: string) {
   switch (format) {
@@ -46,31 +62,94 @@ export default function BigValueChart({
   formatter,
   compareSlot,
   compact = false,
+  fillContainer = false,
 }: Props) {
   const currency = useCurrency();
   if (value === undefined || value === null) {
     return <div style={{ textAlign: "center", color: "#888" }}>No data</div>;
   }
-  return (
+
+  const displayValue = formatter
+    ? formatter(value)
+    : formatValue(value, format ?? "longNumber", currency);
+
+  const content = (
     <Flex
       align="center"
       justify="center"
       direction="column"
       height="100%"
+      width="100%"
       pt="2"
       pb="2"
     >
-      <Heading as="h1" size={compact ? "7" : "9"}>
-        {formatter
-          ? formatter(value)
-          : formatValue(value, format ?? "longNumber", currency)}
-      </Heading>
-      {label && (
-        <Text as="div" size="3" color="gray">
-          {label}
-        </Text>
+      {fillContainer ? (
+        <Heading
+          as="h1"
+          style={{
+            fontSize: FILL_FONT_SIZE.value,
+            lineHeight: 1.05,
+            whiteSpace: "nowrap",
+            maxWidth: "100%",
+          }}
+        >
+          {displayValue}
+        </Heading>
+      ) : (
+        <Heading as="h1" size={compact ? "7" : "9"}>
+          {displayValue}
+        </Heading>
       )}
-      {compareSlot}
+      {label &&
+        (fillContainer ? (
+          <Text
+            as="div"
+            color="gray"
+            style={{
+              fontSize: FILL_FONT_SIZE.label,
+              lineHeight: 1.2,
+              whiteSpace: "nowrap",
+              maxWidth: "100%",
+            }}
+          >
+            {label}
+          </Text>
+        ) : (
+          <Text as="div" size="3" color="gray">
+            {label}
+          </Text>
+        ))}
+      {fillContainer && compareSlot ? (
+        <Box
+          style={{
+            fontSize: FILL_FONT_SIZE.compare,
+            lineHeight: 1.2,
+            maxWidth: "100%",
+          }}
+        >
+          {compareSlot}
+        </Box>
+      ) : (
+        compareSlot
+      )}
     </Flex>
+  );
+
+  if (!fillContainer) return content;
+
+  // Establish a query container so the cqmin/cqw units above resolve against
+  // this card rather than the viewport.
+  return (
+    <div
+      style={
+        {
+          width: "100%",
+          height: "100%",
+          containerType: "size",
+        } as React.CSSProperties
+      }
+    >
+      {content}
+    </div>
   );
 }

--- a/packages/front-end/enterprise/components/ProductAnalytics/ComparisonTrendLabel.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/ComparisonTrendLabel.tsx
@@ -25,7 +25,7 @@ export default function ComparisonTrendLabel({
         ) : (
           <PiArrowDown style={iconScale} color="var(--red-9)" />
         ))}
-      <Text size="small" color="text-mid">
+      <Text size="inherit" color="text-mid">
         {flat
           ? "No change vs comparison"
           : `${pctChange >= 0 ? "+" : "−"}${pctDisplay}% vs comparison`}

--- a/packages/front-end/enterprise/components/ProductAnalytics/ComparisonTrendLabel.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/ComparisonTrendLabel.tsx
@@ -25,7 +25,7 @@ export default function ComparisonTrendLabel({
         ) : (
           <PiArrowDown style={iconScale} color="var(--red-9)" />
         ))}
-      <Text size="inherit" color="text-mid">
+      <Text size="inherit" color="text-mid" whiteSpace="nowrap">
         {flat
           ? "No change vs comparison"
           : `${pctChange >= 0 ? "+" : "−"}${pctDisplay}% vs comparison`}

--- a/packages/front-end/enterprise/components/ProductAnalytics/MainSection/ExplorerChart.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/MainSection/ExplorerChart.tsx
@@ -861,7 +861,7 @@ export default function ExplorerChart({
                     value={card.value}
                     formatter={formatNumber}
                     label={card.label}
-                    compact
+                    fillContainer
                     compareSlot={
                       trend ? (
                         <ComparisonTrendLabel

--- a/packages/front-end/enterprise/components/ProductAnalytics/MainSection/ExplorerChart.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/MainSection/ExplorerChart.tsx
@@ -863,12 +863,7 @@ export default function ExplorerChart({
                     label={card.label}
                     fillContainer
                     compareSlot={
-                      trend ? (
-                        <ComparisonTrendLabel
-                          trend={trend}
-                          priorValueScale={0.5}
-                        />
-                      ) : undefined
+                      trend ? <ComparisonTrendLabel trend={trend} /> : undefined
                     }
                   />
                 </Box>


### PR DESCRIPTION
### Features and Changes
Make big numbers bigger in the view

### Screenshots
Before
<img width="4562" height="2050" alt="image" src="https://github.com/user-attachments/assets/b15aabb3-3843-4e1d-9f6f-e07c567367b9" />
After
<img width="2314" height="927" alt="Screenshot 2026-06-26 at 08 45 18" src="https://github.com/user-attachments/assets/c1236002-74b6-40fc-8085-0e8be1fb28fb" />
<img width="500" height="932" alt="Screenshot 2026-06-26 at 09 35 01" src="https://github.com/user-attachments/assets/0e8d120a-12cb-4ca2-9520-9bd32f8f0255" />
<img width="2363" height="959" alt="Screenshot 2026-06-26 at 09 35 09" src="https://github.com/user-attachments/assets/89d96c55-4a24-4c39-914f-e7e87f3b23dd" />

