### PR TITLE
fix(fact-tables): only refresh columns when SQL or event name actually changes

### DIFF
--- a/packages/back-end/src/api/bulk-import/postBulkImportFacts.ts
+++ b/packages/back-end/src/api/bulk-import/postBulkImportFacts.ts
@@ -102,7 +102,7 @@ export const postBulkImportFacts = createApiRequestHandler(
             (await resolveOwnerToUserId(data.owner, req.context)) ?? "";
         }
         await updateFactTable(req.context, existing, data);
-        if (needsColumnRefresh(data)) {
+        if (needsColumnRefresh(existing, data)) {
           await queueFactTableColumnsRefresh(existing);
         }
         factTableMap.set(existing.id, {

--- a/packages/back-end/src/api/fact-tables/updateFactTable.ts
+++ b/packages/back-end/src/api/fact-tables/updateFactTable.ts
@@ -1,6 +1,9 @@
 import { omit } from "lodash";
 import { updateFactTableValidator } from "shared/validators";
-import { UpdateFactTableProps } from "shared/types/fact-table";
+import {
+  FactTableInterface,
+  UpdateFactTableProps,
+} from "shared/types/fact-table";
 import { queueFactTableColumnsRefresh } from "back-end/src/jobs/refreshFactTableColumns";
 import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 import {
@@ -121,7 +124,7 @@ export const updateFactTable = createApiRequestHandler(
   }
 
   await updateFactTableInDb(req.context, factTable, data);
-  if (needsColumnRefresh(data)) {
+  if (needsColumnRefresh(factTable, data)) {
     await queueFactTableColumnsRefresh(factTable);
   }
 
@@ -156,6 +159,12 @@ export const updateFactTable = createApiRequestHandler(
   };
 });
 
-export function needsColumnRefresh(changes: UpdateFactTableProps): boolean {
-  return !!(changes.sql || changes.eventName);
+export function needsColumnRefresh(
+  existing: Pick<FactTableInterface, "sql" | "eventName">,
+  changes: UpdateFactTableProps,
+): boolean {
+  const sqlChanged = changes.sql !== undefined && changes.sql !== existing.sql;
+  const eventNameChanged =
+    changes.eventName !== undefined && changes.eventName !== existing.eventName;
+  return sqlChanged || eventNameChanged;
 }

--- a/packages/back-end/src/routers/fact-table/fact-table.controller.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.controller.ts
@@ -333,7 +333,7 @@ export const putFactTable = async (
     >
   > | null = null;
 
-  if (forceColumnRefresh || needsColumnRefresh(data)) {
+  if (forceColumnRefresh || needsColumnRefresh(factTable, data)) {
     const { columns, needsBackgroundRefresh } = await refreshColumns(
       context,
       datasource,

--- a/packages/back-end/test/api/fact-tables.test.ts
+++ b/packages/back-end/test/api/fact-tables.test.ts
@@ -1,0 +1,52 @@
+import {
+  FactTableInterface,
+  UpdateFactTableProps,
+} from "shared/types/fact-table";
+import { needsColumnRefresh } from "back-end/src/api/fact-tables/updateFactTable";
+
+const existing: Pick<FactTableInterface, "sql" | "eventName"> = {
+  sql: "SELECT user_id, timestamp FROM events",
+  eventName: "purchase",
+};
+
+describe("needsColumnRefresh", () => {
+  it("returns false when no sql or eventName is in the changes", () => {
+    const changes: UpdateFactTableProps = { name: "Renamed" };
+    expect(needsColumnRefresh(existing, changes)).toBe(false);
+  });
+
+  it("returns false when sql and eventName are resent unchanged", () => {
+    const changes: UpdateFactTableProps = {
+      name: "Renamed",
+      sql: existing.sql,
+      eventName: existing.eventName,
+    };
+    expect(needsColumnRefresh(existing, changes)).toBe(false);
+  });
+
+  it("returns true when sql changes", () => {
+    const changes: UpdateFactTableProps = {
+      sql: "SELECT user_id, timestamp, country FROM events",
+    };
+    expect(needsColumnRefresh(existing, changes)).toBe(true);
+  });
+
+  it("returns true for a whitespace-only sql edit (over-flags, the safe direction)", () => {
+    const changes: UpdateFactTableProps = { sql: existing.sql + "\n" };
+    expect(needsColumnRefresh(existing, changes)).toBe(true);
+  });
+
+  it("returns true when eventName changes", () => {
+    const changes: UpdateFactTableProps = { eventName: "checkout" };
+    expect(needsColumnRefresh(existing, changes)).toBe(true);
+  });
+
+  it("treats a set value against a missing stored value as a change", () => {
+    const blank: Pick<FactTableInterface, "sql" | "eventName"> = {
+      sql: "",
+      eventName: "",
+    };
+    const changes: UpdateFactTableProps = { sql: existing.sql };
+    expect(needsColumnRefresh(blank, changes)).toBe(true);
+  });
+});


### PR DESCRIPTION
### Features and Changes

`needsColumnRefresh` decided whether to run column detection based only on whether `sql` or `eventName` were *present* in the update payload. But clients (the UI and API) often resend those fields unchanged on every edit, so renaming a fact table or tweaking unrelated settings would still trigger a full column detection scan against the warehouse.

Now `needsColumnRefresh` takes the existing fact table and compares values, so column detection only runs when `sql` or `eventName` actually changed. This avoids unnecessary (and potentially expensive) warehouse scans on no-op edits.

### Testing

Unit tests
