### PR TITLE
Visual Editor AI: drop unchanged global CSS/JS from the response

### DIFF
--- a/packages/back-end/src/enterprise/api/visual-editor-ai/postAIEdit.ts
+++ b/packages/back-end/src/enterprise/api/visual-editor-ai/postAIEdit.ts
@@ -736,6 +736,14 @@ export const postAIEdit = createApiRequestHandler(validation)(async (req) => {
       // stronger models (e.g. Sonnet) often re-emit the full UNCHANGED
       // stylesheet instead — which would surface as a phantom "global CSS
       // change" on every follow-up turn. Treat identical = no change.
+      //
+      // The leading truthiness check ALSO drops a falsy result (""/null), so
+      // CLEARING global CSS/JS via the AI is intentionally not supported: the
+      // schema instructs the model never to return an empty string when CSS
+      // exists (it would wipe the variation), and we'd rather no-op than risk
+      // an accidental wipe. To delete all global CSS/JS, use the manual
+      // CSS/JS editor. If deliberate AI clearing is ever wanted, gate it on an
+      // explicit signal (e.g. an `intent: "clear"` field) rather than ""/null.
       ...(result.css && result.css !== currentChange?.css
         ? { css: result.css }
         : {}),

--- a/packages/back-end/src/enterprise/api/visual-editor-ai/postAIEdit.ts
+++ b/packages/back-end/src/enterprise/api/visual-editor-ai/postAIEdit.ts
@@ -731,8 +731,17 @@ export const postAIEdit = createApiRequestHandler(validation)(async (req) => {
             : {}),
         };
       }),
-      ...(result.css ? { css: result.css } : {}),
-      ...(result.js ? { js: result.js } : {}),
+      // Drop css/js that's byte-identical to what's already saved. The model
+      // is told to return null when it isn't touching global CSS/JS, but
+      // stronger models (e.g. Sonnet) often re-emit the full UNCHANGED
+      // stylesheet instead — which would surface as a phantom "global CSS
+      // change" on every follow-up turn. Treat identical = no change.
+      ...(result.css && result.css !== currentChange?.css
+        ? { css: result.css }
+        : {}),
+      ...(result.js && result.js !== currentChange?.js
+        ? { js: result.js }
+        : {}),
       explanation: result.explanation,
     };
   };


### PR DESCRIPTION
## Problem
On follow-up turns the AI re-emits the full, unchanged global CSS/JS, so it shows up as a phantom "global CSS change" every time. It got more common after the Visual Editor moved to Sonnet, which follows the "return the complete CSS" instruction literally.

## Fix
In `finalizeOutput`, only include `css`/`js` in the response when it actually differs from the variation's saved value. Deterministic and model independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
