### PR TITLE
Visual Editor AI: crop replacement images to the original slot aspect

### DIFF
--- a/packages/back-end/src/api/visual-editor-ai/postAIImageGen.ts
+++ b/packages/back-end/src/api/visual-editor-ai/postAIImageGen.ts
@@ -166,7 +166,11 @@ export const postAIImageGen = createApiRequestHandler(validation)(async (
   let unoptimizedCount = 0;
   for (let i = 0; i < generated.length; i++) {
     const img = generated[i];
-    const optimized = await optimizeAIImage(img);
+    // When replacing an existing <img>, the extension sends its exact natural
+    // dimensions as `aspectRatio` ("W:H"). Crop the generated image to that
+    // aspect so it slots in cleanly instead of being center-cropped/zoomed by
+    // the page. Undefined for inserts / background-image targets → plain fit.
+    const optimized = await optimizeAIImage(img, { cropToAspect: aspectRatio });
     if (!optimized.optimized) unoptimizedCount++;
     beforeBytes += img.buffer.length;
     afterBytes += optimized.buffer.length;

--- a/packages/back-end/src/services/imageGeneration.ts
+++ b/packages/back-end/src/services/imageGeneration.ts
@@ -154,27 +154,43 @@ async function generateViaMultimodalText(
   const { context, model, prompt, count, referenceImage } = params;
   const provider = getImageProvider(context, meta);
   const sdkModelId = resolveImageModelIdForSdk(model);
-  // These Gemini models don't accept `n` — fire `count` parallel calls
-  // and settle-all so one transient failure doesn't waste the others.
-  const userContent: Array<
+  // The reference image (if any) is the same on every call.
+  const baseContent: Array<
     | { type: "text"; text: string }
     | { type: "image"; image: Uint8Array; mediaType: string }
   > = [];
   if (referenceImage) {
-    userContent.push({
+    baseContent.push({
       type: "image",
       image: Buffer.from(referenceImage.data, "base64"),
       mediaType: referenceImage.mimeType,
     });
   }
-  userContent.push({ type: "text", text: prompt });
 
-  const callOnce = async (): Promise<GeneratedImage[]> => {
+  // When the user asks for several options at once, nudge each parallel call
+  // toward a distinct result — with identical inputs Gemini collapses to near
+  // duplicates (especially in img2img). The first call is the faithful take;
+  // each subsequent one varies a different lever. Only applied when count > 1.
+  const VARIATION_NUDGES = [
+    "",
+    "\n\nVariation: use a noticeably different composition and camera angle.",
+    "\n\nVariation: use a different color palette and lighting mood.",
+    "\n\nVariation: take a more minimal, alternative styling approach.",
+  ];
+
+  // These Gemini models don't accept `n` — fire `count` parallel calls and
+  // settle-all so one transient failure doesn't waste the others.
+  const callOnce = async (index: number): Promise<GeneratedImage[]> => {
+    const variation = count > 1 ? (VARIATION_NUDGES[index] ?? "") : "";
+    const content = [
+      ...baseContent,
+      { type: "text" as const, text: prompt + variation },
+    ];
     const result = await generateText({
       model: (provider as ReturnType<typeof createGoogleGenerativeAI>)(
         sdkModelId,
       ),
-      messages: [{ role: "user", content: userContent }],
+      messages: [{ role: "user", content }],
       providerOptions: {
         google: {
           // Without this Gemini returns a text description instead of bytes.
@@ -204,7 +220,7 @@ async function generateViaMultimodalText(
   };
 
   const settled = await Promise.allSettled(
-    Array.from({ length: count }, () => callOnce()),
+    Array.from({ length: count }, (_, i) => callOnce(i)),
   );
 
   const out: GeneratedImage[] = [];

--- a/packages/back-end/src/services/imageOptimization.ts
+++ b/packages/back-end/src/services/imageOptimization.ts
@@ -77,13 +77,98 @@ function fitDimensions(
   };
 }
 
-async function krakenOptimize(source: RawImage): Promise<OptimizedImage> {
+// Parse a "W:H" aspect string (e.g. "16:9", "800:600") into a width/height
+// ratio. Returns null for anything malformed so callers fall back to "fit".
+function parseAspectRatio(s: string | undefined): number | null {
+  if (!s) return null;
+  const m = /^\s*(\d+(?:\.\d+)?)\s*:\s*(\d+(?:\.\d+)?)\s*$/.exec(s);
+  if (!m) return null;
+  const w = parseFloat(m[1]);
+  const h = parseFloat(m[2]);
+  if (!(w > 0) || !(h > 0)) return null;
+  return w / h;
+}
+
+// Largest box at `ratio` (w/h) that fits INSIDE the source — so the crop only
+// ever downscales, never upscales — then capped to the longest-edge limit.
+function cropDimensions(
+  sourceWidth: number,
+  sourceHeight: number,
+  ratio: number,
+): { width: number; height: number } {
+  let width = sourceWidth;
+  let height = Math.round(width / ratio);
+  if (height > sourceHeight) {
+    height = sourceHeight;
+    width = Math.round(height * ratio);
+  }
+  const longest = Math.max(width, height);
+  if (longest > MAX_LONGEST_EDGE_PX) {
+    const scale = MAX_LONGEST_EDGE_PX / longest;
+    width = Math.round(width * scale);
+    height = Math.round(height * scale);
+  }
+  return { width: Math.max(1, width), height: Math.max(1, height) };
+}
+
+// Resolve the Kraken resize block + the resulting output dimensions.
+// When `cropToAspect` is a valid ratio that differs from the source, use
+// Kraken's "crop" strategy (resize-to-cover then center-crop) so the output
+// matches the target aspect EXACTLY — the generated image then drops into the
+// page's <img> slot without the browser center-cropping/zooming it. Downscale
+// only (the box fits inside the source). Otherwise fall back to plain "fit".
+function resolveResize(
+  source: RawImage,
+  cropToAspect: string | undefined,
+): {
+  resize: Record<string, unknown>;
+  width: number;
+  height: number;
+} {
+  const ratio = parseAspectRatio(cropToAspect);
+  if (ratio) {
+    const { width, height } = cropDimensions(
+      source.width,
+      source.height,
+      ratio,
+    );
+    return {
+      resize: { strategy: "crop", width, height },
+      width,
+      height,
+    };
+  }
+  const fit = fitDimensions(source.width, source.height);
+  return {
+    resize: {
+      strategy: "fit",
+      width: MAX_LONGEST_EDGE_PX,
+      height: MAX_LONGEST_EDGE_PX,
+    },
+    ...fit,
+  };
+}
+
+async function krakenOptimize(
+  source: RawImage,
+  cropToAspect?: string,
+): Promise<OptimizedImage> {
   // Bound the whole round-trip; abort both requests if it runs long.
   const controller = new AbortController();
   const timer = setTimeout(
     () => controller.abort(),
     AI_IMAGE_OPTIMIZATION_TIMEOUT_MS,
   );
+
+  // "crop" to the original slot's aspect (downscale-only) when we know it, so
+  // the result drops in without the browser center-cropping it; otherwise a
+  // plain "fit" downscale. Output dims are derived here (Kraken doesn't return
+  // them and we don't decode the bytes).
+  const {
+    resize,
+    width: outWidth,
+    height: outHeight,
+  } = resolveResize(source, cropToAspect);
 
   try {
     const form = new FormData();
@@ -95,13 +180,9 @@ async function krakenOptimize(source: RawImage): Promise<OptimizedImage> {
         wait: true,
         lossy: true,
         quality: WEBP_QUALITY,
-        // Convert to WebP and fit within the box without upscaling.
+        // Convert to WebP and resize per resolveResize (crop or fit).
         webp: true,
-        resize: {
-          strategy: "fit",
-          width: MAX_LONGEST_EDGE_PX,
-          height: MAX_LONGEST_EDGE_PX,
-        },
+        resize,
       }),
     );
     form.append("upload", source.buffer, {
@@ -132,13 +213,12 @@ async function krakenOptimize(source: RawImage): Promise<OptimizedImage> {
       throw new Error(`Kraken result download returned HTTP ${imgRes.status}`);
     }
     const buffer = Buffer.from(await imgRes.arrayBuffer());
-    const { width, height } = fitDimensions(source.width, source.height);
     return {
       buffer,
       contentType: "image/webp",
       ext: "webp",
-      width,
-      height,
+      width: outWidth,
+      height: outHeight,
       optimized: true,
     };
   } finally {
@@ -151,13 +231,20 @@ async function krakenOptimize(source: RawImage): Promise<OptimizedImage> {
 // rather than failing image generation outright.
 export async function optimizeAIImage(
   source: RawImage,
+  opts?: {
+    // "W:H" of the slot the image will fill (the original <img>'s natural
+    // dimensions). When set, the result is cropped to this exact aspect so it
+    // drops into the slot without browser-side cropping/zooming. Omit for
+    // inserts / background-image targets where there's no fixed slot aspect.
+    cropToAspect?: string;
+  },
 ): Promise<OptimizedImage> {
   if (DISABLE_AI_IMAGE_OPTIMIZATION || !KRAKEN_API_KEY || !KRAKEN_API_SECRET) {
     return passthrough(source);
   }
 
   try {
-    return await krakenOptimize(source);
+    return await krakenOptimize(source, opts?.cropToAspect);
   } catch (err) {
     logger.warn(
       { err },

--- a/packages/back-end/src/services/imageOptimization.ts
+++ b/packages/back-end/src/services/imageOptimization.ts
@@ -184,7 +184,10 @@ function readImageDimensions(
 // (resize-to-cover then center-crop) so the output matches the target aspect
 // EXACTLY — the generated image then drops into the page's <img> slot without
 // the browser center-cropping/zooming it. Downscale only (the box fits inside
-// the source). Otherwise fall back to plain "fit".
+// the source). Falls back to plain "fit" when no valid ratio is provided.
+// Note: no source-aspect comparison — a ratio equal to the source's still
+// goes through "crop" (equivalent result), so add a skip-if-same guard here
+// if that ever matters.
 function resolveResize(
   srcWidth: number,
   srcHeight: number,

--- a/packages/back-end/src/services/imageOptimization.ts
+++ b/packages/back-end/src/services/imageOptimization.ts
@@ -10,9 +10,11 @@ import {
 
 // AI-generated images are optimized via the Kraken.io API (resize + WebP),
 
-// Downscale to a sane longest-edge cap and re-encode as WebP. Gemini returns
-// ~1 MB lossless PNGs; this yields ~80–150 KB WebP with no perceptible loss.
-const MAX_LONGEST_EDGE_PX = 1280;
+// Downscale to a sane longest-edge cap and re-encode as WebP. 1920 covers
+// full-width hero slots at 1x; aspect-honoring/high-res models (Gemini 3 Pro
+// Image) can fill it, smaller models are only ever downscaled toward it.
+// WebP @82 keeps a 1920px image to a few hundred KB.
+const MAX_LONGEST_EDGE_PX = 1920;
 const WEBP_QUALITY = 82;
 const KRAKEN_UPLOAD_URL = "https://api.kraken.io/v1/upload";
 
@@ -111,14 +113,81 @@ function cropDimensions(
   return { width: Math.max(1, width), height: Math.max(1, height) };
 }
 
-// Resolve the Kraken resize block + the resulting output dimensions.
-// When `cropToAspect` is a valid ratio that differs from the source, use
-// Kraken's "crop" strategy (resize-to-cover then center-crop) so the output
-// matches the target aspect EXACTLY — the generated image then drops into the
-// page's <img> slot without the browser center-cropping/zooming it. Downscale
-// only (the box fits inside the source). Otherwise fall back to plain "fit".
+// Read pixel dimensions straight from the image header (no full decode, zero
+// dependency). The provider tags generated images with NOMINAL dims (a coarse
+// aspect hint, longest edge ~1024), not the real output size, so without this
+// the crop/cap would size against 1024 and silently downscale a higher-res
+// model's output. Returns null for headers we can't parse; callers fall back
+// to the nominal dims. Generated images are PNG (most providers) or JPEG.
+function readImageDimensions(
+  buffer: Buffer,
+): { width: number; height: number } | null {
+  if (buffer.length < 24) return null;
+
+  // PNG: 8-byte signature, then the IHDR chunk with width/height as big-endian
+  // uint32 at byte offsets 16 and 20.
+  if (
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47
+  ) {
+    const width = buffer.readUInt32BE(16);
+    const height = buffer.readUInt32BE(20);
+    return width > 0 && height > 0 ? { width, height } : null;
+  }
+
+  // JPEG: walk the marker segments to the Start-Of-Frame, which carries dims.
+  if (buffer[0] === 0xff && buffer[1] === 0xd8) {
+    let offset = 2;
+    while (offset + 9 < buffer.length) {
+      if (buffer[offset] !== 0xff) {
+        offset++;
+        continue;
+      }
+      const marker = buffer[offset + 1];
+      // SOF0-SOF15 carry frame dimensions; DHT(c4)/JPG(c8)/DAC(cc) don't.
+      if (
+        marker >= 0xc0 &&
+        marker <= 0xcf &&
+        marker !== 0xc4 &&
+        marker !== 0xc8 &&
+        marker !== 0xcc
+      ) {
+        const height = buffer.readUInt16BE(offset + 5);
+        const width = buffer.readUInt16BE(offset + 7);
+        return width > 0 && height > 0 ? { width, height } : null;
+      }
+      // Standalone markers (SOI/EOI/RSTn/TEM) have no length field.
+      if (
+        marker === 0xd8 ||
+        marker === 0xd9 ||
+        marker === 0x01 ||
+        (marker >= 0xd0 && marker <= 0xd7)
+      ) {
+        offset += 2;
+        continue;
+      }
+      const segLen = buffer.readUInt16BE(offset + 2);
+      if (segLen < 2) return null;
+      offset += 2 + segLen;
+    }
+    return null;
+  }
+
+  return null;
+}
+
+// Resolve the Kraken resize block + the resulting output dimensions, sizing
+// against the source's REAL pixel dimensions (srcWidth/srcHeight).
+// When `cropToAspect` is a valid ratio, use Kraken's "crop" strategy
+// (resize-to-cover then center-crop) so the output matches the target aspect
+// EXACTLY — the generated image then drops into the page's <img> slot without
+// the browser center-cropping/zooming it. Downscale only (the box fits inside
+// the source). Otherwise fall back to plain "fit".
 function resolveResize(
-  source: RawImage,
+  srcWidth: number,
+  srcHeight: number,
   cropToAspect: string | undefined,
 ): {
   resize: Record<string, unknown>;
@@ -127,18 +196,14 @@ function resolveResize(
 } {
   const ratio = parseAspectRatio(cropToAspect);
   if (ratio) {
-    const { width, height } = cropDimensions(
-      source.width,
-      source.height,
-      ratio,
-    );
+    const { width, height } = cropDimensions(srcWidth, srcHeight, ratio);
     return {
       resize: { strategy: "crop", width, height },
       width,
       height,
     };
   }
-  const fit = fitDimensions(source.width, source.height);
+  const fit = fitDimensions(srcWidth, srcHeight);
   return {
     resize: {
       strategy: "fit",
@@ -160,15 +225,20 @@ async function krakenOptimize(
     AI_IMAGE_OPTIMIZATION_TIMEOUT_MS,
   );
 
+  // Size against the REAL generated pixels (the provider only tags nominal
+  // ~1024 dims), falling back to those nominal dims if the header won't parse.
   // "crop" to the original slot's aspect (downscale-only) when we know it, so
   // the result drops in without the browser center-cropping it; otherwise a
   // plain "fit" downscale. Output dims are derived here (Kraken doesn't return
-  // them and we don't decode the bytes).
+  // them).
+  const actual = readImageDimensions(source.buffer);
+  const srcWidth = actual?.width ?? source.width;
+  const srcHeight = actual?.height ?? source.height;
   const {
     resize,
     width: outWidth,
     height: outHeight,
-  } = resolveResize(source, cropToAspect);
+  } = resolveResize(srcWidth, srcHeight, cropToAspect);
 
   try {
     const form = new FormData();

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -314,8 +314,15 @@ export function getAISettingsForOrg(
   const visualEditorAIModel: AIModel =
     context.org.settings?.visualEditorAIModel ||
     (IS_CLOUD ? "claude-sonnet-4-5-20250929" : defaultAIModel);
+  // On Cloud, default the visual editor's image model to Gemini 3 Pro Image:
+  // it honors the requested aspect ratio (so replacements aren't center-
+  // cropped/clipped) and renders at higher resolution, while still supporting
+  // reference images for img2img. Self-hosted keeps the stable nano-banana
+  // default (GEMINI_IMAGE_MODEL, env-overridable) rather than a preview model.
+  // An explicit org setting always wins.
   const visualEditorImageModel: string =
-    context.org.settings?.visualEditorImageModel || GEMINI_IMAGE_MODEL;
+    context.org.settings?.visualEditorImageModel ||
+    (IS_CLOUD ? "gemini-3-pro-image-preview" : GEMINI_IMAGE_MODEL);
 
   return {
     aiEnabled,


### PR DESCRIPTION
Improves visual editor image replacement so generated images fit the original slot at full quality.

## Problem
Replacement images are generated at the closest supported aspect ratio, then the page's `<img>` slot center-crops or zooms them to fit, clipping the subject. They also come back low-res: the provider tags images with nominal ~1024 dims (not real pixels), so the optimize step downscaled everything to ~1024.

## Changes
- Crop the generated image to the original slot's exact aspect in Kraken (downscale only), so it drops in with no browser-side cropping. Falls back to "fit" when there is no target aspect (inserts, background images) or Kraken is unavailable.
- Cloud now defaults the image model to `gemini-3-pro-image-preview`, which honors aspect ratio (minimal crop, no clipping) and renders higher-res, and still supports reference images for img2img. Self-hosted keeps the stable default.
- Read true pixel dimensions from the image header (PNG/JPEG, zero dependency) so the crop and cap size against real resolution instead of the nominal hint. This also makes the crop strictly downscale only.
- Raise the optimize cap from 1280 to 1920 so full-width heroes are not downscaled.

Follow-up: the AI-chat `generateImage` tool still uses plain fit, since it only has a coarse model-guessed aspect, not the original slot's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
