### PR TITLE
feat(settings): mark required fields and drop "(optional)" markers

### DIFF
--- a/packages/front-end/components/GeneralSettings/AISettings.tsx
+++ b/packages/front-end/components/GeneralSettings/AISettings.tsx
@@ -197,7 +197,7 @@ function getPrompts(data: { prompts: AIPromptInterface[] }): Array<{
         AI_PROMPT_DEFAULTS["product-analytics-chat"],
       promptDefaultValue: AI_PROMPT_DEFAULTS["product-analytics-chat"],
       promptHelpText:
-        "Optional. Leave blank to use only the built-in assistant instructions. When set, this text is appended to the system prompt.",
+        "Leave blank to use only the built-in assistant instructions. When set, this text is appended to the system prompt.",
       overrideModelHelpText:
         "Tool-heavy assistants often work better with a capable model.",
       overrideModel: data.prompts.find(
@@ -757,7 +757,7 @@ export default function AISettings({
                       placeholder={
                         'e.g. "We\'re a B2B SaaS company. Brand colors: #6E56CF and #1F2D5C. Sentence-case CTAs. Friendly but professional tone."'
                       }
-                      helpText="Optional. Prepended to every Visual Editor AI prompt (text edits + image generation) so the AI follows your brand voice and visual identity."
+                      helpText="Prepended to every Visual Editor AI prompt (text edits + image generation) so the AI follows your brand voice and visual identity."
                       {...form.register("visualEditorAIContext")}
                     />
                   </Box>

--- a/packages/front-end/components/GeneralSettings/DatasourceSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/DatasourceSettings.tsx
@@ -28,7 +28,7 @@ export default function DatasourceSettings() {
 
           <Box mb="6" width="100%">
             <Text as="label" className="font-weight-semibold" size="3">
-              Default Data Source (Optional)
+              Default Data Source
             </Text>
             <Box mb="3">
               The default data source is the default data source selected when

--- a/packages/front-end/components/GeneralSettings/FeatureSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/FeatureSettings.tsx
@@ -112,7 +112,7 @@ export default function FeatureSettings() {
           <Box mb="6" width="100%">
             <Text as="label" htmlFor="featureKeyExample" mb="2">
               <Text size="3" className="font-weight-semibold">
-                Feature Key Example (Optional)
+                Feature Key Example
               </Text>
             </Text>
             <Text as="p" mb="2" size="2">
@@ -133,7 +133,7 @@ export default function FeatureSettings() {
               size="3"
               className="font-weight-semibold"
             >
-              Feature Key Regex Validator (Optional)
+              Feature Key Regex Validator
             </Text>
             <Text as="p" mb="2" size="2">
               When using the create feature modal, this will validate the
@@ -355,7 +355,7 @@ export default function FeatureSettings() {
                   </Box>
                   <Box mb="5">
                     <Field
-                      label="Only show code refs from the following branches (comma-separated, optional):"
+                      label="Only show code refs from the following branches (comma-separated):"
                       type="text"
                       placeholder="main, qa, dev"
                       value={codeRefsBranchesToFilterStr}
@@ -367,7 +367,7 @@ export default function FeatureSettings() {
 
                   <Box mb="5">
                     <SelectField
-                      label="Platform (to allow direct linking, optional):"
+                      label="Platform (to allow direct linking):"
                       labelClassName="font-weight-semibold"
                       containerClassName="mb-0"
                       value={form.watch("codeRefsPlatformUrl") || ""}

--- a/packages/front-end/components/GeneralSettings/MetricsSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/MetricsSettings.tsx
@@ -186,6 +186,7 @@ export default function MetricsSettings() {
               options={currencyOptions}
               onChange={(v: string) => form.setValue("displayCurrency", v)}
               required
+              markRequired
               placeholder="Select currency..."
               helpText="This should match what is stored in the data source and controls what currency symbol is displayed."
             />

--- a/packages/front-end/components/GeneralSettings/RampScheduleTemplates.tsx
+++ b/packages/front-end/components/GeneralSettings/RampScheduleTemplates.tsx
@@ -133,6 +133,7 @@ function EditModal({ template, onClose, onSave }: EditModalProps) {
           value={name}
           onChange={(e) => setName(e.target.value)}
           required
+          markRequired
         />
       </Box>
       <Box mb="5">


### PR DESCRIPTION
### Features and Changes

The General Settings forms signaled optionality inconsistently. Most fields are optional, yet only a handful carried an `(optional)` marker, in several different formats, and required fields were never indicated at all.

This flips the convention to the one that carries more signal on a page where optional is the default. We mark the rare required field and drop the `(optional)` markers everywhere.

- Add the required indicator (the existing `markRequired` red asterisk) to the two fields that are actually required. Display Currency and the ramp schedule Template name.
- Remove every `(optional)` marker. Five label suffixes (Default Data Source, Feature Key Example, Feature Key Regex Validator, and the two code-reference labels) plus two leading "Optional." helpText sentences in AI Settings.

No behavior changes beyond the labels. Both required fields already enforced `required`; this just makes it visible.

### Testing

Type-check passes. Verified each changed string in the running app across the Metrics & Data, Feature Settings, and AI Settings tabs, plus the ramp template modal.

### Screenshots

| Before | After |
|--------|--------|
| <img width="3024" height="1602" alt="before-01-display-currency" src="https://github.com/user-attachments/assets/c3c7910c-6eb8-4030-979e-b9fe2b06fe50" /> | <img width="3024" height="1602" alt="after-01-display-currency" src="https://github.com/user-attachments/assets/cb692e0a-6f58-456c-b0eb-f9a8b1ed7c86" /> |
| <img width="3024" height="1602" alt="before-02-default-datasource" src="https://github.com/user-attachments/assets/65b02a33-78d5-4a3e-b579-d8c13b5acc12" /> | <img width="3024" height="1602" alt="after-02-default-datasource" src="https://github.com/user-attachments/assets/7fb73516-543e-412c-94f3-c661ca725ee5" /> |
| <img width="3024" height="1602" alt="before-03-feature-key-fields" src="https://github.com/user-attachments/assets/6fe8f874-4ce6-4294-acd4-914dc04aa2b7" /> | <img width="3024" height="1602" alt="after-03-feature-key-fields" src="https://github.com/user-attachments/assets/c821a4fd-f038-4712-a422-712bb7f00ef4" /> |
| <img width="3024" height="1602" alt="before-04-coderefs" src="https://github.com/user-attachments/assets/3d8430cd-1297-467d-8125-1f10055f185b" /> | <img width="3024" height="1602" alt="after-04-coderefs" src="https://github.com/user-attachments/assets/131e2bb4-a90a-4336-825b-960b5c95f636" /> |
| <img width="3024" height="1602" alt="before-05-template-name" src="https://github.com/user-attachments/assets/6437191c-a0ec-4d18-ae6e-92ea2d8ee81a" /> | <img width="3024" height="1602" alt="after-05-template-name" src="https://github.com/user-attachments/assets/3d3db965-3d38-4593-a64d-8117b01fbf0b" /> |
| <img width="3024" height="1602" alt="before-06-ai-visual-editor" src="https://github.com/user-attachments/assets/920949c9-332b-4d56-8a04-4fcc8cafe50a" /> | <img width="3024" height="1602" alt="after-06-ai-visual-editor" src="https://github.com/user-attachments/assets/d203b680-5366-473a-afc1-aa93451e05d6" /> |
| <img width="3024" height="1602" alt="after-07-ai-prompt" src="https://github.com/user-attachments/assets/a431499c-c9c3-4a9a-8eed-025fcf8b6c67" /> | <img width="3024" height="1602" alt="before-07-ai-prompt" src="https://github.com/user-attachments/assets/ec912127-5185-47f5-ae22-8e245db7d4c9" /> |

