### PR TITLE
Build-time guard for stripped Python deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,15 +20,21 @@ RUN \
   && poetry build \
   && poetry export -f requirements.txt --output requirements.txt \
   && pip install --no-cache-dir -r requirements.txt \
-  && pip install --no-cache-dir dist/*.whl ddtrace==4.3.2 "cryptography>=48.0.1,<49"
-# cryptography version is specified above to override transitive dependency and fix vulnerability
+  && pip install --no-cache-dir dist/*.whl ddtrace==4.3.2
 
 # Strip poetry and its build-time-only footprint so non-runtime deps don't ship in the venv.
 # These are poetry's own dependencies, not gbstats' (`poetry install --without dev` above already
-# drops gbstats' dev group): poetry pulls in dulwich, keyring and jaraco.classes, and
-# setuptools/wheel are build tooling. Removing them also keeps their CVEs out of the image —
-# e.g. dulwich (CVE-2026-42305 / GHSA-897w-fcg9-f6xj).
-RUN pip uninstall -y poetry poetry-core poetry-plugin-export keyring jaraco.classes setuptools wheel dulwich
+# drops gbstats' dev group): poetry pulls in dulwich, keyring (and its credential-store backend
+# SecretStorage -> jeepney -> cryptography) and jaraco.classes, and setuptools/wheel are build
+# tooling. Removing them keeps their CVEs out of the image — e.g. dulwich (CVE-2026-42305 /
+# GHSA-897w-fcg9-f6xj) and cryptography, which gbstats has no runtime need for. cryptography
+# used to be version-pinned above to dodge its CVEs; uninstalling it ends that treadmill.
+RUN pip uninstall -y poetry poetry-core poetry-plugin-export keyring jaraco.classes setuptools wheel dulwich cryptography SecretStorage jeepney
+
+# Guard against dependency drift: gbstats must still import using only the runtime deps, and the
+# distributions stripped above must stay absent. Fails the build if a future dep change needs one
+# of them or pulls one back in. See the script for details.
+RUN python check_stripped_deps.py
 
 # Build the nodejs app
 FROM node:${NODE_MAJOR}-slim AS nodebuild

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,19 +22,14 @@ RUN \
   && pip install --no-cache-dir -r requirements.txt \
   && pip install --no-cache-dir dist/*.whl ddtrace==4.3.2
 
-# Strip poetry and its build-time-only footprint so non-runtime deps don't ship in the venv.
-# These are poetry's own dependencies, not gbstats' (`poetry install --without dev` above already
-# drops gbstats' dev group): poetry pulls in dulwich, keyring (and its credential-store backend
-# SecretStorage -> jeepney -> cryptography) and jaraco.classes, and setuptools/wheel are build
-# tooling. Removing them keeps their CVEs out of the image — e.g. dulwich (CVE-2026-42305 /
-# GHSA-897w-fcg9-f6xj) and cryptography, which gbstats has no runtime need for. cryptography
-# used to be version-pinned above to dodge its CVEs; uninstalling it ends that treadmill.
-# The package list is sourced from check_stripped_deps.STRIPPED so it can't drift from the guard.
+# Remove poetry's build-only footprint (poetry + its keyring/cryptography backend, setuptools,
+# wheel, etc.) from the runtime venv. None are gbstats runtime deps, so dropping them shrinks the
+# image and its vulnerability surface. The list lives in check_stripped_deps.STRIPPED so it stays
+# in sync with the guard below.
 RUN pip uninstall -y $(python -c "from check_stripped_deps import STRIPPED; print(*STRIPPED)")
 
-# Guard against dependency drift: gbstats must still import using only the runtime deps, and the
-# distributions stripped above must stay absent. Fails the build if a future dep change needs one
-# of them or pulls one back in. See the script for details.
+# Verify the strip held: gbstats still imports with only its runtime deps, and nothing pulled a
+# removed package back in. Fails the build otherwise.
 RUN python check_stripped_deps.py
 
 # Build the nodejs app

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN \
 # tooling. Removing them keeps their CVEs out of the image — e.g. dulwich (CVE-2026-42305 /
 # GHSA-897w-fcg9-f6xj) and cryptography, which gbstats has no runtime need for. cryptography
 # used to be version-pinned above to dodge its CVEs; uninstalling it ends that treadmill.
-RUN pip uninstall -y poetry poetry-core poetry-plugin-export keyring jaraco.classes setuptools wheel dulwich cryptography SecretStorage jeepney
+# The package list is sourced from check_stripped_deps.STRIPPED so it can't drift from the guard.
+RUN pip uninstall -y $(python -c "from check_stripped_deps import STRIPPED; print(*STRIPPED)")
 
 # Guard against dependency drift: gbstats must still import using only the runtime deps, and the
 # distributions stripped above must stay absent. Fails the build if a future dep change needs one

--- a/packages/stats/check_stripped_deps.py
+++ b/packages/stats/check_stripped_deps.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Build-time guard for the production Docker image (see ../../Dockerfile).
+
+The image deliberately ships gbstats with a minimal runtime venv: the dev group
+is never installed, and poetry's build-time footprint (poetry, keyring and its
+credential-store backend, setuptools, wheel, dulwich, ...) is stripped after the
+build. This script fails the build if either assumption stops holding:
+
+  1. Every gbstats submodule must still import using only the runtime deps. If a
+     future change makes gbstats depend on a stripped distribution, the import
+     fails here instead of breaking at runtime.
+  2. The stripped distributions must stay absent from the venv. If a dependency
+     change quietly pulls one back in, the build fails so the reintroduced
+     package and its CVE surface get re-evaluated rather than silently shipped.
+
+This is expected to fail in a normal dev environment, where the dev group and the
+poetry footprint are installed — it only passes against the stripped runtime venv.
+"""
+
+import importlib
+import importlib.metadata
+import pkgutil
+import sys
+
+import gbstats
+
+# Distributions stripped from the runtime image. Keep in sync with the
+# `pip uninstall` list in the Dockerfile. cryptography, SecretStorage and jeepney
+# are poetry's keyring footprint (poetry -> keyring -> SecretStorage ->
+# cryptography), not gbstats runtime deps.
+STRIPPED = [
+    "cryptography",
+    "SecretStorage",
+    "jeepney",
+    "poetry",
+    "poetry-core",
+    "poetry-plugin-export",
+    "keyring",
+    "jaraco.classes",
+    "setuptools",
+    "wheel",
+    "dulwich",
+]
+
+
+def is_installed(distribution: str) -> bool:
+    try:
+        importlib.metadata.distribution(distribution)
+        return True
+    except importlib.metadata.PackageNotFoundError:
+        return False
+
+
+def main() -> None:
+    for mod in pkgutil.walk_packages(gbstats.__path__, "gbstats."):
+        importlib.import_module(mod.name)
+
+    leaked = [dist for dist in STRIPPED if is_installed(dist)]
+    if leaked:
+        sys.exit(
+            f"ERROR: distribution(s) expected to be absent from the runtime venv: {leaked}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/stats/check_stripped_deps.py
+++ b/packages/stats/check_stripped_deps.py
@@ -22,12 +22,11 @@ import importlib.metadata
 import pkgutil
 import sys
 
-import gbstats
-
-# Distributions stripped from the runtime image. Keep in sync with the
-# `pip uninstall` list in the Dockerfile. cryptography, SecretStorage and jeepney
-# are poetry's keyring footprint (poetry -> keyring -> SecretStorage ->
-# cryptography), not gbstats runtime deps.
+# Distributions stripped from the runtime image — the single source of truth. The
+# Dockerfile's `pip uninstall` line generates its arguments from this list, and the
+# guard below asserts they ended up absent, so the two can't drift apart.
+# cryptography, SecretStorage and jeepney are poetry's keyring footprint
+# (poetry -> keyring -> SecretStorage -> cryptography), not gbstats runtime deps.
 STRIPPED = [
     "cryptography",
     "SecretStorage",
@@ -52,6 +51,8 @@ def is_installed(distribution: str) -> bool:
 
 
 def main() -> None:
+    import gbstats
+
     for mod in pkgutil.walk_packages(gbstats.__path__, "gbstats."):
         importlib.import_module(mod.name)
 


### PR DESCRIPTION
### Features and Changes

Follow-up to #6230, addressing @tzjames's review point that gbstats doesn't need `cryptography` (and his Slack ask to guard the modules we strip against future dependency drift).

`cryptography` is not a gbstats runtime dependency — it's absent from the runtime `poetry export` and `ddtrace` doesn't require it. It only lands in the pybuild venv as part of poetry's keyring backend: `poetry -> keyring -> SecretStorage -> cryptography`. Every vuln sweep so far has version-pinned it in the explicit `pip install` to dodge its latest CVE; since we already strip poetry's build-time footprint after the build, the cleaner fix is to uninstall it outright and end the pin treadmill.

- **Drop the `cryptography` pin** from the `pip install` line and add `cryptography`, `SecretStorage`, `jeepney` to the post-build `pip uninstall` (`keyring` was already stripped), so the whole keyring credential-store chain leaves the runtime venv.
- **Add `packages/stats/check_stripped_deps.py`**, run in the pybuild stage. It imports every `gbstats` submodule (fails the build if a future change makes gbstats depend on a stripped package) and asserts the stripped distributions are absent (fails if a dependency change quietly pulls one back in, CVE surface included). Keyed off `importlib.metadata` so leftover namespace dirs don't trip it. The `STRIPPED` list is the single source of truth — the Dockerfile's `pip uninstall` generates its args from it, so the strip and the guard can't drift apart.

Note: dropping the pin alone is **not** sufficient — pip still resolves `cryptography` in via `SecretStorage` and it stays orphaned in the venv after the strip, so it has to be explicitly uninstalled. The new guard caught exactly this during testing.

### Testing

Built the `pybuild` target locally (the final stage needs `docker login dhi.io`, but every changed line is in `pybuild`) and verified in the resulting venv:

- [x] The keyring/cryptography chain (`cryptography`, `SecretStorage`, `jeepney`, `keyring`, `poetry*`, `setuptools`, `wheel`, `dulwich`) is gone — `pip list` shows none of them
- [x] `gbstats` imports cleanly, including a real submodule
- [x] `ddtrace==4.3.2` is still present
- [x] The guard `RUN` exits 0

