### PR TITLE
Skip inlining cloneDeep on saved-group-references-off refresh path

### DIFF
--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -1167,6 +1167,10 @@ export async function buildSDKPayloadForConnection(
     projectsMap = new Map(allProjects.map((p) => [p.id, p]));
   }
 
+  // Expands $inGroup -> $in whenever resolvedSavedGroupReferencesEnabled is
+  // false. getFeatureDefinitionsResponse relies on this via
+  // featuresHaveInlinedSavedGroups below; keep the two in lockstep if this
+  // expansion condition ever changes.
   const featureDefinitions = generateFeaturesPayload({
     features: filteredFeatures,
     environment,
@@ -1256,6 +1260,8 @@ export async function buildSDKPayloadForConnection(
     capabilities,
     usedSavedGroups,
     savedGroupReferencesEnabled: resolvedSavedGroupReferencesEnabled,
+    // generateFeaturesPayload above already expanded $inGroup when references
+    // are off, so the inlining pass downstream would be a redundant no-op.
     featuresHaveInlinedSavedGroups: !resolvedSavedGroupReferencesEnabled,
     organization: context.org,
   });

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -850,6 +850,9 @@ export type FeatureDefinitionsResponseArgs = {
   capabilities: SDKCapability[];
   usedSavedGroups: SavedGroupInterface[];
   savedGroupReferencesEnabled?: boolean;
+  // True when the caller already inlined saved groups into the feature payload
+  // (e.g. generateFeaturesPayload), making the inlining pass below a no-op.
+  featuresHaveInlinedSavedGroups?: boolean;
   organization: OrganizationInterface;
 };
 export async function getFeatureDefinitionsResponse({
@@ -864,6 +867,7 @@ export async function getFeatureDefinitionsResponse({
   capabilities,
   usedSavedGroups,
   savedGroupReferencesEnabled,
+  featuresHaveInlinedSavedGroups,
   organization,
 }: FeatureDefinitionsResponseArgs): Promise<{
   features: Record<string, FeatureDefinition>;
@@ -875,6 +879,7 @@ export async function getFeatureDefinitionsResponse({
   encryptedSavedGroups?: string;
 }> {
   const needsSavedGroupInlining =
+    !featuresHaveInlinedSavedGroups &&
     (!capabilities.includes("savedGroupReferences") ||
       !savedGroupReferencesEnabled) &&
     (usedSavedGroups?.length ?? 0) > 0 &&
@@ -964,7 +969,9 @@ export async function getFeatureDefinitionsResponse({
   if (!encryptPayload || !encryptionKey) {
     return {
       features: processedFeatures,
-      ...(experiments !== undefined && { experiments: processedExperiments }),
+      ...(processedExperiments !== undefined && {
+        experiments: processedExperiments,
+      }),
       dateUpdated,
       savedGroups: savedGroupsForPayload,
     };
@@ -985,7 +992,7 @@ export async function getFeatureDefinitionsResponse({
 
   return {
     features: {},
-    ...(experiments !== undefined && { experiments: [] }),
+    ...(processedExperiments !== undefined && { experiments: [] }),
     dateUpdated,
     encryptedFeatures,
     ...(encryptedExperiments !== undefined && { encryptedExperiments }),
@@ -1108,6 +1115,12 @@ export async function buildSDKPayloadForConnection(
     };
   }
 
+  // Single source of truth: drives both generateFeaturesPayload's saved-group
+  // expansion and the featuresHaveInlinedSavedGroups flag passed downstream.
+  const resolvedSavedGroupReferencesEnabled =
+    !!savedGroupReferencesEnabled &&
+    capabilities.includes("savedGroupReferences");
+
   const projectList = projects && projects.length > 0 ? projects : [];
   const filteredFeatures =
     projectList.length > 0
@@ -1163,9 +1176,7 @@ export async function buildSDKPayloadForConnection(
     safeRolloutMap: data.safeRolloutMap,
     holdoutsMap: holdoutsMapForConnection,
     capabilities,
-    savedGroupReferencesEnabled:
-      !!savedGroupReferencesEnabled &&
-      capabilities.includes("savedGroupReferences"),
+    savedGroupReferencesEnabled: resolvedSavedGroupReferencesEnabled,
     organization: context.org,
     savedGroupsMap,
     includeRuleIds,
@@ -1193,9 +1204,7 @@ export async function buildSDKPayloadForConnection(
     environment,
     prereqStateCache,
     capabilities,
-    savedGroupReferencesEnabled:
-      !!savedGroupReferencesEnabled &&
-      capabilities.includes("savedGroupReferences"),
+    savedGroupReferencesEnabled: resolvedSavedGroupReferencesEnabled,
     organization: context.org,
     savedGroupsMap,
     includeExperimentNames,
@@ -1246,9 +1255,8 @@ export async function buildSDKPayloadForConnection(
     secureAttributeSalt,
     capabilities,
     usedSavedGroups,
-    savedGroupReferencesEnabled:
-      !!savedGroupReferencesEnabled &&
-      capabilities.includes("savedGroupReferences"),
+    savedGroupReferencesEnabled: resolvedSavedGroupReferencesEnabled,
+    featuresHaveInlinedSavedGroups: !resolvedSavedGroupReferencesEnabled,
     organization: context.org,
   });
 }

--- a/packages/back-end/test/services/sdk-payload-generation.test.ts
+++ b/packages/back-end/test/services/sdk-payload-generation.test.ts
@@ -467,6 +467,60 @@ describe("SDK payload generation (exhaustive connection matrix)", () => {
   );
 });
 
+describe("SDK payload generation (shared rawData mutation safety)", () => {
+  // refreshSDKPayloadCache builds many connections from one shared rawData
+  // (run concurrently). The non-hashing fast path returns payload objects
+  // without cloning, so a connection that hashes secure attributes must not
+  // mutate the shared saved groups and corrupt a sibling connection.
+  function hashingContext() {
+    return minimalContext({
+      settings: {
+        secureAttributeSalt: "salt",
+        attributeSchema: [
+          { property: "x", datatype: "secureString", hashAttribute: true },
+        ],
+      },
+    });
+  }
+
+  const referencesConnection = (
+    hashSecureAttributes: boolean,
+  ): ConnectionPayloadOptions => ({
+    capabilities: ["savedGroupReferences", "bucketingV2"],
+    environment: "production",
+    projects: [],
+    savedGroupReferencesEnabled: true,
+    hashSecureAttributes,
+  });
+
+  it("hashing one connection does not mutate saved groups shared with siblings", async () => {
+    const ctx = hashingContext();
+    const data = basicMatrixData();
+    const originalValues = cloneDeep(data.savedGroups[0].values);
+
+    const hashingOut = await buildSDKPayloadForConnection({
+      context: ctx,
+      connection: referencesConnection(true),
+      data,
+    });
+
+    // Sanity: the hashing pass actually ran (otherwise this proves nothing).
+    expect(hashingOut.savedGroups?.sg1).toBeDefined();
+    expect(hashingOut.savedGroups?.sg1).not.toEqual(originalValues);
+
+    // The shared rawData must be untouched by the hashing pass.
+    expect(data.savedGroups[0].values).toEqual(originalValues);
+
+    // A sibling connection over the same rawData sees clean, unhashed values.
+    const plainOut = await buildSDKPayloadForConnection({
+      context: ctx,
+      connection: referencesConnection(false),
+      data,
+    });
+    expect(plainOut.savedGroups?.sg1).toEqual(originalValues);
+  });
+});
+
 describe("SDK payload generation (scenario-specific)", () => {
   it("holdout definitions merged when prerequisites capability", async () => {
     const ctx = minimalContext();


### PR DESCRIPTION
### Features and Changes

Builds on this branch's `cloneDeep` avoidance in `getFeatureDefinitionsResponse`. The current diff still takes a full-payload `cloneDeep` (plus a `recursiveWalk`) whenever `needsSavedGroupInlining` is true — but on the `buildSDKPayloadForConnection` path that inlining is already done upstream by `generateFeaturesPayload`, so the walk is a no-op and the clone is wasted. This covers the "saved group references off" connections the original PR description names but didn't actually optimize.

- **Skip the redundant inlining clone.** `buildSDKPayloadForConnection` hoists the resolved `savedGroupReferencesEnabled` into one local that drives *both* `generateFeaturesPayload`'s expansion and a new `featuresHaveInlinedSavedGroups` flag passed to `getFeatureDefinitionsResponse`. When features arrive already inlined, the downstream inlining pass and its `cloneDeep` are skipped. Net: on the refresh path, the features clone now fires only when secure-attribute hashing runs. Direct callers (e.g. tests) don't pass the flag, so their inlining behavior is unchanged.
- **Tie the two expansion conditions to one variable.** The upstream (`shouldExpandSavedGroups`) and downstream (`needsSavedGroupInlining`) checks weren't textually identical — they even handled `undefined` differently (`=== false` vs `!x`) — and only agreed because both were fed a pre-resolved boolean computed inline three times. Hoisting it removes that divergence structurally.
- **Consistency.** The experiments return spreads now key off `processedExperiments` to match the hashing block.
- **Mutation-safety test.** Added a test that builds a hashing connection and a non-hashing connection from one shared `rawData` (mirroring `refreshSDKPayloadCache`) and asserts they don't corrupt each other's saved groups. This guards the `clone -> cloneDeep` change in `applySavedGroupHashing`, which is the one load-bearing protection now that the upfront clones are gone — verified it fails against a shallow saved-group clone.

Note: `featuresHaveInlinedSavedGroups` still encodes the assumption that `generateFeaturesPayload` inlines exactly when references are off. Making that fully structural would mean changing the generator's return shape — heavier than this optimization warrants.

### Testing

- [x] `pnpm --filter back-end test sdk-payload-generation.test.ts features.test.ts` — 131 pass
- [x] `pnpm --filter back-end type-check` clean (pre-existing `sharp` errors only)
- [x] New mutation-safety test fails against a shallow `applySavedGroupHashing` clone, passes with `cloneDeep`
