### PR TITLE
Fixes null error for dashboards

### DIFF
--- a/packages/back-end/src/enterprise/services/dashboards.ts
+++ b/packages/back-end/src/enterprise/services/dashboards.ts
@@ -428,8 +428,12 @@ export async function updateDashboardExplorations(
       }
       block.explorerAnalysisId = primaryResult.value.id;
       if (comparisonResult.status === "fulfilled") {
-        // Clear a stale comparison id when comparison is off (null result).
-        block.comparisonExplorerAnalysisId = comparisonResult.value?.id;
+        if (comparisonResult.value) {
+          block.comparisonExplorerAnalysisId = comparisonResult.value.id;
+        } else {
+          // Clear a stale comparison id when comparison is off.
+          delete block.comparisonExplorerAnalysisId;
+        }
       } else {
         // Keep the previous comparison id so the primary still refreshes.
         logger.warn(

--- a/packages/shared/src/enterprise/validators/dashboard-block.ts
+++ b/packages/shared/src/enterprise/validators/dashboard-block.ts
@@ -330,7 +330,10 @@ const metricExplorerBlockInterface = baseBlockInterface
     // previous window is derived from the current one on each refresh. The id of
     // that derived analysis is tracked here so it can be fetched and rendered.
     comparison: blockComparisonValidator.optional(),
-    comparisonMetricAnalysisId: z.string().optional(),
+    comparisonMetricAnalysisId: z.preprocess(
+      (value) => (value === null ? undefined : value),
+      z.string().optional(),
+    ),
   })
   .strict();
 

--- a/packages/shared/src/enterprise/validators/dashboard-block.ts
+++ b/packages/shared/src/enterprise/validators/dashboard-block.ts
@@ -348,7 +348,10 @@ export type MetricExplorerBlockInterface = z.infer<
 const explorationBlockCommon = {
   explorerAnalysisId: z.string(),
   comparison: blockComparisonValidator.optional(),
-  comparisonExplorerAnalysisId: z.string().optional(),
+  comparisonExplorerAnalysisId: z.preprocess(
+    (value) => (value === null ? undefined : value),
+    z.string().optional(),
+  ),
 };
 
 const metricExplorationBlockInterface = baseBlockInterface.extend({


### PR DESCRIPTION
### Features and Changes

Fix dashboard validation for legacy product analytics exploration blocks that stored `comparisonExplorerAnalysisId` as `null`.

- Normalize legacy `comparisonExplorerAnalysisId: null` values to `undefined` during dashboard block validation, preserving the canonical `string | undefined` model.
- Clear stale comparison analysis ids by deleting `comparisonExplorerAnalysisId` when comparison is disabled, preventing future refreshes from writing null-ish optional values.
- Restores editing and duplicating older dashboards created before comparison support was added.

- Closes **(add link to issue here)**

### Dependencies

None.

### Testing

- [x] Verified an affected legacy dashboard can be edited without Zod validation errors.
- [x] Verified an affected legacy dashboard can be duplicated without Zod validation errors.
- [x] Checked touched files for IDE diagnostics; no linter errors reported.

### Screenshots

N/A