### PR TITLE
Support enum-constrained list attributes and in-place data-type migration

### DIFF
--- a/docs/docs/features/targeting.mdx
+++ b/docs/docs/features/targeting.mdx
@@ -67,13 +67,11 @@ GrowthBook supports the following attribute data types:
 | **Array of Numbers**        | List of numeric values                                 | `[1, 2, 3, 5, 8]`                  |
 | **Array of Secure Strings** | Multiple hashed string values for secure targeting     | `["user123", "user456"]`           |
 
-#### Constrained Lists ("EnumList")
+#### Constrained List Attributes
 
-Array attributes (**Array of Strings**, **Array of Numbers**, **Array of Secure Strings**) can optionally be restricted to a fixed set of allowed values. When creating or editing an array attribute under **SDK Configurations → Attributes**, fill in the **Allowed Values** field with a comma-separated list.
+Array attributes (**Array of Strings**, **Array of Numbers**, **Array of Secure Strings**) can optionally be restricted to a fixed set of allowed values. When creating or editing an array attribute under **SDK Configurations → Attributes**, fill in the **Allowed Values** field with a comma-separated list — a user can still hold multiple values at once (e.g. `["admin", "editor"]`), but each must be one of the allowed values.
 
-Once restricted, targeting conditions on that attribute use a typeahead multi-select that only accepts the allowed values (no free-form entry), and offer the `includes any of` / `includes none of` operators. Leave **Allowed Values** blank to keep the list unrestricted.
-
-This combines a list-valued attribute (a user can carry multiple values at once, e.g. `["admin", "editor"]`) with enum-style validation — the "EnumList" pattern.
+Once restricted, targeting conditions on that attribute use a typeahead multi-select that only accepts the allowed values (no free-form entry) and offer the `includes any of` / `includes none of` operators. Leave **Allowed Values** blank to keep the list unrestricted.
 
 #### Changing an Attribute's Data Type
 

--- a/docs/docs/features/targeting.mdx
+++ b/docs/docs/features/targeting.mdx
@@ -67,6 +67,20 @@ GrowthBook supports the following attribute data types:
 | **Array of Numbers**        | List of numeric values                                 | `[1, 2, 3, 5, 8]`                  |
 | **Array of Secure Strings** | Multiple hashed string values for secure targeting     | `["user123", "user456"]`           |
 
+#### Constrained Lists ("EnumList")
+
+Array attributes (**Array of Strings**, **Array of Numbers**, **Array of Secure Strings**) can optionally be restricted to a fixed set of allowed values. When creating or editing an array attribute under **SDK Configurations → Attributes**, fill in the **Allowed Values** field with a comma-separated list.
+
+Once restricted, targeting conditions on that attribute use a typeahead multi-select that only accepts the allowed values (no free-form entry), and offer the `includes any of` / `includes none of` operators. Leave **Allowed Values** blank to keep the list unrestricted.
+
+This combines a list-valued attribute (a user can carry multiple values at once, e.g. `["admin", "editor"]`) with enum-style validation — the "EnumList" pattern.
+
+#### Changing an Attribute's Data Type
+
+You can change an attribute's data type in place (including String → Enum) by editing it under **SDK Configurations → Attributes**. You do **not** need to create a new attribute or re-point features — the change is applied in place and existing targeting conditions keep evaluating, since values are stored as-is and the SDK does not enforce data types.
+
+When converting to a constrained type (Enum, or an array with Allowed Values), make sure the allowed values include every value already used in existing conditions. Conditions that reference an out-of-list value, or that use an operator no longer offered for the new type, keep running but become harder to edit. The edit modal lists the features, experiments, and condition groups that reference the attribute so you can audit them first.
+
 #### Semantic Version Targeting
 
 GrowthBook supports semantic version string comparisons, so that `1.0.10` is correctly treated as greater than `1.0.9`.

--- a/packages/front-end/components/Features/AttributeModal.tsx
+++ b/packages/front-end/components/Features/AttributeModal.tsx
@@ -89,13 +89,16 @@ export default function AttributeModal({ close, attribute }: Props) {
     "secureString",
   ];
 
-  // Converting an in-use attribute to a constrained type restricts how existing
-  // conditions can be edited, so surface where it's referenced as a heads-up.
-  const constrainingDatatypeChange =
-    datatypeChanged &&
-    (datatype === "enum" || (isArrayDatatype && !!form.watch("enum")));
+  // Constraining an in-use attribute (converting to enum/enum-list, or tightening
+  // its allowed values) restricts how existing conditions can be edited, so surface
+  // where it's referenced as a heads-up. Fires on both datatype and enum-value edits.
+  const isConstrainedType =
+    datatype === "enum" || (isArrayDatatype && !!form.watch("enum"));
+  const enumChanged = (form.watch("enum") || "") !== (current?.enum || "");
+  const constrainingChange =
+    !!attribute && isConstrainedType && (datatypeChanged || enumChanged);
   const { references } = useAttributeReferences(
-    constrainingDatatypeChange && attribute ? [attribute] : [],
+    constrainingChange && attribute ? [attribute] : [],
   );
   const refs = attribute ? references?.[attribute] : undefined;
   const refCount = refs
@@ -389,7 +392,7 @@ export default function AttributeModal({ close, attribute }: Props) {
           }
         />
       )}
-      {constrainingDatatypeChange ? (
+      {constrainingChange ? (
         <>
           <Callout status="warning" mt="2" mb="2">
             This change is applied in place — no new attribute is created and

--- a/packages/front-end/components/Features/AttributeModal.tsx
+++ b/packages/front-end/components/Features/AttributeModal.tsx
@@ -6,7 +6,9 @@ import {
 } from "shared/types/organization";
 import { FaExclamationCircle, FaInfoCircle } from "react-icons/fa";
 import React from "react";
+import { Box } from "@radix-ui/themes";
 import { useAttributeSchema } from "@/services/features";
+import { useAttributeReferences } from "@/hooks/useAttributeReferences";
 import { useAuth } from "@/services/auth";
 import Modal from "@/components/Modal";
 import Field from "@/components/Forms/Field";
@@ -21,6 +23,7 @@ import useProjectOptions from "@/hooks/useProjectOptions";
 import Callout from "@/ui/Callout";
 import Checkbox from "@/ui/Checkbox";
 import MarkdownInput from "@/components/Markdown/MarkdownInput";
+import AttributeReferencesList from "./AttributeReferencesList";
 import SDKCapabilityWarning from "./SDKCapabilityWarning";
 import TagsField from "./FeatureModal/TagsField";
 
@@ -76,11 +79,28 @@ export default function AttributeModal({ close, attribute }: Props) {
   const propertyChanged = !!attribute && form.watch("property") !== attribute;
   const datatypeChanged = !!attribute && datatype !== current?.datatype;
 
+  const isArrayDatatype = datatype.endsWith("[]");
+  // Enum options constrain both scalar enums and list ("EnumList") attributes.
+  const supportsEnumOptions = datatype === "enum" || isArrayDatatype;
+
   const hashAttributeDataTypes: SDKAttributeType[] = [
     "string",
     "number",
     "secureString",
   ];
+
+  // Converting an in-use attribute to a constrained type restricts how existing
+  // conditions can be edited, so surface where it's referenced as a heads-up.
+  const constrainingDatatypeChange =
+    datatypeChanged &&
+    (datatype === "enum" || (isArrayDatatype && !!form.watch("enum")));
+  const { references } = useAttributeReferences(
+    constrainingDatatypeChange && attribute ? [attribute] : [],
+  );
+  const refs = attribute ? references?.[attribute] : undefined;
+  const refCount = refs
+    ? refs.features.length + refs.experiments.length + refs.savedGroups.length
+    : 0;
 
   const permissionRequired = (project: string) => {
     return attribute
@@ -132,7 +152,8 @@ export default function AttributeModal({ close, attribute }: Props) {
           value.format = "";
           value.disableEqualityConditions = false;
         }
-        if (value.datatype !== "enum") {
+        // Enum options are valid for scalar enums and list attributes; clear them otherwise.
+        if (value.datatype !== "enum" && !value.datatype.endsWith("[]")) {
           value.enum = "";
         }
         if (!hashAttributeDataTypes.includes(value.datatype)) {
@@ -354,16 +375,41 @@ export default function AttributeModal({ close, attribute }: Props) {
           )}
         </>
       )}
-      {datatype === "enum" && (
+      {supportsEnumOptions && (
         <Field
-          label="Enum Options"
+          label={datatype === "enum" ? "Enum Options" : "Allowed Values"}
           textarea
           minRows={1}
-          required
+          required={datatype === "enum"}
           {...form.register(`enum`)}
-          helpText="Comma-separated list of all possible values"
+          helpText={
+            datatype === "enum"
+              ? "Comma-separated list of all possible values"
+              : "Optional. Restrict this list to a fixed set of values (comma-separated). Leave blank to allow any values."
+          }
         />
       )}
+      {constrainingDatatypeChange ? (
+        <>
+          <Callout status="warning" mt="2" mb="2">
+            This change is applied in place — no new attribute is created and
+            features are not updated automatically. Existing targeting
+            conditions keep evaluating. Make sure the values above include every
+            value already used in targeting; conditions using an out-of-list
+            value or a now-unavailable operator will keep running but become
+            hard to edit.
+          </Callout>
+          {refCount > 0 && refs ? (
+            <Box mb="3">
+              <AttributeReferencesList
+                features={refs.features}
+                experiments={refs.experiments}
+                conditionGroups={refs.savedGroups}
+              />
+            </Box>
+          ) : null}
+        </>
+      ) : null}
       {hashAttributeDataTypes.includes(datatype) && (
         <Checkbox
           label="Unique Identifier"

--- a/packages/front-end/components/Features/AttributeModal.tsx
+++ b/packages/front-end/components/Features/AttributeModal.tsx
@@ -395,12 +395,16 @@ export default function AttributeModal({ close, attribute }: Props) {
       {constrainingChange ? (
         <>
           <Callout status="warning" mt="2" mb="2">
-            This change is applied in place — no new attribute is created and
-            features are not updated automatically. Existing targeting
-            conditions keep evaluating. Make sure the values above include every
-            value already used in targeting; conditions using an out-of-list
-            value or a now-unavailable operator will keep running but become
-            hard to edit.
+            <strong>
+              Include every value already used in targeting before saving.
+            </strong>{" "}
+            Conditions referencing a value outside the list — or using an
+            operator no longer offered — keep running but become hard to edit.
+            <span style={{ display: "block", marginTop: "var(--space-2)" }}>
+              The change is applied in place: no new attribute is created,
+              existing conditions keep evaluating, and features are not updated
+              automatically.
+            </span>
           </Callout>
           {refCount > 0 && refs ? (
             <Box mb="3">

--- a/packages/front-end/components/Features/AttributeModal.tsx
+++ b/packages/front-end/components/Features/AttributeModal.tsx
@@ -80,7 +80,7 @@ export default function AttributeModal({ close, attribute }: Props) {
   const datatypeChanged = !!attribute && datatype !== current?.datatype;
 
   const isArrayDatatype = datatype.endsWith("[]");
-  // Enum options constrain both scalar enums and list ("EnumList") attributes.
+  // Enum options constrain both scalar enums and array (list) attributes.
   const supportsEnumOptions = datatype === "enum" || isArrayDatatype;
 
   const hashAttributeDataTypes: SDKAttributeType[] = [
@@ -89,7 +89,7 @@ export default function AttributeModal({ close, attribute }: Props) {
     "secureString",
   ];
 
-  // Constraining an in-use attribute (converting to enum/enum-list, or tightening
+  // Constraining an in-use attribute (converting to enum or a restricted list, or tightening
   // its allowed values) restricts how existing conditions can be edited, so surface
   // where it's referenced as a heads-up. Fires on both datatype and enum-value edits.
   const isConstrainedType =

--- a/packages/front-end/components/Features/ConditionInput.tsx
+++ b/packages/front-end/components/Features/ConditionInput.tsx
@@ -984,15 +984,28 @@ function ConditionAndGroupInput({
                 { label: "is NULL", value: "$notExists" },
               ]
             : attribute.array
-              ? [
-                  { label: "includes", value: "$includes" },
-                  { label: "does not include", value: "$notIncludes" },
-                  { label: "is empty", value: "$empty" },
-                  { label: "is not empty", value: "$notEmpty" },
-                  { label: "is not NULL", value: "$exists" },
-                  { label: "is NULL", value: "$notExists" },
-                ]
-              : attribute.enum?.length || 0 > 0
+              ? attribute.enum.length
+                ? [
+                    // Enum-constrained list: set operators drive the restricted
+                    // MultiSelect; the single-value ops keep older conditions editable.
+                    { label: "includes any of", value: "$in" },
+                    { label: "includes none of", value: "$nin" },
+                    { label: "includes", value: "$includes" },
+                    { label: "does not include", value: "$notIncludes" },
+                    { label: "is empty", value: "$empty" },
+                    { label: "is not empty", value: "$notEmpty" },
+                    { label: "is not NULL", value: "$exists" },
+                    { label: "is NULL", value: "$notExists" },
+                  ]
+                : [
+                    { label: "includes", value: "$includes" },
+                    { label: "does not include", value: "$notIncludes" },
+                    { label: "is empty", value: "$empty" },
+                    { label: "is not empty", value: "$notEmpty" },
+                    { label: "is not NULL", value: "$exists" },
+                    { label: "is NULL", value: "$notExists" },
+                  ]
+              : attribute.enum.length
                 ? [
                     { label: "is equal to", value: "$eq" },
                     { label: "is not equal to", value: "$ne" },

--- a/packages/front-end/components/Features/ConditionInput.tsx
+++ b/packages/front-end/components/Features/ConditionInput.tsx
@@ -987,11 +987,17 @@ function ConditionAndGroupInput({
               ? attribute.enum.length
                 ? [
                     // Enum-constrained list: set operators drive the restricted
-                    // MultiSelect; the single-value ops keep older conditions editable.
+                    // MultiSelect. Single-value ops are only offered to keep an
+                    // existing condition that already uses them editable — hidden
+                    // otherwise to avoid duplicate-looking options.
                     { label: "includes any of", value: "$in" },
                     { label: "includes none of", value: "$nin" },
-                    { label: "includes", value: "$includes" },
-                    { label: "does not include", value: "$notIncludes" },
+                    ...(["$includes", "$notIncludes"].includes(operator)
+                      ? [
+                          { label: "includes", value: "$includes" },
+                          { label: "does not include", value: "$notIncludes" },
+                        ]
+                      : []),
                     { label: "is empty", value: "$empty" },
                     { label: "is not empty", value: "$notEmpty" },
                     { label: "is not NULL", value: "$exists" },

--- a/packages/front-end/components/Features/ConditionInput.tsx
+++ b/packages/front-end/components/Features/ConditionInput.tsx
@@ -1135,6 +1135,9 @@ function ConditionAndGroupInput({
         } else if (attribute.enum === ALL_COUNTRY_CODES) {
           displayType = "isoCountryCode";
         } else if (attribute.enum.length) {
+          // Load-bearing: this must be checked before the array-field branch so
+          // enum-constrained lists get the restricted picker. Relies on
+          // useAttributeMap populating `enum` for `[]` datatypes.
           displayType = "enum";
         } else if (listOperators.includes(operator)) {
           displayType = "array-field";

--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -1508,7 +1508,8 @@ export function useAttributeMap(
         datatype: getAttributeDataType(schema.datatype),
         array: !!schema.datatype.match(/\[\]$/),
         enum:
-          schema.datatype === "enum" && schema.enum
+          (schema.datatype === "enum" || schema.datatype.endsWith("[]")) &&
+          schema.enum
             ? schema.enum.split(",").map((x) => x.trim())
             : schema.format === "isoCountryCode"
               ? ALL_COUNTRY_CODES
@@ -1638,7 +1639,8 @@ export function getDefaultOperator(attribute: AttributeData) {
   if (attribute.datatype === "boolean") {
     return "$true";
   } else if (attribute.array) {
-    return "$includes";
+    // Enum-constrained lists use set operators so the restricted MultiSelect shows.
+    return attribute.enum.length ? "$in" : "$includes";
   } else if (attribute.format === "version") {
     return "$veq";
   } else if (attribute.disableEqualityConditions) {

--- a/packages/front-end/test/features.test.ts
+++ b/packages/front-end/test/features.test.ts
@@ -1,5 +1,10 @@
 import stringify from "json-stringify-pretty-compact";
-import { AttributeData, condToJson, jsonToConds } from "@/services/features";
+import {
+  AttributeData,
+  condToJson,
+  getDefaultOperator,
+  jsonToConds,
+} from "@/services/features";
 
 describe("json <-> conds", () => {
   const attributeMap: Map<string, AttributeData> = new Map();
@@ -48,6 +53,22 @@ describe("json <-> conds", () => {
     datatype: "number",
     array: true,
     enum: [],
+    identifier: false,
+    archived: false,
+  });
+  attributeMap.set("str_arr_enum", {
+    attribute: "str_arr_enum",
+    datatype: "string",
+    array: true,
+    enum: ["a", "b", "c"],
+    identifier: false,
+    archived: false,
+  });
+  attributeMap.set("num_arr_enum", {
+    attribute: "num_arr_enum",
+    datatype: "number",
+    array: true,
+    enum: ["1", "2", "3"],
     identifier: false,
     archived: false,
   });
@@ -246,6 +267,26 @@ describe("json <-> conds", () => {
     expect(jsonToConds(json, attributeMap)).toEqual(conds);
     expect(condToJson(conds, attributeMap)).toEqual(json);
   });
+  it("str_arr_enum - $in", () => {
+    const json = stringify({ str_arr_enum: { $in: ["a", "b"] } });
+    const conds = [[{ field: "str_arr_enum", operator: "$in", value: "a, b" }]];
+    expect(jsonToConds(json, attributeMap)).toEqual(conds);
+    expect(condToJson(conds, attributeMap)).toEqual(json);
+  });
+  it("str_arr_enum - $nin", () => {
+    const json = stringify({ str_arr_enum: { $nin: ["a", "b"] } });
+    const conds = [
+      [{ field: "str_arr_enum", operator: "$nin", value: "a, b" }],
+    ];
+    expect(jsonToConds(json, attributeMap)).toEqual(conds);
+    expect(condToJson(conds, attributeMap)).toEqual(json);
+  });
+  it("num_arr_enum - $in coerces to numbers", () => {
+    const json = stringify({ num_arr_enum: { $in: [1, 2] } });
+    const conds = [[{ field: "num_arr_enum", operator: "$in", value: "1, 2" }]];
+    expect(jsonToConds(json, attributeMap)).toEqual(conds);
+    expect(condToJson(conds, attributeMap)).toEqual(json);
+  });
   it("$savedGroups $in", () => {
     const json = stringify({ $savedGroups: ["sg_1", "sg_2"] });
     const conds = [
@@ -374,4 +415,34 @@ describe("json <-> conds", () => {
     expect(jsonToConds(json, attributeMap)).toEqual(null);
   });
   */
+});
+
+describe("getDefaultOperator", () => {
+  const attr = (overrides: Partial<AttributeData>): AttributeData => ({
+    attribute: "a",
+    datatype: "string",
+    array: false,
+    enum: [],
+    identifier: false,
+    archived: false,
+    ...overrides,
+  });
+
+  it("returns $true for booleans", () => {
+    expect(getDefaultOperator(attr({ datatype: "boolean" }))).toBe("$true");
+  });
+  it("returns $includes for an unconstrained array", () => {
+    expect(getDefaultOperator(attr({ array: true }))).toBe("$includes");
+  });
+  it("returns $in for an enum-constrained array", () => {
+    expect(getDefaultOperator(attr({ array: true, enum: ["a", "b"] }))).toBe(
+      "$in",
+    );
+  });
+  it("returns $veq for version-formatted strings", () => {
+    expect(getDefaultOperator(attr({ format: "version" }))).toBe("$veq");
+  });
+  it("returns $eq for a plain string", () => {
+    expect(getDefaultOperator(attr({}))).toBe("$eq");
+  });
 });


### PR DESCRIPTION
### Features and Changes

Adds enum-constrained list attributes and makes attribute data-type changes safe to do in place. Both address a customer request: a list-valued attribute constrained to a fixed set of values, and a way to migrate a `string` attribute to an `enum` without creating a new attribute or re-pointing features.

- **Enum-constrained array attributes.** Array attributes (`string[]` / `number[]` / `secureString[]`) can now carry an optional **Allowed Values** list. The attribute stays list-valued (a user can hold multiple values at once) but its entries are validated against the allowed set. In the condition editor these attributes offer `includes any of` / `includes none of` (mapping to `$in` / `$nin`), which render the existing enum-restricted MultiSelect — typeahead, no free-form entry. The single-value `includes` / `does not include` operators are still offered when a pre-existing condition already uses them, so older conditions stay editable. Leave **Allowed Values** blank to keep the list unrestricted (existing behavior).
- **No SDK change required.** `mongrule.isIn` already intersects an array-valued attribute against a set, so `$in` / `$nin` mean "includes any of" / "includes none of" for lists out of the box. This is purely an org-settings-metadata + editor-UI change.
- **In-place data-type migration guardrails.** When editing an in-use attribute and constraining it (converting to `enum`, adding **Allowed Values** to an array, or tightening an existing allowed-values set), the modal now warns that the change is applied in place — no new attribute, no manual feature updates — and existing conditions keep evaluating. It reuses the existing `useAttributeReferences` hook + `AttributeReferencesList` to list the features, experiments, and condition groups referencing the attribute, so the allowed values can be checked against what's already in use.
- **Minor.** Fixed a latent operator-precedence bug in the enum operator branch (`attribute.enum?.length || 0 > 0`, which parsed as `enum?.length || false`).

Note: constraining an attribute does not rewrite existing conditions. Conditions referencing an out-of-list value, or using an operator no longer offered for the new type, keep running (the SDK does not enforce data types) but become harder to edit — hence the reference list in the modal.

### Testing

1. Under **SDK Configurations → Attributes**, create an **Array of Strings** attribute (e.g. `roles`) and set **Allowed Values** to `admin,editor,viewer`.
2. In a feature's targeting, select that attribute and confirm a new condition offers `includes any of` / `includes none of` and the value input is a MultiSelect restricted to the allowed values (rejects `foobar`).
3. Set an SDK user attribute to `["admin","viewer"]` and confirm an `includes any of [editor, viewer]` rule evaluates true.
4. Edit an existing `string` attribute that is used by at least one feature and switch it to `Enum`: confirm the warning callout appears and lists the referencing features, the change saves in place, and the prior condition still evaluates at runtime.


### Screenshots

<img width="996" height="1156" alt="image" src="https://github.com/user-attachments/assets/0d10683e-2704-462c-b04b-0f9b505986f1" />

<img width="996" height="1040" alt="image" src="https://github.com/user-attachments/assets/c5c13e93-2b33-40c5-8f1f-df3c29f3ff35" />
