### PR TITLE
Attempt adding disable event logging

### DIFF
--- a/docs/docs/lib/js.mdx
+++ b/docs/docs/lib/js.mdx
@@ -705,20 +705,20 @@ Note: If you evaluate the same feature multiple times (and the value doesn't cha
 
 Sometimes you want to read a feature's value without counting it as an exposure. A common example is evaluating features server-side to build a prefetch payload — the user hasn't actually been exposed to the feature yet, so you don't want to log a feature usage / exposure event at that point.
 
-The `isOn`, `isOff`, `getFeatureValue`, `evalFeature`, and `run` methods accept an optional trailing options argument with a `disableExposureLogging` flag:
+The `isOn`, `isOff`, `getFeatureValue`, `evalFeature`, and `run` methods accept an optional trailing options argument with a `disableTracking` flag:
 
 ```ts
 // Evaluate without firing any feature usage / exposure tracking
 const value = gb.getFeatureValue("button-color", "blue", {
-  disableExposureLogging: true,
+  disableTracking: true,
 });
 
 // Also works with the other evaluation methods
-gb.isOn("my-feature", { disableExposureLogging: true });
-gb.evalFeature("my-feature", { disableExposureLogging: true });
+gb.isOn("my-feature", { disableTracking: true });
+gb.evalFeature("my-feature", { disableTracking: true });
 ```
 
-When `disableExposureLogging` is `true`:
+When `disableTracking` is `true`:
 
 - The feature is still evaluated and its value returned normally.
 - No feature usage callback, experiment tracking callback, deferred tracking, or [Event Forwarder](/app/event-forwarder) event is fired for that call.

--- a/docs/docs/lib/js.mdx
+++ b/docs/docs/lib/js.mdx
@@ -701,14 +701,14 @@ The `result` argument is the same thing returned from `gb.evalFeature`.
 
 Note: If you evaluate the same feature multiple times (and the value doesn't change), the callback will only be fired the first time.
 
-### Disabling Exposure Logging
+### Disabling Tracking
 
-Sometimes you want to read a feature's value without counting it as an exposure. A common example is evaluating features server-side to build a prefetch payload — the user hasn't actually been exposed to the feature yet, so you don't want to log a feature usage / exposure event at that point.
+Sometimes you want to read a feature's value without tracking it as usage. A common example is evaluating features server-side to build a prefetch payload — the user hasn't actually been shown the feature yet, so you don't want to fire a feature usage event at that point.
 
 The `isOn`, `isOff`, `getFeatureValue`, `evalFeature`, and `run` methods accept an optional trailing options argument with a `disableTracking` flag:
 
 ```ts
-// Evaluate without firing any feature usage / exposure tracking
+// Evaluate without firing any tracking
 const value = gb.getFeatureValue("button-color", "blue", {
   disableTracking: true,
 });
@@ -722,9 +722,9 @@ When `disableTracking` is `true`:
 
 - The feature is still evaluated and its value returned normally.
 - No feature usage callback, experiment tracking callback, deferred tracking, or [Event Forwarder](/app/event-forwarder) event is fired for that call.
-- The internal de-dupe cache is left untouched, so a **later** evaluation of the same feature (without the flag) will still log the exposure.
+- The internal de-dupe cache is left untouched, so a **later** evaluation of the same feature (without the flag) will still track.
 
-This lets you separate "evaluate the value" from "count the exposure" — for example, evaluate with the flag during a server-side prefetch, then evaluate again (without the flag) on the client at the moment the user is actually exposed.
+This lets you separate "evaluate the value" from "track the usage" — for example, evaluate with the flag during a server-side prefetch, then evaluate again (without the flag) on the client at the moment the user is actually shown the feature.
 
 ### Dev Mode
 

--- a/docs/docs/lib/js.mdx
+++ b/docs/docs/lib/js.mdx
@@ -701,6 +701,31 @@ The `result` argument is the same thing returned from `gb.evalFeature`.
 
 Note: If you evaluate the same feature multiple times (and the value doesn't change), the callback will only be fired the first time.
 
+### Disabling Exposure Logging
+
+Sometimes you want to read a feature's value without counting it as an exposure. A common example is evaluating features server-side to build a prefetch payload — the user hasn't actually been exposed to the feature yet, so you don't want to log a feature usage / exposure event at that point.
+
+The `isOn`, `isOff`, `getFeatureValue`, `evalFeature`, and `run` methods accept an optional trailing options argument with a `disableExposureLogging` flag:
+
+```ts
+// Evaluate without firing any feature usage / exposure tracking
+const value = gb.getFeatureValue("button-color", "blue", {
+  disableExposureLogging: true,
+});
+
+// Also works with the other evaluation methods
+gb.isOn("my-feature", { disableExposureLogging: true });
+gb.evalFeature("my-feature", { disableExposureLogging: true });
+```
+
+When `disableExposureLogging` is `true`:
+
+- The feature is still evaluated and its value returned normally.
+- No feature usage callback, experiment tracking callback, deferred tracking, or [Event Forwarder](/app/event-forwarder) event is fired for that call.
+- The internal de-dupe cache is left untouched, so a **later** evaluation of the same feature (without the flag) will still log the exposure.
+
+This lets you separate "evaluate the value" from "count the exposure" — for example, evaluate with the flag during a server-side prefetch, then evaluate again (without the flag) on the client at the moment the user is actually exposed.
+
 ### Dev Mode
 
 There is a [GrowthBook Chrome DevTools Extension](https://chrome.google.com/webstore/detail/growthbook-devtools/opemhndcehfgipokneipaafbglcecjia) that can help you debug and test your feature flags in development.

--- a/packages/sdk-js/src/GrowthBook.ts
+++ b/packages/sdk-js/src/GrowthBook.ts
@@ -637,7 +637,7 @@ export class GrowthBook<
       global: this._getGlobalContext(),
       stack: {
         evaluatedFeatures: new Set(),
-        disableTracking: options?.disableExposureLogging,
+        disableTracking: options?.disableTracking,
       },
     };
   }

--- a/packages/sdk-js/src/GrowthBook.ts
+++ b/packages/sdk-js/src/GrowthBook.ts
@@ -20,6 +20,7 @@ import type {
   TrackingData,
   WidenPrimitives,
   EvalContext,
+  FeatureEvalOptions,
   InitOptions,
   InitResponse,
   InitSyncOptions,
@@ -599,8 +600,15 @@ export class GrowthBook<
     this._render();
   }
 
-  public run<T>(experiment: Experiment<T>): Result<T> {
-    const { result } = runExperiment(experiment, null, this._getEvalContext());
+  public run<T>(
+    experiment: Experiment<T>,
+    options?: FeatureEvalOptions,
+  ): Result<T> {
+    const { result } = runExperiment(
+      experiment,
+      null,
+      this._getEvalContext(options),
+    );
     this._onExperimentEval(experiment, result);
     return result;
   }
@@ -623,12 +631,13 @@ export class GrowthBook<
     this._updateAllAutoExperiments(true);
   }
 
-  private _getEvalContext(): EvalContext {
+  private _getEvalContext(options?: FeatureEvalOptions): EvalContext {
     return {
       user: this._getUserContext(),
       global: this._getGlobalContext(),
       stack: {
         evaluatedFeatures: new Set(),
+        disableTracking: options?.disableExposureLogging,
       },
     };
   }
@@ -873,19 +882,25 @@ export class GrowthBook<
     this._completedChangeIds.add(id);
   }
 
-  public isOn<K extends string & keyof AppFeatures = string>(key: K): boolean {
-    return this.evalFeature(key).on;
+  public isOn<K extends string & keyof AppFeatures = string>(
+    key: K,
+    options?: FeatureEvalOptions,
+  ): boolean {
+    return this.evalFeature(key, options).on;
   }
 
-  public isOff<K extends string & keyof AppFeatures = string>(key: K): boolean {
-    return this.evalFeature(key).off;
+  public isOff<K extends string & keyof AppFeatures = string>(
+    key: K,
+    options?: FeatureEvalOptions,
+  ): boolean {
+    return this.evalFeature(key, options).off;
   }
 
   public getFeatureValue<
     V extends AppFeatures[K],
     K extends string & keyof AppFeatures = string,
-  >(key: K, defaultValue: V): WidenPrimitives<V> {
-    const value = this.evalFeature<WidenPrimitives<V>, K>(key).value;
+  >(key: K, defaultValue: V, options?: FeatureEvalOptions): WidenPrimitives<V> {
+    const value = this.evalFeature<WidenPrimitives<V>, K>(key, options).value;
     return value === null ? (defaultValue as WidenPrimitives<V>) : value;
   }
 
@@ -897,15 +912,15 @@ export class GrowthBook<
   public feature<
     V extends AppFeatures[K],
     K extends string & keyof AppFeatures = string,
-  >(id: K): FeatureResult<V | null> {
-    return this.evalFeature(id);
+  >(id: K, options?: FeatureEvalOptions): FeatureResult<V | null> {
+    return this.evalFeature(id, options);
   }
 
   public evalFeature<
     V extends AppFeatures[K],
     K extends string & keyof AppFeatures = string,
-  >(id: K): FeatureResult<V | null> {
-    return _evalFeature(id, this._getEvalContext());
+  >(id: K, options?: FeatureEvalOptions): FeatureResult<V | null> {
+    return _evalFeature(id, this._getEvalContext(options));
   }
 
   log(msg: string, ctx: Record<string, unknown>) {

--- a/packages/sdk-js/src/GrowthBookClient.ts
+++ b/packages/sdk-js/src/GrowthBookClient.ts
@@ -6,6 +6,7 @@ import type {
   ClientOptions,
   DestroyOptions,
   EvalContext,
+  FeatureEvalOptions,
   EventLogger,
   EventProperties,
   Experiment,
@@ -250,16 +251,20 @@ export class GrowthBookClient<
   public runInlineExperiment<T>(
     experiment: Experiment<T>,
     userContext: UserContext,
+    options?: FeatureEvalOptions,
   ): Result<T> {
     const { result } = runExperiment(
       experiment,
       null,
-      this._getEvalContext(userContext),
+      this._getEvalContext(userContext, options),
     );
     return result;
   }
 
-  private _getEvalContext(userContext: UserContext): EvalContext {
+  private _getEvalContext(
+    userContext: UserContext,
+    options?: FeatureEvalOptions,
+  ): EvalContext {
     if (this._options.globalAttributes) {
       userContext = {
         ...userContext,
@@ -275,6 +280,7 @@ export class GrowthBookClient<
       global: this._getGlobalContext(),
       stack: {
         evaluatedFeatures: new Set(),
+        disableTracking: options?.disableExposureLogging,
       },
     };
   }
@@ -297,24 +303,32 @@ export class GrowthBookClient<
   public isOn<K extends string & keyof AppFeatures = string>(
     key: K,
     userContext: UserContext,
+    options?: FeatureEvalOptions,
   ): boolean {
-    return this.evalFeature(key, userContext).on;
+    return this.evalFeature(key, userContext, options).on;
   }
 
   public isOff<K extends string & keyof AppFeatures = string>(
     key: K,
     userContext: UserContext,
+    options?: FeatureEvalOptions,
   ): boolean {
-    return this.evalFeature(key, userContext).off;
+    return this.evalFeature(key, userContext, options).off;
   }
 
   public getFeatureValue<
     V extends AppFeatures[K],
     K extends string & keyof AppFeatures = string,
-  >(key: K, defaultValue: V, userContext: UserContext): WidenPrimitives<V> {
+  >(
+    key: K,
+    defaultValue: V,
+    userContext: UserContext,
+    options?: FeatureEvalOptions,
+  ): WidenPrimitives<V> {
     const value = this.evalFeature<WidenPrimitives<V>, K>(
       key,
       userContext,
+      options,
     ).value;
     return value === null ? (defaultValue as WidenPrimitives<V>) : value;
   }
@@ -322,8 +336,12 @@ export class GrowthBookClient<
   public evalFeature<
     V extends AppFeatures[K],
     K extends string & keyof AppFeatures = string,
-  >(id: K, userContext: UserContext): FeatureResult<V | null> {
-    return _evalFeature(id, this._getEvalContext(userContext));
+  >(
+    id: K,
+    userContext: UserContext,
+    options?: FeatureEvalOptions,
+  ): FeatureResult<V | null> {
+    return _evalFeature(id, this._getEvalContext(userContext, options));
   }
 
   log(msg: string, ctx: Record<string, unknown>) {
@@ -403,30 +421,44 @@ export class UserScopedGrowthBook<
     }
   }
 
-  public runInlineExperiment<T>(experiment: Experiment<T>): Result<T> {
-    return this._gb.runInlineExperiment(experiment, this._userContext);
+  public runInlineExperiment<T>(
+    experiment: Experiment<T>,
+    options?: FeatureEvalOptions,
+  ): Result<T> {
+    return this._gb.runInlineExperiment(experiment, this._userContext, options);
   }
 
-  public isOn<K extends string & keyof AppFeatures = string>(key: K): boolean {
-    return this._gb.isOn(key, this._userContext);
+  public isOn<K extends string & keyof AppFeatures = string>(
+    key: K,
+    options?: FeatureEvalOptions,
+  ): boolean {
+    return this._gb.isOn(key, this._userContext, options);
   }
 
-  public isOff<K extends string & keyof AppFeatures = string>(key: K): boolean {
-    return this._gb.isOff(key, this._userContext);
+  public isOff<K extends string & keyof AppFeatures = string>(
+    key: K,
+    options?: FeatureEvalOptions,
+  ): boolean {
+    return this._gb.isOff(key, this._userContext, options);
   }
 
   public getFeatureValue<
     V extends AppFeatures[K],
     K extends string & keyof AppFeatures = string,
-  >(key: K, defaultValue: V): WidenPrimitives<V> {
-    return this._gb.getFeatureValue(key, defaultValue, this._userContext);
+  >(key: K, defaultValue: V, options?: FeatureEvalOptions): WidenPrimitives<V> {
+    return this._gb.getFeatureValue(
+      key,
+      defaultValue,
+      this._userContext,
+      options,
+    );
   }
 
   public evalFeature<
     V extends AppFeatures[K],
     K extends string & keyof AppFeatures = string,
-  >(id: K): FeatureResult<V | null> {
-    return this._gb.evalFeature(id, this._userContext);
+  >(id: K, options?: FeatureEvalOptions): FeatureResult<V | null> {
+    return this._gb.evalFeature(id, this._userContext, options);
   }
 
   public logEvent(eventName: string, properties?: EventProperties) {

--- a/packages/sdk-js/src/GrowthBookClient.ts
+++ b/packages/sdk-js/src/GrowthBookClient.ts
@@ -280,7 +280,7 @@ export class GrowthBookClient<
       global: this._getGlobalContext(),
       stack: {
         evaluatedFeatures: new Set(),
-        disableTracking: options?.disableExposureLogging,
+        disableTracking: options?.disableTracking,
       },
     };
   }

--- a/packages/sdk-js/src/core.ts
+++ b/packages/sdk-js/src/core.ts
@@ -127,6 +127,11 @@ function onFeatureUsage(
   key: string,
   ret: FeatureResult<unknown>,
 ): void {
+  // Exposure logging disabled for this evaluation - skip all tracking.
+  // Return before the dedupe cache is written so a later evaluation (without
+  // the flag) will still log the exposure.
+  if (ctx.stack.disableTracking) return;
+
   // Only track a feature once, unless the assigned value changed
   if (ctx.user.trackedFeatureUsage) {
     const stringifiedValue = JSON.stringify(ret.value);
@@ -756,8 +761,16 @@ export function runExperiment<T>(
 
   // 14. Fire the tracking callback(s)
   // Store the promise in case we're awaiting it (ex: browser url redirects)
-  const trackingCalls = onExperimentViewed(ctx, experiment, result);
-  if (trackingCalls.length === 0 && ctx.global.saveDeferredTrack) {
+  // Skip entirely (including deferred tracking) when exposure logging is
+  // disabled for this evaluation.
+  const trackingCalls = ctx.stack.disableTracking
+    ? []
+    : onExperimentViewed(ctx, experiment, result);
+  if (
+    !ctx.stack.disableTracking &&
+    trackingCalls.length === 0 &&
+    ctx.global.saveDeferredTrack
+  ) {
     ctx.global.saveDeferredTrack({
       experiment,
       result,

--- a/packages/sdk-js/src/core.ts
+++ b/packages/sdk-js/src/core.ts
@@ -127,9 +127,9 @@ function onFeatureUsage(
   key: string,
   ret: FeatureResult<unknown>,
 ): void {
-  // Exposure logging disabled for this evaluation - skip all tracking.
+  // Tracking disabled for this evaluation - skip all feature usage tracking.
   // Return before the dedupe cache is written so a later evaluation (without
-  // the flag) will still log the exposure.
+  // the flag) will still track.
   if (ctx.stack.disableTracking) return;
 
   // Only track a feature once, unless the assigned value changed
@@ -761,7 +761,7 @@ export function runExperiment<T>(
 
   // 14. Fire the tracking callback(s)
   // Store the promise in case we're awaiting it (ex: browser url redirects)
-  // Skip entirely (including deferred tracking) when exposure logging is
+  // Skip entirely (including deferred tracking) when tracking is
   // disabled for this evaluation.
   const trackingCalls = ctx.stack.disableTracking
     ? []

--- a/packages/sdk-js/src/index.ts
+++ b/packages/sdk-js/src/index.ts
@@ -57,6 +57,7 @@ export type {
   EventProperties,
   Plugin,
   LogUnion,
+  FeatureEvalOptions,
 } from "./types/growthbook";
 
 export type {

--- a/packages/sdk-js/src/types/growthbook.ts
+++ b/packages/sdk-js/src/types/growthbook.ts
@@ -372,12 +372,12 @@ export type EvalContext = {
 
 // Per-call options for feature/experiment evaluation methods
 export type FeatureEvalOptions = {
-  // If true, this evaluation will not log a feature usage / exposure event.
-  // Useful when you want to read a value without counting it as an exposure
-  // (e.g. server-side prefetch). The value is still evaluated and returned
-  // normally, and the dedupe cache is left untouched so a later evaluation
-  // (without this flag) will still log the exposure.
-  disableExposureLogging?: boolean;
+  // If true, this evaluation will not fire any tracking - neither feature usage
+  // tracking nor experiment tracking. Useful when you want to read a value
+  // without counting it as usage/exposure (e.g. server-side prefetch). The
+  // value is still evaluated and returned normally, and the dedupe cache is
+  // left untouched so a later evaluation (without this flag) will still track.
+  disableTracking?: boolean;
 };
 
 export type PrefetchOptions = Pick<

--- a/packages/sdk-js/src/types/growthbook.ts
+++ b/packages/sdk-js/src/types/growthbook.ts
@@ -358,12 +358,26 @@ export type UserContext = {
 export type StackContext = {
   id?: string;
   evaluatedFeatures: Set<string>;
+  // When true, evaluating features/experiments in this context will not fire
+  // any usage/exposure tracking (feature usage callbacks, experiment tracking
+  // callbacks, deferred tracking, or the event logger).
+  disableTracking?: boolean;
 };
 
 export type EvalContext = {
   global: GlobalContext;
   user: UserContext;
   stack: StackContext;
+};
+
+// Per-call options for feature/experiment evaluation methods
+export type FeatureEvalOptions = {
+  // If true, this evaluation will not log a feature usage / exposure event.
+  // Useful when you want to read a value without counting it as an exposure
+  // (e.g. server-side prefetch). The value is still evaluated and returned
+  // normally, and the dedupe cache is left untouched so a later evaluation
+  // (without this flag) will still log the exposure.
+  disableExposureLogging?: boolean;
 };
 
 export type PrefetchOptions = Pick<

--- a/packages/sdk-js/src/types/growthbook.ts
+++ b/packages/sdk-js/src/types/growthbook.ts
@@ -359,8 +359,8 @@ export type StackContext = {
   id?: string;
   evaluatedFeatures: Set<string>;
   // When true, evaluating features/experiments in this context will not fire
-  // any usage/exposure tracking (feature usage callbacks, experiment tracking
-  // callbacks, deferred tracking, or the event logger).
+  // any tracking (feature usage callbacks, experiment tracking callbacks,
+  // deferred tracking, or the event logger).
   disableTracking?: boolean;
 };
 
@@ -374,9 +374,9 @@ export type EvalContext = {
 export type FeatureEvalOptions = {
   // If true, this evaluation will not fire any tracking - neither feature usage
   // tracking nor experiment tracking. Useful when you want to read a value
-  // without counting it as usage/exposure (e.g. server-side prefetch). The
-  // value is still evaluated and returned normally, and the dedupe cache is
-  // left untouched so a later evaluation (without this flag) will still track.
+  // without counting it as usage (e.g. server-side prefetch). The value is
+  // still evaluated and returned normally, and the dedupe cache is left
+  // untouched so a later evaluation (without this flag) will still track.
   disableTracking?: boolean;
 };
 

--- a/packages/sdk-js/test/features.test.ts
+++ b/packages/sdk-js/test/features.test.ts
@@ -406,7 +406,7 @@ describe("features", () => {
     growthbook.destroy();
   });
 
-  it("does not pollute the dedupe cache when exposure logging is disabled", () => {
+  it("does not pollute the dedupe cache when tracking is disabled", () => {
     const context: Context = {
       attributes: { id: "1" },
       features: {

--- a/packages/sdk-js/test/features.test.ts
+++ b/packages/sdk-js/test/features.test.ts
@@ -373,7 +373,7 @@ describe("features", () => {
     growthbook.destroy();
   });
 
-  it("skips feature usage when disableExposureLogging is set", () => {
+  it("skips feature usage when disableTracking is set", () => {
     const context: Context = {
       attributes: { id: "1" },
       features: {
@@ -387,7 +387,7 @@ describe("features", () => {
 
     // Value is still evaluated and returned normally
     const res = growthbook.evalFeature("feature1", {
-      disableExposureLogging: true,
+      disableTracking: true,
     });
     expect(res.value).toEqual(0);
     // But no usage callback fired
@@ -396,11 +396,11 @@ describe("features", () => {
     // getFeatureValue / isOn / isOff also respect the flag
     expect(
       growthbook.getFeatureValue("feature1", 5, {
-        disableExposureLogging: true,
+        disableTracking: true,
       }),
     ).toEqual(0);
-    growthbook.isOn("feature1", { disableExposureLogging: true });
-    growthbook.isOff("feature1", { disableExposureLogging: true });
+    growthbook.isOn("feature1", { disableTracking: true });
+    growthbook.isOff("feature1", { disableTracking: true });
     expect(mock.calls.length).toEqual(0);
 
     growthbook.destroy();
@@ -419,7 +419,7 @@ describe("features", () => {
     const mock = mockCallback(context);
 
     // Suppressed evaluation does not record the feature as tracked
-    growthbook.evalFeature("feature1", { disableExposureLogging: true });
+    growthbook.evalFeature("feature1", { disableTracking: true });
     expect(mock.calls.length).toEqual(0);
 
     // A later normal evaluation still fires the usage callback

--- a/packages/sdk-js/test/features.test.ts
+++ b/packages/sdk-js/test/features.test.ts
@@ -373,6 +373,63 @@ describe("features", () => {
     growthbook.destroy();
   });
 
+  it("skips feature usage when disableExposureLogging is set", () => {
+    const context: Context = {
+      attributes: { id: "1" },
+      features: {
+        feature1: {
+          defaultValue: 0,
+        },
+      },
+    };
+    const growthbook = new GrowthBook(context);
+    const mock = mockCallback(context);
+
+    // Value is still evaluated and returned normally
+    const res = growthbook.evalFeature("feature1", {
+      disableExposureLogging: true,
+    });
+    expect(res.value).toEqual(0);
+    // But no usage callback fired
+    expect(mock.calls.length).toEqual(0);
+
+    // getFeatureValue / isOn / isOff also respect the flag
+    expect(
+      growthbook.getFeatureValue("feature1", 5, {
+        disableExposureLogging: true,
+      }),
+    ).toEqual(0);
+    growthbook.isOn("feature1", { disableExposureLogging: true });
+    growthbook.isOff("feature1", { disableExposureLogging: true });
+    expect(mock.calls.length).toEqual(0);
+
+    growthbook.destroy();
+  });
+
+  it("does not pollute the dedupe cache when exposure logging is disabled", () => {
+    const context: Context = {
+      attributes: { id: "1" },
+      features: {
+        feature1: {
+          defaultValue: 0,
+        },
+      },
+    };
+    const growthbook = new GrowthBook(context);
+    const mock = mockCallback(context);
+
+    // Suppressed evaluation does not record the feature as tracked
+    growthbook.evalFeature("feature1", { disableExposureLogging: true });
+    expect(mock.calls.length).toEqual(0);
+
+    // A later normal evaluation still fires the usage callback
+    const res = growthbook.evalFeature("feature1");
+    expect(mock.calls.length).toEqual(1);
+    expect(mock.calls[0]).toEqual(["feature1", res]);
+
+    growthbook.destroy();
+  });
+
   it("uses fallbacks get getFeatureValue", () => {
     const growthbook = new GrowthBook({
       features: {

--- a/packages/sdk-js/test/multi-user.test.ts
+++ b/packages/sdk-js/test/multi-user.test.ts
@@ -103,6 +103,42 @@ describe("GrowthBookClient", () => {
     gb.destroy();
   });
 
+  it("Skips feature usage callback when disableExposureLogging is set", () => {
+    const track = jest.fn();
+    const gb = new GrowthBookClient({
+      onFeatureUsage: track,
+    });
+
+    gb.initSync({
+      payload: {
+        features: {
+          feature: {
+            defaultValue: false,
+          },
+        },
+      },
+    });
+
+    const user: UserContext = {
+      attributes: {
+        id: "1",
+      },
+    };
+
+    // Value is still returned, but no exposure logged
+    const res = gb.evalFeature("feature", user, {
+      disableExposureLogging: true,
+    });
+    expect(res.value).toEqual(false);
+    expect(track).not.toHaveBeenCalled();
+
+    // A later normal evaluation still fires
+    gb.evalFeature("feature", user);
+    expect(track).toHaveBeenCalledTimes(1);
+
+    gb.destroy();
+  });
+
   it("Supports sticky buckets", async () => {
     const stickyBucketService = new LocalStorageStickyBucketService();
 

--- a/packages/sdk-js/test/multi-user.test.ts
+++ b/packages/sdk-js/test/multi-user.test.ts
@@ -125,7 +125,7 @@ describe("GrowthBookClient", () => {
       },
     };
 
-    // Value is still returned, but no exposure logged
+    // Value is still returned, but no tracking fired
     const res = gb.evalFeature("feature", user, {
       disableTracking: true,
     });

--- a/packages/sdk-js/test/multi-user.test.ts
+++ b/packages/sdk-js/test/multi-user.test.ts
@@ -103,7 +103,7 @@ describe("GrowthBookClient", () => {
     gb.destroy();
   });
 
-  it("Skips feature usage callback when disableExposureLogging is set", () => {
+  it("Skips feature usage callback when disableTracking is set", () => {
     const track = jest.fn();
     const gb = new GrowthBookClient({
       onFeatureUsage: track,
@@ -127,7 +127,7 @@ describe("GrowthBookClient", () => {
 
     // Value is still returned, but no exposure logged
     const res = gb.evalFeature("feature", user, {
-      disableExposureLogging: true,
+      disableTracking: true,
     });
     expect(res.value).toEqual(false);
     expect(track).not.toHaveBeenCalled();

--- a/packages/sdk-react/src/GrowthBookReact.tsx
+++ b/packages/sdk-react/src/GrowthBookReact.tsx
@@ -8,6 +8,7 @@ import type {
   FeatureDefinition,
   Context,
   WidenPrimitives,
+  FeatureEvalOptions,
 } from "@growthbook/growthbook";
 import { GrowthBook } from "@growthbook/growthbook";
 
@@ -70,24 +71,26 @@ export function useExperiment<T>(exp: Experiment<T>): Result<T> {
 
 export function useFeature<T extends JSONValue = any>(
   id: string,
+  options?: FeatureEvalOptions,
 ): FeatureResult<T | null> {
   const growthbook = useGrowthBook();
-  return growthbook.evalFeature<T>(id);
+  return growthbook.evalFeature<T>(id, options);
 }
 
 export function useFeatureIsOn<
   AppFeatures extends Record<string, any> = Record<string, any>,
->(id: string & keyof AppFeatures): boolean {
+>(id: string & keyof AppFeatures, options?: FeatureEvalOptions): boolean {
   const growthbook = useGrowthBook<AppFeatures>();
-  return growthbook.isOn(id);
+  return growthbook.isOn(id, options);
 }
 
 export function useFeatureValue<T extends JSONValue = any>(
   id: string,
   fallback: T,
+  options?: FeatureEvalOptions,
 ): WidenPrimitives<T> {
   const growthbook = useGrowthBook();
-  return growthbook.getFeatureValue(id, fallback);
+  return growthbook.getFeatureValue(id, fallback, options);
 }
 
 export function useGrowthBook<

--- a/packages/sdk-react/src/GrowthBookReact.tsx
+++ b/packages/sdk-react/src/GrowthBookReact.tsx
@@ -8,7 +8,6 @@ import type {
   FeatureDefinition,
   Context,
   WidenPrimitives,
-  FeatureEvalOptions,
 } from "@growthbook/growthbook";
 import { GrowthBook } from "@growthbook/growthbook";
 
@@ -71,26 +70,24 @@ export function useExperiment<T>(exp: Experiment<T>): Result<T> {
 
 export function useFeature<T extends JSONValue = any>(
   id: string,
-  options?: FeatureEvalOptions,
 ): FeatureResult<T | null> {
   const growthbook = useGrowthBook();
-  return growthbook.evalFeature<T>(id, options);
+  return growthbook.evalFeature<T>(id);
 }
 
 export function useFeatureIsOn<
   AppFeatures extends Record<string, any> = Record<string, any>,
->(id: string & keyof AppFeatures, options?: FeatureEvalOptions): boolean {
+>(id: string & keyof AppFeatures): boolean {
   const growthbook = useGrowthBook<AppFeatures>();
-  return growthbook.isOn(id, options);
+  return growthbook.isOn(id);
 }
 
 export function useFeatureValue<T extends JSONValue = any>(
   id: string,
   fallback: T,
-  options?: FeatureEvalOptions,
 ): WidenPrimitives<T> {
   const growthbook = useGrowthBook();
-  return growthbook.getFeatureValue(id, fallback, options);
+  return growthbook.getFeatureValue(id, fallback);
 }
 
 export function useGrowthBook<


### PR DESCRIPTION
### Features and Changes
Adds a per-call disableTracking option to the SDK's feature and experiment evaluation methods, giving developers a way to read a value without logging any usage/exposure event for that call. This is the GrowthBook equivalent of the "disable exposure logging" flag other platforms offer.

The main use case is server-side prefetching: when you evaluate features on the server to build a payload for the client, the user hasn't actually been exposed to the feature yet, so you don't want to count it as usage. You can suppress tracking during the prefetch and let the real exposure be logged later on the client.

When disableTracking: true is passed:

The feature/experiment is still evaluated and its value returned normally.
No feature usage callback, experiment tracking callback, deferred tracking, or Event Forwarder event is fired for that call.
The internal de-dupe cache is left untouched, so a later evaluation of the same feature (without the flag) will still log normally.
The option is accepted by isOn, isOff, getFeatureValue, feature, evalFeature, and run (plus runInlineExperiment) on both GrowthBook and GrowthBookClient, and by the useFeature, useFeatureIsOn, and useFeatureValue React hooks.
```
// Evaluate without counting an exposure (e.g. server-side prefetch)
const value = gb.getFeatureValue("button-color", "blue", {
  disableTracking: true,
});
```
```
gb.isOn("my-feature", { disableTracking: true });
gb.evalFeature("my-feature", { disableTracking: true });
```

### Dependencies
None

### Testing
Type-check and run the SDK test suite:
pnpm --filter @growthbook/growthbook type-check
pnpm --filter @growthbook/growthbook-react type-check
pnpm --filter @growthbook/growthbook test (679 tests, includes new coverage in features.test.ts and multi-user.test.ts)
New/updated test cases verify:
With disableTracking: true, the value is still returned but the feature usage callback / event logger does not fire.
The de-dupe cache is not polluted — a subsequent evaluation without the flag still fires tracking.
Applies to both the browser (GrowthBook) and multi-user server (GrowthBookClient) paths.
Manual check: attach the growthbookTrackingPlugin (or an onFeatureUsage callback), evaluate a feature with { disableTracking: true }, and confirm no Feature Evaluated event is sent to the ingestion endpoint; then evaluate again without the flag and confirm the event fires.