### PR TITLE
Add SDK React for disableTracking

### DIFF
--- a/packages/sdk-react/src/GrowthBookReact.tsx
+++ b/packages/sdk-react/src/GrowthBookReact.tsx
@@ -8,6 +8,7 @@ import type {
   FeatureDefinition,
   Context,
   WidenPrimitives,
+  FeatureEvalOptions,
 } from "@growthbook/growthbook";
 import { GrowthBook } from "@growthbook/growthbook";
 
@@ -70,24 +71,26 @@ export function useExperiment<T>(exp: Experiment<T>): Result<T> {
 
 export function useFeature<T extends JSONValue = any>(
   id: string,
+  options?: FeatureEvalOptions,
 ): FeatureResult<T | null> {
   const growthbook = useGrowthBook();
-  return growthbook.evalFeature<T>(id);
+  return growthbook.evalFeature<T>(id, options);
 }
 
 export function useFeatureIsOn<
   AppFeatures extends Record<string, any> = Record<string, any>,
->(id: string & keyof AppFeatures): boolean {
+>(id: string & keyof AppFeatures, options?: FeatureEvalOptions): boolean {
   const growthbook = useGrowthBook<AppFeatures>();
-  return growthbook.isOn(id);
+  return growthbook.isOn(id, options);
 }
 
 export function useFeatureValue<T extends JSONValue = any>(
   id: string,
   fallback: T,
+  options?: FeatureEvalOptions,
 ): WidenPrimitives<T> {
   const growthbook = useGrowthBook();
-  return growthbook.getFeatureValue(id, fallback);
+  return growthbook.getFeatureValue(id, fallback, options);
 }
 
 export function useGrowthBook<


### PR DESCRIPTION
### Dependencies

- **Depends on the sdk-js change** that adds the `disableTracking` option and exports `FeatureEvalOptions` ([branch `nh/Attempt-adding-disable-logging`](https://github.com/growthbook/growthbook/pull/6253/changes)). This PR's hooks import `FeatureEvalOptions` and pass the option through to `evalFeature` / `isOn` / `getFeatureValue`, so it will not type-check or build until those sdk-js changes are present and linked into `sdk-react`.
- By default `sdk-react` resolves `@growthbook/growthbook` to the **published** npm version (`^1.6.5`), which does not yet contain the new API. The workspace must be linked to the in-repo `sdk-js` (see below) so this PR builds against local source rather than the registry package.

### Linking Instructions

To make `sdk-react` build against the in-repo `sdk-js` instead of the published package:

1. **Point the dependency at the workspace package.** In `packages/sdk-react/package.json`, change:
   ```diff
   -    "@growthbook/growthbook": "^1.6.5"
   +    "@growthbook/growthbook": "workspace:^"
   ```
   `workspace:^` is rewritten to a normal semver range (`^<version>`) at publish time, so the published package is unaffected.

2. **Bring the sdk-js changes into this branch.** Rebase/stack this branch onto `nh/Attempt-adding-disable-logging` (or merge it in) so the workspace `sdk-js` actually contains `FeatureEvalOptions` + the new method signatures to link against.

3. **Regenerate the lockfile** so pnpm records the workspace link:
   ```bash
   pnpm install
   ```
   Confirm `packages/sdk-react` now resolves `@growthbook/growthbook` to a `link:` / workspace entry in `pnpm-lock.yaml` (not `version: 1.6.5` from the registry).

4. **Build sdk-js and verify types:**
   ```bash
   pnpm --filter @growthbook/growthbook build
   pnpm --filter @growthbook/growthbook-react type-check
   ```

**Note:** Because CI installs from the lockfile with a clean store, steps 1–3 (workspace-protocol dep + updated lockfile) are what make the type-check pass in CI — a local-only build/copy of `sdk-js/dist` is not sufficient.