### PR TITLE
Accept experiment phases array from GET endpoint in POST body

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -11539,6 +11539,11 @@ paths:
                     properties:
                       id:
                         type: string
+                      variationId:
+                        description: >-
+                          Alias for `id`. Mirrors the GET response. `id` takes
+                          precedence.
+                        type: string
                       key:
                         type: string
                       name:
@@ -11624,8 +11629,21 @@ paths:
                             - condition
                           additionalProperties: false
                       reason:
+                        description: >-
+                          Deprecated: use `reasonForStopping`. Takes precedence
+                          if set.
+                        deprecated: true
                         type: string
                       condition:
+                        description: >-
+                          Deprecated: use `targetingCondition`. Takes precedence
+                          if set.
+                        deprecated: true
+                        type: string
+                      targetingCondition:
+                        description: >-
+                          Targeting condition as a JSON string. Mirrors the GET
+                          response.
                         type: string
                       savedGroupTargeting:
                         type: array
@@ -11647,9 +11665,27 @@ paths:
                             - savedGroups
                           additionalProperties: false
                       variationWeights:
+                        description: >-
+                          Deprecated: use `trafficSplit`. Takes precedence if
+                          set.
+                        deprecated: true
                         type: array
                         items:
                           type: number
+                      trafficSplit:
+                        description: Per-variation weights. Mirrors the GET response.
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            variationId:
+                              type: string
+                            weight:
+                              type: number
+                          required:
+                            - variationId
+                            - weight
+                          additionalProperties: false
                     required:
                       - name
                       - dateStarted
@@ -12151,6 +12187,11 @@ paths:
                     properties:
                       id:
                         type: string
+                      variationId:
+                        description: >-
+                          Alias for `id`. Mirrors the GET response. `id` takes
+                          precedence.
+                        type: string
                       key:
                         type: string
                       name:
@@ -12230,8 +12271,21 @@ paths:
                             - condition
                           additionalProperties: false
                       reason:
+                        description: >-
+                          Deprecated: use `reasonForStopping`. Takes precedence
+                          if set.
+                        deprecated: true
                         type: string
                       condition:
+                        description: >-
+                          Deprecated: use `targetingCondition`. Takes precedence
+                          if set.
+                        deprecated: true
+                        type: string
+                      targetingCondition:
+                        description: >-
+                          Targeting condition as a JSON string. Mirrors the GET
+                          response.
                         type: string
                       savedGroupTargeting:
                         type: array
@@ -12253,9 +12307,27 @@ paths:
                             - savedGroups
                           additionalProperties: false
                       variationWeights:
+                        description: >-
+                          Deprecated: use `trafficSplit`. Takes precedence if
+                          set.
+                        deprecated: true
                         type: array
                         items:
                           type: number
+                      trafficSplit:
+                        description: Per-variation weights. Mirrors the GET response.
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            variationId:
+                              type: string
+                            weight:
+                              type: number
+                          required:
+                            - variationId
+                            - weight
+                          additionalProperties: false
                     required:
                       - name
                       - dateStarted

--- a/packages/back-end/src/api/experiments/updateExperiment.ts
+++ b/packages/back-end/src/api/experiments/updateExperiment.ts
@@ -206,6 +206,12 @@ export const updateExperiment = createApiRequestHandler(
   }
 
   if (req.body.variations) {
+    // Resolve the `variationId` response-field alias to `id` before validating,
+    // so echoing GET variations back doesn't regenerate ids (validateVariationIds
+    // assigns a fresh id to any variation missing one).
+    req.body.variations.forEach((v) => {
+      if (!v.id && v.variationId) v.id = v.variationId;
+    });
     validateVariationIds(req.body.variations as Variation[]);
   }
 

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2774,6 +2774,7 @@ export async function toExperimentApiInterface(
             const ranges = getNamespaceRanges(p.namespace);
             return {
               namespaceId: p.namespace.name,
+              enabled: p.namespace.enabled,
               range: ranges[0] ?? [0, 0],
               ranges,
             };
@@ -3908,6 +3909,27 @@ function toPhaseNamespaceValue(
 }
 
 /**
+ * Maps the GET-response `trafficSplit` shape ([{ variationId, weight }]) back
+ * to the internal `variationWeights` array, ordered to match `variationIds`.
+ * Each weight is resolved by `variationId` so a reordered/filtered trafficSplit
+ * is still assigned correctly, falling back to positional order when an id has
+ * no match (e.g. create, where variation ids are freshly generated). Returns
+ * undefined when no trafficSplit is provided so callers can fall through to
+ * their own default (e.g. an even split).
+ */
+function phaseWeightsFromTrafficSplit(
+  trafficSplit: { variationId: string; weight: number }[] | undefined,
+  variationIds: string[],
+): number[] | undefined {
+  if (!trafficSplit) return undefined;
+  return variationIds.map(
+    (id, i) =>
+      (trafficSplit.find((e) => e.variationId === id) ?? trafficSplit[i])
+        ?.weight ?? 0,
+  );
+}
+
+/**
  * Converts an API lookbackOverride payload to the internal representation.
  * Validates that "date" values are strings (not raw numbers) and that
  * "window" values are non-negative numbers with a valid unit.
@@ -3966,7 +3988,10 @@ export function postExperimentApiPayloadToInterface(
     variationIds.map((id) => ({ id, status: "active" as const }));
 
   const phases: ExperimentPhase[] = payload.phases?.map((p) => {
-    const conditionRes = validateCondition(p.condition);
+    // Accept the GET-response field names as aliases so a GET -> POST
+    // round-trip is lossless. The POST-only fields take precedence when set.
+    const condition = p.condition || p.targetingCondition || "{}";
+    const conditionRes = validateCondition(condition);
     if (!conditionRes.success) {
       throw new Error(`Invalid targeting condition: ${conditionRes.error}`);
     }
@@ -3983,9 +4008,9 @@ export function postExperimentApiPayloadToInterface(
       ...p,
       dateStarted: new Date(p.dateStarted),
       dateEnded: p.dateEnded ? new Date(p.dateEnded) : undefined,
-      reason: p.reason || "",
+      reason: p.reason || p.reasonForStopping || "",
       coverage: p.coverage != null ? p.coverage : 1,
-      condition: p.condition || "{}",
+      condition,
       prerequisites: p.prerequisites || [],
       savedGroups: (p.savedGroupTargeting || []).map((s) => ({
         match: s.matchType,
@@ -3997,6 +4022,7 @@ export function postExperimentApiPayloadToInterface(
       ),
       variationWeights:
         p.variationWeights ||
+        phaseWeightsFromTrafficSplit(p.trafficSplit, variationIds) ||
         payload.variations.map(() => 1 / payload.variations.length),
       variations: toPhaseVariations(variationIds),
     };
@@ -4219,7 +4245,10 @@ function resolveExperimentUpdateVariationsAndPhases(
 
   if (hasPhasePayload) {
     resolvedPhases = phases.map((p, phaseIndex) => {
-      const conditionRes = validateCondition(p.condition);
+      // Accept the GET-response field names as aliases so a GET -> POST
+      // round-trip is lossless. The POST-only fields take precedence when set.
+      const condition = p.condition || p.targetingCondition || "{}";
+      const conditionRes = validateCondition(condition);
       if (!conditionRes.success) {
         throw new Error(`Invalid targeting condition: ${conditionRes.error}`);
       }
@@ -4242,14 +4271,18 @@ function resolveExperimentUpdateVariationsAndPhases(
 
       const variationWeights =
         p.variationWeights ||
+        phaseWeightsFromTrafficSplit(
+          p.trafficSplit,
+          phaseVariations.map((v) => v.id),
+        ) ||
         phaseVariations.map((_) => 1 / phaseVariations.length);
       return {
         ...p,
         dateStarted: new Date(p.dateStarted),
         dateEnded: p.dateEnded ? new Date(p.dateEnded) : undefined,
-        reason: p.reason || "",
+        reason: p.reason || p.reasonForStopping || "",
         coverage: p.coverage != null ? p.coverage : 1,
-        condition: p.condition || "{}",
+        condition,
         prerequisites: p.prerequisites || [],
         savedGroups: (p.savedGroupTargeting || []).map((s) => ({
           match: s.matchType,

--- a/packages/back-end/test/api/experiments.test.ts
+++ b/packages/back-end/test/api/experiments.test.ts
@@ -230,6 +230,39 @@ describe("experiments API", () => {
       });
     });
 
+    it("serializes an enabled namespace with enabled: true so it round-trips", async () => {
+      const experimentWithNamespace = {
+        ...experiment,
+        phases: [
+          {
+            name: "Main",
+            dateStarted: new Date("2024-01-01"),
+            dateEnded: null,
+            reason: "",
+            seed: "test-seed",
+            coverage: 1,
+            variationWeights: [0.5, 0.5],
+            condition: "",
+            savedGroups: [],
+            prerequisites: [],
+            namespace: { enabled: true, name: "ns_1", range: [0, 0.5] },
+          },
+        ],
+      };
+      (getExperimentById as jest.Mock).mockResolvedValue(
+        experimentWithNamespace,
+      );
+      const res = await request(app)
+        .get("/api/v1/experiments/exp_123")
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      expect(res.body.experiment.phases[0].namespace).toMatchObject({
+        namespaceId: "ns_1",
+        enabled: true,
+      });
+    });
+
     it("returns experiment with draft status", async () => {
       const draftExperiment = { ...experiment, status: "draft" };
       (getExperimentById as jest.Mock).mockResolvedValue(draftExperiment);
@@ -1532,6 +1565,141 @@ describe("experiments API", () => {
         { id: "v1", status: "active" },
         { id: "v0", status: "active" },
       ]);
+    });
+
+    it("honors the GET-response phase field names on a round-trip update", async () => {
+      (getExperimentById as jest.Mock).mockResolvedValue({
+        ...experiment,
+        variations: [
+          { id: "0", key: "control", name: "Control", screenshots: [] },
+          { id: "1", key: "treatment", name: "Treatment", screenshots: [] },
+        ],
+      });
+      (updateExperiment as jest.Mock).mockImplementation(
+        ({ experiment, changes }) => ({ ...experiment, ...changes }),
+      );
+
+      // Simulate echoing a GET response back: targeting/splits arrive under the
+      // response field names (targetingCondition / trafficSplit /
+      // reasonForStopping), which the update must honor.
+      const res = await request(app)
+        .post("/api/v1/experiments/exp_123")
+        .send({
+          phases: [
+            {
+              name: "Main",
+              dateStarted: "2026-01-01T00:00:00.000Z",
+              targetingCondition: '{"path":{"$in":["/checkout"]}}',
+              trafficSplit: [
+                { variationId: "0", weight: 0.9 },
+                { variationId: "1", weight: 0.1 },
+              ],
+              reasonForStopping: "ramp down",
+            },
+          ],
+        })
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      const updateCall = (updateExperiment as jest.Mock).mock.calls[0][0];
+      const phase = updateCall.changes.phases[0];
+      expect(phase.condition).toBe('{"path":{"$in":["/checkout"]}}');
+      expect(phase.variationWeights).toEqual([0.9, 0.1]);
+      expect(phase.reason).toBe("ramp down");
+    });
+
+    it("maps trafficSplit weights by variationId, not array position", async () => {
+      (getExperimentById as jest.Mock).mockResolvedValue({
+        ...experiment,
+        variations: [
+          { id: "0", key: "control", name: "Control", screenshots: [] },
+          { id: "1", key: "treatment", name: "Treatment", screenshots: [] },
+        ],
+      });
+      (updateExperiment as jest.Mock).mockImplementation(
+        ({ experiment, changes }) => ({ ...experiment, ...changes }),
+      );
+
+      // trafficSplit reordered relative to the variations: weights must still
+      // land on the right variation (0 -> 0.9, 1 -> 0.1), not by position.
+      const res = await request(app)
+        .post("/api/v1/experiments/exp_123")
+        .send({
+          phases: [
+            {
+              name: "Main",
+              dateStarted: "2026-01-01T00:00:00.000Z",
+              trafficSplit: [
+                { variationId: "1", weight: 0.1 },
+                { variationId: "0", weight: 0.9 },
+              ],
+            },
+          ],
+        })
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      const phase = (updateExperiment as jest.Mock).mock.calls[0][0].changes
+        .phases[0];
+      expect(phase.variationWeights).toEqual([0.9, 0.1]);
+    });
+
+    it("honors variationId as an alias for id so variations round-trip", async () => {
+      (getExperimentById as jest.Mock).mockResolvedValue(experiment);
+      (updateExperiment as jest.Mock).mockImplementation(
+        ({ experiment, changes }) => ({ ...experiment, ...changes }),
+      );
+
+      // Echoing GET variations back: they arrive with variationId, not id.
+      // Without the alias, id would be regenerated and identity would churn.
+      const res = await request(app)
+        .post("/api/v1/experiments/exp_123")
+        .send({
+          variations: [
+            { variationId: "v0", key: "control", name: "Control" },
+            { variationId: "v1", key: "treatment", name: "Treatment" },
+          ],
+        })
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      const changes = (updateExperiment as jest.Mock).mock.calls[0][0].changes;
+      expect(changes.variations.map((v) => v.id)).toEqual(["v0", "v1"]);
+    });
+
+    it("prefers the POST-only phase fields when both they and their aliases are set", async () => {
+      (getExperimentById as jest.Mock).mockResolvedValue(experiment);
+      (updateExperiment as jest.Mock).mockImplementation(
+        ({ experiment, changes }) => ({ ...experiment, ...changes }),
+      );
+
+      const res = await request(app)
+        .post("/api/v1/experiments/exp_123")
+        .send({
+          phases: [
+            {
+              name: "Main",
+              dateStarted: "2026-01-01T00:00:00.000Z",
+              condition: '{"id":"post"}',
+              targetingCondition: '{"id":"response"}',
+              variationWeights: [0.7, 0.3],
+              trafficSplit: [
+                { variationId: "0", weight: 0.9 },
+                { variationId: "1", weight: 0.1 },
+              ],
+              reason: "post reason",
+              reasonForStopping: "response reason",
+            },
+          ],
+        })
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      const phase = (updateExperiment as jest.Mock).mock.calls[0][0].changes
+        .phases[0];
+      expect(phase.condition).toBe('{"id":"post"}');
+      expect(phase.variationWeights).toEqual([0.7, 0.3]);
+      expect(phase.reason).toBe("post reason");
     });
 
     it("force-syncs phase variations in mixed phases plus top-level variations updates", async () => {

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -980,6 +980,12 @@ const apiMetricOverrideEntryInput = z
 // Variation for input payloads
 const apiVariationInput = z.object({
   id: z.string().optional(),
+  variationId: z
+    .string()
+    .describe(
+      "Alias for `id`. Mirrors the GET response. `id` takes precedence.",
+    )
+    .optional(),
   key: z.string(),
   name: z.string(),
   description: z.string().max(MAX_DESCRIPTION_LENGTH).optional(),
@@ -1020,8 +1026,20 @@ const apiPhaseInput = z.object({
       }),
     )
     .optional(),
-  reason: z.string().optional(),
-  condition: z.string().optional(),
+  reason: z
+    .string()
+    .describe("Deprecated: use `reasonForStopping`. Takes precedence if set.")
+    .meta({ deprecated: true })
+    .optional(),
+  condition: z
+    .string()
+    .describe("Deprecated: use `targetingCondition`. Takes precedence if set.")
+    .meta({ deprecated: true })
+    .optional(),
+  targetingCondition: z
+    .string()
+    .describe("Targeting condition as a JSON string. Mirrors the GET response.")
+    .optional(),
   savedGroupTargeting: z
     .array(
       z.object({
@@ -1030,7 +1048,15 @@ const apiPhaseInput = z.object({
       }),
     )
     .optional(),
-  variationWeights: z.array(z.number()).optional(),
+  variationWeights: z
+    .array(z.number())
+    .describe("Deprecated: use `trafficSplit`. Takes precedence if set.")
+    .meta({ deprecated: true })
+    .optional(),
+  trafficSplit: z
+    .array(z.object({ variationId: z.string(), weight: z.number() }))
+    .describe("Per-variation weights. Mirrors the GET response.")
+    .optional(),
 });
 
 // PostExperimentPayload.yaml
@@ -1280,8 +1306,26 @@ const updateExperimentBody = z
               }),
             )
             .optional(),
-          reason: z.string().optional(),
-          condition: z.string().optional(),
+          reason: z
+            .string()
+            .describe(
+              "Deprecated: use `reasonForStopping`. Takes precedence if set.",
+            )
+            .meta({ deprecated: true })
+            .optional(),
+          condition: z
+            .string()
+            .describe(
+              "Deprecated: use `targetingCondition`. Takes precedence if set.",
+            )
+            .meta({ deprecated: true })
+            .optional(),
+          targetingCondition: z
+            .string()
+            .describe(
+              "Targeting condition as a JSON string. Mirrors the GET response.",
+            )
+            .optional(),
           savedGroupTargeting: z
             .array(
               z.object({
@@ -1290,7 +1334,17 @@ const updateExperimentBody = z
               }),
             )
             .optional(),
-          variationWeights: z.array(z.number()).optional(),
+          variationWeights: z
+            .array(z.number())
+            .describe(
+              "Deprecated: use `trafficSplit`. Takes precedence if set.",
+            )
+            .meta({ deprecated: true })
+            .optional(),
+          trafficSplit: z
+            .array(z.object({ variationId: z.string(), weight: z.number() }))
+            .describe("Per-variation weights. Mirrors the GET response.")
+            .optional(),
         }),
       )
       .optional(),


### PR DESCRIPTION
### Features and Changes

Fixes the silent data-loss bug reported in #6258: fetching an experiment, editing one field, and POSTing it back would wipe phase targeting and traffic splits. The root cause is that the GET response and the create/update request use different field names for the same data, so echoing the response back dropped those fields and the phase was rebuilt with defaults.

Rather than change the endpoint's long-standing "a `phases` array is a full replacement" semantics (which merge-patch, RFC 7396, treats as correct for arrays), this makes the round-trip lossless by teaching the request to accept the GET-response field names as aliases:

- **Phase fields:** `targetingCondition` → `condition`, `trafficSplit` → `variationWeights` (reshaped from `[{ variationId, weight }]` to a weight array by variation index), `reasonForStopping` → `reason` (already accepted in the schema, now actually honored).
- **Variation field:** `variationId` → `id`. Without this, echoing GET variations back (which carry `variationId`, not `id`) regenerated variation ids, desyncing the phase `variations` envelope and sticky bucketing. Resolved before `validateVariationIds` runs so it doesn't assign a fresh id first.
- **The POST-only fields (`condition`/`variationWeights`/`reason`/`id`) take precedence** when both a field and its alias are set, and the phase POST-only fields are marked `deprecated` in the spec so the API converges on the response vocabulary.
- **Enabled namespaces now round-trip.** The GET response emitted a phase `namespace` only when enabled but omitted the `enabled` flag; posting it back through `toPhaseNamespaceValue` (`enabled ?? false`) then disabled it. The response now emits `enabled: true`. (thanks @ahdriel)

Applies to both `POST /api/v1/experiments` and `POST /api/v1/experiments/{id}`. This is purely additive — no existing caller's behavior changes; previously-ignored fields simply start working. Regenerated the OpenAPI spec.

:warning: This does not unify the top-level request/response shapes (the GET response nests analysis config under `settings` and results under `resultSummary`, and `winner` is a variation-ID string in the response but a numeric index in the request). Those mismatches are non-destructive — omitted top-level fields are left unchanged — so they're out of scope here.

### Testing

- [x] Round-trip test: an update sent with `targetingCondition`/`trafficSplit`/`reasonForStopping` applies them to the phase.
- [x] Variation round-trip test: an update sent with `variationId` (no `id`) keeps the ids instead of regenerating them.
- [x] Precedence test: when both a POST-only field and its alias are set, the POST-only field wins.
- [x] Serialization test: an enabled namespace serializes with `enabled: true`.
- [x] Existing experiments API tests (68 total) pass; back-end + shared type-check and lint clean.
