### PR TITLE
feat(agg-tables): opt-in shared-staging restate to share one source scan across idTypes

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -40935,6 +40935,7 @@ components:
           type: string
           enum:
             - started
+            - completed
             - failed
             - skipped
         reason:

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -18975,6 +18975,8 @@ paths:
                       type: integer
                       minimum: 1
                       maximum: 7
+                    useSharedStagingRestate:
+                      type: boolean
                   required:
                     - idTypes
                     - updateTime
@@ -19119,6 +19121,8 @@ paths:
                       type: integer
                       minimum: 1
                       maximum: 7
+                    useSharedStagingRestate:
+                      type: boolean
                   required:
                     - idTypes
                     - updateTime
@@ -40652,6 +40656,8 @@ components:
               type: integer
               minimum: 1
               maximum: 7
+            useSharedStagingRestate:
+              type: boolean
           required:
             - idTypes
             - updateTime

--- a/packages/back-end/src/integrations/GoogleAnalytics.ts
+++ b/packages/back-end/src/integrations/GoogleAnalytics.ts
@@ -41,6 +41,8 @@ import {
   InsertAggregatedFactTableDataQueryParams,
   AggregatedFactTableMaxTimestampQueryParams,
   DropAggregatedFactTableQueryParams,
+  CreateAggregatedFactTableStagingQueryParams,
+  InsertAggregatedFactTableStagingDataQueryParams,
 } from "shared/types/integrations";
 import { parseIntWithDefault } from "shared/util";
 import { GoogleAnalyticsParams } from "shared/types/integrations/googleanalytics";
@@ -257,6 +259,16 @@ export default class GoogleAnalytics implements SourceIntegrationInterface {
   }
   getDropAggregatedFactTableQuery(
     _params: DropAggregatedFactTableQueryParams,
+  ): string {
+    throw new Error("Method not implemented.");
+  }
+  getCreateAggregatedFactTableStagingQuery(
+    _params: CreateAggregatedFactTableStagingQueryParams,
+  ): string {
+    throw new Error("Method not implemented.");
+  }
+  getInsertAggregatedFactTableStagingDataQuery(
+    _params: InsertAggregatedFactTableStagingDataQueryParams,
   ): string {
     throw new Error("Method not implemented.");
   }

--- a/packages/back-end/src/integrations/Mixpanel.ts
+++ b/packages/back-end/src/integrations/Mixpanel.ts
@@ -39,6 +39,8 @@ import {
   InsertAggregatedFactTableDataQueryParams,
   AggregatedFactTableMaxTimestampQueryParams,
   DropAggregatedFactTableQueryParams,
+  CreateAggregatedFactTableStagingQueryParams,
+  InsertAggregatedFactTableStagingDataQueryParams,
   InsertMetricSourceCovariateDataQueryParams,
   InsertMetricSourceCovariateFromAggregatedFactTableQueryParams,
 } from "shared/types/integrations";
@@ -211,6 +213,16 @@ export default class Mixpanel implements SourceIntegrationInterface {
   }
   getDropAggregatedFactTableQuery(
     _params: DropAggregatedFactTableQueryParams,
+  ): string {
+    throw new Error("Method not implemented.");
+  }
+  getCreateAggregatedFactTableStagingQuery(
+    _params: CreateAggregatedFactTableStagingQueryParams,
+  ): string {
+    throw new Error("Method not implemented.");
+  }
+  getInsertAggregatedFactTableStagingDataQuery(
+    _params: InsertAggregatedFactTableStagingDataQueryParams,
   ): string {
     throw new Error("Method not implemented.");
   }

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -90,6 +90,8 @@ import {
   InsertAggregatedFactTableDataQueryParams,
   AggregatedFactTableMaxTimestampQueryParams,
   DropAggregatedFactTableQueryParams,
+  CreateAggregatedFactTableStagingQueryParams,
+  InsertAggregatedFactTableStagingDataQueryParams,
   PipelineIntegration,
 } from "shared/types/integrations";
 import { MetricInterface, MetricType } from "shared/types/metric";
@@ -137,6 +139,10 @@ import { getDimensionSlicesQuery as getDimensionSlicesQueryFromSql } from "back-
 import { getDimensionValuePerUnit } from "back-end/src/integrations/sql/fact-metrics/dimension-value-per-unit";
 import { getDropMetricSourceCovariateTableQuery } from "back-end/src/integrations/sql/queries/drop-metric-source-covariate-table-query";
 import { getCreateAggregatedFactTableQuery } from "back-end/src/integrations/sql/queries/create-aggregated-fact-table-query";
+import {
+  getCreateAggregatedFactTableStagingQuery,
+  getInsertAggregatedFactTableStagingDataQuery,
+} from "back-end/src/integrations/sql/queries/aggregated-fact-table-staging-query";
 import { getInsertAggregatedFactTableDataQuery } from "back-end/src/integrations/sql/queries/insert-aggregated-fact-table-data-query";
 import { getAggregatedFactTableMaxTimestampQuery } from "back-end/src/integrations/sql/queries/aggregated-fact-table-max-timestamp-query";
 import { getDropAggregatedFactTableQuery } from "back-end/src/integrations/sql/queries/drop-aggregated-fact-table-query";
@@ -1889,6 +1895,25 @@ export default abstract class SqlIntegration
     params: DropAggregatedFactTableQueryParams,
   ): string {
     return getDropAggregatedFactTableQuery(this.getSqlDialect(), params);
+  }
+
+  getCreateAggregatedFactTableStagingQuery(
+    params: CreateAggregatedFactTableStagingQueryParams,
+  ): string {
+    return getCreateAggregatedFactTableStagingQuery(
+      this.getSqlDialect(),
+      params,
+      this.createTablePartitions.bind(this),
+    );
+  }
+
+  getInsertAggregatedFactTableStagingDataQuery(
+    params: InsertAggregatedFactTableStagingDataQueryParams,
+  ): string {
+    return getInsertAggregatedFactTableStagingDataQuery(
+      this.getSqlDialect(),
+      params,
+    );
   }
 
   getCreateMetricSourceCovariateTableQuery(

--- a/packages/back-end/src/integrations/sql/ctes/fact-metric-cte.ts
+++ b/packages/back-end/src/integrations/sql/ctes/fact-metric-cte.ts
@@ -33,6 +33,7 @@ export function getFactMetricCTE(
     exclusiveEndDateFilter,
     phase,
     customFields,
+    projectIdTypes,
   }: {
     metricsWithIndices: { metric: FactMetricInterface; index: number }[];
     factTable: FactTableInterface;
@@ -47,6 +48,11 @@ export function getFactMetricCTE(
     exclusiveStartDateFilter?: boolean;
     exclusiveEndDateFilter?: boolean;
     castIdToString?: boolean;
+    // When set, project every listed native idType column instead of only
+    // `baseIdType`. Used by the shared-staging restate to materialize one
+    // event-grain table that all per-idType GROUP BYs can read. Each listed
+    // idType must be native to `factTable.userIdTypes` (no id-join support).
+    projectIdTypes?: string[];
   },
 ): string {
   // Determine if a join is required to match up id types
@@ -194,10 +200,24 @@ export function getFactMetricCTE(
     }
   }
 
+  const idProjection = projectIdTypes?.length
+    ? projectIdTypes
+        .map((t) => {
+          if (!userIdTypes.includes(t)) {
+            throw new Error(
+              `projectIdTypes: id type "${t}" is not native to fact table "${factTable.id}"`,
+            );
+          }
+          const col = `m.${t}`;
+          return `${castIdToString ? dialect.castToString(col) : col} as ${t}`;
+        })
+        .join(",\n        ")
+    : `${castIdToString ? dialect.castToString(userIdCol) : userIdCol} as ${baseIdType}`;
+
   return compileSqlTemplate(
     `-- Fact Table (${factTable.name})
       SELECT
-        ${castIdToString ? dialect.castToString(userIdCol) : userIdCol} as ${baseIdType},
+        ${idProjection},
         ${timestampDateTimeColumn} as timestamp,
         ${metricCols.join(",\n")}
       FROM(

--- a/packages/back-end/src/integrations/sql/queries/aggregated-fact-table-staging-query.ts
+++ b/packages/back-end/src/integrations/sql/queries/aggregated-fact-table-staging-query.ts
@@ -1,0 +1,131 @@
+import { format } from "shared/sql";
+import { isRatioMetric } from "shared/experiments";
+import type {
+  CreateAggregatedFactTableStagingQueryParams,
+  InsertAggregatedFactTableStagingDataQueryParams,
+} from "shared/types/integrations";
+import type { FactMetricInterface } from "shared/types/fact-table";
+import type { SqlDialect } from "shared/types/sql";
+
+import { getFactMetricCTE } from "back-end/src/integrations/sql/ctes/fact-metric-cte";
+
+// Shared-staging tables materialize the event-grain output of the fact-table
+// CTE (all enabled idType columns + timestamp + per-metric raw value columns)
+// once per restate. Each per-idType aggregated table then reads its GROUP BY
+// from the staging table instead of re-scanning the fact-table SQL, so a fact
+// table with N idTypes pays one source scan instead of N.
+
+// Column list of the staging table, in stable order. Metric columns use the
+// same `m{index}` naming as `getFactMetricCTE` so the per-idType insert can
+// read them without a rename.
+export function getAggregatedFactTableStagingColumns({
+  idTypes,
+  metrics,
+  factTableId,
+}: {
+  idTypes: string[];
+  metrics: FactMetricInterface[];
+  factTableId: string;
+}): string[] {
+  const sortedMetrics = [...metrics].sort((a, b) => a.id.localeCompare(b.id));
+  const cols = [...idTypes, "timestamp"];
+  sortedMetrics.forEach((m, index) => {
+    if (m.numerator?.factTableId === factTableId) {
+      cols.push(`m${index}_value`);
+      if (m.numerator.aggregation === "kll merge") {
+        cols.push(`m${index}_n_events`);
+      }
+    }
+    if (isRatioMetric(m) && m.denominator?.factTableId === factTableId) {
+      cols.push(`m${index}_denominator`);
+    }
+  });
+  return cols;
+}
+
+export function getCreateAggregatedFactTableStagingQuery(
+  dialect: SqlDialect,
+  params: CreateAggregatedFactTableStagingQueryParams,
+  createTablePartitions: (
+    columns: string[],
+    opts?: { partitionByDate?: boolean; partitionExpirationDays?: number },
+  ) => string,
+): string {
+  const { stagingTableFullName, factTable, idTypes, metrics, expirationHours } =
+    params;
+
+  // Derive column types from a zero-row projection of the CTE so metric-value
+  // column types (float / KLL sketch / etc.) match the source without a
+  // parallel type-derivation table. `expirationHours` guards against orphaned
+  // staging tables when the coordinating driver dies before the explicit DROP.
+  const cte = getFactMetricCTE(dialect, {
+    baseIdType: idTypes[0],
+    projectIdTypes: idTypes,
+    idJoinMap: {},
+    factTable,
+    startDate: new Date(0),
+    endDate: null,
+    metricsWithIndices: [...metrics]
+      .sort((a, b) => a.id.localeCompare(b.id))
+      .map((metric, index) => ({ metric, index })),
+    addFiltersToWhere: true,
+    castIdToString: true,
+  });
+
+  // CREATE ... AS SELECT with WHERE FALSE derives column types from the CTE
+  // without scanning data; the chunked INSERTs then fill it.
+  return format(
+    `
+    CREATE TABLE ${stagingTableFullName}
+    ${createTablePartitions(["timestamp", ...idTypes], {
+      // The CTE emits `timestamp` as a TIMESTAMP; partition on the trunc, not a
+      // DATE cast, so the schema matches.
+      partitionByDate: false,
+      // Days-granular expiration is the portable option; the hours arg rounds up.
+      partitionExpirationDays: Math.max(1, Math.ceil(expirationHours / 24)),
+    })}
+    AS SELECT * FROM (${cte}) WHERE FALSE
+    `,
+    dialect.formatDialect,
+  );
+}
+
+export function getInsertAggregatedFactTableStagingDataQuery(
+  dialect: SqlDialect,
+  params: InsertAggregatedFactTableStagingDataQueryParams,
+): string {
+  const { stagingTableFullName, factTable, idTypes, metrics } = params;
+
+  const sortedMetrics = [...metrics].sort((a, b) => a.id.localeCompare(b.id));
+  const columns = getAggregatedFactTableStagingColumns({
+    idTypes,
+    metrics,
+    factTableId: factTable.id,
+  });
+
+  const cte = getFactMetricCTE(dialect, {
+    baseIdType: idTypes[0],
+    projectIdTypes: idTypes,
+    idJoinMap: {},
+    factTable,
+    startDate: params.windowStartDate,
+    endDate: params.windowEndDate,
+    metricsWithIndices: sortedMetrics.map((metric, index) => ({
+      metric,
+      index,
+    })),
+    addFiltersToWhere: true,
+    exclusiveStartDateFilter: false,
+    exclusiveEndDateFilter: true,
+    castIdToString: true,
+  });
+
+  return format(
+    `
+    INSERT INTO ${stagingTableFullName}
+    (${columns.join(", \n")})
+    SELECT ${columns.join(", ")} FROM (${cte})
+    `,
+    dialect.formatDialect,
+  );
+}

--- a/packages/back-end/src/integrations/sql/queries/insert-aggregated-fact-table-data-query.ts
+++ b/packages/back-end/src/integrations/sql/queries/insert-aggregated-fact-table-data-query.ts
@@ -7,7 +7,9 @@ import { getFactMetricCTE } from "back-end/src/integrations/sql/ctes/fact-metric
 import { getAggregationMetadata } from "back-end/src/integrations/sql/fact-metrics/aggregation-metadata";
 import { encodeMetricIdForColumnName } from "back-end/src/integrations/sql/fact-metrics/encode-metric-id-for-column-name";
 import { castToTimestamp } from "back-end/src/integrations/sql/primitives/cast-to-timestamp";
+import { toTimestampWithMs } from "back-end/src/integrations/sql/primitives/to-timestamp-with-ms";
 import { getAggregatedFactTableSchema } from "back-end/src/integrations/sql/fact-metrics/aggregated-fact-table-schema";
+import { getAggregatedFactTableStagingColumns } from "back-end/src/integrations/sql/queries/aggregated-fact-table-staging-query";
 
 // Append-only INSERT materializing a new slice of daily aggregates per
 // `(idType, event_date)`. Each output row is a disjoint partial of one event
@@ -39,24 +41,49 @@ export function getInsertAggregatedFactTableDataQuery(
   const columnNames = Array.from(schema.keys());
 
   // No id join is needed: the aggregated table is keyed on a native id type of
-  // this fact table.
-  const factTableCTE = getFactMetricCTE(dialect, {
-    baseIdType: idType,
-    idJoinMap: {},
-    factTable,
-    startDate: params.windowStartDate,
-    endDate: params.windowEndDate ?? null,
-    metricsWithIndices: sortedMetrics.map((metric, index) => ({
-      metric,
-      index,
-    })),
-    addFiltersToWhere: true,
-    exclusiveStartDateFilter: params.exclusiveStart,
-    // Chunk boundaries are half-open [start, end) so chained chunks tile the
-    // window without overlap or gaps.
-    exclusiveEndDateFilter: true,
-    castIdToString: true,
-  });
+  // this fact table. When `sourceTableFullName` is set (shared-staging restate),
+  // the event-grain rows have already been materialized with all idType columns
+  // and `m{index}_*` value columns, so read the projection from there instead of
+  // wrapping the fact-table SQL again.
+  let factTableCTE: string;
+  if (params.sourceTableFullName) {
+    const stagingCols = getAggregatedFactTableStagingColumns({
+      idTypes: [idType],
+      metrics: sortedMetrics,
+      factTableId: factTable.id,
+    });
+    const bounds: string[] = [
+      `timestamp ${params.exclusiveStart ? ">" : ">="} ${toTimestampWithMs(
+        params.windowStartDate,
+      )}`,
+    ];
+    if (params.windowEndDate) {
+      bounds.push(`timestamp < ${toTimestampWithMs(params.windowEndDate)}`);
+    }
+    factTableCTE = `
+      SELECT ${stagingCols.join(", ")}
+      FROM ${params.sourceTableFullName}
+      WHERE ${bounds.join(" AND ")}
+    `;
+  } else {
+    factTableCTE = getFactMetricCTE(dialect, {
+      baseIdType: idType,
+      idJoinMap: {},
+      factTable,
+      startDate: params.windowStartDate,
+      endDate: params.windowEndDate ?? null,
+      metricsWithIndices: sortedMetrics.map((metric, index) => ({
+        metric,
+        index,
+      })),
+      addFiltersToWhere: true,
+      exclusiveStartDateFilter: params.exclusiveStart,
+      // Chunk boundaries are half-open [start, end) so chained chunks tile the
+      // window without overlap or gaps.
+      exclusiveEndDateFilter: true,
+      castIdToString: true,
+    });
+  }
 
   // Per-metric column shape, computed once so the partial / merge / final
   // projections stay aligned.

--- a/packages/back-end/src/jobs/updateAggregatedFactTables.ts
+++ b/packages/back-end/src/jobs/updateAggregatedFactTables.ts
@@ -5,17 +5,27 @@ import {
 } from "back-end/src/models/FactTableModel";
 import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizations";
 import { getAgendaInstance } from "back-end/src/services/queueing";
-import { runAggregatedFactTableUpdate } from "back-end/src/services/aggregatedFactTables";
+import {
+  runAggregatedFactTableSharedStagingUpdate,
+  runAggregatedFactTableUpdate,
+} from "back-end/src/services/aggregatedFactTables";
 import { logger } from "back-end/src/util/logger";
 import { getMostRecentUpdateOccurrence } from "back-end/src/util/factTable";
 
 const QUEUE_AGGREGATED_FACT_TABLE_UPDATES = "queueAggregatedFactTableUpdates";
 const UPDATE_SINGLE_AGGREGATED_FACT_TABLE = "updateSingleAggregatedFactTable";
+const UPDATE_AGGREGATED_FACT_TABLE_SET = "updateAggregatedFactTableSet";
 
 type UpdateSingleAggregatedFactTableJob = Job<{
   organization: string;
   factTableId: string;
   idType: string;
+  forceRestate?: boolean;
+}>;
+
+type UpdateAggregatedFactTableSetJob = Job<{
+  organization: string;
+  factTableId: string;
   forceRestate?: boolean;
 }>;
 
@@ -26,6 +36,8 @@ export default async function (agenda: Agenda) {
     UPDATE_SINGLE_AGGREGATED_FACT_TABLE,
     updateSingleAggregatedFactTable,
   );
+
+  agenda.define(UPDATE_AGGREGATED_FACT_TABLE_SET, updateAggregatedFactTableSet);
 
   await startUpdateJob();
 
@@ -88,6 +100,39 @@ async function pollAggregatedFactTables() {
 
     const context = await getContext(factTable.organization);
     if (!context) continue;
+
+    // With shared-staging enabled, enqueue one job per fact table so a single
+    // coordinator can materialize the source once and fan out per-idType reads.
+    // Still claim every idType's slot so the once-per-day gate holds.
+    if (settings.useSharedStagingRestate && settings.idTypes.length >= 2) {
+      let anyClaimed = false;
+      for (const idType of settings.idTypes) {
+        try {
+          const claimed =
+            await context.models.aggregatedFactTables.claimScheduledSlot(
+              {
+                datasourceId: factTable.datasource,
+                factTableId: factTable.id,
+                idType,
+              },
+              fireTime,
+            );
+          anyClaimed = anyClaimed || claimed;
+        } catch (e) {
+          logger.error(
+            e,
+            `Failed to claim aggregated fact table slot for ${factTable.id}/${idType}`,
+          );
+        }
+      }
+      if (anyClaimed) {
+        await queueAggregatedFactTableSetUpdate({
+          organization: factTable.organization,
+          factTableId: factTable.id,
+        });
+      }
+      continue;
+    }
 
     for (const idType of settings.idTypes) {
       const key = {
@@ -169,5 +214,43 @@ const updateSingleAggregatedFactTable = async (
 
   await runAggregatedFactTableUpdate(context, factTable, idType, {
     forceRestate: !!forceRestate,
+  });
+};
+
+export async function queueAggregatedFactTableSetUpdate({
+  organization,
+  factTableId,
+  forceRestate,
+}: {
+  organization: string;
+  factTableId: string;
+  forceRestate?: boolean;
+}) {
+  const agenda = getAgendaInstance();
+  const job = agenda.create(UPDATE_AGGREGATED_FACT_TABLE_SET, {
+    organization,
+    factTableId,
+    forceRestate: forceRestate ?? false,
+  });
+  job.unique({ organization, factTableId });
+  job.schedule(new Date());
+  await job.save();
+}
+
+const updateAggregatedFactTableSet = async (
+  job: UpdateAggregatedFactTableSetJob,
+) => {
+  const { organization, factTableId, forceRestate } = job.attrs.data ?? {};
+  if (!organization || !factTableId) return;
+
+  const context = await getContextForAgendaJobByOrgId(organization);
+  if (!context.hasPremiumFeature("pipeline-mode")) return;
+
+  const factTable = await getFactTable(context, factTableId);
+  if (!factTable?.aggregatedFactTableSettings?.idTypes?.length) return;
+
+  await runAggregatedFactTableSharedStagingUpdate(context, factTable, {
+    forceRestate: !!forceRestate,
+    awaitResults: true,
   });
 };

--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -90,6 +90,7 @@ const factTableSchema = new mongoose.Schema({
       },
       lookbackWindow: Number,
       restateChunkDays: Number,
+      useSharedStagingRestate: Boolean,
     },
     default: undefined,
   },

--- a/packages/back-end/src/queryRunners/AggregatedFactTableQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/AggregatedFactTableQueryRunner.ts
@@ -46,6 +46,20 @@ export function getRestateChunkBounds(
 
 export type AggregatedFactTableRunMode = "incremental" | "restate";
 
+// Restate-only: build (or reuse) a shared event-grain staging table so multiple
+// idTypes' restates share one fact-table SQL scan. `buildStaging` is set on
+// exactly one idType's runner (which prepends the staging DROP/CREATE/INSERT
+// queries and waits on them before its own restate); the other idTypes' runners
+// only read from `stagingTableFullName`. `allIdTypes` is the full set the
+// staging table projects. The staging table carries a partition-expiration so
+// it auto-drops if the coordinating driver dies before the explicit cleanup.
+export type AggregatedFactTableSharedStaging = {
+  stagingTableFullName: string;
+  allIdTypes: string[];
+  buildStaging: boolean;
+  dropStagingOnComplete: boolean;
+};
+
 export type AggregatedFactTableQueryParams = {
   factTable: FactTableInterface;
   idType: string;
@@ -60,7 +74,12 @@ export type AggregatedFactTableQueryParams = {
   metricState: AggregatedFactTableMetricStateInterface[];
   // How far back a full restate re-scans.
   lookbackWindowDays: number;
+  // Shared-staging restate coordination (opt-in, restate mode only).
+  sharedStaging?: AggregatedFactTableSharedStaging;
 };
+
+export const AGGREGATED_FACT_TABLE_STAGING_PREFIX = "gb_agg_staging";
+export const AGGREGATED_FACT_TABLE_STAGING_EXPIRATION_HOURS = 24;
 
 export type AggregatedFactTableResult = {
   lastMaxTimestamp: Date | null;
@@ -243,8 +262,15 @@ export class AggregatedFactTableQueryRunner extends QueryRunner<
       factTableSettingsHash,
       metricState,
       lookbackWindowDays,
+      sharedStaging,
     } = params;
     const integration = this.integration;
+
+    if (sharedStaging && mode !== "restate") {
+      throw new Error(
+        "sharedStaging is restate-only; incremental mode should not pass it",
+      );
+    }
 
     if (!integration.generateTablePath) {
       throw new Error(
@@ -266,6 +292,105 @@ export class AggregatedFactTableQueryRunner extends QueryRunner<
 
     // The driver decides the mode; the runner just executes it.
     const queries: Queries = [];
+
+    // Compute the restate window / chunk bounds up front so both the staging
+    // build and the per-idType inserts share them.
+    const now = new Date();
+    const restateWindowStart = new Date(
+      now.getTime() - lookbackWindowDays * 24 * 60 * 60 * 1000,
+    );
+    const restateChunkDays =
+      factTable.aggregatedFactTableSettings?.restateChunkDays;
+    const restateChunks =
+      mode === "restate" && restateChunkDays
+        ? getRestateChunkBounds(restateWindowStart, now, restateChunkDays)
+        : [{ start: restateWindowStart, end: null }];
+
+    let stagingReadyQuery: QueryPointer | null = null;
+    if (sharedStaging?.buildStaging) {
+      // Build the shared staging table before this idType's own restate. All
+      // enabled idTypes' inserts (including this one) then read from it. The
+      // staging DROP-IF-EXISTS runs first for idempotency; a partition-
+      // expiration on CREATE ensures cleanup even if the coordinating driver
+      // dies before the explicit drop.
+      const stagingDropSql = integration.getDropAggregatedFactTableQuery({
+        tableFullName: sharedStaging.stagingTableFullName,
+      });
+      const stagingCreateSql =
+        integration.getCreateAggregatedFactTableStagingQuery({
+          stagingTableFullName: sharedStaging.stagingTableFullName,
+          factTable,
+          idTypes: sharedStaging.allIdTypes,
+          metrics,
+          expirationHours: AGGREGATED_FACT_TABLE_STAGING_EXPIRATION_HOURS,
+        });
+
+      const stagingDrop = await this.startQuery({
+        name: "drop_aggregated_fact_table_staging",
+        displayTitle: `Drop Shared Staging (${factTable.name})`,
+        query: stagingDropSql,
+        dependencies: [],
+        run: (query, setExternalId, queryMetadata) =>
+          integration.runIncrementalWithNoOutputQuery(
+            query,
+            setExternalId,
+            queryMetadata,
+          ),
+        queryType: "aggregatedFactTableDrop",
+      });
+      queries.push(stagingDrop);
+
+      const stagingCreate = await this.startQuery({
+        name: "create_aggregated_fact_table_staging",
+        displayTitle: `Create Shared Staging (${factTable.name})`,
+        query: stagingCreateSql,
+        dependencies: [stagingDrop.query],
+        run: (query, setExternalId, queryMetadata) =>
+          integration.runIncrementalWithNoOutputQuery(
+            query,
+            setExternalId,
+            queryMetadata,
+          ),
+        queryType: "aggregatedFactTableCreate",
+      });
+      queries.push(stagingCreate);
+
+      let lastStagingInsert: QueryPointer = stagingCreate;
+      for (let i = 0; i < restateChunks.length; i++) {
+        const chunk = restateChunks[i];
+        const stagingInsertSql =
+          integration.getInsertAggregatedFactTableStagingDataQuery({
+            stagingTableFullName: sharedStaging.stagingTableFullName,
+            factTable,
+            idTypes: sharedStaging.allIdTypes,
+            metrics,
+            windowStartDate: chunk.start,
+            windowEndDate: chunk.end,
+          });
+        const stagingInsert = await this.startQuery({
+          name:
+            restateChunks.length > 1
+              ? `insert_aggregated_fact_table_staging_chunk_${i}`
+              : "insert_aggregated_fact_table_staging",
+          displayTitle:
+            restateChunks.length > 1
+              ? `Populate Shared Staging chunk ${i + 1}/${restateChunks.length} (${factTable.name})`
+              : `Populate Shared Staging (${factTable.name})`,
+          query: stagingInsertSql,
+          dependencies: [lastStagingInsert.query],
+          run: (query, setExternalId, queryMetadata) =>
+            integration.runIncrementalWithNoOutputQuery(
+              query,
+              setExternalId,
+              queryMetadata,
+            ),
+          queryType: "aggregatedFactTableInsertData",
+        });
+        queries.push(stagingInsert);
+        lastStagingInsert = stagingInsert;
+      }
+      stagingReadyQuery = lastStagingInsert;
+    }
 
     let dropQuery: QueryPointer | null = null;
     let createQuery: QueryPointer | null = null;
@@ -290,7 +415,7 @@ export class AggregatedFactTableQueryRunner extends QueryRunner<
         name: "drop_aggregated_fact_table",
         displayTitle: `Drop Aggregated Fact Table (${factTable.name} / ${idType})`,
         query: dropQueryString,
-        dependencies: [],
+        dependencies: stagingReadyQuery ? [stagingReadyQuery.query] : [],
         run: (query, setExternalId, queryMetadata) =>
           integration.runIncrementalWithNoOutputQuery(
             query,
@@ -318,10 +443,6 @@ export class AggregatedFactTableQueryRunner extends QueryRunner<
     }
 
     // Restate re-scans the retained window; incremental slices after the watermark.
-    const now = new Date();
-    const restateWindowStart = new Date(
-      now.getTime() - lookbackWindowDays * 24 * 60 * 60 * 1000,
-    );
     const windowStartDate =
       mode === "restate"
         ? restateWindowStart
@@ -346,11 +467,9 @@ export class AggregatedFactTableQueryRunner extends QueryRunner<
     // Restate optionally slices into sequential `restateChunkDays`-wide INSERTs
     // so each query's output stays inside the engine's per-stage write budget on
     // wide fact tables. Unset (or incremental) runs a single full-window INSERT.
-    const restateChunkDays =
-      factTable.aggregatedFactTableSettings?.restateChunkDays;
     const chunks =
-      mode === "restate" && restateChunkDays
-        ? getRestateChunkBounds(restateWindowStart, now, restateChunkDays)
+      mode === "restate"
+        ? restateChunks
         : [{ start: windowStartDate, end: null }];
     const chunked = chunks.length > 1;
 
@@ -366,6 +485,7 @@ export class AggregatedFactTableQueryRunner extends QueryRunner<
           windowStartDate: chunk.start,
           windowEndDate: chunk.end,
           exclusiveStart,
+          sourceTableFullName: sharedStaging?.stagingTableFullName,
         });
 
       const insertQuery: QueryPointer = await this.startQuery({
@@ -466,6 +586,27 @@ export class AggregatedFactTableQueryRunner extends QueryRunner<
       queryType: "aggregatedFactTableMaxTimestamp",
     });
     queries.push(maxTimestampQuery);
+
+    if (sharedStaging?.dropStagingOnComplete) {
+      // Best-effort cleanup; the partition-expiration set at CREATE guarantees
+      // eventual removal even if this query never runs.
+      const stagingCleanup = await this.startQuery({
+        name: "cleanup_aggregated_fact_table_staging",
+        displayTitle: `Drop Shared Staging (${factTable.name})`,
+        query: integration.getDropAggregatedFactTableQuery({
+          tableFullName: sharedStaging.stagingTableFullName,
+        }),
+        dependencies: [maxTimestampQuery.query],
+        run: (query, setExternalId, queryMetadata) =>
+          integration.runIncrementalWithNoOutputQuery(
+            query,
+            setExternalId,
+            queryMetadata,
+          ),
+        queryType: "aggregatedFactTableDrop",
+      });
+      queries.push(stagingCleanup);
+    }
 
     return queries;
   }

--- a/packages/back-end/src/services/aggregatedFactTables.ts
+++ b/packages/back-end/src/services/aggregatedFactTables.ts
@@ -19,8 +19,10 @@ import { getSourceIntegrationObject } from "back-end/src/services/datasource";
 import { logger } from "back-end/src/util/logger";
 import { getMostRecentUpdateOccurrence } from "back-end/src/util/factTable";
 import {
+  AGGREGATED_FACT_TABLE_STAGING_PREFIX,
   AggregatedFactTableQueryRunner,
   AggregatedFactTableRunMode,
+  AggregatedFactTableSharedStaging,
 } from "back-end/src/queryRunners/AggregatedFactTableQueryRunner";
 import {
   AggregatedFactTableRestateReason,
@@ -335,7 +337,19 @@ export async function runAggregatedFactTableUpdate(
     forceRestate,
     // true (nightly worker): block until queries finish. false (manual UI trigger): return after creating the run and finish in the background.
     awaitResults = false,
-  }: { forceRestate: boolean; awaitResults?: boolean },
+    // When set, this idType's lock is already held under this executionId (the
+    // shared-staging coordinator acquires all N locks up front). Skips the
+    // acquire step and reuses this executionId for all writes.
+    preAcquiredExecutionId,
+    // Shared-staging restate coordination (opt-in, restate mode only). Passed
+    // through to the runner unchanged.
+    sharedStaging,
+  }: {
+    forceRestate: boolean;
+    awaitResults?: boolean;
+    preAcquiredExecutionId?: string;
+    sharedStaging?: AggregatedFactTableSharedStaging;
+  },
 ): Promise<AggregatedFactTableUpdateOutcome> {
   const datasource = await getDataSourceById(context, factTable.datasource);
   if (!datasource) {
@@ -373,16 +387,18 @@ export async function runAggregatedFactTableUpdate(
     idType,
   };
 
-  const executionId = uniqid("aftexec_");
-  const locked = await context.models.aggregatedFactTables.acquireLock(
-    key,
-    executionId,
-  );
-  if (!locked) {
-    logger.debug(
-      `Aggregated fact table update for ${factTable.id}/${idType} already in progress; skipping`,
+  const executionId = preAcquiredExecutionId ?? uniqid("aftexec_");
+  if (!preAcquiredExecutionId) {
+    const locked = await context.models.aggregatedFactTables.acquireLock(
+      key,
+      executionId,
     );
-    return { status: "skipped", reason: "already-in-progress" };
+    if (!locked) {
+      logger.debug(
+        `Aggregated fact table update for ${factTable.id}/${idType} already in progress; skipping`,
+      );
+      return { status: "skipped", reason: "already-in-progress" };
+    }
   }
 
   const registry = await context.models.aggregatedFactTables.getByKey(key);
@@ -486,6 +502,7 @@ export async function runAggregatedFactTableUpdate(
       metricState,
       lookbackWindowDays:
         factTable.aggregatedFactTableSettings?.lookbackWindow ?? 60,
+      sharedStaging: mode === "restate" ? sharedStaging : undefined,
     });
   } catch (e) {
     const error = await handleFailure(e);
@@ -511,4 +528,233 @@ export async function runAggregatedFactTableUpdate(
   }
 
   return { status: "started", runId: run.id };
+}
+
+// Acquire the per-idType lock for every listed idType, or none. Returns the
+// per-idType executionIds on success; on any failure, releases the locks it
+// took and returns null so the caller can fall back to the per-idType path.
+async function acquireAllAggregatedFactTableLocks(
+  context: ReqContext,
+  datasourceId: string,
+  factTableId: string,
+  idTypes: string[],
+): Promise<Map<string, string> | null> {
+  const acquired = new Map<string, string>();
+  for (const idType of idTypes) {
+    const executionId = uniqid("aftexec_");
+    const locked = await context.models.aggregatedFactTables.acquireLock(
+      { datasourceId, factTableId, idType },
+      executionId,
+    );
+    if (!locked) {
+      for (const [heldIdType, heldExec] of acquired) {
+        await context.models.aggregatedFactTables
+          .releaseLock(
+            { datasourceId, factTableId, idType: heldIdType },
+            heldExec,
+          )
+          .catch((e) =>
+            logger.error(
+              e,
+              `Failed to release aggregated fact table lock for ${factTableId}/${heldIdType} during all-or-nothing rollback`,
+            ),
+          );
+      }
+      return null;
+    }
+    acquired.set(idType, executionId);
+  }
+  return acquired;
+}
+
+/**
+ * Coordinates a full-set update for a fact table with `useSharedStagingRestate`
+ * enabled. Determines which idTypes need to restate; when ≥2 do, materializes
+ * the fact-table CTE once to a short-lived staging table (all idType columns +
+ * per-metric value columns) and each per-idType restate reads its GROUP BY from
+ * there instead of re-scanning the source. idTypes that resolve to
+ * `incremental` (or a lone restate) run on the standard per-idType path.
+ *
+ * Restate-only. Any lock or preflight failure falls back to the per-idType
+ * path so the flag never blocks a run that would otherwise proceed.
+ */
+export async function runAggregatedFactTableSharedStagingUpdate(
+  context: ReqContext,
+  factTable: FactTableInterface,
+  {
+    forceRestate,
+    awaitResults = true,
+  }: { forceRestate: boolean; awaitResults?: boolean },
+): Promise<Map<string, AggregatedFactTableUpdateOutcome>> {
+  const idTypes = factTable.aggregatedFactTableSettings?.idTypes ?? [];
+  const outcomes = new Map<string, AggregatedFactTableUpdateOutcome>();
+
+  const runPerIdTypeFallback = async () => {
+    for (const idType of idTypes) {
+      if (outcomes.has(idType)) continue;
+      outcomes.set(
+        idType,
+        await runAggregatedFactTableUpdate(context, factTable, idType, {
+          forceRestate,
+          awaitResults,
+        }),
+      );
+    }
+    return outcomes;
+  };
+
+  if (
+    !factTable.aggregatedFactTableSettings?.useSharedStagingRestate ||
+    idTypes.length < 2
+  ) {
+    return runPerIdTypeFallback();
+  }
+
+  const datasource = await getDataSourceById(context, factTable.datasource);
+  if (!datasource) return runPerIdTypeFallback();
+  const pipelineSettings = datasource.settings.pipelineSettings;
+  const integration = getSourceIntegrationObject(context, datasource, true);
+  if (!pipelineSettings?.writeDataset || !integration.generateTablePath) {
+    return runPerIdTypeFallback();
+  }
+
+  const factMetrics = await context.models.factMetrics.getAll();
+  const metrics = getAggregatedFactTableMetrics({ factMetrics, factTable });
+  if (!metrics.length) return runPerIdTypeFallback();
+
+  const { factTableSettingsHash, metricState } =
+    buildAggregatedFactTableSchemaState({ factTable, metrics });
+
+  // Acquire every idType's lock up front so no per-idType run can interleave
+  // and re-scan the source while the shared staging build is in flight.
+  const executionIds = await acquireAllAggregatedFactTableLocks(
+    context,
+    datasource.id,
+    factTable.id,
+    idTypes,
+  );
+  if (!executionIds) {
+    logger.info(
+      `Shared-staging restate for ${factTable.id}: could not acquire all ${idTypes.length} idType locks; falling back to per-idType`,
+    );
+    return runPerIdTypeFallback();
+  }
+
+  // Partition by resolved mode. Incrementals never touch staging.
+  const restateIdTypes: string[] = [];
+  const incrementalIdTypes: string[] = [];
+  for (const idType of idTypes) {
+    const registry = await context.models.aggregatedFactTables.getByKey({
+      datasourceId: datasource.id,
+      factTableId: factTable.id,
+      idType,
+    });
+    const restateReason = registry
+      ? getAggregatedFactTableRestateReason({
+          registry,
+          factTableSettingsHash,
+          metricState,
+        })
+      : null;
+    const mode: AggregatedFactTableRunMode =
+      forceRestate || !registry?.tableFullName || restateReason !== null
+        ? "restate"
+        : "incremental";
+    (mode === "restate" ? restateIdTypes : incrementalIdTypes).push(idType);
+  }
+
+  if (restateIdTypes.length < 2) {
+    // No shared-scan benefit; release the pre-acquired locks and fall back.
+    for (const [idType, executionId] of executionIds) {
+      await context.models.aggregatedFactTables
+        .releaseLock(
+          { datasourceId: datasource.id, factTableId: factTable.id, idType },
+          executionId,
+        )
+        .catch(() => {});
+    }
+    return runPerIdTypeFallback();
+  }
+
+  const sharedExecutionId = uniqid("aftshared_");
+  const stagingTableFullName = integration.generateTablePath(
+    `${AGGREGATED_FACT_TABLE_STAGING_PREFIX}_${factTable.id}_${sharedExecutionId}`,
+    pipelineSettings.writeDataset,
+    pipelineSettings.writeDatabase,
+    true,
+  );
+
+  logger.info(
+    {
+      event: "aggregated_fact_table_shared_staging_started",
+      organization: context.org.id,
+      factTableId: factTable.id,
+      restateIdTypes,
+      incrementalIdTypes,
+      stagingTableFullName,
+    },
+    "Aggregated fact table shared-staging restate started",
+  );
+
+  // First restating idType's runner builds the staging table (staging queries
+  // are prepended so they show up in that idType's run history), then reads its
+  // own restate from it. Remaining restating idTypes wait for that runner to
+  // complete, then read staging concurrently. The last idType drops staging
+  // after its coverage query; the partition-expiration set at CREATE guarantees
+  // eventual cleanup regardless.
+  const [firstRestateIdType, ...restRestateIdTypes] = restateIdTypes;
+  const staging = (
+    buildStaging: boolean,
+    dropStagingOnComplete: boolean,
+  ): AggregatedFactTableSharedStaging => ({
+    stagingTableFullName,
+    allIdTypes: idTypes,
+    buildStaging,
+    dropStagingOnComplete,
+  });
+
+  outcomes.set(
+    firstRestateIdType,
+    await runAggregatedFactTableUpdate(context, factTable, firstRestateIdType, {
+      forceRestate,
+      awaitResults: true,
+      preAcquiredExecutionId: executionIds.get(firstRestateIdType),
+      sharedStaging: staging(true, restRestateIdTypes.length === 0),
+    }),
+  );
+
+  const stagingBuilt = outcomes.get(firstRestateIdType)?.status === "started";
+  if (!stagingBuilt) {
+    logger.warn(
+      `Shared-staging restate for ${factTable.id}: staging build failed; remaining idTypes fall back to raw restate`,
+    );
+  }
+
+  await Promise.all(
+    restRestateIdTypes.map(async (idType, i) => {
+      const isLast = i === restRestateIdTypes.length - 1;
+      outcomes.set(
+        idType,
+        await runAggregatedFactTableUpdate(context, factTable, idType, {
+          forceRestate,
+          awaitResults,
+          preAcquiredExecutionId: executionIds.get(idType),
+          sharedStaging: stagingBuilt ? staging(false, isLast) : undefined,
+        }),
+      );
+    }),
+  );
+
+  for (const idType of incrementalIdTypes) {
+    outcomes.set(
+      idType,
+      await runAggregatedFactTableUpdate(context, factTable, idType, {
+        forceRestate: false,
+        awaitResults,
+        preAcquiredExecutionId: executionIds.get(idType),
+      }),
+    );
+  }
+
+  return outcomes;
 }

--- a/packages/back-end/src/services/aggregatedFactTables.ts
+++ b/packages/back-end/src/services/aggregatedFactTables.ts
@@ -310,6 +310,8 @@ export function toAggregatedTableRunApiInterface(
 
 export type AggregatedFactTableUpdateOutcome =
   | { status: "started"; runId: string }
+  // awaitResults:true only — the runner ran to a terminal state.
+  | { status: "completed"; runId: string }
   | { status: "failed"; runId: string; error: string }
   | { status: "skipped"; reason: AggregatedTableRefreshSkipReason };
 
@@ -319,10 +321,7 @@ export function toAggregatedTableRefreshTriggerResult(
 ) {
   return {
     idType,
-    runId:
-      outcome.status === "started" || outcome.status === "failed"
-        ? outcome.runId
-        : null,
+    runId: outcome.status === "skipped" ? null : outcome.runId,
     status: outcome.status,
     reason: outcome.status === "skipped" ? outcome.reason : null,
     error: outcome.status === "failed" ? outcome.error : null,
@@ -509,31 +508,32 @@ export async function runAggregatedFactTableUpdate(
     return { status: "failed", runId: run.id, error };
   }
 
-  const waitForCompletion = async () => {
-    try {
-      await runner.waitForResults();
-      executionLogger.logUpdateCompleted(context, { status: "success" });
-      logger.debug(
-        `Updated aggregated fact table ${factTable.id}/${idType} (${mode})`,
-      );
-    } catch (e) {
-      await handleFailure(e);
-    }
-  };
+  const waitForCompletion =
+    async (): Promise<AggregatedFactTableUpdateOutcome> => {
+      try {
+        await runner.waitForResults();
+        executionLogger.logUpdateCompleted(context, { status: "success" });
+        logger.debug(
+          `Updated aggregated fact table ${factTable.id}/${idType} (${mode})`,
+        );
+        return { status: "completed", runId: run.id };
+      } catch (e) {
+        const error = await handleFailure(e);
+        return { status: "failed", runId: run.id, error };
+      }
+    };
 
   if (awaitResults) {
-    await waitForCompletion();
-  } else {
-    void waitForCompletion();
+    return waitForCompletion();
   }
-
+  void waitForCompletion();
   return { status: "started", runId: run.id };
 }
 
 // Acquire the per-idType lock for every listed idType, or none. Returns the
 // per-idType executionIds on success; on any failure, releases the locks it
 // took and returns null so the caller can fall back to the per-idType path.
-async function acquireAllAggregatedFactTableLocks(
+export async function acquireAllAggregatedFactTableLocks(
   context: ReqContext,
   datasourceId: string,
   factTableId: string,
@@ -640,121 +640,151 @@ export async function runAggregatedFactTableSharedStagingUpdate(
     return runPerIdTypeFallback();
   }
 
-  // Partition by resolved mode. Incrementals never touch staging.
-  const restateIdTypes: string[] = [];
-  const incrementalIdTypes: string[] = [];
-  for (const idType of idTypes) {
-    const registry = await context.models.aggregatedFactTables.getByKey({
-      datasourceId: datasource.id,
-      factTableId: factTable.id,
-      idType,
-    });
-    const restateReason = registry
-      ? getAggregatedFactTableRestateReason({
-          registry,
-          factTableSettingsHash,
-          metricState,
-        })
-      : null;
-    const mode: AggregatedFactTableRunMode =
-      forceRestate || !registry?.tableFullName || restateReason !== null
-        ? "restate"
-        : "incremental";
-    (mode === "restate" ? restateIdTypes : incrementalIdTypes).push(idType);
-  }
-
-  if (restateIdTypes.length < 2) {
-    // No shared-scan benefit; release the pre-acquired locks and fall back.
-    for (const [idType, executionId] of executionIds) {
+  // executionIds not yet handed to a runner. A handed-off runner owns its lock
+  // (releases it on success or in handleFailure); the finally below releases
+  // any that never got handed off if this coordinator throws.
+  const unhanded = new Map(executionIds);
+  const releaseUnhanded = async () => {
+    for (const [idType, executionId] of unhanded) {
       await context.models.aggregatedFactTables
         .releaseLock(
           { datasourceId: datasource.id, factTableId: factTable.id, idType },
           executionId,
         )
-        .catch(() => {});
+        .catch((e) =>
+          logger.error(
+            e,
+            `Failed to release unhanded aggregated fact table lock for ${factTable.id}/${idType}`,
+          ),
+        );
     }
-    return runPerIdTypeFallback();
-  }
+    unhanded.clear();
+  };
 
-  const sharedExecutionId = uniqid("aftshared_");
-  const stagingTableFullName = integration.generateTablePath(
-    `${AGGREGATED_FACT_TABLE_STAGING_PREFIX}_${factTable.id}_${sharedExecutionId}`,
-    pipelineSettings.writeDataset,
-    pipelineSettings.writeDatabase,
-    true,
-  );
+  try {
+    // Partition by resolved mode. Incrementals never touch staging.
+    const restateIdTypes: string[] = [];
+    const incrementalIdTypes: string[] = [];
+    for (const idType of idTypes) {
+      const registry = await context.models.aggregatedFactTables.getByKey({
+        datasourceId: datasource.id,
+        factTableId: factTable.id,
+        idType,
+      });
+      const restateReason = registry
+        ? getAggregatedFactTableRestateReason({
+            registry,
+            factTableSettingsHash,
+            metricState,
+          })
+        : null;
+      const mode: AggregatedFactTableRunMode =
+        forceRestate || !registry?.tableFullName || restateReason !== null
+          ? "restate"
+          : "incremental";
+      (mode === "restate" ? restateIdTypes : incrementalIdTypes).push(idType);
+    }
 
-  logger.info(
-    {
-      event: "aggregated_fact_table_shared_staging_started",
-      organization: context.org.id,
-      factTableId: factTable.id,
-      restateIdTypes,
-      incrementalIdTypes,
-      stagingTableFullName,
-    },
-    "Aggregated fact table shared-staging restate started",
-  );
+    if (restateIdTypes.length < 2) {
+      // No shared-scan benefit; release everything and fall back.
+      await releaseUnhanded();
+      return runPerIdTypeFallback();
+    }
 
-  // First restating idType's runner builds the staging table (staging queries
-  // are prepended so they show up in that idType's run history), then reads its
-  // own restate from it. Remaining restating idTypes wait for that runner to
-  // complete, then read staging concurrently. The last idType drops staging
-  // after its coverage query; the partition-expiration set at CREATE guarantees
-  // eventual cleanup regardless.
-  const [firstRestateIdType, ...restRestateIdTypes] = restateIdTypes;
-  const staging = (
-    buildStaging: boolean,
-    dropStagingOnComplete: boolean,
-  ): AggregatedFactTableSharedStaging => ({
-    stagingTableFullName,
-    allIdTypes: idTypes,
-    buildStaging,
-    dropStagingOnComplete,
-  });
-
-  outcomes.set(
-    firstRestateIdType,
-    await runAggregatedFactTableUpdate(context, factTable, firstRestateIdType, {
-      forceRestate,
-      awaitResults: true,
-      preAcquiredExecutionId: executionIds.get(firstRestateIdType),
-      sharedStaging: staging(true, restRestateIdTypes.length === 0),
-    }),
-  );
-
-  const stagingBuilt = outcomes.get(firstRestateIdType)?.status === "started";
-  if (!stagingBuilt) {
-    logger.warn(
-      `Shared-staging restate for ${factTable.id}: staging build failed; remaining idTypes fall back to raw restate`,
+    const sharedExecutionId = uniqid("aftshared_");
+    const stagingTableFullName = integration.generateTablePath(
+      `${AGGREGATED_FACT_TABLE_STAGING_PREFIX}_${factTable.id}_${sharedExecutionId}`,
+      pipelineSettings.writeDataset,
+      pipelineSettings.writeDatabase,
+      true,
     );
-  }
 
-  await Promise.all(
-    restRestateIdTypes.map(async (idType, i) => {
-      const isLast = i === restRestateIdTypes.length - 1;
+    logger.info(
+      {
+        event: "aggregated_fact_table_shared_staging_started",
+        organization: context.org.id,
+        factTableId: factTable.id,
+        restateIdTypes,
+        incrementalIdTypes,
+        stagingTableFullName,
+      },
+      "Aggregated fact table shared-staging restate started",
+    );
+
+    // First restating idType's runner builds the staging table (staging queries
+    // are prepended so they show up in that idType's run history), then reads its
+    // own restate from it. Remaining restating idTypes wait for that runner to
+    // complete, then read staging concurrently. The last idType drops staging
+    // after its coverage query; the partition-expiration set at CREATE guarantees
+    // eventual cleanup regardless.
+    const [firstRestateIdType, ...restRestateIdTypes] = restateIdTypes;
+    const staging = (
+      buildStaging: boolean,
+      dropStagingOnComplete: boolean,
+    ): AggregatedFactTableSharedStaging => ({
+      stagingTableFullName,
+      // Only restating idTypes read staging, so only their columns are projected.
+      allIdTypes: restateIdTypes,
+      buildStaging,
+      dropStagingOnComplete,
+    });
+
+    unhanded.delete(firstRestateIdType);
+    outcomes.set(
+      firstRestateIdType,
+      await runAggregatedFactTableUpdate(
+        context,
+        factTable,
+        firstRestateIdType,
+        {
+          forceRestate,
+          awaitResults: true,
+          preAcquiredExecutionId: executionIds.get(firstRestateIdType),
+          sharedStaging: staging(true, restRestateIdTypes.length === 0),
+        },
+      ),
+    );
+
+    // With awaitResults:true the outcome is terminal ("completed" or "failed");
+    // only proceed to read staging when the build actually completed.
+    const stagingBuilt =
+      outcomes.get(firstRestateIdType)?.status === "completed";
+    if (!stagingBuilt) {
+      logger.warn(
+        `Shared-staging restate for ${factTable.id}: staging build failed; remaining idTypes fall back to raw restate`,
+      );
+    }
+
+    await Promise.all(
+      restRestateIdTypes.map(async (idType, i) => {
+        const isLast = i === restRestateIdTypes.length - 1;
+        unhanded.delete(idType);
+        outcomes.set(
+          idType,
+          await runAggregatedFactTableUpdate(context, factTable, idType, {
+            forceRestate,
+            awaitResults,
+            preAcquiredExecutionId: executionIds.get(idType),
+            sharedStaging: stagingBuilt ? staging(false, isLast) : undefined,
+          }),
+        );
+      }),
+    );
+
+    for (const idType of incrementalIdTypes) {
+      unhanded.delete(idType);
       outcomes.set(
         idType,
         await runAggregatedFactTableUpdate(context, factTable, idType, {
-          forceRestate,
+          forceRestate: false,
           awaitResults,
           preAcquiredExecutionId: executionIds.get(idType),
-          sharedStaging: stagingBuilt ? staging(false, isLast) : undefined,
         }),
       );
-    }),
-  );
+    }
 
-  for (const idType of incrementalIdTypes) {
-    outcomes.set(
-      idType,
-      await runAggregatedFactTableUpdate(context, factTable, idType, {
-        forceRestate: false,
-        awaitResults,
-        preAcquiredExecutionId: executionIds.get(idType),
-      }),
-    );
+    return outcomes;
+  } finally {
+    await releaseUnhanded();
   }
-
-  return outcomes;
 }

--- a/packages/back-end/src/types/Integration.ts
+++ b/packages/back-end/src/types/Integration.ts
@@ -12,6 +12,8 @@ import {
   InsertAggregatedFactTableDataQueryParams,
   AggregatedFactTableMaxTimestampQueryParams,
   DropAggregatedFactTableQueryParams,
+  CreateAggregatedFactTableStagingQueryParams,
+  InsertAggregatedFactTableStagingDataQueryParams,
   DimensionSlicesQueryParams,
   DimensionSlicesQueryResponse,
   DropMetricSourceCovariateTableQueryParams,
@@ -186,6 +188,12 @@ export interface SourceIntegrationInterface {
   ): string;
   getDropAggregatedFactTableQuery(
     params: DropAggregatedFactTableQueryParams,
+  ): string;
+  getCreateAggregatedFactTableStagingQuery(
+    params: CreateAggregatedFactTableStagingQueryParams,
+  ): string;
+  getInsertAggregatedFactTableStagingDataQuery(
+    params: InsertAggregatedFactTableStagingDataQueryParams,
   ): string;
   getCreateMetricSourceCovariateTableQuery(
     params: CreateMetricSourceCovariateTableQueryParams,

--- a/packages/back-end/test/aggregatedFactTableStaging.test.ts
+++ b/packages/back-end/test/aggregatedFactTableStaging.test.ts
@@ -5,6 +5,11 @@ import {
 } from "back-end/src/integrations/sql/queries/aggregated-fact-table-staging-query";
 import { getInsertAggregatedFactTableDataQuery } from "back-end/src/integrations/sql/queries/insert-aggregated-fact-table-data-query";
 import { bigQueryDialect } from "back-end/src/integrations/dialects/bigquery";
+import { ReqContext } from "back-end/types/request";
+import {
+  AggregatedFactTableUpdateOutcome,
+  acquireAllAggregatedFactTableLocks,
+} from "back-end/src/services/aggregatedFactTables";
 import { factTableFactory } from "./factories/FactTable.factory";
 import { factMetricFactory } from "./factories/FactMetric.factory";
 
@@ -177,5 +182,76 @@ describe("getInsertAggregatedFactTableDataQuery with sourceTableFullName", () =>
         expect(readSql).toContain(col);
       }
     }
+  });
+});
+
+describe("acquireAllAggregatedFactTableLocks", () => {
+  const makeContext = (
+    acquireLock: jest.Mock,
+    releaseLock: jest.Mock,
+  ): ReqContext =>
+    ({
+      models: { aggregatedFactTables: { acquireLock, releaseLock } },
+    }) as unknown as ReqContext;
+
+  it("returns per-idType executionIds when every lock is acquired", async () => {
+    const acquireLock = jest.fn().mockResolvedValue(true);
+    const releaseLock = jest.fn().mockResolvedValue(undefined);
+    const result = await acquireAllAggregatedFactTableLocks(
+      makeContext(acquireLock, releaseLock),
+      "ds_1",
+      FT_ID,
+      ["id_a", "id_b", "id_c"],
+    );
+    expect(result).not.toBeNull();
+    expect(result?.size).toBe(3);
+    expect(acquireLock).toHaveBeenCalledTimes(3);
+    expect(releaseLock).not.toHaveBeenCalled();
+  });
+
+  it("releases every acquired lock and returns null when any acquire fails (all-or-nothing)", async () => {
+    const acquireLock = jest
+      .fn()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    const releaseLock = jest.fn().mockResolvedValue(undefined);
+    const result = await acquireAllAggregatedFactTableLocks(
+      makeContext(acquireLock, releaseLock),
+      "ds_1",
+      FT_ID,
+      ["id_a", "id_b", "id_c"],
+    );
+    expect(result).toBeNull();
+    // The two acquired locks are rolled back.
+    expect(releaseLock).toHaveBeenCalledTimes(2);
+    expect(releaseLock).toHaveBeenCalledWith(
+      { datasourceId: "ds_1", factTableId: FT_ID, idType: "id_a" },
+      expect.any(String),
+    );
+    expect(releaseLock).toHaveBeenCalledWith(
+      { datasourceId: "ds_1", factTableId: FT_ID, idType: "id_b" },
+      expect.any(String),
+    );
+  });
+});
+
+describe("AggregatedFactTableUpdateOutcome", () => {
+  // Compile-time check that the shared-staging coordinator's terminal
+  // discrimination ("completed" vs "failed") is expressible on the outcome
+  // type. If someone narrows the union back to just "started", this fails to
+  // typecheck.
+  it("distinguishes completed from failed for awaitResults callers", () => {
+    const completed: AggregatedFactTableUpdateOutcome = {
+      status: "completed",
+      runId: "r1",
+    };
+    const failed: AggregatedFactTableUpdateOutcome = {
+      status: "failed",
+      runId: "r1",
+      error: "boom",
+    };
+    expect(completed.status === "completed").toBe(true);
+    expect(failed.status === "completed").toBe(false);
   });
 });

--- a/packages/back-end/test/aggregatedFactTableStaging.test.ts
+++ b/packages/back-end/test/aggregatedFactTableStaging.test.ts
@@ -1,0 +1,181 @@
+import { getFactMetricCTE } from "back-end/src/integrations/sql/ctes/fact-metric-cte";
+import {
+  getAggregatedFactTableStagingColumns,
+  getInsertAggregatedFactTableStagingDataQuery,
+} from "back-end/src/integrations/sql/queries/aggregated-fact-table-staging-query";
+import { getInsertAggregatedFactTableDataQuery } from "back-end/src/integrations/sql/queries/insert-aggregated-fact-table-data-query";
+import { bigQueryDialect } from "back-end/src/integrations/dialects/bigquery";
+import { factTableFactory } from "./factories/FactTable.factory";
+import { factMetricFactory } from "./factories/FactMetric.factory";
+
+const FT_ID = "ft_test";
+const factTable = factTableFactory.build({
+  id: FT_ID,
+  userIdTypes: ["id_a", "id_b", "id_c"],
+  sql: "SELECT id_a, id_b, id_c, timestamp, amount, cnt FROM events",
+});
+const meanMetric = factMetricFactory.build({
+  id: "fm_1",
+  metricType: "mean",
+  numerator: { factTableId: FT_ID, column: "amount", aggregation: "sum" },
+});
+const ratioMetric = factMetricFactory.build({
+  id: "fm_2",
+  metricType: "ratio",
+  numerator: { factTableId: FT_ID, column: "amount", aggregation: "sum" },
+  denominator: { factTableId: FT_ID, column: "cnt", aggregation: "sum" },
+});
+const startDate = new Date("2024-01-01");
+const endDate = new Date("2024-02-01");
+
+describe("getFactMetricCTE with projectIdTypes", () => {
+  it("projects every listed idType column instead of only baseIdType", () => {
+    const cte = getFactMetricCTE(bigQueryDialect, {
+      metricsWithIndices: [{ metric: meanMetric, index: 0 }],
+      factTable,
+      baseIdType: "id_a",
+      idJoinMap: {},
+      startDate,
+      endDate,
+      projectIdTypes: ["id_a", "id_b", "id_c"],
+      castIdToString: true,
+    });
+    expect(cte).toContain("as id_a");
+    expect(cte).toContain("as id_b");
+    expect(cte).toContain("as id_c");
+    // Still projects the metric value column and wraps the fact-table SQL.
+    expect(cte).toContain("m0_value");
+    expect(cte).toMatch(/FROM\s+events/);
+  });
+
+  it("throws when a projected idType is not native to the fact table", () => {
+    expect(() =>
+      getFactMetricCTE(bigQueryDialect, {
+        metricsWithIndices: [{ metric: meanMetric, index: 0 }],
+        factTable,
+        baseIdType: "id_a",
+        idJoinMap: {},
+        startDate,
+        endDate,
+        projectIdTypes: ["id_a", "not_an_id_type"],
+      }),
+    ).toThrow(/is not native to fact table/);
+  });
+
+  it("is unchanged from single-id projection when projectIdTypes is unset", () => {
+    const cte = getFactMetricCTE(bigQueryDialect, {
+      metricsWithIndices: [{ metric: meanMetric, index: 0 }],
+      factTable,
+      baseIdType: "id_a",
+      idJoinMap: {},
+      startDate,
+      endDate,
+    });
+    expect(cte).toContain("as id_a");
+    expect(cte).not.toContain("as id_b");
+  });
+});
+
+describe("getAggregatedFactTableStagingColumns", () => {
+  it("emits idTypes + timestamp + per-metric value/denominator cols in stable order", () => {
+    // Ratio metric sorts before mean (fm_2 > fm_1 lexically, so mean is index 0).
+    const cols = getAggregatedFactTableStagingColumns({
+      idTypes: ["id_a", "id_b"],
+      metrics: [ratioMetric, meanMetric],
+      factTableId: FT_ID,
+    });
+    expect(cols).toEqual([
+      "id_a",
+      "id_b",
+      "timestamp",
+      "m0_value",
+      "m1_value",
+      "m1_denominator",
+    ]);
+  });
+});
+
+describe("getInsertAggregatedFactTableStagingDataQuery", () => {
+  it("wraps the fact-table SQL once with all idType columns projected", () => {
+    const sql = getInsertAggregatedFactTableStagingDataQuery(bigQueryDialect, {
+      stagingTableFullName: "proj.ds.gb_agg_staging_ft_test_aftshared_1",
+      factTable,
+      idTypes: ["id_a", "id_b", "id_c"],
+      metrics: [meanMetric],
+      windowStartDate: startDate,
+      windowEndDate: endDate,
+    });
+    expect(sql).toMatch(
+      /INSERT INTO\s+proj\.ds\.gb_agg_staging_ft_test_aftshared_1/,
+    );
+    expect(sql).toContain("id_a");
+    expect(sql).toContain("id_b");
+    expect(sql).toContain("id_c");
+    // The one and only source scan.
+    expect(sql).toMatch(/FROM\s+events/);
+  });
+});
+
+describe("getInsertAggregatedFactTableDataQuery with sourceTableFullName", () => {
+  const stagingTable = "proj.ds.gb_agg_staging_ft_test_aftshared_1";
+
+  it("reads the projected columns from the staging table instead of wrapping the fact-table SQL", () => {
+    const sql = getInsertAggregatedFactTableDataQuery(bigQueryDialect, {
+      factTable,
+      idType: "id_b",
+      metrics: [meanMetric, ratioMetric],
+      tableFullName: "proj.ds.gb_aggregated_ft_test_id_b",
+      windowStartDate: startDate,
+      windowEndDate: null,
+      exclusiveStart: false,
+      sourceTableFullName: stagingTable,
+    });
+    // Reads staging, not the raw source.
+    expect(sql).toContain(stagingTable);
+    expect(sql).not.toMatch(/FROM\s+events/);
+    // Projects only this idType from staging.
+    expect(sql).toContain("id_b");
+    expect(sql).not.toMatch(/SELECT[^(]*\bid_a\b/);
+    // Downstream GROUP BY / aggregation shape unchanged.
+    expect(sql).toContain("GROUP BY");
+    expect(sql).toContain("m0_value");
+  });
+
+  it("still wraps the fact-table SQL when sourceTableFullName is unset", () => {
+    const sql = getInsertAggregatedFactTableDataQuery(bigQueryDialect, {
+      factTable,
+      idType: "id_b",
+      metrics: [meanMetric],
+      tableFullName: "proj.ds.gb_aggregated_ft_test_id_b",
+      windowStartDate: startDate,
+      windowEndDate: null,
+      exclusiveStart: false,
+    });
+    expect(sql).toMatch(/FROM\s+events/);
+    expect(sql).not.toContain(stagingTable);
+  });
+
+  it("reuses the metric column alignment (index by sorted metric id) between staging build and read", () => {
+    const stagingCols = getAggregatedFactTableStagingColumns({
+      idTypes: ["id_a", "id_b"],
+      metrics: [ratioMetric, meanMetric],
+      factTableId: FT_ID,
+    });
+    const readSql = getInsertAggregatedFactTableDataQuery(bigQueryDialect, {
+      factTable,
+      idType: "id_a",
+      metrics: [ratioMetric, meanMetric],
+      tableFullName: "proj.ds.gb_aggregated_ft_test_id_a",
+      windowStartDate: startDate,
+      windowEndDate: null,
+      exclusiveStart: false,
+      sourceTableFullName: stagingTable,
+    });
+    // Every m{i}_* column the read projects must exist in the staging schema.
+    for (const col of stagingCols) {
+      if (col.startsWith("m")) {
+        expect(readSql).toContain(col);
+      }
+    }
+  });
+});

--- a/packages/shared/src/validators/aggregated-fact-table-run.ts
+++ b/packages/shared/src/validators/aggregated-fact-table-run.ts
@@ -47,6 +47,7 @@ export type AggregatedFactTableRunInterface = z.infer<
 
 export const aggregatedTableRefreshTriggerStatusValidator = z.enum([
   "started",
+  "completed",
   "failed",
   "skipped",
 ]);

--- a/packages/shared/src/validators/fact-table.ts
+++ b/packages/shared/src/validators/fact-table.ts
@@ -96,6 +96,12 @@ export const aggregatedFactTableSettingsValidator = z
     // per-stage write budget on wide fact tables. Unset = no chunking (a single
     // full-window INSERT).
     restateChunkDays: z.number().int().min(1).max(7).optional(),
+    // When set and ≥2 idTypes are restating together, materialize the fact-table
+    // SQL once to a short-lived staging table (all idType columns + per-metric
+    // value columns), then run each per-idType GROUP BY over the staging table
+    // instead of re-scanning the source. Cuts restate scan cost from N× to ~1×.
+    // Opt-in; incremental mode is unaffected.
+    useSharedStagingRestate: z.boolean().optional(),
   })
   .strict();
 

--- a/packages/shared/types/integrations.d.ts
+++ b/packages/shared/types/integrations.d.ts
@@ -456,6 +456,29 @@ export interface InsertAggregatedFactTableDataQueryParams {
   // of a chunked restate so chunks tile [windowStart, now) half-open; null for
   // incremental, the final restate chunk, and unchunked restates (open to "now").
   windowEndDate: Date | null;
+  // When set, read pre-projected event rows (all idType cols + m{i}_value cols)
+  // from this staging table instead of wrapping the fact-table SQL. Used by
+  // shared-staging restates so N per-idType inserts share one source scan.
+  sourceTableFullName?: string;
+}
+
+export interface CreateAggregatedFactTableStagingQueryParams {
+  stagingTableFullName: string;
+  factTable: FactTableInterface;
+  // All enabled idTypes to project as string columns.
+  idTypes: string[];
+  metrics: FactMetricInterface[];
+  // Auto-drop safeguard so an orphaned staging table doesn't linger.
+  expirationHours: number;
+}
+
+export interface InsertAggregatedFactTableStagingDataQueryParams {
+  stagingTableFullName: string;
+  factTable: FactTableInterface;
+  idTypes: string[];
+  metrics: FactMetricInterface[];
+  windowStartDate: Date;
+  windowEndDate: Date | null;
 }
 
 export interface AggregatedFactTableMaxTimestampQueryParams {


### PR DESCRIPTION
### Problem

A fact table with N enabled `idTypes` runs N independent restates. Each one wraps `factTable.sql` in its own `INSERT ... SELECT ... GROUP BY ${idType}, event_date` and re-scans the full `lookbackWindow` — identical source data, only the GROUP BY key differs. For a fact table with 3 idTypes and a 60-day lookback over a large event stream, that's 3× the source-scan cost every time all three restate together.

Follow-up to #6251 — that PR avoids **unnecessary** restates on schema-compatible SQL churn; this makes **necessary** restates cheaper.

### Fix

Opt-in via `aggregatedFactTableSettings.useSharedStagingRestate` (default `false`). When set and ≥2 idTypes need to restate together:

1. Materialize the fact-table CTE **once** to a short-lived staging table `gb_agg_staging_{ftId}_{sharedExecId}` — event-grain rows with **all** enabled idType columns + the per-metric `m{i}_value` / `m{i}_denominator` / `m{i}_n_events` columns. Partitioned on `timestamp`, chunked by `restateChunkDays` (same write-budget bounds as today), with a `partition_expiration_days` safeguard so an orphaned staging table auto-drops.
2. Each per-idType restate reads its `GROUP BY ${idType}, event_date` from the staging table instead of re-wrapping `factTable.sql`.
3. Last idType's runner drops staging after its coverage query (best-effort; auto-expiration is the guarantee).

The staging build is prepended to the **first** restating idType's runner (so its queries appear in that idType's run history — no new run-doc model). The coordinator awaits that runner, then dispatches the remaining restating idTypes concurrently over staging, then any incrementals.

Saves ~`(N-1)/N` of the restate source-scan cost — ~67% for a 3-idType fact table. Per-idType shuffle/write cost unchanged.

### Before / after

| Condition | Flag off (default) | Flag on |
| --- | --- | --- |
| Nightly incremental | N per-idType agenda jobs, N incremental runners | Unchanged (staging is restate-only) |
| ≥2 idTypes restating (schema drift, forced, first build) | N per-idType agenda jobs, **N full source scans** | 1 `updateAggregatedFactTableSet` agenda job, **1 source scan into staging** + N cheap GROUP BY reads |
| Exactly 1 idType restating | 1 source scan | Unchanged (falls through to per-idType; no staging benefit for 1) |
| Any idType lock unavailable | Per-idType, that idType skipped | All-or-nothing lock acquire fails → falls back to per-idType |
| Staging build fails | — | Remaining idTypes fall back to raw restate (each holds its pre-acquired lock) |

### Implementation notes

- `getFactMetricCTE` gains optional `projectIdTypes: string[]` to project multiple native idType columns instead of only `baseIdType`.
- `getInsertAggregatedFactTableDataQuery` gains optional `sourceTableFullName` — bypasses the fact-table SQL wrap and reads the `m{i}_*` projection from staging with the same timestamp bounds.
- New `aggregated-fact-table-staging-query.ts` builders (create + chunked insert). CREATE uses `AS SELECT ... WHERE FALSE` to derive column types from the CTE without a separate type table.
- `AggregatedFactTableQueryRunner` accepts `sharedStaging` — when `buildStaging`, prepends staging DROP/CREATE/chunked INSERTs and chains its own DROP on the last staging insert; when `dropStagingOnComplete`, appends a staging DROP after coverage.
- `runAggregatedFactTableSharedStagingUpdate` coordinator: acquires all N idType locks (all-or-nothing with rollback), partitions by resolved mode, sequences the staging build → concurrent readers → incrementals.
- Poller enqueues one `updateAggregatedFactTableSet` job per fact table when the flag is set (still claims every idType's daily slot for idempotency).

### Backwards compatibility

Fully additive — with `useSharedStagingRestate` unset (default), the poller enqueues per-idType jobs exactly as before, `sharedStaging` is never passed, and every existing code path is byte-identical. No registry-doc migration.

### Tests

New `aggregatedFactTableStaging.test.ts` (8 cases): `projectIdTypes` projection + native-only guard, staging column-set shape/stability, staging insert wraps source once with all idTypes, per-idType insert reads staging (not raw source) with the right column subset, `m{i}_*` alignment between staging build and read. Existing `aggregatedFactTable`, `aggregatedCovariateReadPath`, and `sqlintegration` suites pass (2353 total). Type-check clean on `back-end` + `shared`.

### Not in scope (follow-ups)

- Manual UI/API refresh trigger still per-idType — routing that through the shared coordinator is a small follow-up once the nightly path is validated.
- Mocked coordinator test for the N-lock all-or-nothing / mode-partition logic — the pure query builders are covered; end-to-end coordinator behaviour needs an integration harness with a mocked model layer.

cc @lukesonnet @ahdriel
