### PR TITLE
Results table styling cleanup (metric name/value + result cell colors)

### DIFF
--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -41,6 +41,7 @@ import { useExperimentDimensionRows } from "@/hooks/useExperimentDimensionRows";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import { useMetricDrilldownContext } from "@/components/MetricDrilldown/useMetricDrilldownContext";
 import Link from "@/ui/Link";
+import Text from "@/ui/Text";
 import UsersTable from "./UsersTable";
 
 export const includeVariation = (
@@ -248,10 +249,7 @@ const BreakDownResults: FC<{
       {tables.map((table, i) => {
         return (
           <Fragment key={table.metric.id + "_" + i}>
-            <h4
-              className="mt-2 mb-1 d-flex position-relative ml-2"
-              style={{ gap: 4 }}
-            >
+            <Text size="large" weight="semibold" color="text-high" ml="2">
               {table.rows[0]?.resultGroup === "goal"
                 ? "Goal Metric"
                 : table.rows[0]?.resultGroup === "secondary"
@@ -259,7 +257,7 @@ const BreakDownResults: FC<{
                   : table.rows[0]?.resultGroup === "guardrail"
                     ? "Guardrail Metric"
                     : null}
-            </h4>
+            </Text>
             <ResultsTable
               key={i}
               experimentId={experimentId}
@@ -287,7 +285,11 @@ const BreakDownResults: FC<{
                 ) : (
                   <div style={{ marginBottom: 2 }}>
                     {getRenderLabelColumn({})({
-                      label: table.metric.name,
+                      label: (
+                        <Text weight="semibold" color="text-high">
+                          {table.metric.name}
+                        </Text>
+                      ),
                       metric: table.metric,
                       row: table.rows[0],
                     })}
@@ -302,7 +304,7 @@ const BreakDownResults: FC<{
               setDifferenceType={setDifferenceType}
               renderLabelColumn={({ label }) => (
                 <div
-                  className="pl-3 font-weight-bold"
+                  className="pl-3"
                   style={{
                     display: "-webkit-box",
                     WebkitLineClamp: 1,
@@ -315,7 +317,9 @@ const BreakDownResults: FC<{
                     label === NULL_DIMENSION_VALUE ? (
                       <em>{formatDimensionValueForDisplay(label)}</em>
                     ) : (
-                      label
+                      <Text color="text-high" weight="medium">
+                        {label}
+                      </Text>
                     )
                   ) : (
                     <em>unknown</em>

--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactElement, useMemo, useState, useEffect, useRef } from "react";
-import { Flex, IconButton, Text } from "@radix-ui/themes";
+import { Box, Flex, IconButton, Text } from "@radix-ui/themes";
 import {
   ExperimentReportResultDimension,
   ExperimentReportVariation,
@@ -666,7 +666,7 @@ export function getRenderLabelColumn({
     // Render non-slice metric
     return (
       <>
-        <div>
+        <Box pl="4">
           <span
             className="ml-2"
             style={
@@ -774,7 +774,7 @@ export function getRenderLabelColumn({
               </Text>
             </span>
           </span>
-        </div>
+        </Box>
       </>
     );
   };

--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -666,7 +666,7 @@ export function getRenderLabelColumn({
     // Render non-slice metric
     return (
       <>
-        <div className="pl-3">
+        <div>
           <span
             className="ml-2"
             style={

--- a/packages/front-end/components/Experiment/MetricValueColumn.tsx
+++ b/packages/front-end/components/Experiment/MetricValueColumn.tsx
@@ -152,22 +152,20 @@ export default function MetricValueColumn({
           <div className="result-number">{overall}</div>
           {showRatio && numerator ? (
             <div className="result-number-sub text-muted">
-              <em>
-                <span
-                  style={{
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  {numerator}
-                </span>
-                {!quantileMetric ? (
-                  <>
-                    {" "}
-                    /&nbsp;
-                    {denominator}
-                  </>
-                ) : null}
-              </em>
+              <span
+                style={{
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {numerator}
+              </span>
+              {!quantileMetric ? (
+                <>
+                  {" "}
+                  /&nbsp;
+                  {denominator}
+                </>
+              ) : null}
             </div>
           ) : null}
         </>

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -795,24 +795,24 @@ pre {
     }
   }
   .won {
-    color: var(--jade-11);
-    font-weight: bold;
+    color: var(--green-11);
+    font-weight: var(--font-weight-medium);
 
     &.results-ctw,
     &.results-pval,
     &.results-mean {
-      color: var(--alert-success-color);
-      background: var(--jade-a3); //rgba(10, 159, 106, 0.19);
+      color: var(--color-text-mid);
+      background: var(--green-a3);
     }
   }
   .lost {
     color: var(--red-11); //#bb1f37;
-    font-weight: bold;
+    font-weight: var(--font-weight-medium);
 
     &.results-ctw,
     &.results-pval,
     &.results-mean {
-      color: var(--alert-danger-color);
+      color: var(--color-text-mid);
       background: var(--red-a3); //#ce372930;
     }
   }


### PR DESCRIPTION
Splits the standalone results-table styling changes out of #6106 so that PR can stay focused on the `VariationLabel`/`VariationNumber` components.

### Changes
- **Metric name labels** — `BreakDownResults.tsx` (Goal/Secondary/Guardrail headings + metric name styling) and `CompactResults.tsx` (metric name label padding).
- **Metric values** — `MetricValueColumn.tsx`: drop the italics around numerator/denominator.
- **Result cell colors** — `global.scss`: update `.won`/`.lost` styling (jade→green, alert colors→`--color-text-mid`, bold→medium weight).

These are independent of the `VariationLabel` component work, so they land cleanly on their own branch off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)