### PR TITLE
fix(ramp-schedules): run scheduled snapshots for monitored ramps so they auto-advance

### DIFF
--- a/packages/back-end/src/jobs/addSafeRolloutSnapshotJob.ts
+++ b/packages/back-end/src/jobs/addSafeRolloutSnapshotJob.ts
@@ -4,7 +4,7 @@ import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizatio
 import { logger } from "back-end/src/util/logger";
 import { getCollection } from "back-end/src/util/mongo.util";
 import { getFeature } from "back-end/src/models/FeatureModel";
-import { getSafeRolloutRuleFromFeature } from "back-end/src/routers/safe-rollout/safe-rollout.helper";
+import { shouldSkipScheduledSafeRolloutSnapshot } from "back-end/src/routers/safe-rollout/safe-rollout.helper";
 import { createSafeRolloutSnapshot } from "back-end/src/services/safeRolloutSnapshots";
 import { COLLECTION_NAME } from "back-end/src/models/SafeRolloutModel";
 
@@ -70,8 +70,7 @@ const updateSingleSafeRolloutSnapshot = async (
   const feature = await getFeature(context, featureId);
   if (!feature || feature.archived) return;
 
-  const safeRolloutRule = getSafeRolloutRuleFromFeature(feature, id, true);
-  if (!safeRolloutRule || !safeRolloutRule.enabled) return;
+  if (shouldSkipScheduledSafeRolloutSnapshot(feature, safeRollout)) return;
 
   try {
     const latestSnapshot =

--- a/packages/back-end/src/routers/safe-rollout/safe-rollout.helper.ts
+++ b/packages/back-end/src/routers/safe-rollout/safe-rollout.helper.ts
@@ -1,4 +1,8 @@
-import { FeatureInterface, SafeRolloutRule } from "shared/validators";
+import {
+  FeatureInterface,
+  SafeRolloutInterface,
+  SafeRolloutRule,
+} from "shared/validators";
 import { getRulesForEnvironment } from "shared/util";
 
 export function getSafeRolloutRuleFromFeature(
@@ -25,4 +29,14 @@ export function getSafeRolloutRuleFromFeature(
     }
   }
   return null;
+}
+
+export function shouldSkipScheduledSafeRolloutSnapshot(
+  feature: FeatureInterface,
+  safeRollout: Pick<SafeRolloutInterface, "id" | "rampScheduleId">,
+): boolean {
+  if (safeRollout.rampScheduleId) return false;
+
+  const rule = getSafeRolloutRuleFromFeature(feature, safeRollout.id, true);
+  return !rule || !rule.enabled;
 }

--- a/packages/back-end/test/routers/safe-rollout.helper.test.ts
+++ b/packages/back-end/test/routers/safe-rollout.helper.test.ts
@@ -1,0 +1,114 @@
+import { FeatureInterface } from "shared/types/feature";
+import {
+  getSafeRolloutRuleFromFeature,
+  shouldSkipScheduledSafeRolloutSnapshot,
+} from "back-end/src/routers/safe-rollout/safe-rollout.helper";
+
+function makeFeature(overrides?: Partial<FeatureInterface>): FeatureInterface {
+  return {
+    id: "feat_test",
+    project: "",
+    dateCreated: new Date(),
+    dateUpdated: new Date(),
+    defaultValue: "false",
+    organization: "org-1",
+    owner: "",
+    valueType: "boolean",
+    archived: false,
+    description: "",
+    version: 1,
+    environmentSettings: {
+      production: { enabled: true },
+    },
+    rules: [],
+    ...overrides,
+  } as FeatureInterface;
+}
+
+const rampRolloutRule = {
+  type: "rollout",
+  id: "rule_ramp",
+  description: "",
+  enabled: true,
+  value: "true",
+  coverage: 0.25,
+  hashAttribute: "id",
+  seed: "seed",
+  allEnvironments: true,
+};
+
+function classicSafeRolloutRule(enabled: boolean) {
+  return {
+    type: "safe-rollout",
+    id: "rule_sr",
+    description: "",
+    enabled,
+    safeRolloutId: "sr_1",
+    controlValue: "false",
+    variationValue: "true",
+    status: "running",
+    hashAttribute: "id",
+    seed: "seed",
+    trackingKey: "tk",
+    allEnvironments: true,
+  };
+}
+
+describe("getSafeRolloutRuleFromFeature", () => {
+  it("returns null for a ramp-monitored feature (no safe-rollout rule)", () => {
+    const feature = makeFeature({ rules: [rampRolloutRule] as never });
+    expect(getSafeRolloutRuleFromFeature(feature, "sr_1")).toBeNull();
+  });
+
+  it("returns the matching safe-rollout rule for a classic rollout", () => {
+    const feature = makeFeature({
+      rules: [classicSafeRolloutRule(true)] as never,
+    });
+    expect(getSafeRolloutRuleFromFeature(feature, "sr_1")?.id).toBe("rule_sr");
+  });
+
+  it("skips rules in disabled environments when asked", () => {
+    const feature = makeFeature({
+      environmentSettings: { production: { enabled: false } } as never,
+      rules: [classicSafeRolloutRule(true)] as never,
+    });
+    expect(getSafeRolloutRuleFromFeature(feature, "sr_1", true)).toBeNull();
+  });
+});
+
+describe("shouldSkipScheduledSafeRolloutSnapshot", () => {
+  it("does not skip a ramp-linked rollout even with no safe-rollout rule", () => {
+    const feature = makeFeature({ rules: [rampRolloutRule] as never });
+    expect(
+      shouldSkipScheduledSafeRolloutSnapshot(feature, {
+        id: "sr_1",
+        rampScheduleId: "rs_1",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not skip a classic rollout with an enabled safe-rollout rule", () => {
+    const feature = makeFeature({
+      rules: [classicSafeRolloutRule(true)] as never,
+    });
+    expect(
+      shouldSkipScheduledSafeRolloutSnapshot(feature, { id: "sr_1" }),
+    ).toBe(false);
+  });
+
+  it("skips a classic rollout whose safe-rollout rule is disabled", () => {
+    const feature = makeFeature({
+      rules: [classicSafeRolloutRule(false)] as never,
+    });
+    expect(
+      shouldSkipScheduledSafeRolloutSnapshot(feature, { id: "sr_1" }),
+    ).toBe(true);
+  });
+
+  it("skips a classic rollout whose safe-rollout rule is missing", () => {
+    const feature = makeFeature({ rules: [rampRolloutRule] as never });
+    expect(
+      shouldSkipScheduledSafeRolloutSnapshot(feature, { id: "sr_1" }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
### Features and Changes

Monitored ramps (ramp-up schedules with monitoring) never auto-advanced. A monitored ramp relies on its linked SafeRollout snapshot being refreshed on the configured cadence, and the ramp advance job only advances once a fresh snapshot exists. The scheduled snapshot job silently skipped monitored ramps, so no fresh snapshot ever arrived and the ramp held forever. Manual and API refresh worked, because they create the snapshot directly and bypass the job.

The cause is a guard in the shared SafeRollout snapshot job (`addSafeRolloutSnapshotJob`). It bailed for any SafeRollout without a matching `safe-rollout` feature rule. A monitored ramp uses a shadow SafeRollout that has no such rule, since its tracking key lives on the SafeRollout entity itself, so every scheduled refresh was dropped. The guard was correct for classic Safe Rollouts and was never updated when monitored ramps started reusing this job.

The fix scopes the feature-rule guard to classic Safe Rollouts. Ramp-linked SafeRollouts (identified by `rampScheduleId`) are no longer skipped. Their refresh eligibility is already governed by the `getAllSafeRolloutsToUpdate` query filter (`autoSnapshots` plus running status), kept in sync by `syncLinkedSafeRolloutForRampState`. The decision is extracted into a small pure predicate, `shouldSkipScheduledSafeRolloutSnapshot`.

### Testing

Unit tests for `shouldSkipScheduledSafeRolloutSnapshot` and `getSafeRolloutRuleFromFeature`, covering the ramp-linked path and the classic paths (enabled rule, disabled rule, missing rule, rule in a disabled environment).
