### PR TITLE
Default feature review sub-tab to Changes when revision is in review

### DIFF
--- a/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
+++ b/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
@@ -546,15 +546,24 @@ export default function ReviewAndPublish({
 
   // ── Sub-tabs ──
   // "Overview" (human-readable changes + review activity) vs "Changes" (JSON
-  // diffs + full timeline). Reflected in the URL hash as `#review` /
-  // `#review,changes` so the view is deep-linkable; a bare `#review` reads as
-  // Overview.
+  // diffs + full timeline). Reflected in the URL hash as `#review,overview` /
+  // `#review,changes` so the view is deep-linkable. With no explicit sub-tab in
+  // the URL, a revision in review defaults to Changes so reviewers land on the
+  // diff; otherwise Conversation. (Mirrors the generic Review & Publish tab.)
   const [urlHash, setUrlHash] = useURLHash();
+  const subTabHash = urlHash?.split(",")[1];
   const subTab: ReviewSubTab =
-    urlHash?.split(",")[1] === "changes" ? "changes" : "overview";
+    subTabHash === "changes"
+      ? "changes"
+      : subTabHash === "overview"
+        ? "overview"
+        : revision?.status === "pending-review" ||
+            revision?.status === "changes-requested"
+          ? "changes"
+          : "overview";
   const setSubTab = useCallback(
     (t: ReviewSubTab) => {
-      setUrlHash(t === "changes" ? "review,changes" : "review");
+      setUrlHash(t === "changes" ? "review,changes" : "review,overview");
     },
     [setUrlHash],
   );


### PR DESCRIPTION
### Features and Changes

When opening the Review & Publish view for a feature revision that is in review (`pending-review` or `changes-requested`), the sub-tab now defaults to **Changes** instead of **Conversation**, so reviewers land directly on the diff. Explicit deep-links (`#review,changes` / `#review,overview`) still take precedence, and selecting Conversation now writes `#review,overview` so the choice sticks. This matches the existing default-tab behavior of the generic (Saved Groups / Constants) Review & Publish tab.

- Closes **(add link to issue here)**

### Dependencies

None

### Testing

- Open a feature whose draft revision is in `pending-review` or `changes-requested` → the Review & Publish view opens on the **Changes** sub-tab.
- Revisions in other states (draft, approved, published, discarded) still open on **Conversation**, and `#review,changes` / `#review,overview` deep-links override the default in both cases.

### Screenshots

N/A — changes only which existing sub-tab is selected by default; no visual changes.
