### PR TITLE
Add computed column support

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "front-end",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "front-end", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -20514,6 +20514,73 @@ paths:
                                         - type
                                         - value
                                       additionalProperties: false
+                              operations:
+                                type: array
+                                items:
+                                  anyOf:
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: replace
+                                        find:
+                                          type: string
+                                        replaceWith:
+                                          type: string
+                                      required:
+                                        - type
+                                        - find
+                                        - replaceWith
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: regexpReplace
+                                        pattern:
+                                          type: string
+                                        replaceWith:
+                                          type: string
+                                      required:
+                                        - type
+                                        - pattern
+                                        - replaceWith
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: regexpExtract
+                                        pattern:
+                                          type: string
+                                      required:
+                                        - type
+                                        - pattern
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: upper
+                                      required:
+                                        - type
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: lower
+                                      required:
+                                        - type
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: trim
+                                      required:
+                                        - type
+                                      additionalProperties: false
                             required:
                               - id
                               - name
@@ -20734,6 +20801,73 @@ paths:
                                       required:
                                         - type
                                         - value
+                                      additionalProperties: false
+                              operations:
+                                type: array
+                                items:
+                                  anyOf:
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: replace
+                                        find:
+                                          type: string
+                                        replaceWith:
+                                          type: string
+                                      required:
+                                        - type
+                                        - find
+                                        - replaceWith
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: regexpReplace
+                                        pattern:
+                                          type: string
+                                        replaceWith:
+                                          type: string
+                                      required:
+                                        - type
+                                        - pattern
+                                        - replaceWith
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: regexpExtract
+                                        pattern:
+                                          type: string
+                                      required:
+                                        - type
+                                        - pattern
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: upper
+                                      required:
+                                        - type
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: lower
+                                      required:
+                                        - type
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: trim
+                                      required:
+                                        - type
                                       additionalProperties: false
                             required:
                               - id
@@ -21291,6 +21425,73 @@ paths:
                                         - type
                                         - value
                                       additionalProperties: false
+                              operations:
+                                type: array
+                                items:
+                                  anyOf:
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: replace
+                                        find:
+                                          type: string
+                                        replaceWith:
+                                          type: string
+                                      required:
+                                        - type
+                                        - find
+                                        - replaceWith
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: regexpReplace
+                                        pattern:
+                                          type: string
+                                        replaceWith:
+                                          type: string
+                                      required:
+                                        - type
+                                        - pattern
+                                        - replaceWith
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: regexpExtract
+                                        pattern:
+                                          type: string
+                                      required:
+                                        - type
+                                        - pattern
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: upper
+                                      required:
+                                        - type
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: lower
+                                      required:
+                                        - type
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: trim
+                                      required:
+                                        - type
+                                      additionalProperties: false
                             required:
                               - id
                               - name
@@ -21511,6 +21712,73 @@ paths:
                                       required:
                                         - type
                                         - value
+                                      additionalProperties: false
+                              operations:
+                                type: array
+                                items:
+                                  anyOf:
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: replace
+                                        find:
+                                          type: string
+                                        replaceWith:
+                                          type: string
+                                      required:
+                                        - type
+                                        - find
+                                        - replaceWith
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: regexpReplace
+                                        pattern:
+                                          type: string
+                                        replaceWith:
+                                          type: string
+                                      required:
+                                        - type
+                                        - pattern
+                                        - replaceWith
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: regexpExtract
+                                        pattern:
+                                          type: string
+                                      required:
+                                        - type
+                                        - pattern
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: upper
+                                      required:
+                                        - type
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: lower
+                                      required:
+                                        - type
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: trim
+                                      required:
+                                        - type
                                       additionalProperties: false
                             required:
                               - id
@@ -43322,6 +43590,73 @@ components:
                                 - type
                                 - value
                               additionalProperties: false
+                      operations:
+                        type: array
+                        items:
+                          anyOf:
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  const: replace
+                                find:
+                                  type: string
+                                replaceWith:
+                                  type: string
+                              required:
+                                - type
+                                - find
+                                - replaceWith
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  const: regexpReplace
+                                pattern:
+                                  type: string
+                                replaceWith:
+                                  type: string
+                              required:
+                                - type
+                                - pattern
+                                - replaceWith
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  const: regexpExtract
+                                pattern:
+                                  type: string
+                              required:
+                                - type
+                                - pattern
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  const: upper
+                              required:
+                                - type
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  const: lower
+                              required:
+                                - type
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  const: trim
+                              required:
+                                - type
+                              additionalProperties: false
                     required:
                       - id
                       - name
@@ -43519,6 +43854,73 @@ components:
                               required:
                                 - type
                                 - value
+                              additionalProperties: false
+                      operations:
+                        type: array
+                        items:
+                          anyOf:
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  const: replace
+                                find:
+                                  type: string
+                                replaceWith:
+                                  type: string
+                              required:
+                                - type
+                                - find
+                                - replaceWith
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  const: regexpReplace
+                                pattern:
+                                  type: string
+                                replaceWith:
+                                  type: string
+                              required:
+                                - type
+                                - pattern
+                                - replaceWith
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  const: regexpExtract
+                                pattern:
+                                  type: string
+                              required:
+                                - type
+                                - pattern
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  const: upper
+                              required:
+                                - type
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  const: lower
+                              required:
+                                - type
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  const: trim
+                              required:
+                                - type
                               additionalProperties: false
                     required:
                       - id

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -20417,57 +20417,42 @@ paths:
                               kind:
                                 type: string
                                 const: number
-                              terms:
+                              operands:
                                 minItems: 1
                                 type: array
                                 items:
-                                  type: object
-                                  properties:
-                                    operands:
-                                      minItems: 1
-                                      type: array
-                                      items:
-                                        anyOf:
-                                          - type: object
-                                            properties:
-                                              type:
-                                                type: string
-                                                const: column
-                                              column:
-                                                type: string
-                                            required:
-                                              - type
-                                              - column
-                                            additionalProperties: false
-                                          - type: object
-                                            properties:
-                                              type:
-                                                type: string
-                                                const: literal
-                                              value:
-                                                type: number
-                                            required:
-                                              - type
-                                              - value
-                                            additionalProperties: false
-                                    operators:
-                                      type: array
-                                      items:
-                                        type: string
-                                        enum:
-                                          - '*'
-                                          - /
-                                  required:
-                                    - operands
-                                    - operators
-                                  additionalProperties: false
-                              termOperators:
+                                  anyOf:
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: column
+                                        column:
+                                          type: string
+                                      required:
+                                        - type
+                                        - column
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: literal
+                                        value:
+                                          type: number
+                                      required:
+                                        - type
+                                        - value
+                                      additionalProperties: false
+                              operators:
                                 type: array
                                 items:
                                   type: string
                                   enum:
                                     - +
                                     - '-'
+                                    - '*'
+                                    - /
                               coalesceZero:
                                 type: boolean
                               rounding:
@@ -20490,8 +20475,8 @@ paths:
                               - id
                               - name
                               - kind
-                              - terms
-                              - termOperators
+                              - operands
+                              - operators
                             additionalProperties: false
                           - type: object
                             properties:
@@ -20653,57 +20638,42 @@ paths:
                               kind:
                                 type: string
                                 const: number
-                              terms:
+                              operands:
                                 minItems: 1
                                 type: array
                                 items:
-                                  type: object
-                                  properties:
-                                    operands:
-                                      minItems: 1
-                                      type: array
-                                      items:
-                                        anyOf:
-                                          - type: object
-                                            properties:
-                                              type:
-                                                type: string
-                                                const: column
-                                              column:
-                                                type: string
-                                            required:
-                                              - type
-                                              - column
-                                            additionalProperties: false
-                                          - type: object
-                                            properties:
-                                              type:
-                                                type: string
-                                                const: literal
-                                              value:
-                                                type: number
-                                            required:
-                                              - type
-                                              - value
-                                            additionalProperties: false
-                                    operators:
-                                      type: array
-                                      items:
-                                        type: string
-                                        enum:
-                                          - '*'
-                                          - /
-                                  required:
-                                    - operands
-                                    - operators
-                                  additionalProperties: false
-                              termOperators:
+                                  anyOf:
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: column
+                                        column:
+                                          type: string
+                                      required:
+                                        - type
+                                        - column
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: literal
+                                        value:
+                                          type: number
+                                      required:
+                                        - type
+                                        - value
+                                      additionalProperties: false
+                              operators:
                                 type: array
                                 items:
                                   type: string
                                   enum:
                                     - +
                                     - '-'
+                                    - '*'
+                                    - /
                               coalesceZero:
                                 type: boolean
                               rounding:
@@ -20726,8 +20696,8 @@ paths:
                               - id
                               - name
                               - kind
-                              - terms
-                              - termOperators
+                              - operands
+                              - operators
                             additionalProperties: false
                           - type: object
                             properties:
@@ -21224,57 +21194,42 @@ paths:
                               kind:
                                 type: string
                                 const: number
-                              terms:
+                              operands:
                                 minItems: 1
                                 type: array
                                 items:
-                                  type: object
-                                  properties:
-                                    operands:
-                                      minItems: 1
-                                      type: array
-                                      items:
-                                        anyOf:
-                                          - type: object
-                                            properties:
-                                              type:
-                                                type: string
-                                                const: column
-                                              column:
-                                                type: string
-                                            required:
-                                              - type
-                                              - column
-                                            additionalProperties: false
-                                          - type: object
-                                            properties:
-                                              type:
-                                                type: string
-                                                const: literal
-                                              value:
-                                                type: number
-                                            required:
-                                              - type
-                                              - value
-                                            additionalProperties: false
-                                    operators:
-                                      type: array
-                                      items:
-                                        type: string
-                                        enum:
-                                          - '*'
-                                          - /
-                                  required:
-                                    - operands
-                                    - operators
-                                  additionalProperties: false
-                              termOperators:
+                                  anyOf:
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: column
+                                        column:
+                                          type: string
+                                      required:
+                                        - type
+                                        - column
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: literal
+                                        value:
+                                          type: number
+                                      required:
+                                        - type
+                                        - value
+                                      additionalProperties: false
+                              operators:
                                 type: array
                                 items:
                                   type: string
                                   enum:
                                     - +
                                     - '-'
+                                    - '*'
+                                    - /
                               coalesceZero:
                                 type: boolean
                               rounding:
@@ -21297,8 +21252,8 @@ paths:
                               - id
                               - name
                               - kind
-                              - terms
-                              - termOperators
+                              - operands
+                              - operators
                             additionalProperties: false
                           - type: object
                             properties:
@@ -21460,57 +21415,42 @@ paths:
                               kind:
                                 type: string
                                 const: number
-                              terms:
+                              operands:
                                 minItems: 1
                                 type: array
                                 items:
-                                  type: object
-                                  properties:
-                                    operands:
-                                      minItems: 1
-                                      type: array
-                                      items:
-                                        anyOf:
-                                          - type: object
-                                            properties:
-                                              type:
-                                                type: string
-                                                const: column
-                                              column:
-                                                type: string
-                                            required:
-                                              - type
-                                              - column
-                                            additionalProperties: false
-                                          - type: object
-                                            properties:
-                                              type:
-                                                type: string
-                                                const: literal
-                                              value:
-                                                type: number
-                                            required:
-                                              - type
-                                              - value
-                                            additionalProperties: false
-                                    operators:
-                                      type: array
-                                      items:
-                                        type: string
-                                        enum:
-                                          - '*'
-                                          - /
-                                  required:
-                                    - operands
-                                    - operators
-                                  additionalProperties: false
-                              termOperators:
+                                  anyOf:
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: column
+                                        column:
+                                          type: string
+                                      required:
+                                        - type
+                                        - column
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: literal
+                                        value:
+                                          type: number
+                                      required:
+                                        - type
+                                        - value
+                                      additionalProperties: false
+                              operators:
                                 type: array
                                 items:
                                   type: string
                                   enum:
                                     - +
                                     - '-'
+                                    - '*'
+                                    - /
                               coalesceZero:
                                 type: boolean
                               rounding:
@@ -21533,8 +21473,8 @@ paths:
                               - id
                               - name
                               - kind
-                              - terms
-                              - termOperators
+                              - operands
+                              - operators
                             additionalProperties: false
                           - type: object
                             properties:
@@ -43285,57 +43225,42 @@ components:
                       kind:
                         type: string
                         const: number
-                      terms:
+                      operands:
                         minItems: 1
                         type: array
                         items:
-                          type: object
-                          properties:
-                            operands:
-                              minItems: 1
-                              type: array
-                              items:
-                                anyOf:
-                                  - type: object
-                                    properties:
-                                      type:
-                                        type: string
-                                        const: column
-                                      column:
-                                        type: string
-                                    required:
-                                      - type
-                                      - column
-                                    additionalProperties: false
-                                  - type: object
-                                    properties:
-                                      type:
-                                        type: string
-                                        const: literal
-                                      value:
-                                        type: number
-                                    required:
-                                      - type
-                                      - value
-                                    additionalProperties: false
-                            operators:
-                              type: array
-                              items:
-                                type: string
-                                enum:
-                                  - '*'
-                                  - /
-                          required:
-                            - operands
-                            - operators
-                          additionalProperties: false
-                      termOperators:
+                          anyOf:
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  const: column
+                                column:
+                                  type: string
+                              required:
+                                - type
+                                - column
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  const: literal
+                                value:
+                                  type: number
+                              required:
+                                - type
+                                - value
+                              additionalProperties: false
+                      operators:
                         type: array
                         items:
                           type: string
                           enum:
                             - +
                             - '-'
+                            - '*'
+                            - /
                       coalesceZero:
                         type: boolean
                       rounding:
@@ -43358,8 +43283,8 @@ components:
                       - id
                       - name
                       - kind
-                      - terms
-                      - termOperators
+                      - operands
+                      - operators
                     additionalProperties: false
                   - type: object
                     properties:
@@ -43498,57 +43423,42 @@ components:
                       kind:
                         type: string
                         const: number
-                      terms:
+                      operands:
                         minItems: 1
                         type: array
                         items:
-                          type: object
-                          properties:
-                            operands:
-                              minItems: 1
-                              type: array
-                              items:
-                                anyOf:
-                                  - type: object
-                                    properties:
-                                      type:
-                                        type: string
-                                        const: column
-                                      column:
-                                        type: string
-                                    required:
-                                      - type
-                                      - column
-                                    additionalProperties: false
-                                  - type: object
-                                    properties:
-                                      type:
-                                        type: string
-                                        const: literal
-                                      value:
-                                        type: number
-                                    required:
-                                      - type
-                                      - value
-                                    additionalProperties: false
-                            operators:
-                              type: array
-                              items:
-                                type: string
-                                enum:
-                                  - '*'
-                                  - /
-                          required:
-                            - operands
-                            - operators
-                          additionalProperties: false
-                      termOperators:
+                          anyOf:
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  const: column
+                                column:
+                                  type: string
+                              required:
+                                - type
+                                - column
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  const: literal
+                                value:
+                                  type: number
+                              required:
+                                - type
+                                - value
+                              additionalProperties: false
+                      operators:
                         type: array
                         items:
                           type: string
                           enum:
                             - +
                             - '-'
+                            - '*'
+                            - /
                       coalesceZero:
                         type: boolean
                       rounding:
@@ -43571,8 +43481,8 @@ components:
                       - id
                       - name
                       - kind
-                      - terms
-                      - termOperators
+                      - operands
+                      - operators
                     additionalProperties: false
                   - type: object
                     properties:

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -20397,6 +20397,144 @@ paths:
                         aggregation (e.g. '= 10' or '>= 1'). Requires
                         `aggregateFilterColumn`.
                       type: string
+                    computedColumns:
+                      description: >-
+                        Metric-scoped computed (derived) columns. A numeric
+                        computed column is a sum-of-products of columns and
+                        numeric literals; a string computed column concatenates
+                        parts. Reference one from `column`,
+                        `aggregateFilterColumn`, or a row filter's `column`
+                        using the marker `$$computed:<id>`.
+                      type: array
+                      items:
+                        anyOf:
+                          - type: object
+                            properties:
+                              id:
+                                type: string
+                              name:
+                                type: string
+                              kind:
+                                type: string
+                                const: number
+                              terms:
+                                minItems: 1
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    operands:
+                                      minItems: 1
+                                      type: array
+                                      items:
+                                        anyOf:
+                                          - type: object
+                                            properties:
+                                              type:
+                                                type: string
+                                                const: column
+                                              column:
+                                                type: string
+                                            required:
+                                              - type
+                                              - column
+                                            additionalProperties: false
+                                          - type: object
+                                            properties:
+                                              type:
+                                                type: string
+                                                const: literal
+                                              value:
+                                                type: number
+                                            required:
+                                              - type
+                                              - value
+                                            additionalProperties: false
+                                    operators:
+                                      type: array
+                                      items:
+                                        type: string
+                                        enum:
+                                          - '*'
+                                          - /
+                                  required:
+                                    - operands
+                                    - operators
+                                  additionalProperties: false
+                              termOperators:
+                                type: array
+                                items:
+                                  type: string
+                                  enum:
+                                    - +
+                                    - '-'
+                              coalesceZero:
+                                type: boolean
+                              rounding:
+                                type: object
+                                properties:
+                                  mode:
+                                    type: string
+                                    enum:
+                                      - round
+                                      - floor
+                                      - ceil
+                                  decimals:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 10
+                                required:
+                                  - mode
+                                additionalProperties: false
+                            required:
+                              - id
+                              - name
+                              - kind
+                              - terms
+                              - termOperators
+                            additionalProperties: false
+                          - type: object
+                            properties:
+                              id:
+                                type: string
+                              name:
+                                type: string
+                              kind:
+                                type: string
+                                const: string
+                              parts:
+                                minItems: 1
+                                type: array
+                                items:
+                                  anyOf:
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: column
+                                        column:
+                                          type: string
+                                      required:
+                                        - type
+                                        - column
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: literal
+                                        value:
+                                          type: string
+                                      required:
+                                        - type
+                                        - value
+                                      additionalProperties: false
+                            required:
+                              - id
+                              - name
+                              - kind
+                              - parts
+                            additionalProperties: false
                   required:
                     - factTableId
                   additionalProperties: false
@@ -20495,6 +20633,144 @@ paths:
                         required:
                           - operator
                         additionalProperties: false
+                    computedColumns:
+                      description: >-
+                        Metric-scoped computed (derived) columns. A numeric
+                        computed column is a sum-of-products of columns and
+                        numeric literals; a string computed column concatenates
+                        parts. Reference one from `column`,
+                        `aggregateFilterColumn`, or a row filter's `column`
+                        using the marker `$$computed:<id>`.
+                      type: array
+                      items:
+                        anyOf:
+                          - type: object
+                            properties:
+                              id:
+                                type: string
+                              name:
+                                type: string
+                              kind:
+                                type: string
+                                const: number
+                              terms:
+                                minItems: 1
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    operands:
+                                      minItems: 1
+                                      type: array
+                                      items:
+                                        anyOf:
+                                          - type: object
+                                            properties:
+                                              type:
+                                                type: string
+                                                const: column
+                                              column:
+                                                type: string
+                                            required:
+                                              - type
+                                              - column
+                                            additionalProperties: false
+                                          - type: object
+                                            properties:
+                                              type:
+                                                type: string
+                                                const: literal
+                                              value:
+                                                type: number
+                                            required:
+                                              - type
+                                              - value
+                                            additionalProperties: false
+                                    operators:
+                                      type: array
+                                      items:
+                                        type: string
+                                        enum:
+                                          - '*'
+                                          - /
+                                  required:
+                                    - operands
+                                    - operators
+                                  additionalProperties: false
+                              termOperators:
+                                type: array
+                                items:
+                                  type: string
+                                  enum:
+                                    - +
+                                    - '-'
+                              coalesceZero:
+                                type: boolean
+                              rounding:
+                                type: object
+                                properties:
+                                  mode:
+                                    type: string
+                                    enum:
+                                      - round
+                                      - floor
+                                      - ceil
+                                  decimals:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 10
+                                required:
+                                  - mode
+                                additionalProperties: false
+                            required:
+                              - id
+                              - name
+                              - kind
+                              - terms
+                              - termOperators
+                            additionalProperties: false
+                          - type: object
+                            properties:
+                              id:
+                                type: string
+                              name:
+                                type: string
+                              kind:
+                                type: string
+                                const: string
+                              parts:
+                                minItems: 1
+                                type: array
+                                items:
+                                  anyOf:
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: column
+                                        column:
+                                          type: string
+                                      required:
+                                        - type
+                                        - column
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: literal
+                                        value:
+                                          type: string
+                                      required:
+                                        - type
+                                        - value
+                                      additionalProperties: false
+                            required:
+                              - id
+                              - name
+                              - kind
+                              - parts
+                            additionalProperties: false
                   required:
                     - factTableId
                     - column
@@ -20928,6 +21204,144 @@ paths:
                         aggregation (e.g. '= 10' or '>= 1'). Requires
                         `aggregateFilterColumn`.
                       type: string
+                    computedColumns:
+                      description: >-
+                        Metric-scoped computed (derived) columns. A numeric
+                        computed column is a sum-of-products of columns and
+                        numeric literals; a string computed column concatenates
+                        parts. Reference one from `column`,
+                        `aggregateFilterColumn`, or a row filter's `column`
+                        using the marker `$$computed:<id>`.
+                      type: array
+                      items:
+                        anyOf:
+                          - type: object
+                            properties:
+                              id:
+                                type: string
+                              name:
+                                type: string
+                              kind:
+                                type: string
+                                const: number
+                              terms:
+                                minItems: 1
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    operands:
+                                      minItems: 1
+                                      type: array
+                                      items:
+                                        anyOf:
+                                          - type: object
+                                            properties:
+                                              type:
+                                                type: string
+                                                const: column
+                                              column:
+                                                type: string
+                                            required:
+                                              - type
+                                              - column
+                                            additionalProperties: false
+                                          - type: object
+                                            properties:
+                                              type:
+                                                type: string
+                                                const: literal
+                                              value:
+                                                type: number
+                                            required:
+                                              - type
+                                              - value
+                                            additionalProperties: false
+                                    operators:
+                                      type: array
+                                      items:
+                                        type: string
+                                        enum:
+                                          - '*'
+                                          - /
+                                  required:
+                                    - operands
+                                    - operators
+                                  additionalProperties: false
+                              termOperators:
+                                type: array
+                                items:
+                                  type: string
+                                  enum:
+                                    - +
+                                    - '-'
+                              coalesceZero:
+                                type: boolean
+                              rounding:
+                                type: object
+                                properties:
+                                  mode:
+                                    type: string
+                                    enum:
+                                      - round
+                                      - floor
+                                      - ceil
+                                  decimals:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 10
+                                required:
+                                  - mode
+                                additionalProperties: false
+                            required:
+                              - id
+                              - name
+                              - kind
+                              - terms
+                              - termOperators
+                            additionalProperties: false
+                          - type: object
+                            properties:
+                              id:
+                                type: string
+                              name:
+                                type: string
+                              kind:
+                                type: string
+                                const: string
+                              parts:
+                                minItems: 1
+                                type: array
+                                items:
+                                  anyOf:
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: column
+                                        column:
+                                          type: string
+                                      required:
+                                        - type
+                                        - column
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: literal
+                                        value:
+                                          type: string
+                                      required:
+                                        - type
+                                        - value
+                                      additionalProperties: false
+                            required:
+                              - id
+                              - name
+                              - kind
+                              - parts
+                            additionalProperties: false
                   required:
                     - factTableId
                   additionalProperties: false
@@ -21026,6 +21440,144 @@ paths:
                         required:
                           - operator
                         additionalProperties: false
+                    computedColumns:
+                      description: >-
+                        Metric-scoped computed (derived) columns. A numeric
+                        computed column is a sum-of-products of columns and
+                        numeric literals; a string computed column concatenates
+                        parts. Reference one from `column`,
+                        `aggregateFilterColumn`, or a row filter's `column`
+                        using the marker `$$computed:<id>`.
+                      type: array
+                      items:
+                        anyOf:
+                          - type: object
+                            properties:
+                              id:
+                                type: string
+                              name:
+                                type: string
+                              kind:
+                                type: string
+                                const: number
+                              terms:
+                                minItems: 1
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    operands:
+                                      minItems: 1
+                                      type: array
+                                      items:
+                                        anyOf:
+                                          - type: object
+                                            properties:
+                                              type:
+                                                type: string
+                                                const: column
+                                              column:
+                                                type: string
+                                            required:
+                                              - type
+                                              - column
+                                            additionalProperties: false
+                                          - type: object
+                                            properties:
+                                              type:
+                                                type: string
+                                                const: literal
+                                              value:
+                                                type: number
+                                            required:
+                                              - type
+                                              - value
+                                            additionalProperties: false
+                                    operators:
+                                      type: array
+                                      items:
+                                        type: string
+                                        enum:
+                                          - '*'
+                                          - /
+                                  required:
+                                    - operands
+                                    - operators
+                                  additionalProperties: false
+                              termOperators:
+                                type: array
+                                items:
+                                  type: string
+                                  enum:
+                                    - +
+                                    - '-'
+                              coalesceZero:
+                                type: boolean
+                              rounding:
+                                type: object
+                                properties:
+                                  mode:
+                                    type: string
+                                    enum:
+                                      - round
+                                      - floor
+                                      - ceil
+                                  decimals:
+                                    type: integer
+                                    minimum: 0
+                                    maximum: 10
+                                required:
+                                  - mode
+                                additionalProperties: false
+                            required:
+                              - id
+                              - name
+                              - kind
+                              - terms
+                              - termOperators
+                            additionalProperties: false
+                          - type: object
+                            properties:
+                              id:
+                                type: string
+                              name:
+                                type: string
+                              kind:
+                                type: string
+                                const: string
+                              parts:
+                                minItems: 1
+                                type: array
+                                items:
+                                  anyOf:
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: column
+                                        column:
+                                          type: string
+                                      required:
+                                        - type
+                                        - column
+                                      additionalProperties: false
+                                    - type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                          const: literal
+                                        value:
+                                          type: string
+                                      required:
+                                        - type
+                                        - value
+                                      additionalProperties: false
+                            required:
+                              - id
+                              - name
+                              - kind
+                              - parts
+                            additionalProperties: false
                   required:
                     - factTableId
                     - column
@@ -42714,6 +43266,143 @@ components:
                 Simple comparison operator and value to apply after aggregation
                 (e.g. '= 10' or '>= 1'). Requires `aggregateFilterColumn`.
               type: string
+            computedColumns:
+              description: >-
+                Metric-scoped computed (derived) columns. A numeric computed
+                column is a sum-of-products of columns and numeric literals; a
+                string computed column concatenates parts. Reference one from
+                `column`, `aggregateFilterColumn`, or a row filter's `column`
+                using the marker `$$computed:<id>`.
+              type: array
+              items:
+                anyOf:
+                  - type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      kind:
+                        type: string
+                        const: number
+                      terms:
+                        minItems: 1
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            operands:
+                              minItems: 1
+                              type: array
+                              items:
+                                anyOf:
+                                  - type: object
+                                    properties:
+                                      type:
+                                        type: string
+                                        const: column
+                                      column:
+                                        type: string
+                                    required:
+                                      - type
+                                      - column
+                                    additionalProperties: false
+                                  - type: object
+                                    properties:
+                                      type:
+                                        type: string
+                                        const: literal
+                                      value:
+                                        type: number
+                                    required:
+                                      - type
+                                      - value
+                                    additionalProperties: false
+                            operators:
+                              type: array
+                              items:
+                                type: string
+                                enum:
+                                  - '*'
+                                  - /
+                          required:
+                            - operands
+                            - operators
+                          additionalProperties: false
+                      termOperators:
+                        type: array
+                        items:
+                          type: string
+                          enum:
+                            - +
+                            - '-'
+                      coalesceZero:
+                        type: boolean
+                      rounding:
+                        type: object
+                        properties:
+                          mode:
+                            type: string
+                            enum:
+                              - round
+                              - floor
+                              - ceil
+                          decimals:
+                            type: integer
+                            minimum: 0
+                            maximum: 10
+                        required:
+                          - mode
+                        additionalProperties: false
+                    required:
+                      - id
+                      - name
+                      - kind
+                      - terms
+                      - termOperators
+                    additionalProperties: false
+                  - type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      kind:
+                        type: string
+                        const: string
+                      parts:
+                        minItems: 1
+                        type: array
+                        items:
+                          anyOf:
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  const: column
+                                column:
+                                  type: string
+                              required:
+                                - type
+                                - column
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  const: literal
+                                value:
+                                  type: string
+                              required:
+                                - type
+                                - value
+                              additionalProperties: false
+                    required:
+                      - id
+                      - name
+                      - kind
+                      - parts
+                    additionalProperties: false
           required:
             - factTableId
             - column
@@ -42790,6 +43479,143 @@ components:
                 required:
                   - operator
                 additionalProperties: false
+            computedColumns:
+              description: >-
+                Metric-scoped computed (derived) columns. A numeric computed
+                column is a sum-of-products of columns and numeric literals; a
+                string computed column concatenates parts. Reference one from
+                `column`, `aggregateFilterColumn`, or a row filter's `column`
+                using the marker `$$computed:<id>`.
+              type: array
+              items:
+                anyOf:
+                  - type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      kind:
+                        type: string
+                        const: number
+                      terms:
+                        minItems: 1
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            operands:
+                              minItems: 1
+                              type: array
+                              items:
+                                anyOf:
+                                  - type: object
+                                    properties:
+                                      type:
+                                        type: string
+                                        const: column
+                                      column:
+                                        type: string
+                                    required:
+                                      - type
+                                      - column
+                                    additionalProperties: false
+                                  - type: object
+                                    properties:
+                                      type:
+                                        type: string
+                                        const: literal
+                                      value:
+                                        type: number
+                                    required:
+                                      - type
+                                      - value
+                                    additionalProperties: false
+                            operators:
+                              type: array
+                              items:
+                                type: string
+                                enum:
+                                  - '*'
+                                  - /
+                          required:
+                            - operands
+                            - operators
+                          additionalProperties: false
+                      termOperators:
+                        type: array
+                        items:
+                          type: string
+                          enum:
+                            - +
+                            - '-'
+                      coalesceZero:
+                        type: boolean
+                      rounding:
+                        type: object
+                        properties:
+                          mode:
+                            type: string
+                            enum:
+                              - round
+                              - floor
+                              - ceil
+                          decimals:
+                            type: integer
+                            minimum: 0
+                            maximum: 10
+                        required:
+                          - mode
+                        additionalProperties: false
+                    required:
+                      - id
+                      - name
+                      - kind
+                      - terms
+                      - termOperators
+                    additionalProperties: false
+                  - type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      kind:
+                        type: string
+                        const: string
+                      parts:
+                        minItems: 1
+                        type: array
+                        items:
+                          anyOf:
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  const: column
+                                column:
+                                  type: string
+                              required:
+                                - type
+                                - column
+                              additionalProperties: false
+                            - type: object
+                              properties:
+                                type:
+                                  type: string
+                                  const: literal
+                                value:
+                                  type: string
+                              required:
+                                - type
+                                - value
+                              additionalProperties: false
+                    required:
+                      - id
+                      - name
+                      - kind
+                      - parts
+                    additionalProperties: false
           required:
             - factTableId
             - column

--- a/packages/back-end/src/integrations/dialects/athena.ts
+++ b/packages/back-end/src/integrations/dialects/athena.ts
@@ -4,6 +4,9 @@ import { baseDialect } from "./base";
 
 export const athenaDialect: SqlDialect = {
   ...baseDialect,
+  // Trino/Presto uses regexp_extract (no REGEXP_SUBSTR).
+  regexpExtract: (expr: string, pattern: string) =>
+    `regexp_extract(${expr}, ${pattern})`,
   formatDialect: "trino",
   toTimestamp: (date: Date) =>
     `from_iso8601_timestamp('${date.toISOString()}')`,

--- a/packages/back-end/src/integrations/dialects/base.ts
+++ b/packages/back-end/src/integrations/dialects/base.ts
@@ -150,6 +150,23 @@ export const baseDialect: Omit<SqlDialect, "unpivotLabeledPairs"> = {
 
   stringLength: (column: string) => `LENGTH(${column})`,
 
+  round: (
+    expr: string,
+    mode: "round" | "floor" | "ceil",
+    decimals?: number,
+  ) => {
+    const d = decimals ?? 0;
+    if (mode === "round") return `ROUND(${expr}, ${d})`;
+    const fn = mode === "floor" ? "FLOOR" : "CEIL";
+    if (d > 0) {
+      const factor = Math.pow(10, d);
+      return `${fn}((${expr}) * ${factor}) / ${factor}`;
+    }
+    return `${fn}(${expr})`;
+  },
+
+  concat: (parts: string[]) => `CONCAT(${parts.join(", ")})`,
+
   arrayElement: (arrayCol: string, index: number) =>
     `${arrayCol}[${index + 1}]`,
 };

--- a/packages/back-end/src/integrations/dialects/base.ts
+++ b/packages/back-end/src/integrations/dialects/base.ts
@@ -167,6 +167,20 @@ export const baseDialect: Omit<SqlDialect, "unpivotLabeledPairs"> = {
 
   concat: (parts: string[]) => `CONCAT(${parts.join(", ")})`,
 
+  // String operations for computed columns. `find`/`pattern`/`replaceWith` are
+  // already-quoted SQL string literals.
+  replace: (expr: string, find: string, replaceWith: string) =>
+    `REPLACE(${expr}, ${find}, ${replaceWith})`,
+  // Most warehouses' REGEXP_REPLACE replaces all matches by default; Postgres
+  // is the exception and overrides this to add a `'g'` flag.
+  regexpReplace: (expr: string, pattern: string, replaceWith: string) =>
+    `REGEXP_REPLACE(${expr}, ${pattern}, ${replaceWith})`,
+  regexpExtract: (expr: string, pattern: string) =>
+    `REGEXP_SUBSTR(${expr}, ${pattern})`,
+  upper: (expr: string) => `UPPER(${expr})`,
+  lower: (expr: string) => `LOWER(${expr})`,
+  trim: (expr: string) => `TRIM(${expr})`,
+
   arrayElement: (arrayCol: string, index: number) =>
     `${arrayCol}[${index + 1}]`,
 };

--- a/packages/back-end/src/integrations/dialects/bigquery.ts
+++ b/packages/back-end/src/integrations/dialects/bigquery.ts
@@ -108,6 +108,9 @@ const bigQueryEscapeStringLiteral = (value: string) =>
 
 export const bigQueryDialect: SqlDialect = {
   ...baseDialect,
+  // BigQuery uses REGEXP_EXTRACT (no REGEXP_SUBSTR).
+  regexpExtract: (expr: string, pattern: string) =>
+    `REGEXP_EXTRACT(${expr}, ${pattern})`,
   formatDialect: "bigquery",
   addTime: (
     col: string,

--- a/packages/back-end/src/integrations/dialects/clickhouse.ts
+++ b/packages/back-end/src/integrations/dialects/clickhouse.ts
@@ -110,6 +110,24 @@ if(
   // than JS .length but fine for the document-size guard.
   stringLength: (column: string) => `length(${column})`,
 
+  // ClickHouse math/string functions are lowercase.
+  round: (
+    expr: string,
+    mode: "round" | "floor" | "ceil",
+    decimals?: number,
+  ) => {
+    const d = decimals ?? 0;
+    if (mode === "round") return `round(${expr}, ${d})`;
+    const fn = mode === "floor" ? "floor" : "ceil";
+    if (d > 0) {
+      const factor = Math.pow(10, d);
+      return `${fn}((${expr}) * ${factor}) / ${factor}`;
+    }
+    return `${fn}(${expr})`;
+  },
+
+  concat: (parts: string[]) => `concat(${parts.join(", ")})`,
+
   // topK(k)(expr) returns the k most frequent values in descending-frequency
   // order with NO counts. Since the outer query sorts by `count DESC`, we
   // synthesize a `count` from the inverse array position (`limit - i + 1`) to

--- a/packages/back-end/src/integrations/dialects/clickhouse.ts
+++ b/packages/back-end/src/integrations/dialects/clickhouse.ts
@@ -128,6 +128,17 @@ if(
 
   concat: (parts: string[]) => `concat(${parts.join(", ")})`,
 
+  // ClickHouse string functions are lowercase and use different names.
+  replace: (expr: string, find: string, replaceWith: string) =>
+    `replaceAll(${expr}, ${find}, ${replaceWith})`,
+  regexpReplace: (expr: string, pattern: string, replaceWith: string) =>
+    `replaceRegexpAll(${expr}, ${pattern}, ${replaceWith})`,
+  regexpExtract: (expr: string, pattern: string) =>
+    `extract(${expr}, ${pattern})`,
+  upper: (expr: string) => `upper(${expr})`,
+  lower: (expr: string) => `lower(${expr})`,
+  trim: (expr: string) => `trimBoth(${expr})`,
+
   // topK(k)(expr) returns the k most frequent values in descending-frequency
   // order with NO counts. Since the outer query sorts by `count DESC`, we
   // synthesize a `count` from the inverse array position (`limit - i + 1`) to

--- a/packages/back-end/src/integrations/dialects/databricks.ts
+++ b/packages/back-end/src/integrations/dialects/databricks.ts
@@ -13,6 +13,9 @@ const databricksEscapeStringLiteral = (value: string) =>
 
 export const databricksDialect: SqlDialect = {
   ...baseDialect,
+  // Spark's regexp_extract requires a capture-group index; 0 = the whole match.
+  regexpExtract: (expr: string, pattern: string) =>
+    `regexp_extract(${expr}, ${pattern}, 0)`,
   formatDialect: "spark",
   toTimestamp: (date: Date) => `TIMESTAMP'${date.toISOString()}'`,
   addTime: (

--- a/packages/back-end/src/integrations/dialects/mssql.ts
+++ b/packages/back-end/src/integrations/dialects/mssql.ts
@@ -52,6 +52,22 @@ export const mssqlDialect: SqlDialect = {
 
   stringLength: (column: string) => `LEN(${column})`,
 
+  // SQL Server uses CEILING, not CEIL.
+  round: (
+    expr: string,
+    mode: "round" | "floor" | "ceil",
+    decimals?: number,
+  ) => {
+    const d = decimals ?? 0;
+    if (mode === "round") return `ROUND(${expr}, ${d})`;
+    const fn = mode === "floor" ? "FLOOR" : "CEILING";
+    if (d > 0) {
+      const factor = Math.pow(10, d);
+      return `${fn}((${expr}) * ${factor}) / ${factor}`;
+    }
+    return `${fn}(${expr})`;
+  },
+
   arrayElement: (arrayCol: string, index: number) =>
     mssqlDialect.castToFloat(`JSON_VALUE(${arrayCol}, '$[${index}]')`),
 

--- a/packages/back-end/src/integrations/dialects/postgres.ts
+++ b/packages/back-end/src/integrations/dialects/postgres.ts
@@ -40,6 +40,14 @@ export const postgresDialect: SqlDialect = {
     }
     return `${fn}(${expr})`;
   },
+  // Postgres REGEXP_REPLACE replaces only the first match unless the `'g'` flag
+  // is passed.
+  regexpReplace: (expr: string, pattern: string, replaceWith: string) =>
+    `REGEXP_REPLACE(${expr}, ${pattern}, ${replaceWith}, 'g')`,
+  // Postgres has no REGEXP_SUBSTR before v15; `substring(x from 'pat')` returns
+  // the first match and works everywhere.
+  regexpExtract: (expr: string, pattern: string) =>
+    `SUBSTRING(${expr} FROM ${pattern})`,
   percentileCapSelectClause: (values, metricTable, where = "") =>
     defaultPercentileCapSelectClause(
       postgresDialect,

--- a/packages/back-end/src/integrations/dialects/postgres.ts
+++ b/packages/back-end/src/integrations/dialects/postgres.ts
@@ -25,6 +25,21 @@ export const postgresDialect: SqlDialect = {
   },
   percentileApprox: (column: string, percentile: number | string) =>
     `PERCENTILE_CONT(${percentile}) WITHIN GROUP (ORDER BY ${column})`,
+  // Postgres has no ROUND(double precision, int); cast to numeric first.
+  round: (
+    expr: string,
+    mode: "round" | "floor" | "ceil",
+    decimals?: number,
+  ) => {
+    const d = decimals ?? 0;
+    if (mode === "round") return `ROUND(CAST(${expr} AS numeric), ${d})`;
+    const fn = mode === "floor" ? "FLOOR" : "CEIL";
+    if (d > 0) {
+      const factor = Math.pow(10, d);
+      return `${fn}((${expr}) * ${factor}) / ${factor}`;
+    }
+    return `${fn}(${expr})`;
+  },
   percentileCapSelectClause: (values, metricTable, where = "") =>
     defaultPercentileCapSelectClause(
       postgresDialect,

--- a/packages/back-end/src/integrations/dialects/presto.ts
+++ b/packages/back-end/src/integrations/dialects/presto.ts
@@ -8,6 +8,9 @@ import { baseDialect } from "./base";
 
 export const prestoDialect: SqlDialect = {
   ...baseDialect,
+  // Trino/Presto uses regexp_extract (no REGEXP_SUBSTR).
+  regexpExtract: (expr: string, pattern: string) =>
+    `regexp_extract(${expr}, ${pattern})`,
   formatDialect: "trino",
   toTimestamp: (date: Date) =>
     `from_iso8601_timestamp('${date.toISOString()}')`,

--- a/packages/back-end/src/integrations/dialects/redshift.ts
+++ b/packages/back-end/src/integrations/dialects/redshift.ts
@@ -60,4 +60,8 @@ export const redshiftDialect: SqlDialect = {
 
   arrayElement: (arrayCol: string, index: number) =>
     redshiftDialect.castToFloat(`${arrayCol}[${index}]`),
+
+  // Redshift's CONCAT only accepts two arguments; use the || operator instead.
+  concat: (parts: string[]) =>
+    parts.length === 1 ? parts[0] : `(${parts.join(" || ")})`,
 };

--- a/packages/back-end/src/integrations/sql/columns/fact-metric-column.ts
+++ b/packages/back-end/src/integrations/sql/columns/fact-metric-column.ts
@@ -1,7 +1,7 @@
 import {
   getAggregateFilters,
-  getColumnExpression,
   isBinomialMetric,
+  resolveColumnExpression,
 } from "shared/experiments";
 import type {
   ColumnRef,
@@ -39,13 +39,19 @@ export function getFactMetricColumn(
       : column === "$$distinctDates"
         ? dialect.dateTrunc(timestampColumn, "day")
         : factTable && column
-          ? getColumnExpression(
+          ? resolveColumnExpression({
               column,
               factTable,
-              (jsonCol: string, path: string, isNumeric: boolean): string =>
-                dialect.jsonExtract(jsonCol, path, isNumeric),
+              computedColumns: columnRef?.computedColumns,
+              jsonExtract: (
+                jsonCol: string,
+                path: string,
+                isNumeric: boolean,
+              ): string => dialect.jsonExtract(jsonCol, path, isNumeric),
+              escapeStringLiteral: dialect.escapeStringLiteral,
+              dialect: { round: dialect.round, concat: dialect.concat },
               alias,
-            )
+            })
           : `${alias}.${column}`;
 
   return {

--- a/packages/back-end/src/integrations/sql/columns/fact-metric-column.ts
+++ b/packages/back-end/src/integrations/sql/columns/fact-metric-column.ts
@@ -2,6 +2,7 @@ import {
   getAggregateFilters,
   isBinomialMetric,
   resolveColumnExpression,
+  computedColumnDialectFromSql,
 } from "shared/experiments";
 import type {
   ColumnRef,
@@ -49,7 +50,7 @@ export function getFactMetricColumn(
                 isNumeric: boolean,
               ): string => dialect.jsonExtract(jsonCol, path, isNumeric),
               escapeStringLiteral: dialect.escapeStringLiteral,
-              dialect: { round: dialect.round, concat: dialect.concat },
+              dialect: computedColumnDialectFromSql(dialect),
               alias,
             })
           : `${alias}.${column}`;

--- a/packages/back-end/src/integrations/sql/ctes/fact-metric-cte.ts
+++ b/packages/back-end/src/integrations/sql/ctes/fact-metric-cte.ts
@@ -3,6 +3,7 @@ import {
   getFactTableTemplateVariables,
   isRatioMetric,
   parseSliceMetricId,
+  computedColumnDialectFromSql,
 } from "shared/experiments";
 import { buildMinimalOrCondition } from "shared/sql";
 import type { PhaseSQLVar, SqlDialect } from "shared/types/sql";
@@ -117,7 +118,7 @@ export function getFactMetricCTE(
         jsonExtract: dialect.jsonExtract,
         evalBoolean: dialect.evalBoolean,
         sliceInfo,
-        dialect: { round: dialect.round, concat: dialect.concat },
+        dialect: computedColumnDialectFromSql(dialect),
       });
 
       const column =
@@ -176,7 +177,7 @@ export function getFactMetricCTE(
         jsonExtract: dialect.jsonExtract,
         evalBoolean: dialect.evalBoolean,
         sliceInfo,
-        dialect: { round: dialect.round, concat: dialect.concat },
+        dialect: computedColumnDialectFromSql(dialect),
       });
       const column =
         filters.length > 0

--- a/packages/back-end/src/integrations/sql/ctes/fact-metric-cte.ts
+++ b/packages/back-end/src/integrations/sql/ctes/fact-metric-cte.ts
@@ -117,6 +117,7 @@ export function getFactMetricCTE(
         jsonExtract: dialect.jsonExtract,
         evalBoolean: dialect.evalBoolean,
         sliceInfo,
+        dialect: { round: dialect.round, concat: dialect.concat },
       });
 
       const column =
@@ -175,6 +176,7 @@ export function getFactMetricCTE(
         jsonExtract: dialect.jsonExtract,
         evalBoolean: dialect.evalBoolean,
         sliceInfo,
+        dialect: { round: dialect.round, concat: dialect.concat },
       });
       const column =
         filters.length > 0

--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -10,6 +10,7 @@ import {
   isComputedColumnRef,
   getComputedColumnRef,
   findComputedColumn,
+  dataSourceSupportsRegexp,
 } from "shared/experiments";
 import { UpdateProps } from "shared/types/base-model";
 import { factMetricValidator, ApiFactMetric } from "shared/validators";
@@ -153,10 +154,13 @@ function validateComputedColumns({
   columnRef,
   factTable,
   errorPrefix,
+  supportsRegexp,
 }: {
   columnRef: ColumnRef;
   factTable: FactTableInterface;
   errorPrefix: string;
+  // Whether the datasource can run REGEXP_REPLACE / REGEXP_SUBSTR.
+  supportsRegexp: boolean;
 }): void {
   const computedColumns = columnRef.computedColumns || [];
 
@@ -230,6 +234,16 @@ function validateComputedColumns({
       for (const part of cc.parts) {
         if (part.type === "column") {
           validateColumnRef(cc, part.column, "string");
+        }
+      }
+      // Regexp operations aren't supported on every warehouse (e.g. MSSQL).
+      if (!supportsRegexp) {
+        for (const op of cc.operations || []) {
+          if (op.type === "regexpReplace" || op.type === "regexpExtract") {
+            throw new Error(
+              `${errorPrefix}Computed column '${cc.name}' uses a regular-expression operation, which this datasource does not support.`,
+            );
+          }
         }
       }
     }
@@ -499,6 +513,11 @@ export class FactMetricModel extends BaseClass {
       throw new Error("Could not find numerator fact table");
     }
 
+    // Used to gate regexp-based computed-column operations, which not every
+    // warehouse supports.
+    const datasource = await getDataSourceById(this.context, data.datasource);
+    const supportsRegexp = dataSourceSupportsRegexp(datasource?.type);
+
     validateSavedFilterIds({
       columnRef: data.numerator,
       factTable: numeratorFactTable,
@@ -509,6 +528,7 @@ export class FactMetricModel extends BaseClass {
       columnRef: data.numerator,
       factTable: numeratorFactTable,
       errorPrefix: "Numerator misspecified. ",
+      supportsRegexp,
     });
 
     // Validate aggregation/datatype constraints (runs for every code path
@@ -580,6 +600,7 @@ export class FactMetricModel extends BaseClass {
         columnRef: data.denominator,
         factTable: denominatorFactTable,
         errorPrefix: "Denominator misspecified. ",
+        supportsRegexp,
       });
 
       validateAggregationSpecification({

--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -7,11 +7,14 @@ import {
 import {
   getAggregateFilters,
   getSelectedColumnDatatype,
+  isComputedColumnRef,
+  getComputedColumnRef,
 } from "shared/experiments";
 import { UpdateProps } from "shared/types/base-model";
 import { factMetricValidator, ApiFactMetric } from "shared/validators";
 import {
   ColumnRef,
+  ComputedColumn,
   FactMetricInterface,
   FactMetricType,
   FactTableInterface,
@@ -85,6 +88,7 @@ function validateUserFilter({
     const columnType = getSelectedColumnDatatype({
       factTable,
       column: numerator.aggregateFilterColumn,
+      computedColumns: numerator.computedColumns,
     });
     if (
       !(
@@ -138,6 +142,117 @@ function validateSavedFilterIds({
     ) {
       throw new Error(`Invalid ${filterType} filter id: ${filterId}`);
     }
+  }
+}
+
+// Validate the metric-scoped computed columns on a ColumnRef: unique ids/names,
+// well-formed operator arrays, operand columns that exist with the right
+// datatype, and that every `$$computed:<id>` reference resolves.
+function validateComputedColumns({
+  columnRef,
+  factTable,
+  errorPrefix,
+}: {
+  columnRef: ColumnRef;
+  factTable: FactTableInterface;
+  errorPrefix: string;
+}): void {
+  const computedColumns = columnRef.computedColumns || [];
+
+  const seenIds = new Set<string>();
+  const seenNames = new Set<string>();
+
+  const isNumericColumn = (col: string) =>
+    getSelectedColumnDatatype({ factTable, column: col }) === "number";
+  const isStringColumn = (col: string) =>
+    getSelectedColumnDatatype({ factTable, column: col }) === "string";
+
+  for (const cc of computedColumns) {
+    if (!cc.name.trim()) {
+      throw new Error(`${errorPrefix}Computed column name is required.`);
+    }
+    if (seenIds.has(cc.id)) {
+      throw new Error(`${errorPrefix}Duplicate computed column id '${cc.id}'.`);
+    }
+    seenIds.add(cc.id);
+    if (seenNames.has(cc.name)) {
+      throw new Error(
+        `${errorPrefix}Duplicate computed column name '${cc.name}'.`,
+      );
+    }
+    seenNames.add(cc.name);
+
+    if (cc.kind === "number") {
+      if (cc.termOperators.length !== cc.terms.length - 1) {
+        throw new Error(
+          `${errorPrefix}Computed column '${cc.name}' has a mismatched number of term operators.`,
+        );
+      }
+      for (const term of cc.terms) {
+        if (term.operators.length !== term.operands.length - 1) {
+          throw new Error(
+            `${errorPrefix}Computed column '${cc.name}' has a mismatched number of operators.`,
+          );
+        }
+        for (const operand of term.operands) {
+          if (operand.type === "column" && !isNumericColumn(operand.column)) {
+            throw new Error(
+              `${errorPrefix}Computed column '${cc.name}' references non-numeric column '${operand.column}'.`,
+            );
+          }
+        }
+      }
+    } else {
+      for (const part of cc.parts) {
+        if (part.type === "column" && !isStringColumn(part.column)) {
+          throw new Error(
+            `${errorPrefix}Computed column '${cc.name}' concatenates non-string column '${part.column}'.`,
+          );
+        }
+      }
+    }
+  }
+
+  // Every `$$computed:<id>` reference (the value, the user filter, and each row
+  // filter) must resolve to a defined computed column.
+  const definedRefs = new Set(
+    computedColumns.map((cc) => getComputedColumnRef(cc.id)),
+  );
+  const referenced: string[] = [];
+  if (isComputedColumnRef(columnRef.column)) referenced.push(columnRef.column);
+  if (isComputedColumnRef(columnRef.aggregateFilterColumn)) {
+    referenced.push(columnRef.aggregateFilterColumn as string);
+  }
+  columnRef.rowFilters?.forEach((f) => {
+    if (isComputedColumnRef(f.column)) referenced.push(f.column as string);
+  });
+  for (const ref of referenced) {
+    if (!definedRefs.has(ref)) {
+      throw new Error(
+        `${errorPrefix}References computed column '${ref}' which is not defined.`,
+      );
+    }
+  }
+
+  // A string computed column produces text, so it can't be the numeric metric
+  // value or the user-filter column.
+  const stringRefs = new Set(
+    computedColumns
+      .filter((cc: ComputedColumn) => cc.kind === "string")
+      .map((cc) => getComputedColumnRef(cc.id)),
+  );
+  if (stringRefs.has(columnRef.column)) {
+    throw new Error(
+      `${errorPrefix}A string computed column cannot be used as the metric value.`,
+    );
+  }
+  if (
+    columnRef.aggregateFilterColumn &&
+    stringRefs.has(columnRef.aggregateFilterColumn)
+  ) {
+    throw new Error(
+      `${errorPrefix}A string computed column cannot be used as the user filter column.`,
+    );
   }
 }
 
@@ -366,6 +481,12 @@ export class FactMetricModel extends BaseClass {
       filterType: "numerator",
     });
 
+    validateComputedColumns({
+      columnRef: data.numerator,
+      factTable: numeratorFactTable,
+      errorPrefix: "Numerator misspecified. ",
+    });
+
     // Validate aggregation/datatype constraints (runs for every code path
     // that hits BaseModel — internal UI controllers, external API,
     // bulk import, etc.)
@@ -429,6 +550,12 @@ export class FactMetricModel extends BaseClass {
         columnRef: data.denominator,
         factTable: denominatorFactTable,
         filterType: "denominator",
+      });
+
+      validateComputedColumns({
+        columnRef: data.denominator,
+        factTable: denominatorFactTable,
+        errorPrefix: "Denominator misspecified. ",
       });
 
       validateAggregationSpecification({

--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -9,6 +9,7 @@ import {
   getSelectedColumnDatatype,
   isComputedColumnRef,
   getComputedColumnRef,
+  findComputedColumn,
 } from "shared/experiments";
 import { UpdateProps } from "shared/types/base-model";
 import { factMetricValidator, ApiFactMetric } from "shared/validators";
@@ -161,11 +162,43 @@ function validateComputedColumns({
 
   const seenIds = new Set<string>();
   const seenNames = new Set<string>();
+  // Computed columns can reference earlier ones (e.g. `avg` then `avg * 100`).
+  // Tracking the ids defined so far both enforces that ordering and guarantees
+  // the reference graph is acyclic.
+  const priorIds = new Set<string>();
 
-  const isNumericColumn = (col: string) =>
-    getSelectedColumnDatatype({ factTable, column: col }) === "number";
-  const isStringColumn = (col: string) =>
-    getSelectedColumnDatatype({ factTable, column: col }) === "string";
+  // A column operand/part may be a plain fact-table column or a `$$computed:<id>`
+  // reference to an earlier computed column. Validate whichever it is against the
+  // required datatype.
+  const validateColumnRef = (
+    cc: ComputedColumn,
+    col: string,
+    requiredKind: "number" | "string",
+  ): void => {
+    if (isComputedColumnRef(col)) {
+      const nested = findComputedColumn(computedColumns, col);
+      if (!nested || !priorIds.has(nested.id)) {
+        throw new Error(
+          `${errorPrefix}Computed column '${cc.name}' references computed column '${col}', which must be defined before it.`,
+        );
+      }
+      if (nested.kind !== requiredKind) {
+        throw new Error(
+          `${errorPrefix}Computed column '${cc.name}' references computed column '${nested.name}', which is not a ${requiredKind}.`,
+        );
+      }
+      return;
+    }
+    if (
+      getSelectedColumnDatatype({ factTable, column: col }) !== requiredKind
+    ) {
+      throw new Error(
+        requiredKind === "number"
+          ? `${errorPrefix}Computed column '${cc.name}' references non-numeric column '${col}'.`
+          : `${errorPrefix}Computed column '${cc.name}' concatenates non-string column '${col}'.`,
+      );
+    }
+  };
 
   for (const cc of computedColumns) {
     if (!cc.name.trim()) {
@@ -183,34 +216,25 @@ function validateComputedColumns({
     seenNames.add(cc.name);
 
     if (cc.kind === "number") {
-      if (cc.termOperators.length !== cc.terms.length - 1) {
+      if (cc.operators.length !== cc.operands.length - 1) {
         throw new Error(
-          `${errorPrefix}Computed column '${cc.name}' has a mismatched number of term operators.`,
+          `${errorPrefix}Computed column '${cc.name}' has a mismatched number of operators.`,
         );
       }
-      for (const term of cc.terms) {
-        if (term.operators.length !== term.operands.length - 1) {
-          throw new Error(
-            `${errorPrefix}Computed column '${cc.name}' has a mismatched number of operators.`,
-          );
-        }
-        for (const operand of term.operands) {
-          if (operand.type === "column" && !isNumericColumn(operand.column)) {
-            throw new Error(
-              `${errorPrefix}Computed column '${cc.name}' references non-numeric column '${operand.column}'.`,
-            );
-          }
+      for (const operand of cc.operands) {
+        if (operand.type === "column") {
+          validateColumnRef(cc, operand.column, "number");
         }
       }
     } else {
       for (const part of cc.parts) {
-        if (part.type === "column" && !isStringColumn(part.column)) {
-          throw new Error(
-            `${errorPrefix}Computed column '${cc.name}' concatenates non-string column '${part.column}'.`,
-          );
+        if (part.type === "column") {
+          validateColumnRef(cc, part.column, "string");
         }
       }
     }
+
+    priorIds.add(cc.id);
   }
 
   // Every `$$computed:<id>` reference (the value, the user filter, and each row

--- a/packages/back-end/src/services/factMetricAggregationValidation.ts
+++ b/packages/back-end/src/services/factMetricAggregationValidation.ts
@@ -26,6 +26,7 @@ export function validateAggregationSpecification({
   const datatype = getSelectedColumnDatatype({
     factTable,
     column: column.column,
+    computedColumns: column.computedColumns,
   });
   if (column.aggregation === "count distinct" && datatype !== "string") {
     throw new Error(

--- a/packages/front-end/components/FactTables/ComputedColumnInput.module.scss
+++ b/packages/front-end/components/FactTables/ComputedColumnInput.module.scss
@@ -1,51 +1,42 @@
 // Groups an operand's operator + column/number + remove control in a subtle
 // block so they read as one unit.
 .operandBlock {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
   background: var(--gray-a3);
   border-radius: var(--radius-3);
-  padding: var(--space-1);
-  // Snug on the right while the remove button is hidden; expands on hover.
-  padding-right: var(--space-1);
-  transition: padding-right 0.15s ease;
+  padding: var(--space-1) var(--space-2);
 }
 
-.operandBlock:hover,
-.operandBlock:focus-within {
-  padding-right: var(--space-2);
-}
-
-// The remove (X) is hidden until the block is hovered so the equation stays
-// clean. While hidden it collapses to zero width and its flex gap is cancelled
-// so the block sits snug; on hover it expands in next to the column/number.
+// Small floating delete badge in the block's top-right corner. Absolutely
+// positioned so it never affects layout (no reflow, no jump) and stays compact.
 .removeButton {
+  position: absolute;
+  top: -7px;
+  right: -7px;
+  z-index: 1;
   display: inline-flex;
   align-items: center;
-  overflow: hidden;
-  max-width: 0;
-  margin-left: calc(-1 * var(--space-2));
-  opacity: 0;
-  transition:
-    max-width 0.15s ease,
-    margin-left 0.15s ease,
-    opacity 0.12s ease;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: 1px solid var(--gray-a5);
+  border-radius: 50%;
+  background: var(--color-panel-solid);
+  box-shadow: var(--shadow-2);
+  color: var(--red-9);
+  font-size: 10px;
+  line-height: 1;
+  cursor: pointer;
 }
 
-.operandBlock:hover .removeButton,
-.operandBlock:focus-within .removeButton {
-  max-width: 40px;
-  // Sit close to the column/number to its left.
-  margin-left: calc(-1 * var(--space-1));
-  opacity: 1;
-}
-
-// Trim the ghost button to an icon-only box so the X reads small.
-.removeButton button {
-  padding: 2px !important;
-  min-width: 0 !important;
-  height: auto !important;
+.removeButton:hover {
+  background: var(--red-3);
+  border-color: var(--red-7);
+  color: var(--red-10);
 }
 
 // Hide the native up/down spinner on the literal Number input.

--- a/packages/front-end/components/FactTables/ComputedColumnInput.module.scss
+++ b/packages/front-end/components/FactTables/ComputedColumnInput.module.scss
@@ -1,0 +1,62 @@
+// Groups an operand's operator + column/number + remove control in a subtle
+// block so they read as one unit.
+.operandBlock {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  background: var(--gray-a3);
+  border-radius: var(--radius-3);
+  padding: var(--space-1);
+  // Snug on the right while the remove button is hidden; expands on hover.
+  padding-right: var(--space-1);
+  transition: padding-right 0.15s ease;
+}
+
+.operandBlock:hover,
+.operandBlock:focus-within {
+  padding-right: var(--space-2);
+}
+
+// The remove (X) is hidden until the block is hovered so the equation stays
+// clean. While hidden it collapses to zero width and its flex gap is cancelled
+// so the block sits snug; on hover it expands in next to the column/number.
+.removeButton {
+  display: inline-flex;
+  align-items: center;
+  overflow: hidden;
+  max-width: 0;
+  margin-left: calc(-1 * var(--space-2));
+  opacity: 0;
+  transition:
+    max-width 0.15s ease,
+    margin-left 0.15s ease,
+    opacity 0.12s ease;
+}
+
+.operandBlock:hover .removeButton,
+.operandBlock:focus-within .removeButton {
+  max-width: 40px;
+  // Sit close to the column/number to its left.
+  margin-left: calc(-1 * var(--space-1));
+  opacity: 1;
+}
+
+// Trim the ghost button to an icon-only box so the X reads small.
+.removeButton button {
+  padding: 2px !important;
+  min-width: 0 !important;
+  height: auto !important;
+}
+
+// Hide the native up/down spinner on the literal Number input.
+.numberInput {
+  appearance: textfield;
+  -moz-appearance: textfield;
+
+  &::-webkit-inner-spin-button,
+  &::-webkit-outer-spin-button {
+    appearance: none;
+    -webkit-appearance: none;
+    margin: 0;
+  }
+}

--- a/packages/front-end/components/FactTables/ComputedColumnInput.tsx
+++ b/packages/front-end/components/FactTables/ComputedColumnInput.tsx
@@ -505,7 +505,6 @@ export function ComputedColumnInput({
 
   return (
     <Flex direction="column" gap="2">
-      <strong>Computed Columns</strong>
       {value.map((column, i) => (
         <Box
           key={column.id}

--- a/packages/front-end/components/FactTables/ComputedColumnInput.tsx
+++ b/packages/front-end/components/FactTables/ComputedColumnInput.tsx
@@ -1,0 +1,594 @@
+import { Box, Flex } from "@radix-ui/themes";
+import {
+  ComputedColumn,
+  ComputedColumnOperand,
+  ComputedColumnStringPart,
+  ComputedColumnTerm,
+  FactTableInterface,
+  NumericComputedColumn,
+  StringComputedColumn,
+} from "shared/types/fact-table";
+import { PiPlus, PiX } from "react-icons/pi";
+import SelectField, { SingleValue } from "@/components/Forms/SelectField";
+import Field from "@/components/Forms/Field";
+import Checkbox from "@/ui/Checkbox";
+import Button from "@/ui/Button";
+import Text from "@/ui/Text";
+
+// A stable-enough client-side id for referencing a computed column via
+// `$$computed:<id>`. Uniqueness only needs to hold within a single metric.
+function genId(): string {
+  return "cc_" + Math.random().toString(36).slice(2, 10);
+}
+
+function newOperand(): ComputedColumnOperand {
+  return { type: "column", column: "" };
+}
+function newTerm(): ComputedColumnTerm {
+  return { operands: [newOperand()], operators: [] };
+}
+function newStringPart(): ComputedColumnStringPart {
+  return { type: "column", column: "" };
+}
+function newNumericComputedColumn(): NumericComputedColumn {
+  return {
+    id: genId(),
+    name: "",
+    kind: "number",
+    terms: [newTerm()],
+    termOperators: [],
+  };
+}
+function newStringComputedColumn(): StringComputedColumn {
+  return { id: genId(), name: "", kind: "string", parts: [newStringPart()] };
+}
+
+// Numeric columns (and numeric JSON fields) usable as operands.
+function getNumericColumnOptions(
+  factTable: Pick<FactTableInterface, "columns" | "userIdTypes">,
+): SingleValue[] {
+  const options: SingleValue[] = [];
+  factTable.columns.forEach((col) => {
+    if (col.deleted) return;
+    if (factTable.userIdTypes?.includes(col.column)) return;
+    if (col.datatype === "number") {
+      options.push({ label: col.name || col.column, value: col.column });
+    }
+    if (col.jsonFields) {
+      Object.entries(col.jsonFields).forEach(([field, data]) => {
+        if (data.datatype === "number") {
+          options.push({
+            label: `${col.name || col.column}.${field}`,
+            value: `${col.column}.${field}`,
+          });
+        }
+      });
+    }
+  });
+  return options;
+}
+
+// String columns (and string JSON fields) usable as concat parts.
+function getStringColumnOptions(
+  factTable: Pick<FactTableInterface, "columns" | "userIdTypes">,
+): SingleValue[] {
+  const options: SingleValue[] = [];
+  factTable.columns.forEach((col) => {
+    if (col.deleted) return;
+    if (factTable.userIdTypes?.includes(col.column)) return;
+    if (col.datatype === "string") {
+      options.push({ label: col.name || col.column, value: col.column });
+    }
+    if (col.jsonFields) {
+      Object.entries(col.jsonFields).forEach(([field, data]) => {
+        if (data.datatype === "string") {
+          options.push({
+            label: `${col.name || col.column}.${field}`,
+            value: `${col.column}.${field}`,
+          });
+        }
+      });
+    }
+  });
+  return options;
+}
+
+const MULTIPLICATIVE_OPERATORS: SingleValue[] = [
+  { label: "×", value: "*" },
+  { label: "÷", value: "/" },
+];
+const ADDITIVE_OPERATORS: SingleValue[] = [
+  { label: "+", value: "+" },
+  { label: "−", value: "-" },
+];
+
+function OperandEditor({
+  operand,
+  columnOptions,
+  onChange,
+  onRemove,
+  canRemove,
+}: {
+  operand: ComputedColumnOperand;
+  columnOptions: SingleValue[];
+  onChange: (o: ComputedColumnOperand) => void;
+  onRemove: () => void;
+  canRemove: boolean;
+}) {
+  return (
+    <Flex align="center" gap="1">
+      <Box style={{ width: 110 }}>
+        <SelectField
+          value={operand.type}
+          onChange={(v) =>
+            onChange(
+              v === "literal"
+                ? { type: "literal", value: 0 }
+                : { type: "column", column: "" },
+            )
+          }
+          options={[
+            { label: "Column", value: "column" },
+            { label: "Number", value: "literal" },
+          ]}
+          sort={false}
+        />
+      </Box>
+      {operand.type === "column" ? (
+        <Box style={{ minWidth: 180 }}>
+          <SelectField
+            value={operand.column}
+            onChange={(column) => onChange({ type: "column", column })}
+            options={columnOptions}
+            placeholder="Select column..."
+            required
+          />
+        </Box>
+      ) : (
+        <Field
+          type="number"
+          step="any"
+          value={operand.value}
+          onChange={(e) =>
+            onChange({ type: "literal", value: e.target.valueAsNumber || 0 })
+          }
+          style={{ maxWidth: 120 }}
+        />
+      )}
+      {canRemove && (
+        <Button variant="ghost" color="red" onClick={onRemove}>
+          <PiX />
+        </Button>
+      )}
+    </Flex>
+  );
+}
+
+// Editor for a single term: operands combined with × / ÷.
+function TermEditor({
+  term,
+  columnOptions,
+  setTerm,
+}: {
+  term: ComputedColumnTerm;
+  columnOptions: SingleValue[];
+  setTerm: (t: ComputedColumnTerm) => void;
+}) {
+  const updateOperand = (i: number, operand: ComputedColumnOperand) => {
+    const operands = [...term.operands];
+    operands[i] = operand;
+    setTerm({ ...term, operands });
+  };
+  const removeOperand = (i: number) => {
+    const operands = [...term.operands];
+    operands.splice(i, 1);
+    const operators = [...term.operators];
+    // The operator that joined this operand to the previous one is dropped.
+    operators.splice(Math.max(0, i - 1), 1);
+    setTerm({ ...term, operands, operators });
+  };
+  const addOperand = () => {
+    setTerm({
+      ...term,
+      operands: [...term.operands, newOperand()],
+      operators: [...term.operators, "*"],
+    });
+  };
+  const setOperator = (i: number, op: "*" | "/") => {
+    const operators = [...term.operators];
+    operators[i] = op;
+    setTerm({ ...term, operators });
+  };
+
+  return (
+    <Box
+      style={{
+        border: "1px solid var(--slate-a4)",
+        borderRadius: 6,
+        padding: "8px",
+      }}
+    >
+      <Flex direction="column" gap="2">
+        {term.operands.map((operand, i) => (
+          <Flex align="center" gap="1" key={i}>
+            {i > 0 && (
+              <Box style={{ width: 70 }}>
+                <SelectField
+                  value={term.operators[i - 1] || "*"}
+                  onChange={(v) => setOperator(i - 1, v as "*" | "/")}
+                  options={MULTIPLICATIVE_OPERATORS}
+                  sort={false}
+                />
+              </Box>
+            )}
+            <OperandEditor
+              operand={operand}
+              columnOptions={columnOptions}
+              onChange={(o) => updateOperand(i, o)}
+              onRemove={() => removeOperand(i)}
+              canRemove={term.operands.length > 1}
+            />
+          </Flex>
+        ))}
+      </Flex>
+      <Box mt="2">
+        <a
+          href="#"
+          onClick={(e) => {
+            e.preventDefault();
+            addOperand();
+          }}
+        >
+          <PiPlus /> Multiply / divide by another column
+        </a>
+      </Box>
+    </Box>
+  );
+}
+
+function NumericComputedColumnEditor({
+  value,
+  factTable,
+  setValue,
+}: {
+  value: NumericComputedColumn;
+  factTable: Pick<FactTableInterface, "columns" | "userIdTypes">;
+  setValue: (v: NumericComputedColumn) => void;
+}) {
+  const columnOptions = getNumericColumnOptions(factTable);
+
+  const setTerm = (i: number, term: ComputedColumnTerm) => {
+    const terms = [...value.terms];
+    terms[i] = term;
+    setValue({ ...value, terms });
+  };
+  const removeTerm = (i: number) => {
+    const terms = [...value.terms];
+    terms.splice(i, 1);
+    const termOperators = [...value.termOperators];
+    termOperators.splice(Math.max(0, i - 1), 1);
+    setValue({ ...value, terms, termOperators });
+  };
+  const addTerm = () => {
+    setValue({
+      ...value,
+      terms: [...value.terms, newTerm()],
+      termOperators: [...value.termOperators, "+"],
+    });
+  };
+  const setTermOperator = (i: number, op: "+" | "-") => {
+    const termOperators = [...value.termOperators];
+    termOperators[i] = op;
+    setValue({ ...value, termOperators });
+  };
+
+  return (
+    <Flex direction="column" gap="2">
+      {value.terms.map((term, i) => (
+        <Flex direction="column" gap="2" key={i}>
+          {i > 0 && (
+            <Flex align="center" gap="2">
+              <Box style={{ width: 70 }}>
+                <SelectField
+                  value={value.termOperators[i - 1] || "+"}
+                  onChange={(v) => setTermOperator(i - 1, v as "+" | "-")}
+                  options={ADDITIVE_OPERATORS}
+                  sort={false}
+                />
+              </Box>
+              {value.terms.length > 1 && (
+                <Button
+                  variant="ghost"
+                  color="red"
+                  onClick={() => removeTerm(i)}
+                >
+                  <PiX /> Remove term
+                </Button>
+              )}
+            </Flex>
+          )}
+          <TermEditor
+            term={term}
+            columnOptions={columnOptions}
+            setTerm={(t) => setTerm(i, t)}
+          />
+        </Flex>
+      ))}
+      <Box>
+        <a
+          href="#"
+          onClick={(e) => {
+            e.preventDefault();
+            addTerm();
+          }}
+        >
+          <PiPlus /> Add / subtract another term
+        </a>
+      </Box>
+
+      <Flex align="center" gap="3" wrap="wrap">
+        <Checkbox
+          label="Treat nulls as 0"
+          value={!!value.coalesceZero}
+          setValue={(v) => setValue({ ...value, coalesceZero: v })}
+        />
+        <Flex align="center" gap="2">
+          <Text size="small">Rounding</Text>
+          <Box style={{ width: 130 }}>
+            <SelectField
+              value={value.rounding?.mode || ""}
+              onChange={(v) =>
+                setValue({
+                  ...value,
+                  rounding: v
+                    ? {
+                        mode: v as "round" | "floor" | "ceil",
+                        decimals: value.rounding?.decimals ?? 2,
+                      }
+                    : undefined,
+                })
+              }
+              options={[
+                { label: "None", value: "" },
+                { label: "Round", value: "round" },
+                { label: "Floor", value: "floor" },
+                { label: "Ceiling", value: "ceil" },
+              ]}
+              sort={false}
+            />
+          </Box>
+          {value.rounding && (
+            <Field
+              type="number"
+              min={0}
+              max={10}
+              value={value.rounding.decimals ?? 2}
+              onChange={(e) =>
+                setValue({
+                  ...value,
+                  rounding: {
+                    mode: value.rounding?.mode || "round",
+                    decimals: Math.max(
+                      0,
+                      Math.min(10, e.target.valueAsNumber || 0),
+                    ),
+                  },
+                })
+              }
+              prepend="decimals"
+              style={{ maxWidth: 80 }}
+            />
+          )}
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+}
+
+function StringComputedColumnEditor({
+  value,
+  factTable,
+  setValue,
+}: {
+  value: StringComputedColumn;
+  factTable: Pick<FactTableInterface, "columns" | "userIdTypes">;
+  setValue: (v: StringComputedColumn) => void;
+}) {
+  const columnOptions = getStringColumnOptions(factTable);
+
+  const updatePart = (i: number, part: ComputedColumnStringPart) => {
+    const parts = [...value.parts];
+    parts[i] = part;
+    setValue({ ...value, parts });
+  };
+  const removePart = (i: number) => {
+    const parts = [...value.parts];
+    parts.splice(i, 1);
+    setValue({ ...value, parts });
+  };
+  const addPart = (part: ComputedColumnStringPart) => {
+    setValue({ ...value, parts: [...value.parts, part] });
+  };
+
+  return (
+    <Flex direction="column" gap="2">
+      {value.parts.map((part, i) => (
+        <Flex align="center" gap="1" key={i}>
+          {i > 0 && <Text size="small">+</Text>}
+          <Box style={{ width: 110 }}>
+            <SelectField
+              value={part.type}
+              onChange={(v) =>
+                updatePart(
+                  i,
+                  v === "literal"
+                    ? { type: "literal", value: "" }
+                    : { type: "column", column: "" },
+                )
+              }
+              options={[
+                { label: "Column", value: "column" },
+                { label: "Text", value: "literal" },
+              ]}
+              sort={false}
+            />
+          </Box>
+          {part.type === "column" ? (
+            <Box style={{ minWidth: 180 }}>
+              <SelectField
+                value={part.column}
+                onChange={(column) => updatePart(i, { type: "column", column })}
+                options={columnOptions}
+                placeholder="Select column..."
+                required
+              />
+            </Box>
+          ) : (
+            <Field
+              value={part.value}
+              onChange={(e) =>
+                updatePart(i, { type: "literal", value: e.target.value })
+              }
+              placeholder="text..."
+            />
+          )}
+          {value.parts.length > 1 && (
+            <Button variant="ghost" color="red" onClick={() => removePart(i)}>
+              <PiX />
+            </Button>
+          )}
+        </Flex>
+      ))}
+      <Flex gap="3">
+        <a
+          href="#"
+          onClick={(e) => {
+            e.preventDefault();
+            addPart(newStringPart());
+          }}
+        >
+          <PiPlus /> Add column
+        </a>
+        <a
+          href="#"
+          onClick={(e) => {
+            e.preventDefault();
+            addPart({ type: "literal", value: "" });
+          }}
+        >
+          <PiPlus /> Add text
+        </a>
+      </Flex>
+    </Flex>
+  );
+}
+
+export function ComputedColumnInput({
+  value,
+  setValue,
+  factTable,
+}: {
+  value: ComputedColumn[];
+  setValue: (value: ComputedColumn[]) => void;
+  factTable: Pick<FactTableInterface, "columns" | "userIdTypes">;
+}) {
+  const updateColumn = (i: number, column: ComputedColumn) => {
+    const next = [...value];
+    next[i] = column;
+    setValue(next);
+  };
+  const removeColumn = (i: number) => {
+    const next = [...value];
+    next.splice(i, 1);
+    setValue(next);
+  };
+
+  return (
+    <Flex direction="column" gap="2">
+      <strong>Computed Columns</strong>
+      {value.map((column, i) => (
+        <Box
+          key={column.id}
+          className="appbox"
+          p="3"
+          mb="0"
+          style={{ background: "var(--color-panel-solid)" }}
+        >
+          <Flex justify="between" align="start" gap="2">
+            <Box style={{ flex: 1 }}>
+              <Field
+                label="Name"
+                value={column.name}
+                onChange={(e) =>
+                  updateColumn(i, { ...column, name: e.target.value })
+                }
+                placeholder="e.g. revenue_per_item"
+                required
+              />
+            </Box>
+            <Box style={{ width: 140 }}>
+              <SelectField
+                label="Type"
+                value={column.kind}
+                onChange={(v) =>
+                  updateColumn(
+                    i,
+                    v === "string"
+                      ? {
+                          ...newStringComputedColumn(),
+                          id: column.id,
+                          name: column.name,
+                        }
+                      : {
+                          ...newNumericComputedColumn(),
+                          id: column.id,
+                          name: column.name,
+                        },
+                  )
+                }
+                options={[
+                  { label: "Number", value: "number" },
+                  { label: "String (concat)", value: "string" },
+                ]}
+                sort={false}
+              />
+            </Box>
+            <Button
+              variant="ghost"
+              color="red"
+              onClick={() => removeColumn(i)}
+              mt="4"
+            >
+              <PiX />
+            </Button>
+          </Flex>
+
+          {column.kind === "number" ? (
+            <NumericComputedColumnEditor
+              value={column}
+              factTable={factTable}
+              setValue={(v) => updateColumn(i, v)}
+            />
+          ) : (
+            <StringComputedColumnEditor
+              value={column}
+              factTable={factTable}
+              setValue={(v) => updateColumn(i, v)}
+            />
+          )}
+        </Box>
+      ))}
+      <div>
+        <a
+          href="#"
+          onClick={(e) => {
+            e.preventDefault();
+            setValue([...value, newNumericComputedColumn()]);
+          }}
+        >
+          <PiPlus /> Add
+        </a>
+      </div>
+    </Flex>
+  );
+}

--- a/packages/front-end/components/FactTables/ComputedColumnInput.tsx
+++ b/packages/front-end/components/FactTables/ComputedColumnInput.tsx
@@ -3,13 +3,16 @@ import {
   ComputedColumn,
   ComputedColumnOperand,
   ComputedColumnStringPart,
-  ComputedColumnTerm,
   FactTableInterface,
   NumericComputedColumn,
   StringComputedColumn,
 } from "shared/types/fact-table";
 import { PiPlus, PiX } from "react-icons/pi";
-import SelectField, { SingleValue } from "@/components/Forms/SelectField";
+import { getComputedColumnRef } from "shared/experiments";
+import SelectField, {
+  GroupedValue,
+  SingleValue,
+} from "@/components/Forms/SelectField";
 import Field from "@/components/Forms/Field";
 import Checkbox from "@/ui/Checkbox";
 import Button from "@/ui/Button";
@@ -24,9 +27,6 @@ function genId(): string {
 function newOperand(): ComputedColumnOperand {
   return { type: "column", column: "" };
 }
-function newTerm(): ComputedColumnTerm {
-  return { operands: [newOperand()], operators: [] };
-}
 function newStringPart(): ComputedColumnStringPart {
   return { type: "column", column: "" };
 }
@@ -35,15 +35,14 @@ function newNumericComputedColumn(): NumericComputedColumn {
     id: genId(),
     name: "",
     kind: "number",
-    terms: [newTerm()],
-    termOperators: [],
+    operands: [newOperand()],
+    operators: [],
   };
 }
 function newStringComputedColumn(): StringComputedColumn {
   return { id: genId(), name: "", kind: "string", parts: [newStringPart()] };
 }
 
-// Numeric columns (and numeric JSON fields) usable as operands.
 function getNumericColumnOptions(
   factTable: Pick<FactTableInterface, "columns" | "userIdTypes">,
 ): SingleValue[] {
@@ -68,7 +67,6 @@ function getNumericColumnOptions(
   return options;
 }
 
-// String columns (and string JSON fields) usable as concat parts.
 function getStringColumnOptions(
   factTable: Pick<FactTableInterface, "columns" | "userIdTypes">,
 ): SingleValue[] {
@@ -93,58 +91,79 @@ function getStringColumnOptions(
   return options;
 }
 
-const MULTIPLICATIVE_OPERATORS: SingleValue[] = [
+// Map already-defined computed columns to selectable `$$computed:<id>` options
+// so a column can be built on top of an earlier one (e.g. `avg` then `avg * 100`).
+function getComputedColumnOptions(
+  priorColumns: ComputedColumn[],
+  kind: "number" | "string",
+): SingleValue[] {
+  return priorColumns
+    .filter((c) => c.kind === kind)
+    .map((c) => ({
+      label: c.name || "(unnamed)",
+      value: getComputedColumnRef(c.id),
+    }));
+}
+
+// Unified operator between two operands: + − × ÷.
+const ARITHMETIC_OPERATORS: SingleValue[] = [
+  { label: "+", value: "+" },
+  { label: "−", value: "-" },
   { label: "×", value: "*" },
   { label: "÷", value: "/" },
 ];
-const ADDITIVE_OPERATORS: SingleValue[] = [
-  { label: "+", value: "+" },
-  { label: "−", value: "-" },
-];
 
-function OperandEditor({
+// Sentinel option for "this operand is a literal number" — selecting it reveals
+// a number input beside the dropdown.
+const NUMBER_OPTION_VALUE = "$$number";
+
+// A thin horizontal rule used to separate the columns from the "Number" option.
+function OperandOptionDivider() {
+  return (
+    <div
+      style={{
+        borderTop: "1px solid var(--border-color-200)",
+        margin: "2px 0",
+      }}
+    />
+  );
+}
+
+function NumericOperandInput({
   operand,
   columnOptions,
   onChange,
-  onRemove,
-  canRemove,
 }: {
   operand: ComputedColumnOperand;
   columnOptions: SingleValue[];
   onChange: (o: ComputedColumnOperand) => void;
-  onRemove: () => void;
-  canRemove: boolean;
 }) {
+  const isLiteral = operand.type === "literal";
+  // Columns (and earlier computed columns) on top, a divider, then "Number".
+  const options: (SingleValue | GroupedValue)[] = [
+    ...columnOptions,
+    { label: "", options: [{ label: "Number", value: NUMBER_OPTION_VALUE }] },
+  ];
   return (
-    <Flex align="center" gap="1">
-      <Box style={{ width: 110 }}>
+    <Flex align="center" gap="2">
+      <Box style={{ minWidth: 200 }}>
         <SelectField
-          value={operand.type}
+          value={isLiteral ? NUMBER_OPTION_VALUE : operand.column}
           onChange={(v) =>
             onChange(
-              v === "literal"
-                ? { type: "literal", value: 0 }
-                : { type: "column", column: "" },
+              v === NUMBER_OPTION_VALUE
+                ? { type: "literal", value: isLiteral ? operand.value : 0 }
+                : { type: "column", column: v },
             )
           }
-          options={[
-            { label: "Column", value: "column" },
-            { label: "Number", value: "literal" },
-          ]}
+          options={options}
+          formatGroupLabel={() => <OperandOptionDivider />}
+          placeholder="Select column or number..."
           sort={false}
+          required
         />
       </Box>
-      {operand.type === "column" ? (
-        <Box style={{ minWidth: 180 }}>
-          <SelectField
-            value={operand.column}
-            onChange={(column) => onChange({ type: "column", column })}
-            options={columnOptions}
-            placeholder="Select column..."
-            required
-          />
-        </Box>
-      ) : (
+      {isLiteral && (
         <Field
           type="number"
           step="any"
@@ -152,86 +171,86 @@ function OperandEditor({
           onChange={(e) =>
             onChange({ type: "literal", value: e.target.valueAsNumber || 0 })
           }
-          style={{ maxWidth: 120 }}
+          style={{ maxWidth: 110, height: 38 }}
         />
-      )}
-      {canRemove && (
-        <Button variant="ghost" color="red" onClick={onRemove}>
-          <PiX />
-        </Button>
       )}
     </Flex>
   );
 }
 
-// Editor for a single term: operands combined with × / ÷.
-function TermEditor({
-  term,
-  columnOptions,
-  setTerm,
+function NumericComputedColumnEditor({
+  value,
+  factTable,
+  priorColumns,
+  setValue,
 }: {
-  term: ComputedColumnTerm;
-  columnOptions: SingleValue[];
-  setTerm: (t: ComputedColumnTerm) => void;
+  value: NumericComputedColumn;
+  factTable: Pick<FactTableInterface, "columns" | "userIdTypes">;
+  priorColumns: ComputedColumn[];
+  setValue: (v: NumericComputedColumn) => void;
 }) {
+  const columnOptions = [
+    ...getNumericColumnOptions(factTable),
+    ...getComputedColumnOptions(priorColumns, "number"),
+  ];
+
   const updateOperand = (i: number, operand: ComputedColumnOperand) => {
-    const operands = [...term.operands];
+    const operands = [...value.operands];
     operands[i] = operand;
-    setTerm({ ...term, operands });
+    setValue({ ...value, operands });
   };
   const removeOperand = (i: number) => {
-    const operands = [...term.operands];
+    const operands = [...value.operands];
     operands.splice(i, 1);
-    const operators = [...term.operators];
-    // The operator that joined this operand to the previous one is dropped.
+    const operators = [...value.operators];
     operators.splice(Math.max(0, i - 1), 1);
-    setTerm({ ...term, operands, operators });
+    setValue({ ...value, operands, operators });
   };
   const addOperand = () => {
-    setTerm({
-      ...term,
-      operands: [...term.operands, newOperand()],
-      operators: [...term.operators, "*"],
+    setValue({
+      ...value,
+      operands: [...value.operands, newOperand()],
+      operators: [...value.operators, "+"],
     });
   };
-  const setOperator = (i: number, op: "*" | "/") => {
-    const operators = [...term.operators];
-    operators[i] = op;
-    setTerm({ ...term, operators });
+  const setOperator = (i: number, op: string) => {
+    const operators = [...value.operators];
+    operators[i] = op as "+" | "-" | "*" | "/";
+    setValue({ ...value, operators });
   };
 
   return (
-    <Box
-      style={{
-        border: "1px solid var(--slate-a4)",
-        borderRadius: 6,
-        padding: "8px",
-      }}
-    >
-      <Flex direction="column" gap="2">
-        {term.operands.map((operand, i) => (
-          <Flex align="center" gap="1" key={i}>
+    <Flex direction="column" gap="3">
+      {/* Flat formula row: operand [op] operand [op] operand ... */}
+      <Flex align="center" gap="2" wrap="wrap">
+        {value.operands.map((operand, i) => (
+          <Flex align="center" gap="2" key={i} wrap="wrap">
             {i > 0 && (
-              <Box style={{ width: 70 }}>
+              <Box style={{ width: 64 }}>
                 <SelectField
-                  value={term.operators[i - 1] || "*"}
-                  onChange={(v) => setOperator(i - 1, v as "*" | "/")}
-                  options={MULTIPLICATIVE_OPERATORS}
+                  value={value.operators[i - 1] || "+"}
+                  onChange={(v) => setOperator(i - 1, v)}
+                  options={ARITHMETIC_OPERATORS}
                   sort={false}
                 />
               </Box>
             )}
-            <OperandEditor
+            <NumericOperandInput
               operand={operand}
               columnOptions={columnOptions}
               onChange={(o) => updateOperand(i, o)}
-              onRemove={() => removeOperand(i)}
-              canRemove={term.operands.length > 1}
             />
+            {value.operands.length > 1 && (
+              <Button
+                variant="ghost"
+                color="red"
+                onClick={() => removeOperand(i)}
+              >
+                <PiX />
+              </Button>
+            )}
           </Flex>
         ))}
-      </Flex>
-      <Box mt="2">
         <a
           href="#"
           onClick={(e) => {
@@ -239,92 +258,12 @@ function TermEditor({
             addOperand();
           }}
         >
-          <PiPlus /> Multiply / divide by another column
+          <PiPlus /> Add
         </a>
-      </Box>
-    </Box>
-  );
-}
-
-function NumericComputedColumnEditor({
-  value,
-  factTable,
-  setValue,
-}: {
-  value: NumericComputedColumn;
-  factTable: Pick<FactTableInterface, "columns" | "userIdTypes">;
-  setValue: (v: NumericComputedColumn) => void;
-}) {
-  const columnOptions = getNumericColumnOptions(factTable);
-
-  const setTerm = (i: number, term: ComputedColumnTerm) => {
-    const terms = [...value.terms];
-    terms[i] = term;
-    setValue({ ...value, terms });
-  };
-  const removeTerm = (i: number) => {
-    const terms = [...value.terms];
-    terms.splice(i, 1);
-    const termOperators = [...value.termOperators];
-    termOperators.splice(Math.max(0, i - 1), 1);
-    setValue({ ...value, terms, termOperators });
-  };
-  const addTerm = () => {
-    setValue({
-      ...value,
-      terms: [...value.terms, newTerm()],
-      termOperators: [...value.termOperators, "+"],
-    });
-  };
-  const setTermOperator = (i: number, op: "+" | "-") => {
-    const termOperators = [...value.termOperators];
-    termOperators[i] = op;
-    setValue({ ...value, termOperators });
-  };
-
-  return (
-    <Flex direction="column" gap="2">
-      {value.terms.map((term, i) => (
-        <Flex direction="column" gap="2" key={i}>
-          {i > 0 && (
-            <Flex align="center" gap="2">
-              <Box style={{ width: 70 }}>
-                <SelectField
-                  value={value.termOperators[i - 1] || "+"}
-                  onChange={(v) => setTermOperator(i - 1, v as "+" | "-")}
-                  options={ADDITIVE_OPERATORS}
-                  sort={false}
-                />
-              </Box>
-              {value.terms.length > 1 && (
-                <Button
-                  variant="ghost"
-                  color="red"
-                  onClick={() => removeTerm(i)}
-                >
-                  <PiX /> Remove term
-                </Button>
-              )}
-            </Flex>
-          )}
-          <TermEditor
-            term={term}
-            columnOptions={columnOptions}
-            setTerm={(t) => setTerm(i, t)}
-          />
-        </Flex>
-      ))}
-      <Box>
-        <a
-          href="#"
-          onClick={(e) => {
-            e.preventDefault();
-            addTerm();
-          }}
-        >
-          <PiPlus /> Add / subtract another term
-        </a>
-      </Box>
+      </Flex>
+      <Text size="small" color="text-low">
+        × and ÷ are calculated before + and −.
+      </Text>
 
       <Flex align="center" gap="3" wrap="wrap">
         <Checkbox
@@ -388,13 +327,18 @@ function NumericComputedColumnEditor({
 function StringComputedColumnEditor({
   value,
   factTable,
+  priorColumns,
   setValue,
 }: {
   value: StringComputedColumn;
   factTable: Pick<FactTableInterface, "columns" | "userIdTypes">;
+  priorColumns: ComputedColumn[];
   setValue: (v: StringComputedColumn) => void;
 }) {
-  const columnOptions = getStringColumnOptions(factTable);
+  const columnOptions = [
+    ...getStringColumnOptions(factTable),
+    ...getComputedColumnOptions(priorColumns, "string"),
+  ];
 
   const updatePart = (i: number, part: ComputedColumnStringPart) => {
     const parts = [...value.parts];
@@ -412,54 +356,56 @@ function StringComputedColumnEditor({
 
   return (
     <Flex direction="column" gap="2">
-      {value.parts.map((part, i) => (
-        <Flex align="center" gap="1" key={i}>
-          {i > 0 && <Text size="small">+</Text>}
-          <Box style={{ width: 110 }}>
-            <SelectField
-              value={part.type}
-              onChange={(v) =>
-                updatePart(
-                  i,
-                  v === "literal"
-                    ? { type: "literal", value: "" }
-                    : { type: "column", column: "" },
-                )
-              }
-              options={[
-                { label: "Column", value: "column" },
-                { label: "Text", value: "literal" },
-              ]}
-              sort={false}
-            />
-          </Box>
-          {part.type === "column" ? (
-            <Box style={{ minWidth: 180 }}>
+      <Flex align="center" gap="2" wrap="wrap">
+        {value.parts.map((part, i) => (
+          <Flex align="center" gap="2" key={i} wrap="wrap">
+            {i > 0 && <Text size="small">+</Text>}
+            <Box style={{ width: 104 }}>
               <SelectField
-                value={part.column}
-                onChange={(column) => updatePart(i, { type: "column", column })}
-                options={columnOptions}
-                placeholder="Select column..."
-                required
+                value={part.type}
+                onChange={(v) =>
+                  updatePart(
+                    i,
+                    v === "literal"
+                      ? { type: "literal", value: "" }
+                      : { type: "column", column: "" },
+                  )
+                }
+                options={[
+                  { label: "Column", value: "column" },
+                  { label: "Text", value: "literal" },
+                ]}
+                sort={false}
               />
             </Box>
-          ) : (
-            <Field
-              value={part.value}
-              onChange={(e) =>
-                updatePart(i, { type: "literal", value: e.target.value })
-              }
-              placeholder="text..."
-            />
-          )}
-          {value.parts.length > 1 && (
-            <Button variant="ghost" color="red" onClick={() => removePart(i)}>
-              <PiX />
-            </Button>
-          )}
-        </Flex>
-      ))}
-      <Flex gap="3">
+            {part.type === "column" ? (
+              <Box style={{ minWidth: 170 }}>
+                <SelectField
+                  value={part.column}
+                  onChange={(column) =>
+                    updatePart(i, { type: "column", column })
+                  }
+                  options={columnOptions}
+                  placeholder="Select column..."
+                  required
+                />
+              </Box>
+            ) : (
+              <Field
+                value={part.value}
+                onChange={(e) =>
+                  updatePart(i, { type: "literal", value: e.target.value })
+                }
+                placeholder="text..."
+              />
+            )}
+            {value.parts.length > 1 && (
+              <Button variant="ghost" color="red" onClick={() => removePart(i)}>
+                <PiX />
+              </Button>
+            )}
+          </Flex>
+        ))}
         <a
           href="#"
           onClick={(e) => {
@@ -467,7 +413,7 @@ function StringComputedColumnEditor({
             addPart(newStringPart());
           }}
         >
-          <PiPlus /> Add column
+          <PiPlus /> Column
         </a>
         <a
           href="#"
@@ -476,7 +422,7 @@ function StringComputedColumnEditor({
             addPart({ type: "literal", value: "" });
           }}
         >
-          <PiPlus /> Add text
+          <PiPlus /> Text
         </a>
       </Flex>
     </Flex>
@@ -523,6 +469,9 @@ export function ComputedColumnInput({
                 }
                 placeholder="e.g. revenue_per_item"
                 required
+                // Match the react-select control height (38px) so the Name input
+                // and Type dropdown line up.
+                style={{ height: 38 }}
               />
             </Box>
             <Box style={{ width: 140 }}>
@@ -566,12 +515,14 @@ export function ComputedColumnInput({
             <NumericComputedColumnEditor
               value={column}
               factTable={factTable}
+              priorColumns={value.slice(0, i)}
               setValue={(v) => updateColumn(i, v)}
             />
           ) : (
             <StringComputedColumnEditor
               value={column}
               factTable={factTable}
+              priorColumns={value.slice(0, i)}
               setValue={(v) => updateColumn(i, v)}
             />
           )}

--- a/packages/front-end/components/FactTables/ComputedColumnInput.tsx
+++ b/packages/front-end/components/FactTables/ComputedColumnInput.tsx
@@ -17,6 +17,7 @@ import Field from "@/components/Forms/Field";
 import Checkbox from "@/ui/Checkbox";
 import Button from "@/ui/Button";
 import Text from "@/ui/Text";
+import styles from "./ComputedColumnInput.module.scss";
 
 // A stable-enough client-side id for referencing a computed column via
 // `$$computed:<id>`. Uniqueness only needs to hold within a single metric.
@@ -117,18 +118,6 @@ const ARITHMETIC_OPERATORS: SingleValue[] = [
 // a number input beside the dropdown.
 const NUMBER_OPTION_VALUE = "$$number";
 
-// A thin horizontal rule used to separate the columns from the "Number" option.
-function OperandOptionDivider() {
-  return (
-    <div
-      style={{
-        borderTop: "1px solid var(--border-color-200)",
-        margin: "2px 0",
-      }}
-    />
-  );
-}
-
 function NumericOperandInput({
   operand,
   columnOptions,
@@ -139,14 +128,19 @@ function NumericOperandInput({
   onChange: (o: ComputedColumnOperand) => void;
 }) {
   const isLiteral = operand.type === "literal";
-  // Columns (and earlier computed columns) on top, a divider, then "Number".
-  const options: (SingleValue | GroupedValue)[] = [
-    ...columnOptions,
-    { label: "", options: [{ label: "Number", value: NUMBER_OPTION_VALUE }] },
-  ];
+  // Two labeled sections: "Columns" (fact + earlier computed columns) and
+  // "Static" (a literal number).
+  const options: GroupedValue[] = [];
+  if (columnOptions.length > 0) {
+    options.push({ label: "Columns", options: columnOptions });
+  }
+  options.push({
+    label: "Static",
+    options: [{ label: "Number", value: NUMBER_OPTION_VALUE }],
+  });
   return (
     <Flex align="center" gap="2">
-      <Box style={{ minWidth: 200 }}>
+      <Box style={{ minWidth: 100, width: "fit-content" }}>
         <SelectField
           value={isLiteral ? NUMBER_OPTION_VALUE : operand.column}
           onChange={(v) =>
@@ -157,10 +151,19 @@ function NumericOperandInput({
             )
           }
           options={options}
-          formatGroupLabel={() => <OperandOptionDivider />}
-          placeholder="Select column or number..."
+          placeholder="Column or number..."
           sort={false}
           required
+          // The default focused-input style stretches the control to fill its
+          // container (`1fr`); inside a fit-content wrapper that makes the
+          // trigger jump wider when opened. Size the search input to its own
+          // content instead so the trigger keeps its closed width.
+          containerStyles={{
+            input: (base) => ({
+              ...base,
+              gridTemplateColumns: "0 minmax(2px, min-content)",
+            }),
+          }}
         />
       </Box>
       {isLiteral && (
@@ -171,7 +174,8 @@ function NumericOperandInput({
           onChange={(e) =>
             onChange({ type: "literal", value: e.target.valueAsNumber || 0 })
           }
-          style={{ maxWidth: 110, height: 38 }}
+          className={styles.numberInput}
+          style={{ width: 50, height: 38 }}
         />
       )}
     </Flex>
@@ -224,9 +228,9 @@ function NumericComputedColumnEditor({
       {/* Flat formula row: operand [op] operand [op] operand ... */}
       <Flex align="center" gap="2" wrap="wrap">
         {value.operands.map((operand, i) => (
-          <Flex align="center" gap="2" key={i} wrap="wrap">
+          <div className={styles.operandBlock} key={i}>
             {i > 0 && (
-              <Box style={{ width: 64 }}>
+              <Box style={{ width: 50 }}>
                 <SelectField
                   value={value.operators[i - 1] || "+"}
                   onChange={(v) => setOperator(i - 1, v)}
@@ -241,15 +245,19 @@ function NumericComputedColumnEditor({
               onChange={(o) => updateOperand(i, o)}
             />
             {value.operands.length > 1 && (
-              <Button
-                variant="ghost"
-                color="red"
-                onClick={() => removeOperand(i)}
-              >
-                <PiX />
-              </Button>
+              <span className={styles.removeButton}>
+                <Button
+                  variant="ghost"
+                  color="red"
+                  size="xs"
+                  aria-label="Remove operand"
+                  onClick={() => removeOperand(i)}
+                >
+                  <PiX size={11} />
+                </Button>
+              </span>
             )}
-          </Flex>
+          </div>
         ))}
         <a
           href="#"

--- a/packages/front-end/components/FactTables/ComputedColumnInput.tsx
+++ b/packages/front-end/components/FactTables/ComputedColumnInput.tsx
@@ -6,9 +6,13 @@ import {
   FactTableInterface,
   NumericComputedColumn,
   StringComputedColumn,
+  StringComputedColumnOperation,
 } from "shared/types/fact-table";
 import { PiPlus, PiX } from "react-icons/pi";
-import { getComputedColumnRef } from "shared/experiments";
+import {
+  getComputedColumnRef,
+  dataSourceSupportsRegexp,
+} from "shared/experiments";
 import SelectField, {
   GroupedValue,
   SingleValue,
@@ -43,6 +47,36 @@ function newNumericComputedColumn(): NumericComputedColumn {
 function newStringComputedColumn(): StringComputedColumn {
   return { id: genId(), name: "", kind: "string", parts: [newStringPart()] };
 }
+
+function newStringOperation(
+  type: StringComputedColumnOperation["type"],
+): StringComputedColumnOperation {
+  switch (type) {
+    case "replace":
+      return { type: "replace", find: "", replaceWith: "" };
+    case "regexpReplace":
+      return { type: "regexpReplace", pattern: "", replaceWith: "" };
+    case "regexpExtract":
+      return { type: "regexpExtract", pattern: "" };
+    case "upper":
+      return { type: "upper" };
+    case "lower":
+      return { type: "lower" };
+    case "trim":
+      return { type: "trim" };
+  }
+}
+
+// Options for the string-operation type dropdown. `regex` ops are filtered out
+// for datasources that can't run regular expressions.
+const STRING_OPERATION_OPTIONS: (SingleValue & { regex?: boolean })[] = [
+  { label: "Replace text", value: "replace" },
+  { label: "Replace (regex)", value: "regexpReplace", regex: true },
+  { label: "Extract (regex)", value: "regexpExtract", regex: true },
+  { label: "Uppercase", value: "upper" },
+  { label: "Lowercase", value: "lower" },
+  { label: "Trim whitespace", value: "trim" },
+];
 
 function getNumericColumnOptions(
   factTable: Pick<FactTableInterface, "columns" | "userIdTypes">,
@@ -187,11 +221,13 @@ function NumericComputedColumnEditor({
   factTable,
   priorColumns,
   setValue,
+  onRemove,
 }: {
   value: NumericComputedColumn;
   factTable: Pick<FactTableInterface, "columns" | "userIdTypes">;
   priorColumns: ComputedColumn[];
   setValue: (v: NumericComputedColumn) => void;
+  onRemove: () => void;
 }) {
   const columnOptions = [
     ...getNumericColumnOptions(factTable),
@@ -204,6 +240,12 @@ function NumericComputedColumnEditor({
     setValue({ ...value, operands });
   };
   const removeOperand = (i: number) => {
+    // Removing the only operand leaves no logic — delete the whole computed
+    // column instead of keeping an empty (invalid) formula.
+    if (value.operands.length <= 1) {
+      onRemove();
+      return;
+    }
     const operands = [...value.operands];
     operands.splice(i, 1);
     const operators = [...value.operators];
@@ -244,19 +286,14 @@ function NumericComputedColumnEditor({
               columnOptions={columnOptions}
               onChange={(o) => updateOperand(i, o)}
             />
-            {value.operands.length > 1 && (
-              <span className={styles.removeButton}>
-                <Button
-                  variant="ghost"
-                  color="red"
-                  size="xs"
-                  aria-label="Remove operand"
-                  onClick={() => removeOperand(i)}
-                >
-                  <PiX size={11} />
-                </Button>
-              </span>
-            )}
+            <button
+              type="button"
+              className={styles.removeButton}
+              aria-label="Remove operand"
+              onClick={() => removeOperand(i)}
+            >
+              <PiX size={9} />
+            </button>
           </div>
         ))}
         <a
@@ -332,16 +369,186 @@ function NumericComputedColumnEditor({
   );
 }
 
+// Ordered list of string transforms applied after the concat (trim, replace,
+// regex replace/extract, upper/lower). Regex ops are hidden when the datasource
+// can't run regular expressions.
+function StringOperationsEditor({
+  operations,
+  supportsRegexp,
+  setOperations,
+}: {
+  operations: StringComputedColumnOperation[];
+  supportsRegexp: boolean;
+  setOperations: (ops: StringComputedColumnOperation[]) => void;
+}) {
+  const typeOptions = STRING_OPERATION_OPTIONS.filter(
+    (o) => supportsRegexp || !o.regex,
+  );
+
+  const updateOp = (i: number, op: StringComputedColumnOperation) => {
+    const next = [...operations];
+    next[i] = op;
+    setOperations(next);
+  };
+  const removeOp = (i: number) => {
+    const next = [...operations];
+    next.splice(i, 1);
+    setOperations(next);
+  };
+
+  return (
+    <Flex direction="column" gap="2">
+      {operations.map((op, i) => (
+        <Flex align="center" gap="2" key={i} wrap="wrap">
+          <Box style={{ width: 160 }}>
+            <SelectField
+              value={op.type}
+              onChange={(v) =>
+                updateOp(
+                  i,
+                  newStringOperation(
+                    v as StringComputedColumnOperation["type"],
+                  ),
+                )
+              }
+              options={typeOptions}
+              sort={false}
+            />
+          </Box>
+          {(op.type === "replace" || op.type === "regexpReplace") && (
+            <>
+              <Field
+                value={op.type === "replace" ? op.find : op.pattern}
+                onChange={(e) =>
+                  updateOp(
+                    i,
+                    op.type === "replace"
+                      ? { ...op, find: e.target.value }
+                      : { ...op, pattern: e.target.value },
+                  )
+                }
+                placeholder={op.type === "replace" ? "find" : "pattern"}
+                style={{ maxWidth: 150 }}
+              />
+              <Text size="small" color="text-low">
+                →
+              </Text>
+              <Field
+                value={op.replaceWith}
+                onChange={(e) =>
+                  updateOp(i, { ...op, replaceWith: e.target.value })
+                }
+                placeholder="replace with"
+                style={{ maxWidth: 150 }}
+              />
+            </>
+          )}
+          {op.type === "regexpExtract" && (
+            <Field
+              value={op.pattern}
+              onChange={(e) => updateOp(i, { ...op, pattern: e.target.value })}
+              placeholder="pattern"
+              style={{ maxWidth: 200 }}
+            />
+          )}
+          <Button
+            variant="ghost"
+            color="red"
+            size="xs"
+            aria-label="Remove transform"
+            onClick={() => removeOp(i)}
+          >
+            <PiX />
+          </Button>
+        </Flex>
+      ))}
+      <div>
+        <a
+          href="#"
+          onClick={(e) => {
+            e.preventDefault();
+            setOperations([...operations, newStringOperation("replace")]);
+          }}
+        >
+          <PiPlus /> Add transform
+        </a>
+      </div>
+    </Flex>
+  );
+}
+
+// Sentinel option for "this part is a static text literal" — selecting it
+// reveals a text input beside the dropdown (mirrors NUMBER_OPTION_VALUE).
+const TEXT_OPTION_VALUE = "$$text";
+
+function StringPartInput({
+  part,
+  columnOptions,
+  onChange,
+}: {
+  part: ComputedColumnStringPart;
+  columnOptions: SingleValue[];
+  onChange: (p: ComputedColumnStringPart) => void;
+}) {
+  const isLiteral = part.type === "literal";
+  const options: GroupedValue[] = [];
+  if (columnOptions.length > 0) {
+    options.push({ label: "Columns", options: columnOptions });
+  }
+  options.push({
+    label: "Static",
+    options: [{ label: "Static Text", value: TEXT_OPTION_VALUE }],
+  });
+  return (
+    <Flex align="center" gap="2">
+      <Box style={{ minWidth: 100, width: "fit-content" }}>
+        <SelectField
+          value={isLiteral ? TEXT_OPTION_VALUE : part.column}
+          onChange={(v) =>
+            onChange(
+              v === TEXT_OPTION_VALUE
+                ? { type: "literal", value: isLiteral ? part.value : "" }
+                : { type: "column", column: v },
+            )
+          }
+          options={options}
+          placeholder="Column or text..."
+          sort={false}
+          required
+          containerStyles={{
+            input: (base) => ({
+              ...base,
+              gridTemplateColumns: "0 minmax(2px, min-content)",
+            }),
+          }}
+        />
+      </Box>
+      {isLiteral && (
+        <Field
+          value={part.value}
+          onChange={(e) => onChange({ type: "literal", value: e.target.value })}
+          placeholder="text"
+          style={{ maxWidth: 150, height: 38 }}
+        />
+      )}
+    </Flex>
+  );
+}
+
 function StringComputedColumnEditor({
   value,
   factTable,
   priorColumns,
+  supportsRegexp,
   setValue,
+  onRemove,
 }: {
   value: StringComputedColumn;
   factTable: Pick<FactTableInterface, "columns" | "userIdTypes">;
   priorColumns: ComputedColumn[];
+  supportsRegexp: boolean;
   setValue: (v: StringComputedColumn) => void;
+  onRemove: () => void;
 }) {
   const columnOptions = [
     ...getStringColumnOptions(factTable),
@@ -354,85 +561,68 @@ function StringComputedColumnEditor({
     setValue({ ...value, parts });
   };
   const removePart = (i: number) => {
+    // Removing the only part leaves nothing — delete the whole computed column.
+    if (value.parts.length <= 1) {
+      onRemove();
+      return;
+    }
     const parts = [...value.parts];
     parts.splice(i, 1);
     setValue({ ...value, parts });
   };
-  const addPart = (part: ComputedColumnStringPart) => {
-    setValue({ ...value, parts: [...value.parts, part] });
+  const addPart = () => {
+    setValue({ ...value, parts: [...value.parts, newStringPart()] });
   };
 
   return (
     <Flex direction="column" gap="2">
+      {/* Concatenation: part [concat] part [concat] part ... */}
       <Flex align="center" gap="2" wrap="wrap">
         {value.parts.map((part, i) => (
-          <Flex align="center" gap="2" key={i} wrap="wrap">
-            {i > 0 && <Text size="small">+</Text>}
-            <Box style={{ width: 104 }}>
-              <SelectField
-                value={part.type}
-                onChange={(v) =>
-                  updatePart(
-                    i,
-                    v === "literal"
-                      ? { type: "literal", value: "" }
-                      : { type: "column", column: "" },
-                  )
-                }
-                options={[
-                  { label: "Column", value: "column" },
-                  { label: "Text", value: "literal" },
-                ]}
-                sort={false}
-              />
-            </Box>
-            {part.type === "column" ? (
-              <Box style={{ minWidth: 170 }}>
-                <SelectField
-                  value={part.column}
-                  onChange={(column) =>
-                    updatePart(i, { type: "column", column })
-                  }
-                  options={columnOptions}
-                  placeholder="Select column..."
-                  required
-                />
-              </Box>
-            ) : (
-              <Field
-                value={part.value}
-                onChange={(e) =>
-                  updatePart(i, { type: "literal", value: e.target.value })
-                }
-                placeholder="text..."
-              />
+          <div className={styles.operandBlock} key={i}>
+            {i > 0 && (
+              <Text size="small" color="text-low">
+                concat
+              </Text>
             )}
-            {value.parts.length > 1 && (
-              <Button variant="ghost" color="red" onClick={() => removePart(i)}>
-                <PiX />
-              </Button>
-            )}
-          </Flex>
+            <StringPartInput
+              part={part}
+              columnOptions={columnOptions}
+              onChange={(p) => updatePart(i, p)}
+            />
+            <button
+              type="button"
+              className={styles.removeButton}
+              aria-label="Remove part"
+              onClick={() => removePart(i)}
+            >
+              <PiX size={9} />
+            </button>
+          </div>
         ))}
         <a
           href="#"
           onClick={(e) => {
             e.preventDefault();
-            addPart(newStringPart());
+            addPart();
           }}
         >
-          <PiPlus /> Column
-        </a>
-        <a
-          href="#"
-          onClick={(e) => {
-            e.preventDefault();
-            addPart({ type: "literal", value: "" });
-          }}
-        >
-          <PiPlus /> Text
+          <PiPlus /> Add
         </a>
       </Flex>
+
+      <Box mt="1">
+        <Text size="small" color="text-low">
+          Then transform (optional)
+        </Text>
+        <StringOperationsEditor
+          operations={value.operations || []}
+          supportsRegexp={supportsRegexp}
+          setOperations={(ops) =>
+            setValue({ ...value, operations: ops.length ? ops : undefined })
+          }
+        />
+      </Box>
     </Flex>
   );
 }
@@ -441,11 +631,16 @@ export function ComputedColumnInput({
   value,
   setValue,
   factTable,
+  datasourceType,
 }: {
   value: ComputedColumn[];
   setValue: (value: ComputedColumn[]) => void;
   factTable: Pick<FactTableInterface, "columns" | "userIdTypes">;
+  // Datasource engine (e.g. "postgres"); gates regexp string operations.
+  datasourceType?: string;
 }) {
+  const supportsRegexp = dataSourceSupportsRegexp(datasourceType);
+
   const updateColumn = (i: number, column: ComputedColumn) => {
     const next = [...value];
     next[i] = column;
@@ -504,7 +699,7 @@ export function ComputedColumnInput({
                 }
                 options={[
                   { label: "Number", value: "number" },
-                  { label: "String (concat)", value: "string" },
+                  { label: "String", value: "string" },
                 ]}
                 sort={false}
               />
@@ -525,13 +720,16 @@ export function ComputedColumnInput({
               factTable={factTable}
               priorColumns={value.slice(0, i)}
               setValue={(v) => updateColumn(i, v)}
+              onRemove={() => removeColumn(i)}
             />
           ) : (
             <StringComputedColumnEditor
               value={column}
               factTable={factTable}
               priorColumns={value.slice(0, i)}
+              supportsRegexp={supportsRegexp}
               setValue={(v) => updateColumn(i, v)}
+              onRemove={() => removeColumn(i)}
             />
           )}
         </Box>

--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -66,7 +66,6 @@ import { OfficialBadge } from "@/components/Metrics/MetricName";
 import { MetricDelaySettings } from "@/components/Metrics/MetricForm/MetricDelaySettings";
 import { MetricPriorSettingsForm } from "@/components/Metrics/MetricForm/MetricPriorSettingsForm";
 import Checkbox from "@/ui/Checkbox";
-import ConfirmDialog from "@/ui/ConfirmDialog";
 import Callout from "@/ui/Callout";
 import Code from "@/components/SyntaxHighlighting/Code";
 import HelperText from "@/ui/HelperText";
@@ -475,13 +474,6 @@ function ColumnRefSelector({
   const aggregationOptions = getAggregationOptions(selectedColumnDatatype);
   const [addUserFilter, setAddUserFilter] = useState(false);
 
-  // Computed columns are hidden behind a toggle. Start expanded when the ref
-  // already has definitions (e.g. editing an existing metric).
-  const [showComputedColumns, setShowComputedColumns] = useState(
-    () => (value.computedColumns?.length || 0) > 0,
-  );
-  const [confirmClearComputed, setConfirmClearComputed] = useState(false);
-
   // Update the ref's computed columns, clearing any reference to a removed one
   // so the metric never points at a `$$computed:<id>` that no longer exists.
   const setComputedColumns = (computedColumns: ComputedColumn[]) => {
@@ -629,46 +621,16 @@ function ColumnRefSelector({
 
       {factTable && (
         <div className="mb-3">
-          <Switch
-            label={<strong>Enable Computed Columns</strong>}
-            value={showComputedColumns}
-            onChange={(checked) => {
-              if (checked) {
-                setShowComputedColumns(true);
-              } else if (value.computedColumns?.length) {
-                // Warn before discarding existing definitions
-                setConfirmClearComputed(true);
-              } else {
-                setShowComputedColumns(false);
-              }
-            }}
+          <div className="mb-2">
+            <strong>Computed Columns</strong>
+          </div>
+          <ComputedColumnInput
+            factTable={factTable}
+            value={value.computedColumns || []}
+            setValue={setComputedColumns}
+            datasourceType={datasource?.type}
           />
-          {showComputedColumns && (
-            <div className="mt-2">
-              <ComputedColumnInput
-                factTable={factTable}
-                value={value.computedColumns || []}
-                setValue={setComputedColumns}
-                datasourceType={datasource?.type}
-              />
-            </div>
-          )}
         </div>
-      )}
-
-      {confirmClearComputed && (
-        <ConfirmDialog
-          title="Remove computed columns?"
-          content="Turning this off will delete all computed column definitions on this metric. Any values or filters that use them will be reset. This cannot be undone."
-          yesText="Remove"
-          noText="Cancel"
-          onConfirm={() => {
-            setComputedColumns([]);
-            setShowComputedColumns(false);
-            setConfirmClearComputed(false);
-          }}
-          onCancel={() => setConfirmClearComputed(false)}
-        />
       )}
 
       {factTable && (

--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -649,6 +649,7 @@ function ColumnRefSelector({
                 factTable={factTable}
                 value={value.computedColumns || []}
                 setValue={setComputedColumns}
+                datasourceType={datasource?.type}
               />
             </div>
           )}

--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -66,6 +66,7 @@ import { OfficialBadge } from "@/components/Metrics/MetricName";
 import { MetricDelaySettings } from "@/components/Metrics/MetricForm/MetricDelaySettings";
 import { MetricPriorSettingsForm } from "@/components/Metrics/MetricForm/MetricPriorSettingsForm";
 import Checkbox from "@/ui/Checkbox";
+import ConfirmDialog from "@/ui/ConfirmDialog";
 import Callout from "@/ui/Callout";
 import Code from "@/components/SyntaxHighlighting/Code";
 import HelperText from "@/ui/HelperText";
@@ -474,6 +475,34 @@ function ColumnRefSelector({
   const aggregationOptions = getAggregationOptions(selectedColumnDatatype);
   const [addUserFilter, setAddUserFilter] = useState(false);
 
+  // Computed columns are hidden behind a toggle. Start expanded when the ref
+  // already has definitions (e.g. editing an existing metric).
+  const [showComputedColumns, setShowComputedColumns] = useState(
+    () => (value.computedColumns?.length || 0) > 0,
+  );
+  const [confirmClearComputed, setConfirmClearComputed] = useState(false);
+
+  // Update the ref's computed columns, clearing any reference to a removed one
+  // so the metric never points at a `$$computed:<id>` that no longer exists.
+  const setComputedColumns = (computedColumns: ComputedColumn[]) => {
+    const validRefs = new Set(
+      computedColumns.map((cc) => getComputedColumnRef(cc.id)),
+    );
+    const isDangling = (col?: string) =>
+      !!col && col.startsWith(getComputedColumnRef("")) && !validRefs.has(col);
+
+    const next: ColumnRef = { ...value, computedColumns };
+    if (isDangling(next.column)) next.column = "$$count";
+    if (isDangling(next.aggregateFilterColumn)) {
+      next.aggregateFilterColumn = "";
+      next.aggregateFilter = "";
+    }
+    if (next.rowFilters?.some((f) => isDangling(f.column))) {
+      next.rowFilters = next.rowFilters.filter((f) => !isDangling(f.column));
+    }
+    setValue(next);
+  };
+
   return (
     <div className="appbox px-3 pt-3 bg-light">
       <div className="row align-items-top">
@@ -600,36 +629,45 @@ function ColumnRefSelector({
 
       {factTable && (
         <div className="mb-3">
-          <ComputedColumnInput
-            factTable={factTable}
-            value={value.computedColumns || []}
-            setValue={(computedColumns) => {
-              // When a computed column is removed, clear any reference to it so
-              // the metric doesn't point at a `$$computed:<id>` that no longer
-              // exists.
-              const validRefs = new Set(
-                computedColumns.map((cc) => getComputedColumnRef(cc.id)),
-              );
-              const isDangling = (col?: string) =>
-                !!col &&
-                col.startsWith(getComputedColumnRef("")) &&
-                !validRefs.has(col);
-
-              const next: ColumnRef = { ...value, computedColumns };
-              if (isDangling(next.column)) next.column = "$$count";
-              if (isDangling(next.aggregateFilterColumn)) {
-                next.aggregateFilterColumn = "";
-                next.aggregateFilter = "";
+          <Switch
+            label={<strong>Enable Computed Columns</strong>}
+            value={showComputedColumns}
+            onChange={(checked) => {
+              if (checked) {
+                setShowComputedColumns(true);
+              } else if (value.computedColumns?.length) {
+                // Warn before discarding existing definitions
+                setConfirmClearComputed(true);
+              } else {
+                setShowComputedColumns(false);
               }
-              if (next.rowFilters?.some((f) => isDangling(f.column))) {
-                next.rowFilters = next.rowFilters.filter(
-                  (f) => !isDangling(f.column),
-                );
-              }
-              setValue(next);
             }}
           />
+          {showComputedColumns && (
+            <div className="mt-2">
+              <ComputedColumnInput
+                factTable={factTable}
+                value={value.computedColumns || []}
+                setValue={setComputedColumns}
+              />
+            </div>
+          )}
         </div>
+      )}
+
+      {confirmClearComputed && (
+        <ConfirmDialog
+          title="Remove computed columns?"
+          content="Turning this off will delete all computed column definitions on this metric. Any values or filters that use them will be reset. This cannot be undone."
+          yesText="Remove"
+          noText="Cancel"
+          onConfirm={() => {
+            setComputedColumns([]);
+            setShowComputedColumns(false);
+            setConfirmClearComputed(false);
+          }}
+          onCancel={() => setConfirmClearComputed(false)}
+        />
       )}
 
       {factTable && (

--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -896,6 +896,7 @@ function getPreviewSQL({
       return buildComputedColumnSQL({
         computedColumn: computed,
         factTable,
+        computedColumns: columnRef.computedColumns,
         jsonExtract: (col, path) => `${col}.${path}`,
         escapeStringLiteral: (s) => s.replace(/'/g, "''"),
       });

--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -21,12 +21,16 @@ import {
   ColumnAggregation,
   FactTableColumnType,
   RowFilter,
+  ComputedColumn,
 } from "shared/types/fact-table";
 import {
   canInlineFilterColumn,
   getAggregateFilters,
   getColumnRefWhereClause,
   getSelectedColumnDatatype,
+  getComputedColumnRef,
+  findComputedColumn,
+  buildComputedColumnSQL,
 } from "shared/experiments";
 import { createLikeStringMatchFn } from "shared/sql";
 import { PiArrowSquareOut, PiPlus } from "react-icons/pi";
@@ -68,6 +72,7 @@ import HelperText from "@/ui/HelperText";
 import PaidFeatureBadge from "@/components/GetStarted/PaidFeatureBadge";
 import { useDemoDataSourceProject } from "@/hooks/useDemoDataSourceProject";
 import { RowFilterInput } from "@/components/FactTables/RowFilterInput";
+import { ComputedColumnInput } from "@/components/FactTables/ComputedColumnInput";
 import { getAttributeFieldsExposedAsColumns } from "@/components/FactTables/rowFilterUtils";
 import { MANAGED_BY_ADMIN } from "@/components/Metrics/MetricForm";
 import { DocLink } from "@/components/DocLink";
@@ -181,6 +186,7 @@ function getColumnOptions({
   showColumnsAsSums = false,
   excludeColumns,
   groupPrefix = "",
+  computedColumns,
 }: {
   factTable: FactTableInterface | null;
   datasource: DataSourceInterfaceWithParams | null;
@@ -194,6 +200,7 @@ function getColumnOptions({
   showColumnsAsSums?: boolean;
   excludeColumns?: Set<string>;
   groupPrefix?: string;
+  computedColumns?: ComputedColumn[];
 }): GroupedValue[] {
   const numericColumnOptions: SingleValue[] = getNumericColumns(factTable).map(
     (col) => ({
@@ -201,6 +208,16 @@ function getColumnOptions({
       value: col.column,
     }),
   );
+
+  // Numeric computed columns can be aggregated like any numeric column.
+  computedColumns?.forEach((cc) => {
+    if (cc.kind !== "number") return;
+    const label = cc.name || cc.id;
+    numericColumnOptions.push({
+      label: showColumnsAsSums ? `SUM(${label})` : label,
+      value: getComputedColumnRef(cc.id),
+    });
+  });
 
   const specialColumnOptions: SingleValue[] = [];
   if (includeCountDistinct) {
@@ -445,11 +462,13 @@ function ColumnRefSelector({
     includeStringColumns:
       datasource.properties?.hasCountDistinctHLL && aggregationType === "unit",
     includeJSONFields: true,
+    computedColumns: value.computedColumns,
   });
 
   const selectedColumnDatatype = getSelectedColumnDatatype({
     factTable,
     column: value.column,
+    computedColumns: value.computedColumns,
   });
 
   const aggregationOptions = getAggregationOptions(selectedColumnDatatype);
@@ -537,6 +556,7 @@ function ColumnRefSelector({
                 const newDatatype = getSelectedColumnDatatype({
                   factTable,
                   column,
+                  computedColumns: value.computedColumns,
                 });
 
                 let aggregation = value.aggregation;
@@ -557,7 +577,8 @@ function ColumnRefSelector({
           </div>
         )}
         {includeColumn &&
-          !value.column.startsWith("$$") &&
+          (!value.column.startsWith("$$") ||
+            value.column.startsWith(getComputedColumnRef(""))) &&
           aggregationType === "unit" && (
             <div className="col-auto">
               <SelectField
@@ -579,9 +600,44 @@ function ColumnRefSelector({
 
       {factTable && (
         <div className="mb-3">
+          <ComputedColumnInput
+            factTable={factTable}
+            value={value.computedColumns || []}
+            setValue={(computedColumns) => {
+              // When a computed column is removed, clear any reference to it so
+              // the metric doesn't point at a `$$computed:<id>` that no longer
+              // exists.
+              const validRefs = new Set(
+                computedColumns.map((cc) => getComputedColumnRef(cc.id)),
+              );
+              const isDangling = (col?: string) =>
+                !!col &&
+                col.startsWith(getComputedColumnRef("")) &&
+                !validRefs.has(col);
+
+              const next: ColumnRef = { ...value, computedColumns };
+              if (isDangling(next.column)) next.column = "$$count";
+              if (isDangling(next.aggregateFilterColumn)) {
+                next.aggregateFilterColumn = "";
+                next.aggregateFilter = "";
+              }
+              if (next.rowFilters?.some((f) => isDangling(f.column))) {
+                next.rowFilters = next.rowFilters.filter(
+                  (f) => !isDangling(f.column),
+                );
+              }
+              setValue(next);
+            }}
+          />
+        </div>
+      )}
+
+      {factTable && (
+        <div className="mb-3">
           <RowFilterInput
             factTable={factTable}
             value={value.rowFilters || []}
+            computedColumns={value.computedColumns}
             setValue={(rowFilters) =>
               setValue({
                 ...value,
@@ -626,6 +682,7 @@ function ColumnRefSelector({
                       includeStringColumns: false,
                       showColumnsAsSums: true,
                       groupPrefix: "Filter by ",
+                      computedColumns: value.computedColumns,
                     })}
                     initialOption="Any User"
                     autoFocus
@@ -787,6 +844,32 @@ function getPreviewSQL({
   const denominatorName =
     "`" + (denominatorFactTable?.name || "Fact Table") + "`";
 
+  // Resolve the column to a SQL expression, expanding computed-column markers
+  // so the preview shows the underlying arithmetic (e.g. SUM((price * qty))).
+  const previewColExpr = (
+    columnRef: ColumnRef,
+    factTable: FactTableInterface | null,
+  ): string => {
+    const computed = findComputedColumn(
+      columnRef.computedColumns,
+      columnRef.column,
+    );
+    if (computed && factTable) {
+      return buildComputedColumnSQL({
+        computedColumn: computed,
+        factTable,
+        jsonExtract: (col, path) => `${col}.${path}`,
+        escapeStringLiteral: (s) => s.replace(/'/g, "''"),
+      });
+    }
+    return columnRef.column;
+  };
+
+  const numeratorColExpr = previewColExpr(numerator, numeratorFactTable);
+  const denominatorColExpr = denominator
+    ? previewColExpr(denominator, denominatorFactTable)
+    : "";
+
   const numeratorCol =
     type === "dailyParticipation" || numerator.column === "$$distinctDates"
       ? `COUNT(DISTINCT DATE(timestamp))`
@@ -795,9 +878,9 @@ function getPreviewSQL({
         : numerator.column === "$$distinctUsers"
           ? "1"
           : numerator.aggregation === "count distinct"
-            ? `COUNT(DISTINCT ${numerator.column})`
+            ? `COUNT(DISTINCT ${numeratorColExpr})`
             : `${(numerator.aggregation ?? "sum").toUpperCase()}(${
-                numerator.column
+                numeratorColExpr
               })`;
   const numeratorAdjustment =
     type === "dailyParticipation" ? "\n\t/ CEIL(days_since_exposure)" : "";
@@ -810,9 +893,9 @@ function getPreviewSQL({
         : denominator?.column === "$$distinctDates"
           ? `COUNT(DISTINCT DATE(timestamp))`
           : denominator?.aggregation === "count distinct"
-            ? `-- HyperLogLog estimation used instead of COUNT DISTINCT\n  COUNT(DISTINCT ${denominator?.column})`
+            ? `-- HyperLogLog estimation used instead of COUNT DISTINCT\n  COUNT(DISTINCT ${denominatorColExpr})`
             : `${(denominator?.aggregation ?? "sum").toUpperCase()}(${
-                denominator?.column
+                denominatorColExpr
               })`;
 
   const WHERE = getWHERE({

--- a/packages/front-end/components/FactTables/RowFilterInput.tsx
+++ b/packages/front-end/components/FactTables/RowFilterInput.tsx
@@ -1,5 +1,10 @@
 import { Flex } from "@radix-ui/themes";
-import { FactTableInterface, RowFilter } from "shared/types/fact-table";
+import {
+  ComputedColumn,
+  FactTableInterface,
+  RowFilter,
+} from "shared/types/fact-table";
+import { getComputedColumnRef } from "shared/experiments";
 import { PiPlus, PiX } from "react-icons/pi";
 import { useState } from "react";
 import Field from "@/components/Forms/Field";
@@ -23,10 +28,13 @@ export function RowFilterInput({
   value,
   setValue,
   factTable,
+  computedColumns,
 }: {
   value: RowFilter[];
   setValue: (value: RowFilter[]) => void;
   factTable: Pick<FactTableInterface, "columns" | "filters" | "userIdTypes">;
+  // Metric-scoped computed columns available to filter on (`$$computed:<id>`)
+  computedColumns?: ComputedColumn[];
 }) {
   const [rowDeleted, setRowDeleted] = useState(false);
   const hiddenAttributeFields = getAttributeFieldsExposedAsColumns(factTable);
@@ -61,6 +69,14 @@ export function RowFilterInput({
               });
             });
           }
+        });
+
+        // Metric-scoped computed columns can also be filtered on
+        computedColumns?.forEach((cc) => {
+          columnOptions.push({
+            label: cc.name || cc.id,
+            value: getComputedColumnRef(cc.id),
+          });
         });
         if (
           filter.column &&
@@ -131,6 +147,7 @@ export function RowFilterInput({
           const { datatype, topValues } = getColumnInfo(
             factTable,
             filter.column,
+            computedColumns,
           );
 
           const allowedOperators = getAllowedOperators(datatype);
@@ -235,7 +252,11 @@ export function RowFilterInput({
                     values: [],
                   });
                 } else {
-                  const { datatype } = getColumnInfo(factTable, v);
+                  const { datatype } = getColumnInfo(
+                    factTable,
+                    v,
+                    computedColumns,
+                  );
 
                   let newOperator = filter.operator;
                   let newValues = filter.values || [];

--- a/packages/front-end/components/FactTables/rowFilterUtils.ts
+++ b/packages/front-end/components/FactTables/rowFilterUtils.ts
@@ -1,4 +1,9 @@
-import { FactTableInterface, RowFilter } from "shared/types/fact-table";
+import {
+  ComputedColumn,
+  FactTableInterface,
+  RowFilter,
+} from "shared/types/fact-table";
+import { findComputedColumn } from "shared/experiments";
 
 export const NUMBER_PATTERN = "^-?(\\d+|\\d*\\.\\d+)$";
 
@@ -88,9 +93,16 @@ export function getAttributeFieldsExposedAsColumns(
 export function getColumnInfo(
   factTable: Pick<FactTableInterface, "columns">,
   column: string | undefined,
+  computedColumns?: ComputedColumn[],
 ) {
   if (!column) {
     return { datatype: "" as const, topValues: [] as string[] };
+  }
+
+  // Computed columns carry their own datatype (number or string)
+  const computed = findComputedColumn(computedColumns, column);
+  if (computed) {
+    return { datatype: computed.kind, topValues: [] as string[] };
   }
 
   // First, look for exact match

--- a/packages/shared/src/experiments/experiments.ts
+++ b/packages/shared/src/experiments/experiments.ts
@@ -10,7 +10,11 @@ import {
   NULL_DIMENSION_VALUE,
   NULL_DIMENSION_DISPLAY,
 } from "shared/constants";
-import { COMPUTED_COLUMN_PREFIX } from "shared/validators";
+// Import directly from the fact-table validator module rather than the
+// `shared/validators` barrel: the barrel pulls in `safe-rollout-snapshot`, which
+// imports from `shared/enterprise`, creating an enterprise → experiments →
+// validators → enterprise initialization cycle (leaves the enterprise validator
+// undefined at load time). See comparison.test.ts.
 import { MetricInterface } from "shared/types/metric";
 import {
   ColumnRef,
@@ -52,6 +56,7 @@ import {
 } from "shared/types/stats";
 import { MetricGroupInterface } from "shared/types/metric-groups";
 import { StringMatchFn, TemplateVariables } from "shared/types/sql";
+import { COMPUTED_COLUMN_PREFIX } from "../validators/fact-table";
 import { stringToBoolean } from "../util";
 
 export type ExperimentMetricInterface = MetricInterface | FactMetricInterface;

--- a/packages/shared/src/experiments/experiments.ts
+++ b/packages/shared/src/experiments/experiments.ts
@@ -15,6 +15,7 @@ import { MetricInterface } from "shared/types/metric";
 import {
   ColumnRef,
   ComputedColumn,
+  ComputedColumnOperand,
   FactMetricInterface,
   FactTableColumnType,
   FactTableInterface,
@@ -204,66 +205,85 @@ export function findComputedColumn(
 /**
  * Build the SQL expression for a computed column.
  *
- * Numeric computed columns are a sum-of-products: `(a * b) + (c / d) - e`.
- * Multiplicative operands within a term are combined first (so precedence is
- * correct without a parser), divisors are wrapped in `NULLIF(x, 0)` to avoid
- * divide-by-zero, and column operands can optionally be wrapped in
- * `COALESCE(col, 0)`. String computed columns concatenate their parts.
+ * Numeric computed columns are a flat arithmetic expression — operands joined by
+ * `+ - * /` (e.g. `price * quantity + shipping`). SQL's native precedence makes
+ * `*` / `/` bind before `+` / `-`, so no parentheses are needed. Divisors are
+ * wrapped in `NULLIF(x, 0)` to avoid divide-by-zero, and column operands can
+ * optionally be wrapped in `COALESCE(col, 0)`. String computed columns
+ * concatenate their parts.
  */
 export function buildComputedColumnSQL({
   computedColumn,
   factTable,
+  computedColumns,
   jsonExtract,
   escapeStringLiteral,
   dialect,
   alias = "",
+  seen = new Set<string>(),
 }: {
   computedColumn: ComputedColumn;
   factTable: Pick<FactTableInterface, "columns">;
+  // Sibling computed columns, so a `$$computed:<id>` operand/part can be resolved
+  // to another computed column defined earlier on the same ColumnRef.
+  computedColumns?: ComputedColumn[];
   jsonExtract: (jsonCol: string, path: string, isNumeric: boolean) => string;
   escapeStringLiteral: (s: string) => string;
   dialect?: ComputedColumnDialect;
   alias?: string;
+  // Ids currently being expanded, used to guard against reference cycles.
+  seen?: Set<string>;
 }): string {
   const concat = dialect?.concat ?? defaultConcat;
   const round = dialect?.round ?? defaultRound;
+
+  // Resolve a column reference, transparently expanding nested computed columns.
+  const nestedSeen = new Set(seen).add(computedColumn.id);
+  const resolveColumn = (col: string): string => {
+    const nested = findComputedColumn(computedColumns, col);
+    if (nested) {
+      // A cycle should be impossible (the UI only lets you reference earlier
+      // columns and validation enforces it), but guard against it anyway so a
+      // malformed doc can't blow the stack.
+      if (nestedSeen.has(nested.id)) return "NULL";
+      return buildComputedColumnSQL({
+        computedColumn: nested,
+        factTable,
+        computedColumns,
+        jsonExtract,
+        escapeStringLiteral,
+        dialect,
+        alias,
+        seen: nestedSeen,
+      });
+    }
+    return getColumnExpression(col, factTable, jsonExtract, alias);
+  };
 
   if (computedColumn.kind === "string") {
     const parts = computedColumn.parts.map((part) =>
       part.type === "literal"
         ? `'${escapeStringLiteral(part.value)}'`
-        : getColumnExpression(part.column, factTable, jsonExtract, alias),
+        : resolveColumn(part.column),
     );
     return concat(parts);
   }
 
-  const termSQLs = computedColumn.terms.map((term) => {
-    const operandSQLs = term.operands.map((operand) => {
-      if (operand.type === "literal") {
-        return formatNumericLiteral(operand.value);
-      }
-      const colExpr = getColumnExpression(
-        operand.column,
-        factTable,
-        jsonExtract,
-        alias,
-      );
-      return computedColumn.coalesceZero ? `COALESCE(${colExpr}, 0)` : colExpr;
-    });
+  const operandSQL = (operand: ComputedColumnOperand): string => {
+    if (operand.type === "literal") {
+      return formatNumericLiteral(operand.value);
+    }
+    const colExpr = resolveColumn(operand.column);
+    return computedColumn.coalesceZero ? `COALESCE(${colExpr}, 0)` : colExpr;
+  };
 
-    let expr = operandSQLs[0];
-    term.operators.forEach((op, i) => {
-      const rhs =
-        op === "/" ? `NULLIF(${operandSQLs[i + 1]}, 0)` : operandSQLs[i + 1];
-      expr = `${expr} ${op} ${rhs}`;
-    });
-    // Parenthesize multi-operand terms so `*`/`/` bind tighter than `+`/`-`
-    return term.operators.length > 0 ? `(${expr})` : expr;
-  });
-
-  let expr = termSQLs[0];
-  computedColumn.termOperators.forEach((op, i) => {
-    expr = `${expr} ${op} ${termSQLs[i + 1]}`;
+  const operandSQLs = computedColumn.operands.map(operandSQL);
+  let expr = operandSQLs[0];
+  computedColumn.operators.forEach((op, i) => {
+    // Guard division against divide-by-zero
+    const rhs =
+      op === "/" ? `NULLIF(${operandSQLs[i + 1]}, 0)` : operandSQLs[i + 1];
+    expr = `${expr} ${op} ${rhs}`;
   });
 
   if (computedColumn.rounding) {
@@ -274,9 +294,9 @@ export function buildComputedColumnSQL({
     );
   }
 
-  // Wrap in parens when the expression combines multiple terms so it composes
-  // safely wherever it is embedded (comparisons, aggregations, etc.).
-  return computedColumn.termOperators.length > 0 ? `(${expr})` : expr;
+  // Wrap in parens when the expression has any operator so it composes safely
+  // wherever it is embedded (comparisons, aggregations, etc.).
+  return computedColumn.operators.length > 0 ? `(${expr})` : expr;
 }
 
 /**
@@ -305,6 +325,7 @@ export function resolveColumnExpression({
     return buildComputedColumnSQL({
       computedColumn: computed,
       factTable,
+      computedColumns,
       jsonExtract,
       escapeStringLiteral,
       dialect,
@@ -457,6 +478,7 @@ export function getRowFilterSQL({
     ? buildComputedColumnSQL({
         computedColumn,
         factTable,
+        computedColumns,
         jsonExtract,
         escapeStringLiteral,
         dialect,

--- a/packages/shared/src/experiments/experiments.ts
+++ b/packages/shared/src/experiments/experiments.ts
@@ -160,6 +160,48 @@ export interface ComputedColumnDialect {
   ) => string;
   // CONCAT of already-stringified parts
   concat?: (parts: string[]) => string;
+  // Literal substring replace. `find`/`replaceWith` are already-quoted SQL
+  // string literals.
+  replace?: (expr: string, find: string, replaceWith: string) => string;
+  // Regular-expression replace (all matches). `pattern`/`replaceWith` are
+  // already-quoted SQL string literals.
+  regexpReplace?: (
+    expr: string,
+    pattern: string,
+    replaceWith: string,
+  ) => string;
+  // Extract the first regular-expression match. `pattern` is an already-quoted
+  // SQL string literal.
+  regexpExtract?: (expr: string, pattern: string) => string;
+  upper?: (expr: string) => string;
+  lower?: (expr: string) => string;
+  trim?: (expr: string) => string;
+}
+
+/**
+ * Build a {@link ComputedColumnDialect} from a full SQL dialect by picking just
+ * the builders computed columns need.
+ */
+export function computedColumnDialectFromSql(d: {
+  round: ComputedColumnDialect["round"];
+  concat: ComputedColumnDialect["concat"];
+  replace: ComputedColumnDialect["replace"];
+  regexpReplace: ComputedColumnDialect["regexpReplace"];
+  regexpExtract: ComputedColumnDialect["regexpExtract"];
+  upper: ComputedColumnDialect["upper"];
+  lower: ComputedColumnDialect["lower"];
+  trim: ComputedColumnDialect["trim"];
+}): ComputedColumnDialect {
+  return {
+    round: d.round,
+    concat: d.concat,
+    replace: d.replace,
+    regexpReplace: d.regexpReplace,
+    regexpExtract: d.regexpExtract,
+    upper: d.upper,
+    lower: d.lower,
+    trim: d.trim,
+  };
 }
 
 function defaultRound(
@@ -181,6 +223,36 @@ function defaultConcat(parts: string[]): string {
   return `CONCAT(${parts.join(", ")})`;
 }
 
+// Default string-operation builders. These use the most broadly-portable
+// spellings; dialects override where their syntax differs (e.g. Postgres needs
+// a `'g'` flag for a global regexp replace, ClickHouse uses `replaceAll`).
+function defaultReplace(
+  expr: string,
+  find: string,
+  replaceWith: string,
+): string {
+  return `REPLACE(${expr}, ${find}, ${replaceWith})`;
+}
+function defaultRegexpReplace(
+  expr: string,
+  pattern: string,
+  replaceWith: string,
+): string {
+  return `REGEXP_REPLACE(${expr}, ${pattern}, ${replaceWith})`;
+}
+function defaultRegexpExtract(expr: string, pattern: string): string {
+  return `REGEXP_SUBSTR(${expr}, ${pattern})`;
+}
+function defaultUpper(expr: string): string {
+  return `UPPER(${expr})`;
+}
+function defaultLower(expr: string): string {
+  return `LOWER(${expr})`;
+}
+function defaultTrim(expr: string): string {
+  return `TRIM(${expr})`;
+}
+
 // Render a numeric literal without scientific notation for typical ranges.
 function formatNumericLiteral(n: number): string {
   if (!Number.isFinite(n)) return "0";
@@ -195,6 +267,14 @@ export function isComputedColumnRef(column: string | undefined): boolean {
 /** Build the `$$computed:<id>` marker used to reference a computed column. */
 export function getComputedColumnRef(id: string): string {
   return `${COMPUTED_COLUMN_PREFIX}${id}`;
+}
+
+// Warehouses that can't run REGEXP_REPLACE / REGEXP_SUBSTR, so regexp-based
+// string operations are hidden in the UI and rejected by validation. MSSQL has
+// no regex functions before SQL Server 2025. (MySQL needs 8.0+, which we assume.)
+const DATA_SOURCES_WITHOUT_REGEXP = new Set(["mssql"]);
+export function dataSourceSupportsRegexp(type?: string | null): boolean {
+  return !!type && !DATA_SOURCES_WITHOUT_REGEXP.has(type);
 }
 
 /** Resolve a `$$computed:<id>` marker to its definition on a ColumnRef. */
@@ -271,7 +351,40 @@ export function buildComputedColumnSQL({
         ? `'${escapeStringLiteral(part.value)}'`
         : resolveColumn(part.column),
     );
-    return concat(parts);
+    // A single part needs no CONCAT wrapper (keeps transforms readable).
+    let expr = parts.length === 1 ? parts[0] : concat(parts);
+
+    const replace = dialect?.replace ?? defaultReplace;
+    const regexpReplace = dialect?.regexpReplace ?? defaultRegexpReplace;
+    const regexpExtract = dialect?.regexpExtract ?? defaultRegexpExtract;
+    const upper = dialect?.upper ?? defaultUpper;
+    const lower = dialect?.lower ?? defaultLower;
+    const trim = dialect?.trim ?? defaultTrim;
+    const lit = (s: string) => `'${escapeStringLiteral(s)}'`;
+
+    (computedColumn.operations ?? []).forEach((op) => {
+      switch (op.type) {
+        case "replace":
+          expr = replace(expr, lit(op.find), lit(op.replaceWith));
+          break;
+        case "regexpReplace":
+          expr = regexpReplace(expr, lit(op.pattern), lit(op.replaceWith));
+          break;
+        case "regexpExtract":
+          expr = regexpExtract(expr, lit(op.pattern));
+          break;
+        case "upper":
+          expr = upper(expr);
+          break;
+        case "lower":
+          expr = lower(expr);
+          break;
+        case "trim":
+          expr = trim(expr);
+          break;
+      }
+    });
+    return expr;
   }
 
   const operandSQL = (operand: ComputedColumnOperand): string => {

--- a/packages/shared/src/experiments/experiments.ts
+++ b/packages/shared/src/experiments/experiments.ts
@@ -10,9 +10,11 @@ import {
   NULL_DIMENSION_VALUE,
   NULL_DIMENSION_DISPLAY,
 } from "shared/constants";
+import { COMPUTED_COLUMN_PREFIX } from "shared/validators";
 import { MetricInterface } from "shared/types/metric";
 import {
   ColumnRef,
+  ComputedColumn,
   FactMetricInterface,
   FactTableColumnType,
   FactTableInterface,
@@ -140,6 +142,178 @@ export function getColumnExpression(
   return alias ? `${alias}.${column}` : column;
 }
 
+// ---- Computed columns ----
+
+/** SQL builders for computed columns that differ by warehouse dialect. */
+export interface ComputedColumnDialect {
+  // ROUND / FLOOR / CEIL to an optional number of decimal places
+  round?: (
+    expr: string,
+    mode: "round" | "floor" | "ceil",
+    decimals?: number,
+  ) => string;
+  // CONCAT of already-stringified parts
+  concat?: (parts: string[]) => string;
+}
+
+function defaultRound(
+  expr: string,
+  mode: "round" | "floor" | "ceil",
+  decimals?: number,
+): string {
+  const d = decimals ?? 0;
+  if (mode === "round") return `ROUND(${expr}, ${d})`;
+  const fn = mode === "floor" ? "FLOOR" : "CEIL";
+  if (d > 0) {
+    const factor = Math.pow(10, d);
+    return `${fn}((${expr}) * ${factor}) / ${factor}`;
+  }
+  return `${fn}(${expr})`;
+}
+
+function defaultConcat(parts: string[]): string {
+  return `CONCAT(${parts.join(", ")})`;
+}
+
+// Render a numeric literal without scientific notation for typical ranges.
+function formatNumericLiteral(n: number): string {
+  if (!Number.isFinite(n)) return "0";
+  return n.toString();
+}
+
+/** True if a `column` string references a computed column (`$$computed:<id>`). */
+export function isComputedColumnRef(column: string | undefined): boolean {
+  return !!column && column.startsWith(COMPUTED_COLUMN_PREFIX);
+}
+
+/** Build the `$$computed:<id>` marker used to reference a computed column. */
+export function getComputedColumnRef(id: string): string {
+  return `${COMPUTED_COLUMN_PREFIX}${id}`;
+}
+
+/** Resolve a `$$computed:<id>` marker to its definition on a ColumnRef. */
+export function findComputedColumn(
+  computedColumns: ComputedColumn[] | undefined,
+  column: string | undefined,
+): ComputedColumn | undefined {
+  if (!computedColumns || !isComputedColumnRef(column)) return undefined;
+  const id = (column as string).slice(COMPUTED_COLUMN_PREFIX.length);
+  return computedColumns.find((c) => c.id === id);
+}
+
+/**
+ * Build the SQL expression for a computed column.
+ *
+ * Numeric computed columns are a sum-of-products: `(a * b) + (c / d) - e`.
+ * Multiplicative operands within a term are combined first (so precedence is
+ * correct without a parser), divisors are wrapped in `NULLIF(x, 0)` to avoid
+ * divide-by-zero, and column operands can optionally be wrapped in
+ * `COALESCE(col, 0)`. String computed columns concatenate their parts.
+ */
+export function buildComputedColumnSQL({
+  computedColumn,
+  factTable,
+  jsonExtract,
+  escapeStringLiteral,
+  dialect,
+  alias = "",
+}: {
+  computedColumn: ComputedColumn;
+  factTable: Pick<FactTableInterface, "columns">;
+  jsonExtract: (jsonCol: string, path: string, isNumeric: boolean) => string;
+  escapeStringLiteral: (s: string) => string;
+  dialect?: ComputedColumnDialect;
+  alias?: string;
+}): string {
+  const concat = dialect?.concat ?? defaultConcat;
+  const round = dialect?.round ?? defaultRound;
+
+  if (computedColumn.kind === "string") {
+    const parts = computedColumn.parts.map((part) =>
+      part.type === "literal"
+        ? `'${escapeStringLiteral(part.value)}'`
+        : getColumnExpression(part.column, factTable, jsonExtract, alias),
+    );
+    return concat(parts);
+  }
+
+  const termSQLs = computedColumn.terms.map((term) => {
+    const operandSQLs = term.operands.map((operand) => {
+      if (operand.type === "literal") {
+        return formatNumericLiteral(operand.value);
+      }
+      const colExpr = getColumnExpression(
+        operand.column,
+        factTable,
+        jsonExtract,
+        alias,
+      );
+      return computedColumn.coalesceZero ? `COALESCE(${colExpr}, 0)` : colExpr;
+    });
+
+    let expr = operandSQLs[0];
+    term.operators.forEach((op, i) => {
+      const rhs =
+        op === "/" ? `NULLIF(${operandSQLs[i + 1]}, 0)` : operandSQLs[i + 1];
+      expr = `${expr} ${op} ${rhs}`;
+    });
+    // Parenthesize multi-operand terms so `*`/`/` bind tighter than `+`/`-`
+    return term.operators.length > 0 ? `(${expr})` : expr;
+  });
+
+  let expr = termSQLs[0];
+  computedColumn.termOperators.forEach((op, i) => {
+    expr = `${expr} ${op} ${termSQLs[i + 1]}`;
+  });
+
+  if (computedColumn.rounding) {
+    return round(
+      expr,
+      computedColumn.rounding.mode,
+      computedColumn.rounding.decimals,
+    );
+  }
+
+  // Wrap in parens when the expression combines multiple terms so it composes
+  // safely wherever it is embedded (comparisons, aggregations, etc.).
+  return computedColumn.termOperators.length > 0 ? `(${expr})` : expr;
+}
+
+/**
+ * Resolve a `column` string to SQL, transparently handling computed-column
+ * markers. Falls back to {@link getColumnExpression} for regular columns.
+ */
+export function resolveColumnExpression({
+  column,
+  factTable,
+  computedColumns,
+  jsonExtract,
+  escapeStringLiteral,
+  dialect,
+  alias = "",
+}: {
+  column: string;
+  factTable: Pick<FactTableInterface, "columns">;
+  computedColumns: ComputedColumn[] | undefined;
+  jsonExtract: (jsonCol: string, path: string, isNumeric: boolean) => string;
+  escapeStringLiteral: (s: string) => string;
+  dialect?: ComputedColumnDialect;
+  alias?: string;
+}): string {
+  const computed = findComputedColumn(computedColumns, column);
+  if (computed) {
+    return buildComputedColumnSQL({
+      computedColumn: computed,
+      factTable,
+      jsonExtract,
+      escapeStringLiteral,
+      dialect,
+      alias,
+    });
+  }
+  return getColumnExpression(column, factTable, jsonExtract, alias);
+}
+
 export function getColumnRefWhereClause({
   factTable,
   columnRef,
@@ -149,6 +323,7 @@ export function getColumnRefWhereClause({
   evalBoolean,
   showSourceComment = false,
   sliceInfo,
+  dialect,
 }: {
   factTable: Pick<FactTableInterface, "columns" | "filters" | "userIdTypes">;
   columnRef: ColumnRef;
@@ -158,6 +333,8 @@ export function getColumnRefWhereClause({
   evalBoolean: (col: string, value: boolean) => string;
   showSourceComment?: boolean;
   sliceInfo?: SliceMetricInfo;
+  // Dialect-specific builders used when a row filter targets a computed column
+  dialect?: ComputedColumnDialect;
 }): string[] {
   const where = new Set<string>();
 
@@ -221,6 +398,8 @@ export function getColumnRefWhereClause({
       stringMatch,
       evalBoolean,
       showSourceComment,
+      computedColumns: columnRef.computedColumns,
+      dialect,
     });
     if (filterSQL) {
       where.add(filterSQL);
@@ -238,6 +417,8 @@ export function getRowFilterSQL({
   stringMatch,
   evalBoolean,
   showSourceComment = false,
+  computedColumns,
+  dialect,
 }: {
   rowFilter: RowFilter;
   factTable: Pick<FactTableInterface, "columns" | "filters" | "userIdTypes">;
@@ -246,6 +427,9 @@ export function getRowFilterSQL({
   stringMatch: StringMatchFn;
   evalBoolean: (col: string, value: boolean) => string;
   showSourceComment?: boolean;
+  // Computed columns defined on the ColumnRef; a filter may target one via `$$computed:<id>`
+  computedColumns?: ComputedColumn[];
+  dialect?: ComputedColumnDialect;
 }): string | null {
   // Some operators do not require a column
   if (rowFilter.operator === "saved_filter") {
@@ -268,15 +452,22 @@ export function getRowFilterSQL({
   if (!rowFilter.column) {
     return null;
   }
-  const columnExpr = getColumnExpression(
-    rowFilter.column,
-    factTable,
-    jsonExtract,
-  );
-  const columnType = getSelectedColumnDatatype({
-    factTable,
-    column: rowFilter.column,
-  });
+  const computedColumn = findComputedColumn(computedColumns, rowFilter.column);
+  const columnExpr = computedColumn
+    ? buildComputedColumnSQL({
+        computedColumn,
+        factTable,
+        jsonExtract,
+        escapeStringLiteral,
+        dialect,
+      })
+    : getColumnExpression(rowFilter.column, factTable, jsonExtract);
+  const columnType = computedColumn
+    ? computedColumn.kind
+    : getSelectedColumnDatatype({
+        factTable,
+        column: rowFilter.column,
+      });
 
   // If a boolean column is using equals operator, convert to is_true/is_false
   let operator = rowFilter.operator;
@@ -534,12 +725,19 @@ export function getSelectedColumnDatatype({
   factTable,
   column,
   excludeDeleted = false,
+  computedColumns,
 }: {
   factTable: Pick<FactTableInterface, "columns"> | null;
   column: string;
   excludeDeleted?: boolean;
+  // Computed columns defined on a ColumnRef; `$$computed:<id>` resolves to their kind
+  computedColumns?: ComputedColumn[];
 }): FactTableColumnType | undefined {
   if (!factTable) return undefined;
+
+  // Computed columns carry their own datatype (number or string)
+  const computedColumn = findComputedColumn(computedColumns, column);
+  if (computedColumn) return computedColumn.kind;
 
   // Might be a JSON column, look at nested field
   const parts = column.split(".");

--- a/packages/shared/src/validators/fact-metrics.ts
+++ b/packages/shared/src/validators/fact-metrics.ts
@@ -4,8 +4,19 @@ import { ownerEmailField, ownerField, ownerInputField } from "./owner-field";
 import { apiPaginationFieldsValidator, paginationQueryFields } from "./shared";
 
 import { namedSchema } from "./openapi-helpers";
+import { computedColumnValidator } from "./fact-table";
 
 // Shared sub-schemas for fact metric column references
+
+// Metric-scoped computed columns, shared by request and response ref schemas.
+// Reference one from `column`, `aggregateFilterColumn`, or a row filter's
+// `column` using the marker `$$computed:<id>`.
+const apiComputedColumnsField = z
+  .array(computedColumnValidator)
+  .describe(
+    "Metric-scoped computed (derived) columns. A numeric computed column is a sum-of-products of columns and numeric literals; a string computed column concatenates parts. Reference one from `column`, `aggregateFilterColumn`, or a row filter's `column` using the marker `$$computed:<id>`.",
+  )
+  .optional();
 
 const apiRowFilterValidator = z.object({
   operator: z.enum([
@@ -78,6 +89,7 @@ const apiNumeratorRef = z.object({
       "Simple comparison operator and value to apply after aggregation (e.g. '= 10' or '>= 1'). Requires `aggregateFilterColumn`.",
     )
     .optional(),
+  computedColumns: apiComputedColumnsField,
 });
 
 const apiDenominatorRef = z.object({
@@ -103,6 +115,7 @@ const apiDenominatorRef = z.object({
       "Filters to apply to the rows of the fact table before aggregation.",
     )
     .optional(),
+  computedColumns: apiComputedColumnsField,
 });
 
 const apiQuantileSettings = z
@@ -345,6 +358,7 @@ const postNumeratorRef = z.object({
       "Simple comparison operator and value to apply after aggregation (e.g. '= 10' or '>= 1'). Requires `aggregateFilterColumn`.",
     )
     .optional(),
+  computedColumns: apiComputedColumnsField,
 });
 
 const postDenominatorRef = z
@@ -381,6 +395,7 @@ const postDenominatorRef = z
         "Filters to apply to the rows of the fact table before aggregation.",
       )
       .optional(),
+    computedColumns: apiComputedColumnsField,
   })
   .describe("Only when metricType is 'ratio'");
 

--- a/packages/shared/src/validators/fact-table.ts
+++ b/packages/shared/src/validators/fact-table.ts
@@ -200,31 +200,29 @@ export const computedColumnRoundModeValidator = z.enum([
   "ceil",
 ]);
 
-// A single operand within a numeric term: either an existing fact-table column
-// (by name or JSON path) or a numeric literal constant (e.g. `/ 100`).
+// Numeric computed columns are a flat arithmetic expression: a list of operands
+// joined by `+ - * /` (e.g. `price * quantity + shipping`). There is no explicit
+// grouping — SQL's native operator precedence applies, so `*` / `/` bind before
+// `+` / `-`. `operators` always has exactly `operands.length - 1` entries.
+
+// An operand is an existing fact-table column (name or JSON path) or a numeric
+// literal constant (e.g. `/ 100`).
 export const computedColumnOperandValidator = z.discriminatedUnion("type", [
   z.object({ type: z.literal("column"), column: z.string() }).strict(),
   z.object({ type: z.literal("literal"), value: z.number() }).strict(),
 ]);
 
-// A term is one or more operands combined with `*` / `/` (multiplicative).
-// `operators` has exactly `operands.length - 1` entries.
-export const computedColumnTermValidator = z
-  .object({
-    operands: z.array(computedColumnOperandValidator).min(1),
-    operators: z.array(z.enum(["*", "/"])),
-  })
-  .strict();
+export const computedColumnOperatorValidator = z.enum(["+", "-", "*", "/"]);
 
-// A numeric computed column is a sum-of-products: terms combined with `+` / `-`.
-// `termOperators` has exactly `terms.length - 1` entries.
+// A numeric computed column is a flat expression, optionally null-safe and
+// rounded.
 export const numericComputedColumnValidator = z
   .object({
     id: z.string(),
     name: z.string(),
     kind: z.literal("number"),
-    terms: z.array(computedColumnTermValidator).min(1),
-    termOperators: z.array(z.enum(["+", "-"])),
+    operands: z.array(computedColumnOperandValidator).min(1),
+    operators: z.array(computedColumnOperatorValidator),
     // When true, wrap column operands in COALESCE(col, 0) so NULLs count as zero.
     coalesceZero: z.boolean().optional(),
     rounding: z

--- a/packages/shared/src/validators/fact-table.ts
+++ b/packages/shared/src/validators/fact-table.ts
@@ -186,6 +186,79 @@ export const rowFilterValidator = z.object({
   values: z.array(z.string()).optional(),
 });
 
+// ---- Computed columns ----
+// Metric-scoped derived columns. They live on a ColumnRef and are referenced
+// elsewhere (the metric value, row filters, the user filter) by the string
+// marker `$$computed:<id>` — the same pseudo-column convention as `$$count`.
+
+// Prefix used to reference a computed column from a `column` string field.
+export const COMPUTED_COLUMN_PREFIX = "$$computed:";
+
+export const computedColumnRoundModeValidator = z.enum([
+  "round",
+  "floor",
+  "ceil",
+]);
+
+// A single operand within a numeric term: either an existing fact-table column
+// (by name or JSON path) or a numeric literal constant (e.g. `/ 100`).
+export const computedColumnOperandValidator = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("column"), column: z.string() }).strict(),
+  z.object({ type: z.literal("literal"), value: z.number() }).strict(),
+]);
+
+// A term is one or more operands combined with `*` / `/` (multiplicative).
+// `operators` has exactly `operands.length - 1` entries.
+export const computedColumnTermValidator = z
+  .object({
+    operands: z.array(computedColumnOperandValidator).min(1),
+    operators: z.array(z.enum(["*", "/"])),
+  })
+  .strict();
+
+// A numeric computed column is a sum-of-products: terms combined with `+` / `-`.
+// `termOperators` has exactly `terms.length - 1` entries.
+export const numericComputedColumnValidator = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    kind: z.literal("number"),
+    terms: z.array(computedColumnTermValidator).min(1),
+    termOperators: z.array(z.enum(["+", "-"])),
+    // When true, wrap column operands in COALESCE(col, 0) so NULLs count as zero.
+    coalesceZero: z.boolean().optional(),
+    rounding: z
+      .object({
+        mode: computedColumnRoundModeValidator,
+        decimals: z.number().int().min(0).max(10).optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+// A single part of a string concat: an existing column or a string literal.
+export const computedColumnStringPartValidator = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("column"), column: z.string() }).strict(),
+  z.object({ type: z.literal("literal"), value: z.string() }).strict(),
+]);
+
+// A string computed column is a concatenation of parts. String computed columns
+// can only be used in row filters / slices, never as a numeric metric value.
+export const stringComputedColumnValidator = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    kind: z.literal("string"),
+    parts: z.array(computedColumnStringPartValidator).min(1),
+  })
+  .strict();
+
+export const computedColumnValidator = z.discriminatedUnion("kind", [
+  numericComputedColumnValidator,
+  stringComputedColumnValidator,
+]);
+
 export const columnRefValidator = z
   .object({
     factTableId: z.string(),
@@ -194,6 +267,8 @@ export const columnRefValidator = z
     rowFilters: z.array(rowFilterValidator).optional(),
     aggregateFilter: z.string().optional(),
     aggregateFilterColumn: z.string().optional(),
+    // Metric-scoped derived columns; referenced via `$$computed:<id>`.
+    computedColumns: z.array(computedColumnValidator).optional(),
   })
   .strict();
 

--- a/packages/shared/src/validators/fact-table.ts
+++ b/packages/shared/src/validators/fact-table.ts
@@ -241,14 +241,50 @@ export const computedColumnStringPartValidator = z.discriminatedUnion("type", [
   z.object({ type: z.literal("literal"), value: z.string() }).strict(),
 ]);
 
-// A string computed column is a concatenation of parts. String computed columns
-// can only be used in row filters / slices, never as a numeric metric value.
+// A transform applied to a string computed column after its parts are
+// concatenated. Operations are applied in order, each wrapping the previous
+// result (e.g. concat -> trim -> lower). `regexpReplace` / `regexpExtract` are
+// not supported on every warehouse (e.g. MSSQL), so the UI hides them and
+// validation blocks them for unsupported datasources.
+export const stringComputedColumnOperationValidator = z.discriminatedUnion(
+  "type",
+  [
+    // Literal substring replace. "Subtract" = replace with an empty string.
+    z
+      .object({
+        type: z.literal("replace"),
+        find: z.string(),
+        replaceWith: z.string(),
+      })
+      .strict(),
+    // Regular-expression replace (all matches).
+    z
+      .object({
+        type: z.literal("regexpReplace"),
+        pattern: z.string(),
+        replaceWith: z.string(),
+      })
+      .strict(),
+    // Extract the first regular-expression match.
+    z
+      .object({ type: z.literal("regexpExtract"), pattern: z.string() })
+      .strict(),
+    z.object({ type: z.literal("upper") }).strict(),
+    z.object({ type: z.literal("lower") }).strict(),
+    z.object({ type: z.literal("trim") }).strict(),
+  ],
+);
+
+// A string computed column concatenates its parts, then applies an optional
+// ordered list of string operations. String computed columns can only be used
+// in row filters / slices, never as a numeric metric value.
 export const stringComputedColumnValidator = z
   .object({
     id: z.string(),
     name: z.string(),
     kind: z.literal("string"),
     parts: z.array(computedColumnStringPartValidator).min(1),
+    operations: z.array(stringComputedColumnOperationValidator).optional(),
   })
   .strict();
 

--- a/packages/shared/test/experiments.test.ts
+++ b/packages/shared/test/experiments.test.ts
@@ -208,24 +208,18 @@ describe("Experiments", () => {
     });
 
     describe("buildComputedColumnSQL", () => {
-      it("adds single-operand terms and wraps the sum-of-products", () => {
+      it("joins operands with + and wraps the expression", () => {
         expect(
           buildComputedColumnSQL({
             computedColumn: {
               id: "1",
               name: "sum",
               kind: "number",
-              terms: [
-                {
-                  operands: [{ type: "column", column: "event_count" }],
-                  operators: [],
-                },
-                {
-                  operands: [{ type: "column", column: "data.b" }],
-                  operators: [],
-                },
+              operands: [
+                { type: "column", column: "event_count" },
+                { type: "column", column: "data.b" },
               ],
-              termOperators: ["+"],
+              operators: ["+"],
             },
             factTable,
             jsonExtract,
@@ -234,58 +228,46 @@ describe("Experiments", () => {
         ).toBe(`(event_count + data:'b'::float)`);
       });
 
-      it("respects multiplicative precedence within a term", () => {
+      it("relies on SQL precedence (* / before + -), no parens", () => {
         expect(
           buildComputedColumnSQL({
             computedColumn: {
               id: "1",
               name: "revenue",
               kind: "number",
-              terms: [
-                {
-                  operands: [
-                    { type: "column", column: "event_count" },
-                    { type: "column", column: "data.b" },
-                  ],
-                  operators: ["*"],
-                },
-                {
-                  operands: [{ type: "column", column: "event_count" }],
-                  operators: [],
-                },
+              operands: [
+                { type: "column", column: "event_count" },
+                { type: "column", column: "data.b" },
+                { type: "column", column: "event_count" },
               ],
-              termOperators: ["+"],
+              operators: ["*", "+"],
             },
             factTable,
             jsonExtract,
             escapeStringLiteral,
           }),
-        ).toBe(`((event_count * data:'b'::float) + event_count)`);
+        ).toBe(`(event_count * data:'b'::float + event_count)`);
       });
 
-      it("guards division with NULLIF and supports numeric literals", () => {
+      it("guards only the divisor with NULLIF and supports literals", () => {
         expect(
           buildComputedColumnSQL({
             computedColumn: {
               id: "1",
               name: "ratio",
               kind: "number",
-              terms: [
-                {
-                  operands: [
-                    { type: "column", column: "event_count" },
-                    { type: "literal", value: 100 },
-                  ],
-                  operators: ["/"],
-                },
+              operands: [
+                { type: "column", column: "event_count" },
+                { type: "column", column: "data.b" },
+                { type: "literal", value: 100 },
               ],
-              termOperators: [],
+              operators: ["+", "/"],
             },
             factTable,
             jsonExtract,
             escapeStringLiteral,
           }),
-        ).toBe(`(event_count / NULLIF(100, 0))`);
+        ).toBe(`(event_count + data:'b'::float / NULLIF(100, 0))`);
       });
 
       it("wraps column operands in COALESCE when coalesceZero is set", () => {
@@ -295,13 +277,8 @@ describe("Experiments", () => {
               id: "1",
               name: "safe",
               kind: "number",
-              terms: [
-                {
-                  operands: [{ type: "column", column: "event_count" }],
-                  operators: [],
-                },
-              ],
-              termOperators: [],
+              operands: [{ type: "column", column: "event_count" }],
+              operators: [],
               coalesceZero: true,
             },
             factTable,
@@ -316,13 +293,8 @@ describe("Experiments", () => {
           id: "1",
           name: "r",
           kind: "number" as const,
-          terms: [
-            {
-              operands: [{ type: "column" as const, column: "event_count" }],
-              operators: [],
-            },
-          ],
-          termOperators: [],
+          operands: [{ type: "column" as const, column: "event_count" }],
+          operators: [],
         };
         expect(
           buildComputedColumnSQL({
@@ -376,6 +348,70 @@ describe("Experiments", () => {
         ).toBe(`CONCAT(event_name, ' - ', page)`);
       });
 
+      it("expands a reference to an earlier computed column", () => {
+        const avg = {
+          id: "avg",
+          name: "avg",
+          kind: "number" as const,
+          operands: [
+            { type: "column" as const, column: "event_count" },
+            { type: "literal" as const, value: 10 },
+          ],
+          operators: ["/" as const],
+        };
+        const avgPct = {
+          id: "avgPct",
+          name: "avgPct",
+          kind: "number" as const,
+          operands: [
+            { type: "column" as const, column: getComputedColumnRef("avg") },
+            { type: "literal" as const, value: 100 },
+          ],
+          operators: ["*" as const],
+        };
+        expect(
+          buildComputedColumnSQL({
+            computedColumn: avgPct,
+            factTable,
+            computedColumns: [avg, avgPct],
+            jsonExtract,
+            escapeStringLiteral,
+          }),
+        ).toBe(`((event_count / NULLIF(10, 0)) * 100)`);
+      });
+
+      it("guards against reference cycles", () => {
+        const a = {
+          id: "a",
+          name: "a",
+          kind: "number" as const,
+          operands: [
+            { type: "column" as const, column: getComputedColumnRef("b") },
+          ],
+          operators: [],
+        };
+        const b = {
+          id: "b",
+          name: "b",
+          kind: "number" as const,
+          operands: [
+            { type: "column" as const, column: getComputedColumnRef("a") },
+          ],
+          operators: [],
+        };
+        // Should terminate rather than recurse infinitely; the cyclic branch
+        // resolves to NULL.
+        expect(
+          buildComputedColumnSQL({
+            computedColumn: a,
+            factTable,
+            computedColumns: [a, b],
+            jsonExtract,
+            escapeStringLiteral,
+          }),
+        ).toBe(`NULL`);
+      });
+
       it("resolves a computed column referenced from a row filter", () => {
         expect(
           getColumnRefWhereClause({
@@ -388,16 +424,11 @@ describe("Experiments", () => {
                   id: "cc1",
                   name: "ratio",
                   kind: "number",
-                  terms: [
-                    {
-                      operands: [
-                        { type: "column", column: "event_count" },
-                        { type: "literal", value: 100 },
-                      ],
-                      operators: ["/"],
-                    },
+                  operands: [
+                    { type: "column", column: "event_count" },
+                    { type: "literal", value: 100 },
                   ],
-                  termOperators: [],
+                  operators: ["/"],
                 },
               ],
               rowFilters: [

--- a/packages/shared/test/experiments.test.ts
+++ b/packages/shared/test/experiments.test.ts
@@ -19,6 +19,8 @@ import {
   getRowFilterSQL,
   getEffectiveLookbackOverride,
   getIntersectionBaseMetricIds,
+  buildComputedColumnSQL,
+  getComputedColumnRef,
 } from "../src/experiments";
 import { createLikeStringMatchFn } from "../src/sql";
 import { LookbackOverride } from "../src/validators/experiments";
@@ -202,6 +204,216 @@ describe("Experiments", () => {
         expect(canInlineFilterColumn(factTable, `${jsonColumn.column}.b`)).toBe(
           false,
         );
+      });
+    });
+
+    describe("buildComputedColumnSQL", () => {
+      it("adds single-operand terms and wraps the sum-of-products", () => {
+        expect(
+          buildComputedColumnSQL({
+            computedColumn: {
+              id: "1",
+              name: "sum",
+              kind: "number",
+              terms: [
+                {
+                  operands: [{ type: "column", column: "event_count" }],
+                  operators: [],
+                },
+                {
+                  operands: [{ type: "column", column: "data.b" }],
+                  operators: [],
+                },
+              ],
+              termOperators: ["+"],
+            },
+            factTable,
+            jsonExtract,
+            escapeStringLiteral,
+          }),
+        ).toBe(`(event_count + data:'b'::float)`);
+      });
+
+      it("respects multiplicative precedence within a term", () => {
+        expect(
+          buildComputedColumnSQL({
+            computedColumn: {
+              id: "1",
+              name: "revenue",
+              kind: "number",
+              terms: [
+                {
+                  operands: [
+                    { type: "column", column: "event_count" },
+                    { type: "column", column: "data.b" },
+                  ],
+                  operators: ["*"],
+                },
+                {
+                  operands: [{ type: "column", column: "event_count" }],
+                  operators: [],
+                },
+              ],
+              termOperators: ["+"],
+            },
+            factTable,
+            jsonExtract,
+            escapeStringLiteral,
+          }),
+        ).toBe(`((event_count * data:'b'::float) + event_count)`);
+      });
+
+      it("guards division with NULLIF and supports numeric literals", () => {
+        expect(
+          buildComputedColumnSQL({
+            computedColumn: {
+              id: "1",
+              name: "ratio",
+              kind: "number",
+              terms: [
+                {
+                  operands: [
+                    { type: "column", column: "event_count" },
+                    { type: "literal", value: 100 },
+                  ],
+                  operators: ["/"],
+                },
+              ],
+              termOperators: [],
+            },
+            factTable,
+            jsonExtract,
+            escapeStringLiteral,
+          }),
+        ).toBe(`(event_count / NULLIF(100, 0))`);
+      });
+
+      it("wraps column operands in COALESCE when coalesceZero is set", () => {
+        expect(
+          buildComputedColumnSQL({
+            computedColumn: {
+              id: "1",
+              name: "safe",
+              kind: "number",
+              terms: [
+                {
+                  operands: [{ type: "column", column: "event_count" }],
+                  operators: [],
+                },
+              ],
+              termOperators: [],
+              coalesceZero: true,
+            },
+            factTable,
+            jsonExtract,
+            escapeStringLiteral,
+          }),
+        ).toBe(`COALESCE(event_count, 0)`);
+      });
+
+      it("applies rounding modes (default dialect)", () => {
+        const base = {
+          id: "1",
+          name: "r",
+          kind: "number" as const,
+          terms: [
+            {
+              operands: [{ type: "column" as const, column: "event_count" }],
+              operators: [],
+            },
+          ],
+          termOperators: [],
+        };
+        expect(
+          buildComputedColumnSQL({
+            computedColumn: {
+              ...base,
+              rounding: { mode: "round", decimals: 2 },
+            },
+            factTable,
+            jsonExtract,
+            escapeStringLiteral,
+          }),
+        ).toBe(`ROUND(event_count, 2)`);
+        expect(
+          buildComputedColumnSQL({
+            computedColumn: { ...base, rounding: { mode: "floor" } },
+            factTable,
+            jsonExtract,
+            escapeStringLiteral,
+          }),
+        ).toBe(`FLOOR(event_count)`);
+        expect(
+          buildComputedColumnSQL({
+            computedColumn: {
+              ...base,
+              rounding: { mode: "ceil", decimals: 2 },
+            },
+            factTable,
+            jsonExtract,
+            escapeStringLiteral,
+          }),
+        ).toBe(`CEIL((event_count) * 100) / 100`);
+      });
+
+      it("concatenates string parts (default dialect)", () => {
+        expect(
+          buildComputedColumnSQL({
+            computedColumn: {
+              id: "1",
+              name: "label",
+              kind: "string",
+              parts: [
+                { type: "column", column: "event_name" },
+                { type: "literal", value: " - " },
+                { type: "column", column: "page" },
+              ],
+            },
+            factTable,
+            jsonExtract,
+            escapeStringLiteral,
+          }),
+        ).toBe(`CONCAT(event_name, ' - ', page)`);
+      });
+
+      it("resolves a computed column referenced from a row filter", () => {
+        expect(
+          getColumnRefWhereClause({
+            factTable,
+            columnRef: {
+              column: "$$count",
+              factTableId: "",
+              computedColumns: [
+                {
+                  id: "cc1",
+                  name: "ratio",
+                  kind: "number",
+                  terms: [
+                    {
+                      operands: [
+                        { type: "column", column: "event_count" },
+                        { type: "literal", value: 100 },
+                      ],
+                      operators: ["/"],
+                    },
+                  ],
+                  termOperators: [],
+                },
+              ],
+              rowFilters: [
+                {
+                  column: getComputedColumnRef("cc1"),
+                  operator: ">",
+                  values: ["5"],
+                },
+              ],
+            },
+            escapeStringLiteral,
+            jsonExtract,
+            evalBoolean,
+            stringMatch,
+          }),
+        ).toStrictEqual([`((event_count / NULLIF(100, 0)) > 5)`]);
       });
     });
 

--- a/packages/shared/test/experiments.test.ts
+++ b/packages/shared/test/experiments.test.ts
@@ -348,6 +348,71 @@ describe("Experiments", () => {
         ).toBe(`CONCAT(event_name, ' - ', page)`);
       });
 
+      it("applies string operations in order (default dialect)", () => {
+        expect(
+          buildComputedColumnSQL({
+            computedColumn: {
+              id: "1",
+              name: "clean",
+              kind: "string",
+              parts: [{ type: "column", column: "event_name" }],
+              operations: [
+                { type: "trim" },
+                { type: "lower" },
+                { type: "replace", find: "-", replaceWith: "_" },
+              ],
+            },
+            factTable,
+            jsonExtract,
+            escapeStringLiteral,
+          }),
+        ).toBe(`REPLACE(LOWER(TRIM(event_name)), '-', '_')`);
+      });
+
+      it("supports regexp replace/extract and escapes literals (default dialect)", () => {
+        expect(
+          buildComputedColumnSQL({
+            computedColumn: {
+              id: "1",
+              name: "re",
+              kind: "string",
+              parts: [{ type: "column", column: "event_name" }],
+              operations: [
+                { type: "regexpReplace", pattern: "a'b", replaceWith: "" },
+                { type: "regexpExtract", pattern: "\\d+" },
+              ],
+            },
+            factTable,
+            jsonExtract,
+            escapeStringLiteral,
+          }),
+        ).toBe(`REGEXP_SUBSTR(REGEXP_REPLACE(event_name, 'a''b', ''), '\\d+')`);
+      });
+
+      it("uses dialect overrides for string operations", () => {
+        expect(
+          buildComputedColumnSQL({
+            computedColumn: {
+              id: "1",
+              name: "re",
+              kind: "string",
+              parts: [{ type: "column", column: "event_name" }],
+              operations: [
+                { type: "regexpReplace", pattern: "x", replaceWith: "y" },
+              ],
+            },
+            factTable,
+            jsonExtract,
+            escapeStringLiteral,
+            dialect: {
+              // Mimic Postgres' global-flag override.
+              regexpReplace: (e, p, r) =>
+                `REGEXP_REPLACE(${e}, ${p}, ${r}, 'g')`,
+            },
+          }),
+        ).toBe(`REGEXP_REPLACE(event_name, 'x', 'y', 'g')`);
+      });
+
       it("expands a reference to an earlier computed column", () => {
         const avg = {
           id: "avg",

--- a/packages/shared/types/fact-table.d.ts
+++ b/packages/shared/types/fact-table.d.ts
@@ -26,6 +26,7 @@ import {
   computedColumnValidator,
   numericComputedColumnValidator,
   stringComputedColumnValidator,
+  stringComputedColumnOperationValidator,
   computedColumnStringPartValidator,
   computedColumnOperandValidator,
 } from "shared/validators";
@@ -138,6 +139,9 @@ export type ComputedColumnOperand = z.infer<
 >;
 export type ComputedColumnStringPart = z.infer<
   typeof computedColumnStringPartValidator
+>;
+export type StringComputedColumnOperation = z.infer<
+  typeof stringComputedColumnOperationValidator
 >;
 
 export type LegacyFactMetricInterface = Omit<

--- a/packages/shared/types/fact-table.d.ts
+++ b/packages/shared/types/fact-table.d.ts
@@ -23,6 +23,12 @@ import {
   jsonColumnFieldsValidator,
   rowFilterValidator,
   aggregatedFactTableSettingsValidator,
+  computedColumnValidator,
+  numericComputedColumnValidator,
+  stringComputedColumnValidator,
+  computedColumnTermValidator,
+  computedColumnOperandValidator,
+  computedColumnStringPartValidator,
 } from "shared/validators";
 import { CreateProps, UpdateProps } from "shared/types/base-model";
 import { TestQueryRow } from "shared/types/integrations";
@@ -120,6 +126,21 @@ export type LegacyColumnRef = ColumnRef & {
 };
 
 export type RowFilter = z.infer<typeof rowFilterValidator>;
+
+export type ComputedColumn = z.infer<typeof computedColumnValidator>;
+export type NumericComputedColumn = z.infer<
+  typeof numericComputedColumnValidator
+>;
+export type StringComputedColumn = z.infer<
+  typeof stringComputedColumnValidator
+>;
+export type ComputedColumnTerm = z.infer<typeof computedColumnTermValidator>;
+export type ComputedColumnOperand = z.infer<
+  typeof computedColumnOperandValidator
+>;
+export type ComputedColumnStringPart = z.infer<
+  typeof computedColumnStringPartValidator
+>;
 
 export type LegacyFactMetricInterface = Omit<
   FactMetricInterface,

--- a/packages/shared/types/fact-table.d.ts
+++ b/packages/shared/types/fact-table.d.ts
@@ -26,9 +26,8 @@ import {
   computedColumnValidator,
   numericComputedColumnValidator,
   stringComputedColumnValidator,
-  computedColumnTermValidator,
-  computedColumnOperandValidator,
   computedColumnStringPartValidator,
+  computedColumnOperandValidator,
 } from "shared/validators";
 import { CreateProps, UpdateProps } from "shared/types/base-model";
 import { TestQueryRow } from "shared/types/integrations";
@@ -134,7 +133,6 @@ export type NumericComputedColumn = z.infer<
 export type StringComputedColumn = z.infer<
   typeof stringComputedColumnValidator
 >;
-export type ComputedColumnTerm = z.infer<typeof computedColumnTermValidator>;
 export type ComputedColumnOperand = z.infer<
   typeof computedColumnOperandValidator
 >;

--- a/packages/shared/types/sql.d.ts
+++ b/packages/shared/types/sql.d.ts
@@ -149,6 +149,18 @@ export interface SqlDialect {
    */
   concat: (parts: string[]) => string;
   /**
+   * String operations for string computed columns. `find` / `pattern` /
+   * `replaceWith` are already-quoted SQL string literals.
+   */
+  replace: (expr: string, find: string, replaceWith: string) => string;
+  /** Regular-expression replace (all matches). */
+  regexpReplace: (expr: string, pattern: string, replaceWith: string) => string;
+  /** Extract the first regular-expression match. */
+  regexpExtract: (expr: string, pattern: string) => string;
+  upper: (expr: string) => string;
+  lower: (expr: string) => string;
+  trim: (expr: string) => string;
+  /**
    * Positional access into an array column, returning a numeric expression.
    * `index` is 0-based logical; each dialect translates to its own array
    * semantics (1-based vs 0-based, native array vs JSON).

--- a/packages/shared/types/sql.d.ts
+++ b/packages/shared/types/sql.d.ts
@@ -134,6 +134,21 @@ export interface SqlDialect {
   ) => UnpivotLabeledPairsResult;
   stringLength: (column: string) => string;
   /**
+   * Round a numeric expression. `mode` is round-half / floor / ceil; `decimals`
+   * is the number of decimal places to keep (defaults to 0). Used by computed
+   * columns.
+   */
+  round: (
+    expr: string,
+    mode: "round" | "floor" | "ceil",
+    decimals?: number,
+  ) => string;
+  /**
+   * Concatenate already-stringified expressions into a single string. Used by
+   * string computed columns.
+   */
+  concat: (parts: string[]) => string;
+  /**
    * Positional access into an array column, returning a numeric expression.
    * `index` is 0-based logical; each dialect translates to its own array
    * semantics (1-based vs 0-based, native array vs JSON).


### PR DESCRIPTION
### Features and Changes

Adds support for **computed (derived) columns** in Fact Table Metrics. Users can now define metric-scoped columns built from arithmetic/concatenation of existing columns and use them as the metric value, in row filters, and in the user filter — without having to add extra physical columns to the fact table.

- New **Computed Columns** section inside "Participation Event" (Create/Edit Fact Table Metric), gated behind a toggle under the Fact Table selector. Toggling it off with existing definitions prompts a confirmation before discarding them.
- **Numeric computed columns** are a sum-of-products: terms joined by `+`/`-`, each term a group of operands joined by `*`/`/`. Operands can be a column **or a numeric literal** (e.g. `amount / 100`, `price * 1.08`). Options include:
  - **Treat nulls as 0** → wraps column operands in `COALESCE(col, 0)`
  - **Rounding** → round / floor / ceiling with optional decimal places
  - Division is guarded with `NULLIF(divisor, 0)`
- **String computed columns** concatenate columns and text literals (usable in row filters / slices only, not as a numeric value).
- Computed columns are stored on the metric's `numerator`/`denominator` `ColumnRef` (new `computedColumns` field) and referenced elsewhere via the `$$computed:<id>` marker — the same pseudo-column convention as `$$count`.
- The **Live SQL Preview** expands computed columns (e.g. `SUM((price * quantity))`).
- SQL generation is dialect-aware: new `round` and `concat` methods on `SqlDialect` with correct overrides for Postgres (`ROUND` numeric cast), MSSQL (`CEILING`), ClickHouse (lowercase fns), and Redshift (multi-arg concat via `||`).

**External API usage:** `POST`/`PUT /api/v1/fact-metrics` now accept an optional `computedColumns` array on `numerator`/`denominator`, and the field is returned on the `FactMetric` response. Reference a computed column from `column`, `aggregateFilterColumn`, or a row filter's `column` using `$$computed:<id>`.

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

### Endpoint

- `POST /api/v1/fact-metrics` — `numerator`/`denominator` now accept optional `computedColumns`
- `PUT /api/v1/fact-metrics/:id` — same
- `GET /api/v1/fact-metrics` and `GET /api/v1/fact-metrics/:id` — responses now include `computedColumns` on `numerator`/`denominator`

(OpenAPI spec regenerated — `generated/spec.yaml`.)

### Dependencies

None.

### Testing

1. **Unit tests** — `pnpm --filter shared test experiments.test.ts` (new `buildComputedColumnSQL` cases cover sum-of-products precedence, `NULLIF` division guard, numeric literals, `COALESCE`, rounding modes, string concat, and computed-column resolution inside a row filter).
2. **UI** — Open **Create Fact Table Metric** → *Participation Event*:
   - Toggle **Computed Columns** on; add a numeric column (e.g. `price * quantity`), confirm the **Value** dropdown, **Row Filter**, and **User Filter** all list it and the **Live SQL Preview** expands it.
   - Add a string (concat) computed column and confirm it appears only in the Row Filter.
   - Toggle the switch **off** with definitions present → confirm the warning dialog appears and clears definitions (and resets any references) on confirm.
3. **API** — `POST /api/v1/fact-metrics` with a `numerator.computedColumns` entry and a `numerator.column` of `$$computed:<id>`; confirm it saves and is returned by `GET`.
4. `pnpm type-check` and `pnpm lint` pass across shared / back-end / front-end.