### PR TITLE
Perf: Fetch only most recent published revision and batch experiment fetches when finding linked experiments

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -2221,11 +2221,14 @@ export async function postExperimentUnarchive(
     if (linkedFeatureIds.length > 0) {
       Promise.all(
         linkedFeatureIds.map(async (featureId) => {
-          const revisions = await getLinkageSyncRevisionSummaries(
-            context.org.id,
+          const { openDrafts, liveRevision } =
+            await getLinkageSyncRevisionSummaries(context.org.id, featureId);
+          return syncFeatureExperimentLinkages(
+            context,
             featureId,
+            openDrafts,
+            liveRevision,
           );
-          return syncFeatureExperimentLinkages(context, featureId, revisions);
         }),
       ).catch((e) => {
         logger.error(e, "syncFeatureExperimentLinkages failed on unarchive");

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -138,7 +138,7 @@ import {
   getFeaturesByIds,
   publishRevision,
 } from "back-end/src/models/FeatureModel";
-import { getNonDiscardedRevisionSummaries } from "back-end/src/models/FeatureRevisionModel";
+import { getLinkageSyncRevisionSummaries } from "back-end/src/models/FeatureRevisionModel";
 import { syncFeatureExperimentLinkages } from "back-end/src/util/featureExperimentSync";
 import { generateExperimentReportSSRData } from "back-end/src/services/reports";
 import {
@@ -2221,7 +2221,7 @@ export async function postExperimentUnarchive(
     if (linkedFeatureIds.length > 0) {
       Promise.all(
         linkedFeatureIds.map(async (featureId) => {
-          const revisions = await getNonDiscardedRevisionSummaries(
+          const revisions = await getLinkageSyncRevisionSummaries(
             context.org.id,
             featureId,
           );

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -336,14 +336,11 @@ export async function countDocuments(
   return FeatureRevisionModel.countDocuments(filter);
 }
 
-/** Returns the version/rules of only the revisions that
- * syncFeatureExperimentLinkages/syncFeatureContextualBanditLinkages actually
- * use: open drafts, plus the single latest published revision. A feature
- * that's been published many times can accumulate thousands of superseded
- * published revisions that are never discarded — fetching those in full
- * wastes memory and network transfer since the sync functions only ever
- * look at the live version anyway. Returned pre-split so callers don't need
- * to re-derive the same distinction the query already made. */
+/** Returns only the revisions that syncFeatureExperimentLinkages/
+ * syncFeatureContextualBanditLinkages need — open drafts, plus the single
+ * latest published revision — pre-split so callers don't have to re-derive
+ * the distinction themselves. A feature's older superseded published
+ * revisions are irrelevant to linkage syncing and deliberately excluded. */
 export async function getLinkageSyncRevisionSummaries(
   organization: string,
   featureId: string,

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -336,18 +336,32 @@ export async function countDocuments(
   return FeatureRevisionModel.countDocuments(filter);
 }
 
-/** Returns the version/status/rules of all non-discarded revisions for a feature.
- * Used by syncFeatureExperimentLinkages callers that don't already have the
- * Mongoose model in scope. */
-export async function getNonDiscardedRevisionSummaries(
+/** Returns the version/status/rules of only the revisions that
+ * syncFeatureExperimentLinkages/syncFeatureContextualBanditLinkages actually
+ * use: open drafts, plus the single latest published revision. A feature
+ * that's been published many times can accumulate thousands of superseded
+ * published revisions that are never discarded — fetching those in full
+ * wastes memory and network transfer since the sync functions only ever
+ * look at the live version anyway. */
+export async function getLinkageSyncRevisionSummaries(
   organization: string,
   featureId: string,
 ): Promise<Pick<FeatureRevisionInterface, "version" | "status" | "rules">[]> {
-  const docs = await FeatureRevisionModel.find({
-    organization,
-    featureId,
-    status: { $nin: ["discarded"] },
-  }).select("version status rules");
+  const [openDrafts, liveRevision] = await Promise.all([
+    FeatureRevisionModel.find({
+      organization,
+      featureId,
+      status: { $in: ACTIVE_DRAFT_STATUSES },
+    }).select("version status rules"),
+    FeatureRevisionModel.findOne({
+      organization,
+      featureId,
+      status: "published",
+    })
+      .sort({ version: -1 })
+      .select("version status rules"),
+  ]);
+  const docs = liveRevision ? [...openDrafts, liveRevision] : openDrafts;
   return docs.map((d) => ({
     version: d.version,
     status: d.status,
@@ -1200,26 +1214,17 @@ export async function updateRevision(
 
   // Fire-and-forget linkage sync whenever draft rules change.
   if (updatedRevision && "rules" in changes) {
-    FeatureRevisionModel.find({
-      organization: revision.organization,
-      featureId: revision.featureId,
-      status: { $nin: ["discarded"] },
-    })
-      .then((docs) => {
-        const summaries = docs.map((d) => ({
-          version: d.version,
-          status: d.status,
-          rules: d.rules,
-        }));
-        return Promise.all([
+    getLinkageSyncRevisionSummaries(revision.organization, revision.featureId)
+      .then((summaries) =>
+        Promise.all([
           syncFeatureExperimentLinkages(context, revision.featureId, summaries),
           syncFeatureContextualBanditLinkages(
             context,
             revision.featureId,
             summaries,
           ),
-        ]);
-      })
+        ]),
+      )
       .catch((e) => {
         logger.error(e, "feature linkage sync failed in updateRevision");
       });
@@ -2235,21 +2240,9 @@ export async function reopenRevision(
     });
 
   // Sync linkages — the reopened revision's rules count as "open drafts" again.
-  FeatureRevisionModel.find({
-    organization: revision.organization,
-    featureId: revision.featureId,
-    status: { $nin: ["discarded"] },
-  })
-    .then((docs) =>
-      syncFeatureExperimentLinkages(
-        context,
-        revision.featureId,
-        docs.map((d) => ({
-          version: d.version,
-          status: d.status,
-          rules: d.rules,
-        })),
-      ),
+  getLinkageSyncRevisionSummaries(revision.organization, revision.featureId)
+    .then((summaries) =>
+      syncFeatureExperimentLinkages(context, revision.featureId, summaries),
     )
     .catch((e) => {
       logger.error(e, "syncFeatureExperimentLinkages failed in reopenRevision");
@@ -2298,26 +2291,17 @@ export async function discardRevision(
     });
 
   // Sync linkages — the discarded revision's rules no longer count as "open drafts".
-  FeatureRevisionModel.find({
-    organization: revision.organization,
-    featureId: revision.featureId,
-    status: { $nin: ["discarded"] },
-  })
-    .then((docs) => {
-      const summaries = docs.map((d) => ({
-        version: d.version,
-        status: d.status,
-        rules: d.rules,
-      }));
-      return Promise.all([
+  getLinkageSyncRevisionSummaries(revision.organization, revision.featureId)
+    .then((summaries) =>
+      Promise.all([
         syncFeatureExperimentLinkages(context, revision.featureId, summaries),
         syncFeatureContextualBanditLinkages(
           context,
           revision.featureId,
           summaries,
         ),
-      ]);
-    })
+      ]),
+    )
     .catch((e) => {
       logger.error(e, "feature linkage sync failed in discardRevision");
     });

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -336,37 +336,44 @@ export async function countDocuments(
   return FeatureRevisionModel.countDocuments(filter);
 }
 
-/** Returns the version/status/rules of only the revisions that
+/** Returns the version/rules of only the revisions that
  * syncFeatureExperimentLinkages/syncFeatureContextualBanditLinkages actually
  * use: open drafts, plus the single latest published revision. A feature
  * that's been published many times can accumulate thousands of superseded
  * published revisions that are never discarded — fetching those in full
  * wastes memory and network transfer since the sync functions only ever
- * look at the live version anyway. */
+ * look at the live version anyway. Returned pre-split so callers don't need
+ * to re-derive the same distinction the query already made. */
 export async function getLinkageSyncRevisionSummaries(
   organization: string,
   featureId: string,
-): Promise<Pick<FeatureRevisionInterface, "version" | "status" | "rules">[]> {
-  const [openDrafts, liveRevision] = await Promise.all([
+): Promise<{
+  openDrafts: Pick<FeatureRevisionInterface, "version" | "rules">[];
+  liveRevision: Pick<FeatureRevisionInterface, "version" | "rules"> | null;
+}> {
+  const [openDraftDocs, liveDoc] = await Promise.all([
     FeatureRevisionModel.find({
       organization,
       featureId,
       status: { $in: ACTIVE_DRAFT_STATUSES },
-    }).select("version status rules"),
+    }).select("version rules"),
     FeatureRevisionModel.findOne({
       organization,
       featureId,
       status: "published",
     })
       .sort({ version: -1 })
-      .select("version status rules"),
+      .select("version rules"),
   ]);
-  const docs = liveRevision ? [...openDrafts, liveRevision] : openDrafts;
-  return docs.map((d) => ({
-    version: d.version,
-    status: d.status,
-    rules: d.rules,
-  }));
+  return {
+    openDrafts: openDraftDocs.map((d) => ({
+      version: d.version,
+      rules: d.rules,
+    })),
+    liveRevision: liveDoc
+      ? { version: liveDoc.version, rules: liveDoc.rules }
+      : null,
+  };
 }
 
 export async function getMinimalRevisions(
@@ -1215,13 +1222,19 @@ export async function updateRevision(
   // Fire-and-forget linkage sync whenever draft rules change.
   if (updatedRevision && "rules" in changes) {
     getLinkageSyncRevisionSummaries(revision.organization, revision.featureId)
-      .then((summaries) =>
+      .then(({ openDrafts, liveRevision }) =>
         Promise.all([
-          syncFeatureExperimentLinkages(context, revision.featureId, summaries),
+          syncFeatureExperimentLinkages(
+            context,
+            revision.featureId,
+            openDrafts,
+            liveRevision,
+          ),
           syncFeatureContextualBanditLinkages(
             context,
             revision.featureId,
-            summaries,
+            openDrafts,
+            liveRevision,
           ),
         ]),
       )
@@ -2241,8 +2254,13 @@ export async function reopenRevision(
 
   // Sync linkages — the reopened revision's rules count as "open drafts" again.
   getLinkageSyncRevisionSummaries(revision.organization, revision.featureId)
-    .then((summaries) =>
-      syncFeatureExperimentLinkages(context, revision.featureId, summaries),
+    .then(({ openDrafts, liveRevision }) =>
+      syncFeatureExperimentLinkages(
+        context,
+        revision.featureId,
+        openDrafts,
+        liveRevision,
+      ),
     )
     .catch((e) => {
       logger.error(e, "syncFeatureExperimentLinkages failed in reopenRevision");
@@ -2292,13 +2310,19 @@ export async function discardRevision(
 
   // Sync linkages — the discarded revision's rules no longer count as "open drafts".
   getLinkageSyncRevisionSummaries(revision.organization, revision.featureId)
-    .then((summaries) =>
+    .then(({ openDrafts, liveRevision }) =>
       Promise.all([
-        syncFeatureExperimentLinkages(context, revision.featureId, summaries),
+        syncFeatureExperimentLinkages(
+          context,
+          revision.featureId,
+          openDrafts,
+          liveRevision,
+        ),
         syncFeatureContextualBanditLinkages(
           context,
           revision.featureId,
-          summaries,
+          openDrafts,
+          liveRevision,
         ),
       ]),
     )

--- a/packages/back-end/src/util/featureContextualBanditSync.ts
+++ b/packages/back-end/src/util/featureContextualBanditSync.ts
@@ -1,15 +1,9 @@
 import { FeatureRevisionInterface } from "shared/types/feature-revision";
-import {
-  ACTIVE_DRAFT_STATUSES,
-  ContextualBanditRefRule,
-  RevisionStatus,
-} from "shared/validators";
+import { ContextualBanditRefRule } from "shared/validators";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import { logger } from "back-end/src/util/logger";
 import { promiseAllChunks } from "back-end/src/util/promise";
-
-const OPEN_DRAFT_STATUSES: Set<RevisionStatus> = new Set(ACTIVE_DRAFT_STATUSES);
 
 function getContextualBanditIdsFromRules(
   rules: FeatureRevisionInterface["rules"] | unknown,
@@ -34,16 +28,10 @@ function getContextualBanditIdsFromRules(
 export async function syncFeatureContextualBanditLinkages(
   context: ReqContext | ApiReqContext,
   featureId: string,
-  revisions: Pick<FeatureRevisionInterface, "version" | "status" | "rules">[],
+  openDrafts: Pick<FeatureRevisionInterface, "version" | "rules">[],
+  liveRevision: Pick<FeatureRevisionInterface, "rules"> | null,
 ): Promise<void> {
   try {
-    const openDrafts = revisions.filter((r) =>
-      OPEN_DRAFT_STATUSES.has(r.status),
-    );
-    const liveRevision = revisions
-      .filter((r) => r.status === "published")
-      .sort((a, b) => b.version - a.version)[0];
-
     const draftVersionsByCb = new Map<string, Set<number>>();
     for (const rev of openDrafts) {
       for (const cbId of getContextualBanditIdsFromRules(rev.rules)) {

--- a/packages/back-end/src/util/featureContextualBanditSync.ts
+++ b/packages/back-end/src/util/featureContextualBanditSync.ts
@@ -1,16 +1,15 @@
 import { FeatureRevisionInterface } from "shared/types/feature-revision";
-import { ContextualBanditRefRule } from "shared/validators";
+import {
+  ACTIVE_DRAFT_STATUSES,
+  ContextualBanditRefRule,
+  RevisionStatus,
+} from "shared/validators";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import { logger } from "back-end/src/util/logger";
 import { promiseAllChunks } from "back-end/src/util/promise";
 
-const OPEN_DRAFT_STATUSES = new Set([
-  "draft",
-  "pending-review",
-  "approved",
-  "changes-requested",
-]);
+const OPEN_DRAFT_STATUSES: Set<RevisionStatus> = new Set(ACTIVE_DRAFT_STATUSES);
 
 function getContextualBanditIdsFromRules(
   rules: FeatureRevisionInterface["rules"] | unknown,

--- a/packages/back-end/src/util/featureContextualBanditSync.ts
+++ b/packages/back-end/src/util/featureContextualBanditSync.ts
@@ -3,6 +3,7 @@ import { ContextualBanditRefRule } from "shared/validators";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import { logger } from "back-end/src/util/logger";
+import { promiseAllChunks } from "back-end/src/util/promise";
 
 const OPEN_DRAFT_STATUSES = new Set([
   "draft",
@@ -61,32 +62,41 @@ export async function syncFeatureContextualBanditLinkages(
 
     const cbModel = context.models.contextualBandits;
 
-    for (const cbId of allCbIds) {
-      const cb = await cbModel.getById(cbId);
-      if (!cb) continue;
+    // Each cbId is independent (no shared mutable state between
+    // iterations), so this is safe to run with bounded concurrency instead
+    // of one-at-a-time — features with many revisions can reference
+    // thousands of distinct contextual bandits, and a fully sequential loop
+    // here was taking a very long time and holding memory the whole way
+    // through.
+    await promiseAllChunks(
+      Array.from(allCbIds).map((cbId) => async () => {
+        const cb = await cbModel.getById(cbId);
+        if (!cb) return;
 
-      if (!cb.linkedFeatures?.includes(featureId)) {
-        await cbModel.addLinkedFeature(cbId, featureId);
-      }
-
-      const desired = draftVersionsByCb.get(cbId) ?? new Set<number>();
-      const current = new Set(
-        (cb.pendingFeatureDrafts ?? [])
-          .filter((d) => d.featureId === featureId)
-          .map((d) => d.revisionVersion),
-      );
-
-      for (const version of desired) {
-        if (!current.has(version)) {
-          await cbModel.addPendingFeatureDraft(cbId, featureId, version);
+        if (!cb.linkedFeatures?.includes(featureId)) {
+          await cbModel.addLinkedFeature(cbId, featureId);
         }
-      }
-      for (const version of current) {
-        if (!desired.has(version)) {
-          await cbModel.removePendingFeatureDraft(cbId, featureId, version);
+
+        const desired = draftVersionsByCb.get(cbId) ?? new Set<number>();
+        const current = new Set(
+          (cb.pendingFeatureDrafts ?? [])
+            .filter((d) => d.featureId === featureId)
+            .map((d) => d.revisionVersion),
+        );
+
+        for (const version of desired) {
+          if (!current.has(version)) {
+            await cbModel.addPendingFeatureDraft(cbId, featureId, version);
+          }
         }
-      }
-    }
+        for (const version of current) {
+          if (!desired.has(version)) {
+            await cbModel.removePendingFeatureDraft(cbId, featureId, version);
+          }
+        }
+      }),
+      10,
+    );
 
     await cbModel.clearStalePendingFeatureDrafts(
       featureId,

--- a/packages/back-end/src/util/featureContextualBanditSync.ts
+++ b/packages/back-end/src/util/featureContextualBanditSync.ts
@@ -49,12 +49,9 @@ export async function syncFeatureContextualBanditLinkages(
 
     const cbModel = context.models.contextualBandits;
 
-    // Each cbId is independent (no shared mutable state between
-    // iterations), so this is safe to run with bounded concurrency instead
-    // of one-at-a-time — features with many revisions can reference
-    // thousands of distinct contextual bandits, and a fully sequential loop
-    // here was taking a very long time and holding memory the whole way
-    // through.
+    // Each cbId is independent (no shared mutable state across
+    // iterations), so bounded concurrency is safe — a feature can
+    // reference thousands of distinct contextual bandits.
     await promiseAllChunks(
       Array.from(allCbIds).map((cbId) => async () => {
         const cb = await cbModel.getById(cbId);

--- a/packages/back-end/src/util/featureExperimentSync.ts
+++ b/packages/back-end/src/util/featureExperimentSync.ts
@@ -23,7 +23,7 @@ function getExperimentIdsFromRules(
   rules: FeatureRevisionInterface["rules"] | unknown,
 ): string[] {
   // Accept v2 (FeatureRule[]) and legacy v1 (Record<envId, FeatureRule[]>):
-  // raw-doc readers (e.g. getNonDiscardedRevisionSummaries) hand us v1 shapes
+  // raw-doc readers (e.g. getLinkageSyncRevisionSummaries) hand us v1 shapes
   // until the migration completes.
   const flat: unknown[] = Array.isArray(rules)
     ? rules

--- a/packages/back-end/src/util/featureExperimentSync.ts
+++ b/packages/back-end/src/util/featureExperimentSync.ts
@@ -10,6 +10,7 @@ import {
   removePendingFeatureDraftFromExperiment,
 } from "back-end/src/models/ExperimentModel";
 import { logger } from "back-end/src/util/logger";
+import { promiseAllChunks } from "back-end/src/util/promise";
 
 const OPEN_DRAFT_STATUSES = new Set([
   "draft",
@@ -76,47 +77,56 @@ export async function syncFeatureExperimentLinkages(
     const liveExpIds = new Set(getExperimentIdsFromRules(liveRevision?.rules));
     const allExpIds = new Set([...liveExpIds, ...draftVersionsByExp.keys()]);
 
-    for (const experimentId of allExpIds) {
-      const experiment = await getExperimentById(context, experimentId);
-      if (!experiment) continue;
+    // Each experimentId is independent (no shared mutable state between
+    // iterations), so this is safe to run with bounded concurrency instead
+    // of one-at-a-time — features with many revisions can reference
+    // thousands of distinct experiments, and a fully sequential loop here
+    // was taking a very long time and holding memory the whole way through.
+    await promiseAllChunks(
+      Array.from(allExpIds).map((experimentId) => async () => {
+        const experiment = await getExperimentById(context, experimentId);
+        if (!experiment) return;
 
-      if (!experiment.linkedFeatures?.includes(featureId)) {
-        await addLinkedFeatureToExperiment(
-          context,
-          experimentId,
-          featureId,
-          experiment,
+        if (!experiment.linkedFeatures?.includes(featureId)) {
+          await addLinkedFeatureToExperiment(
+            context,
+            experimentId,
+            featureId,
+            experiment,
+          );
+        }
+
+        const desired =
+          draftVersionsByExp.get(experimentId) ?? new Set<number>();
+        const current = new Set(
+          (experiment.pendingFeatureDrafts ?? [])
+            .filter((d) => d.featureId === featureId)
+            .map((d) => d.revisionVersion),
         );
-      }
 
-      const desired = draftVersionsByExp.get(experimentId) ?? new Set<number>();
-      const current = new Set(
-        (experiment.pendingFeatureDrafts ?? [])
-          .filter((d) => d.featureId === featureId)
-          .map((d) => d.revisionVersion),
-      );
-
-      for (const version of desired) {
-        if (!current.has(version)) {
-          await addPendingFeatureDraftToExperiment(
-            context,
-            experimentId,
-            featureId,
-            version,
-          );
+        for (const version of desired) {
+          if (!current.has(version)) {
+            await addPendingFeatureDraftToExperiment(
+              context,
+              experimentId,
+              featureId,
+              version,
+            );
+          }
         }
-      }
-      for (const version of current) {
-        if (!desired.has(version)) {
-          await removePendingFeatureDraftFromExperiment(
-            context,
-            experimentId,
-            featureId,
-            version,
-          );
+        for (const version of current) {
+          if (!desired.has(version)) {
+            await removePendingFeatureDraftFromExperiment(
+              context,
+              experimentId,
+              featureId,
+              version,
+            );
+          }
         }
-      }
-    }
+      }),
+      10,
+    );
 
     // Strip pendingFeatureDrafts on experiments no longer referenced by any
     // live or draft rule. linkedFeatures is preserved — removal is user-driven.

--- a/packages/back-end/src/util/featureExperimentSync.ts
+++ b/packages/back-end/src/util/featureExperimentSync.ts
@@ -1,5 +1,9 @@
 import { FeatureRevisionInterface } from "shared/types/feature-revision";
-import { ExperimentRefRule } from "shared/validators";
+import {
+  ACTIVE_DRAFT_STATUSES,
+  ExperimentRefRule,
+  RevisionStatus,
+} from "shared/validators";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import {
@@ -12,12 +16,7 @@ import {
 import { logger } from "back-end/src/util/logger";
 import { promiseAllChunks } from "back-end/src/util/promise";
 
-const OPEN_DRAFT_STATUSES = new Set([
-  "draft",
-  "pending-review",
-  "approved",
-  "changes-requested",
-]);
+const OPEN_DRAFT_STATUSES: Set<RevisionStatus> = new Set(ACTIVE_DRAFT_STATUSES);
 
 function getExperimentIdsFromRules(
   rules: FeatureRevisionInterface["rules"] | unknown,

--- a/packages/back-end/src/util/featureExperimentSync.ts
+++ b/packages/back-end/src/util/featureExperimentSync.ts
@@ -1,9 +1,5 @@
 import { FeatureRevisionInterface } from "shared/types/feature-revision";
-import {
-  ACTIVE_DRAFT_STATUSES,
-  ExperimentRefRule,
-  RevisionStatus,
-} from "shared/validators";
+import { ExperimentRefRule } from "shared/validators";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import {
@@ -15,8 +11,6 @@ import {
 } from "back-end/src/models/ExperimentModel";
 import { logger } from "back-end/src/util/logger";
 import { promiseAllChunks } from "back-end/src/util/promise";
-
-const OPEN_DRAFT_STATUSES: Set<RevisionStatus> = new Set(ACTIVE_DRAFT_STATUSES);
 
 function getExperimentIdsFromRules(
   rules: FeatureRevisionInterface["rules"] | unknown,
@@ -50,16 +44,10 @@ function getExperimentIdsFromRules(
 export async function syncFeatureExperimentLinkages(
   context: ReqContext | ApiReqContext,
   featureId: string,
-  revisions: Pick<FeatureRevisionInterface, "version" | "status" | "rules">[],
+  openDrafts: Pick<FeatureRevisionInterface, "version" | "rules">[],
+  liveRevision: Pick<FeatureRevisionInterface, "rules"> | null,
 ): Promise<void> {
   try {
-    const openDrafts = revisions.filter((r) =>
-      OPEN_DRAFT_STATUSES.has(r.status),
-    );
-    const liveRevision = revisions
-      .filter((r) => r.status === "published")
-      .sort((a, b) => b.version - a.version)[0];
-
     // (expId -> set of open-draft versions referencing it). Multiple drafts
     // of this feature referencing the same experiment all stay tracked — they
     // get applied sequentially on experiment start.

--- a/packages/back-end/src/util/featureExperimentSync.ts
+++ b/packages/back-end/src/util/featureExperimentSync.ts
@@ -64,11 +64,9 @@ export async function syncFeatureExperimentLinkages(
     const liveExpIds = new Set(getExperimentIdsFromRules(liveRevision?.rules));
     const allExpIds = new Set([...liveExpIds, ...draftVersionsByExp.keys()]);
 
-    // Each experimentId is independent (no shared mutable state between
-    // iterations), so this is safe to run with bounded concurrency instead
-    // of one-at-a-time — features with many revisions can reference
-    // thousands of distinct experiments, and a fully sequential loop here
-    // was taking a very long time and holding memory the whole way through.
+    // Each experimentId is independent (no shared mutable state across
+    // iterations), so bounded concurrency is safe — a feature can
+    // reference thousands of distinct experiments.
     await promiseAllChunks(
       Array.from(allExpIds).map((experimentId) => async () => {
         const experiment = await getExperimentById(context, experimentId);


### PR DESCRIPTION
## Summary
- The fire-and-forget linkage sync that runs after any feature revision rule change (`syncFeatureExperimentLinkages` / `syncFeatureContextualBanditLinkages`) looped over every referenced experiment/contextual-bandit ID one at a time, awaiting each DB round-trip sequentially. Batched both loops with the existing `promiseAllChunks` helper (concurrency of 10) instead of a plain `for...of` with `await` inside — same reads/writes, same logic per ID, just bounded-concurrency execution.
- The revision data feeding that sync was also being over-fetched: `getNonDiscardedRevisionSummaries` (now `getLinkageSyncRevisionSummaries`) pulled *every* non-discarded revision for a feature, but the sync functions only ever use open drafts plus the single latest published revision. On a feature with a long publish history this meant fetching and holding thousands of superseded published revisions in memory on every rule change, for no behavioral benefit — one production feature currently has ~2,074 non-discarded revisions (nearly all old published history) despite having zero open drafts. Rewrote the query to fetch only `ACTIVE_DRAFT_STATUSES` revisions plus a single `findOne` for the latest published revision.
- While making that change, found 3 more call sites (`updateRevision`, `reopenRevision`, `discardRevision`) duplicating the same over-fetching query inline — consolidated all of them (plus one external caller in `experiments.ts`) onto the shared `getLinkageSyncRevisionSummaries` helper.
- `getLinkageSyncRevisionSummaries` now returns `{ openDrafts, liveRevision }` pre-split instead of a flattened array, since both sync functions immediately re-derived that same split via filter+sort. Passing it pre-split removes the redundant work and closes off a footgun: a future caller can no longer silently reintroduce the over-fetch bug by passing an unfiltered revision list, since there's no re-filtering step left to mask it.
- `OPEN_DRAFT_STATUSES` (a hand-duplicated literal status list in both sync files) is now gone entirely — status classification happens once, upstream, in `getLinkageSyncRevisionSummaries`, sourced from the canonical `ACTIVE_DRAFT_STATUSES`.

## Why this is safe
Both sync functions previously filtered their input down to open-draft statuses plus the single latest published revision before doing anything with it. Pre-filtering (and now pre-splitting) at the query level produces the exact same effective input set — it just avoids transferring/holding/re-deriving the dead historical revisions used to compute it. No behavior change, just less wasted work.

## Test plan
- [x] `pnpm --filter back-end type-check` passes
- [x] `eslint` passes for the changed files with no errors
- [x] Manually verify on a feature with many draft revisions that experiment/contextual-bandit linkage fields (`linkedFeatures`, `pendingFeatureDrafts`) still reconcile correctly after adding/removing/reopening/discarding a rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)
