### PR TITLE
fix(revisions): normalize both sides of the rebase-before-publish divergence check

### DIFF
--- a/packages/back-end/src/api/constants/postConstantRevisionPublish.ts
+++ b/packages/back-end/src/api/constants/postConstantRevisionPublish.ts
@@ -12,7 +12,10 @@ import {
   NotFoundError,
 } from "back-end/src/util/errors";
 import { getAdapter } from "back-end/src/revisions";
-import { buildMergeDesiredState } from "back-end/src/revisions/util";
+import {
+  buildMergeDesiredState,
+  isRevisionDiverged,
+} from "back-end/src/revisions/util";
 import { dispatchConstantRevisionEvent } from "back-end/src/services/constantRevisionEvents";
 import { loadRevisionByVersion } from "./validations";
 import { toApiConstantRevision } from "./toApiConstantRevision";
@@ -107,10 +110,10 @@ export const postConstantRevisionPublish = createApiRequestHandler(
   if (req.organization.settings?.requireRebaseBeforePublish) {
     const forceMerge = !!req.body.mergeNow && canBypass;
     if (!forceMerge) {
-      const snapshot = revision.target.snapshot as Record<string, unknown>;
-      const liveEntity = constant as unknown as Record<string, unknown>;
-      const diverged = [...updatableFields].some(
-        (key) => !isEqual(snapshot[key], liveEntity[key]),
+      const diverged = isRevisionDiverged(
+        adapter,
+        revision.target.snapshot as Record<string, unknown>,
+        constant as unknown as Record<string, unknown>,
       );
       if (diverged && !canBypass) {
         throw new ConflictError(

--- a/packages/back-end/src/api/saved-groups/postSavedGroupRevisionPublish.ts
+++ b/packages/back-end/src/api/saved-groups/postSavedGroupRevisionPublish.ts
@@ -12,7 +12,10 @@ import {
   NotFoundError,
 } from "back-end/src/util/errors";
 import { getAdapter } from "back-end/src/revisions";
-import { buildMergeDesiredState } from "back-end/src/revisions/util";
+import {
+  buildMergeDesiredState,
+  isRevisionDiverged,
+} from "back-end/src/revisions/util";
 import { dispatchSavedGroupRevisionEvent } from "back-end/src/services/savedGroupRevisionEvents";
 import { loadRevisionByVersion } from "./validations";
 import { toApiSavedGroupRevision } from "./toApiSavedGroupRevision";
@@ -120,10 +123,10 @@ export const postSavedGroupRevisionPublish = createApiRequestHandler(
   if (req.organization.settings?.requireRebaseBeforePublish) {
     const forceMerge = !!req.body.mergeNow && canBypass;
     if (!forceMerge) {
-      const snapshot = revision.target.snapshot as Record<string, unknown>;
-      const liveEntity = savedGroup as unknown as Record<string, unknown>;
-      const diverged = [...updatableFields].some(
-        (key) => !isEqual(snapshot[key], liveEntity[key]),
+      const diverged = isRevisionDiverged(
+        adapter,
+        revision.target.snapshot as Record<string, unknown>,
+        savedGroup as unknown as Record<string, unknown>,
       );
       if (diverged && !canBypass) {
         throw new ConflictError(

--- a/packages/back-end/src/revisions/revisionActions.ts
+++ b/packages/back-end/src/revisions/revisionActions.ts
@@ -11,7 +11,10 @@ import {
 } from "shared/enterprise";
 import type { Context } from "back-end/src/models/BaseModel";
 import { getAdapter } from "back-end/src/revisions";
-import { buildMergeDesiredState } from "back-end/src/revisions/util";
+import {
+  buildMergeDesiredState,
+  isRevisionDiverged,
+} from "back-end/src/revisions/util";
 import { getRevisionWebhookAdapter } from "back-end/src/events/revisionWebhookAdapters";
 import { getContextForUserIdInOrg } from "back-end/src/services/organizations";
 import {
@@ -132,9 +135,10 @@ export async function publishRevision(
   // requireRebaseBeforePublish: a diverged revision must rebase first unless the
   // caller can bypass. Gating here covers every internal publish path.
   if (context.org.settings?.requireRebaseBeforePublish && !canBypass) {
-    const snapshot = revision.target.snapshot as Record<string, unknown>;
-    const diverged = [...adapter.getUpdatableFields()].some(
-      (key) => !isEqual(snapshot[key], entity[key]),
+    const diverged = isRevisionDiverged(
+      adapter,
+      revision.target.snapshot as Record<string, unknown>,
+      entity,
     );
     if (diverged) {
       throw new ConflictError(

--- a/packages/back-end/src/revisions/util.ts
+++ b/packages/back-end/src/revisions/util.ts
@@ -10,6 +10,7 @@ import {
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import { getAdapter } from "back-end/src/revisions/index";
+import type { EntityRevisionAdapter } from "back-end/src/revisions/EntityRevisionAdapter";
 
 /**
  * Apply a set of JSON Patch ops to a snapshot, returning a new object.
@@ -284,4 +285,29 @@ export async function createOrUpdateRevision(
     comment,
     revertedFrom,
   });
+}
+
+/**
+ * True when the revision's base snapshot no longer matches the live entity on
+ * any updatable field.
+ *
+ * Both sides pass through the adapter's `buildSnapshot` before comparing. The
+ * stored snapshot was normalized that way at capture time, but the live
+ * entity comes straight from the database and can carry representation-only
+ * differences — explicit nulls on optional fields, leftover fields removed
+ * from the schema — that no API response or merge check ever surfaces.
+ * Comparing the raw document against the normalized snapshot makes every
+ * draft of such an entity read as diverged forever: rebasing cannot clear it,
+ * because the next snapshot is normalized again.
+ */
+export function isRevisionDiverged(
+  adapter: EntityRevisionAdapter,
+  snapshot: Record<string, unknown>,
+  entity: Record<string, unknown>,
+): boolean {
+  const base = adapter.buildSnapshot(snapshot);
+  const live = adapter.buildSnapshot(entity);
+  return [...adapter.getUpdatableFields()].some(
+    (key) => !isEqual(base[key], live[key]),
+  );
 }

--- a/packages/back-end/src/routers/revision/revision.controller.ts
+++ b/packages/back-end/src/routers/revision/revision.controller.ts
@@ -20,6 +20,7 @@ import {
   getApprovalEnabledEntityTypes,
   getEntityModel,
 } from "back-end/src/revisions";
+import { isRevisionDiverged } from "back-end/src/revisions/util";
 // Generic, entity-agnostic revision webhook dispatch. The adapter is looked up
 // by revision.target.type, so adding a new approval type needs no changes here.
 import { getRevisionWebhookAdapter } from "back-end/src/events/revisionWebhookAdapters";
@@ -1139,10 +1140,10 @@ export const postApproveAndPublish = async (
       entity as Record<string, unknown>,
     );
     if (!canBypass) {
-      const snapshot = revision.target.snapshot as Record<string, unknown>;
-      const liveEntity = entity as Record<string, unknown>;
-      const diverged = [...adapter.getUpdatableFields()].some(
-        (key) => !isEqual(snapshot[key], liveEntity[key]),
+      const diverged = isRevisionDiverged(
+        adapter,
+        revision.target.snapshot as Record<string, unknown>,
+        entity as Record<string, unknown>,
       );
       if (diverged) {
         throw new ConflictError(

--- a/packages/back-end/test/api/saved-groups-revision-publish.test.ts
+++ b/packages/back-end/test/api/saved-groups-revision-publish.test.ts
@@ -1,0 +1,87 @@
+import request from "supertest";
+import mongoose from "mongoose";
+import type { Request } from "express";
+import type { OrganizationInterface } from "shared/types/organization";
+import { ReqContextClass } from "back-end/src/services/context";
+import { setupApp } from "./api.setup";
+
+// Publishing must compare the revision's snapshot against the live document
+// the same way the snapshot was normalized at capture. A stored document can
+// carry representation-only differences — an explicit null on an optional
+// field, a field removed from the schema — that never show up in API output;
+// comparing them raw makes every draft of the entity fail the
+// requireRebaseBeforePublish gate forever (rebasing re-normalizes and cannot
+// clear it).
+
+const ORG_ID = "org_sg_publish_gate";
+const GROUP_ID = "grp_publish_gate_test";
+
+const org = {
+  id: ORG_ID,
+  name: "SG Publish Gate",
+  ownerEmail: "test@test.com",
+  url: "",
+  dateCreated: new Date(),
+  members: [],
+  settings: {
+    requireRebaseBeforePublish: true,
+  },
+} as unknown as OrganizationInterface;
+
+describe("POST /api/v1/saved-groups/:id/revisions/:version/publish", () => {
+  const { app, setReqContext } = setupApp();
+
+  it("publishes a fresh draft of a document that carries legacy nullish fields", async () => {
+    // The caller can edit saved groups but cannot bypass approval checks —
+    // the shape the rebase gate applies to.
+    const context = new ReqContextClass({
+      org,
+      auditUser: { type: "api_key", apiKey: "key_test" },
+      role: "engineer",
+      req: { query: {}, headers: {} } as unknown as Request,
+    });
+    setReqContext(context);
+
+    // Raw stored document with an explicit null on an optional updatable
+    // field — invisible in every API response, present only on the raw doc.
+    await mongoose.connection.collection("savedgroups").insertOne({
+      id: GROUP_ID,
+      organization: ORG_ID,
+      groupName: "Gate test group",
+      owner: "",
+      type: "condition",
+      condition: '{"id": {"$in": ["a"]}}',
+      description: null,
+      dateCreated: new Date(),
+      dateUpdated: new Date(),
+    });
+
+    // Create the draft through the API so its snapshot is captured by the
+    // real adapter (which normalizes nullish fields away).
+    const createRes = await request(app)
+      .post(`/api/v1/saved-groups-revisions/${GROUP_ID}`)
+      .send({})
+      .set("Authorization", "Bearer foo");
+    expect(createRes.status).toBe(200);
+    const version = createRes.body.revision.version;
+
+    const editRes = await request(app)
+      .put(`/api/v1/saved-groups-revisions/${GROUP_ID}/${version}/condition`)
+      .send({ condition: '{"id": {"$in": ["a", "b"]}}' })
+      .set("Authorization", "Bearer foo");
+    expect(editRes.status).toBe(200);
+
+    // Nothing changed the live document since the draft was created, so the
+    // rebase gate must not fire.
+    const publishRes = await request(app)
+      .post(`/api/v1/saved-groups-revisions/${GROUP_ID}/${version}/publish`)
+      .send({})
+      .set("Authorization", "Bearer foo");
+    expect(publishRes.status).toBe(200);
+
+    const doc = await mongoose.connection
+      .collection("savedgroups")
+      .findOne({ id: GROUP_ID });
+    expect(doc?.condition).toBe('{"id": {"$in": ["a", "b"]}}');
+  });
+});

--- a/packages/back-end/test/revisions/util.test.ts
+++ b/packages/back-end/test/revisions/util.test.ts
@@ -210,9 +210,10 @@ describe("isRevisionDiverged", () => {
   };
 
   const snapshotOf = (entity: Record<string, unknown>) =>
-    savedGroupAdapter.buildSnapshot(
-      entity as never,
-    ) as unknown as Record<string, unknown>;
+    savedGroupAdapter.buildSnapshot(entity as never) as unknown as Record<
+      string,
+      unknown
+    >;
 
   it("is not diverged when the live document only differs in representation", () => {
     // Regression for raw stored documents carrying representation-only

--- a/packages/back-end/test/revisions/util.test.ts
+++ b/packages/back-end/test/revisions/util.test.ts
@@ -1,5 +1,9 @@
 import type { JsonPatchOperation } from "shared/enterprise";
-import { buildMergeDesiredState } from "back-end/src/revisions/util";
+import {
+  buildMergeDesiredState,
+  isRevisionDiverged,
+} from "back-end/src/revisions/util";
+import { savedGroupAdapter } from "back-end/src/revisions/adapters/saved-group.adapter";
 
 const updatable = new Set([
   "groupName",
@@ -190,5 +194,53 @@ describe("buildMergeDesiredState", () => {
     );
 
     expect(desired).toEqual(liveEntity);
+  });
+});
+
+describe("isRevisionDiverged", () => {
+  // Minimal live saved-group document as stored in the database.
+  const liveDoc = {
+    id: "sg-1",
+    organization: "org-1",
+    groupName: "My group",
+    type: "condition",
+    condition: '{"id": {"$in": ["a"]}}',
+    dateCreated: new Date("2024-01-01"),
+    dateUpdated: new Date("2024-01-02"),
+  };
+
+  const snapshotOf = (entity: Record<string, unknown>) =>
+    savedGroupAdapter.buildSnapshot(
+      entity as never,
+    ) as unknown as Record<string, unknown>;
+
+  it("is not diverged when the live document only differs in representation", () => {
+    // Regression for raw stored documents carrying representation-only
+    // differences — see the rationale on isRevisionDiverged.
+    const snapshot = snapshotOf(liveDoc);
+    const rawWithNull = { ...liveDoc, description: null };
+    expect(isRevisionDiverged(savedGroupAdapter, snapshot, rawWithNull)).toBe(
+      false,
+    );
+
+    // Same for leftover fields that were removed from the schema.
+    const rawWithLegacyField = { ...liveDoc, passByReferenceOnly: true };
+    expect(
+      isRevisionDiverged(savedGroupAdapter, snapshot, rawWithLegacyField),
+    ).toBe(false);
+  });
+
+  it("is diverged when an updatable field genuinely changed", () => {
+    const snapshot = snapshotOf(liveDoc);
+    const changed = { ...liveDoc, condition: '{"id": {"$in": ["a", "b"]}}' };
+    expect(isRevisionDiverged(savedGroupAdapter, snapshot, changed)).toBe(true);
+  });
+
+  it("ignores changes to non-updatable fields", () => {
+    const snapshot = snapshotOf(liveDoc);
+    const touched = { ...liveDoc, dateUpdated: new Date("2024-06-01") };
+    expect(isRevisionDiverged(savedGroupAdapter, snapshot, touched)).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
**The `requireRebaseBeforePublish` gate compared the revision's normalized snapshot against the raw stored document — a document carrying representation-only differences made every draft of that entity fail the gate forever.**

Revision snapshots are normalized by the adapter's `buildSnapshot` at capture (schema-key pick, nullish values dropped). The divergence check then did `isEqual(snapshot[key], entity[key])` against the entity as loaded from Mongo. A stored document with an explicit `null` on an optional updatable field (or a leftover field removed from the schema — both invisible in every API response) therefore read as "diverged" on every publish attempt:

- every fresh draft failed with *"This revision was created against an older version of the entity. Rebase the revision first."*
- rebasing could never clear it — the next snapshot is normalized again;
- the merge-status endpoint answered `canAutoMerge: true` for the same revision (it normalizes both sides), so preview and enforcement disagreed on identical data;
- only bypass-privileged callers could publish, which masks the bug until a non-admin hits it.

**Fix:** one `isRevisionDiverged(adapter, snapshot, entity)` helper that passes *both* sides through the adapter's `buildSnapshot` before comparing updatable fields, used at all four gate sites (`publishRevision`, the approve-and-publish pre-flight, and the saved-groups / constants REST publish handlers). Normalizing the snapshot side too is deliberate — it heals any legacy-stored snapshot the same way.

**Tests:**
- Unit (`test/revisions/util.test.ts`): explicit-null field and schema-removed field are not divergence; a genuine change to an updatable field is; non-updatable fields are ignored.
- Integration (`test/api/saved-groups-revision-publish.test.ts`): full REST flow over mongodb-memory-server with a raw document carrying `description: null` — create draft, edit condition, publish as a non-bypass role. Returns 409 before this fix, 200 with it.

Not changed (deliberately): `checkMergeConflicts` remains null-tolerant on the live side, so for a live `value → null` change merge-status can still say auto-mergeable while the gate asks for a rebase — that disagreement is in the safe direction and a rebase clears it. Normalization is top-level, matching what `buildSnapshot` does; no current entity type has nested optional-null shapes.
