### PR TITLE
fix(reviews): explicit waiting status and Reviewers empty state for pending review

### DIFF
--- a/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
+++ b/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
@@ -2319,46 +2319,47 @@ export default function ReviewAndPublish({
 
         {requireReviews &&
           (reviewers.length > 0 || revision.status === "pending-review") && (
-          <Box mb="3">
-            <Text
-              size="medium"
-              weight="medium"
-              color="text-high"
-              as="div"
-              mb="2"
-            >
-              Reviewers
-            </Text>
-            {reviewers.length === 0 && revision.status === "pending-review" && (
-              <Text size="small" color="text-mid" as="div">
-                No reviews yet.
+            <Box mb="3">
+              <Text
+                size="medium"
+                weight="medium"
+                color="text-high"
+                as="div"
+                mb="2"
+              >
+                Reviewers
               </Text>
-            )}
-            <Flex direction="column" gap="2">
-              {reviewers.map(({ id, status, timestamp, stale, ...r }) => {
-                const u = users.get(id);
-                const name = u?.name || r.name || "";
-                const email = u?.email || r.email || "";
-                return (
-                  <PersonRow
-                    key={id}
-                    id={id}
-                    name={name}
-                    email={email}
-                    trailing={
-                      <ReviewerVerdictIcon
-                        status={status}
-                        name={name || email}
-                        timestamp={timestamp}
-                        stale={stale}
-                      />
-                    }
-                  />
-                );
-              })}
-            </Flex>
-          </Box>
-        )}
+              {reviewers.length === 0 &&
+                revision.status === "pending-review" && (
+                  <Text size="small" color="text-mid" as="div">
+                    No reviews yet.
+                  </Text>
+                )}
+              <Flex direction="column" gap="2">
+                {reviewers.map(({ id, status, timestamp, stale, ...r }) => {
+                  const u = users.get(id);
+                  const name = u?.name || r.name || "";
+                  const email = u?.email || r.email || "";
+                  return (
+                    <PersonRow
+                      key={id}
+                      id={id}
+                      name={name}
+                      email={email}
+                      trailing={
+                        <ReviewerVerdictIcon
+                          status={status}
+                          name={name || email}
+                          timestamp={timestamp}
+                          stale={stale}
+                        />
+                      }
+                    />
+                  );
+                })}
+              </Flex>
+            </Box>
+          )}
 
         {!experimentsStep &&
           (approved || !requireReviews) &&

--- a/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
+++ b/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
@@ -2317,7 +2317,8 @@ export default function ReviewAndPublish({
           </Box>
         )}
 
-        {requireReviews && reviewers.length > 0 && (
+        {requireReviews &&
+          (reviewers.length > 0 || revision.status === "pending-review") && (
           <Box mb="3">
             <Text
               size="medium"
@@ -2328,6 +2329,11 @@ export default function ReviewAndPublish({
             >
               Reviewers
             </Text>
+            {reviewers.length === 0 && revision.status === "pending-review" && (
+              <Text size="small" color="text-mid" as="div">
+                No reviews yet.
+              </Text>
+            )}
             <Flex direction="column" gap="2">
               {reviewers.map(({ id, status, timestamp, stale, ...r }) => {
                 const u = users.get(id);
@@ -2431,6 +2437,22 @@ export default function ReviewAndPublish({
                 align="center"
               />
             </Flex>
+          )}
+
+          {/* Non-reviewers see an explicit status while the draft waits on a
+              review — without it the tab shows only the status badge and the
+              draft reads as stuck. */}
+          {/* Suppressed when the admin-bypass publish section renders below —
+              "waiting for a reviewer" next to a working Publish button reads
+              as a contradiction. */}
+          {state.waitingForReview && !canReview && !showPublishSection && (
+            <Callout status="info" size="sm">
+              Waiting for a reviewer.{" "}
+              {createdBy?.id === user?.id
+                ? "Authors can't approve their own drafts. "
+                : ""}
+              Anyone with review permission on this feature can approve it.
+            </Callout>
           )}
 
           {(() => {

--- a/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
+++ b/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
@@ -2453,6 +2453,9 @@ export default function ReviewAndPublish({
                 ? "Authors can't approve their own drafts. "
                 : ""}
               Anyone with review permission on this feature can approve it.
+              {state.canRecallReview
+                ? " You can also return the draft to editing, which withdraws the review request."
+                : ""}
             </Callout>
           )}
 

--- a/packages/front-end/components/Reviews/reviewAndPublishState.ts
+++ b/packages/front-end/components/Reviews/reviewAndPublishState.ts
@@ -77,6 +77,11 @@ export interface RnPState {
   canRecallReview: boolean;
   // Reviewer retracts their own verdict → back to pending-review.
   canUndoReview: boolean;
+  // The draft sits in pending review with no primary action for this viewer.
+  // Consumers must render an explicit waiting status in the CTA's place —
+  // with no reviewer verdicts yet, the page otherwise shows nothing but a
+  // status badge and reads as stuck.
+  waitingForReview: boolean;
 }
 
 function publishLabel(
@@ -167,6 +172,7 @@ export function getReviewAndPublishState(input: RnPStateInput): RnPState {
       hasSubmit: true,
       canRecallReview,
       canUndoReview,
+      waitingForReview: false,
     };
   }
 
@@ -198,6 +204,11 @@ export function getReviewAndPublishState(input: RnPStateInput): RnPState {
   // request-review actions have step CTAs. Reviewers use the ReviewCommentPopover.
   const hasSubmit = !isPendingReview || approved;
 
+  // Only "pending-review" waits on someone else; "changes-requested" hands
+  // the ball back to the author, who has edit actions elsewhere on the page.
+  // (hasNextStep requires approved, so !approved already excludes it.)
+  const waitingForReview = status === "pending-review" && !approved;
+
   const ctaEnabled =
     !(experimentsStep && checklistBlocked && !adminPublish) &&
     (!publishLocked || adminPublish) &&
@@ -215,5 +226,6 @@ export function getReviewAndPublishState(input: RnPStateInput): RnPState {
     hasSubmit,
     canRecallReview,
     canUndoReview,
+    waitingForReview,
   };
 }

--- a/packages/front-end/test/components/Reviews/reviewAndPublishState.test.ts
+++ b/packages/front-end/test/components/Reviews/reviewAndPublishState.test.ts
@@ -291,3 +291,44 @@ describe("getReviewAndPublishState", () => {
     });
   });
 });
+
+describe("waitingForReview", () => {
+  it("is set for a pending review with no primary action", () => {
+    const s = getReviewAndPublishState(
+      base({ requireReviews: true, status: "pending-review" }),
+    );
+    expect(s.submitAction).toBe("none");
+    expect(s.waitingForReview).toBe(true);
+  });
+
+  it("is not set once the draft is approved", () => {
+    const s = getReviewAndPublishState(
+      base({ requireReviews: true, status: "approved" }),
+    );
+    expect(s.waitingForReview).toBe(false);
+  });
+
+  it("is not set for changes-requested (the author holds the ball)", () => {
+    const s = getReviewAndPublishState(
+      base({ requireReviews: true, status: "changes-requested" }),
+    );
+    expect(s.waitingForReview).toBe(false);
+  });
+
+  it("is not set when an admin bypass makes the draft publishable", () => {
+    const s = getReviewAndPublishState(
+      base({
+        requireReviews: true,
+        status: "pending-review",
+        adminPublish: true,
+      }),
+    );
+    expect(s.submitAction).toBe("publish");
+    expect(s.waitingForReview).toBe(false);
+  });
+
+  it("is never set on the direct-publish path", () => {
+    const s = getReviewAndPublishState(base({ status: "pending-review" }));
+    expect(s.waitingForReview).toBe(false);
+  });
+});


### PR DESCRIPTION
**A draft author who requests review currently sees only a "Pending review" badge — no explanation, no next step, and no reviewer information — so the draft reads as stuck.**

Since the Review & Publish tab replaced the review modal, `getReviewAndPublishState` resolves `submitAction: "none"` for non-reviewers while a draft sits in pending review, so the CTA area renders nothing; and the Reviewers widget was gated on `reviewers.length > 0` (verdicts), so before the first review nobody who can act is ever named. We've watched authors refresh the page for minutes assuming something was loading. (Observed three times in one org over ~3 months.)

**Fix:**
- The state machine exposes an explicit `waitingForReview` flag (pending-review, not approved) so the "no primary action" state is a first-class outcome rather than an absence.
- Non-reviewers see a status callout in the CTA's place: *"Waiting for a reviewer. Anyone with review permission on this feature can approve it."* — with *"Authors can't approve their own drafts."* added for the draft author. Suppressed when the admin-bypass publish section renders (a "waiting" notice above a working Publish button reads as a contradiction). Reviewers are unaffected — they keep the Submit review popover.
- The Reviewers widget now renders during pending review even before any verdict, with a "No reviews yet." empty state, so the section that names who can act exists from the moment review is requested.

**Tests:** five new cases in `reviewAndPublishState.test.ts` pinning when `waitingForReview` is and isn't set (pending review, approved, changes-requested, admin bypass, direct-publish path). Component behavior rides the existing render tests.

**Deliberately unchanged:** `changes-requested` for a viewer who is neither author nor reviewer is still badge-only — the ball is with the author there, and the Reviewers widget now always shows the verdict; happy to extend the same pattern in a follow-up if wanted. The read-only column's Reviewers widget (locked/live/discarded revisions) keeps its verdicts-only gate, where an empty state would be meaningless.
