### PR TITLE
Apply enum-constrained list attributes via the REST API

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -15804,6 +15804,11 @@ paths:
                   description: Shall the attribute be hashed
                   type: boolean
                 enum:
+                  description: >-
+                    Comma-separated list of allowed values. Required for the
+                    'enum' datatype. For array datatypes (string[], number[],
+                    secureString[]) it optionally restricts the list to these
+                    values. Ignored for all other datatypes.
                   type: string
                 format:
                   description: The attribute's format
@@ -15882,6 +15887,11 @@ paths:
                   description: Shall the attribute be hashed
                   type: boolean
                 enum:
+                  description: >-
+                    Comma-separated list of allowed values. Required for the
+                    'enum' datatype. For array datatypes (string[], number[],
+                    secureString[]) it optionally restricts the list to these
+                    values. Ignored for all other datatypes.
                   type: string
                 format:
                   description: The attribute's format
@@ -41042,6 +41052,11 @@ components:
         archived:
           type: boolean
         enum:
+          description: >-
+            Comma-separated list of allowed values. Required for the 'enum'
+            datatype. For array datatypes (string[], number[], secureString[])
+            it optionally restricts the list to these values. Ignored for all
+            other datatypes.
           type: string
         format:
           type: string

--- a/packages/back-end/src/api/attributes/validations.ts
+++ b/packages/back-end/src/api/attributes/validations.ts
@@ -1,12 +1,17 @@
+import { SDKAttributeType } from "shared/types/organization";
 import { ApiReqContext } from "back-end/types/api";
 
 export const validatePayload = async (
   context: ApiReqContext,
   {
     property,
+    datatype,
+    enum: enumValue,
     projects = [],
   }: {
     property: string;
+    datatype?: SDKAttributeType;
+    enum?: string;
     projects?: string[];
   },
 ) => {
@@ -24,5 +29,15 @@ export const validatePayload = async (
       );
   }
 
-  return { property, projects };
+  // Allowed values ("enum") only apply to the enum datatype and array datatypes,
+  // where they constrain a list attribute to a fixed set. Clear them for any
+  // other datatype, mirroring the attribute editor UI.
+  const enumApplies =
+    datatype === "enum" || (!!datatype && datatype.endsWith("[]"));
+
+  return {
+    property,
+    projects,
+    ...(enumValue && !enumApplies ? { enum: "" } : {}),
+  };
 };

--- a/packages/back-end/test/api/attributes.test.ts
+++ b/packages/back-end/test/api/attributes.test.ts
@@ -587,6 +587,157 @@ describe("attributes API", () => {
     });
   });
 
+  it("keeps allowed values (enum) when creating an array attribute", async () => {
+    setReqContext({
+      models: {
+        projects: {
+          getAll: () => [{ id: "proj1" }],
+        },
+        eventForwarderConfigs: {
+          getAll: () => [],
+        },
+      },
+      org: {
+        id: "org1",
+        settings: {
+          attributeSchema: [],
+        },
+      },
+      permissions: {
+        canCreateAttribute: () => true,
+      },
+    });
+
+    const response = await request(app)
+      .post("/api/v1/attributes")
+      .send({
+        property: "roles",
+        datatype: "string[]",
+        enum: "admin,editor,viewer",
+      })
+      .set("Authorization", "Bearer foo");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      attribute: {
+        property: "roles",
+        datatype: "string[]",
+        enum: "admin,editor,viewer",
+        projects: [],
+      },
+    });
+    expect(updateOrganization).toHaveBeenCalledWith("org1", {
+      settings: {
+        attributeSchema: [
+          {
+            property: "roles",
+            datatype: "string[]",
+            enum: "admin,editor,viewer",
+            projects: [],
+          },
+        ],
+      },
+    });
+  });
+
+  it("clears allowed values (enum) when the datatype does not support them", async () => {
+    setReqContext({
+      models: {
+        projects: {
+          getAll: () => [],
+        },
+        eventForwarderConfigs: {
+          getAll: () => [],
+        },
+      },
+      org: {
+        id: "org1",
+        settings: {
+          attributeSchema: [],
+        },
+      },
+      permissions: {
+        canCreateAttribute: () => true,
+      },
+    });
+
+    const response = await request(app)
+      .post("/api/v1/attributes")
+      .send({
+        property: "flag",
+        datatype: "boolean",
+        enum: "a,b,c",
+      })
+      .set("Authorization", "Bearer foo");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      attribute: {
+        property: "flag",
+        datatype: "boolean",
+        enum: "",
+        projects: [],
+      },
+    });
+  });
+
+  it("clears stale allowed values (enum) when changing to an unsupported datatype", async () => {
+    setReqContext({
+      models: {
+        projects: {
+          getAll: () => [],
+        },
+        eventForwarderConfigs: {
+          getAll: () => [],
+        },
+      },
+      org: {
+        id: "org1",
+        settings: {
+          attributeSchema: [
+            {
+              property: "attr1",
+              datatype: "enum",
+              enum: "a,b,c",
+            },
+          ],
+        },
+      },
+      permissions: {
+        canUpdateAttribute: () => true,
+      },
+    });
+
+    const response = await request(app)
+      .put("/api/v1/attributes/attr1")
+      .send({
+        datatype: "string",
+      })
+      .set("Authorization", "Bearer foo");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      attribute: {
+        property: "attr1",
+        datatype: "string",
+        enum: "",
+        projects: [],
+      },
+    });
+    expect(updateOrganization).toHaveBeenCalledWith("org1", {
+      settings: {
+        attributeSchema: [
+          {
+            property: "attr1",
+            datatype: "string",
+            enum: "",
+            projects: [],
+          },
+        ],
+      },
+    });
+  });
+
   it("allows attribute create when events-forwarder commercial feature is disabled and no forwarder exists", async () => {
     orgHasPremiumFeatureMock.mockReturnValue(false);
     setReqContext({

--- a/packages/shared/src/validators/attributes.ts
+++ b/packages/shared/src/validators/attributes.ts
@@ -2,6 +2,11 @@ import { z } from "zod";
 
 import { namedSchema } from "./openapi-helpers";
 
+const enumFieldDescription =
+  "Comma-separated list of allowed values. Required for the 'enum' datatype. " +
+  "For array datatypes (string[], number[], secureString[]) it optionally " +
+  "restricts the list to these values. Ignored for all other datatypes.";
+
 // Corresponds to schemas/Attribute.yaml
 export const apiAttributeValidator = namedSchema(
   "Attribute",
@@ -21,7 +26,7 @@ export const apiAttributeValidator = namedSchema(
       description: z.string().optional(),
       hashAttribute: z.boolean().optional(),
       archived: z.boolean().optional(),
-      enum: z.string().optional(),
+      enum: z.string().describe(enumFieldDescription).optional(),
       format: z.enum(["", "version", "date", "isoCountryCode"]).optional(),
       projects: z.array(z.string()).optional(),
       tags: z.array(z.string()).optional(),
@@ -54,7 +59,7 @@ const postAttributeBody = z
       .boolean()
       .describe("Shall the attribute be hashed")
       .optional(),
-    enum: z.string().optional(),
+    enum: z.string().describe(enumFieldDescription).optional(),
     format: z
       .enum(["", "version", "date", "isoCountryCode"])
       .describe("The attribute's format")
@@ -89,7 +94,7 @@ const putAttributeBody = z
       .boolean()
       .describe("Shall the attribute be hashed")
       .optional(),
-    enum: z.string().optional(),
+    enum: z.string().describe(enumFieldDescription).optional(),
     format: z
       .enum(["", "version", "date", "isoCountryCode"])
       .describe("The attribute's format")


### PR DESCRIPTION
### Features and Changes

Extends #6252 (enum-constrained list attributes) to the external attributes REST API. The `enum` (Allowed Values) field already flowed through the API, but it wasn't documented as the allowed-values concept and the API didn't mirror the attribute editor's normalization.

- Normalize `enum` in the shared `POST`/`PUT` attribute validation: keep it only for the `enum` datatype and array datatypes (`string[]`/`number[]`/`secureString[]`), and clear it for any other datatype — matching the UI. On update this also clears a stale allowed-values list when converting to an unsupported datatype.
- Document the `enum` field on the OpenAPI validators and regenerate the spec.

### Testing

- [x] `POST /api/v1/attributes` with `datatype: "string[]"` and `enum: "admin,editor,viewer"` -> allowed values are kept
- [x] `POST` with `datatype: "boolean"` and an `enum` -> `enum` is cleared to `""`
- [x] `PUT` an existing `enum` attribute to `datatype: "string"` -> stale allowed values are cleared
- [x] `pnpm --filter back-end test test/api/attributes.test.ts` (19 passing, incl. the 3 new cases)
