### PR TITLE
Address security vulnerabilities (2026-07-07)

### DIFF
--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -66,7 +66,7 @@
     "diff": "^8.0.3",
     "diff2html": "^3.4.56",
     "dirty-json": "^0.9.2",
-    "echarts": "^6.0.0",
+    "echarts": "^6.1.0",
     "echarts-for-react": "^3.0.2",
     "echarts-simple-transform": "^1.0.0",
     "handlebars": "^4.7.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -778,11 +778,11 @@ importers:
         specifier: ^0.9.2
         version: 0.9.2
       echarts:
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.1.0
+        version: 6.1.0
       echarts-for-react:
         specifier: ^3.0.2
-        version: 3.0.2(echarts@6.0.0)(react@18.2.0)
+        version: 3.0.2(echarts@6.1.0)(react@18.2.0)
       echarts-simple-transform:
         specifier: ^1.0.0
         version: 1.0.0
@@ -8174,8 +8174,8 @@ packages:
   echarts-simple-transform@1.0.0:
     resolution: {integrity: sha512-zidekQFwV7s2rLUBVvum9d7kbhX2uoVWqDNYWv+MciEbjBzlhdvLDzciSgeBNe9bwEiqVfGC6NP99zjo3JXDIg==}
 
-  echarts@6.0.0:
-    resolution: {integrity: sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==}
+  echarts@6.1.0:
+    resolution: {integrity: sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -13622,8 +13622,8 @@ packages:
   zod@4.1.12:
     resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
 
-  zrender@6.0.0:
-    resolution: {integrity: sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==}
+  zrender@6.1.0:
+    resolution: {integrity: sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -22451,9 +22451,9 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  echarts-for-react@3.0.2(echarts@6.0.0)(react@18.2.0):
+  echarts-for-react@3.0.2(echarts@6.1.0)(react@18.2.0):
     dependencies:
-      echarts: 6.0.0
+      echarts: 6.1.0
       fast-deep-equal: 3.1.3
       react: 18.2.0
       size-sensor: 1.0.2
@@ -22462,10 +22462,10 @@ snapshots:
     dependencies:
       tslib: 2.0.3
 
-  echarts@6.0.0:
+  echarts@6.1.0:
     dependencies:
       tslib: 2.3.0
-      zrender: 6.0.0
+      zrender: 6.1.0
 
   ee-first@1.1.1: {}
 
@@ -29482,7 +29482,7 @@ snapshots:
 
   zod@4.1.12: {}
 
-  zrender@6.0.0:
+  zrender@6.1.0:
     dependencies:
       tslib: 2.3.0
 


### PR DESCRIPTION
Automated security-vulnerability remediation for the `growthbook` ECR image (Vanta list of 2026-07-07).

## Fixed

- **MEDIUM** `echarts` `6.0.0` → `6.1.0` (CVE-2026-45249) — direct dep in `packages/front-end`; bumped spec `^6.0.0` → `^6.1.0` and refreshed the lockfile (in-major, clean).

## Skipped

- **HIGH** `thrift` `0.16.0` → `0.23.0` (CVE-2026-41636) — **skip-complex**. `thrift` is transitive, pulled in by `@databricks/sql`; OSV confirms no in-major backport (patched only in 0.23.0, cross-major). The upstream bump lives in the databricks-sql-nodejs driver PR 390 (upgrades thrift 0.16.0 → 0.23.0, not linked to avoid a cross-repo backlink), which is **still open/unmerged** as of today. Not self-fixable here without forking the driver; re-check each run.

## Post-deploy projection

| Severity | Total findings | Addressed or auto-clears | Remaining | — of which pending upstream |
| -------- | -------------- | ------------------------ | --------- | --------------------------- |
| HIGH     | 1              | 0                        | 1         | 0                           |
| MEDIUM   | 1              | 1                        | 0         | 0                           |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
