### PR TITLE
Fix tag collision in api spec

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -279,14 +279,11 @@ tags:
     description: >-
       Server metadata, including the running build's version and commit for
       version-skew checks.
-  - name: contextual-bandits
-    x-displayName: contextual-bandits
+  - name: ContextualBandits
+    x-displayName: Contextual Bandits
     description: ''
   - name: Dashboards
     x-displayName: Dashboards
-    description: ''
-  - name: ContextualBandits
-    x-displayName: Contextual Bandits
     description: ''
   - name: ContextualBanditQueries
     x-displayName: Contextual Bandit Queries
@@ -13280,7 +13277,7 @@ paths:
       operationId: getContextualBanditCurrentWeights
       summary: Get current Contextual Bandit leaf weights and latest event
       tags:
-        - contextual-bandits
+        - ContextualBandits
       parameters:
         - name: id
           in: path
@@ -13340,7 +13337,7 @@ paths:
       operationId: listContextualBanditSnapshots
       summary: List Contextual Bandit snapshots
       tags:
-        - contextual-bandits
+        - ContextualBandits
       parameters:
         - name: id
           in: path
@@ -13383,7 +13380,7 @@ paths:
       operationId: getContextualBanditSnapshot
       summary: Get a single Contextual Bandit snapshot
       tags:
-        - contextual-bandits
+        - ContextualBandits
       parameters:
         - name: id
           in: path
@@ -13418,7 +13415,7 @@ paths:
       operationId: listContextualBanditEvents
       summary: List Contextual Bandit weight-update events
       tags:
-        - contextual-bandits
+        - ContextualBandits
       parameters:
         - name: id
           in: path
@@ -13460,7 +13457,7 @@ paths:
       operationId: getContextualBanditEvent
       summary: Get a single Contextual Bandit weight-update event
       tags:
-        - contextual-bandits
+        - ContextualBandits
       parameters:
         - name: id
           in: path
@@ -13502,7 +13499,7 @@ paths:
         contextual bandit. Same payload the GrowthBook UI uses to render the
         contextual bandit results table.
       tags:
-        - contextual-bandits
+        - ContextualBandits
       parameters:
         - name: id
           in: path
@@ -13800,7 +13797,7 @@ paths:
         state, per-environment rule state, and variation values. Same payload
         the GrowthBook UI uses to render the Linked Features section.
       tags:
-        - contextual-bandits
+        - ContextualBandits
       parameters:
         - name: id
           in: path
@@ -13845,7 +13842,7 @@ paths:
         auto-publish. The feature's `contextual-bandit-ref` rule itself is left
         untouched.
       tags:
-        - contextual-bandits
+        - ContextualBandits
       parameters:
         - name: id
           in: path
@@ -50487,9 +50484,8 @@ x-tagGroups:
       - attributes
       - usage
       - meta
-      - contextual-bandits
-      - Dashboards
       - ContextualBandits
+      - Dashboards
       - ContextualBanditQueries
       - CustomFields
       - MetricGroups

--- a/packages/shared/src/validators/contextual-bandit.ts
+++ b/packages/shared/src/validators/contextual-bandit.ts
@@ -358,7 +358,7 @@ export const getContextualBanditCurrentWeightsValidator = {
     .strict(),
   summary: "Get current Contextual Bandit leaf weights and latest event",
   operationId: "getContextualBanditCurrentWeights",
-  tags: ["contextual-bandits"],
+  tags: ["ContextualBandits"],
   method: "get" as const,
   path: "/contextual-bandits/:id/current",
 };
@@ -377,7 +377,7 @@ export const listContextualBanditSnapshotsValidator = {
     .strict(),
   summary: "List Contextual Bandit snapshots",
   operationId: "listContextualBanditSnapshots",
-  tags: ["contextual-bandits"],
+  tags: ["ContextualBandits"],
   method: "get" as const,
   path: "/contextual-bandits/:id/snapshots",
 };
@@ -391,7 +391,7 @@ export const getContextualBanditSnapshotValidator = {
     .strict(),
   summary: "Get a single Contextual Bandit snapshot",
   operationId: "getContextualBanditSnapshot",
-  tags: ["contextual-bandits"],
+  tags: ["ContextualBandits"],
   method: "get" as const,
   path: "/contextual-bandits/:id/snapshots/:snapshotId",
 };
@@ -410,7 +410,7 @@ export const listContextualBanditEventsValidator = {
     .strict(),
   summary: "List Contextual Bandit weight-update events",
   operationId: "listContextualBanditEvents",
-  tags: ["contextual-bandits"],
+  tags: ["ContextualBandits"],
   method: "get" as const,
   path: "/contextual-bandits/:id/events",
 };
@@ -424,7 +424,7 @@ export const getContextualBanditEventValidator = {
     .strict(),
   summary: "Get a single Contextual Bandit weight-update event",
   operationId: "getContextualBanditEvent",
-  tags: ["contextual-bandits"],
+  tags: ["ContextualBandits"],
   method: "get" as const,
   path: "/contextual-bandits/:id/events/:eventId",
 };
@@ -531,7 +531,7 @@ export const getContextualBanditResultsValidator = {
   description:
     "Returns the latest contextual-bandit stats engine output (per-context responses, the context-to-leaf map, and per-leaf aggregated stats), the overall (marginal) variation weights across all contexts, the SRM of the most recent run, and the status of the most recent snapshot run for the contextual bandit. Same payload the GrowthBook UI uses to render the contextual bandit results table.",
   operationId: "getContextualBanditResults",
-  tags: ["contextual-bandits"],
+  tags: ["ContextualBandits"],
   method: "get" as const,
   path: "/contextual-bandits/:id/results",
 };
@@ -550,7 +550,7 @@ export const getContextualBanditLinkedFeaturesValidator = {
   description:
     "Returns the features that reference this contextual bandit via a `contextual-bandit-ref` rule, enriched with each feature's live/draft state, per-environment rule state, and variation values. Same payload the GrowthBook UI uses to render the Linked Features section.",
   operationId: "getContextualBanditLinkedFeatures",
-  tags: ["contextual-bandits"],
+  tags: ["ContextualBandits"],
   method: "get" as const,
   path: "/contextual-bandits/:id/linked-features",
 };
@@ -564,7 +564,7 @@ export const deleteContextualBanditLinkedFeatureValidator = {
   description:
     "Detaches a feature from this contextual bandit by removing it from the bandit's linked-feature list and cancelling any queued draft auto-publish. The feature's `contextual-bandit-ref` rule itself is left untouched.",
   operationId: "deleteContextualBanditLinkedFeature",
-  tags: ["contextual-bandits"],
+  tags: ["ContextualBandits"],
   method: "delete" as const,
   path: "/contextual-bandits/:id/linked-feature/:featureId",
 };


### PR DESCRIPTION
### Features and Changes

CLI generation doesn't work if we have two tags that resolve to the same pascal-case value, so we need to replace the hardcoded `contextual-bandits` with the same `ContextualBandits` that our API generator produces
