### PR TITLE
Add environment displayName to support renaming environments

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -15615,6 +15615,11 @@ paths:
                 description:
                   description: The description of the new environment
                   type: string
+                displayName:
+                  description: >-
+                    A user-facing name for the environment. Falls back to the id
+                    when not set.
+                  type: string
                 toggleOnList:
                   description: Show on feature list page
                   type: boolean
@@ -15670,6 +15675,11 @@ paths:
               properties:
                 description:
                   description: The description of the new environment
+                  type: string
+                displayName:
+                  description: >-
+                    A user-facing name for the environment. Falls back to the id
+                    when not set.
                   type: string
                 toggleOnList:
                   description: Show on feature list page
@@ -41001,6 +41011,8 @@ components:
         id:
           type: string
         description:
+          type: string
+        displayName:
           type: string
         toggleOnList:
           type: boolean

--- a/packages/back-end/src/api/environments/listEnvironments.ts
+++ b/packages/back-end/src/api/environments/listEnvironments.ts
@@ -14,6 +14,7 @@ export const listEnvironments = createApiRequestHandler(
       ({
         id,
         description = "",
+        displayName,
         toggleOnList = false,
         defaultState = false,
         projects = [],
@@ -21,6 +22,7 @@ export const listEnvironments = createApiRequestHandler(
         id,
         projects,
         description,
+        displayName,
         defaultState,
         toggleOnList,
       }),

--- a/packages/back-end/src/api/environments/validations.ts
+++ b/packages/back-end/src/api/environments/validations.ts
@@ -5,6 +5,7 @@ export const validatePayload = async (
   {
     id,
     description = "",
+    displayName,
     projects = [],
     toggleOnList = false,
     defaultState = false,
@@ -12,6 +13,7 @@ export const validatePayload = async (
   }: {
     id: string;
     description?: string;
+    displayName?: string;
     projects?: string[];
     toggleOnList?: boolean;
     defaultState?: boolean;
@@ -36,5 +38,13 @@ export const validatePayload = async (
     throw new Error("Environment inheritance requires an enterprise license");
   }
 
-  return { id, projects, description, toggleOnList, defaultState, parent };
+  return {
+    id,
+    projects,
+    description,
+    displayName,
+    toggleOnList,
+    defaultState,
+    parent,
+  };
 };

--- a/packages/front-end/components/Archetype/ArchetypeAttributesModal.tsx
+++ b/packages/front-end/components/Archetype/ArchetypeAttributesModal.tsx
@@ -2,6 +2,7 @@ import React, { FC } from "react";
 import { MAX_DESCRIPTION_LENGTH } from "shared/constants";
 import { useForm } from "react-hook-form";
 import { ArchetypeInterface } from "shared/types/archetype";
+import { getEnvironmentDisplayName } from "shared/util";
 import Field from "@/components/Forms/Field";
 import AttributeForm from "@/components/Archetype/AttributeForm";
 import { useAuth } from "@/services/auth";
@@ -132,7 +133,7 @@ const ArchetypeAttributesModal: FC<{
                 placeholder="All environments"
                 value={form.watch("environments")}
                 options={environments.map((env) => ({
-                  label: env.id,
+                  label: getEnvironmentDisplayName(env),
                   value: env.id,
                 }))}
                 onChange={(v) => form.setValue("environments", v)}

--- a/packages/front-end/components/Archetype/ArchetypeResults.tsx
+++ b/packages/front-end/components/Archetype/ArchetypeResults.tsx
@@ -1,7 +1,10 @@
 import React, { FC, Fragment, useState } from "react";
 import { ArchetypeInterface } from "shared/types/archetype";
 import { FeatureInterface, FeatureTestResult } from "shared/types/feature";
-import { filterEnvironmentsByFeature } from "shared/util";
+import {
+  filterEnvironmentsByFeature,
+  getEnvironmentDisplayName,
+} from "shared/util";
 import Link from "@/ui/Link";
 import styles from "@/components/Archetype/ArchetypeResults.module.scss";
 import { ArchetypeValueDisplay } from "@/components/Features/ValueDisplay";
@@ -196,7 +199,7 @@ const ArchetypeResults: FC<{
             </th>
             {environments.map((env) => (
               <th key={env.id} title={env.description}>
-                {env.id}
+                {getEnvironmentDisplayName(env)}
               </th>
             ))}
           </tr>

--- a/packages/front-end/components/Archetype/AssignmentTester.tsx
+++ b/packages/front-end/components/Archetype/AssignmentTester.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { FeatureInterface, FeatureTestResult } from "shared/types/feature";
-import { filterEnvironmentsByFeature, stemRuleId } from "shared/util";
+import {
+  filterEnvironmentsByFeature,
+  getEnvironmentDisplayName,
+  stemRuleId,
+} from "shared/util";
 import { FaChevronRight } from "react-icons/fa";
 import { ArchetypeInterface } from "shared/types/archetype";
 import { FiAlertTriangle } from "react-icons/fi";
@@ -399,7 +403,7 @@ export default function AssignmentTester({
                           placeholder="All environments"
                           value={selectedEnvs}
                           options={featureEnvironments.map((env) => ({
-                            label: env.id,
+                            label: getEnvironmentDisplayName(env),
                             value: env.id,
                           }))}
                           onChange={setSelectedEnvs}

--- a/packages/front-end/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal.tsx
@@ -5,6 +5,7 @@ import clsx from "clsx";
 import { Box, Flex } from "@radix-ui/themes";
 import { PiArrowLeft, PiCaretRight, PiCheckCircleFill } from "react-icons/pi";
 import { isEventWebhookWildcard } from "shared/validators";
+import { getEnvironmentDisplayName } from "shared/util";
 import Text from "@/ui/Text";
 import { useAuth } from "@/services/auth";
 import Modal from "@/components/Modal";
@@ -174,7 +175,6 @@ const EventWebHookAddEditSettings = ({
   };
 }) => {
   const environmentSettings = useEnvironments();
-  const environments = environmentSettings.map((env) => env.id);
 
   const selectedPayloadType = form.watch("payloadType");
   const selectedEnvironments = form.watch("environments");
@@ -345,9 +345,9 @@ const EventWebHookAddEditSettings = ({
               labelClassName="w-100"
               sort={false}
               value={form.watch("environments")}
-              options={environments.map((env) => ({
-                label: env,
-                value: env,
+              options={environmentSettings.map((env) => ({
+                label: getEnvironmentDisplayName(env),
+                value: env.id,
               }))}
               onChange={(value: string[]) => {
                 form.setValue("environments", value);

--- a/packages/front-end/components/Features/FeatureModal/EnvironmentSelect.tsx
+++ b/packages/front-end/components/Features/FeatureModal/EnvironmentSelect.tsx
@@ -3,6 +3,7 @@ import { Environment } from "shared/types/organization";
 import { FeatureEnvironment } from "shared/types/feature";
 import { Box, Flex, Grid, Text } from "@radix-ui/themes";
 import { FaCircleCheck, FaCircleXmark } from "react-icons/fa6";
+import { getEnvironmentDisplayName } from "shared/util";
 import { featureStatusColors } from "@/components/Features/FeaturesOverview";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import Checkbox from "@/ui/Checkbox";
@@ -12,9 +13,9 @@ import UIText from "@/ui/Text";
 
 const MAX_VISIBLE_PREVIEW_ENVIRONMENTS = 3;
 
-function envPreviewItem(envId: string, enabled: boolean) {
+function envPreviewItem(env: Environment, enabled: boolean) {
   return (
-    <Flex key={envId} align="center" gap="1">
+    <Flex key={env.id} align="center" gap="1">
       {enabled ? (
         <FaCircleCheck size={14} style={{ color: featureStatusColors.on }} />
       ) : (
@@ -23,7 +24,7 @@ function envPreviewItem(envId: string, enabled: boolean) {
           style={{ color: featureStatusColors.offMuted }}
         />
       )}
-      <UIText size="small">{envId}</UIText>
+      <UIText size="small">{getEnvironmentDisplayName(env)}</UIText>
     </Flex>
   );
 }
@@ -78,7 +79,7 @@ const EnvironmentSelect: FC<{
       {!expanded ? (
         <Flex gap="3" wrap="wrap" align="center">
           {visible.map((env) =>
-            envPreviewItem(env.id, !!environmentSettings[env.id]?.enabled),
+            envPreviewItem(env, !!environmentSettings[env.id]?.enabled),
           )}
           {overflow.length > 0 && (
             <Tooltip
@@ -86,10 +87,7 @@ const EnvironmentSelect: FC<{
               body={
                 <Flex direction="column" gap="1">
                   {overflow.map((env) =>
-                    envPreviewItem(
-                      env.id,
-                      !!environmentSettings[env.id]?.enabled,
-                    ),
+                    envPreviewItem(env, !!environmentSettings[env.id]?.enabled),
                   )}
                 </Flex>
               }
@@ -141,7 +139,7 @@ const EnvironmentSelect: FC<{
                 disabledMessage="You don't have permission to create features in this environment."
                 value={environmentSettings[env.id].enabled}
                 setValue={(enabled) => setValue(env, enabled === true)}
-                label={env.id}
+                label={getEnvironmentDisplayName(env)}
                 key={env.id}
                 weight="regular"
                 mb="1"

--- a/packages/front-end/components/Features/FeatureRules.tsx
+++ b/packages/front-end/components/Features/FeatureRules.tsx
@@ -12,6 +12,7 @@ import {
   MinimalFeatureRevisionInterface,
 } from "shared/types/feature-revision";
 import { Environment } from "shared/types/organization";
+import { getEnvironmentDisplayName } from "shared/util";
 import { Box, Flex, TextField } from "@radix-ui/themes";
 import RuleModal from "@/components/Features/RuleModal/index";
 import RuleList from "@/components/Features/RuleList";
@@ -279,7 +280,11 @@ export default function FeatureRules({
     const count = holdout?.environmentSettings?.[e.id]?.enabled
       ? rulesByEnv[e.id].length + 1
       : rulesByEnv[e.id].length;
-    overflowLabels.push({ key: e.id, label: e.id, count });
+    overflowLabels.push({
+      key: e.id,
+      label: getEnvironmentDisplayName(e),
+      count,
+    });
   }
 
   const [moreOpen, setMoreOpen] = useState(false);
@@ -357,7 +362,7 @@ export default function FeatureRules({
                     }
                   >
                     <Flex align="center" gap="2">
-                      {e.id}
+                      {getEnvironmentDisplayName(e)}
                       <Badge
                         label={String(count)}
                         radius="full"

--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -25,6 +25,7 @@ import {
 import { ago, datetime } from "shared/dates";
 import {
   filterEnvironmentsByFeature,
+  getEnvironmentDisplayName,
   getReviewSetting,
   isScheduledPublishPending,
   isScheduledPublishLockActive,
@@ -1105,9 +1106,9 @@ export default function FeaturesOverview({
                         Enabled Environments
                       </span>
                     </Box>
-                    {envs.map((env) => (
+                    {environments.map((en) => (
                       <Box
-                        key={env}
+                        key={en.id}
                         style={{
                           width: 120,
                           flexShrink: 0,
@@ -1115,7 +1116,9 @@ export default function FeaturesOverview({
                         }}
                       >
                         <Text weight="semibold" color="text-mid">
-                          <OverflowText maxWidth={120}>{env}</OverflowText>
+                          <OverflowText maxWidth={120}>
+                            {getEnvironmentDisplayName(en)}
+                          </OverflowText>
                         </Text>
                       </Box>
                     ))}
@@ -1318,7 +1321,9 @@ export default function FeaturesOverview({
                         align="center"
                         mr="2"
                       >
-                        <span className="font-weight-bold">{en.id}:</span>
+                        <span className="font-weight-bold">
+                          {getEnvironmentDisplayName(en)}:
+                        </span>
                         <Tooltip
                           popperClassName="text-left"
                           flipTheme={false}

--- a/packages/front-end/components/Features/KillSwitchModal.tsx
+++ b/packages/front-end/components/Features/KillSwitchModal.tsx
@@ -13,6 +13,7 @@ import {
   liveRevisionFromFeature,
   buildEffectiveDraft,
   filterEnvironmentsByFeature,
+  getEnvironmentDisplayName,
 } from "shared/util";
 import Switch from "@/ui/Switch";
 import Text from "@/ui/Text";
@@ -91,7 +92,9 @@ function EnvStateGrid({
               style={{ width: COL_W, flexShrink: 0, textAlign: "center" }}
             >
               <Text weight="semibold" color="text-mid">
-                <OverflowText maxWidth={COL_W}>{env.id}</OverflowText>
+                <OverflowText maxWidth={COL_W}>
+                  {getEnvironmentDisplayName(env)}
+                </OverflowText>
               </Text>
             </Box>
           ))}
@@ -465,7 +468,7 @@ export default function KillSwitchModal({
   );
   const modalHeader =
     changedEnvs.length === 1
-      ? `${getEffectiveState(changedEnvs[0].id) ? "Enable" : "Disable"} ${changedEnvs[0].id}`
+      ? `${getEffectiveState(changedEnvs[0].id) ? "Enable" : "Disable"} ${getEnvironmentDisplayName(changedEnvs[0])}`
       : "Change enabled environments";
 
   return (

--- a/packages/front-end/components/Features/RuleEnvScopeBadges.tsx
+++ b/packages/front-end/components/Features/RuleEnvScopeBadges.tsx
@@ -3,6 +3,7 @@ import { MarginProps } from "@radix-ui/themes/dist/esm/props/margin.props.js";
 import { FaRegCircleCheck, FaRegCircleXmark } from "react-icons/fa6";
 import { PiWarningCircle } from "react-icons/pi";
 import { Environment } from "shared/types/organization";
+import { getEnvironmentDisplayName } from "shared/util";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import Text from "@/ui/Text";
 
@@ -22,11 +23,14 @@ type Props = {
   currentEnvironment?: string;
 } & MarginProps;
 
-function envBadge(envId: string, active: boolean) {
+function envBadge(
+  env: Pick<Environment, "id" | "displayName">,
+  active: boolean,
+) {
   const iconColor = active ? "var(--green-11)" : "var(--gray-8)";
   const textColor = active ? undefined : "var(--gray-8)";
   return (
-    <Flex key={envId} align="center" gap="1">
+    <Flex key={env.id} align="center" gap="1">
       <span
         style={{
           color: textColor,
@@ -34,7 +38,7 @@ function envBadge(envId: string, active: boolean) {
           fontWeight: active ? 500 : 300,
         }}
       >
-        {envId}
+        {getEnvironmentDisplayName(env)}
       </span>
       {active ? (
         <FaRegCircleCheck size={14} style={{ color: iconColor }} />
@@ -127,7 +131,7 @@ export default function RuleEnvScopeBadges({
           </Flex>
         </Tooltip>
       ) : (
-        visible.map((env) => envBadge(env.id, activeSet.has(env.id)))
+        visible.map((env) => envBadge(env, activeSet.has(env.id)))
       )}
       {disallowedEnvIds.map((envId) => disallowedEnvBadge(envId))}
       {!noActiveEnvs && overflow.length > 0 && (
@@ -146,7 +150,7 @@ export default function RuleEnvScopeBadges({
                 {overflow.length === 1 ? "" : "s"}
               </Text>
               <Flex gap="4" wrap="wrap">
-                {overflow.map((env) => envBadge(env.id, activeSet.has(env.id)))}
+                {overflow.map((env) => envBadge(env, activeSet.has(env.id)))}
               </Flex>
             </>
           }

--- a/packages/front-end/components/Features/RuleModal/EnvironmentScopeField.tsx
+++ b/packages/front-end/components/Features/RuleModal/EnvironmentScopeField.tsx
@@ -1,6 +1,7 @@
 import { Box } from "@radix-ui/themes";
 import { MarginProps } from "@radix-ui/themes/dist/esm/props/margin.props.js";
 import { Environment } from "shared/types/organization";
+import { getEnvironmentDisplayName } from "shared/util";
 import RadioGroup from "@/ui/RadioGroup";
 import Callout from "@/ui/Callout";
 import MultiSelectField from "@/components/Forms/MultiSelectField";
@@ -29,7 +30,10 @@ export default function RuleEnvironmentScopeField({
   label = "Rule Environments",
   ...marginProps
 }: EnvScopeProps) {
-  const options = environments.map((e) => ({ label: e.id, value: e.id }));
+  const options = environments.map((e) => ({
+    label: getEnvironmentDisplayName(e),
+    value: e.id,
+  }));
 
   const disabledSet = new Set(disabledEnvironmentIds);
   const allEnvsDisabled =

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -23,6 +23,7 @@ import {
 import {
   filterProjectsByEnvironment,
   getDisallowedProjects,
+  getEnvironmentDisplayName,
 } from "shared/util";
 import { PiPackage, PiInfo } from "react-icons/pi";
 import { Flex, Box } from "@radix-ui/themes";
@@ -579,7 +580,7 @@ export default function SDKConnectionForm({
             }
           }}
           options={filteredEnvironments.map((e) => ({
-            label: e.id,
+            label: getEnvironmentDisplayName(e),
             value: e.id,
           }))}
           sort={false}

--- a/packages/front-end/components/GeneralSettings/FeatureSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/FeatureSettings.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import { FaExclamationCircle } from "react-icons/fa";
 import { Box, Flex, Heading, Text } from "@radix-ui/themes";
+import { getEnvironmentDisplayName } from "shared/util";
 import { useUser } from "@/services/UserContext";
 import Field from "@/components/Forms/Field";
 import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
@@ -239,7 +240,7 @@ export default function FeatureSettings() {
                   value: FEATURE_RULES_ALL_ENVS,
                 },
                 ...environments.map((env) => ({
-                  label: env.id,
+                  label: getEnvironmentDisplayName(env),
                   value: env.id,
                 })),
               ]}

--- a/packages/front-end/components/Settings/EnvironmentModal.tsx
+++ b/packages/front-end/components/Settings/EnvironmentModal.tsx
@@ -171,6 +171,7 @@ export default function EnvironmentModal({
       )}
       <Field
         label="Display Name"
+        maxLength={30}
         {...form.register("displayName")}
         placeholder={existing.id || "e.g. Production"}
         helpText="Optional. Shown throughout the UI instead of the id. Leave blank to just show the id."

--- a/packages/front-end/components/Settings/EnvironmentModal.tsx
+++ b/packages/front-end/components/Settings/EnvironmentModal.tsx
@@ -2,7 +2,10 @@ import { useForm } from "react-hook-form";
 import { Environment } from "shared/types/organization";
 import React, { useMemo } from "react";
 import { FaExclamationTriangle } from "react-icons/fa";
-import { DEFAULT_ENVIRONMENT_IDS } from "shared/util";
+import {
+  DEFAULT_ENVIRONMENT_IDS,
+  getEnvironmentDisplayName,
+} from "shared/util";
 import { useAuth } from "@/services/auth";
 import { useEnvironments } from "@/services/features";
 import { useUser } from "@/services/UserContext";
@@ -28,6 +31,7 @@ export default function EnvironmentModal({
     defaultValues: {
       id: existing.id || "",
       description: existing.description || "",
+      displayName: existing.displayName || "",
       toggleOnList: existing.toggleOnList || false,
       defaultState: existing.defaultState ?? true,
       projects: existing.projects || [],
@@ -74,7 +78,7 @@ export default function EnvironmentModal({
       close={close}
       header={
         existing.id
-          ? `Edit ${existing.id} Environment`
+          ? `Edit ${getEnvironmentDisplayName(existing as Environment)} Environment`
           : "Create New Environment"
       }
       submit={form.handleSubmit(async (value) => {
@@ -88,6 +92,7 @@ export default function EnvironmentModal({
             body: JSON.stringify({
               environment: {
                 description: value.description,
+                displayName: value.displayName || undefined,
                 toggleOnList: value.toggleOnList,
                 defaultState: value.defaultState,
                 projects: value.projects,
@@ -106,6 +111,7 @@ export default function EnvironmentModal({
           const newEnv: Environment = {
             id: value.id?.toLowerCase() || "",
             description: value.description || "",
+            displayName: value.displayName || undefined,
             toggleOnList: value.toggleOnList,
             defaultState: value.defaultState,
             projects: value.projects,
@@ -164,6 +170,12 @@ export default function EnvironmentModal({
         />
       )}
       <Field
+        label="Display Name"
+        {...form.register("displayName")}
+        placeholder={existing.id || "e.g. Production"}
+        helpText="Optional. Shown throughout the UI instead of the id. Leave blank to just show the id."
+      />
+      <Field
         label="Description"
         {...form.register("description")}
         placeholder=""
@@ -177,7 +189,10 @@ export default function EnvironmentModal({
             onChange={(value) => {
               form.setValue("parent", value || undefined);
             }}
-            options={environments.map((e) => ({ label: e.id, value: e.id }))}
+            options={environments.map((e) => ({
+              label: getEnvironmentDisplayName(e),
+              value: e.id,
+            }))}
             isClearable
             disabled={!DEFAULT_ENVIRONMENT_IDS.includes(form.watch("id") || "")}
             helpText={

--- a/packages/front-end/components/Settings/Team/InviteList.tsx
+++ b/packages/front-end/components/Settings/Team/InviteList.tsx
@@ -3,6 +3,7 @@ import { Invite, MemberRoleInfo } from "shared/types/organization";
 import { FaCheck, FaTimes } from "react-icons/fa";
 import { datetime } from "shared/dates";
 import { getRoleDisplayName } from "shared/permissions";
+import { getEnvironmentDisplayName } from "shared/util";
 import ConfirmModal from "@/components/ConfirmModal";
 import { roleHasAccessToEnv, useAuth } from "@/services/auth";
 import LoadingOverlay from "@/components/LoadingOverlay";
@@ -158,7 +159,7 @@ const InviteList: FC<{
               <th>{project ? "Project Role" : "Global Role"}</th>
               {!project && <th>Project Roles</th>}
               {environments.map((env) => (
-                <th key={env.id}>{env.id}</th>
+                <th key={env.id}>{getEnvironmentDisplayName(env)}</th>
               ))}
               <th style={{ width: 50 }} />
             </tr>

--- a/packages/front-end/components/Settings/Team/MemberList.tsx
+++ b/packages/front-end/components/Settings/Team/MemberList.tsx
@@ -9,6 +9,7 @@ import {
   getEffectiveRolesForProject,
   getRoleDisplayName,
 } from "shared/permissions";
+import { getEnvironmentDisplayName } from "shared/util";
 import { roleHasAccessToEnv, useAuth } from "@/services/auth";
 import { useUser } from "@/services/UserContext";
 import ProjectBadges from "@/components/ProjectBadges";
@@ -183,7 +184,7 @@ const MemberList: FC<{
                 </th>
                 {!project && <th>Project Roles</th>}
                 {environments.map((env) => (
-                  <th key={env.id}>{env.id}</th>
+                  <th key={env.id}>{getEnvironmentDisplayName(env)}</th>
                 ))}
                 <SortableTH field="numTeams">Teams</SortableTH>
                 <th style={{ width: 50 }} />

--- a/packages/front-end/components/Settings/Team/PendingMemberList.tsx
+++ b/packages/front-end/components/Settings/Team/PendingMemberList.tsx
@@ -3,6 +3,7 @@ import { FaCheck, FaTimes, FaUserCheck } from "react-icons/fa";
 import { PendingMember } from "shared/types/organization";
 import { datetime } from "shared/dates";
 import { getRoleDisplayName } from "shared/permissions";
+import { getEnvironmentDisplayName } from "shared/util";
 import { roleHasAccessToEnv, useAuth } from "@/services/auth";
 import ProjectBadges from "@/components/ProjectBadges";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
@@ -60,7 +61,7 @@ const PendingMemberList: FC<{
             <th>{project ? "Project Role" : "Global Role"}</th>
             {!project && <th>Project Roles</th>}
             {environments.map((env) => (
-              <th key={env.id}>{env.id}</th>
+              <th key={env.id}>{getEnvironmentDisplayName(env)}</th>
             ))}
             <th />
             <th style={{ width: 50 }} />

--- a/packages/front-end/components/Settings/Team/SingleRoleSelector.tsx
+++ b/packages/front-end/components/Settings/Team/SingleRoleSelector.tsx
@@ -7,6 +7,7 @@ import {
   roleSupportsEnvLimit,
   getRoleDisplayName,
 } from "shared/permissions";
+import { getEnvironmentDisplayName } from "shared/util";
 import { useUser } from "@/services/UserContext";
 import { useEnvironments } from "@/services/features";
 import MultiSelectField from "@/components/Forms/MultiSelectField";
@@ -95,7 +96,7 @@ export default function SingleRoleSelector({
     const activeEnvIds = new Set(activeEnvs.map((env) => env.id));
     const envOptions: SingleValue[] = [...activeEnvs].map((env) => {
       return {
-        label: env.id,
+        label: getEnvironmentDisplayName(env),
         value: env.id,
         tooltip: env.description,
       };

--- a/packages/front-end/components/Settings/Teams/TeamsList.tsx
+++ b/packages/front-end/components/Settings/Teams/TeamsList.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from "react";
 import { useRouter } from "next/router";
 import { date } from "shared/dates";
+import { getEnvironmentDisplayName } from "shared/util";
 import { FaCheck, FaTimes } from "react-icons/fa";
 import { RxIdCard } from "react-icons/rx";
 import Link from "@/ui/Link";
@@ -37,7 +38,7 @@ const TeamsList: FC = () => {
                 <th className="col-2">Global Role</th>
                 <th className="col-2">Project Roles</th>
                 {environments.map((env) => (
-                  <th key={env.id}>{env.id}</th>
+                  <th key={env.id}>{getEnvironmentDisplayName(env)}</th>
                 ))}
                 <th className="col-1">Members</th>
                 <th className="w-50" />

--- a/packages/front-end/pages/environments.tsx
+++ b/packages/front-end/pages/environments.tsx
@@ -162,7 +162,9 @@ const EnvironmentsPage: FC = () => {
               return (
                 <TableRow key={e.id}>
                   <TableCell>
-                    <div>{getEnvironmentDisplayName(e)}</div>
+                    <Text as="p" mb="0">
+                      {getEnvironmentDisplayName(e)}
+                    </Text>
                     {e.displayName && e.displayName !== e.id && (
                       <Text as="p" size="small" color="text-mid" mb="0">
                         {e.id}

--- a/packages/front-end/pages/environments.tsx
+++ b/packages/front-end/pages/environments.tsx
@@ -1,6 +1,9 @@
 import { useState, FC, useMemo } from "react";
 import { Environment } from "shared/types/organization";
-import { isProjectListValidForProject } from "shared/util";
+import {
+  getEnvironmentDisplayName,
+  isProjectListValidForProject,
+} from "shared/util";
 import { BiShow } from "react-icons/bi";
 import { BsThreeDotsVertical } from "react-icons/bs";
 import { FaRegCircleCheck, FaRegCircleXmark } from "react-icons/fa6";
@@ -86,7 +89,9 @@ const EnvironmentsPage: FC = () => {
       {showConnectionsModal !== null &&
         filteredEnvironments[showConnectionsModal] && (
           <Modal
-            header={`'${filteredEnvironments[showConnectionsModal].id}' SDK Connections`}
+            header={`'${getEnvironmentDisplayName(
+              filteredEnvironments[showConnectionsModal],
+            )}' SDK Connections`}
             trackingEventModalType="show-environment-connections"
             close={() => setShowConnectionsModal(null)}
             open={true}
@@ -156,7 +161,14 @@ const EnvironmentsPage: FC = () => {
               };
               return (
                 <TableRow key={e.id}>
-                  <TableCell>{e.id}</TableCell>
+                  <TableCell>
+                    <div>{getEnvironmentDisplayName(e)}</div>
+                    {e.displayName && e.displayName !== e.id && (
+                      <Text as="p" size="small" color="text-mid" mb="0">
+                        {e.id}
+                      </Text>
+                    )}
+                  </TableCell>
                   <TableCell>{e.description}</TableCell>
                   <TableCell>
                     {(e?.projects?.length || 0) > 0 ? (

--- a/packages/front-end/pages/features/index.tsx
+++ b/packages/front-end/pages/features/index.tsx
@@ -5,7 +5,7 @@ import { Box, Flex } from "@radix-ui/themes";
 import { FaRegCircleCheck, FaRegCircleXmark } from "react-icons/fa6";
 import { FeatureInterface } from "shared/types/feature";
 import { date, datetime } from "shared/dates";
-import { featureHasEnvironment } from "shared/util";
+import { featureHasEnvironment, getEnvironmentDisplayName } from "shared/util";
 import { getDemoDatasourceProjectIdForOrganization } from "shared/demo-datasource";
 import Link from "@/ui/Link";
 import LoadingOverlay from "@/components/LoadingOverlay";
@@ -354,7 +354,7 @@ export default function FeaturesPage() {
                     key={en.id}
                     style={{ textAlign: "center" }}
                   >
-                    {en.id}
+                    {getEnvironmentDisplayName(en)}
                   </TableColumnHeader>
                 ))}
                 <TableColumnHeader>Data Type</TableColumnHeader>
@@ -467,8 +467,8 @@ export default function FeaturesPage() {
                                   flipTheme={false}
                                   body={
                                     enabled
-                                      ? `${en.id}: enabled`
-                                      : `${en.id}: disabled`
+                                      ? `${getEnvironmentDisplayName(en)}: enabled`
+                                      : `${getEnvironmentDisplayName(en)}: disabled`
                                   }
                                 >
                                   {enabled ? (

--- a/packages/shared/src/util/environments.ts
+++ b/packages/shared/src/util/environments.ts
@@ -1,3 +1,5 @@
+import { Environment } from "shared/types/organization";
+
 // Environments whose IDs match any of these patterns are considered
 // non-production (dev-like). A feature enabled only in these environments
 // is still treated as "draft" for status purposes.
@@ -7,4 +9,14 @@ export const NON_PRODUCTION_ENV_PATTERNS: RegExp[] = [
 
 export function isEnvironmentDevLike(envId: string): boolean {
   return NON_PRODUCTION_ENV_PATTERNS.some((re) => re.test(envId));
+}
+
+// The environment `id` is immutable and used as a reference key everywhere
+// (feature rules, SDK connections, permissions, etc). `displayName` is a
+// purely cosmetic, user-facing label — use this helper anywhere an
+// environment's name is shown to a user so renames stay UI-only.
+export function getEnvironmentDisplayName(
+  env: Pick<Environment, "id" | "displayName">,
+): string {
+  return env.displayName || env.id;
 }

--- a/packages/shared/src/util/environments.ts
+++ b/packages/shared/src/util/environments.ts
@@ -18,5 +18,6 @@ export function isEnvironmentDevLike(envId: string): boolean {
 export function getEnvironmentDisplayName(
   env: Pick<Environment, "id" | "displayName">,
 ): string {
-  return env.displayName || env.id;
+  const displayName = env.displayName?.trim();
+  return displayName || env.id;
 }

--- a/packages/shared/src/util/index.ts
+++ b/packages/shared/src/util/index.ts
@@ -697,4 +697,5 @@ export function capitalizeFirstCharacter(s: string) {
 export {
   NON_PRODUCTION_ENV_PATTERNS,
   isEnvironmentDevLike,
+  getEnvironmentDisplayName,
 } from "./environments";

--- a/packages/shared/src/validators/environment.ts
+++ b/packages/shared/src/validators/environment.ts
@@ -14,6 +14,7 @@ export const updateEnvValidator = z.object({
   environment: z
     .object({
       description: z.string(),
+      displayName: z.string().optional(),
       toggleOnList: z.boolean().optional(),
       defaultState: z.any().optional(),
       projects: z.array(z.string()).optional(),
@@ -25,6 +26,7 @@ export const environment = z
   .object({
     id: z.string(),
     description: z.string(),
+    displayName: z.string().optional(),
     toggleOnList: z.boolean().optional(),
     defaultState: z.boolean().optional(),
     projects: z.array(z.string()).optional(),
@@ -51,6 +53,7 @@ export const apiEnvironmentValidator = namedSchema(
     .object({
       id: z.string(),
       description: z.string(),
+      displayName: z.string().optional(),
       toggleOnList: z.boolean(),
       defaultState: z.boolean(),
       projects: z.array(z.string()),
@@ -66,6 +69,12 @@ const postEnvironmentBody = z
     description: z
       .string()
       .describe("The description of the new environment")
+      .optional(),
+    displayName: z
+      .string()
+      .describe(
+        "A user-facing name for the environment. Falls back to the id when not set.",
+      )
       .optional(),
     toggleOnList: z.boolean().describe("Show on feature list page").optional(),
     defaultState: z
@@ -88,6 +97,12 @@ const putEnvironmentBody = z
     description: z
       .string()
       .describe("The description of the new environment")
+      .optional(),
+    displayName: z
+      .string()
+      .describe(
+        "A user-facing name for the environment. Falls back to the id when not set.",
+      )
       .optional(),
     toggleOnList: z.boolean().describe("Show on feature list page").optional(),
     defaultState: z


### PR DESCRIPTION
## Summary
- Adds an optional `displayName` field to environments. The `id` stays immutable (it's used as a reference key throughout features, SDK connections, permissions, Slack integrations, etc.), but `displayName` is a purely cosmetic user-facing label shown in the UI wherever an environment's name is displayed, falling back to `id` when unset.
- Exposed via both the internal app (Settings → Environments) and the external REST API (`POST`/`PUT`/`GET /api/v1/environments`).

## Test plan
- [x] `pnpm type-check` clean across `shared`, `back-end`, `front-end`
- [x] `pnpm lint` clean on all changed files
- [x] `pnpm --filter back-end generate-openapi` regenerated and committed `generated/spec.yaml`
- [x] Manually verified in the browser: set a display name on an environment and confirmed it renders correctly (with `id` falling back when unset) in:
  - Environments settings list + edit modal
  - Feature list column headers
  - Feature Overview "Enabled Environments" row
  - Feature Rules tab bar and rule environment-scope badges
  - Team Members permission table
- [x] Verified round-trip through the external API validators (create/update/list all correctly handle `displayName`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)