### PR TITLE
Enable GrowthBook client on self-hosted instances

### DIFF
--- a/packages/back-end/src/services/auth/index.ts
+++ b/packages/back-end/src/services/auth/index.ts
@@ -354,7 +354,7 @@ export async function processJWT(
         freeSeats: org?.freeSeats,
         discountCode: org?.discountCode,
         organizationId: hashedOrganizationId,
-        cloudOrgId: orgId,
+        cloudOrgId: IS_CLOUD ? orgId : "",
         accountPlan: org ? getEffectiveAccountPlan(org) : "loading",
         superAdmin: user.superAdmin,
         orgDateCreated: org?.dateCreated

--- a/packages/back-end/src/services/auth/index.ts
+++ b/packages/back-end/src/services/auth/index.ts
@@ -323,76 +323,74 @@ export async function processJWT(
       });
     };
 
-    if (IS_CLOUD) {
-      const gbClient = getGrowthBookClient();
+    const gbClient = getGrowthBookClient();
 
-      if (gbClient) {
-        const build = getBuild();
-        const org = req.organization;
-        const orgId = org?.id || "";
-        const hashedOrganizationId = orgId
-          ? createHash("sha256")
-              .update(GROWTHBOOK_SECURE_ATTRIBUTE_SALT + orgId)
-              .digest("hex")
-          : "";
+    if (gbClient) {
+      const build = getBuild();
+      const org = req.organization;
+      const orgId = org?.id || "";
+      const hashedOrganizationId = orgId
+        ? createHash("sha256")
+            .update(GROWTHBOOK_SECURE_ATTRIBUTE_SALT + orgId)
+            .digest("hex")
+        : "";
 
-        // Create sticky bucket service for Express
-        const stickyBucketService = new ExpressCookieStickyBucketService({
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          req: req as any,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          res: res as any,
+      // Create sticky bucket service for Express
+      const stickyBucketService = new ExpressCookieStickyBucketService({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        req: req as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        res: res as any,
+      });
+
+      const trackingAttributes = getGrowthBookTrackingAttributes(req);
+
+      // Define user attributes
+      // Note: cloud and multiOrg are set as globalAttributes in growthbook.ts
+      const attributes = {
+        id: user.id,
+        user_id: user.id,
+        request_path: req.path,
+        freeSeats: org?.freeSeats,
+        discountCode: org?.discountCode,
+        organizationId: hashedOrganizationId,
+        cloudOrgId: orgId,
+        accountPlan: org ? getEffectiveAccountPlan(org) : "loading",
+        superAdmin: user.superAdmin,
+        orgDateCreated: org?.dateCreated
+          ? new Date(org.dateCreated).toISOString()
+          : "",
+        ...trackingAttributes,
+        role: org?.members.find((m) => m.id === user.id)?.role,
+        hasLicenseKey: org?.licenseKey ? true : false,
+        configFile: usingFileConfig(),
+        usingSSO: usingOpenId(),
+        buildSHA: build.sha,
+        buildDate: build.date,
+        buildVersion: build.lastVersion,
+        orgOwnerJobTitle: org?.demographicData?.ownerJobTitle,
+        orgOwnerUsageIntents: org?.demographicData?.ownerUsageIntents,
+      };
+
+      try {
+        // Apply sticky bucketing and get user context
+        const userContext = await gbClient.applyStickyBuckets(
+          {
+            attributes,
+            url: getGrowthBookRequestUrl(req),
+            enableDevMode: true,
+          },
+          stickyBucketService,
+        );
+
+        // Create scoped instance for this request (reuses singleton)
+        req.gb = gbClient.createScopedInstance(userContext);
+      } catch (error) {
+        logger.error("Failed to create GrowthBook scoped instance", {
+          error,
+          userId: user.id,
         });
-
-        const trackingAttributes = getGrowthBookTrackingAttributes(req);
-
-        // Define user attributes
-        // Note: cloud and multiOrg are set as globalAttributes in growthbook.ts
-        const attributes = {
-          id: user.id,
-          user_id: user.id,
-          request_path: req.path,
-          freeSeats: org?.freeSeats,
-          discountCode: org?.discountCode,
-          organizationId: hashedOrganizationId,
-          cloudOrgId: orgId,
-          accountPlan: org ? getEffectiveAccountPlan(org) : "loading",
-          superAdmin: user.superAdmin,
-          orgDateCreated: org?.dateCreated
-            ? new Date(org.dateCreated).toISOString()
-            : "",
-          ...trackingAttributes,
-          role: org?.members.find((m) => m.id === user.id)?.role,
-          hasLicenseKey: org?.licenseKey ? true : false,
-          configFile: usingFileConfig(),
-          usingSSO: usingOpenId(),
-          buildSHA: build.sha,
-          buildDate: build.date,
-          buildVersion: build.lastVersion,
-          orgOwnerJobTitle: org?.demographicData?.ownerJobTitle,
-          orgOwnerUsageIntents: org?.demographicData?.ownerUsageIntents,
-        };
-
-        try {
-          // Apply sticky bucketing and get user context
-          const userContext = await gbClient.applyStickyBuckets(
-            {
-              attributes,
-              url: getGrowthBookRequestUrl(req),
-              enableDevMode: true,
-            },
-            stickyBucketService,
-          );
-
-          // Create scoped instance for this request (reuses singleton)
-          req.gb = gbClient.createScopedInstance(userContext);
-        } catch (error) {
-          logger.error("Failed to create GrowthBook scoped instance", {
-            error,
-            userId: user.id,
-          });
-          // Continue without feature flags rather than failing request
-        }
+        // Continue without feature flags rather than failing request
       }
     }
   } else {

--- a/packages/back-end/src/services/growthbook.ts
+++ b/packages/back-end/src/services/growthbook.ts
@@ -161,8 +161,6 @@ export function getGrowthBookTrackingAttributes(
 }
 
 function ensureGrowthBookClient(): GrowthBookClient<AppFeatures> | null {
-  if (!IS_CLOUD) return null;
-
   if (!gbClient) {
     gbClient = createGrowthBookClient();
   }
@@ -214,13 +212,6 @@ async function runGrowthBookClientInit(): Promise<void> {
  * Enables real-time feature updates via Server-Sent Events
  */
 export async function initializeGrowthBookClient(): Promise<void> {
-  if (!IS_CLOUD) {
-    logger.info(
-      "GrowthBook client not initialized - not running in cloud mode",
-    );
-    return;
-  }
-
   if (initPromise) return initPromise;
 
   initPromise = runGrowthBookClientInit().catch((error) => {

--- a/packages/back-end/src/services/growthbook.ts
+++ b/packages/back-end/src/services/growthbook.ts
@@ -23,16 +23,6 @@ setPolyfills({ EventSource });
 
 let gbClient: GrowthBookClient<AppFeatures> | null = null;
 let initPromise: Promise<void> | null = null;
-let gbInitSucceeded = false;
-
-function resetGrowthBookClientState(): void {
-  if (gbClient) {
-    gbClient.destroy();
-    gbClient = null;
-  }
-  initPromise = null;
-  gbInitSucceeded = false;
-}
 
 function createGrowthBookClient(): GrowthBookClient<AppFeatures> {
   const client = new GrowthBookClient<AppFeatures>({
@@ -176,7 +166,7 @@ function ensureGrowthBookClient(): GrowthBookClient<AppFeatures> | null {
 export function getGrowthBookClient(): GrowthBookClient<AppFeatures> | null {
   const client = ensureGrowthBookClient();
 
-  if (!gbInitSucceeded && !initPromise) {
+  if (!initPromise) {
     void initializeGrowthBookClient();
   }
 
@@ -194,12 +184,9 @@ async function runGrowthBookClientInit(): Promise<void> {
 
   if (!success) {
     logger.warn({ source, err: error }, "GrowthBook features not loaded");
-    // SDK sets ready=true even with an empty payload; discard and retry later.
-    resetGrowthBookClientState();
     return;
   }
 
-  gbInitSucceeded = true;
   logger.info(
     { source, streaming: true },
     "GrowthBook client initialized successfully",
@@ -215,7 +202,6 @@ export async function initializeGrowthBookClient(): Promise<void> {
   if (initPromise) return initPromise;
 
   initPromise = runGrowthBookClientInit().catch((error) => {
-    resetGrowthBookClientState();
     logger.error({ err: error }, "Failed to initialize GrowthBook client");
     // Don't throw - allow app to continue without feature flags
   });
@@ -228,6 +214,7 @@ export async function initializeGrowthBookClient(): Promise<void> {
  * Call this during graceful shutdown to close SSE connections
  */
 export function destroyGrowthBookClient(): void {
-  resetGrowthBookClientState();
+  gbClient?.destroy();
+  gbClient = null;
   logger.info("GrowthBook client destroyed");
 }

--- a/packages/front-end/services/utils.tsx
+++ b/packages/front-end/services/utils.tsx
@@ -16,7 +16,6 @@ import track, {
   getJitsuAnonymousId,
   getTrackingPageUrl,
 } from "@/services/track";
-import { isCloud, isLocalhost } from "./env";
 
 const DEVICE_ID_COOKIE = "gb_device_id";
 const SESSION_ID_COOKIE = "gb_session_id";
@@ -296,7 +295,7 @@ function getOrGenerateSessionId() {
 export function getGrowthBookTrackingHeaders(
   pagePath?: string,
 ): Record<string, string> {
-  if (typeof window === "undefined" || (!isCloud() && !isLocalhost())) {
+  if (typeof window === "undefined") {
     return {};
   }
 

--- a/packages/front-end/services/utils.tsx
+++ b/packages/front-end/services/utils.tsx
@@ -16,6 +16,7 @@ import track, {
   getJitsuAnonymousId,
   getTrackingPageUrl,
 } from "@/services/track";
+import { isTelemetryEnabled } from "./env";
 
 const DEVICE_ID_COOKIE = "gb_device_id";
 const SESSION_ID_COOKIE = "gb_session_id";
@@ -295,7 +296,7 @@ function getOrGenerateSessionId() {
 export function getGrowthBookTrackingHeaders(
   pagePath?: string,
 ): Record<string, string> {
-  if (typeof window === "undefined") {
+  if (typeof window === "undefined" || !isTelemetryEnabled()) {
     return {};
   }
 


### PR DESCRIPTION
## Summary
- PR #6270 added the GrowthBook SDK client to the back-end (for dogfooding our own feature flags/experiments), but gated all of it behind `IS_CLOUD`. There's no reason self-hosted instances shouldn't get the same benefit, so this removes those gates.
- Removes the `IS_CLOUD` checks in `ensureGrowthBookClient()` and `initializeGrowthBookClient()` in [`growthbook.ts`](packages/back-end/src/services/growthbook.ts), and the `if (IS_CLOUD)` wrapper around scoped-instance/sticky-bucket creation in `processJWT()` in [`auth/index.ts`](packages/back-end/src/services/auth/index.ts).
- Removes the `isCloud() && isLocalhost()` gate on the front-end's `getGrowthBookTrackingHeaders()` in [`utils.tsx`](packages/front-end/services/utils.tsx), so the `X-GB-*` tracking headers are sent from self-hosted instances too.
- Left the unrelated `IS_CLOUD` checks alone (Cloud SSO/Auth0 verification requirement, and the `cloud: IS_CLOUD` global attribute sent to GrowthBook for targeting purposes).
- On a failed init, we were destroying and re-creating the singleton `GrowthBookClient` so the next request would retry from scratch. That actually worked against the SDK's own recovery behavior — a timed-out fetch keeps running in the background even after `init()` returns `success: false`, and if it eventually resolves, the SDK populates the (still-referenced) client and sets up streaming/auto-refresh on its own. Destroying and swapping in a new client instance orphaned that in-flight fetch, discarding any self-heal it would have produced

## Test plan
- [x] `pnpm --filter back-end type-check`
- [x] `pnpm --filter front-end type-check`
- [x] Lint via pre-commit hook
- [ ] Manually verify a self-hosted-mode local instance successfully initializes the GrowthBook client and evaluates feature flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)