### PR TITLE
docs: Update Helm Chart URL

### DIFF
--- a/docs/docs/self-host/kubernetes.mdx
+++ b/docs/docs/self-host/kubernetes.mdx
@@ -21,7 +21,7 @@ Before you apply the example values files, make sure you complete these minimal 
 
 **Kubernetes Cluster Access**
 
-Ensure you have access to a running Kubernetes cluster ([Minikube](https://minikube.sigs.k8s.io/docs/start/?arch=%2Fmacos%2Farm64%2Fstable%2Fbinary+download), [GKE](https://cloud.google.com/kubernetes-engine?hl=en), or [EKS](https://aws.amazon.com/eks/)) with permissions to deploy workloads and required controllers (such as load balancer controllers) installed. You'll need `kubectl` and the GrowthBook Helm chart, which is published as an OCI artifact at [`oci://ghcr.io/growthbook/charts/growthbook`](https://github.com/growthbook/growthbook/pkgs/container/charts%2Fgrowthbook).
+Ensure you have access to a running Kubernetes cluster ([Minikube](https://minikube.sigs.k8s.io/docs/start/?arch=%2Fmacos%2Farm64%2Fstable%2Fbinary+download), [GKE](https://cloud.google.com/kubernetes-engine?hl=en), or [EKS](https://aws.amazon.com/eks/)) with permissions to deploy workloads and required controllers (such as load balancer controllers) installed. You'll need `kubectl` and the [GrowthBook Helm chart](https://artifacthub.io/packages/helm/growthbook/growthbook).
 
 **Authentication Secrets**
 
@@ -156,7 +156,7 @@ ingress:
       </details>
       Installation:
       ```bash
-      helm upgrade --install growthbook oci://ghcr.io/growthbook/charts/growthbook -f values-aws.yaml
+      helm install growthbook oci://ghcr.io/growthbook/charts/growthbook -f values-aws.yaml
       ```
       <div className="admonition info">
         <p>
@@ -262,7 +262,7 @@ ingress:
       </details>
       Installation:
       ```bash
-      helm upgrade --install growthbook oci://ghcr.io/growthbook/charts/growthbook -f values-gcp.yaml
+      helm install growthbook oci://ghcr.io/growthbook/charts/growthbook -f values-gcp.yaml
       ```
       <div className="admonition info">
         <p>
@@ -477,7 +477,7 @@ ingress:
       </details>
       Installation:
       ```bash
-      helm upgrade --install growthbook oci://ghcr.io/growthbook/charts/growthbook -f values-minikube.yaml
+      helm install growthbook oci://ghcr.io/growthbook/charts/growthbook -f values-minikube.yaml
       ```
     </div>
 

--- a/docs/docs/self-host/kubernetes.mdx
+++ b/docs/docs/self-host/kubernetes.mdx
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 # Deploying GrowthBook with Kubernetes
 
 :::tip Deploying GrowthBook with Kubernetes
-Our official Helm chart to deploy GrowthBook on Kubernetes is distributed as a OCI artifact via [ghcr.io](https://ghcr.io/growthbook/charts/growthbook):
+Our official Helm chart to deploy GrowthBook on Kubernetes is distributed as an OCI artifact via [ghcr.io](https://ghcr.io/growthbook/charts/growthbook):
 
 - For production and scalable cloud-native deployments, use GCP (GKE) or AWS (EKS).
 - For local testing and development, use Minikube.
@@ -156,7 +156,7 @@ ingress:
       </details>
       Installation:
       ```bash
-      helm install growthbook growthbook/growthbook -f values-aws.yaml
+      helm upgrade --install growthbook oci://ghcr.io/growthbook/charts/growthbook -f values-aws.yaml
       ```
       <div className="admonition info">
         <p>
@@ -262,7 +262,7 @@ ingress:
       </details>
       Installation:
       ```bash
-      helm install growthbook growthbook/growthbook -f values-gcp.yaml
+      helm upgrade --install growthbook oci://ghcr.io/growthbook/charts/growthbook -f values-gcp.yaml
       ```
       <div className="admonition info">
         <p>

--- a/docs/docs/self-host/kubernetes.mdx
+++ b/docs/docs/self-host/kubernetes.mdx
@@ -21,7 +21,7 @@ Before you apply the example values files, make sure you complete these minimal 
 
 **Kubernetes Cluster Access**
 
-Ensure you have access to a running Kubernetes cluster ([Minikube](https://minikube.sigs.k8s.io/docs/start/?arch=%2Fmacos%2Farm64%2Fstable%2Fbinary+download), [GKE](https://cloud.google.com/kubernetes-engine?hl=en), or [EKS](https://aws.amazon.com/eks/)) with permissions to deploy workloads and required controllers (such as load balancer controllers) installed. You'll need `kubectl` and the GrowthBook Helm chart, which is available on [Artifact Hub](https://artifacthub.io/packages/helm/one-acre-fund/growthbook).
+Ensure you have access to a running Kubernetes cluster ([Minikube](https://minikube.sigs.k8s.io/docs/start/?arch=%2Fmacos%2Farm64%2Fstable%2Fbinary+download), [GKE](https://cloud.google.com/kubernetes-engine?hl=en), or [EKS](https://aws.amazon.com/eks/)) with permissions to deploy workloads and required controllers (such as load balancer controllers) installed. You'll need `kubectl` and the GrowthBook Helm chart, which is available on our [GitHub](https://github.com/growthbook/growthbook/tree/main/charts/growthbook).
 
 **Authentication Secrets**
 

--- a/docs/docs/self-host/kubernetes.mdx
+++ b/docs/docs/self-host/kubernetes.mdx
@@ -21,7 +21,7 @@ Before you apply the example values files, make sure you complete these minimal 
 
 **Kubernetes Cluster Access**
 
-Ensure you have access to a running Kubernetes cluster ([Minikube](https://minikube.sigs.k8s.io/docs/start/?arch=%2Fmacos%2Farm64%2Fstable%2Fbinary+download), [GKE](https://cloud.google.com/kubernetes-engine?hl=en), or [EKS](https://aws.amazon.com/eks/)) with permissions to deploy workloads and required controllers (such as load balancer controllers) installed. You'll need `kubectl` and the GrowthBook Helm chart, which is available on our [GitHub](https://github.com/growthbook/growthbook/tree/main/charts/growthbook).
+Ensure you have access to a running Kubernetes cluster ([Minikube](https://minikube.sigs.k8s.io/docs/start/?arch=%2Fmacos%2Farm64%2Fstable%2Fbinary+download), [GKE](https://cloud.google.com/kubernetes-engine?hl=en), or [EKS](https://aws.amazon.com/eks/)) with permissions to deploy workloads and required controllers (such as load balancer controllers) installed. You'll need `kubectl` and the GrowthBook Helm chart, which is published as an OCI artifact at [`oci://ghcr.io/growthbook/charts/growthbook`](https://github.com/growthbook/growthbook/pkgs/container/charts%2Fgrowthbook).
 
 **Authentication Secrets**
 


### PR DESCRIPTION
### Features and Changes

We have been managing and publishing our own Helm Chart for a bit now, but we have a outdated link.
So this fixes the link to point to the latest helm chart in our GitHub repository.