### PR TITLE
Allow editing a secret API key's permissions without rotating it

### DIFF
--- a/packages/back-end/src/models/ApiKeyModel.ts
+++ b/packages/back-end/src/models/ApiKeyModel.ts
@@ -1,5 +1,7 @@
+import { isEqual } from "lodash";
+import { z } from "zod";
 import { ApiKeyInterface, SecretApiKey } from "shared/types/apikey";
-import { apiKeySchema } from "shared/validators";
+import { apiKeySchema, secretApiKeyUpdatableFields } from "shared/validators";
 import { getRoleById } from "shared/permissions";
 import {
   generateEncryptionKey,
@@ -12,6 +14,27 @@ import { MakeModelClass } from "./BaseModel";
 
 export const COLLECTION_NAME = "apikeys";
 
+const UPDATABLE_KEY_FIELDS: ReadonlySet<string> = new Set(
+  Object.keys(secretApiKeyUpdatableFields.shape),
+);
+
+// Full-replacement semantics: every permission field is required so a caller
+// omitting one can't silently strip a key's restrictions. Only the
+// description merges (kept when omitted).
+type UpdateOrganizationApiKeyProps = Omit<
+  Required<z.infer<typeof secretApiKeyUpdatableFields>>,
+  "role" | "description"
+> & {
+  roleId: string;
+  description?: string;
+};
+
+// Org secret keys are the only kind with editable permissions: PATs inherit
+// their user's permissions and SDK endpoint keys have no role.
+function isOrgSecretKey(apiKey: ApiKeyInterface): boolean {
+  return !!apiKey.secret && !apiKey.userId;
+}
+
 const BaseClass = MakeModelClass({
   schema: apiKeySchema,
   collectionName: COLLECTION_NAME,
@@ -20,6 +43,16 @@ const BaseClass = MakeModelClass({
   idPrefix: "key_",
   additionalIndexes: [{ fields: { id: 1 } }],
   skipDateUpdatedFields: ["lastUsed"],
+  // canUpdate's field allowlist is the authz gate; this hard-fails identity
+  // and key-material writes on every update path regardless of authz
+  readonlyFields: [
+    "key",
+    "encryptionKey",
+    "secret",
+    "userId",
+    "environment",
+    "project",
+  ],
   defaultValues: {
     limitAccessByEnvironment: false,
     environments: [],
@@ -48,12 +81,18 @@ export class ApiKeyModel extends BaseClass {
     apiKey: ApiKeyInterface,
     updates: Partial<ApiKeyInterface>,
   ): boolean {
-    // API keys are immutable except for toggling `disabled`.
-    // Anything else (key value, role, etc.) must never be edited.
     // `lastUsed` is written by auth middleware via the dangerous bypass and never hits this path.
     const keys = Object.keys(updates);
-    if (keys.length !== 1 || keys[0] !== "disabled") return false;
-    return this.canDelete(apiKey);
+    if (keys.length === 1 && keys[0] === "disabled") {
+      return this.canDelete(apiKey);
+    }
+    // The key value itself and identity fields (secret, userId) must never
+    // be edited.
+    if (!isOrgSecretKey(apiKey)) return false;
+    if (!keys.length || !keys.every((k) => UPDATABLE_KEY_FIELDS.has(k))) {
+      return false;
+    }
+    return this.context.permissions.canUpdateApiKey();
   }
   protected canDelete(apiKey: ApiKeyInterface): boolean {
     if (apiKey.secret) {
@@ -81,7 +120,10 @@ export class ApiKeyModel extends BaseClass {
     return { ...doc, key: "", encryptionKey: undefined };
   }
 
-  protected async customValidation(doc: ApiKeyInterface) {
+  protected async customValidation(
+    doc: ApiKeyInterface,
+    previousDoc?: ApiKeyInterface,
+  ) {
     if (doc.userId) {
       // PATs inherit permissions from their user — scoping fields must not be set
       if (doc.limitAccessByEnvironment) {
@@ -95,18 +137,32 @@ export class ApiKeyModel extends BaseClass {
         );
       }
     } else {
-      // Org API keys — validate role, environments, project roles, and commercial features
-      this.validateRole(doc.role);
-      if (
-        doc.limitAccessByEnvironment &&
-        !this.context.hasPremiumFeature("advanced-permissions")
-      ) {
-        this.context.throwPlanDoesNotAllowError(
-          "Your plan does not support restricting API key permissions by environment.",
-        );
+      // Org API keys — validate role, environments, project roles, and
+      // commercial features. Only fields that actually changed are validated,
+      // so pre-existing state that has since become invalid (a deactivated
+      // role, a lapsed premium feature) doesn't block unrelated edits.
+      if (!previousDoc || doc.role !== previousDoc.role) {
+        this.validateRole(doc.role);
       }
-      this.validateEnvironments(doc.environments);
-      if (doc.projectRoles) {
+      const envRestrictionsChanged =
+        !previousDoc ||
+        doc.limitAccessByEnvironment !== previousDoc.limitAccessByEnvironment ||
+        !isEqual(doc.environments, previousDoc.environments);
+      // With the restriction off the env list is inert, and validating it
+      // would stop a key whose org since deleted an environment from ever
+      // turning the restriction off
+      if (envRestrictionsChanged && doc.limitAccessByEnvironment) {
+        if (!this.context.hasPremiumFeature("advanced-permissions")) {
+          this.context.throwPlanDoesNotAllowError(
+            "Your plan does not support restricting API key permissions by environment.",
+          );
+        }
+        this.validateEnvironments(doc.environments);
+      }
+      if (
+        doc.projectRoles?.length &&
+        (!previousDoc || !isEqual(doc.projectRoles, previousDoc.projectRoles))
+      ) {
         if (!this.context.hasPremiumFeature("advanced-permissions")) {
           this.context.throwPlanDoesNotAllowError(
             "Your plan does not support project-level permissions on API keys.",
@@ -176,6 +232,43 @@ export class ApiKeyModel extends BaseClass {
     });
   }
 
+  // Full-replacement update of an org secret key's permissions. The key value
+  // is untouched, so callers keep working — the new permissions apply on their
+  // next request (auth reads the key doc fresh every time). Note the role
+  // embedded in the key string's prefix is cosmetic and may go stale.
+  // Returns void like the other mutators — the unredacted doc must not leak.
+  public async updateOrganizationApiKey(
+    id: string,
+    {
+      description,
+      roleId,
+      limitAccessByEnvironment,
+      environments,
+      projectRoles,
+    }: UpdateOrganizationApiKeyProps,
+  ): Promise<void> {
+    // canUpdate also gates this, but only for updates that change something —
+    // check up front so a value-matching no-op can't be used by unprivileged
+    // members to probe a key's current permissions.
+    if (!this.context.permissions.canUpdateApiKey()) {
+      this.context.permissions.throwPermissionError();
+    }
+    const doc = await this.getUnredactedByIdOrThrow(id);
+    if (!isOrgSecretKey(doc)) {
+      this.context.throwBadRequestError(
+        "Only organization secret API keys support permission updates",
+      );
+    }
+    await this.update(doc, {
+      ...(description !== undefined ? { description } : null),
+      role: roleId,
+      limitAccessByEnvironment,
+      environments,
+      // Explicit undefined clears any existing project-scoped roles
+      projectRoles: projectRoles.length ? projectRoles : undefined,
+    });
+  }
+
   public async createUserPersonalAccessApiKey({
     userId,
     description,
@@ -227,9 +320,14 @@ export class ApiKeyModel extends BaseClass {
   }
 
   public async setDisabled(id: string, disabled: boolean): Promise<void> {
+    const doc = await this.getUnredactedByIdOrThrow(id);
+    await this.update(doc, { disabled });
+  }
+
+  private async getUnredactedByIdOrThrow(id: string): Promise<ApiKeyInterface> {
     const doc = await this._findOne({ id }, { bypassSanitization: true });
     if (!doc) this.context.throwNotFoundError(`API key not found: ${id}`);
-    await this.update(doc, { disabled });
+    return doc;
   }
 
   // Called from authentication middleware on every API request attempt.

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1,4 +1,5 @@
 import { Response } from "express";
+import { z } from "zod";
 import { cloneDeep } from "lodash";
 import { freeEmailDomains } from "free-email-domains-typescript";
 import {
@@ -33,6 +34,7 @@ import {
 } from "shared/types/organization";
 import { ExperimentRule, NamespaceValue } from "shared/types/feature";
 import { TeamInterface } from "shared/types/team";
+import { putApiKeyValidator } from "back-end/src/routers/organizations/organizations.validators";
 import { validateRoleAndEnvs } from "back-end/src/api/members/updateMemberRole";
 import {
   AuthRequest,
@@ -1866,6 +1868,24 @@ export async function deleteApiKey(
   res.status(200).json({
     status: 200,
   });
+}
+
+export async function putApiKey(
+  req: AuthRequest<z.infer<typeof putApiKeyValidator>, { id: string }>,
+  res: Response,
+) {
+  const context = getContextFromReq(req);
+  const { id } = req.params;
+  // Spread so new updatable fields flow through without a hand-maintained
+  // list; only `role` is renamed to match the model's roleId param
+  const { role, ...updates } = req.body;
+
+  await context.models.apiKeys.updateOrganizationApiKey(id, {
+    ...updates,
+    roleId: role,
+  });
+
+  res.status(200).json({ status: 200 });
 }
 
 export async function putApiKeyDisabled(

--- a/packages/back-end/src/routers/organizations/organizations.router.ts
+++ b/packages/back-end/src/routers/organizations/organizations.router.ts
@@ -5,6 +5,7 @@ import { IS_CLOUD } from "back-end/src/util/secrets";
 import {
   postApiKeyValidator,
   putApiKeyDisabledValidator,
+  putApiKeyValidator,
   putDefaultRoleValidator,
   putMemberProjectRoleValidator,
 } from "./organizations.validators";
@@ -95,6 +96,13 @@ router.post(
   organizationsController.postApiKey,
 );
 router.delete("/keys", organizationsController.deleteApiKey);
+router.put(
+  "/keys/:id",
+  validateRequestMiddleware({
+    body: putApiKeyValidator,
+  }),
+  organizationsController.putApiKey,
+);
 router.post("/keys/reveal", organizationsController.postApiKeyReveal);
 router.put(
   "/keys/:id/disabled",

--- a/packages/back-end/src/routers/organizations/organizations.validators.ts
+++ b/packages/back-end/src/routers/organizations/organizations.validators.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { secretApiKeyUpdatableFields } from "shared/validators";
 
 const memberRoleInfoValidator = z
   .object({
@@ -39,6 +40,18 @@ export const postApiKeyValidator = z.strictObject({
   environments: z.array(z.string()).optional(),
   projectRoles: z.array(projectMemberRoleValidator).optional(),
 });
+
+// Full-replacement update: every permission field is required so a partial
+// body can't silently strip a key's env/project restrictions. Only the
+// description is preserved when omitted.
+export const putApiKeyValidator = secretApiKeyUpdatableFields
+  .required({
+    role: true,
+    limitAccessByEnvironment: true,
+    environments: true,
+    projectRoles: true,
+  })
+  .strict();
 
 export const putApiKeyDisabledValidator = z.strictObject({
   disabled: z.boolean(),

--- a/packages/back-end/test/models/ApiKeyModel.test.ts
+++ b/packages/back-end/test/models/ApiKeyModel.test.ts
@@ -1,0 +1,427 @@
+import { Collection } from "mongodb";
+import { ApiKeyInterface } from "shared/types/apikey";
+
+// Break the module cycle ApiKeyModel -> api-key.util/services-organizations ->
+// OrganizationModel/DataSourceModel -> context -> ApiKeyModel, which throws a
+// TDZ error when the test entrypoint is ApiKeyModel itself.
+jest.mock("back-end/src/util/api-key.util", () => ({
+  generateEncryptionKey: jest.fn(async () => "enc_key"),
+  generateSigningKey: jest.fn((prefix: string) => `${prefix}generated`),
+  migrateApiKey: jest.fn((doc) => doc),
+}));
+jest.mock("back-end/src/services/organizations", () => ({
+  getEnvironmentIdsFromOrg: (org: {
+    settings?: { environments?: { id: string }[] };
+  }) => (org.settings?.environments ?? []).map((e) => e.id),
+}));
+
+import { ApiKeyModel } from "back-end/src/models/ApiKeyModel";
+
+import { Context } from "back-end/src/models/BaseModel";
+
+const updateIndexesMock = jest.fn();
+
+class TestApiKeyModel extends ApiKeyModel {
+  public dangerousGetCollectionMock = jest.fn();
+
+  protected updateIndexes() {
+    return updateIndexesMock();
+  }
+
+  protected _dangerousGetCollection(): Collection {
+    return this.dangerousGetCollectionMock();
+  }
+
+  public exposeCanUpdate(
+    apiKey: ApiKeyInterface,
+    updates: Partial<ApiKeyInterface>,
+  ): boolean {
+    return this.canUpdate(apiKey, updates);
+  }
+}
+
+const makeContext = (overrides: Record<string, unknown> = {}) =>
+  ({
+    org: {
+      id: "org_1",
+      deactivatedRoles: [],
+      settings: {
+        environments: [{ id: "production" }, { id: "staging" }],
+      },
+    },
+    userId: "u_self",
+    permissions: {
+      canCreateApiKey: jest.fn(() => true),
+      canUpdateApiKey: jest.fn(() => true),
+      canDeleteApiKey: jest.fn(() => true),
+      canReadSingleProjectResource: jest.fn(() => true),
+      throwPermissionError: jest.fn(() => {
+        throw new Error("You do not have permission to perform this action");
+      }),
+    },
+    hasPremiumFeature: jest.fn(() => true),
+    getProjects: jest.fn(async () => [{ id: "prj_coworker" }]),
+    populateForeignRefs: jest.fn(),
+    registerTags: jest.fn(),
+    throwBadRequestError: (message: string) => {
+      throw new Error(message);
+    },
+    throwNotFoundError: (message?: string) => {
+      throw new Error(message || "Not found");
+    },
+    throwPlanDoesNotAllowError: (message: string) => {
+      throw new Error(message);
+    },
+    ...overrides,
+  }) as unknown as Context;
+
+const orgSecretKey = (
+  overrides: Partial<ApiKeyInterface> = {},
+): ApiKeyInterface =>
+  ({
+    id: "key_1",
+    key: "secret_experimenter_abc123",
+    organization: "org_1",
+    secret: true,
+    role: "experimenter",
+    description: "coworker gateway",
+    environment: "",
+    project: "",
+    limitAccessByEnvironment: false,
+    environments: [],
+    dateCreated: new Date("2026-01-01"),
+    dateUpdated: new Date("2026-01-01"),
+    ...overrides,
+  }) as ApiKeyInterface;
+
+// Everything the required full-replacement signature needs; spread overrides on top
+const baseUpdate = {
+  roleId: "experimenter",
+  limitAccessByEnvironment: false,
+  environments: [] as string[],
+  projectRoles: [] as NonNullable<ApiKeyInterface["projectRoles"]>,
+};
+
+describe("ApiKeyModel.canUpdate", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("still allows toggling disabled with the delete permission", () => {
+    const model = new TestApiKeyModel(makeContext());
+    expect(model.exposeCanUpdate(orgSecretKey(), { disabled: true })).toBe(
+      true,
+    );
+  });
+
+  it("allows permission-field updates on an org secret key with manageApiKeys", () => {
+    const model = new TestApiKeyModel(makeContext());
+    expect(
+      model.exposeCanUpdate(orgSecretKey(), {
+        role: "admin",
+        projectRoles: [
+          {
+            project: "prj_coworker",
+            role: "experimenter",
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        ],
+        environments: [],
+        limitAccessByEnvironment: false,
+        description: "updated",
+      }),
+    ).toBe(true);
+  });
+
+  it("denies permission-field updates without manageApiKeys", () => {
+    const context = makeContext();
+    (context.permissions.canUpdateApiKey as jest.Mock).mockReturnValue(false);
+    const model = new TestApiKeyModel(context);
+    expect(model.exposeCanUpdate(orgSecretKey(), { role: "admin" })).toBe(
+      false,
+    );
+  });
+
+  it("denies permission-field updates on PATs", () => {
+    const model = new TestApiKeyModel(makeContext());
+    expect(
+      model.exposeCanUpdate(orgSecretKey({ userId: "u_self" }), {
+        role: "admin",
+      }),
+    ).toBe(false);
+  });
+
+  it("denies permission-field updates on SDK endpoint keys", () => {
+    const model = new TestApiKeyModel(makeContext());
+    expect(
+      model.exposeCanUpdate(
+        orgSecretKey({ secret: false, environment: "production" }),
+        { role: "admin" },
+      ),
+    ).toBe(false);
+  });
+
+  it("denies edits to identity fields and mixed disabled updates", () => {
+    const model = new TestApiKeyModel(makeContext());
+    expect(
+      model.exposeCanUpdate(orgSecretKey(), { key: "secret_admin_forged" }),
+    ).toBe(false);
+    expect(model.exposeCanUpdate(orgSecretKey(), { userId: "u_other" })).toBe(
+      false,
+    );
+    expect(model.exposeCanUpdate(orgSecretKey(), { encryptionKey: "x" })).toBe(
+      false,
+    );
+    expect(
+      model.exposeCanUpdate(orgSecretKey(), { disabled: true, role: "admin" }),
+    ).toBe(false);
+  });
+});
+
+describe("ApiKeyModel.updateOrganizationApiKey", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const setupModel = (
+    doc: ApiKeyInterface | null,
+    contextOverrides: Record<string, unknown> = {},
+  ) => {
+    const context = makeContext(contextOverrides);
+    const model = new TestApiKeyModel(context);
+    const updateOne = jest.fn(async () => ({ matchedCount: 1 }));
+    model.dangerousGetCollectionMock.mockReturnValue({
+      findOne: jest.fn(async () => doc),
+      updateOne,
+    });
+    return { model, context, updateOne };
+  };
+
+  const setOf = (updateOne: jest.Mock) =>
+    (
+      updateOne.mock.calls[0] as unknown as [
+        Record<string, unknown>,
+        { $set: Record<string, unknown>; $unset?: Record<string, unknown> },
+      ]
+    )[1];
+
+  it("updates role and project roles in place, scoped to the org", async () => {
+    const { model, updateOne } = setupModel(orgSecretKey());
+
+    await model.updateOrganizationApiKey("key_1", {
+      ...baseUpdate,
+      roleId: "readonly",
+      projectRoles: [
+        {
+          project: "prj_coworker",
+          role: "experimenter",
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+      ],
+    });
+
+    expect(updateOne).toHaveBeenCalledTimes(1);
+    const [filter, mutation] = updateOne.mock.calls[0] as unknown as [
+      Record<string, unknown>,
+      { $set: Record<string, unknown> },
+    ];
+    // The key value is untouched (no rotation) and the write is org-scoped
+    expect(filter).toMatchObject({
+      key: "secret_experimenter_abc123",
+      organization: "org_1",
+    });
+    expect(mutation.$set.role).toBe("readonly");
+    expect(mutation.$set.projectRoles).toEqual([
+      {
+        project: "prj_coworker",
+        role: "experimenter",
+        limitAccessByEnvironment: false,
+        environments: [],
+      },
+    ]);
+    expect(mutation.$set).not.toHaveProperty("key");
+  });
+
+  it("clears project roles with an empty array, without the premium gate", async () => {
+    const { model, updateOne } = setupModel(
+      orgSecretKey({
+        projectRoles: [
+          {
+            project: "prj_coworker",
+            role: "experimenter",
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        ],
+      }),
+      { hasPremiumFeature: jest.fn(() => false) },
+    );
+
+    await model.updateOrganizationApiKey("key_1", baseUpdate);
+
+    const mutation = setOf(updateOne);
+    expect(mutation.$unset).toHaveProperty("projectRoles");
+    expect(mutation.$set).not.toHaveProperty("projectRoles");
+  });
+
+  it("rejects PATs", async () => {
+    const { model } = setupModel(orgSecretKey({ userId: "u_self" }));
+    await expect(
+      model.updateOrganizationApiKey("key_1", baseUpdate),
+    ).rejects.toThrow(
+      "Only organization secret API keys support permission updates",
+    );
+  });
+
+  it("rejects SDK endpoint keys", async () => {
+    const { model } = setupModel(
+      orgSecretKey({ secret: false, environment: "production" }),
+    );
+    await expect(
+      model.updateOrganizationApiKey("key_1", baseUpdate),
+    ).rejects.toThrow(
+      "Only organization secret API keys support permission updates",
+    );
+  });
+
+  it("404s when the key does not exist", async () => {
+    const { model } = setupModel(null);
+    await expect(
+      model.updateOrganizationApiKey("key_missing", baseUpdate),
+    ).rejects.toThrow("API key not found: key_missing");
+  });
+
+  it("rejects roles that do not exist or are deactivated", async () => {
+    const { model } = setupModel(orgSecretKey());
+    await expect(
+      model.updateOrganizationApiKey("key_1", {
+        ...baseUpdate,
+        roleId: "not_a_role",
+      }),
+    ).rejects.toThrow("Invalid role: not_a_role");
+
+    const { model: model2 } = setupModel(orgSecretKey(), {
+      org: {
+        id: "org_1",
+        deactivatedRoles: ["admin"],
+        settings: { environments: [{ id: "production" }] },
+      },
+    });
+    await expect(
+      model2.updateOrganizationApiKey("key_1", {
+        ...baseUpdate,
+        roleId: "admin",
+      }),
+    ).rejects.toThrow("Role has been deactivated: admin");
+  });
+
+  it("rejects environments not defined in the org", async () => {
+    const { model } = setupModel(orgSecretKey());
+    await expect(
+      model.updateOrganizationApiKey("key_1", {
+        ...baseUpdate,
+        limitAccessByEnvironment: true,
+        environments: ["nope"],
+      }),
+    ).rejects.toThrow("Invalid environment: nope");
+  });
+
+  it("rejects unknown projects in project roles", async () => {
+    const { model } = setupModel(orgSecretKey());
+    await expect(
+      model.updateOrganizationApiKey("key_1", {
+        ...baseUpdate,
+        projectRoles: [
+          {
+            project: "prj_missing",
+            role: "experimenter",
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        ],
+      }),
+    ).rejects.toThrow("Invalid project: prj_missing");
+  });
+
+  it("enforces the advanced-permissions premium gate like creation does", async () => {
+    const { model } = setupModel(orgSecretKey(), {
+      hasPremiumFeature: jest.fn(() => false),
+    });
+    await expect(
+      model.updateOrganizationApiKey("key_1", {
+        ...baseUpdate,
+        projectRoles: [
+          {
+            project: "prj_coworker",
+            role: "experimenter",
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        ],
+      }),
+    ).rejects.toThrow(
+      "Your plan does not support project-level permissions on API keys.",
+    );
+  });
+
+  it("denies the update without manageApiKeys, even when nothing would change", async () => {
+    const doc = orgSecretKey();
+    const { model, context, updateOne } = setupModel(doc);
+    (context.permissions.canUpdateApiKey as jest.Mock).mockReturnValue(false);
+    // A value-matching no-op must not act as a permission-free probe of the
+    // key's current settings
+    await expect(
+      model.updateOrganizationApiKey("key_1", {
+        ...baseUpdate,
+        roleId: doc.role || "",
+      }),
+    ).rejects.toThrow("You do not have permission to perform this action");
+    expect(updateOne).not.toHaveBeenCalled();
+  });
+
+  it("does not re-validate unchanged fields, so stale state can't block unrelated edits", async () => {
+    // Org downgraded after minting a key with env restrictions; role edits
+    // must still work
+    const { model: m1, updateOne: u1 } = setupModel(
+      orgSecretKey({
+        limitAccessByEnvironment: true,
+        environments: ["production"],
+      }),
+      { hasPremiumFeature: jest.fn(() => false) },
+    );
+    await m1.updateOrganizationApiKey("key_1", {
+      ...baseUpdate,
+      roleId: "readonly",
+      limitAccessByEnvironment: true,
+      environments: ["production"],
+    });
+    expect(setOf(u1).$set.role).toBe("readonly");
+
+    // Role deactivated after the fact; description-only edits must still work
+    const { model: m2, updateOne: u2 } = setupModel(orgSecretKey(), {
+      org: {
+        id: "org_1",
+        deactivatedRoles: ["experimenter"],
+        settings: { environments: [{ id: "production" }] },
+      },
+    });
+    await m2.updateOrganizationApiKey("key_1", {
+      ...baseUpdate,
+      description: "renamed",
+    });
+    expect(setOf(u2).$set.description).toBe("renamed");
+  });
+
+  it("allows turning the env restriction off even when the list holds a deleted environment", async () => {
+    const { model, updateOne } = setupModel(
+      orgSecretKey({
+        limitAccessByEnvironment: true,
+        environments: ["deleted-env"],
+      }),
+    );
+    await model.updateOrganizationApiKey("key_1", {
+      ...baseUpdate,
+      limitAccessByEnvironment: false,
+      environments: ["deleted-env"],
+    });
+    expect(setOf(updateOne).$set.limitAccessByEnvironment).toBe(false);
+  });
+});

--- a/packages/front-end/components/ApiKeysTable/ApiKeysTable.tsx
+++ b/packages/front-end/components/ApiKeysTable/ApiKeysTable.tsx
@@ -25,6 +25,7 @@ type ApiKeysTableProps = {
     keyId: string | undefined,
     disabled: boolean,
   ) => () => Promise<void>;
+  onEdit?: (key: ApiKeyInterface) => void;
 };
 
 export const ApiKeysTable: FC<ApiKeysTableProps> = ({
@@ -34,6 +35,7 @@ export const ApiKeysTable: FC<ApiKeysTableProps> = ({
   canDeleteKeys,
   onReveal,
   onToggleDisabled,
+  onEdit,
 }) => {
   const { organization } = useUser();
   const { projects } = useDefinitions();
@@ -41,6 +43,7 @@ export const ApiKeysTable: FC<ApiKeysTableProps> = ({
   const [pendingToggle, setPendingToggle] = useState<ApiKeyInterface | null>(
     null,
   );
+  const showActionsCol = canDeleteKeys || !!onEdit;
   return (
     <div style={{ overflowX: "auto" }}>
       <table className="table mb-3 appbox gbtable">
@@ -54,7 +57,7 @@ export const ApiKeysTable: FC<ApiKeysTableProps> = ({
               <th key={env.id}>{env.id}</th>
             ))}
             <th>Last Used</th>
-            {canDeleteKeys && <th style={{ width: 30 }}></th>}
+            {showActionsCol && <th style={{ width: 30 }}></th>}
           </tr>
         </thead>
         <tbody>
@@ -151,9 +154,21 @@ export const ApiKeysTable: FC<ApiKeysTableProps> = ({
                   </Tooltip>
                 )}
               </td>
-              {canDeleteKeys && (
+              {showActionsCol && (
                 <td>
                   <MoreMenu useRadix={false}>
+                    {/* Legacy keys created before ids existed can't be edited in place */}
+                    {onEdit && key.id && (
+                      <button
+                        className="dropdown-item"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          onEdit(key);
+                        }}
+                      >
+                        Edit key
+                      </button>
+                    )}
                     {onToggleDisabled && (
                       <button
                         className="dropdown-item"
@@ -165,13 +180,15 @@ export const ApiKeysTable: FC<ApiKeysTableProps> = ({
                         {key.disabled ? "Enable key" : "Disable key"}
                       </button>
                     )}
-                    <DeleteButton
-                      useRadix={false}
-                      onClick={onDelete(key.id)}
-                      className="dropdown-item"
-                      displayName="API Key"
-                      text="Delete key"
-                    />
+                    {canDeleteKeys && (
+                      <DeleteButton
+                        useRadix={false}
+                        onClick={onDelete(key.id)}
+                        className="dropdown-item"
+                        displayName="API Key"
+                        text="Delete key"
+                      />
+                    )}
                   </MoreMenu>
                 </td>
               )}

--- a/packages/front-end/components/Settings/ApiKeysModal.tsx
+++ b/packages/front-end/components/Settings/ApiKeysModal.tsx
@@ -1,20 +1,36 @@
 import { FC, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { getRoles } from "shared/permissions";
+import { ApiKeyInterface } from "shared/types/apikey";
 import { MemberRoleWithProjects } from "shared/types/organization";
 import { useAuth } from "@/services/auth";
 import { useUser } from "@/services/UserContext";
 import track from "@/services/track";
 import Field from "@/components/Forms/Field";
 import ModalStandard from "@/ui/Modal/Patterns/ModalStandard";
+import Callout from "@/ui/Callout";
 import RoleSelector from "@/components/Settings/Team/RoleSelector";
 
-const ApiKeysModal: FC<{
-  close: () => void;
-  onCreate: () => void;
-  personalAccessToken: boolean;
-  defaultDescription?: string;
-}> = ({ close, personalAccessToken, onCreate, defaultDescription = "" }) => {
+const ApiKeysModal: FC<
+  {
+    close: () => void;
+    onCreate: () => void;
+    defaultDescription?: string;
+  } & ( // PATs have no editable permissions, so edit mode is org-keys only
+    | { personalAccessToken: true; existingKey?: never }
+    | {
+        personalAccessToken: false;
+        // When set, the modal edits this key's description and permissions in place
+        existingKey?: ApiKeyInterface;
+      }
+  )
+> = ({
+  close,
+  personalAccessToken,
+  onCreate,
+  defaultDescription = "",
+  existingKey,
+}) => {
   const { apiCall } = useAuth();
   const { organization } = useUser();
 
@@ -31,18 +47,33 @@ const ApiKeysModal: FC<{
     description: string;
   }>({
     defaultValues: {
-      description: defaultDescription,
+      description: existingKey?.description ?? defaultDescription,
     },
   });
 
   const [roleState, setRoleState] = useState<MemberRoleWithProjects>({
-    role: defaultRole,
-    limitAccessByEnvironment: false,
-    environments: [],
+    role: existingKey?.role ?? defaultRole,
+    limitAccessByEnvironment: existingKey?.limitAccessByEnvironment ?? false,
+    environments: existingKey?.environments ?? [],
+    projectRoles: existingKey?.projectRoles,
   });
 
   const onSubmit = form.handleSubmit(async (value) => {
     const { role, ...roleStateData } = roleState;
+    if (existingKey) {
+      await apiCall(`/keys/${existingKey.id}`, {
+        method: "PUT",
+        body: JSON.stringify({
+          description: value.description,
+          role,
+          ...roleStateData,
+          projectRoles: roleStateData.projectRoles ?? [],
+        }),
+      });
+      track("Update API Key");
+      onCreate();
+      return;
+    }
     const key = personalAccessToken
       ? {
           description: value.description,
@@ -67,10 +98,10 @@ const ApiKeysModal: FC<{
     <ModalStandard
       trackingEventModalType=""
       close={close}
-      header="Create API Key"
+      header={existingKey ? "Edit API Key" : "Create API Key"}
       open={true}
       submit={onSubmit}
-      cta="Create"
+      cta={existingKey ? "Save" : "Create"}
     >
       <Field
         label="Description"
@@ -79,6 +110,13 @@ const ApiKeysModal: FC<{
       />
       {!personalAccessToken && (
         <RoleSelector value={roleState} setValue={setRoleState} />
+      )}
+      {existingKey && (
+        <Callout status="info" mt="3">
+          Changes apply to the key&apos;s next request. The key value stays the
+          same, so nothing needs to be rotated (the role name embedded in the
+          key string is cosmetic and may no longer match).
+        </Callout>
       )}
     </ModalStandard>
   );

--- a/packages/front-end/components/Settings/SecretApiKeys.tsx
+++ b/packages/front-end/components/Settings/SecretApiKeys.tsx
@@ -12,9 +12,11 @@ const SecretApiKeys: FC<{ keys: ApiKeyInterface[]; mutate: () => void }> = ({
 }) => {
   const { apiCall } = useAuth();
   const [open, setOpen] = useState(false);
+  const [editKey, setEditKey] = useState<ApiKeyInterface | null>(null);
 
   const permissionsUtils = usePermissionsUtil();
   const canCreateKeys = permissionsUtils.canCreateApiKey();
+  const canUpdateKeys = permissionsUtils.canUpdateApiKey();
   const canDeleteKeys = permissionsUtils.canDeleteApiKey();
 
   const organizationSecretKeys = useMemo(
@@ -69,11 +71,15 @@ const SecretApiKeys: FC<{ keys: ApiKeyInterface[]; mutate: () => void }> = ({
 
   return (
     <div className="mb-4">
-      {open && canCreateKeys && (
+      {((open && canCreateKeys) || (editKey && canUpdateKeys)) && (
         <ApiKeysModal
-          close={() => setOpen(false)}
+          close={() => {
+            setOpen(false);
+            setEditKey(null);
+          }}
           onCreate={mutate}
           personalAccessToken={false}
+          existingKey={editKey ?? undefined}
         />
       )}
 
@@ -91,6 +97,7 @@ const SecretApiKeys: FC<{ keys: ApiKeyInterface[]; mutate: () => void }> = ({
             canDeleteKeys={canDeleteKeys}
             onReveal={onReveal}
             onToggleDisabled={canDeleteKeys ? onToggleDisabled : undefined}
+            onEdit={canUpdateKeys ? setEditKey : undefined}
           />
         )}
         {canCreateKeys && (

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -113,6 +113,10 @@ export class Permissions {
     return this.checkGlobalPermission("manageApiKeys");
   };
 
+  public canUpdateApiKey = (): boolean => {
+    return this.checkGlobalPermission("manageApiKeys");
+  };
+
   public canDeleteApiKey = (): boolean => {
     return this.checkGlobalPermission("manageApiKeys");
   };

--- a/packages/shared/src/validators/apikey.ts
+++ b/packages/shared/src/validators/apikey.ts
@@ -60,6 +60,16 @@ export const apiKeySchema = createBaseSchemaWithPrimaryKey({
     ),
 });
 
+// The only fields editable on an org secret key after creation. Shared so the
+// route validator and the model's canUpdate gate can't drift apart.
+export const secretApiKeyUpdatableFields = apiKeySchema.pick({
+  description: true,
+  role: true,
+  limitAccessByEnvironment: true,
+  environments: true,
+  projectRoles: true,
+});
+
 export const secretApiKey = apiKeySchema
   .omit({ id: true, secret: true, environment: true, project: true })
   .safeExtend({ id: z.string(), secret: z.literal(true) });


### PR DESCRIPTION
**Before:** a secret API key's role, environment restrictions, and project-scoped roles are fixed at creation — changing them means minting a new key and rotating the secret through every consumer.

**After:** admins can edit those permissions in place (Settings → API Keys → ⋮ → Edit key, or `PUT /keys/:id`). Auth reads the key doc fresh on every request, so changes apply on the key's next request with the key value untouched.

### Why

Org keys back long-lived integrations. Granting an integration write access to one more project currently forces a full secret rotation everywhere the key is deployed, which can take days on slow deploy cadences — for what is conceptually a one-line permission change.

### How

- `PUT /keys/:id` with full-replacement semantics: `role`, `limitAccessByEnvironment`, `environments`, and `projectRoles` are all required so a partial body can't silently strip a key's restrictions; only `description` is preserved when omitted. The updatable field set is defined once in `shared/validators` and drives both the route validator and the model's `canUpdate` allowlist.
- Only org secret keys are editable. PATs (permissions come from the user) and legacy SDK endpoint keys stay immutable, enforced in `canUpdate` and the model method; identity fields (`key`, `secret`, `userId`, `encryptionKey`) are additionally hard-stopped via `readonlyFields`.
- Gated on a new `canUpdateApiKey` permission (same `manageApiKeys` policy as create/delete). The permission is checked up front in the model method, so a value-matching no-op PUT can't be used by an unprivileged member to probe a key's current settings.
- `customValidation` now validates only the fields that actually changed on update (creation still validates everything). Without this, a key whose role was later deactivated, or whose env/project scoping outlived a downgraded plan, could never be edited again — even to fix its description. Env lists are validated only while `limitAccessByEnvironment` is on, so a deleted environment lingering in the list can't block turning the restriction off.

### Notes for reviewers

- The role name embedded in the key string's prefix (`secret_readonly_…`) is cosmetic and can now go stale; the edit modal says so. Rotation is the fix if that matters to a consumer.
- Two deliberate behavior changes on existing paths: creating a key with `projectRoles: []` no longer trips the premium gate (an empty array grants nothing), and the disabled toggle no longer re-validates the key's unchanged role/envs (previously you couldn't disable *or* re-enable a key whose role had been deactivated).
- Key create/update/delete still emit no audit events (pre-existing gap; update makes it more interesting — happy to wire `auditLog` up here or in a follow-up if you have a preference for the entity type).

### Test plan

- New `ApiKeyModel` unit tests (18) covering the `canUpdate` gate (PATs, SDK keys, identity fields, mixed updates, permission checks), full-replacement update semantics, `$unset` of cleared project roles, the no-op permission probe, change-scoped validation, and the deleted-environment edge.
- Manually verified against a local mongo + back-end + front-end: created a `readonly` key, confirmed writes 403; `PUT` role→`admin`, same key string immediately writes; downgraded back, writes deny again; strict validator rejects missing/extra fields; PAT edit 400s; disable/enable unaffected. Drove the edit modal end-to-end in the UI (prefill, role change, table refresh) with no console errors.
