### PR TITLE
Perf: Fix laggy search on the saved groups page

### DIFF
--- a/packages/front-end/components/SavedGroups/ConditionGroups.tsx
+++ b/packages/front-end/components/SavedGroups/ConditionGroups.tsx
@@ -61,11 +61,15 @@ export default function ConditionGroups({ groups, mutate }: Props) {
     return groups.filter((g) => g.type === "condition");
   }, [groups]);
 
-  const filteredConditionGroups = project
-    ? conditionGroups.filter((group) =>
-        isProjectListValidForProject(group.projects, project),
-      )
-    : conditionGroups;
+  const filteredConditionGroups = useMemo(
+    () =>
+      project
+        ? conditionGroups.filter((group) =>
+            isProjectListValidForProject(group.projects, project),
+          )
+        : conditionGroups,
+    [conditionGroups, project],
+  );
 
   const [showArchived, setShowArchived] = useState(false);
 

--- a/packages/front-end/components/SavedGroups/IdLists.tsx
+++ b/packages/front-end/components/SavedGroups/IdLists.tsx
@@ -64,11 +64,15 @@ export default function IdLists({ groups, mutate }: Props) {
     return groups.filter((g) => g.type === "list");
   }, [groups]);
 
-  const filteredIdLists = project
-    ? idLists.filter((list) =>
-        isProjectListValidForProject(list.projects, project),
-      )
-    : idLists;
+  const filteredIdLists = useMemo(
+    () =>
+      project
+        ? idLists.filter((list) =>
+            isProjectListValidForProject(list.projects, project),
+          )
+        : idLists,
+    [idLists, project],
+  );
 
   const { hasLargeSavedGroupFeature, unsupportedConnections, connections } =
     useLargeSavedGroupSupport();


### PR DESCRIPTION
### Features and Changes

The search bar on `/saved-groups` rebuilt its full-text search index on every keystroke, making typing lag by seconds for orgs with many saved groups. The Condition Groups and ID Lists tabs filtered by project inline (outside any memo), so each keystroke produced a fresh `items` array reference, which invalidated the MiniSearch index `useMemo` in `useSearch` and forced a full rebuild.

Wraps the project-filtered arrays in `useMemo` so `items` is stable across keystrokes and the index is built once — the same pattern the `/features` search already relies on. Only manifested when a project was selected; without one the array was already the memoized reference.

### Testing

Select a project, go to `/saved-groups`, and type into the search box on the Condition Groups and ID Lists tabs — typing is responsive and results filter without lag.
