### PR TITLE
Migrate FeatureModel to BaseModel

### DIFF
--- a/packages/back-end/src/api/code-refs/getCodeRefs.ts
+++ b/packages/back-end/src/api/code-refs/getCodeRefs.ts
@@ -5,7 +5,6 @@ import {
   getAllCodeRefsForFeature,
   toApiInterface,
 } from "back-end/src/models/FeatureCodeRefs";
-import { getFeature } from "back-end/src/models/FeatureModel";
 
 export const getCodeRefs = createApiRequestHandler(getCodeRefsValidator)(async (
   req,
@@ -13,7 +12,7 @@ export const getCodeRefs = createApiRequestHandler(getCodeRefsValidator)(async (
   // Code ref flag keys equal feature ids. getFeature returns null when the
   // feature doesn't exist or the caller can't read its project. Return the same
   // 404 in both cases so we don't leak the existence of inaccessible features.
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) {
     throw new NotFoundError("Feature not found");
   }

--- a/packages/back-end/src/api/code-refs/listCodeRefs.ts
+++ b/packages/back-end/src/api/code-refs/listCodeRefs.ts
@@ -8,7 +8,6 @@ import {
   toApiInterface,
   uniqueId,
 } from "back-end/src/models/FeatureCodeRefs";
-import { getFeaturesByIds } from "back-end/src/models/FeatureModel";
 
 export const listCodeRefs = createApiRequestHandler(listCodeRefsValidator)(
   async (req) => {
@@ -18,8 +17,7 @@ export const listCodeRefs = createApiRequestHandler(listCodeRefsValidator)(
     // caller can't read, so only refs for readable features survive the filter.
     const readableFeatures = new Set(
       (
-        await getFeaturesByIds(
-          req.context,
+        await req.context.models.features.getByIds(
           orgCodeRefs.map((r) => r.feature),
         )
       ).map((f) => f.id),

--- a/packages/back-end/src/api/code-refs/postCodeRefs.ts
+++ b/packages/back-end/src/api/code-refs/postCodeRefs.ts
@@ -7,7 +7,6 @@ import {
   getFeatureKeysForRepoBranch,
   upsertFeatureCodeRefs,
 } from "back-end/src/models/FeatureCodeRefs";
-import { getFeatureProjectsByIds } from "back-end/src/models/FeatureModel";
 
 export const postCodeRefs = createApiRequestHandler(postCodeRefsValidator)(
   async (req) => {
@@ -41,10 +40,8 @@ export const postCodeRefs = createApiRequestHandler(postCodeRefsValidator)(
     const affectedFeatureIds = [
       ...new Set([...requestedFeatures, ...featuresToRemove]),
     ];
-    const featureProjects = await getFeatureProjectsByIds(
-      req.context,
-      affectedFeatureIds,
-    );
+    const featureProjects =
+      await req.context.models.features.getProjectsByIds(affectedFeatureIds);
     const cannotWriteAll = affectedFeatureIds.some((featureId) => {
       if (featureProjects.has(featureId)) {
         // Existing feature: require write access to its project.

--- a/packages/back-end/src/api/contextual-bandits/deleteLinkedFeature.ts
+++ b/packages/back-end/src/api/contextual-bandits/deleteLinkedFeature.ts
@@ -1,6 +1,5 @@
 import { deleteContextualBanditLinkedFeatureValidator } from "shared/validators";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { unlinkFeatureFromContextualBandit } from "back-end/src/enterprise/services/contextualBandits";
 import { loadContextualBanditForRead } from "./_shared";
 
@@ -20,7 +19,9 @@ export const deleteContextualBanditLinkedFeature = createApiRequestHandler(
 
   // Also require feature-side edit rights — unlinking cancels a queued
   // autopublish that the feature team may be managing.
-  const feature = await getFeature(req.context, req.params.featureId);
+  const feature = await req.context.models.features.getById(
+    req.params.featureId,
+  );
   if (feature && !req.context.permissions.canUpdateFeature(feature, {})) {
     req.context.permissions.throwPermissionError();
   }

--- a/packages/back-end/src/api/features/deleteFeature.ts
+++ b/packages/back-end/src/api/features/deleteFeature.ts
@@ -2,7 +2,6 @@ import { filterEnvironmentsByFeature, PermissionError } from "shared/util";
 import { deleteFeatureValidator } from "shared/validators";
 import type { ApiRequestLocals } from "back-end/types/api";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { deleteFeature, getFeature } from "back-end/src/models/FeatureModel";
 import { auditDetailsDelete } from "back-end/src/services/audit";
 import { getEnvironments } from "back-end/src/util/organization.util";
 import { getEnabledEnvironments } from "back-end/src/util/features";
@@ -13,7 +12,7 @@ import { canUseRestApiBypassSetting } from "./reviewBypass";
 export async function deleteFeatureHandler(
   req: ApiRequestLocals & { params: { id: string } },
 ) {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
 
   if (!feature) {
     throw new Error(
@@ -50,7 +49,7 @@ export async function deleteFeatureHandler(
     }
   }
 
-  await deleteFeature(req.context, feature);
+  await req.context.models.features.delete(feature);
 
   await req.audit({
     event: "feature.delete",

--- a/packages/back-end/src/api/features/deleteFeatureRevisionLogEntryV2.ts
+++ b/packages/back-end/src/api/features/deleteFeatureRevisionLogEntryV2.ts
@@ -1,12 +1,11 @@
 import { deleteFeatureRevisionLogEntryV2Validator } from "shared/validators";
 import { NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 
 export const deleteFeatureRevisionLogEntryV2 = createApiRequestHandler(
   deleteFeatureRevisionLogEntryV2Validator,
 )(async (req) => {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   // Author-of-entry is enforced by the model's canDelete; the model also

--- a/packages/back-end/src/api/features/deleteFeatureRevisionRule.ts
+++ b/packages/back-end/src/api/features/deleteFeatureRevisionRule.ts
@@ -7,7 +7,6 @@ import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvent
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { logger } from "back-end/src/util/logger";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   updateRevision,
@@ -27,7 +26,7 @@ import {
 export const deleteFeatureRevisionRule = createApiRequestHandler(
   deleteFeatureRevisionRuleValidator,
 )(async (req) => {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (

--- a/packages/back-end/src/api/features/deleteFeatureRevisionRuleRampSchedule.ts
+++ b/packages/back-end/src/api/features/deleteFeatureRevisionRuleRampSchedule.ts
@@ -7,7 +7,6 @@ import { toApiRevision } from "back-end/src/services/features";
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   updateRevision,
@@ -35,7 +34,7 @@ export async function clearRuleRampSchedule(
     revisionComment?: string;
   },
 ) {
-  const feature = await getFeature(context, params.id);
+  const feature = await context.models.features.getById(params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (

--- a/packages/back-end/src/api/features/deleteFeatureRevisionRuleV2.ts
+++ b/packages/back-end/src/api/features/deleteFeatureRevisionRuleV2.ts
@@ -6,7 +6,6 @@ import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvent
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { logger } from "back-end/src/util/logger";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   updateRevision,
@@ -20,7 +19,7 @@ import {
 export const deleteFeatureRevisionRuleV2 = createApiRequestHandler(
   deleteFeatureRevisionRuleV2Validator,
 )(async (req) => {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (

--- a/packages/back-end/src/api/features/getFeature.ts
+++ b/packages/back-end/src/api/features/getFeature.ts
@@ -4,7 +4,6 @@ import {
   getRevision,
 } from "back-end/src/models/FeatureRevisionModel";
 import { getExperimentMapForFeature } from "back-end/src/models/ExperimentModel";
-import { getFeature as getFeatureDB } from "back-end/src/models/FeatureModel";
 import {
   getApiFeatureObj,
   getSavedGroupMap,
@@ -19,7 +18,7 @@ export const getFeature = createApiRequestHandler(getFeatureValidator)(async (
   const fetchRevisions = ["all", "drafts", "published"].includes(
     revisionFilter || "none",
   );
-  const feature = await getFeatureDB(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) {
     throw new Error("Could not find a feature with that key");
   }

--- a/packages/back-end/src/api/features/getFeatureKeys.ts
+++ b/packages/back-end/src/api/features/getFeatureKeys.ts
@@ -1,13 +1,12 @@
 import { getFeatureKeysValidator } from "shared/validators";
 import type { ApiReqContext } from "back-end/types/api";
-import { getAllFeatures } from "back-end/src/models/FeatureModel";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 
 export async function listFeatureKeys(
   context: ApiReqContext,
   projectId?: string,
 ) {
-  const features = await getAllFeatures(context, {
+  const features = await context.models.features.getAll({
     projects: projectId ? [projectId] : undefined,
   });
   return features.map((f) => f.id);

--- a/packages/back-end/src/api/features/getFeatureRevision.ts
+++ b/packages/back-end/src/api/features/getFeatureRevision.ts
@@ -3,7 +3,6 @@ import type { ApiReqContext } from "back-end/types/api";
 import { toApiRevision } from "back-end/src/services/features";
 import { NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { getRevision } from "back-end/src/models/FeatureRevisionModel";
 
 export async function loadRevision(
@@ -12,7 +11,7 @@ export async function loadRevision(
   featureId: string,
   version: number,
 ) {
-  const feature = await getFeature(context, featureId);
+  const feature = await context.models.features.getById(featureId);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   const revision = await getRevision({

--- a/packages/back-end/src/api/features/getFeatureRevisionDiffV2.ts
+++ b/packages/back-end/src/api/features/getFeatureRevisionDiffV2.ts
@@ -1,6 +1,5 @@
 import { buildFullJsonObject, buildMinimalJsonDiffObject } from "shared/util";
 import { getFeatureRevisionDiffV2Validator } from "shared/validators";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { getRevision } from "back-end/src/models/FeatureRevisionModel";
 import {
   getLiveRevisionForFeature,
@@ -23,7 +22,7 @@ export const getFeatureRevisionDiffV2 = createApiRequestHandler(
   const { id, version } = req.params;
   const { format = "minimal", base = "baseVersion" } = req.query;
 
-  const feature = await getFeature(req.context, id);
+  const feature = await req.context.models.features.getById(id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   const revision = await getRevision({

--- a/packages/back-end/src/api/features/getFeatureRevisionLatest.ts
+++ b/packages/back-end/src/api/features/getFeatureRevisionLatest.ts
@@ -7,7 +7,6 @@ import type { ApiReqContext } from "back-end/types/api";
 import { toApiRevision } from "back-end/src/services/features";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { getLatestActiveDraftForFeature } from "back-end/src/models/FeatureRevisionModel";
 
 export async function loadLatestDraft(
@@ -24,7 +23,7 @@ export async function loadLatestDraft(
     author?: string;
   } = {},
 ) {
-  const feature = await getFeature(context, featureId);
+  const feature = await context.models.features.getById(featureId);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   const mine = stringToBoolean(mineParam?.toString());

--- a/packages/back-end/src/api/features/getFeatureRevisionLogV2.ts
+++ b/packages/back-end/src/api/features/getFeatureRevisionLogV2.ts
@@ -3,7 +3,6 @@ import { EventUser } from "shared/types/events/event-types";
 import { getValidDate } from "shared/dates";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { NotFoundError } from "back-end/src/util/errors";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { getRevision } from "back-end/src/models/FeatureRevisionModel";
 
 // Strip secrets (API key strings) from the log actor before returning it.
@@ -40,7 +39,7 @@ function sanitizeLogUser(user: EventUser): {
 export const getFeatureRevisionLogV2 = createApiRequestHandler(
   getFeatureRevisionLogV2Validator,
 )(async (req) => {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   // Legacy log entries were stored inline on the revision document

--- a/packages/back-end/src/api/features/getFeatureRevisionMergeStatus.ts
+++ b/packages/back-end/src/api/features/getFeatureRevisionMergeStatus.ts
@@ -7,9 +7,10 @@ import {
   liveRevisionFromFeature,
 } from "shared/util";
 import { getFeatureRevisionMergeStatusValidator } from "shared/validators";
+import type { ApiReqContext } from "back-end/types/api";
+import type { ReqContext } from "back-end/types/request";
 import { NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { getRevision } from "back-end/src/models/FeatureRevisionModel";
 import { getLiveAndBaseRevisionsForFeature } from "back-end/src/services/features";
 import { getEnvironments } from "back-end/src/util/organization.util";
@@ -17,11 +18,11 @@ import { getEnvironments } from "back-end/src/util/organization.util";
 // Shared handler: v1 and v2 have identical request/response schemas and the
 // merge result contains internal rule shapes (not API-serialized).
 export const mergeStatusHandler = async (req: {
-  context: Parameters<typeof getFeature>[0];
+  context: ReqContext | ApiReqContext;
   organization: { id: string };
   params: { id: string; version: number };
 }) => {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   const revision = await getRevision({

--- a/packages/back-end/src/api/features/getFeatureRevisions.ts
+++ b/packages/back-end/src/api/features/getFeatureRevisions.ts
@@ -9,7 +9,6 @@ import {
   getFeatureRevisionsByStatus,
   countDocuments,
 } from "back-end/src/models/FeatureRevisionModel";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { toApiRevision } from "back-end/src/services/features";
 import {
   createApiRequestHandler,
@@ -32,7 +31,7 @@ export async function loadFeatureRevisionsPage(
 ) {
   // getFeature enforces canReadSingleProjectResource and returns null for
   // unreadable projects.
-  const feature = await getFeature(context, featureId);
+  const feature = await context.models.features.getById(featureId);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   const { author } = query;

--- a/packages/back-end/src/api/features/getFeatureStale.ts
+++ b/packages/back-end/src/api/features/getFeatureStale.ts
@@ -5,7 +5,6 @@ import {
 } from "shared/validators";
 import { isFeatureStale } from "shared/util";
 import type { ApiReqContext } from "back-end/types/api";
-import { getAllFeaturesForStaleGraph } from "back-end/src/models/FeatureModel";
 import { getAllExperimentsForStaleGraph } from "back-end/src/models/ExperimentModel";
 import { getRevisionsByStatus } from "back-end/src/models/FeatureRevisionModel";
 import { getEnvironments } from "back-end/src/services/organizations";
@@ -29,7 +28,7 @@ export async function computeFeatureStale(
 
   const idSet = new Set(ids);
   const [allFeatures, allExperiments, draftRevisions] = await Promise.all([
-    getAllFeaturesForStaleGraph(context),
+    context.models.features.getAllForStaleGraph(),
     getAllExperimentsForStaleGraph(context),
     getRevisionsByStatus(context as ReqContext, [...ACTIVE_DRAFT_STATUSES], {
       sparse: true,

--- a/packages/back-end/src/api/features/getFeatureV2.ts
+++ b/packages/back-end/src/api/features/getFeatureV2.ts
@@ -6,7 +6,6 @@ import {
   getRevision,
 } from "back-end/src/models/FeatureRevisionModel";
 import { getExperimentMapForFeature } from "back-end/src/models/ExperimentModel";
-import { getFeature as getFeatureDB } from "back-end/src/models/FeatureModel";
 import {
   getApiFeatureObjV2,
   getSavedGroupMap,
@@ -23,7 +22,7 @@ async function loadFeatureForApiV2(
   const fetchRevisions = ["all", "drafts", "published"].includes(
     revisionFilter,
   );
-  const feature = await getFeatureDB(context, featureId);
+  const feature = await context.models.features.getById(featureId);
   if (!feature) {
     throw new Error("Could not find a feature with that key");
   }

--- a/packages/back-end/src/api/features/listFeatures.ts
+++ b/packages/back-end/src/api/features/listFeatures.ts
@@ -4,11 +4,6 @@ import type { ApiReqContext } from "back-end/types/api";
 import { getFeatureRevisionsByFeaturesCurrentVersion } from "back-end/src/models/FeatureRevisionModel";
 import { getAllPayloadExperiments } from "back-end/src/models/ExperimentModel";
 import {
-  getAllFeatures,
-  getFeaturesPage,
-  countFeatures,
-} from "back-end/src/models/FeatureModel";
-import {
   getApiFeatureObj,
   getSavedGroupMap,
 } from "back-end/src/services/features";
@@ -53,7 +48,9 @@ export async function loadFeaturesPage(
   | { empty: true; response: ReturnType<typeof emptyListResponse> }
   | {
       empty: false;
-      filtered: Awaited<ReturnType<typeof getFeaturesPage>>;
+      filtered: Awaited<
+        ReturnType<ApiReqContext["models"]["features"]["getPage"]>
+      >;
       groupMap: Awaited<ReturnType<typeof getSavedGroupMap>>;
       experimentMap: Awaited<ReturnType<typeof getAllPayloadExperiments>>;
       revisions: Awaited<
@@ -111,12 +108,14 @@ export async function loadFeaturesPage(
     getAllPayloadExperiments(context, experimentScope),
   ]);
 
-  let filtered: Awaited<ReturnType<typeof getFeaturesPage>>;
+  let filtered: Awaited<
+    ReturnType<ApiReqContext["models"]["features"]["getPage"]>
+  >;
   let total: number;
 
   if (query.clientKey) {
     // clientKey: filter by SDK payload, then paginate in memory (or skip)
-    const features = await getAllFeatures(context, {
+    const features = await context.models.features.getAll({
       projects: projectId ? [projectId] : undefined,
       includeArchived,
     });
@@ -145,7 +144,7 @@ export async function loadFeaturesPage(
     }
   } else if (projectId) {
     if (skipPagination) {
-      const features = await getAllFeatures(context, {
+      const features = await context.models.features.getAll({
         projects: [projectId],
         includeArchived,
       });
@@ -155,13 +154,13 @@ export async function loadFeaturesPage(
       filtered = sorted;
       total = sorted.length;
     } else {
-      filtered = await getFeaturesPage(context, {
+      filtered = await context.models.features.getPage({
         project: projectId,
         includeArchived,
         limit,
         offset,
       });
-      total = await countFeatures(context, {
+      total = await context.models.features.count({
         project: projectId,
         includeArchived,
       });
@@ -169,7 +168,7 @@ export async function loadFeaturesPage(
   } else {
     const projectsFilter = projectIds === null ? undefined : projectIds;
     if (skipPagination) {
-      const features = await getAllFeatures(context, {
+      const features = await context.models.features.getAll({
         projects: projectsFilter,
         includeArchived,
       });
@@ -179,13 +178,13 @@ export async function loadFeaturesPage(
       filtered = sorted;
       total = sorted.length;
     } else {
-      filtered = await getFeaturesPage(context, {
+      filtered = await context.models.features.getPage({
         projectIds: projectsFilter,
         includeArchived,
         limit,
         offset,
       });
-      total = await countFeatures(context, {
+      total = await context.models.features.count({
         projectIds: projectsFilter,
         includeArchived,
       });

--- a/packages/back-end/src/api/features/listRevisions.ts
+++ b/packages/back-end/src/api/features/listRevisions.ts
@@ -8,7 +8,6 @@ import {
   getFeatureRevisionsByStatus,
   countDocuments,
 } from "back-end/src/models/FeatureRevisionModel";
-import { getAllFeatures, getFeature } from "back-end/src/models/FeatureModel";
 import {
   createApiRequestHandler,
   validatePagination,
@@ -79,9 +78,11 @@ export async function loadRevisionsPage(
   }
 
   let featureIds: string[] | undefined;
-  let singleFeature: Awaited<ReturnType<typeof getFeature>> | undefined;
+  let singleFeature:
+    | Awaited<ReturnType<ApiReqContext["models"]["features"]["getById"]>>
+    | undefined;
   if (featureId) {
-    singleFeature = await getFeature(context, featureId);
+    singleFeature = await context.models.features.getById(featureId);
     if (!singleFeature) return emptyListResponse(limit, offset);
     // Apply the archived filter consistently with the no-featureId path.
     // When archived=false (default), exclude revisions for archived features
@@ -95,7 +96,7 @@ export async function loadRevisionsPage(
       if (readableProjects.length === 0) {
         return emptyListResponse(limit, offset);
       }
-      const scopedFeatures = await getAllFeatures(context, {
+      const scopedFeatures = await context.models.features.getAll({
         projects: readableProjects,
         includeArchived,
       });

--- a/packages/back-end/src/api/features/postFeature.ts
+++ b/packages/back-end/src/api/features/postFeature.ts
@@ -2,12 +2,12 @@ import { z } from "zod";
 import { validateFeatureValue } from "shared/util";
 import { postFeatureValidator } from "shared/validators";
 import { FeatureInterface } from "shared/types/feature";
+import omit from "lodash/omit";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import {
   resolveOwnerForCreate,
   resolveOwnerEmail,
 } from "back-end/src/services/owner";
-import { createFeature, getFeature } from "back-end/src/models/FeatureModel";
 import { getExperimentMapForFeature } from "back-end/src/models/ExperimentModel";
 import { getEnabledEnvironments } from "back-end/src/util/features";
 import {
@@ -58,7 +58,7 @@ export const postFeature = createApiRequestHandler(postFeatureValidator)(async (
     req.context.permissions.throwPermissionError();
   }
 
-  const existing = await getFeature(req.context, req.body.id);
+  const existing = await req.context.models.features.getById(req.body.id);
   if (existing) {
     throw new Error(`Feature id '${req.body.id}' already exists.`);
   }
@@ -166,7 +166,9 @@ export const postFeature = createApiRequestHandler(postFeatureValidator)(async (
   addIdsToRules(feature.environmentSettings, feature.id);
   addIdsToFlatRules(feature.rules, feature.id);
 
-  await createFeature(req.context, feature);
+  await req.context.models.features.create(
+    omit(feature, ["organization", "dateCreated", "dateUpdated"]),
+  );
 
   await req.audit({
     event: "feature.create",

--- a/packages/back-end/src/api/features/postFeatureRevision.ts
+++ b/packages/back-end/src/api/features/postFeatureRevision.ts
@@ -8,7 +8,6 @@ import { toApiRevision } from "back-end/src/services/features";
 import { dispatchFeatureRevisionEvent } from "back-end/src/services/featureRevisionEvents";
 import { ConflictError, NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   countDocuments,
   createRevision,
@@ -23,7 +22,7 @@ export async function createFeatureDraft(
     query?: { overrideDraftLimit?: string | boolean };
   },
 ) {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (

--- a/packages/back-end/src/api/features/postFeatureRevisionDiscard.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionDiscard.ts
@@ -5,7 +5,6 @@ import { dispatchFeatureRevisionEvent } from "back-end/src/services/featureRevis
 import { auditDetailsUpdate } from "back-end/src/services/audit";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { clearPendingFeatureDraftsForRevision } from "back-end/src/models/ExperimentModel";
 import {
   discardRevision,
@@ -17,7 +16,7 @@ export async function discardFeatureRevision(
     params: { id: string; version: number };
   },
 ) {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (

--- a/packages/back-end/src/api/features/postFeatureRevisionPublish.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionPublish.ts
@@ -13,7 +13,7 @@ import {
 import type { ApiRequestLocals } from "back-end/types/api";
 import { auditDetailsUpdate } from "back-end/src/services/audit";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature, publishRevision } from "back-end/src/models/FeatureModel";
+import { publishRevision } from "back-end/src/services/featureRevisions";
 import { getRevision } from "back-end/src/models/FeatureRevisionModel";
 import { addTagsDiff } from "back-end/src/models/TagModel";
 import {
@@ -38,7 +38,7 @@ export async function publishFeatureRevision(
   },
   canUseRestApiBypass: boolean,
 ) {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (!req.context.permissions.canUpdateFeature(feature, {})) {

--- a/packages/back-end/src/api/features/postFeatureRevisionRebase.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRebase.ts
@@ -16,7 +16,6 @@ import {
 } from "shared/validators";
 import type { ApiReqContext } from "back-end/types/api";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   updateRevision,
@@ -52,7 +51,7 @@ export async function computeRebaseMerge(
   params: { id: string; version: number },
   body: RebaseRequestBody,
 ) {
-  const feature = await getFeature(context, params.id);
+  const feature = await context.models.features.getById(params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   // The preview requires the same permission as the rebase itself: it is a

--- a/packages/back-end/src/api/features/postFeatureRevisionRecallReviewV2.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRecallReviewV2.ts
@@ -2,7 +2,6 @@ import { postFeatureRevisionRecallReviewV2Validator } from "shared/validators";
 import { toApiRevisionV2 } from "back-end/src/services/features";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   recallReview,
@@ -11,7 +10,7 @@ import {
 export const postFeatureRevisionRecallReviewV2 = createApiRequestHandler(
   postFeatureRevisionRecallReviewV2Validator,
 )(async (req) => {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (!req.context.permissions.canManageFeatureDrafts(feature)) {

--- a/packages/back-end/src/api/features/postFeatureRevisionReopenV2.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionReopenV2.ts
@@ -4,7 +4,6 @@ import { dispatchFeatureRevisionEvent } from "back-end/src/services/featureRevis
 import { auditDetailsUpdate } from "back-end/src/services/audit";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   reopenRevision,
@@ -13,7 +12,7 @@ import {
 export const postFeatureRevisionReopenV2 = createApiRequestHandler(
   postFeatureRevisionReopenV2Validator,
 )(async (req) => {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (

--- a/packages/back-end/src/api/features/postFeatureRevisionRequestReview.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRequestReview.ts
@@ -9,7 +9,6 @@ import { dispatchFeatureRevisionEvent } from "back-end/src/services/featureRevis
 import { auditDetailsUpdate } from "back-end/src/services/audit";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   markRevisionAsReviewRequested,
@@ -34,7 +33,7 @@ export async function requestReview(
     };
   },
 ) {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   // Gated on canManageFeatureDrafts only so contributors can request approval

--- a/packages/back-end/src/api/features/postFeatureRevisionRevert.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRevert.ts
@@ -24,10 +24,7 @@ import {
   createRevision,
   getRevision,
 } from "back-end/src/models/FeatureRevisionModel";
-import {
-  createAndPublishRevision,
-  getFeature,
-} from "back-end/src/models/FeatureModel";
+import { createAndPublishRevision } from "back-end/src/services/featureRevisions";
 import { addTagsDiff } from "back-end/src/models/TagModel";
 import { getEnvironments } from "back-end/src/services/organizations";
 import { getEnvironmentIdsFromOrg } from "back-end/src/util/organization.util";
@@ -46,7 +43,7 @@ export async function revertFeatureRevision(
   audit: (input: AuditInterfaceInput) => Promise<void>,
   canUseRestApiBypass: boolean,
 ) {
-  const feature = await getFeature(context, params.id);
+  const feature = await context.models.features.getById(params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (!context.permissions.canUpdateFeature(feature, {})) {

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
@@ -22,7 +22,6 @@ import { getLatestPhaseVariations } from "shared/experiments";
 import { toApiRevision } from "back-end/src/services/features";
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getExperimentById,
   updateExperiment,
@@ -137,7 +136,7 @@ export function buildRuleFromInput(
 export const postFeatureRevisionRuleAdd = createApiRequestHandler(
   postFeatureRevisionRuleAddValidator,
 )(async (req) => {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
@@ -20,7 +20,6 @@ import {
 } from "back-end/src/services/features";
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getExperimentById,
   updateExperiment,
@@ -53,7 +52,7 @@ import { resolveScopeFromInput } from "./v2Shared";
 export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
   postFeatureRevisionRuleAddV2Validator,
 )(async (req) => {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (

--- a/packages/back-end/src/api/features/postFeatureRevisionRulesReorder.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRulesReorder.ts
@@ -6,7 +6,6 @@ import { toApiRevision } from "back-end/src/services/features";
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   updateRevision,
@@ -21,7 +20,7 @@ import {
 export const postFeatureRevisionRulesReorder = createApiRequestHandler(
   postFeatureRevisionRulesReorderValidator,
 )(async (req) => {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (

--- a/packages/back-end/src/api/features/postFeatureRevisionRulesReorderV2.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRulesReorderV2.ts
@@ -5,7 +5,6 @@ import { toApiRevisionV2 } from "back-end/src/services/features";
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   updateRevision,
@@ -19,7 +18,7 @@ import {
 export const postFeatureRevisionRulesReorderV2 = createApiRequestHandler(
   postFeatureRevisionRulesReorderV2Validator,
 )(async (req) => {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (

--- a/packages/back-end/src/api/features/postFeatureRevisionSchedulePublish.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionSchedulePublish.ts
@@ -1,6 +1,5 @@
 import type { ApiRequestLocals } from "back-end/types/api";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   setRevisionScheduledPublish,
@@ -32,7 +31,7 @@ export async function schedulePublish(
     };
   },
 ) {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   const revision = await getRevision({

--- a/packages/back-end/src/api/features/postFeatureRevisionSubmitReview.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionSubmitReview.ts
@@ -5,7 +5,6 @@ import { toApiRevision } from "back-end/src/services/features";
 import { dispatchRevisionReviewEvent } from "back-end/src/services/featureRevisionEvents";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   ReviewSubmittedType,
@@ -29,7 +28,7 @@ export async function submitRevisionReview(
     };
   },
 ) {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (!req.context.permissions.canReviewFeatureDrafts(feature)) {

--- a/packages/back-end/src/api/features/postFeatureRevisionToggle.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionToggle.ts
@@ -6,7 +6,6 @@ import { toApiRevision } from "back-end/src/services/features";
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   updateRevision,
@@ -29,7 +28,7 @@ export async function toggleRevisionEnvironment(
     revisionComment?: string;
   },
 ) {
-  const feature = await getFeature(context, params.id);
+  const feature = await context.models.features.getById(params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (

--- a/packages/back-end/src/api/features/postFeatureRevisionUndoReviewV2.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionUndoReviewV2.ts
@@ -2,7 +2,6 @@ import { postFeatureRevisionUndoReviewV2Validator } from "shared/validators";
 import { toApiRevisionV2 } from "back-end/src/services/features";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   undoReview,
@@ -12,7 +11,7 @@ import { maybeAutoPublishFeatureRevision } from "./autoPublishOnApproval";
 export const postFeatureRevisionUndoReviewV2 = createApiRequestHandler(
   postFeatureRevisionUndoReviewV2Validator,
 )(async (req) => {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (!req.context.permissions.canReviewFeatureDrafts(feature)) {

--- a/packages/back-end/src/api/features/postFeatureV2.ts
+++ b/packages/back-end/src/api/features/postFeatureV2.ts
@@ -1,12 +1,12 @@
 import { validateFeatureValue } from "shared/util";
 import { postFeatureV2Validator } from "shared/validators";
 import { FeatureInterface } from "shared/types/feature";
+import omit from "lodash/omit";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import {
   resolveOwnerEmail,
   resolveOwnerForCreate,
 } from "back-end/src/services/owner";
-import { createFeature, getFeature } from "back-end/src/models/FeatureModel";
 import { getExperimentMapForFeature } from "back-end/src/models/ExperimentModel";
 import { getEnabledEnvironments } from "back-end/src/util/features";
 import {
@@ -31,7 +31,7 @@ export const postFeatureV2 = createApiRequestHandler(postFeatureV2Validator)(
       req.context.permissions.throwPermissionError();
     }
 
-    const existing = await getFeature(req.context, req.body.id);
+    const existing = await req.context.models.features.getById(req.body.id);
     if (existing) {
       throw new Error(`Feature id '${req.body.id}' already exists.`);
     }
@@ -137,7 +137,9 @@ export const postFeatureV2 = createApiRequestHandler(postFeatureV2Validator)(
 
     addIdsToFlatRules(feature.rules, feature.id);
 
-    await createFeature(req.context, feature);
+    await req.context.models.features.create(
+      omit(feature, ["organization", "dateCreated", "dateUpdated"]),
+    );
 
     await req.audit({
       event: "feature.create",

--- a/packages/back-end/src/api/features/putFeatureRevisionArchive.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionArchive.ts
@@ -6,7 +6,6 @@ import { toApiRevision } from "back-end/src/services/features";
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   updateRevision,
@@ -23,7 +22,7 @@ export async function archiveRevision(
   params: { id: string; version: number | "new" },
   body: { archived: boolean; revisionTitle?: string; revisionComment?: string },
 ) {
-  const feature = await getFeature(context, params.id);
+  const feature = await context.models.features.getById(params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (

--- a/packages/back-end/src/api/features/putFeatureRevisionDefaultValue.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionDefaultValue.ts
@@ -6,7 +6,6 @@ import { toApiRevision } from "back-end/src/services/features";
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   updateRevision,
@@ -27,7 +26,7 @@ export async function setRevisionDefaultValue(
     revisionComment?: string;
   },
 ) {
-  const feature = await getFeature(context, params.id);
+  const feature = await context.models.features.getById(params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (

--- a/packages/back-end/src/api/features/putFeatureRevisionHoldout.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionHoldout.ts
@@ -6,7 +6,6 @@ import { toApiRevision } from "back-end/src/services/features";
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   updateRevision,
@@ -27,7 +26,7 @@ export async function setRevisionHoldout(
     revisionComment?: string;
   },
 ) {
-  const feature = await getFeature(context, params.id);
+  const feature = await context.models.features.getById(params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (

--- a/packages/back-end/src/api/features/putFeatureRevisionLogCommentV2.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionLogCommentV2.ts
@@ -1,12 +1,11 @@
 import { putFeatureRevisionLogCommentV2Validator } from "shared/validators";
 import { NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 
 export const putFeatureRevisionLogCommentV2 = createApiRequestHandler(
   putFeatureRevisionLogCommentV2Validator,
 )(async (req) => {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   // Author-of-entry is enforced by the model's canUpdate; the model also

--- a/packages/back-end/src/api/features/putFeatureRevisionMetadata.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionMetadata.ts
@@ -6,7 +6,6 @@ import { toApiRevision } from "back-end/src/services/features";
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   updateRevision,
@@ -38,7 +37,7 @@ export async function setRevisionMetadata(
   params: { id: string; version: number | "new" },
   body: RevisionMetadataBody,
 ) {
-  const feature = await getFeature(context, params.id);
+  const feature = await context.models.features.getById(params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (

--- a/packages/back-end/src/api/features/putFeatureRevisionPrerequisites.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionPrerequisites.ts
@@ -7,7 +7,6 @@ import { toApiRevision } from "back-end/src/services/features";
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
 import { NotFoundError, BadRequestError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   updateRevision,
@@ -30,7 +29,7 @@ export async function setRevisionPrerequisites(
     revisionComment?: string;
   },
 ) {
-  const feature = await getFeature(context, params.id);
+  const feature = await context.models.features.getById(params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (

--- a/packages/back-end/src/api/features/putFeatureRevisionPrerequisitesV2.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionPrerequisitesV2.ts
@@ -2,7 +2,6 @@ import { putFeatureRevisionPrerequisitesV2Validator } from "shared/validators";
 import { toApiRevisionV2 } from "back-end/src/services/features";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { BadRequestError } from "back-end/src/util/errors";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { setRevisionPrerequisites } from "./putFeatureRevisionPrerequisites";
 
 export const putFeatureRevisionPrerequisitesV2 = createApiRequestHandler(
@@ -13,7 +12,7 @@ export const putFeatureRevisionPrerequisitesV2 = createApiRequestHandler(
   // feature-level prerequisites are always "boolean flag is on" gates.
   const normalized = await Promise.all(
     req.body.prerequisites.map(async ({ id }) => {
-      const prereqFeature = await getFeature(req.context, id);
+      const prereqFeature = await req.context.models.features.getById(id);
       if (!prereqFeature) {
         throw new BadRequestError(`Prerequisite feature "${id}" not found`);
       }

--- a/packages/back-end/src/api/features/putFeatureRevisionRule.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionRule.ts
@@ -17,7 +17,6 @@ import { toApiRevision } from "back-end/src/services/features";
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   updateRevision,
@@ -185,7 +184,7 @@ export function applyPatch(
 export const putFeatureRevisionRule = createApiRequestHandler(
   putFeatureRevisionRuleValidator,
 )(async (req) => {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (

--- a/packages/back-end/src/api/features/putFeatureRevisionRuleRampSchedule.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionRuleRampSchedule.ts
@@ -11,7 +11,6 @@ import { toApiRevision } from "back-end/src/services/features";
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   updateRevision,
@@ -42,7 +41,7 @@ export async function setRuleRampSchedule(
     [k: string]: unknown;
   },
 ) {
-  const feature = await getFeature(context, params.id);
+  const feature = await context.models.features.getById(params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (

--- a/packages/back-end/src/api/features/putFeatureRevisionRuleV2.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionRuleV2.ts
@@ -14,7 +14,6 @@ import { toApiRevisionV2 } from "back-end/src/services/features";
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   getRevision,
   updateRevision,
@@ -35,7 +34,7 @@ import { resolveScopeFromInput } from "./v2Shared";
 export const putFeatureRevisionRuleV2 = createApiRequestHandler(
   putFeatureRevisionRuleV2Validator,
 )(async (req) => {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) throw new NotFoundError("Could not find feature");
 
   if (

--- a/packages/back-end/src/api/features/revertFeature.ts
+++ b/packages/back-end/src/api/features/revertFeature.ts
@@ -14,10 +14,7 @@ import { revertFeatureValidator } from "shared/validators";
 import type { ApiReqContext } from "back-end/types/api";
 import { getRevision } from "back-end/src/models/FeatureRevisionModel";
 import { getExperimentMapForFeature } from "back-end/src/models/ExperimentModel";
-import {
-  createAndPublishRevision,
-  getFeature,
-} from "back-end/src/models/FeatureModel";
+import { createAndPublishRevision } from "back-end/src/services/featureRevisions";
 import { auditDetailsUpdate } from "back-end/src/services/audit";
 import {
   getApiFeatureObj,
@@ -40,7 +37,7 @@ export async function revertFeatureCore(
   audit: (input: AuditInterfaceInput) => Promise<void>,
   canUseRestApiBypass: boolean,
 ) {
-  const feature = await getFeature(context, params.id);
+  const feature = await context.models.features.getById(params.id);
   if (!feature) {
     throw new Error("Could not find a feature with that key");
   }

--- a/packages/back-end/src/api/features/toggleFeature.ts
+++ b/packages/back-end/src/api/features/toggleFeature.ts
@@ -13,10 +13,7 @@ import {
   getRevision,
 } from "back-end/src/models/FeatureRevisionModel";
 import { getExperimentMapForFeature } from "back-end/src/models/ExperimentModel";
-import {
-  applyRevisionChanges,
-  getFeature,
-} from "back-end/src/models/FeatureModel";
+import { applyRevisionChanges } from "back-end/src/services/featureRevisions";
 import { auditDetailsUpdate } from "back-end/src/services/audit";
 import {
   getApiFeatureObj,
@@ -39,7 +36,7 @@ export async function toggleFeatureCore(
   audit: (input: AuditInterfaceInput) => Promise<void>,
   canUseRestApiBypass: boolean,
 ) {
-  const feature = await getFeature(context, params.id);
+  const feature = await context.models.features.getById(params.id);
   if (!feature) {
     throw new Error("Could not find a feature with that key");
   }

--- a/packages/back-end/src/api/features/updateFeature.ts
+++ b/packages/back-end/src/api/features/updateFeature.ts
@@ -7,16 +7,13 @@ import { isEqual, omit } from "lodash";
 import { updateFeatureValidator } from "shared/validators";
 import { FeatureInterface, FeatureRule } from "shared/types/feature";
 import { FeatureRevisionInterface } from "shared/types/feature-revision";
+import { UpdateProps } from "shared/types/base-model";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import {
   resolveOwnerToUserId,
   resolveOwnerEmail,
 } from "back-end/src/services/owner";
-import {
-  getFeature,
-  updateFeature as updateFeatureToDb,
-  createAndPublishRevision,
-} from "back-end/src/models/FeatureModel";
+import { createAndPublishRevision } from "back-end/src/services/featureRevisions";
 import { getExperimentMapForFeature } from "back-end/src/models/ExperimentModel";
 import {
   addIdsToFlatRules,
@@ -54,7 +51,7 @@ import {
 
 export const updateFeature = createApiRequestHandler(updateFeatureValidator)(
   async (req) => {
-    const feature = await getFeature(req.context, req.params.id);
+    const feature = await req.context.models.features.getById(req.params.id);
     if (!feature) {
       throw new Error(`Feature id '${req.params.id}' not found.`);
     }
@@ -157,7 +154,7 @@ export const updateFeature = createApiRequestHandler(updateFeatureValidator)(
           )
         : null;
 
-    let updates: Partial<FeatureInterface> = {
+    let updates: UpdateProps<FeatureInterface> = {
       ...(ownerInput !== undefined ? { owner: owner ?? "" } : {}),
       ...(archived != null ? { archived } : {}),
       ...(description != null ? { description } : {}),
@@ -480,8 +477,7 @@ export const updateFeature = createApiRequestHandler(updateFeatureValidator)(
       }
     }
 
-    const updatedFeature = await updateFeatureToDb(
-      req.context,
+    const updatedFeature = await req.context.models.features.update(
       feature,
       updates,
     );

--- a/packages/back-end/src/api/features/updateFeatureV2.ts
+++ b/packages/back-end/src/api/features/updateFeatureV2.ts
@@ -3,16 +3,13 @@ import { isEqual } from "lodash";
 import { updateFeatureV2Validator } from "shared/validators";
 import { FeatureInterface, FeatureRule } from "shared/types/feature";
 import { FeatureRevisionInterface } from "shared/types/feature-revision";
+import { UpdateProps } from "shared/types/base-model";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import {
   resolveOwnerEmail,
   resolveOwnerToUserId,
 } from "back-end/src/services/owner";
-import {
-  getFeature,
-  updateFeature as updateFeatureToDb,
-  createAndPublishRevision,
-} from "back-end/src/models/FeatureModel";
+import { createAndPublishRevision } from "back-end/src/services/featureRevisions";
 import {
   getExperimentMapForFeature,
   addLinkedFeatureToExperiment,
@@ -43,7 +40,7 @@ import {
 export const updateFeatureV2 = createApiRequestHandler(
   updateFeatureV2Validator,
 )(async (req) => {
-  const feature = await getFeature(req.context, req.params.id);
+  const feature = await req.context.models.features.getById(req.params.id);
   if (!feature) {
     throw new Error(`Feature id '${req.params.id}' not found.`);
   }
@@ -163,7 +160,7 @@ export const updateFeatureV2 = createApiRequestHandler(
     }
   }
 
-  let updates: Partial<FeatureInterface> = {
+  let updates: UpdateProps<FeatureInterface> = {
     ...(ownerInput !== undefined ? { owner: owner ?? "" } : {}),
     ...(archived != null ? { archived } : {}),
     ...(description != null ? { description } : {}),
@@ -299,7 +296,10 @@ export const updateFeatureV2 = createApiRequestHandler(
     }
   }
 
-  const updatedFeature = await updateFeatureToDb(req.context, feature, updates);
+  const updatedFeature = await req.context.models.features.update(
+    feature,
+    updates,
+  );
 
   await addTagsDiff(
     req.context.org.id,

--- a/packages/back-end/src/api/features/v2Shared.ts
+++ b/packages/back-end/src/api/features/v2Shared.ts
@@ -1,5 +1,6 @@
 import type { z } from "zod";
 import type { FeatureInterface, FeatureRule } from "shared/types/feature";
+import type { UpdateProps } from "shared/types/base-model";
 import type { postFeatureRuleV2 } from "shared/validators";
 import { validateScheduleRules } from "shared/util";
 import type { ApiReqContext } from "back-end/types/api";
@@ -129,12 +130,14 @@ const METADATA_FIELDS = [
 
 // Pure split of metadata-like fields from feature updates. Returns the
 // metadata subset and a copy of `updates` with those keys removed.
-export function extractRevisionMetadata(updates: Partial<FeatureInterface>): {
+export function extractRevisionMetadata(
+  updates: UpdateProps<FeatureInterface>,
+): {
   metadata: Record<string, unknown>;
-  remaining: Partial<FeatureInterface>;
+  remaining: UpdateProps<FeatureInterface>;
 } {
   const metadata: Record<string, unknown> = {};
-  const remaining: Partial<FeatureInterface> = { ...updates };
+  const remaining: UpdateProps<FeatureInterface> = { ...updates };
   for (const key of METADATA_FIELDS) {
     if (key in remaining && remaining[key] !== undefined) {
       metadata[key] = remaining[key];

--- a/packages/back-end/src/api/features/validations.ts
+++ b/packages/back-end/src/api/features/validations.ts
@@ -15,7 +15,6 @@ import type { FeatureInterface } from "shared/types/feature";
 import type { FeatureRevisionInterface } from "shared/types/feature-revision";
 import { getSavedGroupMap } from "back-end/src/services/features";
 import { assertRegisteredAttributes } from "back-end/src/services/attributes";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   createRevision,
   discardRevision,
@@ -227,7 +226,7 @@ export async function validateRuleReferences(
   }
 
   for (const prereq of rule.prerequisites ?? []) {
-    const prereqFeature = await getFeature(context, prereq.id);
+    const prereqFeature = await context.models.features.getById(prereq.id);
     if (!prereqFeature) {
       throw new NotFoundError(`Prerequisite feature "${prereq.id}" not found`);
     }
@@ -254,7 +253,7 @@ export async function validatePrerequisiteReferences(
         );
       }
     }
-    const prereqFeature = await getFeature(context, prereq.id);
+    const prereqFeature = await context.models.features.getById(prereq.id);
     if (!prereqFeature) {
       throw new NotFoundError(`Prerequisite feature "${prereq.id}" not found`);
     }

--- a/packages/back-end/src/api/ramp-schedules/postRampSchedule.ts
+++ b/packages/back-end/src/api/ramp-schedules/postRampSchedule.ts
@@ -11,7 +11,6 @@ import {
 } from "shared/validators";
 import type { FeatureInterface } from "shared/types/feature";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { rampScheduleToApiInterface } from "back-end/src/models/RampScheduleModel";
 import {
   dispatchRampEvent,
@@ -170,7 +169,7 @@ export const postRampSchedule = createApiRequestHandler(
   let feature: FeatureInterface | null = null;
 
   if (body.featureId) {
-    feature = await getFeature(req.context, body.featureId);
+    feature = await req.context.models.features.getById(body.featureId);
     if (!feature) {
       throw new NotFoundError(`Feature '${body.featureId}' not found`);
     }

--- a/packages/back-end/src/api/ramp-schedules/rampScheduleActions.ts
+++ b/packages/back-end/src/api/ramp-schedules/rampScheduleActions.ts
@@ -705,7 +705,9 @@ export const apiAdvanceRampSchedule = createApiRequestHandler({
         );
       }
       if (freshApprovalPending && force) {
-        const linkedFeature = await getFeature(req.context, fresh.entityId);
+        const linkedFeature = await req.context.models.features.getById(
+          fresh.entityId,
+        );
         if (
           !linkedFeature ||
           !req.context.permissions.canBypassApprovalChecks(linkedFeature)

--- a/packages/back-end/src/api/ramp-schedules/rampScheduleActions.ts
+++ b/packages/back-end/src/api/ramp-schedules/rampScheduleActions.ts
@@ -37,7 +37,6 @@ import {
   updateRampSteps,
 } from "back-end/src/services/rampSchedule";
 import { evaluateCurrentStep } from "back-end/src/services/rampScheduleEvaluator";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { rampScheduleToApiInterface } from "back-end/src/models/RampScheduleModel";
 import { getMetricsByIds } from "back-end/src/models/MetricModel";
 import { getDataSourceById } from "back-end/src/models/DataSourceModel";
@@ -453,7 +452,7 @@ export const addTargetRampSchedule = createApiRequestHandler({
   const { featureId, ruleId, environment } = req.body;
   const envSuffix = environment ? ` in environment '${environment}'` : "";
 
-  const feature = await getFeature(req.context, featureId);
+  const feature = await req.context.models.features.getById(featureId);
   if (!feature) throw new Error(`Feature '${featureId}' not found`);
   const rule = resolveRampTarget(
     { ruleId, environment: environment ?? null },
@@ -667,7 +666,9 @@ export const apiAdvanceRampSchedule = createApiRequestHandler({
     );
   }
   if (approvalPending && force) {
-    const feature = await getFeature(req.context, schedule.entityId);
+    const feature = await req.context.models.features.getById(
+      schedule.entityId,
+    );
     if (!feature || !req.context.permissions.canBypassApprovalChecks(feature)) {
       throw new PermissionError(
         "force: true requires canBypassApprovalChecks permission on the linked feature",
@@ -1446,7 +1447,7 @@ export const refreshMonitoringRampSchedule = createApiRequestHandler({
   }
 
   const feature = safeRollout.featureId
-    ? await getFeature(req.context, safeRollout.featureId)
+    ? await req.context.models.features.getById(safeRollout.featureId)
     : null;
 
   await createSafeRolloutSnapshot({

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -133,11 +133,7 @@ import { getFactTableMap } from "back-end/src/models/FactTableModel";
 import { ReqContext } from "back-end/types/request";
 import { logger } from "back-end/src/util/logger";
 import { BadRequestError } from "back-end/src/util/errors";
-import {
-  getFeature,
-  getFeaturesByIds,
-  publishRevision,
-} from "back-end/src/models/FeatureModel";
+import { publishRevision } from "back-end/src/services/featureRevisions";
 import { getLinkageSyncRevisionSummaries } from "back-end/src/models/FeatureRevisionModel";
 import { syncFeatureExperimentLinkages } from "back-end/src/util/featureExperimentSync";
 import { generateExperimentReportSSRData } from "back-end/src/services/reports";
@@ -775,7 +771,8 @@ export async function getExperiment(
 
   const linkedFeatureIds = experiment.linkedFeatures || [];
 
-  const linkedFeatures = await getFeaturesByIds(context, linkedFeatureIds);
+  const linkedFeatures =
+    await context.models.features.getByIds(linkedFeatureIds);
 
   const envs = getAffectedEnvsForExperiment({
     experiment,
@@ -1651,8 +1648,7 @@ export async function postExperiment(
     experiment.status === "running" &&
     (variationsChanged || coverageChanged || variationWeightsChanged)
   ) {
-    const linkedFeaturesForPayload = await getFeaturesByIds(
-      context,
+    const linkedFeaturesForPayload = await context.models.features.getByIds(
       experiment.linkedFeatures || [],
     );
     const inPayload = includeExperimentInPayload(
@@ -2029,7 +2025,8 @@ export async function postExperiment(
   if (needsRunExperimentsPermission) {
     const linkedFeatureIds = experiment.linkedFeatures || [];
 
-    const linkedFeatures = await getFeaturesByIds(context, linkedFeatureIds);
+    const linkedFeatures =
+      await context.models.features.getByIds(linkedFeatureIds);
 
     const envs = getAffectedEnvsForExperiment({
       experiment,
@@ -2121,7 +2118,8 @@ export async function postExperimentArchive(
 
   const linkedFeatureIds = experiment.linkedFeatures || [];
 
-  const linkedFeatures = await getFeaturesByIds(context, linkedFeatureIds);
+  const linkedFeatures =
+    await context.models.features.getByIds(linkedFeatureIds);
 
   const envs = getAffectedEnvsForExperiment({
     experiment,
@@ -2283,7 +2281,8 @@ export async function postExperimentStatus(
 
   const linkedFeatureIds = experiment.linkedFeatures || [];
 
-  const linkedFeatures = await getFeaturesByIds(context, linkedFeatureIds);
+  const linkedFeatures =
+    await context.models.features.getByIds(linkedFeatureIds);
 
   const { settings } = getScopedSettings({
     organization: org,
@@ -2600,7 +2599,8 @@ export async function deleteExperimentPhase(
 
   const linkedFeatureIds = experiment.linkedFeatures || [];
 
-  const linkedFeatures = await getFeaturesByIds(context, linkedFeatureIds);
+  const linkedFeatures =
+    await context.models.features.getByIds(linkedFeatureIds);
 
   const envs = getAffectedEnvsForExperiment({
     experiment,
@@ -2688,7 +2688,8 @@ export async function putExperimentPhase(
 
   const linkedFeatureIds = experiment.linkedFeatures || [];
 
-  const linkedFeatures = await getFeaturesByIds(context, linkedFeatureIds);
+  const linkedFeatures =
+    await context.models.features.getByIds(linkedFeatureIds);
 
   const envs = getAffectedEnvsForExperiment({
     experiment,
@@ -2808,7 +2809,8 @@ export async function postExperimentTargeting(
 
   const linkedFeatureIds = experiment.linkedFeatures || [];
 
-  const linkedFeatures = await getFeaturesByIds(context, linkedFeatureIds);
+  const linkedFeatures =
+    await context.models.features.getByIds(linkedFeatureIds);
 
   const envs = getAffectedEnvsForExperiment({
     experiment,
@@ -2980,7 +2982,8 @@ export async function postExperimentPhase(
 
   const linkedFeatureIds = experiment.linkedFeatures || [];
 
-  const linkedFeatures = await getFeaturesByIds(context, linkedFeatureIds);
+  const linkedFeatures =
+    await context.models.features.getByIds(linkedFeatureIds);
 
   const envs = getAffectedEnvsForExperiment({
     experiment,
@@ -3116,7 +3119,8 @@ export async function deleteExperiment(
 
   const linkedFeatureIds = experiment.linkedFeatures || [];
 
-  const linkedFeatures = await getFeaturesByIds(context, linkedFeatureIds);
+  const linkedFeatures =
+    await context.models.features.getByIds(linkedFeatureIds);
 
   const envs = getAffectedEnvsForExperiment({
     experiment,
@@ -3874,7 +3878,8 @@ export async function postVisualChangeset(
 
   const linkedFeatureIds = experiment.linkedFeatures || [];
 
-  const linkedFeatures = await getFeaturesByIds(context, linkedFeatureIds);
+  const linkedFeatures =
+    await context.models.features.getByIds(linkedFeatureIds);
 
   const envs = getAffectedEnvsForExperiment({
     experiment,
@@ -3930,7 +3935,8 @@ export async function putVisualChangeset(
 
   const linkedFeatureIds = experiment.linkedFeatures || [];
 
-  const linkedFeatures = await getFeaturesByIds(context, linkedFeatureIds);
+  const linkedFeatures =
+    await context.models.features.getByIds(linkedFeatureIds);
 
   const envs = experiment
     ? getAffectedEnvsForExperiment({
@@ -3979,7 +3985,8 @@ export async function deleteVisualChangeset(
 
   const linkedFeatureIds = experiment?.linkedFeatures || [];
 
-  const linkedFeatures = await getFeaturesByIds(context, linkedFeatureIds);
+  const linkedFeatures =
+    await context.models.features.getByIds(linkedFeatureIds);
 
   const envs = experiment
     ? getAffectedEnvsForExperiment({
@@ -4158,7 +4165,9 @@ export async function postExperimentFeatureValues(
     }
   });
 
-  const featureObjects = await getFeaturesByIds(context, Object.keys(features));
+  const featureObjects = await context.models.features.getByIds(
+    Object.keys(features),
+  );
 
   const envs = getAffectedEnvsForExperiment({
     experiment,
@@ -4319,7 +4328,7 @@ export async function deleteExperimentLinkedFeature(
 
   // Also require feature-side edit rights — unlinking cancels a queued
   // autopublish that the feature team may be managing.
-  const feature = await getFeature(context, featureId);
+  const feature = await context.models.features.getById(featureId);
   if (feature && !context.permissions.canUpdateFeature(feature, {})) {
     context.permissions.throwPermissionError();
   }

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -50,6 +50,7 @@ import {
   RampStepAction,
 } from "shared/validators";
 import { FeatureUsageLookback } from "shared/types/integrations";
+import { UpdateProps } from "shared/types/base-model";
 import {
   ContextualBanditRefRule,
   ExperimentRefRule,
@@ -85,24 +86,11 @@ import {
   getEnvironments,
 } from "back-end/src/services/organizations";
 import {
-  addLinkedExperiment,
-  createFeature,
-  deleteFeature,
   editFeatureRule,
-  getAllFeatures,
-  getAllFeaturesForStaleGraph,
-  getFeature,
-  getFeaturesByIds,
-  getFeatureMetaInfoById,
-  getFeatureMetaInfoByIds,
-  getFeatureEnvStatus,
-  hasArchivedFeatures,
-  migrateDraft,
   prevalidatePublishRevision,
   publishRevision,
   setDefaultValue,
-  updateFeature,
-} from "back-end/src/models/FeatureModel";
+} from "back-end/src/services/featureRevisions";
 import { getRealtimeUsageByHour } from "back-end/src/models/RealtimeModel";
 import { dangerousLookupOrganizationByApiKey } from "back-end/src/util/api-key.util";
 import { generateId } from "back-end/src/util/uuid";
@@ -746,7 +734,7 @@ export async function postFeatures(
     project: otherProps.project || undefined,
   });
 
-  const existing = await getFeature(context, id);
+  const existing = await context.models.features.getById(id);
   if (existing) {
     throw new Error(
       "This feature key already exists. Feature keys must be unique.",
@@ -838,7 +826,9 @@ export async function postFeatures(
   // `id: ""`; stamp ids so they're addressable by later update/delete ops.
   addIdsToFlatRules(feature.rules, feature.id);
 
-  await createFeature(context, feature);
+  await context.models.features.create(
+    omit(feature, ["organization", "dateCreated", "dateUpdated"]),
+  );
   await context.models.watch.upsertWatch({
     userId,
     item: feature.id,
@@ -887,7 +877,7 @@ export async function postFeatureRebase(
   const { org } = context;
   const { strategies, mergeResultSerialized } = req.body;
   const { id, version } = req.params;
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
 
   if (!feature) {
     throw new Error("Could not find feature");
@@ -1088,7 +1078,7 @@ export async function postFeatureScheduledPublish(
   const { id, version } = req.params;
   const { scheduledPublishAt, lockEdits, lockOthers } = req.body;
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) throw new Error("Could not find feature");
 
   const revision = await getRevision({
@@ -1181,7 +1171,7 @@ export async function postFeatureRequestReview(
     scheduledPublishLockEdits,
     scheduledPublishLockOthers,
   } = req.body;
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
@@ -1273,7 +1263,7 @@ export async function postFeatureReviewOrComment(
   const context = getContextFromReq(req);
   const { id, version } = req.params;
   const { comment, review = "Comment" } = req.body;
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
@@ -1392,7 +1382,7 @@ export async function postFeatureApproveAndPublish(
   const context = getContextFromReq(req);
   const { id, version } = req.params;
   const { comment } = req.body;
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) throw new Error("Could not find feature");
 
   if (!context.permissions.canReviewFeatureDrafts(feature)) {
@@ -1560,7 +1550,7 @@ export async function postFeatureToggleAutoPublish(
   const { id, version } = req.params;
   const { enabled } = req.body;
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) throw new Error("Could not find feature");
 
   const revision = await getRevision({
@@ -1620,7 +1610,7 @@ export async function postFeatureRecallReview(
 ) {
   const context = getContextFromReq(req);
   const { id, version } = req.params;
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) throw new Error("Could not find feature");
   if (!context.permissions.canManageFeatureDrafts(feature)) {
     context.permissions.throwPermissionError();
@@ -1645,7 +1635,7 @@ export async function postFeatureUndoReview(
 ) {
   const context = getContextFromReq(req);
   const { id, version } = req.params;
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) throw new Error("Could not find feature");
   if (!context.permissions.canReviewFeatureDrafts(feature)) {
     context.permissions.throwPermissionError();
@@ -1694,7 +1684,7 @@ export async function putFeatureRevisionLogComment(
   if (!comment?.trim()) {
     throw new Error("Comment cannot be empty");
   }
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) throw new Error("Could not find feature");
   await context.models.featureRevisionLogs.updateCommentText(logId, comment, {
     featureId: feature.id,
@@ -1715,7 +1705,7 @@ export async function deleteFeatureRevisionLogEntry(
 ) {
   const context = getContextFromReq(req);
   const { id, version, logId } = req.params;
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) throw new Error("Could not find feature");
   await context.models.featureRevisionLogs.deleteOwnedEntry(logId, {
     featureId: feature.id,
@@ -1766,7 +1756,7 @@ async function repairFeatureDriftIfNeeded(
 
   try {
     const original = { ...feature };
-    const repaired = await updateFeature(context, feature, {
+    const repaired = await context.models.features.update(feature, {
       ...(defaultValueDrift ? { defaultValue: live.defaultValue } : {}),
       rules: liveRulesFlat,
     });
@@ -1836,7 +1826,7 @@ export async function postFeaturePublish(
     publishExperimentIds,
   } = req.body;
   const { id, version } = req.params;
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
 
   if (!feature) {
     throw new Error("Could not find feature");
@@ -2057,8 +2047,7 @@ export async function postFeaturePublish(
       if (!context.permissions.canUpdateExperiment(experiment, {})) {
         context.permissions.throwPermissionError();
       }
-      const linkedFeatures = await getFeaturesByIds(
-        context,
+      const linkedFeatures = await context.models.features.getByIds(
         experiment.linkedFeatures || [],
       );
       const schedEnvs = getAffectedEnvsForExperiment({
@@ -2083,7 +2072,7 @@ export async function postFeaturePublish(
         (d) => d.featureId !== feature.id,
       );
       for (const { featureId, revisionVersion } of otherDrafts) {
-        const otherFeature = await getFeature(context, featureId);
+        const otherFeature = await context.models.features.getById(featureId);
         if (!otherFeature) continue;
         const otherRevision = await getRevision({
           context,
@@ -2245,7 +2234,7 @@ export async function postFeatureRevert(
   const { id, version } = req.params;
   const { comment } = req.body;
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
@@ -2520,7 +2509,7 @@ export async function postFeatureRevertDraft(
   const { id, version } = req.params;
   const { comment } = req.body;
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
@@ -2605,7 +2594,7 @@ export async function postFeatureFork(
   const { org, environments } = context;
   const { id, version } = req.params;
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
 
   if (!feature) {
     throw new Error("Could not find feature");
@@ -2653,7 +2642,7 @@ export async function postFeatureDiscard(
   const { org } = context;
   const { id, version } = req.params;
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
 
   if (!feature) {
     throw new Error("Could not find feature");
@@ -2733,7 +2722,7 @@ export async function postFeatureReopen(
   const { org } = context;
   const { id, version } = req.params;
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
 
   if (!feature) {
     throw new Error("Could not find feature");
@@ -2813,7 +2802,7 @@ export async function postFeatureRule(
     rampSchedule: rampSchedulePayload,
   } = req.body;
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
@@ -3107,7 +3096,10 @@ export async function postFeatureRule(
         rule.experimentId,
         feature.id,
       );
-      await addLinkedExperiment(feature, rule.experimentId);
+      await context.models.features.addLinkedExperiment(
+        feature,
+        rule.experimentId,
+      );
     }
     // Queue the draft for auto-publish when the experiment goes running.
     const draftVersion =
@@ -3143,7 +3135,7 @@ export async function postFeatureSync(
   const { environments, org } = context;
   const { id } = req.params;
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   // If this is a new feature, create it
   if (!feature) {
     await postFeatures(req, res);
@@ -3177,12 +3169,12 @@ export async function postFeatureSync(
     );
   }
 
-  const updates: Partial<FeatureInterface> = {
+  const updates: UpdateProps<FeatureInterface> = {
     description: data.description ?? feature.description,
     owner: data.owner ?? feature.owner,
     tags: data.tags ?? feature.tags,
   };
-  const updatesInRevision: Partial<FeatureInterface> = {};
+  const updatesInRevision: UpdateProps<FeatureInterface> = {};
 
   // The Sync endpoint accepts per-env rule arrays under
   // `environmentSettings[env].rules`. Produce a flat array with unique ids by
@@ -3295,7 +3287,7 @@ export async function postFeatureSync(
     }
   }
 
-  const updatedFeature = await updateFeature(context, feature, updates);
+  const updatedFeature = await context.models.features.update(feature, updates);
 
   await req.audit({
     event: "feature.update",
@@ -3353,7 +3345,7 @@ export async function postFeatureExperimentRefRule(
     );
   }
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
@@ -3517,7 +3509,7 @@ export async function postFeatureExperimentRefRule(
   }
 
   if (!feature.linkedExperiments?.includes(experiment.id)) {
-    await addLinkedExperiment(feature, experiment.id);
+    await context.models.features.addLinkedExperiment(feature, experiment.id);
   }
   await addLinkedFeatureToExperiment(
     context,
@@ -3568,7 +3560,7 @@ export async function postFeatureContextualBanditRefRule(
     );
   }
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
@@ -3744,7 +3736,7 @@ export async function putRevisionComment(
   const { id, version } = req.params;
   const { comment } = req.body;
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
@@ -3801,7 +3793,7 @@ export async function putRevisionTitle(
   const { id, version } = req.params;
   const { title } = req.body;
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
@@ -3858,7 +3850,7 @@ export async function postFeatureDefaultValue(
   const { id, version } = req.params;
   const { defaultValue } = req.body;
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
@@ -3916,7 +3908,7 @@ export async function postFeatureSchema(
   const { id } = req.params;
   const { targetDraftVersion, autoPublish, forceNewDraft, ...schemaDef } =
     req.body;
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
 
   if (!feature) {
     throw new Error("Could not find feature");
@@ -3978,7 +3970,7 @@ export async function putSafeRolloutStatus(
   // `environment` is retained for audit context and reset-review scoping.
   const { status, environment, ruleId } = req.body;
   const { org } = context;
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
@@ -4125,7 +4117,7 @@ export async function putFeatureRule(
     throw new Error("Must provide ruleId to identify the rule");
   }
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
@@ -4442,7 +4434,7 @@ export async function postFeatureCreateDraft(
   const { id } = req.params;
   const { title, comment } = req.body ?? {};
   const context = getContextFromReq(req);
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
 
   if (!feature) {
     throw new Error("Could not find feature");
@@ -4528,7 +4520,7 @@ export async function postFeatureToggle(
   const { environments: orgEnvIds } = context;
   const { id } = req.params;
   const { environments, autoPublish, draftVersion, forceNewDraft } = req.body;
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
 
   if (!feature) {
     throw new Error("Could not find feature");
@@ -4689,7 +4681,7 @@ export async function postFeatureMoveRule(
   const { environments, org } = context;
   const { id, version } = req.params;
   const { from, to } = req.body;
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
 
   if (!feature) {
     throw new Error("Could not find feature");
@@ -4763,7 +4755,8 @@ export async function getDraftandReviewRevisions(
   );
 
   const featureIds = Array.from(new Set(revisions.map((r) => r.featureId)));
-  const featureMeta = await getFeatureMetaInfoByIds(context, featureIds);
+  const featureMeta =
+    await context.models.features.getMetaInfoByIds(featureIds);
   const featureMetaMap = new Map(featureMeta.map((f) => [f.id, f]));
   const revisionsWithMeta = revisions.map((r) => ({
     ...r,
@@ -4789,7 +4782,7 @@ export async function deleteFeatureRule(
     throw new Error("Must provide ruleId to identify the rule");
   }
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
@@ -4901,7 +4894,7 @@ export async function putFeature(
   const context = getContextFromReq(req);
   const { org, environments } = context;
   const { id } = req.params;
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
 
   if (!feature) {
     throw new Error("Could not find feature");
@@ -5103,7 +5096,7 @@ export async function deleteFeatureById(
   const { id } = req.params;
   const context = getContextFromReq(req);
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
 
   if (feature) {
     if (!feature.archived) {
@@ -5124,7 +5117,7 @@ export async function deleteFeatureById(
         logger.warn(e, "Error removing feature from holdout");
       }
     }
-    await deleteFeature(context, feature);
+    await context.models.features.delete(feature);
     await unlinkFeatureFromAllExperiments(context, feature.id);
     await req.audit({
       event: "feature.delete",
@@ -5166,7 +5159,7 @@ export async function postFeatureEvaluate(
     evalDate,
   } = req.body;
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
@@ -5236,7 +5229,7 @@ export async function postFeaturesEvaluate(
   const features: FeatureInterface[] = [];
   await Promise.all(
     featureIds.map(async (featureId) => {
-      const feature = await getFeature(context, featureId);
+      const feature = await context.models.features.getById(featureId);
       if (feature) {
         features.push(feature);
       }
@@ -5283,7 +5276,7 @@ export async function postFeatureArchive(
 ) {
   const { id } = req.params;
   const context = getContextFromReq(req);
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
 
   if (!feature) {
     throw new Error("Could not find feature");
@@ -5390,14 +5383,14 @@ export async function getFeatures(
   }
   const includeArchived = !!req.query.includeArchived;
 
-  const features = await getAllFeatures(context, {
+  const features = await context.models.features.getAll({
     projects: project ? [project] : undefined,
     includeArchived,
   });
 
   const hasArchived = includeArchived
     ? features.some((f) => f.archived)
-    : await hasArchivedFeatures(context, project);
+    : await context.models.features.hasArchivedFeatures(project);
 
   res.status(200).json({
     status: 200,
@@ -5414,7 +5407,7 @@ export async function getFeatureRevisions(
   const { org } = context;
   const { id } = req.params;
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
@@ -5455,7 +5448,7 @@ export async function getRevisionLog(
   const context = getContextFromReq(req);
   const { id, version } = req.params;
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
@@ -5507,7 +5500,7 @@ export async function getFeatureById(
   const { org, environments } = context;
   const { id } = req.params;
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
@@ -5584,7 +5577,7 @@ export async function getFeatureById(
 
   // Migrate old drafts to revisions
   if (feature.legacyDraft) {
-    const draft = await migrateDraft(context, feature);
+    const draft = await context.models.features.migrateDraft(feature);
     if (draft) {
       fullRevisions.push(draft);
     }
@@ -5689,7 +5682,7 @@ export async function getFeatureUsage(
   const { org } = context;
 
   const { id } = req.params;
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
 
   if (!feature) {
     throw new Error("Could not find feature");
@@ -5898,7 +5891,7 @@ export async function toggleStaleFFDetectionForFeature(
     throw new Error("Missing required field: neverStale (boolean)");
   }
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
@@ -5995,7 +5988,7 @@ export async function postPrerequisite(
   const { id } = req.params;
   const { prerequisite, targetDraftVersion, forceNewDraft } = req.body;
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
@@ -6049,7 +6042,7 @@ export async function putPrerequisite(
   const { id } = req.params;
   const { prerequisite, i, targetDraftVersion, forceNewDraft } = req.body;
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
@@ -6102,7 +6095,7 @@ export async function deletePrerequisite(
   const { id } = req.params;
   const { i, targetDraftVersion, forceNewDraft } = req.body;
 
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
@@ -6162,7 +6155,7 @@ export async function getPrerequisiteStates(
   const { org } = context;
   const { id } = req.params;
 
-  const baseFeature = await getFeature(context, id);
+  const baseFeature = await context.models.features.getById(id);
   if (!baseFeature) {
     throw new Error("Could not find feature");
   }
@@ -6253,7 +6246,7 @@ export async function postBatchPrerequisiteStates(
 
   let baseFeature: FeatureInterface | null = null;
   if (baseFeatureId) {
-    baseFeature = await getFeature(context, baseFeatureId);
+    baseFeature = await context.models.features.getById(baseFeatureId);
     if (!baseFeature) {
       throw new Error("Could not find base feature");
     }
@@ -6343,7 +6336,7 @@ async function evaluateBatchPrerequisiteStates({
   // Load all org features so the adjacency graph is complete for cycle
   // detection (cross-project intermediaries, etc.). State evaluation is
   // still bounded to the requested featureIds.
-  const allFeatures = await getAllFeatures(context, {});
+  const allFeatures = await context.models.features.getAll({});
   const featuresMap = new Map<string, FeatureInterface>(
     allFeatures.map((f) => [f.id, f]),
   );
@@ -6451,7 +6444,7 @@ async function evaluatePrerequisiteStateAsync(
     for (const prereq of prerequisites) {
       let prereqFeature = featuresMap.get(prereq.id);
       if (!prereqFeature) {
-        const features = await getFeaturesByIds(context, [prereq.id]);
+        const features = await context.models.features.getByIds([prereq.id]);
         prereqFeature = features[0];
         if (prereqFeature) {
           featuresMap.set(prereq.id, prereqFeature);
@@ -6524,7 +6517,7 @@ async function evaluatePrerequisiteStateAsync(
     for (const prereq of prerequisites) {
       let prereqFeature = featuresMap.get(prereq.id);
       if (!prereqFeature) {
-        const features = await getFeaturesByIds(context, [prereq.id]);
+        const features = await context.models.features.getByIds([prereq.id]);
         prereqFeature = features[0];
         if (prereqFeature) {
           featuresMap.set(prereq.id, prereqFeature);
@@ -6630,7 +6623,7 @@ export async function getFeatureMetaInfo(
   const context = getContextFromReq(req);
   const { defaultValue, project, ids } = req.query;
 
-  const features = await getFeatureMetaInfoById(context, {
+  const features = await context.models.features.getMetaInfo({
     includeDefaultValue: defaultValue === "1",
     project: project || undefined,
     ids: ids ? ids.split(",").filter(Boolean) : undefined,
@@ -6677,7 +6670,7 @@ export async function getFeaturesStaleStates(
     : undefined;
 
   const [allFeatures, allExperiments, draftRevisions] = await Promise.all([
-    getAllFeaturesForStaleGraph(context),
+    context.models.features.getAllForStaleGraph(),
     getAllExperimentsForStaleGraph(context),
     getRevisionsByStatus(context as ReqContext, [...ACTIVE_DRAFT_STATUSES], {
       sparse: true,
@@ -6752,7 +6745,7 @@ export async function getFeaturesStatus(
     ? req.query.ids.split(",").filter(Boolean)
     : undefined;
 
-  const raw = await getFeatureEnvStatus(context, featureIds);
+  const raw = await context.models.features.getEnvStatus(featureIds);
 
   const features: Record<string, Record<string, boolean>> = {};
   for (const f of raw) {
@@ -6793,7 +6786,7 @@ export async function getFeaturesDependents(
   const allEnvIds = getEnvironments(context.org).map((e) => e.id);
 
   const [allFeatures, allExperiments] = await Promise.all([
-    getAllFeaturesForStaleGraph(context, { includeArchived: true }),
+    context.models.features.getAllForStaleGraph({ includeArchived: true }),
     getAllExperimentsForStaleGraph(context, { includeArchived: true }),
   ]);
 
@@ -6964,7 +6957,7 @@ export async function getFeatureContentSearch(
   }
 
   const [allFeatures, draftRevisions] = await Promise.all([
-    getAllFeatures(context, {}),
+    context.models.features.getAll({}),
     getRevisionsByStatus(context as ReqContext, [...ACTIVE_DRAFT_STATUSES]),
   ]);
 
@@ -7046,7 +7039,9 @@ export async function getFeatureDependencyIndex(
   >,
 ) {
   const context = getContextFromReq(req);
-  const allFeatures = await getAllFeatures(context, { includeArchived: true });
+  const allFeatures = await context.models.features.getAll({
+    includeArchived: true,
+  });
 
   const prereqIds = new Set<string>();
   for (let i = 0; i < allFeatures.length; i++) {
@@ -7147,7 +7142,7 @@ export async function getFeatureExperimentStates(
     }
   }
 
-  const allFeatures = await getAllFeatures(context, {});
+  const allFeatures = await context.models.features.getAll({});
   const targetFeatures = featureIds
     ? allFeatures.filter((f) => featureIds.includes(f.id))
     : allFeatures;

--- a/packages/back-end/src/enterprise/saferollouts/safeRolloutUtils.ts
+++ b/packages/back-end/src/enterprise/saferollouts/safeRolloutUtils.ts
@@ -17,7 +17,7 @@ import { orgHasPremiumFeature } from "back-end/src/enterprise/licenseUtil";
 import {
   editFeatureRule,
   publishRevision,
-} from "back-end/src/models/FeatureModel";
+} from "back-end/src/services/featureRevisions";
 import {
   createRevision,
   getRevision,

--- a/packages/back-end/src/jobs/addSafeRolloutSnapshotJob.ts
+++ b/packages/back-end/src/jobs/addSafeRolloutSnapshotJob.ts
@@ -3,7 +3,6 @@ import { SafeRolloutInterface } from "shared/validators";
 import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizations";
 import { logger } from "back-end/src/util/logger";
 import { getCollection } from "back-end/src/util/mongo.util";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { shouldSkipScheduledSafeRolloutSnapshot } from "back-end/src/routers/safe-rollout/safe-rollout.helper";
 import { createSafeRolloutSnapshot } from "back-end/src/services/safeRolloutSnapshots";
 import { COLLECTION_NAME } from "back-end/src/models/SafeRolloutModel";
@@ -67,7 +66,7 @@ const updateSingleSafeRolloutSnapshot = async (
   if (!id || !organization || !featureId) return;
 
   const context = await getContextForAgendaJobByOrgId(organization);
-  const feature = await getFeature(context, featureId);
+  const feature = await context.models.features.getById(featureId);
   if (!feature || feature.archived) return;
 
   if (shouldSkipScheduledSafeRolloutSnapshot(feature, safeRollout)) return;

--- a/packages/back-end/src/jobs/updateRampSchedules.ts
+++ b/packages/back-end/src/jobs/updateRampSchedules.ts
@@ -16,7 +16,6 @@ import {
   evaluateCurrentStep,
 } from "back-end/src/services/rampScheduleEvaluator";
 import { RampAdvanceLockBusyError } from "back-end/src/util/errors";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { RampScheduleModel } from "back-end/src/models/RampScheduleModel";
 
 /**
@@ -126,7 +125,7 @@ export const advanceSingleRampSchedule = async (
       const activatingVersion = getActivatingVersion(screened);
       if (activatingVersion === null) return;
       const feature = screened.entityId
-        ? await getFeature(context, screened.entityId)
+        ? await context.models.features.getById(screened.entityId)
         : undefined;
       if ((feature?.version ?? -1) < activatingVersion) return;
     }
@@ -176,7 +175,7 @@ async function runRampScheduleTick(
       const activatingVersion = getActivatingVersion(current);
       if (activatingVersion !== null) {
         const feature = current.entityId
-          ? await getFeature(context, current.entityId)
+          ? await context.models.features.getById(current.entityId)
           : undefined;
         if ((feature?.version ?? -1) >= activatingVersion) {
           // Activation runs start actions + a catch-up publish — refresh the

--- a/packages/back-end/src/jobs/updateScheduledFeatures.ts
+++ b/packages/back-end/src/jobs/updateScheduledFeatures.ts
@@ -1,9 +1,5 @@
 import Agenda, { Job } from "agenda";
-import {
-  getFeature,
-  getScheduledFeaturesToUpdate,
-  updateNextScheduledDate,
-} from "back-end/src/models/FeatureModel";
+import { FeatureModel } from "back-end/src/models/FeatureModel";
 import {
   getNextScheduledUpdate,
   refreshSDKPayloadCache,
@@ -44,7 +40,9 @@ async function queueFeatureUpdate(
 
 export default async function (agenda: Agenda) {
   agenda.define(QUEUE_FEATURE_UPDATES, async () => {
-    const featureIds = (await getScheduledFeaturesToUpdate()).map((f) => {
+    const featureIds = (
+      await FeatureModel.dangerousGetScheduledFeaturesToUpdate()
+    ).map((f) => {
       return { id: f.id, organization: f.organization };
     });
 
@@ -64,7 +62,7 @@ export const updateSingleFeature = async (job: UpdateSingleFeatureJob) => {
   if (!featureId || !organization) return;
 
   const context = await getContextForAgendaJobByOrgId(organization);
-  const feature = await getFeature(context, featureId);
+  const feature = await context.models.features.getById(featureId);
   if (!feature) return;
 
   const nextScheduledUpdate = getNextScheduledUpdate(feature.rules);
@@ -84,7 +82,12 @@ export const updateSingleFeature = async (job: UpdateSingleFeatureJob) => {
     payloadKeys,
     auditContext: { event: "updated", model: "feature", id: feature.id },
   })
-    .then(() => updateNextScheduledDate(feature, nextScheduledUpdate))
+    .then(() =>
+      context.models.features.updateNextScheduledDate(
+        feature,
+        nextScheduledUpdate,
+      ),
+    )
     .catch((e) =>
       logger.error(e, "Failed updating scheduled feature " + featureId),
     );

--- a/packages/back-end/src/jobs/updateScheduledPublishes.ts
+++ b/packages/back-end/src/jobs/updateScheduledPublishes.ts
@@ -1,7 +1,6 @@
 import Agenda, { Job } from "agenda";
 import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizations";
 import { logger } from "back-end/src/util/logger";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   cancelScheduledPublishesForFeature,
   dangerouslyFindRevisionsDueToPublish,
@@ -59,11 +58,10 @@ const publishScheduledRevision = async (job: ScheduledPublishJob) => {
     const { organization, featureId, version } = data;
     if (!featureId || version === undefined || version === null) return;
 
-    const feature = await getFeature(context, featureId);
+    const feature = await context.models.features.getById(featureId);
     if (!feature) return;
 
-    // archiveFeature already cancels schedules; this guards against a race so we
-    // don't resurrect an archived feature's draft.
+    // Guard so we don't resurrect an archived feature's draft.
     if (feature.archived) {
       await cancelScheduledPublishesForFeature(
         context,

--- a/packages/back-end/src/models/BaseModel.ts
+++ b/packages/back-end/src/models/BaseModel.ts
@@ -1034,11 +1034,14 @@ export abstract class BaseModel<
   ) {
     updates = this.updateValidator.parse(updates);
 
-    // Resolve owner from email to userId if needed
+    // Resolve owner from email to userId if needed. Skip when unchanged so
+    // callers echoing the stored owner (e.g. feature sync / revision publish)
+    // don't fail resolution for a userId whose member has since left the org.
     if (
       "owner" in updates &&
       typeof updates.owner === "string" &&
-      updates.owner
+      updates.owner &&
+      updates.owner !== (doc as { owner?: unknown }).owner
     ) {
       updates.owner = await resolveOwnerToUserId(updates.owner, this.context);
     }

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -66,7 +66,6 @@ import {
   findVisualChangesets,
   VisualChangesetModel,
 } from "./VisualChangesetModel";
-import { getFeaturesByIds } from "./FeatureModel";
 
 const COLLECTION = "experiments";
 
@@ -2132,7 +2131,7 @@ const onExperimentUpdate = async ({
     ]);
     let linkedFeatures: FeatureInterface[] = [];
     if (featureIds.size > 0) {
-      linkedFeatures = await getFeaturesByIds(context, [...featureIds]);
+      linkedFeatures = await context.models.features.getByIds([...featureIds]);
     }
 
     const oldPayloadKeys = oldExperiment
@@ -2190,7 +2189,7 @@ const onExperimentDelete = async (
   const featureIds = [...(experiment.linkedFeatures || [])];
   let linkedFeatures: FeatureInterface[] = [];
   if (featureIds.length > 0) {
-    linkedFeatures = await getFeaturesByIds(context, featureIds);
+    linkedFeatures = await context.models.features.getByIds(featureIds);
   }
 
   const payloadKeys = getPayloadKeys(context, experiment, linkedFeatures);

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -1,28 +1,9 @@
-import mongoose, { FilterQuery } from "mongoose";
-import { v4 as uuidv4 } from "uuid";
-import cloneDeep from "lodash/cloneDeep";
 import omit from "lodash/omit";
+import cloneDeep from "lodash/cloneDeep";
 import isEqual from "lodash/isEqual";
-import {
-  MergeResultChanges,
-  checkIfRevisionNeedsReview,
-  autoMerge,
-  liveRevisionFromFeature,
-  PermissionError,
-  stemRuleId,
-} from "shared/util";
-import {
-  SafeRolloutInterface,
-  SafeRolloutRule,
-  simpleSchemaValidator,
-  RampScheduleInterface,
-  RampScheduleTemplateInterface,
-  RevisionRampAction,
-  RevisionRampCreateAction,
-  RevisionRampUpdateAction,
-  RampStepAction,
-} from "shared/validators";
-import { UpdateProps } from "shared/types/base-model";
+import { UpdateFilter } from "mongodb";
+import { featureInterface, simpleSchemaValidator } from "shared/validators";
+import { CreateProps, UpdateProps } from "shared/types/base-model";
 import {
   FeatureEnvironment,
   FeatureInterface,
@@ -33,33 +14,15 @@ import {
   V1FeatureInterface,
   V1FeatureRule,
 } from "shared/types/feature";
-import { EventUser } from "shared/types/events/event-types";
-import { OrganizationInterface } from "shared/types/organization";
-import { FeatureRevisionInterface } from "shared/types/feature-revision";
 import { ResourceEvents } from "shared/types/events/base-types";
 import { DiffResult } from "shared/types/events/diff";
 import { getDemoDatasourceProjectIdForOrganization } from "shared/demo-datasource";
 import {
-  generateRuleId,
-  addIdsToFlatRules,
   getApiFeatureObj,
-  getNextScheduledUpdate,
   getSavedGroupMap,
   queueSDKPayloadRefresh,
   synthesizeRuleId,
 } from "back-end/src/services/features";
-import {
-  appendRampEvent,
-  assertFeatureNotLockedByRamp,
-  computeNextProcessAt,
-  ensureSafeRolloutForMonitoredRamp,
-  getStartActionsFromRules,
-  mergeStepsForRunningSchedule,
-  remapTemplateActions,
-  runLockedRampScheduleAction,
-  startReadyScheduleNow,
-  syncLinkedSafeRolloutForRampState,
-} from "back-end/src/services/rampSchedule";
 import {
   applyNonRuleFeatureUpgrades,
   upgradeFeatureRule,
@@ -78,29 +41,25 @@ import {
   buildInheritedChildrenByAncestor,
   expandRuleEnvsForInheritance,
   getAffectedSDKPayloadKeys,
+  getLinkedExperiments,
   getSDKPayloadKeysByDiff,
 } from "back-end/src/util/features";
-import { applyPartialFeatureRuleUpdatesToRevision } from "back-end/src/util/featureRevision.util";
-import { NotFoundError } from "back-end/src/util/errors";
 import { logger } from "back-end/src/util/logger";
 import {
   getContextForAgendaJobByOrgId,
   getEnvironmentIdsFromOrg,
 } from "back-end/src/services/organizations";
 import { getEnvironments } from "back-end/src/util/organization.util";
+import { getCollection } from "back-end/src/util/mongo.util";
 import { ApiReqContext } from "back-end/types/api";
 import { deriveLiveFeatureEventEnvironments } from "back-end/src/events/eventEnvironments";
-import { determineNextSafeRolloutSnapshotAttempt } from "back-end/src/enterprise/saferollouts/safeRolloutUtils";
 import {
   createVercelExperimentationItemFromFeature,
   updateVercelExperimentationItemFromFeature,
   deleteVercelExperimentationItemFromFeature,
 } from "back-end/src/services/vercel-native-integration.service";
 import { getObjectDiff } from "back-end/src/events/handlers/webhooks/event-webhooks-utils";
-import {
-  runValidateFeatureHooks,
-  runValidateFeatureRevisionHooks,
-} from "back-end/src/enterprise/sandbox/sandbox-eval";
+import { runValidateFeatureHooks } from "back-end/src/enterprise/sandbox/sandbox-eval";
 import {
   createEvent,
   hasPreviousObject,
@@ -109,75 +68,18 @@ import {
 } from "./EventModel";
 import {
   addLinkedFeatureToExperiment,
-  clearPendingFeatureDraftsForRevision,
-  getExperimentById,
   getExperimentMapForFeature,
   removeLinkedFeatureFromExperiment,
-  updateExperiment,
 } from "./ExperimentModel";
 import {
-  cancelScheduledPublishesForFeature,
   createInitialRevision,
   createRevisionFromLegacyDraft,
   deleteAllRevisionsForFeature,
   getRevision,
-  hasPublishLockingScheduledSibling,
-  markRevisionAsPublished,
-  computeRevisionPublishChanges,
-  updateRevision,
-  createRevision,
 } from "./FeatureRevisionModel";
+import { MakeModelClass } from "./BaseModel";
 
-const featureSchema = new mongoose.Schema({
-  id: String,
-  archived: Boolean,
-  description: String,
-  organization: String,
-  nextScheduledUpdate: Date,
-  owner: String,
-  project: String,
-  dateCreated: Date,
-  dateUpdated: Date,
-  version: Number,
-  valueType: String,
-  defaultValue: String,
-  environments: [String],
-  tags: [String],
-  // `rules` and `environmentSettings` are declared Mixed intentionally —
-  // validation lives in Zod schemas (shared/validators/features.ts) and
-  // Mongoose's default strict mode would silently drop v2 fields
-  // (`allEnvironments`, `environments`) not declared in a sub-schema.
-  rules: {},
-  prerequisites: [
-    {
-      _id: false,
-      id: String,
-      condition: String,
-    },
-  ],
-  environmentSettings: {},
-  draft: {},
-  legacyDraftMigrated: Boolean,
-  revision: {},
-  linkedExperiments: [String],
-  jsonSchema: {},
-  neverStale: Boolean,
-  customFields: {},
-  holdout: {
-    id: String,
-    value: String,
-  },
-});
-
-featureSchema.index({ id: 1, organization: 1 }, { unique: true });
-featureSchema.index({ organization: 1, project: 1 });
-
-type FeatureDocument = mongoose.Document & LegacyFeatureInterface;
-
-export const FeatureModel = mongoose.model<LegacyFeatureInterface>(
-  "Feature",
-  featureSchema,
-);
+const COLLECTION_NAME = "features";
 
 /**
  * JIT-migration chokepoint for features on read. Discriminates v0 / v1 / v2
@@ -386,22 +288,13 @@ function scrubEnvRules<T>(envSettings: Record<string, T>): Record<string, T> {
   return out;
 }
 
-// Exported for round-trip integration tests.
-export const toInterface = (
-  doc: FeatureDocument,
-  context: ReqContext | ApiReqContext,
-): FeatureInterface => {
-  const raw = omit(doc.toJSON<FeatureDocument>(), ["__v", "_id"]);
-  return migrateRawFeatureToV2(raw, context);
-};
-
 // ---------------------------------------------------------------------------
 // Write chokepoint
 // ---------------------------------------------------------------------------
 // Normalize a feature-write payload to the v2 on-disk shape: strip `rules`
 // from each env object, leave everything else alone. Without this scrub, stale
 // `env.rules` would cause the next read to mis-classify the doc as v1 and
-// re-flatten. Use for all $set payloads on FeatureModel writes.
+// re-flatten. Use for all $set payloads on feature writes.
 export function buildFeatureUpdate<
   T extends {
     environmentSettings?: Record<
@@ -452,325 +345,6 @@ export function buildFeatureUpdate<
   }
 
   return next;
-}
-
-export async function getAllFeatures(
-  context: ReqContext | ApiReqContext,
-  {
-    projects,
-    includeArchived = false,
-  }: { projects?: string[]; includeArchived?: boolean } = {},
-): Promise<FeatureInterface[]> {
-  const q: FilterQuery<FeatureDocument> = { organization: context.org.id };
-  if (projects && projects.length === 1) {
-    q.project = projects[0];
-  } else if (projects && projects.length > 1) {
-    q.project = { $in: projects };
-  }
-
-  if (!includeArchived) {
-    q.archived = { $ne: true };
-  }
-
-  const features = (await FeatureModel.find(q)).map((m) =>
-    toInterface(m, context),
-  );
-
-  return features.filter((feature) =>
-    context.permissions.canReadSingleProjectResource(feature.project),
-  );
-}
-
-/**
- * Lightweight sibling of {@link getAllFeatures} for the stale-detection and
- * dependents graph. Skips Mongoose hydration via `.lean()` and projects out
- * heavy fields the graph does not read. Same migration + permission filter as
- * `getAllFeatures`, so results are interchangeable for any caller that only
- * needs the dependency graph.
- *
- * NOTE: the return type is `FeatureInterface[]`, but the projected-out fields
- * (`description` / `jsonSchema` / `customFields` / legacy `draft`) will be
- * absent at runtime. Only use this for graph/stale callers that don't read
- * those fields — reach for `getAllFeatures` if you need a complete feature.
- */
-export async function getAllFeaturesForStaleGraph(
-  context: ReqContext | ApiReqContext,
-  { includeArchived = false }: { includeArchived?: boolean } = {},
-): Promise<FeatureInterface[]> {
-  const q = featureListQuery(context.org.id, { includeArchived });
-
-  const docs = await FeatureModel.find(q, {
-    description: 0,
-    jsonSchema: 0,
-    customFields: 0,
-    draft: 0,
-  }).lean<LegacyFeatureInterface[]>();
-
-  const features = docs.map((raw) =>
-    migrateRawFeatureToV2(
-      omit(raw, ["__v", "_id"]) as LegacyFeatureInterface,
-      context,
-    ),
-  );
-
-  return features.filter((feature) =>
-    context.permissions.canReadSingleProjectResource(feature.project),
-  );
-}
-
-function featureListQuery(
-  orgId: string,
-  opts: { project?: string; projectIds?: string[]; includeArchived?: boolean },
-): FilterQuery<FeatureDocument> {
-  const { project, projectIds, includeArchived = false } = opts;
-  return {
-    organization: orgId,
-    ...(project != null
-      ? { project }
-      : projectIds != null
-        ? { project: { $in: projectIds } }
-        : {}),
-    ...(includeArchived ? {} : { archived: { $ne: true } }),
-  };
-}
-
-export async function getFeaturesPage(
-  context: ReqContext | ApiReqContext,
-  {
-    project,
-    projectIds,
-    includeArchived = false,
-    limit = 10,
-    offset = 0,
-  }: {
-    project?: string;
-    projectIds?: string[];
-    includeArchived?: boolean;
-    limit?: number;
-    offset?: number;
-  },
-): Promise<FeatureInterface[]> {
-  if (projectIds?.length === 0) return [];
-  const q = featureListQuery(context.org.id, {
-    project,
-    projectIds,
-    includeArchived,
-  });
-  const docs = await FeatureModel.find(q)
-    .sort({ _id: 1 })
-    .skip(offset)
-    .limit(limit);
-  return docs
-    .map((m) => toInterface(m, context))
-    .filter((feature) =>
-      context.permissions.canReadSingleProjectResource(feature.project),
-    );
-}
-
-export async function countFeatures(
-  context: ReqContext | ApiReqContext,
-  {
-    project,
-    projectIds,
-    includeArchived = false,
-  }: { project?: string; projectIds?: string[]; includeArchived?: boolean },
-): Promise<number> {
-  if (projectIds?.length === 0) return 0;
-  return FeatureModel.countDocuments(
-    featureListQuery(context.org.id, { project, projectIds, includeArchived }),
-  );
-}
-
-export async function hasArchivedFeatures(
-  context: ReqContext | ApiReqContext,
-  project?: string,
-): Promise<boolean> {
-  const q: FilterQuery<FeatureDocument> = {
-    organization: context.org.id,
-    archived: true,
-  };
-  if (project) {
-    q.project = project;
-  }
-
-  const f = await FeatureModel.findOne(q);
-  return !!f;
-}
-
-export async function getFeature(
-  context: ReqContext | ApiReqContext,
-  id: string,
-): Promise<FeatureInterface | null> {
-  const feature = await FeatureModel.findOne({
-    organization: context.org.id,
-    id,
-  });
-  if (!feature) return null;
-
-  return context.permissions.canReadSingleProjectResource(feature.project)
-    ? toInterface(feature, context)
-    : null;
-}
-
-export async function migrateDraft(
-  context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
-) {
-  if (!feature.legacyDraft || feature.legacyDraftMigrated) return null;
-
-  try {
-    const draft = await createRevisionFromLegacyDraft(context, feature);
-    await FeatureModel.updateOne(
-      {
-        organization: feature.organization,
-        id: feature.id,
-      },
-      {
-        $set: {
-          legacyDraftMigrated: true,
-        },
-      },
-    );
-    return draft;
-  } catch (e) {
-    logger.error(e, "Error migrating old feature draft");
-  }
-  return null;
-}
-
-export async function getFeaturesByIds(
-  context: ReqContext | ApiReqContext,
-  ids: string[],
-): Promise<FeatureInterface[]> {
-  if (!ids.length) return [];
-  const features = (
-    await FeatureModel.find({ organization: context.org.id, id: { $in: ids } })
-  ).map((m) => toInterface(m, context));
-
-  return features.filter((feature) =>
-    context.permissions.canReadSingleProjectResource(feature.project),
-  );
-}
-
-// Returns id -> project for every feature that exists in the org, regardless of
-// the caller's read permission. Intended for permission decisions where missing
-// (inaccessible) and non-existent features must be distinguished — do not use it
-// to return feature data to the caller.
-export async function getFeatureProjectsByIds(
-  context: ReqContext | ApiReqContext,
-  ids: string[],
-): Promise<Map<string, string | undefined>> {
-  if (!ids.length) return new Map();
-  const features = await FeatureModel.find(
-    { organization: context.org.id, id: { $in: ids } },
-    { id: 1, project: 1, _id: 0 },
-  );
-  return new Map(features.map((f) => [f.id, f.project || undefined]));
-}
-
-export async function createFeature(
-  context: ReqContext | ApiReqContext,
-  data: FeatureInterface,
-) {
-  const { org } = context;
-
-  const linkedExperiments = getLinkedExperiments(data);
-
-  const featureToCreate = buildFeatureUpdate({
-    ...data,
-    linkedExperiments,
-  });
-
-  if (Array.isArray(featureToCreate.rules)) {
-    const { rules: dedupedRules, collisions } = ensureUniqueRuleIds(
-      featureToCreate.rules as FeatureRule[],
-    );
-    if (collisions.length > 0) {
-      logger.warn(
-        { featureId: data.id, collisions },
-        "Duplicate rule ids auto-suffixed on feature create",
-      );
-      featureToCreate.rules = dedupedRules;
-    }
-  }
-
-  // Run any custom hooks for this feature
-  await runValidateFeatureHooks({
-    context,
-    feature: featureToCreate,
-    original: null,
-  });
-
-  const feature = await FeatureModel.create(featureToCreate);
-
-  // Historically, we haven't properly removed revisions when deleting a feature
-  // So, clean up any conflicting revisions first before creating a new one
-  await deleteAllRevisionsForFeature(org.id, feature.id);
-
-  await createInitialRevision(
-    context,
-    toInterface(feature, context),
-    context.auditUser,
-    getEnvironmentIdsFromOrg(org),
-  );
-
-  if (linkedExperiments.length > 0) {
-    await Promise.all(
-      linkedExperiments.map(async (exp) => {
-        await addLinkedFeatureToExperiment(context, exp, data.id);
-      }),
-    );
-  }
-
-  onFeatureCreate(context, toInterface(feature, context)).catch((e) => {
-    logger.error(e, "Error refreshing SDK Payload on feature create");
-  });
-}
-
-export async function deleteFeature(
-  context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
-) {
-  await FeatureModel.deleteOne({
-    organization: context.org.id,
-    id: feature.id,
-  });
-  await deleteAllRevisionsForFeature(context.org.id, feature.id);
-  await context.models.featureRevisionLogs.deleteAllByFeature(feature);
-
-  if (feature.linkedExperiments) {
-    await Promise.all(
-      feature.linkedExperiments.map(async (exp) => {
-        await removeLinkedFeatureFromExperiment(context, exp, feature.id);
-      }),
-    );
-  }
-
-  onFeatureDelete(context, feature).catch((e) => {
-    logger.error(e, "Error refreshing SDK Payload on feature delete");
-  });
-}
-
-/**
- * Deletes all features belonging to a project
- * @param projectId
- * @param organization
- */
-export async function deleteAllFeaturesForAProject({
-  projectId,
-  context,
-}: {
-  projectId: string;
-  context: ReqContext | ApiReqContext;
-}) {
-  const featuresToDelete = await FeatureModel.find({
-    organization: context.org.id,
-    project: projectId,
-  });
-
-  for (const feature of featuresToDelete) {
-    await deleteFeature(context, toInterface(feature, context));
-  }
 }
 
 export const createFeatureEvent = async <
@@ -937,266 +511,831 @@ export const logFeatureDeletedEvent = async (
     },
   });
 
-async function onFeatureCreate(
-  context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
-) {
-  queueSDKPayloadRefresh({
-    context,
-    payloadKeys: getAffectedSDKPayloadKeys(
-      [feature],
-      getEnvironmentIdsFromOrg(context.org),
-    ),
-    auditContext: {
-      event: "created",
-      model: "feature",
-      id: feature.id,
+// Feature ids are user-chosen keys, so `id` is required on create (the base
+// CreateProps marks it optional to support generated ids).
+export type CreateFeatureProps = CreateProps<FeatureInterface> & {
+  id: string;
+};
+
+const BaseClass = MakeModelClass({
+  schema: featureInterface,
+  collectionName: COLLECTION_NAME,
+  // Feature ids are user-chosen keys supplied on create (no idPrefix); the
+  // base {id, organization} unique index enforces per-org uniqueness, same as
+  // the legacy Mongoose index.
+  additionalIndexes: [
+    {
+      fields: { organization: 1, project: 1 },
     },
-  });
+  ],
+});
 
-  await logFeatureCreatedEvent(context, feature);
-
-  if (context.org.isVercelIntegration)
-    await createVercelExperimentationItemFromFeature({
-      feature,
-      organization: context.org,
-    });
-}
-
-async function onFeatureDelete(
-  context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
-) {
-  queueSDKPayloadRefresh({
-    context,
-    payloadKeys: getAffectedSDKPayloadKeys(
-      [feature],
-      getEnvironmentIdsFromOrg(context.org),
-    ),
-    auditContext: {
-      event: "deleted",
-      model: "feature",
-      id: feature.id,
-    },
-  });
-
-  await logFeatureDeletedEvent(context, feature);
-
-  if (context.org.isVercelIntegration)
-    await deleteVercelExperimentationItemFromFeature({
-      feature,
-      organization: context.org,
-    });
-}
-
-export async function onFeatureUpdate(
-  context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
-  updatedFeature: FeatureInterface,
-  skipRefreshForProject?: string,
-) {
-  queueSDKPayloadRefresh({
-    context,
-    payloadKeys: getSDKPayloadKeysByDiff(
-      feature,
-      updatedFeature,
-      getEnvironmentIdsFromOrg(context.org),
-    ),
-    skipRefreshForProject,
-    auditContext: {
-      event: "updated",
-      model: "feature",
-      id: feature.id,
-    },
-  });
-
-  // Don't fire webhooks if only `dateUpdated` changes (ex: creating/modifying a unpublished draft)
-  if (
-    !isEqual(
-      omit(feature, ["dateUpdated"]),
-      omit(updatedFeature, ["dateUpdated"]),
-    )
-  ) {
-    // Event-based webhooks
-    await logFeatureUpdatedEvent(context, feature, updatedFeature);
+export class FeatureModel extends BaseClass {
+  protected canRead(doc: FeatureInterface): boolean {
+    return this.context.permissions.canReadSingleProjectResource(doc.project);
+  }
+  protected canCreate(doc: FeatureInterface): boolean {
+    return this.context.permissions.canCreateFeature(doc);
+  }
+  protected canUpdate(
+    existing: FeatureInterface,
+    updates: UpdateProps<FeatureInterface>,
+  ): boolean {
+    return this.context.permissions.canUpdateFeature(existing, updates);
+  }
+  protected canDelete(doc: FeatureInterface): boolean {
+    return this.context.permissions.canDeleteFeature(doc);
   }
 
-  if (context.org.isVercelIntegration)
-    await updateVercelExperimentationItemFromFeature({
-      feature: updatedFeature,
-      organization: context.org,
+  protected migrate(legacyDoc: unknown): FeatureInterface {
+    return migrateRawFeatureToV2(
+      legacyDoc as LegacyFeatureInterface,
+      this.context,
+    );
+  }
+
+  protected async customValidation(
+    doc: FeatureInterface,
+    previousDoc?: FeatureInterface,
+  ) {
+    await runValidateFeatureHooks({
+      context: this.context,
+      feature: doc,
+      original: previousDoc ?? null,
     });
-}
+  }
 
-export async function updateFeature(
-  context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
-  updates: Partial<FeatureInterface>,
-): Promise<FeatureInterface> {
-  const allUpdates = {
-    ...updates,
-    dateUpdated: new Date(),
-  };
-  // Used only for hooks and linkedExperiment derivation; the post-write
-  // value is re-read from Mongo below.
-  const projected = {
-    ...feature,
-    ...allUpdates,
-  };
+  // ---------------------------------------------------------------------------
+  // Reads
+  // ---------------------------------------------------------------------------
 
-  // Refresh linkedExperiments if needed
-  const linkedExperiments = getLinkedExperiments(projected);
-  const experimentsAdded = new Set<string>();
-  if (!isEqual(linkedExperiments, feature.linkedExperiments)) {
-    allUpdates.linkedExperiments = linkedExperiments;
-    projected.linkedExperiments = linkedExperiments;
+  public getAll(
+    options: { projects?: string[]; includeArchived?: boolean } = {},
+  ): Promise<FeatureInterface[]> {
+    return this._find(this.listQuery(options));
+  }
 
-    // New experiments this feature was added to
-    linkedExperiments.forEach((exp) => {
-      if (!feature.linkedExperiments?.includes(exp)) {
-        experimentsAdded.add(exp);
+  /**
+   * Lightweight sibling of {@link getAll} for the stale-detection and
+   * dependents graph. Projects out heavy fields the graph does not read.
+   * Same migration + permission filter as `getAll`, so results are
+   * interchangeable for any caller that only needs the dependency graph.
+   *
+   * NOTE: the return type is `FeatureInterface[]`, but the projected-out fields
+   * (`description` / `jsonSchema` / `customFields` / legacy `draft`) will be
+   * absent at runtime. Only use this for graph/stale callers that don't read
+   * those fields — reach for `getAll` if you need a complete feature.
+   */
+  public getAllForStaleGraph({
+    includeArchived = false,
+  }: { includeArchived?: boolean } = {}): Promise<FeatureInterface[]> {
+    return this._find(this.listQuery({ includeArchived }), {
+      // `draft` is the on-disk name of the legacy draft field.
+      projection: {
+        description: 0,
+        jsonSchema: 0,
+        customFields: 0,
+        draft: 0,
+      } as Partial<Record<keyof FeatureInterface, 0 | 1>>,
+    });
+  }
+
+  private listQuery(opts: {
+    projects?: string[];
+    project?: string;
+    includeArchived?: boolean;
+  }) {
+    const { projects, project, includeArchived = false } = opts;
+    return {
+      ...(project != null
+        ? { project }
+        : projects && projects.length === 1
+          ? { project: projects[0] }
+          : projects != null
+            ? { project: { $in: projects } }
+            : {}),
+      ...(includeArchived ? {} : { archived: { $ne: true } }),
+    };
+  }
+
+  // DB-side pagination — the default `_find` pages in memory after fetching
+  // every matching doc, which is too heavy for the features list endpoint.
+  public async getPage({
+    project,
+    projectIds,
+    includeArchived = false,
+    limit = 10,
+    offset = 0,
+  }: {
+    project?: string;
+    projectIds?: string[];
+    includeArchived?: boolean;
+    limit?: number;
+    offset?: number;
+  }): Promise<FeatureInterface[]> {
+    if (projectIds?.length === 0) return [];
+    const q = {
+      organization: this.context.org.id,
+      ...this.listQuery({ project, projects: projectIds, includeArchived }),
+    };
+    const docs = await this._dangerousGetCollection()
+      .find(q)
+      .sort({ _id: 1 })
+      .skip(offset)
+      .limit(limit)
+      .toArray();
+    const features = docs.map((d) => this.migrate(omit(d, ["__v", "_id"])));
+    return this.filterByReadPermissions(features);
+  }
+
+  public async count({
+    project,
+    projectIds,
+    includeArchived = false,
+  }: {
+    project?: string;
+    projectIds?: string[];
+    includeArchived?: boolean;
+  }): Promise<number> {
+    if (projectIds?.length === 0) return 0;
+    return this._countDocuments(
+      this.listQuery({ project, projects: projectIds, includeArchived }),
+    );
+  }
+
+  public async hasArchivedFeatures(project?: string): Promise<boolean> {
+    const doc = await this._dangerousGetCollection().findOne(
+      {
+        organization: this.context.org.id,
+        archived: true,
+        ...(project ? { project } : {}),
+      },
+      { projection: { _id: 1 } },
+    );
+    return !!doc;
+  }
+
+  public async hasNonDemoFeature(): Promise<boolean> {
+    const demoProjectId = getDemoDatasourceProjectIdForOrganization(
+      this.context.org.id,
+    );
+    const doc = await this._dangerousGetCollection().findOne(
+      {
+        organization: this.context.org.id,
+        project: { $ne: demoProjectId },
+      },
+      { projection: { _id: 1 } },
+    );
+    return !!doc;
+  }
+
+  // Returns id -> project for every feature that exists in the org, regardless of
+  // the caller's read permission. Intended for permission decisions where missing
+  // (inaccessible) and non-existent features must be distinguished — do not use it
+  // to return feature data to the caller.
+  public async getProjectsByIds(
+    ids: string[],
+  ): Promise<Map<string, string | undefined>> {
+    if (!ids.length) return new Map();
+    const docs = await this._dangerousGetCollection()
+      .find(
+        { organization: this.context.org.id, id: { $in: ids } },
+        { projection: { id: 1, project: 1, _id: 0 } },
+      )
+      .toArray();
+    return new Map(
+      docs.map((f) => [f.id as string, (f.project as string) || undefined]),
+    );
+  }
+
+  public async getMetaInfo(
+    opts: {
+      includeDefaultValue?: boolean;
+      project?: string;
+      ids?: string[];
+    } = {},
+  ): Promise<FeatureMetaInfo[]> {
+    const { includeDefaultValue = false, project, ids } = opts;
+
+    const query: Record<string, unknown> = {
+      organization: this.context.org.id,
+    };
+    if (project) {
+      query.project = project;
+    }
+    if (ids?.length) {
+      query.id = { $in: ids };
+    }
+
+    const projection: Record<string, number> = {
+      id: 1,
+      project: 1,
+      archived: 1,
+      description: 1,
+      dateCreated: 1,
+      dateUpdated: 1,
+      tags: 1,
+      owner: 1,
+      valueType: 1,
+      version: 1,
+      linkedExperiments: 1,
+      neverStale: 1,
+      "jsonSchema.enabled": 1,
+      revision: 1,
+      prerequisites: 1,
+      "rules.prerequisites": 1,
+      "rules.savedGroups": 1,
+      environmentSettings: 1,
+    };
+    if (includeDefaultValue) {
+      projection.defaultValue = 1;
+    }
+
+    const features = (await this._dangerousGetCollection()
+      .find(query, { projection })
+      .toArray()) as unknown as LegacyFeatureInterface[];
+
+    return features
+      .filter((f) =>
+        this.context.permissions.canReadSingleProjectResource(f.project),
+      )
+      .map((f) => {
+        const doc = f as unknown as Record<string, unknown>;
+        const rules = doc.rules as
+          | { prerequisites?: unknown[]; savedGroups?: unknown[] }[]
+          | undefined;
+        const envSettings = doc.environmentSettings as
+          | Record<string, { prerequisites?: unknown[] }>
+          | undefined;
+        const topPrereqs = doc.prerequisites as unknown[] | undefined;
+
+        const hasPrerequisites =
+          (topPrereqs?.length ?? 0) > 0 ||
+          (rules ?? []).some((r) => (r.prerequisites?.length ?? 0) > 0) ||
+          Object.values(envSettings ?? {}).some(
+            (e) => (e.prerequisites?.length ?? 0) > 0,
+          );
+
+        const hasSavedGroups = (rules ?? []).some(
+          (r) => (r.savedGroups?.length ?? 0) > 0,
+        );
+
+        return {
+          id: f.id,
+          project: f.project,
+          archived: f.archived,
+          description: f.description,
+          dateCreated: f.dateCreated,
+          dateUpdated: f.dateUpdated,
+          tags: f.tags,
+          owner: f.owner,
+          valueType: f.valueType,
+          version: f.version,
+          linkedExperiments: f.linkedExperiments,
+          neverStale: f.neverStale,
+          hasPrerequisites,
+          hasSavedGroups,
+          revision: doc.revision as FeatureMetaInfo["revision"],
+          ...(includeDefaultValue && { defaultValue: f.defaultValue ?? "" }),
+        };
+      });
+  }
+
+  public async getMetaInfoByIds(ids: string[]): Promise<FeatureMetaInfo[]> {
+    if (!ids.length) return [];
+
+    const features = (await this._dangerousGetCollection()
+      .find(
+        { organization: this.context.org.id, id: { $in: ids } },
+        {
+          projection: {
+            id: 1,
+            project: 1,
+            archived: 1,
+            description: 1,
+            dateCreated: 1,
+            dateUpdated: 1,
+            tags: 1,
+            owner: 1,
+            valueType: 1,
+            version: 1,
+            linkedExperiments: 1,
+            neverStale: 1,
+            "jsonSchema.enabled": 1,
+            revision: 1,
+          },
+        },
+      )
+      .toArray()) as unknown as LegacyFeatureInterface[];
+
+    return features
+      .filter((f) =>
+        this.context.permissions.canReadSingleProjectResource(f.project),
+      )
+      .map((f) => ({
+        id: f.id,
+        project: f.project,
+        archived: f.archived,
+        description: f.description,
+        dateCreated: f.dateCreated,
+        dateUpdated: f.dateUpdated,
+        tags: f.tags,
+        owner: f.owner,
+        valueType: f.valueType,
+        version: f.version,
+        linkedExperiments: f.linkedExperiments,
+        neverStale: f.neverStale,
+        revision: (f as unknown as Record<string, unknown>)
+          .revision as FeatureMetaInfo["revision"],
+      }));
+  }
+
+  public async getEnvStatus(ids?: string[]): Promise<
+    {
+      id: string;
+      environmentSettings: FeatureInterface["environmentSettings"];
+    }[]
+  > {
+    const q: Record<string, unknown> = { organization: this.context.org.id };
+    if (ids && ids.length > 0) {
+      q.id = { $in: ids };
+    }
+
+    // Push project-level read restrictions into the query to avoid fetching
+    // documents that will be filtered out anyway.
+    const allowedProjects =
+      this.context.permissions.getProjectsWithPermission("readData");
+    if (allowedProjects !== null) {
+      if (allowedProjects.length === 0) return [];
+      // Also include features with no project — they're globally accessible
+      q.$or = [
+        { project: { $in: allowedProjects } },
+        { project: { $in: ["", null] } },
+      ];
+    }
+
+    const docs = await this._dangerousGetCollection()
+      .find(q, { projection: { id: 1, environmentSettings: 1 } })
+      .toArray();
+
+    return docs.map((f) => ({
+      id: f.id as string,
+      // This getter only reads `enabled`, so v1 vs v2 env shape doesn't matter.
+      environmentSettings: applyEnvironmentInheritance(
+        this.context.org.settings?.environments || [],
+        (f.environmentSettings || {}) as Record<string, FeatureEnvironment>,
+      ) as FeatureInterface["environmentSettings"],
+    }));
+  }
+
+  // Cross-org cron scan for the scheduled-features job. Builds a per-org job
+  // context so each doc runs through the same JIT migration as normal reads.
+  public static async dangerousGetScheduledFeaturesToUpdate(): Promise<
+    FeatureInterface[]
+  > {
+    const docs = await getCollection<LegacyFeatureInterface>(COLLECTION_NAME)
+      .find({
+        nextScheduledUpdate: {
+          $exists: true,
+          $ne: null,
+          $lt: new Date(),
+        },
+      })
+      .toArray();
+    const orgIds = Array.from(new Set(docs.map((f) => f.organization)));
+    const jobContextsByOrg: Record<string, ApiReqContext> = {};
+    await Promise.all(
+      orgIds.map(async (orgId) => {
+        jobContextsByOrg[orgId] = await getContextForAgendaJobByOrgId(orgId);
+      }),
+    );
+    return docs.map((d) =>
+      migrateRawFeatureToV2(
+        omit(d, ["__v", "_id"]) as LegacyFeatureInterface,
+        jobContextsByOrg[d.organization],
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Writes
+  // ---------------------------------------------------------------------------
+
+  public async create(data: CreateFeatureProps): Promise<FeatureInterface> {
+    const featureToCreate = buildFeatureUpdate({
+      ...data,
+      linkedExperiments: getLinkedExperiments(data),
+    });
+
+    if (Array.isArray(featureToCreate.rules)) {
+      const { rules: dedupedRules, collisions } = ensureUniqueRuleIds(
+        featureToCreate.rules as FeatureRule[],
+      );
+      if (collisions.length > 0) {
+        logger.warn(
+          { featureId: data.id, collisions },
+          "Duplicate rule ids auto-suffixed on feature create",
+        );
+        featureToCreate.rules = dedupedRules;
+      }
+    }
+
+    const doc = await super.create(featureToCreate);
+    // Same JIT pipeline as a read, so callers see canonical state
+    // (e.g. environment inheritance applied).
+    return this.migrate({ ...doc });
+  }
+
+  public update(
+    existing: FeatureInterface,
+    updates: UpdateProps<FeatureInterface>,
+  ): Promise<FeatureInterface> {
+    return super
+      .update(existing, this.prepareUpdates(existing, updates))
+      .then((doc) => this.migrate({ ...doc }));
+  }
+
+  // Same as `update` but skips the canUpdate permission check. For paths whose
+  // authoritative permission is checked by the caller and isn't `manageFeatures`
+  // (env toggles + revision publishes check the env-scoped `publishFeatures`)
+  // and for system-driven writes running without a user.
+  public dangerousUpdateBypassPermission(
+    existing: FeatureInterface,
+    updates: UpdateProps<FeatureInterface>,
+  ): Promise<FeatureInterface> {
+    return super
+      .dangerousUpdateBypassPermission(
+        existing,
+        this.prepareUpdates(existing, updates),
+      )
+      .then((doc) => this.migrate({ ...doc }));
+  }
+
+  private prepareUpdates(
+    existing: FeatureInterface,
+    updates: UpdateProps<FeatureInterface>,
+  ): UpdateProps<FeatureInterface> {
+    const allUpdates = { ...updates };
+
+    // Refresh linkedExperiments if needed
+    const projected = { ...existing, ...allUpdates } as FeatureInterface;
+    const linkedExperiments = getLinkedExperiments(projected);
+    if (!isEqual(linkedExperiments, existing.linkedExperiments)) {
+      allUpdates.linkedExperiments = linkedExperiments;
+    }
+
+    const normalizedUpdates = buildFeatureUpdate(allUpdates);
+
+    if (Array.isArray(normalizedUpdates.rules)) {
+      const { rules: dedupedRules, collisions } = ensureUniqueRuleIds(
+        normalizedUpdates.rules as FeatureRule[],
+      );
+      if (collisions.length > 0) {
+        logger.warn(
+          { featureId: existing.id, collisions },
+          "Duplicate rule ids auto-suffixed on feature update",
+        );
+        normalizedUpdates.rules = dedupedRules;
+      }
+    }
+
+    return normalizedUpdates;
+  }
+
+  public async toggleMultipleEnvironments(
+    feature: FeatureInterface,
+    toggles: Record<string, boolean>,
+  ): Promise<FeatureInterface> {
+    const validEnvs = new Set(getEnvironmentIdsFromOrg(this.context.org));
+
+    let featureCopy = cloneDeep(feature);
+    let hasChanges = false;
+    Object.keys(toggles).forEach((env) => {
+      if (!validEnvs.has(env)) {
+        throw new Error("Invalid environment: " + env);
+      }
+      const state = toggles[env];
+      const currentState = feature.environmentSettings?.[env]?.enabled ?? false;
+      if (currentState !== state) {
+        hasChanges = true;
+        featureCopy = setEnvironmentSettings(featureCopy, env, {
+          enabled: state,
+        });
       }
     });
+
+    // If there are changes we need to apply.
+    // Callers authorize toggles with the env-scoped publishFeatures permission,
+    // so skip the model-level manageFeatures check.
+    if (hasChanges) {
+      return this.dangerousUpdateBypassPermission(feature, {
+        environmentSettings: featureCopy.environmentSettings,
+      });
+    }
+
+    return featureCopy;
   }
 
-  await runValidateFeatureHooks({
-    context,
-    feature: projected,
-    original: feature,
-  });
-
-  // Hygiene: when persisting a new top-level v2 `rules` array, also force-scrub
-  // any legacy `environmentSettings.{env}.rules` from the doc. The JIT read
-  // migration trusts top-level v2 rules over env.rules now (so this is no
-  // longer load-bearing for correctness), but leaving the legacy key around
-  // bloats the doc, confuses direct-mongo readers, and would re-introduce the
-  // shadow if the JIT routing ever regressed. Inject a scrubbed
-  // `environmentSettings` payload so `buildFeatureUpdate`'s scrub path
-  // overwrites them.
-  if (
-    Array.isArray(allUpdates.rules) &&
-    allUpdates.environmentSettings === undefined &&
-    feature.environmentSettings
-  ) {
-    allUpdates.environmentSettings = { ...feature.environmentSettings };
+  public async toggleEnvironment(
+    feature: FeatureInterface,
+    environment: string,
+    state: boolean,
+  ): Promise<FeatureInterface> {
+    return await this.toggleMultipleEnvironments(feature, {
+      [environment]: state,
+    });
   }
 
-  const normalizedUpdates = buildFeatureUpdate(allUpdates);
+  public async setJsonSchema(
+    feature: FeatureInterface,
+    def: Omit<JSONSchemaDef, "date">,
+  ): Promise<FeatureInterface> {
+    // Validate Simple Schema (sanity check)
+    if (def.schemaType === "simple" && def.simple) {
+      simpleSchemaValidator.parse(def.simple);
+    }
 
-  if (Array.isArray(normalizedUpdates.rules)) {
-    const { rules: dedupedRules, collisions } = ensureUniqueRuleIds(
-      normalizedUpdates.rules as FeatureRule[],
+    return await this.update(feature, {
+      jsonSchema: { ...def, date: new Date() },
+    });
+  }
+
+  public async toggleNeverStale(
+    feature: FeatureInterface,
+    neverStale: boolean,
+  ): Promise<FeatureInterface> {
+    return await this.update(feature, { neverStale });
+  }
+
+  public async deleteAllForProject(projectId: string) {
+    const featuresToDelete = await this._find(
+      { project: projectId },
+      { bypassReadPermissionChecks: true },
     );
-    if (collisions.length > 0) {
-      logger.warn(
-        { featureId: feature.id, collisions },
-        "Duplicate rule ids auto-suffixed on feature update",
-      );
-      normalizedUpdates.rules = dedupedRules;
+    for (const feature of featuresToDelete) {
+      await this.delete(feature);
     }
   }
 
-  await FeatureModel.updateOne(
-    { organization: feature.organization, id: feature.id },
-    {
-      $set: normalizedUpdates,
-    },
-  );
+  public async migrateDraft(feature: FeatureInterface) {
+    if (!feature.legacyDraft || feature.legacyDraftMigrated) return null;
 
-  if (experimentsAdded.size > 0) {
-    await Promise.all(
-      [...experimentsAdded].map(async (exp) => {
-        await addLinkedFeatureToExperiment(context, exp, feature.id);
-      }),
+    try {
+      const draft = await createRevisionFromLegacyDraft(this.context, feature);
+      await this._dangerousGetCollection().updateOne(
+        { organization: this.context.org.id, id: feature.id },
+        { $set: { legacyDraftMigrated: true } },
+      );
+      return draft;
+    } catch (e) {
+      logger.error(e, "Error migrating old feature draft");
+    }
+    return null;
+  }
+
+  // Targeted write for the scheduled-features cron; bypasses the update hooks
+  // so this system-driven change doesn't refresh SDK payloads or fire events.
+  public async updateNextScheduledDate(
+    feature: FeatureInterface,
+    nextScheduledUpdate: Date | null,
+  ): Promise<FeatureInterface> {
+    const dateUpdated = new Date();
+    await this._dangerousGetCollection().updateOne(
+      { organization: this.context.org.id, id: feature.id },
+      { $set: { nextScheduledUpdate, dateUpdated } },
+    );
+    return {
+      ...feature,
+      nextScheduledUpdate: nextScheduledUpdate ?? undefined,
+      dateUpdated,
+    };
+  }
+
+  public async addLinkedExperiment(
+    feature: FeatureInterface,
+    experimentId: string,
+  ) {
+    if (feature.linkedExperiments?.includes(experimentId)) return;
+
+    await this._dangerousGetCollection().updateOne(
+      { organization: this.context.org.id, id: feature.id },
+      { $addToSet: { linkedExperiments: experimentId } },
     );
   }
 
-  // Set-then-fetch: the persisted doc flows through the same JIT pipeline as
-  // any other read, so audit/SDK/response all see identical state.
-  const persisted = await FeatureModel.findOne({
-    organization: feature.organization,
-    id: feature.id,
-  });
-  const updatedFeature = persisted
-    ? toInterface(persisted, context)
-    : projected;
+  // Bare $unset without hooks — used by the publish path, which fires its own
+  // update side-effects via the subsequent `update` call.
+  public async removeHoldout(feature: FeatureInterface) {
+    if (!feature.holdout) return;
+    await this._dangerousGetCollection().updateOne(
+      { organization: this.context.org.id, id: feature.id },
+      { $unset: { holdout: "" } },
+    );
+  }
 
-  onFeatureUpdate(context, feature, updatedFeature).catch((e) => {
-    logger.error(e, "Error refreshing SDK Payload on feature update");
-  });
+  public async removeTagFromAllFeatures(tag: string) {
+    const query = { organization: this.context.org.id, tags: tag };
 
-  return updatedFeature;
-}
+    const docs = await this._dangerousGetCollection().find(query).toArray();
+    const features = docs.map((d) => this.migrate(omit(d, ["__v", "_id"])));
 
-// Targeted write for the scheduled-features cron; skips onFeatureUpdate so
-// this system-driven change doesn't generate an audit event.
-export async function updateNextScheduledDate(
-  feature: FeatureInterface,
-  nextScheduledUpdate: Date | null,
-): Promise<FeatureInterface> {
-  const dateUpdated = new Date();
-  await FeatureModel.updateOne(
-    { organization: feature.organization, id: feature.id },
-    { $set: { nextScheduledUpdate, dateUpdated } },
-  );
-  return {
-    ...feature,
-    nextScheduledUpdate: nextScheduledUpdate ?? undefined,
-    dateUpdated,
-  };
-}
+    const pullTag: UpdateFilter<FeatureInterface> = { tags: tag };
+    await this._dangerousGetCollection().updateMany(query, {
+      $pull: pullTag,
+    });
 
-export async function addLinkedExperiment(
-  feature: FeatureInterface,
-  experimentId: string,
-) {
-  if (feature.linkedExperiments?.includes(experimentId)) return;
+    features.forEach((feature) => {
+      const updatedFeature = {
+        ...feature,
+        tags: (feature.tags || []).filter((t) => t !== tag),
+      };
 
-  await FeatureModel.updateOne(
-    { organization: feature.organization, id: feature.id },
-    {
-      $addToSet: {
-        linkedExperiments: experimentId,
+      this.onFeatureUpdate(feature, updatedFeature).catch((e) => {
+        logger.error(e, "Error refreshing SDK Payload on feature update");
+      });
+    });
+  }
+
+  public async removeProjectFromAllFeatures(project: string) {
+    const query = { organization: this.context.org.id, project };
+
+    const docs = await this._dangerousGetCollection().find(query).toArray();
+    const features = docs.map((d) => this.migrate(omit(d, ["__v", "_id"])));
+
+    await this._dangerousGetCollection().updateMany(query, {
+      $set: { project: "" },
+    });
+
+    features.forEach((feature) => {
+      const updatedFeature = {
+        ...feature,
+        project: "",
+      };
+
+      this.onFeatureUpdate(feature, updatedFeature, project).catch((e) => {
+        logger.error(e, "Error refreshing SDK Payload on feature update");
+      });
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle hooks
+  // ---------------------------------------------------------------------------
+
+  protected async afterCreate(doc: FeatureInterface) {
+    const feature = this.migrate({ ...doc });
+
+    // Historically, we haven't properly removed revisions when deleting a feature
+    // So, clean up any conflicting revisions first before creating a new one
+    await deleteAllRevisionsForFeature(this.context.org.id, feature.id);
+
+    await createInitialRevision(
+      this.context,
+      feature,
+      this.context.auditUser,
+      getEnvironmentIdsFromOrg(this.context.org),
+    );
+
+    if (feature.linkedExperiments?.length) {
+      await Promise.all(
+        feature.linkedExperiments.map(async (exp) => {
+          await addLinkedFeatureToExperiment(this.context, exp, feature.id);
+        }),
+      );
+    }
+
+    this.onFeatureCreate(feature).catch((e) => {
+      logger.error(e, "Error refreshing SDK Payload on feature create");
+    });
+  }
+
+  protected async afterUpdate(
+    existing: FeatureInterface,
+    updates: UpdateProps<FeatureInterface>,
+    newDoc: FeatureInterface,
+  ) {
+    // New experiments this feature was added to
+    const experimentsAdded = (newDoc.linkedExperiments ?? []).filter(
+      (exp) => !existing.linkedExperiments?.includes(exp),
+    );
+    if (experimentsAdded.length > 0) {
+      await Promise.all(
+        experimentsAdded.map(async (exp) => {
+          await addLinkedFeatureToExperiment(this.context, exp, newDoc.id);
+        }),
+      );
+    }
+
+    const updatedFeature = this.migrate({ ...newDoc });
+    this.onFeatureUpdate(existing, updatedFeature).catch((e) => {
+      logger.error(e, "Error refreshing SDK Payload on feature update");
+    });
+  }
+
+  protected async afterDelete(doc: FeatureInterface) {
+    await deleteAllRevisionsForFeature(this.context.org.id, doc.id);
+    await this.context.models.featureRevisionLogs.deleteAllByFeature(doc);
+
+    if (doc.linkedExperiments) {
+      await Promise.all(
+        doc.linkedExperiments.map(async (exp) => {
+          await removeLinkedFeatureFromExperiment(this.context, exp, doc.id);
+        }),
+      );
+    }
+
+    this.onFeatureDelete(doc).catch((e) => {
+      logger.error(e, "Error refreshing SDK Payload on feature delete");
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Side effects (SDK payload refresh, event webhooks, Vercel sync)
+  // ---------------------------------------------------------------------------
+
+  private async onFeatureCreate(feature: FeatureInterface) {
+    queueSDKPayloadRefresh({
+      context: this.context,
+      payloadKeys: getAffectedSDKPayloadKeys(
+        [feature],
+        getEnvironmentIdsFromOrg(this.context.org),
+      ),
+      auditContext: {
+        event: "created",
+        model: "feature",
+        id: feature.id,
       },
-    },
-  );
-}
+    });
 
-export async function getScheduledFeaturesToUpdate() {
-  const features = await FeatureModel.find({
-    nextScheduledUpdate: {
-      $exists: true,
-      $ne: null,
-      $lt: new Date(),
-    },
-  });
-  const orgIds = Array.from(new Set(features.map((f) => f.organization)));
-  const jobContextsByOrg: Record<string, ApiReqContext> = {};
-  await Promise.all(
-    orgIds.map(async (orgId) => {
-      jobContextsByOrg[orgId] = await getContextForAgendaJobByOrgId(orgId);
-    }),
-  );
-  return features.map((m) => toInterface(m, jobContextsByOrg[m.organization]));
-}
+    await logFeatureCreatedEvent(this.context, feature);
 
-export async function archiveFeature(
-  context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
-  isArchived: boolean,
-) {
-  const updated = await updateFeature(context, feature, {
-    archived: isArchived,
-  });
-  // Cancel pending schedules so an archived feature can't auto-publish a draft.
-  if (isArchived) {
-    await cancelScheduledPublishesForFeature(
-      context,
-      context.org.id,
-      feature.id,
-    );
+    if (this.context.org.isVercelIntegration)
+      await createVercelExperimentationItemFromFeature({
+        feature,
+        organization: this.context.org,
+      });
   }
-  return updated;
+
+  private async onFeatureDelete(feature: FeatureInterface) {
+    queueSDKPayloadRefresh({
+      context: this.context,
+      payloadKeys: getAffectedSDKPayloadKeys(
+        [feature],
+        getEnvironmentIdsFromOrg(this.context.org),
+      ),
+      auditContext: {
+        event: "deleted",
+        model: "feature",
+        id: feature.id,
+      },
+    });
+
+    await logFeatureDeletedEvent(this.context, feature);
+
+    if (this.context.org.isVercelIntegration)
+      await deleteVercelExperimentationItemFromFeature({
+        feature,
+        organization: this.context.org,
+      });
+  }
+
+  private async onFeatureUpdate(
+    feature: FeatureInterface,
+    updatedFeature: FeatureInterface,
+    skipRefreshForProject?: string,
+  ) {
+    queueSDKPayloadRefresh({
+      context: this.context,
+      payloadKeys: getSDKPayloadKeysByDiff(
+        feature,
+        updatedFeature,
+        getEnvironmentIdsFromOrg(this.context.org),
+      ),
+      skipRefreshForProject,
+      auditContext: {
+        event: "updated",
+        model: "feature",
+        id: feature.id,
+      },
+    });
+
+    // Don't fire webhooks if only `dateUpdated` changes (ex: creating/modifying a unpublished draft)
+    if (
+      !isEqual(
+        omit(feature, ["dateUpdated"]),
+        omit(updatedFeature, ["dateUpdated"]),
+      )
+    ) {
+      // Event-based webhooks
+      await logFeatureUpdatedEvent(this.context, feature, updatedFeature);
+    }
+
+    if (this.context.org.isVercelIntegration)
+      await updateVercelExperimentationItemFromFeature({
+        feature: updatedFeature,
+        organization: this.context.org,
+      });
+  }
 }
 
 function setEnvironmentSettings(
@@ -1217,1633 +1356,4 @@ function setEnvironmentSettings(
   };
 
   return updatedFeature;
-}
-
-export async function toggleMultipleEnvironments(
-  context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
-  toggles: Record<string, boolean>,
-) {
-  const validEnvs = new Set(getEnvironmentIdsFromOrg(context.org));
-
-  let featureCopy = cloneDeep(feature);
-  let hasChanges = false;
-  Object.keys(toggles).forEach((env) => {
-    if (!validEnvs.has(env)) {
-      throw new Error("Invalid environment: " + env);
-    }
-    const state = toggles[env];
-    const currentState = feature.environmentSettings?.[env]?.enabled ?? false;
-    if (currentState !== state) {
-      hasChanges = true;
-      featureCopy = setEnvironmentSettings(featureCopy, env, {
-        enabled: state,
-      });
-    }
-  });
-
-  // If there are changes we need to apply
-  if (hasChanges) {
-    const updatedFeature = await updateFeature(context, feature, {
-      environmentSettings: featureCopy.environmentSettings,
-    });
-
-    return updatedFeature;
-  }
-
-  return featureCopy;
-}
-
-export async function toggleFeatureEnvironment(
-  context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
-  environment: string,
-  state: boolean,
-) {
-  return await toggleMultipleEnvironments(context, feature, {
-    [environment]: state,
-  });
-}
-
-/**
- * Append a rule to `revision.rules`. `envs === undefined` or an `envs` list
- * covering every applicable env collapses to `allEnvironments: true`.
- */
-export async function addFeatureRule(
-  context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
-  revision: FeatureRevisionInterface,
-  envs: string[] | undefined,
-  rule: FeatureRule,
-  user: EventUser,
-  resetReview: boolean,
-) {
-  if (!rule.id) {
-    rule.id = generateRuleId();
-  }
-  if (rule.type === "rollout" && !rule.seed) {
-    rule.seed = rule.id;
-  }
-
-  const applicableEnvs = getEnvironmentIdsFromOrg(context.org);
-  const isAllEnvs =
-    !envs || envs.length === 0 || applicableEnvs.every((e) => envs.includes(e));
-
-  const scopedRule: FeatureRule = isAllEnvs
-    ? ({ ...rule, allEnvironments: true } as FeatureRule)
-    : ({
-        ...rule,
-        allEnvironments: false,
-        environments: [...envs!],
-      } as FeatureRule);
-
-  const nextRules: FeatureRule[] = [...(revision.rules ?? []), scopedRule];
-
-  await updateRevision(
-    context,
-    feature,
-    revision,
-    { rules: nextRules },
-    {
-      user,
-      action: "add rule",
-      subject: isAllEnvs ? "to all environments" : `to ${envs!.join(", ")}`,
-      value: JSON.stringify(scopedRule),
-    },
-    resetReview,
-  );
-}
-
-// Edit a single rule by `ruleId`. `auditEnvironment` is only used for the
-// audit log subject. See `editFeatureRules` for the batch form.
-export async function editFeatureRule(
-  context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
-  revision: FeatureRevisionInterface,
-  ruleId: string,
-  updates: Partial<FeatureRule>,
-  user: EventUser,
-  resetReview: boolean,
-  auditEnvironment?: string,
-) {
-  return await editFeatureRules(
-    context,
-    feature,
-    revision,
-    [{ ruleId, environmentId: auditEnvironment }],
-    updates,
-    user,
-    resetReview,
-  );
-}
-
-/**
- * Batch edit rules matched by `ruleId`. `environmentId` is used only for the
- * audit log subject; matching is by id alone. Duplicate ids collapse to a
- * single overlay (idempotent).
- */
-export async function editFeatureRules(
-  context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
-  revision: FeatureRevisionInterface,
-  matches: { ruleId: string; environmentId?: string }[],
-  updates: Partial<FeatureRule>,
-  user: EventUser,
-  resetReview: boolean,
-) {
-  const projected = applyPartialFeatureRuleUpdatesToRevision(
-    revision,
-    matches.map((m) => m.ruleId),
-    updates,
-  );
-
-  // Audit subject uses caller-supplied envs (the user's tab context), not
-  // the rule's underlying scope.
-  const envs = Array.from(
-    new Set(
-      matches.map((m) => m.environmentId).filter((e): e is string => !!e),
-    ),
-  );
-  const subject =
-    envs.length === 0
-      ? `rule ${matches[0]?.ruleId ?? ""}`
-      : envs.length === 1
-        ? `in ${envs[0]}`
-        : `in ${envs.join(", ")}`;
-
-  const updatedRevision = await updateRevision(
-    context,
-    feature,
-    revision,
-    { rules: projected.rules ?? [] },
-    {
-      user,
-      action: "edit rule",
-      subject,
-      value: JSON.stringify(updates),
-    },
-    resetReview,
-  );
-  return updatedRevision;
-}
-
-export async function removeTagInFeature(
-  context: ReqContext | ApiReqContext,
-  tag: string,
-) {
-  const query = { organization: context.org.id, tags: tag };
-
-  const featureDocs = await FeatureModel.find(query);
-  const features = (featureDocs || []).map((m) => toInterface(m, context));
-
-  await FeatureModel.updateMany(query, {
-    $pull: { tags: tag },
-  });
-
-  features.forEach((feature) => {
-    const updatedFeature = {
-      ...feature,
-      tags: (feature.tags || []).filter((t) => t !== tag),
-    };
-
-    onFeatureUpdate(context, feature, updatedFeature).catch((e) => {
-      logger.error(e, "Error refreshing SDK Payload on feature update");
-    });
-  });
-}
-
-export async function removeHoldoutFromFeature(
-  context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
-) {
-  if (!feature.holdout) return;
-  await FeatureModel.updateOne(
-    { organization: context.org.id, id: feature.id },
-    { $unset: { holdout: "" } },
-  );
-}
-
-export async function removeProjectFromFeatures(
-  context: ReqContext | ApiReqContext,
-  project: string,
-) {
-  const query = { organization: context.org.id, project };
-
-  const featureDocs = await FeatureModel.find(query);
-  const features = (featureDocs || []).map((m) => toInterface(m, context));
-
-  await FeatureModel.updateMany(query, { $set: { project: "" } });
-
-  features.forEach((feature) => {
-    const updatedFeature = {
-      ...feature,
-      project: "",
-    };
-
-    onFeatureUpdate(context, feature, updatedFeature, project).catch((e) => {
-      logger.error(e, "Error refreshing SDK Payload on feature update");
-    });
-  });
-}
-
-export async function setDefaultValue(
-  context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
-  revision: FeatureRevisionInterface,
-  defaultValue: string,
-  user: EventUser,
-  requireReview: boolean,
-) {
-  return updateRevision(
-    context,
-    feature,
-    revision,
-    { defaultValue },
-    {
-      user,
-      action: "edit default value",
-      subject: ``,
-      value: JSON.stringify({ defaultValue }),
-    },
-    requireReview,
-  );
-}
-
-export async function setJsonSchema(
-  context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
-  def: Omit<JSONSchemaDef, "date">,
-) {
-  // Validate Simple Schema (sanity check)
-  if (def.schemaType === "simple" && def.simple) {
-    simpleSchemaValidator.parse(def.simple);
-  }
-
-  return await updateFeature(context, feature, {
-    jsonSchema: { ...def, date: new Date() },
-  });
-}
-
-const updateSafeRolloutStatuses = async (
-  context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
-  revision: FeatureRevisionInterface,
-) => {
-  if (!revision.rules || revision.rules.length === 0) return;
-
-  const safeRolloutStatusesMap: Record<
-    string,
-    { status: "running" | "rolled-back" | "released" | "stopped" }
-  > = Object.fromEntries(
-    revision.rules
-      .filter((rule): rule is SafeRolloutRule => rule?.type === "safe-rollout")
-      .map((rule) => [rule.safeRolloutId, { status: rule.status }]),
-  );
-  // Stop safe rollouts whose rule was removed in this revision.
-  (feature.rules ?? []).forEach((rule) => {
-    if (
-      rule?.type === "safe-rollout" &&
-      !safeRolloutStatusesMap[rule.safeRolloutId]
-    ) {
-      safeRolloutStatusesMap[rule.safeRolloutId] = { status: "stopped" };
-    }
-  });
-
-  const safeRollouts = await context.models.safeRollout.getByIds(
-    Object.keys(safeRolloutStatusesMap),
-  );
-
-  safeRollouts.forEach((safeRollout) => {
-    // sync the status of the safe rollout to the status of the revision
-    const safeRolloutUpdates: UpdateProps<SafeRolloutInterface> = {
-      status: safeRolloutStatusesMap[safeRollout.id].status,
-    };
-    if (!safeRollout.startedAt && safeRolloutUpdates.status === "running") {
-      safeRolloutUpdates["startedAt"] = new Date();
-      const { nextSnapshot, nextRampUp } =
-        determineNextSafeRolloutSnapshotAttempt(safeRollout, context.org);
-      safeRolloutUpdates["nextSnapshotAttempt"] = nextSnapshot;
-      safeRolloutUpdates["rampUpSchedule"] = {
-        ...safeRollout.rampUpSchedule,
-        nextUpdate: nextRampUp,
-      };
-    }
-
-    context.models.safeRollout.update(safeRollout, safeRolloutUpdates);
-  });
-};
-
-// Pure computation of the feature-doc changes a revision merge will produce; no writes
-export function computeRevisionMergeChanges(
-  context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
-  revision: FeatureRevisionInterface,
-  result: MergeResultChanges,
-): {
-  changes: Partial<FeatureInterface>;
-  hasChanges: boolean;
-  removeHoldout: boolean;
-} {
-  let hasChanges = false;
-  const changes: Partial<FeatureInterface> = {};
-  let removeHoldout = false;
-
-  if (result.defaultValue !== undefined) {
-    changes.defaultValue = result.defaultValue;
-    hasChanges = true;
-  }
-
-  if (result.rules !== undefined) {
-    changes.rules = result.rules;
-    // Ensure every rollout rule that's being published has a seed — required
-    // for ramp-monitored payload stability. Rules created before the
-    // seed-backfill was introduced (or attached to a ramp for the first time)
-    // get seed = rule.id here so they match the SDK's featureId fallback.
-    addIdsToFlatRules(changes.rules, feature.id);
-    hasChanges = true;
-  }
-
-  if (result.environmentsEnabled) {
-    const envs = getEnvironmentIdsFromOrg(context.org);
-    const nextEnvSettings = cloneDeep(feature.environmentSettings || {});
-    let envChanged = false;
-    envs.forEach((env) => {
-      const desired = result.environmentsEnabled?.[env];
-      if (desired === undefined) return;
-      const current = nextEnvSettings[env] || { enabled: false };
-      // Skip no-op writes so we don't invalidate the SDK payload cache.
-      if (current.enabled !== desired) envChanged = true;
-      nextEnvSettings[env] = { ...current, enabled: desired };
-    });
-    if (envChanged) {
-      changes.environmentSettings = nextEnvSettings;
-      hasChanges = true;
-    }
-  }
-
-  if (result.prerequisites !== undefined) {
-    changes.prerequisites = result.prerequisites;
-    hasChanges = true;
-  }
-
-  if (result.archived !== undefined) {
-    changes.archived = result.archived;
-    hasChanges = true;
-  }
-
-  if (result.holdout !== undefined) {
-    // null means remove from holdout; object means set/change holdout
-    if (result.holdout === null) {
-      removeHoldout = true;
-    } else {
-      changes.holdout = result.holdout;
-    }
-    hasChanges = true;
-  }
-
-  if (result.metadata) {
-    const m = result.metadata;
-    if (m.description !== undefined) changes.description = m.description;
-    if (m.owner !== undefined) changes.owner = m.owner;
-    if (m.project !== undefined) changes.project = m.project;
-    if (m.tags !== undefined) changes.tags = m.tags;
-    if (m.neverStale !== undefined) changes.neverStale = m.neverStale;
-    if (m.customFields !== undefined)
-      changes.customFields = m.customFields as Record<string, unknown>;
-    if (m.jsonSchema !== undefined) changes.jsonSchema = m.jsonSchema;
-    hasChanges = true;
-  }
-
-  // No content delta — still advance feature.version so the revision we're
-  // about to mark published becomes live. Skipping this leaves a "Locked"
-  // revision behind a stale feature.version, which traps subsequent reverts.
-  if (!hasChanges) {
-    changes.version = revision.version;
-    return { changes, hasChanges, removeHoldout };
-  }
-
-  if (changes.rules !== undefined) {
-    changes.nextScheduledUpdate = getNextScheduledUpdate(changes.rules);
-  }
-
-  changes.version = revision.version;
-
-  return { changes, hasChanges, removeHoldout };
-}
-
-// Apply a revision merge result to the feature document.
-export async function applyRevisionChanges(
-  context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
-  revision: FeatureRevisionInterface,
-  result: MergeResultChanges,
-) {
-  const { changes, hasChanges, removeHoldout } = computeRevisionMergeChanges(
-    context,
-    feature,
-    revision,
-    result,
-  );
-
-  if (!hasChanges) {
-    return await updateFeature(context, feature, changes);
-  }
-
-  await updateSafeRolloutStatuses(context, feature, revision);
-
-  // Handle holdout removal separately since updateFeature only does $set
-  if (removeHoldout) {
-    await removeHoldoutFromFeature(context, feature);
-    // Remove holdout from the feature object so the returned feature is correct
-    const { holdout: _, ...featureWithoutHoldout } = feature;
-    return await updateFeature(
-      context,
-      featureWithoutHoldout as FeatureInterface,
-      changes,
-    );
-  }
-
-  return await updateFeature(context, feature, changes);
-}
-
-// Run HoldoutModel / Experiment side-effects when a feature's holdout
-// membership changes at publish. Called from `publishRevision` when
-// `result.holdout` is defined, so all publish paths (direct, approval,
-// revert, etc.) are covered. `feature` is pre-publish (used for prevHoldout);
-// `newHoldout: null` means "remove from holdout".
-export async function applyHoldoutSideEffects(
-  context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
-  newHoldout: { id: string; value: string } | null,
-) {
-  const prevHoldoutId = feature.holdout?.id;
-  const newHoldoutId = newHoldout?.id;
-
-  if (newHoldoutId === prevHoldoutId) return;
-
-  // Guard: cannot change holdout when there are running experiments, bandits, or safe rollouts
-  if (newHoldout !== null) {
-    const experiments = await Promise.all(
-      (feature.linkedExperiments ?? []).map((id) =>
-        getExperimentById(context, id),
-      ),
-    );
-    const hasNonDraftExperiments = experiments.some(
-      (exp) => exp?.status !== "draft",
-    );
-    const hasBandits = experiments.some(
-      (exp) => exp?.type === "multi-armed-bandit",
-    );
-    const hasSafeRollouts = (feature.rules ?? []).some(
-      (rule) => rule?.type === "safe-rollout",
-    );
-    if (hasNonDraftExperiments || hasBandits || hasSafeRollouts) {
-      throw new Error(
-        "Cannot change holdout when there are running linked experiments, safe rollout rules, or multi-armed bandit rules",
-      );
-    }
-  }
-
-  // Remove feature from the old holdout
-  if (prevHoldoutId) {
-    await context.models.holdout.removeFeatureFromHoldout(
-      prevHoldoutId,
-      feature.id,
-    );
-  }
-
-  // Link feature (and its experiments) to the new holdout
-  if (newHoldoutId) {
-    const holdoutObj = await context.models.holdout.getById(newHoldoutId);
-    if (!holdoutObj) {
-      throw new Error("Holdout not found");
-    }
-
-    await context.models.holdout.updateById(newHoldoutId, {
-      linkedFeatures: {
-        [feature.id]: { id: feature.id, dateAdded: new Date() },
-        ...holdoutObj.linkedFeatures,
-      },
-      ...(feature.linkedExperiments?.length
-        ? {
-            linkedExperiments: {
-              ...Object.fromEntries(
-                feature.linkedExperiments.map((experimentId) => [
-                  experimentId,
-                  { id: experimentId, dateAdded: new Date() },
-                ]),
-              ),
-              ...holdoutObj.linkedExperiments,
-            },
-          }
-        : {}),
-    });
-
-    if (feature.linkedExperiments?.length) {
-      const linkedExperiments = await Promise.all(
-        feature.linkedExperiments.map((eid) => getExperimentById(context, eid)),
-      );
-      await Promise.all(
-        linkedExperiments.map(async (exp) => {
-          if (!exp) return;
-          return updateExperiment({
-            context,
-            experiment: exp,
-            changes: { holdoutId: newHoldoutId },
-          });
-        }),
-      );
-    }
-  }
-}
-
-// Apply deferred ramp create/update actions stored on a revision.
-// - `create` actions are called BEFORE feature write so schedule creation
-//   failures abort publish.
-// - `update` actions are called AFTER publish succeeds (best-effort).
-// Returns only newly created schedule IDs (for rollback on failure).
-async function createRampSchedulesForRevision(
-  context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
-  revision: { version: number },
-  result: MergeResultChanges,
-  actions: RevisionRampAction[],
-): Promise<string[]> {
-  const createdIds: string[] = [];
-
-  for (const action of actions) {
-    if (action.mode !== "create" && action.mode !== "update") continue;
-
-    // Pro gate — see postRampSchedule.ts for rationale.
-    if (!context.hasPremiumFeature("schedule-feature-flag")) {
-      context.throwPlanDoesNotAllowError(
-        "Ramp schedules require a Pro plan or above.",
-      );
-    }
-
-    const existingSchedule =
-      action.mode === "update"
-        ? await context.models.rampSchedules.getById(action.rampScheduleId)
-        : null;
-    if (action.mode === "update" && !existingSchedule) {
-      logger.warn(
-        { rampScheduleId: action.rampScheduleId, ruleId: action.ruleId },
-        "Ramp schedule not found at revision publish time — skipping deferred update action",
-      );
-      continue;
-    }
-
-    const existingTarget =
-      action.mode === "update"
-        ? existingSchedule?.targets.find(
-            (t) => stemRuleId(t.ruleId ?? "") === stemRuleId(action.ruleId),
-          )
-        : null;
-    if (action.mode === "update" && !existingTarget) {
-      logger.warn(
-        {
-          rampScheduleId: action.rampScheduleId,
-          ruleId: action.ruleId,
-        },
-        "Ramp schedule target no longer matches rule at revision publish time — skipping deferred update action",
-      );
-      continue;
-    }
-
-    const targetId = existingTarget?.id ?? uuidv4();
-
-    // Inject the generated targetId into every action and ensure targetType
-    // is always set. Handles both correctly-typed actions and legacy drafts
-    // that were stored without targetType.
-    const normalizeAction = (
-      a: RevisionRampCreateAction["steps"][number]["actions"][number],
-    ): RampStepAction => ({
-      targetType: "feature-rule" as const,
-      targetId,
-      patch: {
-        ...a.patch,
-        ruleId: action.ruleId,
-      },
-    });
-
-    // Template is used as a fallback; explicit steps/endActions win.
-    let template: RampScheduleTemplateInterface | undefined;
-    if (action.templateId) {
-      const tmpl = await context.models.rampScheduleTemplates.getById(
-        action.templateId,
-      );
-      if (!tmpl) {
-        logger.warn(
-          { templateId: action.templateId },
-          "Ramp schedule template not found at revision publish time — skipping template",
-        );
-      } else {
-        template = tmpl;
-      }
-    }
-
-    const defaultName = `Ramp schedule \u2013 ${new Date().toLocaleDateString(
-      "en-US",
-      { month: "short", year: "numeric" },
-    )}`;
-
-    const startDate =
-      action.startDate === null
-        ? null
-        : action.startDate
-          ? new Date(action.startDate)
-          : undefined;
-
-    const explicitSteps = Array.isArray(action.steps) ? action.steps : [];
-    // Whether the caller explicitly provided steps (only when at least one step
-    // is present, or a template is used). When false on an update action,
-    // fall back to the existing schedule's steps to avoid wiping them.
-    // Note: steps: [] is treated as "not provided" — an empty array does NOT
-    // clear existing steps.
-    const stepsExplicit = explicitSteps.length > 0 || !!template;
-    const steps: RampScheduleInterface["steps"] =
-      explicitSteps.length > 0
-        ? explicitSteps.map((step) => ({
-            ...step,
-            actions: Array.isArray(step.actions)
-              ? step.actions.map(normalizeAction)
-              : [],
-            monitored: !!step.monitored,
-            holdConditions: step.holdConditions ?? undefined,
-          }))
-        : template
-          ? template.steps.map((s) => ({
-              interval: s.interval,
-              actions: remapTemplateActions(
-                s.actions,
-                targetId,
-                action.ruleId,
-                feature.valueType,
-              ),
-              approvalNotes: s.approvalNotes ?? undefined,
-              monitored: !!s.monitored,
-              holdConditions: s.holdConditions ?? undefined,
-            }))
-          : action.mode === "update"
-            ? // No explicit steps and no template: preserve the existing
-              // schedule's steps so a caller who only wants to change name /
-              // startDate / cutoffDate doesn't accidentally wipe them.
-              (existingSchedule?.steps ?? [])
-            : [];
-
-    // null = explicitly cleared (skip template); undefined = not set (fall back to template).
-    const endActions: RampStepAction[] =
-      action.endActions !== undefined
-        ? Array.isArray(action.endActions)
-          ? action.endActions.map(normalizeAction)
-          : []
-        : template?.endPatch && Object.keys(template.endPatch).length > 0
-          ? [
-              {
-                targetType: "feature-rule" as const,
-                targetId,
-                patch: {
-                  ruleId: action.ruleId,
-                  ...template.endPatch,
-                },
-              },
-            ]
-          : [];
-
-    const startActions: RampStepAction[] =
-      action.startActions !== undefined
-        ? Array.isArray(action.startActions)
-          ? action.startActions.map(normalizeAction)
-          : []
-        : getStartActionsFromRules({
-            rules: result.rules ?? feature.rules ?? [],
-            targetId,
-            ruleId: action.ruleId,
-            environment: action.environment,
-          });
-
-    if (action.mode === "create") {
-      // Guard against duplicate schedules: if the revision is re-published or
-      // an older revision is published while a live schedule already targets
-      // this rule, skip the create rather than producing a second schedule
-      // that both try to drive the same rule.
-      const existing = await context.models.rampSchedules.findByTargetRule(
-        action.ruleId,
-        action.environment ?? undefined,
-      );
-      if (existing.length > 0) {
-        logger.warn(
-          {
-            ruleId: action.ruleId,
-            conflictingScheduleId: existing[0].id,
-            revisionVersion: revision.version,
-          },
-          "Skipping deferred ramp create action — a live schedule already targets this rule",
-        );
-        continue;
-      }
-
-      const created = await context.models.rampSchedules.create({
-        name: action.name ?? defaultName,
-        entityType: "feature",
-        entityId: feature.id,
-        targets: [
-          {
-            id: targetId,
-            entityType: "feature",
-            entityId: feature.id,
-            ruleId: action.ruleId,
-            // null = patches apply to all environments sharing this ruleId.
-            // A specific environment = patches are scoped to that env only.
-            environment: action.environment ?? null,
-            status: "active",
-            // Link this target to the activating revision so onRevisionPublished
-            // (and the Agenda recovery path) can transition "pending" → "running".
-            activatingRevisionVersion: revision.version,
-          },
-        ],
-        startActions: startActions.length > 0 ? startActions : undefined,
-        steps,
-        endActions: endActions.length > 0 ? endActions : undefined,
-        startDate: startDate ?? undefined,
-        cutoffDate: action.cutoffDate
-          ? new Date(action.cutoffDate)
-          : action.cutoffDate === null
-            ? null
-            : undefined,
-        monitoringConfig: action.monitoringConfig ?? template?.monitoringConfig,
-        lockdownConfig: action.lockdownConfig ?? template?.lockdownConfig,
-        // Start as "pending" — onActivatingRevisionPublished handles the
-        // immediate → "running" transition inline when the revision publishes.
-        status: "pending",
-        currentStepIndex: -1,
-        nextStepAt:
-          !startDate && steps.length > 0 ? new Date() : (startDate ?? null),
-        startedAt: null,
-        phaseStartedAt: null,
-      });
-
-      createdIds.push(created.id);
-      continue;
-    }
-
-    const updateAction = action as RevisionRampUpdateAction;
-    const nextStartDate =
-      startDate !== undefined
-        ? startDate
-        : (existingSchedule?.startDate ?? null);
-    const nextCutoffDate =
-      updateAction.cutoffDate !== undefined
-        ? updateAction.cutoffDate
-          ? new Date(updateAction.cutoffDate)
-          : null
-        : (existingSchedule?.cutoffDate ?? null);
-    const nextMonitoringConfig =
-      updateAction.monitoringConfig !== undefined
-        ? updateAction.monitoringConfig
-        : existingSchedule?.monitoringConfig;
-    // "Start now": user explicitly cleared startDate on a not-yet-started
-    // schedule. Transition ready → running inline so the rule goes live on
-    // publish instead of at the next poller tick. A ready schedule has all
-    // fields editable (startActions included — the ramp hasn't fired), so no
-    // running-merge / paused-clamp handling is needed here.
-    let startDeferredToScheduler = false;
-    if (
-      updateAction.startDate === null &&
-      existingSchedule?.status === "ready"
-    ) {
-      const contentUpdates: Parameters<typeof startReadyScheduleNow>[2] = {};
-      const edited: string[] = [];
-      const set = (provided: boolean, key: string, value: unknown) => {
-        if (!provided) return;
-        (contentUpdates as Record<string, unknown>)[key] = value;
-        edited.push(key);
-      };
-      set(updateAction.name !== undefined, "name", updateAction.name);
-      set(
-        updateAction.startActions !== undefined,
-        "startActions",
-        startActions.length > 0 ? startActions : undefined,
-      );
-      set(stepsExplicit, "steps", steps);
-      set(
-        updateAction.endActions !== undefined,
-        "endActions",
-        endActions.length > 0 ? endActions : undefined,
-      );
-      set(updateAction.cutoffDate !== undefined, "cutoffDate", nextCutoffDate);
-      set(
-        updateAction.monitoringConfig !== undefined,
-        "monitoringConfig",
-        nextMonitoringConfig,
-      );
-      set(
-        updateAction.lockdownConfig !== undefined,
-        "lockdownConfig",
-        updateAction.lockdownConfig,
-      );
-      edited.push("startDate"); // always changed on this path (cleared)
-
-      // A "config-edited" event rides along so startReadyScheduleNow appends
-      // "started" on top of it, matching the direct-edit path.
-      const history = appendRampEvent(existingSchedule, "config-edited", {
-        stepIndex: existingSchedule.currentStepIndex,
-        status: existingSchedule.status,
-        reason: `Edited via draft: ${edited.join(", ")}`,
-      });
-      const started = await startReadyScheduleNow(context, existingSchedule, {
-        ...contentUpdates,
-        cutoffDate: nextCutoffDate,
-        auditEvent: history[history.length - 1],
-      });
-      if (started) continue;
-      // Start didn't run: either the scheduler started it first (the locked
-      // update below applies the edits) or the lock stayed busy and the start
-      // was deferred via startDate=now — don't clobber that deferral.
-      const reread = await context.models.rampSchedules.getById(
-        updateAction.rampScheduleId,
-      );
-      if (!reread) {
-        logger.warn(
-          { rampScheduleId: updateAction.rampScheduleId },
-          "Ramp schedule removed while applying start-now update — skipping",
-        );
-        continue;
-      }
-      startDeferredToScheduler = reread.status === "ready";
-    }
-
-    // Apply the edits under the advance lock, deriving state-dependent pieces
-    // (running merge, paused clamp, audit history, nextProcessAt inputs) from
-    // the in-lock fresh doc — the schedule may have started, advanced, or been
-    // edited since the pre-publish read.
-    try {
-      await runLockedRampScheduleAction(
-        context,
-        updateAction.rampScheduleId,
-        async (fresh) => {
-          const isRunning = fresh.status === "running";
-          const canEditStartActions =
-            fresh.status === "pending" || fresh.status === "ready";
-          const startDateChanged = updateAction.startDate !== undefined;
-
-          // Collect the caller's config edits. `set` writes a key only when the
-          // field was provided, so omitted fields are preserved, and records
-          // which fields changed for the audit trail.
-          const patch: Record<string, unknown> = {};
-          const edited: string[] = [];
-          const set = (provided: boolean, key: string, value: unknown) => {
-            if (!provided) return;
-            patch[key] = value;
-            edited.push(key);
-          };
-
-          set(updateAction.name !== undefined, "name", updateAction.name);
-          set(
-            updateAction.cutoffDate !== undefined,
-            "cutoffDate",
-            nextCutoffDate,
-          );
-          set(
-            updateAction.monitoringConfig !== undefined,
-            "monitoringConfig",
-            nextMonitoringConfig,
-          );
-          set(
-            updateAction.lockdownConfig !== undefined,
-            "lockdownConfig",
-            updateAction.lockdownConfig,
-          );
-          // endActions only apply at completion, so they're safe to edit mid-run.
-          set(
-            updateAction.endActions !== undefined,
-            "endActions",
-            endActions.length > 0 ? endActions : undefined,
-          );
-
-          if (isRunning) {
-            // Running TOCTOU guard: freeze the past, allow only holds/notes on
-            // the current step, apply future steps. startActions stay frozen —
-            // they're the rollback restore point.
-            if (stepsExplicit) {
-              set(
-                true,
-                "steps",
-                mergeStepsForRunningSchedule(fresh, steps).steps,
-              );
-            }
-          } else {
-            set(stepsExplicit, "steps", steps);
-            set(
-              canEditStartActions && updateAction.startActions !== undefined,
-              "startActions",
-              startActions.length > 0 ? startActions : undefined,
-            );
-            if (startDateChanged) edited.push("startDate");
-            if (startDateChanged && !startDeferredToScheduler) {
-              patch.startDate = nextStartDate;
-            }
-            // Steps edited on a paused schedule: clamp the playhead and let
-            // resume recompute timing. Internal fields, not part of the audit.
-            if (
-              fresh.status === "paused" &&
-              fresh.currentStepIndex >= steps.length
-            ) {
-              patch.currentStepIndex = Math.max(steps.length - 1, -1);
-              patch.nextStepAt = null;
-            }
-          }
-
-          if (edited.length > 0) {
-            patch.eventHistory = appendRampEvent(fresh, "config-edited", {
-              stepIndex: fresh.currentStepIndex,
-              status: fresh.status,
-              reason: `Edited via draft: ${edited.join(", ")}`,
-            });
-          }
-
-          patch.nextProcessAt = computeNextProcessAt({
-            status: fresh.status,
-            nextStepAt: fresh.nextStepAt,
-            cutoffDate:
-              updateAction.cutoffDate !== undefined
-                ? nextCutoffDate
-                : (fresh.cutoffDate ?? null),
-            // running ignores startDate; ready uses it. Only reflect the new
-            // startDate when we actually persist it here.
-            startDate:
-              !isRunning && startDateChanged && !startDeferredToScheduler
-                ? nextStartDate
-                : (fresh.startDate ?? null),
-            nextSnapshotAt: fresh.nextSnapshotAt,
-          });
-
-          const updated = await context.models.rampSchedules.updateById(
-            fresh.id,
-            patch,
-          );
-
-          // Sync SafeRollout in case monitored-step membership changed.
-          if (isRunning && patch.steps) {
-            const ensured = await ensureSafeRolloutForMonitoredRamp(
-              context,
-              updated,
-            );
-            await syncLinkedSafeRolloutForRampState(context, ensured);
-          }
-        },
-      );
-    } catch (e) {
-      if (e instanceof NotFoundError) {
-        logger.warn(
-          { rampScheduleId: updateAction.rampScheduleId },
-          "Ramp schedule removed while applying update action — skipping",
-        );
-        continue;
-      }
-      throw e;
-    }
-  }
-
-  return createdIds;
-}
-
-/**
- * Apply detach/update ramp actions stored on a revision.
- * Best-effort: logs errors but does not throw, since these run after the feature is published.
- */
-async function applyDetachRampActions(
-  context: ReqContext | ApiReqContext,
-  actions: RevisionRampAction[],
-) {
-  for (const action of actions) {
-    if (action.mode !== "detach") continue;
-    try {
-      const existing = await context.models.rampSchedules.getById(
-        action.rampScheduleId,
-      );
-      if (existing) {
-        // Stem-match so a bare `fr_abc` detach action matches a suffixed
-        // `fr_abc__production` target (and vice versa).
-        const actionStem = stemRuleId(action.ruleId);
-        const remainingTargets = existing.targets.filter(
-          (t) => stemRuleId(t.ruleId ?? "") !== actionStem,
-        );
-        if (action.deleteScheduleWhenEmpty && remainingTargets.length === 0) {
-          // Stop the linked SafeRollout before deletion so it doesn't continue
-          // taking snapshots against a ramp that no longer exists.
-          if (existing.safeRolloutId) {
-            await syncLinkedSafeRolloutForRampState(
-              context,
-              { ...existing, status: "rolled-back" },
-              "stopped",
-            );
-          }
-          await context.models.rampSchedules.deleteById(existing.id);
-        } else {
-          await context.models.rampSchedules.updateById(existing.id, {
-            targets: remainingTargets,
-          });
-        }
-      }
-    } catch (err) {
-      logger.error(err, {
-        msg: "Failed to apply revision ramp detach action",
-        action,
-      });
-    }
-  }
-}
-
-async function cleanupOrphanedRampSchedules(
-  context: ReqContext | ApiReqContext,
-  oldFeature: FeatureInterface,
-  newFeature: FeatureInterface,
-) {
-  try {
-    // When publishing a change that modifies rules, clean up ramp schedules that
-    // become orphaned. This handles several scenarios:
-    // 1. Rules that target a ramp are deleted → ramp is cleaned up
-    // 2. Reverting to an older revision that predates a ramp's creation → ramp's
-    //    targets (from newer revisions) are removed, orphaning the ramp → cleanup deletes it
-    // 3. Reverting back to a newer revision with a ramp → the ramp is recreated via
-    //    the inline "create" action on the rule (natural behavior)
-    //
-    // Note: If a ramp schedule is deleted and then we revert to a future revision
-    // where it should exist, the "create" action will not fire again. The user must
-    // re-create the ramp. This is the safe, explicit behavior.
-
-    // Compare by stem (not raw id). A rule may be split across revisions —
-    // e.g. `fr_abc` → `fr_abc__production` + `fr_abc__dev` — and ramp
-    // targets reference stem identity.
-    const oldStems = new Set<string>(
-      (oldFeature.rules ?? [])
-        .map((r) => (r?.id ? stemRuleId(r.id) : null))
-        .filter((id): id is string => !!id),
-    );
-    const newStems = new Set<string>(
-      (newFeature.rules ?? [])
-        .map((r) => (r?.id ? stemRuleId(r.id) : null))
-        .filter((id): id is string => !!id),
-    );
-
-    const deletedStems = new Set<string>(
-      [...oldStems].filter((s) => !newStems.has(s)),
-    );
-
-    const allRamps = await context.models?.rampSchedules?.getAllByFeatureId?.(
-      newFeature.id,
-    );
-
-    if (!allRamps) return;
-
-    for (const ramp of allRamps) {
-      const originalTargets = ramp?.targets ?? [];
-      if (originalTargets.length === 0 || !ramp?.id) continue;
-      const remainingTargets = originalTargets.filter(
-        (target: RampScheduleInterface["targets"][0]) => {
-          if (!target?.ruleId) return false;
-          return !deletedStems.has(stemRuleId(target.ruleId));
-        },
-      );
-
-      if (remainingTargets.length === 0) {
-        // Stop the linked SafeRollout before deletion so it doesn't continue
-        // taking snapshots against a ramp that no longer exists.
-        if (ramp.safeRolloutId) {
-          await syncLinkedSafeRolloutForRampState(
-            context,
-            { ...ramp, status: "rolled-back" },
-            "stopped",
-          );
-        }
-        await context.models?.rampSchedules?.deleteById?.(ramp.id);
-      } else if (remainingTargets.length !== originalTargets.length) {
-        // Some targets were orphaned by the delete; prune them so the schedule
-        // doesn't fail trying to resolve a deleted ruleId on its next fire.
-        await context.models?.rampSchedules?.updateById?.(ramp.id, {
-          targets: remainingTargets,
-        });
-      }
-    }
-  } catch (error) {
-    // Log but don't throw — cleanup is a nice-to-have, not essential for publish to succeed.
-    logger.error("Error cleaning up orphaned ramp schedules", error);
-  }
-}
-
-// Best-effort early hook run; updateFeature / markRevisionAsPublished re-run hooks authoritatively
-export async function prevalidatePublishRevision({
-  context,
-  feature,
-  revision,
-  result,
-  comment,
-}: {
-  context: ReqContext | ApiReqContext;
-  feature: FeatureInterface;
-  revision: FeatureRevisionInterface;
-  result: MergeResultChanges;
-  comment?: string;
-}) {
-  const { changes, removeHoldout } = computeRevisionMergeChanges(
-    context,
-    feature,
-    revision,
-    result,
-  );
-  const base = removeHoldout
-    ? (omit(feature, ["holdout"]) as FeatureInterface)
-    : feature;
-  const proposedFeature: FeatureInterface = {
-    ...base,
-    ...changes,
-    dateUpdated: new Date(),
-  };
-  proposedFeature.linkedExperiments = getLinkedExperiments(proposedFeature);
-  await runValidateFeatureHooks({
-    context,
-    feature: proposedFeature,
-    original: feature,
-  });
-  await runValidateFeatureRevisionHooks({
-    context,
-    feature,
-    revision: {
-      ...revision,
-      ...computeRevisionPublishChanges(revision, context.auditUser, comment),
-    },
-    original: revision,
-  });
-}
-
-export async function publishRevision({
-  context,
-  feature,
-  revision,
-  result,
-  comment,
-  bypassLockdown,
-}: {
-  context: ReqContext | ApiReqContext;
-  feature: FeatureInterface;
-  revision: FeatureRevisionInterface;
-  result: MergeResultChanges;
-  comment?: string;
-  bypassLockdown?: boolean;
-}) {
-  if (revision.status === "published" || revision.status === "discarded") {
-    throw new Error("Can only publish a draft revision");
-  }
-
-  if (!bypassLockdown) {
-    await assertFeatureNotLockedByRamp(context, feature.id);
-
-    // A sibling draft's "lock other drafts" schedule freezes other publishes.
-    if (
-      revision.version !== undefined &&
-      (await hasPublishLockingScheduledSibling(
-        context.org.id,
-        feature.id,
-        revision.version,
-      ))
-    ) {
-      throw new Error(
-        "Another draft of this feature is scheduled to publish and has locked publishing of other drafts. Cancel that schedule to publish this revision.",
-      );
-    }
-  }
-
-  // Run custom hooks before the side-effect writes below so a rejection doesn't orphan them
-  await prevalidatePublishRevision({
-    context,
-    feature,
-    revision,
-    result,
-    comment,
-  });
-
-  // Create ramp schedules BEFORE writing the feature so that a schedule
-  // creation failure gates the publish (atomicity: no published feature without
-  // its ramp schedule).
-  const createActions = (revision.rampActions ?? []).filter(
-    (a) => a.mode === "create",
-  );
-  const updateActions = (revision.rampActions ?? []).filter(
-    (a) => a.mode === "update",
-  );
-  const preCreatedScheduleIds: string[] = [];
-  if (createActions.length) {
-    const ids = await createRampSchedulesForRevision(
-      context,
-      feature,
-      revision,
-      result,
-      createActions,
-    );
-    preCreatedScheduleIds.push(...ids);
-  }
-
-  let updatedFeature: FeatureInterface;
-  try {
-    updatedFeature = await applyRevisionChanges(
-      context,
-      feature,
-      revision,
-      result,
-    );
-
-    if (result.holdout !== undefined) {
-      await applyHoldoutSideEffects(context, feature, result.holdout);
-    }
-
-    await markRevisionAsPublished(
-      context,
-      feature,
-      revision,
-      context.auditUser,
-      comment,
-    );
-
-    await clearPendingFeatureDraftsForRevision(
-      context,
-      revision.featureId,
-      revision.version,
-      revision.rules,
-    );
-  } catch (err) {
-    // Roll back pre-created ramp schedules so they don't linger as orphans.
-    for (const id of preCreatedScheduleIds) {
-      try {
-        await context.models.rampSchedules.deleteById(id);
-      } catch (deleteErr) {
-        logger.error(
-          deleteErr,
-          `Failed to delete orphaned ramp schedule ${id} during publish rollback`,
-        );
-      }
-    }
-    throw err;
-  }
-
-  // Apply deferred update actions after publish succeeds.
-  // Best-effort: errors are logged but do not fail the publish response
-  // (feature is already committed; a failed schedule update is recoverable).
-  if (updateActions.length) {
-    try {
-      await createRampSchedulesForRevision(
-        context,
-        updatedFeature,
-        revision,
-        result,
-        updateActions,
-      );
-    } catch (err) {
-      logger.error(
-        err,
-        "Failed to apply deferred ramp update actions after publish",
-      );
-    }
-  }
-
-  // Apply detach actions (best-effort: logged but do not fail publish).
-  if (revision.rampActions?.length) {
-    await applyDetachRampActions(context, revision.rampActions);
-  }
-
-  // Clean up orphaned ramp schedules (best-effort).
-  await cleanupOrphanedRampSchedules(context, feature, updatedFeature);
-
-  return updatedFeature;
-}
-
-// Create a new revision from the given changes and immediately publish it.
-// Either the revision is published and the updated feature is returned, or an
-// error is thrown — a pending-review draft is never silently left behind.
-// canBypassApprovalChecks should be true when the org-level restApiBypassesReviews
-// setting is on, or when the caller's role/token grants bypassApprovalChecks
-// on the feature's project.
-export async function createAndPublishRevision({
-  context,
-  feature,
-  user,
-  org,
-  changes,
-  comment,
-  canBypassApprovalChecks,
-}: {
-  context: ReqContext | ApiReqContext;
-  feature: FeatureInterface;
-  user: EventUser;
-  org: OrganizationInterface;
-  changes: Parameters<typeof createRevision>[0]["changes"];
-  comment?: string;
-  canBypassApprovalChecks: boolean;
-}): Promise<{
-  revision: FeatureRevisionInterface;
-  updatedFeature: FeatureInterface;
-}> {
-  // Filter to envs applicable to this feature's project — avoids over-
-  // triggering approval and creating dangling per-env settings.
-  const orgEnvironments = getEnvironmentIdsFromOrg(org);
-  const orgEnvObjects = getEnvironments(org);
-  const applicableEnvIds = getApplicableEnvIds(orgEnvObjects, feature.project);
-  const applicableEnvSet = new Set(applicableEnvIds);
-  const allEnvironments = orgEnvironments.filter((e) =>
-    applicableEnvSet.has(e),
-  );
-
-  // Determine whether the revision would require review before we create anything.
-  // We need a synthetic revision to check against, mirroring what createRevision would build.
-  const liveRevision = await getRevision({
-    context,
-    organization: feature.organization,
-    featureId: feature.id,
-    feature,
-    version: feature.version,
-  });
-  if (!liveRevision) throw new Error("Could not load live revision");
-
-  // Live baseline for the review check and the publish merge, built from the
-  // feature document (the canonical live state). Stored revision docs can be
-  // sparse or in legacy shapes, so they're not a reliable baseline.
-  const liveBase: FeatureRevisionInterface = {
-    ...liveRevision,
-    ...liveRevisionFromFeature(liveRevision, feature),
-  } as FeatureRevisionInterface;
-
-  // Synthetic revision for the review check; caller-supplied rules replace
-  // the live array wholesale (same as autoMerge).
-  const syntheticRevision: FeatureRevisionInterface = {
-    ...liveBase,
-    ...(changes ?? {}),
-    rules: changes?.rules ?? liveBase.rules ?? [],
-  };
-  const requiresReview = checkIfRevisionNeedsReview({
-    feature,
-    baseRevision: liveBase,
-    revision: syntheticRevision,
-    allEnvironments,
-    settings: org.settings,
-    requireApprovalsLicensed: context.hasPremiumFeature("require-approvals"),
-  });
-
-  if (requiresReview && !canBypassApprovalChecks) {
-    throw new PermissionError(
-      "This feature requires approval before changes can be published. " +
-        "Enable 'REST API always bypasses approval requirements' in organization settings.",
-    );
-  }
-
-  // Create the draft revision (never auto-publishes; publish=false).
-  const revision = await createRevision({
-    context,
-    feature,
-    user,
-    baseVersion: feature.version,
-    comment: comment ?? "Created via REST API",
-    environments: allEnvironments,
-    publish: false,
-    changes,
-    org,
-    canBypassApprovalChecks,
-  });
-
-  // Merge the new revision against the live-feature baseline. base === live
-  // for a fresh revision off HEAD.
-  const mergeResult = autoMerge(
-    liveBase,
-    liveBase,
-    revision,
-    allEnvironments,
-    {},
-  );
-
-  if (!mergeResult.success) {
-    // Shouldn't happen for a brand-new revision off HEAD, but guard anyway.
-    throw new Error(
-      "Merge conflict detected while publishing revision. Please retry.",
-    );
-  }
-
-  const updatedFeature = await publishRevision({
-    context,
-    feature,
-    revision,
-    result: mergeResult.result,
-    comment,
-    // See postFeatureRevisionPublish.ts for the bypassLockdown policy rationale:
-    // approval-bypass permission intentionally doubles as ramp-lockdown bypass.
-    bypassLockdown: canBypassApprovalChecks,
-  });
-
-  return { revision, updatedFeature };
-}
-
-function getLinkedExperiments(feature: FeatureInterface) {
-  // Keep existing links even when a rule is removed — past revisions need
-  // them to render correctly.
-  const expIds: Set<string> = new Set(feature.linkedExperiments || []);
-
-  (feature.rules ?? []).forEach((rule) => {
-    if (rule?.type === "experiment-ref") {
-      expIds.add(rule.experimentId);
-    }
-  });
-
-  return [...expIds];
-}
-
-export async function toggleNeverStale(
-  context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
-  neverStale: boolean,
-) {
-  return await updateFeature(context, feature, { neverStale });
-}
-
-export async function hasNonDemoFeature(context: ReqContext | ApiReqContext) {
-  const demoProjectId = getDemoDatasourceProjectIdForOrganization(
-    context.org.id,
-  );
-  const feature = await FeatureModel.findOne(
-    {
-      organization: context.org.id,
-      project: { $ne: demoProjectId },
-    },
-    { _id: 1 },
-  );
-  return !!feature;
-}
-
-export async function getFeatureMetaInfoById(
-  context: ReqContext | ApiReqContext,
-  opts: {
-    includeDefaultValue?: boolean;
-    project?: string;
-    ids?: string[];
-  } = {},
-): Promise<FeatureMetaInfo[]> {
-  const { includeDefaultValue = false, project, ids } = opts;
-
-  const query: Record<string, unknown> = { organization: context.org.id };
-  if (project) {
-    query.project = project;
-  }
-  if (ids?.length) {
-    query.id = { $in: ids };
-  }
-
-  const projection: Record<string, number> = {
-    id: 1,
-    project: 1,
-    archived: 1,
-    description: 1,
-    dateCreated: 1,
-    dateUpdated: 1,
-    tags: 1,
-    owner: 1,
-    valueType: 1,
-    version: 1,
-    linkedExperiments: 1,
-    neverStale: 1,
-    "jsonSchema.enabled": 1,
-    revision: 1,
-    prerequisites: 1,
-    "rules.prerequisites": 1,
-    "rules.savedGroups": 1,
-    environmentSettings: 1,
-  };
-  if (includeDefaultValue) {
-    projection.defaultValue = 1;
-  }
-
-  const features = await FeatureModel.find(query, projection);
-
-  return features
-    .filter((f) => context.permissions.canReadSingleProjectResource(f.project))
-    .map((f) => {
-      const doc = f as unknown as Record<string, unknown>;
-      const rules = doc.rules as
-        | { prerequisites?: unknown[]; savedGroups?: unknown[] }[]
-        | undefined;
-      const envSettings = doc.environmentSettings as
-        | Record<string, { prerequisites?: unknown[] }>
-        | undefined;
-      const topPrereqs = doc.prerequisites as unknown[] | undefined;
-
-      const hasPrerequisites =
-        (topPrereqs?.length ?? 0) > 0 ||
-        (rules ?? []).some((r) => (r.prerequisites?.length ?? 0) > 0) ||
-        Object.values(envSettings ?? {}).some(
-          (e) => (e.prerequisites?.length ?? 0) > 0,
-        );
-
-      const hasSavedGroups = (rules ?? []).some(
-        (r) => (r.savedGroups?.length ?? 0) > 0,
-      );
-
-      return {
-        id: f.id,
-        project: f.project,
-        archived: f.archived,
-        description: f.description,
-        dateCreated: f.dateCreated,
-        dateUpdated: f.dateUpdated,
-        tags: f.tags,
-        owner: f.owner,
-        valueType: f.valueType,
-        version: f.version,
-        linkedExperiments: f.linkedExperiments,
-        neverStale: f.neverStale,
-        hasPrerequisites,
-        hasSavedGroups,
-        revision: f.revision as FeatureMetaInfo["revision"],
-        ...(includeDefaultValue && { defaultValue: f.defaultValue ?? "" }),
-      };
-    });
-}
-
-export async function getFeatureMetaInfoByIds(
-  context: ReqContext | ApiReqContext,
-  ids: string[],
-): Promise<FeatureMetaInfo[]> {
-  if (!ids.length) return [];
-
-  const features = await FeatureModel.find(
-    { organization: context.org.id, id: { $in: ids } },
-    {
-      id: 1,
-      project: 1,
-      archived: 1,
-      description: 1,
-      dateCreated: 1,
-      dateUpdated: 1,
-      tags: 1,
-      owner: 1,
-      valueType: 1,
-      version: 1,
-      linkedExperiments: 1,
-      neverStale: 1,
-      "jsonSchema.enabled": 1,
-      revision: 1,
-    },
-  );
-
-  return features
-    .filter((f) => context.permissions.canReadSingleProjectResource(f.project))
-    .map((f) => ({
-      id: f.id,
-      project: f.project,
-      archived: f.archived,
-      description: f.description,
-      dateCreated: f.dateCreated,
-      dateUpdated: f.dateUpdated,
-      tags: f.tags,
-      owner: f.owner,
-      valueType: f.valueType,
-      version: f.version,
-      linkedExperiments: f.linkedExperiments,
-      neverStale: f.neverStale,
-      revision: f.revision as FeatureMetaInfo["revision"],
-    }));
-}
-
-export async function getFeatureEnvStatus(
-  context: ReqContext | ApiReqContext,
-  ids?: string[],
-): Promise<
-  { id: string; environmentSettings: FeatureInterface["environmentSettings"] }[]
-> {
-  const q: FilterQuery<FeatureDocument> = { organization: context.org.id };
-  if (ids && ids.length > 0) {
-    q.id = { $in: ids };
-  }
-
-  // Push project-level read restrictions into the query to avoid fetching
-  // documents that will be filtered out anyway.
-  const allowedProjects =
-    context.permissions.getProjectsWithPermission("readData");
-  if (allowedProjects !== null) {
-    if (allowedProjects.length === 0) return [];
-    // Also include features with no project — they're globally accessible
-    q.$or = [
-      { project: { $in: allowedProjects } },
-      { project: { $in: ["", null] } },
-    ];
-  }
-
-  const docs = await FeatureModel.find(q, {
-    id: 1,
-    environmentSettings: 1,
-  });
-
-  return docs.map((f) => ({
-    id: f.id as string,
-    // This getter only reads `enabled`, so v1 vs v2 env shape doesn't matter.
-    environmentSettings: applyEnvironmentInheritance(
-      context.org.settings?.environments || [],
-      f.environmentSettings || {},
-    ) as FeatureInterface["environmentSettings"],
-  }));
 }

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -330,13 +330,21 @@ export function buildFeatureUpdate<
       (r): r is FeatureRule => r != null && typeof r === "object",
     );
     const normalized = filtered.map((r) => {
-      if (r.allEnvironments && Array.isArray(r.environments)) {
-        return {
-          ...omit(r, ["environments"]),
+      // Rules copied from revision docs carry explicit `null`s for absent
+      // optional fields (condition, scheduleRules, ...) which the strict
+      // update validator rejects; drop them here. Null-valued keys mean
+      // "absent" for every rule field, so this is lossless.
+      const nullKeys = Object.keys(r).filter(
+        (k) => (r as Record<string, unknown>)[k] === null,
+      );
+      let rule = nullKeys.length > 0 ? (omit(r, nullKeys) as FeatureRule) : r;
+      if (rule.allEnvironments && Array.isArray(rule.environments)) {
+        rule = {
+          ...omit(rule, ["environments"]),
           allEnvironments: true,
         } as FeatureRule;
       }
-      return r;
+      return rule;
     });
     const changed =
       filtered.length !== inputRules.length ||

--- a/packages/back-end/src/models/GeneratedHypothesis.ts
+++ b/packages/back-end/src/models/GeneratedHypothesis.ts
@@ -6,7 +6,6 @@ import { ExperimentInterface } from "shared/types/experiment";
 import { ReqContext } from "back-end/types/request";
 import { createExperiment } from "./ExperimentModel";
 import { createVisualChangeset } from "./VisualChangesetModel";
-import { createFeature } from "./FeatureModel";
 
 type GeneratedHypothesisDocument = mongoose.Document &
   GeneratedHypothesisInterface;
@@ -41,7 +40,7 @@ export const findOrCreateGeneratedHypothesis = async (
   context: ReqContext,
   uuid: string,
 ): Promise<GeneratedHypothesisInterface> => {
-  const { org, userId } = context;
+  const { userId } = context;
   const existing = await GeneratedHypothesisModel.findOne({
     weblensUuid: uuid,
     organization: context.org.id,
@@ -173,14 +172,13 @@ export const findOrCreateGeneratedHypothesis = async (
   } else {
     // linked feature flag
     const featureId = `${slug}-feature-flag`;
-    await createFeature(context, {
+    // Hypothesis generation is authorized upstream; feature creation here is
+    // incidental, so skip the manageFeatures check like the legacy helper did.
+    await context.models.features.dangerousCreateBypassPermission({
       id: featureId,
       archived: false,
       description: `Feature flag for ${slug} experiment`,
-      organization: org.id,
       owner: userId,
-      dateCreated: new Date(),
-      dateUpdated: new Date(),
       valueType: "boolean",
       defaultValue: "false",
       version: 1,

--- a/packages/back-end/src/models/SafeRolloutModel.ts
+++ b/packages/back-end/src/models/SafeRolloutModel.ts
@@ -3,7 +3,6 @@ import { SafeRolloutInterface, safeRolloutValidator } from "shared/validators";
 import { getEnvironmentIdsFromOrg } from "back-end/src/services/organizations";
 import { queueSDKPayloadRefresh } from "back-end/src/services/features";
 import { getAffectedSDKPayloadKeys } from "back-end/src/util/features";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { MakeModelClass } from "./BaseModel";
 
 export const COLLECTION_NAME = "saferollout";
@@ -83,7 +82,9 @@ export class SafeRolloutModel extends BaseClass {
       updates.rampUpSchedule &&
       existing.rampUpSchedule.step !== updates.rampUpSchedule.step
     ) {
-      const feature = await getFeature(this.context, existing.featureId);
+      const feature = await this.context.models.features.getById(
+        existing.featureId,
+      );
       if (!feature) return;
 
       queueSDKPayloadRefresh({

--- a/packages/back-end/src/models/SafeRolloutSnapshotModel.ts
+++ b/packages/back-end/src/models/SafeRolloutSnapshotModel.ts
@@ -8,7 +8,6 @@ import {
   getSafeRolloutAnalysisSummary,
   notifySafeRolloutChange,
 } from "back-end/src/services/safeRolloutSnapshots";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import {
   checkAndRollbackSafeRollout,
   updateRampUpSchedule,
@@ -161,7 +160,9 @@ export class SafeRolloutSnapshotModel extends BaseClass {
       // rule on the feature, so feature/rule lookup and checkAndRollbackSafeRollout
       // only apply to standalone (non-ramp) SRs.
       if (!safeRollout.rampScheduleId) {
-        const feature = await getFeature(this.context, safeRollout.featureId);
+        const feature = await this.context.models.features.getById(
+          safeRollout.featureId,
+        );
         if (!feature) {
           throw new Error("Feature not found");
         }

--- a/packages/back-end/src/routers/archetype/archetype.controller.ts
+++ b/packages/back-end/src/routers/archetype/archetype.controller.ts
@@ -28,7 +28,6 @@ import {
   evaluateFeature,
   getSavedGroupMap,
 } from "back-end/src/services/features";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { getAllPayloadExperiments } from "back-end/src/models/ExperimentModel";
 import { getRevision } from "back-end/src/models/FeatureRevisionModel";
 
@@ -79,7 +78,7 @@ export const getArchetypeAndEval = async (
     skipRulesWithPrerequisites: skipRulesWithPrerequisitesStr,
     project,
   } = req.query;
-  const feature = await getFeature(context, id);
+  const feature = await context.models.features.getById(id);
 
   const scrubPrerequisites =
     scrubPrerequisitesStr === undefined

--- a/packages/back-end/src/routers/attributes/attributes.controller.ts
+++ b/packages/back-end/src/routers/attributes/attributes.controller.ts
@@ -6,7 +6,6 @@ import { getContextFromReq } from "back-end/src/services/organizations";
 import { updateOrganization } from "back-end/src/models/OrganizationModel";
 import { auditDetailsUpdate } from "back-end/src/services/audit";
 import { addTags, addTagsDiff } from "back-end/src/models/TagModel";
-import { getAllFeatures } from "back-end/src/models/FeatureModel";
 import { getAllExperiments } from "back-end/src/models/ExperimentModel";
 import { syncManagedWarehouseIdentifiersOnAttributeChange } from "back-end/src/services/clickhouse";
 import { syncEventForwarderAfterAttributeSchemaChange } from "back-end/src/services/eventForwarder/attributeSync";
@@ -259,7 +258,7 @@ export const getAttributeReferences = async (
   const keySet = new Set(attributeKeys);
 
   const [allFeatures, allExperiments, allSavedGroups] = await Promise.all([
-    getAllFeatures(context, {}),
+    context.models.features.getAll({}),
     getAllExperiments(context, {}),
     context.models.savedGroups.getAll(),
   ]);

--- a/packages/back-end/src/routers/custom-hooks/custom-hooks.controller.ts
+++ b/packages/back-end/src/routers/custom-hooks/custom-hooks.controller.ts
@@ -5,7 +5,6 @@ import { AuthRequest } from "back-end/src/types/AuthRequest";
 import { getContextFromReq } from "back-end/src/services/organizations";
 import { IS_CLOUD } from "back-end/src/util/secrets";
 import { runInSandbox } from "back-end/src/enterprise/sandbox/sandbox-pool";
-import { getFeature } from "back-end/src/models/FeatureModel";
 
 export const getCustomHooks = async (
   req: AuthRequest,
@@ -136,7 +135,7 @@ export const testCustomHook = async (
   const { entityType, entityId } = req.body;
   if (entityType === "feature" && entityId) {
     // Feature-scoped test: authorize against the target feature
-    const feature = await getFeature(context, entityId);
+    const feature = await context.models.features.getById(entityId);
     if (!feature || !context.permissions.canManageFeatureCustomHooks(feature)) {
       context.permissions.throwPermissionError();
     }

--- a/packages/back-end/src/routers/demo-datasource-project/demo-datasource-project.controller.ts
+++ b/packages/back-end/src/routers/demo-datasource-project/demo-datasource-project.controller.ts
@@ -10,7 +10,6 @@ import { EventUserForResponseLocals } from "shared/types/events/event-types";
 import { PostgresConnectionParams } from "shared/types/integrations/postgres";
 import { DataSourceSettings } from "shared/types/datasource";
 import { ExperimentInterface } from "shared/types/experiment";
-import { FeatureInterface } from "shared/types/feature";
 import { ProjectInterface } from "shared/types/project";
 import { ExperimentSnapshotAnalysisSettings } from "shared/types/experiment-snapshot";
 import {
@@ -30,7 +29,7 @@ import {
 } from "back-end/src/services/experiments";
 import { PrivateApiErrorResponse } from "back-end/types/api";
 import { getMetricMap } from "back-end/src/models/MetricModel";
-import { createFeature } from "back-end/src/models/FeatureModel";
+import { CreateFeatureProps } from "back-end/src/models/FeatureModel";
 import { getApplicableEnvIds } from "back-end/src/util/flattenRules";
 import { getEnvironments } from "back-end/src/util/organization.util";
 import {
@@ -445,13 +444,10 @@ Treatment shows a larger 'Add to Cart' CTA, but with the same functionality.`,
     });
 
     // Create feature
-    const featureToCreate: FeatureInterface = {
+    const featureToCreate: CreateFeatureProps = {
       id: getDemoDataSourceFeatureId(),
       version: 1,
       project: project.id,
-      organization: org.id,
-      dateCreated: new Date(),
-      dateUpdated: new Date(),
       description:
         "Controls add to cart CTA. Employees forced to see new CTA, other users randomly assigned to either the control or treatment.",
       owner: context.userId,
@@ -505,7 +501,11 @@ Treatment shows a larger 'Add to Cart' CTA, but with the same functionality.`,
       },
     );
 
-    await createFeature(context, featureToCreate);
+    // Demo project creation is gated by the project/datasource permission
+    // checks above, not manageFeatures.
+    await context.models.features.dangerousCreateBypassPermission(
+      featureToCreate,
+    );
 
     // Use the same helper the runtime uses so the snapshot's analysis
     // settings line up with what the front-end will compute when checking

--- a/packages/back-end/src/routers/holdout/holdout.controller.ts
+++ b/packages/back-end/src/routers/holdout/holdout.controller.ts
@@ -32,11 +32,6 @@ import {
   hasArchivedExperiments,
   updateExperiment,
 } from "back-end/src/models/ExperimentModel";
-import {
-  getFeature,
-  getFeaturesByIds,
-  removeHoldoutFromFeature,
-} from "back-end/src/models/FeatureModel";
 import { logger } from "back-end/src/util/logger";
 import {
   createExperimentSnapshot,
@@ -93,7 +88,8 @@ export const getHoldout = async (
   const linkedFeatureIds = Object.keys(holdout.linkedFeatures);
   const linkedExperimentIds = Object.keys(holdout.linkedExperiments);
 
-  const linkedFeatures = await getFeaturesByIds(context, linkedFeatureIds);
+  const linkedFeatures =
+    await context.models.features.getByIds(linkedFeatureIds);
   const linkedExperiments = await getExperimentsByIds(
     context,
     linkedExperimentIds,
@@ -696,7 +692,8 @@ export const deleteHoldout = async (
   // Remove holdout from linked features and linked experiments
   const linkedFeatureIds = Object.keys(holdout.linkedFeatures);
   const linkedExperimentIds = Object.keys(holdout.linkedExperiments);
-  const linkedFeatures = await getFeaturesByIds(context, linkedFeatureIds);
+  const linkedFeatures =
+    await context.models.features.getByIds(linkedFeatureIds);
   const linkedExperiments = await getExperimentsByIds(
     context,
     linkedExperimentIds,
@@ -704,7 +701,7 @@ export const deleteHoldout = async (
 
   // Remove holdout links from linked features and experiments
   await Promise.all(
-    linkedFeatures.map((f) => removeHoldoutFromFeature(context, f)),
+    linkedFeatures.map((f) => context.models.features.removeHoldout(f)),
   );
   await Promise.all(
     linkedExperiments.map((e) =>
@@ -750,7 +747,7 @@ export const deleteHoldoutFeature = async (
     return res.status(404).json({ status: 404, message: "Holdout not found" });
   }
 
-  const feature = await getFeature(context, req.params.featureId);
+  const feature = await context.models.features.getById(req.params.featureId);
 
   if (!feature) {
     return res.status(404).json({ status: 404, message: "Feature not found" });
@@ -769,7 +766,7 @@ export const deleteHoldoutFeature = async (
     context.permissions.throwPermissionError();
   }
 
-  await removeHoldoutFromFeature(context, feature);
+  await context.models.features.removeHoldout(feature);
 
   await context.models.holdout.update(holdout, {
     linkedFeatures: omit(holdout.linkedFeatures, feature.id),

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -67,10 +67,6 @@ import {
   getRecentWatchedAudits,
   isValidAuditEntityType,
 } from "back-end/src/services/audit";
-import {
-  getAllFeatures,
-  hasNonDemoFeature,
-} from "back-end/src/models/FeatureModel";
 import { findDimensionsByOrganization } from "back-end/src/models/DimensionModel";
 import {
   ALLOW_SELF_ORG_CREATION,
@@ -1028,7 +1024,7 @@ export async function getNamespaces(req: AuthRequest, res: Response) {
   const namespaces: NamespaceUsage = {};
 
   // Get active legacy experiment rules on features
-  const allFeatures = await getAllFeatures(context);
+  const allFeatures = await context.models.features.getAll();
   allFeatures.forEach((f) => {
     if (f.archived) return;
     environments.forEach((env) => {
@@ -2711,7 +2707,7 @@ export async function postAgreeToAgreement(
 
 export async function getFeatureExpUsage(req: AuthRequest, res: Response) {
   const context = getContextFromReq(req);
-  const hasFeatures = await hasNonDemoFeature(context);
+  const hasFeatures = await context.models.features.hasNonDemoFeature();
   const hasExperiments = await hasNonDemoExperiment(context);
 
   return res.status(200).json({

--- a/packages/back-end/src/routers/project/project.controller.ts
+++ b/packages/back-end/src/routers/project/project.controller.ts
@@ -13,10 +13,6 @@ import {
   deleteAllMetricsForAProject,
   removeProjectFromMetrics,
 } from "back-end/src/models/MetricModel";
-import {
-  deleteAllFeaturesForAProject,
-  removeProjectFromFeatures,
-} from "back-end/src/models/FeatureModel";
 import { removeProjectFromProjectRoles } from "back-end/src/models/OrganizationModel";
 import {
   deleteAllExperimentsForAProject,
@@ -229,12 +225,9 @@ export const deleteProject = async (
         context.permissions.throwPermissionError();
       }
 
-      await deleteAllFeaturesForAProject({
-        projectId: id,
-        context,
-      });
+      await context.models.features.deleteAllForProject(id);
     } else {
-      await removeProjectFromFeatures(context, id);
+      await context.models.features.removeProjectFromAllFeatures(id);
     }
   } catch (e) {
     failedToDeleteResources.push("features");

--- a/packages/back-end/src/routers/ramp-schedule/ramp-schedule.controller.ts
+++ b/packages/back-end/src/routers/ramp-schedule/ramp-schedule.controller.ts
@@ -24,7 +24,6 @@ import {
 } from "back-end/src/services/rampSchedule";
 import { createSafeRolloutSnapshot } from "back-end/src/services/safeRolloutSnapshots";
 import { getDataSourceById } from "back-end/src/models/DataSourceModel";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { ConflictError } from "back-end/src/util/errors";
 
 type CreateBody = Pick<
@@ -397,7 +396,9 @@ export const postRampScheduleAction = async (
         });
       }
       if (approvalPending && forceAdvance) {
-        const linkedFeature = await getFeature(context, schedule.entityId);
+        const linkedFeature = await context.models.features.getById(
+          schedule.entityId,
+        );
         if (
           !linkedFeature ||
           !context.permissions.canBypassApprovalChecks(linkedFeature)
@@ -437,7 +438,9 @@ export const postRampScheduleAction = async (
             );
           }
           if (freshApprovalPending && forceAdvance) {
-            const linkedFeature = await getFeature(context, fresh.entityId);
+            const linkedFeature = await context.models.features.getById(
+              fresh.entityId,
+            );
             if (
               !linkedFeature ||
               !context.permissions.canBypassApprovalChecks(linkedFeature)
@@ -738,7 +741,7 @@ export const postRampScheduleAction = async (
       }
 
       const feature = safeRollout.featureId
-        ? await getFeature(context, safeRollout.featureId)
+        ? await context.models.features.getById(safeRollout.featureId)
         : null;
 
       await createSafeRolloutSnapshot({

--- a/packages/back-end/src/routers/safe-rollout/safe-rollout.controller.ts
+++ b/packages/back-end/src/routers/safe-rollout/safe-rollout.controller.ts
@@ -11,7 +11,6 @@ import { AuthRequest } from "back-end/src/types/AuthRequest";
 import { createSafeRolloutSnapshot } from "back-end/src/services/safeRolloutSnapshots";
 import { getIntegrationFromDatasourceId } from "back-end/src/services/datasource";
 import { SafeRolloutResultsQueryRunner } from "back-end/src/queryRunners/SafeRolloutResultsQueryRunner";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { validateCreateSafeRolloutFields } from "back-end/src/validators/safe-rollout";
 import {
   runLockedRampScheduleAction,
@@ -84,7 +83,7 @@ export const postSafeRolloutSnapshot = async (
     });
   }
 
-  const feature = await getFeature(context, safeRollout.featureId);
+  const feature = await context.models.features.getById(safeRollout.featureId);
   if (!feature) {
     return res.status(404).json({
       status: 404,
@@ -142,7 +141,7 @@ export const cancelSafeRolloutSnapshot = async (
     });
   }
 
-  const feature = await getFeature(context, safeRollout.featureId);
+  const feature = await context.models.features.getById(safeRollout.featureId);
   if (!feature) {
     throw new Error("Could not find feature");
   }

--- a/packages/back-end/src/routers/tag/tag.controller.ts
+++ b/packages/back-end/src/routers/tag/tag.controller.ts
@@ -6,7 +6,6 @@ import { ApiErrorResponse } from "back-end/types/api";
 import { getContextFromReq } from "back-end/src/services/organizations";
 import { addTag, removeTag } from "back-end/src/models/TagModel";
 import { removeTagInMetrics } from "back-end/src/models/MetricModel";
-import { removeTagInFeature } from "back-end/src/models/FeatureModel";
 import { removeTagFromSlackIntegration } from "back-end/src/models/SlackIntegrationModel";
 import { removeTagInAttribute } from "back-end/src/services/attributes";
 import { removeTagFromExperiments } from "back-end/src/models/ExperimentModel";
@@ -82,7 +81,7 @@ export const deleteTag = async (
   await removeTagInMetrics(org.id, id);
 
   // features
-  await removeTagInFeature(context, id);
+  await context.models.features.removeTagFromAllFeatures(id);
 
   // attributes
   await removeTagInAttribute(context, id);

--- a/packages/back-end/src/routers/users/users.controller.ts
+++ b/packages/back-end/src/routers/users/users.controller.ts
@@ -16,7 +16,6 @@ import {
   getUserByEmail,
   updateUser,
 } from "back-end/src/models/UserModel";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
 import { findRecentAuditByUserIdAndOrganization } from "back-end/src/models/AuditModel";
 
@@ -154,7 +153,7 @@ export async function postWatchItem(
   }
 
   if (type === "feature") {
-    item = await getFeature(context, id);
+    item = await context.models.features.getById(id);
   } else if (type === "experiment") {
     item = await getExperimentById(context, id);
     if (item && item.organization !== org.id) {

--- a/packages/back-end/src/scripts/diff-features.ts
+++ b/packages/back-end/src/scripts/diff-features.ts
@@ -464,21 +464,27 @@ async function runApiObj(suffix: "v1" | "v2", args: string[]) {
     string,
     unknown
   >;
-  const { FeatureModel } = featureModelMod as {
-    FeatureModel: typeof import("../models/FeatureModel").FeatureModel;
-  };
   const { getApiFeatureObj } = await import("../services/features");
 
-  // origin/main: `toInterface` is a non-exported `const` and the v0→v1
-  // migration lives in a separate `upgradeFeatureInterface(toInterface(…))`
-  // wrapper at every callsite. We replicate both steps so run1 on main
-  // matches what production emits — otherwise run2 on this branch (where
-  // the migration is folded into the exported `toInterface` /
-  // `migrateRawFeatureToV2`) would diff against a pre-migration v0 doc and
-  // spuriously flag every legacy feature.
   type FeatureInterfaceT = import("shared/types/feature").FeatureInterface;
   type LegacyT = import("shared/types/feature").LegacyFeatureInterface;
-  type FeatureDoc = InstanceType<typeof FeatureModel>;
+
+  // Preferred path: the exported pure JIT migration (present on current main
+  // and on branches where FeatureModel is a BaseModel class). Falls back to
+  // the legacy mongoose-doc + toInterface path for older checkouts where
+  // `FeatureModel` is still a mongoose model and the migration lives in
+  // `upgradeFeatureInterface(toInterface(…))`.
+  const migrateRawFeature = featureModelMod.migrateRawFeatureToV2 as
+    | ((raw: LegacyT, context: ReqContext) => FeatureInterfaceT)
+    | undefined;
+
+  // Legacy mongoose model constructor (older checkouts only — on BaseModel
+  // branches this export is the model class and is never constructed here
+  // because `migrateRawFeature` takes precedence).
+  const LegacyMongooseFeatureModel = featureModelMod.FeatureModel as
+    | (new (raw: LegacyT) => { toJSON: () => Record<string, unknown> })
+    | undefined;
+  type FeatureDoc = { toJSON: () => Record<string, unknown> };
 
   const exportedToInterface = featureModelMod.toInterface as
     | ((doc: FeatureDoc, context: ReqContext) => FeatureInterfaceT)
@@ -600,7 +606,19 @@ async function runApiObj(suffix: "v1" | "v2", args: string[]) {
     const context = { org } as ReqContext;
 
     try {
-      let feature = toInterfaceFn(new FeatureModel(raw), context);
+      let feature: FeatureInterfaceT;
+      if (migrateRawFeature) {
+        const cleaned = { ...(raw as Record<string, unknown>) };
+        delete cleaned.__v;
+        delete cleaned._id;
+        feature = migrateRawFeature(cleaned as unknown as LegacyT, context);
+      } else if (LegacyMongooseFeatureModel) {
+        feature = toInterfaceFn(new LegacyMongooseFeatureModel(raw), context);
+      } else {
+        throw new Error(
+          "FeatureModel module exports neither migrateRawFeatureToV2 nor a mongoose model",
+        );
+      }
       if (upgradeFeatureInterface) {
         feature = upgradeFeatureInterface(feature);
       }

--- a/packages/back-end/src/services/auth/LocalAuthConnection.ts
+++ b/packages/back-end/src/services/auth/LocalAuthConnection.ts
@@ -18,13 +18,21 @@ import { getUserById } from "back-end/src/models/UserModel";
 import { AuthConnection, TokensResponse } from "./AuthConnection";
 import { isNewInstallation } from ".";
 
-const jwtCheck = expressjwt({
-  secret: JWT_SECRET,
-  audience: "https://api.growthbook.io",
-  issuer: "https://api.growthbook.io",
-  algorithms: ["HS256"],
-  requestProperty: "user",
-});
+// Built lazily rather than at module load so a circular-import load order can't
+// evaluate this before JWT_SECRET is initialized (see PR #6306).
+let jwtCheck: ReturnType<typeof expressjwt> | undefined;
+function getJwtCheck() {
+  if (!jwtCheck) {
+    jwtCheck = expressjwt({
+      secret: JWT_SECRET,
+      audience: "https://api.growthbook.io",
+      issuer: "https://api.growthbook.io",
+      algorithms: ["HS256"],
+      requestProperty: "user",
+    });
+  }
+  return jwtCheck;
+}
 
 export class LocalAuthConnection implements AuthConnection {
   async refresh(
@@ -87,7 +95,7 @@ export class LocalAuthConnection implements AuthConnection {
     if (!JWT_SECRET) {
       throw new Error("Must specify JWT_SECRET environment variable");
     }
-    jwtCheck(req, res, next);
+    getJwtCheck()(req, res, next);
   }
   private generateJWT(user: UserInterface) {
     return jwt.sign(

--- a/packages/back-end/src/services/constants.ts
+++ b/packages/back-end/src/services/constants.ts
@@ -7,7 +7,6 @@ import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import { BadRequestError } from "back-end/src/util/errors";
 import { getPayloadKeysForAllEnvs } from "back-end/src/models/ExperimentModel";
-import { getAllFeatures } from "back-end/src/models/FeatureModel";
 import { queueSDKPayloadRefresh } from "./features";
 import { getContextForAgendaJobByOrgObject } from "./organizations";
 
@@ -135,7 +134,7 @@ export async function loadConstantReferences(
     ...constantsReferencingTarget.map((c) => c.key),
   ]);
 
-  const allFeatures = await getAllFeatures(context, {});
+  const allFeatures = await context.models.features.getAll({});
   const features = allFeatures
     .filter((f) => {
       const keys = featureConstantKeys(f);

--- a/packages/back-end/src/services/context.ts
+++ b/packages/back-end/src/services/context.ts
@@ -145,7 +145,11 @@ export type ModelName =
   | "sessionReplays"
   | "eventForwarderConfigs";
 
-export const modelClasses = {
+// Registry of model constructors, used ONLY to derive the ModelName/ModelClass/
+// ModelInstances types below (via ReturnType). Written as a never-called function
+// so the class bindings are not read at module-eval time — otherwise the
+// context <-> FeatureModel import cycle would TDZ on load (see PR #6306).
+export const modelClasses = () => ({
   agreements: AgreementModel,
   aiPrompts: AiPromptModel,
   customFields: CustomFieldModel,
@@ -194,18 +198,18 @@ export const modelClasses = {
   contextualBanditEvents: ContextualBanditEventModel,
   sessionReplays: SessionReplayModel,
   eventForwarderConfigs: EventForwarderConfigModel,
-};
+});
 // ModelClass narrows to only BaseModel-derived model constructors (those
 // expose a static `getModelConfig`). Non-BaseModel context models — e.g.
 // SessionReplayModel, which is backed by ClickHouse + S3 rather than
 // Mongo — are still registered on the request context but excluded from
 // API_MODELS iteration in api.router.ts.
 export type ModelClass = Extract<
-  (typeof modelClasses)[ModelName],
+  ReturnType<typeof modelClasses>[ModelName],
   { getModelConfig: () => unknown }
 >;
 type ModelInstances = {
-  [K in ModelName]: InstanceType<(typeof modelClasses)[K]>;
+  [K in ModelName]: InstanceType<ReturnType<typeof modelClasses>[K]>;
 };
 
 export class ReqContextClass {

--- a/packages/back-end/src/services/context.ts
+++ b/packages/back-end/src/services/context.ts
@@ -61,7 +61,7 @@ import { SavedQueryDataModel } from "back-end/src/models/SavedQueryDataModel";
 import { SavedGroupModel } from "back-end/src/models/SavedGroupModel";
 import { ConstantModel } from "back-end/src/models/ConstantModel";
 import { FeatureRevisionLogModel } from "back-end/src/models/FeatureRevisionLogModel";
-import { getFeaturesByIds } from "back-end/src/models/FeatureModel";
+import { FeatureModel } from "back-end/src/models/FeatureModel";
 import { AiPromptModel } from "back-end/src/enterprise/models/AIPromptModel";
 import { VectorsModel } from "back-end/src/enterprise/models/VectorsModel";
 import { AgreementModel } from "back-end/src/models/AgreementModel";
@@ -100,6 +100,7 @@ export type ModelName =
   | "aiPrompts"
   | "customFields"
   | "factMetrics"
+  | "features"
   | "featureRevisionLogs"
   | "projects"
   | "urlRedirects"
@@ -149,6 +150,7 @@ export const modelClasses = {
   aiPrompts: AiPromptModel,
   customFields: CustomFieldModel,
   factMetrics: FactMetricModel,
+  features: FeatureModel,
   featureRevisionLogs: FeatureRevisionLogModel,
   projects: ProjectModel,
   urlRedirects: UrlRedirectModel,
@@ -215,6 +217,7 @@ export class ReqContextClass {
       aiPrompts: new AiPromptModel(this),
       customFields: new CustomFieldModel(this),
       factMetrics: new FactMetricModel(this),
+      features: new FeatureModel(this),
       featureRevisionLogs: new FeatureRevisionLogModel(this),
       projects: new ProjectModel(this),
       urlRedirects: new UrlRedirectModel(this),
@@ -464,7 +467,7 @@ export class ReqContextClass {
       getExperimentMetricsByIds(this, ids),
     );
     await this.addMissingForeignRefs("feature", feature, (ids) =>
-      getFeaturesByIds(this, ids),
+      this.models.features.getByIds(ids),
     );
   }
   private async addMissingForeignRefs<K extends keyof ForeignRefsCache>(

--- a/packages/back-end/src/services/contextualBanditChanges.ts
+++ b/packages/back-end/src/services/contextualBanditChanges.ts
@@ -5,7 +5,6 @@ import {
   ContextualBanditUpdate,
   determineNextContextualBanditSchedule,
 } from "back-end/src/services/contextualBanditSchedule";
-import { getFeaturesByIds } from "back-end/src/models/FeatureModel";
 import { getAffectedSDKPayloadKeys } from "back-end/src/util/features";
 import { getEnvironmentIdsFromOrg } from "back-end/src/util/organization.util";
 import { queueSDKPayloadRefresh } from "back-end/src/services/features";
@@ -37,8 +36,7 @@ async function refreshLinkedFeaturePayloads(
   cb: ContextualBanditInterface,
   auditEvent: "contextualBandit.start" | "contextualBandit.stop",
 ): Promise<void> {
-  const linkedFeatures = await getFeaturesByIds(
-    context,
+  const linkedFeatures = await context.models.features.getByIds(
     cb.linkedFeatures ?? [],
   );
   if (!linkedFeatures.length) return;

--- a/packages/back-end/src/services/discussions.ts
+++ b/packages/back-end/src/services/discussions.ts
@@ -2,7 +2,6 @@ import uniqid from "uniqid";
 import { Comment, DiscussionParentType } from "shared/types/discussion";
 import { DiscussionModel } from "back-end/src/models/DiscussionModel";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { getMetricById } from "back-end/src/models/MetricModel";
 import { ReqContext } from "back-end/types/request";
 import { getIdeaById } from "./ideas";
@@ -42,7 +41,7 @@ export async function getProjectsByParentId(
     }
 
     case "feature": {
-      const feature = await getFeature(context, parentId);
+      const feature = await context.models.features.getById(parentId);
 
       if (!feature) {
         throw Error("Feature not found");

--- a/packages/back-end/src/services/experiment-feature.ts
+++ b/packages/back-end/src/services/experiment-feature.ts
@@ -28,10 +28,9 @@ import { ApiReqContext } from "back-end/types/api";
 import { applyPartialFeatureRuleUpdatesToRevision } from "back-end/src/util/featureRevision.util";
 import {
   editFeatureRules,
-  getFeature,
   prevalidatePublishRevision,
   publishRevision,
-} from "back-end/src/models/FeatureModel";
+} from "back-end/src/services/featureRevisions";
 import {
   discardRevision,
   getRevision,
@@ -418,7 +417,10 @@ export async function publishPendingFeatureDraftsForExperiment(
   const featureCache = new Map<string, FeatureInterface | null>();
   const getCachedFeature = async (featureId: string) => {
     if (!featureCache.has(featureId)) {
-      featureCache.set(featureId, await getFeature(context, featureId));
+      featureCache.set(
+        featureId,
+        await context.models.features.getById(featureId),
+      );
     }
     return featureCache.get(featureId) ?? null;
   };
@@ -533,7 +535,7 @@ export async function publishPendingFeatureDraftsForExperiment(
     let { feature, revision, mergeResult } = entry;
 
     if (publishedFeatureIds.has(featureId)) {
-      const freshFeature = await getFeature(context, featureId);
+      const freshFeature = await context.models.features.getById(featureId);
       if (!freshFeature) continue;
       feature = freshFeature;
       const freshRevision = await getRevision({
@@ -649,7 +651,7 @@ export async function publishPendingFeatureDraftsForContextualBandit(
   const cbModel = context.models.contextualBandits;
 
   for (const { featureId, revisionVersion } of drafts) {
-    const feature = await getFeature(context, featureId);
+    const feature = await context.models.features.getById(featureId);
     if (!feature) {
       await cbModel.removePendingFeatureDraft(
         cb.id,
@@ -717,7 +719,7 @@ export async function publishPendingFeatureDraftsForContextualBandit(
   const published: ResolvedDraft[] = [];
 
   for (const { featureId, revisionVersion } of ready) {
-    const feature = await getFeature(context, featureId);
+    const feature = await context.models.features.getById(featureId);
     if (!feature) continue;
     const revision = await getRevision({
       context,

--- a/packages/back-end/src/services/experimentChanges/changeExperimentStatus.ts
+++ b/packages/back-end/src/services/experimentChanges/changeExperimentStatus.ts
@@ -20,7 +20,6 @@ import {
   getExperimentById,
   updateExperiment,
 } from "back-end/src/models/ExperimentModel";
-import { getFeaturesByIds } from "back-end/src/models/FeatureModel";
 import { findSDKConnectionsByOrganization } from "back-end/src/models/SdkConnectionModel";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
@@ -311,8 +310,7 @@ async function loadAndValidateExperimentForStatusChange(
     context.permissions.throwPermissionError();
   }
 
-  const linkedFeatures = await getFeaturesByIds(
-    context,
+  const linkedFeatures = await context.models.features.getByIds(
     experiment.linkedFeatures || [],
   );
   const envs = getAffectedEnvsForExperiment({

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -183,7 +183,6 @@ import {
   FactTableMap,
   getFactTableMap,
 } from "back-end/src/models/FactTableModel";
-import { getFeaturesByIds } from "back-end/src/models/FeatureModel";
 import { findSDKConnectionsByOrganization } from "back-end/src/models/SdkConnectionModel";
 import { getFeatureRevisionsByFeatureIds } from "back-end/src/models/FeatureRevisionModel";
 import { getLiveAndBaseRevisionsForFeature } from "back-end/src/services/features";
@@ -4661,7 +4660,7 @@ export async function getRefLinkedFeatureInfo({
 }): Promise<LinkedFeatureInfo[]> {
   if (!linkedFeatureIds.length) return [];
 
-  const features = await getFeaturesByIds(context, linkedFeatureIds);
+  const features = await context.models.features.getByIds(linkedFeatureIds);
 
   const featuresByFeatureId = Object.fromEntries(
     features.map((f) => [f.id, f]),

--- a/packages/back-end/src/services/featureRevisions.ts
+++ b/packages/back-end/src/services/featureRevisions.ts
@@ -1,0 +1,1378 @@
+import { v4 as uuidv4 } from "uuid";
+import cloneDeep from "lodash/cloneDeep";
+import omit from "lodash/omit";
+import {
+  MergeResultChanges,
+  checkIfRevisionNeedsReview,
+  autoMerge,
+  liveRevisionFromFeature,
+  PermissionError,
+  stemRuleId,
+} from "shared/util";
+import {
+  SafeRolloutInterface,
+  SafeRolloutRule,
+  RampScheduleInterface,
+  RampScheduleTemplateInterface,
+  RevisionRampAction,
+  RevisionRampCreateAction,
+  RevisionRampUpdateAction,
+  RampStepAction,
+} from "shared/validators";
+import { UpdateProps } from "shared/types/base-model";
+import { FeatureInterface, FeatureRule } from "shared/types/feature";
+import { EventUser } from "shared/types/events/event-types";
+import { OrganizationInterface } from "shared/types/organization";
+import { FeatureRevisionInterface } from "shared/types/feature-revision";
+import {
+  addIdsToFlatRules,
+  generateRuleId,
+  getNextScheduledUpdate,
+} from "back-end/src/services/features";
+import {
+  appendRampEvent,
+  assertFeatureNotLockedByRamp,
+  computeNextProcessAt,
+  ensureSafeRolloutForMonitoredRamp,
+  getStartActionsFromRules,
+  mergeStepsForRunningSchedule,
+  remapTemplateActions,
+  runLockedRampScheduleAction,
+  startReadyScheduleNow,
+  syncLinkedSafeRolloutForRampState,
+} from "back-end/src/services/rampSchedule";
+import { NotFoundError } from "back-end/src/util/errors";
+import { getApplicableEnvIds } from "back-end/src/util/flattenRules";
+import { ReqContext } from "back-end/types/request";
+import { getLinkedExperiments } from "back-end/src/util/features";
+import { applyPartialFeatureRuleUpdatesToRevision } from "back-end/src/util/featureRevision.util";
+import { logger } from "back-end/src/util/logger";
+import { getEnvironmentIdsFromOrg } from "back-end/src/services/organizations";
+import { getEnvironments } from "back-end/src/util/organization.util";
+import { ApiReqContext } from "back-end/types/api";
+import { determineNextSafeRolloutSnapshotAttempt } from "back-end/src/enterprise/saferollouts/safeRolloutUtils";
+import {
+  runValidateFeatureHooks,
+  runValidateFeatureRevisionHooks,
+} from "back-end/src/enterprise/sandbox/sandbox-eval";
+import {
+  clearPendingFeatureDraftsForRevision,
+  getExperimentById,
+  updateExperiment,
+} from "back-end/src/models/ExperimentModel";
+import {
+  getRevision,
+  hasPublishLockingScheduledSibling,
+  markRevisionAsPublished,
+  computeRevisionPublishChanges,
+  updateRevision,
+  createRevision,
+} from "back-end/src/models/FeatureRevisionModel";
+
+/**
+ * Append a rule to `revision.rules`. `envs === undefined` or an `envs` list
+ * covering every applicable env collapses to `allEnvironments: true`.
+ */
+export async function addFeatureRule(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  revision: FeatureRevisionInterface,
+  envs: string[] | undefined,
+  rule: FeatureRule,
+  user: EventUser,
+  resetReview: boolean,
+) {
+  if (!rule.id) {
+    rule.id = generateRuleId();
+  }
+  if (rule.type === "rollout" && !rule.seed) {
+    rule.seed = rule.id;
+  }
+
+  const applicableEnvs = getEnvironmentIdsFromOrg(context.org);
+  const isAllEnvs =
+    !envs || envs.length === 0 || applicableEnvs.every((e) => envs.includes(e));
+
+  const scopedRule: FeatureRule = isAllEnvs
+    ? ({ ...rule, allEnvironments: true } as FeatureRule)
+    : ({
+        ...rule,
+        allEnvironments: false,
+        environments: [...envs!],
+      } as FeatureRule);
+
+  const nextRules: FeatureRule[] = [...(revision.rules ?? []), scopedRule];
+
+  await updateRevision(
+    context,
+    feature,
+    revision,
+    { rules: nextRules },
+    {
+      user,
+      action: "add rule",
+      subject: isAllEnvs ? "to all environments" : `to ${envs!.join(", ")}`,
+      value: JSON.stringify(scopedRule),
+    },
+    resetReview,
+  );
+}
+
+// Edit a single rule by `ruleId`. `auditEnvironment` is only used for the
+// audit log subject. See `editFeatureRules` for the batch form.
+export async function editFeatureRule(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  revision: FeatureRevisionInterface,
+  ruleId: string,
+  updates: Partial<FeatureRule>,
+  user: EventUser,
+  resetReview: boolean,
+  auditEnvironment?: string,
+) {
+  return await editFeatureRules(
+    context,
+    feature,
+    revision,
+    [{ ruleId, environmentId: auditEnvironment }],
+    updates,
+    user,
+    resetReview,
+  );
+}
+
+/**
+ * Batch edit rules matched by `ruleId`. `environmentId` is used only for the
+ * audit log subject; matching is by id alone. Duplicate ids collapse to a
+ * single overlay (idempotent).
+ */
+export async function editFeatureRules(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  revision: FeatureRevisionInterface,
+  matches: { ruleId: string; environmentId?: string }[],
+  updates: Partial<FeatureRule>,
+  user: EventUser,
+  resetReview: boolean,
+) {
+  const projected = applyPartialFeatureRuleUpdatesToRevision(
+    revision,
+    matches.map((m) => m.ruleId),
+    updates,
+  );
+
+  // Audit subject uses caller-supplied envs (the user's tab context), not
+  // the rule's underlying scope.
+  const envs = Array.from(
+    new Set(
+      matches.map((m) => m.environmentId).filter((e): e is string => !!e),
+    ),
+  );
+  const subject =
+    envs.length === 0
+      ? `rule ${matches[0]?.ruleId ?? ""}`
+      : envs.length === 1
+        ? `in ${envs[0]}`
+        : `in ${envs.join(", ")}`;
+
+  const updatedRevision = await updateRevision(
+    context,
+    feature,
+    revision,
+    { rules: projected.rules ?? [] },
+    {
+      user,
+      action: "edit rule",
+      subject,
+      value: JSON.stringify(updates),
+    },
+    resetReview,
+  );
+  return updatedRevision;
+}
+
+export async function setDefaultValue(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  revision: FeatureRevisionInterface,
+  defaultValue: string,
+  user: EventUser,
+  requireReview: boolean,
+) {
+  return updateRevision(
+    context,
+    feature,
+    revision,
+    { defaultValue },
+    {
+      user,
+      action: "edit default value",
+      subject: ``,
+      value: JSON.stringify({ defaultValue }),
+    },
+    requireReview,
+  );
+}
+
+const updateSafeRolloutStatuses = async (
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  revision: FeatureRevisionInterface,
+) => {
+  if (!revision.rules || revision.rules.length === 0) return;
+
+  const safeRolloutStatusesMap: Record<
+    string,
+    { status: "running" | "rolled-back" | "released" | "stopped" }
+  > = Object.fromEntries(
+    revision.rules
+      .filter((rule): rule is SafeRolloutRule => rule?.type === "safe-rollout")
+      .map((rule) => [rule.safeRolloutId, { status: rule.status }]),
+  );
+  // Stop safe rollouts whose rule was removed in this revision.
+  (feature.rules ?? []).forEach((rule) => {
+    if (
+      rule?.type === "safe-rollout" &&
+      !safeRolloutStatusesMap[rule.safeRolloutId]
+    ) {
+      safeRolloutStatusesMap[rule.safeRolloutId] = { status: "stopped" };
+    }
+  });
+
+  const safeRollouts = await context.models.safeRollout.getByIds(
+    Object.keys(safeRolloutStatusesMap),
+  );
+
+  safeRollouts.forEach((safeRollout) => {
+    // sync the status of the safe rollout to the status of the revision
+    const safeRolloutUpdates: UpdateProps<SafeRolloutInterface> = {
+      status: safeRolloutStatusesMap[safeRollout.id].status,
+    };
+    if (!safeRollout.startedAt && safeRolloutUpdates.status === "running") {
+      safeRolloutUpdates["startedAt"] = new Date();
+      const { nextSnapshot, nextRampUp } =
+        determineNextSafeRolloutSnapshotAttempt(safeRollout, context.org);
+      safeRolloutUpdates["nextSnapshotAttempt"] = nextSnapshot;
+      safeRolloutUpdates["rampUpSchedule"] = {
+        ...safeRollout.rampUpSchedule,
+        nextUpdate: nextRampUp,
+      };
+    }
+
+    context.models.safeRollout.update(safeRollout, safeRolloutUpdates);
+  });
+};
+
+// Pure computation of the feature-doc changes a revision merge will produce; no writes
+export function computeRevisionMergeChanges(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  revision: FeatureRevisionInterface,
+  result: MergeResultChanges,
+): {
+  changes: UpdateProps<FeatureInterface>;
+  hasChanges: boolean;
+  removeHoldout: boolean;
+} {
+  let hasChanges = false;
+  const changes: UpdateProps<FeatureInterface> = {};
+  let removeHoldout = false;
+
+  if (result.defaultValue !== undefined) {
+    changes.defaultValue = result.defaultValue;
+    hasChanges = true;
+  }
+
+  if (result.rules !== undefined) {
+    changes.rules = result.rules;
+    // Ensure every rollout rule that's being published has a seed — required
+    // for ramp-monitored payload stability. Rules created before the
+    // seed-backfill was introduced (or attached to a ramp for the first time)
+    // get seed = rule.id here so they match the SDK's featureId fallback.
+    addIdsToFlatRules(changes.rules, feature.id);
+    hasChanges = true;
+  }
+
+  if (result.environmentsEnabled) {
+    const envs = getEnvironmentIdsFromOrg(context.org);
+    const nextEnvSettings = cloneDeep(feature.environmentSettings || {});
+    let envChanged = false;
+    envs.forEach((env) => {
+      const desired = result.environmentsEnabled?.[env];
+      if (desired === undefined) return;
+      const current = nextEnvSettings[env] || { enabled: false };
+      // Skip no-op writes so we don't invalidate the SDK payload cache.
+      if (current.enabled !== desired) envChanged = true;
+      nextEnvSettings[env] = { ...current, enabled: desired };
+    });
+    if (envChanged) {
+      changes.environmentSettings = nextEnvSettings;
+      hasChanges = true;
+    }
+  }
+
+  if (result.prerequisites !== undefined) {
+    changes.prerequisites = result.prerequisites;
+    hasChanges = true;
+  }
+
+  if (result.archived !== undefined) {
+    changes.archived = result.archived;
+    hasChanges = true;
+  }
+
+  if (result.holdout !== undefined) {
+    // null means remove from holdout; object means set/change holdout
+    if (result.holdout === null) {
+      removeHoldout = true;
+    } else {
+      changes.holdout = result.holdout;
+    }
+    hasChanges = true;
+  }
+
+  if (result.metadata) {
+    const m = result.metadata;
+    if (m.description !== undefined) changes.description = m.description;
+    if (m.owner !== undefined) changes.owner = m.owner;
+    if (m.project !== undefined) changes.project = m.project;
+    if (m.tags !== undefined) changes.tags = m.tags;
+    if (m.neverStale !== undefined) changes.neverStale = m.neverStale;
+    if (m.customFields !== undefined)
+      changes.customFields = m.customFields as Record<string, unknown>;
+    if (m.jsonSchema !== undefined) changes.jsonSchema = m.jsonSchema;
+    hasChanges = true;
+  }
+
+  // No content delta — still advance feature.version so the revision we're
+  // about to mark published becomes live. Skipping this leaves a "Locked"
+  // revision behind a stale feature.version, which traps subsequent reverts.
+  if (!hasChanges) {
+    changes.version = revision.version;
+    return { changes, hasChanges, removeHoldout };
+  }
+
+  if (changes.rules !== undefined) {
+    changes.nextScheduledUpdate = getNextScheduledUpdate(changes.rules);
+  }
+
+  changes.version = revision.version;
+
+  return { changes, hasChanges, removeHoldout };
+}
+
+// Apply a revision merge result to the feature document. Feature writes skip
+// the model-level manageFeatures check — publish authority is the env-scoped
+// publishFeatures permission, checked by the caller.
+export async function applyRevisionChanges(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  revision: FeatureRevisionInterface,
+  result: MergeResultChanges,
+) {
+  const { changes, hasChanges, removeHoldout } = computeRevisionMergeChanges(
+    context,
+    feature,
+    revision,
+    result,
+  );
+
+  if (!hasChanges) {
+    return await context.models.features.dangerousUpdateBypassPermission(
+      feature,
+      changes,
+    );
+  }
+
+  await updateSafeRolloutStatuses(context, feature, revision);
+
+  // Handle holdout removal separately since the feature update only does $set
+  if (removeHoldout) {
+    await context.models.features.removeHoldout(feature);
+    // Remove holdout from the feature object so the returned feature is correct
+    const { holdout: _, ...featureWithoutHoldout } = feature;
+    return await context.models.features.dangerousUpdateBypassPermission(
+      featureWithoutHoldout as FeatureInterface,
+      changes,
+    );
+  }
+
+  return await context.models.features.dangerousUpdateBypassPermission(
+    feature,
+    changes,
+  );
+}
+
+// Run HoldoutModel / Experiment side-effects when a feature's holdout
+// membership changes at publish. Called from `publishRevision` when
+// `result.holdout` is defined, so all publish paths (direct, approval,
+// revert, etc.) are covered. `feature` is pre-publish (used for prevHoldout);
+// `newHoldout: null` means "remove from holdout".
+export async function applyHoldoutSideEffects(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  newHoldout: { id: string; value: string } | null,
+) {
+  const prevHoldoutId = feature.holdout?.id;
+  const newHoldoutId = newHoldout?.id;
+
+  if (newHoldoutId === prevHoldoutId) return;
+
+  // Guard: cannot change holdout when there are running experiments, bandits, or safe rollouts
+  if (newHoldout !== null) {
+    const experiments = await Promise.all(
+      (feature.linkedExperiments ?? []).map((id) =>
+        getExperimentById(context, id),
+      ),
+    );
+    const hasNonDraftExperiments = experiments.some(
+      (exp) => exp?.status !== "draft",
+    );
+    const hasBandits = experiments.some(
+      (exp) => exp?.type === "multi-armed-bandit",
+    );
+    const hasSafeRollouts = (feature.rules ?? []).some(
+      (rule) => rule?.type === "safe-rollout",
+    );
+    if (hasNonDraftExperiments || hasBandits || hasSafeRollouts) {
+      throw new Error(
+        "Cannot change holdout when there are running linked experiments, safe rollout rules, or multi-armed bandit rules",
+      );
+    }
+  }
+
+  // Remove feature from the old holdout
+  if (prevHoldoutId) {
+    await context.models.holdout.removeFeatureFromHoldout(
+      prevHoldoutId,
+      feature.id,
+    );
+  }
+
+  // Link feature (and its experiments) to the new holdout
+  if (newHoldoutId) {
+    const holdoutObj = await context.models.holdout.getById(newHoldoutId);
+    if (!holdoutObj) {
+      throw new Error("Holdout not found");
+    }
+
+    await context.models.holdout.updateById(newHoldoutId, {
+      linkedFeatures: {
+        [feature.id]: { id: feature.id, dateAdded: new Date() },
+        ...holdoutObj.linkedFeatures,
+      },
+      ...(feature.linkedExperiments?.length
+        ? {
+            linkedExperiments: {
+              ...Object.fromEntries(
+                feature.linkedExperiments.map((experimentId) => [
+                  experimentId,
+                  { id: experimentId, dateAdded: new Date() },
+                ]),
+              ),
+              ...holdoutObj.linkedExperiments,
+            },
+          }
+        : {}),
+    });
+
+    if (feature.linkedExperiments?.length) {
+      const linkedExperiments = await Promise.all(
+        feature.linkedExperiments.map((eid) => getExperimentById(context, eid)),
+      );
+      await Promise.all(
+        linkedExperiments.map(async (exp) => {
+          if (!exp) return;
+          return updateExperiment({
+            context,
+            experiment: exp,
+            changes: { holdoutId: newHoldoutId },
+          });
+        }),
+      );
+    }
+  }
+}
+
+// Apply deferred ramp create/update actions stored on a revision.
+// - `create` actions are called BEFORE feature write so schedule creation
+//   failures abort publish.
+// - `update` actions are called AFTER publish succeeds (best-effort).
+// Returns only newly created schedule IDs (for rollback on failure).
+async function createRampSchedulesForRevision(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  revision: { version: number },
+  result: MergeResultChanges,
+  actions: RevisionRampAction[],
+): Promise<string[]> {
+  const createdIds: string[] = [];
+
+  for (const action of actions) {
+    if (action.mode !== "create" && action.mode !== "update") continue;
+
+    // Pro gate — see postRampSchedule.ts for rationale.
+    if (!context.hasPremiumFeature("schedule-feature-flag")) {
+      context.throwPlanDoesNotAllowError(
+        "Ramp schedules require a Pro plan or above.",
+      );
+    }
+
+    const existingSchedule =
+      action.mode === "update"
+        ? await context.models.rampSchedules.getById(action.rampScheduleId)
+        : null;
+    if (action.mode === "update" && !existingSchedule) {
+      logger.warn(
+        { rampScheduleId: action.rampScheduleId, ruleId: action.ruleId },
+        "Ramp schedule not found at revision publish time — skipping deferred update action",
+      );
+      continue;
+    }
+
+    const existingTarget =
+      action.mode === "update"
+        ? existingSchedule?.targets.find(
+            (t) => stemRuleId(t.ruleId ?? "") === stemRuleId(action.ruleId),
+          )
+        : null;
+    if (action.mode === "update" && !existingTarget) {
+      logger.warn(
+        {
+          rampScheduleId: action.rampScheduleId,
+          ruleId: action.ruleId,
+        },
+        "Ramp schedule target no longer matches rule at revision publish time — skipping deferred update action",
+      );
+      continue;
+    }
+
+    const targetId = existingTarget?.id ?? uuidv4();
+
+    // Inject the generated targetId into every action and ensure targetType
+    // is always set. Handles both correctly-typed actions and legacy drafts
+    // that were stored without targetType.
+    const normalizeAction = (
+      a: RevisionRampCreateAction["steps"][number]["actions"][number],
+    ): RampStepAction => ({
+      targetType: "feature-rule" as const,
+      targetId,
+      patch: {
+        ...a.patch,
+        ruleId: action.ruleId,
+      },
+    });
+
+    // Template is used as a fallback; explicit steps/endActions win.
+    let template: RampScheduleTemplateInterface | undefined;
+    if (action.templateId) {
+      const tmpl = await context.models.rampScheduleTemplates.getById(
+        action.templateId,
+      );
+      if (!tmpl) {
+        logger.warn(
+          { templateId: action.templateId },
+          "Ramp schedule template not found at revision publish time — skipping template",
+        );
+      } else {
+        template = tmpl;
+      }
+    }
+
+    const defaultName = `Ramp schedule \u2013 ${new Date().toLocaleDateString(
+      "en-US",
+      { month: "short", year: "numeric" },
+    )}`;
+
+    const startDate =
+      action.startDate === null
+        ? null
+        : action.startDate
+          ? new Date(action.startDate)
+          : undefined;
+
+    const explicitSteps = Array.isArray(action.steps) ? action.steps : [];
+    // Whether the caller explicitly provided steps (only when at least one step
+    // is present, or a template is used). When false on an update action,
+    // fall back to the existing schedule's steps to avoid wiping them.
+    // Note: steps: [] is treated as "not provided" — an empty array does NOT
+    // clear existing steps.
+    const stepsExplicit = explicitSteps.length > 0 || !!template;
+    const steps: RampScheduleInterface["steps"] =
+      explicitSteps.length > 0
+        ? explicitSteps.map((step) => ({
+            ...step,
+            actions: Array.isArray(step.actions)
+              ? step.actions.map(normalizeAction)
+              : [],
+            monitored: !!step.monitored,
+            holdConditions: step.holdConditions ?? undefined,
+          }))
+        : template
+          ? template.steps.map((s) => ({
+              interval: s.interval,
+              actions: remapTemplateActions(
+                s.actions,
+                targetId,
+                action.ruleId,
+                feature.valueType,
+              ),
+              approvalNotes: s.approvalNotes ?? undefined,
+              monitored: !!s.monitored,
+              holdConditions: s.holdConditions ?? undefined,
+            }))
+          : action.mode === "update"
+            ? // No explicit steps and no template: preserve the existing
+              // schedule's steps so a caller who only wants to change name /
+              // startDate / cutoffDate doesn't accidentally wipe them.
+              (existingSchedule?.steps ?? [])
+            : [];
+
+    // null = explicitly cleared (skip template); undefined = not set (fall back to template).
+    const endActions: RampStepAction[] =
+      action.endActions !== undefined
+        ? Array.isArray(action.endActions)
+          ? action.endActions.map(normalizeAction)
+          : []
+        : template?.endPatch && Object.keys(template.endPatch).length > 0
+          ? [
+              {
+                targetType: "feature-rule" as const,
+                targetId,
+                patch: {
+                  ruleId: action.ruleId,
+                  ...template.endPatch,
+                },
+              },
+            ]
+          : [];
+
+    const startActions: RampStepAction[] =
+      action.startActions !== undefined
+        ? Array.isArray(action.startActions)
+          ? action.startActions.map(normalizeAction)
+          : []
+        : getStartActionsFromRules({
+            rules: result.rules ?? feature.rules ?? [],
+            targetId,
+            ruleId: action.ruleId,
+            environment: action.environment,
+          });
+
+    if (action.mode === "create") {
+      // Guard against duplicate schedules: if the revision is re-published or
+      // an older revision is published while a live schedule already targets
+      // this rule, skip the create rather than producing a second schedule
+      // that both try to drive the same rule.
+      const existing = await context.models.rampSchedules.findByTargetRule(
+        action.ruleId,
+        action.environment ?? undefined,
+      );
+      if (existing.length > 0) {
+        logger.warn(
+          {
+            ruleId: action.ruleId,
+            conflictingScheduleId: existing[0].id,
+            revisionVersion: revision.version,
+          },
+          "Skipping deferred ramp create action — a live schedule already targets this rule",
+        );
+        continue;
+      }
+
+      const created = await context.models.rampSchedules.create({
+        name: action.name ?? defaultName,
+        entityType: "feature",
+        entityId: feature.id,
+        targets: [
+          {
+            id: targetId,
+            entityType: "feature",
+            entityId: feature.id,
+            ruleId: action.ruleId,
+            // null = patches apply to all environments sharing this ruleId.
+            // A specific environment = patches are scoped to that env only.
+            environment: action.environment ?? null,
+            status: "active",
+            // Link this target to the activating revision so onRevisionPublished
+            // (and the Agenda recovery path) can transition "pending" → "running".
+            activatingRevisionVersion: revision.version,
+          },
+        ],
+        startActions: startActions.length > 0 ? startActions : undefined,
+        steps,
+        endActions: endActions.length > 0 ? endActions : undefined,
+        startDate: startDate ?? undefined,
+        cutoffDate: action.cutoffDate
+          ? new Date(action.cutoffDate)
+          : action.cutoffDate === null
+            ? null
+            : undefined,
+        monitoringConfig: action.monitoringConfig ?? template?.monitoringConfig,
+        lockdownConfig: action.lockdownConfig ?? template?.lockdownConfig,
+        // Start as "pending" — onActivatingRevisionPublished handles the
+        // immediate → "running" transition inline when the revision publishes.
+        status: "pending",
+        currentStepIndex: -1,
+        nextStepAt:
+          !startDate && steps.length > 0 ? new Date() : (startDate ?? null),
+        startedAt: null,
+        phaseStartedAt: null,
+      });
+
+      createdIds.push(created.id);
+      continue;
+    }
+
+    const updateAction = action as RevisionRampUpdateAction;
+    const nextStartDate =
+      startDate !== undefined
+        ? startDate
+        : (existingSchedule?.startDate ?? null);
+    const nextCutoffDate =
+      updateAction.cutoffDate !== undefined
+        ? updateAction.cutoffDate
+          ? new Date(updateAction.cutoffDate)
+          : null
+        : (existingSchedule?.cutoffDate ?? null);
+    const nextMonitoringConfig =
+      updateAction.monitoringConfig !== undefined
+        ? updateAction.monitoringConfig
+        : existingSchedule?.monitoringConfig;
+    // "Start now": user explicitly cleared startDate on a not-yet-started
+    // schedule. Transition ready → running inline so the rule goes live on
+    // publish instead of at the next poller tick. A ready schedule has all
+    // fields editable (startActions included — the ramp hasn't fired), so no
+    // running-merge / paused-clamp handling is needed here.
+    let startDeferredToScheduler = false;
+    if (
+      updateAction.startDate === null &&
+      existingSchedule?.status === "ready"
+    ) {
+      const contentUpdates: Parameters<typeof startReadyScheduleNow>[2] = {};
+      const edited: string[] = [];
+      const set = (provided: boolean, key: string, value: unknown) => {
+        if (!provided) return;
+        (contentUpdates as Record<string, unknown>)[key] = value;
+        edited.push(key);
+      };
+      set(updateAction.name !== undefined, "name", updateAction.name);
+      set(
+        updateAction.startActions !== undefined,
+        "startActions",
+        startActions.length > 0 ? startActions : undefined,
+      );
+      set(stepsExplicit, "steps", steps);
+      set(
+        updateAction.endActions !== undefined,
+        "endActions",
+        endActions.length > 0 ? endActions : undefined,
+      );
+      set(updateAction.cutoffDate !== undefined, "cutoffDate", nextCutoffDate);
+      set(
+        updateAction.monitoringConfig !== undefined,
+        "monitoringConfig",
+        nextMonitoringConfig,
+      );
+      set(
+        updateAction.lockdownConfig !== undefined,
+        "lockdownConfig",
+        updateAction.lockdownConfig,
+      );
+      edited.push("startDate"); // always changed on this path (cleared)
+
+      // A "config-edited" event rides along so startReadyScheduleNow appends
+      // "started" on top of it, matching the direct-edit path.
+      const history = appendRampEvent(existingSchedule, "config-edited", {
+        stepIndex: existingSchedule.currentStepIndex,
+        status: existingSchedule.status,
+        reason: `Edited via draft: ${edited.join(", ")}`,
+      });
+      const started = await startReadyScheduleNow(context, existingSchedule, {
+        ...contentUpdates,
+        cutoffDate: nextCutoffDate,
+        auditEvent: history[history.length - 1],
+      });
+      if (started) continue;
+      // Start didn't run: either the scheduler started it first (the locked
+      // update below applies the edits) or the lock stayed busy and the start
+      // was deferred via startDate=now — don't clobber that deferral.
+      const reread = await context.models.rampSchedules.getById(
+        updateAction.rampScheduleId,
+      );
+      if (!reread) {
+        logger.warn(
+          { rampScheduleId: updateAction.rampScheduleId },
+          "Ramp schedule removed while applying start-now update — skipping",
+        );
+        continue;
+      }
+      startDeferredToScheduler = reread.status === "ready";
+    }
+
+    // Apply the edits under the advance lock, deriving state-dependent pieces
+    // (running merge, paused clamp, audit history, nextProcessAt inputs) from
+    // the in-lock fresh doc — the schedule may have started, advanced, or been
+    // edited since the pre-publish read.
+    try {
+      await runLockedRampScheduleAction(
+        context,
+        updateAction.rampScheduleId,
+        async (fresh) => {
+          const isRunning = fresh.status === "running";
+          const canEditStartActions =
+            fresh.status === "pending" || fresh.status === "ready";
+          const startDateChanged = updateAction.startDate !== undefined;
+
+          // Collect the caller's config edits. `set` writes a key only when the
+          // field was provided, so omitted fields are preserved, and records
+          // which fields changed for the audit trail.
+          const patch: Record<string, unknown> = {};
+          const edited: string[] = [];
+          const set = (provided: boolean, key: string, value: unknown) => {
+            if (!provided) return;
+            patch[key] = value;
+            edited.push(key);
+          };
+
+          set(updateAction.name !== undefined, "name", updateAction.name);
+          set(
+            updateAction.cutoffDate !== undefined,
+            "cutoffDate",
+            nextCutoffDate,
+          );
+          set(
+            updateAction.monitoringConfig !== undefined,
+            "monitoringConfig",
+            nextMonitoringConfig,
+          );
+          set(
+            updateAction.lockdownConfig !== undefined,
+            "lockdownConfig",
+            updateAction.lockdownConfig,
+          );
+          // endActions only apply at completion, so they're safe to edit mid-run.
+          set(
+            updateAction.endActions !== undefined,
+            "endActions",
+            endActions.length > 0 ? endActions : undefined,
+          );
+
+          if (isRunning) {
+            // Running TOCTOU guard: freeze the past, allow only holds/notes on
+            // the current step, apply future steps. startActions stay frozen —
+            // they're the rollback restore point.
+            if (stepsExplicit) {
+              set(
+                true,
+                "steps",
+                mergeStepsForRunningSchedule(fresh, steps).steps,
+              );
+            }
+          } else {
+            set(stepsExplicit, "steps", steps);
+            set(
+              canEditStartActions && updateAction.startActions !== undefined,
+              "startActions",
+              startActions.length > 0 ? startActions : undefined,
+            );
+            if (startDateChanged) edited.push("startDate");
+            if (startDateChanged && !startDeferredToScheduler) {
+              patch.startDate = nextStartDate;
+            }
+            // Steps edited on a paused schedule: clamp the playhead and let
+            // resume recompute timing. Internal fields, not part of the audit.
+            if (
+              fresh.status === "paused" &&
+              fresh.currentStepIndex >= steps.length
+            ) {
+              patch.currentStepIndex = Math.max(steps.length - 1, -1);
+              patch.nextStepAt = null;
+            }
+          }
+
+          if (edited.length > 0) {
+            patch.eventHistory = appendRampEvent(fresh, "config-edited", {
+              stepIndex: fresh.currentStepIndex,
+              status: fresh.status,
+              reason: `Edited via draft: ${edited.join(", ")}`,
+            });
+          }
+
+          patch.nextProcessAt = computeNextProcessAt({
+            status: fresh.status,
+            nextStepAt: fresh.nextStepAt,
+            cutoffDate:
+              updateAction.cutoffDate !== undefined
+                ? nextCutoffDate
+                : (fresh.cutoffDate ?? null),
+            // running ignores startDate; ready uses it. Only reflect the new
+            // startDate when we actually persist it here.
+            startDate:
+              !isRunning && startDateChanged && !startDeferredToScheduler
+                ? nextStartDate
+                : (fresh.startDate ?? null),
+            nextSnapshotAt: fresh.nextSnapshotAt,
+          });
+
+          const updated = await context.models.rampSchedules.updateById(
+            fresh.id,
+            patch,
+          );
+
+          // Sync SafeRollout in case monitored-step membership changed.
+          if (isRunning && patch.steps) {
+            const ensured = await ensureSafeRolloutForMonitoredRamp(
+              context,
+              updated,
+            );
+            await syncLinkedSafeRolloutForRampState(context, ensured);
+          }
+        },
+      );
+    } catch (e) {
+      if (e instanceof NotFoundError) {
+        logger.warn(
+          { rampScheduleId: updateAction.rampScheduleId },
+          "Ramp schedule removed while applying update action — skipping",
+        );
+        continue;
+      }
+      throw e;
+    }
+  }
+
+  return createdIds;
+}
+
+/**
+ * Apply detach/update ramp actions stored on a revision.
+ * Best-effort: logs errors but does not throw, since these run after the feature is published.
+ */
+async function applyDetachRampActions(
+  context: ReqContext | ApiReqContext,
+  actions: RevisionRampAction[],
+) {
+  for (const action of actions) {
+    if (action.mode !== "detach") continue;
+    try {
+      const existing = await context.models.rampSchedules.getById(
+        action.rampScheduleId,
+      );
+      if (existing) {
+        // Stem-match so a bare `fr_abc` detach action matches a suffixed
+        // `fr_abc__production` target (and vice versa).
+        const actionStem = stemRuleId(action.ruleId);
+        const remainingTargets = existing.targets.filter(
+          (t) => stemRuleId(t.ruleId ?? "") !== actionStem,
+        );
+        if (action.deleteScheduleWhenEmpty && remainingTargets.length === 0) {
+          // Stop the linked SafeRollout before deletion so it doesn't continue
+          // taking snapshots against a ramp that no longer exists.
+          if (existing.safeRolloutId) {
+            await syncLinkedSafeRolloutForRampState(
+              context,
+              { ...existing, status: "rolled-back" },
+              "stopped",
+            );
+          }
+          await context.models.rampSchedules.deleteById(existing.id);
+        } else {
+          await context.models.rampSchedules.updateById(existing.id, {
+            targets: remainingTargets,
+          });
+        }
+      }
+    } catch (err) {
+      logger.error(err, {
+        msg: "Failed to apply revision ramp detach action",
+        action,
+      });
+    }
+  }
+}
+
+async function cleanupOrphanedRampSchedules(
+  context: ReqContext | ApiReqContext,
+  oldFeature: FeatureInterface,
+  newFeature: FeatureInterface,
+) {
+  try {
+    // When publishing a change that modifies rules, clean up ramp schedules that
+    // become orphaned. This handles several scenarios:
+    // 1. Rules that target a ramp are deleted → ramp is cleaned up
+    // 2. Reverting to an older revision that predates a ramp's creation → ramp's
+    //    targets (from newer revisions) are removed, orphaning the ramp → cleanup deletes it
+    // 3. Reverting back to a newer revision with a ramp → the ramp is recreated via
+    //    the inline "create" action on the rule (natural behavior)
+    //
+    // Note: If a ramp schedule is deleted and then we revert to a future revision
+    // where it should exist, the "create" action will not fire again. The user must
+    // re-create the ramp. This is the safe, explicit behavior.
+
+    // Compare by stem (not raw id). A rule may be split across revisions —
+    // e.g. `fr_abc` → `fr_abc__production` + `fr_abc__dev` — and ramp
+    // targets reference stem identity.
+    const oldStems = new Set<string>(
+      (oldFeature.rules ?? [])
+        .map((r) => (r?.id ? stemRuleId(r.id) : null))
+        .filter((id): id is string => !!id),
+    );
+    const newStems = new Set<string>(
+      (newFeature.rules ?? [])
+        .map((r) => (r?.id ? stemRuleId(r.id) : null))
+        .filter((id): id is string => !!id),
+    );
+
+    const deletedStems = new Set<string>(
+      [...oldStems].filter((s) => !newStems.has(s)),
+    );
+
+    const allRamps = await context.models?.rampSchedules?.getAllByFeatureId?.(
+      newFeature.id,
+    );
+
+    if (!allRamps) return;
+
+    for (const ramp of allRamps) {
+      const originalTargets = ramp?.targets ?? [];
+      if (originalTargets.length === 0 || !ramp?.id) continue;
+      const remainingTargets = originalTargets.filter(
+        (target: RampScheduleInterface["targets"][0]) => {
+          if (!target?.ruleId) return false;
+          return !deletedStems.has(stemRuleId(target.ruleId));
+        },
+      );
+
+      if (remainingTargets.length === 0) {
+        // Stop the linked SafeRollout before deletion so it doesn't continue
+        // taking snapshots against a ramp that no longer exists.
+        if (ramp.safeRolloutId) {
+          await syncLinkedSafeRolloutForRampState(
+            context,
+            { ...ramp, status: "rolled-back" },
+            "stopped",
+          );
+        }
+        await context.models?.rampSchedules?.deleteById?.(ramp.id);
+      } else if (remainingTargets.length !== originalTargets.length) {
+        // Some targets were orphaned by the delete; prune them so the schedule
+        // doesn't fail trying to resolve a deleted ruleId on its next fire.
+        await context.models?.rampSchedules?.updateById?.(ramp.id, {
+          targets: remainingTargets,
+        });
+      }
+    }
+  } catch (error) {
+    // Log but don't throw — cleanup is a nice-to-have, not essential for publish to succeed.
+    logger.error("Error cleaning up orphaned ramp schedules", error);
+  }
+}
+
+// Best-effort early hook run; the feature update / markRevisionAsPublished re-run hooks authoritatively
+export async function prevalidatePublishRevision({
+  context,
+  feature,
+  revision,
+  result,
+  comment,
+}: {
+  context: ReqContext | ApiReqContext;
+  feature: FeatureInterface;
+  revision: FeatureRevisionInterface;
+  result: MergeResultChanges;
+  comment?: string;
+}) {
+  const { changes, removeHoldout } = computeRevisionMergeChanges(
+    context,
+    feature,
+    revision,
+    result,
+  );
+  const base = removeHoldout
+    ? (omit(feature, ["holdout"]) as FeatureInterface)
+    : feature;
+  const proposedFeature: FeatureInterface = {
+    ...base,
+    ...changes,
+    dateUpdated: new Date(),
+  };
+  proposedFeature.linkedExperiments = getLinkedExperiments(proposedFeature);
+  await runValidateFeatureHooks({
+    context,
+    feature: proposedFeature,
+    original: feature,
+  });
+  await runValidateFeatureRevisionHooks({
+    context,
+    feature,
+    revision: {
+      ...revision,
+      ...computeRevisionPublishChanges(revision, context.auditUser, comment),
+    },
+    original: revision,
+  });
+}
+
+export async function publishRevision({
+  context,
+  feature,
+  revision,
+  result,
+  comment,
+  bypassLockdown,
+}: {
+  context: ReqContext | ApiReqContext;
+  feature: FeatureInterface;
+  revision: FeatureRevisionInterface;
+  result: MergeResultChanges;
+  comment?: string;
+  bypassLockdown?: boolean;
+}) {
+  if (revision.status === "published" || revision.status === "discarded") {
+    throw new Error("Can only publish a draft revision");
+  }
+
+  if (!bypassLockdown) {
+    await assertFeatureNotLockedByRamp(context, feature.id);
+
+    // A sibling draft's "lock other drafts" schedule freezes other publishes.
+    if (
+      revision.version !== undefined &&
+      (await hasPublishLockingScheduledSibling(
+        context.org.id,
+        feature.id,
+        revision.version,
+      ))
+    ) {
+      throw new Error(
+        "Another draft of this feature is scheduled to publish and has locked publishing of other drafts. Cancel that schedule to publish this revision.",
+      );
+    }
+  }
+
+  // Run custom hooks before the side-effect writes below so a rejection doesn't orphan them
+  await prevalidatePublishRevision({
+    context,
+    feature,
+    revision,
+    result,
+    comment,
+  });
+
+  // Create ramp schedules BEFORE writing the feature so that a schedule
+  // creation failure gates the publish (atomicity: no published feature without
+  // its ramp schedule).
+  const createActions = (revision.rampActions ?? []).filter(
+    (a) => a.mode === "create",
+  );
+  const updateActions = (revision.rampActions ?? []).filter(
+    (a) => a.mode === "update",
+  );
+  const preCreatedScheduleIds: string[] = [];
+  if (createActions.length) {
+    const ids = await createRampSchedulesForRevision(
+      context,
+      feature,
+      revision,
+      result,
+      createActions,
+    );
+    preCreatedScheduleIds.push(...ids);
+  }
+
+  let updatedFeature: FeatureInterface;
+  try {
+    updatedFeature = await applyRevisionChanges(
+      context,
+      feature,
+      revision,
+      result,
+    );
+
+    if (result.holdout !== undefined) {
+      await applyHoldoutSideEffects(context, feature, result.holdout);
+    }
+
+    await markRevisionAsPublished(
+      context,
+      feature,
+      revision,
+      context.auditUser,
+      comment,
+    );
+
+    await clearPendingFeatureDraftsForRevision(
+      context,
+      revision.featureId,
+      revision.version,
+      revision.rules,
+    );
+  } catch (err) {
+    // Roll back pre-created ramp schedules so they don't linger as orphans.
+    for (const id of preCreatedScheduleIds) {
+      try {
+        await context.models.rampSchedules.deleteById(id);
+      } catch (deleteErr) {
+        logger.error(
+          deleteErr,
+          `Failed to delete orphaned ramp schedule ${id} during publish rollback`,
+        );
+      }
+    }
+    throw err;
+  }
+
+  // Apply deferred update actions after publish succeeds.
+  // Best-effort: errors are logged but do not fail the publish response
+  // (feature is already committed; a failed schedule update is recoverable).
+  if (updateActions.length) {
+    try {
+      await createRampSchedulesForRevision(
+        context,
+        updatedFeature,
+        revision,
+        result,
+        updateActions,
+      );
+    } catch (err) {
+      logger.error(
+        err,
+        "Failed to apply deferred ramp update actions after publish",
+      );
+    }
+  }
+
+  // Apply detach actions (best-effort: logged but do not fail publish).
+  if (revision.rampActions?.length) {
+    await applyDetachRampActions(context, revision.rampActions);
+  }
+
+  // Clean up orphaned ramp schedules (best-effort).
+  await cleanupOrphanedRampSchedules(context, feature, updatedFeature);
+
+  return updatedFeature;
+}
+
+// Create a new revision from the given changes and immediately publish it.
+// Either the revision is published and the updated feature is returned, or an
+// error is thrown — a pending-review draft is never silently left behind.
+// canBypassApprovalChecks should be true when the org-level restApiBypassesReviews
+// setting is on, or when the caller's role/token grants bypassApprovalChecks
+// on the feature's project.
+export async function createAndPublishRevision({
+  context,
+  feature,
+  user,
+  org,
+  changes,
+  comment,
+  canBypassApprovalChecks,
+}: {
+  context: ReqContext | ApiReqContext;
+  feature: FeatureInterface;
+  user: EventUser;
+  org: OrganizationInterface;
+  changes: Parameters<typeof createRevision>[0]["changes"];
+  comment?: string;
+  canBypassApprovalChecks: boolean;
+}): Promise<{
+  revision: FeatureRevisionInterface;
+  updatedFeature: FeatureInterface;
+}> {
+  // Filter to envs applicable to this feature's project — avoids over-
+  // triggering approval and creating dangling per-env settings.
+  const orgEnvironments = getEnvironmentIdsFromOrg(org);
+  const orgEnvObjects = getEnvironments(org);
+  const applicableEnvIds = getApplicableEnvIds(orgEnvObjects, feature.project);
+  const applicableEnvSet = new Set(applicableEnvIds);
+  const allEnvironments = orgEnvironments.filter((e) =>
+    applicableEnvSet.has(e),
+  );
+
+  // Determine whether the revision would require review before we create anything.
+  // We need a synthetic revision to check against, mirroring what createRevision would build.
+  const liveRevision = await getRevision({
+    context,
+    organization: feature.organization,
+    featureId: feature.id,
+    feature,
+    version: feature.version,
+  });
+  if (!liveRevision) throw new Error("Could not load live revision");
+
+  // Live baseline for the review check and the publish merge, built from the
+  // feature document (the canonical live state). Stored revision docs can be
+  // sparse or in legacy shapes, so they're not a reliable baseline.
+  const liveBase: FeatureRevisionInterface = {
+    ...liveRevision,
+    ...liveRevisionFromFeature(liveRevision, feature),
+  } as FeatureRevisionInterface;
+
+  // Synthetic revision for the review check; caller-supplied rules replace
+  // the live array wholesale (same as autoMerge).
+  const syntheticRevision: FeatureRevisionInterface = {
+    ...liveBase,
+    ...(changes ?? {}),
+    rules: changes?.rules ?? liveBase.rules ?? [],
+  };
+  const requiresReview = checkIfRevisionNeedsReview({
+    feature,
+    baseRevision: liveBase,
+    revision: syntheticRevision,
+    allEnvironments,
+    settings: org.settings,
+    requireApprovalsLicensed: context.hasPremiumFeature("require-approvals"),
+  });
+
+  if (requiresReview && !canBypassApprovalChecks) {
+    throw new PermissionError(
+      "This feature requires approval before changes can be published. " +
+        "Enable 'REST API always bypasses approval requirements' in organization settings.",
+    );
+  }
+
+  // Create the draft revision (never auto-publishes; publish=false).
+  const revision = await createRevision({
+    context,
+    feature,
+    user,
+    baseVersion: feature.version,
+    comment: comment ?? "Created via REST API",
+    environments: allEnvironments,
+    publish: false,
+    changes,
+    org,
+    canBypassApprovalChecks,
+  });
+
+  // Merge the new revision against the live-feature baseline. base === live
+  // for a fresh revision off HEAD.
+  const mergeResult = autoMerge(
+    liveBase,
+    liveBase,
+    revision,
+    allEnvironments,
+    {},
+  );
+
+  if (!mergeResult.success) {
+    // Shouldn't happen for a brand-new revision off HEAD, but guard anyway.
+    throw new Error(
+      "Merge conflict detected while publishing revision. Please retry.",
+    );
+  }
+
+  const updatedFeature = await publishRevision({
+    context,
+    feature,
+    revision,
+    result: mergeResult.result,
+    comment,
+    // See postFeatureRevisionPublish.ts for the bypassLockdown policy rationale:
+    // approval-bypass permission intentionally doubles as ramp-lockdown bypass.
+    bypassLockdown: canBypassApprovalChecks,
+  });
+
+  return { revision, updatedFeature };
+}

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -96,7 +96,6 @@ import { SafeRolloutInterface } from "shared/types/safe-rollout";
 import { SDKConnectionInterface } from "shared/types/sdk-connection";
 import { ApiReqContext } from "back-end/types/api";
 import { assertRegisteredAttributes } from "back-end/src/services/attributes";
-import { getAllFeatures } from "back-end/src/models/FeatureModel";
 import {
   getAllPayloadExperiments,
   getAllURLRedirectExperiments,
@@ -807,7 +806,7 @@ export async function refreshSDKPayloadCache({
     await context.models.safeRollout.getAllPayloadSafeRollouts();
   const savedGroups = await context.models.savedGroups.getAll();
   const groupMap = await getSavedGroupMap(context, savedGroups);
-  const allFeatures = await getAllFeatures(context);
+  const allFeatures = await context.models.features.getAll();
   const constants = await context.models.constants.getAll();
   const rampMonitoredRuleMap =
     await context.models.rampSchedules.getPayloadRampMonitoredRuleMap();
@@ -1445,7 +1444,7 @@ export async function getFeatureDefinitions(
   const { context, environment = "production", projects } = args;
   const projectFilter = projects && projects.length > 0 ? projects : undefined;
   const allSavedGroups = await context.models.savedGroups.getAll();
-  const allFeatures = await getAllFeatures(context, {
+  const allFeatures = await context.models.features.getAll({
     projects: projectFilter,
   });
   const groupMap = await getSavedGroupMap(context, allSavedGroups);
@@ -1664,7 +1663,7 @@ export async function evaluateAllFeatures({
   const results: { [key: string]: FeatureTestResult }[] = [];
   const savedGroups = getSavedGroupsValuesFromGroupMap(groupMap);
 
-  const allFeaturesRaw = await getAllFeatures(context);
+  const allFeaturesRaw = await context.models.features.getAll();
   const constants = await context.models.constants.getAll();
   const allFeatures: Record<string, FeatureDefinition> = {};
   if (allFeaturesRaw.length) {

--- a/packages/back-end/src/services/rampSchedule.ts
+++ b/packages/back-end/src/services/rampSchedule.ts
@@ -21,7 +21,7 @@ import uniqid from "uniqid";
 import { getEnvironments } from "back-end/src/services/organizations";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
-import { getFeature, publishRevision } from "back-end/src/models/FeatureModel";
+import { publishRevision } from "back-end/src/services/featureRevisions";
 // NOTE: rampScheduleEvaluator also imports from this module (advanceStep, etc).
 // The cycle is safe: every cross-module reference is a hoisted function
 // declaration used only at call time, never at module top-level.
@@ -582,7 +582,7 @@ export const featureEntityHandler: EntityHandler = {
   async applyActions(ctx, entityId, actions, opts) {
     const { stepLabel, user, environment } = opts;
 
-    const feature = await getFeature(ctx, entityId);
+    const feature = await ctx.models.features.getById(entityId);
     if (!feature) throw new Error(`Feature not found: ${entityId}`);
 
     const updatedRules: FeatureRule[] = (feature.rules ?? []).map((r) => ({
@@ -2271,7 +2271,7 @@ export async function dispatchRampEvent<T extends RampFeatureEvent>(
     let environments: string[] = [];
     let tags: string[] = [];
     if ("targets" in schedule && schedule.entityType === "feature") {
-      const feature = await getFeature(ctx, schedule.entityId);
+      const feature = await ctx.models.features.getById(schedule.entityId);
       if (feature) {
         projects = feature.project ? [feature.project] : [];
         tags = feature.tags ?? [];
@@ -2407,7 +2407,7 @@ export async function approveAndPublishStep(
 ): Promise<ApproveStepError | null> {
   const stepIndex = schedule.currentStepIndex;
 
-  const feature = await getFeature(ctx, schedule.entityId);
+  const feature = await ctx.models.features.getById(schedule.entityId);
   if (!feature) return { code: "feature_not_found" };
 
   if (!ctx.permissions.canUpdateFeature(feature, feature)) {

--- a/packages/back-end/src/services/safeRolloutSnapshots.ts
+++ b/packages/back-end/src/services/safeRolloutSnapshots.ts
@@ -57,7 +57,6 @@ import {
 } from "back-end/src/models/FactTableModel";
 import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 import { orgHasPremiumFeature } from "back-end/src/enterprise";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { createEvent, CreateEventData } from "back-end/src/models/EventModel";
 import { getSafeRolloutRuleFromFeature } from "back-end/src/routers/safe-rollout/safe-rollout.helper";
 import { determineNextSafeRolloutSnapshotAttempt } from "back-end/src/enterprise/saferollouts/safeRolloutUtils";
@@ -413,7 +412,7 @@ export async function _createSafeRolloutSnapshot({
 }): Promise<SafeRolloutResultsQueryRunner> {
   const { org: organization } = context;
   const metricGroups = await context.models.metricGroups.getAll();
-  const feature = await getFeature(context, safeRollout.featureId);
+  const feature = await context.models.features.getById(safeRollout.featureId);
   if (!feature) {
     throw new Error("Could not load safe rollout feature");
   }
@@ -519,7 +518,9 @@ export async function createSafeRolloutSnapshot({
   const { settingsForSnapshotMetrics, regressionAdjustmentEnabled } =
     await getSettingsForSnapshotMetrics(context, safeRollout);
 
-  const srFeature = await getFeature(context, safeRollout.featureId);
+  const srFeature = await context.models.features.getById(
+    safeRollout.featureId,
+  );
   const srProjectId = srFeature?.project ?? undefined;
   const pValueThreshold = await getPValueThresholdForProject(
     context,
@@ -669,7 +670,9 @@ export async function notifySafeRolloutChange({
     healthSettings,
     daysLeft,
   });
-  const feature = await getFeature(context, updatedSafeRollout.featureId);
+  const feature = await context.models.features.getById(
+    updatedSafeRollout.featureId,
+  );
   if (!feature) {
     throw new Error("Could not find feature to fire event");
   }

--- a/packages/back-end/src/services/savedGroups.ts
+++ b/packages/back-end/src/services/savedGroups.ts
@@ -8,7 +8,6 @@ import {
   getPayloadKeysForAllEnvs,
 } from "back-end/src/models/ExperimentModel";
 import { ApiReqContext } from "back-end/types/api";
-import { getAllFeatures } from "back-end/src/models/FeatureModel";
 import { queueSDKPayloadRefresh } from "./features";
 import { getContextForAgendaJobByOrgObject } from "./organizations";
 
@@ -68,7 +67,7 @@ export async function loadSavedGroupReferences(
   const environments = context.org.settings?.environments || [];
 
   const [allFeatures, allExperiments] = await Promise.all([
-    getAllFeatures(context, {}),
+    context.models.features.getAll({}),
     getAllExperiments(context, {}),
   ]);
 

--- a/packages/back-end/src/util/features.ts
+++ b/packages/back-end/src/util/features.ts
@@ -462,6 +462,22 @@ export function getAffectedSDKPayloadKeys(
 
 export { getJSONValue };
 
+export function getLinkedExperiments(
+  feature: Pick<FeatureInterface, "rules" | "linkedExperiments">,
+): string[] {
+  // Keep existing links even when a rule is removed — past revisions need
+  // them to render correctly.
+  const expIds: Set<string> = new Set(feature.linkedExperiments || []);
+
+  (feature.rules ?? []).forEach((rule) => {
+    if (rule?.type === "experiment-ref") {
+      expIds.add(rule.experimentId);
+    }
+  });
+
+  return [...expIds];
+}
+
 export function roundVariationWeight(num: number): number {
   return Math.round(num * 10000) / 10000;
 }

--- a/packages/back-end/test/api/features.test.ts
+++ b/packages/back-end/test/api/features.test.ts
@@ -1,11 +1,6 @@
 import request from "supertest";
 import { FeatureInterface } from "shared/types/feature";
-import {
-  createFeature,
-  getFeature,
-  updateFeature,
-  createAndPublishRevision,
-} from "back-end/src/models/FeatureModel";
+import { createAndPublishRevision } from "back-end/src/services/featureRevisions";
 import { getRevision } from "back-end/src/models/FeatureRevisionModel";
 import { getExperimentMapForFeature } from "back-end/src/models/ExperimentModel";
 import { addTags } from "back-end/src/models/TagModel";
@@ -20,10 +15,7 @@ import {
 } from "back-end/src/services/features";
 import { setupApp } from "./api.setup";
 
-jest.mock("back-end/src/models/FeatureModel", () => ({
-  getFeature: jest.fn(),
-  createFeature: jest.fn(),
-  updateFeature: jest.fn(),
+jest.mock("back-end/src/services/featureRevisions", () => ({
   createAndPublishRevision: jest.fn(),
 }));
 
@@ -112,11 +104,20 @@ describe("features API", () => {
     getCustomFieldsBySectionAndProject: jest.fn().mockResolvedValue([]),
   });
 
+  // Mock context-registered features model (context.models.features).
+  // Declared once so both setup and assertions can reference the same fns.
+  const featuresModel = {
+    getById: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  };
+
   const defaultModels = () => ({
     safeRollout: {
       getAllPayloadSafeRollouts: jest.fn().mockResolvedValue(new Map()),
     },
     customFields: getEmptyCustomFieldsModel(),
+    features: featuresModel,
   });
 
   const defaultPermissions = (extra = {}) => ({
@@ -163,10 +164,10 @@ describe("features API", () => {
     );
 
     // Default write mocks — individual tests can override as needed.
-    (getFeature as jest.Mock).mockReturnValue(undefined);
+    featuresModel.getById.mockResolvedValue(undefined);
     (addTags as jest.Mock).mockReturnValue(undefined);
-    (createFeature as jest.Mock).mockImplementation((v) => v);
-    (updateFeature as jest.Mock).mockImplementation((ctx, f, updates) =>
+    featuresModel.create.mockImplementation((v) => Promise.resolve(v));
+    featuresModel.update.mockImplementation((f, updates) =>
       Promise.resolve({ ...f, ...updates }),
     );
     (createInterfaceEnvSettingsFromApiEnvSettings as jest.Mock).mockReturnValue(
@@ -365,7 +366,7 @@ describe("features API", () => {
     expect(response.body.message).toContain(
       'Custom field "Owning Team" is required.',
     );
-    expect(createFeature).not.toHaveBeenCalled();
+    expect(featuresModel.create).not.toHaveBeenCalled();
   });
 
   // ---------------------------------------------------------------------------
@@ -405,7 +406,7 @@ describe("features API", () => {
       requireProjectContext();
 
       const existingFeature = makeFeature({ project: "project" });
-      (getFeature as jest.Mock).mockResolvedValue(existingFeature);
+      featuresModel.getById.mockResolvedValue(existingFeature);
 
       const response = await request(app)
         .post(`/api/v1/features/${existingFeature.id}`)
@@ -419,7 +420,7 @@ describe("features API", () => {
       requireProjectContext();
 
       const existingFeature = makeFeature({ project: "" });
-      (getFeature as jest.Mock).mockResolvedValue(existingFeature);
+      featuresModel.getById.mockResolvedValue(existingFeature);
 
       const newDescription = "This is an updated description";
       const response = await request(app)
@@ -460,14 +461,14 @@ describe("features API", () => {
       });
 
       const existingFeature = makeFeature({ customFields: {} });
-      (getFeature as jest.Mock).mockResolvedValue(existingFeature);
+      featuresModel.getById.mockResolvedValue(existingFeature);
 
       const response = await request(app)
         .post(`/api/v1/features/${existingFeature.id}`)
         .send({ description: "new description" });
 
       expect(response.status).toBe(200);
-      expect(updateFeature).toHaveBeenCalled();
+      expect(featuresModel.update).toHaveBeenCalled();
       expect(getCustomFieldsBySectionAndProject).not.toHaveBeenCalled();
     });
 
@@ -492,14 +493,14 @@ describe("features API", () => {
       });
 
       const existingFeature = makeFeature({ customFields: {} });
-      (getFeature as jest.Mock).mockResolvedValue(existingFeature);
+      featuresModel.getById.mockResolvedValue(existingFeature);
 
       const response = await request(app)
         .post(`/api/v1/features/${existingFeature.id}`)
         .send({ description: "new description", customFields: {} });
 
       expect(response.status).toBe(200);
-      expect(updateFeature).toHaveBeenCalled();
+      expect(featuresModel.update).toHaveBeenCalled();
       expect(getCustomFieldsBySectionAndProject).not.toHaveBeenCalled();
     });
 
@@ -526,7 +527,7 @@ describe("features API", () => {
       const existingFeature = makeFeature({
         customFields: { cfd_team: "growth" },
       });
-      (getFeature as jest.Mock).mockResolvedValue(existingFeature);
+      featuresModel.getById.mockResolvedValue(existingFeature);
 
       const response = await request(app)
         .post(`/api/v1/features/${existingFeature.id}`)
@@ -536,7 +537,7 @@ describe("features API", () => {
       expect(response.body.message).toContain(
         'Custom field "Owning Team" is required.',
       );
-      expect(updateFeature).not.toHaveBeenCalled();
+      expect(featuresModel.update).not.toHaveBeenCalled();
       expect(getCustomFieldsBySectionAndProject).toHaveBeenCalled();
     });
 
@@ -562,14 +563,14 @@ describe("features API", () => {
       });
 
       const existingFeature = makeFeature({ customFields: {} });
-      (getFeature as jest.Mock).mockResolvedValue(existingFeature);
+      featuresModel.getById.mockResolvedValue(existingFeature);
 
       const response = await request(app)
         .post(`/api/v1/features/${existingFeature.id}`)
         .send({ description: "new description", project: "project" });
 
       expect(response.status).toBe(200);
-      expect(updateFeature).toHaveBeenCalled();
+      expect(featuresModel.update).toHaveBeenCalled();
       expect(getCustomFieldsBySectionAndProject).not.toHaveBeenCalled();
     });
 
@@ -601,7 +602,7 @@ describe("features API", () => {
       });
 
       const existingFeature = makeFeature({ customFields: {} });
-      (getFeature as jest.Mock).mockResolvedValue(existingFeature);
+      featuresModel.getById.mockResolvedValue(existingFeature);
 
       const response = await request(app)
         .post(`/api/v1/features/${existingFeature.id}`)
@@ -611,7 +612,7 @@ describe("features API", () => {
       expect(response.body.message).toContain(
         'Custom field "Owning Team" is required.',
       );
-      expect(updateFeature).not.toHaveBeenCalled();
+      expect(featuresModel.update).not.toHaveBeenCalled();
     });
 
     it("revalidates and rejects when changing project and customFields payload is changed", async () => {
@@ -644,7 +645,7 @@ describe("features API", () => {
       const existingFeature = makeFeature({
         customFields: { cfd_team: "growth" },
       });
-      (getFeature as jest.Mock).mockResolvedValue(existingFeature);
+      featuresModel.getById.mockResolvedValue(existingFeature);
 
       const response = await request(app)
         .post(`/api/v1/features/${existingFeature.id}`)
@@ -658,7 +659,7 @@ describe("features API", () => {
       expect(response.body.message).toContain(
         'Custom field "Owning Team" is required.',
       );
-      expect(updateFeature).not.toHaveBeenCalled();
+      expect(featuresModel.update).not.toHaveBeenCalled();
     });
   });
 
@@ -706,7 +707,7 @@ describe("features API", () => {
         environmentSettings: { production: { enabled: true, rules: [] } },
       });
 
-      (getFeature as jest.Mock).mockResolvedValue(existingFeature);
+      featuresModel.getById.mockResolvedValue(existingFeature);
       (
         updateInterfaceEnvSettingsFromApiEnvSettings as jest.Mock
       ).mockReturnValue(updatedEnvironmentSettings);
@@ -743,8 +744,7 @@ describe("features API", () => {
         });
 
       expect(response.status).toBe(200);
-      expect(updateFeature).toHaveBeenCalledWith(
-        expect.anything(),
+      expect(featuresModel.update).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
           environmentSettings: updatedEnvironmentSettings,
@@ -780,7 +780,7 @@ describe("features API", () => {
         },
       });
 
-      (getFeature as jest.Mock).mockResolvedValue(existingFeature);
+      featuresModel.getById.mockResolvedValue(existingFeature);
       (getNextScheduledUpdate as jest.Mock).mockImplementation((envSettings) =>
         envSettings ? new Date("2026-02-20T08:00:00.000Z") : null,
       );
@@ -791,9 +791,9 @@ describe("features API", () => {
         .send({ project: "project_2" });
 
       expect(response.status).toBe(200);
-      expect(updateFeature).toHaveBeenCalled();
-      const updateFeatureCall = (updateFeature as jest.Mock).mock.calls[0];
-      const updatesArg = updateFeatureCall[2];
+      expect(featuresModel.update).toHaveBeenCalled();
+      const updateCall = featuresModel.update.mock.calls[0];
+      const updatesArg = updateCall[1];
       expect(updatesArg).toEqual({ version: originalVersion + 1 });
     });
   });
@@ -820,7 +820,7 @@ describe("features API", () => {
         org: { ...org, settings: { ...org.settings, ...orgSettings } },
         permissions: defaultPermissions(permissionsOverride),
       });
-      (getFeature as jest.Mock).mockResolvedValue(existingFeature);
+      featuresModel.getById.mockResolvedValue(existingFeature);
       return existingFeature;
     };
 
@@ -938,7 +938,7 @@ describe("features API", () => {
       setupUpdateTest();
       // Send a field that results in no revision-tracked delta
       const existingFeature = makeFeature();
-      (getFeature as jest.Mock).mockResolvedValue(existingFeature);
+      featuresModel.getById.mockResolvedValue(existingFeature);
       // defaultValue same as current — no change
       const response = await request(app)
         .post("/api/v1/features/myfeature")

--- a/packages/back-end/test/api/features/ruleAddCustomHooks.test.ts
+++ b/packages/back-end/test/api/features/ruleAddCustomHooks.test.ts
@@ -8,7 +8,6 @@ import {
   createInitialRevision,
   createRevision,
 } from "back-end/src/models/FeatureRevisionModel";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { setupApp } from "../api.setup";
 
 // Regression tests: a custom-hook rejection on the rule-add endpoint must not orphan a SafeRollout doc
@@ -82,7 +81,7 @@ async function seedFeature() {
 }
 
 async function seedDraftRevision(context: ReqContextClass) {
-  const feature = await getFeature(context, FEATURE_ID);
+  const feature = await context.models.features.getById(FEATURE_ID);
   if (!feature) throw new Error("seed feature missing");
   // createRevision requires a published base revision for feature.version.
   await createInitialRevision(context, feature, context.auditUser, [

--- a/packages/back-end/test/api/features/updateFeatureV1SparseEnvs.test.ts
+++ b/packages/back-end/test/api/features/updateFeatureV1SparseEnvs.test.ts
@@ -3,7 +3,6 @@ import mongoose from "mongoose";
 import type { Request } from "express";
 import type { OrganizationInterface } from "shared/types/organization";
 import { ReqContextClass } from "back-end/src/services/context";
-import { getFeature } from "back-end/src/models/FeatureModel";
 import { createInitialRevision } from "back-end/src/models/FeatureRevisionModel";
 import { setupApp } from "../api.setup";
 
@@ -77,7 +76,7 @@ async function seedFeature({
 }
 
 async function seedPublishedRevisionFromFeature(context: ReqContextClass) {
-  const feature = await getFeature(context, FEATURE_ID);
+  const feature = await context.models.features.getById(FEATURE_ID);
   if (!feature) throw new Error("seed feature missing");
   await createInitialRevision(
     context,

--- a/packages/back-end/test/api/revertFeature.test.ts
+++ b/packages/back-end/test/api/revertFeature.test.ts
@@ -1,8 +1,7 @@
 import type { OrganizationInterface } from "shared/types/organization";
 import type { EventUser } from "shared/types/events/event-types";
 
-jest.mock("back-end/src/models/FeatureModel", () => ({
-  getFeature: jest.fn(),
+jest.mock("back-end/src/services/featureRevisions", () => ({
   createAndPublishRevision: jest.fn(),
 }));
 
@@ -39,14 +38,11 @@ jest.mock("back-end/src/util/organization.util", () => ({
 }));
 
 import { revertFeatureCore } from "back-end/src/api/features/revertFeature";
-import {
-  createAndPublishRevision,
-  getFeature,
-} from "back-end/src/models/FeatureModel";
+import { createAndPublishRevision } from "back-end/src/services/featureRevisions";
 import { getRevision } from "back-end/src/models/FeatureRevisionModel";
 import { getExperimentMapForFeature } from "back-end/src/models/ExperimentModel";
 
-const mockGetFeature = getFeature as jest.MockedFunction<typeof getFeature>;
+const mockGetFeature = jest.fn();
 const mockGetRevision = getRevision as jest.MockedFunction<typeof getRevision>;
 const mockCreateAndPublish = createAndPublishRevision as jest.MockedFunction<
   typeof createAndPublishRevision
@@ -70,6 +66,7 @@ const ctx = {
     safeRollout: {
       getAllPayloadSafeRollouts: jest.fn().mockResolvedValue(new Map()),
     },
+    features: { getById: mockGetFeature },
   },
 } as never;
 

--- a/packages/back-end/test/jobs/updateScheduledFeatures.test.ts
+++ b/packages/back-end/test/jobs/updateScheduledFeatures.test.ts
@@ -1,20 +1,18 @@
 import { FeatureInterface } from "shared/types/feature";
 import { updateSingleFeature } from "back-end/src/jobs/updateScheduledFeatures";
 import {
-  getFeature,
-  updateNextScheduledDate,
-} from "back-end/src/models/FeatureModel";
-import {
   getNextScheduledUpdate,
   refreshSDKPayloadCache,
 } from "back-end/src/services/features";
 import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizations";
 
 jest.mock("back-end/src/models/FeatureModel", () => ({
-  getFeature: jest.fn(),
-  updateNextScheduledDate: jest.fn(),
-  getScheduledFeaturesToUpdate: jest.fn(),
+  FeatureModel: { dangerousGetScheduledFeaturesToUpdate: jest.fn() },
 }));
+
+// Feature lookups/updates now go through ctx.models.features.
+const mockGetById = jest.fn();
+const mockUpdateNextScheduledDate = jest.fn();
 
 jest.mock("back-end/src/services/features", () => ({
   getNextScheduledUpdate: jest.fn(),
@@ -48,6 +46,12 @@ const makeContext = () => ({
     settings: { environments: [{ id: "production" }] },
   },
   environments: ["production"],
+  models: {
+    features: {
+      getById: mockGetById,
+      updateNextScheduledDate: mockUpdateNextScheduledDate,
+    },
+  },
 });
 
 describe("updateSingleFeature", () => {
@@ -55,10 +59,10 @@ describe("updateSingleFeature", () => {
     (getContextForAgendaJobByOrgId as jest.Mock).mockResolvedValue(
       makeContext(),
     );
-    (getFeature as jest.Mock).mockResolvedValue(makeFeature());
+    mockGetById.mockResolvedValue(makeFeature());
     (getNextScheduledUpdate as jest.Mock).mockReturnValue(null);
     (refreshSDKPayloadCache as jest.Mock).mockResolvedValue(undefined);
-    (updateNextScheduledDate as jest.Mock).mockResolvedValue(undefined);
+    mockUpdateNextScheduledDate.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -70,7 +74,7 @@ describe("updateSingleFeature", () => {
     (refreshSDKPayloadCache as jest.Mock).mockImplementation(async () => {
       order.push("refresh");
     });
-    (updateNextScheduledDate as jest.Mock).mockImplementation(async () => {
+    mockUpdateNextScheduledDate.mockImplementation(async () => {
       order.push("ack");
     });
 
@@ -90,15 +94,15 @@ describe("updateSingleFeature", () => {
     await updateSingleFeature(makeJob());
     await new Promise(process.nextTick);
 
-    expect(updateNextScheduledDate).not.toHaveBeenCalled();
+    expect(mockUpdateNextScheduledDate).not.toHaveBeenCalled();
   });
 
   it("does nothing when the feature does not exist", async () => {
-    (getFeature as jest.Mock).mockResolvedValue(null);
+    mockGetById.mockResolvedValue(null);
 
     await updateSingleFeature(makeJob());
 
     expect(refreshSDKPayloadCache).not.toHaveBeenCalled();
-    expect(updateNextScheduledDate).not.toHaveBeenCalled();
+    expect(mockUpdateNextScheduledDate).not.toHaveBeenCalled();
   });
 });

--- a/packages/back-end/test/models/FeatureModel.test.ts
+++ b/packages/back-end/test/models/FeatureModel.test.ts
@@ -1529,6 +1529,41 @@ describe("buildFeatureUpdate", () => {
     const out = buildFeatureUpdate(input);
     expect((out as { rules: unknown }).rules).toBe(input.rules);
   });
+
+  it("drops null-valued keys from rules (revision docs store explicit nulls)", () => {
+    // Mirrors a rule as persisted by the v2 rule-add API into a revision doc:
+    // absent optional fields are stored as explicit nulls, which the strict
+    // update validator would reject at publish time.
+    const out = buildFeatureUpdate({
+      rules: [
+        {
+          id: "r1",
+          type: "force",
+          description: "",
+          value: "true",
+          enabled: true,
+          allEnvironments: false,
+          environments: ["production"],
+          condition: null,
+          savedGroups: null,
+          prerequisites: null,
+          scheduleRules: null,
+          scheduleType: null,
+        },
+      ],
+    } as Record<string, unknown>);
+
+    const rules = (out as { rules: Array<Record<string, unknown>> }).rules;
+    expect(rules[0]).toEqual({
+      id: "r1",
+      type: "force",
+      description: "",
+      value: "true",
+      enabled: true,
+      allEnvironments: false,
+      environments: ["production"],
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/back-end/test/models/FeatureModel.test.ts
+++ b/packages/back-end/test/models/FeatureModel.test.ts
@@ -1,18 +1,23 @@
+import omit from "lodash/omit";
 import { FeatureRule } from "shared/validators";
 import { FeatureInterface, LegacyFeatureInterface } from "shared/types/feature";
 import { Environment } from "shared/types/organization";
 import { suffixRuleId } from "shared/util";
+// context.ts and FeatureModel.ts form an import cycle (the request context
+// registers the FeatureModel class). Runtime entrypoints always evaluate
+// context.ts before FeatureModel.ts; requiring FeatureModel.ts first would
+// hit the class binding's TDZ, so load the context module graph first.
+import "back-end/src/services/context";
 import {
-  FeatureModel,
   migrateRawFeatureToV2,
   buildFeatureUpdate,
-  toInterface,
 } from "back-end/src/models/FeatureModel";
 import { ReqContext } from "back-end/types/request";
 
 // ---------------------------------------------------------------------------
-// migrateRawFeatureToV2 is the pure-function core of FeatureModel.toInterface.
-// It accepts a raw document (already stripped of Mongoose metadata) and a
+// migrateRawFeatureToV2 is the pure-function JIT-migration chokepoint behind
+// FeatureModel's `migrate()` (every BaseModel read routes through it).
+// It accepts a raw document (already stripped of driver metadata) and a
 // minimal ReqContext, and emits a v2 FeatureInterface via JIT migration.
 //
 // Integration test matrix:
@@ -1527,25 +1532,22 @@ describe("buildFeatureUpdate", () => {
 });
 
 // ---------------------------------------------------------------------------
-// toInterface round-trip integration tests. Verify that a document
-// constructed via `new FeatureModel({...})` (as Mongoose hydrates on read)
-// round-trips to the same v2 `FeatureInterface` as calling
-// `migrateRawFeatureToV2` directly on the raw payload.
+// Raw-doc read-path round-trip tests. The runtime read path is
+// raw driver doc → omit(__v, _id) → migrateRawFeatureToV2 (via
+// FeatureModel.migrate). Verify that raw on-disk shapes — including driver
+// metadata crust — land on the same canonical v2 `FeatureInterface`.
 // ---------------------------------------------------------------------------
 
-describe("toInterface round-trip", () => {
-  const runRoundTrip = (raw: Record<string, unknown>) => {
-    const direct = migrateRawFeatureToV2(
-      raw as unknown as LegacyFeatureInterface,
+describe("raw-doc read path (omit driver metadata + migrateRawFeatureToV2)", () => {
+  // Mirrors the runtime read chokepoint: strip `__v`/`_id` and JIT-migrate.
+  const readPath = (raw: Record<string, unknown>) =>
+    migrateRawFeatureToV2(
+      omit(raw, ["__v", "_id"]) as unknown as LegacyFeatureInterface,
       mockContext(),
     );
-    const doc = new FeatureModel(raw);
-    const viaDoc = toInterface(doc, mockContext());
-    return { direct, viaDoc };
-  };
 
-  it("v1 hydrated via Mongoose flattens to the same v2 shape as migrateRawFeatureToV2", () => {
-    const raw = {
+  it("v1 raw doc with driver metadata flattens to the same v2 shape as a clean doc", () => {
+    const clean = {
       ...BASE_META,
       environmentSettings: {
         dev: { enabled: true, rules: [v1Rule("r1") as FeatureRule] },
@@ -1555,7 +1557,11 @@ describe("toInterface round-trip", () => {
         },
       },
     };
-    const { direct, viaDoc } = runRoundTrip(raw);
+    const direct = migrateRawFeatureToV2(
+      clean as unknown as LegacyFeatureInterface,
+      mockContext(),
+    );
+    const viaDoc = readPath({ ...clean, _id: "mongo-object-id", __v: 0 });
 
     expect(viaDoc.rules).toHaveLength(direct.rules.length);
     expect(viaDoc.rules.map((r) => r.id)).toEqual(
@@ -1571,7 +1577,7 @@ describe("toInterface round-trip", () => {
     expect((viaDoc as unknown as { __v?: unknown }).__v).toBeUndefined();
   });
 
-  it("v2 hydrated via Mongoose passes through without rewriting ids", () => {
+  it("v2 raw doc passes through the read path without rewriting ids", () => {
     const raw = {
       ...BASE_META,
       environmentSettings: {
@@ -1579,33 +1585,35 @@ describe("toInterface round-trip", () => {
         production: { enabled: true, prerequisites: [] },
       },
       rules: [v2Rule("r1")],
+      _id: "mongo-object-id",
+      __v: 0,
     };
-    const { direct, viaDoc } = runRoundTrip(raw);
+    const viaDoc = readPath(raw);
 
     expect(viaDoc.rules).toHaveLength(1);
     expect(viaDoc.rules[0].id).toBe("r1");
-    expect(viaDoc.rules[0].id).toBe(direct.rules[0].id);
     expect(viaDoc.rules[0].allEnvironments).toBe(true);
   });
 
-  it("v0 hydrated via Mongoose flattens through the full pipeline to v2", () => {
+  it("v0 raw doc flattens through the full pipeline to v2", () => {
     const raw = {
       ...BASE_META,
       environments: ["dev", "production"],
       rules: [v1Rule("r1") as FeatureRule],
+      _id: "mongo-object-id",
+      __v: 0,
     };
     delete (raw as Record<string, unknown>).environmentSettings;
 
-    const { direct, viaDoc } = runRoundTrip(raw);
+    const viaDoc = readPath(raw);
 
     expect(viaDoc.rules).toHaveLength(1);
     expect(viaDoc.rules[0].id).toBe("r1");
     expect(viaDoc.rules[0].allEnvironments).toBe(true);
-    expect(viaDoc.rules[0].id).toBe(direct.rules[0].id);
   });
 
-  it("idempotent: writing a v2 doc's toInterface result back in yields the same output", () => {
-    // Simulates a read -> (no-op transform) -> hydrate-as-v2 -> read loop.
+  it("idempotent: feeding a v2 doc's read-path result back in yields the same output", () => {
+    // Simulates a read -> (no-op transform) -> write-as-v2 -> read loop.
     // Ids and ordering must be stable across the round-trip.
     const raw = {
       ...BASE_META,
@@ -1622,11 +1630,8 @@ describe("toInterface round-trip", () => {
       ],
     };
 
-    const first = toInterface(new FeatureModel(raw), mockContext());
-    const second = toInterface(
-      new FeatureModel(first as unknown as Record<string, unknown>),
-      mockContext(),
-    );
+    const first = readPath(raw);
+    const second = readPath(first as unknown as Record<string, unknown>);
 
     expect(second.rules.map((r) => r.id)).toEqual(first.rules.map((r) => r.id));
     expect(second.rules.map((r) => r.allEnvironments)).toEqual(
@@ -1634,19 +1639,18 @@ describe("toInterface round-trip", () => {
     );
   });
 
-  it("strips Mongoose-injected _id and __v from the application-visible result", () => {
+  it("strips driver-injected _id and __v from the application-visible result", () => {
     const raw = {
       ...BASE_META,
       environmentSettings: {
         dev: { enabled: true, rules: [] },
         production: { enabled: true, rules: [] },
       },
+      _id: "mongo-object-id",
+      __v: 3,
     };
-    const doc = new FeatureModel(raw);
-    const rawJson = doc.toJSON<Record<string, unknown>>();
-    expect(rawJson._id).toBeDefined();
 
-    const result = toInterface(doc, mockContext());
+    const result = readPath(raw);
     expect((result as unknown as { _id?: unknown })._id).toBeUndefined();
     expect((result as unknown as { __v?: unknown }).__v).toBeUndefined();
   });

--- a/packages/back-end/test/models/computeRevisionMergeChanges.test.ts
+++ b/packages/back-end/test/models/computeRevisionMergeChanges.test.ts
@@ -2,7 +2,7 @@ import { FeatureInterface, FeatureRule } from "shared/types/feature";
 import { FeatureRevisionInterface } from "shared/types/feature-revision";
 import { Environment } from "shared/types/organization";
 import { MergeResultChanges } from "shared/util";
-import { computeRevisionMergeChanges } from "back-end/src/models/FeatureModel";
+import { computeRevisionMergeChanges } from "back-end/src/services/featureRevisions";
 import { ReqContext } from "back-end/types/request";
 
 const ORG_ENVS: Environment[] = [

--- a/packages/back-end/test/services/features-holdout.test.ts
+++ b/packages/back-end/test/services/features-holdout.test.ts
@@ -1,14 +1,10 @@
 import { ReqContext } from "shared/types/organization";
 import { getFeatureDefinitionsWithCache } from "back-end/src/controllers/features";
-import { getAllFeatures } from "back-end/src/models/FeatureModel";
 import {
   getAllPayloadExperiments,
   getAllVisualExperiments,
   getAllURLRedirectExperiments,
 } from "back-end/src/models/ExperimentModel";
-jest.mock("back-end/src/models/FeatureModel", () => ({
-  getAllFeatures: jest.fn(),
-}));
 
 jest.mock("back-end/src/models/ExperimentModel", () => ({
   getAllPayloadExperiments: jest.fn(),
@@ -53,6 +49,11 @@ describe("getFeatureDefinitionsWithCache - Holdout Tests", () => {
       },
     },
     models: {
+      // Feature reads go through the context-registered model now
+      // (ctx.models.features.getAll), not a module-level helper.
+      features: {
+        getAll: jest.fn() as jest.Mock,
+      },
       safeRollout: {
         getAllPayloadSafeRollouts: jest
           .fn()
@@ -92,7 +93,7 @@ describe("getFeatureDefinitionsWithCache - Holdout Tests", () => {
 
   it("should include holdout and holdout rule when holdout has the requested project", async () => {
     // Mock features
-    (getAllFeatures as jest.Mock).mockResolvedValue([
+    (mockContext.models.features.getAll as jest.Mock).mockResolvedValue([
       {
         id: "feature-with-holdout",
         valueType: "string",
@@ -206,7 +207,7 @@ describe("getFeatureDefinitionsWithCache - Holdout Tests", () => {
 
   it("should NOT include holdout and holdout rule when holdout doesn't have the requested project", async () => {
     // Mock features
-    (getAllFeatures as jest.Mock).mockResolvedValue([
+    (mockContext.models.features.getAll as jest.Mock).mockResolvedValue([
       {
         id: "feature-with-holdout",
         valueType: "string",
@@ -293,7 +294,7 @@ describe("getFeatureDefinitionsWithCache - Holdout Tests", () => {
 
   it("should include holdout and holdout rule when requested project is in holdout projects array", async () => {
     // Mock features
-    (getAllFeatures as jest.Mock).mockResolvedValue([
+    (mockContext.models.features.getAll as jest.Mock).mockResolvedValue([
       {
         id: "feature-with-holdout",
         valueType: "string",
@@ -405,7 +406,7 @@ describe("getFeatureDefinitionsWithCache - Holdout Tests", () => {
 
   it("should NOT include holdout rule when holdout feature definition is missing", async () => {
     // Mock features
-    (getAllFeatures as jest.Mock).mockResolvedValue([
+    (mockContext.models.features.getAll as jest.Mock).mockResolvedValue([
       {
         id: "feature-with-holdout",
         valueType: "string",
@@ -456,7 +457,7 @@ describe("getFeatureDefinitionsWithCache - Holdout Tests", () => {
 
   it("should NOT include holdout feature definition when no feature has a holdout", async () => {
     // Mock features
-    (getAllFeatures as jest.Mock).mockResolvedValue([
+    (mockContext.models.features.getAll as jest.Mock).mockResolvedValue([
       {
         id: "feature-with-holdout",
         valueType: "string",
@@ -537,7 +538,7 @@ describe("getFeatureDefinitionsWithCache - Holdout Tests", () => {
 
   it("should include feature definitions normally when no holdouts are present", async () => {
     // Mock features
-    (getAllFeatures as jest.Mock).mockResolvedValue([
+    (mockContext.models.features.getAll as jest.Mock).mockResolvedValue([
       {
         id: "feature-1",
         valueType: "string",

--- a/packages/back-end/test/services/getApiFeatureObj.test.ts
+++ b/packages/back-end/test/services/getApiFeatureObj.test.ts
@@ -302,11 +302,9 @@ describe("getApiFeatureObj: per-env rule shape parity (vs origin/main)", () => {
   });
 
   // Project-scoped feature, identical experiment rule in dev + production.
-  // Exercises raw mongo doc → `new FeatureModel(raw)` → `toInterface(doc, ctx)`.
-  it("preserves [] fields for project-scoped experiment rule via Mongoose", async () => {
-    const { FeatureModel, toInterface } = await import(
-      "back-end/src/models/FeatureModel"
-    );
+  // Exercises raw mongo doc → `migrateRawFeatureToV2(raw, ctx)` (the runtime
+  // read path).
+  it("preserves [] fields for project-scoped experiment rule via the raw-doc read path", () => {
     const organization = {
       id: "org_test",
       settings: {
@@ -363,9 +361,10 @@ describe("getApiFeatureObj: per-env rule shape parity (vs origin/main)", () => {
       },
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const doc = new FeatureModel(raw as any);
-    const feature = toInterface(doc, ctx);
+    const feature = migrateRawFeatureToV2(
+      raw as unknown as LegacyFeatureInterface,
+      ctx,
+    );
 
     const api = getApiFeatureObj({
       feature,
@@ -387,12 +386,9 @@ describe("getApiFeatureObj: per-env rule shape parity (vs origin/main)", () => {
   });
 
   // Origin/main's typed Mongoose `rules: [...]` schema seeded `[]` defaults
-  // for `savedGroups`/`scheduleRules`/`variations`; our Mixed schema does
-  // not, and we intentionally do NOT backfill those either.
-  it("does NOT backfill [] defaults on v0 rules missing savedGroups/scheduleRules/variations", async () => {
-    const { FeatureModel, toInterface } = await import(
-      "back-end/src/models/FeatureModel"
-    );
+  // for `savedGroups`/`scheduleRules`/`variations`; the raw-driver read path
+  // does not, and we intentionally do NOT backfill those either.
+  it("does NOT backfill [] defaults on v0 rules missing savedGroups/scheduleRules/variations", () => {
     const organization = {
       id: "org_v0",
       settings: { environments: [{ id: "dev" }, { id: "production" }] },
@@ -432,9 +428,10 @@ describe("getApiFeatureObj: per-env rule shape parity (vs origin/main)", () => {
       },
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const doc = new FeatureModel(raw as any);
-    const feature = toInterface(doc, ctx);
+    const feature = migrateRawFeatureToV2(
+      raw as unknown as LegacyFeatureInterface,
+      ctx,
+    );
 
     const api = getApiFeatureObj({
       feature,
@@ -463,10 +460,7 @@ describe("getApiFeatureObj: per-env rule shape parity (vs origin/main)", () => {
   // whose envs have `rules: []` (key present, empty). Must NOT leak the
   // legacy top-level rule through the v2 path — origin/main's
   // `updateEnvironmentSettings` skips re-copying when the key is present.
-  it("ignores legacy top-level rules when env settings have empty rules: [] (hybrid v0/v1)", async () => {
-    const { FeatureModel, toInterface } = await import(
-      "back-end/src/models/FeatureModel"
-    );
+  it("ignores legacy top-level rules when env settings have empty rules: [] (hybrid v0/v1)", () => {
     const organization = {
       id: "org_test",
       settings: { environments: [{ id: "dev" }, { id: "production" }] },
@@ -506,9 +500,10 @@ describe("getApiFeatureObj: per-env rule shape parity (vs origin/main)", () => {
       },
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const doc = new FeatureModel(raw as any);
-    const feature = toInterface(doc, ctx);
+    const feature = migrateRawFeatureToV2(
+      raw as unknown as LegacyFeatureInterface,
+      ctx,
+    );
 
     // Top-level v2 rules array must NOT carry the legacy stale rule.
     expect(feature.rules).toEqual([]);
@@ -530,10 +525,7 @@ describe("getApiFeatureObj: per-env rule shape parity (vs origin/main)", () => {
   // `upgradeFeatureInterface` hard-codes `dev`+`production` env entries and
   // backfills missing ones from the top-level rules — we mirror that so a
   // production-only legacy rule isn't silently dropped on first read.
-  it("backfills production from legacy top-level rules when environmentSettings only has dev (sparse v0/v1 hybrid)", async () => {
-    const { FeatureModel, toInterface } = await import(
-      "back-end/src/models/FeatureModel"
-    );
+  it("backfills production from legacy top-level rules when environmentSettings only has dev (sparse v0/v1 hybrid)", () => {
     const organization = {
       id: "org_test",
       settings: { environments: [{ id: "dev" }, { id: "production" }] },
@@ -588,9 +580,10 @@ describe("getApiFeatureObj: per-env rule shape parity (vs origin/main)", () => {
       },
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const doc = new FeatureModel(raw as any);
-    const feature = toInterface(doc, ctx);
+    const feature = migrateRawFeatureToV2(
+      raw as unknown as LegacyFeatureInterface,
+      ctx,
+    );
 
     // Both legacy-flavored rules survive: dev's own rule + production's
     // backfilled-from-top-level rule.
@@ -613,10 +606,7 @@ describe("getApiFeatureObj: per-env rule shape parity (vs origin/main)", () => {
     ]);
   });
 
-  it("does not enroll non-(dev|production) envs lacking a rules key into top-level rule backfill", async () => {
-    const { FeatureModel, toInterface } = await import(
-      "back-end/src/models/FeatureModel"
-    );
+  it("does not enroll non-(dev|production) envs lacking a rules key into top-level rule backfill", () => {
     // Custom envs lack a `rules` key; `dev` is stale (in envSettings, not in
     // the org list).
     const organization = {
@@ -662,9 +652,10 @@ describe("getApiFeatureObj: per-env rule shape parity (vs origin/main)", () => {
       },
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const doc = new FeatureModel(raw as any);
-    const feature = toInterface(doc, ctx);
+    const feature = migrateRawFeatureToV2(
+      raw as unknown as LegacyFeatureInterface,
+      ctx,
+    );
 
     const api = getApiFeatureObj({
       feature,
@@ -681,12 +672,10 @@ describe("getApiFeatureObj: per-env rule shape parity (vs origin/main)", () => {
     expect(api.environments.custom_b.rules).toEqual([]);
   });
 
-  // Catches anything Mongoose's schema/toJSON pass strips that the bare
-  // `migrateRawFeatureToV2` test does not.
-  it("preserves [] fields end-to-end through Mongoose toInterface (v1 on-disk)", async () => {
-    const { FeatureModel, toInterface } = await import(
-      "back-end/src/models/FeatureModel"
-    );
+  // End-to-end read-path pass over a v1 on-disk doc: raw fixture →
+  // migrateRawFeatureToV2 → getApiFeatureObj. Locks down that no layer of
+  // the pipeline drops legacy `[]` fields.
+  it("preserves [] fields end-to-end through the raw-doc read path (v1 on-disk)", () => {
     const organization = {
       id: "org_test",
       settings: {
@@ -731,9 +720,10 @@ describe("getApiFeatureObj: per-env rule shape parity (vs origin/main)", () => {
       },
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const doc = new FeatureModel(raw as any);
-    const feature = toInterface(doc, ctx);
+    const feature = migrateRawFeatureToV2(
+      raw as unknown as LegacyFeatureInterface,
+      ctx,
+    );
 
     const v2Rule = feature.rules[0] as unknown as Record<string, unknown>;
     expect(v2Rule.savedGroups).toEqual([]);

--- a/packages/back-end/test/services/publishPendingFeatureDraftsForExperiment.test.ts
+++ b/packages/back-end/test/services/publishPendingFeatureDraftsForExperiment.test.ts
@@ -2,8 +2,7 @@ import type { ExperimentInterface } from "shared/validators";
 import { autoMerge, checkIfRevisionNeedsReview } from "shared/util";
 import type { ReqContext } from "back-end/types/request";
 
-jest.mock("back-end/src/models/FeatureModel", () => ({
-  getFeature: jest.fn(),
+jest.mock("back-end/src/services/featureRevisions", () => ({
   publishRevision: jest.fn(),
   prevalidatePublishRevision: jest.fn(),
   editFeatureRules: jest.fn(),
@@ -40,10 +39,9 @@ import {
   publishPendingFeatureDraftsForExperiment,
 } from "back-end/src/services/experiment-feature";
 import {
-  getFeature,
   prevalidatePublishRevision,
   publishRevision,
-} from "back-end/src/models/FeatureModel";
+} from "back-end/src/services/featureRevisions";
 import {
   getRevision,
   discardRevision,
@@ -51,7 +49,7 @@ import {
 import { removePendingFeatureDraftFromExperiment } from "back-end/src/models/ExperimentModel";
 import { getLiveAndBaseRevisionsForFeature } from "back-end/src/services/features";
 
-const mockGetFeature = getFeature as jest.MockedFunction<typeof getFeature>;
+const mockGetFeature = jest.fn();
 const mockGetRevision = getRevision as jest.MockedFunction<typeof getRevision>;
 const mockDiscardRevision = discardRevision as jest.MockedFunction<
   typeof discardRevision
@@ -81,6 +79,7 @@ const ctx = {
   org: { id: "org_1", settings: {} },
   environments: ["production"],
   hasPremiumFeature: () => true,
+  models: { features: { getById: mockGetFeature } },
 } as unknown as ReqContext;
 
 function makeExperiment(

--- a/packages/back-end/test/services/rampSchedule.test.ts
+++ b/packages/back-end/test/services/rampSchedule.test.ts
@@ -57,8 +57,7 @@ import {
 // Module mocks (must be declared before imports that use them)
 // ---------------------------------------------------------------------------
 
-jest.mock("back-end/src/models/FeatureModel", () => ({
-  getFeature: jest.fn(),
+jest.mock("back-end/src/services/featureRevisions", () => ({
   publishRevision: jest.fn(),
 }));
 
@@ -90,12 +89,14 @@ jest.mock("back-end/src/util/secrets", () => ({
 }));
 
 // Pull in mocked module references AFTER the mock declarations.
-import { getFeature, publishRevision } from "back-end/src/models/FeatureModel";
+import { publishRevision } from "back-end/src/services/featureRevisions";
 import { createRevision } from "back-end/src/models/FeatureRevisionModel";
 import { createEvent } from "back-end/src/models/EventModel";
 import { RampAdvanceLockBusyError } from "back-end/src/util/errors";
 
-const mockGetFeature = getFeature as jest.MockedFunction<typeof getFeature>;
+// Feature lookups now go through ctx.models.features.getById; this standalone
+// mock is wired into each test context's models.features below.
+const mockGetFeature = jest.fn();
 const mockPublishRevision = publishRevision as jest.MockedFunction<
   typeof publishRevision
 >;
@@ -237,6 +238,7 @@ function makeContext(scheduleUpdates: Partial<RampScheduleInterface> = {}) {
         canPublishFeature: jest.fn().mockReturnValue(true),
       },
       models: {
+        features: { getById: mockGetFeature },
         rampSchedules: {
           updateById,
           getById: jest.fn(),
@@ -1489,6 +1491,9 @@ describe("featureEntityHandler.applyActions", () => {
     org: { id: ORG_ID, settings: {} },
     environments: [],
     auditUser: { type: "system" },
+    models: {
+      features: { getById: mockGetFeature },
+    },
   } as never;
 
   it("calls publishRevision with sparse-patched rules", async () => {
@@ -1950,6 +1955,7 @@ describe("advanceScheduleManually", () => {
         canPublishFeature: jest.fn().mockReturnValue(true),
       },
       models: {
+        features: { getById: mockGetFeature },
         rampSchedules: {
           updateById: rampUpdateById,
           getById: jest.fn().mockImplementation(async () => current),
@@ -2354,6 +2360,7 @@ describe("resumeSchedule", () => {
         canPublishFeature: jest.fn().mockReturnValue(true),
       },
       models: {
+        features: { getById: mockGetFeature },
         rampSchedules: {
           updateById,
           getById,
@@ -2425,6 +2432,7 @@ describe("restartSchedule", () => {
         canPublishFeature: jest.fn().mockReturnValue(true),
       },
       models: {
+        features: { getById: mockGetFeature },
         rampSchedules: { updateById, getById },
         safeRollout: { getById: safeRolloutGetById, update: safeRolloutUpdate },
       },
@@ -2564,6 +2572,7 @@ describe("advanceUntilBlocked", () => {
       environments: [],
       permissions: {},
       models: {
+        features: { getById: mockGetFeature },
         rampSchedules: { updateById, getById: jest.fn() },
       },
     };
@@ -2629,6 +2638,7 @@ describe("advanceUntilBlocked", () => {
       environments: [],
       permissions: {},
       models: {
+        features: { getById: mockGetFeature },
         rampSchedules: { updateById, getById: jest.fn() },
       },
     };
@@ -2683,7 +2693,10 @@ describe("advanceUntilBlocked", () => {
       auditUser: { type: "system" },
       environments: [],
       permissions: {},
-      models: { rampSchedules: { updateById, getById: jest.fn() } },
+      models: {
+        features: { getById: mockGetFeature },
+        rampSchedules: { updateById, getById: jest.fn() },
+      },
     };
 
     await advanceUntilBlocked(ctx as never, schedule, new Date());
@@ -2762,7 +2775,10 @@ describe("advanceUntilBlocked", () => {
       auditUser: { type: "system" },
       environments: [],
       permissions: {},
-      models: { rampSchedules: { updateById, getById: jest.fn() } },
+      models: {
+        features: { getById: mockGetFeature },
+        rampSchedules: { updateById, getById: jest.fn() },
+      },
     };
 
     await advanceUntilBlocked(ctx as never, schedule, new Date());
@@ -2831,7 +2847,10 @@ describe("advanceUntilBlocked", () => {
       auditUser: { type: "system" },
       environments: [],
       permissions: {},
-      models: { rampSchedules: { updateById, getById: jest.fn() } },
+      models: {
+        features: { getById: mockGetFeature },
+        rampSchedules: { updateById, getById: jest.fn() },
+      },
     };
 
     await advanceUntilBlocked(ctx as never, schedule, new Date());
@@ -2913,7 +2932,10 @@ describe("advanceUntilBlocked", () => {
       auditUser: { type: "system" },
       environments: [],
       permissions: {},
-      models: { rampSchedules: { updateById, getById: jest.fn() } },
+      models: {
+        features: { getById: mockGetFeature },
+        rampSchedules: { updateById, getById: jest.fn() },
+      },
     };
 
     await advanceUntilBlocked(ctx as never, schedule, new Date());
@@ -2950,6 +2972,7 @@ describe("advanceUntilBlocked", () => {
       environments: [],
       permissions: {},
       models: {
+        features: { getById: mockGetFeature },
         rampSchedules: { updateById, getById: jest.fn(), deleteById },
         safeRollout: { getById: jest.fn().mockResolvedValue(null) },
       },
@@ -2981,6 +3004,7 @@ describe("advanceUntilBlocked", () => {
       environments: [],
       permissions: {},
       models: {
+        features: { getById: mockGetFeature },
         rampSchedules: { updateById, getById: jest.fn(), deleteById },
         safeRollout: { getById: jest.fn().mockResolvedValue(null) },
       },
@@ -3016,6 +3040,7 @@ describe("advanceUntilBlocked", () => {
       environments: [],
       permissions: {},
       models: {
+        features: { getById: mockGetFeature },
         rampSchedules: { updateById, getById: jest.fn(), deleteById },
         safeRollout: { getById: jest.fn().mockResolvedValue(null) },
       },
@@ -3057,6 +3082,7 @@ describe("advanceUntilBlocked", () => {
       environments: [],
       permissions: {},
       models: {
+        features: { getById: mockGetFeature },
         rampSchedules: {
           updateById,
           getById: jest.fn(),
@@ -3438,6 +3464,7 @@ describe("startReadyScheduleNow", () => {
         canPublishFeature: jest.fn().mockReturnValue(true),
       },
       models: {
+        features: { getById: mockGetFeature },
         rampSchedules: {
           updateById,
           getById,
@@ -3715,6 +3742,7 @@ describe("startReadyScheduleNow", () => {
         canPublishFeature: jest.fn().mockReturnValue(true),
       },
       models: {
+        features: { getById: mockGetFeature },
         rampSchedules: {
           updateById,
           // First read is the lock wrapper's freshness check (must be ready);
@@ -3894,6 +3922,7 @@ describe("approveAndPublishStep", () => {
           canPublishFeature: jest.fn().mockReturnValue(true),
         },
         models: {
+          features: { getById: mockGetFeature },
           rampSchedules: { updateById, getById: jest.fn() },
         },
       },
@@ -4016,6 +4045,7 @@ describe("approveAndPublishStep", () => {
         canPublishFeature: jest.fn().mockReturnValue(true),
       },
       models: {
+        features: { getById: mockGetFeature },
         rampSchedules: {
           updateById,
           getById: jest.fn().mockImplementation(() => current),
@@ -4089,6 +4119,7 @@ describe("approveAndPublishStep", () => {
         canPublishFeature: jest.fn().mockReturnValue(true),
       },
       models: {
+        features: { getById: mockGetFeature },
         rampSchedules: {
           updateById,
           getById: jest.fn().mockImplementation(() => current),
@@ -4157,6 +4188,7 @@ describe("approveAndPublishStep", () => {
         canPublishFeature: jest.fn().mockReturnValue(true),
       },
       models: {
+        features: { getById: mockGetFeature },
         rampSchedules: {
           updateById,
           getById: jest.fn().mockImplementation(() => current),
@@ -4229,6 +4261,7 @@ describe("approveAndPublishStep", () => {
         canPublishFeature: jest.fn().mockReturnValue(true),
       },
       models: {
+        features: { getById: mockGetFeature },
         rampSchedules: {
           updateById,
           getById: jest.fn().mockImplementation(() => current),
@@ -4580,6 +4613,7 @@ describe("pauseSchedule", () => {
         canUpdateFeature: jest.fn().mockReturnValue(true),
       },
       models: {
+        features: { getById: mockGetFeature },
         rampSchedules: { updateById, getById: jest.fn() },
       },
     };
@@ -4615,6 +4649,7 @@ describe("pauseSchedule", () => {
         canUpdateFeature: jest.fn().mockReturnValue(true),
       },
       models: {
+        features: { getById: mockGetFeature },
         rampSchedules: { updateById, getById: jest.fn() },
       },
     };

--- a/packages/back-end/test/services/rampScheduleSafeRolloutSync.test.ts
+++ b/packages/back-end/test/services/rampScheduleSafeRolloutSync.test.ts
@@ -7,8 +7,7 @@ import {
   syncLinkedSafeRolloutForRampState,
 } from "back-end/src/services/rampSchedule";
 
-jest.mock("back-end/src/models/FeatureModel", () => ({
-  getFeature: jest.fn(),
+jest.mock("back-end/src/services/featureRevisions", () => ({
   publishRevision: jest.fn(),
 }));
 
@@ -83,6 +82,7 @@ function makeContext(safeRollout: SafeRolloutInterface) {
           getById: jest.fn().mockResolvedValue(safeRollout),
           update,
         },
+        features: { getById: jest.fn() },
       },
     },
     update,
@@ -287,6 +287,7 @@ describe("restartSchedule SafeRollout floor reset", () => {
             getById: jest.fn().mockResolvedValue(safeRollout),
             update: updateSafeRollout,
           },
+          features: { getById: jest.fn() },
         },
       },
       updateSafeRollout,

--- a/packages/back-end/test/services/sdk-payload-lifecycle.test.ts
+++ b/packages/back-end/test/services/sdk-payload-lifecycle.test.ts
@@ -21,7 +21,6 @@ import {
   type SDKPayloadRawData,
   type ConnectionPayloadOptions,
 } from "back-end/src/services/features";
-import * as FeatureModel from "back-end/src/models/FeatureModel";
 import * as ExperimentModel from "back-end/src/models/ExperimentModel";
 
 jest.mock("back-end/src/models/SdkConnectionModel", () => ({
@@ -38,9 +37,6 @@ jest.mock("back-end/src/util/api-key.util", () => ({
 jest.mock("back-end/src/models/SdkConnectionCacheModel", () => ({
   ...jest.requireActual("back-end/src/models/SdkConnectionCacheModel"),
   getSDKPayloadCacheLocation: jest.fn(),
-}));
-jest.mock("back-end/src/models/FeatureModel", () => ({
-  getAllFeatures: jest.fn().mockResolvedValue([]),
 }));
 jest.mock("back-end/src/models/ExperimentModel", () => ({
   getAllPayloadExperiments: jest.fn().mockResolvedValue(new Map()),
@@ -75,6 +71,9 @@ const findSDKConnectionsByOrganization = jest.requireMock(
 const triggerWebhookJobs = jest.requireMock("back-end/src/jobs/updateAllJobs")
   .triggerWebhookJobs as jest.Mock;
 
+// Feature listing now goes through context.models.features.getAll().
+const getAllFeaturesMock = jest.fn().mockResolvedValue([]);
+
 function minimalContext(overrides?: Partial<ApiReqContext>): ApiReqContext {
   return {
     org: {
@@ -87,7 +86,9 @@ function minimalContext(overrides?: Partial<ApiReqContext>): ApiReqContext {
       invites: [],
       settings: { environments: [{ id: "production", projects: [] }] },
     },
-    models: {} as ApiReqContext["models"],
+    models: {
+      features: { getAll: getAllFeaturesMock },
+    } as unknown as ApiReqContext["models"],
     userId: "u1",
     email: "e@e.com",
     userName: "User",
@@ -199,7 +200,7 @@ describe("SDK payload lifecycle (comprehensive)", () => {
         projects: [],
       } as SDKConnectionInterface;
       findSDKConnectionsByOrganization.mockResolvedValue([conn1, conn2]);
-      (FeatureModel.getAllFeatures as jest.Mock).mockResolvedValue([]);
+      getAllFeaturesMock.mockResolvedValue([]);
       (ExperimentModel.getAllPayloadExperiments as jest.Mock).mockResolvedValue(
         new Map(),
       );
@@ -211,6 +212,7 @@ describe("SDK payload lifecycle (comprehensive)", () => {
       ).mockResolvedValue([]);
 
       const mockModels = {
+        features: { getAll: getAllFeaturesMock },
         sdkConnectionCache: {
           deleteAllLegacyCacheEntries: deleteAllLegacy,
           upsert,
@@ -242,7 +244,7 @@ describe("SDK payload lifecycle (comprehensive)", () => {
       });
 
       expect(deleteAllLegacy).toHaveBeenCalled();
-      expect(FeatureModel.getAllFeatures).toHaveBeenCalled();
+      expect(getAllFeaturesMock).toHaveBeenCalled();
       expect(findSDKConnectionsByOrganization).toHaveBeenCalled();
       expect(upsert).toHaveBeenCalledTimes(2);
       expect(upsert).toHaveBeenCalledWith(
@@ -269,7 +271,7 @@ describe("SDK payload lifecycle (comprehensive)", () => {
         projects: [],
       } as SDKConnectionInterface;
 
-      (FeatureModel.getAllFeatures as jest.Mock).mockResolvedValue([]);
+      getAllFeaturesMock.mockResolvedValue([]);
       (ExperimentModel.getAllPayloadExperiments as jest.Mock).mockResolvedValue(
         new Map(),
       );
@@ -281,6 +283,7 @@ describe("SDK payload lifecycle (comprehensive)", () => {
       ).mockResolvedValue([]);
 
       const mockModels = {
+        features: { getAll: getAllFeaturesMock },
         sdkConnectionCache: {
           deleteAllLegacyCacheEntries: deleteAllLegacy,
           upsert,
@@ -387,7 +390,7 @@ describe("SDK payload lifecycle (comprehensive)", () => {
         projects: [],
       } as SDKConnectionInterface;
       findSDKConnectionsByOrganization.mockResolvedValue([conn]);
-      (FeatureModel.getAllFeatures as jest.Mock).mockResolvedValue([]);
+      getAllFeaturesMock.mockResolvedValue([]);
       (ExperimentModel.getAllPayloadExperiments as jest.Mock).mockResolvedValue(
         new Map(),
       );
@@ -398,6 +401,7 @@ describe("SDK payload lifecycle (comprehensive)", () => {
         ExperimentModel.getAllURLRedirectExperiments as jest.Mock
       ).mockResolvedValue([]);
       const mockModels = {
+        features: { getAll: getAllFeaturesMock },
         sdkConnectionCache: {
           deleteAllLegacyCacheEntries: deleteAllLegacy,
           upsert,
@@ -447,7 +451,7 @@ describe("SDK payload lifecycle (comprehensive)", () => {
         environment: "production",
         projects: [],
       } as SDKConnectionInterface;
-      (FeatureModel.getAllFeatures as jest.Mock).mockResolvedValue([]);
+      getAllFeaturesMock.mockResolvedValue([]);
       (ExperimentModel.getAllPayloadExperiments as jest.Mock).mockResolvedValue(
         new Map(),
       );
@@ -458,6 +462,7 @@ describe("SDK payload lifecycle (comprehensive)", () => {
         ExperimentModel.getAllURLRedirectExperiments as jest.Mock
       ).mockResolvedValue([]);
       const mockModels = {
+        features: { getAll: getAllFeaturesMock },
         sdkConnectionCache: {
           deleteAllLegacyCacheEntries: deleteAllLegacy,
           upsert,


### PR DESCRIPTION
### Features and Changes

Migrates `FeatureModel` from the legacy mongoose pattern to `BaseModel` (`MakeModelClass`). This is a refactor with no intended behavior change.

- **Model class.** `FeatureModel` now extends the `BaseClass` with `canRead`/`canCreate`/`canUpdate`/`canDelete`, `migrate`, `customValidation`, and `afterCreate`/`afterUpdate`/`afterDelete` hooks. The former free-function helpers are absorbed as methods, and the model is registered on the request context as `context.models.features`. All call sites are updated to go through the context.
- **Revision service.** The feature-revision business logic that lived in `FeatureModel.ts` (rule add/edit, default value, merge-change computation, publish) is extracted into a new `services/featureRevisions.ts`, keeping the model file to model concerns only. The ramp-schedule update-action path is #6330's code moved verbatim.
- **Out-of-org statics.** Codepaths that run outside a single org's context (e.g. scheduled-feature jobs) use `dangerous`-prefixed static methods, which bypass BaseModel's in-org query protections by design.
- **Fixes from live testing.** Two regressions surfaced by manual testing and are fixed here: (1) revision docs store explicit `null`s for absent optional rule fields, which BaseModel's strict update validator rejected — breaking every publish of an API-drafted rule; `buildFeatureUpdate` now drops null-valued rule keys. (2) BaseModel resolved `owner` on every update before its no-change diff, so publishes/syncs echoing a stored owner threw `Unable to find user` once that member left the org; resolution is now skipped when `owner` is unchanged.

Note: the new `rampSchedule` ⇄ `featureRevisions` import cycle changed module load order enough to evaluate `LocalAuthConnection`'s `expressjwt()` before `JWT_SECRET` was initialized, crashing ~10 test suites at import. `LocalAuthConnection` now builds that middleware lazily (on first use) instead of at module load.

### Testing

- [x] `pnpm --filter back-end type-check`, `pnpm lint` (changed files)
- [x] `FeatureModel.test.ts`, `BaseModel.test.ts`, `computeRevisionMergeChanges.test.ts`, `getApiFeatureObj.test.ts`, `rampSchedule.test.ts`, `updateScheduledFeatures.test.ts`, `features.test.ts` + API integration suites
- [x] All manual cases below, against a local dev instance

<details>
<summary><b>Manual test matrix (copy-pastable)</b></summary>

Setup — `AUTH` is a Personal Access Token, `ORG` your org id:

```bash
GB=http://localhost:3100
AUTH="Bearer key_..."         # Personal Access Token
ORG=org_...
api() { curl -s -X "$1" "$GB$2" -H "Authorization: $AUTH" -H "Content-Type: application/json" ${3:+-d "$3"}; }
m() { docker exec mongo mongosh "mongodb://root:password@localhost:27017/test?authSource=admin" --quiet --eval "$1"; }
```

Draft revision versions below (`/revisions/2/...`) assume a fresh feature; take the actual `version` from the prior response.

**1. CRUD lifecycle + hooks** — initial revision, events, cleanup:

```bash
api POST /api/v2/features '{"id":"t1","valueType":"boolean","defaultValue":"false"}'
m "db.featurerevisions.countDocuments({organization:'$ORG', featureId:'t1'})"       # 1 (initial revision)
m "db.events.find({organizationId:'$ORG'}).sort({dateCreated:-1}).limit(1).toArray().map(e=>e.event)"  # feature.created
api POST /api/v2/features/t1 '{"description":"x"}'                                  # feature.updated event, version bump
api DELETE /api/v2/features/t1
m "db.featurerevisions.countDocuments({organization:'$ORG', featureId:'t1'})"       # 0; feature.deleted event
```

**2. Publish with API-drafted rule** (regression fix 1 — revision rules carry `condition: null` etc. on disk):

```bash
api POST /api/v2/features '{"id":"t2","valueType":"boolean","defaultValue":"false"}'
api POST /api/v2/features/t2/revisions/new/rules '{"rule":{"type":"force","description":"","value":"true","enabled":true,"environments":["production"]}}'
api POST /api/v2/features/t2/revisions/2/publish '{}'   # 200; pre-fix: 400 Zod "expected string, received null"
m "db.features.findOne({organization:'$ORG', id:'t2'}).rules"   # rule persisted with no null-valued keys
```

**3. Owner echo for a departed member** (regression fix 2):

```bash
m "db.features.updateOne({organization:'$ORG', id:'t2'}, {\$set:{owner:'u_departed0000'}})"
api PUT /api/v2/features/t2/revisions/new/metadata '{"owner":"u_departed0000","description":"y"}'
api POST /api/v2/features/t2/revisions/3/publish '{}'   # 200, owner preserved as-is; pre-fix: 400 "Unable to find user"
```

**4. Environment toggle** (`dangerousUpdateBypassPermission` path):

```bash
api POST /api/v2/features/t2/toggle '{"environments":{"production":true}}'
m "db.features.findOne({organization:'$ORG', id:'t2'}).environmentSettings.production.enabled"  # true
```

**5. Legacy v1/v0 docs read through `migrate()`** — insert raw legacy shapes, read via API:

```bash
m "db.features.insertOne({id:'t-v1', organization:'$ORG', dateCreated:new Date(), dateUpdated:new Date(),
  valueType:'string', defaultValue:'off', owner:'', project:'', tags:[], version:1,
  environmentSettings:{production:{enabled:true, rules:[{type:'force', value:'on', condition:'{}', enabled:true, description:''}]}},
  revision:{version:1}})"
api GET /api/v2/features/t-v1     # per-env rule flattened to v2 with synthesized fr_h_* id, scoped to production; SDK definition present
m "db.features.insertOne({id:'t-v0', organization:'$ORG', dateCreated:new Date(), dateUpdated:new Date(),
  valueType:'boolean', defaultValue:'false', owner:'', project:'', tags:[],
  environments:['production'], rules:[{type:'force', value:'true', enabled:true, description:''}]})"
api GET /api/v2/features/t-v0     # v0 top-level rule distributed to dev+production; enabled backfilled from environments array
```

**6. Permission enforcement** — set your API user's member role to `readonly` (Settings → Members), then:

```bash
api POST   /api/v2/features '{"id":"t3","valueType":"boolean","defaultValue":"false"}'   # 403
api POST   /api/v2/features/t2 '{"description":"z"}'                                     # 403
api DELETE /api/v2/features/t2                                                           # 403
api POST   /api/v2/features/t2/toggle '{"environments":{"production":false}}'            # 403
api GET    /api/v2/features/t2                                                           # 200
```

Project-scoped reads: give the member no global role and a role on a single project, move `t2` to a different project (`m "db.features.updateOne(..., {\$set:{project:'prj_other'}})"`) → `GET /api/v2/features/t2` returns "Could not find a feature with that key" and the list excludes it. Restore the role afterwards.

**7. Scheduled-features job** (`dangerousGetScheduledFeaturesToUpdate` + `updateNextScheduledDate`) — simulate an existing feature with legacy schedule fields:

```bash
m "db.features.updateOne({organization:'$ORG', id:'t2'}, {\$set:{
  'rules.0.scheduleType':'schedule',
  'rules.0.scheduleRules':[{timestamp:new Date().toISOString(), enabled:true},{timestamp:null, enabled:false}],
  nextScheduledUpdate:new Date()}})"
# wait ~1 min for the agenda job, then:
m "db.features.findOne({organization:'$ORG', id:'t2'}).nextScheduledUpdate"   # cleared (no future entries), dateUpdated bumped
```

**8. Ramp schedules via revision publish** (`createRampSchedulesForRevision` — includes #6330's rewrite). Create path, then the start-now update path:

```bash
api POST /api/v2/features '{"id":"t4","valueType":"boolean","defaultValue":"false"}'
api POST /api/v2/features/t4/revisions/new/rules '{"rule":{"type":"force","description":"","value":"true","enabled":false,"environments":["production"]},"schedule":{"startDate":"2027-01-01T00:00:00.000Z"}}'
api POST /api/v2/features/t4/revisions/2/publish '{}'
m "db.rampschedules.findOne({organization:'$ORG', entityId:'t4'})"   # status "ready", target ruleId set, activatingRevisionVersion 2
# start now: update action with startDate null (RULE_ID from the schedule's target)
api PUT /api/v2/features/t4/revisions/new/rules/RULE_ID '{"rule":{},"rampSchedule":{"name":"start now","startDate":null}}'
api POST /api/v2/features/t4/revisions/3/publish '{}'
m "db.features.findOne({organization:'$ORG', id:'t4'}).rules[0].enabled"   # true — start actions applied inline
m "db.rampschedules.countDocuments({organization:'$ORG', entityId:'t4'})"  # 0 — zero-step schedule completes and self-deletes
```

**9. Linked-experiment sync** (`afterUpdate`/`afterDelete`):

```bash
api POST /api/v2/features '{"id":"t5","valueType":"string","defaultValue":"control"}'
api POST /api/v2/features/t5/revisions/new/rules '{"rule":{"type":"experiment-ref","description":"","experimentId":"EXP_ID","environments":["production"],"enabled":true,"variations":[{"variationId":"0","value":"control"},{"variationId":"1","value":"treatment"}]}}'
api POST /api/v2/features/t5/revisions/2/publish '{}'
m "db.experiments.findOne({organization:'$ORG', id:'EXP_ID'}).linkedFeatures"   # includes t5
api DELETE /api/v2/features/t5
m "db.experiments.findOne({organization:'$ORG', id:'EXP_ID'}).linkedFeatures"   # t5 removed
```

**10. Cascades** (internal app API — needs a logged-in session JWT instead of the PAT):

```bash
# tag removal pulls the tag from every feature (removeTagFromAllFeatures)
api DELETE /tag '{"id":"some-tag"}'
# project delete: default orphans features to project "" (removeProjectFromAllFeatures);
# ?deleteResources=true deletes them + their revisions (deleteAllForProject)
api DELETE /projects/prj_x
api DELETE "/projects/prj_y?deleteResources=true"
```

**11. Reads and payloads** — pagination (`getPage`/`count`), archive, SDK payload, projection reads:

```bash
api GET "/api/v2/features?limit=5&offset=10"          # stable pages, correct total/hasMore/nextOffset
api PUT /api/v2/features/t2/revisions/new/archive '{"archived":true}'
api POST /api/v2/features/t2/revisions/4/publish '{}'
api GET "/api/v2/features?limit=100"                  # t2 excluded; ...&archived=true includes it
curl -s $GB/api/features/CLIENT_KEY                   # SDK payload serves all features with correct definitions
# internal (session JWT): /features/meta-info, /features/stale, /features/dependents all 200 with expected shapes
```

All cases passed. Not covered live: Vercel-integration sync hooks (no local Vercel org).

</details>
