### PR TITLE
Fix for inserting elements correctly with the visual editor. 

### DIFF
--- a/packages/back-end/src/api/visual-editor-ai/insertPrimitive.ts
+++ b/packages/back-end/src/api/visual-editor-ai/insertPrimitive.ts
@@ -1,0 +1,72 @@
+// Shared insert primitive for the Visual Editor AI endpoints.
+//
+// Adding new DOM (a banner, a section, a component) must NOT go through a
+// dom-mutator `html` mutation: `append` re-fires dom-mutator's MutationObserver
+// and multiplies the inserted markup (a guaranteed freeze on `body`), and
+// `set` on a container replaces its entire contents (wiping the page on
+// body/html). Instead we inject through the variation's `js` field with an
+// idempotent `insertAdjacentHTML` snippet — the SDK runs `js` once as a
+// <script>, with no observer, so it can't loop or duplicate.
+//
+// Both postFigmaToVariant (component injection) and postAIEdit (AI "add a
+// banner" edits) build inserts the same way, so the primitive lives here.
+
+import { v4 as uuidv4 } from "uuid";
+
+// The four insertAdjacentHTML positions, relative to the target element:
+//   beforebegin — before the element (previous sibling)
+//   afterbegin  — inside the element, as its first child
+//   beforeend   — inside the element, as its last child
+//   afterend    — after the element (next sibling)
+export type InsertPosition =
+  | "beforebegin"
+  | "afterbegin"
+  | "beforeend"
+  | "afterend";
+
+export const INSERT_POSITIONS: readonly InsertPosition[] = [
+  "beforebegin",
+  "afterbegin",
+  "beforeend",
+  "afterend",
+] as const;
+
+// A unique scope class for one injected component. Doubles as the
+// idempotency guard in the insert script (never insert twice) and, for the
+// Figma path, the prefix every scoped CSS rule hangs off of.
+export function makeScopeToken(): string {
+  return `gbf-${uuidv4().replace(/-/g, "").slice(0, 8)}`;
+}
+
+// Guarantee the injected markup has a single root carrying the scope class,
+// so (a) the insert script's idempotency check has something to match and
+// (b) the Figma path's scoped CSS applies. Wraps only when the token isn't
+// already present (the model is asked to include it, but wrap defensively).
+export function wrapWithScope(rawHtml: string, scopeToken: string): string {
+  const html = rawHtml.trim();
+  return html.includes(scopeToken)
+    ? html
+    : `<div class="${scopeToken}">${html}</div>`;
+}
+
+// Build a self-contained, idempotent insertion script for the variation's
+// `js` field. It runs once in the SDK (and our editor preview), guards on the
+// unique scope class so it never double-inserts, and waits (bounded to 10s)
+// for late/SPA-rendered targets before giving up — so it never loops.
+export function buildInsertJs({
+  scopeToken,
+  targetSelector,
+  position,
+  html,
+}: {
+  scopeToken: string;
+  targetSelector: string;
+  position: InsertPosition;
+  html: string;
+}): string {
+  const S = JSON.stringify(scopeToken);
+  const T = JSON.stringify(targetSelector);
+  const P = JSON.stringify(position);
+  const H = JSON.stringify(html);
+  return `(function(){var S=${S};function ins(){if(document.querySelector("."+S))return true;var t=document.querySelector(${T});if(!t)return false;t.insertAdjacentHTML(${P},${H});return true;}if(ins())return;var mo=new MutationObserver(function(){if(ins())mo.disconnect();});mo.observe(document.documentElement,{childList:true,subtree:true});setTimeout(function(){mo.disconnect();},10000);})();`;
+}

--- a/packages/back-end/src/api/visual-editor-ai/insertPrimitive.ts
+++ b/packages/back-end/src/api/visual-editor-ai/insertPrimitive.ts
@@ -57,6 +57,27 @@ export function wrapWithScope(rawHtml: string, scopeToken: string): string {
   return rootHasScope ? html : `<div class="${scopeToken}">${html}</div>`;
 }
 
+// insertAdjacentHTML throws for "beforebegin"/"afterend" on the <html> root —
+// you can't add a sibling to the document's root element. The AI-edit schema
+// lets the model target "html"/":root", so remap those two impossible cases to
+// the equivalent spot inside <body> (top/bottom of the page) instead of letting
+// the insert throw (and silently no-op behind buildInsertJs's try/catch).
+// Everything else passes through unchanged. Apply this BEFORE building the
+// script AND the preview descriptor so both agree on where the node lands.
+export function normalizeInsertPlacement(
+  targetSelector: string,
+  position: InsertPosition,
+): { targetSelector: string; position: InsertPosition } {
+  const isRoot = /^\s*(?:html|:root)\s*$/i.test(targetSelector);
+  if (isRoot && position === "beforebegin") {
+    return { targetSelector: "body", position: "afterbegin" };
+  }
+  if (isRoot && position === "afterend") {
+    return { targetSelector: "body", position: "beforeend" };
+  }
+  return { targetSelector, position };
+}
+
 // Build a self-contained, idempotent insertion script for the variation's
 // `js` field. It runs once in the SDK (and our editor preview), guards on the
 // unique scope class so it never double-inserts, and waits (bounded to 10s)

--- a/packages/back-end/src/api/visual-editor-ai/insertPrimitive.ts
+++ b/packages/back-end/src/api/visual-editor-ai/insertPrimitive.ts
@@ -44,15 +44,27 @@ export function makeScopeToken(): string {
 // already present (the model is asked to include it, but wrap defensively).
 export function wrapWithScope(rawHtml: string, scopeToken: string): string {
   const html = rawHtml.trim();
-  return html.includes(scopeToken)
-    ? html
-    : `<div class="${scopeToken}">${html}</div>`;
+  // Only skip the wrapper when the token is a class on the ROOT element — not
+  // just present somewhere in the markup. If the model put the class on a
+  // child (or in text / an inline style) but not the root, we must still wrap,
+  // otherwise the root lacks the class the insert script's idempotency guard
+  // and the scoped CSS rely on. The token is a controlled `gbf-…` slug (see
+  // makeScopeToken), so it's safe to embed in the RegExp.
+  const rootTag = html.match(/^<[^>]+>/)?.[0] ?? "";
+  const rootHasScope = new RegExp(
+    `\\bclass=["'][^"']*\\b${scopeToken}\\b`,
+  ).test(rootTag);
+  return rootHasScope ? html : `<div class="${scopeToken}">${html}</div>`;
 }
 
 // Build a self-contained, idempotent insertion script for the variation's
 // `js` field. It runs once in the SDK (and our editor preview), guards on the
 // unique scope class so it never double-inserts, and waits (bounded to 10s)
-// for late/SPA-rendered targets before giving up — so it never loops.
+// for late/SPA-rendered targets before giving up — so it never loops. The
+// insertAdjacentHTML call is wrapped in try/catch: some position + target
+// combinations throw (e.g. "beforebegin"/"afterend" on the <html> root), and
+// an uncaught throw here would abort the rest of the variation's JS. We treat
+// a throw as a clean give-up (return true) rather than letting it propagate.
 export function buildInsertJs({
   scopeToken,
   targetSelector,
@@ -68,5 +80,5 @@ export function buildInsertJs({
   const T = JSON.stringify(targetSelector);
   const P = JSON.stringify(position);
   const H = JSON.stringify(html);
-  return `(function(){var S=${S};function ins(){if(document.querySelector("."+S))return true;var t=document.querySelector(${T});if(!t)return false;t.insertAdjacentHTML(${P},${H});return true;}if(ins())return;var mo=new MutationObserver(function(){if(ins())mo.disconnect();});mo.observe(document.documentElement,{childList:true,subtree:true});setTimeout(function(){mo.disconnect();},10000);})();`;
+  return `(function(){var S=${S};function ins(){if(document.querySelector("."+S))return true;var t=document.querySelector(${T});if(!t)return false;try{t.insertAdjacentHTML(${P},${H});}catch(e){}return true;}if(ins())return;var mo=new MutationObserver(function(){if(ins())mo.disconnect();});mo.observe(document.documentElement,{childList:true,subtree:true});setTimeout(function(){mo.disconnect();},10000);})();`;
 }

--- a/packages/back-end/src/enterprise/api/visual-editor-ai/postAIEdit.ts
+++ b/packages/back-end/src/enterprise/api/visual-editor-ai/postAIEdit.ts
@@ -15,6 +15,11 @@ import {
   VISUAL_EDITOR_MAX_STEPS,
 } from "back-end/src/api/visual-editor-ai/aiTools";
 import { aiEditJobStore } from "back-end/src/api/visual-editor-ai/aiTools/clientJob";
+import {
+  buildInsertJs,
+  makeScopeToken,
+  wrapWithScope,
+} from "back-end/src/api/visual-editor-ai/insertPrimitive";
 
 // Output-token cap for the edit generation. Above the 8000 parsePrompt
 // default because an edit can REPLACE the variation's entire global CSS/JS
@@ -227,15 +232,56 @@ const outputSchema = z.object({
     .describe(
       "Complete global JS for this variation. REPLACES any prior JS — to add, modify, or remove code, return the rest of the existing JS verbatim alongside your change. Set to null when the user's request doesn't touch global JS (the existing JS stays as-is). Do NOT return a partial fragment or an empty string when JS exists; that wipes it.",
     ),
+  insert: z
+    .array(
+      z.object({
+        targetSelector: z
+          .string()
+          .describe(
+            'Existing element to position the new content relative to. Must be a real selector from the Page elements catalog (e.g. "body", "header", a section selector). For a site-wide banner at the very top of the page, use "body".',
+          ),
+        position: z
+          .enum(["beforebegin", "afterbegin", "beforeend", "afterend"])
+          .describe(
+            'Where to place the new content relative to targetSelector: "beforebegin" = immediately before it (previous sibling); "afterbegin" = as its FIRST child (use this with "body" for a banner at the top of the page); "beforeend" = as its LAST child; "afterend" = immediately after it (next sibling).',
+          ),
+        html: z
+          .string()
+          .describe(
+            "Complete HTML markup for the NEW content only — never include the page's existing DOM. Put styling inline or in the global `css` field. Keep it a single logical block (wrap multiple elements in one container).",
+          ),
+      }),
+    )
+    .nullable()
+    .describe(
+      "New elements to INSERT into the page — use this for ANY request to ADD, insert, prepend, or append NEW content (banners, notices, sections, blocks, buttons that don't exist yet). This is the ONLY correct way to add content: NEVER add content by setting/appending \"html\" on body/html or another container (that replaces its entire contents and crashes the page). Null when the request doesn't add any new elements.",
+    ),
   explanation: z
     .string()
     .describe("One-paragraph summary of the changes for the editor user."),
 });
 
+// Selectors whose innerHTML must never be replaced.
+const PAGE_ROOT_SELECTOR_RE = /^\s*(?::root|html|body)\s*$/i;
+
+// Backstop for the crash the `insert` field + prompt rules are meant to
+// prevent: an html mutation is unsafe when it targets a page-root container
+// (replacing body/html innerHTML wipes the page, and dom-mutator's observer
+// then re-fires → freeze) OR its value echoes whole-document markup (a sign
+// the model serialized the existing page instead of a small content swap).
+// The same mutation would run in the production SDK, so this guard protects
+// real visitors, not just the editor preview.
+function isUnsafeHtmlMutation(selector: string, value: string | null): boolean {
+  if (PAGE_ROOT_SELECTOR_RE.test(selector)) return true;
+  if (value && /<\s*(?:!doctype|html|head|body)[\s>]/i.test(value)) return true;
+  return false;
+}
+
 const instructions = `You are GrowthBook's Visual Editor assistant. Your job is to translate natural-language change requests into a structured set of DOM mutations that GrowthBook can apply to a web page in an A/B test variation.
 
 Allowed attribute values and what they do:
 - "html" — replaces the element's innerHTML. Use this for ANY visible text change (plain text is valid HTML). Example: { selector: ".headline", action: "set", attribute: "html", value: "Welcome back!" }
+  CRITICAL: "html" REPLACES everything inside the target element. Only ever target a small, specific element whose entire contents you intend to swap. NEVER use "html" (with "set" OR "append") on "body", "html", ":root", or any large structural/layout container — that destroys the whole page and crashes it. NEVER put the page's existing DOM into an html value (don't echo the current markup back). To ADD new content to the page, use the \`insert\` field (see "Inserting new elements" below) — never an html mutation on a container.
 - "style" — replaces the element's inline style. Value is a CSS declaration string, e.g. "display:none" or "color:red;font-size:20px".
 - "class" — with action "set" replaces the className, with action "append" adds classes (space-separated).
 - "position" — moves the element into a new parent. Use action "set". value MUST be null. Set parentSelector to the destination parent (required, must be in the catalog). Set insertBeforeSelector to a sibling inside that parent to insert this element BEFORE it; omit (null) to append at the end. Example to move a CTA above the headline:
@@ -244,6 +290,13 @@ Allowed attribute values and what they do:
 - Any real HTML attribute name: "src", "href", "alt", "title", "aria-label", "data-foo", etc.
 
 DO NOT invent attribute names. There is NO "text" attribute. To change visible text, ALWAYS use attribute "html". To hide an element use attribute "style" with value containing "display:none".
+
+Inserting new elements (banners, notices, sections, new blocks) — use the \`insert\` field, NOT an html mutation:
+- When the user asks to ADD, insert, prepend, append, or place NEW content on the page (a promotional banner, an announcement bar, a new section, a CTA that doesn't exist yet), return it in the \`insert\` array. Do NOT try to add content by setting or appending "html" on "body"/"html"/a container — that replaces the container's entire contents and crashes the page.
+- Each insert entry has: \`targetSelector\` (an existing element from the catalog to anchor to), \`position\` (beforebegin / afterbegin / beforeend / afterend, relative to that element), and \`html\` (the NEW markup ONLY — never the page's existing content).
+- "A full-width banner at the TOP of the page" → { targetSelector: "body", position: "afterbegin", html: "<div …>…</div>" }. "At the very bottom" → targetSelector "body", position "beforeend". Directly before/after a specific section → that section's selector with "beforebegin"/"afterend".
+- Style the inserted markup with inline styles, or add rules to the global \`css\` field. Give your new elements their own class names so your CSS can target them. (If the request wants a photographic image inside the banner, call \`generateImage\` and place the returned URL in the markup.)
+- You may return \`insert\` alongside \`mutations\` and \`css\` in one response. Inserts are applied idempotently and are safe on "body". Leave \`insert\` null when the request doesn't add any new elements.
 
 Position-move rules (critical):
 - A move is applied as parentSelector.insertBefore(element, insertBeforeSelector). The hard DOM requirement is on insertBeforeSelector ONLY: it must resolve to a DIRECT CHILD of parentSelector — it's the reference node the browser inserts before, and insertBefore fails if it isn't a direct child of the parent. The moved element (selector) can live ANYWHERE in the DOM — it's detached from its current spot and re-inserted — so relocating an element into a different container is perfectly valid. The common mistake is naming a deeper descendant as insertBeforeSelector (e.g. a link nested inside a list item), which is NOT a direct child of the parent, so the insert fails.
@@ -320,7 +373,7 @@ Offering alternatives for the user to choose from:
 - For ordinary single changes (no "alternatives"/"options" language), leave \`options\` null and just set \`value\`.
 
 Conversation continuity:
-- You may be given a "Previous conversation" block. Use it to resolve pronouns ("it", "them", "the same one") and references to earlier edits. Do not re-apply mutations already accepted in earlier turns unless explicitly asked.
+- You may be given a "Previous conversation" block. Use it to resolve pronouns ("it", "them", "the same one") and references to earlier edits. Do not re-apply mutations, or re-insert content, already accepted in earlier turns unless explicitly asked (re-inserting a banner you already added would duplicate it).
 
 Picked-element computed styles:
 - Picked elements may carry a \`computedStyles\` map — a subset of the element's CURRENT CSS (font-family, font-size, color, background-color, padding, margin, border, border-radius, box-shadow, etc.) as the browser is rendering it right now.
@@ -653,6 +706,12 @@ export const postAIEdit = createApiRequestHandler(validation)(async (req) => {
     mutations: unknown[];
     css?: string;
     js?: string;
+    insert?: Array<{
+      targetSelector: string;
+      position: "beforebegin" | "afterbegin" | "beforeend" | "afterend";
+      html: string;
+      scopeToken: string;
+    }>;
     explanation: string;
   }> => {
     let result = raw;
@@ -678,7 +737,21 @@ export const postAIEdit = createApiRequestHandler(validation)(async (req) => {
       }
     }
 
+    let droppedUnsafeHtml = false;
     const sanitizedMutations = result.mutations.filter((m) => {
+      const attr = m.attribute === "text" ? "html" : m.attribute;
+      // Guard (#3): never let an html mutation replace a page-root container
+      // or carry whole-document markup. Adding content must go through
+      // `insert`; this backstops the prompt rules and protects visitors
+      // (the same mutation runs in the SDK).
+      if (attr === "html" && isUnsafeHtmlMutation(m.selector, m.value)) {
+        droppedUnsafeHtml = true;
+        logger.warn(
+          { selector: m.selector },
+          "[visual-editor-ai] dropping unsafe html mutation (page-root target or full-document value)",
+        );
+        return false;
+      }
       if (m.attribute !== "position") return true;
       if (!m.parentSelector) {
         logger.warn(
@@ -703,6 +776,58 @@ export const postAIEdit = createApiRequestHandler(validation)(async (req) => {
       }
       return true;
     });
+
+    // Compile any `insert`s the model returned into idempotent
+    // insertAdjacentHTML snippets (see insertPrimitive.ts). Adding new DOM
+    // goes through the variation's `js`, never a dom-mutation — dom-mutator
+    // has no safe insert primitive.
+    const insertDescriptors: Array<{
+      targetSelector: string;
+      position: "beforebegin" | "afterbegin" | "beforeend" | "afterend";
+      html: string;
+      scopeToken: string;
+    }> = [];
+    const insertJsSnippets: string[] = [];
+    for (const ins of result.insert ?? []) {
+      const targetSelector = ins.targetSelector.trim();
+      const rawHtml = ins.html.trim();
+      if (!targetSelector || !rawHtml) continue;
+      const scopeToken = makeScopeToken();
+      const html = wrapWithScope(rawHtml, scopeToken);
+      insertJsSnippets.push(
+        buildInsertJs({
+          scopeToken,
+          targetSelector,
+          position: ins.position,
+          html,
+        }),
+      );
+      insertDescriptors.push({
+        targetSelector,
+        position: ins.position,
+        html,
+        scopeToken,
+      });
+    }
+
+    // Merge the insert snippets into the variation's JS. The model's `js`
+    // (per its contract) is the COMPLETE new global JS; fall back to the
+    // existing JS when it left js null, then append our snippets.
+    let finalJs: string | undefined;
+    if (insertJsSnippets.length > 0) {
+      const baseJs = (result.js ?? currentChange?.js ?? "").trim();
+      finalJs = [baseJs, ...insertJsSnippets]
+        .filter((s) => s.length > 0)
+        .join("\n\n");
+    } else if (result.js && result.js !== currentChange?.js) {
+      finalJs = result.js;
+    }
+
+    let explanation = result.explanation;
+    if (droppedUnsafeHtml) {
+      explanation +=
+        " (Skipped an unsafe change that would have replaced the entire page. To add content to the page, ask me to insert a banner or section instead.)";
+    }
 
     return {
       mutations: sanitizedMutations.map((m) => {
@@ -747,10 +872,9 @@ export const postAIEdit = createApiRequestHandler(validation)(async (req) => {
       ...(result.css && result.css !== currentChange?.css
         ? { css: result.css }
         : {}),
-      ...(result.js && result.js !== currentChange?.js
-        ? { js: result.js }
-        : {}),
-      explanation: result.explanation,
+      ...(finalJs ? { js: finalJs } : {}),
+      ...(insertDescriptors.length > 0 ? { insert: insertDescriptors } : {}),
+      explanation,
     };
   };
 

--- a/packages/back-end/src/enterprise/api/visual-editor-ai/postAIEdit.ts
+++ b/packages/back-end/src/enterprise/api/visual-editor-ai/postAIEdit.ts
@@ -18,6 +18,7 @@ import { aiEditJobStore } from "back-end/src/api/visual-editor-ai/aiTools/client
 import {
   buildInsertJs,
   makeScopeToken,
+  normalizeInsertPlacement,
   wrapWithScope,
 } from "back-end/src/api/visual-editor-ai/insertPrimitive";
 
@@ -788,25 +789,23 @@ export const postAIEdit = createApiRequestHandler(validation)(async (req) => {
     }> = [];
     const insertJsSnippets: string[] = [];
     for (const ins of result.insert) {
-      const targetSelector = ins.targetSelector.trim();
+      const rawTarget = ins.targetSelector.trim();
       const rawHtml = ins.html.trim();
-      if (!targetSelector || !rawHtml) continue;
+      if (!rawTarget || !rawHtml) continue;
+      // Remap root-relative positions insertAdjacentHTML can't do on <html>
+      // (e.g. "beforebegin" on the root) to a valid spot inside <body>, so a
+      // top/bottom-of-page insert actually lands instead of silently failing.
+      // Normalize once, then use for both the script and the preview descriptor.
+      const { targetSelector, position } = normalizeInsertPlacement(
+        rawTarget,
+        ins.position,
+      );
       const scopeToken = makeScopeToken();
       const html = wrapWithScope(rawHtml, scopeToken);
       insertJsSnippets.push(
-        buildInsertJs({
-          scopeToken,
-          targetSelector,
-          position: ins.position,
-          html,
-        }),
+        buildInsertJs({ scopeToken, targetSelector, position, html }),
       );
-      insertDescriptors.push({
-        targetSelector,
-        position: ins.position,
-        html,
-        scopeToken,
-      });
+      insertDescriptors.push({ targetSelector, position, html, scopeToken });
     }
 
     // Merge the insert snippets into the variation's JS. The model's `js`

--- a/packages/back-end/src/enterprise/api/visual-editor-ai/postAIEdit.ts
+++ b/packages/back-end/src/enterprise/api/visual-editor-ai/postAIEdit.ts
@@ -814,7 +814,14 @@ export const postAIEdit = createApiRequestHandler(validation)(async (req) => {
     // existing JS when it left js null, then append our snippets.
     let finalJs: string | undefined;
     if (insertJsSnippets.length > 0) {
-      const baseJs = (result.js ?? currentChange?.js ?? "").trim();
+      // Only treat the model's `js` as the new base when it actually has
+      // content. A schema-valid empty string must NOT drop the variation's
+      // existing JS — a plain "add a banner" edit leaves js empty, and `??`
+      // wouldn't catch "" (only null/undefined), so fall back explicitly.
+      const baseJs =
+        result.js && result.js.trim().length > 0
+          ? result.js.trim()
+          : (currentChange?.js ?? "").trim();
       finalJs = [baseJs, ...insertJsSnippets]
         .filter((s) => s.length > 0)
         .join("\n\n");

--- a/packages/back-end/src/enterprise/api/visual-editor-ai/postAIEdit.ts
+++ b/packages/back-end/src/enterprise/api/visual-editor-ai/postAIEdit.ts
@@ -252,9 +252,8 @@ const outputSchema = z.object({
           ),
       }),
     )
-    .nullable()
     .describe(
-      "New elements to INSERT into the page — use this for ANY request to ADD, insert, prepend, or append NEW content (banners, notices, sections, blocks, buttons that don't exist yet). This is the ONLY correct way to add content: NEVER add content by setting/appending \"html\" on body/html or another container (that replaces its entire contents and crashes the page). Null when the request doesn't add any new elements.",
+      "New elements to INSERT into the page — use this for ANY request to ADD, insert, prepend, or append NEW content (banners, notices, sections, blocks, buttons that don't exist yet). This is the ONLY correct way to add content: NEVER add content by setting/appending \"html\" on body/html or another container (that replaces its entire contents and crashes the page). Return an empty array when the request doesn't add any new elements.",
     ),
   explanation: z
     .string()
@@ -296,7 +295,7 @@ Inserting new elements (banners, notices, sections, new blocks) — use the \`in
 - Each insert entry has: \`targetSelector\` (an existing element from the catalog to anchor to), \`position\` (beforebegin / afterbegin / beforeend / afterend, relative to that element), and \`html\` (the NEW markup ONLY — never the page's existing content).
 - "A full-width banner at the TOP of the page" → { targetSelector: "body", position: "afterbegin", html: "<div …>…</div>" }. "At the very bottom" → targetSelector "body", position "beforeend". Directly before/after a specific section → that section's selector with "beforebegin"/"afterend".
 - Style the inserted markup with inline styles, or add rules to the global \`css\` field. Give your new elements their own class names so your CSS can target them. (If the request wants a photographic image inside the banner, call \`generateImage\` and place the returned URL in the markup.)
-- You may return \`insert\` alongside \`mutations\` and \`css\` in one response. Inserts are applied idempotently and are safe on "body". Leave \`insert\` null when the request doesn't add any new elements.
+- You may return \`insert\` alongside \`mutations\` and \`css\` in one response. Inserts are applied idempotently and are safe on "body". Return an empty \`insert\` array when the request doesn't add any new elements.
 
 Position-move rules (critical):
 - A move is applied as parentSelector.insertBefore(element, insertBeforeSelector). The hard DOM requirement is on insertBeforeSelector ONLY: it must resolve to a DIRECT CHILD of parentSelector — it's the reference node the browser inserts before, and insertBefore fails if it isn't a direct child of the parent. The moved element (selector) can live ANYWHERE in the DOM — it's detached from its current spot and re-inserted — so relocating an element into a different container is perfectly valid. The common mistake is naming a deeper descendant as insertBeforeSelector (e.g. a link nested inside a list item), which is NOT a direct child of the parent, so the insert fails.
@@ -788,7 +787,7 @@ export const postAIEdit = createApiRequestHandler(validation)(async (req) => {
       scopeToken: string;
     }> = [];
     const insertJsSnippets: string[] = [];
-    for (const ins of result.insert ?? []) {
+    for (const ins of result.insert) {
       const targetSelector = ins.targetSelector.trim();
       const rawHtml = ins.html.trim();
       if (!targetSelector || !rawHtml) continue;

--- a/packages/back-end/src/enterprise/api/visual-editor-ai/postFigmaToVariant.ts
+++ b/packages/back-end/src/enterprise/api/visual-editor-ai/postFigmaToVariant.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { v4 as uuidv4 } from "uuid";
 import { pickVisionModel } from "shared/ai";
 import { findVisualChangesetById } from "back-end/src/models/VisualChangesetModel";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
@@ -19,6 +18,11 @@ import {
 } from "back-end/src/services/figma";
 import { requireUserAuth } from "back-end/src/api/visual-editor-ai/requireUserAuth";
 import { scopeCss } from "back-end/src/api/visual-editor-ai/scopeCss";
+import {
+  buildInsertJs,
+  makeScopeToken,
+  wrapWithScope,
+} from "back-end/src/api/visual-editor-ai/insertPrimitive";
 
 // Reuse the reference-image shape from image-gen: plain base64, mimeType
 // enum, 8 MB cap. No `data:` URL → no SSRF on the mockup-image path.
@@ -154,7 +158,9 @@ If the requested design is too large or structural to be a single in-page compon
 
 type InjectionMode = "append" | "set" | "before" | "after";
 
-// insertAdjacentHTML position for each insert mode.
+// insertAdjacentHTML position for each insert mode. (A narrow subset of the
+// shared InsertPosition type — Figma only ever inserts before/after/append,
+// never afterbegin. Assignable to buildInsertJs's wider position param.)
 const INSERT_POSITION: Record<
   Exclude<InjectionMode, "set">,
   "beforeend" | "beforebegin" | "afterend"
@@ -179,28 +185,6 @@ function placementSentence(
     default:
       return `The component will be APPENDED inside the target element (${targetSelector}).`;
   }
-}
-
-// Build a self-contained, idempotent insertion script for the variation's
-// `js` field. It runs once in the SDK (and our preview), guards on the
-// unique scope class so it never double-inserts, and waits (bounded) for
-// late/SPA-rendered targets before giving up — so it never loops.
-function buildInsertJs({
-  scopeToken,
-  targetSelector,
-  position,
-  html,
-}: {
-  scopeToken: string;
-  targetSelector: string;
-  position: "beforeend" | "beforebegin" | "afterend";
-  html: string;
-}): string {
-  const S = JSON.stringify(scopeToken);
-  const T = JSON.stringify(targetSelector);
-  const P = JSON.stringify(position);
-  const H = JSON.stringify(html);
-  return `(function(){var S=${S};function ins(){if(document.querySelector("."+S))return true;var t=document.querySelector(${T});if(!t)return false;t.insertAdjacentHTML(${P},${H});return true;}if(ins())return;var mo=new MutationObserver(function(){if(ins())mo.disconnect();});mo.observe(document.documentElement,{childList:true,subtree:true});setTimeout(function(){mo.disconnect();},10000);})();`;
 }
 
 function buildFigmaUserPrompt({
@@ -332,7 +316,7 @@ export const postFigmaToVariant = createApiRequestHandler(validation)(async (
 
   // Unique per-request scope token the model must use verbatim. Generated
   // server-side so the model can't reuse a colliding class across turns.
-  const scopeToken = `gbf-${uuidv4().replace(/-/g, "").slice(0, 8)}`;
+  const scopeToken = makeScopeToken();
   const scopeClass = `.${scopeToken}`;
 
   let instructions = baseInstructions.replace(/SCOPE_CLASS/g, scopeToken);
@@ -408,9 +392,7 @@ export const postFigmaToVariant = createApiRequestHandler(validation)(async (
   // Guarantee the injected markup's root carries the scope class so the
   // scoped CSS actually applies (the model is told to wrap it, but wrap
   // defensively when it didn't).
-  const html = rawHtml.includes(scopeToken)
-    ? rawHtml
-    : `<div class="${scopeToken}">${rawHtml}</div>`;
+  const html = wrapWithScope(rawHtml, scopeToken);
 
   const scopedCss = result.css ? scopeCss(result.css, scopeClass) : "";
 


### PR DESCRIPTION
The visual editor sometimes gets confused when asked to insert elements. It can replace large contents of the page using innerHTML which causes problems. This change allows the AI to better inject elements using JS. 