### PR TITLE
Perf: parallelize datasource enrichment in the definitions endpoint

### DIFF
--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -182,7 +182,9 @@ export async function getDefinitions(req: AuthRequest, res: Response) {
     webhookSecrets,
   ] = await Promise.all([
     getMetricsByOrganization(context),
-    getDataSourcesByOrganization(context),
+    getDataSourcesByOrganization(context).then((ds) =>
+      getDataSourcesWithParams(context, ds),
+    ),
     findDimensionsByOrganization(orgId),
     context.models.segments.getAll(),
     context.models.metricGroups.getAll(),
@@ -200,7 +202,7 @@ export async function getDefinitions(req: AuthRequest, res: Response) {
   return res.status(200).json({
     status: 200,
     metrics,
-    datasources: await getDataSourcesWithParams(context, datasources),
+    datasources,
     dimensions,
     segments,
     metricGroups,


### PR DESCRIPTION
### Features and Changes

`GET /organization/definitions` fetches 14 collections in a `Promise.all`, but then ran `getDataSourcesWithParams` (builds integration objects and looks up event-forwarder metadata per datasource) serially after all of them finished. This chains it onto the datasource fetch inside the `Promise.all` instead, removing a serial round-trip batch from every definitions request.

### Testing

Load the app and confirm `/organization/definitions` returns the same `datasources` shape (params, properties, `eventForwarderConfig`).
