### PR TITLE
Perf: slim heavy metric fields out of the definitions endpoint

### DIFF
--- a/packages/back-end/src/controllers/metrics.ts
+++ b/packages/back-end/src/controllers/metrics.ts
@@ -121,9 +121,14 @@ export async function deleteMetric(
   });
 }
 
-export async function getMetrics(req: AuthRequest, res: Response) {
+export async function getMetrics(
+  req: AuthRequest<null, null, { includeArchived?: string }>,
+  res: Response,
+) {
   const context = getContextFromReq(req);
-  const metrics = await getMetricsByOrganization(context);
+  // Default to excluding archived metrics; the general case doesn't want them.
+  const includeArchived = req.query.includeArchived === "true";
+  const metrics = await getMetricsByOrganization(context, { includeArchived });
   res.status(200).json({
     status: 200,
     metrics,

--- a/packages/back-end/src/models/MetricModel.ts
+++ b/packages/back-end/src/models/MetricModel.ts
@@ -325,7 +325,7 @@ async function findMetrics(
   const metrics: MetricInterface[] = [];
   const metricIds = new Set<string>();
 
-  // If using config.yml, first check there (projection can't apply here)
+  // If using config.yml, first check there
   if (usingFileConfig()) {
     getConfigMetrics(context)
       .filter((m) => !additionalQuery || evalCondition(m, additionalQuery))
@@ -376,11 +376,15 @@ export async function getMetricsByOrganization(
   options?: {
     datasourceId?: string;
     projectId?: string;
+    includeArchived?: boolean;
   },
 ) {
   const query: FilterQuery<LegacyMetricInterface> = {
     ...(options?.datasourceId && { datasource: options.datasourceId }),
     ...(options?.projectId && projectFilterQuery(options.projectId)),
+    ...(options?.includeArchived === false && {
+      status: { $ne: "archived" },
+    }),
   };
 
   return findMetrics(context, query);

--- a/packages/back-end/src/models/MetricModel.ts
+++ b/packages/back-end/src/models/MetricModel.ts
@@ -1,9 +1,11 @@
 import mongoose, { FilterQuery } from "mongoose";
 import { evalCondition } from "@growthbook/growthbook";
 import { ExperimentMetricInterface } from "shared/experiments";
+import omit from "lodash/omit";
 import {
   InsertMetricProps,
   LegacyMetricInterface,
+  MetricDefinitionInterface,
   MetricInterface,
 } from "shared/types/metric";
 import { getConfigMetrics, usingFileConfig } from "back-end/src/init/config";
@@ -376,6 +378,64 @@ export async function getMetricsByOrganization(
   };
 
   return findMetrics(context, query);
+}
+
+const METRIC_DEFINITION_EXCLUDED_FIELDS = [
+  "sql",
+  "templateVariables",
+  "conditions",
+  "queries",
+  "analysis",
+  "analysisError",
+] as const;
+
+// Slimmed version of getMetricsByOrganization for the definitions endpoint.
+// Heavy fields are excluded at the DB layer to keep the payload small.
+export async function getMetricsForDefinitions(
+  context: ReqContext | ApiReqContext,
+): Promise<MetricDefinitionInterface[]> {
+  const metrics: MetricDefinitionInterface[] = [];
+  const metricIds = new Set<string>();
+
+  // If using config.yml, first check there (projection can't apply here)
+  if (usingFileConfig()) {
+    getConfigMetrics(context).forEach((m) => {
+      metrics.push(omit(m, METRIC_DEFINITION_EXCLUDED_FIELDS));
+      metricIds.add(m.id);
+    });
+
+    // If metrics are locked down to just a config file, return immediately
+    if (!ALLOW_CREATE_METRICS) {
+      return metrics;
+    }
+  }
+
+  const docs = await getCollection(COLLECTION)
+    .find(
+      { organization: context.org.id },
+      {
+        projection: {
+          sql: 0,
+          templateVariables: 0,
+          conditions: 0,
+          queries: 0,
+          analysis: 0,
+          analysisError: 0,
+        },
+      },
+    )
+    .toArray();
+  docs.forEach((doc) => {
+    if (metricIds.has(doc.id)) {
+      return;
+    }
+    metrics.push(toInterface(doc));
+    metricIds.add(doc.id);
+  });
+
+  return metrics.filter((m) =>
+    context.permissions.canReadMultiProjectResource(m.projects),
+  );
 }
 
 export async function getMetricsByDatasource(

--- a/packages/back-end/src/models/MetricModel.ts
+++ b/packages/back-end/src/models/MetricModel.ts
@@ -320,16 +320,19 @@ export async function getMetricMap(
 async function findMetrics(
   context: ReqContext | ApiReqContext,
   additionalQuery?: FilterQuery<LegacyMetricInterface>,
-) {
+  excludeFields?: readonly (keyof MetricInterface)[],
+): Promise<MetricInterface[]> {
   const metrics: MetricInterface[] = [];
   const metricIds = new Set<string>();
 
-  // If using config.yml, first check there
+  // If using config.yml, first check there (projection can't apply here)
   if (usingFileConfig()) {
     getConfigMetrics(context)
       .filter((m) => !additionalQuery || evalCondition(m, additionalQuery))
       .forEach((m) => {
-        metrics.push(m);
+        metrics.push(
+          excludeFields ? (omit(m, excludeFields) as MetricInterface) : m,
+        );
         metricIds.add(m.id);
       });
 
@@ -339,17 +342,20 @@ async function findMetrics(
     }
   }
 
+  // `analysis` is never needed when finding multiple metrics and can get
+  // quite large, so it's always excluded
+  const projection: Record<string, 0> = { analysis: 0 };
+  excludeFields?.forEach((f) => {
+    projection[f] = 0;
+  });
+
   const docs = await getCollection(COLLECTION)
     .find(
       {
         ...additionalQuery,
         organization: context.org.id,
       },
-      {
-        // This is never needed when finding multiple metrics
-        // This field can get quite large, so it's best to exclude it
-        projection: { analysis: 0 },
-      },
+      { projection },
     )
     .toArray();
   docs.forEach((doc) => {
@@ -394,48 +400,7 @@ const METRIC_DEFINITION_EXCLUDED_FIELDS = [
 export async function getMetricsForDefinitions(
   context: ReqContext | ApiReqContext,
 ): Promise<MetricDefinitionInterface[]> {
-  const metrics: MetricDefinitionInterface[] = [];
-  const metricIds = new Set<string>();
-
-  // If using config.yml, first check there (projection can't apply here)
-  if (usingFileConfig()) {
-    getConfigMetrics(context).forEach((m) => {
-      metrics.push(omit(m, METRIC_DEFINITION_EXCLUDED_FIELDS));
-      metricIds.add(m.id);
-    });
-
-    // If metrics are locked down to just a config file, return immediately
-    if (!ALLOW_CREATE_METRICS) {
-      return metrics;
-    }
-  }
-
-  const docs = await getCollection(COLLECTION)
-    .find(
-      { organization: context.org.id },
-      {
-        projection: {
-          sql: 0,
-          templateVariables: 0,
-          conditions: 0,
-          queries: 0,
-          analysis: 0,
-          analysisError: 0,
-        },
-      },
-    )
-    .toArray();
-  docs.forEach((doc) => {
-    if (metricIds.has(doc.id)) {
-      return;
-    }
-    metrics.push(toInterface(doc));
-    metricIds.add(doc.id);
-  });
-
-  return metrics.filter((m) =>
-    context.permissions.canReadMultiProjectResource(m.projects),
-  );
+  return findMetrics(context, undefined, METRIC_DEFINITION_EXCLUDED_FIELDS);
 }
 
 export async function getMetricsByDatasource(

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -87,7 +87,7 @@ import {
   sendOwnerEmailChangeEmail,
 } from "back-end/src/services/email";
 import { getDataSourcesByOrganization } from "back-end/src/models/DataSourceModel";
-import { getMetricsByOrganization } from "back-end/src/models/MetricModel";
+import { getMetricsForDefinitions } from "back-end/src/models/MetricModel";
 import {
   createOrganization,
   findOrganizationByInviteKey,
@@ -181,7 +181,7 @@ export async function getDefinitions(req: AuthRequest, res: Response) {
     decisionCriteria,
     webhookSecrets,
   ] = await Promise.all([
-    getMetricsByOrganization(context),
+    getMetricsForDefinitions(context),
     getDataSourcesByOrganization(context),
     findDimensionsByOrganization(orgId),
     context.models.segments.getAll(),

--- a/packages/back-end/test/models/MetricModel.test.ts
+++ b/packages/back-end/test/models/MetricModel.test.ts
@@ -1,0 +1,153 @@
+import mongoose from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { Permissions, roleToPermissionMap } from "shared/permissions";
+import { OrganizationInterface } from "shared/types/organization";
+import { MetricInterface } from "shared/types/metric";
+import { getMetricsForDefinitions } from "back-end/src/models/MetricModel";
+import { usingFileConfig, getConfigMetrics } from "back-end/src/init/config";
+import { ReqContext } from "back-end/types/request";
+
+jest.mock("back-end/src/init/config");
+
+const mockedUsingFileConfig = usingFileConfig as jest.MockedFunction<
+  typeof usingFileConfig
+>;
+const mockedGetConfigMetrics = getConfigMetrics as jest.MockedFunction<
+  typeof getConfigMetrics
+>;
+
+const org: OrganizationInterface = {
+  id: "org_1",
+  name: "Test",
+  url: "",
+  ownerEmail: "",
+  dateCreated: new Date(),
+  members: [],
+  invites: [],
+  settings: {},
+};
+
+const context = {
+  org,
+  permissions: new Permissions({
+    global: {
+      permissions: roleToPermissionMap("admin", org),
+      limitAccessByEnvironment: false,
+      environments: [],
+    },
+    projects: {},
+  }),
+} as unknown as ReqContext;
+
+function makeMetric(overrides: Partial<MetricInterface> = {}): MetricInterface {
+  return {
+    id: "met_1",
+    organization: "org_1",
+    owner: "",
+    datasource: "ds_1",
+    dateCreated: new Date(),
+    dateUpdated: new Date(),
+    name: "Test Metric",
+    description: "",
+    type: "count",
+    inverse: false,
+    ignoreNulls: false,
+    cappingSettings: { type: "", value: 0 },
+    windowSettings: {
+      type: "conversion",
+      windowValue: 72,
+      windowUnit: "hours",
+      delayValue: 0,
+      delayUnit: "hours",
+    },
+    priorSettings: { override: false, proper: false, mean: 0, stddev: 0.3 },
+    sql: "SELECT user_id, value FROM purchases",
+    templateVariables: { eventName: "purchase" },
+    conditions: [{ column: "country", operator: "=", value: "US" }],
+    queries: [],
+    runStarted: null,
+    analysis: {
+      createdAt: new Date(),
+      average: 1,
+      dates: [],
+    },
+    analysisError: "some error",
+    ...overrides,
+  };
+}
+
+const HEAVY_FIELDS = [
+  "sql",
+  "templateVariables",
+  "conditions",
+  "queries",
+  "analysis",
+  "analysisError",
+] as const;
+
+describe("getMetricsForDefinitions", () => {
+  let mongod: MongoMemoryServer;
+
+  beforeAll(async () => {
+    mongod = await MongoMemoryServer.create();
+    await mongoose.connect(mongod.getUri());
+  }, 60000);
+
+  afterAll(async () => {
+    await mongoose.connection.close();
+    await mongod.stop();
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+    await mongoose.connection.db!.collection("metrics").deleteMany({});
+  });
+
+  it("excludes heavy fields from metrics read from the database", async () => {
+    mockedUsingFileConfig.mockReturnValue(false);
+    await mongoose.connection
+      .db!.collection("metrics")
+      .insertMany([makeMetric(), makeMetric({ id: "met_2", name: "Other" })]);
+
+    const metrics = await getMetricsForDefinitions(context);
+
+    expect(metrics).toHaveLength(2);
+    metrics.forEach((m) => {
+      HEAVY_FIELDS.forEach((field) => {
+        expect(m).not.toHaveProperty(field);
+      });
+    });
+    expect(metrics.map((m) => m.name).sort()).toEqual(["Other", "Test Metric"]);
+    // Still runs the doc migration/defaults
+    expect(metrics[0].windowSettings).toBeDefined();
+    expect(metrics[0].userIdTypes).toBeDefined();
+  });
+
+  it("excludes heavy fields from config.yml metrics", async () => {
+    mockedUsingFileConfig.mockReturnValue(true);
+    mockedGetConfigMetrics.mockReturnValue([makeMetric({ id: "met_cfg" })]);
+
+    const metrics = await getMetricsForDefinitions(context);
+
+    expect(metrics.map((m) => m.id)).toContain("met_cfg");
+    metrics.forEach((m) => {
+      HEAVY_FIELDS.forEach((field) => {
+        expect(m).not.toHaveProperty(field);
+      });
+    });
+  });
+
+  it("does not return metrics from other organizations", async () => {
+    mockedUsingFileConfig.mockReturnValue(false);
+    await mongoose.connection
+      .db!.collection("metrics")
+      .insertMany([
+        makeMetric(),
+        makeMetric({ id: "met_other", organization: "org_2" }),
+      ]);
+
+    const metrics = await getMetricsForDefinitions(context);
+
+    expect(metrics.map((m) => m.id)).toEqual(["met_1"]);
+  });
+});

--- a/packages/back-end/test/models/MetricModel.test.ts
+++ b/packages/back-end/test/models/MetricModel.test.ts
@@ -3,7 +3,10 @@ import { MongoMemoryServer } from "mongodb-memory-server";
 import { Permissions, roleToPermissionMap } from "shared/permissions";
 import { OrganizationInterface } from "shared/types/organization";
 import { MetricInterface } from "shared/types/metric";
-import { getMetricsForDefinitions } from "back-end/src/models/MetricModel";
+import {
+  getMetricsForDefinitions,
+  getMetricsByOrganization,
+} from "back-end/src/models/MetricModel";
 import { usingFileConfig, getConfigMetrics } from "back-end/src/init/config";
 import { ReqContext } from "back-end/types/request";
 
@@ -149,5 +152,74 @@ describe("getMetricsForDefinitions", () => {
     const metrics = await getMetricsForDefinitions(context);
 
     expect(metrics.map((m) => m.id)).toEqual(["met_1"]);
+  });
+});
+
+describe("getMetricsByOrganization includeArchived", () => {
+  let mongod: MongoMemoryServer;
+
+  beforeAll(async () => {
+    mongod = await MongoMemoryServer.create();
+    await mongoose.connect(mongod.getUri());
+  }, 60000);
+
+  afterAll(async () => {
+    await mongoose.connection.close();
+    await mongod.stop();
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+    await mongoose.connection.db!.collection("metrics").deleteMany({});
+  });
+
+  it("excludes archived metrics from the database when includeArchived is false", async () => {
+    mockedUsingFileConfig.mockReturnValue(false);
+    await mongoose.connection.db!.collection("metrics").insertMany([
+      makeMetric({ id: "met_active", status: "active" }),
+      makeMetric({ id: "met_archived", status: "archived" }),
+      // Metrics with no status should be kept (matches the $ne semantics)
+      makeMetric({ id: "met_nostatus", status: undefined }),
+    ]);
+
+    const metrics = await getMetricsByOrganization(context, {
+      includeArchived: false,
+    });
+
+    expect(metrics.map((m) => m.id).sort()).toEqual([
+      "met_active",
+      "met_nostatus",
+    ]);
+  });
+
+  it("excludes archived config.yml metrics when includeArchived is false", async () => {
+    mockedUsingFileConfig.mockReturnValue(true);
+    mockedGetConfigMetrics.mockReturnValue([
+      makeMetric({ id: "met_active", status: "active" }),
+      makeMetric({ id: "met_archived", status: "archived" }),
+    ]);
+
+    const metrics = await getMetricsByOrganization(context, {
+      includeArchived: false,
+    });
+
+    expect(metrics.map((m) => m.id)).toEqual(["met_active"]);
+  });
+
+  it("includes archived metrics by default", async () => {
+    mockedUsingFileConfig.mockReturnValue(false);
+    await mongoose.connection
+      .db!.collection("metrics")
+      .insertMany([
+        makeMetric({ id: "met_active", status: "active" }),
+        makeMetric({ id: "met_archived", status: "archived" }),
+      ]);
+
+    const metrics = await getMetricsByOrganization(context);
+
+    expect(metrics.map((m) => m.id).sort()).toEqual([
+      "met_active",
+      "met_archived",
+    ]);
   });
 });

--- a/packages/front-end/components/Experiment/AlignedGraph.tsx
+++ b/packages/front-end/components/Experiment/AlignedGraph.tsx
@@ -7,7 +7,7 @@ import { Line } from "@visx/shape";
 import { ViolinPlot } from "@visx/stats";
 import normal from "@stdlib/stats/base/dists/normal";
 import clsx from "clsx";
-import { ExperimentMetricInterface } from "shared/experiments";
+import { ExperimentMetricDefinition } from "shared/experiments";
 import { getExperimentMetricFormatter } from "@/services/metrics";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useCurrency } from "@/hooks/useCurrency";
@@ -31,7 +31,7 @@ interface Props
   axisOnly?: boolean;
   zeroLineWidth?: number;
   zeroLineOffset?: number;
-  metricForFormatting?: ExperimentMetricInterface | null;
+  metricForFormatting?: ExperimentMetricDefinition | null;
   className?: string;
   rowStatus?: string;
   isHovered?: boolean;

--- a/packages/front-end/components/Experiment/BanditDateGraph.tsx
+++ b/packages/front-end/components/Experiment/BanditDateGraph.tsx
@@ -17,7 +17,7 @@ import { date, datetime } from "shared/dates";
 import { ExperimentInterfaceStringDates } from "shared/types/experiment";
 import { ScaleLinear, ScaleTime } from "d3-scale";
 import {
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   getLatestPhaseVariations,
 } from "shared/experiments";
 import { BanditEvent } from "shared/validators";
@@ -56,7 +56,7 @@ export interface BanditDateGraphDataPoint {
 }
 export interface BanditDateGraphProps {
   experiment: ExperimentInterfaceStringDates;
-  metric: ExperimentMetricInterface | null;
+  metric: ExperimentMetricDefinition | null;
   phase: number;
   label?: string;
   mode: "values" | "probabilities" | "weights";
@@ -95,7 +95,7 @@ const getTooltipContents = (
   data: TooltipData,
   variations: GraphVariation[],
   mode: "values" | "probabilities" | "weights",
-  metric: ExperimentMetricInterface | null,
+  metric: ExperimentMetricDefinition | null,
   getFactTableById: any,
   metricFormatterOptions: any,
   showVariations: boolean[],

--- a/packages/front-end/components/Experiment/BanditSummaryTable.tsx
+++ b/packages/front-end/components/Experiment/BanditSummaryTable.tsx
@@ -4,7 +4,7 @@ import { ExperimentInterfaceStringDates } from "shared/types/experiment";
 import { BanditEvent } from "shared/validators";
 import clsx from "clsx";
 import {
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   getLatestPhaseVariations,
 } from "shared/experiments";
 import { SnapshotMetric } from "shared/types/experiment-snapshot";
@@ -25,7 +25,7 @@ const ROW_HEIGHT_CONDENSED = 34;
 
 export type BanditSummaryTableProps = {
   experiment: ExperimentInterfaceStringDates;
-  metric: ExperimentMetricInterface | null;
+  metric: ExperimentMetricDefinition | null;
   phase: number;
   isTabActive: boolean;
   ssrPolyfills?: SSRPolyfills;

--- a/packages/front-end/components/Experiment/BanditSummaryTableTooltip/useBanditSummaryTooltip.tsx
+++ b/packages/front-end/components/Experiment/BanditSummaryTableTooltip/useBanditSummaryTooltip.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useTooltip, useTooltipInPortal } from "@visx/tooltip";
 import { BanditEvent } from "shared/validators";
-import { ExperimentMetricInterface } from "shared/experiments";
+import { ExperimentMetricDefinition } from "shared/experiments";
 import { WIN_THRESHOLD_PROBABILITY } from "@/components/Experiment/BanditSummaryTable";
 import {
   LayoutX,
@@ -20,7 +20,7 @@ export function useBanditSummaryTooltip({
   probabilities,
   regressionAdjustmentEnabled,
 }: {
-  metric: ExperimentMetricInterface | null;
+  metric: ExperimentMetricDefinition | null;
   variations: { id: string; index: number; name: string }[];
   currentEvent: BanditEvent;
   probabilities: number[];

--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -21,7 +21,7 @@ import {
   StatsEngine,
 } from "shared/types/stats";
 import {
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   ExperimentSortBy,
   SetExperimentSortBy,
   formatDimensionValueForDisplay,
@@ -89,7 +89,7 @@ const BreakDownResults: FC<{
   experimentType?: ExperimentType;
   ssrPolyfills?: SSRPolyfills;
   renderMetricName?: (
-    metric: ExperimentMetricInterface,
+    metric: ExperimentMetricDefinition,
   ) => React.ReactElement | string;
   noStickyHeader?: boolean;
   sortBy?: ExperimentSortBy;

--- a/packages/front-end/components/Experiment/ChanceToWinColumn.tsx
+++ b/packages/front-end/components/Experiment/ChanceToWinColumn.tsx
@@ -3,7 +3,7 @@ import { Flex } from "@radix-ui/themes";
 import { SnapshotMetric } from "shared/types/experiment-snapshot";
 import { DetailedHTMLProps, TdHTMLAttributes } from "react";
 import { DifferenceType, StatsEngine } from "shared/types/stats";
-import { ExperimentMetricInterface } from "shared/experiments";
+import { ExperimentMetricDefinition } from "shared/experiments";
 import { PiWarningCircle } from "react-icons/pi";
 import { RowResults } from "@/services/experiments";
 import NotEnoughData from "@/components/Experiment/NotEnoughData";
@@ -30,7 +30,7 @@ interface Props
   className?: string;
   hideScaledImpact?: boolean;
   // Props for popover
-  metric?: ExperimentMetricInterface;
+  metric?: ExperimentMetricDefinition;
   pValueThreshold: number;
   differenceType?: DifferenceType;
   statsEngine?: StatsEngine;

--- a/packages/front-end/components/Experiment/ChangeColumn.tsx
+++ b/packages/front-end/components/Experiment/ChangeColumn.tsx
@@ -4,7 +4,7 @@ import { SnapshotMetric } from "shared/types/experiment-snapshot";
 import { FaArrowDown, FaArrowUp } from "react-icons/fa";
 import React, { DetailedHTMLProps, TdHTMLAttributes } from "react";
 import { DifferenceType, StatsEngine } from "shared/types/stats";
-import { ExperimentMetricInterface } from "shared/experiments";
+import { ExperimentMetricDefinition } from "shared/experiments";
 import { RowResults } from "@/services/experiments";
 import {
   formatPercent,
@@ -20,7 +20,7 @@ interface Props
     TdHTMLAttributes<HTMLTableCellElement>,
     HTMLTableCellElement
   > {
-  metric: ExperimentMetricInterface;
+  metric: ExperimentMetricDefinition;
   pValueThreshold: number;
   stats: SnapshotMetric;
   rowResults: Pick<

--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -29,7 +29,7 @@ import {
 } from "react-icons/pi";
 import {
   expandMetricGroups,
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   getMetricLink,
   ExperimentSortBy,
   SetExperimentSortBy,
@@ -249,7 +249,7 @@ const CompactResults: FC<{
       ...expandedSecondaries,
       ...expandedGuardrails,
     ];
-    const allMetricsMap = new Map<string, ExperimentMetricInterface>();
+    const allMetricsMap = new Map<string, ExperimentMetricDefinition>();
     allExpandedIds.forEach((id) => {
       const metric = getExperimentMetricById(id);
       if (metric && !allMetricsMap.has(id)) {
@@ -553,7 +553,7 @@ export function getRenderLabelColumn({
     metricId: string,
     resultGroup: "goal" | "secondary" | "guardrail",
   ) => void;
-  getExperimentMetricById?: (id: string) => null | ExperimentMetricInterface;
+  getExperimentMetricById?: (id: string) => null | ExperimentMetricDefinition;
   getFactTableById?: (id: string) => null | FactTableInterface;
   shouldShowMetricSlices?: boolean;
   getChildRowCounts?: (metricId: string) => number;
@@ -567,7 +567,7 @@ export function getRenderLabelColumn({
     location,
   }: {
     label: string | ReactElement;
-    metric: ExperimentMetricInterface;
+    metric: ExperimentMetricDefinition;
     row?: ExperimentTableRow;
     maxRows?: number;
     location?: "goal" | "secondary" | "guardrail";

--- a/packages/front-end/components/Experiment/DateResults.tsx
+++ b/packages/front-end/components/Experiment/DateResults.tsx
@@ -6,7 +6,7 @@ import {
 import { getValidDate, getValidDateOffsetByUTC } from "shared/dates";
 import {
   expandMetricGroups,
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   isExpectedDirection,
   isStatSig,
   quantileMetricType,
@@ -38,7 +38,7 @@ const numberFormatter = new Intl.NumberFormat();
 
 // Represents data for one metric graph
 type Metric = {
-  metric: ExperimentMetricInterface;
+  metric: ExperimentMetricDefinition;
   resultGroup: "goal" | "secondary" | "guardrail";
   datapoints: ExperimentDateGraphDataPoint[];
 };

--- a/packages/front-end/components/Experiment/EditMetricsForm.tsx
+++ b/packages/front-end/components/Experiment/EditMetricsForm.tsx
@@ -10,7 +10,7 @@ import {
   DEFAULT_REGRESSION_ADJUSTMENT_DAYS,
 } from "shared/constants";
 import { OrganizationSettings } from "shared/types/organization";
-import { ExperimentMetricInterface } from "shared/experiments";
+import { ExperimentMetricDefinition } from "shared/experiments";
 import { CustomMetricSlice } from "shared/validators";
 import Collapsible from "react-collapsible";
 import { PiCaretRightFill } from "react-icons/pi";
@@ -42,7 +42,7 @@ export interface EditMetricsFormInterface {
 
 export function getDefaultMetricOverridesFormValue(
   overrides: MetricOverride[],
-  getExperimentMetricById: (id: string) => ExperimentMetricInterface | null,
+  getExperimentMetricById: (id: string) => ExperimentMetricDefinition | null,
   settings: OrganizationSettings,
 ) {
   const defaultMetricOverrides = cloneDeep(overrides);

--- a/packages/front-end/components/Experiment/ExperimentMetricTimeSeriesGraphWrapper.tsx
+++ b/packages/front-end/components/Experiment/ExperimentMetricTimeSeriesGraphWrapper.tsx
@@ -10,7 +10,7 @@ import {
 import { daysBetween, getValidDate } from "shared/dates";
 import { addDays, min } from "date-fns";
 import { filterInvalidMetricTimeSeries } from "shared/util";
-import { ExperimentMetricInterface, getAdjustedCI } from "shared/experiments";
+import { ExperimentMetricDefinition, getAdjustedCI } from "shared/experiments";
 import useApi from "@/hooks/useApi";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import {
@@ -122,7 +122,7 @@ interface ExperimentMetricTimeSeriesGraphWrapperProps {
   experimentId: string;
   pValueThreshold: number;
   phase: number;
-  metric: ExperimentMetricInterface;
+  metric: ExperimentMetricDefinition;
   differenceType: DifferenceType;
   variations: GraphVariation[];
   showVariations: boolean[];

--- a/packages/front-end/components/Experiment/ExperimentResultTooltipContent/ExperimentResultTooltipContent.tsx
+++ b/packages/front-end/components/Experiment/ExperimentResultTooltipContent/ExperimentResultTooltipContent.tsx
@@ -5,7 +5,7 @@ import { PiWarningCircle } from "react-icons/pi";
 import { Box, Flex, Text } from "@radix-ui/themes";
 import { DifferenceType, StatsEngine } from "shared/types/stats";
 import { SnapshotMetric } from "shared/types/experiment-snapshot";
-import { ExperimentMetricInterface, isFactMetric } from "shared/experiments";
+import { ExperimentMetricDefinition, isFactMetric } from "shared/experiments";
 import { SSRPolyfills } from "@/hooks/useSSRPolyfills";
 import { useCurrency } from "@/hooks/useCurrency";
 import { useDefinitions } from "@/services/DefinitionsContext";
@@ -29,7 +29,7 @@ export interface StatusLabels {
 
 interface ExperimentResultTooltipContentProps {
   stats: SnapshotMetric;
-  metric: ExperimentMetricInterface;
+  metric: ExperimentMetricDefinition;
   pValueThreshold: number;
   significant: boolean;
   resultsStatus: RowResults["resultsStatus"];

--- a/packages/front-end/components/Experiment/MetricValueColumn.tsx
+++ b/packages/front-end/components/Experiment/MetricValueColumn.tsx
@@ -6,7 +6,7 @@ import {
   TdHTMLAttributes,
 } from "react";
 import {
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   isFactMetric,
   isRatioMetric,
   quantileMetricType,
@@ -29,7 +29,7 @@ const numberFormatter = Intl.NumberFormat("en-US", {
  * populated (e.g. safe-rollout snapshots). Derive a per-user rate for display.
  */
 function effectiveCrForDisplay(
-  metric: ExperimentMetricInterface,
+  metric: ExperimentMetricDefinition,
   stats: SnapshotMetric,
 ): number {
   const cr = stats.cr;
@@ -62,7 +62,7 @@ interface Props
     TdHTMLAttributes<HTMLTableCellElement>,
     HTMLTableCellElement
   > {
-  metric: ExperimentMetricInterface;
+  metric: ExperimentMetricDefinition;
   stats: SnapshotMetric;
   users: number;
   className?: string;
@@ -71,7 +71,7 @@ interface Props
   showRatio?: boolean;
   noDataMessage?: ReactElement | string;
   displayCurrency: string;
-  getExperimentMetricById: (id: string) => null | ExperimentMetricInterface;
+  getExperimentMetricById: (id: string) => null | ExperimentMetricDefinition;
   getFactTableById: (id: string) => null | FactTableInterface;
   asTd?: boolean;
 }

--- a/packages/front-end/components/Experiment/MetricsSelector.tsx
+++ b/packages/front-end/components/Experiment/MetricsSelector.tsx
@@ -1,7 +1,7 @@
 import { FC, ReactNode, useCallback, useMemo, useState } from "react";
 import { isProjectListValidForProject } from "shared/util";
 import {
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   isFactMetric,
   isMetricGroupId,
   isMetricJoinable,
@@ -322,7 +322,7 @@ const MetricsSelector: FC<{
   const groupMetricsJoinableMap = useMemo(() => {
     const map = new Map<
       string,
-      { metric: ExperimentMetricInterface | null; joinable: boolean }[]
+      { metric: ExperimentMetricDefinition | null; joinable: boolean }[]
     >();
     for (const opt of filteredOptions) {
       if (!opt.isGroup || !opt.metrics) continue;

--- a/packages/front-end/components/Experiment/PValueColumn.tsx
+++ b/packages/front-end/components/Experiment/PValueColumn.tsx
@@ -6,7 +6,7 @@ import {
   PValueCorrection,
   StatsEngine,
 } from "shared/types/stats";
-import { ExperimentMetricInterface } from "shared/experiments";
+import { ExperimentMetricDefinition } from "shared/experiments";
 import { PiWarningCircle } from "react-icons/pi";
 import { pValueFormatter, RowResults } from "@/services/experiments";
 import NotEnoughData from "@/components/Experiment/NotEnoughData";
@@ -30,7 +30,7 @@ interface Props
   className?: string;
   hideScaledImpact?: boolean;
   // Props for popover
-  metric?: ExperimentMetricInterface;
+  metric?: ExperimentMetricDefinition;
   pValueThreshold: number;
   differenceType?: DifferenceType;
   statsEngine?: StatsEngine;

--- a/packages/front-end/components/Experiment/PercentGraph.tsx
+++ b/packages/front-end/components/Experiment/PercentGraph.tsx
@@ -1,7 +1,7 @@
 import { SnapshotMetric } from "shared/types/experiment-snapshot";
 import React, { DetailedHTMLProps, HTMLAttributes } from "react";
 import {
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   hasEnoughData,
   isStatSig,
 } from "shared/experiments";
@@ -19,7 +19,7 @@ import { useResultPopover } from "./useResultPopover";
 
 interface Props
   extends DetailedHTMLProps<HTMLAttributes<SVGPathElement>, SVGPathElement> {
-  metric: ExperimentMetricInterface;
+  metric: ExperimentMetricDefinition;
   significanceThresholds: SignificanceThresholds;
   baseline: SnapshotMetric;
   stats: SnapshotMetric;

--- a/packages/front-end/components/Experiment/ResultsFilter/ResultsFilter.tsx
+++ b/packages/front-end/components/Experiment/ResultsFilter/ResultsFilter.tsx
@@ -5,7 +5,7 @@ import { FactTableColumnType } from "shared/types/fact-table";
 import {
   parseSliceQueryString,
   isMetricGroupId,
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   isSliceTagSelectAll,
   generateSelectAllSliceString,
 } from "shared/experiments";
@@ -165,7 +165,7 @@ export function isSliceCoveredBySelectAll(
 
 export function formatMetricOptionLabel(
   option: { value: string; label: string; isOrphaned?: boolean },
-  getExperimentMetricById: (id: string) => ExperimentMetricInterface | null,
+  getExperimentMetricById: (id: string) => ExperimentMetricDefinition | null,
   getMetricGroupById: (id: string) => MetricGroupInterface | null,
   showGroupIcon?: boolean,
 ) {

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -30,7 +30,7 @@ import { getValidDate } from "shared/dates";
 import { MetricTimeSeries } from "shared/validators";
 import { Flex } from "@radix-ui/themes";
 import {
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   ExperimentSortBy,
   SetExperimentSortBy,
   isFactMetric,
@@ -97,7 +97,7 @@ export type ResultsTableProps = {
     location,
   }: {
     label: string | ReactElement;
-    metric: ExperimentMetricInterface;
+    metric: ExperimentMetricDefinition;
     row: ExperimentTableRow;
     maxRows?: number;
     numDimensions?: number;

--- a/packages/front-end/components/Experiment/ResultsTableTooltip/ResultsTableTooltip.tsx
+++ b/packages/front-end/components/Experiment/ResultsTableTooltip/ResultsTableTooltip.tsx
@@ -11,7 +11,7 @@ import {
 } from "shared/types/stats";
 import { BsX } from "react-icons/bs";
 import clsx from "clsx";
-import { ExperimentMetricInterface } from "shared/experiments";
+import { ExperimentMetricDefinition } from "shared/experiments";
 import { RowResults } from "@/services/experiments";
 import { SSRPolyfills } from "@/hooks/useSSRPolyfills";
 import AnalysisResultSummary from "@/ui/AnalysisResultSummary";
@@ -31,7 +31,7 @@ export type YAlign = "top" | "bottom";
 
 export interface TooltipData {
   metricRow: number;
-  metric: ExperimentMetricInterface;
+  metric: ExperimentMetricDefinition;
   metricSnapshotSettings?: MetricSnapshotSettings;
   sliceLevels?: Array<{
     dimension: string;

--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
@@ -18,7 +18,7 @@ import {
   isFactMetric,
   isMetricJoinable,
   expandAllSliceMetricsInMap,
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   getLatestPhaseVariations,
   isDimensionPrecomputed,
   getExperimentOutdatedReasonLabel,
@@ -532,7 +532,7 @@ export default function AnalysisSettingsSummary({
       ...expandedSecondaries,
       ...expandedGuardrails,
     ];
-    const allMetricsMap = new Map<string, ExperimentMetricInterface>();
+    const allMetricsMap = new Map<string, ExperimentMetricDefinition>();
     allExpandedIds.forEach((id) => {
       const metric = getExperimentMetricById(id);
       if (metric && !allMetricsMap.has(id)) {
@@ -572,12 +572,12 @@ export default function AnalysisSettingsSummary({
       const expanded = expandMetricGroups(filtered, groupsToUse);
       const defs = expanded
         .map((id) => getExperimentMetricById(id))
-        .filter((m): m is ExperimentMetricInterface => !!m);
+        .filter((m): m is ExperimentMetricDefinition => !!m);
       return filterMetricsByTags(defs, metricTagFilter);
     };
 
     const filteredIds = allMetricsArrays.flatMap(processMetrics);
-    const filteredMetricsMap = new Map<string, ExperimentMetricInterface>();
+    const filteredMetricsMap = new Map<string, ExperimentMetricDefinition>();
     filteredIds.forEach((id) => {
       const metric = getExperimentMetricById(id);
       if (metric && !filteredMetricsMap.has(id)) {
@@ -975,7 +975,7 @@ export default function AnalysisSettingsSummary({
               supportsNotebooks={!!datasource?.settings?.notebookRunQuery}
               hasData={hasData}
               metrics={useMemo(() => {
-                const metricMap = new Map<string, ExperimentMetricInterface>();
+                const metricMap = new Map<string, ExperimentMetricDefinition>();
                 const allBaseMetrics = [...metrics, ...factMetrics];
                 allBaseMetrics.forEach((metric) =>
                   metricMap.set(metric.id, metric),

--- a/packages/front-end/components/Experiment/TabbedPage/DecisionMakingSettings.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/DecisionMakingSettings.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from "react";
 import { getScopedSettings } from "shared/settings";
 import {
   expandMetricGroups,
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   isFactMetric,
 } from "shared/experiments";
 import { DEFAULT_TARGET_MDE } from "shared/constants";
@@ -35,7 +35,7 @@ const percentFormatter = new Intl.NumberFormat(undefined, {
 });
 
 export type ExperimentMetricInterfaceWithComputedTargetMDE = Omit<
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   "targetMDE"
 > & {
   computedTargetMDE: number;

--- a/packages/front-end/components/Experiment/useColumnStatusPopovers.tsx
+++ b/packages/front-end/components/Experiment/useColumnStatusPopovers.tsx
@@ -1,6 +1,6 @@
 import { SnapshotMetric } from "shared/types/experiment-snapshot";
 import { DifferenceType, StatsEngine } from "shared/types/stats";
-import { ExperimentMetricInterface } from "shared/experiments";
+import { ExperimentMetricDefinition } from "shared/experiments";
 import { RowResults } from "@/services/experiments";
 import { SSRPolyfills } from "@/hooks/useSSRPolyfills";
 import { useResultPopover } from "./useResultPopover";
@@ -8,7 +8,7 @@ import { useResultPopover } from "./useResultPopover";
 interface UseColumnStatusPopoversOptions {
   stats: SnapshotMetric;
   rowResults: RowResults;
-  metric?: ExperimentMetricInterface;
+  metric?: ExperimentMetricDefinition;
   pValueThreshold: number;
   differenceType?: DifferenceType;
   statsEngine?: StatsEngine;

--- a/packages/front-end/components/Experiment/useResultPopover.tsx
+++ b/packages/front-end/components/Experiment/useResultPopover.tsx
@@ -7,7 +7,7 @@ import React, {
 } from "react";
 import { SnapshotMetric } from "shared/types/experiment-snapshot";
 import { DifferenceType, StatsEngine } from "shared/types/stats";
-import { ExperimentMetricInterface } from "shared/experiments";
+import { ExperimentMetricDefinition } from "shared/experiments";
 import { RowResults } from "@/services/experiments";
 import { SSRPolyfills } from "@/hooks/useSSRPolyfills";
 import { useHoverTooltip } from "@/hooks/useHoverTooltip";
@@ -18,7 +18,7 @@ import ExperimentResultTooltipContent, {
 
 interface ResultPopoverData {
   stats: SnapshotMetric;
-  metric: ExperimentMetricInterface;
+  metric: ExperimentMetricDefinition;
   pValueThreshold: number;
   significant: boolean;
   resultsStatus: RowResults["resultsStatus"];

--- a/packages/front-end/components/FactTables/NewMetricModal.tsx
+++ b/packages/front-end/components/FactTables/NewMetricModal.tsx
@@ -10,6 +10,7 @@ import FactMetricModal from "@/components/FactTables/FactMetricModal";
 import MetricForm from "@/components/Metrics/MetricForm";
 import useApi from "@/hooks/useApi";
 import LoadingOverlay from "@/components/LoadingOverlay";
+import Modal from "@/ui/Modal";
 import Callout from "@/ui/Callout";
 
 export type MetricModalState = {
@@ -85,16 +86,41 @@ function EditMetricModal({
   );
 
   if (error) {
-    return <Callout status="error">{error.message}</Callout>;
+    return (
+      <Modal.Root
+        open={true}
+        onOpenChange={(open) => {
+          if (!open) close();
+        }}
+        dismissible
+        trackingEventModalType=""
+      >
+        <Modal.Header>
+          <Modal.Title>
+            {mode === "edit" ? "Edit Metric" : "Duplicate Metric"}
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Callout status="error">{error.message}</Callout>
+        </Modal.Body>
+      </Modal.Root>
+    );
   }
   if (!data) {
     return <LoadingOverlay />;
   }
 
-  // When duplicating, keep the caller's overrides (e.g. "(copy)" name and
-  // cleared managedBy) on top of the full fetched metric
+  // When duplicating, apply only the caller's intended overrides on top of the
+  // full fetched metric — the rest of currentMetric is a possibly-stale
+  // definitions copy
   const current: MetricInterface =
-    mode === "edit" ? data.metric : { ...data.metric, ...currentMetric };
+    mode === "edit"
+      ? data.metric
+      : {
+          ...data.metric,
+          name: currentMetric.name,
+          managedBy: currentMetric.managedBy,
+        };
 
   return (
     <MetricForm

--- a/packages/front-end/components/FactTables/NewMetricModal.tsx
+++ b/packages/front-end/components/FactTables/NewMetricModal.tsx
@@ -12,6 +12,7 @@ import useApi from "@/hooks/useApi";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import Modal from "@/ui/Modal";
 import Callout from "@/ui/Callout";
+import Button from "@/ui/Button";
 
 export type MetricModalState = {
   currentMetric?: MetricDefinitionInterface;
@@ -103,6 +104,13 @@ function EditMetricModal({
         <Modal.Body>
           <Callout status="error">{error.message}</Callout>
         </Modal.Body>
+        <Modal.Footer>
+          <Modal.Close>
+            <Button variant="ghost" onClick={close}>
+              Close
+            </Button>
+          </Modal.Close>
+        </Modal.Footer>
       </Modal.Root>
     );
   }

--- a/packages/front-end/components/FactTables/NewMetricModal.tsx
+++ b/packages/front-end/components/FactTables/NewMetricModal.tsx
@@ -1,13 +1,19 @@
 import { useState } from "react";
 import { isProjectListValidForProject } from "shared/util";
-import { MetricInterface } from "shared/types/metric";
+import {
+  MetricDefinitionInterface,
+  MetricInterface,
+} from "shared/types/metric";
 import { FactMetricInterface } from "shared/types/fact-table";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import FactMetricModal from "@/components/FactTables/FactMetricModal";
 import MetricForm from "@/components/Metrics/MetricForm";
+import useApi from "@/hooks/useApi";
+import LoadingOverlay from "@/components/LoadingOverlay";
+import Callout from "@/ui/Callout";
 
 export type MetricModalState = {
-  currentMetric?: MetricInterface;
+  currentMetric?: MetricDefinitionInterface;
   currentFactMetric?: FactMetricInterface;
   mode: "edit" | "duplicate" | "new";
 };
@@ -38,12 +44,11 @@ export function MetricModal({
     );
   } else if (currentMetric) {
     return (
-      <MetricForm
-        current={currentMetric}
-        edit={mode === "edit"}
-        duplicate={mode === "duplicate"}
-        source={source + (mode === "duplicate" ? "-duplicate" : "")}
-        onClose={close}
+      <EditMetricModal
+        close={close}
+        mode={mode}
+        source={source}
+        currentMetric={currentMetric}
       />
     );
   } else if (currentFactMetric) {
@@ -59,6 +64,47 @@ export function MetricModal({
     // This should never happen
     return null;
   }
+}
+
+// Metrics coming from the definitions endpoint are missing heavy fields like
+// `sql`, so fetch the full metric before seeding the form. Otherwise saving an
+// edit would silently wipe those fields.
+function EditMetricModal({
+  close,
+  mode,
+  source,
+  currentMetric,
+}: {
+  close: () => void;
+  mode: "edit" | "duplicate";
+  source: string;
+  currentMetric: MetricDefinitionInterface;
+}) {
+  const { data, error } = useApi<{ metric: MetricInterface }>(
+    `/metric/${currentMetric.id}`,
+  );
+
+  if (error) {
+    return <Callout status="error">{error.message}</Callout>;
+  }
+  if (!data) {
+    return <LoadingOverlay />;
+  }
+
+  // When duplicating, keep the caller's overrides (e.g. "(copy)" name and
+  // cleared managedBy) on top of the full fetched metric
+  const current: MetricInterface =
+    mode === "edit" ? data.metric : { ...data.metric, ...currentMetric };
+
+  return (
+    <MetricForm
+      current={current}
+      edit={mode === "edit"}
+      duplicate={mode === "duplicate"}
+      source={source + (mode === "duplicate" ? "-duplicate" : "")}
+      onClose={close}
+    />
+  );
 }
 
 export function NewMetricModal({ close, source, datasource }: NewMetricProps) {

--- a/packages/front-end/components/FactTables/NewMetricModal.tsx
+++ b/packages/front-end/components/FactTables/NewMetricModal.tsx
@@ -94,6 +94,7 @@ function EditMetricModal({
           if (!open) close();
         }}
         dismissible
+        hasDescription={false}
         trackingEventModalType=""
       >
         <Modal.Header>

--- a/packages/front-end/components/MetricDrilldown/MetricDrilldownDebug.tsx
+++ b/packages/front-end/components/MetricDrilldown/MetricDrilldownDebug.tsx
@@ -1,5 +1,5 @@
 import { FC, useMemo } from "react";
-import { ExperimentMetricInterface } from "shared/experiments";
+import { ExperimentMetricDefinition } from "shared/experiments";
 import {
   DifferenceType,
   StatsEngine,
@@ -21,7 +21,7 @@ import { useSnapshot } from "@/components/Experiment/SnapshotProvider";
 
 interface MetricDrilldownDebugProps {
   row?: ExperimentTableRow;
-  metric: ExperimentMetricInterface;
+  metric: ExperimentMetricDefinition;
   statsEngine: StatsEngine;
   differenceType: DifferenceType;
   setDifferenceType: (type: DifferenceType) => void;

--- a/packages/front-end/components/MetricDrilldown/MetricDrilldownMetricCard.tsx
+++ b/packages/front-end/components/MetricDrilldown/MetricDrilldownMetricCard.tsx
@@ -7,7 +7,7 @@ import {
   RowFilter,
 } from "shared/types/fact-table";
 import {
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   getAggregateFilters,
   isBinomialMetric,
   isFactMetric,
@@ -22,7 +22,7 @@ import { getPercentileLabel } from "@/services/metrics";
 import InlineCode from "@/components/SyntaxHighlighting/InlineCode";
 
 interface MetricDrilldownMetricCardProps {
-  metric: ExperimentMetricInterface;
+  metric: ExperimentMetricDefinition;
   type: "numerator" | "denominator";
 }
 

--- a/packages/front-end/components/MetricDrilldown/MetricDrilldownModal.tsx
+++ b/packages/front-end/components/MetricDrilldown/MetricDrilldownModal.tsx
@@ -3,7 +3,7 @@ import { PiArrowSquareOut } from "react-icons/pi";
 import { Box, Flex, Text } from "@radix-ui/themes";
 import {
   getMetricLink,
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   ExperimentSortBy,
   isDimensionPrecomputed,
 } from "shared/experiments";
@@ -123,7 +123,7 @@ interface MetricDrilldownModalProps {
  */
 interface MetricDrilldownContentProps {
   row: ExperimentTableRow;
-  metric: ExperimentMetricInterface;
+  metric: ExperimentMetricDefinition;
   initialResults: ExperimentReportResultDimension;
   goalMetrics: string[];
   secondaryMetrics: string[];

--- a/packages/front-end/components/MetricDrilldown/MetricDrilldownSlices.tsx
+++ b/packages/front-end/components/MetricDrilldown/MetricDrilldownSlices.tsx
@@ -1,7 +1,7 @@
 import { FC, useState, useMemo } from "react";
 import { PiInfo } from "react-icons/pi";
 import {
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   ExperimentSortBy,
 } from "shared/experiments";
 import {
@@ -26,7 +26,7 @@ import { filterRowsForMetricDrilldown } from "./helpers";
 import { type DrilldownDimensionInfo } from "./useMetricDrilldownContext";
 
 interface MetricDrilldownSlicesProps {
-  metric: ExperimentMetricInterface;
+  metric: ExperimentMetricDefinition;
   // Rows computed by parent using useExperimentTableRows
   rows: ExperimentTableRow[];
   variationNames: string[];

--- a/packages/front-end/components/MetricExperiments/MetricExperiments.tsx
+++ b/packages/front-end/components/MetricExperiments/MetricExperiments.tsx
@@ -4,7 +4,7 @@ import clsx from "clsx";
 import { Flex } from "@radix-ui/themes";
 import { date, datetime } from "shared/dates";
 import {
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   getLatestPhaseVariations,
   getMetricResultStatus,
   isFactMetric,
@@ -39,7 +39,7 @@ import Callout from "@/ui/Callout";
 import LoadingSpinner from "@/components/LoadingSpinner";
 
 interface MetricAnalysisProps {
-  metric: ExperimentMetricInterface;
+  metric: ExperimentMetricDefinition;
   outerClassName?: string;
   bandits?: boolean;
   includeOnlyResults?: boolean;
@@ -50,7 +50,7 @@ interface MetricAnalysisProps {
 
 interface Props {
   experimentsWithSnapshot: ExperimentWithSnapshot[];
-  metric: ExperimentMetricInterface;
+  metric: ExperimentMetricDefinition;
   bandits?: boolean;
   numPerPage?: number;
   differenceType?: DifferenceType;

--- a/packages/front-end/components/Metrics/MetricGroupDetails.tsx
+++ b/packages/front-end/components/Metrics/MetricGroupDetails.tsx
@@ -18,7 +18,7 @@ import {
 import { MetricGroupInterface } from "shared/types/metric-groups";
 import { CSS } from "@dnd-kit/utilities";
 import { GrDrag } from "react-icons/gr";
-import { ExperimentMetricInterface, isFactMetric } from "shared/experiments";
+import { ExperimentMetricDefinition, isFactMetric } from "shared/experiments";
 import Link from "@/ui/Link";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import { useAuth } from "@/services/auth";
@@ -39,7 +39,7 @@ export default function MetricGroupDetails({
   const permissionsUtil = usePermissionsUtil();
   const { getMetricById, getFactMetricById } = useDefinitions();
   const factMetricsInList: string[] = [];
-  const metricObjs: ExperimentMetricInterface[] = metricGroup.metrics
+  const metricObjs: ExperimentMetricDefinition[] = metricGroup.metrics
     .map((id) => {
       const mi = getMetricById(id);
       if (mi) return mi;
@@ -49,7 +49,7 @@ export default function MetricGroupDetails({
         return fm;
       }
     })
-    .filter((m) => m) as ExperimentMetricInterface[];
+    .filter((m) => m) as ExperimentMetricDefinition[];
 
   const [items, setItems] = useState(metricObjs.length ? metricObjs : []);
   useEffect(() => {
@@ -213,7 +213,7 @@ function SortableMetricRow(props) {
 }
 
 interface SortableProps {
-  metric: ExperimentMetricInterface;
+  metric: ExperimentMetricDefinition;
   metricGroupId: string;
   i: number;
   mutate?: () => void;

--- a/packages/front-end/components/Metrics/MetricName.tsx
+++ b/packages/front-end/components/Metrics/MetricName.tsx
@@ -1,6 +1,6 @@
 import { HiBadgeCheck } from "react-icons/hi";
 import {
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   isFactMetric,
   quantileMetricType,
 } from "shared/experiments";
@@ -18,7 +18,7 @@ import HelperText from "@/ui/HelperText";
 export function PercentileLabel({
   metric,
 }: {
-  metric: ExperimentMetricInterface;
+  metric: ExperimentMetricDefinition;
 }) {
   if (
     isFactMetric(metric) &&
@@ -139,14 +139,14 @@ export default function MetricName({
   officialBadgeLeftGap = true,
 }: {
   id?: string;
-  metric?: ExperimentMetricInterface;
+  metric?: ExperimentMetricDefinition;
   disableTooltip?: boolean;
   showOfficialLabel?: boolean;
   showDescription?: boolean;
   filterConversionWindowMetrics?: boolean;
   isGroup?: boolean;
   showGroupIcon?: boolean;
-  metrics?: { metric: ExperimentMetricInterface | null; joinable: boolean }[];
+  metrics?: { metric: ExperimentMetricDefinition | null; joinable: boolean }[];
   showLink?: boolean;
   badgeColor?: string;
   officialBadgePosition?: "left" | "right";

--- a/packages/front-end/components/Metrics/MetricTooltipBody.tsx
+++ b/packages/front-end/components/Metrics/MetricTooltipBody.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import {
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   isFactMetric,
   quantileMetricType,
 } from "shared/experiments";
@@ -22,7 +22,7 @@ import MetricName from "./MetricName";
 import FactMetricTypeDisplayName from "./FactMetricTypeDisplayName";
 
 interface MetricToolTipCompProps {
-  metric: ExperimentMetricInterface;
+  metric: ExperimentMetricDefinition;
   row?: ExperimentTableRow;
   statsEngine?: StatsEngine;
   hideDetails?: boolean;

--- a/packages/front-end/components/PowerCalculation/PowerCalculationSettingsModal/SelectStep.tsx
+++ b/packages/front-end/components/PowerCalculation/PowerCalculationSettingsModal/SelectStep.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import {
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   getAllMetricIdsFromExperiment,
   isBinomialMetric,
   isFactMetric,
@@ -137,7 +137,7 @@ export const SelectStep = ({
 
   // only allow metrics from the same datasource in an analysis
   // combine both metrics and remove quantile metrics
-  const availableMetrics: ExperimentMetricInterface[] = useMemo(
+  const availableMetrics: ExperimentMetricDefinition[] = useMemo(
     () =>
       [...appMetrics, ...appFactMetrics].filter((m) => {
         // drop quantile metrics
@@ -273,7 +273,7 @@ export const SelectStep = ({
 
   const field = (
     key: keyof typeof config,
-    metric: ExperimentMetricInterface,
+    metric: ExperimentMetricDefinition,
   ) => ({
     [key]: defaultValue(config[key], metric.priorSettings, settings),
   });

--- a/packages/front-end/components/RampSchedule/SafeRolloutRuleDashboard/dummyData.tsx
+++ b/packages/front-end/components/RampSchedule/SafeRolloutRuleDashboard/dummyData.tsx
@@ -6,7 +6,7 @@ import {
 import { SnapshotMetric } from "shared/types/experiment-snapshot";
 import { SafeRolloutSnapshotInterface } from "shared/types/safe-rollout";
 import {
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   isBinomialMetric,
 } from "shared/experiments";
 import {
@@ -21,7 +21,7 @@ function dummyPerUnitMeanAndTotal(
   metricId: string,
   users: number,
   rand: () => number,
-  getExperimentMetricById?: (id: string) => ExperimentMetricInterface | null,
+  getExperimentMetricById?: (id: string) => ExperimentMetricDefinition | null,
 ): { mean: number; total: number } {
   const metric = getExperimentMetricById?.(metricId);
   if (metric && !isBinomialMetric(metric)) {
@@ -37,7 +37,7 @@ export function generateDummySnapshotMetrics(
   scenarios: DummyScenario[],
   issueProfile?: DummyIssueProfile,
   isInverseMetric: (metricId: string) => boolean = () => false,
-  getExperimentMetricById?: (id: string) => ExperimentMetricInterface | null,
+  getExperimentMetricById?: (id: string) => ExperimentMetricDefinition | null,
 ): Record<string, { baseline: SnapshotMetric; variation: SnapshotMetric }> {
   const result: Record<
     string,

--- a/packages/front-end/components/Report/ConfigureLegacyReport.tsx
+++ b/packages/front-end/components/Report/ConfigureLegacyReport.tsx
@@ -16,7 +16,7 @@ import {
 } from "shared/constants";
 import { datetime, getValidDate } from "shared/dates";
 import { getScopedSettings } from "shared/settings";
-import { MetricInterface } from "shared/types/metric";
+import { MetricDefinitionInterface } from "shared/types/metric";
 import { DifferenceType } from "shared/types/stats";
 import {
   getAllMetricIdsFromExperiment,
@@ -101,7 +101,7 @@ export default function ConfigureLegacyReport({
       .map((m) => m?.denominator)
       .filter((m) => m && typeof m === "string") as string[],
   );
-  const denominatorMetrics: MetricInterface[] = useMemo(() => {
+  const denominatorMetrics: MetricDefinitionInterface[] = useMemo(() => {
     return denominatorMetricIds
       .map((m) => getMetricById(m as string))
       .filter(isDefined);

--- a/packages/front-end/components/SafeRollout/Results/CompactResults.tsx
+++ b/packages/front-end/components/SafeRollout/Results/CompactResults.tsx
@@ -18,7 +18,7 @@ import Link from "next/link";
 import { FaTimes } from "react-icons/fa";
 import {
   expandMetricGroups,
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   getMetricLink,
   setAdjustedCIs,
   setAdjustedPValuesOnResults,
@@ -225,7 +225,7 @@ export function getRenderLabelColumn({
     row,
     maxRows,
   }: {
-    metric: ExperimentMetricInterface;
+    metric: ExperimentMetricDefinition;
     row?: ExperimentTableRow;
     maxRows?: number;
   }) {

--- a/packages/front-end/components/SafeRollout/Results/ResultsTable.tsx
+++ b/packages/front-end/components/SafeRollout/Results/ResultsTable.tsx
@@ -24,7 +24,7 @@ import {
 } from "shared/types/stats";
 import { getValidDate } from "shared/dates";
 import { filterInvalidMetricTimeSeries } from "shared/util";
-import { ExperimentMetricInterface, isFactMetric } from "shared/experiments";
+import { ExperimentMetricDefinition, isFactMetric } from "shared/experiments";
 import { PiPencilSimpleFill } from "react-icons/pi";
 import AnalysisResultSummary from "@/ui/AnalysisResultSummary";
 import { useAnalysisResultSummary } from "@/ui/hooks/useAnalysisResultSummary";
@@ -63,7 +63,7 @@ export type ResultsTableProps = {
     maxRows,
   }: {
     label: string | ReactNode;
-    metric: ExperimentMetricInterface;
+    metric: ExperimentMetricDefinition;
     row: ExperimentTableRow;
     maxRows?: number;
   }) => string | ReactElement;

--- a/packages/front-end/components/Settings/BackupConfigYamlButton.tsx
+++ b/packages/front-end/components/Settings/BackupConfigYamlButton.tsx
@@ -1,20 +1,28 @@
 import { dump } from "js-yaml";
 import { useMemo } from "react";
 import { OrganizationSettings } from "shared/types/organization";
+import { MetricInterface } from "shared/types/metric";
 import { FaDownload } from "react-icons/fa";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useConfigJson } from "@/services/config";
+import useApi from "@/hooks/useApi";
 
 export default function BackupConfigYamlButton({
   settings = {},
 }: {
   settings?: OrganizationSettings;
 }) {
-  const { datasources, metrics, dimensions, segments } = useDefinitions();
+  const { datasources, dimensions, segments } = useDefinitions();
+
+  // Definitions only contain slimmed metrics (no sql, etc.), so fetch the
+  // full versions for the export
+  const { data: metricsData } = useApi<{ metrics: MetricInterface[] }>(
+    "/metrics",
+  );
 
   const config = useConfigJson({
     datasources,
-    metrics,
+    metrics: metricsData?.metrics || [],
     dimensions,
     settings,
     segments,
@@ -34,7 +42,7 @@ export default function BackupConfigYamlButton({
     }
   }, [config]);
 
-  if (!href) return null;
+  if (!href || !metricsData) return null;
 
   return (
     <a href={href} download="config.yml" className="btn btn-primary">

--- a/packages/front-end/components/Settings/BackupConfigYamlButton.tsx
+++ b/packages/front-end/components/Settings/BackupConfigYamlButton.tsx
@@ -6,6 +6,7 @@ import { FaDownload } from "react-icons/fa";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useConfigJson } from "@/services/config";
 import useApi from "@/hooks/useApi";
+import Button from "@/ui/Button";
 
 export default function BackupConfigYamlButton({
   settings = {},
@@ -44,7 +45,14 @@ export default function BackupConfigYamlButton({
     }
   }, [config]);
 
-  if (!href || !metricsData) return null;
+  if (!metricsData) {
+    return (
+      <Button disabled loading icon={<FaDownload />}>
+        Export to config.yml
+      </Button>
+    );
+  }
+  if (!href) return null;
 
   return (
     <a href={href} download="config.yml" className="btn btn-primary">

--- a/packages/front-end/components/Settings/BackupConfigYamlButton.tsx
+++ b/packages/front-end/components/Settings/BackupConfigYamlButton.tsx
@@ -16,12 +16,12 @@ export default function BackupConfigYamlButton({
   const { datasources, dimensions, segments } = useDefinitions();
 
   // Definitions only contain slimmed metrics (no sql, etc.), so fetch the
-  // full versions for the export. Skip archived metrics to match the old
-  // definitions-based behavior (/metrics includes them, definitions didn't).
+  // full versions for the export. /metrics excludes archived metrics by
+  // default, matching the old definitions-based behavior.
   const { data: metricsData } = useApi<{ metrics: MetricInterface[] }>(
     "/metrics",
   );
-  const metrics = metricsData?.metrics.filter((m) => m.status !== "archived");
+  const metrics = metricsData?.metrics;
 
   const config = useConfigJson({
     datasources,

--- a/packages/front-end/components/Settings/BackupConfigYamlButton.tsx
+++ b/packages/front-end/components/Settings/BackupConfigYamlButton.tsx
@@ -15,14 +15,16 @@ export default function BackupConfigYamlButton({
   const { datasources, dimensions, segments } = useDefinitions();
 
   // Definitions only contain slimmed metrics (no sql, etc.), so fetch the
-  // full versions for the export
+  // full versions for the export. Skip archived metrics to match the old
+  // definitions-based behavior (/metrics includes them, definitions didn't).
   const { data: metricsData } = useApi<{ metrics: MetricInterface[] }>(
     "/metrics",
   );
+  const metrics = metricsData?.metrics.filter((m) => m.status !== "archived");
 
   const config = useConfigJson({
     datasources,
-    metrics: metricsData?.metrics || [],
+    metrics: metrics || [],
     dimensions,
     settings,
     segments,

--- a/packages/front-end/components/Settings/RestoreConfigYamlButton.tsx
+++ b/packages/front-end/components/Settings/RestoreConfigYamlButton.tsx
@@ -20,6 +20,7 @@ import { useAuth } from "@/services/auth";
 import { useConfigJson } from "@/services/config";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import useApi from "@/hooks/useApi";
+import Button from "@/ui/Button";
 import Field from "@/components/Forms/Field";
 import Page from "@/components/Modal/Page";
 import PagedModal from "@/components/Modal/PagedModal";
@@ -246,7 +247,13 @@ export default function RestoreConfigYamlButton({
     }
   }
 
-  if (!metricsData) return null;
+  if (!metricsData) {
+    return (
+      <Button disabled loading icon={<FaUpload />}>
+        Import from config.yml
+      </Button>
+    );
+  }
 
   return (
     <div>

--- a/packages/front-end/components/Settings/RestoreConfigYamlButton.tsx
+++ b/packages/front-end/components/Settings/RestoreConfigYamlButton.tsx
@@ -55,10 +55,12 @@ export default function RestoreConfigYamlButton({
     useDefinitions();
 
   // Definitions only contain slimmed metrics (no sql, etc.), so fetch the
-  // full versions for the import diff
+  // full versions for the import diff. Skip archived metrics to match the old
+  // definitions-based behavior (/metrics includes them, definitions didn't).
   const { data: metricsData } = useApi<{ metrics: MetricInterface[] }>(
     "/metrics",
   );
+  const metrics = metricsData?.metrics.filter((m) => m.status !== "archived");
 
   const [open, setOpen] = useState(false);
   const [step, setStep] = useState(0);
@@ -75,7 +77,7 @@ export default function RestoreConfigYamlButton({
 
   const config = useConfigJson({
     datasources,
-    metrics: metricsData?.metrics || [],
+    metrics: metrics || [],
     dimensions,
     settings,
     segments,

--- a/packages/front-end/components/Settings/RestoreConfigYamlButton.tsx
+++ b/packages/front-end/components/Settings/RestoreConfigYamlButton.tsx
@@ -56,12 +56,12 @@ export default function RestoreConfigYamlButton({
     useDefinitions();
 
   // Definitions only contain slimmed metrics (no sql, etc.), so fetch the
-  // full versions for the import diff. Skip archived metrics to match the old
-  // definitions-based behavior (/metrics includes them, definitions didn't).
+  // full versions for the import diff. /metrics excludes archived metrics by
+  // default, matching the old definitions-based behavior.
   const { data: metricsData } = useApi<{ metrics: MetricInterface[] }>(
     "/metrics",
   );
-  const metrics = metricsData?.metrics.filter((m) => m.status !== "archived");
+  const metrics = metricsData?.metrics;
 
   const [open, setOpen] = useState(false);
   const [step, setStep] = useState(0);

--- a/packages/front-end/components/Settings/RestoreConfigYamlButton.tsx
+++ b/packages/front-end/components/Settings/RestoreConfigYamlButton.tsx
@@ -15,9 +15,11 @@ import {
   DEFAULT_METRIC_WINDOW_DELAY_HOURS,
   DEFAULT_METRIC_WINDOW_HOURS,
 } from "shared/constants";
+import { MetricInterface } from "shared/types/metric";
 import { useAuth } from "@/services/auth";
 import { useConfigJson } from "@/services/config";
 import { useDefinitions } from "@/services/DefinitionsContext";
+import useApi from "@/hooks/useApi";
 import Field from "@/components/Forms/Field";
 import Page from "@/components/Modal/Page";
 import PagedModal from "@/components/Modal/PagedModal";
@@ -49,8 +51,14 @@ export default function RestoreConfigYamlButton({
   settings?: OrganizationSettings;
   mutate: () => void;
 }) {
-  const { datasources, metrics, dimensions, mutateDefinitions, segments } =
+  const { datasources, dimensions, mutateDefinitions, segments } =
     useDefinitions();
+
+  // Definitions only contain slimmed metrics (no sql, etc.), so fetch the
+  // full versions for the import diff
+  const { data: metricsData } = useApi<{ metrics: MetricInterface[] }>(
+    "/metrics",
+  );
 
   const [open, setOpen] = useState(false);
   const [step, setStep] = useState(0);
@@ -67,7 +75,7 @@ export default function RestoreConfigYamlButton({
 
   const config = useConfigJson({
     datasources,
-    metrics,
+    metrics: metricsData?.metrics || [],
     dimensions,
     settings,
     segments,
@@ -235,6 +243,8 @@ export default function RestoreConfigYamlButton({
       throw new Error(e);
     }
   }
+
+  if (!metricsData) return null;
 
   return (
     <div>

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/index.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/index.tsx
@@ -16,7 +16,7 @@ import {
 import { SavedQuery } from "shared/validators";
 import {
   expandMetricGroups,
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
 } from "shared/experiments";
 import { ErrorBoundary } from "@sentry/nextjs";
 import { BsThreeDotsVertical } from "react-icons/bs";
@@ -60,14 +60,14 @@ import ProductAnalyticsExplorerBlock from "./ProductAnalyticsExplorerBlock";
 // Typescript helpers for passing objects to the block components based on id fields
 interface BlockIdFieldToObjectMap {
   experimentId: ExperimentInterfaceStringDates;
-  metricIds: ExperimentMetricInterface[];
+  metricIds: ExperimentMetricDefinition[];
   factMetricId: FactMetricInterface;
   savedQueryId: SavedQuery;
   metricAnalysisId: MetricAnalysisInterface;
 }
 type ObjectProps<Block> = {
   [K in keyof BlockIdFieldToObjectMap as K extends keyof Block
-    ? // Formatting to strip the trailing Id or Ids so metricId: string becomes metric: ExperimentMetricInterface
+    ? // Formatting to strip the trailing Id or Ids so metricId: string becomes metric: ExperimentMetricDefinition
       K extends `${infer Base}Id`
       ? Base
       : K extends `${infer Base}Ids`

--- a/packages/front-end/enterprise/components/Insights/MetricCorrelations.tsx
+++ b/packages/front-end/enterprise/components/Insights/MetricCorrelations.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useCallback, useState, useMemo } from "react";
 import {
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   getAllMetricIdsFromExperiment,
   getLatestPhaseVariations,
 } from "shared/experiments";
@@ -385,7 +385,7 @@ const MetricCorrelationCard = ({
 
   const getLiftFormatter = useCallback(
     (
-      metric: ExperimentMetricInterface | null,
+      metric: ExperimentMetricDefinition | null,
       differenceType: DifferenceType,
     ) => {
       if (!metric) {

--- a/packages/front-end/enterprise/components/Insights/MetricCorrelations/MetricCorrelationsExperimentTable.tsx
+++ b/packages/front-end/enterprise/components/Insights/MetricCorrelations/MetricCorrelationsExperimentTable.tsx
@@ -3,7 +3,7 @@ import { FaShippingFast } from "react-icons/fa";
 import clsx from "clsx";
 import { date, datetime } from "shared/dates";
 import {
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   getLatestPhaseVariations,
   getMetricResultStatus,
   isSuspiciousUplift,
@@ -36,7 +36,7 @@ import Checkbox from "@/ui/Checkbox";
 
 interface Props {
   experimentsWithSnapshot: ExperimentWithSnapshot[];
-  metrics: ExperimentMetricInterface[];
+  metrics: ExperimentMetricDefinition[];
   bandits?: boolean;
   numPerPage?: number;
   differenceType?: DifferenceType;

--- a/packages/front-end/hooks/useExperimentDimensionRows.ts
+++ b/packages/front-end/hooks/useExperimentDimensionRows.ts
@@ -7,7 +7,7 @@ import { MetricOverride } from "shared/types/experiment";
 import { PValueCorrection, StatsEngine } from "shared/types/stats";
 import {
   expandMetricGroups,
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   ExperimentSortBy,
   quantileMetricType,
   setAdjustedCIs,
@@ -54,7 +54,7 @@ export interface UseExperimentDimensionRowsParams {
 
 export interface UseExperimentDimensionRowsReturn {
   tables: Array<{
-    metric: ExperimentMetricInterface;
+    metric: ExperimentMetricDefinition;
     isGuardrail: boolean;
     rows: ExperimentTableRow[];
   }>;
@@ -282,7 +282,7 @@ export function useExperimentDimensionRows({
             ssrPolyfills?.getExperimentMetricById?.(metricId) ||
             getExperimentMetricById(metricId),
         )
-        .filter((m): m is ExperimentMetricInterface => !!m);
+        .filter((m): m is ExperimentMetricDefinition => !!m);
 
       // Apply tag filtering first (independent of sorting)
       const filteredMetricIds = filterMetricsByTags(
@@ -369,7 +369,7 @@ export function useExperimentDimensionRows({
           };
         })
         .filter((table) => table?.metric) as Array<{
-        metric: ExperimentMetricInterface;
+        metric: ExperimentMetricDefinition;
         isGuardrail: boolean;
         rows: ExperimentTableRow[];
       }>;
@@ -466,7 +466,7 @@ export function generateDimensionRowsForMetric({
   dimensionValuesFilter?: string[];
   overrideFields: string[];
   metricSnapshotSettings: MetricSnapshotSettings | undefined;
-  newMetric: ExperimentMetricInterface;
+  newMetric: ExperimentMetricDefinition;
 }): ExperimentTableRow[] {
   const filteredResults = includeVariation(results, dimensionValuesFilter);
 

--- a/packages/front-end/hooks/useExperimentTableRows.ts
+++ b/packages/front-end/hooks/useExperimentTableRows.ts
@@ -11,7 +11,7 @@ import {
 } from "shared/types/fact-table";
 import {
   expandMetricGroups,
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   ExperimentSortBy,
   createCustomSliceDataForMetric,
   createAutoSliceDataForMetric,
@@ -482,7 +482,7 @@ export function generateRowsForMetric({
     }>;
   }>;
   expandedMetrics?: Record<string, boolean>;
-  getExperimentMetricById: (id: string) => ExperimentMetricInterface | null;
+  getExperimentMetricById: (id: string) => ExperimentMetricDefinition | null;
   getFactTableById: (id: string) => FactTableInterface | null;
   sliceTagsFilter?: string[];
 }): ExperimentTableRow[] {
@@ -713,7 +713,7 @@ export function generateRowsForMetric({
 }
 
 export function sortMetricsByCustomOrder(
-  metrics: ExperimentMetricInterface[],
+  metrics: ExperimentMetricDefinition[],
   customOrder: string[],
   metricGroups?: MetricGroupInterface[],
 ): string[] {
@@ -755,7 +755,7 @@ export function sortMetricsByCustomOrder(
 }
 
 export function sortMetricsByTags(
-  metrics: ExperimentMetricInterface[],
+  metrics: ExperimentMetricDefinition[],
   metricTagFilter: string[],
   metricGroups: MetricGroupInterface[],
 ): string[] {
@@ -796,7 +796,7 @@ export function sortMetricsByTags(
 }
 
 export function filterMetricsByTags(
-  metrics: ExperimentMetricInterface[],
+  metrics: ExperimentMetricDefinition[],
   tagFilter?: string[],
 ): string[] {
   // If no filter, return all metrics

--- a/packages/front-end/hooks/useSSRPolyfills.ts
+++ b/packages/front-end/hooks/useSSRPolyfills.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_P_VALUE_THRESHOLD,
 } from "shared/constants";
 import { ExperimentReportSSRData } from "shared/types/report";
-import { ExperimentMetricInterface } from "shared/experiments";
+import { ExperimentMetricDefinition } from "shared/experiments";
 import { CommercialFeature } from "shared/enterprise";
 import { MetricGroupInterface } from "shared/types/metric-groups";
 import { FactTableInterface } from "shared/types/fact-table";
@@ -23,7 +23,7 @@ import {
 } from "@/hooks/useOrganizationMetricDefaults";
 
 export interface SSRPolyfills {
-  getExperimentMetricById: (id: string) => null | ExperimentMetricInterface;
+  getExperimentMetricById: (id: string) => null | ExperimentMetricDefinition;
   metricGroups: MetricGroupInterface[];
   getMetricGroupById: (id: string) => null | MetricGroupInterface;
   getFactTableById: (id: string) => null | FactTableInterface;

--- a/packages/front-end/services/DefinitionsContext.tsx
+++ b/packages/front-end/services/DefinitionsContext.tsx
@@ -1,6 +1,6 @@
 import { DataSourceInterfaceWithParams } from "shared/types/datasource";
 import { DimensionInterface } from "shared/types/dimension";
-import { MetricInterface } from "shared/types/metric";
+import { MetricDefinitionInterface } from "shared/types/metric";
 import { SegmentInterface } from "shared/types/segment";
 import { ProjectInterface } from "shared/types/project";
 import {
@@ -18,7 +18,7 @@ import {
   FactMetricInterface,
   FactTableInterface,
 } from "shared/types/fact-table";
-import { ExperimentMetricInterface, isFactMetricId } from "shared/experiments";
+import { ExperimentMetricDefinition, isFactMetricId } from "shared/experiments";
 import { SavedGroupWithoutValues } from "shared/types/saved-group";
 import { ConstantWithoutValue } from "shared/types/constant";
 import { MetricGroupInterface } from "shared/types/metric-groups";
@@ -32,8 +32,8 @@ import { findClosestRadixColor } from "./tags";
 import { useUser } from "./UserContext";
 
 type Definitions = {
-  metrics: MetricInterface[];
-  _metricsIncludingArchived: MetricInterface[];
+  metrics: MetricDefinitionInterface[];
+  _metricsIncludingArchived: MetricDefinitionInterface[];
   datasources: DataSourceInterfaceWithParams[];
   dimensions: DimensionInterface[];
   segments: SegmentInterface[];
@@ -60,7 +60,7 @@ type DefinitionContextValue = Definitions & {
   setProject: (id: string) => void;
   refreshTags: (newTags: string[]) => Promise<void>;
   mutateDefinitions: (changes?: Partial<Definitions>) => Promise<void>;
-  getMetricById: (id: string) => null | MetricInterface;
+  getMetricById: (id: string) => null | MetricDefinitionInterface;
   getDatasourceById: (id: string) => null | DataSourceInterfaceWithParams;
   getDimensionById: (id: string) => null | DimensionInterface;
   getSegmentById: (id: string) => null | SegmentInterface;
@@ -71,7 +71,7 @@ type DefinitionContextValue = Definitions & {
   getTagById: (id: string) => null | TagInterface;
   getFactTableById: (id: string) => null | FactTableInterface;
   getFactMetricById: (id: string) => null | FactMetricInterface;
-  getExperimentMetricById: (id: string) => null | ExperimentMetricInterface;
+  getExperimentMetricById: (id: string) => null | ExperimentMetricDefinition;
   getMetricGroupById: (id: string) => null | MetricGroupInterface;
   getDecisionCriteriaById: (id: string) => null | DecisionCriteriaInterface;
 };

--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -26,7 +26,7 @@ import {
   FactTableColumnType,
 } from "shared/types/fact-table";
 import {
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   getAllMetricIdsFromExperiment,
   getEqualWeights,
   getLatestPhaseVariations,
@@ -185,7 +185,7 @@ export function getFutureScheduledStartDate(
 
 export type ExperimentTableRow = {
   label: string | ReactElement;
-  metric: ExperimentMetricInterface;
+  metric: ExperimentMetricDefinition;
   metricOverrideFields: string[];
   variations: SnapshotMetric[];
   rowClass?: string;
@@ -333,7 +333,7 @@ export function useDomain(
   return [lowerBound, upperBound];
 }
 
-export function applyMetricOverrides<T extends ExperimentMetricInterface>(
+export function applyMetricOverrides<T extends ExperimentMetricDefinition>(
   metric: T,
   metricOverrides?: MetricOverride[],
 ): {
@@ -615,8 +615,8 @@ export function getRowResults({
   baseline: SnapshotMetric;
   statsEngine: StatsEngine;
   differenceType: DifferenceType;
-  metric: ExperimentMetricInterface;
-  denominator?: ExperimentMetricInterface;
+  metric: ExperimentMetricDefinition;
+  denominator?: ExperimentMetricDefinition;
   metricDefaults: MetricDefaults;
   minSampleSize: number;
   ciUpper: number;
@@ -1060,7 +1060,7 @@ export function getAvailableMetricsFilters({
   secondaryMetrics: string[];
   guardrailMetrics: string[];
   metricGroups: MetricGroupInterface[];
-  getExperimentMetricById: (id: string) => ExperimentMetricInterface | null;
+  getExperimentMetricById: (id: string) => ExperimentMetricDefinition | null;
 }): {
   groups: { id: string; name: string }[];
   metrics: { id: string; name: string }[];
@@ -1118,7 +1118,7 @@ export function getAvailableMetricTags({
   secondaryMetrics: string[];
   guardrailMetrics: string[];
   metricGroups: MetricGroupInterface[];
-  getExperimentMetricById: (id: string) => ExperimentMetricInterface | null;
+  getExperimentMetricById: (id: string) => ExperimentMetricDefinition | null;
 }): string[] {
   const expandedGoals = expandMetricGroups(goalMetrics, metricGroups);
   const expandedSecondaries = expandMetricGroups(
@@ -1168,7 +1168,7 @@ export function getAvailableSliceTags({
   }> | null;
   metricGroups: MetricGroupInterface[];
   factTables: FactTableInterface[];
-  getExperimentMetricById: (id: string) => ExperimentMetricInterface | null;
+  getExperimentMetricById: (id: string) => ExperimentMetricDefinition | null;
   getFactTableById: (id: string) => FactTableInterface | null;
 }): AvailableSliceTag[] {
   const sliceTagsMap = new Map<

--- a/packages/front-end/services/metrics.tsx
+++ b/packages/front-end/services/metrics.tsx
@@ -9,7 +9,7 @@ import {
 } from "shared/types/fact-table";
 import {
   canInlineFilterColumn,
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
 } from "shared/experiments";
 import {
   DEFAULT_FACT_METRIC_WINDOW,
@@ -325,7 +325,7 @@ export function getColumnRefFormatter(
 }
 
 export function getExperimentMetricFormatter(
-  metric: ExperimentMetricInterface,
+  metric: ExperimentMetricDefinition,
   getFactTableById: (id: string) => FactTableInterface | null,
   proportionFormat: "number" | "percentagePoints" | "percentage" = "percentage",
 ): (value: number, options?: Intl.NumberFormatOptions) => string {

--- a/packages/front-end/ui/AnalysisResultSummary.tsx
+++ b/packages/front-end/ui/AnalysisResultSummary.tsx
@@ -11,7 +11,7 @@ import {
   StatsEngine,
 } from "shared/types/stats";
 import { SnapshotMetric } from "shared/types/experiment-snapshot";
-import { ExperimentMetricInterface, isFactMetric } from "shared/experiments";
+import { ExperimentMetricDefinition, isFactMetric } from "shared/experiments";
 import { DEFAULT_PROPER_PRIOR_STDDEV } from "shared/constants";
 import { MdSwapCalls } from "react-icons/md";
 import { PiInfo } from "react-icons/pi";
@@ -32,7 +32,7 @@ import VariationStatsTable from "@/ui/VariationStatsTable";
 export interface AnalysisResultSummaryProps {
   data?: {
     metricRow: number;
-    metric: ExperimentMetricInterface;
+    metric: ExperimentMetricDefinition;
     metricSnapshotSettings?: MetricSnapshotSettings;
     dimensionName?: string;
     dimensionValue?: string | ReactNode;

--- a/packages/front-end/ui/VariationStatsTable.tsx
+++ b/packages/front-end/ui/VariationStatsTable.tsx
@@ -1,7 +1,7 @@
 import { Flex, Text } from "@radix-ui/themes";
 import { SnapshotMetric } from "shared/types/experiment-snapshot";
 import {
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
   quantileMetricType,
   isFactMetric,
 } from "shared/experiments";
@@ -35,7 +35,7 @@ export interface VariationStatRow {
 }
 
 interface VariationStatsTableProps {
-  metric: ExperimentMetricInterface;
+  metric: ExperimentMetricDefinition;
   rows: VariationStatRow[];
   isBandit?: boolean;
   ssrPolyfills?: SSRPolyfills;

--- a/packages/shared/src/enterprise/pipeline.ts
+++ b/packages/shared/src/enterprise/pipeline.ts
@@ -4,7 +4,7 @@ import {
   isFactMetric,
   isExperimentOutdatedReasonField,
   quantileMetricType,
-  ExperimentMetricInterface,
+  ExperimentMetricDefinition,
 } from "shared/experiments";
 import type {
   DataSourceType,
@@ -146,7 +146,7 @@ export function getIncrementalPipelineUnsupportedReason(params: {
   orgHasIncrementalPipelineFeature: boolean;
   skipPartialData: boolean;
   activationMetric: string | null | undefined;
-  metrics: ExperimentMetricInterface[];
+  metrics: ExperimentMetricDefinition[];
   experimentType: ExperimentInterface["type"];
 }): string | null {
   if (!params.orgHasIncrementalPipelineFeature) {

--- a/packages/shared/src/experiments/experiments.ts
+++ b/packages/shared/src/experiments/experiments.ts
@@ -10,7 +10,10 @@ import {
   NULL_DIMENSION_VALUE,
   NULL_DIMENSION_DISPLAY,
 } from "shared/constants";
-import { MetricInterface } from "shared/types/metric";
+import {
+  MetricDefinitionInterface,
+  MetricInterface,
+} from "shared/types/metric";
 import {
   ColumnRef,
   FactMetricInterface,
@@ -53,6 +56,13 @@ import { stringToBoolean } from "../util";
 
 export type ExperimentMetricInterface = MetricInterface | FactMetricInterface;
 
+// Metrics as returned by the definitions endpoint, where legacy metrics are
+// slimmed (fact metrics are always returned in full). A full
+// ExperimentMetricInterface is assignable to this type.
+export type ExperimentMetricDefinition =
+  | MetricDefinitionInterface
+  | FactMetricInterface;
+
 export type ExperimentSortBy =
   | "significance"
   | "change"
@@ -81,7 +91,7 @@ export function isMetricGroupId(id: string): boolean {
 }
 
 export function isFactMetric(
-  m: ExperimentMetricInterface,
+  m: ExperimentMetricDefinition,
 ): m is FactMetricInterface {
   if (!m || typeof m !== "object") return false;
   return "metricType" in m;
@@ -89,7 +99,11 @@ export function isFactMetric(
 
 export function isLegacyMetric(
   m: ExperimentMetricInterface,
-): m is MetricInterface {
+): m is MetricInterface;
+export function isLegacyMetric(
+  m: ExperimentMetricDefinition,
+): m is MetricDefinitionInterface;
+export function isLegacyMetric(m: ExperimentMetricDefinition): boolean {
   return !isFactMetric(m);
 }
 
@@ -425,30 +439,30 @@ export function getMetricTemplateVariables(
   return m.templateVariables || {};
 }
 
-export function isCappableMetricType(m: ExperimentMetricInterface) {
+export function isCappableMetricType(m: ExperimentMetricDefinition) {
   return !quantileMetricType(m) && !isBinomialMetric(m);
 }
 
-export function isBinomialMetric(m: ExperimentMetricInterface) {
+export function isBinomialMetric(m: ExperimentMetricDefinition) {
   if (isFactMetric(m))
     return ["proportion", "retention"].includes(m.metricType);
   return m.type === "binomial";
 }
 
-export function isRetentionMetric(m: ExperimentMetricInterface) {
+export function isRetentionMetric(m: ExperimentMetricDefinition) {
   return isFactMetric(m) && m.metricType === "retention";
 }
 
 export function isRatioMetric(
-  m: ExperimentMetricInterface,
-  denominatorMetric?: ExperimentMetricInterface,
+  m: ExperimentMetricDefinition,
+  denominatorMetric?: ExperimentMetricDefinition,
 ): boolean {
   if (isFactMetric(m)) return m.metricType === "ratio";
   return !!denominatorMetric && !isBinomialMetric(denominatorMetric);
 }
 
 export function quantileMetricType(
-  m: ExperimentMetricInterface,
+  m: ExperimentMetricDefinition,
 ): "" | MetricQuantileSettings["type"] {
   if (isFactMetric(m) && m.metricType === "quantile") {
     return m.quantileSettings?.type || "";
@@ -457,16 +471,16 @@ export function quantileMetricType(
 }
 
 export function isFunnelMetric(
-  m: ExperimentMetricInterface,
-  denominatorMetric?: ExperimentMetricInterface,
+  m: ExperimentMetricDefinition,
+  denominatorMetric?: ExperimentMetricDefinition,
 ): boolean {
   if (isFactMetric(m)) return false;
   return !!denominatorMetric && isBinomialMetric(denominatorMetric);
 }
 
 export function isRegressionAdjusted(
-  m: ExperimentMetricInterface,
-  denominatorMetric?: ExperimentMetricInterface,
+  m: ExperimentMetricDefinition,
+  denominatorMetric?: ExperimentMetricDefinition,
 ) {
   const isLegacyRatioMetric: boolean =
     isRatioMetric(m, denominatorMetric) && !isFactMetric(m);
@@ -478,7 +492,7 @@ export function isRegressionAdjusted(
   );
 }
 
-export function isPercentileCappedMetric(metric: ExperimentMetricInterface) {
+export function isPercentileCappedMetric(metric: ExperimentMetricDefinition) {
   return (
     metric.cappingSettings.type === "percentile" &&
     !!metric.cappingSettings.value &&
@@ -487,7 +501,7 @@ export function isPercentileCappedMetric(metric: ExperimentMetricInterface) {
   );
 }
 
-function isAbsoluteCappedMetric(metric: ExperimentMetricInterface) {
+function isAbsoluteCappedMetric(metric: ExperimentMetricDefinition) {
   return (
     metric.cappingSettings.type === "absolute" &&
     !!metric.cappingSettings.value &&
@@ -495,11 +509,11 @@ function isAbsoluteCappedMetric(metric: ExperimentMetricInterface) {
   );
 }
 
-export function isSliceMetric(metric: ExperimentMetricInterface) {
+export function isSliceMetric(metric: ExperimentMetricDefinition) {
   return parseSliceMetricId(metric.id).isSliceMetric;
 }
 
-export function eligibleForUncappedMetric(metric: ExperimentMetricInterface) {
+export function eligibleForUncappedMetric(metric: ExperimentMetricDefinition) {
   return (
     (isPercentileCappedMetric(metric) || isAbsoluteCappedMetric(metric)) &&
     !isSliceMetric(metric)
@@ -560,7 +574,7 @@ export function getSelectedColumnDatatype({
 }
 
 export function getUserIdTypes(
-  metric: ExperimentMetricInterface,
+  metric: ExperimentMetricDefinition,
   factTableMap: FactTableMap,
   useDenominator?: boolean,
 ): string[] {
@@ -723,7 +737,9 @@ export function getMetricLink(id: string): string {
   return `/metric/${id}`;
 }
 
-export function getMetricSnapshotSettings<T extends ExperimentMetricInterface>({
+export function getMetricSnapshotSettings<
+  T extends ExperimentMetricDefinition,
+>({
   metric,
   denominatorMetrics,
   experimentRegressionAdjustmentEnabled,
@@ -731,13 +747,13 @@ export function getMetricSnapshotSettings<T extends ExperimentMetricInterface>({
   metricOverrides,
 }: {
   metric: T;
-  denominatorMetrics: MetricInterface[];
+  denominatorMetrics: MetricDefinitionInterface[];
   experimentRegressionAdjustmentEnabled: boolean;
   organizationSettings?: Partial<OrganizationSettings>; // can be RA and prior settings from a snapshot of org settings
   metricOverrides?: MetricOverride[];
 }): {
   newMetric: T;
-  denominatorMetrics: MetricInterface[];
+  denominatorMetrics: MetricDefinitionInterface[];
   metricSnapshotSettings: MetricSnapshotSettings;
 } {
   const newMetric = cloneDeep<T>(metric);
@@ -895,7 +911,7 @@ export function getAllMetricSettingsForSnapshot({
   datasourceType,
   hasRegressionAdjustmentFeature,
 }: {
-  allExperimentMetrics: (ExperimentMetricInterface | null)[];
+  allExperimentMetrics: (ExperimentMetricDefinition | null)[];
   denominatorMetrics: MetricInterface[];
   orgSettings: OrganizationSettings;
   experimentRegressionAdjustmentEnabled?: boolean;
@@ -991,7 +1007,7 @@ export function shouldHighlight({
 export function getMetricSampleSize(
   baseline: SnapshotMetric,
   stats: SnapshotMetric,
-  metric: ExperimentMetricInterface,
+  metric: ExperimentMetricDefinition,
 ): { baselineValue?: number; variationValue?: number } {
   return quantileMetricType(metric)
     ? {
@@ -1004,7 +1020,7 @@ export function getMetricSampleSize(
 export function hasEnoughData(
   baseline: SnapshotMetric,
   stats: SnapshotMetric,
-  metric: ExperimentMetricInterface,
+  metric: ExperimentMetricDefinition,
   metricDefaults: MetricDefaults,
 ): boolean {
   const { baselineValue, variationValue } = getMetricSampleSize(
@@ -1087,7 +1103,7 @@ export function getMetricResultStatus({
   statsEngine,
   differenceType,
 }: {
-  metric: ExperimentMetricInterface;
+  metric: ExperimentMetricDefinition;
   metricDefaults: MetricDefaults;
   baseline: SnapshotMetric;
   stats: SnapshotMetric;
@@ -1308,7 +1324,7 @@ export function getAllExpandedMetricIdsFromExperiment({
     guardrailMetrics?: string[];
     activationMetric?: string | null;
   };
-  expandedMetricMap: Map<string, ExperimentMetricInterface>;
+  expandedMetricMap: Map<string, ExperimentMetricDefinition>;
   includeActivationMetric?: boolean;
   metricGroups?: MetricGroupInterface[];
 }): string[] {
@@ -1353,7 +1369,7 @@ export function createAutoSliceDataForMetric({
   factTable,
   includeOther = true,
 }: {
-  parentMetric: ExperimentMetricInterface | null | undefined;
+  parentMetric: ExperimentMetricDefinition | null | undefined;
   factTable: FactTableInterface | null | undefined;
   includeOther?: boolean;
 }): SliceDataForMetric[] {
@@ -1914,7 +1930,7 @@ export function expandAllSliceMetricsInMap({
   experiment,
   metricGroups = [],
 }: {
-  metricMap: Map<string, ExperimentMetricInterface>;
+  metricMap: Map<string, ExperimentMetricDefinition>;
   factTableMap: FactTableMap;
   experiment: Pick<
     ExperimentInterface,
@@ -1990,7 +2006,7 @@ export function expandAllSliceMetricsInMap({
 
         const sliceString = generateSliceStringFromLevels(sliceLevelsForString);
 
-        const customSliceMetric: ExperimentMetricInterface = {
+        const customSliceMetric: ExperimentMetricDefinition = {
           ...metric,
           id: `${metric.id}?${sliceString}`,
           name: `${metric.name} (${sortedSliceGroups.map((combo) => `${combo.column}: ${combo.levels[0] || ""}`).join(", ")})`,

--- a/packages/shared/src/settings/types.ts
+++ b/packages/shared/src/settings/types.ts
@@ -4,7 +4,7 @@ import {
   AttributionModel,
   ExperimentInterfaceStringDates,
 } from "shared/types/experiment";
-import { MetricInterface } from "shared/types/metric";
+import { MetricDefinitionInterface } from "shared/types/metric";
 import {
   OrganizationSettings,
   NorthStarMetric,
@@ -18,7 +18,7 @@ import { StatsEngine, PValueCorrection } from "shared/types/stats";
 import { ProjectInterface } from "shared/types/project";
 import { ReportInterface } from "shared/types/report";
 import { MetricWindowSettings } from "shared/types/fact-table";
-import { ExperimentMetricInterface } from "../experiments/experiments";
+import { ExperimentMetricDefinition } from "../experiments/experiments";
 
 interface SettingMetadata {
   scopeApplied?: keyof ScopeDefinition | "organization";
@@ -43,8 +43,8 @@ export interface ScopeDefinition {
   project?: ProjectInterface;
   datasource?: DataSourceInterface;
   experiment?: ExperimentInterface | ExperimentInterfaceStringDates;
-  metric?: ExperimentMetricInterface;
-  denominatorMetric?: MetricInterface;
+  metric?: ExperimentMetricDefinition;
+  denominatorMetric?: MetricDefinitionInterface;
   report?: ReportInterface;
 }
 

--- a/packages/shared/types/metric.d.ts
+++ b/packages/shared/types/metric.d.ts
@@ -96,6 +96,18 @@ export interface MetricInterface {
   queryFormat?: "sql" | "builder";
 }
 
+// Slimmed metric returned by the definitions endpoint. Heavy fields are
+// excluded; fetch the full metric by id when they're needed.
+export type MetricDefinitionInterface = Omit<
+  MetricInterface,
+  | "sql"
+  | "templateVariables"
+  | "conditions"
+  | "queries"
+  | "analysis"
+  | "analysisError"
+>;
+
 export type LegacyMetricInterface = Omit<
   MetricInterface,
   "cappingSettings" | "windowSettings" | "priorSettings"

--- a/packages/shared/types/metric.d.ts
+++ b/packages/shared/types/metric.d.ts
@@ -98,9 +98,6 @@ export interface MetricInterface {
 
 // Slimmed metric returned by the definitions endpoint. Heavy fields are
 // excluded; fetch the full metric by id when they're needed.
-// NOTE: omitting the required `queries` field is what makes this type
-// non-assignable to MetricInterface (the other omitted fields are optional).
-// If `queries` ever becomes optional, that compile-time guard disappears.
 export type MetricDefinitionInterface = Omit<
   MetricInterface,
   | "sql"

--- a/packages/shared/types/metric.d.ts
+++ b/packages/shared/types/metric.d.ts
@@ -98,6 +98,9 @@ export interface MetricInterface {
 
 // Slimmed metric returned by the definitions endpoint. Heavy fields are
 // excluded; fetch the full metric by id when they're needed.
+// NOTE: omitting the required `queries` field is what makes this type
+// non-assignable to MetricInterface (the other omitted fields are optional).
+// If `queries` ever becomes optional, that compile-time guard disappears.
 export type MetricDefinitionInterface = Omit<
   MetricInterface,
   | "sql"


### PR DESCRIPTION
### Features and Changes

`GET /organization/definitions` returned full legacy metric documents, including `sql`, `templateVariables`, `conditions`, `queries`, `analysis`, and `analysisError` — none of which the definitions consumers read. For orgs with many metrics this is a large share of the endpoint's payload (and of its Mongo read + serialization time). Follows the same pattern as saved groups (`getAllWithoutValues`) and constants.

- **Back-end**: new `getMetricsForDefinitions` in `MetricModel` excludes the fields via a DB projection (`lodash/omit` for the config.yml branch, where projections can't apply). `getMetricsByOrganization`/`getMetricMap` are untouched, so experiment analysis still sees full metrics. New shared type `MetricDefinitionInterface` (`Omit` of the dropped fields).
- **Front-end types**: `DefinitionsContext` metrics are now `MetricDefinitionInterface`, and `getExperimentMetricById` returns the new `ExperimentMetricDefinition` union. Shared utils and component props that never read the dropped fields were loosened to the slim types — no runtime changes, and a full metric remains assignable everywhere.
- **Edit/duplicate guard**: `MetricModal` now fetches the full metric via `GET /metric/:id` before seeding `MetricForm`. Previously it seeded from the context metric, so without this the slimmed payload would have silently wiped `sql` on save.
- **config.yml export/import**: `BackupConfigYamlButton`/`RestoreConfigYamlButton` fetch full metrics from the existing (previously FE-unused) `GET /metrics` endpoint so the exported YAML keeps metric SQL.

### Testing

- [x] Jest tests for `getMetricsForDefinitions`: heavy fields absent from DB and config.yml reads, org scoping, doc migration still applied
- [x] Type-check passes across shared/back-end/front-end (the compiler enumerates every consumer of the dropped fields)
- [ ] Edit + duplicate a metric from the `/metrics` list and from a datasource page → SQL/conditions preserved after save
- [ ] Export config.yml → metric definitions still include `sql`
