### PR TITLE
Perf: parallelize GET /organization and stop re-fetching installation metadata

### DIFF
--- a/packages/back-end/src/models/InstallationModel.ts
+++ b/packages/back-end/src/models/InstallationModel.ts
@@ -35,6 +35,24 @@ export async function getInstallation(): Promise<InstallationInterface> {
   }
 }
 
+// The installation doc is a singleton and rarely changes, so cache it for
+// hot paths (TTL covers renames made by other instances)
+const INSTALLATION_CACHE_TTL = 15 * 60 * 1000;
+let installationCache: {
+  installation: InstallationInterface;
+  expires: number;
+} | null = null;
+
+export async function getInstallationCached(): Promise<InstallationInterface> {
+  if (!installationCache || installationCache.expires < Date.now()) {
+    installationCache = {
+      installation: await getInstallation(),
+      expires: Date.now() + INSTALLATION_CACHE_TTL,
+    };
+  }
+  return installationCache.installation;
+}
+
 export async function setInstallationName(name: string): Promise<void> {
   const installation = await InstallationModel.findOne({});
   if (installation) {
@@ -44,4 +62,5 @@ export async function setInstallationName(name: string): Promise<void> {
     const installationId = `installation-${randomUUID()}`;
     await InstallationModel.create({ id: installationId, name });
   }
+  installationCache = null;
 }

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -136,6 +136,7 @@ import {
 import { getAllFactTablesForOrganization } from "back-end/src/models/FactTableModel";
 import { fireSdkWebhook } from "back-end/src/jobs/sdkWebhooks";
 import {
+  getInstallationName,
   getLicenseMetaData,
   getUserCodesForOrg,
 } from "back-end/src/services/licenseData";
@@ -881,22 +882,36 @@ export async function getOrganization(
     isVercelIntegration,
   } = org;
 
-  let license: Partial<LicenseInterface> | null = null;
-  if (licenseKey || process.env.LICENSE_KEY) {
-    // automatically set the license data based on org license key
-    license = getLicense(licenseKey || process.env.LICENSE_KEY);
-    if (!license || (license.organizationId && license.organizationId !== id)) {
-      try {
-        license =
-          (await licenseInit(org, getUserCodesForOrg, getLicenseMetaData)) ||
-          null;
-      } catch (e) {
-        logger.error(e, "setting license failed");
+  const resolveLicense =
+    async (): Promise<Partial<LicenseInterface> | null> => {
+      if (!licenseKey && !process.env.LICENSE_KEY) return null;
+      // automatically set the license data based on org license key
+      let license: Partial<LicenseInterface> | null =
+        getLicense(licenseKey || process.env.LICENSE_KEY) || null;
+      if (
+        !license ||
+        (license.organizationId && license.organizationId !== id)
+      ) {
+        try {
+          license =
+            (await licenseInit(org, getUserCodesForOrg, getLicenseMetaData)) ||
+            null;
+        } catch (e) {
+          logger.error(e, "setting license failed");
+        }
       }
-    }
-  }
+      return license;
+    };
 
-  const installationName = (await getLicenseMetaData())?.installationName;
+  // These lookups don't depend on each other, so run them in parallel
+  const [license, installationName, expandedMembers, agreements, watch] =
+    await Promise.all([
+      resolveLicense(),
+      getInstallationName(org),
+      expandOrgMembers(members, userId),
+      context.models.agreements.getAll(),
+      context.models.watch.getWatchedByUser(userId),
+    ]);
 
   const filteredAttributes = settings?.attributeSchema?.filter((attribute) =>
     context.permissions.canReadMultiProjectResource(attribute.projects),
@@ -918,9 +933,8 @@ export async function getOrganization(
     ? getSSOConnectionSummary(req.loginMethod)
     : null;
 
-  const expandedMembers = await expandOrgMembers(members, userId);
-
-  const teams = await context.models.teams.getAll();
+  // Teams were already loaded (unfiltered) by the auth middleware
+  const teams = context.teams;
 
   const teamsWithMembers: TeamInterface[] = teams.map((team) => {
     const memberIds = getMembersOfTeam(org, team.id);
@@ -935,23 +949,21 @@ export async function getOrganization(
     org,
     teams || [],
   );
-  const agreements = await context.models.agreements.getAll();
   const agreementsAgreed = Array.from(
     new Set(agreements.map((a) => a.agreement as AgreementType)),
   );
   const seatsInUse = getNumberOfUniqueMembersAndInvites(org);
 
-  const watch = await context.models.watch.getWatchedByUser(userId);
-
   const commercialFeatureLowestPlan = getLowestPlanPerFeature(accountFeatures);
+  const effectiveAccountPlan = getEffectiveAccountPlan(org);
 
   return res.status(200).json({
     status: 200,
     enterpriseSSO,
     accountPlan: getAccountPlan(org),
-    effectiveAccountPlan: getEffectiveAccountPlan(org),
+    effectiveAccountPlan,
     licenseError: getLicenseError(org),
-    commercialFeatures: [...accountFeatures[getEffectiveAccountPlan(org)]],
+    commercialFeatures: [...accountFeatures[effectiveAccountPlan]],
     commercialFeatureLowestPlan: commercialFeatureLowestPlan,
     roles: getRoles(org),
     members: expandedMembers,

--- a/packages/back-end/src/services/licenseData.ts
+++ b/packages/back-end/src/services/licenseData.ts
@@ -2,10 +2,17 @@ import path from "path";
 import fs from "fs";
 import md5 from "md5";
 import { LicenseUserCodes } from "shared/enterprise";
-import { MemberRole, OrgMemberInfo } from "shared/types/organization";
+import {
+  MemberRole,
+  OrgMemberInfo,
+  OrganizationInterface,
+} from "shared/types/organization";
 import { TeamInterface } from "shared/types/team";
 import { findAllSDKConnectionsAcrossAllOrgs } from "back-end/src/models/SdkConnectionModel";
-import { getInstallation } from "back-end/src/models/InstallationModel";
+import {
+  getInstallation,
+  getInstallationCached,
+} from "back-end/src/models/InstallationModel";
 import { IS_CLOUD, IS_MULTI_ORG } from "back-end/src/util/secrets";
 import { getInstallationDatasources } from "back-end/src/models/DataSourceModel";
 import {
@@ -84,6 +91,25 @@ export async function getLicenseMetaData() {
     eventTrackers: eventTrackers,
     isCloud: IS_CLOUD,
   };
+}
+
+// Cheaper alternative to getLicenseMetaData() for per-request use: resolves
+// only the installation name, using the cached installation doc and the
+// caller's org (single-org self-hosted uses the org name) to avoid DB lookups
+export async function getInstallationName(
+  org: OrganizationInterface,
+): Promise<string> {
+  if (IS_CLOUD) return "cloud";
+  try {
+    const installation = await getInstallationCached();
+    if (IS_MULTI_ORG) {
+      return installation.name || installation.id;
+    }
+    return org.name || installation.id;
+  } catch (e) {
+    logger.error("Error getting installation name: " + e.message);
+    return "unknown";
+  }
 }
 
 function isReadOnlyRole(role: MemberRole): boolean {


### PR DESCRIPTION
### Features and Changes

`GET /organization` (~442ms avg for a large customer) awaited ~6 mutually independent operations strictly sequentially: license resolution, installation metadata, member expansion, teams, agreements, and the user's watch list. They now run in one `Promise.all`, collapsing the serial round trips into a single max-latency wait.

Two of the operations also got cheaper. The teams query was an identical second fetch of what the auth middleware already loads (`TeamModel.canRead` is unconditionally `true`, so `getAll()` applies no filtering) — the handler now reuses `context.teams`. And the per-request `getLicenseMetaData()` call — which on Cloud did an uncached installation `findOne` only to answer `"cloud"`, and on self-hosted additionally ran cross-org SDK-connection and datasource scans — is replaced by a new `getInstallationName()` that short-circuits on Cloud and otherwise uses a 15-min-cached installation doc (invalidated by `setInstallationName`) plus the org already in hand.

The response shape is unchanged; this is latency-only.

### Testing

- [x] Back-end type-check + license test suite pass
- [x] Diff a captured `GET /organization` response before/after — should be byte-identical (modulo usage/date fields)
