### PR TITLE
Re-enable managed warehouse migration with async recreate

### DIFF
--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -2045,7 +2045,15 @@ export async function postRecreateManagedWarehouse(
     );
   }
 
-  await dangerousRecreateClickhouseTables(context.org.id);
+  const result = await dangerousRecreateClickhouseTables(context.org.id);
+  if (result === "already-running") {
+    res.status(409).json({
+      status: 409,
+      message:
+        "A recreate is already in progress for this Managed Warehouse. Please wait for it to finish before triggering another.",
+    });
+    return;
+  }
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/integrations/ClickHouse.ts
+++ b/packages/back-end/src/integrations/ClickHouse.ts
@@ -8,14 +8,14 @@ import {
 } from "shared/types/integrations";
 import { ClickHouseConnectionParams } from "shared/types/integrations/clickhouse";
 import {
-  // isManagedWarehouseAwaitingJsonMigration,
+  isManagedWarehouseAwaitingJsonMigration,
   isManagedWarehouseAwaitingProvisioning,
   isManagedWarehouseMigrating,
   ManagedWarehousePendingError,
 } from "shared/util";
 import { SqlDialect } from "shared/types/sql";
 import { decryptDataSourceParams } from "back-end/src/services/datasource";
-// import { queueMigrateManagedWarehouse } from "back-end/src/jobs/migrateManagedWarehouse";
+import { queueMigrateManagedWarehouse } from "back-end/src/jobs/migrateManagedWarehouse";
 import { getHost } from "back-end/src/util/sql";
 import { logger } from "back-end/src/util/logger";
 import SqlIntegration from "./SqlIntegration";
@@ -58,15 +58,15 @@ export default class ClickHouse extends SqlIntegration {
     // Runs before the guards below so a warehouse left mid-migration (pending +
     // matcols still present) OR stuck fully-migrated-but-still-`migrating` (the
     // flag clear failed) can re-trigger and recover itself on next use.
-    // if (
-    //   isManagedWarehouseAwaitingJsonMigration(this.datasource) ||
-    //   isManagedWarehouseMigrating(this.datasource)
-    // ) {
-    //   void queueMigrateManagedWarehouse(this.datasource.organization).catch(
-    //     (e) =>
-    //       logger.error(e, "Failed to queue managed warehouse JSON migration"),
-    //   );
-    // }
+    if (
+      isManagedWarehouseAwaitingJsonMigration(this.datasource) ||
+      isManagedWarehouseMigrating(this.datasource)
+    ) {
+      void queueMigrateManagedWarehouse(this.datasource.organization).catch(
+        (e) =>
+          logger.error(e, "Failed to queue managed warehouse JSON migration"),
+      );
+    }
     // Block queries while never-provisioned OR mid-migration (tables being recreated).
     // Reuse the pending error so existing UI surfaces show the managed-warehouse callout;
     // the callout distinguishes the migrating case for honest "upgrading" copy.

--- a/packages/back-end/src/jobs/migrateManagedWarehouse.ts
+++ b/packages/back-end/src/jobs/migrateManagedWarehouse.ts
@@ -1,6 +1,7 @@
 import Agenda, { Job } from "agenda";
 import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizations";
 import { migrateManagedWarehouseToJson } from "back-end/src/services/clickhouse";
+import { getBackendFeatureValue } from "back-end/src/services/growthbook";
 import { logger } from "back-end/src/util/logger";
 
 const MIGRATE_MANAGED_WAREHOUSE = "migrateManagedWarehouse";
@@ -38,6 +39,14 @@ export async function queueMigrateManagedWarehouse(organization: string) {
 const migrateManagedWarehouse = async (job: MigrateManagedWarehouseJob) => {
   const orgId = job.attrs.data?.organization;
   if (!orgId) return;
+
+  if (
+    !getBackendFeatureValue("managed-warehouse-json-migration", false, {
+      organizationId: orgId,
+    })
+  ) {
+    return;
+  }
 
   const context = await getContextForAgendaJobByOrgId(orgId);
   try {

--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -30,6 +30,7 @@ import {
   getConfigDatasources,
 } from "back-end/src/init/config";
 import { upgradeDatasourceObject } from "back-end/src/util/migrations";
+import { getCollection } from "back-end/src/util/mongo.util";
 import { queueCreateInformationSchema } from "back-end/src/jobs/createInformationSchema";
 import { IS_CLOUD } from "back-end/src/util/secrets";
 import { ReqContext } from "back-end/types/request";
@@ -161,6 +162,32 @@ export async function dangerouslyGetGrowthbookDatasourceBypassPermission(
     organization: context.org.id,
   });
   return doc ? toInterface(doc) : null;
+}
+
+/**
+ * Read the managed-warehouse recreate coordination fields the license server
+ * writes to the shared datasource doc: `lockUntil` (a rebuild is in progress) and
+ * `recreateStatus` (its outcome). Both live top-level (outside `settings`, which
+ * GrowthBook rewrites), so they aren't on the Mongoose schema — read them raw.
+ */
+export async function getManagedWarehouseRecreateState(
+  id: string,
+  organization: string,
+): Promise<{ locked: boolean; recreateStatus: "success" | "error" | null }> {
+  const doc = await getCollection<{
+    lockUntil?: Date | string | number | null;
+    recreateStatus?: { status?: string } | null;
+  }>("datasources").findOne(
+    { id, organization },
+    { projection: { lockUntil: 1, recreateStatus: 1 } },
+  );
+  const lockUntil = doc?.lockUntil ? new Date(doc.lockUntil) : null;
+  const locked = lockUntil !== null && lockUntil.getTime() > Date.now();
+  const status = doc?.recreateStatus?.status;
+  return {
+    locked,
+    recreateStatus: status === "success" || status === "error" ? status : null,
+  };
 }
 
 export async function getDataSourceById(

--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -189,6 +189,21 @@ export async function getManagedWarehouseRecreateState(
   };
 }
 
+/**
+ * Clear the license-server recreate outcome at the start of a migration so a stale
+ * `recreateStatus` from an earlier rebuild (e.g. a prior super-admin recreate) can't
+ * be misread as the current migration's result. Raw `$unset` since `recreateStatus`
+ * is a top-level field the license server owns, not on the Mongoose schema.
+ */
+export async function clearManagedWarehouseRecreateStatus(
+  context: ReqContext | ApiReqContext,
+): Promise<void> {
+  await getCollection<{ recreateStatus?: unknown }>("datasources").updateOne(
+    { organization: context.org.id, type: "growthbook_clickhouse" },
+    { $unset: { recreateStatus: "" } },
+  );
+}
+
 export async function getDataSourceById(
   context: ReqContext | ApiReqContext,
   id: string,

--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -171,14 +171,13 @@ export async function dangerouslyGetGrowthbookDatasourceBypassPermission(
  * GrowthBook rewrites), so they aren't on the Mongoose schema — read them raw.
  */
 export async function getManagedWarehouseRecreateState(
-  id: string,
-  organization: string,
+  context: ReqContext | ApiReqContext,
 ): Promise<{ locked: boolean; recreateStatus: "success" | "error" | null }> {
   const doc = await getCollection<{
     lockUntil?: Date | string | number | null;
     recreateStatus?: { status?: string } | null;
   }>("datasources").findOne(
-    { id, organization },
+    { organization: context.org.id, type: "growthbook_clickhouse" },
     { projection: { lockUntil: 1, recreateStatus: 1 } },
   );
   const lockUntil = doc?.lockUntil ? new Date(doc.lockUntil) : null;

--- a/packages/back-end/src/services/clickhouse.ts
+++ b/packages/back-end/src/services/clickhouse.ts
@@ -597,10 +597,8 @@ export async function migrateManagedWarehouseToJson(
     return;
   }
 
-  const { locked, recreateStatus } = await getManagedWarehouseRecreateState(
-    datasource.id,
-    datasource.organization,
-  );
+  const { locked, recreateStatus } =
+    await getManagedWarehouseRecreateState(context);
 
   // A rebuild is running on the license server (ours or another operation's). It
   // holds the lock for its duration, so wait rather than re-request — the sweep /

--- a/packages/back-end/src/services/clickhouse.ts
+++ b/packages/back-end/src/services/clickhouse.ts
@@ -36,16 +36,14 @@ import {
 import {
   getGrowthbookDatasource,
   dangerouslyGetGrowthbookDatasourceBypassPermission,
+  getManagedWarehouseRecreateState,
   updateDataSource,
 } from "back-end/src/models/DataSourceModel";
 import {
   dangerousRecreateClickhouseTables,
   updateMaterializedColumnsInClickhouse,
 } from "back-end/src/services/licenseServerManagedClickhouse";
-import {
-  getMigratedDimensionColumns,
-  resolveMigrationFinalState,
-} from "back-end/src/util/migrateManagedWarehouseColumns";
+import { getMigratedDimensionColumns } from "back-end/src/util/migrateManagedWarehouseColumns";
 import { getSourceIntegrationObject } from "back-end/src/services/datasource";
 import SqlIntegration from "back-end/src/integrations/SqlIntegration";
 import { logger } from "back-end/src/util/logger";
@@ -552,10 +550,31 @@ export async function syncManagedWarehouseIdentifiersOnAttributeChange(
   }
 }
 
+// Kick off the async table rebuild. The license server acks and rebuilds in the
+// background, so this doesn't wait for the tables — a later run finalizes once the
+// rebuild's lock frees (see migrateManagedWarehouseToJson).
+async function fireManagedWarehouseRecreate(
+  organization: string,
+): Promise<void> {
+  const result = await dangerousRecreateClickhouseTables(organization);
+  if (result === "already-running") {
+    // The lock was taken between our read and this call; the in-progress rebuild
+    // will record its own outcome, so just wait for it.
+    logger.info(
+      `Managed warehouse migration for org ${organization}: recreate already in progress; waiting`,
+    );
+  }
+}
+
 // Migrate a legacy (materialized-column) managed warehouse to native JSON columns.
-// Idempotent + resumable: no-ops once `useJsonColumns` is set and `materializedColumns`
-// is cleared, and a crash mid-migration leaves a re-runnable state. Triggered lazily
-// on first use of a legacy warehouse (see the runQuery hook + migrateManagedWarehouse job).
+// Recreate now acks and rebuilds the per-org tables in the background under a
+// datasource lock (holding the connection open for the whole rebuild 504'd behind the
+// proxy), so this is idempotent + resumable and re-driven by the sweep / next query
+// until it settles: it prepares metadata and fires the rebuild, then finalizes on
+// success or retries on failure once the lock frees — reading `lockUntil` (rebuild in
+// progress) and `recreateStatus` (its outcome) via getManagedWarehouseRecreateState.
+// A crash at any step leaves a re-runnable state, and `migrating` blocks queries
+// throughout so nothing hits the tables mid-rebuild.
 export async function migrateManagedWarehouseToJson(
   context: ReqContext | ApiReqContext,
 ): Promise<void> {
@@ -565,32 +584,53 @@ export async function migrateManagedWarehouseToJson(
     return;
   }
 
-  // Recovery: a fully-migrated warehouse still flagged `migrating` (e.g. the
-  // finally-block flag clear failed after a successful run) is stuck — queries
-  // block but nothing re-derives migration work. Clear the flag and return.
-  if (
-    isManagedWarehouseMigrating(datasource) &&
-    !isManagedWarehouseAwaitingJsonMigration(datasource)
-  ) {
-    await updateDataSource(
-      context,
-      datasource,
-      { settings: { ...datasource.settings, migrating: false } },
-      { skipExposureQueryValidation: true },
-    );
+  // Defer until provisioned: recreating tables for a never-provisioned org would
+  // race the normal provisioning flow (and spam Sentry).
+  if (isManagedWarehouseAwaitingProvisioning(datasource)) {
     return;
   }
 
-  if (
-    !isManagedWarehouseAwaitingJsonMigration(datasource) ||
-    // Defer until provisioned: recreating tables for a never-provisioned org would
-    // race the normal provisioning flow (and spam Sentry). The runQuery enqueue runs
-    // before its guard, so a genuinely stuck mid-migration warehouse still recovers.
-    isManagedWarehouseAwaitingProvisioning(datasource)
-  ) {
+  const migrating = isManagedWarehouseMigrating(datasource);
+  const awaiting = isManagedWarehouseAwaitingJsonMigration(datasource);
+  // Fully migrated and settled — nothing to do.
+  if (!migrating && !awaiting) {
     return;
   }
 
+  const { locked, recreateStatus } = await getManagedWarehouseRecreateState(
+    datasource.id,
+    datasource.organization,
+  );
+
+  // A rebuild is running on the license server (ours or another operation's). It
+  // holds the lock for its duration, so wait rather than re-request — the sweep /
+  // next query re-drives this once the lock frees.
+  if (locked) {
+    return;
+  }
+
+  // We already prepared the migration (materializedColumns cleared) and the rebuild
+  // we fired is no longer running — settle based on its recorded outcome.
+  if (migrating && !awaiting) {
+    if (recreateStatus === "success") {
+      // Tables were rebuilt as JSON and the fact table was synced before we fired the
+      // rebuild, so unblocking queries now is safe.
+      await updateDataSource(
+        context,
+        datasource,
+        { settings: { ...datasource.settings, migrating: false } },
+        { skipExposureQueryValidation: true },
+      );
+      return;
+    }
+    // "error", or missing (rebuild crashed before recording its outcome, or we
+    // crashed before firing it): retry. The rebuild is idempotent and matcols stay
+    // cleared (JSON tables ignore them), so re-firing rebuilds the JSON tables cleanly.
+    await fireManagedWarehouseRecreate(datasource.organization);
+    return;
+  }
+
+  // awaiting === true: (re)start the migration.
   const matColumns = datasource.settings.materializedColumns || [];
   const attributeSchema = context.org.settings?.attributeSchema;
 
@@ -615,10 +655,10 @@ export async function migrateManagedWarehouseToJson(
   );
 
   // Enter the transient "migrating" state (still provisioned) so in-flight usage
-  // degrades to "warehouse upgrading" instead of hitting tables mid-recreate, and flip
+  // degrades to "warehouse upgrading" instead of hitting tables mid-rebuild, and flip
   // the flag (the license server reads `useJsonColumns` to pick the JSON DDL). Record the
   // preserved identifiers + dimensions up front so the sync (below) aliases them. Keep
-  // `materializedColumns` until the end so a crash before the final clear is re-runnable.
+  // `materializedColumns` for now so a crash before we clear them re-runs this branch.
   await updateDataSource(
     context,
     datasource,
@@ -636,69 +676,34 @@ export async function migrateManagedWarehouseToJson(
     { skipExposureQueryValidation: true },
   );
 
-  let recreated = false;
-  try {
-    // Recreate the per-org ClickHouse tables as JSON and repopulate from enriched_events.
-    await dangerousRecreateClickhouseTables(datasource.organization);
-    recreated = true;
-    // Regenerate the ch_events fact table + datasource userIdTypes/exposure queries.
-    // The sync re-exposes the preserved identifiers and dimensions as top-level aliases
-    // (from migratedIdentifiers/migratedColumns), so existing metric refs keep resolving
-    // against real columns — no metric rewrite needed.
-    await syncManagedWarehouseIdentifiers(context);
-    // Clear materializedColumns (re-fetch: sync mutated the datasource settings).
-    const updated =
-      await dangerouslyGetGrowthbookDatasourceBypassPermission(context);
-    if (updated && updated.type === "growthbook_clickhouse") {
-      await updateDataSource(
-        context,
-        updated,
-        {
-          settings: { ...updated.settings, materializedColumns: undefined },
-        },
-        { skipExposureQueryValidation: true },
-      );
-    } else {
-      // Couldn't re-fetch the warehouse to clear materializedColumns: it stays
-      // awaiting-migration and will re-trigger on next use. Log so the (rare)
-      // re-trigger loop is visible rather than silent.
-      logger.error(
-        `Managed warehouse migration for org ${datasource.organization}: could not re-fetch datasource to clear materializedColumns; migration will re-trigger on next use`,
-      );
-    }
-  } finally {
-    const finalDs =
-      await dangerouslyGetGrowthbookDatasourceBypassPermission(context);
-    if (
-      finalDs &&
-      finalDs.type === "growthbook_clickhouse" &&
-      finalDs.settings.migrating
-    ) {
-      // Compute the settle state from whether recreate ran and whether the run finished
-      // (see resolveMigrationFinalState). null = stay blocked: the tables are JSON but
-      // metric refs aren't rewritten yet, so queries must keep blocking until the
-      // re-triggered run finishes (else they'd hit "Unknown identifier").
-      const patch = resolveMigrationFinalState({
-        recreated,
-        stillAwaiting: isManagedWarehouseAwaitingJsonMigration(finalDs),
-      });
-      if (patch) {
-        try {
-          await updateDataSource(
-            context,
-            finalDs,
-            { settings: { ...finalDs.settings, ...patch } },
-            { skipExposureQueryValidation: true },
-          );
-        } catch (e) {
-          // Leaves the warehouse stuck `migrating: true`; the recovery branch on the
-          // next run (re-triggered by runQuery's enqueue) clears it without manual help.
-          logger.error(
-            e,
-            `Managed warehouse migration for org ${finalDs.organization}: failed to clear migrating flag; will self-heal on next use`,
-          );
-        }
-      }
-    }
+  // Regenerate the ch_events fact table + datasource userIdTypes/exposure queries.
+  // Mongo-only (queries stay blocked by `migrating`), and re-exposes the preserved
+  // identifiers/dimensions as top-level aliases so existing metric refs keep resolving —
+  // no metric rewrite needed. Must finish before we fire the rebuild, so that when a
+  // later run unblocks queries on success, the fact table already matches the tables.
+  await syncManagedWarehouseIdentifiers(context);
+
+  // Clear materializedColumns (re-fetch: sync mutated the datasource settings). Only once
+  // this is persisted is the warehouse structurally migrated; the rebuild we fire next
+  // produces the physical JSON tables.
+  const synced =
+    await dangerouslyGetGrowthbookDatasourceBypassPermission(context);
+  if (!synced || synced.type !== "growthbook_clickhouse") {
+    // Couldn't re-fetch to clear materializedColumns: it stays awaiting-migration and
+    // re-runs this branch on next use. Log so the (rare) re-trigger loop is visible.
+    logger.error(
+      `Managed warehouse migration for org ${datasource.organization}: could not re-fetch datasource after sync; migration will re-trigger on next use`,
+    );
+    return;
   }
+  await updateDataSource(
+    context,
+    synced,
+    { settings: { ...synced.settings, materializedColumns: undefined } },
+    { skipExposureQueryValidation: true },
+  );
+
+  // Fire the async rebuild last: the license server acks and rebuilds in the background,
+  // recording the outcome. A later run finalizes (unblocks) once the lock frees.
+  await fireManagedWarehouseRecreate(datasource.organization);
 }

--- a/packages/back-end/src/services/clickhouse.ts
+++ b/packages/back-end/src/services/clickhouse.ts
@@ -36,6 +36,7 @@ import {
 import {
   getGrowthbookDatasource,
   dangerouslyGetGrowthbookDatasourceBypassPermission,
+  clearManagedWarehouseRecreateStatus,
   getManagedWarehouseRecreateState,
   updateDataSource,
 } from "back-end/src/models/DataSourceModel";
@@ -694,6 +695,11 @@ export async function migrateManagedWarehouseToJson(
     );
     return;
   }
+  // Forget any prior rebuild outcome BEFORE clearing materializedColumns, so once the
+  // warehouse is structurally migrated (matcols cleared) the settle branch can't read a
+  // stale `recreateStatus="success"` from an earlier recreate and unblock over the wrong
+  // tables. The rebuild we fire below records this migration's fresh outcome.
+  await clearManagedWarehouseRecreateStatus(context);
   await updateDataSource(
     context,
     synced,

--- a/packages/back-end/src/services/growthbook.ts
+++ b/packages/back-end/src/services/growthbook.ts
@@ -210,6 +210,26 @@ export async function initializeGrowthBookClient(): Promise<void> {
 }
 
 /**
+ * Evaluate a backend AppFeatures flag using the global singleton client.
+ * Usable anywhere (jobs, services) — unlike req.gb, which only exists on
+ * authenticated routes. Returns `fallback` when the client or flag isn't
+ * loaded, so callers keep safe default behavior during a CDN blip.
+ */
+export function getBackendFeatureValue<K extends string & keyof AppFeatures>(
+  key: K,
+  fallback: AppFeatures[K],
+  attributes: Record<string, unknown> = {},
+): AppFeatures[K] {
+  const client = getGrowthBookClient();
+  if (!client) return fallback;
+  // getFeatureValue widens primitives (e.g. boolean literals); narrow back to
+  // the flag's declared type, which is sound for all AppFeatures value types.
+  return client.getFeatureValue(key, fallback, {
+    attributes,
+  }) as AppFeatures[K];
+}
+
+/**
  * Cleanup the GrowthBook client on shutdown
  * Call this during graceful shutdown to close SSE connections
  */

--- a/packages/back-end/src/services/licenseServerManagedClickhouse.ts
+++ b/packages/back-end/src/services/licenseServerManagedClickhouse.ts
@@ -40,6 +40,7 @@ function errorDetailForLog(text: string, status: number): string {
 async function postManagedClickhouse(
   path: string,
   body: unknown,
+  { allowStatuses = [] }: { allowStatuses?: number[] } = {},
 ): Promise<Response> {
   if (!CLOUD_SECRET) {
     throw new Error(
@@ -90,7 +91,7 @@ async function postManagedClickhouse(
     clearTimeout(timeoutId);
   }
 
-  if (!res.ok) {
+  if (!res.ok && !allowStatuses.includes(res.status)) {
     const rawBody = await res.text();
     const contentType = res.headers.get("content-type") ?? "";
     const detail = errorDetailForLog(rawBody, res.status);
@@ -138,10 +139,21 @@ async function postManagedClickhouseJson<T>(
   }
 }
 
+/**
+ * Kick off an async table rebuild on the license server. The server acks (202)
+ * and rebuilds in the background under a datasource lock, so this returns as soon
+ * as the rebuild is accepted — not when it finishes. A 423 means a rebuild is
+ * already running for this org, so the caller should wait rather than re-request.
+ */
 export async function dangerousRecreateClickhouseTables(
   orgId: string,
-): Promise<void> {
-  await postManagedClickhouse("recreate-tables", { orgId });
+): Promise<"started" | "already-running"> {
+  const res = await postManagedClickhouse(
+    "recreate-tables",
+    { orgId },
+    { allowStatuses: [423] },
+  );
+  return res.status === 423 ? "already-running" : "started";
 }
 
 export async function deleteClickhouseUser(orgId: string): Promise<void> {

--- a/packages/back-end/src/util/migrateManagedWarehouseColumns.ts
+++ b/packages/back-end/src/util/migrateManagedWarehouseColumns.ts
@@ -21,30 +21,3 @@ export function getMigratedDimensionColumns(
       !reservedColumnNames.has(col.columnName.toLowerCase()),
   );
 }
-
-/**
- * Settings patch to leave behind once a migration run settles, given whether the per-org
- * tables were recreated as JSON (`recreated`) and whether the warehouse is still awaiting
- * migration afterward (`stillAwaiting` — `materializedColumns` not yet cleared, i.e. the
- * run didn't finish). Returns `null` to stay in the `migrating` state.
- *
- *   recreated │ stillAwaiting │ result
- *   ──────────┼───────────────┼──────────────────────────────────────────────────────
- *    true     │ false         │ { migrating: false }       full success → unblock
- *    true     │ true          │ null                       tables JSON but rewrite
- *             │               │                            unfinished → keep blocked so
- *             │               │                            the next query re-triggers
- *             │               │                            (queries would otherwise hit
- *             │               │                            "Unknown identifier")
- *    false    │ (any)         │ { migrating: false,        recreate never ran; tables
- *             │               │   useJsonColumns: false }   still legacy → revert the flag
- */
-export function resolveMigrationFinalState(opts: {
-  recreated: boolean;
-  stillAwaiting: boolean;
-}): { migrating: false; useJsonColumns?: false } | null {
-  if (opts.recreated) {
-    return opts.stillAwaiting ? null : { migrating: false };
-  }
-  return { migrating: false, useJsonColumns: false };
-}

--- a/packages/back-end/test/util/migrateManagedWarehouseColumns.test.ts
+++ b/packages/back-end/test/util/migrateManagedWarehouseColumns.test.ts
@@ -1,9 +1,6 @@
 import { MaterializedColumn } from "shared/types/datasource";
 import { FactTableColumnType } from "shared/types/fact-table";
-import {
-  getMigratedDimensionColumns,
-  resolveMigrationFinalState,
-} from "back-end/src/util/migrateManagedWarehouseColumns";
+import { getMigratedDimensionColumns } from "back-end/src/util/migrateManagedWarehouseColumns";
 
 const reserved = new Set(["geo_country", "url_path", "device_id"]);
 
@@ -52,30 +49,5 @@ describe("getMigratedDimensionColumns", () => {
   it("matches reserved names case-insensitively", () => {
     const cols = [matCol("Geo_Country", "Geo_Country", "dimension")];
     expect(getMigratedDimensionColumns(cols, reserved)).toEqual([]);
-  });
-});
-
-describe("resolveMigrationFinalState", () => {
-  it("full success (recreated, not still awaiting): clears migrating only", () => {
-    expect(
-      resolveMigrationFinalState({ recreated: true, stillAwaiting: false }),
-    ).toEqual({ migrating: false });
-  });
-
-  it("recreated but unfinished (still awaiting): stays blocked (null)", () => {
-    expect(
-      resolveMigrationFinalState({ recreated: true, stillAwaiting: true }),
-    ).toBeNull();
-  });
-
-  it("recreate never ran: clears migrating AND reverts useJsonColumns", () => {
-    expect(
-      resolveMigrationFinalState({ recreated: false, stillAwaiting: true }),
-    ).toEqual({ migrating: false, useJsonColumns: false });
-    // stillAwaiting can't actually be false when recreate didn't run, but the result
-    // is still the safe legacy-consistent state.
-    expect(
-      resolveMigrationFinalState({ recreated: false, stillAwaiting: false }),
-    ).toEqual({ migrating: false, useJsonColumns: false });
   });
 });

--- a/packages/shared/types/app-features.ts
+++ b/packages/shared/types/app-features.ts
@@ -118,6 +118,7 @@ export type AppFeatures = {
   "events-forwarder": boolean;
   "enable-error-tracking": boolean;
   "managed-warehouse-diagnostics": boolean;
+  "managed-warehouse-json-migration": boolean;
   "session-replays": boolean;
   "login-page-content": Record<string, unknown>;
   "slackbot-enabled": boolean;


### PR DESCRIPTION
### Features and Changes

#6317 disabled the managed-warehouse JSON-columns migration because the license-server `recreate-tables` call held the connection open for the whole rebuild and 504'd. The license server now acks and rebuilds in the background, so this re-enables the migration and adapts it to that async pattern.

- **Re-enable the trigger.** `ClickHouse` runs the lazy on-read migration enqueue again, reverting #6317.
- **Resumable state machine.** `migrateManagedWarehouseToJson` no longer waits for the rebuild inline. It prepares metadata (flip `useJsonColumns`, sync the `ch_events` fact table, clear `materializedColumns`) and fires the rebuild, then — re-driven by the sweep / next query — finalizes on success or retries on failure once the rebuild's lock frees, reading `lockUntil` and `recreateStatus` from the shared datasource doc via `getManagedWarehouseRecreateState`. It never re-requests while a rebuild is in progress, and `migrating` blocks queries throughout so nothing hits the tables mid-rebuild.
- **Client.** `dangerousRecreateClickhouseTables` returns `started`/`already-running` and treats the `423` "locked" response as expected rather than logging an error.
- **Dark launch.** The migration job is gated behind the `managed-warehouse-json-migration` flag (default off).

Note: the fact-table sync runs before the rebuild is fired, so when a later run unblocks queries on success the fact table already matches the rebuilt tables. The old synchronous settle helper (`resolveMigrationFinalState`) is removed.

### Dependencies

growthbook/central-license-server#161 (recreate-tables must ack + rebuild in the background) needs to ship first.

### Testing

`back-end` + `shared` type-check, lint, and the `migrateManagedWarehouseColumns` unit tests pass. Gated behind an off-by-default flag, so prioritizing shipping to unblock the stuck migration state over manual verification.
