### PR TITLE
Enable background sweep to migrate managed warehouse

### DIFF
--- a/packages/back-end/src/jobs/sweepManagedWarehouseMigrations.ts
+++ b/packages/back-end/src/jobs/sweepManagedWarehouseMigrations.ts
@@ -1,7 +1,7 @@
 import Agenda from "agenda";
 import { getCollection } from "back-end/src/util/mongo.util";
 import { logger } from "back-end/src/util/logger";
-import { MANAGED_WAREHOUSE_MIGRATION_SWEEP_ENABLED } from "back-end/src/util/secrets";
+import { getBackendFeatureValue } from "back-end/src/services/growthbook";
 import { queueMigrateManagedWarehouse } from "back-end/src/jobs/migrateManagedWarehouse";
 
 const JOB_NAME = "sweepManagedWarehouseMigrations";
@@ -39,6 +39,13 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 // (deduped + idempotent) in small batches. Throughput is bounded by that job's
 // concurrency cap, not this sweep, so a backlog of queued jobs is harmless.
 const sweepManagedWarehouseMigrations = async () => {
+  // Killswitch for the proactive background sweep. Default off (matches the old
+  // env var); flip `managed-warehouse-migration-sweep` on in GrowthBook to drain
+  // legacy warehouses. Evaluated per run so toggling takes effect without a redeploy.
+  if (!getBackendFeatureValue("managed-warehouse-migration-sweep", false)) {
+    return;
+  }
+
   const datasources =
     getCollection<ManagedWarehouseDatasourceDoc>("datasources");
 
@@ -62,8 +69,8 @@ const sweepManagedWarehouseMigrations = async () => {
 export default async function (agenda: Agenda) {
   agenda.define(JOB_NAME, sweepManagedWarehouseMigrations);
 
-  if (!MANAGED_WAREHOUSE_MIGRATION_SWEEP_ENABLED) return;
-
+  // Always schedule; the sweep body no-ops unless the feature flag is on, so the
+  // flag can be toggled at runtime without restarting the app.
   const job = agenda.create(JOB_NAME, {});
   job.unique({});
   job.repeatEvery(SWEEP_INTERVAL);

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -257,13 +257,6 @@ export const REMOTE_EVAL_EDGE_API_TOKEN =
 
 export const CRON_ENABLED = !stringToBoolean(process.env.CRON_DISABLED);
 
-// Kill-switch for the proactive managed-warehouse JSON migration sweep. Default
-// off; enabled in cloud to drain legacy materialized-column warehouses in the
-// background. Self-hosted has no managed warehouses, so it stays off there.
-export const MANAGED_WAREHOUSE_MIGRATION_SWEEP_ENABLED = stringToBoolean(
-  process.env.MANAGED_WAREHOUSE_MIGRATION_SWEEP_ENABLED,
-);
-
 export const SENTRY_DSN = process.env.SENTRY_DSN || "";
 
 export const STORE_SEGMENTS_IN_MONGO = stringToBoolean(

--- a/packages/shared/types/app-features.ts
+++ b/packages/shared/types/app-features.ts
@@ -119,6 +119,7 @@ export type AppFeatures = {
   "enable-error-tracking": boolean;
   "managed-warehouse-diagnostics": boolean;
   "managed-warehouse-json-migration": boolean;
+  "managed-warehouse-migration-sweep": boolean;
   "session-replays": boolean;
   "login-page-content": Record<string, unknown>;
   "slackbot-enabled": boolean;


### PR DESCRIPTION
### Features and Changes

Enables the background migration sweep for managed warehouses via a gb flag