### PR TITLE
fix(sdk-js): match falsy array elements in $elemMatch

### DIFF
--- a/packages/sdk-js/src/mongrule.ts
+++ b/packages/sdk-js/src/mongrule.ts
@@ -142,7 +142,9 @@ function elemMatch(actual: any, expected: any, savedGroups: SavedGroupsValues) {
     ? (v: any) => evalConditionValue(expected, v, savedGroups)
     : (v: any) => evalCondition(v, expected, savedGroups);
   for (let i = 0; i < actual.length; i++) {
-    if (actual[i] && check(actual[i])) {
+    // Only skip nullish elements; falsy values like 0, "" and false are valid
+    // array members and must still be tested against the condition.
+    if (actual[i] != null && check(actual[i])) {
       return true;
     }
   }

--- a/packages/sdk-js/src/mongrule.ts
+++ b/packages/sdk-js/src/mongrule.ts
@@ -144,7 +144,7 @@ function elemMatch(actual: any, expected: any, savedGroups: SavedGroupsValues) {
   for (let i = 0; i < actual.length; i++) {
     // Only skip nullish elements; falsy values like 0, "" and false are valid
     // array members and must still be tested against the condition.
-    if (actual[i] != null && check(actual[i])) {
+    if ((actual[i] ?? null) !== null && check(actual[i])) {
       return true;
     }
   }

--- a/packages/sdk-js/src/mongrule.ts
+++ b/packages/sdk-js/src/mongrule.ts
@@ -144,7 +144,7 @@ function elemMatch(actual: any, expected: any, savedGroups: SavedGroupsValues) {
   for (let i = 0; i < actual.length; i++) {
     // Only skip nullish elements; falsy values like 0, "" and false are valid
     // array members and must still be tested against the condition.
-    if ((actual[i] ?? null) !== null && check(actual[i])) {
+    if (actual[i] != null && check(actual[i])) {
       return true;
     }
   }

--- a/packages/sdk-js/test/mongrule.test.ts
+++ b/packages/sdk-js/test/mongrule.test.ts
@@ -172,4 +172,35 @@ describe("Mongrule", () => {
       ).toBe(false);
     });
   });
+
+  describe("$elemMatch with falsy array elements", () => {
+    it("matches falsy elements (0, false, empty string) in an array", () => {
+      expect(
+        evalCondition({ nums: [0] }, { nums: { $elemMatch: { $eq: 0 } } }, {}),
+      ).toBe(true);
+      expect(
+        evalCondition(
+          { flags: [false] },
+          { flags: { $elemMatch: { $eq: false } } },
+          {},
+        ),
+      ).toBe(true);
+      expect(
+        evalCondition(
+          { tags: [""] },
+          { tags: { $elemMatch: { $eq: "" } } },
+          {},
+        ),
+      ).toBe(true);
+    });
+    it("still returns false when no array element matches", () => {
+      expect(
+        evalCondition(
+          { nums: [1, 2] },
+          { nums: { $elemMatch: { $eq: 0 } } },
+          {},
+        ),
+      ).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
### Problem
`$elemMatch` guarded each array element with `actual[i] && check(actual[i])`, which skips **falsy** members (`0`, `""`, `false`) before ever testing them. So `{ nums: { $elemMatch: { $eq: 0 } } }` never matched `[0]`, and likewise for `false` / `""`.

### Fix
Skip only *nullish* elements (`actual[i] != null`) so falsy-but-present values are evaluated against the condition like any other element.

### Test
Added a scoped `mongrule.test.ts` block (not the shared `cases.json`, to avoid cross-SDK impact): falsy elements now match; a non-matching array still returns `false`. Verified both directions and formatted with prettier 3.6.2.
