### PR TITLE
fix(experiments): preserve 0% coverage instead of defaulting to 100%

### DIFF
--- a/packages/back-end/src/api/fact-metrics/postFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/postFactMetric.ts
@@ -83,18 +83,18 @@ export async function getCreateMetricPropsFromBody(
       scopedSettings.winRisk.value ||
       DEFAULT_WIN_RISK_THRESHOLD,
     maxPercentChange:
-      maxPercentChange ||
-      scopedSettings.metricDefaults.value.maxPercentageChange ||
+      maxPercentChange ??
+      scopedSettings.metricDefaults.value.maxPercentageChange ??
       0,
     minPercentChange:
-      minPercentChange ||
-      scopedSettings.metricDefaults.value.minPercentageChange ||
+      minPercentChange ??
+      scopedSettings.metricDefaults.value.minPercentageChange ??
       0,
     targetMDE:
       targetMDE || scopedSettings.metricDefaults.value.targetMDE || 0.1,
     minSampleSize:
-      minSampleSize ||
-      scopedSettings.metricDefaults.value.minimumSampleSize ||
+      minSampleSize ??
+      scopedSettings.metricDefaults.value.minimumSampleSize ??
       150,
     description: "",
     owner: "",

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -583,7 +583,7 @@ export async function getAllExperimentsForStaleGraph(
       if (exp.status === "stopped" && exp.results === "lost") {
         exp.releasedVariationId = exp.variations?.[0]?.id || "";
       } else if (exp.status === "stopped" && exp.results === "won") {
-        exp.releasedVariationId = exp.variations?.[exp.winner || 1]?.id || "";
+        exp.releasedVariationId = exp.variations?.[exp.winner ?? 1]?.id || "";
       } else {
         exp.releasedVariationId = "";
       }

--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -746,7 +746,7 @@ export function upgradeExperimentDoc(
         experiment.releasedVariationId = experiment.variations[0]?.id || "";
       } else if (experiment.results === "won") {
         experiment.releasedVariationId =
-          experiment.variations[experiment.winner || 1]?.id || "";
+          experiment.variations[experiment.winner ?? 1]?.id || "";
       } else {
         experiment.releasedVariationId = "";
       }

--- a/packages/back-end/test/migrations.test.ts
+++ b/packages/back-end/test/migrations.test.ts
@@ -1869,6 +1869,22 @@ describe("Experiment Migration", () => {
       releasedVariationId: "foo",
     });
   });
+  it("uses `winner` 0 (control won) for releasedVariationId, not the default 1", () => {
+    expect(
+      upgradeExperimentDoc({
+        ...exp,
+        status: "stopped",
+        results: "won",
+        winner: 0,
+      }),
+    ).toEqual({
+      ...upgraded,
+      status: "stopped",
+      results: "won",
+      winner: 0,
+      releasedVariationId: "0",
+    });
+  });
   it("Doesn't overwrite other attribution models", () => {
     expect(
       upgradeExperimentDoc({

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -325,7 +325,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
           ? [
               {
                 ...initialValue.phases[lastPhase],
-                coverage: initialValue.phases?.[lastPhase]?.coverage || 1,
+                coverage: initialValue.phases?.[lastPhase]?.coverage ?? 1,
                 dateStarted: getValidDate(
                   initialValue.phases?.[lastPhase]?.dateStarted ?? "",
                 )

--- a/packages/front-end/components/Experiment/NewPhaseForm.tsx
+++ b/packages/front-end/components/Experiment/NewPhaseForm.tsx
@@ -44,7 +44,7 @@ const NewPhaseForm: FC<{
   const form = useForm<ExperimentPhaseStringDates>({
     defaultValues: {
       name: prevPhase.name || "Main",
-      coverage: prevPhase.coverage || 1,
+      coverage: prevPhase.coverage ?? 1,
       variationWeights:
         prevPhase.variationWeights ||
         getEqualWeights(lastPhaseVariations.length),

--- a/packages/front-end/components/Experiment/Templates/TemplateForm.tsx
+++ b/packages/front-end/components/Experiment/Templates/TemplateForm.tsx
@@ -111,7 +111,7 @@ const TemplateForm: FC<Props> = ({
       skipPartialData: initialValue.skipPartialData ? "strict" : "loose",
       segment: initialValue.segment || "",
       targeting: {
-        coverage: initialValue.targeting?.coverage || 1,
+        coverage: initialValue.targeting?.coverage ?? 1,
         savedGroups: initialValue.targeting?.savedGroups || [],
         prerequisites: initialValue.targeting?.prerequisites || [],
         condition: initialValue.targeting?.condition || "",

--- a/packages/front-end/components/Features/ExperimentRefSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentRefSummary.tsx
@@ -203,7 +203,7 @@ export default function ExperimentRefSummary({
               color="gray"
               label={
                 <Text color="text-high">
-                  {percentFormatter.format(phase?.coverage || 1)}
+                  {percentFormatter.format(phase?.coverage ?? 1)}
                 </Text>
               }
             />

--- a/packages/front-end/components/Features/HoldoutRule.tsx
+++ b/packages/front-end/components/Features/HoldoutRule.tsx
@@ -253,8 +253,8 @@ export const HoldoutRule = forwardRef<HTMLDivElement, Props>(
                 value={feature.holdout?.value || ""}
                 hashAttribute={holdoutExperiment.hashAttribute || ""}
                 holdoutWeight={
-                  holdoutExperiment.phases[0].coverage *
-                    holdoutExperiment.phases[0].variationWeights[0] || 1
+                  (holdoutExperiment.phases[0]?.coverage ?? 0) *
+                  (holdoutExperiment.phases[0]?.variationWeights[0] ?? 0)
                 }
               />
             </Box>

--- a/packages/front-end/components/Features/HoldoutRule.tsx
+++ b/packages/front-end/components/Features/HoldoutRule.tsx
@@ -253,8 +253,8 @@ export const HoldoutRule = forwardRef<HTMLDivElement, Props>(
                 value={feature.holdout?.value || ""}
                 hashAttribute={holdoutExperiment.hashAttribute || ""}
                 holdoutWeight={
-                  (holdoutExperiment.phases[0]?.coverage ?? 0) *
-                  (holdoutExperiment.phases[0]?.variationWeights[0] ?? 0)
+                  holdoutExperiment.phases[0].coverage *
+                  holdoutExperiment.phases[0].variationWeights[0]
                 }
               />
             </Box>

--- a/packages/front-end/enterprise/components/ContextualBandit/ContextualBanditForm.tsx
+++ b/packages/front-end/enterprise/components/ContextualBandit/ContextualBanditForm.tsx
@@ -163,7 +163,7 @@ const ContextualBanditForm: FC<ContextualBanditFormProps> = ({
       targetURLRegex: initialValue?.targetURLRegex || "",
       description: initialValue?.description || "",
       variations: initialExpVariations,
-      coverage: initialValue?.coverage || 1,
+      coverage: initialValue?.coverage ?? 1,
       condition: initialValue?.condition,
       savedGroups: initialValue?.savedGroups,
       prerequisites: initialValue?.prerequisites,

--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -1572,7 +1572,7 @@ export function getExperimentDefinitionFromFeature(
     variations,
     phases: [
       {
-        coverage: expRule.coverage || 1,
+        coverage: expRule.coverage ?? 1,
         variationWeights,
         variations: variations.map((v) => ({
           id: v.id,


### PR DESCRIPTION
### Features and Changes

`coverage || 1` treats a real `0` as falsy and replaces it with `1` (100%). A holdout set to 0% was displaying as 100%, and the same falsy-fallback pattern turned up in a few nearby places. Switched the affected sites to nullish coalescing (`??`) so a configured `0` is preserved and only `undefined`/`null` falls back to the default.

The change spans three layers:

- **Display**: `HoldoutRule` and `ExperimentRefSummary` now show 0% coverage as 0% instead of 100%.
- **Serving**: `upgradeExperimentDoc` and `ExperimentModel` backfilled `releasedVariationId` as `variations[winner || 1]` for legacy stopped-and-won experiments. When the control won (`winner === 0`), `0 || 1` picked a treatment, so the SDK would force-serve that treatment to everyone instead of the control. Now `winner ?? 1`.
- **Forms and API**: the new-phase / new-experiment / template / bandit forms keep a 0% coverage default instead of pre-filling 100%, and the fact-metric create API preserves an explicit `0` for `minSampleSize`, `minPercentChange`, and `maxPercentChange`.

### Testing

- Added a `winner: 0` (control won) case to the `upgradeExperimentDoc` tests. Red before the serving fix (backfilled `"1"`), green after (`"0"`).
- `pnpm --filter back-end test migrations.test.ts` passes.

[Slack thread](https://growthbookapp.slack.com/archives/C05QYS2UFRD/p1783628493890039?thread_ts=1783628493.890039&cid=C05QYS2UFRD)
