### PR TITLE
fix feature modal to use filter projects by environment

### DIFF
--- a/packages/front-end/components/Features/FeatureModal/EnvironmentSelect.tsx
+++ b/packages/front-end/components/Features/FeatureModal/EnvironmentSelect.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useState } from "react";
+import { FC, useEffect, useMemo, useState } from "react";
 import { Environment } from "shared/types/organization";
 import { FeatureEnvironment } from "shared/types/feature";
 import { filterProjectsByEnvironment } from "shared/util";
@@ -57,9 +57,24 @@ const EnvironmentSelect: FC<{
     });
   }, [relevantEnvironments, permissionsUtil, project]);
 
-  const selectAllChecked = environmentsUserCanAccess.every(
-    (env) => environmentSettings[env.id]?.enabled,
-  );
+  useEffect(() => {
+    environments.forEach((env) => {
+      const isRelevant = relevantEnvironments.some((e) => e.id === env.id);
+      if (!isRelevant && environmentSettings[env.id]?.enabled) {
+        setValue(env, false);
+      }
+    });
+    // Only re-run when the relevant set changes (i.e. selected project
+    // changes) — environments/environmentSettings/setValue are recreated
+    // every render and would otherwise cause a render loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [relevantEnvironments]);
+
+  const selectAllChecked =
+    environmentsUserCanAccess.length > 0 &&
+    environmentsUserCanAccess.every(
+      (env) => environmentSettings[env.id]?.enabled,
+    );
   const selectAllIndeterminate = environmentsUserCanAccess.some(
     (env) => environmentSettings[env.id]?.enabled,
   );

--- a/packages/front-end/components/Features/FeatureModal/EnvironmentSelect.tsx
+++ b/packages/front-end/components/Features/FeatureModal/EnvironmentSelect.tsx
@@ -57,10 +57,6 @@ const EnvironmentSelect: FC<{
     });
   }, [relevantEnvironments, permissionsUtil, project]);
 
-  // Effect should only re-run when the relevant set changes (i.e. the
-  // selected project changes), not on every render — environments,
-  // environmentSettings, and setValue are recreated each render, so read
-  // them from a ref instead of listing them as dependencies.
   const latestRef = useRef({ environments, environmentSettings, setValue });
   latestRef.current = { environments, environmentSettings, setValue };
 

--- a/packages/front-end/components/Features/FeatureModal/EnvironmentSelect.tsx
+++ b/packages/front-end/components/Features/FeatureModal/EnvironmentSelect.tsx
@@ -1,6 +1,7 @@
 import { FC, useMemo, useState } from "react";
 import { Environment } from "shared/types/organization";
 import { FeatureEnvironment } from "shared/types/feature";
+import { filterProjectsByEnvironment } from "shared/util";
 import { Box, Flex, Grid, Text } from "@radix-ui/themes";
 import { FaCircleCheck, FaCircleXmark } from "react-icons/fa6";
 import { featureStatusColors } from "@/components/Features/FeaturesOverview";
@@ -42,11 +43,22 @@ const EnvironmentSelect: FC<{
   isEditing = false,
 }) => {
   const permissionsUtil = usePermissionsUtil();
+
+  // Environments can be scoped to specific projects. Exclude ones that don't
+  // apply to the selected project so users can't accidentally toggle a
+  // feature in an environment meant for another project.
+  const relevantEnvironments = useMemo(() => {
+    if (!project) return environments;
+    return environments.filter(
+      (env) => filterProjectsByEnvironment([project], env).length > 0,
+    );
+  }, [environments, project]);
+
   const environmentsUserCanAccess = useMemo(() => {
-    return environments.filter((env) => {
+    return relevantEnvironments.filter((env) => {
       return permissionsUtil.canPublishFeature({ project }, [env.id]);
     });
-  }, [environments, permissionsUtil, project]);
+  }, [relevantEnvironments, permissionsUtil, project]);
 
   const selectAllChecked = environmentsUserCanAccess.every(
     (env) => environmentSettings[env.id]?.enabled,
@@ -57,8 +69,11 @@ const EnvironmentSelect: FC<{
 
   const [expanded, setExpanded] = useState(isEditing);
 
-  const visible = environments.slice(0, MAX_VISIBLE_PREVIEW_ENVIRONMENTS);
-  const overflow = environments.slice(MAX_VISIBLE_PREVIEW_ENVIRONMENTS);
+  const visible = relevantEnvironments.slice(
+    0,
+    MAX_VISIBLE_PREVIEW_ENVIRONMENTS,
+  );
+  const overflow = relevantEnvironments.slice(MAX_VISIBLE_PREVIEW_ENVIRONMENTS);
 
   return (
     <div className="form-group">
@@ -133,7 +148,7 @@ const EnvironmentSelect: FC<{
             style={{ maxHeight: "168px", wordBreak: "break-all" }}
             overflowY="auto"
           >
-            {environments.map((env) => (
+            {relevantEnvironments.map((env) => (
               <Checkbox
                 disabled={
                   !permissionsUtil.canPublishFeature({ project }, [env.id])

--- a/packages/front-end/components/Features/FeatureModal/EnvironmentSelect.tsx
+++ b/packages/front-end/components/Features/FeatureModal/EnvironmentSelect.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useMemo, useState } from "react";
+import { FC, useEffect, useMemo, useRef, useState } from "react";
 import { Environment } from "shared/types/organization";
 import { FeatureEnvironment } from "shared/types/feature";
 import { filterProjectsByEnvironment } from "shared/util";
@@ -57,17 +57,21 @@ const EnvironmentSelect: FC<{
     });
   }, [relevantEnvironments, permissionsUtil, project]);
 
+  // Effect should only re-run when the relevant set changes (i.e. the
+  // selected project changes), not on every render — environments,
+  // environmentSettings, and setValue are recreated each render, so read
+  // them from a ref instead of listing them as dependencies.
+  const latestRef = useRef({ environments, environmentSettings, setValue });
+  latestRef.current = { environments, environmentSettings, setValue };
+
   useEffect(() => {
+    const { environments, environmentSettings, setValue } = latestRef.current;
     environments.forEach((env) => {
       const isRelevant = relevantEnvironments.some((e) => e.id === env.id);
       if (!isRelevant && environmentSettings[env.id]?.enabled) {
         setValue(env, false);
       }
     });
-    // Only re-run when the relevant set changes (i.e. selected project
-    // changes) — environments/environmentSettings/setValue are recreated
-    // every render and would otherwise cause a render loop.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [relevantEnvironments]);
 
   const selectAllChecked =

--- a/packages/front-end/components/Features/FeatureModal/EnvironmentSelect.tsx
+++ b/packages/front-end/components/Features/FeatureModal/EnvironmentSelect.tsx
@@ -44,9 +44,6 @@ const EnvironmentSelect: FC<{
 }) => {
   const permissionsUtil = usePermissionsUtil();
 
-  // Environments can be scoped to specific projects. Exclude ones that don't
-  // apply to the selected project so users can't accidentally toggle a
-  // feature in an environment meant for another project.
   const relevantEnvironments = useMemo(() => {
     if (!project) return environments;
     return environments.filter(


### PR DESCRIPTION

Environments scoped to other projects were still shown and toggleable when creating a new feature, risking accidental changes that affect projects the environment wasn't meant for. this filters out those envs

### Features and Changes

<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Closes  #6283 

### Dependencies


### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
