### PR TITLE
Ramp schedules: collapse catch-up into one publish + serialize advances

### DIFF
--- a/docs/docs/features/ramp-schedules.mdx
+++ b/docs/docs/features/ramp-schedules.mdx
@@ -31,6 +31,8 @@ Each step also has an **Action** that controls when it advances:
 
 When a step's Action clears, GrowthBook applies the step's changes to the rule and starts the next step. Each advance publishes a new feature revision automatically, so your SDKs pick up the change through the normal feature payload.
 
+If a schedule falls behind (for example, it was paused past several steps' hold times), the overdue steps are caught up in a **single** advance: one revision publish (labeled with the folded range, such as "Ramp steps 4–12 of 20") and one `rampSchedule.actions.step.advanced` webhook whose `previousStepIndex` shows the gap. Consumers mirroring ramp progress should diff `currentStepIndex - previousStepIndex` rather than counting events. Approval and monitored steps are never skipped by a catch-up — the schedule always stops at them.
+
 The grid always ends with an **end** row, set to 100% by default. That is the state the rule lands in when the schedule finishes; open its menu to attach final rule changes, such as removing targeting.
 
 <MaxWidthImage border>
@@ -120,10 +122,10 @@ Turn on **Monitor this release** and configure monitoring once on the schedule:
 
 Under **Advanced Settings**, choose what happens when an automated check fails:
 
-| Check                 | UI control              | Options                                |
-| --------------------- | ----------------------- | -------------------------------------- |
-| Sample ratio mismatch | **If SRM detected**     | Hold step (default), Roll back, Warn only |
-| No traffic            | **If no traffic**       | Hold step (default), Roll back, Warn only |
+| Check                 | UI control                | Options                                   |
+| --------------------- | ------------------------- | ----------------------------------------- |
+| Sample ratio mismatch | **If SRM detected**       | Hold step (default), Roll back, Warn only |
+| No traffic            | **If no traffic**         | Hold step (default), Roll back, Warn only |
 | Multiple exposures    | **If multiple exposures** | Hold step (default), Roll back, Warn only |
 
 **Hold step** pauses the ramp for review, **Roll back** rewinds the rule to its pre-ramp state and ends the schedule, and **Warn only** flags the issue without stopping the ramp. The no-traffic grace period defaults to 24 hours and is editable next to **If no traffic**. Guardrail regressions always roll back and disable the rule; that behavior is not configurable here.
@@ -140,14 +142,14 @@ Once started, a schedule reports its status and progress on the feature's rule.
 ![A running ramp schedule on a feature rule, showing the current rollout percentage, the served value, the current step, time remaining, and the step timeline](/images/features/ramp-schedule-timeline.webp)
 </MaxWidthImage>
 
-| Status        | Meaning                                                          |
-| ------------- | ---------------------------------------------------------------- |
-| `pending`     | Created but not yet armed. Publish the revision to start.        |
-| `ready`       | Armed and waiting for the start date.                            |
-| `running`     | Actively advancing through steps.                                |
-| `paused`      | Halted by a user or a `hold` health action. Resume to continue.  |
-| `completed`   | All steps applied and the end state set.                         |
-| `rolled-back` | Returned to the pre-ramp state.                                  |
+| Status        | Meaning                                                         |
+| ------------- | --------------------------------------------------------------- |
+| `pending`     | Created but not yet armed. Publish the revision to start.       |
+| `ready`       | Armed and waiting for the start date.                           |
+| `running`     | Actively advancing through steps.                               |
+| `paused`      | Halted by a user or a `hold` health action. Resume to continue. |
+| `completed`   | All steps applied and the end state set.                        |
+| `rolled-back` | Returned to the pre-ramp state.                                 |
 
 From the UI or API you can start, pause, resume, manually advance, jump to a specific step, approve a gated step, roll back to the pre-ramp state, or restart a finished schedule. Every transition is recorded in the schedule's event history.
 

--- a/docs/docs/features/ramp-schedules.mdx
+++ b/docs/docs/features/ramp-schedules.mdx
@@ -31,7 +31,7 @@ Each step also has an **Action** that controls when it advances:
 
 When a step's Action clears, GrowthBook applies the step's changes to the rule and starts the next step. Each advance publishes a new feature revision automatically, so your SDKs pick up the change through the normal feature payload.
 
-If a schedule falls behind (for example, it was paused past several steps' hold times), the overdue steps are caught up in a **single** advance: one revision publish (labeled with the folded range, such as "Ramp steps 4–12 of 20") and one `rampSchedule.actions.step.advanced` webhook whose `previousStepIndex` shows the gap. Consumers mirroring ramp progress should diff `currentStepIndex - previousStepIndex` rather than counting events. Approval and monitored steps are never skipped by a catch-up — the schedule always stops at them.
+If a schedule falls behind (for example, background processing was interrupted past several steps' hold times — pausing doesn't cause this, since pause shifts the timers), the overdue steps are caught up in a **single** advance: one revision publish (labeled with the folded range, such as "Ramp steps 4–12 of 20") and one webhook whose `previousStepIndex` shows the gap — `rampSchedule.actions.step.advanced`, or `rampSchedule.actions.completed` when the fold finishes the ramp. Consumers mirroring ramp progress should diff `currentStepIndex - previousStepIndex` rather than counting events. Approval and monitored steps are never skipped by a catch-up — the schedule always stops at them.
 
 The grid always ends with an **end** row, set to 100% by default. That is the state the rule lands in when the schedule finishes; open its menu to attach final rule changes, such as removing targeting.
 

--- a/docs/src/partials/event-webhook/_event-webhook-list.md
+++ b/docs/src/partials/event-webhook/_event-webhook-list.md
@@ -14,7 +14,7 @@
 | **[feature.rampSchedule.actions.completed](#featurerampScheduleactionscompleted)** | Triggered when a feature ramp schedule completes all steps |
 | **[feature.rampSchedule.actions.rolledBack](#featurerampScheduleactionsrolledBack)** | Triggered when a feature ramp schedule is rolled back or reset to start |
 | **[feature.rampSchedule.actions.jumped](#featurerampScheduleactionsjumped)** | Triggered when a feature ramp schedule is jumped to a specific step |
-| **[feature.rampSchedule.actions.step.advanced](#featurerampScheduleactionsstepadvanced)** | Triggered when a feature ramp schedule advances to the next step |
+| **[feature.rampSchedule.actions.step.advanced](#featurerampScheduleactionsstepadvanced)** | Triggered when a feature ramp schedule advances. Overdue steps are caught up in a single advance: when `currentStepIndex - previousStepIndex > 1`, the intermediate steps were folded into this one event (one revision publish) rather than fired individually. |
 | **[feature.rampSchedule.actions.step.approvalRequired](#featurerampScheduleactionsstepapprovalRequired)** | Triggered when a feature ramp step is waiting for approval |
 | **[feature.revision.created](#featurerevisioncreated)** | Triggered when a new draft revision is created for a feature |
 | **[feature.revision.updated](#featurerevisionupdated)** | Triggered when a draft revision is modified (rules, default value, toggles, prerequisites, metadata, etc.). The `change` field indicates the specific kind of mutation. |
@@ -730,7 +730,7 @@ Triggered when a feature ramp schedule is jumped to a specific step
 
 ### feature.rampSchedule.actions.step.advanced
 
-Triggered when a feature ramp schedule advances to the next step
+Triggered when a feature ramp schedule advances. Overdue steps are caught up in a single advance: when `currentStepIndex - previousStepIndex > 1`, the intermediate steps were folded into this one event (one revision publish) rather than fired individually.
 
 <details>
   <summary>Payload</summary>

--- a/docs/src/partials/event-webhook/_event-webhook-list.md
+++ b/docs/src/partials/event-webhook/_event-webhook-list.md
@@ -605,6 +605,7 @@ Triggered when a feature ramp schedule completes all steps
             orgId: string;
             currentStepIndex: number;
             status: string;
+            previousStepIndex?: number | undefined;
         };
     };
     user: {

--- a/docs/src/partials/event-webhook/_event-webhook-list.md
+++ b/docs/src/partials/event-webhook/_event-webhook-list.md
@@ -748,6 +748,7 @@ Triggered when a feature ramp schedule advances to the next step
             orgId: string;
             currentStepIndex: number;
             status: string;
+            previousStepIndex?: number | undefined;
         };
     };
     user: {

--- a/packages/back-end/src/api/ramp-schedules/rampScheduleActions.ts
+++ b/packages/back-end/src/api/ramp-schedules/rampScheduleActions.ts
@@ -212,6 +212,14 @@ export const jumpRampSchedule = createApiRequestHandler({
           `Cannot jump: schedule changed to "${fresh.status}" while the request was in flight`,
         );
       }
+      // Re-validate bounds against the in-lock steps — a concurrent steps
+      // edit can shrink the array, and an out-of-range playhead reads as
+      // past-end (unintended completion) downstream.
+      if (targetStepIndex >= fresh.steps.length) {
+        throw new ConflictError(
+          `Cannot jump: step ${targetStepIndex} no longer exists (the schedule's steps changed while the request was in flight)`,
+        );
+      }
       return jumpSchedule(req.context, fresh, targetStepIndex);
     },
   );
@@ -299,11 +307,21 @@ export const approveStepRampSchedule = createApiRequestHandler({
     req.context,
     schedule.id,
     (fresh) => {
+      // Pin to the step the reviewer saw — with consecutive approval gates, a
+      // queued approval must not land on a step that was never reviewed.
+      if (fresh.currentStepIndex !== schedule.currentStepIndex) {
+        throw new ConflictError(
+          "Cannot approve step: the schedule advanced while the request was in flight",
+        );
+      }
+      // Duplicate approval of the same step is idempotent success.
+      if (fresh.stepApproval?.stepIndex === fresh.currentStepIndex) {
+        return Promise.resolve(null);
+      }
       const freshStep = fresh.steps[fresh.currentStepIndex];
       const stillAwaiting =
         fresh.status === "running" &&
-        freshStep?.holdConditions?.requiresApproval &&
-        fresh.stepApproval?.stepIndex !== fresh.currentStepIndex;
+        freshStep?.holdConditions?.requiresApproval;
       if (!stillAwaiting) {
         throw new ConflictError(
           "Cannot approve step: schedule changed while the request was in flight",
@@ -485,19 +503,25 @@ export const addTargetRampSchedule = createApiRequestHandler({
     status: "active" as const,
   };
 
-  const isFirstTarget = schedule.targets.length === 0;
-  const entityUpdate = schedule.entityId === "" ? { entityId: featureId } : {};
-  const statusUpdate =
-    isFirstTarget && schedule.status === "pending"
-      ? { status: "ready" as const }
-      : {};
-
-  const updated = await req.context.models.rampSchedules.updateById(
+  // Locked read-modify-write: concurrent add/eject calls would drop a target,
+  // and the pending→ready flip from a stale read could rewind a schedule the
+  // scheduler concurrently activated.
+  const updated = await runLockedRampScheduleAction(
+    req.context,
     schedule.id,
-    {
-      targets: [...schedule.targets, newTarget],
-      ...entityUpdate,
-      ...statusUpdate,
+    (fresh) => {
+      const isFirstTarget = fresh.targets.length === 0;
+      const entityUpdate = fresh.entityId === "" ? { entityId: featureId } : {};
+      const statusUpdate =
+        isFirstTarget && fresh.status === "pending"
+          ? { status: "ready" as const }
+          : {};
+
+      return req.context.models.rampSchedules.updateById(fresh.id, {
+        targets: [...fresh.targets, newTarget],
+        ...entityUpdate,
+        ...statusUpdate,
+      });
     },
   );
 
@@ -545,46 +569,54 @@ export const ejectTargetRampSchedule = createApiRequestHandler({
 
   const { targetId, ruleId, environment } = req.body;
 
-  const remaining = schedule.targets.filter((t) => {
-    if (targetId) return t.id !== targetId;
-    return !rampTargetsEquivalent(t, {
-      ruleId,
-      environment: environment ?? null,
-    });
-  });
-
-  if (remaining.length === schedule.targets.length) {
-    throw new Error("No matching target found on this schedule");
-  }
-
-  if (remaining.length === 0) {
-    // No rollback is applied when the last target is ejected. This is intentional:
-    // "eject" means "remove the schedule and leave the rule as-is right now" — the
-    // feature rule stays at whatever coverage/state it is currently at, under the
-    // user's full manual control from this point. If the intent were to revert the
-    // rule to its pre-ramp state, the caller should execute a rollback action first
-    // (which applies startActions) and then eject, or use the delete-schedule flow
-    // that already pauses/rolls back before removing.
-    //
-    // Stop the linked SafeRollout before deleting so agenda ticks don't keep
-    // firing against a now-deleted parent schedule.
-    if (schedule.safeRolloutId) {
-      await syncLinkedSafeRolloutForRampState(
-        req.context,
-        { ...schedule, status: "rolled-back" },
-        "stopped",
-      );
-    }
-    await req.context.models.rampSchedules.deleteById(schedule.id);
-    return { deleted: true, rampScheduleId: schedule.id };
-  }
-
-  const updated = await req.context.models.rampSchedules.updateById(
+  // Locked: the targets filter is a read-modify-write, and the last-target
+  // deleteById must not remove the doc out from under an in-flight advance.
+  return runLockedRampScheduleAction(
+    req.context,
     schedule.id,
-    { targets: remaining },
-  );
+    async (fresh) => {
+      const remaining = fresh.targets.filter((t) => {
+        if (targetId) return t.id !== targetId;
+        return !rampTargetsEquivalent(t, {
+          ruleId,
+          environment: environment ?? null,
+        });
+      });
 
-  return { rampSchedule: rampScheduleToApiInterface(updated) };
+      if (remaining.length === fresh.targets.length) {
+        throw new Error("No matching target found on this schedule");
+      }
+
+      if (remaining.length === 0) {
+        // No rollback is applied when the last target is ejected. This is intentional:
+        // "eject" means "remove the schedule and leave the rule as-is right now" — the
+        // feature rule stays at whatever coverage/state it is currently at, under the
+        // user's full manual control from this point. If the intent were to revert the
+        // rule to its pre-ramp state, the caller should execute a rollback action first
+        // (which applies startActions) and then eject, or use the delete-schedule flow
+        // that already pauses/rolls back before removing.
+        //
+        // Stop the linked SafeRollout before deleting so agenda ticks don't keep
+        // firing against a now-deleted parent schedule.
+        if (fresh.safeRolloutId) {
+          await syncLinkedSafeRolloutForRampState(
+            req.context,
+            { ...fresh, status: "rolled-back" },
+            "stopped",
+          );
+        }
+        await req.context.models.rampSchedules.deleteById(fresh.id);
+        return { deleted: true, rampScheduleId: fresh.id };
+      }
+
+      const updated = await req.context.models.rampSchedules.updateById(
+        fresh.id,
+        { targets: remaining },
+      );
+
+      return { rampSchedule: rampScheduleToApiInterface(updated) };
+    },
+  );
 });
 
 export const apiAdvanceRampSchedule = createApiRequestHandler({
@@ -636,14 +668,6 @@ export const apiAdvanceRampSchedule = createApiRequestHandler({
         "force: true requires canBypassApprovalChecks permission on the linked feature",
       );
     }
-    await req.audit({
-      event: "rampSchedule.approval-bypassed",
-      entity: { object: "rampSchedule", id: schedule.id },
-      details: JSON.stringify({
-        stepIndex: schedule.currentStepIndex,
-        reason: req.body?.reason,
-      }),
-    });
   }
 
   let current = await runLockedRampScheduleAction(
@@ -655,9 +679,29 @@ export const apiAdvanceRampSchedule = createApiRequestHandler({
           `Cannot advance: schedule changed to "${fresh.status}" while the request was in flight`,
         );
       }
+      // Pin the playhead: the approval/force gates above were screened
+      // against this step; if a concurrent advance moved it, this request
+      // would silently skip an extra step (or an unscreened approval gate).
+      if (fresh.currentStepIndex !== schedule.currentStepIndex) {
+        throw new ConflictError(
+          "Cannot advance: the schedule advanced while the request was in flight",
+        );
+      }
       return advanceScheduleManually(req.context, fresh);
     },
   );
+  // Audit after the advance succeeds so the trail never records a bypass that
+  // was rejected by the in-lock validation.
+  if (approvalPending && force) {
+    await req.audit({
+      event: "rampSchedule.approval-bypassed",
+      entity: { object: "rampSchedule", id: schedule.id },
+      details: JSON.stringify({
+        stepIndex: schedule.currentStepIndex,
+        reason: req.body?.reason,
+      }),
+    });
+  }
   current =
     (await req.context.models.rampSchedules.getById(schedule.id)) ?? current;
 
@@ -1341,9 +1385,12 @@ export const refreshMonitoringRampSchedule = createApiRequestHandler({
     : null;
 
   if (!safeRollout && currentStep?.monitored) {
-    const updated = await ensureSafeRolloutForMonitoredRamp(
+    // Serialize against the tick, which runs the same ensure — otherwise both
+    // create a SafeRollout and one becomes an orphan.
+    const updated = await runLockedRampScheduleAction(
       req.context,
-      schedule,
+      schedule.id,
+      (fresh) => ensureSafeRolloutForMonitoredRamp(req.context, fresh),
     );
     safeRollout = updated.safeRolloutId
       ? await req.context.models.safeRollout.getById(updated.safeRolloutId)

--- a/packages/back-end/src/api/ramp-schedules/rampScheduleActions.ts
+++ b/packages/back-end/src/api/ramp-schedules/rampScheduleActions.ts
@@ -82,13 +82,13 @@ export const startRampSchedule = createApiRequestHandler({
   const current = await runLockedRampScheduleAction(
     req.context,
     schedule.id,
-    (fresh) => {
+    (fresh, heartbeat) => {
       if (fresh.status !== "ready") {
         throw new ConflictError(
           `Cannot start: schedule changed to "${fresh.status}" while the request was in flight`,
         );
       }
-      return startSchedule(req.context, fresh);
+      return startSchedule(req.context, fresh, heartbeat);
     },
   );
   return { rampSchedule: rampScheduleToApiInterface(current) };
@@ -157,13 +157,13 @@ export const resumeRampSchedule = createApiRequestHandler({
   const updated = await runLockedRampScheduleAction(
     req.context,
     schedule.id,
-    (fresh) => {
+    (fresh, heartbeat) => {
       if (fresh.status !== "paused") {
         throw new ConflictError(
           `Cannot resume: schedule changed to "${fresh.status}" while the request was in flight`,
         );
       }
-      return resumeSchedule(req.context, fresh);
+      return resumeSchedule(req.context, fresh, heartbeat);
     },
   );
 
@@ -210,13 +210,6 @@ export const jumpRampSchedule = createApiRequestHandler({
       if (["completed", "rolled-back"].includes(fresh.status)) {
         throw new ConflictError(
           `Cannot jump: schedule changed to "${fresh.status}" while the request was in flight`,
-        );
-      }
-      // A concurrent steps edit can shrink the array, turning the playhead
-      // past-end (unintended completion).
-      if (targetStepIndex >= fresh.steps.length) {
-        throw new ConflictError(
-          `Cannot jump: step ${targetStepIndex} no longer exists (the schedule's steps changed while the request was in flight)`,
         );
       }
       return jumpSchedule(req.context, fresh, targetStepIndex);
@@ -313,19 +306,9 @@ export const approveStepRampSchedule = createApiRequestHandler({
           "Cannot approve step: the schedule advanced while the request was in flight",
         );
       }
-      // Duplicate approval of the same step is idempotent success.
-      if (fresh.stepApproval?.stepIndex === fresh.currentStepIndex) {
-        return Promise.resolve(null);
-      }
-      const freshStep = fresh.steps[fresh.currentStepIndex];
-      const stillAwaiting =
-        fresh.status === "running" &&
-        freshStep?.holdConditions?.requiresApproval;
-      if (!stillAwaiting) {
-        throw new ConflictError(
-          "Cannot approve step: schedule changed while the request was in flight",
-        );
-      }
+      // Idempotency and awaiting-approval validation live in
+      // approveAndPublishStep, AFTER its permission checks — duplicating them
+      // here would return success to callers that were never permission-checked.
       return approveAndPublishStep(req.context, fresh, "api");
     },
   );
@@ -428,13 +411,13 @@ export const restartRampSchedule = createApiRequestHandler({
   const updated = await runLockedRampScheduleAction(
     req.context,
     schedule.id,
-    (fresh) => {
+    (fresh, heartbeat) => {
       if (!["rolled-back", "completed"].includes(fresh.status)) {
         throw new ConflictError(
           `Cannot restart: schedule changed to "${fresh.status}" while the request was in flight`,
         );
       }
-      return restartSchedule(req.context, fresh);
+      return restartSchedule(req.context, fresh, heartbeat);
     },
   );
   return { rampSchedule: rampScheduleToApiInterface(updated) };
@@ -507,7 +490,31 @@ export const addTargetRampSchedule = createApiRequestHandler({
   const updated = await runLockedRampScheduleAction(
     req.context,
     schedule.id,
-    (fresh) => {
+    async (fresh) => {
+      // Re-check exclusivity in-lock: a racing add could otherwise put the
+      // rule under two schedules whose advances publish competing coverage.
+      const freshConflicts =
+        await req.context.models.rampSchedules.findByTargetRule(
+          ruleId,
+          environment ?? undefined,
+        );
+      if (freshConflicts.some((c) => c.id !== fresh.id)) {
+        throw new ConflictError(
+          `Another schedule attached rule '${ruleId}'${envSuffix} while the request was in flight.`,
+        );
+      }
+      if (
+        fresh.targets.some((t) =>
+          rampTargetsEquivalent(t, {
+            ruleId,
+            environment: environment ?? null,
+          }),
+        )
+      ) {
+        throw new ConflictError(
+          `Rule '${ruleId}'${envSuffix} is already a target of this schedule.`,
+        );
+      }
       const isFirstTarget = fresh.targets.length === 0;
       const entityUpdate = fresh.entityId === "" ? { entityId: featureId } : {};
       const statusUpdate =
@@ -668,10 +675,11 @@ export const apiAdvanceRampSchedule = createApiRequestHandler({
     }
   }
 
+  let bypassedApproval = false;
   let current = await runLockedRampScheduleAction(
     req.context,
     schedule.id,
-    (fresh) => {
+    async (fresh) => {
       if (!["running", "paused"].includes(fresh.status)) {
         throw new ConflictError(
           `Cannot advance: schedule changed to "${fresh.status}" while the request was in flight`,
@@ -684,12 +692,35 @@ export const apiAdvanceRampSchedule = createApiRequestHandler({
           "Cannot advance: the schedule advanced while the request was in flight",
         );
       }
+      // Re-derive the approval gate — holdConditions can change in place
+      // (steps editors allow it on the current step) while we waited.
+      const freshStep = fresh.steps[fresh.currentStepIndex];
+      const freshApprovalPending =
+        freshStep?.holdConditions?.requiresApproval &&
+        fresh.stepApproval?.stepIndex !== fresh.currentStepIndex;
+      if (freshApprovalPending && !force) {
+        throw new ConflictError(
+          "This step requires approval before advancing. Call `/actions/approve-step` first, or pass `force: true` to bypass (requires canBypassApprovalChecks permission).",
+        );
+      }
+      if (freshApprovalPending && force) {
+        const linkedFeature = await getFeature(req.context, fresh.entityId);
+        if (
+          !linkedFeature ||
+          !req.context.permissions.canBypassApprovalChecks(linkedFeature)
+        ) {
+          throw new PermissionError(
+            "force: true requires canBypassApprovalChecks permission on the linked feature",
+          );
+        }
+        bypassedApproval = true;
+      }
       return advanceScheduleManually(req.context, fresh);
     },
   );
   // Audit after the advance succeeds so the trail never records a bypass that
   // was rejected by the in-lock validation.
-  if (approvalPending && force) {
+  if (bypassedApproval) {
     await req.audit({
       event: "rampSchedule.approval-bypassed",
       entity: { object: "rampSchedule", id: schedule.id },

--- a/packages/back-end/src/api/ramp-schedules/rampScheduleActions.ts
+++ b/packages/back-end/src/api/ramp-schedules/rampScheduleActions.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { v4 as uuidv4 } from "uuid";
 import { PermissionError } from "shared/util";
-import type { RampScheduleInterface } from "shared/validators";
 import {
   apiRampScheduleInterface,
   DEFAULT_NO_TRAFFIC_GRACE_PERIOD_HOURS,
@@ -29,6 +28,7 @@ import {
   rollbackSchedule,
   restartSchedule,
   resumeSchedule,
+  runLockedRampScheduleAction,
   setRampMonitoringMode,
   startSchedule,
   syncLinkedSafeRolloutForRampState,
@@ -79,7 +79,18 @@ export const startRampSchedule = createApiRequestHandler({
     );
   }
 
-  const current = await startSchedule(req.context, schedule);
+  const current = await runLockedRampScheduleAction(
+    req.context,
+    schedule.id,
+    (fresh) => {
+      if (fresh.status !== "ready") {
+        throw new ConflictError(
+          `Cannot start: schedule changed to "${fresh.status}" while the request was in flight`,
+        );
+      }
+      return startSchedule(req.context, fresh);
+    },
+  );
   return { rampSchedule: rampScheduleToApiInterface(current) };
 });
 
@@ -105,7 +116,18 @@ export const pauseRampSchedule = createApiRequestHandler({
     );
   }
 
-  const updated = await pauseSchedule(req.context, schedule);
+  const updated = await runLockedRampScheduleAction(
+    req.context,
+    schedule.id,
+    (fresh) => {
+      if (fresh.status !== "running") {
+        throw new ConflictError(
+          `Cannot pause: schedule changed to "${fresh.status}" while the request was in flight`,
+        );
+      }
+      return pauseSchedule(req.context, fresh);
+    },
+  );
 
   return { rampSchedule: rampScheduleToApiInterface(updated) };
 });
@@ -132,7 +154,18 @@ export const resumeRampSchedule = createApiRequestHandler({
     );
   }
 
-  const updated = await resumeSchedule(req.context, schedule);
+  const updated = await runLockedRampScheduleAction(
+    req.context,
+    schedule.id,
+    (fresh) => {
+      if (fresh.status !== "paused") {
+        throw new ConflictError(
+          `Cannot resume: schedule changed to "${fresh.status}" while the request was in flight`,
+        );
+      }
+      return resumeSchedule(req.context, fresh);
+    },
+  );
 
   return { rampSchedule: rampScheduleToApiInterface(updated) };
 });
@@ -170,7 +203,18 @@ export const jumpRampSchedule = createApiRequestHandler({
     throw new Error(`Invalid targetStepIndex ${targetStepIndex}`);
   }
 
-  const updated = await jumpSchedule(req.context, schedule, targetStepIndex);
+  const updated = await runLockedRampScheduleAction(
+    req.context,
+    schedule.id,
+    (fresh) => {
+      if (["completed", "rolled-back"].includes(fresh.status)) {
+        throw new ConflictError(
+          `Cannot jump: schedule changed to "${fresh.status}" while the request was in flight`,
+        );
+      }
+      return jumpSchedule(req.context, fresh, targetStepIndex);
+    },
+  );
 
   return { rampSchedule: rampScheduleToApiInterface(updated) };
 });
@@ -197,19 +241,27 @@ export const completeRampSchedule = createApiRequestHandler({
     );
   }
 
-  const isSimple = schedule.steps.length === 0 && !!schedule.cutoffDate;
-  const disableNow = req.body?.disableRule === true || isSimple;
-  const hasFutureCutoff =
-    schedule.cutoffDate && schedule.cutoffDate > new Date();
+  const completed = await runLockedRampScheduleAction(
+    req.context,
+    schedule.id,
+    (fresh) => {
+      if (["completed", "rolled-back"].includes(fresh.status)) {
+        throw new ConflictError(
+          `Cannot complete: schedule changed to "${fresh.status}" while the request was in flight`,
+        );
+      }
+      const isSimple = fresh.steps.length === 0 && !!fresh.cutoffDate;
+      const disableNow = req.body?.disableRule === true || isSimple;
+      const hasFutureCutoff = fresh.cutoffDate && fresh.cutoffDate > new Date();
 
-  let completed: RampScheduleInterface;
-  if (!disableNow && hasFutureCutoff) {
-    completed = await completeRampKeepCutoff(req.context, schedule);
-  } else {
-    completed = await completeRollout(req.context, schedule, {
-      disableActiveTargets: disableNow,
-    });
-  }
+      if (!disableNow && hasFutureCutoff) {
+        return completeRampKeepCutoff(req.context, fresh);
+      }
+      return completeRollout(req.context, fresh, {
+        disableActiveTargets: disableNow,
+      });
+    },
+  );
 
   return { rampSchedule: rampScheduleToApiInterface(completed) };
 });
@@ -243,7 +295,23 @@ export const approveStepRampSchedule = createApiRequestHandler({
     );
   }
 
-  const err = await approveAndPublishStep(req.context, schedule, "api");
+  const err = await runLockedRampScheduleAction(
+    req.context,
+    schedule.id,
+    (fresh) => {
+      const freshStep = fresh.steps[fresh.currentStepIndex];
+      const stillAwaiting =
+        fresh.status === "running" &&
+        freshStep?.holdConditions?.requiresApproval &&
+        fresh.stepApproval?.stepIndex !== fresh.currentStepIndex;
+      if (!stillAwaiting) {
+        throw new ConflictError(
+          "Cannot approve step: schedule changed while the request was in flight",
+        );
+      }
+      return approveAndPublishStep(req.context, fresh, "api");
+    },
+  );
   if (err) {
     const detail = "detail" in err ? err.detail : undefined;
     if (err.code === "permission_denied") {
@@ -302,7 +370,18 @@ export const rollbackRampSchedule = createApiRequestHandler({
 
   const cause = req.body.reason?.trim();
   const reason = cause ? `Manual: ${cause}` : "Manual";
-  const updated = await rollbackSchedule(req.context, schedule, reason);
+  const updated = await runLockedRampScheduleAction(
+    req.context,
+    schedule.id,
+    (fresh) => {
+      if (["completed", "rolled-back"].includes(fresh.status)) {
+        throw new ConflictError(
+          `Cannot rollback: schedule changed to "${fresh.status}" while the request was in flight`,
+        );
+      }
+      return rollbackSchedule(req.context, fresh, reason);
+    },
+  );
 
   return { rampSchedule: rampScheduleToApiInterface(updated) };
 });
@@ -329,7 +408,18 @@ export const restartRampSchedule = createApiRequestHandler({
     );
   }
 
-  const updated = await restartSchedule(req.context, schedule);
+  const updated = await runLockedRampScheduleAction(
+    req.context,
+    schedule.id,
+    (fresh) => {
+      if (!["rolled-back", "completed"].includes(fresh.status)) {
+        throw new ConflictError(
+          `Cannot restart: schedule changed to "${fresh.status}" while the request was in flight`,
+        );
+      }
+      return restartSchedule(req.context, fresh);
+    },
+  );
   return { rampSchedule: rampScheduleToApiInterface(updated) };
 });
 
@@ -556,7 +646,18 @@ export const apiAdvanceRampSchedule = createApiRequestHandler({
     });
   }
 
-  let current = await advanceScheduleManually(req.context, schedule);
+  let current = await runLockedRampScheduleAction(
+    req.context,
+    schedule.id,
+    (fresh) => {
+      if (!["running", "paused"].includes(fresh.status)) {
+        throw new ConflictError(
+          `Cannot advance: schedule changed to "${fresh.status}" while the request was in flight`,
+        );
+      }
+      return advanceScheduleManually(req.context, fresh);
+    },
+  );
   current =
     (await req.context.models.rampSchedules.getById(schedule.id)) ?? current;
 
@@ -1013,10 +1114,11 @@ export const setMonitoringModeRampSchedule = createApiRequestHandler({
     req.params.id,
   );
   if (!schedule) throw new Error("Ramp schedule not found");
-  const updated = await setRampMonitoringMode(
+  const updated = await runLockedRampScheduleAction(
     req.context,
-    schedule,
-    req.body.monitoringMode,
+    schedule.id,
+    (fresh) =>
+      setRampMonitoringMode(req.context, fresh, req.body.monitoringMode),
   );
   return rampScheduleToApiInterface(updated);
 });
@@ -1043,10 +1145,15 @@ export const setAutoUpdateRampSchedule = createApiRequestHandler({
     req.params.id,
   );
   if (!schedule) throw new Error("Ramp schedule not found");
-  const updated = await setRampMonitoringMode(
+  const updated = await runLockedRampScheduleAction(
     req.context,
-    schedule,
-    req.body.enabled ? "auto" : "manual",
+    schedule.id,
+    (fresh) =>
+      setRampMonitoringMode(
+        req.context,
+        fresh,
+        req.body.enabled ? "auto" : "manual",
+      ),
   );
   return rampScheduleToApiInterface(updated);
 });
@@ -1069,10 +1176,10 @@ export const updateMonitoringConfigRampSchedule = createApiRequestHandler({
     req.params.id,
   );
   if (!schedule) throw new Error("Ramp schedule not found");
-  const updated = await updateRampMonitoringConfig(
+  const updated = await runLockedRampScheduleAction(
     req.context,
-    schedule,
-    req.body,
+    schedule.id,
+    (fresh) => updateRampMonitoringConfig(req.context, fresh, req.body),
   );
   return rampScheduleToApiInterface(updated);
 });
@@ -1093,10 +1200,10 @@ export const updateLockdownConfigRampSchedule = createApiRequestHandler({
     req.params.id,
   );
   if (!schedule) throw new Error("Ramp schedule not found");
-  const updated = await updateRampLockdownConfig(
+  const updated = await runLockedRampScheduleAction(
     req.context,
-    schedule,
-    req.body,
+    schedule.id,
+    (fresh) => updateRampLockdownConfig(req.context, fresh, req.body),
   );
   return rampScheduleToApiInterface(updated);
 });
@@ -1153,22 +1260,25 @@ export const updateStepsRampSchedule = createApiRequestHandler({
   );
   if (!schedule) throw new Error("Ramp schedule not found");
 
-  // Normalize incoming steps to the internal shape, preserving existing step
-  // actions (coverage patches) since the PUT body intentionally omits them.
-  const incomingSteps: (typeof schedule)["steps"] = req.body.steps.map(
-    (s, idx) => ({
-      interval: s.interval,
-      monitored: s.monitored ?? false,
-      holdConditions: s.holdConditions,
-      approvalNotes: s.approvalNotes ?? undefined,
-      actions: schedule.steps[idx]?.actions ?? [],
-    }),
-  );
-
-  const { schedule: updated } = await updateRampSteps(
+  const { schedule: updated } = await runLockedRampScheduleAction(
     req.context,
-    schedule,
-    incomingSteps,
+    schedule.id,
+    (fresh) => {
+      // Normalize incoming steps to the internal shape, preserving existing
+      // step actions (coverage patches) since the PUT body intentionally
+      // omits them. Read them from the in-lock doc so a concurrent advance's
+      // state isn't clobbered with stale actions.
+      const incomingSteps: (typeof fresh)["steps"] = req.body.steps.map(
+        (s, idx) => ({
+          interval: s.interval,
+          monitored: s.monitored ?? false,
+          holdConditions: s.holdConditions,
+          approvalNotes: s.approvalNotes ?? undefined,
+          actions: fresh.steps[idx]?.actions ?? [],
+        }),
+      );
+      return updateRampSteps(req.context, fresh, incomingSteps);
+    },
   );
 
   return { rampSchedule: rampScheduleToApiInterface(updated) };

--- a/packages/back-end/src/api/ramp-schedules/rampScheduleActions.ts
+++ b/packages/back-end/src/api/ramp-schedules/rampScheduleActions.ts
@@ -212,9 +212,8 @@ export const jumpRampSchedule = createApiRequestHandler({
           `Cannot jump: schedule changed to "${fresh.status}" while the request was in flight`,
         );
       }
-      // Re-validate bounds against the in-lock steps — a concurrent steps
-      // edit can shrink the array, and an out-of-range playhead reads as
-      // past-end (unintended completion) downstream.
+      // A concurrent steps edit can shrink the array, turning the playhead
+      // past-end (unintended completion).
       if (targetStepIndex >= fresh.steps.length) {
         throw new ConflictError(
           `Cannot jump: step ${targetStepIndex} no longer exists (the schedule's steps changed while the request was in flight)`,
@@ -307,8 +306,8 @@ export const approveStepRampSchedule = createApiRequestHandler({
     req.context,
     schedule.id,
     (fresh) => {
-      // Pin to the step the reviewer saw — with consecutive approval gates, a
-      // queued approval must not land on a step that was never reviewed.
+      // Pin to the step the reviewer saw — a queued approval must not land
+      // on a step that was never reviewed.
       if (fresh.currentStepIndex !== schedule.currentStepIndex) {
         throw new ConflictError(
           "Cannot approve step: the schedule advanced while the request was in flight",
@@ -503,9 +502,8 @@ export const addTargetRampSchedule = createApiRequestHandler({
     status: "active" as const,
   };
 
-  // Locked read-modify-write: concurrent add/eject calls would drop a target,
-  // and the pending→ready flip from a stale read could rewind a schedule the
-  // scheduler concurrently activated.
+  // Locked: concurrent add/eject calls would drop a target, and a stale
+  // pending→ready flip could rewind a scheduler-activated schedule.
   const updated = await runLockedRampScheduleAction(
     req.context,
     schedule.id,
@@ -679,9 +677,8 @@ export const apiAdvanceRampSchedule = createApiRequestHandler({
           `Cannot advance: schedule changed to "${fresh.status}" while the request was in flight`,
         );
       }
-      // Pin the playhead: the approval/force gates above were screened
-      // against this step; if a concurrent advance moved it, this request
-      // would silently skip an extra step (or an unscreened approval gate).
+      // Pin the playhead: a concurrent advance would make this skip an
+      // extra (unscreened) step.
       if (fresh.currentStepIndex !== schedule.currentStepIndex) {
         throw new ConflictError(
           "Cannot advance: the schedule advanced while the request was in flight",
@@ -1308,10 +1305,9 @@ export const updateStepsRampSchedule = createApiRequestHandler({
     req.context,
     schedule.id,
     (fresh) => {
-      // Normalize incoming steps to the internal shape, preserving existing
-      // step actions (coverage patches) since the PUT body intentionally
-      // omits them. Read them from the in-lock doc so a concurrent advance's
-      // state isn't clobbered with stale actions.
+      // The PUT body intentionally omits step actions (coverage patches) —
+      // preserve them from the in-lock doc so a concurrent advance's state
+      // isn't clobbered.
       const incomingSteps: (typeof fresh)["steps"] = req.body.steps.map(
         (s, idx) => ({
           interval: s.interval,

--- a/packages/back-end/src/jobs/updateRampSchedules.ts
+++ b/packages/back-end/src/jobs/updateRampSchedules.ts
@@ -115,9 +115,8 @@ export const advanceSingleRampSchedule = async (
   const context = await getContextForAgendaJobByOrgId(organization);
   const now = new Date();
 
-  // Screen the common no-op cases before taking the lock: the pending poll
-  // clause is time-unbounded (a schedule can await its draft publish for
-  // weeks), and those ticks shouldn't pay two lock writes per minute.
+  // Pre-lock screen: the pending poll is time-unbounded (a schedule can await
+  // its draft publish for weeks) and shouldn't pay two lock writes per minute.
   const screened = await context.models.rampSchedules.getById(rampScheduleId);
   if (!screened) return;
   if (screened.status === "pending") {
@@ -129,10 +128,8 @@ export const advanceSingleRampSchedule = async (
     if ((feature?.version ?? -1) < activatingVersion) return;
   }
 
-  // Serialize against every other advance path: only one advance runs per
-  // schedule at a time, so they can't replay/publish concurrently and clobber
-  // coverage. If another advance holds the lock, skip this tick — the
-  // schedule's nextProcessAt keeps it queued for a retry.
+  // If another advance holds the lock, skip this tick — the schedule's
+  // nextProcessAt keeps it queued for a retry.
   try {
     await withRampScheduleAdvanceLock(
       context,
@@ -160,8 +157,6 @@ async function runRampScheduleTick(
   heartbeat: () => Promise<void>,
 ) {
   try {
-    // Re-read inside the lock so we act on fresh state, not a snapshot taken
-    // before a concurrent advance completed.
     const schedule = await context.models.rampSchedules.getById(rampScheduleId);
     if (!schedule) return;
 
@@ -232,8 +227,7 @@ async function runRampScheduleTick(
     current = await ensureSafeRolloutForMonitoredRamp(context, current);
 
     const decision = await evaluateCurrentStep(context, current, now);
-    // The evaluation above can involve slow snapshot reads; refresh the
-    // lock's liveness before the (potentially slow) publish phase.
+    // Refresh the lease between the slow evaluation and slow publish phases.
     await heartbeat();
     await applyRampEvaluationDecision(context, current, decision, now);
   } catch (e) {

--- a/packages/back-end/src/jobs/updateRampSchedules.ts
+++ b/packages/back-end/src/jobs/updateRampSchedules.ts
@@ -10,12 +10,16 @@ import {
   ensureSafeRolloutForMonitoredRamp,
   onActivatingRevisionPublished,
   syncLinkedSafeRolloutForRampState,
+  withRampScheduleAdvanceLock,
 } from "back-end/src/services/rampSchedule";
 import {
   applyRampEvaluationDecision,
   evaluateCurrentStep,
 } from "back-end/src/services/rampScheduleEvaluator";
-import { ConcurrentIncrementalRefreshError } from "back-end/src/util/errors";
+import {
+  ConcurrentIncrementalRefreshError,
+  RampAdvanceLockBusyError,
+} from "back-end/src/util/errors";
 import { getFeature } from "back-end/src/models/FeatureModel";
 import { RampScheduleModel } from "back-end/src/models/RampScheduleModel";
 
@@ -26,6 +30,7 @@ import { RampScheduleModel } from "back-end/src/models/RampScheduleModel";
  */
 function isTransientRampError(e: unknown): boolean {
   if (e instanceof ConcurrentIncrementalRefreshError) return true;
+  if (e instanceof RampAdvanceLockBusyError) return true;
   // Mongo network / topology errors surface as generic Errors whose name or
   // message contains well-known driver strings.
   if (e instanceof Error) {
@@ -94,6 +99,17 @@ export default async function addRampScheduleJob(agenda: Agenda) {
   await job.save();
 }
 
+function getActivatingVersion(schedule: {
+  targets: { activatingRevisionVersion?: number | null }[];
+}): number | null {
+  const v = schedule.targets.find(
+    (t) =>
+      t.activatingRevisionVersion !== undefined &&
+      t.activatingRevisionVersion !== null,
+  )?.activatingRevisionVersion;
+  return v ?? null;
+}
+
 export const advanceSingleRampSchedule = async (
   job: AdvanceSingleRampScheduleJob,
 ) => {
@@ -102,21 +118,63 @@ export const advanceSingleRampSchedule = async (
   if (!rampScheduleId || !organization) return;
 
   const context = await getContextForAgendaJobByOrgId(organization);
-  const schedule = await context.models.rampSchedules.getById(rampScheduleId);
-  if (!schedule) return;
-
   const now = new Date();
 
+  // Screen the common no-op cases before taking the lock: the pending poll
+  // clause is time-unbounded (a schedule can await its draft publish for
+  // weeks), and those ticks shouldn't pay two lock writes per minute.
+  const screened = await context.models.rampSchedules.getById(rampScheduleId);
+  if (!screened) return;
+  if (screened.status === "pending") {
+    const activatingVersion = getActivatingVersion(screened);
+    if (activatingVersion === null) return;
+    const feature = screened.entityId
+      ? await getFeature(context, screened.entityId)
+      : undefined;
+    if ((feature?.version ?? -1) < activatingVersion) return;
+  }
+
+  // Serialize against every other advance path: only one advance runs per
+  // schedule at a time, so they can't replay/publish concurrently and clobber
+  // coverage. If another advance holds the lock, skip this tick — the
+  // schedule's nextProcessAt keeps it queued for a retry.
   try {
+    await withRampScheduleAdvanceLock(
+      context,
+      rampScheduleId,
+      async (heartbeat) => {
+        await runRampScheduleTick(context, rampScheduleId, now, heartbeat);
+      },
+    );
+  } catch (e) {
+    if (e instanceof RampAdvanceLockBusyError) {
+      logger.info(
+        { rampScheduleId },
+        "Skipping ramp schedule tick — advance already in progress",
+      );
+      return;
+    }
+    throw e;
+  }
+};
+
+async function runRampScheduleTick(
+  context: Awaited<ReturnType<typeof getContextForAgendaJobByOrgId>>,
+  rampScheduleId: string,
+  now: Date,
+  heartbeat: () => Promise<void>,
+) {
+  try {
+    // Re-read inside the lock so we act on fresh state, not a snapshot taken
+    // before a concurrent advance completed.
+    const schedule = await context.models.rampSchedules.getById(rampScheduleId);
+    if (!schedule) return;
+
     let current = schedule;
 
     if (current.status === "pending") {
-      const activatingVersion = current.targets.find(
-        (t) =>
-          t.activatingRevisionVersion !== undefined &&
-          t.activatingRevisionVersion !== null,
-      )?.activatingRevisionVersion;
-      if (activatingVersion !== undefined && activatingVersion !== null) {
+      const activatingVersion = getActivatingVersion(current);
+      if (activatingVersion !== null) {
         const feature = current.entityId
           ? await getFeature(context, current.entityId)
           : undefined;
@@ -175,21 +233,17 @@ export const advanceSingleRampSchedule = async (
       current = await ensureSafeRolloutForMonitoredRamp(context, current);
 
       const decision = await evaluateCurrentStep(context, current, now);
-      const result = await applyRampEvaluationDecision(
-        context,
-        current,
-        decision,
-      );
-      if (result.handled) {
-        return;
-      }
-      current = result.schedule;
+      // The evaluation above can involve slow snapshot reads; refresh the
+      // lock's liveness before the (potentially slow) publish phase.
+      await heartbeat();
+      await applyRampEvaluationDecision(context, current, decision);
+      return;
     }
 
     await advanceUntilBlocked(context, current, now);
   } catch (e) {
-    // Transient errors (lock contention, network blips) — log and let the
-    // next scheduler tick retry.
+    // Transient errors (network blips, cross-domain lock contention) — log
+    // and let the next scheduler tick retry.
     if (isTransientRampError(e)) {
       logger.info(
         { rampScheduleId },
@@ -231,4 +285,4 @@ export const advanceSingleRampSchedule = async (
       }
     }
   }
-};
+}

--- a/packages/back-end/src/jobs/updateRampSchedules.ts
+++ b/packages/back-end/src/jobs/updateRampSchedules.ts
@@ -2,7 +2,6 @@ import Agenda, { Job } from "agenda";
 import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizations";
 import { logger } from "back-end/src/util/logger";
 import {
-  advanceUntilBlocked,
   appendRampEvent,
   applyRampStartActions,
   completeRollout,
@@ -16,10 +15,7 @@ import {
   applyRampEvaluationDecision,
   evaluateCurrentStep,
 } from "back-end/src/services/rampScheduleEvaluator";
-import {
-  ConcurrentIncrementalRefreshError,
-  RampAdvanceLockBusyError,
-} from "back-end/src/util/errors";
+import { RampAdvanceLockBusyError } from "back-end/src/util/errors";
 import { getFeature } from "back-end/src/models/FeatureModel";
 import { RampScheduleModel } from "back-end/src/models/RampScheduleModel";
 
@@ -29,7 +25,6 @@ import { RampScheduleModel } from "back-end/src/models/RampScheduleModel";
  * in the UI.
  */
 function isTransientRampError(e: unknown): boolean {
-  if (e instanceof ConcurrentIncrementalRefreshError) return true;
   if (e instanceof RampAdvanceLockBusyError) return true;
   // Mongo network / topology errors surface as generic Errors whose name or
   // message contains well-known driver strings.
@@ -179,6 +174,9 @@ async function runRampScheduleTick(
           ? await getFeature(context, current.entityId)
           : undefined;
         if ((feature?.version ?? -1) >= activatingVersion) {
+          // Activation runs start actions + a catch-up publish — refresh the
+          // lease before this potentially slow multi-publish phase.
+          await heartbeat();
           await onActivatingRevisionPublished(context, current);
           current =
             (await context.models.rampSchedules.getById(current.id)) ?? current;
@@ -229,21 +227,18 @@ async function runRampScheduleTick(
       return;
     }
 
-    if (current.status === "running") {
-      current = await ensureSafeRolloutForMonitoredRamp(context, current);
+    if (current.status !== "running") return;
 
-      const decision = await evaluateCurrentStep(context, current, now);
-      // The evaluation above can involve slow snapshot reads; refresh the
-      // lock's liveness before the (potentially slow) publish phase.
-      await heartbeat();
-      await applyRampEvaluationDecision(context, current, decision);
-      return;
-    }
+    current = await ensureSafeRolloutForMonitoredRamp(context, current);
 
-    await advanceUntilBlocked(context, current, now);
+    const decision = await evaluateCurrentStep(context, current, now);
+    // The evaluation above can involve slow snapshot reads; refresh the
+    // lock's liveness before the (potentially slow) publish phase.
+    await heartbeat();
+    await applyRampEvaluationDecision(context, current, decision, now);
   } catch (e) {
-    // Transient errors (network blips, cross-domain lock contention) — log
-    // and let the next scheduler tick retry.
+    // Transient errors (network blips, lock contention) — log and let the
+    // next scheduler tick retry.
     if (isTransientRampError(e)) {
       logger.info(
         { rampScheduleId },

--- a/packages/back-end/src/jobs/updateRampSchedules.ts
+++ b/packages/back-end/src/jobs/updateRampSchedules.ts
@@ -117,15 +117,25 @@ export const advanceSingleRampSchedule = async (
 
   // Pre-lock screen: the pending poll is time-unbounded (a schedule can await
   // its draft publish for weeks) and shouldn't pay two lock writes per minute.
-  const screened = await context.models.rampSchedules.getById(rampScheduleId);
-  if (!screened) return;
-  if (screened.status === "pending") {
-    const activatingVersion = getActivatingVersion(screened);
-    if (activatingVersion === null) return;
-    const feature = screened.entityId
-      ? await getFeature(context, screened.entityId)
-      : undefined;
-    if ((feature?.version ?? -1) < activatingVersion) return;
+  // Screening errors skip the tick rather than failing the agenda job — the
+  // in-lock body re-reads everything and owns the error-pause semantics.
+  try {
+    const screened = await context.models.rampSchedules.getById(rampScheduleId);
+    if (!screened) return;
+    if (screened.status === "pending") {
+      const activatingVersion = getActivatingVersion(screened);
+      if (activatingVersion === null) return;
+      const feature = screened.entityId
+        ? await getFeature(context, screened.entityId)
+        : undefined;
+      if ((feature?.version ?? -1) < activatingVersion) return;
+    }
+  } catch (e) {
+    logger.warn(
+      { rampScheduleId, error: e instanceof Error ? e.message : String(e) },
+      "Error screening ramp schedule — skipping tick; will retry next poll",
+    );
+    return;
   }
 
   // If another advance holds the lock, skip this tick — the schedule's

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -2067,21 +2067,32 @@ async function createRampSchedulesForRevision(
     // enabled immediately when this revision publishes rather than waiting
     // for the next poller tick.
     //
-    // The pre-built auditEvent ("config-edited") is passed via contentUpdates
-    // so startReadyScheduleNow appends "started" on top of it, preserving
-    // full audit history parity with the direct-edit path.
+    // The "config-edited" audit event is passed so startReadyScheduleNow
+    // appends "started" on top of it, preserving full audit history parity
+    // with the direct-edit path.
+    let currentSchedule = existingSchedule;
+    let startDeferredToScheduler = false;
     if (
       updateAction.startDate === null &&
       existingSchedule?.status === "ready"
     ) {
-      await startReadyScheduleNow(context, existingSchedule, {
+      const configEditedEvent =
+        auditEvent.eventHistory?.[auditEvent.eventHistory.length - 1];
+      const started = await startReadyScheduleNow(context, existingSchedule, {
         ...contentUpdates,
         cutoffDate: nextCutoffDate,
-        ...(auditEvent.eventHistory
-          ? { eventHistory: auditEvent.eventHistory }
-          : {}),
+        ...(configEditedEvent ? { auditEvent: configEditedEvent } : {}),
       });
-      continue;
+      if (started) continue;
+      // The start didn't run: either the scheduler started it first (now
+      // running — the merge branch below applies the edits safely) or the
+      // lock stayed busy (still ready, start deferred to the scheduler via
+      // startDate=now — apply the edits without clobbering that deferral).
+      currentSchedule =
+        (await context.models.rampSchedules.getById(
+          updateAction.rampScheduleId,
+        )) ?? existingSchedule;
+      startDeferredToScheduler = currentSchedule.status === "ready";
     }
 
     // Running schedule TOCTOU guard: the schedule may have transitioned from
@@ -2093,11 +2104,11 @@ async function createRampSchedulesForRevision(
     // current step only accepts holdConditions/approvalNotes, and future steps
     // are fully applied — keeping publish from failing while avoiding
     // mid-run structural desyncs.
-    if (existingSchedule?.status === "running") {
+    if (currentSchedule?.status === "running") {
       const safeUpdates: Record<string, unknown> = {};
       if (stepsExplicit) {
         const { steps: mergedSteps } = mergeStepsForRunningSchedule(
-          existingSchedule,
+          currentSchedule,
           steps,
         );
         safeUpdates.steps = mergedSteps;
@@ -2116,7 +2127,7 @@ async function createRampSchedulesForRevision(
           ...auditEvent,
           nextProcessAt: computeNextProcessAt({
             status: "running",
-            nextStepAt: existingSchedule.nextStepAt,
+            nextStepAt: currentSchedule.nextStepAt,
             cutoffDate: nextCutoffDate,
             nextSnapshotAt: nextSnapshotAt,
           }),
@@ -2136,14 +2147,16 @@ async function createRampSchedulesForRevision(
     await context.models.rampSchedules.updateById(updateAction.rampScheduleId, {
       ...contentUpdates,
       ...auditEvent,
-      ...(updateAction.startDate !== undefined
+      ...(updateAction.startDate !== undefined && !startDeferredToScheduler
         ? { startDate: nextStartDate }
         : {}),
       nextProcessAt: computeNextProcessAt({
-        status: existingSchedule?.status ?? "paused",
-        nextStepAt: existingSchedule?.nextStepAt ?? null,
+        status: currentSchedule?.status ?? "paused",
+        nextStepAt: currentSchedule?.nextStepAt ?? null,
         cutoffDate: nextCutoffDate,
-        startDate: nextStartDate,
+        startDate: startDeferredToScheduler
+          ? (currentSchedule?.startDate ?? null)
+          : nextStartDate,
         nextSnapshotAt: nextSnapshotAt,
       }),
     });

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -56,6 +56,7 @@ import {
   getStartActionsFromRules,
   mergeStepsForRunningSchedule,
   remapTemplateActions,
+  runLockedRampScheduleAction,
   startReadyScheduleNow,
   syncLinkedSafeRolloutForRampState,
 } from "back-end/src/services/rampSchedule";
@@ -80,6 +81,7 @@ import {
   getSDKPayloadKeysByDiff,
 } from "back-end/src/util/features";
 import { applyPartialFeatureRuleUpdatesToRevision } from "back-end/src/util/featureRevision.util";
+import { NotFoundError } from "back-end/src/util/errors";
 import { logger } from "back-end/src/util/logger";
 import {
   getContextForAgendaJobByOrgId,
@@ -2000,9 +2002,6 @@ async function createRampSchedulesForRevision(
       updateAction.monitoringConfig !== undefined
         ? updateAction.monitoringConfig
         : existingSchedule?.monitoringConfig;
-    const nextSnapshotAt =
-      existingSchedule?.nextSnapshotAt ?? existingSchedule?.nextStepAt ?? null;
-
     // Build the content-level updates that apply regardless of start-now vs normal.
     const contentUpdates = {
       ...(updateAction.name !== undefined ? { name: updateAction.name } : {}),
@@ -2069,7 +2068,6 @@ async function createRampSchedulesForRevision(
     //
     // The "config-edited" audit event rides along so startReadyScheduleNow
     // appends "started" on top of it, matching the direct-edit path.
-    let currentSchedule = existingSchedule;
     let startDeferredToScheduler = false;
     if (
       updateAction.startDate === null &&
@@ -2083,81 +2081,173 @@ async function createRampSchedulesForRevision(
         ...(configEditedEvent ? { auditEvent: configEditedEvent } : {}),
       });
       if (started) continue;
-      // Start didn't run: either the scheduler started it first (the merge
-      // branch below applies the edits) or the lock stayed busy and the start
+      // Start didn't run: either the scheduler started it first (the locked
+      // update below applies the edits) or the lock stayed busy and the start
       // was deferred via startDate=now — don't clobber that deferral.
-      currentSchedule =
-        (await context.models.rampSchedules.getById(
-          updateAction.rampScheduleId,
-        )) ?? existingSchedule;
-      startDeferredToScheduler = currentSchedule.status === "ready";
+      const reread = await context.models.rampSchedules.getById(
+        updateAction.rampScheduleId,
+      );
+      if (!reread) {
+        logger.warn(
+          { rampScheduleId: updateAction.rampScheduleId },
+          "Ramp schedule removed while applying start-now update — skipping",
+        );
+        continue;
+      }
+      startDeferredToScheduler = reread.status === "ready";
     }
 
-    // Running schedule TOCTOU guard: the schedule may have transitioned from
-    // ready → running between when the user opened the modal and when this
-    // revision was published. Since the UI prevents editing a running
-    // schedule's steps/startDate, a stale draft update here is almost always
-    // an accidental race. We apply metadata updates normally and use
-    // mergeStepsForRunningSchedule for steps: past steps are frozen, the
-    // current step only accepts holdConditions/approvalNotes, and future steps
-    // are fully applied — keeping publish from failing while avoiding
-    // mid-run structural desyncs.
-    if (currentSchedule?.status === "running") {
-      const safeUpdates: Record<string, unknown> = {};
-      if (stepsExplicit) {
-        const { steps: mergedSteps } = mergeStepsForRunningSchedule(
-          currentSchedule,
-          steps,
-        );
-        safeUpdates.steps = mergedSteps;
-      }
-      if (updateAction.name !== undefined) safeUpdates.name = updateAction.name;
-      if (updateAction.cutoffDate !== undefined)
-        safeUpdates.cutoffDate = nextCutoffDate;
-      if (updateAction.monitoringConfig !== undefined)
-        safeUpdates.monitoringConfig = nextMonitoringConfig;
-      if (updateAction.lockdownConfig !== undefined)
-        safeUpdates.lockdownConfig = updateAction.lockdownConfig;
-      const updatedRunning = await context.models.rampSchedules.updateById(
+    // Apply the edits under the advance lock, deriving state-dependent pieces
+    // (running merge, paused clamp, audit history, nextProcessAt inputs) from
+    // the in-lock fresh doc — the schedule may have started, advanced, or been
+    // edited since the pre-publish read.
+    try {
+      await runLockedRampScheduleAction(
+        context,
         updateAction.rampScheduleId,
-        {
-          ...safeUpdates,
-          ...auditEvent,
-          nextProcessAt: computeNextProcessAt({
-            status: "running",
-            nextStepAt: currentSchedule.nextStepAt,
-            cutoffDate: nextCutoffDate,
-            nextSnapshotAt: nextSnapshotAt,
-          }),
+        async (fresh) => {
+          const effectiveCutoff =
+            updateAction.cutoffDate !== undefined
+              ? nextCutoffDate
+              : (fresh.cutoffDate ?? null);
+          const withAudit = (updates: Record<string, unknown>) => {
+            const edited = Object.keys(updates).filter(
+              (k) =>
+                !["eventHistory", "currentStepIndex", "nextStepAt"].includes(k),
+            );
+            if (updateAction.startDate !== undefined) edited.push("startDate");
+            if (edited.length === 0) return updates;
+            return {
+              ...updates,
+              eventHistory: appendRampEvent(fresh, "config-edited", {
+                stepIndex: fresh.currentStepIndex,
+                status: fresh.status,
+                reason: `Edited via draft: ${edited.join(", ")}`,
+              }),
+            };
+          };
+
+          // Running schedule TOCTOU guard: a stale draft update racing a
+          // started schedule applies metadata normally and merges steps (past
+          // steps frozen, current step limited to holds/notes, future steps
+          // fully applied) so publish neither fails nor desyncs the run.
+          if (fresh.status === "running") {
+            const safeUpdates: Record<string, unknown> = {};
+            if (stepsExplicit) {
+              const { steps: mergedSteps } = mergeStepsForRunningSchedule(
+                fresh,
+                steps,
+              );
+              safeUpdates.steps = mergedSteps;
+            }
+            if (updateAction.name !== undefined)
+              safeUpdates.name = updateAction.name;
+            if (updateAction.cutoffDate !== undefined)
+              safeUpdates.cutoffDate = nextCutoffDate;
+            if (updateAction.monitoringConfig !== undefined)
+              safeUpdates.monitoringConfig = nextMonitoringConfig;
+            if (updateAction.lockdownConfig !== undefined)
+              safeUpdates.lockdownConfig = updateAction.lockdownConfig;
+            // endActions apply at completion, so they're safe to update
+            // mid-run (startActions stay frozen — they're the rollback
+            // restore point).
+            if (updateAction.endActions !== undefined)
+              safeUpdates.endActions =
+                endActions.length > 0 ? endActions : undefined;
+            const updatedRunning =
+              await context.models.rampSchedules.updateById(
+                fresh.id,
+                withAudit({
+                  ...safeUpdates,
+                  nextProcessAt: computeNextProcessAt({
+                    status: "running",
+                    nextStepAt: fresh.nextStepAt,
+                    cutoffDate: effectiveCutoff,
+                    nextSnapshotAt: fresh.nextSnapshotAt,
+                  }),
+                }),
+              );
+            // Sync SafeRollout state in case monitored-step membership changed.
+            if (safeUpdates.steps) {
+              const ensured = await ensureSafeRolloutForMonitoredRamp(
+                context,
+                updatedRunning,
+              );
+              await syncLinkedSafeRolloutForRampState(context, ensured);
+            }
+            return;
+          }
+
+          const freshContentUpdates = {
+            ...(updateAction.name !== undefined
+              ? { name: updateAction.name }
+              : {}),
+            // startActions are the rollback restore point — only editable
+            // before the ramp has fired.
+            ...(updateAction.startActions !== undefined &&
+            (fresh.status === "pending" || fresh.status === "ready")
+              ? {
+                  startActions:
+                    startActions.length > 0 ? startActions : undefined,
+                }
+              : {}),
+            ...(stepsExplicit ? { steps } : {}),
+            ...(updateAction.endActions !== undefined
+              ? { endActions: endActions.length > 0 ? endActions : undefined }
+              : {}),
+            ...(updateAction.cutoffDate !== undefined
+              ? { cutoffDate: nextCutoffDate }
+              : {}),
+            ...(updateAction.monitoringConfig !== undefined
+              ? { monitoringConfig: nextMonitoringConfig }
+              : {}),
+            ...(updateAction.lockdownConfig !== undefined
+              ? { lockdownConfig: updateAction.lockdownConfig }
+              : {}),
+            // Steps edited on a paused schedule: clamp the playhead and clear
+            // nextStepAt so resume recalculates timing from scratch.
+            ...(fresh.status === "paused" &&
+            fresh.currentStepIndex >= steps.length
+              ? {
+                  currentStepIndex: Math.max(steps.length - 1, -1),
+                  nextStepAt: null,
+                }
+              : {}),
+          };
+
+          await context.models.rampSchedules.updateById(
+            fresh.id,
+            withAudit({
+              ...freshContentUpdates,
+              ...(updateAction.startDate !== undefined &&
+              !startDeferredToScheduler
+                ? { startDate: nextStartDate }
+                : {}),
+              nextProcessAt: computeNextProcessAt({
+                status: fresh.status,
+                nextStepAt: fresh.nextStepAt,
+                cutoffDate: effectiveCutoff,
+                startDate: startDeferredToScheduler
+                  ? (fresh.startDate ?? null)
+                  : updateAction.startDate !== undefined
+                    ? nextStartDate
+                    : (fresh.startDate ?? null),
+                nextSnapshotAt: fresh.nextSnapshotAt,
+              }),
+            }),
+          );
         },
       );
-      // Sync SafeRollout state in case monitored-step membership changed.
-      if (safeUpdates.steps) {
-        const ensured = await ensureSafeRolloutForMonitoredRamp(
-          context,
-          updatedRunning,
+    } catch (e) {
+      if (e instanceof NotFoundError) {
+        logger.warn(
+          { rampScheduleId: updateAction.rampScheduleId },
+          "Ramp schedule removed while applying update action — skipping",
         );
-        await syncLinkedSafeRolloutForRampState(context, ensured);
+        continue;
       }
-      continue;
+      throw e;
     }
-
-    await context.models.rampSchedules.updateById(updateAction.rampScheduleId, {
-      ...contentUpdates,
-      ...auditEvent,
-      ...(updateAction.startDate !== undefined && !startDeferredToScheduler
-        ? { startDate: nextStartDate }
-        : {}),
-      nextProcessAt: computeNextProcessAt({
-        status: currentSchedule?.status ?? "paused",
-        nextStepAt: currentSchedule?.nextStepAt ?? null,
-        cutoffDate: nextCutoffDate,
-        startDate: startDeferredToScheduler
-          ? (currentSchedule?.startDate ?? null)
-          : nextStartDate,
-        nextSnapshotAt: nextSnapshotAt,
-      }),
-    });
   }
 
   return createdIds;

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -2067,9 +2067,8 @@ async function createRampSchedulesForRevision(
     // enabled immediately when this revision publishes rather than waiting
     // for the next poller tick.
     //
-    // The "config-edited" audit event is passed so startReadyScheduleNow
-    // appends "started" on top of it, preserving full audit history parity
-    // with the direct-edit path.
+    // The "config-edited" audit event rides along so startReadyScheduleNow
+    // appends "started" on top of it, matching the direct-edit path.
     let currentSchedule = existingSchedule;
     let startDeferredToScheduler = false;
     if (
@@ -2084,10 +2083,9 @@ async function createRampSchedulesForRevision(
         ...(configEditedEvent ? { auditEvent: configEditedEvent } : {}),
       });
       if (started) continue;
-      // The start didn't run: either the scheduler started it first (now
-      // running — the merge branch below applies the edits safely) or the
-      // lock stayed busy (still ready, start deferred to the scheduler via
-      // startDate=now — apply the edits without clobbering that deferral).
+      // Start didn't run: either the scheduler started it first (the merge
+      // branch below applies the edits) or the lock stayed busy and the start
+      // was deferred via startDate=now — don't clobber that deferral.
       currentSchedule =
         (await context.models.rampSchedules.getById(
           updateAction.rampScheduleId,

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -2067,19 +2067,19 @@ async function createRampSchedulesForRevision(
     // enabled immediately when this revision publishes rather than waiting
     // for the next poller tick.
     //
-    // Thread the pre-built auditEvent ("config-edited") into the schedule
-    // object so startReadyScheduleNow appends "started" on top of it,
-    // preserving full audit history parity with the direct-edit path.
+    // The pre-built auditEvent ("config-edited") is passed via contentUpdates
+    // so startReadyScheduleNow appends "started" on top of it, preserving
+    // full audit history parity with the direct-edit path.
     if (
       updateAction.startDate === null &&
       existingSchedule?.status === "ready"
     ) {
-      const scheduleForStart = auditEvent.eventHistory
-        ? { ...existingSchedule, eventHistory: auditEvent.eventHistory }
-        : existingSchedule;
-      await startReadyScheduleNow(context, scheduleForStart, {
+      await startReadyScheduleNow(context, existingSchedule, {
         ...contentUpdates,
         cutoffDate: nextCutoffDate,
+        ...(auditEvent.eventHistory
+          ? { eventHistory: auditEvent.eventHistory }
+          : {}),
       });
       continue;
     }

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -2002,83 +2002,59 @@ async function createRampSchedulesForRevision(
       updateAction.monitoringConfig !== undefined
         ? updateAction.monitoringConfig
         : existingSchedule?.monitoringConfig;
-    // Build the content-level updates that apply regardless of start-now vs normal.
-    const contentUpdates = {
-      ...(updateAction.name !== undefined ? { name: updateAction.name } : {}),
-      // Don't overwrite startActions once a ramp has actually started executing.
-      // They are the pre-ramp rule state used as the rollback restore point; if
-      // we let a stale draft overwrite them, "roll back to start" applies the
-      // degraded runtime coverage instead of the original 0%.
-      // Only update startActions for ramps that haven't fired yet (pending/ready).
-      ...(updateAction.startActions !== undefined &&
-      (existingSchedule?.status === "pending" ||
-        existingSchedule?.status === "ready")
-        ? { startActions: startActions.length > 0 ? startActions : undefined }
-        : {}),
-      // Only include steps when the caller explicitly provided them (non-empty
-      // steps array or a template). When absent, existing steps are preserved
-      // via the `existingSchedule.steps` fallback in the `steps` variable above.
-      ...(stepsExplicit ? { steps } : {}),
-      ...(updateAction.endActions !== undefined
-        ? { endActions: endActions.length > 0 ? endActions : undefined }
-        : {}),
-      ...(updateAction.cutoffDate !== undefined
-        ? { cutoffDate: nextCutoffDate }
-        : {}),
-      ...(updateAction.monitoringConfig !== undefined
-        ? { monitoringConfig: nextMonitoringConfig }
-        : {}),
-      ...(updateAction.lockdownConfig !== undefined
-        ? { lockdownConfig: updateAction.lockdownConfig }
-        : {}),
-      // Q9: if steps were edited on a paused schedule, clamp currentStepIndex
-      // to avoid an out-of-bounds access on resume, and clear nextStepAt so
-      // resumeSchedule() recalculates timing from scratch instead of
-      // adjusting a stale value that reflects the old step intervals.
-      ...(existingSchedule?.status === "paused" &&
-      existingSchedule.currentStepIndex >= steps.length
-        ? {
-            currentStepIndex: Math.max(steps.length - 1, -1),
-            nextStepAt: null,
-          }
-        : {}),
-    };
-
-    // Audit event: record which fields changed via the draft/publish path,
-    // mirroring what the direct-edit controller already does.
-    const editedFields = Object.keys(contentUpdates).filter(
-      (k) => !["eventHistory", "currentStepIndex", "nextStepAt"].includes(k),
-    );
-    if (updateAction.startDate !== undefined) editedFields.push("startDate");
-    const auditEvent =
-      editedFields.length > 0 && existingSchedule
-        ? {
-            eventHistory: appendRampEvent(existingSchedule, "config-edited", {
-              stepIndex: existingSchedule.currentStepIndex,
-              status: existingSchedule.status,
-              reason: `Edited via draft: ${editedFields.join(", ")}`,
-            }),
-          }
-        : {};
-
-    // "Start now": user explicitly cleared startDate on a schedule that has
-    // not yet started. Transition ready → running inline so the rule is
-    // enabled immediately when this revision publishes rather than waiting
-    // for the next poller tick.
-    //
-    // The "config-edited" audit event rides along so startReadyScheduleNow
-    // appends "started" on top of it, matching the direct-edit path.
+    // "Start now": user explicitly cleared startDate on a not-yet-started
+    // schedule. Transition ready → running inline so the rule goes live on
+    // publish instead of at the next poller tick. A ready schedule has all
+    // fields editable (startActions included — the ramp hasn't fired), so no
+    // running-merge / paused-clamp handling is needed here.
     let startDeferredToScheduler = false;
     if (
       updateAction.startDate === null &&
       existingSchedule?.status === "ready"
     ) {
-      const configEditedEvent =
-        auditEvent.eventHistory?.[auditEvent.eventHistory.length - 1];
+      const contentUpdates: Parameters<typeof startReadyScheduleNow>[2] = {};
+      const edited: string[] = [];
+      const set = (provided: boolean, key: string, value: unknown) => {
+        if (!provided) return;
+        (contentUpdates as Record<string, unknown>)[key] = value;
+        edited.push(key);
+      };
+      set(updateAction.name !== undefined, "name", updateAction.name);
+      set(
+        updateAction.startActions !== undefined,
+        "startActions",
+        startActions.length > 0 ? startActions : undefined,
+      );
+      set(stepsExplicit, "steps", steps);
+      set(
+        updateAction.endActions !== undefined,
+        "endActions",
+        endActions.length > 0 ? endActions : undefined,
+      );
+      set(updateAction.cutoffDate !== undefined, "cutoffDate", nextCutoffDate);
+      set(
+        updateAction.monitoringConfig !== undefined,
+        "monitoringConfig",
+        nextMonitoringConfig,
+      );
+      set(
+        updateAction.lockdownConfig !== undefined,
+        "lockdownConfig",
+        updateAction.lockdownConfig,
+      );
+      edited.push("startDate"); // always changed on this path (cleared)
+
+      // A "config-edited" event rides along so startReadyScheduleNow appends
+      // "started" on top of it, matching the direct-edit path.
+      const history = appendRampEvent(existingSchedule, "config-edited", {
+        stepIndex: existingSchedule.currentStepIndex,
+        status: existingSchedule.status,
+        reason: `Edited via draft: ${edited.join(", ")}`,
+      });
       const started = await startReadyScheduleNow(context, existingSchedule, {
         ...contentUpdates,
         cutoffDate: nextCutoffDate,
-        ...(configEditedEvent ? { auditEvent: configEditedEvent } : {}),
+        auditEvent: history[history.length - 1],
       });
       if (started) continue;
       // Start didn't run: either the scheduler started it first (the locked
@@ -2106,136 +2082,115 @@ async function createRampSchedulesForRevision(
         context,
         updateAction.rampScheduleId,
         async (fresh) => {
-          const effectiveCutoff =
-            updateAction.cutoffDate !== undefined
-              ? nextCutoffDate
-              : (fresh.cutoffDate ?? null);
-          const withAudit = (updates: Record<string, unknown>) => {
-            const edited = Object.keys(updates).filter(
-              (k) =>
-                !["eventHistory", "currentStepIndex", "nextStepAt"].includes(k),
-            );
-            if (updateAction.startDate !== undefined) edited.push("startDate");
-            if (edited.length === 0) return updates;
-            return {
-              ...updates,
-              eventHistory: appendRampEvent(fresh, "config-edited", {
-                stepIndex: fresh.currentStepIndex,
-                status: fresh.status,
-                reason: `Edited via draft: ${edited.join(", ")}`,
-              }),
-            };
+          const isRunning = fresh.status === "running";
+          const canEditStartActions =
+            fresh.status === "pending" || fresh.status === "ready";
+          const startDateChanged = updateAction.startDate !== undefined;
+
+          // Collect the caller's config edits. `set` writes a key only when the
+          // field was provided, so omitted fields are preserved, and records
+          // which fields changed for the audit trail.
+          const patch: Record<string, unknown> = {};
+          const edited: string[] = [];
+          const set = (provided: boolean, key: string, value: unknown) => {
+            if (!provided) return;
+            patch[key] = value;
+            edited.push(key);
           };
 
-          // Running schedule TOCTOU guard: a stale draft update racing a
-          // started schedule applies metadata normally and merges steps (past
-          // steps frozen, current step limited to holds/notes, future steps
-          // fully applied) so publish neither fails nor desyncs the run.
-          if (fresh.status === "running") {
-            const safeUpdates: Record<string, unknown> = {};
+          set(updateAction.name !== undefined, "name", updateAction.name);
+          set(
+            updateAction.cutoffDate !== undefined,
+            "cutoffDate",
+            nextCutoffDate,
+          );
+          set(
+            updateAction.monitoringConfig !== undefined,
+            "monitoringConfig",
+            nextMonitoringConfig,
+          );
+          set(
+            updateAction.lockdownConfig !== undefined,
+            "lockdownConfig",
+            updateAction.lockdownConfig,
+          );
+          // endActions only apply at completion, so they're safe to edit mid-run.
+          set(
+            updateAction.endActions !== undefined,
+            "endActions",
+            endActions.length > 0 ? endActions : undefined,
+          );
+
+          if (isRunning) {
+            // Running TOCTOU guard: freeze the past, allow only holds/notes on
+            // the current step, apply future steps. startActions stay frozen —
+            // they're the rollback restore point.
             if (stepsExplicit) {
-              const { steps: mergedSteps } = mergeStepsForRunningSchedule(
-                fresh,
-                steps,
+              set(
+                true,
+                "steps",
+                mergeStepsForRunningSchedule(fresh, steps).steps,
               );
-              safeUpdates.steps = mergedSteps;
             }
-            if (updateAction.name !== undefined)
-              safeUpdates.name = updateAction.name;
-            if (updateAction.cutoffDate !== undefined)
-              safeUpdates.cutoffDate = nextCutoffDate;
-            if (updateAction.monitoringConfig !== undefined)
-              safeUpdates.monitoringConfig = nextMonitoringConfig;
-            if (updateAction.lockdownConfig !== undefined)
-              safeUpdates.lockdownConfig = updateAction.lockdownConfig;
-            // endActions apply at completion, so they're safe to update
-            // mid-run (startActions stay frozen — they're the rollback
-            // restore point).
-            if (updateAction.endActions !== undefined)
-              safeUpdates.endActions =
-                endActions.length > 0 ? endActions : undefined;
-            const updatedRunning =
-              await context.models.rampSchedules.updateById(
-                fresh.id,
-                withAudit({
-                  ...safeUpdates,
-                  nextProcessAt: computeNextProcessAt({
-                    status: "running",
-                    nextStepAt: fresh.nextStepAt,
-                    cutoffDate: effectiveCutoff,
-                    nextSnapshotAt: fresh.nextSnapshotAt,
-                  }),
-                }),
-              );
-            // Sync SafeRollout state in case monitored-step membership changed.
-            if (safeUpdates.steps) {
-              const ensured = await ensureSafeRolloutForMonitoredRamp(
-                context,
-                updatedRunning,
-              );
-              await syncLinkedSafeRolloutForRampState(context, ensured);
+          } else {
+            set(stepsExplicit, "steps", steps);
+            set(
+              canEditStartActions && updateAction.startActions !== undefined,
+              "startActions",
+              startActions.length > 0 ? startActions : undefined,
+            );
+            if (startDateChanged) edited.push("startDate");
+            if (startDateChanged && !startDeferredToScheduler) {
+              patch.startDate = nextStartDate;
             }
-            return;
+            // Steps edited on a paused schedule: clamp the playhead and let
+            // resume recompute timing. Internal fields, not part of the audit.
+            if (
+              fresh.status === "paused" &&
+              fresh.currentStepIndex >= steps.length
+            ) {
+              patch.currentStepIndex = Math.max(steps.length - 1, -1);
+              patch.nextStepAt = null;
+            }
           }
 
-          const freshContentUpdates = {
-            ...(updateAction.name !== undefined
-              ? { name: updateAction.name }
-              : {}),
-            // startActions are the rollback restore point — only editable
-            // before the ramp has fired.
-            ...(updateAction.startActions !== undefined &&
-            (fresh.status === "pending" || fresh.status === "ready")
-              ? {
-                  startActions:
-                    startActions.length > 0 ? startActions : undefined,
-                }
-              : {}),
-            ...(stepsExplicit ? { steps } : {}),
-            ...(updateAction.endActions !== undefined
-              ? { endActions: endActions.length > 0 ? endActions : undefined }
-              : {}),
-            ...(updateAction.cutoffDate !== undefined
-              ? { cutoffDate: nextCutoffDate }
-              : {}),
-            ...(updateAction.monitoringConfig !== undefined
-              ? { monitoringConfig: nextMonitoringConfig }
-              : {}),
-            ...(updateAction.lockdownConfig !== undefined
-              ? { lockdownConfig: updateAction.lockdownConfig }
-              : {}),
-            // Steps edited on a paused schedule: clamp the playhead and clear
-            // nextStepAt so resume recalculates timing from scratch.
-            ...(fresh.status === "paused" &&
-            fresh.currentStepIndex >= steps.length
-              ? {
-                  currentStepIndex: Math.max(steps.length - 1, -1),
-                  nextStepAt: null,
-                }
-              : {}),
-          };
+          if (edited.length > 0) {
+            patch.eventHistory = appendRampEvent(fresh, "config-edited", {
+              stepIndex: fresh.currentStepIndex,
+              status: fresh.status,
+              reason: `Edited via draft: ${edited.join(", ")}`,
+            });
+          }
 
-          await context.models.rampSchedules.updateById(
+          patch.nextProcessAt = computeNextProcessAt({
+            status: fresh.status,
+            nextStepAt: fresh.nextStepAt,
+            cutoffDate:
+              updateAction.cutoffDate !== undefined
+                ? nextCutoffDate
+                : (fresh.cutoffDate ?? null),
+            // running ignores startDate; ready uses it. Only reflect the new
+            // startDate when we actually persist it here.
+            startDate:
+              !isRunning && startDateChanged && !startDeferredToScheduler
+                ? nextStartDate
+                : (fresh.startDate ?? null),
+            nextSnapshotAt: fresh.nextSnapshotAt,
+          });
+
+          const updated = await context.models.rampSchedules.updateById(
             fresh.id,
-            withAudit({
-              ...freshContentUpdates,
-              ...(updateAction.startDate !== undefined &&
-              !startDeferredToScheduler
-                ? { startDate: nextStartDate }
-                : {}),
-              nextProcessAt: computeNextProcessAt({
-                status: fresh.status,
-                nextStepAt: fresh.nextStepAt,
-                cutoffDate: effectiveCutoff,
-                startDate: startDeferredToScheduler
-                  ? (fresh.startDate ?? null)
-                  : updateAction.startDate !== undefined
-                    ? nextStartDate
-                    : (fresh.startDate ?? null),
-                nextSnapshotAt: fresh.nextSnapshotAt,
-              }),
-            }),
+            patch,
           );
+
+          // Sync SafeRollout in case monitored-step membership changed.
+          if (isRunning && patch.steps) {
+            const ensured = await ensureSafeRolloutForMonitoredRamp(
+              context,
+              updated,
+            );
+            await syncLinkedSafeRolloutForRampState(context, ensured);
+          }
         },
       );
     } catch (e) {

--- a/packages/back-end/src/models/RampScheduleModel.ts
+++ b/packages/back-end/src/models/RampScheduleModel.ts
@@ -27,13 +27,9 @@ import { MakeModelClass } from "./BaseModel";
 
 export const COLLECTION_NAME = "rampschedules";
 
-// An advance lock is stale once its heartbeat is older than this, so a holder
-// that crashed mid-advance can't wedge the schedule. The scheduler holds the
-// lock across its whole tick (evaluator + publish + syncs) and heartbeats
-// between phases, so this only needs to cover a single slow phase. Matches
-// INCREMENTAL_LOCK_STALE_MS — under the load conditions where publishes get
-// slow, a short threshold would let a live holder be stale-reclaimed and
-// reintroduce the concurrent double-publish this lock exists to prevent.
+// Stale = crashed-holder reclaim. 10min plus between-phase heartbeats: a
+// shorter threshold let live holders be stale-reclaimed under slow publishes,
+// reintroducing the double-publish this lock exists to prevent.
 const ADVANCE_LOCK_STALE_MS = 10 * 60 * 1000;
 
 export function migrateRampScheduleEndCondition<
@@ -447,8 +443,7 @@ export class RampScheduleModel extends BaseClass {
       );
     }
 
-    // Locked so the read-modify-write (steps/eventHistory/nextProcessAt)
-    // can't clobber a concurrent advance.
+    // Locked so the read-modify-write can't clobber a concurrent advance.
     return runLockedRampScheduleAction(
       this.context,
       req.params.id,
@@ -722,9 +717,7 @@ export class RampScheduleModel extends BaseClass {
     return map;
   }
 
-  // Atomically claim the per-schedule advance lock. Returns false if another
-  // holder has it and its claim isn't stale. Modeled on
-  // IncrementalRefreshModel.acquireLock.
+  // Modeled on IncrementalRefreshModel.acquireLock.
   public async acquireAdvanceLock(id: string, token: string): Promise<boolean> {
     const staleThreshold = new Date(Date.now() - ADVANCE_LOCK_STALE_MS);
     const result = await this._dangerousGetCollection().updateOne(
@@ -764,10 +757,8 @@ export class RampScheduleModel extends BaseClass {
     );
   }
 
-  // Refresh the lock's liveness timestamp so a long multi-phase advance isn't
-  // stale-reclaimed mid-flight. Returns false when the token no longer holds
-  // the lock (stale-reclaimed) so the holder can abort instead of writing
-  // concurrently with the reclaimer.
+  // Returns false when the token no longer holds the lock (stale-reclaimed)
+  // so the holder can abort instead of writing concurrently with the reclaimer.
   public async touchAdvanceLockHeartbeat(
     id: string,
     token: string,

--- a/packages/back-end/src/models/RampScheduleModel.ts
+++ b/packages/back-end/src/models/RampScheduleModel.ts
@@ -18,6 +18,7 @@ import {
   getEffectiveRampAutoUpdateState,
   getRampAutoUpdatePreference,
   getRampMonitoringMode,
+  runLockedRampScheduleAction,
   syncLinkedSafeRolloutForRampState,
 } from "back-end/src/services/rampSchedule";
 import { applyPagination } from "back-end/src/util/handler";
@@ -440,17 +441,25 @@ export class RampScheduleModel extends BaseClass {
   public override async handleApiUpdate(
     req: Parameters<InstanceType<typeof BaseClass>["handleApiUpdate"]>[0],
   ) {
-    const schedule = await this.getById(req.params.id);
-    if (!schedule) {
-      throw new Error("Ramp schedule not found");
-    }
-
     if (!this.context.hasPremiumFeature("ramp-schedules")) {
       this.context.throwPlanDoesNotAllowError(
         "Ramp schedules require an Enterprise plan.",
       );
     }
 
+    // Locked so the read-modify-write (steps/eventHistory/nextProcessAt)
+    // can't clobber a concurrent advance.
+    return runLockedRampScheduleAction(
+      this.context,
+      req.params.id,
+      (schedule) => this.applyApiUpdateLocked(req, schedule),
+    );
+  }
+
+  private async applyApiUpdateLocked(
+    req: Parameters<InstanceType<typeof BaseClass>["handleApiUpdate"]>[0],
+    schedule: RampScheduleInterface,
+  ) {
     if (!["pending", "ready", "paused"].includes(schedule.status)) {
       throw new Error(
         `Cannot update ramp schedule in status "${schedule.status}". Only pending, ready, or paused schedules can be modified.`,
@@ -756,12 +765,14 @@ export class RampScheduleModel extends BaseClass {
   }
 
   // Refresh the lock's liveness timestamp so a long multi-phase advance isn't
-  // stale-reclaimed mid-flight. No-op if the token no longer holds the lock.
+  // stale-reclaimed mid-flight. Returns false when the token no longer holds
+  // the lock (stale-reclaimed) so the holder can abort instead of writing
+  // concurrently with the reclaimer.
   public async touchAdvanceLockHeartbeat(
     id: string,
     token: string,
-  ): Promise<void> {
-    await this._dangerousGetCollection().updateOne(
+  ): Promise<boolean> {
+    const result = await this._dangerousGetCollection().updateOne(
       {
         organization: this.context.org.id,
         id,
@@ -769,6 +780,7 @@ export class RampScheduleModel extends BaseClass {
       },
       { $set: { advanceLockAt: new Date() } },
     );
+    return result.matchedCount > 0;
   }
 
   /**

--- a/packages/back-end/src/models/RampScheduleModel.ts
+++ b/packages/back-end/src/models/RampScheduleModel.ts
@@ -26,6 +26,15 @@ import { MakeModelClass } from "./BaseModel";
 
 export const COLLECTION_NAME = "rampschedules";
 
+// An advance lock is stale once its heartbeat is older than this, so a holder
+// that crashed mid-advance can't wedge the schedule. The scheduler holds the
+// lock across its whole tick (evaluator + publish + syncs) and heartbeats
+// between phases, so this only needs to cover a single slow phase. Matches
+// INCREMENTAL_LOCK_STALE_MS — under the load conditions where publishes get
+// slow, a short threshold would let a live holder be stale-reclaimed and
+// reintroduce the concurrent double-publish this lock exists to prevent.
+const ADVANCE_LOCK_STALE_MS = 10 * 60 * 1000;
+
 export function migrateRampScheduleEndCondition<
   T extends {
     endCondition?: { trigger?: { type: string; at: unknown } | null } | null;
@@ -702,6 +711,64 @@ export class RampScheduleModel extends BaseClass {
       }
     }
     return map;
+  }
+
+  // Atomically claim the per-schedule advance lock. Returns false if another
+  // holder has it and its claim isn't stale. Modeled on
+  // IncrementalRefreshModel.acquireLock.
+  public async acquireAdvanceLock(id: string, token: string): Promise<boolean> {
+    const staleThreshold = new Date(Date.now() - ADVANCE_LOCK_STALE_MS);
+    const result = await this._dangerousGetCollection().updateOne(
+      {
+        organization: this.context.org.id,
+        id,
+        $or: [
+          // Unlocked ({ field: null } also matches docs missing the field).
+          { advanceLockToken: null },
+          // Holder crashed/stalled — reclaim.
+          { advanceLockAt: { $lt: staleThreshold, $ne: null } },
+        ],
+      },
+      {
+        $set: {
+          advanceLockToken: token,
+          advanceLockAt: new Date(),
+        },
+      },
+    );
+    return (result.modifiedCount ?? 0) > 0;
+  }
+
+  public async releaseAdvanceLock(id: string, token: string): Promise<void> {
+    await this._dangerousGetCollection().updateOne(
+      {
+        organization: this.context.org.id,
+        id,
+        advanceLockToken: token,
+      },
+      {
+        $set: {
+          advanceLockToken: null,
+          advanceLockAt: null,
+        },
+      },
+    );
+  }
+
+  // Refresh the lock's liveness timestamp so a long multi-phase advance isn't
+  // stale-reclaimed mid-flight. No-op if the token no longer holds the lock.
+  public async touchAdvanceLockHeartbeat(
+    id: string,
+    token: string,
+  ): Promise<void> {
+    await this._dangerousGetCollection().updateOne(
+      {
+        organization: this.context.org.id,
+        id,
+        advanceLockToken: token,
+      },
+      { $set: { advanceLockAt: new Date() } },
+    );
   }
 
   /**

--- a/packages/back-end/src/models/RampScheduleModel.ts
+++ b/packages/back-end/src/models/RampScheduleModel.ts
@@ -22,6 +22,7 @@ import {
   syncLinkedSafeRolloutForRampState,
 } from "back-end/src/services/rampSchedule";
 import { applyPagination } from "back-end/src/util/handler";
+import { ConflictError, NotFoundError } from "back-end/src/util/errors";
 import { rampTargetsEquivalent } from "back-end/src/util/flattenRules";
 import { MakeModelClass } from "./BaseModel";
 
@@ -437,6 +438,12 @@ export class RampScheduleModel extends BaseClass {
   public override async handleApiUpdate(
     req: Parameters<InstanceType<typeof BaseClass>["handleApiUpdate"]>[0],
   ) {
+    // Neutral not-found for unknown ids; the lock helper's "no longer exists"
+    // message is reserved for the deleted-while-locked race.
+    if (!(await this.getById(req.params.id))) {
+      throw new NotFoundError("Ramp schedule not found");
+    }
+
     if (!this.context.hasPremiumFeature("ramp-schedules")) {
       this.context.throwPlanDoesNotAllowError(
         "Ramp schedules require an Enterprise plan.",
@@ -612,7 +619,19 @@ export class RampScheduleModel extends BaseClass {
       );
     }
 
-    await this.deleteById(schedule.id);
+    // Locked so the doc can't be deleted out from under an in-flight advance.
+    await runLockedRampScheduleAction(
+      this.context,
+      schedule.id,
+      async (fresh) => {
+        if (fresh.status === "running") {
+          throw new ConflictError(
+            "Cannot delete: the schedule started running while the request was in flight",
+          );
+        }
+        await this.deleteById(fresh.id);
+      },
+    );
 
     await dispatchRampEvent(this.context, schedule, "rampSchedule.deleted", {
       object: {
@@ -729,6 +748,9 @@ export class RampScheduleModel extends BaseClass {
           { advanceLockToken: null },
           // Holder crashed/stalled — reclaim.
           { advanceLockAt: { $lt: staleThreshold, $ne: null } },
+          // Self-token idempotency: a retried acquire whose first write applied
+          // but whose response was lost must not orphan its own lock.
+          { advanceLockToken: token },
         ],
       },
       {
@@ -739,6 +761,23 @@ export class RampScheduleModel extends BaseClass {
       },
     );
     return (result.modifiedCount ?? 0) > 0;
+  }
+
+  // Status-guarded write for the start-now busy fallback: arms the scheduler
+  // to perform a deferred start, but only while the schedule is still ready —
+  // a blind write could re-arm the poller on a terminal doc or override a
+  // concurrent edit.
+  public async deferReadyScheduleStart(id: string): Promise<boolean> {
+    const now = new Date();
+    const result = await this._dangerousGetCollection().updateOne(
+      {
+        organization: this.context.org.id,
+        id,
+        status: "ready",
+      },
+      { $set: { startDate: now, nextProcessAt: now, dateUpdated: now } },
+    );
+    return result.matchedCount > 0;
   }
 
   public async releaseAdvanceLock(id: string, token: string): Promise<void> {
@@ -791,6 +830,9 @@ export class RampScheduleModel extends BaseClass {
               status: "pending",
               "targets.activatingRevisionVersion": { $exists: true, $ne: null },
             },
+            // Ready schedules whose start is due are matched by startDate too,
+            // so a deferred "start now" survives a clobbered nextProcessAt.
+            { status: "ready", startDate: { $ne: null, $lte: now } },
           ],
         },
         { projection: { id: 1, organization: 1, _id: 0 } },

--- a/packages/back-end/src/routers/ramp-schedule/ramp-schedule.controller.ts
+++ b/packages/back-end/src/routers/ramp-schedule/ramp-schedule.controller.ts
@@ -17,12 +17,14 @@ import {
   rollbackSchedule,
   restartSchedule,
   resumeSchedule,
+  runLockedRampScheduleAction,
   setRampMonitoringMode,
   startSchedule,
 } from "back-end/src/services/rampSchedule";
 import { createSafeRolloutSnapshot } from "back-end/src/services/safeRolloutSnapshots";
 import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 import { getFeature } from "back-end/src/models/FeatureModel";
+import { ConflictError } from "back-end/src/util/errors";
 
 type CreateBody = Pick<
   RampScheduleInterface,
@@ -295,7 +297,18 @@ export const postRampScheduleAction = async (
           message: `Cannot start a schedule in status "${schedule.status}" — must be "ready"`,
         });
       }
-      updated = await startSchedule(context, schedule);
+      updated = await runLockedRampScheduleAction(
+        context,
+        schedule.id,
+        (fresh) => {
+          if (fresh.status !== "ready") {
+            throw new ConflictError(
+              `Cannot start: schedule changed to "${fresh.status}" while the request was in flight`,
+            );
+          }
+          return startSchedule(context, fresh);
+        },
+      );
       break;
     }
 
@@ -306,7 +319,18 @@ export const postRampScheduleAction = async (
           message: `Cannot pause a schedule in status "${schedule.status}"`,
         });
       }
-      updated = await pauseSchedule(context, schedule);
+      updated = await runLockedRampScheduleAction(
+        context,
+        schedule.id,
+        (fresh) => {
+          if (fresh.status !== "running") {
+            throw new ConflictError(
+              `Cannot pause: schedule changed to "${fresh.status}" while the request was in flight`,
+            );
+          }
+          return pauseSchedule(context, fresh);
+        },
+      );
       break;
 
     case "resume": {
@@ -316,7 +340,18 @@ export const postRampScheduleAction = async (
           message: `Cannot resume a schedule in status "${schedule.status}"`,
         });
       }
-      updated = await resumeSchedule(context, schedule);
+      updated = await runLockedRampScheduleAction(
+        context,
+        schedule.id,
+        (fresh) => {
+          if (fresh.status !== "paused") {
+            throw new ConflictError(
+              `Cannot resume: schedule changed to "${fresh.status}" while the request was in flight`,
+            );
+          }
+          return resumeSchedule(context, fresh);
+        },
+      );
       break;
     }
 
@@ -352,7 +387,18 @@ export const postRampScheduleAction = async (
           });
         }
       }
-      updated = await advanceScheduleManually(context, schedule);
+      updated = await runLockedRampScheduleAction(
+        context,
+        schedule.id,
+        (fresh) => {
+          if (!["running", "paused"].includes(fresh.status)) {
+            throw new ConflictError(
+              `Cannot advance: schedule changed to "${fresh.status}" while the request was in flight`,
+            );
+          }
+          return advanceScheduleManually(context, fresh);
+        },
+      );
       break;
     }
 
@@ -363,20 +409,28 @@ export const postRampScheduleAction = async (
           message: `Schedule is already in terminal status "${schedule.status}"`,
         });
       }
-      {
-        const isSimple = schedule.steps.length === 0 && !!schedule.cutoffDate;
-        const disableNow = req.body?.disableRule === true || isSimple;
-        const hasFutureCutoff =
-          schedule.cutoffDate && schedule.cutoffDate > new Date();
+      updated = await runLockedRampScheduleAction(
+        context,
+        schedule.id,
+        (fresh) => {
+          if (["completed", "rolled-back"].includes(fresh.status)) {
+            throw new ConflictError(
+              `Cannot complete: schedule changed to "${fresh.status}" while the request was in flight`,
+            );
+          }
+          const isSimple = fresh.steps.length === 0 && !!fresh.cutoffDate;
+          const disableNow = req.body?.disableRule === true || isSimple;
+          const hasFutureCutoff =
+            fresh.cutoffDate && fresh.cutoffDate > new Date();
 
-        if (!disableNow && hasFutureCutoff) {
-          updated = await completeRampKeepCutoff(context, schedule);
-        } else {
-          updated = await completeRollout(context, schedule, {
+          if (!disableNow && hasFutureCutoff) {
+            return completeRampKeepCutoff(context, fresh);
+          }
+          return completeRollout(context, fresh, {
             disableActiveTargets: disableNow,
           });
-        }
-      }
+        },
+      );
       break;
 
     case "rollback": {
@@ -388,7 +442,18 @@ export const postRampScheduleAction = async (
       }
       const cause = req.body?.reason?.trim();
       const reason = cause ? `Manual: ${cause}` : "Manual";
-      updated = await rollbackSchedule(context, schedule, reason);
+      updated = await runLockedRampScheduleAction(
+        context,
+        schedule.id,
+        (fresh) => {
+          if (["completed", "rolled-back"].includes(fresh.status)) {
+            throw new ConflictError(
+              `Cannot rollback: schedule changed to "${fresh.status}" while the request was in flight`,
+            );
+          }
+          return rollbackSchedule(context, fresh, reason);
+        },
+      );
       break;
     }
 
@@ -399,7 +464,18 @@ export const postRampScheduleAction = async (
           message: `Cannot restart a schedule in status "${schedule.status}". Only terminal (rolled-back / completed) schedules can be restarted.`,
         });
       }
-      updated = await restartSchedule(context, schedule);
+      updated = await runLockedRampScheduleAction(
+        context,
+        schedule.id,
+        (fresh) => {
+          if (!["rolled-back", "completed"].includes(fresh.status)) {
+            throw new ConflictError(
+              `Cannot restart: schedule changed to "${fresh.status}" while the request was in flight`,
+            );
+          }
+          return restartSchedule(context, fresh);
+        },
+      );
       break;
     }
 
@@ -422,7 +498,18 @@ export const postRampScheduleAction = async (
         });
       }
 
-      updated = await jumpSchedule(context, schedule, jumpTarget);
+      updated = await runLockedRampScheduleAction(
+        context,
+        schedule.id,
+        (fresh) => {
+          if (["completed", "rolled-back"].includes(fresh.status)) {
+            throw new ConflictError(
+              `Cannot jump: schedule changed to "${fresh.status}" while the request was in flight`,
+            );
+          }
+          return jumpSchedule(context, fresh, jumpTarget);
+        },
+      );
       break;
     }
 
@@ -439,7 +526,23 @@ export const postRampScheduleAction = async (
           message: `Cannot approve step: schedule is not awaiting approval (currently "${schedule.status}")`,
         });
       }
-      const approveErr = await approveAndPublishStep(context, schedule, "ui");
+      const approveErr = await runLockedRampScheduleAction(
+        context,
+        schedule.id,
+        (fresh) => {
+          const freshStep = fresh.steps[fresh.currentStepIndex];
+          const stillAwaiting =
+            fresh.status === "running" &&
+            freshStep?.holdConditions?.requiresApproval &&
+            fresh.stepApproval?.stepIndex !== fresh.currentStepIndex;
+          if (!stillAwaiting) {
+            throw new ConflictError(
+              "Cannot approve step: schedule changed while the request was in flight",
+            );
+          }
+          return approveAndPublishStep(context, fresh, "ui");
+        },
+      );
       if (approveErr) {
         const httpStatus =
           approveErr.code === "permission_denied"
@@ -493,7 +596,11 @@ export const postRampScheduleAction = async (
           message: 'monitoringMode must be "auto" or "manual"',
         });
       }
-      updated = await setRampMonitoringMode(context, schedule, requestedMode);
+      updated = await runLockedRampScheduleAction(
+        context,
+        schedule.id,
+        (fresh) => setRampMonitoringMode(context, fresh, requestedMode),
+      );
       break;
     }
 

--- a/packages/back-end/src/routers/ramp-schedule/ramp-schedule.controller.ts
+++ b/packages/back-end/src/routers/ramp-schedule/ramp-schedule.controller.ts
@@ -1,5 +1,6 @@
 import type { Response } from "express";
 import { RampScheduleInterface } from "shared/validators";
+import { PermissionError } from "shared/util";
 import { getContextFromReq } from "back-end/src/services/organizations";
 import { AuthRequest } from "back-end/src/types/AuthRequest";
 import {
@@ -321,13 +322,13 @@ export const postRampScheduleAction = async (
       updated = await runLockedRampScheduleAction(
         context,
         schedule.id,
-        (fresh) => {
+        (fresh, heartbeat) => {
           if (fresh.status !== "ready") {
             throw new ConflictError(
               `Cannot start: schedule changed to "${fresh.status}" while the request was in flight`,
             );
           }
-          return startSchedule(context, fresh);
+          return startSchedule(context, fresh, heartbeat);
         },
       );
       break;
@@ -364,13 +365,13 @@ export const postRampScheduleAction = async (
       updated = await runLockedRampScheduleAction(
         context,
         schedule.id,
-        (fresh) => {
+        (fresh, heartbeat) => {
           if (fresh.status !== "paused") {
             throw new ConflictError(
               `Cannot resume: schedule changed to "${fresh.status}" while the request was in flight`,
             );
           }
-          return resumeSchedule(context, fresh);
+          return resumeSchedule(context, fresh, heartbeat);
         },
       );
       break;
@@ -411,7 +412,7 @@ export const postRampScheduleAction = async (
       updated = await runLockedRampScheduleAction(
         context,
         schedule.id,
-        (fresh) => {
+        async (fresh) => {
           if (!["running", "paused"].includes(fresh.status)) {
             throw new ConflictError(
               `Cannot advance: schedule changed to "${fresh.status}" while the request was in flight`,
@@ -423,6 +424,28 @@ export const postRampScheduleAction = async (
             throw new ConflictError(
               "Cannot advance: the schedule advanced while the request was in flight",
             );
+          }
+          // Re-derive the approval gate — holdConditions can change in place
+          // (steps editors allow it on the current step) while we waited.
+          const freshStep = fresh.steps[fresh.currentStepIndex];
+          const freshApprovalPending =
+            freshStep?.holdConditions?.requiresApproval &&
+            fresh.stepApproval?.stepIndex !== fresh.currentStepIndex;
+          if (freshApprovalPending && !forceAdvance) {
+            throw new ConflictError(
+              "This step requires approval before advancing. Use approve-step first, or pass force: true to bypass (requires canBypassApprovalChecks).",
+            );
+          }
+          if (freshApprovalPending && forceAdvance) {
+            const linkedFeature = await getFeature(context, fresh.entityId);
+            if (
+              !linkedFeature ||
+              !context.permissions.canBypassApprovalChecks(linkedFeature)
+            ) {
+              throw new PermissionError(
+                "Permission denied: canBypassApprovalChecks required on the linked feature",
+              );
+            }
           }
           return advanceScheduleManually(context, fresh);
         },
@@ -495,13 +518,13 @@ export const postRampScheduleAction = async (
       updated = await runLockedRampScheduleAction(
         context,
         schedule.id,
-        (fresh) => {
+        (fresh, heartbeat) => {
           if (!["rolled-back", "completed"].includes(fresh.status)) {
             throw new ConflictError(
               `Cannot restart: schedule changed to "${fresh.status}" while the request was in flight`,
             );
           }
-          return restartSchedule(context, fresh);
+          return restartSchedule(context, fresh, heartbeat);
         },
       );
       break;
@@ -535,13 +558,6 @@ export const postRampScheduleAction = async (
               `Cannot jump: schedule changed to "${fresh.status}" while the request was in flight`,
             );
           }
-          // A concurrent steps edit can shrink the array, turning the
-          // playhead past-end (unintended completion).
-          if (jumpTarget >= fresh.steps.length) {
-            throw new ConflictError(
-              `Cannot jump: step ${jumpTarget} no longer exists (the schedule's steps changed while the request was in flight)`,
-            );
-          }
           return jumpSchedule(context, fresh, jumpTarget);
         },
       );
@@ -572,19 +588,9 @@ export const postRampScheduleAction = async (
               "Cannot approve step: the schedule advanced while the request was in flight",
             );
           }
-          // Duplicate approval of the same step is idempotent success.
-          if (fresh.stepApproval?.stepIndex === fresh.currentStepIndex) {
-            return Promise.resolve(null);
-          }
-          const freshStep = fresh.steps[fresh.currentStepIndex];
-          const stillAwaiting =
-            fresh.status === "running" &&
-            freshStep?.holdConditions?.requiresApproval;
-          if (!stillAwaiting) {
-            throw new ConflictError(
-              "Cannot approve step: schedule changed while the request was in flight",
-            );
-          }
+          // Idempotency and awaiting-approval validation live in
+          // approveAndPublishStep, AFTER its permission checks — duplicating
+          // them here would return success to unchecked callers.
           return approveAndPublishStep(context, fresh, "ui");
         },
       );

--- a/packages/back-end/src/routers/ramp-schedule/ramp-schedule.controller.ts
+++ b/packages/back-end/src/routers/ramp-schedule/ramp-schedule.controller.ts
@@ -181,57 +181,68 @@ export const putRampSchedule = async (
   }
 
   const body = req.body;
-  const updates: Record<string, unknown> = {};
-  if (body.name !== undefined) updates.name = body.name;
-  if (body.startActions !== undefined) updates.startActions = body.startActions;
-  if (body.steps !== undefined) updates.steps = body.steps;
-  if (body.endActions !== undefined) updates.endActions = body.endActions;
-  if ("startDate" in body) {
-    updates.startDate = body.startDate ? new Date(body.startDate) : null;
-  }
-  if ("cutoffDate" in body) {
-    updates.cutoffDate = body.cutoffDate ? new Date(body.cutoffDate) : null;
-  }
-  if (body.lockdownConfig !== undefined) {
-    updates.lockdownConfig = body.lockdownConfig;
-  }
-  if (body.monitoringConfig !== undefined) {
-    const monitoringConfig = normalizeMonitoringConfig(body.monitoringConfig);
-    await assertCanUpdateLinkedSafeRolloutMonitoringConfig(
-      context,
-      schedule,
-      monitoringConfig,
-    );
-    updates.monitoringConfig = monitoringConfig;
-  }
-  if (body.experimentHealthAction !== undefined) {
-    updates.experimentHealthAction = body.experimentHealthAction;
-  }
-  updates.nextProcessAt = computeNextProcessAt({
-    status: schedule.status,
-    nextStepAt: schedule.nextStepAt,
-    cutoffDate: ("cutoffDate" in updates
-      ? updates.cutoffDate
-      : schedule.cutoffDate) as RampScheduleInterface["cutoffDate"],
-    startDate: ("startDate" in updates
-      ? updates.startDate
-      : schedule.startDate) as RampScheduleInterface["startDate"],
-  });
-
-  const editedFields = Object.keys(updates).filter(
-    (k) => k !== "nextProcessAt" && k !== "eventHistory",
-  );
-  if (editedFields.length > 0) {
-    updates.eventHistory = appendRampEvent(schedule, "config-edited", {
-      stepIndex: schedule.currentStepIndex,
-      status: schedule.status,
-      reason: `Edited: ${editedFields.join(", ")}`,
-    });
-  }
-
-  const updated = await context.models.rampSchedules.updateById(
+  const updated = await runLockedRampScheduleAction(
+    context,
     schedule.id,
-    updates,
+    async (fresh) => {
+      if (!["pending", "ready", "paused"].includes(fresh.status)) {
+        throw new ConflictError(
+          `Cannot update: schedule changed to "${fresh.status}" while the request was in flight`,
+        );
+      }
+      const updates: Record<string, unknown> = {};
+      if (body.name !== undefined) updates.name = body.name;
+      if (body.startActions !== undefined)
+        updates.startActions = body.startActions;
+      if (body.steps !== undefined) updates.steps = body.steps;
+      if (body.endActions !== undefined) updates.endActions = body.endActions;
+      if ("startDate" in body) {
+        updates.startDate = body.startDate ? new Date(body.startDate) : null;
+      }
+      if ("cutoffDate" in body) {
+        updates.cutoffDate = body.cutoffDate ? new Date(body.cutoffDate) : null;
+      }
+      if (body.lockdownConfig !== undefined) {
+        updates.lockdownConfig = body.lockdownConfig;
+      }
+      if (body.monitoringConfig !== undefined) {
+        const monitoringConfig = normalizeMonitoringConfig(
+          body.monitoringConfig,
+        );
+        await assertCanUpdateLinkedSafeRolloutMonitoringConfig(
+          context,
+          fresh,
+          monitoringConfig,
+        );
+        updates.monitoringConfig = monitoringConfig;
+      }
+      if (body.experimentHealthAction !== undefined) {
+        updates.experimentHealthAction = body.experimentHealthAction;
+      }
+      updates.nextProcessAt = computeNextProcessAt({
+        status: fresh.status,
+        nextStepAt: fresh.nextStepAt,
+        cutoffDate: ("cutoffDate" in updates
+          ? updates.cutoffDate
+          : fresh.cutoffDate) as RampScheduleInterface["cutoffDate"],
+        startDate: ("startDate" in updates
+          ? updates.startDate
+          : fresh.startDate) as RampScheduleInterface["startDate"],
+      });
+
+      const editedFields = Object.keys(updates).filter(
+        (k) => k !== "nextProcessAt" && k !== "eventHistory",
+      );
+      if (editedFields.length > 0) {
+        updates.eventHistory = appendRampEvent(fresh, "config-edited", {
+          stepIndex: fresh.currentStepIndex,
+          status: fresh.status,
+          reason: `Edited: ${editedFields.join(", ")}`,
+        });
+      }
+
+      return context.models.rampSchedules.updateById(fresh.id, updates);
+    },
   );
   res.status(200).json({ status: 200, rampSchedule: updated });
 };
@@ -262,7 +273,17 @@ export const deleteRampSchedule = async (
   //     which the user has chosen to keep by not rolling back before deleting.
   // In all cases the caller is assumed to have made a deliberate choice about
   // the rule's state before removing the schedule record.
-  await context.models.rampSchedules.deleteById(schedule.id);
+  //
+  // Locked so the doc can't be deleted out from under an in-flight advance
+  // (whose subsequent writes would fail mid-publish).
+  await runLockedRampScheduleAction(context, schedule.id, async (fresh) => {
+    if (fresh.status === "running") {
+      throw new ConflictError(
+        "Cannot delete: the schedule started running while the request was in flight",
+      );
+    }
+    await context.models.rampSchedules.deleteById(fresh.id);
+  });
 
   await dispatchRampEvent(context, schedule, "rampSchedule.deleted", {
     object: {
@@ -396,6 +417,14 @@ export const postRampScheduleAction = async (
               `Cannot advance: schedule changed to "${fresh.status}" while the request was in flight`,
             );
           }
+          // Pin the playhead: the approval/force gates above were screened
+          // against this step; if a concurrent advance moved it, this click
+          // would silently skip an extra step (or an unscreened approval gate).
+          if (fresh.currentStepIndex !== schedule.currentStepIndex) {
+            throw new ConflictError(
+              "Cannot advance: the schedule advanced while the request was in flight",
+            );
+          }
           return advanceScheduleManually(context, fresh);
         },
       );
@@ -507,6 +536,14 @@ export const postRampScheduleAction = async (
               `Cannot jump: schedule changed to "${fresh.status}" while the request was in flight`,
             );
           }
+          // Re-validate bounds against the in-lock steps — a concurrent steps
+          // edit can shrink the array, and an out-of-range playhead reads as
+          // past-end (unintended completion) downstream.
+          if (jumpTarget >= fresh.steps.length) {
+            throw new ConflictError(
+              `Cannot jump: step ${jumpTarget} no longer exists (the schedule's steps changed while the request was in flight)`,
+            );
+          }
           return jumpSchedule(context, fresh, jumpTarget);
         },
       );
@@ -530,11 +567,23 @@ export const postRampScheduleAction = async (
         context,
         schedule.id,
         (fresh) => {
+          // Pin to the step the reviewer saw — with consecutive approval
+          // gates, a queued approval must not land on a step that was never
+          // reviewed.
+          if (fresh.currentStepIndex !== schedule.currentStepIndex) {
+            throw new ConflictError(
+              "Cannot approve step: the schedule advanced while the request was in flight",
+            );
+          }
+          // Duplicate approval of the same step (double-click / racing
+          // reviewers) is idempotent success, matching approveAndPublishStep.
+          if (fresh.stepApproval?.stepIndex === fresh.currentStepIndex) {
+            return Promise.resolve(null);
+          }
           const freshStep = fresh.steps[fresh.currentStepIndex];
           const stillAwaiting =
             fresh.status === "running" &&
-            freshStep?.holdConditions?.requiresApproval &&
-            fresh.stepApproval?.stepIndex !== fresh.currentStepIndex;
+            freshStep?.holdConditions?.requiresApproval;
           if (!stillAwaiting) {
             throw new ConflictError(
               "Cannot approve step: schedule changed while the request was in flight",
@@ -642,9 +691,13 @@ export const postRampScheduleAction = async (
         : null;
 
       if (!safeRollout && currentStep?.monitored) {
-        const updatedSchedule = await ensureSafeRolloutForMonitoredRamp(
+        // ensureSafeRolloutForMonitoredRamp mutates the schedule (SR creation
+        // + link write) — serialize against the tick, which runs the same
+        // ensure, or both create a SafeRollout and one becomes an orphan.
+        const updatedSchedule = await runLockedRampScheduleAction(
           context,
-          schedule,
+          schedule.id,
+          (fresh) => ensureSafeRolloutForMonitoredRamp(context, fresh),
         );
         safeRollout = updatedSchedule.safeRolloutId
           ? await context.models.safeRollout.getById(

--- a/packages/back-end/src/routers/ramp-schedule/ramp-schedule.controller.ts
+++ b/packages/back-end/src/routers/ramp-schedule/ramp-schedule.controller.ts
@@ -417,9 +417,8 @@ export const postRampScheduleAction = async (
               `Cannot advance: schedule changed to "${fresh.status}" while the request was in flight`,
             );
           }
-          // Pin the playhead: the approval/force gates above were screened
-          // against this step; if a concurrent advance moved it, this click
-          // would silently skip an extra step (or an unscreened approval gate).
+          // Pin the playhead: a concurrent advance would make this skip an
+          // extra (unscreened) step.
           if (fresh.currentStepIndex !== schedule.currentStepIndex) {
             throw new ConflictError(
               "Cannot advance: the schedule advanced while the request was in flight",
@@ -536,9 +535,8 @@ export const postRampScheduleAction = async (
               `Cannot jump: schedule changed to "${fresh.status}" while the request was in flight`,
             );
           }
-          // Re-validate bounds against the in-lock steps — a concurrent steps
-          // edit can shrink the array, and an out-of-range playhead reads as
-          // past-end (unintended completion) downstream.
+          // A concurrent steps edit can shrink the array, turning the
+          // playhead past-end (unintended completion).
           if (jumpTarget >= fresh.steps.length) {
             throw new ConflictError(
               `Cannot jump: step ${jumpTarget} no longer exists (the schedule's steps changed while the request was in flight)`,
@@ -567,16 +565,14 @@ export const postRampScheduleAction = async (
         context,
         schedule.id,
         (fresh) => {
-          // Pin to the step the reviewer saw — with consecutive approval
-          // gates, a queued approval must not land on a step that was never
-          // reviewed.
+          // Pin to the step the reviewer saw — a queued approval must not
+          // land on a step that was never reviewed.
           if (fresh.currentStepIndex !== schedule.currentStepIndex) {
             throw new ConflictError(
               "Cannot approve step: the schedule advanced while the request was in flight",
             );
           }
-          // Duplicate approval of the same step (double-click / racing
-          // reviewers) is idempotent success, matching approveAndPublishStep.
+          // Duplicate approval of the same step is idempotent success.
           if (fresh.stepApproval?.stepIndex === fresh.currentStepIndex) {
             return Promise.resolve(null);
           }
@@ -691,9 +687,8 @@ export const postRampScheduleAction = async (
         : null;
 
       if (!safeRollout && currentStep?.monitored) {
-        // ensureSafeRolloutForMonitoredRamp mutates the schedule (SR creation
-        // + link write) — serialize against the tick, which runs the same
-        // ensure, or both create a SafeRollout and one becomes an orphan.
+        // Serialize against the tick, which runs the same ensure — otherwise
+        // both create a SafeRollout and one becomes an orphan.
         const updatedSchedule = await runLockedRampScheduleAction(
           context,
           schedule.id,

--- a/packages/back-end/src/routers/safe-rollout/safe-rollout.controller.ts
+++ b/packages/back-end/src/routers/safe-rollout/safe-rollout.controller.ts
@@ -14,10 +14,8 @@ import { SafeRolloutResultsQueryRunner } from "back-end/src/queryRunners/SafeRol
 import { getFeature } from "back-end/src/models/FeatureModel";
 import { validateCreateSafeRolloutFields } from "back-end/src/validators/safe-rollout";
 import {
-  appendRampEvent,
-  computeNextProcessAt,
   runLockedRampScheduleAction,
-  syncLinkedSafeRolloutForRampState,
+  setRampMonitoringMode,
 } from "back-end/src/services/rampSchedule";
 import { NotFoundError } from "back-end/src/util/errors";
 import { logger } from "back-end/src/util/logger";
@@ -246,55 +244,38 @@ export async function putAutoSnapshots(
     throw new Error("Could not find safe rollout");
   }
 
-  await context.models.safeRollout.update(safeRollout, {
-    autoSnapshots: enabled,
-  });
-
   if (safeRollout.rampScheduleId) {
-    // An unlocked write here can clobber a concurrent advance's
-    // eventHistory/nextProcessAt.
+    // Both writes run under the lock: contention 409s BEFORE anything applies,
+    // so the SafeRollout toggle can never half-apply without its schedule
+    // mirror. Delegates to setRampMonitoringMode rather than re-deriving it.
     try {
       await runLockedRampScheduleAction(
         context,
         safeRollout.rampScheduleId,
         async (fresh) => {
+          await context.models.safeRollout.update(safeRollout, {
+            autoSnapshots: enabled,
+          });
           if (!fresh.monitoringConfig) return;
-          const nextSnapshotAt = enabled
-            ? (safeRollout.nextSnapshotAttempt ?? new Date())
-            : null;
-          const updated = await context.models.rampSchedules.updateById(
-            fresh.id,
-            {
-              monitoringConfig: {
-                ...fresh.monitoringConfig,
-                monitoringMode: enabled ? "auto" : "manual",
-                autoUpdate: enabled,
-              },
-              nextSnapshotAt,
-              nextProcessAt: computeNextProcessAt({
-                status: fresh.status,
-                nextStepAt: fresh.nextStepAt,
-                nextSnapshotAt,
-                cutoffDate: fresh.cutoffDate,
-                startDate: fresh.startDate,
-              }),
-              eventHistory: appendRampEvent(fresh, "auto-update-toggled", {
-                stepIndex: fresh.currentStepIndex,
-                status: fresh.status,
-                reason: enabled
-                  ? "Auto-update enabled"
-                  : "Auto-update disabled",
-              }),
-            },
+          await setRampMonitoringMode(
+            context,
+            fresh,
+            enabled ? "auto" : "manual",
           );
-          await syncLinkedSafeRolloutForRampState(context, updated);
         },
       );
     } catch (e) {
-      // The SafeRollout's own toggle already applied; a deleted ramp schedule
-      // just means there is nothing to mirror.
+      // A deleted ramp schedule means there is nothing to mirror — apply the
+      // SafeRollout's own toggle and move on.
       if (!(e instanceof NotFoundError)) throw e;
+      await context.models.safeRollout.update(safeRollout, {
+        autoSnapshots: enabled,
+      });
     }
+  } else {
+    await context.models.safeRollout.update(safeRollout, {
+      autoSnapshots: enabled,
+    });
   }
 
   res.status(200).json({ status: 200 });

--- a/packages/back-end/src/routers/safe-rollout/safe-rollout.controller.ts
+++ b/packages/back-end/src/routers/safe-rollout/safe-rollout.controller.ts
@@ -16,8 +16,10 @@ import { validateCreateSafeRolloutFields } from "back-end/src/validators/safe-ro
 import {
   appendRampEvent,
   computeNextProcessAt,
+  runLockedRampScheduleAction,
   syncLinkedSafeRolloutForRampState,
 } from "back-end/src/services/rampSchedule";
+import { NotFoundError } from "back-end/src/util/errors";
 import { logger } from "back-end/src/util/logger";
 
 // region GET /safe-rollout/:id/snapshot
@@ -249,37 +251,49 @@ export async function putAutoSnapshots(
   });
 
   if (safeRollout.rampScheduleId) {
-    const schedule = await context.models.rampSchedules.getById(
-      safeRollout.rampScheduleId,
-    );
-    if (schedule?.monitoringConfig) {
-      const nextSnapshotAt = enabled
-        ? (safeRollout.nextSnapshotAttempt ?? new Date())
-        : null;
-      const updated = await context.models.rampSchedules.updateById(
-        schedule.id,
-        {
-          monitoringConfig: {
-            ...schedule.monitoringConfig,
-            monitoringMode: enabled ? "auto" : "manual",
-            autoUpdate: enabled,
-          },
-          nextSnapshotAt,
-          nextProcessAt: computeNextProcessAt({
-            status: schedule.status,
-            nextStepAt: schedule.nextStepAt,
-            nextSnapshotAt,
-            cutoffDate: schedule.cutoffDate,
-            startDate: schedule.startDate,
-          }),
-          eventHistory: appendRampEvent(schedule, "auto-update-toggled", {
-            stepIndex: schedule.currentStepIndex,
-            status: schedule.status,
-            reason: enabled ? "Auto-update enabled" : "Auto-update disabled",
-          }),
+    // Locked read-modify-write against the ramp engine — an unlocked write
+    // here can clobber a concurrent advance's eventHistory/nextProcessAt.
+    try {
+      await runLockedRampScheduleAction(
+        context,
+        safeRollout.rampScheduleId,
+        async (fresh) => {
+          if (!fresh.monitoringConfig) return;
+          const nextSnapshotAt = enabled
+            ? (safeRollout.nextSnapshotAttempt ?? new Date())
+            : null;
+          const updated = await context.models.rampSchedules.updateById(
+            fresh.id,
+            {
+              monitoringConfig: {
+                ...fresh.monitoringConfig,
+                monitoringMode: enabled ? "auto" : "manual",
+                autoUpdate: enabled,
+              },
+              nextSnapshotAt,
+              nextProcessAt: computeNextProcessAt({
+                status: fresh.status,
+                nextStepAt: fresh.nextStepAt,
+                nextSnapshotAt,
+                cutoffDate: fresh.cutoffDate,
+                startDate: fresh.startDate,
+              }),
+              eventHistory: appendRampEvent(fresh, "auto-update-toggled", {
+                stepIndex: fresh.currentStepIndex,
+                status: fresh.status,
+                reason: enabled
+                  ? "Auto-update enabled"
+                  : "Auto-update disabled",
+              }),
+            },
+          );
+          await syncLinkedSafeRolloutForRampState(context, updated);
         },
       );
-      await syncLinkedSafeRolloutForRampState(context, updated);
+    } catch (e) {
+      // The SafeRollout's own toggle already applied; a deleted ramp schedule
+      // just means there is nothing to mirror.
+      if (!(e instanceof NotFoundError)) throw e;
     }
   }
 

--- a/packages/back-end/src/routers/safe-rollout/safe-rollout.controller.ts
+++ b/packages/back-end/src/routers/safe-rollout/safe-rollout.controller.ts
@@ -251,8 +251,8 @@ export async function putAutoSnapshots(
   });
 
   if (safeRollout.rampScheduleId) {
-    // Locked read-modify-write against the ramp engine — an unlocked write
-    // here can clobber a concurrent advance's eventHistory/nextProcessAt.
+    // An unlocked write here can clobber a concurrent advance's
+    // eventHistory/nextProcessAt.
     try {
       await runLockedRampScheduleAction(
         context,

--- a/packages/back-end/src/services/rampSchedule.ts
+++ b/packages/back-end/src/services/rampSchedule.ts
@@ -2045,46 +2045,42 @@ export async function onActivatingRevisionPublished(
 export async function startReadyScheduleNow(
   ctx: ReqContext | ApiReqContext,
   schedule: RampScheduleInterface,
-  contentUpdates: Partial<
-    Pick<
-      RampScheduleInterface,
-      | "name"
-      | "steps"
-      | "startActions"
-      | "endActions"
-      | "cutoffDate"
-      | "monitoringConfig"
-      | "lockdownConfig"
-    >
-  > = {},
+  contentUpdates: StartNowContentUpdates = {},
 ): Promise<void> {
   if (schedule.status !== "ready") return;
 
-  // Serialize against the scheduler tick; re-verify "ready" inside the lock.
-  // Retry rather than defer: with startDate about to be cleared, the scheduler
-  // has no path that would replay this start.
+  // Serialize against the scheduler tick; re-verify "ready" inside the lock
+  // and start from the in-lock read so an edit that landed while waiting
+  // isn't overwritten with the caller's stale snapshot. Retry rather than
+  // defer: with startDate about to be cleared, the scheduler has no path
+  // that would replay this start.
   await withRampScheduleAdvanceLockRetry(ctx, schedule.id, async () => {
     const fresh = await ctx.models.rampSchedules.getById(schedule.id);
     if (!fresh || fresh.status !== "ready") return;
-    await startReadyScheduleNowLocked(ctx, schedule, contentUpdates);
+    await startReadyScheduleNowLocked(ctx, fresh, contentUpdates);
   });
 }
+
+type StartNowContentUpdates = Partial<
+  Pick<
+    RampScheduleInterface,
+    | "name"
+    | "steps"
+    | "startActions"
+    | "endActions"
+    | "cutoffDate"
+    | "monitoringConfig"
+    | "lockdownConfig"
+    // Pre-built history (e.g. a "config-edited" audit event) for the
+    // "started" event to append on top of, instead of the stored history.
+    | "eventHistory"
+  >
+>;
 
 async function startReadyScheduleNowLocked(
   ctx: ReqContext | ApiReqContext,
   schedule: RampScheduleInterface,
-  contentUpdates: Partial<
-    Pick<
-      RampScheduleInterface,
-      | "name"
-      | "steps"
-      | "startActions"
-      | "endActions"
-      | "cutoffDate"
-      | "monitoringConfig"
-      | "lockdownConfig"
-    >
-  > = {},
+  contentUpdates: StartNowContentUpdates = {},
 ): Promise<void> {
   const now = new Date();
   const steps = contentUpdates.steps ?? schedule.steps;
@@ -2093,6 +2089,10 @@ async function startReadyScheduleNowLocked(
       ? contentUpdates.cutoffDate
       : schedule.cutoffDate;
   const initialNextStepAt = steps.length > 0 ? now : null;
+
+  const eventBase = contentUpdates.eventHistory
+    ? { ...schedule, eventHistory: contentUpdates.eventHistory }
+    : schedule;
 
   let current = await ctx.models.rampSchedules.updateById(schedule.id, {
     ...contentUpdates,
@@ -2107,7 +2107,7 @@ async function startReadyScheduleNowLocked(
       nextStepAt: initialNextStepAt,
       cutoffDate: cutoffDate ?? null,
     }),
-    eventHistory: appendRampEvent(schedule, "started", {
+    eventHistory: appendRampEvent(eventBase, "started", {
       stepIndex: -1,
       status: "running",
       previousStatus: schedule.status,

--- a/packages/back-end/src/services/rampSchedule.ts
+++ b/packages/back-end/src/services/rampSchedule.ts
@@ -38,6 +38,7 @@ import {
 } from "back-end/src/util/flattenRules";
 import { logger } from "back-end/src/util/logger";
 import {
+  ConflictError,
   NotFoundError,
   RampAdvanceLockBusyError,
 } from "back-end/src/util/errors";
@@ -72,6 +73,12 @@ async function runWithAcquiredAdvanceLock<T>(
           token,
         );
       if (!stillHeld) {
+        // Distinct from benign contention: a live holder exceeded the stale
+        // threshold and lost its lease — the signal the threshold is mis-sized.
+        logger.warn(
+          { rampScheduleId: scheduleId },
+          "Ramp advance lock lease lost mid-flight; aborting the holder",
+        );
         throw new RampAdvanceLockBusyError(
           `Ramp schedule ${scheduleId} advance lock was reclaimed mid-flight`,
         );
@@ -98,18 +105,7 @@ export async function withRampScheduleAdvanceLock<T>(
   scheduleId: string,
   fn: (heartbeat: () => Promise<void>) => Promise<T>,
 ): Promise<T> {
-  const token = uniqid("ral_");
-  const acquired = await ctx.models.rampSchedules.acquireAdvanceLock(
-    scheduleId,
-    token,
-  );
-  if (!acquired) {
-    await assertScheduleExistsAfterFailedAcquire(ctx, scheduleId);
-    throw new RampAdvanceLockBusyError(
-      `Ramp schedule ${scheduleId} advance already in progress`,
-    );
-  }
-  return runWithAcquiredAdvanceLock(ctx, scheduleId, token, fn);
+  return withRampScheduleAdvanceLockRetry(ctx, scheduleId, fn, 1);
 }
 
 // For user-initiated actions whose intent the scheduler cannot replay. Only
@@ -1092,6 +1088,7 @@ export async function advanceStep(
     // otherwise the rule would complete permanently enabled.
     return completeRollout(ctx, schedule, {
       disableActiveTargets: !!schedule.cutoffDate,
+      autoCatchUp: isJump,
     });
   }
 
@@ -1360,6 +1357,7 @@ export async function pauseSchedule(
 export async function resumeSchedule(
   ctx: ReqContext | ApiReqContext,
   schedule: RampScheduleInterface,
+  heartbeat?: () => Promise<void>,
 ): Promise<RampScheduleInterface> {
   // Must be called with the advance lock held and `schedule` read inside it —
   // a pre-lock snapshot could resurrect state a concurrent tick produced
@@ -1467,6 +1465,7 @@ export async function resumeSchedule(
   // Chain through any time-due steps (nextStepAt <= now). Steps with no
   // interval (approval gates, instant steps) have nextStepAt=null and are not
   // traversed here — the agenda re-picks them via nextProcessAt.
+  await heartbeat?.();
   await advanceUntilBlocked(ctx, updated, now);
   updated = (await ctx.models.rampSchedules.getById(schedule.id)) ?? updated;
 
@@ -1478,6 +1477,7 @@ export async function resumeSchedule(
 export async function restartSchedule(
   ctx: ReqContext | ApiReqContext,
   schedule: RampScheduleInterface,
+  heartbeat?: () => Promise<void>,
 ): Promise<RampScheduleInterface> {
   if (schedule.currentStepIndex >= 0) {
     // Suppress the rolledBack webhook — this is a user-initiated restart, not
@@ -1527,7 +1527,8 @@ export async function restartSchedule(
     }
   }
 
-  return startSchedule(ctx, readied);
+  await heartbeat?.();
+  return startSchedule(ctx, readied, heartbeat);
 }
 
 /**
@@ -1541,6 +1542,14 @@ export async function jumpSchedule(
   schedule: RampScheduleInterface,
   targetStepIndex: number,
 ): Promise<RampScheduleInterface> {
+  // Owns its bounds precondition: an out-of-range playhead reads as past-end
+  // (unintended completion) downstream, and callers' pre-lock checks can be
+  // stale against a concurrent steps edit.
+  if (targetStepIndex < -1 || targetStepIndex >= schedule.steps.length) {
+    throw new ConflictError(
+      `Cannot jump: step ${targetStepIndex} does not exist on this schedule`,
+    );
+  }
   const now = new Date();
   const freshPhaseStartedAt = (() => {
     if (targetStepIndex <= 0) return now;
@@ -1695,10 +1704,16 @@ export async function advanceScheduleManually(
     );
 
     const now = new Date();
-    const advanced = await advanceStep(ctx, scheduleToAdvance);
-    // Chain through any subsequent instant-clearable steps in the same pass
-    // so the caller sees the schedule at its first blocking point immediately.
-    await advanceUntilBlocked(ctx, advanced, now);
+    // Fold the user-cleared advance and any due backlog behind it into one
+    // publish, like the scheduler paths — advanceStep(+1) followed by a
+    // catch-up would publish twice.
+    const target = Math.max(
+      computeAutoAdvanceTarget(scheduleToAdvance, now, {
+        currentStepCleared: true,
+      }),
+      scheduleToAdvance.currentStepIndex + 1,
+    );
+    const advanced = await advanceStep(ctx, scheduleToAdvance, target);
     return (await ctx.models.rampSchedules.getById(advanced.id)) ?? advanced;
   } catch (e) {
     // If we transitioned from paused→running and then failed, revert to paused
@@ -1726,6 +1741,7 @@ export async function advanceScheduleManually(
 export async function startSchedule(
   ctx: ReqContext | ApiReqContext,
   schedule: RampScheduleInterface,
+  heartbeat?: () => Promise<void>,
 ): Promise<RampScheduleInterface> {
   const now = new Date();
   const initialNextStepAt = schedule.steps.length > 0 ? now : null;
@@ -1750,6 +1766,7 @@ export async function startSchedule(
 
   await applyRampStartActions(ctx, current);
   current = await ensureSafeRolloutForMonitoredRamp(ctx, current);
+  await heartbeat?.();
   await advanceUntilBlocked(ctx, current, now);
   current = (await ctx.models.rampSchedules.getById(schedule.id)) ?? current;
   await syncLinkedSafeRolloutForRampState(ctx, current);
@@ -1902,6 +1919,18 @@ async function applyEndActionsAndAwaitCutoff(
   });
 
   await syncLinkedSafeRolloutForRampState(ctx, updated);
+
+  await dispatchRampEvent(ctx, updated, "rampSchedule.actions.step.advanced", {
+    object: {
+      rampScheduleId: updated.id,
+      rampName: updated.name,
+      orgId: ctx.org.id,
+      currentStepIndex: updated.currentStepIndex,
+      previousStepIndex: schedule.currentStepIndex,
+      status: updated.status,
+    },
+  });
+
   return updated;
 }
 
@@ -1923,7 +1952,7 @@ export async function completeRollout(
   // `disableActiveTargets` folds `enabled: false` into the same publish as
   // `endActions` so callers (e.g. cutoffDate-driven completion) don't have
   // to fire a second revision publish for the disable.
-  opts: { disableActiveTargets?: boolean } = {},
+  opts: { disableActiveTargets?: boolean; autoCatchUp?: boolean } = {},
 ): Promise<RampScheduleInterface> {
   const effective = computeEffectivePatch(schedule, schedule.steps.length);
 
@@ -1972,6 +2001,7 @@ export async function completeRollout(
       schedule,
       schedule.steps.length,
       actionsToApply,
+      opts.autoCatchUp ? { fromStepIndex: schedule.currentStepIndex } : {},
     );
   }
 
@@ -2002,6 +2032,7 @@ export async function completeRollout(
       rampName: updated.name,
       orgId: ctx.org.id,
       currentStepIndex: updated.currentStepIndex,
+      previousStepIndex: schedule.currentStepIndex,
       status: updated.status,
     },
   });
@@ -2101,15 +2132,14 @@ export async function startReadyScheduleNow(
   } catch (e) {
     if (!(e instanceof RampAdvanceLockBusyError)) throw e;
     // Lock stayed busy: startDate=now defers the start to the scheduler
-    // instead of losing the user's "start now". Scheduling fields only;
-    // content edits are the caller's responsibility on the false return.
-    const now = new Date();
-    await ctx.models.rampSchedules.updateById(schedule.id, {
-      startDate: now,
-      nextProcessAt: now,
-    });
+    // instead of losing the user's "start now". Status-guarded so it can't
+    // re-arm a schedule that left "ready" while waiting; content edits are
+    // the caller's responsibility on the false return.
+    const deferred = await ctx.models.rampSchedules.deferReadyScheduleStart(
+      schedule.id,
+    );
     logger.warn(
-      { rampScheduleId: schedule.id },
+      { rampScheduleId: schedule.id, deferred },
       "Start-now lock stayed busy; deferred the start to the scheduler via startDate",
     );
     return false;
@@ -2210,6 +2240,8 @@ export async function onRevisionPublished(
         await onActivatingRevisionPublished(ctx, fresh);
       });
     } catch (e) {
+      // Deleted mid-loop: nothing to activate; don't abort the sibling ramps.
+      if (e instanceof NotFoundError) continue;
       if (!(e instanceof RampAdvanceLockBusyError)) throw e;
       // The scheduler is already processing this schedule; its pending branch
       // re-checks activation every tick, so the start is not lost.

--- a/packages/back-end/src/services/rampSchedule.ts
+++ b/packages/back-end/src/services/rampSchedule.ts
@@ -44,33 +44,41 @@ import {
 
 const LOCKDOWN_ACTIVE_STATUSES = ["running"] as const;
 
-// Serialize schedule mutation across every entry point (scheduler tick,
-// snapshot hook, HTTP/API actions). Throws RampAdvanceLockBusyError when held.
-// Non-reentrant: never call from code already inside the lock. Callers must
-// re-read the schedule *inside* `fn` — acting on a pre-lock snapshot would
-// replay steps another advance already applied.
-export async function withRampScheduleAdvanceLock<T>(
+// A failed acquire means either contention or a deleted document — check so
+// callers don't burn retries and report "in progress" for a missing doc.
+async function assertScheduleExistsAfterFailedAcquire(
   ctx: ReqContext | ApiReqContext,
   scheduleId: string,
-  // `heartbeat` refreshes the lock's liveness timestamp; long multi-phase
-  // holders (the scheduler tick) should call it between phases so a slow
-  // phase isn't stale-reclaimed mid-flight.
+): Promise<void> {
+  const exists = await ctx.models.rampSchedules.getById(scheduleId);
+  if (!exists) {
+    throw new NotFoundError("Ramp schedule no longer exists");
+  }
+}
+
+// Runs `fn` with the already-acquired lock, releasing on the way out. The
+// heartbeat passed to `fn` refreshes the lock's liveness timestamp between
+// slow phases; it throws RampAdvanceLockBusyError if the lease was stale-
+// reclaimed, so a robbed holder aborts instead of writing concurrently.
+async function runWithAcquiredAdvanceLock<T>(
+  ctx: ReqContext | ApiReqContext,
+  scheduleId: string,
+  token: string,
   fn: (heartbeat: () => Promise<void>) => Promise<T>,
 ): Promise<T> {
-  const token = uniqid("ral_");
-  const acquired = await ctx.models.rampSchedules.acquireAdvanceLock(
-    scheduleId,
-    token,
-  );
-  if (!acquired) {
-    throw new RampAdvanceLockBusyError(
-      `Ramp schedule ${scheduleId} advance already in progress`,
-    );
-  }
   try {
-    return await fn(() =>
-      ctx.models.rampSchedules.touchAdvanceLockHeartbeat(scheduleId, token),
-    );
+    return await fn(async () => {
+      const stillHeld =
+        await ctx.models.rampSchedules.touchAdvanceLockHeartbeat(
+          scheduleId,
+          token,
+        );
+      if (!stillHeld) {
+        throw new RampAdvanceLockBusyError(
+          `Ramp schedule ${scheduleId} advance lock was reclaimed mid-flight`,
+        );
+      }
+    });
   } finally {
     // Never let a release failure mask the error `fn` threw; a leaked lock
     // self-heals via the stale threshold.
@@ -85,43 +93,82 @@ export async function withRampScheduleAdvanceLock<T>(
   }
 }
 
+// Serialize schedule mutation across every entry point (scheduler tick,
+// snapshot hook, HTTP/API actions). Throws RampAdvanceLockBusyError when held.
+// Non-reentrant: never call from code already inside the lock. Callers must
+// re-read the schedule *inside* `fn` — acting on a pre-lock snapshot would
+// replay steps another advance already applied.
+export async function withRampScheduleAdvanceLock<T>(
+  ctx: ReqContext | ApiReqContext,
+  scheduleId: string,
+  fn: (heartbeat: () => Promise<void>) => Promise<T>,
+): Promise<T> {
+  const token = uniqid("ral_");
+  const acquired = await ctx.models.rampSchedules.acquireAdvanceLock(
+    scheduleId,
+    token,
+  );
+  if (!acquired) {
+    await assertScheduleExistsAfterFailedAcquire(ctx, scheduleId);
+    throw new RampAdvanceLockBusyError(
+      `Ramp schedule ${scheduleId} advance already in progress`,
+    );
+  }
+  return runWithAcquiredAdvanceLock(ctx, scheduleId, token, fn);
+}
+
 // For user-initiated actions (resume, manual advance, jump) whose intent the
-// scheduler cannot replay: contention windows are seconds long, so retry a few
-// times before surfacing the busy error to the user.
+// scheduler cannot replay: contention windows are seconds long, so retry the
+// ACQUISITION a few times before surfacing the busy error. Only the acquire is
+// retried — `fn` runs exactly once, so side effects (revision publishes) can
+// never be re-executed by a busy error escaping from inside `fn`.
 export async function withRampScheduleAdvanceLockRetry<T>(
   ctx: ReqContext | ApiReqContext,
   scheduleId: string,
-  fn: () => Promise<T>,
+  fn: (heartbeat: () => Promise<void>) => Promise<T>,
   attempts = 4,
 ): Promise<T> {
+  const token = uniqid("ral_");
   for (let attempt = 1; ; attempt++) {
-    try {
-      return await withRampScheduleAdvanceLock(ctx, scheduleId, fn);
-    } catch (e) {
-      if (!(e instanceof RampAdvanceLockBusyError) || attempt >= attempts) {
-        throw e;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
+    const acquired = await ctx.models.rampSchedules.acquireAdvanceLock(
+      scheduleId,
+      token,
+    );
+    if (acquired) break;
+    // Fail fast on a deleted doc rather than sleeping through the ladder.
+    await assertScheduleExistsAfterFailedAcquire(ctx, scheduleId);
+    if (attempt >= attempts) {
+      throw new RampAdvanceLockBusyError(
+        `Ramp schedule ${scheduleId} advance already in progress`,
+      );
     }
+    await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
   }
+  return runWithAcquiredAdvanceLock(ctx, scheduleId, token, fn);
 }
 
-// Boundary wrapper for controller/API schedule actions: lock (with retry), a
-// fresh in-lock read, then the action. `fn` must re-validate any status
-// preconditions screened on the caller's pre-lock read — the schedule may have
-// changed while waiting for the lock (e.g. a tick completed it).
+// Boundary wrapper for controller/API schedule actions. `fn` must re-validate
+// any status preconditions screened on the caller's pre-lock read — the
+// schedule may have changed while waiting for the lock.
 export async function runLockedRampScheduleAction<T>(
   ctx: ReqContext | ApiReqContext,
   scheduleId: string,
-  fn: (fresh: RampScheduleInterface) => Promise<T>,
+  fn: (
+    fresh: RampScheduleInterface,
+    heartbeat: () => Promise<void>,
+  ) => Promise<T>,
 ): Promise<T> {
-  return withRampScheduleAdvanceLockRetry(ctx, scheduleId, async () => {
-    const fresh = await ctx.models.rampSchedules.getById(scheduleId);
-    if (!fresh) {
-      throw new NotFoundError("Ramp schedule no longer exists");
-    }
-    return fn(fresh);
-  });
+  return withRampScheduleAdvanceLockRetry(
+    ctx,
+    scheduleId,
+    async (heartbeat) => {
+      const fresh = await ctx.models.rampSchedules.getById(scheduleId);
+      if (!fresh) {
+        throw new NotFoundError("Ramp schedule no longer exists");
+      }
+      return fn(fresh, heartbeat);
+    },
+  );
 }
 
 const MAX_EVENT_HISTORY = 500;
@@ -1060,9 +1107,16 @@ export async function advanceStep(
 
   if (!step) {
     if (schedule.cutoffDate && schedule.cutoffDate > new Date()) {
-      return applyEndActionsAndAwaitCutoff(ctx, schedule);
+      return applyEndActionsAndAwaitCutoff(ctx, schedule, {
+        autoCatchUp: true,
+      });
     }
-    return completeRollout(ctx, schedule);
+    // Reaching here with a cutoffDate means it already lapsed (the future case
+    // returned above), so honor the cutoff's disable semantics — otherwise the
+    // rule would complete permanently enabled at end-state coverage.
+    return completeRollout(ctx, schedule, {
+      disableActiveTargets: !!schedule.cutoffDate,
+    });
   }
 
   const now = new Date();
@@ -1807,6 +1861,9 @@ export async function jumpAheadToStep(
 async function applyEndActionsAndAwaitCutoff(
   ctx: ReqContext | ApiReqContext,
   schedule: RampScheduleInterface,
+  // Only the advanceStep route sets this — a manual completeRampKeepCutoff
+  // spanning multiple steps must not be recorded as an automatic catch-up.
+  opts: { autoCatchUp?: boolean } = {},
 ): Promise<RampScheduleInterface> {
   const now = new Date();
   const effective = computeEffectivePatch(schedule, schedule.steps.length);
@@ -1840,12 +1897,13 @@ async function applyEndActionsAndAwaitCutoff(
       schedule,
       schedule.steps.length,
       actionsToApply,
-      { fromStepIndex: schedule.currentStepIndex },
+      opts.autoCatchUp ? { fromStepIndex: schedule.currentStepIndex } : {},
     );
   }
 
   const pastEndIndex = schedule.steps.length;
-  const isJump = pastEndIndex > schedule.currentStepIndex + 1;
+  const isJump =
+    !!opts.autoCatchUp && pastEndIndex > schedule.currentStepIndex + 1;
   const updated = await ctx.models.rampSchedules.updateById(schedule.id, {
     status: "running",
     currentStepIndex: pastEndIndex,
@@ -2041,24 +2099,49 @@ export async function onActivatingRevisionPublished(
  * Content-level fields (name, steps, cutoffDate, etc.) should already be
  * applied to `schedule` before this is called, or passed in via
  * `contentUpdates` so they land atomically in a single write.
+ *
+ * Returns false when the start did NOT run (schedule no longer ready, or the
+ * lock stayed busy) so the caller can apply its content edits through the
+ * normal update path instead of silently dropping them.
  */
 export async function startReadyScheduleNow(
   ctx: ReqContext | ApiReqContext,
   schedule: RampScheduleInterface,
   contentUpdates: StartNowContentUpdates = {},
-): Promise<void> {
-  if (schedule.status !== "ready") return;
+): Promise<boolean> {
+  if (schedule.status !== "ready") return false;
 
-  // Serialize against the scheduler tick; re-verify "ready" inside the lock
-  // and start from the in-lock read so an edit that landed while waiting
-  // isn't overwritten with the caller's stale snapshot. Retry rather than
-  // defer: with startDate about to be cleared, the scheduler has no path
-  // that would replay this start.
-  await withRampScheduleAdvanceLockRetry(ctx, schedule.id, async () => {
-    const fresh = await ctx.models.rampSchedules.getById(schedule.id);
-    if (!fresh || fresh.status !== "ready") return;
-    await startReadyScheduleNowLocked(ctx, fresh, contentUpdates);
-  });
+  try {
+    // Serialize against the scheduler tick; re-verify "ready" inside the lock
+    // and start from the in-lock read so an edit that landed while waiting
+    // isn't overwritten with the caller's stale snapshot.
+    return await withRampScheduleAdvanceLockRetry(
+      ctx,
+      schedule.id,
+      async () => {
+        const fresh = await ctx.models.rampSchedules.getById(schedule.id);
+        if (!fresh || fresh.status !== "ready") return false;
+        await startReadyScheduleNowLocked(ctx, fresh, contentUpdates);
+        return true;
+      },
+    );
+  } catch (e) {
+    if (!(e instanceof RampAdvanceLockBusyError)) throw e;
+    // Lock stayed busy: hand the start to the scheduler instead of silently
+    // losing the user's "start now" — its ready branch starts any ready
+    // schedule whose startDate has arrived. Scheduling fields only; content
+    // edits are the caller's responsibility on the false return.
+    const now = new Date();
+    await ctx.models.rampSchedules.updateById(schedule.id, {
+      startDate: now,
+      nextProcessAt: now,
+    });
+    logger.warn(
+      { rampScheduleId: schedule.id },
+      "Start-now lock stayed busy; deferred the start to the scheduler via startDate",
+    );
+    return false;
+  }
 }
 
 type StartNowContentUpdates = Partial<
@@ -2071,11 +2154,13 @@ type StartNowContentUpdates = Partial<
     | "cutoffDate"
     | "monitoringConfig"
     | "lockdownConfig"
-    // Pre-built history (e.g. a "config-edited" audit event) for the
-    // "started" event to append on top of, instead of the stored history.
-    | "eventHistory"
   >
->;
+> & {
+  // A pre-built audit event (e.g. "config-edited") recorded beneath the
+  // "started" event — appended onto the in-lock history so concurrently
+  // appended events aren't clobbered by a caller-built array.
+  auditEvent?: RampEvent;
+};
 
 async function startReadyScheduleNowLocked(
   ctx: ReqContext | ApiReqContext,
@@ -2083,19 +2168,23 @@ async function startReadyScheduleNowLocked(
   contentUpdates: StartNowContentUpdates = {},
 ): Promise<void> {
   const now = new Date();
-  const steps = contentUpdates.steps ?? schedule.steps;
+  const { auditEvent, ...contentFields } = contentUpdates;
+  const steps = contentFields.steps ?? schedule.steps;
   const cutoffDate =
-    "cutoffDate" in contentUpdates
-      ? contentUpdates.cutoffDate
+    "cutoffDate" in contentFields
+      ? contentFields.cutoffDate
       : schedule.cutoffDate;
   const initialNextStepAt = steps.length > 0 ? now : null;
 
-  const eventBase = contentUpdates.eventHistory
-    ? { ...schedule, eventHistory: contentUpdates.eventHistory }
+  const eventBase = auditEvent
+    ? {
+        ...schedule,
+        eventHistory: [...(schedule.eventHistory ?? []), auditEvent],
+      }
     : schedule;
 
   let current = await ctx.models.rampSchedules.updateById(schedule.id, {
-    ...contentUpdates,
+    ...contentFields,
     startDate: null,
     status: "running",
     startedAt: now,

--- a/packages/back-end/src/services/rampSchedule.ts
+++ b/packages/back-end/src/services/rampSchedule.ts
@@ -11,11 +11,13 @@ import {
   RampMonitoringMode,
   RampScheduleInterface,
   RampScheduleTemplateInterface,
+  RampStep,
   RampStepAction,
   SafeRolloutInterface,
 } from "shared/validators";
 import { ResourceEvents } from "shared/types/events/base-types";
 import { filterEnvironmentsByFeature, MergeResultChanges } from "shared/util";
+import uniqid from "uniqid";
 import { getEnvironments } from "back-end/src/services/organizations";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
@@ -35,8 +37,92 @@ import {
   getApplicableEnvIds,
 } from "back-end/src/util/flattenRules";
 import { logger } from "back-end/src/util/logger";
+import {
+  NotFoundError,
+  RampAdvanceLockBusyError,
+} from "back-end/src/util/errors";
 
 const LOCKDOWN_ACTIVE_STATUSES = ["running"] as const;
+
+// Serialize schedule mutation across every entry point (scheduler tick,
+// snapshot hook, HTTP/API actions). Throws RampAdvanceLockBusyError when held.
+// Non-reentrant: never call from code already inside the lock. Callers must
+// re-read the schedule *inside* `fn` — acting on a pre-lock snapshot would
+// replay steps another advance already applied.
+export async function withRampScheduleAdvanceLock<T>(
+  ctx: ReqContext | ApiReqContext,
+  scheduleId: string,
+  // `heartbeat` refreshes the lock's liveness timestamp; long multi-phase
+  // holders (the scheduler tick) should call it between phases so a slow
+  // phase isn't stale-reclaimed mid-flight.
+  fn: (heartbeat: () => Promise<void>) => Promise<T>,
+): Promise<T> {
+  const token = uniqid("ral_");
+  const acquired = await ctx.models.rampSchedules.acquireAdvanceLock(
+    scheduleId,
+    token,
+  );
+  if (!acquired) {
+    throw new RampAdvanceLockBusyError(
+      `Ramp schedule ${scheduleId} advance already in progress`,
+    );
+  }
+  try {
+    return await fn(() =>
+      ctx.models.rampSchedules.touchAdvanceLockHeartbeat(scheduleId, token),
+    );
+  } finally {
+    // Never let a release failure mask the error `fn` threw; a leaked lock
+    // self-heals via the stale threshold.
+    try {
+      await ctx.models.rampSchedules.releaseAdvanceLock(scheduleId, token);
+    } catch (releaseErr) {
+      logger.warn(
+        { rampScheduleId: scheduleId, error: (releaseErr as Error).message },
+        "Failed to release ramp advance lock; stale threshold will reclaim it",
+      );
+    }
+  }
+}
+
+// For user-initiated actions (resume, manual advance, jump) whose intent the
+// scheduler cannot replay: contention windows are seconds long, so retry a few
+// times before surfacing the busy error to the user.
+export async function withRampScheduleAdvanceLockRetry<T>(
+  ctx: ReqContext | ApiReqContext,
+  scheduleId: string,
+  fn: () => Promise<T>,
+  attempts = 4,
+): Promise<T> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await withRampScheduleAdvanceLock(ctx, scheduleId, fn);
+    } catch (e) {
+      if (!(e instanceof RampAdvanceLockBusyError) || attempt >= attempts) {
+        throw e;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
+    }
+  }
+}
+
+// Boundary wrapper for controller/API schedule actions: lock (with retry), a
+// fresh in-lock read, then the action. `fn` must re-validate any status
+// preconditions screened on the caller's pre-lock read — the schedule may have
+// changed while waiting for the lock (e.g. a tick completed it).
+export async function runLockedRampScheduleAction<T>(
+  ctx: ReqContext | ApiReqContext,
+  scheduleId: string,
+  fn: (fresh: RampScheduleInterface) => Promise<T>,
+): Promise<T> {
+  return withRampScheduleAdvanceLockRetry(ctx, scheduleId, async () => {
+    const fresh = await ctx.models.rampSchedules.getById(scheduleId);
+    if (!fresh) {
+      throw new NotFoundError("Ramp schedule no longer exists");
+    }
+    return fn(fresh);
+  });
+}
 
 const MAX_EVENT_HISTORY = 500;
 export const MONITORING_NO_TRAFFIC_GRACE_PERIOD_MS =
@@ -552,6 +638,77 @@ export function computeNextStepAt(
   return new Date(phaseStart.getTime() + total * 1000);
 }
 
+// A step may be folded past (skipped as an individual landing) in a catch-up
+// jump only if its effects are idempotent feature-rule patches. Tautologically
+// true today (the schema only allows targetType "feature-rule"); exists so a
+// future non-idempotent action type gets an individual landing instead of
+// being silently folded. NOTE: adding such an action type also requires
+// extending computeEffectivePatch/executeStepActions, which currently drop
+// non-feature-rule actions even at landings.
+export function stepIsCollapsible(step: RampStep): boolean {
+  return step.actions.every((a) => a.targetType === "feature-rule");
+}
+
+// Furthest step index the auto-advancer can reach: chains through purely
+// time-gated, collapsible steps whose timer has elapsed and stops *at* (never
+// past) any monitored / approval / sample-size hold. Returns currentStepIndex
+// when nothing is due, or steps.length to signal completion. Jumping straight
+// to this target in one publish equals stepping (computeEffectivePatch is
+// cumulative).
+//
+// `currentStepCleared`: the caller (evaluator) has already verified the
+// current step's holds and dueness with real data — skip our gate for the
+// first hop so the cleared advance and any due backlog behind it fold into a
+// single publish.
+export function computeAutoAdvanceTarget(
+  schedule: RampScheduleInterface,
+  now: Date,
+  opts: { currentStepCleared?: boolean } = {},
+): number {
+  const startIndex = schedule.currentStepIndex;
+  const maxSteps = schedule.steps.length;
+  let target = startIndex;
+
+  while (target < maxSteps) {
+    const isFirstHop = target === startIndex;
+    const firstHopCleared = isFirstHop && opts.currentStepCleared === true;
+
+    // A hold on the step we're currently on gates advancing out of it. There is
+    // no current step pre-start (target < 0), so step 0 is always reachable.
+    if (target >= 0 && !firstHopCleared) {
+      const step = schedule.steps[target];
+      const purelyTimeGated =
+        !step.monitored &&
+        !step.holdConditions?.requiresApproval &&
+        !step.holdConditions?.minSampleSize;
+      if (!purelyTimeGated) break;
+    }
+
+    // Never fold past an unvisited non-collapsible step; land on it instead so
+    // its effects fire. The current step (target === startIndex) is exempt —
+    // its landing already happened, and collapsibility is a static property
+    // with no release mechanism, so gating exit on it would wedge the schedule.
+    if (target > startIndex && !stepIsCollapsible(schedule.steps[target])) {
+      break;
+    }
+
+    // Time gate to leave `target`. The stored nextStepAt is authoritative for
+    // the current position and has no recomputable equivalent at index -1
+    // (computeNextStepAt(schedule, -1, now) is null); later hops recompute
+    // deterministically from the fixed phaseStartedAt.
+    const gate = firstHopCleared
+      ? now
+      : isFirstHop
+        ? schedule.nextStepAt
+        : computeNextStepAt(schedule, target, now);
+    if (!gate || gate > now) break;
+
+    target += 1;
+  }
+
+  return target;
+}
+
 export function computeNextProcessAt(schedule: {
   status: RampScheduleInterface["status"];
   nextStepAt?: Date | null;
@@ -675,6 +832,10 @@ async function executeStepActions(
   schedule: RampScheduleInterface,
   stepIndex: number,
   actions: RampStepAction[],
+  // fromStepIndex: the position before a multi-step catch-up jump, so the
+  // published revision's label shows the folded range instead of reading like
+  // a normal single advance.
+  opts: { fromStepIndex?: number } = {},
 ): Promise<void> {
   const ruleActions = actions.filter((a) => a.targetType === "feature-rule");
   if (!ruleActions.length) return;
@@ -719,13 +880,22 @@ async function executeStepActions(
   const isSimpleSchedule = schedule.steps.length === 0;
   const isStartAction = stepIndex < 0;
   const isCompleteAction = stepIndex >= schedule.steps.length;
+  // A catch-up jump folds steps (fromStepIndex+1 .. stepIndex) into one
+  // publish; 1-based that's (fromStepIndex+2 .. stepIndex+1).
+  const isJump =
+    opts.fromStepIndex !== undefined && stepIndex > opts.fromStepIndex + 1;
+  const jumpRange = isJump
+    ? `steps ${(opts.fromStepIndex ?? 0) + 2}–${Math.min(stepIndex, schedule.steps.length - 1) + 1} of ${schedule.steps.length}`
+    : "";
   let stepLabel: string;
   if (isSimpleSchedule) {
     stepLabel = isStartAction ? "Schedule started" : "Schedule ended";
   } else if (isStartAction) {
     stepLabel = "Ramp started";
   } else if (isCompleteAction) {
-    stepLabel = "Ramp complete";
+    stepLabel = isJump ? `Ramp complete (${jumpRange})` : "Ramp complete";
+  } else if (isJump) {
+    stepLabel = `Ramp ${jumpRange}`;
   } else {
     stepLabel = `Ramp step ${stepIndex + 1} of ${schedule.steps.length}`;
   }
@@ -866,8 +1036,26 @@ export async function transitionLinkedSafeRollout(
 export async function advanceStep(
   ctx: ReqContext | ApiReqContext,
   schedule: RampScheduleInterface,
+  targetStepIndex?: number,
 ): Promise<RampScheduleInterface> {
-  const nextStepIndex = schedule.currentStepIndex + 1;
+  const nextStepIndex = targetStepIndex ?? schedule.currentStepIndex + 1;
+
+  // A backwards/no-op target means the caller computed it from a stale
+  // snapshot (another advance already moved the playhead). Publishing it would
+  // silently rewind live coverage while recording a forward advance — refuse.
+  if (nextStepIndex <= schedule.currentStepIndex) {
+    logger.warn(
+      {
+        rampScheduleId: schedule.id,
+        currentStepIndex: schedule.currentStepIndex,
+        targetStepIndex: nextStepIndex,
+      },
+      "Refusing ramp advance to a non-forward step (stale caller snapshot?)",
+    );
+    return schedule;
+  }
+
+  const isJump = nextStepIndex > schedule.currentStepIndex + 1;
   const step = schedule.steps[nextStepIndex];
 
   if (!step) {
@@ -904,7 +1092,9 @@ export async function advanceStep(
       patch,
     }),
   );
-  await executeStepActions(ctx, schedule, nextStepIndex, effectiveActions);
+  await executeStepActions(ctx, schedule, nextStepIndex, effectiveActions, {
+    fromStepIndex: schedule.currentStepIndex,
+  });
 
   // `nextStepAt` is the time gate. Steps without an interval (pure approval /
   // instant gates) have no time gate, so nextStepAt is null. For instant
@@ -958,12 +1148,19 @@ export async function advanceStep(
       nextSnapshotAt,
       cutoffDate: schedule.cutoffDate,
     }),
-    eventHistory: appendRampEvent(schedule, "step-advanced", {
-      stepIndex: nextStepIndex,
-      previousStepIndex: schedule.currentStepIndex,
-      status: newStatus,
-      previousStatus: schedule.status,
-    }),
+    eventHistory: appendRampEvent(
+      schedule,
+      isJump ? "step-jumped" : "step-advanced",
+      {
+        stepIndex: nextStepIndex,
+        previousStepIndex: schedule.currentStepIndex,
+        status: newStatus,
+        previousStatus: schedule.status,
+        // Distinguishes automatic catch-up jumps from user-initiated
+        // jumpSchedule jumps in the timeline/audit view.
+        ...(isJump ? { reason: "Automatic catch-up of overdue steps" } : {}),
+      },
+    ),
   });
 
   await syncLinkedSafeRolloutForRampState(ctx, updated);
@@ -974,6 +1171,7 @@ export async function advanceStep(
       rampName: updated.name,
       orgId: ctx.org.id,
       currentStepIndex: updated.currentStepIndex,
+      previousStepIndex: schedule.currentStepIndex,
       status: updated.status,
     },
   });
@@ -1133,6 +1331,10 @@ export async function resumeSchedule(
   ctx: ReqContext | ApiReqContext,
   schedule: RampScheduleInterface,
 ): Promise<RampScheduleInterface> {
+  // Must be called with the advance lock held and `schedule` read inside the
+  // lock (the controller/API boundary handles both) — writing the resume from
+  // a pre-lock snapshot would clobber or resurrect state a concurrent tick is
+  // producing (e.g. flipping a just-completed schedule back to running).
   const now = new Date();
   const pauseDurationMs = schedule.pausedAt
     ? now.getTime() - schedule.pausedAt.getTime()
@@ -1233,9 +1435,9 @@ export async function resumeSchedule(
     resumeUpdates,
   );
 
-  // After resuming, chain through any time-due steps (nextStepAt <= now).
-  // Steps with no interval (approval gates, instant steps) have nextStepAt=null
-  // and are not traversed here — the agenda re-picks them via nextProcessAt.
+  // Chain through any time-due steps (nextStepAt <= now). Steps with no
+  // interval (approval gates, instant steps) have nextStepAt=null and are not
+  // traversed here — the agenda re-picks them via nextProcessAt.
   await advanceUntilBlocked(ctx, updated, now);
   updated = (await ctx.models.rampSchedules.getById(schedule.id)) ?? updated;
 
@@ -1609,6 +1811,22 @@ async function applyEndActionsAndAwaitCutoff(
   const now = new Date();
   const effective = computeEffectivePatch(schedule, schedule.steps.length);
 
+  // Mirror advanceStep/completeRollout: a never-started schedule (a catch-up
+  // jump from -1 straight past the end) has its rule still disabled, so fold
+  // enabled:true into this publish or the rule would sit at end-state coverage
+  // without ever serving traffic.
+  if (schedule.currentStepIndex < 0 && schedule.steps.length > 0) {
+    for (const target of schedule.targets) {
+      if (target.status !== "active" || target.entityType !== "feature") {
+        continue;
+      }
+      const existing = effective.get(target.id) ?? {
+        ruleId: target.ruleId ?? "",
+      };
+      effective.set(target.id, { ...existing, enabled: true });
+    }
+  }
+
   const actionsToApply: RampStepAction[] = [...effective.entries()].map(
     ([targetId, patch]) => ({
       targetType: "feature-rule" as const,
@@ -1622,10 +1840,12 @@ async function applyEndActionsAndAwaitCutoff(
       schedule,
       schedule.steps.length,
       actionsToApply,
+      { fromStepIndex: schedule.currentStepIndex },
     );
   }
 
   const pastEndIndex = schedule.steps.length;
+  const isJump = pastEndIndex > schedule.currentStepIndex + 1;
   const updated = await ctx.models.rampSchedules.updateById(schedule.id, {
     status: "running",
     currentStepIndex: pastEndIndex,
@@ -1636,12 +1856,17 @@ async function applyEndActionsAndAwaitCutoff(
       status: "running",
       cutoffDate: schedule.cutoffDate,
     }),
-    eventHistory: appendRampEvent(schedule, "step-advanced", {
-      stepIndex: pastEndIndex,
-      previousStepIndex: schedule.currentStepIndex,
-      status: "running",
-      previousStatus: schedule.status,
-    }),
+    eventHistory: appendRampEvent(
+      schedule,
+      isJump ? "step-jumped" : "step-advanced",
+      {
+        stepIndex: pastEndIndex,
+        previousStepIndex: schedule.currentStepIndex,
+        status: "running",
+        previousStatus: schedule.status,
+        ...(isJump ? { reason: "Automatic catch-up of overdue steps" } : {}),
+      },
+    ),
   });
 
   await syncLinkedSafeRolloutForRampState(ctx, updated);
@@ -1835,6 +2060,32 @@ export async function startReadyScheduleNow(
 ): Promise<void> {
   if (schedule.status !== "ready") return;
 
+  // Serialize against the scheduler tick; re-verify "ready" inside the lock.
+  // Retry rather than defer: with startDate about to be cleared, the scheduler
+  // has no path that would replay this start.
+  await withRampScheduleAdvanceLockRetry(ctx, schedule.id, async () => {
+    const fresh = await ctx.models.rampSchedules.getById(schedule.id);
+    if (!fresh || fresh.status !== "ready") return;
+    await startReadyScheduleNowLocked(ctx, schedule, contentUpdates);
+  });
+}
+
+async function startReadyScheduleNowLocked(
+  ctx: ReqContext | ApiReqContext,
+  schedule: RampScheduleInterface,
+  contentUpdates: Partial<
+    Pick<
+      RampScheduleInterface,
+      | "name"
+      | "steps"
+      | "startActions"
+      | "endActions"
+      | "cutoffDate"
+      | "monitoringConfig"
+      | "lockdownConfig"
+    >
+  > = {},
+): Promise<void> {
   const now = new Date();
   const steps = contentUpdates.steps ?? schedule.steps;
   const cutoffDate =
@@ -1890,7 +2141,24 @@ export async function onRevisionPublished(
       revision.version,
     );
   for (const schedule of activatingRamps) {
-    await onActivatingRevisionPublished(ctx, schedule);
+    try {
+      // Serialize against the scheduler's pending branch, which runs the same
+      // activation under its own lock — without this, both can observe
+      // "pending" and double-start the ramp.
+      await withRampScheduleAdvanceLock(ctx, schedule.id, async () => {
+        const fresh = await ctx.models.rampSchedules.getById(schedule.id);
+        if (!fresh || fresh.status !== "pending") return;
+        await onActivatingRevisionPublished(ctx, fresh);
+      });
+    } catch (e) {
+      if (!(e instanceof RampAdvanceLockBusyError)) throw e;
+      // The scheduler is already processing this schedule; its pending branch
+      // re-checks activation every tick, so the start is not lost.
+      logger.info(
+        { rampScheduleId: schedule.id },
+        "Deferring ramp activation to scheduler — advance already in progress",
+      );
+    }
   }
 }
 
@@ -1970,11 +2238,9 @@ export function initRampScheduleHooks(): void {
 
 export async function advanceUntilBlocked(
   ctx: ReqContext | ApiReqContext,
-  initial: RampScheduleInterface,
+  current: RampScheduleInterface,
   now: Date,
 ): Promise<void> {
-  let current = initial;
-
   // A running schedule with no remaining work (no steps and no cutoffDate)
   // is terminal — auto-complete so it doesn't sit in "running" forever after
   // its start action fired. Schedules with a cutoffDate still wait for it;
@@ -1993,9 +2259,7 @@ export async function advanceUntilBlocked(
     return;
   }
 
-  // cutoffDate check sits outside the steps loop so it fires for 0-step
-  // "enable on publish, disable on date" schedules too (maxSteps would be 0
-  // and the loop body would never execute, stranding the schedule indefinitely).
+  // Must run even for 0-step "enable on publish, disable on date" schedules.
   if (
     current.cutoffDate &&
     current.cutoffDate <= now &&
@@ -2028,42 +2292,14 @@ export async function advanceUntilBlocked(
     }
   }
 
-  const maxSteps = current.steps.length;
+  if (current.status !== "running") return;
 
-  for (let i = 0; i < maxSteps; i++) {
-    if (
-      current.cutoffDate &&
-      current.cutoffDate <= now &&
-      ["running", "paused"].includes(current.status)
-    ) {
-      await completeRollout(ctx, current, { disableActiveTargets: true });
-      return;
-    }
-
-    if (current.status !== "running") return;
-    if (!current.nextStepAt || current.nextStepAt > now) return;
-
-    // Only chain through steps that are purely time-gated (interval only, no
-    // hold conditions, not monitored). Any other hold — approval, minSampleSize,
-    // monitoring-derived gates, or anything added in the future — must be
-    // evaluated by the agenda/evaluator with real data before advancing.
-    //
-    // This check runs BEFORE advancing so that a step whose timer has elapsed
-    // but whose holds have not been cleared (e.g. paused after timer but before
-    // approval was given) is not silently skipped on resume.
-    //
-    // When currentStepIndex is -1 (pre-start), there is no current step to
-    // gate on — the schedule is allowed to advance to step 0.
-    const stepBeforeAdvance = current.steps[current.currentStepIndex];
-    if (stepBeforeAdvance) {
-      const currentIsPurelyTimeGated =
-        !stepBeforeAdvance.monitored &&
-        !stepBeforeAdvance.holdConditions?.requiresApproval &&
-        !stepBeforeAdvance.holdConditions?.minSampleSize;
-      if (!currentIsPurelyTimeGated) return;
-    }
-
-    current = await advanceStep(ctx, current);
+  // Collapse the overdue backlog into a single jump publish — publishing once
+  // per due step regenerates the full SDK payload and fires webhooks per step,
+  // the storm that took down pods when a large backlog replayed in one request.
+  const target = computeAutoAdvanceTarget(current, now);
+  if (target > current.currentStepIndex) {
+    await advanceStep(ctx, current, target);
   }
 }
 

--- a/packages/back-end/src/services/rampSchedule.ts
+++ b/packages/back-end/src/services/rampSchedule.ts
@@ -56,10 +56,8 @@ async function assertScheduleExistsAfterFailedAcquire(
   }
 }
 
-// Runs `fn` with the already-acquired lock, releasing on the way out. The
-// heartbeat passed to `fn` refreshes the lock's liveness timestamp between
-// slow phases; it throws RampAdvanceLockBusyError if the lease was stale-
-// reclaimed, so a robbed holder aborts instead of writing concurrently.
+// The heartbeat passed to `fn` throws RampAdvanceLockBusyError when the lease
+// was stale-reclaimed, so a robbed holder aborts instead of writing concurrently.
 async function runWithAcquiredAdvanceLock<T>(
   ctx: ReqContext | ApiReqContext,
   scheduleId: string,
@@ -80,8 +78,7 @@ async function runWithAcquiredAdvanceLock<T>(
       }
     });
   } finally {
-    // Never let a release failure mask the error `fn` threw; a leaked lock
-    // self-heals via the stale threshold.
+    // Never mask fn's error with a release failure; a leaked lock self-heals.
     try {
       await ctx.models.rampSchedules.releaseAdvanceLock(scheduleId, token);
     } catch (releaseErr) {
@@ -93,9 +90,7 @@ async function runWithAcquiredAdvanceLock<T>(
   }
 }
 
-// Serialize schedule mutation across every entry point (scheduler tick,
-// snapshot hook, HTTP/API actions). Throws RampAdvanceLockBusyError when held.
-// Non-reentrant: never call from code already inside the lock. Callers must
+// Non-reentrant; throws RampAdvanceLockBusyError when held. Callers must
 // re-read the schedule *inside* `fn` — acting on a pre-lock snapshot would
 // replay steps another advance already applied.
 export async function withRampScheduleAdvanceLock<T>(
@@ -117,11 +112,9 @@ export async function withRampScheduleAdvanceLock<T>(
   return runWithAcquiredAdvanceLock(ctx, scheduleId, token, fn);
 }
 
-// For user-initiated actions (resume, manual advance, jump) whose intent the
-// scheduler cannot replay: contention windows are seconds long, so retry the
-// ACQUISITION a few times before surfacing the busy error. Only the acquire is
-// retried — `fn` runs exactly once, so side effects (revision publishes) can
-// never be re-executed by a busy error escaping from inside `fn`.
+// For user-initiated actions whose intent the scheduler cannot replay. Only
+// the acquisition is retried — `fn` runs exactly once, so publishes can never
+// be re-executed by a busy error escaping from inside `fn`.
 export async function withRampScheduleAdvanceLockRetry<T>(
   ctx: ReqContext | ApiReqContext,
   scheduleId: string,
@@ -147,9 +140,8 @@ export async function withRampScheduleAdvanceLockRetry<T>(
   return runWithAcquiredAdvanceLock(ctx, scheduleId, token, fn);
 }
 
-// Boundary wrapper for controller/API schedule actions. `fn` must re-validate
-// any status preconditions screened on the caller's pre-lock read — the
-// schedule may have changed while waiting for the lock.
+// `fn` must re-validate any status preconditions screened on the caller's
+// pre-lock read — the schedule may have changed while waiting for the lock.
 export async function runLockedRampScheduleAction<T>(
   ctx: ReqContext | ApiReqContext,
   scheduleId: string,
@@ -685,28 +677,17 @@ export function computeNextStepAt(
   return new Date(phaseStart.getTime() + total * 1000);
 }
 
-// A step may be folded past (skipped as an individual landing) in a catch-up
-// jump only if its effects are idempotent feature-rule patches. Tautologically
-// true today (the schema only allows targetType "feature-rule"); exists so a
-// future non-idempotent action type gets an individual landing instead of
-// being silently folded. NOTE: adding such an action type also requires
-// extending computeEffectivePatch/executeStepActions, which currently drop
-// non-feature-rule actions even at landings.
+// Tautological today (the schema only allows targetType "feature-rule").
+// A future non-feature-rule action type must land individually AND extend
+// computeEffectivePatch/executeStepActions, which currently drop it.
 export function stepIsCollapsible(step: RampStep): boolean {
   return step.actions.every((a) => a.targetType === "feature-rule");
 }
 
-// Furthest step index the auto-advancer can reach: chains through purely
-// time-gated, collapsible steps whose timer has elapsed and stops *at* (never
-// past) any monitored / approval / sample-size hold. Returns currentStepIndex
-// when nothing is due, or steps.length to signal completion. Jumping straight
-// to this target in one publish equals stepping (computeEffectivePatch is
-// cumulative).
-//
-// `currentStepCleared`: the caller (evaluator) has already verified the
-// current step's holds and dueness with real data — skip our gate for the
-// first hop so the cleared advance and any due backlog behind it fold into a
-// single publish.
+// Returns currentStepIndex when nothing is due, or steps.length to signal
+// completion. Jumping straight to the target in one publish equals stepping
+// (computeEffectivePatch is cumulative). `currentStepCleared`: the evaluator
+// already verified the current step with real data — skip the first-hop gates.
 export function computeAutoAdvanceTarget(
   schedule: RampScheduleInterface,
   now: Date,
@@ -731,17 +712,15 @@ export function computeAutoAdvanceTarget(
       if (!purelyTimeGated) break;
     }
 
-    // Never fold past an unvisited non-collapsible step; land on it instead so
-    // its effects fire. The current step (target === startIndex) is exempt —
-    // its landing already happened, and collapsibility is a static property
-    // with no release mechanism, so gating exit on it would wedge the schedule.
+    // Never fold past an unvisited non-collapsible step — land on it so its
+    // effects fire. The current step is exempt: its landing already happened,
+    // and gating exit on a static property would wedge the schedule.
     if (target > startIndex && !stepIsCollapsible(schedule.steps[target])) {
       break;
     }
 
-    // Time gate to leave `target`. The stored nextStepAt is authoritative for
-    // the current position and has no recomputable equivalent at index -1
-    // (computeNextStepAt(schedule, -1, now) is null); later hops recompute
+    // The stored nextStepAt is authoritative for the current position (it has
+    // no recomputable equivalent at index -1); later hops recompute
     // deterministically from the fixed phaseStartedAt.
     const gate = firstHopCleared
       ? now
@@ -879,9 +858,8 @@ async function executeStepActions(
   schedule: RampScheduleInterface,
   stepIndex: number,
   actions: RampStepAction[],
-  // fromStepIndex: the position before a multi-step catch-up jump, so the
-  // published revision's label shows the folded range instead of reading like
-  // a normal single advance.
+  // fromStepIndex: position before a catch-up jump, so the published
+  // revision's label shows the folded range instead of a normal single advance.
   opts: { fromStepIndex?: number } = {},
 ): Promise<void> {
   const ruleActions = actions.filter((a) => a.targetType === "feature-rule");
@@ -1087,9 +1065,8 @@ export async function advanceStep(
 ): Promise<RampScheduleInterface> {
   const nextStepIndex = targetStepIndex ?? schedule.currentStepIndex + 1;
 
-  // A backwards/no-op target means the caller computed it from a stale
-  // snapshot (another advance already moved the playhead). Publishing it would
-  // silently rewind live coverage while recording a forward advance — refuse.
+  // A backwards/no-op target means the caller's snapshot is stale (another
+  // advance moved the playhead); publishing would silently rewind live coverage.
   if (nextStepIndex <= schedule.currentStepIndex) {
     logger.warn(
       {
@@ -1111,9 +1088,8 @@ export async function advanceStep(
         autoCatchUp: true,
       });
     }
-    // Reaching here with a cutoffDate means it already lapsed (the future case
-    // returned above), so honor the cutoff's disable semantics — otherwise the
-    // rule would complete permanently enabled at end-state coverage.
+    // A cutoffDate here has already lapsed, so honor its disable semantics —
+    // otherwise the rule would complete permanently enabled.
     return completeRollout(ctx, schedule, {
       disableActiveTargets: !!schedule.cutoffDate,
     });
@@ -1385,10 +1361,9 @@ export async function resumeSchedule(
   ctx: ReqContext | ApiReqContext,
   schedule: RampScheduleInterface,
 ): Promise<RampScheduleInterface> {
-  // Must be called with the advance lock held and `schedule` read inside the
-  // lock (the controller/API boundary handles both) — writing the resume from
-  // a pre-lock snapshot would clobber or resurrect state a concurrent tick is
-  // producing (e.g. flipping a just-completed schedule back to running).
+  // Must be called with the advance lock held and `schedule` read inside it —
+  // a pre-lock snapshot could resurrect state a concurrent tick produced
+  // (e.g. flipping a just-completed schedule back to running).
   const now = new Date();
   const pauseDurationMs = schedule.pausedAt
     ? now.getTime() - schedule.pausedAt.getTime()
@@ -1868,10 +1843,9 @@ async function applyEndActionsAndAwaitCutoff(
   const now = new Date();
   const effective = computeEffectivePatch(schedule, schedule.steps.length);
 
-  // Mirror advanceStep/completeRollout: a never-started schedule (a catch-up
-  // jump from -1 straight past the end) has its rule still disabled, so fold
-  // enabled:true into this publish or the rule would sit at end-state coverage
-  // without ever serving traffic.
+  // A never-started schedule (catch-up jump from -1 past the end) has its rule
+  // still disabled — fold enabled:true into this publish or the rule would sit
+  // at end-state coverage without ever serving traffic.
   if (schedule.currentStepIndex < 0 && schedule.steps.length > 0) {
     for (const target of schedule.targets) {
       if (target.status !== "active" || target.entityType !== "feature") {
@@ -2112,9 +2086,8 @@ export async function startReadyScheduleNow(
   if (schedule.status !== "ready") return false;
 
   try {
-    // Serialize against the scheduler tick; re-verify "ready" inside the lock
-    // and start from the in-lock read so an edit that landed while waiting
-    // isn't overwritten with the caller's stale snapshot.
+    // Re-verify "ready" and start from the in-lock read so an edit that landed
+    // while waiting isn't overwritten with the caller's stale snapshot.
     return await withRampScheduleAdvanceLockRetry(
       ctx,
       schedule.id,
@@ -2127,10 +2100,9 @@ export async function startReadyScheduleNow(
     );
   } catch (e) {
     if (!(e instanceof RampAdvanceLockBusyError)) throw e;
-    // Lock stayed busy: hand the start to the scheduler instead of silently
-    // losing the user's "start now" — its ready branch starts any ready
-    // schedule whose startDate has arrived. Scheduling fields only; content
-    // edits are the caller's responsibility on the false return.
+    // Lock stayed busy: startDate=now defers the start to the scheduler
+    // instead of losing the user's "start now". Scheduling fields only;
+    // content edits are the caller's responsibility on the false return.
     const now = new Date();
     await ctx.models.rampSchedules.updateById(schedule.id, {
       startDate: now,
@@ -2156,9 +2128,8 @@ type StartNowContentUpdates = Partial<
     | "lockdownConfig"
   >
 > & {
-  // A pre-built audit event (e.g. "config-edited") recorded beneath the
-  // "started" event — appended onto the in-lock history so concurrently
-  // appended events aren't clobbered by a caller-built array.
+  // Recorded beneath the "started" event; appended onto the in-lock history
+  // so concurrently appended events aren't clobbered by a caller-built array.
   auditEvent?: RampEvent;
 };
 
@@ -2231,9 +2202,8 @@ export async function onRevisionPublished(
     );
   for (const schedule of activatingRamps) {
     try {
-      // Serialize against the scheduler's pending branch, which runs the same
-      // activation under its own lock — without this, both can observe
-      // "pending" and double-start the ramp.
+      // Without the lock, this hook and the scheduler's pending branch can
+      // both observe "pending" and double-start the ramp.
       await withRampScheduleAdvanceLock(ctx, schedule.id, async () => {
         const fresh = await ctx.models.rampSchedules.getById(schedule.id);
         if (!fresh || fresh.status !== "pending") return;

--- a/packages/back-end/src/services/rampScheduleEvaluator.ts
+++ b/packages/back-end/src/services/rampScheduleEvaluator.ts
@@ -15,11 +15,14 @@ import { ApiReqContext } from "back-end/types/api";
 import {
   MONITORING_NO_TRAFFIC_GRACE_PERIOD_MS,
   advanceStep,
-  advanceUntilBlocked,
+  computeAutoAdvanceTarget,
   computeNextProcessAt,
   pauseSchedule,
   rollbackSchedule,
+  withRampScheduleAdvanceLock,
 } from "back-end/src/services/rampSchedule";
+import { RampAdvanceLockBusyError } from "back-end/src/util/errors";
+import { logger } from "back-end/src/util/logger";
 
 export type EvalDecision =
   | { action: "advance" }
@@ -514,8 +517,21 @@ export async function applyRampEvaluationDecision(
     return { handled: true, schedule: updated };
   }
 
-  const updated = await advanceStep(ctx, schedule);
-  return { handled: false, schedule: updated };
+  // The evaluator has verified the current step's holds/dueness with real
+  // data, so fold this advance and any purely-time-gated backlog behind it
+  // into a single jump publish (rather than one publish here plus a second
+  // catch-up publish from the caller's advanceUntilBlocked). An "advance"
+  // decision always moves at least one step — for a past-end schedule the
+  // walk returns startIndex, but +1 routes advanceStep into its completion
+  // branch (the pre-collapse behavior).
+  const target = Math.max(
+    computeAutoAdvanceTarget(schedule, new Date(), {
+      currentStepCleared: true,
+    }),
+    schedule.currentStepIndex + 1,
+  );
+  const updated = await advanceStep(ctx, schedule, target);
+  return { handled: true, schedule: updated };
 }
 
 export async function evaluateRampScheduleAfterSafeRolloutSnapshot(
@@ -524,21 +540,26 @@ export async function evaluateRampScheduleAfterSafeRolloutSnapshot(
   now: Date = new Date(),
 ): Promise<void> {
   if (!safeRollout.rampScheduleId) return;
-  const schedule = await ctx.models.rampSchedules.getById(
-    safeRollout.rampScheduleId,
-  );
-  if (!schedule || schedule.status !== "running") return;
-  const step = schedule.steps[schedule.currentStepIndex];
-  if (!step?.monitored) return;
+  const rampScheduleId = safeRollout.rampScheduleId;
 
-  const decision = await evaluateCurrentStep(ctx, schedule, now);
-  const result = await applyRampEvaluationDecision(ctx, schedule, decision);
+  try {
+    // Serialize against the scheduler tick — both run this same
+    // evaluate-and-advance pipeline and would otherwise double-publish.
+    await withRampScheduleAdvanceLock(ctx, rampScheduleId, async () => {
+      const schedule = await ctx.models.rampSchedules.getById(rampScheduleId);
+      if (!schedule || schedule.status !== "running") return;
+      const step = schedule.steps[schedule.currentStepIndex];
+      if (!step?.monitored) return;
 
-  // When the decision is "advance", applyRampEvaluationDecision performs one
-  // advanceStep but stops there. Continue traversing until blocked so that
-  // consecutive non-monitoring steps don't wait for the next agenda tick —
-  // matching the behavior of the agenda-driven advancement path.
-  if (!result.handled) {
-    await advanceUntilBlocked(ctx, result.schedule, now);
+      const decision = await evaluateCurrentStep(ctx, schedule, now);
+      await applyRampEvaluationDecision(ctx, schedule, decision);
+    });
+  } catch (e) {
+    if (!(e instanceof RampAdvanceLockBusyError)) throw e;
+    // The tick is already evaluating this schedule with the same data.
+    logger.info(
+      { rampScheduleId },
+      "Skipping post-snapshot ramp evaluation — advance already in progress",
+    );
   }
 }

--- a/packages/back-end/src/services/rampScheduleEvaluator.ts
+++ b/packages/back-end/src/services/rampScheduleEvaluator.ts
@@ -15,6 +15,7 @@ import { ApiReqContext } from "back-end/types/api";
 import {
   MONITORING_NO_TRAFFIC_GRACE_PERIOD_MS,
   advanceStep,
+  completeRollout,
   computeAutoAdvanceTarget,
   computeNextProcessAt,
   pauseSchedule,
@@ -551,6 +552,14 @@ export async function evaluateRampScheduleAfterSafeRolloutSnapshot(
     await withRampScheduleAdvanceLockRetry(ctx, rampScheduleId, async () => {
       const schedule = await ctx.models.rampSchedules.getById(rampScheduleId);
       if (!schedule || schedule.status !== "running") return;
+
+      // Mirror the tick's cutoff branch: a lapsed cutoff must complete-with-
+      // disable, never raise coverage further.
+      if (schedule.cutoffDate && schedule.cutoffDate <= now) {
+        await completeRollout(ctx, schedule, { disableActiveTargets: true });
+        return;
+      }
+
       const step = schedule.steps[schedule.currentStepIndex];
       if (!step?.monitored) return;
 

--- a/packages/back-end/src/services/rampScheduleEvaluator.ts
+++ b/packages/back-end/src/services/rampScheduleEvaluator.ts
@@ -19,9 +19,12 @@ import {
   computeNextProcessAt,
   pauseSchedule,
   rollbackSchedule,
-  withRampScheduleAdvanceLock,
+  withRampScheduleAdvanceLockRetry,
 } from "back-end/src/services/rampSchedule";
-import { RampAdvanceLockBusyError } from "back-end/src/util/errors";
+import {
+  NotFoundError,
+  RampAdvanceLockBusyError,
+} from "back-end/src/util/errors";
 import { logger } from "back-end/src/util/logger";
 
 export type EvalDecision =
@@ -495,14 +498,15 @@ export async function applyRampEvaluationDecision(
   ctx: ReqContext | ApiReqContext,
   schedule: RampScheduleInterface,
   decision: EvalDecision,
-): Promise<{ handled: boolean; schedule: RampScheduleInterface }> {
+  // The clock the decision was evaluated against — reused for the fold so the
+  // advance is internally consistent with the caller's cutoff/dueness checks.
+  now: Date = new Date(),
+): Promise<RampScheduleInterface> {
   if (decision.action === "rollback") {
-    const updated = await rollbackSchedule(ctx, schedule, decision.reason);
-    return { handled: true, schedule: updated };
+    return rollbackSchedule(ctx, schedule, decision.reason);
   }
   if (decision.action === "pause") {
-    const updated = await pauseSchedule(ctx, schedule, decision.reason);
-    return { handled: true, schedule: updated };
+    return pauseSchedule(ctx, schedule, decision.reason);
   }
   if (decision.action === "hold") {
     const nextProcessAt = computeNextProcessAt({
@@ -511,10 +515,9 @@ export async function applyRampEvaluationDecision(
       nextSnapshotAt: schedule.nextSnapshotAt,
       cutoffDate: schedule.cutoffDate,
     });
-    const updated = await ctx.models.rampSchedules.updateById(schedule.id, {
+    return ctx.models.rampSchedules.updateById(schedule.id, {
       nextProcessAt,
     });
-    return { handled: true, schedule: updated };
   }
 
   // The evaluator has verified the current step's holds/dueness with real
@@ -523,15 +526,14 @@ export async function applyRampEvaluationDecision(
   // catch-up publish from the caller's advanceUntilBlocked). An "advance"
   // decision always moves at least one step — for a past-end schedule the
   // walk returns startIndex, but +1 routes advanceStep into its completion
-  // branch (the pre-collapse behavior).
+  // branch, and for a pre-start (-1) schedule the unconditional first hop
+  // doubles as the unstick mechanism for broken nextStepAt states (both match
+  // the pre-collapse behavior).
   const target = Math.max(
-    computeAutoAdvanceTarget(schedule, new Date(), {
-      currentStepCleared: true,
-    }),
+    computeAutoAdvanceTarget(schedule, now, { currentStepCleared: true }),
     schedule.currentStepIndex + 1,
   );
-  const updated = await advanceStep(ctx, schedule, target);
-  return { handled: true, schedule: updated };
+  return advanceStep(ctx, schedule, target);
 }
 
 export async function evaluateRampScheduleAfterSafeRolloutSnapshot(
@@ -542,24 +544,35 @@ export async function evaluateRampScheduleAfterSafeRolloutSnapshot(
   if (!safeRollout.rampScheduleId) return;
   const rampScheduleId = safeRollout.rampScheduleId;
 
+  // Cheap pre-lock screen: many snapshot completions land after the ramp is no
+  // longer running/monitored (paused mid-query, manual refreshes on stopped
+  // ramps) — don't pay lock writes for those. Re-screened inside the lock.
+  const screened = await ctx.models.rampSchedules.getById(rampScheduleId);
+  if (!screened || screened.status !== "running") return;
+  if (!screened.steps[screened.currentStepIndex]?.monitored) return;
+
   try {
     // Serialize against the scheduler tick — both run this same
     // evaluate-and-advance pipeline and would otherwise double-publish.
-    await withRampScheduleAdvanceLock(ctx, rampScheduleId, async () => {
+    // Retry rather than skip: a busy holder may be a user action (which
+    // evaluates nothing) or a tick that read PRE-snapshot data — dropping the
+    // evaluation would discard fresh analysis, including rollback decisions,
+    // until the next scheduled evaluation.
+    await withRampScheduleAdvanceLockRetry(ctx, rampScheduleId, async () => {
       const schedule = await ctx.models.rampSchedules.getById(rampScheduleId);
       if (!schedule || schedule.status !== "running") return;
       const step = schedule.steps[schedule.currentStepIndex];
       if (!step?.monitored) return;
 
       const decision = await evaluateCurrentStep(ctx, schedule, now);
-      await applyRampEvaluationDecision(ctx, schedule, decision);
+      await applyRampEvaluationDecision(ctx, schedule, decision, now);
     });
   } catch (e) {
+    if (e instanceof NotFoundError) return;
     if (!(e instanceof RampAdvanceLockBusyError)) throw e;
-    // The tick is already evaluating this schedule with the same data.
     logger.info(
       { rampScheduleId },
-      "Skipping post-snapshot ramp evaluation — advance already in progress",
+      "Skipping post-snapshot ramp evaluation — advance lock still held after retries",
     );
   }
 }

--- a/packages/back-end/src/services/rampScheduleEvaluator.ts
+++ b/packages/back-end/src/services/rampScheduleEvaluator.ts
@@ -520,15 +520,10 @@ export async function applyRampEvaluationDecision(
     });
   }
 
-  // The evaluator has verified the current step's holds/dueness with real
-  // data, so fold this advance and any purely-time-gated backlog behind it
-  // into a single jump publish (rather than one publish here plus a second
-  // catch-up publish from the caller's advanceUntilBlocked). An "advance"
-  // decision always moves at least one step — for a past-end schedule the
-  // walk returns startIndex, but +1 routes advanceStep into its completion
-  // branch, and for a pre-start (-1) schedule the unconditional first hop
-  // doubles as the unstick mechanism for broken nextStepAt states (both match
-  // the pre-collapse behavior).
+  // Fold the verified advance and any due backlog into a single jump publish.
+  // The +1 forces past-end schedules into advanceStep's completion branch; the
+  // unconditional first hop doubles as the unstick mechanism for broken
+  // nextStepAt states.
   const target = Math.max(
     computeAutoAdvanceTarget(schedule, now, { currentStepCleared: true }),
     schedule.currentStepIndex + 1,
@@ -544,20 +539,15 @@ export async function evaluateRampScheduleAfterSafeRolloutSnapshot(
   if (!safeRollout.rampScheduleId) return;
   const rampScheduleId = safeRollout.rampScheduleId;
 
-  // Cheap pre-lock screen: many snapshot completions land after the ramp is no
-  // longer running/monitored (paused mid-query, manual refreshes on stopped
-  // ramps) — don't pay lock writes for those. Re-screened inside the lock.
+  // Pre-lock screen: don't pay lock writes for no-op snapshot completions.
+  // Re-screened inside the lock.
   const screened = await ctx.models.rampSchedules.getById(rampScheduleId);
   if (!screened || screened.status !== "running") return;
   if (!screened.steps[screened.currentStepIndex]?.monitored) return;
 
   try {
-    // Serialize against the scheduler tick — both run this same
-    // evaluate-and-advance pipeline and would otherwise double-publish.
-    // Retry rather than skip: a busy holder may be a user action (which
-    // evaluates nothing) or a tick that read PRE-snapshot data — dropping the
-    // evaluation would discard fresh analysis, including rollback decisions,
-    // until the next scheduled evaluation.
+    // Retry rather than skip: the busy holder may have read pre-snapshot data,
+    // and dropping the evaluation would discard rollback decisions.
     await withRampScheduleAdvanceLockRetry(ctx, rampScheduleId, async () => {
       const schedule = await ctx.models.rampSchedules.getById(rampScheduleId);
       if (!schedule || schedule.status !== "running") return;

--- a/packages/back-end/src/util/errors.ts
+++ b/packages/back-end/src/util/errors.ts
@@ -173,6 +173,16 @@ export class ConcurrentIncrementalRefreshError extends Error {
   }
 }
 
+// Another advance holds a ramp schedule's advance lock. Transient: callers
+// either retry briefly (user-initiated actions) or defer to the scheduler.
+export class RampAdvanceLockBusyError extends Error {
+  status = 409;
+  constructor(message: string) {
+    super(message);
+    this.name = "RampAdvanceLockBusyError";
+  }
+}
+
 export class ExperimentIncrementalPipelineRequiresFullRefreshError extends Error {
   readonly status = 409;
   readonly code = "requires_full_refresh";

--- a/packages/back-end/test/services/rampSchedule.test.ts
+++ b/packages/back-end/test/services/rampSchedule.test.ts
@@ -17,6 +17,7 @@
 
 import type {
   RampScheduleInterface,
+  RampStepAction,
   SafeRolloutInterface,
 } from "shared/validators";
 import type { FeatureRule } from "shared/types/feature";
@@ -26,6 +27,11 @@ import {
 } from "shared/src/validators/ramp-schedule";
 import {
   computeNextStepAt,
+  computeAutoAdvanceTarget,
+  stepIsCollapsible,
+  withRampScheduleAdvanceLock,
+  withRampScheduleAdvanceLockRetry,
+  runLockedRampScheduleAction,
   computePhaseStartAfterApproval,
   applyPatchToRule,
   computeEffectivePatch,
@@ -87,6 +93,7 @@ jest.mock("back-end/src/util/secrets", () => ({
 import { getFeature, publishRevision } from "back-end/src/models/FeatureModel";
 import { createRevision } from "back-end/src/models/FeatureRevisionModel";
 import { createEvent } from "back-end/src/models/EventModel";
+import { RampAdvanceLockBusyError } from "back-end/src/util/errors";
 
 const mockGetFeature = getFeature as jest.MockedFunction<typeof getFeature>;
 const mockPublishRevision = publishRevision as jest.MockedFunction<
@@ -230,7 +237,12 @@ function makeContext(scheduleUpdates: Partial<RampScheduleInterface> = {}) {
         canPublishFeature: jest.fn().mockReturnValue(true),
       },
       models: {
-        rampSchedules: { updateById, getById: jest.fn() },
+        rampSchedules: {
+          updateById,
+          getById: jest.fn(),
+          acquireAdvanceLock: jest.fn().mockResolvedValue(true),
+          releaseAdvanceLock: jest.fn().mockResolvedValue(undefined),
+        },
       },
     },
     updateById,
@@ -981,6 +993,392 @@ describe("computeNextStepAt", () => {
     const schedule = makeSchedule({ steps: [] });
     const result = computeNextStepAt(schedule, 0, now);
     expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("computeAutoAdvanceTarget", () => {
+  const phaseStart = new Date("2025-01-01T00:00:00Z");
+  const plainStep = (interval: number) => ({ interval, actions: [] });
+
+  it("does not advance when the next step's timer has not elapsed", () => {
+    const now = new Date("2025-01-01T00:01:00Z"); // 60s in; step 0 fires at 300s
+    const schedule = makeSchedule({
+      currentStepIndex: -1,
+      nextStepAt: new Date("2025-01-01T00:05:00Z"),
+      phaseStartedAt: phaseStart,
+      steps: [plainStep(300), plainStep(300)],
+    });
+    expect(computeAutoAdvanceTarget(schedule, now)).toBe(-1);
+  });
+
+  it("chains through all due purely-time-gated steps to completion", () => {
+    const now = new Date("2025-01-01T01:00:00Z"); // all gates elapsed
+    const schedule = makeSchedule({
+      currentStepIndex: -1,
+      nextStepAt: phaseStart,
+      phaseStartedAt: phaseStart,
+      steps: [plainStep(300), plainStep(300)],
+    });
+    // steps.length signals "advance past the last step to completion"
+    expect(computeAutoAdvanceTarget(schedule, now)).toBe(2);
+  });
+
+  it("stops at (does not skip past) an approval hold", () => {
+    const now = new Date("2025-01-01T01:00:00Z");
+    const schedule = makeSchedule({
+      currentStepIndex: -1,
+      nextStepAt: phaseStart,
+      phaseStartedAt: phaseStart,
+      steps: [
+        plainStep(300),
+        {
+          interval: 600,
+          holdConditions: { requiresApproval: true },
+          actions: [],
+        },
+      ],
+    });
+    expect(computeAutoAdvanceTarget(schedule, now)).toBe(1);
+  });
+
+  it("stops at a monitored step", () => {
+    const now = new Date("2025-01-01T01:00:00Z");
+    const schedule = makeSchedule({
+      currentStepIndex: -1,
+      nextStepAt: phaseStart,
+      phaseStartedAt: phaseStart,
+      steps: [plainStep(300), { interval: 600, monitored: true, actions: [] }],
+    });
+    expect(computeAutoAdvanceTarget(schedule, now)).toBe(1);
+  });
+
+  it("advances only through the steps whose timers have elapsed", () => {
+    // 720s in: steps 0 (300s) and 1 (600s) are due; step 2 (900s) is not.
+    const now = new Date("2025-01-01T00:12:00Z");
+    const schedule = makeSchedule({
+      currentStepIndex: -1,
+      nextStepAt: phaseStart,
+      phaseStartedAt: phaseStart,
+      steps: [plainStep(300), plainStep(300), plainStep(300)],
+    });
+    expect(computeAutoAdvanceTarget(schedule, now)).toBe(2);
+  });
+
+  it("does not advance out of a hold step it is already sitting on", () => {
+    const now = new Date("2025-01-01T01:00:00Z");
+    const schedule = makeSchedule({
+      currentStepIndex: 1,
+      nextStepAt: phaseStart,
+      phaseStartedAt: phaseStart,
+      steps: [
+        plainStep(300),
+        {
+          interval: 600,
+          holdConditions: { requiresApproval: true },
+          actions: [],
+        },
+        plainStep(300),
+      ],
+    });
+    expect(computeAutoAdvanceTarget(schedule, now)).toBe(1);
+  });
+
+  it("stops at (does not fold past) a step with non-idempotent side effects", () => {
+    const now = new Date("2025-01-01T01:00:00Z");
+    // Simulate a hypothetical future per-step side effect (e.g. a webhook
+    // dispatch) via a non-"feature-rule" action so the collapse must land on
+    // the step individually rather than skip its effect.
+    const sideEffectStep = {
+      interval: 600,
+      actions: [
+        {
+          targetType: "webhook",
+          targetId: TARGET_ID,
+          patch: {},
+        } as unknown as RampStepAction,
+      ],
+    };
+    const schedule = makeSchedule({
+      currentStepIndex: -1,
+      nextStepAt: phaseStart,
+      phaseStartedAt: phaseStart,
+      steps: [plainStep(300), sideEffectStep, plainStep(300)],
+    });
+    expect(computeAutoAdvanceTarget(schedule, now)).toBe(1);
+  });
+
+  it("advances OUT of a non-collapsible step it is sitting on (no wedge)", () => {
+    const now = new Date("2025-01-01T01:00:00Z");
+    // The landing already happened for the current step, so its
+    // non-collapsibility must not gate exit — only unvisited steps are
+    // protected from folding.
+    const sideEffectStep = {
+      interval: 600,
+      actions: [
+        {
+          targetType: "webhook",
+          targetId: TARGET_ID,
+          patch: {},
+        } as unknown as RampStepAction,
+      ],
+    };
+    const schedule = makeSchedule({
+      currentStepIndex: 1,
+      nextStepAt: phaseStart, // gate to leave step 1 already elapsed
+      phaseStartedAt: phaseStart,
+      steps: [plainStep(300), sideEffectStep, plainStep(300)],
+    });
+    expect(computeAutoAdvanceTarget(schedule, now)).toBe(3);
+  });
+
+  it("currentStepCleared bypasses the first hop's hold and gate only", () => {
+    const now = new Date("2025-01-01T00:00:30Z"); // step timers NOT elapsed
+    const schedule = makeSchedule({
+      currentStepIndex: 0,
+      nextStepAt: null, // monitored steps have no nextStepAt gate
+      phaseStartedAt: phaseStart,
+      steps: [
+        { interval: 300, monitored: true, actions: [] },
+        plainStep(300),
+        plainStep(300),
+      ],
+    });
+
+    // Without the option, the monitored current step blocks everything.
+    expect(computeAutoAdvanceTarget(schedule, now)).toBe(0);
+    // With it, the evaluator-verified step is cleared, but subsequent steps
+    // still respect their own (unelapsed) time gates.
+    expect(
+      computeAutoAdvanceTarget(schedule, now, { currentStepCleared: true }),
+    ).toBe(1);
+  });
+
+  it("currentStepCleared folds the due backlog behind the cleared step", () => {
+    const now = new Date("2025-01-01T01:00:00Z"); // all timers elapsed
+    const schedule = makeSchedule({
+      currentStepIndex: 0,
+      nextStepAt: null,
+      phaseStartedAt: phaseStart,
+      steps: [
+        { interval: 300, monitored: true, actions: [] },
+        plainStep(300),
+        plainStep(300),
+      ],
+    });
+    expect(
+      computeAutoAdvanceTarget(schedule, now, { currentStepCleared: true }),
+    ).toBe(3);
+  });
+});
+
+describe("advanceStep target clamp", () => {
+  it("refuses a non-forward target from a stale caller instead of rewinding coverage", async () => {
+    const schedule = makeSchedule({ currentStepIndex: 2, status: "running" });
+    const updateById = jest.fn();
+    const ctx = {
+      org: { id: ORG_ID, settings: {} },
+      auditUser: { type: "system" },
+      environments: [],
+      permissions: {},
+      models: { rampSchedules: { updateById, getById: jest.fn() } },
+    };
+
+    const result = await advanceStep(ctx as never, schedule, 1);
+
+    expect(result).toBe(schedule);
+    expect(updateById).not.toHaveBeenCalled();
+    expect(mockPublishRevision).not.toHaveBeenCalled();
+  });
+});
+
+describe("withRampScheduleAdvanceLock", () => {
+  const makeLockCtx = (acquired: boolean) => {
+    const acquireAdvanceLock = jest.fn().mockResolvedValue(acquired);
+    const releaseAdvanceLock = jest.fn().mockResolvedValue(undefined);
+    const ctx = {
+      models: { rampSchedules: { acquireAdvanceLock, releaseAdvanceLock } },
+    };
+    return { ctx, acquireAdvanceLock, releaseAdvanceLock };
+  };
+
+  it("runs fn and releases the lock when acquired", async () => {
+    const { ctx, releaseAdvanceLock } = makeLockCtx(true);
+    const fn = jest.fn().mockResolvedValue("done");
+
+    const result = await withRampScheduleAdvanceLock(ctx as never, "rs_1", fn);
+
+    expect(result).toBe("done");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(releaseAdvanceLock).toHaveBeenCalledWith("rs_1", expect.any(String));
+  });
+
+  it("throws and does not run fn when the lock is held by another advance", async () => {
+    const { ctx, releaseAdvanceLock } = makeLockCtx(false);
+    const fn = jest.fn();
+
+    await expect(
+      withRampScheduleAdvanceLock(ctx as never, "rs_1", fn),
+    ).rejects.toThrow();
+    expect(fn).not.toHaveBeenCalled();
+    expect(releaseAdvanceLock).not.toHaveBeenCalled();
+  });
+
+  it("releases the lock even if fn throws", async () => {
+    const { ctx, releaseAdvanceLock } = makeLockCtx(true);
+    const fn = jest.fn().mockRejectedValue(new Error("boom"));
+
+    await expect(
+      withRampScheduleAdvanceLock(ctx as never, "rs_1", fn),
+    ).rejects.toThrow("boom");
+    expect(releaseAdvanceLock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws RampAdvanceLockBusyError (not a generic error) on contention", async () => {
+    const { ctx } = makeLockCtx(false);
+    await expect(
+      withRampScheduleAdvanceLock(ctx as never, "rs_1", jest.fn()),
+    ).rejects.toBeInstanceOf(RampAdvanceLockBusyError);
+  });
+
+  it("does not let a failing release mask the error fn threw", async () => {
+    const { ctx, releaseAdvanceLock } = makeLockCtx(true);
+    releaseAdvanceLock.mockRejectedValue(new Error("mongo down"));
+    const fn = jest.fn().mockRejectedValue(new Error("real failure"));
+
+    await expect(
+      withRampScheduleAdvanceLock(ctx as never, "rs_1", fn),
+    ).rejects.toThrow("real failure");
+  });
+});
+
+describe("withRampScheduleAdvanceLockRetry", () => {
+  it("retries contention and succeeds once the lock frees up", async () => {
+    const acquireAdvanceLock = jest
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const releaseAdvanceLock = jest.fn().mockResolvedValue(undefined);
+    const ctx = {
+      models: { rampSchedules: { acquireAdvanceLock, releaseAdvanceLock } },
+    };
+    const fn = jest.fn().mockResolvedValue("done");
+
+    const result = await withRampScheduleAdvanceLockRetry(
+      ctx as never,
+      "rs_1",
+      fn,
+    );
+    expect(result).toBe("done");
+    expect(acquireAdvanceLock).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces the busy error after exhausting attempts", async () => {
+    const acquireAdvanceLock = jest.fn().mockResolvedValue(false);
+    const ctx = {
+      models: {
+        rampSchedules: {
+          acquireAdvanceLock,
+          releaseAdvanceLock: jest.fn(),
+        },
+      },
+    };
+
+    await expect(
+      withRampScheduleAdvanceLockRetry(ctx as never, "rs_1", jest.fn(), 2),
+    ).rejects.toBeInstanceOf(RampAdvanceLockBusyError);
+    expect(acquireAdvanceLock).toHaveBeenCalledTimes(2);
+  }, 15_000);
+
+  it("does not retry non-contention errors from fn", async () => {
+    const acquireAdvanceLock = jest.fn().mockResolvedValue(true);
+    const ctx = {
+      models: {
+        rampSchedules: {
+          acquireAdvanceLock,
+          releaseAdvanceLock: jest.fn().mockResolvedValue(undefined),
+        },
+      },
+    };
+    const fn = jest.fn().mockRejectedValue(new Error("boom"));
+
+    await expect(
+      withRampScheduleAdvanceLockRetry(ctx as never, "rs_1", fn),
+    ).rejects.toThrow("boom");
+    expect(acquireAdvanceLock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("runLockedRampScheduleAction", () => {
+  it("passes the fresh in-lock read to fn, not the caller's snapshot", async () => {
+    const freshDoc = { id: "rs_1", status: "completed" };
+    const ctx = {
+      models: {
+        rampSchedules: {
+          acquireAdvanceLock: jest.fn().mockResolvedValue(true),
+          releaseAdvanceLock: jest.fn().mockResolvedValue(undefined),
+          getById: jest.fn().mockResolvedValue(freshDoc),
+        },
+      },
+    };
+    const fn = jest.fn().mockResolvedValue("ok");
+
+    await runLockedRampScheduleAction(ctx as never, "rs_1", fn);
+    expect(fn).toHaveBeenCalledWith(freshDoc);
+  });
+
+  it("throws when the schedule was deleted while waiting for the lock", async () => {
+    const ctx = {
+      models: {
+        rampSchedules: {
+          acquireAdvanceLock: jest.fn().mockResolvedValue(true),
+          releaseAdvanceLock: jest.fn().mockResolvedValue(undefined),
+          getById: jest.fn().mockResolvedValue(null),
+        },
+      },
+    };
+
+    await expect(
+      runLockedRampScheduleAction(ctx as never, "rs_1", jest.fn()),
+    ).rejects.toThrow("no longer exists");
+  });
+});
+
+describe("stepIsCollapsible", () => {
+  it("is true for a step whose actions are all feature-rule patches", () => {
+    expect(
+      stepIsCollapsible({
+        interval: 300,
+        actions: [
+          {
+            targetType: "feature-rule",
+            targetId: TARGET_ID,
+            patch: { ruleId: RULE_ID, coverage: 0.5 },
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("is true for a step with no actions", () => {
+    expect(stepIsCollapsible({ interval: 300, actions: [] })).toBe(true);
+  });
+
+  it("is false when a step carries a non-feature-rule (side-effecting) action", () => {
+    expect(
+      stepIsCollapsible({
+        interval: 300,
+        actions: [
+          {
+            targetType: "webhook",
+            targetId: TARGET_ID,
+            patch: {},
+          } as unknown as RampStepAction,
+        ],
+      }),
+    ).toBe(false);
   });
 });
 
@@ -1896,7 +2294,12 @@ describe("resumeSchedule", () => {
         canPublishFeature: jest.fn().mockReturnValue(true),
       },
       models: {
-        rampSchedules: { updateById, getById },
+        rampSchedules: {
+          updateById,
+          getById,
+          acquireAdvanceLock: jest.fn().mockResolvedValue(true),
+          releaseAdvanceLock: jest.fn().mockResolvedValue(undefined),
+        },
       },
     };
 
@@ -2267,13 +2670,14 @@ describe("advanceUntilBlocked", () => {
     const schedule = makeSchedule({
       currentStepIndex: -1,
       nextStepAt: past,
+      // Overdue backlog: every time gate has elapsed, so the catch-up would
+      // reach the monitored step. It must still stop there (monitored steps
+      // need the evaluator's snapshot data before advancing).
+      phaseStartedAt: new Date(Date.now() - 10_000_000),
       status: "running",
       steps,
     });
 
-    // After advancing to step 0, return a schedule where step 1 is already due
-    // (simulates a late agenda tick). The loop must stop at step 1 because it's
-    // monitored, even though its timer has elapsed.
     let callCount = 0;
     const updateById = jest
       .fn()
@@ -2303,9 +2707,10 @@ describe("advanceUntilBlocked", () => {
 
     await advanceUntilBlocked(ctx as never, schedule, new Date());
 
-    // Advances step 0 (not monitored, continues) then step 1 (monitored, stops).
-    expect(callCount).toBe(2);
-    const [, lastUpdates] = updateById.mock.calls[1];
+    // Collapses steps 0→1 into one jump, landing on the monitored step 1 and
+    // stopping there (a single publish rather than one per step).
+    expect(callCount).toBe(1);
+    const [, lastUpdates] = updateById.mock.calls[0];
     expect(lastUpdates.currentStepIndex).toBe(1);
   });
 
@@ -2337,6 +2742,8 @@ describe("advanceUntilBlocked", () => {
     const schedule = makeSchedule({
       currentStepIndex: -1,
       nextStepAt: past,
+      // Overdue backlog so the catch-up reaches the minSampleSize step.
+      phaseStartedAt: new Date(Date.now() - 10_000_000),
       status: "running",
       steps,
     });
@@ -2369,9 +2776,10 @@ describe("advanceUntilBlocked", () => {
 
     await advanceUntilBlocked(ctx as never, schedule, new Date());
 
-    // Advances step 0 (no minSampleSize, continues) then step 1 (has minSampleSize, stops).
-    expect(callCount).toBe(2);
-    const [, lastUpdates] = updateById.mock.calls[1];
+    // Collapses steps 0→1 into one jump, landing on the minSampleSize step 1
+    // and stopping there (needs the evaluator + snapshot before advancing).
+    expect(callCount).toBe(1);
+    const [, lastUpdates] = updateById.mock.calls[0];
     expect(lastUpdates.currentStepIndex).toBe(1);
   });
 
@@ -2410,9 +2818,13 @@ describe("advanceUntilBlocked", () => {
         ],
       },
     ];
+    // phaseStartedAt is set so steps 0 and 1's time gates have elapsed but step
+    // 2's has not: the catch-up should advance through 0→1→2 and stop on step 2
+    // (still inside its interval), without completing.
     const schedule = makeSchedule({
       currentStepIndex: -1,
       nextStepAt: past,
+      phaseStartedAt: new Date(Date.now() - 700_000),
       status: "running",
       steps,
     });
@@ -2425,7 +2837,6 @@ describe("advanceUntilBlocked", () => {
           callCount++;
           const newStepIndex =
             updates.currentStepIndex ?? schedule.currentStepIndex;
-          // Steps 0 and 1 are due; step 2 lands in the future.
           const nextStepAt = newStepIndex < 2 ? past : future;
           return {
             ...schedule,
@@ -2447,10 +2858,9 @@ describe("advanceUntilBlocked", () => {
 
     await advanceUntilBlocked(ctx as never, schedule, new Date());
 
-    // Chains through steps 0, 1, and 2 (all due, all purely time-gated); stops
-    // when the loop exhausts the step array after landing on step 2.
-    expect(callCount).toBe(3);
-    const lastCall = updateById.mock.calls[callCount - 1];
+    // Collapses the 0→1→2 backlog into a single jump/publish landing on step 2.
+    expect(callCount).toBe(1);
+    const lastCall = updateById.mock.calls[0];
     expect(lastCall[1].currentStepIndex).toBe(2);
   });
 
@@ -2634,6 +3044,42 @@ describe("advanceUntilBlocked", () => {
     const rules: FeatureRule[] = forceResult.rules ?? [];
     const patched = rules.find((r) => r.id === RULE_ID);
     expect(patched?.enabled).toBe(true);
+  });
+
+  // ------------------------------------------------------------------------
+  // Collapse straight past the end (never-started backlog + future cutoff)
+  // ------------------------------------------------------------------------
+
+  it("injects enabled:true when a never-started backlog collapses past the end (future cutoff)", async () => {
+    // Regression: the -1 → past-end jump routes through
+    // applyEndActionsAndAwaitCutoff, which must fold enabled:true like every
+    // other landing — otherwise the rule sits at 100% coverage but disabled
+    // and never serves traffic.
+    const past = new Date(Date.now() - 10_000_000);
+    const schedule = makeSchedule({
+      currentStepIndex: -1,
+      status: "running",
+      nextStepAt: new Date(Date.now() - 1000),
+      phaseStartedAt: past, // every step's time gate elapsed
+      cutoffDate: new Date(Date.now() + 24 * 60 * 60_000),
+    });
+    const { ctx, updateById } = makeContext();
+
+    await advanceUntilBlocked(ctx as never, schedule, new Date());
+
+    expect(mockPublishRevision).toHaveBeenCalledTimes(1);
+    const { result: forceResult } = mockPublishRevision.mock.calls[0][0];
+    const rules: FeatureRule[] = forceResult.rules ?? [];
+    const patched = rules.find((r) => r.id === RULE_ID);
+    expect(patched?.enabled).toBe(true);
+    expect((patched as { coverage?: number })?.coverage).toBe(1.0);
+
+    // Lands past the end, awaiting cutoff, recorded as a jump (not a
+    // single-step advance).
+    const [, updates] = updateById.mock.calls[0];
+    expect(updates.currentStepIndex).toBe(schedule.steps.length);
+    const lastEvent = updates.eventHistory?.[updates.eventHistory.length - 1];
+    expect(lastEvent?.type).toBe("step-jumped");
   });
 });
 
@@ -2932,7 +3378,14 @@ describe("startReadyScheduleNow", () => {
         canPublishFeature: jest.fn().mockReturnValue(true),
       },
       models: {
-        rampSchedules: { updateById, getById, deleteById },
+        rampSchedules: {
+          updateById,
+          getById,
+          deleteById,
+          acquireAdvanceLock: jest.fn().mockResolvedValue(true),
+          releaseAdvanceLock: jest.fn().mockResolvedValue(undefined),
+          touchAdvanceLockHeartbeat: jest.fn().mockResolvedValue(undefined),
+        },
         safeRollout: {
           getById: safeRolloutGetById,
           create: safeRolloutCreate,
@@ -3208,12 +3661,20 @@ describe("startReadyScheduleNow", () => {
       models: {
         rampSchedules: {
           updateById,
-          getById: jest.fn().mockImplementation(async () => ({
-            ...base,
-            status: "running",
-            nextStepAt: new Date(Date.now() + 3_600_000),
-          })),
+          // First read is the lock wrapper's freshness check (must be ready);
+          // later reads reflect the post-start running state.
+          getById: jest
+            .fn()
+            .mockImplementationOnce(async () => base)
+            .mockImplementation(async () => ({
+              ...base,
+              status: "running",
+              nextStepAt: new Date(Date.now() + 3_600_000),
+            })),
           deleteById: jest.fn().mockResolvedValue(undefined),
+          acquireAdvanceLock: jest.fn().mockResolvedValue(true),
+          releaseAdvanceLock: jest.fn().mockResolvedValue(undefined),
+          touchAdvanceLockHeartbeat: jest.fn().mockResolvedValue(undefined),
         },
         safeRollout: {
           getById: jest.fn().mockResolvedValue(null),

--- a/packages/back-end/test/services/rampSchedule.test.ts
+++ b/packages/back-end/test/services/rampSchedule.test.ts
@@ -1173,7 +1173,40 @@ describe("computeAutoAdvanceTarget", () => {
   });
 });
 
+describe("advanceStep past-end with a lapsed cutoff", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetFeature.mockResolvedValue(makeFeature() as never);
+    mockCreateRevision.mockResolvedValue(makeRevision() as never);
+    mockPublishRevision.mockResolvedValue(undefined);
+  });
+
+  it("completes WITH disableActiveTargets so the rule doesn't stay enabled past its end date", async () => {
+    // Regression: a catch-up fold can land past the end after the cutoff
+    // lapsed (hook race, or the cutoff lapsing during a slow evaluate); the
+    // completion must honor the cutoff's disable semantics.
+    const schedule = makeSchedule({
+      currentStepIndex: 2, // last step done
+      status: "running",
+      cutoffDate: new Date(Date.now() - 60_000), // lapsed
+    });
+    const { ctx } = makeContext();
+
+    await advanceStep(ctx as never, schedule, schedule.steps.length);
+
+    expect(mockPublishRevision).toHaveBeenCalledTimes(1);
+    const { result: forceResult } = mockPublishRevision.mock.calls[0][0];
+    const rules: FeatureRule[] = forceResult.rules ?? [];
+    const patched = rules.find((r) => r.id === RULE_ID);
+    expect(patched?.enabled).toBe(false);
+  });
+});
+
 describe("advanceStep target clamp", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("refuses a non-forward target from a stale caller instead of rewinding coverage", async () => {
     const schedule = makeSchedule({ currentStepIndex: 2, status: "running" });
     const updateById = jest.fn();
@@ -1197,10 +1230,14 @@ describe("withRampScheduleAdvanceLock", () => {
   const makeLockCtx = (acquired: boolean) => {
     const acquireAdvanceLock = jest.fn().mockResolvedValue(acquired);
     const releaseAdvanceLock = jest.fn().mockResolvedValue(undefined);
+    // The doc exists — a failed acquire is diagnosed as contention, not 404.
+    const getById = jest.fn().mockResolvedValue({ id: "rs_1" });
     const ctx = {
-      models: { rampSchedules: { acquireAdvanceLock, releaseAdvanceLock } },
+      models: {
+        rampSchedules: { acquireAdvanceLock, releaseAdvanceLock, getById },
+      },
     };
-    return { ctx, acquireAdvanceLock, releaseAdvanceLock };
+    return { ctx, acquireAdvanceLock, releaseAdvanceLock, getById };
   };
 
   it("runs fn and releases the lock when acquired", async () => {
@@ -1254,14 +1291,17 @@ describe("withRampScheduleAdvanceLock", () => {
 });
 
 describe("withRampScheduleAdvanceLockRetry", () => {
-  it("retries contention and succeeds once the lock frees up", async () => {
+  it("retries contention and succeeds once the lock frees up (fn runs once)", async () => {
     const acquireAdvanceLock = jest
       .fn()
       .mockResolvedValueOnce(false)
       .mockResolvedValueOnce(true);
     const releaseAdvanceLock = jest.fn().mockResolvedValue(undefined);
+    const getById = jest.fn().mockResolvedValue({ id: "rs_1" });
     const ctx = {
-      models: { rampSchedules: { acquireAdvanceLock, releaseAdvanceLock } },
+      models: {
+        rampSchedules: { acquireAdvanceLock, releaseAdvanceLock, getById },
+      },
     };
     const fn = jest.fn().mockResolvedValue("done");
 
@@ -1282,6 +1322,7 @@ describe("withRampScheduleAdvanceLockRetry", () => {
         rampSchedules: {
           acquireAdvanceLock,
           releaseAdvanceLock: jest.fn(),
+          getById: jest.fn().mockResolvedValue({ id: "rs_1" }),
         },
       },
     };
@@ -1291,6 +1332,25 @@ describe("withRampScheduleAdvanceLockRetry", () => {
     ).rejects.toBeInstanceOf(RampAdvanceLockBusyError);
     expect(acquireAdvanceLock).toHaveBeenCalledTimes(2);
   }, 15_000);
+
+  it("fails fast with 404 semantics when the schedule was deleted", async () => {
+    const acquireAdvanceLock = jest.fn().mockResolvedValue(false);
+    const ctx = {
+      models: {
+        rampSchedules: {
+          acquireAdvanceLock,
+          releaseAdvanceLock: jest.fn(),
+          getById: jest.fn().mockResolvedValue(null),
+        },
+      },
+    };
+
+    await expect(
+      withRampScheduleAdvanceLockRetry(ctx as never, "rs_1", jest.fn()),
+    ).rejects.toThrow("no longer exists");
+    // No retry ladder for a missing doc.
+    expect(acquireAdvanceLock).toHaveBeenCalledTimes(1);
+  });
 
   it("does not retry non-contention errors from fn", async () => {
     const acquireAdvanceLock = jest.fn().mockResolvedValue(true);
@@ -1326,7 +1386,7 @@ describe("runLockedRampScheduleAction", () => {
     const fn = jest.fn().mockResolvedValue("ok");
 
     await runLockedRampScheduleAction(ctx as never, "rs_1", fn);
-    expect(fn).toHaveBeenCalledWith(freshDoc);
+    expect(fn).toHaveBeenCalledWith(freshDoc, expect.any(Function));
   });
 
   it("throws when the schedule was deleted while waiting for the lock", async () => {

--- a/packages/back-end/test/services/rampSchedule.test.ts
+++ b/packages/back-end/test/services/rampSchedule.test.ts
@@ -3479,19 +3479,15 @@ describe("startReadyScheduleNow", () => {
   it("sets nextStepAt≈now for multi-step schedules", async () => {
     // Multi-step schedule with a far-future cutoffDate to keep advanceUntilBlocked
     // from completing. nextStepAt in the initial update must be ≈ now so step 0
-    // is immediately eligible.
-    const { ctx, updateById } = makeStartNowCtx();
-    const multiStepSchedule = makeSchedule({
-      status: "ready",
-      currentStepIndex: -1,
+    // is immediately eligible. The steps live on the stored doc (the in-lock
+    // fresh read is authoritative, not the caller's snapshot).
+    const { ctx, updateById, schedule } = makeStartNowCtx({
+      steps: makeSchedule({}).steps,
       nextStepAt: null,
-      startedAt: null,
-      phaseStartedAt: null,
-      cutoffDate: new Date(Date.now() + 24 * 60 * 60_000),
     });
 
     const before = Date.now();
-    await startReadyScheduleNow(ctx as never, multiStepSchedule);
+    await startReadyScheduleNow(ctx as never, schedule);
     const after = Date.now();
 
     // The first updateById call is the transition; subsequent calls may come

--- a/packages/back-end/test/services/rampSchedule.test.ts
+++ b/packages/back-end/test/services/rampSchedule.test.ts
@@ -3444,7 +3444,7 @@ describe("startReadyScheduleNow", () => {
           deleteById,
           acquireAdvanceLock: jest.fn().mockResolvedValue(true),
           releaseAdvanceLock: jest.fn().mockResolvedValue(undefined),
-          touchAdvanceLockHeartbeat: jest.fn().mockResolvedValue(undefined),
+          touchAdvanceLockHeartbeat: jest.fn().mockResolvedValue(true),
         },
         safeRollout: {
           getById: safeRolloutGetById,
@@ -3730,7 +3730,7 @@ describe("startReadyScheduleNow", () => {
           deleteById: jest.fn().mockResolvedValue(undefined),
           acquireAdvanceLock: jest.fn().mockResolvedValue(true),
           releaseAdvanceLock: jest.fn().mockResolvedValue(undefined),
-          touchAdvanceLockHeartbeat: jest.fn().mockResolvedValue(undefined),
+          touchAdvanceLockHeartbeat: jest.fn().mockResolvedValue(true),
         },
         safeRollout: {
           getById: jest.fn().mockResolvedValue(null),

--- a/packages/back-end/test/services/rampScheduleEvaluator.test.ts
+++ b/packages/back-end/test/services/rampScheduleEvaluator.test.ts
@@ -136,6 +136,9 @@ function makeContext({
               ...updates,
             }),
           ),
+        acquireAdvanceLock: jest.fn().mockResolvedValue(true),
+        releaseAdvanceLock: jest.fn().mockResolvedValue(undefined),
+        touchAdvanceLockHeartbeat: jest.fn().mockResolvedValue(undefined),
       },
       safeRollout: {
         getById: jest.fn().mockResolvedValue(safeRollout),

--- a/packages/back-end/test/services/rampScheduleEvaluator.test.ts
+++ b/packages/back-end/test/services/rampScheduleEvaluator.test.ts
@@ -138,7 +138,7 @@ function makeContext({
           ),
         acquireAdvanceLock: jest.fn().mockResolvedValue(true),
         releaseAdvanceLock: jest.fn().mockResolvedValue(undefined),
-        touchAdvanceLockHeartbeat: jest.fn().mockResolvedValue(undefined),
+        touchAdvanceLockHeartbeat: jest.fn().mockResolvedValue(true),
       },
       safeRollout: {
         getById: jest.fn().mockResolvedValue(safeRollout),

--- a/packages/shared/src/validators/events.ts
+++ b/packages/shared/src/validators/events.ts
@@ -156,7 +156,7 @@ export const notificationEvents = {
     "rampSchedule.actions.step.advanced": {
       schema: rampScheduleStepAdvancedPayload,
       description:
-        "Triggered when a feature ramp schedule advances to the next step",
+        "Triggered when a feature ramp schedule advances. Overdue steps are caught up in a single advance: when `currentStepIndex - previousStepIndex > 1`, the intermediate steps were folded into this one event (one revision publish) rather than fired individually.",
     },
     "rampSchedule.actions.step.approvalRequired": {
       schema: rampScheduleStepApprovalRequiredPayload,

--- a/packages/shared/src/validators/ramp-schedule-notifications.ts
+++ b/packages/shared/src/validators/ramp-schedule-notifications.ts
@@ -15,7 +15,13 @@ export type RampScheduleStartedPayload = z.infer<
 >;
 
 export const rampScheduleStepAdvancedPayload =
-  rampScheduleBaseNotificationPayload.strict();
+  rampScheduleBaseNotificationPayload
+    .extend({
+      // Where the schedule was before this advance. A gap > 1 means a catch-up
+      // jump collapsed multiple overdue steps into this single event.
+      previousStepIndex: z.number().int().optional(),
+    })
+    .strict();
 export type RampScheduleStepAdvancedPayload = z.infer<
   typeof rampScheduleStepAdvancedPayload
 >;

--- a/packages/shared/src/validators/ramp-schedule-notifications.ts
+++ b/packages/shared/src/validators/ramp-schedule-notifications.ts
@@ -34,8 +34,13 @@ export type RampScheduleStepApprovalRequiredPayload = z.infer<
   typeof rampScheduleStepApprovalRequiredPayload
 >;
 
-export const rampScheduleCompletedPayload =
-  rampScheduleBaseNotificationPayload.strict();
+export const rampScheduleCompletedPayload = rampScheduleBaseNotificationPayload
+  .extend({
+    // Where the schedule was before completion; a gap > 1 means overdue steps
+    // were folded into the completing advance.
+    previousStepIndex: z.number().int().optional(),
+  })
+  .strict();
 export type RampScheduleCompletedPayload = z.infer<
   typeof rampScheduleCompletedPayload
 >;

--- a/packages/shared/src/validators/ramp-schedule.ts
+++ b/packages/shared/src/validators/ramp-schedule.ts
@@ -235,6 +235,13 @@ export const rampScheduleValidator = baseSchema
     lastRollbackAt: z.date().nullish(),
     lastRollbackReason: z.string().nullish(),
 
+    // Per-schedule advance lock. Serializes progression across the resume HTTP
+    // path and the scheduler job so they can't concurrently replay/publish and
+    // clobber each other's coverage. `advanceLockAt` powers a stale fallback so
+    // a crashed holder can't wedge the schedule forever.
+    advanceLockToken: z.string().nullish(),
+    advanceLockAt: z.date().nullish(),
+
     // Append-only playhead history.
     eventHistory: z.array(rampEvent).optional(),
   })


### PR DESCRIPTION
## What this does

Fixes a production incident with feature ramp schedules (staged rollouts). Resuming a rollout with a large backlog of overdue steps replayed every step at once inside one request, pinning the server and taking pods down. A second bug let two processes advance the same rollout at once, leaving the UI and the served coverage disagreeing.

## Changes

**Catch up in one jump instead of step-by-step**
An overdue rollout now advances straight to where it should be in a single publish instead of replaying each step. Same end state, ~60× cheaper — the behavior that crashed pods can't happen anymore.

**One advance at a time per rollout**
A per-schedule lock ensures only one process advances a given rollout at once. Every path that changes a rollout — resume, advance, approve, jump, edit, delete, add/remove targets, monitoring toggles, the scheduler, and the publish hooks — goes through it and re-reads fresh state, so nothing collides mid-flight.

**Correctness hardening**
- Rollouts no longer finish with the rule left enabled past its end date, or disabled when it should be live.
- An advance can't slip past a freshly-added approval gate, and approvals can't land on the wrong step.
- "Start now," edits, and approvals are never silently lost to a timing collision — they apply or return a clear conflict error.
- The lock recovers correctly from crashes, slow operations, and network blips.

**Observability**
- Webhooks and the audit trail now correctly show when a catch-up folded multiple steps together (via `previousStepIndex`), so external consumers stay in sync.
- Docs updated to describe the catch-up behavior.

## Testing

Full back-end suite green (163 suites / 5,051 tests), including new regression tests for the catch-up collapse, the lock protocol, and the cutoff/approval edge cases.