### PR TITLE
fix: truncate long breadcrumb title so it does not overlap the top nav

### DIFF
--- a/packages/front-end/ui/Breadcrumbs.module.scss
+++ b/packages/front-end/ui/Breadcrumbs.module.scss
@@ -10,6 +10,16 @@
   }
 }
 
+// The last breadcrumb item is the current page title. Long titles are
+// truncated with an ellipsis so they stay on one line and don't overflow
+// the fixed top bar. min-width: 0 lets the item shrink inside the flex row.
+.current {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 // Separator icons are hidden on small screens (even for the last item's
 // separator, since its preceding ancestors are hidden and a floating ">"
 // would appear before the current page name)

--- a/packages/front-end/ui/Breadcrumbs.tsx
+++ b/packages/front-end/ui/Breadcrumbs.tsx
@@ -29,7 +29,7 @@ export default function Breadcrumbs({ items }: { items: BreadcrumbItem[] }) {
               )}
               <span
                 title={item.display}
-                className={!isLast ? styles.ancestor : undefined}
+                className={!isLast ? styles.ancestor : styles.current}
               >
                 {item.href ? (
                   <Link


### PR DESCRIPTION
### Features and Changes

Long page titles in the top nav breadcrumb overflowed the fixed bar and overlapped the heading. The current-page breadcrumb now truncates with an ellipsis and stays on one line.

The truncation was previously attempted on the outer wrapper, but `text-overflow: ellipsis` cannot apply through the nested flex/span structure, so titles got hard-clipped mid-word. Moving the truncation onto the current breadcrumb item itself (whose children are inline) plus `min-width: 0` lets it shrink inside the flex row and render a proper ellipsis.

- Closes #6284

### Dependencies

None

### Testing

1. Open any report or experiment page with a very long title.
2. Before: the title overflows the top bar and overlaps the H1 (or is hard-clipped mid-word).
3. After: the title stays on a single line inside the bar and ends with an ellipsis, with the full text available on hover via the existing `title` attribute.

### Screenshots

Behavior verified by rendering the `TopNav` / `Breadcrumbs` markup directly: a long title truncates to one line (`Experiments > My name is Natasha and I am writing a very lon…`) and sits inside the 56px bar with no overlap. Happy to add a screenshot from a live instance if useful.
