### PR TITLE
Compute etag for organization/definitions

### DIFF
--- a/packages/back-end/src/models/TagModel.ts
+++ b/packages/back-end/src/models/TagModel.ts
@@ -8,6 +8,12 @@ const tagSchema = new mongoose.Schema({
   },
   tags: [String],
   settings: {},
+  // Must be set (via $set) on every write below. Read by
+  // `getDefinitionsVersion` (back-end/src/util/definitionsVersion.ts) to
+  // detect tag changes cheaply — if a new write path is added here without
+  // updating this field, that change won't invalidate the cached
+  // /organization/definitions response.
+  dateUpdated: Date,
 });
 
 type TagDocument = mongoose.Document & TagDBInterface;
@@ -52,6 +58,9 @@ export async function addTags(organization: string, tags: string[]) {
       $addToSet: {
         tags: { $each: tags },
       },
+      $set: {
+        dateUpdated: new Date(),
+      },
     },
     {
       upsert: true,
@@ -90,6 +99,7 @@ export async function addTag(
         // Need to set the entire settings object, not just settings.{tag},
         // since tags can contains dots in the name
         settings,
+        dateUpdated: new Date(),
       },
     },
     {
@@ -105,6 +115,7 @@ export async function removeTag(organization: string, tag: string) {
     },
     {
       $pull: { tags: tag },
+      $set: { dateUpdated: new Date() },
     },
   );
 }

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -158,6 +158,7 @@ import {
   getInstallation,
   setInstallationName,
 } from "back-end/src/models/InstallationModel";
+import { getDefinitionsVersion } from "back-end/src/util/definitionsVersion";
 
 export async function getDefinitions(req: AuthRequest, res: Response) {
   const context = getContextFromReq(req);
@@ -166,6 +167,18 @@ export async function getDefinitions(req: AuthRequest, res: Response) {
     throw new Error("Must be part of an organization");
   }
 
+  const version = await getDefinitionsVersion(orgId);
+  const ifNoneMatch = req.headers["if-none-match"];
+  if (typeof ifNoneMatch === "string" && ifNoneMatch === version) {
+    res.set("ETag", version);
+    return res.status(304).end();
+  }
+  res.set("ETag", version);
+
+  // If you add/remove/rename a source below, update the mirrored collection
+  // list in `getDefinitionsVersion` (back-end/src/util/definitionsVersion.ts)
+  // too — otherwise its ETag won't reflect changes to the new source and
+  // clients can get served a stale 304.
   const [
     metrics,
     datasources,

--- a/packages/back-end/src/util/definitionsVersion.ts
+++ b/packages/back-end/src/util/definitionsVersion.ts
@@ -1,0 +1,60 @@
+import { getCollection } from "back-end/src/util/mongo.util";
+
+// This list must mirror the sources read by `getDefinitions` in
+// back-end/src/routers/organizations/organizations.controller.ts. If that
+// handler starts (or stops) reading from a collection, add/remove it here
+// too — otherwise the ETag won't change when that source does, and clients
+// can get served a stale 304 for data they don't have yet.
+//
+// Every collection here must set `dateUpdated` on every write (create,
+// update, and any array/subfield mutation), so the most recent one can be
+// found via an indexed query on `organization` without reading/transforming
+// full documents. `tags` is a single upserted doc per org (see TagModel.ts)
+// rather than one doc per tag — a document count would never change after
+// the first write, so it relies on `dateUpdated` too, same as the rest.
+const DATE_UPDATED_COLLECTIONS = [
+  "metrics",
+  "datasources",
+  "dimensions",
+  "segments",
+  "metricgroups",
+  "tags",
+  "savedgroups",
+  "constants",
+  "customfields",
+  "projects",
+  "facttables",
+  "factmetrics",
+  "decisioncriteria",
+  "webhooksecrets",
+] as const;
+
+async function getMaxDateUpdated(
+  collectionName: string,
+  organization: string,
+): Promise<number> {
+  const doc = await getCollection<{ organization: string; dateUpdated?: Date }>(
+    collectionName,
+  ).findOne(
+    { organization },
+    { projection: { dateUpdated: 1, _id: 0 }, sort: { dateUpdated: -1 } },
+  );
+  return doc?.dateUpdated ? new Date(doc.dateUpdated).getTime() : 0;
+}
+
+/**
+ * Cheap, indexed fingerprint of everything the `/organization/definitions`
+ * endpoint reads. Lets the endpoint short-circuit its expensive reads,
+ * transforms, and serialization when the client's cached copy is still current.
+ */
+export async function getDefinitionsVersion(
+  organization: string,
+): Promise<string> {
+  const parts = await Promise.all(
+    DATE_UPDATED_COLLECTIONS.map((name) =>
+      getMaxDateUpdated(name, organization),
+    ),
+  );
+
+  return `"${parts.join("-")}"`;
+}

--- a/packages/shared/types/tag.d.ts
+++ b/packages/shared/types/tag.d.ts
@@ -8,6 +8,7 @@ export interface TagDBInterface {
   organization: string;
   tags: string[];
   settings: { [key: string]: TagSettings };
+  dateUpdated?: Date;
 }
 
 export interface TagSettings {


### PR DESCRIPTION
### Features and Changes
We have a [94% etag](https://us5.datadoghq.com/apm/resource/prod-api/express.request/dee10d8ba694afdf?dependencyMap.showNetworkMetrics=false&deployments=qson%3A%28data%3A%28hits%3A%28selected%3Aversion_count%2CgroupBy%3A%5Bversion%5D%29%2Cerrors%3A%28selected%3Aversion_count%2CgroupBy%3A%5Bversion%5D%29%2Clatency%3A%28selected%3Ap95%2CgroupBy%3A%5Bversion%5D%29%2CtopN%3Aall%29%2Cversion%3A%210%29&fromUser=false&fullscreen_end_ts=1783699305968&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_start_ts=1781107305968&graph-explorer__tile_def=N4IgbglgXiBcIBcIFsCmBnVAnCGQBoQtUBHAVwwXTgG1R0EBPAG1TlAAcBDVhBN%2BN178A%2BggAWXBCIAmAewwA7aagAeEBiAC%2BhJhwEgARlyzVCxdBzmLMIgGZysyKXEQoM2XGZDlPeWHQgMlJcIuhyZFgAxgZoCDhR3opcaK7iEFQEPhRYjK7oZMiw8VwxAHRqHBboZcS%2BDGXpVMAWEdGosDKoqACMAAwyABzGAGwAnAAsXHYydviYWJAxsFVyMgC0XBwQ%2BAAE4nwcZQxSZOgiUWsdAEx9fVplXOeXZMoAFACU2vigwQih4UiMVccQSSRSBl8uR6WSheXgBSKJXKlWqtVIFAaTXQLQwbWWXV6A2GXHGUxmcwWSw6qw2Wx2%2B0Ox3%2BCDOFyusAAzH0JlpdoZGLtgAcEEcTqznlcHk92a8EJ9tABdQgOJxkZhPWigVXIdVcVxwnq7AD0uze2N2AGpdoavlpFfatEA&graphType=flamegraph&groupMapByOperation=null&historicalData=true&shouldShowLegend=true&spanID=5998893326234619515&traceQuery=&start=1783695798147&end=1783699398147&paused=false) hit rate on organization/definitions.  For a lot of the bigger organizations this endpoint can take >1s to run and it gets called frequently.  Right now in order to compute the etag we have to run all the normal queries to get the response so latency takes just as long, even if the end result is we don't send the data back to the client.  This PR does "cheap" queries to get the last updated for all the models that this endpoint uses and bases the etag off that. 

This should change the performance of the route:
- The etag cache hit ration might go down if the average update to these models changes things in a way that would not change the organization/definitions output
- The 304 request latency should go way down as only the etag computation queries would run
- The 200 request latency should go a little bit up as the etag computation queries would get run in addition to all the other queries.

### Alternates Considered
This PR does not try and pre-compute the definitions endpoint, though that can be done in the future.
Also if all models are on the BaseModel we could update an etag automatically on writes more easily.

- Closes **(add link to issue here)**

### Dependencies

- Create feature and experiments to track whether this performs better in a real world db.

### Testing

- [ ] Setup the feature and experiments locally
- [ ] Run local ingestor
- [ ] See the experiment results for local dev usage.
