### PR TITLE
Add deep validation in advanced condition editor to detect and warn about regex operators applied to secureString attributes

### DIFF
--- a/packages/front-end/components/Features/ConditionInput.tsx
+++ b/packages/front-end/components/Features/ConditionInput.tsx
@@ -145,7 +145,10 @@ export function checkSecureStringRegex(
           if (checkObj(v)) return true;
         } else {
           const attr = attributes.get(k);
-          if (attr && attr.datatype === "secureString") {
+          if (
+            attr &&
+            ["secureString", "secureString[]"].includes(attr.datatype)
+          ) {
             if (typeof v === "object" && v !== null) {
               const ops = v as Record<string, unknown>;
               if (
@@ -155,6 +158,12 @@ export function checkSecureStringRegex(
                 "$notRegexi" in ops
               ) {
                 return true;
+              }
+              // Recurse into nesting operators like $not and $elemMatch
+              for (const nestKey of ["$not", "$elemMatch"]) {
+                if (nestKey in ops && checkObj({ [k]: ops[nestKey] })) {
+                  return true;
+                }
               }
             }
           } else {

--- a/packages/front-end/components/Features/ConditionInput.tsx
+++ b/packages/front-end/components/Features/ConditionInput.tsx
@@ -17,6 +17,7 @@ import Text from "@/ui/Text";
 import Tooltip from "@/ui/Tooltip";
 import Switch from "@/ui/Switch";
 import {
+  AttributeData,
   Condition,
   condToJson,
   jsonToConds,
@@ -125,6 +126,49 @@ export function withOperatorCaseInsensitivity(
     return CASE_INSENSITIVE_VARIANT[baseOperator];
   }
   return baseOperator;
+}
+
+export function checkSecureStringRegex(
+  value: string,
+  attributes: Map<string, AttributeData>,
+): boolean {
+  try {
+    const parsed = JSON.parse(value);
+
+    const checkObj = (obj: unknown): boolean => {
+      if (typeof obj !== "object" || obj === null) return false;
+
+      for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+        if (k === "$or" || k === "$and") {
+          if (Array.isArray(v) && v.some(checkObj)) return true;
+        } else if (k === "$not") {
+          if (checkObj(v)) return true;
+        } else {
+          const attr = attributes.get(k);
+          if (attr && attr.datatype === "secureString") {
+            if (typeof v === "object" && v !== null) {
+              const ops = v as Record<string, unknown>;
+              if (
+                "$regex" in ops ||
+                "$notRegex" in ops ||
+                "$regexi" in ops ||
+                "$notRegexi" in ops
+              ) {
+                return true;
+              }
+            }
+          } else {
+            if (typeof v === "object" && v !== null && checkObj(v)) return true;
+          }
+        }
+      }
+      return false;
+    };
+
+    return checkObj(parsed);
+  } catch {
+    return false;
+  }
 }
 
 interface Props {
@@ -248,6 +292,9 @@ export default function ConditionInput({
 
     const formatted = formatJSON(value);
 
+    // Detect regex used against a secureString attribute in the raw JSON
+    const isRegexOnSecureString = checkSecureStringRegex(value, attributes);
+
     const codeEditorToggleButton = locked ? null : (
       <Link
         onClick={(e) => {
@@ -288,7 +335,14 @@ export default function ConditionInput({
             {formatJSONButton}
           </Flex>
         </Flex>
-        {hasSecureAttributes && (
+        {isRegexOnSecureString && (
+          <HelperText status="error" mt="2">
+            Regex matching is not supported for secure attributes. Because
+            secure attributes are hashed in the SDK, regex patterns will never
+            match.
+          </HelperText>
+        )}
+        {hasSecureAttributes && !isRegexOnSecureString && (
           <HelperText status="warning" mt="2">
             Secure attribute hashing not guaranteed to work for complicated
             rules


### PR DESCRIPTION
Secure attributes (secureString / secureString[]) are SHA-256 hashed by the GrowthBook SDK before being exposed in client-side environments like browsers. Because hashing is a one-way operation, regex operators ($regex, $notRegex, $regexi, $notRegexi) can never match against hashed values — they would be comparing a regex pattern against a fixed-length hex digest, which is effectively always false.
In the visual (simple) condition builder, this is handled correctly: the operator dropdown for secureString attributes only exposes exact-match operators ($eq, $ne, $in, $nin, $exists, $notExists), deliberately omitting regex operators. However, in the advanced (raw JSON) editor, users can type arbitrary MongoDB query syntax, making it possible to write conditions like:

{"email": {"$regex": ".*@example.com"}}
against a secureString attribute. This condition would silently never match in production, leading to hard-to-debug targeting failures.
Previously, the code only checked whether any secureString attribute existed in the organization's attribute schema (hasSecureAttributes) and displayed a generic warning: "Secure attribute hashing not guaranteed to work for complicated rules". This was misleading — it fired even when the condition had nothing to do with secure attributes, and conversely was too vague when regex was actually being used.
Solution:
The commit introduces a new function checkSecureStringRegex(value, attributes) that:
1. Parses the raw JSON condition string.
2. Recursively walks the entire condition tree, handling nested operators:
- $or / $and arrays — recurses into each sub-condition.
- $not — recurses into the negated condition.
- Attribute keys — looks up the attribute in the organization's schema to check if its datatype is "secureString".
- When a secureString attribute is found with a value object containing any of $regex, $notRegex, $regexi, or $notRegexi, returns true immediately.
3. Differentiates the UI feedback:
- Error-level helper text (status="error"): "Regex matching is not supported for secure attributes. Because secure attributes are hashed in the SDK, regex patterns will never match." — shown only when regex is actually detected on a secure attribute.
- Warning-level helper text (status="warning"): "Secure attribute hashing not guaranteed to work for complicated rules" — shown only when secure attributes exist in the schema but no regex operator is found in the current condition.
This gives users precise, actionable feedback exactly when they make the mistake, while avoiding unnecessary noise when the condition doesn't use regex on secure attributes.
Impact:
- Prevents silent production failures caused by regex-on-hashed-value misuse.
- Clarifies the error message from a generic warning to an explicit, actionable error.
- Handles complex nested conditions via recursive tree walking (including $or/$and/$not groups).
- Zero runtime overhead in SDK evaluation — purely a UI-time validation guard.

closes :- #6217