### PR TITLE
Fix some ramp-up UI bugs

### DIFF
--- a/packages/front-end/components/RampSchedule/RampScheduleBadge.tsx
+++ b/packages/front-end/components/RampSchedule/RampScheduleBadge.tsx
@@ -65,7 +65,7 @@ export default function RampScheduleBadge({
       ready: "Schedule scheduled",
       running: "Schedule active",
       paused: "Schedule paused",
-      completed: "Schedule complete",
+      completed: "Schedule completed",
       "rolled-back": "Rolled back",
     };
     const displayLabel = isReadyForApproval(rs)
@@ -142,14 +142,14 @@ export default function RampScheduleBadge({
     ready: "Ramp scheduled",
     running: "Ramp active",
     paused: "Ramp paused",
-    completed: "Ramp complete",
+    completed: "Ramp completed",
     "rolled-back": "Rolled back",
   };
   let featureContextLabel = isReadyForApproval(rs)
     ? "Ramp needs approval"
     : (featureContextLabels[rs.status] ?? `Ramp ${baseLabel.toLowerCase()}`);
   if (allStepsDone && futureEnd) {
-    featureContextLabel = "Ramp complete";
+    featureContextLabel = "Ramp completed";
   }
   const displayLabel = featureRuleContext ? featureContextLabel : baseLabel;
 

--- a/packages/front-end/components/RampSchedule/RampTimeline.tsx
+++ b/packages/front-end/components/RampSchedule/RampTimeline.tsx
@@ -711,7 +711,7 @@ export function getRampStatusLabel(rs: RampScheduleInterface): string {
     pending: "Schedule Start is Pending",
     running: "Running",
     paused: "Paused",
-    completed: "Complete",
+    completed: "Completed",
     "rolled-back": "Rolled back",
   };
   return labels[rs.status] ?? rs.status;

--- a/packages/front-end/components/RampSchedule/RampTimeline.tsx
+++ b/packages/front-end/components/RampSchedule/RampTimeline.tsx
@@ -18,6 +18,10 @@ import InlineCode from "@/components/SyntaxHighlighting/InlineCode";
 import ConditionDisplay from "@/components/Features/ConditionDisplay";
 import SavedGroupTargetingDisplay from "@/components/Features/SavedGroupTargetingDisplay";
 import MonitoredIcon from "@/components/Features/RuleModal/MonitoredIcon";
+import {
+  NodeState,
+  resolveNodeStatus,
+} from "@/components/RampSchedule/rampTimelineStatus";
 import styles from "./RampTimeline.module.scss";
 
 // ─── helpers ────────────────────────────────────────────────────────────────
@@ -335,10 +339,7 @@ function PopoverPatchDisplay({
 
 interface NodePopoverContentProps {
   heading: string;
-  headingColor: string;
-  nodeColor: string;
   nodeState: NodeState;
-  status: RampScheduleStatus;
   // Step's time gate in seconds (null = no time gate). null is also used for
   // start/end synthetic nodes that aren't backed by a step.
   interval: number | null;
@@ -359,10 +360,7 @@ interface NodePopoverContentProps {
 
 function NodePopoverContent({
   heading,
-  headingColor,
-  nodeColor,
   nodeState,
-  status,
   interval,
   triggerLabel,
   actions,
@@ -411,28 +409,18 @@ function NodePopoverContent({
     }
   }
 
-  type StatusMeta = { label: string; color: string };
-  const statusMeta: StatusMeta = (() => {
-    if (nodeState === "completed")
-      return { label: "Completed", color: "var(--violet-9)" };
-    if (nodeState === "active") {
-      if (isReadyForApproval(rs)) {
-        return { label: "Awaiting Approval", color: "var(--orange-9)" };
-      }
-      if (status === "paused")
-        return { label: "Paused", color: "var(--amber-11)" };
-      if (monitored) return { label: "Monitoring", color: "var(--blue-9)" };
-      return { label: "Running", color: "var(--green-9)" };
-    }
-    return { label: "Upcoming", color: "var(--gray-12)" };
-  })();
+  const statusVisual = resolveNodeStatus(nodeState, rs, !!monitored);
 
   return (
     <Box className={styles.popoverBox}>
       {/* Header */}
       <Flex align="center" gap="2" mb="2">
-        <NodeDot state={nodeState} color={nodeColor} status={status} />
-        <span style={{ color: headingColor }}>
+        <NodeDot
+          state={nodeState}
+          color={statusVisual.dotColor}
+          pulse={statusVisual.pulse}
+        />
+        <span style={{ color: statusVisual.labelColor }}>
           <Text weight="medium">
             {heading}
             {nodeState === "active" && (
@@ -443,7 +431,7 @@ function NodePopoverContent({
             )}{" "}
             —{" "}
             <span className={styles.popoverStatusLabel}>
-              {statusMeta.label}
+              {statusVisual.label}
             </span>
           </Text>
         </span>
@@ -577,58 +565,22 @@ function completedNodeCount(rs: RampScheduleInterface): number {
   return rs.currentStepIndex + 1;
 }
 
-type NodeState = "completed" | "active" | "future";
-
-function activeDotColor(status: RampScheduleStatus): string {
-  if (status === "running") return "var(--green-9)";
-  if (status === "pending" || status === "ready" || status === "paused")
-    return "var(--amber-9)";
-  if (status === "rolled-back") return "var(--gray-8)";
-  return "var(--accent-9)";
-}
-
-function activeLabelColor(status: RampScheduleStatus): string {
-  if (status === "running") return "var(--green-11)";
-  if (status === "pending" || status === "ready" || status === "paused")
-    return "var(--amber-11)";
-  if (status === "rolled-back") return "var(--gray-10)";
-  return "var(--accent-11)";
-}
-
-function dotColor(state: NodeState, status: RampScheduleStatus): string {
-  if (state === "completed") return "var(--violet-9)";
-  if (state === "future") return "var(--ramp-future-dot)";
-  return activeDotColor(status);
-}
-
-function nodeLabelColor(state: NodeState, status: RampScheduleStatus): string {
-  if (state === "completed") return "var(--violet-12)";
-  if (state === "future") return "var(--ramp-future-label)";
-  return activeLabelColor(status);
-}
-
-function connectorColor(left: NodeState, status: RampScheduleStatus): string {
-  if (left === "completed") return "var(--violet-9)";
-  if (left === "active") return activeDotColor(status);
-  return "var(--ramp-future-connector)";
-}
-
 // ─── NodeDot ─────────────────────────────────────────────────────────────────
 
 function NodeDot({
   state,
   color,
-  status,
+  pulse = false,
 }: {
   state: NodeState;
   color: string;
-  status: RampScheduleStatus;
+  pulse?: boolean;
 }) {
   return (
     <Box className={styles.dotContainer}>
       {state === "active" && (
         <Box
-          className={`${styles.dotRing}${status === "running" ? ` ${styles.dotRingPulse}` : ""}`}
+          className={`${styles.dotRing}${pulse ? ` ${styles.dotRingPulse}` : ""}`}
           style={{ border: `2px solid ${color}` }}
         />
       )}
@@ -647,8 +599,7 @@ interface NodeMeta {
   sublabel: ReactNode;
   /** Trigger label rendered underneath the connector that leads INTO this node. */
   connectorLabel?: ReactNode;
-  dotColorOverride?: string;
-  labelColorOverride?: string;
+  monitored?: boolean;
   /** Pre-built popover content — when present, wraps node in a hover popover. */
   popoverContent?: ReactNode;
 }
@@ -656,20 +607,21 @@ interface NodeMeta {
 function Node({
   node,
   state,
-  status,
+  dotColor,
+  labelColor,
+  pulse,
 }: {
   node: NodeMeta;
   state: NodeState;
-  status: RampScheduleStatus;
+  dotColor: string;
+  labelColor: string;
+  pulse: boolean;
 }) {
-  const color = node.dotColorOverride ?? dotColor(state, status);
-  const labelColor = node.labelColorOverride ?? nodeLabelColor(state, status);
-
   const nodeContent = (
     <Flex direction="column" align="center" className={styles.nodeInner}>
       {/* Dot */}
       <Box my="1">
-        <NodeDot state={state} color={color} status={status} />
+        <NodeDot state={state} color={dotColor} pulse={pulse} />
       </Box>
 
       {/* Labels */}
@@ -717,19 +669,17 @@ function Node({
 // ─── Connector ───────────────────────────────────────────────────────────────
 
 function Connector({
-  left,
-  status,
+  color,
   triggerLabel,
 }: {
-  left: NodeState;
-  status: RampScheduleStatus;
+  color: string;
   triggerLabel?: ReactNode;
 }) {
   return (
     <Flex direction="column" className={styles.connector}>
       <Box
         className={styles.connectorLine}
-        style={{ backgroundColor: connectorColor(left, status) }}
+        style={{ backgroundColor: color }}
       />
       {triggerLabel && (
         <Box className={styles.connectorLabel}>{triggerLabel}</Box>
@@ -851,10 +801,7 @@ export default function RampTimeline({
       popoverContent: (
         <NodePopoverContent
           heading="Start"
-          headingColor={nodeLabelColor(getState(0), status)}
-          nodeColor={dotColor(getState(0), status)}
           nodeState={getState(0)}
-          status={status}
           interval={null}
           triggerLabel={startInline}
           actions={rs.startActions ?? []}
@@ -879,6 +826,7 @@ export default function RampTimeline({
           String(i + 1)
         ),
         sublabel: null,
+        monitored: step.monitored,
         connectorLabel:
           i === 0 ? (
             !startDate ? (
@@ -890,10 +838,7 @@ export default function RampTimeline({
         popoverContent: (
           <NodePopoverContent
             heading={`Step ${i + 1}`}
-            headingColor={nodeLabelColor(state, status)}
-            nodeColor={dotColor(state, status)}
             nodeState={state}
-            status={status}
             interval={step.interval}
             triggerLabel={formatStepGate(step.interval, step.holdConditions)}
             actions={step.actions}
@@ -930,10 +875,7 @@ export default function RampTimeline({
             popoverContent: (
               <NodePopoverContent
                 heading="End"
-                headingColor={nodeLabelColor(getState(rampEndIdx), status)}
-                nodeColor={dotColor(getState(rampEndIdx), status)}
                 nodeState={getState(rampEndIdx)}
-                status={status}
                 interval={null}
                 triggerLabel={null}
                 actions={rs.endActions ?? []}
@@ -952,10 +894,7 @@ export default function RampTimeline({
             popoverContent: (
               <NodePopoverContent
                 heading="Disable"
-                headingColor={nodeLabelColor(getState(cutoffIdx), status)}
-                nodeColor={dotColor(getState(cutoffIdx), status)}
                 nodeState={getState(cutoffIdx)}
-                status={status}
                 interval={null}
                 triggerLabel={formatScheduledDate(rs.cutoffDate!, {
                   inline: true,
@@ -985,10 +924,7 @@ export default function RampTimeline({
           popoverContent: (
             <NodePopoverContent
               heading={hasDisableDate ? "Disable" : "End"}
-              headingColor={nodeLabelColor(getState(endNodeIndex), status)}
-              nodeColor={dotColor(getState(endNodeIndex), status)}
               nodeState={getState(endNodeIndex)}
-              status={status}
               interval={null}
               triggerLabel={
                 singleDate
@@ -1025,6 +961,13 @@ export default function RampTimeline({
     </>
   );
 
+  // Resolve each node's visuals once, shared by the node and its connector.
+  const states = nodes.map((_, i) => getState(i));
+  const visuals = nodes.map((node, i) =>
+    resolveNodeStatus(states[i], rs, !!node.monitored),
+  );
+  const pendingVisual = resolveNodeStatus("active", rs, false);
+
   return (
     <Box className={styles.timelineRoot}>
       {/* Single-row timeline */}
@@ -1038,11 +981,11 @@ export default function RampTimeline({
                   key: "pending-removal",
                   label: "removal",
                   sublabel: revisionSublabel,
-                  dotColorOverride: "var(--red-9)",
-                  labelColorOverride: "var(--red-11)",
                 }}
                 state="active"
-                status={status}
+                dotColor="var(--red-9)"
+                labelColor="var(--red-11)"
+                pulse={false}
               />
               <Box className={styles.connectorSpacer} />
             </>
@@ -1057,7 +1000,9 @@ export default function RampTimeline({
                     sublabel: revisionSublabel,
                   }}
                   state="active"
-                  status={status}
+                  dotColor={pendingVisual.dotColor}
+                  labelColor={pendingVisual.labelColor}
+                  pulse={pendingVisual.pulse}
                 />
                 <Box className={styles.connectorSpacer} />
               </>
@@ -1068,14 +1013,19 @@ export default function RampTimeline({
             <Fragment key={node.key}>
               {i > 0 && (
                 <Connector
-                  left={getState(i - 1)}
-                  status={status}
+                  color={visuals[i - 1].connectorColor}
                   triggerLabel={
-                    getState(i) === "future" ? node.connectorLabel : undefined
+                    states[i] === "future" ? node.connectorLabel : undefined
                   }
                 />
               )}
-              <Node node={node} state={getState(i)} status={status} />
+              <Node
+                node={node}
+                state={states[i]}
+                dotColor={visuals[i].dotColor}
+                labelColor={visuals[i].labelColor}
+                pulse={visuals[i].pulse}
+              />
             </Fragment>
           ))}
         </Flex>

--- a/packages/front-end/components/RampSchedule/rampTimelineStatus.ts
+++ b/packages/front-end/components/RampSchedule/rampTimelineStatus.ts
@@ -1,0 +1,128 @@
+import { isReadyForApproval } from "shared/validators";
+
+// Single source of truth: a timeline node's status → label + colors. The dot,
+// label, connector, and popover all resolve here so they can't drift apart.
+
+// Minimal schedule shape the derivation needs; tracks isReadyForApproval's input.
+type StatusSchedule = Parameters<typeof isReadyForApproval>[0];
+
+export type NodeState = "completed" | "active" | "future";
+
+export type NodeStatusToken =
+  | "completed"
+  | "awaiting-approval"
+  | "monitoring"
+  | "running"
+  | "paused"
+  | "scheduled"
+  | "rolled-back"
+  | "future";
+
+export interface NodeStatusVisual {
+  token: NodeStatusToken;
+  label: string;
+  dotColor: string;
+  labelColor: string;
+  // Color of the connector segment leaving this node.
+  connectorColor: string;
+  // Only live states pulse; holds, pauses, and stops are static.
+  pulse: boolean;
+}
+
+const FUTURE_CONNECTOR = "var(--ramp-future-connector)";
+
+const STATUS_VISUALS: Record<
+  NodeStatusToken,
+  Omit<NodeStatusVisual, "token">
+> = {
+  completed: {
+    label: "Completed",
+    dotColor: "var(--violet-9)",
+    labelColor: "var(--violet-12)",
+    connectorColor: "var(--violet-9)",
+    pulse: false,
+  },
+  // Approval is a hard stop — outgoing edge stays gray so it doesn't read as
+  // "already advanced"; the orange dot + "approval" label carry the signal.
+  "awaiting-approval": {
+    label: "Needs Approval",
+    dotColor: "var(--orange-9)",
+    labelColor: "var(--orange-11)",
+    connectorColor: FUTURE_CONNECTOR,
+    pulse: false,
+  },
+  monitoring: {
+    label: "Monitoring",
+    dotColor: "var(--blue-9)",
+    labelColor: "var(--blue-11)",
+    connectorColor: "var(--blue-9)",
+    pulse: true,
+  },
+  running: {
+    label: "Running",
+    dotColor: "var(--green-9)",
+    labelColor: "var(--green-11)",
+    connectorColor: "var(--green-9)",
+    pulse: true,
+  },
+  paused: {
+    label: "Paused",
+    dotColor: "var(--amber-9)",
+    labelColor: "var(--amber-11)",
+    connectorColor: "var(--amber-9)",
+    pulse: false,
+  },
+  scheduled: {
+    label: "Scheduled",
+    dotColor: "var(--amber-9)",
+    labelColor: "var(--amber-11)",
+    connectorColor: "var(--amber-9)",
+    pulse: false,
+  },
+  "rolled-back": {
+    label: "Rolled back",
+    dotColor: "var(--gray-8)",
+    labelColor: "var(--gray-10)",
+    connectorColor: "var(--gray-8)",
+    pulse: false,
+  },
+  future: {
+    label: "Upcoming",
+    dotColor: "var(--ramp-future-dot)",
+    labelColor: "var(--ramp-future-label)",
+    connectorColor: FUTURE_CONNECTOR,
+    pulse: false,
+  },
+};
+
+export function nodeStatusToken(
+  nodeState: NodeState,
+  rs: StatusSchedule,
+  monitored: boolean,
+): NodeStatusToken {
+  if (nodeState === "completed") return "completed";
+  if (nodeState === "future") return "future";
+
+  // Approval is the top-priority active hold, mirroring the rule badge.
+  if (isReadyForApproval(rs)) return "awaiting-approval";
+  switch (rs.status) {
+    case "paused":
+      return "paused";
+    case "pending":
+    case "ready":
+      return "scheduled";
+    case "rolled-back":
+      return "rolled-back";
+    default:
+      return monitored ? "monitoring" : "running";
+  }
+}
+
+export function resolveNodeStatus(
+  nodeState: NodeState,
+  rs: StatusSchedule,
+  monitored: boolean,
+): NodeStatusVisual {
+  const token = nodeStatusToken(nodeState, rs, monitored);
+  return { token, ...STATUS_VISUALS[token] };
+}

--- a/packages/front-end/components/RampSchedule/rampTimelineStatus.ts
+++ b/packages/front-end/components/RampSchedule/rampTimelineStatus.ts
@@ -106,6 +106,8 @@ export function nodeStatusToken(
   // Approval is the top-priority active hold, mirroring the rule badge.
   if (isReadyForApproval(rs)) return "awaiting-approval";
   switch (rs.status) {
+    case "running":
+      return monitored ? "monitoring" : "running";
     case "paused":
       return "paused";
     case "pending":
@@ -113,8 +115,10 @@ export function nodeStatusToken(
       return "scheduled";
     case "rolled-back":
       return "rolled-back";
+    // Unknown/stale status: fall back to a neutral, non-live state rather than
+    // a pulsing green/blue that implies healthy progress.
     default:
-      return monitored ? "monitoring" : "running";
+      return "scheduled";
   }
 }
 

--- a/packages/front-end/test/components/rampTimelineStatus.test.ts
+++ b/packages/front-end/test/components/rampTimelineStatus.test.ts
@@ -74,6 +74,16 @@ describe("rampTimelineStatus", () => {
     ).toBe("rolled-back");
   });
 
+  it("falls back to a neutral, non-live state for an unknown status", () => {
+    const v = resolveNodeStatus(
+      "active",
+      { ...running, status: "some-future-status" },
+      false,
+    );
+    expect(v.token).toBe("scheduled");
+    expect(v.pulse).toBe(false);
+  });
+
   it("gives approval priority over monitoring on the same step", () => {
     expect(nodeStatusToken("active", approvalReady, true)).toBe(
       "awaiting-approval",

--- a/packages/front-end/test/components/rampTimelineStatus.test.ts
+++ b/packages/front-end/test/components/rampTimelineStatus.test.ts
@@ -1,0 +1,96 @@
+import {
+  nodeStatusToken,
+  resolveNodeStatus,
+} from "@/components/RampSchedule/rampTimelineStatus";
+
+type StatusInput = Parameters<typeof nodeStatusToken>[1];
+
+const approvalReady: StatusInput = {
+  status: "running",
+  currentStepIndex: 0,
+  steps: [{ interval: null, holdConditions: { requiresApproval: true } }],
+  stepApproval: null,
+};
+
+const running: StatusInput = {
+  status: "running",
+  currentStepIndex: 0,
+  steps: [{ interval: 3600 }],
+};
+
+describe("rampTimelineStatus", () => {
+  it("resolves completed/future from node state regardless of schedule status", () => {
+    expect(nodeStatusToken("completed", running, false)).toBe("completed");
+    expect(nodeStatusToken("completed", approvalReady, true)).toBe("completed");
+    expect(nodeStatusToken("future", approvalReady, true)).toBe("future");
+  });
+
+  // The regression this whole file exists to prevent: an active step holding
+  // for approval must resolve to orange, not the running green.
+  it("resolves an awaiting-approval active step to orange with a gray outgoing edge", () => {
+    const v = resolveNodeStatus("active", approvalReady, false);
+    expect(v.token).toBe("awaiting-approval");
+    expect(v.label).toBe("Needs Approval");
+    expect(v.dotColor).toBe("var(--orange-9)");
+    expect(v.labelColor).toBe("var(--orange-11)");
+    expect(v.connectorColor).toBe("var(--ramp-future-connector)");
+  });
+
+  it("resolves a monitored active step to blue with a blue outgoing edge", () => {
+    const v = resolveNodeStatus("active", running, true);
+    expect(v.token).toBe("monitoring");
+    expect(v.dotColor).toBe("var(--blue-9)");
+    expect(v.connectorColor).toBe("var(--blue-9)");
+  });
+
+  it("keeps a rolled-back node's dot and outgoing edge the same gray", () => {
+    const v = resolveNodeStatus(
+      "active",
+      { ...running, status: "rolled-back" },
+      false,
+    );
+    expect(v.dotColor).toBe("var(--gray-8)");
+    expect(v.connectorColor).toBe("var(--gray-8)");
+  });
+
+  it("resolves a plain running active step to green", () => {
+    const v = resolveNodeStatus("active", running, false);
+    expect(v.token).toBe("running");
+    expect(v.dotColor).toBe("var(--green-9)");
+  });
+
+  it("resolves paused / scheduled / rolled-back active steps", () => {
+    expect(
+      nodeStatusToken("active", { ...running, status: "paused" }, false),
+    ).toBe("paused");
+    expect(
+      nodeStatusToken("active", { ...running, status: "pending" }, false),
+    ).toBe("scheduled");
+    expect(
+      nodeStatusToken("active", { ...running, status: "ready" }, false),
+    ).toBe("scheduled");
+    expect(
+      nodeStatusToken("active", { ...running, status: "rolled-back" }, false),
+    ).toBe("rolled-back");
+  });
+
+  it("gives approval priority over monitoring on the same step", () => {
+    expect(nodeStatusToken("active", approvalReady, true)).toBe(
+      "awaiting-approval",
+    );
+  });
+
+  it("pulses only for live states, not holds/pauses/stops", () => {
+    expect(resolveNodeStatus("active", running, false).pulse).toBe(true);
+    expect(resolveNodeStatus("active", running, true).pulse).toBe(true);
+    expect(resolveNodeStatus("active", approvalReady, false).pulse).toBe(false);
+    expect(
+      resolveNodeStatus("active", { ...running, status: "paused" }, false)
+        .pulse,
+    ).toBe(false);
+    expect(
+      resolveNodeStatus("active", { ...running, status: "rolled-back" }, false)
+        .pulse,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes a regression where a ramp step awaiting approval showed as green "running" instead of orange on the timeline, and unifies the dot/label/connector/popover status colors behind one tested resolver so they can't drift apart again.

Also: monitored steps now render blue, held/paused/stopped states no longer pulse, and no progression logic was touched — this is UI-only.

<img width="1274" height="335" alt="image" src="https://github.com/user-attachments/assets/f54cc6cf-7a98-4afc-8106-40da52ac9fca" />
