### PR TITLE
fix: prevent long variation names from overlapping Actual Units column in balance check table

### DIFF
--- a/packages/front-end/components/Experiment/TabbedPage/VariationUsersTable.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/VariationUsersTable.tsx
@@ -75,7 +75,7 @@ export default function VariationUsersTable({
           {variations.map((v, i) => {
             return (
               <tr key={v.id}>
-                <td className={"border-right"}>
+                <td className="border-right text-truncate">
                   {hideVariationIndex ? (
                     <Text color="text-mid" weight="medium">
                       {v.name}


### PR DESCRIPTION
## Summary

The **Experiment Balance Check** table on the **Health** tab has a UI layout issue where long variation names overlap with the **Actual Units** column, making unit counts unreadable.

## Changes

- Added Bootstrap's `text-truncate` class to the variation name cell in `VariationUsersTable`
- Long names now truncate with an ellipsis instead of overflowing into adjacent columns
- The full name remains visible via the existing tooltip on `VariationLabel`

Closes #6304