### PR TITLE
Allow removing preserved legacy identifiers from a managed warehouse

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -1102,6 +1102,10 @@ app.post(
   "/datasource/:datasourceId/recreate-managed-warehouse",
   datasourcesController.postRecreateManagedWarehouse,
 );
+app.post(
+  "/datasource/:datasourceId/managed-warehouse/remove-legacy-identifier",
+  datasourcesController.postRemoveManagedWarehouseLegacyIdentifier,
+);
 
 if (IS_CLOUD) {
   app.post(

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -2086,7 +2086,7 @@ export async function postRemoveManagedWarehouseLegacyIdentifier(
     context.permissions.throwPermissionError();
   }
 
-  await removeManagedWarehouseLegacyIdentifier(context, identifier);
+  await removeManagedWarehouseLegacyIdentifier(context, datasource, identifier);
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -109,6 +109,7 @@ import { logger } from "back-end/src/util/logger";
 import { IS_CLOUD } from "back-end/src/util/secrets";
 import {
   getReservedColumnNames,
+  removeManagedWarehouseLegacyIdentifier,
   updateMaterializedColumns,
 } from "back-end/src/services/clickhouse";
 import { dangerousRecreateClickhouseTables } from "back-end/src/services/licenseServerManagedClickhouse";
@@ -2054,6 +2055,38 @@ export async function postRecreateManagedWarehouse(
     });
     return;
   }
+
+  res.status(200).json({
+    status: 200,
+  });
+}
+
+export async function postRemoveManagedWarehouseLegacyIdentifier(
+  req: AuthRequest<{ identifier?: string }, { datasourceId: string }>,
+  res: Response,
+) {
+  const context = getContextFromReq(req);
+  const { datasourceId } = req.params;
+  const { identifier } = req.body;
+
+  if (!identifier || typeof identifier !== "string") {
+    throw new Error("Must specify an identifier to remove");
+  }
+
+  const datasource = await getDataSourceById(context, datasourceId);
+  if (!datasource) {
+    throw new Error("Cannot find datasource");
+  }
+  if (datasource.type !== "growthbook_clickhouse") {
+    throw new Error(
+      "Can only manage identifiers on a Managed Warehouse datasource",
+    );
+  }
+  if (!context.permissions.canUpdateDataSourceSettings(datasource)) {
+    context.permissions.throwPermissionError();
+  }
+
+  await removeManagedWarehouseLegacyIdentifier(context, identifier);
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/services/clickhouse.ts
+++ b/packages/back-end/src/services/clickhouse.ts
@@ -551,6 +551,45 @@ export async function syncManagedWarehouseIdentifiersOnAttributeChange(
   }
 }
 
+// Drop a preserved legacy identifier from a managed warehouse. The JSON migration
+// keeps legacy join keys (identifiers present pre-migration but no longer in the
+// attribute schema) in `migratedIdentifiers` so historical experiments don't break —
+// but there was no way to remove one that's since gone dead (e.g. a renamed attribute).
+// Only entries in `migratedIdentifiers` are removable; builtins and current
+// hashAttribute identifiers are managed via the attribute schema, not here. The re-sync
+// rebuilds userIdTypes / exposure queries and drops the identifier's fact-table column.
+export async function removeManagedWarehouseLegacyIdentifier(
+  context: ReqContext | ApiReqContext,
+  identifier: string,
+): Promise<void> {
+  const datasource =
+    await dangerouslyGetGrowthbookDatasourceBypassPermission(context);
+  if (!datasource || datasource.type !== "growthbook_clickhouse") {
+    throw new Error("No managed warehouse datasource found");
+  }
+
+  const migrated = datasource.settings.migratedIdentifiers || [];
+  if (!migrated.includes(identifier)) {
+    throw new Error(
+      `"${identifier}" is not a removable legacy identifier. Only preserved legacy identifiers can be removed; current identifiers are managed through your attributes.`,
+    );
+  }
+
+  await updateDataSource(
+    context,
+    datasource,
+    {
+      settings: {
+        ...datasource.settings,
+        migratedIdentifiers: migrated.filter((t) => t !== identifier),
+      },
+    },
+    { skipExposureQueryValidation: true },
+  );
+
+  await syncManagedWarehouseIdentifiers(context);
+}
+
 // Kick off the async table rebuild. The license server acks and rebuilds in the
 // background, so this doesn't wait for the tables — a later run finalizes once the
 // rebuild's lock frees (see migrateManagedWarehouseToJson).

--- a/packages/back-end/src/services/clickhouse.ts
+++ b/packages/back-end/src/services/clickhouse.ts
@@ -374,9 +374,14 @@ export async function syncManagedWarehouseIdentifiers(
   // Pass the freshly-updated schema; context.org may still be stale post-mutation.
   attributeSchema: SDKAttributeSchema | undefined = context.org.settings
     ?.attributeSchema,
+  // Optionally reconcile a specific (already-fetched) warehouse instead of
+  // re-selecting by org — callers that just mutated one datasource pass it so the
+  // rebuild targets the same doc.
+  providedDatasource: DataSourceInterface | null = null,
 ): Promise<void> {
   const datasource =
-    await dangerouslyGetGrowthbookDatasourceBypassPermission(context);
+    providedDatasource ??
+    (await dangerouslyGetGrowthbookDatasourceBypassPermission(context));
   if (
     !datasource ||
     datasource.type !== "growthbook_clickhouse" ||
@@ -575,19 +580,23 @@ export async function removeManagedWarehouseLegacyIdentifier(
     );
   }
 
+  const updatedSettings = {
+    ...datasource.settings,
+    migratedIdentifiers: migrated.filter((t) => t !== identifier),
+  };
   await updateDataSource(
     context,
     datasource,
-    {
-      settings: {
-        ...datasource.settings,
-        migratedIdentifiers: migrated.filter((t) => t !== identifier),
-      },
-    },
+    { settings: updatedSettings },
     { skipExposureQueryValidation: true },
   );
 
-  await syncManagedWarehouseIdentifiers(context);
+  // Reconcile the same datasource we just updated (with its post-removal settings),
+  // rather than letting the sync re-select a warehouse by org.
+  await syncManagedWarehouseIdentifiers(context, undefined, {
+    ...datasource,
+    settings: updatedSettings,
+  });
 }
 
 // Kick off the async table rebuild. The license server acks and rebuilds in the

--- a/packages/back-end/src/services/clickhouse.ts
+++ b/packages/back-end/src/services/clickhouse.ts
@@ -14,6 +14,7 @@ import {
   MANAGED_WAREHOUSE_RESERVED_COLUMN_NAMES,
 } from "shared/util";
 import {
+  DataSourceInterface,
   GrowthbookClickhouseDataSource,
   MaterializedColumn,
 } from "shared/types/datasource";
@@ -560,12 +561,11 @@ export async function syncManagedWarehouseIdentifiersOnAttributeChange(
 // rebuilds userIdTypes / exposure queries and drops the identifier's fact-table column.
 export async function removeManagedWarehouseLegacyIdentifier(
   context: ReqContext | ApiReqContext,
+  datasource: DataSourceInterface,
   identifier: string,
 ): Promise<void> {
-  const datasource =
-    await dangerouslyGetGrowthbookDatasourceBypassPermission(context);
-  if (!datasource || datasource.type !== "growthbook_clickhouse") {
-    throw new Error("No managed warehouse datasource found");
+  if (datasource.type !== "growthbook_clickhouse") {
+    throw new Error("Not a managed warehouse datasource");
   }
 
   const migrated = datasource.settings.migratedIdentifiers || [];

--- a/packages/front-end/components/Settings/EditDataSource/ClickhouseManagedWarehouseIdentifiers.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ClickhouseManagedWarehouseIdentifiers.tsx
@@ -86,8 +86,8 @@ export default function ClickhouseManagedWarehouseIdentifiers({
           <>
             {" "}
             Identifiers shown in gray were preserved from a past migration and
-            are no longer among your attributes&mdash;delete any you no longer
-            need.
+            are no longer among your attributes
+            {canEdit ? <>&mdash;delete any you no longer need</> : null}.
           </>
         ) : null}
       </Callout>

--- a/packages/front-end/components/Settings/EditDataSource/ClickhouseManagedWarehouseIdentifiers.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ClickhouseManagedWarehouseIdentifiers.tsx
@@ -2,24 +2,44 @@ import { Box, Flex } from "@radix-ui/themes";
 import { GrowthbookClickhouseDataSourceWithParams } from "shared/types/datasource";
 import { getManagedWarehouseUserIdTypes } from "shared/util";
 import useOrgSettings from "@/hooks/useOrgSettings";
+import { useAuth } from "@/services/auth";
 import Badge from "@/ui/Badge";
 import Callout from "@/ui/Callout";
+import DeleteButton from "@/components/DeleteButton/DeleteButton";
 import Heading from "@/ui/Heading";
 import Link from "@/ui/Link";
 import Text from "@/ui/Text";
 
-// Read-only identifiers view for JSON-column managed warehouses. Identifiers come
-// from the org's attributes; every other attribute is queryable from `attributes`.
+// Identifiers view for JSON-column managed warehouses. Identifiers come from the org's
+// attributes; every other attribute is queryable from `attributes`. Legacy identifiers
+// preserved from a past migration (in `migratedIdentifiers`, no longer among the org's
+// attributes) can be removed here — nothing else exposes them.
 export default function ClickhouseManagedWarehouseIdentifiers({
   dataSource,
+  canEdit = false,
+  mutate,
 }: {
   dataSource: GrowthbookClickhouseDataSourceWithParams;
+  canEdit?: boolean;
+  mutate?: () => void;
 }) {
   const settings = useOrgSettings();
+  const { apiCall } = useAuth();
 
   const identifiers =
     dataSource.settings.userIdTypes?.map((u) => u.userIdType) ??
     getManagedWarehouseUserIdTypes(settings.attributeSchema);
+
+  const legacy = new Set(dataSource.settings.migratedIdentifiers ?? []);
+  const hasLegacy = identifiers.some((id) => legacy.has(id));
+
+  const removeIdentifier = async (identifier: string) => {
+    await apiCall(
+      `/datasource/${dataSource.id}/managed-warehouse/remove-legacy-identifier`,
+      { method: "POST", body: JSON.stringify({ identifier }) },
+    );
+    mutate?.();
+  };
 
   return (
     <Box>
@@ -32,7 +52,21 @@ export default function ClickhouseManagedWarehouseIdentifiers({
       </Text>
       <Flex gap="2" wrap="wrap" my="3">
         {identifiers.length ? (
-          identifiers.map((id) => <Badge key={id} label={id} color="violet" />)
+          identifiers.map((id) =>
+            canEdit && legacy.has(id) ? (
+              <Flex key={id} align="center" gap="1">
+                <Badge label={id} color="gray" />
+                <DeleteButton
+                  displayName={id}
+                  title={`Remove legacy identifier "${id}"`}
+                  deleteMessage={`Remove the legacy identifier "${id}"? It was preserved from a past migration and is no longer one of your attributes. It will stop being selectable and be removed from your warehouse fact tables. Any experiment still using it will need a different identifier.`}
+                  onClick={() => removeIdentifier(id)}
+                />
+              </Flex>
+            ) : (
+              <Badge key={id} label={id} color="violet" />
+            ),
+          )
         ) : (
           <Text color="text-mid">No identifiers configured.</Text>
         )}
@@ -43,6 +77,14 @@ export default function ClickhouseManagedWarehouseIdentifiers({
         identifiers). Every other attribute your SDK sends is automatically
         queryable from the <code>attributes</code>
         <span> </span>JSON column on your fact tables&mdash;no setup required.
+        {hasLegacy ? (
+          <>
+            {" "}
+            Identifiers shown in gray were preserved from a past migration and
+            are no longer among your attributes&mdash;remove any you no longer
+            need.
+          </>
+        ) : null}
       </Callout>
     </Box>
   );

--- a/packages/front-end/components/Settings/EditDataSource/ClickhouseManagedWarehouseIdentifiers.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ClickhouseManagedWarehouseIdentifiers.tsx
@@ -57,9 +57,12 @@ export default function ClickhouseManagedWarehouseIdentifiers({
               <Flex key={id} align="center" gap="1">
                 <Badge label={id} color="gray" />
                 <DeleteButton
+                  useRadix={false}
+                  useIcon={true}
+                  link={true}
                   displayName={id}
-                  title={`Remove legacy identifier "${id}"`}
-                  deleteMessage={`Remove the legacy identifier "${id}"? It was preserved from a past migration and is no longer one of your attributes. It will stop being selectable and be removed from your warehouse fact tables. Any experiment still using it will need a different identifier.`}
+                  title={`Delete legacy identifier "${id}"`}
+                  deleteMessage={`Delete the legacy identifier "${id}"? It was preserved from a past migration and is no longer one of your attributes. It will stop being selectable and be removed from your warehouse fact tables. Any experiment still using it will need a different identifier.`}
                   onClick={() => removeIdentifier(id)}
                 />
               </Flex>
@@ -81,7 +84,7 @@ export default function ClickhouseManagedWarehouseIdentifiers({
           <>
             {" "}
             Identifiers shown in gray were preserved from a past migration and
-            are no longer among your attributes&mdash;remove any you no longer
+            are no longer among your attributes&mdash;delete any you no longer
             need.
           </>
         ) : null}

--- a/packages/front-end/components/Settings/EditDataSource/ClickhouseManagedWarehouseIdentifiers.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ClickhouseManagedWarehouseIdentifiers.tsx
@@ -53,18 +53,20 @@ export default function ClickhouseManagedWarehouseIdentifiers({
       <Flex gap="2" wrap="wrap" my="3">
         {identifiers.length ? (
           identifiers.map((id) =>
-            canEdit && legacy.has(id) ? (
+            legacy.has(id) ? (
               <Flex key={id} align="center" gap="1">
                 <Badge label={id} color="gray" />
-                <DeleteButton
-                  useRadix={false}
-                  useIcon={true}
-                  link={true}
-                  displayName={id}
-                  title={`Delete legacy identifier "${id}"`}
-                  deleteMessage={`Delete the legacy identifier "${id}"? It was preserved from a past migration and is no longer one of your attributes. It will stop being selectable and be removed from your warehouse fact tables. Any experiment still using it will need a different identifier.`}
-                  onClick={() => removeIdentifier(id)}
-                />
+                {canEdit ? (
+                  <DeleteButton
+                    useRadix={false}
+                    useIcon={true}
+                    link={true}
+                    displayName={id}
+                    title={`Delete legacy identifier "${id}"`}
+                    deleteMessage={`Delete the legacy identifier "${id}"? It was preserved from a past migration and is no longer one of your attributes. It will stop being selectable and be removed from your warehouse fact tables. Any experiment still using it will need a different identifier.`}
+                    onClick={() => removeIdentifier(id)}
+                  />
+                ) : null}
               </Flex>
             ) : (
               <Badge key={id} label={id} color="violet" />

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -474,7 +474,12 @@ mixpanel.init('YOUR PROJECT TOKEN', {
                       <ClickhouseManagedWarehouseIdentifiers
                         dataSource={d}
                         canEdit={canUpdateDataSourceSettings}
-                        mutate={mutateDefinitions}
+                        mutate={async () => {
+                          await Promise.all([
+                            mutateDefinitions({}),
+                            mutateCurrentDataSource(),
+                          ]);
+                        }}
                       />
                     ) : (
                       <ClickhouseMaterializedColumns

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -471,7 +471,11 @@ mixpanel.init('YOUR PROJECT TOKEN', {
                   </Frame>
                   <Frame>
                     {d.settings.useJsonColumns ? (
-                      <ClickhouseManagedWarehouseIdentifiers dataSource={d} />
+                      <ClickhouseManagedWarehouseIdentifiers
+                        dataSource={d}
+                        canEdit={canUpdateDataSourceSettings}
+                        mutate={mutateDefinitions}
+                      />
                     ) : (
                       <ClickhouseMaterializedColumns
                         dataSource={d}


### PR DESCRIPTION
### Features and Changes

The JSON-columns migration (#6175) preserves legacy join keys in `settings.migratedIdentifiers` so historical experiments don't break, but that list is write-once and never reconciled — so an identifier that has since gone dead (e.g. an attribute renamed from `org_id` to `organizationId`) stays selectable as an Experiment Assignment identifier with no backing attribute, and the managed-warehouse Identifiers panel was read-only with no way to remove it.

Adds a way to remove a preserved-legacy identifier:

- `removeManagedWarehouseLegacyIdentifier` drops the entry from `settings.migratedIdentifiers` and re-runs `syncManagedWarehouseIdentifiers`, which rebuilds `userIdTypes` + exposure queries and marks the orphaned `ch_events` column deleted. Only entries in `migratedIdentifiers` are removable — builtins and current hashAttribute identifiers stay managed through attributes.
- New `POST /datasource/:id/managed-warehouse/remove-legacy-identifier` (gated on `canUpdateDataSourceSettings`).
- The Identifiers panel now renders preserved-legacy identifiers in gray with a remove action (behind a confirm noting any experiment still using it will need a different identifier); current identifiers stay non-removable. Corrected the panel copy, which previously claimed all identifiers come from attributes.

Note: removing an identifier that an experiment still references intentionally invalidates that experiment's assignment query — that's the point of retiring a dead identifier, and the confirm dialog says so.

`settings.migratedColumns` (preserved legacy *dimensions*) has the same write-once staleness but no surface in this panel; left as a follow-up.

### Testing

`back-end` + `front-end` type-check and lint pass. Not exercised in a live UI — the removable set is `migratedIdentifiers` membership (builtins/current-attribute identifiers are excluded by construction), and the existing sync handles all downstream cleanup.
