### PR TITLE
fix: handle duplicate attributes in rule conditions

### DIFF
--- a/packages/front-end/components/Features/ConditionInput.tsx
+++ b/packages/front-end/components/Features/ConditionInput.tsx
@@ -98,8 +98,35 @@ const BASE_OPERATOR: Record<string, string> = {
   $ini: "$in",
   $nini: "$nin",
   $regexi: "$regex",
-  $notRegexi: "$notRegex",
+  $notRegexi: "$notRegexi",
 };
+
+/**
+ * Returns the internal object keys used by `condToJson` for a given operator.
+ * This is used to detect if two conditions on the same attribute will overwrite each other.
+ */
+function getSerializationKeys(operator: string): string[] {
+  if (
+    operator === "$notRegex" ||
+    operator === "$notRegexi" ||
+    operator === "$notIncludes"
+  ) {
+    return ["$not"];
+  }
+  if (operator === "$notExists" || operator === "$exists") {
+    return ["$exists"];
+  }
+  if (operator === "$true" || operator === "$false") {
+    return ["$eq"];
+  }
+  if (operator === "$includes") {
+    return ["$elemMatch"];
+  }
+  if (operator === "$empty" || operator === "$notEmpty") {
+    return ["$size"];
+  }
+  return [operator];
+}
 
 export function operatorSupportsCaseInsensitive(operator: string): boolean {
   return OPERATORS_WITH_CASE_INSENSITIVE.has(operator);
@@ -1149,6 +1176,13 @@ function ConditionAndGroupInput({
         const hasExtraWhitespace =
           displayType === "string" && value !== value.trim();
 
+        const myKeys = getSerializationKeys(operator);
+        const willOverwrite = conds.some((c, index) => {
+          if (index === i || c.field !== field) return false;
+          const theirKeys = getSerializationKeys(c.operator);
+          return myKeys.some((k) => theirKeys.includes(k));
+        });
+
         return [
           ...(i > 0
             ? [
@@ -1436,6 +1470,14 @@ function ConditionAndGroupInput({
               )
             }
           />,
+          willOverwrite && (
+            <HelperText key={`warn-${i}`} status="warning" mt="1">
+              Warning: This condition conflicts with another condition for the
+              same attribute. It will overwrite the previous one in the
+              generated JSON. Use &quot;is any of&quot; or &quot;is none
+              of&quot; for multiple values.
+            </HelperText>
+          ),
         ];
       })}
     </>

--- a/packages/front-end/test/components/Features/ConditionInput.test.tsx
+++ b/packages/front-end/test/components/Features/ConditionInput.test.tsx
@@ -324,4 +324,58 @@ describe("ConditionInput", () => {
       expect(screen.getByText("Identifier")).toBeInTheDocument();
     });
   });
+
+  it("shows a warning when duplicate attributes will overwrite each other", async () => {
+    // Setup
+    const mockOnChange = vi.fn();
+    const { container } = render(
+      <RadixTheme>
+        <TooltipProvider>
+          <ConditionInput
+            defaultValue="[]"
+            onChange={mockOnChange}
+            project=""
+          />
+        </TooltipProvider>
+      </RadixTheme>,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Target by Attributes")).toBeInTheDocument();
+    });
+    const addButton = screen.getByText("Add attribute targeting");
+    fireEvent.click(addButton);
+    await waitFor(() => {
+      expect(screen.getByText("INCLUDE")).toBeInTheDocument();
+    });
+
+    // 1st Condition: user_id (default) = "5"
+    let valueInputs = screen.getAllByRole("textbox");
+    fireEvent.change(valueInputs[0], { target: { value: "5" } });
+
+    // Click 'AND' button to add a second condition in the same group
+    await waitFor(() => {
+      const addAndButton = container.querySelector(".and-button") as Element;
+      expect(addAndButton).toBeDefined();
+      fireEvent.click(addAndButton);
+    });
+
+    // 2nd Condition: user_id (default) = "10"
+    await waitFor(() => {
+      valueInputs = screen.getAllByRole("textbox");
+      expect(valueInputs.length).toBe(2);
+    });
+    fireEvent.change(valueInputs[1], { target: { value: "10" } });
+
+    // Assert that the warning is displayed because $eq and $eq conflict
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(
+          (_, element) =>
+            element?.textContent?.includes(
+              "This condition conflicts with another condition",
+            ) ?? false,
+        ).length,
+      ).toBeGreaterThan(0);
+    });
+  });
 });


### PR DESCRIPTION
Closes #6279

### Features and Changes

This PR improves the rule builder UX by warning users when multiple conditions on the same attribute will overwrite each other during serialization.

Previously, users could create multiple conditions for the same attribute (for example, multiple `is` or `is not` conditions), but only the last condition would be preserved in the generated JSON because of how `condToJson` serializes conditions. This could lead to confusing and unexpected behavior.

### What's changed

* Added conflict detection based on the serialization behavior of `condToJson`.
* Displays an inline warning when two conditions on the same attribute serialize to the same JSON key and one would overwrite the other.
* Preserves valid combinations (such as numeric ranges using different operators) by warning only when an actual serialization conflict exists.
* Keeps existing rule-building behavior intact while providing users with clear feedback before saving a conflicting rule.

### Testing

* Verified the project compiles successfully with:

  ```bash
  pnpm --filter front-end type-check
  ```

* Added/updated tests for the warning behavior in `ConditionInput.test.tsx`.

* Manually verified:

  * Duplicate conflicting conditions display an inline warning.
  * Valid combinations (for example, range conditions using different operators) do not display a warning.
  * Existing configurations continue to render correctly.
