### PR TITLE
Verify invitee email when accepting an invitation

### DIFF
--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -641,7 +641,7 @@ export async function putMember(
     );
     if (invite) {
       // if user already invited, accept invite
-      await acceptInvite(invite.key, req.userId);
+      await acceptInvite(invite.key, req.userId, req.email);
     } else if (organization.autoApproveMembers) {
       // if auto approve, add user as member
       await addMemberToOrg({
@@ -1345,10 +1345,10 @@ export async function postInviteAccept(
   const { key } = req.body;
 
   try {
-    if (!req.userId) {
+    if (!req.userId || !req.email) {
       throw new Error("Must be logged in");
     }
-    const org = await acceptInvite(key, req.userId);
+    const org = await acceptInvite(key, req.userId, req.email);
     await licenseInit(org, getUserCodesForOrg, getLicenseMetaData, true);
 
     return res.status(200).json({

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -690,7 +690,7 @@ export async function addPendingMemberToOrg({
   await updateOrganization(organization.id, { pendingMembers });
 }
 
-export async function acceptInvite(key: string, userId: string) {
+export async function acceptInvite(key: string, userId: string, email: string) {
   const organization = await findOrganizationByInviteKey(key);
   if (!organization) {
     throw new Error("Invalid key");
@@ -706,6 +706,12 @@ export async function acceptInvite(key: string, userId: string) {
   const invite = organization.invites.filter((invite) => invite.key === key)[0];
   if (!invite) {
     throw new Error("Could not find invitation with that key");
+  }
+
+  // Ensure the invite was issued to the authenticated user's email; otherwise a
+  // leaked invite key would let any logged-in user join with the invited role.
+  if (!email || email.toLowerCase() !== invite.email.toLowerCase()) {
+    throw new Error("This invitation was sent to a different email address");
   }
 
   // Remove invite


### PR DESCRIPTION
### Features and Changes

`acceptInvite()` added the logged-in user to an org using only the invite key, without checking that their email matched `invite.email`. Any authenticated user who obtained a leaked invite key (forwarded email, referrer/proxy logs, shared screen) could accept it and join the org with the invited role, which defaults to `admin`. The auto-join path in `putMember` already enforced this match; the explicit accept-link path (`postInviteAccept`) did not.

Adds an `email` parameter to `acceptInvite` and rejects the request when it doesn't match the invite's email. Both callers pass `req.email` (the authenticated user's verified email).

### Testing

- [x] Invite `a@example.com`, accept while logged in as `a@example.com` → joins successfully
- [x] Invite `a@example.com`, accept while logged in as `b@example.com` → rejected with "This invitation was sent to a different email address"

Verified on a local dev server by hitting `POST /invite/accept` as a non-admin test user against an org holding one invite for that user's email and one for a different address: the mismatched key returned 400 with the new error message (invite left intact, no membership change); the matching key returned 200 and added the member with the invited role, consuming the invite.
