### PR TITLE
Require runQueries to create experiment snapshots via internal API

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -3251,6 +3251,10 @@ export async function postSnapshot(
     throw new Error("Could not find datasource for this experiment");
   }
 
+  if (!context.permissions.canCreateExperimentSnapshot(datasource)) {
+    context.permissions.throwPermissionError();
+  }
+
   const force = !!req.query["force"];
   if (
     dimension &&
@@ -3411,6 +3415,10 @@ export async function postBanditSnapshot(
   const datasource = await getDataSourceById(context, experiment.datasource);
   if (!datasource) {
     throw new Error("Could not find datasource for this experiment");
+  }
+
+  if (!context.permissions.canCreateExperimentSnapshot(datasource)) {
+    context.permissions.throwPermissionError();
   }
 
   // We wait until the snapshot is fully updated, which can


### PR DESCRIPTION
### Features and Changes

The internal endpoints `POST /experiment/:id/snapshot` and `POST /experiment/:id/banditSnapshot` ran warehouse queries after only read-level checks on the experiment and datasource, never verifying `canCreateExperimentSnapshot` (which requires `runQueries` on the datasource's projects). The external REST API already enforced this, so a read-only member could trigger snapshot query execution through the app that they'd be blocked from via the API. Adds the check to both internal handlers.

### Testing

- [x] As a member without `runQueries`, refresh experiment results / bandit snapshot → 403
- [x] As a member with `runQueries`, both still succeed

Verified on a local dev server against a running experiment. As a `collaborator`, both endpoints returned 403 ("You do not have permission to perform this action") with no snapshot record written. As an `experimenter`, `POST /snapshot` returned 200 with a new snapshot running its queries; `POST /banditSnapshot` got past the permission gate into query execution (the dev org has no bandit experiment, so it then failed on a pre-existing missing-BQ-table error rather than completing — the permission behavior is what changed here and is what was exercised).
