### PR TITLE
Fail fast on dashboard refresh to avoid orphan snapshot writes

### DIFF
--- a/packages/back-end/src/routers/dashboards/dashboards.controller.ts
+++ b/packages/back-end/src/routers/dashboards/dashboards.controller.ts
@@ -193,6 +193,10 @@ export async function refreshDashboardData(
     const datasource = await getDataSourceById(context, experiment.datasource);
     if (!datasource) throw new Error("Failed to find connected datasource");
 
+    if (!context.permissions.canCreateExperimentSnapshot(datasource)) {
+      context.permissions.throwPermissionError();
+    }
+
     const plannedExperimentMainSnapshot = await planExperimentSnapshot({
       context,
       experiment,
@@ -271,6 +275,9 @@ export async function refreshDashboardData(
       blocks: newBlocks,
     });
   } else {
+    if (!context.permissions.canCreateAnalyses(dashboard.projects)) {
+      context.permissions.throwPermissionError();
+    }
     await updateNonExperimentDashboard(context, dashboard);
   }
 

--- a/packages/back-end/src/routers/dashboards/dashboards.controller.ts
+++ b/packages/back-end/src/routers/dashboards/dashboards.controller.ts
@@ -193,6 +193,8 @@ export async function refreshDashboardData(
     const datasource = await getDataSourceById(context, experiment.datasource);
     if (!datasource) throw new Error("Failed to find connected datasource");
 
+    // Fail fast before createExperimentSnapshotModel persists an orphan snapshot
+    // record. The query runner enforces this same permission again downstream.
     if (!context.permissions.canCreateExperimentSnapshot(datasource)) {
       context.permissions.throwPermissionError();
     }
@@ -275,9 +277,6 @@ export async function refreshDashboardData(
       blocks: newBlocks,
     });
   } else {
-    if (!context.permissions.canCreateAnalyses(dashboard.projects)) {
-      context.permissions.throwPermissionError();
-    }
     await updateNonExperimentDashboard(context, dashboard);
   }
 


### PR DESCRIPTION
### Features and Changes

Adds a fail-fast `canCreateExperimentSnapshot(datasource)` check to `POST /dashboards/:id/refresh`. Datasource query permissions are already enforced downstream (every refresh query runs through a `QueryRunner` whose ctor checks `runQueries`/`runSqlExplorerQueries` on the block's own datasource; metric-analysis/exploration models gate `create()` on `canCreate`), so this isn't an auth-boundary fix. The one gap is that `createExperimentSnapshotModel` persists a snapshot record *before* the runner's check throws — so without this check a read-only user could repeatedly hit refresh and litter the DB with orphan `error` snapshots. The check mirrors the permission the runner enforces and fails before that write.

### Testing

- [x] As a read-only member, refresh a shared experiment dashboard → 403, and no new snapshot record is created
- [x] As a member with `runQueries` on the datasource → refresh succeeds as before

Verified on a local dev server with a dashboard holding an `experiment-metric` block, including a control run on `main` that reproduces the bug this fixes: on `main`, a `readonly` member's refresh returned 403 but persisted an orphan snapshot (`status: error`, `error: "You do not have permission to perform this action"`, 0 queries). On this branch the same request returned 403 with the snapshot count unchanged, and an `experimenter`'s refresh returned 200, created the snapshot, and rewired the block's `snapshotId` to it.
