### PR TITLE
Fix: enforce datasource project access on external dimension read APIs

### DIFF
--- a/packages/back-end/src/api/dimensions/deleteDimension.ts
+++ b/packages/back-end/src/api/dimensions/deleteDimension.ts
@@ -16,11 +16,11 @@ export const deleteDimension = createApiRequestHandler(
   const organization = req.organization.id;
   const dimension = await findDimensionById(req.params.id, organization);
 
-  if (
-    !dimension ||
-    !(await hasDimensionDatasourceAccess(req.context, dimension))
-  ) {
+  if (!dimension) {
     throw new Error("Could not find dimension with that id");
+  }
+  if (!(await hasDimensionDatasourceAccess(req.context, dimension))) {
+    throw new Error("You don't have access to this dimension");
   }
 
   await deleteDimensionById(req.context, dimension);

--- a/packages/back-end/src/api/dimensions/deleteDimension.ts
+++ b/packages/back-end/src/api/dimensions/deleteDimension.ts
@@ -2,6 +2,7 @@ import { deleteDimensionValidator } from "shared/validators";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import {
   findDimensionById,
+  hasDimensionDatasourceAccess,
   deleteDimensionById,
 } from "back-end/src/models/DimensionModel";
 
@@ -15,7 +16,10 @@ export const deleteDimension = createApiRequestHandler(
   const organization = req.organization.id;
   const dimension = await findDimensionById(req.params.id, organization);
 
-  if (!dimension) {
+  if (
+    !dimension ||
+    !(await hasDimensionDatasourceAccess(req.context, dimension))
+  ) {
     throw new Error("Could not find dimension with that id");
   }
 

--- a/packages/back-end/src/api/dimensions/getDimension.ts
+++ b/packages/back-end/src/api/dimensions/getDimension.ts
@@ -3,6 +3,7 @@ import {
   findDimensionById,
   toDimensionApiInterface,
 } from "back-end/src/models/DimensionModel";
+import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 import { resolveOwnerEmail } from "back-end/src/services/owner";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 
@@ -12,7 +13,12 @@ export const getDimension = createApiRequestHandler(getDimensionValidator)(
       req.params.id,
       req.organization.id,
     );
-    if (!dimension) {
+    // A dimension's project access is inherited from its datasource, which
+    // returns null when the caller lacks access to its projects.
+    if (
+      !dimension ||
+      !(await getDataSourceById(req.context, dimension.datasource))
+    ) {
       throw new Error("Could not find dimension with that id");
     }
 

--- a/packages/back-end/src/api/dimensions/getDimension.ts
+++ b/packages/back-end/src/api/dimensions/getDimension.ts
@@ -3,7 +3,10 @@ import {
   findDimensionById,
   toDimensionApiInterface,
 } from "back-end/src/models/DimensionModel";
-import { getDataSourceById } from "back-end/src/models/DataSourceModel";
+import {
+  getAllDatasourceIdsByOrganization,
+  getDataSourceById,
+} from "back-end/src/models/DataSourceModel";
 import { resolveOwnerEmail } from "back-end/src/services/owner";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 
@@ -13,11 +16,19 @@ export const getDimension = createApiRequestHandler(getDimensionValidator)(
       req.params.id,
       req.organization.id,
     );
-    // A dimension's project access is inherited from its datasource, which
-    // returns null when the caller lacks access to its projects.
+    if (!dimension) {
+      throw new Error("Could not find dimension with that id");
+    }
+
+    // A dimension inherits project access from its datasource. Hide it only when
+    // the datasource exists but is inaccessible; orphaned dimensions whose
+    // datasource no longer exists stay reachable.
     if (
-      !dimension ||
-      !(await getDataSourceById(req.context, dimension.datasource))
+      dimension.datasource &&
+      !(await getDataSourceById(req.context, dimension.datasource)) &&
+      (await getAllDatasourceIdsByOrganization(req.context)).has(
+        dimension.datasource,
+      )
     ) {
       throw new Error("Could not find dimension with that id");
     }

--- a/packages/back-end/src/api/dimensions/getDimension.ts
+++ b/packages/back-end/src/api/dimensions/getDimension.ts
@@ -1,12 +1,9 @@
 import { getDimensionValidator } from "shared/validators";
 import {
   findDimensionById,
+  hasDimensionDatasourceAccess,
   toDimensionApiInterface,
 } from "back-end/src/models/DimensionModel";
-import {
-  getAllDatasourceIdsByOrganization,
-  getDataSourceById,
-} from "back-end/src/models/DataSourceModel";
 import { resolveOwnerEmail } from "back-end/src/services/owner";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 
@@ -16,19 +13,9 @@ export const getDimension = createApiRequestHandler(getDimensionValidator)(
       req.params.id,
       req.organization.id,
     );
-    if (!dimension) {
-      throw new Error("Could not find dimension with that id");
-    }
-
-    // A dimension inherits project access from its datasource. Hide it only when
-    // the datasource exists but is inaccessible; orphaned dimensions whose
-    // datasource no longer exists stay reachable.
     if (
-      dimension.datasource &&
-      !(await getDataSourceById(req.context, dimension.datasource)) &&
-      (await getAllDatasourceIdsByOrganization(req.context)).has(
-        dimension.datasource,
-      )
+      !dimension ||
+      !(await hasDimensionDatasourceAccess(req.context, dimension))
     ) {
       throw new Error("Could not find dimension with that id");
     }

--- a/packages/back-end/src/api/dimensions/listDimensions.ts
+++ b/packages/back-end/src/api/dimensions/listDimensions.ts
@@ -3,10 +3,7 @@ import {
   findDimensionsByOrganization,
   toDimensionApiInterface,
 } from "back-end/src/models/DimensionModel";
-import {
-  getAllDatasourceIdsByOrganization,
-  getDataSourcesByOrganization,
-} from "back-end/src/models/DataSourceModel";
+import { getDataSourcesByOrganization } from "back-end/src/models/DataSourceModel";
 import { resolveOwnerEmails } from "back-end/src/services/owner";
 import {
   applyFilter,
@@ -18,24 +15,16 @@ export const listDimensions = createApiRequestHandler(listDimensionsValidator)(
   async (req) => {
     const dimensions = await findDimensionsByOrganization(req.organization.id);
 
-    // A dimension inherits project access from its datasource. Drop it only when
-    // the datasource exists but is inaccessible; orphaned dimensions whose
-    // datasource no longer exists stay in the list.
+    // A dimension inherits project access from its datasource, so drop any whose
+    // datasource is inaccessible or no longer exists.
     const readableDatasourceIds = new Set(
       (await getDataSourcesByOrganization(req.context)).map((ds) => ds.id),
-    );
-    const allDatasourceIds = await getAllDatasourceIdsByOrganization(
-      req.context,
     );
 
     // TODO: Move sorting/limiting to the database query for better performance
     const { filtered, returnFields } = applyPagination(
       dimensions
-        .filter(
-          (dimension) =>
-            readableDatasourceIds.has(dimension.datasource) ||
-            !allDatasourceIds.has(dimension.datasource),
-        )
+        .filter((dimension) => readableDatasourceIds.has(dimension.datasource))
         .filter((dimension) =>
           applyFilter(req.query.datasourceId, dimension.datasource),
         )

--- a/packages/back-end/src/api/dimensions/listDimensions.ts
+++ b/packages/back-end/src/api/dimensions/listDimensions.ts
@@ -3,7 +3,10 @@ import {
   findDimensionsByOrganization,
   toDimensionApiInterface,
 } from "back-end/src/models/DimensionModel";
-import { getDataSourcesByOrganization } from "back-end/src/models/DataSourceModel";
+import {
+  getAllDatasourceIdsByOrganization,
+  getDataSourcesByOrganization,
+} from "back-end/src/models/DataSourceModel";
 import { resolveOwnerEmails } from "back-end/src/services/owner";
 import {
   applyFilter,
@@ -15,16 +18,24 @@ export const listDimensions = createApiRequestHandler(listDimensionsValidator)(
   async (req) => {
     const dimensions = await findDimensionsByOrganization(req.organization.id);
 
-    // A dimension's project access is inherited from its datasource, so restrict
-    // to datasources the caller can read (already filtered by project access).
+    // A dimension inherits project access from its datasource. Drop it only when
+    // the datasource exists but is inaccessible; orphaned dimensions whose
+    // datasource no longer exists stay in the list.
     const readableDatasourceIds = new Set(
       (await getDataSourcesByOrganization(req.context)).map((ds) => ds.id),
+    );
+    const allDatasourceIds = await getAllDatasourceIdsByOrganization(
+      req.context,
     );
 
     // TODO: Move sorting/limiting to the database query for better performance
     const { filtered, returnFields } = applyPagination(
       dimensions
-        .filter((dimension) => readableDatasourceIds.has(dimension.datasource))
+        .filter(
+          (dimension) =>
+            readableDatasourceIds.has(dimension.datasource) ||
+            !allDatasourceIds.has(dimension.datasource),
+        )
         .filter((dimension) =>
           applyFilter(req.query.datasourceId, dimension.datasource),
         )

--- a/packages/back-end/src/api/dimensions/listDimensions.ts
+++ b/packages/back-end/src/api/dimensions/listDimensions.ts
@@ -3,6 +3,7 @@ import {
   findDimensionsByOrganization,
   toDimensionApiInterface,
 } from "back-end/src/models/DimensionModel";
+import { getDataSourcesByOrganization } from "back-end/src/models/DataSourceModel";
 import { resolveOwnerEmails } from "back-end/src/services/owner";
 import {
   applyFilter,
@@ -14,9 +15,16 @@ export const listDimensions = createApiRequestHandler(listDimensionsValidator)(
   async (req) => {
     const dimensions = await findDimensionsByOrganization(req.organization.id);
 
+    // A dimension's project access is inherited from its datasource, so restrict
+    // to datasources the caller can read (already filtered by project access).
+    const readableDatasourceIds = new Set(
+      (await getDataSourcesByOrganization(req.context)).map((ds) => ds.id),
+    );
+
     // TODO: Move sorting/limiting to the database query for better performance
     const { filtered, returnFields } = applyPagination(
       dimensions
+        .filter((dimension) => readableDatasourceIds.has(dimension.datasource))
         .filter((dimension) =>
           applyFilter(req.query.datasourceId, dimension.datasource),
         )

--- a/packages/back-end/src/api/dimensions/updateDimension.ts
+++ b/packages/back-end/src/api/dimensions/updateDimension.ts
@@ -23,11 +23,11 @@ export const updateDimension = createApiRequestHandler(
   const organization = req.organization.id;
   const dimension = await findDimensionById(req.params.id, organization);
 
-  if (
-    !dimension ||
-    !(await hasDimensionDatasourceAccess(req.context, dimension))
-  ) {
+  if (!dimension) {
     throw new Error("Could not find dimension with that id");
+  }
+  if (!(await hasDimensionDatasourceAccess(req.context, dimension))) {
+    throw new Error("You don't have access to this dimension");
   }
   if (req.body.datasourceId) {
     const datasourceDoc = await getDataSourceById(

--- a/packages/back-end/src/api/dimensions/updateDimension.ts
+++ b/packages/back-end/src/api/dimensions/updateDimension.ts
@@ -7,6 +7,7 @@ import {
 } from "back-end/src/services/owner";
 import {
   findDimensionById,
+  hasDimensionDatasourceAccess,
   updateDimension as updateDimensionModel,
   toDimensionApiInterface,
 } from "back-end/src/models/DimensionModel";
@@ -22,7 +23,10 @@ export const updateDimension = createApiRequestHandler(
   const organization = req.organization.id;
   const dimension = await findDimensionById(req.params.id, organization);
 
-  if (!dimension) {
+  if (
+    !dimension ||
+    !(await hasDimensionDatasourceAccess(req.context, dimension))
+  ) {
     throw new Error("Could not find dimension with that id");
   }
   if (req.body.datasourceId) {

--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -125,23 +125,6 @@ export async function getDataSourcesByOrganization(
   );
 }
 
-// Returns the ids of every datasource in the org, ignoring project access.
-// Used to distinguish an inaccessible datasource from a deleted one.
-export async function getAllDatasourceIdsByOrganization(
-  context: ReqContext | ApiReqContext,
-): Promise<Set<string>> {
-  if (usingFileConfig()) {
-    return new Set(getConfigDatasources(context.org.id).map((ds) => ds.id));
-  }
-
-  const docs: DataSourceDocument[] = await DataSourceModel.find(
-    { organization: context.org.id },
-    { id: 1 },
-  );
-
-  return new Set(docs.map((doc) => doc.id));
-}
-
 // WARNING: This does not restrict by organization
 export async function _dangerourslyGetAllDatasourcesByOrganizations(
   organizations: string[],

--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -125,6 +125,23 @@ export async function getDataSourcesByOrganization(
   );
 }
 
+// Returns the ids of every datasource in the org, ignoring project access.
+// Used to distinguish an inaccessible datasource from a deleted one.
+export async function getAllDatasourceIdsByOrganization(
+  context: ReqContext | ApiReqContext,
+): Promise<Set<string>> {
+  if (usingFileConfig()) {
+    return new Set(getConfigDatasources(context.org.id).map((ds) => ds.id));
+  }
+
+  const docs: DataSourceDocument[] = await DataSourceModel.find(
+    { organization: context.org.id },
+    { id: 1 },
+  );
+
+  return new Set(docs.map((doc) => doc.id));
+}
+
 // WARNING: This does not restrict by organization
 export async function _dangerourslyGetAllDatasourcesByOrganizations(
   organizations: string[],

--- a/packages/back-end/src/models/DimensionModel.ts
+++ b/packages/back-end/src/models/DimensionModel.ts
@@ -5,10 +5,7 @@ import { getConfigDimensions, usingFileConfig } from "back-end/src/init/config";
 import { ApiReqContext } from "back-end/types/api";
 import { ReqContext } from "back-end/types/request";
 import { ALLOW_CREATE_DIMENSIONS } from "back-end/src/util/secrets";
-import {
-  getAllDatasourceIdsByOrganization,
-  getDataSourceById,
-} from "back-end/src/models/DataSourceModel";
+import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 
 const dimensionSchema = new mongoose.Schema({
   id: String,
@@ -111,18 +108,14 @@ export async function findDimensionById(id: string, organization: string) {
   return doc ? toInterface(doc) : null;
 }
 
-// A dimension inherits project access from its datasource. Access is granted
-// when the datasource is readable, or when it no longer exists (an orphaned
-// dimension has no project boundary to enforce). Only a datasource that exists
-// but is inaccessible blocks access.
+// A dimension inherits project access from its datasource, so access is granted
+// only when that datasource is readable. A dimension whose datasource is
+// inaccessible or no longer exists is treated as not found.
 export async function hasDimensionDatasourceAccess(
   context: ReqContext | ApiReqContext,
   dimension: DimensionInterface,
 ): Promise<boolean> {
-  if (!dimension.datasource) return true;
-  if (await getDataSourceById(context, dimension.datasource)) return true;
-  const datasourceIds = await getAllDatasourceIdsByOrganization(context);
-  return !datasourceIds.has(dimension.datasource);
+  return !!(await getDataSourceById(context, dimension.datasource));
 }
 
 export async function findDimensionsByDataSource(

--- a/packages/back-end/src/models/DimensionModel.ts
+++ b/packages/back-end/src/models/DimensionModel.ts
@@ -5,6 +5,10 @@ import { getConfigDimensions, usingFileConfig } from "back-end/src/init/config";
 import { ApiReqContext } from "back-end/types/api";
 import { ReqContext } from "back-end/types/request";
 import { ALLOW_CREATE_DIMENSIONS } from "back-end/src/util/secrets";
+import {
+  getAllDatasourceIdsByOrganization,
+  getDataSourceById,
+} from "back-end/src/models/DataSourceModel";
 
 const dimensionSchema = new mongoose.Schema({
   id: String,
@@ -105,6 +109,20 @@ export async function findDimensionById(id: string, organization: string) {
   const doc = await DimensionModel.findOne({ id, organization });
 
   return doc ? toInterface(doc) : null;
+}
+
+// A dimension inherits project access from its datasource. Access is granted
+// when the datasource is readable, or when it no longer exists (an orphaned
+// dimension has no project boundary to enforce). Only a datasource that exists
+// but is inaccessible blocks access.
+export async function hasDimensionDatasourceAccess(
+  context: ReqContext | ApiReqContext,
+  dimension: DimensionInterface,
+): Promise<boolean> {
+  if (!dimension.datasource) return true;
+  if (await getDataSourceById(context, dimension.datasource)) return true;
+  const datasourceIds = await getAllDatasourceIdsByOrganization(context);
+  return !datasourceIds.has(dimension.datasource);
 }
 
 export async function findDimensionsByDataSource(

--- a/packages/back-end/src/routers/dimension/dimension.controller.ts
+++ b/packages/back-end/src/routers/dimension/dimension.controller.ts
@@ -152,8 +152,11 @@ export const putDimension = async (
   const { id } = req.params;
   const dimension = await findDimensionById(id, org.id);
 
-  if (!dimension || !(await hasDimensionDatasourceAccess(context, dimension))) {
+  if (!dimension) {
     throw new Error("Could not find dimension");
+  }
+  if (!(await hasDimensionDatasourceAccess(context, dimension))) {
+    throw new Error("You don't have access to this dimension");
   }
 
   const { datasource, name, sql, userIdType, owner, description } = req.body;
@@ -207,8 +210,11 @@ export const deleteDimension = async (
   const { org } = context;
   const dimension = await findDimensionById(id, org.id);
 
-  if (!dimension || !(await hasDimensionDatasourceAccess(context, dimension))) {
+  if (!dimension) {
     throw new Error("Could not find dimension");
+  }
+  if (!(await hasDimensionDatasourceAccess(context, dimension))) {
+    throw new Error("You don't have access to this dimension");
   }
   try {
     await deleteDimensionById(context, dimension);

--- a/packages/back-end/src/routers/dimension/dimension.controller.ts
+++ b/packages/back-end/src/routers/dimension/dimension.controller.ts
@@ -13,7 +13,6 @@ import {
   updateDimension,
 } from "back-end/src/models/DimensionModel";
 import {
-  getAllDatasourceIdsByOrganization,
   getDataSourceById,
   getDataSourcesByOrganization,
 } from "back-end/src/models/DataSourceModel";
@@ -40,20 +39,16 @@ export const getDimensions = async (
   const context = getContextFromReq(req);
   const dimensions = await findDimensionsByOrganization(context.org.id);
 
-  // A dimension inherits project access from its datasource. Drop it only when
-  // the datasource exists but is inaccessible; orphaned dimensions whose
-  // datasource no longer exists stay in the list.
+  // A dimension inherits project access from its datasource, so drop any whose
+  // datasource is inaccessible or no longer exists.
   const readableDatasourceIds = new Set(
     (await getDataSourcesByOrganization(context)).map((ds) => ds.id),
   );
-  const allDatasourceIds = await getAllDatasourceIdsByOrganization(context);
 
   res.status(200).json({
     status: 200,
-    dimensions: dimensions.filter(
-      (dimension) =>
-        readableDatasourceIds.has(dimension.datasource) ||
-        !allDatasourceIds.has(dimension.datasource),
+    dimensions: dimensions.filter((dimension) =>
+      readableDatasourceIds.has(dimension.datasource),
     ),
   });
 };

--- a/packages/back-end/src/routers/dimension/dimension.controller.ts
+++ b/packages/back-end/src/routers/dimension/dimension.controller.ts
@@ -12,6 +12,7 @@ import {
   updateDimension,
 } from "back-end/src/models/DimensionModel";
 import {
+  getAllDatasourceIdsByOrganization,
   getDataSourceById,
   getDataSourcesByOrganization,
 } from "back-end/src/models/DataSourceModel";
@@ -38,16 +39,20 @@ export const getDimensions = async (
   const context = getContextFromReq(req);
   const dimensions = await findDimensionsByOrganization(context.org.id);
 
-  // A dimension's project access is inherited from its datasource, so restrict
-  // to datasources the caller can read (already filtered by project access).
+  // A dimension inherits project access from its datasource. Drop it only when
+  // the datasource exists but is inaccessible; orphaned dimensions whose
+  // datasource no longer exists stay in the list.
   const readableDatasourceIds = new Set(
     (await getDataSourcesByOrganization(context)).map((ds) => ds.id),
   );
+  const allDatasourceIds = await getAllDatasourceIdsByOrganization(context);
 
   res.status(200).json({
     status: 200,
-    dimensions: dimensions.filter((dimension) =>
-      readableDatasourceIds.has(dimension.datasource),
+    dimensions: dimensions.filter(
+      (dimension) =>
+        readableDatasourceIds.has(dimension.datasource) ||
+        !allDatasourceIds.has(dimension.datasource),
     ),
   });
 };

--- a/packages/back-end/src/routers/dimension/dimension.controller.ts
+++ b/packages/back-end/src/routers/dimension/dimension.controller.ts
@@ -9,6 +9,7 @@ import {
   deleteDimensionById,
   findDimensionById,
   findDimensionsByOrganization,
+  hasDimensionDatasourceAccess,
   updateDimension,
 } from "back-end/src/models/DimensionModel";
 import {
@@ -156,7 +157,7 @@ export const putDimension = async (
   const { id } = req.params;
   const dimension = await findDimensionById(id, org.id);
 
-  if (!dimension) {
+  if (!dimension || !(await hasDimensionDatasourceAccess(context, dimension))) {
     throw new Error("Could not find dimension");
   }
 
@@ -211,7 +212,7 @@ export const deleteDimension = async (
   const { org } = context;
   const dimension = await findDimensionById(id, org.id);
 
-  if (!dimension) {
+  if (!dimension || !(await hasDimensionDatasourceAccess(context, dimension))) {
     throw new Error("Could not find dimension");
   }
   try {

--- a/packages/back-end/src/routers/dimension/dimension.controller.ts
+++ b/packages/back-end/src/routers/dimension/dimension.controller.ts
@@ -11,7 +11,10 @@ import {
   findDimensionsByOrganization,
   updateDimension,
 } from "back-end/src/models/DimensionModel";
-import { getDataSourceById } from "back-end/src/models/DataSourceModel";
+import {
+  getDataSourceById,
+  getDataSourcesByOrganization,
+} from "back-end/src/models/DataSourceModel";
 
 // region GET /dimensions
 
@@ -32,11 +35,20 @@ export const getDimensions = async (
   req: GetDimensionsRequest,
   res: Response<GetDimensionsResponse | PrivateApiErrorResponse>,
 ) => {
-  const { org } = getContextFromReq(req);
-  const dimensions = await findDimensionsByOrganization(org.id);
+  const context = getContextFromReq(req);
+  const dimensions = await findDimensionsByOrganization(context.org.id);
+
+  // A dimension's project access is inherited from its datasource, so restrict
+  // to datasources the caller can read (already filtered by project access).
+  const readableDatasourceIds = new Set(
+    (await getDataSourcesByOrganization(context)).map((ds) => ds.id),
+  );
+
   res.status(200).json({
     status: 200,
-    dimensions,
+    dimensions: dimensions.filter((dimension) =>
+      readableDatasourceIds.has(dimension.datasource),
+    ),
   });
 };
 

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -86,10 +86,7 @@ import {
   sendPendingMemberApprovalEmail,
   sendOwnerEmailChangeEmail,
 } from "back-end/src/services/email";
-import {
-  getAllDatasourceIdsByOrganization,
-  getDataSourcesByOrganization,
-} from "back-end/src/models/DataSourceModel";
+import { getDataSourcesByOrganization } from "back-end/src/models/DataSourceModel";
 import { getMetricsForDefinitions } from "back-end/src/models/MetricModel";
 import {
   createOrganization,
@@ -203,15 +200,11 @@ export async function getDefinitions(req: AuthRequest, res: Response) {
     context.models.webhookSecrets.getAllForFrontEnd(),
   ]);
 
-  // A dimension inherits project access from its datasource. Drop it only when
-  // the datasource exists but is inaccessible; orphaned dimensions whose
-  // datasource no longer exists stay in the list.
+  // A dimension inherits project access from its datasource, so drop any whose
+  // datasource is inaccessible or no longer exists.
   const readableDatasourceIds = new Set(datasources.map((ds) => ds.id));
-  const allDatasourceIds = await getAllDatasourceIdsByOrganization(context);
-  const visibleDimensions = dimensions.filter(
-    (dimension) =>
-      readableDatasourceIds.has(dimension.datasource) ||
-      !allDatasourceIds.has(dimension.datasource),
+  const visibleDimensions = dimensions.filter((dimension) =>
+    readableDatasourceIds.has(dimension.datasource),
   );
 
   return res.status(200).json({

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -86,7 +86,10 @@ import {
   sendPendingMemberApprovalEmail,
   sendOwnerEmailChangeEmail,
 } from "back-end/src/services/email";
-import { getDataSourcesByOrganization } from "back-end/src/models/DataSourceModel";
+import {
+  getAllDatasourceIdsByOrganization,
+  getDataSourcesByOrganization,
+} from "back-end/src/models/DataSourceModel";
 import { getMetricsForDefinitions } from "back-end/src/models/MetricModel";
 import {
   createOrganization,
@@ -200,11 +203,22 @@ export async function getDefinitions(req: AuthRequest, res: Response) {
     context.models.webhookSecrets.getAllForFrontEnd(),
   ]);
 
+  // A dimension inherits project access from its datasource. Drop it only when
+  // the datasource exists but is inaccessible; orphaned dimensions whose
+  // datasource no longer exists stay in the list.
+  const readableDatasourceIds = new Set(datasources.map((ds) => ds.id));
+  const allDatasourceIds = await getAllDatasourceIdsByOrganization(context);
+  const visibleDimensions = dimensions.filter(
+    (dimension) =>
+      readableDatasourceIds.has(dimension.datasource) ||
+      !allDatasourceIds.has(dimension.datasource),
+  );
+
   return res.status(200).json({
     status: 200,
     metrics,
     datasources,
-    dimensions,
+    dimensions: visibleDimensions,
     segments,
     metricGroups,
     tags,


### PR DESCRIPTION
### Features and Changes

Dimensions were scoped by organization only across their read and write surfaces. A dimension has no `projects` field of its own — its project access is inherited from the parent datasource, and dimension permissions (`createDimensions`) are global — so a caller restricted to a subset of projects could read dimension SQL from, and mutate, dimensions tied to datasources in projects they were excluded from. This affected the external REST API (reachable by a project-restricted API key) and the internal endpoints.

Access is now enforced from the parent datasource everywhere, mirroring how metrics and segments already gate project access:

- **Read** — `hasDimensionDatasourceAccess` (new helper) gates `GET /api/v1/dimensions/:id`, and the list endpoints (`GET /api/v1/dimensions`, internal `GET /dimensions`) and the internal `/definitions` endpoint filter dimensions to accessible datasources. In `/definitions`, dimensions were previously the only definition type returned unfiltered alongside already-scoped metrics/datasources/segments.
- **Write** — update and delete (external API + internal controller) now verify access to the dimension's existing datasource before mutating. Previously they ran only the global `createDimensions` permission, letting a restricted caller edit or delete dimensions in projects they couldn't access. Create paths already validate the target datasource.
- **Orphaned dimensions** — a dimension whose datasource is inaccessible *or no longer exists* is treated as not found across all these endpoints. Deleting a datasource soft-deletes its dimensions, so an orphaned dimension is legacy-only; rather than special-case it, access is gated purely on datasource readability (`getDataSourceById`, which returns null for both an access-denied and a deleted datasource). Orphans therefore become invisible and unmanageable through these endpoints for every caller — the intended behavior per review.

### Testing

- [x] Caller restricted to Project A, dimension's datasource in Project B → `GET /api/v1/dimensions/:id` returns "Could not find dimension with that id"; `PUT`/`DELETE` likewise rejected
- [x] Same caller → `GET /api/v1/dimensions`, internal `GET /dimensions`, and `/definitions` all omit Project B dimensions
- [x] Unrestricted caller → all read endpoints return every dimension as before
- [x] Dimension whose datasource was deleted → omitted from the list endpoints and GET-by-id (treated as not found)

Verified on a local dev server using a PAT for a member restricted to Project A (`noaccess` global + project role on A) against a dimension whose datasource sat in Project B, plus a control run on `main` confirming the leak this closes: on `main`, the restricted PAT's `GET /api/v1/dimensions/:id` returned the Project B dimension including its SQL; on this branch the same call returns "Could not find dimension with that id", and the dimension disappears from `GET /api/v1/dimensions`, internal `GET /dimensions`, and `/definitions` for that caller. Update/delete as the restricted caller were rejected (403 from the global `createDimensions` check, which runs ahead of the new datasource gate). An unrestricted PAT saw all dimensions on every read endpoint and could update the Project B dimension.
