### PR TITLE
refactor(ui): remove orange "attention" Callout status

### DIFF
--- a/packages/front-end/components/Features/Rule.tsx
+++ b/packages/front-end/components/Features/Rule.tsx
@@ -1369,7 +1369,7 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
             rampSchedule.steps[rampSchedule.currentStepIndex]
               ?.approvalNotes && (
               <Callout
-                status="attention"
+                status="warning"
                 mt="3"
                 size="sm"
                 icon={<PiSpinnerGapBold />}
@@ -1838,8 +1838,8 @@ export function getRuleMetaInfo({
   ));
 
   // The status badge is derived from the same banners as the callouts, so its
-  // colour + icon always mirror the callout: orange/octagon for unreachable,
-  // amber/triangle for a softer "may not reach" conflict.
+  // colour + icon always mirror the callout: an amber/triangle warning for
+  // both unreachable and softer "may not reach" conflicts.
   const conflictBadge = getConflictBadge(conflictBanners);
   const conflictPill = conflictBadge ? (
     <Badge

--- a/packages/front-end/components/Features/RuleCard.tsx
+++ b/packages/front-end/components/Features/RuleCard.tsx
@@ -19,7 +19,7 @@ const sideColorVar: Record<RuleCardSideColor, string> = {
   active: "var(--green-9)",
   skipped: "var(--amber-7)",
   disabled: "var(--gray-5)",
-  unreachable: "var(--orange-7)",
+  unreachable: "var(--amber-7)",
   removed: "var(--red-7)",
 };
 

--- a/packages/front-end/services/rule-conflicts.tsx
+++ b/packages/front-end/services/rule-conflicts.tsx
@@ -6,7 +6,7 @@ import { paddedVersionString } from "@growthbook/growthbook";
 import Callout from "@/ui/Callout";
 import Link from "@/ui/Link";
 import Text from "@/ui/Text";
-import { getRadixColor, RadixColor, RadixStatusIcon } from "@/ui/HelperText";
+import { RadixColor, RadixStatusIcon } from "@/ui/HelperText";
 import { getUpcomingScheduleRule } from "@/services/scheduleRules";
 import { isRuleInactive } from "@/services/features";
 
@@ -1470,8 +1470,8 @@ function joinEnvNames(names: string[]): ReactElement {
 
 // The status badge for a rule's conflicts, mirroring the colour + icon of the
 // callout it summarizes so the top-right pill and the detail banner can never
-// disagree. Unreachable is the strongest tier (orange + the error/octagon icon);
-// any lesser conflict ("will not reach" / "may not reach") is an amber warning.
+// disagree. Both unreachable and lesser conflicts render as an amber warning;
+// only the label differs ("Unreachable" vs "Conflict").
 // Returns null when the rule has no conflicts (no badge).
 export type ConflictBadge = {
   color: RadixColor;
@@ -1484,21 +1484,14 @@ export function getConflictBadge(
   banners: ConflictBanner[] | undefined,
 ): ConflictBadge | null {
   if (!banners?.length) return null;
-  if (banners.some((b) => b.isUnreachable)) {
-    return {
-      // Sourced from the "attention" status so the badge and the
-      // ConflictCallout always share the same orange + octagon icon.
-      color: getRadixColor("attention"),
-      icon: <RadixStatusIcon status="attention" size="sm" />,
-      label: "Unreachable",
-      title: "No matching traffic will reach this rule",
-    };
-  }
+  const isUnreachable = banners.some((b) => b.isUnreachable);
   return {
     color: "amber",
     icon: <RadixStatusIcon status="warning" size="sm" />,
-    label: "Conflict",
-    title: "Some matching traffic may not reach this rule",
+    label: isUnreachable ? "Unreachable" : "Conflict",
+    title: isUnreachable
+      ? "No matching traffic will reach this rule"
+      : "Some matching traffic may not reach this rule",
   };
 }
 
@@ -1537,12 +1530,10 @@ export function ConflictCallout({
     </span>
   );
   const hasDetails = hasHard || hasSoft;
-  // Unreachable uses the orange "attention" status (orange + the error octagon
-  // icon + alert role) so the banner matches its status badge; lesser conflicts
-  // stay amber "warning".
-  const status = isUnreachable ? "attention" : "warning";
+  // Both conflict tiers render as an amber warning: a prompt to confirm the
+  // rule order is intentional, not a hard error.
   return (
-    <Callout status={status} size="sm">
+    <Callout status="warning" size="sm">
       <Flex direction="column" gap="1">
         <Flex align="center" gap="2" wrap="wrap">
           {headline}

--- a/packages/front-end/ui/Callout.tsx
+++ b/packages/front-end/ui/Callout.tsx
@@ -88,10 +88,7 @@ export default forwardRef<
       ref={ref}
       className={styles.callout}
       color={getRadixColor(status)}
-      role={
-        role ??
-        (status === "error" || status === "attention" ? "alert" : undefined)
-      }
+      role={role ?? (status === "error" ? "alert" : undefined)}
       size={getRadixSize(size)}
       {...containerProps}
       style={

--- a/packages/front-end/ui/HelperText.tsx
+++ b/packages/front-end/ui/HelperText.tsx
@@ -10,18 +10,7 @@ import {
 import { MarginProps } from "@radix-ui/themes/dist/esm/props/margin.props.js";
 import { Responsive } from "@radix-ui/themes/dist/esm/props/prop-def.js";
 
-// "attention" is an orange severity tier between "warning" (amber) and "error"
-// (red). It defaults to the error octagon icon and gets role="alert", but is
-// recolored orange, for banners that should stand out more than a warning without
-// reading as a hard error. Used by the rule-conflict "unreachable" banner and the
-// rule approval-notes banner.
-export type Status =
-  | "wizard"
-  | "info"
-  | "warning"
-  | "error"
-  | "success"
-  | "attention";
+export type Status = "wizard" | "info" | "warning" | "error" | "success";
 export type RadixColor = TextProps["color"];
 export type Size = "sm" | "md";
 
@@ -37,8 +26,6 @@ export function getRadixColor(status: Status): TextProps["color"] {
       return "red";
     case "success":
       return "green";
-    case "attention":
-      return "orange";
   }
 }
 
@@ -78,10 +65,6 @@ export function RadixStatusIcon({
       return <PiWarningOctagonFill size={getIconSize(size)} />;
     case "success":
       return <PiCheckCircleFill size={getIconSize(size)} />;
-    // Shares the error octagon: attention is error-shaped severity, only the
-    // color differs (and callers can override the icon, e.g. a spinner).
-    case "attention":
-      return <PiWarningOctagonFill size={getIconSize(size)} />;
   }
 }
 


### PR DESCRIPTION
### Features and Changes

Removes the orange "attention" `Callout` status.

The two callers move to the standard statuses:

- The rule-conflict "unreachable" badge and banner now use `warning`
- The rule approval-notes banner now uses `warning`

### Screenshots

| Before | After |
|--------|--------|
| <img width="3024" height="1602" alt="1- before-approval-notes" src="https://github.com/user-attachments/assets/a3aeabc2-fec9-4b45-9feb-784a77d304bf" /> | <img width="3024" height="1602" alt="2-after-approval-notes" src="https://github.com/user-attachments/assets/2526dd45-a2d9-478a-a1d3-293375483afd" /> |
| <img width="3024" height="1602" alt="3-before-unreachable" src="https://github.com/user-attachments/assets/7c54eeb4-2833-4f44-8f07-78d7a0653267" /> | <img width="3024" height="1602" alt="4-after-unreachable" src="https://github.com/user-attachments/assets/8cc93b1e-bc31-4785-881f-8f5eb92fa3f2" /> | 
