### PR TITLE
Add EF Form Validation

### DIFF
--- a/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
@@ -179,6 +179,12 @@ function getEventForwarderDraft(
   return null;
 }
 
+// Only validates what the browser's native `required` validation can't cover:
+// read-only/derived fields (Snowflake access URL), datasource connection params
+// that aren't inputs in this modal (account/username/auth method), and table
+// prefix *format*. Empty visible required fields (BigQuery project/dataset,
+// Snowflake database/schema) are handled by native `required` on the inputs, so
+// don't re-check them here — that would duplicate the per-field tooltip.
 function getEventForwarderValidationErrors(
   draft: EventForwarderDatasourceDraft,
 ): string[] {
@@ -188,8 +194,6 @@ function getEventForwarderValidationErrors(
   const errors: string[] = [];
 
   if (cfg.sinkType === "bigquery") {
-    if (!cfg.config.projectId.trim()) errors.push("Enter a BigQuery project.");
-    if (!cfg.config.dataset.trim()) errors.push("Enter a BigQuery dataset.");
     try {
       normalizeBigQueryTablePrefixForEventForwarder(cfg.config.tablePrefix);
     } catch (e) {
@@ -203,8 +207,6 @@ function getEventForwarderValidationErrors(
   if (cfg.sinkType === "snowflake") {
     const p = rawParams as Partial<SnowflakeConnectionParams>;
     const authMethod = p.authMethod ?? "password";
-    if (!cfg.config.database.trim()) errors.push("Enter a Snowflake database.");
-    if (!cfg.config.schema.trim()) errors.push("Enter a Snowflake schema.");
     if (!cfg.config.accessUrl?.trim())
       errors.push("Enter a Snowflake access URL.");
     if (!p.account?.trim()) errors.push("Enter a Snowflake account.");

--- a/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
@@ -17,8 +17,7 @@ import { BigQueryConnectionParams } from "shared/types/integrations/bigquery";
 import { SnowflakeConnectionParams } from "shared/types/integrations/snowflake";
 import { Box, Card, Flex } from "@radix-ui/themes";
 import { useFeatureValue } from "@growthbook/growthbook-react";
-import { FaChevronRight } from "react-icons/fa";
-import { PiPause, PiPencilSimple, PiPlay } from "react-icons/pi";
+import { PiCaretRight, PiPause, PiPencilSimple, PiPlay } from "react-icons/pi";
 import { useAuth } from "@/services/auth";
 import { useUser } from "@/services/UserContext";
 import PremiumCallout from "@/ui/PremiumCallout";
@@ -283,7 +282,7 @@ function EventForwarderConfirmButton({
         type="submit"
         disabled={!usEventForwarderFlowConsent}
         loading={loading}
-        icon={<FaChevronRight size={12} />}
+        icon={<PiCaretRight size={12} />}
         iconPosition="right"
       >
         Confirm
@@ -318,7 +317,6 @@ function EventForwarderModal({
   const isEditingEventForwarder = !!dataSource.eventForwarderConfig;
   const [usEventForwarderFlowConsent, setUsEventForwarderFlowConsent] =
     useState(isEditingEventForwarder);
-
   const setEventForwarderConfig = (
     eventForwarderConfig: EventForwarderConfigDraft | null,
   ) => {
@@ -366,7 +364,8 @@ function EventForwarderModal({
             const validationErrors =
               getEventForwarderValidationErrors(datasourceDraft);
             if (validationErrors.length) {
-              throw new Error(validationErrors.join(" "));
+              // ErrorDisplay renders with pre-wrap, so each error gets a line.
+              throw new Error(validationErrors.join("\n"));
             }
             // Unreachable once validation passes (a null config yields an
             // error above); the throw narrows the type for the request body.

--- a/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
@@ -179,41 +179,50 @@ function getEventForwarderDraft(
   return null;
 }
 
-function getCanConfirmEventForwarder(
+function getEventForwarderValidationErrors(
   draft: EventForwarderDatasourceDraft,
-): boolean {
+): string[] {
   const cfg = draft.eventForwarderConfig;
-  if (!cfg) return false;
+  if (!cfg) return ["Event forwarder configuration is missing."];
   const rawParams = draft.params || {};
+  const errors: string[] = [];
+
   if (cfg.sinkType === "bigquery") {
+    if (!cfg.config.projectId.trim()) errors.push("Enter a BigQuery project.");
+    if (!cfg.config.dataset.trim()) errors.push("Enter a BigQuery dataset.");
     try {
       normalizeBigQueryTablePrefixForEventForwarder(cfg.config.tablePrefix);
-      return !!cfg.config.projectId.trim() && !!cfg.config.dataset.trim();
-    } catch {
-      return false;
+    } catch (e) {
+      errors.push(
+        e instanceof Error ? e.message : "Enter a valid table prefix.",
+      );
     }
+    return errors;
   }
+
   if (cfg.sinkType === "snowflake") {
     const p = rawParams as Partial<SnowflakeConnectionParams>;
     const authMethod = p.authMethod ?? "password";
-    const hasSnowflakePrivateKey =
-      authMethod === "key-pair" || !!p.privateKey?.trim();
+    if (!cfg.config.database.trim()) errors.push("Enter a Snowflake database.");
+    if (!cfg.config.schema.trim()) errors.push("Enter a Snowflake schema.");
+    if (!cfg.config.accessUrl?.trim())
+      errors.push("Enter a Snowflake access URL.");
+    if (!p.account?.trim()) errors.push("Enter a Snowflake account.");
+    if (!p.username?.trim()) errors.push("Enter a Snowflake username.");
+    if (authMethod !== "key-pair") {
+      errors.push("Use key-pair authentication for the Snowflake connection.");
+    }
     try {
       normalizeSnowflakeTablePrefixForEventForwarder(cfg.config.tablePrefix);
-    } catch {
-      return false;
+    } catch (e) {
+      errors.push(
+        e instanceof Error ? e.message : "Enter a valid table prefix.",
+      );
     }
-    return (
-      !!cfg.config.database.trim() &&
-      !!cfg.config.schema.trim() &&
-      !!cfg.config.accessUrl?.trim() &&
-      !!p.account?.trim() &&
-      !!p.username?.trim() &&
-      authMethod === "key-pair" &&
-      hasSnowflakePrivateKey
-    );
+    return errors;
   }
-  return false;
+
+  return ["Unsupported event forwarder type."];
 }
 
 function EventForwarderConfigField({
@@ -256,33 +265,21 @@ function SyncSubmittingRef({
 }
 
 function EventForwarderConfirmButton({
-  canConfirmEventForwarder,
   usEventForwarderFlowConsent,
-  datasourceDraft,
 }: {
-  canConfirmEventForwarder: boolean;
   usEventForwarderFlowConsent: boolean;
-  datasourceDraft: EventForwarderDatasourceDraft;
 }) {
   const { loading } = useModalForm();
-  const ctaEnabled = canConfirmEventForwarder && usEventForwarderFlowConsent;
-  const disabledMessage = !canConfirmEventForwarder
-    ? datasourceDraft.type === "bigquery"
-      ? "Enter a BigQuery project and dataset before confirming."
-      : "Enter Snowflake database, schema, URL, and required connection fields before confirming."
-    : !usEventForwarderFlowConsent
-      ? "Acknowledge US data flow and authorization to use Confirm."
-      : undefined;
 
   return (
     <Tooltip
-      body={disabledMessage || ""}
-      shouldDisplay={!ctaEnabled && !!disabledMessage}
+      body="Acknowledge US data flow and authorization to use Confirm."
+      shouldDisplay={!usEventForwarderFlowConsent}
       tipPosition="top"
     >
       <Button
         type="submit"
-        disabled={!ctaEnabled}
+        disabled={!usEventForwarderFlowConsent}
         loading={loading}
         icon={<FaChevronRight size={12} />}
         iconPosition="right"
@@ -344,8 +341,6 @@ function EventForwarderModal({
     eventForwarderConfig,
   });
 
-  const canConfirmEventForwarder = getCanConfirmEventForwarder(datasourceDraft);
-
   const attemptClose = useCallback(() => {
     if (isSubmittingRef.current) {
       setShowCloseConfirm(true);
@@ -367,6 +362,11 @@ function EventForwarderModal({
         <ModalForm
           onSubmit={async () => {
             if (!eventForwarderConfig) return;
+            const validationErrors =
+              getEventForwarderValidationErrors(datasourceDraft);
+            if (validationErrors.length) {
+              throw new Error(validationErrors.join(" "));
+            }
             try {
               await testEventForwarderAccess();
               await apiCall(`/datasource/${dataSource.id}/event-forwarder`, {
@@ -416,9 +416,7 @@ function EventForwarderModal({
               Cancel
             </Button>
             <EventForwarderConfirmButton
-              canConfirmEventForwarder={canConfirmEventForwarder}
               usEventForwarderFlowConsent={usEventForwarderFlowConsent}
-              datasourceDraft={datasourceDraft}
             />
           </Modal.Footer>
         </ModalForm>

--- a/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
@@ -363,11 +363,15 @@ function EventForwarderModal({
       >
         <ModalForm
           onSubmit={async () => {
-            if (!eventForwarderConfig) return;
             const validationErrors =
               getEventForwarderValidationErrors(datasourceDraft);
             if (validationErrors.length) {
               throw new Error(validationErrors.join(" "));
+            }
+            // Unreachable once validation passes (a null config yields an
+            // error above); the throw narrows the type for the request body.
+            if (!eventForwarderConfig) {
+              throw new Error(EVENT_FORWARDER_MODAL_FAILURE_MESSAGE);
             }
             try {
               await testEventForwarderAccess();


### PR DESCRIPTION
### Features and Changes

Reworked the Event Forwarder creation/edit modal so the **Confirm** button no longer hides *why* a configuration is invalid.

Previously the button was disabled whenever the config was incomplete, and a single generic tooltip ("Enter ... required connection fields") lumped every failure together — so reasons like *auth method must be key-pair* or an *invalid table prefix* were never surfaced to the user.

Now:
- **Confirm** is enabled once the US-data-flow consent checkbox is acknowledged; its tooltip is reduced to just the consent reminder.
- Configuration is validated **on submit**. The new `getEventForwarderValidationErrors()` helper (replacing the boolean `getCanConfirmEventForwarder`) returns one specific message per failing condition — per-field for BigQuery and Snowflake, plus the table-prefix normalizer's own error — and the modal throws the combined message so it renders in the error area.
- Surfaces two reasons that were previously invisible: auth method must be key-pair, and invalid table prefix.

Behaviour preserved: private-key value is still not required (the prior logic only required key-pair auth and never validated the key string), avoiding a regression in the edit flow where the secret isn't re-sent.

### Dependencies

None

### Testing

1. Open a BigQuery or Snowflake data source in **Settings → Data Sources** and launch **Set Up Event Forwarder**.
2. Leave the consent checkbox unchecked → **Confirm** is disabled and its tooltip explains the consent requirement.
3. Check consent but leave required fields blank / use password auth / enter an invalid table prefix → click **Confirm** → a combined error message lists each specific problem, and no request is sent.
4. Fill in all required fields with key-pair auth and a valid prefix → **Confirm** succeeds and the forwarder is created.
5. Edit an existing forwarder (consent pre-checked) and confirm it still saves without re-entering the private key.

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
