### PR TITLE
Allow editing Access URL

### DIFF
--- a/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
@@ -179,14 +179,15 @@ function getEventForwarderDraft(
   return null;
 }
 
-// Only validates what the browser's native `required` validation can't cover:
+// Validates what the browser's native `required` validation can't cover:
 // datasource connection params that aren't inputs in this modal
 // (account/username/auth method), and *format* of free-form fields (table
-// prefix, and the access URL when it's editable). Empty visible required
-// fields (BigQuery project/dataset, Snowflake database/schema, and the access
-// URL when the user must enter it) are handled by native `required` on the
-// inputs, so don't re-check emptiness here — that duplicates the per-field
-// tooltip.
+// prefix, access URL). Empty visible required fields (BigQuery project/dataset,
+// Snowflake database/schema) are handled by native `required` on the inputs, so
+// don't re-check emptiness here — that duplicates the per-field tooltip. The
+// access URL is the exception: it's only conditionally editable/required in the
+// UI, so this validator owns its emptiness too as a backstop (native gates
+// submit first, so it never double-messages).
 function getEventForwarderValidationErrors(
   draft: EventForwarderDatasourceDraft,
 ): string[] {
@@ -214,10 +215,10 @@ function getEventForwarderValidationErrors(
     if (authMethod !== "key-pair") {
       errors.push("Use key-pair authentication for the Snowflake connection.");
     }
-    // Emptiness is handled by native `required`; validate the format of
-    // whatever the user entered (derived URLs are already well-formed).
     const accessUrl = cfg.config.accessUrl?.trim();
-    if (accessUrl) {
+    if (!accessUrl) {
+      errors.push("Enter a Snowflake access URL.");
+    } else {
       try {
         normalizeSnowflakeEventForwarderAccessUrl(accessUrl);
       } catch (e) {

--- a/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
@@ -2,6 +2,7 @@ import { useCallback, useRef, useState } from "react";
 import {
   DEFAULT_EVENT_FORWARDER_TABLE_PREFIX,
   normalizeBigQueryTablePrefixForEventForwarder,
+  normalizeSnowflakeEventForwarderAccessUrl,
   normalizeSnowflakeTablePrefixForEventForwarder,
   stripLeadingUtf8ByteOrderMark,
   supportsEventForwarder,
@@ -179,11 +180,13 @@ function getEventForwarderDraft(
 }
 
 // Only validates what the browser's native `required` validation can't cover:
-// read-only/derived fields (Snowflake access URL), datasource connection params
-// that aren't inputs in this modal (account/username/auth method), and table
-// prefix *format*. Empty visible required fields (BigQuery project/dataset,
-// Snowflake database/schema) are handled by native `required` on the inputs, so
-// don't re-check them here — that would duplicate the per-field tooltip.
+// datasource connection params that aren't inputs in this modal
+// (account/username/auth method), and *format* of free-form fields (table
+// prefix, and the access URL when it's editable). Empty visible required
+// fields (BigQuery project/dataset, Snowflake database/schema, and the access
+// URL when the user must enter it) are handled by native `required` on the
+// inputs, so don't re-check emptiness here — that duplicates the per-field
+// tooltip.
 function getEventForwarderValidationErrors(
   draft: EventForwarderDatasourceDraft,
 ): string[] {
@@ -206,12 +209,24 @@ function getEventForwarderValidationErrors(
   if (cfg.sinkType === "snowflake") {
     const p = rawParams as Partial<SnowflakeConnectionParams>;
     const authMethod = p.authMethod ?? "password";
-    if (!cfg.config.accessUrl?.trim())
-      errors.push("Enter a Snowflake access URL.");
     if (!p.account?.trim()) errors.push("Enter a Snowflake account.");
     if (!p.username?.trim()) errors.push("Enter a Snowflake username.");
     if (authMethod !== "key-pair") {
       errors.push("Use key-pair authentication for the Snowflake connection.");
+    }
+    // Emptiness is handled by native `required`; validate the format of
+    // whatever the user entered (derived URLs are already well-formed).
+    const accessUrl = cfg.config.accessUrl?.trim();
+    if (accessUrl) {
+      try {
+        normalizeSnowflakeEventForwarderAccessUrl(accessUrl);
+      } catch (e) {
+        errors.push(
+          e instanceof Error
+            ? e.message
+            : "Enter a valid Snowflake access URL.",
+        );
+      }
     }
     try {
       normalizeSnowflakeTablePrefixForEventForwarder(cfg.config.tablePrefix);

--- a/packages/front-end/components/Settings/SnowflakeEventForwarderForm.tsx
+++ b/packages/front-end/components/Settings/SnowflakeEventForwarderForm.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, useState } from "react";
 import { Flex } from "@radix-ui/themes";
 import { EventForwarderConfigDraft } from "shared/types/event-forwarder";
 import Field from "@/components/Forms/Field";
@@ -14,6 +14,16 @@ const SnowflakeEventForwarderForm: FC<{
 }> = ({ eventForwarderConfig, setEventForwarderConfig }) => {
   const snowflakeEventForwarderConfig =
     eventForwarderConfig.sinkType === "snowflake" ? eventForwarderConfig : null;
+
+  // The access URL is normally derived from the datasource account and shown
+  // read-only. When it couldn't be derived (e.g. a bare account locator like
+  // "xy12345"), it arrives empty — let the user enter it directly instead.
+  // Decided once on mount so typing the first character doesn't re-lock it.
+  const [accessUrlReadOnly] = useState(
+    () =>
+      eventForwarderConfig.sinkType === "snowflake" &&
+      !!eventForwarderConfig.config.accessUrl?.trim(),
+  );
 
   if (!snowflakeEventForwarderConfig) return null;
 
@@ -37,8 +47,12 @@ const SnowflakeEventForwarderForm: FC<{
         value={snowflakeEventForwarderConfig.config.accessUrl || ""}
         onChange={(accessUrl) => updateConfig({ accessUrl })}
         placeholder="https://myorg-account123.snowflakecomputing.com"
-        tooltip="Derived from the Snowflake datasource connection (account or access URL). Update the datasource settings to change this value."
-        readOnly
+        tooltip={
+          accessUrlReadOnly
+            ? "Derived from the Snowflake datasource connection (account or access URL). Update the datasource settings to change this value."
+            : "Couldn't be derived from the datasource account. Enter the full Snowflake URL (e.g. https://myorg-account123.snowflakecomputing.com)."
+        }
+        readOnly={accessUrlReadOnly}
       />
       <Field
         label="Database"


### PR DESCRIPTION
### Features and Changes

Makes the Snowflake Access URL field in the Event Forwarder modal editable when it can't be derived, so users are never blocked by a read-only field they have no way to fill.

Previously the Access URL was always read-only and populated from the datasource — either the explicit URL or one derived from the account. But `tryDeriveSnowflakeAccessUrlFromAccount` intentionally returns `null` for bare account locators (e.g. `xy12345`), leaving the field empty and read-only. The user then hit "Enter a Snowflake access URL." with no way to enter one.

Now the field's read-only vs. editable state depends on whether a value was available at open time:

| Datasource has explicit `accessUrl`? | Account derivable? | Field in EF form |
| --- | --- | --- |
| Yes | — | Copied value, **read-only** |
| No | Yes (`myorg-account123`, `xy12345.us-east-1`) | Derived value, **read-only** |
| No | No (bare locator `xy12345`) | Empty, **editable + required** |

- The read-only/editable decision is captured once on mount, so typing the first character doesn't re-lock the field.
- The field tooltip is now context-aware: the "derived from the datasource connection" message when read-only, and guidance to enter the full URL when editable.
- Validation follows the modal's split-ownership rule: emptiness of the now-editable, `required` field is handled by native browser validation, so the submit validator no longer re-checks it. Instead it validates the *format* of whatever the user entered via `normalizeSnowflakeEventForwarderAccessUrl` (mirroring the table-prefix check), catching a malformed URL client-side.

- Closes **(add link to issue here)**

### Dependencies

None

### Testing

1. Open a **Snowflake** data source in **Settings → Data Sources** and launch **Set Up Event Forwarder**.
2. **Explicit URL:** datasource created with an Access URL → field is pre-filled and read-only.
3. **Derivable account:** datasource account like `myorg-account123` or `xy12345.us-east-1` → field shows the derived URL, read-only.
4. **Bare locator:** datasource account like `xy12345` with no explicit URL → field is empty and editable.
   - Leave it blank and click **Confirm** → native "Please fill out this field." tooltip blocks submit.
   - Enter a malformed value (e.g. `not a url`) → specific format error appears in the modal error area; no request sent.
   - Enter a valid URL (e.g. `https://xy12345.us-east-1.snowflakecomputing.com`) and complete the form → **Confirm** succeeds.
5. Confirm typing into the editable field works continuously (it doesn't lock after the first character).