### PR TITLE
fix(experiments): Short variation labels in results column labels should not collapse

### DIFF
--- a/packages/front-end/components/Experiment/BaselineChooserColumnLabel.tsx
+++ b/packages/front-end/components/Experiment/BaselineChooserColumnLabel.tsx
@@ -188,7 +188,8 @@ export default function BaselineChooserColumnLabel({
           ) : (
             <Box
               style={{
-                maxWidth: labelMaxWidth + 20,
+                width: labelMaxWidth + 20,
+                maxWidth: "100%",
                 minWidth: 0,
                 marginLeft: -4,
               }}

--- a/packages/front-end/components/Experiment/VariationChooserColumnLabel.tsx
+++ b/packages/front-end/components/Experiment/VariationChooserColumnLabel.tsx
@@ -173,7 +173,12 @@ export default function VariationChooserColumnLabel({
     const selectedVariation = filteredVariations[0];
     triggerContent = (
       <Box
-        style={{ maxWidth: labelMaxWidth + 20, minWidth: 0, marginLeft: -4 }}
+        style={{
+          width: labelMaxWidth + 20,
+          maxWidth: "100%",
+          minWidth: 0,
+          marginLeft: -4,
+        }}
       >
         <VariationLabel
           number={selectedVariation.index}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

- Fix short variation names in experiment baseline/variation chooser headers collapsing to number-only when there is enough available space.
- Give the chooser label wrapper an intended width while capping it to the available table header space, so `VariationLabel` measures the real available space instead of its intrinsic short-name width.

### Dependencies

None.

### Testing

- `pnpm --filter front-end type-check`
- Pre-commit targeted ESLint (`pnpm eslint --fix --max-warnings 0 ...`) passed on the touched TypeScript files.
- Browser walkthrough with a local probe importing the real `VariationLabel` verified:
  - long variation names show number + truncated name,
  - short names like `Dev` and `QA` show number + name when there is room,
  - switching long -> short -> QA -> long -> short does not leave labels stuck number-only,
  - a truly narrow container still collapses to number-only.

### Screenshots

<img width="286" height="103" alt="Screenshot 2026-07-13 at 2 42 08 PM" src="https://github.com/user-attachments/assets/c94d4074-e1ea-40a9-9381-b44b95df8f93" />

[VariationLabel short name final verification](https://cursor.com/agents/bc-35f05b63-4846-5198-ba0a-bbb8f5ce5816/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvariation_label_short_name_final_clean.webp)

[variation_label_short_name_switching_clean.mp4](https://cursor.com/agents/bc-35f05b63-4846-5198-ba0a-bbb8f5ce5816/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvariation_label_short_name_switching_clean.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/D0ANTLUD22J/p1774465571901549?thread_ts=1774465571.901549&cid=D0ANTLUD22J)

<div><a href="https://cursor.com/agents/bc-35f05b63-4846-5198-ba0a-bbb8f5ce5816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35f05b63-4846-5198-ba0a-bbb8f5ce5816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

