### PR TITLE
Show an API badge for API/PAT actions in the audit log

### DIFF
--- a/packages/front-end/components/Avatar/EventUser.tsx
+++ b/packages/front-end/components/Avatar/EventUser.tsx
@@ -135,7 +135,7 @@ export default function EventUser({
         label="API"
         size="xs"
         ml="1"
-        title="via API Key or Personal Access Token"
+        title={email ? "via Personal Access Token" : "via API Key"}
       />
     ) : null;
 

--- a/packages/front-end/components/Avatar/EventUser.tsx
+++ b/packages/front-end/components/Avatar/EventUser.tsx
@@ -126,15 +126,18 @@ export default function EventUser({
     );
   }
 
-  const apiBadge = isApi ? (
-    <Badge
-      variant="outline"
-      label="API"
-      size="xs"
-      ml="1"
-      title="via API Key or Personal Access Token"
-    />
-  ) : null;
+  // Only badge named actors; a nameless key already reads as "API Key" (see
+  // getUserLabel), so the badge would just double the "API" signal.
+  const apiBadge =
+    isApi && (name || email) ? (
+      <Badge
+        variant="outline"
+        label="API"
+        size="xs"
+        ml="1"
+        title="via API Key or Personal Access Token"
+      />
+    ) : null;
 
   const freshUser = { ...user, name, email } as EventUserType;
 

--- a/packages/front-end/components/Avatar/EventUser.tsx
+++ b/packages/front-end/components/Avatar/EventUser.tsx
@@ -49,7 +49,7 @@ function getUserLabel(user?: EventUserType | null, bothNameAndEmail?: boolean) {
     );
   }
 
-  return <span>Unknown</span>;
+  return <span>{user?.type === "api_key" ? "API Key" : "Unknown"}</span>;
 }
 
 export default function EventUser({

--- a/packages/front-end/components/HistoryTable.tsx
+++ b/packages/front-end/components/HistoryTable.tsx
@@ -11,6 +11,8 @@ import Callout from "@/ui/Callout";
 import Button from "./Button";
 import Code from "./SyntaxHighlighting/Code";
 import LoadingOverlay from "./LoadingOverlay";
+import EventUser from "./Avatar/EventUser";
+import { auditInterfaceUserToEventUser } from "./Avatar/auditUserToEventUser";
 
 function EventDetails({
   eventType,
@@ -101,12 +103,6 @@ export function HistoryTableRow({
   itemName?: string;
   url?: string;
 }) {
-  const user = event.user;
-  const userDisplay =
-    ("name" in user && user.name) ||
-    ("email" in user && user.email) ||
-    ("apiKey" in user && "API Key") ||
-    ("system" in user && "System");
   let colSpanNum = 4;
   if (showName) colSpanNum++;
   if (showType) colSpanNum++;
@@ -135,7 +131,12 @@ export function HistoryTableRow({
         {showName && (
           <td>{url ? <Link href={url}>{displayName}</Link> : displayName}</td>
         )}
-        <td>{userDisplay}</td>
+        <td>
+          <EventUser
+            user={auditInterfaceUserToEventUser(event.user)}
+            display="name"
+          />
+        </td>
         <td>{event.event}</td>
         <td style={{ width: 30 }}>
           {event.details && (open ? <FaAngleUp /> : <FaAngleDown />)}


### PR DESCRIPTION
### Features and Changes

The audit-log table only rendered the actor's name/email, so an action taken via an API key or Personal Access Token was indistinguishable from a logged-in UI action. Render the actor with the existing `EventUser` component instead, which appends an "API" badge to named API actors. A key with no name (non-PAT with a blank description) reads as plain "API Key":

- PAT / named key → `Kevin Chant [API]`
- Non-PAT key with a description → `Production SDK [API]`
- Non-PAT key without a description → `API Key`

### Testing

View an entity's Audit Log (or the Activity page) and confirm API/PAT actions are labelled per the cases above, while UI actions show just the user with no badge.
