### PR TITLE
Fix: Allow reviewer self-approval when blockSelfApproval is disabled 

### DIFF
--- a/packages/back-end/src/api/constants/postConstantRevisionSubmitReview.ts
+++ b/packages/back-end/src/api/constants/postConstantRevisionSubmitReview.ts
@@ -33,14 +33,18 @@ export const postConstantRevisionSubmitReview = createApiRequestHandler(
 
   const { decision, comment } = req.body;
 
-  // Block the author from any non-comment review action.
-  if (revision.authorId === req.context.userId && decision !== "comment") {
+  // `request-changes` by the author doesn't make sense. Author may approve
+  // their own revision and may always comment.
+  if (
+    revision.authorId === req.context.userId &&
+    decision === "request-changes"
+  ) {
     throw new BadRequestError("Cannot submit a review on a draft you created");
   }
 
-  // Block contributor self-approve when blockSelfApproval is set. The shared
-  // helper routes constants through the requireReviews model — same rule the
-  // internal /revision/:id/review endpoint enforces.
+  // Block self-approval when `blockSelfApproval` is set. The shared helper
+  // checks both the author and contributors against the org setting, so when
+  // the setting is off, self-approval is allowed.
   if (decision === "approve") {
     const blocked = isUserBlockedFromApproving({
       settings: req.context.org.settings,

--- a/packages/back-end/src/api/features/postFeatureRevisionSubmitReview.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionSubmitReview.ts
@@ -48,27 +48,33 @@ export async function submitRevisionReview(
   const { action = "comment", comment } = req.body;
   const review = actionToReviewType[action];
 
-  // Block the creator from any non-comment review action.
+  // `request-changes` by the author doesn't make sense. Author may approve
+  // their own revision when blockSelfApproval is off, and may always comment.
   if (
     revision.createdBy != null &&
     "id" in revision.createdBy &&
     revision.createdBy.id === req.context.userId &&
-    action !== "comment"
+    action === "request-changes"
   ) {
     throw new BadRequestError("Cannot submit a review on a draft you created");
   }
 
-  // Block contributors from self-approving when `blockSelfApproval` is set.
-  // request-changes / comment are intentionally allowed.
+  // Block self-approval when `blockSelfApproval` is set at the org level.
+  // When the setting is off, authors may approve their own revisions.
+  // request-changes / comment are intentionally allowed for authors.
   if (action === "approve") {
     const requireReviews = req.context.org.settings?.requireReviews;
     const reviewSetting = Array.isArray(requireReviews)
       ? getReviewSetting(requireReviews, feature)
       : undefined;
     if (reviewSetting?.blockSelfApproval) {
-      const isSelfApproval = (revision.contributors ?? []).some(
-        (id) => id === req.context.userId,
-      );
+      const createdByUser = revision.createdBy as
+        | { id: string }
+        | null
+        | undefined;
+      const isSelfApproval =
+        (revision.contributors ?? []).some((id) => id === req.context.userId) ||
+        createdByUser?.id === req.context.userId;
       if (isSelfApproval) {
         throw new BadRequestError(
           "You cannot approve a draft you contributed to.",

--- a/packages/back-end/src/api/saved-groups/postSavedGroupRevisionSubmitReview.ts
+++ b/packages/back-end/src/api/saved-groups/postSavedGroupRevisionSubmitReview.ts
@@ -37,14 +37,18 @@ export const postSavedGroupRevisionSubmitReview = createApiRequestHandler(
 
   const { decision, comment } = req.body;
 
-  // Block the author from any non-comment review action.
-  if (revision.authorId === req.context.userId && decision !== "comment") {
+  // `request-changes` by the author doesn't make sense. Author may approve
+  // their own revision and may always comment.
+  if (
+    revision.authorId === req.context.userId &&
+    decision === "request-changes"
+  ) {
     throw new BadRequestError("Cannot submit a review on a draft you created");
   }
 
-  // Block contributor self-approve when `blockSelfApproval` is set. Same
-  // rule the internal /revision/:id/review endpoint enforces — using the
-  // shared helper keeps the logic in lockstep.
+  // Block self-approval when `blockSelfApproval` is set. The shared helper
+  // checks both the author and contributors against the org setting, so when
+  // the setting is off, self-approval is allowed.
   if (decision === "approve") {
     const blocked = isUserBlockedFromApproving({
       settings: req.context.org.settings,

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -1299,26 +1299,19 @@ export async function postFeatureReviewOrComment(
     throw new Error("Comment cannot be empty");
   }
 
+  // request-changes / comment by the author don't make sense.
   if (createdByUser?.id === context.userId && review !== "Comment") {
-    throw Error("cannot submit a review for your self");
-  }
-
-  // Block contributors from self-approving when the org setting is enabled.
-  // Note: contributors[] is only populated on drafts created after contributor tracking was
-  // deployed. Legacy drafts with no contributors[] bypass this check — there is no way to
-  // retroactively determine co-authors without reading revision logs.
-  if (review === "Approved") {
-    const requireReviews = context.org.settings?.requireReviews;
-    const reviewSetting = Array.isArray(requireReviews)
-      ? getReviewSetting(requireReviews, feature)
-      : undefined;
-    if (reviewSetting?.blockSelfApproval) {
-      const isSelfApproval = (revision.contributors ?? []).some(
-        (id) => id === context.userId,
-      );
-      if (isSelfApproval) {
+    if (review === "Approved") {
+      // When blockSelfApproval is OFF, the author may self-approve.
+      const requireReviews = context.org.settings?.requireReviews;
+      const reviewSetting = Array.isArray(requireReviews)
+        ? getReviewSetting(requireReviews, feature)
+        : undefined;
+      if (reviewSetting?.blockSelfApproval) {
         throw new Error("You cannot approve a draft you contributed to.");
       }
+    } else {
+      throw Error("cannot submit a review for your self");
     }
   }
   // dont allow review unless you are adding a comment
@@ -1409,16 +1402,18 @@ export async function postFeatureApproveAndPublish(
   if (!revision) throw new Error("Could not find feature revision");
 
   const createdByUser = revision.createdBy as EventUserLoggedIn;
-  if (createdByUser?.id === context.userId) {
-    throw Error("Cannot approve a draft you created");
-  }
 
-  if (revision.contributors?.some((cid) => cid === context.userId)) {
-    const requireReviews = context.org.settings?.requireReviews;
-    const reviewSetting = Array.isArray(requireReviews)
-      ? getReviewSetting(requireReviews, feature)
-      : undefined;
-    if (reviewSetting?.blockSelfApproval) {
+  // When blockSelfApproval is ON, the author and any contributor are blocked.
+  // When it's OFF, self-approval is allowed.
+  const requireReviews = context.org.settings?.requireReviews;
+  const reviewSetting = Array.isArray(requireReviews)
+    ? getReviewSetting(requireReviews, feature)
+    : undefined;
+  if (reviewSetting?.blockSelfApproval) {
+    const isSelfApproval =
+      createdByUser?.id === context.userId ||
+      (revision.contributors ?? []).some((cid) => cid === context.userId);
+    if (isSelfApproval) {
       throw new Error("You cannot approve a draft you contributed to.");
     }
   }

--- a/packages/back-end/src/revisions/revisionActions.ts
+++ b/packages/back-end/src/revisions/revisionActions.ts
@@ -35,10 +35,6 @@ export async function approveRevision(
     context.permissions.throwPermissionError();
   }
 
-  if (revision.authorId === context.userId) {
-    throw new BadRequestError("Cannot approve your own revision");
-  }
-
   if (
     context.hasPremiumFeature("require-approvals") &&
     isUserBlockedFromApproving({

--- a/packages/back-end/src/routers/revision/revision.controller.ts
+++ b/packages/back-end/src/routers/revision/revision.controller.ts
@@ -517,18 +517,18 @@ export const postReview = async (
       .json({ message: "Cannot review a discarded or merged revision" });
   }
 
-  // Prevent self-review (author cannot approve or request changes on own revision)
-  if (existingRevision.authorId === userId && decision !== "comment") {
+  // `request-changes` by the author doesn't make sense. Author may approve
+  // their own revision and may always comment.
+  if (existingRevision.authorId === userId && decision === "request-changes") {
     return res.status(403).json({
-      message: "Cannot approve or request changes on your own revision",
+      message: "Cannot request changes on your own revision",
     });
   }
 
   // When `blockSelfApproval` is enabled for this entity type, anyone in the
   // contributors[] list (in addition to the author) is barred from approving.
   // Only `approve` is gated; `request-changes` and `comment` remain open.
-  // Legacy revisions with no `contributors` field fall back to `[authorId]`,
-  // which means the existing author check above is the only effective guard.
+  // Legacy revisions with no `contributors` field fall back to `[authorId]`.
   if (
     decision === "approve" &&
     context.hasPremiumFeature("require-approvals") &&

--- a/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
+++ b/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
@@ -676,12 +676,14 @@ export default function ReviewAndPublish({
   const reviewSetting = Array.isArray(requireReviewSettings)
     ? getReviewSetting(requireReviewSettings, feature)
     : undefined;
+  const isAuthor = createdBy?.id === user?.id;
   const isBlockedContributor =
     reviewSetting?.blockSelfApproval &&
-    (revision?.contributors ?? []).some((id) => id === user?.id);
+    ((revision?.contributors ?? []).some((id) => id === user?.id) ||
+      !!isAuthor);
   const canReview =
     !!isPendingReview &&
-    createdBy?.id !== user?.id &&
+    !(isAuthor && reviewSetting?.blockSelfApproval) &&
     permissionsUtil.canReviewFeatureDrafts(feature);
   const approved = revision?.status === "approved" || adminPublish;
 

--- a/packages/front-end/components/Revision/ReviewAndPublishTab.tsx
+++ b/packages/front-end/components/Revision/ReviewAndPublishTab.tsx
@@ -493,7 +493,20 @@ function ReviewAndPublishRevision<T>({
   const isPendingReview =
     revision.status === "pending-review" ||
     revision.status === "changes-requested";
-  const canReview = isPendingReview && !isAuthor && canEditEntity;
+  // Author can review when blockSelfApproval is OFF (self-approval allowed).
+  // When ON, isUserBlockedFromApproving returns true for the author.
+  const isBlockedFromSelfApproval =
+    isAuthor &&
+    !!userId &&
+    hasCommercialFeature("require-approvals") &&
+    isUserBlockedFromApproving({
+      settings: organization?.settings,
+      entityType: revision.target.type,
+      revision,
+      userId,
+    });
+  const canReview =
+    isPendingReview && !isBlockedFromSelfApproval && canEditEntity;
   const approved = revision.status === "approved" || adminPublish;
 
   // ── Comments: posted as `comment`-decision reviews on the generic


### PR DESCRIPTION
 Users with `canReview` permission (e.g. Engineer role) are unable to self-approve                                                                                                              
 their own feature flag changes even when self-approval is enabled in                                 
 organization settings (`blockSelfApproval: false`).                                                                                                                                                                
                                                                                                                                                                                                                                   Every approval code path had an unconditional hard-coded check:                                                                                                                       LSP                                     
     LSPs are disabled                       
     if (authorId === userId) throw "Cannot approve your own revision"                                                                                                                                            
                                                                                                                                                                                                                                    
     This ran before the blockSelfApproval org setting was evaluated, so the                                                                                                                                                        
     setting was never consulted for the author. Admins were unaffected because they                                                                                                                                                
     bypass approvals entirely via bypassApprovalChecks.                                                                                                                                                                            
                                                                                                                                                                                                                                    
     Fix                                                                                                                                                                                                                            
                                                                                                                                                                                                                                    
     Removed the hard-coded author block from all 7 backend approval handlers.                                                                                                                                                      
     The author's ability to approve is now governed solely by blockSelfApproval:                                                                                                                                               
                                                                                                                                                                                                                                    
     request-changes by the author is still blocked (it doesn't make sense                                                                                                                                                          
     regardless of the setting).
     
      Files changed                                                                                                                                                                                                                  
                                                                                                                                                                                                                                    
     - revisionActions.ts — removed authorId === userId throw                                                                                                                                                                       
     - revision.controller.ts — author block narrowed to request-changes only                                                                                                                                                       
     - controllers/features.ts — both postFeatureReviewOrComment and                                                                                                                                                                
       postFeatureApproveAndPublish updated                                                                                                                                                                                         
     - postFeatureRevisionSubmitReview.ts — external feature API                                                                                                                                                                    
     - postSavedGroupRevisionSubmitReview.ts — external saved-group API                                                                                                                                                             
     - postConstantRevisionSubmitReview.ts — external constant API                                                                                                                                                                  
     - ReviewAndPublishTab.tsx — frontend canReview gated by blockSelfApproval                                                                                                                                                      
     - ReviewAndPublish.tsx — frontend canReview gated by blockSelfApproval                                                                                                                                                         
                                                                                                                                                                                                                                    
     Verification                                                                                                                                                                                                                   
                                                                                                                                                                                                                                    
     - All type checks pass (back-end, front-end, shared)                                                                                                                                                                           
     - 1386 shared tests, 197 back-end tests pass                                                                                                                                                                                   
     - No regressions in existing permission/approval tests                                                                                                                                                                         
     
     close :- #6185 