### PR TITLE
feat: add sortable dimension values to experiment breakdown tables    

### DIFF
--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -97,6 +97,7 @@ const BreakDownResults: FC<{
   setSortBy?: SetExperimentSortBy;
   sortDirection?: "asc" | "desc" | null;
   setSortDirection?: (d: "asc" | "desc" | null) => void;
+  dimensionSortBy?: ExperimentSortBy;
   customMetricOrder?: string[];
   analysisBarSettings?: {
     variationFilter: number[];
@@ -149,6 +150,7 @@ const BreakDownResults: FC<{
   setSortBy,
   sortDirection,
   setSortDirection,
+  dimensionSortBy,
   customMetricOrder,
   analysisBarSettings,
   setBaselineRow,
@@ -183,6 +185,7 @@ const BreakDownResults: FC<{
     metricsFilter,
     sortBy,
     sortDirection,
+    dimensionSortBy,
     customMetricOrder,
     analysisBarSettings,
     statsEngine,

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -70,6 +70,7 @@ const Results: FC<{
   setSortBy?: (s: "significance" | "change" | null) => void;
   sortDirection?: "asc" | "desc" | null;
   setSortDirection?: (d: "asc" | "desc" | null) => void;
+  dimensionSortBy?: "dimension-traffic" | "dimension-alpha" | null;
 }> = ({
   experiment,
   mutateExperiment,
@@ -88,6 +89,7 @@ const Results: FC<{
   setSortBy,
   sortDirection,
   setSortDirection,
+  dimensionSortBy,
 }) => {
   const { apiCall } = useAuth();
 
@@ -477,6 +479,7 @@ const Results: FC<{
               setSortBy={setSortBy}
               sortDirection={sortDirection}
               setSortDirection={setSortDirection}
+              dimensionSortBy={dimensionSortBy ?? null}
               analysisBarSettings={analysisBarSettings}
             />
           ) : showCompactResults ? (

--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
@@ -40,7 +40,7 @@ import {
   DEFAULT_STATS_ENGINE,
 } from "shared/constants";
 import { startCase } from "lodash";
-import { PiArrowSquareOut } from "react-icons/pi";
+import { PiArrowSquareOut, PiCaretDownFill } from "react-icons/pi";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import ResultMoreMenu, {
   shouldOfferMenuRefresh,
@@ -72,6 +72,7 @@ import Metadata from "@/ui/Metadata";
 import ResultsFilter from "@/components/Experiment/ResultsFilter/ResultsFilter";
 import { filterMetricsByTags } from "@/hooks/useExperimentTableRows";
 import DimensionChooser from "@/components/Dimensions/DimensionChooser";
+import { DropdownMenu, DropdownMenuItem } from "@/ui/DropdownMenu";
 import Link from "@/ui/Link";
 import Text from "@/ui/Text";
 import MigrateResultsToDashboardModal from "@/components/Experiment/ResultsFilter/MigrateResultsToDashboardModal";
@@ -105,6 +106,10 @@ export interface Props {
   setSliceTagsFilter?: (tags: string[]) => void;
   sortBy?: "significance" | "change" | "custom" | null;
   sortDirection?: "asc" | "desc" | null;
+  dimensionSortBy?: "dimension-traffic" | "dimension-alpha" | null;
+  setDimensionSortBy?: (
+    s: "dimension-traffic" | "dimension-alpha" | null,
+  ) => void;
   onSnapshotSuccessfulUpdate?: () => void;
 }
 
@@ -131,6 +136,8 @@ export default function AnalysisSettingsSummary({
   setSliceTagsFilter,
   sortBy,
   sortDirection,
+  dimensionSortBy,
+  setDimensionSortBy,
   onSnapshotSuccessfulUpdate,
 }: Props) {
   const {
@@ -1022,13 +1029,44 @@ export default function AnalysisSettingsSummary({
                 userIdType={userIdType as "user" | "anonymous" | undefined}
                 analysis={analysis}
                 snapshot={snapshot}
-                // DimensionChooser appends a new analysis to the existing
-                // snapshot in place — pass `inPlace: true` so the heavy
-                // fetch refreshes (the id-keyed auto-upgrade won't fire).
                 mutate={() => mutate({ inPlace: true })}
                 setAnalysisSettings={setAnalysisSettings}
                 setSnapshotDimension={setSnapshotDimension}
               />
+            )}
+            {setDimensionSortBy && (
+              <>
+                <Separator orientation="vertical" ml="3" mr="2" />
+                <DropdownMenu
+                  trigger={
+                    <Link type="button">
+                      <Text weight="semibold" color="text-high" size="small">
+                        {dimensionSortBy === "dimension-alpha"
+                          ? "Sort: A-Z"
+                          : "Sort: Traffic"}
+                      </Text>
+                      <PiCaretDownFill />
+                    </Link>
+                  }
+                >
+                  <DropdownMenuItem
+                    onClick={() => setDimensionSortBy(null)}
+                    color={dimensionSortBy === null ? "default" : undefined}
+                  >
+                    Sort: Traffic
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => setDimensionSortBy("dimension-alpha")}
+                    color={
+                      dimensionSortBy === "dimension-alpha"
+                        ? "default"
+                        : undefined
+                    }
+                  >
+                    Sort: A-Z
+                  </DropdownMenuItem>
+                </DropdownMenu>
+              </>
             )}
             {shouldRenderMetricFilter && (
               <>

--- a/packages/front-end/components/Experiment/TabbedPage/ResultsTab.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ResultsTab.tsx
@@ -74,6 +74,10 @@ export interface Props {
   setSortBy: (s: "significance" | "change" | null) => void;
   sortDirection: "asc" | "desc" | null;
   setSortDirection: (d: "asc" | "desc" | null) => void;
+  dimensionSortBy: "dimension-traffic" | "dimension-alpha" | null;
+  setDimensionSortBy: (
+    s: "dimension-traffic" | "dimension-alpha" | null,
+  ) => void;
 }
 
 export default function ResultsTab({
@@ -99,6 +103,8 @@ export default function ResultsTab({
   setSortBy,
   sortDirection,
   setSortDirection,
+  dimensionSortBy,
+  setDimensionSortBy,
 }: Props) {
   const {
     getDatasourceById,
@@ -384,6 +390,8 @@ export default function ResultsTab({
             setSliceTagsFilter={setSliceTagsFilter}
             sortBy={sortBy}
             sortDirection={sortDirection}
+            dimensionSortBy={dimensionSortBy}
+            setDimensionSortBy={setDimensionSortBy}
             onSnapshotSuccessfulUpdate={onSnapshotSuccessfulUpdate}
           />
           {experiment.status === "draft" ? (
@@ -447,6 +455,7 @@ export default function ResultsTab({
                   setSortBy={setSortBy}
                   sortDirection={sortDirection}
                   setSortDirection={setSortDirection}
+                  dimensionSortBy={dimensionSortBy}
                 />
               )}
             </>

--- a/packages/front-end/components/Experiment/TabbedPage/index.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/index.tsx
@@ -173,6 +173,9 @@ export default function TabbedPage({
   const [sortDirection, setSortDirection] = useLocalStorage<
     "asc" | "desc" | null
   >(`experiment-page__${experiment.id}__sort_direction`, null);
+  const [dimensionSortBy, setDimensionSortBy] = useLocalStorage<
+    "dimension-traffic" | "dimension-alpha" | null
+  >(`experiment-page__${experiment.id}__dimension_sort_by`, null);
 
   const setMetricTagFilterWithPriority = (newMetricTagFilter: string[]) => {
     setMetricTagFilter(newMetricTagFilter);
@@ -704,6 +707,8 @@ export default function TabbedPage({
           setSortBy={setSortBy}
           sortDirection={sortDirection}
           setSortDirection={setSortDirection}
+          dimensionSortBy={dimensionSortBy}
+          setDimensionSortBy={setDimensionSortBy}
         />
       </div>
       <div

--- a/packages/front-end/hooks/useExperimentDimensionRows.ts
+++ b/packages/front-end/hooks/useExperimentDimensionRows.ts
@@ -19,6 +19,8 @@ import {
   applyMetricOverrides,
   ExperimentTableRow,
   compareRows,
+  sortDimensionsByTraffic,
+  sortDimensionsByAlpha,
 } from "@/services/experiments";
 import { RowError } from "@/components/Experiment/ResultsTable";
 import { SSRPolyfills } from "@/hooks/useSSRPolyfills";
@@ -40,6 +42,7 @@ export interface UseExperimentDimensionRowsParams {
   metricsFilter?: string[];
   sortBy?: ExperimentSortBy;
   sortDirection?: "asc" | "desc" | null;
+  dimensionSortBy?: ExperimentSortBy;
   customMetricOrder?: string[];
   analysisBarSettings?: {
     variationFilter: number[];
@@ -71,6 +74,7 @@ export function useExperimentDimensionRows({
   metricsFilter,
   sortBy,
   sortDirection,
+  dimensionSortBy,
   customMetricOrder,
   analysisBarSettings,
   statsEngine,
@@ -265,9 +269,23 @@ export function useExperimentDimensionRows({
       return [];
     }
 
+    // Apply dimension-level sorting before building per-metric tables
+    let sortedResults: ExperimentReportResultDimension[];
+    if (dimensionSortBy === "dimension-traffic") {
+      sortedResults = sortDimensionsByTraffic(results);
+    } else if (dimensionSortBy === "dimension-alpha") {
+      sortedResults = sortDimensionsByAlpha(results);
+    } else {
+      sortedResults = results;
+    }
+
     if (pValueCorrection && statsEngine === "frequentist") {
-      setAdjustedPValuesOnResults(results, expandedGoals, pValueCorrection);
-      setAdjustedCIs(results, pValueThreshold);
+      setAdjustedPValuesOnResults(
+        sortedResults,
+        expandedGoals,
+        pValueCorrection,
+      );
+      setAdjustedCIs(sortedResults, pValueThreshold);
     }
 
     // Helper function to process metrics by type
@@ -355,7 +373,7 @@ export function useExperimentDimensionRows({
           const rows = generateDimensionRowsForMetric({
             metricId,
             resultGroup,
-            results,
+            results: sortedResults,
             dimensionValuesFilter,
             overrideFields,
             metricSnapshotSettings: _metricSnapshotSettings,
@@ -405,6 +423,7 @@ export function useExperimentDimensionRows({
     metricTagFilter,
     sortBy,
     sortDirection,
+    dimensionSortBy,
     customMetricOrder,
     analysisBarSettings,
     statsEngine,

--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -1,6 +1,7 @@
 import { SnapshotMetric } from "shared/types/experiment-snapshot";
 import { DifferenceType, StatsEngine } from "shared/types/stats";
 import {
+  ExperimentReportResultDimension,
   ExperimentReportVariation,
   MetricSnapshotSettings,
 } from "shared/types/report";
@@ -47,6 +48,7 @@ import {
 } from "shared/experiments";
 import { MetricGroupInterface } from "shared/types/metric-groups";
 import { ReactElement } from "react";
+import { NULL_DIMENSION_VALUE } from "shared/constants";
 import { useOrganizationMetricDefaults } from "@/hooks/useOrganizationMetricDefaults";
 import { getDefaultVariations } from "@/components/Experiment/NewExperimentForm";
 import { useAddComputedFields, useSearch } from "@/services/search";
@@ -155,6 +157,43 @@ export const compareRows = (
 
   return sortDirection === "desc" ? -comparisonResult : comparisonResult;
 };
+
+const ALWAYS_LAST_DIMENSION_VALUES = new Set(["(other)", NULL_DIMENSION_VALUE]);
+
+function dimensionSortKey(dimension: ExperimentReportResultDimension): string {
+  if (ALWAYS_LAST_DIMENSION_VALUES.has(dimension.name)) {
+    return "\uffff";
+  }
+  return dimension.name;
+}
+
+export function sortDimensionsByTraffic(
+  results: ExperimentReportResultDimension[],
+): ExperimentReportResultDimension[] {
+  return [...results].sort((a, b) => {
+    const aIsLast = dimensionSortKey(a) === "\uffff";
+    const bIsLast = dimensionSortKey(b) === "\uffff";
+    if (aIsLast && bIsLast) return 0;
+    if (aIsLast) return 1;
+    if (bIsLast) return -1;
+    const aUsers = a.variations.reduce((sum, v) => sum + v.users, 0);
+    const bUsers = b.variations.reduce((sum, v) => sum + v.users, 0);
+    return bUsers - aUsers;
+  });
+}
+
+export function sortDimensionsByAlpha(
+  results: ExperimentReportResultDimension[],
+): ExperimentReportResultDimension[] {
+  return [...results].sort((a, b) => {
+    const aIsLast = dimensionSortKey(a) === "\uffff";
+    const bIsLast = dimensionSortKey(b) === "\uffff";
+    if (aIsLast && bIsLast) return 0;
+    if (aIsLast) return 1;
+    if (bIsLast) return -1;
+    return a.name.localeCompare(b.name, undefined, { numeric: true });
+  });
+}
 
 export function experimentDate(exp: ExperimentInterfaceStringDates): string {
   return (

--- a/packages/front-end/test/services/sortDimensions.test.ts
+++ b/packages/front-end/test/services/sortDimensions.test.ts
@@ -1,0 +1,149 @@
+import { NULL_DIMENSION_VALUE } from "shared/constants";
+import { ExperimentReportResultDimension } from "shared/types/report";
+import {
+  sortDimensionsByAlpha,
+  sortDimensionsByTraffic,
+} from "@/services/experiments";
+
+function makeDim(
+  name: string,
+  usersPerVariation: number[] = [100, 50],
+): ExperimentReportResultDimension {
+  return {
+    name,
+    srm: 1,
+    variations: usersPerVariation.map((users) => ({
+      users,
+      metrics: {},
+    })),
+  };
+}
+
+describe("sortDimensionsByTraffic", () => {
+  it("sorts by total user count descending", () => {
+    const dims = [
+      makeDim("Safari", [100, 20]),
+      makeDim("Chrome", [500, 300]),
+      makeDim("Firefox", [50, 10]),
+    ];
+    const sorted = sortDimensionsByTraffic(dims);
+    expect(sorted.map((d) => d.name)).toEqual(["Chrome", "Safari", "Firefox"]);
+  });
+
+  it("pushes (other) to the end", () => {
+    const dims = [
+      makeDim("(other)", [999, 999]),
+      makeDim("Chrome", [500, 300]),
+      makeDim("Safari", [100, 20]),
+    ];
+    const sorted = sortDimensionsByTraffic(dims);
+    expect(sorted[sorted.length - 1].name).toBe("(other)");
+    expect(sorted[0].name).toBe("Chrome");
+  });
+
+  it("pushes __NULL_DIMENSION to the end", () => {
+    const dims = [
+      makeDim(NULL_DIMENSION_VALUE, [999, 999]),
+      makeDim("Chrome", [500, 300]),
+      makeDim("Safari", [100, 20]),
+    ];
+    const sorted = sortDimensionsByTraffic(dims);
+    expect(sorted[sorted.length - 1].name).toBe(NULL_DIMENSION_VALUE);
+    expect(sorted[0].name).toBe("Chrome");
+  });
+
+  it("handles empty array", () => {
+    expect(sortDimensionsByTraffic([])).toEqual([]);
+  });
+
+  it("handles single element", () => {
+    const dims = [makeDim("Chrome", [100, 50])];
+    expect(sortDimensionsByTraffic(dims)).toEqual(dims);
+  });
+
+  it("preserves original array (returns copy)", () => {
+    const dims = [makeDim("B", [10]), makeDim("A", [100])];
+    const sorted = sortDimensionsByTraffic(dims);
+    expect(dims[0].name).toBe("B");
+    expect(sorted[0].name).toBe("A");
+  });
+
+  it("sums users across all variations", () => {
+    const dims = [makeDim("Three", [10, 20, 30]), makeDim("Two", [100, 200])];
+    const sorted = sortDimensionsByTraffic(dims);
+    expect(sorted[0].name).toBe("Two");
+    expect(sorted[1].name).toBe("Three");
+  });
+});
+
+describe("sortDimensionsByAlpha", () => {
+  it("sorts alphabetically A-Z", () => {
+    const dims = [
+      makeDim("Safari"),
+      makeDim("Chrome"),
+      makeDim("Firefox"),
+      makeDim("Edge"),
+    ];
+    const sorted = sortDimensionsByAlpha(dims);
+    expect(sorted.map((d) => d.name)).toEqual([
+      "Chrome",
+      "Edge",
+      "Firefox",
+      "Safari",
+    ]);
+  });
+
+  it("pushes (other) to the end", () => {
+    const dims = [makeDim("(other)"), makeDim("Chrome"), makeDim("Safari")];
+    const sorted = sortDimensionsByAlpha(dims);
+    expect(sorted[sorted.length - 1].name).toBe("(other)");
+    expect(sorted[0].name).toBe("Chrome");
+  });
+
+  it("pushes __NULL_DIMENSION to the end", () => {
+    const dims = [
+      makeDim(NULL_DIMENSION_VALUE),
+      makeDim("Chrome"),
+      makeDim("Safari"),
+    ];
+    const sorted = sortDimensionsByAlpha(dims);
+    expect(sorted[sorted.length - 1].name).toBe(NULL_DIMENSION_VALUE);
+    expect(sorted[0].name).toBe("Chrome");
+  });
+
+  it("sorts numeric strings naturally", () => {
+    const dims = [
+      makeDim("Version 10"),
+      makeDim("Version 2"),
+      makeDim("Version 1"),
+    ];
+    const sorted = sortDimensionsByAlpha(dims);
+    expect(sorted.map((d) => d.name)).toEqual([
+      "Version 1",
+      "Version 2",
+      "Version 10",
+    ]);
+  });
+
+  it("handles empty array", () => {
+    expect(sortDimensionsByAlpha([])).toEqual([]);
+  });
+
+  it("handles single element", () => {
+    const dims = [makeDim("Chrome")];
+    expect(sortDimensionsByAlpha(dims)).toEqual(dims);
+  });
+
+  it("preserves original array (returns copy)", () => {
+    const dims = [makeDim("B"), makeDim("A")];
+    const sorted = sortDimensionsByAlpha(dims);
+    expect(dims[0].name).toBe("B");
+    expect(sorted[0].name).toBe("A");
+  });
+
+  it("sorts case-insensitively", () => {
+    const dims = [makeDim("safari"), makeDim("Chrome"), makeDim("edge")];
+    const sorted = sortDimensionsByAlpha(dims);
+    expect(sorted.map((d) => d.name)).toEqual(["Chrome", "edge", "safari"]);
+  });
+});

--- a/packages/shared/src/experiments/experiments.ts
+++ b/packages/shared/src/experiments/experiments.ts
@@ -68,6 +68,8 @@ export type ExperimentMetricDefinition =
 export type ExperimentSortBy =
   | "significance"
   | "change"
+  | "dimension-traffic"
+  | "dimension-alpha"
   | "metrics"
   | "metricTags"
   | null;


### PR DESCRIPTION
## Summary

This PR adds client-side sorting for experiment breakdown dimensions, allowing users to view dimension values in a more convenient order without affecting backend data.

## Changes

- Added a **Sort** dropdown to the Analysis Settings toolbar.
- Introduced two sorting modes:
  - **Traffic** (default) – preserves the existing backend order by total users.
  - **A–Z** – sorts dimension values alphabetically using natural ordering (`Version 1 < Version 2 < Version 10`).
- Kept special values (`(other)` and `NULL (unset)`) pinned to the bottom in all sorting modes.
- Persisted the selected sort mode in `localStorage` on a per-experiment basis.
- Added unit tests covering:
  - Natural sorting
  - Case-insensitive ordering
  - Special values
  - Empty and single-element arrays
  - Immutability

## Notes

This change only affects the frontend presentation of breakdown tables. It does not modify experiment data or backend sorting.