### PR TITLE
fix(safe-rollout): Ensure next snapshot uses ramp up schedule

### DIFF
--- a/packages/back-end/src/enterprise/saferollouts/safeRolloutUtils.ts
+++ b/packages/back-end/src/enterprise/saferollouts/safeRolloutUtils.ts
@@ -185,6 +185,17 @@ export function determineNextSafeRolloutSnapshotAttempt(
   safeRollout: SafeRolloutInterface,
   organization: OrganizationInterface,
 ): { nextSnapshot: Date; nextRampUp: Date } {
+  // Monitored ramp schedules carry their own refresh cadence in minutes. Honor
+  // it directly. The org-wide experiment update schedule below is far coarser
+  // (often daily) and would starve short monitored steps of the fresh analysis
+  // they need to advance, stranding them until the next org refresh.
+  if (safeRollout.updateScheduleMinutes) {
+    const next = new Date(
+      Date.now() + safeRollout.updateScheduleMinutes * 60 * 1000,
+    );
+    return { nextSnapshot: next, nextRampUp: next };
+  }
+
   const rampUpSchedule = safeRollout?.rampUpSchedule;
   const nextUpdate =
     determineNextDate(organization.settings?.updateSchedule || null) ||

--- a/packages/back-end/test/enterprise/safeRolloutUtils.test.ts
+++ b/packages/back-end/test/enterprise/safeRolloutUtils.test.ts
@@ -1,0 +1,83 @@
+import { SafeRolloutInterface } from "shared/types/safe-rollout";
+import { OrganizationInterface } from "shared/types/organization";
+import { determineNextSafeRolloutSnapshotAttempt } from "back-end/src/enterprise/saferollouts/safeRolloutUtils";
+
+const ORG_SCHEDULE_NEXT = new Date("2026-07-14T20:45:55.000Z");
+const NOW = new Date("2026-07-14T15:00:00.000Z");
+
+jest.mock("back-end/src/services/experiments", () => ({
+  determineNextDate: jest.fn(() => new Date("2026-07-14T20:45:55.000Z")),
+}));
+
+jest.mock("back-end/src/models/FeatureModel", () => ({
+  editFeatureRule: jest.fn(),
+  publishRevision: jest.fn(),
+}));
+
+jest.mock("back-end/src/models/FeatureRevisionModel", () => ({
+  createRevision: jest.fn(),
+  getRevision: jest.fn(),
+}));
+
+jest.mock("back-end/src/enterprise/licenseUtil", () => ({
+  orgHasPremiumFeature: jest.fn(),
+}));
+
+function makeSafeRollout(
+  overrides: Partial<SafeRolloutInterface> = {},
+): SafeRolloutInterface {
+  return {
+    id: "sr_1",
+    organization: "org_1",
+    featureId: "feat_1",
+    status: "running",
+    ...overrides,
+  } as SafeRolloutInterface;
+}
+
+const org = {
+  id: "org_1",
+  settings: { updateSchedule: { type: "stale", hours: 24 } },
+} as OrganizationInterface;
+
+describe("determineNextSafeRolloutSnapshotAttempt", () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(NOW);
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("honors the ramp's updateScheduleMinutes cadence over the org schedule", () => {
+    const safeRollout = makeSafeRollout({ updateScheduleMinutes: 360 });
+
+    const { nextSnapshot, nextRampUp } =
+      determineNextSafeRolloutSnapshotAttempt(safeRollout, org);
+
+    expect(nextSnapshot.getTime()).toBe(NOW.getTime() + 360 * 60 * 1000);
+    expect(nextSnapshot.getTime()).not.toBe(ORG_SCHEDULE_NEXT.getTime());
+    expect(nextRampUp.getTime()).toBe(NOW.getTime() + 360 * 60 * 1000);
+  });
+
+  it("respects a sub-hour cadence", () => {
+    const safeRollout = makeSafeRollout({ updateScheduleMinutes: 10 });
+
+    const { nextSnapshot } = determineNextSafeRolloutSnapshotAttempt(
+      safeRollout,
+      org,
+    );
+
+    expect(nextSnapshot.getTime()).toBe(NOW.getTime() + 10 * 60 * 1000);
+  });
+
+  it("falls back to the org update schedule when updateScheduleMinutes is unset", () => {
+    const safeRollout = makeSafeRollout();
+
+    const { nextSnapshot } = determineNextSafeRolloutSnapshotAttempt(
+      safeRollout,
+      org,
+    );
+
+    expect(nextSnapshot.getTime()).toBe(ORG_SCHEDULE_NEXT.getTime());
+  });
+});


### PR DESCRIPTION
### Features and Changes

For Safe Rollouts, the ramp up schedule can be different than the global Experiment Update schedule, so we need to honor it.

### Testing

New unit tests
