### PR TITLE
contextual bandit nits

### DIFF
--- a/packages/front-end/components/ContextualBandit/ContextualBanditDetailPage.tsx
+++ b/packages/front-end/components/ContextualBandit/ContextualBanditDetailPage.tsx
@@ -127,6 +127,8 @@ export default function ContextualBanditDetailPage({
     projects.find((p) => p.id === cb.project)?.name ?? cb.project ?? "None";
   const metricName = (id: string) => getExperimentMetricById(id)?.name ?? id;
 
+  const showResultsTab = cb.status !== "draft";
+
   const coveragePct = cb.coverage != null ? Math.round(cb.coverage * 100) : 100;
 
   const formatConversionWindow = (value: number, unit: string): string =>
@@ -359,7 +361,9 @@ export default function ContextualBanditDetailPage({
       <Tabs defaultValue="overview" persistInURL={true}>
         <TabsList>
           <TabsTrigger value="overview">Overview</TabsTrigger>
-          <TabsTrigger value="results">Results</TabsTrigger>
+          {showResultsTab ? (
+            <TabsTrigger value="results">Results</TabsTrigger>
+          ) : null}
         </TabsList>
 
         <TabsContent value="overview">
@@ -508,13 +512,15 @@ export default function ContextualBanditDetailPage({
           </Box>
         </TabsContent>
 
-        <TabsContent value="results">
-          <Box pt="4">
-            <Frame>
-              <ContextualBanditResultsTable cb={cb} mutate={mutate} />
-            </Frame>
-          </Box>
-        </TabsContent>
+        {showResultsTab ? (
+          <TabsContent value="results">
+            <Box pt="4">
+              <Frame>
+                <ContextualBanditResultsTable cb={cb} mutate={mutate} />
+              </Frame>
+            </Box>
+          </TabsContent>
+        ) : null}
       </Tabs>
 
       {showStart && cb.status === "draft" ? (

--- a/packages/front-end/pages/contextual-bandits/index.tsx
+++ b/packages/front-end/pages/contextual-bandits/index.tsx
@@ -91,7 +91,7 @@ const ContextualBanditsPage = (): React.ReactElement => {
     }
   }, [didInitializeTab, setStoredTab, storedTab, tab]);
 
-  const { contextualBandits, error, loading, hasArchived, mutate } =
+  const { contextualBandits, error, loading, hasArchived } =
     useContextualBandits(project, activeTab === "archived");
 
   const [showMineOnly, setShowMineOnly] = useLocalStorage(
@@ -428,10 +428,6 @@ const ContextualBanditsPage = (): React.ReactElement => {
       {openNewModal && (
         <ContextualBanditForm
           onClose={() => setOpenNewModal(false)}
-          onCreate={async () => {
-            await mutate();
-            setOpenNewModal(false);
-          }}
           source="contextual-bandits-list"
           isNewExperiment={true}
         />


### PR DESCRIPTION
### Features and Changes

Two small UX fixes on the Contextual Bandit surfaces:

**Hide the Results tab until the bandit is running.** On the CB detail page, the Results tab (both the trigger and its content) now only renders when `cb.status !== "draft"`. While a bandit is in draft there are no results to show, so the tab is hidden; it appears once the bandit is started and remains available after it's stopped.

**Route to the new detail page after creation.** Creating a Contextual Bandit from the list page previously just refreshed the list and closed the modal, leaving the user on the index. It now navigates to `/contextual-bandit/{id}`, matching the post-creation behavior of features and experiments. The `ContextualBanditForm` already contained this `router.push` in its default branch — the list page was overriding it with a custom `onCreate` handler. Removing that override lets the form's built-in navigation run (and drops the now-unused `mutate` from the list's `useContextualBandits` destructuring).

Files touched:

- `packages/front-end/components/ContextualBandit/ContextualBanditDetailPage.tsx`
- `packages/front-end/pages/contextual-bandits/index.tsx`

- Closes **(add link to issue here)**

### Dependencies

None.

### Testing

1. Create a new Contextual Bandit from the Contextual Bandits list page. Confirm you are redirected to the new bandit's detail page (`/contextual-bandit/{id}`) instead of staying on the list.
2. On a bandit in **draft** status, confirm only the **Overview** tab is visible — no **Results** tab.
3. Start the bandit. Confirm the **Results** tab now appears and its content renders.
4. Stop the bandit. Confirm the **Results** tab remains visible so past results can still be reviewed.

### Screenshots

<!-- Add before/after of the CB detail page tabs (draft vs. running), and optionally the redirect after creation -->