### PR TITLE
fix(safe-rollouts): Ensure we drop `null` customFields

### DIFF
--- a/packages/back-end/src/services/safeRolloutSnapshots.ts
+++ b/packages/back-end/src/services/safeRolloutSnapshots.ts
@@ -354,7 +354,10 @@ export function getSafeRolloutSnapshotSettings({
     phase: {
       index: "0",
     },
-    customFields,
+    // customFields originates from feature.customFields, a legacy Mongoose Mixed
+    // field that can be null. The settings validator's .optional() rejects null
+    // (accepts only undefined/record), so normalize to an empty record.
+    customFields: customFields ?? {},
     datasourceId: safeRollout.datasourceId || "",
     dimensions: settings.dimensions.map((id) => ({ id })),
     // Honor the rolling floor so post-restart snapshots skip prior-run exposures.


### PR DESCRIPTION
### Features and Changes

SafeRollouts, if they have been saved with `null` before we landed fixes to `BaseModel`, now throw a validation error.

This fixes it by coalescing from `null` to `(empty)` which is the correct API.

Note: this is a targeted fix. The proper fix is on the `BaseModel` but is riskier, so we are merging this to unblock users while we keep working on the `BaseModel` fix.
