### PR TITLE
fix(sdk): preserve repeated query parameters on redirects

### DIFF
--- a/packages/sdk-js/src/util.ts
+++ b/packages/sdk-js/src/util.ts
@@ -359,12 +359,13 @@ export function mergeQueryStrings(oldUrl: string, newUrl: string): string {
     return newUrl;
   }
 
+  const redirectKeys = new Set<string>();
+  redirectUrl.searchParams.forEach((_, key) => redirectKeys.add(key));
+
   currUrl.searchParams.forEach((value, key) => {
-    // skip  if search param already exists in redirectUrl
-    if (redirectUrl.searchParams.has(key)) {
-      return;
+    if (!redirectKeys.has(key)) {
+      redirectUrl.searchParams.append(key, value);
     }
-    redirectUrl.searchParams.set(key, value);
   });
 
   return redirectUrl.toString();

--- a/packages/sdk-js/test/cases.json
+++ b/packages/sdk-js/test/cases.json
@@ -7128,10 +7128,10 @@
       ]
     ],
     [
-      "redirects with query string on original url and persistQueryString enabled",
+      "preserves repeated query parameters when persistQueryString is enabled",
       {
         "attributes": { "id": "1" },
-        "url": "http://www.example.com/home?color=blue&food=sushi",
+        "url": "http://www.example.com/home?color=blue&color=green&food=sushi",
         "experiments": [
           {
             "key": "my-experiment",
@@ -7157,7 +7157,7 @@
         {
           "inExperiment": true,
           "urlRedirect": "http://www.example.com/home-new",
-          "urlWithParams": "http://www.example.com/home-new?color=blue&food=sushi"
+          "urlWithParams": "http://www.example.com/home-new?color=blue&color=green&food=sushi"
         }
       ]
     ],


### PR DESCRIPTION
### Features and Changes

Preserve repeated query parameters from the source URL when `persistQueryString` is enabled for an SDK URL redirect. Parameters already present in the destination URL still take precedence.

`mergeQueryStrings` previously copied parameters with `URLSearchParams.set()`. After the first value for a key was copied, the destination contained that key, so subsequent values were skipped.

### Testing

- `pnpm --filter @growthbook/growthbook test --runInBand test/json.test.ts` (475 tests)
- `pnpm --filter @growthbook/growthbook type-check`
- `pnpm exec eslint packages/sdk-js/src/util.ts --max-warnings 0`
- `pnpm exec prettier --check packages/sdk-js/src/util.ts packages/sdk-js/test/cases.json`
- `pnpm --filter @growthbook/growthbook build`
