### PR TITLE
fix(experiments): Allow variation key changes on running experiments with unknown variations

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1449,6 +1449,7 @@ export async function postExperiment(
       phaseEndDate?: string;
       variationWeights?: number[];
       coverage?: number;
+      isVariationKeyReconciliation?: boolean;
     },
     { id: string }
   >,
@@ -1461,7 +1462,13 @@ export async function postExperiment(
   const context = getContextFromReq(req);
   const { org, userId } = context;
   const { id } = req.params;
-  const { phaseStartDate, phaseEndDate, currentPhase, ...data } = req.body;
+  const {
+    phaseStartDate,
+    phaseEndDate,
+    currentPhase,
+    isVariationKeyReconciliation,
+    ...data
+  } = req.body;
 
   const experiment = await getExperimentById(context, id);
   const aiSettings = getAISettingsForOrg(context);
@@ -1641,16 +1648,18 @@ export async function postExperiment(
   const variationKeysChanged =
     !!data.variations &&
     data.variations.some((v) => v.key !== existingKeyById.get(v.id));
-  const variationsChanged = variationIdsChanged || variationKeysChanged;
   const coverageChanged =
     data.coverage !== undefined && data.coverage !== latestPhase?.coverage;
   const variationWeightsChanged =
     data.variationWeights !== undefined &&
     !isEqual(data.variationWeights, latestPhase?.variationWeights);
-  if (
-    experiment.status === "running" &&
-    (variationsChanged || coverageChanged || variationWeightsChanged)
-  ) {
+
+  const changesLivePayload =
+    variationIdsChanged ||
+    (variationKeysChanged && !isVariationKeyReconciliation) ||
+    coverageChanged ||
+    variationWeightsChanged;
+  if (experiment.status === "running" && changesLivePayload) {
     const linkedFeaturesForPayload = await getFeaturesByIds(
       context,
       experiment.linkedFeatures || [],

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -344,6 +344,7 @@ const Results: FC<{
                     key: ids[i] ?? v.key,
                   };
                 }),
+                isVariationKeyReconciliation: true,
               }),
             });
 

--- a/packages/front-end/components/Experiment/VariationIdWarning.tsx
+++ b/packages/front-end/components/Experiment/VariationIdWarning.tsx
@@ -103,7 +103,7 @@ const VariationIdWarning: FC<{
         {idModal && setVariationIds && (
           <FixVariationIds
             close={() => setIdModal(false)}
-            expected={definedVariations}
+            expected={variations.map((v) => v.id)}
             actual={returnedVariations}
             names={variations.map((v) => v.name)}
             setVariationIds={setVariationIds}


### PR DESCRIPTION
### Features and Changes

The simple creation flow PR introduced some guards around editing variation keys on a running experiment that is live in the payload. This broke the flow to "Fix Variation Ids" when there are unknown variations caught by the query runner. This PR allows those edits again through that flow.

### Dependencies

N/A

### Testing

- [x] Fixing variation ids no longer throws an error

### Screenshots

N/A
