### PR TITLE
Emit revision.published event when reverting a feature

### DIFF
--- a/packages/back-end/src/api/features/postFeatureRevisionPublish.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionPublish.ts
@@ -21,7 +21,10 @@ import {
   getMergeResultPublishEnvs,
   toApiRevision,
 } from "back-end/src/services/features";
-import { dispatchFeatureRevisionEvent } from "back-end/src/services/featureRevisionEvents";
+import {
+  dispatchFeatureRevisionEvent,
+  getPublishedRevisionForEvents,
+} from "back-end/src/services/featureRevisionEvents";
 import { getEnvironments } from "back-end/src/util/organization.util";
 import {
   BadRequestError,
@@ -244,14 +247,13 @@ export async function publishFeatureRevision(
     }),
   });
 
-  const updated = await getRevision({
-    context: req.context,
-    organization: req.organization.id,
-    featureId: feature.id,
-    feature,
-    version: req.params.version,
-  });
-  const finalRevision = updated ?? revision;
+  // Re-read so the event carries the published status; falls back to the
+  // in-memory revision instead of failing the already-committed publish.
+  const finalRevision = await getPublishedRevisionForEvents(
+    req.context,
+    updatedFeature,
+    revision,
+  );
 
   await dispatchFeatureRevisionEvent(
     req.context,

--- a/packages/back-end/src/api/features/postFeatureRevisionRevert.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRevert.ts
@@ -12,7 +12,10 @@ import { FeatureRevisionInterface } from "shared/types/feature-revision";
 import { postFeatureRevisionRevertValidator } from "shared/validators";
 import type { ApiReqContext } from "back-end/types/api";
 import { toApiRevision } from "back-end/src/services/features";
-import { dispatchFeatureRevisionEvent } from "back-end/src/services/featureRevisionEvents";
+import {
+  dispatchFeatureRevisionEvent,
+  getPublishedRevisionForEvents,
+} from "back-end/src/services/featureRevisionEvents";
 import { auditDetailsUpdate } from "back-end/src/services/audit";
 import {
   BadRequestError,
@@ -338,14 +341,13 @@ export async function revertFeatureRevision(
     }),
   });
 
-  const updated = await getRevision({
+  // Re-read so events and the response carry the published status; falls back
+  // to the in-memory revision instead of failing the already-committed revert.
+  const finalRevision = await getPublishedRevisionForEvents(
     context,
-    organization: organization.id,
-    featureId: feature.id,
-    feature,
-    version: publishedRevision.version,
-  });
-  const finalRevision = updated ?? publishedRevision;
+    updatedFeature,
+    publishedRevision,
+  );
 
   await dispatchFeatureRevisionEvent(
     context,

--- a/packages/back-end/src/api/features/postFeatureRevisionRevert.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRevert.ts
@@ -355,6 +355,16 @@ export async function revertFeatureRevision(
     { revertedToVersion: targetRevision.version },
   );
 
+  // A revert publishes a new revision, so emit the same lifecycle event as a
+  // regular publish — consumers watching `revision.published` see reverts too.
+  await dispatchFeatureRevisionEvent(
+    context,
+    updatedFeature,
+    finalRevision,
+    "revision.published",
+    {},
+  );
+
   return { feature, revision: finalRevision };
 }
 

--- a/packages/back-end/src/api/features/revertFeature.ts
+++ b/packages/back-end/src/api/features/revertFeature.ts
@@ -19,7 +19,10 @@ import {
   getFeature,
 } from "back-end/src/models/FeatureModel";
 import { auditDetailsUpdate } from "back-end/src/services/audit";
-import { dispatchFeatureRevisionEvent } from "back-end/src/services/featureRevisionEvents";
+import {
+  dispatchFeatureRevisionEvent,
+  getPublishedRevisionForEvents,
+} from "back-end/src/services/featureRevisionEvents";
 import {
   getApiFeatureObj,
   getSavedGroupMap,
@@ -271,29 +274,26 @@ export async function revertFeatureCore(
 
   const groupMap = await getSavedGroupMap(context);
   const experimentMap = await getExperimentMapForFeature(context, feature.id);
-  const latestRevision = await getRevision({
+  // Re-read so events and the response carry the published status; falls back
+  // to the in-memory revision instead of failing the already-committed revert.
+  const latestRevision = await getPublishedRevisionForEvents(
     context,
-    organization: updatedFeature.organization,
-    featureId: updatedFeature.id,
-    feature: updatedFeature,
-    version: updatedFeature.version,
-  });
+    updatedFeature,
+    newRevision,
+  );
   // Emit the same revision lifecycle events as the app's revert flow so
-  // webhook consumers see API-initiated reverts too. The re-read revision
-  // carries the published status; fall back to the in-memory one if the
-  // re-read came back empty.
-  const eventRevision = latestRevision ?? newRevision;
+  // webhook consumers see API-initiated reverts too.
   await dispatchFeatureRevisionEvent(
     context,
     updatedFeature,
-    eventRevision,
+    latestRevision,
     "revision.reverted",
     { revertedToVersion: version },
   );
   await dispatchFeatureRevisionEvent(
     context,
     updatedFeature,
-    eventRevision,
+    latestRevision,
     "revision.published",
     {},
   );

--- a/packages/back-end/src/api/features/revertFeature.ts
+++ b/packages/back-end/src/api/features/revertFeature.ts
@@ -19,6 +19,7 @@ import {
   getFeature,
 } from "back-end/src/models/FeatureModel";
 import { auditDetailsUpdate } from "back-end/src/services/audit";
+import { dispatchFeatureRevisionEvent } from "back-end/src/services/featureRevisionEvents";
 import {
   getApiFeatureObj,
   getSavedGroupMap,
@@ -277,6 +278,26 @@ export async function revertFeatureCore(
     feature: updatedFeature,
     version: updatedFeature.version,
   });
+  // Emit the same revision lifecycle events as the app's revert flow so
+  // webhook consumers see API-initiated reverts too. The re-read revision
+  // carries the published status; fall back to the in-memory one if the
+  // re-read came back empty.
+  const eventRevision = latestRevision ?? newRevision;
+  await dispatchFeatureRevisionEvent(
+    context,
+    updatedFeature,
+    eventRevision,
+    "revision.reverted",
+    { revertedToVersion: version },
+  );
+  await dispatchFeatureRevisionEvent(
+    context,
+    updatedFeature,
+    eventRevision,
+    "revision.published",
+    {},
+  );
+
   const safeRolloutMap =
     await context.models.safeRollout.getAllPayloadSafeRollouts();
 

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -2496,12 +2496,33 @@ export async function postFeatureRevert(
     }),
   });
 
+  // Re-read the revision so dispatched events carry the published status —
+  // publishRevision updates the document in Mongo, not the in-memory object.
+  const publishedRevision = await getRevision({
+    context,
+    organization: org.id,
+    featureId: feature.id,
+    feature: updatedFeature,
+    version: newRevision.version,
+  });
+  const finalRevision = publishedRevision ?? newRevision;
+
   await dispatchFeatureRevisionEvent(
     context,
     updatedFeature,
-    newRevision,
+    finalRevision,
     "revision.reverted",
     { revertedToVersion: revision.version },
+  );
+
+  // A revert publishes a new revision, so emit the same lifecycle event as a
+  // regular publish — consumers watching `revision.published` see reverts too.
+  await dispatchFeatureRevisionEvent(
+    context,
+    updatedFeature,
+    finalRevision,
+    "revision.published",
+    {},
   );
 
   res.status(200).json({

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -141,6 +141,7 @@ import {
 import {
   dispatchFeatureRevisionEvent,
   dispatchRevisionReviewEvent,
+  getPublishedRevisionForEvents,
   recordRevisionUpdate,
 } from "back-end/src/services/featureRevisionEvents";
 import {
@@ -2151,17 +2152,17 @@ export async function postFeaturePublish(
     }),
   });
 
-  const publishedRevision = await getRevision({
+  // Re-read so the event carries the published status; falls back to the
+  // in-memory revision instead of failing the already-committed publish.
+  const publishedRevision = await getPublishedRevisionForEvents(
     context,
-    organization: org.id,
-    featureId: feature.id,
-    feature,
-    version: parseInt(version),
-  });
+    updatedFeature,
+    revision,
+  );
   await dispatchFeatureRevisionEvent(
     context,
     updatedFeature,
-    publishedRevision ?? revision,
+    publishedRevision,
     "revision.published",
     {},
   );
@@ -2496,16 +2497,13 @@ export async function postFeatureRevert(
     }),
   });
 
-  // Re-read the revision so dispatched events carry the published status —
-  // publishRevision updates the document in Mongo, not the in-memory object.
-  const publishedRevision = await getRevision({
+  // Re-read so dispatched events carry the published status; falls back to
+  // the in-memory revision instead of failing the already-committed revert.
+  const finalRevision = await getPublishedRevisionForEvents(
     context,
-    organization: org.id,
-    featureId: feature.id,
-    feature: updatedFeature,
-    version: newRevision.version,
-  });
-  const finalRevision = publishedRevision ?? newRevision;
+    updatedFeature,
+    newRevision,
+  );
 
   await dispatchFeatureRevisionEvent(
     context,

--- a/packages/back-end/src/services/featureRevisionEvents.ts
+++ b/packages/back-end/src/services/featureRevisionEvents.ts
@@ -42,12 +42,18 @@ type ExtraPayload<T extends FeatureRevisionEvent> = Omit<
 // status (publishRevision updates the stored document, not the in-memory
 // object). Never throws: by the time this runs the publish has already
 // committed, so a failed read must not fail the request — fall back to the
-// caller's in-memory revision instead.
+// caller's in-memory revision instead. The in-memory object is still a draft,
+// so correct its status on the fallback since publication already succeeded —
+// a `revision.published` event that reported "draft" would misinform consumers.
 export async function getPublishedRevisionForEvents(
   ctx: ReqContext | ApiReqContext,
   feature: FeatureInterface,
   fallback: FeatureRevisionInterface,
 ): Promise<FeatureRevisionInterface> {
+  const publishedFallback: FeatureRevisionInterface = {
+    ...fallback,
+    status: "published",
+  };
   try {
     const updated = await getRevision({
       context: ctx,
@@ -56,10 +62,10 @@ export async function getPublishedRevisionForEvents(
       feature,
       version: fallback.version,
     });
-    return updated ?? fallback;
+    return updated ?? publishedFallback;
   } catch (e) {
     logger.error(e, "Error re-reading revision after publish for events");
-    return fallback;
+    return publishedFallback;
   }
 }
 

--- a/packages/back-end/src/services/featureRevisionEvents.ts
+++ b/packages/back-end/src/services/featureRevisionEvents.ts
@@ -8,6 +8,7 @@ import { FeatureRevisionUpdatedPayload } from "shared/validators";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import { createEvent, CreateEventData } from "back-end/src/models/EventModel";
+import { getRevision } from "back-end/src/models/FeatureRevisionModel";
 import { logger } from "back-end/src/util/logger";
 import {
   revisionToApiInterface,
@@ -36,6 +37,31 @@ type ExtraPayload<T extends FeatureRevisionEvent> = Omit<
   NotificationEventPayloadSchemaType<"feature", T>,
   RevisionBaseKeys
 >;
+
+// Re-read a just-published revision so event payloads carry the published
+// status (publishRevision updates the stored document, not the in-memory
+// object). Never throws: by the time this runs the publish has already
+// committed, so a failed read must not fail the request — fall back to the
+// caller's in-memory revision instead.
+export async function getPublishedRevisionForEvents(
+  ctx: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  fallback: FeatureRevisionInterface,
+): Promise<FeatureRevisionInterface> {
+  try {
+    const updated = await getRevision({
+      context: ctx,
+      organization: feature.organization,
+      featureId: feature.id,
+      feature,
+      version: fallback.version,
+    });
+    return updated ?? fallback;
+  } catch (e) {
+    logger.error(e, "Error re-reading revision after publish for events");
+    return fallback;
+  }
+}
 
 // Dispatch a `feature.revision.*` webhook event. Pulls projects/environments/tags
 // from the parent feature so downstream Slack/webhook filters work the same as

--- a/packages/back-end/test/api/revertFeature.test.ts
+++ b/packages/back-end/test/api/revertFeature.test.ts
@@ -23,6 +23,10 @@ jest.mock("back-end/src/services/audit", () => ({
   auditDetailsUpdate: jest.fn(() => ({})),
 }));
 
+jest.mock("back-end/src/services/featureRevisionEvents", () => ({
+  dispatchFeatureRevisionEvent: jest.fn(),
+}));
+
 jest.mock("back-end/src/services/organizations", () => ({
   getEnvironments: jest.fn(() => [
     { id: "production", description: "" },
@@ -45,6 +49,7 @@ import {
 } from "back-end/src/models/FeatureModel";
 import { getRevision } from "back-end/src/models/FeatureRevisionModel";
 import { getExperimentMapForFeature } from "back-end/src/models/ExperimentModel";
+import { dispatchFeatureRevisionEvent } from "back-end/src/services/featureRevisionEvents";
 
 const mockGetFeature = getFeature as jest.MockedFunction<typeof getFeature>;
 const mockGetRevision = getRevision as jest.MockedFunction<typeof getRevision>;
@@ -53,6 +58,9 @@ const mockCreateAndPublish = createAndPublishRevision as jest.MockedFunction<
 >;
 const mockGetExperimentMap = getExperimentMapForFeature as jest.MockedFunction<
   typeof getExperimentMapForFeature
+>;
+const mockDispatchEvent = dispatchFeatureRevisionEvent as jest.MockedFunction<
+  typeof dispatchFeatureRevisionEvent
 >;
 
 const ctx = {
@@ -159,5 +167,107 @@ describe("revertFeatureCore empty-diff guard", () => {
     expect(mockCreateAndPublish.mock.calls[0][0].changes).toEqual({
       defaultValue: "old-default",
     });
+  });
+});
+
+describe("revertFeatureCore revision events", () => {
+  function setupSuccessfulRevert() {
+    mockGetFeature.mockResolvedValue(makeFeature());
+    const targetRevision = {
+      version: 3,
+      status: "published",
+      defaultValue: "old-default",
+      rules: [],
+    } as never;
+    const updatedFeature = makeFeature({
+      version: 6,
+      defaultValue: "old-default",
+    });
+    mockCreateAndPublish.mockResolvedValue({
+      revision: { version: 6, status: "draft" } as never,
+      updatedFeature,
+    });
+    return { targetRevision, updatedFeature };
+  }
+
+  it("dispatches revision.reverted and revision.published with the re-read published revision", async () => {
+    const { targetRevision } = setupSuccessfulRevert();
+    const publishedRevision = { version: 6, status: "published" } as never;
+    // First getRevision call resolves the target revision; the second is the
+    // post-publish re-read. (The approval-check read in between is skipped
+    // because ctx mocks canBypassApprovalChecks to true — if that changes,
+    // queue a third value here.)
+    mockGetRevision
+      .mockResolvedValueOnce(targetRevision)
+      .mockResolvedValueOnce(publishedRevision);
+
+    await revertFeatureCore(
+      ctx,
+      org,
+      eventAudit,
+      { id: "feat_1" },
+      { revision: 3 },
+      jest.fn(),
+      false,
+    );
+
+    expect(mockDispatchEvent).toHaveBeenCalledTimes(2);
+    const [revertedCall, publishedCall] = mockDispatchEvent.mock.calls;
+    expect(revertedCall[2]).toBe(publishedRevision);
+    expect(revertedCall[3]).toBe("revision.reverted");
+    expect(revertedCall[4]).toEqual({ revertedToVersion: 3 });
+    expect(publishedCall[2]).toBe(publishedRevision);
+    expect(publishedCall[3]).toBe("revision.published");
+  });
+
+  it("falls back to the in-memory revision when the post-publish read returns nothing", async () => {
+    const { targetRevision } = setupSuccessfulRevert();
+    mockGetRevision
+      .mockResolvedValueOnce(targetRevision)
+      .mockResolvedValueOnce(null);
+
+    await revertFeatureCore(
+      ctx,
+      org,
+      eventAudit,
+      { id: "feat_1" },
+      { revision: 3 },
+      jest.fn(),
+      false,
+    );
+
+    expect(mockDispatchEvent).toHaveBeenCalledTimes(2);
+    expect(mockDispatchEvent.mock.calls[0][2]).toEqual({
+      version: 6,
+      status: "draft",
+    });
+    expect(mockDispatchEvent.mock.calls[1][2]).toEqual({
+      version: 6,
+      status: "draft",
+    });
+  });
+
+  it("dispatches no events when there is nothing to revert", async () => {
+    mockGetFeature.mockResolvedValue(makeFeature());
+    mockGetRevision.mockResolvedValue({
+      version: 3,
+      status: "published",
+      defaultValue: "live-default",
+      rules: [],
+    } as never);
+
+    await expect(
+      revertFeatureCore(
+        ctx,
+        org,
+        eventAudit,
+        { id: "feat_1" },
+        { revision: 3 },
+        jest.fn(),
+        false,
+      ),
+    ).rejects.toThrow(/Nothing to revert/);
+
+    expect(mockDispatchEvent).not.toHaveBeenCalled();
   });
 });

--- a/packages/back-end/test/api/revertFeature.test.ts
+++ b/packages/back-end/test/api/revertFeature.test.ts
@@ -231,7 +231,7 @@ describe("revertFeatureCore revision events", () => {
     expect(publishedCall[3]).toBe("revision.published");
   });
 
-  it("falls back to the in-memory revision when the post-publish read returns nothing", async () => {
+  it("falls back to the in-memory revision with a corrected published status when the post-publish read returns nothing", async () => {
     const { targetRevision } = setupSuccessfulRevert();
     mockGetRevision
       .mockResolvedValueOnce(targetRevision)
@@ -247,14 +247,16 @@ describe("revertFeatureCore revision events", () => {
       false,
     );
 
+    // Publication succeeded, so the fallback reports published — a
+    // revision.published event that said "draft" would misinform consumers.
     expect(mockDispatchEvent).toHaveBeenCalledTimes(2);
     expect(mockDispatchEvent.mock.calls[0][2]).toEqual({
       version: 6,
-      status: "draft",
+      status: "published",
     });
     expect(mockDispatchEvent.mock.calls[1][2]).toEqual({
       version: 6,
-      status: "draft",
+      status: "published",
     });
   });
 
@@ -278,7 +280,7 @@ describe("revertFeatureCore revision events", () => {
     expect(mockDispatchEvent).toHaveBeenCalledTimes(2);
     expect(mockDispatchEvent.mock.calls[0][2]).toEqual({
       version: 6,
-      status: "draft",
+      status: "published",
     });
   });
 

--- a/packages/back-end/test/api/revertFeature.test.ts
+++ b/packages/back-end/test/api/revertFeature.test.ts
@@ -23,7 +23,18 @@ jest.mock("back-end/src/services/audit", () => ({
   auditDetailsUpdate: jest.fn(() => ({})),
 }));
 
+jest.mock("back-end/src/models/EventModel", () => ({
+  createEvent: jest.fn(),
+}));
+
+jest.mock("back-end/src/util/logger", () => ({
+  logger: { error: jest.fn() },
+}));
+
+// Keep the real getPublishedRevisionForEvents (it drives the re-read/fallback
+// behavior under test, via the mocked getRevision) and stub only the dispatch.
 jest.mock("back-end/src/services/featureRevisionEvents", () => ({
+  ...jest.requireActual("back-end/src/services/featureRevisionEvents"),
   dispatchFeatureRevisionEvent: jest.fn(),
 }));
 
@@ -242,6 +253,30 @@ describe("revertFeatureCore revision events", () => {
       status: "draft",
     });
     expect(mockDispatchEvent.mock.calls[1][2]).toEqual({
+      version: 6,
+      status: "draft",
+    });
+  });
+
+  it("falls back and still succeeds when the post-publish read fails", async () => {
+    const { targetRevision } = setupSuccessfulRevert();
+    mockGetRevision
+      .mockResolvedValueOnce(targetRevision)
+      .mockRejectedValueOnce(new Error("mongo unavailable"));
+
+    // Must not throw — the revert already committed by the time the re-read runs.
+    await revertFeatureCore(
+      ctx,
+      org,
+      eventAudit,
+      { id: "feat_1" },
+      { revision: 3 },
+      jest.fn(),
+      false,
+    );
+
+    expect(mockDispatchEvent).toHaveBeenCalledTimes(2);
+    expect(mockDispatchEvent.mock.calls[0][2]).toEqual({
       version: 6,
       status: "draft",
     });

--- a/packages/back-end/test/services/featureRevisionEvents.test.ts
+++ b/packages/back-end/test/services/featureRevisionEvents.test.ts
@@ -3,6 +3,35 @@ import { FeatureRevisionInterface } from "shared/types/feature-revision";
 import { Environment } from "shared/types/organization";
 import { deriveRevisionEventEnvironments } from "back-end/src/events/eventEnvironments";
 
+jest.mock("back-end/src/models/FeatureRevisionModel", () => ({
+  getRevision: jest.fn(),
+}));
+jest.mock("back-end/src/models/EventModel", () => ({
+  createEvent: jest.fn(),
+}));
+jest.mock("back-end/src/util/logger", () => ({
+  logger: { error: jest.fn() },
+}));
+// The real services/features pulls in a heavy model/integration chain that
+// this unit test must not load. Only referenced inside dispatch functions,
+// which these tests never call.
+jest.mock("back-end/src/services/features", () => ({
+  revisionToApiInterface: jest.fn(),
+  toApiRevision: jest.fn(),
+}));
+jest.mock("back-end/src/services/audit", () => ({
+  auditDetailsUpdate: jest.fn(),
+}));
+jest.mock("back-end/src/util/organization.util", () => ({
+  getEnvironments: jest.fn(() => []),
+}));
+
+import { getPublishedRevisionForEvents } from "back-end/src/services/featureRevisionEvents";
+import { getRevision } from "back-end/src/models/FeatureRevisionModel";
+import { logger } from "back-end/src/util/logger";
+
+const mockGetRevision = getRevision as jest.MockedFunction<typeof getRevision>;
+
 // Dispatch of `feature.revision.*` events fans out to webhook/Slack filters
 // keyed by (project, tag, environment). The derivation here feeds that
 // `environments` filter. Regression: `Object.keys(revision.rules)` returns
@@ -214,5 +243,51 @@ describe("deriveRevisionEventEnvironments", () => {
     expect(out.sort()).toEqual(["dev", "production", "staging"]);
     // Each env listed exactly once.
     expect(new Set(out).size).toBe(out.length);
+  });
+});
+
+describe("getPublishedRevisionForEvents", () => {
+  const ctx = { org: { id: "org-1" } } as never;
+  const feature = mkFeature();
+  const fallback = {
+    version: 7,
+    status: "draft",
+  } as unknown as FeatureRevisionInterface;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns the re-read revision when the read succeeds", async () => {
+    const published = { version: 7, status: "published" } as never;
+    mockGetRevision.mockResolvedValue(published);
+
+    const result = await getPublishedRevisionForEvents(ctx, feature, fallback);
+
+    expect(result).toBe(published);
+    expect(mockGetRevision).toHaveBeenCalledWith({
+      context: ctx,
+      organization: feature.organization,
+      featureId: feature.id,
+      feature,
+      version: 7,
+    });
+  });
+
+  it("returns the fallback when the read finds nothing", async () => {
+    mockGetRevision.mockResolvedValue(null);
+
+    const result = await getPublishedRevisionForEvents(ctx, feature, fallback);
+
+    expect(result).toBe(fallback);
+  });
+
+  it("returns the fallback and logs instead of throwing when the read fails", async () => {
+    mockGetRevision.mockRejectedValue(new Error("mongo unavailable"));
+
+    const result = await getPublishedRevisionForEvents(ctx, feature, fallback);
+
+    expect(result).toBe(fallback);
+    expect(logger.error).toHaveBeenCalled();
   });
 });

--- a/packages/back-end/test/services/featureRevisionEvents.test.ts
+++ b/packages/back-end/test/services/featureRevisionEvents.test.ts
@@ -274,20 +274,21 @@ describe("getPublishedRevisionForEvents", () => {
     });
   });
 
-  it("returns the fallback when the read finds nothing", async () => {
+  it("returns the fallback with a corrected published status when the read finds nothing", async () => {
     mockGetRevision.mockResolvedValue(null);
 
     const result = await getPublishedRevisionForEvents(ctx, feature, fallback);
 
-    expect(result).toBe(fallback);
+    // Publication already succeeded, so the fallback is reported as published.
+    expect(result).toEqual({ ...fallback, status: "published" });
   });
 
-  it("returns the fallback and logs instead of throwing when the read fails", async () => {
+  it("returns the fallback with a corrected published status and logs instead of throwing when the read fails", async () => {
     mockGetRevision.mockRejectedValue(new Error("mongo unavailable"));
 
     const result = await getPublishedRevisionForEvents(ctx, feature, fallback);
 
-    expect(result).toBe(fallback);
+    expect(result).toEqual({ ...fallback, status: "published" });
     expect(logger.error).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Features and Changes

Reverting a feature publishes a new revision immediately, but webhook consumers couldn't tell:

- The one-click revert (`postFeatureRevert`) dispatched `feature.revision.reverted` using the in-memory revision object, which still had `status: "draft"` — `createRevision` starts revisions as drafts and `markRevisionAsPublished` only updates the stored document, never the in-memory one. So the webhook payload described a just-published revert as a draft.
- No revert path emitted `feature.revision.published`, so consumers that track live-state changes via publish lifecycle events never saw reverts. The REST revert endpoint (`revertFeatureCore`) emitted no revision events at all.

Reverts usually happen when something is wrong, so they're exactly the changes downstream consumers most need to see promptly.

This PR:

- Re-reads the revision after `publishRevision` (the same pattern the publish endpoints already use, with the same in-memory fallback if the re-read returns nothing) so `revision.reverted` carries the real published status.
- Dispatches `revision.published` from all three revert paths: the app's one-click revert, `POST /api/v2/features/:id/revert`, and `POST /api/v2/features/:id/revisions/:version/revert` with `strategy: "publish"` (the draft strategy is unchanged — nothing is published there).

Note on behavior: a revert now emits both `revision.reverted` and `revision.published` for the same revision. Consumers subscribed to both event types will receive two events per revert; `revision.reverted` remains the one carrying `revertedToVersion`. A possible future refactor is to dispatch publish events from `publishRevision` itself so every publish-shaped flow is covered uniformly, but that's a larger behavioral change than this fix needs.

- Closes **(no linked issue)**

### Dependencies

None

### Testing

- Extended `test/api/revertFeature.test.ts` with three cases: events dispatched with the re-read published revision; fallback to the in-memory revision when the re-read returns null; no events when there is nothing to revert.
- Verified manually against a local server (Mongo + back-end): before the change, a revert emitted `revision.reverted` with `status: "draft"` and no publish event; after, all three revert paths emit `feature.updated` + `revision.reverted` (status `published`, `revertedToVersion` set) + `revision.published`, confirmed in the stored events.

### Screenshots

N/A (back-end only)