### PR TITLE
Expose stepApproval and awaitingApproval in the ramp schedule API

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -24081,6 +24081,17 @@ paths:
                           - context
                         additionalProperties: false
                       - type: 'null'
+                  awaitingApproval:
+                    description: >-
+                      Computed at read time: whether a human approval is the
+                      gate blocking the schedule right now — either the
+                      start-approval gate (`requiresStartApproval` before step
+                      0) or the current step's `holdConditions.requiresApproval`
+                      once its time hold (if any) has elapsed. Paused schedules
+                      report `false` (the pause is the blocking gate). For
+                      monitored steps the approve-step endpoint may still reject
+                      an approval until analysis-based gates clear.
+                    type: boolean
                   monitoringStartDate:
                     description: >-
                       When the monitored section most recently started (first
@@ -24169,6 +24180,7 @@ paths:
                   - status
                   - currentStepIndex
                   - nextStepAt
+                  - awaitingApproval
                 additionalProperties: false
       x-codeSamples:
         - lang: cURL
@@ -24449,6 +24461,17 @@ paths:
                           - context
                         additionalProperties: false
                       - type: 'null'
+                  awaitingApproval:
+                    description: >-
+                      Computed at read time: whether a human approval is the
+                      gate blocking the schedule right now — either the
+                      start-approval gate (`requiresStartApproval` before step
+                      0) or the current step's `holdConditions.requiresApproval`
+                      once its time hold (if any) has elapsed. Paused schedules
+                      report `false` (the pause is the blocking gate). For
+                      monitored steps the approve-step endpoint may still reject
+                      an approval until analysis-based gates clear.
+                    type: boolean
                   monitoringStartDate:
                     description: >-
                       When the monitored section most recently started (first
@@ -24537,6 +24560,7 @@ paths:
                   - status
                   - currentStepIndex
                   - nextStepAt
+                  - awaitingApproval
                 additionalProperties: false
       x-codeSamples:
         - lang: cURL
@@ -24879,6 +24903,17 @@ paths:
                           - context
                         additionalProperties: false
                       - type: 'null'
+                  awaitingApproval:
+                    description: >-
+                      Computed at read time: whether a human approval is the
+                      gate blocking the schedule right now — either the
+                      start-approval gate (`requiresStartApproval` before step
+                      0) or the current step's `holdConditions.requiresApproval`
+                      once its time hold (if any) has elapsed. Paused schedules
+                      report `false` (the pause is the blocking gate). For
+                      monitored steps the approve-step endpoint may still reject
+                      an approval until analysis-based gates clear.
+                    type: boolean
                   monitoringStartDate:
                     description: >-
                       When the monitored section most recently started (first
@@ -24967,6 +25002,7 @@ paths:
                   - status
                   - currentStepIndex
                   - nextStepAt
+                  - awaitingApproval
                 additionalProperties: false
       x-codeSamples:
         - lang: cURL
@@ -25250,6 +25286,17 @@ paths:
                           - context
                         additionalProperties: false
                       - type: 'null'
+                  awaitingApproval:
+                    description: >-
+                      Computed at read time: whether a human approval is the
+                      gate blocking the schedule right now — either the
+                      start-approval gate (`requiresStartApproval` before step
+                      0) or the current step's `holdConditions.requiresApproval`
+                      once its time hold (if any) has elapsed. Paused schedules
+                      report `false` (the pause is the blocking gate). For
+                      monitored steps the approve-step endpoint may still reject
+                      an approval until analysis-based gates clear.
+                    type: boolean
                   monitoringStartDate:
                     description: >-
                       When the monitored section most recently started (first
@@ -25338,6 +25385,7 @@ paths:
                   - status
                   - currentStepIndex
                   - nextStepAt
+                  - awaitingApproval
                 additionalProperties: false
       x-codeSamples:
         - lang: cURL
@@ -46545,6 +46593,16 @@ components:
                 - context
               additionalProperties: false
             - type: 'null'
+        awaitingApproval:
+          description: >-
+            Computed at read time: whether a human approval is the gate blocking
+            the schedule right now — either the start-approval gate
+            (`requiresStartApproval` before step 0) or the current step's
+            `holdConditions.requiresApproval` once its time hold (if any) has
+            elapsed. Paused schedules report `false` (the pause is the blocking
+            gate). For monitored steps the approve-step endpoint may still
+            reject an approval until analysis-based gates clear.
+          type: boolean
         monitoringStartDate:
           description: >-
             When the monitored section most recently started (first monitored
@@ -46625,6 +46683,7 @@ components:
         - status
         - currentStepIndex
         - nextStepAt
+        - awaitingApproval
       additionalProperties: false
     Report:
       type: object

--- a/packages/back-end/src/models/RampScheduleModel.ts
+++ b/packages/back-end/src/models/RampScheduleModel.ts
@@ -6,6 +6,8 @@ import {
   RampScheduleInterface,
   RampStepAction,
   StepHoldConditions,
+  isAwaitingStartApproval,
+  isReadyForApproval,
   rampScheduleValidator,
 } from "shared/validators";
 import { RULE_ID_ENV_SUFFIX_DELIMITER, stemRuleId } from "shared/util";
@@ -187,6 +189,20 @@ export function rampScheduleToApiInterface(
       : doc.monitoringConfig,
     experimentHealthAction: doc.experimentHealthAction,
     currentStepEnteredAt: dateToIso(doc.currentStepEnteredAt),
+    // Reads bypass zod validation (only migrate() runs), so guard against
+    // legacy docs whose approvedAt is a string or an Invalid Date — the field
+    // was silently dropped before this mapping existed, so bad values were
+    // harmless and may still exist.
+    stepApproval:
+      doc.stepApproval &&
+      doc.stepApproval.approvedAt instanceof Date &&
+      !isNaN(doc.stepApproval.approvedAt.getTime())
+        ? {
+            ...doc.stepApproval,
+            approvedAt: doc.stepApproval.approvedAt.toISOString(),
+          }
+        : undefined,
+    awaitingApproval: isReadyForApproval(doc) || isAwaitingStartApproval(doc),
     monitoringStartDate: dateToIso(doc.monitoringStartDate),
     lastRollbackAt: dateToIso(doc.lastRollbackAt),
     lastRollbackReason: doc.lastRollbackReason,

--- a/packages/back-end/src/models/RampScheduleModel.ts
+++ b/packages/back-end/src/models/RampScheduleModel.ts
@@ -189,12 +189,19 @@ export function rampScheduleToApiInterface(
       : doc.monitoringConfig,
     experimentHealthAction: doc.experimentHealthAction,
     currentStepEnteredAt: dateToIso(doc.currentStepEnteredAt),
-    // Reads bypass zod validation (only migrate() runs), so guard against
+    // The record is only meaningful for the current step (see the field's
+    // "Valid only while stepApproval.stepIndex === currentStepIndex" contract).
+    // The service nulls stepApproval on every step transition, so a mismatch
+    // shouldn't occur, but guard defensively so we never surface a prior step's
+    // approver against the current step — matching how isAwaitingApproval treats
+    // it internally.
+    // Reads also bypass zod validation (only migrate() runs), so guard against
     // legacy docs whose approvedAt is a string or an Invalid Date — the field
     // was silently dropped before this mapping existed, so bad values were
     // harmless and may still exist.
     stepApproval:
       doc.stepApproval &&
+      doc.stepApproval.stepIndex === doc.currentStepIndex &&
       doc.stepApproval.approvedAt instanceof Date &&
       !isNaN(doc.stepApproval.approvedAt.getTime())
         ? {

--- a/packages/back-end/test/models/rampScheduleToApiInterface.test.ts
+++ b/packages/back-end/test/models/rampScheduleToApiInterface.test.ts
@@ -89,4 +89,28 @@ describe("rampScheduleToApiInterface approval fields", () => {
       context: "api",
     });
   });
+
+  it("omits stepApproval when it belongs to a step other than the current one", () => {
+    const api = rampScheduleToApiInterface(
+      makeSchedule({
+        currentStepIndex: 1,
+        steps: [
+          { interval: null, actions: [], holdConditions: {} },
+          {
+            interval: null,
+            actions: [],
+            holdConditions: { requiresApproval: true },
+          },
+        ] as unknown as RampScheduleInterface["steps"],
+        stepApproval: {
+          stepIndex: 0,
+          approvedAt: new Date("2024-01-02T03:04:05Z"),
+          approvedBy: "u_1",
+          context: "api",
+        },
+      }),
+    );
+    expect(api.stepApproval).toBeUndefined();
+    expect(api.awaitingApproval).toBe(true);
+  });
 });

--- a/packages/back-end/test/models/rampScheduleToApiInterface.test.ts
+++ b/packages/back-end/test/models/rampScheduleToApiInterface.test.ts
@@ -1,0 +1,92 @@
+// Mocked only to sever the heavy services/rampSchedule import chain — no test
+// here exercises the monitoringStatus branch that calls these.
+jest.mock("back-end/src/services/rampSchedule", () => ({
+  getEffectiveRampAutoUpdateState: jest.fn(),
+  getRampMonitoringMode: jest.fn(),
+  getRampAutoUpdatePreference: jest.fn(),
+}));
+
+import { RampScheduleInterface } from "shared/validators";
+import { rampScheduleToApiInterface } from "back-end/src/models/RampScheduleModel";
+
+function makeSchedule(
+  overrides: Partial<RampScheduleInterface> = {},
+): RampScheduleInterface {
+  return {
+    id: "rs_1",
+    organization: "org_1",
+    dateCreated: new Date("2024-01-01T00:00:00Z"),
+    dateUpdated: new Date("2024-01-01T00:00:00Z"),
+    name: "Test ramp",
+    entityType: "feature",
+    entityId: "feat_1",
+    targets: [],
+    steps: [
+      {
+        interval: null,
+        actions: [],
+        holdConditions: { requiresApproval: true },
+      },
+    ],
+    status: "running",
+    currentStepIndex: 0,
+    nextStepAt: null,
+    ...overrides,
+  } as unknown as RampScheduleInterface;
+}
+
+describe("rampScheduleToApiInterface approval fields", () => {
+  it("reports awaitingApproval when the current step's only remaining gate is approval", () => {
+    const api = rampScheduleToApiInterface(makeSchedule());
+    expect(api.awaitingApproval).toBe(true);
+    expect(api.stepApproval).toBeUndefined();
+  });
+
+  it("reports awaitingApproval for a pre-start schedule with an unapproved start gate", () => {
+    const api = rampScheduleToApiInterface(
+      makeSchedule({
+        status: "ready",
+        currentStepIndex: -1,
+        requiresStartApproval: true,
+        startApprovedAt: null,
+      }),
+    );
+    expect(api.awaitingApproval).toBe(true);
+  });
+
+  it("does not report awaitingApproval while an approval step's time hold is still counting", () => {
+    const api = rampScheduleToApiInterface(
+      makeSchedule({
+        steps: [
+          {
+            interval: 3600,
+            actions: [],
+            holdConditions: { requiresApproval: true },
+          },
+        ],
+        nextStepAt: new Date(Date.now() + 60 * 60 * 1000),
+      } as unknown as Partial<RampScheduleInterface>),
+    );
+    expect(api.awaitingApproval).toBe(false);
+  });
+
+  it("clears awaitingApproval and serializes stepApproval once the current step is approved", () => {
+    const api = rampScheduleToApiInterface(
+      makeSchedule({
+        stepApproval: {
+          stepIndex: 0,
+          approvedAt: new Date("2024-01-02T03:04:05Z"),
+          approvedBy: "u_1",
+          context: "api",
+        },
+      }),
+    );
+    expect(api.awaitingApproval).toBe(false);
+    expect(api.stepApproval).toEqual({
+      stepIndex: 0,
+      approvedAt: "2024-01-02T03:04:05.000Z",
+      approvedBy: "u_1",
+      context: "api",
+    });
+  });
+});

--- a/packages/shared/src/validators/ramp-schedule.ts
+++ b/packages/shared/src/validators/ramp-schedule.ts
@@ -607,6 +607,11 @@ export const apiRampScheduleInterface = namedSchema(
       .describe(
         "Approval record for the current step. Valid only while `stepApproval.stepIndex === currentStepIndex`.",
       ),
+    awaitingApproval: z
+      .boolean()
+      .describe(
+        "Computed at read time: whether a human approval is the gate blocking the schedule right now — either the start-approval gate (`requiresStartApproval` before step 0) or the current step's `holdConditions.requiresApproval` once its time hold (if any) has elapsed. Paused schedules report `false` (the pause is the blocking gate). For monitored steps the approve-step endpoint may still reject an approval until analysis-based gates clear.",
+      ),
     monitoringStartDate: z.iso
       .datetime()
       .nullish()


### PR DESCRIPTION
### Features and Changes

Two related gaps in the ramp schedule REST API responses:

1. **`stepApproval` was silently dropped.** The API schema declares it, but `rampScheduleToApiInterface` never mapped it, so it was absent from every response even though the OpenAPI docs promised it.
2. **No way to tell a schedule is waiting on a human.** Deriving "held for approval" externally requires `stepApproval` (missing, per above) plus re-implementing the monitored-vs-non-monitored interval timing logic — easy to get wrong. A consumer polling the API couldn't distinguish "held waiting for approval" from "partway through a step's time interval", so approval holds could go unnoticed.

This PR:

- Maps `stepApproval` in the serializer (with a guard for legacy docs whose `approvedAt` is malformed — those were harmlessly dropped before this mapping existed, so they must not start 500ing the list endpoint now).
- Adds a computed `awaitingApproval` boolean to ramp schedule responses: `true` when a human approval is the gate blocking the schedule *right now* — the start-approval gate before step 0, or the current step's `requiresApproval` hold once its time hold (if any) has elapsed. It uses the same `isReadyForApproval` derivation as the app's "Needs Approval" surface, so consumers aren't prompted to approve steps whose timers are still counting (the approve-step endpoint would reject those as premature anyway). Paused schedules report `false`; for monitored steps, approve-step may still reject until analysis-based gates clear (noted in the field description).
- Regenerates the OpenAPI spec.

### Dependencies

None

### Testing

- New unit tests for `rampScheduleToApiInterface` covering: approval-only step (true), pre-start start gate (true), approval step mid-interval (false), and approved step (false + `stepApproval` serialized).
- Verified manually against a local server: seeded schedules for all cases (including one with a garbage string `approvedAt`) and confirmed `GET /api/v1/ramp-schedules` and get-by-id return the expected `awaitingApproval`/`stepApproval` values without errors.

### Screenshots

N/A (back-end only)