### PR TITLE
BugFix/Redshift HLL type casting to use HLLSKETCH instead of VARBINARY

### DIFF
--- a/packages/back-end/src/integrations/dialects/redshift.ts
+++ b/packages/back-end/src/integrations/dialects/redshift.ts
@@ -23,38 +23,9 @@ export const redshiftDialect: SqlDialect = {
   hllAggregate: (col: string) => `HLL_CREATE_SKETCH(${col})`,
   hllReaggregate: (col: string) => `HLL_COMBINE(${col})`,
   hllCardinality: (col: string) => `HLL_CARDINALITY(${col})`,
-  // HLL_CREATE_SKETCH/HLL_COMBINE already return Redshift's native HLLSKETCH
-  // type. The base dialect's default of VARBINARY doesn't apply here — Redshift
-  // has no cast path from HLLSKETCH to VARBINARY/VARBYTE, so CAST(... AS
-  // VARBINARY) fails with "cannot cast type hllsketch to binary varying".
-  // Casting to HLLSKETCH instead is a no-op that keeps the column typed
-  // correctly for later HLL_COMBINE/HLL_CARDINALITY calls.
+  // HLL_CREATE_SKETCH/HLL_COMBINE return HLLSKETCH; casting to VARBINARY fails, so cast to HLLSKETCH (no-op) instead.
   getDataType: (dataType: DataType): string => {
-    switch (dataType) {
-      case "string":
-        return "VARCHAR";
-      case "integer":
-        return "INTEGER";
-      case "float":
-        return "DOUBLE";
-      case "boolean":
-        return "BOOLEAN";
-      case "date":
-        return "DATE";
-      case "timestamp":
-        return "TIMESTAMP";
-      case "hll":
-        return "HLLSKETCH";
-      case "quantileSketch":
-        // Quantile sketches aren't supported on Redshift (quantileSketchInit
-        // etc. fall back to the base dialect's "not supported" errors), so
-        // this value is never actually used to build SQL.
-        return "VARBINARY";
-      default: {
-        const _: never = dataType;
-        throw new Error(`Unsupported data type: ${dataType}`);
-      }
-    }
+    return dataType === "hll" ? "HLLSKETCH" : baseDialect.getDataType(dataType);
   },
   jsonExtract: (jsonCol: string, path: string, isNumeric: boolean) => {
     const raw = `JSON_EXTRACT_PATH_TEXT(${jsonCol}, ${path

--- a/packages/back-end/src/integrations/dialects/redshift.ts
+++ b/packages/back-end/src/integrations/dialects/redshift.ts
@@ -1,3 +1,4 @@
+import type { DataType } from "shared/types/integrations";
 import { createLikeStringMatchFn } from "shared/sql";
 import type { SqlDialect } from "shared/types/sql";
 import { indicesTableUnpivot } from "back-end/src/integrations/sql/clauses/indices-table-unpivot";
@@ -22,6 +23,39 @@ export const redshiftDialect: SqlDialect = {
   hllAggregate: (col: string) => `HLL_CREATE_SKETCH(${col})`,
   hllReaggregate: (col: string) => `HLL_COMBINE(${col})`,
   hllCardinality: (col: string) => `HLL_CARDINALITY(${col})`,
+  // HLL_CREATE_SKETCH/HLL_COMBINE already return Redshift's native HLLSKETCH
+  // type. The base dialect's default of VARBINARY doesn't apply here — Redshift
+  // has no cast path from HLLSKETCH to VARBINARY/VARBYTE, so CAST(... AS
+  // VARBINARY) fails with "cannot cast type hllsketch to binary varying".
+  // Casting to HLLSKETCH instead is a no-op that keeps the column typed
+  // correctly for later HLL_COMBINE/HLL_CARDINALITY calls.
+  getDataType: (dataType: DataType): string => {
+    switch (dataType) {
+      case "string":
+        return "VARCHAR";
+      case "integer":
+        return "INTEGER";
+      case "float":
+        return "DOUBLE";
+      case "boolean":
+        return "BOOLEAN";
+      case "date":
+        return "DATE";
+      case "timestamp":
+        return "TIMESTAMP";
+      case "hll":
+        return "HLLSKETCH";
+      case "quantileSketch":
+        // Quantile sketches aren't supported on Redshift (quantileSketchInit
+        // etc. fall back to the base dialect's "not supported" errors), so
+        // this value is never actually used to build SQL.
+        return "VARBINARY";
+      default: {
+        const _: never = dataType;
+        throw new Error(`Unsupported data type: ${dataType}`);
+      }
+    }
+  },
   jsonExtract: (jsonCol: string, path: string, isNumeric: boolean) => {
     const raw = `JSON_EXTRACT_PATH_TEXT(${jsonCol}, ${path
       .split(".")

--- a/packages/back-end/test/integrations/dialects/hll-data-type.test.ts
+++ b/packages/back-end/test/integrations/dialects/hll-data-type.test.ts
@@ -5,14 +5,8 @@ import { databricksDialect } from "back-end/src/integrations/dialects/databricks
 import { redshiftDialect } from "back-end/src/integrations/dialects/redshift";
 import { castToHllDataType } from "back-end/src/integrations/sql/primitives/cast-to-hll-data-type";
 
-// Every dialect that implements hllAggregate (i.e. supports "count distinct"
-// fact metrics) must also override getDataType("hll") to match whatever type
-// its HLL functions actually return. If a dialect's HLL sketch type isn't
-// castable to the base default of VARBINARY, castToHllDataType() produces
-// invalid SQL. See growthbook/growthbook#<issue> — Redshift previously fell
-// through to VARBINARY even though HLL_CREATE_SKETCH returns HLLSKETCH,
-// which cannot be cast to VARBINARY/VARBYTE and errored with
-// "cannot cast type hllsketch to binary varying".
+// Dialects supporting HLL count-distinct must override getDataType("hll")
+// to match their sketch type, or castToHllDataType() emits invalid SQL.
 describe("SqlDialect getDataType('hll') matches each dialect's HLL sketch type", () => {
   const cases: [
     string,

--- a/packages/back-end/test/integrations/dialects/hll-data-type.test.ts
+++ b/packages/back-end/test/integrations/dialects/hll-data-type.test.ts
@@ -1,0 +1,41 @@
+import { baseDialect } from "back-end/src/integrations/dialects/base";
+import { bigQueryDialect } from "back-end/src/integrations/dialects/bigquery";
+import { snowflakeDialect } from "back-end/src/integrations/dialects/snowflake";
+import { databricksDialect } from "back-end/src/integrations/dialects/databricks";
+import { redshiftDialect } from "back-end/src/integrations/dialects/redshift";
+import { castToHllDataType } from "back-end/src/integrations/sql/primitives/cast-to-hll-data-type";
+
+// Every dialect that implements hllAggregate (i.e. supports "count distinct"
+// fact metrics) must also override getDataType("hll") to match whatever type
+// its HLL functions actually return. If a dialect's HLL sketch type isn't
+// castable to the base default of VARBINARY, castToHllDataType() produces
+// invalid SQL. See growthbook/growthbook#<issue> — Redshift previously fell
+// through to VARBINARY even though HLL_CREATE_SKETCH returns HLLSKETCH,
+// which cannot be cast to VARBINARY/VARBYTE and errored with
+// "cannot cast type hllsketch to binary varying".
+describe("SqlDialect getDataType('hll') matches each dialect's HLL sketch type", () => {
+  const cases: [
+    string,
+    { getDataType: typeof baseDialect.getDataType },
+    string,
+  ][] = [
+    ["bigquery", bigQueryDialect, "BYTES"],
+    ["databricks", databricksDialect, "BINARY"],
+    ["snowflake", snowflakeDialect, "BINARY"],
+    [
+      "redshift (native HLLSKETCH, not VARBINARY)",
+      redshiftDialect,
+      "HLLSKETCH",
+    ],
+  ];
+
+  it.each(cases)("%s", (_name, dialect, expected) => {
+    expect(dialect.getDataType("hll")).toBe(expected);
+  });
+
+  it("redshift: castToHllDataType casts to HLLSKETCH, not VARBINARY", () => {
+    expect(castToHllDataType(redshiftDialect, "HLL_CREATE_SKETCH(col)")).toBe(
+      "CAST(HLL_CREATE_SKETCH(col) AS HLLSKETCH)",
+    );
+  });
+});


### PR DESCRIPTION
### Features and Changes

Fact metrics using "count distinct" aggregation on Redshift failed with `Analysis error: cannot cast type hllsketch to binary varying`. `castToHllDataType()` casts every HLL sketch to `dialect.getDataType("hll")` before storing it for re-aggregation across days, and that defaults to `VARBINARY` unless a dialect overrides it. BigQuery, Databricks, and Snowflake already override it to their own native sketch type, but the Redshift dialect never did. Add a `getDataType` override so Redshift casts to `HLLSKETCH` instead, matching what `HLL_CREATE_SKETCH`/`HLL_COMBINE` actually return:

- Before: `CAST(HLL_CREATE_SKETCH(col) AS VARBINARY)` → errors, Redshift has no cast path from `HLLSKETCH` to `VARBINARY`/`VARBYTE`
- After: `CAST(HLL_CREATE_SKETCH(col) AS HLLSKETCH)` → no-op cast, matches the native return type

### Testing

Added `hll-data-type.test.ts`, asserting each HLL-capable dialect's `getDataType("hll")` matches its own sketch type, plus a regression check on the exact Redshift cast output. `jest test/integrations/dialects` passes, and `prettier`/`eslint` are clean on both changed files. To verify end-to-end, run a "count distinct" fact metric analysis against a Redshift data source and confirm the query no longer errors.