### PR TITLE
Migrate never-provisioned legacy managed warehouses with a settings-only rewrite

### DIFF
--- a/packages/back-end/src/jobs/sweepManagedWarehouseMigrations.ts
+++ b/packages/back-end/src/jobs/sweepManagedWarehouseMigrations.ts
@@ -12,20 +12,21 @@ const ENQUEUE_DELAY_MS = 1000;
 type ManagedWarehouseDatasourceDoc = {
   organization: string;
   type: string;
-  settings?: { useJsonColumns?: boolean; hasBeenProvisioned?: boolean };
+  settings?: { useJsonColumns?: boolean };
 };
 
-// Provisioned managed warehouses that aren't fully migrated yet. Mirrors
+// Managed warehouses that aren't fully migrated yet. Mirrors
 // isManagedWarehouseAwaitingJsonMigration (useJsonColumns not set OR materializedColumns
 // not yet cleared) plus a stuck-after-success `migrating: true`, so partially-migrated
-// and stuck warehouses are still drained even if they're never queried. A fully migrated
-// warehouse (useJsonColumns set, materializedColumns cleared, not migrating) drops out, so
-// this set shrinks monotonically. countDocuments on this filter is also the cutover gate:
-// once it holds at 0 there are no partial migrations left, so the legacy code paths can be
+// and stuck warehouses are still drained even if they're never queried. Never-provisioned
+// legacy warehouses are included: they get a Mongo-only settings rewrite (no tables exist
+// yet), so eventual provisioning creates JSON DDL directly. A fully migrated warehouse
+// (useJsonColumns set, materializedColumns cleared, not migrating) drops out, so this set
+// shrinks monotonically. countDocuments on this filter is also the cutover gate: once it
+// holds at 0 there are no partial migrations left, so the legacy code paths can be
 // removed.
 const LEGACY_FILTER = {
   type: "growthbook_clickhouse",
-  "settings.hasBeenProvisioned": { $ne: false },
   $or: [
     { "settings.useJsonColumns": { $ne: true } },
     { "settings.materializedColumns.0": { $exists: true } },

--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -204,6 +204,44 @@ export async function clearManagedWarehouseRecreateStatus(
   );
 }
 
+/**
+ * Best-effort acquire of the license server's per-datasource lock (`lockUntil` —
+ * top-level and schema-less like the recreate fields, with matching semantics) so
+ * app-side managed-warehouse mutations can mutually exclude license-server
+ * operations (provision/recreate) on the same doc. Returns false when the lock is
+ * already held; pair with `unlockManagedWarehouseDatasource` in a `finally`.
+ */
+export async function tryLockManagedWarehouseDatasource(
+  context: ReqContext | ApiReqContext,
+  seconds: number,
+): Promise<boolean> {
+  const now = new Date();
+  const result = await getCollection<{ lockUntil?: Date | null }>(
+    "datasources",
+  ).updateOne(
+    {
+      organization: context.org.id,
+      type: "growthbook_clickhouse",
+      $or: [
+        { lockUntil: { $exists: false } },
+        { lockUntil: null },
+        { lockUntil: { $lte: now } },
+      ],
+    },
+    { $set: { lockUntil: new Date(now.getTime() + seconds * 1000) } },
+  );
+  return result.matchedCount > 0;
+}
+
+export async function unlockManagedWarehouseDatasource(
+  context: ReqContext | ApiReqContext,
+): Promise<void> {
+  await getCollection<{ lockUntil?: Date | null }>("datasources").updateOne(
+    { organization: context.org.id, type: "growthbook_clickhouse" },
+    { $set: { lockUntil: null } },
+  );
+}
+
 export async function getDataSourceById(
   context: ReqContext | ApiReqContext,
   id: string,

--- a/packages/back-end/src/services/clickhouse.ts
+++ b/packages/back-end/src/services/clickhouse.ts
@@ -615,6 +615,85 @@ async function fireManagedWarehouseRecreate(
   }
 }
 
+// Legacy matcol metadata to carry through the JSON migration:
+// - Identifiers: every legacy custom identifier (a `userIdType` that isn't a built-in
+//   or a current hashAttribute) is preserved as an `attributes`-aliased top-level
+//   column, exactly like a hashAttribute identifier. This keeps the join keys
+//   experiments/metrics depend on, so the migration never has to skip a warehouse
+//   over identifier drift. Persisted in `migratedIdentifiers` so the attribute-change
+//   sync re-includes them.
+// - Dimensions: non-identifier matcols preserved as top-level aliases (so bare
+//   references in raw-SQL filters, exposure breakdowns, and fact-table-routed
+//   metrics keep resolving).
+function getPreservedLegacyColumns(
+  context: ReqContext | ApiReqContext,
+  datasource: GrowthbookClickhouseDataSource,
+) {
+  const attributeSchema = context.org.settings?.attributeSchema;
+  const builtins = new Set<string>(MANAGED_WAREHOUSE_BUILTIN_IDENTIFIERS);
+  const schemaIdentifiers = new Set(
+    getManagedWarehouseCustomIdentifiers(attributeSchema),
+  );
+  const migratedIdentifiers = (datasource.settings.userIdTypes || [])
+    .map((u) => u.userIdType)
+    .filter((t) => !builtins.has(t) && !schemaIdentifiers.has(t));
+  const migratedColumns = getMigratedDimensionColumns(
+    datasource.settings.materializedColumns || [],
+    MANAGED_WAREHOUSE_RESERVED_COLUMN_NAMES,
+  );
+  return { migratedIdentifiers, migratedColumns };
+}
+
+// Migrate a never-provisioned legacy warehouse with Mongo-only settings updates: no
+// ClickHouse database exists yet, so there is nothing to rebuild and no queries to
+// block (`migrating` stays unset). Mirrors the provisioned flow's metadata steps and
+// its crash-safety: `materializedColumns` is cleared last, so a crash re-runs this on
+// the next sweep or on-read trigger.
+async function migrateUnprovisionedManagedWarehouseSettings(
+  context: ReqContext | ApiReqContext,
+  datasource: GrowthbookClickhouseDataSource,
+): Promise<void> {
+  const { migratedIdentifiers, migratedColumns } = getPreservedLegacyColumns(
+    context,
+    datasource,
+  );
+
+  await updateDataSource(
+    context,
+    datasource,
+    {
+      settings: {
+        ...datasource.settings,
+        useJsonColumns: true,
+        migratedIdentifiers,
+        migratedColumns,
+      },
+    },
+    { skipExposureQueryValidation: true },
+  );
+
+  // Mongo-only: regenerates userIdTypes/exposure queries (and the ch_events fact
+  // table, if one exists) for the JSON model.
+  await syncManagedWarehouseIdentifiers(context);
+
+  // Clear materializedColumns last (re-fetch: the sync mutated the datasource
+  // settings); only then is the warehouse fully migrated and out of the legacy set.
+  const synced =
+    await dangerouslyGetGrowthbookDatasourceBypassPermission(context);
+  if (!synced || synced.type !== "growthbook_clickhouse") {
+    logger.error(
+      `Managed warehouse migration for org ${datasource.organization}: could not re-fetch datasource after sync; migration will re-trigger on next sweep`,
+    );
+    return;
+  }
+  await updateDataSource(
+    context,
+    synced,
+    { settings: { ...synced.settings, materializedColumns: undefined } },
+    { skipExposureQueryValidation: true },
+  );
+}
+
 // Migrate a legacy (materialized-column) managed warehouse to native JSON columns.
 // Recreate now acks and rebuilds the per-org tables in the background under a
 // datasource lock (holding the connection open for the whole rebuild 504'd behind the
@@ -633,9 +712,14 @@ export async function migrateManagedWarehouseToJson(
     return;
   }
 
-  // Defer until provisioned: recreating tables for a never-provisioned org would
-  // race the normal provisioning flow (and spam Sentry).
+  // Never-provisioned warehouses have no physical tables, so a Mongo-only settings
+  // rewrite fully migrates them (recreating tables here would race the normal
+  // provisioning flow). Once `useJsonColumns` is persisted, eventual provisioning
+  // creates the JSON DDL directly.
   if (isManagedWarehouseAwaitingProvisioning(datasource)) {
+    if (isManagedWarehouseAwaitingJsonMigration(datasource)) {
+      await migrateUnprovisionedManagedWarehouseSettings(context, datasource);
+    }
     return;
   }
 
@@ -678,27 +762,9 @@ export async function migrateManagedWarehouseToJson(
   }
 
   // awaiting === true: (re)start the migration.
-  const matColumns = datasource.settings.materializedColumns || [];
-  const attributeSchema = context.org.settings?.attributeSchema;
-
-  // Preserve every legacy custom identifier (a `userIdType` that isn't a built-in or a
-  // current hashAttribute) by carrying it as an `attributes`-aliased top-level column,
-  // exactly like a hashAttribute identifier. This keeps the join keys experiments/metrics
-  // depend on, so the migration never has to skip a warehouse over identifier drift.
-  // Persisted in `migratedIdentifiers` so the attribute-change sync re-includes them.
-  const builtins = new Set<string>(MANAGED_WAREHOUSE_BUILTIN_IDENTIFIERS);
-  const schemaIdentifiers = new Set(
-    getManagedWarehouseCustomIdentifiers(attributeSchema),
-  );
-  const migratedIdentifiers = (datasource.settings.userIdTypes || [])
-    .map((u) => u.userIdType)
-    .filter((t) => !builtins.has(t) && !schemaIdentifiers.has(t));
-
-  // Non-identifier dimensions to preserve as top-level aliases (so bare references in
-  // raw-SQL filters, exposure breakdowns, and fact-table-routed metrics keep resolving).
-  const migratedColumns = getMigratedDimensionColumns(
-    matColumns,
-    MANAGED_WAREHOUSE_RESERVED_COLUMN_NAMES,
+  const { migratedIdentifiers, migratedColumns } = getPreservedLegacyColumns(
+    context,
+    datasource,
   );
 
   // Enter the transient "migrating" state (still provisioned) so in-flight usage

--- a/packages/back-end/src/services/clickhouse.ts
+++ b/packages/back-end/src/services/clickhouse.ts
@@ -39,6 +39,8 @@ import {
   dangerouslyGetGrowthbookDatasourceBypassPermission,
   clearManagedWarehouseRecreateStatus,
   getManagedWarehouseRecreateState,
+  tryLockManagedWarehouseDatasource,
+  unlockManagedWarehouseDatasource,
   updateDataSource,
 } from "back-end/src/models/DataSourceModel";
 import {
@@ -649,49 +651,76 @@ function getPreservedLegacyColumns(
 // block (`migrating` stays unset). Mirrors the provisioned flow's metadata steps and
 // its crash-safety: `materializedColumns` is cleared last, so a crash re-runs this on
 // the next sweep or on-read trigger.
+//
+// Runs under the license server's per-datasource lock to mutually exclude
+// event-triggered provisioning: without it, our full-settings write could revert a
+// concurrent provision's `hasBeenProvisioned: true`, or the provision could create
+// legacy DDL from a pre-rewrite settings read. If provisioning wins instead, the doc
+// re-enters the sweep as a provisioned legacy warehouse and the rebuild path handles
+// it.
 async function migrateUnprovisionedManagedWarehouseSettings(
   context: ReqContext | ApiReqContext,
-  datasource: GrowthbookClickhouseDataSource,
 ): Promise<void> {
-  const { migratedIdentifiers, migratedColumns } = getPreservedLegacyColumns(
-    context,
-    datasource,
-  );
-
-  await updateDataSource(
-    context,
-    datasource,
-    {
-      settings: {
-        ...datasource.settings,
-        useJsonColumns: true,
-        migratedIdentifiers,
-        migratedColumns,
-      },
-    },
-    { skipExposureQueryValidation: true },
-  );
-
-  // Mongo-only: regenerates userIdTypes/exposure queries (and the ch_events fact
-  // table, if one exists) for the JSON model.
-  await syncManagedWarehouseIdentifiers(context);
-
-  // Clear materializedColumns last (re-fetch: the sync mutated the datasource
-  // settings); only then is the warehouse fully migrated and out of the legacy set.
-  const synced =
-    await dangerouslyGetGrowthbookDatasourceBypassPermission(context);
-  if (!synced || synced.type !== "growthbook_clickhouse") {
-    logger.error(
-      `Managed warehouse migration for org ${datasource.organization}: could not re-fetch datasource after sync; migration will re-trigger on next sweep`,
-    );
+  if (!(await tryLockManagedWarehouseDatasource(context, 120))) {
+    // Locked: provisioning (or another operation) is in flight. Skip — the doc
+    // stays in the legacy set and the next sweep pass retries.
     return;
   }
-  await updateDataSource(
-    context,
-    synced,
-    { settings: { ...synced.settings, materializedColumns: undefined } },
-    { skipExposureQueryValidation: true },
-  );
+  try {
+    // Re-read under the lock; the caller's snapshot predates it.
+    const datasource =
+      await dangerouslyGetGrowthbookDatasourceBypassPermission(context);
+    if (
+      !datasource ||
+      datasource.type !== "growthbook_clickhouse" ||
+      !isManagedWarehouseAwaitingProvisioning(datasource) ||
+      !isManagedWarehouseAwaitingJsonMigration(datasource)
+    ) {
+      return;
+    }
+
+    const { migratedIdentifiers, migratedColumns } = getPreservedLegacyColumns(
+      context,
+      datasource,
+    );
+
+    await updateDataSource(
+      context,
+      datasource,
+      {
+        settings: {
+          ...datasource.settings,
+          useJsonColumns: true,
+          migratedIdentifiers,
+          migratedColumns,
+        },
+      },
+      { skipExposureQueryValidation: true },
+    );
+
+    // Mongo-only: regenerates userIdTypes/exposure queries (and the ch_events fact
+    // table, if one exists) for the JSON model.
+    await syncManagedWarehouseIdentifiers(context);
+
+    // Clear materializedColumns last (re-fetch: the sync mutated the datasource
+    // settings); only then is the warehouse fully migrated and out of the legacy set.
+    const synced =
+      await dangerouslyGetGrowthbookDatasourceBypassPermission(context);
+    if (!synced || synced.type !== "growthbook_clickhouse") {
+      logger.error(
+        `Managed warehouse migration for org ${context.org.id}: could not re-fetch datasource after sync; migration will re-trigger on next sweep`,
+      );
+      return;
+    }
+    await updateDataSource(
+      context,
+      synced,
+      { settings: { ...synced.settings, materializedColumns: undefined } },
+      { skipExposureQueryValidation: true },
+    );
+  } finally {
+    await unlockManagedWarehouseDatasource(context);
+  }
 }
 
 // Migrate a legacy (materialized-column) managed warehouse to native JSON columns.
@@ -718,7 +747,7 @@ export async function migrateManagedWarehouseToJson(
   // creates the JSON DDL directly.
   if (isManagedWarehouseAwaitingProvisioning(datasource)) {
     if (isManagedWarehouseAwaitingJsonMigration(datasource)) {
-      await migrateUnprovisionedManagedWarehouseSettings(context, datasource);
+      await migrateUnprovisionedManagedWarehouseSettings(context);
     }
     return;
   }


### PR DESCRIPTION
### Features and Changes

Unblocks the staged cleanup after #6368: prod has 34 legacy managed-warehouse docs that were never provisioned (`hasBeenProvisioned: false`, `useJsonColumns` unset). The migration explicitly deferred them, but provisioning is event-triggered and reads the stored settings — so any of these orgs starting to send events would get legacy matcol DDL and an immediate table rebuild today, or a permanently unmanageable legacy warehouse once the migration machinery is retired.

`migrateManagedWarehouseToJson` now migrates them with a Mongo-only settings rewrite — preserve legacy identifiers/dimensions, set `useJsonColumns`, resync, clear `materializedColumns` — skipping the table rebuild and the `migrating` query-block, since no ClickHouse database exists yet. The sweep's `LEGACY_FILTER` drops its `hasBeenProvisioned` clause so these docs drain too (the on-read trigger also reaches them unchanged). Once rewritten, eventual provisioning creates JSON DDL directly.

The rewrite runs under the license server's per-datasource `lockUntil` lock (same field, same semantics; new `tryLock`/`unlock` helpers in `DataSourceModel`) and re-reads the doc under it, so it can't interleave with event-triggered provisioning: if provisioning holds the lock the rewrite skips and the sweep retries; if provisioning wins outright, the doc re-enters the sweep as a provisioned legacy warehouse and the existing rebuild path converges it.

Rollout: flip `managed-warehouse-migration-sweep` on to drain; the cutover gate for retiring the legacy code paths is `LEGACY_FILTER` count holding at 0.

### Testing

- [x] Live-tested on dev: set the warehouse doc to the legacy-unprovisioned shape (default + custom identifier + dimension matcols) and ran `migrateManagedWarehouseToJson` -> `useJsonColumns: true`, matcols cleared, `migrating` never set, `hasBeenProvisioned` untouched, custom identifier preserved in `migratedIdentifiers`, dimension in `migratedColumns`, userIdTypes/exposure queries regenerated, no license-server recreate fired
- [x] Migrated doc drops out of the widened `LEGACY_FILTER`; a second run no-ops; `lockUntil` released after the run
- [x] With a held lock (simulated in-flight provisioning): rewrite skips, doc and foreign lock untouched
- [x] back-end type-check, eslint, and `clickhouse.test.ts` pass
