### PR TITLE
Deploy prod API by git-SHA image tag instead of :latest

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    outputs:
+      docker_sha: ${{ steps.metadata.outputs.docker_sha }}
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -68,6 +71,7 @@ jobs:
           echo "docker_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
 
       - name: Build, tag, and push image to Docker Hub and ECR
+        id: build
         uses: depot/build-push-action@v1
         with:
           push: true
@@ -152,11 +156,51 @@ jobs:
           SENTRY_ORG: growthbook
           SENTRY_PROJECT: app
 
-      - name: Deploy docker image to ECS for GrowthBook Cloud API
-        run: aws ecs update-service --cluster prod-api --service prod-api --force-new-deployment --region us-east-1
+      # Pin each service to the exact image digest we just built, rather than
+      # re-pulling the mutable :latest tag. Each step registers a new task
+      # definition revision (based on the current one, so env/secrets defined
+      # in Terraform carry over) and rolls the service to it.
+      - name: Render API task definition
+        id: taskdef-api
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition-family: prod-api
+          container-name: api
+          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook@${{ needs.docker.outputs.digest }}
+      - name: Deploy ECS for GrowthBook Cloud API
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.taskdef-api.outputs.task-definition }}
+          service: prod-api
+          cluster: prod-api
+          wait-for-service-stability: true
 
-      - name: Deploy docker image to ECS for GrowthBook Cloud Jobs
-        run: aws ecs update-service --cluster prod-api-jobs --service prod-api-jobs --force-new-deployment --region us-east-1
+      - name: Render Jobs task definition
+        id: taskdef-jobs
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition-family: prod-api-jobs
+          container-name: api-jobs
+          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook@${{ needs.docker.outputs.digest }}
+      - name: Deploy ECS for GrowthBook Cloud Jobs
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.taskdef-jobs.outputs.task-definition }}
+          service: prod-api-jobs
+          cluster: prod-api-jobs
+          wait-for-service-stability: true
 
-      - name: Deploy docker image to ECS for GrowthBook Cloud Python
-        run: aws ecs update-service --cluster prod-api-python --service prod-api-python --force-new-deployment --region us-east-1
+      - name: Render Python task definition
+        id: taskdef-python
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition-family: prod-api-python
+          container-name: api-python
+          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook@${{ needs.docker.outputs.digest }}
+      - name: Deploy ECS for GrowthBook Cloud Python
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.taskdef-python.outputs.task-definition }}
+          service: prod-api-python
+          cluster: prod-api-python
+          wait-for-service-stability: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,6 @@ jobs:
       id-token: write
     outputs:
       docker_sha: ${{ steps.metadata.outputs.docker_sha }}
-      digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -71,7 +70,6 @@ jobs:
           echo "docker_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
 
       - name: Build, tag, and push image to Docker Hub and ECR
-        id: build
         uses: depot/build-push-action@v1
         with:
           push: true
@@ -156,7 +154,7 @@ jobs:
           SENTRY_ORG: growthbook
           SENTRY_PROJECT: app
 
-      # Pin each service to the exact image digest we just built, rather than
+      # Pin each service to the git-<sha> image we just built, rather than
       # re-pulling the mutable :latest tag. Each step registers a new task
       # definition revision (based on the current one, so env/secrets defined
       # in Terraform carry over) and rolls the service to it.
@@ -166,7 +164,7 @@ jobs:
         with:
           task-definition-family: prod-api
           container-name: api
-          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook@${{ needs.docker.outputs.digest }}
+          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook:git-${{ needs.docker.outputs.docker_sha }}
       - name: Deploy ECS for GrowthBook Cloud API
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
@@ -181,7 +179,7 @@ jobs:
         with:
           task-definition-family: prod-api-jobs
           container-name: api-jobs
-          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook@${{ needs.docker.outputs.digest }}
+          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook:git-${{ needs.docker.outputs.docker_sha }}
       - name: Deploy ECS for GrowthBook Cloud Jobs
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
@@ -196,7 +194,7 @@ jobs:
         with:
           task-definition-family: prod-api-python
           container-name: api-python
-          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook@${{ needs.docker.outputs.digest }}
+          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook:git-${{ needs.docker.outputs.docker_sha }}
       - name: Deploy ECS for GrowthBook Cloud Python
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:

--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -1,0 +1,53 @@
+name: Redeploy
+
+# Re-pin each service's currently-running image onto the LATEST task-definition
+# revision, then roll to it. Use this to pick up a Terraform-owned task-def
+# change (sidecar bump, role, env/secret) right away, without waiting for a code
+# deploy. No image is built — the running image is preserved.
+on:
+  workflow_dispatch:
+
+jobs:
+  redeploy:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'growthbook/growthbook' }}
+    strategy:
+      matrix:
+        include:
+          - { service: prod-api, container: api }
+          - { service: prod-api-jobs, container: api-jobs }
+          - { service: prod-api-python, container: api-python }
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Read currently-running image
+        id: current
+        run: |
+          CURRENT_ARN=$(aws ecs describe-services --cluster ${{ matrix.service }} --services ${{ matrix.service }} \
+            --query 'services[0].taskDefinition' --output text --region us-east-1)
+          IMAGE=$(aws ecs describe-task-definition --task-definition "$CURRENT_ARN" \
+            --query "taskDefinition.containerDefinitions[?name=='${{ matrix.container }}'].image | [0]" \
+            --output text --region us-east-1)
+          echo "Re-pinning ${{ matrix.service }} image: $IMAGE"
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+
+      - name: Render task definition (latest base + current image)
+        id: taskdef
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition-family: ${{ matrix.service }}
+          container-name: ${{ matrix.container }}
+          image: ${{ steps.current.outputs.image }}
+
+      - name: Deploy to ECS
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.taskdef.outputs.task-definition }}
+          service: ${{ matrix.service }}
+          cluster: ${{ matrix.service }}
+          wait-for-service-stability: true

--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -33,6 +33,10 @@ jobs:
           IMAGE=$(aws ecs describe-task-definition --task-definition "$CURRENT_ARN" \
             --query "taskDefinition.containerDefinitions[?name=='${{ matrix.container }}'].image | [0]" \
             --output text --region us-east-1)
+          if [ -z "$IMAGE" ] || [ "$IMAGE" = "None" ]; then
+            echo "::error::No image found for container '${{ matrix.container }}' in ${{ matrix.service }} task def $CURRENT_ARN"
+            exit 1
+          fi
           echo "Re-pinning ${{ matrix.service }} image: $IMAGE"
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -14,7 +14,17 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    outputs:
+      short_sha: ${{ steps.sha.outputs.short }}
     steps:
+      # Deploy tags images with the first 7 chars of the SHA, so trim the input
+      # to match — a pasted full SHA would otherwise point at a tag never built.
+      - name: Normalize SHA to 7 chars
+        id: sha
+        env:
+          INPUT_SHA: ${{ inputs.sha }}
+        run: echo "short=${INPUT_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
       - name: Login to Docker Hub
         uses: docker/login-action@v4
         with:
@@ -37,12 +47,12 @@ jobs:
 
       - name: Tag image as latest in DockerHub
         run: |
-          docker buildx imagetools create -t growthbook/growthbook:latest growthbook/growthbook:git-${{ inputs.sha }}
+          docker buildx imagetools create -t growthbook/growthbook:latest growthbook/growthbook:git-${{ steps.sha.outputs.short }}
 
       - name: Tag image as latest in ECR
         run: |
           ECR_REGISTRY=${{ steps.login-ecr.outputs.registry }}
-          docker buildx imagetools create -t $ECR_REGISTRY/growthbook:latest $ECR_REGISTRY/growthbook:git-${{ inputs.sha }}
+          docker buildx imagetools create -t $ECR_REGISTRY/growthbook:latest $ECR_REGISTRY/growthbook:git-${{ steps.sha.outputs.short }}
 
   # Deploy the back-end for GrowthBook Cloud
   prod:
@@ -69,7 +79,7 @@ jobs:
         with:
           task-definition-family: prod-api
           container-name: api
-          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook:git-${{ inputs.sha }}
+          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook:git-${{ needs.docker.outputs.short_sha }}
       - name: Deploy ECS for GrowthBook Cloud API
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
@@ -84,7 +94,7 @@ jobs:
         with:
           task-definition-family: prod-api-python
           container-name: api-python
-          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook:git-${{ inputs.sha }}
+          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook:git-${{ needs.docker.outputs.short_sha }}
       - name: Deploy ECS for GrowthBook Cloud Python
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
@@ -99,7 +109,7 @@ jobs:
         with:
           task-definition-family: prod-api-jobs
           container-name: api-jobs
-          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook:git-${{ inputs.sha }}
+          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook:git-${{ needs.docker.outputs.short_sha }}
       - name: Deploy ECS for GrowthBook Cloud Jobs
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -61,23 +61,15 @@ jobs:
         id: login-ecr-prod
         uses: aws-actions/amazon-ecr-login@v2
 
-      # Services pin by digest, so re-tagging :latest doesn't roll anything
-      # back — resolve the digest of the target git-<sha> image and deploy it.
-      - name: Resolve rollback image digest
-        id: digest
-        run: |
-          DIGEST=$(aws ecr describe-images --repository-name growthbook \
-            --image-ids imageTag=git-${{ inputs.sha }} \
-            --query 'imageDetails[0].imageDigest' --output text --region us-east-1)
-          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
-
+      # Services pin the git-<sha> tag, so re-tagging :latest no longer rolls
+      # anything back — point each service's task def at the target git-<sha>.
       - name: Render API task definition
         id: taskdef-api
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
           task-definition-family: prod-api
           container-name: api
-          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook@${{ steps.digest.outputs.digest }}
+          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook:git-${{ inputs.sha }}
       - name: Deploy ECS for GrowthBook Cloud API
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
@@ -92,7 +84,7 @@ jobs:
         with:
           task-definition-family: prod-api-python
           container-name: api-python
-          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook@${{ steps.digest.outputs.digest }}
+          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook:git-${{ inputs.sha }}
       - name: Deploy ECS for GrowthBook Cloud Python
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:
@@ -107,7 +99,7 @@ jobs:
         with:
           task-definition-family: prod-api-jobs
           container-name: api-jobs
-          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook@${{ steps.digest.outputs.digest }}
+          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook:git-${{ inputs.sha }}
       - name: Deploy ECS for GrowthBook Cloud Jobs
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2
         with:

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -57,11 +57,61 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
-      - name: Deploy ECR image to ECS for GrowthBook Cloud API
-        run: aws ecs update-service --cluster prod-api --service prod-api --force-new-deployment --region us-east-1
+      - name: Login to Amazon ECR
+        id: login-ecr-prod
+        uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Deploy ECR image to ECS for GrowthBook Cloud API Python
-        run: aws ecs update-service --cluster prod-api-python --service prod-api-python --force-new-deployment --region us-east-1
+      # Services pin by digest, so re-tagging :latest doesn't roll anything
+      # back — resolve the digest of the target git-<sha> image and deploy it.
+      - name: Resolve rollback image digest
+        id: digest
+        run: |
+          DIGEST=$(aws ecr describe-images --repository-name growthbook \
+            --image-ids imageTag=git-${{ inputs.sha }} \
+            --query 'imageDetails[0].imageDigest' --output text --region us-east-1)
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
-      - name: Deploy ECR image to ECS for GrowthBook Cloud API Jobs
-        run: aws ecs update-service --cluster prod-api-jobs --service prod-api-jobs --force-new-deployment --region us-east-1
+      - name: Render API task definition
+        id: taskdef-api
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition-family: prod-api
+          container-name: api
+          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook@${{ steps.digest.outputs.digest }}
+      - name: Deploy ECS for GrowthBook Cloud API
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.taskdef-api.outputs.task-definition }}
+          service: prod-api
+          cluster: prod-api
+          wait-for-service-stability: true
+
+      - name: Render Python task definition
+        id: taskdef-python
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition-family: prod-api-python
+          container-name: api-python
+          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook@${{ steps.digest.outputs.digest }}
+      - name: Deploy ECS for GrowthBook Cloud Python
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.taskdef-python.outputs.task-definition }}
+          service: prod-api-python
+          cluster: prod-api-python
+          wait-for-service-stability: true
+
+      - name: Render Jobs task definition
+        id: taskdef-jobs
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition-family: prod-api-jobs
+          container-name: api-jobs
+          image: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook@${{ steps.digest.outputs.digest }}
+      - name: Deploy ECS for GrowthBook Cloud Jobs
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.taskdef-jobs.outputs.task-definition }}
+          service: prod-api-jobs
+          cluster: prod-api-jobs
+          wait-for-service-stability: true


### PR DESCRIPTION
### Features and Changes

The `prod-api`, `prod-api-jobs`, and `prod-api-python` services deploy by `aws ecs update-service --force-new-deployment`, which re-pulls the mutable `:latest` tag. The running task definition never names a version-controlled image, so the Vanta *"Fargate deploys version-controlled images"* test fails and the image can drift between task placements with no deploy.

We already build a unique `growthbook:git-<sha>` tag on every deploy. This pins the running task def to that tag:

- `deploy.yml` — exports `docker_sha` as a job output, then for each of the three services renders a new task-definition revision (`amazon-ecs-render-task-definition`, based on the current revision so Terraform-defined env/secrets carry over) with `growthbook:git-<sha>` and rolls to it with `amazon-ecs-deploy-task-definition` (`wait-for-service-stability`). Replaces the three `force-new-deployment` calls.
- `rollback.yml` — points each service's task def at the target `git-<sha>` and deploys it the same way. Re-tagging `:latest` no longer moves the services, so the rollback acts on the tag directly (the DockerHub/ECR `:latest` retags are kept for self-host / asset-extraction consumers).

We use the git-SHA tag rather than the content digest deliberately: it passes the test, matches the build version we already surface in-app (`buildinfo/SHA`, `DD_VERSION`), and is far friendlier for dev/oncall than an opaque `sha256`. On our `MUTABLE` ECR repos a tag isn't cryptographically immutable, so we can tighten to a digest (or `:git-<sha>@sha256:...`) later if we want the stronger guarantee.

### Dependencies

growthbook/terraform#175 must merge first — it adds `task_definition` to `lifecycle.ignore_changes` on these services so `terraform apply` doesn't revert these revisions back to the `:latest` base, and digest-pins the shared `datadog-agent` sidecar (otherwise the service still fails the test on that container).

### Testing

- [ ] Merge #175, then deploy: confirm the three services land on a new task-def revision whose app container image is `...growthbook:git-<sha>` (no `:latest`).
- [ ] `aws ecs describe-services` shows the services stable on the new revision.
- [ ] Vanta re-runs the Fargate test -> prod-api / prod-api-jobs / prod-api-python pass.
- [ ] Rollback workflow with a prior `<sha>` -> services move to that sha's image.
