### PR TITLE
feat(visual-editor): duplicate a variant (copy css/js/domMutations)

### DIFF
--- a/packages/back-end/src/api/visual-editor-ai/postAddVariant.ts
+++ b/packages/back-end/src/api/visual-editor-ai/postAddVariant.ts
@@ -22,6 +22,10 @@ const bodySchema = z
   .object({
     visualChangesetId: z.string(),
     name: z.string().min(1).max(120).optional(),
+    // When set, the new variant is a duplicate: its css / js / domMutations
+    // are copied from this existing variation (matched on the internal
+    // `variation` id). Omit for a blank variant.
+    sourceVariationId: z.string().optional(),
   })
   .strict();
 
@@ -43,7 +47,7 @@ const validation = {
 export const postAddVariant = createApiRequestHandler(validation)(async (
   req,
 ) => {
-  const { visualChangesetId, name } = req.body;
+  const { visualChangesetId, name, sourceVariationId } = req.body;
   const context = req.context;
   requireUserAuth(context);
 
@@ -65,11 +69,30 @@ export const postAddVariant = createApiRequestHandler(validation)(async (
     context.permissions.throwPermissionError();
   }
 
+  // For a duplicate, resolve the source variation's visual change (matched
+  // on the internal `variation` id) and the source variation itself (for the
+  // default "(copy)" name). Fail loudly on an unknown id rather than silently
+  // creating a blank variant.
+  const sourceChange = sourceVariationId
+    ? changeset.visualChanges.find((vc) => vc.variation === sourceVariationId)
+    : undefined;
+  const sourceVariation = sourceVariationId
+    ? experiment.variations.find((v) => v.id === sourceVariationId)
+    : undefined;
+  if (sourceVariationId && !sourceChange) {
+    return context.throwBadRequestError(
+      "Source variation not found in this changeset",
+    );
+  }
+
   // Internal `id` (not API-level `variationId`) — that's what
   // visualChange.variation references and getLatestPhaseVariations matches.
   const nextIndex = experiment.variations.length;
   const newVariationId = uuidv4();
-  const newVariationName = name?.trim() || `Variant ${nextIndex}`;
+  const defaultName = sourceVariation
+    ? `${sourceVariation.name} (copy)`
+    : `Variant ${nextIndex}`;
+  const newVariationName = name?.trim() || defaultName;
   const newVariationKey = `${nextIndex}`;
 
   const nextVariations = [
@@ -119,15 +142,17 @@ export const postAddVariant = createApiRequestHandler(validation)(async (
     },
   });
 
-  // Omitting `id` lets updateVisualChangeset's merge logic mint one.
+  // Omitting `id` lets updateVisualChangeset's merge logic mint one. For a
+  // duplicate we copy the source's css / js / domMutations (deep-copying each
+  // mutation so the two variations don't share object references).
   const nextVisualChanges = [
     ...changeset.visualChanges,
     {
       variation: newVariationId,
       description: newVariationName,
-      css: "",
-      js: "",
-      domMutations: [],
+      css: sourceChange?.css ?? "",
+      js: sourceChange?.js ?? "",
+      domMutations: (sourceChange?.domMutations ?? []).map((m) => ({ ...m })),
     },
   ];
 

--- a/packages/back-end/src/api/visual-editor-ai/postAddVariant.ts
+++ b/packages/back-end/src/api/visual-editor-ai/postAddVariant.ts
@@ -79,7 +79,7 @@ export const postAddVariant = createApiRequestHandler(validation)(async (
   const sourceVariation = sourceVariationId
     ? experiment.variations.find((v) => v.id === sourceVariationId)
     : undefined;
-  if (sourceVariationId && !sourceChange) {
+  if (sourceVariationId && (!sourceChange || !sourceVariation)) {
     return context.throwBadRequestError(
       "Source variation not found in this changeset",
     );


### PR DESCRIPTION
## What

Extends the internal add-variant endpoint (`POST /visual-editor/add-variant`, [postAddVariant.ts](packages/back-end/src/api/visual-editor-ai/postAddVariant.ts)) so the Visual Editor can **duplicate** an existing variant, not just create a blank one.

## Why

Users asked for a way to "duplicate this variant so I can save the one I'm working on while making edits to a new one." Doing the copy atomically on the server (rather than add-then-PUT from the extension) avoids a partial-state window and keeps it one round-trip.

## How

- New optional body field `sourceVariationId`.
- When present: the appended visual change copies the source variation's `css`, `js`, and `domMutations` (each mutation deep-copied so the two variations don't share object references), and the default name becomes `"<source> (copy)"`.
- An unknown `sourceVariationId` returns a 400 instead of silently creating a blank variant.
- Omitting the field preserves the existing blank-variant behavior exactly.

## Scope

Single file, additive. Back-end `type-check` passes. The matching "Duplicate this variant" affordance in the extension is a separate change that will ship after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)