### PR TITLE
Fix missing SQL template checks

### DIFF
--- a/packages/front-end/components/Metrics/MetricForm/index.tsx
+++ b/packages/front-end/components/Metrics/MetricForm/index.tsx
@@ -77,12 +77,12 @@ export type MetricFormProps = {
   switchToFact?: () => void;
 };
 
-export function usesValueColumn(sql: string) {
-  return !!sql.match(/\{\{[^}]*valueColumn/g);
+export function usesValueColumn(sql?: string | null) {
+  return !!sql?.match(/\{\{[^}]*valueColumn/g);
 }
 
-export function usesEventName(sql: string) {
-  return !!sql.match(/\{\{[^}]*eventName/g);
+export function usesEventName(sql?: string | null) {
+  return !!sql?.match(/\{\{[^}]*eventName/g);
 }
 
 function validateMetricSQL(

--- a/packages/front-end/test/components/Metrics/metricSqlTemplateVariables.test.ts
+++ b/packages/front-end/test/components/Metrics/metricSqlTemplateVariables.test.ts
@@ -1,0 +1,25 @@
+import {
+  usesEventName,
+  usesValueColumn,
+} from "@/components/Metrics/MetricForm";
+
+describe("metric SQL template variables", () => {
+  it("returns false when SQL is omitted from a slim payload", () => {
+    const slimFactTable: { sql?: string } = {};
+
+    expect(usesEventName(slimFactTable.sql)).toBe(false);
+    expect(usesValueColumn(slimFactTable.sql)).toBe(false);
+  });
+
+  it("detects supported template variables", () => {
+    expect(
+      usesEventName("SELECT * FROM events WHERE event = '{{ eventName }}'"),
+    ).toBe(true);
+    expect(usesValueColumn("SELECT {{ valueColumn }} AS value")).toBe(true);
+  });
+
+  it("returns false when the template variables are absent", () => {
+    expect(usesEventName("SELECT event_name FROM events")).toBe(false);
+    expect(usesValueColumn("SELECT value FROM events")).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

- Make SQL template-variable detection tolerate slim payloads where `sql` is omitted.
- Apply the same behavior to both `eventName` and `valueColumn` checks.
- Add regression coverage for missing SQL and normal template detection.

### Dependencies

None.

### Testing

- Focused regression: 3 tests passed
- Complete front-end suite: 48 files and 728 tests passed
- Front-end TypeScript check passed
- ESLint passed for changed files

<a href="/opt/cursor/artifacts/sql_template_test_results.txt">Test results</a>

### Screenshots

Not applicable; there is no visual change.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C034BRM9WR0/p1783672006264009?thread_ts=1783672006.264009&cid=C034BRM9WR0)

<div><a href="https://cursor.com/agents/bc-8596d4cc-9925-5bdb-84fb-a1cf20928702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8596d4cc-9925-5bdb-84fb-a1cf20928702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

