### PR TITLE
Mk/date picker bug

### DIFF
--- a/packages/front-end/components/DatePicker/index.tsx
+++ b/packages/front-end/components/DatePicker/index.tsx
@@ -42,6 +42,7 @@ type Props = {
   wrapRangeInputs?: boolean;
   compact?: boolean;
   disabled?: boolean;
+  inputStyle?: React.CSSProperties;
   fixedSpanMode?: {
     phase: "committed" | "choosing";
     anchorDate?: Date;
@@ -116,6 +117,7 @@ export default function DatePicker({
   wrapRangeInputs = false,
   compact = false,
   disabled,
+  inputStyle,
   fixedSpanMode,
 }: Props) {
   const inputHeight = compact ? 32 : 38;
@@ -404,6 +406,7 @@ export default function DatePicker({
                       minHeight: inputHeight,
                       cursor: "pointer",
                       ...compactFieldStyle,
+                      ...inputStyle,
                     }}
                     className={clsx("date-picker-field", {
                       "text-muted": isRange ? !date || !date2 : !date,

--- a/packages/front-end/components/DatePicker/index.tsx
+++ b/packages/front-end/components/DatePicker/index.tsx
@@ -159,6 +159,11 @@ export default function DatePicker({
   const fieldClickedTime = useRef(new Date());
 
   useEffect(() => {
+    // While editing a range, the buffered values are the source of truth.
+    // Parent updates can create new Date objects for unchanged values and
+    // otherwise overwrite an incomplete value that the user is still typing.
+    if (rangeFieldFocused && setDate2) return;
+
     if (date) {
       setBufferedDate(format(parseDateInput(date), dateFormat));
     } else {
@@ -169,7 +174,7 @@ export default function DatePicker({
     } else {
       setBufferedDate2("");
     }
-  }, [date, date2, dateFormat, parseDateInput]);
+  }, [date, date2, dateFormat, parseDateInput, rangeFieldFocused, setDate2]);
 
   const disabledMatchers: Matcher[] = [];
   if (disableBefore) {
@@ -289,10 +294,15 @@ export default function DatePicker({
 
       if (startTrim) {
         const parsedDate = parseDateInput(startTrim);
-        const finalDate = clampParsedDate(parsedDate);
-        setDate(finalDate);
-        setBufferedDate(format(finalDate, dateFormat));
-        anchor = finalDate;
+        // Keep incomplete input buffered while the user is typing. Invalid
+        // values fall back to the current date in parseDateInput, so applying
+        // them here would overwrite partial values after the debounce.
+        if (format(parsedDate, dateFormat) === startTrim) {
+          const finalDate = clampParsedDate(parsedDate);
+          setDate(finalDate);
+          setBufferedDate(format(finalDate, dateFormat));
+          anchor = finalDate;
+        }
       } else {
         setDate(undefined);
         setBufferedDate("");
@@ -300,10 +310,12 @@ export default function DatePicker({
 
       if (endTrim) {
         const parsedDate2 = parseDateInput(endTrim);
-        const finalDate2 = clampParsedDate(parsedDate2);
-        setDate2?.(finalDate2);
-        setBufferedDate2(format(finalDate2, dateFormat));
-        anchor = finalDate2;
+        if (format(parsedDate2, dateFormat) === endTrim) {
+          const finalDate2 = clampParsedDate(parsedDate2);
+          setDate2?.(finalDate2);
+          setBufferedDate2(format(finalDate2, dateFormat));
+          anchor = finalDate2;
+        }
       } else {
         setDate2?.(undefined);
         setBufferedDate2("");

--- a/packages/front-end/components/DatePicker/index.tsx
+++ b/packages/front-end/components/DatePicker/index.tsx
@@ -158,6 +158,7 @@ export default function DatePicker({
   );
   const [open, setOpen] = useState(false);
   const [rangeFieldFocused, setRangeFieldFocused] = useState(false);
+  const [rangeSeparatorEntered, setRangeSeparatorEntered] = useState(false);
   const fieldClickedTime = useRef(new Date());
 
   useEffect(() => {
@@ -253,6 +254,7 @@ export default function DatePicker({
     const b = bufferedDate2;
     if (!a && !b) return "";
     if (a && b) return `${a}${RANGE_DISPLAY_SEP}${b}`;
+    if (rangeSeparatorEntered) return `${a}${RANGE_DISPLAY_SEP}${b}`;
     return a || b;
   }, [
     bufferedDate,
@@ -263,6 +265,7 @@ export default function DatePicker({
     parseDateInput,
     precision,
     rangeFieldFocused,
+    rangeSeparatorEntered,
   ]);
 
   const clampParsedDate = useCallback(
@@ -302,7 +305,9 @@ export default function DatePicker({
         if (format(parsedDate, dateFormat) === startTrim) {
           const finalDate = clampParsedDate(parsedDate);
           setDate(finalDate);
-          setBufferedDate(format(finalDate, dateFormat));
+          if (format(finalDate, dateFormat) !== startTrim) {
+            setBufferedDate(format(finalDate, dateFormat));
+          }
           anchor = finalDate;
         }
       } else {
@@ -315,7 +320,9 @@ export default function DatePicker({
         if (format(parsedDate2, dateFormat) === endTrim) {
           const finalDate2 = clampParsedDate(parsedDate2);
           setDate2?.(finalDate2);
-          setBufferedDate2(format(finalDate2, dateFormat));
+          if (format(finalDate2, dateFormat) !== endTrim) {
+            setBufferedDate2(format(finalDate2, dateFormat));
+          }
           anchor = finalDate2;
         }
       } else {
@@ -431,6 +438,7 @@ export default function DatePicker({
                       if (isRange) {
                         const v = e.target.value;
                         const [startPart, endPart] = splitRangeFieldInput(v);
+                        setRangeSeparatorEntered(v.includes(RANGE_DISPLAY_SEP));
                         setBufferedDate(startPart);
                         setBufferedDate2(endPart);
                         debouncedApplyRange(startPart, endPart);
@@ -443,6 +451,7 @@ export default function DatePicker({
                       if (!isRange) return;
                       setRangeFieldFocused(true);
                       if (date && date2) {
+                        setRangeSeparatorEntered(true);
                         setBufferedDate(
                           format(parseDateInput(date), dateFormat),
                         );
@@ -456,6 +465,7 @@ export default function DatePicker({
                       debouncedApplyRange.flush();
                       if (isRange) {
                         setRangeFieldFocused(false);
+                        setRangeSeparatorEntered(false);
                       }
                     }}
                     onClick={(e) => {
@@ -533,8 +543,10 @@ export default function DatePicker({
                       setBufferedDate("");
                     }
                     if (to) {
+                      setRangeSeparatorEntered(true);
                       setBufferedDate2(format(to, dateFormat));
                     } else {
+                      setRangeSeparatorEntered(false);
                       setBufferedDate2("");
                     }
                   }}

--- a/packages/front-end/components/DatePicker/index.tsx
+++ b/packages/front-end/components/DatePicker/index.tsx
@@ -143,6 +143,10 @@ export default function DatePicker({
         : getValidDateOffsetByUTC(value),
     [precision],
   );
+  const normalizedDate = date ? format(parseDateInput(date), dateFormat) : "";
+  const normalizedDate2 = date2
+    ? format(parseDateInput(date2), dateFormat)
+    : "";
   const [bufferedDate, setBufferedDate] = useState(
     date ? format(getValidDate(date), dateFormat) : "",
   );
@@ -160,24 +164,20 @@ export default function DatePicker({
   const [rangeFieldFocused, setRangeFieldFocused] = useState(false);
   const [rangeSeparatorEntered, setRangeSeparatorEntered] = useState(false);
   const fieldClickedTime = useRef(new Date());
-
-  useEffect(() => {
-    // While editing a range, the buffered values are the source of truth.
-    // Parent updates can create new Date objects for unchanged values and
-    // otherwise overwrite an incomplete value that the user is still typing.
-    if (rangeFieldFocused && setDate2) return;
-
-    if (date) {
-      setBufferedDate(format(parseDateInput(date), dateFormat));
-    } else {
-      setBufferedDate("");
-    }
-    if (date2) {
-      setBufferedDate2(format(parseDateInput(date2), dateFormat));
-    } else {
-      setBufferedDate2("");
-    }
-  }, [date, date2, dateFormat, parseDateInput, rangeFieldFocused, setDate2]);
+  const dateRef = useRef(date);
+  const normalizedDateRef = useRef(normalizedDate);
+  const normalizedDate2Ref = useRef(normalizedDate2);
+  const setDateRef = useRef(setDate);
+  const setDate2Ref = useRef(setDate2);
+  const lastEmittedRangeRef = useRef<{
+    date: string;
+    date2: string;
+  } | null>(null);
+  dateRef.current = date;
+  normalizedDateRef.current = normalizedDate;
+  normalizedDate2Ref.current = normalizedDate2;
+  setDateRef.current = setDate;
+  setDate2Ref.current = setDate2;
 
   const disabledMatchers: Matcher[] = [];
   if (disableBefore) {
@@ -285,17 +285,26 @@ export default function DatePicker({
     return debounce((value: string) => {
       const parsedDate = parseDateInput(value);
       const finalDate = clampParsedDate(parsedDate);
-      setDate(finalDate);
+      lastEmittedRangeRef.current = {
+        date: format(finalDate, dateFormat),
+        date2: normalizedDate2Ref.current,
+      };
+      setDateRef.current(finalDate);
       setBufferedDate(format(finalDate, dateFormat));
       setCalendarMonth(new Date(finalDate.getFullYear(), finalDate.getMonth()));
     }, 500);
-  }, [clampParsedDate, setDate, setCalendarMonth, dateFormat, parseDateInput]);
+  }, [clampParsedDate, setCalendarMonth, dateFormat, parseDateInput]);
 
   const debouncedApplyRange = useMemo(() => {
     return debounce((startStr: string, endStr: string) => {
       const startTrim = startStr.trim();
       const endTrim = endStr.trim();
-      let anchor = getValidDate(date ?? new Date());
+      let anchor = getValidDate(dateRef.current ?? new Date());
+      const emittedRange = {
+        date: normalizedDateRef.current,
+        date2: normalizedDate2Ref.current,
+      };
+      lastEmittedRangeRef.current = emittedRange;
 
       if (startTrim) {
         const parsedDate = parseDateInput(startTrim);
@@ -304,14 +313,16 @@ export default function DatePicker({
         // them here would overwrite partial values after the debounce.
         if (format(parsedDate, dateFormat) === startTrim) {
           const finalDate = clampParsedDate(parsedDate);
-          setDate(finalDate);
+          emittedRange.date = format(finalDate, dateFormat);
+          setDateRef.current(finalDate);
           if (format(finalDate, dateFormat) !== startTrim) {
             setBufferedDate(format(finalDate, dateFormat));
           }
           anchor = finalDate;
         }
       } else {
-        setDate(undefined);
+        emittedRange.date = "";
+        setDateRef.current(undefined);
         setBufferedDate("");
       }
 
@@ -319,28 +330,47 @@ export default function DatePicker({
         const parsedDate2 = parseDateInput(endTrim);
         if (format(parsedDate2, dateFormat) === endTrim) {
           const finalDate2 = clampParsedDate(parsedDate2);
-          setDate2?.(finalDate2);
+          emittedRange.date2 = format(finalDate2, dateFormat);
+          setDate2Ref.current?.(finalDate2);
           if (format(finalDate2, dateFormat) !== endTrim) {
             setBufferedDate2(format(finalDate2, dateFormat));
           }
           anchor = finalDate2;
         }
       } else {
-        setDate2?.(undefined);
+        emittedRange.date2 = "";
+        setDate2Ref.current?.(undefined);
         setBufferedDate2("");
       }
 
       setCalendarMonth(new Date(anchor.getFullYear(), anchor.getMonth()));
     }, 500);
-  }, [
-    clampParsedDate,
-    date,
-    dateFormat,
-    parseDateInput,
-    setCalendarMonth,
-    setDate,
-    setDate2,
-  ]);
+  }, [clampParsedDate, dateFormat, parseDateInput, setCalendarMonth]);
+
+  useEffect(() => {
+    const lastEmittedRange = lastEmittedRangeRef.current;
+    if (
+      lastEmittedRange?.date === normalizedDate &&
+      lastEmittedRange.date2 === normalizedDate2
+    ) {
+      lastEmittedRangeRef.current = null;
+      return;
+    }
+
+    lastEmittedRangeRef.current = null;
+    debouncedSetDate.cancel();
+    debouncedApplyRange.cancel();
+    setBufferedDate(normalizedDate);
+    setBufferedDate2(normalizedDate2);
+    setRangeSeparatorEntered(!!normalizedDate && !!normalizedDate2);
+  }, [debouncedApplyRange, debouncedSetDate, normalizedDate, normalizedDate2]);
+
+  useEffect(() => {
+    return () => {
+      debouncedSetDate.cancel();
+      debouncedApplyRange.cancel();
+    };
+  }, [debouncedApplyRange, debouncedSetDate]);
 
   return (
     <div className={clsx(containerClassName, { "mb-0": !label && !label2 })}>

--- a/packages/front-end/enterprise/components/ProductAnalytics/MainSection/Toolbar/DateRangePicker.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/MainSection/Toolbar/DateRangePicker.tsx
@@ -15,6 +15,10 @@ import {
 } from "@/enterprise/components/ProductAnalytics/dateRangeLabels";
 import { useMergedDateRangeUpdates } from "./useMergedDateRangeUpdates";
 
+const DATE_RANGE_INPUT_STYLE: React.CSSProperties = {
+  backgroundColor: "transparent",
+};
+
 function MicroLabel({ children }: { children: ReactNode }) {
   return (
     <Text size="small" color="text-low" weight="regular">
@@ -235,6 +239,7 @@ function CurrentCustomRangeField({
       compact
       wrapRangeInputs={fullWidth ? false : shouldWrap}
       disabled={disabled}
+      inputStyle={DATE_RANGE_INPUT_STYLE}
       date={
         value.startDate ? getValidDateOffsetByUTC(value.startDate) : undefined
       }
@@ -415,6 +420,7 @@ function ComparisonPreviousRangePicker({
       containerClassName="mb-0"
       compact
       wrapRangeInputs={fullWidth ? false : shouldWrap}
+      inputStyle={DATE_RANGE_INPUT_STYLE}
       date={getValidDateOffsetByUTC(previousTimeFrame.startDate)}
       date2={getValidDateOffsetByUTC(previousTimeFrame.endDate)}
       setDate={(d) => {


### PR DESCRIPTION
### Features and Changes

- Fixes manual date entry so partial values are preserved while typing instead of reverting after the debounce.
- Supports typing complete date ranges, including preserving the separator before the end date is entered.
- Aligns Product Analytics date-range input colors with adjacent Select controls in dark mode without changing DatePicker styling app-wide.

### Dependencies

None.

### Testing

- [x] Enter a start date slowly and confirm partial input is not reset.
- [x] Edit an existing date using backspace and confirm the partial value remains.
- [x] Type a complete range such as `2022-01-01 - 2022-01-31`.
- [x] Confirm calendar-based date selection still works.
- [x] Verify Product Analytics date inputs match adjacent Select backgrounds in light and dark modes.
- [x] Verify the date picker elsewhere in the app still works without regressions (tested the scheduled rule picker and the insights timeline picker)

### Screenshots

https://www.loom.com/share/20bfea0628804669b8a1fc9630a995a1