### PR TITLE
Respect block size for newly created dashboards

### DIFF
--- a/packages/front-end/enterprise/components/Dashboards/DashboardWorkspace.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardWorkspace.tsx
@@ -6,7 +6,6 @@ import {
   DashboardBlockInterface,
   DashboardBlockType,
   CREATE_BLOCK_TYPE,
-  dashboardBlockHasIds,
   getBlockData,
   getInitialConfigByBlockType,
   DASHBOARD_GRID_COLS,
@@ -38,6 +37,7 @@ import { useExploreData } from "@/enterprise/components/ProductAnalytics/useExpl
 import DashboardEditor, {
   DASHBOARD_TOPBAR_HEIGHT,
   GENERAL_DASHBOARD_BLOCK_TYPES,
+  getGridKeyForBlock,
   isBlockTypeAllowed,
 } from "./DashboardEditor";
 import { SubmitDashboard, UpdateDashboardArgs } from "./DashboardsTab";
@@ -585,9 +585,8 @@ export default function DashboardWorkspace({
                     return;
                   const byId = new Map(layouts.map((l) => [l.i, l] as const));
                   let changed = false;
-                  const next = blocks.map((b) => {
-                    if (!dashboardBlockHasIds(b)) return b;
-                    const l = byId.get(b.id);
+                  const next = blocks.map((b, index) => {
+                    const l = byId.get(getGridKeyForBlock(b, index));
                     if (!l) return b;
                     const w = Math.min(l.w, DASHBOARD_GRID_COLS);
                     const h = Math.max(1, l.h);


### PR DESCRIPTION
### Features and Changes

- Preserve resized dimensions and positions for blocks when saving a new dashboard.
- Use the editor’s synthetic grid keys for unsaved blocks, while retaining persisted IDs for existing blocks.

### Dependencies

None.

### Testing

- [x] Create a new dashboard and add a block.
- [x] Resize and reposition the block.
- [x] Save the dashboard and verify its layout is preserved.
- [x] Verify resizing blocks on existing dashboards still works.

### Screenshots

https://www.loom.com/share/2ef45ee8497146c9b498d6561193f0f7