### PR TITLE
Scope Enterprise SSO identity matching to the connection's organization

### DIFF
--- a/packages/back-end/src/services/auth/index.ts
+++ b/packages/back-end/src/services/auth/index.ts
@@ -7,6 +7,7 @@ import { userHasPermission } from "shared/permissions";
 import { AuditInterface } from "shared/types/audit";
 import { Permission } from "shared/types/organization";
 import { UserInterface } from "shared/types/user";
+import { SSOConnectionInterface } from "shared/types/sso-connection";
 import {
   EventUserForResponseLocals,
   EventUserLoggedIn,
@@ -20,6 +21,7 @@ import {
   getUserByEmail,
 } from "back-end/src/models/UserModel";
 import {
+  isUserAuthorizedForSSOConnection,
   getOrganizationById,
   validateLoginMethod,
 } from "back-end/src/services/organizations";
@@ -77,7 +79,10 @@ export function getAuthConnection(): AuthConnection {
   return usingOpenId() ? new OpenIdAuthConnection() : new LocalAuthConnection();
 }
 
-async function getUserFromJWT(info: JWTInfo): Promise<null | UserInterface> {
+async function getUserFromJWT(
+  info: JWTInfo,
+  loginMethod?: SSOConnectionInterface,
+): Promise<null | UserInterface> {
   if (!info.email) {
     throw new Error("Id token does not contain email address");
   }
@@ -90,6 +95,17 @@ async function getUserFromJWT(info: JWTInfo): Promise<null | UserInterface> {
         "Your session has been revoked. Please refresh the page and login.",
       );
     }
+  }
+
+  // Don't let an Enterprise SSO connection silently authenticate as an existing
+  // account it has no legitimate relationship with (see isUserAuthorizedForSSOConnection).
+  if (
+    loginMethod &&
+    !(await isUserAuthorizedForSSOConnection(user, loginMethod))
+  ) {
+    throw new Error(
+      "This SSO connection is not authorized to log in as this account.",
+    );
   }
 
   return user;
@@ -162,7 +178,7 @@ export async function processJWT(
     }
   };
 
-  const user = await getUserFromJWT(parsedJWT);
+  const user = await getUserFromJWT(parsedJWT, req.loginMethod);
 
   if (user) {
     req.currentUser = user;

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -40,6 +40,7 @@ import {
   PendingMember,
   ProjectMemberRole,
 } from "shared/types/organization";
+import { UserInterface } from "shared/types/user";
 import { MetricInterface } from "shared/types/metric";
 import { DimensionInterface } from "shared/types/dimension";
 import { DataSourceInterface } from "shared/types/datasource";
@@ -52,6 +53,7 @@ import {
   findOrganizationById,
   findOrganizationByInviteKey,
   findOrganizationsByDomain,
+  findOrganizationsByMemberId,
   updateOrganization,
 } from "back-end/src/models/OrganizationModel";
 import {
@@ -1173,6 +1175,41 @@ export function isEnterpriseSSO(connection?: SSOConnectionInterface) {
   if (connection.id.startsWith("vercel:")) return false;
 
   return true;
+}
+
+// On Cloud, an Enterprise SSO connection is scoped to a single organization and
+// has no legitimate authority over an existing account that org has never
+// interacted with. Otherwise, a permissive IdP on org A could assert org B's
+// user's email and authenticate as them. This mirrors the relationships
+// `addMemberFromSSOConnection` itself is willing to create (member, invite,
+// pending member, or domain-based auto-join for a brand-new-to-GrowthBook user)
+// so it doesn't break legitimate invite/auto-join flows that haven't completed yet.
+export async function isUserAuthorizedForSSOConnection(
+  user: Pick<UserInterface, "id" | "email">,
+  ssoConnection: SSOConnectionInterface,
+): Promise<boolean> {
+  if (!ssoConnection.organization) return true;
+
+  const org = await getOrganizationById(ssoConnection.organization);
+  if (!org) return false;
+
+  if (org.members.some((m) => m.id === user.id)) return true;
+  if (org.pendingMembers?.some((m) => m.id === user.id)) return true;
+  if (
+    org.invites.some((i) => i.email.toLowerCase() === user.email.toLowerCase())
+  ) {
+    return true;
+  }
+
+  if (ssoConnection.emailDomains?.length) {
+    const emailDomain = user.email.split("@").pop()?.toLowerCase() || "";
+    if (ssoConnection.emailDomains.includes(emailDomain)) {
+      const existingOrgs = await findOrganizationsByMemberId(user.id);
+      if (!existingOrgs.length) return true;
+    }
+  }
+
+  return false;
 }
 
 // Auto-add user to an organization if using Enterprise SSO


### PR DESCRIPTION
### Features and Changes

Enterprise SSO login previously matched an incoming JWT to an existing user record by email alone, with no check on which SSO connection authenticated the request. Since `validateLoginMethod` only blocks access when the *target* org has explicitly opted into `restrictLoginMethod`, a permissive or malicious IdP behind one org's SSO connection could assert an email belonging to an existing user of a completely unrelated org and get authenticated as that user — a cross-org account-takeover path.

This closes that gap with `isUserAuthorizedForSSOConnection` (`packages/back-end/src/services/organizations.ts`): an org-scoped Enterprise SSO connection may only authenticate as an existing account if that org already has some legitimate relationship to it — an existing member, a pending invite (matched by email), a pending member record, or (for a brand-new-to-GrowthBook user) a matching auto-join email domain with zero existing org memberships. This mirrors exactly the relationships `addMemberFromSSOConnection` is already willing to create, so in-flight invite/auto-join flows aren't broken.

This intentionally does **not** depend on the JWT's `email_verified` claim — an earlier attempt (#5765) gated on that and was reverted because most real enterprise IdPs don't set it, generating too much noise/false blocking. Scoping by connection ↔ organization relationship closes the actual account-takeover/cross-org-confusion risk without adding any friction for legitimate repeat logins.

- Closes N/A — proactive security hardening, no linked issue

### Dependencies

None

### Testing

- `pnpm --filter back-end type-check` and `eslint` pass on the changed files.
- Existing `test/services/auth.test.ts` suite passes unchanged.
- Manual verification requires two Cloud orgs each with their own Enterprise SSO connection (one pointed at a test/mock OIDC provider you control) — mint an ID token asserting an existing user's email from the *other* org's connection and confirm the login is now rejected with `400: This SSO connection is not authorized to log in as this account.` instead of succeeding. Also re-verify the legitimate flows still work: brand-new domain-matched auto-join, pending-invite acceptance, and normal repeat logins for existing members.

### Screenshots

N/A — back-end only, no UI changes.