### PR TITLE
Add event tracking for the site-wide AI assistant

### DIFF
--- a/packages/front-end/components/Agent/AgentPanel.tsx
+++ b/packages/front-end/components/Agent/AgentPanel.tsx
@@ -410,7 +410,7 @@ export default function AgentPanel({
 
   const handleSend = useCallback(() => {
     const text = input.trim();
-    if (!text) return;
+    if (!text || loading) return;
     if (askPrompt && !askPrompt.resolved) {
       // Typing a free-text reply also resolves the active question.
       setAskPrompt({ ...askPrompt, resolved: true });
@@ -421,7 +421,7 @@ export default function AgentPanel({
     }
     trackMessageSent();
     sendMessage();
-  }, [input, sendMessage, askPrompt, confirmPrompt, trackMessageSent]);
+  }, [input, loading, sendMessage, askPrompt, confirmPrompt, trackMessageSent]);
 
   const handleAskOption = useCallback(
     (option: AskUserOption) => {

--- a/packages/front-end/components/Agent/AgentPanel.tsx
+++ b/packages/front-end/components/Agent/AgentPanel.tsx
@@ -5,6 +5,8 @@ import { PiX, PiPlus, PiArrowLineLeft, PiArrowLineRight } from "react-icons/pi";
 import type { AIChatMessage } from "shared/ai-chat";
 import Markdown from "@/components/Markdown/Markdown";
 import Text from "@/ui/Text";
+import track from "@/services/track";
+import { useAISettings } from "@/hooks/useOrgSettings";
 import { useAIChat } from "@/enterprise/hooks/useAIChat";
 import type { ActiveTurnItem } from "@/enterprise/hooks/useAIChat/types";
 import { useDefaultDataSourceId } from "@/enterprise/components/ProductAnalytics/ExplorerContext";
@@ -146,6 +148,7 @@ export default function AgentPanel({
   // active-turn → persisted-message remount so it doesn't snap shut mid-turn.
   const toolDetailsOpenRef = useRef<Record<string, boolean>>({});
   const router = useRouter();
+  const { defaultAIModel } = useAISettings();
   // Read latest pathname inside the callback (not at render) so the URL
   // captured matches where the user is when they hit send, not where they
   // were when the panel rendered.
@@ -339,6 +342,25 @@ export default function AgentPanel({
     onSSEEvent: handleSSEEvent,
     onConversationLoaded: handleConversationLoaded,
     conversationStorageKey: STORAGE_KEY,
+    onMessageComplete: (info) => {
+      track("AI Assistant Response Completed", {
+        model: defaultAIModel,
+        durationMs: info.durationMs,
+        toolCallCount: info.toolCallCount,
+      });
+    },
+    onMessageCancelled: (info) => {
+      track("AI Assistant Generation Cancelled", {
+        model: defaultAIModel,
+        durationMs: info.durationMs,
+      });
+    },
+    onMessageError: (info) => {
+      track("AI Assistant Error", {
+        errorType: info.errorType,
+        httpStatus: info.httpStatus,
+      });
+    },
   });
 
   // Keep the feedback hook's ref in sync with the current conversation id.
@@ -378,6 +400,14 @@ export default function AgentPanel({
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, activeTurnItems]);
 
+  const trackMessageSent = useCallback(() => {
+    track("AI Assistant Message Sent", {
+      model: defaultAIModel,
+      messageCount: messages.length,
+      isFirstMessage: messages.length === 0,
+    });
+  }, [defaultAIModel, messages.length]);
+
   const handleSend = useCallback(() => {
     const text = input.trim();
     if (!text) return;
@@ -389,16 +419,18 @@ export default function AgentPanel({
       // Typing instead of clicking supersedes the parked mutation server-side.
       setConfirmPrompt({ ...confirmPrompt, resolved: true });
     }
+    trackMessageSent();
     sendMessage();
-  }, [input, sendMessage, askPrompt, confirmPrompt]);
+  }, [input, sendMessage, askPrompt, confirmPrompt, trackMessageSent]);
 
   const handleAskOption = useCallback(
     (option: AskUserOption) => {
       if (!askPrompt || askPrompt.resolved || loading) return;
       setAskPrompt({ ...askPrompt, resolved: true });
+      trackMessageSent();
       sendMessage(option.label);
     },
-    [askPrompt, sendMessage, loading],
+    [askPrompt, sendMessage, loading, trackMessageSent],
   );
 
   const handleConfirmAction = useCallback(
@@ -410,11 +442,12 @@ export default function AgentPanel({
         confirmDecision: decision,
       };
       // The decision is a control signal — don't render it as a user bubble.
+      trackMessageSent();
       sendMessage(decision === "confirm" ? "Confirm" : "Cancel", {
         suppressUserMessage: true,
       });
     },
-    [confirmPrompt, sendMessage, loading],
+    [confirmPrompt, sendMessage, loading, trackMessageSent],
   );
 
   const handleKeyDown = useCallback(
@@ -436,14 +469,24 @@ export default function AgentPanel({
   }, []);
 
   const handleNewChat = useCallback(() => {
+    track("AI Assistant New Conversation", {
+      previousConversationMessageCount: messages.length,
+    });
     newChat();
     resetTransientState();
     clearFeedback();
     focusInput();
-  }, [newChat, resetTransientState, clearFeedback, focusInput]);
+  }, [
+    messages.length,
+    newChat,
+    resetTransientState,
+    clearFeedback,
+    focusInput,
+  ]);
 
   const handleSelectConversation = useCallback(
     (id: string) => {
+      track("AI Assistant Load Conversation");
       void loadConversation(id);
       resetTransientState();
       focusInput();
@@ -562,6 +605,7 @@ export default function AgentPanel({
               toolDetailsOpenRef={toolDetailsOpenRef}
               feedbackMap={feedbackMap}
               onFeedbackSubmit={handleFeedbackSubmit}
+              feedbackTrackingEventName="AI Assistant Feedback"
             />
           ))}
 
@@ -725,6 +769,7 @@ function PersistedTurn({
   toolDetailsOpenRef,
   feedbackMap,
   onFeedbackSubmit,
+  feedbackTrackingEventName,
 }: {
   turn: MessageTurn;
   onInternalLinkClick?: (href: string) => void;
@@ -735,6 +780,7 @@ function PersistedTurn({
     rating: "positive" | "negative" | null,
     comment: string,
   ) => void;
+  feedbackTrackingEventName?: string;
 }) {
   const { preWork, replyContent, replyMessageId } = classifyTurn(turn.rest);
   const steps = preWorkToSteps(preWork, turn.rest, toolDetailsOpenRef);
@@ -765,6 +811,7 @@ function PersistedTurn({
           messageId={replyMessageId}
           value={feedbackMap[replyMessageId] ?? { rating: null, comment: "" }}
           onSubmit={onFeedbackSubmit}
+          trackingEventName={feedbackTrackingEventName}
         />
       )}
     </>

--- a/packages/front-end/components/Agent/AgentPanelContext.tsx
+++ b/packages/front-end/components/Agent/AgentPanelContext.tsx
@@ -1,6 +1,13 @@
-import React, { createContext, useCallback, useContext, useState } from "react";
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useRef,
+  useState,
+} from "react";
 import { useUser } from "@/services/UserContext";
 import { useAISettings } from "@/hooks/useOrgSettings";
+import track from "@/services/track";
 
 interface AgentPanelContextValue {
   /** Whether the agent UI should be available to the current user/org. */
@@ -35,16 +42,30 @@ export function AgentPanelProvider({
 
   const [open, setOpen] = useState(false);
   const [expanded, setExpanded] = useState(false);
+  // Mirror for open/close handlers so tracking stays outside setState updaters.
+  const openRef = useRef(open);
+  openRef.current = open;
 
   const openPanel = useCallback(() => {
+    if (!openRef.current) {
+      track("AI Assistant Panel Opened");
+    }
     setOpen(true);
   }, []);
 
   const closePanel = useCallback(() => {
+    if (openRef.current) {
+      track("AI Assistant Panel Closed");
+    }
     setOpen(false);
   }, []);
 
   const togglePanel = useCallback(() => {
+    track(
+      openRef.current
+        ? "AI Assistant Panel Closed"
+        : "AI Assistant Panel Opened",
+    );
     setOpen((prev) => !prev);
   }, []);
 

--- a/packages/front-end/enterprise/components/AIChat/AIChatFeedback.tsx
+++ b/packages/front-end/enterprise/components/AIChat/AIChatFeedback.tsx
@@ -36,12 +36,15 @@ interface AIChatFeedbackProps {
     rating: AIChatFeedbackRating | null,
     comment: string,
   ) => void;
+  /** Defaults to "AI Chat Feedback" (PA). General agent passes "AI Assistant Feedback". */
+  trackingEventName?: string;
 }
 
 export function AIChatFeedback({
   messageId,
   value,
   onSubmit,
+  trackingEventName = "AI Chat Feedback",
 }: AIChatFeedbackProps) {
   const [commentOpen, setCommentOpen] = useState(false);
   const [draftComment, setDraftComment] = useState(value.comment);
@@ -59,13 +62,13 @@ export function AIChatFeedback({
       action: "rate" | "comment" | "clear",
       rating: AIChatFeedbackRating | null,
     ) => {
-      track("AI Chat Feedback", {
+      track(trackingEventName, {
         action,
         rating,
         hasComment: action === "comment",
       });
     },
-    [],
+    [trackingEventName],
   );
 
   const handleThumbsUp = useCallback(() => {


### PR DESCRIPTION
## Summary
- Instrument core site-wide general agent usage with dedicated `AI Assistant …` Jitsu events (panel open/close, message sent, response completed/cancelled/error, new/load conversation, feedback)
- Keep Product Analytics AI Chat events unchanged; shared `AIChatFeedback` accepts an optional `trackingEventName` so the general agent can emit `AI Assistant Feedback`