### PR TITLE
Visual editor: raise AI prompt limit 2000 -> 8000 chars

### DIFF
--- a/packages/back-end/src/enterprise/api/visual-editor-ai/postAIEdit.ts
+++ b/packages/back-end/src/enterprise/api/visual-editor-ai/postAIEdit.ts
@@ -140,7 +140,7 @@ const conversationTurnSchema = z.object({
 
 const bodySchema = z
   .object({
-    prompt: z.string().min(1).max(2000),
+    prompt: z.string().min(1).max(8000),
     elementContext: z.array(elementContextSchema).max(20).default([]),
     variationId: z.string(),
     visualChangesetId: z.string(),

--- a/packages/back-end/src/enterprise/api/visual-editor-ai/postFigmaToVariant.ts
+++ b/packages/back-end/src/enterprise/api/visual-editor-ai/postFigmaToVariant.ts
@@ -36,7 +36,7 @@ const designImageSchema = z.object({
 
 const bodySchema = z
   .object({
-    prompt: z.string().min(1).max(2000),
+    prompt: z.string().min(1).max(8000),
     variationId: z.string(),
     visualChangesetId: z.string(),
     // CSS selector of the element the user picked as the injection point.


### PR DESCRIPTION
Bumps the max prompt length on the AI edit and Figma-to-variant endpoints. The extension enforces the same cap client-side and blocks send when exceeded, so a longer prompt no longer produces a surprise server-side validation error.
