### PR TITLE
Fix managed warehouse ClickHouse timestamps being parsed as local time

### DIFF
--- a/packages/back-end/src/integrations/ClickHouse.ts
+++ b/packages/back-end/src/integrations/ClickHouse.ts
@@ -8,6 +8,7 @@ import {
 } from "shared/types/integrations";
 import { ClickHouseConnectionParams } from "shared/types/integrations/clickhouse";
 import {
+  isManagedWarehouse,
   isManagedWarehouseAwaitingJsonMigration,
   isManagedWarehouseAwaitingProvisioning,
   isManagedWarehouseMigrating,
@@ -20,6 +21,39 @@ import { getHost } from "back-end/src/util/sql";
 import { logger } from "back-end/src/util/logger";
 import SqlIntegration from "./SqlIntegration";
 import { clickHouseDialect } from "./dialects/clickhouse";
+
+// Matches ClickHouse DateTime/DateTime64 column types with no explicit
+// timezone argument (e.g. "DateTime", "DateTime64(3)", "Nullable(DateTime64(3))").
+// Types with an explicit timezone (e.g. "DateTime('UTC')") contain a quote
+// and are intentionally excluded, since their naive-string rendering already
+// reflects that declared zone rather than needing this override.
+const NAIVE_CLICKHOUSE_DATETIME_TYPE =
+  /^Nullable\(DateTime(64\(\d+\))?\)$|^DateTime(64\(\d+\))?$/;
+
+// Managed warehouse DateTime/DateTime64 columns carry no explicit timezone,
+// so ClickHouse renders them as bare "YYYY-MM-DD HH:mm:ss[.ffffff]" strings
+// (no "Z"/offset) in UTC, GrowthBook's convention for that schema. JS's
+// `new Date(...)` parses that shape as local time on whatever host runs the
+// app server, silently shifting it. Append "Z" so it's parsed as UTC instead.
+function normalizeManagedWarehouseDatetimes(
+  // eslint-disable-next-line
+  rows: Record<string, any>[],
+  meta: Array<{ name: string; type: string }> | undefined,
+): void {
+  const dateCols = (meta ?? [])
+    .filter((col) => NAIVE_CLICKHOUSE_DATETIME_TYPE.test(col.type))
+    .map((col) => col.name);
+  if (!dateCols.length) return;
+
+  for (const row of rows) {
+    for (const col of dateCols) {
+      const value = row[col];
+      if (typeof value === "string") {
+        row[col] = value.replace(" ", "T") + "Z";
+      }
+    }
+  }
+}
 
 export default class ClickHouse extends SqlIntegration {
   params!: ClickHouseConnectionParams;
@@ -93,8 +127,12 @@ export default class ClickHouse extends SqlIntegration {
     const results = await client.query({ query: sql, format: "JSON" });
     // eslint-disable-next-line
     const data: ResponseJSON<Record<string, any>[]> = await results.json();
+    const rows = data.data ? data.data : [];
+    if (isManagedWarehouse(this.datasource)) {
+      normalizeManagedWarehouseDatetimes(rows, data.meta);
+    }
     return {
-      rows: data.data ? data.data : [],
+      rows,
       statistics: data.statistics
         ? {
             executionDurationMs: data.statistics.elapsed,

--- a/packages/back-end/src/integrations/ClickHouse.ts
+++ b/packages/back-end/src/integrations/ClickHouse.ts
@@ -250,7 +250,7 @@ WITH _data as (
     return {
       start: start.getTime(),
       rows: res.rows.map((row) => ({
-        timestamp: new Date(row.ts + "Z"),
+        timestamp: new Date(row.ts.includes("T") ? row.ts : row.ts + "Z"),
         environment: "" + row.environment,
         value: "" + row.value,
         source: "" + row.source,


### PR DESCRIPTION
## Summary
- ClickHouse renders naive `DateTime`/`DateTime64` columns as timezone-less strings (e.g. `"2026-07-20 10:12:35"`, no `Z`/offset). JS's `new Date(...)` interprets that shape as local time on whatever host runs the back-end, not UTC — silently shifting timestamps by the server's local offset.
- This showed up as SQL Explorer displaying a different (double-shifted) time for `feature_usage.timestamp` than querying ClickHouse directly, and affects session replay (`started_at`/`ended_at`/etc.) the same way, since both flow through `ClickHouse.runQuery`.
- Fix: use ClickHouse's response column metadata (`data.meta`) to detect columns with no explicit timezone in their type (`DateTime`, `DateTime64(3)`, `Nullable(...)` — as opposed to `DateTime('Some/Zone')`, which is left untouched), and normalize their string values to proper UTC ISO strings before they leave `runQuery`.
- Gated behind `isManagedWarehouse(this.datasource)` — self-hosted/BYO ClickHouse connections may have real per-column or server-level non-UTC timezones we can't safely assume, so they're intentionally left unaffected.

## Test plan
- [x] `pnpm --filter back-end type-check`
- [x] `pnpm --filter back-end lint` (ran via pre-commit hook)
- [x] Verified the normalization/regex logic in isolation against sample ClickHouse metadata (bare `DateTime64(3)`, `DateTime('UTC')`, `Nullable(DateTime64(3))`, `String`, `null`)
- [x] Manually verify in a running app against a managed warehouse datasource: SQL Explorer's `SELECT * FROM feature_usage ORDER BY timestamp DESC` timestamp matches the raw ClickHouse value

🤖 Generated with [Claude Code](https://claude.com/claude-code)