### PR TITLE
Allow editing of feature usage query for ef data sources

### DIFF
--- a/packages/front-end/components/Settings/EditDataSource/FeatureEvaluationQueries/FeatureEvaluationQueries.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/FeatureEvaluationQueries/FeatureEvaluationQueries.tsx
@@ -127,7 +127,7 @@ export const FeatureEvaluationQueries: FC<FeatureEvaluationQueriesProps> = ({
                 <FaPlus className="mr-1" /> Add
               </Button>
             )}
-            {featureUsageQuery && !isManagedQuery && (
+            {featureUsageQuery && (
               <MoreMenu useRadix={false}>
                 <button
                   className="dropdown-item py-2"
@@ -136,20 +136,24 @@ export const FeatureEvaluationQueries: FC<FeatureEvaluationQueriesProps> = ({
                   Edit Query
                 </button>
 
-                <hr className="dropdown-divider" />
-                <DeleteButton
-                  useRadix={false}
-                  onClick={handleActionDeleteClicked()}
-                  className="dropdown-item text-danger py-2"
-                  iconClassName="mr-2"
-                  style={{ borderRadius: 0 }}
-                  useIcon={false}
-                  displayName={"Feature Usage Query"}
-                  deleteMessage={`Are you sure you want to delete this feature usage query?`}
-                  title="Delete"
-                  text="Delete"
-                  outline={false}
-                />
+                {!isManagedQuery && (
+                  <>
+                    <hr className="dropdown-divider" />
+                    <DeleteButton
+                      useRadix={false}
+                      onClick={handleActionDeleteClicked()}
+                      className="dropdown-item text-danger py-2"
+                      iconClassName="mr-2"
+                      style={{ borderRadius: 0 }}
+                      useIcon={false}
+                      displayName={"Feature Usage Query"}
+                      deleteMessage={`Are you sure you want to delete this feature usage query?`}
+                      title="Delete"
+                      text="Delete"
+                      outline={false}
+                    />
+                  </>
+                )}
               </MoreMenu>
             )}
           </Flex>


### PR DESCRIPTION
### Features and Changes

- Allow users to edit Event Forwarder-managed Feature Usage Queries when the generated SQL does not match their warehouse schema.
- Continue preventing deletion of managed queries so Event Forwarder configuration remains intact.

- Closes **(add link to issue here)**

### Dependencies

None.

### Testing

- [x] Confirm a managed Feature Usage Query can be edited and saved.
- [x] Confirm a managed query cannot be deleted.
- [x] Confirm manually configured queries can still be edited and deleted.
- [x] Confirm datasource permissions continue to control editing access.

### Screenshots