### PR TITLE
Update Skills docs to cover new Product Analytics skills

### DIFF
--- a/docs/docs/integrations/ai-agents/agent-skills/experiments.mdx
+++ b/docs/docs/integrations/ai-agents/agent-skills/experiments.mdx
@@ -39,6 +39,7 @@ After you stop an experiment, the feature flag it ran through usually still need
 ## Next steps
 
 - [Feature flag skills](/integrations/ai-agents/agent-skills/feature-flags): create, target, and clean up the flags your experiments run on
+- [Product analytics skills](/integrations/ai-agents/agent-skills/product-analytics): find the metrics and fact tables your experiments measure
 - [Agent Skills overview](/integrations/ai-agents/agent-skills): install and setup
 - [Experimentation documentation](/app/experiment-configuration): the underlying concepts
 

--- a/docs/docs/integrations/ai-agents/agent-skills/feature-flags.mdx
+++ b/docs/docs/integrations/ai-agents/agent-skills/feature-flags.mdx
@@ -62,6 +62,7 @@ Find and audit flags, and trace how they depend on one another. Both skills are 
 ## Next steps
 
 - [Experiment skills](/integrations/ai-agents/agent-skills/experiments): design, launch, analyze, and stop tests
+- [Product analytics skills](/integrations/ai-agents/agent-skills/product-analytics): search metrics and chart your product data
 - [Agent Skills overview](/integrations/ai-agents/agent-skills): install and setup
 - [Feature flag documentation](/features/basics): the underlying concepts
 

--- a/docs/docs/integrations/ai-agents/agent-skills/index.mdx
+++ b/docs/docs/integrations/ai-agents/agent-skills/index.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 [Agent Skills](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview) are folders of instructions, scripts, and resources that an AI agent loads on demand to carry out a specialized task. Anthropic introduced the format, and it works in any agent that follows the [Agent Skills standard](https://agentskills.io), including Claude Code, Cursor, and Codex.
 
-GrowthBook publishes a library of them that runs the entire feature flag and experiment lifecycle from your AI coding agent (create a flag, roll it out, run an experiment, read the results, and clean up afterward) without leaving your editor and **without running an MCP server**.
+GrowthBook publishes a library of them that runs the entire feature flag and experiment lifecycle from your AI coding agent (create a flag, roll it out, run an experiment, read the results, and clean up afterward), plus explore your product data, all without leaving your editor and **without running an MCP server**.
 
 Each skill is a playbook your agent follows: it knows the GrowthBook REST API, the right order of operations, and the guardrails (draft → review → publish, safe rollouts, two-step deletes) that keep changes safe.
 
@@ -101,11 +101,12 @@ Because each skill names its trigger phrases and routes to sibling skills, they 
 
 ## What's included
 
-The skills fall into three groups. The two reference pages list each one with an example prompt you can run.
+The skills fall into four groups. The three reference pages list each one with an example prompt you can run.
 
 - **Setup** — `gb-setup` configures and validates your API credentials.
 - **[Feature flag skills](/integrations/ai-agents/agent-skills/feature-flags)** — create, target, roll out, ramp, monitor, review, publish, search, and clean up flags across their full lifecycle.
 - **[Experiment skills](/integrations/ai-agents/agent-skills/experiments)** — brainstorm, design, launch, analyze, and stop A/B tests.
+- **[Product analytics skills](/integrations/ai-agents/agent-skills/product-analytics)** — search your metrics and fact tables, then chart your product data with a link back to the rendered chart.
 
 ## Example prompts
 
@@ -114,6 +115,7 @@ The skills fall into three groups. The two reference pages list each one with an
 - "Design an A/B test for the new pricing page and launch it on the `pricing-v2` flag."
 - "What are the results of our checkout experiment? Should we ship the winner?"
 - "Stop the `homepage-hero` experiment and roll the winning variation out to everyone."
+- "Chart daily active users over the last 30 days."
 
 ## Safety and governance
 
@@ -128,6 +130,7 @@ The skills follow GrowthBook's built-in safeguards:
 
 - [Feature flag skills](/integrations/ai-agents/agent-skills/feature-flags): the full flag catalog
 - [Experiment skills](/integrations/ai-agents/agent-skills/experiments): design, launch, analyze, and stop tests
+- [Product analytics skills](/integrations/ai-agents/agent-skills/product-analytics): search metrics and chart your product data
 - [Agent Skills vs. the MCP Server](/integrations/ai-agents)
 - [GrowthBook REST API](/app/api), which the skills call under the hood
 - [Skills source on GitHub](https://github.com/growthbook/skills)

--- a/docs/docs/integrations/ai-agents/agent-skills/product-analytics.mdx
+++ b/docs/docs/integrations/ai-agents/agent-skills/product-analytics.mdx
@@ -1,0 +1,51 @@
+---
+title: Product Analytics skills
+description: "The GrowthBook Agent Skills for Product Analytics: search your metrics and fact tables, then chart data over time from your AI agent, with a deep link back to the rendered chart."
+sidebar_label: Product Analytics skills
+---
+
+These [Agent Skills](/integrations/ai-agents/agent-skills) let you explore your product data from your AI agent: find the metrics and fact tables you have, then chart them and read back the numbers. Install the plugin and run [`/growthbook:gb-setup`](/integrations/ai-agents/agent-skills#installation) first.
+
+You can invoke the skills directly or your agent may run these skills automatically when it detects matching intent.
+
+## Prerequisites
+
+- **A SQL warehouse datasource**, [connected in the GrowthBook UI](/warehouses). Explorations run real queries against your warehouse (Postgres, BigQuery, Snowflake, and the like). Mixpanel and Google Analytics datasources can't run explorations.
+- **At least one fact metric or [Fact Table](/app/metrics#fact-tables)** to chart. Only fact metrics (IDs starting `fact__`) can be explored. Legacy metrics work in experiments but not in Product Analytics.
+- These skills read and query your data. They never create or edit metrics, fact tables, or dashboards.
+
+## The two skills
+
+`metric-search` is the discovery front door, and `analytics-explore` runs the chart. Search for what you want, then explore it.
+
+| Skill              | What it does                                                                                                                            | Example prompt                                 |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `metric-search`    | Search, list, and audit your metrics and fact tables: inventory, look up a definition, or triage what's chartable. Read-only.          | "What metrics do we have tagged growth?"       |
+| `analytics-explore` | Build and run a Product Analytics exploration from a metric, a fact table, or a raw warehouse table, then report the numbers and a link to the chart. | "Chart daily active users over the last month" |
+
+## What you can chart
+
+`analytics-explore` supports three dataset types, and picks the right one for your request:
+
+- **A fact metric** ("signup conversion", "revenue"). Preferred when a metric exists, because it carries curated logic (filters, aggregation, capping) that a raw aggregation won't reproduce.
+- **A fact table aggregation** ("orders by country", "unique users"). Counts, distinct-unit counts, and sums straight off a fact table.
+- **A raw warehouse table** with no fact table defined on it, using your data source's information schema.
+
+You control the shape of the result through natural language: the chart type (line, bar, big number, and more), the date range, a breakdown dimension ("break that down by plan"), and row filters. Follow-ups like "make it a bar chart" or "last 90 days instead" adjust the previous chart rather than rebuilding it.
+
+## Reading the results
+
+Every exploration returns the underlying numbers plus a deep link that opens the interactive chart in GrowthBook, which is your visual. Your agent reports the key figures inline and hands you the link to explore further.
+
+:::info Analytics, not experiment results
+These skills answer general questions about your product data. For A/B test readouts (lifts, confidence intervals, guardrails), use the [`experiment-analyze`](/integrations/ai-agents/agent-skills/experiments) skill instead.
+:::
+
+## Next steps
+
+- [Experiment skills](/integrations/ai-agents/agent-skills/experiments): brainstorm, design, launch, analyze, and stop tests
+- [Feature flag skills](/integrations/ai-agents/agent-skills/feature-flags): create, target, roll out, and clean up flags
+- [Agent Skills overview](/integrations/ai-agents/agent-skills): install and setup
+- [Product Analytics documentation](/app/product-analytics): the underlying concepts
+
+[Join our community Slack for additional tips and tricks](https://join.slack.com/t/growthbookusers/shared_invite/zt-2xw8fu279-Y~hwnfCEf7WrEI9qScHURQ)

--- a/docs/docs/integrations/ai-agents/index.mdx
+++ b/docs/docs/integrations/ai-agents/index.mdx
@@ -7,7 +7,7 @@ sidebar_label: AI Agents
 GrowthBook works directly inside your AI coding agent: Claude Code, Cursor, and others. There are two ways to connect, and they're complementary:
 
 - **[MCP Server](/integrations/mcp):** a live set of tools your agent can call mid-conversation.
-- **[Agent Skills](/integrations/ai-agents/agent-skills):** installable workflows that run the full feature-flag and experiment lifecycle, with GrowthBook's draft → review → publish guardrails built in. No server to run.
+- **[Agent Skills](/integrations/ai-agents/agent-skills):** installable workflows that run the full feature-flag and experiment lifecycle and explore your product data, with GrowthBook's draft → review → publish guardrails built into every change. No server to run.
 
 You can install both. Many teams reach for the MCP server for quick, conversational tasks and the skills for repeatable, end-to-end workflows.
 
@@ -18,7 +18,7 @@ You can install both. Many teams reach for the MCP server for quick, conversatio
 | **What it is**         | A server exposing GrowthBook tools to your agent                        | Markdown playbooks your agent follows step by step                                                                        |
 | **Setup**              | Add an MCP server entry that runs `npx @growthbook/mcp`                 | Install the plugin (no running server)                                                                                    |
 | **Best for**           | Quick lookups and one-off actions while you code                        | Repeatable, multi-step lifecycle workflows                                                                                |
-| **Lifecycle coverage** | Core flag, experiment, and product analytics actions                    | The full flag and experimentation lifecycle: create, target, ramp, experiment, analyze, stop, and clean up                |
+| **Lifecycle coverage** | Core flag, experiment, and product analytics actions                    | The full flag and experimentation lifecycle plus product analytics: create, target, ramp, experiment, analyze, stop, chart, and clean up |
 | **Governance**         | Direct API calls                                                        | Draft → review → publish, safe rollouts, and two-step deletes built into each skill                                       |
 | **Where it runs**      | Any MCP-compatible host, including agents that can't run shell commands | Agents that can run shell commands: Claude Code, Cursor, Codex, and other [agentskills.io](https://agentskills.io) agents |
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -664,6 +664,11 @@ export default {
                   id: "integrations/ai-agents/agent-skills/experiments",
                   label: "Experiment skills",
                 },
+                {
+                  type: "doc",
+                  id: "integrations/ai-agents/agent-skills/product-analytics",
+                  label: "Product Analytics skills",
+                },
               ],
             },
           ],


### PR DESCRIPTION
Updates Skills docs for new Product Analytics skills:

- Updates overview pages to include reference to the new skills
- Adds a page just for the PA skills, mirroring flag and experimentation skills
- Adds PA skills link to sidebar nav
