### PR TITLE
Show managed warehouse callout in View Queries UI

### DIFF
--- a/packages/front-end/components/Queries/AsyncQueriesModal.tsx
+++ b/packages/front-end/components/Queries/AsyncQueriesModal.tsx
@@ -2,12 +2,14 @@ import { FC, Fragment, useMemo, useState } from "react";
 import { QueryInterface } from "shared/types/query";
 import { FaAngleDown, FaAngleRight } from "react-icons/fa";
 import { SavedQuery } from "shared/validators";
+import { isManagedWarehousePendingQueryError } from "shared/util";
 import useApi from "@/hooks/useApi";
 import Modal from "@/components/Modal";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import Code from "@/components/SyntaxHighlighting/Code";
 import ExpandableSavedQuery from "@/components/SavedQueries/ExpandableSavedQuery";
+import ManagedWarehouseNoEventsCallout from "@/components/ManagedWarehouse/ManagedWarehouseNoEventsCallout";
 import Callout from "@/ui/Callout";
 import ExpandableQuery from "./ExpandableQuery";
 import QueryStatsRow from "./QueryStatsRow";
@@ -68,23 +70,28 @@ const AsyncQueriesModal: FC<{
 
   const contents = (
     <>
-      {error && (
-        <Callout status="error">
-          <div>
-            <strong>Error Processing Query Results</strong>
+      {error &&
+        (isManagedWarehousePendingQueryError(_error) ? (
+          <div className="mb-3">
+            <ManagedWarehouseNoEventsCallout />
           </div>
-          {error}
-          {traceback ? (
-            <Code
-              language="python"
-              filename="Python stack trace"
-              code={traceback.trim()}
-              showLineNumbers={false}
-              style={{ maxHeight: 500 }}
-            />
-          ) : null}
-        </Callout>
-      )}{" "}
+        ) : (
+          <Callout status="error">
+            <div>
+              <strong>Error Processing Query Results</strong>
+            </div>
+            {error}
+            {traceback ? (
+              <Code
+                language="python"
+                filename="Python stack trace"
+                code={traceback.trim()}
+                showLineNumbers={false}
+                style={{ maxHeight: 500 }}
+              />
+            ) : null}
+          </Callout>
+        ))}{" "}
       {data && data.queries.filter((q) => q === null).length > 0 && (
         <Callout status="error">
           Could not fetch information about one or more of these queries. Try

--- a/packages/front-end/components/Queries/ExpandableQuery.tsx
+++ b/packages/front-end/components/Queries/ExpandableQuery.tsx
@@ -9,10 +9,12 @@ import {
 } from "react-icons/fa";
 import { getValidDate } from "shared/dates";
 import { isFactMetricId } from "shared/experiments";
+import { isManagedWarehousePendingQueryError } from "shared/util";
 import { FaBoltLightning } from "react-icons/fa6";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import Code from "@/components/SyntaxHighlighting/Code";
 import Tooltip from "@/components/Tooltip/Tooltip";
+import ManagedWarehouseNoEventsCallout from "@/components/ManagedWarehouse/ManagedWarehouseNoEventsCallout";
 import Callout from "@/ui/Callout";
 import HelperText from "@/ui/HelperText";
 import QueryStatsRow, { getNumberOfMetricsInQuery } from "./QueryStatsRow";
@@ -118,13 +120,18 @@ const ExpandableQuery: FC<{
         )}
       </h4>
       <Code language={query.language} code={query.query} expandable={true} />
-      {query.error && (
-        <Callout status="error" my="3">
-          <pre className="m-0 p-0" style={{ whiteSpace: "pre-wrap" }}>
-            {query.error}
-          </pre>
-        </Callout>
-      )}
+      {query.error &&
+        (isManagedWarehousePendingQueryError(query.error) ? (
+          <div className="my-3">
+            <ManagedWarehouseNoEventsCallout />
+          </div>
+        ) : (
+          <Callout status="error" my="3">
+            <pre className="m-0 p-0" style={{ whiteSpace: "pre-wrap" }}>
+              {query.error}
+            </pre>
+          </Callout>
+        ))}
       {query.status === "succeeded" && (
         <>
           {query.rawResult?.[0] ? (


### PR DESCRIPTION
## Summary
- Replace the raw `managed_warehouse_pending` error in `AsyncQueriesModal` and `ExpandableQuery` with `ManagedWarehouseNoEventsCallout`
- Matches the existing guidance already shown on SQL test results, Product Analytics, Metric Analysis, and other query surfaces

## Test plan
- [ ] With a Managed Warehouse that has not received events / is awaiting provisioning, run an experiment update (or other query) so it fails with `managed_warehouse_pending`
- [ ] Open **View Queries** and confirm the modal shows the managed warehouse callout instead of “Error Processing Query Results / managed_warehouse_pending”
- [ ] Confirm each failed query section also shows the callout instead of the raw error code
- [ ] Confirm a normal (non-pending) query failure still shows the previous error UI


Made with [Cursor](https://cursor.com)