### PR TITLE
Features: fix drift when reviewing/publishing a draft on a "base that disagrees with live"

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -8,6 +8,7 @@ import {
   getSnapshotAnalysis,
   isDefined,
   autoMerge,
+  reconcileMergeBaselines,
   includeExperimentInPayload,
 } from "shared/util";
 import {
@@ -4302,7 +4303,18 @@ export async function postExperimentFeatureValues(
         revision: updatedRevision,
       });
       // Auto publish permission check is in validateExperimentFeatureUpdates
-      const mergeResult = autoMerge(live, base, updatedRevision, orgEnvIds, {});
+      const { live: mergeLive, base: mergeBase } = reconcileMergeBaselines(
+        feature,
+        live,
+        base,
+      );
+      const mergeResult = autoMerge(
+        mergeLive,
+        mergeBase,
+        updatedRevision,
+        orgEnvIds,
+        {},
+      );
 
       // This should never happen since we only allow auto-publising new revisions, but guard against it just in case
       if (!mergeResult.success) {

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -27,6 +27,7 @@ import {
   mergeRevision,
   liveRevisionFromFeature,
   fillRevisionFromFeature,
+  reconcileMergeBaselines,
   getReviewSetting,
   namespacesToMap,
   pruneOrphanedRampActions,
@@ -3541,7 +3542,18 @@ export async function postFeatureExperimentRefRule(
       revision: updatedRevision,
     });
     const orgEnvIds = environments;
-    const mergeResult = autoMerge(live, base, updatedRevision, orgEnvIds, {});
+    const { live: mergeLive, base: mergeBase } = reconcileMergeBaselines(
+      feature,
+      live,
+      base,
+    );
+    const mergeResult = autoMerge(
+      mergeLive,
+      mergeBase,
+      updatedRevision,
+      orgEnvIds,
+      {},
+    );
     if (!mergeResult.success) {
       throw new Error(
         `Unable to auto-publish: please resolve conflicts on draft #${updatedRevision.version} before publishing.`,
@@ -3755,7 +3767,18 @@ export async function postFeatureContextualBanditRefRule(
       revision: updatedRevision,
     });
     const orgEnvIds = environments;
-    const mergeResult = autoMerge(live, base, updatedRevision, orgEnvIds, {});
+    const { live: mergeLive, base: mergeBase } = reconcileMergeBaselines(
+      feature,
+      live,
+      base,
+    );
+    const mergeResult = autoMerge(
+      mergeLive,
+      mergeBase,
+      updatedRevision,
+      orgEnvIds,
+      {},
+    );
     if (!mergeResult.success) {
       throw new Error(
         `Unable to auto-publish: please resolve conflicts on draft #${updatedRevision.version} before publishing.`,

--- a/packages/back-end/src/enterprise/saferollouts/safeRolloutUtils.ts
+++ b/packages/back-end/src/enterprise/saferollouts/safeRolloutUtils.ts
@@ -3,7 +3,7 @@ import {
   getHealthSettings,
   getSafeRolloutResultStatus,
 } from "shared/enterprise";
-import { autoMerge } from "shared/util";
+import { autoMerge, reconcileMergeBaselines } from "shared/util";
 import { SafeRolloutStatus, SafeRolloutRule } from "shared/validators";
 import {
   SafeRolloutInterface,
@@ -165,7 +165,12 @@ export async function checkAndRollbackSafeRollout({
       throw new Error("Could not lookup feature history");
     }
 
-    const mergeResult = autoMerge(live, base, revision, ruleEnvs, {});
+    const { live: mergeLive, base: mergeBase } = reconcileMergeBaselines(
+      feature,
+      live,
+      base,
+    );
+    const mergeResult = autoMerge(mergeLive, mergeBase, revision, ruleEnvs, {});
     if (!mergeResult.success) {
       throw new Error("could not merge the status");
     }

--- a/packages/back-end/src/services/experiment-feature.ts
+++ b/packages/back-end/src/services/experiment-feature.ts
@@ -8,6 +8,7 @@ import {
   liveRevisionFromFeature,
   MatchingRule,
   mergeResultHasChanges,
+  reconcileMergeBaselines,
   resetReviewOnChange,
   checkIfRevisionNeedsReview,
 } from "shared/util";
@@ -761,7 +762,18 @@ export async function publishPendingFeatureDraftsForContextualBandit(
       feature,
       revision,
     });
-    const mergeResult = autoMerge(live, base, revision, orgEnvIds, {});
+    const { live: mergeLive, base: mergeBase } = reconcileMergeBaselines(
+      feature,
+      live,
+      base,
+    );
+    const mergeResult = autoMerge(
+      mergeLive,
+      mergeBase,
+      revision,
+      orgEnvIds,
+      {},
+    );
     if (!mergeResult.success) {
       logger.warn(
         {

--- a/packages/front-end/components/Avatar/EventUser.tsx
+++ b/packages/front-end/components/Avatar/EventUser.tsx
@@ -114,6 +114,11 @@ export default function EventUser({
     }
   }
 
+  // Treat a blank/whitespace-only name as absent so it never renders as an
+  // empty label line or a blank avatar initial (some user records carry " ").
+  name = (name || "").trim();
+  email = (email || "").trim();
+
   if (display === "avatar") {
     return (
       <UserAvatar

--- a/packages/front-end/components/Reviews/ReviewPeople.tsx
+++ b/packages/front-end/components/Reviews/ReviewPeople.tsx
@@ -26,7 +26,10 @@ export function PersonRow({
   email: string;
   trailing?: React.ReactNode;
 }) {
-  const displayName = name || email || "Unknown";
+  // Treat a blank/whitespace-only name as absent so the top line never renders
+  // empty (some user records carry " "); the email then becomes the sole line.
+  const trimmedName = (name || "").trim();
+  const displayName = trimmedName || email || "Unknown";
   return (
     <Flex align="start" gap="2">
       <Box flexShrink="0" mt="1">
@@ -40,7 +43,7 @@ export function PersonRow({
         <Text size="small" color="text-high" as="div" overflowWrap="anywhere">
           {displayName}
         </Text>
-        {name && email && (
+        {trimmedName && email && (
           <Text size="small" color="text-low" as="div" overflowWrap="anywhere">
             {email}
           </Text>

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -1194,6 +1194,22 @@ export function buildEffectiveDraft(
   };
 }
 
+// Reconciles a raw (live, base) revision pair against the live feature document
+// so every autoMerge caller compares against the same feature-model-anchored
+// baseline. Passing raw revision snapshots straight into autoMerge lets drift
+// between a snapshot and feature.environmentSettings/rules (e.g. from the legacy
+// v1/v2 write bridge) hide or invent changes, and leaves callers out of unison.
+export function reconcileMergeBaselines(
+  feature: FeatureInterface,
+  live: RevisionFields,
+  base: RevisionFields,
+): { live: RevisionFields; base: RevisionFields } {
+  return {
+    live: liveRevisionFromFeature(live, feature),
+    base: fillRevisionFromFeature(base, feature),
+  };
+}
+
 // Returns true if the draft differs from live across any tracked field.
 export function draftDiffersFromLive(
   draftRevision: RevisionFields,
@@ -1775,11 +1791,17 @@ export function autoMerge(
       result.rules = revRules;
     }
 
-    // environmentsEnabled
+    // environmentsEnabled — anchor to the live feature model, not the base
+    // snapshot. `base` and `live` share a version here, so they should match;
+    // when they drift (e.g. a legacy v1 REST write that updated the feature doc
+    // but not the revision), a stale base value that equals the draft would
+    // otherwise swallow a real toggle and report "no changes to publish".
+    // `live` is feature-model-sourced (liveRevisionFromFeature), matching
+    // draftDiffersFromLive so the dashboard and REST publish gates stay in unison.
     if (revision.environmentsEnabled) {
       for (const env of Object.keys(revision.environmentsEnabled)) {
         const revVal = revision.environmentsEnabled[env];
-        if (revVal !== base.environmentsEnabled?.[env]) {
+        if (revVal !== live.environmentsEnabled?.[env]) {
           result.environmentsEnabled = result.environmentsEnabled || {};
           result.environmentsEnabled[env] = revVal;
         }

--- a/packages/shared/test/util/feature-revisions.test.ts
+++ b/packages/shared/test/util/feature-revisions.test.ts
@@ -13,6 +13,7 @@ import {
   RevisionFields,
   draftDiffersFromLive,
   liveRevisionFromFeature,
+  reconcileMergeBaselines,
 } from "../../src/util";
 
 // ---------------------------------------------------------------------------
@@ -483,6 +484,43 @@ describe("autoMerge with new envelopes", () => {
       }
     });
 
+    // Regression: when the base revision snapshot drifts from the live feature
+    // model (e.g. a legacy v1 REST write updated the feature doc but not the
+    // revision), a draft toggle that happens to match the stale base value must
+    // still register as a change to publish. Anchoring to `live` (feature model)
+    // instead of `base` is what makes this surface instead of "No changes".
+    it("detects an env toggle even when the base snapshot drifted to match it", () => {
+      const driftedBase: RevisionFields = {
+        version: 5,
+        defaultValue: "false",
+        rules: {},
+        environmentsEnabled: { production: true }, // stale snapshot
+      };
+      const liveFeatureModel: RevisionFields = {
+        version: 5,
+        defaultValue: "false",
+        rules: {},
+        environmentsEnabled: { production: false }, // what's actually live
+      };
+      const revision: RevisionFields = {
+        version: 6,
+        defaultValue: "false",
+        rules: {},
+        environmentsEnabled: { production: true }, // draft wants it on
+      };
+      const result = autoMerge(
+        liveFeatureModel,
+        driftedBase,
+        revision,
+        ["production"],
+        {},
+      );
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result.environmentsEnabled).toEqual({ production: true });
+      }
+    });
+
     it("includes metadata changes", () => {
       const revision: RevisionFields = {
         version: 4,
@@ -818,6 +856,67 @@ describe("backward compatibility — old revisions without envelopes", () => {
 // ---------------------------------------------------------------------------
 // fillRevisionFromFeature
 // ---------------------------------------------------------------------------
+
+describe("reconcileMergeBaselines", () => {
+  // The core "keep in unison" property: even when a raw live revision snapshot
+  // disagrees with the feature document on an env (drift), the reconciled `live`
+  // baseline must reflect the feature model — otherwise raw-snapshot callers
+  // (auto-publish, safe rollout, experiments) diff against a stale value.
+  it("sources the live baseline env state from the feature model, not the raw snapshot", () => {
+    // baseFeature: production enabled=true, staging enabled=false.
+    const staleLive = makeRevision({
+      version: 3,
+      environmentsEnabled: { production: false, staging: false }, // drifted
+    });
+    const base = makeRevision({
+      version: 3,
+      environmentsEnabled: { production: false, staging: false },
+    });
+
+    const reconciled = reconcileMergeBaselines(baseFeature, staleLive, base);
+
+    // Feature model wins for the live baseline.
+    expect(reconciled.live.environmentsEnabled?.production).toBe(true);
+    expect(reconciled.live.environmentsEnabled?.staging).toBe(false);
+  });
+
+  it("feeds autoMerge a delta when the draft matches a stale base but differs from the feature model", () => {
+    // baseFeature has staging disabled. The stale snapshots claim it's already
+    // enabled, and the draft also enables it — so without reconciliation the
+    // draft === base and the toggle is swallowed.
+    const staleLive = makeRevision({
+      version: 3,
+      environmentsEnabled: { staging: true }, // drifted: model says false
+    });
+    const staleBase = makeRevision({
+      version: 3,
+      environmentsEnabled: { staging: true },
+    });
+    const revision = makeRevision({
+      version: 4,
+      environmentsEnabled: { staging: true },
+    });
+
+    const { live, base } = reconcileMergeBaselines(
+      baseFeature,
+      staleLive,
+      staleBase,
+    );
+    const result = autoMerge(
+      live,
+      base,
+      revision,
+      ["production", "staging"],
+      {},
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // Without reconciliation this would be swallowed (draft === stale base).
+      expect(result.result.environmentsEnabled).toEqual({ staging: true });
+    }
+  });
+});
 
 describe("fillRevisionFromFeature", () => {
   it("backfills environmentsEnabled for environments not present in revision", () => {

--- a/packages/shared/test/util/feature-revisions.test.ts
+++ b/packages/shared/test/util/feature-revisions.test.ts
@@ -612,6 +612,50 @@ describe("autoMerge with new envelopes", () => {
       expect(result.success).toBe(true);
     });
 
+    // Drift-safety (diverged): the draft never moved an env (revVal === base),
+    // but the live feature model has since moved it (e.g. ops flipped a kill
+    // switch after the draft forked). Publishing must KEEP the live value and
+    // emit no env delta — never revert live from a stale draft snapshot. This is
+    // the diverged counterpart to the non-diverged fix, and it intentionally
+    // does NOT anchor to the draft, so a stale base can't re-enable a killed env.
+    it("keeps the live value when the draft did not touch an env that live moved", () => {
+      const liveMoved: RevisionFields = {
+        ...live,
+        environmentsEnabled: { production: false }, // live killed it post-fork
+      };
+      const revision: RevisionFields = {
+        version: 4,
+        defaultValue: "false",
+        rules: {},
+        environmentsEnabled: { production: true }, // unchanged from base (true)
+      };
+      const result = autoMerge(liveMoved, base, revision, ["production"], {});
+      expect(result.success).toBe(true);
+      if (result.success) {
+        // No env entry → computeRevisionMergeChanges leaves live (false) intact.
+        expect(result.result.environmentsEnabled).toBeUndefined();
+        expect(result.conflicts).toHaveLength(0);
+      }
+    });
+
+    it("emits no env delta when the draft already matches the live feature model", () => {
+      const liveMoved: RevisionFields = {
+        ...live,
+        environmentsEnabled: { production: false },
+      };
+      const revision: RevisionFields = {
+        version: 4,
+        defaultValue: "false",
+        rules: {},
+        environmentsEnabled: { production: false }, // same as live
+      };
+      const result = autoMerge(liveMoved, base, revision, ["production"], {});
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result.environmentsEnabled).toBeUndefined();
+      }
+    });
+
     it("applies non-conflicting metadata change", () => {
       const revision: RevisionFields = {
         version: 4,


### PR DESCRIPTION
Fix "No changes to publish" when a feature's live state disagrees with its revision snapshot

When a feature's live environment-enabled state (`feature.environmentSettings`) drifts from its revision snapshot — e.g. from legacy v1 REST writes — the Review & Publish pane could report "No changes to publish" even though a draft genuinely toggled an environment on/off, blocking the publish entirely.

The merge diff was comparing the draft against the base revision snapshot instead of the actual live feature state. This anchors it to the feature model (the served truth), matching the REST publish gate so the dashboard and API agree.

- `autoMerge` env-enabled comparison now diffs against live feature state, not the base snapshot.
- New shared `reconcileMergeBaselines` helper routes all `autoMerge` callers (auto-publish, experiment/bandit ref rules, safe rollout) through the same feature-model-anchored baseline, so they stay in unison.
- No behavior change for features whose feature doc and revisions already agree (the common case) — the diff is a no-op there.

Adds regression coverage for the drift case and diverged-path drift-safety (never reverts a concurrent live env change).