### PR TITLE
Fix ramp schedules re-disabling their rule from the startActions snapshot

### DIFF
--- a/packages/back-end/src/services/rampSchedule.ts
+++ b/packages/back-end/src/services/rampSchedule.ts
@@ -423,7 +423,15 @@ export function computeEffectivePatch(
 
   // Seed with startActions — the base-layer rule state (condition, savedGroups,
   // coverage, etc.) that all steps inherit from unless explicitly overridden.
-  for (const a of schedule.startActions ?? []) merge(a);
+  // `enabled` is deliberately dropped from the seed: the engine owns the rule's
+  // enabled state while a ramp is live, and a snapshot captured from a disabled
+  // rule would otherwise re-disable the rule on every forward publish. Full
+  // rollback (-1) applies the raw startActions instead of this function, so a
+  // captured enabled state is still honored there.
+  for (const a of schedule.startActions ?? []) {
+    const { enabled: _enabled, ...patch } = a.patch;
+    merge({ ...a, patch });
+  }
 
   const lastStepIdx = Math.min(stepIndex, schedule.steps.length - 1);
   for (let i = 0; i <= lastStepIdx; i++) {
@@ -2064,8 +2072,10 @@ export async function completeRollout(
 
   // Mirror advanceStep: if the schedule was never started (currentStepIndex < 0)
   // and it has actual ramp steps, inject enabled:true so the rule is not left
-  // permanently disabled after completion. Simple schedules (steps: []) handle
-  // enabling via startActions and don't need this injection.
+  // permanently disabled after completion. Zero-step schedules are excluded on
+  // purpose: their natural flow enables via applyRampStartActions in the same
+  // tick, and injecting here would add a redundant completion publish (the
+  // effective patch no longer carries `enabled` from the startActions seed).
   if (schedule.currentStepIndex < 0 && schedule.steps.length > 0) {
     // This crosses -1 → serving, so honor the start-approval gate. Skipped when
     // disableActiveTargets is set — that path disables (e.g. cutoff-driven

--- a/packages/back-end/test/services/rampSchedule.test.ts
+++ b/packages/back-end/test/services/rampSchedule.test.ts
@@ -786,6 +786,57 @@ describe("computeEffectivePatch", () => {
       force: "variant-b",
     });
   });
+
+  it("drops enabled from the startActions seed", () => {
+    // A snapshot captured from a disabled rule must not re-disable the rule
+    // on forward publishes (e.g. zero-step schedule auto-completion).
+    const sched = {
+      steps: [],
+      startActions: [
+        {
+          targetType: "feature-rule" as const,
+          targetId: TARGET_ID,
+          patch: {
+            ruleId: RULE_ID,
+            coverage: 1.0,
+            condition: "{}",
+            enabled: false,
+          },
+        },
+      ],
+    };
+    const patch = computeEffectivePatch(sched, 0).get(TARGET_ID);
+    expect(patch).not.toHaveProperty("enabled");
+    expect(patch).toMatchObject({ coverage: 1.0, condition: "{}" });
+  });
+
+  it("steps and endActions can still set enabled explicitly", () => {
+    const sched = {
+      steps: [
+        {
+          interval: 300,
+          actions: [action(TARGET_ID, { coverage: 0.5, enabled: true })],
+        },
+      ],
+      startActions: [
+        {
+          targetType: "feature-rule" as const,
+          targetId: TARGET_ID,
+          patch: { ruleId: RULE_ID, coverage: 0.0, enabled: false },
+        },
+      ],
+      endActions: [action(TARGET_ID, { enabled: false })],
+    } as Pick<RampScheduleInterface, "steps" | "endActions" | "startActions">;
+
+    // At step 0: enabled comes from the step, not the seed.
+    expect(computeEffectivePatch(sched, 0).get(TARGET_ID)).toMatchObject({
+      enabled: true,
+    });
+    // At completion: endActions' explicit enabled:false wins.
+    expect(computeEffectivePatch(sched, 1).get(TARGET_ID)).toMatchObject({
+      enabled: false,
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Features and Changes

Ramp schedules created via the REST API (`POST /api/v1/ramp-schedules`) or a deferred revision publish get a server-attached `startActions` snapshot of the rule's pre-ramp state — including `enabled` (`getStartPatchForRule`). Because `computeEffectivePatch` seeded every forward publish from that snapshot, a schedule created over a **disabled** rule re-applied `enabled: false` on later publishes.

Most visible failure: a zero-step "enable on date" schedule enables its rule (`applyRampStartActions` injects `enabled: true`) and then, in the same scheduler tick, `advanceUntilBlocked` auto-completes it via `completeRollout` — which republished the snapshot's `enabled: false`. The rule flips ON→OFF within milliseconds, the schedule reports "completed", and no error surfaces anywhere. We hit this on a self-hosted deployment: a launch flag's history showed "Schedule started" and "Schedule ended" revisions ~250ms apart with the rule left disabled.

The same seeding also meant a multi-step ramp materialized over a disabled rule would re-disable its rule on every advance past step 0 (the `enabled: true` injection only fires on the -1 crossing).

**Fix:** drop `enabled` from the `startActions` seed layer in `computeEffectivePatch`:

- The engine owns the rule's enabled state on forward publishes (injected on the -1 crossing, forced off by cutoff/disable paths).
- Steps and `endActions` can still set `enabled` explicitly — only the seed layer is stripped.
- Full rollback (-1) applies the raw `startActions` (it doesn't go through this function), so a captured enabled state is still honored for restore-to-pre-ramp semantics.
- This matches UI-built snapshots (`buildRampStartActionsFromRule`), which already omit `enabled` for exactly this reason.

Two deliberate semantics worth calling out for review:

1. A rule manually disabled mid-ramp now **stays** disabled through later advances/completion (previously, an API-created snapshot with `enabled: true` would silently re-enable it). We think respecting the manual kill is the safer behavior, and it's what UI-created schedules already did.
2. An explicit `startState: { enabled: ... }` passed to the REST API now only takes effect on full rollback, consistent with the OpenAPI description of `startActions` ("Actions that restore controlled rules to their pre-ramp state").

- Closes **N/A** (no issue filed; happy to open one if preferred)

### Dependencies

None.

### Testing

Unit tests added in `packages/back-end/test/services/rampSchedule.test.ts`:
- `drops enabled from the startActions seed`
- `steps and endActions can still set enabled explicitly`

End-to-end repro against a locally-run back-end (before/after):
1. Create a feature with a disabled force rule.
2. `POST /api/v1/ramp-schedules` with that rule, no steps, no `startActions`, `startDate` in the near future — the server attaches a snapshot with `"enabled": false`.
3. Wait for the schedule to fire.
   - **Before:** revision history shows "Schedule started" then "Schedule ended" ~35ms apart; the rule ends disabled; the schedule reports completed.
   - **After:** same schedule shape; the rule ends enabled and stays enabled; schedule completes normally.

`pnpm --filter back-end test test/services/rampSchedule.test.ts` (195 passing) and `pnpm --filter back-end type-check` are green.

### Screenshots

N/A (back-end only).