### PR TITLE
Add "while you're here" link-migration pre-commit nudge

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -26,6 +26,10 @@ fi
 echo "#### Linting typescript, scss, and markdown files"
 pnpm lint-staged
 
+# Non-blocking "while you're here" reminder for staged files that still use
+# raw <a> tags or next/link. Never fails the commit.
+node scripts/link-nudge.js || true
+
 # Add eslint-suppressions.json if it was modified during linting
 if [ -n "$(git status --porcelain eslint-suppressions.json)" ]
   then

--- a/scripts/link-nudge.js
+++ b/scripts/link-nudge.js
@@ -1,0 +1,96 @@
+/* eslint-disable */
+/**
+ * "While you're here..." link-migration nudge.
+ *
+ * Non-blocking pre-commit reminder: for each staged front-end file that still
+ * uses a raw <a> tag or imports next/link, print a friendly note suggesting a
+ * migration to @/ui/Link / @/ui/LinkButton. It NEVER fails the commit — the
+ * hard guardrail against *new* violations is the ESLint rules
+ * (react/forbid-elements, no-restricted-imports) baselined in
+ * eslint-suppressions.json. This just encourages chipping away at the backlog
+ * in files you're already touching.
+ */
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.join(__dirname, "..");
+
+// Only nudge on real front-end app code. The design-system wrappers under
+// packages/front-end/ui/ are allowed to use next/link and are excluded from the
+// lint rules, so we skip them here too.
+const isRelevant = (rel) =>
+  rel.startsWith("packages/front-end/") &&
+  !rel.startsWith("packages/front-end/ui/") &&
+  /\.(tsx|ts)$/.test(rel) &&
+  !/\.(test|stories)\.(tsx|ts)$/.test(rel);
+
+function stagedFiles() {
+  try {
+    const out = execSync("git diff --cached --name-only --diff-filter=ACM", {
+      cwd: ROOT,
+      encoding: "utf8",
+    });
+    return out.split("\n").map((s) => s.trim()).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+const NEXT_LINK_IMPORT = /from\s+["']next\/link["']/;
+
+function scan(rel) {
+  const full = path.join(ROOT, rel);
+  let src;
+  try {
+    src = fs.readFileSync(full, "utf8");
+  } catch {
+    return null;
+  }
+
+  const lines = src.split("\n");
+  let anchors = 0;
+  lines.forEach((line, i) => {
+    if (!/<a[\s>]/.test(line)) return;
+    // Respect explicit opt-outs: skip anchors the author intentionally kept.
+    const prev = lines[i - 1] || "";
+    if (/eslint-disable/.test(line) || /eslint-disable-next-line/.test(prev)) {
+      return;
+    }
+    anchors += (line.match(/<a[\s>]/g) || []).length;
+  });
+
+  const nextLink = NEXT_LINK_IMPORT.test(src);
+  if (!anchors && !nextLink) return null;
+  return { rel, anchors, nextLink };
+}
+
+function main() {
+  const hits = stagedFiles().filter(isRelevant).map(scan).filter(Boolean);
+  if (!hits.length) return;
+
+  const yellow = (s) => `\x1b[33m${s}\x1b[0m`;
+  const dim = (s) => `\x1b[2m${s}\x1b[0m`;
+
+  console.log("");
+  console.log(yellow("📎 Link migration — \"while you're here\" reminder"));
+  console.log(
+    dim(
+      "   These staged files still use raw <a> or next/link (not blocking your commit):",
+    ),
+  );
+  for (const h of hits) {
+    const parts = [];
+    if (h.anchors) parts.push(`${h.anchors} raw <a>`);
+    if (h.nextLink) parts.push("next/link import");
+    console.log(`     • ${h.rel} ${dim(`(${parts.join(", ")})`)}`);
+  }
+  console.log(
+    dim(
+      "   Consider migrating to @/ui/Link (text) or @/ui/LinkButton (button-styled).",
+    ),
+  );
+  console.log("");
+}
+
+main();

--- a/scripts/link-nudge.js
+++ b/scripts/link-nudge.js
@@ -11,7 +11,6 @@
  * in files you're already touching.
  */
 const { execSync } = require("child_process");
-const fs = require("fs");
 const path = require("path");
 
 const ROOT = path.join(__dirname, "..");
@@ -40,10 +39,16 @@ function stagedFiles() {
 const NEXT_LINK_IMPORT = /from\s+["']next\/link["']/;
 
 function scan(rel) {
-  const full = path.join(ROOT, rel);
+  // Read the staged blob (index), not the working tree, so the reminder
+  // reflects exactly what will be committed. A partially-staged file can have
+  // different content on disk than in the index.
   let src;
   try {
-    src = fs.readFileSync(full, "utf8");
+    src = execSync(`git show ":${rel}"`, {
+      cwd: ROOT,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
   } catch {
     return null;
   }


### PR DESCRIPTION

## Summary
Adds a non-blocking "while you're here" pre-commit nudge for the link migration.
- For staged front-end files that still contain raw `<a>` or `next/link`, it prints a friendly reminder to migrate to `@/ui/Link` / `@/ui/LinkButton`.
- Only looks at files you're already touching; **never fails the commit**.
- Independent of the ESLint rules — the hard gate against new violations lives in the guardrails PR.
## Test plan
- [x] Stage a file with a baselined `<a>` → nudge prints, commit still succeeds
- [x] `node scripts/link-nudge.js` exits 0 even with offenders present
### Screenshots

<img width="1083" height="280" alt="image" src="https://github.com/user-attachments/assets/f764a699-6ab1-4a6a-bb39-3edc09d2ac52" />
