### PR TITLE
Align legacy ratio percentile cap populations

### DIFF
--- a/packages/back-end/src/integrations/sql/ctes/bandit-statistics-cte.ts
+++ b/packages/back-end/src/integrations/sql/ctes/bandit-statistics-cte.ts
@@ -24,7 +24,7 @@ export function getBanditStatisticsCTE(
     metricData,
     dimensionCols,
     hasRegressionAdjustment,
-    hasCapping,
+    hasNumeratorCapping,
     ignoreNulls,
     denominatorIsPercentileCapped,
   }: {
@@ -32,7 +32,7 @@ export function getBanditStatisticsCTE(
     metricData: BanditMetricData[];
     dimensionCols: DimensionColumnData[];
     hasRegressionAdjustment: boolean;
-    hasCapping: boolean;
+    hasNumeratorCapping: boolean;
     ignoreNulls?: boolean;
     denominatorIsPercentileCapped?: boolean;
   },
@@ -118,7 +118,7 @@ export function getBanditStatisticsCTE(
         `
         : ""
     }
-    ${hasCapping ? `CROSS JOIN __capValue cap` : ""}
+    ${hasNumeratorCapping ? `CROSS JOIN __capValue cap` : ""}
     ${ignoreNulls ? `WHERE m.value != 0` : ""}
     GROUP BY
       m.variation

--- a/packages/back-end/src/integrations/sql/queries/snapshot-metric-query.ts
+++ b/packages/back-end/src/integrations/sql/queries/snapshot-metric-query.ts
@@ -435,6 +435,18 @@ WITH
         ${
           denominator && denominatorIsPercentileCapped
             ? `
+          ${
+            denominator.cappingSettings.ignoreZeros
+              ? ""
+              : `, __userDenominatorCapPopulation AS (
+                  -- Materialize implicit zeros without changing denominator aggregation semantics
+                  SELECT COALESCE(d.value, 0) AS value
+                  FROM __userMetricAgg m
+                  LEFT JOIN __userDenominatorAgg d ON (
+                    d.${baseIdType} = m.${baseIdType}
+                  )
+                )`
+          }
           , __capValueDenominator AS (
             ${dialect.percentileCapSelectClause(
               [
@@ -446,7 +458,9 @@ WITH
                   sourceIndex: 0,
                 },
               ],
-              "__userDenominatorAgg",
+              denominator.cappingSettings.ignoreZeros
+                ? "__userDenominatorAgg"
+                : "__userDenominatorCapPopulation",
               `WHERE value IS NOT NULL${
                 denominator.cappingSettings.ignoreZeros ? " AND value != 0" : ""
               }`,
@@ -504,7 +518,7 @@ WITH
           ],
           dimensionCols,
           hasRegressionAdjustment: regressionAdjusted,
-          hasCapping: isPercentileCapped || denominatorIsPercentileCapped,
+          hasNumeratorCapping: isPercentileCapped,
           ignoreNulls: "ignoreNulls" in metric && metric.ignoreNulls,
           denominatorIsPercentileCapped,
         })

--- a/packages/back-end/test/integrations/sql/queries/snapshot-metric-query.test.ts
+++ b/packages/back-end/test/integrations/sql/queries/snapshot-metric-query.test.ts
@@ -390,4 +390,33 @@ describe("legacy ratio percentile-cap populations", () => {
     expect(sql).not.toMatch(/__capValue\s+AS\s*\(/i);
     expect(banditStatistics).not.toMatch(/CROSS JOIN __capValue cap\b/i);
   });
+
+  it.each([
+    {
+      name: "numerator-only",
+      denominatorCappingType: "" as const,
+      hasDenominatorCap: false,
+    },
+    {
+      name: "dual-capped",
+      denominatorCappingType: "percentile" as const,
+      hasDenominatorCap: true,
+    },
+  ])(
+    "joins the numerator cap into $name bandit queries",
+    ({ denominatorCappingType, hasDenominatorCap }) => {
+      const sql = buildQuery(bigQueryDialect, {
+        ignoreZeros: false,
+        denominatorCappingType,
+        bandit: true,
+      });
+      const banditStatistics = getCteBody(sql, "__banditPeriodStatistics");
+
+      expect(sql).toMatch(/__capValue\s+AS\s*\(/i);
+      expect(banditStatistics).toMatch(/CROSS JOIN __capValue cap\b/i);
+      expect(
+        /CROSS JOIN __capValueDenominator capd\b/i.test(banditStatistics),
+      ).toBe(hasDenominatorCap);
+    },
+  );
 });

--- a/packages/back-end/test/integrations/sql/queries/snapshot-metric-query.test.ts
+++ b/packages/back-end/test/integrations/sql/queries/snapshot-metric-query.test.ts
@@ -1,0 +1,393 @@
+import type { DataSourceInterface } from "shared/types/datasource";
+import type { ExperimentSnapshotSettings } from "shared/types/experiment-snapshot";
+import type { ExperimentMetricQueryParams } from "shared/types/integrations";
+import type { MetricInterface } from "shared/types/metric";
+import type { SqlDialect } from "shared/types/sql";
+import { athenaDialect } from "back-end/src/integrations/dialects/athena";
+import { bigQueryDialect } from "back-end/src/integrations/dialects/bigquery";
+import { clickHouseDialect } from "back-end/src/integrations/dialects/clickhouse";
+import { databricksDialect } from "back-end/src/integrations/dialects/databricks";
+import { mssqlDialect } from "back-end/src/integrations/dialects/mssql";
+import { mysqlDialect } from "back-end/src/integrations/dialects/mysql";
+import { postgresDialect } from "back-end/src/integrations/dialects/postgres";
+import { prestoDialect } from "back-end/src/integrations/dialects/presto";
+import { redshiftDialect } from "back-end/src/integrations/dialects/redshift";
+import { snowflakeDialect } from "back-end/src/integrations/dialects/snowflake";
+import { verticaDialect } from "back-end/src/integrations/dialects/vertica";
+import { getSnapshotMetricQuery } from "back-end/src/integrations/sql/queries/snapshot-metric-query";
+
+const datasource: DataSourceInterface = {
+  id: "ds_test",
+  name: "Test datasource",
+  description: "",
+  organization: "org_test",
+  dateCreated: null,
+  dateUpdated: null,
+  params: "",
+  settings: { queries: { identityJoins: [] } },
+  type: "bigquery",
+};
+
+const settings: ExperimentSnapshotSettings = {
+  manual: false,
+  dimensions: [],
+  metricSettings: [],
+  goalMetrics: [],
+  secondaryMetrics: [],
+  guardrailMetrics: [],
+  activationMetric: null,
+  defaultMetricPriorSettings: {
+    override: false,
+    proper: false,
+    mean: 0,
+    stddev: 1,
+  },
+  regressionAdjustmentEnabled: false,
+  attributionModel: "firstExposure",
+  experimentId: "exp_test",
+  queryFilter: "",
+  segment: "",
+  skipPartialData: false,
+  datasourceId: datasource.id,
+  exposureQueryId: "exposure_test",
+  startDate: new Date("2026-01-01T00:00:00Z"),
+  endDate: new Date("2026-01-31T00:00:00Z"),
+  variations: [],
+};
+
+function buildMetric({
+  id,
+  valueColumn,
+  denominator,
+  ignoreZeros,
+  cappingType = "percentile",
+  aggregation,
+}: {
+  id: string;
+  valueColumn: string;
+  denominator?: string;
+  ignoreZeros?: boolean;
+  cappingType?: "" | "absolute" | "percentile";
+  aggregation?: string;
+}): MetricInterface {
+  return {
+    id,
+    organization: "org_test",
+    owner: "",
+    datasource: datasource.id,
+    dateCreated: null,
+    dateUpdated: null,
+    name: id,
+    description: "",
+    type: "count",
+    denominator,
+    inverse: false,
+    aggregation,
+    ignoreNulls: false,
+    sql: `SELECT user_id, timestamp, ${valueColumn} AS value FROM purchases`,
+    queryFormat: "sql",
+    userIdTypes: ["user_id"],
+    cappingSettings: {
+      type: cappingType,
+      value: 0.98,
+      ignoreZeros,
+    },
+    windowSettings: {
+      type: "conversion",
+      delayValue: 0,
+      delayUnit: "hours",
+      windowValue: 72,
+      windowUnit: "hours",
+    },
+    priorSettings: {
+      override: false,
+      proper: false,
+      mean: 0,
+      stddev: 1,
+    },
+    queries: [],
+    runStarted: null,
+  };
+}
+
+function buildQuery(
+  dialect: SqlDialect,
+  {
+    ignoreZeros,
+    numeratorIgnoreZeros,
+    denominatorIgnoreZeros,
+    numeratorCappingType = "percentile",
+    denominatorCappingType = "percentile",
+    denominatorAggregation,
+    bandit = false,
+  }: {
+    ignoreZeros?: boolean;
+    numeratorIgnoreZeros?: boolean;
+    denominatorIgnoreZeros?: boolean;
+    numeratorCappingType?: "" | "absolute" | "percentile";
+    denominatorCappingType?: "" | "absolute" | "percentile";
+    denominatorAggregation?: string;
+    bandit?: boolean;
+  },
+): string {
+  const denominator = buildMetric({
+    id: "orders",
+    valueColumn: "orders",
+    ignoreZeros: denominatorIgnoreZeros ?? ignoreZeros,
+    cappingType: denominatorCappingType,
+    aggregation: denominatorAggregation,
+  });
+  const metric = buildMetric({
+    id: "revenue_per_order",
+    valueColumn: "revenue",
+    denominator: denominator.id,
+    ignoreZeros: numeratorIgnoreZeros ?? ignoreZeros,
+    cappingType: numeratorCappingType,
+  });
+
+  const querySettings: ExperimentSnapshotSettings = bandit
+    ? {
+        ...settings,
+        variations: [
+          { id: "control", weight: 0.5 },
+          { id: "treatment", weight: 0.5 },
+        ],
+        banditSettings: {
+          reweight: true,
+          decisionMetric: metric.id,
+          seed: 1,
+          currentWeights: [0.5, 0.5],
+          historicalWeights: [
+            {
+              date: new Date("2026-01-15T00:00:00Z"),
+              weights: [0.5, 0.5],
+              totalUsers: 100,
+            },
+          ],
+        },
+      }
+    : settings;
+
+  const params: ExperimentMetricQueryParams = {
+    settings: querySettings,
+    unitsSettings: {
+      experimentId: querySettings.experimentId,
+      exposureQuery: { query: "", userIdType: "user_id" },
+      startDate: querySettings.startDate,
+      endDate: querySettings.endDate,
+      skipPartialData: querySettings.skipPartialData,
+      attributionModel: querySettings.attributionModel,
+      queryFilter: querySettings.queryFilter,
+      variations: querySettings.variations,
+      metricSettings: querySettings.metricSettings,
+    },
+    metric,
+    denominatorMetrics: [denominator],
+    activationMetric: null,
+    factTableMap: new Map(),
+    dimensions: [],
+    segment: null,
+    unitsSource: "exposureTable",
+    unitsTableFullName: "experiment_units",
+  };
+
+  return getSnapshotMetricQuery(dialect, datasource, params);
+}
+
+function getCteBody(sql: string, cte: string): string {
+  const start = new RegExp(`${cte}\\s+AS\\s*\\(`, "i").exec(sql);
+  if (!start) {
+    throw new Error(`Could not find ${cte}`);
+  }
+
+  const openParen = start.index + start[0].lastIndexOf("(");
+  let depth = 1;
+  let end = openParen + 1;
+  while (depth > 0 && end < sql.length) {
+    if (sql[end] === "(") depth += 1;
+    if (sql[end] === ")") depth -= 1;
+    end += 1;
+  }
+  if (depth !== 0) {
+    throw new Error(`Could not find the end of ${cte}`);
+  }
+
+  return sql
+    .slice(openParen + 1, end - 1)
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+const dialects: { name: string; dialect: SqlDialect }[] = [
+  { name: "Athena", dialect: athenaDialect },
+  { name: "BigQuery", dialect: bigQueryDialect },
+  { name: "ClickHouse", dialect: clickHouseDialect },
+  { name: "Databricks", dialect: databricksDialect },
+  { name: "Microsoft SQL Server", dialect: mssqlDialect },
+  { name: "MySQL", dialect: mysqlDialect },
+  { name: "Postgres", dialect: postgresDialect },
+  { name: "Presto", dialect: prestoDialect },
+  { name: "Redshift", dialect: redshiftDialect },
+  { name: "Snowflake", dialect: snowflakeDialect },
+  { name: "Vertica", dialect: verticaDialect },
+];
+
+describe("legacy ratio percentile-cap populations", () => {
+  it.each(dialects)(
+    "$name includes users without denominator events in the denominator cap population",
+    ({ dialect }) => {
+      const sql = buildQuery(dialect, { ignoreZeros: false });
+      const denominatorCapPopulation = getCteBody(
+        sql,
+        "__userDenominatorCapPopulation",
+      );
+
+      expect(denominatorCapPopulation).toMatch(
+        /SELECT COALESCE\(d\.value,\s*0\) AS value FROM __userMetricAgg m LEFT JOIN __userDenominatorAgg d ON/i,
+      );
+
+      const numeratorCap = getCteBody(sql, "__capValue");
+      const denominatorCap = getCteBody(sql, "__capValueDenominator");
+      expect(numeratorCap).toMatch(
+        /FROM __userMetricAgg WHERE value IS NOT NULL/i,
+      );
+      expect(denominatorCap).toMatch(
+        /FROM __userDenominatorCapPopulation WHERE value IS NOT NULL/i,
+      );
+      expect(numeratorCap).not.toMatch(/value\s*!=\s*0/i);
+      expect(denominatorCap).not.toMatch(/value\s*!=\s*0/i);
+    },
+  );
+
+  it.each(dialects)(
+    "$name excludes zero-valued users only when ignoreZeros is enabled",
+    ({ dialect }) => {
+      const sql = buildQuery(dialect, { ignoreZeros: true });
+      const numeratorCap = getCteBody(sql, "__capValue");
+      const denominatorCap = getCteBody(sql, "__capValueDenominator");
+
+      expect(sql).not.toMatch(/__userDenominatorCapPopulation\s+AS\s*\(/i);
+      expect(denominatorCap).toMatch(
+        /FROM __userDenominatorAgg WHERE value IS NOT NULL/i,
+      );
+      expect(numeratorCap).toMatch(/value\s*!=\s*0/i);
+      expect(denominatorCap).toMatch(/value\s*!=\s*0/i);
+    },
+  );
+
+  it("does not change the denominator aggregation input for custom SQL aggregations", () => {
+    const sql = buildQuery(bigQueryDialect, {
+      ignoreZeros: false,
+      denominatorAggregation: "AVG(COALESCE(value, 1))",
+    });
+    const denominatorAgg = getCteBody(sql, "__userDenominatorAgg");
+    const denominatorCapPopulation = getCteBody(
+      sql,
+      "__userDenominatorCapPopulation",
+    );
+
+    expect(denominatorAgg).toMatch(
+      /AVG\(COALESCE\(value,\s*1\)\) as value FROM __distinctUsers d JOIN __denominator0 m ON/i,
+    );
+    expect(denominatorAgg).toMatch(
+      /WHERE m\.timestamp\s*>=\s*d\.timestamp AND m\.timestamp\s*<=/i,
+    );
+    expect(denominatorCapPopulation).toMatch(
+      /SELECT COALESCE\(d\.value,\s*0\) AS value/i,
+    );
+  });
+
+  it.each(["uncapped", "absolute"] as const)(
+    "does not materialize a denominator cap population for %s ratios",
+    (mode) => {
+      const cappingType = mode === "absolute" ? "absolute" : "";
+      const sql = buildQuery(bigQueryDialect, {
+        ignoreZeros: false,
+        numeratorCappingType: cappingType,
+        denominatorCappingType: cappingType,
+      });
+
+      expect(sql).not.toMatch(/__userDenominatorCapPopulation\s+AS\s*\(/i);
+      expect(sql).not.toMatch(/__capValueDenominator\s+AS\s*\(/i);
+      expect(getCteBody(sql, "__userDenominatorAgg")).toMatch(
+        /FROM __distinctUsers d JOIN __denominator0 m ON/i,
+      );
+    },
+  );
+
+  it("does not materialize a denominator cap population for numerator-only capping", () => {
+    const sql = buildQuery(bigQueryDialect, {
+      ignoreZeros: false,
+      denominatorCappingType: "",
+    });
+
+    expect(sql).toMatch(/__capValue\s+AS\s*\(/i);
+    expect(sql).not.toMatch(/__userDenominatorCapPopulation\s+AS\s*\(/i);
+    expect(sql).not.toMatch(/__capValueDenominator\s+AS\s*\(/i);
+  });
+
+  it("treats an omitted ignoreZeros setting as include zeros", () => {
+    const sql = buildQuery(bigQueryDialect, { ignoreZeros: undefined });
+
+    expect(sql).toMatch(/__userDenominatorCapPopulation\s+AS\s*\(/i);
+    expect(getCteBody(sql, "__capValueDenominator")).not.toMatch(
+      /value\s*!=\s*0/i,
+    );
+  });
+
+  it.each([
+    {
+      name: "numerator only",
+      numeratorIgnoreZeros: true,
+      denominatorIgnoreZeros: false,
+      hasDenominatorCapPopulation: true,
+    },
+    {
+      name: "denominator only",
+      numeratorIgnoreZeros: false,
+      denominatorIgnoreZeros: true,
+      hasDenominatorCapPopulation: false,
+    },
+  ])(
+    "applies ignoreZeros independently when enabled for the $name",
+    ({
+      numeratorIgnoreZeros,
+      denominatorIgnoreZeros,
+      hasDenominatorCapPopulation,
+    }) => {
+      const sql = buildQuery(bigQueryDialect, {
+        numeratorIgnoreZeros,
+        denominatorIgnoreZeros,
+      });
+      const numeratorCap = getCteBody(sql, "__capValue");
+      const denominatorCap = getCteBody(sql, "__capValueDenominator");
+
+      expect(/value\s*!=\s*0/i.test(numeratorCap)).toBe(numeratorIgnoreZeros);
+      expect(denominatorCap).toMatch(
+        denominatorIgnoreZeros
+          ? /FROM __userDenominatorAgg WHERE value IS NOT NULL AND value != 0/i
+          : /FROM __userDenominatorCapPopulation WHERE value IS NOT NULL/i,
+      );
+      expect(/__userDenominatorCapPopulation\s+AS\s*\(/i.test(sql)).toBe(
+        hasDenominatorCapPopulation,
+      );
+    },
+  );
+
+  it("does not join a missing numerator cap into denominator-only capped bandit queries", () => {
+    const sql = buildQuery(bigQueryDialect, {
+      ignoreZeros: false,
+      numeratorCappingType: "",
+      bandit: true,
+    });
+    const banditStatistics = getCteBody(sql, "__banditPeriodStatistics");
+    const denominatorCap = getCteBody(sql, "__capValueDenominator");
+
+    expect(denominatorCap).toMatch(
+      /FROM __userDenominatorCapPopulation WHERE value IS NOT NULL/i,
+    );
+    expect(banditStatistics).toMatch(/CROSS JOIN __capValueDenominator capd/i);
+    expect(sql).not.toMatch(/__capValue\s+AS\s*\(/i);
+    expect(banditStatistics).not.toMatch(/CROSS JOIN __capValue cap\b/i);
+  });
+});


### PR DESCRIPTION
## Summary

- Build the legacy ratio denominator's include-zero percentile population from the same cap-population skeleton as the numerator.
- Preserve the existing denominator event aggregation, conversion-window filtering, and custom aggregation semantics.
- Limit the new denominator cap-population CTE to percentile caps that include zeros; other cap-population paths remain unchanged.
- Prevent denominator-only capped bandit queries from cross-joining a numerator cap CTE that was never generated.

Addresses the remaining legacy-query analogue of #6331.

## Scope

#6331 was reported against a v4.0.0 fact-ratio query. On current `main`, fact metrics are routed through the newer fact-metric query pipeline, where numerator and denominator values already share a full-unit skeleton. The same population mismatch is still present in the legacy `MetricInterface` query path, which this PR fixes.

The affected legacy configuration is deliberately narrow: a ratio metric whose denominator uses percentile capping with `ignoreZeros` false or omitted, with at least one unit missing from—or contributing `NULL` to—the previous denominator cap input. Mean metrics, numerator-only caps, absolute caps, uncapped ratios, and denominator caps with `ignoreZeros: true` do not use the new CTE.

## Root cause and fix

The [legacy metric documentation](https://github.com/growthbook/growthbook/blob/7946ef2144967246040320f02df45e3f9e560b8f/docs/docs/metrics/legacy-metrics.mdx#L238-L240) defines the percentile population as the unit-level aggregate for all units; zeros are removed only when `ignoreZeros` is enabled. The legacy numerator cap follows that contract because `__userMetricAgg` contains an aggregate row for every unit in the numerator cap population. The denominator cap instead reads `__userDenominatorAgg`, whose inner event join contains only units with an in-window denominator row.

That inner join is correct for the existing ratio arithmetic: the final join already maps a missing denominator aggregate to zero. It is only the cap distribution that is inconsistent. Changing the event join itself would also change valid custom aggregations such as `AVG(COALESCE(value, 1))` by injecting synthetic rows.

This PR therefore leaves `__userDenominatorAgg` intact and adds a cap-only population when zeros are included:

```sql
__userDenominatorCapPopulation AS (
  SELECT COALESCE(d.value, 0) AS value
  FROM __userMetricAgg m
  LEFT JOIN __userDenominatorAgg d ON d.user_id = m.user_id
)
```

`__capValueDenominator` reads this population only when the denominator includes zeros. When `ignoreZeros` is enabled, it continues reading the original denominator aggregates and filtering zero values.

## Statistical validation

Let `pi` be the fraction of units contributing a non-null value to the previous denominator cap input, `p` the configured percentile, and `G` that value distribution. For ordinary nonnegative denominator metrics, the intended include-zero cap is zero when `p <= 1 - pi`; otherwise it is `G^-1(1 - (1 - p) / pi)`. The previous query always used `G^-1(p)`. At `p = 0.98` and `pi = 0.20`, the previous query selects the P98 among event-bearing units instead of the intended P90.

A P95 fixture chosen to avoid interpolation ambiguity makes the resulting estimand mismatch explicit:

| Units | Numerator `X` | Denominator `Y` |
| ---: | ---: | ---: |
| 80 | 0 | 0 |
| 16 | 20 | 1 |
| 4 | 400 | 20 |

Here `X = 20Y` for every unit. Consistent all-unit caps `(20, 1)` return 20, and consistent nonzero-only caps `(400, 20)` also return 20. The previous mixed caps `(20, 20)` return `400 / 96 = 4.1667`, violating proportionality.

The mismatch can also reverse a decision. With pooled P95 caps over two 100-unit arms:

- Control: 80 zeros and 20 units at `(20, 1)`.
- Treatment: 80 zeros, 16 units at `(22, 1)`, and 4 units at `(44, 2)`.

The consistent caps produce control 20, treatment 22, and a **+10%** lift. Computing only the denominator cap over the 40 units with an in-window denominator row—all nonzero in this fixture—produces control 20, treatment 18.333, and a **-8.33%** lift. The cap mismatch also changes denominator squares and numerator-denominator cross-products, so the impact is not limited to the ratio point estimate.

This does not imply a universal direction of treatment-effect bias; under exchangeable arm distributions, level distortion may cancel in the contrast. It does show that the generated query can target a different winsorized estimand than configured and can reverse effects when arm tail structure differs.

## Adjacent bandit correction

The cap-mode regression matrix exposed an independent generated-SQL error for denominator-only capped bandits. `getBanditStatisticsCTE` treated any cap as evidence that the numerator `__capValue` CTE existed, producing a dangling cross join. The renamed `hasNumeratorCapping` flag now controls that join specifically; the denominator cap remains controlled by `denominatorIsPercentileCapped`.

## Testing

```bash
pnpm test
pnpm type-check
pnpm lint:ci
pnpm --filter back-end test snapshot-metric-query.test.ts --runInBand
pnpm --filter back-end test sqlintegration.test.ts --runInBand
pnpm --filter back-end type-check
pnpm exec eslint \
  packages/back-end/src/integrations/sql/ctes/bandit-statistics-cte.ts \
  packages/back-end/src/integrations/sql/queries/snapshot-metric-query.ts \
  packages/back-end/test/integrations/sql/queries/snapshot-metric-query.test.ts \
  --max-warnings 0
pnpm exec prettier --check \
  packages/back-end/src/integrations/sql/ctes/bandit-statistics-cte.ts \
  packages/back-end/src/integrations/sql/queries/snapshot-metric-query.ts \
  packages/back-end/test/integrations/sql/queries/snapshot-metric-query.test.ts
git diff --check origin/main...HEAD
```

- 32 focused query-generation tests covering all 11 SQL dialect generators, both zero policies, omitted and asymmetric settings, custom aggregation preservation, no/absolute/numerator-only/denominator-only/dual cap modes, and the denominator-only bandit path.
- Full backend SQL integration suite: 2,289 tests and 2,248 snapshots passed with no snapshot changes.
- Full monorepo test, type-check, and lint suites passed. The backend portion completed 191 suites, 5,473 tests, and 2,251 snapshots.
- Targeted ESLint, Prettier, and `git diff --check` passed.


