### PR TITLE
feat(sdk): add optional user arg to trackingCallback

### DIFF
--- a/packages/sdk-js/src/GrowthBook.ts
+++ b/packages/sdk-js/src/GrowthBook.ts
@@ -940,6 +940,7 @@ export class GrowthBook<
           (this._options.trackingCallback as TrackingCallback)(
             call.experiment,
             call.result,
+            call.user,
           ),
         );
       }

--- a/packages/sdk-js/src/core.ts
+++ b/packages/sdk-js/src/core.ts
@@ -15,6 +15,7 @@ import {
   FeatureApiResponse,
   Options,
   ClientOptions,
+  UserContext,
 } from "./types/growthbook";
 import { evalCondition } from "./mongrule";
 import { ConditionInterface } from "./types/mongrule";
@@ -100,7 +101,9 @@ function onExperimentViewed(
   }
   if (ctx.user.trackingCallback) {
     const cb = ctx.user.trackingCallback;
-    calls.push(safeCall(() => cb(experiment, result)));
+    calls.push(
+      safeCall(() => cb(experiment, result, getTrackingUserContext(ctx))),
+    );
   }
   if (ctx.global.eventLogger) {
     const cb = ctx.global.eventLogger;
@@ -307,6 +310,7 @@ export function evalFeature<V = unknown>(
               ctx.global.saveDeferredTrack({
                 experiment: t.experiment,
                 result: t.result,
+                user: getTrackingUserContext(ctx),
               });
             }
           });
@@ -761,6 +765,7 @@ export function runExperiment<T>(
     ctx.global.saveDeferredTrack({
       experiment,
       result,
+      user: getTrackingUserContext(ctx),
     });
   }
   const trackingCall = !trackingCalls.length
@@ -816,6 +821,14 @@ function getAttributes(ctx: EvalContext) {
     ...ctx.user.attributes,
     ...ctx.user.attributeOverrides,
   };
+}
+
+// A lean, serializable UserContext carrying only the user's (merged)
+// attributes. Used for the trackingCallback third argument and for deferred
+// tracking calls so we don't pass the full context (functions, sticky bucket
+// service, etc.) or invent a separate bare-attributes shape.
+function getTrackingUserContext(ctx: EvalContext): UserContext {
+  return { attributes: getAttributes(ctx) };
 }
 
 function conditionPasses(

--- a/packages/sdk-js/src/core.ts
+++ b/packages/sdk-js/src/core.ts
@@ -823,10 +823,6 @@ function getAttributes(ctx: EvalContext) {
   };
 }
 
-// A lean, serializable UserContext carrying only the user's (merged)
-// attributes. Used for the trackingCallback third argument and for deferred
-// tracking calls so we don't pass the full context (functions, sticky bucket
-// service, etc.) or invent a separate bare-attributes shape.
 function getTrackingUserContext(ctx: EvalContext): UserContext {
   return { attributes: getAttributes(ctx) };
 }

--- a/packages/sdk-js/src/core.ts
+++ b/packages/sdk-js/src/core.ts
@@ -310,7 +310,7 @@ export function evalFeature<V = unknown>(
               ctx.global.saveDeferredTrack({
                 experiment: t.experiment,
                 result: t.result,
-                user: getTrackingUserContext(ctx),
+                user: getTrackingUserContext(ctx, true),
               });
             }
           });
@@ -765,7 +765,7 @@ export function runExperiment<T>(
     ctx.global.saveDeferredTrack({
       experiment,
       result,
-      user: getTrackingUserContext(ctx),
+      user: getTrackingUserContext(ctx, true),
     });
   }
   const trackingCall = !trackingCalls.length
@@ -823,8 +823,11 @@ function getAttributes(ctx: EvalContext) {
   };
 }
 
-function getTrackingUserContext(ctx: EvalContext): UserContext {
-  return { attributes: getAttributes(ctx) };
+function getTrackingUserContext(ctx: EvalContext, deep = false): UserContext {
+  const attributes = getAttributes(ctx);
+  return {
+    attributes: deep ? JSON.parse(JSON.stringify(attributes)) : attributes,
+  };
 }
 
 function conditionPasses(

--- a/packages/sdk-js/src/core.ts
+++ b/packages/sdk-js/src/core.ts
@@ -15,7 +15,7 @@ import {
   FeatureApiResponse,
   Options,
   ClientOptions,
-  UserContext,
+  UserContextAttributes,
 } from "./types/growthbook";
 import { evalCondition } from "./mongrule";
 import { ConditionInterface } from "./types/mongrule";
@@ -310,7 +310,7 @@ export function evalFeature<V = unknown>(
               ctx.global.saveDeferredTrack({
                 experiment: t.experiment,
                 result: t.result,
-                user: getTrackingUserContext(ctx, true),
+                user: getTrackingUserContext(ctx),
               });
             }
           });
@@ -765,7 +765,7 @@ export function runExperiment<T>(
     ctx.global.saveDeferredTrack({
       experiment,
       result,
-      user: getTrackingUserContext(ctx, true),
+      user: getTrackingUserContext(ctx),
     });
   }
   const trackingCall = !trackingCalls.length
@@ -823,10 +823,9 @@ function getAttributes(ctx: EvalContext) {
   };
 }
 
-function getTrackingUserContext(ctx: EvalContext, deep = false): UserContext {
-  const attributes = getAttributes(ctx);
+function getTrackingUserContext(ctx: EvalContext): UserContextAttributes {
   return {
-    attributes: deep ? JSON.parse(JSON.stringify(attributes)) : attributes,
+    attributes: { ...getAttributes(ctx) },
   };
 }
 

--- a/packages/sdk-js/src/types/growthbook.ts
+++ b/packages/sdk-js/src/types/growthbook.ts
@@ -173,8 +173,6 @@ export interface TrackingDataWithUser {
 export type TrackingCallback = (
   experiment: Experiment<any>,
   result: Result<any>,
-  // A lean UserContext carrying only the user's attributes. Reuses the
-  // UserContext shape instead of passing a bare attributes object.
   user?: UserContext,
 ) => Promise<void> | void;
 

--- a/packages/sdk-js/src/types/growthbook.ts
+++ b/packages/sdk-js/src/types/growthbook.ts
@@ -159,6 +159,9 @@ export type Attributes = Record<string, any>;
 export interface TrackingData {
   experiment: Experiment<any>;
   result: Result<any>;
+  // A lean UserContext carrying only the user's attributes, so deferred
+  // tracking calls stay serializable and match the trackingCallback shape.
+  user?: UserContext;
 }
 
 export interface TrackingDataWithUser {
@@ -170,6 +173,9 @@ export interface TrackingDataWithUser {
 export type TrackingCallback = (
   experiment: Experiment<any>,
   result: Result<any>,
+  // A lean UserContext carrying only the user's attributes. Reuses the
+  // UserContext shape instead of passing a bare attributes object.
+  user?: UserContext,
 ) => Promise<void> | void;
 
 export type TrackingCallbackWithUser = (

--- a/packages/sdk-js/src/types/growthbook.ts
+++ b/packages/sdk-js/src/types/growthbook.ts
@@ -156,12 +156,12 @@ export interface Result<T> {
 
 export type Attributes = Record<string, any>;
 
+export type UserContextAttributes = Pick<UserContext, "attributes">;
+
 export interface TrackingData {
   experiment: Experiment<any>;
   result: Result<any>;
-  // A lean UserContext carrying only the user's attributes, so deferred
-  // tracking calls stay serializable and match the trackingCallback shape.
-  user?: UserContext;
+  user?: UserContextAttributes;
 }
 
 export interface TrackingDataWithUser {

--- a/packages/sdk-js/test/experiments.test.ts
+++ b/packages/sdk-js/test/experiments.test.ts
@@ -26,9 +26,9 @@ const mockCallback = (options: Options) => {
 
 const mockAsyncCallback = (options: Options) => {
   const onExperimentViewed = jest.fn();
-  options.trackingCallback = async (experiment, result) => {
+  options.trackingCallback = async (experiment, result, user) => {
     await sleep(500);
-    onExperimentViewed(experiment, result);
+    onExperimentViewed(experiment, result, user);
   };
   return onExperimentViewed.mock;
 };
@@ -60,9 +60,9 @@ describe("experiments", () => {
     const res5 = growthbook.run(exp2);
 
     expect(mock.calls.length).toEqual(3);
-    expect(mock.calls[0]).toEqual([exp1, res1]);
-    expect(mock.calls[1]).toEqual([exp2, res4]);
-    expect(mock.calls[2]).toEqual([exp2, res5]);
+    expect(mock.calls[0]).toEqual([exp1, res1, { attributes: { id: "1" } }]);
+    expect(mock.calls[1]).toEqual([exp2, res4, { attributes: { id: "1" } }]);
+    expect(mock.calls[2]).toEqual([exp2, res5, { attributes: { id: "2" } }]);
 
     growthbook.destroy();
   });
@@ -92,9 +92,9 @@ describe("experiments", () => {
 
     await sleep(1000);
     expect(mock.calls.length).toEqual(3);
-    expect(mock.calls[0]).toEqual([exp1, res1]);
-    expect(mock.calls[1]).toEqual([exp2, res4]);
-    expect(mock.calls[2]).toEqual([exp2, res5]);
+    expect(mock.calls[0]).toEqual([exp1, res1, { attributes: { id: "1" } }]);
+    expect(mock.calls[1]).toEqual([exp2, res4, { attributes: { id: "1" } }]);
+    expect(mock.calls[2]).toEqual([exp2, res5, { attributes: { id: "2" } }]);
 
     growthbook.destroy();
   });
@@ -812,12 +812,15 @@ describe("experiments", () => {
       {
         experiment: exp,
         result,
+        user: { attributes: { id: "1" } },
       },
     ]);
     expect(gb.getCompletedChangeIds()).toEqual(["123"]);
     gb.setTrackingCallback(trackingCallback);
     expect(trackingCallback).toHaveBeenCalledTimes(1);
-    expect(trackingCallback).toHaveBeenCalledWith(exp, result);
+    expect(trackingCallback).toHaveBeenCalledWith(exp, result, {
+      attributes: { id: "1" },
+    });
 
     // Does not call trackingCallback again for the same experiment
     gb.run(exp);
@@ -840,7 +843,9 @@ describe("experiments", () => {
     expect(trackingCallback2).toHaveBeenCalledTimes(0);
     gb2.fireDeferredTrackingCalls();
     expect(trackingCallback2).toHaveBeenCalledTimes(1);
-    expect(trackingCallback2).toHaveBeenCalledWith(exp, result);
+    // These deferred calls were set manually without a user field, so
+    // the callback receives `undefined` for the optional user arg.
+    expect(trackingCallback2).toHaveBeenCalledWith(exp, result, undefined);
     expect(gb2.getDeferredTrackingCalls()).toEqual([]);
 
     gb2.destroy();
@@ -874,7 +879,7 @@ describe("experiments", () => {
 
     gb2.setTrackingCallback(trackingCallback);
     expect(trackingCallback).toHaveBeenCalledTimes(1);
-    expect(trackingCallback).toHaveBeenCalledWith(exp, result);
+    expect(trackingCallback).toHaveBeenCalledWith(exp, result, undefined);
     expect(gb2.getDeferredTrackingCalls()).toEqual([]);
 
     gb2.destroy();

--- a/packages/sdk-js/test/features.test.ts
+++ b/packages/sdk-js/test/features.test.ts
@@ -436,7 +436,11 @@ describe("features", () => {
     expect(res.source).toEqual("force");
 
     expect(onExperimentViewed.mock.calls.length).toEqual(1);
-    expect(onExperimentViewed.mock.calls[0]).toEqual([exp, result]);
+    expect(onExperimentViewed.mock.calls[0]).toEqual([
+      exp,
+      result,
+      { attributes: {} },
+    ]);
 
     growthbook.destroy();
   });


### PR DESCRIPTION
Extend the trackingCallback signature with an optional third argument: a lean UserContext carrying only the user's merged attributes. This lets consumers access the resolved attributes at track time without changing existing (2-arg) callbacks, which keep working unchanged.

- types: TrackingCallback gains `user?: UserContext`; TrackingData gains an optional `user` field so deferred calls carry the same context.
- core: new getTrackingUserContext(ctx) helper builds the lean context from merged attributes; passed to the user trackingCallback and stored on deferred tracks (onExperimentViewed + runExperiment).
- GrowthBook.fireDeferredTrackingCalls forwards the stored user arg.
- tests: experiments/features updated for the 3rd arg (undefined when a deferred call was set manually without a user field).

Split out of #6274 (contextual bandit SDK payload) so the callback shape change can be reviewed and land independently.

