### PR TITLE
Stop pushing :latest to ECR (immutable repo prep)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,10 +79,11 @@ jobs:
             DD_GIT_COMMIT_SHA=${{ github.sha }}
             DD_GIT_REPOSITORY_URL=https://github.com/growthbook/growthbook.git
             DD_VERSION=${{ github.sha }}
+          # No ECR :latest — the ECR repo is immutable, so we push only the
+          # unique git-<sha> tag. Docker Hub :latest stays for self-host.
           tags: |
             growthbook/growthbook:latest
             growthbook/growthbook:git-${{ steps.metadata.outputs.docker_sha }}
-            ${{ steps.login-ecr.outputs.registry }}/growthbook:latest
             ${{ steps.login-ecr.outputs.registry }}/growthbook:git-${{ steps.metadata.outputs.docker_sha }}
           platforms: linux/amd64,linux/arm64
 
@@ -115,10 +116,10 @@ jobs:
 
       - name: Extract static assets from Docker image and upload to S3
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr-prod.outputs.registry }}
+          IMAGE: ${{ steps.login-ecr-prod.outputs.registry }}/growthbook:git-${{ needs.docker.outputs.docker_sha }}
         run: |
-          docker pull ${ECR_REGISTRY}/growthbook:latest
-          docker create --name temp-container ${ECR_REGISTRY}/growthbook:latest
+          docker pull ${IMAGE}
+          docker create --name temp-container ${IMAGE}
           docker cp temp-container:/usr/local/src/app/packages/front-end/.next/static ./static
           # Back-end-dist and front-end-dist is for the sentry source maps task below.
           docker cp temp-container:/usr/local/src/app/packages/back-end/dist ./back-end-dist

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -34,25 +34,9 @@ jobs:
       - name: Install buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Configure AWS credentials for GrowthBook Cloud
-        uses: aws-actions/configure-aws-credentials@v5
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
       - name: Tag image as latest in DockerHub
         run: |
           docker buildx imagetools create -t growthbook/growthbook:latest growthbook/growthbook:git-${{ steps.sha.outputs.short }}
-
-      - name: Tag image as latest in ECR
-        run: |
-          ECR_REGISTRY=${{ steps.login-ecr.outputs.registry }}
-          docker buildx imagetools create -t $ECR_REGISTRY/growthbook:latest $ECR_REGISTRY/growthbook:git-${{ steps.sha.outputs.short }}
 
   # Deploy the back-end for GrowthBook Cloud
   prod:


### PR DESCRIPTION
### Features and Changes

Prep for making the ECR `growthbook` repo immutable (fixes the Vanta *"Fargate deploys version-controlled images"* test). An immutable repo forbids overwriting a tag, so re-pushing `:latest` every build would start failing — this stops pushing `:latest` to ECR and relies on the unique `git-<sha>` tag we already push.

- `deploy.yml` — drop the `…/growthbook:latest` ECR tag from the build/push; the "extract static assets" step now pulls the `git-<sha>` image instead of `:latest`. Docker Hub `growthbook/growthbook:latest` is unchanged (self-host consumers).
- `rollback.yml` — drop the ECR `:latest` re-tag and its now-unused ECR login / AWS-creds steps. Rollback already redeploys the target `git-<sha>` directly; the Docker Hub `:latest` re-tag stays.

### Dependencies

Merge **before** growthbook/terraform#186 (which flips the repo to `IMMUTABLE`). If the repo goes immutable while this still pushes `:latest`, the next deploy's push fails.

### Testing

- [ ] Deploy from `main`: build pushes `ecr/growthbook:git-<sha>` (no `:latest`); asset-extraction pulls the `git-<sha>` image and syncs `_next/static` to S3.
- [ ] Docker Hub still gets `growthbook/growthbook:latest`.
- [ ] Rollback workflow: services move to the target `git-<sha>`, Docker Hub `:latest` re-tagged.
