### PR TITLE
Move the publish-revisions endpoint to /api/v1

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -24029,7 +24029,7 @@ paths:
             'https://api.growthbook.io/api/v1/configs-revisions/{key}/{version}/revert'
             \
               -H 'Authorization: Bearer YOUR_API_KEY'
-  /v2/releases/publish-revisions:
+  /v1/releases/publish-revisions:
     post:
       operationId: postReleasePublishRevisions
       summary: Atomically publish revisions across multiple entities
@@ -24181,7 +24181,7 @@ paths:
         - lang: cURL
           source: >-
             curl -X POST
-            'https://api.growthbook.io/api/v2/releases/publish-revisions' \
+            'https://api.growthbook.io/api/v1/releases/publish-revisions' \
               -H 'Authorization: Bearer YOUR_API_KEY'
   /v1/custom-hooks:
     get:

--- a/packages/back-end/test/api/release-publish-revisions-failure.test.ts
+++ b/packages/back-end/test/api/release-publish-revisions-failure.test.ts
@@ -5,7 +5,7 @@ import type { OrganizationInterface } from "shared/types/organization";
 import { ReqContextClass } from "back-end/src/services/context";
 import { setupApp } from "./api.setup";
 
-// Commit-phase failure coverage for POST /api/v2/releases/publish-revisions:
+// Commit-phase failure coverage for POST /api/v1/releases/publish-revisions:
 // inject a fault into the FEATURE apply (after the constant already applied)
 // and assert the full compensation contract — pre-images restored, revisions
 // reopened, zero success-side signals, revision.publishFailed emitted per
@@ -142,7 +142,7 @@ function makeContext(): ReqContextClass {
 
 const { app, setReqContext } = setupApp();
 
-describe("POST /api/v2/releases/publish-revisions — commit failure", () => {
+describe("POST /api/v1/releases/publish-revisions — commit failure", () => {
   afterEach(() => {
     mockFailFeatureApply = false;
     mockFailConstantRestore = false;
@@ -219,7 +219,7 @@ describe("POST /api/v2/releases/publish-revisions — commit failure", () => {
     // Constant first: it fully applies before the feature apply throws, so
     // compensation must restore an already-committed entity write.
     const res = await request(app)
-      .post("/api/v2/releases/publish-revisions")
+      .post("/api/v1/releases/publish-revisions")
       .send({
         revisions: [
           { entityType: "constant", key: "fail-const", version: constVersion },
@@ -353,7 +353,7 @@ describe("POST /api/v2/releases/publish-revisions — commit failure", () => {
     mockFailFeatureApply = true;
     mockFailConstantRestore = true;
     const res = await request(app)
-      .post("/api/v2/releases/publish-revisions")
+      .post("/api/v1/releases/publish-revisions")
       .send({
         revisions: [
           { entityType: "constant", key: "stuck-const", version: constVersion },
@@ -480,7 +480,7 @@ describe("POST /api/v2/releases/publish-revisions — commit failure", () => {
     mockFailFeatureApply = true;
     mockFailConstantReleaseClaim = true;
     const res = await request(app)
-      .post("/api/v2/releases/publish-revisions")
+      .post("/api/v1/releases/publish-revisions")
       .send({
         revisions: [
           { entityType: "constant", key: "reopen-fail", version: constVersion },
@@ -586,7 +586,7 @@ describe("POST /api/v2/releases/publish-revisions — commit failure", () => {
     mockFeatureClaimConflict = true;
     mockFailConstantReleaseClaim = true;
     const res = await request(app)
-      .post("/api/v2/releases/publish-revisions")
+      .post("/api/v1/releases/publish-revisions")
       .send({
         revisions: [
           { entityType: "constant", key: "abort-stuck", version: constVersion },
@@ -693,7 +693,7 @@ describe("POST /api/v2/releases/publish-revisions — commit failure", () => {
     mockFailFeatureApply = true;
     mockFeatureReleaseNoop = true;
     const res = await request(app)
-      .post("/api/v2/releases/publish-revisions")
+      .post("/api/v1/releases/publish-revisions")
       .send({
         revisions: [
           { entityType: "constant", key: "noop-reopen", version: constVersion },
@@ -809,7 +809,7 @@ describe("POST /api/v2/releases/publish-revisions — commit failure", () => {
     };
 
     const res = await request(app)
-      .post("/api/v2/releases/publish-revisions")
+      .post("/api/v1/releases/publish-revisions")
       .send({
         revisions: [
           { entityType: "constant", key: "restamp", version: constVersion },
@@ -918,7 +918,7 @@ describe("POST /api/v2/releases/publish-revisions — commit failure", () => {
     mockConstantBaselineUnavailable = true;
     mockFailFeatureApply = true;
     const res = await request(app)
-      .post("/api/v2/releases/publish-revisions")
+      .post("/api/v1/releases/publish-revisions")
       .send({
         revisions: [
           { entityType: "constant", key: "nobaseline", version: constVersion },
@@ -1055,7 +1055,7 @@ describe("POST /api/v2/releases/publish-revisions — commit failure", () => {
     mockFailConstantApply = true;
 
     const res = await request(app)
-      .post("/api/v2/releases/publish-revisions")
+      .post("/api/v1/releases/publish-revisions")
       .send({
         revisions: [
           { entityType: "feature", id: "sat-feat", version: 2 },

--- a/packages/back-end/test/api/release-publish-revisions-scenario.test.ts
+++ b/packages/back-end/test/api/release-publish-revisions-scenario.test.ts
@@ -5,7 +5,7 @@ import type { OrganizationInterface } from "shared/types/organization";
 import { ReqContextClass } from "back-end/src/services/context";
 import { setupApp } from "./api.setup";
 
-// Scenario QA for POST /api/v2/releases/publish-revisions: a realistic
+// Scenario QA for POST /api/v1/releases/publish-revisions: a realistic
 // multi-entity world built through the REST creation endpoints, then a saga
 // walking a matrix of failure modes — approvals, schema breaks, permission-
 // gated overrides, merge conflicts + rebase, scheduled siblings, closed
@@ -66,7 +66,7 @@ const api = {
 };
 
 const publish = (body: Record<string, unknown>) =>
-  api.post("/api/v2/releases/publish-revisions", body);
+  api.post("/api/v1/releases/publish-revisions", body);
 
 const gateTypes = (body: { gates?: { type: string }[] }) =>
   (body.gates ?? []).map((g) => g.type).sort();

--- a/packages/back-end/test/api/release-publish-revisions.test.ts
+++ b/packages/back-end/test/api/release-publish-revisions.test.ts
@@ -7,7 +7,7 @@ import { ReqContextClass } from "back-end/src/services/context";
 import { getAllFeaturesWithoutEditorFields } from "back-end/src/models/FeatureModel";
 import { setupApp } from "./api.setup";
 
-// Coverage for POST /api/v2/releases/publish-revisions — the atomic multi-entity
+// Coverage for POST /api/v1/releases/publish-revisions — the atomic multi-entity
 // publish shortcut:
 //  1. `dryRun: true` reports would-publish results and gates with ZERO writes.
 //  2. A real publish lands a constant + config draft pair atomically: both
@@ -100,14 +100,14 @@ async function stageConfigDraft(
 
 async function publishRevisions(body: Record<string, unknown>) {
   return request(app)
-    .post("/api/v2/releases/publish-revisions")
+    .post("/api/v1/releases/publish-revisions")
     .send(body)
     .set("Authorization", "Bearer foo");
 }
 
 const { app, setReqContext } = setupApp();
 
-describe("POST /api/v2/releases/publish-revisions", () => {
+describe("POST /api/v1/releases/publish-revisions", () => {
   it("dry run reports would-publish outcomes without writing", async () => {
     setReqContext(makeContext());
     await insertRawConstant("qp-dry-const");

--- a/packages/shared/src/validators/releases.ts
+++ b/packages/shared/src/validators/releases.ts
@@ -184,5 +184,5 @@ export const postReleasePublishRevisionsValidator = {
       ),
     warnings: z.array(z.string()),
   }),
-  version: "v2" as const,
+  version: "v1" as const,
 };


### PR DESCRIPTION
Moves `POST /releases/publish-revisions` from `/api/v2/` to `/api/v1/`, where the rest of the REST API lives. Route swap only — no behavior changes. Spec regenerated.