### PR TITLE
Fix stats-engine readiness race causing prod-api-python OOM at startup

### DIFF
--- a/packages/back-end/scripts/stats_server.py
+++ b/packages/back-end/scripts/stats_server.py
@@ -5,6 +5,12 @@ import sys
 import traceback
 from gbstats.gbstats import process_multiple_experiment_results
 
+# Signal readiness now that the slow numpy/pandas/scipy import chain above is
+# done, so the Node side doesn't treat this process as usable the instant
+# it's spawned (well before it can actually read stdin).
+sys.stdout.write(json.dumps({"ready": True}) + "\n")
+sys.stdout.flush()
+
 for line in sys.stdin:
     start = time.time()
 

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -32,6 +32,7 @@ import {
   getExperimentConfig,
   getExperimentsScript,
 } from "./controllers/config";
+import { statsServerPool } from "./services/python";
 import { getAuthConnection, processJWT, usingOpenId } from "./services/auth";
 import { wrapController } from "./routers/wrapController";
 import apiRouter from "./api/api.router";
@@ -235,7 +236,20 @@ app.use(cookieParser());
 
 // Health check route  (does not require JWT or cors)
 app.get("/healthcheck", (req, res) => {
-  // TODO: more robust health check?
+  // Any instance that serves stats requests from its own local pool (i.e.
+  // isn't proxying to EXTERNAL_PYTHON_SERVER_URL — same condition python.ts
+  // uses to decide whether the local pool is in play) shouldn't accept
+  // traffic until the pool has finished spawning its minimum Python processes
+  // (numpy/pandas/scipy imports are slow) — otherwise a burst of requests can
+  // force several more to cold-start concurrently right as the container is
+  // already booting.
+  if (
+    !process.env.EXTERNAL_PYTHON_SERVER_URL &&
+    statsServerPool.available < statsServerPool.min
+  ) {
+    return res.status(503).json({ status: 503, healthy: false });
+  }
+
   res.status(200).json({
     status: 200,
     healthy: true,

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -245,7 +245,8 @@ app.get("/healthcheck", (req, res) => {
   // already booting.
   if (
     !process.env.EXTERNAL_PYTHON_SERVER_URL &&
-    statsServerPool.available < statsServerPool.min
+    // available + borrowed = ready workers, whether idle or busy.
+    statsServerPool.available + statsServerPool.borrowed < statsServerPool.min
   ) {
     return res.status(503).json({ status: 503, healthy: false });
   }

--- a/packages/back-end/src/server.ts
+++ b/packages/back-end/src/server.ts
@@ -9,6 +9,7 @@ import {
   initializeGrowthBookClient,
   destroyGrowthBookClient,
 } from "./services/growthbook";
+import { statsServerPool } from "./services/python";
 
 // Initialize GrowthBook singleton before starting server
 initializeGrowthBookClient().catch((error) => {
@@ -54,6 +55,9 @@ function onClose() {
 
     // Cleanup GrowthBook client
     destroyGrowthBookClient();
+
+    await statsServerPool.drain();
+    await statsServerPool.clear();
 
     // Gracefully close Agenda
     const agenda = getAgendaInstance();

--- a/packages/back-end/src/server.ts
+++ b/packages/back-end/src/server.ts
@@ -56,7 +56,15 @@ function onClose() {
     // Cleanup GrowthBook client
     destroyGrowthBookClient();
 
-    await statsServerPool.drain();
+    // Bounded: a stats call from a background job (not covered by
+    // server.close()'s in-flight-request wait above) can hold a resource for
+    // up to GB_STATS_ENGINE_TIMEOUT_MS - far longer than the platform's
+    // SIGTERM->SIGKILL grace period. Give it a short grace period, then clear
+    // whatever's left rather than block Agenda/exit indefinitely.
+    await Promise.race([
+      statsServerPool.drain(),
+      new Promise((resolve) => setTimeout(resolve, 5_000)),
+    ]);
     await statsServerPool.clear();
 
     // Gracefully close Agenda

--- a/packages/back-end/src/services/python.ts
+++ b/packages/back-end/src/services/python.ts
@@ -45,6 +45,14 @@ const STATS_ENGINE_TIMEOUT_MS = parseEnvInt(
   { min: 1, name: "GB_STATS_ENGINE_TIMEOUT_MS" },
 );
 
+// Cold start (numpy/pandas/scipy import) usually finishes in a couple seconds;
+// this is a generous ceiling for a slow/contended boot before giving up.
+const STATS_ENGINE_STARTUP_TIMEOUT_MS = parseEnvInt(
+  process.env.GB_STATS_ENGINE_STARTUP_TIMEOUT_MS,
+  60_000,
+  { min: 1, name: "GB_STATS_ENGINE_STARTUP_TIMEOUT_MS" },
+);
+
 // stats_server.py writes via json.dumps(allow_nan=True), so output is strict
 // JSON unless it contains NaN/Infinity literals — fall back to JSON5 for those.
 function parsePythonOutput<T>(line: string): T {
@@ -53,6 +61,14 @@ function parsePythonOutput<T>(line: string): T {
   } catch {
     return JSON5.parse(line);
   }
+}
+
+function isReadySignal(parsed: unknown): parsed is { ready: true } {
+  return (
+    typeof parsed === "object" &&
+    parsed !== null &&
+    (parsed as { ready?: unknown }).ready === true
+  );
 }
 
 let cloudWatchClient: CloudWatchClient | null = null;
@@ -66,6 +82,11 @@ class PythonStatsServer<Input, Output> {
   private python: ChildProcess;
   private rl?: readline.Interface;
   private pid = -1;
+  private ready = false;
+  private resolveReady!: () => void;
+  private rejectReady!: (reason: Error) => void;
+  private readyPromise: Promise<void>;
+  private startupTimer: NodeJS.Timeout;
   private promises: Map<
     string,
     {
@@ -87,6 +108,18 @@ class PythonStatsServer<Input, Output> {
     logger.debug(`Python stats server (pid: ${this.pid}) started`);
     this.promises = new Map();
 
+    this.readyPromise = new Promise<void>((resolve, reject) => {
+      this.resolveReady = resolve;
+      this.rejectReady = reject;
+    });
+    this.startupTimer = setTimeout(() => {
+      this.rejectReady(
+        new Error(
+          `Python stats server (pid: ${this.pid}) did not become ready within ${STATS_ENGINE_STARTUP_TIMEOUT_MS}ms`,
+        ),
+      );
+    }, STATS_ENGINE_STARTUP_TIMEOUT_MS);
+
     if (this.python.stdout) {
       this.rl = readline
         .createInterface({ input: this.python.stdout, crlfDelay: Infinity })
@@ -96,8 +129,13 @@ class PythonStatsServer<Input, Output> {
           try {
             const parsed:
               | PythonServerResponse<Output>
-              | { id: string; error: string; stack_trace?: string } =
-              parsePythonOutput(output);
+              | { id: string; error: string; stack_trace?: string }
+              | { ready: true } = parsePythonOutput(output);
+
+            if (isReadySignal(parsed)) {
+              this.markReady();
+              return;
+            }
 
             if (!parsed.id) {
               logger.error(
@@ -158,11 +196,31 @@ class PythonStatsServer<Input, Output> {
       logger.debug(
         `Python stats server (pid: ${this.pid}) exited with code ${code} ${signal}. Destroying server.`,
       );
+      this.rejectReady(
+        new Error(
+          `Python stats server (pid: ${this.pid}) exited before becoming ready (code ${code}, signal ${signal})`,
+        ),
+      );
       this.destroy();
     });
   }
 
+  private markReady() {
+    if (this.ready) return;
+    this.ready = true;
+    clearTimeout(this.startupTimer);
+    this.resolveReady();
+    logger.debug(`Python stats server (pid: ${this.pid}) ready`);
+  }
+
+  // Resolves once the process has finished its (slow) numpy/pandas/scipy
+  // import and is actually reading stdin, rather than the instant it's spawned.
+  waitUntilReady(): Promise<void> {
+    return this.readyPromise;
+  }
+
   destroy() {
+    clearTimeout(this.startupTimer);
     this.rl?.removeAllListeners("line");
     this.rl?.close();
     if (this.isRunning()) {
@@ -177,6 +235,10 @@ class PythonStatsServer<Input, Output> {
 
   isRunning() {
     return this.python.exitCode === null;
+  }
+
+  isReady() {
+    return this.ready && this.isRunning();
   }
 
   async call(data: Input) {
@@ -246,13 +308,15 @@ class PythonStatsServer<Input, Output> {
 export const statsServerPool = createPool(
   {
     create: async () => {
-      return new PythonStatsServer<
+      const server = new PythonStatsServer<
         ExperimentDataForStatsEngine[],
         MultipleExperimentMetricAnalysis[]
       >(path.join(__dirname, "..", "..", "scripts", "stats_server.py"));
+      await server.waitUntilReady();
+      return server;
     },
     destroy: async (server) => server.destroy(),
-    validate: async (server) => server.isRunning(),
+    validate: async (server) => server.isReady(),
   },
   {
     min: MIN_POOL_SIZE,

--- a/packages/back-end/src/services/python.ts
+++ b/packages/back-end/src/services/python.ts
@@ -118,6 +118,8 @@ class PythonStatsServer<Input, Output> {
           `Python stats server (pid: ${this.pid}) did not become ready within ${STATS_ENGINE_STARTUP_TIMEOUT_MS}ms`,
         ),
       );
+      // Never joined the pool, so nothing else will kill it - do it here.
+      this.destroy();
     }, STATS_ENGINE_STARTUP_TIMEOUT_MS);
 
     if (this.python.stdout) {


### PR DESCRIPTION
### Features and Changes

`prod-api-python` tasks were intermittently getting OOM-killed shortly after boot (CloudWatch showed individual tasks spiking to ~99.8% of the 4096 MB task memory limit in that window, while the service-wide average stayed ~40%). The cause was a readiness race: `/healthcheck` (`app.ts`) returned 200 unconditionally the instant Express started listening, well before the Python stats-engine pool (`packages/back-end/src/services/python.ts`) was actually warm — only `GB_STATS_ENGINE_MIN_POOL_SIZE` (default 1) process is eagerly spawned at boot. The ALB marks a target healthy after 3 checks at a 10s interval (~20-30s post-boot) and immediately starts routing real traffic. If several concurrent stats-engine requests land right at that moment, the pool has to cold-start multiple additional Python interpreters simultaneously to keep up — each a genuinely heavy boot (numpy/pandas/scipy import measured at ~1.7-2s, vs. ~1ms for the process spawn itself) — stacking directly on top of Next.js/Node's own still-elevated boot-time memory. That combined spike is what tipped tasks over the memory limit.

Fix:
- `stats_server.py` now emits a `{"ready": true}` signal once its import completes, and `python.ts`'s pool `create()` factory waits for that signal before considering a resource created — so `statsServerPool.available`/`size` reflect actual readiness instead of the instant a process is spawned.
- `/healthcheck` uses that to hold off returning 200 until the local pool has reached its minimum warm size, for any instance that serves stats requests from its own pool (`!EXTERNAL_PYTHON_SERVER_URL`, matching the condition `python.ts` already uses elsewhere to decide if the local pool is in play) — so the ALB doesn't route traffic until the pool can actually absorb a burst.

Also included: `server.ts` now drains and clears `statsServerPool` on graceful shutdown (SIGTERM/SIGINT). Nothing previously killed pooled Python children explicitly on shutdown — Node already holds their `ChildProcess` handles, so this is a straightforward gap-fill, unrelated to the OOM issue above.

### Testing

- [x] `pnpm --filter back-end type-check` passes
- [x] Spawned `stats_server.py` directly and confirmed the ready signal fires only after the import completes (~1.7-2s), with the real response coming back near-instantly once ready
- [ ] Deploy to prod and confirm ALB health checks don't flap during boot and memory stays flatter under a traffic burst right after deploy
