### PR TITLE
Fix sticky Metric Drilldown hover tooltip

### DIFF
--- a/packages/front-end/hooks/useHoverTooltip.tsx
+++ b/packages/front-end/hooks/useHoverTooltip.tsx
@@ -198,7 +198,6 @@ function TooltipPortal({
           ref={refs.setFloating}
           className={styles.tooltip}
           style={cursorTooltipStyle}
-          onClick={handleClick}
         >
           {content}
         </div>

--- a/packages/front-end/hooks/useHoverTooltip.tsx
+++ b/packages/front-end/hooks/useHoverTooltip.tsx
@@ -135,6 +135,7 @@ function TooltipPortal({
 
   const { refs, floatingStyles, update, placement } = useFloating({
     placement: "top",
+    strategy: positioning === "cursor" ? "fixed" : "absolute",
     middleware: [
       offset(VERTICAL_OFFSET_PX),
       flip({ fallbackPlacements: ["bottom", "top"] }),
@@ -180,7 +181,12 @@ function TooltipPortal({
     zIndex: 9999,
   };
 
-  // Prevent clicks from passing through to elements below the tooltip
+  const cursorTooltipStyle: React.CSSProperties = {
+    ...tooltipStyle,
+    pointerEvents: "none",
+  };
+
+  // Element-mode tooltips are interactive, so clicks should not pass through.
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
   };
@@ -191,7 +197,7 @@ function TooltipPortal({
         <div
           ref={refs.setFloating}
           className={styles.tooltip}
-          style={tooltipStyle}
+          style={cursorTooltipStyle}
           onClick={handleClick}
         >
           {content}
@@ -289,6 +295,22 @@ export function useHoverTooltip({
       window.removeEventListener("scroll", handleScroll, { capture: true });
     };
   }, [isVisible, close]);
+
+  useEffect(() => {
+    if (!isVisible || positioning !== "cursor") return;
+
+    const handleMove = () => {
+      close();
+    };
+
+    window.addEventListener("mousemove", handleMove);
+    window.addEventListener("pointermove", handleMove);
+
+    return () => {
+      window.removeEventListener("mousemove", handleMove);
+      window.removeEventListener("pointermove", handleMove);
+    };
+  }, [isVisible, positioning, close]);
 
   const onMouseEnter = useCallback(
     (e: React.MouseEvent) => {

--- a/packages/front-end/test/hooks/useHoverTooltip.test.tsx
+++ b/packages/front-end/test/hooks/useHoverTooltip.test.tsx
@@ -436,6 +436,44 @@ describe("useHoverTooltip - cursor mode", () => {
 
     expect(result.current.isVisible).toBe(false);
   });
+
+  it.each(["mousemove", "pointermove"])(
+    "should close when %s is dispatched on window",
+    (eventName) => {
+      const { result } = renderHook(
+        () => useHoverTooltip({ positioning: "cursor", delayMs: 100 }),
+        { wrapper },
+      );
+
+      act(() => {
+        result.current.triggerProps.onMouseEnter({
+          clientX: 150,
+          clientY: 250,
+          currentTarget: {
+            getBoundingClientRect: () => ({
+              left: 0,
+              top: 0,
+              width: 200,
+              height: 200,
+            }),
+          },
+          stopPropagation: () => {},
+        } as unknown as React.MouseEvent);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+
+      expect(result.current.isVisible).toBe(true);
+
+      act(() => {
+        window.dispatchEvent(new Event(eventName));
+      });
+
+      expect(result.current.isVisible).toBe(false);
+    },
+  );
 });
 
 describe("useHoverTooltip - single tooltip at a time", () => {
@@ -589,6 +627,37 @@ describe("HoverTooltip component", () => {
     });
 
     expect(screen.getByText("Tooltip content")).toBeInTheDocument();
+  });
+
+  it("should render cursor tooltip without pointer events", async () => {
+    render(
+      <HoverTooltipProvider>
+        <HoverTooltip
+          content={<span>Cursor tooltip content</span>}
+          delayMs={100}
+          positioning="cursor"
+        >
+          <button>Trigger</button>
+        </HoverTooltip>
+      </HoverTooltipProvider>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Trigger" });
+
+    fireEvent.mouseEnter(trigger, { clientX: 150, clientY: 250 });
+
+    await act(async () => {
+      vi.advanceTimersByTime(100);
+    });
+
+    const tooltipContent = screen.getByText("Cursor tooltip content");
+    const tooltip = tooltipContent.parentElement;
+
+    if (tooltip === null) {
+      throw new Error("Expected cursor tooltip to render in a portal");
+    }
+
+    expect(tooltip).toHaveStyle({ pointerEvents: "none" });
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

The "Click anywhere in a row to open the Metric Drilldown" tip could stick on screen after the pointer left the results row, especially around drilldown modal open. Cursor-mode tooltips were a real hit target (`pointer-events: auto`) at z-index 9999, and dismiss only ran if the row kept receiving `mousemove`.

This restores the old non-interactive cursor tip behavior and dismisses on any window pointer move while visible.

- Closes **(no linked issue)**

### Dependencies

None

### Testing

1. Open an experiment with results (Metric Drilldown enabled).
2. Hover a metric row until the tip appears (~1.5s stillness).
3. Move the mouse or open the drilldown. The tip should disappear immediately and must not sit above the modal.
4. Unit: `pnpm --filter front-end test test/hooks/useHoverTooltip.test.tsx`

### Screenshots

[Tip shown with pointer-events none](https://cursor.com/agents/bc-c91db9f4-a551-4f72-b61d-b1f5ffbc1128/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsticky-tooltip-repro%2F90-fixed-shown.png)
[Tip gone after move; modal opens cleanly](https://cursor.com/agents/bc-c91db9f4-a551-4f72-b61d-b1f5ffbc1128/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsticky-tooltip-repro%2F92-fixed-modal.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c91db9f4-a551-4f72-b61d-b1f5ffbc1128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c91db9f4-a551-4f72-b61d-b1f5ffbc1128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

