### PR TITLE
Fix ramp schedules losing their dates when legacy scheduled triggers are converted

### DIFF
--- a/packages/back-end/src/models/RampScheduleModel.ts
+++ b/packages/back-end/src/models/RampScheduleModel.ts
@@ -24,7 +24,11 @@ import {
   syncLinkedSafeRolloutForRampState,
 } from "back-end/src/services/rampSchedule";
 import { applyPagination } from "back-end/src/util/handler";
-import { ConflictError, NotFoundError } from "back-end/src/util/errors";
+import {
+  BadRequestError,
+  ConflictError,
+  NotFoundError,
+} from "back-end/src/util/errors";
 import { rampTargetsEquivalent } from "back-end/src/util/flattenRules";
 import { MakeModelClass } from "./BaseModel";
 
@@ -104,18 +108,65 @@ type LegacyTriggerStep = {
   holdConditions?: StepHoldConditions;
 };
 
+function toEpochMs(value: Date | string | null | undefined): number | null {
+  if ((value ?? null) === null) return null;
+  const time = (value instanceof Date ? value : new Date(value!)).getTime();
+  return Number.isNaN(time) ? null : time;
+}
+
 // Normalizes legacy `trigger` discriminated union to the unified `interval` +
 // `holdConditions.requiresApproval` shape. Idempotent on already-migrated docs.
+//
+// "scheduled" triggers carry an absolute fire date; the unified shape is
+// relative (cumulative intervals from the phase start), so each date becomes
+// the delta from the previous gate. Dropping the date instead would leave the
+// step with no gate at all — the evaluator treats a gate-less step as instant
+// and advances one per tick, so a multi-day plan would run to completion in
+// minutes.
 export function migrateRampStepTriggers<
-  T extends { steps?: LegacyTriggerStep[] | null },
+  T extends {
+    steps?: LegacyTriggerStep[] | null;
+    phaseStartedAt?: Date | string | null;
+    startedAt?: Date | string | null;
+    startDate?: Date | string | null;
+    dateCreated?: Date | string;
+  },
 >(doc: T): T {
   if (!doc.steps || !Array.isArray(doc.steps)) return doc;
   let changed = false;
+  // Running total of when the previous gate fires, accumulated in the same
+  // way the evaluator fires steps (anchor + cumulative interval). The anchor
+  // mirrors computeNextStepAt's precedence — phaseStartedAt, then startedAt —
+  // so converted intervals reproduce the plan's absolute dates for schedules
+  // that started later than their startDate (and, because this migration is
+  // recomputed on every read, pause/resume shifts to phaseStartedAt
+  // self-correct). Not-yet-started docs fall back to the scheduled start,
+  // creation time, or the first step's own date. Interval steps push the
+  // cursor forward by their duration; approval steps don't move it (their
+  // wait is unbounded).
+  let cursorMs =
+    toEpochMs(doc.phaseStartedAt) ??
+    toEpochMs(doc.startedAt) ??
+    toEpochMs(doc.startDate) ??
+    toEpochMs(doc.dateCreated) ??
+    doc.steps.reduce<number | null>(
+      (found, s) =>
+        found ??
+        (s?.trigger?.type === "scheduled" ? toEpochMs(s.trigger.at) : null),
+      null,
+    );
   const steps = doc.steps.map((s) => {
-    if (!s || !s.trigger) return s;
+    if (!s) return s;
+    if (!s.trigger) {
+      if (typeof s.interval === "number" && cursorMs !== null) {
+        cursorMs += s.interval * 1000;
+      }
+      return s;
+    }
     changed = true;
     const { trigger, ...rest } = s;
     if (trigger.type === "interval") {
+      if (cursorMs !== null) cursorMs += trigger.seconds * 1000;
       return { ...rest, interval: trigger.seconds };
     }
     if (trigger.type === "approval") {
@@ -128,10 +179,25 @@ export function migrateRampStepTriggers<
         },
       };
     }
-    // "scheduled" steps were only emitted by buildScheduleRampAction as a
-    // synthetic step-0; their `at` is already represented at the ramp level
-    // via startDate. Strip the trigger and let the schedule's startDate drive.
-    return { ...rest, interval: null };
+    // "scheduled": convert the absolute date to a relative interval. A date
+    // at or before the previous gate means the step is already due — clamp
+    // to 1s so the catch-up fold lands on it as a time-due step.
+    const atMs = toEpochMs(trigger.at);
+    if (atMs === null || cursorMs === null) {
+      // Unparseable date (or no anchor to measure from): fail safe by
+      // holding for a human instead of advancing without a gate.
+      return {
+        ...rest,
+        interval: null,
+        holdConditions: {
+          ...(rest.holdConditions ?? {}),
+          requiresApproval: true,
+        },
+      };
+    }
+    const interval = Math.max(1, Math.round((atMs - cursorMs) / 1000));
+    cursorMs += interval * 1000;
+    return { ...rest, interval };
   });
   return changed ? { ...doc, steps } : doc;
 }
@@ -246,53 +312,66 @@ type PostBodyAction = {
   patch: Partial<RampStepAction["patch"]>;
 };
 
-// Normalize a legacy API trigger input into the unified `interval` +
-// `holdConditions` shape used internally and on output.
-function normalizeLegacyApiTrigger(
-  trigger: LegacyApiRampTrigger,
-  existingHoldConditions?: StepHoldConditions,
-): { interval: number | null; holdConditions?: StepHoldConditions } {
-  if (trigger.type === "interval") {
-    return {
-      interval: trigger.seconds,
-      ...(existingHoldConditions
-        ? { holdConditions: existingHoldConditions }
-        : {}),
-    };
-  }
-  if (trigger.type === "approval") {
-    return {
-      interval: null,
-      holdConditions: {
-        ...(existingHoldConditions ?? {}),
-        requiresApproval: true,
-      },
-    };
-  }
-  // `scheduled` trigger types are no longer accepted as step-level triggers;
-  // callers should set `startDate` at the schedule level instead.
-  return {
-    interval: null,
-    ...(existingHoldConditions
-      ? { holdConditions: existingHoldConditions }
-      : {}),
-  };
-}
-
 // Accepts both the new `{ interval, holdConditions }` shape and the legacy
 // `{ trigger: { type, ... } }` shape on input. Returns the unified shape.
-function normalizeApiStepShape(s: {
-  interval?: number | null;
-  trigger?: LegacyApiRampTrigger;
-  holdConditions?: StepHoldConditions;
-}): { interval: number | null; holdConditions?: StepHoldConditions } {
-  if (s.trigger) {
-    return normalizeLegacyApiTrigger(s.trigger, s.holdConditions);
-  }
-  return {
-    interval: s.interval ?? null,
-    ...(s.holdConditions ? { holdConditions: s.holdConditions } : {}),
-  };
+//
+// Normalization needs the whole array: legacy `scheduled` triggers carry
+// absolute dates, and the unified shape is relative, so each date becomes the
+// delta from the previous gate (`anchor` seeds the first; see
+// migrateRampStepTriggers for the full rationale). Dates that don't parse or
+// don't increase are rejected so the caller learns the plan is malformed
+// instead of it running unpaced. Note the current v2 request schema strips
+// unrecognized step fields, so the trigger branch is defense-in-depth for
+// direct model callers and any future schema that re-admits the shape.
+export function normalizeApiStepShapes(
+  steps: {
+    interval?: number | null;
+    trigger?: LegacyApiRampTrigger;
+    holdConditions?: StepHoldConditions;
+  }[],
+  anchor: Date,
+): { interval: number | null; holdConditions?: StepHoldConditions }[] {
+  // Running total of when the previous gate fires. Approval steps don't move
+  // it (their wait is unbounded); gate-less steps are instant and don't either.
+  let cursorMs = anchor.getTime();
+  return steps.map((s, i) => {
+    const trigger = s.trigger;
+    const holdConditions = s.holdConditions
+      ? { holdConditions: s.holdConditions }
+      : {};
+    if (!trigger) {
+      if (typeof s.interval === "number") cursorMs += s.interval * 1000;
+      return { interval: s.interval ?? null, ...holdConditions };
+    }
+    if (trigger.type === "interval") {
+      cursorMs += trigger.seconds * 1000;
+      return { interval: trigger.seconds, ...holdConditions };
+    }
+    if (trigger.type === "approval") {
+      return {
+        interval: null,
+        holdConditions: {
+          ...(s.holdConditions ?? {}),
+          requiresApproval: true,
+        },
+      };
+    }
+    const atMs = toEpochMs(trigger.at);
+    if (atMs === null) {
+      throw new BadRequestError(
+        `steps[${i}].trigger.at is not a valid date: "${trigger.at}".`,
+      );
+    }
+    if (atMs <= cursorMs) {
+      throw new BadRequestError(
+        `steps[${i}].trigger.at (${trigger.at}) must be after the previous step's fire time. ` +
+          `Scheduled triggers are converted to relative intervals, so each date must be later than the schedule's timing anchor (its phase start once started, otherwise its start date) and all earlier steps.`,
+      );
+    }
+    const interval = Math.max(1, Math.round((atMs - cursorMs) / 1000));
+    cursorMs += interval * 1000;
+    return { interval, ...holdConditions };
+  });
 }
 
 export class RampScheduleModel extends BaseClass {
@@ -534,33 +613,45 @@ export class RampScheduleModel extends BaseClass {
       updates.startActions = body.startActions.map(resolveTargetId);
     }
     if (body.steps !== undefined) {
-      updates.steps = body.steps.map(
-        (step: {
-          interval?: number | null;
-          trigger?: LegacyApiRampTrigger;
-          actions?: {
-            targetType?: "feature-rule";
-            targetId?: string;
-            patch?: unknown;
-          }[];
-          approvalNotes?: string | null;
-          monitored?: boolean | null;
-          holdConditions?: StepHoldConditions | null;
-        }) => {
-          const normalized = normalizeApiStepShape({
-            interval: step.interval,
-            trigger: step.trigger,
-            holdConditions: step.holdConditions ?? undefined,
-          });
-          return {
-            interval: normalized.interval,
-            actions: (step.actions ?? []).map(resolveTargetId),
-            approvalNotes: step.approvalNotes ?? undefined,
-            monitored: !!step.monitored,
-            holdConditions: normalized.holdConditions,
-          };
-        },
+      const stepBodies = body.steps as {
+        interval?: number | null;
+        trigger?: LegacyApiRampTrigger;
+        actions?: {
+          targetType?: "feature-rule";
+          targetId?: string;
+          patch?: unknown;
+        }[];
+        approvalNotes?: string | null;
+        monitored?: boolean | null;
+        holdConditions?: StepHoldConditions | null;
+      }[];
+      // Legacy `scheduled` triggers become relative intervals measured from
+      // the point the step timers run from: the phase start once the schedule
+      // has started, otherwise the scheduled start (including one being set
+      // in this same request), otherwise now.
+      const bodyStartDate =
+        "startDate" in body
+          ? body.startDate
+            ? new Date(body.startDate)
+            : null
+          : undefined;
+      const normalized = normalizeApiStepShapes(
+        stepBodies.map((step) => ({
+          interval: step.interval,
+          trigger: step.trigger,
+          holdConditions: step.holdConditions ?? undefined,
+        })),
+        schedule.phaseStartedAt ??
+          (bodyStartDate !== undefined ? bodyStartDate : schedule.startDate) ??
+          new Date(),
       );
+      updates.steps = stepBodies.map((step, i) => ({
+        interval: normalized[i].interval,
+        actions: (step.actions ?? []).map(resolveTargetId),
+        approvalNotes: step.approvalNotes ?? undefined,
+        monitored: !!step.monitored,
+        holdConditions: normalized[i].holdConditions,
+      }));
     }
     if (body.endActions !== undefined) {
       updates.endActions = body.endActions.map(resolveTargetId);

--- a/packages/back-end/src/models/RampScheduleTemplateModel.ts
+++ b/packages/back-end/src/models/RampScheduleTemplateModel.ts
@@ -33,9 +33,16 @@ const BaseClass = MakeModelClass({
 export class RampScheduleTemplateModel extends BaseClass {
   protected migrate(legacyDoc: unknown): RampScheduleTemplateInterface {
     const doc = legacyDoc as RampScheduleTemplateInterface;
-    const migrated = migrateRampStepTriggers(
-      doc as unknown as Parameters<typeof migrateRampStepTriggers>[0],
-    ) as unknown as RampScheduleTemplateInterface;
+    // Templates are reusable plans, so a legacy scheduled trigger's absolute
+    // date is meaningless against the template's creation time. Convert with
+    // no date anchor: the first scheduled date anchors the walk, preserving
+    // the plan's relative pacing (the first such step becomes ~instant).
+    const migrated = {
+      ...doc,
+      ...(migrateRampStepTriggers({ steps: doc.steps } as Parameters<
+        typeof migrateRampStepTriggers
+      >[0]) as unknown as Pick<RampScheduleTemplateInterface, "steps">),
+    };
     // Legacy templates predate the `order` field — default them to 0 so they
     // keep a stable (date-created) order until the first manual reorder.
     return { ...migrated, order: migrated.order ?? 0 };

--- a/packages/back-end/test/models/rampScheduleStepTriggers.test.ts
+++ b/packages/back-end/test/models/rampScheduleStepTriggers.test.ts
@@ -1,0 +1,237 @@
+// Mocked only to sever the heavy services/rampSchedule import chain — no test
+// here exercises the monitoringStatus branch that calls these.
+jest.mock("back-end/src/services/rampSchedule", () => ({
+  getEffectiveRampAutoUpdateState: jest.fn(),
+  getRampMonitoringMode: jest.fn(),
+  getRampAutoUpdatePreference: jest.fn(),
+}));
+
+import {
+  migrateRampStepTriggers,
+  normalizeApiStepShapes,
+} from "back-end/src/models/RampScheduleModel";
+import { BadRequestError } from "back-end/src/util/errors";
+
+const START = new Date("2024-01-01T00:00:00Z");
+const DAY = 24 * 60 * 60;
+
+function isoDaysAfterStart(days: number): string {
+  return new Date(START.getTime() + days * DAY * 1000).toISOString();
+}
+
+describe("migrateRampStepTriggers", () => {
+  it("converts scheduled trigger dates to relative intervals", () => {
+    // A dated multi-day plan: each step scheduled one day after the previous.
+    const doc = {
+      startDate: START,
+      dateCreated: START,
+      steps: [1, 2, 3, 4, 5].map((day) => ({
+        trigger: { type: "scheduled" as const, at: isoDaysAfterStart(day) },
+        actions: [],
+      })),
+    };
+    const migrated = migrateRampStepTriggers(doc);
+    expect(migrated.steps?.map((s) => s.interval)).toEqual([
+      DAY,
+      DAY,
+      DAY,
+      DAY,
+      DAY,
+    ]);
+    expect(migrated.steps?.every((s) => !("trigger" in s))).toBe(true);
+    expect(migrated.steps?.every((s) => !s.holdConditions)).toBe(true);
+  });
+
+  it("prefers the phase start over startDate as the anchor, matching the evaluator", () => {
+    // A schedule that started 2 days late: steps fire at phaseStartedAt +
+    // cumulative interval, so deltas must be measured from phaseStartedAt to
+    // reproduce the plan's absolute dates.
+    const phaseStart = new Date(START.getTime() + 2 * DAY * 1000);
+    const doc = {
+      startDate: START,
+      phaseStartedAt: phaseStart,
+      steps: [
+        {
+          trigger: { type: "scheduled" as const, at: isoDaysAfterStart(5) },
+          actions: [],
+        },
+      ],
+    };
+    expect(migrateRampStepTriggers(doc).steps?.[0].interval).toBe(3 * DAY);
+  });
+
+  it("anchors at the first scheduled date when the doc has no date fields", () => {
+    // Revision ramp actions and templates carry no dateCreated (and may have
+    // no startDate): the first step fires ~instantly and later steps keep the
+    // plan's relative pacing.
+    const doc = {
+      steps: [
+        {
+          trigger: { type: "scheduled" as const, at: isoDaysAfterStart(10) },
+          actions: [],
+        },
+        {
+          trigger: { type: "scheduled" as const, at: isoDaysAfterStart(12) },
+          actions: [],
+        },
+      ],
+    };
+    const migrated = migrateRampStepTriggers(doc);
+    // Step 0 clamps to 1s (its date IS the anchor); step 1 keeps the plan's
+    // 2-day spacing, less the 1s the clamp already consumed.
+    expect(migrated.steps?.map((s) => s.interval)).toEqual([1, 2 * DAY - 1]);
+    expect(migrated.steps?.every((s) => !s.holdConditions)).toBe(true);
+  });
+
+  it("anchors the first scheduled step at startDate, falling back to dateCreated", () => {
+    const noStartDate = {
+      dateCreated: START,
+      steps: [
+        {
+          trigger: { type: "scheduled" as const, at: isoDaysAfterStart(2) },
+          actions: [],
+        },
+      ],
+    };
+    expect(migrateRampStepTriggers(noStartDate).steps?.[0].interval).toBe(
+      2 * DAY,
+    );
+  });
+
+  it("clamps past or out-of-order dates to a 1s interval instead of removing the gate", () => {
+    const doc = {
+      startDate: START,
+      steps: [
+        {
+          trigger: { type: "scheduled" as const, at: isoDaysAfterStart(3) },
+          actions: [],
+        },
+        // Earlier than the previous step — already due per the plan.
+        {
+          trigger: { type: "scheduled" as const, at: isoDaysAfterStart(1) },
+          actions: [],
+        },
+      ],
+    };
+    const migrated = migrateRampStepTriggers(doc);
+    expect(migrated.steps?.[0].interval).toBe(3 * DAY);
+    expect(migrated.steps?.[1].interval).toBe(1);
+  });
+
+  it("advances the date cursor across interval triggers and already-migrated steps", () => {
+    const doc = {
+      startDate: START,
+      steps: [
+        // Already-migrated step: one day.
+        { interval: DAY, actions: [] },
+        // Legacy interval trigger: one more day.
+        { trigger: { type: "interval" as const, seconds: DAY }, actions: [] },
+        // Scheduled at day 3 — only one day after the two above.
+        {
+          trigger: { type: "scheduled" as const, at: isoDaysAfterStart(3) },
+          actions: [],
+        },
+      ],
+    };
+    const migrated = migrateRampStepTriggers(doc);
+    expect(migrated.steps?.map((s) => s.interval)).toEqual([DAY, DAY, DAY]);
+  });
+
+  it("fails safe to an approval hold when a scheduled date is unparseable", () => {
+    const doc = {
+      startDate: START,
+      steps: [
+        {
+          trigger: { type: "scheduled" as const, at: "not-a-date" },
+          actions: [],
+        },
+      ],
+    };
+    const migrated = migrateRampStepTriggers(doc);
+    expect(migrated.steps?.[0].interval).toBeNull();
+    expect(migrated.steps?.[0].holdConditions?.requiresApproval).toBe(true);
+  });
+
+  it("is idempotent and preserves approval and interval trigger conversion", () => {
+    const doc = {
+      startDate: START,
+      steps: [
+        { trigger: { type: "interval" as const, seconds: 300 }, actions: [] },
+        { trigger: { type: "approval" as const }, actions: [] },
+      ],
+    };
+    const once = migrateRampStepTriggers(doc);
+    expect(once.steps?.[0].interval).toBe(300);
+    expect(once.steps?.[1].interval).toBeNull();
+    expect(once.steps?.[1].holdConditions?.requiresApproval).toBe(true);
+    const twice = migrateRampStepTriggers(once);
+    expect(twice).toBe(once);
+  });
+});
+
+describe("normalizeApiStepShapes", () => {
+  it("converts scheduled trigger dates to relative intervals from the anchor", () => {
+    const normalized = normalizeApiStepShapes(
+      [
+        { trigger: { type: "scheduled", at: isoDaysAfterStart(1) } },
+        { trigger: { type: "scheduled", at: isoDaysAfterStart(2) } },
+      ],
+      START,
+    );
+    expect(normalized).toEqual([{ interval: DAY }, { interval: DAY }]);
+  });
+
+  it("passes through the unified shape and legacy interval/approval triggers", () => {
+    const normalized = normalizeApiStepShapes(
+      [
+        { interval: 600, holdConditions: { minSampleSize: 100 } },
+        { trigger: { type: "interval", seconds: 300 } },
+        { trigger: { type: "approval" } },
+      ],
+      START,
+    );
+    expect(normalized).toEqual([
+      { interval: 600, holdConditions: { minSampleSize: 100 } },
+      { interval: 300 },
+      { interval: null, holdConditions: { requiresApproval: true } },
+    ]);
+  });
+
+  it("measures a scheduled date against preceding interval steps", () => {
+    const normalized = normalizeApiStepShapes(
+      [
+        { interval: DAY },
+        { trigger: { type: "scheduled", at: isoDaysAfterStart(3) } },
+      ],
+      START,
+    );
+    expect(normalized[1].interval).toBe(2 * DAY);
+  });
+
+  it("rejects an unparseable scheduled date", () => {
+    expect(() =>
+      normalizeApiStepShapes(
+        [{ trigger: { type: "scheduled", at: "not-a-date" } }],
+        START,
+      ),
+    ).toThrow(BadRequestError);
+  });
+
+  it("rejects scheduled dates that do not increase", () => {
+    expect(() =>
+      normalizeApiStepShapes(
+        [
+          { trigger: { type: "scheduled", at: isoDaysAfterStart(2) } },
+          { trigger: { type: "scheduled", at: isoDaysAfterStart(1) } },
+        ],
+        START,
+      ),
+    ).toThrow(BadRequestError);
+    expect(() =>
+      normalizeApiStepShapes(
+        [{ trigger: { type: "scheduled", at: START.toISOString() } }],
+        START,
+      ),
+    ).toThrow(BadRequestError);
+  });
+});


### PR DESCRIPTION
### Features and Changes

Legacy ramp-schedule step triggers of type `scheduled` carry an absolute fire date. Both places that convert the legacy shape into the unified `interval` + `holdConditions` shape — the JIT document migration (`migrateRampStepTriggers`) and the API input normalizer — discarded that date and produced a step with **no interval and no hold conditions**. The evaluator treats a gate-less step as instant and advances one per scheduler tick, so a dated multi-day plan converts into a schedule that runs to full coverage in minutes, one publish per tick.

The migration's comment assumed `scheduled` triggers only ever appeared as a synthetic step-0 whose date was mirrored by the schedule-level `startDate`. That holds for the current emitter, but any stored plan with dated steps beyond step 0 (e.g. "25% on Monday, 50% on Tuesday, …") loses every date past the first.

This PR converts the dates instead of discarding them:

- Each scheduled date becomes the delta from the previous gate, accumulated the same way the evaluator fires steps (`anchor + cumulative interval`).
- The anchor mirrors `computeNextStepAt`'s precedence — `phaseStartedAt`, then `startedAt` — so converted intervals reproduce the plan's absolute dates even for schedules that started later than their `startDate`. Because the migration is recomputed on every read, pause/resume shifts to `phaseStartedAt` self-correct. Not-yet-started docs fall back to `startDate`, then `dateCreated`, then the first scheduled date itself.
- Docs with no date fields at all (ramp schedule **templates** and revision-embedded ramp actions, which have no `dateCreated`) anchor at the first scheduled date: the first such step becomes ~instant and later steps keep the plan's relative pacing — absolute dates are meaningless for a reusable template anyway.
- Past or out-of-order dates clamp to a 1-second interval in the migration (the step is already due; the existing catch-up fold collapses overdue time-gated steps into a single publish).
- Unparseable dates in stored docs fail safe to an approval hold (`interval: null` + `requiresApproval: true`) rather than advancing without a gate.
- The API input path (`normalizeApiStepShapes`) does the same conversion but rejects unparseable or non-increasing dates with a 400, and anchors at `phaseStartedAt ?? startDate ?? now`, honoring a `startDate` supplied in the same update request. Note: the current v2 request schema requires `interval` and strips unknown step fields, so this layer is defense-in-depth for direct model callers and any future schema that re-admits the legacy shape.

One known limitation: documents whose scheduled steps were already flattened to `interval: null` at write time by the old API normalizer have lost their dates permanently — no read migration can recover them. Those schedules should be deleted and recreated.

### Dependencies

None.

### Testing

- New unit tests in `packages/back-end/test/models/rampScheduleStepTriggers.test.ts` (13 tests): date→interval conversion for multi-day plans, anchor precedence (`phaseStartedAt` over `startDate`, `startDate` over `dateCreated`, first-scheduled-date fallback), cursor accounting across mixed interval/already-migrated steps, out-of-order clamping, unparseable-date fail-safe, idempotency (already-migrated docs are returned by reference, unchanged), and the API normalizer's passthrough/conversion/rejection behaviors.
- Verified end-to-end against a local server + Mongo: inserted a ramp schedule whose steps carry legacy `{trigger: {type: "scheduled", at: <4 dates, one day apart>}}` docs.
  - Before this change: `GET /api/v1/ramp-schedules/:id` returns every step as `interval: null` with no hold conditions (four gate-less instant steps).
  - After this change: the same document returns `interval: 86400` for each step, anchored at the schedule's `startDate`.
- `pnpm --filter back-end test` ramp suites (existing 200 tests in `rampSchedule.test.ts` + `rampScheduleToApiInterface.test.ts`) pass unchanged; eslint and type-check clean.

### Screenshots

N/A (back-end only).
