### PR TITLE
fix(holdouts): Improve holdout <-> feature <-> experiment linking and rely on feature rule list

### DIFF
--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
@@ -186,10 +186,8 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
           "Either provide variationId for all variations or none; mixed inputs are not allowed.",
         );
       }
-      // Always resolve the experiment for experiment-ref rules: needed to fill
-      // missing variationIds, to enforce holdout compatibility on holdout-bound
-      // features, and to block adding a holdout-bound experiment to a feature
-      // that is not itself in a holdout (below).
+      // Always resolve the experiment to check for missing variations
+      // and to check for holdout compatibility
       const experiment = await getExperimentById(
         req.context,
         ruleInput.experimentId,
@@ -213,10 +211,7 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
         }));
       }
 
-      // Use the target draft's holdout (revision.holdout carries the draft's
-      // holdout change, or a carry-forward of live), not just the live feature's
-      // — so a holdout added in this same draft satisfies the compatibility
-      // rules and a matching-holdout experiment can be added.
+      // Use target revision holdout to check compatibility
       const effectiveHoldout = revision.holdout ?? null;
       if (effectiveHoldout?.id) {
         if (experiment.status !== "draft") {
@@ -253,10 +248,6 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
           holdoutExperimentToLink = experiment;
         }
       } else if (experiment.holdoutId) {
-        // Feature is not in a holdout but the experiment is. Holdout gating is
-        // applied per-feature at payload build time (feature.holdout), so the
-        // experiment would run with no holdout carve-out. Require the feature to
-        // join the holdout first.
         const expHoldout = await req.context.models.holdout.getById(
           experiment.holdoutId,
         );

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
@@ -26,7 +26,10 @@ import {
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { getFeature } from "back-end/src/models/FeatureModel";
-import { resolveHoldoutExperimentToLink } from "back-end/src/services/holdouts";
+import {
+  linkExperimentToHoldout,
+  resolveHoldoutExperimentToLink,
+} from "back-end/src/services/holdouts";
 import {
   getExperimentById,
   updateExperiment,
@@ -340,25 +343,15 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
     }
 
     if (holdoutExperimentToLink && feature.holdout?.id) {
-      await updateExperiment({
-        context: req.context,
-        experiment: holdoutExperimentToLink,
-        changes: { holdoutId: feature.holdout.id },
-      });
+      // Record ids for compensation BEFORE the writes — the rollback is
+      // idempotent, so a mid-write failure is still fully compensated.
       linkedExperimentId = holdoutExperimentToLink.id;
-      const holdout = await req.context.models.holdout.getById(
+      linkedHoldoutId = feature.holdout.id;
+      await linkExperimentToHoldout(
+        req.context,
+        holdoutExperimentToLink,
         feature.holdout.id,
       );
-      await req.context.models.holdout.updateById(feature.holdout.id, {
-        linkedExperiments: {
-          ...holdout?.linkedExperiments,
-          [holdoutExperimentToLink.id]: {
-            id: holdoutExperimentToLink.id,
-            dateAdded: new Date(),
-          },
-        },
-      });
-      linkedHoldoutId = feature.holdout.id;
     }
 
     await updateRevision(

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
@@ -14,7 +14,7 @@ import type {
   RolloutRule,
   SafeRolloutRule,
 } from "shared/validators";
-import { resetReviewOnChange } from "shared/util";
+import { getEffectiveRevisionHoldout, resetReviewOnChange } from "shared/util";
 import { RevisionChanges } from "shared/types/feature-revision";
 import { ExperimentInterface } from "shared/types/experiment";
 import { CreateProps } from "shared/types/base-model";
@@ -212,9 +212,9 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
         }));
       }
 
-      // Use target revision holdout to check compatibility. Linking writes are
-      // deferred until after custom-hook prevalidation below.
-      const effectiveHoldout = revision.holdout ?? null;
+      // Use target revision holdout to check compatibility.
+      // Linking writes are deferred until after custom-hook prevalidation below.
+      const effectiveHoldout = getEffectiveRevisionHoldout(revision, feature);
       holdoutExperimentToLink = await resolveHoldoutExperimentToLink({
         context: req.context,
         feature,

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
@@ -186,66 +186,83 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
           "Either provide variationId for all variations or none; mixed inputs are not allowed.",
         );
       }
-      const needsHoldoutCheck = Boolean(feature.holdout?.id);
-      if (anyMissing || needsHoldoutCheck) {
-        const experiment = await getExperimentById(
-          req.context,
-          ruleInput.experimentId,
+      // Always resolve the experiment for experiment-ref rules: needed to fill
+      // missing variationIds, to enforce holdout compatibility on holdout-bound
+      // features, and to block adding a holdout-bound experiment to a feature
+      // that is not itself in a holdout (below).
+      const experiment = await getExperimentById(
+        req.context,
+        ruleInput.experimentId,
+      );
+      if (!experiment) {
+        throw new NotFoundError(
+          `Could not find experiment "${ruleInput.experimentId}"`,
         );
-        if (!experiment) {
-          throw new NotFoundError(
-            `Could not find experiment "${ruleInput.experimentId}"`,
+      }
+
+      if (anyMissing) {
+        const phaseVariations = getLatestPhaseVariations(experiment);
+        if (phaseVariations.length < ruleInput.variations.length) {
+          throw new BadRequestError(
+            `Experiment has ${phaseVariations.length} variation(s) but ${ruleInput.variations.length} were specified`,
+          );
+        }
+        ruleInput.variations = ruleInput.variations.map((v, i) => ({
+          variationId: phaseVariations[i].id,
+          value: v.value,
+        }));
+      }
+
+      // Use the target draft's holdout (revision.holdout carries the draft's
+      // holdout change, or a carry-forward of live), not just the live feature's
+      // — so a holdout added in this same draft satisfies the compatibility
+      // rules and a matching-holdout experiment can be added.
+      const effectiveHoldout = revision.holdout ?? null;
+      if (effectiveHoldout?.id) {
+        if (experiment.status !== "draft") {
+          throw new BadRequestError(
+            `Cannot add experiment rule: this feature uses a holdout, so the experiment must be in "draft" status (currently "${experiment.status}").`,
+          );
+        }
+        const expHasLinkedChanges =
+          (experiment.linkedFeatures?.length ?? 0) > 0 ||
+          experiment.hasURLRedirects ||
+          experiment.hasVisualChangesets;
+        if (expHasLinkedChanges) {
+          throw new BadRequestError(
+            `Cannot add experiment rule: this feature uses a holdout, but the experiment already has linked features, URL redirects, or visual changesets. Unlink them first.`,
+          );
+        }
+        if (
+          experiment.holdoutId &&
+          experiment.holdoutId !== effectiveHoldout.id
+        ) {
+          const featureHoldout = await req.context.models.holdout.getById(
+            effectiveHoldout.id,
+          );
+          const expHoldout = experiment.holdoutId
+            ? await req.context.models.holdout.getById(experiment.holdoutId)
+            : null;
+          throw new BadRequestError(
+            `Cannot add experiment rule: experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}" but this feature uses holdout "${featureHoldout?.name || effectiveHoldout.id}".`,
           );
         }
 
-        if (anyMissing) {
-          const phaseVariations = getLatestPhaseVariations(experiment);
-          if (phaseVariations.length < ruleInput.variations.length) {
-            throw new BadRequestError(
-              `Experiment has ${phaseVariations.length} variation(s) but ${ruleInput.variations.length} were specified`,
-            );
-          }
-          ruleInput.variations = ruleInput.variations.map((v, i) => ({
-            variationId: phaseVariations[i].id,
-            value: v.value,
-          }));
+        if (!experiment.holdoutId) {
+          // Deferred until after custom-hook prevalidation below
+          holdoutExperimentToLink = experiment;
         }
-
-        if (needsHoldoutCheck && feature.holdout?.id) {
-          if (experiment.status !== "draft") {
-            throw new BadRequestError(
-              `Cannot add experiment rule: this feature uses a holdout, so the experiment must be in "draft" status (currently "${experiment.status}").`,
-            );
-          }
-          const expHasLinkedChanges =
-            (experiment.linkedFeatures?.length ?? 0) > 0 ||
-            experiment.hasURLRedirects ||
-            experiment.hasVisualChangesets;
-          if (expHasLinkedChanges) {
-            throw new BadRequestError(
-              `Cannot add experiment rule: this feature uses a holdout, but the experiment already has linked features, URL redirects, or visual changesets. Unlink them first.`,
-            );
-          }
-          if (
-            experiment.holdoutId &&
-            experiment.holdoutId !== feature.holdout.id
-          ) {
-            const featureHoldout = await req.context.models.holdout.getById(
-              feature.holdout.id,
-            );
-            const expHoldout = experiment.holdoutId
-              ? await req.context.models.holdout.getById(experiment.holdoutId)
-              : null;
-            throw new BadRequestError(
-              `Cannot add experiment rule: experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}" but this feature uses holdout "${featureHoldout?.name || feature.holdout.id}".`,
-            );
-          }
-
-          if (!experiment.holdoutId) {
-            // Deferred until after custom-hook prevalidation below
-            holdoutExperimentToLink = experiment;
-          }
-        }
+      } else if (experiment.holdoutId) {
+        // Feature is not in a holdout but the experiment is. Holdout gating is
+        // applied per-feature at payload build time (feature.holdout), so the
+        // experiment would run with no holdout carve-out. Require the feature to
+        // join the holdout first.
+        const expHoldout = await req.context.models.holdout.getById(
+          experiment.holdoutId,
+        );
+        throw new BadRequestError(
+          `Cannot add experiment rule: this experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}", but this feature is not in a holdout. Add the feature to that holdout first, then add the experiment.`,
+        );
       }
     }
 

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
@@ -26,6 +26,7 @@ import {
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { getFeature } from "back-end/src/models/FeatureModel";
+import { resolveHoldoutExperimentToLink } from "back-end/src/services/holdouts";
 import {
   getExperimentById,
   updateExperiment,
@@ -211,50 +212,16 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
         }));
       }
 
-      // Use target revision holdout to check compatibility
+      // Use target revision holdout to check compatibility. Linking writes are
+      // deferred until after custom-hook prevalidation below.
       const effectiveHoldout = revision.holdout ?? null;
-      if (effectiveHoldout?.id) {
-        if (experiment.status !== "draft") {
-          throw new BadRequestError(
-            `Cannot add experiment rule: this feature uses a holdout, so the experiment must be in "draft" status (currently "${experiment.status}").`,
-          );
-        }
-        const expHasLinkedChanges =
-          (experiment.linkedFeatures?.length ?? 0) > 0 ||
-          experiment.hasURLRedirects ||
-          experiment.hasVisualChangesets;
-        if (expHasLinkedChanges) {
-          throw new BadRequestError(
-            `Cannot add experiment rule: this feature uses a holdout, but the experiment already has linked features, URL redirects, or visual changesets. Unlink them first.`,
-          );
-        }
-        if (
-          experiment.holdoutId &&
-          experiment.holdoutId !== effectiveHoldout.id
-        ) {
-          const featureHoldout = await req.context.models.holdout.getById(
-            effectiveHoldout.id,
-          );
-          const expHoldout = experiment.holdoutId
-            ? await req.context.models.holdout.getById(experiment.holdoutId)
-            : null;
-          throw new BadRequestError(
-            `Cannot add experiment rule: experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}" but this feature uses holdout "${featureHoldout?.name || effectiveHoldout.id}".`,
-          );
-        }
-
-        if (!experiment.holdoutId) {
-          // Deferred until after custom-hook prevalidation below
-          holdoutExperimentToLink = experiment;
-        }
-      } else if (experiment.holdoutId) {
-        const expHoldout = await req.context.models.holdout.getById(
-          experiment.holdoutId,
-        );
-        throw new BadRequestError(
-          `Cannot add experiment rule: this experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}", but this feature is not in a holdout. Add the feature to that holdout first, then add the experiment.`,
-        );
-      }
+      holdoutExperimentToLink = await resolveHoldoutExperimentToLink({
+        context: req.context,
+        feature,
+        experiment,
+        effectiveHoldout,
+        makeError: (message) => new BadRequestError(message),
+      });
     }
 
     const rule = buildRuleFromInput(ruleInput, uuidv4());

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
@@ -342,15 +342,23 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
       createdSafeRolloutId = safeRollout.id;
     }
 
-    if (holdoutExperimentToLink && feature.holdout?.id) {
+    // Link now only when the validated holdout is already live on the feature. A draft-only
+    // holdout defers to publish — applyHoldoutSideEffects enrolls the
+    // experiments in the merged rules when the holdout change lands.
+    const linkHoldoutId = getEffectiveRevisionHoldout(revision, feature)?.id;
+    if (
+      holdoutExperimentToLink &&
+      linkHoldoutId &&
+      feature.holdout?.id === linkHoldoutId
+    ) {
       // Record ids for compensation BEFORE the writes — the rollback is
       // idempotent, so a mid-write failure is still fully compensated.
       linkedExperimentId = holdoutExperimentToLink.id;
-      linkedHoldoutId = feature.holdout.id;
+      linkedHoldoutId = linkHoldoutId;
       await linkExperimentToHoldout(
         req.context,
         holdoutExperimentToLink,
-        feature.holdout.id,
+        linkHoldoutId,
       );
     }
 

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
@@ -9,7 +9,7 @@ import {
   SafeRolloutInterface,
 } from "shared/validators";
 import type { FeatureRule, SafeRolloutRule } from "shared/validators";
-import { resetReviewOnChange } from "shared/util";
+import { getEffectiveRevisionHoldout, resetReviewOnChange } from "shared/util";
 import { RevisionChanges } from "shared/types/feature-revision";
 import { ExperimentInterface } from "shared/types/experiment";
 import { CreateProps } from "shared/types/base-model";
@@ -129,7 +129,10 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
           "Either provide variationId for all variations or none; mixed inputs are not allowed.",
         );
       }
-      const needsHoldoutCheck = Boolean(feature.holdout?.id);
+      // Legacy revisions store holdout sparsely, so absence carries the
+      // feature's holdout forward.
+      const effectiveHoldout = getEffectiveRevisionHoldout(revision, feature);
+      const needsHoldoutCheck = Boolean(effectiveHoldout?.id);
       if (anyMissing || needsHoldoutCheck) {
         const experiment = await getExperimentById(
           req.context,
@@ -153,13 +156,13 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
           }));
         }
 
-        if (needsHoldoutCheck && feature.holdout?.id) {
+        if (needsHoldoutCheck) {
           // Linking writes are deferred until after custom-hook prevalidation below.
           holdoutExperimentToLink = await resolveHoldoutExperimentToLink({
             context: req.context,
             feature,
             experiment,
-            effectiveHoldout: feature.holdout,
+            effectiveHoldout,
             makeError: (message) => new BadRequestError(message),
           });
         }

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
@@ -23,7 +23,10 @@ import { assertConfigBackedFeatureValuesValid } from "back-end/src/services/conf
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { getFeature } from "back-end/src/models/FeatureModel";
-import { resolveHoldoutExperimentToLink } from "back-end/src/services/holdouts";
+import {
+  linkExperimentToHoldout,
+  resolveHoldoutExperimentToLink,
+} from "back-end/src/services/holdouts";
 import {
   getExperimentById,
   updateExperiment,
@@ -360,25 +363,15 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
     }
 
     if (holdoutExperimentToLink && feature.holdout?.id) {
-      await updateExperiment({
-        context: req.context,
-        experiment: holdoutExperimentToLink,
-        changes: { holdoutId: feature.holdout.id },
-      });
+      // Record ids for compensation BEFORE the writes — the rollback is
+      // idempotent, so a mid-write failure is still fully compensated.
       linkedExperimentId = holdoutExperimentToLink.id;
-      const holdout = await req.context.models.holdout.getById(
+      linkedHoldoutId = feature.holdout.id;
+      await linkExperimentToHoldout(
+        req.context,
+        holdoutExperimentToLink,
         feature.holdout.id,
       );
-      await req.context.models.holdout.updateById(feature.holdout.id, {
-        linkedExperiments: {
-          ...holdout?.linkedExperiments,
-          [holdoutExperimentToLink.id]: {
-            id: holdoutExperimentToLink.id,
-            dateAdded: new Date(),
-          },
-        },
-      });
-      linkedHoldoutId = feature.holdout.id;
     }
 
     await updateRevision(

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
@@ -359,15 +359,23 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
       createdSafeRolloutId = safeRollout.id;
     }
 
-    if (holdoutExperimentToLink && feature.holdout?.id) {
+    // Link now only when the validated holdout is already live. A draft-only
+    // holdout defers to publish — applyHoldoutSideEffects enrolls the
+    // experiments in the merged rules when the holdout change lands.
+    const linkHoldoutId = getEffectiveRevisionHoldout(revision, feature)?.id;
+    if (
+      holdoutExperimentToLink &&
+      linkHoldoutId &&
+      feature.holdout?.id === linkHoldoutId
+    ) {
       // Record ids for compensation BEFORE the writes — the rollback is
       // idempotent, so a mid-write failure is still fully compensated.
       linkedExperimentId = holdoutExperimentToLink.id;
-      linkedHoldoutId = feature.holdout.id;
+      linkedHoldoutId = linkHoldoutId;
       await linkExperimentToHoldout(
         req.context,
         holdoutExperimentToLink,
-        feature.holdout.id,
+        linkHoldoutId,
       );
     }
 

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
@@ -132,44 +132,41 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
           "Either provide variationId for all variations or none; mixed inputs are not allowed.",
         );
       }
-      // Legacy revisions store holdout sparsely, so absence carries the
-      // feature's holdout forward.
-      const effectiveHoldout = getEffectiveRevisionHoldout(revision, feature);
-      const needsHoldoutCheck = Boolean(effectiveHoldout?.id);
-      if (anyMissing || needsHoldoutCheck) {
-        const experiment = await getExperimentById(
-          req.context,
-          ruleInput.experimentId,
+      // Always resolve the experiment: holdout compatibility must be checked
+      // in both directions (the experiment may belong to a holdout even when
+      // this Feature Flag does not).
+      const experiment = await getExperimentById(
+        req.context,
+        ruleInput.experimentId,
+      );
+      if (!experiment)
+        throw new NotFoundError(
+          `Could not find experiment "${ruleInput.experimentId}"`,
         );
-        if (!experiment)
-          throw new NotFoundError(
-            `Could not find experiment "${ruleInput.experimentId}"`,
+
+      if (anyMissing) {
+        const phaseVariations = getLatestPhaseVariations(experiment);
+        if (phaseVariations.length < ruleInput.variations.length) {
+          throw new BadRequestError(
+            `Experiment has ${phaseVariations.length} variation(s) but ${ruleInput.variations.length} were specified`,
           );
-
-        if (anyMissing) {
-          const phaseVariations = getLatestPhaseVariations(experiment);
-          if (phaseVariations.length < ruleInput.variations.length) {
-            throw new BadRequestError(
-              `Experiment has ${phaseVariations.length} variation(s) but ${ruleInput.variations.length} were specified`,
-            );
-          }
-          ruleInput.variations = ruleInput.variations.map((v, i) => ({
-            variationId: phaseVariations[i].id,
-            value: v.value,
-          }));
         }
-
-        if (needsHoldoutCheck) {
-          // Linking writes are deferred until after custom-hook prevalidation below.
-          holdoutExperimentToLink = await resolveHoldoutExperimentToLink({
-            context: req.context,
-            feature,
-            experiment,
-            effectiveHoldout,
-            makeError: (message) => new BadRequestError(message),
-          });
-        }
+        ruleInput.variations = ruleInput.variations.map((v, i) => ({
+          variationId: phaseVariations[i].id,
+          value: v.value,
+        }));
       }
+
+      // Legacy revisions store holdout sparsely, so absence carries the
+      // feature's holdout forward. Linking writes are deferred until after
+      // custom-hook prevalidation below.
+      holdoutExperimentToLink = await resolveHoldoutExperimentToLink({
+        context: req.context,
+        feature,
+        experiment,
+        effectiveHoldout: getEffectiveRevisionHoldout(revision, feature),
+        makeError: (message) => new BadRequestError(message),
+      });
     }
 
     // V2: derive scope from the rule itself, not from a body `environment` field.

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
@@ -23,6 +23,7 @@ import { assertConfigBackedFeatureValuesValid } from "back-end/src/services/conf
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { getFeature } from "back-end/src/models/FeatureModel";
+import { resolveHoldoutExperimentToLink } from "back-end/src/services/holdouts";
 import {
   getExperimentById,
   updateExperiment,
@@ -153,38 +154,14 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
         }
 
         if (needsHoldoutCheck && feature.holdout?.id) {
-          if (experiment.status !== "draft") {
-            throw new BadRequestError(
-              `Cannot add experiment rule: this feature uses a holdout, so the experiment must be in "draft" status (currently "${experiment.status}").`,
-            );
-          }
-          const expHasLinkedChanges =
-            (experiment.linkedFeatures?.length ?? 0) > 0 ||
-            experiment.hasURLRedirects ||
-            experiment.hasVisualChangesets;
-          if (expHasLinkedChanges) {
-            throw new BadRequestError(
-              `Cannot add experiment rule: this feature uses a holdout, but the experiment already has linked features, URL redirects, or visual changesets. Unlink them first.`,
-            );
-          }
-          if (
-            experiment.holdoutId &&
-            experiment.holdoutId !== feature.holdout.id
-          ) {
-            const featureHoldout = await req.context.models.holdout.getById(
-              feature.holdout.id,
-            );
-            const expHoldout = experiment.holdoutId
-              ? await req.context.models.holdout.getById(experiment.holdoutId)
-              : null;
-            throw new BadRequestError(
-              `Cannot add experiment rule: experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}" but this feature uses holdout "${featureHoldout?.name || feature.holdout.id}".`,
-            );
-          }
-          if (!experiment.holdoutId) {
-            // Deferred until after custom-hook prevalidation below
-            holdoutExperimentToLink = experiment;
-          }
+          // Linking writes are deferred until after custom-hook prevalidation below.
+          holdoutExperimentToLink = await resolveHoldoutExperimentToLink({
+            context: req.context,
+            feature,
+            experiment,
+            effectiveHoldout: feature.holdout,
+            makeError: (message) => new BadRequestError(message),
+          });
         }
       }
     }

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1712,6 +1712,8 @@ export async function postExperiment(
     }
   }
 
+  // TODO(holdouts): allow changing holdout if the experiment is not linked to a feature
+  // in the live! feature revision
   const experimentHasLinkedChanges =
     experiment.hasURLRedirects ||
     experiment.hasVisualChangesets ||

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -32,6 +32,7 @@ import {
   namespacesToMap,
   pruneOrphanedRampActions,
   assertSchemaMatchesValueType,
+  getEffectiveRevisionHoldout,
 } from "shared/util";
 import { SAFE_ROLLOUT_TRACKING_KEY_PREFIX } from "shared/constants";
 import {
@@ -2915,21 +2916,9 @@ export async function postFeatureRule(
     rule.safeRolloutId = generateId("sr_");
   }
 
-  let effectiveHoldout = feature.holdout ?? null;
-  // If posting to a different revision, use the holdout from that revision
-  // to check compatibility
-  if (parseInt(version) !== feature.version) {
-    const targetRevision = await getRevision({
-      context,
-      organization: feature.organization,
-      featureId: feature.id,
-      feature,
-      version: parseInt(version),
-    });
-    if (targetRevision) {
-      effectiveHoldout = targetRevision.holdout ?? null;
-    }
-  }
+  const revision = await getDraftRevision(context, feature, parseInt(version));
+
+  const effectiveHoldout = getEffectiveRevisionHoldout(revision, feature);
 
   // Add holdout to existing experiment and experiment to holdout linkedExperiments
   // if the experiment is not running and has no linked implementations for
@@ -2952,7 +2941,6 @@ export async function postFeatureRule(
     }
   }
 
-  const revision = await getDraftRevision(context, feature, parseInt(version));
   const resetReview = resetReviewOnChange({
     feature,
     changedEnvironments: selectedEnvironments,
@@ -3106,6 +3094,8 @@ export async function postFeatureRule(
     }
   }
 
+  // TODO(holdouts): remove code below (which makes this endpoint consistent with API routes)
+  // and instead only link when the holdout and experiment go live
   if (holdoutExperimentToLink && feature.holdout?.id) {
     await updateExperiment({
       context,
@@ -3466,19 +3456,11 @@ export async function postFeatureExperimentRefRule(
       ? feature.version
       : (draftVersion ?? feature.version);
 
+  const revision = await getDraftRevision(context, feature, targetVersion);
+
   // If posting to a different revision, use the holdout from that revision
   // to check compatibility
-  let effectiveHoldout = feature.holdout ?? null;
-  if (targetVersion !== feature.version) {
-    const targetRevision = await getRevision({
-      context,
-      organization: feature.organization,
-      featureId: feature.id,
-      feature,
-      version: targetVersion,
-    });
-    if (targetRevision) effectiveHoldout = targetRevision.holdout ?? null;
-  }
+  const effectiveHoldout = getEffectiveRevisionHoldout(revision, feature);
 
   const holdoutExperimentToLink = await resolveHoldoutExperimentToLink({
     context,
@@ -3487,8 +3469,6 @@ export async function postFeatureExperimentRefRule(
     effectiveHoldout,
     allowExistingLinkToThisFeature: true,
   });
-
-  const revision = await getDraftRevision(context, feature, targetVersion);
 
   // One-way: any rule-footprint env that's currently off flips on. We never
   // turn envs off here.

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -2914,13 +2914,9 @@ export async function postFeatureRule(
     rule.safeRolloutId = generateId("sr_");
   }
 
-  // Determine the holdout that will be live when this rule's revision is
-  // published: the target draft's holdout when editing an existing draft,
-  // otherwise the live feature's (a new draft branched from live carries
-  // feature.holdout forward). Checking the draft — not just live — lets a
-  // holdout added in the same draft satisfy the compatibility rules below.
-  // Read-only here so a rejection never leaves a stray draft behind.
   let effectiveHoldout = feature.holdout ?? null;
+  // If posting to a different revision, use the holdout from that revision
+  // to check compatibility
   if (parseInt(version) !== feature.version) {
     const targetRevision = await getRevision({
       context,
@@ -2971,11 +2967,6 @@ export async function postFeatureRule(
       holdoutExperimentToLink = experiment;
     }
   } else if (rule.type === "experiment-ref" && !effectiveHoldout?.id) {
-    // Block adding a holdout-bound experiment to a feature/draft that is not in
-    // a holdout. Holdout gating is applied per-feature at payload build time
-    // (via feature.holdout), so the experiment would run with no holdout
-    // carve-out and its analysis would be wrong. Require the feature to join the
-    // holdout first — either in this draft or a published revision.
     const experiment = await getExperimentById(context, rule.experimentId);
     if (experiment?.holdoutId) {
       const expHoldout = await context.models.holdout.getById(
@@ -3501,10 +3492,8 @@ export async function postFeatureExperimentRefRule(
       ? feature.version
       : (draftVersion ?? feature.version);
 
-  // Reconcile holdout membership between the experiment and the feature/draft,
-  // mirroring postFeatureRule so linking a feature from an experiment obeys the
-  // same invariant. Draft-aware: read the target draft's holdout read-only, so a
-  // rejection here never creates a stray draft.
+  // If posting to a different revision, use the holdout from that revision
+  // to check compatibility
   let effectiveHoldout = feature.holdout ?? null;
   if (targetVersion !== feature.version) {
     const targetRevision = await getRevision({
@@ -3530,9 +3519,6 @@ export async function postFeatureExperimentRefRule(
         `Cannot add experiment rule: experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}" but this feature uses holdout "${featureHoldout?.name || effectiveHoldout.id}".`,
       );
     }
-    // A holdout-free experiment joining a holdout feature must be safe to pull
-    // into the holdout; if so it's linked below (mirroring postFeatureRule).
-    // When the experiment is already in this holdout there's nothing to do.
     if (!experiment.holdoutId) {
       if (experiment.status !== "draft") {
         throw new Error(
@@ -3691,9 +3677,8 @@ export async function postFeatureExperimentRefRule(
     experiment,
   );
 
-  // Link the experiment into the feature's holdout when that holdout is already
-  // live. If it exists only in the draft, linking defers to publish via
-  // applyHoldoutSideEffects (the experiment is now in feature.linkedExperiments).
+  // TODO(holdouts): remove code below (which makes this endpoint consistent with API routes)
+  // and instead only link when the holdout and experiment go live
   if (holdoutExperimentToLink && feature.holdout?.id) {
     await updateExperiment({
       context,

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -2914,11 +2914,31 @@ export async function postFeatureRule(
     rule.safeRolloutId = generateId("sr_");
   }
 
+  // Determine the holdout that will be live when this rule's revision is
+  // published: the target draft's holdout when editing an existing draft,
+  // otherwise the live feature's (a new draft branched from live carries
+  // feature.holdout forward). Checking the draft — not just live — lets a
+  // holdout added in the same draft satisfy the compatibility rules below.
+  // Read-only here so a rejection never leaves a stray draft behind.
+  let effectiveHoldout = feature.holdout ?? null;
+  if (parseInt(version) !== feature.version) {
+    const targetRevision = await getRevision({
+      context,
+      organization: feature.organization,
+      featureId: feature.id,
+      feature,
+      version: parseInt(version),
+    });
+    if (targetRevision) {
+      effectiveHoldout = targetRevision.holdout ?? null;
+    }
+  }
+
   // Add holdout to existing experiment and experiment to holdout linkedExperiments
   // if the experiment is not running and has no linked implementations for
   // experiment-ref rules (writes deferred until after custom-hook prevalidation)
   let holdoutExperimentToLink: ExperimentInterface | null = null;
-  if (rule.type === "experiment-ref" && feature.holdout?.id) {
+  if (rule.type === "experiment-ref" && effectiveHoldout?.id) {
     const experiment = await getExperimentById(context, rule.experimentId);
 
     if (experiment?.status !== "draft") {
@@ -2935,20 +2955,35 @@ export async function postFeatureRule(
         `Cannot add experiment rule: this feature uses a holdout, but the experiment already has linked features, URL redirects, or visual changesets. Unlink them first.`,
       );
     }
-    if (experiment.holdoutId && experiment.holdoutId !== feature.holdout.id) {
+    if (experiment.holdoutId && experiment.holdoutId !== effectiveHoldout.id) {
       const featureHoldout = await context.models.holdout.getById(
-        feature.holdout.id,
+        effectiveHoldout.id,
       );
       const expHoldout = experiment.holdoutId
         ? await context.models.holdout.getById(experiment.holdoutId)
         : null;
       throw new Error(
-        `Cannot add experiment rule: experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}" but this feature uses holdout "${featureHoldout?.name || feature.holdout.id}".`,
+        `Cannot add experiment rule: experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}" but this feature uses holdout "${featureHoldout?.name || effectiveHoldout.id}".`,
       );
     }
 
     if (!experiment.holdoutId) {
       holdoutExperimentToLink = experiment;
+    }
+  } else if (rule.type === "experiment-ref" && !effectiveHoldout?.id) {
+    // Block adding a holdout-bound experiment to a feature/draft that is not in
+    // a holdout. Holdout gating is applied per-feature at payload build time
+    // (via feature.holdout), so the experiment would run with no holdout
+    // carve-out and its analysis would be wrong. Require the feature to join the
+    // holdout first — either in this draft or a published revision.
+    const experiment = await getExperimentById(context, rule.experimentId);
+    if (experiment?.holdoutId) {
+      const expHoldout = await context.models.holdout.getById(
+        experiment.holdoutId,
+      );
+      throw new Error(
+        `Cannot add experiment rule: this experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}", but this feature is not in a holdout. Add the feature to that holdout first, then add the experiment.`,
+      );
     }
   }
 

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -3500,6 +3500,66 @@ export async function postFeatureExperimentRefRule(
     : forceNewDraft
       ? feature.version
       : (draftVersion ?? feature.version);
+
+  // Reconcile holdout membership between the experiment and the feature/draft,
+  // mirroring postFeatureRule so linking a feature from an experiment obeys the
+  // same invariant. Draft-aware: read the target draft's holdout read-only, so a
+  // rejection here never creates a stray draft.
+  let effectiveHoldout = feature.holdout ?? null;
+  if (targetVersion !== feature.version) {
+    const targetRevision = await getRevision({
+      context,
+      organization: feature.organization,
+      featureId: feature.id,
+      feature,
+      version: targetVersion,
+    });
+    if (targetRevision) effectiveHoldout = targetRevision.holdout ?? null;
+  }
+
+  let holdoutExperimentToLink: ExperimentInterface | null = null;
+  if (effectiveHoldout?.id) {
+    if (experiment.holdoutId && experiment.holdoutId !== effectiveHoldout.id) {
+      const featureHoldout = await context.models.holdout.getById(
+        effectiveHoldout.id,
+      );
+      const expHoldout = await context.models.holdout.getById(
+        experiment.holdoutId,
+      );
+      throw new Error(
+        `Cannot add experiment rule: experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}" but this feature uses holdout "${featureHoldout?.name || effectiveHoldout.id}".`,
+      );
+    }
+    // A holdout-free experiment joining a holdout feature must be safe to pull
+    // into the holdout; if so it's linked below (mirroring postFeatureRule).
+    // When the experiment is already in this holdout there's nothing to do.
+    if (!experiment.holdoutId) {
+      if (experiment.status !== "draft") {
+        throw new Error(
+          `Cannot add experiment rule: this feature uses a holdout, so the experiment must be in "draft" status (currently "${experiment.status}").`,
+        );
+      }
+      const expHasOtherLinkedChanges =
+        (experiment.linkedFeatures?.some((fid) => fid !== feature.id) ??
+          false) ||
+        experiment.hasURLRedirects ||
+        experiment.hasVisualChangesets;
+      if (expHasOtherLinkedChanges) {
+        throw new Error(
+          `Cannot add experiment rule: this feature uses a holdout, but the experiment already has linked features, URL redirects, or visual changesets. Unlink them first.`,
+        );
+      }
+      holdoutExperimentToLink = experiment;
+    }
+  } else if (experiment.holdoutId) {
+    const expHoldout = await context.models.holdout.getById(
+      experiment.holdoutId,
+    );
+    throw new Error(
+      `Cannot add experiment rule: this experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}", but this feature is not in a holdout. Add the feature to that holdout first, then add the experiment.`,
+    );
+  }
+
   const revision = await getDraftRevision(context, feature, targetVersion);
 
   // One-way: any rule-footprint env that's currently off flips on. We never
@@ -3630,6 +3690,27 @@ export async function postFeatureExperimentRefRule(
     feature.id,
     experiment,
   );
+
+  // Link the experiment into the feature's holdout when that holdout is already
+  // live. If it exists only in the draft, linking defers to publish via
+  // applyHoldoutSideEffects (the experiment is now in feature.linkedExperiments).
+  if (holdoutExperimentToLink && feature.holdout?.id) {
+    await updateExperiment({
+      context,
+      experiment: holdoutExperimentToLink,
+      changes: { holdoutId: feature.holdout.id },
+    });
+    const holdout = await context.models.holdout.getById(feature.holdout.id);
+    await context.models.holdout.updateById(feature.holdout.id, {
+      linkedExperiments: {
+        ...holdout?.linkedExperiments,
+        [holdoutExperimentToLink.id]: {
+          id: holdoutExperimentToLink.id,
+          dateAdded: new Date(),
+        },
+      },
+    });
+  }
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -125,7 +125,10 @@ import {
   assertCanAutoPublish,
   revisionRequiresReview,
 } from "back-end/src/services/features";
-import { resolveHoldoutExperimentToLink } from "back-end/src/services/holdouts";
+import {
+  linkExperimentToHoldout,
+  resolveHoldoutExperimentToLink,
+} from "back-end/src/services/holdouts";
 import { assertFeatureArchiveDependentsGuard } from "back-end/src/services/archiveDependentsGuard";
 import { getResolvableValues } from "back-end/src/services/resolvableValues";
 import { assertConfigBackedFeatureValuesValid } from "back-end/src/services/configValidation";
@@ -3097,23 +3100,11 @@ export async function postFeatureRule(
   // TODO(holdouts): remove code below (which makes this endpoint consistent with API routes)
   // and instead only link when the holdout and experiment go live
   if (holdoutExperimentToLink && feature.holdout?.id) {
-    await updateExperiment({
+    await linkExperimentToHoldout(
       context,
-      experiment: holdoutExperimentToLink,
-      changes: {
-        holdoutId: feature.holdout.id,
-      },
-    });
-    const holdout = await context.models.holdout.getById(feature.holdout.id);
-    await context.models.holdout.updateById(feature.holdout.id, {
-      linkedExperiments: {
-        ...holdout?.linkedExperiments,
-        [holdoutExperimentToLink.id]: {
-          id: holdoutExperimentToLink.id,
-          dateAdded: new Date(),
-        },
-      },
-    });
+      holdoutExperimentToLink,
+      feature.holdout.id,
+    );
   }
 
   const auditSubject =
@@ -3602,21 +3593,11 @@ export async function postFeatureExperimentRefRule(
   // TODO(holdouts): remove code below (which makes this endpoint consistent with API routes)
   // and instead only link when the holdout and experiment go live
   if (holdoutExperimentToLink && feature.holdout?.id) {
-    await updateExperiment({
+    await linkExperimentToHoldout(
       context,
-      experiment: holdoutExperimentToLink,
-      changes: { holdoutId: feature.holdout.id },
-    });
-    const holdout = await context.models.holdout.getById(feature.holdout.id);
-    await context.models.holdout.updateById(feature.holdout.id, {
-      linkedExperiments: {
-        ...holdout?.linkedExperiments,
-        [holdoutExperimentToLink.id]: {
-          id: holdoutExperimentToLink.id,
-          dateAdded: new Date(),
-        },
-      },
-    });
+      holdoutExperimentToLink,
+      feature.holdout.id,
+    );
   }
 
   res.status(200).json({

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -3099,12 +3099,17 @@ export async function postFeatureRule(
 
   // TODO(holdouts): remove code below (which makes this endpoint consistent with API routes)
   // and instead only link when the holdout and experiment go live
-  if (holdoutExperimentToLink && feature.holdout?.id) {
-    await linkExperimentToHoldout(
-      context,
-      holdoutExperimentToLink,
-      feature.holdout.id,
-    );
+  if (holdoutExperimentToLink && effectiveHoldout?.id) {
+    // Link now only when the validated holdout is already live. A draft-only
+    // holdout defers to publish — applyHoldoutSideEffects enrolls the
+    // experiments in the merged rules when the holdout change lands.
+    if (feature.holdout?.id === effectiveHoldout.id) {
+      await linkExperimentToHoldout(
+        context,
+        holdoutExperimentToLink,
+        effectiveHoldout.id,
+      );
+    }
   }
 
   const auditSubject =
@@ -3592,12 +3597,17 @@ export async function postFeatureExperimentRefRule(
 
   // TODO(holdouts): remove code below (which makes this endpoint consistent with API routes)
   // and instead only link when the holdout and experiment go live
-  if (holdoutExperimentToLink && feature.holdout?.id) {
-    await linkExperimentToHoldout(
-      context,
-      holdoutExperimentToLink,
-      feature.holdout.id,
-    );
+  if (holdoutExperimentToLink && effectiveHoldout?.id) {
+    // Link now only when the validated holdout is already live. A draft-only
+    // holdout defers to publish — applyHoldoutSideEffects enrolls the
+    // experiments in the merged rules when the holdout change lands.
+    if (feature.holdout?.id === effectiveHoldout.id) {
+      await linkExperimentToHoldout(
+        context,
+        holdoutExperimentToLink,
+        effectiveHoldout.id,
+      );
+    }
   }
 
   res.status(200).json({

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -124,6 +124,7 @@ import {
   assertCanAutoPublish,
   revisionRequiresReview,
 } from "back-end/src/services/features";
+import { resolveHoldoutExperimentToLink } from "back-end/src/services/holdouts";
 import { assertFeatureArchiveDependentsGuard } from "back-end/src/services/archiveDependentsGuard";
 import { getResolvableValues } from "back-end/src/services/resolvableValues";
 import { assertConfigBackedFeatureValuesValid } from "back-end/src/services/configValidation";
@@ -2934,47 +2935,20 @@ export async function postFeatureRule(
   // if the experiment is not running and has no linked implementations for
   // experiment-ref rules (writes deferred until after custom-hook prevalidation)
   let holdoutExperimentToLink: ExperimentInterface | null = null;
-  if (rule.type === "experiment-ref" && effectiveHoldout?.id) {
+  if (rule.type === "experiment-ref") {
     const experiment = await getExperimentById(context, rule.experimentId);
-
-    if (experiment?.status !== "draft") {
-      throw new Error(
-        `Cannot add experiment rule: this feature uses a holdout, so the experiment must be in "draft" status (currently "${experiment?.status ?? "unknown"}").`,
-      );
+    // With a holdout in play the experiment must exist; without one, a missing
+    // experiment is left for downstream validation (preserves prior behavior).
+    if (effectiveHoldout?.id && !experiment) {
+      throw new Error(`Could not find experiment "${rule.experimentId}"`);
     }
-    const expHasLinkedChanges =
-      (experiment.linkedFeatures?.length ?? 0) > 0 ||
-      experiment.hasURLRedirects ||
-      experiment.hasVisualChangesets;
-    if (expHasLinkedChanges) {
-      throw new Error(
-        `Cannot add experiment rule: this feature uses a holdout, but the experiment already has linked features, URL redirects, or visual changesets. Unlink them first.`,
-      );
-    }
-    if (experiment.holdoutId && experiment.holdoutId !== effectiveHoldout.id) {
-      const featureHoldout = await context.models.holdout.getById(
-        effectiveHoldout.id,
-      );
-      const expHoldout = experiment.holdoutId
-        ? await context.models.holdout.getById(experiment.holdoutId)
-        : null;
-      throw new Error(
-        `Cannot add experiment rule: experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}" but this feature uses holdout "${featureHoldout?.name || effectiveHoldout.id}".`,
-      );
-    }
-
-    if (!experiment.holdoutId) {
-      holdoutExperimentToLink = experiment;
-    }
-  } else if (rule.type === "experiment-ref" && !effectiveHoldout?.id) {
-    const experiment = await getExperimentById(context, rule.experimentId);
-    if (experiment?.holdoutId) {
-      const expHoldout = await context.models.holdout.getById(
-        experiment.holdoutId,
-      );
-      throw new Error(
-        `Cannot add experiment rule: this experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}", but this feature is not in a holdout. Add the feature to that holdout first, then add the experiment.`,
-      );
+    if (experiment) {
+      holdoutExperimentToLink = await resolveHoldoutExperimentToLink({
+        context,
+        feature,
+        experiment,
+        effectiveHoldout,
+      });
     }
   }
 
@@ -3506,45 +3480,13 @@ export async function postFeatureExperimentRefRule(
     if (targetRevision) effectiveHoldout = targetRevision.holdout ?? null;
   }
 
-  let holdoutExperimentToLink: ExperimentInterface | null = null;
-  if (effectiveHoldout?.id) {
-    if (experiment.holdoutId && experiment.holdoutId !== effectiveHoldout.id) {
-      const featureHoldout = await context.models.holdout.getById(
-        effectiveHoldout.id,
-      );
-      const expHoldout = await context.models.holdout.getById(
-        experiment.holdoutId,
-      );
-      throw new Error(
-        `Cannot add experiment rule: experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}" but this feature uses holdout "${featureHoldout?.name || effectiveHoldout.id}".`,
-      );
-    }
-    if (!experiment.holdoutId) {
-      if (experiment.status !== "draft") {
-        throw new Error(
-          `Cannot add experiment rule: this feature uses a holdout, so the experiment must be in "draft" status (currently "${experiment.status}").`,
-        );
-      }
-      const expHasOtherLinkedChanges =
-        (experiment.linkedFeatures?.some((fid) => fid !== feature.id) ??
-          false) ||
-        experiment.hasURLRedirects ||
-        experiment.hasVisualChangesets;
-      if (expHasOtherLinkedChanges) {
-        throw new Error(
-          `Cannot add experiment rule: this feature uses a holdout, but the experiment already has linked features, URL redirects, or visual changesets. Unlink them first.`,
-        );
-      }
-      holdoutExperimentToLink = experiment;
-    }
-  } else if (experiment.holdoutId) {
-    const expHoldout = await context.models.holdout.getById(
-      experiment.holdoutId,
-    );
-    throw new Error(
-      `Cannot add experiment rule: this experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}", but this feature is not in a holdout. Add the feature to that holdout first, then add the experiment.`,
-    );
-  }
+  const holdoutExperimentToLink = await resolveHoldoutExperimentToLink({
+    context,
+    feature,
+    experiment,
+    effectiveHoldout,
+    allowExistingLinkToThisFeature: true,
+  });
 
   const revision = await getDraftRevision(context, feature, targetVersion);
 

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -1740,54 +1740,133 @@ export async function applyRevisionChanges(
   return await updateFeature(context, feature, changes);
 }
 
+// Refuse to remove/change a feature's holdout while a linked experiment still
+// belongs to it. We deliberately do NOT auto-unlink the experiment: doing so
+// would silently mutate a possibly-running experiment (and can't be right when
+// the experiment is shared with other features). Instead the user detaches the
+// experiment side explicitly first — either remove the experiment rule from the
+// feature, or remove the experiment from the holdout on the experiment.
+export async function assertNoLinkedHoldoutExperiments(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  holdoutId: string,
+) {
+  const linked = await Promise.all(
+    (feature.linkedExperiments ?? []).map((eid) =>
+      getExperimentById(context, eid),
+    ),
+  );
+  const stillInHoldout = linked
+    .filter(
+      (exp): exp is NonNullable<typeof exp> =>
+        !!exp && exp.holdoutId === holdoutId,
+    )
+    .map((exp) => `"${exp.name}"`);
+  if (stillInHoldout.length) {
+    const plural = stillInHoldout.length > 1;
+    throw new Error(
+      `Cannot remove the holdout while experiment${plural ? "s" : ""} ${stillInHoldout.join(
+        ", ",
+      )} ${plural ? "are" : "is"} linked to this feature and in the holdout. ` +
+        `Remove the experiment rule from this feature, or remove the experiment from the holdout, first.`,
+    );
+  }
+}
+
+// Read-only guard for a holdout membership change. Extracted from
+// `applyHoldoutSideEffects` so publish paths can run it BEFORE mutating the
+// feature: `applyRevisionChanges` advances `feature.version` and writes
+// `feature.holdout`, so a guard that throws afterward would strand the feature
+// pointing at a still-draft revision (the "live version is actually a draft"
+// corruption). Runs nothing side-effecting, so callers can invoke it up front.
+//
+// `rules` should be the feature's POST-publish rule set (the revision's merged
+// rules), not the stale live `feature.rules` — otherwise a draft that bundles a
+// new experiment-ref for an already-running experiment slips past the guard.
+export async function assertHoldoutChangeAllowed(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  newHoldout: { id: string; value: string } | null,
+  rules: FeatureRule[],
+  // `isRevert` skips the guard — a rollback restores a previously-valid holdout
+  // state (the caller reverts the transiently-blocking rules moments later), so
+  // this create-time check would wrongly refuse it.
+  { isRevert }: { isRevert?: boolean } = {},
+) {
+  if (isRevert) return;
+
+  const prevHoldoutId = feature.holdout?.id;
+  const newHoldoutId = newHoldout?.id;
+
+  // No change.
+  if (newHoldoutId === prevHoldoutId) return;
+
+  // Leaving the current holdout (removal, or a change to a different one):
+  // refuse while any linked experiment still belongs to it. The user detaches
+  // the experiment side first rather than us silently unlinking it.
+  if (prevHoldoutId) {
+    await assertNoLinkedHoldoutExperiments(context, feature, prevHoldoutId);
+  }
+
+  // Pure removal: nothing further to validate.
+  if (newHoldout === null) return;
+
+  // Adding or changing to a holdout: the feature's post-publish rules must not
+  // carry running experiments, bandits, or safe rollouts.
+  const currentExperimentIds = (rules ?? [])
+    .filter((rule) => rule.type === "experiment-ref")
+    .map((rule) => rule.experimentId);
+  const experimentResults = await Promise.all(
+    currentExperimentIds.map((id) => getExperimentById(context, id)),
+  );
+  // Filter out deleted experiments (null/undefined) before checking status
+  const experiments = experimentResults.filter(
+    (exp): exp is NonNullable<typeof exp> => exp !== null && exp !== undefined,
+  );
+  const hasNonDraftExperiments = experiments.some(
+    (exp) => exp.status !== "draft",
+  );
+  const hasBandits = experiments.some(
+    (exp) => exp.type === "multi-armed-bandit",
+  );
+  const hasSafeRollouts = (rules ?? []).some(
+    (rule) => rule?.type === "safe-rollout",
+  );
+  if (hasNonDraftExperiments || hasBandits || hasSafeRollouts) {
+    throw new Error(
+      "Cannot change holdout when there are running linked experiments, safe rollout rules, or multi-armed bandit rules",
+    );
+  }
+}
+
 // Run HoldoutModel / Experiment side-effects when a feature's holdout
 // membership changes at publish. Called from `publishRevision` when
 // `result.holdout` is defined, so all publish paths (direct, approval,
 // revert, etc.) are covered. `feature` is pre-publish (used for prevHoldout);
 // `newHoldout: null` means "remove from holdout".
+
 export async function applyHoldoutSideEffects(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
   newHoldout: { id: string; value: string } | null,
-  // `isRevert` skips the guard below — a rollback restores a previously-valid
-  // holdout state (the caller reverts the transiently-blocking rules moments
-  // later), so this create-time check would wrongly refuse it.
-  { isRevert }: { isRevert?: boolean } = {},
+  // `isRevert` skips the guard — see assertHoldoutChangeAllowed. `skipGuard` is
+  // set by callers that already ran assertHoldoutChangeAllowed BEFORE mutating
+  // the feature, so the guard isn't re-run against the stale live rules here.
+  { isRevert, skipGuard }: { isRevert?: boolean; skipGuard?: boolean } = {},
 ) {
   const prevHoldoutId = feature.holdout?.id;
   const newHoldoutId = newHoldout?.id;
 
   if (newHoldoutId === prevHoldoutId) return;
 
-  // Guard: cannot change holdout when there are running experiments, bandits, or safe rollouts
-  if (newHoldout !== null && !isRevert) {
-    // Only check experiments currently in the feature's rules, not the historical
-    // linkedExperiments list (which is kept for revision rendering).
-    const currentExperimentIds = (feature.rules ?? [])
-      .filter((rule) => rule.type === "experiment-ref")
-      .map((rule) => rule.experimentId);
-    const experimentResults = await Promise.all(
-      currentExperimentIds.map((id) => getExperimentById(context, id)),
+  if (!skipGuard) {
+    await assertHoldoutChangeAllowed(
+      context,
+      feature,
+      newHoldout,
+      feature.rules ?? [],
+      { isRevert },
     );
-    // Filter out deleted experiments (null/undefined) before checking status
-    const experiments = experimentResults.filter(
-      (exp): exp is NonNullable<typeof exp> =>
-        exp !== null && exp !== undefined,
-    );
-    const hasNonDraftExperiments = experiments.some(
-      (exp) => exp.status !== "draft",
-    );
-    const hasBandits = experiments.some(
-      (exp) => exp.type === "multi-armed-bandit",
-    );
-    const hasSafeRollouts = (feature.rules ?? []).some(
-      (rule) => rule?.type === "safe-rollout",
-    );
-    if (hasNonDraftExperiments || hasBandits || hasSafeRollouts) {
-      throw new Error(
-        "Cannot change holdout when there are running linked experiments, safe rollout rules, or multi-armed bandit rules",
-      );
-    }
   }
 
   // Resolve the new holdout BEFORE removing from the old one, so a missing
@@ -1799,7 +1878,10 @@ export async function applyHoldoutSideEffects(
     throw new Error("Holdout not found");
   }
 
-  // Remove feature from the old holdout
+  // Remove feature from the old holdout. The guard (assertHoldoutChangeAllowed)
+  // has already refused this move if any linked experiment still belongs to the
+  // old holdout, so there's nothing to cascade here — the experiment side is
+  // detached explicitly by the user first.
   if (prevHoldoutId) {
     await context.models.holdout.removeFeatureFromHoldout(
       prevHoldoutId,
@@ -2718,6 +2800,20 @@ export async function publishRevision({
     skipValidation: skipPrevalidateValidation,
   });
 
+  // Guard the holdout change BEFORE any mutation. applyRevisionChanges (below)
+  // advances feature.version and writes feature.holdout; if the holdout guard
+  // ran only afterward and threw, the feature would be left pointing at this
+  // still-draft revision. Check the revision's merged rules (post-publish state)
+  // so a bundled experiment-ref for an already-running experiment is caught.
+  if (result.holdout !== undefined) {
+    await assertHoldoutChangeAllowed(
+      context,
+      feature,
+      result.holdout,
+      result.rules ?? feature.rules ?? [],
+    );
+  }
+
   // Create ramp schedules BEFORE writing the feature so that a schedule
   // creation failure gates the publish (atomicity: no published feature without
   // its ramp schedule).
@@ -2749,7 +2845,10 @@ export async function publishRevision({
     );
 
     if (result.holdout !== undefined) {
-      await applyHoldoutSideEffects(context, feature, result.holdout);
+      // Guard already ran above (before any mutation) — skip the re-check.
+      await applyHoldoutSideEffects(context, feature, result.holdout, {
+        skipGuard: true,
+      });
     }
 
     await markRevisionAsPublished(

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -1761,16 +1761,21 @@ export async function applyHoldoutSideEffects(
 
   // Guard: cannot change holdout when there are running experiments, bandits, or safe rollouts
   if (newHoldout !== null && !isRevert) {
-    const experiments = await Promise.all(
+    const experimentResults = await Promise.all(
       (feature.linkedExperiments ?? []).map((id) =>
         getExperimentById(context, id),
       ),
     );
+    // Filter out deleted experiments (null/undefined) before checking status
+    const experiments = experimentResults.filter(
+      (exp): exp is NonNullable<typeof exp> =>
+        exp !== null && exp !== undefined,
+    );
     const hasNonDraftExperiments = experiments.some(
-      (exp) => exp?.status !== "draft",
+      (exp) => exp.status !== "draft",
     );
     const hasBandits = experiments.some(
-      (exp) => exp?.type === "multi-armed-bandit",
+      (exp) => exp.type === "multi-armed-bandit",
     );
     const hasSafeRollouts = (feature.rules ?? []).some(
       (rule) => rule?.type === "safe-rollout",

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -2850,9 +2850,16 @@ export async function publishRevision({
 
     if (result.holdout !== undefined) {
       // Guard already ran above (before any mutation) — skip the re-check.
-      await applyHoldoutSideEffects(context, feature, result.holdout, {
-        skipGuard: true,
-      });
+      // Pass the POST-publish rules: side effects enroll the experiments in
+      // the feature's rules, and a draft can add the holdout and the
+      // experiment-ref rule together — the pre-publish rules would miss it
+      // (the deferred half of the eager-link-at-rule-add flow).
+      await applyHoldoutSideEffects(
+        context,
+        { ...feature, rules: result.rules ?? feature.rules },
+        result.holdout,
+        { skipGuard: true },
+      );
     }
 
     await markRevisionAsPublished(

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -1740,17 +1740,13 @@ export async function applyRevisionChanges(
   return await updateFeature(context, feature, changes);
 }
 
-// Refuse to remove/change a feature's holdout while a linked experiment still
-// belongs to it. We deliberately do NOT auto-unlink the experiment: doing so
-// would silently mutate a possibly-running experiment (and can't be right when
-// the experiment is shared with other features).
+// Refuse to remove/change a feature's holdout while an experiment in the current
+// draft is linked to the holdout.
 export async function assertNoLinkedHoldoutExperiments(
   context: ReqContext | ApiReqContext,
-  feature: FeatureInterface,
   holdoutId: string,
-  // The feature's post-publish rules (revision's merged rules), defaulting to
-  // the live rules. Folded in alongside linkedExperiments below.
-  rules?: FeatureRule[],
+  // The feature's post-publish rules (revision's merged rules)
+  rules: FeatureRule[],
 ) {
   // Union of two views of "experiments attached to this feature":
   //  - linkedExperiments: catches enrollments whose experiment-ref rule is still
@@ -1759,16 +1755,14 @@ export async function assertNoLinkedHoldoutExperiments(
   //    has drifted from the rules.
   // Either one being in this holdout means removing the feature's holdout would
   // strand that experiment, so block on the union.
-  const ruleExperimentIds = (rules ?? feature.rules ?? [])
+  const experimentIds = rules
     .filter((rule) => rule.type === "experiment-ref")
     .map((rule) => rule.experimentId);
-  const experimentIds = Array.from(
-    new Set([...(feature.linkedExperiments ?? []), ...ruleExperimentIds]),
-  );
-  const linked = await Promise.all(
+
+  const experiments = await Promise.all(
     experimentIds.map((eid) => getExperimentById(context, eid)),
   );
-  const stillInHoldout = linked
+  const stillInHoldout = experiments
     .filter(
       (exp): exp is NonNullable<typeof exp> =>
         !!exp && exp.holdoutId === holdoutId,
@@ -1779,8 +1773,8 @@ export async function assertNoLinkedHoldoutExperiments(
     throw new Error(
       `Cannot remove the holdout while experiment${plural ? "s" : ""} ${stillInHoldout.join(
         ", ",
-      )} ${plural ? "are" : "is"} linked to this feature and in the holdout. ` +
-        `Remove the experiment rule from this feature, or remove the experiment from the holdout, first.`,
+      )} ${plural ? "are" : "is"} in the rules for this feature and in the holdout. ` +
+        `Remove the experiment rule from this feature first or in the same draft.`,
     );
   }
 }
@@ -1808,22 +1802,17 @@ export async function assertHoldoutChangeAllowed(
   if (newHoldoutId === prevHoldoutId) return;
 
   // Leaving the current holdout (removal, or a change to a different one):
-  // refuse while any linked experiment still belongs to it. The user detaches
+  // refuse while any experiment in the rules for this feature still belongs to it. The user detaches
   // the experiment side first rather than us silently unlinking it.
   if (prevHoldoutId) {
-    await assertNoLinkedHoldoutExperiments(
-      context,
-      feature,
-      prevHoldoutId,
-      rules,
-    );
+    await assertNoLinkedHoldoutExperiments(context, prevHoldoutId, rules);
   }
 
   // Pure removal: nothing further to validate.
   if (newHoldout === null) return;
 
   // Adding or changing to a holdout: the feature's post-publish rules must not
-  // carry running experiments, bandits, or safe rollouts.
+  // carry running experiments in a different holdout, bandits, or safe rollouts.
   const currentExperimentIds = (rules ?? [])
     .filter((rule) => rule.type === "experiment-ref")
     .map((rule) => rule.experimentId);
@@ -1834,8 +1823,8 @@ export async function assertHoldoutChangeAllowed(
   const experiments = experimentResults.filter(
     (exp): exp is NonNullable<typeof exp> => exp !== null && exp !== undefined,
   );
-  const hasNonDraftExperiments = experiments.some(
-    (exp) => exp.status !== "draft",
+  const hasNonDraftExperimentsInDifferentHoldout = experiments.some(
+    (exp) => exp.status !== "draft" && exp.holdoutId !== newHoldoutId,
   );
   const hasBandits = experiments.some(
     (exp) => exp.type === "multi-armed-bandit",
@@ -1843,9 +1832,13 @@ export async function assertHoldoutChangeAllowed(
   const hasSafeRollouts = (rules ?? []).some(
     (rule) => rule?.type === "safe-rollout",
   );
-  if (hasNonDraftExperiments || hasBandits || hasSafeRollouts) {
+  if (
+    hasNonDraftExperimentsInDifferentHoldout ||
+    hasBandits ||
+    hasSafeRollouts
+  ) {
     throw new Error(
-      "Cannot change holdout when there are running linked experiments, safe rollout rules, or multi-armed bandit rules",
+      "Cannot change holdout when there are running linked experiments in different holdouts, safe rollout rules, or multi-armed bandit rules",
     );
   }
 }

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -1741,20 +1741,13 @@ export async function applyRevisionChanges(
 }
 
 // Refuse to remove/change a feature's holdout while an experiment in the current
-// draft is linked to the holdout.
+// draft rules for this feature is linked to the holdout.
 export async function assertNoLinkedHoldoutExperiments(
   context: ReqContext | ApiReqContext,
   holdoutId: string,
   // The feature's post-publish rules (revision's merged rules)
   rules: FeatureRule[],
 ) {
-  // Union of two views of "experiments attached to this feature":
-  //  - linkedExperiments: catches enrollments whose experiment-ref rule is still
-  //    only in a draft (e.g. create-from-experiment) — live rules would miss it.
-  //  - experiment-ref rules: forward-looking, and a backstop if linkedExperiments
-  //    has drifted from the rules.
-  // Either one being in this holdout means removing the feature's holdout would
-  // strand that experiment, so block on the union.
   const experimentIds = rules
     .filter((rule) => rule.type === "experiment-ref")
     .map((rule) => rule.experimentId);
@@ -1892,18 +1885,26 @@ export async function applyHoldoutSideEffects(
     );
   }
 
-  // Link feature (and its experiments) to the new holdout
+  // Link feature (and experiments in its rules) to the new holdout.
   if (newHoldoutId && holdoutObj) {
+    const ruleExperimentIds = Array.from(
+      new Set(
+        (feature.rules ?? [])
+          .filter((rule) => rule.type === "experiment-ref")
+          .map((rule) => rule.experimentId),
+      ),
+    );
+
     await context.models.holdout.updateById(newHoldoutId, {
       linkedFeatures: {
         [feature.id]: { id: feature.id, dateAdded: new Date() },
         ...holdoutObj.linkedFeatures,
       },
-      ...(feature.linkedExperiments?.length
+      ...(ruleExperimentIds.length
         ? {
             linkedExperiments: {
               ...Object.fromEntries(
-                feature.linkedExperiments.map((experimentId) => [
+                ruleExperimentIds.map((experimentId) => [
                   experimentId,
                   { id: experimentId, dateAdded: new Date() },
                 ]),
@@ -1914,9 +1915,9 @@ export async function applyHoldoutSideEffects(
         : {}),
     });
 
-    if (feature.linkedExperiments?.length) {
+    if (ruleExperimentIds.length) {
       const linkedExperiments = await Promise.all(
-        feature.linkedExperiments.map((eid) => getExperimentById(context, eid)),
+        ruleExperimentIds.map((eid) => getExperimentById(context, eid)),
       );
       await Promise.all(
         linkedExperiments.map(async (exp) => {

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -1743,18 +1743,30 @@ export async function applyRevisionChanges(
 // Refuse to remove/change a feature's holdout while a linked experiment still
 // belongs to it. We deliberately do NOT auto-unlink the experiment: doing so
 // would silently mutate a possibly-running experiment (and can't be right when
-// the experiment is shared with other features). Instead the user detaches the
-// experiment side explicitly first — either remove the experiment rule from the
-// feature, or remove the experiment from the holdout on the experiment.
+// the experiment is shared with other features).
 export async function assertNoLinkedHoldoutExperiments(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
   holdoutId: string,
+  // The feature's post-publish rules (revision's merged rules), defaulting to
+  // the live rules. Folded in alongside linkedExperiments below.
+  rules?: FeatureRule[],
 ) {
+  // Union of two views of "experiments attached to this feature":
+  //  - linkedExperiments: catches enrollments whose experiment-ref rule is still
+  //    only in a draft (e.g. create-from-experiment) — live rules would miss it.
+  //  - experiment-ref rules: forward-looking, and a backstop if linkedExperiments
+  //    has drifted from the rules.
+  // Either one being in this holdout means removing the feature's holdout would
+  // strand that experiment, so block on the union.
+  const ruleExperimentIds = (rules ?? feature.rules ?? [])
+    .filter((rule) => rule.type === "experiment-ref")
+    .map((rule) => rule.experimentId);
+  const experimentIds = Array.from(
+    new Set([...(feature.linkedExperiments ?? []), ...ruleExperimentIds]),
+  );
   const linked = await Promise.all(
-    (feature.linkedExperiments ?? []).map((eid) =>
-      getExperimentById(context, eid),
-    ),
+    experimentIds.map((eid) => getExperimentById(context, eid)),
   );
   const stillInHoldout = linked
     .filter(
@@ -1773,16 +1785,10 @@ export async function assertNoLinkedHoldoutExperiments(
   }
 }
 
-// Read-only guard for a holdout membership change. Extracted from
-// `applyHoldoutSideEffects` so publish paths can run it BEFORE mutating the
-// feature: `applyRevisionChanges` advances `feature.version` and writes
-// `feature.holdout`, so a guard that throws afterward would strand the feature
-// pointing at a still-draft revision (the "live version is actually a draft"
-// corruption). Runs nothing side-effecting, so callers can invoke it up front.
-//
-// `rules` should be the feature's POST-publish rule set (the revision's merged
-// rules), not the stale live `feature.rules` — otherwise a draft that bundles a
-// new experiment-ref for an already-running experiment slips past the guard.
+// Use POST-publish rule set for `rules` so we can check for holdout compatibility
+// on the draft revision and make sure the holdout change is allowed.
+
+// Read-only so a rejection doesn't happen mid-publish and strand features.
 export async function assertHoldoutChangeAllowed(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
@@ -1805,7 +1811,12 @@ export async function assertHoldoutChangeAllowed(
   // refuse while any linked experiment still belongs to it. The user detaches
   // the experiment side first rather than us silently unlinking it.
   if (prevHoldoutId) {
-    await assertNoLinkedHoldoutExperiments(context, feature, prevHoldoutId);
+    await assertNoLinkedHoldoutExperiments(
+      context,
+      feature,
+      prevHoldoutId,
+      rules,
+    );
   }
 
   // Pure removal: nothing further to validate.
@@ -1844,7 +1855,6 @@ export async function assertHoldoutChangeAllowed(
 // `result.holdout` is defined, so all publish paths (direct, approval,
 // revert, etc.) are covered. `feature` is pre-publish (used for prevHoldout);
 // `newHoldout: null` means "remove from holdout".
-
 export async function applyHoldoutSideEffects(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
@@ -2877,6 +2887,8 @@ export async function publishRevision({
         );
       }
     }
+
+    // TODO(holdouts): undo holdout side effects if the publish failed
     throw err;
   }
 

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -1761,10 +1761,13 @@ export async function applyHoldoutSideEffects(
 
   // Guard: cannot change holdout when there are running experiments, bandits, or safe rollouts
   if (newHoldout !== null && !isRevert) {
+    // Only check experiments currently in the feature's rules, not the historical
+    // linkedExperiments list (which is kept for revision rendering).
+    const currentExperimentIds = (feature.rules ?? [])
+      .filter((rule) => rule.type === "experiment-ref")
+      .map((rule) => rule.experimentId);
     const experimentResults = await Promise.all(
-      (feature.linkedExperiments ?? []).map((id) =>
-        getExperimentById(context, id),
-      ),
+      currentExperimentIds.map((id) => getExperimentById(context, id)),
     );
     // Filter out deleted experiments (null/undefined) before checking status
     const experiments = experimentResults.filter(

--- a/packages/back-end/src/revisions/bulkPublish/featureBulkAdapter.ts
+++ b/packages/back-end/src/revisions/bulkPublish/featureBulkAdapter.ts
@@ -387,9 +387,14 @@ export const featureBulkAdapter: BulkPublishableAdapter = {
 
     if (mergeResult.holdout !== undefined) {
       // Guard already ran above (before any mutation) — skip the re-check.
-      await applyHoldoutSideEffects(context, feature, mergeResult.holdout, {
-        skipGuard: true,
-      });
+      // Pass the POST-publish rules so experiments added in the same revision
+      // are enrolled (mirrors publishRevision).
+      await applyHoldoutSideEffects(
+        context,
+        { ...feature, rules: mergeResult.rules ?? feature.rules },
+        mergeResult.holdout,
+        { skipGuard: true },
+      );
     }
   },
 

--- a/packages/back-end/src/revisions/bulkPublish/featureBulkAdapter.ts
+++ b/packages/back-end/src/revisions/bulkPublish/featureBulkAdapter.ts
@@ -5,6 +5,7 @@ import type { SafeRolloutInterface } from "shared/validators";
 import { logger } from "back-end/src/util/logger";
 import {
   applyHoldoutSideEffects,
+  assertHoldoutChangeAllowed,
   applyRampCreateActionsForRevision,
   applyRevisionChanges,
   computeRevisionMergeChanges,
@@ -315,6 +316,20 @@ export const featureBulkAdapter: BulkPublishableAdapter = {
     const desired = desiredState as unknown as FeatureDesiredState;
     const { mergeResult } = desired;
 
+    // Guard the holdout change BEFORE any mutation (ramp schedules, feature
+    // write) so a rejected change fails fast without relying on compensation to
+    // undo an already-advanced feature.version. Check the merged (post-publish)
+    // rules so a bundled experiment-ref for an already-running experiment is
+    // caught.
+    if (mergeResult.holdout !== undefined) {
+      await assertHoldoutChangeAllowed(
+        context,
+        feature,
+        mergeResult.holdout,
+        mergeResult.rules ?? feature.rules ?? [],
+      );
+    }
+
     // Ramp `create` actions run BEFORE the feature write: a schedule-creation
     // failure gates the publish, and the ids are stashed for compensation.
     desired.createdRampScheduleIds = await applyRampCreateActionsForRevision(
@@ -371,7 +386,10 @@ export const featureBulkAdapter: BulkPublishableAdapter = {
     }
 
     if (mergeResult.holdout !== undefined) {
-      await applyHoldoutSideEffects(context, feature, mergeResult.holdout);
+      // Guard already ran above (before any mutation) — skip the re-check.
+      await applyHoldoutSideEffects(context, feature, mergeResult.holdout, {
+        skipGuard: true,
+      });
     }
   },
 

--- a/packages/back-end/src/routers/holdout/holdout.controller.ts
+++ b/packages/back-end/src/routers/holdout/holdout.controller.ts
@@ -33,6 +33,7 @@ import {
 } from "back-end/src/models/ExperimentModel";
 import { deleteHoldoutAndExperiment } from "back-end/src/services/holdouts";
 import {
+  assertNoLinkedHoldoutExperiments,
   getFeature,
   getFeaturesByIds,
   removeHoldoutFromFeature,
@@ -736,6 +737,12 @@ export const deleteHoldoutFeature = async (
   ) {
     context.permissions.throwPermissionError();
   }
+
+  // Same invariant as the revision-based removal path: don't strip the holdout
+  // off a feature while a linked experiment still belongs to it, or the
+  // experiment would be left held-out with no feature gating it. Detach the
+  // experiment (remove its rule, or remove it from the holdout) first.
+  await assertNoLinkedHoldoutExperiments(context, feature, holdout.id);
 
   await removeHoldoutFromFeature(context, feature);
 

--- a/packages/back-end/src/routers/holdout/holdout.controller.ts
+++ b/packages/back-end/src/routers/holdout/holdout.controller.ts
@@ -742,7 +742,12 @@ export const deleteHoldoutFeature = async (
   // off a feature while a linked experiment still belongs to it, or the
   // experiment would be left held-out with no feature gating it. Detach the
   // experiment (remove its rule, or remove it from the holdout) first.
-  await assertNoLinkedHoldoutExperiments(context, feature, holdout.id);
+  await assertNoLinkedHoldoutExperiments(
+    context,
+    feature,
+    holdout.id,
+    feature.rules,
+  );
 
   await removeHoldoutFromFeature(context, feature);
 

--- a/packages/back-end/src/routers/holdout/holdout.controller.ts
+++ b/packages/back-end/src/routers/holdout/holdout.controller.ts
@@ -742,12 +742,7 @@ export const deleteHoldoutFeature = async (
   // off a feature while a linked experiment still belongs to it, or the
   // experiment would be left held-out with no feature gating it. Detach the
   // experiment (remove its rule, or remove it from the holdout) first.
-  await assertNoLinkedHoldoutExperiments(
-    context,
-    feature,
-    holdout.id,
-    feature.rules,
-  );
+  await assertNoLinkedHoldoutExperiments(context, holdout.id, feature.rules);
 
   await removeHoldoutFromFeature(context, feature);
 

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -57,7 +57,7 @@ export async function resolveHoldoutExperimentToLink({
         experiment.holdoutId,
       );
       throw makeError(
-        `Cannot add experiment rule: experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}" but this feature uses holdout "${featureHoldout?.name || effectiveHoldout.id}".`,
+        `Cannot add experiment rule: experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}" but this Feature Flag uses holdout "${featureHoldout?.name || effectiveHoldout.id}".`,
       );
     }
 
@@ -66,7 +66,7 @@ export async function resolveHoldoutExperimentToLink({
     if (!experiment.holdoutId) {
       if (experiment.status !== "draft") {
         throw makeError(
-          `Cannot add experiment rule: this feature uses a holdout, so the experiment must be in "draft" status (currently "${experiment.status ?? "unknown"}").`,
+          `Cannot add experiment rule: this Feature Flag uses a holdout, so the experiment must be in "draft" status (currently "${experiment.status ?? "unknown"}").`,
         );
       }
       const expHasLinkedChanges =
@@ -78,7 +78,7 @@ export async function resolveHoldoutExperimentToLink({
         experiment.hasVisualChangesets;
       if (expHasLinkedChanges) {
         throw makeError(
-          `Cannot add experiment rule: this feature uses a holdout, but the experiment already has linked features, URL redirects, or visual changesets. Unlink them first.`,
+          `Cannot add experiment rule: this Feature Flag uses a holdout, but the experiment already has linked Feature Flags, URL redirects, or visual changesets. Unlink them first.`,
         );
       }
       return experiment;
@@ -94,7 +94,7 @@ export async function resolveHoldoutExperimentToLink({
       experiment.holdoutId,
     );
     throw makeError(
-      `Cannot add experiment rule: this experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}", but this feature is not in a holdout. Add the feature to that holdout first, then add the experiment.`,
+      `Cannot add experiment rule: this experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}", but this Feature Flag is not in a holdout. Add the Feature Flag to that holdout first, then add the experiment.`,
     );
   }
 

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -1,6 +1,8 @@
 import { HoldoutInterface } from "shared/validators";
 import { ExperimentInterface } from "shared/types/experiment";
+import { FeatureInterface } from "shared/types/feature";
 import { ReqContext } from "back-end/types/request";
+import { ApiReqContext } from "back-end/types/api";
 import {
   deleteExperimentByIdForOrganization,
   getExperimentsByIds,
@@ -13,6 +15,91 @@ import {
 import { getEnvironmentIdsFromOrg } from "back-end/src/services/organizations";
 import { getAffectedSDKPayloadKeys } from "back-end/src/util/holdouts";
 import { queueSDKPayloadRefresh } from "back-end/src/services/features";
+
+/**
+ * Holdout-compatibility gate for adding an experiment-ref rule to a feature.
+ *
+ * `effectiveHoldout` is the holdout the rule will publish under, resolved by the
+ * caller (the live `feature.holdout`, or the target revision's holdout when
+ * posting to a different draft). Given the referenced `experiment`, this
+ * enforces the constraints for attaching an experiment to a holdout and returns
+ * the experiment that should be eagerly linked, or `null` when no linking is
+ * needed (experiment already in this holdout, or neither side uses a holdout).
+ *
+ * Incompatibilities throw via `makeError`, so REST handlers can surface a 400
+ * (`BadRequestError`) while controllers get a plain `Error` (the default).
+ */
+export async function resolveHoldoutExperimentToLink({
+  context,
+  feature,
+  experiment,
+  effectiveHoldout,
+  // `postFeatureExperimentRefRule` tolerates the experiment already being linked
+  // to *this* feature (create-from-experiment); the other call sites reject any
+  // pre-existing linked feature.
+  allowExistingLinkToThisFeature = false,
+  makeError = (message: string) => new Error(message),
+}: {
+  context: ReqContext | ApiReqContext;
+  feature: FeatureInterface;
+  experiment: ExperimentInterface;
+  effectiveHoldout: { id: string } | null | undefined;
+  allowExistingLinkToThisFeature?: boolean;
+  makeError?: (message: string) => Error;
+}): Promise<ExperimentInterface | null> {
+  if (effectiveHoldout?.id) {
+    // Experiment already belongs to a different holdout — refuse the mismatch.
+    if (experiment.holdoutId && experiment.holdoutId !== effectiveHoldout.id) {
+      const featureHoldout = await context.models.holdout.getById(
+        effectiveHoldout.id,
+      );
+      const expHoldout = await context.models.holdout.getById(
+        experiment.holdoutId,
+      );
+      throw makeError(
+        `Cannot add experiment rule: experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}" but this feature uses holdout "${featureHoldout?.name || effectiveHoldout.id}".`,
+      );
+    }
+
+    // Not yet linked: validate it can join the holdout, then signal the caller
+    // to perform the link.
+    if (!experiment.holdoutId) {
+      if (experiment.status !== "draft") {
+        throw makeError(
+          `Cannot add experiment rule: this feature uses a holdout, so the experiment must be in "draft" status (currently "${experiment.status ?? "unknown"}").`,
+        );
+      }
+      const expHasLinkedChanges =
+        (allowExistingLinkToThisFeature
+          ? (experiment.linkedFeatures?.some((fid) => fid !== feature.id) ??
+            false)
+          : (experiment.linkedFeatures?.length ?? 0) > 0) ||
+        experiment.hasURLRedirects ||
+        experiment.hasVisualChangesets;
+      if (expHasLinkedChanges) {
+        throw makeError(
+          `Cannot add experiment rule: this feature uses a holdout, but the experiment already has linked features, URL redirects, or visual changesets. Unlink them first.`,
+        );
+      }
+      return experiment;
+    }
+
+    // Already linked to this same holdout: nothing to do.
+    return null;
+  }
+
+  // Feature is not in a holdout, but the experiment already belongs to one.
+  if (experiment.holdoutId) {
+    const expHoldout = await context.models.holdout.getById(
+      experiment.holdoutId,
+    );
+    throw makeError(
+      `Cannot add experiment rule: this experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}", but this feature is not in a holdout. Add the feature to that holdout first, then add the experiment.`,
+    );
+  }
+
+  return null;
+}
 
 /**
  * Delete a holdout along with its underlying experiment, unlink it from its

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -17,6 +17,37 @@ import { getAffectedSDKPayloadKeys } from "back-end/src/util/holdouts";
 import { queueSDKPayloadRefresh } from "back-end/src/services/features";
 
 /**
+ * Eagerly link an experiment into a holdout: set `experiment.holdoutId` and add
+ * the experiment to the holdout's `linkedExperiments` map. The write-side
+ * companion to `resolveHoldoutExperimentToLink` — call it with the experiment
+ * that resolver returned.
+ *
+ * Callers that compensate on downstream failure should record the experiment
+ * and holdout ids BEFORE calling: the standard rollback (clear `holdoutId`,
+ * remove the map entry if present) is idempotent, so compensating a write that
+ * never happened is harmless, while the reverse ordering would leave a
+ * mid-failure (experiment written, holdout write failed) uncompensated.
+ */
+export async function linkExperimentToHoldout(
+  context: ReqContext | ApiReqContext,
+  experiment: ExperimentInterface,
+  holdoutId: string,
+): Promise<void> {
+  await updateExperiment({
+    context,
+    experiment,
+    changes: { holdoutId },
+  });
+  const holdout = await context.models.holdout.getById(holdoutId);
+  await context.models.holdout.updateById(holdoutId, {
+    linkedExperiments: {
+      ...holdout?.linkedExperiments,
+      [experiment.id]: { id: experiment.id, dateAdded: new Date() },
+    },
+  });
+}
+
+/**
  * Holdout-compatibility gate for adding an experiment-ref rule to a feature.
  *
  * `effectiveHoldout` is the holdout the rule will publish under, resolved by the
@@ -57,7 +88,7 @@ export async function resolveHoldoutExperimentToLink({
         experiment.holdoutId,
       );
       throw makeError(
-        `Cannot add experiment rule: experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}" but this Feature Flag uses holdout "${featureHoldout?.name || effectiveHoldout.id}".`,
+        `Cannot add experiment rule: experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}" but this feature flag uses holdout "${featureHoldout?.name || effectiveHoldout.id}".`,
       );
     }
 
@@ -66,7 +97,7 @@ export async function resolveHoldoutExperimentToLink({
     if (!experiment.holdoutId) {
       if (experiment.status !== "draft") {
         throw makeError(
-          `Cannot add experiment rule: this Feature Flag uses a holdout, so the experiment must be in "draft" status (currently "${experiment.status ?? "unknown"}").`,
+          `Cannot add experiment rule: this feature flag uses a holdout, so the experiment must be in "draft" status (currently "${experiment.status ?? "unknown"}").`,
         );
       }
       const expHasLinkedChanges =
@@ -78,7 +109,7 @@ export async function resolveHoldoutExperimentToLink({
         experiment.hasVisualChangesets;
       if (expHasLinkedChanges) {
         throw makeError(
-          `Cannot add experiment rule: this Feature Flag uses a holdout, but the experiment already has linked Feature Flags, URL redirects, or visual changesets. Unlink them first.`,
+          `Cannot add experiment rule: this feature flag uses a holdout, but the experiment already has linked Feature Flags, URL redirects, or visual changesets. Unlink them first.`,
         );
       }
       return experiment;
@@ -94,7 +125,7 @@ export async function resolveHoldoutExperimentToLink({
       experiment.holdoutId,
     );
     throw makeError(
-      `Cannot add experiment rule: this experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}", but this Feature Flag is not in a holdout. Add the Feature Flag to that holdout first, then add the experiment.`,
+      `Cannot add experiment rule: this experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}", but this feature flag is not in a holdout. Add the feature flag to that holdout first, then add the experiment.`,
     );
   }
 

--- a/packages/front-end/components/Experiment/holdout/RemoveFromHoldoutModal.tsx
+++ b/packages/front-end/components/Experiment/holdout/RemoveFromHoldoutModal.tsx
@@ -17,11 +17,12 @@ export default function RemoveFromHoldoutModal({
 }: Props) {
   const { apiCall } = useAuth();
 
+  // TODO(holdouts): allow removing from holdout if the experiment is not linked to a feature
+  // in the live feature revision
   const experimentIsDraft = experiment.status === "draft";
   const experimentHasLinkedChanges =
-    experiment.hasURLRedirects ||
-    experiment.hasVisualChangesets ||
-    (experiment.linkedFeatures?.length ?? 0) > 0;
+    experiment.hasURLRedirects || experiment.hasVisualChangesets; //||
+  //(experiment.linkedFeatures?.length ?? 0) > 0;
   const canRemoveFromHoldout = experimentIsDraft && !experimentHasLinkedChanges;
 
   const handleSubmit = async () => {

--- a/packages/front-end/components/Experiment/holdout/RemoveFromHoldoutModal.tsx
+++ b/packages/front-end/components/Experiment/holdout/RemoveFromHoldoutModal.tsx
@@ -21,8 +21,9 @@ export default function RemoveFromHoldoutModal({
   // in the live feature revision
   const experimentIsDraft = experiment.status === "draft";
   const experimentHasLinkedChanges =
-    experiment.hasURLRedirects || experiment.hasVisualChangesets; //||
-  //(experiment.linkedFeatures?.length ?? 0) > 0;
+    experiment.hasURLRedirects ||
+    experiment.hasVisualChangesets ||
+    (experiment.linkedFeatures?.length ?? 0) > 0;
   const canRemoveFromHoldout = experimentIsDraft && !experimentHasLinkedChanges;
 
   const handleSubmit = async () => {

--- a/packages/front-end/components/Features/AddToHoldoutModal.tsx
+++ b/packages/front-end/components/Features/AddToHoldoutModal.tsx
@@ -130,8 +130,8 @@ const AddToHoldoutModal = ({
   }, [effectiveRules, experimentsMap, selectedHoldoutId]);
 
   const hasBlockers =
-    holdoutBlockers.nonDraftExperimentsWithoutHoldout.length > 0 &&
-    holdoutBlockers.banditExperiments.length > 0 &&
+    holdoutBlockers.nonDraftExperimentsWithoutHoldout.length > 0 ||
+    holdoutBlockers.banditExperiments.length > 0 ||
     holdoutBlockers.hasSafeRollout;
 
   const showHoldoutSelect = !hasBlockers;

--- a/packages/front-end/components/Features/AddToHoldoutModal.tsx
+++ b/packages/front-end/components/Features/AddToHoldoutModal.tsx
@@ -77,7 +77,7 @@ const AddToHoldoutModal = ({
   // Categorize what would block the holdout so the warning can name each one.
   // Deleted experiments (absent from experimentsMap) don't block — they're gone.
   const holdoutBlockers = useMemo(() => {
-    const nonDraftExperiments: {
+    const nonDraftExperimentsWithoutHoldout: {
       id: string;
       name: string;
       status: string;
@@ -92,8 +92,8 @@ const AddToHoldoutModal = ({
         if (exp.type === "multi-armed-bandit") {
           banditExperiments.push({ id: exp.id, name: exp.name });
         }
-        if (exp.status !== "draft") {
-          nonDraftExperiments.push({
+        if (exp.status !== "draft" && !exp.holdoutId) {
+          nonDraftExperimentsWithoutHoldout.push({
             id: exp.id,
             name: exp.name,
             status: exp.status,
@@ -106,7 +106,7 @@ const AddToHoldoutModal = ({
     );
 
     return {
-      nonDraftExperiments,
+      nonDraftExperimentsWithoutHoldout,
       banditExperiments,
       hasSafeRollout,
     };
@@ -130,8 +130,8 @@ const AddToHoldoutModal = ({
   }, [effectiveRules, experimentsMap, selectedHoldoutId]);
 
   const hasBlockers =
-    holdoutBlockers.nonDraftExperiments.length > 0 ||
-    holdoutBlockers.banditExperiments.length > 0 ||
+    holdoutBlockers.nonDraftExperimentsWithoutHoldout.length > 0 &&
+    holdoutBlockers.banditExperiments.length > 0 &&
     holdoutBlockers.hasSafeRollout;
 
   const showHoldoutSelect = !hasBlockers;
@@ -188,10 +188,11 @@ const AddToHoldoutModal = ({
             following are resolved:
           </Text>
           <ul style={{ marginBottom: 0 }}>
-            {holdoutBlockers.nonDraftExperiments.map((exp) => (
+            {holdoutBlockers.nonDraftExperimentsWithoutHoldout.map((exp) => (
               <li key={`status-${exp.id}`}>
                 Experiment &ldquo;{exp.name}&rdquo; is {exp.status}. You
-                can&apos;t add a holdout in front of a non-draft experiment.
+                can&apos;t add a holdout in front of a non-draft experiment with
+                no holdout.
               </li>
             ))}
             {holdoutBlockers.banditExperiments.map((exp) => (

--- a/packages/front-end/components/Features/AddToHoldoutModal.tsx
+++ b/packages/front-end/components/Features/AddToHoldoutModal.tsx
@@ -56,20 +56,23 @@ const AddToHoldoutModal = ({
     defaultDraft,
   );
 
-  // Only allow adding to holdout if all existing experiments are in draft status
+  // Only check experiments currently in the feature's rules, not the historical
+  // linkedExperiments list (which is kept for revision rendering).
+  const currentExperimentIds = (feature.rules ?? [])
+    .filter((rule) => rule.type === "experiment-ref")
+    .map((rule) => rule.experimentId);
+
+  // Allow adding to holdout if all current experiments are in draft status
   // and don't have a holdoutId or have the same holdoutId as the feature.
-  // Skip deleted experiments (not in experimentsMap) since they no longer block holdout changes.
-  const experimentsAreInDraft = feature.linkedExperiments?.every(
-    (experimentId) => {
-      const exp = experimentsMap[experimentId];
-      // Skip deleted experiments - they no longer block holdout assignment
-      if (!exp) return true;
-      return (
-        exp.status === "draft" &&
-        (!exp.holdoutId || exp.holdoutId === feature.holdout?.id)
-      );
-    },
-  );
+  const experimentsAreInDraft = currentExperimentIds.every((experimentId) => {
+    const exp = experimentsMap[experimentId];
+    // Skip deleted experiments - they no longer block holdout assignment
+    if (!exp) return true;
+    return (
+      exp.status === "draft" &&
+      (!exp.holdoutId || exp.holdoutId === feature.holdout?.id)
+    );
+  });
 
   const eligibleToAddToHoldout = (feature.rules ?? []).every(
     (rule) => rule.type !== "safe-rollout",

--- a/packages/front-end/components/Features/AddToHoldoutModal.tsx
+++ b/packages/front-end/components/Features/AddToHoldoutModal.tsx
@@ -14,6 +14,7 @@ import DraftSelectorForChanges, {
   DraftMode,
 } from "@/components/Features/DraftSelectorForChanges";
 import { HoldoutSelect } from "@/components/Holdout/HoldoutSelect";
+import { useFeatureRevisionsContext } from "@/contexts/FeatureRevisionsContext";
 
 const AddToHoldoutModal = ({
   feature,
@@ -56,29 +57,86 @@ const AddToHoldoutModal = ({
     defaultDraft,
   );
 
-  // Only check experiments currently in the feature's rules, not the historical
-  // linkedExperiments list (which is kept for revision rendering).
-  const currentExperimentIds = (feature.rules ?? [])
-    .filter((rule) => rule.type === "experiment-ref")
-    .map((rule) => rule.experimentId);
+  const revisionsCtx = useFeatureRevisionsContext();
 
-  // Allow adding to holdout if all current experiments are in draft status
-  // and don't have a holdoutId or have the same holdoutId as the feature.
-  const experimentsAreInDraft = currentExperimentIds.every((experimentId) => {
-    const exp = experimentsMap[experimentId];
-    // Skip deleted experiments - they no longer block holdout assignment
-    if (!exp) return true;
-    return (
-      exp.status === "draft" &&
-      (!exp.holdoutId || exp.holdoutId === feature.holdout?.id)
+  // The rules the publish will actually evaluate depending on the draft
+  // selected in the modal.
+  const effectiveRules = useMemo(() => {
+    if (mode === "existing" && selectedDraft !== null) {
+      const draftRevision = revisionsCtx?.revisions.find(
+        (r) => r.version === selectedDraft,
+      );
+      if (draftRevision) return draftRevision.rules ?? [];
+    }
+    // Fall back to the live rules if no existing draft is selected.
+    return revisionsCtx?.baseFeature.rules ?? feature.rules ?? [];
+  }, [mode, selectedDraft, revisionsCtx, feature.rules]);
+
+  const selectedHoldoutId = form.watch("holdout")?.id ?? null;
+
+  // Categorize what would block the holdout so the warning can name each one.
+  // Deleted experiments (absent from experimentsMap) don't block — they're gone.
+  const holdoutBlockers = useMemo(() => {
+    const nonDraftExperiments: {
+      id: string;
+      name: string;
+      status: string;
+    }[] = [];
+    const banditExperiments: { id: string; name: string }[] = [];
+
+    effectiveRules
+      .filter((rule) => rule.type === "experiment-ref")
+      .forEach((rule) => {
+        const exp = experimentsMap.get(rule.experimentId);
+        if (!exp) return;
+        if (exp.type === "multi-armed-bandit") {
+          banditExperiments.push({ id: exp.id, name: exp.name });
+        }
+        if (exp.status !== "draft") {
+          nonDraftExperiments.push({
+            id: exp.id,
+            name: exp.name,
+            status: exp.status,
+          });
+        }
+      });
+
+    const hasSafeRollout = effectiveRules.some(
+      (rule) => rule.type === "safe-rollout",
     );
-  });
 
-  const eligibleToAddToHoldout = (feature.rules ?? []).every(
-    (rule) => rule.type !== "safe-rollout",
-  );
+    return {
+      nonDraftExperiments,
+      banditExperiments,
+      hasSafeRollout,
+    };
+  }, [effectiveRules, experimentsMap]);
 
-  const showHoldoutSelect = experimentsAreInDraft && eligibleToAddToHoldout;
+  // Experiments already tied to a different holdout than the one selected in
+  // this modal. This doesn't hide the selector — it just blocks submitting
+  // until the user picks the holdout those experiments already belong to.
+  const conflictingHoldoutExperiments = useMemo(() => {
+    const conflicts: { id: string; name: string }[] = [];
+    effectiveRules
+      .filter((rule) => rule.type === "experiment-ref")
+      .forEach((rule) => {
+        const exp = experimentsMap.get(rule.experimentId);
+        if (!exp) return;
+        if (exp.holdoutId && exp.holdoutId !== selectedHoldoutId) {
+          conflicts.push({ id: exp.id, name: exp.name });
+        }
+      });
+    return conflicts;
+  }, [effectiveRules, experimentsMap, selectedHoldoutId]);
+
+  const hasBlockers =
+    holdoutBlockers.nonDraftExperiments.length > 0 ||
+    holdoutBlockers.banditExperiments.length > 0 ||
+    holdoutBlockers.hasSafeRollout;
+
+  const showHoldoutSelect = !hasBlockers;
+  const canSubmit =
+    showHoldoutSelect && conflictingHoldoutExperiments.length === 0;
 
   return (
     <ModalStandard
@@ -87,55 +145,70 @@ const AddToHoldoutModal = ({
       open={true}
       trackingEventModalType="add-feature-to-holdout"
       size="lg"
-      submit={
-        showHoldoutSelect
-          ? form.handleSubmit(async (value) => {
-              const isPublish = mode === "publish";
-              const res = await apiCall<{
-                feature: FeatureInterface;
-                draftVersion?: number;
-              }>(`/feature/${feature.id}`, {
-                method: "PUT",
-                body: JSON.stringify({
-                  ...value,
-                  ...(isPublish
-                    ? { autoPublish: true }
-                    : mode === "existing" && selectedDraft !== null
-                      ? { targetDraftVersion: selectedDraft }
-                      : { forceNewDraft: true }),
-                }),
-              });
+      ctaEnabled={canSubmit}
+      submit={form.handleSubmit(async (value) => {
+        const isPublish = mode === "publish";
+        const res = await apiCall<{
+          feature: FeatureInterface;
+          draftVersion?: number;
+        }>(`/feature/${feature.id}`, {
+          method: "PUT",
+          body: JSON.stringify({
+            ...value,
+            ...(isPublish
+              ? { autoPublish: true }
+              : mode === "existing" && selectedDraft !== null
+                ? { targetDraftVersion: selectedDraft }
+                : { forceNewDraft: true }),
+          }),
+        });
 
-              await mutate();
-              const resolvedVersion =
-                res.draftVersion ??
-                (mode === "existing" ? selectedDraft : null);
-              if (resolvedVersion !== null) setVersion(resolvedVersion);
-            })
-          : undefined
-      }
+        await mutate();
+        const resolvedVersion =
+          res.draftVersion ?? (mode === "existing" ? selectedDraft : null);
+        if (resolvedVersion !== null) setVersion(resolvedVersion);
+      })}
     >
-      {(!experimentsAreInDraft || !eligibleToAddToHoldout) && (
-        <Callout status="error">
-          <Text>
-            Holdouts cannot be added to features with safe rollout rules or
-            experiments that are not in a draft state.
+      <DraftSelectorForChanges
+        feature={feature}
+        revisionList={revisionList}
+        mode={mode}
+        setMode={setMode}
+        selectedDraft={selectedDraft}
+        setSelectedDraft={setSelectedDraft}
+        canAutoPublish={false}
+        gatedEnvSet={gatedEnvSet}
+      />
+
+      {hasBlockers && (
+        <Callout status="error" mt="3">
+          <Text as="div">
+            A holdout can&apos;t be added to{" "}
+            {mode === "existing" ? "this draft" : "this Feature Flag"} until the
+            following are resolved:
           </Text>
+          <ul style={{ marginBottom: 0 }}>
+            {holdoutBlockers.nonDraftExperiments.map((exp) => (
+              <li key={`status-${exp.id}`}>
+                Experiment &ldquo;{exp.name}&rdquo; is {exp.status}. You
+                can&apos;t add a holdout in front of a non-draft experiment.
+              </li>
+            ))}
+            {holdoutBlockers.banditExperiments.map((exp) => (
+              <li key={`bandit-${exp.id}`}>
+                &ldquo;{exp.name}&rdquo; is a Bandit, which can&apos;t run under
+                a holdout.
+              </li>
+            ))}
+            {holdoutBlockers.hasSafeRollout && (
+              <li>Remove the safe rollout rule before adding a holdout.</li>
+            )}
+          </ul>
         </Callout>
       )}
 
       {showHoldoutSelect && (
         <>
-          <DraftSelectorForChanges
-            feature={feature}
-            revisionList={revisionList}
-            mode={mode}
-            setMode={setMode}
-            selectedDraft={selectedDraft}
-            setSelectedDraft={setSelectedDraft}
-            canAutoPublish={false}
-            gatedEnvSet={gatedEnvSet}
-          />
           <HoldoutSelect
             selectedProject={feature.project}
             setHoldout={(holdoutId) => {
@@ -144,9 +217,26 @@ const AddToHoldoutModal = ({
                 value: feature.defaultValue,
               });
             }}
-            selectedHoldoutId={form.watch("holdout")?.id}
+            selectedHoldoutId={selectedHoldoutId ?? undefined}
             formType="feature"
           />
+
+          {conflictingHoldoutExperiments.length > 0 && (
+            <Callout status="error" mt="3">
+              <Text as="div">
+                The selected holdout doesn&apos;t match the holdout these
+                experiments already belong to. Select their holdout to continue:
+              </Text>
+              <ul style={{ marginBottom: 0 }}>
+                {conflictingHoldoutExperiments.map((exp) => (
+                  <li key={`holdout-${exp.id}`}>
+                    Experiment &ldquo;{exp.name}&rdquo; belongs to a different
+                    holdout.
+                  </li>
+                ))}
+              </ul>
+            </Callout>
+          )}
         </>
       )}
     </ModalStandard>

--- a/packages/front-end/components/Features/AddToHoldoutModal.tsx
+++ b/packages/front-end/components/Features/AddToHoldoutModal.tsx
@@ -56,12 +56,19 @@ const AddToHoldoutModal = ({
     defaultDraft,
   );
 
-  // Only allow adding to holdout if all experiments are in draft status and don't have a holdoutId or have the same holdoutId as the feature
+  // Only allow adding to holdout if all existing experiments are in draft status
+  // and don't have a holdoutId or have the same holdoutId as the feature.
+  // Skip deleted experiments (not in experimentsMap) since they no longer block holdout changes.
   const experimentsAreInDraft = feature.linkedExperiments?.every(
-    (experimentId) =>
-      experimentsMap[experimentId]?.status === "draft" &&
-      (!experimentsMap[experimentId]?.holdoutId ||
-        experimentsMap[experimentId]?.holdoutId === feature.holdout?.id),
+    (experimentId) => {
+      const exp = experimentsMap[experimentId];
+      // Skip deleted experiments - they no longer block holdout assignment
+      if (!exp) return true;
+      return (
+        exp.status === "draft" &&
+        (!exp.holdoutId || exp.holdoutId === feature.holdout?.id)
+      );
+    },
   );
 
   const eligibleToAddToHoldout = (feature.rules ?? []).every(

--- a/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
@@ -299,6 +299,35 @@ export default function FeatureFromExperimentModal({
     return null;
   }, [existing, existingFeature, experiment.holdoutId, holdoutsMap]);
 
+  // A holdout-free experiment linked to an existing feature that IS in a holdout
+  // will be enrolled in that holdout on submit — surface it. Name is null when
+  // this doesn't apply (no existing feature holdout, or the experiment already
+  // has a holdout, which holdoutWarning handles).
+  const holdoutToAddToExperiment = useMemo<string | null>(() => {
+    if (!existing || !existingFeature?.holdout?.id) return null;
+    if (experiment.holdoutId) return null;
+    return holdoutsMap.get(existingFeature.holdout.id)?.name ?? "the holdout";
+  }, [existing, existingFeature, experiment.holdoutId, holdoutsMap]);
+
+  // The experiment can only join a holdout if it's otherwise clean — the
+  // back-end (postFeatureExperimentRefRule) rejects it otherwise, so block here.
+  const experimentHasOtherLinkedChanges = useMemo(
+    () =>
+      (experiment.linkedFeatures?.some((fid) => fid !== existingFeature?.id) ??
+        false) ||
+      !!experiment.hasVisualChangesets ||
+      !!experiment.hasURLRedirects,
+    [
+      experiment.linkedFeatures,
+      experiment.hasVisualChangesets,
+      experiment.hasURLRedirects,
+      existingFeature?.id,
+    ],
+  );
+
+  const holdoutLinkBlockedByLinkedChanges =
+    !!holdoutToAddToExperiment && experimentHasOtherLinkedChanges;
+
   let ctaEnabled = true;
   let disabledMessage: string | undefined;
 
@@ -312,7 +341,7 @@ export default function FeatureFromExperimentModal({
       "You don't have permission to create feature flag drafts.";
   }
 
-  if (holdoutWarning) {
+  if (holdoutWarning || holdoutLinkBlockedByLinkedChanges) {
     ctaEnabled = false;
   }
 
@@ -531,6 +560,21 @@ export default function FeatureFromExperimentModal({
           {holdoutWarning}
         </Callout>
       )}
+
+      {holdoutToAddToExperiment &&
+        (holdoutLinkBlockedByLinkedChanges ? (
+          <Callout status="error" mb="3">
+            The selected feature is in holdout &ldquo;{holdoutToAddToExperiment}
+            &rdquo;, so linking this experiment would add it to the holdout —
+            but the experiment already has other linked features, visual
+            changes, or URL redirects. Unlink those first.
+          </Callout>
+        ) : (
+          <Callout status="info" mb="3">
+            The selected feature is in holdout &ldquo;{holdoutToAddToExperiment}
+            &rdquo;. Adding this experiment will also add it to that holdout.
+          </Callout>
+        ))}
 
       {disabledMessage && (
         <Callout status="warning" mb="3">

--- a/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
@@ -309,25 +309,6 @@ export default function FeatureFromExperimentModal({
     return holdoutsMap.get(existingFeature.holdout.id)?.name ?? "the holdout";
   }, [existing, existingFeature, experiment.holdoutId, holdoutsMap]);
 
-  // The experiment can only join a holdout if it's otherwise clean — the
-  // back-end (postFeatureExperimentRefRule) rejects it otherwise, so block here.
-  const experimentHasOtherLinkedChanges = useMemo(
-    () =>
-      (experiment.linkedFeatures?.some((fid) => fid !== existingFeature?.id) ??
-        false) ||
-      !!experiment.hasVisualChangesets ||
-      !!experiment.hasURLRedirects,
-    [
-      experiment.linkedFeatures,
-      experiment.hasVisualChangesets,
-      experiment.hasURLRedirects,
-      existingFeature?.id,
-    ],
-  );
-
-  const holdoutLinkBlockedByLinkedChanges =
-    !!holdoutToAddToExperiment && experimentHasOtherLinkedChanges;
-
   let ctaEnabled = true;
   let disabledMessage: string | undefined;
 
@@ -341,7 +322,7 @@ export default function FeatureFromExperimentModal({
       "You don't have permission to create feature flag drafts.";
   }
 
-  if (holdoutWarning || holdoutLinkBlockedByLinkedChanges) {
+  if (holdoutWarning) {
     ctaEnabled = false;
   }
 
@@ -561,20 +542,12 @@ export default function FeatureFromExperimentModal({
         </Callout>
       )}
 
-      {holdoutToAddToExperiment &&
-        (holdoutLinkBlockedByLinkedChanges ? (
-          <Callout status="error" mb="3">
-            The selected feature is in holdout &ldquo;{holdoutToAddToExperiment}
-            &rdquo;, so linking this experiment would add it to the holdout —
-            but the experiment already has other linked features, visual
-            changes, or URL redirects. Unlink those first.
-          </Callout>
-        ) : (
-          <Callout status="info" mb="3">
-            The selected feature is in holdout &ldquo;{holdoutToAddToExperiment}
-            &rdquo;. Adding this experiment will also add it to that holdout.
-          </Callout>
-        ))}
+      {holdoutToAddToExperiment && (
+        <Callout status="info" mb="3">
+          The selected feature is in holdout &ldquo;{holdoutToAddToExperiment}
+          &rdquo;. Adding this experiment will also add it to that holdout.
+        </Callout>
+      )}
 
       {disabledMessage && (
         <Callout status="warning" mb="3">

--- a/packages/front-end/components/Features/FeatureRules.tsx
+++ b/packages/front-end/components/Features/FeatureRules.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/services/features";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { isHoldoutEnabledAnyEnv } from "@/hooks/useHoldouts";
+import useApi from "@/hooks/useApi";
 import Switch from "@/ui/Switch";
 import Button from "@/ui/Button";
 import Badge from "@/ui/Badge";
@@ -183,15 +184,45 @@ export default function FeatureRules({
     !feature.holdout?.id &&
     !!baseFeature.holdout?.id &&
     holdoutEnabledInActiveEnv;
-  const includeHoldoutRule = liveHoldoutActive || draftDeletesHoldout;
+
+  // A draft adds a holdout when the merged (viewed) feature references one that
+  // live doesn't. The page-level `holdout` prop is resolved from the live
+  // feature, so it's undefined here — fetch the added holdout to know which
+  // envs it's enabled in (SWR dedupes with HoldoutRule's own fetch).
+  const draftAddsHoldoutBase =
+    !!feature.holdout?.id && !baseFeature.holdout?.id;
+  const { data: addedHoldoutData } = useApi<{ holdout: HoldoutInterface }>(
+    `/holdout/${feature.holdout?.id}`,
+    { shouldRun: () => draftAddsHoldoutBase },
+  );
+  const addedHoldout = draftAddsHoldoutBase
+    ? addedHoldoutData?.holdout
+    : undefined;
+  const draftAddsHoldout =
+    draftAddsHoldoutBase &&
+    !!activeEnv &&
+    !!addedHoldout?.environmentSettings?.[activeEnv.id]?.enabled;
+
+  const includeHoldoutRule =
+    liveHoldoutActive || draftDeletesHoldout || draftAddsHoldout;
 
   // Show holdout in All-Envs whenever it's enabled in any of the org's envs.
   const holdoutEnabledAnyEnv = isHoldoutEnabledAnyEnv(holdout, envs);
   const liveHoldoutActiveAnyEnv = !!feature.holdout?.id && holdoutEnabledAnyEnv;
   const draftDeletesHoldoutAnyEnv =
     !feature.holdout?.id && !!baseFeature.holdout?.id && holdoutEnabledAnyEnv;
+  const draftAddsHoldoutAnyEnv =
+    draftAddsHoldoutBase && isHoldoutEnabledAnyEnv(addedHoldout, envs);
   const includeHoldoutRuleAllEnvs =
-    liveHoldoutActiveAnyEnv || draftDeletesHoldoutAnyEnv;
+    liveHoldoutActiveAnyEnv ||
+    draftDeletesHoldoutAnyEnv ||
+    draftAddsHoldoutAnyEnv;
+
+  // Whether a holdout row occupies the given env's rule list — the live/deleted
+  // holdout (from the page `holdout` prop) or a draft-added one.
+  const holdoutRowInEnv = (envId: string) =>
+    !!holdout?.environmentSettings?.[envId]?.enabled ||
+    !!addedHoldout?.environmentSettings?.[envId]?.enabled;
 
   // Tab overflow: cache each trigger's natural width once, then compute
   // cumulative-width overflow against the tabs-bar. Caching avoids the
@@ -285,7 +316,7 @@ export default function FeatureRules({
     }
     const e = envById.get(key);
     if (!e) continue;
-    const count = holdout?.environmentSettings?.[e.id]?.enabled
+    const count = holdoutRowInEnv(e.id)
       ? rulesByEnv[e.id].length + 1
       : rulesByEnv[e.id].length;
     overflowLabels.push({ key: e.id, label: e.id, count });
@@ -353,7 +384,7 @@ export default function FeatureRules({
               {orderedEnvIds.map((id) => {
                 const e = envById.get(id);
                 if (!e) return null;
-                const count = holdout?.environmentSettings?.[e.id]?.enabled
+                const count = holdoutRowInEnv(e.id)
                   ? rulesByEnv[e.id].length + 1
                   : rulesByEnv[e.id].length;
                 return (
@@ -504,6 +535,7 @@ export default function FeatureRules({
                 safeRolloutsMap={safeRolloutsMap}
                 holdout={liveHoldoutActiveAnyEnv ? holdout : undefined}
                 holdoutIsDeleted={draftDeletesHoldoutAnyEnv}
+                holdoutIsPendingAdd={draftAddsHoldoutAnyEnv}
                 openHoldoutModal={() => setHoldoutModal(true)}
                 revisionList={revisionList}
                 rampSchedules={rampSchedules}
@@ -558,6 +590,7 @@ export default function FeatureRules({
                 safeRolloutsMap={safeRolloutsMap}
                 holdout={liveHoldoutActive ? holdout : undefined}
                 holdoutIsDeleted={draftDeletesHoldout}
+                holdoutIsPendingAdd={draftAddsHoldout}
                 openHoldoutModal={() => setHoldoutModal(true)}
                 revisionList={revisionList}
                 rampSchedules={rampSchedules}

--- a/packages/front-end/components/Features/HoldoutRule.tsx
+++ b/packages/front-end/components/Features/HoldoutRule.tsx
@@ -35,6 +35,8 @@ interface Props {
   setRuleModal: () => void;
   setVersion: (version: number) => void;
   isDeleted?: boolean;
+  // The current draft adds this holdout; it goes live when the draft publishes.
+  isPendingAdd?: boolean;
   isLocked?: boolean;
   // Per-env tab passes its env id so the badge sorts current env first;
   // omitted in the All-Environments view.
@@ -51,6 +53,7 @@ export const HoldoutRule = forwardRef<HTMLDivElement, Props>(
       mutate,
       setVersion,
       isDeleted = false,
+      isPendingAdd = false,
       isLocked = false,
       currentEnvironment,
       ...props
@@ -215,6 +218,11 @@ export const HoldoutRule = forwardRef<HTMLDivElement, Props>(
               <Callout status="error" size="sm">
                 This feature has been removed from the holdout in the current
                 draft. Publish or discard the draft to resolve.
+              </Callout>
+            ) : isPendingAdd ? (
+              <Callout status="info" size="sm">
+                This feature will be added to the holdout when the current draft
+                is published. Discard the draft to cancel.
               </Callout>
             ) : holdoutExperiment.status === "stopped" ? (
               <Callout status="info">

--- a/packages/front-end/components/Features/RemoveFromHoldoutModal.tsx
+++ b/packages/front-end/components/Features/RemoveFromHoldoutModal.tsx
@@ -69,6 +69,8 @@ export default function RemoveFromHoldoutModal({
     if (resolvedVersion !== null) setVersion(resolvedVersion);
   };
 
+  // TODO(holdouts): add a check to see if the publish will work, and if not, show a warning to
+  // remove the experiment first
   return (
     <ModalStandard
       header="Remove from holdout"

--- a/packages/front-end/components/Features/RuleList.tsx
+++ b/packages/front-end/components/Features/RuleList.tsx
@@ -66,6 +66,7 @@ type CommonProps = {
   safeRolloutsMap: Map<string, SafeRolloutInterface>;
   holdout: HoldoutInterface | undefined;
   holdoutIsDeleted: boolean;
+  holdoutIsPendingAdd: boolean;
   openHoldoutModal: () => void;
   revisionList: MinimalFeatureRevisionInterface[];
   rampSchedules?: RampScheduleInterface[];
@@ -108,6 +109,7 @@ export default function RuleList(props: RuleListProps) {
     safeRolloutsMap,
     holdout,
     holdoutIsDeleted,
+    holdoutIsPendingAdd,
     openHoldoutModal,
     revisionList,
     rampSchedules,
@@ -273,7 +275,7 @@ export default function RuleList(props: RuleListProps) {
   // 1-based position (offset by 1 for the holdout row when present).
   const bannersByRule = useMemo<Map<string, ConflictBanner[]>>(() => {
     const flat = feature.rules ?? [];
-    const offset = holdout ? 2 : 1;
+    const offset = holdout || holdoutIsPendingAdd ? 2 : 1;
     const ruleNumber = (id: string) => {
       const idx = flat.findIndex((r) => r.id === id);
       return idx === -1 ? undefined : idx + offset;
@@ -313,11 +315,12 @@ export default function RuleList(props: RuleListProps) {
     props.environments,
     feature.rules,
     holdout,
+    holdoutIsPendingAdd,
   ]);
 
   const inactiveRules = items.filter((r) => isRuleInactive(r, experimentsMap));
 
-  if (!items.length && !holdout && !holdoutIsDeleted) {
+  if (!items.length && !holdout && !holdoutIsDeleted && !holdoutIsPendingAdd) {
     return (
       <div className="px-3 mb-3">
         <em>None</em>
@@ -414,10 +417,11 @@ export default function RuleList(props: RuleListProps) {
             <em>No Active Rules</em>
           </div>
         )}
-        {(holdout || holdoutIsDeleted) && (
+        {(holdout || holdoutIsDeleted || holdoutIsPendingAdd) && (
           <HoldoutRule
             feature={holdoutIsDeleted ? baseFeature : feature}
             isDeleted={holdoutIsDeleted}
+            isPendingAdd={holdoutIsPendingAdd}
             setRuleModal={openHoldoutModal}
             mutate={mutate}
             revisionList={revisionList}

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -81,6 +81,7 @@ import DraftSelectorForChanges, {
   DraftMode,
 } from "@/components/Features/DraftSelectorForChanges";
 import { useDefaultDraft } from "@/hooks/useDefaultDraft";
+import { useFeatureRevisionsContext } from "@/contexts/FeatureRevisionsContext";
 import { useTemplates } from "@/hooks/useTemplates";
 import SafeRolloutFields from "@/components/Features/RuleModal/SafeRolloutFields";
 import RampScheduleSection from "@/components/Features/RuleModal/RampScheduleSection";
@@ -360,6 +361,19 @@ export default function RuleModal({
     draftMode === "existing" && selectedDraft !== null
       ? selectedDraft
       : feature.version;
+
+  // Holdout a newly-created experiment should join: the holdout of the draft the
+  // rule is being added to (revision.holdout), not just the live feature's — so
+  // a holdout added in that same draft is picked up. Falls back to the merged
+  // feature's holdout when the target revision isn't in context (e.g. a new
+  // draft branched from the viewed version carries that holdout forward).
+  const revisionsCtx = useFeatureRevisionsContext();
+  const targetHoldoutId = useMemo(() => {
+    const targetRev = revisionsCtx?.revisions.find(
+      (r) => r.version === targetVersion,
+    );
+    return (targetRev ? targetRev.holdout : feature.holdout)?.id;
+  }, [revisionsCtx, targetVersion, feature.holdout]);
 
   const gatedEnvSet: Set<string> | "all" | "none" = useMemo(() => {
     const raw = settings?.requireReviews;
@@ -1076,9 +1090,7 @@ export default function RuleModal({
           statsEngine: values.statsEngine ?? undefined,
           type: values.experimentType,
           holdoutId:
-            values.experimentType === "standard"
-              ? feature.holdout?.id
-              : undefined,
+            values.experimentType === "standard" ? targetHoldoutId : undefined,
         };
 
         if (values?.customFields) {

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -1072,6 +1072,19 @@ export type RevisionFields = Pick<
   | "rampActions"
 >;
 
+// Resolves the holdout a revision will publish under. Revisions store holdout
+// sparsely: `undefined` (legacy revisions that predate the field) means
+// carry-forward from the live feature, while an explicit `null` means the
+// draft removes the holdout.
+export function getEffectiveRevisionHoldout(
+  revision: Pick<RevisionFields, "holdout">,
+  feature: FeatureInterface,
+): Exclude<RevisionFields["holdout"], undefined> {
+  return revision.holdout !== undefined
+    ? revision.holdout
+    : (feature.holdout ?? null);
+}
+
 // Per-field backfill for old/sparse revisions before passing to autoMerge.
 // Fields not listed here are left as-is; sparse absence is meaningful for those.
 const revisionFieldFillers: Partial<{
@@ -1110,9 +1123,8 @@ const revisionFieldFillers: Partial<{
   // Backfill holdout from feature so that removing a holdout is detected as a change.
   // Without this, comparing draft.holdout (null) vs base.holdout (undefined → null)
   // would show no change when the feature actually has a holdout.
-  // Note: we check for undefined explicitly because null is a valid value (means removal).
   holdout: (feature, current) =>
-    current !== undefined ? current : (feature.holdout ?? null),
+    getEffectiveRevisionHoldout({ holdout: current }, feature),
 };
 
 // Backfills stale/missing fields on a revision before passing to autoMerge.

--- a/packages/shared/test/util/feature-revisions.test.ts
+++ b/packages/shared/test/util/feature-revisions.test.ts
@@ -6,6 +6,7 @@ import {
   checkIfRevisionNeedsReview,
   fillRevisionFromFeature,
   getDraftAffectedEnvironments,
+  getEffectiveRevisionHoldout,
   getReviewSetting,
   getFeatureAutopublishOnApproval,
   mergeResultHasChanges,
@@ -1139,6 +1140,41 @@ describe("fillRevisionFromFeature", () => {
     };
     const filled = fillRevisionFromFeature(revision, feature);
     expect(filled.holdout).toBeNull();
+  });
+});
+
+describe("getEffectiveRevisionHoldout", () => {
+  const featureHoldout = { id: "h-1", value: "feature-value" };
+
+  it("carries the feature's holdout forward when the revision predates the field", () => {
+    const feature: FeatureInterface = {
+      ...baseFeature,
+      holdout: featureHoldout,
+    };
+    expect(getEffectiveRevisionHoldout({}, feature)).toEqual(featureHoldout);
+  });
+
+  it("returns null for an explicit removal even when the feature has a holdout", () => {
+    const feature: FeatureInterface = {
+      ...baseFeature,
+      holdout: featureHoldout,
+    };
+    expect(getEffectiveRevisionHoldout({ holdout: null }, feature)).toBeNull();
+  });
+
+  it("prefers the revision's holdout over the feature's", () => {
+    const revisionHoldout = { id: "h-2", value: "revision-value" };
+    const feature: FeatureInterface = {
+      ...baseFeature,
+      holdout: featureHoldout,
+    };
+    expect(
+      getEffectiveRevisionHoldout({ holdout: revisionHoldout }, feature),
+    ).toEqual(revisionHoldout);
+  });
+
+  it("returns null when neither the revision nor the feature has a holdout", () => {
+    expect(getEffectiveRevisionHoldout({}, baseFeature)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes holdout ↔ feature ↔ experiment linking integrity, starting from a user-reported bug where
removing experiments from a feature flag wasn't enough to unblock adding a Feature Flag to a holdout.

One of the key changes is really decreasing the importance of `linkedExperiments` and `linkedFeatures` and instead relying on the active list of rules published or in draft (depending on use case). More can be done here, but this PR unlocks the core functionality.

**Guards & validation**
- Holdout eligibility now checks the experiments in the revision's **rules** (deleted experiments
  skipped), not the historical `linkedExperiments` list
- All four rule-add paths (internal rule add, add-experiment-to-feature, REST v1, REST V2) share one service,
  `resolveHoldoutExperimentToLink`: blocks holdout mismatches and holdout-experiments on
  holdout-less features; auto-links a clean draft experiment into the feature's holdout
- Validation is **draft-aware**: checks run against the target draft's holdout, not just live
- `publishRevision` validates holdout changes **before** mutating the feature (no more stranded
  "live version is actually a draft" state); same in bulk publish
- Removing/changing a feature's holdout is blocked while an in-holdout experiment is in the
  publishing rules — removing the rule and holdout in the *same draft* is allowed
- `DELETE /holdout/:id/feature/:featureId` now runs the same removal guard
- Adding a feature to a holdout no longer blocks on running experiments *already in* that holdout <- although this should never really be possible in the first place, there's no reason to block it

**UI**
- AddToHoldoutModal: names each blocker (running experiments, Bandits, safe rollouts), draft-aware,
  blocks submit on holdout conflicts
- RuleModal: new inline experiments inherit the target draft's holdout
- FeatureFromExperimentModal: info callout when linking adds the experiment to the feature's holdout

**Known follow-ups**
- [ ] Eager link should use the validated `effectiveHoldout`, not live `feature.holdout` (extract shared `linkExperimentToHoldout`)
- [ ] Publish-time guard vs `applyHoldoutSideEffects` source mismatch (rules vs `linkedExperiments`; draft experiments can switch holdouts silently)
- [ ] RemoveFromHoldoutModal for both features and experiments can have improved UX, TODOs are in code with `TODO(holdouts)`
- [ ] Audit linkedExperiments and linkedFeatures for accuracy
- [ ] Block for "monitored release" as well as legacy safe rollout
- [ ] Change holdouts on reversion

## Manual test checklist

**Add to holdout (feature side)**
- [x] Feature with only deleted experiments left behind → adds to holdout cleanly (original bug)
- [x] Feature with a running experiment (no holdout) → modal names the experiment and blocks
- [x] Feature with a running experiment already in holdout H → adding to H succeeds
- [x] Feature with a Bandit / legacy safe rollout rule → blocked with the specific reason
- [ ] Feature whose draft experiment is in H2 → selecting H blocks submit; selecting H2 allows
- [x] Bundle holdout into an experiment's draft, then start the experiment → publishes without
      corrupting `feature.version` (no "live version is a draft" state)

**Add experiment rule to a feature**
- [x] Holdout-free draft experiment → feature in holdout H → rule added AND experiment joins H
- [x] Experiment in H → feature with no holdout → blocked ("add the feature to that holdout first")
- [x] Experiment in H → feature in H2 → blocked (mismatch)
- [x] Experiment in H → draft that added H (not yet published) → allowed (draft-aware)
- [x] Same via REST v1 `/features/:id/revisions/:version/rules` → same outcomes
- [x] Same via REST **v2** → same outcomes

**Create feature from experiment**
- [x] New feature from holdout experiment → feature is live in the holdout at rev 1; rule in draft rev 2;
      draft auto-publishes when the experiment starts
- [x] Existing feature in the same holdout → info callout, rule added
- [x] Existing feature in a different / no holdout → blocked with guidance

**Remove / change holdout**
- [x] Feature with an in-holdout experiment rule → removal blocked with "remove the rule first or in the same draft"
- [x] One draft removes the experiment rule AND the holdout → publishes cleanly
- [ ] Holdout page: remove a feature whose rules are clean → works; verify experiment state if its rule was draft-only (known gap)
- [x] Delete the whole holdout → all linked features AND experiments unlinked atomically
- [x] Experiment page: remove from holdout with a linked feature → blocked in the modal

**Regression**
- [x] New experiment created inline in a draft that has a holdout → experiment gets that holdout
- [X] Revert a revision → holdout membership intentionally unchanged (revert carries no holdout delta)
- [ ] Rule numbering in conflict banners when a draft deletes/adds the holdout row