### PR TITLE
fix(api): Preserve variation IDs when creating experiments

### DIFF
--- a/packages/back-end/src/api/experiments/postExperiment.ts
+++ b/packages/back-end/src/api/experiments/postExperiment.ts
@@ -2,7 +2,6 @@ import { getAllMetricIdsFromExperiment } from "shared/experiments";
 import {
   ExperimentInterfaceExcludingHoldouts,
   ExperimentTemplateInterface,
-  Variation,
   postExperimentValidator,
 } from "shared/validators";
 import { omit } from "lodash";
@@ -245,7 +244,7 @@ export const postExperiment = createApiRequestHandler(postExperimentValidator)(
       }
     }
     if (payload.variations) {
-      validateVariationIds(payload.variations as Variation[]);
+      validateVariationIds(payload.variations);
     }
 
     if (payload.precomputedUnitDimensionIds !== undefined) {

--- a/packages/back-end/src/api/experiments/updateExperiment.ts
+++ b/packages/back-end/src/api/experiments/updateExperiment.ts
@@ -1,7 +1,6 @@
 import { getAllMetricIdsFromExperiment } from "shared/experiments";
 import {
   ExperimentInterfaceExcludingHoldouts,
-  Variation,
   updateExperimentValidator,
 } from "shared/validators";
 import { getDataSourceById } from "back-end/src/models/DataSourceModel";
@@ -209,13 +208,7 @@ export const updateExperiment = createApiRequestHandler(
   }
 
   if (req.body.variations) {
-    // Resolve the `variationId` response-field alias to `id` before validating,
-    // so echoing GET variations back doesn't regenerate ids (validateVariationIds
-    // assigns a fresh id to any variation missing one).
-    req.body.variations.forEach((v) => {
-      if (!v.id && v.variationId) v.id = v.variationId;
-    });
-    validateVariationIds(req.body.variations as Variation[]);
+    validateVariationIds(req.body.variations);
   }
 
   const effectivePrecomputedUnitDimensionType =

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2079,15 +2079,25 @@ export function fillEmptyVariationKeys(
   }
 }
 
-export function validateVariationIds(variations: Variation[]) {
+export function validateVariationIds(
+  variations: {
+    id?: string;
+    variationId?: string;
+    key?: string;
+  }[],
+) {
   variations.forEach((variation, i) => {
     if (!variation.id) {
-      variation.id = uniqid("var_");
+      variation.id = variation.variationId || uniqid("var_");
     }
     if (!variation.key) {
       variation.key = i + "";
     }
   });
+  const ids = variations.map((v) => v.id);
+  if (ids.length !== new Set(ids).size) {
+    throw new Error("Variation IDs must be unique.");
+  }
   const keys = variations.map((v) => v.key);
   if (keys.length !== new Set(keys).size) {
     throw new Error("Variation keys must be unique");
@@ -3986,7 +3996,10 @@ export function postExperimentApiPayloadToInterface(
   organization: OrganizationInterface,
   datasource: DataSourceInterface | null,
 ): Omit<ExperimentInterface, "dateCreated" | "dateUpdated" | "id"> {
-  const variationIds = payload.variations.map(() => generateVariationId());
+  const variationIds = payload.variations.map(
+    (variation) =>
+      variation.id || variation.variationId || generateVariationId(),
+  );
 
   const toPhaseVariations = (variationIds: string[]) =>
     variationIds.map((id) => ({ id, status: "active" as const }));

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -70,6 +70,7 @@ import {
   BanditResult,
   ExperimentAnalysisSummary,
   ExperimentAnalysisSummaryResultsStatus,
+  ApiVariationInput,
   GoalMetricResult,
   SafeRolloutInterface,
   postExperimentValidator,
@@ -2080,11 +2081,7 @@ export function fillEmptyVariationKeys(
 }
 
 export function validateVariationIds(
-  variations: {
-    id?: string;
-    variationId?: string;
-    key?: string;
-  }[],
+  variations: Partial<Pick<ApiVariationInput, "id" | "variationId" | "key">>[],
 ) {
   variations.forEach((variation, i) => {
     if (!variation.id) {

--- a/packages/back-end/test/api/experiments.test.ts
+++ b/packages/back-end/test/api/experiments.test.ts
@@ -575,6 +575,89 @@ describe("experiments API", () => {
       expect(createExperiment).toHaveBeenCalled();
     });
 
+    it("preserves id and variationId values when creating an experiment", async () => {
+      (getDataSourceById as jest.Mock).mockResolvedValue({
+        id: "ds_123",
+        type: "postgres",
+        settings: {
+          queries: { exposure: [{ id: "user_id", name: "User ID" }] },
+        },
+      });
+      (getExperimentByTrackingKey as jest.Mock).mockResolvedValue(null);
+      (createExperiment as jest.Mock).mockResolvedValue(experiment);
+
+      const res = await request(app)
+        .post("/api/v1/experiments")
+        .send({
+          trackingKey: "exp_custom_variation_ids",
+          name: "Custom variation IDs",
+          datasourceId: "ds_123",
+          assignmentQueryId: "user_id",
+          variations: [
+            {
+              id: "control",
+              variationId: "ignored",
+              key: "control",
+              name: "Control",
+            },
+            {
+              variationId: "treatment",
+              key: "treatment",
+              name: "Treatment",
+            },
+          ],
+        })
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      const createCall = (createExperiment as jest.Mock).mock.calls[0][0];
+      expect(createCall.data.variations.map((v) => v.id)).toEqual([
+        "control",
+        "treatment",
+      ]);
+      expect(createCall.data.phases[0].variations).toEqual([
+        { id: "control", status: "active" },
+        { id: "treatment", status: "active" },
+      ]);
+    });
+
+    it("rejects duplicate user-specified variation ids", async () => {
+      (getDataSourceById as jest.Mock).mockResolvedValue({
+        id: "ds_123",
+        type: "postgres",
+        settings: {
+          queries: { exposure: [{ id: "user_id", name: "User ID" }] },
+        },
+      });
+      (getExperimentByTrackingKey as jest.Mock).mockResolvedValue(null);
+
+      const res = await request(app)
+        .post("/api/v1/experiments")
+        .send({
+          trackingKey: "exp_duplicate_variation_ids",
+          name: "Duplicate variation IDs",
+          datasourceId: "ds_123",
+          assignmentQueryId: "user_id",
+          variations: [
+            {
+              id: "duplicate",
+              key: "control",
+              name: "Control",
+            },
+            {
+              variationId: "duplicate",
+              key: "treatment",
+              name: "Treatment",
+            },
+          ],
+        })
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toBe("Variation IDs must be unique.");
+      expect(createExperiment).not.toHaveBeenCalled();
+    });
+
     it("rejects create when required custom fields are missing", async () => {
       updateReqContext({
         models: {

--- a/packages/back-end/test/services/experiments.test.ts
+++ b/packages/back-end/test/services/experiments.test.ts
@@ -19,9 +19,35 @@ import {
   putMetricApiPayloadToMetricInterface,
   updateExperimentApiPayloadToInterface,
   validateStatusUpdateSchedule,
+  validateVariationIds,
 } from "back-end/src/services/experiments";
 
 describe("experiments utils", () => {
+  describe("validateVariationIds", () => {
+    it("resolves variationId aliases while preferring explicit ids", () => {
+      const variations = [
+        { id: "control", variationId: "ignored", key: "0" },
+        { variationId: "treatment", key: "1" },
+        { key: "2" },
+      ];
+
+      validateVariationIds(variations);
+
+      expect(variations[0].id).toBe("control");
+      expect(variations[1].id).toBe("treatment");
+      expect(variations[2].id).toMatch(/^var_/);
+    });
+
+    it("rejects duplicate resolved variation ids", () => {
+      expect(() =>
+        validateVariationIds([
+          { id: "duplicate", key: "0" },
+          { variationId: "duplicate", key: "1" },
+        ]),
+      ).toThrow("Variation IDs must be unique.");
+    });
+  });
+
   describe("postMetricApiPayloadIsValid", () => {
     it("should return a successful result when providing the minimum number of fields", () => {
       const input: z.infer<typeof postMetricValidator.bodySchema> = {
@@ -1498,6 +1524,40 @@ describe("putMetricApiPayloadToMetricInterface", () => {
         decisionFrameworkMetricOverrides: [{ id: "met_1", targetMDE: 0.1 }],
       });
       expect(out.postStratificationEnabled).toBe(false);
+    });
+
+    it("postExperimentApiPayloadToInterface preserves variation ids and traffic splits", () => {
+      const payload: z.infer<typeof postExperimentValidator.bodySchema> = {
+        trackingKey: "track_ids",
+        name: "Experiment with custom variation ids",
+        assignmentQueryId: "exp_query_1",
+        variations: [
+          { id: "control", key: "0", name: "Control" },
+          { variationId: "treatment", key: "1", name: "Treatment" },
+        ],
+        phases: [
+          {
+            name: "Main",
+            dateStarted: "2026-07-23T00:00:00.000Z",
+            trafficSplit: [
+              { variationId: "treatment", weight: 0.25 },
+              { variationId: "control", weight: 0.75 },
+            ],
+          },
+        ],
+      };
+
+      const out = postExperimentApiPayloadToInterface(payload, org, datasource);
+
+      expect(out.variations.map((variation) => variation.id)).toEqual([
+        "control",
+        "treatment",
+      ]);
+      expect(out.phases[0].variations).toEqual([
+        { id: "control", status: "active" },
+        { id: "treatment", status: "active" },
+      ]);
+      expect(out.phases[0].variationWeights).toEqual([0.75, 0.25]);
     });
 
     it("updateExperimentApiPayloadToInterface sets exposureQueryId from assignmentQueryId", () => {

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -1002,6 +1002,7 @@ const apiVariationInput = z.object({
     )
     .optional(),
 });
+export type ApiVariationInput = z.infer<typeof apiVariationInput>;
 
 // Phase for input payloads
 const apiPhaseInput = z.object({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

- Preserve caller-supplied `id` and `variationId` values when creating experiments through the REST API, with `id` taking precedence.
- Keep phase variation IDs and traffic split weights aligned with the supplied IDs.
- Reject duplicate resolved variation IDs across create and update flows.
- Add targeted service and API regression coverage.

### Dependencies

None.

### Testing

- `pnpm --filter back-end test test/services/experiments.test.ts --runInBand` (67 passed)
- `pnpm --filter back-end test test/api/experiments.test.ts --runInBand` (71 passed)
- `pnpm --filter back-end type-check` (passed)
- Tests executed with Node.js 24.14.0.
- Manual Testing

<a href="/opt/cursor/artifacts/experiment_variation_id_validation_node24.txt">Node 24 validation output</a>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/D0ANTLUD22J/p1774465571901549?thread_ts=1774465571.901549&cid=D0ANTLUD22J)

<div><a href="https://cursor.com/agents/bc-d35bb3d9-2184-5ef5-b4d0-94b72fe23bd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d35bb3d9-2184-5ef5-b4d0-94b72fe23bd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

