### PR TITLE
Update What's New sidebar links for 5.0

### DIFF
--- a/packages/front-end/components/GetStarted/DocumentationSidebar.tsx
+++ b/packages/front-end/components/GetStarted/DocumentationSidebar.tsx
@@ -31,6 +31,9 @@ const DocumentationSidebar = ({
       <SidebarHeading>WHAT&apos;S NEW</SidebarHeading>
       <Flex direction="column" gapY="3">
         <AIVisualEditorCallout />
+        <LinkItem href="https://www.growthbook.io/blog/growthbook-version-5-0">
+          GrowthBook 5.0 Overview
+        </LinkItem>
         <LinkItem href="https://docs.growthbook.io/integrations/ai-agents/agent-skills/">
           Agent Skills
         </LinkItem>


### PR DESCRIPTION
Updates the "WHAT'S NEW" section of the in-app sidebar:

- Adds a launch week link to the launch post:  **GrowthBook 5.0 Overview** (→ `growthbook.io/blog/growthbook-version-5-0`)
- Keeps the **Agent Skills** link, now positioned below the 5.0 Overview