### PR TITLE
Track back-end requests

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -289,7 +289,6 @@ app.get("/", (req, res) => {
 });
 
 app.use(httpLogger);
-app.use(trackRequestCompletion as unknown as RequestHandler);
 
 // Initialize db connections
 app.use(async (req, res, next) => {
@@ -515,6 +514,10 @@ app.use(auth.middleware as RequestHandler);
 
 // Add logged in user props to the request
 app.use(asyncHandler(processJWT as unknown as RequestHandler));
+
+// Track request completion for GrowthBook telemetry — only routes past this
+// point can have `req.gb` set, so earlier (public/SDK) routes never pay for it
+app.use(trackRequestCompletion as unknown as RequestHandler);
 
 // Add logged in user props to the logger
 app.use(((

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -33,6 +33,7 @@ import {
   getExperimentsScript,
 } from "./controllers/config";
 import { getAuthConnection, processJWT, usingOpenId } from "./services/auth";
+import { trackRequestCompletion } from "./services/growthbook";
 import { wrapController } from "./routers/wrapController";
 import apiRouter from "./api/api.router";
 import scimRouter from "./scim/scim.router";
@@ -288,6 +289,7 @@ app.get("/", (req, res) => {
 });
 
 app.use(httpLogger);
+app.use(trackRequestCompletion as unknown as RequestHandler);
 
 // Initialize db connections
 app.use(async (req, res, next) => {

--- a/packages/back-end/src/services/growthbook.ts
+++ b/packages/back-end/src/services/growthbook.ts
@@ -6,9 +6,10 @@ import {
 } from "@growthbook/growthbook";
 import { growthbookTrackingPlugin } from "@growthbook/growthbook/plugins";
 import { EventSource } from "eventsource";
-import { Request } from "express";
+import { NextFunction, Request, Response } from "express";
 import { AppFeatures } from "shared/types/app-features";
 import { logger } from "back-end/src/util/logger";
+import { AuthRequest } from "back-end/src/types/AuthRequest";
 import {
   GB_SDK_ID,
   IS_CLOUD,
@@ -148,6 +149,66 @@ export function getGrowthBookTrackingAttributes(
     ...(ip ? { ip } : {}),
     ...(ua ? { ua } : {}),
   };
+}
+
+const EVENT_REQUEST_COMPLETED = "Request Completed";
+
+function parseContentLength(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * Route pattern (e.g. "/auth/reset/:token") rather than the resolved path, so
+ * dynamic segments that carry secrets (tokens, keys, etc.) never appear in the event.
+ */
+function getRoutePath(req: {
+  path: string;
+  baseUrl: string;
+  route?: { path?: string };
+}): string {
+  return req.route?.path ? `${req.baseUrl}${req.route.path}` : req.path;
+}
+
+/**
+ * Logs a "Request Completed" event with latency, payload sizes, and status once
+ * the response finishes, using the per-request scoped client (`req.gb`, set in
+ * auth/index.ts) so the event carries the same user attributes as feature events.
+ */
+export function trackRequestCompletion(
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction,
+) {
+  const start = Date.now();
+
+  // compression strips Content-Length for compressed responses, so measure
+  // the actual bytes written instead of trusting the response header
+  let resContentSize = 0;
+  const origWrite = res.write.bind(res);
+  const origEnd = res.end.bind(res);
+  res.write = ((chunk: unknown, ...rest: unknown[]) => {
+    if (chunk) resContentSize += Buffer.byteLength(chunk as string);
+    return (origWrite as (...a: unknown[]) => boolean)(chunk, ...rest);
+  }) as typeof res.write;
+  res.end = ((chunk?: unknown, ...rest: unknown[]) => {
+    if (chunk && typeof chunk !== "function")
+      resContentSize += Buffer.byteLength(chunk as string);
+    return (origEnd as (...a: unknown[]) => Response)(chunk, ...rest);
+  }) as typeof res.end;
+
+  res.on("finish", () => {
+    req.gb?.logEvent(EVENT_REQUEST_COMPLETED, {
+      path: getRoutePath(req),
+      method: req.method,
+      statusCode: res.statusCode,
+      latencyMs: Date.now() - start,
+      reqContentSize: parseContentLength(req.headers["content-length"]),
+      resContentSize,
+    });
+  });
+  next();
 }
 
 function ensureGrowthBookClient(): GrowthBookClient<AppFeatures> | null {

--- a/packages/back-end/src/services/growthbook.ts
+++ b/packages/back-end/src/services/growthbook.ts
@@ -153,7 +153,9 @@ export function getGrowthBookTrackingAttributes(
 
 const EVENT_REQUEST_COMPLETED = "Request Completed";
 
-function parseContentLength(value: string | undefined): number | undefined {
+export function parseContentLength(
+  value: string | undefined,
+): number | undefined {
   if (value === undefined) return undefined;
   const parsed = Number(value);
   return Number.isNaN(parsed) ? undefined : parsed;
@@ -163,7 +165,7 @@ function parseContentLength(value: string | undefined): number | undefined {
  * Route pattern (e.g. "/auth/reset/:token") rather than the resolved path, so
  * dynamic segments that carry secrets (tokens, keys, etc.) never appear in the event.
  */
-function getRoutePath(req: {
+export function getRoutePath(req: {
   path: string;
   baseUrl: string;
   route?: { path?: string };
@@ -200,7 +202,10 @@ export function trackRequestCompletion(
     return (origEnd as (...a: unknown[]) => Response)(chunk, ...rest);
   }) as typeof res.end;
 
-  res.on("finish", () => {
+  // "close" also covers requests the client aborted before "finish" fired
+  const onComplete = () => {
+    res.removeListener("finish", onComplete);
+    res.removeListener("close", onComplete);
     req.gb?.logEvent(EVENT_REQUEST_COMPLETED, {
       path: getRoutePath(req),
       method: req.method,
@@ -209,7 +214,9 @@ export function trackRequestCompletion(
       reqContentSize: parseContentLength(req.headers["content-length"]),
       resContentSize,
     });
-  });
+  };
+  res.on("finish", onComplete);
+  res.on("close", onComplete);
   next();
 }
 

--- a/packages/back-end/src/services/growthbook.ts
+++ b/packages/back-end/src/services/growthbook.ts
@@ -168,7 +168,9 @@ function getRoutePath(req: {
   baseUrl: string;
   route?: { path?: string };
 }): string {
-  return req.route?.path ? `${req.baseUrl}${req.route.path}` : req.path;
+  // No matched route (e.g. a 404) means no safe pattern to bound the path to,
+  // so don't fall back to the raw path, which may contain arbitrary user input.
+  return req.route?.path ? `${req.baseUrl}${req.route.path}` : "(unmatched)";
 }
 
 /**

--- a/packages/back-end/src/services/growthbook.ts
+++ b/packages/back-end/src/services/growthbook.ts
@@ -187,8 +187,9 @@ export function trackRequestCompletion(
 ) {
   const start = Date.now();
 
-  // compression strips Content-Length for compressed responses, so measure
-  // the actual bytes written instead of trusting the response header
+  // Sum the bytes written by handlers. This runs above the compression
+  // middleware, so it's the uncompressed payload size (independent of the
+  // client's Accept-Encoding), not the on-wire byte count.
   let resContentSize = 0;
   const origWrite = res.write.bind(res);
   const origEnd = res.end.bind(res);

--- a/packages/back-end/test/services/growthbook.test.ts
+++ b/packages/back-end/test/services/growthbook.test.ts
@@ -1,0 +1,54 @@
+import {
+  getRoutePath,
+  parseContentLength,
+} from "back-end/src/services/growthbook";
+
+describe("parseContentLength", () => {
+  it("returns undefined when the header is absent", () => {
+    expect(parseContentLength(undefined)).toBeUndefined();
+  });
+
+  it("parses a numeric header value", () => {
+    expect(parseContentLength("1234")).toBe(1234);
+  });
+
+  it("parses a zero-length header value", () => {
+    expect(parseContentLength("0")).toBe(0);
+  });
+
+  it("returns undefined for a non-numeric header value", () => {
+    expect(parseContentLength("not-a-number")).toBeUndefined();
+  });
+});
+
+describe("getRoutePath", () => {
+  it("combines baseUrl and the matched route pattern", () => {
+    expect(
+      getRoutePath({
+        path: "/reset/abc123secrettoken",
+        baseUrl: "/auth",
+        route: { path: "/reset/:token" },
+      }),
+    ).toBe("/auth/reset/:token");
+  });
+
+  it("returns the bare route pattern when there is no baseUrl", () => {
+    expect(
+      getRoutePath({
+        path: "/revision/feature",
+        baseUrl: "",
+        route: { path: "/revision/feature" },
+      }),
+    ).toBe("/revision/feature");
+  });
+
+  it("falls back to a placeholder instead of the raw path when nothing matched", () => {
+    expect(
+      getRoutePath({
+        path: "/api/keys/sk-live-abc123",
+        baseUrl: "",
+        route: undefined,
+      }),
+    ).toBe("(unmatched)");
+  });
+});


### PR DESCRIPTION
### Features and Changes
Start tracking back-end requests for logged-in routes to Growthbook.  This will let us test out performance related improvements in A/B tests.  
It tracks:
- the path pattern
- the method
- the statusCode
- latencyMS
- reqContentSize (for POST and PUT)
- resContentSize

### Testing
Set `DISABLE_TELEMETRY=enable-with-debug` in .env.local
Do a PUT or a POST in dev in order to be able to see reqContentSize.
See the logging event in the dev logs.

### Screenshots

```
packages/back-end dev: [1] Logging event to GrowthBook {
packages/back-end dev: [1]   event_name: 'Request Completed',
packages/back-end dev: [1]   properties_json: {
packages/back-end dev: [1]     path: '/feature/:id/:version/title',
packages/back-end dev: [1]     method: 'PUT',
packages/back-end dev: [1]     statusCode: 200,
packages/back-end dev: [1]     latencyMs: 293,
packages/back-end dev: [1]     reqContentSize: 31,
packages/back-end dev: [1]     resContentSize: 19
packages/back-end dev: [1]   },
packages/back-end dev: [1]   user_id: 'u_4posg1kwim7kjhjba',
packages/back-end dev: [1]   device_id: '2d3e5f44-d669-49a3-8f0f-48f55c0d4610',
packages/back-end dev: [1]   page_id: '14e99594-5edb-4534-9349-7802308a667a',
packages/back-end dev: [1]   session_id: '628fe025-897d-4d26-a3df-8e57016315bf',
packages/back-end dev: [1]   sdk_language: 'js',
packages/back-end dev: [1]   sdk_version: '1.6.5',
packages/back-end dev: [1]   url: 'http://localhost/features/feature-for-experiment',
packages/back-end dev: [1]   context_json: {
packages/back-end dev: [1]     cloud: true,
packages/back-end dev: [1]     multiOrg: true,
packages/back-end dev: [1]     requestSource: 'backend',
packages/back-end dev: [1]     request_path: '/feature/feature-for-experiment/3/title',
packages/back-end dev: [1]     organizationId: '29e52e08d620678774a3f5e16a47b59076f2c720d35182b80b6afeb64fd338f2',
packages/back-end dev: [1]     cloudOrgId: 'org_4posg1kwim7kjjcrr',
packages/back-end dev: [1]     accountPlan: 'enterprise',
packages/back-end dev: [1]     superAdmin: true,
packages/back-end dev: [1]     orgDateCreated: '2025-02-25T13:47:05.703Z',
packages/back-end dev: [1]     url: '/features/[fid]',
packages/back-end dev: [1]     ip: '::1',
packages/back-end dev: [1]     ua: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36',
packages/back-end dev: [1]     role: 'admin',
packages/back-end dev: [1]     hasLicenseKey: true,
packages/back-end dev: [1]     configFile: false,
packages/back-end dev: [1]     usingSSO: true,
packages/back-end dev: [1]     buildSHA: '591795858880491f2d6043a8860157b56ea74a91',
packages/back-end dev: [1]     buildDate: '2026-02-20T14:33:51Z',
packages/back-end dev: [1]     buildVersion: '5.0.0',
packages/back-end dev: [1]     orgOwnerJobTitle: 'engineer',
packages/back-end dev: [1]     orgOwnerUsageIntents: [ 'featureFlags', 'experiments' ]
packages/back-end dev: [1]   }
packages/back-end dev: [1] }
```
