### PR TITLE
Backfill rollout rule seeds with the feature id instead of the rule id

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -6873,6 +6873,11 @@ paths:
                             type: number
                           hashAttribute:
                             type: string
+                          seed:
+                            description: >-
+                              Optional seed for the hash function; defaults to
+                              the feature id
+                            type: string
                           hashVersion:
                             anyOf:
                               - type: number
@@ -7502,6 +7507,11 @@ paths:
                           coverage:
                             type: number
                           hashAttribute:
+                            type: string
+                          seed:
+                            description: >-
+                              Optional seed for the hash function; defaults to
+                              the feature id
                             type: string
                           hashVersion:
                             anyOf:
@@ -46823,7 +46833,7 @@ components:
             hashAttribute:
               type: string
             seed:
-              description: Optional seed for the hash function; defaults to the rule id
+              description: Optional seed for the hash function; defaults to the feature id
               type: string
             hashVersion:
               description: >-

--- a/packages/back-end/src/api/features/v2Shared.ts
+++ b/packages/back-end/src/api/features/v2Shared.ts
@@ -284,6 +284,12 @@ export function mapV2ApiRuleToFeatureRule(
       ...(ruleInput.sparse !== undefined && { sparse: ruleInput.sparse }),
       coverage: ruleInput.coverage ?? 1,
       hashAttribute: ruleInput.hashAttribute ?? "",
+      // Preserve bucketing inputs on round-trips: dropping them would let
+      // the seed backfill (or the hashVersion default) re-bucket the rollout.
+      ...(ruleInput.seed !== undefined && { seed: ruleInput.seed }),
+      ...(ruleInput.hashVersion !== undefined && {
+        hashVersion: ruleInput.hashVersion,
+      }),
     };
   }
   if (ruleInput.type === "safe-rollout") {

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -2960,15 +2960,7 @@ export async function postFeatureRule(
     settings: org?.settings,
   });
 
-  // Assign rule ID if not present
-  if (!rule.id) {
-    rule.id = generateRuleId();
-  }
-  // Rollout rules always carry an explicit seed (= rule.id when user didn't set
-  // one) so monitored and non-monitored steps bucket users identically.
-  if (rule.type === "rollout" && !rule.seed) {
-    rule.seed = rule.id;
-  }
+  addIdsToFlatRules([rule], feature.id);
   let rampActionsUpdate:
     | RevisionRampCreateAction
     | RevisionRampDetachAction

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -41,7 +41,6 @@ import { ResourceEvents } from "shared/types/events/base-types";
 import { DiffResult } from "shared/types/events/diff";
 import { getDemoDatasourceProjectIdForOrganization } from "shared/demo-datasource";
 import {
-  generateRuleId,
   addIdsToFlatRules,
   getApiFeatureObj,
   getNextScheduledUpdate,
@@ -1334,12 +1333,7 @@ export async function addFeatureRule(
   user: EventUser,
   resetReview: boolean,
 ) {
-  if (!rule.id) {
-    rule.id = generateRuleId();
-  }
-  if (rule.type === "rollout" && !rule.seed) {
-    rule.seed = rule.id;
-  }
+  addIdsToFlatRules([rule], feature.id);
 
   const applicableEnvs = getEnvironmentIdsFromOrg(context.org);
   const isAllEnvs =
@@ -1631,7 +1625,8 @@ export function computeRevisionMergeChanges(
     // Ensure every rollout rule that's being published has a seed — required
     // for ramp-monitored payload stability. Rules created before the
     // seed-backfill was introduced (or attached to a ramp for the first time)
-    // get seed = rule.id here so they match the SDK's featureId fallback.
+    // get seed = feature ID here, matching the SDK's fallback when no seed is
+    // sent so the backfill never re-buckets an existing rollout.
     addIdsToFlatRules(changes.rules, feature.id);
     hasChanges = true;
   }

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -1841,17 +1841,7 @@ export function addIdsToRules(
   Object.values(environmentSettings).forEach((env) => {
     const rules = (env as unknown as { rules?: FeatureRule[] }).rules;
     if (rules && rules.length) {
-      rules.forEach((r) => {
-        if (r.type === "experiment" && !r?.trackingKey) {
-          r.trackingKey = featureId;
-        }
-        if (!r.id) {
-          r.id = generateRuleId();
-        }
-        if (r.type === "rollout" && !r.seed) {
-          r.seed = r.id;
-        }
-      });
+      addIdsToFlatRules(rules, featureId);
     }
   });
 }
@@ -1867,12 +1857,11 @@ export function addIdsToFlatRules(
     if (!r.id) {
       r.id = generateRuleId();
     }
-    // Rollout rules without an explicit seed default to their rule ID.
-    // This ensures the SDK (which falls back to rule.id when no seed is sent)
-    // and the monitored-ramp payload both bucket users identically, preventing
-    // variation hopping when a rule transitions between monitored/unmonitored.
+    // Backfill seed = feature ID — the SDK's no-seed fallback — so persisting
+    // it never changes who is in the rollout, and the monitored-ramp payload
+    // (same fallback) buckets identically across monitored/unmonitored steps.
     if (r.type === "rollout" && !r.seed) {
-      r.seed = r.id;
+      r.seed = featureId;
     }
   });
 }
@@ -3143,6 +3132,10 @@ export const fromApiEnvSettingsRulesToFeatureEnvSettingsRules = (
             match: s.matchType,
           })),
           enabled: r.enabled != null ? r.enabled : true,
+          // Preserve bucketing inputs on round-trips: dropping them would let
+          // the seed backfill (or the hashVersion default) re-bucket the rollout.
+          ...(r.seed !== undefined && { seed: r.seed }),
+          ...(r.hashVersion !== undefined && { hashVersion: r.hashVersion }),
           ...(r.sparse !== undefined && { sparse: r.sparse }),
           ...(r.prerequisites && { prerequisites: r.prerequisites }),
           ...(r.scheduleRules && { scheduleRules: r.scheduleRules }),

--- a/packages/back-end/src/util/features.ts
+++ b/packages/back-end/src/util/features.ts
@@ -1128,7 +1128,8 @@ export function getFeatureDefinition({
           // payload (tracking key, stable bucketing). Fall back to feature.id (matches
           // the SDK's own `rule.seed || featureId` fallback for force-coverage rules)
           // for older rules that predate the seed-at-write-time backfill.
-          // New rules always have seed persisted as rule.id via addIdsToFlatRules.
+          // Persisted seeds are used verbatim; existing rules may carry any
+          // value (including their rule ID) and are never rewritten.
           if (monitorInfo && r.hashAttribute) {
             const monitoredSeed = r.seed || feature.id;
             // Reuse rollout bucketing so monitored steps do not cause variation hopping.

--- a/packages/back-end/test/features.test.ts
+++ b/packages/back-end/test/features.test.ts
@@ -3280,10 +3280,12 @@ describe("generateRuleId invariant", () => {
 // Rollout rules must always carry an explicit seed so that the monitored-ramp
 // payload and the plain-rollout payload hash users through the same seed,
 // preventing variation hopping when a rule transitions between states.
+// The backfilled value must be the feature ID — the SDK's fallback when no
+// seed is sent — so persisting it never changes who is inside the rollout.
 // ---------------------------------------------------------------------------
 
 describe("addIdsToFlatRules — rollout seed backfill", () => {
-  it("backfills seed = id for a rollout rule with no explicit seed", () => {
+  it("backfills seed = feature ID for a rollout rule with no explicit seed", () => {
     const rules: FeatureInterface["rules"] = [
       {
         type: "rollout",
@@ -3300,7 +3302,7 @@ describe("addIdsToFlatRules — rollout seed backfill", () => {
       rules as Parameters<typeof addIdsToFlatRules>[0],
       "feat_1",
     );
-    expect((rules[0] as { seed?: string }).seed).toBe("fr_abc");
+    expect((rules[0] as { seed?: string }).seed).toBe("feat_1");
   });
 
   it("assigns a new id AND backfills seed when rule has neither", () => {
@@ -3319,7 +3321,7 @@ describe("addIdsToFlatRules — rollout seed backfill", () => {
     const r = rules[0] as { id?: string; seed?: string };
     expect(r.id).toBeDefined();
     expect(r.id!.startsWith("fr_")).toBe(true);
-    expect(r.seed).toBe(r.id);
+    expect(r.seed).toBe("feat_1");
   });
 
   it("preserves an explicitly-set seed and does not overwrite it", () => {
@@ -3395,13 +3397,13 @@ describe("addIdsToFlatRules — rollout seed backfill", () => {
       },
     ] as Parameters<typeof addIdsToFlatRules>[0];
     addIdsToFlatRules(rules, "feat_1");
-    expect((rules[0] as { seed?: string }).seed).toBe("fr_1");
+    expect((rules[0] as { seed?: string }).seed).toBe("feat_1");
     expect((rules[1] as { seed?: string }).seed).toBe("explicit"); // untouched
   });
 });
 
 describe("addIdsToRules — rollout seed backfill (legacy env format)", () => {
-  it("backfills seed = id for rollout rules in legacy environmentSettings", () => {
+  it("backfills seed = feature ID for rollout rules in legacy environmentSettings", () => {
     const envSettings = {
       production: {
         enabled: true,
@@ -3424,7 +3426,7 @@ describe("addIdsToRules — rollout seed backfill (legacy env format)", () => {
     );
     const rule = (envSettings.production as { rules?: { seed?: string }[] })
       .rules?.[0];
-    expect(rule?.seed).toBe("fr_legacy");
+    expect(rule?.seed).toBe("feat_legacy");
   });
 
   it("preserves an explicit seed in the legacy path", () => {

--- a/packages/back-end/test/models/computeRevisionMergeChanges.test.ts
+++ b/packages/back-end/test/models/computeRevisionMergeChanges.test.ts
@@ -91,10 +91,9 @@ describe("computeRevisionMergeChanges", () => {
 
     expect(hasChanges).toBe(true);
     expect(changes.rules?.[0].id).toBeTruthy();
-    // Rollout rules without an explicit seed default to their rule id.
-    expect((changes.rules?.[0] as { seed?: string }).seed).toBe(
-      changes.rules?.[0].id,
-    );
+    // Rollout rules without an explicit seed default to the feature id — the
+    // SDK's no-seed fallback, so the backfill never re-buckets the rollout.
+    expect((changes.rules?.[0] as { seed?: string }).seed).toBe("feat_test");
     expect("nextScheduledUpdate" in changes).toBe(true);
   });
 

--- a/packages/back-end/test/util/ramp-monitored-payload.test.ts
+++ b/packages/back-end/test/util/ramp-monitored-payload.test.ts
@@ -388,10 +388,10 @@ describe("ramp-monitored SDK payload", () => {
       expect(rule.variations).toBeUndefined();
     });
 
-    it("uses rule.id as payload seed when the rule's seed was backfilled (seed === rule.id)", () => {
-      // After addIdsToFlatRules, rollout rules have seed = rule.id persisted.
-      // The monitored payload uses r.seed, which is now rule.id. The SDK's own
-      // rollout path uses rule.seed (also rule.id after backfill), so both hash
+    it("uses the persisted seed as payload seed even when it equals rule.id", () => {
+      // Rules stamped while the backfill wrote seed = rule.id keep that value
+      // (an explicit seed is never rewritten). The monitored payload uses
+      // r.seed verbatim, and the SDK's own rollout path does too, so both hash
       // consistently and no variation hopping occurs.
       const feature = makeRolloutFeature({
         rules: [
@@ -1025,16 +1025,17 @@ describe("ramp-monitored SDK payload", () => {
     });
   });
 
-  describe("seed backfill (rule.id as default seed) prevents hopping for new rules", () => {
-    // When a rollout rule has no explicit seed, addIdsToFlatRules now persists
-    // seed = rule.id. The SDK's own rollout fallback is also `rule.seed || id`
-    // (where id is the rule id), so both paths hash identically.
-    // These tests verify that a rule whose seed equals its id produces the same
-    // bucketing across monitored and unmonitored steps — i.e. no variation hopping.
+  describe("rules stamped with seed = rule.id keep bucketing consistently", () => {
+    // An earlier version of the write-time backfill persisted seed = rule.id.
+    // Those rules keep that seed (explicit seeds are never rewritten), and both
+    // monitored and unmonitored payloads must carry it verbatim so the SDK
+    // hashes users through the same space — i.e. no variation hopping.
+    // (The backfill itself now writes the feature ID, matching the SDK's
+    // no-seed fallback `rule.seed || featureId`.)
     const RULE_ID = "fr_backfill_rule";
     const FEATURE_ID = "feat_backfill";
 
-    it("getFeatureDefinition uses rule.id as seed when rule.seed is backfilled to rule.id", () => {
+    it("getFeatureDefinition uses rule.id as seed when the persisted seed is rule.id", () => {
       const feature = makeRolloutFeature({
         id: FEATURE_ID,
         rules: [
@@ -1046,7 +1047,7 @@ describe("ramp-monitored SDK payload", () => {
             value: "true",
             coverage: 0.5,
             hashAttribute: "id",
-            seed: RULE_ID, // post-backfill: seed === rule.id
+            seed: RULE_ID, // stamped by the old backfill: seed === rule.id
             allEnvironments: true,
           },
         ],
@@ -1058,8 +1059,8 @@ describe("ramp-monitored SDK payload", () => {
       expect(rule.seed).not.toBe(FEATURE_ID);
     });
 
-    it("backfilled rule: monitored and unmonitored payloads use the same seed", () => {
-      // After addIdsToFlatRules, rule.seed === rule.id. Both monitored (experiment)
+    it("legacy-stamped rule: monitored and unmonitored payloads use the same seed", () => {
+      // Rules may carry a persisted seed === rule.id. Both monitored (experiment)
       // and unmonitored (force-coverage) payloads must carry that same seed so the
       // SDK hashes users through the same space and no variation hopping can occur.
       const ruleId = "fr_backfill_rule";

--- a/packages/shared/src/validators/features-v2.ts
+++ b/packages/shared/src/validators/features-v2.ts
@@ -511,6 +511,10 @@ const v2RuleRolloutBase = z.object({
   sparse: v2SparseRuleField,
   coverage: z.number(),
   hashAttribute: z.string(),
+  seed: z
+    .string()
+    .describe("Optional seed for the hash function; defaults to the feature id")
+    .optional(),
   hashVersion: z.union([z.literal(1), z.literal(2)]).optional(),
 });
 

--- a/packages/shared/src/validators/features.ts
+++ b/packages/shared/src/validators/features.ts
@@ -901,7 +901,7 @@ export const apiFeatureRolloutRuleValidator = namedSchema(
       seed: z
         .string()
         .describe(
-          "Optional seed for the hash function; defaults to the rule id",
+          "Optional seed for the hash function; defaults to the feature id",
         )
         .optional(),
       hashVersion: z


### PR DESCRIPTION
## The bug

Since #5906, the server backfills a missing `seed` on rollout rules with the **rule ID** at save/publish time (`addIdsToFlatRules` and three hand-copied variants). But every SDK falls back to the **feature key** when no seed is sent (`rule.seed || id` in `evalFeature`), so before the backfill these rules hashed users with the feature key.

The result: any rollout rule created before #5906 gets silently **re-bucketed** the next time its feature is saved or published — same cohort size, different members. We hit this on three production rollouts (the affected users flipped in/out of the rollout with no change to the rule's targeting or coverage). Experiments are unaffected (they bucket via tracking key / phase seed).

## The fix

- **Backfill with the feature ID instead** — the exact value the SDK already hashes with, so persisting it is a pure no-op on bucketing (verified end-to-end: created a seedless rollout rule, confirmed the persisted doc and the SDK payload both carry the feature ID).
- **Consolidate the four stamping sites** (`addIdsToRules`, `addIdsToFlatRules`, `FeatureModel.addFeatureRule`, `postFeatureRule` controller) onto `addIdsToFlatRules`, so the invariant lives in one place. The copies had already drifted once — that's this bug.
- **Preserve caller-supplied `seed`/`hashVersion` through the API converters.** The v1 env-settings converter dropped both fields on write (the backfill then rewrote the seed), and the v2 rule input schema didn't accept `seed` at all — even though the v2 docs say to GET → mutate → PUT the full `rules` array, which would silently strip a persisted seed and re-bucket the rollout. Both round-trips now preserve the fields (also verified live).
- Corrected the comments that claimed the SDK falls back to the rule ID, and the API schema description ("defaults to the rule id" → "defaults to the feature id"; spec regenerated).

## Deliberate limitations

- **Rules already stamped with their rule ID keep it.** An explicit seed is never rewritten: we can't distinguish a backfilled seed from an intentional one, and rewriting would re-bucket those rollouts a second time. Installs that want to restore a pre-#5906 cohort can manually set the rule's seed back to the feature key (hashing is deterministic, so that restores the original membership exactly).
- **Sibling seedless rollout rules on one feature share the feature-ID seed**, so their cohorts are correlated. That is the pre-#5906 SDK-fallback behavior being restored, not a new property; rules that need independent cohorts can set explicit seeds.

## Tests

- Updated the backfill unit tests to pin `seed = featureId` (including the publish-path test in `computeRevisionMergeChanges.test.ts`).
- Kept the `seed === rule.id` payload tests, re-framed as coverage for rules stamped during the rule-ID era — those exist in the wild and must keep bucketing consistently.
