### PR TITLE
agentic-bugfix/Surface a clear error when legacy JSONExtract calls hit native JSON columns

### DIFF
--- a/packages/back-end/src/integrations/ClickHouse.ts
+++ b/packages/back-end/src/integrations/ClickHouse.ts
@@ -11,7 +11,9 @@ import {
   isManagedWarehouse,
   isManagedWarehouseAwaitingJsonMigration,
   isManagedWarehouseAwaitingProvisioning,
+  isManagedWarehouseJsonSyntaxError,
   isManagedWarehouseMigrating,
+  ManagedWarehouseJsonSyntaxError,
   ManagedWarehousePendingError,
 } from "shared/util";
 import { SqlDialect } from "shared/types/sql";
@@ -124,9 +126,25 @@ export default class ClickHouse extends SqlIntegration {
         ),
       },
     });
-    const results = await client.query({ query: sql, format: "JSON" });
     // eslint-disable-next-line
-    const data: ResponseJSON<Record<string, any>[]> = await results.json();
+    let data: ResponseJSON<Record<string, any>[]>;
+    try {
+      const results = await client.query({ query: sql, format: "JSON" });
+      data = await results.json();
+    } catch (e) {
+      // Post-JSON-migration, legacy JSONExtract* calls against `attributes`/
+      // `properties` throw ClickHouse's "illegal type: JSON" error. Surface a
+      // stable code so the UI can show migration guidance instead of raw SQL.
+      if (
+        isManagedWarehouse(this.datasource) &&
+        isManagedWarehouseJsonSyntaxError(
+          e instanceof Error ? e.message : String(e),
+        )
+      ) {
+        throw new ManagedWarehouseJsonSyntaxError();
+      }
+      throw e;
+    }
     const rows = data.data ? data.data : [];
     if (isManagedWarehouse(this.datasource)) {
       normalizeManagedWarehouseDatetimes(rows, data.meta);

--- a/packages/front-end/components/ManagedWarehouse/ManagedWarehouseJsonSyntaxCallout.tsx
+++ b/packages/front-end/components/ManagedWarehouse/ManagedWarehouseJsonSyntaxCallout.tsx
@@ -1,0 +1,26 @@
+import {
+  MANAGED_WAREHOUSE_JSON_SYNTAX_DOC_URL,
+  MANAGED_WAREHOUSE_JSON_SYNTAX_MESSAGE,
+} from "shared/util";
+import Callout from "@/ui/Callout";
+import Link from "@/ui/Link";
+import Text from "@/ui/Text";
+
+// Shown when a query throws ManagedWarehouseJsonSyntaxError (see ClickHouse.ts).
+export default function ManagedWarehouseJsonSyntaxCallout() {
+  return (
+    <Callout status="info">
+      <Text>
+        {MANAGED_WAREHOUSE_JSON_SYNTAX_MESSAGE} See{" "}
+        <Link
+          href={MANAGED_WAREHOUSE_JSON_SYNTAX_DOC_URL}
+          target="_blank"
+          rel="noreferrer"
+        >
+          querying attributes and properties
+        </Link>{" "}
+        for examples.
+      </Text>
+    </Callout>
+  );
+}

--- a/packages/shared/src/util/managedWarehouse.ts
+++ b/packages/shared/src/util/managedWarehouse.ts
@@ -47,6 +47,40 @@ export function isManagedWarehousePendingQueryError(
   return message.includes(MANAGED_WAREHOUSE_PENDING_ERROR_CODE);
 }
 
+/** Docs: querying attributes/properties on native JSON columns. */
+export const MANAGED_WAREHOUSE_JSON_SYNTAX_DOC_URL =
+  "https://docs.growthbook.io/app/managed-warehouse#querying-attributes-and-properties";
+
+export const MANAGED_WAREHOUSE_JSON_SYNTAX_MESSAGE =
+  "attributes/properties are native JSON columns. Use dot notation (e.g. attributes.foo::Nullable(String)) instead of JSONExtract on a String.";
+
+/** Returned in API `error` fields so the front-end can show the JSON-syntax callout. */
+export const MANAGED_WAREHOUSE_JSON_SYNTAX_ERROR_CODE =
+  "managed_warehouse_json_syntax_error" as const;
+
+export class ManagedWarehouseJsonSyntaxError extends Error {
+  readonly code: typeof MANAGED_WAREHOUSE_JSON_SYNTAX_ERROR_CODE =
+    MANAGED_WAREHOUSE_JSON_SYNTAX_ERROR_CODE;
+
+  constructor() {
+    super(MANAGED_WAREHOUSE_JSON_SYNTAX_ERROR_CODE);
+    this.name = "ManagedWarehouseJsonSyntaxError";
+    Object.setPrototypeOf(this, ManagedWarehouseJsonSyntaxError.prototype);
+  }
+}
+
+export function isManagedWarehouseJsonSyntaxError(
+  message: string | null | undefined,
+): boolean {
+  if (message == null || message === "") return false;
+  if (message.includes(MANAGED_WAREHOUSE_JSON_SYNTAX_ERROR_CODE)) return true;
+  // ClickHouse's error when a JSONExtract* / has() call targets a native JSON
+  // column instead of a String, e.g. post-26.3 on `attributes`/`properties`.
+  return (
+    /illegal type: JSON/i.test(message) && /JSONExtract|\bhas\(/i.test(message)
+  );
+}
+
 /**
  * Information schema and other APIs may persist a legacy long message, the
  * stable pending code, or the no-events sentence alone — use this to show the
@@ -71,6 +105,9 @@ export function formatQueryExecutionErrorForApi(e: unknown): string {
     e.message === MANAGED_WAREHOUSE_PENDING_ERROR_CODE
   ) {
     return MANAGED_WAREHOUSE_PENDING_ERROR_CODE;
+  }
+  if (e instanceof ManagedWarehouseJsonSyntaxError) {
+    return MANAGED_WAREHOUSE_JSON_SYNTAX_ERROR_CODE;
   }
   return e instanceof Error ? e.message : String(e);
 }


### PR DESCRIPTION
### Features and Changes

Post-migration to native JSON attributes/properties columns, legacy JSONExtractString(attributes, 'key')-style queries throw ClickHouse's raw illegal type: JSON exception in the SQL Explorer, with no indication of the actual fix. Catch this specific error in ClickHouse.runQuery and surface a stable code + docs-linked callout instead, mirroring the existing ManagedWarehousePendingError pattern:

ManagedWarehouseJsonSyntaxError (shared/util) — thrown only for growthbook_clickhouse datasources when the ClickHouse message matches illegal type: JSON + a JSONExtract/has( call
formatQueryExecutionErrorForApi now maps it to a stable managed_warehouse_json_syntax_error code
New ManagedWarehouseJsonSyntaxCallout renders guidance + a link to the dot-notation docs section

Not in scope: a backward-compatible shim that makes old queries "just work." Unlike the identifier/dimension aliasing already done for named migrated columns, SQL Explorer allows arbitrary JSONExtract paths — there's no generic way to alias those, so the fix is a clear error, not silent compatibility.

TODO for reviewer: wire ManagedWarehouseJsonSyntaxCallout in wherever the query-result panel currently checks isManagedWarehousePendingQueryError — didn't have visibility into that exact call site.

### Testing

Run a Managed Warehouse SQL Explorer query using old-style JSONExtractString(attributes, 'key') syntax and confirm it now shows the JSON-syntax callout with a link to the docs, instead of a raw ClickHouse exception. Confirm unrelated ClickHouse errors (bad table name, syntax error, etc.) still pass through unchanged, and that BYO-ClickHouse datasources are unaffected.