### PR TITLE
Fix rollout rules re-bucketing when a legacy flag is saved

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -7153,6 +7153,11 @@ paths:
                             type: number
                           hashAttribute:
                             type: string
+                          seed:
+                            description: >-
+                              Optional seed for the hash function; defaults to
+                              the rule id
+                            type: string
                           hashVersion:
                             anyOf:
                               - type: number
@@ -7852,6 +7857,11 @@ paths:
                           coverage:
                             type: number
                           hashAttribute:
+                            type: string
+                          seed:
+                            description: >-
+                              Optional seed for the hash function; defaults to
+                              the rule id
                             type: string
                           hashVersion:
                             anyOf:

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
@@ -253,9 +253,7 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
     const rule = buildRuleFromInput(ruleInput, uuidv4());
 
     // Seed a new rollout off its own rule id so stacked rollouts hash
-    // independently — same chokepoint the v2 add endpoint uses. Without this the
-    // rule persists seedless and gets pinned to the feature id on read, which
-    // would make a second stacked rollout overlap the first.
+    // independently (same chokepoint the v2 add endpoint uses).
     addIdsToFlatRules([rule], feature.id);
 
     // Enforce the feature's JSON schema on the new rule's values (no-op for

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
@@ -20,6 +20,7 @@ import { ExperimentInterface } from "shared/types/experiment";
 import { CreateProps } from "shared/types/base-model";
 import { getLatestPhaseVariations } from "shared/experiments";
 import {
+  addIdsToFlatRules,
   assertFeatureValuesValid,
   toApiRevision,
 } from "back-end/src/services/features";
@@ -250,6 +251,12 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
     }
 
     const rule = buildRuleFromInput(ruleInput, uuidv4());
+
+    // Seed a new rollout off its own rule id so stacked rollouts hash
+    // independently — same chokepoint the v2 add endpoint uses. Without this the
+    // rule persists seedless and gets pinned to the feature id on read, which
+    // would make a second stacked rollout overlap the first.
+    addIdsToFlatRules([rule], feature.id);
 
     // Enforce the feature's JSON schema on the new rule's values (no-op for
     // config-backed values). Opt out with ?skipSchemaValidation=true.

--- a/packages/back-end/src/api/features/putFeatureRevisionRule.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionRule.ts
@@ -14,6 +14,7 @@ import {
 import { RevisionChanges } from "shared/types/feature-revision";
 import { updateRuleAtEnvIndex } from "back-end/src/util/revisionRuleOps";
 import {
+  addIdsToFlatRules,
   assertFeatureValuesValid,
   toApiRevision,
 } from "back-end/src/services/features";
@@ -288,6 +289,11 @@ export const putFeatureRevisionRule = createApiRequestHandler(
         );
     }
     const updatedRule = applyPatch(oldRule, patch);
+
+    // A coverage patch can turn a force rule into a rollout, which arrives with
+    // no seed. Stamp it so it hashes off its own rule id; an existing rollout
+    // already carries a seed here (pinned on read) and is left untouched.
+    addIdsToFlatRules([updatedRule as FeatureRule], feature.id);
 
     // Enforce the feature's JSON schema on the patched rule values (no-op for
     // config-backed values). Opt out with ?skipSchemaValidation=true.

--- a/packages/back-end/src/api/features/putFeatureRevisionRule.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionRule.ts
@@ -290,9 +290,8 @@ export const putFeatureRevisionRule = createApiRequestHandler(
     }
     const updatedRule = applyPatch(oldRule, patch);
 
-    // A coverage patch can turn a force rule into a rollout, which arrives with
-    // no seed. Stamp it so it hashes off its own rule id; an existing rollout
-    // already carries a seed here (pinned on read) and is left untouched.
+    // A coverage patch can convert a force rule to a rollout, which arrives
+    // seedless. Existing rollouts already carry a seed and are left untouched.
     addIdsToFlatRules([updatedRule as FeatureRule], feature.id);
 
     // Enforce the feature's JSON schema on the patched rule values (no-op for

--- a/packages/back-end/src/api/features/putFeatureRevisionRuleV2.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionRuleV2.ts
@@ -15,6 +15,7 @@ import {
 } from "shared/validators";
 import { RevisionChanges } from "shared/types/feature-revision";
 import {
+  addIdsToFlatRules,
   assertFeatureValuesValid,
   toApiRevisionV2,
 } from "back-end/src/services/features";
@@ -220,6 +221,11 @@ export const putFeatureRevisionRuleV2 = createApiRequestHandler(
             : v.value,
       }));
     }
+
+    // A coverage patch can turn a force rule into a rollout, which arrives with
+    // no seed. Stamp it so it hashes off its own rule id; an existing rollout
+    // already carries a seed here (pinned on read) and is left untouched.
+    addIdsToFlatRules([updatedRule as FeatureRule], feature.id);
 
     // Enforce the feature's JSON schema on the patched rule values (no-op for
     // config-backed values, whose schema lives on the config). Opt out with

--- a/packages/back-end/src/api/features/putFeatureRevisionRuleV2.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionRuleV2.ts
@@ -222,9 +222,8 @@ export const putFeatureRevisionRuleV2 = createApiRequestHandler(
       }));
     }
 
-    // A coverage patch can turn a force rule into a rollout, which arrives with
-    // no seed. Stamp it so it hashes off its own rule id; an existing rollout
-    // already carries a seed here (pinned on read) and is left untouched.
+    // A coverage patch can convert a force rule to a rollout, which arrives
+    // seedless. Existing rollouts already carry a seed and are left untouched.
     addIdsToFlatRules([updatedRule as FeatureRule], feature.id);
 
     // Enforce the feature's JSON schema on the patched rule values (no-op for

--- a/packages/back-end/src/api/features/updateFeature.ts
+++ b/packages/back-end/src/api/features/updateFeature.ts
@@ -22,6 +22,7 @@ import { getExperimentMapForFeature } from "back-end/src/models/ExperimentModel"
 import { BadRequestError } from "back-end/src/util/errors";
 import {
   addIdsToFlatRules,
+  inheritStoredRolloutSeeds,
   addIdsToRules,
   fromApiEnvSettingsRulesToFeatureEnvSettingsRules,
   getApiFeatureObj,
@@ -299,6 +300,9 @@ export const updateFeature = createApiRequestHandler(updateFeatureValidator)(
         envSettings.rules,
         feature.rules ?? [],
       );
+      // Carry seed/hashVersion forward from the stored rule when the caller
+      // echoes a rule by id but omits them, so the backfill can't re-bucket it.
+      inheritStoredRolloutSeeds(converted, feature.rules ?? []);
       // Stamp ids before flattening — `flattenV1ToV2Rules` groups by id and
       // drops id-less rules. Without this, v1 clients that omit ids would
       // lose those rules on PUT.

--- a/packages/back-end/src/api/features/updateFeature.ts
+++ b/packages/back-end/src/api/features/updateFeature.ts
@@ -300,8 +300,7 @@ export const updateFeature = createApiRequestHandler(updateFeatureValidator)(
         envSettings.rules,
         feature.rules ?? [],
       );
-      // Carry seed/hashVersion forward from the stored rule when the caller
-      // echoes a rule by id but omits them, so the backfill can't re-bucket it.
+      // Inherit stored seed/hashVersion first so the backfill can't re-bucket a legacy rollout.
       inheritStoredRolloutSeeds(converted, feature.rules ?? []);
       // Stamp ids before flattening — `flattenV1ToV2Rules` groups by id and
       // drops id-less rules. Without this, v1 clients that omit ids would

--- a/packages/back-end/src/api/features/updateFeature.ts
+++ b/packages/back-end/src/api/features/updateFeature.ts
@@ -22,12 +22,12 @@ import { getExperimentMapForFeature } from "back-end/src/models/ExperimentModel"
 import { BadRequestError } from "back-end/src/util/errors";
 import {
   addIdsToFlatRules,
-  inheritStoredRolloutSeeds,
   addIdsToRules,
   fromApiEnvSettingsRulesToFeatureEnvSettingsRules,
   getApiFeatureObj,
   getNextScheduledUpdate,
   getSavedGroupMap,
+  inheritStoredRolloutSeeds,
   updateInterfaceEnvSettingsFromApiEnvSettings,
 } from "back-end/src/services/features";
 import { getEnabledEnvironments } from "back-end/src/util/features";

--- a/packages/back-end/src/api/features/updateFeatureV2.ts
+++ b/packages/back-end/src/api/features/updateFeatureV2.ts
@@ -263,8 +263,7 @@ export const updateFeatureV2 = createApiRequestHandler(
       effectiveBaseConfig,
       effectiveProject,
     );
-    // Carry seed/hashVersion forward from the stored rule when the caller echoes
-    // a rule by id but omits them, so the backfill below can't re-bucket it.
+    // Inherit stored seed/hashVersion first so the backfill can't re-bucket a legacy rollout.
     inheritStoredRolloutSeeds(inboundFlatRules, feature.rules ?? []);
     addIdsToFlatRules(inboundFlatRules, feature.id);
     // `mapV2ApiRuleToFeatureRule` doesn't validate values; enforce the schema

--- a/packages/back-end/src/api/features/updateFeatureV2.ts
+++ b/packages/back-end/src/api/features/updateFeatureV2.ts
@@ -26,6 +26,7 @@ import {
 } from "back-end/src/models/ExperimentModel";
 import {
   addIdsToFlatRules,
+  inheritStoredRolloutSeeds,
   assertFeatureValuesValid,
   getApiFeatureObjV2,
   getNextScheduledUpdate,
@@ -262,6 +263,9 @@ export const updateFeatureV2 = createApiRequestHandler(
       effectiveBaseConfig,
       effectiveProject,
     );
+    // Carry seed/hashVersion forward from the stored rule when the caller echoes
+    // a rule by id but omits them, so the backfill below can't re-bucket it.
+    inheritStoredRolloutSeeds(inboundFlatRules, feature.rules ?? []);
     addIdsToFlatRules(inboundFlatRules, feature.id);
     // `mapV2ApiRuleToFeatureRule` doesn't validate values; enforce the schema
     // here (against the effective schema, opt-out via ?skipSchemaValidation).

--- a/packages/back-end/src/api/features/updateFeatureV2.ts
+++ b/packages/back-end/src/api/features/updateFeatureV2.ts
@@ -26,11 +26,11 @@ import {
 } from "back-end/src/models/ExperimentModel";
 import {
   addIdsToFlatRules,
-  inheritStoredRolloutSeeds,
   assertFeatureValuesValid,
   getApiFeatureObjV2,
   getNextScheduledUpdate,
   getSavedGroupMap,
+  inheritStoredRolloutSeeds,
 } from "back-end/src/services/features";
 import { assertConfigBackedFeatureValuesValid } from "back-end/src/services/configValidation";
 import { getEnabledEnvironments } from "back-end/src/util/features";

--- a/packages/back-end/src/api/features/v2Shared.ts
+++ b/packages/back-end/src/api/features/v2Shared.ts
@@ -308,6 +308,11 @@ export function mapV2ApiRuleToFeatureRule(
       ...(ruleInput.sparse !== undefined && { sparse: ruleInput.sparse }),
       coverage: ruleInput.coverage ?? 1,
       hashAttribute: ruleInput.hashAttribute ?? "",
+      // Preserve on round-trips — dropping seed/hashVersion re-buckets the rollout.
+      ...(ruleInput.seed !== undefined && { seed: ruleInput.seed }),
+      ...(ruleInput.hashVersion !== undefined && {
+        hashVersion: ruleInput.hashVersion,
+      }),
     };
   }
   if (ruleInput.type === "safe-rollout") {

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -2982,15 +2982,8 @@ export async function postFeatureRule(
     settings: org?.settings,
   });
 
-  // Assign rule ID if not present
-  if (!rule.id) {
-    rule.id = generateRuleId();
-  }
-  // Rollout rules always carry an explicit seed (= rule.id when user didn't set
-  // one) so monitored and non-monitored steps bucket users identically.
-  if (rule.type === "rollout" && !rule.seed) {
-    rule.seed = rule.id;
-  }
+  // Stamp id + rollout seed via the shared chokepoint (safe-rollout seed set above).
+  addIdsToFlatRules([rule], feature.id);
   let rampActionsUpdate:
     | RevisionRampCreateAction
     | RevisionRampDetachAction

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -114,6 +114,7 @@ import {
   addIdsToRules,
   assertFeatureDeletable,
   evaluateAllFeatures,
+  inheritStoredRolloutSeeds,
   evaluateFeature,
   FeatureDefinitionSDKPayload,
   generateRuleId,
@@ -4322,6 +4323,16 @@ export async function putFeatureRule(
   }
 
   if (!existingRule) throw new Error("Unknown rule");
+
+  // A rollout can arrive without a seed: an edit that omitted it, or a force
+  // rule the UI promoted by dropping coverage below 100%. Inherit the stored
+  // (read-time-pinned) seed so an existing rollout is never re-bucketed; a
+  // promoted rule has no rollout history, so it seeds off its own id and stacks
+  // independently. Guarantee the id first so the stamp can't mint a new one.
+  const inboundRule = rule as FeatureRule;
+  if (!inboundRule.id) inboundRule.id = ruleId;
+  inheritStoredRolloutSeeds([inboundRule], existingRules);
+  addIdsToFlatRules([inboundRule], feature.id);
 
   // Audit/review scope is the rule's own env scope.
   const ruleChangedEnvs: string[] =

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -112,9 +112,9 @@ import { generateId } from "back-end/src/util/uuid";
 import {
   addIdsToFlatRules,
   addIdsToRules,
+  inheritStoredRolloutSeeds,
   assertFeatureDeletable,
   evaluateAllFeatures,
-  inheritStoredRolloutSeeds,
   evaluateFeature,
   FeatureDefinitionSDKPayload,
   generateRuleId,
@@ -4324,11 +4324,9 @@ export async function putFeatureRule(
 
   if (!existingRule) throw new Error("Unknown rule");
 
-  // A rollout can arrive without a seed: an edit that omitted it, or a force
-  // rule the UI promoted by dropping coverage below 100%. Inherit the stored
-  // (read-time-pinned) seed so an existing rollout is never re-bucketed; a
-  // promoted rule has no rollout history, so it seeds off its own id and stacks
-  // independently. Guarantee the id first so the stamp can't mint a new one.
+  // An existing rollout inherits its stored (read-time-pinned) seed so it's
+  // never re-bucketed; a force rule the UI promoted by dropping coverage has no
+  // rollout history, so it seeds off its own id. Id first, so nothing mints one.
   const inboundRule = rule as FeatureRule;
   if (!inboundRule.id) inboundRule.id = ruleId;
   inheritStoredRolloutSeeds([inboundRule], existingRules);

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -42,7 +42,6 @@ import { ResourceEvents } from "shared/types/events/base-types";
 import { DiffResult } from "shared/types/events/diff";
 import { getDemoDatasourceProjectIdForOrganization } from "shared/demo-datasource";
 import {
-  generateRuleId,
   addIdsToFlatRules,
   getApiFeatureObj,
   getNextScheduledUpdate,
@@ -69,6 +68,7 @@ import {
 } from "back-end/src/services/rampSchedule";
 import {
   applyNonRuleFeatureUpgrades,
+  pinLegacyRolloutSeeds,
   upgradeFeatureRule,
   upgradeV0Feature,
 } from "back-end/src/util/migrations";
@@ -345,6 +345,7 @@ export function migrateRawFeatureToV2(
       envOrder: orgEnvs.map((e) => e.id),
       applicableEnvs,
     });
+    v2.rules = pinLegacyRolloutSeeds(v2.rules, v2.id);
     v2.environmentSettings = scrubEnvRules(inheritedSettings) as Record<
       string,
       FeatureEnvironment
@@ -378,6 +379,7 @@ export function migrateRawFeatureToV2(
     }
     return expandRuleEnvsForInheritance(upgraded, childrenByAncestor);
   });
+  v2.rules = pinLegacyRolloutSeeds(v2.rules, v2.id);
   v2.environmentSettings = scrubEnvRules(inheritedEnvSettings) as Record<
     string,
     FeatureEnvironment
@@ -1366,12 +1368,7 @@ export async function addFeatureRule(
   user: EventUser,
   resetReview: boolean,
 ) {
-  if (!rule.id) {
-    rule.id = generateRuleId();
-  }
-  if (rule.type === "rollout" && !rule.seed) {
-    rule.seed = rule.id;
-  }
+  addIdsToFlatRules([rule], feature.id);
 
   const applicableEnvs = getEnvironmentIdsFromOrg(context.org);
   const isAllEnvs =
@@ -1712,10 +1709,8 @@ export function computeRevisionMergeChanges(
 
   if (result.rules !== undefined) {
     changes.rules = result.rules;
-    // Ensure every rollout rule that's being published has a seed — required
-    // for ramp-monitored payload stability. Rules created before the
-    // seed-backfill was introduced (or attached to a ramp for the first time)
-    // get seed = rule.id here so they match the SDK's featureId fallback.
+    // Stamp seeds/ids on new rules being published. Legacy rules were pinned on
+    // read, so this never re-seeds (and re-buckets) an existing rollout.
     addIdsToFlatRules(changes.rules, feature.id);
     hasChanges = true;
   }

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -37,7 +37,10 @@ import {
   narrowRuleToApplicableEnvs,
   V1RulesByEnv,
 } from "back-end/src/util/flattenRules";
-import { upgradeFeatureRule } from "back-end/src/util/migrations";
+import {
+  pinLegacyRolloutSeeds,
+  upgradeFeatureRule,
+} from "back-end/src/util/migrations";
 import {
   applyEnvironmentInheritance,
   buildInheritedChildrenByAncestor,
@@ -305,6 +308,12 @@ export function buildFeatureRevisionInterface(
       applicableEnvs,
     });
   }
+
+  // Pin legacy seedless rollout rules to the feature id — see migrations.ts.
+  revision.rules = pinLegacyRolloutSeeds(
+    revision.rules as FeatureRule[],
+    revision.featureId,
+  );
 
   // JIT migration: normalize legacy ramp action shapes on read:
   //   - endCondition → cutoffDate

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -1875,6 +1875,34 @@ export function addIdsToFlatRules(
   });
 }
 
+// A bulk update replaces the whole rules array, so an inbound rollout rule that
+// echoes an existing rule by id but omits seed/hashVersion would have them reset
+// by `addIdsToFlatRules` (seed → rule.id) — re-drawing the cohort. Inherit those
+// bucketing inputs from the stored rule when the request omits them, so
+// `addIdsToFlatRules` only stamps rules with no prior history. Callers pass the
+// existing (already read-time-pinned) feature rules as `storedRules`, so a legacy
+// rule inherits its pinned feature-id seed. hashAttribute is a required input and
+// can't be dropped this way.
+export function inheritStoredRolloutSeeds(
+  inbound: FeatureRule[] = [],
+  storedRules: FeatureRule[] = [],
+): void {
+  const priorById = new Map(
+    storedRules.filter((r) => r?.id).map((r) => [r.id, r]),
+  );
+  inbound.forEach((r) => {
+    if (r?.type !== "rollout" || !r.id) return;
+    const prior = priorById.get(r.id);
+    if (prior?.type !== "rollout") return;
+    if (r.seed === undefined && prior.seed !== undefined) {
+      r.seed = prior.seed;
+    }
+    if (r.hashVersion === undefined && prior.hashVersion !== undefined) {
+      r.hashVersion = prior.hashVersion;
+    }
+  });
+}
+
 export function arrayMove<T>(
   array: Array<T>,
   from: number,

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -1876,13 +1876,9 @@ export function addIdsToFlatRules(
 }
 
 // A bulk update replaces the whole rules array, so an inbound rollout rule that
-// echoes an existing rule by id but omits seed/hashVersion would have them reset
-// by `addIdsToFlatRules` (seed → rule.id) — re-drawing the cohort. Inherit those
-// bucketing inputs from the stored rule when the request omits them, so
-// `addIdsToFlatRules` only stamps rules with no prior history. Callers pass the
-// existing (already read-time-pinned) feature rules as `storedRules`, so a legacy
-// rule inherits its pinned feature-id seed. hashAttribute is a required input and
-// can't be dropped this way.
+// echoes an existing rule by id but omits seed/hashVersion would be re-stamped
+// (seed → rule.id) by addIdsToFlatRules, re-drawing the cohort. Inherit those from
+// the stored (read-time-pinned) rule so only rules with no history get stamped.
 export function inheritStoredRolloutSeeds(
   inbound: FeatureRule[] = [],
   storedRules: FeatureRule[] = [],

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -1848,21 +1848,13 @@ export function addIdsToRules(
   Object.values(environmentSettings).forEach((env) => {
     const rules = (env as unknown as { rules?: FeatureRule[] }).rules;
     if (rules && rules.length) {
-      rules.forEach((r) => {
-        if (r.type === "experiment" && !r?.trackingKey) {
-          r.trackingKey = featureId;
-        }
-        if (!r.id) {
-          r.id = generateRuleId();
-        }
-        if (r.type === "rollout" && !r.seed) {
-          r.seed = r.id;
-        }
-      });
+      addIdsToFlatRules(rules, featureId);
     }
   });
 }
 
+// Single write-time chokepoint for rule ids, experiment tracking keys, and
+// rollout seeds — consolidated so the invariant can't drift across call sites.
 export function addIdsToFlatRules(
   rules: FeatureRule[] = [],
   featureId: string,
@@ -1874,10 +1866,9 @@ export function addIdsToFlatRules(
     if (!r.id) {
       r.id = generateRuleId();
     }
-    // Rollout rules without an explicit seed default to their rule ID.
-    // This ensures the SDK (which falls back to rule.id when no seed is sent)
-    // and the monitored-ramp payload both bucket users identically, preventing
-    // variation hopping when a rule transitions between monitored/unmonitored.
+    // Seed new rollout rules off their own id so stacked rollouts hash
+    // independently. Legacy seedless rules are pinned to the feature id on read
+    // (`pinLegacyRolloutSeeds`), so this only ever applies to new rules.
     if (r.type === "rollout" && !r.seed) {
       r.seed = r.id;
     }
@@ -2027,6 +2018,8 @@ export function normalizeRuleForApi(rule: FeatureRule): ApiFeatureRule {
         coverage: rule.coverage ?? 1,
         hashAttribute: rule.hashAttribute,
         seed: rule.seed,
+        // Emit so a GET→edit→PUT round-trip preserves it (else the rollout re-buckets).
+        hashVersion: rule.hashVersion,
       };
     case "experiment":
       return {
@@ -3176,6 +3169,9 @@ export const fromApiEnvSettingsRulesToFeatureEnvSettingsRules = (
             match: s.matchType,
           })),
           enabled: r.enabled != null ? r.enabled : true,
+          // Preserve on round-trips — dropping seed/hashVersion re-buckets the rollout.
+          ...(r.seed !== undefined && { seed: r.seed }),
+          ...(r.hashVersion !== undefined && { hashVersion: r.hashVersion }),
           ...(r.sparse !== undefined && { sparse: r.sparse }),
           ...(r.prerequisites && { prerequisites: r.prerequisites }),
           ...(r.scheduleRules && { scheduleRules: r.scheduleRules }),

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -1890,8 +1890,9 @@ export function inheritStoredRolloutSeeds(
     if (r?.type !== "rollout" || !r.id) return;
     const prior = priorById.get(r.id);
     if (prior?.type !== "rollout") return;
-    // `!r.seed` (not `=== undefined`) to match addIdsToFlatRules and the read
-    // pin, so an empty-string seed can't slip past inheritance and get stamped.
+    // Seed uses `!r.seed` to match addIdsToFlatRules and the read pin, so an
+    // empty string counts as unset; hashVersion is numeric, so only `undefined`
+    // does.
     if (!r.seed && prior.seed) {
       r.seed = prior.seed;
     }

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -1890,7 +1890,9 @@ export function inheritStoredRolloutSeeds(
     if (r?.type !== "rollout" || !r.id) return;
     const prior = priorById.get(r.id);
     if (prior?.type !== "rollout") return;
-    if (r.seed === undefined && prior.seed !== undefined) {
+    // `!r.seed` (not `=== undefined`) to match addIdsToFlatRules and the read
+    // pin, so an empty-string seed can't slip past inheritance and get stamped.
+    if (!r.seed && prior.seed) {
       r.seed = prior.seed;
     }
     if (r.hashVersion === undefined && prior.hashVersion !== undefined) {

--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -383,6 +383,21 @@ export function upgradeFeatureRule(rule: FeatureRule): FeatureRule {
   return rule;
 }
 
+// Materialize the SDK's own no-seed fallback (`rule.seed || featureId`) for
+// seedless rollout rules, so the write-time default (rule.id) can't re-bucket a
+// legacy rollout on its next save. New rules are seeded at write, so anything
+// seedless on read is legacy. Safe rollouts keep their own seed.
+export function pinLegacyRolloutSeeds<T extends FeatureRule>(
+  rules: T[] = [],
+  featureId: string,
+): T[] {
+  return rules.map((r) =>
+    r != null && r.type === "rollout" && !r.seed
+      ? { ...r, seed: featureId }
+      : r,
+  );
+}
+
 // Non-rule backfills shared by v1 and v2 docs (`version`, `jsonSchema.*`).
 // Mutates and returns. Rules go through `upgradeFeatureRule` separately.
 export function applyNonRuleFeatureUpgrades<

--- a/packages/back-end/test/api/features.test.ts
+++ b/packages/back-end/test/api/features.test.ts
@@ -48,6 +48,7 @@ jest.mock("back-end/src/services/features", () => ({
   getNextScheduledUpdate: jest.fn(),
   addIdsToRules: jest.fn(),
   addIdsToFlatRules: jest.fn(),
+  inheritStoredRolloutSeeds: jest.fn(),
   createInterfaceEnvSettingsFromApiEnvSettings: jest.fn(),
   updateInterfaceEnvSettingsFromApiEnvSettings: jest.fn(),
   buildFeatureRulesFromApiEnvSettings: jest.fn(() => []),

--- a/packages/back-end/test/api/features/putFeatureRevisionRule.test.ts
+++ b/packages/back-end/test/api/features/putFeatureRevisionRule.test.ts
@@ -4,10 +4,8 @@ import { applyPatch } from "back-end/src/api/features/putFeatureRevisionRule";
 import { addIdsToFlatRules } from "back-end/src/services/features";
 
 // `applyPatch` re-infers force-vs-rollout from the effective coverage, so a
-// coverage patch can turn a force rule into a rollout. That converted rule has
-// no seed, so the handler stamps it — otherwise it would persist seedless, get
-// pinned to the feature id on read, and overlap any sibling rollout in hash
-// space instead of bucketing independently.
+// coverage patch converts a force rule into a seedless rollout — which the
+// handler must stamp, or it loses independent bucketing.
 describe("applyPatch — force/rollout seed stamping", () => {
   const force = {
     id: "fr_1",
@@ -18,6 +16,8 @@ describe("applyPatch — force/rollout seed stamping", () => {
   } as unknown as FeatureRule;
 
   const patch = (p: Record<string, unknown>) => p as unknown as RulePatchInput;
+  const stamp = (r: unknown) => addIdsToFlatRules([r as FeatureRule], "feat_1");
+  const seedOf = (r: unknown) => (r as { seed?: string }).seed;
 
   it("converts force → rollout with no seed, then stamps the rule id", () => {
     const converted = applyPatch(
@@ -25,11 +25,11 @@ describe("applyPatch — force/rollout seed stamping", () => {
       patch({ coverage: 0.5, hashAttribute: "id" }),
     );
     expect(converted.type).toBe("rollout");
-    expect((converted as { seed?: string }).seed).toBeUndefined();
+    expect(seedOf(converted)).toBeUndefined();
 
-    addIdsToFlatRules([converted as FeatureRule], "feat_1");
-    expect((converted as { seed?: string }).seed).toBe("fr_1");
-    expect((converted as { seed?: string }).seed).not.toBe("feat_1");
+    stamp(converted);
+    expect(seedOf(converted)).toBe("fr_1");
+    expect(seedOf(converted)).not.toBe("feat_1");
   });
 
   it("leaves a rollout's existing (read-time-pinned) seed untouched", () => {
@@ -42,8 +42,8 @@ describe("applyPatch — force/rollout seed stamping", () => {
     } as unknown as FeatureRule;
 
     const updated = applyPatch(legacy, patch({ coverage: 0.25 }));
-    addIdsToFlatRules([updated as FeatureRule], "feat_1");
-    expect((updated as { seed?: string }).seed).toBe("feat_1");
+    stamp(updated);
+    expect(seedOf(updated)).toBe("feat_1");
   });
 
   it("honors an explicit seed in the patch", () => {
@@ -51,7 +51,7 @@ describe("applyPatch — force/rollout seed stamping", () => {
       force,
       patch({ coverage: 0.5, hashAttribute: "id", seed: "custom" }),
     );
-    addIdsToFlatRules([converted as FeatureRule], "feat_1");
-    expect((converted as { seed?: string }).seed).toBe("custom");
+    stamp(converted);
+    expect(seedOf(converted)).toBe("custom");
   });
 });

--- a/packages/back-end/test/api/features/putFeatureRevisionRule.test.ts
+++ b/packages/back-end/test/api/features/putFeatureRevisionRule.test.ts
@@ -1,0 +1,57 @@
+import type { FeatureRule } from "shared/types/feature";
+import type { RulePatchInput } from "shared/validators";
+import { applyPatch } from "back-end/src/api/features/putFeatureRevisionRule";
+import { addIdsToFlatRules } from "back-end/src/services/features";
+
+// `applyPatch` re-infers force-vs-rollout from the effective coverage, so a
+// coverage patch can turn a force rule into a rollout. That converted rule has
+// no seed, so the handler stamps it — otherwise it would persist seedless, get
+// pinned to the feature id on read, and overlap any sibling rollout in hash
+// space instead of bucketing independently.
+describe("applyPatch — force/rollout seed stamping", () => {
+  const force = {
+    id: "fr_1",
+    type: "force",
+    description: "",
+    value: "true",
+    enabled: true,
+  } as unknown as FeatureRule;
+
+  const patch = (p: Record<string, unknown>) => p as unknown as RulePatchInput;
+
+  it("converts force → rollout with no seed, then stamps the rule id", () => {
+    const converted = applyPatch(
+      force,
+      patch({ coverage: 0.5, hashAttribute: "id" }),
+    );
+    expect(converted.type).toBe("rollout");
+    expect((converted as { seed?: string }).seed).toBeUndefined();
+
+    addIdsToFlatRules([converted as FeatureRule], "feat_1");
+    expect((converted as { seed?: string }).seed).toBe("fr_1");
+    expect((converted as { seed?: string }).seed).not.toBe("feat_1");
+  });
+
+  it("leaves a rollout's existing (read-time-pinned) seed untouched", () => {
+    const legacy = {
+      ...force,
+      type: "rollout",
+      coverage: 0.5,
+      hashAttribute: "id",
+      seed: "feat_1", // pinned to the feature id on read
+    } as unknown as FeatureRule;
+
+    const updated = applyPatch(legacy, patch({ coverage: 0.25 }));
+    addIdsToFlatRules([updated as FeatureRule], "feat_1");
+    expect((updated as { seed?: string }).seed).toBe("feat_1");
+  });
+
+  it("honors an explicit seed in the patch", () => {
+    const converted = applyPatch(
+      force,
+      patch({ coverage: 0.5, hashAttribute: "id", seed: "custom" }),
+    );
+    addIdsToFlatRules([converted as FeatureRule], "feat_1");
+    expect((converted as { seed?: string }).seed).toBe("custom");
+  });
+});

--- a/packages/back-end/test/api/features/v2Shared.test.ts
+++ b/packages/back-end/test/api/features/v2Shared.test.ts
@@ -172,6 +172,37 @@ describe("mapV2ApiRuleToFeatureRule", () => {
         hashAttribute: "userId",
       });
     });
+
+    // GET→edit→PUT must persist id/seed/hashVersion verbatim (else re-bucketing).
+    it("preserves id, seed, and hashVersion on round-trip", () => {
+      const out = mapV2ApiRuleToFeatureRule({
+        id: "fr_explicit",
+        type: "rollout",
+        value: "v",
+        coverage: 0.5,
+        hashAttribute: "userId",
+        seed: "my-seed",
+        hashVersion: 2,
+      } as ApiRuleV2Input);
+      expect(out).toMatchObject({
+        id: "fr_explicit",
+        seed: "my-seed",
+        hashVersion: 2,
+        hashAttribute: "userId",
+      });
+    });
+
+    // Absent seed stays absent — the write-time backfill owns the default.
+    it("does not invent a seed when the caller omits one", () => {
+      const out = mapV2ApiRuleToFeatureRule({
+        type: "rollout",
+        value: "v",
+        coverage: 0.5,
+        hashAttribute: "userId",
+      } as ApiRuleV2Input);
+      expect(out).not.toHaveProperty("seed");
+      expect(out).not.toHaveProperty("hashVersion");
+    });
   });
 
   describe("experiment-ref rule", () => {

--- a/packages/back-end/test/features.test.ts
+++ b/packages/back-end/test/features.test.ts
@@ -15,6 +15,7 @@ import {
   generateRuleId,
   addIdsToFlatRules,
   addIdsToRules,
+  inheritStoredRolloutSeeds,
   getFeatureDefinitionsResponse,
   hashStrings,
   sha256,
@@ -3711,5 +3712,76 @@ describe("addIdsToRules — rollout seed backfill (legacy env format)", () => {
     const rule = (envSettings.production as { rules?: { seed?: string }[] })
       .rules?.[0];
     expect(rule?.seed).toBe("keep-me");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inheritStoredRolloutSeeds — a bulk update that echoes a rollout rule by id
+// but omits seed/hashVersion must inherit them from the stored (already
+// read-time-pinned) rule, so the write-time backfill can't re-bucket it.
+// ---------------------------------------------------------------------------
+describe("inheritStoredRolloutSeeds", () => {
+  const inboundRollout = (over: Record<string, unknown> = {}) =>
+    ({
+      id: "fr_legacy",
+      type: "rollout",
+      value: "true",
+      coverage: 0.5,
+      hashAttribute: "id",
+      ...over,
+    }) as unknown as FeatureInterface["rules"][number];
+
+  const storedRollout = (over: Record<string, unknown> = {}) =>
+    ({
+      id: "fr_legacy",
+      type: "rollout",
+      value: "true",
+      coverage: 0.5,
+      hashAttribute: "id",
+      seed: "feat_1", // pinned to the feature id at read time
+      ...over,
+    }) as unknown as FeatureInterface["rules"][number];
+
+  it("inherits a stored seed when the inbound rule omits it", () => {
+    const inbound = [inboundRollout()];
+    inheritStoredRolloutSeeds(inbound, [storedRollout()]);
+    expect((inbound[0] as { seed?: string }).seed).toBe("feat_1");
+  });
+
+  it("inherits stored hashVersion when omitted", () => {
+    const inbound = [inboundRollout()];
+    inheritStoredRolloutSeeds(inbound, [
+      storedRollout({ hashVersion: 1, seed: "feat_1" }),
+    ]);
+    expect((inbound[0] as { hashVersion?: number }).hashVersion).toBe(1);
+  });
+
+  it("does not override a seed the caller explicitly sent", () => {
+    const inbound = [inboundRollout({ seed: "client-seed" })];
+    inheritStoredRolloutSeeds(inbound, [storedRollout()]);
+    expect((inbound[0] as { seed?: string }).seed).toBe("client-seed");
+  });
+
+  it("only matches by id — a new rule (no stored match) is left seedless", () => {
+    const inbound = [inboundRollout({ id: "fr_new" })];
+    inheritStoredRolloutSeeds(inbound, [storedRollout()]);
+    expect((inbound[0] as { seed?: string }).seed).toBeUndefined();
+  });
+
+  it("ignores non-rollout stored/inbound rules", () => {
+    const inbound = [inboundRollout({ type: "force" })];
+    inheritStoredRolloutSeeds(inbound, [storedRollout()]);
+    expect(inbound[0]).not.toHaveProperty("seed");
+  });
+
+  // The regression Anna reported: a client echoes a legacy rule by id but omits
+  // the seed. With inheritance it settles on the stored (feature-id) seed; the
+  // backfill must NOT then stamp the rule id.
+  it("keeps a legacy rollout on the feature-id seed through inherit → backfill", () => {
+    const inbound = [inboundRollout()]; // no seed
+    inheritStoredRolloutSeeds(inbound, [storedRollout({ seed: "feat_1" })]);
+    addIdsToFlatRules(inbound as FeatureInterface["rules"], "feat_1");
+    expect((inbound[0] as { seed?: string }).seed).toBe("feat_1");
+    expect((inbound[0] as { seed?: string }).seed).not.toBe(inbound[0].id);
   });
 });

--- a/packages/back-end/test/features.test.ts
+++ b/packages/back-end/test/features.test.ts
@@ -3402,6 +3402,41 @@ describe("buildFeatureRulesFromApiEnvSettings", () => {
     expect(rules[0]).not.toHaveProperty("prerequisites");
   });
 
+  // GET→edit→PUT must persist rollout id/seed/hashVersion verbatim (else re-bucketing).
+  it("preserves rollout id/seed/hashVersion through the v1 converter", () => {
+    const rules = buildFeatureRulesFromApiEnvSettings(
+      mockContext,
+      baseFeature,
+      [{ id: "production" }],
+      {
+        production: {
+          enabled: true,
+          rules: [
+            {
+              id: "fr_explicit",
+              type: "rollout",
+              value: "true",
+              coverage: 0.5,
+              hashAttribute: "userId",
+              seed: "my-seed",
+              hashVersion: 2,
+            },
+          ],
+        },
+      },
+    );
+    const rule = rules[0] as {
+      id?: string;
+      seed?: string;
+      hashAttribute?: string;
+      hashVersion?: number;
+    };
+    expect(rule.id).toBe("fr_explicit");
+    expect(rule.seed).toBe("my-seed");
+    expect(rule.hashAttribute).toBe("userId");
+    expect(rule.hashVersion).toBe(2);
+  });
+
   // ---------------------------------------------------------------------------
   // Content-identical rules across envs must merge into ONE v2 rule with a
   // multi-env footprint — not two split rules with the second id suffixed by

--- a/packages/back-end/test/features.test.ts
+++ b/packages/back-end/test/features.test.ts
@@ -3774,6 +3774,30 @@ describe("inheritStoredRolloutSeeds", () => {
     expect(inbound[0]).not.toHaveProperty("seed");
   });
 
+  // force → rollout promotion: the stored rule shares the id but is a force
+  // rule, so there's no cohort to preserve. Inheritance must skip it, leaving
+  // the backfill to seed it off its own id for independent stacking.
+  it("skips inheritance when the stored rule is a force rule (promotion)", () => {
+    const inbound = [inboundRollout()];
+    const storedForce = {
+      id: "fr_legacy",
+      type: "force",
+      value: "true",
+    } as unknown as FeatureInterface["rules"][number];
+
+    inheritStoredRolloutSeeds(inbound, [storedForce]);
+    expect((inbound[0] as { seed?: string }).seed).toBeUndefined();
+
+    addIdsToFlatRules(inbound as FeatureInterface["rules"], "feat_1");
+    expect((inbound[0] as { seed?: string }).seed).toBe("fr_legacy");
+  });
+
+  it("treats an empty-string seed as absent and inherits the stored seed", () => {
+    const inbound = [inboundRollout({ seed: "" })];
+    inheritStoredRolloutSeeds(inbound, [storedRollout()]);
+    expect((inbound[0] as { seed?: string }).seed).toBe("feat_1");
+  });
+
   // The regression Anna reported: a client echoes a legacy rule by id but omits
   // the seed. With inheritance it settles on the stored (feature-id) seed; the
   // backfill must NOT then stamp the rule id.

--- a/packages/back-end/test/migrations.test.ts
+++ b/packages/back-end/test/migrations.test.ts
@@ -42,6 +42,7 @@ import { SavedGroupModel } from "back-end/src/models/SavedGroupModel";
 import {
   migrateExperimentReport,
   migrateSnapshot,
+  pinLegacyRolloutSeeds,
   upgradeDatasourceObject,
   upgradeExperimentDoc,
   upgradeFeatureRule,
@@ -2966,5 +2967,57 @@ describe("saved group migrations", () => {
       type: "condition",
       condition: JSON.stringify({ id: { $eq: "123" } }),
     });
+  });
+});
+
+describe("pinLegacyRolloutSeeds", () => {
+  const rollout = (over: Partial<FeatureRule> = {}) =>
+    ({
+      id: "fr_rule",
+      type: "rollout",
+      value: "true",
+      coverage: 0.5,
+      hashAttribute: "id",
+      ...over,
+    }) as FeatureRule;
+
+  it("pins a seedless rollout rule to the feature id", () => {
+    const [pinned] = pinLegacyRolloutSeeds([rollout()], "feat_1");
+    expect((pinned as { seed?: string }).seed).toBe("feat_1");
+  });
+
+  it("leaves an explicitly-seeded rollout rule untouched", () => {
+    const [pinned] = pinLegacyRolloutSeeds(
+      [rollout({ seed: "fr_rule" })],
+      "feat_1",
+    );
+    // An existing seed (rule.id default or a custom seed) is never rewritten.
+    expect((pinned as { seed?: string }).seed).toBe("fr_rule");
+  });
+
+  it("does not touch non-rollout rules", () => {
+    const force = { id: "fr_f", type: "force", value: "true" } as FeatureRule;
+    const safe = {
+      id: "fr_s",
+      type: "safe-rollout",
+      safeRolloutId: "sr_1",
+    } as unknown as FeatureRule;
+    const [pForce, pSafe] = pinLegacyRolloutSeeds([force, safe], "feat_1");
+    expect(pForce).not.toHaveProperty("seed");
+    // Safe rollouts carry their own random seed and are never pinned.
+    expect((pSafe as { seed?: string }).seed).toBeUndefined();
+  });
+
+  it("does not mutate the input rule objects", () => {
+    const input = rollout();
+    pinLegacyRolloutSeeds([input], "feat_1");
+    expect((input as { seed?: string }).seed).toBeUndefined();
+  });
+
+  it("tolerates sparse null array entries", () => {
+    const rules = [null, rollout()] as unknown as FeatureRule[];
+    const out = pinLegacyRolloutSeeds(rules, "feat_1");
+    expect(out[0]).toBeNull();
+    expect((out[1] as { seed?: string }).seed).toBe("feat_1");
   });
 });

--- a/packages/back-end/test/models/FeatureModel.test.ts
+++ b/packages/back-end/test/models/FeatureModel.test.ts
@@ -8,6 +8,7 @@ import {
   buildFeatureUpdate,
   toInterface,
 } from "back-end/src/models/FeatureModel";
+import { getFeatureDefinition } from "back-end/src/util/features";
 import { ReqContext } from "back-end/types/request";
 
 // ---------------------------------------------------------------------------
@@ -1649,5 +1650,108 @@ describe("toInterface round-trip", () => {
     const result = toInterface(doc, mockContext());
     expect((result as unknown as { _id?: unknown })._id).toBeUndefined();
     expect((result as unknown as { __v?: unknown }).__v).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legacy rollout seed pin, end to end: the hydration path (migrateRawFeatureToV2)
+// must materialize a seedless rollout's seed as the feature id, and that value
+// must reach the SDK payload — the seed the SDK already resolves via its own
+// `rule.seed || featureId` fallback, so no live user moves.
+// ---------------------------------------------------------------------------
+describe("legacy rollout seed pin (hydration → SDK payload)", () => {
+  const rolloutRule = (
+    id: string,
+    opts: Partial<FeatureRule> = {},
+  ): FeatureRule =>
+    v2Rule(id, {
+      type: "rollout",
+      coverage: 0.5,
+      hashAttribute: "id",
+      ...opts,
+    } as Partial<FeatureRule>);
+
+  const v2Doc = (rules: FeatureRule[]) =>
+    ({
+      ...BASE_META,
+      environmentSettings: {
+        dev: { enabled: true, prerequisites: [] },
+        production: { enabled: true, prerequisites: [] },
+      },
+      rules,
+      prerequisites: [],
+    }) as unknown as LegacyFeatureInterface;
+
+  const payloadSeed = (feature: FeatureInterface): string | undefined => {
+    const def = getFeatureDefinition({
+      feature,
+      environment: "production",
+      groupMap: new Map(),
+      experimentMap: new Map(),
+      safeRolloutMap: new Map(),
+    });
+    return (def?.rules?.[0] as { seed?: string } | undefined)?.seed;
+  };
+
+  it("pins a seedless v2 rollout rule to the feature id on hydration", () => {
+    const out = migrateRawFeatureToV2(
+      v2Doc([rolloutRule("r1")]),
+      mockContext(),
+    );
+    expect((out.rules[0] as { seed?: string }).seed).toBe(FEATURE_ID);
+  });
+
+  it("pins a seedless v1 rollout rule to the feature id on hydration", () => {
+    const v1 = {
+      ...BASE_META,
+      environmentSettings: {
+        production: {
+          enabled: true,
+          rules: [
+            v1Rule("r1", {
+              type: "rollout",
+              coverage: 0.5,
+              hashAttribute: "id",
+            }),
+          ],
+        },
+      },
+    } as unknown as LegacyFeatureInterface;
+    const out = migrateRawFeatureToV2(v1, mockContext());
+    const rollout = out.rules.find((r) => r.type === "rollout");
+    expect((rollout as { seed?: string }).seed).toBe(FEATURE_ID);
+  });
+
+  it("leaves an explicit rollout seed untouched on hydration", () => {
+    const out = migrateRawFeatureToV2(
+      v2Doc([rolloutRule("r1", { seed: "custom" } as Partial<FeatureRule>)]),
+      mockContext(),
+    );
+    expect((out.rules[0] as { seed?: string }).seed).toBe("custom");
+  });
+
+  it("does not add a seed to a non-rollout rule on hydration", () => {
+    const out = migrateRawFeatureToV2(v2Doc([v2Rule("f1")]), mockContext());
+    expect(out.rules[0]).not.toHaveProperty("seed");
+  });
+
+  it("serves the feature id as the rollout's SDK-payload seed (raw seedless → hydrate → payload)", () => {
+    const hydrated = migrateRawFeatureToV2(
+      v2Doc([rolloutRule("r1")]),
+      mockContext(),
+    );
+    expect(payloadSeed(hydrated)).toBe(FEATURE_ID);
+  });
+
+  it("serves a new rollout's own rule-id seed (independent stacking survives to the payload)", () => {
+    // A rule written after the fix carries seed = rule.id; the payload must use
+    // it, not the feature id, so stacked rollouts stay in independent spaces.
+    const hydrated = migrateRawFeatureToV2(
+      v2Doc([rolloutRule("r1", { seed: "r1" } as Partial<FeatureRule>)]),
+      mockContext(),
+    );
+    const seed = payloadSeed(hydrated);
+    expect(seed).toBe("r1");
+    expect(seed).not.toBe(FEATURE_ID);
   });
 });

--- a/packages/back-end/test/models/computeRevisionMergeChanges.test.ts
+++ b/packages/back-end/test/models/computeRevisionMergeChanges.test.ts
@@ -98,6 +98,36 @@ describe("computeRevisionMergeChanges", () => {
     expect("nextScheduledUpdate" in changes).toBe(true);
   });
 
+  // A legacy rule pinned to the feature id on read must survive publish
+  // untouched — stamping rule.id here would re-bucket the cohort.
+  it("preserves a seed already pinned to the feature id (no re-bucketing on publish)", () => {
+    const rules = [
+      {
+        id: "fr_legacy",
+        type: "rollout",
+        description: "",
+        value: "true",
+        coverage: 0.5,
+        hashAttribute: "id",
+        seed: "feat_test", // pinned at read time to the feature id
+        enabled: true,
+        allEnvironments: true,
+      },
+    ] as unknown as FeatureRule[];
+
+    const { changes } = computeRevisionMergeChanges(
+      mockContext(),
+      makeFeature(),
+      REVISION,
+      { rules } as MergeResultChanges,
+    );
+
+    expect((changes.rules?.[0] as { seed?: string }).seed).toBe("feat_test");
+    expect((changes.rules?.[0] as { seed?: string }).seed).not.toBe(
+      changes.rules?.[0].id,
+    );
+  });
+
   it("skips no-op environment toggles so the SDK payload cache is preserved", () => {
     const { changes, hasChanges } = computeRevisionMergeChanges(
       mockContext(),

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -1,4 +1,5 @@
 import { useForm, FormProvider } from "react-hook-form";
+import omit from "lodash/omit";
 import {
   FeatureEnvironment,
   FeatureInterface,
@@ -143,7 +144,11 @@ const genFormDefaultValues = ({
         targetingProjects: featureToDuplicate.targetingProjects ?? [],
         tags: featureToDuplicate.tags,
         environmentSettings,
-        rules: featureToDuplicate.rules ?? [],
+        // Drop rollout seeds so the copy buckets independently of the source
+        // flag; the back end stamps each rule's own id on create.
+        rules: (featureToDuplicate.rules ?? []).map((r) =>
+          r?.type === "rollout" ? omit(r, ["seed"]) : r,
+        ) as FeatureInterface["rules"],
         customFields: customFieldValues,
         holdout: featureToDuplicate.holdout?.id
           ? featureToDuplicate.holdout

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -148,7 +148,7 @@ const genFormDefaultValues = ({
         // flag; the back end stamps each rule's own id on create.
         rules: (featureToDuplicate.rules ?? []).map((r) =>
           r?.type === "rollout" ? omit(r, ["seed"]) : r,
-        ) as FeatureInterface["rules"],
+        ),
         customFields: customFieldValues,
         holdout: featureToDuplicate.holdout?.id
           ? featureToDuplicate.holdout

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -1232,6 +1232,19 @@ export default function RuleModal({
         // eslint-disable-next-line
         delete (values as any).seed;
         delete (values as { hashVersion?: number }).hashVersion;
+      } else if (values.type === "rollout") {
+        // A duplicate must bucket independently of its original, so drop the
+        // seed and let the back end stamp the new rule's id. Opt in to the same
+        // cohort with `sameSeed` (mirrors the safe-rollout branch above).
+        if (
+          mode === "duplicate" &&
+          !(values as { sameSeed?: boolean }).sameSeed
+        ) {
+          // eslint-disable-next-line
+          delete (values as any).seed;
+        }
+        // eslint-disable-next-line
+        delete (values as any).sameSeed;
       }
       if (
         values.scheduleRules &&

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -408,11 +408,9 @@ export default function RuleModal({
   const defaultValues = {
     ...defaultRuleValues,
     ...convertRuleToFormValues(rule),
-    // A duplicated rollout must bucket independently of its original, so start
-    // from an empty seed and let the back end stamp the new rule's id. The Seed
-    // field stays editable for anyone who wants to reuse the original's cohort.
-    // Safe-rollout duplicates are excluded — they opt in via their own
-    // "Same seed" checkbox.
+    // A duplicated rollout starts seedless so it buckets independently; the Seed
+    // field stays editable to reuse the original's cohort. Safe-rollout has its
+    // own "Same seed" checkbox, so it's excluded here.
     ...(mode === "duplicate" && rule?.type === "rollout" ? { seed: "" } : {}),
     // Pre-set the ID for new rollout rules so ramp creation can reference it
     // without a second round-trip. Back-end preserves a truthy id from the client.

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -408,6 +408,12 @@ export default function RuleModal({
   const defaultValues = {
     ...defaultRuleValues,
     ...convertRuleToFormValues(rule),
+    // A duplicated rollout must bucket independently of its original, so start
+    // from an empty seed and let the back end stamp the new rule's id. The Seed
+    // field stays editable for anyone who wants to reuse the original's cohort.
+    // Safe-rollout duplicates are excluded — they opt in via their own
+    // "Same seed" checkbox.
+    ...(mode === "duplicate" && rule?.type === "rollout" ? { seed: "" } : {}),
     // Pre-set the ID for new rollout rules so ramp creation can reference it
     // without a second round-trip. Back-end preserves a truthy id from the client.
     ...(mode === "create" && !rule ? { id: pregenRuleId } : {}),
@@ -1233,18 +1239,12 @@ export default function RuleModal({
         delete (values as any).seed;
         delete (values as { hashVersion?: number }).hashVersion;
       } else if (values.type === "rollout") {
-        // A duplicate must bucket independently of its original, so drop the
-        // seed and let the back end stamp the new rule's id. Opt in to the same
-        // cohort with `sameSeed` (mirrors the safe-rollout branch above).
-        if (
-          mode === "duplicate" &&
-          !(values as { sameSeed?: boolean }).sameSeed
-        ) {
+        // An empty seed means "stamp this rule's own id" (the default for
+        // duplicates) — omit it rather than submitting "".
+        if (!values.seed) {
           // eslint-disable-next-line
           delete (values as any).seed;
         }
-        // eslint-disable-next-line
-        delete (values as any).sameSeed;
       }
       if (
         values.scheduleRules &&

--- a/packages/shared/src/validators/features-v2.ts
+++ b/packages/shared/src/validators/features-v2.ts
@@ -528,6 +528,10 @@ const v2RuleRolloutBase = z.object({
   sparse: v2SparseRuleField,
   coverage: z.number(),
   hashAttribute: z.string(),
+  seed: z
+    .string()
+    .describe("Optional seed for the hash function; defaults to the rule id")
+    .optional(),
   hashVersion: z.union([z.literal(1), z.literal(2)]).optional(),
 });
 


### PR DESCRIPTION
## The bug

Rollout rules created before we started persisting a `seed` were stored without one, and every SDK buckets a seedless rollout by the **feature key** (`rule.seed || featureId`). When such a flag was next saved or published, the server backfilled the missing seed with the **rule id** — silently re-drawing which users were in the rollout (same coverage %, different people). This hit three production rollouts.

## The fix

- **New rollout rules seed off their own rule id**, so stacked rollouts hash independently — a 50% + 50% stack serves ~75% of traffic rather than 50%. This preserves the independence Safe Rollouts have always had via their random seed.
- **Pre-existing seedless rollout rules are pinned to the feature key at read time** — the SDK's own fallback — so saving or publishing a legacy flag never re-draws its cohort. They settle onto that seed permanently on their next save.
- **Every path that creates or edits a rollout now seeds it consistently**: the bulk feature update (v1 + v2), the per-rule add and edit endpoints, the UI rule editor, and rule/feature duplication. Several of these previously left a rollout seedless — including a force rule promoted to a rollout by dropping coverage below 100% — which meant a second stacked rollout silently served no traffic.
- **`seed` and `hashVersion` survive the v1 and v2 REST round-trips.** v2's rule input schema didn't accept `seed`, so the documented GET → edit → PUT flow dropped it and re-bucketed the rollout; `hashVersion` wasn't returned at all. A bulk update that omits either now inherits it from the stored rule, so a client that rebuilds the rules array can't reset it.
- **Duplicating a rollout rule or a feature no longer copies the seed**, so a copy buckets independently of its original instead of serving the same users.

## Rules the earlier backfill already re-seeded

Those rules keep their current seed here — we can't distinguish an intentional seed from a backfilled one, and rewriting would move their cohort a second time. Restoring one to its original cohort is a manual seed edit: set it back to the feature key (hashing is deterministic, so that reproduces the original membership exactly).

One caveat: those rules can still be rewritten by the existing feature/revision drift repair, which runs on a feature page load and treats the revision as authoritative. That is pre-existing behavior rather than something introduced here — and this PR stabilizes it, because once the feature and revision agree on the feature-key seed they stop drifting. Tracking separately.

## Testing

- Unit tests for the read-time pin, stored-seed inheritance, both REST converters, the force→rollout promotion, and the publish path.
- Verified against the running API: new rollouts get independent seeds, v1 and v2 round-trips preserve them, and a seedless rule resolves to the feature key in both the API response and the SDK payload without moving anyone.
- Measured the stacking fix end-to-end with the real SDK over 20k users: two stacked 50% rollouts enrolled **49.6%** before and **75.0%** after.
