### PR TITLE
Fix phase variation IDs in getExperimentApiResponse

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2763,14 +2763,14 @@ export async function toExperimentApiInterface(
         ),
       })),
     ),
-    phases: experiment.phases.map((p) => ({
+    phases: experiment.phases.map((p, phaseIndex) => ({
       name: p.name,
       dateStarted: p.dateStarted.toISOString(),
       dateEnded: p.dateEnded ? p.dateEnded.toISOString() : "",
       reasonForStopping: p.reason || "",
       seed: p.seed || experiment.trackingKey,
       coverage: p.coverage,
-      trafficSplit: getLatestPhaseVariations(experiment).map((v, i) => ({
+      trafficSplit: getPhaseVariations(experiment, phaseIndex).map((v, i) => ({
         variationId: v.id,
         weight: p.variationWeights[i] || 0,
       })),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

`getExperimentApiResponse` was building each phase's `trafficSplit` using the latest phase's variations for every phase, causing historical phases to report the current phase's variation IDs instead of their own.

The fix changes the phases mapping from:
```ts
phases: experiment.phases.map((p) => ({
  // ...
  trafficSplit: getLatestPhaseVariations(experiment).map((v, i) => ({
```

To:
```ts
phases: experiment.phases.map((p, phaseIndex) => ({
  // ...
  trafficSplit: getPhaseVariations(experiment, phaseIndex).map((v, i) => ({
```

This ensures each phase's `trafficSplit[].variationId` correctly reflects that phase's own variation IDs. The `getPhaseVariations` function already existed in the codebase and handles the common case where phases don't have distinct per-phase variations by falling back to all experiment variations.

- Fixes https://github.com/growthbook/growthbook/issues/6461

### Dependencies

None

### Testing

The fix is straightforward—using the correct function (`getPhaseVariations` with phase index) that already existed and was used elsewhere in the codebase (e.g., line 2943). The change passes type-check and lint.

To manually verify:
1. Create an experiment with multiple phases where earlier phases have different per-phase variation IDs than the current phase
2. GET the experiment via the API
3. Verify each phase's `trafficSplit[].variationId` now correctly reflects that phase's own variation IDs

### Screenshots

N/A - backend API change only
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C07NK4F016Z/p1784907160356209?thread_ts=1784907160.356209&cid=C07NK4F016Z)

<div><a href="https://cursor.com/agents/bc-f1b3d196-b15f-5a48-b256-3752f89fa174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1b3d196-b15f-5a48-b256-3752f89fa174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

