### PR TITLE
Move experiments list pagination into MongoDB

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -12639,6 +12639,36 @@ paths:
               - draft
               - running
               - stopped
+        - $ref: '#/components/parameters/q'
+        - $ref: '#/components/parameters/owner'
+        - $ref: '#/components/parameters/result'
+        - $ref: '#/components/parameters/tag'
+        - $ref: '#/components/parameters/type'
+        - $ref: '#/components/parameters/metricId'
+        - $ref: '#/components/parameters/bandits'
+        - name: archived
+          in: query
+          description: >-
+            Filter by archived status. Set to `true` to return only archived
+            experiments, `false` to exclude them. If omitted, both archived and
+            non-archived experiments are returned.
+          schema:
+            description: >-
+              Filter by archived status. Set to `true` to return only archived
+              experiments, `false` to exclude them. If omitted, both archived
+              and non-archived experiments are returned.
+            anyOf:
+              - type: string
+                const: 'true'
+              - type: string
+                const: 'false'
+              - type: string
+                const: '0'
+              - type: string
+                const: '1'
+              - type: boolean
+        - $ref: '#/components/parameters/sortBy'
+        - $ref: '#/components/parameters/sortOrder'
       responses:
         '200':
           description: Successful response
@@ -16187,9 +16217,23 @@ paths:
           schema:
             description: Filter by comma-separated statuses (draft, running, stopped)
             type: string
-        - $ref: '#/components/parameters/result'
+        - name: result
+          in: query
+          description: Filter by comma-separated results (won, lost, inconclusive, dnf)
+          schema:
+            description: Filter by comma-separated results (won, lost, inconclusive, dnf)
+            type: string
         - $ref: '#/components/parameters/tag'
-        - $ref: '#/components/parameters/type'
+        - name: type
+          in: query
+          description: >-
+            Filter by comma-separated experiment types (feature, visualChange,
+            redirect)
+          schema:
+            description: >-
+              Filter by comma-separated experiment types (feature, visualChange,
+              redirect)
+            type: string
         - $ref: '#/components/parameters/bandits'
         - $ref: '#/components/parameters/startDate'
         - $ref: '#/components/parameters/endDate'
@@ -45877,6 +45921,90 @@ components:
           confusion, consider using `trackingKey` instead, which is functionally
           identical. You cannot use both params at the same time.
         type: string
+    q:
+      name: q
+      in: query
+      description: >-
+        Raw experiment search/filter string (same syntax as the app's experiment
+        list filters, e.g. `status:running tag:checkout`). Negation (`!`) and
+        operators (`~`, `^`, `>`, `<`, `=`) are not supported and return a 400
+      schema:
+        description: >-
+          Raw experiment search/filter string (same syntax as the app's
+          experiment list filters, e.g. `status:running tag:checkout`). Negation
+          (`!`) and operators (`~`, `^`, `>`, `<`, `=`) are not supported and
+          return a 400
+        type: string
+    owner:
+      name: owner
+      in: query
+      description: Filter by comma-separated owner ids, names, or emails
+      schema:
+        description: Filter by comma-separated owner ids, names, or emails
+        type: string
+    result:
+      name: result
+      in: query
+      description: ''
+      schema:
+        type: string
+    tag:
+      name: tag
+      in: query
+      description: Filter by comma-separated tags
+      schema:
+        description: Filter by comma-separated tags
+        type: string
+    type:
+      name: type
+      in: query
+      description: ''
+      schema:
+        type: string
+    metricId:
+      name: metricId
+      in: query
+      description: >-
+        Filter by comma-separated metric ids. Matches experiments that use a
+        metric as a goal, secondary, or guardrail metric
+      schema:
+        description: >-
+          Filter by comma-separated metric ids. Matches experiments that use a
+          metric as a goal, secondary, or guardrail metric
+        type: string
+    bandits:
+      name: bandits
+      in: query
+      description: When true, return only multi-armed bandits; when false, exclude them
+      schema:
+        description: When true, return only multi-armed bandits; when false, exclude them
+        type: string
+        enum:
+          - 'true'
+          - 'false'
+    sortBy:
+      name: sortBy
+      in: query
+      description: Field to sort the results by
+      schema:
+        default: dateCreated
+        description: Field to sort the results by
+        type: string
+        enum:
+          - dateCreated
+          - dateUpdated
+          - name
+    sortOrder:
+      name: sortOrder
+      in: query
+      description: Sort direction (used with `sortBy`)
+      schema:
+        default: asc
+        description: Sort direction (used with `sortBy`)
+        type: string
+        enum:
+          - asc
+          - desc
     phase:
       name: phase
       in: query
@@ -45912,62 +46040,6 @@ components:
       schema:
         description: The event id
         type: string
-    q:
-      name: q
-      in: query
-      description: >-
-        Raw experiment search/filter string (same syntax as the app's experiment
-        list filters, e.g. `status:running tag:checkout`). Negation (`!`) and
-        operators (`~`, `^`, `>`, `<`, `=`) are not supported and return a 400
-      schema:
-        description: >-
-          Raw experiment search/filter string (same syntax as the app's
-          experiment list filters, e.g. `status:running tag:checkout`). Negation
-          (`!`) and operators (`~`, `^`, `>`, `<`, `=`) are not supported and
-          return a 400
-        type: string
-    owner:
-      name: owner
-      in: query
-      description: Filter by comma-separated owner ids, names, or emails
-      schema:
-        description: Filter by comma-separated owner ids, names, or emails
-        type: string
-    result:
-      name: result
-      in: query
-      description: Filter by comma-separated results (won, lost, inconclusive, dnf)
-      schema:
-        description: Filter by comma-separated results (won, lost, inconclusive, dnf)
-        type: string
-    tag:
-      name: tag
-      in: query
-      description: Filter by comma-separated tags
-      schema:
-        description: Filter by comma-separated tags
-        type: string
-    type:
-      name: type
-      in: query
-      description: >-
-        Filter by comma-separated experiment types (feature, visualChange,
-        redirect)
-      schema:
-        description: >-
-          Filter by comma-separated experiment types (feature, visualChange,
-          redirect)
-        type: string
-    bandits:
-      name: bandits
-      in: query
-      description: When true, return only multi-armed bandits; when false, exclude them
-      schema:
-        description: When true, return only multi-armed bandits; when false, exclude them
-        type: string
-        enum:
-          - 'true'
-          - 'false'
     startDate:
       name: startDate
       in: query

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -45945,9 +45945,22 @@ components:
     result:
       name: result
       in: query
-      description: ''
+      description: >-
+        Filter by comma-separated results (won, lost, inconclusive, dnf). Only
+        stopped experiments carry a result
       schema:
-        type: string
+        description: >-
+          Filter by comma-separated results (won, lost, inconclusive, dnf). Only
+          stopped experiments carry a result
+        type: array
+        items:
+          type: string
+          enum:
+            - dnf
+            - won
+            - lost
+            - inconclusive
+      explode: false
     tag:
       name: tag
       in: query
@@ -45958,9 +45971,21 @@ components:
     type:
       name: type
       in: query
-      description: ''
+      description: >-
+        Filter by comma-separated experiment types (feature, visualChange,
+        redirect)
       schema:
-        type: string
+        description: >-
+          Filter by comma-separated experiment types (feature, visualChange,
+          redirect)
+        type: array
+        items:
+          type: string
+          enum:
+            - feature
+            - visualChange
+            - redirect
+      explode: false
     metricId:
       name: metricId
       in: query

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -12643,7 +12643,7 @@ paths:
         - $ref: '#/components/parameters/owner'
         - $ref: '#/components/parameters/result'
         - $ref: '#/components/parameters/tag'
-        - $ref: '#/components/parameters/type'
+        - $ref: '#/components/parameters/implementationType'
         - $ref: '#/components/parameters/metricId'
         - $ref: '#/components/parameters/bandits'
         - name: archived
@@ -16224,16 +16224,7 @@ paths:
             description: Filter by comma-separated results (won, lost, inconclusive, dnf)
             type: string
         - $ref: '#/components/parameters/tag'
-        - name: type
-          in: query
-          description: >-
-            Filter by comma-separated experiment types (feature, visualChange,
-            redirect)
-          schema:
-            description: >-
-              Filter by comma-separated experiment types (feature, visualChange,
-              redirect)
-            type: string
+        - $ref: '#/components/parameters/type'
         - $ref: '#/components/parameters/bandits'
         - $ref: '#/components/parameters/startDate'
         - $ref: '#/components/parameters/endDate'
@@ -45946,12 +45937,16 @@ components:
       name: result
       in: query
       description: >-
-        Filter by comma-separated results (won, lost, inconclusive, dnf). Only
-        stopped experiments carry a result
+        Filter by comma-separated results (won, lost, inconclusive, dnf).
+        Matches the experiment's recorded result — set when an experiment is
+        stopped and retained if it's later restarted, so running experiments can
+        match too
       schema:
         description: >-
-          Filter by comma-separated results (won, lost, inconclusive, dnf). Only
-          stopped experiments carry a result
+          Filter by comma-separated results (won, lost, inconclusive, dnf).
+          Matches the experiment's recorded result — set when an experiment is
+          stopped and retained if it's later restarted, so running experiments
+          can match too
         type: array
         items:
           type: string
@@ -45968,16 +45963,18 @@ components:
       schema:
         description: Filter by comma-separated tags
         type: string
-    type:
-      name: type
+    implementationType:
+      name: implementationType
       in: query
       description: >-
-        Filter by comma-separated experiment types (feature, visualChange,
-        redirect)
+        Filter by comma-separated implementation types (feature, visualChange,
+        redirect) — the kinds of changes linked to the experiment. To filter
+        standard experiments vs bandits, use `bandits` instead
       schema:
         description: >-
-          Filter by comma-separated experiment types (feature, visualChange,
-          redirect)
+          Filter by comma-separated implementation types (feature, visualChange,
+          redirect) — the kinds of changes linked to the experiment. To filter
+          standard experiments vs bandits, use `bandits` instead
         type: array
         items:
           type: string
@@ -46064,6 +46061,17 @@ components:
       description: The event id
       schema:
         description: The event id
+        type: string
+    type:
+      name: type
+      in: query
+      description: >-
+        Filter by comma-separated experiment types (feature, visualChange,
+        redirect)
+      schema:
+        description: >-
+          Filter by comma-separated experiment types (feature, visualChange,
+          redirect)
         type: string
     startDate:
       name: startDate

--- a/packages/back-end/src/agent/skills/experiments/SKILL.md
+++ b/packages/back-end/src/agent/skills/experiments/SKILL.md
@@ -41,10 +41,13 @@ When the user message starts with `[Page context: <path>]`:
 - **List filtering/sorting:** `GET /api/v1/experiments` filters by `q` (the
   app's search syntax plus free text — rejects `!` and operators with a 400),
   `projectId`, `status` (`draft` | `running` | `stopped`), `tag`, `owner`,
-  `result` (`won` | `lost` | `inconclusive` | `dnf`), `type` (`feature` |
-  `visualChange` | `redirect`), `metricId`, `bandits` (`true` | `false`), and
+  `result` (`won` | `lost` | `inconclusive` | `dnf` — the recorded result,
+  retained even if the experiment is restarted), `implementationType`
+  (`feature` | `visualChange` | `redirect` — the linked-change kind, not the
+  response's `type` field), `metricId`, `bandits` (`true` | `false`), and
   `archived` (`true` | `false`; omit for both). `tag`, `owner`, `result`,
-  `type`, and `metricId` take comma-separated values, ORed within a param;
+  `implementationType`, and `metricId` take comma-separated values, ORed
+  within a param;
   separate params AND together. Sort with `sortBy`
   (`dateCreated` | `dateUpdated` | `name`) + `sortOrder` (default is
   `dateCreated` ascending — oldest first). Filter and sort API-side instead

--- a/packages/back-end/src/agent/skills/experiments/SKILL.md
+++ b/packages/back-end/src/agent/skills/experiments/SKILL.md
@@ -38,6 +38,13 @@ When the user message starts with `[Page context: <path>]`:
 
 - **Mutations:** non-GET `callApi` calls are gated except
   `POST .../snapshot` (results refresh — runs immediately).
+- **List filtering/sorting:** `GET /api/v1/experiments` filters by `q` (the
+  app's search syntax plus free text — rejects `!` and operators with a 400),
+  `projectId`, `status`, `tag`, `owner`, `result`, `type`, `metricId`,
+  `bandits`, and `archived` (comma-separated values ORed within a param), and
+  sorts with `sortBy` (`dateCreated` | `dateUpdated` | `name`) + `sortOrder`
+  (default is `dateCreated` ascending — oldest first). Filter and sort
+  API-side instead of pulling pages and filtering by hand.
 - **Identifiers:** reference experiments by **name** in replies; use `id` for
   API calls and `/experiment/<id>` links.
 - **Results:** cite numbers from `GET .../results`; do not fabricate uplift.

--- a/packages/back-end/src/agent/skills/experiments/SKILL.md
+++ b/packages/back-end/src/agent/skills/experiments/SKILL.md
@@ -40,11 +40,15 @@ When the user message starts with `[Page context: <path>]`:
   `POST .../snapshot` (results refresh — runs immediately).
 - **List filtering/sorting:** `GET /api/v1/experiments` filters by `q` (the
   app's search syntax plus free text — rejects `!` and operators with a 400),
-  `projectId`, `status`, `tag`, `owner`, `result`, `type`, `metricId`,
-  `bandits`, and `archived` (comma-separated values ORed within a param), and
-  sorts with `sortBy` (`dateCreated` | `dateUpdated` | `name`) + `sortOrder`
-  (default is `dateCreated` ascending — oldest first). Filter and sort
-  API-side instead of pulling pages and filtering by hand.
+  `projectId`, `status` (`draft` | `running` | `stopped`), `tag`, `owner`,
+  `result` (`won` | `lost` | `inconclusive` | `dnf`), `type` (`feature` |
+  `visualChange` | `redirect`), `metricId`, `bandits` (`true` | `false`), and
+  `archived` (`true` | `false`; omit for both). `tag`, `owner`, `result`,
+  `type`, and `metricId` take comma-separated values, ORed within a param;
+  separate params AND together. Sort with `sortBy`
+  (`dateCreated` | `dateUpdated` | `name`) + `sortOrder` (default is
+  `dateCreated` ascending — oldest first). Filter and sort API-side instead
+  of pulling pages and filtering by hand.
 - **Identifiers:** reference experiments by **name** in replies; use `id` for
   API calls and `/experiment/<id>` links.
 - **Results:** cite numbers from `GET .../results`; do not fabricate uplift.

--- a/packages/back-end/src/agent/skills/experiments/experiment-analyze.md
+++ b/packages/back-end/src/agent/skills/experiments/experiment-analyze.md
@@ -13,6 +13,23 @@ Use the `callApi` tool for every REST request. This skill is read-only — it ne
 
 1. **Fetch results + experiment metadata in one call.** `/results` returns `{ experiment, result }` — the same payload that powers the GrowthBook UI's results view, so there's no need for a separate metadata call.
 
+   If the user gave a name instead of an ID ("the checkout test"), resolve it first — `q` matches against name, tracking key, description, and hypothesis:
+
+   ```json
+   {
+     "method": "GET",
+     "path": "/api/v1/experiments",
+     "query": {
+       "q": "checkout",
+       "sortBy": "dateUpdated",
+       "sortOrder": "desc",
+       "limit": "10"
+     }
+   }
+   ```
+
+   If more than one experiment plausibly matches, list the candidates and let the user pick — don't guess.
+
    ```json
    { "method": "GET", "path": "/api/v1/experiments/<experiment-id>/results" }
    ```
@@ -170,9 +187,11 @@ Use the `callApi` tool for every REST request. This skill is read-only — it ne
 - **Snapshot timestamp matters.** Always surface `result.dateUpdated` when reporting results — it's both how step 2 decides whether to refresh and how the user judges whether a slow-traffic experiment has moved. Stale snapshots are common; don't hide them.
 - **24h is a deliberate ceiling, not the auto-refresh cadence.** The server auto-refreshes every 6h by default, so a snapshot under 24h has almost always been refreshed at least once. Don't drop it to "any data older than a minute" — that's how you pin a busy org against the 60 rpm limit.
 - **Read-only.** This skill never stops or modifies the experiment. Hand off to `experiment-stop` when the user wants to act.
+- **`q` rejects negation and operators with a 400.** The list endpoint's `q` param takes the app's search syntax (`status:running tag:checkout` plus free text) but hard-rejects `!`, `~`, `^`, `>`, `<`, `=`. Send plain `field:value` tokens and free text only.
 
 ## Endpoints used
 
+- `GET /api/v1/experiments?q=<text>` — resolve an experiment ID when the user only gave a name or keyword. `q` matches name, tracking key, description, and hypothesis; pair with `sortBy=dateUpdated&sortOrder=desc` so active experiments surface first.
 - `GET /api/v1/experiments/<id>/results` — primary entry point; returns `{ experiment, result }` so step 1 grabs metadata, status, and the snapshot timestamp (`result.dateUpdated`) in a single call. Accepts `phase` / `dimension` query params.
 - `POST /api/v1/experiments/<id>/snapshot` — trigger a fresh snapshot when results are over 24h old or the user wants a phase/dimension cut the cached snapshot doesn't cover. Body accepts `phase` (integer) and `dimension` (string).
 - `GET /api/v1/snapshots/<snapshot-id>` — check snapshot completion (one call, not a poll loop). Returns `{ snapshot: { id, experiment, status } }`.

--- a/packages/back-end/src/agent/skills/experiments/experiment-brainstorm.md
+++ b/packages/back-end/src/agent/skills/experiments/experiment-brainstorm.md
@@ -17,11 +17,18 @@ Use the `callApi` tool for every REST request. This skill is read-only — it pr
    {
      "method": "GET",
      "path": "/api/v1/experiments",
-     "query": { "limit": "50", "status": "stopped" }
+     "query": {
+       "limit": "50",
+       "status": "stopped",
+       "sortBy": "dateCreated",
+       "sortOrder": "desc"
+     }
    }
    ```
 
-   Returns up to 50 experiments per page (the API cap).
+   Returns up to 50 experiments per page (`limit` caps at 100). Keep `sortBy=dateCreated` with `sortOrder=desc` — the API's default order is oldest-first, and on an org with more than one page of history an unsorted pull grounds every proposal in ancient experiments.
+
+   If the user scoped the brainstorm ("ideas for checkout", "what should the growth team test next"), narrow the pull with filters instead of discarding results after the fact: add `"tag": "checkout"`, `"projectId": "prj_abc123"`, or `"owner": "<email>"` to the query. Filter params take comma-separated values (ORed within a param; separate params AND together).
 
 2. **Fetch results for each stopped experiment.** Loop over the stopped IDs:
 
@@ -65,7 +72,7 @@ Use the `callApi` tool for every REST request. This skill is read-only — it pr
 
 ## Endpoints used
 
-- `GET /api/v1/experiments?limit=50&status=stopped` — list experiments (returns metadata including status). Cap is 50 per page.
+- `GET /api/v1/experiments?limit=50&status=stopped&sortBy=dateCreated&sortOrder=desc` — list stopped experiments, newest first (`limit` caps at 100). Optional scoping filters: `tag`, `projectId`, `owner` (comma-separated values ORed within a param).
 - `GET /api/v1/experiments/{id}/results` — full results for one experiment. One call per stopped experiment in scope.
 
 ## Output template

--- a/packages/back-end/src/agent/skills/experiments/experiment-brainstorm.md
+++ b/packages/back-end/src/agent/skills/experiments/experiment-brainstorm.md
@@ -28,7 +28,7 @@ Use the `callApi` tool for every REST request. This skill is read-only — it pr
 
    Returns up to 50 experiments per page (`limit` caps at 100). Keep `sortBy=dateCreated` with `sortOrder=desc` — the API's default order is oldest-first, and on an org with more than one page of history an unsorted pull grounds every proposal in ancient experiments.
 
-   If the user scoped the brainstorm ("ideas for checkout", "what should the growth team test next"), narrow the pull with filters instead of discarding results after the fact: add `"tag": "checkout"`, `"projectId": "prj_abc123"`, or `"owner": "<email>"` to the query. Filter params take comma-separated values (ORed within a param; separate params AND together).
+   If the user scoped the brainstorm ("ideas for checkout", "what should the growth team test next"), narrow the pull with filters instead of discarding results after the fact: add `"tag": "checkout"`, `"projectId": "prj_abc123"`, or `"owner": "<email>"` to the query. `tag` and `owner` take comma-separated values (ORed within a param); `projectId` takes a single project id. Separate params AND together.
 
 2. **Fetch results for each stopped experiment.** Loop over the stopped IDs:
 
@@ -72,7 +72,7 @@ Use the `callApi` tool for every REST request. This skill is read-only — it pr
 
 ## Endpoints used
 
-- `GET /api/v1/experiments?limit=50&status=stopped&sortBy=dateCreated&sortOrder=desc` — list stopped experiments, newest first (`limit` caps at 100). Optional scoping filters: `tag`, `projectId`, `owner` (comma-separated values ORed within a param).
+- `GET /api/v1/experiments?limit=50&status=stopped&sortBy=dateCreated&sortOrder=desc` — list stopped experiments, newest first (`limit` caps at 100). Optional scoping filters: `tag` and `owner` (comma-separated values ORed within a param), `projectId` (single project id).
 - `GET /api/v1/experiments/{id}/results` — full results for one experiment. One call per stopped experiment in scope.
 
 ## Output template

--- a/packages/back-end/src/agent/skills/experiments/experiment-stop.md
+++ b/packages/back-end/src/agent/skills/experiments/experiment-stop.md
@@ -17,6 +17,18 @@ Use the `callApi` tool for every REST request. Mutating calls are gated automati
    { "method": "GET", "path": "/api/v1/experiments/<experiment-id>" }
    ```
 
+   If the user gave a name instead of an ID ("stop the checkout test"), resolve it first — `q` matches against name, tracking key, description, and hypothesis, and `status=running` keeps the candidates to experiments this skill can act on:
+
+   ```json
+   {
+     "method": "GET",
+     "path": "/api/v1/experiments",
+     "query": { "q": "checkout", "status": "running" }
+   }
+   ```
+
+   If more than one experiment plausibly matches, list the candidates and let the user pick — don't guess. Stopping the wrong experiment is not cleanly reversible.
+
    Check the `status` field. Only `running` experiments should be stopped via this skill. If `status === "draft"`, the experiment hasn't started — the user wants to delete it, not stop it (different operation). If `status === "stopped"`, it's already done.
 
    Also capture the `type` field. If `type === "multi-armed-bandit"`, halt and tell the user this skill targets standard A/B tests; bandits have their own lifecycle (stop is similar but interpretation and rollout differ — recommend they review in the UI before scripting).
@@ -125,9 +137,11 @@ Use the `callApi` tool for every REST request. Mutating calls are gated automati
 - **Always remind about the linked flag.** Stopping the experiment does not remove the `experiment-ref` rule from the linked flag. Without a temporary rollout, the flag keeps routing to a stale experiment until the user cleans the rule up.
 - **`analysis` should explain the decision in plain English (markdown).** Future readers (including future-self) will want context. Don't leave it blank when declaring a winner.
 - **Run `experiment-analyze` first if the user hasn't.** Stopping based on a glance at the dashboard is a common mistake — interim numbers can flip, and the data-quality checks in `experiment-analyze` can flag results that look conclusive but aren't.
+- **`q` rejects negation and operators with a 400.** The list endpoint's `q` param takes the app's search syntax (`status:running tag:checkout` plus free text) but hard-rejects `!`, `~`, `^`, `>`, `<`, `=`. Send plain `field:value` tokens and free text only.
 
 ## Endpoints used
 
+- `GET /api/v1/experiments?q=<text>&status=running` — resolve an experiment ID when the user only gave a name or keyword. `q` matches name, tracking key, description, and hypothesis.
 - `GET /api/v1/experiments/<id>` — fetch state, variations, and `type`
 - `POST /api/v1/experiments/<id>/stop` — stop and optionally declare a winner + temporary rollout
 - `POST /api/v1/experiments/<id>/modify-temporary-rollout` — toggle the temporary rollout off (or on) after stopping, without re-running this skill

--- a/packages/back-end/src/api/experiments/listExperiments.ts
+++ b/packages/back-end/src/api/experiments/listExperiments.ts
@@ -2,9 +2,17 @@ import {
   ExperimentInterfaceExcludingHoldouts,
   listExperimentsValidator,
 } from "shared/validators";
+import { stringToBoolean } from "shared/util";
 import { ProjectInterface } from "shared/types/project";
 import { getAllExperiments } from "back-end/src/models/ExperimentModel";
 import { toExperimentApiInterface } from "back-end/src/services/experiments";
+import {
+  buildExperimentFilterResolvers,
+  filterExperiments,
+  normalizeExperimentFilters,
+  parseExperimentSearchString,
+  splitCsv,
+} from "back-end/src/services/experimentFilters";
 import { resolveOwnerEmails } from "back-end/src/services/owner";
 import {
   applyPagination,
@@ -20,19 +28,75 @@ export const listExperiments = createApiRequestHandler(
     );
   }
 
-  // Filter and sort at the database level for better performance
+  // Reject unsupported search syntax (negation/operators) with a 400 instead
+  // of silently dropping it like the internal endpoint does
+  if (req.query.q) {
+    parseExperimentSearchString(req.query.q, { strict: true });
+  }
+
+  // booleanQueryField accepts string and native boolean forms; normalize to
+  // a tri-state boolean (undefined = don't filter on archived)
+  const archived =
+    req.query.archived === undefined
+      ? undefined
+      : stringToBoolean(req.query.archived.toString());
+
+  // Filter and sort at the database level where possible
   // Note: type is not specified, which defaults to excluding holdouts
   const experiments = await getAllExperiments(req.context, {
     includeArchived: true,
+    archived,
     project: req.query.projectId,
     datasourceId: req.query.datasourceId,
     trackingKey: req.query.trackingKey ?? req.query.experimentId,
     status: req.query.status,
-    sortBy: { dateCreated: 1 },
+    sortBy: {
+      [req.query.sortBy ?? "dateCreated"]:
+        req.query.sortOrder === "desc" ? -1 : 1,
+    },
   });
 
+  // The remaining filters share the app's experiment-list semantics (matching
+  // is case-insensitive; values within a category are ORed, categories are
+  // ANDed), so apply them in memory via the shared filtering service.
+  // filterExperiments preserves input order, keeping the sort from above.
+  const filters = normalizeExperimentFilters({
+    searchString: req.query.q,
+    filters: {
+      owners: splitCsv(req.query.owner),
+      results: splitCsv(req.query.result),
+      tags: splitCsv(req.query.tag),
+      types: splitCsv(req.query.type),
+      metrics: splitCsv(req.query.metricId),
+    },
+  });
+
+  const bandits =
+    req.query.bandits === "true"
+      ? true
+      : req.query.bandits === "false"
+        ? false
+        : undefined;
+
+  // Resolvers require extra lookups (projects, org members), so skip the
+  // filter pass entirely when no in-memory filters were requested
+  const hasFilters =
+    bandits !== undefined ||
+    Object.values(filters).some((value) => value !== undefined);
+  const filteredExperiments = hasFilters
+    ? filterExperiments({
+        experiments,
+        filters,
+        resolvers: await buildExperimentFilterResolvers(req.context),
+        bandits,
+      })
+    : experiments;
+
   // TODO: Move pagination (limit/offset) to database for better performance
-  const { filtered, returnFields } = applyPagination(experiments, req.query);
+  const { filtered, returnFields } = applyPagination(
+    filteredExperiments,
+    req.query,
+  );
 
   // Batch-load all projects for the filtered experiments to avoid N+1 queries
   const projectIds = [

--- a/packages/back-end/src/api/experiments/listExperiments.ts
+++ b/packages/back-end/src/api/experiments/listExperiments.ts
@@ -66,7 +66,7 @@ export const listExperiments = createApiRequestHandler(
       owners: splitCsv(req.query.owner),
       results: splitCsv(req.query.result),
       tags: splitCsv(req.query.tag),
-      types: splitCsv(req.query.type),
+      implementationTypes: splitCsv(req.query.implementationType),
       metrics: splitCsv(req.query.metricId),
     },
   });

--- a/packages/back-end/src/api/experiments/listExperiments.ts
+++ b/packages/back-end/src/api/experiments/listExperiments.ts
@@ -41,7 +41,7 @@ export const listExperiments = createApiRequestHandler(
       ? undefined
       : stringToBoolean(req.query.archived.toString());
 
-  // Filter and sort at the database level where possible
+  // Filter at the database level where possible
   // Note: type is not specified, which defaults to excluding holdouts
   const experiments = await getAllExperiments(req.context, {
     includeArchived: true,
@@ -50,16 +50,11 @@ export const listExperiments = createApiRequestHandler(
     datasourceId: req.query.datasourceId,
     trackingKey: req.query.trackingKey ?? req.query.experimentId,
     status: req.query.status,
-    sortBy: {
-      [req.query.sortBy ?? "dateCreated"]:
-        req.query.sortOrder === "desc" ? -1 : 1,
-    },
   });
 
   // The remaining filters share the app's experiment-list semantics (matching
   // is case-insensitive; values within a category are ORed, categories are
   // ANDed), so apply them in memory via the shared filtering service.
-  // filterExperiments preserves input order, keeping the sort from above.
   const filters = normalizeExperimentFilters({
     searchString: req.query.q,
     filters: {
@@ -92,11 +87,22 @@ export const listExperiments = createApiRequestHandler(
       })
     : experiments;
 
+  // Sort in Node: the endpoint materializes the full (permission-filtered)
+  // result set for in-memory pagination anyway, so sorting here is free,
+  // sidesteps Mongo's in-memory sort memory ceiling on large orgs, and lets
+  // `name` sort case-insensitively (Mongo would sort by raw byte order)
+  const sortBy = req.query.sortBy ?? "dateCreated";
+  const sortDir = req.query.sortOrder === "desc" ? -1 : 1;
+  const sorted = [...filteredExperiments].sort((a, b) => {
+    const diff =
+      sortBy === "name"
+        ? a.name.localeCompare(b.name, undefined, { sensitivity: "base" })
+        : a[sortBy].getTime() - b[sortBy].getTime();
+    return sortDir === -1 ? -diff : diff;
+  });
+
   // TODO: Move pagination (limit/offset) to database for better performance
-  const { filtered, returnFields } = applyPagination(
-    filteredExperiments,
-    req.query,
-  );
+  const { filtered, returnFields } = applyPagination(sorted, req.query);
 
   // Batch-load all projects for the filtered experiments to avoid N+1 queries
   const projectIds = [

--- a/packages/back-end/src/api/experiments/listExperiments.ts
+++ b/packages/back-end/src/api/experiments/listExperiments.ts
@@ -4,7 +4,12 @@ import {
 } from "shared/validators";
 import { stringToBoolean } from "shared/util";
 import { ProjectInterface } from "shared/types/project";
-import { getAllExperiments } from "back-end/src/models/ExperimentModel";
+import { ExperimentInterface } from "shared/types/experiment";
+import {
+  countExperiments,
+  getAllExperiments,
+  getExperimentsPage,
+} from "back-end/src/models/ExperimentModel";
 import { toExperimentApiInterface } from "back-end/src/services/experiments";
 import {
   buildExperimentFilterResolvers,
@@ -17,6 +22,7 @@ import { resolveOwnerEmails } from "back-end/src/services/owner";
 import {
   applyPagination,
   createApiRequestHandler,
+  validatePagination,
 } from "back-end/src/util/handler";
 
 export const listExperiments = createApiRequestHandler(
@@ -41,6 +47,137 @@ export const listExperiments = createApiRequestHandler(
       ? undefined
       : stringToBoolean(req.query.archived.toString());
 
+  const sortBy = req.query.sortBy ?? "dateCreated";
+  const sortDir = req.query.sortOrder === "desc" ? -1 : 1;
+
+  // Filters with the app's experiment-list semantics (case-insensitive
+  // matching; values within a category ORed, categories ANDed). These aren't
+  // expressible in the Mongo query, so requesting any of them takes the
+  // fetch-all path below.
+  const filters = normalizeExperimentFilters({
+    searchString: req.query.q,
+    filters: {
+      owners: splitCsv(req.query.owner),
+      results: splitCsv(req.query.result),
+      tags: splitCsv(req.query.tag),
+      implementationTypes: splitCsv(req.query.implementationType),
+      metrics: splitCsv(req.query.metricId),
+    },
+  });
+  const hasInMemoryFilters = Object.values(filters).some(
+    (value) => value !== undefined,
+  );
+
+  const bandits =
+    req.query.bandits === "true"
+      ? true
+      : req.query.bandits === "false"
+        ? false
+        : undefined;
+
+  // Shared serializer for whichever path produced the page
+  const serializePage = async (page: ExperimentInterface[]) => {
+    // Batch-load all projects for the page to avoid N+1 queries
+    const pageProjectIds = [
+      ...new Set(
+        page.map((exp) => exp.project).filter((p): p is string => !!p),
+      ),
+    ];
+    const projects = pageProjectIds.length
+      ? await req.context.models.projects.getByIds(pageProjectIds)
+      : [];
+    const projectMap = new Map<string, ProjectInterface>(
+      projects.map((p) => [p.id, p]),
+    );
+    const promises = page.map((experiment) =>
+      toExperimentApiInterface(
+        req.context,
+        experiment as ExperimentInterfaceExcludingHoldouts,
+        projectMap,
+      ),
+    );
+    return resolveOwnerEmails(await Promise.all(promises), req.context);
+  };
+
+  // Fast path: every requested filter is expressible in the Mongo query and
+  // the sort is backed by an { organization, <date> } index, so page in the
+  // database instead of materializing the whole org's experiments. `name`
+  // sorts take the fetch-all path so they can sort case-insensitively.
+  // The query is pre-scoped to readable projects to keep the page and total
+  // correct (mirrors loadFeaturesPage).
+  if (!hasInMemoryFilters && sortBy !== "name") {
+    const { limit, offset } = validatePagination(req.query);
+    const emptyPage = {
+      experiments: [],
+      limit,
+      offset,
+      count: 0,
+      total: 0,
+      hasMore: false,
+      nextOffset: null,
+    };
+
+    let projectIds: string[] | undefined;
+    if (req.query.projectId) {
+      if (
+        !req.context.permissions.canReadSingleProjectResource(
+          req.query.projectId,
+        )
+      ) {
+        return emptyPage;
+      }
+    } else {
+      const readable =
+        req.context.permissions.getProjectsWithPermission("readData");
+      if (readable !== null) {
+        if (readable.length === 0) return emptyPage;
+        projectIds = readable;
+      }
+    }
+
+    const dbFilters = {
+      includeArchived: true,
+      archived,
+      project: req.query.projectId,
+      projectIds,
+      datasourceId: req.query.datasourceId,
+      trackingKey: req.query.trackingKey ?? req.query.experimentId,
+      status: req.query.status,
+      // The bandits param maps onto the type field (omitting type still
+      // excludes holdouts)
+      type:
+        bandits === true
+          ? ("multi-armed-bandit" as const)
+          : bandits === false
+            ? ("standard" as const)
+            : undefined,
+    };
+
+    const [page, total] = await Promise.all([
+      getExperimentsPage(req.context, {
+        ...dbFilters,
+        // _id tiebreak keeps equal dates paginating deterministically
+        sort: { [sortBy]: sortDir, _id: 1 },
+        limit,
+        offset,
+      }),
+      countExperiments(req.context, dbFilters),
+    ]);
+
+    const nextOffset = offset + limit;
+    const hasMore = nextOffset < total;
+    return {
+      experiments: await serializePage(page),
+      limit,
+      offset,
+      count: page.length,
+      total,
+      hasMore,
+      nextOffset: hasMore ? nextOffset : null,
+    };
+  }
+
+  // Fetch-all path: in-memory filters and/or a name sort were requested.
   // Filter at the database level where possible
   // Note: type is not specified, which defaults to excluding holdouts
   const experiments = await getAllExperiments(req.context, {
@@ -52,47 +189,22 @@ export const listExperiments = createApiRequestHandler(
     status: req.query.status,
   });
 
-  // The remaining filters share the app's experiment-list semantics (matching
-  // is case-insensitive; values within a category are ORed, categories are
-  // ANDed), so apply them in memory via the shared filtering service.
-  const filters = normalizeExperimentFilters({
-    searchString: req.query.q,
-    filters: {
-      owners: splitCsv(req.query.owner),
-      results: splitCsv(req.query.result),
-      tags: splitCsv(req.query.tag),
-      implementationTypes: splitCsv(req.query.implementationType),
-      metrics: splitCsv(req.query.metricId),
-    },
-  });
-
-  const bandits =
-    req.query.bandits === "true"
-      ? true
-      : req.query.bandits === "false"
-        ? false
-        : undefined;
-
   // Resolvers require extra lookups (projects, org members), so skip the
-  // filter pass entirely when no in-memory filters were requested
-  const hasFilters =
-    bandits !== undefined ||
-    Object.values(filters).some((value) => value !== undefined);
-  const filteredExperiments = hasFilters
-    ? filterExperiments({
-        experiments,
-        filters,
-        resolvers: await buildExperimentFilterResolvers(req.context),
-        bandits,
-      })
-    : experiments;
+  // filter pass entirely when only a name sort routed us here
+  const filteredExperiments =
+    hasInMemoryFilters || bandits !== undefined
+      ? filterExperiments({
+          experiments,
+          filters,
+          resolvers: await buildExperimentFilterResolvers(req.context),
+          bandits,
+        })
+      : experiments;
 
-  // Sort in Node: the endpoint materializes the full (permission-filtered)
+  // Sort in Node: this path materializes the full (permission-filtered)
   // result set for in-memory pagination anyway, so sorting here is free,
   // sidesteps Mongo's in-memory sort memory ceiling on large orgs, and lets
   // `name` sort case-insensitively (Mongo would sort by raw byte order)
-  const sortBy = req.query.sortBy ?? "dateCreated";
-  const sortDir = req.query.sortOrder === "desc" ? -1 : 1;
   const sorted = [...filteredExperiments].sort((a, b) => {
     const diff =
       sortBy === "name"
@@ -101,36 +213,10 @@ export const listExperiments = createApiRequestHandler(
     return sortDir === -1 ? -diff : diff;
   });
 
-  // TODO: Move pagination (limit/offset) to database for better performance
   const { filtered, returnFields } = applyPagination(sorted, req.query);
 
-  // Batch-load all projects for the filtered experiments to avoid N+1 queries
-  const projectIds = [
-    ...new Set(
-      filtered.map((exp) => exp.project).filter((p): p is string => !!p),
-    ),
-  ];
-  const projects = projectIds.length
-    ? await req.context.models.projects.getByIds(projectIds)
-    : [];
-  const projectMap = new Map<string, ProjectInterface>(
-    projects.map((p) => [p.id, p]),
-  );
-
-  const promises = filtered.map((experiment) =>
-    toExperimentApiInterface(
-      req.context,
-      experiment as ExperimentInterfaceExcludingHoldouts,
-      projectMap,
-    ),
-  );
-  const apiExperiments = await resolveOwnerEmails(
-    await Promise.all(promises),
-    req.context,
-  );
-
   return {
-    experiments: apiExperiments,
+    experiments: await serializePage(filtered),
     ...returnFields,
   };
 });

--- a/packages/back-end/src/api/experiments/listExperiments.ts
+++ b/packages/back-end/src/api/experiments/listExperiments.ts
@@ -99,12 +99,14 @@ export const listExperiments = createApiRequestHandler(
     return resolveOwnerEmails(await Promise.all(promises), req.context);
   };
 
-  // Fast path: every requested filter is expressible in the Mongo query and
-  // the sort is backed by an { organization, <date> } index, so page in the
-  // database instead of materializing the whole org's experiments. `name`
-  // sorts take the fetch-all path so they can sort case-insensitively.
-  // The query is pre-scoped to readable projects to keep the page and total
-  // correct (mirrors loadFeaturesPage).
+  // Fast path: every requested filter is expressible in the Mongo query, so
+  // page in the database instead of materializing the whole org's experiments
+  // in Node. The sort is unindexed (Mongo does a bounded blocking sort), but
+  // the win is that only one page crosses the wire and gets hydrated +
+  // migrated, rather than every experiment in the org. `name` sorts take the
+  // fetch-all path so they can sort case-insensitively. The query is
+  // pre-scoped to readable projects to keep the page and total correct
+  // (mirrors loadFeaturesPage).
   if (!hasInMemoryFilters && sortBy !== "name") {
     const { limit, offset } = validatePagination(req.query);
     const emptyPage = {
@@ -156,8 +158,11 @@ export const listExperiments = createApiRequestHandler(
     const [page, total] = await Promise.all([
       getExperimentsPage(req.context, {
         ...dbFilters,
-        // _id tiebreak keeps equal dates paginating deterministically
-        sort: { [sortBy]: sortDir, _id: 1 },
+        // _id tiebreak keeps equal dates paginating deterministically; its
+        // direction matches sortDir so the spec stays index-eligible if a
+        // { organization, <field>, _id } index is ever added (a
+        // mixed-direction tiebreak can never use one)
+        sort: { [sortBy]: sortDir, _id: sortDir },
         limit,
         offset,
       }),

--- a/packages/back-end/src/api/metrics/listMetricExperiments.ts
+++ b/packages/back-end/src/api/metrics/listMetricExperiments.ts
@@ -38,7 +38,9 @@ export const listMetricExperiments = createApiRequestHandler(
     statuses: splitCsv(req.query.status),
     results: splitCsv(req.query.result),
     tags: splitCsv(req.query.tag),
-    types: splitCsv(req.query.type),
+    // The public wire param stays `type` (shipped API surface); internally
+    // these are implementation types (feature | visualChange | redirect)
+    implementationTypes: splitCsv(req.query.type),
   };
 
   const bandits =

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -386,6 +386,9 @@ const experimentSchema = new mongoose.Schema({
 experimentSchema.index({ organization: 1, datasource: 1 });
 experimentSchema.index({ organization: 1, project: 1 });
 experimentSchema.index({ organization: 1, trackingKey: 1 });
+experimentSchema.index({ organization: 1, dateCreated: 1 });
+experimentSchema.index({ organization: 1, dateUpdated: 1 });
+experimentSchema.index({ organization: 1, name: 1 });
 experimentSchema.index(
   { "nextScheduledStatusUpdate.date": 1 },
   { sparse: true },
@@ -483,6 +486,7 @@ export async function getAllExperiments(
   {
     project,
     includeArchived = false,
+    archived,
     type,
     datasourceId,
     trackingKey,
@@ -492,6 +496,9 @@ export async function getAllExperiments(
   }: {
     project?: string;
     includeArchived?: boolean;
+    // Tri-state archived filter: true = archived only, false = exclude
+    // archived, undefined = fall back to `includeArchived`.
+    archived?: boolean;
     type?: ExperimentType;
     datasourceId?: string;
     trackingKey?: string;
@@ -519,7 +526,9 @@ export async function getAllExperiments(
     query.trackingKey = trackingKey;
   }
 
-  if (!includeArchived) {
+  if (archived !== undefined) {
+    query.archived = archived ? true : { $ne: true };
+  } else if (!includeArchived) {
     query.archived = { $ne: true };
   }
 

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -78,7 +78,7 @@ type FindOrganizationOptions = {
 
 type FilterKeys = ExperimentInterface & { _id: string };
 
-type SortFilter = {
+export type SortFilter = {
   [key in keyof Partial<FilterKeys>]: 1 | -1;
 };
 
@@ -386,6 +386,12 @@ const experimentSchema = new mongoose.Schema({
 experimentSchema.index({ organization: 1, datasource: 1 });
 experimentSchema.index({ organization: 1, project: 1 });
 experimentSchema.index({ organization: 1, trackingKey: 1 });
+// Back the API list's DB-paginated date sorts: with skip/limit in the query,
+// an index-order scan reads ~one page instead of fetching and sorting the
+// whole org. `name` sorts intentionally take the fetch-all path (Node sorts
+// case-insensitively), so there is no name index.
+experimentSchema.index({ organization: 1, dateCreated: 1 });
+experimentSchema.index({ organization: 1, dateUpdated: 1 });
 experimentSchema.index(
   { "nextScheduledStatusUpdate.date": 1 },
   { sparse: true },
@@ -414,9 +420,13 @@ async function findExperiments(
   query: FilterQuery<ExperimentDocument>,
   limit?: number,
   sortBy?: SortFilter,
+  offset?: number,
 ): Promise<ExperimentInterface[]> {
   let cursor = getCollection(COLLECTION).find(query);
 
+  if (offset) {
+    cursor = cursor.skip(offset);
+  }
   if (limit) {
     cursor = cursor.limit(limit);
   }
@@ -507,12 +517,57 @@ export async function getAllExperiments(
     limit?: number;
   } = {},
 ): Promise<ExperimentInterface[]> {
+  const query = experimentListQuery(context.org.id, {
+    project,
+    includeArchived,
+    archived,
+    type,
+    datasourceId,
+    trackingKey,
+    status,
+  });
+
+  return await findExperiments(context, query, limit, sortBy);
+}
+
+export type ExperimentListFilters = {
+  project?: string;
+  // Restrict to these projects — used by the API list to pre-scope the query
+  // to the projects the caller can read so DB-level pagination stays correct.
+  // Ignored when `project` is set. An empty array matches nothing (callers
+  // should short-circuit instead of querying).
+  projectIds?: string[];
+  includeArchived?: boolean;
+  // Tri-state archived filter: true = archived only, false = exclude
+  // archived, undefined = fall back to `includeArchived`.
+  archived?: boolean;
+  type?: ExperimentType;
+  datasourceId?: string;
+  trackingKey?: string;
+  status?: ExperimentStatus;
+};
+
+function experimentListQuery(
+  orgId: string,
+  {
+    project,
+    projectIds,
+    includeArchived = false,
+    archived,
+    type,
+    datasourceId,
+    trackingKey,
+    status,
+  }: ExperimentListFilters,
+): FilterQuery<ExperimentDocument> {
   const query: FilterQuery<ExperimentDocument> = {
-    organization: context.org.id,
+    organization: orgId,
   };
 
   if (project) {
     query.project = project;
+  } else if (projectIds) {
+    query.project = { $in: projectIds };
   }
 
   if (datasourceId) {
@@ -543,7 +598,42 @@ export async function getAllExperiments(
     query.type = { $ne: "holdout" };
   }
 
-  return await findExperiments(context, query, limit, sortBy);
+  return query;
+}
+
+/**
+ * One page of experiments for the API list's DB-pagination fast path. The
+ * query must be pre-scoped to readable projects via `project`/`projectIds`
+ * (see ExperimentListFilters) — the per-doc permission filter still runs as
+ * defense in depth, but anything it removes would shorten the page, so
+ * callers must not rely on it.
+ */
+export async function getExperimentsPage(
+  context: ReqContext | ApiReqContext,
+  {
+    sort,
+    limit,
+    offset,
+    ...filters
+  }: ExperimentListFilters & {
+    sort: SortFilter;
+    limit: number;
+    offset: number;
+  },
+): Promise<ExperimentInterface[]> {
+  if (filters.projectIds?.length === 0) return [];
+  const query = experimentListQuery(context.org.id, filters);
+  return await findExperiments(context, query, limit, sort, offset);
+}
+
+export async function countExperiments(
+  context: ReqContext | ApiReqContext,
+  filters: ExperimentListFilters,
+): Promise<number> {
+  if (filters.projectIds?.length === 0) return 0;
+  return getCollection(COLLECTION).countDocuments(
+    experimentListQuery(context.org.id, filters),
+  );
 }
 
 /**

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -386,12 +386,14 @@ const experimentSchema = new mongoose.Schema({
 experimentSchema.index({ organization: 1, datasource: 1 });
 experimentSchema.index({ organization: 1, project: 1 });
 experimentSchema.index({ organization: 1, trackingKey: 1 });
-// Back the API list's DB-paginated date sorts: with skip/limit in the query,
-// an index-order scan reads ~one page instead of fetching and sorting the
-// whole org. `name` sorts intentionally take the fetch-all path (Node sorts
-// case-insensitively), so there is no name index.
-experimentSchema.index({ organization: 1, dateCreated: 1 });
-experimentSchema.index({ organization: 1, dateUpdated: 1 });
+// No index backs the API list's date sorts. Mongo does a bounded (top-k)
+// blocking sort per page instead: it examines every matching doc in the org
+// but only ships one page and caps sort memory at the page size. Deemed not
+// worth the write overhead for now. If it becomes a bottleneck, note that
+// { organization, <field> } alone does NOT help — the sort spec carries an
+// _id tiebreak, and Mongo uses an index for a sort only when it satisfies the
+// whole sort key in one direction. It needs { organization, <field>, _id }
+// with the tiebreak direction matching sortOrder.
 experimentSchema.index(
   { "nextScheduledStatusUpdate.date": 1 },
   { sparse: true },

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -386,9 +386,6 @@ const experimentSchema = new mongoose.Schema({
 experimentSchema.index({ organization: 1, datasource: 1 });
 experimentSchema.index({ organization: 1, project: 1 });
 experimentSchema.index({ organization: 1, trackingKey: 1 });
-experimentSchema.index({ organization: 1, dateCreated: 1 });
-experimentSchema.index({ organization: 1, dateUpdated: 1 });
-experimentSchema.index({ organization: 1, name: 1 });
 experimentSchema.index(
   { "nextScheduledStatusUpdate.date": 1 },
   { sparse: true },

--- a/packages/back-end/src/scripts/generate-openapi.ts
+++ b/packages/back-end/src/scripts/generate-openapi.ts
@@ -676,11 +676,13 @@ curl https://api.growthbook.io/api/v1/features \
       stripDefaultedFromRequired(jsonSchema);
       Object.entries(jsonSchema.properties ?? {}).forEach(([name, schema]) => {
         const isRequired = (jsonSchema.required ?? []).includes(name);
-        // Hoist x- extension fields from schema to parameter level
+        // Hoist x- extension fields — plus serialization fields like
+        // `explode`/`style`, which schemas can set via .meta() but belong on
+        // the parameter — from schema to parameter level
         const schemaObj = schema as Record<string, unknown>;
         const extensions: Record<string, unknown> = {};
         for (const key of Object.keys(schemaObj)) {
-          if (key.startsWith("x-")) {
+          if (key.startsWith("x-") || key === "explode" || key === "style") {
             extensions[key] = schemaObj[key];
             delete schemaObj[key];
           }

--- a/packages/back-end/src/services/experimentFilters.ts
+++ b/packages/back-end/src/services/experimentFilters.ts
@@ -12,7 +12,10 @@ import { getExperimentsUsingMetric } from "back-end/src/models/ExperimentModel";
  *
  * - `search` is the free-text remainder (matched against name / trackingKey /
  *   description / hypothesis).
- * - `types` tokens are normalized to "feature" | "visualChange" | "redirect".
+ * - `implementationTypes` tokens are normalized to
+ *   "feature" | "visualChange" | "redirect". (Named to avoid confusion with
+ *   the top-level `experiment.type` field, which means standard vs bandit vs
+ *   holdout.)
  */
 export type StructuredExperimentFilters = {
   projects?: string[];
@@ -21,7 +24,7 @@ export type StructuredExperimentFilters = {
   results?: string[];
   statuses?: string[];
   tags?: string[];
-  types?: string[];
+  implementationTypes?: string[];
   search?: string;
 };
 
@@ -49,7 +52,7 @@ const SEARCH_FILTER_KEYS = [
 
 // Normalize the various "has" tokens that useExperimentSearch recognizes down
 // to the three experiment types ExperimentSearchFilters can set.
-function normalizeTypeToken(token: string): string | undefined {
+function normalizeImplementationTypeToken(token: string): string | undefined {
   const t = token.toLowerCase();
   if (t === "feature" || t === "features") return "feature";
   if (t === "visualchange" || t === "visualchanges") return "visualChange";
@@ -134,9 +137,9 @@ export function parseExperimentSearchString(
         break;
       case "has":
         addValues(
-          "types",
+          "implementationTypes",
           values
-            .map(normalizeTypeToken)
+            .map(normalizeImplementationTypeToken)
             .filter((v): v is string => v !== undefined),
         );
         break;
@@ -181,10 +184,10 @@ export function normalizeExperimentFilters({
   filters?: StructuredExperimentFilters;
 }): StructuredExperimentFilters {
   const parsed = searchString ? parseExperimentSearchString(searchString) : {};
-  const types = mergeStringArrays(
-    parsed.types,
-    filters?.types
-      ?.map(normalizeTypeToken)
+  const implementationTypes = mergeStringArrays(
+    parsed.implementationTypes,
+    filters?.implementationTypes
+      ?.map(normalizeImplementationTypeToken)
       .filter((v): v is string => v !== undefined),
   );
   return {
@@ -194,7 +197,7 @@ export function normalizeExperimentFilters({
     results: mergeStringArrays(parsed.results, filters?.results),
     statuses: mergeStringArrays(parsed.statuses, filters?.statuses),
     tags: mergeStringArrays(parsed.tags, filters?.tags),
-    types,
+    implementationTypes,
     search: filters?.search ?? parsed.search,
   };
 }
@@ -220,7 +223,7 @@ function matchesCategory(
   return values.some((v) => haystack.has(v.toLowerCase()));
 }
 
-function experimentHasType(
+function experimentHasImplementationType(
   experiment: ExperimentInterface,
   type: string,
 ): boolean {
@@ -303,7 +306,9 @@ export function filterExperiments({
       return false;
     }
 
-    // Result (only stopped experiments carry a result)
+    // Result — matches the recorded `results` field regardless of status.
+    // Results are set when an experiment is stopped but are retained if it's
+    // later restarted, so a running experiment can carry (and match) one.
     if (!matchesCategory(filters.results, [e.results])) return false;
 
     // Status
@@ -326,8 +331,13 @@ export function filterExperiments({
     }
 
     // Type / has (OR across requested types)
-    if (filters.types && filters.types.length > 0) {
-      if (!filters.types.some((t) => experimentHasType(e, t))) return false;
+    if (filters.implementationTypes && filters.implementationTypes.length > 0) {
+      if (
+        !filters.implementationTypes.some((t) =>
+          experimentHasImplementationType(e, t),
+        )
+      )
+        return false;
     }
 
     // Free-text search (approximation of useExperimentSearch's fuzzy match

--- a/packages/back-end/test/api/experiments.test.ts
+++ b/packages/back-end/test/api/experiments.test.ts
@@ -72,6 +72,7 @@ describe("experiments API", () => {
         projects: {
           getById: jest.fn().mockResolvedValue(null),
           getByIds: jest.fn().mockResolvedValue([]),
+          getAll: jest.fn().mockResolvedValue([]),
           ensureProjectsExist: jest.fn().mockResolvedValue(undefined),
         },
         dataSources: {
@@ -515,6 +516,208 @@ describe("experiments API", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.experiments).toHaveLength(2);
+    });
+
+    it("sorts by dateCreated ascending by default", async () => {
+      (getAllExperiments as jest.Mock).mockResolvedValue([experiment]);
+      const res = await request(app)
+        .get("/api/v1/experiments")
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      expect(getAllExperiments).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ sortBy: { dateCreated: 1 } }),
+      );
+    });
+
+    it("passes sortBy and sortOrder to the query", async () => {
+      (getAllExperiments as jest.Mock).mockResolvedValue([experiment]);
+      const res = await request(app)
+        .get("/api/v1/experiments?sortBy=name&sortOrder=desc")
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      expect(getAllExperiments).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ sortBy: { name: -1 } }),
+      );
+    });
+
+    it("rejects an unsupported sortBy field", async () => {
+      const res = await request(app)
+        .get("/api/v1/experiments?sortBy=owner")
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(400);
+    });
+
+    it("filters by comma-separated tags", async () => {
+      const tagged = { ...experiment, id: "exp_tagged", tags: ["checkout"] };
+      (getAllExperiments as jest.Mock).mockResolvedValue([experiment, tagged]);
+      const res = await request(app)
+        .get("/api/v1/experiments?tag=checkout,promo")
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      expect(res.body.experiments).toHaveLength(1);
+      expect(res.body.experiments[0].id).toBe("exp_tagged");
+    });
+
+    it("filters by linked-change type", async () => {
+      const withFeature = {
+        ...experiment,
+        id: "exp_feature",
+        linkedFeatures: ["feat_1"],
+      };
+      (getAllExperiments as jest.Mock).mockResolvedValue([
+        experiment,
+        withFeature,
+      ]);
+      const res = await request(app)
+        .get("/api/v1/experiments?type=feature")
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      expect(res.body.experiments).toHaveLength(1);
+      expect(res.body.experiments[0].id).toBe("exp_feature");
+    });
+
+    it("rejects an unsupported type value", async () => {
+      const res = await request(app)
+        .get("/api/v1/experiments?type=banana")
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(400);
+    });
+
+    it("filters by owner id", async () => {
+      const owned = { ...experiment, id: "exp_owned", owner: "u_123" };
+      (getAllExperiments as jest.Mock).mockResolvedValue([experiment, owned]);
+      const res = await request(app)
+        .get("/api/v1/experiments?owner=u_123")
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      expect(res.body.experiments).toHaveLength(1);
+      expect(res.body.experiments[0].id).toBe("exp_owned");
+    });
+
+    it("filters by result", async () => {
+      const won = {
+        ...experiment,
+        id: "exp_won",
+        status: "stopped",
+        results: "won",
+      };
+      (getAllExperiments as jest.Mock).mockResolvedValue([experiment, won]);
+      const res = await request(app)
+        .get("/api/v1/experiments?result=won,lost")
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      expect(res.body.experiments).toHaveLength(1);
+      expect(res.body.experiments[0].id).toBe("exp_won");
+    });
+
+    it("rejects an unsupported result value", async () => {
+      const res = await request(app)
+        .get("/api/v1/experiments?result=maybe")
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(400);
+    });
+
+    it("filters by metric id across goal, secondary, and guardrail metrics", async () => {
+      const withMetric = {
+        ...experiment,
+        id: "exp_metric",
+        guardrailMetrics: ["met_1"],
+      };
+      (getAllExperiments as jest.Mock).mockResolvedValue([
+        experiment,
+        withMetric,
+      ]);
+      const res = await request(app)
+        .get("/api/v1/experiments?metricId=met_1")
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      expect(res.body.experiments).toHaveLength(1);
+      expect(res.body.experiments[0].id).toBe("exp_metric");
+    });
+
+    it("filters bandits in or out with the bandits param", async () => {
+      const bandit = {
+        ...experiment,
+        id: "exp_bandit",
+        type: "multi-armed-bandit",
+      };
+      (getAllExperiments as jest.Mock).mockResolvedValue([experiment, bandit]);
+
+      const onlyBandits = await request(app)
+        .get("/api/v1/experiments?bandits=true")
+        .set("Authorization", "Bearer foo");
+      expect(onlyBandits.status).toBe(200);
+      expect(onlyBandits.body.experiments).toHaveLength(1);
+      expect(onlyBandits.body.experiments[0].id).toBe("exp_bandit");
+
+      (getAllExperiments as jest.Mock).mockResolvedValue([experiment, bandit]);
+      const noBandits = await request(app)
+        .get("/api/v1/experiments?bandits=false")
+        .set("Authorization", "Bearer foo");
+      expect(noBandits.status).toBe(200);
+      expect(noBandits.body.experiments).toHaveLength(1);
+      expect(noBandits.body.experiments[0].id).toBe("exp_123");
+    });
+
+    it("applies filters from a q search string", async () => {
+      const tagged = { ...experiment, id: "exp_tagged", tags: ["checkout"] };
+      (getAllExperiments as jest.Mock).mockResolvedValue([experiment, tagged]);
+      const res = await request(app)
+        .get("/api/v1/experiments?q=tag:checkout")
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      expect(res.body.experiments).toHaveLength(1);
+      expect(res.body.experiments[0].id).toBe("exp_tagged");
+    });
+
+    it("rejects unsupported q search syntax", async () => {
+      const res = await request(app)
+        .get("/api/v1/experiments?q=tag:!checkout")
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(400);
+    });
+
+    it("leaves the archived filter unset when the param is omitted", async () => {
+      (getAllExperiments as jest.Mock).mockResolvedValue([experiment]);
+      const res = await request(app)
+        .get("/api/v1/experiments")
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      expect(getAllExperiments).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ archived: undefined, includeArchived: true }),
+      );
+    });
+
+    it.each([
+      ["true", true],
+      ["false", false],
+    ])("passes archived=%s through as a boolean", async (param, value) => {
+      (getAllExperiments as jest.Mock).mockResolvedValue([experiment]);
+      const res = await request(app)
+        .get(`/api/v1/experiments?archived=${param}`)
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      expect(getAllExperiments).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ archived: value }),
+      );
     });
   });
 

--- a/packages/back-end/test/api/experiments.test.ts
+++ b/packages/back-end/test/api/experiments.test.ts
@@ -564,7 +564,7 @@ describe("experiments API", () => {
       expect(res.body.experiments[0].id).toBe("exp_tagged");
     });
 
-    it("filters by linked-change type", async () => {
+    it("filters by implementation type", async () => {
       const withFeature = {
         ...experiment,
         id: "exp_feature",
@@ -575,7 +575,7 @@ describe("experiments API", () => {
         withFeature,
       ]);
       const res = await request(app)
-        .get("/api/v1/experiments?type=feature")
+        .get("/api/v1/experiments?implementationType=feature")
         .set("Authorization", "Bearer foo");
 
       expect(res.status).toBe(200);
@@ -583,9 +583,9 @@ describe("experiments API", () => {
       expect(res.body.experiments[0].id).toBe("exp_feature");
     });
 
-    it("rejects an unsupported type value", async () => {
+    it("rejects an unsupported implementationType value", async () => {
       const res = await request(app)
-        .get("/api/v1/experiments?type=banana")
+        .get("/api/v1/experiments?implementationType=banana")
         .set("Authorization", "Bearer foo");
 
       expect(res.status).toBe(400);

--- a/packages/back-end/test/api/experiments.test.ts
+++ b/packages/back-end/test/api/experiments.test.ts
@@ -4,6 +4,8 @@ import {
   getExperimentByTrackingKey,
   createExperiment,
   getAllExperiments,
+  getExperimentsPage,
+  countExperiments,
   updateExperiment,
 } from "../../src/models/ExperimentModel";
 import {
@@ -27,6 +29,8 @@ jest.mock("../../src/models/ExperimentModel", () => ({
   createExperiment: jest.fn(),
   updateExperiment: jest.fn(),
   getAllExperiments: jest.fn(),
+  getExperimentsPage: jest.fn(),
+  countExperiments: jest.fn(),
 }));
 
 jest.mock("../../src/models/ExperimentSnapshotModel", () => ({
@@ -94,6 +98,8 @@ describe("experiments API", () => {
         canCreateExperiment: () => true,
         canUpdateExperiment: () => true,
         canAddComment: () => true,
+        canReadSingleProjectResource: () => true,
+        getProjectsWithPermission: () => null,
       },
       hasPremiumFeature: () => false,
       getUsersByIds: jest.fn().mockResolvedValue([]),
@@ -435,7 +441,8 @@ describe("experiments API", () => {
 
   describe("GET /api/v1/experiments", () => {
     it("returns signed screenshot URLs for all experiments", async () => {
-      (getAllExperiments as jest.Mock).mockResolvedValue([experiment]);
+      (getExperimentsPage as jest.Mock).mockResolvedValue([experiment]);
+      (countExperiments as jest.Mock).mockResolvedValue(1);
       const res = await request(app)
         .get("/api/v1/experiments")
         .set("Authorization", "Bearer foo");
@@ -448,7 +455,8 @@ describe("experiments API", () => {
     });
 
     it("returns empty array when no experiments exist", async () => {
-      (getAllExperiments as jest.Mock).mockResolvedValue([]);
+      (getExperimentsPage as jest.Mock).mockResolvedValue([]);
+      (countExperiments as jest.Mock).mockResolvedValue(0);
       const res = await request(app)
         .get("/api/v1/experiments")
         .set("Authorization", "Bearer foo");
@@ -464,10 +472,11 @@ describe("experiments API", () => {
         trackingKey: "exp_456",
         name: "Second Experiment",
       };
-      (getAllExperiments as jest.Mock).mockResolvedValue([
+      (getExperimentsPage as jest.Mock).mockResolvedValue([
         experiment,
         experiment2,
       ]);
+      (countExperiments as jest.Mock).mockResolvedValue(2);
       const res = await request(app)
         .get("/api/v1/experiments")
         .set("Authorization", "Bearer foo");
@@ -476,11 +485,14 @@ describe("experiments API", () => {
       expect(res.body.experiments).toHaveLength(2);
       expect(res.body.experiments[0].id).toBe("exp_123");
       expect(res.body.experiments[1].id).toBe("exp_456");
+      expect(res.body.total).toBe(2);
+      expect(res.body.hasMore).toBe(false);
     });
 
     it("filters experiments by project", async () => {
       const projectExperiment = { ...experiment, project: "proj_1" };
-      (getAllExperiments as jest.Mock).mockResolvedValue([projectExperiment]);
+      (getExperimentsPage as jest.Mock).mockResolvedValue([projectExperiment]);
+      (countExperiments as jest.Mock).mockResolvedValue(1);
       const res = await request(app)
         .get("/api/v1/experiments?projectId=proj_1")
         .set("Authorization", "Bearer foo");
@@ -488,10 +500,54 @@ describe("experiments API", () => {
       expect(res.status).toBe(200);
       expect(res.body.experiments).toHaveLength(1);
       expect(res.body.experiments[0].project).toBe("proj_1");
+      expect(getExperimentsPage).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ project: "proj_1" }),
+      );
+    });
+
+    it("returns an empty page when the requested project is not readable", async () => {
+      updateReqContext({
+        permissions: {
+          canViewExperiment: () => true,
+          canReadSingleProjectResource: () => false,
+          getProjectsWithPermission: () => null,
+        },
+      });
+      const res = await request(app)
+        .get("/api/v1/experiments?projectId=proj_hidden")
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      expect(res.body.experiments).toEqual([]);
+      expect(res.body.total).toBe(0);
+      expect(getExperimentsPage).not.toHaveBeenCalled();
+    });
+
+    it("pre-scopes the query to readable projects", async () => {
+      updateReqContext({
+        permissions: {
+          canViewExperiment: () => true,
+          canReadSingleProjectResource: () => true,
+          getProjectsWithPermission: () => ["proj_a", "proj_b"],
+        },
+      });
+      (getExperimentsPage as jest.Mock).mockResolvedValue([experiment]);
+      (countExperiments as jest.Mock).mockResolvedValue(1);
+      const res = await request(app)
+        .get("/api/v1/experiments")
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      expect(getExperimentsPage).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ projectIds: ["proj_a", "proj_b"] }),
+      );
     });
 
     it("returns experiments with correct metadata", async () => {
-      (getAllExperiments as jest.Mock).mockResolvedValue([experiment]);
+      (getExperimentsPage as jest.Mock).mockResolvedValue([experiment]);
+      (countExperiments as jest.Mock).mockResolvedValue(1);
       const res = await request(app)
         .get("/api/v1/experiments")
         .set("Authorization", "Bearer foo");
@@ -506,10 +562,11 @@ describe("experiments API", () => {
 
     it("includes archived experiments in list when requested", async () => {
       const archivedExp = { ...experiment, archived: true };
-      (getAllExperiments as jest.Mock).mockResolvedValue([
+      (getExperimentsPage as jest.Mock).mockResolvedValue([
         experiment,
         archivedExp,
       ]);
+      (countExperiments as jest.Mock).mockResolvedValue(2);
       const res = await request(app)
         .get("/api/v1/experiments")
         .set("Authorization", "Bearer foo");
@@ -518,27 +575,40 @@ describe("experiments API", () => {
       expect(res.body.experiments).toHaveLength(2);
     });
 
-    it("sorts by dateCreated ascending by default", async () => {
-      const older = {
-        ...experiment,
-        id: "exp_older",
-        dateCreated: new Date("2020-01-01"),
-      };
-      const newer = {
-        ...experiment,
-        id: "exp_newer",
-        dateCreated: new Date("2024-01-01"),
-      };
-      (getAllExperiments as jest.Mock).mockResolvedValue([newer, older]);
+    it("pages in the database with the default dateCreated sort", async () => {
+      (getExperimentsPage as jest.Mock).mockResolvedValue([experiment]);
+      (countExperiments as jest.Mock).mockResolvedValue(25);
       const res = await request(app)
-        .get("/api/v1/experiments")
+        .get("/api/v1/experiments?limit=10&offset=10")
         .set("Authorization", "Bearer foo");
 
       expect(res.status).toBe(200);
-      expect(res.body.experiments.map((e: { id: string }) => e.id)).toEqual([
-        "exp_older",
-        "exp_newer",
-      ]);
+      expect(getExperimentsPage).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          sort: { dateCreated: 1, _id: 1 },
+          limit: 10,
+          offset: 10,
+        }),
+      );
+      expect(res.body.total).toBe(25);
+      expect(res.body.hasMore).toBe(true);
+      expect(res.body.nextOffset).toBe(20);
+      expect(getAllExperiments).not.toHaveBeenCalled();
+    });
+
+    it("passes sortBy and sortOrder to the database sort", async () => {
+      (getExperimentsPage as jest.Mock).mockResolvedValue([experiment]);
+      (countExperiments as jest.Mock).mockResolvedValue(1);
+      const res = await request(app)
+        .get("/api/v1/experiments?sortBy=dateUpdated&sortOrder=desc")
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      expect(getExperimentsPage).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ sort: { dateUpdated: -1, _id: 1 } }),
+      );
     });
 
     it("sorts by name descending, case-insensitively", async () => {
@@ -660,28 +730,51 @@ describe("experiments API", () => {
       expect(res.body.experiments[0].id).toBe("exp_metric");
     });
 
-    it("filters bandits in or out with the bandits param", async () => {
+    it("maps the bandits param onto the type filter in the database", async () => {
       const bandit = {
         ...experiment,
         id: "exp_bandit",
         type: "multi-armed-bandit",
       };
-      (getAllExperiments as jest.Mock).mockResolvedValue([experiment, bandit]);
+      (getExperimentsPage as jest.Mock).mockResolvedValue([bandit]);
+      (countExperiments as jest.Mock).mockResolvedValue(1);
 
       const onlyBandits = await request(app)
         .get("/api/v1/experiments?bandits=true")
         .set("Authorization", "Bearer foo");
       expect(onlyBandits.status).toBe(200);
-      expect(onlyBandits.body.experiments).toHaveLength(1);
-      expect(onlyBandits.body.experiments[0].id).toBe("exp_bandit");
+      expect(getExperimentsPage).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ type: "multi-armed-bandit" }),
+      );
 
-      (getAllExperiments as jest.Mock).mockResolvedValue([experiment, bandit]);
+      (getExperimentsPage as jest.Mock).mockResolvedValue([experiment]);
       const noBandits = await request(app)
         .get("/api/v1/experiments?bandits=false")
         .set("Authorization", "Bearer foo");
       expect(noBandits.status).toBe(200);
-      expect(noBandits.body.experiments).toHaveLength(1);
-      expect(noBandits.body.experiments[0].id).toBe("exp_123");
+      expect(getExperimentsPage).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ type: "standard" }),
+      );
+    });
+
+    it("still filters bandits in memory when combined with in-memory filters", async () => {
+      const bandit = {
+        ...experiment,
+        id: "exp_bandit",
+        type: "multi-armed-bandit",
+        tags: ["checkout"],
+      };
+      const tagged = { ...experiment, id: "exp_tagged", tags: ["checkout"] };
+      (getAllExperiments as jest.Mock).mockResolvedValue([tagged, bandit]);
+      const res = await request(app)
+        .get("/api/v1/experiments?bandits=true&tag=checkout")
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      expect(res.body.experiments).toHaveLength(1);
+      expect(res.body.experiments[0].id).toBe("exp_bandit");
     });
 
     it("applies filters from a q search string", async () => {
@@ -705,13 +798,14 @@ describe("experiments API", () => {
     });
 
     it("leaves the archived filter unset when the param is omitted", async () => {
-      (getAllExperiments as jest.Mock).mockResolvedValue([experiment]);
+      (getExperimentsPage as jest.Mock).mockResolvedValue([experiment]);
+      (countExperiments as jest.Mock).mockResolvedValue(1);
       const res = await request(app)
         .get("/api/v1/experiments")
         .set("Authorization", "Bearer foo");
 
       expect(res.status).toBe(200);
-      expect(getAllExperiments).toHaveBeenCalledWith(
+      expect(getExperimentsPage).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ archived: undefined, includeArchived: true }),
       );
@@ -721,13 +815,14 @@ describe("experiments API", () => {
       ["true", true],
       ["false", false],
     ])("passes archived=%s through as a boolean", async (param, value) => {
-      (getAllExperiments as jest.Mock).mockResolvedValue([experiment]);
+      (getExperimentsPage as jest.Mock).mockResolvedValue([experiment]);
+      (countExperiments as jest.Mock).mockResolvedValue(1);
       const res = await request(app)
         .get(`/api/v1/experiments?archived=${param}`)
         .set("Authorization", "Bearer foo");
 
       expect(res.status).toBe(200);
-      expect(getAllExperiments).toHaveBeenCalledWith(
+      expect(getExperimentsPage).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ archived: value }),
       );

--- a/packages/back-end/test/api/experiments.test.ts
+++ b/packages/back-end/test/api/experiments.test.ts
@@ -519,29 +519,42 @@ describe("experiments API", () => {
     });
 
     it("sorts by dateCreated ascending by default", async () => {
-      (getAllExperiments as jest.Mock).mockResolvedValue([experiment]);
+      const older = {
+        ...experiment,
+        id: "exp_older",
+        dateCreated: new Date("2020-01-01"),
+      };
+      const newer = {
+        ...experiment,
+        id: "exp_newer",
+        dateCreated: new Date("2024-01-01"),
+      };
+      (getAllExperiments as jest.Mock).mockResolvedValue([newer, older]);
       const res = await request(app)
         .get("/api/v1/experiments")
         .set("Authorization", "Bearer foo");
 
       expect(res.status).toBe(200);
-      expect(getAllExperiments).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({ sortBy: { dateCreated: 1 } }),
-      );
+      expect(res.body.experiments.map((e: { id: string }) => e.id)).toEqual([
+        "exp_older",
+        "exp_newer",
+      ]);
     });
 
-    it("passes sortBy and sortOrder to the query", async () => {
-      (getAllExperiments as jest.Mock).mockResolvedValue([experiment]);
+    it("sorts by name descending, case-insensitively", async () => {
+      const apple = { ...experiment, id: "exp_apple", name: "apple test" };
+      const zebra = { ...experiment, id: "exp_zebra", name: "Zebra test" };
+      (getAllExperiments as jest.Mock).mockResolvedValue([apple, zebra]);
       const res = await request(app)
         .get("/api/v1/experiments?sortBy=name&sortOrder=desc")
         .set("Authorization", "Bearer foo");
 
       expect(res.status).toBe(200);
-      expect(getAllExperiments).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({ sortBy: { name: -1 } }),
-      );
+      // Case-insensitive: "Zebra" sorts after "apple" despite uppercase Z
+      expect(res.body.experiments.map((e: { id: string }) => e.id)).toEqual([
+        "exp_zebra",
+        "exp_apple",
+      ]);
     });
 
     it("rejects an unsupported sortBy field", async () => {

--- a/packages/back-end/test/api/experiments.test.ts
+++ b/packages/back-end/test/api/experiments.test.ts
@@ -607,7 +607,7 @@ describe("experiments API", () => {
       expect(res.status).toBe(200);
       expect(getExperimentsPage).toHaveBeenCalledWith(
         expect.anything(),
-        expect.objectContaining({ sort: { dateUpdated: -1, _id: 1 } }),
+        expect.objectContaining({ sort: { dateUpdated: -1, _id: -1 } }),
       );
     });
 

--- a/packages/back-end/test/services/experimentFilters.test.ts
+++ b/packages/back-end/test/services/experimentFilters.test.ts
@@ -37,7 +37,7 @@ describe("parseExperimentSearchString", () => {
     expect(
       parseExperimentSearchString("has:feature,redirects,visualChange"),
     ).toEqual({
-      types: ["feature", "redirect", "visualChange"],
+      implementationTypes: ["feature", "redirect", "visualChange"],
     });
   });
 
@@ -99,16 +99,16 @@ describe("normalizeExperimentFilters", () => {
       results: undefined,
       statuses: ["running"],
       tags: ["a", "b"],
-      types: undefined,
+      implementationTypes: undefined,
       search: undefined,
     });
   });
 
   it("normalizes structured type tokens", () => {
     const result = normalizeExperimentFilters({
-      filters: { types: ["features", "redirects"] },
+      filters: { implementationTypes: ["features", "redirects"] },
     });
-    expect(result.types).toEqual(["feature", "redirect"]);
+    expect(result.implementationTypes).toEqual(["feature", "redirect"]);
   });
 });
 
@@ -204,7 +204,7 @@ describe("filterExperiments", () => {
     ).toHaveLength(1);
   });
 
-  it("filters by experiment type via has/types", () => {
+  it("filters by implementation type via has/implementationTypes", () => {
     const experiments = [
       makeExperiment({ id: "feat", linkedFeatures: ["feat_1"] }),
       makeExperiment({ id: "redir", hasURLRedirects: true }),
@@ -212,7 +212,7 @@ describe("filterExperiments", () => {
     ];
     const result = filterExperiments({
       experiments,
-      filters: { types: ["feature"] },
+      filters: { implementationTypes: ["feature"] },
       resolvers,
     });
     expect(result.map((e) => e.id)).toEqual(["feat"]);

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -11,6 +11,8 @@ import {
   paginationQueryFields,
   apiPaginationFieldsValidator,
   ignoreWarningsBodyField,
+  booleanQueryField,
+  csvQueryField,
 } from "./shared";
 import { windowTypeValidator } from "./fact-table";
 import {
@@ -207,6 +209,15 @@ export type ExperimentType = (typeof experimentType)[number];
 
 export const banditStageType = ["explore", "exploit", "paused"] as const;
 export type BanditStageType = (typeof banditStageType)[number];
+
+// The linked-change types the app's experiment "Type" filter recognizes; the
+// back-end normalizer (normalizeTypeToken in services/experimentFilters) also
+// accepts plural and differently-cased forms of these tokens.
+export const experimentLinkedChangeTypes = [
+  "feature",
+  "visualChange",
+  "redirect",
+] as const;
 
 export const decisionFrameworkMetricOverrides = z.object({
   id: z.string(),
@@ -1514,6 +1525,15 @@ const idAndVariationParams = z
 // Route validators
 // ---------------------------------------------------------------------------
 
+// Each sortable field is backed by a compound { organization, <field> } index
+// in ExperimentModel — keep the two lists in sync when adding fields.
+export const sortableExperimentFields = [
+  "dateCreated",
+  "dateUpdated",
+  "name",
+] as const;
+export type SortableExperimentField = (typeof sortableExperimentFields)[number];
+
 export const listExperimentsValidator = {
   bodySchema: z.never(),
   querySchema: z
@@ -1534,6 +1554,49 @@ export const listExperimentsValidator = {
         .meta({ deprecated: true }),
 
       status: z.enum(experimentStatus).optional(),
+      q: z
+        .string()
+        .describe(
+          "Raw experiment search/filter string (same syntax as the app's experiment list filters, e.g. `status:running tag:checkout`). Negation (`!`) and operators (`~`, `^`, `>`, `<`, `=`) are not supported and return a 400",
+        )
+        .optional(),
+      owner: ownerInputField
+        .describe("Filter by comma-separated owner ids, names, or emails")
+        .optional(),
+      result: csvQueryField(
+        experimentResultsType,
+        "Filter by comma-separated results (won, lost, inconclusive, dnf). Only stopped experiments carry a result",
+      ),
+      tag: z.string().describe("Filter by comma-separated tags").optional(),
+      type: csvQueryField(
+        experimentLinkedChangeTypes,
+        "Filter by comma-separated experiment types (feature, visualChange, redirect)",
+      ),
+      metricId: z
+        .string()
+        .describe(
+          "Filter by comma-separated metric ids. Matches experiments that use a metric as a goal, secondary, or guardrail metric",
+        )
+        .optional(),
+      bandits: z
+        .enum(["true", "false"])
+        .describe(
+          "When true, return only multi-armed bandits; when false, exclude them",
+        )
+        .optional(),
+      archived: booleanQueryField.describe(
+        "Filter by archived status. Set to `true` to return only archived experiments, `false` to exclude them. If omitted, both archived and non-archived experiments are returned.",
+      ),
+      sortBy: z
+        .enum(sortableExperimentFields)
+        .describe("Field to sort the results by")
+        .optional()
+        .meta({ default: "dateCreated" }),
+      sortOrder: z
+        .enum(["asc", "desc"])
+        .describe("Sort direction (used with `sortBy`)")
+        .optional()
+        .meta({ default: "asc" }),
     })
     .strict(),
   paramsSchema: z.never(),

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -210,10 +210,12 @@ export type ExperimentType = (typeof experimentType)[number];
 export const banditStageType = ["explore", "exploit", "paused"] as const;
 export type BanditStageType = (typeof banditStageType)[number];
 
-// The linked-change types the app's experiment "Type" filter recognizes; the
-// back-end normalizer (normalizeTypeToken in services/experimentFilters) also
+// The implementation (linked-change) types the app's experiment "Type" filter
+// recognizes — distinct from the top-level `experiment.type` field (standard
+// vs bandit vs holdout). The back-end normalizer
+// (normalizeImplementationTypeToken in services/experimentFilters) also
 // accepts plural and differently-cased forms of these tokens.
-export const experimentLinkedChangeTypes = [
+export const experimentImplementationTypes = [
   "feature",
   "visualChange",
   "redirect",
@@ -1565,12 +1567,12 @@ export const listExperimentsValidator = {
         .optional(),
       result: csvQueryField(
         experimentResultsType,
-        "Filter by comma-separated results (won, lost, inconclusive, dnf). Only stopped experiments carry a result",
+        "Filter by comma-separated results (won, lost, inconclusive, dnf). Matches the experiment's recorded result — set when an experiment is stopped and retained if it's later restarted, so running experiments can match too",
       ),
       tag: z.string().describe("Filter by comma-separated tags").optional(),
-      type: csvQueryField(
-        experimentLinkedChangeTypes,
-        "Filter by comma-separated experiment types (feature, visualChange, redirect)",
+      implementationType: csvQueryField(
+        experimentImplementationTypes,
+        "Filter by comma-separated implementation types (feature, visualChange, redirect) — the kinds of changes linked to the experiment. To filter standard experiments vs bandits, use `bandits` instead",
       ),
       metricId: z
         .string()

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -1527,9 +1527,9 @@ const idAndVariationParams = z
 // Route validators
 // ---------------------------------------------------------------------------
 
-// Sorting is applied in the API handler after the (in-memory) permission
-// filter, so sortable fields need no backing index. `name` sorts
-// case-insensitively.
+// None of these are index-backed: date sorts run as a bounded blocking sort
+// in Mongo (see the index note in ExperimentModel) and `name` sorts in the
+// API handler, case-insensitively, on the fetch-all path.
 export const sortableExperimentFields = [
   "dateCreated",
   "dateUpdated",

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -1527,8 +1527,9 @@ const idAndVariationParams = z
 // Route validators
 // ---------------------------------------------------------------------------
 
-// Each sortable field is backed by a compound { organization, <field> } index
-// in ExperimentModel — keep the two lists in sync when adding fields.
+// Sorting is applied in the API handler after the (in-memory) permission
+// filter, so sortable fields need no backing index. `name` sorts
+// case-insensitively.
 export const sortableExperimentFields = [
   "dateCreated",
   "dateUpdated",

--- a/packages/shared/src/validators/shared.ts
+++ b/packages/shared/src/validators/shared.ts
@@ -79,6 +79,32 @@ export const paginationQueryFields = {
     .meta({ default: 0 }),
 };
 
+/**
+ * Comma-separated query param restricted to a fixed set of values
+ * (case-insensitive), e.g. `?result=won,lost`.
+ */
+export const csvQueryField = (
+  allowed: readonly string[],
+  description: string,
+) => {
+  const allowedSet = new Set(allowed.map((v) => v.toLowerCase()));
+  return z
+    .string()
+    .describe(description)
+    .refine(
+      (v) =>
+        v
+          .split(",")
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0)
+          .every((t) => allowedSet.has(t.toLowerCase())),
+      {
+        message: `Must be a comma-separated list of: ${allowed.join(", ")}`,
+      },
+    )
+    .optional();
+};
+
 /** Accepts boolean query params in both string and native boolean form. */
 export const booleanQueryField = z
   .union([

--- a/packages/shared/src/validators/shared.ts
+++ b/packages/shared/src/validators/shared.ts
@@ -82,27 +82,43 @@ export const paginationQueryFields = {
 /**
  * Comma-separated query param restricted to a fixed set of values
  * (case-insensitive), e.g. `?result=won,lost`.
+ *
+ * At runtime the value is a plain string validated by the refinement. The
+ * meta() overrides the generated OpenAPI schema to the spec-correct encoding
+ * for CSV enums — `type: array` with `items.enum` and `explode: false` (the
+ * generator hoists `explode` to the parameter level) — so the docs surface
+ * the allowed values instead of a bare string.
  */
 export const csvQueryField = (
   allowed: readonly string[],
   description: string,
 ) => {
   const allowedSet = new Set(allowed.map((v) => v.toLowerCase()));
-  return z
-    .string()
-    .describe(description)
-    .refine(
-      (v) =>
-        v
-          .split(",")
-          .map((s) => s.trim())
-          .filter((s) => s.length > 0)
-          .every((t) => allowedSet.has(t.toLowerCase())),
-      {
-        message: `Must be a comma-separated list of: ${allowed.join(", ")}`,
-      },
-    )
-    .optional();
+  return (
+    z
+      .string()
+      .refine(
+        (v) =>
+          v
+            .split(",")
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0)
+            .every((t) => allowedSet.has(t.toLowerCase())),
+        {
+          message: `Must be a comma-separated list of: ${allowed.join(", ")}`,
+        },
+      )
+      // describe() must come after refine() — refine() clones the schema and
+      // the clone doesn't carry registry metadata, so the description would be
+      // dropped from the generated OpenAPI spec
+      .describe(description)
+      .meta({
+        type: "array",
+        items: { type: "string", enum: [...allowed] },
+        explode: false,
+      })
+      .optional()
+  );
 };
 
 /** Accepts boolean query params in both string and native boolean form. */


### PR DESCRIPTION
## What

Follow-up to #6418 (merged). The experiments list endpoint previously materialized the **whole org's experiments** in Node on every page request (fetch all → permission-filter → in-memory paginate) — the `TODO: Move pagination to database` in the handler. This adds a DB-pagination fast path:

- **When no in-memory filters are requested** (`owner`, `result`, `tag`, `implementationType`, `metricId`, `q`) **and the sort is a date field**, the handler pre-scopes the query to the caller's readable projects (`getProjectsWithPermission("readData")`, mirroring `loadFeaturesPage`), then skips/limits/sorts in MongoDB via new `getExperimentsPage` / `countExperiments` model functions built on a shared `experimentListQuery` builder.
- **`bandits` maps onto the `type` field** in the fast path, so a bandits-only query also pages in the DB.
- **Everything else falls back to the existing fetch-all path**: in-memory filters can't be applied after DB pagination without corrupting page counts, and `name` sorts stay in Node so they remain case-insensitive.

## No new indexes (updated)

An earlier revision of this PR added `{ organization, dateCreated }` / `{ organization, dateUpdated }`. Both are **removed** — verified against MongoDB 7.0.4 that they were never used for the sort anyway:

| index | sort spec | plan | docs examined |
| --- | --- | --- | --- |
| `{org, dateCreated}` | `{dateCreated: 1, _id: 1}` | `SORT ← FETCH ← IXSCAN` | 2000 |
| `{org, dateCreated}` | `{dateCreated: 1}` | `LIMIT ← FETCH ← IXSCAN` | 100 |
| `{org, dateCreated, _id}` | `{dateCreated: -1, _id: 1}` (mixed) | `SORT ← FETCH ← IXSCAN` | 2000 |
| `{org, dateCreated, _id}` | `{dateCreated: -1, _id: -1}` | `LIMIT ← FETCH ← IXSCAN` | 100 |

Mongo only uses an index for a sort when it satisfies the *entire* sort key in a consistent direction, and our spec carries an `_id` tiebreak for stable pagination. Making the indexes pay off would require `{ organization, <field>, _id }` **and** a tiebreak direction matching `sortOrder` — not worth the insert cost without evidence it matters (thanks @jdorn). The requirements are documented in `ExperimentModel` so a future attempt doesn't repeat the mistake, and the tiebreak direction now follows `sortDir` so the spec is index-eligible the day someone adds one.

**The refactor still stands on its own without indexes.** The sort runs as a bounded (top-k) blocking sort — `sortLimitAmount` equals the page size, so Mongo examines the org's docs server-side but caps sort memory at one page and ships only that page. What this PR eliminates is transferring, hydrating (BSON→JS) and running `upgradeExperimentDoc` over every experiment in the org on every page request, just to slice out ten.

## Trade-offs (same ones `listFeaturesV2` already ships with)

- The per-doc permission filter still runs as defense-in-depth after the query. If a user has global readData but a no-access project role, a fast-path page can come back short — identical to `loadFeaturesPage` behavior today.
- `total` comes from `countDocuments` on the pre-scoped query.

## Testing

- 89 API tests pass, including new coverage: DB path used for unfiltered queries (sort/limit/offset forwarded, `getAllExperiments` not called), project pre-scoping, unreadable-project → empty page, bandits→type mapping, fallback to fetch-all when combined with in-memory filters.
- Type-checks and lints clean; OpenAPI spec unchanged (no wire-format changes).

> **Note:** branched before #6418 merged, so it needs a rebase onto `main` and a base change from `gm/experiment-api-filters` before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)