### PR TITLE
Add EU (eu-west-1) region support to managed warehouse and Event Forwarder

### DIFF
--- a/docs/docs/experimentation-analysis/event-forwarder.mdx
+++ b/docs/docs/experimentation-analysis/event-forwarder.mdx
@@ -195,6 +195,21 @@ req.growthbook.logEvent("Sign Up", {
 });
 ```
 
+#### Sending events to the right region
+
+The tracking plugin sends events to `https://us1.gb-ingest.com` by default. If you selected **eu-west-1** as your Event Forwarder's Data Region, override the ingestor host so events reach the right Kafka/Confluent resources instead of being dropped:
+
+- **HTML Script Tag**: add `data-event-ingestor-host="https://eu-west-1.gb-ingest.com"` to the script tag.
+- **JavaScript / React / Node.js**: pass `ingestorHost` to `growthbookTrackingPlugin()`:
+
+```js
+growthbookTrackingPlugin({
+  ingestorHost: "https://eu-west-1.gb-ingest.com",
+})
+```
+
+You can find your Event Forwarder's configured region on the data source's Event Forwarder settings.
+
 ### Ingestion API
 
 You can also send events directly to our ingestion API. Pass an array of event objects, each with the following properties:
@@ -202,9 +217,11 @@ You can also send events directly to our ingestion API. Pass an array of event o
 - **event_name**: The name of the event (e.g., "Purchase", "Button Click")
 - **properties**: Optional key-value pairs with properties of the event itself
 - **attributes**: Optional key-value pairs with attributes of the user or context at the time of the event
+- YOUR_WAREHOUSE_REGION: either us1 or eu-west-1 depending on what you selected when creating your datasource
+- YOUR_CLIENT_KEY: The key from your sdk connection. Go to https://app.growthbook.io/sdks/ click on your connection or make a new one. Copy the text from the "Client Key"
 
 ```bash
-curl -X POST "https://us1.gb-ingest.com/track?client_key=YOUR_CLIENT_KEY" \
+curl -X POST "https://YOUR_WAREHOUSE_REGION.gb-ingest.com/track?client_key=YOUR_CLIENT_KEY" \
 -H "Content-Type: application/json" \
 -d '[{
   "event_name": "Purchase",
@@ -217,7 +234,7 @@ curl -X POST "https://us1.gb-ingest.com/track?client_key=YOUR_CLIENT_KEY" \
 }]'
 ```
 
-The example above uses the `us1.gb-ingest.com` endpoint, for forwarders provisioned in the `us-east-1` **Data Region**. If you chose `eu-west-1` when setting up your Event Forwarder, send events to `https://eu1.gb-ingest.com` instead — using the wrong host means events won't reach the Kafka/Confluent resources your forwarder is actually wired up to.
+Using the wrong host means events won't reach the Kafka/Confluent resources your forwarder is actually wired up to.
 
 #### Experiment View Events
 

--- a/docs/docs/experimentation-analysis/event-forwarder.mdx
+++ b/docs/docs/experimentation-analysis/event-forwarder.mdx
@@ -217,7 +217,7 @@ curl -X POST "https://us1.gb-ingest.com/track?client_key=YOUR_CLIENT_KEY" \
 }]'
 ```
 
-The example above uses the `us1.gb-ingest.com` endpoint. Contact your account manager to find out which endpoint you should use.
+The example above uses the `us1.gb-ingest.com` endpoint, for forwarders provisioned in the `us-east-1` **Data Region**. If you chose `eu-west-1` when setting up your Event Forwarder, send events to `https://eu1.gb-ingest.com` instead — using the wrong host means events won't reach the Kafka/Confluent resources your forwarder is actually wired up to.
 
 #### Experiment View Events
 

--- a/docs/docs/experimentation-analysis/managed-warehouse.mdx
+++ b/docs/docs/experimentation-analysis/managed-warehouse.mdx
@@ -276,7 +276,14 @@ req.growthbook.logEvent("Sign Up", {
 
 ### Ingestion API
 
-You can also send events directly to our ingestion API. Pass an array of event objects, each with the following properties:
+You can also send events directly to our ingestion API. The host depends on the **Data Region** you chose when creating your Managed Warehouse datasource:
+
+- `us-east-1` → `https://us1.gb-ingest.com`
+- `eu-west-1` → `https://eu1.gb-ingest.com`
+
+Sending events to the wrong region's host means they won't reach the ClickHouse cluster your data warehouse actually lives in — always match the host to the region shown on your datasource's settings page.
+
+Pass an array of event objects, each with the following properties:
 
 - **event_name**: The name of the event (e.g., "Purchase", "Button Click")
 - **properties**: Optional key-value pairs with properties of the event itself

--- a/docs/docs/experimentation-analysis/managed-warehouse.mdx
+++ b/docs/docs/experimentation-analysis/managed-warehouse.mdx
@@ -62,6 +62,10 @@ Go to **Metrics and Data** &rarr; **Data Sources** and click **Create** on the M
 
 Add the GrowthBook SDK to your application with the tracking plugin enabled. Here are the two most common setups:
 
+:::info Using eu-west-1?
+Events default to the `us-east-1` ingestor. If you selected **eu-west-1** as your Data Region, add the `ingestorHost` (or `data-event-ingestor-host` for the script tag) override — see [Sending events to the right region](#sending-events-to-the-right-region) below — otherwise your events won't reach your warehouse.
+:::
+
 **HTML Script Tag**: add one line to your page:
 
 ```html
@@ -274,12 +278,27 @@ req.growthbook.logEvent("Sign Up", {
 });
 ```
 
+#### Sending events to the right region
+
+The tracking plugin sends events to `https://us1.gb-ingest.com` by default. If you selected **eu-west-1** as your Data Region when creating your Managed Warehouse, override the ingestor host so events reach the right ClickHouse cluster instead of being dropped:
+
+- **HTML Script Tag**: add `data-event-ingestor-host="https://eu-west-1.gb-ingest.com"` to the script tag.
+- **JavaScript / React / Node.js**: pass `ingestorHost` to `growthbookTrackingPlugin()`:
+
+```js
+growthbookTrackingPlugin({
+  ingestorHost: "https://eu-west-1.gb-ingest.com",
+})
+```
+
+You can find your datasource's configured region on its settings page.
+
 ### Ingestion API
 
 You can also send events directly to our ingestion API. The host depends on the **Data Region** you chose when creating your Managed Warehouse datasource:
 
 - `us-east-1` → `https://us1.gb-ingest.com`
-- `eu-west-1` → `https://eu1.gb-ingest.com`
+- `eu-west-1` → `https://eu-west-1.gb-ingest.com`
 
 Sending events to the wrong region's host means they won't reach the ClickHouse cluster your data warehouse actually lives in — always match the host to the region shown on your datasource's settings page.
 
@@ -291,7 +310,7 @@ Pass an array of event objects, each with the following properties:
 - **timestamp**: Optional ISO timestamp of when the event occurred. Only used when batching events with a `sentAt` field (see [Event timestamps](#event-timestamps) below).
 
 ```bash
-curl -X POST "https://us1.gb-ingest.com/track?client_key=YOUR_CLIENT_KEY" \
+curl -X POST "https://YOUR_WAREHOUSE_REGION.gb-ingest.com/track?client_key=YOUR_CLIENT_KEY" \
 -H "Content-Type: application/json" \
 -d '[{
   "event_name": "Purchase",

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -292,7 +292,7 @@ export async function postDataSources(
 }
 
 export async function postManagedWarehouse(
-  req: AuthRequest,
+  req: AuthRequest<{ region?: string }>,
   res: Response<
     | {
         status: 200;
@@ -321,6 +321,9 @@ export async function postManagedWarehouse(
     context.permissions.throwPermissionError();
   }
 
+  const region: GrowthbookClickhouseSettings["region"] =
+    req.body?.region === "eu-west-1" ? "eu-west-1" : "us-east-1";
+
   const params: ClickHouseConnectionParams = {
     url: "https://managed-warehouse-placeholder.invalid",
     port: 443,
@@ -332,7 +335,7 @@ export async function postManagedWarehouse(
   // queries are derived from the org's hashAttribute attributes.
   const datasourceSettings = getManagedWarehouseJsonSettings(
     context.org.settings?.attributeSchema,
-    { hasBeenProvisioned: false },
+    { hasBeenProvisioned: false, region },
   );
 
   const datasource = await createDataSource(

--- a/packages/back-end/src/models/SessionReplayModel.ts
+++ b/packages/back-end/src/models/SessionReplayModel.ts
@@ -14,6 +14,7 @@ import {
   getSessionReplayEventsByStoragePrefix,
 } from "back-end/src/services/session-replay";
 import { findSDKConnectionsByOrganization } from "back-end/src/models/SdkConnectionModel";
+import { getGrowthbookDatasource } from "back-end/src/models/DataSourceModel";
 
 /**
  * Internal API model for Session Replay metadata.
@@ -124,8 +125,15 @@ export class SessionReplayModel {
     // s3Key is the full object key (e.g. .../uuid/0.json.gz); strip the
     // chunk filename so the S3 listing finds all chunks for the session.
     const prefix = s3Key.substring(0, s3Key.lastIndexOf("/") + 1);
+    const datasource = await getGrowthbookDatasource(this.context);
+    const region =
+      datasource?.type === "growthbook_clickhouse" &&
+      datasource.settings.region === "eu-west-1"
+        ? "eu-west-1"
+        : "us-east-1";
     const events = (await getSessionReplayEventsByStoragePrefix(
       prefix,
+      region,
     )) as unknown as SessionReplayRrwebEvent[];
     return events;
   }

--- a/packages/back-end/src/services/eventForwarder/config.ts
+++ b/packages/back-end/src/services/eventForwarder/config.ts
@@ -342,6 +342,7 @@ export function toEventForwarderConfigDraft(
       >(config.config);
       return {
         sinkType: "bigquery",
+        region: config.region,
         config: {
           projectId: decrypted.projectId || "",
           dataset: decrypted.dataset || "",
@@ -356,6 +357,7 @@ export function toEventForwarderConfigDraft(
       );
       return {
         sinkType: "snowflake",
+        region: config.region,
         config: {
           database: decrypted.database || "",
           schema: decrypted.schema || "",
@@ -508,6 +510,7 @@ export async function syncEventForwarderConfigFromDatasource({
       // Provisioning resolves the current registry schema id after the topic exists.
       schemaId: 0,
       sinkType: draft.sinkType,
+      region: draft.region ?? "us-east-1",
       config: encryptSinkConfig(normalizedPayload),
       status: "pending",
       connectorName: "",

--- a/packages/back-end/src/services/files.ts
+++ b/packages/back-end/src/services/files.ts
@@ -24,6 +24,7 @@ import {
   GCS_DOMAIN,
   AWS_ASSUME_ROLE,
   S3_SESSION_REPLAY_BUCKET,
+  S3_SESSION_REPLAY_BUCKET_EU,
   S3_SESSION_REPLAY_ASSUME_ROLE,
   VISUAL_EDITOR_ASSETS_S3_BUCKET,
   VISUAL_EDITOR_ASSETS_S3_REGION,
@@ -125,22 +126,35 @@ function getS3Client(region: string): S3Client {
   return client;
 }
 
-let sessionReplayS3Client: S3Client | null = null;
+// Which AWS region an org's managed warehouse (and therefore its
+// session-replay data) is provisioned in. Mirrors `GrowthbookClickhouseSettings.region`.
+export type SessionReplayRegion = "us-east-1" | "eu-west-1";
+
+function getSessionReplayBucket(region: SessionReplayRegion): string {
+  return region === "eu-west-1"
+    ? S3_SESSION_REPLAY_BUCKET_EU
+    : S3_SESSION_REPLAY_BUCKET;
+}
+
+const sessionReplayS3Clients = new Map<SessionReplayRegion, S3Client>();
 
 /**
- * S3 client scoped to the session-replay bucket. May use a different role
- * (via `S3_SESSION_REPLAY_ASSUME_ROLE`) than the uploads client so that read
- * access to replay payloads can be granted independently of write access to
- * the general uploads bucket.
+ * S3 client scoped to the session-replay bucket for the given region. May use
+ * a different role (via `S3_SESSION_REPLAY_ASSUME_ROLE`) than the uploads
+ * client so that read access to replay payloads can be granted independently
+ * of write access to the general uploads bucket.
  */
-function getSessionReplayS3Client(): S3Client {
-  if (!sessionReplayS3Client) {
-    sessionReplayS3Client = buildS3Client({
+function getSessionReplayS3Client(region: SessionReplayRegion): S3Client {
+  let client = sessionReplayS3Clients.get(region);
+  if (!client) {
+    client = buildS3Client({
       assumeRoleArn: S3_SESSION_REPLAY_ASSUME_ROLE,
       roleSessionName: "growthbook-session-replay-reads",
+      region,
     });
+    sessionReplayS3Clients.set(region, client);
   }
-  return sessionReplayS3Client;
+  return client;
 }
 
 // --- Low-level S3 primitives ---
@@ -476,26 +490,30 @@ export async function getSignedUploadUrl(
  * `S3_SESSION_REPLAY_BUCKET` set). Use this in the controller to short-circuit
  * with a clean 4xx when the deployment hasn't enabled session-replay reads.
  */
-export function isSessionReplayStorageConfigured(): boolean {
-  return UPLOAD_METHOD === "s3" && !!S3_SESSION_REPLAY_BUCKET;
+export function isSessionReplayStorageConfigured(
+  region: SessionReplayRegion,
+): boolean {
+  return UPLOAD_METHOD === "s3" && !!getSessionReplayBucket(region);
 }
 
 /**
- * Lists every object key under `storagePrefix` in the session-replay bucket.
- * Returns the raw S3 keys (in S3 ordering, which is lexicographic — callers
- * that need numeric chunk-index ordering should sort after parsing).
+ * Lists every object key under `storagePrefix` in the session-replay bucket
+ * for the given region. Returns the raw S3 keys (in S3 ordering, which is
+ * lexicographic — callers that need numeric chunk-index ordering should sort
+ * after parsing).
  */
 export async function listSessionReplayChunks(
   storagePrefix: string,
+  region: SessionReplayRegion,
 ): Promise<string[]> {
-  if (!isSessionReplayStorageConfigured()) {
+  if (!isSessionReplayStorageConfigured(region)) {
     throw new Error(
-      "Session-replay storage is not configured (set S3_SESSION_REPLAY_BUCKET)",
+      "Session-replay storage is not configured (set S3_SESSION_REPLAY_BUCKET / S3_SESSION_REPLAY_BUCKET_EU)",
     );
   }
   return s3ListByPrefix(
-    getSessionReplayS3Client(),
-    S3_SESSION_REPLAY_BUCKET,
+    getSessionReplayS3Client(region),
+    getSessionReplayBucket(region),
     storagePrefix,
   );
 }
@@ -508,15 +526,16 @@ export async function listSessionReplayChunks(
  */
 export async function getSessionReplayObjectBuffer(
   key: string,
+  region: SessionReplayRegion,
 ): Promise<Buffer> {
-  if (!isSessionReplayStorageConfigured()) {
+  if (!isSessionReplayStorageConfigured(region)) {
     throw new Error(
-      "Session-replay storage is not configured (set S3_SESSION_REPLAY_BUCKET)",
+      "Session-replay storage is not configured (set S3_SESSION_REPLAY_BUCKET / S3_SESSION_REPLAY_BUCKET_EU)",
     );
   }
   return s3GetObjectBuffer(
-    getSessionReplayS3Client(),
-    S3_SESSION_REPLAY_BUCKET,
+    getSessionReplayS3Client(region),
+    getSessionReplayBucket(region),
     key,
   );
 }

--- a/packages/back-end/src/services/session-replay.ts
+++ b/packages/back-end/src/services/session-replay.ts
@@ -1,17 +1,23 @@
 import { promisify } from "util";
 import zlib from "zlib";
-import { getSessionReplayObjectBuffer, listSessionReplayChunks } from "./files";
+import {
+  getSessionReplayObjectBuffer,
+  listSessionReplayChunks,
+  SessionReplayRegion,
+} from "./files";
 
 const gunzip = promisify(zlib.gunzip);
 
 export async function getSessionReplayEventsByStoragePrefix(
   storagePrefix: string,
+  region: SessionReplayRegion,
 ): Promise<unknown[]> {
-  // Routed through the session-replay bucket (S3_SESSION_REPLAY_BUCKET) using
-  // the session-replay S3 client/role, not the general uploads bucket. The
-  // back-end proxies these bytes to the browser so replay payloads stay
-  // entirely behind authenticated REST endpoints.
-  const chunkKeys = await listSessionReplayChunks(storagePrefix);
+  // Routed through the session-replay bucket (S3_SESSION_REPLAY_BUCKET /
+  // S3_SESSION_REPLAY_BUCKET_EU) using the session-replay S3 client/role, not
+  // the general uploads bucket. The back-end proxies these bytes to the
+  // browser so replay payloads stay entirely behind authenticated REST
+  // endpoints.
+  const chunkKeys = await listSessionReplayChunks(storagePrefix, region);
   const sortedChunkKeys = sortReplayChunkKeysByChunkIndex(chunkKeys);
 
   if (!sortedChunkKeys.length) {
@@ -20,7 +26,7 @@ export async function getSessionReplayEventsByStoragePrefix(
 
   const eventsByChunk = await Promise.all(
     sortedChunkKeys.map(async (chunkKey) => {
-      const gzippedChunk = await getSessionReplayObjectBuffer(chunkKey);
+      const gzippedChunk = await getSessionReplayObjectBuffer(chunkKey, region);
       const decompressed = await gunzip(gzippedChunk);
       return JSON.parse(decompressed.toString("utf-8"));
     }),

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -159,6 +159,10 @@ export const AWS_ASSUME_ROLE = process.env.AWS_ASSUME_ROLE || "";
 // empty to disable signed-URL session-replay reads.
 export const S3_SESSION_REPLAY_BUCKET =
   process.env.S3_SESSION_REPLAY_BUCKET || "";
+// Bucket for orgs whose managed warehouse (and therefore session-replay data)
+// is provisioned in eu-west-1. Same read role as the default bucket.
+export const S3_SESSION_REPLAY_BUCKET_EU =
+  process.env.S3_SESSION_REPLAY_BUCKET_EU || "";
 // Optional override for the role used to read the session-replay bucket. Falls
 // back to AWS_ASSUME_ROLE when unset, so single-role setups need no extra env.
 export const S3_SESSION_REPLAY_ASSUME_ROLE =

--- a/packages/back-end/test/models/SessionReplayModel.test.ts
+++ b/packages/back-end/test/models/SessionReplayModel.test.ts
@@ -7,6 +7,7 @@ import {
   SessionReplayRow,
 } from "back-end/src/services/clickhouse";
 import { getSessionReplayEventsByStoragePrefix } from "back-end/src/services/session-replay";
+import { getGrowthbookDatasource } from "back-end/src/models/DataSourceModel";
 import { logger } from "back-end/src/util/logger";
 
 jest.mock("back-end/src/services/clickhouse", () => ({
@@ -27,6 +28,10 @@ jest.mock("back-end/src/models/SdkConnectionModel", () => ({
     .mockResolvedValue([{ key: "ck_test", projects: [] }]),
 }));
 
+jest.mock("back-end/src/models/DataSourceModel", () => ({
+  getGrowthbookDatasource: jest.fn().mockResolvedValue(null),
+}));
+
 jest.mock("back-end/src/util/logger", () => ({
   logger: {
     warn: jest.fn(),
@@ -41,6 +46,7 @@ const mockGetSessionReplayChunksBySessionId = jest.mocked(
   getSessionReplayChunksBySessionId,
 );
 const mockGetEvents = jest.mocked(getSessionReplayEventsByStoragePrefix);
+const mockGetGrowthbookDatasource = jest.mocked(getGrowthbookDatasource);
 const mockLoggerWarn = jest.mocked(logger.warn);
 
 // ---------------------------------------------------------------------------
@@ -496,9 +502,10 @@ describe("SessionReplayModel — getBySessionId()", () => {
 describe("SessionReplayModel — getEventsForS3Key()", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetGrowthbookDatasource.mockResolvedValue(null);
   });
 
-  it("strips the chunk filename and passes the directory prefix to the service", async () => {
+  it("strips the chunk filename and passes the directory prefix and region to the service", async () => {
     const events = [
       { type: 2, timestamp: 1000, data: {} },
       { type: 3, timestamp: 2000, data: {} },
@@ -513,6 +520,7 @@ describe("SessionReplayModel — getEventsForS3Key()", () => {
     expect(result).toEqual(events);
     expect(mockGetEvents).toHaveBeenCalledWith(
       "session-replays/org_1/2026/04/29/sess_abc123/",
+      "us-east-1",
     );
   });
 
@@ -525,5 +533,38 @@ describe("SessionReplayModel — getEventsForS3Key()", () => {
     );
 
     expect(result).toEqual([]);
+  });
+
+  it("uses eu-west-1 when the org's managed warehouse is provisioned there", async () => {
+    mockGetGrowthbookDatasource.mockResolvedValue({
+      type: "growthbook_clickhouse",
+      settings: { region: "eu-west-1" },
+    } as never);
+    mockGetEvents.mockResolvedValue([]);
+
+    const model = new SessionReplayModel(makeContext());
+    await model.getEventsForS3Key(
+      "session-replays/org_1/2026/04/29/sess_abc123/0.json.gz",
+    );
+
+    expect(mockGetEvents).toHaveBeenCalledWith(
+      "session-replays/org_1/2026/04/29/sess_abc123/",
+      "eu-west-1",
+    );
+  });
+
+  it("defaults to us-east-1 when no managed warehouse datasource exists", async () => {
+    mockGetGrowthbookDatasource.mockResolvedValue(null);
+    mockGetEvents.mockResolvedValue([]);
+
+    const model = new SessionReplayModel(makeContext());
+    await model.getEventsForS3Key(
+      "session-replays/org_1/2026/04/29/sess_abc123/0.json.gz",
+    );
+
+    expect(mockGetEvents).toHaveBeenCalledWith(
+      "session-replays/org_1/2026/04/29/sess_abc123/",
+      "us-east-1",
+    );
   });
 });

--- a/packages/back-end/test/services/session-replay.test.ts
+++ b/packages/back-end/test/services/session-replay.test.ts
@@ -117,7 +117,10 @@ describe("sortReplayChunkKeysByChunkIndex", () => {
 describe("getSessionReplayEventsByStoragePrefix", () => {
   it("returns an empty array when there are no chunks", async () => {
     mockListChunks.mockResolvedValue([]);
-    const result = await getSessionReplayEventsByStoragePrefix("org/session");
+    const result = await getSessionReplayEventsByStoragePrefix(
+      "org/session",
+      "us-east-1",
+    );
     expect(result).toEqual([]);
     expect(mockGetBuffer).not.toHaveBeenCalled();
   });
@@ -130,7 +133,10 @@ describe("getSessionReplayEventsByStoragePrefix", () => {
     mockListChunks.mockResolvedValue(["org/session/0.json.gz"]);
     mockGetBuffer.mockResolvedValue(gzip(events));
 
-    const result = await getSessionReplayEventsByStoragePrefix("org/session");
+    const result = await getSessionReplayEventsByStoragePrefix(
+      "org/session",
+      "us-east-1",
+    );
     expect(result).toEqual(events);
   });
 
@@ -146,7 +152,10 @@ describe("getSessionReplayEventsByStoragePrefix", () => {
       .mockResolvedValueOnce(gzip(chunk0))
       .mockResolvedValueOnce(gzip(chunk1));
 
-    const result = await getSessionReplayEventsByStoragePrefix("org/session");
+    const result = await getSessionReplayEventsByStoragePrefix(
+      "org/session",
+      "us-east-1",
+    );
     expect(result).toEqual([...chunk0, ...chunk1]);
   });
 
@@ -167,7 +176,10 @@ describe("getSessionReplayEventsByStoragePrefix", () => {
       throw new Error(`unexpected key: ${key}`);
     });
 
-    const result = await getSessionReplayEventsByStoragePrefix("org/session");
+    const result = await getSessionReplayEventsByStoragePrefix(
+      "org/session",
+      "us-east-1",
+    );
     // chunk0 events must precede chunk2 events
     expect(result).toEqual([...chunk0, ...chunk2]);
   });
@@ -187,7 +199,10 @@ describe("getSessionReplayEventsByStoragePrefix", () => {
       .mockResolvedValueOnce(gzip(chunk0))
       .mockResolvedValueOnce(gzip(chunk1));
 
-    const result = await getSessionReplayEventsByStoragePrefix("org/session");
+    const result = await getSessionReplayEventsByStoragePrefix(
+      "org/session",
+      "us-east-1",
+    );
     expect(Array.isArray(result)).toBe(true);
     expect(result).toHaveLength(chunk0.length + chunk1.length);
   });
@@ -197,7 +212,7 @@ describe("getSessionReplayEventsByStoragePrefix", () => {
     mockGetBuffer.mockResolvedValue(Buffer.from("not-gzip-data"));
 
     await expect(
-      getSessionReplayEventsByStoragePrefix("org/session"),
+      getSessionReplayEventsByStoragePrefix("org/session", "us-east-1"),
     ).rejects.toThrow();
   });
 });

--- a/packages/front-end/components/InitialSetup/ManagedWarehouseModal.tsx
+++ b/packages/front-end/components/InitialSetup/ManagedWarehouseModal.tsx
@@ -17,6 +17,11 @@ import Modal from "@/components/Modal";
 import Badge from "@/ui/Badge";
 import SelectField from "@/components/Forms/SelectField";
 import Checkbox from "@/ui/Checkbox";
+import {
+  DATA_REGION_OPTIONS,
+  DEFAULT_DATA_REGION,
+  DataRegion,
+} from "@/services/dataRegions";
 
 export default function ManagedWarehouseModal({
   close,
@@ -31,7 +36,7 @@ export default function ManagedWarehouseModal({
 
   const [agree, setAgree] = useState(false);
   const [upgradeOpen, setUpgradeOpen] = useState(false);
-  const [region, setRegion] = useState<"us-east-1" | "eu-west-1">("us-east-1");
+  const [region, setRegion] = useState<DataRegion>(DEFAULT_DATA_REGION);
 
   const settings = useOrgSettings();
   const { metricDefaults } = useOrganizationMetricDefaults();
@@ -148,13 +153,10 @@ export default function ManagedWarehouseModal({
 
       <SelectField
         size="legacy"
-        label="Data Region"
+        label="Data region"
         value={region}
-        onChange={(value) => setRegion(value as "us-east-1" | "eu-west-1")}
-        options={[
-          { label: "AWS us-east-1", value: "us-east-1" },
-          { label: "AWS eu-west-1", value: "eu-west-1" },
-        ]}
+        onChange={(value) => setRegion(value as DataRegion)}
+        options={DATA_REGION_OPTIONS}
         helpText="Where your event data will be ingested and stored. This cannot be changed later."
       />
 

--- a/packages/front-end/components/InitialSetup/ManagedWarehouseModal.tsx
+++ b/packages/front-end/components/InitialSetup/ManagedWarehouseModal.tsx
@@ -31,6 +31,7 @@ export default function ManagedWarehouseModal({
 
   const [agree, setAgree] = useState(false);
   const [upgradeOpen, setUpgradeOpen] = useState(false);
+  const [region, setRegion] = useState<"us-east-1" | "eu-west-1">("us-east-1");
 
   const settings = useOrgSettings();
   const { metricDefaults } = useOrganizationMetricDefaults();
@@ -112,6 +113,7 @@ export default function ManagedWarehouseModal({
           datasource: DataSourceInterfaceWithParams;
         }>("/datasources/managed-warehouse", {
           method: "POST",
+          body: JSON.stringify({ region }),
         });
 
         if (res.id) {
@@ -147,11 +149,13 @@ export default function ManagedWarehouseModal({
       <SelectField
         size="legacy"
         label="Data Region"
-        value="us-east-1"
-        onChange={() => {}}
-        options={[{ label: "AWS us-east-1", value: "us-east-1" }]}
-        disabled
-        helpText="This is the only region available for now."
+        value={region}
+        onChange={(value) => setRegion(value as "us-east-1" | "eu-west-1")}
+        options={[
+          { label: "AWS us-east-1", value: "us-east-1" },
+          { label: "AWS eu-west-1", value: "eu-west-1" },
+        ]}
+        helpText="Where your event data will be ingested and stored. This cannot be changed later."
       />
 
       <div className="mb-3">

--- a/packages/front-end/components/InitialSetup/ManagedWarehouseModal.tsx
+++ b/packages/front-end/components/InitialSetup/ManagedWarehouseModal.tsx
@@ -18,9 +18,9 @@ import Badge from "@/ui/Badge";
 import SelectField from "@/components/Forms/SelectField";
 import Checkbox from "@/ui/Checkbox";
 import {
-  DATA_REGION_OPTIONS,
   DEFAULT_DATA_REGION,
   DataRegion,
+  useDataRegionOptions,
 } from "@/services/dataRegions";
 
 export default function ManagedWarehouseModal({
@@ -37,6 +37,7 @@ export default function ManagedWarehouseModal({
   const [agree, setAgree] = useState(false);
   const [upgradeOpen, setUpgradeOpen] = useState(false);
   const [region, setRegion] = useState<DataRegion>(DEFAULT_DATA_REGION);
+  const dataRegionOptions = useDataRegionOptions();
 
   const settings = useOrgSettings();
   const { metricDefaults } = useOrganizationMetricDefaults();
@@ -156,7 +157,7 @@ export default function ManagedWarehouseModal({
         label="Data region"
         value={region}
         onChange={(value) => setRegion(value as DataRegion)}
-        options={DATA_REGION_OPTIONS}
+        options={dataRegionOptions}
         helpText="Where your event data will be ingested and stored. This cannot be changed later."
       />
 

--- a/packages/front-end/components/Settings/BigQueryEventForwarderForm.tsx
+++ b/packages/front-end/components/Settings/BigQueryEventForwarderForm.tsx
@@ -23,7 +23,7 @@ const BigQueryEventForwarderForm: FC<{
     patch: Partial<typeof bigQueryEventForwarderConfig.config>,
   ) => {
     setEventForwarderConfig({
-      sinkType: "bigquery",
+      ...bigQueryEventForwarderConfig,
       config: {
         ...bigQueryEventForwarderConfig.config,
         ...patch,

--- a/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
@@ -42,6 +42,12 @@ import {
   PROVISIONING_TIMEOUT_MESSAGE,
   useEventForwarderProvisioningPoll,
 } from "@/components/Settings/EditDataSource/EventForwarder/useEventForwarderProvisioningPoll";
+import {
+  DATA_REGION_OPTIONS,
+  DEFAULT_DATA_REGION,
+  DataRegion,
+  getDataRegionLabel,
+} from "@/services/dataRegions";
 
 type Props = {
   dataSource: DataSourceInterfaceWithParams;
@@ -444,20 +450,17 @@ function EventForwarderModal({
             {eventForwarderConfig ? (
               <SelectField
                 size="small"
-                label="Data Region"
-                value={eventForwarderConfig.region ?? "us-east-1"}
+                label="Data region"
+                value={eventForwarderConfig.region ?? DEFAULT_DATA_REGION}
                 onChange={(value) => {
                   setEventForwarderConfig({
                     ...eventForwarderConfig,
-                    region: value as "us-east-1" | "eu-west-1",
+                    region: value as DataRegion,
                   });
                   setUsEventForwarderFlowConsent(false);
                 }}
                 disabled={isEditingEventForwarder}
-                options={[
-                  { label: "AWS us-east-1", value: "us-east-1" },
-                  { label: "AWS eu-west-1", value: "eu-west-1" },
-                ]}
+                options={DATA_REGION_OPTIONS}
                 helpText="Where the forwarder's Kafka/Confluent resources are provisioned. This cannot be changed later."
               />
             ) : null}
@@ -466,9 +469,9 @@ function EventForwarderModal({
                 value={usEventForwarderFlowConsent}
                 setValue={setUsEventForwarderFlowConsent}
                 disabled={isEditingEventForwarder}
-                label={`I understand that event data will flow through GrowthBook's servers in ${
-                  eventForwarderConfig?.region ?? "us-east-1"
-                } and confirm I'm authorized to enable this for my organization.`}
+                label={`I understand that event data will flow through GrowthBook's servers in ${getDataRegionLabel(
+                  eventForwarderConfig?.region ?? DEFAULT_DATA_REGION,
+                )} and confirm I'm authorized to enable this for my organization.`}
                 weight="regular"
               />
             </Callout>

--- a/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
@@ -22,6 +22,7 @@ import { PiCaretRight, PiPause, PiPencilSimple, PiPlay } from "react-icons/pi";
 import { useAuth } from "@/services/auth";
 import { useUser } from "@/services/UserContext";
 import PremiumCallout from "@/ui/PremiumCallout";
+import SelectField from "@/components/Forms/SelectField";
 import BigQueryEventForwarderForm from "@/components/Settings/BigQueryEventForwarderForm";
 import SnowflakeEventForwarderForm from "@/components/Settings/SnowflakeEventForwarderForm";
 import { useEventForwarderAccessTest } from "@/components/Settings/useEventForwarderAccessTest";
@@ -120,6 +121,7 @@ function getEventForwarderDraft(
   if (existing?.sinkType === "bigquery") {
     return {
       sinkType: "bigquery",
+      region: existing.region,
       config: {
         projectId: existing.config.projectId,
         dataset: existing.config.dataset,
@@ -131,6 +133,7 @@ function getEventForwarderDraft(
   if (existing?.sinkType === "snowflake") {
     return {
       sinkType: "snowflake",
+      region: existing.region,
       config: {
         database: existing.config.database,
         schema: existing.config.schema,
@@ -150,6 +153,7 @@ function getEventForwarderDraft(
 
     return {
       sinkType: "bigquery",
+      region: "us-east-1",
       config: {
         projectId: params.defaultProject || params.projectId || "",
         dataset: params.defaultDataset || "",
@@ -162,6 +166,7 @@ function getEventForwarderDraft(
     const params = dataSource.params as SnowflakeConnectionParams;
     return {
       sinkType: "snowflake",
+      region: "us-east-1",
       config: {
         database: params.database || "",
         schema: params.schema || "",
@@ -436,12 +441,33 @@ function EventForwarderModal({
                 setEventForwarderConfig={setEventForwarderConfig}
               />
             ) : null}
+            {eventForwarderConfig ? (
+              <SelectField
+                size="small"
+                label="Data Region"
+                value={eventForwarderConfig.region ?? "us-east-1"}
+                onChange={(value) =>
+                  setEventForwarderConfig({
+                    ...eventForwarderConfig,
+                    region: value as "us-east-1" | "eu-west-1",
+                  })
+                }
+                disabled={isEditingEventForwarder}
+                options={[
+                  { label: "AWS us-east-1", value: "us-east-1" },
+                  { label: "AWS eu-west-1", value: "eu-west-1" },
+                ]}
+                helpText="Where the forwarder's Kafka/Confluent resources are provisioned. This cannot be changed later."
+              />
+            ) : null}
             <Callout status="info" mb="0" mt="3" icon={null}>
               <Checkbox
                 value={usEventForwarderFlowConsent}
                 setValue={setUsEventForwarderFlowConsent}
                 disabled={isEditingEventForwarder}
-                label="I understand that event data will flow through GrowthBook's US servers and confirm I'm authorized to enable this for my organization."
+                label={`I understand that event data will flow through GrowthBook's servers in ${
+                  eventForwarderConfig?.region ?? "us-east-1"
+                } and confirm I'm authorized to enable this for my organization.`}
                 weight="regular"
               />
             </Callout>

--- a/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
@@ -450,6 +450,7 @@ function EventForwarderModal({
             {eventForwarderConfig ? (
               <SelectField
                 size="small"
+                legacyLabelFormatting={false}
                 label="Data region"
                 value={eventForwarderConfig.region ?? DEFAULT_DATA_REGION}
                 onChange={(value) => {

--- a/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
@@ -446,12 +446,13 @@ function EventForwarderModal({
                 size="small"
                 label="Data Region"
                 value={eventForwarderConfig.region ?? "us-east-1"}
-                onChange={(value) =>
+                onChange={(value) => {
                   setEventForwarderConfig({
                     ...eventForwarderConfig,
                     region: value as "us-east-1" | "eu-west-1",
-                  })
-                }
+                  });
+                  setUsEventForwarderFlowConsent(false);
+                }}
                 disabled={isEditingEventForwarder}
                 options={[
                   { label: "AWS us-east-1", value: "us-east-1" },

--- a/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
@@ -43,10 +43,10 @@ import {
   useEventForwarderProvisioningPoll,
 } from "@/components/Settings/EditDataSource/EventForwarder/useEventForwarderProvisioningPoll";
 import {
-  DATA_REGION_OPTIONS,
   DEFAULT_DATA_REGION,
   DataRegion,
   getDataRegionLabel,
+  useDataRegionOptions,
 } from "@/services/dataRegions";
 
 type Props = {
@@ -334,6 +334,7 @@ function EventForwarderModal({
   const { apiCall } = useAuth();
   const isSubmittingRef = useRef(false);
   const [showCloseConfirm, setShowCloseConfirm] = useState(false);
+  const dataRegionOptions = useDataRegionOptions();
   const [datasourceDraft, setDatasourceDraft] =
     useState<EventForwarderDatasourceDraft>(() => ({
       type: dataSource.type as "bigquery" | "snowflake",
@@ -461,7 +462,7 @@ function EventForwarderModal({
                   setUsEventForwarderFlowConsent(false);
                 }}
                 disabled={isEditingEventForwarder}
-                options={DATA_REGION_OPTIONS}
+                options={dataRegionOptions}
                 helpText="Where the forwarder's Kafka/Confluent resources are provisioned. This cannot be changed later."
               />
             ) : null}

--- a/packages/front-end/components/Settings/SnowflakeEventForwarderForm.tsx
+++ b/packages/front-end/components/Settings/SnowflakeEventForwarderForm.tsx
@@ -21,7 +21,7 @@ const SnowflakeEventForwarderForm: FC<{
     patch: Partial<typeof snowflakeEventForwarderConfig.config>,
   ) => {
     setEventForwarderConfig({
-      sinkType: "snowflake",
+      ...snowflakeEventForwarderConfig,
       config: {
         ...snowflakeEventForwarderConfig.config,
         ...patch,

--- a/packages/front-end/pages/admin.tsx
+++ b/packages/front-end/pages/admin.tsx
@@ -175,10 +175,12 @@ function OrganizationRow({
           <Box mt="3">
             <SelectField
               size="small"
+              legacyLabelFormatting={false}
               label="Data region"
               value={clickhouseRegion}
               onChange={(value) => setClickhouseRegion(value as DataRegion)}
               options={DATA_REGION_OPTIONS}
+              helpText="Where this org's event data is stored. This cannot be changed later."
             />
           </Box>
         </Modal>

--- a/packages/front-end/pages/admin.tsx
+++ b/packages/front-end/pages/admin.tsx
@@ -42,9 +42,9 @@ import StringArrayField from "@/ui/StringArrayField";
 import Checkbox from "@/ui/Checkbox";
 import Callout from "@/ui/Callout";
 import {
-  DATA_REGION_OPTIONS,
   DEFAULT_DATA_REGION,
   DataRegion,
+  useDataRegionOptions,
 } from "@/services/dataRegions";
 
 interface memberOrgProps {
@@ -87,6 +87,7 @@ function OrganizationRow({
   const [clickhouseModalOpen, setClickhouseModalOpen] = useState(false);
   const [clickhouseRegion, setClickhouseRegion] =
     useState<DataRegion>(DEFAULT_DATA_REGION);
+  const dataRegionOptions = useDataRegionOptions();
   const [managedWarehouseId, setManagedWarehouseId] = useState(
     datasources.find((ds) => ds.type === "growthbook_clickhouse")?.id || null,
   );
@@ -179,7 +180,7 @@ function OrganizationRow({
               label="Data region"
               value={clickhouseRegion}
               onChange={(value) => setClickhouseRegion(value as DataRegion)}
-              options={DATA_REGION_OPTIONS}
+              options={dataRegionOptions}
               helpText="Where this org's event data is stored. This cannot be changed later."
             />
           </Box>

--- a/packages/front-end/pages/admin.tsx
+++ b/packages/front-end/pages/admin.tsx
@@ -80,6 +80,9 @@ function OrganizationRow({
   const [licenseLoading, setLicenseLoading] = useState(false);
   const { apiCall } = useAuth();
   const [clickhouseModalOpen, setClickhouseModalOpen] = useState(false);
+  const [clickhouseRegion, setClickhouseRegion] = useState<
+    "us-east-1" | "eu-west-1"
+  >("us-east-1");
   const [managedWarehouseId, setManagedWarehouseId] = useState(
     datasources.find((ds) => ds.type === "growthbook_clickhouse")?.id || null,
   );
@@ -135,6 +138,7 @@ function OrganizationRow({
       {
         method: "POST",
         headers: { "X-Organization": organization.id },
+        body: JSON.stringify({ region: clickhouseRegion }),
       },
     );
     setClickhouseModalOpen(false);
@@ -164,6 +168,18 @@ function OrganizationRow({
         >
           Are you sure you want to create a Managed Warehouse data source for
           this organization?
+          <SelectField
+            size="small"
+            label="Data Region"
+            value={clickhouseRegion}
+            onChange={(value) =>
+              setClickhouseRegion(value as "us-east-1" | "eu-west-1")
+            }
+            options={[
+              { label: "AWS us-east-1", value: "us-east-1" },
+              { label: "AWS eu-west-1", value: "eu-west-1" },
+            ]}
+          />
         </Modal>
       )}
       {editSSOOpen && (

--- a/packages/front-end/pages/admin.tsx
+++ b/packages/front-end/pages/admin.tsx
@@ -41,6 +41,11 @@ import SelectField from "@/components/Forms/SelectField";
 import StringArrayField from "@/ui/StringArrayField";
 import Checkbox from "@/ui/Checkbox";
 import Callout from "@/ui/Callout";
+import {
+  DATA_REGION_OPTIONS,
+  DEFAULT_DATA_REGION,
+  DataRegion,
+} from "@/services/dataRegions";
 
 interface memberOrgProps {
   id: string;
@@ -80,9 +85,8 @@ function OrganizationRow({
   const [licenseLoading, setLicenseLoading] = useState(false);
   const { apiCall } = useAuth();
   const [clickhouseModalOpen, setClickhouseModalOpen] = useState(false);
-  const [clickhouseRegion, setClickhouseRegion] = useState<
-    "us-east-1" | "eu-west-1"
-  >("us-east-1");
+  const [clickhouseRegion, setClickhouseRegion] =
+    useState<DataRegion>(DEFAULT_DATA_REGION);
   const [managedWarehouseId, setManagedWarehouseId] = useState(
     datasources.find((ds) => ds.type === "growthbook_clickhouse")?.id || null,
   );
@@ -168,18 +172,15 @@ function OrganizationRow({
         >
           Are you sure you want to create a Managed Warehouse data source for
           this organization?
-          <SelectField
-            size="small"
-            label="Data Region"
-            value={clickhouseRegion}
-            onChange={(value) =>
-              setClickhouseRegion(value as "us-east-1" | "eu-west-1")
-            }
-            options={[
-              { label: "AWS us-east-1", value: "us-east-1" },
-              { label: "AWS eu-west-1", value: "eu-west-1" },
-            ]}
-          />
+          <Box mt="3">
+            <SelectField
+              size="small"
+              label="Data region"
+              value={clickhouseRegion}
+              onChange={(value) => setClickhouseRegion(value as DataRegion)}
+              options={DATA_REGION_OPTIONS}
+            />
+          </Box>
         </Modal>
       )}
       {editSSOOpen && (

--- a/packages/front-end/services/dataRegions.ts
+++ b/packages/front-end/services/dataRegions.ts
@@ -1,3 +1,5 @@
+import { useFeatureIsOn } from "@growthbook/growthbook-react";
+
 export type DataRegion = "us-east-1" | "eu-west-1";
 
 export const DATA_REGION_OPTIONS: { label: string; value: DataRegion }[] = [
@@ -6,6 +8,14 @@ export const DATA_REGION_OPTIONS: { label: string; value: DataRegion }[] = [
 ];
 
 export const DEFAULT_DATA_REGION: DataRegion = "us-east-1";
+
+// The eu-west-1 option is gated behind the "eu-data-region" flag during rollout.
+export function useDataRegionOptions(): { label: string; value: DataRegion }[] {
+  const euRegionEnabled = useFeatureIsOn("eu-data-region");
+  return euRegionEnabled
+    ? DATA_REGION_OPTIONS
+    : DATA_REGION_OPTIONS.filter((o) => o.value !== "eu-west-1");
+}
 
 export function getDataRegionLabel(region: DataRegion): string {
   return DATA_REGION_OPTIONS.find((o) => o.value === region)?.label ?? region;

--- a/packages/front-end/services/dataRegions.ts
+++ b/packages/front-end/services/dataRegions.ts
@@ -1,0 +1,12 @@
+export type DataRegion = "us-east-1" | "eu-west-1";
+
+export const DATA_REGION_OPTIONS: { label: string; value: DataRegion }[] = [
+  { label: "AWS us-east-1", value: "us-east-1" },
+  { label: "AWS eu-west-1", value: "eu-west-1" },
+];
+
+export const DEFAULT_DATA_REGION: DataRegion = "us-east-1";
+
+export function getDataRegionLabel(region: DataRegion): string {
+  return DATA_REGION_OPTIONS.find((o) => o.value === region)?.label ?? region;
+}

--- a/packages/shared/src/validators/event-forwarder-access-test.ts
+++ b/packages/shared/src/validators/event-forwarder-access-test.ts
@@ -2,8 +2,11 @@ import { z } from "zod";
 
 const datasourceParamsSchema = z.record(z.string(), z.unknown());
 
+const eventForwarderRegionSchema = z.enum(["us-east-1", "eu-west-1"]);
+
 const bigQueryEventForwarderConfigSchema = z.object({
   sinkType: z.literal("bigquery"),
+  region: eventForwarderRegionSchema.optional(),
   config: z.object({
     projectId: z.string(),
     dataset: z.string(),
@@ -14,6 +17,7 @@ const bigQueryEventForwarderConfigSchema = z.object({
 
 const snowflakeEventForwarderConfigSchema = z.object({
   sinkType: z.literal("snowflake"),
+  region: eventForwarderRegionSchema.optional(),
   config: z.object({
     database: z.string(),
     schema: z.string(),

--- a/packages/shared/src/validators/event-forwarder-config.ts
+++ b/packages/shared/src/validators/event-forwarder-config.ts
@@ -19,6 +19,8 @@ export const eventForwarderConfigValidator = baseSchema
     topic: z.string(),
     schemaId: z.number(), // The confluent schema registry schema id
     sinkType: eventForwarderSinkTypeValidator,
+    /** AWS region hosting this forwarder's Kafka/Confluent resources. Set once at creation; absent means `us-east-1`. */
+    region: z.enum(["us-east-1", "eu-west-1"]).optional(),
     config: z.string(), // Encrypted sink-specific configuration
     status: eventForwarderStatusValidator,
     /** Confluent connector name — set after successful provisioning; teardown uses this only (not env-derived). */

--- a/packages/shared/types/app-features.ts
+++ b/packages/shared/types/app-features.ts
@@ -141,4 +141,5 @@ export type AppFeatures = {
   "playstation-new-internal-dashboard": boolean;
   tester123: boolean;
   "pricing-phase-1-limits": Record<string, unknown>;
+  "eu-data-region": boolean;
 };

--- a/packages/shared/types/datasource.d.ts
+++ b/packages/shared/types/datasource.d.ts
@@ -319,6 +319,8 @@ export interface GrowthbookClickhouseSettings extends DataSourceSettings {
   /** When false, the warehouse exists in GrowthBook but ClickHouse was not provisioned yet. */
   hasBeenProvisioned?: boolean;
   sessionReplayProvisioned?: boolean;
+  /** AWS region the managed warehouse is provisioned in. Absent means `us-east-1` (pre-EU warehouses). */
+  region?: "us-east-1" | "eu-west-1";
   /** @deprecated Replaced by native JSON columns (`useJsonColumns`); kept for legacy warehouses. */
   materializedColumns?: MaterializedColumn[];
   /**

--- a/packages/shared/types/event-forwarder.d.ts
+++ b/packages/shared/types/event-forwarder.d.ts
@@ -61,10 +61,14 @@ export type EventForwarderConfigDraft =
   | {
       sinkType: "bigquery";
       config: BigQueryEventForwarderConfigDraft;
+      /** AWS region to provision the forwarder's Kafka/Confluent resources in. Set once at creation. */
+      region?: "us-east-1" | "eu-west-1";
     }
   | {
       sinkType: "snowflake";
       config: SnowflakeEventForwarderConfigDraft;
+      /** AWS region to provision the forwarder's Kafka/Confluent resources in. Set once at creation. */
+      region?: "us-east-1" | "eu-west-1";
     };
 
 export type EventForwarderConfigWithMetadata = EventForwarderConfigDraft & {


### PR DESCRIPTION
## Summary
- Adds a self-serve "Data Region" (`us-east-1` / `eu-west-1`) selector when creating a Managed Warehouse datasource (both the normal-user and admin flows) and when configuring an Event Forwarder — region is stored on the datasource/forwarder doc for central-license-server and the ingestor to route on downstream.
- Event Forwarder gets its own independent region field (rather than inheriting from a managed-warehouse datasource), since a forwarder doesn't require an org to have a managed warehouse at all.
- Updates the `managed-warehouse.mdx` and `event-forwarder.mdx` docs to cover both regional ingestion hostnames and note that the SDK tracking config must match the region chosen for the datasource/forwarder.

## Dependencies
License Server PR needs to land first to be able to create the DB in the eu.
https://github.com/growthbook/central-license-server/pull/169
Ingestor needs to land for the eu ingestor service to pick it up.
https://github.com/growthbook/growthbook-ingestor/pull/90

## Test plan
- [x] `pnpm --filter shared type-check`, `pnpm --filter back-end type-check`, `pnpm --filter front-end type-check` all pass
- [ ] Manually create a managed warehouse as a normal user and as super-admin (via `/admin`), confirming the chosen region round-trips into `settings.region`
- [ ] Manually create/edit an Event Forwarder, confirming region is stored and immutable after creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)