### PR TITLE
Add static dimension support to Group By editor in dashboard explorer

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2005,11 +2005,6 @@
       "count": 2
     }
   },
-  "packages/front-end/enterprise/components/ProductAnalytics/SideBar/GroupBySection.tsx": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
   "packages/front-end/enterprise/components/ProductAnalytics/SideBar/MetricTabContent.tsx": {
     "no-restricted-syntax": {
       "count": 1

--- a/packages/back-end/src/enterprise/services/product-analytics-agent.ts
+++ b/packages/back-end/src/enterprise/services/product-analytics-agent.ts
@@ -69,8 +69,9 @@ If the user asks for data that spans both a fact table and a metric (different e
 </chart_rules>
 
 <dimension_rules>
-Only use dimensionType 'dynamic'. Never use 'static' or 'slice'.
-'dynamic' shows the top N values for a column — set maxValues (1–20, default 5).
+Only use dimensionType 'dynamic' or 'static'. Never use 'slice'.
+'dynamic' shows the top N values for a column — set maxValues (1–20, default 5). Use this for an open-ended "break down by X" request.
+'static' pins a fixed list of column values (1–20, set via values) — rows whose column value isn't in the list are dropped (no top-N/'other' bucket). Use this when the user names specific values to compare (e.g. "compare US vs UK vs Canada"). Always call getColumnValues first to confirm the real values before setting them — never guess.
 Use dateGranularity 'auto' by default for date dimensions; only use a specific granularity (hour/day/week/month/year) when the user requests it.
 Maximum 2 total dimensions (including the date dimension for timeseries). If dataset has more than 1 value, max 1 dimension.
 bigNumber charts (only when explicitly requested): 0 dimensions and exactly 1 value.
@@ -225,6 +226,7 @@ function buildConfigSchemaSummary(): string {
     "dimensions: array of dimension objects:",
     "  date: { dimensionType: 'date', column: null, dateGranularity: 'auto'|'hour'|'day'|'week'|'month'|'year' }",
     "  dynamic: { dimensionType: 'dynamic', column: string, maxValues: number (1-20) }",
+    "  static: { dimensionType: 'static', column: string, values: string[] (1-20) }",
     'dataset for type="metric": { type: "metric", values: [{ type: "metric", name, metricId, unit, denominatorUnit, rowFilters }] }',
     'dataset for type="fact_table": { type: "fact_table", factTableId, values: [{ type: "fact_table", name, valueType: "unit_count"|"count"|"sum", valueColumn, unit, rowFilters }] }',
     'rowFilters: [{ operator: "="|"!="|"in"|"not_in"|"contains"|"not_contains"|"starts_with"|"ends_with"|"is_null"|"not_null", column: string, values: string[] }]',
@@ -670,29 +672,12 @@ async function normalizeConfigForExplorer(
   let dims = config.dimensions;
   let dataset = config.dataset;
 
-  // Convert static → dynamic; drop slice
-  const hadStatic = dims.some((d) => d.dimensionType === "static");
+  // Drop slice dimensions — the agent isn't equipped to author them.
   const hadSlice = dims.some((d) => d.dimensionType === "slice");
-  dims = dims
-    .map((d) => {
-      if (d.dimensionType === "static") {
-        return {
-          dimensionType: "dynamic" as const,
-          column: d.column,
-          maxValues: Math.min(d.values.length || 5, 20),
-        };
-      }
-      return d;
-    })
-    .filter((d) => d.dimensionType !== "slice");
-  if (hadStatic) {
-    warnings.push(
-      "Static dimensions are not supported — converted to dynamic. Only use dimensionType 'dynamic'.",
-    );
-  }
+  dims = dims.filter((d) => d.dimensionType !== "slice");
   if (hadSlice) {
     warnings.push(
-      "Slice dimensions are not supported and were removed. Only use dimensionType 'dynamic'.",
+      "Slice dimensions are not supported and were removed. Only use dimensionType 'dynamic' or 'static'.",
     );
   }
 

--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ExplorerSideBar.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ExplorerSideBar.tsx
@@ -163,6 +163,16 @@ export default function ExplorerSideBar({
     });
   };
 
+  const emptyStaticDimension = draftExploreState.dimensions.some(
+    (d) => d.dimensionType === "static" && d.values.length === 0,
+  );
+  const updateDisabledReason =
+    hasInputs && !isSubmittable
+      ? emptyStaticDimension
+        ? "Select at least one value for the pinned dimension before updating."
+        : "Configure a valid exploration before updating."
+      : undefined;
+
   const isTimeSeriesChart = ["line", "area", "timeseries-table"].includes(
     draftExploreState.chartType,
   );
@@ -256,8 +266,11 @@ export default function ExplorerSideBar({
           <Flex direction="row" align="center" justify="between" width="100%">
             <DataSourceDropdown />
             <Tooltip
-              body="Configuration has changed. Click to refresh the chart."
-              shouldDisplay={isStale}
+              body={
+                updateDisabledReason ||
+                "Configuration has changed. Click to refresh the chart."
+              }
+              shouldDisplay={!!updateDisabledReason || isStale}
             >
               <Button
                 size="md"

--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/GroupBySection.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/GroupBySection.tsx
@@ -384,6 +384,7 @@ export default function GroupBySection() {
                       }
                       options={BREAKDOWN_TYPE_OPTIONS}
                       sort={false}
+                      containerStyle={{ marginBottom: 0 }}
                     />
                   </Flex>
                 </Tooltip>
@@ -450,6 +451,7 @@ export default function GroupBySection() {
                         : undefined
                     }
                     errorLevel="warning"
+                    showCopyButton={false}
                   />
                 )}
               </Flex>

--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/GroupBySection.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/GroupBySection.tsx
@@ -2,17 +2,64 @@ import { Flex } from "@radix-ui/themes";
 import { PiCaretDown, PiCaretRight, PiPlus, PiX } from "react-icons/pi";
 import { useEffect, useMemo, useRef, useState } from "react";
 import Collapsible from "react-collapsible";
+import type {
+  ProductAnalyticsDimension,
+  ProductAnalyticsDynamicDimension,
+  ProductAnalyticsStaticDimension,
+} from "shared/validators";
 import Button from "@/ui/Button";
-import { getMaxDimensions } from "@/enterprise/components/ProductAnalytics/util";
+import {
+  getMaxDimensions,
+  getColumnTopValues,
+} from "@/enterprise/components/ProductAnalytics/util";
 import { useExplorerContext } from "@/enterprise/components/ProductAnalytics/ExplorerContext";
+import { useDefinitions } from "@/services/DefinitionsContext";
 import Text from "@/ui/Text";
 import Tooltip from "@/ui/Tooltip";
 import SelectField from "@/components/Forms/SelectField";
 import Field from "@/components/Forms/Field";
+import MultiSelectField from "@/ui/MultiSelectField";
+
+const DEFAULT_MAX_VALUES = 5;
+const MAX_PINNED_DIMENSION_VALUES = 20;
+
+type GroupByDimension =
+  | ProductAnalyticsDynamicDimension
+  | ProductAnalyticsStaticDimension;
+
+function isGroupByDimension(
+  dim: ProductAnalyticsDimension,
+): dim is GroupByDimension {
+  return dim.dimensionType === "dynamic" || dim.dimensionType === "static";
+}
+
+// Explicit choice, not inferred from pinned values — one input shows at a
+// time, and it scales to future dimension types.
+const BREAKDOWN_TYPE_OPTIONS: { label: string; value: "dynamic" | "static" }[] =
+  [
+    { label: "Top values", value: "dynamic" },
+    { label: "Pinned values", value: "static" },
+  ];
+
+// Shifts keys above `removedIndex` down by one and drops it, so index-keyed
+// maps stay aligned after a splice-out instead of losing other dimensions' state.
+function reindexAfterRemoval<T>(
+  record: Record<number, T>,
+  removedIndex: number,
+): Record<number, T> {
+  const next: Record<number, T> = {};
+  Object.entries(record).forEach(([key, value]) => {
+    const idx = Number(key);
+    if (idx === removedIndex) return;
+    next[idx > removedIndex ? idx - 1 : idx] = value;
+  });
+  return next;
+}
 
 export default function GroupBySection() {
   const { draftExploreState, setDraftExploreState, commonColumns } =
     useExplorerContext();
+  const { getFactTableById, getFactMetricById } = useDefinitions();
   const [advancedSettingsOpen, setAdvancedSettingsOpen] = useState(
     Array(draftExploreState.dimensions.length).fill(false),
   );
@@ -21,15 +68,38 @@ export default function GroupBySection() {
   >({});
   const latestMaxValuesRef = useRef<Record<number, string>>({});
   const skipBlurCommitRef = useRef(false);
+  // True when the last Values selection/paste exceeded the cap, so the
+  // field can surface that extras were dropped.
+  const [capExceeded, setCapExceeded] = useState<Record<number, boolean>>({});
 
-  const prevDimensionsLengthRef = useRef(draftExploreState.dimensions.length);
+  // Tracks the length these maps were last synced to; Add/Remove update it
+  // directly. A mismatch means something outside those handlers reshaped
+  // `dimensions` (e.g. changeChartType) — full reset only then.
+  const expectedDimensionsLengthRef = useRef(
+    draftExploreState.dimensions.length,
+  );
   useEffect(() => {
-    if (draftExploreState.dimensions.length < prevDimensionsLengthRef.current) {
+    if (
+      draftExploreState.dimensions.length !==
+      expectedDimensionsLengthRef.current
+    ) {
       setLocalMaxValues({});
       latestMaxValuesRef.current = {};
+      setCapExceeded({});
+      expectedDimensionsLengthRef.current = draftExploreState.dimensions.length;
     }
-    prevDimensionsLengthRef.current = draftExploreState.dimensions.length;
   }, [draftExploreState.dimensions.length]);
+
+  // handleAdd/RemoveDimension already keep this in sync for their own
+  // changes. A mismatch means something else reshaped `dimensions` (e.g.
+  // changeChartType) — resync then, not on every ordinary Add/Remove.
+  useEffect(() => {
+    if (advancedSettingsOpen.length !== draftExploreState.dimensions.length) {
+      setAdvancedSettingsOpen(
+        Array(draftExploreState.dimensions.length).fill(false),
+      );
+    }
+  }, [draftExploreState.dimensions.length, advancedSettingsOpen.length]);
 
   const availableColumns = useMemo(() => {
     // Filter out columns already used in dimensions
@@ -43,8 +113,7 @@ export default function GroupBySection() {
 
   const getColumnOptionsForDimension = (index: number) => {
     const dim = draftExploreState.dimensions[index];
-    if (!dim || dim.dimensionType !== "dynamic" || !("column" in dim))
-      return [];
+    if (!dim || !isGroupByDimension(dim)) return [];
     const usedByOthers = new Set(
       draftExploreState.dimensions
         .map((d, i) => (i !== index && "column" in d ? d.column : null))
@@ -57,6 +126,9 @@ export default function GroupBySection() {
 
   const handleAddDimension = () => {
     setAdvancedSettingsOpen((prev) => [...prev, false]); // New dimension defaults to collapsed
+    // Appending doesn't shift existing indices — just mark this length
+    // change as already accounted for.
+    expectedDimensionsLengthRef.current += 1;
     setDraftExploreState((prev) => ({
       ...prev,
       dimensions: [
@@ -64,31 +136,73 @@ export default function GroupBySection() {
         {
           dimensionType: "dynamic",
           column: null,
-          maxValues: 5,
+          maxValues: DEFAULT_MAX_VALUES,
         },
       ],
     }));
   };
 
-  const handleUpdateDimension = (
-    index: number,
-    dimension: { column: string | null; maxValues: number },
-  ) => {
-    setDraftExploreState((prev) => ({
-      ...prev,
-      dimensions: prev.dimensions.map((d, i) =>
-        i === index && d.dimensionType === "dynamic"
-          ? { ...d, ...dimension }
-          : d,
-      ),
-    }));
-  };
-
   const handleRemoveDimension = (index: number) => {
     setAdvancedSettingsOpen((prev) => prev.filter((_, i) => i !== index));
+    // Splicing shifts later indices down by one — reindex instead of
+    // resetting other dimensions' state.
+    expectedDimensionsLengthRef.current -= 1;
+    setLocalMaxValues((prev) => reindexAfterRemoval(prev, index));
+    latestMaxValuesRef.current = reindexAfterRemoval(
+      latestMaxValuesRef.current,
+      index,
+    );
+    setCapExceeded((prev) => reindexAfterRemoval(prev, index));
     setDraftExploreState((prev) => ({
       ...prev,
       dimensions: prev.dimensions.filter((_, i) => i !== index),
+    }));
+  };
+
+  // Keeps the breakdown type (a separate choice) but resets values/maxValues,
+  // since those were scoped to the previous column.
+  const handleColumnChange = (index: number, column: string) => {
+    setCapExceeded((prev) => ({ ...prev, [index]: false }));
+    setDraftExploreState((prev) => ({
+      ...prev,
+      dimensions: prev.dimensions.map((d, i) => {
+        if (i !== index || !isGroupByDimension(d)) return d;
+        if (d.dimensionType === "static") {
+          return { dimensionType: "static", column, values: [] };
+        }
+        return {
+          dimensionType: "dynamic",
+          column,
+          maxValues: DEFAULT_MAX_VALUES,
+        };
+      }),
+    }));
+  };
+
+  // Explicit choice via the selector below, not inferred from pinned values.
+  // Switching starts the new type fresh, like a column change.
+  const handleDimensionTypeChange = (
+    index: number,
+    dimensionType: GroupByDimension["dimensionType"],
+  ) => {
+    setCapExceeded((prev) => ({ ...prev, [index]: false }));
+    setDraftExploreState((prev) => ({
+      ...prev,
+      dimensions: prev.dimensions.map((d, i) => {
+        if (i !== index || !isGroupByDimension(d)) return d;
+        if (dimensionType === "static") {
+          return {
+            dimensionType: "static",
+            column: d.column ?? "",
+            values: [],
+          };
+        }
+        return {
+          dimensionType: "dynamic",
+          column: d.column,
+          maxValues: DEFAULT_MAX_VALUES,
+        };
+      }),
     }));
   };
 
@@ -109,7 +223,14 @@ export default function GroupBySection() {
 
     const dim = draftExploreState.dimensions[index];
     if (dim && dim.dimensionType === "dynamic") {
-      handleUpdateDimension(index, { column: dim.column, maxValues: parsed });
+      setDraftExploreState((prev) => ({
+        ...prev,
+        dimensions: prev.dimensions.map((d, i) =>
+          i === index && d.dimensionType === "dynamic"
+            ? { ...d, maxValues: parsed }
+            : d,
+        ),
+      }));
     }
     setLocalMaxValues((prev) => {
       const next = { ...prev };
@@ -117,6 +238,26 @@ export default function GroupBySection() {
       return next;
     });
     delete latestMaxValuesRef.current[index];
+  };
+
+  // Only edits the pinned list — switching type happens via the
+  // breakdown-type selector above, not by pinning/clearing values here.
+  const handleValuesChange = (index: number, values: string[]) => {
+    const capped = values.slice(0, MAX_PINNED_DIMENSION_VALUES);
+
+    setCapExceeded((prev) => ({
+      ...prev,
+      [index]: values.length > MAX_PINNED_DIMENSION_VALUES,
+    }));
+
+    setDraftExploreState((prev) => ({
+      ...prev,
+      dimensions: prev.dimensions.map((d, i) =>
+        i === index && d.dimensionType === "static"
+          ? { ...d, values: capped }
+          : d,
+      ),
+    }));
   };
 
   return (
@@ -155,8 +296,16 @@ export default function GroupBySection() {
       </Flex>
       {/* Display existing dimensions */}
       {draftExploreState.dimensions.map((dim, i) => {
-        if (dim.dimensionType === "date") return null; // Skip date dimension as it's usually handled separately or fixed
-        if (dim.dimensionType !== "dynamic") return null; // Skip static and slice dimensions for now
+        if (!isGroupByDimension(dim)) return null; // Skip date and slice dimensions for now
+        const isStatic = dim.dimensionType === "static";
+        const pinnedValues = isStatic ? dim.values : [];
+        const valueOptions = getColumnTopValues(
+          draftExploreState.dataset,
+          dim.column,
+          getFactTableById,
+          getFactMetricById,
+        ).map((v) => ({ label: v, value: v }));
+
         return (
           <Flex
             key={i}
@@ -171,15 +320,10 @@ export default function GroupBySection() {
           >
             <Flex direction="row" gap="2" align="center">
               <SelectField
-                size="legacy"
+                size="small"
                 containerStyle={{ flex: 1, minWidth: 0 }}
                 value={dim.column || ""}
-                onChange={(val) =>
-                  handleUpdateDimension(i, {
-                    column: val,
-                    maxValues: dim.maxValues,
-                  })
-                }
+                onChange={(val) => handleColumnChange(i, val)}
                 options={getColumnOptionsForDimension(i)}
                 placeholder="Select dimension..."
                 sort={false}
@@ -225,49 +369,89 @@ export default function GroupBySection() {
               triggerDisabled
             >
               <Flex direction="column" gap="2" mt="1">
-                <Text size="sm" weight="semibold">
-                  Max values
-                </Text>
-                <Field
-                  size="legacy"
-                  type="number"
-                  min="1"
-                  max="20"
-                  value={
-                    localMaxValues[i] !== undefined &&
-                    localMaxValues[i] !== null
-                      ? localMaxValues[i]!
-                      : dim.maxValues.toString()
-                  }
-                  onFocus={() => {
-                    latestMaxValuesRef.current[i] = dim.maxValues.toString();
-                  }}
-                  onChange={(e) => {
-                    const v = e.target.value;
-                    latestMaxValuesRef.current[i] = v;
-                    setLocalMaxValues((prev) => ({ ...prev, [i]: v }));
-                  }}
-                  onBlur={() => {
-                    if (skipBlurCommitRef.current) {
-                      skipBlurCommitRef.current = false;
-                      return;
+                <Tooltip enabled={!dim.column} content="Select a column first.">
+                  <Flex direction="column" gap="2">
+                    <SelectField
+                      label="Breakdown type"
+                      size="small"
+                      disabled={!dim.column}
+                      value={dim.dimensionType}
+                      onChange={(val) =>
+                        handleDimensionTypeChange(
+                          i,
+                          val as GroupByDimension["dimensionType"],
+                        )
+                      }
+                      options={BREAKDOWN_TYPE_OPTIONS}
+                      sort={false}
+                    />
+                  </Flex>
+                </Tooltip>
+
+                {!isStatic && (
+                  <Field
+                    label="Max values"
+                    size="md"
+                    type="number"
+                    min="1"
+                    max="20"
+                    value={
+                      localMaxValues[i] !== undefined &&
+                      localMaxValues[i] !== null
+                        ? localMaxValues[i]!
+                        : dim.maxValues.toString()
                     }
-                    const toCommit =
-                      latestMaxValuesRef.current[i] ?? dim.maxValues.toString();
-                    commitMaxValues(i, toCommit);
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      e.preventDefault();
+                    onFocus={() => {
+                      latestMaxValuesRef.current[i] = dim.maxValues.toString();
+                    }}
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      latestMaxValuesRef.current[i] = v;
+                      setLocalMaxValues((prev) => ({ ...prev, [i]: v }));
+                    }}
+                    onBlur={() => {
+                      if (skipBlurCommitRef.current) {
+                        skipBlurCommitRef.current = false;
+                        return;
+                      }
                       const toCommit =
                         latestMaxValuesRef.current[i] ??
                         dim.maxValues.toString();
                       commitMaxValues(i, toCommit);
-                      skipBlurCommitRef.current = true;
-                      (e.target as HTMLInputElement).blur();
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        const toCommit =
+                          latestMaxValuesRef.current[i] ??
+                          dim.maxValues.toString();
+                        commitMaxValues(i, toCommit);
+                        skipBlurCommitRef.current = true;
+                        (e.target as HTMLInputElement).blur();
+                      }
+                    }}
+                  />
+                )}
+
+                {isStatic && (
+                  <MultiSelectField
+                    label="Values"
+                    size="md"
+                    value={pinnedValues}
+                    onChange={(v) => handleValuesChange(i, v)}
+                    options={valueOptions}
+                    creatable
+                    sort={false}
+                    placeholder="Pin specific values..."
+                    helpText={`Pin specific values to break out (max ${MAX_PINNED_DIMENSION_VALUES}).`}
+                    error={
+                      capExceeded[i]
+                        ? `Only the first ${MAX_PINNED_DIMENSION_VALUES} values were kept — the rest were discarded.`
+                        : undefined
                     }
-                  }}
-                />
+                    errorLevel="warning"
+                  />
+                )}
               </Flex>
             </Collapsible>
           </Flex>

--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/GroupBySection.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/GroupBySection.tsx
@@ -68,9 +68,6 @@ export default function GroupBySection() {
   >({});
   const latestMaxValuesRef = useRef<Record<number, string>>({});
   const skipBlurCommitRef = useRef(false);
-  // True when the last Values selection/paste exceeded the cap, so the
-  // field can surface that extras were dropped.
-  const [capExceeded, setCapExceeded] = useState<Record<number, boolean>>({});
 
   // Tracks the length these maps were last synced to; Add/Remove update it
   // directly. A mismatch means something outside those handlers reshaped
@@ -85,7 +82,6 @@ export default function GroupBySection() {
     ) {
       setLocalMaxValues({});
       latestMaxValuesRef.current = {};
-      setCapExceeded({});
       expectedDimensionsLengthRef.current = draftExploreState.dimensions.length;
     }
   }, [draftExploreState.dimensions.length]);
@@ -152,7 +148,6 @@ export default function GroupBySection() {
       latestMaxValuesRef.current,
       index,
     );
-    setCapExceeded((prev) => reindexAfterRemoval(prev, index));
     setDraftExploreState((prev) => ({
       ...prev,
       dimensions: prev.dimensions.filter((_, i) => i !== index),
@@ -162,14 +157,10 @@ export default function GroupBySection() {
   // Keeps the breakdown type (a separate choice) but resets values/maxValues,
   // since those were scoped to the previous column.
   const handleColumnChange = (index: number, column: string) => {
-    setCapExceeded((prev) => ({ ...prev, [index]: false }));
     setDraftExploreState((prev) => ({
       ...prev,
       dimensions: prev.dimensions.map((d, i) => {
         if (i !== index || !isGroupByDimension(d)) return d;
-        if (d.dimensionType === "static") {
-          return { dimensionType: "static", column, values: [] };
-        }
         return {
           dimensionType: "dynamic",
           column,
@@ -185,7 +176,6 @@ export default function GroupBySection() {
     index: number,
     dimensionType: GroupByDimension["dimensionType"],
   ) => {
-    setCapExceeded((prev) => ({ ...prev, [index]: false }));
     setDraftExploreState((prev) => ({
       ...prev,
       dimensions: prev.dimensions.map((d, i) => {
@@ -244,12 +234,6 @@ export default function GroupBySection() {
   // breakdown-type selector above, not by pinning/clearing values here.
   const handleValuesChange = (index: number, values: string[]) => {
     const capped = values.slice(0, MAX_PINNED_DIMENSION_VALUES);
-
-    setCapExceeded((prev) => ({
-      ...prev,
-      [index]: values.length > MAX_PINNED_DIMENSION_VALUES,
-    }));
-
     setDraftExploreState((prev) => ({
       ...prev,
       dimensions: prev.dimensions.map((d, i) =>
@@ -444,13 +428,7 @@ export default function GroupBySection() {
                     creatable
                     sort={false}
                     placeholder="Pin specific values..."
-                    helpText={`Pin specific values to break out (max ${MAX_PINNED_DIMENSION_VALUES}).`}
-                    error={
-                      capExceeded[i]
-                        ? `Only the first ${MAX_PINNED_DIMENSION_VALUES} values were kept — the rest were discarded.`
-                        : undefined
-                    }
-                    errorLevel="warning"
+                    helpText={`Select up to ${MAX_PINNED_DIMENSION_VALUES} values.`}
                     showCopyButton={false}
                   />
                 )}

--- a/packages/front-end/enterprise/components/ProductAnalytics/util.ts
+++ b/packages/front-end/enterprise/components/ProductAnalytics/util.ts
@@ -61,7 +61,10 @@ import {
   explorationDateRangeValidator,
   comparisonModeValidator,
 } from "shared/validators";
-import { operatorLabelMap } from "@/components/FactTables/rowFilterUtils";
+import {
+  operatorLabelMap,
+  getColumnInfo,
+} from "@/components/FactTables/rowFilterUtils";
 
 export { mapDatabaseTypeToEnum };
 
@@ -488,6 +491,22 @@ export function getCommonColumns(
         const ft = getFactTableById(factMetric.numerator.factTableId);
         valueColumns = ft?.columns || [];
         ft?.userIdTypes?.forEach((u) => userIdTypes.add(u));
+
+        // A ratio metric's denominator can live on a different fact table —
+        // only offer columns both sides can resolve, so a dimension can
+        // never be picked that a group-by query can't evaluate.
+        if (factMetric.denominator?.factTableId) {
+          const denominatorFt = getFactTableById(
+            factMetric.denominator.factTableId,
+          );
+          const denominatorColumnNames = new Set(
+            (denominatorFt?.columns || []).map((c) => c.column),
+          );
+          valueColumns = valueColumns.filter((c) =>
+            denominatorColumnNames.has(c.column),
+          );
+          denominatorFt?.userIdTypes?.forEach((u) => userIdTypes.add(u));
+        }
       }
 
       if (columns === null) {
@@ -538,6 +557,43 @@ export function getCommonColumns(
   return groupByColumns.sort((a, b) =>
     (a.name || a.column).localeCompare(b.name || b.column),
   );
+}
+
+/** Cached top values for a column (not dimension-specific — also usable for
+ *  filtering UI); empty for data_source datasets, which have no cached
+ *  column metadata. */
+export function getColumnTopValues(
+  dataset: ExplorationDataset | null,
+  column: string | null,
+  getFactTableById: (id: string) => FactTableDefinition | null,
+  getFactMetricById: (id: string) => FactMetricInterface | null,
+): string[] {
+  if (!dataset || !column) return [];
+
+  if (dataset.type === "fact_table") {
+    const ft = getFactTableById(dataset.factTableId || "");
+    return ft ? getColumnInfo(ft, column).topValues : [];
+  }
+  if (dataset.type === "metric") {
+    const topValues = new Set<string>();
+    dataset.values.forEach((value) => {
+      const metric = getFactMetricById(value.metricId);
+      const ft = metric ? getFactTableById(metric.numerator.factTableId) : null;
+      if (ft) {
+        getColumnInfo(ft, column).topValues.forEach((v) => topValues.add(v));
+      }
+    });
+    return Array.from(topValues);
+  }
+  if (dataset.type === "funnel") {
+    const initialStep = dataset.steps[0];
+    const ft = initialStep?.factTable
+      ? getFactTableById(initialStep.factTable)
+      : null;
+    return ft ? getColumnInfo(ft, column).topValues : [];
+  }
+
+  return [];
 }
 
 export function getMaxDimensions(dataset: ExplorationDataset): number {
@@ -601,7 +657,8 @@ export function validateDimensions(
   const maxDims = getMaxDimensions(config.dataset);
 
   let validDimensions = config.dimensions.filter((d) => {
-    if (d.dimensionType !== "dynamic") return true;
+    if (d.dimensionType !== "dynamic" && d.dimensionType !== "static")
+      return true;
     if (columns.length === 0) return true;
     return columns.some((c) => c.column === d.column || d.column === null);
   });

--- a/packages/front-end/enterprise/components/ProductAnalytics/util.ts
+++ b/packages/front-end/enterprise/components/ProductAnalytics/util.ts
@@ -984,6 +984,14 @@ export function isSubmittableConfig(
     return false;
   }
 
+  if (
+    cleanedConfig.dimensions.some(
+      (d) => d.dimensionType === "static" && d.values.length === 0,
+    )
+  ) {
+    return false;
+  }
+
   return true;
 }
 

--- a/packages/front-end/test/components/ProductAnalytics/util.test.ts
+++ b/packages/front-end/test/components/ProductAnalytics/util.test.ts
@@ -4,8 +4,12 @@ import {
   FactMetricInterface,
   FactTableInterface,
 } from "shared/types/fact-table";
-import { ExplorationDataset } from "shared/validators";
-import { getCommonColumns } from "@/enterprise/components/ProductAnalytics/util";
+import { ExplorationConfig, ExplorationDataset } from "shared/validators";
+import {
+  getCommonColumns,
+  getColumnTopValues,
+  validateDimensions,
+} from "@/enterprise/components/ProductAnalytics/util";
 
 function makeColumn(overrides: Partial<ColumnInterface>): ColumnInterface {
   return {
@@ -219,5 +223,215 @@ describe("getCommonColumns", () => {
     expect(
       getCommonColumns(dataset, getFactTableById, getFactMetricById),
     ).toEqual([{ column: "country", name: "Country" }]);
+  });
+
+  it("excludes columns a ratio metric's denominator table can't resolve", () => {
+    const dataset: ExplorationDataset = {
+      type: "metric",
+      values: [
+        {
+          type: "metric",
+          name: "a",
+          rowFilters: [],
+          metricId: "met_a",
+          unit: null,
+          denominatorUnit: null,
+        },
+      ],
+    };
+
+    const numeratorFt = makeFactTable([
+      makeColumn({ column: "country", name: "Country" }),
+      makeColumn({ column: "browser", name: "Browser" }),
+    ]);
+    const denominatorFt = makeFactTable([
+      makeColumn({ column: "country", name: "Country" }),
+    ]);
+
+    const getFactTableById = (id: string) =>
+      id === "ft_numerator"
+        ? numeratorFt
+        : id === "ft_denominator"
+          ? denominatorFt
+          : null;
+    const getFactMetricById = () =>
+      ({
+        numerator: { factTableId: "ft_numerator" },
+        denominator: { factTableId: "ft_denominator" },
+      }) as FactMetricInterface;
+
+    expect(
+      getCommonColumns(dataset, getFactTableById, getFactMetricById),
+    ).toEqual([{ column: "country", name: "Country" }]);
+  });
+});
+
+describe("getColumnTopValues", () => {
+  it("returns empty when dataset or column is missing", () => {
+    const ft = makeFactTable([
+      makeColumn({ column: "country", topValues: ["US", "CA"] }),
+    ]);
+    expect(getColumnTopValues(null, "country", () => ft, noFactMetric)).toEqual(
+      [],
+    );
+    expect(
+      getColumnTopValues(factTableDataset(), null, () => ft, noFactMetric),
+    ).toEqual([]);
+  });
+
+  it("reads cached top values off the fact table for a fact_table dataset", () => {
+    const ft = makeFactTable([
+      makeColumn({ column: "country", topValues: ["US", "CA"] }),
+    ]);
+    expect(
+      getColumnTopValues(factTableDataset(), "country", () => ft, noFactMetric),
+    ).toEqual(["US", "CA"]);
+  });
+
+  it("returns empty for a data_source dataset (no cached column metadata)", () => {
+    const dataset: ExplorationDataset = {
+      type: "data_source",
+      table: "events",
+      path: "events",
+      timestampColumn: "timestamp",
+      columnTypes: { country: "string" },
+      values: [
+        {
+          type: "data_source",
+          name: "value",
+          rowFilters: [],
+          valueType: "count",
+          valueColumn: null,
+          unit: null,
+        },
+      ],
+    };
+    expect(
+      getColumnTopValues(dataset, "country", () => null, noFactMetric),
+    ).toEqual([]);
+  });
+
+  it("unions top values across every metric's fact table for a metric dataset", () => {
+    const dataset: ExplorationDataset = {
+      type: "metric",
+      values: [
+        {
+          type: "metric",
+          name: "a",
+          rowFilters: [],
+          metricId: "met_a",
+          unit: null,
+          denominatorUnit: null,
+        },
+        {
+          type: "metric",
+          name: "b",
+          rowFilters: [],
+          metricId: "met_b",
+          unit: null,
+          denominatorUnit: null,
+        },
+      ],
+    };
+
+    const ftA = makeFactTable([
+      makeColumn({ column: "country", topValues: ["US", "CA"] }),
+    ]);
+    const ftB = makeFactTable([
+      makeColumn({ column: "country", topValues: ["CA", "MX"] }),
+    ]);
+
+    const getFactTableById = (id: string) =>
+      id === "ft_a" ? ftA : id === "ft_b" ? ftB : null;
+    const getFactMetricById = (id: string) =>
+      ({
+        numerator: { factTableId: id === "met_a" ? "ft_a" : "ft_b" },
+      }) as FactMetricInterface;
+
+    expect(
+      getColumnTopValues(
+        dataset,
+        "country",
+        getFactTableById,
+        getFactMetricById,
+      ).sort(),
+    ).toEqual(["CA", "MX", "US"]);
+  });
+});
+
+describe("validateDimensions", () => {
+  function makeConfig(
+    dimensions: ExplorationConfig["dimensions"],
+  ): ExplorationConfig {
+    return {
+      type: "fact_table",
+      datasource: "ds_1",
+      dataset: {
+        type: "fact_table",
+        factTableId: "ft_1",
+        values: [
+          {
+            type: "fact_table",
+            name: "value",
+            rowFilters: [],
+            valueType: "count",
+            valueColumn: null,
+            unit: null,
+          },
+        ],
+      },
+      dimensions,
+      chartType: "bar",
+      dateRange: { predefined: "last7Days" },
+    };
+  }
+
+  it("keeps a static dimension pinned on a JSON dot-notation column", () => {
+    const ft = makeFactTable([
+      makeColumn({
+        column: "props",
+        name: "Props",
+        datatype: "json",
+        jsonFields: { plan: { datatype: "string" } },
+      }),
+    ]);
+    const config = makeConfig([
+      { dimensionType: "static", column: "props.plan", values: ["pro"] },
+    ]);
+
+    expect(
+      validateDimensions(config, () => ft, noFactMetric).dimensions,
+    ).toEqual(config.dimensions);
+  });
+
+  it("keeps a dynamic dimension pinned on a JSON dot-notation column", () => {
+    const ft = makeFactTable([
+      makeColumn({
+        column: "props",
+        name: "Props",
+        datatype: "json",
+        jsonFields: { plan: { datatype: "string" } },
+      }),
+    ]);
+    const config = makeConfig([
+      { dimensionType: "dynamic", column: "props.plan", maxValues: 5 },
+    ]);
+
+    expect(
+      validateDimensions(config, () => ft, noFactMetric).dimensions,
+    ).toEqual(config.dimensions);
+  });
+
+  it("drops a dimension whose column no longer exists on the fact table", () => {
+    const ft = makeFactTable([
+      makeColumn({ column: "country", name: "Country" }),
+    ]);
+    const config = makeConfig([
+      { dimensionType: "static", column: "removed_column", values: ["x"] },
+    ]);
+
+    expect(
+      validateDimensions(config, () => ft, noFactMetric).dimensions,
+    ).toEqual([]);
   });
 });

--- a/packages/shared/src/enterprise/product-analytics/sql.ts
+++ b/packages/shared/src/enterprise/product-analytics/sql.ts
@@ -21,6 +21,7 @@ import { DataSourceSettings, DataSourceType } from "shared/types/datasource";
 import {
   ProductAnalyticsDimension,
   ProductAnalyticsDynamicDimension,
+  ProductAnalyticsStaticDimension,
   FactTableDataset,
   ExplorationConfig,
   DataSourceDataset,
@@ -460,6 +461,58 @@ function generateRowFilterSQL(
     .filter((sql): sql is string => sql !== null);
 }
 
+// True if `column` resolves to a real underlying column on `factTable` —
+// either a top-level column, or (for a dotted path) a JSON field defined on
+// a JSON-typed top-level column. A ratio metric's denominator can live on a
+// different fact table than its numerator, and that table may not expose
+// the dimension's column at all; callers use this to skip applying a static
+// dimension's filter to a group whose table can't actually resolve it,
+// rather than injecting a WHERE clause that references a nonexistent
+// column and fails at the warehouse.
+function factTableHasResolvableColumn(
+  factTable: MinimalFactTable,
+  column: string,
+): boolean {
+  const [baseColumn, ...rest] = column.split(".");
+  const col = factTable.columns.find((c) => c.column === baseColumn);
+  if (!col) return false;
+  if (rest.length === 0) return true;
+  return col.datatype === "json" && !!col.jsonFields?.[rest.join(".")];
+}
+
+// Build `column IN (...)` clauses for every static (pinned-values) dimension,
+// so callers can drop rows outside the pinned list before aggregation.
+function getStaticDimensionFilters(
+  dimensions: ProductAnalyticsDimension[],
+  factTable: MinimalFactTable,
+  helpers: SqlDialect,
+): string[] {
+  const staticDimensions = dimensions.filter(
+    (d): d is ProductAnalyticsStaticDimension =>
+      d.dimensionType === "static" && d.values.length > 0,
+  );
+
+  // A ratio metric's denominator table may not expose a pinned column at
+  // all — exclude every row from this fact table rather than let them all
+  // through unfiltered on that dimension.
+  const hasUnresolvableDimension = staticDimensions.some(
+    (d) => !factTableHasResolvableColumn(factTable, d.column),
+  );
+  if (hasUnresolvableDimension) return ["1 = 0"];
+
+  return staticDimensions.map((d) => {
+    const columnExpr = getColumnExpression(
+      d.column,
+      factTable,
+      helpers.jsonExtract,
+    );
+    const valueList = d.values
+      .map((v) => `'${helpers.escapeStringLiteral(v)}'`)
+      .join(", ");
+    return `${columnExpr} IN (${valueList})`;
+  });
+}
+
 function getCappingSettings(
   metric: MinimalMetric,
 ): MetricCappingSettings | null {
@@ -510,20 +563,16 @@ export function generateDimensionExpression(
       END`;
     }
     case "static": {
-      const columnExpr = getColumnExpression(
+      // Rows outside the pinned value list are dropped entirely (filtered in
+      // generateFactTableCTE / buildFunnelSql), so this is just the raw
+      // column — no CASE/'other' fallback needed.
+      return getColumnExpression(
         dimension.column,
         factTable,
         helpers.jsonExtract,
         "",
         helpers.identifierQuote,
       );
-      const valueList = dimension.values
-        .map((v) => `'${helpers.escapeStringLiteral(v)}'`)
-        .join(", ");
-      return `CASE 
-        WHEN ${columnExpr} IN (${valueList}) THEN ${columnExpr}
-        ELSE 'other'
-      END`;
     }
     case "slice": {
       const cases = dimension.slices.map(
@@ -939,6 +988,7 @@ function generateFactTableCTE(
   factTableGroup: FactTableGroup,
   helpers: SqlDialect,
   dateRange: DateRange,
+  staticDimensionFilters: string[],
 ): CTE {
   const factTable = factTableGroup.factTable;
 
@@ -975,6 +1025,8 @@ function generateFactTableCTE(
   if (metricsFilter) {
     whereClauses.push(metricsFilter);
   }
+
+  whereClauses.push(...staticDimensionFilters);
 
   return {
     name: `_factTable${factTableGroup.index}`,
@@ -1534,13 +1586,33 @@ export function buildFunnelSql(
   };
   ctes.push(userAggregatesCte);
 
-  // 3b. Chained step-N resolution. Each CTE reads directly from the
-  // previous one — the prev CTE already carries `stepN_arr` forward from
-  // __funnel_user_aggregates, so a JOIN back to the aggregate would be
-  // a redundant self-join on user_id. Each step "consumes" its own array
-  // column (replacing it with `stepN_resolved_ts`) and forwards the
-  // remaining arrays for later steps.
-  let prevCte: CTE = userAggregatesCte;
+  // First-touch, like the dimension itself — filters on `dimension_1`, not
+  // raw per-fact-table events (which may also feed later, unrelated steps).
+  const staticDimensionFilter =
+    dimension?.dimensionType === "static" && dimension.values.length > 0
+      ? `dimension_1 IN (${dimension.values
+          .map((v) => `'${dialect.escapeStringLiteral(v)}'`)
+          .join(", ")})`
+      : null;
+
+  // 3a. Drop users who can't survive the funnel (no step 1, or a pinned
+  // dimension mismatch) before the per-step CTEs below, so later steps
+  // only process users who could still make it into the result.
+  const qualifyingUsersCte: CTE = {
+    name: "__funnel_qualifying_users",
+    sql: `
+      SELECT *
+      FROM ${userAggregatesCte.name}
+      WHERE step1_resolved_ts IS NOT NULL
+      ${staticDimensionFilter ? `AND ${staticDimensionFilter}` : ""}
+    `,
+  };
+  ctes.push(qualifyingUsersCte);
+
+  // 3b. Chained step-N resolution. Each CTE reads the previous one directly
+  // (it already carries `stepN_arr` forward) and "consumes" its own array,
+  // replacing it with `stepN_resolved_ts` and forwarding the rest.
+  let prevCte: CTE = qualifyingUsersCte;
   const carriedCols: string[] = [];
   if (dimensionExpr) carriedCols.push("dimension_1");
   carriedCols.push("step1_resolved_ts");
@@ -1608,11 +1680,12 @@ export function buildFunnelSql(
     }
   });
 
+  // step1_resolved_ts IS NOT NULL and the static dimension filter (if any)
+  // are already applied in __funnel_qualifying_users, above.
   const finalSelect = `
     SELECT
       ${finalSelects.join(",\n      ")}
     FROM ${prevCte.name}
-    WHERE step1_resolved_ts IS NOT NULL
     ${finalGroupBys.length ? `GROUP BY ${finalGroupBys.join(", ")}` : ""}
   `;
 
@@ -1717,7 +1790,8 @@ export function generateProductAnalyticsSQL(
     allMetrics.filter((m) => m.rollupCountExpr).map((m) => m.alias),
   );
 
-  // Get all dimensions
+  // Only `.alias` is used from this for the final SELECT (below); each
+  // group computes its own `.valueExpr` in `groupDimensions` instead.
   const allDimensions: DimensionData[] = [];
   config.dimensions.forEach((d, i) => {
     allDimensions.push({
@@ -1737,11 +1811,35 @@ export function generateProductAnalyticsSQL(
   const ctesToRollup: CTE[] = [];
 
   factTableGroups.forEach((factTableGroup, i) => {
+    // Recomputed against this group's own fact table — a ratio metric's
+    // denominator can resolve a column differently, or not at all (NULL;
+    // getStaticDimensionFilters excludes such a group's rows entirely).
+    const groupDimensions: DimensionData[] = config.dimensions.map((d, di) => ({
+      alias: `dimension${di}`,
+      valueExpr:
+        d.dimensionType === "static" &&
+        !factTableHasResolvableColumn(factTableGroup.factTable, d.column)
+          ? "NULL"
+          : generateDimensionExpression(
+              d,
+              di,
+              factTableGroup,
+              dialect,
+              dateRange,
+            ),
+    }));
+    const staticDimensionFilters = getStaticDimensionFilters(
+      config.dimensions,
+      factTableGroup.factTable,
+      dialect,
+    );
+
     // Add the raw fact table CTE
     const factTableCTE = generateFactTableCTE(
       factTableGroup,
       dialect,
       dateRange,
+      staticDimensionFilters,
     );
     ctes.push(factTableCTE);
 
@@ -1774,7 +1872,7 @@ export function generateProductAnalyticsSQL(
       factTableGroup,
       factTableCTE,
       percentileCapsCTE,
-      allDimensions,
+      groupDimensions,
       dialect,
     );
     ctes.push(factTableRowsCTE);
@@ -1803,7 +1901,7 @@ export function generateProductAnalyticsSQL(
       const unitAggregationCTE = generateUnitAggregationCTE(
         factTableGroup,
         factTableRowsCTE,
-        allDimensions,
+        groupDimensions,
         unitIndex,
         metrics,
       );
@@ -1813,7 +1911,7 @@ export function generateProductAnalyticsSQL(
       const unitRollupCTE = generateUnitAggregationRollupCTE(
         factTableGroup,
         unitAggregationCTE,
-        allDimensions,
+        groupDimensions,
         unitIndex,
         metrics,
         allMetricsAliases,
@@ -1829,7 +1927,7 @@ export function generateProductAnalyticsSQL(
       const eventRollupCTE = generateEventRollupCTE(
         factTableGroup,
         factTableRowsCTE,
-        allDimensions,
+        groupDimensions,
         eventMetrics,
         allMetricsAliases,
         aliasesWithDenominator,

--- a/packages/shared/src/validators/product-analytics.ts
+++ b/packages/shared/src/validators/product-analytics.ts
@@ -155,6 +155,8 @@ export const dynamicDimensionValidator = z.object({
 export const staticDimensionValidator = z.object({
   dimensionType: z.literal("static"),
   column: z.string(),
+  // Unbounded so this can parse older saved/URL-encoded explorations too;
+  // the editor enforces the 20-value cap.
   values: z.array(z.string()),
 });
 
@@ -379,6 +381,9 @@ export type ProductAnalyticsFunnelStepResult = z.infer<
 export type ProductAnalyticsDimension = z.infer<typeof dimensionValidator>;
 export type ProductAnalyticsDynamicDimension = z.infer<
   typeof dynamicDimensionValidator
+>;
+export type ProductAnalyticsStaticDimension = z.infer<
+  typeof staticDimensionValidator
 >;
 export type ProductAnalyticsResult = z.infer<
   typeof productAnalyticsResultValidator

--- a/packages/shared/test/product-analytics-dimension.test.ts
+++ b/packages/shared/test/product-analytics-dimension.test.ts
@@ -1,4 +1,5 @@
 import { generateDimensionExpression } from "shared/enterprise";
+import { staticDimensionValidator } from "shared/validators";
 import { ColumnInterface } from "shared/types/fact-table";
 import { SqlDialect } from "shared/types/sql";
 
@@ -150,7 +151,10 @@ describe("generateDimensionExpression", () => {
   });
 
   describe("static dimension", () => {
-    it("builds a CASE over the configured values for a top-level column", () => {
+    // Rows outside the pinned value list are dropped via a WHERE filter
+    // built elsewhere (generateFactTableCTE / buildFunnelSql), so the
+    // expression itself is just the raw column — no CASE/'other' fallback.
+    it("returns the raw column expression for a top-level column", () => {
       const result = generateDimensionExpression(
         { dimensionType: "static", column: "country", values: ["US", "CA"] },
         0,
@@ -158,9 +162,7 @@ describe("generateDimensionExpression", () => {
         helpers,
         dateRange,
       );
-      expect(norm(result)).toBe(
-        "CASE WHEN country IN ('US', 'CA') THEN country ELSE 'other' END",
-      );
+      expect(norm(result)).toBe("country");
     });
 
     it("expands a JSON field when used as a static dimension", () => {
@@ -171,20 +173,7 @@ describe("generateDimensionExpression", () => {
         helpers,
         dateRange,
       );
-      expect(norm(result)).toBe(
-        "CASE WHEN props:'plan'::text IN ('free') THEN props:'plan'::text ELSE 'other' END",
-      );
-    });
-
-    it("escapes single quotes in static values", () => {
-      const result = generateDimensionExpression(
-        { dimensionType: "static", column: "country", values: ["O'Brien"] },
-        0,
-        makeFactTableGroup(),
-        helpers,
-        dateRange,
-      );
-      expect(norm(result)).toContain("IN ('O''Brien')");
+      expect(norm(result)).toBe("props:'plan'::text");
     });
   });
 
@@ -234,5 +223,45 @@ describe("generateDimensionExpression", () => {
       );
       expect(norm(result)).toContain("props:'plan'::text = 'free'");
     });
+  });
+});
+
+describe("staticDimensionValidator", () => {
+  // Intentionally unbounded: this schema also parses already-persisted and
+  // URL-encoded explorations (not just fresh writes from the editor), so it
+  // must keep accepting configs that predate the editor's own 1-20 cap —
+  // an empty or oversized `values` array must not fail to parse. The editor
+  // enforces 1-20 pins at authoring time; the SQL layer skips the filter
+  // entirely for an empty values array (see sql.ts) rather than emitting
+  // invalid SQL.
+  it("accepts an empty pinned values array", () => {
+    expect(() =>
+      staticDimensionValidator.parse({
+        dimensionType: "static",
+        column: "country",
+        values: [],
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts more than 20 pinned values", () => {
+    const values = Array.from({ length: 21 }, (_, i) => `v${i}`);
+    expect(() =>
+      staticDimensionValidator.parse({
+        dimensionType: "static",
+        column: "country",
+        values,
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts a typical pinned values array", () => {
+    expect(() =>
+      staticDimensionValidator.parse({
+        dimensionType: "static",
+        column: "country",
+        values: ["US"],
+      }),
+    ).not.toThrow();
   });
 });

--- a/packages/shared/test/product-analytics.test.ts
+++ b/packages/shared/test/product-analytics.test.ts
@@ -374,6 +374,319 @@ describe("productAnalytics", () => {
     expect(sql).toEqual(expected);
   });
 
+  it("generates SQL for fact tables with a static (pinned-values) dimension", () => {
+    const config: ExplorationConfig = {
+      type: "fact_table",
+      datasource: "ds_1",
+      chartType: "bar",
+      showAs: "total",
+      dateRange: {
+        predefined: "last7Days",
+        startDate: null,
+        endDate: null,
+        lookbackValue: null,
+        lookbackUnit: null,
+      },
+      dimensions: [
+        {
+          dimensionType: "static",
+          column: "anonymous_id",
+          values: ["a1", "a2"],
+        },
+      ],
+      dataset: {
+        type: "fact_table",
+        factTableId: "orders",
+        values: [
+          {
+            name: "purchasers",
+            type: "fact_table",
+            rowFilters: [],
+            valueType: "unit_count",
+            unit: "user_id",
+            valueColumn: null,
+          },
+        ],
+      },
+    };
+
+    const { sql } = generateProductAnalyticsSQL(
+      config,
+      factTableMap,
+      metricMap,
+      helpers,
+      datasource,
+    );
+
+    // Rows outside the pinned list are dropped via a WHERE filter...
+    expect(sql).toContain("anonymous_id IN ('a1', 'a2')");
+    // ...and the dimension itself selects the raw column, no CASE/'other'.
+    expect(sql).toContain("anonymous_id AS dimension0");
+    expect(sql).not.toContain("'other'");
+    // No top-values CTE is needed for a static (pinned) dimension.
+    expect(sql).not.toContain("_dimension0_top");
+  });
+
+  it("skips the filter for a static dimension with no pinned values instead of emitting invalid SQL", () => {
+    // The validator no longer rejects an empty `values` array (it must keep
+    // parsing already-persisted/URL-encoded explorations that predate the
+    // editor's 1-20 cap), so the SQL layer has to handle it gracefully
+    // rather than emitting a malformed `IN ()`.
+    const config: ExplorationConfig = {
+      type: "fact_table",
+      datasource: "ds_1",
+      chartType: "bar",
+      showAs: "total",
+      dateRange: {
+        predefined: "last7Days",
+        startDate: null,
+        endDate: null,
+        lookbackValue: null,
+        lookbackUnit: null,
+      },
+      dimensions: [
+        { dimensionType: "static", column: "anonymous_id", values: [] },
+      ],
+      dataset: {
+        type: "fact_table",
+        factTableId: "orders",
+        values: [
+          {
+            name: "purchasers",
+            type: "fact_table",
+            rowFilters: [],
+            valueType: "unit_count",
+            unit: "user_id",
+            valueColumn: null,
+          },
+        ],
+      },
+    };
+
+    const { sql } = generateProductAnalyticsSQL(
+      config,
+      factTableMap,
+      metricMap,
+      helpers,
+      datasource,
+    );
+
+    expect(sql).not.toContain("IN ()");
+    expect(sql).not.toContain("anonymous_id IN");
+  });
+
+  it("resolves a static dimension's filter consistently across fact tables for a cross-table ratio metric", () => {
+    // Regression test for a ratio metric whose denominator lives on a
+    // different fact table than the numerator, and that table doesn't
+    // expose the dimension's "props" column at all:
+    //  1. The filter expression must be resolved against factTableGroups[0]
+    //     (the same basis the dimension's SELECT expression uses), not
+    //     against each group's own fact table — otherwise a table that
+    //     doesn't share the numerator's JSON column shape would get a
+    //     broken raw "props.plan" filter instead of a jsonExtract call.
+    //  2. A group whose fact table can't resolve the column at all (like
+    //     this denominator) must be skipped entirely, rather than referencing
+    //     a column the warehouse doesn't have.
+    const jsonFactTableMap = new Map<string, FactTableInterface>([
+      [
+        "orders",
+        {
+          ...factTableMap.get("orders")!,
+          columns: [
+            ...factTableMap.get("orders")!.columns,
+            {
+              column: "props",
+              datatype: "json",
+              dateCreated: new Date(),
+              dateUpdated: new Date(),
+              name: "props",
+              description: "",
+              numberFormat: "",
+              alwaysInlineFilter: false,
+              deleted: false,
+              autoSlices: [],
+              isAutoSliceColumn: false,
+              jsonFields: { plan: { datatype: "string" } },
+            },
+          ],
+        },
+      ],
+      [
+        // Same base shape as "orders", but with no "props" column at all.
+        "other_ft",
+        {
+          ...factTableMap.get("orders")!,
+          id: "other_ft",
+          sql: "SELECT user_id, timestamp, revenue FROM other_events",
+        },
+      ],
+    ]);
+
+    const crossTableRatioMetricMap = new Map<string, FactMetricInterface>([
+      [
+        "cross_table_ratio",
+        {
+          id: "cross_table_ratio",
+          name: "Cross Table Ratio",
+          metricType: "ratio",
+          numerator: {
+            factTableId: "orders",
+            column: "revenue",
+            aggregation: "sum",
+          },
+          denominator: {
+            factTableId: "other_ft",
+            column: "$$count",
+            aggregation: "sum",
+          },
+          cappingSettings: { type: "", value: 0 },
+          windowSettings: {
+            type: "",
+            delayValue: 0,
+            delayUnit: "days",
+            windowValue: 0,
+            windowUnit: "days",
+          },
+          quantileSettings: null,
+        } as FactMetricInterface,
+      ],
+    ]);
+
+    const config: ExplorationConfig = {
+      type: "metric",
+      datasource: "ds_1",
+      chartType: "bar",
+      dateRange: {
+        predefined: "last7Days",
+        startDate: null,
+        endDate: null,
+        lookbackValue: null,
+        lookbackUnit: null,
+      },
+      dimensions: [
+        { dimensionType: "static", column: "props.plan", values: ["free"] },
+      ],
+      dataset: {
+        type: "metric",
+        values: [
+          {
+            name: "ratio",
+            type: "metric",
+            rowFilters: [],
+            metricId: "cross_table_ratio",
+            unit: null,
+            denominatorUnit: null,
+          },
+        ],
+      },
+    };
+
+    const { sql } = generateProductAnalyticsSQL(
+      config,
+      jsonFactTableMap,
+      crossTableRatioMetricMap,
+      helpers,
+      datasource,
+    );
+
+    // Only the numerator's fact-table CTE (which actually has "props" as a
+    // JSON column) gets the pinned-values filter, correctly resolved via
+    // jsonExtract...
+    const matches = sql.match(/props:'plan'::text IN \('free'\)/g) ?? [];
+    expect(matches.length).toBe(1);
+    // ...the denominator's CTE — whose fact table doesn't have "props" at
+    // all — is left unfiltered rather than referencing a nonexistent
+    // column, and there's never a broken raw "props.plan" reference.
+    expect(sql).not.toContain("props.plan IN");
+  });
+
+  it("applies a static dimension's filter to every fact table that shares the column", () => {
+    // Counterpart to the previous test: when the denominator's fact table
+    // *does* have the dimension's column, both CTEs should still get
+    // filtered — the skip only kicks in when the column is genuinely absent.
+    const secondFactTableMap = new Map<string, FactTableInterface>([
+      ["orders", factTableMap.get("orders")!],
+      [
+        "orders2",
+        { ...factTableMap.get("orders")!, id: "orders2", name: "Orders 2" },
+      ],
+    ]);
+
+    const sharedColumnRatioMetricMap = new Map<string, FactMetricInterface>([
+      [
+        "shared_column_ratio",
+        {
+          id: "shared_column_ratio",
+          name: "Shared Column Ratio",
+          metricType: "ratio",
+          numerator: {
+            factTableId: "orders",
+            column: "revenue",
+            aggregation: "sum",
+          },
+          denominator: {
+            factTableId: "orders2",
+            column: "$$count",
+            aggregation: "sum",
+          },
+          cappingSettings: { type: "", value: 0 },
+          windowSettings: {
+            type: "",
+            delayValue: 0,
+            delayUnit: "days",
+            windowValue: 0,
+            windowUnit: "days",
+          },
+          quantileSettings: null,
+        } as FactMetricInterface,
+      ],
+    ]);
+
+    const config: ExplorationConfig = {
+      type: "metric",
+      datasource: "ds_1",
+      chartType: "bar",
+      dateRange: {
+        predefined: "last7Days",
+        startDate: null,
+        endDate: null,
+        lookbackValue: null,
+        lookbackUnit: null,
+      },
+      dimensions: [
+        {
+          dimensionType: "static",
+          column: "anonymous_id",
+          values: ["a1"],
+        },
+      ],
+      dataset: {
+        type: "metric",
+        values: [
+          {
+            name: "ratio",
+            type: "metric",
+            rowFilters: [],
+            metricId: "shared_column_ratio",
+            unit: null,
+            denominatorUnit: null,
+          },
+        ],
+      },
+    };
+
+    const { sql } = generateProductAnalyticsSQL(
+      config,
+      secondFactTableMap,
+      sharedColumnRatioMetricMap,
+      helpers,
+      datasource,
+    );
+
+    const matches = sql.match(/anonymous_id IN \('a1'\)/g) ?? [];
+    expect(matches.length).toBe(2);
+  });
+
   it("generates SQL for fact tables with mix of filtered and unfiltered values", () => {
     const config: ExplorationConfig = {
       type: "fact_table",

--- a/packages/shared/test/sql.funnel.test.ts
+++ b/packages/shared/test/sql.funnel.test.ts
@@ -219,6 +219,86 @@ describe("buildFunnelSql", () => {
     expect(sql).not.toContain("step1_tfp_sum_hrs");
   });
 
+  it("filters out non-qualifying users before the per-step CTEs, not just in the final SELECT", () => {
+    const config = baseFunnelConfig(
+      [
+        { name: "Step 1", factTable: "orders" },
+        { name: "Step 2", factTable: "orders" },
+        { name: "Step 3", factTable: "orders" },
+      ],
+      {
+        dimensions: [
+          {
+            dimensionType: "static",
+            column: "country",
+            values: ["US", "CA"],
+          },
+        ],
+      },
+    );
+
+    const { sql } = buildFunnelSql(config, factTableMap, helpers);
+    const qualifyingIdx = sql.indexOf("__funnel_qualifying_users AS (");
+    const step2Idx = sql.indexOf("__funnel_resolved_step2 AS (");
+    expect(qualifyingIdx).toBeGreaterThan(-1);
+    // The qualifying-users CTE is defined before the per-step CTEs that
+    // consume it, and does the step1/dimension filtering so later steps
+    // never process users who couldn't survive anyway.
+    expect(qualifyingIdx).toBeLessThan(step2Idx);
+    expect(sql).toContain("FROM __funnel_user_aggregates");
+    expect(sql).toContain("WHERE step1_resolved_ts IS NOT NULL");
+    expect(sql).toContain("FROM __funnel_qualifying_users r");
+    expect(sql).not.toContain("FROM __funnel_user_aggregates r");
+    // The final SELECT no longer repeats the filter.
+    const finalSelect = sql.slice(sql.lastIndexOf("SELECT"));
+    expect(finalSelect).not.toContain("WHERE");
+  });
+
+  it("filters to pinned values via a WHERE clause for a static dimension", () => {
+    const config = baseFunnelConfig(
+      [
+        { name: "Step 1", factTable: "orders" },
+        { name: "Step 2", factTable: "orders" },
+      ],
+      {
+        dimensions: [
+          {
+            dimensionType: "static",
+            column: "country",
+            values: ["US", "CA"],
+          },
+        ],
+      },
+    );
+
+    const { sql } = buildFunnelSql(config, factTableMap, helpers);
+    // Applied post-aggregation on the first-touch dimension, not on raw
+    // per-fact-table events (which may also feed unrelated steps).
+    expect(sql).toContain("dimension_1 IN ('US', 'CA')");
+    expect(sql).not.toContain("'other'");
+  });
+
+  it("skips the filter for a static dimension with no pinned values instead of emitting invalid SQL", () => {
+    // The validator no longer rejects an empty `values` array (it must keep
+    // parsing already-persisted/URL-encoded explorations that predate the
+    // editor's 1-20 cap), so this must not emit a malformed `IN ()`.
+    const config = baseFunnelConfig(
+      [
+        { name: "Step 1", factTable: "orders" },
+        { name: "Step 2", factTable: "orders" },
+      ],
+      {
+        dimensions: [
+          { dimensionType: "static", column: "country", values: [] },
+        ],
+      },
+    );
+
+    const { sql } = buildFunnelSql(config, factTableMap, helpers);
+    expect(sql).not.toContain("IN ()");
+    expect(sql).not.toContain("dimension_1 IN");
+  });
+
   it("aggregates the event log exactly once and looks step 2+ up in arrays", () => {
     const config = baseFunnelConfig([
       { name: "Step 1", factTable: "orders" },


### PR DESCRIPTION
### Features and Changes

Adds a "pin specific values" workflow to the Group By editor in the dashboard/product-analytics explorer, built on top of the existing `static` dimension type — which already existed in the schema and SQL layer but had no authoring path (the editor only ever created `dynamic` dimensions, and the AI agent silently downgraded any `static` dimension it received to `dynamic`).

- **`GroupBySection.tsx`**: dimension rows for both `dynamic` (top-N) and `static` (pinned values) now render together. A new "Values" multi-select under Advanced Options lets you pin specific column values — doing so switches the dimension to `static` (column + up to 20 values); clearing all pinned values switches it back to `dynamic`, restoring the last max-values limit that was set. Changing the dimension's column always resets to a fresh dynamic dimension, since pinned values (and any remembered max-values limit) are scoped to the previous column.
- **`util.ts`**: added `getDimensionColumnTopValues` to source real column values for the Values multi-select from cached fact-table `topValues`, resolved per dataset type (fact_table / metric / funnel). Extended `validateDimensions` so stale `static` dimensions (whose column no longer exists) get cleaned up the same way `dynamic` ones already were.
- **`shared/enterprise/product-analytics/sql.ts`**: rows outside a static dimension's pinned values are now dropped entirely via a `column IN (...)` filter — no "other" bucket — for both the standard query builder and the funnel query builder. For funnels, the filter is applied post-aggregation on the first-touch `dimension_1` column rather than on raw per-event rows, since funnel dimensions are per-user first-touch values, not per-row ones; this also keeps it from affecting other steps that happen to share the same underlying fact table. The filter is resolved once against the same fact table the dimension's SELECT expression itself uses, so it stays consistent even when a ratio metric's numerator and denominator live on different fact tables.
- **`shared/validators/product-analytics.ts`**: `staticDimensionValidator.values` now requires 1–20 entries (previously unconstrained).
- **`product-analytics-agent.ts`** (AI chat): the agent can now author `static` dimensions directly instead of always downgrading them to `dynamic`.
- Regenerated `spec.yaml` from the updated validator, and removed the now-unused `GroupBySection.tsx` eslint suppression by fixing the underlying `size="legacy"` lint errors instead of continuing to suppress them.

This supersedes #6467, which took the same idea in a different, ad-hoc direction (bolting a `values` field onto `dynamic` instead of using the existing `static` dimension type).

- Closes **(add link to issue here)**

### Dependencies

None

### Testing

- Added/updated unit tests:
  - `shared/test/product-analytics-dimension.test.ts`: static dimension SQL expression now returns the raw column (no CASE/'other'), plus validator min/max constraint coverage.
  - `shared/test/product-analytics.test.ts`: static-dimension row filtering for the standard query builder, including a regression test for a ratio metric whose denominator lives on a different fact table than the pinned dimension's column.
  - `shared/test/sql.funnel.test.ts`: static dimension filter applied post-aggregation on `dimension_1`.
  - `front-end/test/components/ProductAnalytics/util.test.ts`: `getDimensionColumnTopValues` coverage across dataset types.
- Manually verify in the dashboard/explorer UI: add a Group By dimension, expand Advanced Options, pin specific values, and confirm the chart only includes those values (no "other" bucket) and Max Values becomes disabled while pinned.

### Screenshots
<img width="409" height="328" alt="Screenshot 2026-07-30 at 9 38 56 AM" src="https://github.com/user-attachments/assets/773e0b9c-cc24-4b11-baaf-a92b2cac61ac" />
<img width="406" height="311" alt="Screenshot 2026-08-04 at 1 20 09 PM" src="https://github.com/user-attachments/assets/5efba1d9-c559-4346-9741-6bfa02154901" />
<img width="483" height="456" alt="Screenshot 2026-08-04 at 1 20 16 PM" src="https://github.com/user-attachments/assets/335485ec-532e-46de-8da3-a1f42bc66bc0" />
<img width="1166" height="405" alt="Screenshot 2026-07-27 at 4 05 35 PM" src="https://github.com/user-attachments/assets/260b0919-1245-404d-bccc-11413d79144d" />

