### PR TITLE
fix(ui): stop dropdown menus rendering stray separators

### DIFF
--- a/packages/front-end/components/Features/Rule.tsx
+++ b/packages/front-end/components/Features/Rule.tsx
@@ -1357,22 +1357,24 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
                       </>
                     )}
                     {!locked && (
-                      <DropdownMenuGroup>
+                      <>
                         <DropdownMenuSeparator />
-                        <DropdownMenuItem
-                          color="red"
-                          onClick={() => {
-                            setDeleteMode(
-                              defaultDraft !== null ? "existing" : "new",
-                            );
-                            setDeleteSelectedDraft(defaultDraft);
-                            setShowDeleteRuleModal(true);
-                            setDropdownOpen(false);
-                          }}
-                        >
-                          Delete rule
-                        </DropdownMenuItem>
-                      </DropdownMenuGroup>
+                        <DropdownMenuGroup>
+                          <DropdownMenuItem
+                            color="red"
+                            onClick={() => {
+                              setDeleteMode(
+                                defaultDraft !== null ? "existing" : "new",
+                              );
+                              setDeleteSelectedDraft(defaultDraft);
+                              setShowDeleteRuleModal(true);
+                              setDropdownOpen(false);
+                            }}
+                          >
+                            Delete rule
+                          </DropdownMenuItem>
+                        </DropdownMenuGroup>
+                      </>
                     )}
                   </DropdownMenu>
                 )}

--- a/packages/front-end/styles/global-radix-overrides.scss
+++ b/packages/front-end/styles/global-radix-overrides.scss
@@ -295,8 +295,12 @@
   &:last-child {
     display: none;
   }
+  // Adjacent to another separator, or bordering a group emptied by
+  // all-conditional items. The empty group is hidden above but stays in the
+  // DOM, so :first-child / :last-child cannot see past it in either direction.
   & + &,
-  .rt-BaseMenuGroup:empty + & {
+  .rt-BaseMenuGroup:empty + &,
+  &:has(+ .rt-BaseMenuGroup:empty:last-child) {
     display: none;
   }
 }

--- a/packages/front-end/styles/global-radix-overrides.scss
+++ b/packages/front-end/styles/global-radix-overrides.scss
@@ -281,6 +281,25 @@
   max-width: var(--radix-dropdown-menu-content-available-width);
   max-height: var(--radix-dropdown-menu-content-available-height);
 }
+// A menu separator is decorative and must sit between two visible things.
+// Consumers gate separators by hand against the conditions of the items around
+// them, and that bookkeeping drifts, leaving a stray divider at the top or
+// bottom of the menu (or a doubled one). Heal it structurally so no consumer
+// has to get the conditions exactly right. Hide separators with nothing
+// rendered on one side, and drop groups left empty by all-conditional items.
+.rt-BaseMenuGroup:empty {
+  display: none;
+}
+.rt-BaseMenuSeparator {
+  &:first-child,
+  &:last-child {
+    display: none;
+  }
+  & + &,
+  .rt-BaseMenuGroup:empty + & {
+    display: none;
+  }
+}
 .rt-BaseMenuItem {
   cursor: pointer !important;
   &[data-disabled] {


### PR DESCRIPTION
## What

The experiment results 3-dot menu (`ResultMoreMenu`) renders a stray divider line at the bottom of the menu, below "Add / remove metrics", when the experiment has no data yet.

## Root cause

Menu separators (`DropdownMenuSeparator`) are gated by hand in each consumer against the render conditions of the items around them. That bookkeeping drifts. In `ResultMoreMenu`, the trailing separator renders when `onAddToDashboard` is truthy, and `AnalysisSettingsSummary` always passes a truthy `onAddToDashboard`. But every item that would follow it ("Add to Dashboard", "Download notebook", "Export CSV") additionally needs `results`/`hasData`, which are absent before the first update. The separator renders with nothing after it.

An audit of all ~40 `DropdownMenuSeparator` usages found this is a class of bug, not a one-off: ~10 call sites can render a leading, trailing, or doubled separator, plus 5 more that trail an always-rendered-but-empty group.

## Fix

Heal it structurally rather than patching every call site. One global rule in `global-radix-overrides.scss` hides a separator that is the first/last child of its container, adjacent to another separator, or trailing a group left empty by all-conditional items, and drops the empty group itself.

`Rule.tsx` was the one place that authored a legitimate divider as the *first child of a group*, which the new rule would hide. Its separator is moved out to a between-group divider (matching every other consumer) so it stays visible.

Existing per-consumer separator gating is left in place; the rule is a structural safety net for the cases where that gating drifts.

## Verification

Built a throwaway render harness exercising the actual `DropdownMenu`/`DropdownMenuItem`/`DropdownMenuSeparator` components in a browser and read computed `display` off the real Radix DOM with the compiled stylesheet:

| case | separator outcome |
|---|---|
| trailing dangle (the reported bug) | stray one hidden, real divider kept |
| legitimate mid-menu divider | kept |
| leading / adjacent / empty-group-trailing | hidden |
| between-group divider (fixed `Rule.tsx` shape) | kept |

`pnpm --filter front-end type-check` passes.