### PR TITLE
feat(sdk-js): consume contextual bandit payload

### DIFF
--- a/packages/sdk-js/src/GrowthBook.ts
+++ b/packages/sdk-js/src/GrowthBook.ts
@@ -221,6 +221,9 @@ export class GrowthBook<
     if (data.savedGroups) {
       this._options.savedGroups = data.savedGroups;
     }
+    if (data.contextualBandits) {
+      this._options.contextualBandits = data.contextualBandits;
+    }
     if (data.experiments) {
       this._options.experiments = data.experiments;
       this._updateAllAutoExperiments();
@@ -253,6 +256,12 @@ export class GrowthBook<
     this._decryptedPayload = payload;
     if (payload.features) {
       this._options.features = payload.features;
+    }
+    if (payload.savedGroups) {
+      this._options.savedGroups = payload.savedGroups;
+    }
+    if (payload.contextualBandits) {
+      this._options.contextualBandits = payload.contextualBandits;
     }
     if (payload.experiments) {
       this._options.experiments = payload.experiments;
@@ -664,6 +673,7 @@ export class GrowthBook<
       enabled: this._options.enabled,
       qaMode: this._options.qaMode,
       savedGroups: this._options.savedGroups,
+      contextualBandits: this._options.contextualBandits,
       groups: this._options.groups,
       overrides: this._options.overrides,
       onExperimentEval: this._onExperimentEval,

--- a/packages/sdk-js/src/GrowthBookClient.ts
+++ b/packages/sdk-js/src/GrowthBookClient.ts
@@ -95,6 +95,9 @@ export class GrowthBookClient<
     if (data.savedGroups) {
       this._options.savedGroups = data.savedGroups;
     }
+    if (data.contextualBandits) {
+      this._options.contextualBandits = data.contextualBandits;
+    }
     this.ready = true;
   }
 
@@ -109,6 +112,12 @@ export class GrowthBookClient<
     this._decryptedPayload = payload;
     if (payload.features) {
       this._features = payload.features;
+    }
+    if (payload.savedGroups) {
+      this._options.savedGroups = payload.savedGroups;
+    }
+    if (payload.contextualBandits) {
+      this._options.contextualBandits = payload.contextualBandits;
     }
     if (payload.experiments) {
       this._experiments = payload.experiments;
@@ -287,6 +296,7 @@ export class GrowthBookClient<
       enabled: this._options.enabled,
       qaMode: this._options.qaMode,
       savedGroups: this._options.savedGroups,
+      contextualBandits: this._options.contextualBandits,
       forcedFeatureValues: this._options.forcedFeatureValues,
       forcedVariations: this._options.forcedVariations,
       trackingCallback: this._options.trackingCallback,

--- a/packages/sdk-js/src/core.ts
+++ b/packages/sdk-js/src/core.ts
@@ -1224,9 +1224,7 @@ function deriveStickyBucketIdentifierAttributes(
     const feature = features[id];
     if (feature.rules) {
       for (const rule of feature.rules) {
-        // Contextual bandit rules carry their variations under
-        // `contextualVariations`; match either so CB rules also register
-        // their hash/fallback attributes for sticky bucketing.
+        // Contextual bandit rules carry their variations under `contextualVariations`
         if (rule.variations || rule.contextualVariations) {
           attributes.add(rule.hashAttribute || "id");
           if (rule.fallbackAttribute) {

--- a/packages/sdk-js/src/core.ts
+++ b/packages/sdk-js/src/core.ts
@@ -1,5 +1,6 @@
 import {
   EvalContext,
+  ContextualBanditDefinition,
   FeatureDefinition,
   FeatureResult,
   Experiment,
@@ -23,6 +24,7 @@ import {
   chooseVariation,
   decrypt,
   getBucketRanges,
+  getEqualWeights,
   getQueryStringOverride,
   getUrlRegExp,
   hash,
@@ -318,7 +320,10 @@ export function evalFeature<V = unknown>(
 
         return getFeatureResult(ctx, id, rule.force as V, "force", rule.id);
       }
-      if (!rule.variations) {
+      // Contextual bandit rules carry their variations under
+      // `contextualVariations` so older SDKs skip them; read either field here.
+      const ruleVariations = rule.contextualVariations ?? rule.variations;
+      if (!ruleVariations) {
         process.env.NODE_ENV !== "production" &&
           ctx.global.log("Skip invalid rule", {
             id,
@@ -330,7 +335,7 @@ export function evalFeature<V = unknown>(
 
       // For experiment rules, run an experiment
       const exp: Experiment<V> = {
-        variations: rule.variations as [V, V, ...V[]],
+        variations: ruleVariations as [V, V, ...V[]],
         key: rule.key || id,
       };
       if ("coverage" in rule) exp.coverage = rule.coverage;
@@ -353,9 +358,15 @@ export function evalFeature<V = unknown>(
       if (rule.hashVersion) exp.hashVersion = rule.hashVersion;
       if (rule.filters) exp.filters = rule.filters;
       if (rule.condition) exp.condition = rule.condition;
+      if (rule.contextualBanditRef) {
+        buildContextualBanditExperiment(exp, rule.contextualBanditRef, id, ctx);
+      }
 
       // Only return a value if the user is part of the experiment
       const { result } = runExperiment(exp, id, ctx);
+      if (exp.contextualBandit && !(result.hashUsed && result.inExperiment)) {
+        delete exp.contextualBandit;
+      }
       ctx.global.onExperimentEval && ctx.global.onExperimentEval(exp, result);
       if (result.inExperiment && !result.passthrough) {
         return getFeatureResult(
@@ -829,6 +840,73 @@ function getTrackingUserContext(ctx: EvalContext): UserContextAttributes {
   };
 }
 
+function getContextualBanditLeaf(
+  cbDefinition: ContextualBanditDefinition,
+  ctx: EvalContext,
+): { leafId: number; weights: number[] } | null {
+  for (const context of cbDefinition.contexts || []) {
+    if (conditionPasses((context.condition || {}) as ConditionInterface, ctx)) {
+      return { leafId: context.leafId, weights: context.weights };
+    }
+  }
+
+  return null;
+}
+
+const CONTEXTUAL_BANDIT_FALLBACK_LEAF_ID = -1;
+
+function buildContextualBanditExperiment<T>(
+  experiment: Experiment<T>,
+  contextualBanditRef: string,
+  id: string,
+  ctx: EvalContext,
+): void {
+  const cbDefinition = ctx.global.contextualBandits?.[contextualBanditRef];
+  if (!cbDefinition) {
+    process.env.NODE_ENV !== "production" &&
+      ctx.global.log(
+        "Contextual bandit ref not found in payload, using aggregate weights",
+        { id, contextualBanditRef },
+      );
+    return;
+  }
+
+  let leaf: { leafId: number; weights: number[] } | null = null;
+  if (cbDefinition.contexts && cbDefinition.contexts.length) {
+    try {
+      leaf = getContextualBanditLeaf(cbDefinition, ctx);
+    } catch (e) {
+      process.env.NODE_ENV !== "production" &&
+        ctx.global.log(
+          "Contextual bandit leaf selection threw, using fallback weights",
+          { id, contextualBanditRef, error: e },
+        );
+    }
+  }
+
+  if (leaf) {
+    experiment.weights = leaf.weights;
+    experiment.contextualBandit = {
+      leafId: leaf.leafId,
+      variationWeights: leaf.weights,
+      banditVersion: cbDefinition.banditVersion,
+    };
+    return;
+  }
+
+  process.env.NODE_ENV !== "production" &&
+    ctx.global.log(
+      "Contextual bandit: no matching leaf, using fallback weights",
+      { id, contextualBanditRef },
+    );
+  experiment.contextualBandit = {
+    leafId: CONTEXTUAL_BANDIT_FALLBACK_LEAF_ID,
+    variationWeights:
+      experiment.weights ?? getEqualWeights(experiment.variations.length),
+    banditVersion: cbDefinition.banditVersion,
+  };
+}
+
 function conditionPasses(
   condition: ConditionInterface,
   ctx: EvalContext,
@@ -921,6 +999,13 @@ export function getExperimentResult<T>(
   if (meta.name) res.name = meta.name;
   if (bucket !== undefined) res.bucket = bucket;
   if (meta.passthrough) res.passthrough = meta.passthrough;
+
+  const cb = experiment.contextualBandit;
+  if (cb && hashUsed && inExperiment) {
+    res.leafId = cb.leafId;
+    res.variationWeights = cb.variationWeights;
+    if (cb.banditVersion !== undefined) res.banditVersion = cb.banditVersion;
+  }
 
   return res;
 }
@@ -1139,7 +1224,10 @@ function deriveStickyBucketIdentifierAttributes(
     const feature = features[id];
     if (feature.rules) {
       for (const rule of feature.rules) {
-        if (rule.variations) {
+        // Contextual bandit rules carry their variations under
+        // `contextualVariations`; match either so CB rules also register
+        // their hash/fallback attributes for sticky bucketing.
+        if (rule.variations || rule.contextualVariations) {
           attributes.add(rule.hashAttribute || "id");
           if (rule.fallbackAttribute) {
             attributes.add(rule.fallbackAttribute);
@@ -1215,6 +1303,16 @@ export async function decryptPayload(
       console.error(e);
     }
     delete data.encryptedSavedGroups;
+  }
+  if (data.encryptedContextualBandits) {
+    try {
+      data.contextualBandits = JSON.parse(
+        await decrypt(data.encryptedContextualBandits, decryptionKey, subtle),
+      );
+    } catch (e) {
+      console.error(e);
+    }
+    delete data.encryptedContextualBandits;
   }
   return data;
 }

--- a/packages/sdk-js/src/core.ts
+++ b/packages/sdk-js/src/core.ts
@@ -429,6 +429,13 @@ export function runExperiment<T>(
   // 2.5. Merge in experiment overrides from the context
   experiment = mergeOverrides(experiment, ctx);
 
+  if (experiment.contextualBandit && experiment.weights) {
+    experiment.contextualBandit = {
+      ...experiment.contextualBandit,
+      variationWeights: experiment.weights,
+    };
+  }
+
   // 2.6 New, more powerful URL targeting
   if (
     experiment.urlPatterns &&

--- a/packages/sdk-js/src/types/growthbook.ts
+++ b/packages/sdk-js/src/types/growthbook.ts
@@ -48,7 +48,27 @@ export type FeatureRule<T = any> = {
     experiment: Experiment<T>;
     result: Result<T>;
   }>;
+  contextualBanditRef?: string;
+  // Contextual bandit rules carry their variations here instead of under
+  // `variations` so that older SDKs (which key off `variations` to detect an
+  // experiment rule) skip the rule entirely rather than mis-bucketing users
+  // into an even split. CB-capable SDKs read this into the experiment.
+  contextualVariations?: T[];
 };
+
+export type ContextualBanditDefinition = {
+  banditVersion?: number;
+  contexts: {
+    leafId: number;
+    condition: Record<string, unknown>;
+    weights: number[];
+  }[];
+};
+
+export type ContextualBanditDefinitions = Record<
+  string,
+  ContextualBanditDefinition
+>;
 
 export interface FeatureDefinition<T = any> {
   defaultValue?: T;
@@ -111,6 +131,7 @@ export type Experiment<T> = {
   minBucketVersion?: number;
   active?: boolean;
   persistQueryString?: boolean;
+  contextualBandit?: CBContext;
   /** @deprecated */
   status?: ExperimentStatus;
   /** @deprecated */
@@ -152,7 +173,16 @@ export interface Result<T> {
   hashValue: string;
   featureId: string | null;
   stickyBucketUsed?: boolean;
+  leafId?: number;
+  variationWeights?: number[];
+  banditVersion?: number;
 }
+
+export type CBContext = {
+  leafId: number;
+  variationWeights: number[];
+  banditVersion?: number;
+};
 
 export type Attributes = Record<string, any>;
 
@@ -276,6 +306,7 @@ export type Options = {
   antiFlickerTimeout?: number;
   applyDomChangesCallback?: ApplyDomChangesCallback;
   savedGroups?: SavedGroupsValues;
+  contextualBandits?: ContextualBanditDefinitions;
   plugins?: Plugin[];
 };
 
@@ -302,6 +333,7 @@ export type ClientOptions = {
   clientKey?: string;
   decryptionKey?: string;
   savedGroups?: SavedGroupsValues;
+  contextualBandits?: ContextualBanditDefinitions;
   plugins?: Plugin[];
 };
 
@@ -313,6 +345,7 @@ export type GlobalContext = {
   enabled?: boolean;
   qaMode?: boolean;
   savedGroups?: SavedGroupsValues;
+  contextualBandits?: ContextualBanditDefinitions;
   forcedVariations?: Record<string, number>;
   forcedFeatureValues?: Map<string, any>;
   trackingCallback?: TrackingCallbackWithUser;
@@ -449,6 +482,8 @@ export type FeatureApiResponse = {
   encryptedExperiments?: string;
   savedGroups?: SavedGroupsValues;
   encryptedSavedGroups?: string;
+  contextualBandits?: ContextualBanditDefinitions;
+  encryptedContextualBandits?: string;
 };
 
 // Alias

--- a/packages/sdk-js/src/types/growthbook.ts
+++ b/packages/sdk-js/src/types/growthbook.ts
@@ -49,10 +49,6 @@ export type FeatureRule<T = any> = {
     result: Result<T>;
   }>;
   contextualBanditRef?: string;
-  // Contextual bandit rules carry their variations here instead of under
-  // `variations` so that older SDKs (which key off `variations` to detect an
-  // experiment rule) skip the rule entirely rather than mis-bucketing users
-  // into an even split. CB-capable SDKs read this into the experiment.
   contextualVariations?: T[];
 };
 

--- a/packages/sdk-js/test/cases.json
+++ b/packages/sdk-js/test/cases.json
@@ -1,5 +1,5 @@
 {
-  "specVersion": "0.7.1",
+  "specVersion": "0.8.0",
   "evalCondition": [
     [
       "$not - pass",
@@ -5173,6 +5173,541 @@
         },
         "ruleId": ""
       }
+    ],
+    [
+      "CB rule with empty contexts (explore) buckets on marginal weights with fallback leaf -1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "pro"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [1, 0],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": []
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094,
+          "leafId": -1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule with no contexts key falls back to marginal weights (fallback leaf -1)",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [1, 0],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094,
+          "leafId": -1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule with empty contexts uses marginal weights (fallback leaf -1)",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0, 1],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": []
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [0, 1],
+            "banditVersion": 7
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [0, 1],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094,
+          "leafId": -1,
+          "variationWeights": [0, 1],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "multi-armed-bandit type is treated as a standard experiment",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashVersion": 2,
+                "coverage": 1,
+                "variations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "type": "multi-armed-bandit"
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094
+        }
+      }
+    ],
+    [
+      "standard type is treated as a standard experiment",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashVersion": 2,
+                "coverage": 1,
+                "variations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "type": "standard"
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094
+        }
+      }
+    ],
+    [
+      "unknown bandit fields on a non-CB rule are ignored",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashVersion": 2,
+                "coverage": 1,
+                "variations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "banditVersion": 9
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094
+        }
+      }
+    ],
+    [
+      "CB rule with empty contexts is overridden by forced variation like a normal experiment",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "pro"
+        },
+        "forcedVariations": {
+          "promo_bandit": 1
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": []
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
+      }
     ]
   ],
   "run": [
@@ -7261,6 +7796,3030 @@
           "urlWithParams": "http://www.example.com/home-new-new"
         }
       ]
+    ]
+  ],
+  "contextualBandit": [
+    [
+      "single catch-all leaf routes and sets CB result fields",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "anything"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [1, 0]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "matches the first (specific) leaf",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "falls through to the catch-all leaf",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "free"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": 2,
+            "variationWeights": [0, 1],
+            "banditVersion": 7
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [0, 1],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094,
+          "leafId": 2,
+          "variationWeights": [0, 1],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf condition operators - $in matches",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "free",
+          "cartValue": 100
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": {
+                    "$in": ["free", "basic"]
+                  }
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {
+                  "cartValue": {
+                    "$gte": 500
+                  }
+                },
+                "weights": [0, 1]
+              },
+              {
+                "leafId": 3,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf condition operators - $gte matches second leaf",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "pro",
+          "cartValue": 600
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": {
+                    "$in": ["free", "basic"]
+                  }
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {
+                  "cartValue": {
+                    "$gte": 500
+                  }
+                },
+                "weights": [0, 1]
+              },
+              {
+                "leafId": 3,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": 2,
+            "variationWeights": [0, 1],
+            "banditVersion": 7
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [0, 1],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094,
+          "leafId": 2,
+          "variationWeights": [0, 1],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "first-match-wins when multiple leaf conditions match",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "pro",
+          "country": "US"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "pro"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {
+                  "country": "US"
+                },
+                "weights": [0, 1]
+              },
+              {
+                "leafId": 3,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "missing attribute used by a leaf condition falls into the catch-all leaf",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": 2,
+            "variationWeights": [0, 1],
+            "banditVersion": 7
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [0, 1],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094,
+          "leafId": 2,
+          "variationWeights": [0, 1],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule outer condition fails, a following force rule applies",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "condition": {
+                  "country": "US"
+                },
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              },
+              {
+                "force": "forced"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "forced",
+        "on": true,
+        "off": false,
+        "source": "force",
+        "ruleId": ""
+      }
+    ],
+    [
+      "outer condition fails - CB rule skipped",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "condition": {
+                  "country": "US"
+                },
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "coverage excludes user even though a leaf matched",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 0.01,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "three-arm CB leaf routes with positional weights",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["c0", "c1", "c2"],
+                "weights": [0.34, 0.33, 0.33],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  },
+                  {
+                    "key": "2"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [0, 0, 1]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0.34, 0.33, 0.33]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "c2",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0, 0, 1],
+            "banditVersion": 7
+          },
+          "variations": ["c0", "c1", "c2"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [0, 0, 1],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            },
+            {
+              "key": "2"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "2",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 2,
+          "value": "c2",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094,
+          "leafId": 1,
+          "variationWeights": [0, 0, 1],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB rule as a later rule in the list",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise",
+          "country": "US"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "first",
+                "seed": "first",
+                "hashVersion": 2,
+                "coverage": 1,
+                "variations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "condition": {
+                  "country": "CA"
+                }
+              },
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with even weights distributes users - id 1",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094,
+          "leafId": 1,
+          "variationWeights": [0.5, 0.5],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with even weights distributes users - id 2",
+      {
+        "attributes": {
+          "id": "2"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "2",
+          "stickyBucketUsed": false,
+          "bucket": 0.7366,
+          "leafId": 1,
+          "variationWeights": [0.5, 0.5],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with even weights distributes users - id 3",
+      {
+        "attributes": {
+          "id": "3"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [0.5, 0.5]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "3",
+          "stickyBucketUsed": false,
+          "bucket": 0.3854,
+          "leafId": 1,
+          "variationWeights": [0.5, 0.5],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with uneven weights distributes users - id 1",
+      {
+        "attributes": {
+          "id": "1"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [0.1, 0.9]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.1, 0.9],
+            "banditVersion": 7
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [0.1, 0.9],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094,
+          "leafId": 1,
+          "variationWeights": [0.1, 0.9],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "leaf with uneven weights distributes users - id 4",
+      {
+        "attributes": {
+          "id": "4"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [0.1, 0.9]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.1, 0.9],
+            "banditVersion": 7
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [0.1, 0.9],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "4",
+          "stickyBucketUsed": false,
+          "bucket": 0.1604,
+          "leafId": 1,
+          "variationWeights": [0.1, 0.9],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "CB empty hashAttribute - not in experiment",
+      {
+        "attributes": {
+          "id": "",
+          "plan": "enterprise"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB null hashAttribute - not in experiment",
+      {
+        "attributes": {
+          "id": null,
+          "plan": "enterprise"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB missing hashAttribute - not in experiment",
+      {
+        "attributes": {
+          "plan": "enterprise"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB buckets on a custom hashAttribute",
+      {
+        "attributes": {
+          "anonId": "123",
+          "plan": "enterprise"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "anonId",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "anonId",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "anonId",
+          "hashValue": "123",
+          "stickyBucketUsed": false,
+          "bucket": 0.2512,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "forcedVariations from context overrides CB routing",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "forcedVariations": {
+          "promo_bandit": 1
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
+      }
+    ],
+    [
+      "querystring force overrides CB routing",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "url": "https://example.com/?promo_bandit=1",
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "treatment",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "1",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 1,
+          "value": "treatment",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
+      }
+    ],
+    [
+      "CB skipped in QA mode",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "qaMode": true,
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "CB in QA mode if forced in context",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "qaMode": true,
+        "forcedVariations": {
+          "promo_bandit": 0
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": false,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false
+        }
+      }
+    ],
+    [
+      "CB rule when globally disabled",
+      {
+        "enabled": false,
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "JSON variation values with CB routing",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": {
+              "color": "none"
+            },
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": [
+                  {
+                    "color": "blue"
+                  },
+                  {
+                    "color": "green"
+                  }
+                ],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": {
+          "color": "blue"
+        },
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          },
+          "variations": [
+            {
+              "color": "blue"
+            },
+            {
+              "color": "green"
+            }
+          ],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": {
+            "color": "blue"
+          },
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "single-variation CB rule is invalid - not in experiment",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control"],
+                "weights": [1],
+                "meta": [
+                  {
+                    "key": "0"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [1]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "outer condition passes - CB routes",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise",
+          "country": "US"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "condition": {
+                  "country": "US"
+                },
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2,
+          "condition": {
+            "country": "US"
+          }
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "coverage distribution within a leaf - id 1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 0.5,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 0.5,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094,
+          "leafId": 1,
+          "variationWeights": [1, 0],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "coverage distribution within a leaf - id 8",
+      {
+        "attributes": {
+          "id": "8",
+          "plan": "enterprise"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 0.5,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "dangling contextualBanditRef uses marginal weights with no CB metadata",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094
+        }
+      }
+    ],
+    [
+      "empty contexts array uses marginal weights with fallback leaf -1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": []
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094,
+          "leafId": -1,
+          "variationWeights": [0.5, 0.5],
+          "banditVersion": 7
+        }
+      }
+    ],
+    [
+      "banditVersion omitted from definition is absent from result",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "enterprise"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {},
+                "weights": [1, 0]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0]
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [1, 0],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094,
+          "leafId": 1,
+          "variationWeights": [1, 0]
+        }
+      }
+    ],
+    [
+      "required attribute present but no leaf matches - fallback leaf -1",
+      {
+        "attributes": {
+          "id": "1",
+          "plan": "free"
+        },
+        "features": {
+          "promo": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "promo_bandit",
+                "seed": "promo_bandit",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 1,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb_promo_bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb_promo_bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              }
+            ]
+          }
+        }
+      },
+      "promo",
+      {
+        "value": "control",
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "ruleId": "",
+        "experiment": {
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          },
+          "variations": ["control", "treatment"],
+          "key": "promo_bandit",
+          "coverage": 1,
+          "weights": [0.5, 0.5],
+          "hashAttribute": "id",
+          "meta": [
+            {
+              "key": "0"
+            },
+            {
+              "key": "1"
+            }
+          ],
+          "seed": "promo_bandit",
+          "hashVersion": 2
+        },
+        "experimentResult": {
+          "key": "0",
+          "featureId": "promo",
+          "inExperiment": true,
+          "hashUsed": true,
+          "variationId": 0,
+          "value": "control",
+          "hashAttribute": "id",
+          "hashValue": "1",
+          "stickyBucketUsed": false,
+          "bucket": 0.3094,
+          "leafId": -1,
+          "variationWeights": [0.5, 0.5],
+          "banditVersion": 7
+        }
+      }
     ]
   ]
 }

--- a/packages/sdk-js/test/cases.json
+++ b/packages/sdk-js/test/cases.json
@@ -5182,12 +5182,12 @@
           "plan": "pro"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -5201,19 +5201,19 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": []
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "control",
         "on": true,
@@ -5221,13 +5221,8 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": -1,
-            "variationWeights": [1, 0],
-            "banditVersion": 7
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [1, 0],
           "hashAttribute": "id",
@@ -5239,12 +5234,17 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
           "key": "0",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
           "variationId": 0,
@@ -5252,7 +5252,7 @@
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094,
+          "bucket": 0.5305,
           "leafId": -1,
           "variationWeights": [1, 0],
           "banditVersion": 7
@@ -5266,12 +5266,12 @@
           "id": "1"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -5285,18 +5285,18 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "control",
         "on": true,
@@ -5304,13 +5304,8 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": -1,
-            "variationWeights": [1, 0],
-            "banditVersion": 7
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [1, 0],
           "hashAttribute": "id",
@@ -5322,12 +5317,17 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
           "key": "0",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
           "variationId": 0,
@@ -5335,7 +5335,7 @@
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094,
+          "bucket": 0.5305,
           "leafId": -1,
           "variationWeights": [1, 0],
           "banditVersion": 7
@@ -5349,12 +5349,12 @@
           "id": "1"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -5368,19 +5368,19 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": []
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "treatment",
         "on": true,
@@ -5388,13 +5388,8 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": -1,
-            "variationWeights": [0, 1],
-            "banditVersion": 7
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [0, 1],
           "hashAttribute": "id",
@@ -5406,12 +5401,17 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [0, 1],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
           "key": "1",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
           "variationId": 1,
@@ -5419,7 +5419,7 @@
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094,
+          "bucket": 0.5305,
           "leafId": -1,
           "variationWeights": [0, 1],
           "banditVersion": 7
@@ -5433,12 +5433,12 @@
           "id": "1"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashVersion": 2,
                 "coverage": 1,
                 "variations": ["control", "treatment"],
@@ -5457,16 +5457,16 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
-        "value": "control",
+        "value": "treatment",
         "on": true,
         "off": false,
         "source": "experiment",
         "ruleId": "",
         "experiment": {
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [0.5, 0.5],
           "meta": [
@@ -5477,20 +5477,20 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
+          "seed": "bandit-exp",
           "hashVersion": 2
         },
         "experimentResult": {
-          "key": "0",
-          "featureId": "promo",
+          "key": "1",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
-          "variationId": 0,
-          "value": "control",
+          "variationId": 1,
+          "value": "treatment",
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094
+          "bucket": 0.5305
         }
       }
     ],
@@ -5501,12 +5501,12 @@
           "id": "1"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashVersion": 2,
                 "coverage": 1,
                 "variations": ["control", "treatment"],
@@ -5525,16 +5525,16 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
-        "value": "control",
+        "value": "treatment",
         "on": true,
         "off": false,
         "source": "experiment",
         "ruleId": "",
         "experiment": {
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [0.5, 0.5],
           "meta": [
@@ -5545,20 +5545,20 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
+          "seed": "bandit-exp",
           "hashVersion": 2
         },
         "experimentResult": {
-          "key": "0",
-          "featureId": "promo",
+          "key": "1",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
-          "variationId": 0,
-          "value": "control",
+          "variationId": 1,
+          "value": "treatment",
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094
+          "bucket": 0.5305
         }
       }
     ],
@@ -5569,12 +5569,12 @@
           "id": "1"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashVersion": 2,
                 "coverage": 1,
                 "variations": ["control", "treatment"],
@@ -5593,16 +5593,16 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
-        "value": "control",
+        "value": "treatment",
         "on": true,
         "off": false,
         "source": "experiment",
         "ruleId": "",
         "experiment": {
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [0.5, 0.5],
           "meta": [
@@ -5613,20 +5613,20 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
+          "seed": "bandit-exp",
           "hashVersion": 2
         },
         "experimentResult": {
-          "key": "0",
-          "featureId": "promo",
+          "key": "1",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
-          "variationId": 0,
-          "value": "control",
+          "variationId": 1,
+          "value": "treatment",
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094
+          "bucket": 0.5305
         }
       }
     ],
@@ -5638,15 +5638,15 @@
           "plan": "pro"
         },
         "forcedVariations": {
-          "promo_bandit": 1
+          "bandit-exp": 1
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -5660,19 +5660,19 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": []
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "treatment",
         "on": true,
@@ -5681,7 +5681,7 @@
         "ruleId": "",
         "experiment": {
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [0.5, 0.5],
           "hashAttribute": "id",
@@ -5693,12 +5693,12 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
+          "seed": "bandit-exp",
           "hashVersion": 2
         },
         "experimentResult": {
           "key": "1",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": false,
           "variationId": 1,
@@ -7807,12 +7807,12 @@
           "plan": "anything"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -7826,13 +7826,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -7844,7 +7844,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "control",
         "on": true,
@@ -7852,13 +7852,8 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": 1,
-            "variationWeights": [1, 0],
-            "banditVersion": 7
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [1, 0],
           "hashAttribute": "id",
@@ -7870,12 +7865,17 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
           "key": "0",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
           "variationId": 0,
@@ -7883,7 +7883,7 @@
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094,
+          "bucket": 0.5305,
           "leafId": 1,
           "variationWeights": [1, 0],
           "banditVersion": 7
@@ -7898,12 +7898,12 @@
           "plan": "enterprise"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -7917,13 +7917,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -7942,7 +7942,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "control",
         "on": true,
@@ -7950,13 +7950,8 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": 1,
-            "variationWeights": [1, 0],
-            "banditVersion": 7
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [1, 0],
           "hashAttribute": "id",
@@ -7968,12 +7963,17 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
           "key": "0",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
           "variationId": 0,
@@ -7981,7 +7981,7 @@
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094,
+          "bucket": 0.5305,
           "leafId": 1,
           "variationWeights": [1, 0],
           "banditVersion": 7
@@ -7996,12 +7996,12 @@
           "plan": "free"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -8015,13 +8015,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -8040,7 +8040,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "treatment",
         "on": true,
@@ -8048,13 +8048,8 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": 2,
-            "variationWeights": [0, 1],
-            "banditVersion": 7
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [0, 1],
           "hashAttribute": "id",
@@ -8066,12 +8061,17 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 2,
+            "variationWeights": [0, 1],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
           "key": "1",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
           "variationId": 1,
@@ -8079,7 +8079,7 @@
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094,
+          "bucket": 0.5305,
           "leafId": 2,
           "variationWeights": [0, 1],
           "banditVersion": 7
@@ -8095,12 +8095,12 @@
           "cartValue": 100
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -8114,13 +8114,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -8150,7 +8150,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "control",
         "on": true,
@@ -8158,13 +8158,8 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": 1,
-            "variationWeights": [1, 0],
-            "banditVersion": 7
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [1, 0],
           "hashAttribute": "id",
@@ -8176,12 +8171,17 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
           "key": "0",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
           "variationId": 0,
@@ -8189,7 +8189,7 @@
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094,
+          "bucket": 0.5305,
           "leafId": 1,
           "variationWeights": [1, 0],
           "banditVersion": 7
@@ -8205,12 +8205,12 @@
           "cartValue": 600
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -8224,13 +8224,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -8260,7 +8260,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "treatment",
         "on": true,
@@ -8268,13 +8268,8 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": 2,
-            "variationWeights": [0, 1],
-            "banditVersion": 7
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [0, 1],
           "hashAttribute": "id",
@@ -8286,12 +8281,17 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 2,
+            "variationWeights": [0, 1],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
           "key": "1",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
           "variationId": 1,
@@ -8299,7 +8299,7 @@
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094,
+          "bucket": 0.5305,
           "leafId": 2,
           "variationWeights": [0, 1],
           "banditVersion": 7
@@ -8315,12 +8315,12 @@
           "country": "US"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -8334,13 +8334,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -8366,7 +8366,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "control",
         "on": true,
@@ -8374,13 +8374,8 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": 1,
-            "variationWeights": [1, 0],
-            "banditVersion": 7
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [1, 0],
           "hashAttribute": "id",
@@ -8392,12 +8387,17 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
           "key": "0",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
           "variationId": 0,
@@ -8405,7 +8405,7 @@
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094,
+          "bucket": 0.5305,
           "leafId": 1,
           "variationWeights": [1, 0],
           "banditVersion": 7
@@ -8419,12 +8419,12 @@
           "id": "1"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -8438,13 +8438,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -8463,7 +8463,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "treatment",
         "on": true,
@@ -8471,13 +8471,8 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": 2,
-            "variationWeights": [0, 1],
-            "banditVersion": 7
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [0, 1],
           "hashAttribute": "id",
@@ -8489,12 +8484,17 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 2,
+            "variationWeights": [0, 1],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
           "key": "1",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
           "variationId": 1,
@@ -8502,7 +8502,7 @@
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094,
+          "bucket": 0.5305,
           "leafId": 2,
           "variationWeights": [0, 1],
           "banditVersion": 7
@@ -8516,12 +8516,12 @@
           "id": "1"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -8538,7 +8538,7 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               },
               {
                 "force": "forced"
@@ -8547,7 +8547,7 @@
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -8566,7 +8566,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "forced",
         "on": true,
@@ -8583,12 +8583,12 @@
           "plan": "enterprise"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -8605,13 +8605,13 @@
                 "condition": {
                   "country": "US"
                 },
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -8630,7 +8630,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "default",
         "on": true,
@@ -8647,12 +8647,12 @@
           "plan": "enterprise"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 0.01,
@@ -8666,13 +8666,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -8691,7 +8691,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "default",
         "on": true,
@@ -8708,12 +8708,12 @@
           "plan": "enterprise"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -8730,13 +8730,13 @@
                     "key": "2"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -8755,7 +8755,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "c2",
         "on": true,
@@ -8763,13 +8763,8 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": 1,
-            "variationWeights": [0, 0, 1],
-            "banditVersion": 7
-          },
           "variations": ["c0", "c1", "c2"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [0, 0, 1],
           "hashAttribute": "id",
@@ -8784,12 +8779,17 @@
               "key": "2"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0, 0, 1],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
           "key": "2",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
           "variationId": 2,
@@ -8797,7 +8797,7 @@
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094,
+          "bucket": 0.5305,
           "leafId": 1,
           "variationWeights": [0, 0, 1],
           "banditVersion": 7
@@ -8813,7 +8813,7 @@
           "country": "US"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
@@ -8836,8 +8836,8 @@
                 }
               },
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -8851,13 +8851,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -8876,7 +8876,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "control",
         "on": true,
@@ -8884,13 +8884,8 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": 1,
-            "variationWeights": [1, 0],
-            "banditVersion": 7
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [1, 0],
           "hashAttribute": "id",
@@ -8902,12 +8897,17 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
           "key": "0",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
           "variationId": 0,
@@ -8915,7 +8915,7 @@
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094,
+          "bucket": 0.5305,
           "leafId": 1,
           "variationWeights": [1, 0],
           "banditVersion": 7
@@ -8929,12 +8929,12 @@
           "id": "1"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -8948,13 +8948,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -8966,21 +8966,16 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
-        "value": "control",
+        "value": "treatment",
         "on": true,
         "off": false,
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": 1,
-            "variationWeights": [0.5, 0.5],
-            "banditVersion": 7
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [0.5, 0.5],
           "hashAttribute": "id",
@@ -8992,20 +8987,25 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
-          "key": "0",
-          "featureId": "promo",
+          "key": "1",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
-          "variationId": 0,
-          "value": "control",
+          "variationId": 1,
+          "value": "treatment",
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094,
+          "bucket": 0.5305,
           "leafId": 1,
           "variationWeights": [0.5, 0.5],
           "banditVersion": 7
@@ -9019,12 +9019,12 @@
           "id": "2"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -9038,13 +9038,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -9056,7 +9056,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "treatment",
         "on": true,
@@ -9064,13 +9064,8 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": 1,
-            "variationWeights": [0.5, 0.5],
-            "banditVersion": 7
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [0.5, 0.5],
           "hashAttribute": "id",
@@ -9082,12 +9077,17 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
           "key": "1",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
           "variationId": 1,
@@ -9095,7 +9095,7 @@
           "hashAttribute": "id",
           "hashValue": "2",
           "stickyBucketUsed": false,
-          "bucket": 0.7366,
+          "bucket": 0.9374,
           "leafId": 1,
           "variationWeights": [0.5, 0.5],
           "banditVersion": 7
@@ -9109,12 +9109,12 @@
           "id": "3"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -9128,13 +9128,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -9146,21 +9146,16 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
-        "value": "control",
+        "value": "treatment",
         "on": true,
         "off": false,
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": 1,
-            "variationWeights": [0.5, 0.5],
-            "banditVersion": 7
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [0.5, 0.5],
           "hashAttribute": "id",
@@ -9172,20 +9167,25 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
-          "key": "0",
-          "featureId": "promo",
+          "key": "1",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
-          "variationId": 0,
-          "value": "control",
+          "variationId": 1,
+          "value": "treatment",
           "hashAttribute": "id",
           "hashValue": "3",
           "stickyBucketUsed": false,
-          "bucket": 0.3854,
+          "bucket": 0.8606,
           "leafId": 1,
           "variationWeights": [0.5, 0.5],
           "banditVersion": 7
@@ -9199,12 +9199,12 @@
           "id": "1"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -9218,13 +9218,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -9236,7 +9236,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "treatment",
         "on": true,
@@ -9244,13 +9244,8 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": 1,
-            "variationWeights": [0.1, 0.9],
-            "banditVersion": 7
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [0.1, 0.9],
           "hashAttribute": "id",
@@ -9262,12 +9257,17 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.1, 0.9],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
           "key": "1",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
           "variationId": 1,
@@ -9275,7 +9275,7 @@
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094,
+          "bucket": 0.5305,
           "leafId": 1,
           "variationWeights": [0.1, 0.9],
           "banditVersion": 7
@@ -9289,12 +9289,12 @@
           "id": "4"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -9308,13 +9308,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -9326,7 +9326,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "treatment",
         "on": true,
@@ -9334,13 +9334,8 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": 1,
-            "variationWeights": [0.1, 0.9],
-            "banditVersion": 7
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [0.1, 0.9],
           "hashAttribute": "id",
@@ -9352,12 +9347,17 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [0.1, 0.9],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
           "key": "1",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
           "variationId": 1,
@@ -9365,7 +9365,7 @@
           "hashAttribute": "id",
           "hashValue": "4",
           "stickyBucketUsed": false,
-          "bucket": 0.1604,
+          "bucket": 0.4818,
           "leafId": 1,
           "variationWeights": [0.1, 0.9],
           "banditVersion": 7
@@ -9380,12 +9380,12 @@
           "plan": "enterprise"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -9399,13 +9399,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -9424,7 +9424,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "default",
         "on": true,
@@ -9441,12 +9441,12 @@
           "plan": "enterprise"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -9460,13 +9460,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -9485,7 +9485,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "default",
         "on": true,
@@ -9501,12 +9501,12 @@
           "plan": "enterprise"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -9520,13 +9520,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -9545,7 +9545,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "default",
         "on": true,
@@ -9562,12 +9562,12 @@
           "plan": "enterprise"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "anonId",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -9581,13 +9581,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -9606,7 +9606,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "control",
         "on": true,
@@ -9614,13 +9614,8 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": 1,
-            "variationWeights": [1, 0],
-            "banditVersion": 7
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [1, 0],
           "hashAttribute": "anonId",
@@ -9632,12 +9627,17 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
           "key": "0",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
           "variationId": 0,
@@ -9645,7 +9645,7 @@
           "hashAttribute": "anonId",
           "hashValue": "123",
           "stickyBucketUsed": false,
-          "bucket": 0.2512,
+          "bucket": 0.0484,
           "leafId": 1,
           "variationWeights": [1, 0],
           "banditVersion": 7
@@ -9660,15 +9660,15 @@
           "plan": "enterprise"
         },
         "forcedVariations": {
-          "promo_bandit": 1
+          "bandit-exp": 1
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -9682,13 +9682,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -9707,7 +9707,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "treatment",
         "on": true,
@@ -9716,7 +9716,7 @@
         "ruleId": "",
         "experiment": {
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [1, 0],
           "hashAttribute": "id",
@@ -9728,12 +9728,12 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
+          "seed": "bandit-exp",
           "hashVersion": 2
         },
         "experimentResult": {
           "key": "1",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": false,
           "variationId": 1,
@@ -9751,14 +9751,14 @@
           "id": "1",
           "plan": "enterprise"
         },
-        "url": "https://example.com/?promo_bandit=1",
+        "url": "https://example.com/?bandit-exp=1",
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -9772,13 +9772,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -9797,7 +9797,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "treatment",
         "on": true,
@@ -9806,7 +9806,7 @@
         "ruleId": "",
         "experiment": {
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [1, 0],
           "hashAttribute": "id",
@@ -9818,12 +9818,12 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
+          "seed": "bandit-exp",
           "hashVersion": 2
         },
         "experimentResult": {
           "key": "1",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": false,
           "variationId": 1,
@@ -9843,12 +9843,12 @@
         },
         "qaMode": true,
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -9862,13 +9862,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -9887,7 +9887,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "default",
         "on": true,
@@ -9905,15 +9905,15 @@
         },
         "qaMode": true,
         "forcedVariations": {
-          "promo_bandit": 0
+          "bandit-exp": 0
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -9927,13 +9927,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -9952,7 +9952,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "control",
         "on": true,
@@ -9961,7 +9961,7 @@
         "ruleId": "",
         "experiment": {
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [1, 0],
           "hashAttribute": "id",
@@ -9973,12 +9973,12 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
+          "seed": "bandit-exp",
           "hashVersion": 2
         },
         "experimentResult": {
           "key": "0",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": false,
           "variationId": 0,
@@ -9998,12 +9998,12 @@
           "plan": "enterprise"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -10017,13 +10017,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -10042,7 +10042,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "default",
         "on": true,
@@ -10059,14 +10059,14 @@
           "plan": "enterprise"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": {
               "color": "none"
             },
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -10087,13 +10087,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -10112,7 +10112,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": {
           "color": "blue"
@@ -10122,11 +10122,6 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": 1,
-            "variationWeights": [1, 0],
-            "banditVersion": 7
-          },
           "variations": [
             {
               "color": "blue"
@@ -10135,7 +10130,7 @@
               "color": "green"
             }
           ],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [1, 0],
           "hashAttribute": "id",
@@ -10147,12 +10142,17 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
           "key": "0",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
           "variationId": 0,
@@ -10162,7 +10162,7 @@
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094,
+          "bucket": 0.5305,
           "leafId": 1,
           "variationWeights": [1, 0],
           "banditVersion": 7
@@ -10177,12 +10177,12 @@
           "plan": "enterprise"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -10193,13 +10193,13 @@
                     "key": "0"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -10211,7 +10211,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "default",
         "on": true,
@@ -10229,12 +10229,12 @@
           "country": "US"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -10251,13 +10251,13 @@
                 "condition": {
                   "country": "US"
                 },
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -10276,7 +10276,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "control",
         "on": true,
@@ -10284,13 +10284,8 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": 1,
-            "variationWeights": [1, 0],
-            "banditVersion": 7
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [1, 0],
           "hashAttribute": "id",
@@ -10302,15 +10297,20 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
+          "seed": "bandit-exp",
           "hashVersion": 2,
           "condition": {
             "country": "US"
+          },
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
           }
         },
         "experimentResult": {
           "key": "0",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
           "variationId": 0,
@@ -10318,7 +10318,7 @@
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094,
+          "bucket": 0.5305,
           "leafId": 1,
           "variationWeights": [1, 0],
           "banditVersion": 7
@@ -10333,12 +10333,12 @@
           "plan": "enterprise"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 0.5,
@@ -10352,13 +10352,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -10377,7 +10377,68 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
+      {
+        "value": "default",
+        "on": true,
+        "off": false,
+        "source": "defaultValue",
+        "ruleId": ""
+      }
+    ],
+    [
+      "coverage distribution within a leaf - id 8",
+      {
+        "attributes": {
+          "id": "8",
+          "plan": "enterprise"
+        },
+        "features": {
+          "bandit-feature": {
+            "defaultValue": "default",
+            "rules": [
+              {
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
+                "hashAttribute": "id",
+                "hashVersion": 2,
+                "coverage": 0.5,
+                "contextualVariations": ["control", "treatment"],
+                "weights": [0.5, 0.5],
+                "meta": [
+                  {
+                    "key": "0"
+                  },
+                  {
+                    "key": "1"
+                  }
+                ],
+                "contextualBanditRef": "cb-bandit"
+              }
+            ]
+          }
+        },
+        "contextualBandits": {
+          "cb-bandit": {
+            "banditVersion": 7,
+            "contexts": [
+              {
+                "leafId": 1,
+                "condition": {
+                  "plan": "enterprise"
+                },
+                "weights": [1, 0]
+              },
+              {
+                "leafId": 2,
+                "condition": {},
+                "weights": [0, 1]
+              }
+            ]
+          }
+        }
+      },
+      "bandit-feature",
       {
         "value": "control",
         "on": true,
@@ -10385,13 +10446,8 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": 1,
-            "variationWeights": [1, 0],
-            "banditVersion": 7
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 0.5,
           "weights": [1, 0],
           "hashAttribute": "id",
@@ -10403,85 +10459,29 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
           "key": "0",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
           "variationId": 0,
           "value": "control",
           "hashAttribute": "id",
-          "hashValue": "1",
+          "hashValue": "8",
           "stickyBucketUsed": false,
-          "bucket": 0.3094,
+          "bucket": 0.011,
           "leafId": 1,
           "variationWeights": [1, 0],
           "banditVersion": 7
         }
-      }
-    ],
-    [
-      "coverage distribution within a leaf - id 8",
-      {
-        "attributes": {
-          "id": "8",
-          "plan": "enterprise"
-        },
-        "features": {
-          "promo": {
-            "defaultValue": "default",
-            "rules": [
-              {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
-                "hashAttribute": "id",
-                "hashVersion": 2,
-                "coverage": 0.5,
-                "contextualVariations": ["control", "treatment"],
-                "weights": [0.5, 0.5],
-                "meta": [
-                  {
-                    "key": "0"
-                  },
-                  {
-                    "key": "1"
-                  }
-                ],
-                "contextualBanditRef": "cb_promo_bandit"
-              }
-            ]
-          }
-        },
-        "contextualBandits": {
-          "cb_promo_bandit": {
-            "banditVersion": 7,
-            "contexts": [
-              {
-                "leafId": 1,
-                "condition": {
-                  "plan": "enterprise"
-                },
-                "weights": [1, 0]
-              },
-              {
-                "leafId": 2,
-                "condition": {},
-                "weights": [0, 1]
-              }
-            ]
-          }
-        }
-      },
-      "promo",
-      {
-        "value": "default",
-        "on": true,
-        "off": false,
-        "source": "defaultValue",
-        "ruleId": ""
       }
     ],
     [
@@ -10492,12 +10492,12 @@
           "plan": "enterprise"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -10511,22 +10511,22 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
-        "value": "control",
+        "value": "treatment",
         "on": true,
         "off": false,
         "source": "experiment",
         "ruleId": "",
         "experiment": {
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [0.5, 0.5],
           "hashAttribute": "id",
@@ -10538,20 +10538,20 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
+          "seed": "bandit-exp",
           "hashVersion": 2
         },
         "experimentResult": {
-          "key": "0",
-          "featureId": "promo",
+          "key": "1",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
-          "variationId": 0,
-          "value": "control",
+          "variationId": 1,
+          "value": "treatment",
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094
+          "bucket": 0.5305
         }
       }
     ],
@@ -10563,12 +10563,12 @@
           "plan": "enterprise"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -10582,33 +10582,28 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": []
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
-        "value": "control",
+        "value": "treatment",
         "on": true,
         "off": false,
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": -1,
-            "variationWeights": [0.5, 0.5],
-            "banditVersion": 7
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [0.5, 0.5],
           "hashAttribute": "id",
@@ -10620,20 +10615,25 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
-          "key": "0",
-          "featureId": "promo",
+          "key": "1",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
-          "variationId": 0,
-          "value": "control",
+          "variationId": 1,
+          "value": "treatment",
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094,
+          "bucket": 0.5305,
           "leafId": -1,
           "variationWeights": [0.5, 0.5],
           "banditVersion": 7
@@ -10648,12 +10648,12 @@
           "plan": "enterprise"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -10667,13 +10667,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "contexts": [
               {
                 "leafId": 1,
@@ -10684,7 +10684,7 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
         "value": "control",
         "on": true,
@@ -10692,12 +10692,8 @@
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": 1,
-            "variationWeights": [1, 0]
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [1, 0],
           "hashAttribute": "id",
@@ -10709,12 +10705,16 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": 1,
+            "variationWeights": [1, 0]
+          }
         },
         "experimentResult": {
           "key": "0",
-          "featureId": "promo",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
           "variationId": 0,
@@ -10722,7 +10722,7 @@
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094,
+          "bucket": 0.5305,
           "leafId": 1,
           "variationWeights": [1, 0]
         }
@@ -10736,12 +10736,12 @@
           "plan": "free"
         },
         "features": {
-          "promo": {
+          "bandit-feature": {
             "defaultValue": "default",
             "rules": [
               {
-                "key": "promo_bandit",
-                "seed": "promo_bandit",
+                "key": "bandit-exp",
+                "seed": "bandit-exp",
                 "hashAttribute": "id",
                 "hashVersion": 2,
                 "coverage": 1,
@@ -10755,13 +10755,13 @@
                     "key": "1"
                   }
                 ],
-                "contextualBanditRef": "cb_promo_bandit"
+                "contextualBanditRef": "cb-bandit"
               }
             ]
           }
         },
         "contextualBandits": {
-          "cb_promo_bandit": {
+          "cb-bandit": {
             "banditVersion": 7,
             "contexts": [
               {
@@ -10775,21 +10775,16 @@
           }
         }
       },
-      "promo",
+      "bandit-feature",
       {
-        "value": "control",
+        "value": "treatment",
         "on": true,
         "off": false,
         "source": "experiment",
         "ruleId": "",
         "experiment": {
-          "contextualBandit": {
-            "leafId": -1,
-            "variationWeights": [0.5, 0.5],
-            "banditVersion": 7
-          },
           "variations": ["control", "treatment"],
-          "key": "promo_bandit",
+          "key": "bandit-exp",
           "coverage": 1,
           "weights": [0.5, 0.5],
           "hashAttribute": "id",
@@ -10801,20 +10796,25 @@
               "key": "1"
             }
           ],
-          "seed": "promo_bandit",
-          "hashVersion": 2
+          "seed": "bandit-exp",
+          "hashVersion": 2,
+          "contextualBandit": {
+            "leafId": -1,
+            "variationWeights": [0.5, 0.5],
+            "banditVersion": 7
+          }
         },
         "experimentResult": {
-          "key": "0",
-          "featureId": "promo",
+          "key": "1",
+          "featureId": "bandit-feature",
           "inExperiment": true,
           "hashUsed": true,
-          "variationId": 0,
-          "value": "control",
+          "variationId": 1,
+          "value": "treatment",
           "hashAttribute": "id",
           "hashValue": "1",
           "stickyBucketUsed": false,
-          "bucket": 0.3094,
+          "bucket": 0.5305,
           "leafId": -1,
           "variationWeights": [0.5, 0.5],
           "banditVersion": 7

--- a/packages/sdk-js/test/contextual-bandit.test.ts
+++ b/packages/sdk-js/test/contextual-bandit.test.ts
@@ -1,0 +1,459 @@
+import { GrowthBook } from "../src";
+import { GrowthBookClient } from "../src/GrowthBookClient";
+import { ContextualBanditDefinitions } from "../src/types/growthbook";
+
+function cbRule(overrides: Record<string, unknown> = {}) {
+  return {
+    key: "promo_bandit",
+    seed: "promo_bandit",
+    hashAttribute: "id",
+    hashVersion: 2,
+    coverage: 1,
+    contextualVariations: ["control", "treatment"],
+    weights: [1, 0],
+    meta: [{ key: "0" }, { key: "1" }],
+    contextualBanditRef: "cb_promo",
+    ...overrides,
+  };
+}
+
+function cbFeatures(overrides: Record<string, unknown> = {}) {
+  return {
+    promo: {
+      defaultValue: "default",
+      rules: [cbRule(overrides)],
+    },
+  };
+}
+
+function cbMap(
+  overrides: Record<string, unknown> = {},
+): ContextualBanditDefinitions {
+  return {
+    cb_promo: {
+      banditVersion: 7,
+      contexts: [
+        { leafId: 1, condition: { plan: "enterprise" }, weights: [1, 0] },
+        { leafId: 2, condition: {}, weights: [0, 1] },
+      ],
+      ...overrides,
+    },
+  };
+}
+
+describe("contextual bandit feature rules", () => {
+  it("routes a user into the matching leaf and uses that leaf's weights", () => {
+    const gb = new GrowthBook({
+      attributes: { id: "u1", plan: "enterprise" },
+      features: cbFeatures(),
+      contextualBandits: cbMap(),
+    });
+
+    const res = gb.evalFeature("promo");
+    expect(res.source).toEqual("experiment");
+    expect(res.value).toEqual("control");
+    expect(res.experimentResult?.inExperiment).toEqual(true);
+    expect(res.experimentResult?.variationId).toEqual(0);
+    expect(res.experimentResult?.leafId).toEqual(1);
+    expect(res.experimentResult?.variationWeights).toEqual([1, 0]);
+    expect(res.experimentResult?.banditVersion).toEqual(7);
+
+    gb.destroy();
+  });
+
+  it("skips a CB rule whose variations were stripped (old-SDK payload), no even-split fallback", () => {
+    // An SDK without the contextualBandits capability drops the CB-gated keys
+    // (`contextualVariations` and `contextualBanditRef`) and never sees
+    // `variations`, so the rule must be skipped and fall through to the default
+    // rather than run as a plain 50/50 experiment.
+    const gb = new GrowthBook({
+      attributes: { id: "u1", plan: "enterprise" },
+      features: {
+        promo: {
+          defaultValue: "default",
+          rules: [
+            {
+              key: "promo_bandit",
+              seed: "promo_bandit",
+              hashAttribute: "id",
+              hashVersion: 2,
+              coverage: 1,
+              weights: [1, 0],
+              meta: [{ key: "0" }, { key: "1" }],
+            },
+          ],
+        },
+      },
+      contextualBandits: cbMap(),
+    });
+
+    const res = gb.evalFeature("promo");
+    expect(res.source).toEqual("defaultValue");
+    expect(res.value).toEqual("default");
+    expect(res.experimentResult).toBeUndefined();
+
+    gb.destroy();
+  });
+
+  it("buckets into a leaf only when both global targeting and the leaf condition pass", () => {
+    // Rule-level `condition` is the global targeting; it is ANDed with the
+    // per-leaf context condition. Here the user passes both.
+    const gb = new GrowthBook({
+      attributes: { id: "u1", plan: "enterprise", country: "US" },
+      features: cbFeatures({ condition: { country: "US" } }),
+      contextualBandits: cbMap(),
+    });
+
+    const res = gb.evalFeature("promo");
+    expect(res.source).toEqual("experiment");
+    expect(res.value).toEqual("control");
+    expect(res.experimentResult?.inExperiment).toEqual(true);
+    expect(res.experimentResult?.leafId).toEqual(1);
+
+    gb.destroy();
+  });
+
+  it("excludes the user (no exposure, no leaf metadata) when global targeting fails even if a leaf matches", () => {
+    // The user matches leaf 1 (plan=enterprise) but fails the global targeting
+    // condition (country != US). Must be excluded and leak no leaf metadata.
+    const trackingCallback = jest.fn();
+    const gb = new GrowthBook({
+      attributes: { id: "u1", plan: "enterprise", country: "CA" },
+      trackingCallback,
+      features: cbFeatures({ condition: { country: "US" } }),
+      contextualBandits: cbMap(),
+    });
+
+    const res = gb.evalFeature("promo");
+    expect(res.source).toEqual("defaultValue");
+    expect(res.value).toEqual("default");
+    expect(res.experimentResult).toBeUndefined();
+    expect(trackingCallback.mock.calls.length).toEqual(0);
+
+    gb.destroy();
+  });
+
+  it("falls through to the catch-all leaf when no specific leaf matches", () => {
+    const gb = new GrowthBook({
+      attributes: { id: "u1", plan: "free" },
+      features: cbFeatures(),
+      contextualBandits: cbMap(),
+    });
+
+    const res = gb.evalFeature("promo");
+    expect(res.source).toEqual("experiment");
+    expect(res.value).toEqual("treatment");
+    expect(res.experimentResult?.variationId).toEqual(1);
+    expect(res.experimentResult?.leafId).toEqual(2);
+    expect(res.experimentResult?.variationWeights).toEqual([0, 1]);
+
+    gb.destroy();
+  });
+
+  it("resolves the same contextualBandits entry from multiple linked features", () => {
+    const gb = new GrowthBook({
+      attributes: { id: "u1", plan: "enterprise" },
+      features: {
+        ...cbFeatures(),
+        banner: {
+          defaultValue: "off",
+          rules: [
+            cbRule({
+              contextualVariations: ["off", "on"],
+            }),
+          ],
+        },
+      },
+      contextualBandits: cbMap(),
+    });
+
+    const promo = gb.evalFeature("promo");
+    const banner = gb.evalFeature("banner");
+    expect(promo.experimentResult?.leafId).toEqual(1);
+    expect(banner.experimentResult?.leafId).toEqual(1);
+    expect(banner.value).toEqual("off");
+    expect(banner.experimentResult?.banditVersion).toEqual(7);
+
+    gb.destroy();
+  });
+
+  it("falls into the catch-all leaf when an attribute used by a leaf condition is missing", () => {
+    // The SDK no longer enforces a list of required attributes. A user missing
+    // `plan` simply fails the specific leaf condition and matches the catch-all
+    // leaf like any other non-enterprise user.
+    const trackingCallback = jest.fn();
+    const gb = new GrowthBook({
+      attributes: { id: "u1" },
+      trackingCallback,
+      features: cbFeatures(),
+      contextualBandits: cbMap(),
+    });
+
+    const res = gb.evalFeature("promo");
+    expect(res.source).toEqual("experiment");
+    expect(res.value).toEqual("treatment");
+    expect(res.experimentResult?.inExperiment).toEqual(true);
+    expect(res.experimentResult?.variationId).toEqual(1);
+    expect(res.experimentResult?.leafId).toEqual(2);
+    expect(res.experimentResult?.variationWeights).toEqual([0, 1]);
+    expect(res.experimentResult?.banditVersion).toEqual(7);
+    expect(trackingCallback.mock.calls.length).toEqual(1);
+
+    gb.destroy();
+  });
+
+  it("buckets on fallback weights (leafId -1) and tracks when no leaf matches", () => {
+    // User passes global targeting and has the required attribute, but matches
+    // none of the leaves (no catch-all present). Fallback leaf, still tracked.
+    const trackingCallback = jest.fn();
+    const gb = new GrowthBook({
+      attributes: { id: "u1", plan: "free" },
+      trackingCallback,
+      features: cbFeatures(),
+      contextualBandits: cbMap({
+        contexts: [
+          { leafId: 1, condition: { plan: "enterprise" }, weights: [1, 0] },
+        ],
+      }),
+    });
+
+    const res = gb.evalFeature("promo");
+    expect(res.source).toEqual("experiment");
+    expect(res.value).toEqual("control");
+    expect(res.experimentResult?.inExperiment).toEqual(true);
+    expect(res.experimentResult?.variationId).toEqual(0);
+    expect(res.experimentResult?.leafId).toEqual(-1);
+    expect(res.experimentResult?.variationWeights).toEqual([1, 0]);
+    expect(res.experimentResult?.banditVersion).toEqual(7);
+    expect(trackingCallback.mock.calls.length).toEqual(1);
+
+    gb.destroy();
+  });
+
+  it("does not crash and uses fallback weights (leafId -1) when leaf selection throws", () => {
+    const trackingCallback = jest.fn();
+    // A condition that throws when evaluated (e.g. a malformed payload).
+    const throwingCondition = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error("boom");
+        },
+      },
+    ) as Record<string, unknown>;
+    const bandits = cbMap();
+    bandits.cb_promo.contexts[0].condition = throwingCondition;
+
+    const gb = new GrowthBook({
+      attributes: { id: "u1", plan: "enterprise" },
+      trackingCallback,
+      features: cbFeatures(),
+      contextualBandits: bandits,
+    });
+
+    // Should not throw; the user falls back to aggregate weights rather than
+    // being dropped, and is tracked as a fallback-leaf exposure.
+    let res: ReturnType<typeof gb.evalFeature>;
+    expect(() => {
+      res = gb.evalFeature("promo");
+    }).not.toThrow();
+    expect(res!.source).toEqual("experiment");
+    expect(res!.value).toEqual("control");
+    expect(res!.experimentResult?.leafId).toEqual(-1);
+    expect(res!.experimentResult?.variationWeights).toEqual([1, 0]);
+    expect(res!.experimentResult?.banditVersion).toEqual(7);
+    expect(trackingCallback.mock.calls.length).toEqual(1);
+
+    gb.destroy();
+  });
+
+  it("passes resolved attributes to the standard trackingCallback for CB exposures", () => {
+    const trackingCallback = jest.fn();
+    const gb = new GrowthBook({
+      attributes: { id: "u1", plan: "enterprise" },
+      trackingCallback,
+      features: cbFeatures(),
+      contextualBandits: cbMap(),
+    });
+
+    gb.evalFeature("promo");
+
+    expect(trackingCallback.mock.calls.length).toEqual(1);
+    const [experiment, result, user] = trackingCallback.mock.calls[0];
+    expect(experiment.key).toEqual("promo_bandit");
+    expect(result.leafId).toEqual(1);
+    expect(result.variationId).toEqual(0);
+    expect(result.variationWeights).toEqual([1, 0]);
+    expect(result.banditVersion).toEqual(7);
+    expect(user.attributes).toEqual({ id: "u1", plan: "enterprise" });
+
+    gb.destroy();
+  });
+
+  it("passes attributes to the trackingCallback for non-CB experiments too (no leaf data on result)", () => {
+    const trackingCallback = jest.fn();
+    const gb = new GrowthBook({
+      attributes: { id: "u1" },
+      trackingCallback,
+      features: {
+        plain: {
+          defaultValue: "default",
+          rules: [
+            {
+              key: "plain_exp",
+              seed: "plain_exp",
+              hashAttribute: "id",
+              hashVersion: 2,
+              coverage: 1,
+              variations: ["control", "treatment"],
+              weights: [0, 1],
+              meta: [{ key: "0" }, { key: "1" }],
+            },
+          ],
+        },
+      },
+    });
+
+    const res = gb.evalFeature("plain");
+    expect(res.source).toEqual("experiment");
+    expect(res.experimentResult?.leafId).toBeUndefined();
+
+    expect(trackingCallback.mock.calls.length).toEqual(1);
+    const [, result, user] = trackingCallback.mock.calls[0];
+    expect(result.leafId).toBeUndefined();
+    expect(result.banditVersion).toBeUndefined();
+    expect(user.attributes).toEqual({ id: "u1" });
+
+    gb.destroy();
+  });
+
+  it("uses marginal weights with fallback-leaf metadata when contexts[] is empty (explore stage)", () => {
+    // An explore-stage CB has no leaves yet. Users are bucketed on the aggregate
+    // weights but the exposure is still attributable via the fallback leaf (-1)
+    // and banditVersion, so it can be tied to a weight generation.
+    const gb = new GrowthBook({
+      attributes: { id: "u1" },
+      features: cbFeatures(),
+      contextualBandits: cbMap({ contexts: [] }),
+    });
+
+    const res = gb.evalFeature("promo");
+    expect(res.source).toEqual("experiment");
+    expect(res.value).toEqual("control");
+    expect(res.experimentResult?.variationId).toEqual(0);
+    expect(res.experimentResult?.leafId).toEqual(-1);
+    expect(res.experimentResult?.variationWeights).toEqual([1, 0]);
+    expect(res.experimentResult?.banditVersion).toEqual(7);
+
+    gb.destroy();
+  });
+
+  it("falls back to marginal weights with NO metadata when the contextualBanditRef is dangling", () => {
+    // No CB definition in the payload at all, so there is no banditVersion to
+    // report — the rule runs as a plain MAB experiment with no leaf metadata.
+    const gb = new GrowthBook({
+      attributes: { id: "u1" },
+      features: cbFeatures(),
+      // No contextualBandits map at all
+    });
+
+    const res = gb.evalFeature("promo");
+    expect(res.source).toEqual("experiment");
+    expect(res.value).toEqual("control");
+    expect(res.experimentResult?.variationId).toEqual(0);
+    expect(res.experimentResult?.leafId).toBeUndefined();
+    expect(res.experimentResult?.variationWeights).toBeUndefined();
+    expect(res.experimentResult?.banditVersion).toBeUndefined();
+
+    gb.destroy();
+  });
+
+  it("preserves attributes through deferred tracking calls", async () => {
+    // No trackingCallback at eval time => the exposure is deferred.
+    const gb = new GrowthBook({
+      attributes: { id: "u1", plan: "enterprise" },
+      features: cbFeatures(),
+      contextualBandits: cbMap(),
+    });
+
+    gb.evalFeature("promo");
+
+    const deferred = gb.getDeferredTrackingCalls();
+    expect(deferred.length).toEqual(1);
+    expect(deferred[0].user?.attributes).toEqual({
+      id: "u1",
+      plan: "enterprise",
+    });
+    expect(deferred[0].result.leafId).toEqual(1);
+    expect(deferred[0].result.banditVersion).toEqual(7);
+
+    const trackingCallback = jest.fn();
+    gb.setTrackingCallback(trackingCallback);
+    await gb.fireDeferredTrackingCalls();
+
+    expect(trackingCallback.mock.calls.length).toEqual(1);
+    const [, result, user] = trackingCallback.mock.calls[0];
+    expect(result.variationWeights).toEqual([1, 0]);
+    expect(user.attributes).toEqual({ id: "u1", plan: "enterprise" });
+
+    gb.destroy();
+  });
+
+  it("ingests contextualBandits from a payload via setPayload", async () => {
+    const gb = new GrowthBook({
+      attributes: { id: "u1", plan: "enterprise" },
+    });
+    await gb.setPayload({
+      features: cbFeatures(),
+      contextualBandits: cbMap(),
+    });
+
+    const res = gb.evalFeature("promo");
+    expect(res.experimentResult?.leafId).toEqual(1);
+    expect(res.experimentResult?.banditVersion).toEqual(7);
+
+    gb.destroy();
+  });
+
+  it("ingests contextualBandits from a payload via initSync (routes to the matched leaf)", () => {
+    const gb = new GrowthBook({
+      attributes: { id: "u1", plan: "enterprise" },
+    });
+    gb.initSync({
+      payload: {
+        features: cbFeatures(),
+        contextualBandits: cbMap(),
+      },
+    });
+
+    const res = gb.evalFeature("promo");
+    expect(res.source).toEqual("experiment");
+    expect(res.value).toEqual("control");
+    expect(res.experimentResult?.leafId).toEqual(1);
+    expect(res.experimentResult?.variationWeights).toEqual([1, 0]);
+    expect(res.experimentResult?.banditVersion).toEqual(7);
+
+    gb.destroy();
+  });
+
+  it("ingests contextualBandits from a payload via GrowthBookClient.initSync", () => {
+    const gb = new GrowthBookClient();
+    gb.initSync({
+      payload: {
+        features: cbFeatures(),
+        contextualBandits: cbMap(),
+      },
+    });
+
+    const res = gb.evalFeature("promo", {
+      attributes: { id: "u1", plan: "enterprise" },
+    });
+    expect(res.source).toEqual("experiment");
+    expect(res.value).toEqual("control");
+    expect(res.experimentResult?.leafId).toEqual(1);
+    expect(res.experimentResult?.variationWeights).toEqual([1, 0]);
+    expect(res.experimentResult?.banditVersion).toEqual(7);
+
+    gb.destroy();
+  });
+});

--- a/packages/sdk-js/test/contextual-bandit.test.ts
+++ b/packages/sdk-js/test/contextual-bandit.test.ts
@@ -4,22 +4,22 @@ import { ContextualBanditDefinitions } from "../src/types/growthbook";
 
 function cbRule(overrides: Record<string, unknown> = {}) {
   return {
-    key: "promo_bandit",
-    seed: "promo_bandit",
+    key: "bandit-exp",
+    seed: "bandit-exp",
     hashAttribute: "id",
     hashVersion: 2,
     coverage: 1,
     contextualVariations: ["control", "treatment"],
     weights: [1, 0],
     meta: [{ key: "0" }, { key: "1" }],
-    contextualBanditRef: "cb_promo",
+    contextualBanditRef: "cb-bandit",
     ...overrides,
   };
 }
 
 function cbFeatures(overrides: Record<string, unknown> = {}) {
   return {
-    promo: {
+    "bandit-feature": {
       defaultValue: "default",
       rules: [cbRule(overrides)],
     },
@@ -30,7 +30,7 @@ function cbMap(
   overrides: Record<string, unknown> = {},
 ): ContextualBanditDefinitions {
   return {
-    cb_promo: {
+    "cb-bandit": {
       banditVersion: 7,
       contexts: [
         { leafId: 1, condition: { plan: "enterprise" }, weights: [1, 0] },
@@ -49,7 +49,7 @@ describe("contextual bandit feature rules", () => {
       contextualBandits: cbMap(),
     });
 
-    const res = gb.evalFeature("promo");
+    const res = gb.evalFeature("bandit-feature");
     expect(res.source).toEqual("experiment");
     expect(res.value).toEqual("control");
     expect(res.experimentResult?.inExperiment).toEqual(true);
@@ -69,12 +69,12 @@ describe("contextual bandit feature rules", () => {
     const gb = new GrowthBook({
       attributes: { id: "u1", plan: "enterprise" },
       features: {
-        promo: {
+        "bandit-feature": {
           defaultValue: "default",
           rules: [
             {
-              key: "promo_bandit",
-              seed: "promo_bandit",
+              key: "bandit-exp",
+              seed: "bandit-exp",
               hashAttribute: "id",
               hashVersion: 2,
               coverage: 1,
@@ -87,7 +87,7 @@ describe("contextual bandit feature rules", () => {
       contextualBandits: cbMap(),
     });
 
-    const res = gb.evalFeature("promo");
+    const res = gb.evalFeature("bandit-feature");
     expect(res.source).toEqual("defaultValue");
     expect(res.value).toEqual("default");
     expect(res.experimentResult).toBeUndefined();
@@ -104,7 +104,7 @@ describe("contextual bandit feature rules", () => {
       contextualBandits: cbMap(),
     });
 
-    const res = gb.evalFeature("promo");
+    const res = gb.evalFeature("bandit-feature");
     expect(res.source).toEqual("experiment");
     expect(res.value).toEqual("control");
     expect(res.experimentResult?.inExperiment).toEqual(true);
@@ -124,7 +124,7 @@ describe("contextual bandit feature rules", () => {
       contextualBandits: cbMap(),
     });
 
-    const res = gb.evalFeature("promo");
+    const res = gb.evalFeature("bandit-feature");
     expect(res.source).toEqual("defaultValue");
     expect(res.value).toEqual("default");
     expect(res.experimentResult).toBeUndefined();
@@ -140,7 +140,7 @@ describe("contextual bandit feature rules", () => {
       contextualBandits: cbMap(),
     });
 
-    const res = gb.evalFeature("promo");
+    const res = gb.evalFeature("bandit-feature");
     expect(res.source).toEqual("experiment");
     expect(res.value).toEqual("treatment");
     expect(res.experimentResult?.variationId).toEqual(1);
@@ -167,9 +167,9 @@ describe("contextual bandit feature rules", () => {
       contextualBandits: cbMap(),
     });
 
-    const promo = gb.evalFeature("promo");
+    const feature = gb.evalFeature("bandit-feature");
     const banner = gb.evalFeature("banner");
-    expect(promo.experimentResult?.leafId).toEqual(1);
+    expect(feature.experimentResult?.leafId).toEqual(1);
     expect(banner.experimentResult?.leafId).toEqual(1);
     expect(banner.value).toEqual("off");
     expect(banner.experimentResult?.banditVersion).toEqual(7);
@@ -189,7 +189,7 @@ describe("contextual bandit feature rules", () => {
       contextualBandits: cbMap(),
     });
 
-    const res = gb.evalFeature("promo");
+    const res = gb.evalFeature("bandit-feature");
     expect(res.source).toEqual("experiment");
     expect(res.value).toEqual("treatment");
     expect(res.experimentResult?.inExperiment).toEqual(true);
@@ -217,7 +217,7 @@ describe("contextual bandit feature rules", () => {
       }),
     });
 
-    const res = gb.evalFeature("promo");
+    const res = gb.evalFeature("bandit-feature");
     expect(res.source).toEqual("experiment");
     expect(res.value).toEqual("control");
     expect(res.experimentResult?.inExperiment).toEqual(true);
@@ -242,7 +242,7 @@ describe("contextual bandit feature rules", () => {
       },
     ) as Record<string, unknown>;
     const bandits = cbMap();
-    bandits.cb_promo.contexts[0].condition = throwingCondition;
+    bandits["cb-bandit"].contexts[0].condition = throwingCondition;
 
     const gb = new GrowthBook({
       attributes: { id: "u1", plan: "enterprise" },
@@ -255,7 +255,7 @@ describe("contextual bandit feature rules", () => {
     // being dropped, and is tracked as a fallback-leaf exposure.
     let res: ReturnType<typeof gb.evalFeature>;
     expect(() => {
-      res = gb.evalFeature("promo");
+      res = gb.evalFeature("bandit-feature");
     }).not.toThrow();
     expect(res!.source).toEqual("experiment");
     expect(res!.value).toEqual("control");
@@ -276,11 +276,11 @@ describe("contextual bandit feature rules", () => {
       contextualBandits: cbMap(),
     });
 
-    gb.evalFeature("promo");
+    gb.evalFeature("bandit-feature");
 
     expect(trackingCallback.mock.calls.length).toEqual(1);
     const [experiment, result, user] = trackingCallback.mock.calls[0];
-    expect(experiment.key).toEqual("promo_bandit");
+    expect(experiment.key).toEqual("bandit-exp");
     expect(result.leafId).toEqual(1);
     expect(result.variationId).toEqual(0);
     expect(result.variationWeights).toEqual([1, 0]);
@@ -337,7 +337,7 @@ describe("contextual bandit feature rules", () => {
       contextualBandits: cbMap({ contexts: [] }),
     });
 
-    const res = gb.evalFeature("promo");
+    const res = gb.evalFeature("bandit-feature");
     expect(res.source).toEqual("experiment");
     expect(res.value).toEqual("control");
     expect(res.experimentResult?.variationId).toEqual(0);
@@ -357,7 +357,7 @@ describe("contextual bandit feature rules", () => {
       // No contextualBandits map at all
     });
 
-    const res = gb.evalFeature("promo");
+    const res = gb.evalFeature("bandit-feature");
     expect(res.source).toEqual("experiment");
     expect(res.value).toEqual("control");
     expect(res.experimentResult?.variationId).toEqual(0);
@@ -376,7 +376,7 @@ describe("contextual bandit feature rules", () => {
       contextualBandits: cbMap(),
     });
 
-    gb.evalFeature("promo");
+    gb.evalFeature("bandit-feature");
 
     const deferred = gb.getDeferredTrackingCalls();
     expect(deferred.length).toEqual(1);
@@ -408,7 +408,7 @@ describe("contextual bandit feature rules", () => {
       contextualBandits: cbMap(),
     });
 
-    const res = gb.evalFeature("promo");
+    const res = gb.evalFeature("bandit-feature");
     expect(res.experimentResult?.leafId).toEqual(1);
     expect(res.experimentResult?.banditVersion).toEqual(7);
 
@@ -426,7 +426,7 @@ describe("contextual bandit feature rules", () => {
       },
     });
 
-    const res = gb.evalFeature("promo");
+    const res = gb.evalFeature("bandit-feature");
     expect(res.source).toEqual("experiment");
     expect(res.value).toEqual("control");
     expect(res.experimentResult?.leafId).toEqual(1);
@@ -445,7 +445,7 @@ describe("contextual bandit feature rules", () => {
       },
     });
 
-    const res = gb.evalFeature("promo", {
+    const res = gb.evalFeature("bandit-feature", {
       attributes: { id: "u1", plan: "enterprise" },
     });
     expect(res.source).toEqual("experiment");

--- a/packages/sdk-js/test/contextual-bandit.test.ts
+++ b/packages/sdk-js/test/contextual-bandit.test.ts
@@ -290,6 +290,37 @@ describe("contextual bandit feature rules", () => {
     gb.destroy();
   });
 
+  it("reports the override weights (not the leaf weights) when a context weights-override changes bucketing", () => {
+    const trackingCallback = jest.fn();
+    const gb = new GrowthBook({
+      attributes: { id: "u1", plan: "enterprise" }, // matches leaf 1 -> [1, 0]
+      trackingCallback,
+      features: cbFeatures(),
+      contextualBandits: cbMap(),
+      // Override flips the weights so the user buckets into variation 1 instead.
+      overrides: { "bandit-exp": { weights: [0, 1] } },
+    });
+
+    const res = gb.evalFeature("bandit-feature");
+
+    // Leaf selection is unchanged (still leaf 1)...
+    expect(res.experimentResult?.leafId).toEqual(1);
+    // ...but bucketing used the override weights, so the reported weights and
+    // the assigned variation must reflect [0, 1], not the leaf's [1, 0].
+    expect(res.experimentResult?.variationId).toEqual(1);
+    expect(res.experimentResult?.value).toEqual("treatment");
+    expect(res.experimentResult?.variationWeights).toEqual([0, 1]);
+
+    // The trackingCallback must see the same override weights.
+    expect(trackingCallback.mock.calls.length).toEqual(1);
+    const [experiment, result] = trackingCallback.mock.calls[0];
+    expect(result.variationWeights).toEqual([0, 1]);
+    expect(experiment.contextualBandit.variationWeights).toEqual([0, 1]);
+    expect(experiment.weights).toEqual([0, 1]);
+
+    gb.destroy();
+  });
+
   it("passes attributes to the trackingCallback for non-CB experiments too (no leaf data on result)", () => {
     const trackingCallback = jest.fn();
     const gb = new GrowthBook({

--- a/packages/sdk-js/test/json.test.ts
+++ b/packages/sdk-js/test/json.test.ts
@@ -35,6 +35,8 @@ type Cases = {
   run: [string, Context, Experiment<any>, any, boolean, boolean][];
   // name, context, feature key, result
   feature: [string, Context, string, FeatureResult][];
+  // name, context, feature key, result (contextual-bandit feature rules)
+  contextualBandit: [string, Context, string, FeatureResult][];
   // name, condition, attribute, result
   evalCondition: [string, any, any, boolean, SavedGroupsValues][];
   // name, args ([numVariations, coverage, weights]), result
@@ -88,6 +90,15 @@ global.TextEncoder = TextEncoder;
 describe("json test suite", () => {
   it.each((cases as Cases).feature)(
     "feature[%#] %s",
+    (name, ctx, key, expected) => {
+      const growthbook = new GrowthBook(ctx);
+      expect(growthbook.evalFeature(key)).toEqual(expected);
+      growthbook.destroy();
+    },
+  );
+
+  it.each((cases as Cases).contextualBandit)(
+    "contextualBandit[%#] %s",
     (name, ctx, key, expected) => {
       const growthbook = new GrowthBook(ctx);
       expect(growthbook.evalFeature(key)).toEqual(expected);


### PR DESCRIPTION
### Features and Changes

Adds SDK-side support for consuming contextual bandit (CB) payloads to `@growthbook/growthbook` (`packages/sdk-js`). This is the SDK-only slice split out of the larger contextual-bandit branch; the back-end payload generation, versioning capability, and app/UI changes ship separately.

The SDK can now read CB definitions from the payload and select per-context ("leaf") variation weights at evaluation time, while remaining fully backwards compatible with existing payloads and older SDK behavior.

**What changed:**

- **New payload fields (all optional):** `contextualBandits` / `encryptedContextualBandits` on the feature API response, plumbed through `GrowthBook`, `GrowthBookClient`, and the global eval context. `decryptPayload` now decrypts `encryptedContextualBandits`.
- **CB rule handling in `core.ts`:** experiment rules may carry a `contextualBanditRef` (pointing into the top-level `contextualBandits` map) and their variations under `contextualVariations` instead of `variations`. At eval time the SDK resolves the matching leaf by condition, applies that leaf's `weights`, and records `leafId` / `variationWeights` / `banditVersion` on the result.
- **Graceful fallback:** if the ref is missing, no leaf matches, or leaf selection throws, the SDK falls back to the experiment's existing/equal weights (fallback `leafId = -1`) rather than skipping or erroring.
- **New types:** `ContextualBanditDefinition(s)` and `CBContext`, plus optional `contextualBandit` on `Experiment` and `leafId` / `variationWeights` / `banditVersion` on `Result`.
- **Sticky bucketing:** CB rules now register their hash/fallback attributes (they were previously missed because they key off `variations`).

**Backwards compatibility:**

- All new fields on existing types are optional — existing payloads evaluate exactly as before.
- CB rules deliberately store variations under `contextualVariations` (not `variations`), so **older SDKs skip these rules** instead of mis-bucketing users into an even split.
- Full `cases.json` spec suite passes unchanged.

- Closes **(add link to issue here)**

### Dependencies

None. This PR is standalone and can merge on its own — the back-end does not import any new sdk-js exports (it uses its own `ContextualBanditDefinitions` type from `shared/types/sdk`), and nothing consumes the CB payload until the back-end/versioning PR ships the `1.7.0 → contextualBandits` capability. No merge-order requirement.

### Testing

- `packages/sdk-js`: `npx jest` — **752 tests pass** across all 17 suites.
  - New `test/contextual-bandit.test.ts` covers leaf matching, fallback weights, ref-not-found, encrypted payloads, and sticky bucketing for CB rules.
  - New `contextualBandit` cases added to `test/cases.json` and run via the shared `test/json.test.ts` spec runner; all pre-existing `run` / `feature` / `evalCondition` cases still pass.
- `npx tsc --noEmit` compiles clean.

### Screenshots

N/A — SDK library changes only, no UI.