### PR TITLE
fix(safe-rollouts): render drilldown metric changes as absolute, not percent

### DIFF
--- a/packages/front-end/components/RampSchedule/SafeRolloutRuleDashboard/MetricSection.tsx
+++ b/packages/front-end/components/RampSchedule/SafeRolloutRuleDashboard/MetricSection.tsx
@@ -452,7 +452,9 @@ function SafeRolloutMetricDrilldownModal({
         goalMetrics={[]}
         secondaryMetrics={resultGroup === "secondary" ? signalMetricIds : []}
         statsEngine="frequentist"
-        localDifferenceType="relative"
+        // Safe rollout snapshots are always analyzed with an absolute
+        // differenceType, so the results must be rendered as absolute too.
+        localDifferenceType="absolute"
         preloadedTimeSeries={timeSeries}
         valueColumnWidth={170}
         labelMaxWidth={120}
@@ -536,7 +538,7 @@ export function MetricSection({
         metricDefaults,
         minSampleSize: getMinSampleSizeForMetric(row.metric),
         statsEngine: "frequentist",
-        differenceType: "relative",
+        differenceType: "absolute",
         ciUpper: 0.975,
         ciLower: 0.025,
         pValueThreshold: 0.05,


### PR DESCRIPTION
### Features and Changes

in the monitored rollout metric drilldown modal, "% Change" was wildly wrong — a metric moving from 22.35 → 22.68 displayed as **33.5%** instead of the true **+1.5%**.

Safe rollout snapshots are always analyzed with `differenceType: "absolute"` ([safeRolloutSnapshots.ts:138](../blob/main/packages/back-end/src/services/safeRolloutSnapshots.ts#L138), [:277](../blob/main/packages/back-end/src/services/safeRolloutSnapshots.ts#L277)), so `expected` and `ci` are absolute deltas in metric units. But `SafeRolloutMetricDrilldownModal` hardcoded `"relative"`, which sent that absolute delta through `formatPercent`. `0.335` → `"33.5%"`.

Two one-line changes in `MetricSection.tsx`:

1. `localDifferenceType="absolute"` — the column header now derives to "Change" via `getEffectLabel` and the value formats in metric units.
2. `differenceType: "absolute"` in the `getRowResults` call — this one is a real logic fix, not just display. `isSuspiciousUplift` divides by `baseline.cr` when the type is `absolute` ([experiments.ts:1055-1058](../blob/main/packages/shared/src/experiments/experiments.ts#L1055)); under `"relative"` it was comparing a raw absolute delta against the `maxPercentChange` percentage, so guardrail suspicious-change detection was evaluated on the wrong scale.

This brings the drilldown in line with the main safe rollout results table, which already passes `"absolute"` ([CompactResults.tsx:193](../blob/main/packages/front-end/components/SafeRollout/Results/CompactResults.tsx#L193)).

Note: showing a true relative % here isn't a formatting change — the snapshot contains no relative estimate or relative CI, and dividing the CI bounds by the baseline does not yield a valid interval. Producing one would require gbstats to run a relative analysis for safe rollouts. Out of scope.

- Closes **(add link to issue here)**

### Dependencies

None.

### Testing

Reproduced locally by seeding a safe rollout snapshot with these figures:

| | Units | Numerator | Value |
|---|---|---|---|
| Control | 943,956 | 21,097,149 | 22.3497 |
| Rollout | 943,948 | 21,413,305 | 22.6848 |

Absolute delta = `0.33512`. On `main` the modal renders "% Change **33.5%**" (`Intl.NumberFormat({style:"percent"})` of 0.33512); with this branch it renders "Change **0.34**", consistent with the "Absolute Change" time series shown directly beneath it in the same modal.

`pnpm --filter front-end type-check`, eslint (`--max-warnings 0`) and prettier all pass.

### Screenshots

<!-- before/after of the guardrail metric drilldown modal -->

---

### Follow-ups found while investigating (not in this PR)

- **P-values always display `0.500`.** Safe rollouts always run sequential + one-sided, which has no closed-form p-value; gbstats bisects on alpha with `max_alpha = 0.4999` hardcoded ([tests.py:371](../blob/main/packages/stats/gbstats/frequentist/tests.py#L371)) and returns that ceiling verbatim when the interval doesn't exclude zero (`:400`, `:418`). `(0.4999).toFixed(3)` → `"0.500"`. So every guardrail not trending badly reports 0.500. The cap is legitimate (the one-sided sequential CI is undefined for alpha ≥ 0.5), but the UI should show `>0.499`/`n/a` rather than a falsely precise number.
- **`pValueThreshold: 0.05` is hardcoded** at `MetricSection.tsx:435` and `:544` instead of using the safe rollout's configured threshold, skewing significance highlighting in the same modal.
- **`MetricDrilldownOverview` defaults `localDifferenceType` to `"relative"`**, so any future caller that omits it inherits this same bug. Worth making the prop required.
