### PR TITLE
fix(ui,experiments): handle deleted and expand metrics for notices

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2259,12 +2259,12 @@ export async function planExperimentSnapshot({
   const postStratificationEnabled = settings.postStratificationEnabled.value;
 
   const metricMap = await getMetricMap(context);
-  const allExperimentMetrics = metricIds
-    .map((metricId) => metricMap.get(metricId))
-    .filter(isDefined);
-  if (allExperimentMetrics.length === 0) {
+  const allExperimentMetrics = metricIds.map(
+    (metricId) => metricMap.get(metricId) ?? null,
+  );
+  if (!allExperimentMetrics.some(isDefined)) {
     throw new BadRequestError(
-      "Experiment must have at least 1 metric selected.",
+      "Experiment must have at least 1 metric selected to be analyzed.",
     );
   }
 

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2236,14 +2236,9 @@ export async function planExperimentSnapshot({
     metricGroups,
   );
 
-  // Reject up front instead of persisting a snapshot that the query runner
-  // would immediately fail (every experiment runner requires at least one
-  // metric). Guarding here keeps the request path free of orphaned "error"
-  // snapshot records for both the internal and public snapshot APIs, and
-  // matches the front-end "Add at least 1 metric" gate.
   if (metricIds.length === 0) {
     throw new BadRequestError(
-      "Experiment must have at least 1 metric selected.",
+      "Experiment must have at least 1 metric selected to be analyzed.",
     );
   }
 
@@ -2264,9 +2259,14 @@ export async function planExperimentSnapshot({
   const postStratificationEnabled = settings.postStratificationEnabled.value;
 
   const metricMap = await getMetricMap(context);
-  const factTableMap = await getFactTableMap(context);
-
-  const allExperimentMetrics = metricIds.map((m) => metricMap.get(m) || null);
+  const allExperimentMetrics = metricIds
+    .map((metricId) => metricMap.get(metricId))
+    .filter(isDefined);
+  if (allExperimentMetrics.length === 0) {
+    throw new BadRequestError(
+      "Experiment must have at least 1 metric selected.",
+    );
+  }
 
   const denominatorMetricIds = uniq<string>(
     allExperimentMetrics
@@ -2276,6 +2276,8 @@ export async function planExperimentSnapshot({
   const denominatorMetrics = denominatorMetricIds
     .map((m) => metricMap.get(m) || null)
     .filter(isDefined) as MetricInterface[];
+
+  const factTableMap = await getFactTableMap(context);
 
   const { settingsForSnapshotMetrics, regressionAdjustmentEnabled } =
     getAllMetricSettingsForSnapshot({

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -201,6 +201,7 @@ import {
 } from "back-end/src/services/dimensions";
 import {
   getErrorMessage,
+  BadRequestError,
   ConcurrentIncrementalRefreshError,
   ExperimentIncrementalPipelineRequiresFullRefreshError,
 } from "back-end/src/util/errors";
@@ -2228,6 +2229,24 @@ export async function planExperimentSnapshot({
       phaseIndex: phase,
     });
 
+  const metricGroups = await context.models.metricGroups.getAll();
+  const metricIds = getAllMetricIdsFromExperiment(
+    experiment,
+    false,
+    metricGroups,
+  );
+
+  // Reject up front instead of persisting a snapshot that the query runner
+  // would immediately fail (every experiment runner requires at least one
+  // metric). Guarding here keeps the request path free of orphaned "error"
+  // snapshot records for both the internal and public snapshot APIs, and
+  // matches the front-end "Add at least 1 metric" gate.
+  if (metricIds.length === 0) {
+    throw new BadRequestError(
+      "Experiment must have at least 1 metric selected.",
+    );
+  }
+
   let project = null;
   if (experiment.project) {
     project = await context.models.projects.getById(experiment.project);
@@ -2243,15 +2262,9 @@ export async function planExperimentSnapshot({
   });
   const statsEngine = settings.statsEngine.value;
   const postStratificationEnabled = settings.postStratificationEnabled.value;
+
   const metricMap = await getMetricMap(context);
   const factTableMap = await getFactTableMap(context);
-
-  const metricGroups = await context.models.metricGroups.getAll();
-  const metricIds = getAllMetricIdsFromExperiment(
-    experiment,
-    false,
-    metricGroups,
-  );
 
   const allExperimentMetrics = metricIds.map((m) => metricMap.get(m) || null);
 

--- a/packages/back-end/test/services/snapshot-planning.test.ts
+++ b/packages/back-end/test/services/snapshot-planning.test.ts
@@ -26,6 +26,7 @@ import {
 } from "back-end/src/services/experiments";
 import { planMetricFanOut } from "back-end/src/services/experimentQueries/planMetricFanOut";
 import { updateExperiment } from "back-end/src/models/ExperimentModel";
+import { getMetricMap } from "back-end/src/models/MetricModel";
 import {
   createExperimentSnapshotModel,
   findSnapshotById,
@@ -34,7 +35,10 @@ import {
 import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 import { getSourceIntegrationObject } from "back-end/src/services/datasource";
 import { updateExperimentDashboards } from "back-end/src/enterprise/services/dashboards";
-import { FactTableMap } from "back-end/src/models/FactTableModel";
+import {
+  FactTableMap,
+  getFactTableMap,
+} from "back-end/src/models/FactTableModel";
 import { factMetricFactory } from "../factories/FactMetric.factory";
 import { factTableFactory } from "../factories/FactTable.factory";
 
@@ -50,6 +54,17 @@ jest.mock("back-end/src/models/ExperimentSnapshotModel", () => ({
 
 jest.mock("back-end/src/models/DataSourceModel", () => ({
   getDataSourceById: jest.fn(),
+}));
+
+jest.mock("back-end/src/models/MetricModel", () => ({
+  getMetricById: jest.fn(),
+  getMetricMap: jest.fn(),
+  getMetricsByIds: jest.fn(),
+  insertMetric: jest.fn(),
+}));
+
+jest.mock("back-end/src/models/FactTableModel", () => ({
+  getFactTableMap: jest.fn(),
 }));
 
 jest.mock("back-end/src/services/datasource", () => ({
@@ -96,6 +111,12 @@ const getLatestSuccessfulSnapshotMock =
   >;
 const getDataSourceByIdMock = getDataSourceById as jest.MockedFunction<
   typeof getDataSourceById
+>;
+const getMetricMapMock = getMetricMap as jest.MockedFunction<
+  typeof getMetricMap
+>;
+const getFactTableMapMock = getFactTableMap as jest.MockedFunction<
+  typeof getFactTableMap
 >;
 const getSourceIntegrationObjectMock =
   getSourceIntegrationObject as jest.MockedFunction<
@@ -211,6 +232,8 @@ describe("snapshot planning", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     getDataSourceByIdMock.mockResolvedValue(makeDatasource());
+    getMetricMapMock.mockResolvedValue(new Map());
+    getFactTableMapMock.mockResolvedValue(new Map() as FactTableMap);
     getSourceIntegrationObjectMock.mockReturnValue({} as never);
     exploratoryOverallRequiresFullRefreshMock.mockReturnValue(false);
   });
@@ -258,6 +281,25 @@ describe("snapshot planning", () => {
       }),
     ).rejects.toThrow(BadRequestError);
 
+    expect(createExperimentSnapshotModelMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a snapshot when none of the selected metrics can be resolved", async () => {
+    await expect(
+      createExperimentSnapshot({
+        context: makeContext(),
+        experiment: makeExperiment({
+          goalMetrics: ["fact__deleted"],
+          metricOverrides: [],
+        }),
+        datasource: makeDatasource(),
+        dimension: undefined,
+        phase: 0,
+        useCache: false,
+      }),
+    ).rejects.toThrow(BadRequestError);
+
+    expect(getMetricMapMock).toHaveBeenCalled();
     expect(createExperimentSnapshotModelMock).not.toHaveBeenCalled();
   });
 

--- a/packages/back-end/test/services/snapshot-planning.test.ts
+++ b/packages/back-end/test/services/snapshot-planning.test.ts
@@ -14,9 +14,13 @@ import {
   assertIncrementalRefreshPrerequisites,
   exploratoryOverallRequiresFullRefresh,
 } from "back-end/src/enterprise/services/data-pipeline";
-import { ExperimentIncrementalPipelineRequiresFullRefreshError } from "back-end/src/util/errors";
+import {
+  BadRequestError,
+  ExperimentIncrementalPipelineRequiresFullRefreshError,
+} from "back-end/src/util/errors";
 import { orgHasPremiumFeature } from "back-end/src/enterprise";
 import {
+  createExperimentSnapshot,
   getSnapshotSettings,
   planSnapshot,
 } from "back-end/src/services/experiments";
@@ -236,6 +240,25 @@ describe("snapshot planning", () => {
     expect(createExperimentSnapshotModelMock).not.toHaveBeenCalled();
     expect(updateExperimentMock).not.toHaveBeenCalled();
     expect(updateExperimentDashboardsMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a snapshot for an experiment with no metrics without persisting a record", async () => {
+    await expect(
+      createExperimentSnapshot({
+        context: makeContext(),
+        experiment: makeExperiment({
+          goalMetrics: [],
+          secondaryMetrics: [],
+          guardrailMetrics: [],
+        }),
+        datasource: makeDatasource(),
+        dimension: undefined,
+        phase: 0,
+        useCache: false,
+      }),
+    ).rejects.toThrow(BadRequestError);
+
+    expect(createExperimentSnapshotModelMock).not.toHaveBeenCalled();
   });
 
   it("surfaces pipeline validation errors as incremental fallback reasons", async () => {

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -32,6 +32,7 @@ import { trackSnapshot } from "@/services/track";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import Callout from "@/ui/Callout";
 import Link from "@/ui/Link";
+import Button from "@/ui/Button";
 import AsyncQueriesModal from "@/components/Queries/AsyncQueriesModal";
 import { MetricDrilldownProvider } from "@/components/MetricDrilldown/MetricDrilldownContext";
 import { getIsExperimentIncludedInIncrementalRefresh } from "@/services/experiments";
@@ -244,24 +245,20 @@ const Results: FC<{
       )}
 
       {!hasMetrics && (
-        <Callout status="info" m="3">
-          Add at least 1 metric to view results.{" "}
-          {editMetrics && (
-            <button
-              className="btn btn-primary btn-sm ml-3"
-              type="button"
-              onClick={(e) => {
-                e.preventDefault();
-                editMetrics();
-              }}
-            >
-              Add Metrics
-            </button>
-          )}
+        <Callout
+          status="info"
+          m="3"
+          action={
+            editMetrics && (
+              <Button onClick={() => editMetrics()}>Add metrics</Button>
+            )
+          }
+        >
+          Add at least 1 metric to view results.
         </Callout>
       )}
 
-      {status === "failed" && !hasData && !snapshotLoading ? (
+      {status === "failed" && !hasData && !snapshotLoading && hasMetrics ? (
         <Callout status="error" mx="3" my="4">
           The most recent update failed.
           {hasQueries ? (

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -14,6 +14,7 @@ import {
 import {
   isDimensionPrecomputed,
   getEffectiveLookbackOverride,
+  getAllMetricIdsFromExperiment,
   getLatestPhaseVariations,
 } from "shared/experiments";
 import { ExperimentSnapshotInterface } from "shared/types/experiment-snapshot";
@@ -135,7 +136,8 @@ const Results: FC<{
   }, [experiment.phases.length, setPhase]);
 
   const permissionsUtil = usePermissionsUtil();
-  const { getDatasourceById } = useDefinitions();
+  const { getDatasourceById, getExperimentMetricById, metricGroups } =
+    useDefinitions();
   const incrementalPipelineUnsupportedReason =
     useIncrementalPipelineUnsupportedReason(experiment);
 
@@ -228,10 +230,11 @@ const Results: FC<{
     isIncrementalActive &&
     !(dimensionless && !dimensionless.dimension);
 
-  const hasMetrics =
-    experiment.goalMetrics.length > 0 ||
-    experiment.secondaryMetrics.length > 0 ||
-    experiment.guardrailMetrics.length > 0;
+  const hasMetrics = getAllMetricIdsFromExperiment(
+    experiment,
+    false,
+    metricGroups,
+  ).some((metricId) => getExperimentMetricById(metricId) !== null);
 
   const isBandit = experiment.type === "multi-armed-bandit";
   const hasQueries = queryStrings.length > 0;

--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
@@ -1063,7 +1063,10 @@ export default function AnalysisSettingsSummary({
         </Box>
       )}
 
-      {incrementalUpdatesUnavailable && (
+      {/* Gate on metrics so this warning only shows alongside the refresh
+          button (same `allMetrics.length > 0` gate). With no metrics there is
+          nothing to rescan, and Results already shows "Add at least 1 metric". */}
+      {incrementalUpdatesUnavailable && allMetrics.length > 0 && (
         <Callout status="warning" mt="2">
           <Text weight="semibold" size="medium">
             Updates will rescan full experiment data.


### PR DESCRIPTION
### Features and Changes

- Ensure we handle deleted and metric groups for the `hasMetric` checks on Experiment Results
- Update `Add at least 1 metric` Callout to use `ui/Button`
- Add validation on the API and error out earlier if no effective `metricIds` are available for the snapshot
- Do not show Incremental Pipeline Callouts if no metrics are added. The `add metric` callout has priority.

### Screenshots

| Before | After |
|--------|--------|
| <img width="2560" height="1602" alt="before" src="https://github.com/user-attachments/assets/7b810e76-19dd-41bb-8122-ee073cd7070e" /> | <img width="2560" height="1602" alt="after" src="https://github.com/user-attachments/assets/ac8d46cf-12d1-47e7-89fd-162a94bb3790" /> | 

### Testing

- Unit tests