### PR TITLE
fix(holdouts): repair holdout publish, revert, and project scoping

### DIFF
--- a/packages/back-end/src/api/features/postFeatureRevisionDiscard.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionDiscard.ts
@@ -40,7 +40,12 @@ export async function discardFeatureRevision(
     throw new BadRequestError(`Cannot discard a ${revision.status} revision`);
   }
 
-  await discardRevision(req.context, revision, req.context.auditUser);
+  await discardRevision(
+    req.context,
+    revision,
+    req.context.auditUser,
+    feature.version,
+  );
   await clearPendingFeatureDraftsForRevision(
     req.context,
     feature.id,

--- a/packages/back-end/src/api/features/postFeatureRevisionPublish.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionPublish.ts
@@ -1,4 +1,5 @@
 import { postFeatureRevisionPublishValidator } from "shared/validators";
+import { isStrandedLiveRevision } from "shared/util";
 import type { ApiRequestLocals } from "back-end/types/api";
 import { auditDetailsUpdate } from "back-end/src/services/audit";
 import { createApiRequestHandler } from "back-end/src/util/handler";
@@ -77,7 +78,15 @@ export async function publishFeatureRevision(
     revision,
   });
   const { environmentIds, mergeResult: mergeChanges } = plan;
-  if (!plan.hasChanges) {
+  // A stranded live revision also has no changes, but publishing it is the
+  // supported way to reconcile it — refusing would leave no route out.
+  const isStranded = isStrandedLiveRevision({
+    featureVersion: feature.version,
+    revisionVersion: revision.version,
+    revisionStatus: revision.status,
+    hasChanges: plan.hasChanges,
+  });
+  if (!plan.hasChanges && !isStranded) {
     throw new BadRequestError(
       "Cannot publish: no changes detected in this revision",
     );

--- a/packages/back-end/src/api/features/postFeatureRevisionPublish.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionPublish.ts
@@ -78,8 +78,6 @@ export async function publishFeatureRevision(
     revision,
   });
   const { environmentIds, mergeResult: mergeChanges } = plan;
-  // A stranded live revision also has no changes, but publishing it is the
-  // supported way to reconcile it — refusing would leave no route out.
   const isStranded = isStrandedLiveRevision({
     featureVersion: feature.version,
     revisionVersion: revision.version,

--- a/packages/back-end/src/api/features/postFeatureRevisionRevert.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRevert.ts
@@ -248,7 +248,11 @@ export async function revertFeatureRevision(
   const targetHoldout = getRevertTargetHoldout(targetRevision);
   // Read-gated: restoring a holdout the caller cannot see would attach the
   // feature outside their scope, since publish resolves linkage unscoped.
-  await assertValidHoldout(targetHoldout, context);
+  await assertValidHoldout(
+    targetHoldout,
+    context,
+    changes.metadata?.project ?? feature.project,
+  );
   const holdoutChanged = !isEqual(targetHoldout, feature.holdout ?? null);
   if (holdoutChanged) {
     if (

--- a/packages/back-end/src/api/features/postFeatureRevisionRevert.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRevert.ts
@@ -5,6 +5,7 @@ import {
   filterEnvironmentsByFeature,
   MergeResultChanges,
   checkIfRevisionNeedsReview,
+  getEffectiveRevisionHoldout,
   getRulesForEnvironment,
 } from "shared/util";
 import { isEqual } from "lodash";
@@ -243,11 +244,30 @@ export async function revertFeatureRevision(
     }
   }
 
+  // Holdout membership is part of the state a revert restores: reverting to a
+  // revision that predates a holdout must detach it, and reverting to one that
+  // had it must reattach it (with the linkage side effects publish runs).
+  const targetHoldout = getEffectiveRevisionHoldout(targetRevision, feature);
+  const holdoutChanged = !isEqual(targetHoldout, feature.holdout ?? null);
+  if (holdoutChanged) {
+    if (
+      isPublish &&
+      !context.permissions.canPublishFeature(feature, allEnabledEnvs)
+    ) {
+      context.permissions.throwPermissionError();
+    }
+    changes.holdout = targetHoldout;
+  }
+
   // Full target state for the new revision; sparse `changes` above is only
   // used for per-field permission checks.
   const revisionChanges: Partial<FeatureRevisionInterface> = {
     defaultValue: targetRevision.defaultValue,
     rules: targetRevision.rules ?? feature.rules ?? [],
+    holdout: targetHoldout,
+    // Marks the new revision as a revert, so publish-time guards recognize it
+    // even when the revert is staged as a draft and published later.
+    revertedFrom: targetRevision.version,
   };
   if (targetRevision.environmentsEnabled !== undefined) {
     revisionChanges.environmentsEnabled = targetRevision.environmentsEnabled;

--- a/packages/back-end/src/api/features/postFeatureRevisionRevert.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRevert.ts
@@ -35,6 +35,7 @@ import {
 import { addTagsDiff } from "back-end/src/models/TagModel";
 import { getEnvironments } from "back-end/src/services/organizations";
 import { getEnvironmentIdsFromOrg } from "back-end/src/util/organization.util";
+import { assertValidHoldout } from "./v2Shared";
 import { canUseRestApiBypassSetting } from "./reviewBypass";
 
 export async function revertFeatureRevision(
@@ -245,6 +246,9 @@ export async function revertFeatureRevision(
   }
 
   const targetHoldout = getRevertTargetHoldout(targetRevision);
+  // Read-gated: restoring a holdout the caller cannot see would attach the
+  // feature outside their scope, since publish resolves linkage unscoped.
+  await assertValidHoldout(targetHoldout, context);
   const holdoutChanged = !isEqual(targetHoldout, feature.holdout ?? null);
   if (holdoutChanged) {
     if (

--- a/packages/back-end/src/api/features/postFeatureRevisionRevert.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRevert.ts
@@ -244,9 +244,6 @@ export async function revertFeatureRevision(
     }
   }
 
-  // Holdout membership is part of the state a revert restores: reverting to a
-  // revision that predates a holdout must detach it, and reverting to one that
-  // had it must reattach it (with the linkage side effects publish runs).
   const targetHoldout = getEffectiveRevisionHoldout(targetRevision, feature);
   const holdoutChanged = !isEqual(targetHoldout, feature.holdout ?? null);
   if (holdoutChanged) {

--- a/packages/back-end/src/api/features/postFeatureRevisionRevert.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRevert.ts
@@ -5,7 +5,7 @@ import {
   filterEnvironmentsByFeature,
   MergeResultChanges,
   checkIfRevisionNeedsReview,
-  getEffectiveRevisionHoldout,
+  getRevertTargetHoldout,
   getRulesForEnvironment,
 } from "shared/util";
 import { isEqual } from "lodash";
@@ -244,7 +244,7 @@ export async function revertFeatureRevision(
     }
   }
 
-  const targetHoldout = getEffectiveRevisionHoldout(targetRevision, feature);
+  const targetHoldout = getRevertTargetHoldout(targetRevision);
   const holdoutChanged = !isEqual(targetHoldout, feature.holdout ?? null);
   if (holdoutChanged) {
     if (

--- a/packages/back-end/src/api/features/postFeatureRevisionRevert.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRevert.ts
@@ -265,9 +265,6 @@ export async function revertFeatureRevision(
     defaultValue: targetRevision.defaultValue,
     rules: targetRevision.rules ?? feature.rules ?? [],
     holdout: targetHoldout,
-    // Marks the new revision as a revert, so publish-time guards recognize it
-    // even when the revert is staged as a draft and published later.
-    revertedFrom: targetRevision.version,
   };
   if (targetRevision.environmentsEnabled !== undefined) {
     revisionChanges.environmentsEnabled = targetRevision.environmentsEnabled;
@@ -301,6 +298,7 @@ export async function revertFeatureRevision(
       changes: revisionChanges,
       org: context.org,
       canBypassApprovalChecks: false,
+      revertedFrom: targetRevision.version,
     });
 
     return { feature, revision: newDraft };
@@ -350,6 +348,7 @@ export async function revertFeatureRevision(
       changes: revisionChanges,
       comment: comment ?? defaultComment,
       canBypassApprovalChecks: canBypass,
+      revertedFrom: targetRevision.version,
     });
 
   if (

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
@@ -1,5 +1,4 @@
 import cloneDeep from "lodash/cloneDeep";
-import omit from "lodash/omit";
 import { v4 as uuidv4 } from "uuid";
 import {
   RevisionRampCreateAction,
@@ -426,15 +425,10 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
     }
     if (linkedHoldoutId && linkedExperimentId) {
       try {
-        const holdout =
-          await req.context.models.holdout.getById(linkedHoldoutId);
-        if (holdout?.linkedExperiments?.[linkedExperimentId]) {
-          await req.context.models.holdout.updateById(linkedHoldoutId, {
-            linkedExperiments: omit(holdout.linkedExperiments, [
-              linkedExperimentId,
-            ]),
-          });
-        }
+        await req.context.models.holdout.removeExperimentFromHoldout(
+          linkedHoldoutId,
+          linkedExperimentId,
+        );
       } catch {
         // best effort
       }

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
@@ -1,5 +1,4 @@
 import cloneDeep from "lodash/cloneDeep";
-import omit from "lodash/omit";
 import { v4 as uuidv4 } from "uuid";
 import {
   RevisionRampCreateAction,
@@ -439,15 +438,10 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
     }
     if (linkedHoldoutId && linkedExperimentId) {
       try {
-        const holdout =
-          await req.context.models.holdout.getById(linkedHoldoutId);
-        if (holdout?.linkedExperiments?.[linkedExperimentId]) {
-          await req.context.models.holdout.updateById(linkedHoldoutId, {
-            linkedExperiments: omit(holdout.linkedExperiments, [
-              linkedExperimentId,
-            ]),
-          });
-        }
+        await req.context.models.holdout.removeExperimentFromHoldout(
+          linkedHoldoutId,
+          linkedExperimentId,
+        );
       } catch {
         /* best effort */
       }

--- a/packages/back-end/src/api/features/putFeatureRevisionHoldout.ts
+++ b/packages/back-end/src/api/features/putFeatureRevisionHoldout.ts
@@ -16,6 +16,7 @@ import {
   isDraftStatus,
   resolveOrCreateRevision,
 } from "./validations";
+import { assertValidHoldout } from "./v2Shared";
 
 export async function setRevisionHoldout(
   context: ApiReqContext,
@@ -37,12 +38,7 @@ export async function setRevisionHoldout(
     context.permissions.throwPermissionError();
   }
 
-  if (body.holdout) {
-    const holdout = await context.models.holdout.getById(body.holdout.id);
-    if (!holdout) {
-      throw new NotFoundError(`Could not find holdout "${body.holdout.id}"`);
-    }
-  }
+  await assertValidHoldout(body.holdout, context, feature.project);
 
   const { revision, created } = await resolveOrCreateRevision(
     context,

--- a/packages/back-end/src/api/features/revertFeature.ts
+++ b/packages/back-end/src/api/features/revertFeature.ts
@@ -210,8 +210,7 @@ export async function revertFeatureCore(
     }
   }
 
-  // Holdout membership is part of the state a revert restores, so a
-  // holdout-only difference is a real revert rather than an empty diff.
+  // Runs before the empty-diff check: a holdout-only difference is a real revert.
   const targetHoldout = getEffectiveRevisionHoldout(revision, feature);
   if (!isEqual(targetHoldout, feature.holdout ?? null)) {
     if (

--- a/packages/back-end/src/api/features/revertFeature.ts
+++ b/packages/back-end/src/api/features/revertFeature.ts
@@ -286,12 +286,10 @@ export async function revertFeatureCore(
       feature,
       user: eventAudit,
       org: organization,
-      // `revertedFrom` marks the new revision as a revert for publish-time
-      // guards. Added here rather than to `changes` so it can't satisfy the
-      // empty-diff check above.
-      changes: { ...changes, revertedFrom: version },
+      changes,
       comment: comment ?? `Reverted to revision #${version}`,
       canBypassApprovalChecks: canBypass,
+      revertedFrom: version,
     });
 
   await audit({

--- a/packages/back-end/src/api/features/revertFeature.ts
+++ b/packages/back-end/src/api/features/revertFeature.ts
@@ -215,7 +215,11 @@ export async function revertFeatureCore(
   const targetHoldout = getRevertTargetHoldout(revision);
   // Read-gated: restoring a holdout the caller cannot see would attach the
   // feature outside their scope, since publish resolves linkage unscoped.
-  await assertValidHoldout(targetHoldout, context);
+  await assertValidHoldout(
+    targetHoldout,
+    context,
+    changes.metadata?.project ?? feature.project,
+  );
   if (!isEqual(targetHoldout, feature.holdout ?? null)) {
     if (
       !context.permissions.canPublishFeature(

--- a/packages/back-end/src/api/features/revertFeature.ts
+++ b/packages/back-end/src/api/features/revertFeature.ts
@@ -6,7 +6,7 @@ import {
   MergeResultChanges,
   PermissionError,
   checkIfRevisionNeedsReview,
-  getEffectiveRevisionHoldout,
+  getRevertTargetHoldout,
   getRevertValueValidationWarnings,
   getRulesForEnvironment,
 } from "shared/util";
@@ -211,7 +211,7 @@ export async function revertFeatureCore(
   }
 
   // Runs before the empty-diff check: a holdout-only difference is a real revert.
-  const targetHoldout = getEffectiveRevisionHoldout(revision, feature);
+  const targetHoldout = getRevertTargetHoldout(revision);
   if (!isEqual(targetHoldout, feature.holdout ?? null)) {
     if (
       !context.permissions.canPublishFeature(

--- a/packages/back-end/src/api/features/revertFeature.ts
+++ b/packages/back-end/src/api/features/revertFeature.ts
@@ -6,6 +6,7 @@ import {
   MergeResultChanges,
   PermissionError,
   checkIfRevisionNeedsReview,
+  getEffectiveRevisionHoldout,
   getRevertValueValidationWarnings,
   getRulesForEnvironment,
 } from "shared/util";
@@ -209,6 +210,21 @@ export async function revertFeatureCore(
     }
   }
 
+  // Holdout membership is part of the state a revert restores, so a
+  // holdout-only difference is a real revert rather than an empty diff.
+  const targetHoldout = getEffectiveRevisionHoldout(revision, feature);
+  if (!isEqual(targetHoldout, feature.holdout ?? null)) {
+    if (
+      !context.permissions.canPublishFeature(
+        feature,
+        Array.from(getEnabledEnvironments(feature, environmentIds)),
+      )
+    ) {
+      context.permissions.throwPermissionError();
+    }
+    changes.holdout = targetHoldout;
+  }
+
   // No diff against live — refuse before creating an empty "Locked" revision.
   if (Object.keys(changes).length === 0) {
     throw new Error(
@@ -270,7 +286,10 @@ export async function revertFeatureCore(
       feature,
       user: eventAudit,
       org: organization,
-      changes,
+      // `revertedFrom` marks the new revision as a revert for publish-time
+      // guards. Added here rather than to `changes` so it can't satisfy the
+      // empty-diff check above.
+      changes: { ...changes, revertedFrom: version },
       comment: comment ?? `Reverted to revision #${version}`,
       canBypassApprovalChecks: canBypass,
     });

--- a/packages/back-end/src/api/features/revertFeature.ts
+++ b/packages/back-end/src/api/features/revertFeature.ts
@@ -34,6 +34,7 @@ import { NotFoundError, SoftWarningError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { getEnabledEnvironments } from "back-end/src/util/features";
 import { getEnvironmentIdsFromOrg } from "back-end/src/util/organization.util";
+import { assertValidHoldout } from "./v2Shared";
 import { canUseRestApiBypassSetting } from "./reviewBypass";
 
 export async function revertFeatureCore(
@@ -212,6 +213,9 @@ export async function revertFeatureCore(
 
   // Runs before the empty-diff check: a holdout-only difference is a real revert.
   const targetHoldout = getRevertTargetHoldout(revision);
+  // Read-gated: restoring a holdout the caller cannot see would attach the
+  // feature outside their scope, since publish resolves linkage unscoped.
+  await assertValidHoldout(targetHoldout, context);
   if (!isEqual(targetHoldout, feature.holdout ?? null)) {
     if (
       !context.permissions.canPublishFeature(

--- a/packages/back-end/src/api/features/updateFeature.ts
+++ b/packages/back-end/src/api/features/updateFeature.ts
@@ -156,7 +156,13 @@ export const updateFeature = createApiRequestHandler(updateFeatureValidator)(
           }))
         : null;
 
-    await assertValidHoldout(req.body.holdout, req.context);
+    if (req.body.holdout !== undefined || req.body.project !== undefined) {
+      await assertValidHoldout(
+        req.body.holdout !== undefined ? req.body.holdout : feature.holdout,
+        req.context,
+        req.body.project ?? feature.project,
+      );
+    }
 
     const jsonSchema =
       feature.valueType !== "boolean" && req.body.jsonSchema != null

--- a/packages/back-end/src/api/features/updateFeatureV2.ts
+++ b/packages/back-end/src/api/features/updateFeatureV2.ts
@@ -223,7 +223,13 @@ export const updateFeatureV2 = createApiRequestHandler(
         }))
       : null;
 
-  await assertValidHoldout(req.body.holdout, req.context);
+  if (req.body.holdout !== undefined || req.body.project !== undefined) {
+    await assertValidHoldout(
+      req.body.holdout !== undefined ? req.body.holdout : feature.holdout,
+      req.context,
+      req.body.project ?? feature.project,
+    );
+  }
 
   // Block a config-backed default value coexisting with an enabled JSON schema
   // (either inbound or already on the flag), using the effective post-update

--- a/packages/back-end/src/api/features/v2Shared.ts
+++ b/packages/back-end/src/api/features/v2Shared.ts
@@ -12,6 +12,7 @@ import {
 } from "shared/util";
 import type { ApiReqContext } from "back-end/types/api";
 import type { ReqContext } from "back-end/types/request";
+import { getHoldoutAvailableForProject } from "back-end/src/services/holdout-availability";
 import { BadRequestError } from "back-end/src/util/errors";
 import type { ApiFeatureEnvSettings } from "./postFeature";
 
@@ -423,17 +424,18 @@ export async function assertValidRuleProjectIds(
 }
 
 // `null` (explicit removal) and `undefined` (no change) are both no-ops.
-// `getById` is read-permission filtered, so this is also the authorization check
-// that stops a caller linking a flag into a Holdout they cannot see.
+// Validates both read access and the Holdout's Project scope.
 export async function assertValidHoldout(
   holdout: { id: string } | null | undefined,
   context: ReqContext | ApiReqContext,
+  project: string | undefined,
 ): Promise<void> {
   if (!holdout) return;
-  const holdoutObj = await context.models.holdout.getById(holdout.id);
-  if (!holdoutObj) {
-    throw new Error(`Holdout id '${holdout.id}' not found.`);
-  }
+  await getHoldoutAvailableForProject({
+    context,
+    holdoutId: holdout.id,
+    project,
+  });
 }
 
 // Pro/Enterprise gated. Validates scheduleRules on v1-shape env rules.

--- a/packages/back-end/src/api/features/v2Shared.ts
+++ b/packages/back-end/src/api/features/v2Shared.ts
@@ -423,9 +423,11 @@ export async function assertValidRuleProjectIds(
 }
 
 // `null` (explicit removal) and `undefined` (no change) are both no-ops.
+// `getById` is read-permission filtered, so this is also the authorization check
+// that stops a caller linking a flag into a Holdout they cannot see.
 export async function assertValidHoldout(
   holdout: { id: string } | null | undefined,
-  context: ApiReqContext,
+  context: ReqContext | ApiReqContext,
 ): Promise<void> {
   if (!holdout) return;
   const holdoutObj = await context.models.holdout.getById(holdout.id);

--- a/packages/back-end/src/api/features/validations.ts
+++ b/packages/back-end/src/api/features/validations.ts
@@ -124,7 +124,8 @@ export async function discardIfJustCreated(
 ): Promise<void> {
   if (!created) return;
   try {
-    await discardRevision(context, revision, context.auditUser);
+    // Only ever discards a draft it just created, which can't be the live version.
+    await discardRevision(context, revision, context.auditUser, null);
   } catch (err) {
     logger.warn(
       { err, featureId: revision.featureId, version: revision.version },

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -163,6 +163,8 @@ import {
   validateExperimentFeatureUpdates,
   validateExperimentFeatureVariations,
 } from "back-end/src/services/experiment-feature";
+import { canLinkExperimentToHoldoutFromFeatures } from "back-end/src/services/holdouts";
+import { getHoldoutAvailableForProject } from "back-end/src/services/holdout-availability";
 
 export const SNAPSHOT_TIMEOUT = 30 * 60 * 1000;
 
@@ -1355,16 +1357,21 @@ export async function postExperiments(
     });
 
     if (holdoutId) {
-      const holdoutObj = await context.models.holdout.getById(holdoutId);
-      if (!holdoutObj) {
-        throw new Error("Holdout not found");
-      }
-      await context.models.holdout.updateById(holdoutId, {
-        linkedExperiments: {
-          ...holdoutObj.linkedExperiments,
-          [experiment.id]: { id: experiment.id, dateAdded: new Date() },
-        },
+      const canLinkFromFeature = await canLinkExperimentToHoldoutFromFeatures(
+        context,
+        holdoutId,
+        data.linkedFeatures ?? [],
+      );
+      await getHoldoutAvailableForProject({
+        context,
+        holdoutId,
+        project: experiment.project,
+        bypassReadPermissionChecks: canLinkFromFeature,
       });
+      await context.models.holdout.addExperimentToHoldout(
+        holdoutId,
+        experiment.id,
+      );
     }
 
     if (req.query.originalId) {
@@ -1712,6 +1719,20 @@ export async function postExperiment(
     }
   }
 
+  if (data.holdoutId && data.holdoutId !== experiment.holdoutId) {
+    await getHoldoutAvailableForProject({
+      context,
+      holdoutId: data.holdoutId,
+      project: data.project ?? experiment.project,
+    });
+  } else if (data.project !== undefined && experiment.holdoutId) {
+    await getHoldoutAvailableForProject({
+      context,
+      holdoutId: experiment.holdoutId,
+      project: data.project,
+    });
+  }
+
   // TODO(holdouts): allow changing holdout if the experiment is not linked to a feature
   // in the live! feature revision
   const experimentHasLinkedChanges =
@@ -1751,16 +1772,10 @@ export async function postExperiment(
   }
 
   if (data.holdoutId && data.holdoutId !== experiment.holdoutId) {
-    const holdoutObj = await context.models.holdout.getById(data.holdoutId);
-    if (!holdoutObj) {
-      throw new Error("Holdout not found");
-    }
-    await context.models.holdout.updateById(data.holdoutId, {
-      linkedExperiments: {
-        ...holdoutObj.linkedExperiments,
-        [experiment.id]: { id: experiment.id, dateAdded: new Date() },
-      },
-    });
+    await context.models.holdout.addExperimentToHoldout(
+      data.holdoutId,
+      experiment.id,
+    );
   }
 
   if (data.defaultDashboardId) {

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -2509,8 +2509,6 @@ export async function postFeatureRevert(
     }
     mergeChanges.holdout = targetHoldout;
   }
-  // Marks the new revision as a revert, so publish-time guards recognize it.
-  revisionChanges.revertedFrom = revision.version;
 
   const newRevision = await createRevision({
     context,
@@ -2521,6 +2519,7 @@ export async function postFeatureRevert(
     environments: contextEnvironments,
     org,
     comment: comment || `Revert to revision #${revision.version}`,
+    revertedFrom: revision.version,
   });
 
   // Reverts restore a previously-published (already-reviewed) state. When the
@@ -2645,7 +2644,6 @@ export async function postFeatureRevertDraft(
   // reverted to; `revertedFrom` survives on it so the later publish still
   // applies revert semantics.
   changes.holdout = getEffectiveRevisionHoldout(revision, feature);
-  changes.revertedFrom = revision.version;
 
   const newRevision = await createRevision({
     context,
@@ -2656,6 +2654,7 @@ export async function postFeatureRevertDraft(
     environments: contextEnvironments,
     org,
     comment: comment || `Revert to revision #${revision.version}`,
+    revertedFrom: revision.version,
   });
 
   await req.audit({

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -2468,6 +2468,9 @@ export async function postFeatureRevert(
 
   // Runs before the empty-diff check: a holdout-only difference is a real revert.
   const targetHoldout = getRevertTargetHoldout(revision);
+  // Read-gated: restoring a holdout the caller cannot see would attach the
+  // feature outside their scope, since publish resolves linkage unscoped.
+  await assertValidHoldout(targetHoldout, context);
   if (!isEqual(targetHoldout, feature.holdout ?? null)) {
     if (!context.permissions.canPublishFeature(feature, allEnabledEnvs)) {
       context.permissions.throwPermissionError();
@@ -2647,6 +2650,7 @@ export async function postFeatureRevertDraft(
     changes.metadata = revision.metadata;
   }
   changes.holdout = getRevertTargetHoldout(revision);
+  await assertValidHoldout(changes.holdout, context);
 
   const newRevision = await createRevision({
     context,

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -878,16 +878,7 @@ export async function postFeatures(
   });
 
   if (holdout && holdout.id) {
-    const holdoutObj = await context.models.holdout.getById(holdout.id);
-    if (!holdoutObj) {
-      throw new Error("Holdout not found");
-    }
-    await context.models.holdout.updateById(holdout.id, {
-      linkedFeatures: {
-        ...holdoutObj.linkedFeatures,
-        [id]: { id, dateAdded: new Date() },
-      },
-    });
+    await context.models.holdout.addFeatureToHoldout(holdout.id, id);
   }
 
   res.status(200).json({
@@ -2506,9 +2497,20 @@ export async function postFeatureRevert(
   if (revision.metadata !== undefined) {
     revisionChanges.metadata = revision.metadata;
   }
-  // Holdout intentionally excluded: changes require the dedicated updateHoldout
-  // flow (side effects + guards), and the field is sparse in revisions so
-  // absent !== "no holdout".
+  // Holdout membership is part of the state a revert restores. It must land in
+  // BOTH objects — `revisionChanges` so the revision doc records it, and
+  // `mergeChanges` so the publish sees a delta and runs the linkage side effects.
+  // Setting only one is a silent no-op.
+  const targetHoldout = getEffectiveRevisionHoldout(revision, feature);
+  revisionChanges.holdout = targetHoldout;
+  if (!isEqual(targetHoldout, feature.holdout ?? null)) {
+    if (!context.permissions.canPublishFeature(feature, allEnabledEnvs)) {
+      context.permissions.throwPermissionError();
+    }
+    mergeChanges.holdout = targetHoldout;
+  }
+  // Marks the new revision as a revert, so publish-time guards recognize it.
+  revisionChanges.revertedFrom = revision.version;
 
   const newRevision = await createRevision({
     context,
@@ -2639,6 +2641,11 @@ export async function postFeatureRevertDraft(
   if (revision.metadata !== undefined) {
     changes.metadata = revision.metadata;
   }
+  // The draft carries the target's holdout so it represents the state being
+  // reverted to; `revertedFrom` survives on it so the later publish still
+  // applies revert semantics.
+  changes.holdout = getEffectiveRevisionHoldout(revision, feature);
+  changes.revertedFrom = revision.version;
 
   const newRevision = await createRevision({
     context,
@@ -2752,7 +2759,12 @@ export async function postFeatureDiscard(
     context.permissions.throwPermissionError();
   }
 
-  await discardRevision(context, revision, res.locals.eventAudit);
+  await discardRevision(
+    context,
+    revision,
+    res.locals.eventAudit,
+    feature.version,
+  );
   await clearPendingFeatureDraftsForRevision(
     context,
     feature.id,

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -765,7 +765,11 @@ export async function postFeatures(
   // Read-gated, so a caller can't link a flag into a Holdout outside their scope.
   // The linkage write itself deliberately bypasses read scope, so this is the
   // only place the id is authorized.
-  await assertValidHoldout(holdout?.id ? holdout : null, context);
+  await assertValidHoldout(
+    holdout?.id ? holdout : null,
+    context,
+    otherProps.project ?? "",
+  );
 
   await validateCustomFieldsForSection({
     customFieldValues: customFields,
@@ -2470,7 +2474,11 @@ export async function postFeatureRevert(
   const targetHoldout = getRevertTargetHoldout(revision);
   // Read-gated: restoring a holdout the caller cannot see would attach the
   // feature outside their scope, since publish resolves linkage unscoped.
-  await assertValidHoldout(targetHoldout, context);
+  await assertValidHoldout(
+    targetHoldout,
+    context,
+    mergeChanges.metadata?.project ?? feature.project,
+  );
   if (!isEqual(targetHoldout, feature.holdout ?? null)) {
     if (!context.permissions.canPublishFeature(feature, allEnabledEnvs)) {
       context.permissions.throwPermissionError();
@@ -2650,7 +2658,11 @@ export async function postFeatureRevertDraft(
     changes.metadata = revision.metadata;
   }
   changes.holdout = getRevertTargetHoldout(revision);
-  await assertValidHoldout(changes.holdout, context);
+  await assertValidHoldout(
+    changes.holdout,
+    context,
+    changes.metadata?.project ?? feature.project,
+  );
 
   const newRevision = await createRevision({
     context,
@@ -5177,7 +5189,13 @@ export async function putFeature(
   // Read-gated, so a caller can't link a flag into a Holdout outside their scope.
   // The publish-time linkage write deliberately bypasses read scope, so this is
   // the only place the id is authorized.
-  await assertValidHoldout(holdoutUpdate ?? null, context);
+  if (holdoutUpdate !== undefined || metadataUpdates.project !== undefined) {
+    await assertValidHoldout(
+      holdoutUpdate !== undefined ? holdoutUpdate : (feature.holdout ?? null),
+      context,
+      metadataUpdates.project ?? feature.project,
+    );
+  }
 
   if (Object.keys(metadataUpdates).length > 0 || holdoutUpdate !== undefined) {
     const envelopeChanges: Parameters<

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -35,6 +35,7 @@ import {
   pruneOrphanedRampActions,
   assertSchemaMatchesValueType,
   getEffectiveRevisionHoldout,
+  getRevertTargetHoldout,
 } from "shared/util";
 import { SAFE_ROLLOUT_TRACKING_KEY_PREFIX } from "shared/constants";
 import {
@@ -2466,7 +2467,7 @@ export async function postFeatureRevert(
   }
 
   // Runs before the empty-diff check: a holdout-only difference is a real revert.
-  const targetHoldout = getEffectiveRevisionHoldout(revision, feature);
+  const targetHoldout = getRevertTargetHoldout(revision);
   if (!isEqual(targetHoldout, feature.holdout ?? null)) {
     if (!context.permissions.canPublishFeature(feature, allEnabledEnvs)) {
       context.permissions.throwPermissionError();
@@ -2645,7 +2646,7 @@ export async function postFeatureRevertDraft(
   if (revision.metadata !== undefined) {
     changes.metadata = revision.metadata;
   }
-  changes.holdout = getEffectiveRevisionHoldout(revision, feature);
+  changes.holdout = getRevertTargetHoldout(revision);
 
   const newRevision = await createRevision({
     context,

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -243,6 +243,7 @@ import {
   maybeAutoPublishFeatureRevision,
   parseScheduledPublishDate,
 } from "back-end/src/api/features/autoPublishOnApproval";
+import { assertValidHoldout } from "back-end/src/api/features/v2Shared";
 import {
   shouldValidateCustomFieldsOnUpdate,
   validateCustomFieldsForSection,
@@ -760,6 +761,10 @@ export async function postFeatures(
   if (createTargetingProjects?.length) {
     await context.models.projects.ensureProjectsExist(createTargetingProjects);
   }
+  // Read-gated, so a caller can't link a flag into a Holdout outside their scope.
+  // The linkage write itself deliberately bypasses read scope, so this is the
+  // only place the id is authorized.
+  await assertValidHoldout(holdout?.id ? holdout : null, context);
 
   await validateCustomFieldsForSection({
     customFieldValues: customFields,
@@ -2460,6 +2465,15 @@ export async function postFeatureRevert(
     }
   }
 
+  // Runs before the empty-diff check: a holdout-only difference is a real revert.
+  const targetHoldout = getEffectiveRevisionHoldout(revision, feature);
+  if (!isEqual(targetHoldout, feature.holdout ?? null)) {
+    if (!context.permissions.canPublishFeature(feature, allEnabledEnvs)) {
+      context.permissions.throwPermissionError();
+    }
+    mergeChanges.holdout = targetHoldout;
+  }
+
   // No diff against live — refuse before creating an empty "Locked" revision.
   if (Object.keys(mergeChanges).length === 0) {
     throw new Error(
@@ -2484,6 +2498,9 @@ export async function postFeatureRevert(
   const revisionChanges: Partial<FeatureRevisionInterface> = {
     defaultValue: revision.defaultValue,
     rules: revision.rules ?? feature.rules ?? [],
+    // Both objects: `revisionChanges` records it on the revision doc, `mergeChanges`
+    // makes the publish see a delta and run the linkage side effects.
+    holdout: targetHoldout,
   };
   if (revision.environmentsEnabled !== undefined) {
     revisionChanges.environmentsEnabled = revision.environmentsEnabled;
@@ -2496,18 +2513,6 @@ export async function postFeatureRevert(
   }
   if (revision.metadata !== undefined) {
     revisionChanges.metadata = revision.metadata;
-  }
-  // Holdout membership is part of the state a revert restores. It must land in
-  // BOTH objects — `revisionChanges` so the revision doc records it, and
-  // `mergeChanges` so the publish sees a delta and runs the linkage side effects.
-  // Setting only one is a silent no-op.
-  const targetHoldout = getEffectiveRevisionHoldout(revision, feature);
-  revisionChanges.holdout = targetHoldout;
-  if (!isEqual(targetHoldout, feature.holdout ?? null)) {
-    if (!context.permissions.canPublishFeature(feature, allEnabledEnvs)) {
-      context.permissions.throwPermissionError();
-    }
-    mergeChanges.holdout = targetHoldout;
   }
 
   const newRevision = await createRevision({
@@ -2640,9 +2645,6 @@ export async function postFeatureRevertDraft(
   if (revision.metadata !== undefined) {
     changes.metadata = revision.metadata;
   }
-  // The draft carries the target's holdout so it represents the state being
-  // reverted to; `revertedFrom` survives on it so the later publish still
-  // applies revert semantics.
   changes.holdout = getEffectiveRevisionHoldout(revision, feature);
 
   const newRevision = await createRevision({
@@ -5167,6 +5169,10 @@ export async function putFeature(
   ) as Partial<FeatureInterface>;
   normalizeTargetingInUpdates(metadataUpdates, feature);
   const holdoutUpdate = "holdout" in updates ? updates.holdout : undefined;
+  // Read-gated, so a caller can't link a flag into a Holdout outside their scope.
+  // The publish-time linkage write deliberately bypasses read scope, so this is
+  // the only place the id is authorized.
+  await assertValidHoldout(holdoutUpdate ?? null, context);
 
   if (Object.keys(metadataUpdates).length > 0 || holdoutUpdate !== undefined) {
     const envelopeChanges: Parameters<

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -3220,14 +3220,27 @@ export async function publishRevision({
 
     rewinds.push({
       what: "feature document",
-      undo: () =>
-        restorePublishedFeatureDoc(
+      undo: async () => {
+        // Paired with the rules restore: a reverted rule set must not leave the
+        // experiments it added still pointing back at this feature.
+        const addedExperiments = (
+          updatedFeature.linkedExperiments ?? []
+        ).filter((id) => !(feature.linkedExperiments ?? []).includes(id));
+        for (const experimentId of addedExperiments) {
+          await removeLinkedFeatureFromExperiment(
+            context,
+            experimentId,
+            feature.id,
+          );
+        }
+        await restorePublishedFeatureDoc(
           context,
           feature,
           revision,
           result,
           updatedFeature,
-        ),
+        );
+      },
     });
 
     if (result.holdout !== undefined) {

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -88,6 +88,7 @@ import {
   getAffectedSDKPayloadKeys,
   getSDKPayloadKeysByDiff,
 } from "back-end/src/util/features";
+import { getHoldoutAvailableForProject } from "back-end/src/services/holdout-availability";
 import { applyPartialFeatureRuleUpdatesToRevision } from "back-end/src/util/featureRevision.util";
 import { getErrorMessage, NotFoundError } from "back-end/src/util/errors";
 import { logger } from "back-end/src/util/logger";
@@ -1952,12 +1953,15 @@ export async function assertHoldoutChangeAllowed(
 export async function assertHoldoutLinkageResolvable(
   context: ReqContext | ApiReqContext,
   newHoldout: { id: string; value: string } | null,
+  project: string | undefined,
 ) {
   if (!newHoldout?.id) return;
-  const holdout = await context.models.holdout.getByIdForLinkage(newHoldout.id);
-  if (!holdout) {
-    throw new Error("Holdout not found");
-  }
+  await getHoldoutAvailableForProject({
+    context,
+    holdoutId: newHoldout.id,
+    project,
+    bypassReadPermissionChecks: true,
+  });
 }
 
 // Lives here, not in services/featurePublishGates: that module already imports
@@ -1973,9 +1977,17 @@ export async function collectHoldoutChangeGates({
   mergeResult: MergeResultChanges;
   isRevert?: boolean;
 }): Promise<PublishGate[]> {
-  if (mergeResult.holdout === undefined) return [];
+  if (
+    mergeResult.holdout === undefined &&
+    mergeResult.metadata?.project === undefined
+  ) {
+    return [];
+  }
   const gates: PublishGate[] = [];
-  const newHoldout = mergeResult.holdout ?? null;
+  const newHoldout =
+    mergeResult.holdout === undefined
+      ? (feature.holdout ?? null)
+      : (mergeResult.holdout ?? null);
 
   // Merged (post-publish) rules, so a bundled experiment-ref for an
   // already-running experiment is caught.
@@ -1997,7 +2009,11 @@ export async function collectHoldoutChangeGates({
   }
 
   try {
-    await assertHoldoutLinkageResolvable(context, newHoldout);
+    await assertHoldoutLinkageResolvable(
+      context,
+      newHoldout,
+      mergeResult.metadata?.project ?? feature.project,
+    );
   } catch (e) {
     gates.push(
       makeBlockingGate({
@@ -2041,7 +2057,7 @@ export async function applyHoldoutSideEffects(
 
   // Resolve the new holdout BEFORE removing from the old one, so a missing
   // holdout fails with no membership mutated (no partial transition).
-  await assertHoldoutLinkageResolvable(context, newHoldout);
+  await assertHoldoutLinkageResolvable(context, newHoldout, feature.project);
 
   // Remove feature from the old holdout. The guard (assertHoldoutChangeAllowed)
   // has already refused this move if any linked experiment still belongs to the

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -1948,8 +1948,7 @@ export async function assertHoldoutChangeAllowed(
   }
 }
 
-// Read-only, so it can run before any mutation instead of after the feature
-// version has already advanced.
+// Read-only, so publish paths can check this before mutating the feature.
 export async function assertHoldoutLinkageResolvable(
   context: ReqContext | ApiReqContext,
   newHoldout: { id: string; value: string } | null,
@@ -1961,15 +1960,8 @@ export async function assertHoldoutLinkageResolvable(
   }
 }
 
-/**
- * The holdout-transition publish gates, shared by every publish surface so the
- * rule has one implementation. Both checks are decidable read-only and so belong
- * at plan time — the linkage writes they precede run after the feature document
- * is advanced, where a failure strands the feature.
- *
- * Lives here rather than in services/featurePublishGates because that module
- * already imports this one; the reverse would be a runtime import cycle.
- */
+// Lives here, not in services/featurePublishGates: that module already imports
+// this one, and the reverse would be a runtime import cycle.
 export async function collectHoldoutChangeGates({
   context,
   feature,
@@ -2093,6 +2085,105 @@ export async function applyHoldoutSideEffects(
         }),
       );
     }
+  }
+}
+
+// The linkage a holdout transition is about to write, captured before the forward
+// pass so its rewind can restore the pre-publish state instead of re-deriving it
+// by running the transition backwards (which cannot express "there was no
+// holdout" and mis-attributes experiments the draft newly added).
+export type HoldoutLinkagePreImage = {
+  featureId: string;
+  prevHoldoutId: string | null;
+  // The old holdout's `linkedFeatures` entry for this feature, so the rewind puts
+  // it back with its original `dateAdded`. Null when it was not linked.
+  prevFeatureEntry: { id: string; dateAdded: Date } | null;
+  newHoldoutId: string | null;
+  addsFeature: boolean;
+  addsExperimentIds: string[];
+  // Keyed by experiment id; "" is the clear sentinel `updateExperiment` expects.
+  experimentHoldoutIds: Record<string, string>;
+};
+
+export async function captureHoldoutLinkagePreImage(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  newHoldout: { id: string } | null,
+  // Post-publish rules, so the captured experiment set matches the forward pass.
+  rules: FeatureRule[],
+): Promise<HoldoutLinkagePreImage | null> {
+  const prevHoldoutId = feature.holdout?.id ?? null;
+  const newHoldoutId = newHoldout?.id ?? null;
+  if (newHoldoutId === prevHoldoutId) return null;
+
+  const experimentHoldoutIds: Record<string, string> = {};
+  if (newHoldoutId) {
+    const ruleExperimentIds = Array.from(
+      new Set(
+        rules
+          .filter((rule) => rule.type === "experiment-ref")
+          .map((rule) => rule.experimentId),
+      ),
+    );
+    // `getExperimentById` is read-filtered, so this sees exactly the experiments
+    // the forward pass will restamp.
+    const experiments = await Promise.all(
+      ruleExperimentIds.map((id) => getExperimentById(context, id)),
+    );
+    for (const exp of experiments) {
+      if (exp) experimentHoldoutIds[exp.id] = exp.holdoutId ?? "";
+    }
+  }
+
+  const newHoldoutDoc = newHoldoutId
+    ? await context.models.holdout.getByIdForLinkage(newHoldoutId)
+    : null;
+  const prevHoldoutDoc = prevHoldoutId
+    ? await context.models.holdout.getByIdForLinkage(prevHoldoutId)
+    : null;
+
+  return {
+    featureId: feature.id,
+    prevHoldoutId,
+    prevFeatureEntry: prevHoldoutDoc?.linkedFeatures[feature.id] ?? null,
+    newHoldoutId,
+    // Only what this publish adds: an entry that was already there belongs to
+    // another writer and must survive the rewind.
+    addsFeature: !!newHoldoutDoc && !newHoldoutDoc.linkedFeatures[feature.id],
+    addsExperimentIds: Object.keys(experimentHoldoutIds).filter(
+      (id) => !newHoldoutDoc?.linkedExperiments[id],
+    ),
+    experimentHoldoutIds,
+  };
+}
+
+// Undoes exactly what `applyHoldoutSideEffects` wrote for this publish. Every
+// step converges on the captured value, so it is a no-op when the forward pass
+// never landed.
+export async function rewindHoldoutLinkage(
+  context: ReqContext | ApiReqContext,
+  pre: HoldoutLinkagePreImage,
+) {
+  if (pre.newHoldoutId) {
+    await context.models.holdout.removeLinkageFromHoldout(pre.newHoldoutId, {
+      featureId: pre.addsFeature ? pre.featureId : null,
+      experimentIds: pre.addsExperimentIds,
+    });
+  }
+
+  for (const [experimentId, holdoutId] of Object.entries(
+    pre.experimentHoldoutIds,
+  )) {
+    const experiment = await getExperimentById(context, experimentId);
+    if (!experiment || (experiment.holdoutId ?? "") === holdoutId) continue;
+    await updateExperiment({ context, experiment, changes: { holdoutId } });
+  }
+
+  if (pre.prevHoldoutId && pre.prevFeatureEntry) {
+    await context.models.holdout.restoreFeatureLinkage(
+      pre.prevHoldoutId,
+      pre.prevFeatureEntry,
+    );
   }
 }
 
@@ -2913,16 +3004,16 @@ export async function prevalidatePublishRevision({
   });
 }
 
-/**
- * Restores only the fields this publish wrote, and only while the live doc still
- * holds the value we wrote — a concurrent writer's different value is newer
- * intent (the bulk publisher's compensation uses the same ownership rule).
- */
+// Restores a key only while the live doc still holds the value this publish
+// wrote — a concurrent writer's different value is newer intent.
 async function restorePublishedFeatureDoc(
   context: ReqContext | ApiReqContext,
   preImage: FeatureInterface,
   revision: FeatureRevisionInterface,
   result: MergeResultChanges,
+  // The persisted post-apply doc, not the computed $set: applyRevisionChanges
+  // mutates `changes` before writing and the read-back normalizes further.
+  writtenFeature: FeatureInterface,
 ) {
   const current = await getFeature(context, preImage.id);
   if (!current) return;
@@ -2941,10 +3032,7 @@ async function restorePublishedFeatureDoc(
   const restore = ownedRestoreValues({
     keys: restoreKeys,
     preImage: preImage as unknown as Record<string, unknown>,
-    written: {
-      ...changes,
-      ...(result.holdout === null ? { holdout: undefined } : {}),
-    },
+    written: writtenFeature as unknown as Record<string, unknown>,
     current: current as unknown as Record<string, unknown>,
   }) as Partial<FeatureInterface>;
 
@@ -2953,13 +3041,8 @@ async function restorePublishedFeatureDoc(
   }
 }
 
-/**
- * Read-only publishability probe: runs every deterministic check and collects
- * them all, so a caller learns everything blocking the publish in one pass
- * instead of fixing one and rediscovering the next. Anything decidable without
- * mutating belongs here, which leaves the commit phase only infra failures and
- * makes the rewind a last resort rather than the primary safety net.
- */
+// Every check decidable without mutating belongs here, so the commit phase is
+// left with only infra failures.
 export async function collectPublishRevisionBlockers({
   context,
   feature,
@@ -2976,13 +3059,15 @@ export async function collectPublishRevisionBlockers({
   comment?: string;
   bypassLockdown?: boolean;
   skipPrevalidateValidation?: boolean;
-}): Promise<string[]> {
-  const blockers: string[] = [];
+}): Promise<Error[]> {
+  // Errors, not messages: SoftWarningError (422 + warnings) and BadRequestError
+  // (400) reach the caller as themselves rather than a generic 500.
+  const blockers: Error[] = [];
   const probe = async (check: () => Promise<void>) => {
     try {
       await check();
     } catch (e) {
-      blockers.push(e instanceof Error ? e.message : String(e));
+      blockers.push(e instanceof Error ? e : new Error(getErrorMessage(e)));
     }
   };
 
@@ -3015,18 +3100,16 @@ export async function collectPublishRevisionBlockers({
     }),
   );
 
-  // Same holdout gates the REST handler and the bulk adapter collect, so the
-  // rule lives in exactly one place across all three publish surfaces. Flattened
-  // to messages here because this legacy commit path throws rather than
-  // returning a structured 422; the gate objects are what survive the eventual
-  // move onto the bulk plan/commit pipeline.
+  // Flattened to one error per message: this path throws instead of returning gates.
   const holdoutGates = await collectHoldoutChangeGates({
     context,
     feature,
     mergeResult: result,
     isRevert: !!revision.revertedFrom,
   });
-  blockers.push(...holdoutGates.flatMap((g) => g.messages));
+  blockers.push(
+    ...holdoutGates.flatMap((g) => g.messages.map((m) => new Error(m))),
+  );
 
   return blockers;
 }
@@ -3057,9 +3140,8 @@ export async function publishRevision({
     throw new Error("Can only publish a draft revision");
   }
 
-  // Everything decidable runs read-only BEFORE any mutation: applyRevisionChanges
-  // advances feature.version and writes feature.holdout, so a check that threw
-  // afterward would leave the feature live on a still-draft revision.
+  // Before any mutation: applyRevisionChanges advances feature.version, so a
+  // later throw would leave the feature live on a still-draft revision.
   const blockers = await collectPublishRevisionBlockers({
     context,
     feature,
@@ -3070,12 +3152,12 @@ export async function publishRevision({
     skipPrevalidateValidation,
   });
   if (blockers.length === 1) {
-    throw new Error(blockers[0]);
+    throw blockers[0];
   }
   if (blockers.length > 1) {
     throw new Error(
       `This revision cannot be published:\n${blockers
-        .map((b) => `• ${b}`)
+        .map((b) => `• ${b.message}`)
         .join("\n")}`,
     );
   }
@@ -3089,9 +3171,9 @@ export async function publishRevision({
   const updateActions = (revision.rampActions ?? []).filter(
     (a) => a.mode === "update",
   );
-  // Each committed step registers how to undo itself, so a later failure can
-  // put live state back instead of leaving a half-published feature behind.
-  const rewinds: { what: string; undo: () => Promise<unknown> }[] = [];
+  type Rewind = { what: string; undo: () => Promise<unknown> };
+  const rewinds: Rewind[] = [];
+  let revisionStatusRewind: Rewind | null = null;
 
   if (createActions.length) {
     const preCreatedScheduleIds = await createRampSchedulesForRevision(
@@ -3116,6 +3198,19 @@ export async function publishRevision({
 
   let updatedFeature: FeatureInterface;
   try {
+    // Captured before any mutation — the holdout transition is several
+    // non-transactional writes, so a failure partway through has already mutated
+    // linkage and must still be repaired.
+    const holdoutPreImage =
+      result.holdout === undefined
+        ? null
+        : await captureHoldoutLinkagePreImage(
+            context,
+            feature,
+            result.holdout,
+            result.rules ?? feature.rules ?? [],
+          );
+
     updatedFeature = await applyRevisionChanges(
       context,
       feature,
@@ -3126,33 +3221,22 @@ export async function publishRevision({
     rewinds.push({
       what: "feature document",
       undo: () =>
-        restorePublishedFeatureDoc(context, feature, revision, result),
+        restorePublishedFeatureDoc(
+          context,
+          feature,
+          revision,
+          result,
+          updatedFeature,
+        ),
     });
 
     if (result.holdout !== undefined) {
-      // Registered BEFORE the transition starts: it is several non-transactional
-      // writes (unlink old, link new, restamp experiments), so a failure partway
-      // through has already mutated linkage and must still be repaired.
-      // Converges to the pre-image rather than undoing a delta, which makes it an
-      // idempotent no-op when the forward write never landed.
-      rewinds.push({
-        what: "holdout linkage",
-        undo: () =>
-          applyHoldoutSideEffects(
-            context,
-            {
-              ...feature,
-              // POST-publish rules, matching the forward pass: it enrolls the
-              // experiments in the merged rules, so the reversal has to consider
-              // that same set or experiments this publish added keep pointing at
-              // the new holdout.
-              rules: result.rules ?? feature.rules,
-              holdout: result.holdout ?? undefined,
-            },
-            feature.holdout ?? null,
-            { isRevert: true },
-          ),
-      });
+      if (holdoutPreImage) {
+        rewinds.push({
+          what: "holdout linkage",
+          undo: () => rewindHoldoutLinkage(context, holdoutPreImage),
+        });
+      }
 
       // Guard already ran above (before any mutation) — skip the re-check.
       // Pass the POST-publish rules: side effects enroll the experiments in
@@ -3174,16 +3258,42 @@ export async function publishRevision({
       context.auditUser,
       comment,
     );
-    rewinds.push({
+    revisionStatusRewind = {
       what: "revision status",
       undo: async () => {
-        await restoreFeatureRevisionAfterFailedBulkPublish(
+        const reopened = await restoreFeatureRevisionAfterFailedBulkPublish(
           revision,
           publishStamp,
         );
+        if (!reopened) {
+          throw new Error("revision was re-published concurrently");
+        }
       },
-    });
+    };
+  } catch (err) {
+    // Leave-whole: on the first failed step, stop — a doc reverted beside a
+    // satellite that stayed published is a worse shape than a publish that
+    // stands. Reopening the revision goes last, so it is never a draft while
+    // the feature doc it advanced stays published.
+    const unwind = [...rewinds].reverse();
+    if (revisionStatusRewind) unwind.push(revisionStatusRewind);
+    for (const { what, undo } of unwind) {
+      try {
+        await undo();
+      } catch (rewindErr) {
+        logger.error(
+          rewindErr,
+          `Failed to rewind ${what} for feature ${feature.id} revision ${revision.version} after a failed publish — stopping rewind, everything not yet rewound stays at the published state`,
+        );
+        break;
+      }
+    }
+    throw err;
+  }
 
+  // The publish is committed once the revision is marked published, so this
+  // sweep must not be able to unwind it.
+  try {
     await clearPendingFeatureDraftsForRevision(
       context,
       revision.featureId,
@@ -3191,23 +3301,10 @@ export async function publishRevision({
       revision.rules,
     );
   } catch (err) {
-    // Reverse order, so satellites unwind before the feature document they hang
-    // off. Leave-whole (same rule as the bulk publisher's compensation): the
-    // moment one step fails, stop and leave the feature published — reverting
-    // the document beside a satellite that stayed published is a worse shape
-    // than a publish that simply stands. The original error always surfaces.
-    for (const { what, undo } of rewinds.reverse()) {
-      try {
-        await undo();
-      } catch (rewindErr) {
-        logger.error(
-          rewindErr,
-          `Failed to rewind ${what} for feature ${feature.id} revision ${revision.version} after a failed publish — stopping rewind, feature left at the published state`,
-        );
-        break;
-      }
-    }
-    throw err;
+    logger.error(
+      err,
+      `Failed to clear pending feature drafts for feature ${feature.id} revision ${revision.version} after publish`,
+    );
   }
 
   // Apply deferred update actions after publish succeeds.
@@ -3264,7 +3361,6 @@ export async function createAndPublishRevision({
   changes: Parameters<typeof createRevision>[0]["changes"];
   comment?: string;
   canBypassApprovalChecks: boolean;
-  // Marks the new revision as a revert; publish-time guards read it off the doc.
   revertedFrom?: number;
 }): Promise<{
   revision: FeatureRevisionInterface;

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -3140,7 +3140,15 @@ export async function publishRevision({
         undo: () =>
           applyHoldoutSideEffects(
             context,
-            { ...feature, holdout: result.holdout ?? undefined },
+            {
+              ...feature,
+              // POST-publish rules, matching the forward pass: it enrolls the
+              // experiments in the merged rules, so the reversal has to consider
+              // that same set or experiments this publish added keep pointing at
+              // the new holdout.
+              rules: result.rules ?? feature.rules,
+              holdout: result.holdout ?? undefined,
+            },
             feature.holdout ?? null,
             { isRevert: true },
           ),

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -2175,15 +2175,27 @@ export async function rewindHoldoutLinkage(
     pre.experimentHoldoutIds,
   )) {
     const experiment = await getExperimentById(context, experimentId);
-    if (!experiment || (experiment.holdoutId ?? "") === holdoutId) continue;
+    if (!experiment) continue;
+    const current = experiment.holdoutId ?? "";
+    if (current === holdoutId) continue;
+    // Undo only our own write: anything else is a later writer's intent, and
+    // the same ownership rule the bulk publisher's compensation uses.
+    if (current !== (pre.newHoldoutId ?? "")) continue;
     await updateExperiment({ context, experiment, changes: { holdoutId } });
   }
 
   if (pre.prevHoldoutId && pre.prevFeatureEntry) {
-    await context.models.holdout.restoreFeatureLinkage(
+    // Skip when something already occupies the slot — re-adding would clobber
+    // a linkage written after this publish failed.
+    const prevHoldout = await context.models.holdout.getByIdForLinkage(
       pre.prevHoldoutId,
-      pre.prevFeatureEntry,
     );
+    if (prevHoldout && !prevHoldout.linkedFeatures[pre.featureId]) {
+      await context.models.holdout.restoreFeatureLinkage(
+        pre.prevHoldoutId,
+        pre.prevFeatureEntry,
+      );
+    }
   }
 }
 

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -90,7 +90,11 @@ import {
 } from "back-end/src/util/features";
 import { getHoldoutAvailableForProject } from "back-end/src/services/holdout-availability";
 import { applyPartialFeatureRuleUpdatesToRevision } from "back-end/src/util/featureRevision.util";
-import { getErrorMessage, NotFoundError } from "back-end/src/util/errors";
+import {
+  BadRequestError,
+  getErrorMessage,
+  NotFoundError,
+} from "back-end/src/util/errors";
 import { logger } from "back-end/src/util/logger";
 import { ownedRestoreValues } from "back-end/src/revisions/bulkPublish/ownedRestore";
 import {
@@ -1876,7 +1880,7 @@ export async function assertNoLinkedHoldoutExperiments(
     .map((exp) => `"${exp.name}"`);
   if (stillInHoldout.length) {
     const plural = stillInHoldout.length > 1;
-    throw new Error(
+    throw new BadRequestError(
       `Cannot remove the holdout while experiment${plural ? "s" : ""} ${stillInHoldout.join(
         ", ",
       )} ${plural ? "are" : "is"} in the rules for this feature and in the holdout. ` +
@@ -1943,7 +1947,7 @@ export async function assertHoldoutChangeAllowed(
     hasBandits ||
     hasSafeRollouts
   ) {
-    throw new Error(
+    throw new BadRequestError(
       "Cannot change holdout when there are running linked experiments in different holdouts, safe rollout rules, or multi-armed bandit rules",
     );
   }

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -89,8 +89,13 @@ import {
   getSDKPayloadKeysByDiff,
 } from "back-end/src/util/features";
 import { applyPartialFeatureRuleUpdatesToRevision } from "back-end/src/util/featureRevision.util";
-import { NotFoundError } from "back-end/src/util/errors";
+import { getErrorMessage, NotFoundError } from "back-end/src/util/errors";
 import { logger } from "back-end/src/util/logger";
+import { ownedRestoreValues } from "back-end/src/revisions/bulkPublish/ownedRestore";
+import {
+  makeBlockingGate,
+  type PublishGate,
+} from "back-end/src/revisions/publishGates";
 import {
   getContextForAgendaJobByOrgId,
   getEnvironmentIdsFromOrg,
@@ -133,6 +138,7 @@ import {
   hasPublishLockingScheduledSibling,
   markRevisionAsPublished,
   computeRevisionPublishChanges,
+  restoreFeatureRevisionAfterFailedBulkPublish,
   updateRevision,
   createRevision,
 } from "./FeatureRevisionModel";
@@ -1942,6 +1948,76 @@ export async function assertHoldoutChangeAllowed(
   }
 }
 
+// Read-only, so it can run before any mutation instead of after the feature
+// version has already advanced.
+export async function assertHoldoutLinkageResolvable(
+  context: ReqContext | ApiReqContext,
+  newHoldout: { id: string; value: string } | null,
+) {
+  if (!newHoldout?.id) return;
+  const holdout = await context.models.holdout.getByIdForLinkage(newHoldout.id);
+  if (!holdout) {
+    throw new Error("Holdout not found");
+  }
+}
+
+/**
+ * The holdout-transition publish gates, shared by every publish surface so the
+ * rule has one implementation. Both checks are decidable read-only and so belong
+ * at plan time — the linkage writes they precede run after the feature document
+ * is advanced, where a failure strands the feature.
+ *
+ * Lives here rather than in services/featurePublishGates because that module
+ * already imports this one; the reverse would be a runtime import cycle.
+ */
+export async function collectHoldoutChangeGates({
+  context,
+  feature,
+  mergeResult,
+  isRevert,
+}: {
+  context: ReqContext | ApiReqContext;
+  feature: FeatureInterface;
+  mergeResult: MergeResultChanges;
+  isRevert?: boolean;
+}): Promise<PublishGate[]> {
+  if (mergeResult.holdout === undefined) return [];
+  const gates: PublishGate[] = [];
+  const newHoldout = mergeResult.holdout ?? null;
+
+  // Merged (post-publish) rules, so a bundled experiment-ref for an
+  // already-running experiment is caught.
+  try {
+    await assertHoldoutChangeAllowed(
+      context,
+      feature,
+      newHoldout,
+      mergeResult.rules ?? feature.rules ?? [],
+      { isRevert },
+    );
+  } catch (e) {
+    gates.push(
+      makeBlockingGate({
+        type: "holdout-change-conflict",
+        messages: [getErrorMessage(e)],
+      }),
+    );
+  }
+
+  try {
+    await assertHoldoutLinkageResolvable(context, newHoldout);
+  } catch (e) {
+    gates.push(
+      makeBlockingGate({
+        type: "holdout-unresolvable",
+        messages: [getErrorMessage(e)],
+      }),
+    );
+  }
+
+  return gates;
+}
+
 // Run HoldoutModel / Experiment side-effects when a feature's holdout
 // membership changes at publish. Called from `publishRevision` when
 // `result.holdout` is defined, so all publish paths (direct, approval,
@@ -1973,12 +2049,7 @@ export async function applyHoldoutSideEffects(
 
   // Resolve the new holdout BEFORE removing from the old one, so a missing
   // holdout fails with no membership mutated (no partial transition).
-  const holdoutObj = newHoldoutId
-    ? await context.models.holdout.getById(newHoldoutId)
-    : null;
-  if (newHoldoutId && !holdoutObj) {
-    throw new Error("Holdout not found");
-  }
+  await assertHoldoutLinkageResolvable(context, newHoldout);
 
   // Remove feature from the old holdout. The guard (assertHoldoutChangeAllowed)
   // has already refused this move if any linked experiment still belongs to the
@@ -1992,7 +2063,7 @@ export async function applyHoldoutSideEffects(
   }
 
   // Link feature (and experiments in its rules) to the new holdout.
-  if (newHoldoutId && holdoutObj) {
+  if (newHoldoutId) {
     const ruleExperimentIds = Array.from(
       new Set(
         (feature.rules ?? [])
@@ -2001,25 +2072,11 @@ export async function applyHoldoutSideEffects(
       ),
     );
 
-    await context.models.holdout.updateById(newHoldoutId, {
-      linkedFeatures: {
-        [feature.id]: { id: feature.id, dateAdded: new Date() },
-        ...holdoutObj.linkedFeatures,
-      },
-      ...(ruleExperimentIds.length
-        ? {
-            linkedExperiments: {
-              ...Object.fromEntries(
-                ruleExperimentIds.map((experimentId) => [
-                  experimentId,
-                  { id: experimentId, dateAdded: new Date() },
-                ]),
-              ),
-              ...holdoutObj.linkedExperiments,
-            },
-          }
-        : {}),
-    });
+    await context.models.holdout.addFeatureToHoldout(
+      newHoldoutId,
+      feature.id,
+      ruleExperimentIds,
+    );
 
     if (ruleExperimentIds.length) {
       const linkedExperiments = await Promise.all(
@@ -2856,6 +2913,124 @@ export async function prevalidatePublishRevision({
   });
 }
 
+/**
+ * Restores only the fields this publish wrote, and only while the live doc still
+ * holds the value we wrote — a concurrent writer's different value is newer
+ * intent (the bulk publisher's compensation uses the same ownership rule).
+ */
+async function restorePublishedFeatureDoc(
+  context: ReqContext | ApiReqContext,
+  preImage: FeatureInterface,
+  revision: FeatureRevisionInterface,
+  result: MergeResultChanges,
+) {
+  const current = await getFeature(context, preImage.id);
+  if (!current) return;
+
+  const { changes } = computeRevisionMergeChanges(
+    context,
+    preImage,
+    revision,
+    result,
+  );
+  const restoreKeys = new Set([...Object.keys(changes), "version"]);
+  // A holdout removal lands via removeHoldoutFromFeature rather than `changes`,
+  // so name the key explicitly whenever this publish transitioned it.
+  if (result.holdout !== undefined) restoreKeys.add("holdout");
+
+  const restore = ownedRestoreValues({
+    keys: restoreKeys,
+    preImage: preImage as unknown as Record<string, unknown>,
+    written: {
+      ...changes,
+      ...(result.holdout === null ? { holdout: undefined } : {}),
+    },
+    current: current as unknown as Record<string, unknown>,
+  }) as Partial<FeatureInterface>;
+
+  if (Object.keys(restore).length) {
+    await updateFeature(context, current, restore);
+  }
+}
+
+/**
+ * Read-only publishability probe: runs every deterministic check and collects
+ * them all, so a caller learns everything blocking the publish in one pass
+ * instead of fixing one and rediscovering the next. Anything decidable without
+ * mutating belongs here, which leaves the commit phase only infra failures and
+ * makes the rewind a last resort rather than the primary safety net.
+ */
+export async function collectPublishRevisionBlockers({
+  context,
+  feature,
+  revision,
+  result,
+  comment,
+  bypassLockdown,
+  skipPrevalidateValidation,
+}: {
+  context: ReqContext | ApiReqContext;
+  feature: FeatureInterface;
+  revision: FeatureRevisionInterface;
+  result: MergeResultChanges;
+  comment?: string;
+  bypassLockdown?: boolean;
+  skipPrevalidateValidation?: boolean;
+}): Promise<string[]> {
+  const blockers: string[] = [];
+  const probe = async (check: () => Promise<void>) => {
+    try {
+      await check();
+    } catch (e) {
+      blockers.push(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  if (!bypassLockdown) {
+    await probe(() => assertFeatureNotLockedByRamp(context, feature.id));
+    await probe(async () => {
+      if (
+        revision.version !== undefined &&
+        (await hasPublishLockingScheduledSibling(
+          context.org.id,
+          feature.id,
+          revision.version,
+        ))
+      ) {
+        throw new Error(
+          "Another draft of this feature is scheduled to publish and has locked publishing of other drafts. Cancel that schedule to publish this revision.",
+        );
+      }
+    });
+  }
+
+  await probe(() =>
+    prevalidatePublishRevision({
+      context,
+      feature,
+      revision,
+      result,
+      comment,
+      skipValidation: skipPrevalidateValidation,
+    }),
+  );
+
+  // Same holdout gates the REST handler and the bulk adapter collect, so the
+  // rule lives in exactly one place across all three publish surfaces. Flattened
+  // to messages here because this legacy commit path throws rather than
+  // returning a structured 422; the gate objects are what survive the eventual
+  // move onto the bulk plan/commit pipeline.
+  const holdoutGates = await collectHoldoutChangeGates({
+    context,
+    feature,
+    mergeResult: result,
+    isRevert: !!revision.revertedFrom,
+  });
+  blockers.push(...holdoutGates.flatMap((g) => g.messages));
+
+  return blockers;
+}
+
 export async function publishRevision({
   context,
   feature,
@@ -2882,45 +3057,26 @@ export async function publishRevision({
     throw new Error("Can only publish a draft revision");
   }
 
-  if (!bypassLockdown) {
-    await assertFeatureNotLockedByRamp(context, feature.id);
-
-    // A sibling draft's "lock other drafts" schedule freezes other publishes.
-    if (
-      revision.version !== undefined &&
-      (await hasPublishLockingScheduledSibling(
-        context.org.id,
-        feature.id,
-        revision.version,
-      ))
-    ) {
-      throw new Error(
-        "Another draft of this feature is scheduled to publish and has locked publishing of other drafts. Cancel that schedule to publish this revision.",
-      );
-    }
-  }
-
-  // Run custom hooks before the side-effect writes below so a rejection doesn't orphan them
-  await prevalidatePublishRevision({
+  // Everything decidable runs read-only BEFORE any mutation: applyRevisionChanges
+  // advances feature.version and writes feature.holdout, so a check that threw
+  // afterward would leave the feature live on a still-draft revision.
+  const blockers = await collectPublishRevisionBlockers({
     context,
     feature,
     revision,
     result,
     comment,
-    skipValidation: skipPrevalidateValidation,
+    bypassLockdown,
+    skipPrevalidateValidation,
   });
-
-  // Guard the holdout change BEFORE any mutation. applyRevisionChanges (below)
-  // advances feature.version and writes feature.holdout; if the holdout guard
-  // ran only afterward and threw, the feature would be left pointing at this
-  // still-draft revision. Check the revision's merged rules (post-publish state)
-  // so a bundled experiment-ref for an already-running experiment is caught.
-  if (result.holdout !== undefined) {
-    await assertHoldoutChangeAllowed(
-      context,
-      feature,
-      result.holdout,
-      result.rules ?? feature.rules ?? [],
+  if (blockers.length === 1) {
+    throw new Error(blockers[0]);
+  }
+  if (blockers.length > 1) {
+    throw new Error(
+      `This revision cannot be published:\n${blockers
+        .map((b) => `• ${b}`)
+        .join("\n")}`,
     );
   }
 
@@ -2933,16 +3089,29 @@ export async function publishRevision({
   const updateActions = (revision.rampActions ?? []).filter(
     (a) => a.mode === "update",
   );
-  const preCreatedScheduleIds: string[] = [];
+  // Each committed step registers how to undo itself, so a later failure can
+  // put live state back instead of leaving a half-published feature behind.
+  const rewinds: { what: string; undo: () => Promise<unknown> }[] = [];
+
   if (createActions.length) {
-    const ids = await createRampSchedulesForRevision(
+    const preCreatedScheduleIds = await createRampSchedulesForRevision(
       context,
       feature,
       revision,
       result,
       createActions,
     );
-    preCreatedScheduleIds.push(...ids);
+    if (preCreatedScheduleIds.length) {
+      rewinds.push({
+        what: "ramp schedules",
+        undo: () =>
+          Promise.all(
+            preCreatedScheduleIds.map((id) =>
+              context.models.rampSchedules.deleteById(id),
+            ),
+          ),
+      });
+    }
   }
 
   let updatedFeature: FeatureInterface;
@@ -2953,6 +3122,12 @@ export async function publishRevision({
       revision,
       result,
     );
+
+    rewinds.push({
+      what: "feature document",
+      undo: () =>
+        restorePublishedFeatureDoc(context, feature, revision, result),
+    });
 
     if (result.holdout !== undefined) {
       // Guard already ran above (before any mutation) — skip the re-check.
@@ -2966,15 +3141,37 @@ export async function publishRevision({
         result.holdout,
         { skipGuard: true },
       );
+      // Converges to the pre-image rather than undoing a delta: a failure
+      // mid-transition still needs repairing, and every step is an idempotent
+      // no-op when the forward write never landed.
+      rewinds.push({
+        what: "holdout linkage",
+        undo: () =>
+          applyHoldoutSideEffects(
+            context,
+            { ...feature, holdout: result.holdout ?? undefined },
+            feature.holdout ?? null,
+            { isRevert: true },
+          ),
+      });
     }
 
-    await markRevisionAsPublished(
+    const publishStamp = await markRevisionAsPublished(
       context,
       feature,
       revision,
       context.auditUser,
       comment,
     );
+    rewinds.push({
+      what: "revision status",
+      undo: async () => {
+        await restoreFeatureRevisionAfterFailedBulkPublish(
+          revision,
+          publishStamp,
+        );
+      },
+    });
 
     await clearPendingFeatureDraftsForRevision(
       context,
@@ -2983,19 +3180,22 @@ export async function publishRevision({
       revision.rules,
     );
   } catch (err) {
-    // Roll back pre-created ramp schedules so they don't linger as orphans.
-    for (const id of preCreatedScheduleIds) {
+    // Reverse order, so satellites unwind before the feature document they hang
+    // off. Leave-whole (same rule as the bulk publisher's compensation): the
+    // moment one step fails, stop and leave the feature published — reverting
+    // the document beside a satellite that stayed published is a worse shape
+    // than a publish that simply stands. The original error always surfaces.
+    for (const { what, undo } of rewinds.reverse()) {
       try {
-        await context.models.rampSchedules.deleteById(id);
-      } catch (deleteErr) {
+        await undo();
+      } catch (rewindErr) {
         logger.error(
-          deleteErr,
-          `Failed to delete orphaned ramp schedule ${id} during publish rollback`,
+          rewindErr,
+          `Failed to rewind ${what} for feature ${feature.id} revision ${revision.version} after a failed publish — stopping rewind, feature left at the published state`,
         );
+        break;
       }
     }
-
-    // TODO(holdouts): undo holdout side effects if the publish failed
     throw err;
   }
 
@@ -3049,6 +3249,8 @@ export async function createAndPublishRevision({
   feature: FeatureInterface;
   user: EventUser;
   org: OrganizationInterface;
+  // Pass `revertedFrom` here to mark the new revision as a revert; publish-time
+  // guards read it off the revision.
   changes: Parameters<typeof createRevision>[0]["changes"];
   comment?: string;
   canBypassApprovalChecks: boolean;

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -3130,6 +3130,22 @@ export async function publishRevision({
     });
 
     if (result.holdout !== undefined) {
+      // Registered BEFORE the transition starts: it is several non-transactional
+      // writes (unlink old, link new, restamp experiments), so a failure partway
+      // through has already mutated linkage and must still be repaired.
+      // Converges to the pre-image rather than undoing a delta, which makes it an
+      // idempotent no-op when the forward write never landed.
+      rewinds.push({
+        what: "holdout linkage",
+        undo: () =>
+          applyHoldoutSideEffects(
+            context,
+            { ...feature, holdout: result.holdout ?? undefined },
+            feature.holdout ?? null,
+            { isRevert: true },
+          ),
+      });
+
       // Guard already ran above (before any mutation) — skip the re-check.
       // Pass the POST-publish rules: side effects enroll the experiments in
       // the feature's rules, and a draft can add the holdout and the
@@ -3141,19 +3157,6 @@ export async function publishRevision({
         result.holdout,
         { skipGuard: true },
       );
-      // Converges to the pre-image rather than undoing a delta: a failure
-      // mid-transition still needs repairing, and every step is an idempotent
-      // no-op when the forward write never landed.
-      rewinds.push({
-        what: "holdout linkage",
-        undo: () =>
-          applyHoldoutSideEffects(
-            context,
-            { ...feature, holdout: result.holdout ?? undefined },
-            feature.holdout ?? null,
-            { isRevert: true },
-          ),
-      });
     }
 
     const publishStamp = await markRevisionAsPublished(
@@ -3244,16 +3247,17 @@ export async function createAndPublishRevision({
   changes,
   comment,
   canBypassApprovalChecks,
+  revertedFrom,
 }: {
   context: ReqContext | ApiReqContext;
   feature: FeatureInterface;
   user: EventUser;
   org: OrganizationInterface;
-  // Pass `revertedFrom` here to mark the new revision as a revert; publish-time
-  // guards read it off the revision.
   changes: Parameters<typeof createRevision>[0]["changes"];
   comment?: string;
   canBypassApprovalChecks: boolean;
+  // Marks the new revision as a revert; publish-time guards read it off the doc.
+  revertedFrom?: number;
 }): Promise<{
   revision: FeatureRevisionInterface;
   updatedFeature: FeatureInterface;
@@ -3322,6 +3326,7 @@ export async function createAndPublishRevision({
     changes,
     org,
     canBypassApprovalChecks,
+    revertedFrom,
   });
 
   // Merge the new revision against the live-feature baseline. base === live

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -3024,7 +3024,14 @@ async function restorePublishedFeatureDoc(
     revision,
     result,
   );
-  const restoreKeys = new Set([...Object.keys(changes), "version"]);
+  const restoreKeys = new Set([
+    ...Object.keys(changes),
+    "version",
+    // updateFeature derives this rather than taking it from `changes`, and it
+    // only ever appends — so restoring the rules alone would leave the feature
+    // listing experiments whose own back-reference the rewind just removed.
+    "linkedExperiments",
+  ]);
   // A holdout removal lands via removeHoldoutFromFeature rather than `changes`,
   // so name the key explicitly whenever this publish transitioned it.
   if (result.holdout !== undefined) restoreKeys.add("holdout");

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -937,6 +937,7 @@ export async function createRevision({
   title,
   org,
   canBypassApprovalChecks,
+  revertedFrom,
 }: {
   context: ReqContext | ApiReqContext;
   feature: FeatureInterface;
@@ -944,6 +945,11 @@ export async function createRevision({
   environments: string[];
   baseVersion?: number;
   changes?: Partial<FeatureRevisionInterface>;
+  // Deliberately its own parameter rather than a `changes` field: callers that
+  // clone a whole revision into `changes` (forking a draft) must not inherit
+  // another revision's revert marker, which would let an edited fork publish
+  // with the revert guard relaxations.
+  revertedFrom?: number;
   publish?: boolean;
   comment?: string;
   title?: string;
@@ -1053,9 +1059,7 @@ export async function createRevision({
     archived,
     metadata,
     holdout,
-    ...(changes?.revertedFrom !== undefined
-      ? { revertedFrom: changes.revertedFrom }
-      : {}),
+    ...(revertedFrom !== undefined ? { revertedFrom } : {}),
   } as FeatureRevisionInterface;
   const requiresReview = checkIfRevisionNeedsReview({
     feature,

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -1145,6 +1145,9 @@ export function computeRevisionUpdate(
   // flip to "-stale" variants (see `staleReviews`) so they stay attributable
   // without counting as active verdicts.
   clearReviews: boolean;
+  // True when a content edit means this revision no longer represents the state
+  // it was created to revert to, so its `revertedFrom` marker must be dropped.
+  clearRevertedFrom: boolean;
   // The `reviews` array to persist when `clearReviews` is true: prior active
   // verdicts demoted to "approved-stale" / "changes-requested-stale".
   staleReviews: FeatureRevisionInterface["reviews"];
@@ -1197,6 +1200,12 @@ export function computeRevisionUpdate(
         }
       : changes;
 
+  // A revert marker only describes the revision as it was created. Once its
+  // content is edited it no longer restores that previously-live state, so the
+  // publish-time guard relaxations it grants must not carry over.
+  const clearRevertedFrom =
+    hasMutableChange && revision.revertedFrom !== undefined;
+
   const clearReviews =
     status === "pending-review" && revision.status !== "pending-review";
   const staleReviews = clearReviews
@@ -1219,7 +1228,9 @@ export function computeRevisionUpdate(
       ...normalizedChanges,
       status,
       ...(clearReviews ? { reviews: staleReviews } : {}),
+      ...(clearRevertedFrom ? { revertedFrom: undefined } : {}),
     },
+    clearRevertedFrom,
     clearReviews,
     staleReviews,
   };
@@ -1270,6 +1281,7 @@ export async function updateRevision(
     status,
     proposedRevision,
     clearReviews,
+    clearRevertedFrom,
     staleReviews,
   } = computeRevisionUpdate(context, feature, revision, changes, resetReview);
 
@@ -1309,6 +1321,7 @@ export async function updateRevision(
         // older content, while the UI can still attribute them.
         ...(clearReviews ? { reviews: staleReviews } : {}),
       },
+      ...(clearRevertedFrom ? { $unset: { revertedFrom: 1 } } : {}),
       ...contributorUpdate,
     },
     { new: true },

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -107,6 +107,8 @@ const featureRevisionSchema = new mongoose.Schema({
   // Live feature version captured when this revision was approved; used to
   // detect approvals that have gone stale due to subsequent publishes.
   approvedBaseVersion: Number,
+  // Version this revision reverts to; marks the revision as a revert.
+  revertedFrom: Number,
   dateCreated: Date,
   dateUpdated: Date,
   datePublished: Date,
@@ -1051,6 +1053,9 @@ export async function createRevision({
     archived,
     metadata,
     holdout,
+    ...(changes?.revertedFrom !== undefined
+      ? { revertedFrom: changes.revertedFrom }
+      : {}),
   } as FeatureRevisionInterface;
   const requiresReview = checkIfRevisionNeedsReview({
     feature,
@@ -1418,6 +1423,11 @@ export async function markRevisionAsPublished(
     });
 
   await dispatchRevisionPublishedHook(context, revision);
+
+  // The datePublished this call stamped: a caller that has to undo the publish
+  // passes it back as the claim fingerprint, so the restore becomes a no-op once
+  // a concurrent legitimate publish has re-stamped the revision.
+  return changes.datePublished ?? null;
 }
 
 /**
@@ -2565,9 +2575,21 @@ export async function discardRevision(
   context: ReqContext | ApiReqContext,
   revision: FeatureRevisionInterface,
   user: EventUser,
+  // The parent feature's current version. Pass it whenever the caller has the
+  // feature so this can refuse to discard the revision the feature is live on.
+  liveVersion?: number,
 ) {
   if (revision.status === "published" || revision.status === "discarded") {
     throw new Error(`Can not discard ${revision.status} revisions`);
+  }
+
+  // Discarding the revision the feature is live on turns a recoverable split
+  // into silent corruption: the feature keeps serving a revision that then
+  // reports as never published, and publishing it can no longer reconcile it.
+  if (liveVersion !== undefined && revision.version === liveVersion) {
+    throw new Error(
+      "This revision is the live version of the Feature Flag, so it cannot be discarded. An earlier publish updated the Feature Flag without marking this revision published — publish it again to reconcile.",
+    );
   }
 
   await FeatureRevisionModel.updateOne(

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -1,6 +1,7 @@
 import mongoose from "mongoose";
 import uniqid from "uniqid";
 import omit from "lodash/omit";
+import isEqual from "lodash/isEqual";
 import {
   checkIfRevisionNeedsReview,
   isRevisionEditLockedBySchedule,
@@ -107,7 +108,7 @@ const featureRevisionSchema = new mongoose.Schema({
   // Live feature version captured when this revision was approved; used to
   // detect approvals that have gone stale due to subsequent publishes.
   approvedBaseVersion: Number,
-  // Version this revision reverts to; marks the revision as a revert.
+  // Version this revision reverts to.
   revertedFrom: Number,
   dateCreated: Date,
   dateUpdated: Date,
@@ -945,10 +946,7 @@ export async function createRevision({
   environments: string[];
   baseVersion?: number;
   changes?: Partial<FeatureRevisionInterface>;
-  // Deliberately its own parameter rather than a `changes` field: callers that
-  // clone a whole revision into `changes` (forking a draft) must not inherit
-  // another revision's revert marker, which would let an edited fork publish
-  // with the revert guard relaxations.
+  // Not a `changes` field: a draft forked from a revert must not inherit the marker.
   revertedFrom?: number;
   publish?: boolean;
   comment?: string;
@@ -1145,8 +1143,7 @@ export function computeRevisionUpdate(
   // flip to "-stale" variants (see `staleReviews`) so they stay attributable
   // without counting as active verdicts.
   clearReviews: boolean;
-  // True when a content edit means this revision no longer represents the state
-  // it was created to revert to, so its `revertedFrom` marker must be dropped.
+  // True when a content edit invalidated the revert marker.
   clearRevertedFrom: boolean;
   // The `reviews` array to persist when `clearReviews` is true: prior active
   // verdicts demoted to "approved-stale" / "changes-requested-stale".
@@ -1200,11 +1197,13 @@ export function computeRevisionUpdate(
         }
       : changes;
 
-  // A revert marker only describes the revision as it was created. Once its
-  // content is edited it no longer restores that previously-live state, so the
-  // publish-time guard relaxations it grants must not carry over.
+  // Compared by value, not presence: a rebase re-sends every mutable field.
   const clearRevertedFrom =
-    hasMutableChange && revision.revertedFrom !== undefined;
+    revision.revertedFrom !== undefined &&
+    MUTABLE_FIELDS.some(
+      (f) =>
+        f in normalizedChanges && !isEqual(normalizedChanges[f], revision[f]),
+    );
 
   const clearReviews =
     status === "pending-review" && revision.status !== "pending-review";
@@ -1391,7 +1390,7 @@ export async function markRevisionAsPublished(
   revision: FeatureRevisionInterface,
   user: EventUser,
   comment?: string,
-) {
+): Promise<Date | null> {
   // "re-publish" only applies to a revision that was already live; publishing
   // an approved (or otherwise in-flight) draft for the first time is a "publish".
   const action = revision.status === "published" ? "re-publish" : "publish";
@@ -1441,9 +1440,6 @@ export async function markRevisionAsPublished(
 
   await dispatchRevisionPublishedHook(context, revision);
 
-  // The datePublished this call stamped: a caller that has to undo the publish
-  // passes it back as the claim fingerprint, so the restore becomes a no-op once
-  // a concurrent legitimate publish has re-stamped the revision.
   return changes.datePublished ?? null;
 }
 
@@ -2592,18 +2588,15 @@ export async function discardRevision(
   context: ReqContext | ApiReqContext,
   revision: FeatureRevisionInterface,
   user: EventUser,
-  // The parent feature's current version. Pass it whenever the caller has the
-  // feature so this can refuse to discard the revision the feature is live on.
-  liveVersion?: number,
+  // The parent feature's current version, or null when the caller can't have
+  // published this revision.
+  liveVersion: number | null,
 ) {
   if (revision.status === "published" || revision.status === "discarded") {
     throw new Error(`Can not discard ${revision.status} revisions`);
   }
 
-  // Discarding the revision the feature is live on turns a recoverable split
-  // into silent corruption: the feature keeps serving a revision that then
-  // reports as never published, and publishing it can no longer reconcile it.
-  if (liveVersion !== undefined && revision.version === liveVersion) {
+  if (liveVersion !== null && revision.version === liveVersion) {
     throw new Error(
       "This revision is the live version of the Feature Flag, so it cannot be discarded. An earlier publish updated the Feature Flag without marking this revision published — publish it again to reconcile.",
     );

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -883,6 +883,9 @@ export async function createInitialRevision(
     environmentsEnabled,
     prerequisites: feature.prerequisites || [],
     archived: feature.archived ?? false,
+    // A feature can be created already attached to a holdout; omitting it here
+    // left revision 1 disagreeing with the feature document.
+    holdout: feature.holdout ?? null,
     metadata: {
       description: feature.description,
       owner: feature.owner,

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -55,6 +55,13 @@ export class HoldoutModel extends BaseClass {
     existing: HoldoutInterface,
     updates: Partial<HoldoutInterface>,
   ) {
+    // Every check below validates schedule dates. Returning early keeps a
+    // linkage-only write from having to resolve the holdout's experiment, which
+    // `getExperimentById` hides from anyone without `readData` on its project —
+    // the holdout experiment carries `project: ""`, so that is the caller's
+    // global role, and a project-scoped flag publisher would fail mid-publish.
+    if ((updates.statusUpdateSchedule ?? null) === null) return;
+
     const holdoutExperiment = await getExperimentById(
       this.context,
       existing.experimentId,
@@ -220,13 +227,10 @@ export class HoldoutModel extends BaseClass {
     holdoutId: string,
     experimentId: string,
   ) {
-    const holdout = await this.getById(holdoutId);
-    if (!holdout) {
-      throw new Error("Holdout not found");
-    }
+    const holdout = await this.getLinkageTarget(holdoutId);
     const { [experimentId]: _, ...linkedExperiments } =
       holdout.linkedExperiments;
-    await this.updateById(holdoutId, { linkedExperiments });
+    await this.writeLinkage(holdout, { linkedExperiments });
   }
 
   public async removeFeatureFromHoldout(holdoutId: string, featureId: string) {
@@ -262,10 +266,53 @@ export class HoldoutModel extends BaseClass {
     });
   }
 
-  // Resolve a linkage target regardless of the caller's read scope: the Holdout
-  // reference is already committed on the Feature Flag, so a linkage write must
-  // not depend on the publisher also being able to see the Holdout's Projects.
-  // Public so a publish path can preflight resolution before it mutates.
+  // Publish-rewind counterpart to `addFeatureToHoldout`: drops only the entries a
+  // failed publish added, in one write, leaving entries other features
+  // contributed alone. No-ops when the maps are already at the target state, so
+  // rewinding a forward pass that never landed writes nothing.
+  public async removeLinkageFromHoldout(
+    holdoutId: string,
+    {
+      featureId,
+      experimentIds,
+    }: { featureId?: string | null; experimentIds?: string[] },
+  ) {
+    const holdout = await this.getByIdForLinkage(holdoutId);
+    if (!holdout) return;
+
+    const drop = new Set(experimentIds ?? []);
+    const linkedExperiments = Object.fromEntries(
+      Object.entries(holdout.linkedExperiments).filter(([id]) => !drop.has(id)),
+    );
+    const linkedFeatures = { ...holdout.linkedFeatures };
+    if (featureId) delete linkedFeatures[featureId];
+
+    if (
+      Object.keys(linkedExperiments).length ===
+        Object.keys(holdout.linkedExperiments).length &&
+      Object.keys(linkedFeatures).length ===
+        Object.keys(holdout.linkedFeatures).length
+    ) {
+      return;
+    }
+    await this.writeLinkage(holdout, { linkedFeatures, linkedExperiments });
+  }
+
+  // Puts a feature back under the holdout it was unlinked from, with its original
+  // `dateAdded`. No-ops when it is still linked.
+  public async restoreFeatureLinkage(
+    holdoutId: string,
+    feature: { id: string; dateAdded: Date },
+  ) {
+    const holdout = await this.getByIdForLinkage(holdoutId);
+    if (!holdout || holdout.linkedFeatures[feature.id]) return;
+    await this.writeLinkage(holdout, {
+      linkedFeatures: { ...holdout.linkedFeatures, [feature.id]: feature },
+    });
+  }
+
+  // Bypasses read scope: the Holdout reference is already committed on the
+  // Feature Flag, so linkage must not depend on the publisher seeing its Projects.
   public async getByIdForLinkage(
     holdoutId: string,
   ): Promise<HoldoutInterface | null> {
@@ -284,16 +331,8 @@ export class HoldoutModel extends BaseClass {
     return holdout;
   }
 
-  // Linkage maps are the back-reference to `feature.holdout`, maintained as a
-  // side effect of an authorized Feature Flag write rather than a user-initiated
-  // Holdout edit — so flag edit/publish authority is enough. Gating them on
-  // Holdout update authority (`createAnalyses`) instead fails mid-publish for
-  // roles that can publish flags but not manage analyses, and an unlinked
-  // Holdout drops out of the SDK payload (getAllPayloadHoldouts) entirely.
-  //
-  // Takes the resolved doc, not an id: the by-id variant re-reads through the
-  // read-permission filter and would reintroduce the same failure for a Holdout
-  // outside the publisher's read scope.
+  // A side effect of an authorized Feature Flag write, so flag authority is
+  // enough — gating on `createAnalyses` fails mid-publish for flag publishers.
   private async writeLinkage(
     holdout: HoldoutInterface,
     updates: UpdateProps<HoldoutInterface>,

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -2,6 +2,7 @@ import { HoldoutInterface, holdoutValidator } from "shared/validators";
 import { UpdateProps } from "shared/types/base-model";
 import { ExperimentInterface } from "shared/types/experiment";
 import { getCollection } from "back-end/src/util/mongo.util";
+import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 import { MakeModelClass } from "./BaseModel";
 import { getExperimentById } from "./ExperimentModel";
 
@@ -67,7 +68,7 @@ export class HoldoutModel extends BaseClass {
       existing.experimentId,
     );
     if (!holdoutExperiment) {
-      throw new Error("Holdout experiment not found");
+      throw new NotFoundError("Holdout experiment not found");
     }
 
     const { startAt, startAnalysisPeriodAt, stopAt } =
@@ -81,7 +82,7 @@ export class HoldoutModel extends BaseClass {
       holdoutExperiment.status === "draft" &&
       new Date(startAt) < now
     ) {
-      throw new Error("Scheduled start date cannot be in the past");
+      throw new BadRequestError("Scheduled start date cannot be in the past");
     }
     if (
       startAnalysisPeriodAt &&
@@ -89,14 +90,16 @@ export class HoldoutModel extends BaseClass {
       !existing.analysisStartDate &&
       new Date(startAnalysisPeriodAt) < now
     ) {
-      throw new Error("Scheduled analysis start date cannot be in the past");
+      throw new BadRequestError(
+        "Scheduled analysis start date cannot be in the past",
+      );
     }
     if (
       stopAt &&
       holdoutExperiment.status !== "stopped" &&
       new Date(stopAt) < now
     ) {
-      throw new Error("Scheduled stop date cannot be in the past");
+      throw new BadRequestError("Scheduled stop date cannot be in the past");
     }
 
     // Check date dependencies
@@ -105,7 +108,7 @@ export class HoldoutModel extends BaseClass {
       stopAt &&
       (!startAt || !startAnalysisPeriodAt)
     ) {
-      throw new Error(
+      throw new BadRequestError(
         "To set a stop date, you must also set a start date and an analysis start date",
       );
     }
@@ -114,7 +117,7 @@ export class HoldoutModel extends BaseClass {
       startAnalysisPeriodAt &&
       !startAt
     ) {
-      throw new Error(
+      throw new BadRequestError(
         "To set an analysis start date, you must first set a start date",
       );
     }
@@ -125,7 +128,7 @@ export class HoldoutModel extends BaseClass {
       stopAt &&
       !startAnalysisPeriodAt
     ) {
-      throw new Error(
+      throw new BadRequestError(
         "To set a stop date, you must first set an analysis start date",
       );
     }
@@ -145,7 +148,7 @@ export class HoldoutModel extends BaseClass {
         !existing.analysisStartDate &&
         startAnalysisPeriodAt > stopAt);
     if (dateError) {
-      throw new Error("Scheduled dates must be consecutive");
+      throw new BadRequestError("Scheduled dates must be consecutive");
     }
   }
 
@@ -336,7 +339,7 @@ export class HoldoutModel extends BaseClass {
   private async getLinkageTarget(holdoutId: string): Promise<HoldoutInterface> {
     const holdout = await this.getByIdForLinkage(holdoutId);
     if (!holdout) {
-      throw new Error("Holdout not found");
+      throw new NotFoundError("Holdout not found");
     }
     return holdout;
   }

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -266,6 +266,16 @@ export class HoldoutModel extends BaseClass {
     });
   }
 
+  public async addExperimentToHoldout(holdoutId: string, experimentId: string) {
+    const holdout = await this.getLinkageTarget(holdoutId);
+    await this.writeLinkage(holdout, {
+      linkedExperiments: {
+        ...holdout.linkedExperiments,
+        [experimentId]: { id: experimentId, dateAdded: new Date() },
+      },
+    });
+  }
+
   // Publish-rewind counterpart to `addFeatureToHoldout`: drops only the entries a
   // failed publish added, in one write, leaving entries other features
   // contributed alone. No-ops when the maps are already at the target state, so

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -230,11 +230,74 @@ export class HoldoutModel extends BaseClass {
   }
 
   public async removeFeatureFromHoldout(holdoutId: string, featureId: string) {
-    const holdout = await this.getById(holdoutId);
+    const holdout = await this.getLinkageTarget(holdoutId);
+    const { [featureId]: _, ...linkedFeatures } = holdout.linkedFeatures;
+    await this.writeLinkage(holdout, { linkedFeatures });
+  }
+
+  public async addFeatureToHoldout(
+    holdoutId: string,
+    featureId: string,
+    experimentIds: string[] = [],
+  ) {
+    const holdout = await this.getLinkageTarget(holdoutId);
+    await this.writeLinkage(holdout, {
+      linkedFeatures: {
+        [featureId]: { id: featureId, dateAdded: new Date() },
+        ...holdout.linkedFeatures,
+      },
+      ...(experimentIds.length
+        ? {
+            linkedExperiments: {
+              ...Object.fromEntries(
+                experimentIds.map((experimentId) => [
+                  experimentId,
+                  { id: experimentId, dateAdded: new Date() },
+                ]),
+              ),
+              ...holdout.linkedExperiments,
+            },
+          }
+        : {}),
+    });
+  }
+
+  // Resolve a linkage target regardless of the caller's read scope: the Holdout
+  // reference is already committed on the Feature Flag, so a linkage write must
+  // not depend on the publisher also being able to see the Holdout's Projects.
+  // Public so a publish path can preflight resolution before it mutates.
+  public async getByIdForLinkage(
+    holdoutId: string,
+  ): Promise<HoldoutInterface | null> {
+    const [holdout] = await this._find(
+      { id: holdoutId },
+      { bypassReadPermissionChecks: true },
+    );
+    return holdout ?? null;
+  }
+
+  private async getLinkageTarget(holdoutId: string): Promise<HoldoutInterface> {
+    const holdout = await this.getByIdForLinkage(holdoutId);
     if (!holdout) {
       throw new Error("Holdout not found");
     }
-    const { [featureId]: _, ...linkedFeatures } = holdout.linkedFeatures;
-    await this.updateById(holdoutId, { linkedFeatures });
+    return holdout;
+  }
+
+  // Linkage maps are the back-reference to `feature.holdout`, maintained as a
+  // side effect of an authorized Feature Flag write rather than a user-initiated
+  // Holdout edit — so flag edit/publish authority is enough. Gating them on
+  // Holdout update authority (`createAnalyses`) instead fails mid-publish for
+  // roles that can publish flags but not manage analyses, and an unlinked
+  // Holdout drops out of the SDK payload (getAllPayloadHoldouts) entirely.
+  //
+  // Takes the resolved doc, not an id: the by-id variant re-reads through the
+  // read-permission filter and would reintroduce the same failure for a Holdout
+  // outside the publisher's read scope.
+  private async writeLinkage(
+    holdout: HoldoutInterface,
+    updates: UpdateProps<HoldoutInterface>,
+  ) {
+    await this.dangerousUpdateBypassPermission(holdout, updates);
   }
 }

--- a/packages/back-end/src/revisions/bulkPublish/featureBulkAdapter.ts
+++ b/packages/back-end/src/revisions/bulkPublish/featureBulkAdapter.ts
@@ -1,4 +1,4 @@
-import type { MergeResultChanges } from "shared/util";
+import { isStrandedLiveRevision, type MergeResultChanges } from "shared/util";
 import { FeatureInterface } from "shared/types/feature";
 import { FeatureRevisionInterface } from "shared/types/feature-revision";
 import type { SafeRolloutInterface } from "shared/validators";
@@ -206,7 +206,17 @@ export const featureBulkAdapter: BulkPublishableAdapter = {
 
     // The generic no-op merge path doesn't apply to features — a publish must
     // advance the live version pointer — so an empty revision blocks.
-    if (!plan.hasChanges) {
+    if (
+      !plan.hasChanges &&
+      // A stranded live revision has no changes either, but publishing it is
+      // how it gets reconciled — gating it would leave no route out.
+      !isStrandedLiveRevision({
+        featureVersion: feature.version,
+        revisionVersion: raw.version,
+        revisionStatus: raw.status,
+        hasChanges: plan.hasChanges,
+      })
+    ) {
       gates.push(
         makeBlockingGate({
           type: "no-changes",

--- a/packages/back-end/src/revisions/bulkPublish/featureBulkAdapter.ts
+++ b/packages/back-end/src/revisions/bulkPublish/featureBulkAdapter.ts
@@ -8,10 +8,13 @@ import {
   assertHoldoutChangeAllowed,
   applyRampCreateActionsForRevision,
   applyRevisionChanges,
+  captureHoldoutLinkagePreImage,
   computeRevisionMergeChanges,
   computeSafeRolloutStatusMap,
   finalizeRampActionsAfterPublish,
   getFeature,
+  type HoldoutLinkagePreImage,
+  rewindHoldoutLinkage,
   rollbackCreatedRampSchedules,
   updateFeature,
 } from "back-end/src/models/FeatureModel";
@@ -79,6 +82,12 @@ type FeatureDesiredState = {
     writtenStatus: string;
     post?: SafeRolloutInterface;
   }>;
+  /**
+   * The holdout linkage the apply is about to write, captured before any
+   * mutation. Absent means the apply threw before that point, so there is
+   * nothing for compensation to reverse.
+   */
+  holdoutLinkage?: HoldoutLinkagePreImage | null;
 };
 
 function toRef(revision: FeatureRevisionInterface): BulkRevisionRef {
@@ -208,8 +217,7 @@ export const featureBulkAdapter: BulkPublishableAdapter = {
     // advance the live version pointer — so an empty revision blocks.
     if (
       !plan.hasChanges &&
-      // A stranded live revision has no changes either, but publishing it is
-      // how it gets reconciled — gating it would leave no route out.
+      // Publishing a stranded revision is how it gets reconciled.
       !isStrandedLiveRevision({
         featureVersion: feature.version,
         revisionVersion: raw.version,
@@ -326,13 +334,18 @@ export const featureBulkAdapter: BulkPublishableAdapter = {
     const desired = desiredState as unknown as FeatureDesiredState;
     const { mergeResult } = desired;
 
-    // Guard the holdout change BEFORE any mutation (ramp schedules, feature
-    // write) so a rejected change fails fast without relying on compensation to
-    // undo an already-advanced feature.version. Check the merged (post-publish)
-    // rules so a bundled experiment-ref for an already-running experiment is
-    // caught.
+    // TOCTOU backstop — the plan gate is the primary check. Runs before any
+    // mutation so a change that became invalid since planning fails fast,
+    // without relying on compensation to undo an advanced feature.version.
     if (mergeResult.holdout !== undefined) {
       await assertHoldoutChangeAllowed(
+        context,
+        feature,
+        mergeResult.holdout,
+        mergeResult.rules ?? feature.rules ?? [],
+        { isRevert: !!raw.revertedFrom },
+      );
+      desired.holdoutLinkage = await captureHoldoutLinkagePreImage(
         context,
         feature,
         mergeResult.holdout,
@@ -467,21 +480,16 @@ export const featureBulkAdapter: BulkPublishableAdapter = {
       assertNoReversalFailures();
     }
 
-    // Reverse the apply-time holdout transition. `isRevert` skips the config-
-    // time guard: this restores a previously-valid holdout state, and the
-    // still-published rules transiently include state the guard would refuse.
-    // Deliberately unconditional (converge to pre-image, not delta-undo): if
-    // the apply threw before the forward holdout write, every step here is an
-    // idempotent no-op; if it threw mid-transition, this repairs the half —
-    // gating on "did the forward write run" would leave that case broken.
-    if (mergeResult.holdout !== undefined) {
+    // Reverse the apply-time holdout transition from the pre-image the apply
+    // captured before any mutation, rather than running the transition backwards:
+    // a reversal derived from the delta cannot express "there was no holdout
+    // before" (its experiment restamping would be skipped entirely) and would
+    // stamp the old holdout onto experiments this revision newly added. Every
+    // step converges on a captured value, so it is an idempotent no-op if the
+    // forward write never landed and repairs the half if it landed partway.
+    if (desired.holdoutLinkage) {
       try {
-        await applyHoldoutSideEffects(
-          context,
-          { ...current, holdout: mergeResult.holdout ?? undefined },
-          feature.holdout ?? null,
-          { isRevert: true },
-        );
+        await rewindHoldoutLinkage(context, desired.holdoutLinkage);
       } catch (e) {
         reversalFailures.push("holdout");
         logger.error(

--- a/packages/back-end/src/routers/holdout/holdout.controller.ts
+++ b/packages/back-end/src/routers/holdout/holdout.controller.ts
@@ -1,4 +1,5 @@
 import type { Response } from "express";
+import isEqual from "lodash/isEqual";
 import { getValidDate } from "shared/dates";
 import { DEFAULT_SEQUENTIAL_TESTING_TUNING_PARAMETER } from "shared/constants";
 import { v4 as uuidv4 } from "uuid";
@@ -31,7 +32,10 @@ import {
   hasArchivedExperiments,
   updateExperiment,
 } from "back-end/src/models/ExperimentModel";
-import { deleteHoldoutAndExperiment } from "back-end/src/services/holdouts";
+import {
+  assertHoldoutScopeCoversLinked,
+  deleteHoldoutAndExperiment,
+} from "back-end/src/services/holdouts";
 import {
   assertNoLinkedHoldoutExperiments,
   getFeature,
@@ -461,6 +465,12 @@ export const updateHoldout = async (
     } else {
       updates.nextScheduledStatusUpdate = null;
     }
+  }
+
+  // Only when the scope actually changes — a Holdout already holding a stranded
+  // link (created before this guard existed) must stay editable so it can be fixed.
+  if (updates.projects && !isEqual(updates.projects, holdout.projects)) {
+    await assertHoldoutScopeCoversLinked(context, holdout, updates.projects);
   }
 
   const updatedHoldout = await context.models.holdout.update(holdout, updates);

--- a/packages/back-end/src/routers/holdout/holdout.controller.ts
+++ b/packages/back-end/src/routers/holdout/holdout.controller.ts
@@ -46,7 +46,11 @@ import {
   validateVariationIds,
 } from "back-end/src/services/experiments";
 import { auditDetailsCreate } from "back-end/src/services/audit";
-import { SoftWarningError } from "back-end/src/util/errors";
+import {
+  BadRequestError,
+  InternalServerError,
+  SoftWarningError,
+} from "back-end/src/util/errors";
 import { validateExperimentChange } from "back-end/src/services/experimentChanges/changeExperimentStatus";
 import { PrivateApiErrorResponse } from "back-end/types/api";
 import { getAffectedSDKPayloadKeys } from "back-end/src/util/holdouts";
@@ -258,7 +262,7 @@ export const createHoldout = async (
     });
 
     if (!holdout) {
-      throw new Error("Failed to create holdout");
+      throw new InternalServerError("Failed to create holdout");
     }
 
     if (datasource && req.query.autoRefreshResults && metricIds.length > 0) {
@@ -573,7 +577,7 @@ export const editStatus = async (
   } else if (req.body.status === "running") {
     // check to see if already in analysis phase
     if (!phases[0]) {
-      throw new Error("Holdout does not have a phase");
+      throw new BadRequestError("Holdout does not have a phase");
     }
     if (
       !phases[1] ||

--- a/packages/back-end/src/services/experiment-feature.ts
+++ b/packages/back-end/src/services/experiment-feature.ts
@@ -616,12 +616,21 @@ export async function publishPendingFeatureDraftsForExperiment(
         { experimentId: experiment.id, featureId, revisionVersion },
         "Discarding no-op pending feature draft on experiment start",
       );
-      await discardRevision(
-        context,
-        revision,
-        context.auditUser,
-        feature.version,
-      );
+      try {
+        await discardRevision(
+          context,
+          revision,
+          context.auditUser,
+          feature.version,
+        );
+      } catch (err) {
+        logger.error(
+          { err, experimentId: experiment.id, featureId, revisionVersion },
+          "Failed to discard no-op pending feature draft on experiment start",
+        );
+        failed.push({ featureId, revisionVersion, reason: "publish-error" });
+        break;
+      }
       await removePendingFeatureDraftFromExperiment(
         context,
         experiment.id,

--- a/packages/back-end/src/services/experiment-feature.ts
+++ b/packages/back-end/src/services/experiment-feature.ts
@@ -616,7 +616,12 @@ export async function publishPendingFeatureDraftsForExperiment(
         { experimentId: experiment.id, featureId, revisionVersion },
         "Discarding no-op pending feature draft on experiment start",
       );
-      await discardRevision(context, revision, context.auditUser);
+      await discardRevision(
+        context,
+        revision,
+        context.auditUser,
+        feature.version,
+      );
       await removePendingFeatureDraftFromExperiment(
         context,
         experiment.id,

--- a/packages/back-end/src/services/featurePublishGates.ts
+++ b/packages/back-end/src/services/featurePublishGates.ts
@@ -15,7 +15,10 @@ import { FeatureRevisionInterface } from "shared/types/feature-revision";
 import type { EventUser } from "shared/types/events/event-types";
 import type { ApiReqContext } from "back-end/types/api";
 import type { ReqContext } from "back-end/types/request";
-import { computeProposedFeatureForValidation } from "back-end/src/models/FeatureModel";
+import {
+  collectHoldoutChangeGates,
+  computeProposedFeatureForValidation,
+} from "back-end/src/models/FeatureModel";
 import { computeRevisionPublishChanges } from "back-end/src/models/FeatureRevisionModel";
 import {
   collectFeatureValueErrorsForPublish,
@@ -183,10 +186,11 @@ export async function planFeatureRevisionMerge({
 
 /**
  * The interactive publish handler's gate set: stale-base, approval-required,
- * and (when `includeValidationGates`) publish-time value validation, custom
- * hooks, and archive-dependents. Throws on a config-backed default carrying
- * its own override patch — a structural payload error no override clears
- * (the bulk adapter catches it and reports it as a no-override gate).
+ * holdout transition, and (when `includeValidationGates`) publish-time value
+ * validation, custom hooks, and archive-dependents. Throws on a config-backed
+ * default carrying its own override patch — a structural payload error no
+ * override clears (the bulk adapter catches it and reports it as a no-override
+ * gate).
  */
 export async function collectFeaturePublishGates({
   context,
@@ -255,6 +259,19 @@ export async function collectFeaturePublishGates({
       }),
     );
   }
+
+  // Above the validation-gate cutoff on purpose: a holdout conflict is a
+  // structural guard, not data validation, and every publish surface — including
+  // the armed/scheduled ones that skip validation gates — must bail out before
+  // the linkage writes rather than throwing after the feature has advanced.
+  gates.push(
+    ...(await collectHoldoutChangeGates({
+      context,
+      feature,
+      mergeResult: plan.mergeResult,
+      isRevert: !!revision.revertedFrom,
+    })),
+  );
 
   if (!includeValidationGates) return gates;
 

--- a/packages/back-end/src/services/featurePublishGates.ts
+++ b/packages/back-end/src/services/featurePublishGates.ts
@@ -260,10 +260,8 @@ export async function collectFeaturePublishGates({
     );
   }
 
-  // Above the validation-gate cutoff on purpose: a holdout conflict is a
-  // structural guard, not data validation, and every publish surface — including
-  // the armed/scheduled ones that skip validation gates — must bail out before
-  // the linkage writes rather than throwing after the feature has advanced.
+  // Above the validation-gate cutoff on purpose: surfaces that skip validation
+  // gates still must not reach the linkage writes with a bad holdout transition.
   gates.push(
     ...(await collectHoldoutChangeGates({
       context,

--- a/packages/back-end/src/services/holdout-availability.ts
+++ b/packages/back-end/src/services/holdout-availability.ts
@@ -1,0 +1,32 @@
+import { HoldoutInterface } from "shared/validators";
+import { ApiReqContext } from "back-end/types/api";
+import { ReqContext } from "back-end/types/request";
+
+export async function getHoldoutAvailableForProject({
+  context,
+  holdoutId,
+  project,
+  bypassReadPermissionChecks = false,
+}: {
+  context: ReqContext | ApiReqContext;
+  holdoutId: string;
+  project: string | undefined;
+  bypassReadPermissionChecks?: boolean;
+}): Promise<HoldoutInterface> {
+  const holdout = bypassReadPermissionChecks
+    ? await context.models.holdout.getByIdForLinkage(holdoutId)
+    : await context.models.holdout.getById(holdoutId);
+  if (!holdout) {
+    throw new Error("Holdout not found");
+  }
+
+  const available =
+    holdout.projects.length === 0 ||
+    (!!project && holdout.projects.includes(project));
+  if (!available) {
+    throw new Error(
+      `Holdout "${holdout.name}" is not available in the selected Project.`,
+    );
+  }
+  return holdout;
+}

--- a/packages/back-end/src/services/holdout-availability.ts
+++ b/packages/back-end/src/services/holdout-availability.ts
@@ -1,6 +1,7 @@
 import { HoldoutInterface } from "shared/validators";
 import { ApiReqContext } from "back-end/types/api";
 import { ReqContext } from "back-end/types/request";
+import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 
 export async function getHoldoutAvailableForProject({
   context,
@@ -17,14 +18,16 @@ export async function getHoldoutAvailableForProject({
     ? await context.models.holdout.getByIdForLinkage(holdoutId)
     : await context.models.holdout.getById(holdoutId);
   if (!holdout) {
-    throw new Error("Holdout not found");
+    // Also the read-scope failure mode: an unreadable Holdout is indistinguishable
+    // from a missing one, deliberately.
+    throw new NotFoundError("Holdout not found");
   }
 
   const available =
     holdout.projects.length === 0 ||
     (!!project && holdout.projects.includes(project));
   if (!available) {
-    throw new Error(
+    throw new BadRequestError(
       `Holdout "${holdout.name}" is not available in the selected Project.`,
     );
   }

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -16,6 +16,7 @@ import { getEnvironmentIdsFromOrg } from "back-end/src/services/organizations";
 import { getAffectedSDKPayloadKeys } from "back-end/src/util/holdouts";
 import { queueSDKPayloadRefresh } from "back-end/src/services/features";
 import { getHoldoutAvailableForProject } from "back-end/src/services/holdout-availability";
+import { BadRequestError } from "back-end/src/util/errors";
 
 /**
  * Eagerly link an experiment into a holdout: set `experiment.holdoutId` and add
@@ -199,4 +200,52 @@ export async function deleteHoldoutAndExperiment(
       id: holdout.id,
     },
   });
+}
+
+/**
+ * Mirror of `getHoldoutAvailableForProject`, applied from the Holdout side:
+ * narrowing a Holdout's Projects must not strand entities that are already
+ * linked from outside the new scope. Without this, the same invalid pairing the
+ * feature/experiment side refuses can be created by editing the Holdout, and a
+ * project-scoped SDK Connection then drops the Holdout from its payload while
+ * the Feature Flag still shows the rule.
+ */
+export async function assertHoldoutScopeCoversLinked(
+  context: ReqContext | ApiReqContext,
+  holdout: HoldoutInterface,
+  projects: string[],
+): Promise<void> {
+  // No Projects means every Project, so nothing can fall outside.
+  if (!projects.length) return;
+
+  const covered = new Set(projects);
+  const featureIds = Object.keys(holdout.linkedFeatures ?? {});
+  const experimentIds = Object.keys(holdout.linkedExperiments ?? {});
+  if (!featureIds.length && !experimentIds.length) return;
+
+  const stranded: string[] = [];
+
+  if (featureIds.length) {
+    const features = await getFeaturesByIds(context, featureIds);
+    for (const feature of features) {
+      if (!covered.has(feature.project ?? "")) {
+        stranded.push(`Feature Flag "${feature.id}"`);
+      }
+    }
+  }
+
+  if (experimentIds.length) {
+    const experiments = await getExperimentsByIds(context, experimentIds);
+    for (const experiment of experiments) {
+      if (!covered.has(experiment.project ?? "")) {
+        stranded.push(`Experiment "${experiment.name}"`);
+      }
+    }
+  }
+
+  if (stranded.length) {
+    throw new BadRequestError(
+      `${stranded.join(", ")} ${stranded.length > 1 ? "are" : "is"} linked to this Holdout but ${stranded.length > 1 ? "are" : "is"} not in the selected Projects. Remove ${stranded.length > 1 ? "them" : "it"} from the Holdout first.`,
+    );
+  }
 }

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -15,6 +15,7 @@ import {
 import { getEnvironmentIdsFromOrg } from "back-end/src/services/organizations";
 import { getAffectedSDKPayloadKeys } from "back-end/src/util/holdouts";
 import { queueSDKPayloadRefresh } from "back-end/src/services/features";
+import { getHoldoutAvailableForProject } from "back-end/src/services/holdout-availability";
 
 /**
  * Eagerly link an experiment into a holdout: set `experiment.holdoutId` and add
@@ -33,18 +34,33 @@ export async function linkExperimentToHoldout(
   experiment: ExperimentInterface,
   holdoutId: string,
 ): Promise<void> {
+  await getHoldoutAvailableForProject({
+    context,
+    holdoutId,
+    project: experiment.project,
+    bypassReadPermissionChecks: true,
+  });
   await updateExperiment({
     context,
     experiment,
     changes: { holdoutId },
   });
-  const holdout = await context.models.holdout.getById(holdoutId);
-  await context.models.holdout.updateById(holdoutId, {
-    linkedExperiments: {
-      ...holdout?.linkedExperiments,
-      [experiment.id]: { id: experiment.id, dateAdded: new Date() },
-    },
-  });
+  await context.models.holdout.addExperimentToHoldout(holdoutId, experiment.id);
+}
+
+export async function canLinkExperimentToHoldoutFromFeatures(
+  context: ReqContext | ApiReqContext,
+  holdoutId: string,
+  featureIds: string[],
+): Promise<boolean> {
+  if (!featureIds.length) return false;
+  const features = await getFeaturesByIds(context, featureIds);
+  return features.some(
+    (feature) =>
+      feature.holdout?.id === holdoutId &&
+      context.permissions.canUpdateFeature(feature, {}) &&
+      context.permissions.canManageFeatureDrafts(feature),
+  );
 }
 
 /**

--- a/packages/back-end/test/api/features/holdout-publish.test.ts
+++ b/packages/back-end/test/api/features/holdout-publish.test.ts
@@ -1,0 +1,207 @@
+import request from "supertest";
+import mongoose from "mongoose";
+import type { Request } from "express";
+import type { OrganizationInterface } from "shared/types/organization";
+import { ReqContextClass } from "back-end/src/services/context";
+import { setupApp } from "../api.setup";
+
+// Coverage for the three headline behaviors of the holdout-publish fixes:
+//  1. Publishing a holdout change no longer needs `createAnalyses`. The linkage
+//     back-reference on the Holdout is a side effect of an authorized flag
+//     publish, so an engineer (FeaturesFullAccess, no HoldoutsFullAccess) must
+//     be able to complete it — it used to throw mid-publish, after the feature
+//     document had already advanced, stranding the flag.
+//  2. A stranded live revision (feature.version === revision.version, still a
+//     draft, diffs empty) publishes: the revision closes as published and the
+//     feature version does NOT advance again.
+//  3. That same revision cannot be discarded — discarding it would leave the
+//     feature serving a revision that reports as never published.
+
+const ORG_ID = "org_holdout_publish";
+
+const org = {
+  id: ORG_ID,
+  name: "Holdout Publish",
+  ownerEmail: "test@test.com",
+  url: "",
+  dateCreated: new Date(),
+  members: [],
+  settings: {
+    environments: [{ id: "production" }],
+  },
+} as unknown as OrganizationInterface;
+
+// Engineer: FeaturesFullAccess + SDKPayloadPublish + ReadData, but NOT
+// HoldoutsFullAccess — so `canUpdateHoldout` (createAnalyses) is false while
+// every flag publish permission passes. Exactly the role shape that used to
+// fail mid-publish.
+function makeEngineerContext(): ReqContextClass {
+  const context = new ReqContextClass({
+    org,
+    auditUser: { type: "api_key", apiKey: "key_engineer" },
+    role: "engineer",
+    req: { query: {}, headers: {}, body: {} } as unknown as Request,
+  });
+  context.hasPremiumFeature = () => true;
+  return context;
+}
+
+async function insertFeature(id: string, version = 1): Promise<void> {
+  const now = new Date();
+  await mongoose.connection.collection("features").insertOne({
+    id,
+    organization: ORG_ID,
+    owner: "",
+    description: "",
+    project: "",
+    valueType: "boolean",
+    defaultValue: "false",
+    version,
+    archived: false,
+    tags: [],
+    rules: [],
+    environmentSettings: { production: { enabled: true, rules: [] } },
+    prerequisites: [],
+    dateCreated: now,
+    dateUpdated: now,
+  });
+}
+
+async function insertHoldout(id: string): Promise<void> {
+  const now = new Date();
+  await mongoose.connection.collection("experiments").insertOne({
+    id: `exp_${id}`,
+    organization: ORG_ID,
+    project: "",
+    trackingKey: id,
+    name: `${id} holdout experiment`,
+    status: "running",
+    archived: false,
+    variations: [],
+    phases: [],
+    dateCreated: now,
+    dateUpdated: now,
+  });
+  await mongoose.connection.collection("holdouts").insertOne({
+    id,
+    organization: ORG_ID,
+    name: id,
+    projects: [],
+    experimentId: `exp_${id}`,
+    linkedExperiments: {},
+    linkedFeatures: {},
+    environmentSettings: { production: { enabled: true, rules: [] } },
+    dateCreated: now,
+    dateUpdated: now,
+  });
+}
+
+async function insertRevision(
+  featureId: string,
+  version: number,
+  status: "published" | "draft",
+): Promise<void> {
+  const now = new Date();
+  await mongoose.connection.collection("featurerevisions").insertOne({
+    id: `frev_${featureId}_${version}`,
+    organization: ORG_ID,
+    featureId,
+    version,
+    baseVersion: Math.max(version - 1, 0),
+    status,
+    createdBy: { type: "api_key", apiKey: "key_engineer" },
+    comment: "",
+    defaultValue: "false",
+    rules: [],
+    dateCreated: now,
+    dateUpdated: now,
+    ...(status === "published" ? { datePublished: now } : {}),
+  });
+}
+
+// The feature is live on version 2 but that revision was never marked published
+// — the stranded shape a mid-publish throw used to leave behind.
+async function insertStrandedFeature(featureId: string): Promise<void> {
+  await insertFeature(featureId, 2);
+  await insertRevision(featureId, 1, "published");
+  await insertRevision(featureId, 2, "draft");
+}
+
+describe("holdout publish", () => {
+  const { app, setReqContext } = setupApp();
+
+  it("publishes a holdout change for a role without createAnalyses and writes the linkage", async () => {
+    const context = makeEngineerContext();
+    setReqContext(context);
+    // The relaxation is what makes this pass; assert the role really lacks
+    // holdout-update authority so the test can't silently stop covering it.
+    expect(context.permissions.canUpdateHoldout({ projects: [] }, {})).toBe(
+      false,
+    );
+
+    await insertFeature("flag_holdout_link");
+    await insertRevision("flag_holdout_link", 1, "published");
+    await insertHoldout("hld_link_target");
+
+    const setRes = await request(app)
+      .put("/api/v2/features/flag_holdout_link/revisions/new/holdout")
+      .send({ holdout: { id: "hld_link_target", value: "false" } })
+      .set("Authorization", "Bearer foo");
+    expect(setRes.status).toBe(200);
+    const version = setRes.body.revision.version;
+
+    const publishRes = await request(app)
+      .post(`/api/v2/features/flag_holdout_link/revisions/${version}/publish`)
+      .send({})
+      .set("Authorization", "Bearer foo");
+    expect(publishRes.status).toBe(200);
+
+    const holdout = await mongoose.connection
+      .collection("holdouts")
+      .findOne({ id: "hld_link_target" });
+    expect(holdout?.linkedFeatures?.flag_holdout_link).toBeTruthy();
+
+    const feature = await mongoose.connection
+      .collection("features")
+      .findOne({ id: "flag_holdout_link" });
+    expect(feature?.holdout?.id).toBe("hld_link_target");
+  });
+
+  it("publishing a stranded live revision closes it without advancing the feature version", async () => {
+    setReqContext(makeEngineerContext());
+    await insertStrandedFeature("flag_stranded");
+
+    const publishRes = await request(app)
+      .post("/api/v2/features/flag_stranded/revisions/2/publish")
+      .send({})
+      .set("Authorization", "Bearer foo");
+    expect(publishRes.status).toBe(200);
+
+    const revision = await mongoose.connection
+      .collection("featurerevisions")
+      .findOne({ featureId: "flag_stranded", version: 2 });
+    expect(revision?.status).toBe("published");
+
+    const feature = await mongoose.connection
+      .collection("features")
+      .findOne({ id: "flag_stranded" });
+    expect(feature?.version).toBe(2);
+  });
+
+  it("refuses to discard the revision the feature is live on", async () => {
+    setReqContext(makeEngineerContext());
+    await insertStrandedFeature("flag_no_discard");
+
+    const res = await request(app)
+      .post("/api/v2/features/flag_no_discard/revisions/2/discard")
+      .send({})
+      .set("Authorization", "Bearer foo");
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/live version of the Feature Flag/);
+
+    const revision = await mongoose.connection
+      .collection("featurerevisions")
+      .findOne({ featureId: "flag_no_discard", version: 2 });
+    expect(revision?.status).toBe("draft");
+  });
+});

--- a/packages/back-end/test/api/features/holdout-publish.test.ts
+++ b/packages/back-end/test/api/features/holdout-publish.test.ts
@@ -3,18 +3,22 @@ import mongoose from "mongoose";
 import type { Request } from "express";
 import type { OrganizationInterface } from "shared/types/organization";
 import { ReqContextClass } from "back-end/src/services/context";
+import { canLinkExperimentToHoldoutFromFeatures } from "back-end/src/services/holdouts";
+import { getHoldoutAvailableForProject } from "back-end/src/services/holdout-availability";
 import { setupApp } from "../api.setup";
 
-// Coverage for the three headline behaviors of the holdout-publish fixes:
+// Coverage for the headline behaviors of the holdout-publish fixes:
 //  1. Publishing a holdout change no longer needs `createAnalyses`. The linkage
 //     back-reference on the Holdout is a side effect of an authorized flag
 //     publish, so an engineer (FeaturesFullAccess, no HoldoutsFullAccess) must
 //     be able to complete it — it used to throw mid-publish, after the feature
 //     document had already advanced, stranding the flag.
-//  2. A stranded live revision (feature.version === revision.version, still a
+//  2. Adding an experiment rule to a holdout-bound flag likewise does not need
+//     permission to edit the holdout's other fields.
+//  3. A stranded live revision (feature.version === revision.version, still a
 //     draft, diffs empty) publishes: the revision closes as published and the
 //     feature version does NOT advance again.
-//  3. That same revision cannot be discarded — discarding it would leave the
+//  4. That same revision cannot be discarded — discarding it would leave the
 //     feature serving a revision that reports as never published.
 
 const ORG_ID = "org_holdout_publish";
@@ -35,31 +39,39 @@ const org = {
 // HoldoutsFullAccess — so `canUpdateHoldout` (createAnalyses) is false while
 // every flag publish permission passes. Exactly the role shape that used to
 // fail mid-publish.
-function makeEngineerContext(): ReqContextClass {
+function makeContext(
+  role: "engineer" | "experimenter" = "engineer",
+): ReqContextClass {
   const context = new ReqContextClass({
     org,
     auditUser: { type: "api_key", apiKey: "key_engineer" },
-    role: "engineer",
+    role,
     req: { query: {}, headers: {}, body: {} } as unknown as Request,
   });
   context.hasPremiumFeature = () => true;
   return context;
 }
 
-async function insertFeature(id: string, version = 1): Promise<void> {
+async function insertFeature(
+  id: string,
+  version = 1,
+  holdout?: { id: string; value: string },
+  project = "",
+): Promise<void> {
   const now = new Date();
   await mongoose.connection.collection("features").insertOne({
     id,
     organization: ORG_ID,
     owner: "",
     description: "",
-    project: "",
+    project,
     valueType: "boolean",
     defaultValue: "false",
     version,
     archived: false,
     tags: [],
     rules: [],
+    ...(holdout ? { holdout } : {}),
     environmentSettings: { production: { enabled: true, rules: [] } },
     prerequisites: [],
     dateCreated: now,
@@ -67,7 +79,55 @@ async function insertFeature(id: string, version = 1): Promise<void> {
   });
 }
 
-async function insertHoldout(id: string): Promise<void> {
+async function insertExperiment(id: string, project = ""): Promise<void> {
+  const now = new Date();
+  await mongoose.connection.collection("experiments").insertOne({
+    id,
+    organization: ORG_ID,
+    project,
+    projects: [],
+    trackingKey: id,
+    name: id,
+    type: "standard",
+    hypothesis: "",
+    description: "",
+    tags: [],
+    owner: "",
+    status: "draft",
+    archived: false,
+    variations: [
+      {
+        id: "v0",
+        key: "0",
+        name: "Control",
+        description: "",
+        screenshots: [],
+      },
+      {
+        id: "v1",
+        key: "1",
+        name: "Variation",
+        description: "",
+        screenshots: [],
+      },
+    ],
+    phases: [],
+    goalMetrics: [],
+    secondaryMetrics: [],
+    guardrailMetrics: [],
+    linkedFeatures: [],
+    hasVisualChangesets: false,
+    hasURLRedirects: false,
+    customFields: {},
+    dateCreated: now,
+    dateUpdated: now,
+  });
+}
+
+async function insertHoldout(
+  id: string,
+  projects: string[] = [],
+): Promise<void> {
   const now = new Date();
   await mongoose.connection.collection("experiments").insertOne({
     id: `exp_${id}`,
@@ -86,7 +146,7 @@ async function insertHoldout(id: string): Promise<void> {
     id,
     organization: ORG_ID,
     name: id,
-    projects: [],
+    projects,
     experimentId: `exp_${id}`,
     linkedExperiments: {},
     linkedFeatures: {},
@@ -131,7 +191,7 @@ describe("holdout publish", () => {
   const { app, setReqContext } = setupApp();
 
   it("publishes a holdout change for a role without createAnalyses and writes the linkage", async () => {
-    const context = makeEngineerContext();
+    const context = makeContext();
     setReqContext(context);
     // The relaxation is what makes this pass; assert the role really lacks
     // holdout-update authority so the test can't silently stop covering it.
@@ -167,8 +227,88 @@ describe("holdout publish", () => {
     expect(feature?.holdout?.id).toBe("hld_link_target");
   });
 
+  it("adds an experiment rule to a holdout-bound feature without holdout access", async () => {
+    const context = makeContext("experimenter");
+    jest.spyOn(context.permissions, "canUpdateHoldout").mockReturnValue(false);
+    jest
+      .spyOn(context.permissions, "canReadMultiProjectResource")
+      .mockImplementation(
+        (projects) => !projects.includes("project_without_access"),
+      );
+    setReqContext(context);
+
+    await insertHoldout("hld_existing", [
+      "project_with_access",
+      "project_without_access",
+    ]);
+    await insertFeature(
+      "flag_existing_holdout",
+      1,
+      {
+        id: "hld_existing",
+        value: "false",
+      },
+      "project_with_access",
+    );
+    await insertRevision("flag_existing_holdout", 1, "published");
+    await insertRevision("flag_existing_holdout", 2, "draft");
+    await insertExperiment("exp_new", "project_with_access");
+    expect(
+      await canLinkExperimentToHoldoutFromFeatures(context, "hld_existing", [
+        "flag_existing_holdout",
+      ]),
+    ).toBe(true);
+    expect(
+      await canLinkExperimentToHoldoutFromFeatures(context, "hld_existing", [
+        "missing_feature",
+      ]),
+    ).toBe(false);
+    await expect(
+      getHoldoutAvailableForProject({
+        context,
+        holdoutId: "hld_existing",
+        project: "project_with_access",
+        bypassReadPermissionChecks: true,
+      }),
+    ).resolves.toMatchObject({ id: "hld_existing" });
+    await expect(
+      getHoldoutAvailableForProject({
+        context,
+        holdoutId: "hld_existing",
+        project: "unavailable_project",
+        bypassReadPermissionChecks: true,
+      }),
+    ).rejects.toThrow(/not available in the selected Project/);
+
+    const res = await request(app)
+      .post("/api/v1/features/flag_existing_holdout/revisions/2/rules")
+      .send({
+        environment: "production",
+        rule: {
+          type: "experiment-ref",
+          condition: "",
+          experimentId: "exp_new",
+          variations: [
+            { variationId: "v0", value: "false" },
+            { variationId: "v1", value: "true" },
+          ],
+        },
+      })
+      .set("Authorization", "Bearer foo");
+
+    expect(res.status).toBe(200);
+    const experiment = await mongoose.connection
+      .collection("experiments")
+      .findOne({ id: "exp_new" });
+    expect(experiment?.holdoutId).toBe("hld_existing");
+    const holdout = await mongoose.connection
+      .collection("holdouts")
+      .findOne({ id: "hld_existing" });
+    expect(holdout?.linkedExperiments?.exp_new).toBeTruthy();
+  });
+
   it("publishing a stranded live revision closes it without advancing the feature version", async () => {
-    setReqContext(makeEngineerContext());
+    setReqContext(makeContext());
     await insertStrandedFeature("flag_stranded");
 
     const publishRes = await request(app)
@@ -189,7 +329,7 @@ describe("holdout publish", () => {
   });
 
   it("refuses to discard the revision the feature is live on", async () => {
-    setReqContext(makeEngineerContext());
+    setReqContext(makeContext());
     await insertStrandedFeature("flag_no_discard");
 
     const res = await request(app)

--- a/packages/back-end/test/models/computeRevisionUpdate.test.ts
+++ b/packages/back-end/test/models/computeRevisionUpdate.test.ts
@@ -247,6 +247,23 @@ describe("computeRevisionUpdate revert marker", () => {
     expect(proposedRevision.revertedFrom).toBe(1);
   });
 
+  it("keeps the marker when mutable fields are re-sent unchanged", () => {
+    const revision = revertDraft();
+    const { clearRevertedFrom, proposedRevision } = computeRevisionUpdate(
+      mockContext(),
+      FEATURE,
+      revision,
+      {
+        defaultValue: revision.defaultValue,
+        rules: revision.rules,
+        baseVersion: 3,
+      } as RevisionChanges,
+      false,
+    );
+    expect(clearRevertedFrom).toBe(false);
+    expect(proposedRevision.revertedFrom).toBe(1);
+  });
+
   it("is a no-op for revisions that were never reverts", () => {
     const { clearRevertedFrom } = computeRevisionUpdate(
       mockContext(),

--- a/packages/back-end/test/models/computeRevisionUpdate.test.ts
+++ b/packages/back-end/test/models/computeRevisionUpdate.test.ts
@@ -218,3 +218,43 @@ describe("computeRevisionPublishChanges", () => {
     expect(changes.comment).toBe("original");
   });
 });
+
+describe("computeRevisionUpdate revert marker", () => {
+  const revertDraft = () =>
+    makeRevision({ revertedFrom: 1, status: "draft" as const });
+
+  it("drops the marker once the revert draft's content is edited", () => {
+    const { clearRevertedFrom, proposedRevision } = computeRevisionUpdate(
+      mockContext(),
+      FEATURE,
+      revertDraft(),
+      { defaultValue: "false" } as RevisionChanges,
+      false,
+    );
+    expect(clearRevertedFrom).toBe(true);
+    expect(proposedRevision.revertedFrom).toBeUndefined();
+  });
+
+  it("keeps the marker for non-content updates", () => {
+    const { clearRevertedFrom, proposedRevision } = computeRevisionUpdate(
+      mockContext(),
+      FEATURE,
+      revertDraft(),
+      { comment: "just a description" } as RevisionChanges,
+      false,
+    );
+    expect(clearRevertedFrom).toBe(false);
+    expect(proposedRevision.revertedFrom).toBe(1);
+  });
+
+  it("is a no-op for revisions that were never reverts", () => {
+    const { clearRevertedFrom } = computeRevisionUpdate(
+      mockContext(),
+      FEATURE,
+      makeRevision(),
+      { defaultValue: "false" } as RevisionChanges,
+      false,
+    );
+    expect(clearRevertedFrom).toBe(false);
+  });
+});

--- a/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
+++ b/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
@@ -1475,8 +1475,6 @@ export default function ReviewAndPublish({
   const allDiffs = [...resultDiffs, ...rampDiffs];
   const hasChanges = mergeResultHasChanges(mergeResult) || rampDiffs.length > 0;
 
-  // Diffs empty against live but publishing it is the reconciliation, so the
-  // CTA stays enabled below instead of dead-ending on "nothing to publish".
   const isStranded = isStrandedLiveRevision({
     featureVersion: feature.version,
     revisionVersion: revision.version,
@@ -1567,8 +1565,6 @@ export default function ReviewAndPublish({
     requireReviews,
     status: revision.status,
     mergeSuccess: mergeResult.success,
-    // A stranded revision is publishable despite having no diff — publishing is
-    // what reconciles it.
     hasChanges: hasChanges || isStranded,
     hasReviewPermission: permissionsUtil.canReviewFeatureDrafts(feature),
     canManageDraft: permissionsUtil.canManageFeatureDrafts(feature),

--- a/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
+++ b/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
@@ -15,6 +15,7 @@ import {
   liveRevisionFromFeature,
   filterEnvironmentsByFeature,
   getEnvsFromRampSchedule,
+  isStrandedLiveRevision,
   mergeResultHasChanges,
   getReviewSetting,
   getFeatureAutopublishOnApproval,
@@ -1474,6 +1475,15 @@ export default function ReviewAndPublish({
   const allDiffs = [...resultDiffs, ...rampDiffs];
   const hasChanges = mergeResultHasChanges(mergeResult) || rampDiffs.length > 0;
 
+  // Diffs empty against live but publishing it is the reconciliation, so the
+  // CTA stays enabled below instead of dead-ending on "nothing to publish".
+  const isStranded = isStrandedLiveRevision({
+    featureVersion: feature.version,
+    revisionVersion: revision.version,
+    revisionStatus: revision.status,
+    hasChanges,
+  });
+
   const linkedRamps = (rampSchedules ?? []).filter(
     (r) =>
       r.status === "pending" &&
@@ -1557,7 +1567,9 @@ export default function ReviewAndPublish({
     requireReviews,
     status: revision.status,
     mergeSuccess: mergeResult.success,
-    hasChanges,
+    // A stranded revision is publishable despite having no diff — publishing is
+    // what reconciles it.
+    hasChanges: hasChanges || isStranded,
     hasReviewPermission: permissionsUtil.canReviewFeatureDrafts(feature),
     canManageDraft: permissionsUtil.canManageFeatureDrafts(feature),
     isReviewRequester,
@@ -2061,7 +2073,7 @@ export default function ReviewAndPublish({
   type BlockInfo = { overridable: boolean } | null;
   const blockInfo: BlockInfo = (() => {
     if (!mergeResult.success) return { overridable: false };
-    if (!hasChanges) return { overridable: false };
+    if (!hasChanges && !isStranded) return { overridable: false };
     if (!hasPublishPermission) return { overridable: false };
     if (
       requireReviews &&
@@ -2771,12 +2783,22 @@ export default function ReviewAndPublish({
                         </Callout>
                       ))}
 
-                      {!hasChanges && (
-                        <Callout status="info" size="sm">
-                          No changes to publish. Discard the draft or add
-                          changes first.
-                        </Callout>
-                      )}
+                      {!hasChanges &&
+                        (isStranded ? (
+                          <Callout status="warning" size="sm">
+                            This revision is already the live version of the
+                            Feature Flag, but was never marked published — an
+                            earlier publish updated the Feature Flag without
+                            finishing. Publish it to reconcile the two. Do not
+                            discard it: that would leave the Feature Flag
+                            serving a revision it reports as never published.
+                          </Callout>
+                        ) : (
+                          <Callout status="info" size="sm">
+                            No changes to publish. Discard the draft or add
+                            changes first.
+                          </Callout>
+                        ))}
 
                       {featureLockedBySchedule && !adminPublish && (
                         <Callout status="warning" size="sm">

--- a/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
+++ b/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
@@ -2786,12 +2786,11 @@ export default function ReviewAndPublish({
                       {!hasChanges &&
                         (isStranded ? (
                           <Callout status="warning" size="sm">
-                            This revision is already the live version of the
-                            Feature Flag, but was never marked published — an
-                            earlier publish updated the Feature Flag without
-                            finishing. Publish it to reconcile the two. Do not
-                            discard it: that would leave the Feature Flag
-                            serving a revision it reports as never published.
+                            This revision is already live but was never marked
+                            published — an earlier publish didn&apos;t finish.
+                            Publish it to reconcile; don&apos;t discard it, or
+                            the Feature Flag will keep serving a revision it
+                            reports as unpublished.
                           </Callout>
                         ) : (
                           <Callout status="info" size="sm">

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -1090,6 +1090,16 @@ export function getEffectiveRevisionHoldout(
     : (feature.holdout ?? null);
 }
 
+// The holdout a revert restores. Unlike getEffectiveRevisionHoldout, an absent
+// value means "no holdout" rather than carrying the live one forward — carrying
+// forward makes a holdout attached after this revision un-revertable, which
+// reads as a revert that silently does nothing.
+export function getRevertTargetHoldout(
+  revision: Pick<RevisionFields, "holdout">,
+): Exclude<RevisionFields["holdout"], undefined> {
+  return revision.holdout ?? null;
+}
+
 // An open draft that is already the feature's live version: a publish advanced
 // the feature but never marked the revision published. Publishing it reconciles.
 export function isStrandedLiveRevision({

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -1090,6 +1090,33 @@ export function getEffectiveRevisionHoldout(
     : (feature.holdout ?? null);
 }
 
+/**
+ * An open draft that is already the feature's live version: a publish advanced
+ * the feature but never marked the revision published. It diffs empty against
+ * live, so the ordinary "nothing to publish" handling would dead-end it — and
+ * discarding it would leave the feature serving a revision reported as never
+ * published. Publishing it is the reconciliation: no feature write is needed,
+ * only the revision's status.
+ */
+export function isStrandedLiveRevision({
+  featureVersion,
+  revisionVersion,
+  revisionStatus,
+  hasChanges,
+}: {
+  featureVersion: number;
+  revisionVersion: number;
+  revisionStatus: string;
+  hasChanges: boolean;
+}): boolean {
+  return (
+    !hasChanges &&
+    revisionVersion === featureVersion &&
+    revisionStatus !== "published" &&
+    revisionStatus !== "discarded"
+  );
+}
+
 // Per-field backfill for old/sparse revisions before passing to autoMerge.
 // Fields not listed here are left as-is; sparse absence is meaningful for those.
 const revisionFieldFillers: Partial<{

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -1090,14 +1090,8 @@ export function getEffectiveRevisionHoldout(
     : (feature.holdout ?? null);
 }
 
-/**
- * An open draft that is already the feature's live version: a publish advanced
- * the feature but never marked the revision published. It diffs empty against
- * live, so the ordinary "nothing to publish" handling would dead-end it — and
- * discarding it would leave the feature serving a revision reported as never
- * published. Publishing it is the reconciliation: no feature write is needed,
- * only the revision's status.
- */
+// An open draft that is already the feature's live version: a publish advanced
+// the feature but never marked the revision published. Publishing it reconciles.
 export function isStrandedLiveRevision({
   featureVersion,
   revisionVersion,

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -1864,10 +1864,15 @@ export function autoMerge(
       result.archived = revision.archived;
     }
 
-    // holdout
+    // holdout — compared against live, not base. Membership lives on the feature
+    // document, and a base revision snapshot can predate an attach that happened
+    // outside a publish, in which case a draft's removal equals the stale base
+    // and the change would be dropped. `live` is canonical (see
+    // liveRevisionFromFeature), which also keeps this in step with
+    // draftDiffersFromLive.
     if (
       "holdout" in revision &&
-      !isEqual(revision.holdout, base.holdout ?? null)
+      !isEqual(revision.holdout ?? null, live.holdout ?? null)
     ) {
       result.holdout = revision.holdout;
     }
@@ -2043,13 +2048,16 @@ export function autoMerge(
     }
   }
 
-  // holdout (nullable object, same conflict pattern as archived)
+  // holdout (nullable object, same conflict pattern as archived) — differing
+  // from live is what makes it a change, since membership lives on the feature
+  // document and a base snapshot can predate an attach made outside a publish.
+  // base is then only consulted to tell a conflict from a clean change.
   if ("holdout" in revision) {
-    const revVal = revision.holdout;
+    const revVal = revision.holdout ?? null;
     const baseVal = base.holdout ?? null;
     const liveVal = live.holdout ?? null;
-    if (!isEqual(revVal, baseVal) && !isEqual(revVal, liveVal)) {
-      if (!isEqual(liveVal, baseVal) && !isEqual(liveVal, revVal)) {
+    if (!isEqual(revVal, liveVal)) {
+      if (!isEqual(liveVal, baseVal)) {
         const conflictInfo: MergeConflict = {
           name: "Holdout",
           key: "holdout",

--- a/packages/shared/src/validators/features.ts
+++ b/packages/shared/src/validators/features.ts
@@ -645,6 +645,12 @@ const featureRevisionInterface = minimalFeatureRevisionInterface
     // Used to detect "stale" approvals — i.e. changes published after approval.
     // Absent on drafts that were never approved and on legacy approvals.
     approvedBaseVersion: z.number().optional(),
+    // Version this revision reverts to. Marks the revision itself as a revert so
+    // publish-time guards that must not refuse a restored-but-transiently-invalid
+    // state can recognize it — including when the revert was staged as a draft and
+    // published later, which a call-time parameter can't survive. Mirrors
+    // `revertedFrom` on the generic revision system.
+    revertedFrom: z.number().optional(),
     dateCreated: z.date(),
     publishedBy: z.union([z.null(), eventUser]),
     comment: z.string(),

--- a/packages/shared/src/validators/features.ts
+++ b/packages/shared/src/validators/features.ts
@@ -645,11 +645,8 @@ const featureRevisionInterface = minimalFeatureRevisionInterface
     // Used to detect "stale" approvals — i.e. changes published after approval.
     // Absent on drafts that were never approved and on legacy approvals.
     approvedBaseVersion: z.number().optional(),
-    // Version this revision reverts to. Marks the revision itself as a revert so
-    // publish-time guards that must not refuse a restored-but-transiently-invalid
-    // state can recognize it — including when the revert was staged as a draft and
-    // published later, which a call-time parameter can't survive. Mirrors
-    // `revertedFrom` on the generic revision system.
+    // Version this revision reverts to. Persisted rather than passed at call time
+    // so a revert staged as a draft still relaxes the publish guards later.
     revertedFrom: z.number().optional(),
     dateCreated: z.date(),
     publishedBy: z.union([z.null(), eventUser]),

--- a/packages/shared/test/util/feature-revisions.test.ts
+++ b/packages/shared/test/util/feature-revisions.test.ts
@@ -523,6 +523,37 @@ describe("autoMerge with new envelopes", () => {
       }
     });
 
+    // Same drift, on holdout: membership lives on the feature document, so a
+    // base snapshot predating an attach made outside a publish would otherwise
+    // equal the draft's removal and drop it.
+    it("detects a holdout removal even when the base snapshot drifted to match it", () => {
+      const holdout = { id: "hld_1", value: "false" };
+      const driftedBase: RevisionFields = {
+        version: 2,
+        defaultValue: "OFF",
+        rules: {},
+        holdout: null, // stale snapshot, predates the attach
+      };
+      const liveFeatureModel: RevisionFields = {
+        version: 2,
+        defaultValue: "OFF",
+        rules: {},
+        holdout, // what's actually live
+      };
+      const revision: RevisionFields = {
+        version: 4,
+        defaultValue: "OFF",
+        rules: {},
+        holdout: null, // draft removes it
+      };
+      const result = autoMerge(liveFeatureModel, driftedBase, revision, [], {});
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result.holdout).toBeNull();
+        expect(mergeResultHasChanges(result)).toBe(true);
+      }
+    });
+
     it("includes metadata changes", () => {
       const revision: RevisionFields = {
         version: 4,

--- a/packages/shared/test/util/feature-revisions.test.ts
+++ b/packages/shared/test/util/feature-revisions.test.ts
@@ -8,6 +8,7 @@ import {
   getDraftAffectedEnvironments,
   getEffectiveRevisionHoldout,
   getReviewSetting,
+  isStrandedLiveRevision,
   getFeatureAutopublishOnApproval,
   mergeResultHasChanges,
   mergeRevision,
@@ -2244,4 +2245,41 @@ describe("getFeatureAutopublishOnApproval", () => {
       ).toBe(false);
     },
   );
+});
+
+describe("isStrandedLiveRevision", () => {
+  const stranded = {
+    featureVersion: 13,
+    revisionVersion: 13,
+    revisionStatus: "draft",
+    hasChanges: false,
+  };
+
+  it("detects an open draft that is already the live version", () => {
+    expect(isStrandedLiveRevision(stranded)).toBe(true);
+    expect(
+      isStrandedLiveRevision({ ...stranded, revisionStatus: "approved" }),
+    ).toBe(true);
+  });
+
+  it("is false when the revision still has changes to publish", () => {
+    expect(isStrandedLiveRevision({ ...stranded, hasChanges: true })).toBe(
+      false,
+    );
+  });
+
+  it("is false for an ordinary no-op draft ahead of the live version", () => {
+    expect(isStrandedLiveRevision({ ...stranded, revisionVersion: 14 })).toBe(
+      false,
+    );
+  });
+
+  it("is false for revisions already published or discarded", () => {
+    expect(
+      isStrandedLiveRevision({ ...stranded, revisionStatus: "published" }),
+    ).toBe(false);
+    expect(
+      isStrandedLiveRevision({ ...stranded, revisionStatus: "discarded" }),
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
Adding a holdout to a feature flag and publishing could leave the flag live on a revision that was never marked published — the UI showed a "Live" badge and a "this was never published" banner on the same revision. The holdout also stopped applying: an unlinked holdout drops out of the SDK payload, so the carve-out silently went away while the UI still displayed the rule. Recovering required editing Mongo by hand.

The cause was authority, not the holdout itself. Publishing wrote the feature document first and only then updated the holdout's linkage, and that second write required analyses permissions. A role that can publish flags but not manage analyses (Engineer, for one) failed there every time, with nothing rolling the feature write back.

## Publishing

- **Holdout linkage follows flag authority.** Maintaining the holdout's back-reference is a side effect of an authorized flag write, not a holdout edit, so anyone who can edit or publish the flag can do it. Same for creating a flag with a holdout and deleting one.
- **Publish checks everything before it writes anything,** and reports all the blockers at once instead of one at a time.
- **A publish that fails partway rewinds** the feature document, holdout linkage, experiment links, revision status, and ramp schedules it had already committed — restoring the revision's status last, so a failed rewind can't leave the flag live on a reopened draft.
- **You can't discard the revision a flag is live on.** That discard is what turned a recoverable state into permanent corruption.
- **A revision stranded by an earlier failure can be reconciled by publishing it,** rather than needing a database fix.

## Holdout changes that wouldn't publish or revert

- **Removing a holdout is publishable again.** The publish diff compared the draft against its base revision snapshot, which can predate a holdout being attached outside a publish — so a removal looked like no change at all, and the UI refused to publish it. It now compares against live, matching the check the back end already used.
- **Reverting restores holdout membership.** Previously all four revert paths silently left the holdout as-is, so reverting past the change that added a holdout kept it attached. A revert is now marked on the revision itself, so one staged as a draft still reverts correctly when published later.

## Project scope

- **A holdout can only be linked within its projects,** on flags and experiments, including when either is moved to another project.
- **Narrowing a holdout's projects can't strand what's already linked to it** — the same invalid pairing, reached from the holdout side.

## Notes

Bulk publish gets the holdout checks at plan time through the gate collector it already shares with the interactive publish endpoint, so a holdout conflict blocks in the dry run instead of throwing halfway through applying.

Publish still writes the feature before marking the revision published, so a concurrent edit in that window is undetected — recoverable now, but not impossible. Moving the single-publish paths onto the bulk publisher's claim-first ordering is the follow-up.

Reverting to a revision recorded before revisions stored holdouts treats its absent holdout as "no holdout" and detaches. That's what makes reverts work at all, but a flag *created* with a holdout before this change has no holdout on revision 1, so reverting there will detach it.
