### PR TITLE
Fall back to attributes JSON for built-in identifier columns in managed warehouse SQL

### DIFF
--- a/packages/shared/src/util/managedWarehouse.ts
+++ b/packages/shared/src/util/managedWarehouse.ts
@@ -552,10 +552,12 @@ function migratedColumnSelectExpr(col: MaterializedColumn): string {
 // keys in the same precedence, so both eras resolve (folded rows can't
 // double-resolve: their JSON no longer contains the keys).
 function builtinIdentifierReplaceClause(): string {
+  // nullIf-wrapped so empty strings fall through, matching the plugin's falsy
+  // `||` chain — a JSON `device_id: ""` must not shadow a populated `id`.
   const path = (key: string) =>
-    `${MANAGED_WAREHOUSE_ATTRIBUTES_COLUMN}.${chIdentifier(
+    `nullIf(${MANAGED_WAREHOUSE_ATTRIBUTES_COLUMN}.${chIdentifier(
       key,
-    )}::Nullable(String)`;
+    )}::Nullable(String), '')`;
   return ` REPLACE (
   coalesce(nullIf(user_id, ''), ${path("user_id")}) AS user_id,
   coalesce(nullIf(device_id, ''), ${path("device_id")}, ${path(

--- a/packages/shared/src/util/managedWarehouse.ts
+++ b/packages/shared/src/util/managedWarehouse.ts
@@ -329,10 +329,14 @@ export function getManagedWarehouseAttributesJsonFields(
 
 /**
  * Version of the JSON-ergonomics setup (per-org user settings + typed attribute
- * ALIAS columns). Persisted per warehouse as `settings.jsonErgonomicsVersion`
- * once applied; bump to make the backfill sweep re-apply everywhere.
+ * ALIAS columns + the generated fact-table/exposure SQL the sweep's sync
+ * persists). Persisted per warehouse as `settings.jsonErgonomicsVersion` once
+ * applied; bump to make the backfill sweep re-apply everywhere.
+ *
+ * v2: built-in identifier columns fall back to their folded `attributes` JSON
+ * paths in generated SQL (pre-plugin integrations never populate the columns).
  */
-export const MANAGED_WAREHOUSE_JSON_ERGONOMICS_VERSION = 1;
+export const MANAGED_WAREHOUSE_JSON_ERGONOMICS_VERSION = 2;
 
 /**
  * Attributes to expose as typed `attributes.<property>` ALIAS columns on the
@@ -539,10 +543,32 @@ function migratedColumnSelectExpr(col: MaterializedColumn): string {
   return `${expr} AS ${chIdentifier(col.columnName)}`;
 }
 
-// The full SELECT-list alias clause for a migrated warehouse: custom identifiers
-// (join-key aliases) followed by preserved dimensions, each aliased out of `attributes`.
-// Empty when there's nothing to alias. Callers must pass dimensions already deduped
-// against the identifiers via `dedupeMigratedDimensions`.
+// Fall back to the `attributes` JSON for the built-in identifier columns. The SDK
+// tracking plugin folds these attribute keys into the columns at ingest (user_id
+// <- user_id; device_id <- device_id || anonymous_id || id, see parseAttributes /
+// BUILTIN_ATTRIBUTE_TO_IDENTIFIER) and strips them from `attributes` — but events
+// from integrations that predate the plugin carry the values only inside the JSON,
+// leaving the columns empty. REPLACE each column with a coalesce through the same
+// keys in the same precedence, so both eras resolve (folded rows can't
+// double-resolve: their JSON no longer contains the keys).
+function builtinIdentifierReplaceClause(): string {
+  const path = (key: string) =>
+    `${MANAGED_WAREHOUSE_ATTRIBUTES_COLUMN}.${chIdentifier(
+      key,
+    )}::Nullable(String)`;
+  return ` REPLACE (
+  coalesce(nullIf(user_id, ''), ${path("user_id")}) AS user_id,
+  coalesce(nullIf(device_id, ''), ${path("device_id")}, ${path(
+    "anonymous_id",
+  )}, ${path("id")}) AS device_id
+)`;
+}
+
+// The full SELECT-list decoration for a JSON-columns warehouse, placed directly
+// after `SELECT *`: the built-in identifier fallback REPLACE, then custom
+// identifiers (join-key aliases) and preserved dimensions, each aliased out of
+// `attributes`. Callers must pass dimensions already deduped against the
+// identifiers via `dedupeMigratedDimensions`.
 function attributeAliasClause(
   customIdentifiers: string[],
   dimensions: MaterializedColumn[],
@@ -551,16 +577,17 @@ function attributeAliasClause(
     ...customIdentifiers.map(customIdentifierSelectExpr),
     ...dimensions.map(migratedColumnSelectExpr),
   ];
-  if (!exprs.length) return "";
-  return ",\n  " + exprs.join(",\n  ");
+  const aliases = exprs.length ? ",\n  " + exprs.join(",\n  ") : "";
+  return builtinIdentifierReplaceClause() + aliases;
 }
 
 /**
- * The SELECT-list alias clause (custom identifiers + preserved dimensions) for a
- * MIGRATED managed warehouse, derived from datasource settings alone. Lets callers
- * without the org attribute schema — e.g. Product Analytics `data_source` explorations
- * that query a per-org table directly — re-expose former columns the same way the
- * `ch_events` fact table does, so bare references keep resolving.
+ * The SELECT-list decoration (built-in identifier fallback + custom identifiers +
+ * preserved dimensions) for a MIGRATED managed warehouse, derived from datasource
+ * settings alone. Lets callers without the org attribute schema — e.g. Product
+ * Analytics `data_source` explorations that query a per-org table directly —
+ * re-expose former columns the same way the `ch_events` fact table does, so bare
+ * references keep resolving.
  *
  * Returns "" unless `useJsonColumns` is set: on a pre-migration warehouse these columns
  * are still physical, so `SELECT *, attributes.x AS x` would duplicate a column. Only

--- a/packages/shared/test/util/managedWarehouse.test.ts
+++ b/packages/shared/test/util/managedWarehouse.test.ts
@@ -265,12 +265,23 @@ describe("getManagedWarehouseUserIdTypes", () => {
 describe("buildManagedWarehouseEventsFactTableSql", () => {
   it("selects all columns with no JSON aliases for the default schema", () => {
     const sql = buildManagedWarehouseEventsFactTableSql(defaultSchema);
-    expect(sql).toContain("SELECT *");
+    expect(sql).toContain("SELECT * REPLACE (");
     expect(sql).toContain("FROM events");
     expect(sql).toContain(
       "WHERE timestamp BETWEEN '{{startDate}}' AND '{{endDate}}'",
     );
-    expect(sql).not.toContain("attributes.");
+    // Only the built-in fallback REPLACE, no alias list after it.
+    expect(sql).toContain(")\nFROM events");
+  });
+
+  it("falls back to the attributes JSON for the built-in identifier columns", () => {
+    const sql = buildManagedWarehouseEventsFactTableSql(defaultSchema);
+    expect(sql).toContain(
+      "coalesce(nullIf(user_id, ''), attributes.user_id::Nullable(String)) AS user_id",
+    );
+    expect(sql).toContain(
+      "coalesce(nullIf(device_id, ''), attributes.device_id::Nullable(String), attributes.anonymous_id::Nullable(String), attributes.id::Nullable(String)) AS device_id",
+    );
   });
 
   it("aliases custom identifiers out of the attributes JSON column", () => {
@@ -727,14 +738,22 @@ describe("buildManagedWarehouseAttributeAliasClause", () => {
     ],
   };
 
+  // The clause every JSON warehouse gets, even with nothing custom to alias.
+  const builtinOnlyClause = buildManagedWarehouseAttributeAliasClause({
+    useJsonColumns: true,
+    userIdTypes: [
+      { userIdType: "user_id", description: "" },
+      { userIdType: "device_id", description: "" },
+    ],
+  } as GrowthbookClickhouseSettings);
+
   it("aliases custom identifiers and preserved dimensions for a migrated warehouse", () => {
     const clause = buildManagedWarehouseAttributeAliasClause(migratedSettings);
-    // custom identifier (not the built-ins)
+    // custom identifier (the built-ins live in the REPLACE, not the alias list)
     expect(clause).toContain(
       "attributes.company_id::Nullable(String) AS company_id",
     );
-    expect(clause).not.toContain("AS user_id");
-    expect(clause).not.toContain("AS device_id");
+    expect(clause).toContain("REPLACE (");
     // dimensions (numeric coerces via toFloat64OrNull)
     expect(clause).toContain("attributes.plan::Nullable(String) AS plan");
     expect(clause).toContain(
@@ -751,16 +770,13 @@ describe("buildManagedWarehouseAttributeAliasClause", () => {
     ).toBe("");
   });
 
-  it("returns empty when there are no custom identifiers or dimensions", () => {
-    expect(
-      buildManagedWarehouseAttributeAliasClause({
-        useJsonColumns: true,
-        userIdTypes: [
-          { userIdType: "user_id", description: "" },
-          { userIdType: "device_id", description: "" },
-        ],
-      } as GrowthbookClickhouseSettings),
-    ).toBe("");
+  it("emits only the built-in fallback when there are no custom identifiers or dimensions", () => {
+    expect(builtinOnlyClause).toContain("REPLACE (");
+    expect(builtinOnlyClause).toContain(
+      "coalesce(nullIf(user_id, ''), attributes.user_id::Nullable(String)) AS user_id",
+    );
+    // No alias list after the REPLACE.
+    expect(builtinOnlyClause.trimEnd().endsWith(")")).toBe(true);
   });
 
   it("does not alias a dimension that collides with a custom identifier", () => {
@@ -793,7 +809,8 @@ describe("buildManagedWarehouseAttributeAliasClause", () => {
       ],
     } as GrowthbookClickhouseSettings);
     // geo_country is a physical column post-migration; aliasing it would duplicate it.
-    expect(clause).toBe("");
+    expect(clause).not.toContain("geo_country");
+    expect(clause).toBe(builtinOnlyClause);
   });
 
   it("drops a custom identifier whose name collides with a real SELECT * column", () => {
@@ -801,6 +818,7 @@ describe("buildManagedWarehouseAttributeAliasClause", () => {
       useJsonColumns: true,
       userIdTypes: [{ userIdType: "session_id", description: "" }],
     } as GrowthbookClickhouseSettings);
-    expect(clause).toBe("");
+    expect(clause).not.toContain("session_id");
+    expect(clause).toBe(builtinOnlyClause);
   });
 });

--- a/packages/shared/test/util/managedWarehouse.test.ts
+++ b/packages/shared/test/util/managedWarehouse.test.ts
@@ -277,10 +277,10 @@ describe("buildManagedWarehouseEventsFactTableSql", () => {
   it("falls back to the attributes JSON for the built-in identifier columns", () => {
     const sql = buildManagedWarehouseEventsFactTableSql(defaultSchema);
     expect(sql).toContain(
-      "coalesce(nullIf(user_id, ''), attributes.user_id::Nullable(String)) AS user_id",
+      "coalesce(nullIf(user_id, ''), nullIf(attributes.user_id::Nullable(String), '')) AS user_id",
     );
     expect(sql).toContain(
-      "coalesce(nullIf(device_id, ''), attributes.device_id::Nullable(String), attributes.anonymous_id::Nullable(String), attributes.id::Nullable(String)) AS device_id",
+      "coalesce(nullIf(device_id, ''), nullIf(attributes.device_id::Nullable(String), ''), nullIf(attributes.anonymous_id::Nullable(String), ''), nullIf(attributes.id::Nullable(String), '')) AS device_id",
     );
   });
 
@@ -773,7 +773,7 @@ describe("buildManagedWarehouseAttributeAliasClause", () => {
   it("emits only the built-in fallback when there are no custom identifiers or dimensions", () => {
     expect(builtinOnlyClause).toContain("REPLACE (");
     expect(builtinOnlyClause).toContain(
-      "coalesce(nullIf(user_id, ''), attributes.user_id::Nullable(String)) AS user_id",
+      "coalesce(nullIf(user_id, ''), nullIf(attributes.user_id::Nullable(String), '')) AS user_id",
     );
     // No alias list after the REPLACE.
     expect(builtinOnlyClause.trimEnd().endsWith(")")).toBe(true);


### PR DESCRIPTION
### Features and Changes

Events from integrations that predate the tracking plugin carry their identifiers only inside the `attributes` JSON — the plugin-fed `user_id`/`device_id` columns are empty, so exposure queries match nothing. Legacy materialized columns used to extract these values, but the JSON migration intentionally dropped builtin-named identifier mappings, silently breaking experiment results for such orgs (one affected customer org has ~9.8M exposure rows with `attributes.id` populated and both identifier columns empty).

Generated SQL (`ch_events` fact table, exposure queries, Product Analytics `data_source` stubs) now emits `SELECT * REPLACE (...)`, coalescing each built-in identifier column with its folded attribute paths in the SDK plugin's own precedence: `user_id <- attributes.user_id`; `device_id <- attributes.device_id, anonymous_id, id`. Plugin-era rows are unaffected — populated columns win, and the plugin strips folded keys from the JSON, so rows can't double-resolve. Query-time only: no DDL, no backfill, no license-server change.

Bumps `MANAGED_WAREHOUSE_JSON_ERGONOMICS_VERSION` to 2 so the ergonomics sweep re-persists the regenerated SQL fleet-wide (requires the `managed-warehouse-json-ergonomics-sweep` flag, same as v1).

### Testing

Verified against the dev managed warehouse (ClickHouse 26.4) with the real builder output:

- [x] synthetic customer-shaped row (empty columns, `{"id":"cust-9007199254740993"}`) -> `device_id` resolves from the JSON with exact digits
- [x] plugin-era row (columns populated) -> column values win, JSON ignored
- [x] `anonymous_id` and `id` both in JSON -> `anonymous_id` wins (plugin precedence)
- [x] empty-string JSON values fall through (`{"device_id":"","id":"x"}` -> `x`), matching the plugin's falsy `||` chain; an all-empty row resolves NULL, not `""`
- [x] `user_id` stays NULL when neither the column nor `attributes.user_id` has a value (no cross-leak from `id`)
- [x] fact-table SQL, all generated exposure queries, and the PA `data_source` stub execute unmodified

Affected orgs' experiments hashing on `id` should use the `device_id` assignment query (the canonical post-migration mapping for that attribute); with this change that query returns their full history.
