### PR TITLE
feat(experiments): persist snapshot runner kind

### DIFF
--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -73,6 +73,7 @@ const experimentSnapshotSchema = new mongoose.Schema({
   type: { type: String },
   triggeredBy: String,
   report: String,
+  runnerKind: String,
   dateCreated: Date,
   sourceSnapshotId: String,
   sourceSnapshotDateCreated: Date,

--- a/packages/back-end/src/services/experimentUpdateExecutionLogger.ts
+++ b/packages/back-end/src/services/experimentUpdateExecutionLogger.ts
@@ -1,12 +1,12 @@
 import { DataSourceInterface } from "shared/types/datasource";
 import {
+  SnapshotQueryRunnerKind,
   SnapshotTriggeredBy,
   SnapshotType,
 } from "shared/types/experiment-snapshot";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import type { CovariateInsertPathReason } from "back-end/src/integrations/sql/fact-metrics/resolve-covariate-insert-path";
-import { SnapshotQueryRunnerKind } from "./experiments";
 
 type ExperimentUpdateLogMeta = {
   experimentId: string;

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -1300,7 +1300,7 @@ export function resolveSnapshotRunner({
   return { runnerFamily: "incremental", incrementalFallbackReason: null };
 }
 
-function finalizeSnapshotQueryRunnerKind({
+function getSnapshotQueryRunnerKind({
   runnerFamily,
   fullRefresh,
 }: {
@@ -1777,7 +1777,7 @@ export async function planSnapshot({
 
   const snapshot = {
     ...data,
-    runnerKind: finalizeSnapshotQueryRunnerKind({
+    runnerKind: getSnapshotQueryRunnerKind({
       runnerFamily: runnerPlan.runnerFamily,
       fullRefresh: runnerPlan.fullRefresh,
     }),
@@ -1813,8 +1813,12 @@ export async function createSnapshotFromPlan({
   const integration = getSourceIntegrationObject(context, datasource, true);
   const { runnerKind } = plan.snapshot;
 
-  // Main incremental runs mutate the pipeline tables while exploratory runs
-  // read them, so all incremental kinds share the per-experiment lock.
+  // Incremental full/update mutate the per-experiment pipeline tables
+  // (DROP/CREATE/RENAME on units + metric-source tables). Exploratory reads
+  // those tables. Lock all three so concurrent triggers (scheduled
+  // auto-refresh + manual Update) cannot race and produce empty or malformed
+  // results. The results runner only writes per-snapshot ephemeral tables, so
+  // it does not need this lock.
   const needsIncrementalRefreshLock =
     runnerKind === "incremental-full" ||
     runnerKind === "incremental-update" ||

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -97,6 +97,7 @@ import {
   ExperimentSnapshotAnalysisSettings,
   ExperimentSnapshotInterface,
   ExperimentSnapshotSettings,
+  SnapshotQueryRunnerKind,
   SnapshotTriggeredBy,
   SnapshotType,
   SnapshotBanditSettings,
@@ -1238,7 +1239,7 @@ export type ExperimentSnapshotQueryRunner =
   | ExperimentIncrementalRefreshQueryRunner
   | ExperimentIncrementalRefreshExploratoryQueryRunner;
 
-export type SnapshotQueryRunnerKind =
+type SnapshotQueryRunnerFamily =
   | "results"
   | "incremental"
   | "incremental-exploratory";
@@ -1256,7 +1257,7 @@ export function resolveSnapshotRunner({
   hasSnapshotDimensions: boolean;
   hasMaterializedUnitsTable: boolean;
 }): {
-  runnerKind: SnapshotQueryRunnerKind;
+  runnerFamily: SnapshotQueryRunnerFamily;
   incrementalFallbackReason: string | null;
 } {
   if (
@@ -1265,7 +1266,7 @@ export function resolveSnapshotRunner({
       experiment.id,
     )
   ) {
-    return { runnerKind: "results", incrementalFallbackReason: null };
+    return { runnerFamily: "results", incrementalFallbackReason: null };
   }
 
   const unsupportedTypeReason = getUnsupportedIncrementalExperimentTypeReason(
@@ -1273,7 +1274,7 @@ export function resolveSnapshotRunner({
   );
   if (unsupportedTypeReason) {
     return {
-      runnerKind: "results",
+      runnerFamily: "results",
       incrementalFallbackReason: unsupportedTypeReason,
     };
   }
@@ -1283,20 +1284,40 @@ export function resolveSnapshotRunner({
     // Results have materialized the units table.
     if (!hasMaterializedUnitsTable) {
       return {
-        runnerKind: "results",
+        runnerFamily: "results",
         incrementalFallbackReason:
           "No materialized units table yet for Overall Results.",
       };
     }
     return {
-      runnerKind: hasSnapshotDimensions
+      runnerFamily: hasSnapshotDimensions
         ? "incremental-exploratory"
         : "incremental",
       incrementalFallbackReason: null,
     };
   }
 
-  return { runnerKind: "incremental", incrementalFallbackReason: null };
+  return { runnerFamily: "incremental", incrementalFallbackReason: null };
+}
+
+function finalizeSnapshotQueryRunnerKind({
+  runnerFamily,
+  fullRefresh,
+}: {
+  runnerFamily: SnapshotQueryRunnerFamily;
+  fullRefresh: boolean;
+}): SnapshotQueryRunnerKind {
+  switch (runnerFamily) {
+    case "results":
+      return "results";
+    case "incremental":
+      return fullRefresh ? "incremental-full" : "incremental-update";
+    case "incremental-exploratory":
+      return "incremental-exploratory";
+    default:
+      runnerFamily satisfies never;
+      throw new Error(`Unknown snapshot runner family: ${runnerFamily}`);
+  }
 }
 
 /**
@@ -1368,7 +1389,7 @@ async function resolveIncrementalPrerequisiteFailure({
 }: {
   error: unknown;
   decision: {
-    runnerKind: SnapshotQueryRunnerKind;
+    runnerFamily: SnapshotQueryRunnerFamily;
     incrementalFallbackReason: string | null;
   };
   experiment: ExperimentInterface;
@@ -1379,7 +1400,7 @@ async function resolveIncrementalPrerequisiteFailure({
   prerequisites: IncrementalRefreshPrerequisiteArgs;
   throwOnErrorInsteadOfFallback: boolean;
 }): Promise<{
-  runnerKind: SnapshotQueryRunnerKind;
+  runnerFamily: SnapshotQueryRunnerFamily;
   incrementalFallbackReason: string | null;
   fullRefresh: boolean;
   fullRefreshReason: string | null;
@@ -1415,7 +1436,7 @@ async function resolveIncrementalPrerequisiteFailure({
         `Experiment ${experiment.id} does not support incremental refresh even as a full refresh: ${fullRefreshValidationError}`,
       );
       return {
-        runnerKind: "results",
+        runnerFamily: "results",
         incrementalFallbackReason: fullRefreshValidationError,
         fullRefresh,
         fullRefreshReason,
@@ -1434,7 +1455,7 @@ async function resolveIncrementalPrerequisiteFailure({
     `Experiment ${experiment.id} does not support incremental refresh: ${validationError}`,
   );
   return {
-    runnerKind: "results",
+    runnerFamily: "results",
     incrementalFallbackReason: validationError,
     fullRefresh,
     fullRefreshReason,
@@ -1470,7 +1491,7 @@ async function planSnapshotQueryRunner({
   triggeredBy: SnapshotTriggeredBy;
   throwOnErrorInsteadOfFallback: boolean;
 }): Promise<{
-  runnerKind: SnapshotQueryRunnerKind;
+  runnerFamily: SnapshotQueryRunnerFamily;
   incrementalFallbackReason: string | null;
   fullRefresh: boolean;
   fullRefreshReason: string | null;
@@ -1483,14 +1504,14 @@ async function planSnapshotQueryRunner({
     hasMaterializedUnitsTable: !!incrementalRefreshModel?.unitsTableFullName,
   });
 
-  if (decision.runnerKind === "results") {
+  if (decision.runnerFamily === "results") {
     return { ...decision, fullRefresh, fullRefreshReason };
   }
 
   // Dimension breakdowns read the Overall Results units table. If experiment
   // settings drifted, Overall Results must rebuild that table first.
   if (
-    decision.runnerKind === "incremental-exploratory" &&
+    decision.runnerFamily === "incremental-exploratory" &&
     incrementalRefreshModel &&
     exploratoryOverallRequiresFullRefresh({
       snapshotSettings,
@@ -1505,7 +1526,7 @@ async function planSnapshotQueryRunner({
     }
 
     return {
-      runnerKind: "results",
+      runnerFamily: "results",
       incrementalFallbackReason:
         "Overall Results need a full refresh; running non-incremental update instead of reading stale data.",
       fullRefresh,
@@ -1548,8 +1569,9 @@ async function planSnapshotQueryRunner({
 }
 
 export type PlannedExperimentSnapshot = {
-  snapshot: ExperimentSnapshotInterface;
-  runnerKind: SnapshotQueryRunnerKind;
+  snapshot: ExperimentSnapshotInterface & {
+    runnerKind: SnapshotQueryRunnerKind;
+  };
   useCache: boolean;
   fullRefresh: boolean;
   settingsForSnapshotMetrics: MetricSnapshotSettings[];
@@ -1733,7 +1755,7 @@ export async function planSnapshot({
     ),
   });
 
-  if (runnerPlan.runnerKind === "incremental-exploratory") {
+  if (runnerPlan.runnerFamily === "incremental-exploratory") {
     // The snapshot whose run materialized the tables this breakdown reads is
     // the source of its freshness date. Absent for legacy docs that predate the
     // field; the UI falls back to the breakdown's own dateCreated in that case.
@@ -1753,9 +1775,16 @@ export async function planSnapshot({
     }
   }
 
+  const snapshot = {
+    ...data,
+    runnerKind: finalizeSnapshotQueryRunnerKind({
+      runnerFamily: runnerPlan.runnerFamily,
+      fullRefresh: runnerPlan.fullRefresh,
+    }),
+  };
+
   return {
-    snapshot: data,
-    runnerKind: runnerPlan.runnerKind,
+    snapshot,
     incrementalFallbackReason: runnerPlan.incrementalFallbackReason,
     useCache,
     fullRefresh: runnerPlan.fullRefresh,
@@ -1782,17 +1811,14 @@ export async function createSnapshotFromPlan({
     throw new Error("Could not load data source");
   }
   const integration = getSourceIntegrationObject(context, datasource, true);
+  const { runnerKind } = plan.snapshot;
 
-  // Both incremental runner kinds need exclusive access to the per-experiment
-  // pipeline tables: "incremental" mutates them (DROP/CREATE/RENAME on the
-  // units + metric-source tables), and "incremental-exploratory" reads them.
-  // Locking both prevents concurrent triggers (e.g. scheduled auto-refresh +
-  // manual Update) from racing on those tables and producing empty or
-  // malformed results. The "results" runner writes only to per-snapshot
-  // ephemeral tables, so it does not need this lock.
+  // Main incremental runs mutate the pipeline tables while exploratory runs
+  // read them, so all incremental kinds share the per-experiment lock.
   const needsIncrementalRefreshLock =
-    plan.runnerKind === "incremental" ||
-    plan.runnerKind === "incremental-exploratory";
+    runnerKind === "incremental-full" ||
+    runnerKind === "incremental-update" ||
+    runnerKind === "incremental-exploratory";
 
   let hasIncrementalRefreshLock = false;
   if (needsIncrementalRefreshLock) {
@@ -1846,7 +1872,7 @@ export async function createSnapshotFromPlan({
     createdSnapshotId = snapshot.id;
 
     const experimentUpdateLog: ExperimentUpdateLogPlan = {
-      runnerKind: plan.runnerKind,
+      runnerKind,
       incrementalFallbackReason: plan.incrementalFallbackReason,
       useCache: plan.useCache,
       fullRefresh: plan.fullRefresh,
@@ -1871,7 +1897,7 @@ export async function createSnapshotFromPlan({
     );
 
     let queryRunner: ExperimentSnapshotQueryRunner;
-    switch (plan.runnerKind) {
+    switch (runnerKind) {
       case "incremental-exploratory":
         queryRunner = new ExperimentIncrementalRefreshExploratoryQueryRunner(
           context,
@@ -1880,7 +1906,8 @@ export async function createSnapshotFromPlan({
           false, // TODO(incremental-refresh): allow cache + cache override for exploratory queries
         );
         break;
-      case "incremental":
+      case "incremental-full":
+      case "incremental-update":
         queryRunner = new ExperimentIncrementalRefreshQueryRunner(
           context,
           snapshot,
@@ -1897,8 +1924,8 @@ export async function createSnapshotFromPlan({
         );
         break;
       default:
-        plan.runnerKind satisfies never;
-        throw new Error(`Unknown snapshot runner kind: ${plan.runnerKind}`);
+        runnerKind satisfies never;
+        throw new Error(`Unknown snapshot runner kind: ${runnerKind}`);
     }
 
     queryRunner.setExperimentUpdateExecutionLogger(
@@ -1918,16 +1945,19 @@ export async function createSnapshotFromPlan({
       },
     };
 
-    if (plan.runnerKind === "incremental") {
+    if (
+      runnerKind === "incremental-full" ||
+      runnerKind === "incremental-update"
+    ) {
       await (
         queryRunner as ExperimentIncrementalRefreshQueryRunner
       ).startAnalysis({
         ...analysisProps,
         experimentId: experiment.id,
         incrementalRefreshStartTime: new Date(),
-        fullRefresh: plan.fullRefresh,
+        fullRefresh: runnerKind === "incremental-full",
       });
-    } else if (plan.runnerKind === "incremental-exploratory") {
+    } else if (runnerKind === "incremental-exploratory") {
       await (
         queryRunner as ExperimentIncrementalRefreshExploratoryQueryRunner
       ).startAnalysis({

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -571,6 +571,7 @@ export async function createReportSnapshot({
     type: snapshotType,
     report: report.id,
     triggeredBy: "manual",
+    runnerKind: "results",
     error: "",
     runStarted: new Date(),
     dateCreated: new Date(),

--- a/packages/back-end/test/services/experiment-update-log.test.ts
+++ b/packages/back-end/test/services/experiment-update-log.test.ts
@@ -11,7 +11,7 @@ describe("ExperimentUpdateExecutionLogger", () => {
   });
 
   const plan = {
-    runnerKind: "incremental" as const,
+    runnerKind: "incremental-full" as const,
     useCache: false,
     fullRefresh: true,
     fullRefreshReason:

--- a/packages/back-end/test/services/snapshot-lifecycle.test.ts
+++ b/packages/back-end/test/services/snapshot-lifecycle.test.ts
@@ -5,6 +5,7 @@ import {
   ExperimentSnapshotAnalysisSettings,
   ExperimentSnapshotInterface,
   ExperimentSnapshotSettings,
+  SnapshotQueryRunnerKind,
 } from "shared/types/experiment-snapshot";
 import { buildAnalysisKey } from "shared/snapshot-analysis-chunks";
 import { MetricSnapshotSettings } from "shared/types/report";
@@ -184,9 +185,19 @@ function makeAnalysisSettings(
   } as ExperimentSnapshotAnalysisSettings;
 }
 
-function makePlan(
-  overrides: Partial<PlannedExperimentSnapshot> = {},
-): PlannedExperimentSnapshot {
+type MakePlanOverrides = Omit<
+  Partial<PlannedExperimentSnapshot>,
+  "snapshot"
+> & {
+  runnerKind?: SnapshotQueryRunnerKind;
+  snapshot?: Partial<PlannedExperimentSnapshot["snapshot"]>;
+};
+
+function makePlan({
+  runnerKind = "results",
+  snapshot: snapshotOverrides,
+  ...overrides
+}: MakePlanOverrides = {}): PlannedExperimentSnapshot {
   const defaultAnalysisSettings = makeAnalysisSettings();
   return {
     snapshot: {
@@ -214,8 +225,9 @@ function makePlan(
         },
       ],
       status: "running",
-    } as ExperimentSnapshotInterface,
-    runnerKind: "results",
+      ...snapshotOverrides,
+      runnerKind,
+    },
     useCache: true,
     fullRefresh: false,
     settingsForSnapshotMetrics: [] as MetricSnapshotSettings[],
@@ -317,31 +329,43 @@ describe("snapshot lifecycle", () => {
     expect(updateExperimentDashboardsMock).not.toHaveBeenCalled();
   });
 
-  it("passes fullRefresh to the incremental runner for standard snapshots", async () => {
-    const context = makeContext();
-    const experiment = makeExperiment();
-    const plan = makePlan({
-      runnerKind: "incremental",
-      fullRefresh: true,
-    });
+  it.each([
+    ["incremental-full", false, true],
+    ["incremental-update", true, false],
+  ] as const)(
+    "uses the shared incremental runner for %s and derives fullRefresh from the kind",
+    async (runnerKind, plannedFullRefresh, expectedFullRefresh) => {
+      const context = makeContext();
+      const experiment = makeExperiment();
+      const plan = makePlan({
+        runnerKind,
+        fullRefresh: plannedFullRefresh,
+      });
 
-    await createSnapshotFromPlan({
-      plan,
-      context,
-      experiment,
-      metricMap: new Map<string, ExperimentMetricInterface>(),
-      factTableMap: new Map() as FactTableMap,
-    });
+      await createSnapshotFromPlan({
+        plan,
+        context,
+        experiment,
+        metricMap: new Map<string, ExperimentMetricInterface>(),
+        factTableMap: new Map() as FactTableMap,
+      });
 
-    const queryRunner = incrementalQueryRunnerMock.mock.results[0].value;
-    expect(queryRunner.startAnalysis).toHaveBeenCalledWith(
-      expect.objectContaining({
-        experimentId: experiment.id,
-        fullRefresh: true,
-        snapshotType: "standard",
-      }),
-    );
-  });
+      expect(incrementalQueryRunnerMock).toHaveBeenCalledWith(
+        context,
+        plan.snapshot,
+        expect.any(Object),
+        false,
+      );
+      const queryRunner = incrementalQueryRunnerMock.mock.results[0].value;
+      expect(queryRunner.startAnalysis).toHaveBeenCalledWith(
+        expect.objectContaining({
+          experimentId: experiment.id,
+          fullRefresh: expectedFullRefresh,
+          snapshotType: "standard",
+        }),
+      );
+    },
+  );
 
   it("uses the exploratory incremental runner for exploratory snapshots", async () => {
     const context = makeContext();
@@ -408,24 +432,30 @@ describe("snapshot lifecycle", () => {
   });
 
   describe("incremental refresh lock", () => {
-    it("acquires lock before starting incremental snapshot", async () => {
-      const context = makeContext();
-      const experiment = makeExperiment();
-      const plan = makePlan({ runnerKind: "incremental" });
+    it.each([
+      "incremental-full",
+      "incremental-update",
+      "incremental-exploratory",
+    ] as const)(
+      "acquires lock before starting a %s snapshot",
+      async (runnerKind) => {
+        const context = makeContext();
+        const experiment = makeExperiment();
+        const plan = makePlan({ runnerKind });
 
-      await createSnapshotFromPlan({
-        plan,
-        context,
-        experiment,
-        metricMap: new Map<string, ExperimentMetricInterface>(),
-        factTableMap: new Map() as FactTableMap,
-      });
+        await createSnapshotFromPlan({
+          plan,
+          context,
+          experiment,
+          metricMap: new Map<string, ExperimentMetricInterface>(),
+          factTableMap: new Map() as FactTableMap,
+        });
 
-      expect(
-        context.models.incrementalRefresh.acquireLock,
-      ).toHaveBeenCalledWith(experiment.id, plan.snapshot.id);
-      expect(incrementalQueryRunnerMock).toHaveBeenCalled();
-    });
+        expect(
+          context.models.incrementalRefresh.acquireLock,
+        ).toHaveBeenCalledWith(experiment.id, plan.snapshot.id);
+      },
+    );
 
     it("throws ConcurrentIncrementalRefreshError when lock cannot be acquired", async () => {
       const context = makeContext();
@@ -433,7 +463,7 @@ describe("snapshot lifecycle", () => {
         context.models.incrementalRefresh.acquireLock as jest.Mock
       ).mockResolvedValue(false);
       const experiment = makeExperiment();
-      const plan = makePlan({ runnerKind: "incremental" });
+      const plan = makePlan({ runnerKind: "incremental-update" });
 
       await expect(
         createSnapshotFromPlan({
@@ -452,7 +482,7 @@ describe("snapshot lifecycle", () => {
     it("releases lock when snapshot creation fails", async () => {
       const context = makeContext();
       const experiment = makeExperiment();
-      const plan = makePlan({ runnerKind: "incremental" });
+      const plan = makePlan({ runnerKind: "incremental-full" });
 
       // Make snapshot creation throw
       createExperimentSnapshotModelMock.mockRejectedValueOnce(

--- a/packages/back-end/test/services/snapshot-planning.test.ts
+++ b/packages/back-end/test/services/snapshot-planning.test.ts
@@ -253,7 +253,7 @@ describe("snapshot planning", () => {
       factTableMap: new Map() as FactTableMap,
     });
 
-    expect(plan.runnerKind).toBe("results");
+    expect(plan.snapshot.runnerKind).toBe("results");
     // useCache: false → full refresh, with a free-form reason explaining why.
     expect(plan.fullRefresh).toBe(true);
     expect(plan.fullRefreshReason).toBe("Full refresh explicitly requested.");
@@ -341,7 +341,7 @@ describe("snapshot planning", () => {
     });
 
     expect(assertIncrementalRefreshPrerequisitesMock).toHaveBeenCalled();
-    expect(plan.runnerKind).toBe("results");
+    expect(plan.snapshot.runnerKind).toBe("results");
     expect(plan.incrementalFallbackReason).toBe("metric not compatible");
   });
 
@@ -382,7 +382,7 @@ describe("snapshot planning", () => {
       factTableMap: new Map() as FactTableMap,
     });
 
-    expect(plan.runnerKind).toBe("incremental");
+    expect(plan.snapshot.runnerKind).toBe("incremental-full");
     // The incremental runner must not discard the computed full refresh, or it
     // would attempt an incremental update against a non-existent units table.
     expect(plan.fullRefresh).toBe(true);
@@ -523,7 +523,7 @@ describe("snapshot planning", () => {
     expect(assertIncrementalRefreshPrerequisitesMock).toHaveBeenCalledWith(
       expect.objectContaining({ analysisType: "main-update" }),
     );
-    expect(plan.runnerKind).toBe("incremental");
+    expect(plan.snapshot.runnerKind).toBe("incremental-update");
     expect(plan.fullRefresh).toBe(false);
     expect(plan.incrementalFallbackReason).toBeNull();
 
@@ -599,7 +599,7 @@ describe("snapshot planning", () => {
     expect(assertIncrementalRefreshPrerequisitesMock).not.toHaveBeenCalledWith(
       expect.objectContaining({ analysisType: "main-fullRefresh" }),
     );
-    expect(plan.runnerKind).toBe("results");
+    expect(plan.snapshot.runnerKind).toBe("results");
     expect(plan.incrementalFallbackReason).toBe(staleConfigMessage);
     expect(plan.fullRefresh).toBe(false);
     expect(plan.fullRefreshReason).toBeNull();
@@ -647,7 +647,7 @@ describe("snapshot planning", () => {
     expect(assertIncrementalRefreshPrerequisitesMock).toHaveBeenCalledWith(
       expect.objectContaining({ analysisType: "main-update" }),
     );
-    expect(plan.runnerKind).toBe("incremental");
+    expect(plan.snapshot.runnerKind).toBe("incremental-update");
     expect(plan.fullRefresh).toBe(false);
     expect(plan.fullRefreshReason).toBeNull();
     expect(plan.incrementalFallbackReason).toBeNull();
@@ -709,7 +709,7 @@ describe("snapshot planning", () => {
     );
     // The incremental runner is kept and promoted to a full refresh instead of
     // silently downgrading to the non-incremental results runner.
-    expect(plan.runnerKind).toBe("incremental");
+    expect(plan.snapshot.runnerKind).toBe("incremental-full");
     expect(plan.fullRefresh).toBe(true);
     expect(plan.fullRefreshReason).toBe(staleConfigMessage);
     expect(plan.incrementalFallbackReason).toBeNull();
@@ -758,7 +758,7 @@ describe("snapshot planning", () => {
     });
 
     expect(assertIncrementalRefreshPrerequisitesMock).toHaveBeenCalledTimes(2);
-    expect(plan.runnerKind).toBe("results");
+    expect(plan.snapshot.runnerKind).toBe("results");
     expect(plan.incrementalFallbackReason).toBe("metric not compatible");
     expect(plan.fullRefresh).toBe(false);
     expect(plan.fullRefreshReason).toBeNull();
@@ -802,7 +802,7 @@ describe("snapshot planning", () => {
       factTableMap: new Map() as FactTableMap,
     });
 
-    expect(plan.runnerKind).toBe("incremental-exploratory");
+    expect(plan.snapshot.runnerKind).toBe("incremental-exploratory");
     expect(findSnapshotByIdMock).toHaveBeenCalledWith(
       context,
       materializedBySnapshotId,
@@ -843,7 +843,7 @@ describe("snapshot planning", () => {
       factTableMap: new Map() as FactTableMap,
     });
 
-    expect(plan.runnerKind).toBe("incremental-exploratory");
+    expect(plan.snapshot.runnerKind).toBe("incremental-exploratory");
     expect(findSnapshotByIdMock).not.toHaveBeenCalled();
     expect(getLatestSuccessfulSnapshotMock).not.toHaveBeenCalled();
     expect(plan.snapshot.sourceSnapshotId).toBeUndefined();
@@ -947,7 +947,7 @@ describe("snapshot planning", () => {
       factTableMap: new Map() as FactTableMap,
     });
 
-    expect(plan.runnerKind).toBe("results");
+    expect(plan.snapshot.runnerKind).toBe("results");
     expect(plan.incrementalFallbackReason).toBe("metric not compatible");
   });
 
@@ -986,7 +986,7 @@ describe("snapshot planning", () => {
       factTableMap: new Map() as FactTableMap,
     });
 
-    expect(plan.runnerKind).toBe("incremental-exploratory");
+    expect(plan.snapshot.runnerKind).toBe("incremental-exploratory");
   });
 
   it("throws ExperimentIncrementalPipelineRequiresFullRefreshError when the Overall units table requires a full refresh and prompting enabled", async () => {
@@ -1038,7 +1038,7 @@ describe("snapshot planning", () => {
       factTableMap: new Map() as FactTableMap,
     });
 
-    expect(plan.runnerKind).toBe("results");
+    expect(plan.snapshot.runnerKind).toBe("results");
     expect(plan.incrementalFallbackReason).toBe(
       "Overall Results need a full refresh; running non-incremental update instead of reading stale data.",
     );

--- a/packages/back-end/test/services/snapshot-query-runner-kind.test.ts
+++ b/packages/back-end/test/services/snapshot-query-runner-kind.test.ts
@@ -41,7 +41,7 @@ describe("resolveSnapshotRunner", () => {
         snapshotType: "standard",
         hasSnapshotDimensions: false,
         hasMaterializedUnitsTable: true,
-      }).runnerKind,
+      }).runnerFamily,
     ).toBe("incremental");
   });
 
@@ -53,7 +53,7 @@ describe("resolveSnapshotRunner", () => {
         snapshotType: "exploratory",
         hasSnapshotDimensions: true,
         hasMaterializedUnitsTable: true,
-      }).runnerKind,
+      }).runnerFamily,
     ).toBe("incremental-exploratory");
   });
 
@@ -65,7 +65,7 @@ describe("resolveSnapshotRunner", () => {
         snapshotType: "exploratory",
         hasSnapshotDimensions: false,
         hasMaterializedUnitsTable: true,
-      }).runnerKind,
+      }).runnerFamily,
     ).toBe("incremental");
   });
 
@@ -79,7 +79,7 @@ describe("resolveSnapshotRunner", () => {
         hasMaterializedUnitsTable: false,
       }),
     ).toEqual({
-      runnerKind: "results",
+      runnerFamily: "results",
       incrementalFallbackReason:
         "No materialized units table yet for Overall Results.",
     });
@@ -95,7 +95,7 @@ describe("resolveSnapshotRunner", () => {
         hasMaterializedUnitsTable: false,
       }),
     ).toEqual({
-      runnerKind: "results",
+      runnerFamily: "results",
       incrementalFallbackReason:
         "No materialized units table yet for Overall Results.",
     });
@@ -109,7 +109,7 @@ describe("resolveSnapshotRunner", () => {
         snapshotType: "standard",
         hasSnapshotDimensions: false,
         hasMaterializedUnitsTable: false,
-      }).runnerKind,
+      }).runnerFamily,
     ).toBe("incremental");
   });
 
@@ -124,7 +124,7 @@ describe("resolveSnapshotRunner", () => {
         hasMaterializedUnitsTable: true,
       }),
     ).toEqual({
-      runnerKind: "results",
+      runnerFamily: "results",
       incrementalFallbackReason: null,
     });
   });
@@ -142,7 +142,7 @@ describe("resolveSnapshotRunner", () => {
         hasMaterializedUnitsTable: true,
       }),
     ).toEqual({
-      runnerKind: "results",
+      runnerFamily: "results",
       incrementalFallbackReason: null,
     });
   });
@@ -160,7 +160,7 @@ describe("resolveSnapshotRunner", () => {
         hasMaterializedUnitsTable: true,
       }),
     ).toEqual({
-      runnerKind: "results",
+      runnerFamily: "results",
       incrementalFallbackReason: null,
     });
   });
@@ -176,7 +176,7 @@ describe("resolveSnapshotRunner", () => {
         snapshotType: "standard",
         hasSnapshotDimensions: false,
         hasMaterializedUnitsTable: true,
-      }).runnerKind,
+      }).runnerFamily,
     ).toBe("incremental");
   });
 
@@ -190,7 +190,7 @@ describe("resolveSnapshotRunner", () => {
         hasMaterializedUnitsTable: true,
       }),
     ).toEqual({
-      runnerKind: "results",
+      runnerFamily: "results",
       incrementalFallbackReason:
         'Experiment type "multi-armed-bandit" is not supported for Incremental Pipeline mode.',
     });
@@ -206,7 +206,7 @@ describe("resolveSnapshotRunner", () => {
         hasMaterializedUnitsTable: true,
       }),
     ).toEqual({
-      runnerKind: "results",
+      runnerFamily: "results",
       incrementalFallbackReason:
         'Experiment type "holdout" is not supported for Incremental Pipeline mode.',
     });
@@ -223,7 +223,7 @@ describe("resolveSnapshotRunner", () => {
         hasMaterializedUnitsTable: true,
       }),
     ).toEqual({
-      runnerKind: "results",
+      runnerFamily: "results",
       incrementalFallbackReason: null,
     });
   });
@@ -236,7 +236,7 @@ describe("resolveSnapshotRunner", () => {
         snapshotType: "standard",
         hasSnapshotDimensions: false,
         hasMaterializedUnitsTable: true,
-      }).runnerKind,
+      }).runnerFamily,
     ).toBe("incremental");
   });
 
@@ -252,7 +252,7 @@ describe("resolveSnapshotRunner", () => {
         snapshotType: "standard",
         hasSnapshotDimensions: false,
         hasMaterializedUnitsTable: true,
-      }).runnerKind,
+      }).runnerFamily,
     ).toBe("incremental");
   });
 
@@ -270,7 +270,7 @@ describe("resolveSnapshotRunner", () => {
         hasMaterializedUnitsTable: true,
       }),
     ).toEqual({
-      runnerKind: "results",
+      runnerFamily: "results",
       incrementalFallbackReason: null,
     });
   });
@@ -288,7 +288,7 @@ describe("resolveSnapshotRunner", () => {
         snapshotType: "standard",
         hasSnapshotDimensions: false,
         hasMaterializedUnitsTable: true,
-      }).runnerKind,
+      }).runnerFamily,
     ).toBe("results");
   });
 
@@ -307,7 +307,7 @@ describe("resolveSnapshotRunner", () => {
         hasMaterializedUnitsTable: true,
       }),
     ).toEqual({
-      runnerKind: "results",
+      runnerFamily: "results",
       incrementalFallbackReason: null,
     });
   });

--- a/packages/shared/types/experiment-snapshot.d.ts
+++ b/packages/shared/types/experiment-snapshot.d.ts
@@ -143,6 +143,11 @@ export interface ExperimentSnapshotAnalysisSettings {
 }
 
 export type SnapshotType = "standard" | "exploratory" | "report";
+export type SnapshotQueryRunnerKind =
+  | "results"
+  | "incremental-full"
+  | "incremental-update"
+  | "incremental-exploratory";
 export type SnapshotTriggeredBy =
   | "schedule"
   | "manual"
@@ -232,6 +237,7 @@ export interface ExperimentSnapshotInterface {
   type?: SnapshotType;
   triggeredBy?: SnapshotTriggeredBy;
   report?: string;
+  runnerKind?: SnapshotQueryRunnerKind;
 
   // List of queries that were run as part of this snapshot
   queries: Queries;


### PR DESCRIPTION
### Features and Changes

- Add `runnerKind` the snapshot document in mongo so we record how each snapshot was actually generated
- Split the concept in two: an internal `SnapshotQueryRunnerFamily` (used to pick the query runner) and a persisted `SnapshotQueryRunnerKind` which details how the update happened

### Testing

- Unit tests
