### PR TITLE
update the default etag feature flag to true

### DIFF
--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -176,7 +176,7 @@ export async function getDefinitions(req: AuthRequest, res: Response) {
   // user's permission fingerprint (the response is permission-filtered) and,
   // under config.yml, the parsed file's hash (file-managed resources bypass the
   // Mongo writes that bump the version). Gated behind a feature flag.
-  if (req.gb?.getFeatureValue("definitions-etag-304", false) === true) {
+  if (req.gb?.getFeatureValue("definitions-etag-304", true) === true) {
     const { version, projectVersions } =
       await getDefinitionsVersionState(orgId);
     const etag = buildDefinitionsEtag({


### PR DESCRIPTION
### Features and Changes
The experiment was a success, and the cache hit rates seem the same.  We are leaving the feature in order to help detect any future bugs in the cache bumping logic.
