### PR TITLE
fix(fact-tables): preserve API-managed userIdTypes on column refresh

### DIFF
--- a/packages/back-end/src/jobs/refreshFactTableColumns.ts
+++ b/packages/back-end/src/jobs/refreshFactTableColumns.ts
@@ -129,11 +129,14 @@ const refreshFactTableColumns = async (job: RefreshFactTableColumnsJob) => {
     updates.columns = columns;
     updates.columnsError = null;
 
-    updates.userIdTypes = resolveUserIdTypesForColumnRefresh({
+    const resolvedUserIdTypes = resolveUserIdTypesForColumnRefresh({
       datasource,
       factTable,
       columns,
     });
+    if (resolvedUserIdTypes !== null) {
+      updates.userIdTypes = resolvedUserIdTypes;
+    }
   } catch (e) {
     updates.columnsError = e.message;
   }

--- a/packages/back-end/src/jobs/refreshFactTableColumns.ts
+++ b/packages/back-end/src/jobs/refreshFactTableColumns.ts
@@ -24,8 +24,8 @@ import { determineColumnTypes } from "back-end/src/util/sql";
 import { getSourceIntegrationObject } from "back-end/src/services/datasource";
 import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizations";
 import {
-  deriveUserIdTypesFromColumns,
   normalizePersistedColumn,
+  resolveUserIdTypesForColumnRefresh,
 } from "back-end/src/util/factTable";
 import { logger } from "back-end/src/util/logger";
 
@@ -129,7 +129,11 @@ const refreshFactTableColumns = async (job: RefreshFactTableColumnsJob) => {
     updates.columns = columns;
     updates.columnsError = null;
 
-    updates.userIdTypes = deriveUserIdTypesFromColumns(datasource, columns);
+    updates.userIdTypes = resolveUserIdTypesForColumnRefresh({
+      datasource,
+      factTable,
+      columns,
+    });
   } catch (e) {
     updates.columnsError = e.message;
   }

--- a/packages/back-end/src/routers/fact-table/fact-table.controller.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.controller.ts
@@ -368,11 +368,14 @@ export const putFactTable = async (
       columnRefreshPending: needsBackgroundRefresh,
     };
 
-    columnRefreshResults.userIdTypes = resolveUserIdTypesForColumnRefresh({
+    const resolvedUserIdTypes = resolveUserIdTypesForColumnRefresh({
       datasource,
       factTable,
       columns,
     });
+    if (resolvedUserIdTypes !== null) {
+      columnRefreshResults.userIdTypes = resolvedUserIdTypes;
+    }
   }
 
   if (data.aggregatedFactTableSettings) {

--- a/packages/back-end/src/routers/fact-table/fact-table.controller.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.controller.ts
@@ -43,7 +43,7 @@ import {
   queueFactTableColumnsRefresh,
 } from "back-end/src/jobs/refreshFactTableColumns";
 import {
-  deriveUserIdTypesFromColumns,
+  resolveUserIdTypesForColumnRefresh,
   validateAggregatedFactTableSettings,
   getNextUpdateOccurrence,
 } from "back-end/src/util/factTable";
@@ -368,10 +368,11 @@ export const putFactTable = async (
       columnRefreshPending: needsBackgroundRefresh,
     };
 
-    columnRefreshResults.userIdTypes = deriveUserIdTypesFromColumns(
+    columnRefreshResults.userIdTypes = resolveUserIdTypesForColumnRefresh({
       datasource,
+      factTable,
       columns,
-    );
+    });
   }
 
   if (data.aggregatedFactTableSettings) {

--- a/packages/back-end/src/util/factTable.ts
+++ b/packages/back-end/src/util/factTable.ts
@@ -4,9 +4,11 @@ import {
   AggregatedFactTableSettings,
   ColumnInterface,
   CreateColumnProps,
+  FactTableInterface,
   JSONColumnFields,
 } from "shared/types/fact-table";
 import { DataSourceInterface } from "shared/types/datasource";
+import { isManagedWarehouse } from "shared/util";
 
 /**
  * Clears datatype-incompatible props. Empty datatype skips checks while
@@ -111,6 +113,40 @@ export function deriveUserIdTypesFromColumns(
   return (datasource.settings?.userIdTypes || [])
     .map((u) => u.userIdType)
     .filter((id) => activeColumns.has(id));
+}
+
+/**
+ * Decides a fact table's userIdTypes after a column refresh.
+ *
+ * Managed Warehouse (growthbook_clickhouse) owns its identifier mapping and
+ * syncs it from the datasource, so we always re-derive from the columns, even
+ * for API-managed tables (see #5358).
+ *
+ * On customer-owned warehouses an API-managed table's userIdTypes are declared
+ * explicitly by the caller. Auto-deriving there would silently re-add any
+ * column whose name happens to match another datasource identifier type, so we
+ * preserve the caller's selection instead.
+ *
+ * Everything else keeps the UI behavior of deriving identifiers by column name.
+ */
+export function resolveUserIdTypesForColumnRefresh({
+  datasource,
+  factTable,
+  columns,
+}: {
+  datasource: DataSourceInterface;
+  factTable: Pick<FactTableInterface, "managedBy" | "userIdTypes">;
+  columns: ColumnInterface[];
+}): string[] {
+  if (isManagedWarehouse(datasource)) {
+    return deriveUserIdTypesFromColumns(datasource, columns);
+  }
+
+  if (factTable.managedBy === "api") {
+    return factTable.userIdTypes;
+  }
+
+  return deriveUserIdTypesFromColumns(datasource, columns);
 }
 
 export function columnsHaveAutoSlices(

--- a/packages/back-end/src/util/factTable.ts
+++ b/packages/back-end/src/util/factTable.ts
@@ -116,7 +116,8 @@ export function deriveUserIdTypesFromColumns(
 }
 
 /**
- * Decides a fact table's userIdTypes after a column refresh.
+ * Resolves the userIdTypes to persist after a column refresh, or `null` when
+ * the refresh should leave the stored value untouched.
  *
  * Managed Warehouse (growthbook_clickhouse) owns its identifier mapping and
  * syncs it from the datasource, so we always re-derive from the columns, even
@@ -124,8 +125,10 @@ export function deriveUserIdTypesFromColumns(
  *
  * On customer-owned warehouses an API-managed table's userIdTypes are declared
  * explicitly by the caller. Auto-deriving there would silently re-add any
- * column whose name happens to match another datasource identifier type, so we
- * preserve the caller's selection instead.
+ * column whose name happens to match another datasource identifier type. We
+ * return `null` so the refresh does not write userIdTypes at all, which both
+ * preserves the caller's selection and avoids clobbering a concurrent API
+ * update with a stale snapshot read earlier in the request/job.
  *
  * Everything else keeps the UI behavior of deriving identifiers by column name.
  */
@@ -135,15 +138,15 @@ export function resolveUserIdTypesForColumnRefresh({
   columns,
 }: {
   datasource: DataSourceInterface;
-  factTable: Pick<FactTableInterface, "managedBy" | "userIdTypes">;
+  factTable: Pick<FactTableInterface, "managedBy">;
   columns: ColumnInterface[];
-}): string[] {
+}): string[] | null {
   if (isManagedWarehouse(datasource)) {
     return deriveUserIdTypesFromColumns(datasource, columns);
   }
 
   if (factTable.managedBy === "api") {
-    return factTable.userIdTypes;
+    return null;
   }
 
   return deriveUserIdTypesFromColumns(datasource, columns);

--- a/packages/back-end/test/util/factTable.test.ts
+++ b/packages/back-end/test/util/factTable.test.ts
@@ -468,24 +468,21 @@ describe("deriveUserIdTypesFromColumns", () => {
 describe("resolveUserIdTypesForColumnRefresh", () => {
   function makeFactTable(
     managedBy: FactTableInterface["managedBy"],
-    userIdTypes: string[],
-  ): Pick<FactTableInterface, "managedBy" | "userIdTypes"> {
-    return { managedBy, userIdTypes };
+  ): Pick<FactTableInterface, "managedBy"> {
+    return { managedBy };
   }
 
   describe("growthbook_clickhouse datasource", () => {
-    it("always derives from columns, even for API-managed tables (#5358)", () => {
+    it("derives from columns, even for API-managed tables (#5358)", () => {
       const ds = makeClickhouseDatasource([
         { columnName: "user_id", type: "identifier" },
         { columnName: "device_id", type: "identifier" },
       ]);
       const columns = [makeColumn("user_id"), makeColumn("device_id")];
-      // Stale stored selection must be overwritten by the derived set.
-      const factTable = makeFactTable("api", ["user_id"]);
       expect(
         resolveUserIdTypesForColumnRefresh({
           datasource: ds,
-          factTable,
+          factTable: makeFactTable("api"),
           columns,
         }),
       ).toEqual(["user_id", "device_id"]);
@@ -496,11 +493,10 @@ describe("resolveUserIdTypesForColumnRefresh", () => {
         { columnName: "user_id", type: "identifier" },
       ]);
       const columns = [makeColumn("user_id"), makeColumn("device_id")];
-      const factTable = makeFactTable("", []);
       expect(
         resolveUserIdTypesForColumnRefresh({
           datasource: ds,
-          factTable,
+          factTable: makeFactTable(""),
           columns,
         }),
       ).toEqual(["user_id"]);
@@ -508,22 +504,22 @@ describe("resolveUserIdTypesForColumnRefresh", () => {
   });
 
   describe("customer-owned (non-ClickHouse) datasources", () => {
-    it("preserves the caller's userIdTypes for API-managed tables", () => {
+    it("returns null (leave userIdTypes untouched) for API-managed tables", () => {
       const ds = makeStandardDatasource([
         { userIdType: "visitor_id" },
         { userIdType: "user_id" },
       ]);
       // SQL returns a user_id column that name-matches a datasource identifier
-      // type, but the caller only declared visitor_id.
+      // type, but the caller declared only visitor_id, so the refresh must not
+      // overwrite their selection.
       const columns = [makeColumn("visitor_id"), makeColumn("user_id")];
-      const factTable = makeFactTable("api", ["visitor_id"]);
       expect(
         resolveUserIdTypesForColumnRefresh({
           datasource: ds,
-          factTable,
+          factTable: makeFactTable("api"),
           columns,
         }),
-      ).toEqual(["visitor_id"]);
+      ).toBeNull();
     });
 
     it("derives from columns for unmanaged tables", () => {
@@ -532,11 +528,10 @@ describe("resolveUserIdTypesForColumnRefresh", () => {
         { userIdType: "user_id" },
       ]);
       const columns = [makeColumn("visitor_id"), makeColumn("user_id")];
-      const factTable = makeFactTable("", ["visitor_id"]);
       expect(
         resolveUserIdTypesForColumnRefresh({
           datasource: ds,
-          factTable,
+          factTable: makeFactTable(""),
           columns,
         }),
       ).toEqual(["visitor_id", "user_id"]);
@@ -548,11 +543,10 @@ describe("resolveUserIdTypesForColumnRefresh", () => {
         { userIdType: "user_id" },
       ]);
       const columns = [makeColumn("visitor_id"), makeColumn("user_id")];
-      const factTable = makeFactTable("admin", ["visitor_id"]);
       expect(
         resolveUserIdTypesForColumnRefresh({
           datasource: ds,
-          factTable,
+          factTable: makeFactTable("admin"),
           columns,
         }),
       ).toEqual(["visitor_id", "user_id"]);

--- a/packages/back-end/test/util/factTable.test.ts
+++ b/packages/back-end/test/util/factTable.test.ts
@@ -1,4 +1,4 @@
-import { ColumnInterface } from "shared/types/fact-table";
+import { ColumnInterface, FactTableInterface } from "shared/types/fact-table";
 import {
   DataSourceInterface,
   GrowthbookClickhouseDataSource,
@@ -10,6 +10,7 @@ import {
   normalizePersistedColumn,
   getMostRecentUpdateOccurrence,
   normalizeJSONFieldsInput,
+  resolveUserIdTypesForColumnRefresh,
   stripIncompatibleFields,
 } from "back-end/src/util/factTable";
 
@@ -460,6 +461,101 @@ describe("deriveUserIdTypesFromColumns", () => {
       const ds = makeStandardDatasource([{ userIdType: "user_id" }]);
       const cols = [makeColumn("revenue"), makeColumn("country")];
       expect(deriveUserIdTypesFromColumns(ds, cols)).toEqual([]);
+    });
+  });
+});
+
+describe("resolveUserIdTypesForColumnRefresh", () => {
+  function makeFactTable(
+    managedBy: FactTableInterface["managedBy"],
+    userIdTypes: string[],
+  ): Pick<FactTableInterface, "managedBy" | "userIdTypes"> {
+    return { managedBy, userIdTypes };
+  }
+
+  describe("growthbook_clickhouse datasource", () => {
+    it("always derives from columns, even for API-managed tables (#5358)", () => {
+      const ds = makeClickhouseDatasource([
+        { columnName: "user_id", type: "identifier" },
+        { columnName: "device_id", type: "identifier" },
+      ]);
+      const columns = [makeColumn("user_id"), makeColumn("device_id")];
+      // Stale stored selection must be overwritten by the derived set.
+      const factTable = makeFactTable("api", ["user_id"]);
+      expect(
+        resolveUserIdTypesForColumnRefresh({
+          datasource: ds,
+          factTable,
+          columns,
+        }),
+      ).toEqual(["user_id", "device_id"]);
+    });
+
+    it("derives from columns for unmanaged tables", () => {
+      const ds = makeClickhouseDatasource([
+        { columnName: "user_id", type: "identifier" },
+      ]);
+      const columns = [makeColumn("user_id"), makeColumn("device_id")];
+      const factTable = makeFactTable("", []);
+      expect(
+        resolveUserIdTypesForColumnRefresh({
+          datasource: ds,
+          factTable,
+          columns,
+        }),
+      ).toEqual(["user_id"]);
+    });
+  });
+
+  describe("customer-owned (non-ClickHouse) datasources", () => {
+    it("preserves the caller's userIdTypes for API-managed tables", () => {
+      const ds = makeStandardDatasource([
+        { userIdType: "visitor_id" },
+        { userIdType: "user_id" },
+      ]);
+      // SQL returns a user_id column that name-matches a datasource identifier
+      // type, but the caller only declared visitor_id.
+      const columns = [makeColumn("visitor_id"), makeColumn("user_id")];
+      const factTable = makeFactTable("api", ["visitor_id"]);
+      expect(
+        resolveUserIdTypesForColumnRefresh({
+          datasource: ds,
+          factTable,
+          columns,
+        }),
+      ).toEqual(["visitor_id"]);
+    });
+
+    it("derives from columns for unmanaged tables", () => {
+      const ds = makeStandardDatasource([
+        { userIdType: "visitor_id" },
+        { userIdType: "user_id" },
+      ]);
+      const columns = [makeColumn("visitor_id"), makeColumn("user_id")];
+      const factTable = makeFactTable("", ["visitor_id"]);
+      expect(
+        resolveUserIdTypesForColumnRefresh({
+          datasource: ds,
+          factTable,
+          columns,
+        }),
+      ).toEqual(["visitor_id", "user_id"]);
+    });
+
+    it("derives from columns for admin-managed tables", () => {
+      const ds = makeStandardDatasource([
+        { userIdType: "visitor_id" },
+        { userIdType: "user_id" },
+      ]);
+      const columns = [makeColumn("visitor_id"), makeColumn("user_id")];
+      const factTable = makeFactTable("admin", ["visitor_id"]);
+      expect(
+        resolveUserIdTypesForColumnRefresh({
+          datasource: ds,
+          factTable,
+          columns,
+        }),
+      ).toEqual(["visitor_id", "user_id"]);
     });
   });
 });


### PR DESCRIPTION
## What

Column refresh was silently re-marking columns as identifier types on API-managed fact tables, overriding the `userIdTypes` the API caller declared and breaking experiments. Reported by a customer whose `.py` definition declared only `visitor_id`, but a `user_id` column kept getting auto-marked as an identifier within a minute of each refresh.

## Root cause

On every column refresh, GrowthBook recomputed `userIdTypes` via `deriveUserIdTypesFromColumns`, which returns `{ datasource identifier types } ∩ { returned column names }` and **fully replaces** the stored value. A column shows as an identifier in the UI purely because its name is in `factTable.userIdTypes` (`ColumnList.tsx`). So any column whose name matched another datasource-declared identifier type was force-added, and the async refresh job re-applied it, so the user could not keep it unmarked.

This behavior has existed since #5358 (managed-warehouse). It is intended for UI-built SQL fact tables (a column named like a datasource identifier type *is* a join key), but wrong for API-managed tables where the caller controls `userIdTypes` explicitly. It is **not** a regression from #6423.

## Fix

Route the refresh job and the internal update controller through a new `resolveUserIdTypesForColumnRefresh` helper:

- **Managed Warehouse (`growthbook_clickhouse`)**: always derive from columns, even for API-managed tables. Preserves #5358, which owns the identifier mapping and syncs it from the datasource.
- **API-managed tables on customer-owned warehouses**: keep the caller's declared `userIdTypes`.
- **Everything else** (unmanaged, admin-managed): keep the UI name-match behavior.

`deriveUserIdTypesFromColumns` is unchanged, so #5358's unit tests still pass as-is.

## Scope note

`managedBy === "admin"` (config.yml) tables still derive, per the requested scope (only `"api"` preserves). If we want config-managed tables to keep their declared identifiers too, that's a one-line follow-up.

## Testing

- 5 new unit tests for `resolveUserIdTypesForColumnRefresh` covering all branches, including a regression guard that ClickHouse + API-managed still derives (#5358).
- Verified the fix goes red under the old derive-everywhere behavior (`user_id` reappears) and green with the fix.
- `pnpm --filter back-end test` on the util, API, and model fact-table suites all pass; type-check and lint clean.

Not verified via a live UI repro (would require a customer-warehouse datasource declaring 2+ identifier types plus an API-managed fact table). Happy to run that if wanted.