### PR TITLE
chore(lint): remove switch-exhaustiveness suppressions (part 1)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,35 +1,10 @@
 {
-  "packages/back-end/src/enterprise/models/DashboardModel.ts": {
-    "@typescript-eslint/switch-exhaustiveness-check": {
-      "count": 3
-    }
-  },
-  "packages/back-end/src/enterprise/services/agent-handler.ts": {
-    "@typescript-eslint/switch-exhaustiveness-check": {
-      "count": 1
-    }
-  },
   "packages/back-end/src/events/handlers/legacy.ts": {
     "@typescript-eslint/switch-exhaustiveness-check": {
       "count": 1
     }
   },
-  "packages/back-end/src/jobs/updateExperimentStatus.ts": {
-    "@typescript-eslint/switch-exhaustiveness-check": {
-      "count": 1
-    }
-  },
   "packages/back-end/src/services/features.ts": {
-    "@typescript-eslint/switch-exhaustiveness-check": {
-      "count": 1
-    }
-  },
-  "packages/back-end/src/services/informationSchema.ts": {
-    "@typescript-eslint/switch-exhaustiveness-check": {
-      "count": 3
-    }
-  },
-  "packages/back-end/src/services/rampSchedule.ts": {
     "@typescript-eslint/switch-exhaustiveness-check": {
       "count": 1
     }
@@ -98,11 +73,6 @@
   "packages/front-end/components/AutoGenerateMetricsModal.tsx": {
     "no-restricted-syntax": {
       "count": 2
-    }
-  },
-  "packages/front-end/components/Configs/fieldSchema.ts": {
-    "@typescript-eslint/switch-exhaustiveness-check": {
-      "count": 3
     }
   },
   "packages/front-end/components/Configs/invariantConditions.ts": {
@@ -251,9 +221,6 @@
     }
   },
   "packages/front-end/components/Experiment/BanditDateGraph.tsx": {
-    "@typescript-eslint/switch-exhaustiveness-check": {
-      "count": 1
-    },
     "no-restricted-syntax": {
       "count": 1
     }
@@ -329,11 +296,6 @@
       "count": 2
     }
   },
-  "packages/front-end/components/Experiment/ExperimentDateGraph.tsx": {
-    "@typescript-eslint/switch-exhaustiveness-check": {
-      "count": 1
-    }
-  },
   "packages/front-end/components/Experiment/ExperimentGraph.tsx": {
     "no-restricted-syntax": {
       "count": 1
@@ -350,9 +312,6 @@
     }
   },
   "packages/front-end/components/Experiment/ExperimentTimeSeriesGraph.tsx": {
-    "@typescript-eslint/switch-exhaustiveness-check": {
-      "count": 1
-    },
     "no-restricted-imports": {
       "count": 1
     }
@@ -1446,11 +1405,6 @@
       "count": 1
     }
   },
-  "packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx": {
-    "@typescript-eslint/switch-exhaustiveness-check": {
-      "count": 1
-    }
-  },
   "packages/front-end/components/Reviews/RevisionStatusBadge.tsx": {
     "@typescript-eslint/switch-exhaustiveness-check": {
       "count": 3
@@ -1537,9 +1491,6 @@
     }
   },
   "packages/front-end/components/SchemaBrowser/SqlExplorerModal.tsx": {
-    "@typescript-eslint/switch-exhaustiveness-check": {
-      "count": 1
-    },
     "no-restricted-imports": {
       "count": 1
     },
@@ -2208,9 +2159,6 @@
     }
   },
   "packages/front-end/pages/features/FeaturesDraftTable.tsx": {
-    "@typescript-eslint/switch-exhaustiveness-check": {
-      "count": 1
-    },
     "no-restricted-syntax": {
       "count": 1
     }
@@ -2329,52 +2277,12 @@
       "count": 1
     }
   },
-  "packages/front-end/services/initial-resources.ts": {
-    "@typescript-eslint/switch-exhaustiveness-check": {
-      "count": 1
-    }
-  },
-  "packages/front-end/services/rule-conflicts.tsx": {
-    "@typescript-eslint/switch-exhaustiveness-check": {
-      "count": 1
-    }
-  },
   "packages/front-end/test/components/Forms/MultiSelectField.test.tsx": {
     "no-restricted-syntax": {
       "count": 21
     }
   },
-  "packages/shared/src/enterprise/decision-criteria/statusIndicatorData.ts": {
-    "@typescript-eslint/switch-exhaustiveness-check": {
-      "count": 1
-    }
-  },
-  "packages/shared/src/revisions/helpers.ts": {
-    "@typescript-eslint/switch-exhaustiveness-check": {
-      "count": 1
-    }
-  },
-  "packages/shared/src/util/config-schema/typescript.ts": {
-    "@typescript-eslint/switch-exhaustiveness-check": {
-      "count": 1
-    }
-  },
-  "packages/shared/src/util/event-forwarder-datasource.ts": {
-    "@typescript-eslint/switch-exhaustiveness-check": {
-      "count": 2
-    }
-  },
-  "packages/shared/src/util/event-forwarder-fact-table.ts": {
-    "@typescript-eslint/switch-exhaustiveness-check": {
-      "count": 3
-    }
-  },
   "packages/shared/src/util/features.ts": {
-    "@typescript-eslint/switch-exhaustiveness-check": {
-      "count": 2
-    }
-  },
-  "packages/shared/src/util/managedWarehouse.ts": {
     "@typescript-eslint/switch-exhaustiveness-check": {
       "count": 1
     }

--- a/packages/back-end/src/enterprise/models/DashboardModel.ts
+++ b/packages/back-end/src/enterprise/models/DashboardModel.ts
@@ -888,7 +888,6 @@ export function migrateBlock(
     case "fact-table-exploration":
     case "data-source-exploration":
     case "funnel-exploration":
-      return doc;
     default:
       return doc;
   }
@@ -924,7 +923,6 @@ function toBlockApiInterface(
     case "fact-table-exploration":
     case "data-source-exploration":
     case "funnel-exploration":
-      return block;
     default:
       return block;
   }
@@ -962,7 +960,6 @@ export function fromBlockApiInterface(
     case "fact-table-exploration":
     case "data-source-exploration":
     case "funnel-exploration":
-      return apiBlock;
     default:
       return apiBlock;
   }

--- a/packages/back-end/src/enterprise/models/DashboardModel.ts
+++ b/packages/back-end/src/enterprise/models/DashboardModel.ts
@@ -880,6 +880,15 @@ export function migrateBlock(
       }
       return migrated;
     }
+    case "metric-explorer":
+    case "markdown":
+    case "experiment-metadata":
+    case "experiment-traffic":
+    case "metric-exploration":
+    case "fact-table-exploration":
+    case "data-source-exploration":
+    case "funnel-exploration":
+      return doc;
     default:
       return doc;
   }
@@ -900,6 +909,22 @@ function toBlockApiInterface(
           endDate: getValidDate(block.analysisSettings.endDate).toISOString(),
         },
       };
+    case "experiment-metric":
+    case "experiment-dimension":
+    case "experiment-time-series":
+    case "sql-explorer":
+    case "markdown":
+    case "experiment-metadata":
+    case "metric-experiments":
+    case "experiments-scaled-impact":
+    case "experiments-win-rate":
+    case "experiments-status":
+    case "experiment-traffic":
+    case "metric-exploration":
+    case "fact-table-exploration":
+    case "data-source-exploration":
+    case "funnel-exploration":
+      return block;
     default:
       return block;
   }
@@ -923,6 +948,21 @@ export function fromBlockApiInterface(
         ...apiBlock,
         blockConfig: apiBlock.blockConfig ?? [],
       };
+    case "experiment-metric":
+    case "experiment-dimension":
+    case "experiment-time-series":
+    case "markdown":
+    case "experiment-metadata":
+    case "metric-experiments":
+    case "experiments-scaled-impact":
+    case "experiments-win-rate":
+    case "experiments-status":
+    case "experiment-traffic":
+    case "metric-exploration":
+    case "fact-table-exploration":
+    case "data-source-exploration":
+    case "funnel-exploration":
+      return apiBlock;
     default:
       return apiBlock;
   }

--- a/packages/back-end/src/enterprise/services/agent-handler.ts
+++ b/packages/back-end/src/enterprise/services/agent-handler.ts
@@ -594,6 +594,22 @@ async function processStream<TParams>(
           processor.setError(errorMsg);
           break;
         }
+        case "file":
+        case "tool-approval-request":
+        case "source":
+        case "text-start":
+        case "text-end":
+        case "reasoning-start":
+        case "reasoning-end":
+        case "tool-input-end":
+        case "finish":
+        case "raw":
+        case "tool-output-denied":
+        case "start-step":
+        case "finish-step":
+        case "start":
+        case "abort":
+          break;
         default:
           break;
       }

--- a/packages/back-end/src/enterprise/services/agent-handler.ts
+++ b/packages/back-end/src/enterprise/services/agent-handler.ts
@@ -609,7 +609,6 @@ async function processStream<TParams>(
         case "finish-step":
         case "start":
         case "abort":
-          break;
         default:
           break;
       }

--- a/packages/back-end/src/jobs/updateExperimentStatus.ts
+++ b/packages/back-end/src/jobs/updateExperimentStatus.ts
@@ -143,6 +143,7 @@ const updateSingleExperimentStatus = async (
         break;
       }
       // TODO(schedule-status-updates): handle "stop" once stopAt is supported
+      case "stop":
       default:
         logger.info(
           `Skipping status update: Experiment ${experiment.id} has unsupported scheduled type ${scheduled.type}`,

--- a/packages/back-end/src/services/informationSchema.ts
+++ b/packages/back-end/src/services/informationSchema.ts
@@ -349,7 +349,6 @@ export function getTablePath(
     case "databricks":
     case "mixpanel":
     case "vertica":
-      return returnValue;
     default:
       return returnValue;
   }
@@ -388,7 +387,6 @@ export function getSchemaPath(
     case "databricks":
     case "mixpanel":
     case "vertica":
-      return returnValue;
     default:
       return returnValue;
   }
@@ -424,7 +422,6 @@ export function getDatabasePath(
     case "databricks":
     case "mixpanel":
     case "vertica":
-      return catalog;
     default:
       return catalog;
   }

--- a/packages/back-end/src/services/informationSchema.ts
+++ b/packages/back-end/src/services/informationSchema.ts
@@ -339,6 +339,17 @@ export function getTablePath(
     case "growthbook_clickhouse":
       return tableName; // Only return the table name
 
+    case "redshift":
+    case "athena":
+    case "google_analytics":
+    case "snowflake":
+    case "postgres":
+    case "mssql":
+    case "presto":
+    case "databricks":
+    case "mixpanel":
+    case "vertica":
+      return returnValue;
     default:
       return returnValue;
   }
@@ -367,6 +378,17 @@ export function getSchemaPath(
     case "growthbook_clickhouse":
       return ""; // Only return the table name
 
+    case "redshift":
+    case "athena":
+    case "google_analytics":
+    case "snowflake":
+    case "postgres":
+    case "mssql":
+    case "presto":
+    case "databricks":
+    case "mixpanel":
+    case "vertica":
+      return returnValue;
     default:
       return returnValue;
   }
@@ -392,6 +414,17 @@ export function getDatabasePath(
     case "growthbook_clickhouse":
       return ""; // Only return the table name
 
+    case "redshift":
+    case "athena":
+    case "google_analytics":
+    case "snowflake":
+    case "postgres":
+    case "mssql":
+    case "presto":
+    case "databricks":
+    case "mixpanel":
+    case "vertica":
+      return catalog;
     default:
       return catalog;
   }

--- a/packages/back-end/src/services/rampSchedule.ts
+++ b/packages/back-end/src/services/rampSchedule.ts
@@ -768,6 +768,10 @@ export function computeNextProcessAt(schedule: {
       return schedule.startDate ?? null;
     case "paused":
       return cutoff;
+    case "pending":
+    case "completed":
+    case "rolled-back":
+      return null;
     default:
       return null;
   }

--- a/packages/back-end/src/services/rampSchedule.ts
+++ b/packages/back-end/src/services/rampSchedule.ts
@@ -771,7 +771,6 @@ export function computeNextProcessAt(schedule: {
     case "pending":
     case "completed":
     case "rolled-back":
-      return null;
     default:
       return null;
   }

--- a/packages/front-end/components/Configs/fieldSchema.ts
+++ b/packages/front-end/components/Configs/fieldSchema.ts
@@ -258,7 +258,6 @@ export function typeDefault(field: SchemaField | null): unknown {
     case "float":
       return 0;
     case "string":
-      return "";
     default:
       return "";
   }
@@ -309,7 +308,6 @@ export function fieldValueType(
     case "float":
       return "number";
     case "string":
-      return "string";
     default:
       return "string";
   }
@@ -331,7 +329,6 @@ export function valueToDisplayString(
     case "number":
       return value === null ? "null" : String(value);
     case "string":
-      return typeof value === "string" ? value : JSON.stringify(value);
     default:
       return typeof value === "string" ? value : JSON.stringify(value);
   }

--- a/packages/front-end/components/Configs/fieldSchema.ts
+++ b/packages/front-end/components/Configs/fieldSchema.ts
@@ -257,6 +257,8 @@ export function typeDefault(field: SchemaField | null): unknown {
     case "integer":
     case "float":
       return 0;
+    case "string":
+      return "";
     default:
       return "";
   }
@@ -306,6 +308,8 @@ export function fieldValueType(
     case "integer":
     case "float":
       return "number";
+    case "string":
+      return "string";
     default:
       return "string";
   }
@@ -326,6 +330,8 @@ export function valueToDisplayString(
       return value ? "true" : "false";
     case "number":
       return value === null ? "null" : String(value);
+    case "string":
+      return typeof value === "string" ? value : JSON.stringify(value);
     default:
       return typeof value === "string" ? value : JSON.stringify(value);
   }

--- a/packages/front-end/components/Experiment/BanditDateGraph.tsx
+++ b/packages/front-end/components/Experiment/BanditDateGraph.tsx
@@ -267,6 +267,8 @@ const getYVal = (
       return variation.probability ?? 0;
     case "weights":
       return variation.weight ?? 0;
+    case undefined:
+      return undefined;
     default:
       return undefined;
   }

--- a/packages/front-end/components/Experiment/BanditDateGraph.tsx
+++ b/packages/front-end/components/Experiment/BanditDateGraph.tsx
@@ -268,7 +268,6 @@ const getYVal = (
     case "weights":
       return variation.weight ?? 0;
     case undefined:
-      return undefined;
     default:
       return undefined;
   }

--- a/packages/front-end/components/Experiment/ExperimentDateGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentDateGraph.tsx
@@ -219,6 +219,8 @@ const getYVal = (
       return variation.v;
     case "effect":
       return variation.up ?? 0;
+    case undefined:
+      return variation.v;
     default:
       return variation.v;
   }

--- a/packages/front-end/components/Experiment/ExperimentDateGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentDateGraph.tsx
@@ -220,7 +220,6 @@ const getYVal = (
     case "effect":
       return variation.up ?? 0;
     case undefined:
-      return variation.v;
     default:
       return variation.v;
   }

--- a/packages/front-end/components/Experiment/ExperimentTimeSeriesGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentTimeSeriesGraph.tsx
@@ -342,6 +342,8 @@ const getYVal = (variation?: DataPointVariation, yaxis?: AxisType) => {
   switch (yaxis) {
     case "effect":
       return variation.up;
+    case undefined:
+      return undefined;
   }
 };
 

--- a/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
+++ b/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
@@ -1626,7 +1626,6 @@ export default function ReviewAndPublish({
           onPublish && onPublish();
           return;
         case "none":
-          return;
         default:
           return;
       }

--- a/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
+++ b/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
@@ -1625,6 +1625,8 @@ export default function ReviewAndPublish({
           await mutate();
           onPublish && onPublish();
           return;
+        case "none":
+          return;
         default:
           return;
       }

--- a/packages/front-end/components/SchemaBrowser/SqlExplorerModal.tsx
+++ b/packages/front-end/components/SchemaBrowser/SqlExplorerModal.tsx
@@ -436,6 +436,13 @@ export default function SqlExplorerModal({
                 );
               }
               break;
+
+            case "today":
+            case "last7Days":
+            case "last30Days":
+            case "greaterThanOrEqualTo":
+            case "lessThanOrEqualTo":
+              break;
           }
         });
       }

--- a/packages/front-end/pages/features/FeaturesDraftTable.tsx
+++ b/packages/front-end/pages/features/FeaturesDraftTable.tsx
@@ -74,6 +74,10 @@ export default function FeaturesDraftTable() {
       case "changes-requested":
         dateAndStatus = parseInt(`1${dateAndStatus}`);
         break;
+      case "discarded":
+      case "published":
+      case "pending-parent":
+        break;
     }
     return {
       // Composite ID so MiniSearch never sees duplicate IDs when a feature has

--- a/packages/front-end/services/initial-resources.ts
+++ b/packages/front-end/services/initial-resources.ts
@@ -672,6 +672,21 @@ export function getInitialDatasourceResources({
       return getRudderstackResources(datasource);
     case "amplitude":
       return getAmplitudeResources(datasource);
+    case undefined:
+    case "custom":
+    case "mixpanel":
+    case "snowplow":
+    case "jitsu":
+    case "freshpaint":
+    case "fullstory":
+    case "matomo":
+    case "heap":
+    case "mparticle":
+    case "firebase":
+    case "keen":
+    case "clevertap":
+    case "eventForwarder":
+      break;
     // TODO: add more
   }
 

--- a/packages/front-end/services/rule-conflicts.tsx
+++ b/packages/front-end/services/rule-conflicts.tsx
@@ -290,7 +290,6 @@ function simplify(e: Expr): Expr {
     }
     case "atom":
     case "opaque":
-      return e;
     default:
       return e;
   }

--- a/packages/front-end/services/rule-conflicts.tsx
+++ b/packages/front-end/services/rule-conflicts.tsx
@@ -288,6 +288,9 @@ function simplify(e: Expr): Expr {
       if (c.type === "or") return simplify(and(c.children.map(not)));
       return not(c);
     }
+    case "atom":
+    case "opaque":
+      return e;
     default:
       return e;
   }

--- a/packages/shared/src/enterprise/decision-criteria/statusIndicatorData.ts
+++ b/packages/shared/src/enterprise/decision-criteria/statusIndicatorData.ts
@@ -104,13 +104,6 @@ export function getStatusIndicatorData(
           sortOrder: 1,
         };
       case undefined:
-        return {
-          color: "amber",
-          status: "Stopped",
-          detailedStatus: "Awaiting decision",
-          needsAttention: true,
-          sortOrder: 5,
-        };
       default:
         return {
           color: "amber",

--- a/packages/shared/src/enterprise/decision-criteria/statusIndicatorData.ts
+++ b/packages/shared/src/enterprise/decision-criteria/statusIndicatorData.ts
@@ -103,6 +103,14 @@ export function getStatusIndicatorData(
           detailedStatus: "Didn't finish",
           sortOrder: 1,
         };
+      case undefined:
+        return {
+          color: "amber",
+          status: "Stopped",
+          detailedStatus: "Awaiting decision",
+          needsAttention: true,
+          sortOrder: 5,
+        };
       default:
         return {
           color: "amber",

--- a/packages/shared/src/revisions/helpers.ts
+++ b/packages/shared/src/revisions/helpers.ts
@@ -46,6 +46,9 @@ export const getApprovalFlowSettings = (
       return approvalFlows.savedGroups?.[0];
     // Constants don't use this config — they inherit the feature `requireReviews`
     // settings (see constantRequiresReview).
+    case "config":
+    case "constant":
+      return undefined;
     default:
       return undefined;
   }

--- a/packages/shared/src/revisions/helpers.ts
+++ b/packages/shared/src/revisions/helpers.ts
@@ -48,7 +48,6 @@ export const getApprovalFlowSettings = (
     // settings (see constantRequiresReview).
     case "config":
     case "constant":
-      return undefined;
     default:
       return undefined;
   }

--- a/packages/shared/src/util/config-schema/typescript.ts
+++ b/packages/shared/src/util/config-schema/typescript.ts
@@ -888,6 +888,8 @@ function jsonSchemaNodeToTsExpr(
       }
       return withNull(`{ ${propEntries.map(memberExpr).join("; ")} }`);
     }
+    case undefined:
+      return withNull("unknown");
   }
   return withNull("unknown");
 }

--- a/packages/shared/src/util/event-forwarder-datasource.ts
+++ b/packages/shared/src/util/event-forwarder-datasource.ts
@@ -63,6 +63,19 @@ export function getEventForwarderSinkTypeForDatasource(datasource: {
       return "bigquery";
     case "snowflake":
       return "snowflake";
+    case "growthbook_clickhouse":
+    case "redshift":
+    case "athena":
+    case "google_analytics":
+    case "postgres":
+    case "mysql":
+    case "mssql":
+    case "clickhouse":
+    case "presto":
+    case "databricks":
+    case "mixpanel":
+    case "vertica":
+      return null;
     default:
       return null;
   }
@@ -84,6 +97,19 @@ export function getEventForwarderDatasourceParams(
       return params as BigQueryConnectionParams;
     case "snowflake":
       return params as SnowflakeConnectionParams;
+    case "growthbook_clickhouse":
+    case "redshift":
+    case "athena":
+    case "google_analytics":
+    case "postgres":
+    case "mysql":
+    case "mssql":
+    case "clickhouse":
+    case "presto":
+    case "databricks":
+    case "mixpanel":
+    case "vertica":
+      return undefined;
     default:
       return undefined;
   }

--- a/packages/shared/src/util/event-forwarder-datasource.ts
+++ b/packages/shared/src/util/event-forwarder-datasource.ts
@@ -75,7 +75,6 @@ export function getEventForwarderSinkTypeForDatasource(datasource: {
     case "databricks":
     case "mixpanel":
     case "vertica":
-      return null;
     default:
       return null;
   }
@@ -109,7 +108,6 @@ export function getEventForwarderDatasourceParams(
     case "databricks":
     case "mixpanel":
     case "vertica":
-      return undefined;
     default:
       return undefined;
   }

--- a/packages/shared/src/util/event-forwarder-fact-table.ts
+++ b/packages/shared/src/util/event-forwarder-fact-table.ts
@@ -150,6 +150,11 @@ function sdkAttributeTypeToValueDatatype(
     case "number[]":
     case "secureString[]":
       return "json";
+    case undefined:
+    case "string":
+    case "enum":
+    case "secureString":
+      return "string";
     default:
       return "string";
   }
@@ -173,6 +178,8 @@ function buildBigQueryFlatMapAttributeValueSql(
       // JSON_QUERY on a native BigQuery JSON column returns JSON type (not STRING),
       // so the fact table column refresh job will correctly infer the type as "json".
       return `JSON_QUERY(${quotedAttributes}, ${jsonPath})`;
+    case "string":
+      return `JSON_VALUE(${quotedAttributes}, ${jsonPath})`;
     default:
       return `JSON_VALUE(${quotedAttributes}, ${jsonPath})`;
   }
@@ -194,6 +201,9 @@ function buildSnowflakeFlatMapAttributeValueSql(
       return `TRY_TO_BOOLEAN(${rawString})`;
     case "json":
       return `TRY_PARSE_JSON(${rawString})`;
+    case "string":
+      // Map values are strings in Avro; cast so Snowflake reports VARCHAR not VARIANT.
+      return rawString;
     default:
       // Map values are strings in Avro; cast so Snowflake reports VARCHAR not VARIANT.
       return rawString;

--- a/packages/shared/src/util/event-forwarder-fact-table.ts
+++ b/packages/shared/src/util/event-forwarder-fact-table.ts
@@ -154,7 +154,6 @@ function sdkAttributeTypeToValueDatatype(
     case "string":
     case "enum":
     case "secureString":
-      return "string";
     default:
       return "string";
   }
@@ -179,7 +178,6 @@ function buildBigQueryFlatMapAttributeValueSql(
       // so the fact table column refresh job will correctly infer the type as "json".
       return `JSON_QUERY(${quotedAttributes}, ${jsonPath})`;
     case "string":
-      return `JSON_VALUE(${quotedAttributes}, ${jsonPath})`;
     default:
       return `JSON_VALUE(${quotedAttributes}, ${jsonPath})`;
   }
@@ -202,8 +200,6 @@ function buildSnowflakeFlatMapAttributeValueSql(
     case "json":
       return `TRY_PARSE_JSON(${rawString})`;
     case "string":
-      // Map values are strings in Avro; cast so Snowflake reports VARCHAR not VARIANT.
-      return rawString;
     default:
       // Map values are strings in Avro; cast so Snowflake reports VARCHAR not VARIANT.
       return rawString;

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -3714,6 +3714,12 @@ export function inferSchemaField(
       }
       max = Math.max(max || 999, value);
       break;
+    case "bigint":
+    case "symbol":
+    case "undefined":
+    case "object":
+    case "function":
+      throw new Error(`Invalid value type: ${typeof value}`);
     default:
       throw new Error(`Invalid value type: ${typeof value}`);
   }

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -3719,7 +3719,6 @@ export function inferSchemaField(
     case "undefined":
     case "object":
     case "function":
-      throw new Error(`Invalid value type: ${typeof value}`);
     default:
       throw new Error(`Invalid value type: ${typeof value}`);
   }

--- a/packages/shared/src/util/managedWarehouse.ts
+++ b/packages/shared/src/util/managedWarehouse.ts
@@ -293,6 +293,11 @@ function attributeDatatypeToFactColumnType(
     case "number[]":
     case "secureString[]":
       return "other";
+    case "string":
+    case "enum":
+    case "secureString":
+      // string, secureString, enum, "" — all treated as string.
+      return "string";
     default:
       // string, secureString, enum, "" — all treated as string.
       return "string";

--- a/packages/shared/src/util/managedWarehouse.ts
+++ b/packages/shared/src/util/managedWarehouse.ts
@@ -296,8 +296,6 @@ function attributeDatatypeToFactColumnType(
     case "string":
     case "enum":
     case "secureString":
-      // string, secureString, enum, "" — all treated as string.
-      return "string";
     default:
       // string, secureString, enum, "" — all treated as string.
       return "string";


### PR DESCRIPTION
### Features and Changes

Follow-up to #6473, which turned on `@typescript-eslint/switch-exhaustiveness-check` and grandfathered the existing violations into `eslint-suppressions`. This is part 1 of removing those suppressions.

This part is the straight-forward ones, where behavior does not change. 

### Testing

- `pnpm lint:ci`
- `pnpm type-check`
