### PR TITLE
feat(fact-tables): preserve warehouse-reported column types

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -54555,6 +54555,22 @@ components:
           description: The actual column name in the database/SQL query
           type: string
         datatype:
+          description: >-
+            The column's data type (can be an override of the warehouse-reported
+            datatype, for JSON string columns for example).
+          type: string
+          enum:
+            - number
+            - string
+            - date
+            - boolean
+            - json
+            - binary
+            - other
+            - ''
+        dataTypeFromWarehouse:
+          readOnly: true
+          description: The warehouse-reported datatype.
           type: string
           enum:
             - number
@@ -54725,14 +54741,6 @@ components:
           type: array
           items:
             type: string
-        dateCreated:
-          readOnly: true
-          format: date-time
-          type: string
-        dateUpdated:
-          readOnly: true
-          format: date-time
-          type: string
       required:
         - column
       additionalProperties: false

--- a/packages/back-end/src/jobs/refreshFactTableColumns.ts
+++ b/packages/back-end/src/jobs/refreshFactTableColumns.ts
@@ -255,10 +255,12 @@ export async function runRefreshColumnsQuery(
 
   const typeMap = new Map<string, FactTableColumnType>();
   const jsonMap = new Map<string, JSONColumnFields>();
+  const warehouseTypeMap = new Map<string, FactTableColumnType>();
 
   result.columns?.forEach((col) => {
     // If the underlying SQL engine returned the datatype, use it
     if (col.dataType !== undefined) {
+      warehouseTypeMap.set(col.name, col.dataType);
       // For JSON, only return if we have the field information, otherwise skip
       // so we can infer from the returned data
       if (
@@ -311,6 +313,15 @@ export async function runRefreshColumnsQuery(
         col.dateUpdated = new Date();
       }
 
+      const warehouseType = warehouseTypeMap.get(col.column);
+      if (
+        warehouseType !== undefined &&
+        col.dataTypeFromWarehouse !== warehouseType
+      ) {
+        col.dataTypeFromWarehouse = warehouseType;
+        col.dateUpdated = new Date();
+      }
+
       // If we now know the datatype, update it
       if (col.datatype === "" && type !== "") {
         col.datatype = type;
@@ -342,6 +353,7 @@ export async function runRefreshColumnsQuery(
       columns.push({
         column,
         datatype,
+        dataTypeFromWarehouse: warehouseTypeMap.get(column),
         jsonFields: jsonMap.get(column),
         dateCreated: new Date(),
         dateUpdated: new Date(),

--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -64,6 +64,7 @@ const factTableSchema = new mongoose.Schema({
       column: String,
       numberFormat: String,
       datatype: String,
+      dataTypeFromWarehouse: String,
       jsonFields: {},
       deleted: Boolean,
       alwaysInlineFilter: Boolean,

--- a/packages/back-end/test/jobs/refreshFactTableColumns.test.ts
+++ b/packages/back-end/test/jobs/refreshFactTableColumns.test.ts
@@ -1,5 +1,22 @@
 import { ColumnInterface } from "shared/types/fact-table";
-import { selectColumnsForTopValues } from "back-end/src/jobs/refreshFactTableColumns";
+import { DataSourceInterface } from "shared/types/datasource";
+import { TestQueryResult } from "shared/types/integrations";
+import {
+  runRefreshColumnsQuery,
+  selectColumnsForTopValues,
+} from "back-end/src/jobs/refreshFactTableColumns";
+import { getSourceIntegrationObject } from "back-end/src/services/datasource";
+import { SourceIntegrationInterface } from "back-end/src/types/Integration";
+import { ReqContext } from "back-end/types/request";
+
+jest.mock("back-end/src/services/datasource", () => ({
+  getSourceIntegrationObject: jest.fn(),
+}));
+
+const getSourceIntegrationObjectMock =
+  getSourceIntegrationObject as jest.MockedFunction<
+    typeof getSourceIntegrationObject
+  >;
 
 function makeCol(
   column: string,
@@ -16,6 +33,36 @@ function makeCol(
     dateUpdated: new Date(),
     ...overrides,
   };
+}
+
+async function refreshColumns({
+  column,
+  result,
+}: {
+  column: ColumnInterface;
+  result: TestQueryResult;
+}): Promise<ColumnInterface[]> {
+  // @ts-expect-error - this test only needs the query methods
+  const integration: SourceIntegrationInterface = {
+    getTestQuery: jest.fn().mockReturnValue("SELECT * FROM fact_table"),
+    runTestQuery: jest.fn().mockResolvedValue(result),
+  };
+  getSourceIntegrationObjectMock.mockReturnValue(integration);
+
+  // @ts-expect-error - this test only needs permissions and organization settings
+  const context: ReqContext = {
+    permissions: { canRunFactQueries: () => true },
+    org: {},
+  };
+  // @ts-expect-error - this test does not read datasource fields
+  const datasource: DataSourceInterface = {};
+
+  return runRefreshColumnsQuery(context, datasource, {
+    sql: "SELECT * FROM fact_table",
+    eventName: "",
+    columns: [column],
+    userIdTypes: [],
+  });
 }
 
 describe("selectColumnsForTopValues", () => {
@@ -147,5 +194,43 @@ describe("selectColumnsForTopValues", () => {
       userIdTypes: ["user_id"],
     });
     expect(result.map((c) => c.column)).toEqual(["country"]);
+  });
+});
+
+describe("runRefreshColumnsQuery", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("keeps the last warehouse datatype when the query response has no metadata", async () => {
+    const columns = await refreshColumns({
+      column: makeCol("payload", {
+        datatype: "json",
+        dataTypeFromWarehouse: "string",
+      }),
+      result: {
+        results: [{ payload: '{"id": 1}' }],
+        duration: 1,
+      },
+    });
+
+    expect(columns[0].dataTypeFromWarehouse).toBe("string");
+  });
+
+  it("marks a missing column deleted without clearing its warehouse datatype", async () => {
+    const columns = await refreshColumns({
+      column: makeCol("payload", {
+        dataTypeFromWarehouse: "string",
+      }),
+      result: {
+        results: [],
+        duration: 1,
+      },
+    });
+
+    expect(columns[0]).toMatchObject({
+      deleted: true,
+      dataTypeFromWarehouse: "string",
+    });
   });
 });

--- a/packages/shared/src/validators/fact-table.ts
+++ b/packages/shared/src/validators/fact-table.ts
@@ -350,16 +350,13 @@ export const apiFactTableColumnValidator = namedSchema(
       column: z
         .string()
         .describe("The actual column name in the database/SQL query"),
-      datatype: z.enum([
-        "number",
-        "string",
-        "date",
-        "boolean",
-        "json",
-        "binary",
-        "other",
-        "",
-      ]),
+      datatype: factTableColumnTypeValidator.describe(
+        "The column's data type (can be an override of the warehouse-reported datatype, for JSON string columns for example).",
+      ),
+      dataTypeFromWarehouse: factTableColumnTypeValidator
+        .describe("The warehouse-reported datatype.")
+        .readonly()
+        .optional(),
       numberFormat: z
         .enum([
           "",
@@ -438,6 +435,11 @@ export const apiFactTableColumnValidator = namedSchema(
 export const apiFactTableColumnInputValidator = componentSchema(
   "FactTableColumnInput",
   apiFactTableColumnValidator
+    .omit({
+      dataTypeFromWarehouse: true,
+      dateCreated: true,
+      dateUpdated: true,
+    })
     .extend({
       datatype: apiFactTableColumnValidator.shape.datatype
         .describe(

--- a/packages/shared/test/validators/fact-table.test.ts
+++ b/packages/shared/test/validators/fact-table.test.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import {
+  apiFactTableColumnValidator,
+  updateFactTableValidator,
+} from "../../src/validators/fact-table";
+
+function isResponseOnly(schema: z.ZodType): boolean {
+  if (schema instanceof z.ZodOptional) {
+    return isResponseOnly(schema.unwrap());
+  }
+  return schema instanceof z.ZodReadonly;
+}
+
+describe("updateFactTableValidator", () => {
+  it("excludes every response-only column field", () => {
+    const updateColumnShape =
+      updateFactTableValidator.bodySchema.shape.columns.unwrap().element.shape;
+    const responseOnlyFields = Object.entries(apiFactTableColumnValidator.shape)
+      .filter(([, schema]) => isResponseOnly(schema))
+      .map(([field]) => field);
+
+    expect(responseOnlyFields.length).toBeGreaterThan(0);
+    for (const field of responseOnlyFields) {
+      expect(updateColumnShape).not.toHaveProperty(field);
+    }
+  });
+
+  it.each([
+    ["dataTypeFromWarehouse", "string"],
+    ["dateCreated", "2026-01-01T00:00:00.000Z"],
+    ["dateUpdated", "2026-01-01T00:00:00.000Z"],
+  ])("rejects the response-only column field %s", (field, value) => {
+    const result = updateFactTableValidator.bodySchema.safeParse({
+      columns: [
+        {
+          column: "payload",
+          datatype: "json",
+          [field]: value,
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/shared/types/fact-table.d.ts
+++ b/packages/shared/types/fact-table.d.ts
@@ -39,6 +39,7 @@ export interface ColumnInterface {
   description: string;
   column: string;
   datatype: FactTableColumnType;
+  dataTypeFromWarehouse?: FactTableColumnType;
   numberFormat: NumberFormat;
   alwaysInlineFilter?: boolean;
   topValues?: string[];


### PR DESCRIPTION
### Features and Changes

- We now have `dataTypeFromWarehouse` for fact table columns
- Users (and our json string handling) are still allowed to override `dataType`

### Testing

- Unit tests