### PR TITLE
Demote the OAuth consent remote-redirect notice to info level

### DIFF
--- a/packages/front-end/pages/oauth/authorize.tsx
+++ b/packages/front-end/pages/oauth/authorize.tsx
@@ -10,6 +10,7 @@ import Button from "@/ui/Button";
 import Callout from "@/ui/Callout";
 import Frame from "@/ui/Frame";
 import Heading from "@/ui/Heading";
+import HelperText from "@/ui/HelperText";
 import Link from "@/ui/Link";
 import { Select, SelectItem } from "@/ui/Select";
 import Text from "@/ui/Text";
@@ -22,6 +23,34 @@ type AuthorizeInfoResponse = {
   organizations?: { id: string; name: string }[];
   user?: { id: string; email: string; name: string };
 };
+
+// Loopback hosts are the OS itself, so a code delivered here never leaves the
+// user's machine.
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
+
+// Where the authorization code will be delivered. This is the one signal on
+// this page the app cannot fake: the code always goes to a redirect_uri
+// pre-registered by the client.
+//
+// `isLocal` decides whether it is worth mentioning at all. Loopback and
+// custom-scheme targets hand the code to something already running on this
+// machine, so a bare "localhost:8787" is noise. Only a remote host is
+// surfaced, and only as an informational note.
+function describeRedirectTarget(
+  redirectUri?: string,
+): { host: string; isLocal: boolean } | null {
+  if (!redirectUri) return null;
+  try {
+    const url = new URL(redirectUri);
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      return { host: url.host, isLocal: LOOPBACK_HOSTS.has(url.hostname) };
+    }
+    // Custom schemes (cursor://, etc.) hand off to a locally installed app.
+    return { host: url.protocol.replace(":", "") + "://", isLocal: true };
+  } catch {
+    return null;
+  }
+}
 
 // Shared narrow-page wrapper so the consent and success screens can't drift.
 function ConsentPageWrapper({ children }: { children: ReactNode }) {
@@ -223,6 +252,7 @@ export default function OAuthAuthorizePage() {
   }
 
   const claimedName = info?.client?.clientName;
+  const redirectTarget = describeRedirectTarget(info?.redirectUri);
   const showDetails = !!info?.client && !error;
 
   return (
@@ -241,6 +271,11 @@ export default function OAuthAuthorizePage() {
             Name provided by the application. GrowthBook does not verify
             application identity.
           </Text>
+          {redirectTarget && !redirectTarget.isLocal ? (
+            <HelperText status="info" size="sm" mt="2">
+              Your authorization code will be sent to {redirectTarget.host}
+            </HelperText>
+          ) : null}
         </Flex>
       ) : (
         <Heading as="h1" size="x-large" mb="4">

--- a/packages/front-end/pages/oauth/authorize.tsx
+++ b/packages/front-end/pages/oauth/authorize.tsx
@@ -23,35 +23,6 @@ type AuthorizeInfoResponse = {
   user?: { id: string; email: string; name: string };
 };
 
-// Loopback hosts are the OS itself, so a code delivered here never leaves the
-// user's machine.
-const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
-
-// Where the authorization code will be delivered. This is the one signal on
-// this page the app cannot fake: the code always goes to a redirect_uri
-// pre-registered by the client.
-//
-// `isLocal` decides whether it is worth the user's attention. Loopback and
-// custom-scheme targets hand the code to something already running on this
-// machine, so a remote attacker never receives it and showing a bare
-// "localhost:8787" is noise. A remote host is the case that matters, and is
-// the only one surfaced.
-function describeRedirectTarget(
-  redirectUri?: string,
-): { host: string; isLocal: boolean } | null {
-  if (!redirectUri) return null;
-  try {
-    const url = new URL(redirectUri);
-    if (url.protocol === "http:" || url.protocol === "https:") {
-      return { host: url.host, isLocal: LOOPBACK_HOSTS.has(url.hostname) };
-    }
-    // Custom schemes (cursor://, etc.) hand off to a locally installed app.
-    return { host: url.protocol.replace(":", "") + "://", isLocal: true };
-  } catch {
-    return null;
-  }
-}
-
 // Shared narrow-page wrapper so the consent and success screens can't drift.
 function ConsentPageWrapper({ children }: { children: ReactNode }) {
   return (
@@ -252,7 +223,6 @@ export default function OAuthAuthorizePage() {
   }
 
   const claimedName = info?.client?.clientName;
-  const redirectTarget = describeRedirectTarget(info?.redirectUri);
   const showDetails = !!info?.client && !error;
 
   return (
@@ -281,16 +251,6 @@ export default function OAuthAuthorizePage() {
       {error ? (
         <Callout status="error" mb="4">
           {error}
-        </Callout>
-      ) : null}
-
-      {redirectTarget && !redirectTarget.isLocal ? (
-        <Callout status="warning" mb="4">
-          Your authorization code will be sent to{" "}
-          <Text as="span" size="inherit" weight="semibold">
-            {redirectTarget.host}
-          </Text>
-          . Continue only if you recognize that destination.
         </Callout>
       ) : null}
 


### PR DESCRIPTION
Follow-up to #6497. The remote-redirect destination was rendered as a warning `Callout`; this demotes it to an info-level `HelperText` sitting under the app identity, alongside the "name is self-reported" disclosure.

Same trigger as before — remote hosts only, loopback and custom schemes stay hidden. Lower severity, no background panel, and it drops the "Continue only if you recognize that destination" imperative, which was warning-tier language for what is really just a statement of fact.

## Screenshot
NOTE: Screenshot shows localhost url (for testing) but this would only appear if host is remote
<img width="782" height="768" alt="image" src="https://github.com/user-attachments/assets/a48161ee-3070-44c4-b0df-d555222e0a83" />