### PR TITLE
feat(event-forwarder): Include Properties in Event Forwarder Feature Usage Query

### DIFF
--- a/packages/back-end/src/services/eventForwarder/bigquery.ts
+++ b/packages/back-end/src/services/eventForwarder/bigquery.ts
@@ -53,6 +53,7 @@ const EXPERIMENT_VIEWED_SCHEMA: bq.TableField[] = [
 const FEATURE_USAGE_SCHEMA: bq.TableField[] = [
   ...BASE_FIELDS,
   { name: "feature_key", type: "STRING", mode: "NULLABLE" },
+  { name: "properties", type: "JSON", mode: "NULLABLE" },
   { name: "attributes", type: "JSON", mode: "NULLABLE" },
 ];
 

--- a/packages/shared/src/util/event-forwarder-fact-table.ts
+++ b/packages/shared/src/util/event-forwarder-fact-table.ts
@@ -130,6 +130,19 @@ export function quoteBigQueryIdentifier(identifier: string): string {
   return `\`${identifier}\``;
 }
 
+/**
+ * Escapes a JSON key for embedding inside a BigQuery JSONPath quoted member that
+ * is itself wrapped in a single-quoted SQL string literal: `'$."<key>"'`.
+ *
+ * Two nested contexts must be escaped, in order:
+ *  1. JSONPath quoted member (`$."<key>"`): escape `\` then `"`.
+ *  2. Single-quoted SQL string literal: escape `\` then `'`.
+ */
+function escapeBigQueryJsonPathKey(key: string): string {
+  const jsonPathEscaped = key.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return jsonPathEscaped.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
 function quoteSnowflakeVariantFieldName(fieldName: string): string {
   return `"${fieldName.replace(/"/g, '""')}"`;
 }
@@ -165,7 +178,7 @@ function buildBigQueryFlatMapAttributeValueSql(
   const quotedAttributes = quoteBigQueryIdentifier(
     EVENT_FORWARDER_AVRO_ATTRIBUTES_FIELD,
   );
-  const jsonPath = `'$."${fieldName}"'`;
+  const jsonPath = `'$."${escapeBigQueryJsonPathKey(fieldName)}"'`;
 
   switch (valueDatatype) {
     case "number":
@@ -296,7 +309,9 @@ export function buildEventForwarderPropertyValueSql({
     const propertiesCol = quoteBigQueryIdentifier(
       EVENT_FORWARDER_AVRO_PROPERTIES_FIELD,
     );
-    return `JSON_VALUE(${propertiesCol}, '$."${propertyKey}"')`;
+    return `JSON_VALUE(${propertiesCol}, '$."${escapeBigQueryJsonPathKey(
+      propertyKey,
+    )}"')`;
   }
 
   const propertiesCol = EVENT_FORWARDER_AVRO_PROPERTIES_FIELD.toUpperCase();

--- a/packages/shared/src/util/event-forwarder-fact-table.ts
+++ b/packages/shared/src/util/event-forwarder-fact-table.ts
@@ -19,6 +19,9 @@ export const EVENT_FORWARDER_AVRO_PARTITION_FIELD = "received_at" as const;
 /** Map field holding org targeting attributes in the forwarder Avro schema. */
 export const EVENT_FORWARDER_AVRO_ATTRIBUTES_FIELD = "attributes" as const;
 
+/** Map field holding event properties in the forwarder Avro schema. */
+export const EVENT_FORWARDER_AVRO_PROPERTIES_FIELD = "properties" as const;
+
 /**
  * Sanitizes a string for use as an Avro/BigQuery/Snowflake field name.
  *
@@ -274,6 +277,30 @@ export function buildEventForwarderNestedAttributeValueSql({
       }),
     ),
   );
+}
+
+/**
+ * Extracts a single key out of the forwarder `properties` map as a string.
+ * BigQuery stores `properties` as a native JSON column; Snowflake as a
+ * schematized VARIANT object. Property keys are the raw SDK names (e.g.
+ * "ruleId", "variationId").
+ */
+export function buildEventForwarderPropertyValueSql({
+  sinkType,
+  propertyKey,
+}: {
+  sinkType: "bigquery" | "snowflake";
+  propertyKey: string;
+}): string {
+  if (sinkType === "bigquery") {
+    const propertiesCol = quoteBigQueryIdentifier(
+      EVENT_FORWARDER_AVRO_PROPERTIES_FIELD,
+    );
+    return `JSON_VALUE(${propertiesCol}, '$."${propertyKey}"')`;
+  }
+
+  const propertiesCol = EVENT_FORWARDER_AVRO_PROPERTIES_FIELD.toUpperCase();
+  return `${propertiesCol}:${quoteSnowflakeVariantFieldName(propertyKey)}::STRING`;
 }
 
 function getEventForwarderEventsFactTableAttributes(

--- a/packages/shared/src/util/event-forwarder-warehouse-queries.ts
+++ b/packages/shared/src/util/event-forwarder-warehouse-queries.ts
@@ -13,6 +13,7 @@ import {
 import {
   buildBigQueryEventForwarderTableReference,
   buildEventForwarderNestedAttributeValueSql,
+  buildEventForwarderPropertyValueSql,
   buildSnowflakeEventForwarderTableReference,
   EVENT_FORWARDER_AVRO_PARTITION_FIELD,
   quoteBigQueryIdentifier,
@@ -330,14 +331,24 @@ export function buildEventForwarderFeatureUsageQuerySql({
   if (sinkType === "bigquery") {
     return `SELECT
   timestamp AS timestamp,
-  feature_key AS feature_key
+  feature_key AS feature_key,
+  environment AS environment,
+  ${buildEventForwarderPropertyValueSql({ sinkType, propertyKey: "value" })} AS value,
+  ${buildEventForwarderPropertyValueSql({ sinkType, propertyKey: "source" })} AS source,
+  ${buildEventForwarderPropertyValueSql({ sinkType, propertyKey: "ruleId" })} AS rule_id,
+  ${buildEventForwarderPropertyValueSql({ sinkType, propertyKey: "variationId" })} AS variation_id
 FROM ${tableRef}
 WHERE ${EVENT_FORWARDER_AVRO_PARTITION_FIELD} BETWEEN '{{startDate}}' AND '{{endDate}}'`;
   }
 
   return `SELECT
   TIMESTAMP AS timestamp,
-  FEATURE_KEY AS feature_key
+  FEATURE_KEY AS feature_key,
+  ENVIRONMENT AS environment,
+  ${buildEventForwarderPropertyValueSql({ sinkType, propertyKey: "value" })} AS value,
+  ${buildEventForwarderPropertyValueSql({ sinkType, propertyKey: "source" })} AS source,
+  ${buildEventForwarderPropertyValueSql({ sinkType, propertyKey: "ruleId" })} AS rule_id,
+  ${buildEventForwarderPropertyValueSql({ sinkType, propertyKey: "variationId" })} AS variation_id
 FROM ${tableRef}`;
 }
 

--- a/packages/shared/test/util/event-forwarder-warehouse-queries.test.ts
+++ b/packages/shared/test/util/event-forwarder-warehouse-queries.test.ts
@@ -18,7 +18,10 @@ import {
   reconcileEventForwarderManagedExposureQueries,
   refreshEventForwarderManagedExposureQuery,
 } from "../../src/util/event-forwarder-warehouse-queries";
-import { EVENT_FORWARDER_AVRO_PARTITION_FIELD } from "../../src/util/event-forwarder-fact-table";
+import {
+  buildEventForwarderPropertyValueSql,
+  EVENT_FORWARDER_AVRO_PARTITION_FIELD,
+} from "../../src/util/event-forwarder-fact-table";
 
 describe("event-forwarder-warehouse-queries experiment_viewed table reference", () => {
   it("builds BigQuery experiment_viewed table reference", () => {
@@ -431,7 +434,7 @@ describe("event-forwarder-warehouse-queries feature_usage table reference", () =
 describe("buildEventForwarderFeatureUsageQuerySql", () => {
   const tableRef = "`proj`.`ds`.`feature_usage`";
 
-  it("includes received_at partition filter for BigQuery only", () => {
+  it("includes received_at partition filter and property columns for BigQuery", () => {
     const sql = buildEventForwarderFeatureUsageQuerySql({
       sinkType: "bigquery",
       tableRef,
@@ -439,6 +442,15 @@ describe("buildEventForwarderFeatureUsageQuerySql", () => {
 
     expect(sql).toContain("timestamp AS timestamp");
     expect(sql).toContain("feature_key AS feature_key");
+    expect(sql).toContain("environment AS environment");
+    expect(sql).toContain("JSON_VALUE(`properties`, '$.\"value\"') AS value");
+    expect(sql).toContain("JSON_VALUE(`properties`, '$.\"source\"') AS source");
+    expect(sql).toContain(
+      "JSON_VALUE(`properties`, '$.\"ruleId\"') AS rule_id",
+    );
+    expect(sql).toContain(
+      "JSON_VALUE(`properties`, '$.\"variationId\"') AS variation_id",
+    );
     expect(sql).toContain(`FROM ${tableRef}`);
     expect(sql).toContain(
       `WHERE ${EVENT_FORWARDER_AVRO_PARTITION_FIELD} BETWEEN '{{startDate}}' AND '{{endDate}}'`,
@@ -453,8 +465,33 @@ describe("buildEventForwarderFeatureUsageQuerySql", () => {
 
     expect(sql).toContain("TIMESTAMP AS timestamp");
     expect(sql).toContain("FEATURE_KEY AS feature_key");
+    expect(sql).toContain("ENVIRONMENT AS environment");
+    expect(sql).toContain('PROPERTIES:"value"::STRING AS value');
+    expect(sql).toContain('PROPERTIES:"source"::STRING AS source');
+    expect(sql).toContain('PROPERTIES:"ruleId"::STRING AS rule_id');
+    expect(sql).toContain('PROPERTIES:"variationId"::STRING AS variation_id');
     expect(sql).toContain("FROM MY_DB.PUBLIC.FEATURE_USAGE");
     expect(sql).not.toContain("WHERE");
+  });
+});
+
+describe("buildEventForwarderPropertyValueSql", () => {
+  it("extracts a property from the BigQuery JSON column", () => {
+    expect(
+      buildEventForwarderPropertyValueSql({
+        sinkType: "bigquery",
+        propertyKey: "ruleId",
+      }),
+    ).toBe("JSON_VALUE(`properties`, '$.\"ruleId\"')");
+  });
+
+  it("extracts a property from the Snowflake VARIANT column", () => {
+    expect(
+      buildEventForwarderPropertyValueSql({
+        sinkType: "snowflake",
+        propertyKey: "variationId",
+      }),
+    ).toBe('PROPERTIES:"variationId"::STRING');
   });
 });
 

--- a/packages/shared/test/util/event-forwarder-warehouse-queries.test.ts
+++ b/packages/shared/test/util/event-forwarder-warehouse-queries.test.ts
@@ -493,6 +493,33 @@ describe("buildEventForwarderPropertyValueSql", () => {
       }),
     ).toBe('PROPERTIES:"variationId"::STRING');
   });
+
+  it("escapes double quotes in BigQuery property keys", () => {
+    expect(
+      buildEventForwarderPropertyValueSql({
+        sinkType: "bigquery",
+        propertyKey: 'a"b',
+      }),
+    ).toBe('JSON_VALUE(`properties`, \'$."a\\\\"b"\')');
+  });
+
+  it("escapes backslashes in BigQuery property keys", () => {
+    expect(
+      buildEventForwarderPropertyValueSql({
+        sinkType: "bigquery",
+        propertyKey: "a\\b",
+      }),
+    ).toBe("JSON_VALUE(`properties`, '$.\"a\\\\\\\\b\"')");
+  });
+
+  it("escapes single quotes in BigQuery property keys", () => {
+    expect(
+      buildEventForwarderPropertyValueSql({
+        sinkType: "bigquery",
+        propertyKey: "a'b",
+      }),
+    ).toBe("JSON_VALUE(`properties`, '$.\"a\\'b\"')");
+  });
 });
 
 describe("buildEventForwarderFeatureUsageQuery", () => {


### PR DESCRIPTION
### Features and Changes

Surfaces Feature Evaluated event metadata in the **Feature Diagnostics** tab for event forwarder users. The managed feature usage query now selects `environment` (a top-level column) plus `value`, `source`, `rule_id`, and `variation_id` (extracted from the Avro `properties` map). These columns flow through automatically to the diagnostics table, so no front-end changes were needed.

### Dependencies

N/A

### Testing

- [x] Unit tests for the new columns and `buildEventForwarderPropertyValueSql` 
- [x] Manually run the generated query against a real Snowflake `*_feature_usage` table and confirm `value`/`source`/`rule_id`/`variation_id`/`environment` populate
- [x] Verify the columns render in the Feature Diagnostics tab

### Screenshots

N/A
