### PR TITLE
Fix Dashboard Editor dropdown group label bold styling

### DIFF
--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/index.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/index.tsx
@@ -347,8 +347,10 @@ function AddBlockDropdown({
 
         return (
           <Fragment key={`${subgroup}-${i}`}>
-            <DropdownMenuLabel className="font-weight-bold">
-              <Text color="text-high">{subgroup}</Text>
+            <DropdownMenuLabel>
+              <Text color="text-high" weight="semibold">
+                {subgroup}
+              </Text>
             </DropdownMenuLabel>
             {allowedBlockTypes.map((bType) => {
               if (BLOCK_TYPE_INFO[bType].deprecated) {


### PR DESCRIPTION
### Features and Changes

The group labels in the Dashboard Editor's "Add Block" dropdown (e.g. "Product Analytics", "Experimentation", "Other") were meant to render bold, but weren't. The `font-weight-bold` className was applied to the outer `DropdownMenuLabel` wrapper, while the actual text renders inside a nested `Text` component that defaults to `weight="regular"` — that explicit weight on the text node overrode the inherited bold from the ancestor. Fixed by passing `weight="semibold"` directly to the `Text` component instead, matching the pattern already used elsewhere in the file.

### Dependencies

None

### Testing

1. Open a dashboard in the Dashboard Editor.
2. Click "Add Block" to open the block-type dropdown.
3. Confirm the group labels ("Product Analytics", "Experimentation", "Other") render in bold, distinct from the regular-weight item labels below them.

### Screenshots
<img width="187" height="469" alt="Screenshot 2026-07-29 at 1 34 00 PM" src="https://github.com/user-attachments/assets/4fad4eb2-bfce-48f4-a89f-0cc81fabfa80" />
