### PR TITLE
fix(holdouts): derive experiment linkage from published rules

### DIFF
--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
@@ -208,7 +208,6 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
       // Use target revision holdout to check compatibility.
       // Linking writes are deferred until after custom-hook prevalidation below.
       const effectiveHoldout = getEffectiveRevisionHoldout(revision, feature);
-      // Validation only: linkage itself is derived from published rules at publish.
       await resolveHoldoutExperimentToLink({
         context: req.context,
         feature,

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAdd.ts
@@ -15,7 +15,6 @@ import type {
 } from "shared/validators";
 import { getEffectiveRevisionHoldout, resetReviewOnChange } from "shared/util";
 import { RevisionChanges } from "shared/types/feature-revision";
-import { ExperimentInterface } from "shared/types/experiment";
 import { CreateProps } from "shared/types/base-model";
 import { getLatestPhaseVariations } from "shared/experiments";
 import {
@@ -26,14 +25,8 @@ import {
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { getFeature } from "back-end/src/models/FeatureModel";
-import {
-  linkExperimentToHoldout,
-  resolveHoldoutExperimentToLink,
-} from "back-end/src/services/holdouts";
-import {
-  getExperimentById,
-  updateExperiment,
-} from "back-end/src/models/ExperimentModel";
+import { resolveHoldoutExperimentToLink } from "back-end/src/services/holdouts";
+import { getExperimentById } from "back-end/src/models/ExperimentModel";
 import {
   getRevision,
   prevalidateRevisionUpdate,
@@ -170,9 +163,6 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
   // Track side effects so we can compensate on downstream failure (discard
   // draft, delete orphan SafeRollout, revert experiment/holdout auto-link).
   let createdSafeRolloutId: string | undefined;
-  let linkedExperimentId: string | undefined;
-  let linkedHoldoutId: string | undefined;
-  let holdoutExperimentToLink: ExperimentInterface | null = null;
   try {
     if (!isDraftStatus(revision.status)) {
       throw new BadRequestError(
@@ -218,7 +208,8 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
       // Use target revision holdout to check compatibility.
       // Linking writes are deferred until after custom-hook prevalidation below.
       const effectiveHoldout = getEffectiveRevisionHoldout(revision, feature);
-      holdoutExperimentToLink = await resolveHoldoutExperimentToLink({
+      // Validation only: linkage itself is derived from published rules at publish.
+      await resolveHoldoutExperimentToLink({
         context: req.context,
         feature,
         experiment,
@@ -347,24 +338,6 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
     }
 
     // Link now only when the validated holdout is already live on the feature. A draft-only
-    // holdout defers to publish — applyHoldoutSideEffects enrolls the
-    // experiments in the merged rules when the holdout change lands.
-    const linkHoldoutId = getEffectiveRevisionHoldout(revision, feature)?.id;
-    if (
-      holdoutExperimentToLink &&
-      linkHoldoutId &&
-      feature.holdout?.id === linkHoldoutId
-    ) {
-      // Record ids for compensation BEFORE the writes — the rollback is
-      // idempotent, so a mid-write failure is still fully compensated.
-      linkedExperimentId = holdoutExperimentToLink.id;
-      linkedHoldoutId = linkHoldoutId;
-      await linkExperimentToHoldout(
-        req.context,
-        holdoutExperimentToLink,
-        linkHoldoutId,
-      );
-    }
 
     await updateRevision(
       req.context,
@@ -405,30 +378,6 @@ export const postFeatureRevisionRuleAdd = createApiRequestHandler(
     if (createdSafeRolloutId) {
       try {
         await req.context.models.safeRollout.deleteById(createdSafeRolloutId);
-      } catch {
-        // best effort
-      }
-    }
-    if (linkedExperimentId) {
-      try {
-        const exp = await getExperimentById(req.context, linkedExperimentId);
-        if (exp) {
-          await updateExperiment({
-            context: req.context,
-            experiment: exp,
-            changes: { holdoutId: "" },
-          });
-        }
-      } catch {
-        // best effort
-      }
-    }
-    if (linkedHoldoutId && linkedExperimentId) {
-      try {
-        await req.context.models.holdout.removeExperimentFromHoldout(
-          linkedHoldoutId,
-          linkedExperimentId,
-        );
       } catch {
         // best effort
       }

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
@@ -10,7 +10,6 @@ import {
 import type { FeatureRule, SafeRolloutRule } from "shared/validators";
 import { getEffectiveRevisionHoldout, resetReviewOnChange } from "shared/util";
 import { RevisionChanges } from "shared/types/feature-revision";
-import { ExperimentInterface } from "shared/types/experiment";
 import { CreateProps } from "shared/types/base-model";
 import { getLatestPhaseVariations } from "shared/experiments";
 import {
@@ -22,14 +21,8 @@ import { assertConfigBackedFeatureValuesValid } from "back-end/src/services/conf
 import { recordRevisionUpdate } from "back-end/src/services/featureRevisionEvents";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { getFeature } from "back-end/src/models/FeatureModel";
-import {
-  linkExperimentToHoldout,
-  resolveHoldoutExperimentToLink,
-} from "back-end/src/services/holdouts";
-import {
-  getExperimentById,
-  updateExperiment,
-} from "back-end/src/models/ExperimentModel";
+import { resolveHoldoutExperimentToLink } from "back-end/src/services/holdouts";
+import { getExperimentById } from "back-end/src/models/ExperimentModel";
 import {
   getRevision,
   prevalidateRevisionUpdate,
@@ -105,9 +98,6 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
   );
 
   let createdSafeRolloutId: string | undefined;
-  let linkedExperimentId: string | undefined;
-  let linkedHoldoutId: string | undefined;
-  let holdoutExperimentToLink: ExperimentInterface | null = null;
   try {
     if (!isDraftStatus(revision.status)) {
       throw new BadRequestError(
@@ -159,7 +149,8 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
       // Legacy revisions store holdout sparsely, so absence carries the
       // feature's holdout forward. Linking writes are deferred until after
       // custom-hook prevalidation below.
-      holdoutExperimentToLink = await resolveHoldoutExperimentToLink({
+      // Validation only: linkage itself is derived from published rules at publish.
+      await resolveHoldoutExperimentToLink({
         context: req.context,
         feature,
         experiment,
@@ -358,26 +349,6 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
       createdSafeRolloutId = safeRollout.id;
     }
 
-    // Link now only when the validated holdout is already live. A draft-only
-    // holdout defers to publish — applyHoldoutSideEffects enrolls the
-    // experiments in the merged rules when the holdout change lands.
-    const linkHoldoutId = getEffectiveRevisionHoldout(revision, feature)?.id;
-    if (
-      holdoutExperimentToLink &&
-      linkHoldoutId &&
-      feature.holdout?.id === linkHoldoutId
-    ) {
-      // Record ids for compensation BEFORE the writes — the rollback is
-      // idempotent, so a mid-write failure is still fully compensated.
-      linkedExperimentId = holdoutExperimentToLink.id;
-      linkedHoldoutId = linkHoldoutId;
-      await linkExperimentToHoldout(
-        req.context,
-        holdoutExperimentToLink,
-        linkHoldoutId,
-      );
-    }
-
     await updateRevision(
       req.context,
       feature,
@@ -419,29 +390,6 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
     if (createdSafeRolloutId) {
       try {
         await req.context.models.safeRollout.deleteById(createdSafeRolloutId);
-      } catch {
-        /* best effort */
-      }
-    }
-    if (linkedExperimentId) {
-      try {
-        const exp = await getExperimentById(req.context, linkedExperimentId);
-        if (exp)
-          await updateExperiment({
-            context: req.context,
-            experiment: exp,
-            changes: { holdoutId: "" },
-          });
-      } catch {
-        /* best effort */
-      }
-    }
-    if (linkedHoldoutId && linkedExperimentId) {
-      try {
-        await req.context.models.holdout.removeExperimentFromHoldout(
-          linkedHoldoutId,
-          linkedExperimentId,
-        );
       } catch {
         /* best effort */
       }

--- a/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
+++ b/packages/back-end/src/api/features/postFeatureRevisionRuleAddV2.ts
@@ -149,7 +149,6 @@ export const postFeatureRevisionRuleAddV2 = createApiRequestHandler(
       // Legacy revisions store holdout sparsely, so absence carries the
       // feature's holdout forward. Linking writes are deferred until after
       // custom-hook prevalidation below.
-      // Validation only: linkage itself is derived from published rules at publish.
       await resolveHoldoutExperimentToLink({
         context: req.context,
         feature,

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -2986,7 +2986,6 @@ export async function postFeatureRule(
       throw new Error(`Could not find experiment "${rule.experimentId}"`);
     }
     if (experiment) {
-      // Validation only: linkage is derived from published rules at publish.
       await resolveHoldoutExperimentToLink({
         context,
         feature,
@@ -3497,7 +3496,6 @@ export async function postFeatureExperimentRefRule(
   // to check compatibility
   const effectiveHoldout = getEffectiveRevisionHoldout(revision, feature);
 
-  // Validation only: linkage is derived from published rules at publish.
   await resolveHoldoutExperimentToLink({
     context,
     feature,

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -129,10 +129,7 @@ import {
   assertCanAutoPublish,
   revisionRequiresReview,
 } from "back-end/src/services/features";
-import {
-  linkExperimentToHoldout,
-  resolveHoldoutExperimentToLink,
-} from "back-end/src/services/holdouts";
+import { resolveHoldoutExperimentToLink } from "back-end/src/services/holdouts";
 import { assertFeatureArchiveDependentsGuard } from "back-end/src/services/archiveDependentsGuard";
 import { getResolvableValues } from "back-end/src/services/resolvableValues";
 import { assertConfigBackedFeatureValuesValid } from "back-end/src/services/configValidation";
@@ -2981,7 +2978,6 @@ export async function postFeatureRule(
   // Add holdout to existing experiment and experiment to holdout linkedExperiments
   // if the experiment is not running and has no linked implementations for
   // experiment-ref rules (writes deferred until after custom-hook prevalidation)
-  let holdoutExperimentToLink: ExperimentInterface | null = null;
   if (rule.type === "experiment-ref") {
     const experiment = await getExperimentById(context, rule.experimentId);
     // With a holdout in play the experiment must exist; without one, a missing
@@ -2990,7 +2986,8 @@ export async function postFeatureRule(
       throw new Error(`Could not find experiment "${rule.experimentId}"`);
     }
     if (experiment) {
-      holdoutExperimentToLink = await resolveHoldoutExperimentToLink({
+      // Validation only: linkage is derived from published rules at publish.
+      await resolveHoldoutExperimentToLink({
         context,
         feature,
         experiment,
@@ -3151,21 +3148,6 @@ export async function postFeatureRule(
 
     if (!safeRollout) {
       throw new Error("Failed to create safe rollout");
-    }
-  }
-
-  // TODO(holdouts): remove code below (which makes this endpoint consistent with API routes)
-  // and instead only link when the holdout and experiment go live
-  if (holdoutExperimentToLink && effectiveHoldout?.id) {
-    // Link now only when the validated holdout is already live. A draft-only
-    // holdout defers to publish — applyHoldoutSideEffects enrolls the
-    // experiments in the merged rules when the holdout change lands.
-    if (feature.holdout?.id === effectiveHoldout.id) {
-      await linkExperimentToHoldout(
-        context,
-        holdoutExperimentToLink,
-        effectiveHoldout.id,
-      );
     }
   }
 
@@ -3515,7 +3497,8 @@ export async function postFeatureExperimentRefRule(
   // to check compatibility
   const effectiveHoldout = getEffectiveRevisionHoldout(revision, feature);
 
-  const holdoutExperimentToLink = await resolveHoldoutExperimentToLink({
+  // Validation only: linkage is derived from published rules at publish.
+  await resolveHoldoutExperimentToLink({
     context,
     feature,
     experiment,
@@ -3651,21 +3634,6 @@ export async function postFeatureExperimentRefRule(
     feature.id,
     experiment,
   );
-
-  // TODO(holdouts): remove code below (which makes this endpoint consistent with API routes)
-  // and instead only link when the holdout and experiment go live
-  if (holdoutExperimentToLink && effectiveHoldout?.id) {
-    // Link now only when the validated holdout is already live. A draft-only
-    // holdout defers to publish — applyHoldoutSideEffects enrolls the
-    // experiments in the merged rules when the holdout change lands.
-    if (feature.holdout?.id === effectiveHoldout.id) {
-      await linkExperimentToHoldout(
-        context,
-        holdoutExperimentToLink,
-        effectiveHoldout.id,
-      );
-    }
-  }
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -3503,7 +3503,6 @@ export async function postFeatureExperimentRefRule(
     feature,
     experiment,
     effectiveHoldout,
-    allowExistingLinkToThisFeature: true,
   });
 
   // One-way: any rule-footprint env that's currently off flips on. We never

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -2169,6 +2169,8 @@ async function planLinkageForHoldout(
   if (candidates.length) {
     // Only other features' LIVE rules count: an unpublished draft elsewhere has
     // no linkage of its own to protect, which is what keeps this decidable.
+    // TODO: consider querying with a rules[] projection if performance becomes
+    // an issue — only `rules` and `holdout` are read here.
     const otherFeatures = await getFeaturesByIds(
       context,
       Object.keys(holdout.linkedFeatures).filter((id) => id !== feature.id),

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -2080,59 +2080,39 @@ export async function applyHoldoutSideEffects(
     );
   }
 
-  // Feature side only. The experiments in its rules are reconciled from
-  // published state by planHoldoutExperimentLinkage, which owns that half for
-  // every direction (join, leave, and a rules-only change).
+  // Feature side only; planHoldoutExperimentLinkage owns the experiment half.
   if (newHoldoutId) {
     await context.models.holdout.addFeatureToHoldout(newHoldoutId, feature.id);
   }
 }
 
-/**
- * The `linkedExperiments` writes a publish is about to make for one feature,
- * plus the experiment `holdoutId`s they overwrite. Read-only to compute, so the
- * rewind can be registered before any of it is applied.
- */
 export type HoldoutExperimentLinkagePlan = {
   holdoutId: string;
   toLink: string[];
   toUnlink: string[];
-  // Pre-publish values, so the reversal converges to them instead of guessing.
   // "" is the clear sentinel `updateExperiment` expects.
   prevExperimentHoldoutIds: Record<string, string>;
 };
 
-/**
- * Work out how a holdout's experiment linkage should change given what this
- * feature is publishing.
- *
- * Linkage is derived from published rules rather than written when a rule is
- * added to a draft, so a draft that is edited or discarded leaves nothing to
- * unwind. This runs for a rules-only publish too — that is how an
- * experiment-ref rule added to an already-held feature gets enrolled.
- */
+// Derived from published rules, so an edited or discarded draft leaves nothing
+// to unwind.
 export async function planHoldoutExperimentLinkage(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
-  // Post-publish holdout and rules for this feature.
   holdoutId: string | null,
   publishedRules: FeatureRule[],
 ): Promise<HoldoutExperimentLinkagePlan[]> {
   const plans: HoldoutExperimentLinkagePlan[] = [];
 
-  // Leaving a holdout (or moving to another) has to drop what this feature
-  // contributed to the old one. Nothing else does: the transition path unlinks
-  // only the feature, and the guard that would force detaching experiments first
-  // reads post-publish rules — so a draft that removes the holdout and the rule
-  // together sails past it.
+  // Nothing else drops what this feature contributed to the holdout it is
+  // leaving: the transition unlinks only the feature, and the guard that would
+  // force detaching experiments first reads post-publish rules.
   const prevHoldoutId = feature.holdout?.id ?? null;
   if (prevHoldoutId && prevHoldoutId !== holdoutId) {
     const leaving = await planLinkageForHoldout(
       context,
       feature,
       prevHoldoutId,
-      // No rules under the old holdout any more, so everything this feature
-      // brought is a candidate to unlink.
       [],
       feature.rules ?? [],
     );
@@ -2158,15 +2138,14 @@ async function planLinkageForHoldout(
   feature: FeatureInterface,
   holdoutId: string,
   publishedRules: FeatureRule[],
-  // The feature's pre-publish rules — the bound on what it may withdraw.
+  // Bounds what this feature may withdraw.
   previousRules: FeatureRule[],
 ): Promise<HoldoutExperimentLinkagePlan | null> {
   const holdout = await context.models.holdout.getByIdForLinkage(holdoutId);
   if (!holdout) return null;
 
-  // Only this holdout's OTHER features can justify keeping a link, and only
-  // their live rules count — an unpublished draft elsewhere has no linkage of
-  // its own to protect, which is what makes this decidable from published state.
+  // Only other features' LIVE rules count: an unpublished draft elsewhere has no
+  // linkage of its own to protect, which is what keeps this decidable.
   const otherFeatureIds = Object.keys(holdout.linkedFeatures).filter(
     (id) => id !== feature.id,
   );
@@ -2178,9 +2157,6 @@ async function planLinkageForHoldout(
   const { toLink, toUnlink } = computeHoldoutExperimentLinkageDelta({
     publishedRules,
     previousRules,
-    // Always a real holdout here; the "leaving" case expresses itself by passing
-    // no rules, which yields an empty desired set.
-    hasHoldout: true,
     linkedExperimentIds: Object.keys(holdout.linkedExperiments),
     experimentIdsReferencedElsewhere,
   });
@@ -2192,9 +2168,8 @@ async function planLinkageForHoldout(
       const exp = await getExperimentById(context, id);
       if (!exp) return;
       prevExperimentHoldoutIds[id] = exp.holdoutId ?? "";
-      // Enforced here rather than at rule-add so it can't be bypassed by moving
-      // the experiment afterwards; the plan is read-only, so this refuses the
-      // publish before anything is written.
+      // Also checked at rule-add; re-checked here so moving the experiment
+      // afterwards can't bypass it.
       if (toLink.includes(id)) {
         assertHoldoutAvailableForProject(holdout, exp.project);
       }
@@ -2239,8 +2214,8 @@ export async function applyHoldoutExperimentLinkage(
   });
 }
 
-// Converges back to the planned pre-image rather than inverting each write, so a
-// forward pass that failed partway still lands on the pre-publish state.
+// Converges to the pre-image rather than inverting each write, so a forward pass
+// that failed partway still lands on the pre-publish state.
 export async function reverseHoldoutExperimentLinkage(
   context: ReqContext | ApiReqContext,
   plan: HoldoutExperimentLinkagePlan,
@@ -2253,20 +2228,10 @@ export async function reverseHoldoutExperimentLinkage(
     plan.holdoutId,
     plan.toLink,
   );
-  // The experiment write is the step most likely to have failed on the way in
-  // (updateExperiment serializes the whole experiment for its update event, which
-  // throws on some legacy docs). Letting that abort the reversal would strand the
-  // feature at the published version with its revision still a draft — the exact
-  // split the rewind exists to prevent — so it is logged rather than thrown, and
-  // the rest of the rewind proceeds.
-  try {
-    await setExperimentHoldoutIds(context, plan.prevExperimentHoldoutIds);
-  } catch (e) {
-    logger.error(
-      e,
-      `Failed to restore experiment holdoutIds while rewinding publish for holdout ${plan.holdoutId}`,
-    );
-  }
+  // Throws on failure: publishRevision treats this as a satellite and carries on
+  // to the feature document, while bulk compensation records it and reports the
+  // item stuck rather than cleanly rolled back.
+  await setExperimentHoldoutIds(context, plan.prevExperimentHoldoutIds);
 }
 
 // The linkage a holdout transition is about to write, captured before the forward
@@ -3342,12 +3307,8 @@ export async function publishRevision({
   const updateActions = (revision.rampActions ?? []).filter(
     (a) => a.mode === "update",
   );
-  // `critical` marks the steps that decide what is live and what the UI shows —
-  // the feature document, and the revision status that follows it. A satellite
-  // (ramp schedules, holdout linkage) that cannot be reversed is logged and
-  // skipped: abandoning the document restore because a satellite failed leaves
-  // the feature published on a revision still marked draft, which is the worst
-  // available outcome and the one this rewind exists to avoid.
+  // `critical` = decides what is live (the feature document, then the revision
+  // status). A satellite that can't be reversed must not abandon those.
   type Rewind = {
     what: string;
     undo: () => Promise<unknown>;
@@ -3387,14 +3348,9 @@ export async function publishRevision({
         ? null
         : await captureHoldoutLinkagePreImage(context, feature, result.holdout);
 
-    // Planned here for the same reason: computing it is read-only, so the rewind
-    // is registrable before the first linkage write.
-    //
-    // Deliberately not gated on the merge carrying a rule or holdout change:
-    // linkage is reconciled against published state, and a publish with no delta
-    // is exactly the case where state can be out of sync (reconciling a revision
-    // an earlier failed publish left stranded). The plan short-circuits when the
-    // feature has no holdout, so this costs nothing for most publishes.
+    // Not gated on the merge carrying a change: a publish with no delta is
+    // exactly when state can be out of sync (reconciling a stranded revision).
+    // Short-circuits when the feature has no holdout.
     const experimentLinkagePlans = await planHoldoutExperimentLinkage(
       context,
       feature,
@@ -3457,9 +3413,6 @@ export async function publishRevision({
       );
     }
 
-    // Experiment linkage is derived from published rules, so it has to run for a
-    // rules-only publish too — that is how a rule added to an already-held
-    // feature gets enrolled, and how a removed one gets dropped.
     for (const plan of experimentLinkagePlans) {
       rewinds.push({
         what: `holdout experiment linkage (${plan.holdoutId})`,
@@ -3497,8 +3450,7 @@ export async function publishRevision({
     if (revisionStatusRewind) unwind.push(revisionStatusRewind);
     let criticalFailed = false;
     for (const { what, undo, critical } of unwind) {
-      // Once the document could not be restored, reopening the revision would
-      // make it contradict a feature that is still published.
+      // Reopening the revision now would contradict a still-published feature.
       if (criticalFailed) {
         logger.error(
           `Skipping rewind of ${what} for feature ${feature.id} revision ${revision.version}: an earlier critical step could not be reversed`,

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -2080,37 +2080,11 @@ export async function applyHoldoutSideEffects(
     );
   }
 
-  // Link feature (and experiments in its rules) to the new holdout.
+  // Feature side only. The experiments in its rules are reconciled from
+  // published state by planHoldoutExperimentLinkage, which owns that half for
+  // every direction (join, leave, and a rules-only change).
   if (newHoldoutId) {
-    const ruleExperimentIds = Array.from(
-      new Set(
-        (feature.rules ?? [])
-          .filter((rule) => rule.type === "experiment-ref")
-          .map((rule) => rule.experimentId),
-      ),
-    );
-
-    await context.models.holdout.addFeatureToHoldout(
-      newHoldoutId,
-      feature.id,
-      ruleExperimentIds,
-    );
-
-    if (ruleExperimentIds.length) {
-      const linkedExperiments = await Promise.all(
-        ruleExperimentIds.map((eid) => getExperimentById(context, eid)),
-      );
-      await Promise.all(
-        linkedExperiments.map(async (exp) => {
-          if (!exp) return;
-          return updateExperiment({
-            context,
-            experiment: exp,
-            changes: { holdoutId: newHoldoutId },
-          });
-        }),
-      );
-    }
+    await context.models.holdout.addFeatureToHoldout(newHoldoutId, feature.id);
   }
 }
 
@@ -2143,11 +2117,46 @@ export async function planHoldoutExperimentLinkage(
   // Post-publish holdout and rules for this feature.
   holdoutId: string | null,
   publishedRules: FeatureRule[],
-): Promise<HoldoutExperimentLinkagePlan | null> {
-  // With no holdout there is no map to reconcile against; the holdout transition
-  // path unlinks the feature and its experiments.
-  if (!holdoutId) return null;
+): Promise<HoldoutExperimentLinkagePlan[]> {
+  const plans: HoldoutExperimentLinkagePlan[] = [];
 
+  // Leaving a holdout (or moving to another) has to drop what this feature
+  // contributed to the old one. Nothing else does: the transition path unlinks
+  // only the feature, and the guard that would force detaching experiments first
+  // reads post-publish rules — so a draft that removes the holdout and the rule
+  // together sails past it.
+  const prevHoldoutId = feature.holdout?.id ?? null;
+  if (prevHoldoutId && prevHoldoutId !== holdoutId) {
+    const leaving = await planLinkageForHoldout(
+      context,
+      feature,
+      prevHoldoutId,
+      // No rules under the old holdout any more, so everything this feature
+      // brought is a candidate to unlink.
+      [],
+    );
+    if (leaving) plans.push(leaving);
+  }
+
+  if (holdoutId) {
+    const joining = await planLinkageForHoldout(
+      context,
+      feature,
+      holdoutId,
+      publishedRules,
+    );
+    if (joining) plans.push(joining);
+  }
+
+  return plans;
+}
+
+async function planLinkageForHoldout(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  holdoutId: string,
+  publishedRules: FeatureRule[],
+): Promise<HoldoutExperimentLinkagePlan | null> {
   const holdout = await context.models.holdout.getByIdForLinkage(holdoutId);
   if (!holdout) return null;
 
@@ -2164,6 +2173,8 @@ export async function planHoldoutExperimentLinkage(
 
   const { toLink, toUnlink } = computeHoldoutExperimentLinkageDelta({
     publishedRules,
+    // Always a real holdout here; the "leaving" case expresses itself by passing
+    // no rules, which yields an empty desired set.
     hasHoldout: true,
     linkedExperimentIds: Object.keys(holdout.linkedExperiments),
     experimentIdsReferencedElsewhere,
@@ -2265,40 +2276,16 @@ export type HoldoutLinkagePreImage = {
   prevFeatureEntry: { id: string; dateAdded: Date } | null;
   newHoldoutId: string | null;
   addsFeature: boolean;
-  addsExperimentIds: string[];
-  // Keyed by experiment id; "" is the clear sentinel `updateExperiment` expects.
-  experimentHoldoutIds: Record<string, string>;
 };
 
 export async function captureHoldoutLinkagePreImage(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
   newHoldout: { id: string } | null,
-  // Post-publish rules, so the captured experiment set matches the forward pass.
-  rules: FeatureRule[],
 ): Promise<HoldoutLinkagePreImage | null> {
   const prevHoldoutId = feature.holdout?.id ?? null;
   const newHoldoutId = newHoldout?.id ?? null;
   if (newHoldoutId === prevHoldoutId) return null;
-
-  const experimentHoldoutIds: Record<string, string> = {};
-  if (newHoldoutId) {
-    const ruleExperimentIds = Array.from(
-      new Set(
-        rules
-          .filter((rule) => rule.type === "experiment-ref")
-          .map((rule) => rule.experimentId),
-      ),
-    );
-    // `getExperimentById` is read-filtered, so this sees exactly the experiments
-    // the forward pass will restamp.
-    const experiments = await Promise.all(
-      ruleExperimentIds.map((id) => getExperimentById(context, id)),
-    );
-    for (const exp of experiments) {
-      if (exp) experimentHoldoutIds[exp.id] = exp.holdoutId ?? "";
-    }
-  }
 
   const newHoldoutDoc = newHoldoutId
     ? await context.models.holdout.getByIdForLinkage(newHoldoutId)
@@ -2315,10 +2302,6 @@ export async function captureHoldoutLinkagePreImage(
     // Only what this publish adds: an entry that was already there belongs to
     // another writer and must survive the rewind.
     addsFeature: !!newHoldoutDoc && !newHoldoutDoc.linkedFeatures[feature.id],
-    addsExperimentIds: Object.keys(experimentHoldoutIds).filter(
-      (id) => !newHoldoutDoc?.linkedExperiments[id],
-    ),
-    experimentHoldoutIds,
   };
 }
 
@@ -2332,21 +2315,7 @@ export async function rewindHoldoutLinkage(
   if (pre.newHoldoutId) {
     await context.models.holdout.removeLinkageFromHoldout(pre.newHoldoutId, {
       featureId: pre.addsFeature ? pre.featureId : null,
-      experimentIds: pre.addsExperimentIds,
     });
-  }
-
-  for (const [experimentId, holdoutId] of Object.entries(
-    pre.experimentHoldoutIds,
-  )) {
-    const experiment = await getExperimentById(context, experimentId);
-    if (!experiment) continue;
-    const current = experiment.holdoutId ?? "";
-    if (current === holdoutId) continue;
-    // Undo only our own write: anything else is a later writer's intent, and
-    // the same ownership rule the bulk publisher's compensation uses.
-    if (current !== (pre.newHoldoutId ?? "")) continue;
-    await updateExperiment({ context, experiment, changes: { holdoutId } });
   }
 
   if (pre.prevHoldoutId && pre.prevFeatureEntry) {
@@ -3401,12 +3370,7 @@ export async function publishRevision({
     const holdoutPreImage =
       result.holdout === undefined
         ? null
-        : await captureHoldoutLinkagePreImage(
-            context,
-            feature,
-            result.holdout,
-            result.rules ?? feature.rules ?? [],
-          );
+        : await captureHoldoutLinkagePreImage(context, feature, result.holdout);
 
     // Planned here for the same reason: computing it is read-only, so the rewind
     // is registrable before the first linkage write.
@@ -3416,7 +3380,7 @@ export async function publishRevision({
     // is exactly the case where state can be out of sync (reconciling a revision
     // an earlier failed publish left stranded). The plan short-circuits when the
     // feature has no holdout, so this costs nothing for most publishes.
-    const experimentLinkagePlan = await planHoldoutExperimentLinkage(
+    const experimentLinkagePlans = await planHoldoutExperimentLinkage(
       context,
       feature,
       (result.holdout !== undefined
@@ -3480,13 +3444,12 @@ export async function publishRevision({
     // Experiment linkage is derived from published rules, so it has to run for a
     // rules-only publish too — that is how a rule added to an already-held
     // feature gets enrolled, and how a removed one gets dropped.
-    if (experimentLinkagePlan) {
+    for (const plan of experimentLinkagePlans) {
       rewinds.push({
-        what: "holdout experiment linkage",
-        undo: () =>
-          reverseHoldoutExperimentLinkage(context, experimentLinkagePlan),
+        what: `holdout experiment linkage (${plan.holdoutId})`,
+        undo: () => reverseHoldoutExperimentLinkage(context, plan),
       });
-      await applyHoldoutExperimentLinkage(context, experimentLinkagePlan);
+      await applyHoldoutExperimentLinkage(context, plan);
     }
 
     const publishStamp = await markRevisionAsPublished(

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -2237,7 +2237,20 @@ export async function reverseHoldoutExperimentLinkage(
     plan.holdoutId,
     plan.toLink,
   );
-  await setExperimentHoldoutIds(context, plan.prevExperimentHoldoutIds);
+  // The experiment write is the step most likely to have failed on the way in
+  // (updateExperiment serializes the whole experiment for its update event, which
+  // throws on some legacy docs). Letting that abort the reversal would strand the
+  // feature at the published version with its revision still a draft — the exact
+  // split the rewind exists to prevent — so it is logged rather than thrown, and
+  // the rest of the rewind proceeds.
+  try {
+    await setExperimentHoldoutIds(context, plan.prevExperimentHoldoutIds);
+  } catch (e) {
+    logger.error(
+      e,
+      `Failed to restore experiment holdoutIds while rewinding publish for holdout ${plan.holdoutId}`,
+    );
+  }
 }
 
 // The linkage a holdout transition is about to write, captured before the forward
@@ -3397,17 +3410,20 @@ export async function publishRevision({
 
     // Planned here for the same reason: computing it is read-only, so the rewind
     // is registrable before the first linkage write.
-    const experimentLinkagePlan =
-      result.holdout === undefined && result.rules === undefined
-        ? null
-        : await planHoldoutExperimentLinkage(
-            context,
-            feature,
-            (result.holdout !== undefined
-              ? result.holdout?.id
-              : feature.holdout?.id) ?? null,
-            result.rules ?? feature.rules ?? [],
-          );
+    //
+    // Deliberately not gated on the merge carrying a rule or holdout change:
+    // linkage is reconciled against published state, and a publish with no delta
+    // is exactly the case where state can be out of sync (reconciling a revision
+    // an earlier failed publish left stranded). The plan short-circuits when the
+    // feature has no holdout, so this costs nothing for most publishes.
+    const experimentLinkagePlan = await planHoldoutExperimentLinkage(
+      context,
+      feature,
+      (result.holdout !== undefined
+        ? result.holdout?.id
+        : feature.holdout?.id) ?? null,
+      result.rules ?? feature.rules ?? [],
+    );
 
     updatedFeature = await applyRevisionChanges(
       context,

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -2069,10 +2069,8 @@ export async function applyHoldoutSideEffects(
   // holdout fails with no membership mutated (no partial transition).
   await assertHoldoutLinkageResolvable(context, newHoldout, feature.project);
 
-  // Remove feature from the old holdout. The guard (assertHoldoutChangeAllowed)
-  // has already refused this move if any linked experiment still belongs to the
-  // old holdout, so there's nothing to cascade here — the experiment side is
-  // detached explicitly by the user first.
+  // Feature side only: planHoldoutExperimentLinkage withdraws the experiments
+  // this feature contributed to the holdout it is leaving.
   if (prevHoldoutId) {
     await context.models.holdout.removeFeatureFromHoldout(
       prevHoldoutId,
@@ -3422,16 +3420,10 @@ export async function publishRevision({
         });
       }
 
-      // Guard already ran above (before any mutation) — skip the re-check.
-      // Pass the POST-publish rules: side effects enroll the experiments in
-      // the feature's rules, and a draft can add the holdout and the
-      // experiment-ref rule together.
-      await applyHoldoutSideEffects(
-        context,
-        { ...feature, rules: result.rules ?? feature.rules },
-        result.holdout,
-        { skipGuard: true },
-      );
+      // Guard already ran above, before any mutation.
+      await applyHoldoutSideEffects(context, feature, result.holdout, {
+        skipGuard: true,
+      });
     }
 
     for (const plan of experimentLinkagePlans) {

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -3473,8 +3473,14 @@ export async function publishRevision({
     // Say so in the response: continuing past a satellite keeps the feature and
     // its revision consistent, but whatever could not be reversed is left behind
     // and the caller is the only one positioned to act on it.
-    if (unreversed.length && err instanceof Error) {
-      err.message += ` (could not be rolled back: ${unreversed.join(", ")} — see server logs)`;
+    if (unreversed.length) {
+      const residue = `(could not be rolled back: ${unreversed.join(", ")} — see server logs)`;
+      // Appending keeps the original error's class, and so its status code.
+      if (err instanceof Error) {
+        err.message += ` ${residue}`;
+        throw err;
+      }
+      throw new Error(`${getErrorMessage(err)} ${residue}`);
     }
     throw err;
   }

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -3449,23 +3449,32 @@ export async function publishRevision({
     const unwind = [...rewinds].reverse();
     if (revisionStatusRewind) unwind.push(revisionStatusRewind);
     let criticalFailed = false;
+    const unreversed: string[] = [];
     for (const { what, undo, critical } of unwind) {
       // Reopening the revision now would contradict a still-published feature.
       if (criticalFailed) {
         logger.error(
           `Skipping rewind of ${what} for feature ${feature.id} revision ${revision.version}: an earlier critical step could not be reversed`,
         );
+        unreversed.push(what);
         continue;
       }
       try {
         await undo();
       } catch (rewindErr) {
         if (critical) criticalFailed = true;
+        unreversed.push(what);
         logger.error(
           rewindErr,
           `Failed to rewind ${what} for feature ${feature.id} revision ${revision.version} after a failed publish${critical ? " — the feature stays at the published state" : " (satellite; continuing)"}`,
         );
       }
+    }
+    // Say so in the response: continuing past a satellite keeps the feature and
+    // its revision consistent, but whatever could not be reversed is left behind
+    // and the caller is the only one positioned to act on it.
+    if (unreversed.length && err instanceof Error) {
+      err.message += ` (could not be rolled back: ${unreversed.join(", ")} — see server logs)`;
     }
     throw err;
   }

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -11,6 +11,8 @@ import {
   PermissionError,
   stemRuleId,
   resolveTargetingProjectIds,
+  computeHoldoutExperimentLinkageDelta,
+  getExperimentIdsFromRules,
 } from "shared/util";
 import {
   SafeRolloutInterface,
@@ -88,7 +90,10 @@ import {
   getAffectedSDKPayloadKeys,
   getSDKPayloadKeysByDiff,
 } from "back-end/src/util/features";
-import { getHoldoutAvailableForProject } from "back-end/src/services/holdout-availability";
+import {
+  assertHoldoutAvailableForProject,
+  getHoldoutAvailableForProject,
+} from "back-end/src/services/holdout-availability";
 import { applyPartialFeatureRuleUpdatesToRevision } from "back-end/src/util/featureRevision.util";
 import {
   BadRequestError,
@@ -2109,6 +2114,132 @@ export async function applyHoldoutSideEffects(
   }
 }
 
+/**
+ * The `linkedExperiments` writes a publish is about to make for one feature,
+ * plus the experiment `holdoutId`s they overwrite. Read-only to compute, so the
+ * rewind can be registered before any of it is applied.
+ */
+export type HoldoutExperimentLinkagePlan = {
+  holdoutId: string;
+  toLink: string[];
+  toUnlink: string[];
+  // Pre-publish values, so the reversal converges to them instead of guessing.
+  // "" is the clear sentinel `updateExperiment` expects.
+  prevExperimentHoldoutIds: Record<string, string>;
+};
+
+/**
+ * Work out how a holdout's experiment linkage should change given what this
+ * feature is publishing.
+ *
+ * Linkage is derived from published rules rather than written when a rule is
+ * added to a draft, so a draft that is edited or discarded leaves nothing to
+ * unwind. This runs for a rules-only publish too — that is how an
+ * experiment-ref rule added to an already-held feature gets enrolled.
+ */
+export async function planHoldoutExperimentLinkage(
+  context: ReqContext | ApiReqContext,
+  feature: FeatureInterface,
+  // Post-publish holdout and rules for this feature.
+  holdoutId: string | null,
+  publishedRules: FeatureRule[],
+): Promise<HoldoutExperimentLinkagePlan | null> {
+  // With no holdout there is no map to reconcile against; the holdout transition
+  // path unlinks the feature and its experiments.
+  if (!holdoutId) return null;
+
+  const holdout = await context.models.holdout.getByIdForLinkage(holdoutId);
+  if (!holdout) return null;
+
+  // Only this holdout's OTHER features can justify keeping a link, and only
+  // their live rules count — an unpublished draft elsewhere has no linkage of
+  // its own to protect, which is what makes this decidable from published state.
+  const otherFeatureIds = Object.keys(holdout.linkedFeatures).filter(
+    (id) => id !== feature.id,
+  );
+  const otherFeatures = await getFeaturesByIds(context, otherFeatureIds);
+  const experimentIdsReferencedElsewhere = otherFeatures
+    .filter((f) => f.holdout?.id === holdoutId)
+    .flatMap((f) => getExperimentIdsFromRules(f.rules ?? []));
+
+  const { toLink, toUnlink } = computeHoldoutExperimentLinkageDelta({
+    publishedRules,
+    hasHoldout: true,
+    linkedExperimentIds: Object.keys(holdout.linkedExperiments),
+    experimentIdsReferencedElsewhere,
+  });
+  if (!toLink.length && !toUnlink.length) return null;
+
+  const prevExperimentHoldoutIds: Record<string, string> = {};
+  await Promise.all(
+    [...toLink, ...toUnlink].map(async (id) => {
+      const exp = await getExperimentById(context, id);
+      if (!exp) return;
+      prevExperimentHoldoutIds[id] = exp.holdoutId ?? "";
+      // Enforced here rather than at rule-add so it can't be bypassed by moving
+      // the experiment afterwards; the plan is read-only, so this refuses the
+      // publish before anything is written.
+      if (toLink.includes(id)) {
+        assertHoldoutAvailableForProject(holdout, exp.project);
+      }
+    }),
+  );
+
+  return { holdoutId, toLink, toUnlink, prevExperimentHoldoutIds };
+}
+
+async function setExperimentHoldoutIds(
+  context: ReqContext | ApiReqContext,
+  targets: Record<string, string>,
+) {
+  await Promise.all(
+    Object.entries(targets).map(async ([id, next]) => {
+      const exp = await getExperimentById(context, id);
+      if (!exp || (exp.holdoutId ?? "") === next) return;
+      await updateExperiment({
+        context,
+        experiment: exp,
+        changes: { holdoutId: next },
+      });
+    }),
+  );
+}
+
+export async function applyHoldoutExperimentLinkage(
+  context: ReqContext | ApiReqContext,
+  plan: HoldoutExperimentLinkagePlan,
+) {
+  await context.models.holdout.addExperimentsToHoldout(
+    plan.holdoutId,
+    plan.toLink,
+  );
+  await context.models.holdout.removeExperimentsFromHoldout(
+    plan.holdoutId,
+    plan.toUnlink,
+  );
+  await setExperimentHoldoutIds(context, {
+    ...Object.fromEntries(plan.toLink.map((id) => [id, plan.holdoutId])),
+    ...Object.fromEntries(plan.toUnlink.map((id) => [id, ""])),
+  });
+}
+
+// Converges back to the planned pre-image rather than inverting each write, so a
+// forward pass that failed partway still lands on the pre-publish state.
+export async function reverseHoldoutExperimentLinkage(
+  context: ReqContext | ApiReqContext,
+  plan: HoldoutExperimentLinkagePlan,
+) {
+  await context.models.holdout.addExperimentsToHoldout(
+    plan.holdoutId,
+    plan.toUnlink,
+  );
+  await context.models.holdout.removeExperimentsFromHoldout(
+    plan.holdoutId,
+    plan.toLink,
+  );
+  await setExperimentHoldoutIds(context, plan.prevExperimentHoldoutIds);
+}
+
 // The linkage a holdout transition is about to write, captured before the forward
 // pass so its rewind can restore the pre-publish state instead of re-deriving it
 // by running the transition backwards (which cannot express "there was no
@@ -3264,6 +3395,20 @@ export async function publishRevision({
             result.rules ?? feature.rules ?? [],
           );
 
+    // Planned here for the same reason: computing it is read-only, so the rewind
+    // is registrable before the first linkage write.
+    const experimentLinkagePlan =
+      result.holdout === undefined && result.rules === undefined
+        ? null
+        : await planHoldoutExperimentLinkage(
+            context,
+            feature,
+            (result.holdout !== undefined
+              ? result.holdout?.id
+              : feature.holdout?.id) ?? null,
+            result.rules ?? feature.rules ?? [],
+          );
+
     updatedFeature = await applyRevisionChanges(
       context,
       feature,
@@ -3307,14 +3452,25 @@ export async function publishRevision({
       // Guard already ran above (before any mutation) — skip the re-check.
       // Pass the POST-publish rules: side effects enroll the experiments in
       // the feature's rules, and a draft can add the holdout and the
-      // experiment-ref rule together — the pre-publish rules would miss it
-      // (the deferred half of the eager-link-at-rule-add flow).
+      // experiment-ref rule together.
       await applyHoldoutSideEffects(
         context,
         { ...feature, rules: result.rules ?? feature.rules },
         result.holdout,
         { skipGuard: true },
       );
+    }
+
+    // Experiment linkage is derived from published rules, so it has to run for a
+    // rules-only publish too — that is how a rule added to an already-held
+    // feature gets enrolled, and how a removed one gets dropped.
+    if (experimentLinkagePlan) {
+      rewinds.push({
+        what: "holdout experiment linkage",
+        undo: () =>
+          reverseHoldoutExperimentLinkage(context, experimentLinkagePlan),
+      });
+      await applyHoldoutExperimentLinkage(context, experimentLinkagePlan);
     }
 
     const publishStamp = await markRevisionAsPublished(

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -2134,6 +2134,7 @@ export async function planHoldoutExperimentLinkage(
       // No rules under the old holdout any more, so everything this feature
       // brought is a candidate to unlink.
       [],
+      feature.rules ?? [],
     );
     if (leaving) plans.push(leaving);
   }
@@ -2144,6 +2145,7 @@ export async function planHoldoutExperimentLinkage(
       feature,
       holdoutId,
       publishedRules,
+      feature.rules ?? [],
     );
     if (joining) plans.push(joining);
   }
@@ -2156,6 +2158,8 @@ async function planLinkageForHoldout(
   feature: FeatureInterface,
   holdoutId: string,
   publishedRules: FeatureRule[],
+  // The feature's pre-publish rules — the bound on what it may withdraw.
+  previousRules: FeatureRule[],
 ): Promise<HoldoutExperimentLinkagePlan | null> {
   const holdout = await context.models.holdout.getByIdForLinkage(holdoutId);
   if (!holdout) return null;
@@ -2173,6 +2177,7 @@ async function planLinkageForHoldout(
 
   const { toLink, toUnlink } = computeHoldoutExperimentLinkageDelta({
     publishedRules,
+    previousRules,
     // Always a real holdout here; the "leaving" case expresses itself by passing
     // no rules, which yields an empty desired set.
     hasHoldout: true,

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -2113,20 +2113,20 @@ export async function planHoldoutExperimentLinkage(
       context,
       feature,
       prevHoldoutId,
-      [],
-      feature.rules ?? [],
+      {
+        mode: "withdraw",
+        previousRules: feature.rules ?? [],
+      },
     );
     if (leaving) plans.push(leaving);
   }
 
   if (holdoutId) {
-    const joining = await planLinkageForHoldout(
-      context,
-      feature,
-      holdoutId,
+    const joining = await planLinkageForHoldout(context, feature, holdoutId, {
+      mode: "reconcile",
       publishedRules,
-      feature.rules ?? [],
-    );
+      previousRules: feature.rules ?? [],
+    });
     if (joining) plans.push(joining);
   }
 
@@ -2137,30 +2137,49 @@ async function planLinkageForHoldout(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
   holdoutId: string,
-  publishedRules: FeatureRule[],
-  // Bounds what this feature may withdraw.
-  previousRules: FeatureRule[],
+  // `previousRules` bounds what this feature may withdraw; `withdraw` publishes
+  // no rules under this holdout, so everything it contributed is a candidate.
+  args:
+    | {
+        mode: "reconcile";
+        publishedRules: FeatureRule[];
+        previousRules: FeatureRule[];
+      }
+    | { mode: "withdraw"; previousRules: FeatureRule[] },
 ): Promise<HoldoutExperimentLinkagePlan | null> {
   const holdout = await context.models.holdout.getByIdForLinkage(holdoutId);
   if (!holdout) return null;
 
-  // Only other features' LIVE rules count: an unpublished draft elsewhere has no
-  // linkage of its own to protect, which is what keeps this decidable.
-  const otherFeatureIds = Object.keys(holdout.linkedFeatures).filter(
-    (id) => id !== feature.id,
-  );
-  const otherFeatures = await getFeaturesByIds(context, otherFeatureIds);
-  const experimentIdsReferencedElsewhere = otherFeatures
-    .filter((f) => f.holdout?.id === holdoutId)
-    .flatMap((f) => getExperimentIdsFromRules(f.rules ?? []));
+  const publishedRules = args.mode === "reconcile" ? args.publishedRules : [];
+  const linkedExperimentIds = Object.keys(holdout.linkedExperiments);
+  const delta = (experimentIdsReferencedElsewhere: string[]) =>
+    computeHoldoutExperimentLinkageDelta({
+      publishedRules,
+      previousRules: args.previousRules,
+      linkedExperimentIds,
+      experimentIdsReferencedElsewhere,
+    });
 
-  const { toLink, toUnlink } = computeHoldoutExperimentLinkageDelta({
-    publishedRules,
-    previousRules,
-    linkedExperimentIds: Object.keys(holdout.linkedExperiments),
-    experimentIdsReferencedElsewhere,
-  });
-  if (!toLink.length && !toUnlink.length) return null;
+  // Costed before the fan-out below: a holdout can hold a lot of features, and
+  // only a withdrawal needs to know what they reference.
+  const { toLink, toUnlink: candidates } = delta([]);
+  if (!toLink.length && !candidates.length) return null;
+
+  let toUnlink = candidates;
+  if (candidates.length) {
+    // Only other features' LIVE rules count: an unpublished draft elsewhere has
+    // no linkage of its own to protect, which is what keeps this decidable.
+    const otherFeatures = await getFeaturesByIds(
+      context,
+      Object.keys(holdout.linkedFeatures).filter((id) => id !== feature.id),
+    );
+    toUnlink = delta(
+      otherFeatures
+        .filter((f) => f.holdout?.id === holdoutId)
+        .flatMap((f) => getExperimentIdsFromRules(f.rules ?? [])),
+    ).toUnlink;
+    if (!toLink.length && !toUnlink.length) return null;
+  }
 
   const prevExperimentHoldoutIds: Record<string, string> = {};
   await Promise.all(

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -3342,7 +3342,17 @@ export async function publishRevision({
   const updateActions = (revision.rampActions ?? []).filter(
     (a) => a.mode === "update",
   );
-  type Rewind = { what: string; undo: () => Promise<unknown> };
+  // `critical` marks the steps that decide what is live and what the UI shows —
+  // the feature document, and the revision status that follows it. A satellite
+  // (ramp schedules, holdout linkage) that cannot be reversed is logged and
+  // skipped: abandoning the document restore because a satellite failed leaves
+  // the feature published on a revision still marked draft, which is the worst
+  // available outcome and the one this rewind exists to avoid.
+  type Rewind = {
+    what: string;
+    undo: () => Promise<unknown>;
+    critical?: boolean;
+  };
   const rewinds: Rewind[] = [];
   let revisionStatusRewind: Rewind | null = null;
 
@@ -3403,6 +3413,7 @@ export async function publishRevision({
 
     rewinds.push({
       what: "feature document",
+      critical: true,
       undo: async () => {
         // Paired with the rules restore: a reverted rule set must not leave the
         // experiments it added still pointing back at this feature.
@@ -3466,6 +3477,7 @@ export async function publishRevision({
     );
     revisionStatusRewind = {
       what: "revision status",
+      critical: true,
       undo: async () => {
         const reopened = await restoreFeatureRevisionAfterFailedBulkPublish(
           revision,
@@ -3483,15 +3495,24 @@ export async function publishRevision({
     // the feature doc it advanced stays published.
     const unwind = [...rewinds].reverse();
     if (revisionStatusRewind) unwind.push(revisionStatusRewind);
-    for (const { what, undo } of unwind) {
+    let criticalFailed = false;
+    for (const { what, undo, critical } of unwind) {
+      // Once the document could not be restored, reopening the revision would
+      // make it contradict a feature that is still published.
+      if (criticalFailed) {
+        logger.error(
+          `Skipping rewind of ${what} for feature ${feature.id} revision ${revision.version}: an earlier critical step could not be reversed`,
+        );
+        continue;
+      }
       try {
         await undo();
       } catch (rewindErr) {
+        if (critical) criticalFailed = true;
         logger.error(
           rewindErr,
-          `Failed to rewind ${what} for feature ${feature.id} revision ${revision.version} after a failed publish — stopping rewind, everything not yet rewound stays at the published state`,
+          `Failed to rewind ${what} for feature ${feature.id} revision ${revision.version} after a failed publish${critical ? " — the feature stays at the published state" : " (satellite; continuing)"}`,
         );
-        break;
       }
     }
     throw err;

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -270,12 +270,38 @@ export class HoldoutModel extends BaseClass {
   }
 
   public async addExperimentToHoldout(holdoutId: string, experimentId: string) {
+    await this.addExperimentsToHoldout(holdoutId, [experimentId]);
+  }
+
+  // Batch form, so a publish reconciling several rules writes once.
+  public async addExperimentsToHoldout(
+    holdoutId: string,
+    experimentIds: string[],
+  ) {
+    if (!experimentIds.length) return;
     const holdout = await this.getLinkageTarget(holdoutId);
+    const added = Object.fromEntries(
+      experimentIds.map((id) => [id, { id, dateAdded: new Date() }]),
+    );
     await this.writeLinkage(holdout, {
-      linkedExperiments: {
-        ...holdout.linkedExperiments,
-        [experimentId]: { id: experimentId, dateAdded: new Date() },
-      },
+      // Existing entries win, so re-linking keeps the original `dateAdded`.
+      linkedExperiments: { ...added, ...holdout.linkedExperiments },
+    });
+  }
+
+  public async removeExperimentsFromHoldout(
+    holdoutId: string,
+    experimentIds: string[],
+  ) {
+    if (!experimentIds.length) return;
+    const holdout = await this.getLinkageTarget(holdoutId);
+    const drop = new Set(experimentIds);
+    await this.writeLinkage(holdout, {
+      linkedExperiments: Object.fromEntries(
+        Object.entries(holdout.linkedExperiments).filter(
+          ([id]) => !drop.has(id),
+        ),
+      ),
     });
   }
 

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -273,7 +273,6 @@ export class HoldoutModel extends BaseClass {
     await this.addExperimentsToHoldout(holdoutId, [experimentId]);
   }
 
-  // Batch form, so a publish reconciling several rules writes once.
   public async addExperimentsToHoldout(
     holdoutId: string,
     experimentIds: string[],

--- a/packages/back-end/src/revisions/bulkPublish/featureBulkAdapter.ts
+++ b/packages/back-end/src/revisions/bulkPublish/featureBulkAdapter.ts
@@ -357,6 +357,18 @@ export const featureBulkAdapter: BulkPublishableAdapter = {
       );
     }
 
+    // Same pre-mutation rule: planning is read-only, and its project check must
+    // refuse the publish before feature.version moves. Covers a rules-only
+    // publish too (mirrors publishRevision).
+    desired.holdoutExperimentLinkage = await planHoldoutExperimentLinkage(
+      context,
+      feature,
+      (mergeResult.holdout !== undefined
+        ? mergeResult.holdout?.id
+        : feature.holdout?.id) ?? null,
+      mergeResult.rules ?? feature.rules ?? [],
+    );
+
     // Ramp `create` actions run BEFORE the feature write: a schedule-creation
     // failure gates the publish, and the ids are stashed for compensation.
     desired.createdRampScheduleIds = await applyRampCreateActionsForRevision(
@@ -413,25 +425,13 @@ export const featureBulkAdapter: BulkPublishableAdapter = {
     }
 
     if (mergeResult.holdout !== undefined) {
-      // Guard already ran above (before any mutation) — skip the re-check.
-      await applyHoldoutSideEffects(
-        context,
-        { ...feature, rules: mergeResult.rules ?? feature.rules },
-        mergeResult.holdout,
-        { skipGuard: true },
-      );
+      // Guard already ran above, before any mutation.
+      await applyHoldoutSideEffects(context, feature, mergeResult.holdout, {
+        skipGuard: true,
+      });
     }
 
-    // Runs for a rules-only publish too (mirrors publishRevision).
-    desired.holdoutExperimentLinkage = await planHoldoutExperimentLinkage(
-      context,
-      feature,
-      (mergeResult.holdout !== undefined
-        ? mergeResult.holdout?.id
-        : feature.holdout?.id) ?? null,
-      mergeResult.rules ?? feature.rules ?? [],
-    );
-    for (const plan of desired.holdoutExperimentLinkage) {
+    for (const plan of desired.holdoutExperimentLinkage ?? []) {
       await applyHoldoutExperimentLinkage(context, plan);
     }
   },

--- a/packages/back-end/src/revisions/bulkPublish/featureBulkAdapter.ts
+++ b/packages/back-end/src/revisions/bulkPublish/featureBulkAdapter.ts
@@ -92,11 +92,6 @@ type FeatureDesiredState = {
    * nothing for compensation to reverse.
    */
   holdoutLinkage?: HoldoutLinkagePreImage | null;
-  /**
-   * Experiment-linkage plans for the holdouts this revision joins or leaves,
-   * computed read-only at plan time so compensation can reverse exactly what was
-   * written. Empty when the published rules already match.
-   */
   holdoutExperimentLinkage?: HoldoutExperimentLinkagePlan[];
 };
 
@@ -419,7 +414,6 @@ export const featureBulkAdapter: BulkPublishableAdapter = {
 
     if (mergeResult.holdout !== undefined) {
       // Guard already ran above (before any mutation) — skip the re-check.
-      // Feature side only; experiments are reconciled below.
       await applyHoldoutSideEffects(
         context,
         { ...feature, rules: mergeResult.rules ?? feature.rules },
@@ -428,8 +422,7 @@ export const featureBulkAdapter: BulkPublishableAdapter = {
       );
     }
 
-    // Experiment linkage is derived from published rules, so it runs for a
-    // rules-only publish too (mirrors publishRevision).
+    // Runs for a rules-only publish too (mirrors publishRevision).
     desired.holdoutExperimentLinkage = await planHoldoutExperimentLinkage(
       context,
       feature,

--- a/packages/back-end/src/revisions/bulkPublish/featureBulkAdapter.ts
+++ b/packages/back-end/src/revisions/bulkPublish/featureBulkAdapter.ts
@@ -4,6 +4,8 @@ import { FeatureRevisionInterface } from "shared/types/feature-revision";
 import type { SafeRolloutInterface } from "shared/validators";
 import { logger } from "back-end/src/util/logger";
 import {
+  applyHoldoutExperimentLinkage,
+  type HoldoutExperimentLinkagePlan,
   applyHoldoutSideEffects,
   assertHoldoutChangeAllowed,
   applyRampCreateActionsForRevision,
@@ -14,6 +16,8 @@ import {
   finalizeRampActionsAfterPublish,
   getFeature,
   type HoldoutLinkagePreImage,
+  planHoldoutExperimentLinkage,
+  reverseHoldoutExperimentLinkage,
   rewindHoldoutLinkage,
   rollbackCreatedRampSchedules,
   updateFeature,
@@ -88,6 +92,12 @@ type FeatureDesiredState = {
    * nothing for compensation to reverse.
    */
   holdoutLinkage?: HoldoutLinkagePreImage | null;
+  /**
+   * Experiment-linkage plans for the holdouts this revision joins or leaves,
+   * computed read-only at plan time so compensation can reverse exactly what was
+   * written. Empty when the published rules already match.
+   */
+  holdoutExperimentLinkage?: HoldoutExperimentLinkagePlan[];
 };
 
 function toRef(revision: FeatureRevisionInterface): BulkRevisionRef {
@@ -349,7 +359,6 @@ export const featureBulkAdapter: BulkPublishableAdapter = {
         context,
         feature,
         mergeResult.holdout,
-        mergeResult.rules ?? feature.rules ?? [],
       );
     }
 
@@ -410,14 +419,27 @@ export const featureBulkAdapter: BulkPublishableAdapter = {
 
     if (mergeResult.holdout !== undefined) {
       // Guard already ran above (before any mutation) — skip the re-check.
-      // Pass the POST-publish rules so experiments added in the same revision
-      // are enrolled (mirrors publishRevision).
+      // Feature side only; experiments are reconciled below.
       await applyHoldoutSideEffects(
         context,
         { ...feature, rules: mergeResult.rules ?? feature.rules },
         mergeResult.holdout,
         { skipGuard: true },
       );
+    }
+
+    // Experiment linkage is derived from published rules, so it runs for a
+    // rules-only publish too (mirrors publishRevision).
+    desired.holdoutExperimentLinkage = await planHoldoutExperimentLinkage(
+      context,
+      feature,
+      (mergeResult.holdout !== undefined
+        ? mergeResult.holdout?.id
+        : feature.holdout?.id) ?? null,
+      mergeResult.rules ?? feature.rules ?? [],
+    );
+    for (const plan of desired.holdoutExperimentLinkage) {
+      await applyHoldoutExperimentLinkage(context, plan);
     }
   },
 
@@ -487,6 +509,19 @@ export const featureBulkAdapter: BulkPublishableAdapter = {
     // stamp the old holdout onto experiments this revision newly added. Every
     // step converges on a captured value, so it is an idempotent no-op if the
     // forward write never landed and repairs the half if it landed partway.
+    for (const plan of desired.holdoutExperimentLinkage ?? []) {
+      try {
+        await reverseHoldoutExperimentLinkage(context, plan);
+      } catch (e) {
+        reversalFailures.push("holdout experiments");
+        logger.error(
+          e,
+          `bulk publish compensation: failed to reverse experiment linkage for holdout ${plan.holdoutId} on feature ${feature.id}`,
+        );
+      }
+    }
+    assertNoReversalFailures();
+
     if (desired.holdoutLinkage) {
       try {
         await rewindHoldoutLinkage(context, desired.holdoutLinkage);

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2897,17 +2897,13 @@ export async function toExperimentApiInterface(
     precomputedUnitDimensionIds: experiment.precomputedUnitDimensionIds ?? [],
     defaultDashboardId: experiment.defaultDashboardId,
     templateId: experiment.templateId || undefined,
-    // `statusUpdateSchedule` is a nested Mongoose path, so a document with no
-    // schedule hydrates it as `{}` rather than undefined — truthy, with no
-    // `startAt`. Keying off `startAt` instead of the object keeps that from
-    // throwing, which would fail any write that serializes the experiment for
-    // its update event.
+    // Nested Mongoose path: a document with no schedule hydrates it as `{}`, so
+    // key off `startAt` rather than the object.
     statusUpdateSchedule: experiment.statusUpdateSchedule?.startAt
       ? {
           startAt: experiment.statusUpdateSchedule.startAt.toISOString(),
         }
-      : // An explicit null means "cleared" and is distinct from absent, so it is
-        // preserved; a hydrated `{}` collapses to absent.
+      : // null means "cleared", distinct from absent.
         experiment.statusUpdateSchedule === null
         ? null
         : undefined,

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2897,11 +2897,20 @@ export async function toExperimentApiInterface(
     precomputedUnitDimensionIds: experiment.precomputedUnitDimensionIds ?? [],
     defaultDashboardId: experiment.defaultDashboardId,
     templateId: experiment.templateId || undefined,
-    statusUpdateSchedule: experiment.statusUpdateSchedule
+    // `statusUpdateSchedule` is a nested Mongoose path, so a document with no
+    // schedule hydrates it as `{}` rather than undefined — truthy, with no
+    // `startAt`. Keying off `startAt` instead of the object keeps that from
+    // throwing, which would fail any write that serializes the experiment for
+    // its update event.
+    statusUpdateSchedule: experiment.statusUpdateSchedule?.startAt
       ? {
           startAt: experiment.statusUpdateSchedule.startAt.toISOString(),
         }
-      : experiment.statusUpdateSchedule,
+      : // An explicit null means "cleared" and is distinct from absent, so it is
+        // preserved; a hydrated `{}` collapses to absent.
+        experiment.statusUpdateSchedule === null
+        ? null
+        : undefined,
     // Only "start" is produced for experiments; updateExperimentStatus.ts
     // clears any other type before it can be observed. Filter defensively
     // so the API response always matches the documented schema.

--- a/packages/back-end/src/services/holdout-availability.ts
+++ b/packages/back-end/src/services/holdout-availability.ts
@@ -3,6 +3,29 @@ import { ApiReqContext } from "back-end/types/api";
 import { ReqContext } from "back-end/types/request";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 
+// A Holdout with no Projects is global; otherwise the linked entity's Project
+// must be one of them.
+export function isHoldoutAvailableForProject(
+  holdout: Pick<HoldoutInterface, "projects">,
+  project: string | undefined,
+): boolean {
+  return (
+    holdout.projects.length === 0 ||
+    (!!project && holdout.projects.includes(project))
+  );
+}
+
+export function assertHoldoutAvailableForProject(
+  holdout: Pick<HoldoutInterface, "projects" | "name">,
+  project: string | undefined,
+): void {
+  if (!isHoldoutAvailableForProject(holdout, project)) {
+    throw new BadRequestError(
+      `Holdout "${holdout.name}" is not available in the selected Project.`,
+    );
+  }
+}
+
 export async function getHoldoutAvailableForProject({
   context,
   holdoutId,
@@ -23,13 +46,6 @@ export async function getHoldoutAvailableForProject({
     throw new NotFoundError("Holdout not found");
   }
 
-  const available =
-    holdout.projects.length === 0 ||
-    (!!project && holdout.projects.includes(project));
-  if (!available) {
-    throw new BadRequestError(
-      `Holdout "${holdout.name}" is not available in the selected Project.`,
-    );
-  }
+  assertHoldoutAvailableForProject(holdout, project);
   return holdout;
 }

--- a/packages/back-end/src/services/holdout-availability.ts
+++ b/packages/back-end/src/services/holdout-availability.ts
@@ -3,8 +3,6 @@ import { ApiReqContext } from "back-end/types/api";
 import { ReqContext } from "back-end/types/request";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
 
-// A Holdout with no Projects is global; otherwise the linked entity's Project
-// must be one of them.
 export function isHoldoutAvailableForProject(
   holdout: Pick<HoldoutInterface, "projects">,
   project: string | undefined,

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -50,17 +50,12 @@ export async function resolveHoldoutExperimentToLink({
   feature,
   experiment,
   effectiveHoldout,
-  // `postFeatureExperimentRefRule` tolerates the experiment already being linked
-  // to *this* feature (create-from-experiment); the other call sites reject any
-  // pre-existing linked feature.
-  allowExistingLinkToThisFeature = false,
   makeError = (message: string) => new Error(message),
 }: {
   context: ReqContext | ApiReqContext;
   feature: FeatureInterface;
   experiment: ExperimentInterface;
   effectiveHoldout: { id: string } | null | undefined;
-  allowExistingLinkToThisFeature?: boolean;
   makeError?: (message: string) => Error;
 }): Promise<void> {
   if (effectiveHoldout?.id) {
@@ -98,11 +93,14 @@ export async function resolveHoldoutExperimentToLink({
           `Cannot add experiment rule: this feature flag uses a holdout, so the experiment must be in "draft" status (currently "${experiment.status ?? "unknown"}").`,
         );
       }
+      // A link to THIS feature never counts: linkedFeatures is deliberately
+      // sticky (see syncFeatureExperimentLinkages — "removal is user-driven"),
+      // so an earlier draft on this same feature leaves one behind even when
+      // discarded. Counting it made re-adding the rule impossible, with advice
+      // the UI gives no way to follow.
       const expHasLinkedChanges =
-        (allowExistingLinkToThisFeature
-          ? (experiment.linkedFeatures?.some((fid) => fid !== feature.id) ??
-            false)
-          : (experiment.linkedFeatures?.length ?? 0) > 0) ||
+        (experiment.linkedFeatures?.some((fid) => fid !== feature.id) ??
+          false) ||
         experiment.hasURLRedirects ||
         experiment.hasVisualChangesets;
       if (expHasLinkedChanges) {

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -38,9 +38,8 @@ export async function canLinkExperimentToHoldoutFromFeatures(
  *
  * `effectiveHoldout` is the holdout the rule will publish under, resolved by the
  * caller (the live `feature.holdout`, or the target revision's holdout when
- * posting to a different draft). Validation only — the linkage itself is derived
- * from published rules at publish time, so an abandoned draft leaves nothing to
- * unwind. The publish re-checks these constraints against live state.
+ * posting to a different draft). Validation only; the publish re-checks these
+ * against live state.
  *
  * Incompatibilities throw via `makeError`, so REST handlers can surface a 400
  * (`BadRequestError`) while controllers get a plain `Error` (the default).
@@ -75,8 +74,7 @@ export async function resolveHoldoutExperimentToLink({
     // Not yet linked: validate it can join the holdout, then signal the caller
     // to perform the link.
     if (!experiment.holdoutId) {
-      // Re-checked at publish, where it is what actually gates the linkage —
-      // here so the rule is refused at edit time rather than at publish.
+      // Re-checked at publish, which is what actually gates the linkage.
       const holdout = await context.models.holdout.getByIdForLinkage(
         effectiveHoldout.id,
       );
@@ -93,11 +91,9 @@ export async function resolveHoldoutExperimentToLink({
           `Cannot add experiment rule: this feature flag uses a holdout, so the experiment must be in "draft" status (currently "${experiment.status ?? "unknown"}").`,
         );
       }
-      // A link to THIS feature never counts: linkedFeatures is deliberately
-      // sticky (see syncFeatureExperimentLinkages — "removal is user-driven"),
-      // so an earlier draft on this same feature leaves one behind even when
-      // discarded. Counting it made re-adding the rule impossible, with advice
-      // the UI gives no way to follow.
+      // Self-links never count: linkedFeatures is deliberately sticky (see
+      // syncFeatureExperimentLinkages), so a discarded draft on this same feature
+      // leaves one behind, and counting it blocked re-adding the rule.
       const expHasLinkedChanges =
         (experiment.linkedFeatures?.some((fid) => fid !== feature.id) ??
           false) ||

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -13,41 +13,10 @@ import {
   removeHoldoutFromFeature,
 } from "back-end/src/models/FeatureModel";
 import { getEnvironmentIdsFromOrg } from "back-end/src/services/organizations";
+import { isHoldoutAvailableForProject } from "back-end/src/services/holdout-availability";
 import { getAffectedSDKPayloadKeys } from "back-end/src/util/holdouts";
 import { queueSDKPayloadRefresh } from "back-end/src/services/features";
-import { getHoldoutAvailableForProject } from "back-end/src/services/holdout-availability";
 import { BadRequestError } from "back-end/src/util/errors";
-
-/**
- * Eagerly link an experiment into a holdout: set `experiment.holdoutId` and add
- * the experiment to the holdout's `linkedExperiments` map. The write-side
- * companion to `resolveHoldoutExperimentToLink` — call it with the experiment
- * that resolver returned.
- *
- * Callers that compensate on downstream failure should record the experiment
- * and holdout ids BEFORE calling: the standard rollback (clear `holdoutId`,
- * remove the map entry if present) is idempotent, so compensating a write that
- * never happened is harmless, while the reverse ordering would leave a
- * mid-failure (experiment written, holdout write failed) uncompensated.
- */
-export async function linkExperimentToHoldout(
-  context: ReqContext | ApiReqContext,
-  experiment: ExperimentInterface,
-  holdoutId: string,
-): Promise<void> {
-  await getHoldoutAvailableForProject({
-    context,
-    holdoutId,
-    project: experiment.project,
-    bypassReadPermissionChecks: true,
-  });
-  await updateExperiment({
-    context,
-    experiment,
-    changes: { holdoutId },
-  });
-  await context.models.holdout.addExperimentToHoldout(holdoutId, experiment.id);
-}
 
 export async function canLinkExperimentToHoldoutFromFeatures(
   context: ReqContext | ApiReqContext,
@@ -69,10 +38,9 @@ export async function canLinkExperimentToHoldoutFromFeatures(
  *
  * `effectiveHoldout` is the holdout the rule will publish under, resolved by the
  * caller (the live `feature.holdout`, or the target revision's holdout when
- * posting to a different draft). Given the referenced `experiment`, this
- * enforces the constraints for attaching an experiment to a holdout and returns
- * the experiment that should be eagerly linked, or `null` when no linking is
- * needed (experiment already in this holdout, or neither side uses a holdout).
+ * posting to a different draft). Validation only — the linkage itself is derived
+ * from published rules at publish time, so an abandoned draft leaves nothing to
+ * unwind. The publish re-checks these constraints against live state.
  *
  * Incompatibilities throw via `makeError`, so REST handlers can surface a 400
  * (`BadRequestError`) while controllers get a plain `Error` (the default).
@@ -94,7 +62,7 @@ export async function resolveHoldoutExperimentToLink({
   effectiveHoldout: { id: string } | null | undefined;
   allowExistingLinkToThisFeature?: boolean;
   makeError?: (message: string) => Error;
-}): Promise<ExperimentInterface | null> {
+}): Promise<void> {
   if (effectiveHoldout?.id) {
     // Experiment already belongs to a different holdout — refuse the mismatch.
     if (experiment.holdoutId && experiment.holdoutId !== effectiveHoldout.id) {
@@ -112,6 +80,19 @@ export async function resolveHoldoutExperimentToLink({
     // Not yet linked: validate it can join the holdout, then signal the caller
     // to perform the link.
     if (!experiment.holdoutId) {
+      // Re-checked at publish, where it is what actually gates the linkage —
+      // here so the rule is refused at edit time rather than at publish.
+      const holdout = await context.models.holdout.getByIdForLinkage(
+        effectiveHoldout.id,
+      );
+      if (
+        holdout &&
+        !isHoldoutAvailableForProject(holdout, experiment.project)
+      ) {
+        throw makeError(
+          `Cannot add experiment rule: holdout "${holdout.name}" is not available in the experiment's Project.`,
+        );
+      }
       if (experiment.status !== "draft") {
         throw makeError(
           `Cannot add experiment rule: this feature flag uses a holdout, so the experiment must be in "draft" status (currently "${experiment.status ?? "unknown"}").`,
@@ -129,11 +110,11 @@ export async function resolveHoldoutExperimentToLink({
           `Cannot add experiment rule: this feature flag uses a holdout, but the experiment already has linked Feature Flags, URL redirects, or visual changesets. Unlink them first.`,
         );
       }
-      return experiment;
+      return;
     }
 
     // Already linked to this same holdout: nothing to do.
-    return null;
+    return;
   }
 
   // Feature is not in a holdout, but the experiment already belongs to one.
@@ -145,8 +126,6 @@ export async function resolveHoldoutExperimentToLink({
       `Cannot add experiment rule: this experiment belongs to holdout "${expHoldout?.name || experiment.holdoutId}", but this feature flag is not in a holdout. Add the feature flag to that holdout first, then add the experiment.`,
     );
   }
-
-  return null;
 }
 
 /**

--- a/packages/back-end/src/util/featureExperimentSync.ts
+++ b/packages/back-end/src/util/featureExperimentSync.ts
@@ -1,5 +1,5 @@
+import { getExperimentIdsFromRules } from "shared/util";
 import { FeatureRevisionInterface } from "shared/types/feature-revision";
-import { ExperimentRefRule } from "shared/validators";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import {
@@ -11,28 +11,6 @@ import {
 } from "back-end/src/models/ExperimentModel";
 import { logger } from "back-end/src/util/logger";
 import { promiseAllChunks } from "back-end/src/util/promise";
-
-function getExperimentIdsFromRules(
-  rules: FeatureRevisionInterface["rules"] | unknown,
-): string[] {
-  // Accept v2 (FeatureRule[]) and legacy v1 (Record<envId, FeatureRule[]>):
-  // raw-doc readers (e.g. getLinkageSyncRevisionSummaries) hand us v1 shapes
-  // until the migration completes.
-  const flat: unknown[] = Array.isArray(rules)
-    ? rules
-    : rules && typeof rules === "object"
-      ? Object.values(rules as Record<string, unknown[]>).flat()
-      : [];
-  return flat
-    .filter(
-      (r): r is ExperimentRefRule =>
-        !!r &&
-        typeof r === "object" &&
-        (r as { type?: string }).type === "experiment-ref",
-    )
-    .map((r) => r.experimentId)
-    .filter((id): id is string => !!id);
-}
 
 /**
  * Reconciles experiment.linkedFeatures and experiment.pendingFeatureDrafts

--- a/packages/back-end/test/api/features/holdout-publish.test.ts
+++ b/packages/back-end/test/api/features/holdout-publish.test.ts
@@ -297,6 +297,24 @@ describe("holdout publish", () => {
       .set("Authorization", "Bearer foo");
 
     expect(res.status).toBe(200);
+
+    // Nothing is linked yet: an abandoned draft must leave no enrollment behind.
+    const draftExperiment = await mongoose.connection
+      .collection("experiments")
+      .findOne({ id: "exp_new" });
+    expect(draftExperiment?.holdoutId ?? "").toBe("");
+    const draftHoldout = await mongoose.connection
+      .collection("holdouts")
+      .findOne({ id: "hld_existing" });
+    expect(draftHoldout?.linkedExperiments?.exp_new).toBeFalsy();
+
+    const publishRes = await request(app)
+      .post("/api/v1/features/flag_existing_holdout/revisions/2/publish")
+      .send({})
+      .set("Authorization", "Bearer foo");
+    expect(publishRes.status).toBe(200);
+
+    // Publishing links it, still without holdout access.
     const experiment = await mongoose.connection
       .collection("experiments")
       .findOne({ id: "exp_new" });

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -3858,50 +3858,44 @@ export function getApiFeatureAllEnvs(feature: ApiFeature) {
   return Object.keys(feature.environments);
 }
 
-// Experiment ids an `experiment-ref` rule set enrolls in a holdout.
-export function getExperimentIdsFromRules(rules: FeatureRule[]): string[] {
+// Accepts legacy v1 (Record<env, rules>) as well as v2 arrays: raw-doc readers
+// hand over v1 shapes until the migration completes.
+export function getExperimentIdsFromRules(rules: unknown): string[] {
   return Array.from(
-    new Set(rules.filter(isExperimentRefRule).map((r) => r.experimentId)),
+    new Set(
+      naiveFlattenV1Rules(rules)
+        .filter(isExperimentRefRule)
+        .map((r) => r.experimentId)
+        .filter(Boolean),
+    ),
   );
 }
 
 /**
- * The holdout `linkedExperiments` delta a publish should apply for one feature,
- * derived from published state only.
- *
- * Unlinking is doubly constrained, because the holdout's experiment list is NOT
- * merely a projection of feature rules — an experiment can be added to a holdout
- * directly, with no feature referencing it. So a candidate must both have been
- * contributed by THIS feature (present in its previous rules) and be referenced
- * by nothing else. Anything else in the list belongs to another writer and is
- * left alone.
+ * Unlinking is doubly bounded: a holdout's experiment list is not only a
+ * projection of feature rules — experiments can be added to a holdout directly —
+ * so a candidate must both have been contributed by THIS feature and be
+ * referenced by nothing else. Anything else belongs to another writer.
  */
 export function computeHoldoutExperimentLinkageDelta({
   publishedRules,
   previousRules,
-  hasHoldout,
   linkedExperimentIds,
   experimentIdsReferencedElsewhere,
 }: {
   publishedRules: FeatureRule[];
-  // The feature's rules before this publish: the only experiments it can be said
-  // to have contributed, and so the only ones it may withdraw.
   previousRules: FeatureRule[];
-  // False when this publish leaves the feature with no holdout.
-  hasHoldout: boolean;
-  // The holdout's current `linkedExperiments` keys.
   linkedExperimentIds: string[];
-  // Experiment ids the holdout's OTHER features still reference in live rules.
   experimentIdsReferencedElsewhere: string[];
 }): { toLink: string[]; toUnlink: string[] } {
-  const desired = hasHoldout ? getExperimentIdsFromRules(publishedRules) : [];
+  const desired = getExperimentIdsFromRules(publishedRules);
   const desiredSet = new Set(desired);
-  const linkedSet = new Set(linkedExperimentIds);
+  const linked = new Set(linkedExperimentIds);
   const elsewhere = new Set(experimentIdsReferencedElsewhere);
   const contributed = new Set(getExperimentIdsFromRules(previousRules));
 
   return {
-    toLink: desired.filter((id) => !linkedSet.has(id)),
+    toLink: desired.filter((id) => !linked.has(id)),
     toUnlink: linkedExperimentIds.filter(
       (id) => contributed.has(id) && !desiredSet.has(id) && !elsewhere.has(id),
     ),

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -3857,3 +3857,45 @@ export function getApiFeatureEnabledEnvs(feature: ApiFeature) {
 export function getApiFeatureAllEnvs(feature: ApiFeature) {
   return Object.keys(feature.environments);
 }
+
+// Experiment ids an `experiment-ref` rule set enrolls in a holdout.
+export function getExperimentIdsFromRules(rules: FeatureRule[]): string[] {
+  return Array.from(
+    new Set(rules.filter(isExperimentRefRule).map((r) => r.experimentId)),
+  );
+}
+
+/**
+ * The holdout `linkedExperiments` delta a publish should apply for one feature,
+ * derived from published state only.
+ *
+ * Unlinking is deliberately conservative: an experiment stays linked while any
+ * other feature in the same holdout still references it, so publishing one
+ * feature can never revoke a holdout membership another feature is relying on.
+ */
+export function computeHoldoutExperimentLinkageDelta({
+  publishedRules,
+  hasHoldout,
+  linkedExperimentIds,
+  experimentIdsReferencedElsewhere,
+}: {
+  publishedRules: FeatureRule[];
+  // False when this publish leaves the feature with no holdout.
+  hasHoldout: boolean;
+  // The holdout's current `linkedExperiments` keys.
+  linkedExperimentIds: string[];
+  // Experiment ids the holdout's OTHER features still reference in live rules.
+  experimentIdsReferencedElsewhere: string[];
+}): { toLink: string[]; toUnlink: string[] } {
+  const desired = hasHoldout ? getExperimentIdsFromRules(publishedRules) : [];
+  const desiredSet = new Set(desired);
+  const linkedSet = new Set(linkedExperimentIds);
+  const elsewhere = new Set(experimentIdsReferencedElsewhere);
+
+  return {
+    toLink: desired.filter((id) => !linkedSet.has(id)),
+    toUnlink: linkedExperimentIds.filter(
+      (id) => !desiredSet.has(id) && !elsewhere.has(id),
+    ),
+  };
+}

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -3869,17 +3869,24 @@ export function getExperimentIdsFromRules(rules: FeatureRule[]): string[] {
  * The holdout `linkedExperiments` delta a publish should apply for one feature,
  * derived from published state only.
  *
- * Unlinking is deliberately conservative: an experiment stays linked while any
- * other feature in the same holdout still references it, so publishing one
- * feature can never revoke a holdout membership another feature is relying on.
+ * Unlinking is doubly constrained, because the holdout's experiment list is NOT
+ * merely a projection of feature rules — an experiment can be added to a holdout
+ * directly, with no feature referencing it. So a candidate must both have been
+ * contributed by THIS feature (present in its previous rules) and be referenced
+ * by nothing else. Anything else in the list belongs to another writer and is
+ * left alone.
  */
 export function computeHoldoutExperimentLinkageDelta({
   publishedRules,
+  previousRules,
   hasHoldout,
   linkedExperimentIds,
   experimentIdsReferencedElsewhere,
 }: {
   publishedRules: FeatureRule[];
+  // The feature's rules before this publish: the only experiments it can be said
+  // to have contributed, and so the only ones it may withdraw.
+  previousRules: FeatureRule[];
   // False when this publish leaves the feature with no holdout.
   hasHoldout: boolean;
   // The holdout's current `linkedExperiments` keys.
@@ -3891,11 +3898,12 @@ export function computeHoldoutExperimentLinkageDelta({
   const desiredSet = new Set(desired);
   const linkedSet = new Set(linkedExperimentIds);
   const elsewhere = new Set(experimentIdsReferencedElsewhere);
+  const contributed = new Set(getExperimentIdsFromRules(previousRules));
 
   return {
     toLink: desired.filter((id) => !linkedSet.has(id)),
     toUnlink: linkedExperimentIds.filter(
-      (id) => !desiredSet.has(id) && !elsewhere.has(id),
+      (id) => contributed.has(id) && !desiredSet.has(id) && !elsewhere.has(id),
     ),
   };
 }

--- a/packages/shared/test/util/holdout-linkage.test.ts
+++ b/packages/shared/test/util/holdout-linkage.test.ts
@@ -48,7 +48,6 @@ describe("computeHoldoutExperimentLinkageDelta", () => {
       computeHoldoutExperimentLinkageDelta({
         publishedRules: [expRule("exp_a"), expRule("exp_b")],
         previousRules: [expRule("exp_a")],
-        hasHoldout: true,
         linkedExperimentIds: ["exp_a"],
         experimentIdsReferencedElsewhere: [],
       }),
@@ -60,7 +59,6 @@ describe("computeHoldoutExperimentLinkageDelta", () => {
       computeHoldoutExperimentLinkageDelta({
         publishedRules: [expRule("exp_a")],
         previousRules: [expRule("exp_a"), expRule("exp_b")],
-        hasHoldout: true,
         linkedExperimentIds: ["exp_a", "exp_b"],
         experimentIdsReferencedElsewhere: [],
       }),
@@ -75,19 +73,18 @@ describe("computeHoldoutExperimentLinkageDelta", () => {
       computeHoldoutExperimentLinkageDelta({
         publishedRules: [],
         previousRules: [expRule("exp_a"), expRule("exp_b")],
-        hasHoldout: true,
         linkedExperimentIds: ["exp_a", "exp_b"],
         experimentIdsReferencedElsewhere: ["exp_a"],
       }),
     ).toEqual({ toLink: [], toUnlink: ["exp_b"] });
   });
 
+  // Leaving the holdout is expressed by publishing no rules under it.
   it("unlinks everything unreferenced when the feature leaves the holdout", () => {
     expect(
       computeHoldoutExperimentLinkageDelta({
-        publishedRules: [expRule("exp_a")],
+        publishedRules: [],
         previousRules: [expRule("exp_a"), expRule("exp_b")],
-        hasHoldout: false,
         linkedExperimentIds: ["exp_a", "exp_b"],
         experimentIdsReferencedElsewhere: [],
       }),
@@ -99,7 +96,6 @@ describe("computeHoldoutExperimentLinkageDelta", () => {
       computeHoldoutExperimentLinkageDelta({
         publishedRules: [expRule("exp_a")],
         previousRules: [expRule("exp_a")],
-        hasHoldout: true,
         linkedExperimentIds: ["exp_a"],
         experimentIdsReferencedElsewhere: [],
       }),
@@ -111,7 +107,6 @@ describe("computeHoldoutExperimentLinkageDelta", () => {
       computeHoldoutExperimentLinkageDelta({
         publishedRules: [forceRule("r1")],
         previousRules: [forceRule("r1")],
-        hasHoldout: true,
         linkedExperimentIds: [],
         experimentIdsReferencedElsewhere: [],
       }),
@@ -126,7 +121,6 @@ describe("computeHoldoutExperimentLinkageDelta", () => {
       computeHoldoutExperimentLinkageDelta({
         publishedRules: [expRule("exp_mine")],
         previousRules: [expRule("exp_mine")],
-        hasHoldout: true,
         linkedExperimentIds: ["exp_mine", "exp_added_directly"],
         experimentIdsReferencedElsewhere: [],
       }),
@@ -138,7 +132,6 @@ describe("computeHoldoutExperimentLinkageDelta", () => {
       computeHoldoutExperimentLinkageDelta({
         publishedRules: [],
         previousRules: [expRule("exp_mine")],
-        hasHoldout: false,
         linkedExperimentIds: ["exp_mine", "exp_added_directly"],
         experimentIdsReferencedElsewhere: [],
       }),

--- a/packages/shared/test/util/holdout-linkage.test.ts
+++ b/packages/shared/test/util/holdout-linkage.test.ts
@@ -1,0 +1,114 @@
+import {
+  computeHoldoutExperimentLinkageDelta,
+  getExperimentIdsFromRules,
+} from "../../src/util/features";
+import { FeatureRule } from "../../types/feature";
+
+function expRule(experimentId: string, id = experimentId): FeatureRule {
+  return {
+    id,
+    type: "experiment-ref",
+    experimentId,
+    variations: [],
+    enabled: true,
+    description: "",
+  } as unknown as FeatureRule;
+}
+
+function forceRule(id: string): FeatureRule {
+  return {
+    id,
+    type: "force",
+    value: "true",
+    enabled: true,
+    description: "",
+  } as unknown as FeatureRule;
+}
+
+describe("getExperimentIdsFromRules", () => {
+  it("returns only experiment-ref ids, deduped", () => {
+    expect(
+      getExperimentIdsFromRules([
+        expRule("exp_a", "r1"),
+        forceRule("r2"),
+        expRule("exp_a", "r3"),
+        expRule("exp_b", "r4"),
+      ]),
+    ).toEqual(["exp_a", "exp_b"]);
+  });
+
+  it("returns nothing for an empty rule set", () => {
+    expect(getExperimentIdsFromRules([])).toEqual([]);
+  });
+});
+
+describe("computeHoldoutExperimentLinkageDelta", () => {
+  it("links experiments the published rules added", () => {
+    expect(
+      computeHoldoutExperimentLinkageDelta({
+        publishedRules: [expRule("exp_a"), expRule("exp_b")],
+        hasHoldout: true,
+        linkedExperimentIds: ["exp_a"],
+        experimentIdsReferencedElsewhere: [],
+      }),
+    ).toEqual({ toLink: ["exp_b"], toUnlink: [] });
+  });
+
+  it("unlinks experiments the published rules dropped", () => {
+    expect(
+      computeHoldoutExperimentLinkageDelta({
+        publishedRules: [expRule("exp_a")],
+        hasHoldout: true,
+        linkedExperimentIds: ["exp_a", "exp_b"],
+        experimentIdsReferencedElsewhere: [],
+      }),
+    ).toEqual({ toLink: [], toUnlink: ["exp_b"] });
+  });
+
+  // The case that makes a blind scrub unsafe: another feature in the same
+  // holdout still references the experiment, so publishing this one must not
+  // revoke a membership that feature is relying on.
+  it("keeps an experiment another feature still references", () => {
+    expect(
+      computeHoldoutExperimentLinkageDelta({
+        publishedRules: [],
+        hasHoldout: true,
+        linkedExperimentIds: ["exp_a", "exp_b"],
+        experimentIdsReferencedElsewhere: ["exp_a"],
+      }),
+    ).toEqual({ toLink: [], toUnlink: ["exp_b"] });
+  });
+
+  it("unlinks everything unreferenced when the feature leaves the holdout", () => {
+    expect(
+      computeHoldoutExperimentLinkageDelta({
+        publishedRules: [expRule("exp_a")],
+        hasHoldout: false,
+        linkedExperimentIds: ["exp_a", "exp_b"],
+        experimentIdsReferencedElsewhere: [],
+      }),
+    ).toEqual({ toLink: [], toUnlink: ["exp_a", "exp_b"] });
+  });
+
+  it("is a no-op when published rules already match the linkage", () => {
+    expect(
+      computeHoldoutExperimentLinkageDelta({
+        publishedRules: [expRule("exp_a")],
+        hasHoldout: true,
+        linkedExperimentIds: ["exp_a"],
+        experimentIdsReferencedElsewhere: [],
+      }),
+    ).toEqual({ toLink: [], toUnlink: [] });
+  });
+
+  it("ignores non-experiment rules", () => {
+    expect(
+      computeHoldoutExperimentLinkageDelta({
+        publishedRules: [forceRule("r1")],
+        hasHoldout: true,
+        linkedExperimentIds: [],
+        experimentIdsReferencedElsewhere: [],
+      }),
+    ).toEqual({ toLink: [], toUnlink: [] });
+  });
+});

--- a/packages/shared/test/util/holdout-linkage.test.ts
+++ b/packages/shared/test/util/holdout-linkage.test.ts
@@ -47,6 +47,7 @@ describe("computeHoldoutExperimentLinkageDelta", () => {
     expect(
       computeHoldoutExperimentLinkageDelta({
         publishedRules: [expRule("exp_a"), expRule("exp_b")],
+        previousRules: [expRule("exp_a")],
         hasHoldout: true,
         linkedExperimentIds: ["exp_a"],
         experimentIdsReferencedElsewhere: [],
@@ -58,6 +59,7 @@ describe("computeHoldoutExperimentLinkageDelta", () => {
     expect(
       computeHoldoutExperimentLinkageDelta({
         publishedRules: [expRule("exp_a")],
+        previousRules: [expRule("exp_a"), expRule("exp_b")],
         hasHoldout: true,
         linkedExperimentIds: ["exp_a", "exp_b"],
         experimentIdsReferencedElsewhere: [],
@@ -72,6 +74,7 @@ describe("computeHoldoutExperimentLinkageDelta", () => {
     expect(
       computeHoldoutExperimentLinkageDelta({
         publishedRules: [],
+        previousRules: [expRule("exp_a"), expRule("exp_b")],
         hasHoldout: true,
         linkedExperimentIds: ["exp_a", "exp_b"],
         experimentIdsReferencedElsewhere: ["exp_a"],
@@ -83,6 +86,7 @@ describe("computeHoldoutExperimentLinkageDelta", () => {
     expect(
       computeHoldoutExperimentLinkageDelta({
         publishedRules: [expRule("exp_a")],
+        previousRules: [expRule("exp_a"), expRule("exp_b")],
         hasHoldout: false,
         linkedExperimentIds: ["exp_a", "exp_b"],
         experimentIdsReferencedElsewhere: [],
@@ -94,6 +98,7 @@ describe("computeHoldoutExperimentLinkageDelta", () => {
     expect(
       computeHoldoutExperimentLinkageDelta({
         publishedRules: [expRule("exp_a")],
+        previousRules: [expRule("exp_a")],
         hasHoldout: true,
         linkedExperimentIds: ["exp_a"],
         experimentIdsReferencedElsewhere: [],
@@ -105,10 +110,38 @@ describe("computeHoldoutExperimentLinkageDelta", () => {
     expect(
       computeHoldoutExperimentLinkageDelta({
         publishedRules: [forceRule("r1")],
+        previousRules: [forceRule("r1")],
         hasHoldout: true,
         linkedExperimentIds: [],
         experimentIdsReferencedElsewhere: [],
       }),
     ).toEqual({ toLink: [], toUnlink: [] });
+  });
+
+  // Regression: an experiment can be added to a holdout directly, with no
+  // feature referencing it. Publishing an unrelated feature must not withdraw
+  // it just because no feature's rules mention it.
+  it("leaves experiments this feature never contributed alone", () => {
+    expect(
+      computeHoldoutExperimentLinkageDelta({
+        publishedRules: [expRule("exp_mine")],
+        previousRules: [expRule("exp_mine")],
+        hasHoldout: true,
+        linkedExperimentIds: ["exp_mine", "exp_added_directly"],
+        experimentIdsReferencedElsewhere: [],
+      }),
+    ).toEqual({ toLink: [], toUnlink: [] });
+  });
+
+  it("withdraws only its own contribution when it leaves the holdout", () => {
+    expect(
+      computeHoldoutExperimentLinkageDelta({
+        publishedRules: [],
+        previousRules: [expRule("exp_mine")],
+        hasHoldout: false,
+        linkedExperimentIds: ["exp_mine", "exp_added_directly"],
+        experimentIdsReferencedElsewhere: [],
+      }),
+    ).toEqual({ toLink: [], toUnlink: ["exp_mine"] });
   });
 });


### PR DESCRIPTION
Adding an experiment rule to a draft immediately enrolled the experiment in the feature's holdout, on both the experiment and the holdout. Editing the rule away or discarding the draft left that enrollment behind, so a holdout kept an experiment — and stayed in the SDK payload — for a rule that was never published and no longer exists. Publishing is now what changes linkage, so an abandoned draft leaves nothing behind.

## What changes

- **Linkage is derived from published rules.** It is reconciled on every publish, including a rules-only change, which is how a rule added to an already-held feature gets enrolled.
- **Unlinking is bounded by what the feature itself contributed** and skips anything another feature in the holdout still references. A holdout's experiment list is not only a projection of feature rules — experiments can be added to a holdout directly — so publishing one feature can never withdraw someone else's membership.
- **Leaving a holdout drops the experiments the feature brought.** Previously the feature was unlinked but its experiments stayed enrolled, because the guard that should force detaching them first reads post-publish rules and a draft can remove the holdout and the rule together.
- **Re-adding an experiment rule after discarding a draft works again.** It was refused with "the experiment already has linked Feature Flags — unlink them first", naming a link to the feature being edited, which the UI gives no way to remove.
- **One owner for experiment linkage.** The holdout transition keeps the feature side; the publish reconcile handles joining, leaving, and rule changes alike. Bulk publish plans and compensates it the same way.
- **A failed publish rewinds further.** The steps that decide what is live — the feature document and revision status — no longer get abandoned because a satellite like ramp schedules or holdout linkage could not be reversed.

Also fixes a crash this surfaced: `statusUpdateSchedule` is a nested Mongoose path, so an experiment with no schedule hydrates it as `{}` rather than undefined, and serializing the experiment for its update event threw on the missing `startAt`. That failed any publish which wrote an experiment.

## Testing

Verified against a real dataset — draft add, discard, re-add, publish, rule removal, and revert — checking the holdout and experiment documents at each step, with membership counts confirming nothing collateral moved. Unit tests cover the linkage delta, including the multi-feature and added-directly cases.
