### PR TITLE
fix: use phase-specific variations in experiment API traffic splits

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2717,6 +2717,19 @@ function getExperimentMetric(
   return ret;
 }
 
+export function getExperimentPhaseTrafficSplit(
+  experiment: ExperimentInterface,
+  phaseIndex: number,
+) {
+  const phase = experiment.phases[phaseIndex];
+  if (!phase) return [];
+
+  return getPhaseVariations(experiment, phaseIndex).map((variation, index) => ({
+    variationId: variation.id,
+    weight: phase.variationWeights[index] || 0,
+  }));
+}
+
 export async function toExperimentApiInterface(
   context: ReqContext | ApiReqContext,
   experiment: ExperimentInterface,
@@ -2778,17 +2791,14 @@ export async function toExperimentApiInterface(
         ),
       })),
     ),
-    phases: experiment.phases.map((p) => ({
+    phases: experiment.phases.map((p, phaseIndex) => ({
       name: p.name,
       dateStarted: p.dateStarted.toISOString(),
       dateEnded: p.dateEnded ? p.dateEnded.toISOString() : "",
       reasonForStopping: p.reason || "",
       seed: p.seed || experiment.trackingKey,
       coverage: p.coverage,
-      trafficSplit: getLatestPhaseVariations(experiment).map((v, i) => ({
-        variationId: v.id,
-        weight: p.variationWeights[i] || 0,
-      })),
+      trafficSplit: getExperimentPhaseTrafficSplit(experiment, phaseIndex),
       targetingCondition: p.condition || "",
       prerequisites: p.prerequisites || [],
       savedGroupTargeting: (p.savedGroups || []).map((s) => ({

--- a/packages/back-end/test/services/experiments.test.ts
+++ b/packages/back-end/test/services/experiments.test.ts
@@ -17,6 +17,7 @@ import {
   postMetricApiPayloadToMetricInterface,
   putMetricApiPayloadIsValid,
   putMetricApiPayloadToMetricInterface,
+  getExperimentPhaseTrafficSplit,
   updateExperimentApiPayloadToInterface,
   validateStatusUpdateSchedule,
   validateVariationIds,
@@ -1582,6 +1583,63 @@ describe("putMetricApiPayloadToMetricInterface", () => {
         (changes as { assignmentQueryId?: string }).assignmentQueryId,
       ).toBe(undefined);
     });
+  });
+});
+
+describe("getExperimentPhaseTrafficSplit", () => {
+  it("uses each phase's variations for traffic splits", () => {
+    const experiment = {
+      trackingKey: "phase-variations",
+      variations: [
+        {
+          id: "control",
+          key: "0",
+          name: "Control",
+          screenshots: [],
+        },
+        {
+          id: "treatment",
+          key: "1",
+          name: "Treatment",
+          screenshots: [],
+        },
+      ],
+      phases: [
+        {
+          name: "Ramp",
+          dateStarted: new Date("2026-01-01"),
+          variationWeights: [0.75, 0.25],
+          variations: [
+            { id: "control", status: "active" },
+            { id: "treatment", status: "active" },
+          ],
+        },
+        {
+          name: "Main",
+          dateStarted: new Date("2026-02-01"),
+          variationWeights: [0.6, 0.4],
+          variations: [
+            { id: "treatment", status: "active" },
+            { id: "control", status: "active" },
+          ],
+        },
+      ],
+    } as unknown as ExperimentInterface;
+
+    expect(
+      experiment.phases.map((_, phaseIndex) =>
+        getExperimentPhaseTrafficSplit(experiment, phaseIndex),
+      ),
+    ).toEqual([
+      [
+        { variationId: "control", weight: 0.75 },
+        { variationId: "treatment", weight: 0.25 },
+      ],
+      [
+        { variationId: "treatment", weight: 0.6 },
+        { variationId: "control", weight: 0.4 },
+      ],
+    ]);
   });
 });
 


### PR DESCRIPTION
### Features and Changes

The experiment API now builds each phase's `trafficSplit` from that phase's own variation order instead of reusing the latest phase's variations. This keeps historical phase variation IDs aligned with their corresponding weights.

A focused regression test covers phases with different variation orders.

- Closes https://github.com/growthbook/growthbook/issues/6461

### Dependencies

None.

### Testing

- `pnpm --filter back-end exec jest test/services/experiments.test.ts --runInBand` (68 tests passed)
- `pnpm --filter back-end type-check`
- ESLint and Prettier checks on the two changed files

### Screenshots

Not applicable; no UI changes.
