### PR TITLE
fix: holdout project selector

### DIFF
--- a/packages/front-end/components/Experiment/TabbedPage/EditHoldoutInfoModal.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/EditHoldoutInfoModal.tsx
@@ -31,8 +31,8 @@ export default function EditHoldoutInfoModal({
 }: Props) {
   const { apiCall } = useAuth();
   const permissionsUtil = usePermissionsUtil();
-  const canUpdateHoldoutProjects = (project) =>
-    permissionsUtil.canUpdateHoldout({ projects: [project] }, { projects: [] });
+  const canUpdateHoldoutProjects = (project: string) =>
+    permissionsUtil.canUpdateHoldout(holdout, { projects: [project] });
 
   const form = useForm({
     defaultValues: {
@@ -103,10 +103,9 @@ export default function EditHoldoutInfoModal({
         placeholder="All Projects"
         autoFocus={focusSelector === "projects"}
         value={form.watch("projects") || []}
-        options={useProjectOptions(
-          (project) => canUpdateHoldoutProjects(project),
-          experiment.project ? [experiment.project] : [],
-        )}
+        // A Holdout's scope lives on the Holdout, not on its underlying
+        // Experiment, which is always created with an empty project.
+        options={useProjectOptions(canUpdateHoldoutProjects, holdout.projects)}
         onChange={(v) => form.setValue("projects", v)}
         customClassName="label-overflow-ellipsis"
         helpText="Assign this holdout to specific projects"


### PR DESCRIPTION
Holdout project selector used to show incorrect information and options, now it shows the selected project.

Back-end remains the validation for whether a project switch is valid and errors if not.