### PR TITLE
Skip definitions-version bump on no-op fact table / metric updates

### DIFF
--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -408,6 +408,15 @@ export async function updateFactTable(
   );
 
   await audit.logUpdate(context, factTable, { ...factTable, ...changes });
+
+  // Skip the bump when nothing actually changed (e.g. a no-op save, or a
+  // client re-PUTting the same definition) — an unconditional touch here
+  // tanks the ETag hit rate for no reason. Mirrors updateFactTableColumns.
+  const changedDefinitionFields = Object.entries(changes).some(
+    ([k, v]) => !isEqual(factTable[k as keyof FactTableInterface], v),
+  );
+  if (!changedDefinitionFields) return;
+
   await touchDefinitionsVersion(
     factTable.organization,
     definitionsScope(
@@ -821,16 +830,23 @@ export async function updateFactFilter(
   const filterIndex = filters.findIndex((f) => f.id === filterId);
   if (filterIndex < 0) throw new Error("Could not find filter with that id");
 
+  const existingFilter = filters[filterIndex];
+
   if (
     factTable.managedBy === "api" &&
-    filters[filterIndex]?.managedBy === "api" &&
+    existingFilter?.managedBy === "api" &&
     context.auditUser?.type !== "api_key"
   ) {
     throw new Error("This fact filter is managed by the API");
   }
 
+  // Skip the bump when nothing actually changed — mirrors updateFactTable.
+  const changedDefinitionFields = Object.entries(changes).some(
+    ([k, v]) => !isEqual(existingFilter[k as keyof FactFilterInterface], v),
+  );
+
   filters[filterIndex] = {
-    ...filters[filterIndex],
+    ...existingFilter,
     ...changes,
     dateUpdated: new Date(),
   };
@@ -847,6 +863,9 @@ export async function updateFactFilter(
       },
     },
   );
+
+  if (!changedDefinitionFields) return;
+
   await touchDefinitionsVersion(
     factTable.organization,
     definitionsScope(factTable.projects),

--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -394,7 +394,12 @@ export async function updateFactTable(
     }
   }
 
-  await FactTableModel.updateOne(
+  // Use findOneAndUpdate (rather than updateOne) so the "before" snapshot
+  // below reflects the document as MongoDB saw it at the instant of this
+  // write, not whatever was read earlier by the caller — two concurrent
+  // updates could otherwise each diff against a stale copy and both wrongly
+  // conclude nothing changed, skipping a bump that should have happened.
+  const before = await FactTableModel.findOneAndUpdate(
     {
       id: factTable.id,
       organization: factTable.organization,
@@ -405,6 +410,7 @@ export async function updateFactTable(
         dateUpdated: new Date(),
       },
     },
+    { new: false },
   );
 
   await audit.logUpdate(context, factTable, { ...factTable, ...changes });
@@ -412,8 +418,9 @@ export async function updateFactTable(
   // Skip the bump when nothing actually changed (e.g. a no-op save, or a
   // client re-PUTting the same definition) — an unconditional touch here
   // tanks the ETag hit rate for no reason. Mirrors updateFactTableColumns.
+  const beforeInterface = before ? toInterface(before) : factTable;
   const changedDefinitionFields = Object.entries(changes).some(
-    ([k, v]) => !isEqual(factTable[k as keyof FactTableInterface], v),
+    ([k, v]) => !isEqual(beforeInterface[k as keyof FactTableInterface], v),
   );
   if (!changedDefinitionFields) return;
 
@@ -840,18 +847,17 @@ export async function updateFactFilter(
     throw new Error("This fact filter is managed by the API");
   }
 
-  // Skip the bump when nothing actually changed — mirrors updateFactTable.
-  const changedDefinitionFields = Object.entries(changes).some(
-    ([k, v]) => !isEqual(existingFilter[k as keyof FactFilterInterface], v),
-  );
-
   filters[filterIndex] = {
     ...existingFilter,
     ...changes,
     dateUpdated: new Date(),
   };
 
-  await FactTableModel.updateOne(
+  // Use findOneAndUpdate (rather than updateOne) so the "before" snapshot
+  // below reflects the document as MongoDB saw it at the instant of this
+  // write, not the possibly-stale `factTable` passed in by the caller — see
+  // updateFactTable for the full race-condition rationale.
+  const before = await FactTableModel.findOneAndUpdate(
     {
       id: factTable.id,
       organization: factTable.organization,
@@ -862,8 +868,17 @@ export async function updateFactFilter(
         filters: filters,
       },
     },
+    { new: false },
   );
 
+  // Skip the bump when nothing actually changed — mirrors updateFactTable.
+  const beforeFilter =
+    (before ? toInterface(before) : factTable).filters.find(
+      (f) => f.id === filterId,
+    ) ?? existingFilter;
+  const changedDefinitionFields = Object.entries(changes).some(
+    ([k, v]) => !isEqual(beforeFilter[k as keyof FactFilterInterface], v),
+  );
   if (!changedDefinitionFields) return;
 
   await touchDefinitionsVersion(

--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -378,6 +378,15 @@ export async function updateFactTable(
     context.permissions.throwPermissionError();
   }
 
+  // Bail on a no-op save before writing anything — the front-end resubmits the
+  // whole form on every save, and some API clients re-PUT the same definition
+  // on a schedule. Not writing means there is nothing to invalidate, so the
+  // write and the definitions-version bump stay in lockstep.
+  const changed = Object.entries(changes).some(
+    ([k, v]) => !isEqual(factTable[k as keyof FactTableInterface], v),
+  );
+  if (!changed) return;
+
   // Clean up auto slices from metrics if columns were deleted or modified
   if (changes.columns) {
     const removedColumns = detectRemovedColumns(
@@ -394,12 +403,7 @@ export async function updateFactTable(
     }
   }
 
-  // Use findOneAndUpdate (rather than updateOne) so the "before" snapshot
-  // below reflects the document as MongoDB saw it at the instant of this
-  // write, not whatever was read earlier by the caller — two concurrent
-  // updates could otherwise each diff against a stale copy and both wrongly
-  // conclude nothing changed, skipping a bump that should have happened.
-  const before = await FactTableModel.findOneAndUpdate(
+  await FactTableModel.updateOne(
     {
       id: factTable.id,
       organization: factTable.organization,
@@ -410,19 +414,9 @@ export async function updateFactTable(
         dateUpdated: new Date(),
       },
     },
-    { new: false },
   );
 
   await audit.logUpdate(context, factTable, { ...factTable, ...changes });
-
-  // Skip the bump when nothing actually changed (e.g. a no-op save, or a
-  // client re-PUTting the same definition) — an unconditional touch here
-  // tanks the ETag hit rate for no reason. Mirrors updateFactTableColumns.
-  const beforeInterface = before ? toInterface(before) : factTable;
-  const changedDefinitionFields = Object.entries(changes).some(
-    ([k, v]) => !isEqual(beforeInterface[k as keyof FactTableInterface], v),
-  );
-  if (!changedDefinitionFields) return;
 
   await touchDefinitionsVersion(
     factTable.organization,
@@ -847,17 +841,21 @@ export async function updateFactFilter(
     throw new Error("This fact filter is managed by the API");
   }
 
+  // Bail on a no-op save before writing — see updateFactTable. Returning here
+  // also avoids rewriting the whole filters array from a snapshot a concurrent
+  // write may already have superseded.
+  const changed = Object.entries(changes).some(
+    ([k, v]) => !isEqual(existingFilter[k as keyof FactFilterInterface], v),
+  );
+  if (!changed) return;
+
   filters[filterIndex] = {
     ...existingFilter,
     ...changes,
     dateUpdated: new Date(),
   };
 
-  // Use findOneAndUpdate (rather than updateOne) so the "before" snapshot
-  // below reflects the document as MongoDB saw it at the instant of this
-  // write, not the possibly-stale `factTable` passed in by the caller — see
-  // updateFactTable for the full race-condition rationale.
-  const before = await FactTableModel.findOneAndUpdate(
+  await FactTableModel.updateOne(
     {
       id: factTable.id,
       organization: factTable.organization,
@@ -868,18 +866,7 @@ export async function updateFactFilter(
         filters: filters,
       },
     },
-    { new: false },
   );
-
-  // Skip the bump when nothing actually changed — mirrors updateFactTable.
-  const beforeFilter =
-    (before ? toInterface(before) : factTable).filters.find(
-      (f) => f.id === filterId,
-    ) ?? existingFilter;
-  const changedDefinitionFields = Object.entries(changes).some(
-    ([k, v]) => !isEqual(beforeFilter[k as keyof FactFilterInterface], v),
-  );
-  if (!changedDefinitionFields) return;
 
   await touchDefinitionsVersion(
     factTable.organization,

--- a/packages/back-end/src/models/MetricModel.ts
+++ b/packages/back-end/src/models/MetricModel.ts
@@ -645,19 +645,10 @@ export async function updateMetric(
   metric: MetricInterface,
   updates: Partial<MetricInterface>,
 ) {
-  // Compare against the stored values (not just which keys were submitted) so
-  // resubmitting a field with its current value doesn't bump the definitions
-  // version — the front-end resends the whole form on every save. Fields in
-  // FIELDS_NOT_REQUIRING_DATE_UPDATED (queries/analysis/analysisError/
-  // runStarted) are excluded: they're not part of the definitions payload,
-  // but they DO change on every analysis run (see updateModel in
-  // LegacyMetricAnalysisQueryRunner), so comparing their values would bump
-  // the version on routine analysis completion.
-  const changedDefinitionFields = Object.entries(updates).some(
-    ([k, v]) =>
-      !FIELDS_NOT_REQUIRING_DATE_UPDATED.includes(k as keyof MetricInterface) &&
-      !isEqual(metric[k as keyof MetricInterface], v),
-  );
+  // Diffed against the actual pre-write DB state below (not this `updates`
+  // object) — keep the as-submitted shape before addDateUpdatedToUpdates
+  // merges in a fresh `dateUpdated` that would otherwise always look changed.
+  const submittedUpdates = updates;
 
   updates = addDateUpdatedToUpdates(updates);
 
@@ -678,17 +669,24 @@ export async function updateMetric(
 
   validatePriorSettings(updates.priorSettings);
 
-  // If using config.yml, need to do an `upsert` since it might not exist in mongo yet
+  // Use findOneAndUpdate (rather than updateOne) so the definitions-version
+  // bump decision below is based on the document's actual state at the
+  // instant of this write, not the possibly-stale `metric` argument passed
+  // in by the caller — see updateFactTable for the full race-condition
+  // rationale (two concurrent updates could otherwise each diff against a
+  // stale copy and both wrongly conclude nothing changed).
+  let before;
   if (metric.managedBy === "config") {
-    await MetricModel.updateOne(
+    // If using config.yml, need to do an `upsert` since it might not exist in mongo yet
+    before = await MetricModel.findOneAndUpdate(
       { id: metric.id, organization: context.org.id },
       {
         $set: updates,
       },
-      { upsert: true },
+      { upsert: true, new: false },
     );
   } else {
-    await MetricModel.updateOne(
+    before = await MetricModel.findOneAndUpdate(
       {
         id: metric.id,
         organization: context.org.id,
@@ -696,8 +694,24 @@ export async function updateMetric(
       {
         $set: updates,
       },
+      { new: false },
     );
   }
+
+  // Compare against the stored values (not just which keys were submitted) so
+  // resubmitting a field with its current value doesn't bump the definitions
+  // version — the front-end resends the whole form on every save. Fields in
+  // FIELDS_NOT_REQUIRING_DATE_UPDATED (queries/analysis/analysisError/
+  // runStarted) are excluded: they're not part of the definitions payload,
+  // but they DO change on every analysis run (see updateModel in
+  // LegacyMetricAnalysisQueryRunner), so comparing their values would bump
+  // the version on routine analysis completion.
+  const beforeInterface = before ? toInterface(before) : metric;
+  const changedDefinitionFields = Object.entries(submittedUpdates).some(
+    ([k, v]) =>
+      !FIELDS_NOT_REQUIRING_DATE_UPDATED.includes(k as keyof MetricInterface) &&
+      !isEqual(beforeInterface[k as keyof MetricInterface], v),
+  );
 
   await addTagsDiff(context.org.id, metric.tags || [], updates.tags || []);
 

--- a/packages/back-end/src/models/MetricModel.ts
+++ b/packages/back-end/src/models/MetricModel.ts
@@ -1,6 +1,7 @@
 import mongoose, { FilterQuery } from "mongoose";
 import { evalCondition } from "@growthbook/growthbook";
 import { ExperimentMetricInterface } from "shared/experiments";
+import isEqual from "lodash/isEqual";
 import omit from "lodash/omit";
 import {
   InsertMetricProps,
@@ -644,12 +645,14 @@ export async function updateMetric(
   metric: MetricInterface,
   updates: Partial<MetricInterface>,
 ) {
-  updates = addDateUpdatedToUpdates(updates);
+  // Compare against the stored values (not just which keys were submitted) so
+  // resubmitting a field with its current value doesn't bump the definitions
+  // version — the front-end resends the whole form on every save.
+  const changedDefinitionFields = Object.entries(updates).some(
+    ([k, v]) => !isEqual(metric[k as keyof MetricInterface], v),
+  );
 
-  // dateUpdated is only stamped when a payload-relevant field changed, so use
-  // it to decide whether to bump the definitions version (avoids churning the
-  // cache when only queries/analysis/runStarted change — see updateMetricQueriesAndStatus).
-  const changedDefinitionFields = "dateUpdated" in updates;
+  updates = addDateUpdatedToUpdates(updates);
 
   const safeUpdates = (Object.keys(updates) as (keyof MetricInterface)[]).every(
     (k) => FILE_CONFIG_UPDATEABLE_FIELDS.includes(k),

--- a/packages/back-end/src/models/MetricModel.ts
+++ b/packages/back-end/src/models/MetricModel.ts
@@ -647,9 +647,16 @@ export async function updateMetric(
 ) {
   // Compare against the stored values (not just which keys were submitted) so
   // resubmitting a field with its current value doesn't bump the definitions
-  // version — the front-end resends the whole form on every save.
+  // version — the front-end resends the whole form on every save. Fields in
+  // FIELDS_NOT_REQUIRING_DATE_UPDATED (queries/analysis/analysisError/
+  // runStarted) are excluded: they're not part of the definitions payload,
+  // but they DO change on every analysis run (see updateModel in
+  // LegacyMetricAnalysisQueryRunner), so comparing their values would bump
+  // the version on routine analysis completion.
   const changedDefinitionFields = Object.entries(updates).some(
-    ([k, v]) => !isEqual(metric[k as keyof MetricInterface], v),
+    ([k, v]) =>
+      !FIELDS_NOT_REQUIRING_DATE_UPDATED.includes(k as keyof MetricInterface) &&
+      !isEqual(metric[k as keyof MetricInterface], v),
   );
 
   updates = addDateUpdatedToUpdates(updates);

--- a/packages/back-end/src/models/MetricModel.ts
+++ b/packages/back-end/src/models/MetricModel.ts
@@ -645,13 +645,6 @@ export async function updateMetric(
   metric: MetricInterface,
   updates: Partial<MetricInterface>,
 ) {
-  // Diffed against the actual pre-write DB state below (not this `updates`
-  // object) — keep the as-submitted shape before addDateUpdatedToUpdates
-  // merges in a fresh `dateUpdated` that would otherwise always look changed.
-  const submittedUpdates = updates;
-
-  updates = addDateUpdatedToUpdates(updates);
-
   const safeUpdates = (Object.keys(updates) as (keyof MetricInterface)[]).every(
     (k) => FILE_CONFIG_UPDATEABLE_FIELDS.includes(k),
   );
@@ -669,24 +662,38 @@ export async function updateMetric(
 
   validatePriorSettings(updates.priorSettings);
 
-  // Use findOneAndUpdate (rather than updateOne) so the definitions-version
-  // bump decision below is based on the document's actual state at the
-  // instant of this write, not the possibly-stale `metric` argument passed
-  // in by the caller — see updateFactTable for the full race-condition
-  // rationale (two concurrent updates could otherwise each diff against a
-  // stale copy and both wrongly conclude nothing changed).
-  let before;
+  // Compare submitted values against the caller's snapshot (read fresh in the
+  // same request) rather than checking which keys were submitted — the
+  // front-end resubmits the whole form on every save. Bailing before the write
+  // keeps the write and the definitions-version bump in lockstep. Config
+  // metrics always write: the upsert below is what materializes their doc.
+  const changedFields = (
+    Object.keys(updates) as (keyof MetricInterface)[]
+  ).filter((k) => !isEqual(metric[k], updates[k]));
+  if (!changedFields.length && metric.managedBy !== "config") return;
+
+  // queries/analysis/analysisError/runStarted change on every analysis run but
+  // aren't in the definitions payload (METRIC_DEFINITION_EXCLUDED_FIELDS, kept
+  // in sync by MetricModel.test.ts), so they stamp neither dateUpdated nor the
+  // definitions version.
+  const changedDefinitionFields = changedFields.some(
+    (k) => !FIELDS_NOT_REQUIRING_DATE_UPDATED.includes(k),
+  );
+  if (changedDefinitionFields) {
+    updates = { ...updates, dateUpdated: new Date() };
+  }
+
+  // If using config.yml, need to do an `upsert` since it might not exist in mongo yet
   if (metric.managedBy === "config") {
-    // If using config.yml, need to do an `upsert` since it might not exist in mongo yet
-    before = await MetricModel.findOneAndUpdate(
+    await MetricModel.updateOne(
       { id: metric.id, organization: context.org.id },
       {
         $set: updates,
       },
-      { upsert: true, new: false },
+      { upsert: true },
     );
   } else {
-    before = await MetricModel.findOneAndUpdate(
+    await MetricModel.updateOne(
       {
         id: metric.id,
         organization: context.org.id,
@@ -694,24 +701,8 @@ export async function updateMetric(
       {
         $set: updates,
       },
-      { new: false },
     );
   }
-
-  // Compare against the stored values (not just which keys were submitted) so
-  // resubmitting a field with its current value doesn't bump the definitions
-  // version — the front-end resends the whole form on every save. Fields in
-  // FIELDS_NOT_REQUIRING_DATE_UPDATED (queries/analysis/analysisError/
-  // runStarted) are excluded: they're not part of the definitions payload,
-  // but they DO change on every analysis run (see updateModel in
-  // LegacyMetricAnalysisQueryRunner), so comparing their values would bump
-  // the version on routine analysis completion.
-  const beforeInterface = before ? toInterface(before) : metric;
-  const changedDefinitionFields = Object.entries(submittedUpdates).some(
-    ([k, v]) =>
-      !FIELDS_NOT_REQUIRING_DATE_UPDATED.includes(k as keyof MetricInterface) &&
-      !isEqual(beforeInterface[k as keyof MetricInterface], v),
-  );
 
   await addTagsDiff(context.org.id, metric.tags || [], updates.tags || []);
 


### PR DESCRIPTION
### Features and Changes

Follow-up to #6341 (bump-on-write ETag for `/organization/definitions`).

`updateFactTable` and `updateFactFilter` bumped the org's definitions version unconditionally on every update, and `updateMetric` decided whether to bump based on which keys were *submitted* rather than whether their values actually *changed*. Since the front-end resubmits the whole form on every save (and some API clients re-PUT the same fact table definition on a schedule), a no-op edit still invalidated the `/organization/definitions` ETag for every reader in the org — tanking the cache hit rate for reasons unrelated to any real content change.

Confirmed via production analytics + audit log: a `factTable.update` audit entry with byte-for-byte identical `pre`/`post` content landed inside an observed spurious-cache-miss window (control-arm request confirmed nothing had actually changed org-wide; the treatment-arm request right before it still got a needless cache miss).

- `updateFactTable`: skip `touchDefinitionsVersion` when none of the submitted `changes` differ from the stored fact table.
- `updateFactFilter`: same guard, comparing against the filter being replaced.
- `updateMetric`: replaced the presence-based check (`"dateUpdated" in updates`) with a value-based `isEqual` comparison against the stored metric.

All three mirror the existing `isEqual`-based guard already used by `updateFactTableColumns` for the same reason (that one was guarded because it runs from a background cron; these run from the interactive/API save path, which turns out to matter just as much).

### Testing

- [x] `pnpm --filter back-end type-check` passes
- [x] `pnpm --filter back-end test -- test/models/factTableModel.test.ts test/models/MetricModel.test.ts` — 31/31 existing tests pass unmodified
- [x] Lint clean
- [ ] No new tests added for the no-op-update case itself — happy to add if wanted