### PR TITLE
Per-org id attribute mapping for managed warehouse identifiers

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -1123,6 +1123,10 @@ app.post(
   "/datasource/:datasourceId/managed-warehouse/remove-legacy-identifier",
   datasourcesController.postRemoveManagedWarehouseLegacyIdentifier,
 );
+app.put(
+  "/datasource/:datasourceId/managed-warehouse/id-attribute-identifier",
+  datasourcesController.putManagedWarehouseIdAttributeIdentifier,
+);
 
 if (IS_CLOUD) {
   app.post(

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -101,7 +101,10 @@ import {
 import { DimensionSlicesQueryRunner } from "back-end/src/queryRunners/DimensionSlicesQueryRunner";
 import { logger } from "back-end/src/util/logger";
 import { IS_CLOUD } from "back-end/src/util/secrets";
-import { removeManagedWarehouseLegacyIdentifier } from "back-end/src/services/clickhouse";
+import {
+  removeManagedWarehouseLegacyIdentifier,
+  setManagedWarehouseIdAttributeIdentifier,
+} from "back-end/src/services/clickhouse";
 import { dangerousRecreateClickhouseTables } from "back-end/src/services/licenseServerManagedClickhouse";
 import { UNITS_TABLE_PREFIX } from "back-end/src/queryRunners/ExperimentResultsQueryRunner";
 import { getExperimentsByTrackingKeys } from "back-end/src/models/ExperimentModel";
@@ -1781,6 +1784,42 @@ export async function postRemoveManagedWarehouseLegacyIdentifier(
   });
 }
 
+export async function putManagedWarehouseIdAttributeIdentifier(
+  req: AuthRequest<{ identifier?: string }, { datasourceId: string }>,
+  res: Response,
+) {
+  const context = getContextFromReq(req);
+  const { datasourceId } = req.params;
+  const { identifier } = req.body;
+
+  if (identifier !== "user_id" && identifier !== "device_id") {
+    throw new Error('Identifier must be "user_id" or "device_id"');
+  }
+
+  const datasource = await getDataSourceById(context, datasourceId);
+  if (!datasource) {
+    throw new Error("Cannot find datasource");
+  }
+  if (datasource.type !== "growthbook_clickhouse") {
+    throw new Error(
+      "Can only change the id attribute mapping on a Managed Warehouse datasource",
+    );
+  }
+  if (!context.permissions.canUpdateDataSourceSettings(datasource)) {
+    context.permissions.throwPermissionError();
+  }
+
+  await setManagedWarehouseIdAttributeIdentifier(
+    context,
+    datasource,
+    identifier,
+  );
+
+  res.status(200).json({
+    status: 200,
+  });
+}
+
 // Managed-warehouse settings for the JSON-columns model: identifiers and exposure
 // queries derive from the org's hashAttribute attributes.
 function getManagedWarehouseJsonSettings(
@@ -1794,7 +1833,12 @@ function getManagedWarehouseJsonSettings(
     userIdTypes: getManagedWarehouseUserIdTypeSettings(attributeSchema),
     queries: {
       ...existing.queries,
-      exposure: buildManagedWarehouseExposureQueries(attributeSchema),
+      exposure: buildManagedWarehouseExposureQueries(
+        attributeSchema,
+        [],
+        [],
+        existing.idAttributeIdentifier === "user_id" ? "user_id" : "device_id",
+      ),
     },
   };
 }

--- a/packages/back-end/src/jobs/syncManagedWarehouseJsonErgonomics.ts
+++ b/packages/back-end/src/jobs/syncManagedWarehouseJsonErgonomics.ts
@@ -94,6 +94,7 @@ const syncManagedWarehouseJsonErgonomics = async (job: SyncJob) => {
         org.settings?.attributeSchema ?? [],
         ds.settings.migratedIdentifiers ?? [],
         ds.settings.migratedColumns ?? [],
+        ds.settings.idAttributeIdentifier ?? "device_id",
       ]);
     if (
       derivationInputs(context.org, datasource) !==

--- a/packages/back-end/src/services/clickhouse.ts
+++ b/packages/back-end/src/services/clickhouse.ts
@@ -531,24 +531,28 @@ export async function setManagedWarehouseIdAttributeIdentifier(
     );
   }
 
-  if ((datasource.settings.idAttributeIdentifier ?? "device_id") === identifier)
-    return;
-
-  const updatedSettings = {
-    ...datasource.settings,
-    idAttributeIdentifier: identifier,
-  };
+  // Merge onto a fresh read rather than the request-start snapshot: this is a
+  // full-settings write, so a stale spread could revert a concurrent update
+  // (an attribute sync's derived metadata, a provisioning flag flip).
+  const fresh =
+    await dangerouslyGetGrowthbookDatasourceBypassPermission(context);
+  if (
+    !fresh ||
+    fresh.type !== "growthbook_clickhouse" ||
+    fresh.id !== datasource.id
+  ) {
+    throw new Error("Cannot find datasource");
+  }
   await updateDataSource(
     context,
-    datasource,
-    { settings: updatedSettings },
+    fresh,
+    { settings: { ...fresh.settings, idAttributeIdentifier: identifier } },
     { skipExposureQueryValidation: true },
   );
 
-  // Reconcile the same datasource we just updated (with the new mapping), rather
-  // than letting the sync re-select a warehouse by org.
-  await syncManagedWarehouseIdentifiers(context, undefined, {
-    ...datasource,
-    settings: updatedSettings,
-  });
+  // Always re-sync — even when the flag already matches — and let the sync
+  // re-fetch the doc it derives from. A retry after a failed regeneration then
+  // heals the persisted SQL instead of short-circuiting on the already-persisted
+  // flag, and the sync's own full-settings write bases on the freshest state.
+  await syncManagedWarehouseIdentifiers(context);
 }

--- a/packages/back-end/src/services/clickhouse.ts
+++ b/packages/back-end/src/services/clickhouse.ts
@@ -10,6 +10,7 @@ import {
   isManagedWarehouseMigrating,
   MANAGED_WAREHOUSE_ATTRIBUTES_COLUMN,
   MANAGED_WAREHOUSE_RESERVED_COLUMN_NAMES,
+  ManagedWarehouseIdAttributeIdentifier,
 } from "shared/util";
 import { DataSourceInterface } from "shared/types/datasource";
 import { SDKAttributeSchema } from "shared/types/organization";
@@ -250,6 +251,10 @@ export async function syncManagedWarehouseIdentifiers(
   // names (so bare references keep resolving).
   const extraIdentifiers = datasource.settings.migratedIdentifiers || [];
   const migratedColumns = datasource.settings.migratedColumns || [];
+  const idAttributeIdentifier =
+    datasource.settings.idAttributeIdentifier === "user_id"
+      ? "user_id"
+      : "device_id";
 
   const newUserIdTypes = getManagedWarehouseUserIdTypes(
     attributeSchema,
@@ -287,6 +292,7 @@ export async function syncManagedWarehouseIdentifiers(
             attributeSchema,
             extraIdentifiers,
             migratedColumns,
+            idAttributeIdentifier,
           ),
         },
       },
@@ -383,6 +389,7 @@ export async function syncManagedWarehouseIdentifiers(
     attributeSchema,
     extraIdentifiers,
     migratedColumns,
+    idAttributeIdentifier,
   );
 
   // Skip the write when nothing changed (e.g. a tag/description-only edit on an
@@ -502,4 +509,46 @@ export async function removeManagedWarehouseLegacyIdentifier(
       "Failed to sync typed attribute columns after removing legacy identifier",
     ),
   );
+}
+
+// Change which built-in identifier the `id` attribute folds into in generated SQL
+// (see GrowthbookClickhouseSettings.idAttributeIdentifier), then regenerate the
+// exposure queries and fact-table SQL from the new mapping. Query-time only — no
+// ClickHouse DDL changes — so flipping it back fully reverts. Experiments assigned
+// on the `id` attribute read their exposures through the other identifier's
+// Experiment Assignment Query after a flip and need to be re-pointed.
+export async function setManagedWarehouseIdAttributeIdentifier(
+  context: ReqContext | ApiReqContext,
+  datasource: DataSourceInterface,
+  identifier: ManagedWarehouseIdAttributeIdentifier,
+): Promise<void> {
+  if (
+    datasource.type !== "growthbook_clickhouse" ||
+    !datasource.settings.useJsonColumns
+  ) {
+    throw new Error(
+      "The id attribute mapping can only be changed on a JSON-columns Managed Warehouse",
+    );
+  }
+
+  if ((datasource.settings.idAttributeIdentifier ?? "device_id") === identifier)
+    return;
+
+  const updatedSettings = {
+    ...datasource.settings,
+    idAttributeIdentifier: identifier,
+  };
+  await updateDataSource(
+    context,
+    datasource,
+    { settings: updatedSettings },
+    { skipExposureQueryValidation: true },
+  );
+
+  // Reconcile the same datasource we just updated (with the new mapping), rather
+  // than letting the sync re-select a warehouse by org.
+  await syncManagedWarehouseIdentifiers(context, undefined, {
+    ...datasource,
+    settings: updatedSettings,
+  });
 }

--- a/packages/back-end/src/services/clickhouse.ts
+++ b/packages/back-end/src/services/clickhouse.ts
@@ -32,6 +32,7 @@ import {
   dangerouslyGetGrowthbookDatasourceBypassPermission,
   updateDataSource,
 } from "back-end/src/models/DataSourceModel";
+import { getCollection } from "back-end/src/util/mongo.util";
 import { syncJsonErgonomicsInClickhouse } from "back-end/src/services/licenseServerManagedClickhouse";
 import { getSourceIntegrationObject } from "back-end/src/services/datasource";
 import SqlIntegration from "back-end/src/integrations/SqlIntegration";
@@ -531,28 +532,28 @@ export async function setManagedWarehouseIdAttributeIdentifier(
     );
   }
 
-  // Merge onto a fresh read rather than the request-start snapshot: this is a
-  // full-settings write, so a stale spread could revert a concurrent update
-  // (an attribute sync's derived metadata, a provisioning flag flip).
-  const fresh =
-    await dangerouslyGetGrowthbookDatasourceBypassPermission(context);
-  if (
-    !fresh ||
-    fresh.type !== "growthbook_clickhouse" ||
-    fresh.id !== datasource.id
-  ) {
-    throw new Error("Cannot find datasource");
-  }
-  await updateDataSource(
-    context,
-    fresh,
-    { settings: { ...fresh.settings, idAttributeIdentifier: identifier } },
-    { skipExposureQueryValidation: true },
+  // Targeted single-key $set (the sweep job's pattern): a full settings write
+  // from a snapshot could revert a concurrent update (an attribute sync's
+  // derived metadata, a provisioning flag flip), while a dot-path write can't
+  // clobber anything. Filter-guarded so a same-value PUT leaves the doc alone.
+  await getCollection("datasources").updateOne(
+    {
+      organization: context.org.id,
+      id: datasource.id,
+      "settings.idAttributeIdentifier": { $ne: identifier },
+    },
+    {
+      $set: {
+        "settings.idAttributeIdentifier": identifier,
+        dateUpdated: new Date(),
+      },
+    },
   );
 
   // Always re-sync — even when the flag already matches — and let the sync
   // re-fetch the doc it derives from. A retry after a failed regeneration then
   // heals the persisted SQL instead of short-circuiting on the already-persisted
-  // flag, and the sync's own full-settings write bases on the freshest state.
+  // flag, and the audit entry / definitions-version bump for the resulting
+  // generated-SQL change happen through the sync's own updateDataSource.
   await syncManagedWarehouseIdentifiers(context);
 }

--- a/packages/front-end/components/Settings/EditDataSource/ClickhouseManagedWarehouseIdentifiers.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ClickhouseManagedWarehouseIdentifiers.tsx
@@ -46,6 +46,13 @@ export default function ClickhouseManagedWarehouseIdentifiers({
       : "device_id";
   const [pendingIdIdentifier, setPendingIdIdentifier] =
     useState<ManagedWarehouseIdAttributeIdentifier | null>(null);
+  // Nothing to map unless the org actually assigns on `id`. Still shown when the
+  // setting is already non-default, so it stays visible and revertable.
+  const showIdAttributeMapping =
+    idAttributeIdentifier === "user_id" ||
+    (settings.attributeSchema ?? []).some(
+      (a) => a.property === "id" && a.hashAttribute && !a.archived,
+    );
 
   const removeIdentifier = async (identifier: string) => {
     await apiCall(
@@ -116,7 +123,7 @@ export default function ClickhouseManagedWarehouseIdentifiers({
           </>
         ) : null}
       </Callout>
-      {dataSource.settings.useJsonColumns ? (
+      {dataSource.settings.useJsonColumns && showIdAttributeMapping ? (
         <Box mt="4" maxWidth="420px">
           <Select
             label={

--- a/packages/front-end/components/Settings/EditDataSource/ClickhouseManagedWarehouseIdentifiers.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ClickhouseManagedWarehouseIdentifiers.tsx
@@ -117,7 +117,7 @@ export default function ClickhouseManagedWarehouseIdentifiers({
         ) : null}
       </Callout>
       {dataSource.settings.useJsonColumns ? (
-        <Box mt="4">
+        <Box mt="4" maxWidth="420px">
           <Select
             label={
               <Text as="label" weight="semibold">
@@ -133,7 +133,6 @@ export default function ClickhouseManagedWarehouseIdentifiers({
               }
             }}
             disabled={!canEdit}
-            style={{ maxWidth: 420 }}
           >
             <SelectItem value="device_id">
               device_id &mdash; anonymous or device IDs (default)

--- a/packages/front-end/components/Settings/EditDataSource/ClickhouseManagedWarehouseIdentifiers.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ClickhouseManagedWarehouseIdentifiers.tsx
@@ -1,13 +1,20 @@
+import { useState } from "react";
 import { Box, Flex } from "@radix-ui/themes";
 import { GrowthbookClickhouseDataSourceWithParams } from "shared/types/datasource";
-import { getManagedWarehouseUserIdTypes } from "shared/util";
+import {
+  getManagedWarehouseUserIdTypes,
+  ManagedWarehouseIdAttributeIdentifier,
+} from "shared/util";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import { useAuth } from "@/services/auth";
 import Badge from "@/ui/Badge";
 import Callout from "@/ui/Callout";
+import ConfirmDialog from "@/ui/ConfirmDialog";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
 import Heading from "@/ui/Heading";
+import HelperText from "@/ui/HelperText";
 import Link from "@/ui/Link";
+import { Select, SelectItem } from "@/ui/Select";
 import Text from "@/ui/Text";
 
 // Identifiers view for JSON-column managed warehouses. Identifiers come from the org's
@@ -33,11 +40,29 @@ export default function ClickhouseManagedWarehouseIdentifiers({
   const legacy = new Set(dataSource.settings.migratedIdentifiers ?? []);
   const hasLegacy = identifiers.some((id) => legacy.has(id));
 
+  const idAttributeIdentifier: ManagedWarehouseIdAttributeIdentifier =
+    dataSource.settings.idAttributeIdentifier === "user_id"
+      ? "user_id"
+      : "device_id";
+  const [pendingIdIdentifier, setPendingIdIdentifier] =
+    useState<ManagedWarehouseIdAttributeIdentifier | null>(null);
+
   const removeIdentifier = async (identifier: string) => {
     await apiCall(
       `/datasource/${dataSource.id}/managed-warehouse/remove-legacy-identifier`,
       { method: "POST", body: JSON.stringify({ identifier }) },
     );
+    mutate?.();
+  };
+
+  const saveIdIdentifier = async (
+    identifier: ManagedWarehouseIdAttributeIdentifier,
+  ) => {
+    await apiCall(
+      `/datasource/${dataSource.id}/managed-warehouse/id-attribute-identifier`,
+      { method: "PUT", body: JSON.stringify({ identifier }) },
+    );
+    setPendingIdIdentifier(null);
     mutate?.();
   };
 
@@ -91,6 +116,72 @@ export default function ClickhouseManagedWarehouseIdentifiers({
           </>
         ) : null}
       </Callout>
+      {dataSource.settings.useJsonColumns ? (
+        <Box mt="4">
+          <Select
+            label={
+              <Text as="label" weight="semibold">
+                The <code>id</code> attribute maps to
+              </Text>
+            }
+            value={idAttributeIdentifier}
+            setValue={(v) => {
+              if (v !== idAttributeIdentifier) {
+                setPendingIdIdentifier(
+                  v === "user_id" ? "user_id" : "device_id",
+                );
+              }
+            }}
+            disabled={!canEdit}
+            style={{ maxWidth: 420 }}
+          >
+            <SelectItem value="device_id">
+              device_id &mdash; anonymous or device IDs (default)
+            </SelectItem>
+            <SelectItem value="user_id">
+              user_id &mdash; logged-in user IDs (Ingestion API only)
+            </SelectItem>
+          </Select>
+          {idAttributeIdentifier === "user_id" ? (
+            <HelperText status="warning" mt="1">
+              Applies to Ingestion API events only&mdash;SDKs using the tracking
+              plugin always fold <code>id</code> into <code>device_id</code> on
+              the client, out of reach of this setting.
+            </HelperText>
+          ) : null}
+        </Box>
+      ) : null}
+      {pendingIdIdentifier ? (
+        <ConfirmDialog
+          title={`Map the id attribute to ${pendingIdIdentifier}`}
+          content={
+            <>
+              <Text as="p">
+                Generated SQL will resolve the <code>id</code> attribute as{" "}
+                <code>{pendingIdIdentifier}</code> instead of{" "}
+                <code>{idAttributeIdentifier}</code>. This regenerates this Data
+                Source&apos;s assignment queries and fact-table SQL. Experiments
+                assigned on the <code>id</code> attribute will need their
+                assignment query switched to <code>{pendingIdIdentifier}</code>{" "}
+                and their results updated.
+              </Text>
+              {pendingIdIdentifier === "user_id" ? (
+                <Text as="p" mt="2">
+                  Only use this if you send events through the Ingestion API
+                  with a logged-in user ID under the <code>id</code> key. SDKs
+                  using the tracking plugin fold <code>id</code> into the{" "}
+                  <code>device_id</code> column on the client, where this
+                  setting cannot reach it&mdash;with the plugin, keep the
+                  default.
+                </Text>
+              ) : null}
+            </>
+          }
+          yesText="Change mapping"
+          onConfirm={() => saveIdIdentifier(pendingIdIdentifier)}
+          onCancel={() => setPendingIdIdentifier(null)}
+        />
+      ) : null}
     </Box>
   );
 }

--- a/packages/shared/src/util/managedWarehouse.ts
+++ b/packages/shared/src/util/managedWarehouse.ts
@@ -432,6 +432,21 @@ const BUILTIN_ATTRIBUTE_TO_IDENTIFIER: Record<string, string> = {
   id: "device_id",
 };
 
+/**
+ * Per-org override for what the `id` attribute means (`settings.idAttributeIdentifier`):
+ * "device_id" (default, the plugin contract above) or "user_id" for orgs whose
+ * Ingestion API events carry a logged-in user ID under the `id` key. An explicit
+ * input to the SQL derivation — every builder that folds built-ins takes it, and
+ * the ergonomics sweep treats it as a freshness-guard input.
+ */
+export type ManagedWarehouseIdAttributeIdentifier = "user_id" | "device_id";
+
+function getIdAttributeIdentifier(
+  settings: Pick<GrowthbookClickhouseSettings, "idAttributeIdentifier">,
+): ManagedWarehouseIdAttributeIdentifier {
+  return settings.idAttributeIdentifier === "user_id" ? "user_id" : "device_id";
+}
+
 // Resolve the managed-warehouse identifier column (which doubles as the exposure
 // query's userIdType) that a hash attribute maps to. Legacy materialized-column
 // warehouses return the stored SQL column, or null when the attribute isn't an
@@ -451,6 +466,7 @@ export function getManagedWarehouseIdentifierForAttribute({
     )?.columnName;
     return column ?? null;
   }
+  if (attribute === "id") return getIdAttributeIdentifier(settings);
   return BUILTIN_ATTRIBUTE_TO_IDENTIFIER[attribute] ?? attribute;
 }
 
@@ -551,18 +567,31 @@ function migratedColumnSelectExpr(col: MaterializedColumn): string {
 // leaving the columns empty. REPLACE each column with a coalesce through the same
 // keys in the same precedence, so both eras resolve (folded rows can't
 // double-resolve: their JSON no longer contains the keys).
-function builtinIdentifierReplaceClause(): string {
+//
+// `idAttributeIdentifier` moves the `attributes.id` fallback (always last in its
+// chain, mirroring the plugin's precedence) between the two columns — each key
+// feeds exactly one identifier, so a value can never resolve under both.
+function builtinIdentifierReplaceClause(
+  idAttributeIdentifier: ManagedWarehouseIdAttributeIdentifier,
+): string {
   // nullIf-wrapped so empty strings fall through, matching the plugin's falsy
   // `||` chain — a JSON `device_id: ""` must not shadow a populated `id`.
   const path = (key: string) =>
     `nullIf(${MANAGED_WAREHOUSE_ATTRIBUTES_COLUMN}.${chIdentifier(
       key,
     )}::Nullable(String), '')`;
+  const userIdSources = [`nullIf(user_id, '')`, path("user_id")];
+  const deviceIdSources = [
+    `nullIf(device_id, '')`,
+    path("device_id"),
+    path("anonymous_id"),
+  ];
+  (idAttributeIdentifier === "user_id" ? userIdSources : deviceIdSources).push(
+    path("id"),
+  );
   return ` REPLACE (
-  coalesce(nullIf(user_id, ''), ${path("user_id")}) AS user_id,
-  coalesce(nullIf(device_id, ''), ${path("device_id")}, ${path(
-    "anonymous_id",
-  )}, ${path("id")}) AS device_id
+  coalesce(${userIdSources.join(", ")}) AS user_id,
+  coalesce(${deviceIdSources.join(", ")}) AS device_id
 )`;
 }
 
@@ -574,13 +603,14 @@ function builtinIdentifierReplaceClause(): string {
 function attributeAliasClause(
   customIdentifiers: string[],
   dimensions: MaterializedColumn[],
+  idAttributeIdentifier: ManagedWarehouseIdAttributeIdentifier,
 ): string {
   const exprs = [
     ...customIdentifiers.map(customIdentifierSelectExpr),
     ...dimensions.map(migratedColumnSelectExpr),
   ];
   const aliases = exprs.length ? ",\n  " + exprs.join(",\n  ") : "";
-  return builtinIdentifierReplaceClause() + aliases;
+  return builtinIdentifierReplaceClause(idAttributeIdentifier) + aliases;
 }
 
 /**
@@ -617,6 +647,7 @@ export function buildManagedWarehouseAttributeAliasClause(
   return attributeAliasClause(
     customIdentifiers,
     dedupeMigratedDimensions(customIdentifiers, s.migratedColumns || []),
+    getIdAttributeIdentifier(s),
   );
 }
 
@@ -627,6 +658,7 @@ export function buildManagedWarehouseEventsFactTableSql(
   attributeSchema: SDKAttributeSchema | undefined,
   extraIdentifiers: string[] = [],
   migratedColumns: MaterializedColumn[] = [],
+  idAttributeIdentifier: ManagedWarehouseIdAttributeIdentifier = "device_id",
 ): string {
   const customIdentifiers = getManagedWarehouseCustomIdentifiers(
     attributeSchema,
@@ -636,7 +668,11 @@ export function buildManagedWarehouseEventsFactTableSql(
     customIdentifiers,
     migratedColumns,
   );
-  return `SELECT *${attributeAliasClause(customIdentifiers, dimensionAliases)}
+  return `SELECT *${attributeAliasClause(
+    customIdentifiers,
+    dimensionAliases,
+    idAttributeIdentifier,
+  )}
 FROM ${MANAGED_WAREHOUSE_EVENTS_TABLE}
 WHERE timestamp BETWEEN '{{startDate}}' AND '{{endDate}}'`;
 }
@@ -646,6 +682,7 @@ export function buildManagedWarehouseExposureQueries(
   attributeSchema: SDKAttributeSchema | undefined,
   extraIdentifiers: string[] = [],
   migratedColumns: MaterializedColumn[] = [],
+  idAttributeIdentifier: ManagedWarehouseIdAttributeIdentifier = "device_id",
 ): ExposureQuery[] {
   const customIdentifiers = getManagedWarehouseCustomIdentifiers(
     attributeSchema,
@@ -658,6 +695,7 @@ export function buildManagedWarehouseExposureQueries(
   const query = `SELECT *${attributeAliasClause(
     customIdentifiers,
     dimensionAliases,
+    idAttributeIdentifier,
   )}
 FROM ${MANAGED_WAREHOUSE_EXPERIMENT_VIEWS_TABLE}
 WHERE

--- a/packages/shared/test/util/managedWarehouse.test.ts
+++ b/packages/shared/test/util/managedWarehouse.test.ts
@@ -381,6 +381,123 @@ describe("buildManagedWarehouseExposureQueries", () => {
   });
 });
 
+describe("idAttributeIdentifier (per-org `id` attribute mapping)", () => {
+  const USER_ID_CHAIN_WITH_ID =
+    "coalesce(nullIf(user_id, ''), nullIf(attributes.user_id::Nullable(String), ''), nullIf(attributes.id::Nullable(String), '')) AS user_id";
+  const DEVICE_ID_CHAIN_WITHOUT_ID =
+    "coalesce(nullIf(device_id, ''), nullIf(attributes.device_id::Nullable(String), ''), nullIf(attributes.anonymous_id::Nullable(String), '')) AS device_id";
+
+  it("moves the attributes.id fallback to the user_id chain in fact-table SQL", () => {
+    const sql = buildManagedWarehouseEventsFactTableSql(
+      defaultSchema,
+      [],
+      [],
+      "user_id",
+    );
+    expect(sql).toContain(USER_ID_CHAIN_WITH_ID);
+    expect(sql).toContain(DEVICE_ID_CHAIN_WITHOUT_ID);
+    // The key feeds exactly one identifier — never both chains.
+    expect(sql.match(/attributes\.id::Nullable\(String\)/g)?.length).toBe(1);
+  });
+
+  it("moves the attributes.id fallback in every generated exposure query", () => {
+    const queries = buildManagedWarehouseExposureQueries(
+      defaultSchema,
+      [],
+      [],
+      "user_id",
+    );
+    queries.forEach((q) => {
+      expect(q.query).toContain(USER_ID_CHAIN_WITH_ID);
+      expect(q.query).toContain(DEVICE_ID_CHAIN_WITHOUT_ID);
+    });
+  });
+
+  it("passing device_id explicitly matches the default output", () => {
+    expect(
+      buildManagedWarehouseEventsFactTableSql(
+        defaultSchema,
+        [],
+        [],
+        "device_id",
+      ),
+    ).toBe(buildManagedWarehouseEventsFactTableSql(defaultSchema));
+  });
+
+  it("buildManagedWarehouseAttributeAliasClause reads the flag from settings", () => {
+    const clause = buildManagedWarehouseAttributeAliasClause({
+      useJsonColumns: true,
+      idAttributeIdentifier: "user_id",
+    });
+    expect(clause).toContain(USER_ID_CHAIN_WITH_ID);
+    expect(clause).toContain(DEVICE_ID_CHAIN_WITHOUT_ID);
+  });
+
+  it("remaps only `id` in the attribute -> identifier fold", () => {
+    const settings: GrowthbookClickhouseSettings = {
+      useJsonColumns: true,
+      idAttributeIdentifier: "user_id",
+    };
+    const cases: Array<[string, string]> = [
+      ["id", "user_id"],
+      ["user_id", "user_id"],
+      ["device_id", "device_id"],
+      ["anonymous_id", "device_id"],
+      ["company_id", "company_id"],
+    ];
+    cases.forEach(([attribute, identifier]) => {
+      expect(
+        getManagedWarehouseIdentifierForAttribute({ settings, attribute }),
+      ).toBe(identifier);
+    });
+  });
+
+  it("resolves the user_id exposure query for the id attribute when flagged", () => {
+    const settings: GrowthbookClickhouseSettings = {
+      useJsonColumns: true,
+      idAttributeIdentifier: "user_id",
+      queries: {
+        exposure: buildManagedWarehouseExposureQueries(
+          defaultSchema,
+          [],
+          [],
+          "user_id",
+        ),
+      },
+    };
+    expect(
+      getManagedWarehouseExposureQueryIdForAttribute({
+        settings,
+        attribute: "id",
+      }),
+    ).toBe("user_id");
+  });
+
+  it("does not affect the legacy materialized-column mapping", () => {
+    const settings: GrowthbookClickhouseSettings = {
+      idAttributeIdentifier: "user_id",
+      materializedColumns: [
+        {
+          sourceField: "id",
+          columnName: "user_id",
+          datatype: "string",
+          type: "identifier",
+        },
+      ],
+    };
+    // The stored legacy mapping wins; the flag is only read on JSON warehouses.
+    expect(
+      getManagedWarehouseIdentifierForAttribute({ settings, attribute: "id" }),
+    ).toBe("user_id");
+    expect(
+      getManagedWarehouseIdentifierForAttribute({
+        settings,
+        attribute: "unknown",
+      }),
+    ).toBeNull();
+  });
+});
+
 describe("getManagedWarehouseEventsFactTableColumns", () => {
   it("always includes the attributes/properties JSON columns and standard fields", () => {
     const columns = getManagedWarehouseEventsFactTableColumns(defaultSchema);

--- a/packages/shared/types/datasource.d.ts
+++ b/packages/shared/types/datasource.d.ts
@@ -378,6 +378,16 @@ export interface GrowthbookClickhouseSettings extends DataSourceSettings {
    * MANAGED_WAREHOUSE_JSON_ERGONOMICS_VERSION; bump that constant to re-sweep.
    */
   jsonErgonomicsVersion?: number;
+  /**
+   * Which built-in identifier the `id` attribute folds into in generated SQL.
+   * Defaults to "device_id" (the SDK tracking plugin's contract). Orgs that send
+   * a logged-in user ID under the `id` key via the Ingestion API can set
+   * "user_id" so `attributes.id` participates in user_id joins instead. Only
+   * meaningful on JSON-column warehouses, and incompatible with the tracking
+   * plugin: the plugin folds `id` into the physical device_id column client-side
+   * and strips it from the JSON, where this query-time remap can't see it.
+   */
+  idAttributeIdentifier?: "user_id" | "device_id";
 }
 
 interface DataSourceBase {


### PR DESCRIPTION
### Features and Changes

Follow-up to #6484. Orgs that send a logged-in user ID under the `id` attribute key (Ingestion API integrations) see it resolve as `device_id` — mechanically correct, but their metrics are keyed on `user_id` and the label misleads experimenters.

Adds `settings.idAttributeIdentifier` (`"user_id" | "device_id"`, default `device_id`) as an explicit input to the generated-SQL derivation. It moves the `attributes.id` coalesce between the two built-in identifier chains in the `REPLACE` fallback (each key feeds exactly one identifier, never both), and hash-attribute &rarr; assignment-query folding follows it. A new `PUT /datasource/:id/managed-warehouse/id-attribute-identifier` endpoint updates the setting and re-syncs the org's exposure queries and fact-table SQL; the datasource page gets a select with a confirm dialog. The ergonomics sweep treats the flag as a freshness-guard input. Query-time only — no DDL — so flipping back fully reverts.

Note: the setting only helps Ingestion API senders. The SDK tracking plugin folds `id` into the physical `device_id` column client-side and strips it from the JSON, out of reach of query-time remapping — the UI warns on both the control and the confirm dialog.

### Testing

- [x] Shared tests (61 passing, 7 new): flagged SQL moves `attributes.id` to the `user_id` chain and out of the `device_id` chain, explicit `device_id` matches the default output byte-for-byte, fold + exposure-query resolution remap only `id`, legacy materialized-column mapping unaffected
- [x] Type-check + lint across shared / back-end / front-end
- [x] Dev e2e (managed warehouse, ClickHouse 26.4): `PUT` flip to `user_id` -> persisted EAQs and `ch_events` fact-table SQL regenerate with the remapped chains; customer-shaped row (empty identifier columns, `{"id":"cust-9007199254740993"}`) resolves through the persisted `user_id` EAQ verbatim with exact digits and `device_id` NULL (no double-resolve); flip back to `device_id` -> exposure queries, fact SQL, and userIdTypes byte-identical to the pre-flip baseline
