### PR TITLE
Fix styling for new id attribute setting description

### DIFF
--- a/packages/front-end/components/Settings/EditDataSource/ClickhouseManagedWarehouseIdentifiers.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ClickhouseManagedWarehouseIdentifiers.tsx
@@ -150,9 +150,12 @@ export default function ClickhouseManagedWarehouseIdentifiers({
           </Select>
           {idAttributeIdentifier === "user_id" ? (
             <HelperText status="warning" mt="1">
-              Applies to Ingestion API events only&mdash;SDKs using the tracking
-              plugin always fold <code>id</code> into <code>device_id</code> on
-              the client, out of reach of this setting.
+              <span>
+                Applies to Ingestion API events only&mdash;SDKs using the
+                tracking plugin always fold <code>id</code> into{" "}
+                <code>device_id</code> on the client, out of reach of this
+                setting.
+              </span>
             </HelperText>
           ) : null}
         </Box>


### PR DESCRIPTION
### Features and Changes

Quick fix for a CSS issue I missed in #6515


### Screenshots

Current style on prod
<img width="937" height="322" alt="image" src="https://github.com/user-attachments/assets/29a37688-7ce7-4a61-afe6-577a8b368e5e" />


New style
<img width="951" height="321" alt="image" src="https://github.com/user-attachments/assets/e9fc2af2-d6c8-4893-9a2e-c65ea2aa0378" />
