### PR TITLE
Adds additional dashboard block controls

### DIFF
--- a/packages/front-end/components/Experiment/ResultsFilter/MigrateResultsToDashboardModalPages.tsx
+++ b/packages/front-end/components/Experiment/ResultsFilter/MigrateResultsToDashboardModalPages.tsx
@@ -25,7 +25,7 @@ import SelectField from "@/components/Forms/SelectField";
 import DashboardSelector from "@/enterprise/components/Dashboards/DashboardSelector";
 import { autoUpdateDisabledMessage } from "@/enterprise/components/Dashboards/DashboardsTab";
 import Link from "@/ui/Link";
-import { BLOCK_TYPE_INFO } from "@/enterprise/components/Dashboards/DashboardEditor";
+import { BLOCK_TYPE_INFO } from "@/enterprise/components/Dashboards/DashboardEditor/dashboardBlockTypes";
 import Avatar from "@/ui/Avatar";
 import Badge from "@/ui/Badge";
 

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/BlockErrorStates.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/BlockErrorStates.tsx
@@ -5,7 +5,7 @@ import {
 import { Flex, Text } from "@radix-ui/themes";
 import Callout from "@/ui/Callout";
 import LoadingSpinner from "@/components/LoadingSpinner";
-import { BLOCK_TYPE_INFO } from "@/enterprise/components/Dashboards/DashboardEditor";
+import { BLOCK_TYPE_INFO } from "@/enterprise/components/Dashboards/DashboardEditor/dashboardBlockTypes";
 
 interface BlockErrorStateProps {
   block: DashboardBlockInterfaceOrData<DashboardBlockInterface>;

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/index.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/index.tsx
@@ -3,6 +3,7 @@ import { ExperimentInterfaceStringDates } from "shared/types/experiment";
 import {
   DashboardBlockInterface,
   DashboardBlockInterfaceOrData,
+  DashboardBlockType,
   blockHasFieldOfType,
   blockUsesDashboardDateControl,
   DashboardInterface,
@@ -30,6 +31,7 @@ import {
   DropdownMenu,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownSubMenu,
 } from "@/ui/DropdownMenu";
 import { useExperiments } from "@/hooks/useExperiments";
 import {
@@ -41,8 +43,9 @@ import { useDefinitions } from "@/services/DefinitionsContext";
 import useApi from "@/hooks/useApi";
 import Field from "@/components/Forms/Field";
 import Badge from "@/ui/Badge";
-import { BLOCK_TYPE_INFO } from "@/enterprise/components/Dashboards/DashboardEditor";
 import { isSubmittableConfig } from "@/enterprise/components/ProductAnalytics/util";
+import { DashboardBlockTypeMenuItems } from "@/enterprise/components/Dashboards/DashboardEditor/DashboardBlockTypeMenu";
+import { BLOCK_TYPE_INFO } from "@/enterprise/components/Dashboards/DashboardEditor/dashboardBlockTypes";
 import MarkdownBlock from "./MarkdownBlock";
 import ExperimentMetadataBlock from "./ExperimentMetadataBlock";
 import ExperimentMetricBlock from "./ExperimentMetricBlock";
@@ -105,6 +108,7 @@ interface Props<DashboardBlock extends DashboardBlockInterface> {
   isFocused: boolean;
   isEditing: boolean;
   editingBlock: boolean;
+  canMoveBlock: boolean;
   disableBlock: "full" | "partial" | "none";
   scrollAreaRef: null | React.MutableRefObject<HTMLDivElement | null>;
   setBlock:
@@ -113,6 +117,9 @@ interface Props<DashboardBlock extends DashboardBlockInterface> {
   editBlock: () => void;
   duplicateBlock: () => void;
   deleteBlock: () => void;
+  addBlockBefore?: (bType: DashboardBlockType) => void;
+  addBlockAfter?: (bType: DashboardBlockType) => void;
+  isGeneralDashboard: boolean;
   mutate: () => void;
   canEdit?: boolean;
   setIsEditing?: (value: boolean) => void;
@@ -148,12 +155,16 @@ export default function DashboardBlock<T extends DashboardBlockInterface>({
   isEditing,
   isFocused,
   editingBlock,
+  canMoveBlock,
   disableBlock,
   scrollAreaRef,
   setBlock,
   editBlock,
   duplicateBlock,
   deleteBlock,
+  addBlockBefore,
+  addBlockAfter,
+  isGeneralDashboard,
   mutate,
   canEdit,
   setIsEditing,
@@ -446,7 +457,7 @@ export default function DashboardBlock<T extends DashboardBlockInterface>({
         ></div>
       )}
       <Flex align="center" mb="2">
-        {isEditing && !editingBlock && disableBlock !== "full" && (
+        {isEditing && canMoveBlock && disableBlock !== "full" && (
           <IconButton
             className="dashboard-block-drag-handle"
             variant="ghost"
@@ -572,6 +583,28 @@ export default function DashboardBlock<T extends DashboardBlockInterface>({
                 >
                   Duplicate
                 </DropdownMenuItem>
+                {disableBlock === "none" && addBlockBefore && addBlockAfter && (
+                  <>
+                    <DropdownSubMenu trigger="Add block before">
+                      <DashboardBlockTypeMenuItems
+                        isGeneralDashboard={isGeneralDashboard}
+                        onSelect={(bType) => {
+                          addBlockBefore(bType);
+                          setDropdownOpen(false);
+                        }}
+                      />
+                    </DropdownSubMenu>
+                    <DropdownSubMenu trigger="Add block after">
+                      <DashboardBlockTypeMenuItems
+                        isGeneralDashboard={isGeneralDashboard}
+                        onSelect={(bType) => {
+                          addBlockAfter(bType);
+                          setDropdownOpen(false);
+                        }}
+                      />
+                    </DropdownSubMenu>
+                  </>
+                )}
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
                   onClick={(e) => {

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlockTypeMenu.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlockTypeMenu.tsx
@@ -1,0 +1,104 @@
+import { Fragment, ReactNode, useState } from "react";
+import { DashboardBlockType } from "shared/enterprise";
+import {
+  DropdownMenu,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from "@/ui/DropdownMenu";
+import Text from "@/ui/Text";
+import {
+  BLOCK_SUBGROUPS,
+  BLOCK_TYPE_INFO,
+  getAvailableBlockTypes,
+} from "./dashboardBlockTypes";
+
+export function DashboardBlockTypeMenuItems({
+  isGeneralDashboard,
+  onSelect,
+  filterBlockType,
+}: {
+  isGeneralDashboard: boolean;
+  onSelect: (blockType: DashboardBlockType) => void;
+  filterBlockType?: (blockType: DashboardBlockType) => boolean;
+}) {
+  const availableBlockTypes = new Set(
+    getAvailableBlockTypes(isGeneralDashboard).filter(
+      (blockType) => !filterBlockType || filterBlockType(blockType),
+    ),
+  );
+
+  return (
+    <>
+      {BLOCK_SUBGROUPS.map(([subgroup, blockTypes], index) => {
+        const filteredBlockTypes = blockTypes.filter((blockType) =>
+          availableBlockTypes.has(blockType),
+        );
+        if (filteredBlockTypes.length === 0) return null;
+
+        return (
+          <Fragment key={subgroup}>
+            <DropdownMenuLabel>
+              <Text color="text-high" weight="semibold">
+                {subgroup}
+              </Text>
+            </DropdownMenuLabel>
+            {filteredBlockTypes.map((blockType) => (
+              <DropdownMenuItem
+                key={blockType}
+                onClick={() => onSelect(blockType)}
+              >
+                {BLOCK_TYPE_INFO[blockType].name}
+              </DropdownMenuItem>
+            ))}
+            {index < BLOCK_SUBGROUPS.length - 1 && <DropdownMenuSeparator />}
+          </Fragment>
+        );
+      })}
+    </>
+  );
+}
+
+export function AddBlockDropdown({
+  trigger,
+  addBlockType,
+  onDropdownOpen,
+  onDropdownClose,
+  isGeneralDashboard = false,
+  filterBlockType,
+}: {
+  trigger: ReactNode;
+  addBlockType: (blockType: DashboardBlockType) => void;
+  onDropdownOpen?: () => void;
+  onDropdownClose?: () => void;
+  isGeneralDashboard?: boolean;
+  filterBlockType?: (blockType: DashboardBlockType) => boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const updateOpen = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (nextOpen) {
+      onDropdownOpen?.();
+    } else {
+      onDropdownClose?.();
+    }
+  };
+
+  return (
+    <DropdownMenu
+      variant="solid"
+      open={open}
+      onOpenChange={updateOpen}
+      trigger={trigger}
+    >
+      <DashboardBlockTypeMenuItems
+        isGeneralDashboard={isGeneralDashboard}
+        filterBlockType={filterBlockType}
+        onSelect={(blockType) => {
+          updateOpen(false);
+          addBlockType(blockType);
+        }}
+      />
+    </DropdownMenu>
+  );
+}

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardEditorSidebar/EditSingleBlock.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardEditorSidebar/EditSingleBlock.tsx
@@ -73,7 +73,7 @@ import {
   useDashboardSnapshot,
   DashboardSnapshotContext,
 } from "@/enterprise/components/Dashboards/DashboardSnapshotProvider";
-import { BLOCK_TYPE_INFO } from "@/enterprise/components/Dashboards/DashboardEditor";
+import { BLOCK_TYPE_INFO } from "@/enterprise/components/Dashboards/DashboardEditor/dashboardBlockTypes";
 import { isSubmittableConfig } from "@/enterprise/components/ProductAnalytics/util";
 import MetricExplorerSettings from "./MetricExplorerSettings";
 import ProductAnalyticsExplorerSettings from "./ProductAnalyticsExplorerSettings";

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardEditorSidebar/index.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardEditorSidebar/index.tsx
@@ -26,25 +26,11 @@ import Button from "@/ui/Button";
 import {
   BLOCK_SUBGROUPS,
   BLOCK_TYPE_INFO,
-  isBlockTypeAllowed,
-} from "@/enterprise/components/Dashboards/DashboardEditor";
+  GENERAL_DASHBOARD_BLOCK_TYPES,
+  getAvailableBlockTypes,
+} from "@/enterprise/components/Dashboards/DashboardEditor/dashboardBlockTypes";
 import Text from "@/ui/Text";
 import EditSingleBlock from "./EditSingleBlock";
-
-// Block types that are allowed in general dashboards (non-experiment specific)
-const GENERAL_DASHBOARD_BLOCK_TYPES: DashboardBlockType[] = [
-  "markdown",
-  "metric-exploration",
-  "metric-experiments",
-  "experiments-scaled-impact",
-  "experiments-win-rate",
-  "experiments-status",
-  "fact-table-exploration",
-  "data-source-exploration",
-  "funnel-exploration",
-  "sql-explorer",
-  "metric-explorer",
-];
 
 function moveBlocks<T>(
   blocks: Array<T>,
@@ -104,7 +90,7 @@ interface Props {
   setStagedBlock: React.Dispatch<
     DashboardBlockInterfaceOrData<DashboardBlockInterface> | undefined
   >;
-  addBlockType: (bType: DashboardBlockType, i?: number) => void;
+  addBlockType: (bType: DashboardBlockType) => void;
   focusBlock: (index: number) => void;
   editBlock: (index: number) => void;
   duplicateBlock: (index: number) => void;
@@ -156,13 +142,16 @@ export default function DashboardEditorSidebar({
   }, [blocks, draggingBlockIndex, previewBlockPlacement]);
 
   const blockNavigatorEnabled = false;
+  const availableBlockTypes = useMemo(
+    () => new Set(getAvailableBlockTypes(isGeneralDashboard)),
+    [isGeneralDashboard],
+  );
 
   const addBlocksContent = (
     <Flex direction="column" align="start" px="4" pb="4" pt="2" gap="5">
       {BLOCK_SUBGROUPS.map(([subgroup, blockTypes], i) => {
-        // Filter block types based on dashboard type
-        const allowedBlockTypes = blockTypes.filter((bType) =>
-          isBlockTypeAllowed(bType, isGeneralDashboard),
+        const allowedBlockTypes = blockTypes.filter((blockType) =>
+          availableBlockTypes.has(blockType),
         );
 
         // Don't render the subgroup if no block types are allowed
@@ -188,9 +177,6 @@ export default function DashboardEditorSidebar({
             </Text>
 
             {allowedBlockTypes.map((bType) => {
-              if (BLOCK_TYPE_INFO[bType].deprecated) {
-                return null;
-              }
               return (
                 <Tooltip
                   key={bType}

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/dashboardBlockTypes.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/dashboardBlockTypes.tsx
@@ -1,0 +1,168 @@
+import { ReactElement } from "react";
+import { DashboardBlockType } from "shared/enterprise";
+import {
+  PiArticleMediumDuotone,
+  PiChartBar,
+  PiChartBarDuotone,
+  PiChartLineDuotone,
+  PiDatabase,
+  PiFileSqlDuotone,
+  PiFunnel,
+  PiGaugeDuotone,
+  PiListDashesDuotone,
+  PiTable,
+  PiTableDuotone,
+} from "react-icons/pi";
+
+type BlockTypeInfo = {
+  name: string;
+  icon: ReactElement;
+  description?: string;
+  deprecated?: boolean;
+};
+
+export const BLOCK_TYPE_INFO: Record<DashboardBlockType, BlockTypeInfo> = {
+  markdown: {
+    name: "Markdown",
+    icon: <PiArticleMediumDuotone />,
+    description: "Adds formatted text, links, and images to your dashboard.",
+  },
+  "experiment-metadata": {
+    name: "Experiment Metadata",
+    icon: <PiListDashesDuotone />,
+  },
+  "experiment-metric": {
+    name: "Metric Results",
+    icon: <PiTableDuotone />,
+  },
+  "metric-experiments": {
+    name: "Experiments with Lift",
+    icon: <PiTableDuotone />,
+    description: "Shows experiments with lift for a selected metric.",
+  },
+  "experiments-scaled-impact": {
+    name: "Scaled Impact",
+    icon: <PiChartLineDuotone />,
+    description:
+      "Shows the scaled impact of a metric across multiple experiments.",
+  },
+  "experiments-win-rate": {
+    name: "Win Percentage",
+    icon: <PiGaugeDuotone />,
+    description:
+      "Shows the win percentage for selected experiments, optionally filtered by project.",
+  },
+  "experiments-status": {
+    name: "Team Velocity",
+    icon: <PiChartBarDuotone />,
+    description:
+      "Shows number of experiments in each status (won, lost, inconclusive, and dnf) over a selected date range.",
+  },
+  "experiment-dimension": {
+    name: "Dimension Results",
+    icon: <PiTableDuotone />,
+  },
+  "experiment-time-series": {
+    name: "Time Series",
+    icon: <PiChartLineDuotone />,
+  },
+  "experiment-traffic": {
+    name: "Experiment Traffic",
+    icon: <PiChartLineDuotone />,
+  },
+  "sql-explorer": {
+    name: "Custom SQL Query",
+    icon: <PiFileSqlDuotone />,
+    description:
+      "Displays results and saved visualizations from a custom SQL query.",
+  },
+  "metric-explorer": {
+    name: "Metric",
+    icon: <PiFileSqlDuotone />,
+    description: "Shows an analysis of a single Fact Metric.",
+    deprecated: true,
+  },
+  "metric-exploration": {
+    name: "Metric Explorer",
+    icon: <PiChartBar />,
+    description:
+      "Charts one or more of your existing GrowthBook Metrics over a selected date range. View trends, compare time periods, and slice/dice your data.",
+  },
+  "fact-table-exploration": {
+    name: "Fact Table Explorer",
+    icon: <PiTable />,
+    description:
+      "Builds an analysis directly from events and columns in one of your existing Fact Tables.",
+  },
+  "data-source-exploration": {
+    name: "Data Source Explorer",
+    icon: <PiDatabase />,
+    description:
+      "Builds a custom analysis from tables and columns from one of your connected Data Sources.",
+  },
+  "funnel-exploration": {
+    name: "Funnel Explorer",
+    icon: <PiFunnel />,
+    description:
+      "Builds a custom funnel from events and columns from one of your existing Fact Tables.",
+  },
+};
+
+export const BLOCK_SUBGROUPS: [string, DashboardBlockType[]][] = [
+  [
+    "Metric Results",
+    ["experiment-metric", "experiment-dimension", "experiment-time-series"],
+  ],
+  ["Experiment Info", ["experiment-metadata", "experiment-traffic"]],
+  [
+    "Product Analytics",
+    [
+      "metric-exploration",
+      "fact-table-exploration",
+      "data-source-exploration",
+      "funnel-exploration",
+    ],
+  ],
+  [
+    "Experimentation",
+    [
+      "experiments-status",
+      "experiments-win-rate",
+      "metric-experiments",
+      "experiments-scaled-impact",
+    ],
+  ],
+  ["Other", ["sql-explorer", "markdown", "metric-explorer"]],
+];
+
+export const GENERAL_DASHBOARD_BLOCK_TYPES: DashboardBlockType[] = [
+  "sql-explorer",
+  "metric-explorer",
+  "metric-exploration",
+  "fact-table-exploration",
+  "data-source-exploration",
+  "funnel-exploration",
+  "metric-experiments",
+  "experiments-scaled-impact",
+  "experiments-win-rate",
+  "experiments-status",
+  "markdown",
+];
+
+export const isBlockTypeAllowed = (
+  blockType: DashboardBlockType,
+  isGeneralDashboard: boolean,
+): boolean =>
+  !isGeneralDashboard || GENERAL_DASHBOARD_BLOCK_TYPES.includes(blockType);
+
+export function getAvailableBlockTypes(
+  isGeneralDashboard: boolean,
+): DashboardBlockType[] {
+  return BLOCK_SUBGROUPS.flatMap(([, blockTypes]) =>
+    blockTypes.filter(
+      (blockType) =>
+        isBlockTypeAllowed(blockType, isGeneralDashboard) &&
+        !BLOCK_TYPE_INFO[blockType].deprecated,
+    ),
+  );
+}

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/dashboardLayout.ts
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/dashboardLayout.ts
@@ -1,0 +1,277 @@
+import {
+  DASHBOARD_GRID_COLS,
+  DashboardBlockInterface,
+  DashboardBlockInterfaceOrData,
+  DashboardBlockType,
+  getBlockSizeBounds,
+} from "shared/enterprise";
+import { LayoutItem } from "react-grid-layout";
+
+export const DASHBOARD_GRID_MARGIN = 12;
+
+export type BlockInsertionPlacement = "before" | "after" | "gap";
+
+export type AddBlockOptions = {
+  index?: number;
+  placement?: BlockInsertionPlacement;
+  initialLayout?: NonNullable<DashboardBlockInterface["layout"]>;
+};
+
+export type DashboardGridGap = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  insertIndex: number;
+};
+
+type DashboardBlock = DashboardBlockInterfaceOrData<DashboardBlockInterface>;
+
+function insertAtIndex(
+  blocks: DashboardBlock[],
+  block: DashboardBlock,
+  index: number,
+): DashboardBlock[] {
+  return [...blocks.slice(0, index), block, ...blocks.slice(index)];
+}
+
+function tryInsertInAnchorRow({
+  blocks,
+  block,
+  index,
+  placement,
+}: {
+  blocks: DashboardBlock[];
+  block: DashboardBlock;
+  index: number;
+  placement: Exclude<BlockInsertionPlacement, "gap">;
+}): DashboardBlock[] | null {
+  const anchorIndex = placement === "before" ? index : index - 1;
+  const anchorLayout =
+    anchorIndex >= 0 ? blocks[anchorIndex]?.layout : undefined;
+  if (!anchorLayout) return null;
+
+  const rowBlocks = blocks.filter(
+    (existingBlock) => existingBlock.layout?.y === anchorLayout.y,
+  );
+  const bounds = getBlockSizeBounds(block.type);
+  const inferredWidth = block.layout?.w ?? anchorLayout.w;
+  const inferredHeight = block.layout?.h ?? anchorLayout.h;
+  if (inferredWidth < bounds.minW || inferredHeight < bounds.minH) return null;
+
+  const precedingRowEnd = rowBlocks.reduce((maxX, existingBlock) => {
+    if (!existingBlock.layout || existingBlock.layout.x >= anchorLayout.x) {
+      return maxX;
+    }
+    return Math.max(maxX, existingBlock.layout.x + existingBlock.layout.w);
+  }, 0);
+  const insertionX =
+    placement === "before" ? precedingRowEnd : anchorLayout.x + anchorLayout.w;
+  const insertionEnd = insertionX + inferredWidth;
+  const firstOverlappingX = rowBlocks.reduce((minX, existingBlock) => {
+    if (
+      !existingBlock.layout ||
+      existingBlock.layout.x >= insertionEnd ||
+      existingBlock.layout.x + existingBlock.layout.w <= insertionX
+    ) {
+      return minX;
+    }
+    return Math.min(minX, existingBlock.layout.x);
+  }, Number.POSITIVE_INFINITY);
+  const shiftX = Number.isFinite(firstOverlappingX)
+    ? insertionEnd - firstOverlappingX
+    : 0;
+  const furthestEdge = rowBlocks.reduce((maxX, existingBlock) => {
+    if (!existingBlock.layout) return maxX;
+    const shiftedX =
+      shiftX > 0 && existingBlock.layout.x >= firstOverlappingX
+        ? existingBlock.layout.x + shiftX
+        : existingBlock.layout.x;
+    return Math.max(maxX, shiftedX + existingBlock.layout.w);
+  }, insertionEnd);
+  if (furthestEdge > DASHBOARD_GRID_COLS) return null;
+
+  const blocksWithShiftedRow = blocks.map((existingBlock) => {
+    if (
+      existingBlock.layout?.y !== anchorLayout.y ||
+      shiftX === 0 ||
+      existingBlock.layout.x < firstOverlappingX
+    ) {
+      return existingBlock;
+    }
+    return {
+      ...existingBlock,
+      layout: {
+        ...existingBlock.layout,
+        x: existingBlock.layout.x + shiftX,
+      },
+    };
+  });
+
+  return insertAtIndex(
+    blocksWithShiftedRow,
+    {
+      ...block,
+      layout: {
+        x: insertionX,
+        y: anchorLayout.y,
+        w: inferredWidth,
+        h: inferredHeight,
+      },
+    },
+    index,
+  );
+}
+
+function insertInNewRow(
+  blocks: DashboardBlock[],
+  block: DashboardBlock,
+  index: number,
+): DashboardBlock[] {
+  const precedingBlocks = blocks.slice(0, index);
+  const followingBlocks = blocks.slice(index);
+  const bounds = getBlockSizeBounds(block.type);
+  const w = block.layout?.w ?? bounds.w;
+  const h = block.layout?.h ?? bounds.h;
+  const insertionY = precedingBlocks.reduce((maxY, existingBlock) => {
+    if (!existingBlock.layout) return maxY;
+    return Math.max(maxY, existingBlock.layout.y + existingBlock.layout.h);
+  }, 0);
+  const firstFollowingY = followingBlocks.reduce(
+    (minY, existingBlock) =>
+      existingBlock.layout ? Math.min(minY, existingBlock.layout.y) : minY,
+    Number.POSITIVE_INFINITY,
+  );
+  const shiftY = Math.max(0, insertionY + h - firstFollowingY);
+  const shiftedFollowingBlocks = followingBlocks.map((existingBlock) => {
+    if (!existingBlock.layout) return existingBlock;
+    return {
+      ...existingBlock,
+      layout: {
+        ...existingBlock.layout,
+        y: existingBlock.layout.y + shiftY,
+      },
+    };
+  });
+
+  return [
+    ...precedingBlocks,
+    {
+      ...block,
+      layout: {
+        x: 0,
+        y: insertionY,
+        w: Math.min(w, DASHBOARD_GRID_COLS),
+        h,
+      },
+    },
+    ...shiftedFollowingBlocks,
+  ];
+}
+
+export function insertBlockAtIndex(
+  blocks: DashboardBlock[],
+  block: DashboardBlock,
+  index: number,
+  placement?: BlockInsertionPlacement,
+): DashboardBlock[] {
+  if (placement === "gap" && block.layout) {
+    return insertAtIndex(blocks, block, index);
+  }
+  if (blocks.some((existingBlock) => !existingBlock.layout)) {
+    return block.layout
+      ? insertInNewRow(blocks, block, index)
+      : insertAtIndex(blocks, block, index);
+  }
+  if (placement === "before" || placement === "after") {
+    const rowInsertion = tryInsertInAnchorRow({
+      blocks,
+      block,
+      index,
+      placement,
+    });
+    if (rowInsertion) return rowInsertion;
+  }
+  return insertInNewRow(blocks, block, index);
+}
+
+export function getHorizontalGridGaps(
+  layout: readonly LayoutItem[],
+): DashboardGridGap[] {
+  const rows = new Map<number, Array<{ item: LayoutItem; index: number }>>();
+  layout.forEach((item, index) => {
+    const row = rows.get(item.y) ?? [];
+    row.push({ item, index });
+    rows.set(item.y, row);
+  });
+
+  const isEmptyRectangle = (gap: DashboardGridGap): boolean =>
+    layout.every(
+      (item) =>
+        gap.x + gap.w <= item.x ||
+        gap.x >= item.x + item.w ||
+        gap.y + gap.h <= item.y ||
+        gap.y >= item.y + item.h,
+    );
+
+  return [...rows.entries()].flatMap(([y, row]) => {
+    const sortedRow = [...row].sort((a, b) => a.item.x - b.item.x);
+    const h = Math.min(...sortedRow.map(({ item }) => item.h));
+    const gaps: DashboardGridGap[] = [];
+    let nextX = 0;
+
+    sortedRow.forEach(({ item, index }) => {
+      if (item.x > nextX) {
+        gaps.push({
+          x: nextX,
+          y,
+          w: item.x - nextX,
+          h,
+          insertIndex: index,
+        });
+      }
+      nextX = Math.max(nextX, item.x + item.w);
+    });
+
+    const lastBlock = sortedRow[sortedRow.length - 1];
+    if (lastBlock && nextX < DASHBOARD_GRID_COLS) {
+      gaps.push({
+        x: nextX,
+        y,
+        w: DASHBOARD_GRID_COLS - nextX,
+        h,
+        insertIndex: lastBlock.index + 1,
+      });
+    }
+
+    return gaps.filter(isEmptyRectangle);
+  });
+}
+
+export function blockFitsGap(
+  blockType: DashboardBlockType,
+  gap: DashboardGridGap,
+): boolean {
+  const bounds = getBlockSizeBounds(blockType);
+  return bounds.minW <= gap.w && bounds.minH <= gap.h;
+}
+
+export function gridRectToPixels({
+  rect,
+  containerWidth,
+  rowHeight,
+}: {
+  rect: Pick<DashboardGridGap, "x" | "y" | "w" | "h">;
+  containerWidth: number;
+  rowHeight: number;
+}) {
+  const columnWidth =
+    (containerWidth - DASHBOARD_GRID_MARGIN * (DASHBOARD_GRID_COLS - 1)) /
+    DASHBOARD_GRID_COLS;
+  return {
+    left: rect.x * (columnWidth + DASHBOARD_GRID_MARGIN),
+    top: rect.y * (rowHeight + DASHBOARD_GRID_MARGIN),
+    width: rect.w * columnWidth + (rect.w - 1) * DASHBOARD_GRID_MARGIN,
+    height: rect.h * rowHeight + (rect.h - 1) * DASHBOARD_GRID_MARGIN,
+  };
+}

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/dashboardLayout.ts
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/dashboardLayout.ts
@@ -51,13 +51,19 @@ function tryInsertInAnchorRow({
     anchorIndex >= 0 ? blocks[anchorIndex]?.layout : undefined;
   if (!anchorLayout) return null;
 
-  const rowBlocks = blocks.filter(
-    (existingBlock) => existingBlock.layout?.y === anchorLayout.y,
-  );
   const bounds = getBlockSizeBounds(block.type);
   const inferredWidth = block.layout?.w ?? anchorLayout.w;
   const inferredHeight = block.layout?.h ?? anchorLayout.h;
   if (inferredWidth < bounds.minW || inferredHeight < bounds.minH) return null;
+  const insertionBottom = anchorLayout.y + inferredHeight;
+  const rowBlocks = blocks.filter((existingBlock) => {
+    const layout = existingBlock.layout;
+    return (
+      layout &&
+      layout.y < insertionBottom &&
+      layout.y + layout.h > anchorLayout.y
+    );
+  });
 
   const precedingRowEnd = rowBlocks.reduce((maxX, existingBlock) => {
     if (!existingBlock.layout || existingBlock.layout.x >= anchorLayout.x) {
@@ -93,7 +99,9 @@ function tryInsertInAnchorRow({
 
   const blocksWithShiftedRow = blocks.map((existingBlock) => {
     if (
-      existingBlock.layout?.y !== anchorLayout.y ||
+      !existingBlock.layout ||
+      existingBlock.layout.y >= insertionBottom ||
+      existingBlock.layout.y + existingBlock.layout.h <= anchorLayout.y ||
       shiftX === 0 ||
       existingBlock.layout.x < firstOverlappingX
     ) {
@@ -123,39 +131,75 @@ function tryInsertInAnchorRow({
   );
 }
 
+function getVerticalBand(
+  blocks: DashboardBlock[],
+  anchor: NonNullable<DashboardBlock["layout"]>,
+) {
+  let top = anchor.y;
+  let bottom = anchor.y + anchor.h;
+  let expanded = true;
+
+  while (expanded) {
+    expanded = false;
+    blocks.forEach((block) => {
+      const layout = block.layout;
+      if (!layout || layout.y >= bottom || layout.y + layout.h <= top) return;
+      const nextTop = Math.min(top, layout.y);
+      const nextBottom = Math.max(bottom, layout.y + layout.h);
+      if (nextTop !== top || nextBottom !== bottom) {
+        top = nextTop;
+        bottom = nextBottom;
+        expanded = true;
+      }
+    });
+  }
+
+  return { top, bottom };
+}
+
 function insertInNewRow(
   blocks: DashboardBlock[],
   block: DashboardBlock,
   index: number,
+  placement?: Exclude<BlockInsertionPlacement, "gap">,
 ): DashboardBlock[] {
-  const precedingBlocks = blocks.slice(0, index);
-  const followingBlocks = blocks.slice(index);
   const bounds = getBlockSizeBounds(block.type);
   const w = block.layout?.w ?? bounds.w;
   const h = block.layout?.h ?? bounds.h;
-  const insertionY = precedingBlocks.reduce((maxY, existingBlock) => {
-    if (!existingBlock.layout) return maxY;
-    return Math.max(maxY, existingBlock.layout.y + existingBlock.layout.h);
-  }, 0);
-  const firstFollowingY = followingBlocks.reduce(
-    (minY, existingBlock) =>
-      existingBlock.layout ? Math.min(minY, existingBlock.layout.y) : minY,
-    Number.POSITIVE_INFINITY,
-  );
-  const shiftY = Math.max(0, insertionY + h - firstFollowingY);
-  const shiftedFollowingBlocks = followingBlocks.map((existingBlock) => {
-    if (!existingBlock.layout) return existingBlock;
+  const anchorIndex =
+    placement === "before"
+      ? index
+      : placement === "after"
+        ? index - 1
+        : undefined;
+  const anchorLayout =
+    anchorIndex !== undefined && anchorIndex >= 0
+      ? blocks[anchorIndex]?.layout
+      : undefined;
+  const band = anchorLayout ? getVerticalBand(blocks, anchorLayout) : null;
+  const insertionY = band
+    ? placement === "before"
+      ? band.top
+      : band.bottom
+    : blocks.reduce((maxY, existingBlock) => {
+        if (!existingBlock.layout) return maxY;
+        return Math.max(maxY, existingBlock.layout.y + existingBlock.layout.h);
+      }, 0);
+  const shiftedBlocks = blocks.map((existingBlock) => {
+    if (!band || !existingBlock.layout || existingBlock.layout.y < insertionY) {
+      return existingBlock;
+    }
     return {
       ...existingBlock,
       layout: {
         ...existingBlock.layout,
-        y: existingBlock.layout.y + shiftY,
+        y: existingBlock.layout.y + h,
       },
     };
   });
 
-  return [
-    ...precedingBlocks,
+  return insertAtIndex(
+    shiftedBlocks,
     {
       ...block,
       layout: {
@@ -165,8 +209,8 @@ function insertInNewRow(
         h,
       },
     },
-    ...shiftedFollowingBlocks,
-  ];
+    index,
+  );
 }
 
 export function insertBlockAtIndex(
@@ -192,7 +236,12 @@ export function insertBlockAtIndex(
     });
     if (rowInsertion) return rowInsertion;
   }
-  return insertInNewRow(blocks, block, index);
+  return insertInNewRow(
+    blocks,
+    block,
+    index,
+    placement === "before" || placement === "after" ? placement : undefined,
+  );
 }
 
 export function getHorizontalGridGaps(

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/index.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/index.tsx
@@ -814,7 +814,6 @@ function DashboardGrid({
       // LegacyRef signature without changing runtime behaviour.
       ref={containerRef as unknown as React.RefObject<HTMLDivElement>}
       className={clsx("dashboard-grid-container", { "is-editing": isEditing })}
-      style={{ position: "relative" }}
     >
       {mounted && (
         <ResponsiveGridLayout

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/index.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/index.tsx
@@ -1,27 +1,5 @@
-import React, {
-  Fragment,
-  ReactElement,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
-import {
-  PiCaretDownFill,
-  PiTableDuotone,
-  PiChartLineDuotone,
-  PiFileSqlDuotone,
-  PiListDashesDuotone,
-  PiArticleMediumDuotone,
-  PiPencilSimpleFill,
-  PiDatabase,
-  PiTable,
-  PiChartBar,
-  PiFunnel,
-  PiChartBarDuotone,
-  PiGaugeDuotone,
-} from "react-icons/pi";
+import React, { useCallback, useContext, useMemo, useState } from "react";
+import { PiCaretDownFill, PiPencilSimpleFill } from "react-icons/pi";
 import { BsThreeDotsVertical } from "react-icons/bs";
 import {
   DashboardBlockInterfaceOrData,
@@ -54,7 +32,6 @@ import {
   DropdownMenu,
   DropdownMenuItem,
   DropdownMenuGroup,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
 } from "@/ui/DropdownMenu";
 import Callout from "@/ui/Callout";
@@ -74,156 +51,17 @@ import { DashboardSnapshotContext } from "@/enterprise/components/Dashboards/Das
 import DashboardUpdateDisplay from "./DashboardUpdateDisplay";
 import DashboardBlock from "./DashboardBlock";
 import DashboardGlobalControlsBar from "./DashboardGlobalControlsBar";
+import { AddBlockDropdown } from "./DashboardBlockTypeMenu";
+import { getAvailableBlockTypes } from "./dashboardBlockTypes";
+import {
+  AddBlockOptions,
+  blockFitsGap,
+  DASHBOARD_GRID_MARGIN,
+  getHorizontalGridGaps,
+  gridRectToPixels,
+} from "./dashboardLayout";
 
 export const DASHBOARD_TOPBAR_HEIGHT = "40px";
-type BlockTypeInfo = {
-  name: string;
-  icon: ReactElement;
-  description?: string;
-  deprecated?: boolean;
-};
-
-export const BLOCK_TYPE_INFO: Record<DashboardBlockType, BlockTypeInfo> = {
-  markdown: {
-    name: "Markdown",
-    icon: <PiArticleMediumDuotone />,
-    description: "Adds formatted text, links, and images to your dashboard.",
-  },
-  "experiment-metadata": {
-    name: "Experiment Metadata",
-    icon: <PiListDashesDuotone />,
-  },
-  "experiment-metric": {
-    name: "Metric Results",
-    icon: <PiTableDuotone />,
-  },
-  "metric-experiments": {
-    name: "Experiments with Lift",
-    icon: <PiTableDuotone />,
-    description: "Shows experiments with lift for a selected metric.",
-  },
-  "experiments-scaled-impact": {
-    name: "Scaled Impact",
-    icon: <PiChartLineDuotone />,
-    description:
-      "Shows the scaled impact of a metric across multiple experiments.",
-  },
-  "experiments-win-rate": {
-    name: "Win Percentage",
-    icon: <PiGaugeDuotone />,
-    description:
-      "Shows the win percentage for selected experiments, optionally filtered by project.",
-  },
-  "experiments-status": {
-    name: "Team Velocity",
-    icon: <PiChartBarDuotone />,
-    description:
-      "Shows number of experiments in each status (won, lost, inconclusive, and dnf) over a selected date range.",
-  },
-  "experiment-dimension": {
-    name: "Dimension Results",
-    icon: <PiTableDuotone />,
-  },
-  "experiment-time-series": {
-    name: "Time Series",
-    icon: <PiChartLineDuotone />,
-  },
-  "experiment-traffic": {
-    name: "Experiment Traffic",
-    icon: <PiChartLineDuotone />,
-  },
-  "sql-explorer": {
-    name: "Custom SQL Query",
-    icon: <PiFileSqlDuotone />,
-    description:
-      "Displays results and saved visualizations from a custom SQL query.",
-  },
-  "metric-explorer": {
-    name: "Metric",
-    icon: <PiFileSqlDuotone />,
-    description: "Shows an analysis of a single Fact Metric.",
-    deprecated: true,
-  },
-  "metric-exploration": {
-    name: "Metric Explorer",
-    icon: <PiChartBar />,
-    description:
-      "Charts one or more of your existing GrowthBook Metrics over a selected date range. View trends, compare time periods, and slice/dice your data.",
-  },
-  "fact-table-exploration": {
-    name: "Fact Table Explorer",
-    icon: <PiTable />,
-    description:
-      "Builds an analysis directly from events and columns in one of your existing Fact Tables.",
-  },
-  "data-source-exploration": {
-    name: "Data Source Explorer",
-    icon: <PiDatabase />,
-    description:
-      "Builds a custom analysis from tables and columns from one of your connected Data Sources.",
-  },
-  "funnel-exploration": {
-    name: "Funnel Explorer",
-    icon: <PiFunnel />,
-    description:
-      "Builds a custom funnel from events and columns from one of your connected Fact Tables.",
-  },
-};
-
-export const BLOCK_SUBGROUPS: [string, DashboardBlockType[]][] = [
-  [
-    "Metric Results",
-    ["experiment-metric", "experiment-dimension", "experiment-time-series"],
-  ],
-  ["Experiment Info", ["experiment-metadata", "experiment-traffic"]],
-  [
-    "Product Analytics",
-    [
-      "metric-exploration",
-      "fact-table-exploration",
-      "data-source-exploration",
-      "funnel-exploration",
-    ],
-  ],
-  [
-    "Experimentation",
-    [
-      "experiments-status",
-      "experiments-win-rate",
-      "metric-experiments",
-      "experiments-scaled-impact",
-    ],
-  ],
-  ["Other", ["sql-explorer", "markdown", "metric-explorer"]],
-];
-
-// Block types that are allowed in general dashboards (non-experiment specific)
-export const GENERAL_DASHBOARD_BLOCK_TYPES: DashboardBlockType[] = [
-  "sql-explorer",
-  "metric-explorer",
-  "metric-exploration",
-  "fact-table-exploration",
-  "data-source-exploration",
-  "funnel-exploration",
-  "metric-experiments",
-  "experiments-scaled-impact",
-  "experiments-win-rate",
-  "experiments-status",
-  "markdown",
-];
-
-// Helper function to check if a block type is allowed for the given dashboard type
-export const isBlockTypeAllowed = (
-  blockType: DashboardBlockType,
-  isGeneralDashboard: boolean,
-): boolean => {
-  if (isGeneralDashboard) {
-    return GENERAL_DASHBOARD_BLOCK_TYPES.includes(blockType);
-  } else {
-    return true; // All block types are allowed for experiment dashboards
-  }
-};
-
 // Stable RGL key for a block (uses block id when persisted, else a synthetic
 // key for the at-most-one staged add block).
 export function getGridKeyForBlock(
@@ -302,86 +140,16 @@ const CANONICAL_COL_BREAKPOINTS: ReadonlyArray<keyof typeof RGL_BREAKPOINTS> = (
   Object.keys(RGL_COLS) as Array<keyof typeof RGL_COLS>
 ).filter((bp) => RGL_COLS[bp] === RGL_COLS[RGL_CANONICAL_BREAKPOINT]);
 
-function AddBlockDropdown({
-  trigger,
-  addBlockType,
-  onDropdownOpen,
-  onDropdownClose,
-  isGeneralDashboard = false,
-}: {
-  trigger: React.ReactNode;
-  addBlockType: (bType: DashboardBlockType) => void;
-  onDropdownOpen?: () => void;
-  onDropdownClose?: () => void;
-  isGeneralDashboard?: boolean;
-}) {
-  const [dropdownOpen, setDropdownOpen] = useState<boolean>(false);
-  useEffect(() => {
-    if (dropdownOpen) {
-      onDropdownOpen && onDropdownOpen();
-    } else {
-      onDropdownClose && onDropdownClose();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dropdownOpen]);
-
-  return (
-    <DropdownMenu
-      variant="solid"
-      open={dropdownOpen}
-      onOpenChange={(o) => {
-        setDropdownOpen(!!o);
-      }}
-      trigger={trigger}
-    >
-      {BLOCK_SUBGROUPS.map(([subgroup, blockTypes], i) => {
-        // Filter block types based on dashboard type
-        const allowedBlockTypes = blockTypes.filter((bType) =>
-          isBlockTypeAllowed(bType, isGeneralDashboard),
-        );
-
-        // Don't render the subgroup if no block types are allowed
-        if (allowedBlockTypes.length === 0) {
-          return null;
-        }
-
-        return (
-          <Fragment key={`${subgroup}-${i}`}>
-            <DropdownMenuLabel>
-              <Text color="text-high" weight="semibold">
-                {subgroup}
-              </Text>
-            </DropdownMenuLabel>
-            {allowedBlockTypes.map((bType) => {
-              if (BLOCK_TYPE_INFO[bType].deprecated) {
-                return null;
-              }
-              return (
-                <DropdownMenuItem
-                  key={bType}
-                  onClick={() => {
-                    setDropdownOpen(false);
-                    addBlockType(bType);
-                  }}
-                >
-                  {BLOCK_TYPE_INFO[bType].name}
-                </DropdownMenuItem>
-              );
-            })}
-            {i < BLOCK_SUBGROUPS.length - 1 && <DropdownMenuSeparator />}
-          </Fragment>
-        );
-      })}
-    </DropdownMenu>
-  );
-}
-
 interface EditBlockProps {
   scrollAreaRef: null | React.MutableRefObject<HTMLDivElement | null>;
   editSidebarDirty: boolean;
   focusedBlockIndex: number | undefined;
   stagedBlockIndex: number | undefined;
-  addBlockType: (bType: DashboardBlockType, i?: number) => void;
+  isAddingBlock: boolean;
+  addBlockType: (
+    blockType: DashboardBlockType,
+    options?: AddBlockOptions,
+  ) => void;
   editBlock: (index: number) => void;
   duplicateBlock: (index: number) => void;
   deleteBlock: (index: number) => void;
@@ -458,6 +226,7 @@ function DashboardEditor({
     editSidebarDirty,
     focusedBlockIndex,
     stagedBlockIndex,
+    isAddingBlock,
     scrollAreaRef,
     addBlockType,
     editBlock,
@@ -533,6 +302,9 @@ function DashboardEditor({
         isEditing={isEditing}
         isFocused={isFocused}
         editingBlock={isEditingBlock}
+        canMoveBlock={
+          !isDefined(stagedBlockIndex) || (!isAddingBlock && isEditingBlock)
+        }
         disableBlock={
           editSidebarDirty && !isEditingBlock
             ? "full"
@@ -545,6 +317,22 @@ function DashboardEditor({
         editBlock={editBlock ? () => editBlock(i) : () => {}}
         duplicateBlock={duplicateBlock ? () => duplicateBlock(i) : () => {}}
         deleteBlock={deleteBlock ? () => deleteBlock(i) : () => {}}
+        addBlockBefore={
+          addBlockType
+            ? (blockType) =>
+                addBlockType(blockType, { index: i, placement: "before" })
+            : undefined
+        }
+        addBlockAfter={
+          addBlockType
+            ? (blockType) =>
+                addBlockType(blockType, {
+                  index: i + 1,
+                  placement: "after",
+                })
+            : undefined
+        }
+        isGeneralDashboard={isGeneralDashboard}
         mutate={mutate}
         canEdit={canEdit}
         setIsEditing={setIsEditing}
@@ -877,7 +665,10 @@ function DashboardEditor({
             isEditing={isEditing}
             editSidebarDirty={!!editSidebarDirty}
             stagedBlockIndex={stagedBlockIndex}
+            isAddingBlock={!!isAddingBlock}
             updateLayout={updateLayout}
+            addBlockType={addBlockType}
+            isGeneralDashboard={isGeneralDashboard}
             renderBlock={(block, i) =>
               renderSingleBlock({
                 i,
@@ -925,7 +716,12 @@ interface DashboardGridProps {
   isEditing: boolean;
   editSidebarDirty: boolean;
   stagedBlockIndex: number | undefined;
+  isAddingBlock: boolean;
   updateLayout: ((layout: readonly LayoutItem[]) => void) | undefined;
+  addBlockType:
+    | ((blockType: DashboardBlockType, options?: AddBlockOptions) => void)
+    | undefined;
+  isGeneralDashboard: boolean;
   renderBlock: (
     block: DashboardBlockInterfaceOrData<DashboardBlockInterface>,
     index: number,
@@ -933,25 +729,55 @@ interface DashboardGridProps {
 }
 
 // Wraps blocks in react-grid-layout so users can drag, drop, and resize.
-// Drag/resize are disabled outside edit mode and while a staged block is being
-// added/edited. We only persist layout changes from the canonical (lg)
+// Drag/resize are disabled outside edit mode and while a new block is being
+// added. We only persist layout changes from the canonical (lg)
 // breakpoint; smaller breakpoints are auto-derived for responsive viewing only.
 function DashboardGrid({
   blocks,
   isEditing,
   editSidebarDirty,
   stagedBlockIndex,
+  isAddingBlock,
   updateLayout,
+  addBlockType,
+  isGeneralDashboard,
   renderBlock,
 }: DashboardGridProps) {
   const { width, containerRef, mounted } = useContainerWidth({
     initialWidth: 1280,
   });
+  const [openGapKey, setOpenGapKey] = useState<string | null>(null);
+  const [isGridInteracting, setIsGridInteracting] = useState(false);
 
   const layout = useMemo(
     () => buildRGLLayout(blocks, RGL_COLS[RGL_CANONICAL_BREAKPOINT]),
     [blocks],
   );
+  const gaps = useMemo(() => {
+    if (
+      !isEditing ||
+      !addBlockType ||
+      editSidebarDirty ||
+      isGridInteracting ||
+      blocks.some((block) => !block.layout) ||
+      isDefined(stagedBlockIndex)
+    ) {
+      return [];
+    }
+    const allowedBlockTypes = getAvailableBlockTypes(isGeneralDashboard);
+    return getHorizontalGridGaps(layout).filter((gap) =>
+      allowedBlockTypes.some((blockType) => blockFitsGap(blockType, gap)),
+    );
+  }, [
+    addBlockType,
+    blocks,
+    editSidebarDirty,
+    isEditing,
+    isGeneralDashboard,
+    isGridInteracting,
+    layout,
+    stagedBlockIndex,
+  ]);
   // Every breakpoint shares the same canonical column count, so we hand RGL
   // the same layout for all of them. This is what makes side-by-side blocks
   // keep their x positions when the editing drawer narrows the container.
@@ -974,10 +800,7 @@ function DashboardGrid({
     [updateLayout],
   );
 
-  // While the side panel is open editing/adding a block, we disable RGL
-  // interaction so the user can't shuffle blocks mid-edit.
-  const isInteractive =
-    isEditing && !editSidebarDirty && !isDefined(stagedBlockIndex);
+  const isInteractive = isEditing && !isAddingBlock;
   // When we're in edit mode but interaction is disabled (because the edit
   // drawer is open), keep the resize handle visible-but-dimmed and surface a
   // tooltip explaining why it doesn't respond. Outside of edit mode the
@@ -991,6 +814,7 @@ function DashboardGrid({
       // LegacyRef signature without changing runtime behaviour.
       ref={containerRef as unknown as React.RefObject<HTMLDivElement>}
       className={clsx("dashboard-grid-container", { "is-editing": isEditing })}
+      style={{ position: "relative" }}
     >
       {mounted && (
         <ResponsiveGridLayout
@@ -1003,7 +827,7 @@ function DashboardGrid({
           breakpoints={RGL_BREAKPOINTS}
           cols={RGL_COLS}
           rowHeight={DASHBOARD_GRID_ROW_HEIGHT_DEFAULT}
-          margin={[12, 12]}
+          margin={[DASHBOARD_GRID_MARGIN, DASHBOARD_GRID_MARGIN]}
           containerPadding={[0, 0]}
           dragConfig={{
             enabled: isInteractive,
@@ -1011,15 +835,38 @@ function DashboardGrid({
             bounded: false,
             threshold: 3,
           }}
-          resizeConfig={{ enabled: isInteractive, handles: ["se"] }}
+          resizeConfig={{
+            enabled: isInteractive,
+            handles: ["se", "sw"],
+          }}
           compactor={verticalCompactor}
-          onDragStop={(curr) => persistLayout(curr)}
-          onResizeStop={(curr) => persistLayout(curr)}
+          onDragStart={() => {
+            setOpenGapKey(null);
+            setIsGridInteracting(true);
+          }}
+          onDragStop={(curr) => {
+            persistLayout(curr);
+            setIsGridInteracting(false);
+          }}
+          onResizeStart={() => {
+            setOpenGapKey(null);
+            setIsGridInteracting(true);
+          }}
+          onResizeStop={(curr) => {
+            persistLayout(curr);
+            setIsGridInteracting(false);
+          }}
         >
           {blocks.map((block, i) => {
             const key = getGridKeyForBlock(block, i);
             return (
-              <div key={key} className="dashboard-grid-item">
+              <div
+                key={key}
+                className={clsx("dashboard-grid-item", {
+                  "is-grid-interaction-disabled":
+                    isDefined(stagedBlockIndex) && i !== stagedBlockIndex,
+                })}
+              >
                 {renderBlock(block, i)}
                 {showDisabledResizeOverlay && (
                   // Tooltip wraps its children in an inline <span> and anchors
@@ -1045,6 +892,54 @@ function DashboardGrid({
           })}
         </ResponsiveGridLayout>
       )}
+      {mounted &&
+        addBlockType &&
+        gaps.map((gap) => {
+          const gapKey = `${gap.x}-${gap.y}-${gap.w}-${gap.h}`;
+          const gapStyle = gridRectToPixels({
+            rect: gap,
+            containerWidth: width,
+            rowHeight: DASHBOARD_GRID_ROW_HEIGHT_DEFAULT,
+          });
+
+          return (
+            <div
+              key={gapKey}
+              className={clsx("dashboard-grid-add-block-gap", {
+                "is-open": openGapKey === gapKey,
+              })}
+              style={gapStyle}
+            >
+              <AddBlockDropdown
+                isGeneralDashboard={isGeneralDashboard}
+                filterBlockType={(blockType) => blockFitsGap(blockType, gap)}
+                onDropdownOpen={() => setOpenGapKey(gapKey)}
+                onDropdownClose={() =>
+                  setOpenGapKey((currentKey) =>
+                    currentKey === gapKey ? null : currentKey,
+                  )
+                }
+                addBlockType={(blockType) => {
+                  addBlockType(blockType, {
+                    index: gap.insertIndex,
+                    placement: "gap",
+                    initialLayout: {
+                      x: gap.x,
+                      y: gap.y,
+                      w: gap.w,
+                      h: gap.h,
+                    },
+                  });
+                }}
+                trigger={
+                  <Button size="sm" variant="outline">
+                    Add block
+                  </Button>
+                }
+              />
+            </div>
+          );
+        })}
     </div>
   );
 }

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/index.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/index.tsx
@@ -749,10 +749,17 @@ function DashboardGrid({
   const [openGapKey, setOpenGapKey] = useState<string | null>(null);
   const [isGridInteracting, setIsGridInteracting] = useState(false);
 
-  const layout = useMemo(
-    () => buildRGLLayout(blocks, RGL_COLS[RGL_CANONICAL_BREAKPOINT]),
-    [blocks],
-  );
+  const layout = useMemo(() => {
+    const nextLayout = buildRGLLayout(
+      blocks,
+      RGL_COLS[RGL_CANONICAL_BREAKPOINT],
+    );
+    if (!isDefined(stagedBlockIndex) || isAddingBlock) return nextLayout;
+    return nextLayout.map((item, index) => ({
+      ...item,
+      static: index !== stagedBlockIndex,
+    }));
+  }, [blocks, isAddingBlock, stagedBlockIndex]);
   const gaps = useMemo(() => {
     if (
       !isEditing ||

--- a/packages/front-end/enterprise/components/Dashboards/DashboardWorkspace.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardWorkspace.tsx
@@ -705,7 +705,9 @@ export default function DashboardWorkspace({
               setBlocks={setBlocksAndSubmit}
               setStagedBlock={(block) => {
                 if (stagedInsert) {
-                  setStagedInsert({ ...stagedInsert, block });
+                  setStagedInsert(
+                    block ? { ...stagedInsert, block } : undefined,
+                  );
                 } else {
                   setStagedEditBlock(block);
                 }

--- a/packages/front-end/enterprise/components/Dashboards/DashboardWorkspace.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardWorkspace.tsx
@@ -36,16 +36,25 @@ import LoadingSpinner from "@/components/LoadingSpinner";
 import { useExploreData } from "@/enterprise/components/ProductAnalytics/useExploreData";
 import DashboardEditor, {
   DASHBOARD_TOPBAR_HEIGHT,
-  GENERAL_DASHBOARD_BLOCK_TYPES,
   getGridKeyForBlock,
-  isBlockTypeAllowed,
 } from "./DashboardEditor";
 import { SubmitDashboard, UpdateDashboardArgs } from "./DashboardsTab";
 import DashboardEditorSidebar from "./DashboardEditor/DashboardEditorSidebar";
+import { isBlockTypeAllowed } from "./DashboardEditor/dashboardBlockTypes";
+import {
+  AddBlockOptions,
+  insertBlockAtIndex,
+} from "./DashboardEditor/dashboardLayout";
 import DashboardModal from "./DashboardModal";
 
 export const DASHBOARD_WORKSPACE_NAV_HEIGHT = "72px";
 export const DASHBOARD_WORKSPACE_NAV_BOTTOM_PADDING = "12px";
+
+type StagedInsert = {
+  block: DashboardBlockInterfaceOrData<DashboardBlockInterface>;
+  index: number;
+  placement?: AddBlockOptions["placement"];
+};
 
 interface Props {
   isTabActive: boolean;
@@ -243,8 +252,7 @@ export default function DashboardWorkspace({
   const [hasMadeChanges, setHasMadeChanges] = useState(false);
 
   const clearEditingState = () => {
-    setAddBlockIndex(undefined);
-    setStagedAddBlock(undefined);
+    setStagedInsert(undefined);
     setEditingBlockIndex(undefined);
     setStagedEditBlock(undefined);
     setEditSidebarDirty(false);
@@ -267,20 +275,20 @@ export default function DashboardWorkspace({
     onConsumeInitialEditBlockIndex?.();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialEditBlockIndex, onConsumeInitialEditBlockIndex]);
-  const [addBlockIndex, setAddBlockIndex] = useState<number | undefined>(
-    undefined,
-  );
-  const [stagedAddBlock, setStagedAddBlock] = useState<
-    DashboardBlockInterfaceOrData<DashboardBlockInterface> | undefined
-  >(undefined);
+  const [stagedInsert, setStagedInsert] = useState<StagedInsert | undefined>();
   const [stagedEditBlock, setStagedEditBlock] = useState<
     DashboardBlockInterfaceOrData<DashboardBlockInterface> | undefined
   >(undefined);
 
   useEffect(() => {
     if (!globalControls?.dateRange) return;
-    setStagedAddBlock((block) =>
-      block ? autoEnrollDashboardBlocksInDateControl([block])[0] : block,
+    setStagedInsert((insert) =>
+      insert
+        ? {
+            ...insert,
+            block: autoEnrollDashboardBlocksInDateControl([insert.block])[0],
+          }
+        : insert,
     );
     setStagedEditBlock((block) =>
       block ? autoEnrollDashboardBlocksInDateControl([block])[0] : block,
@@ -289,34 +297,25 @@ export default function DashboardWorkspace({
 
   // Whenever a block becomes staged (via add, duplicate, or edit), make sure
   // the editing drawer is open so the user can actually configure/save it.
-  // Without this, paths like duplicateBlock - which only set addBlockIndex +
-  // stagedAddBlock - leave a staged block with no visible way to commit it
-  // when the drawer happens to be collapsed.
   useEffect(() => {
-    if (isDefined(addBlockIndex) || isDefined(editingBlockIndex)) {
+    if (stagedInsert || isDefined(editingBlockIndex)) {
       setEditSidebarExpanded(true);
     }
-  }, [addBlockIndex, editingBlockIndex]);
+  }, [stagedInsert, editingBlockIndex]);
 
   const [dashboardCopy] = useState<DashboardInterface | undefined>(
     cloneDeep(dashboard),
   );
 
-  const addBlockType = (bType: DashboardBlockType, index?: number) => {
+  const addBlockType = (
+    bType: DashboardBlockType,
+    options: AddBlockOptions = {},
+  ) => {
+    const { index = blocks.length, placement, initialLayout } = options;
     // Validate that the block type is allowed for this dashboard type
     if (!isBlockTypeAllowed(bType, isGeneralDashboard)) {
       console.warn(
         `Block type ${bType} is not allowed for ${isGeneralDashboard ? "general" : "experiment"} dashboards`,
-      );
-      return;
-    }
-
-    index = index ?? blocks.length;
-
-    // For general dashboards, only allow blocks that don't require experiment
-    if (isGeneralDashboard && !GENERAL_DASHBOARD_BLOCK_TYPES.includes(bType)) {
-      console.warn(
-        `Block type ${bType} requires an experiment and cannot be used in general dashboards`,
       );
       return;
     }
@@ -344,40 +343,38 @@ export default function DashboardWorkspace({
         : undefined,
     });
 
-    setStagedAddBlock(
-      isDashboardGlobalControlSupportedBlock(blockData)
-        ? {
-            ...blockData,
-            globalControlSettings: {
-              ...blockData.globalControlSettings,
-              dateRange: true,
-            },
-          }
-        : blockData,
-    );
-    setAddBlockIndex(index);
+    const blockWithGlobalControls = isDashboardGlobalControlSupportedBlock(
+      blockData,
+    )
+      ? {
+          ...blockData,
+          globalControlSettings: {
+            ...blockData.globalControlSettings,
+            dateRange: true,
+          },
+        }
+      : blockData;
+    setStagedInsert({
+      block: initialLayout
+        ? { ...blockWithGlobalControls, layout: initialLayout }
+        : blockWithGlobalControls,
+      index,
+      placement,
+    });
     setEditSidebarDirty(true);
   };
 
-  const effectiveBlocks = blocks
-    .flatMap<DashboardBlockInterfaceOrData<DashboardBlockInterface>>(
-      (block, i) => {
-        // Show in-progress edits directly on the block
-        const isEditingBlock = i === editingBlockIndex;
-        const effectiveBlock = isEditingBlock
-          ? (stagedEditBlock ?? block)
-          : block;
-        if (i === addBlockIndex && isDefined(stagedAddBlock)) {
-          return [stagedAddBlock, effectiveBlock];
-        }
-        return effectiveBlock;
-      },
-    )
-    .concat(
-      addBlockIndex === blocks.length && isDefined(stagedAddBlock)
-        ? [stagedAddBlock]
-        : [],
-    );
+  const blocksWithStagedEdit = blocks.map((block, i) =>
+    i === editingBlockIndex ? (stagedEditBlock ?? block) : block,
+  );
+  const effectiveBlocks = stagedInsert
+    ? insertBlockAtIndex(
+        blocksWithStagedEdit,
+        stagedInsert.block,
+        stagedInsert.index,
+        stagedInsert.placement,
+      )
+    : blocksWithStagedEdit;
 
   const focusBlock = (i: number) => {
     setFocusedBlockIndex(i);
@@ -396,14 +393,13 @@ export default function DashboardWorkspace({
     clearEditingState();
   };
 
-  // Strip layout so the duplicate doesn't land on top of the source block
-  // (normalizeLayouts on the server doesn't resolve overlaps).
   const duplicateBlock = (i: number) => {
-    setAddBlockIndex(i + 1);
-    setStagedAddBlock({
-      ...getBlockData(effectiveBlocks[i]),
-      layout: undefined,
+    setStagedInsert({
+      block: getBlockData(effectiveBlocks[i]),
+      index: i + 1,
+      placement: "after",
     });
+    setEditSidebarDirty(true);
   };
 
   return (
@@ -566,8 +562,10 @@ export default function DashboardWorkspace({
               setBlock={(i, block) => {
                 if (i === editingBlockIndex) {
                   setStagedEditBlock(block);
-                } else if (i === addBlockIndex) {
-                  setStagedAddBlock(block);
+                } else if (i === stagedInsert?.index) {
+                  setStagedInsert((insert) =>
+                    insert ? { ...insert, block } : insert,
+                  );
                 } else {
                   setBlocksAndSubmit([
                     ...blocks.slice(0, i),
@@ -579,11 +577,11 @@ export default function DashboardWorkspace({
               editBlockProps={{
                 editSidebarDirty: editSidebarDirty,
                 focusedBlockIndex: focusedBlockIndex,
-                stagedBlockIndex: addBlockIndex ?? editingBlockIndex,
+                stagedBlockIndex: stagedInsert?.index ?? editingBlockIndex,
+                isAddingBlock: !!stagedInsert,
                 scrollAreaRef: scrollAreaRef,
                 updateLayout: (layouts: readonly LayoutItem[]) => {
-                  if (isDefined(addBlockIndex) || isDefined(editingBlockIndex))
-                    return;
+                  if (stagedInsert) return;
                   const byId = new Map(layouts.map((l) => [l.i, l] as const));
                   let changed = false;
                   const next = blocks.map((b, index) => {
@@ -612,6 +610,14 @@ export default function DashboardWorkspace({
                     return { ...b, layout: nextLayout };
                   });
                   if (!changed) return;
+                  if (isDefined(editingBlockIndex)) {
+                    const editedLayout = next[editingBlockIndex]?.layout;
+                    if (editedLayout) {
+                      setStagedEditBlock((block) =>
+                        block ? { ...block, layout: editedLayout } : block,
+                      );
+                    }
+                  }
                   setBlocksAndSubmit(next);
                 },
                 addBlockType: addBlockType,
@@ -641,7 +647,7 @@ export default function DashboardWorkspace({
                 maxHeight: DASHBOARD_TOPBAR_HEIGHT,
               }}
             >
-              {isDefined(addBlockIndex) || isDefined(editingBlockIndex) ? (
+              {stagedInsert || isDefined(editingBlockIndex) ? (
                 <IconButton
                   mb="1"
                   onClick={clearEditingState}
@@ -673,12 +679,15 @@ export default function DashboardWorkspace({
               open={editSidebarExpanded}
               cancel={clearEditingState}
               submit={() => {
-                if (isDefined(addBlockIndex) && isDefined(stagedAddBlock)) {
-                  setBlocksAndSubmit([
-                    ...blocks.slice(0, addBlockIndex),
-                    stagedAddBlock,
-                    ...blocks.slice(addBlockIndex),
-                  ]);
+                if (stagedInsert) {
+                  setBlocksAndSubmit(
+                    insertBlockAtIndex(
+                      blocks,
+                      stagedInsert.block,
+                      stagedInsert.index,
+                      stagedInsert.placement,
+                    ),
+                  );
                 } else if (
                   isDefined(editingBlockIndex) &&
                   isDefined(stagedEditBlock)
@@ -692,14 +701,14 @@ export default function DashboardWorkspace({
                 clearEditingState();
               }}
               blocks={blocks}
-              stagedBlock={
-                isDefined(stagedAddBlock) ? stagedAddBlock : stagedEditBlock
-              }
+              stagedBlock={stagedInsert?.block ?? stagedEditBlock}
               setBlocks={setBlocksAndSubmit}
               setStagedBlock={(block) => {
-                isDefined(stagedAddBlock)
-                  ? setStagedAddBlock(block)
-                  : setStagedEditBlock(block);
+                if (stagedInsert) {
+                  setStagedInsert({ ...stagedInsert, block });
+                } else {
+                  setStagedEditBlock(block);
+                }
                 setEditSidebarDirty(true);
               }}
               addBlockType={addBlockType}

--- a/packages/front-end/enterprise/components/Dashboards/DashboardWorkspace.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardWorkspace.tsx
@@ -617,6 +617,7 @@ export default function DashboardWorkspace({
                         block ? { ...block, layout: editedLayout } : block,
                       );
                     }
+                    return;
                   }
                   setBlocksAndSubmit(next);
                 },

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -3781,6 +3781,10 @@ input:disabled {
 }
 
 // react-grid-layout overrides for dashboard blocks
+.dashboard-grid-container {
+  position: relative;
+}
+
 .dashboard-grid {
   position: relative;
 

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -3792,6 +3792,10 @@ input:disabled {
     height: 100%;
     width: 100%;
     position: relative;
+
+    &.is-grid-interaction-disabled .react-resizable-handle {
+      display: none !important;
+    }
   }
 
   // RGL adds .react-resizable-handle on every item; only show it while the
@@ -3825,6 +3829,35 @@ input:disabled {
     border: 2px dashed var(--violet-9);
     border-radius: 6px;
     opacity: 1 !important;
+  }
+}
+
+.dashboard-grid-add-block-gap {
+  position: absolute;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed transparent;
+  border-radius: 6px;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease;
+
+  button {
+    opacity: 0;
+    transition: opacity 120ms ease;
+  }
+
+  &:hover,
+  &:focus-within,
+  &.is-open {
+    background: var(--violet-a2);
+    border-color: var(--violet-a7);
+
+    button {
+      opacity: 1;
+    }
   }
 }
 

--- a/packages/shared/src/enterprise/validators/dashboard-block.ts
+++ b/packages/shared/src/enterprise/validators/dashboard-block.ts
@@ -55,7 +55,7 @@ export const DEFAULT_BLOCK_SIZE_BY_TYPE: Record<
   DashboardBlockType,
   BlockSizeBounds
 > = {
-  markdown: { w: DASHBOARD_GRID_COLS, h: 3, minW: 4, minH: 2 },
+  markdown: { w: DASHBOARD_GRID_COLS, h: 3, minW: 8, minH: 2 },
   "experiment-metadata": { w: DASHBOARD_GRID_COLS, h: 8, minW: 12, minH: 4 },
   "experiment-traffic": { w: DASHBOARD_GRID_COLS, h: 8, minW: 12, minH: 4 },
   "experiment-metric": { w: DASHBOARD_GRID_COLS, h: 8, minW: 12, minH: 4 },


### PR DESCRIPTION
### Features and Changes

- Adds “Add block before” and “Add block after” actions to dashboard block menus, with block types filtered by dashboard compatibility.
- Intelligently sizes and positions inserted blocks based on neighboring layouts, preserves duplicate block dimensions, and avoids overlapping existing blocks.
- Adds contextual “Add block” controls to usable empty spaces within dashboard rows.
- Allows existing blocks to be dragged and resized while their configuration panel is open, while keeping staged additions and unrelated blocks locked.
- Adds resize handles to both bottom corners.
- Centralizes dashboard block metadata, menus, gap detection, and layout planning into reusable helpers.

- Closes **(add link to issue here)**

### Dependencies

None.

### Testing

- [x] Verify block menus contain “Add block before” and “Add block after”.
- [x] Verify available block types are correct for general and experiment dashboards.
- [x] Add blocks before and after the first, middle, and last blocks.
- [x] Verify inserted blocks reuse neighboring dimensions when space permits.
- [x] Verify insertion falls back to a new row when insufficient horizontal space exists.
- [x] Duplicate resized blocks and verify dimensions are preserved without overlap.
- [x] Hover over usable row gaps and verify the “Add block” control appears.
- [x] Verify gap menus only show block types that fit.
- [x] Verify gap controls remain highlighted while their dropdown is open.
- [x] Verify gap controls remain hidden during dragging, resizing, and staged edits.
- [x] Drag and resize an existing block while its configuration panel is open.
- [x] Verify both bottom-left and bottom-right resize handles work.
- [x] Verify canceling and saving staged block changes preserve the expected layout.

### Screenshots / Videos

Silent walkthrough video
https://www.loom.com/share/401a3ba899b749d1bb9f5bdeac7f05e8

<img width="1509" height="822" alt="Screenshot 2026-07-31 at 8 51 40 AM" src="https://github.com/user-attachments/assets/1e97c0c6-d0ab-4b76-91e9-877a30126e08" />
<img width="1506" height="821" alt="Screenshot 2026-07-31 at 8 51 49 AM" src="https://github.com/user-attachments/assets/4e890b2b-b7a9-4127-bff1-e6c2b44f0b9a" />
