### PR TITLE
CBAQ Attribute Validation Fix 

### DIFF
--- a/packages/front-end/components/ContextualBandit/AddEditContextualBanditQueryModal.tsx
+++ b/packages/front-end/components/ContextualBandit/AddEditContextualBanditQueryModal.tsx
@@ -151,7 +151,7 @@ export const AddEditContextualBanditQueryModal: FC<Props> = ({
     }
 
     const missingInQuery = columns.filter(
-      (col) => !new RegExp(`\\b${col}\\b`).test(value.query ?? ""),
+      (col) => !new RegExp(`\\b${col}\\b`, "i").test(value.query ?? ""),
     );
     if (missingInQuery.length > 0) {
       throw new Error(
@@ -192,8 +192,11 @@ export const AddEditContextualBanditQueryModal: FC<Props> = ({
 
   const validateResponse = (result: TestQueryRow) => {
     if (!result) return;
+    const returnedColumns = new Set(
+      Object.keys(result).map((c) => c.toLowerCase()),
+    );
     const missingColumns = Array.from(requiredColumns).filter(
-      (col) => !(col in result),
+      (col) => !returnedColumns.has(col.toLowerCase()),
     );
     if (missingColumns.length > 0) {
       throw new Error(


### PR DESCRIPTION
### Features and Changes

Fixes broken targeting-attribute validation in the Contextual Bandit Assignment Query (CBAQ) modal, where a **compliant SQL query could fail the Test Query check** depending on the order of operations.

The root cause: `validateResponse` matched required columns against the query's returned columns using an exact, case-sensitive `col in result` check. GrowthBook attribute properties are often camelCase (e.g. `userCountry`), but warehouses fold unquoted identifiers (Postgres/Redshift lowercase, Snowflake uppercase), so a valid `... as userCountry` alias comes back as `usercountry`/`USERCOUNTRY` and was reported as missing. Because base columns are all lowercase snake_case, only targeting attributes broke — and only when added to the list before editing SQL, which put them under the test gate.

Changes:
- `validateResponse` now compares required columns to returned columns case-insensitively.
- Applied the same case-insensitive treatment to the save-time `missingInQuery` regex, so a query that passes Test Query can't then be rejected on save.

Validation still runs on Test Query; behavior is now order-independent (adding the attribute before or after editing SQL behaves identically).

- Closes **(add link to issue here)**

### Dependencies

None.

### Testing

1. In a CBAQ modal, select a **camelCase** targeting attribute (e.g. `userCountry`) before customizing SQL.
2. Customize SQL with a compliant `... as userCountry` alias and run Test Query with "Test query before confirming" checked.
3. Confirm the query saves without a spurious "You are missing the following columns" error.
4. Verify both orders (attribute-first and SQL-first) behave the same, and that a genuinely missing column still errors.

### Screenshots

N/A — no visual changes.