### PR TITLE
Stop double-logging our own backend telemetry events

### DIFF
--- a/packages/back-end/src/services/growthbook.ts
+++ b/packages/back-end/src/services/growthbook.ts
@@ -1,9 +1,4 @@
-import {
-  GrowthBookClient,
-  setPolyfills,
-  EVENT_EXPERIMENT_VIEWED,
-  EVENT_FEATURE_EVALUATED,
-} from "@growthbook/growthbook";
+import { GrowthBookClient, setPolyfills } from "@growthbook/growthbook";
 import { growthbookTrackingPlugin } from "@growthbook/growthbook/plugins";
 import { EventSource } from "eventsource";
 import { NextFunction, Request, Response } from "express";
@@ -47,35 +42,6 @@ function createGrowthBookClient(): GrowthBookClient<AppFeatures> {
         dedupeKeyAttributes: ["id", "organizationId"],
       }),
     ],
-    onFeatureUsage: (key, result, userContext) => {
-      client.logEvent(
-        EVENT_FEATURE_EVALUATED,
-        {
-          feature: key,
-          source: result.source,
-          value: result.value,
-          ruleId:
-            result.source === "defaultValue" ? "$default" : result.ruleId || "",
-          variationId: result.experimentResult
-            ? result.experimentResult.key
-            : "",
-        },
-        userContext,
-      );
-    },
-  });
-
-  // GrowthBookClient does not pass eventLogger into the eval context (unlike the
-  // browser SDK), so route experiment callbacks through logEvent for the plugin.
-  client.setTrackingCallback((experiment, result, userContext) => {
-    client.logEvent(
-      EVENT_EXPERIMENT_VIEWED,
-      {
-        experimentId: experiment.key,
-        variationId: result.key,
-      },
-      userContext,
-    );
   });
 
   return client;


### PR DESCRIPTION
Follow-up to #6491. Now that `GrowthBookClient` fires Feature Evaluated and Experiment Viewed on its own, our back-end telemetry client was logging both a second time by hand.

Experiment Viewed was duplicated outright — the manual payload carried only `experimentId` and `variationId` while the SDK's also carries `hashAttribute` and `hashValue`, so the de-dupe cache saw two different events. Feature Evaluated escaped duplication only because the hand-written payload happened to match the SDK's field for field.

Removing both shims. Exposures now also carry the hash attribute and value, which they previously lost.

Verified against the real client options: two users produce one Feature Evaluated and one Experiment Viewed each, and the `accountPlan: "loading"` filter still suppresses events as before.
