### PR TITLE
fix(ui): align variation numbers at 1x density

### DIFF
--- a/packages/front-end/ui/VariationNumber.module.scss
+++ b/packages/front-end/ui/VariationNumber.module.scss
@@ -28,6 +28,10 @@ $text-colors:
     border: 1px solid var(--slate-a11);
     border-radius: 50%;
     box-sizing: border-box;
+
+    .number {
+      display: inline-block;
+    }
   }
 
   @for $i from 0 through 99 {

--- a/packages/front-end/ui/VariationNumber.module.scss
+++ b/packages/front-end/ui/VariationNumber.module.scss
@@ -31,6 +31,11 @@ $text-colors:
 
     .number {
       display: inline-block;
+
+      // At 1×, glyphs for the 11px Inter face rasterize half a pixel left.
+      @media (resolution: 1dppx) {
+        transform: translateX(0.5px);
+      }
     }
   }
 

--- a/packages/front-end/ui/VariationNumber.tsx
+++ b/packages/front-end/ui/VariationNumber.tsx
@@ -6,33 +6,18 @@ type VariationNumberProps = { number: number } & ComponentPropsWithoutRef<
   typeof Box
 >;
 
-type DigitEdgeMetrics = {
-  actualLeft: number;
-  trailingSpace: number;
-};
-
-// Canvas text metrics for Inter 500 at 11px, matching VariationNumber.module.scss.
-const interDigitEdgeMetrics = new Map<string, DigitEdgeMetrics>([
-  ["0", { actualLeft: -0.605, trailingSpace: 0.605 }],
-  ["1", { actualLeft: -0.51, trailingSpace: 0.886 }],
-  ["2", { actualLeft: -0.764, trailingSpace: 0.722 }],
-  ["3", { actualLeft: -0.624, trailingSpace: 0.605 }],
-  ["4", { actualLeft: -0.61, trailingSpace: 0.587 }],
-  ["5", { actualLeft: -0.626, trailingSpace: 0.605 }],
-  ["6", { actualLeft: -0.605, trailingSpace: 0.605 }],
-  ["7", { actualLeft: -0.486, trailingSpace: 0.486 }],
-  ["8", { actualLeft: -0.605, trailingSpace: 0.605 }],
-  ["9", { actualLeft: -0.605, trailingSpace: 0.605 }],
-]);
+// The `1`'s flag makes it look left-heavy when its text box is centered.
+const digitOpticalOffsets = new Map<string, number>([["1", 0.5]]);
 
 function getOpticalOffset(number: number): number {
   const digits = String(number);
-  const firstDigit = interDigitEdgeMetrics.get(digits.charAt(0));
-  const lastDigit = interDigitEdgeMetrics.get(digits.charAt(digits.length - 1));
 
-  if (!firstDigit || !lastDigit) return 0;
-
-  return (firstDigit.actualLeft + lastDigit.trailingSpace) / 2;
+  return (
+    [...digits].reduce(
+      (offset, digit) => offset + (digitOpticalOffsets.get(digit) ?? 0),
+      0,
+    ) / digits.length
+  );
 }
 
 export default forwardRef<HTMLDivElement, VariationNumberProps>(

--- a/packages/front-end/ui/VariationNumber.tsx
+++ b/packages/front-end/ui/VariationNumber.tsx
@@ -6,24 +6,8 @@ type VariationNumberProps = { number: number } & ComponentPropsWithoutRef<
   typeof Box
 >;
 
-// The `1`'s flag makes it look left-heavy when its text box is centered.
-const digitOpticalOffsets = new Map<string, number>([["1", 0.5]]);
-
-function getOpticalOffset(number: number): number {
-  const digits = String(number);
-
-  return (
-    [...digits].reduce(
-      (offset, digit) => offset + (digitOpticalOffsets.get(digit) ?? 0),
-      0,
-    ) / digits.length
-  );
-}
-
 export default forwardRef<HTMLDivElement, VariationNumberProps>(
   function VariationNumber({ number, className, ...rest }, ref) {
-    const opticalOffset = getOpticalOffset(number);
-
     return (
       <Box
         ref={ref}
@@ -33,12 +17,7 @@ export default forwardRef<HTMLDivElement, VariationNumberProps>(
         }`}
       >
         <Box as="span" className={styles.label}>
-          <span
-            className={styles.number}
-            style={{ transform: `translateX(${opticalOffset}px)` }}
-          >
-            {number}
-          </span>
+          <span className={styles.number}>{number}</span>
         </Box>
       </Box>
     );

--- a/packages/front-end/ui/VariationNumber.tsx
+++ b/packages/front-end/ui/VariationNumber.tsx
@@ -6,8 +6,39 @@ type VariationNumberProps = { number: number } & ComponentPropsWithoutRef<
   typeof Box
 >;
 
+type DigitEdgeMetrics = {
+  actualLeft: number;
+  trailingSpace: number;
+};
+
+// Canvas text metrics for Inter 500 at 11px, matching VariationNumber.module.scss.
+const interDigitEdgeMetrics = new Map<string, DigitEdgeMetrics>([
+  ["0", { actualLeft: -0.605, trailingSpace: 0.605 }],
+  ["1", { actualLeft: -0.51, trailingSpace: 0.886 }],
+  ["2", { actualLeft: -0.764, trailingSpace: 0.722 }],
+  ["3", { actualLeft: -0.624, trailingSpace: 0.605 }],
+  ["4", { actualLeft: -0.61, trailingSpace: 0.587 }],
+  ["5", { actualLeft: -0.626, trailingSpace: 0.605 }],
+  ["6", { actualLeft: -0.605, trailingSpace: 0.605 }],
+  ["7", { actualLeft: -0.486, trailingSpace: 0.486 }],
+  ["8", { actualLeft: -0.605, trailingSpace: 0.605 }],
+  ["9", { actualLeft: -0.605, trailingSpace: 0.605 }],
+]);
+
+function getOpticalOffset(number: number): number {
+  const digits = String(number);
+  const firstDigit = interDigitEdgeMetrics.get(digits.charAt(0));
+  const lastDigit = interDigitEdgeMetrics.get(digits.charAt(digits.length - 1));
+
+  if (!firstDigit || !lastDigit) return 0;
+
+  return (firstDigit.actualLeft + lastDigit.trailingSpace) / 2;
+}
+
 export default forwardRef<HTMLDivElement, VariationNumberProps>(
   function VariationNumber({ number, className, ...rest }, ref) {
+    const opticalOffset = getOpticalOffset(number);
+
     return (
       <Box
         ref={ref}
@@ -17,7 +48,12 @@ export default forwardRef<HTMLDivElement, VariationNumberProps>(
         }`}
       >
         <Box as="span" className={styles.label}>
-          {number}
+          <span
+            className={styles.number}
+            style={{ transform: `translateX(${opticalOffset}px)` }}
+          >
+            {number}
+          </span>
         </Box>
       </Box>
     );


### PR DESCRIPTION
### Features and Changes

- Nudge variation number glyphs right by 0.5px on 1× displays, where 11px Inter otherwise rasterizes visibly left of the circle center.
- Leave 2× Retina rendering unchanged.

### Testing

- `pnpm exec prettier --check packages/front-end/ui/VariationNumber.tsx packages/front-end/ui/VariationNumber.module.scss`
- `pnpm exec eslint packages/front-end/ui/VariationNumber.tsx`
- `pnpm --filter front-end type-check`
- Rendered `/design-system` at DPR 1 and 2. The adjustment applies only at DPR 1.