### PR TITLE
docs: deprecate Segments, document multi-dimension workarounds, clari…

### DIFF
--- a/docs/docs/experimentation-analysis/dimensions.mdx
+++ b/docs/docs/experimentation-analysis/dimensions.mdx
@@ -21,6 +21,20 @@ The two best use cases are identfying bugs (the `browser` example) and getting i
 
 Dimensions are supported for both Mixpanel and SQL data sources.
 
+## Breaking down by more than one dimension
+
+GrowthBook currently only supports selecting a single dimension at a time when viewing experiment
+results. There isn't native support yet for combining two or more dimensions into one breakdown, but
+there are two workarounds:
+
+- **Custom SQL filter**: If one of your dimensions already exists on your experiment assignment query,
+  add a custom SQL filter in the experiment's analysis settings to restrict results to a specific value
+  of that dimension, then use the dimension selector to break down by the second dimension.
+- **Custom dimension SQL**: Create a new dimension whose SQL computes the intersection of the two
+  dimensions you care about — for example, concatenating `country` and `account_type` into a single
+  value like `US - premium`. See the [User Dimensions](#user-dimensions) section below for how to write
+  custom dimension SQL.
+
 ## SQL
 
 There are two types of dimensions for SQL data sources: Experiment Dimensions and User Dimensions. Experiment dimensions are more reliable for producing unbiased experiment analyses because we can always know the dimension that is associated with the first experiment exposure for a unit. Using dimension data that could be affected by the experiment (e.g. that is collected _after_ the first experiment exposure) could bias dimension drill-downs. Therefore, use user dimensions with caution, and we suggest using immutable dimensions as your user dimensions (e.g. the first client the user ever used, or the first country the user ever logged in from).

--- a/docs/docs/experimentation-analysis/experiment-configuration.mdx
+++ b/docs/docs/experimentation-analysis/experiment-configuration.mdx
@@ -75,7 +75,13 @@ You can also configure targeting and traffic to your experiment's linked feature
 
 ### Analysis Settings
 
-Here is where much of your experiment analysis is configured. Many of the fields here have some text explaining how they affect your analysis. Here are a few of them in more detail:
+Here is where much of your experiment analysis is configured. On the experiment's Overview tab, this section is accessed via the **Edit Settings** button — the label shown on the button that opens the Analysis Settings form. Many of the fields here have some text explaining how they affect your analysis. Here are a few of them in more detail:
+
+:::note Permissions required
+
+The **Edit Settings** button is only visible to users with permission to edit the experiment's analysis settings (for example, the `Admin`, `Experimenter`, or `Project Admin` roles, or a custom role with equivalent permissions). If you don't have one of these roles, the button will not appear, and you'll need to ask an organization or project admin to make changes on your behalf. See [User Permissions](/account/user-permissions) for details on roles.
+
+:::
 
 **Experiment Key**
 

--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -226,19 +226,26 @@ const getUUID=()=>{const a=(a,b)=>{var c=new Date;c.setTime(c.getTime()+86400000
 
 ### What is the difference between a Dimension and a Segment?
 
-:::info Dimensions recommended over Segments
+:::caution Segments are deprecated
 
-We recommend using Dimensions instead of Segments for new implementations. While Segments remain fully supported, we plan to deprecate them in a future release.
+Segments have been deprecated and are being phased out. If you don't already have a Segment configured, you shouldn't create one — use a Dimension instead, or apply a custom SQL filter in the experiment's analysis settings.
 
 :::
 
 A dimension is a user attribute that can have multiple values. Some examples are `country`, `account_type`, and `browser`.
 
-A segment is a specific group of users. Some examples are `visitors in the US`, `premium users`, and `chrome users`.
+A segment was a specific group of users, defined with SQL from the "Data and Metrics → Segments" page. Some examples are `visitors in the US`, `premium users`, and `chrome users`. Segments could apply a filter to results, usually to compensate for bad data — for example, if your experiment was only visible to premium users, but your database inaccurately shows that free users were also included, you could apply a `premium users` segment to only include those who were actually exposed to the test.
 
 Dimensions are used to explore experiment results. For example, you can use a `country` dimension to see which countries had the highest conversion rates. Or an `account_type` dimension to see if there was a significant difference in how free vs paid users behaved. Or a `browser` dimension to detect any browser-specific bugs in your implementation.
 
-Segments can apply a filter to results, usually to compensate for bad data. For example, if your experiment was only visible to premium users, but your database inaccurately shows that free users were also included, you could apply a `premium users` segment to only include those who were actually exposed to the test. Ideally, you could just fix the underlying data, but that's often not feasible so segments provide a quick and dirty alternative.
+If you were relying on a Segment to filter out bad data (rather than to explore results), a custom SQL filter in the experiment's analysis settings is the recommended replacement, provided the dimension you need to filter on already exists on your experiment assignment query.
+
+### How do I break down experiment results by more than one dimension?
+
+GrowthBook only lets you select a single dimension at a time when viewing experiment results. There isn't native support yet for combining two or more dimensions in one breakdown, but there are two workarounds:
+
+- **Custom SQL filter**: If one of the dimensions you care about already exists on your experiment assignment query, add a custom SQL filter in the experiment's analysis settings to restrict results to a specific value of that dimension, then use the dimension selector to break down by the second dimension.
+- **Custom dimension SQL**: Create a new dimension whose SQL computes the intersection of the two dimensions you care about (for example, concatenating `country` and `account_type` into a single value like `US - premium`). See [Dimensions](/app/dimensions) for how to write custom dimension SQL.
 
 ### My old exported notebook stopped working. How can I fix it?
 

--- a/docs/docs/kb/experiments/troubleshooting-experiments.mdx
+++ b/docs/docs/kb/experiments/troubleshooting-experiments.mdx
@@ -15,7 +15,7 @@ Check the following to correct a lack of traffic to the experiment:
 
 - **Ensure the trackingCallback in the SDK is configured correctly.** It should be using the intended tracking library (e.g. Google Analytics [GA4], Segment, Amplitude) and actually emitting tracking events to your data warehouse.
 - **Ensure the Hash Attribute identifier is being set for each user.** When you start an experiment in GrowthBook, you need to choose which Attribute to use to assign users to variations, often the user `id`. If you do not set that Attribute when you instantiate the GrowthBook SDK, then users can't be assigned to the right variation and users will default to not entering the experiment at all.
-- **Remove any Segments or Activation Metrics that may be filtering out users.** Open the Analysis Settings for your experiment and remove any selected Activation Metric or Segment. These may be filter out users. If removing them causes data to show up, you need to investigate your configuration of that Activation Metric or your Segment.
+- **Remove any Segments or Activation Metrics that may be filtering out users.** Open the Analysis Settings for your experiment (click the **Edit Settings** button — only visible if you have edit permissions, see [User Permissions](/account/user-permissions)) and remove any selected Activation Metric or Segment. These may be filter out users. If removing them causes data to show up, you need to investigate your configuration of that Activation Metric or your Segment.
 - **Ensure the Experiment Assignment Query in your data source is configured correctly.** You can find this query on your data source's detail page.
 
 ## Problem 2: SRM errors (traffic imbalance) in the experiment

--- a/docs/docs/kb/glossary.mdx
+++ b/docs/docs/kb/glossary.mdx
@@ -212,7 +212,7 @@ hide_table_of_contents: true
 
 [Secure Attributes](/lib/js#secure-attributes): Mark specific targeting attributes (e.g. email address) as "secure" and they will be hashed before being sent to client-side SDKs
 
-[Segment](/using/experimenting#digging-deeper): A Segment in GrowthBook is a subset of users that match a particular attribute, allowing you to filter experiment results to only show users that match the segment, and can be created with SQL from the "Data and Metrics → Segments" page.
+[Segment](/using/experimenting#digging-deeper) (deprecated): A Segment in GrowthBook was a subset of users that match a particular attribute, allowing you to filter experiment results to only show users that match the segment, created with SQL from the "Data and Metrics → Segments" page. Segments have been deprecated and are being phased out; if you don't already have one, use a [Dimension](/app/dimensions) or a custom SQL filter in the experiment's analysis settings instead.
 
 [Self-Hosted](/self-host): Self-Hosted in GrowthBook refers to the option of hosting the GrowthBook platform on your own infrastructure, giving you full control over your data and allowing you to customize the platform to suit your specific needs.
 

--- a/docs/docs/using/experimenting.mdx
+++ b/docs/docs/using/experimenting.mdx
@@ -233,16 +233,20 @@ change.
 
 ### Segmentation
 
-Segments are applied to experiment results to only show users that match a particular attribute. For
-example, you might have “country” as a dimension, and create a segment for just “US visitors”. In the
-experiment you can configure the experiment to just look at one particular segment of users. Segments
-can be created with SQL from the "Data and Metrics → Segments" page.
+:::caution Segments are deprecated
 
-![Segments](/images/using/segments-page.png)
+Segments have been deprecated and are being phased out. If you don't already have one configured, you
+shouldn't create one. Use a [Dimension](/app/dimensions) instead, or apply a custom SQL filter in the
+experiment's analysis settings to only show users that match a particular attribute.
 
-There are two ways you can use segments in your experiment results. The first is to use the
-experiment's 'analytics settings' and add one of the segments. The other way is to create a custom
-report, and then click on 'customize' and select a segment to apply to the results.
+:::
+
+Previously, Segments could be applied to experiment results to only show users that match a particular
+attribute. For example, you might have “country” as a dimension, and create a segment for just “US
+visitors”. In the experiment you could configure the experiment to just look at one particular segment
+of users. If you need this kind of filtering today, a custom SQL filter in the experiment's analysis
+settings is the recommended approach, as long as the attribute you want to filter on already exists on
+your experiment assignment query.
 
 ### Dimensions
 


### PR DESCRIPTION
## Doc Updates:
deprecate Segments, document multi-dimension workarounds, clarify Edit Settings permissions

Segments have been deprecated and are being phased out. Update all references to reflect this: FAQ, Segmentation section, and glossary entry now direct users to Dimensions or a custom SQL filter in the experiment's analysis settings instead. Also document the two supported workarounds for breaking down results by more than one dimension, since there is no native multi-dimension breakdown.

Separately, clarify that the Analysis Settings section is opened via the "Edit Settings" button, and that this button is only visible to users with edit permissions on the experiment (Admin, Experimenter, Project Admin, or an equivalent custom role).

- faq.mdx: update Dimension vs Segment entry to reflect full deprecation; add new FAQ for multi-dimension breakdowns
- using/experimenting.mdx: replace Segmentation section with deprecation notice and custom SQL filter guidance
- experimentation-analysis/dimensions.mdx: add "Breaking down by more than one dimension" section (custom SQL filter vs. custom dimension SQL intersection)
- kb/glossary.mdx: mark Segment glossary entry as deprecated
- experimentation-analysis/experiment-configuration.mdx: name the "Edit Settings" button and add a permissions note linking to User Permissions
- kb/experiments/troubleshooting-experiments.mdx: reference the Edit Settings button by name with the same visibility caveat


