### PR TITLE
Prevent stale license after upgrade

### DIFF
--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -873,10 +873,8 @@ export async function getOrganization(
 
   const context = getContextFromReq(req);
   const { org, userId } = context;
-  const forceLicenseRefresh = req.query.forceLicenseRefresh === "true";
-  if (forceLicenseRefresh && !context.permissions.canManageBilling()) {
-    context.permissions.throwPermissionError();
-  }
+  const forceLicenseRefresh = req.query.forceLicenseRefresh !== undefined;
+
   const {
     invites,
     members,

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -861,7 +861,7 @@ export async function putInviteRole(
 }
 
 export async function getOrganization(
-  req: AuthRequest,
+  req: AuthRequest<unknown, unknown, { forceLicenseRefresh?: string }>,
   res: Response<GetOrganizationResponse | { status: 200; organization: null }>,
 ) {
   if (!req.organization) {
@@ -873,6 +873,10 @@ export async function getOrganization(
 
   const context = getContextFromReq(req);
   const { org, userId } = context;
+  const forceLicenseRefresh = req.query.forceLicenseRefresh === "true";
+  if (forceLicenseRefresh && !context.permissions.canManageBilling()) {
+    context.permissions.throwPermissionError();
+  }
   const {
     invites,
     members,
@@ -898,15 +902,23 @@ export async function getOrganization(
       let license: Partial<LicenseInterface> | null =
         getLicense(licenseKey || process.env.LICENSE_KEY) || null;
       if (
+        forceLicenseRefresh ||
         !license ||
         (license.organizationId && license.organizationId !== id)
       ) {
         try {
           license =
-            (await licenseInit(org, getUserCodesForOrg, getLicenseMetaData)) ||
-            null;
+            (await licenseInit(
+              org,
+              getUserCodesForOrg,
+              getLicenseMetaData,
+              forceLicenseRefresh,
+            )) || null;
         } catch (e) {
           logger.error(e, "setting license failed");
+          if (forceLicenseRefresh) {
+            throw e;
+          }
         }
       }
       return license;

--- a/packages/front-end/components/Auth/SelectInitialPlan.tsx
+++ b/packages/front-end/components/Auth/SelectInitialPlan.tsx
@@ -484,7 +484,7 @@ const ProPaymentFormInner: FC<ProPaymentFormProps> = ({
               : undefined,
         }),
       });
-      await refreshOrganization();
+      await refreshOrganization({ forceLicenseRefresh: true });
       setLoading(false);
       onSuccess();
     } catch (e) {

--- a/packages/front-end/components/Auth/SelectInitialPlan.tsx
+++ b/packages/front-end/components/Auth/SelectInitialPlan.tsx
@@ -1,6 +1,7 @@
 import { FC, useState, useCallback } from "react";
 import { useRouter } from "next/router";
 import { Box, Flex } from "@radix-ui/themes";
+import { captureException as sentryCaptureException } from "@sentry/nextjs";
 import {
   AddressElement,
   PaymentElement,
@@ -61,7 +62,7 @@ const SelectInitialPlan: FC = () => {
     orgId,
     setOrgId,
   } = useAuth();
-  const { email } = useUser();
+  const { email, refreshOrganization } = useUser();
   const plan: InitialPlanOptions =
     initialPlanSelection === "pro" || initialPlanSelection === "starter"
       ? initialPlanSelection
@@ -70,6 +71,8 @@ const SelectInitialPlan: FC = () => {
   const [step, setStep] = useState<number>(1);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [organizationRefreshFailed, setOrganizationRefreshFailed] =
+    useState(false);
   const billingForm = useForm<ProBillingData>({
     defaultValues: {
       email: email ?? "",
@@ -77,6 +80,22 @@ const SelectInitialPlan: FC = () => {
       taxIdValue: undefined,
     },
   });
+
+  const refreshOrganizationAfterUpgrade = async () => {
+    try {
+      await refreshOrganization({ forceLicenseRefresh: true });
+      setOrganizationRefreshFailed(false);
+    } catch (error) {
+      sentryCaptureException(error);
+      setOrganizationRefreshFailed(true);
+    }
+  };
+
+  const retryOrganizationRefresh = async () => {
+    setLoading(true);
+    await refreshOrganizationAfterUpgrade();
+    setLoading(false);
+  };
 
   const completeFlow = useCallback(() => {
     track("Initial signup: flow completed", { plan });
@@ -253,15 +272,40 @@ const SelectInitialPlan: FC = () => {
           onBack={handleBack}
           setLoading={setLoading}
           setError={setError}
+          refreshOrganizationAfterUpgrade={refreshOrganizationAfterUpgrade}
         />
       )}
       {step >= 4 && (
         <div style={{ maxWidth: "500px" }}>
-          <h2 className="h3 mb-1">Welcome to GrowthBook Pro!</h2>
-          <p className="text-muted mb-3">
-            You&apos;re all set! Go to your GrowthBook dashboard to start your
-            setup.
-          </p>
+          <h2 className="h3 mb-1">
+            {organizationRefreshFailed
+              ? "GrowthBook Pro Subscription Created"
+              : "Welcome to GrowthBook Pro!"}
+          </h2>
+          {!organizationRefreshFailed && (
+            <p className="text-muted mb-3">
+              You&apos;re all set! Go to your GrowthBook dashboard to start your
+              setup.
+            </p>
+          )}
+          {organizationRefreshFailed && (
+            <Callout
+              status="warning"
+              mt="3"
+              action={
+                <Button
+                  color="secondary"
+                  loading={loading}
+                  onClick={retryOrganizationRefresh}
+                >
+                  Try again
+                </Button>
+              }
+            >
+              We couldn&apos;t refresh your organization details. Try again to
+              see your updated plan.
+            </Callout>
+          )}
           <Button color="primary" onClick={completeFlow} disabled={loading}>
             Get started
           </Button>
@@ -377,6 +421,7 @@ type ProPaymentStepProps = {
   onBack: () => void;
   setLoading: (v: boolean) => void;
   setError: (v: string | null) => void;
+  refreshOrganizationAfterUpgrade: () => Promise<void>;
 };
 
 const ProPaymentStep: FC<ProPaymentStepProps> = ({
@@ -386,6 +431,7 @@ const ProPaymentStep: FC<ProPaymentStepProps> = ({
   onBack,
   setLoading,
   setError,
+  refreshOrganizationAfterUpgrade,
 }) => {
   // StripeProvider now owns the load-Stripe-then-create-Radar-session-then-
   // fetch-SetupIntent flow, so this component just renders it directly.
@@ -398,6 +444,7 @@ const ProPaymentStep: FC<ProPaymentStepProps> = ({
         setLoading={setLoading}
         setError={setError}
         error={error}
+        refreshOrganizationAfterUpgrade={refreshOrganizationAfterUpgrade}
       />
     </StripeProvider>
   );
@@ -410,6 +457,7 @@ type ProPaymentFormProps = {
   setLoading: (v: boolean) => void;
   setError: (v: string | null) => void;
   error: string | null;
+  refreshOrganizationAfterUpgrade: () => Promise<void>;
 };
 
 const ProPaymentFormInner: FC<ProPaymentFormProps> = ({
@@ -419,9 +467,10 @@ const ProPaymentFormInner: FC<ProPaymentFormProps> = ({
   setLoading,
   setError,
   error,
+  refreshOrganizationAfterUpgrade,
 }) => {
   const { apiCall } = useAuth();
-  const { organization, refreshOrganization } = useUser();
+  const { organization } = useUser();
   const stripe = useStripe();
   const elements = useElements();
   const { clientSecret } = useStripeContext();
@@ -484,14 +533,16 @@ const ProPaymentFormInner: FC<ProPaymentFormProps> = ({
               : undefined,
         }),
       });
-      await refreshOrganization({ forceLicenseRefresh: true });
-      setLoading(false);
-      onSuccess();
     } catch (e) {
       setLoading(false);
       const message = e instanceof Error ? e.message : "Something went wrong";
       setError(message);
+      return;
     }
+
+    await refreshOrganizationAfterUpgrade();
+    setLoading(false);
+    onSuccess();
   };
 
   return (

--- a/packages/front-end/components/Auth/SelectInitialPlan.tsx
+++ b/packages/front-end/components/Auth/SelectInitialPlan.tsx
@@ -23,6 +23,7 @@ import SelectField from "@/components/Forms/SelectField";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import { GBInfo } from "@/components/Icons";
 import Checkbox from "@/ui/Checkbox";
+import UIButton from "@/ui/Button";
 import Button from "@/components/Button";
 import track from "@/services/track";
 import Callout from "@/ui/Callout";
@@ -293,13 +294,14 @@ const SelectInitialPlan: FC = () => {
               status="warning"
               mt="3"
               action={
-                <Button
-                  color="secondary"
+                <UIButton
+                  size="sm"
+                  color="inherit"
                   loading={loading}
                   onClick={retryOrganizationRefresh}
                 >
                   Try again
-                </Button>
+                </UIButton>
               }
             >
               We couldn&apos;t refresh your organization details. Try again to

--- a/packages/front-end/enterprise/components/Billing/CloudProUpgradeModal.tsx
+++ b/packages/front-end/enterprise/components/Billing/CloudProUpgradeModal.tsx
@@ -145,6 +145,16 @@ export default function CloudProUpgradeModal({ close, closeParent }: Props) {
   const elements = useElements();
   const stripe = useStripe();
 
+  const refreshOrganizationAfterUpgrade = async () => {
+    try {
+      await refreshOrganization({ forceLicenseRefresh: true });
+      setOrganizationRefreshFailed(false);
+    } catch (error) {
+      sentryCaptureException(error);
+      setOrganizationRefreshFailed(true);
+    }
+  };
+
   const form = useForm<{
     address: StripeAddress | undefined;
     name: string; // This is what the user will see on their Invoices
@@ -229,15 +239,16 @@ export default function CloudProUpgradeModal({ close, closeParent }: Props) {
       throw new Error(e.message);
     }
 
-    try {
-      await refreshOrganization({ forceLicenseRefresh: true });
-    } catch (error) {
-      sentryCaptureException(error);
-      setOrganizationRefreshFailed(true);
-    }
+    await refreshOrganizationAfterUpgrade();
 
     setLoading(false);
     setSuccess(true);
+  };
+
+  const retryOrganizationRefresh = async () => {
+    setLoading(true);
+    await refreshOrganizationAfterUpgrade();
+    setLoading(false);
   };
 
   if (success) {
@@ -257,11 +268,17 @@ export default function CloudProUpgradeModal({ close, closeParent }: Props) {
         showHeaderCloseButton={false}
       >
         <div className="container-fluid dashboard p-3 ">
-          <h3>Welcome to GrowthBook Pro!</h3>
-          <span>
-            You&apos;re all set! Your organization now has access to all
-            GrowthBook Pro features.
-          </span>
+          <h3>
+            {organizationRefreshFailed
+              ? "GrowthBook Pro Subscription Created"
+              : "Welcome to GrowthBook Pro!"}
+          </h3>
+          {!organizationRefreshFailed ? (
+            <span>
+              You&apos;re all set! Your organization now has access to all
+              GrowthBook Pro features.
+            </span>
+          ) : null}
           {organizationRefreshFailed ? (
             <Callout
               status="warning"
@@ -270,14 +287,15 @@ export default function CloudProUpgradeModal({ close, closeParent }: Props) {
                 <Button
                   size="sm"
                   color="inherit"
-                  onClick={() => window.location.reload()}
+                  loading={loading}
+                  onClick={retryOrganizationRefresh}
                 >
-                  Reload page
+                  Try again
                 </Button>
               }
             >
-              Your subscription was created, but we couldn&apos;t refresh your
-              organization details. Reload the page to see your updated plan.
+              We couldn&apos;t refresh your organization details. Try again to
+              see your updated plan.
             </Callout>
           ) : null}
         </div>

--- a/packages/front-end/enterprise/components/Billing/CloudProUpgradeModal.tsx
+++ b/packages/front-end/enterprise/components/Billing/CloudProUpgradeModal.tsx
@@ -219,7 +219,7 @@ export default function CloudProUpgradeModal({ close, closeParent }: Props) {
               : undefined,
         }),
       });
-      refreshOrganization();
+      await refreshOrganization();
       setLoading(false);
       setSuccess(true);
     } catch (e) {

--- a/packages/front-end/enterprise/components/Billing/CloudProUpgradeModal.tsx
+++ b/packages/front-end/enterprise/components/Billing/CloudProUpgradeModal.tsx
@@ -7,6 +7,7 @@ import {
 } from "@stripe/react-stripe-js";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
+import { captureException as sentryCaptureException } from "@sentry/nextjs";
 import { TaxIdType, StripeAddress } from "shared/types/subscriptions";
 import { PiCaretRight } from "react-icons/pi";
 import { useStripeContext } from "@/hooks/useStripeContext";
@@ -19,6 +20,8 @@ import SelectField from "@/components/Forms/SelectField";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import { GBInfo } from "@/components/Icons";
 import Checkbox from "@/ui/Checkbox";
+import Button from "@/ui/Button";
+import Callout from "@/ui/Callout";
 import Modal from "@/components/Modal";
 
 export const taxIdTypeOptions: { label: string; value: TaxIdType }[] = [
@@ -132,6 +135,8 @@ interface Props {
 export default function CloudProUpgradeModal({ close, closeParent }: Props) {
   const [step, setStep] = useState(0);
   const [success, setSuccess] = useState(false);
+  const [organizationRefreshFailed, setOrganizationRefreshFailed] =
+    useState(false);
   const [loading, setLoading] = useState(false);
   const [showAddress, setShowAddress] = useState(false);
   const { clientSecret } = useStripeContext();
@@ -219,13 +224,20 @@ export default function CloudProUpgradeModal({ close, closeParent }: Props) {
               : undefined,
         }),
       });
-      await refreshOrganization({ forceLicenseRefresh: true });
-      setLoading(false);
-      setSuccess(true);
     } catch (e) {
       setLoading(false);
       throw new Error(e.message);
     }
+
+    try {
+      await refreshOrganization({ forceLicenseRefresh: true });
+    } catch (error) {
+      sentryCaptureException(error);
+      setOrganizationRefreshFailed(true);
+    }
+
+    setLoading(false);
+    setSuccess(true);
   };
 
   if (success) {
@@ -250,6 +262,24 @@ export default function CloudProUpgradeModal({ close, closeParent }: Props) {
             You&apos;re all set! Your organization now has access to all
             GrowthBook Pro features.
           </span>
+          {organizationRefreshFailed ? (
+            <Callout
+              status="warning"
+              mt="3"
+              action={
+                <Button
+                  size="sm"
+                  color="inherit"
+                  onClick={() => window.location.reload()}
+                >
+                  Reload page
+                </Button>
+              }
+            >
+              Your subscription was created, but we couldn&apos;t refresh your
+              organization details. Reload the page to see your updated plan.
+            </Callout>
+          ) : null}
         </div>
       </Modal>
     );

--- a/packages/front-end/enterprise/components/Billing/CloudProUpgradeModal.tsx
+++ b/packages/front-end/enterprise/components/Billing/CloudProUpgradeModal.tsx
@@ -219,7 +219,7 @@ export default function CloudProUpgradeModal({ close, closeParent }: Props) {
               : undefined,
         }),
       });
-      await refreshOrganization();
+      await refreshOrganization({ forceLicenseRefresh: true });
       setLoading(false);
       setSuccess(true);
     } catch (e) {

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -71,6 +71,10 @@ export type Team = Omit<TeamInterface, "members"> & {
   members?: ExpandedMember[];
 };
 
+interface RefreshOrganizationOptions {
+  forceLicenseRefresh?: boolean;
+}
+
 export const DEFAULT_PERMISSIONS: Record<GlobalPermission, boolean> = {
   createDimensions: false,
   createPresentations: false,
@@ -107,7 +111,7 @@ export interface UserContextValue {
   getUserDisplay: (id: string, fallback?: boolean) => string;
   getOwnerDisplay: (owner: string | undefined) => string;
   updateUser: () => Promise<void>;
-  refreshOrganization: () => Promise<void>;
+  refreshOrganization: (options?: RefreshOrganizationOptions) => Promise<void>;
   permissions: Record<GlobalPermission, boolean> & PermissionFunctions;
   settings: OrganizationSettings;
   enterpriseSSO?: Partial<SSOConnectionInterface> | null;
@@ -200,7 +204,7 @@ export function getCurrentUser() {
 }
 
 export function UserContextProvider({ children }: { children: ReactNode }) {
-  const { isAuthenticated, orgId, setOrganizations } = useAuth();
+  const { apiCall, isAuthenticated, orgId, setOrganizations } = useAuth();
 
   const {
     data,
@@ -219,11 +223,27 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
 
   const {
     data: currentOrg,
-    mutate: refreshOrganization,
+    mutate: mutateOrganization,
     error: orgLoadingError,
   } = useApi<GetOrganizationResponse>(`/organization`, {
     shouldRun: () => !!orgId,
   });
+
+  const refreshOrganization = useCallback(
+    async (options?: RefreshOrganizationOptions) => {
+      if (!options?.forceLicenseRefresh) {
+        await mutateOrganization();
+        return;
+      }
+
+      const organization = await apiCall<GetOrganizationResponse>(
+        "/organization?forceLicenseRefresh=true",
+        { method: "GET" },
+      );
+      await mutateOrganization(organization, false);
+    },
+    [apiCall, mutateOrganization],
+  );
 
   const hashedOrganizationId = useMemo(() => {
     const id = currentOrg?.organization?.id || "";
@@ -525,7 +545,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
         users,
         getUserDisplay: getUserDisplay,
         getOwnerDisplay: getOwnerDisplay,
-        refreshOrganization: refreshOrganization as () => Promise<void>,
+        refreshOrganization,
         roles: currentOrg?.roles || [],
         permissions,
         permissionsUtil,


### PR DESCRIPTION
### Features and Changes

- Prevent stale Starter organization state after a successful Pro subscription by forcing an authoritative license refresh.
- Add an optional forced refresh mode to `refreshOrganization`, bypassing process-local license caches while preserving existing behavior for all other callers.
- Restrict forced license refreshes to users with billing permissions.
- Apply the forced refresh to both existing-organization upgrades and initial Pro plan selection.

### Dependencies

None.

### Testing

- [x] Start a Pro subscription from an existing Starter organization and verify the Pro experience appears after closing the success modal.
- [x] Select Pro during initial organization setup and verify the organization reflects the active subscription.
- [x] Verify normal organization refreshes continue using cached license data.
- [x] Verify users without billing permissions cannot request a forced license refresh.
- [x] Run front-end and back-end type checks.

### Screenshots

None — no visual changes.