### PR TITLE
fix(experiments): contain SQL build failures to their own query

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -61196,6 +61196,12 @@ components:
           type: string
         status:
           type: string
+        error:
+          description: >-
+            Why this snapshot failed. Present only when status is `error`. Names
+            the underlying cause, such as the warehouse error or the reason a
+            metric's query could not be built.
+          type: string
       required:
         - id
         - experiment
@@ -64111,6 +64117,12 @@ components:
         experiment:
           type: string
         status:
+          type: string
+        error:
+          description: >-
+            Why this snapshot failed. Present only when status is `error`. Names
+            the underlying cause, such as the warehouse error or the reason a
+            metric's query could not be built.
           type: string
       required:
         - id

--- a/packages/back-end/src/api/experiments/postExperimentSnapshot.ts
+++ b/packages/back-end/src/api/experiments/postExperimentSnapshot.ts
@@ -3,6 +3,7 @@ import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
 import { auditDetailsCreate } from "back-end/src/services/audit";
 import { createExperimentSnapshot } from "back-end/src/services/experiments";
+import { toApiExperimentSnapshot } from "back-end/src/api/snapshots/toApiExperimentSnapshot";
 import { validateSnapshotDimension } from "back-end/src/services/snapshotDimension";
 import { ExperimentIncrementalPipelineRequiresFullRefreshError } from "back-end/src/util/errors";
 import { createApiRequestHandler } from "back-end/src/util/handler";
@@ -106,10 +107,6 @@ export const postExperimentSnapshot = createApiRequestHandler(
     }),
   });
   return {
-    snapshot: {
-      id: snapshot.id,
-      experiment: snapshot.experiment,
-      status: snapshot.status,
-    },
+    snapshot: toApiExperimentSnapshot(snapshot),
   };
 });

--- a/packages/back-end/src/api/snapshots/getExperimentSnapshot.ts
+++ b/packages/back-end/src/api/snapshots/getExperimentSnapshot.ts
@@ -2,6 +2,7 @@ import { getExperimentSnapshotValidator } from "shared/validators";
 import { findSnapshotById } from "back-end/src/models/ExperimentSnapshotModel";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
 import { createApiRequestHandler } from "back-end/src/util/handler";
+import { toApiExperimentSnapshot } from "./toApiExperimentSnapshot";
 
 export const getExperimentSnapshot = createApiRequestHandler(
   getExperimentSnapshotValidator,
@@ -17,10 +18,6 @@ export const getExperimentSnapshot = createApiRequestHandler(
     throw new Error("Snapshot not found or no permission to access");
   }
   return {
-    snapshot: {
-      id: snapshot.id,
-      experiment: snapshot.experiment,
-      status: snapshot.status,
-    },
+    snapshot: toApiExperimentSnapshot(snapshot),
   };
 });

--- a/packages/back-end/src/api/snapshots/toApiExperimentSnapshot.ts
+++ b/packages/back-end/src/api/snapshots/toApiExperimentSnapshot.ts
@@ -1,0 +1,21 @@
+import { ApiExperimentSnapshot } from "shared/validators";
+import { ExperimentSnapshotInterface } from "shared/types/experiment-snapshot";
+
+/**
+ * Build the `ExperimentSnapshot` public API model.
+ *
+ * Two endpoints return it, `GET /snapshots/{id}` and
+ * `POST /experiments/{id}/snapshot`, so it is built here rather than inline in
+ * each. The validator is `.strict()`, so the two hand-written literals it
+ * replaced had to stay in lockstep with it and with each other.
+ */
+export function toApiExperimentSnapshot(
+  snapshot: ExperimentSnapshotInterface,
+): ApiExperimentSnapshot {
+  return {
+    id: snapshot.id,
+    experiment: snapshot.experiment,
+    status: snapshot.status,
+    error: snapshot.error,
+  };
+}

--- a/packages/back-end/src/models/QueryModel.ts
+++ b/packages/back-end/src/models/QueryModel.ts
@@ -14,6 +14,7 @@ export const queriesSchema = [
     query: String,
     status: String,
     name: String,
+    error: String,
   },
 ];
 
@@ -359,6 +360,54 @@ export async function createNewQuery({
     status: running ? "running" : "queued",
     dependencies: dependencies,
     runAtEnd: runAtEnd,
+    queryType,
+  };
+  const doc = await QueryModel.create(data);
+  return toInterface(doc);
+}
+
+/**
+ * Create a Query document that is already in a terminal "failed" state, without
+ * ever executing it. Used to turn a build-time SQL-generation throw into a
+ * failed-query record so the runner's existing dependency-cascade and status
+ * machinery attributes the failure to the owning metric/group instead of
+ * escaping and failing the whole snapshot.
+ */
+export async function createFailedQuery({
+  organization,
+  datasource,
+  language,
+  query,
+  displayTitle,
+  dependencies = [],
+  queryType = "unknown",
+  error,
+}: {
+  organization: string;
+  datasource: string;
+  language: QueryLanguage;
+  query: string;
+  displayTitle?: string;
+  dependencies?: string[];
+  queryType: QueryType;
+  error: string;
+}): Promise<QueryInterface> {
+  const now = new Date();
+  const data: QueryInterface = {
+    createdAt: now,
+    datasource,
+    heartbeat: now,
+    id: generateId("qry_"),
+    language,
+    organization,
+    query,
+    displayTitle,
+    startedAt: now,
+    finishedAt: now,
+    status: "failed",
+    error,
+    dependencies,
+    runAtEnd: false,
     queryType,
   };
   const doc = await QueryModel.create(data);

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
@@ -42,6 +42,10 @@ import {
   StartQueryParams,
 } from "./QueryRunner";
 import { SnapshotResult } from "./ExperimentResultsQueryRunner";
+import {
+  getIncrementalCrossStatisticsQueryName,
+  getIncrementalStatisticsQueryName,
+} from "./incrementalStatisticsQueryNaming";
 
 export type ExperimentIncrementalRefreshExploratoryQueryParams = {
   snapshotType: SnapshotType;
@@ -240,33 +244,35 @@ export const startExperimentIncrementalRefreshExploratoryQueries = async (
     const sourceName = factTable ? `(${factTable.name})` : "";
 
     const statisticsQuery = await startQuery({
-      name: `statistics_${group.groupId}`,
+      name: getIncrementalStatisticsQueryName(group.groupId),
       displayTitle: `Compute Statistics ${sourceName}`,
-      query: integration.getIncrementalRefreshStatisticsQuery({
-        settings: snapshotSettings,
-        exposureQuery: resolvedExposureQuery,
-        activationMetric: activationMetric,
-        // TODO(incremental-refresh): add post-stratification to exploratory
-        // analysis. Pre-computation is unused here; we lean on
-        // dimensionsForAnalysis to drive breakdowns instead.
-        dimensionsForPrecomputation: [],
-        dimensionsForAnalysis: dimensionObjs,
-        factTableMap: params.factTableMap,
-        metricSources: [
-          {
-            factTableId: group.factTableId,
-            tableFullName: existingSource.tableFullName,
-            ...(anyMetricHasCuped && existingCovariateSource
-              ? {
-                  covariateTableFullName: existingCovariateSource.tableFullName,
-                }
-              : {}),
-          },
-        ],
-        unitsSourceTableFullName: unitsTableFullName,
-        metrics: sameFtMetrics,
-        lastMaxTimestamp: existingSource?.maxTimestamp || null,
-      }),
+      query: () =>
+        integration.getIncrementalRefreshStatisticsQuery({
+          settings: snapshotSettings,
+          exposureQuery: resolvedExposureQuery,
+          activationMetric: activationMetric,
+          // TODO(incremental-refresh): add post-stratification to exploratory
+          // analysis. Pre-computation is unused here; we lean on
+          // dimensionsForAnalysis to drive breakdowns instead.
+          dimensionsForPrecomputation: [],
+          dimensionsForAnalysis: dimensionObjs,
+          factTableMap: params.factTableMap,
+          metricSources: [
+            {
+              factTableId: group.factTableId,
+              tableFullName: existingSource.tableFullName,
+              ...(anyMetricHasCuped && existingCovariateSource
+                ? {
+                    covariateTableFullName:
+                      existingCovariateSource.tableFullName,
+                  }
+                : {}),
+            },
+          ],
+          unitsSourceTableFullName: unitsTableFullName,
+          metrics: sameFtMetrics,
+          lastMaxTimestamp: existingSource?.maxTimestamp || null,
+        }),
       dependencies: [],
       run: fenced((query, setExternalId, queryMetadata) =>
         integration.runIncrementalRefreshStatisticsQuery(
@@ -301,38 +307,42 @@ export const startExperimentIncrementalRefreshExploratoryQueries = async (
     const sourceName = ftA && ftB ? `(${ftA.name} x ${ftB.name})` : "";
 
     const crossStatsQuery = await startQuery({
-      name: `statistics_cross_${pipelineA.group.groupId}__${pipelineB.group.groupId}`,
+      name: getIncrementalCrossStatisticsQueryName(
+        pipelineA.group.groupId,
+        pipelineB.group.groupId,
+      ),
       displayTitle: `Compute Cross-Fact Statistics ${sourceName}`,
-      query: integration.getIncrementalRefreshStatisticsQuery({
-        settings: snapshotSettings,
-        exposureQuery: resolvedExposureQuery,
-        activationMetric: activationMetric,
-        dimensionsForPrecomputation: [],
-        dimensionsForAnalysis: dimensionObjs,
-        factTableMap: params.factTableMap,
-        unitsSourceTableFullName: unitsTableFullName,
-        metrics: subGroup.metrics.map((m) => m.metric),
-        lastMaxTimestamp: null,
-        // Cross-FT CUPED reads each side's covariate cache. Either
-        // pipeline may have none (if its metrics aren't RA), and we omit
-        // `covariateTableFullName` in that case.
-        metricSources: [
-          {
-            factTableId: pipelineA.group.factTableId,
-            tableFullName: pipelineA.tableFullName,
-            ...(pipelineA.covariateTableFullName
-              ? { covariateTableFullName: pipelineA.covariateTableFullName }
-              : {}),
-          },
-          {
-            factTableId: pipelineB.group.factTableId,
-            tableFullName: pipelineB.tableFullName,
-            ...(pipelineB.covariateTableFullName
-              ? { covariateTableFullName: pipelineB.covariateTableFullName }
-              : {}),
-          },
-        ],
-      }),
+      query: () =>
+        integration.getIncrementalRefreshStatisticsQuery({
+          settings: snapshotSettings,
+          exposureQuery: resolvedExposureQuery,
+          activationMetric: activationMetric,
+          dimensionsForPrecomputation: [],
+          dimensionsForAnalysis: dimensionObjs,
+          factTableMap: params.factTableMap,
+          unitsSourceTableFullName: unitsTableFullName,
+          metrics: subGroup.metrics.map((m) => m.metric),
+          lastMaxTimestamp: null,
+          // Cross-FT CUPED reads each side's covariate cache. Either
+          // pipeline may have none (if its metrics aren't RA), and we omit
+          // `covariateTableFullName` in that case.
+          metricSources: [
+            {
+              factTableId: pipelineA.group.factTableId,
+              tableFullName: pipelineA.tableFullName,
+              ...(pipelineA.covariateTableFullName
+                ? { covariateTableFullName: pipelineA.covariateTableFullName }
+                : {}),
+            },
+            {
+              factTableId: pipelineB.group.factTableId,
+              tableFullName: pipelineB.tableFullName,
+              ...(pipelineB.covariateTableFullName
+                ? { covariateTableFullName: pipelineB.covariateTableFullName }
+                : {}),
+            },
+          ],
+        }),
       dependencies: [],
       run: fenced((query, setExternalId, queryMetadata) =>
         integration.runIncrementalRefreshStatisticsQuery(

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -74,6 +74,10 @@ import {
   StartQueryParams,
 } from "./QueryRunner";
 import { shouldRunHealthTrafficQuery } from "./snapshotQueryHelpers";
+import {
+  getIncrementalCrossStatisticsQueryName,
+  getIncrementalStatisticsQueryName,
+} from "./incrementalStatisticsQueryNaming";
 
 export const INCREMENTAL_UNITS_TABLE_PREFIX = "gb_units";
 export const INCREMENTAL_METRICS_TABLE_PREFIX = "gb_metrics";
@@ -1006,29 +1010,41 @@ const startExperimentIncrementalRefreshQueries = async (
           ? []
           : eligibleDimensionsWithSlicesUnderMaxCells;
 
+      // Isolate a build-time SQL-generation failure to this group's statistics
+      // query (e.g. a fact-table misconfiguration surfaced while resolving the
+      // group's metrics) instead of letting the throw escape and fail the whole
+      // snapshot. The failed-query record flows through the normal status
+      // machinery (a total wipeout is handled as a snapshot error downstream).
+      const statisticsQueryName = getIncrementalStatisticsQueryName(
+        group.groupId,
+      );
       const statisticsQuery = await startQuery({
-        name: `statistics_${group.groupId}`,
+        name: statisticsQueryName,
         displayTitle: `Compute Statistics ${sourceName}`,
-        query: integration.getIncrementalRefreshStatisticsQuery({
-          settings: snapshotSettings,
-          exposureQuery: resolvedExposureQuery,
-          activationMetric: activationMetric,
-          factTableMap: params.factTableMap,
-          unitsSourceTableFullName: unitsTableFullName,
-          metrics: sameFtMetrics,
-          lastMaxTimestamp: existingSource?.maxTimestamp || null,
-          dimensionsForPrecomputation,
-          dimensionsForAnalysis: [],
-          metricSources: [
-            {
-              factTableId: group.factTableId,
-              tableFullName: metricSourceTableFullName,
-              ...(anyMetricHasCuped && metricSourceCovariateTableFullName
-                ? { covariateTableFullName: metricSourceCovariateTableFullName }
-                : {}),
-            },
-          ],
-        }),
+        query: () =>
+          integration.getIncrementalRefreshStatisticsQuery({
+            settings: snapshotSettings,
+            exposureQuery: resolvedExposureQuery,
+            activationMetric: activationMetric,
+            factTableMap: params.factTableMap,
+            unitsSourceTableFullName: unitsTableFullName,
+            metrics: sameFtMetrics,
+            lastMaxTimestamp: existingSource?.maxTimestamp || null,
+            dimensionsForPrecomputation,
+            dimensionsForAnalysis: [],
+            metricSources: [
+              {
+                factTableId: group.factTableId,
+                tableFullName: metricSourceTableFullName,
+                ...(anyMetricHasCuped && metricSourceCovariateTableFullName
+                  ? {
+                      covariateTableFullName:
+                        metricSourceCovariateTableFullName,
+                    }
+                  : {}),
+              },
+            ],
+          }),
         dependencies: [
           insertMetricsSourceDataQuery.query,
           ...(insertMetricCovariateDataQuery
@@ -1075,46 +1091,52 @@ const startExperimentIncrementalRefreshQueries = async (
       ? []
       : eligibleDimensionsWithSlicesUnderMaxCells;
 
+    // Same per-unit build isolation as the per-FT statistics query above.
+    const crossStatsQueryName = getIncrementalCrossStatisticsQueryName(
+      pipelineA.group.groupId,
+      pipelineB.group.groupId,
+    );
     const crossStatsQuery = await startQuery({
-      name: `statistics_cross_${pipelineA.group.groupId}__${pipelineB.group.groupId}`,
+      name: crossStatsQueryName,
       displayTitle: `Compute Cross-Fact Statistics ${sourceName}`,
-      query: integration.getIncrementalRefreshStatisticsQuery({
-        settings: snapshotSettings,
-        exposureQuery: resolvedExposureQuery,
-        activationMetric: activationMetric,
-        factTableMap: params.factTableMap,
-        unitsSourceTableFullName: unitsTableFullName,
-        metrics: subGroup.metrics.map((m) => m.metric),
-        // The earliest of the two caches' max timestamps gates which rows
-        // we can trust as fully populated. For simplicity we just pass
-        // null; the stats query reads whatever each cache holds and the
-        // ratio aggregation works regardless of catch-up state.
-        lastMaxTimestamp: null,
-        dimensionsForPrecomputation,
-        dimensionsForAnalysis: [],
-        // Cross-FT CUPED uses one covariate cache per pipeline — the
-        // numerator FT's cache carries `_value` covariates, the
-        // denominator FT's cache carries `_denominator_value` covariates,
-        // and the per-source covariate LEFT JOIN inside each
-        // `__joinedData{i}` picks the right side from each side's cache.
-        // Pipelines with no RA metrics omit `covariateTableFullName`.
-        metricSources: [
-          {
-            factTableId: pipelineA.group.factTableId,
-            tableFullName: pipelineA.tableFullName,
-            ...(pipelineA.covariateTableFullName
-              ? { covariateTableFullName: pipelineA.covariateTableFullName }
-              : {}),
-          },
-          {
-            factTableId: pipelineB.group.factTableId,
-            tableFullName: pipelineB.tableFullName,
-            ...(pipelineB.covariateTableFullName
-              ? { covariateTableFullName: pipelineB.covariateTableFullName }
-              : {}),
-          },
-        ],
-      }),
+      query: () =>
+        integration.getIncrementalRefreshStatisticsQuery({
+          settings: snapshotSettings,
+          exposureQuery: resolvedExposureQuery,
+          activationMetric: activationMetric,
+          factTableMap: params.factTableMap,
+          unitsSourceTableFullName: unitsTableFullName,
+          metrics: subGroup.metrics.map((m) => m.metric),
+          // The earliest of the two caches' max timestamps gates which rows
+          // we can trust as fully populated. For simplicity we just pass
+          // null; the stats query reads whatever each cache holds and the
+          // ratio aggregation works regardless of catch-up state.
+          lastMaxTimestamp: null,
+          dimensionsForPrecomputation,
+          dimensionsForAnalysis: [],
+          // Cross-FT CUPED uses one covariate cache per pipeline — the
+          // numerator FT's cache carries `_value` covariates, the
+          // denominator FT's cache carries `_denominator_value` covariates,
+          // and the per-source covariate LEFT JOIN inside each
+          // `__joinedData{i}` picks the right side from each side's cache.
+          // Pipelines with no RA metrics omit `covariateTableFullName`.
+          metricSources: [
+            {
+              factTableId: pipelineA.group.factTableId,
+              tableFullName: pipelineA.tableFullName,
+              ...(pipelineA.covariateTableFullName
+                ? { covariateTableFullName: pipelineA.covariateTableFullName }
+                : {}),
+            },
+            {
+              factTableId: pipelineB.group.factTableId,
+              tableFullName: pipelineB.tableFullName,
+              ...(pipelineB.covariateTableFullName
+                ? { covariateTableFullName: pipelineB.covariateTableFullName }
+                : {}),
+            },
+          ],
+        }),
       dependencies: [
         pipelineA.insertQuery.query,
         pipelineB.insertQuery.query,
@@ -1233,7 +1255,7 @@ export class ExperimentIncrementalRefreshQueryRunner extends QueryRunner<
       this.experimentUpdateExecutionLogger.execution.covariateSources = [];
     }
 
-    return await startExperimentIncrementalRefreshQueries(
+    return startExperimentIncrementalRefreshQueries(
       this.context,
       params,
       this.integration,

--- a/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
@@ -46,7 +46,10 @@ import {
 } from "back-end/src/models/ExperimentSnapshotModel";
 import { getExposureQueryEligibleDimensions } from "back-end/src/services/dimensions";
 import { getExposureQuery } from "back-end/src/integrations/sql/queries/exposure-query";
-import { getFactMetricGroups } from "back-end/src/services/experimentQueries/experimentQueries";
+import {
+  getFactMetricGroupQueryName,
+  getFactMetricGroups,
+} from "back-end/src/services/experimentQueries/experimentQueries";
 import { parseDimension } from "back-end/src/services/experiments";
 import {
   analyzeExperimentResults,
@@ -87,6 +90,12 @@ export type ExperimentResultsQueryParams = {
 export const TRAFFIC_QUERY_NAME = "traffic";
 
 export const UNITS_TABLE_PREFIX = "growthbook_tmp_units";
+
+// Canonical name of the query that drops the shared units table. The builder and
+// the metric-query classifier below both derive it from here so they can't drift.
+export function getDropUnitsTableQueryName(queryParentId: string): string {
+  return `drop_${queryParentId}`;
+}
 
 export const startExperimentResultQueries = async (
   context: ApiReqContext,
@@ -230,13 +239,20 @@ export const startExperimentResultQueries = async (
       // The shared units table carries both the parent's experiment-dim
       // columns and one dim_unit_<id> column per configured unit dimension so
       // the isolated per-dim metric queries can read it.
-      query: integration.getExperimentUnitsTableQuery({
-        ...unitQueryParams,
-        dimensions: [
-          ...unitQueryParams.dimensions,
-          ...unitDimensionsToPrecompute,
-        ],
-      }),
+      //
+      // Passing a builder isolates a build-time SQL-generation failure of the
+      // shared units table: it becomes a failed-query record whose dependents
+      // (every metric query) cascade with "Dependencies failed: …", instead of
+      // the throw escaping and producing an opaque snapshot error with no
+      // query pointers at all.
+      query: () =>
+        integration.getExperimentUnitsTableQuery({
+          ...unitQueryParams,
+          dimensions: [
+            ...unitQueryParams.dimensions,
+            ...unitDimensionsToPrecompute,
+          ],
+        }),
       dependencies: [],
       run: (query, setExternalId, queryMetadata) =>
         integration.runExperimentUnitsQuery(
@@ -285,10 +301,13 @@ export const startExperimentResultQueries = async (
       unitsTableFullName: unitsTableFullName,
       factTableMap: params.factTableMap,
     };
+    // Passing a builder isolates build-time SQL-generation failures to the
+    // owning metric: a throw becomes a failed-query record instead of escaping
+    // and failing the whole snapshot, so every other metric still builds/runs.
     queries.push(
       await startQuery({
         name: m.id,
-        query: integration.getSnapshotMetricQuery(queryParams),
+        query: () => integration.getSnapshotMetricQuery(queryParams),
         dependencies: unitQuery ? [unitQuery.query] : [],
         run: (query, setExternalId, queryMetadata) =>
           integration.runSnapshotMetricQuery(
@@ -325,11 +344,17 @@ export const startExperimentResultQueries = async (
     ) {
       throw new Error("Integration does not support multi-metric queries");
     }
+    const getExperimentFactMetricsQuery =
+      integration.getExperimentFactMetricsQuery.bind(integration);
 
+    // Passing a builder isolates build-time SQL-generation failures to the
+    // owning group: a throw becomes a failed-query record for `group_<i>`,
+    // which Phase 1's attribution maps to each constituent metric, while other
+    // groups still build and run.
     queries.push(
       await startQuery({
-        name: `group_${i}`,
-        query: integration.getExperimentFactMetricsQuery(queryParams),
+        name: getFactMetricGroupQueryName(i),
+        query: () => getExperimentFactMetricsQuery(queryParams),
         dependencies: unitQuery ? [unitQuery.query] : [],
         run: (query, setExternalId, queryMetadata) =>
           (integration as SqlIntegration).runExperimentFactMetricsQuery(
@@ -356,6 +381,8 @@ export const startExperimentResultQueries = async (
         ) {
           throw new Error("Integration does not support multi-metric queries");
         }
+        const getExperimentFactMetricsQuery =
+          integration.getExperimentFactMetricsQuery.bind(integration);
         const queryParams: ExperimentFactMetricsQueryParams = {
           activationMetric,
           dimensions: [unitDim],
@@ -367,10 +394,14 @@ export const startExperimentResultQueries = async (
           unitsTableFullName: unitsTableFullName,
           factTableMap: params.factTableMap,
         };
+        const unitDimGroupName = getUnitDimQueryName(
+          dimensionId,
+          getFactMetricGroupQueryName(i),
+        );
         queries.push(
           await startQuery({
-            name: getUnitDimQueryName(dimensionId, `group_${i}`),
-            query: integration.getExperimentFactMetricsQuery(queryParams),
+            name: unitDimGroupName,
+            query: () => getExperimentFactMetricsQuery(queryParams),
             dependencies: [unitQuery.query],
             run: (query, setExternalId, queryMetadata) =>
               (integration as SqlIntegration).runExperimentFactMetricsQuery(
@@ -413,10 +444,11 @@ export const startExperimentResultQueries = async (
           unitsTableFullName: unitsTableFullName,
           factTableMap: params.factTableMap,
         };
+        const unitDimMetricName = getUnitDimQueryName(dimensionId, m.id);
         queries.push(
           await startQuery({
-            name: getUnitDimQueryName(dimensionId, m.id),
-            query: integration.getSnapshotMetricQuery(queryParams),
+            name: unitDimMetricName,
+            query: () => integration.getSnapshotMetricQuery(queryParams),
             dependencies: [unitQuery.query],
             run: (query, setExternalId, queryMetadata) =>
               integration.runSnapshotMetricQuery(
@@ -449,14 +481,17 @@ export const startExperimentResultQueries = async (
 
     trafficQuery = await startQuery({
       name: TRAFFIC_QUERY_NAME,
-      query: integration.getExperimentAggregateUnitsQuery({
-        ...unitQueryParams,
-        settings: snapshotSettings,
-        dimensions: snapshotDimensionsForTraffic.length
-          ? snapshotDimensionsForTraffic
-          : dimensionsForTraffic,
-        useUnitsTable: !!unitQuery,
-      }),
+      // Owns no metric, but its build throw escapes today all the same; as a
+      // failed query it lands on the traffic health block instead.
+      query: () =>
+        integration.getExperimentAggregateUnitsQuery({
+          ...unitQueryParams,
+          settings: snapshotSettings,
+          dimensions: snapshotDimensionsForTraffic.length
+            ? snapshotDimensionsForTraffic
+            : dimensionsForTraffic,
+          useUnitsTable: !!unitQuery,
+        }),
       dependencies: unitQuery ? [unitQuery.query] : [],
       run: (query, setExternalId, queryMetadata) =>
         integration.runExperimentAggregateUnitsQuery(
@@ -474,10 +509,11 @@ export const startExperimentResultQueries = async (
     settings.pipelineSettings?.unitsTableDeletion;
   if (useUnitsTable && dropUnitsTable) {
     const dropUnitsTableQuery = await startQuery({
-      name: `drop_${queryParentId}`,
-      query: integration.getDropUnitsTableQuery({
-        fullTablePath: unitsTableFullName,
-      }),
+      name: getDropUnitsTableQueryName(queryParentId),
+      query: () =>
+        integration.getDropUnitsTableQuery({
+          fullTablePath: unitsTableFullName,
+        }),
       dependencies: [],
       // all other queries in model must succeed or fail first
       runAtEnd: true,

--- a/packages/back-end/src/queryRunners/PopulationDataQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/PopulationDataQueryRunner.ts
@@ -32,7 +32,10 @@ import { SourceIntegrationInterface } from "back-end/src/types/Integration";
 import { expandDenominatorMetrics } from "back-end/src/util/sql";
 import { FactTableMap } from "back-end/src/models/FactTableModel";
 import SqlIntegration from "back-end/src/integrations/SqlIntegration";
-import { getFactMetricGroups } from "back-end/src/services/experimentQueries/experimentQueries";
+import {
+  getFactMetricGroupQueryName,
+  getFactMetricGroups,
+} from "back-end/src/services/experimentQueries/experimentQueries";
 import {
   QueryRunner,
   QueryMap,
@@ -175,7 +178,7 @@ export const startPopulationDataQueries = async (
 
     queries.push(
       await startQuery({
-        name: `group_${i}`,
+        name: getFactMetricGroupQueryName(i),
         query: integration.getPopulationFactMetricsQuery(queryParams),
         dependencies: [],
         run: (query, setExternalId, queryMetadata) =>

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -11,6 +11,7 @@ import {
 import { parseIntWithDefault, parseOptionalInt } from "shared/util";
 import {
   countRunningQueries,
+  createFailedQuery,
   createNewQuery,
   createNewQueryFromCached,
   getQueriesByIds,
@@ -59,7 +60,11 @@ export type ProcessedRowsType = Record<string, any>;
 export type StartQueryParams<Rows, ProcessedRows> = {
   name: string;
   displayTitle?: string;
-  query: string;
+  // Either the already-built SQL, or a builder invoked inside startQuery. Pass a
+  // builder when construction can throw (invalid metric/fact-table config): the
+  // throw is caught and recorded as a terminal failed query for this unit
+  // instead of escaping and failing the whole snapshot.
+  query: string | (() => string);
   dependencies: string[];
   run: (
     query: string,
@@ -83,19 +88,43 @@ const MAX_CONCURRENCY_TIMEOUT = 4000;
 const GENERIC_QUERY_FAILURE_ERROR =
   "Failed to run a majority of the database queries";
 
+// Prefix the dependency-cascade mechanism (startReadyQueries) writes onto a
+// query's error when it is marked failed because an upstream dependency failed
+// (i.e. one of the queries it depends on failed). This string is persisted on
+// Query documents and matched in multiple places, so it must be a single
+// source of truth — do not inline the literal.
+export const DEPENDENCY_FAILURE_PREFIX = "Dependencies failed";
+
+// Prefix written onto a query's error when its SQL failed to build (a throw
+// during query construction). Turning a build-time throw into a failed-query
+// record carrying this prefix lets the existing per-metric attribution
+// (buildMetricErrorFromQuery) classify it as an `errorType: "build"` error and
+// lets dependent queries cascade-fail through the normal mechanism, instead of
+// the throw escaping and failing the whole snapshot. Single source of truth —
+// do not inline the literal.
+export const BUILD_FAILURE_PREFIX = "Failed to build query";
+
 // Pick the most useful error to surface for a failed runner. Prefer a real
 // failing query's error (e.g. the warehouse's invalid-SQL message) over the
 // "Dependencies failed: ..." cascade messages the runner writes onto queries
 // whose upstream failed, and fall back to a generic message when no query
 // carries a usable error.
-export function getQueryFailureError(queryMap: QueryMap): string {
-  const failed = Array.from(queryMap.values()).filter(
-    (q) => q.status === "failed" && q.error,
-  );
+//
+// Works on anything carrying a status + error, so it can chain the root cause
+// from either the standalone Query documents (`getQueryFailureError`) or the
+// embedded query pointers, which carry the error too.
+export function pickQueryFailureError(
+  queries: { status: QueryStatus; error?: string }[],
+): string {
+  const failed = queries.filter((q) => q.status === "failed" && q.error);
   const rootCause = failed.find(
-    (q) => !q.error?.startsWith("Dependencies failed"),
+    (q) => !q.error?.startsWith(DEPENDENCY_FAILURE_PREFIX),
   );
   return (rootCause ?? failed[0])?.error || GENERIC_QUERY_FAILURE_ERROR;
+}
+
+export function getQueryFailureError(queryMap: QueryMap): string {
+  return pickQueryFailureError(Array.from(queryMap.values()));
 }
 
 export async function getQueryMap(
@@ -377,7 +406,10 @@ export abstract class QueryRunner<
     } else if (queryStatus === "failed") {
       this.experimentUpdateExecutionLogger?.endPhase("runQueries");
       logger.debug(this.model.id + " runner: Query failed immediately");
-      error = "Error running one or more database queries";
+      // Queries that failed before ever running (build-time SQL-generation
+      // failures, cached failures) already carry their error on the pointer, so
+      // chain the real root cause instead of a generic message.
+      error = pickQueryFailureError(queries);
     }
 
     const newModel = await this.updateModel({
@@ -488,7 +520,7 @@ export abstract class QueryRunner<
         await updateQuery(this.context, query, {
           finishedAt: new Date(),
           status: "failed",
-          error: `Dependencies failed: ${failedDependencies.map(
+          error: `${DEPENDENCY_FAILURE_PREFIX}: ${failedDependencies.map(
             (q) => q.query,
           )}`,
         });
@@ -887,7 +919,7 @@ export abstract class QueryRunner<
     const {
       name,
       displayTitle,
-      query,
+      query: queryOrBuilder,
       dependencies,
       runAtEnd,
       run,
@@ -896,6 +928,40 @@ export abstract class QueryRunner<
       onSuccess,
       queryType,
     } = params;
+
+    // Resolve the SQL. Building it can throw (e.g. invalid metric/fact-table
+    // config); when it does, register a terminal failed query for this unit
+    // rather than letting the exception escape and fail the whole snapshot.
+    // Downstream attribution and the aggregate status machinery then treat it
+    // like any other failed query.
+    let query: string;
+    try {
+      query =
+        typeof queryOrBuilder === "function"
+          ? queryOrBuilder()
+          : queryOrBuilder;
+    } catch (e) {
+      const error = `${BUILD_FAILURE_PREFIX}: ${
+        e instanceof Error ? e.message : String(e)
+      }`;
+      const doc = await createFailedQuery({
+        query: "",
+        queryType,
+        displayTitle,
+        datasource: this.integration.datasource.id,
+        organization: this.integration.context.org.id,
+        language: this.integration.getSourceProperties().queryLanguage,
+        dependencies,
+        error,
+      });
+      return {
+        name,
+        query: doc.id,
+        status: "failed",
+        error,
+      };
+    }
+
     // Re-use recent identical query if it exists
     if (this.useCache) {
       logger.debug("Trying to reuse existing query for " + name);
@@ -1084,6 +1150,13 @@ export abstract class QueryRunner<
       if (pointer.status !== query.status) {
         hasChanges = true;
         pointer.status = query.status;
+      }
+
+      // Copy the standalone Query's error onto the embedded pointer so the
+      // per-query error is reachable from the snapshot without a separate fetch.
+      if ((pointer.error ?? undefined) !== (query.error ?? undefined)) {
+        hasChanges = true;
+        pointer.error = query.error;
       }
 
       // If the query succeeded, add it to the cache

--- a/packages/back-end/src/queryRunners/incrementalStatisticsQueryNaming.ts
+++ b/packages/back-end/src/queryRunners/incrementalStatisticsQueryNaming.ts
@@ -1,0 +1,15 @@
+// Canonical names of the queries that compute metric statistics in the
+// incremental pipeline. The builders and the classifier below both live here so
+// they can't drift (same reason as getDropUnitsTableQueryName).
+const STATISTICS_QUERY_PREFIX = "statistics_";
+
+export function getIncrementalStatisticsQueryName(groupId: string): string {
+  return `${STATISTICS_QUERY_PREFIX}${groupId}`;
+}
+
+export function getIncrementalCrossStatisticsQueryName(
+  groupIdA: string,
+  groupIdB: string,
+): string {
+  return `${STATISTICS_QUERY_PREFIX}cross_${groupIdA}__${groupIdB}`;
+}

--- a/packages/back-end/src/services/experimentQueries/experimentQueries.ts
+++ b/packages/back-end/src/services/experimentQueries/experimentQueries.ts
@@ -273,6 +273,14 @@ export interface GroupedMetrics {
   legacyMetricSingles: MetricInterface[];
 }
 
+// Canonical query name for the i-th fact-metric group. The query-building loops
+// and the error-attribution map both derive names from here so they can never
+// drift apart — changing the format in one place would silently break the
+// mapping of a failed group query back to its constituent metrics.
+export function getFactMetricGroupQueryName(i: number): string {
+  return `group_${i}`;
+}
+
 export function getFactMetricGroups(
   metrics: ExperimentMetricInterface[],
   settings: ExperimentSnapshotSettings,

--- a/packages/back-end/test/api/snapshots.test.ts
+++ b/packages/back-end/test/api/snapshots.test.ts
@@ -66,6 +66,36 @@ describe("snapshots API", () => {
     });
   });
 
+  it("surfaces why a snapshot failed", async () => {
+    setReqContext({
+      org,
+      permissions: {
+        canReadSingleProjectResource: () => true,
+      },
+    });
+
+    const snapshot = snapshotFactory.build({
+      organization: org.id,
+      status: "error",
+      error: "Failed to build query: Unknown fact table",
+    });
+
+    findSnapshotById.mockReturnValueOnce(snapshot);
+    getExperimentById.mockReturnValueOnce({ id: snapshot.experiment });
+
+    const response = await request(app)
+      .get("/api/v1/snapshots/snp_1")
+      .set("Authorization", "Bearer foo");
+
+    expect(response.status).toBe(200);
+    expect(response.body.snapshot).toEqual({
+      id: snapshot.id,
+      experiment: snapshot.experiment,
+      status: "error",
+      error: "Failed to build query: Unknown fact table",
+    });
+  });
+
   it("checks permission on experiment when getting a snapshot", async () => {
     setReqContext({
       org,

--- a/packages/back-end/test/queryRunners/ExperimentResultsQueryRunner.test.ts
+++ b/packages/back-end/test/queryRunners/ExperimentResultsQueryRunner.test.ts
@@ -1,0 +1,307 @@
+import { ExperimentMetricInterface } from "shared/experiments";
+import { QueryPointer } from "shared/types/query";
+import { buildUnitsQuerySettingsFromSnapshot } from "shared/util";
+import { startExperimentResultQueries } from "back-end/src/queryRunners/ExperimentResultsQueryRunner";
+import { getFactMetricGroups } from "back-end/src/services/experimentQueries/experimentQueries";
+import { orgHasPremiumFeature } from "back-end/src/enterprise";
+import { getExposureQuery } from "back-end/src/integrations/sql/queries/exposure-query";
+import { parseDimension } from "back-end/src/services/experiments";
+import { shouldRunHealthTrafficQuery } from "back-end/src/queryRunners/snapshotQueryHelpers";
+import { factMetricFactory } from "back-end/test/factories/FactMetric.factory";
+
+// Only override the specific collaborators the build-isolation path touches;
+// keep the pure helpers (e.g. getFactMetricGroupQueryName) real.
+jest.mock("back-end/src/services/experimentQueries/experimentQueries", () => ({
+  ...jest.requireActual(
+    "back-end/src/services/experimentQueries/experimentQueries",
+  ),
+  getFactMetricGroups: jest.fn(),
+}));
+
+jest.mock("back-end/src/enterprise", () => ({
+  orgHasPremiumFeature: jest.fn(),
+}));
+
+jest.mock("back-end/src/integrations/sql/queries/exposure-query", () => ({
+  getExposureQuery: jest.fn(),
+}));
+
+jest.mock("back-end/src/services/experiments", () => ({
+  parseDimension: jest.fn(),
+}));
+
+jest.mock("back-end/src/queryRunners/snapshotQueryHelpers", () => ({
+  shouldRunHealthTrafficQuery: jest.fn(),
+}));
+
+jest.mock("shared/util", () => ({
+  ...jest.requireActual("shared/util"),
+  buildUnitsQuerySettingsFromSnapshot: jest.fn(),
+}));
+
+jest.mock("back-end/src/util/logger", () => ({
+  logger: {
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const mockedGetFactMetricGroups = getFactMetricGroups as jest.Mock;
+const mockedOrgHasPremiumFeature = orgHasPremiumFeature as jest.Mock;
+const mockedGetExposureQuery = getExposureQuery as jest.Mock;
+const mockedParseDimension = parseDimension as jest.Mock;
+const mockedShouldRunHealthTrafficQuery =
+  shouldRunHealthTrafficQuery as jest.Mock;
+const mockedBuildUnitsQuerySettings =
+  buildUnitsQuerySettingsFromSnapshot as jest.Mock;
+
+function buildLegacyMetric(id: string): ExperimentMetricInterface {
+  return { id, denominator: null } as unknown as ExperimentMetricInterface;
+}
+
+describe("startExperimentResultQueries build-time error isolation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedOrgHasPremiumFeature.mockReturnValue(false);
+    mockedGetExposureQuery.mockReturnValue({});
+    mockedParseDimension.mockResolvedValue(null);
+    // No units table, no traffic query — keep the DAG to just the metric and
+    // group queries so the assertions stay focused on build isolation.
+    mockedShouldRunHealthTrafficQuery.mockReturnValue(false);
+    mockedBuildUnitsQuerySettings.mockReturnValue({});
+  });
+
+  it("records a failed query for a metric/group whose construction throws, while the others still start", async () => {
+    const legacyOk = buildLegacyMetric("met_ok");
+    const legacyBad = buildLegacyMetric("met_bad");
+    const groupOk = factMetricFactory.build({ id: "fact_ok" });
+    const groupBad = factMetricFactory.build({ id: "fact_bad" });
+
+    mockedGetFactMetricGroups.mockReturnValue({
+      legacyMetricSingles: [legacyOk, legacyBad],
+      factMetricGroups: [[groupOk], [groupBad]],
+    });
+
+    const metricMap = new Map<string, ExperimentMetricInterface>([
+      [legacyOk.id, legacyOk],
+      [legacyBad.id, legacyBad],
+      [groupOk.id, groupOk],
+      [groupBad.id, groupBad],
+    ]);
+
+    // Fail construction for the "bad" legacy metric and the second group.
+    const integration = {
+      datasource: { id: "ds_1", settings: {} },
+      getSourceProperties: () => ({
+        separateExperimentResultQueries: true,
+        supportsWritingTables: false,
+        queryLanguage: "sql",
+        dropUnitsTable: false,
+      }),
+      getSnapshotMetricQuery: jest.fn((params) => {
+        if (params.metric.id === "met_bad") {
+          throw new Error("bad legacy metric SQL");
+        }
+        return "SELECT 1 -- legacy";
+      }),
+      getExperimentFactMetricsQuery: jest.fn((params) => {
+        if (params.metrics[0].id === "fact_bad") {
+          throw new Error("Unknown fact table");
+        }
+        return "SELECT 1 -- group";
+      }),
+      runSnapshotMetricQuery: jest.fn(),
+      runExperimentFactMetricsQuery: jest.fn(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const context = {
+      org: { id: "org_1", settings: {} },
+      models: { segments: { getById: jest.fn() } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const params = {
+      snapshotType: "standard",
+      snapshotSettings: {
+        metricSettings: [
+          { id: "met_ok" },
+          { id: "met_bad" },
+          { id: "fact_ok" },
+          { id: "fact_bad" },
+        ],
+        dimensions: [],
+        variations: [],
+        exposureQueryId: "",
+      },
+      variationNames: [],
+      metricMap,
+      factTableMap: new Map(),
+      queryParentId: "snp_1",
+      experimentQueryMetadata: null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    // Injected startQuery stands in for the real method: it resolves the SQL
+    // builder and, when construction throws, records a terminal failed query
+    // (mirroring QueryRunner.startQuery's build-guard) rather than letting the
+    // throw escape. startExperimentResultQueries must pass a builder (not an
+    // eagerly-constructed string) so a per-unit throw is isolated here.
+    const startQuery = jest.fn(
+      async ({
+        name,
+        query,
+      }: {
+        name: string;
+        query: string | (() => string);
+      }): Promise<QueryPointer> => {
+        try {
+          if (typeof query === "function") query();
+          return { name, query: `qry_${name}`, status: "queued" };
+        } catch (e) {
+          return {
+            name,
+            query: `qry_failed_${name}`,
+            status: "failed",
+            error: `Failed to build query: ${
+              e instanceof Error ? e.message : String(e)
+            }`,
+          };
+        }
+      },
+    );
+
+    const queries = await startExperimentResultQueries(
+      context,
+      params,
+      integration,
+      startQuery,
+    );
+
+    // Every unit — including the ones whose construction throws — is handed to
+    // startQuery: the loop delegates construction lazily rather than aborting.
+    const startedNames = startQuery.mock.calls.map((c) => c[0].name);
+    expect(startedNames).toEqual(
+      expect.arrayContaining(["met_ok", "met_bad", "group_0", "group_1"]),
+    );
+
+    // All four units are represented in the returned DAG with the right status,
+    // and the failing ones carry the chained build error message.
+    const byName = new Map(queries.map((q) => [q.name, q]));
+    expect(byName.get("met_ok")?.status).toBe("queued");
+    expect(byName.get("group_0")?.status).toBe("queued");
+    expect(byName.get("met_bad")?.status).toBe("failed");
+    expect(byName.get("met_bad")?.error).toBe(
+      "Failed to build query: bad legacy metric SQL",
+    );
+    expect(byName.get("group_1")?.status).toBe("failed");
+    expect(byName.get("group_1")?.error).toBe(
+      "Failed to build query: Unknown fact table",
+    );
+  });
+
+  it("records a failed query when the shared units-table construction throws, and still starts the dependent metric queries", async () => {
+    mockedOrgHasPremiumFeature.mockReturnValue(true);
+    const legacy = buildLegacyMetric("met_ok");
+    mockedGetFactMetricGroups.mockReturnValue({
+      legacyMetricSingles: [legacy],
+      factMetricGroups: [],
+    });
+
+    const metricMap = new Map<string, ExperimentMetricInterface>([
+      [legacy.id, legacy],
+    ]);
+
+    const integration = {
+      datasource: {
+        id: "ds_1",
+        settings: {
+          pipelineSettings: {
+            allowWriting: true,
+            mode: "ephemeral",
+            writeDataset: "gb_tmp",
+          },
+        },
+      },
+      getSourceProperties: () => ({
+        separateExperimentResultQueries: true,
+        supportsWritingTables: true,
+        queryLanguage: "sql",
+        dropUnitsTable: false,
+      }),
+      generateTablePath: () => "gb_tmp.units",
+      getExperimentUnitsTableQuery: jest.fn(() => {
+        throw new Error("Unknown variable: ce_bad_units_var");
+      }),
+      getSnapshotMetricQuery: jest.fn(() => "SELECT 1 -- legacy"),
+      runExperimentUnitsQuery: jest.fn(),
+      runSnapshotMetricQuery: jest.fn(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const context = {
+      org: { id: "org_1", settings: {} },
+      models: { segments: { getById: jest.fn() } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const params = {
+      snapshotType: "standard",
+      snapshotSettings: {
+        metricSettings: [{ id: "met_ok" }],
+        dimensions: [],
+        variations: [],
+        exposureQueryId: "",
+      },
+      variationNames: [],
+      metricMap,
+      factTableMap: new Map(),
+      queryParentId: "snp_1",
+      experimentQueryMetadata: null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const startQuery = jest.fn(
+      async ({
+        name,
+        query,
+      }: {
+        name: string;
+        query: string | (() => string);
+      }): Promise<QueryPointer> => {
+        try {
+          if (typeof query === "function") query();
+          return { name, query: `qry_${name}`, status: "queued" };
+        } catch (e) {
+          return {
+            name,
+            query: `qry_failed_${name}`,
+            status: "failed",
+            error: `Failed to build query: ${
+              e instanceof Error ? e.message : String(e)
+            }`,
+          };
+        }
+      },
+    );
+
+    const queries = await startExperimentResultQueries(
+      context,
+      params,
+      integration,
+      startQuery,
+    );
+
+    const byName = new Map(queries.map((q) => [q.name, q]));
+    // The units-table build throw is recorded, not escaped...
+    expect(byName.get("snp_1")?.status).toBe("failed");
+    expect(byName.get("snp_1")?.error).toBe(
+      "Failed to build query: Unknown variable: ce_bad_units_var",
+    );
+    // ...and the dependent metric query is still created, so the runtime
+    // cascade can mark it "Dependencies failed: …".
+    expect(byName.get("met_ok")?.status).toBe("queued");
+  });
+});

--- a/packages/back-end/test/queryRunners/QueryRunner.test.ts
+++ b/packages/back-end/test/queryRunners/QueryRunner.test.ts
@@ -7,7 +7,11 @@ import {
   getQueryFailureError,
 } from "back-end/src/queryRunners/QueryRunner";
 import { SourceIntegrationInterface } from "back-end/src/types/Integration";
-import { getQueriesByIds, updateQuery } from "back-end/src/models/QueryModel";
+import {
+  createFailedQuery,
+  getQueriesByIds,
+  updateQuery,
+} from "back-end/src/models/QueryModel";
 
 jest.mock("back-end/src/models/QueryModel");
 
@@ -92,6 +96,7 @@ const createMockIntegration = (): SourceIntegrationInterface => {
     context: {
       org: { id: "test-org" },
     },
+    getSourceProperties: () => ({ queryLanguage: "sql" }),
   } as unknown as SourceIntegrationInterface;
 };
 
@@ -144,6 +149,56 @@ describe("getQueryFailureError", () => {
   it("returns the generic message when no failed query has an error", () => {
     const error = getQueryFailureError(makeFailedQueryMap(["a", { id: "q1" }]));
     expect(error).toBe("Failed to run a majority of the database queries");
+  });
+});
+
+describe("startQuery build-time isolation", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("records a terminal failed query when the SQL builder throws, instead of escaping", async () => {
+    const model: InterfaceWithQueries = {
+      id: "test-model",
+      organization: "test-org",
+      queries: [],
+      runStarted: new Date(),
+    };
+    const runner = new TestQueryRunner(
+      createMockContext(),
+      model,
+      createMockIntegration(),
+    );
+
+    (createFailedQuery as jest.Mock).mockResolvedValue({ id: "qry_failed" });
+
+    const pointer = await runner.startQuery({
+      name: "met_bad",
+      query: () => {
+        throw new Error("Unknown fact table");
+      },
+      dependencies: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      run: jest.fn() as any,
+      queryType: "experimentMetric",
+    });
+
+    expect(pointer).toEqual({
+      name: "met_bad",
+      query: "qry_failed",
+      status: "failed",
+      error: "Failed to build query: Unknown fact table",
+    });
+    // The failure is persisted as a terminal failed Query doc, never executed.
+    expect(createFailedQuery as jest.Mock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: "Failed to build query: Unknown fact table",
+        queryType: "experimentMetric",
+        organization: "test-org",
+        datasource: "test-ds",
+      }),
+    );
+    expect(runner.executeQuerySpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardUpdateDisplay.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardUpdateDisplay.tsx
@@ -71,7 +71,7 @@ function DashboardStatusSummary({
           : lastUpdateTime
             ? `Updated ${ago(lastUpdateTime).replace("about ", "")}`
             : "Not started yet";
-  const tooltipBody = refreshError ? refreshError : undefined;
+  const tooltipBody = refreshError ?? snapshotError ?? undefined;
 
   return (
     <Flex gap="1" align="center">

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -868,11 +868,21 @@ const apiExperimentSnapshotShape = z.object({
   id: z.string(),
   experiment: z.string(),
   status: z.string(),
+  error: z
+    .string()
+    .describe(
+      "Why this snapshot failed. Present only when status is `error`. Names the underlying cause, such as the warehouse error or the reason a metric's query could not be built.",
+    )
+    .optional(),
 });
 export const apiExperimentSnapshotValidator = namedSchema(
   "ExperimentSnapshot",
   apiExperimentSnapshotShape.strict(),
 );
+
+export type ApiExperimentSnapshot = z.infer<
+  typeof apiExperimentSnapshotValidator
+>;
 
 // Corresponds to schemas/ExperimentResults.yaml
 export const apiExperimentResultsValidator = namedSchema(

--- a/packages/shared/src/validators/queries.ts
+++ b/packages/shared/src/validators/queries.ts
@@ -15,6 +15,9 @@ export const queryPointerValidator = z
     query: z.string(),
     status: queryStatusValidator,
     name: z.string(),
+    // Raw error from the underlying Query doc, copied onto the pointer so the
+    // per-query error is reachable from the snapshot without a separate fetch.
+    error: z.string().optional(),
   })
   .strict();
 


### PR DESCRIPTION
### Features and Changes

A result query used to receive its SQL already built, so a throw during construction (an invalid metric, or a fact table that no longer resolves) escaped `startQuery`, aborted the whole snapshot before a single query ran, and reported a generic message that named neither the query nor the reason.

- `startQuery` now accepts a query *builder* and runs it inside a try/catch. On a throw it writes a terminal failed `Query` (`Failed to build query: <reason>`) and returns a failed pointer, so the existing dependency-cascade and aggregate-status machinery contains the failure to that one unit instead of taking down the snapshot.
- Persist `QueryPointer.error` and copy each query's error onto its pointer, so the snapshot alone explains why a query failed, with no second fetch.
- `pickQueryFailureError` chains the real root cause, preferring it over the "Dependencies failed" cascade messages, and `startAnalysis` surfaces that instead of "Error running one or more database queries".
- Public API: `ExperimentSnapshot` gains an optional `error`, so a caller polling `GET /snapshots/{id}` or `POST /experiments/{id}/snapshot` can see why a refresh failed. One `toApiExperimentSnapshot` mapper replaces the two hand-built response literals.

### Testing

- `pnpm type-check`
- Build-isolation tests in `QueryRunner.test.ts` and `ExperimentResultsQueryRunner.test.ts`
- `test/api/snapshots.test.ts` for the new `error` field
