### PR TITLE
fix(experiments): keep analyzing metrics whose queries survived

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -51638,6 +51638,18 @@ components:
           type: array
           items:
             type: string
+        queryStatus:
+          description: >-
+            Outcome of the warehouse queries behind these results.
+            `partially-succeeded` means at least one metric produced no results,
+            so the metric list is incomplete.
+          type: string
+          enum:
+            - queued
+            - running
+            - succeeded
+            - partially-succeeded
+            - failed
         results:
           type: array
           items:
@@ -61202,6 +61214,18 @@ components:
             the underlying cause, such as the warehouse error or the reason a
             metric's query could not be built.
           type: string
+        queryStatus:
+          description: >-
+            Outcome of the warehouse queries behind these results.
+            `partially-succeeded` means at least one metric produced no results,
+            so the metric list is incomplete.
+          type: string
+          enum:
+            - queued
+            - running
+            - succeeded
+            - partially-succeeded
+            - failed
       required:
         - id
         - experiment
@@ -64124,6 +64148,18 @@ components:
             the underlying cause, such as the warehouse error or the reason a
             metric's query could not be built.
           type: string
+        queryStatus:
+          description: >-
+            Outcome of the warehouse queries behind these results.
+            `partially-succeeded` means at least one metric produced no results,
+            so the metric list is incomplete.
+          type: string
+          enum:
+            - queued
+            - running
+            - succeeded
+            - partially-succeeded
+            - failed
       required:
         - id
         - experiment

--- a/packages/back-end/src/api/snapshots/toApiExperimentSnapshot.ts
+++ b/packages/back-end/src/api/snapshots/toApiExperimentSnapshot.ts
@@ -1,5 +1,6 @@
 import { ApiExperimentSnapshot } from "shared/validators";
 import { ExperimentSnapshotInterface } from "shared/types/experiment-snapshot";
+import { getMetricAwareQueryStatus } from "back-end/src/queryRunners/QueryRunner";
 
 /**
  * Build the `ExperimentSnapshot` public API model.
@@ -17,5 +18,9 @@ export function toApiExperimentSnapshot(
     experiment: snapshot.experiment,
     status: snapshot.status,
     error: snapshot.error,
+    // `status` cannot express a partial run: it is "success" whenever anything
+    // analyzable survived. Absent for snapshots stored before queries recorded
+    // the metrics they own, where completeness is genuinely unknowable.
+    queryStatus: getMetricAwareQueryStatus(snapshot.queries) ?? undefined,
   };
 }

--- a/packages/back-end/src/models/QueryModel.ts
+++ b/packages/back-end/src/models/QueryModel.ts
@@ -14,6 +14,15 @@ export const queriesSchema = [
     query: String,
     status: String,
     name: String,
+    metrics: {
+      type: [String],
+      default: undefined,
+    },
+    metricScope: {
+      type: String,
+      enum: ["primary", "dimension"],
+    },
+    metricScopeId: String,
     error: String,
   },
 ];

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
@@ -40,6 +40,7 @@ import {
   ProcessedRowsType,
   RowsType,
   StartQueryParams,
+  getMetricAwareQueryStatus,
 } from "./QueryRunner";
 import { SnapshotResult } from "./ExperimentResultsQueryRunner";
 import {
@@ -245,6 +246,7 @@ export const startExperimentIncrementalRefreshExploratoryQueries = async (
 
     const statisticsQuery = await startQuery({
       name: getIncrementalStatisticsQueryName(group.groupId),
+      metrics: sameFtMetrics.map((metric) => metric.id),
       displayTitle: `Compute Statistics ${sourceName}`,
       query: () =>
         integration.getIncrementalRefreshStatisticsQuery({
@@ -311,6 +313,7 @@ export const startExperimentIncrementalRefreshExploratoryQueries = async (
         pipelineA.group.groupId,
         pipelineB.group.groupId,
       ),
+      metrics: subGroup.metrics.map((metric) => metric.metric.id),
       displayTitle: `Compute Cross-Fact Statistics ${sourceName}`,
       query: () =>
         integration.getIncrementalRefreshStatisticsQuery({
@@ -370,6 +373,13 @@ export class ExperimentIncrementalRefreshExploratoryQueryRunner extends QueryRun
   checkPermissions(): boolean {
     return this.context.permissions.canRunExperimentQueries(
       this.integration.datasource,
+    );
+  }
+
+  protected override getOverallQueryStatus(): QueryStatus {
+    return (
+      getMetricAwareQueryStatus(this.model.queries) ??
+      super.getOverallQueryStatus()
     );
   }
 

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -72,6 +72,7 @@ import {
   ProcessedRowsType,
   RowsType,
   StartQueryParams,
+  getMetricAwareQueryStatus,
 } from "./QueryRunner";
 import { shouldRunHealthTrafficQuery } from "./snapshotQueryHelpers";
 import {
@@ -1020,6 +1021,7 @@ const startExperimentIncrementalRefreshQueries = async (
       );
       const statisticsQuery = await startQuery({
         name: statisticsQueryName,
+        metrics: sameFtMetrics.map((metric) => metric.id),
         displayTitle: `Compute Statistics ${sourceName}`,
         query: () =>
           integration.getIncrementalRefreshStatisticsQuery({
@@ -1098,6 +1100,7 @@ const startExperimentIncrementalRefreshQueries = async (
     );
     const crossStatsQuery = await startQuery({
       name: crossStatsQueryName,
+      metrics: subGroup.metrics.map((metric) => metric.metric.id),
       displayTitle: `Compute Cross-Fact Statistics ${sourceName}`,
       query: () =>
         integration.getIncrementalRefreshStatisticsQuery({
@@ -1193,10 +1196,20 @@ export class ExperimentIncrementalRefreshQueryRunner extends QueryRunner<
 > {
   private variationNames: string[] = [];
   private metricMap: Map<string, ExperimentMetricInterface> = new Map();
-
   checkPermissions(): boolean {
     return this.context.permissions.canRunExperimentQueries(
       this.integration.datasource,
+    );
+  }
+
+  // A statistics-query failure is this pipeline's metric failure: every metric
+  // is computed by one of them. Failing only when none survived (rather than
+  // the base 50% rule) means a total wipeout reports the chained root cause
+  // instead of an analyzed-looking snapshot with no metric data.
+  protected override getOverallQueryStatus(): QueryStatus {
+    return (
+      getMetricAwareQueryStatus(this.model.queries) ??
+      super.getOverallQueryStatus()
     );
   }
 

--- a/packages/back-end/src/queryRunners/ExperimentReportQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentReportQueryRunner.ts
@@ -16,6 +16,7 @@ import { getSnapshotSettingsFromReportArgs } from "back-end/src/services/reports
 import { analyzeExperimentResults } from "back-end/src/services/stats";
 import {
   ExperimentResultsQueryParams,
+  getExperimentResultsQueryStatus,
   startExperimentResultQueries,
 } from "./ExperimentResultsQueryRunner";
 import { QueryRunner, QueryMap } from "./QueryRunner";
@@ -45,6 +46,16 @@ export class ExperimentReportQueryRunner extends QueryRunner<
   checkPermissions(): boolean {
     return this.context.permissions.canRunExperimentQueries(
       this.integration.datasource,
+    );
+  }
+
+  // Shares `startExperimentResultQueries`, so it shares its metric-aware
+  // aggregate status: analyze the metric queries that survived rather than
+  // failing everything once half the queries failed.
+  protected override getOverallQueryStatus(): QueryStatus {
+    return (
+      getExperimentResultsQueryStatus(this.model.queries) ??
+      super.getOverallQueryStatus()
     );
   }
 

--- a/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
@@ -66,6 +66,7 @@ import {
   ProcessedRowsType,
   RowsType,
   StartQueryParams,
+  getMetricAwareQueryStatus,
 } from "./QueryRunner";
 import { shouldRunHealthTrafficQuery } from "./snapshotQueryHelpers";
 import { getUnitDimQueryName } from "./unitDimensionQueryNaming";
@@ -95,6 +96,16 @@ export const UNITS_TABLE_PREFIX = "growthbook_tmp_units";
 // the metric-query classifier below both derive it from here so they can't drift.
 export function getDropUnitsTableQueryName(queryParentId: string): string {
   return `drop_${queryParentId}`;
+}
+
+// Aggregate query status for the runners built on `startExperimentResultQueries`
+// (experiment results, reports, safe rollouts): analyze whatever metric queries
+// survived, and only fail the whole run when none did. Legacy snapshots without
+// ownership metadata fall back to the runner's original aggregate policy.
+export function getExperimentResultsQueryStatus(
+  queries: Queries,
+): QueryStatus | null {
+  return getMetricAwareQueryStatus(queries);
 }
 
 export const startExperimentResultQueries = async (
@@ -307,6 +318,7 @@ export const startExperimentResultQueries = async (
     queries.push(
       await startQuery({
         name: m.id,
+        metrics: [m.id],
         query: () => integration.getSnapshotMetricQuery(queryParams),
         dependencies: unitQuery ? [unitQuery.query] : [],
         run: (query, setExternalId, queryMetadata) =>
@@ -354,6 +366,7 @@ export const startExperimentResultQueries = async (
     queries.push(
       await startQuery({
         name: getFactMetricGroupQueryName(i),
+        metrics: m.map((metric) => metric.id),
         query: () => getExperimentFactMetricsQuery(queryParams),
         dependencies: unitQuery ? [unitQuery.query] : [],
         run: (query, setExternalId, queryMetadata) =>
@@ -401,6 +414,9 @@ export const startExperimentResultQueries = async (
         queries.push(
           await startQuery({
             name: unitDimGroupName,
+            metrics: m.map((metric) => metric.id),
+            metricScope: "dimension",
+            metricScopeId: dimensionId,
             query: () => getExperimentFactMetricsQuery(queryParams),
             dependencies: [unitQuery.query],
             run: (query, setExternalId, queryMetadata) =>
@@ -448,6 +464,9 @@ export const startExperimentResultQueries = async (
         queries.push(
           await startQuery({
             name: unitDimMetricName,
+            metrics: [m.id],
+            metricScope: "dimension",
+            metricScopeId: dimensionId,
             query: () => integration.getSnapshotMetricQuery(queryParams),
             dependencies: [unitQuery.query],
             run: (query, setExternalId, queryMetadata) =>
@@ -538,6 +557,17 @@ export class ExperimentResultsQueryRunner extends QueryRunner<
   checkPermissions(): boolean {
     return this.context.permissions.canRunExperimentQueries(
       this.integration.datasource,
+    );
+  }
+
+  // Analyze whatever metric queries survived instead of the base class's
+  // "half the queries failed → fail everything" rule. `queryParentId` is always
+  // the model id (see `createSnapshotFromPlan`), which is also the name of the
+  // shared units-table query.
+  protected override getOverallQueryStatus(): QueryStatus {
+    return (
+      getExperimentResultsQueryStatus(this.model.queries) ??
+      super.getOverallQueryStatus()
     );
   }
 
@@ -754,6 +784,7 @@ export class ExperimentResultsQueryRunner extends QueryRunner<
       await this.startQuery({
         queryType: "experimentResults",
         name: "results",
+        metrics: selectedMetrics.map((metric) => metric.id),
         query: query,
         dependencies: [],
         run: async () => {

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -60,6 +60,9 @@ export type ProcessedRowsType = Record<string, any>;
 export type StartQueryParams<Rows, ProcessedRows> = {
   name: string;
   displayTitle?: string;
+  metrics?: string[];
+  metricScope?: "primary" | "dimension";
+  metricScopeId?: string;
   // Either the already-built SQL, or a builder invoked inside startQuery. Pass a
   // builder when construction can throw (invalid metric/fact-table config): the
   // throw is caught and recorded as a terminal failed query for this unit
@@ -86,7 +89,7 @@ const INITIAL_CONCURRENCY_TIMEOUT = 250;
 const MAX_CONCURRENCY_TIMEOUT = 4000;
 
 const GENERIC_QUERY_FAILURE_ERROR =
-  "Failed to run a majority of the database queries";
+  "Failed to run the database queries for this analysis";
 
 // Prefix the dependency-cascade mechanism (startReadyQueries) writes onto a
 // query's error when it is marked failed because an upstream dependency failed
@@ -125,6 +128,65 @@ export function pickQueryFailureError(
 
 export function getQueryFailureError(queryMap: QueryMap): string {
   return pickQueryFailureError(Array.from(queryMap.values()));
+}
+
+// Aggregate status for runners whose queries include *metric-owning* queries
+// (one per legacy metric or per fact-metric group) alongside queries that own
+// no metric results (the shared units table, its drop, the traffic/SRM query).
+//
+// Replaces the base class's fixed "half the queries failed → failed" rule for
+// those runners. Any metric query that survived is worth analyzing, so we only
+// report `failed` when *no* metric query survived — the total-wipeout case (e.g.
+// a datasource outage cascading through the shared units table), where the
+// caller surfaces the chained root cause via `pickQueryFailureError`. Anything
+// less is `partially-succeeded`, which still runs the analysis and renders the
+// surviving metrics with per-metric inline errors for the rest. A failure that
+// owns no metric (traffic in particular) therefore can never force `failed`.
+export function getMetricAwareQueryStatus(
+  queries: Queries,
+  metricScope: "primary" | "dimension" = "primary",
+  metricScopeId?: string,
+): QueryStatus | null {
+  const metricQueries = queries.filter(
+    (query) =>
+      query.metrics?.length &&
+      (query.metricScope ?? "primary") === metricScope &&
+      (metricScopeId === undefined || query.metricScopeId === metricScopeId),
+  );
+  if (!metricQueries.length) return null;
+
+  // Anything still in flight could yet survive, so don't call it either way.
+  // (The base class short-circuits to `failed` here; waiting costs nothing but
+  // the time the remaining queries were going to take anyway.)
+  if (queries.some((q) => q.status === "running" || q.status === "queued")) {
+    return "running";
+  }
+
+  const anyFailed = queries.some((q) => q.status === "failed");
+  if (!anyFailed) return "succeeded";
+
+  const allMetricQueriesFailed = metricQueries.every(
+    (q) => q.status === "failed",
+  );
+  return allMetricQueriesFailed ? "failed" : "partially-succeeded";
+}
+
+export function getMetricQueryOwnership(
+  queries: Queries,
+  metricScope: "primary" | "dimension" = "primary",
+  metricScopeId?: string,
+): Record<string, string[]> {
+  return Object.fromEntries(
+    queries
+      .filter(
+        (query) =>
+          query.metrics?.length &&
+          (query.metricScope ?? "primary") === metricScope &&
+          (metricScopeId === undefined ||
+            query.metricScopeId === metricScopeId),
+      )
+      .map((query) => [query.name, query.metrics as string[]]),
+  );
 }
 
 export async function getQueryMap(
@@ -390,8 +452,10 @@ export abstract class QueryRunner<
     let result: Result | undefined = undefined;
 
     const queryStatus = this.getOverallQueryStatus();
-    if (queryStatus === "succeeded") {
-      logger.debug(this.model.id + " runner: Query already succeeded (cached)");
+    if (queryStatus === "succeeded" || queryStatus === "partially-succeeded") {
+      logger.debug(
+        `${this.model.id} runner: Cached queries ${queryStatus}, running analysis`,
+      );
       const queryMap = await this.getQueryMap(queries);
       try {
         this.experimentUpdateExecutionLogger?.endPhase("runQueries");
@@ -919,6 +983,9 @@ export abstract class QueryRunner<
     const {
       name,
       displayTitle,
+      metrics,
+      metricScope,
+      metricScopeId,
       query: queryOrBuilder,
       dependencies,
       runAtEnd,
@@ -959,6 +1026,9 @@ export abstract class QueryRunner<
         query: doc.id,
         status: "failed",
         error,
+        metrics,
+        metricScope,
+        metricScopeId,
       };
     }
 
@@ -1031,6 +1101,9 @@ export abstract class QueryRunner<
             name,
             query: copiedCachedDoc.id,
             status: copiedCachedDoc.status,
+            metrics,
+            metricScope,
+            metricScopeId,
           };
         }
       } catch (e) {
@@ -1082,6 +1155,9 @@ export abstract class QueryRunner<
       name,
       query: doc.id,
       status: doc.status,
+      metrics,
+      metricScope,
+      metricScopeId,
     };
   }
 
@@ -1104,6 +1180,12 @@ export abstract class QueryRunner<
     return numRunningQueries >= numericConcurrencyLimit;
   }
 
+  // Default aggregate: a runner whose queries are all equally load-bearing has
+  // nothing useful to salvage once half of them failed. Runners that emit
+  // metric-owning queries (experiment results, reports, safe rollouts) override
+  // this with `getMetricAwareQueryStatus` so surviving metrics are still
+  // analyzed; `AggregatedFactTableQueryRunner` overrides it with an all-or-
+  // nothing rule.
   protected getOverallQueryStatus(): QueryStatus {
     const failedQueries = this.model.queries.filter(
       (q) => q.status === "failed",

--- a/packages/back-end/src/queryRunners/SafeRolloutResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/SafeRolloutResultsQueryRunner.ts
@@ -18,6 +18,7 @@ import { logger } from "back-end/src/util/logger";
 import { QueryRunner, QueryMap } from "./QueryRunner";
 import {
   ExperimentResultsQueryParams,
+  getExperimentResultsQueryStatus,
   startExperimentResultQueries,
   TRAFFIC_QUERY_NAME,
 } from "./ExperimentResultsQueryRunner";
@@ -45,6 +46,16 @@ export class SafeRolloutResultsQueryRunner extends QueryRunner<
   checkPermissions(): boolean {
     return this.context.permissions.canRunExperimentQueries(
       this.integration.datasource,
+    );
+  }
+
+  // Shares `startExperimentResultQueries`, so it shares its metric-aware
+  // aggregate status: analyze the metric queries that survived rather than
+  // failing everything once half the queries failed.
+  protected override getOverallQueryStatus(): QueryStatus {
+    return (
+      getExperimentResultsQueryStatus(this.model.queries) ??
+      super.getOverallQueryStatus()
     );
   }
 

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -176,7 +176,11 @@ import { ReqContext } from "back-end/types/request";
 import { logger } from "back-end/src/util/logger";
 import { LegacyMetricAnalysisQueryRunner } from "back-end/src/queryRunners/LegacyMetricAnalysisQueryRunner";
 import { ExperimentResultsQueryRunner } from "back-end/src/queryRunners/ExperimentResultsQueryRunner";
-import { QueryMap, getQueryMap } from "back-end/src/queryRunners/QueryRunner";
+import {
+  QueryMap,
+  getMetricAwareQueryStatus,
+  getQueryMap,
+} from "back-end/src/queryRunners/QueryRunner";
 import {
   buildUnitDimensionQueryMap,
   filterParentQueryMap,
@@ -2428,13 +2432,7 @@ async function getSnapshotAnalyses(
       return;
     }
 
-    const totalQueries = snapshot.queries.length;
-    const failedQueries = snapshot.queries.filter((q) => q.status === "failed");
-    const runningQueries = snapshot.queries.filter(
-      (q) => q.status === "running",
-    );
-
-    if (runningQueries.length > 0 || failedQueries.length >= totalQueries / 2) {
+    if (!snapshotQueriesAvailableForAnalysis(snapshot, [analysisSettings])) {
       logger.error(
         `Snapshot queries not available for analysis: ${snapshot.id}`,
       );
@@ -2506,6 +2504,44 @@ async function getSnapshotAnalyses(
   return analysisParamsMap;
 }
 
+function getUnitDimensionIdForAnalysis(
+  snapshot: ExperimentSnapshotInterface,
+  analysisSettingsList: ExperimentSnapshotAnalysisSettings[],
+): string | null {
+  const dimensionId = analysisSettingsList[0]?.dimensions[0];
+  return dimensionId &&
+    snapshot.settings.precomputedUnitDimensionIds?.includes(dimensionId)
+    ? dimensionId
+    : null;
+}
+
+function snapshotQueriesAvailableForAnalysis(
+  snapshot: ExperimentSnapshotInterface,
+  analysisSettingsList: ExperimentSnapshotAnalysisSettings[],
+): boolean {
+  const dimensionId = getUnitDimensionIdForAnalysis(
+    snapshot,
+    analysisSettingsList,
+  );
+  const metricStatus = dimensionId
+    ? getMetricAwareQueryStatus(snapshot.queries, "dimension", dimensionId)
+    : getMetricAwareQueryStatus(snapshot.queries);
+  if (metricStatus !== null) {
+    return metricStatus !== "running" && metricStatus !== "failed";
+  }
+
+  // Legacy snapshots have no ownership metadata. Preserve their original
+  // availability policy.
+  const failedQueries = snapshot.queries.filter((q) => q.status === "failed");
+  const runningQueries = snapshot.queries.filter(
+    (q) => q.status === "running" || q.status === "queued",
+  );
+  return (
+    runningQueries.length === 0 &&
+    failedQueries.length < snapshot.queries.length / 2
+  );
+}
+
 // Loads the query results needed to run gbstats for the given analyses. For
 // unit-dimension analyses (whose queries live under a `unitdim:<dim>:` prefix
 // on the parent snapshot), the map is filtered + renamed so gbstats sees the
@@ -2516,11 +2552,11 @@ async function getQueryMapForAnalysis(
   analysisSettingsList: ExperimentSnapshotAnalysisSettings[],
 ): Promise<QueryMap> {
   const queryMap = await getQueryMap(context, snapshot.queries);
-  const dimensionId = analysisSettingsList[0]?.dimensions[0];
-  if (
-    dimensionId &&
-    snapshot.settings.precomputedUnitDimensionIds?.includes(dimensionId)
-  ) {
+  const dimensionId = getUnitDimensionIdForAnalysis(
+    snapshot,
+    analysisSettingsList,
+  );
+  if (dimensionId) {
     const unitDimQueryMap = buildUnitDimensionQueryMap(queryMap, dimensionId);
     if (unitDimQueryMap.size === 0) {
       // The parent snapshot lists this unit dimension in its settings but
@@ -2562,11 +2598,7 @@ export async function createSnapshotAnalysis(
     throw new Error("Analysis not allowed with this snapshot");
   }
 
-  const totalQueries = snapshot.queries.length;
-  const failedQueries = snapshot.queries.filter((q) => q.status === "failed");
-  const runningQueries = snapshot.queries.filter((q) => q.status === "running");
-
-  if (runningQueries.length > 0 || failedQueries.length >= totalQueries / 2) {
+  if (!snapshotQueriesAvailableForAnalysis(snapshot, [analysisSettings])) {
     throw new Error("Snapshot queries not available for analysis");
   }
   const analysis: ExperimentSnapshotAnalysis = {
@@ -2631,10 +2663,7 @@ export async function createSnapshotAnalysesBatched(
     }
   }
 
-  const totalQueries = snapshot.queries.length;
-  const failedQueries = snapshot.queries.filter((q) => q.status === "failed");
-  const runningQueries = snapshot.queries.filter((q) => q.status === "running");
-  if (runningQueries.length > 0 || failedQueries.length >= totalQueries / 2) {
+  if (!snapshotQueriesAvailableForAnalysis(snapshot, analysisSettingsList)) {
     throw new Error("Snapshot queries not available for analysis");
   }
 
@@ -3075,6 +3104,9 @@ export function toSnapshotApiInterface(
         : null),
     },
     queryIds: snapshot.queries.map((q) => q.query),
+    // See toApiExperimentSnapshot: snapshot `status` collapses a partial run
+    // into "success", so completeness needs a field of its own.
+    queryStatus: getMetricAwareQueryStatus(snapshot.queries) ?? undefined,
     results: (analysis?.results || []).map((s) => {
       return {
         dimension: s.name,

--- a/packages/back-end/test/api/experiments.test.ts
+++ b/packages/back-end/test/api/experiments.test.ts
@@ -2379,6 +2379,87 @@ describe("experiments API", () => {
       expect(res.body).toHaveProperty("result");
     });
 
+    it("reports partially-succeeded on results whose snapshot status is success", async () => {
+      updateReqContext({
+        org,
+        permissions: {
+          canViewExperiment: () => true,
+        },
+      });
+
+      const experimentWithPhases = {
+        ...experiment,
+        phases: [
+          {
+            name: "Main",
+            dateStarted: new Date("2024-01-01"),
+            dateEnded: null,
+            reason: "",
+            seed: "test-seed",
+            coverage: 1,
+            variationWeights: [0.5, 0.5],
+            condition: "",
+            savedGroups: [],
+            prerequisites: [],
+            namespace: { enabled: false },
+          },
+        ],
+      };
+      (getExperimentById as jest.Mock).mockResolvedValue(experimentWithPhases);
+      (getLatestSuccessfulSnapshot as jest.Mock).mockResolvedValue({
+        id: "snap_123",
+        organization: "org_1",
+        experiment: "exp_123",
+        phase: 0,
+        dimension: null,
+        dateCreated: new Date(),
+        runStarted: new Date(),
+        // One metric query survived, one failed. The snapshot is stored as
+        // "success", so queryStatus is the only signal that a metric is missing.
+        queries: [
+          {
+            name: "met_ok",
+            query: "qry_1",
+            status: "succeeded",
+            metrics: ["met_ok"],
+          },
+          {
+            name: "met_bad",
+            query: "qry_2",
+            status: "failed",
+            metrics: ["met_bad"],
+          },
+        ],
+        unknownVariations: [],
+        multipleExposures: 0,
+        hasCorrectedStats: false,
+        results: [],
+        settings: {
+          manual: false,
+          activationMetric: null,
+          queryFilter: "",
+          segment: "",
+          skipPartialData: false,
+          attributionModel: "firstExposure",
+          experimentId: "exp_123",
+          statsEngine: "bayesian",
+          regressionAdjustmentEnabled: false,
+          sequentialTestingEnabled: false,
+          sequentialTestingTuningParameter: 5000,
+          pValueThreshold: 0.05,
+          pValueCorrection: null,
+          differenceType: "relative",
+        },
+      });
+
+      const res = await request(app)
+        .get("/api/v1/experiments/exp_123/results")
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      expect(res.body.result.queryStatus).toBe("partially-succeeded");
+    });
+
     it("includes metricName and variationName for each metric/variation pair", async () => {
       updateReqContext({
         org,

--- a/packages/back-end/test/api/snapshots.test.ts
+++ b/packages/back-end/test/api/snapshots.test.ts
@@ -96,6 +96,72 @@ describe("snapshots API", () => {
     });
   });
 
+  it("reports a partially successful run as partially-succeeded, even though status is success", async () => {
+    setReqContext({
+      org,
+      permissions: {
+        canReadSingleProjectResource: () => true,
+      },
+    });
+
+    // One metric query failed, one survived. The snapshot status collapses that
+    // to "success", so queryStatus is the only field that says results are
+    // incomplete.
+    const snapshot = snapshotFactory.build({
+      organization: org.id,
+      status: "success",
+      queries: [
+        {
+          name: "met_ok",
+          query: "qry_1",
+          status: "succeeded",
+          metrics: ["met_ok"],
+        },
+        {
+          name: "met_bad",
+          query: "qry_2",
+          status: "failed",
+          metrics: ["met_bad"],
+        },
+      ],
+    });
+
+    findSnapshotById.mockReturnValueOnce(snapshot);
+    getExperimentById.mockReturnValueOnce({ id: snapshot.experiment });
+
+    const response = await request(app)
+      .get("/api/v1/snapshots/snp_1")
+      .set("Authorization", "Bearer foo");
+
+    expect(response.status).toBe(200);
+    expect(response.body.snapshot.status).toBe("success");
+    expect(response.body.snapshot.queryStatus).toBe("partially-succeeded");
+  });
+
+  it("omits queryStatus for a snapshot whose queries never recorded metric ownership", async () => {
+    setReqContext({
+      org,
+      permissions: {
+        canReadSingleProjectResource: () => true,
+      },
+    });
+
+    const snapshot = snapshotFactory.build({
+      organization: org.id,
+      queries: [{ name: "met_1", query: "qry_1", status: "succeeded" }],
+    });
+
+    findSnapshotById.mockReturnValueOnce(snapshot);
+    getExperimentById.mockReturnValueOnce({ id: snapshot.experiment });
+
+    const response = await request(app)
+      .get("/api/v1/snapshots/snp_1")
+      .set("Authorization", "Bearer foo");
+
+    expect(response.status).toBe(200);
+    expect(response.body.snapshot).not.toHaveProperty("queryStatus");
+  });
+
   it("checks permission on experiment when getting a snapshot", async () => {
     setReqContext({
       org,

--- a/packages/back-end/test/queryRunners/QueryRunner.test.ts
+++ b/packages/back-end/test/queryRunners/QueryRunner.test.ts
@@ -5,10 +5,21 @@ import {
   QueryMap,
   InterfaceWithQueries,
   getQueryFailureError,
+  getMetricAwareQueryStatus,
 } from "back-end/src/queryRunners/QueryRunner";
+import { TRAFFIC_QUERY_NAME } from "back-end/src/queryRunners/ExperimentResultsQueryRunner";
+import { getUnitDimQueryName } from "back-end/src/queryRunners/unitDimensionQueryNaming";
+import {
+  getIncrementalCrossStatisticsQueryName,
+  getIncrementalStatisticsQueryName,
+} from "back-end/src/queryRunners/incrementalStatisticsQueryNaming";
 import { SourceIntegrationInterface } from "back-end/src/types/Integration";
 import {
+  countRunningQueries,
   createFailedQuery,
+  createNewQuery,
+  createNewQueryFromCached,
+  getRecentQuery,
   getQueriesByIds,
   updateQuery,
 } from "back-end/src/models/QueryModel";
@@ -148,7 +159,178 @@ describe("getQueryFailureError", () => {
 
   it("returns the generic message when no failed query has an error", () => {
     const error = getQueryFailureError(makeFailedQueryMap(["a", { id: "q1" }]));
-    expect(error).toBe("Failed to run a majority of the database queries");
+    expect(error).toBe("Failed to run the database queries for this analysis");
+  });
+});
+
+describe("getMetricAwareQueryStatus", () => {
+  const SNAPSHOT_ID = "snp_1";
+
+  const pointer = (
+    name: string,
+    status: QueryStatus,
+    metrics?: string[],
+    metricScope?: "primary" | "dimension",
+    metricScopeId?: string,
+  ): Queries[number] => ({
+    query: `qry_${name}`,
+    name,
+    status,
+    metrics,
+    metricScope,
+    metricScopeId,
+  });
+
+  it("analyzes survivors when a majority of metric queries failed", () => {
+    const status = getMetricAwareQueryStatus([
+      pointer("query_a", "failed", ["met_a"]),
+      pointer("query_b", "failed", ["met_b"]),
+      pointer("query_c", "failed", ["met_c"]),
+      pointer("query_d", "succeeded", ["met_d"]),
+    ]);
+    // The old rule (>= half failed) would have returned "failed" and skipped
+    // analysis entirely, discarding met_d's results.
+    expect(status).toBe("partially-succeeded");
+  });
+
+  it("fails only when no metric query survived", () => {
+    const status = getMetricAwareQueryStatus([
+      pointer("query_a", "failed", ["met_a"]),
+      pointer("query_b", "failed", ["met_b"]),
+    ]);
+    expect(status).toBe("failed");
+  });
+
+  it("does not fail when only the traffic query failed", () => {
+    const status = getMetricAwareQueryStatus([
+      pointer("query_a", "succeeded", ["met_a"]),
+      pointer(TRAFFIC_QUERY_NAME, "failed"),
+    ]);
+    expect(status).toBe("partially-succeeded");
+  });
+
+  it("does not fail when only the shared units table and its drop failed", () => {
+    // These own no metric results directly; dependent metric queries cascade
+    // and are counted as metric failures in their own right.
+    const status = getMetricAwareQueryStatus([
+      pointer("query_a", "succeeded", ["met_a"]),
+      pointer(SNAPSHOT_ID, "failed"),
+      pointer(`drop_${SNAPSHOT_ID}`, "failed"),
+    ]);
+    expect(status).toBe("partially-succeeded");
+  });
+
+  it("ignores unit-dimension queries, which belong to their own analyses", () => {
+    const status = getMetricAwareQueryStatus([
+      pointer("query_a", "succeeded", ["met_a"]),
+      pointer(
+        getUnitDimQueryName("dim_1", "met_a"),
+        "failed",
+        ["met_a"],
+        "dimension",
+        "dim_1",
+      ),
+    ]);
+    expect(status).toBe("partially-succeeded");
+  });
+
+  it("waits while any query is still in flight", () => {
+    const status = getMetricAwareQueryStatus([
+      pointer("query_a", "failed", ["met_a"]),
+      pointer("query_b", "running", ["met_b"]),
+    ]);
+    expect(status).toBe("running");
+  });
+
+  it("reports success when nothing failed", () => {
+    const status = getMetricAwareQueryStatus([
+      pointer("query_a", "succeeded", ["met_a"]),
+      pointer(TRAFFIC_QUERY_NAME, "succeeded"),
+    ]);
+    expect(status).toBe("succeeded");
+  });
+
+  const statsA = getIncrementalStatisticsQueryName("ft_1_ab12340");
+  const statsB = getIncrementalStatisticsQueryName("ft_2_ab12341");
+  const statsCross = getIncrementalCrossStatisticsQueryName(
+    "ft_1_ab12340",
+    "ft_2_ab12341",
+  );
+
+  it("fails when every statistics query failed, even though the pipeline queries succeeded", () => {
+    // The base 50% rule returned "partially-succeeded" here, so analysis ran
+    // with no metric data and the snapshot carried no explanation.
+    const status = getMetricAwareQueryStatus([
+      pointer("create_metrics_source_ft_1_ab12340", "succeeded"),
+      pointer("insert_metrics_source_data_ft_1_ab12340", "succeeded"),
+      pointer("max_timestamp_metrics_source_ft_1_ab12340", "succeeded"),
+      pointer(statsA, "failed", ["met_a"]),
+    ]);
+    expect(status).toBe("failed");
+  });
+
+  it("analyzes survivors when one statistics query of several failed", () => {
+    const status = getMetricAwareQueryStatus([
+      pointer(statsA, "failed", ["met_a"]),
+      pointer(statsB, "succeeded", ["met_b"]),
+      pointer(statsCross, "failed", ["met_c"]),
+    ]);
+    expect(status).toBe("partially-succeeded");
+  });
+
+  it("does not fail when only an infrastructure query failed", () => {
+    const status = getMetricAwareQueryStatus([
+      pointer(statsA, "succeeded", ["met_a"]),
+      pointer("drop_metrics_covariate_table_ft_1_ab12340", "failed"),
+    ]);
+    expect(status).toBe("partially-succeeded");
+  });
+
+  it("waits while any query is still in flight", () => {
+    const status = getMetricAwareQueryStatus([
+      pointer(statsA, "failed", ["met_a"]),
+      pointer(statsB, "running", ["met_b"]),
+    ]);
+    expect(status).toBe("running");
+  });
+
+  it("reports success when nothing failed", () => {
+    const status = getMetricAwareQueryStatus([
+      pointer(statsA, "succeeded", ["met_a"]),
+      pointer("insert_metrics_source_data_ft_1_ab12340", "succeeded"),
+    ]);
+    expect(status).toBe("succeeded");
+  });
+
+  it("returns null for legacy pointers without ownership metadata", () => {
+    expect(
+      getMetricAwareQueryStatus([pointer("legacy_metric", "succeeded")]),
+    ).toBeNull();
+  });
+
+  it("evaluates one unit-dimension scope independently", () => {
+    expect(
+      getMetricAwareQueryStatus(
+        [
+          pointer(
+            "unitdim:country:met_a",
+            "failed",
+            ["met_a"],
+            "dimension",
+            "country",
+          ),
+          pointer(
+            "unitdim:browser:met_a",
+            "succeeded",
+            ["met_a"],
+            "dimension",
+            "browser",
+          ),
+        ],
+        "dimension",
+        "country",
+      ),
+    ).toBe("failed");
   });
 });
 
@@ -174,6 +356,7 @@ describe("startQuery build-time isolation", () => {
 
     const pointer = await runner.startQuery({
       name: "met_bad",
+      metrics: ["met_bad"],
       query: () => {
         throw new Error("Unknown fact table");
       },
@@ -188,6 +371,9 @@ describe("startQuery build-time isolation", () => {
       query: "qry_failed",
       status: "failed",
       error: "Failed to build query: Unknown fact table",
+      metrics: ["met_bad"],
+      metricScope: undefined,
+      metricScopeId: undefined,
     });
     // The failure is persisted as a terminal failed Query doc, never executed.
     expect(createFailedQuery as jest.Mock).toHaveBeenCalledWith(
@@ -199,6 +385,83 @@ describe("startQuery build-time isolation", () => {
       }),
     );
     expect(runner.executeQuerySpy).not.toHaveBeenCalled();
+  });
+
+  it("preserves metric ownership on a cached query pointer", async () => {
+    const runner = new TestQueryRunner(
+      createMockContext(),
+      {
+        id: "test-model",
+        organization: "test-org",
+        queries: [],
+        runStarted: new Date(),
+      },
+      createMockIntegration(),
+    );
+    (getRecentQuery as jest.Mock).mockResolvedValue(
+      createMockQuery("qry_cached", "succeeded"),
+    );
+    (createNewQueryFromCached as jest.Mock).mockResolvedValue(
+      createMockQuery("qry_copy", "succeeded"),
+    );
+
+    const pointer = await runner.startQuery({
+      name: "unitdim:country:group_0",
+      metrics: ["met_a", "met_b"],
+      metricScope: "dimension",
+      metricScopeId: "country",
+      query: "SELECT 1",
+      dependencies: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      run: jest.fn() as any,
+      queryType: "experimentMultiMetric",
+    });
+
+    expect(pointer).toEqual({
+      name: "unitdim:country:group_0",
+      query: "qry_copy",
+      status: "succeeded",
+      metrics: ["met_a", "met_b"],
+      metricScope: "dimension",
+      metricScopeId: "country",
+    });
+  });
+
+  it("preserves metric ownership on a fresh query pointer", async () => {
+    const runner = new TestQueryRunner(
+      createMockContext(),
+      {
+        id: "test-model",
+        organization: "test-org",
+        queries: [],
+        runStarted: new Date(),
+      },
+      createMockIntegration(),
+      false,
+    );
+    (countRunningQueries as jest.Mock).mockResolvedValue(0);
+    (createNewQuery as jest.Mock).mockResolvedValue(
+      createMockQuery("qry_fresh", "running"),
+    );
+
+    const pointer = await runner.startQuery({
+      name: "statistics_group_0",
+      metrics: ["met_a"],
+      query: "SELECT 1",
+      dependencies: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      run: jest.fn() as any,
+      queryType: "experimentIncrementalRefreshStatistics",
+    });
+
+    expect(pointer).toEqual({
+      name: "statistics_group_0",
+      query: "qry_fresh",
+      status: "running",
+      metrics: ["met_a"],
+      metricScope: undefined,
+      metricScopeId: undefined,
+    });
   });
 });
 
@@ -600,6 +863,7 @@ describe("QueryRunner", () => {
       public persistedQueries: Queries = [];
       public updateModelSpy = jest.fn();
       public onQueryFinishSpy = jest.fn();
+      public runAnalysisSpy = jest.fn();
 
       checkPermissions() {
         return true;
@@ -610,6 +874,7 @@ describe("QueryRunner", () => {
       }
 
       async runAnalysis() {
+        this.runAnalysisSpy();
         return { success: true };
       }
 
@@ -706,6 +971,35 @@ describe("QueryRunner", () => {
         jest.clearAllTimers();
         jest.useRealTimers();
       }
+    });
+
+    it("analyzes cached partial results immediately", async () => {
+      const model: InterfaceWithQueries = {
+        id: "test-model",
+        organization: "test-org",
+        queries: [],
+        runStarted: new Date(),
+      };
+      const runner = new RaceTestQueryRunner(
+        mockContext,
+        model,
+        mockIntegration,
+      );
+      const pointers: Queries = [
+        { name: "a", query: "qry_a", status: "failed" },
+        { name: "b", query: "qry_b", status: "succeeded" },
+        { name: "c", query: "qry_c", status: "succeeded" },
+      ];
+
+      await runner.startAnalysis({ pointers });
+
+      expect(runner.runAnalysisSpy).toHaveBeenCalledTimes(1);
+      expect(runner.updateModelSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: "partially-succeeded",
+          result: { success: true },
+        }),
+      );
     });
 
     class FailingAnalysisQueryRunner extends RaceTestQueryRunner {

--- a/packages/back-end/test/services/experimentSnapshotAnalyses.test.ts
+++ b/packages/back-end/test/services/experimentSnapshotAnalyses.test.ts
@@ -23,6 +23,7 @@ jest.mock("back-end/src/services/stats", () => ({
 
 jest.mock("back-end/src/queryRunners/QueryRunner", () => ({
   QueryRunner: class {},
+  getMetricAwareQueryStatus: jest.fn(() => null),
   getQueryMap: jest.fn(),
 }));
 

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -863,6 +863,13 @@ export const apiExperimentWithEnhancedStatus = namedSchema(
   ),
 );
 
+const apiQueryStatusDescription =
+  "Outcome of the warehouse queries behind these results. `partially-succeeded` means at least one metric produced no results, so the metric list is incomplete.";
+
+const apiSnapshotQueryStatus = z
+  .enum(["queued", "running", "succeeded", "partially-succeeded", "failed"])
+  .describe(apiQueryStatusDescription);
+
 // Corresponds to schemas/ExperimentSnapshot.yaml
 const apiExperimentSnapshotShape = z.object({
   id: z.string(),
@@ -874,6 +881,7 @@ const apiExperimentSnapshotShape = z.object({
       "Why this snapshot failed. Present only when status is `error`. Names the underlying cause, such as the warehouse error or the reason a metric's query could not be built.",
     )
     .optional(),
+  queryStatus: apiSnapshotQueryStatus.optional(),
 });
 export const apiExperimentSnapshotValidator = namedSchema(
   "ExperimentSnapshot",
@@ -901,6 +909,7 @@ export const apiExperimentResultsValidator = namedSchema(
       }),
       settings: apiExperimentAnalysisSettingsValidator,
       queryIds: z.array(z.string()),
+      queryStatus: apiSnapshotQueryStatus.optional(),
       results: z.array(
         z.object({
           dimension: z.string(),

--- a/packages/shared/src/validators/queries.ts
+++ b/packages/shared/src/validators/queries.ts
@@ -15,6 +15,9 @@ export const queryPointerValidator = z
     query: z.string(),
     status: queryStatusValidator,
     name: z.string(),
+    metrics: z.array(z.string()).min(1).optional(),
+    metricScope: z.enum(["primary", "dimension"]).optional(),
+    metricScopeId: z.string().optional(),
     // Raw error from the underlying Query doc, copied onto the pointer so the
     // per-query error is reachable from the snapshot without a separate fetch.
     error: z.string().optional(),


### PR DESCRIPTION
### Features and Changes

One failed query used to be able to discard every metric that computed fine. The base aggregate rule fails a runner once half its queries have failed, and it counts every query equally, so a hiccup on the traffic query or on one fact-metric group could throw away the rest of the results.

- Queries now declare the `metrics` (plus `metricScope`/`metricScopeId`) they own, persisted on the pointer. Ownership is the protocol; query names stay labels.
- `getMetricAwareQueryStatus` replaces the half-failed rule across every result-producing runner. It reports `failed` only when no metric-owning query survived, the total-wipeout case. Anything less is `partially-succeeded`, which runs the analysis and renders the metrics that made it. A query that owns no metric, like the traffic query, can no longer force `failed` on its own.
- `startAnalysis` and the three on-demand entry points in `services/experiments.ts` now run the analysis for a `partially-succeeded` run too, instead of dropping the surviving results. Snapshots with no ownership metadata keep the old policy, so stored snapshots behave exactly as before.
- Public API: `ExperimentResults` and `ExperimentSnapshot` gain an optional `queryStatus`, derived from the same rule, so a caller can tell complete results from incomplete ones. It is absent for snapshots stored before queries recorded the metrics they own.

**Note:** `ExperimentIncrementalRefreshQueryRunner.updateModel` maps `partially-succeeded` to snapshot status `success` and records `materializedBySnapshotId`, so a mostly-failed incremental run now claims its pipeline tables were materialized. This widens an existing soft spot (the adjacent `TODO`) rather than fixing it.

### Testing

- `pnpm type-check`
- `getMetricAwareQueryStatus` and the cached partial-success test in `QueryRunner.test.ts`
- `test/api/snapshots.test.ts` and `test/api/experiments.test.ts` for the new field and its absence on a legacy snapshot
