### PR TITLE
fix(stats): contain a gbstats failure to its own analysis slot

### DIFF
--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -229,11 +229,13 @@ export async function runSnapshotAnalysis(
     throw new Error("Error in stats engine: no rows returned");
   }
   if (analysis.error) {
-    let errorMsg = "Failed to run stats model:\n" + analysis.error;
+    const errorMsg = "Failed to run stats model:\n" + analysis.error;
     logger.error(analysis.error, errorMsg);
     if (analysis.traceback) {
-      logger.error("Traceback:\n" + analysis.traceback);
-      errorMsg += "\n\n" + analysis.traceback;
+      logger.error(
+        { experimentId: params.id, traceback: analysis.traceback },
+        "Stats engine analysis failed",
+      );
     }
     throw new Error("Error in stats engine: " + errorMsg);
   }
@@ -503,18 +505,24 @@ function parseStatsEngineResult({
   analysisSettings.forEach((_, i) => {
     const dimensionMap: Map<string, ExperimentReportResultDimension> =
       new Map();
-    result.forEach(({ metric, analyses }) => {
+    // A failed analysis cell contributes no rows here. Its structured error is
+    // collected separately into the corresponding snapshot analysis.
+    result.forEach(({ metric, analyses, error }) => {
+      const analysis = analyses[i];
+      const analysisError = analysis?.error ?? error;
+      if (analysisError) {
+        return;
+      }
       // each result can have multiple analyses (a set of computations that
       // use the same snapshot)
       // we loop over the analyses requested and pull out the results for each one
-      const result = analyses[i];
-      if (!result) return;
+      if (!analysis) return;
 
       unknownVariationsCopy = unknownVariationsCopy.concat(
-        result.unknownVariations,
+        analysis.unknownVariations,
       );
 
-      result.dimensions.forEach((row) => {
+      analysis.dimensions.forEach((row) => {
         const dim = dimensionMap.get(row.dimension) || {
           name: row.dimension,
           srm: 1,
@@ -616,6 +624,16 @@ export async function writeSnapshotAnalyses(
     const { analysisObj, unknownVariations } = params.data;
 
     if (result.error) {
+      if (result.traceback) {
+        logger.error(
+          {
+            experimentId: snapshotSettings.experimentId,
+            snapshotId: snapshot,
+            traceback: result.traceback,
+          },
+          "Stats engine analysis failed",
+        );
+      }
       analysisObj.results = [];
       analysisObj.status = "error";
       analysisObj.error = result.error;

--- a/packages/shared/types/stats.d.ts
+++ b/packages/shared/types/stats.d.ts
@@ -166,7 +166,13 @@ export type ExperimentMetricAnalysis = {
     unknownVariations: string[];
     multipleExposures: number;
     dimensions: StatsEngineDimensionResponse[];
+    error?: string;
+    traceback?: string;
   }[];
+  // Legacy whole-metric failure fields. New stats engines return one result
+  // slot per requested analysis and put failures on the corresponding slot.
+  error?: string;
+  traceback?: string;
 }[];
 
 export type SingleVariationResult = {

--- a/packages/stats/gbstats/gbstats.py
+++ b/packages/stats/gbstats/gbstats.py
@@ -1154,7 +1154,7 @@ def process_single_metric(
     all_var_ids: Set[str] = set([v for a in analyses for v in a.var_ids])
     unknown_var_ids = detect_unknown_variations(rows=pdrows, var_ids=all_var_ids)
 
-    results: List[List[DimensionResponse]] = []
+    results: List[ExperimentMetricAnalysisResult] = []
     for a in analyses:
         # skip pre-computed dimension reaggregation for quantile metrics
         attempted_quantile_dimension_reaggregation = a.dimension.startswith(
@@ -1169,25 +1169,41 @@ def process_single_metric(
             attempted_quantile_dimension_reaggregation
             or attempted_quantile_overall_reaggregation
         ):
+            results.append(
+                ExperimentMetricAnalysisResult(
+                    unknownVariations=list(unknown_var_ids),
+                    dimensions=[],
+                    multipleExposures=0,
+                )
+            )
             continue
-        results.append(
-            process_analysis(
+        try:
+            dimensions = process_analysis(
                 rows=pdrows,
                 var_id_map=get_var_id_map(a.var_ids),
                 metric=metric,
                 analysis=a,
             )
-        )
+            results.append(
+                ExperimentMetricAnalysisResult(
+                    unknownVariations=list(unknown_var_ids),
+                    dimensions=dimensions,
+                    multipleExposures=0,
+                )
+            )
+        except Exception as e:
+            results.append(
+                ExperimentMetricAnalysisResult(
+                    unknownVariations=list(unknown_var_ids),
+                    dimensions=[],
+                    multipleExposures=0,
+                    error=str(e),
+                    traceback=traceback.format_exc(),
+                )
+            )
     return ExperimentMetricAnalysis(
         metric=metric.id,
-        analyses=[
-            ExperimentMetricAnalysisResult(
-                unknownVariations=list(unknown_var_ids),
-                dimensions=r,
-                multipleExposures=0,
-            )
-            for r in results
-        ],
+        analyses=results,
     )
 
 
@@ -1378,24 +1394,27 @@ def process_experiment_results(
     bandit_result: Optional[BanditResult] = None
     for query_result in d.query_results:
         for i, metric in enumerate(query_result.metrics):
-            if metric in d.metrics:
+            if metric not in d.metrics:
+                continue
+            try:
                 this_metric = d.metrics[metric]
                 rows = filter_query_rows(query_result.rows, i)
-                if len(rows):
-                    if d.bandit_settings:
-                        metric_settings_bandit = copy.deepcopy(this_metric)
-                        # when using multi-period data, binomial is no longer iid and variance is wrong
-                        if metric_settings_bandit.main_metric_type == "binomial":
-                            metric_settings_bandit.main_metric_type = "count"
-                        if metric_settings_bandit.covariate_metric_type == "binomial":
-                            metric_settings_bandit.covariate_metric_type = "count"
-                        # TODO: after we have added the functionality for ratio_ra, remove this
-                        if metric_settings_bandit.statistic_type == "ratio_ra":
-                            metric_settings_bandit.statistic_type = "ratio"
-                        if (
-                            metric == d.bandit_settings.decision_metric
-                            and not d.analyses[0].dimension
-                        ):
+                metric_for_analysis = this_metric
+                if d.bandit_settings and len(rows):
+                    metric_settings_bandit = copy.deepcopy(this_metric)
+                    # when using multi-period data, binomial is no longer iid and variance is wrong
+                    if metric_settings_bandit.main_metric_type == "binomial":
+                        metric_settings_bandit.main_metric_type = "count"
+                    if metric_settings_bandit.covariate_metric_type == "binomial":
+                        metric_settings_bandit.covariate_metric_type = "count"
+                    # TODO: after we have added the functionality for ratio_ra, remove this
+                    if metric_settings_bandit.statistic_type == "ratio_ra":
+                        metric_settings_bandit.statistic_type = "ratio"
+                    if (
+                        metric == d.bandit_settings.decision_metric
+                        and not d.analyses[0].dimension
+                    ):
+                        try:
                             if bandit_result is not None:
                                 raise ValueError("Bandit weights already computed")
                             bandit_result = get_bandit_result(
@@ -1404,21 +1423,39 @@ def process_experiment_results(
                                 settings=d.analyses[0],
                                 bandit_settings=d.bandit_settings,
                             )
-                        results.append(
-                            process_single_metric(
-                                rows=rows,
-                                metric=metric_settings_bandit,
-                                analyses=d.analyses,
+                        except Exception as e:
+                            bandit_result = get_error_bandit_result(
+                                single_variation_results=None,
+                                update_message="not updated",
+                                error=str(e),
+                                reweight=d.bandit_settings.reweight,
+                                current_weights=d.bandit_settings.current_weights,
                             )
+                    metric_for_analysis = metric_settings_bandit
+                metric_result = process_single_metric(
+                    rows=rows,
+                    metric=metric_for_analysis,
+                    analyses=d.analyses,
+                )
+            except Exception as e:
+                # Failures outside an individual analysis cell still belong to
+                # this metric. Preserve one error slot for every requested
+                # analysis and continue with the remaining metrics.
+                error_traceback = traceback.format_exc()
+                metric_result = ExperimentMetricAnalysis(
+                    metric=metric,
+                    analyses=[
+                        ExperimentMetricAnalysisResult(
+                            unknownVariations=[],
+                            dimensions=[],
+                            multipleExposures=0,
+                            error=str(e),
+                            traceback=error_traceback,
                         )
-                    else:
-                        results.append(
-                            process_single_metric(
-                                rows=rows,
-                                metric=this_metric,
-                                analyses=d.analyses,
-                            )
-                        )
+                        for _ in d.analyses
+                    ],
+                )
+            results.append(metric_result)
 
     if d.bandit_settings and bandit_result is None:
         bandit_result = get_error_bandit_result(

--- a/packages/stats/gbstats/models/results.py
+++ b/packages/stats/gbstats/models/results.py
@@ -199,12 +199,16 @@ class ExperimentMetricAnalysisResult:
     unknownVariations: List[str]
     multipleExposures: float
     dimensions: List[DimensionResponse]
+    error: Optional[str] = None
+    traceback: Optional[str] = None
 
 
 @dataclass
 class ExperimentMetricAnalysis:
     metric: str
     analyses: List[ExperimentMetricAnalysisResult]
+    error: Optional[str] = None
+    traceback: Optional[str] = None
 
 
 @dataclass

--- a/packages/stats/tests/test_gbstats.py
+++ b/packages/stats/tests/test_gbstats.py
@@ -1,6 +1,8 @@
 import dataclasses
 from functools import partial
+from types import SimpleNamespace
 from unittest import TestCase, main as unittest_main
+from unittest.mock import patch
 import numpy as np
 import pandas as pd
 import copy
@@ -15,9 +17,11 @@ from gbstats.gbstats import (
     get_metric_dfs,
     variation_statistic_from_metric_row,
     process_analysis,
+    process_experiment_results,
     get_bandit_result,
     create_bandit_statistics,
     preprocess_bandits,
+    process_single_metric,
 )
 from gbstats.bayesian.bandits import BanditsSimple
 
@@ -32,6 +36,8 @@ from gbstats.models.results import (
     FrequentistVariationResponseIndividual,
     MetricStats,
     FrequentistVariationResponse,
+    ExperimentMetricAnalysis,
+    ExperimentMetricAnalysisResult,
 )
 
 DECIMALS = 9
@@ -1507,6 +1513,168 @@ class TestThreeArmedCuped(TestCase):
             round_(baseline_stats_three_armed.stddev),
             round_(baseline_stats_02.stddev),
             "Baseline stddev should be the same, implying theta from 0 vs 2 comparison is used",
+        )
+
+
+class TestProcessExperimentResultsErrorIsolation(TestCase):
+    def test_bandit_error_does_not_discard_metric_analysis(self):
+        analysis = copy.deepcopy(DEFAULT_ANALYSIS)
+        analysis.dimension = ""
+        bandit_settings = copy.deepcopy(BANDIT_ANALYSIS)
+        bandit_settings.decision_metric = COUNT_METRIC.id
+        d = SimpleNamespace(
+            metrics={COUNT_METRIC.id: COUNT_METRIC},
+            analyses=[analysis],
+            query_results=[
+                SimpleNamespace(
+                    metrics=[COUNT_METRIC.id],
+                    rows=[{"m0_main_sum": 1}],
+                )
+            ],
+            bandit_settings=bandit_settings,
+        )
+        metric_result = ExperimentMetricAnalysis(
+            metric=COUNT_METRIC.id,
+            analyses=[
+                ExperimentMetricAnalysisResult(
+                    unknownVariations=[],
+                    multipleExposures=0,
+                    dimensions=[],
+                )
+            ],
+        )
+
+        with patch("gbstats.gbstats.process_data_dict", return_value=d), patch(
+            "gbstats.gbstats.get_bandit_result",
+            side_effect=ValueError("simulated bandit failure"),
+        ), patch(
+            "gbstats.gbstats.process_single_metric",
+            return_value=metric_result,
+        ):
+            results, bandit_result = process_experiment_results({})
+
+        self.assertEqual(results, [metric_result])
+        self.assertIsNotNone(bandit_result)
+        self.assertEqual(
+            bandit_result.error if bandit_result else None,
+            "simulated bandit failure",
+        )
+
+    def test_per_analysis_error_is_isolated(self):
+        good_analysis = copy.deepcopy(DEFAULT_ANALYSIS)
+        good_analysis.dimension = "good"
+        bad_analysis = copy.deepcopy(DEFAULT_ANALYSIS)
+        bad_analysis.dimension = "bad"
+
+        def fake_process_analysis(rows, var_id_map, metric, analysis):
+            if analysis.dimension == "bad":
+                raise ValueError("simulated analysis failure")
+            return []
+
+        with patch(
+            "gbstats.gbstats.detect_unknown_variations", return_value=set()
+        ), patch(
+            "gbstats.gbstats.process_analysis",
+            side_effect=fake_process_analysis,
+        ):
+            result = process_single_metric(
+                rows=[{"variation": "0"}],
+                metric=COUNT_METRIC,
+                analyses=[good_analysis, bad_analysis],
+            )
+
+        self.assertEqual(len(result.analyses), 2)
+        self.assertIsNone(result.analyses[0].error)
+        self.assertEqual(result.analyses[0].dimensions, [])
+        self.assertEqual(
+            result.analyses[1].error,
+            "simulated analysis failure",
+        )
+        self.assertIn("ValueError", result.analyses[1].traceback or "")
+
+    def test_skipped_quantile_analysis_preserves_result_index(self):
+        metric = copy.deepcopy(COUNT_METRIC)
+        metric.statistic_type = "quantile_event"
+        skipped_analysis = copy.deepcopy(DEFAULT_ANALYSIS)
+        skipped_analysis.dimension = "precomputed:country"
+        included_analysis = copy.deepcopy(DEFAULT_ANALYSIS)
+        included_analysis.dimension = "country"
+
+        with patch(
+            "gbstats.gbstats.detect_unknown_variations", return_value=set()
+        ), patch("gbstats.gbstats.process_analysis", return_value=[]):
+            result = process_single_metric(
+                rows=[{"variation": "0"}],
+                metric=metric,
+                analyses=[skipped_analysis, included_analysis],
+            )
+
+        self.assertEqual(len(result.analyses), 2)
+        self.assertEqual(result.analyses[0].dimensions, [])
+        self.assertIsNone(result.analyses[0].error)
+        self.assertEqual(result.analyses[1].dimensions, [])
+
+    def test_outer_metric_error_creates_one_error_slot_per_analysis(self):
+        # Two metrics share one combined query; one raises during analysis while
+        # the other analyzes normally. The raising metric should get its own
+        # ExperimentMetricAnalysis carrying an error slot for every requested
+        # analysis, and the surviving metric should still return normally.
+        good_metric = copy.deepcopy(COUNT_METRIC)
+        good_metric.id = "good_metric"
+        bad_metric = copy.deepcopy(COUNT_METRIC)
+        bad_metric.id = "bad_metric"
+
+        d = SimpleNamespace(
+            metrics={"good_metric": good_metric, "bad_metric": bad_metric},
+            analyses=[copy.deepcopy(DEFAULT_ANALYSIS), copy.deepcopy(DEFAULT_ANALYSIS)],
+            query_results=[
+                SimpleNamespace(
+                    metrics=["good_metric", "bad_metric"],
+                    rows=[{"m0_main_sum": 1, "m1_main_sum": 1}],
+                )
+            ],
+            bandit_settings=None,
+        )
+
+        def fake_process_single_metric(rows, metric, analyses):
+            if metric.id == "bad_metric":
+                raise ValueError("simulated analysis failure")
+            return ExperimentMetricAnalysis(
+                metric=metric.id,
+                analyses=[
+                    ExperimentMetricAnalysisResult(
+                        unknownVariations=[],
+                        multipleExposures=0,
+                        dimensions=[],
+                    )
+                ],
+            )
+
+        with patch("gbstats.gbstats.process_data_dict", return_value=d), patch(
+            "gbstats.gbstats.process_single_metric",
+            side_effect=fake_process_single_metric,
+        ):
+            results, bandit_result = process_experiment_results({})
+
+        self.assertIsNone(bandit_result)
+        by_metric = {r.metric: r for r in results}
+        self.assertEqual(set(by_metric.keys()), {"good_metric", "bad_metric"})
+
+        good = by_metric["good_metric"]
+        self.assertIsNone(good.error)
+        self.assertIsNone(good.traceback)
+        self.assertEqual(len(good.analyses), 1)
+
+        bad = by_metric["bad_metric"]
+        self.assertEqual(len(bad.analyses), 2)
+        self.assertTrue(
+            all(
+                analysis.error == "simulated analysis failure"
+                for analysis in bad.analyses
+            )
+        )
+        self.assertTrue(
+            all("ValueError" in (analysis.traceback or "") for analysis in bad.analyses)
         )
 
 


### PR DESCRIPTION
### Features and Changes

One raised exception inside the stats engine failed the whole call. Every metric in the batch was lost, including the ones whose math was fine, and the snapshot failed with them. A single degenerate metric, or one bad analysis variant, was enough.

- `process_experiment_results` runs each metric under its own guard, and `process_single_metric` returns exactly one result slot per requested analysis, so a failure lands on its own slot and its siblings are unaffected. A Bandit failure produces a Bandit error result and does not touch the metric slots.
- `ExperimentMetricAnalysis` carries `error` and `traceback` per slot, and `parseStatsEngineResult` skips a slot that reports an error instead of folding its absent rows into the dimension map.
- Tracebacks are logged with the experiment and snapshot id and never persisted. They used to be appended to the user-visible error string.

Python and TypeScript land together because `process_single_metric` previously appended no slot when it skipped a quantile reaggregation, which left `analyses` short and shifted every later slot. Callers index that array positionally.

### Testing

- `pnpm --filter stats test`
- `pnpm type-check`
