### PR TITLE
feat(experiments): show why each metric failed on its row

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -51650,6 +51650,39 @@ components:
             - succeeded
             - partially-succeeded
             - failed
+        metricErrors:
+          description: >-
+            Metrics that produced no results, and why each one failed. A metric
+            listed here is absent from `results`.
+          type: array
+          items:
+            type: object
+            properties:
+              metricId:
+                type: string
+              metricName:
+                type: string
+              type:
+                description: >-
+                  Which stage failed. `query` the metric's warehouse query
+                  failed, `build` its query could not be generated, `analysis`
+                  its statistics failed, `dependency` an upstream query it
+                  needed failed, `config-drift` the metric changed or was
+                  deleted after the query started.
+                type: string
+                enum:
+                  - query
+                  - build
+                  - analysis
+                  - dependency
+                  - config-drift
+              message:
+                type: string
+            required:
+              - metricId
+              - type
+              - message
+            additionalProperties: false
         results:
           type: array
           items:

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
@@ -41,6 +41,7 @@ import {
   RowsType,
   StartQueryParams,
   getMetricAwareQueryStatus,
+  getMetricQueryOwnership,
 } from "./QueryRunner";
 import { SnapshotResult } from "./ExperimentResultsQueryRunner";
 import {
@@ -438,14 +439,18 @@ export class ExperimentIncrementalRefreshExploratoryQueryRunner extends QueryRun
 
   // largely copied from ExperimentResultsQueryRunner
   async runAnalysis(queryMap: QueryMap): Promise<SnapshotResult> {
-    const { results: analysesResults, banditResult } =
-      await analyzeExperimentResults({
-        queryData: queryMap,
-        snapshotSettings: this.model.settings,
-        analysisSettings: this.model.analyses.map((a) => a.settings),
-        variationNames: this.variationNames,
-        metricMap: this.metricMap,
-      });
+    const {
+      results: analysesResults,
+      banditResult,
+      metricErrors,
+    } = await analyzeExperimentResults({
+      queryData: queryMap,
+      snapshotSettings: this.model.settings,
+      analysisSettings: this.model.analyses.map((a) => a.settings),
+      variationNames: this.variationNames,
+      metricMap: this.metricMap,
+      factMetricGroups: getMetricQueryOwnership(this.model.queries),
+    });
 
     const result: SnapshotResult = {
       analyses: this.model.analyses,
@@ -461,6 +466,7 @@ export class ExperimentIncrementalRefreshExploratoryQueryRunner extends QueryRun
       analysis.results = results.dimensions || [];
       analysis.status = "success";
       analysis.error = "";
+      analysis.metricErrors = metricErrors[i];
 
       // TODO: do this once, not per analysis
       result.unknownVariations = results.unknownVariations || [];

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -73,6 +73,7 @@ import {
   RowsType,
   StartQueryParams,
   getMetricAwareQueryStatus,
+  getMetricQueryOwnership,
 } from "./QueryRunner";
 import { shouldRunHealthTrafficQuery } from "./snapshotQueryHelpers";
 import {
@@ -1279,14 +1280,25 @@ export class ExperimentIncrementalRefreshQueryRunner extends QueryRunner<
 
   // largely copied from ExperimentResultsQueryRunner
   async runAnalysis(queryMap: QueryMap): Promise<SnapshotResult> {
-    const { results: analysesResults, banditResult } =
-      await analyzeExperimentResults({
-        queryData: queryMap,
-        snapshotSettings: this.model.settings,
-        analysisSettings: this.model.analyses.map((a) => a.settings),
-        variationNames: this.variationNames,
-        metricMap: this.metricMap,
-      });
+    // As in ExperimentResultsQueryRunner, the metric-analysis step is
+    // deliberately NOT isolated: a throw here means there are no metric results
+    // to persist, so it stays fatal to the snapshot. The health steps below are
+    // isolated so they cannot discard results that did compute.
+    const {
+      results: analysesResults,
+      banditResult,
+      metricErrors,
+    } = await analyzeExperimentResults({
+      queryData: queryMap,
+      snapshotSettings: this.model.settings,
+      analysisSettings: this.model.analyses.map((a) => a.settings),
+      variationNames: this.variationNames,
+      metricMap: this.metricMap,
+      // Attribute a failed statistics query to the metrics it computed.
+      // getMetricsAndQueryDataForStatsEngine already routes these queries
+      // through its group branch (by queryType), so it only needs the map.
+      factMetricGroups: getMetricQueryOwnership(this.model.queries),
+    });
 
     const result: SnapshotResult = {
       analyses: this.model.analyses,
@@ -1302,6 +1314,9 @@ export class ExperimentIncrementalRefreshQueryRunner extends QueryRunner<
       analysis.results = results.dimensions || [];
       analysis.status = "success";
       analysis.error = "";
+      // Structured per-metric errors for metrics that failed before producing
+      // any result (a failed statistics query). Surviving metrics still render.
+      analysis.metricErrors = metricErrors[i];
 
       // TODO: do this once, not per analysis
       result.unknownVariations = results.unknownVariations || [];

--- a/packages/back-end/src/queryRunners/ExperimentReportQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentReportQueryRunner.ts
@@ -19,7 +19,7 @@ import {
   getExperimentResultsQueryStatus,
   startExperimentResultQueries,
 } from "./ExperimentResultsQueryRunner";
-import { QueryRunner, QueryMap } from "./QueryRunner";
+import { QueryRunner, QueryMap, getMetricQueryOwnership } from "./QueryRunner";
 
 export type SnapshotResult = {
   unknownVariations: string[];
@@ -101,14 +101,18 @@ export class ExperimentReportQueryRunner extends QueryRunner<
         );
 
       // todo: bandits? (probably not needed)
-      const { results } = await analyzeExperimentResults({
+      const { results, metricErrors } = await analyzeExperimentResults({
         variationNames: this.model.args.variations.map((v) => v.name),
         queryData: queryMap,
         metricMap: this.metricMap,
         snapshotSettings,
         analysisSettings: [analysisSettings],
+        factMetricGroups: getMetricQueryOwnership(this.model.queries),
       });
-      return results[0];
+      return {
+        ...results[0],
+        metricErrors: metricErrors[0],
+      };
     }
 
     throw new Error("Unsupported report type");

--- a/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
@@ -67,6 +67,7 @@ import {
   RowsType,
   StartQueryParams,
   getMetricAwareQueryStatus,
+  getMetricQueryOwnership,
 } from "./QueryRunner";
 import { shouldRunHealthTrafficQuery } from "./snapshotQueryHelpers";
 import { getUnitDimQueryName } from "./unitDimensionQueryNaming";
@@ -594,14 +595,24 @@ export class ExperimentResultsQueryRunner extends QueryRunner<
   }
 
   async runAnalysis(queryMap: QueryMap): Promise<SnapshotResult> {
-    const { results: analysesResults, banditResult } =
-      await analyzeExperimentResults({
-        queryData: queryMap,
-        snapshotSettings: this.model.settings,
-        analysisSettings: this.model.analyses.map((a) => a.settings),
-        variationNames: this.variationNames,
-        metricMap: this.metricMap,
-      });
+    // The metric-analysis step is deliberately NOT isolated: it is a single
+    // gbstats call covering every analysis, so a throw here means there are no
+    // metric results at all to persist (per-metric failures inside it are
+    // already isolated — see parseStatsEngineResult). It stays fatal so the
+    // snapshot reports an error rather than looking like a successful update
+    // with an empty results table.
+    const {
+      results: analysesResults,
+      banditResult,
+      metricErrors,
+    } = await analyzeExperimentResults({
+      queryData: queryMap,
+      snapshotSettings: this.model.settings,
+      analysisSettings: this.model.analyses.map((a) => a.settings),
+      variationNames: this.variationNames,
+      metricMap: this.metricMap,
+      factMetricGroups: getMetricQueryOwnership(this.model.queries),
+    });
 
     const result: SnapshotResult = {
       analyses: this.model.analyses,
@@ -617,6 +628,9 @@ export class ExperimentResultsQueryRunner extends QueryRunner<
       analysis.results = results.dimensions || [];
       analysis.status = "success";
       analysis.error = "";
+      // Structured per-metric errors for metrics that failed before producing
+      // any result (query/dependency failures). Surviving metrics still render.
+      analysis.metricErrors = metricErrors[i];
 
       // TODO: do this once, not per analysis
       result.unknownVariations = results.unknownVariations || [];

--- a/packages/back-end/src/queryRunners/SafeRolloutResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/SafeRolloutResultsQueryRunner.ts
@@ -15,7 +15,7 @@ import {
   analyzeExperimentTraffic,
 } from "back-end/src/services/stats";
 import { logger } from "back-end/src/util/logger";
-import { QueryRunner, QueryMap } from "./QueryRunner";
+import { QueryRunner, QueryMap, getMetricQueryOwnership } from "./QueryRunner";
 import {
   ExperimentResultsQueryParams,
   getExperimentResultsQueryStatus,
@@ -88,13 +88,19 @@ export class SafeRolloutResultsQueryRunner extends QueryRunner<
     const { snapshotSettings, analysisSettings } =
       getSnapshotSettingsFromSafeRolloutArgs(this.model);
 
-    const { results: analysesResults } = await analyzeExperimentResults({
-      queryData: queryMap,
-      snapshotSettings: snapshotSettings,
-      analysisSettings: [analysisSettings],
-      variationNames: ["control", "variation"],
-      metricMap: this.metricMap,
-    });
+    // As in ExperimentResultsQueryRunner, the metric-analysis step is
+    // deliberately NOT isolated: a throw here means there are no metric results
+    // to persist, so it stays fatal to the snapshot. The traffic step below is
+    // isolated so it cannot discard results that did compute.
+    const { results: analysesResults, metricErrors } =
+      await analyzeExperimentResults({
+        queryData: queryMap,
+        snapshotSettings: snapshotSettings,
+        analysisSettings: [analysisSettings],
+        variationNames: ["control", "variation"],
+        metricMap: this.metricMap,
+        factMetricGroups: getMetricQueryOwnership(this.model.queries),
+      });
 
     const result: SafeRolloutSnapshotResult = {
       analyses: this.model.analyses,
@@ -109,6 +115,7 @@ export class SafeRolloutResultsQueryRunner extends QueryRunner<
       analysis.results = results.dimensions || [];
       analysis.status = "success";
       analysis.error = "";
+      analysis.metricErrors = metricErrors[i];
 
       // TODO: do this once, not per analysis
       result.unknownVariations = results.unknownVariations || [];

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -179,11 +179,13 @@ import { ExperimentResultsQueryRunner } from "back-end/src/queryRunners/Experime
 import {
   QueryMap,
   getMetricAwareQueryStatus,
+  getMetricQueryOwnership,
   getQueryMap,
 } from "back-end/src/queryRunners/QueryRunner";
 import {
   buildUnitDimensionQueryMap,
   filterParentQueryMap,
+  parseUnitDimQueryName,
 } from "back-end/src/queryRunners/unitDimensionQueryNaming";
 import {
   FactTableMap,
@@ -2455,10 +2457,17 @@ async function getSnapshotAnalyses(
       }),
     );
 
+    const dimensionId = getUnitDimensionIdForAnalysis(snapshot, [
+      analysisSettings,
+    ]);
+    const analysisQueryMap = dimensionId
+      ? buildUnitDimensionQueryMap(queryMap, dimensionId)
+      : filterParentQueryMap(queryMap);
     const mdat = getMetricsAndQueryDataForStatsEngine(
-      queryMap,
+      analysisQueryMap,
       expandedMetricMap,
       snapshot.settings,
+      getMetricOwnershipForAnalysis(snapshot, [analysisSettings]),
     );
     const id = `${i}_${experiment.id}_${snapshot.id}`;
     const variationNames = getLatestPhaseVariations(experiment).map(
@@ -2492,6 +2501,7 @@ async function getSnapshotAnalyses(
       data: {
         unknownVariations: unknownVariations,
         analysisObj: analysis,
+        metricErrors: mdat.metricErrors,
       },
     });
   });
@@ -2513,6 +2523,30 @@ function getUnitDimensionIdForAnalysis(
     snapshot.settings.precomputedUnitDimensionIds?.includes(dimensionId)
     ? dimensionId
     : null;
+}
+
+function getMetricOwnershipForAnalysis(
+  snapshot: ExperimentSnapshotInterface,
+  analysisSettingsList: ExperimentSnapshotAnalysisSettings[],
+): Record<string, string[]> {
+  const dimensionId = getUnitDimensionIdForAnalysis(
+    snapshot,
+    analysisSettingsList,
+  );
+  if (!dimensionId) {
+    return getMetricQueryOwnership(snapshot.queries);
+  }
+
+  return Object.fromEntries(
+    Object.entries(
+      getMetricQueryOwnership(snapshot.queries, "dimension", dimensionId),
+    ).flatMap(([name, metricIds]) => {
+      const parsed = parseUnitDimQueryName(name);
+      return parsed?.dimensionId === dimensionId
+        ? [[parsed.baseQueryName, metricIds]]
+        : [];
+    }),
+  );
 }
 
 function snapshotQueriesAvailableForAnalysis(
@@ -2621,16 +2655,20 @@ export async function createSnapshotAnalysis(
   ]);
 
   // Run the analysis
-  const { results } = await analyzeExperimentResults({
+  const { results, metricErrors } = await analyzeExperimentResults({
     queryData: queryMap,
     snapshotSettings: snapshot.settings,
     analysisSettings: [analysisSettings],
     variationNames: getLatestPhaseVariations(experiment).map((v) => v.name),
     metricMap: metricMap,
+    factMetricGroups: getMetricOwnershipForAnalysis(snapshot, [
+      analysisSettings,
+    ]),
   });
   analysis.results = results[0]?.dimensions || [];
   analysis.status = "success";
   analysis.error = undefined;
+  analysis.metricErrors = metricErrors[0];
 
   await updateSnapshotAnalysis({
     context,
@@ -2687,12 +2725,16 @@ export async function createSnapshotAnalysesBatched(
   // metric settings, so we can use a single python process
   let completedAnalyses: ExperimentSnapshotAnalysis[];
   try {
-    const { results } = await analyzeExperimentResults({
+    const { results, metricErrors } = await analyzeExperimentResults({
       queryData: queryMap,
       snapshotSettings: snapshot.settings,
       analysisSettings: analysisSettingsList,
       variationNames: getLatestPhaseVariations(experiment).map((v) => v.name),
       metricMap,
+      factMetricGroups: getMetricOwnershipForAnalysis(
+        snapshot,
+        analysisSettingsList,
+      ),
     });
 
     completedAnalyses = analyses.map((analysis, i) => ({
@@ -2700,6 +2742,7 @@ export async function createSnapshotAnalysesBatched(
       results: results[i]?.dimensions ?? [],
       status: "success" as const,
       error: undefined,
+      metricErrors: metricErrors[i],
     }));
   } catch (e) {
     const error = e instanceof Error ? e.message : String(e);
@@ -3038,12 +3081,20 @@ export function toSnapshotApiInterface(
     });
   });
 
-  // Resolve display names for every metric that appears in the results, using
-  // the canonical "Parent (col: val, ...)" format for slice metrics so the
-  // payload is self-describing.
+  // Metrics that produced no results at all. Deliberately kept out of
+  // `metricIds`, which drives the `results[].metrics[]` array: a metric with no
+  // data does not belong there as a row of zeros.
+  const metricErrorEntries = Object.entries(analysis?.metricErrors ?? {});
+
+  // Resolve display names for every metric that appears in the results or
+  // failed, using the canonical "Parent (col: val, ...)" format for slice
+  // metrics so the payload is self-describing.
   const baseMetricIds = Array.from(
     new Set(
-      Array.from(metricIds).map((id) => parseSliceMetricId(id).baseMetricId),
+      [
+        ...Array.from(metricIds),
+        ...metricErrorEntries.map(([metricId]) => metricId),
+      ].map((id) => parseSliceMetricId(id).baseMetricId),
     ),
   );
   const baseMetricsById = new Map(
@@ -3107,6 +3158,14 @@ export function toSnapshotApiInterface(
     // See toApiExperimentSnapshot: snapshot `status` collapses a partial run
     // into "success", so completeness needs a field of its own.
     queryStatus: getMetricAwareQueryStatus(snapshot.queries) ?? undefined,
+    metricErrors: metricErrorEntries.length
+      ? metricErrorEntries.map(([metricId, { type, message }]) => ({
+          metricId,
+          metricName: getMetricName(metricId),
+          type,
+          message,
+        }))
+      : undefined,
     results: (analysis?.results || []).map((s) => {
       return {
         dimension: s.name,

--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -48,6 +48,7 @@ import {
   ExperimentSnapshotSettings,
   ExperimentSnapshotTraffic,
   ExperimentSnapshotTrafficDimension,
+  MetricError,
   SnapshotBanditSettings,
   SnapshotSettingsVariation,
 } from "shared/types/experiment-snapshot";
@@ -55,7 +56,11 @@ import { BanditResult } from "shared/types/experiment";
 import { checkSrm, chi2pvalue } from "back-end/src/util/stats";
 import { promiseAllChunks } from "back-end/src/util/promise";
 import { logger } from "back-end/src/util/logger";
-import { QueryMap } from "back-end/src/queryRunners/QueryRunner";
+import {
+  BUILD_FAILURE_PREFIX,
+  DEPENDENCY_FAILURE_PREFIX,
+  QueryMap,
+} from "back-end/src/queryRunners/QueryRunner";
 import {
   filterParentQueryMap,
   parseUnitDimQueryName,
@@ -353,13 +358,111 @@ export function getMetricSettingsForStatsEngine(
   };
 }
 
+// Build a structured per-metric error from a failed query's raw error string,
+// chaining the root cause up to the metric. A cascade failure ("Dependencies
+// failed: …") becomes a `dependency` error; a build-time SQL-generation failure
+// ("Failed to build query: …") becomes a `build` error; anything else is a
+// runtime `query` error.
+export function buildMetricErrorFromQuery(rawError?: string): MetricError {
+  const raw = rawError ?? "";
+  if (raw.startsWith(DEPENDENCY_FAILURE_PREFIX)) {
+    const detail = raw
+      .slice(DEPENDENCY_FAILURE_PREFIX.length)
+      .replace(/^:?\s*/, "");
+    return {
+      type: "dependency",
+      message: detail ? `Dependency failed: ${detail}` : "Dependency failed",
+    };
+  }
+  if (raw.startsWith(BUILD_FAILURE_PREFIX)) {
+    // The runner already formats this as "Failed to build query: <detail>",
+    // so the raw string is the chained message we want to surface as-is.
+    return {
+      type: "build",
+      message: raw,
+    };
+  }
+  return {
+    type: "query",
+    message: raw ? `Query failed: ${raw}` : "Query failed",
+  };
+}
+
+// Structured per-metric error for a metric whose analysis raised inside gbstats.
+export function buildAnalysisMetricError(rawError: string): MetricError {
+  return {
+    type: "analysis",
+    message: `Analysis error: ${rawError}`,
+  };
+}
+
+// Collect per-analysis metric errors from gbstats into one map per requested
+// analysis. Older external stats servers may still return a whole-metric error;
+// apply that to every analysis to preserve compatibility.
+export function buildAnalysisMetricErrors(
+  result: ExperimentMetricAnalysis,
+  analysisCount: number,
+  logContext: { experimentId?: string; snapshotId?: string } = {},
+): Record<string, MetricError>[] {
+  const metricErrors = Array.from(
+    { length: analysisCount },
+    (): Record<string, MetricError> => ({}),
+  );
+  result.forEach(({ metric, analyses, error, traceback }) => {
+    // Backward compatibility for responses from an older external stats server.
+    if (error) {
+      if (traceback) {
+        logger.error(
+          { ...logContext, metricId: metric, traceback },
+          "Stats engine metric analysis failed",
+        );
+      }
+      metricErrors.forEach((errors) => {
+        errors[metric] = buildAnalysisMetricError(error);
+      });
+      return;
+    }
+    analyses.forEach((analysis, index) => {
+      if (!analysis.error || !metricErrors[index]) return;
+      if (analysis.traceback) {
+        logger.error(
+          {
+            ...logContext,
+            metricId: metric,
+            analysisIndex: index,
+            traceback: analysis.traceback,
+          },
+          "Stats engine metric analysis failed",
+        );
+      }
+      metricErrors[index][metric] = buildAnalysisMetricError(analysis.error);
+    });
+  });
+  return metricErrors;
+}
+
 export function getMetricsAndQueryDataForStatsEngine(
   queryData: QueryMap,
   metricMap: Map<string, ExperimentMetricInterface>,
   settings: ExperimentSnapshotSettings,
+  // Maps a fact-metric group query name (e.g. "group_0") to the metric ids in
+  // that group, so a failed/empty group query can be attributed to each of its
+  // constituent metrics (whose ids are otherwise only recoverable from the
+  // — now missing — result rows).
+  factMetricGroups?: Record<string, string[]>,
 ) {
   const queryResults: QueryResultsForStatsEngine[] = [];
   const metricSettings: Record<string, MetricSettingsForStatsEngine> = {};
+  const metricErrors: Record<string, MetricError> = {};
+  Object.values(factMetricGroups ?? {})
+    .flat()
+    .forEach((metricId) => {
+      if (metricMap.has(metricId)) return;
+      metricErrors[metricId] = {
+        type: "config-drift",
+        message: "Metric configuration changed after the query started",
+      };
+    });
   let unknownVariations: string[] = [];
   // Everything done in a single query (Mixpanel, Google Analytics)
   // Need to convert to the same format as SQL rows
@@ -411,13 +514,49 @@ export function getMetricsAndQueryDataForStatsEngine(
       if (parseUnitDimQueryName(key)) {
         return;
       }
+      const ownedMetricIds = factMetricGroups?.[key];
+      // Query ownership is the protocol for new snapshots. Query type and the
+      // historical group-name convention remain fallbacks for old snapshots.
+      const isMultiMetricQuery =
+        (ownedMetricIds?.length ?? 0) > 1 ||
+        query.queryType === "experimentMultiMetric" ||
+        query.queryType === "experimentIncrementalRefreshStatistics" ||
+        (ownedMetricIds === undefined && !!key.match(/group_/));
+
       // Multi-metric query
-      if (
-        key.match(/group_/) ||
-        query.queryType === "experimentIncrementalRefreshStatistics"
-      ) {
+      if (isMultiMetricQuery) {
         const rows = query.result as ExperimentFactMetricsQueryResponseRows;
-        if (!rows?.length) return;
+        if (!rows?.length) {
+          const groupMetricIds = (ownedMetricIds ?? []).filter((metricId) =>
+            metricMap.has(metricId),
+          );
+          groupMetricIds.forEach((metricId) => {
+            const metric = metricMap.get(metricId);
+            if (!metric) return;
+            metricSettings[metricId] = getMetricSettingsForStatsEngine(
+              metric,
+              metricMap,
+              settings,
+              true,
+            );
+          });
+          // A failed group query produced no rows. Attribute the failure to each
+          // constituent metric instead of silently dropping the whole group.
+          // (A query that succeeded with zero rows is a legitimately empty
+          // result, not an error, so we only attribute when status is failed.)
+          if (query.status === "failed") {
+            groupMetricIds.forEach((metricId) => {
+              metricErrors[metricId] = buildMetricErrorFromQuery(query.error);
+            });
+          } else if (groupMetricIds.length) {
+            queryResults.push({
+              metrics: groupMetricIds,
+              rows: [],
+              sql: query.query,
+            });
+          }
+          return;
+        }
         const metricIds: (string | null)[] = [];
         for (let i = 0; i < MAX_METRICS_PER_QUERY; i++) {
           const prefix = `m${i}_`;
@@ -447,17 +586,25 @@ export function getMetricsAndQueryDataForStatsEngine(
         return;
       }
 
-      // Single metric query, just return rows as-is
-      const metric = metricMap.get(key);
+      // Single metric query
+      const metricId = ownedMetricIds?.[0] ?? key;
+      const metric = metricMap.get(metricId);
       if (!metric) return;
-      metricSettings[key] = getMetricSettingsForStatsEngine(
+      metricSettings[metricId] = getMetricSettingsForStatsEngine(
         metric,
         metricMap,
         settings,
         false,
       );
+      // A failed single-metric query has no result. Record a per-metric error
+      // and do NOT push blank rows to gbstats (which would treat an empty
+      // result as a legitimate "no data" outcome rather than a failure).
+      if (query.status === "failed") {
+        metricErrors[metricId] = buildMetricErrorFromQuery(query.error);
+        return;
+      }
       queryResults.push({
-        metrics: [key],
+        metrics: [metricId],
         rows: (query.result ?? []) as ExperimentMetricQueryResponseRows,
         sql: query.query,
       });
@@ -467,6 +614,7 @@ export function getMetricsAndQueryDataForStatsEngine(
     queryResults,
     metricSettings,
     unknownVariations,
+    metricErrors,
   };
 }
 
@@ -621,7 +769,11 @@ export async function writeSnapshotAnalyses(
 
     const { snapshot, snapshotSettings } = params.context;
     const { analyses, queryResults } = params.params;
-    const { analysisObj, unknownVariations } = params.data;
+    const {
+      analysisObj,
+      unknownVariations,
+      metricErrors: queryMetricErrors,
+    } = params.data;
 
     if (result.error) {
       if (result.traceback) {
@@ -650,6 +802,13 @@ export async function writeSnapshotAnalyses(
       analysisObj.results = experimentReportResults[0]?.dimensions || [];
       analysisObj.status = "success";
       analysisObj.error = undefined;
+      analysisObj.metricErrors = {
+        ...queryMetricErrors,
+        ...buildAnalysisMetricErrors(result.results, 1, {
+          experimentId: snapshotSettings.experimentId,
+          snapshotId: snapshot,
+        })[0],
+      };
     }
 
     promises.push(async () =>
@@ -671,23 +830,27 @@ export async function analyzeExperimentResults({
   snapshotSettings,
   variationNames,
   metricMap,
+  factMetricGroups,
 }: {
   queryData: QueryMap;
   analysisSettings: ExperimentSnapshotAnalysisSettings[];
   snapshotSettings: ExperimentSnapshotSettings;
   variationNames: string[];
   metricMap: Map<string, ExperimentMetricInterface>;
+  factMetricGroups?: Record<string, string[]>;
 }): Promise<{
   results: ExperimentReportResults[];
   banditResult?: BanditResult;
+  metricErrors: Record<string, MetricError>[];
 }> {
   const parentQueryData = filterParentQueryMap(queryData);
   const mdat = getMetricsAndQueryDataForStatsEngine(
     parentQueryData,
     metricMap,
     snapshotSettings,
+    factMetricGroups,
   );
-  const { queryResults, metricSettings } = mdat;
+  const { queryResults, metricSettings, metricErrors } = mdat;
   const { unknownVariations } = mdat;
 
   const params: ExperimentMetricAnalysisParams = {
@@ -716,7 +879,16 @@ export async function analyzeExperimentResults({
     unknownVariations,
     result: analysis,
   });
-  return { results, banditResult };
+  return {
+    results,
+    banditResult,
+    // Query/build/dependency failures (the metric never reached gbstats) plus
+    // analysis failures gbstats reported per metric. The two sets are disjoint:
+    // a metric whose query failed is never sent to the stats engine.
+    metricErrors: buildAnalysisMetricErrors(analysis, analysisSettings.length, {
+      experimentId: snapshotSettings.experimentId,
+    }).map((analysisErrors) => ({ ...metricErrors, ...analysisErrors })),
+  };
 }
 
 export function analyzeExperimentTraffic({

--- a/packages/back-end/test/api/experiments.test.ts
+++ b/packages/back-end/test/api/experiments.test.ts
@@ -2460,6 +2460,114 @@ describe("experiments API", () => {
       expect(res.body.result.queryStatus).toBe("partially-succeeded");
     });
 
+    it("lists a failed metric in metricErrors and keeps it out of results", async () => {
+      updateReqContext({
+        org,
+        permissions: {
+          canViewExperiment: () => true,
+        },
+      });
+
+      (getMetricsByIds as jest.Mock).mockResolvedValue([
+        { id: "met_bad", name: "Broken Revenue" },
+      ]);
+      (getExperimentById as jest.Mock).mockResolvedValue({
+        ...experiment,
+        phases: [
+          {
+            name: "Main",
+            dateStarted: new Date("2024-01-01"),
+            dateEnded: null,
+            reason: "",
+            seed: "test-seed",
+            coverage: 1,
+            variationWeights: [0.5, 0.5],
+            condition: "",
+            savedGroups: [],
+            prerequisites: [],
+            namespace: { enabled: false },
+          },
+        ],
+      });
+      (getLatestSuccessfulSnapshot as jest.Mock).mockResolvedValue({
+        id: "snap_123",
+        organization: "org_1",
+        experiment: "exp_123",
+        phase: 0,
+        dimension: null,
+        dateCreated: new Date(),
+        runStarted: new Date(),
+        queries: [],
+        unknownVariations: [],
+        multipleExposures: 0,
+        hasCorrectedStats: false,
+        results: [],
+        analyses: [
+          {
+            dateCreated: new Date(),
+            status: "success",
+            settings: {
+              dimensions: [],
+              statsEngine: "bayesian",
+              differenceType: "relative",
+              baselineVariationIndex: 0,
+            },
+            // met_bad never produced a row, so it is absent from results and
+            // only reachable through metricErrors.
+            metricErrors: {
+              met_bad: {
+                type: "query",
+                message: "Query failed: table not found",
+              },
+            },
+            results: [
+              {
+                name: "",
+                srm: 1,
+                variations: [{ users: 100, metrics: {} }],
+              },
+            ],
+          },
+        ],
+        settings: {
+          manual: false,
+          activationMetric: null,
+          queryFilter: "",
+          segment: "",
+          skipPartialData: false,
+          attributionModel: "firstExposure",
+          experimentId: "exp_123",
+          statsEngine: "bayesian",
+          regressionAdjustmentEnabled: false,
+          sequentialTestingEnabled: false,
+          sequentialTestingTuningParameter: 5000,
+          pValueThreshold: 0.05,
+          pValueCorrection: null,
+          differenceType: "relative",
+        },
+      });
+
+      const res = await request(app)
+        .get("/api/v1/experiments/exp_123/results")
+        .set("Authorization", "Bearer foo");
+
+      expect(res.status).toBe(200);
+      expect(res.body.result.metricErrors).toEqual([
+        {
+          metricId: "met_bad",
+          metricName: "Broken Revenue",
+          type: "query",
+          message: "Query failed: table not found",
+        },
+      ]);
+      // The failed metric is not reported as a row of zeros.
+      const reportedMetricIds = (res.body.result.results ?? []).flatMap(
+        (d: { metrics: { metricId: string }[] }) =>
+          d.metrics.map((m) => m.metricId),
+      );
+      expect(reportedMetricIds).not.toContain("met_bad");
+    });
+
     it("includes metricName and variationName for each metric/variation pair", async () => {
       updateReqContext({
         org,

--- a/packages/back-end/test/queryRunners/ExperimentResultsQueryRunner.test.ts
+++ b/packages/back-end/test/queryRunners/ExperimentResultsQueryRunner.test.ts
@@ -1,12 +1,26 @@
+import { analyzeExperimentPower } from "shared/enterprise";
 import { ExperimentMetricInterface } from "shared/experiments";
+import { tabulateCovariateImbalance } from "shared/health";
+import { ExperimentSnapshotInterface } from "shared/types/experiment-snapshot";
 import { QueryPointer } from "shared/types/query";
 import { buildUnitsQuerySettingsFromSnapshot } from "shared/util";
-import { startExperimentResultQueries } from "back-end/src/queryRunners/ExperimentResultsQueryRunner";
+import {
+  ExperimentResultsQueryRunner,
+  startExperimentResultQueries,
+  TRAFFIC_QUERY_NAME,
+} from "back-end/src/queryRunners/ExperimentResultsQueryRunner";
+import { QueryMap } from "back-end/src/queryRunners/QueryRunner";
 import { getFactMetricGroups } from "back-end/src/services/experimentQueries/experimentQueries";
 import { orgHasPremiumFeature } from "back-end/src/enterprise";
 import { getExposureQuery } from "back-end/src/integrations/sql/queries/exposure-query";
 import { parseDimension } from "back-end/src/services/experiments";
+import {
+  analyzeExperimentResults,
+  analyzeExperimentTraffic,
+} from "back-end/src/services/stats";
 import { shouldRunHealthTrafficQuery } from "back-end/src/queryRunners/snapshotQueryHelpers";
+import { SourceIntegrationInterface } from "back-end/src/types/Integration";
+import { ReqContext } from "back-end/types/api";
 import { factMetricFactory } from "back-end/test/factories/FactMetric.factory";
 
 // Only override the specific collaborators the build-isolation path touches;
@@ -39,6 +53,22 @@ jest.mock("shared/util", () => ({
   buildUnitsQuerySettingsFromSnapshot: jest.fn(),
 }));
 
+jest.mock("back-end/src/services/stats", () => ({
+  ...jest.requireActual("back-end/src/services/stats"),
+  analyzeExperimentResults: jest.fn(),
+  analyzeExperimentTraffic: jest.fn(),
+}));
+
+jest.mock("shared/enterprise", () => ({
+  ...jest.requireActual("shared/enterprise"),
+  analyzeExperimentPower: jest.fn(),
+}));
+
+jest.mock("shared/health", () => ({
+  ...jest.requireActual("shared/health"),
+  tabulateCovariateImbalance: jest.fn(),
+}));
+
 jest.mock("back-end/src/util/logger", () => ({
   logger: {
     error: jest.fn(),
@@ -56,6 +86,11 @@ const mockedShouldRunHealthTrafficQuery =
   shouldRunHealthTrafficQuery as jest.Mock;
 const mockedBuildUnitsQuerySettings =
   buildUnitsQuerySettingsFromSnapshot as jest.Mock;
+const mockedAnalyzeExperimentResults = analyzeExperimentResults as jest.Mock;
+const mockedAnalyzeExperimentTraffic = analyzeExperimentTraffic as jest.Mock;
+const mockedAnalyzeExperimentPower = analyzeExperimentPower as jest.Mock;
+const mockedTabulateCovariateImbalance =
+  tabulateCovariateImbalance as jest.Mock;
 
 function buildLegacyMetric(id: string): ExperimentMetricInterface {
   return { id, denominator: null } as unknown as ExperimentMetricInterface;
@@ -303,5 +338,162 @@ describe("startExperimentResultQueries build-time error isolation", () => {
     // ...and the dependent metric query is still created, so the runtime
     // cascade can mark it "Dependencies failed: …".
     expect(byName.get("met_ok")?.status).toBe("queued");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runAnalysis step isolation
+// ---------------------------------------------------------------------------
+
+const METRIC_DIMENSION = {
+  name: "",
+  srm: 1,
+  variations: [
+    { users: 100, metrics: { met_1: { value: 10, cr: 0.1, users: 100 } } },
+    { users: 100, metrics: { met_1: { value: 12, cr: 0.12, users: 100 } } },
+  ],
+};
+
+const TRAFFIC_HEALTH = {
+  overall: { name: "All", srm: 1, variationUnits: [100, 100] },
+  dimension: {},
+};
+
+function makeSnapshotModel(): ExperimentSnapshotInterface {
+  return {
+    id: "snp_1",
+    organization: "org_1",
+    experiment: "exp_1",
+    phase: 0,
+    dimension: null,
+    dateCreated: new Date("2026-01-01T00:00:00Z"),
+    runStarted: new Date("2026-01-01T00:00:00Z"),
+    status: "running",
+    queries: [],
+    unknownVariations: [],
+    multipleExposures: 0,
+    settings: {
+      metricSettings: [{ id: "met_1" }],
+      goalMetrics: ["met_1"],
+      secondaryMetrics: [],
+      guardrailMetrics: [],
+      variations: [
+        { id: "0", weight: 0.5 },
+        { id: "1", weight: 0.5 },
+      ],
+      startDate: new Date("2026-01-01T00:00:00Z"),
+      endDate: new Date("2026-01-08T00:00:00Z"),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+    analyses: [
+      {
+        analysisKey: "default",
+        dateCreated: new Date("2026-01-01T00:00:00Z"),
+        status: "running",
+        results: [],
+        settings: {
+          dimensions: [],
+          statsEngine: "frequentist",
+          differenceType: "relative",
+          numGoalMetrics: 1,
+          numGuardrailMetrics: 0,
+          // Makes both the power and covariate-imbalance steps eligible.
+          useCovariateAsResponse: true,
+        },
+      },
+    ],
+  };
+}
+
+function makeRunner(
+  model: ExperimentSnapshotInterface,
+): ExperimentResultsQueryRunner {
+  const context = {
+    org: { id: "org_1", settings: {} },
+    permissions: {
+      canRunExperimentQueries: () => true,
+      throwPermissionError: () => {
+        throw new Error("permission error");
+      },
+    },
+  } as unknown as ReqContext;
+  const integration = {
+    datasource: { id: "ds_1", settings: {} },
+    getSourceProperties: () => ({ separateExperimentResultQueries: true }),
+  } as unknown as SourceIntegrationInterface;
+
+  return new ExperimentResultsQueryRunner(context, model, integration, false);
+}
+
+function makeQueryMap(): QueryMap {
+  return new Map([
+    [
+      TRAFFIC_QUERY_NAME,
+      // One row is enough to make the snapshot eligible for power analysis.
+      { result: [{ variation: "0", users: 100 }] },
+    ],
+  ]) as unknown as QueryMap;
+}
+
+describe("ExperimentResultsQueryRunner.runAnalysis step isolation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedAnalyzeExperimentResults.mockResolvedValue({
+      results: [
+        {
+          dimensions: [METRIC_DIMENSION],
+          unknownVariations: [],
+          multipleExposures: 0,
+        },
+      ],
+      banditResult: undefined,
+      metricErrors: [
+        {
+          met_2: { type: "query", message: "Query failed: boom" },
+        },
+      ],
+    });
+    mockedAnalyzeExperimentTraffic.mockImplementation(
+      ({ error }: { error?: string }) =>
+        error ? { ...TRAFFIC_HEALTH, error } : TRAFFIC_HEALTH,
+    );
+    mockedAnalyzeExperimentPower.mockReturnValue({
+      type: "success",
+      power: 0.9,
+      isLowPowered: false,
+      additionalDaysNeeded: 0,
+      metricVariationPowerResults: [],
+    });
+    mockedTabulateCovariateImbalance.mockReturnValue({
+      isImbalanced: false,
+      pValueThreshold: 0.001,
+      numGoalMetrics: 1,
+      numGoalMetricsImbalanced: 0,
+      numGuardrailMetrics: 0,
+      numGuardrailMetricsImbalanced: 0,
+      numSecondaryMetrics: 0,
+      numSecondaryMetricsImbalanced: 0,
+      metricVariationCovariateImbalanceResults: [],
+    });
+  });
+
+  it("still analyzes metrics when recomputing fact-metric group membership throws", async () => {
+    mockedGetFactMetricGroups.mockImplementation(() => {
+      throw new Error("grouping failed");
+    });
+    const metric = { id: "met_1" } as ExperimentMetricInterface;
+    const model = makeSnapshotModel();
+    const runner = makeRunner(model);
+    // metricMap is normally populated by startQueries.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (runner as any).metricMap = new Map([[metric.id, metric]]);
+
+    const result = await runner.runAnalysis(makeQueryMap());
+
+    // Attribution degrades to an empty group map; results are unaffected.
+    expect(mockedAnalyzeExperimentResults).toHaveBeenCalledWith(
+      expect.objectContaining({ factMetricGroups: {} }),
+    );
+    expect(result.analyses[0].results).toEqual([METRIC_DIMENSION]);
   });
 });

--- a/packages/back-end/test/services/experimentSnapshotAnalyses.test.ts
+++ b/packages/back-end/test/services/experimentSnapshotAnalyses.test.ts
@@ -24,6 +24,7 @@ jest.mock("back-end/src/services/stats", () => ({
 jest.mock("back-end/src/queryRunners/QueryRunner", () => ({
   QueryRunner: class {},
   getMetricAwareQueryStatus: jest.fn(() => null),
+  getMetricQueryOwnership: jest.fn(() => ({})),
   getQueryMap: jest.fn(),
 }));
 
@@ -189,6 +190,7 @@ describe("createSnapshotAnalysesBatched", () => {
     );
     (analyzeExperimentResults as jest.Mock).mockResolvedValue({
       results: [{ dimensions: [{ name: "US", variations: [] }] }],
+      metricErrors: [{}],
     });
 
     const analysisSettingsList = [
@@ -243,6 +245,7 @@ describe("createSnapshotAnalysis", () => {
     );
     (analyzeExperimentResults as jest.Mock).mockResolvedValue({
       results: [{ dimensions: [] }],
+      metricErrors: [{}],
     });
 
     await createSnapshotAnalysis({ org: { id: "org_1" } } as never, {

--- a/packages/back-end/test/services/stats.test.ts
+++ b/packages/back-end/test/services/stats.test.ts
@@ -1,0 +1,388 @@
+import { ExperimentMetricInterface } from "shared/experiments";
+import { ExperimentSnapshotSettings } from "shared/types/experiment-snapshot";
+import { QueryInterface } from "shared/types/query";
+import {
+  buildAnalysisMetricErrors,
+  buildMetricErrorFromQuery,
+  getMetricsAndQueryDataForStatsEngine,
+} from "back-end/src/services/stats";
+import { QueryMap } from "back-end/src/queryRunners/QueryRunner";
+import { factMetricFactory } from "back-end/test/factories/FactMetric.factory";
+
+// Minimal snapshot settings — only the fields read by
+// getMetricsAndQueryDataForStatsEngine / getMetricSettingsForStatsEngine.
+function buildSettings(metricIds: string[]): ExperimentSnapshotSettings {
+  return {
+    metricSettings: [],
+    goalMetrics: metricIds,
+    secondaryMetrics: [],
+    guardrailMetrics: [],
+    regressionAdjustmentEnabled: false,
+    variations: [],
+  } as unknown as ExperimentSnapshotSettings;
+}
+
+// Only the fields read by the function under test matter; cast the rest.
+function buildQuery(overrides: Partial<QueryInterface>): QueryInterface {
+  return {
+    id: "qry_" + Math.random().toString(36).slice(2),
+    organization: "org_1",
+    datasource: "ds_1",
+    language: "sql",
+    query: "SELECT 1",
+    status: "succeeded",
+    createdAt: new Date(),
+    heartbeat: new Date(),
+    ...overrides,
+  } as QueryInterface;
+}
+
+describe("getMetricsAndQueryDataForStatsEngine per-metric error attribution", () => {
+  const metricIds = ["m_ok", "m_failed", "m_group_a", "m_group_b", "m_dep"];
+
+  function buildMetricMap(): Map<string, ExperimentMetricInterface> {
+    const metrics = metricIds.map((id) => factMetricFactory.build({ id }));
+    return new Map(metrics.map((m) => [m.id, m]));
+  }
+
+  it("records a per-metric query error for a failed single-metric query and keeps surviving metrics in queryResults", () => {
+    const metricMap = buildMetricMap();
+    const settings = buildSettings(metricIds);
+
+    const queryData: QueryMap = new Map();
+    // A surviving metric with a succeeded query
+    queryData.set(
+      "m_ok",
+      buildQuery({ status: "succeeded", result: [{ variation: "0" }] }),
+    );
+    // A failed single-metric query
+    queryData.set(
+      "m_failed",
+      buildQuery({ status: "failed", error: "Column not found" }),
+    );
+
+    const { queryResults, metricErrors } = getMetricsAndQueryDataForStatsEngine(
+      queryData,
+      metricMap,
+      settings,
+    );
+
+    // Surviving metric is still analyzed
+    expect(queryResults.some((qr) => qr.metrics.includes("m_ok"))).toBe(true);
+    // Failed metric is NOT pushed as a blank result
+    expect(queryResults.some((qr) => qr.metrics.includes("m_failed"))).toBe(
+      false,
+    );
+    // Failed metric gets a structured "query" error with the chained message
+    expect(metricErrors["m_failed"]).toEqual({
+      type: "query",
+      message: "Query failed: Column not found",
+    });
+    expect(metricErrors["m_ok"]).toBeUndefined();
+  });
+
+  it("uses explicit ownership instead of a single-metric query name", () => {
+    const metricMap = buildMetricMap();
+    const settings = buildSettings(metricIds);
+    const queryData: QueryMap = new Map([
+      [
+        "renamed_query",
+        buildQuery({
+          status: "failed",
+          error: "Column not found",
+          queryType: "experimentMetric",
+        }),
+      ],
+    ]);
+
+    const { metricErrors } = getMetricsAndQueryDataForStatsEngine(
+      queryData,
+      metricMap,
+      settings,
+      { renamed_query: ["m_failed"] },
+    );
+
+    expect(metricErrors["m_failed"]).toEqual({
+      type: "query",
+      message: "Query failed: Column not found",
+    });
+    expect(metricErrors["renamed_query"]).toBeUndefined();
+  });
+
+  it("uses explicit ownership instead of a multi-metric query name", () => {
+    const metricMap = buildMetricMap();
+    const settings = buildSettings(metricIds);
+    const queryData: QueryMap = new Map([
+      [
+        "renamed_query",
+        buildQuery({
+          status: "failed",
+          error: "Table not found",
+          queryType: "experimentMultiMetric",
+        }),
+      ],
+    ]);
+
+    const { metricErrors } = getMetricsAndQueryDataForStatsEngine(
+      queryData,
+      metricMap,
+      settings,
+      { renamed_query: ["m_group_a", "m_group_b"] },
+    );
+
+    expect(metricErrors["m_group_a"]).toEqual({
+      type: "query",
+      message: "Query failed: Table not found",
+    });
+    expect(metricErrors["m_group_b"]).toEqual(metricErrors["m_group_a"]);
+  });
+
+  it("attributes a failed fact-group query to each constituent metric (query vs dependency)", () => {
+    const metricMap = buildMetricMap();
+    const settings = buildSettings(metricIds);
+
+    const queryData: QueryMap = new Map();
+    // A surviving single metric
+    queryData.set(
+      "m_ok",
+      buildQuery({ status: "succeeded", result: [{ variation: "0" }] }),
+    );
+    // A group query that failed at runtime
+    queryData.set(
+      "group_0",
+      buildQuery({ status: "failed", error: "Syntax error near FROM" }),
+    );
+    // A group query that failed because an upstream dependency failed
+    queryData.set(
+      "group_1",
+      buildQuery({
+        status: "failed",
+        error: "Dependencies failed: qry_units",
+      }),
+    );
+
+    const factMetricGroups: Record<string, string[]> = {
+      group_0: ["m_group_a", "m_group_b"],
+      group_1: ["m_dep"],
+    };
+
+    const { queryResults, metricErrors } = getMetricsAndQueryDataForStatsEngine(
+      queryData,
+      metricMap,
+      settings,
+      factMetricGroups,
+    );
+
+    // Every metric in the failed group gets the same runtime query error
+    expect(metricErrors["m_group_a"]).toEqual({
+      type: "query",
+      message: "Query failed: Syntax error near FROM",
+    });
+    expect(metricErrors["m_group_b"]).toEqual({
+      type: "query",
+      message: "Query failed: Syntax error near FROM",
+    });
+    // A cascade failure is classified as a dependency error
+    expect(metricErrors["m_dep"]).toEqual({
+      type: "dependency",
+      message: "Dependency failed: qry_units",
+    });
+    // Failed groups contribute no rows to gbstats; the survivor still does
+    expect(queryResults.some((qr) => qr.metrics.includes("m_ok"))).toBe(true);
+    expect(queryResults.some((qr) => qr.metrics.includes("m_group_a"))).toBe(
+      false,
+    );
+  });
+
+  it("does not record an error for a query that succeeded with zero rows", () => {
+    const metricMap = buildMetricMap();
+    const settings = buildSettings(metricIds);
+
+    const queryData: QueryMap = new Map();
+    // Succeeded group query with no rows is a legitimately empty result
+    queryData.set("group_0", buildQuery({ status: "succeeded", result: [] }));
+
+    const { metricErrors, queryResults } = getMetricsAndQueryDataForStatsEngine(
+      queryData,
+      metricMap,
+      settings,
+      { group_0: ["m_group_a", "m_group_b"] },
+    );
+
+    expect(Object.keys(metricErrors)).toHaveLength(0);
+    expect(queryResults).toEqual([
+      {
+        metrics: ["m_group_a", "m_group_b"],
+        rows: [],
+        sql: "SELECT 1",
+      },
+    ]);
+  });
+
+  it("classifies a build-time SQL-generation failure as a build error", () => {
+    const metricMap = buildMetricMap();
+    const settings = buildSettings(metricIds);
+
+    const queryData: QueryMap = new Map();
+    // A metric whose query failed to build (Phase 2 records it as a failed
+    // query with the "Failed to build query" prefix).
+    queryData.set(
+      "m_failed",
+      buildQuery({
+        status: "failed",
+        error: "Failed to build query: Unknown fact table",
+      }),
+    );
+
+    const { metricErrors } = getMetricsAndQueryDataForStatsEngine(
+      queryData,
+      metricMap,
+      settings,
+    );
+
+    expect(metricErrors["m_failed"]).toEqual({
+      type: "build",
+      message: "Failed to build query: Unknown fact table",
+    });
+  });
+
+  it("attributes a failed incremental statistics query to the metrics it computed", () => {
+    const metricMap = buildMetricMap();
+    const settings = buildSettings(metricIds);
+
+    const queryData: QueryMap = new Map();
+    // Same-FT statistics query that failed at runtime
+    queryData.set(
+      "statistics_ft_1_ab12340",
+      buildQuery({
+        status: "failed",
+        error: "Table not found",
+        queryType: "experimentIncrementalRefreshStatistics",
+      }),
+    );
+    // Cross-FT statistics query that cascaded from a failed insert
+    queryData.set(
+      "statistics_cross_ft_1_ab12340__ft_2_ab12341",
+      buildQuery({
+        status: "failed",
+        error: "Dependencies failed: qry_insert",
+        queryType: "experimentIncrementalRefreshStatistics",
+      }),
+    );
+
+    const { metricErrors } = getMetricsAndQueryDataForStatsEngine(
+      queryData,
+      metricMap,
+      settings,
+      {
+        statistics_ft_1_ab12340: ["m_group_a", "m_group_b"],
+        statistics_cross_ft_1_ab12340__ft_2_ab12341: ["m_dep"],
+      },
+    );
+
+    expect(metricErrors["m_group_a"]).toEqual({
+      type: "query",
+      message: "Query failed: Table not found",
+    });
+    expect(metricErrors["m_group_b"]).toEqual(metricErrors["m_group_a"]);
+    expect(metricErrors["m_dep"]).toEqual({
+      type: "dependency",
+      message: "Dependency failed: qry_insert",
+    });
+  });
+
+  it("reports ownership metadata that references a missing metric as config drift", () => {
+    const { metricErrors } = getMetricsAndQueryDataForStatsEngine(
+      new Map([
+        [
+          "group_0",
+          buildQuery({
+            status: "succeeded",
+            result: [],
+            queryType: "experimentMultiMetric",
+          }),
+        ],
+      ]),
+      buildMetricMap(),
+      buildSettings(metricIds),
+      { group_0: ["metric_deleted_after_query_start"] },
+    );
+
+    expect(metricErrors["metric_deleted_after_query_start"]).toEqual({
+      type: "config-drift",
+      message: "Metric configuration changed after the query started",
+    });
+  });
+});
+
+describe("buildAnalysisMetricErrors", () => {
+  it("keeps analysis failures scoped to their analysis index", () => {
+    const metricErrors = buildAnalysisMetricErrors(
+      [
+        {
+          metric: "m_failed",
+          analyses: [
+            {
+              unknownVariations: [],
+              multipleExposures: 0,
+              dimensions: [],
+              error: "first analysis failed",
+              traceback: "sensitive traceback",
+            },
+            {
+              unknownVariations: [],
+              multipleExposures: 0,
+              dimensions: [],
+            },
+          ],
+        },
+      ],
+      2,
+    );
+
+    expect(metricErrors).toEqual([
+      {
+        m_failed: {
+          type: "analysis",
+          message: "Analysis error: first analysis failed",
+        },
+      },
+      {},
+    ]);
+    expect(JSON.stringify(metricErrors)).not.toContain("sensitive traceback");
+  });
+});
+
+describe("buildMetricErrorFromQuery", () => {
+  it("classifies a build-time failure as a build error and preserves the message", () => {
+    expect(
+      buildMetricErrorFromQuery("Failed to build query: Unknown fact table"),
+    ).toEqual({
+      type: "build",
+      message: "Failed to build query: Unknown fact table",
+    });
+  });
+
+  it("classifies a dependency cascade as a dependency error", () => {
+    expect(buildMetricErrorFromQuery("Dependencies failed: qry_units")).toEqual(
+      {
+        type: "dependency",
+        message: "Dependency failed: qry_units",
+      },
+    );
+  });
+
+  it("classifies any other failure as a runtime query error", () => {
+    expect(buildMetricErrorFromQuery("Syntax error near FROM")).toEqual({
+      type: "query",
+      message: "Query failed: Syntax error near FROM",
+    });
+  });
+
+  it("falls back to a generic message when no raw error is present", () => {
+    expect(buildMetricErrorFromQuery()).toEqual({
+      type: "query",
+      message: "Query failed",
+    });
+  });
+});

--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -13,6 +13,7 @@ import {
   ExperimentSnapshotAnalysis,
   ExperimentSnapshotAnalysisSettings,
   ExperimentSnapshotInterface,
+  MetricError,
 } from "shared/types/experiment-snapshot";
 import {
   DifferenceType,
@@ -30,7 +31,10 @@ import { NULL_DIMENSION_VALUE } from "shared/constants";
 import { FaCaretRight } from "react-icons/fa";
 import Collapsible from "react-collapsible";
 import { useDefinitions } from "@/services/DefinitionsContext";
-import { ExperimentTableRow } from "@/services/experiments";
+import {
+  ExperimentTableRow,
+  getMetricErrorsForDisplay,
+} from "@/services/experiments";
 import ResultsTable, {
   RESULTS_TABLE_COLUMNS,
 } from "@/components/Experiment/ResultsTable";
@@ -104,6 +108,7 @@ const BreakDownResults: FC<{
   setBaselineRow?: (baselineRow: number) => void;
   snapshot?: ExperimentSnapshotInterface;
   analysis?: ExperimentSnapshotAnalysis;
+  metricErrors?: Record<string, MetricError>;
   setAnalysisSettings?: (
     settings: ExperimentSnapshotAnalysisSettings | null,
   ) => void;
@@ -154,6 +159,7 @@ const BreakDownResults: FC<{
   setBaselineRow,
   snapshot,
   analysis,
+  metricErrors,
   setAnalysisSettings,
   mutate,
   setDifferenceType,
@@ -165,6 +171,11 @@ const BreakDownResults: FC<{
 
   // Detect drilldown context for automatic row click handling
   const drilldownContext = useMetricDrilldownContext();
+  const displayMetricErrors = getMetricErrorsForDisplay({
+    metricErrors: metricErrors ?? analysis?.metricErrors,
+    queries: snapshot?.queries,
+    failedQueryNames: queryStatusData?.failedNames,
+  });
 
   const dimension =
     ssrPolyfills?.getDimensionById?.(dimensionId)?.name ||
@@ -191,6 +202,7 @@ const BreakDownResults: FC<{
     dimensionValuesFilter,
     showErrorsOnQuantileMetrics,
     pValueThreshold: significanceThresholds.pValueThreshold,
+    metricErrors: displayMetricErrors,
   });
 
   const activationMetricObj = activationMetric

--- a/packages/front-end/components/Experiment/ChangeColumn.tsx
+++ b/packages/front-end/components/Experiment/ChangeColumn.tsx
@@ -13,6 +13,7 @@ import {
 import { useCurrency } from "@/hooks/useCurrency";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { SSRPolyfills } from "@/hooks/useSSRPolyfills";
+import Tooltip from "@/components/Tooltip/Tooltip";
 import { useResultPopover } from "./useResultPopover";
 
 interface Props
@@ -129,7 +130,9 @@ export default function ChangeColumn({
         ) : null}
       </span>{" "}
       {expected === 0 && stats.errorMessage ? (
-        <span className="expected">n/a</span>
+        <Tooltip body={stats.errorMessage}>
+          <span className="expected">n/a</span>
+        </Tooltip>
       ) : (
         <span className="expected">
           {formatter(expected, formatterOptions)}{" "}

--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -14,6 +14,7 @@ import {
   ExperimentSnapshotAnalysis,
   ExperimentSnapshotAnalysisSettings,
   ExperimentSnapshotInterface,
+  MetricError,
 } from "shared/types/experiment-snapshot";
 import {
   DifferenceType,
@@ -37,7 +38,10 @@ import {
 import Link from "@/ui/Link";
 import { useExperimentTableRows } from "@/hooks/useExperimentTableRows";
 import { useDefinitions } from "@/services/DefinitionsContext";
-import { ExperimentTableRow } from "@/services/experiments";
+import {
+  ExperimentTableRow,
+  getMetricErrorsForDisplay,
+} from "@/services/experiments";
 import { QueryStatusData } from "@/components/Queries/RunQueriesButton";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import { SSRPolyfills } from "@/hooks/useSSRPolyfills";
@@ -101,6 +105,7 @@ const CompactResults: FC<{
   setBaselineRow?: (baselineRow: number) => void;
   snapshot?: ExperimentSnapshotInterface;
   analysis?: ExperimentSnapshotAnalysis;
+  metricErrors?: Record<string, MetricError>;
   setAnalysisSettings?: (
     settings: ExperimentSnapshotAnalysisSettings | null,
   ) => void;
@@ -156,6 +161,7 @@ const CompactResults: FC<{
   setBaselineRow,
   snapshot,
   analysis,
+  metricErrors,
   setAnalysisSettings,
   mutate,
   setDifferenceType,
@@ -183,6 +189,11 @@ const CompactResults: FC<{
   const [expandedMetrics, setExpandedMetrics] = useState<
     Record<string, boolean>
   >({});
+  const displayMetricErrors = getMetricErrorsForDisplay({
+    metricErrors: metricErrors ?? analysis?.metricErrors,
+    queries: snapshot?.queries,
+    failedQueryNames: queryStatusData?.failedNames,
+  });
   const toggleExpandedMetric = (
     metricId: string,
     resultGroup: "goal" | "secondary" | "guardrail",
@@ -215,6 +226,7 @@ const CompactResults: FC<{
     enableExpansion: true,
     expandedMetrics,
     pValueThreshold: significanceThresholds.pValueThreshold,
+    metricErrors: displayMetricErrors,
   });
 
   const expandedGoals = useMemo(

--- a/packages/front-end/components/Experiment/Public/PublicExperimentResults.tsx
+++ b/packages/front-end/components/Experiment/Public/PublicExperimentResults.tsx
@@ -185,6 +185,7 @@ export default function PublicExperimentResults({
                 significanceThresholds={significanceThresholds}
                 key={snapshot.dimension}
                 results={analysis?.results ?? []}
+                metricErrors={analysis?.metricErrors}
                 queryStatusData={queryStatusData}
                 variations={variations}
                 goalMetrics={experiment.goalMetrics}
@@ -214,6 +215,7 @@ export default function PublicExperimentResults({
                 variations={variations}
                 multipleExposures={snapshot.multipleExposures || 0}
                 results={analysis.results[0]}
+                metricErrors={analysis.metricErrors}
                 queryStatusData={queryStatusData}
                 reportDate={snapshot.dateCreated}
                 startDate={phaseObj?.dateStarted ?? ""}

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -36,7 +36,10 @@ import Link from "@/ui/Link";
 import Button from "@/ui/Button";
 import AsyncQueriesModal from "@/components/Queries/AsyncQueriesModal";
 import { MetricDrilldownProvider } from "@/components/MetricDrilldown/MetricDrilldownContext";
-import { getIsExperimentIncludedInIncrementalRefresh } from "@/services/experiments";
+import {
+  getIsExperimentIncludedInIncrementalRefresh,
+  getSnapshotMetricFailureSummary,
+} from "@/services/experiments";
 import { useIncrementalPipelineUnsupportedReason } from "@/hooks/useIncrementalPipelineUnsupportedReason";
 import { ExperimentTab } from "./TabbedPage";
 
@@ -142,6 +145,15 @@ const Results: FC<{
     useIncrementalPipelineUnsupportedReason(experiment);
 
   const hasData = (analysis?.results?.[0]?.variations?.length ?? 0) > 0;
+
+  // Surviving metrics are always analyzed now, so a snapshot can succeed with
+  // some metrics failed. Summarize that at the snapshot level so partial results
+  // are never mistaken for complete ones (the per-metric rows carry the detail).
+  const metricFailures = getSnapshotMetricFailureSummary({
+    metricErrors: analysis?.metricErrors,
+    snapshotMetricIds:
+      snapshot?.settings?.metricSettings?.map((m) => m.id) ?? [],
+  });
   const hasValidStatsEngine =
     !analysis?.settings ||
     (analysis?.settings?.statsEngine || DEFAULT_STATS_ENGINE) === statsEngine;
@@ -238,6 +250,14 @@ const Results: FC<{
 
   const isBandit = experiment.type === "multi-armed-bandit";
   const hasQueries = queryStrings.length > 0;
+  const allMetricsFailed =
+    metricFailures.totalCount > 0 &&
+    metricFailures.failedCount >= metricFailures.totalCount;
+  const analysisErrorMessage =
+    analysis?.status === "error"
+      ? analysis.error || "Analysis could not be completed."
+      : "";
+  const snapshotErrored = (latest?.status ?? snapshot?.status) === "error";
   return (
     <>
       {!draftMode ? null : (
@@ -261,7 +281,7 @@ const Results: FC<{
         </Callout>
       )}
 
-      {status === "failed" && !hasData && !snapshotLoading && hasMetrics ? (
+      {snapshotErrored && !hasData && !snapshotLoading && hasMetrics ? (
         <Callout status="error" mx="3" my="4">
           The most recent update failed.
           {hasQueries ? (
@@ -276,10 +296,48 @@ const Results: FC<{
             ""
           )}
         </Callout>
+      ) : analysisErrorMessage && !snapshotLoading ? (
+        <Callout status="error" mx="3" my="4">
+          {analysisErrorMessage}
+        </Callout>
+      ) : metricFailures.failedCount > 0 && !snapshotLoading ? (
+        <Callout
+          // Every metric failing is worth an error, not a warning — there are no
+          // results to read. A snapshot whose queries all failed is covered by
+          // the callout above instead (its analysis never ran).
+          status={allMetricsFailed ? "error" : "warning"}
+          mx="3"
+          my="4"
+        >
+          {allMetricsFailed
+            ? `${
+                metricFailures.totalCount === 1
+                  ? "The only metric"
+                  : `All ${metricFailures.totalCount} metrics`
+              } failed to compute in the most recent update.`
+            : `${metricFailures.failedCount} of ${metricFailures.totalCount} metrics failed to compute in the most recent update. The results below are incomplete.`}{" "}
+          {allMetricsFailed ? (
+            hasQueries ? (
+              <>
+                <Link onClick={() => setQueriesModalOpen(true)}>
+                  View queries
+                </Link>
+                {" to see what went wrong."}
+              </>
+            ) : null
+          ) : (
+            <>See each metric&apos;s row for details.</>
+          )}
+        </Callout>
       ) : null}
 
       {(!hasData || !hasValidStatsEngine) &&
-        status !== "failed" && // failed is handled above
+        !snapshotErrored &&
+        // The all-metrics-failed error Callout above already explains this
+        // empty table; "Make sure your Experiment is tracking properly" would
+        // be actively wrong (the data arrived, the analysis failed).
+        !allMetricsFailed &&
+        !analysisErrorMessage &&
         status !== "running" &&
         !snapshot?.unknownVariations?.length &&
         hasMetrics &&

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -169,7 +169,6 @@ export default function ResultsTable({
   isLatestPhase,
   phase,
   status,
-  queryStatusData,
   rows,
   dimension,
   tableRowAxis,
@@ -453,10 +452,8 @@ export default function ResultsTable({
             rr[i].push(null);
             return;
           }
-          if (
-            queryStatusData?.status === "partially-succeeded" &&
-            queryStatusData?.failedNames?.includes(row.metric.id)
-          ) {
+          // Structured per-metric error from the snapshot analysis.
+          if (row.metricError) {
             rr[i].push("query error");
             return;
           }
@@ -517,7 +514,6 @@ export default function ResultsTable({
       startDate,
       isLatestPhase,
       status,
-      queryStatusData,
       ssrPolyfills,
       getExperimentMetricById,
     ]);
@@ -947,7 +943,8 @@ export default function ResultsTable({
                                             mx="2"
                                           >
                                             {isQueryError
-                                              ? "Query error"
+                                              ? (row.metricError?.message ??
+                                                "Query error")
                                               : "Quantile metrics not available for pre-computed dimensions. Use a custom report instead."}
                                           </HelperText>
                                         </>

--- a/packages/front-end/components/MetricDrilldown/MetricDrilldownModal.tsx
+++ b/packages/front-end/components/MetricDrilldown/MetricDrilldownModal.tsx
@@ -244,6 +244,7 @@ const MetricDrilldownContent: FC<MetricDrilldownContentProps> = ({
     enableExpansion: true,
     expandedMetrics,
     pValueThreshold: significanceThresholds.pValueThreshold,
+    metricErrors: analysis?.metricErrors,
   });
 
   const mainMetricRow = useMemo(() => {

--- a/packages/front-end/components/Report/LegacyReportPage.tsx
+++ b/packages/front-end/components/Report/LegacyReportPage.tsx
@@ -511,6 +511,7 @@ export default function LegacyReportPage({
                     metricOverrides={report.args.metricOverrides || []}
                     reportDate={report.dateCreated}
                     results={report.results?.dimensions || []}
+                    metricErrors={report.results?.metricErrors}
                     queryStatusData={queryStatusData}
                     status={"stopped"}
                     startDate={getValidDate(
@@ -579,6 +580,7 @@ export default function LegacyReportPage({
                       variations={variations}
                       multipleExposures={report.results?.multipleExposures || 0}
                       results={report.results?.dimensions?.[0]}
+                      metricErrors={report.results?.metricErrors}
                       queryStatusData={queryStatusData}
                       reportDate={report.dateCreated}
                       startDate={getValidDate(

--- a/packages/front-end/components/Report/ReportResults.tsx
+++ b/packages/front-end/components/Report/ReportResults.tsx
@@ -242,6 +242,7 @@ export default function ReportResults({
                 significanceThresholds={significanceThresholds}
                 key={snapshot.dimension}
                 results={analysis?.results ?? []}
+                metricErrors={analysis?.metricErrors}
                 queryStatusData={queryStatusData}
                 variations={variations}
                 // variationFilter={variationFilter}
@@ -282,6 +283,7 @@ export default function ReportResults({
                 variations={variations}
                 multipleExposures={snapshot.multipleExposures || 0}
                 results={analysis.results[0]}
+                metricErrors={analysis.metricErrors}
                 queryStatusData={queryStatusData}
                 reportDate={snapshot.dateCreated}
                 startDate={getValidDate(phaseObj.dateStarted).toISOString()}

--- a/packages/front-end/components/SafeRollout/Results/CompactResults.tsx
+++ b/packages/front-end/components/SafeRollout/Results/CompactResults.tsx
@@ -25,10 +25,13 @@ import {
 } from "shared/experiments";
 import { isDefined } from "shared/util";
 import { SafeRolloutReportResultDimension } from "shared/validators";
+import { MetricError } from "shared/types/experiment-snapshot";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import {
   applyMetricOverrides,
   ExperimentTableRow,
+  getMetricErrorsForDisplay,
+  resolveMetricRowError,
 } from "@/services/experiments";
 import { GBCuped } from "@/components/Icons";
 import { QueryStatusData } from "@/components/Queries/RunQueriesButton";
@@ -63,6 +66,7 @@ const CompactResults: FC<{
   experimentType?: ExperimentType;
   ssrPolyfills?: SSRPolyfills;
   hideDetails?: boolean;
+  metricErrors?: Record<string, MetricError>;
 }> = ({
   significanceThresholds,
   editMetrics,
@@ -87,10 +91,15 @@ const CompactResults: FC<{
   experimentType,
   ssrPolyfills,
   hideDetails,
+  metricErrors,
 }) => {
   const { getExperimentMetricById, metricGroups, ready } = useDefinitions();
 
   const { pValueThreshold } = significanceThresholds;
+  const displayMetricErrors = getMetricErrorsForDisplay({
+    metricErrors,
+    failedQueryNames: queryStatusData?.failedNames,
+  });
 
   const { expandedGoals, expandedGuardrails } = useMemo(() => {
     const expandedGoals = expandMetricGroups(
@@ -141,6 +150,10 @@ const CompactResults: FC<{
         }),
         metricSnapshotSettings,
         resultGroup,
+        metricError: resolveMetricRowError({
+          metricId,
+          metricErrors: displayMetricErrors,
+        }),
       };
     }
 
@@ -167,6 +180,7 @@ const CompactResults: FC<{
     ready,
     ssrPolyfills,
     getExperimentMetricById,
+    displayMetricErrors,
   ]);
 
   const isBandit = experimentType === "multi-armed-bandit";

--- a/packages/front-end/components/SafeRollout/Results/ResultsTable.tsx
+++ b/packages/front-end/components/SafeRollout/Results/ResultsTable.tsx
@@ -84,7 +84,6 @@ export default function ResultsTable({
   significanceThresholds,
   isLatestPhase,
   status,
-  queryStatusData,
   rows,
   dimension,
   editMetrics,
@@ -177,10 +176,7 @@ export default function ResultsTable({
           rr[i].push(null);
           return;
         }
-        if (
-          queryStatusData?.status === "partially-succeeded" &&
-          queryStatusData?.failedNames?.includes(row.metric.id)
-        ) {
+        if (row.metricError) {
           rr[i].push("query error");
           return;
         }
@@ -235,7 +231,6 @@ export default function ResultsTable({
     startDate,
     isLatestPhase,
     status,
-    queryStatusData,
     ssrPolyfills,
     getExperimentMetricById,
   ]);
@@ -429,7 +424,7 @@ export default function ResultsTable({
                                 </div>
                               ) : null}
                               <Callout status="error" mb="1" ml="1" size="sm">
-                                Query error
+                                {row.metricError?.message ?? "Query error"}
                               </Callout>
                             </>
                           ),

--- a/packages/front-end/components/SafeRollout/SafeRolloutResults.tsx
+++ b/packages/front-end/components/SafeRollout/SafeRolloutResults.tsx
@@ -185,6 +185,7 @@ const SafeRolloutResults: FC<{
                 significanceThresholds={significanceThresholds}
                 variations={SAFE_ROLLOUT_VARIATIONS}
                 results={analysis.results[0]}
+                metricErrors={analysis.metricErrors}
                 queryStatusData={queryStatusData}
                 reportDate={snapshot.dateCreated}
                 startDate={getValidDate(safeRollout.startedAt).toDateString()}

--- a/packages/front-end/components/Share/Presentation.tsx
+++ b/packages/front-end/components/Share/Presentation.tsx
@@ -489,6 +489,7 @@ const Presentation = ({
                 )}
                 multipleExposures={snapshot.multipleExposures || 0}
                 results={snapshot?.analyses?.[0]?.results?.[0]}
+                metricErrors={snapshot?.analyses?.[0]?.metricErrors}
                 reportDate={snapshot.dateCreated}
                 startDate={phase?.dateStarted ?? ""}
                 endDate={phase?.dateEnded ?? ""}

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentDimensionBlock.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentDimensionBlock.tsx
@@ -156,6 +156,7 @@ export default function ExperimentDimensionBlock({
         idPrefix={blockId}
         key={snapshot.dimension}
         results={analysis.results}
+        metricErrors={analysis.metricErrors}
         queryStatusData={queryStatusData}
         variations={variations}
         variationFilter={variationFilter}

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentMetricBlock.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentMetricBlock.tsx
@@ -20,6 +20,7 @@ import ResultsTable from "@/components/Experiment/ResultsTable";
 import { MetricDrilldownProvider } from "@/components/MetricDrilldown/MetricDrilldownContext";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useExperimentTableRows } from "@/hooks/useExperimentTableRows";
+import { getMetricErrorsForDisplay } from "@/services/experiments";
 import { getRenderLabelColumn } from "@/components/Experiment/CompactResults";
 import { getQueryStatus } from "@/components/Queries/RunQueriesButton";
 import { useDashboardEditorHooks } from "@/enterprise/hooks/useDashboardEditorHooks";
@@ -79,6 +80,11 @@ export default function ExperimentMetricBlock({
   const lastPhaseIndex = experiment.phases.length - 1;
   const latestPhase = experiment.phases[lastPhaseIndex];
   const result = analysis.results[0];
+  const displayMetricErrors = getMetricErrorsForDisplay({
+    metricErrors: analysis.metricErrors,
+    queries: snapshot.queries,
+    failedQueryNames: queryStatusData.failedNames,
+  });
 
   const settingsForSnapshotMetrics: MetricSnapshotSettings[] =
     snapshot?.settings?.metricSettings?.map((m) => ({
@@ -144,6 +150,7 @@ export default function ExperimentMetricBlock({
         ? blockMetricIds
         : undefined,
     pValueThreshold,
+    metricErrors: displayMetricErrors,
   });
 
   // Filter rows based on expansion state when there's no slice filter

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentTimeSeriesBlock.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentTimeSeriesBlock.tsx
@@ -10,6 +10,7 @@ import useOrgSettings from "@/hooks/useOrgSettings";
 import usePValueThreshold from "@/hooks/usePValueThreshold";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useExperimentTableRows } from "@/hooks/useExperimentTableRows";
+import { getMetricErrorsForDisplay } from "@/services/experiments";
 import { getRenderLabelColumn } from "@/components/Experiment/CompactResults";
 import { BlockProps } from ".";
 
@@ -41,6 +42,10 @@ export default function ExperimentTimeSeriesBlock({
     ssrPolyfills?.usePValueThreshold?.(experiment.project) || _pValueThreshold;
 
   const result = analysis.results[0];
+  const displayMetricErrors = getMetricErrorsForDisplay({
+    metricErrors: analysis.metricErrors,
+    queries: snapshot.queries,
+  });
 
   const currentPhase = experiment.phases[snapshot.phase];
   const phaseStartDate = currentPhase?.dateStarted
@@ -102,6 +107,7 @@ export default function ExperimentTimeSeriesBlock({
         ? blockMetricIds
         : undefined,
     pValueThreshold,
+    metricErrors: displayMetricErrors,
   });
 
   // Filter rows based on expansion state when there's no slice filter

--- a/packages/front-end/hooks/useExperimentDimensionRows.ts
+++ b/packages/front-end/hooks/useExperimentDimensionRows.ts
@@ -4,6 +4,7 @@ import {
   MetricSnapshotSettings,
 } from "shared/types/report";
 import { MetricOverride } from "shared/types/experiment";
+import { MetricError } from "shared/types/experiment-snapshot";
 import { PValueCorrection, StatsEngine } from "shared/types/stats";
 import {
   expandMetricGroups,
@@ -19,6 +20,7 @@ import {
   applyMetricOverrides,
   ExperimentTableRow,
   compareRows,
+  resolveMetricRowError,
 } from "@/services/experiments";
 import { RowError } from "@/components/Experiment/ResultsTable";
 import { SSRPolyfills } from "@/hooks/useSSRPolyfills";
@@ -50,6 +52,8 @@ export interface UseExperimentDimensionRowsParams {
   dimensionValuesFilter?: string[];
   showErrorsOnQuantileMetrics?: boolean;
   pValueThreshold: number;
+  // Structured per-metric errors from the snapshot analysis, keyed by metricId.
+  metricErrors?: Record<string, MetricError>;
 }
 
 export interface UseExperimentDimensionRowsReturn {
@@ -79,6 +83,7 @@ export function useExperimentDimensionRows({
   dimensionValuesFilter,
   showErrorsOnQuantileMetrics = false,
   pValueThreshold,
+  metricErrors,
 }: UseExperimentDimensionRowsParams): UseExperimentDimensionRowsReturn {
   const { getExperimentMetricById, metricGroups, ready } = useDefinitions();
   const { metricDefaults } = useOrganizationMetricDefaults();
@@ -360,6 +365,7 @@ export function useExperimentDimensionRows({
             overrideFields,
             metricSnapshotSettings: _metricSnapshotSettings,
             newMetric,
+            metricErrors,
           });
 
           return {
@@ -419,6 +425,7 @@ export function useExperimentDimensionRows({
     expandedSecondaries,
     expandedGuardrails,
     showErrorsOnQuantileMetrics,
+    metricErrors,
   ]);
 
   return {
@@ -459,6 +466,7 @@ export function generateDimensionRowsForMetric({
   overrideFields,
   metricSnapshotSettings,
   newMetric,
+  metricErrors,
 }: {
   metricId: string;
   resultGroup: "goal" | "secondary" | "guardrail";
@@ -467,6 +475,7 @@ export function generateDimensionRowsForMetric({
   overrideFields: string[];
   metricSnapshotSettings: MetricSnapshotSettings | undefined;
   newMetric: ExperimentMetricDefinition;
+  metricErrors?: Record<string, MetricError>;
 }): ExperimentTableRow[] {
   const filteredResults = includeVariation(results, dimensionValuesFilter);
 
@@ -474,23 +483,28 @@ export function generateDimensionRowsForMetric({
 
   // Create a row for each dimension result
   filteredResults.forEach((dimensionResult) => {
+    const variations = dimensionResult.variations.map((v) => {
+      return (
+        v.metrics?.[metricId] || {
+          users: 0,
+          value: 0,
+          cr: 0,
+          errorMessage: "No data",
+        }
+      );
+    });
     const row: ExperimentTableRow = {
       label: dimensionResult.name,
       metric: newMetric,
       metricOverrideFields: overrideFields,
       rowClass: newMetric?.inverse ? "inverse" : "",
-      variations: dimensionResult.variations.map((v) => {
-        return (
-          v.metrics?.[metricId] || {
-            users: 0,
-            value: 0,
-            cr: 0,
-            errorMessage: "No data",
-          }
-        );
-      }),
+      variations,
       metricSnapshotSettings,
       resultGroup,
+      metricError: resolveMetricRowError({
+        metricId,
+        metricErrors,
+      }),
     };
 
     rows.push(row);

--- a/packages/front-end/hooks/useExperimentTableRows.ts
+++ b/packages/front-end/hooks/useExperimentTableRows.ts
@@ -25,6 +25,7 @@ import {
   isMetricGroupId,
 } from "shared/experiments";
 import { MetricGroupInterface } from "shared/types/metric-groups";
+import { MetricError, SnapshotMetric } from "shared/types/experiment-snapshot";
 import { isDefined } from "shared/util";
 import { useDefinitions } from "@/services/DefinitionsContext";
 
@@ -38,6 +39,7 @@ const METRIC_SELECTOR_IDS = [
 import {
   applyMetricOverrides,
   ExperimentTableRow,
+  resolveMetricRowError,
 } from "@/services/experiments";
 import { SSRPolyfills } from "@/hooks/useSSRPolyfills";
 import { useTableSorting } from "@/hooks/useTableSorting";
@@ -71,6 +73,8 @@ export interface UseExperimentTableRowsParams {
   enableExpansion?: boolean;
   expandedMetrics: Record<string, boolean>;
   pValueThreshold: number;
+  // Structured per-metric errors from the snapshot analysis, keyed by metricId.
+  metricErrors?: Record<string, MetricError>;
 }
 
 export interface UseExperimentTableRowsReturn {
@@ -100,6 +104,7 @@ export function useExperimentTableRows({
   enableExpansion: _enableExpansion = true,
   expandedMetrics,
   pValueThreshold,
+  metricErrors,
 }: UseExperimentTableRowsParams): UseExperimentTableRowsReturn {
   const {
     getExperimentMetricById: _getExperimentMetricById,
@@ -297,6 +302,7 @@ export function useExperimentTableRows({
         getExperimentMetricById,
         getFactTableById,
         sliceTagsFilter,
+        metricErrors,
       });
     }
 
@@ -433,6 +439,7 @@ export function useExperimentTableRows({
     customMetricSlices,
     sortBy,
     customMetricOrder,
+    metricErrors,
   ]);
 
   // Apply sorting using the reusable useTableSorting hook
@@ -468,6 +475,7 @@ export function generateRowsForMetric({
   getExperimentMetricById,
   getFactTableById,
   sliceTagsFilter,
+  metricErrors,
 }: {
   metricId: string;
   resultGroup: "goal" | "secondary" | "guardrail";
@@ -485,6 +493,7 @@ export function generateRowsForMetric({
   getExperimentMetricById: (id: string) => ExperimentMetricDefinition | null;
   getFactTableById: (id: string) => FactTableDefinition | null;
   sliceTagsFilter?: string[];
+  metricErrors?: Record<string, MetricError>;
 }): ExperimentTableRow[] {
   const resultsArray = Array.isArray(results) ? results : [results];
   const metric = getExperimentMetricById(metricId);
@@ -547,32 +556,40 @@ export function generateRowsForMetric({
     numSlices > 0 &&
     !sliceTagsFilter.includes("overall");
 
+  const parentVariations: SnapshotMetric[] = isLabelOnly
+    ? resultsArray[0].variations.map(() => ({
+        users: 0,
+        value: 0,
+        cr: 0,
+        errorMessage: "No data",
+      }))
+    : resultsArray[0].variations.map((v) => {
+        return (
+          v.metrics?.[metricId] || {
+            users: 0,
+            value: 0,
+            cr: 0,
+            errorMessage: "No data",
+          }
+        );
+      });
+
+  const metricError = resolveMetricRowError({
+    metricId,
+    metricErrors,
+  });
+
   const parentRow: ExperimentTableRow = {
     label: newMetric?.name,
     metric: newMetric,
     metricOverrideFields: overrideFields,
     rowClass: newMetric?.inverse ? "inverse" : "",
-    variations: isLabelOnly
-      ? resultsArray[0].variations.map(() => ({
-          users: 0,
-          value: 0,
-          cr: 0,
-          errorMessage: "No data",
-        }))
-      : resultsArray[0].variations.map((v) => {
-          return (
-            v.metrics?.[metricId] || {
-              users: 0,
-              value: 0,
-              cr: 0,
-              errorMessage: "No data",
-            }
-          );
-        }),
+    variations: parentVariations,
     metricSnapshotSettings,
     resultGroup,
     numSlices,
     labelOnly: isLabelOnly,
+    metricError,
   };
 
   const rows: ExperimentTableRow[] = [];
@@ -672,6 +689,10 @@ export function generateRowsForMetric({
         resultGroup,
         numSlices: 0,
         isSliceRow: true,
+        metricError: resolveMetricRowError({
+          metricId: slice.id,
+          metricErrors,
+        }),
         parentRowId: metricId,
         sliceLevels: slice.sliceLevels.map((dl) => ({
           column: dl.column,

--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -1,4 +1,5 @@
-import { SnapshotMetric } from "shared/types/experiment-snapshot";
+import { MetricError, SnapshotMetric } from "shared/types/experiment-snapshot";
+import { Queries } from "shared/types/query";
 import { DifferenceType, StatsEngine } from "shared/types/stats";
 import {
   ExperimentReportVariation,
@@ -168,6 +169,87 @@ export function experimentDate(exp: ExperimentInterfaceStringDates): string {
   );
 }
 
+export type SnapshotMetricFailureSummary = {
+  /** Distinct metrics that failed somewhere in the pipeline. */
+  failedCount: number;
+  /** Metrics the snapshot set out to analyze. */
+  totalCount: number;
+};
+
+/**
+ * Counts the metrics in the analysis's authoritative error map.
+ */
+export function getSnapshotMetricFailureSummary({
+  metricErrors,
+  snapshotMetricIds,
+}: {
+  metricErrors?: Record<string, MetricError>;
+  snapshotMetricIds: string[];
+}): SnapshotMetricFailureSummary {
+  const failed = new Set<string>(Object.keys(metricErrors ?? {}));
+
+  return {
+    failedCount: failed.size,
+    // Guard against an id that failed but is missing from the snapshot's metric
+    // list, so the summary can never read "3 of 2 metrics failed".
+    totalCount: Math.max(new Set(snapshotMetricIds).size, failed.size),
+  };
+}
+
+/**
+ * Resolves the structured error to render on a metric's row. Shared by the main
+ * and dimension row hooks so every results surface uses the same source.
+ */
+export function resolveMetricRowError({
+  metricId,
+  metricErrors,
+}: {
+  metricId: string;
+  metricErrors?: Record<string, MetricError>;
+}): MetricError | undefined {
+  return metricErrors?.[metricId];
+}
+
+/**
+ * Uses the persisted analysis map when present. For snapshots created before
+ * that map existed, reconstruct the old failed-query indication from query
+ * pointers (or their names when only aggregate status data is available).
+ */
+export function getMetricErrorsForDisplay({
+  metricErrors,
+  queries,
+  failedQueryNames,
+}: {
+  metricErrors?: Record<string, MetricError>;
+  queries?: Queries;
+  failedQueryNames?: string[];
+}): Record<string, MetricError> | undefined {
+  if (metricErrors !== undefined) return metricErrors;
+
+  const fallbackErrors: Record<string, MetricError> = {};
+  queries
+    ?.filter((query) => query.status === "failed")
+    .forEach((query) => {
+      const metricIds = query.metrics ?? [query.name];
+      metricIds.forEach((metricId) => {
+        fallbackErrors[metricId] = {
+          type: "query",
+          message: query.error
+            ? `Query failed: ${query.error}`
+            : "Query failed",
+        };
+      });
+    });
+  failedQueryNames?.forEach((metricId) => {
+    fallbackErrors[metricId] ??= {
+      type: "query",
+      message: "Query failed",
+    };
+  });
+
+  return Object.keys(fallbackErrors).length ? fallbackErrors : undefined;
+}
+
 /**
  * Returns the `statusUpdateSchedule.startAt` Date for an experiment if it
  * parses to a future date, otherwise null. Past-dated and missing schedules
@@ -192,6 +274,11 @@ export type ExperimentTableRow = {
   metricSnapshotSettings?: MetricSnapshotSettings;
   resultGroup: "goal" | "secondary" | "guardrail";
   error?: RowError;
+  // Structured per-metric error sourced from the snapshot analysis
+  // (`ExperimentSnapshotAnalysis.metricErrors`), carrying
+  // the chained root-cause message and its class so the UI can show specific
+  // copy instead of inferring failures by string-matching query names.
+  metricError?: MetricError;
   numSlices?: number;
   // Slice row properties
   isSliceRow?: boolean;

--- a/packages/front-end/test/services/metricRowError.test.ts
+++ b/packages/front-end/test/services/metricRowError.test.ts
@@ -1,0 +1,73 @@
+import {
+  getMetricErrorsForDisplay,
+  resolveMetricRowError,
+} from "@/services/experiments";
+
+describe("resolveMetricRowError", () => {
+  it("prefers the metricErrors map", () => {
+    expect(
+      resolveMetricRowError({
+        metricId: "met_a",
+        metricErrors: {
+          met_a: { type: "query", message: "Query failed: timeout" },
+        },
+      }),
+    ).toEqual({ type: "query", message: "Query failed: timeout" });
+  });
+
+  it("returns undefined when nothing failed", () => {
+    expect(
+      resolveMetricRowError({
+        metricId: "met_a",
+        metricErrors: { met_b: { type: "query", message: "Query failed" } },
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("getMetricErrorsForDisplay", () => {
+  it("treats an existing analysis map as authoritative", () => {
+    expect(
+      getMetricErrorsForDisplay({
+        metricErrors: {},
+        queries: [
+          {
+            query: "qry_group",
+            name: "group_0",
+            status: "failed",
+            metrics: ["met_a", "met_b"],
+          },
+        ],
+      }),
+    ).toEqual({});
+  });
+
+  it("reconstructs metric errors from legacy failed query pointers", () => {
+    expect(
+      getMetricErrorsForDisplay({
+        queries: [
+          {
+            query: "qry_group",
+            name: "group_0",
+            status: "failed",
+            error: "warehouse timeout",
+            metrics: ["met_a", "met_b"],
+          },
+        ],
+      }),
+    ).toEqual({
+      met_a: { type: "query", message: "Query failed: warehouse timeout" },
+      met_b: { type: "query", message: "Query failed: warehouse timeout" },
+    });
+  });
+
+  it("falls back to failed query names for older snapshots", () => {
+    expect(
+      getMetricErrorsForDisplay({
+        failedQueryNames: ["met_a"],
+      }),
+    ).toEqual({
+      met_a: { type: "query", message: "Query failed" },
+    });
+  });
+});

--- a/packages/front-end/test/services/snapshotMetricFailures.test.ts
+++ b/packages/front-end/test/services/snapshotMetricFailures.test.ts
@@ -1,0 +1,44 @@
+import { getSnapshotMetricFailureSummary } from "@/services/experiments";
+
+describe("getSnapshotMetricFailureSummary", () => {
+  it("counts nothing when no metric failed", () => {
+    expect(
+      getSnapshotMetricFailureSummary({
+        snapshotMetricIds: ["met_a", "met_b"],
+      }),
+    ).toEqual({ failedCount: 0, totalCount: 2 });
+  });
+
+  it("counts metrics that never produced a result, from the metricErrors map", () => {
+    expect(
+      getSnapshotMetricFailureSummary({
+        metricErrors: {
+          met_a: { type: "query", message: "Query failed: timeout" },
+          met_b: { type: "build", message: "Failed to build query: bad SQL" },
+        },
+        snapshotMetricIds: ["met_a", "met_b", "met_c"],
+      }),
+    ).toEqual({ failedCount: 2, totalCount: 3 });
+  });
+
+  it("never reports more failures than the total", () => {
+    // A failed id missing from the snapshot's metric list would otherwise read
+    // as "2 of 1 metrics failed".
+    expect(
+      getSnapshotMetricFailureSummary({
+        metricErrors: {
+          met_a: { type: "query", message: "Query failed: timeout" },
+          met_gone: { type: "query", message: "Query failed: timeout" },
+        },
+        snapshotMetricIds: ["met_a"],
+      }),
+    ).toEqual({ failedCount: 2, totalCount: 2 });
+  });
+
+  it("handles a snapshot with no analysis yet", () => {
+    expect(getSnapshotMetricFailureSummary({ snapshotMetricIds: [] })).toEqual({
+      failedCount: 0,
+      totalCount: 0,
+    });
+  });
+});

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -910,6 +910,29 @@ export const apiExperimentResultsValidator = namedSchema(
       settings: apiExperimentAnalysisSettingsValidator,
       queryIds: z.array(z.string()),
       queryStatus: apiSnapshotQueryStatus.optional(),
+      metricErrors: z
+        .array(
+          z.object({
+            metricId: z.string(),
+            metricName: z.string().optional(),
+            type: z
+              .enum([
+                "query",
+                "build",
+                "analysis",
+                "dependency",
+                "config-drift",
+              ])
+              .describe(
+                "Which stage failed. `query` the metric's warehouse query failed, `build` its query could not be generated, `analysis` its statistics failed, `dependency` an upstream query it needed failed, `config-drift` the metric changed or was deleted after the query started.",
+              ),
+            message: z.string(),
+          }),
+        )
+        .describe(
+          "Metrics that produced no results, and why each one failed. A metric listed here is absent from `results`.",
+        )
+        .optional(),
       results: z.array(
         z.object({
           dimension: z.string(),

--- a/packages/shared/src/validators/safe-rollout-snapshot.ts
+++ b/packages/shared/src/validators/safe-rollout-snapshot.ts
@@ -212,6 +212,21 @@ const safeRolloutSnapshotAnalysisObject = z.object({
   dateCreated: z.date(),
   status: z.enum(["running", "success", "error"]),
   error: z.string().optional(),
+  metricErrors: z
+    .record(
+      z.string(),
+      z.object({
+        type: z.enum([
+          "query",
+          "build",
+          "analysis",
+          "dependency",
+          "config-drift",
+        ]),
+        message: z.string(),
+      }),
+    )
+    .optional(),
   results: z.array(safeRolloutReportResultDimensionObject),
 });
 

--- a/packages/shared/types/experiment-snapshot.d.ts
+++ b/packages/shared/types/experiment-snapshot.d.ts
@@ -33,6 +33,27 @@ import {
   LookbackOverride,
 } from "./experiment";
 
+/**
+ * Class of a per-metric failure, used by the UI to pick copy:
+ * - `query`: the metric's warehouse query failed at runtime
+ * - `build`: the metric's query failed to build (SQL generation threw)
+ * - `analysis`: the metric's analysis math failed inside gbstats
+ * - `dependency`: an upstream query the metric depends on failed (cascade)
+ * - `config-drift`: the metric changed or disappeared after its query started
+ */
+export type MetricErrorType =
+  | "query"
+  | "build"
+  | "analysis"
+  | "dependency"
+  | "config-drift";
+
+export interface MetricError {
+  type: MetricErrorType;
+  /** Human-readable detail, chained up to the metric (e.g. "Query failed: …"). */
+  message: string;
+}
+
 export interface SnapshotMetric {
   value: number;
   cr: number;
@@ -162,6 +183,8 @@ export interface ExperimentSnapshotAnalysis {
   dateCreated: Date;
   status: "running" | "success" | "error";
   error?: string;
+  // Per-metric errors for this analysis. Keyed by metricId.
+  metricErrors?: Record<string, MetricError>;
   results: ExperimentReportResultDimension[];
 }
 
@@ -325,6 +348,7 @@ export type ExperimentMetricAnalysisContext = {
 export type ExperimentMetricAnalysisData = {
   analysisObj: ExperimentSnapshotAnalysis;
   unknownVariations: string[];
+  metricErrors: Record<string, MetricError>;
 };
 
 export type ExperimentAnalysisParamsContextData = {

--- a/packages/shared/types/report.d.ts
+++ b/packages/shared/types/report.d.ts
@@ -16,7 +16,7 @@ import {
   Variation,
   ExperimentAnalysisSettings,
 } from "./experiment";
-import { SnapshotVariation } from "./experiment-snapshot";
+import { MetricError, SnapshotVariation } from "./experiment-snapshot";
 import { Queries } from "./query";
 import { DifferenceType, StatsEngine } from "./stats";
 
@@ -151,6 +151,7 @@ export interface ExperimentReportResults {
   unknownVariations: string[];
   multipleExposures: number;
   dimensions: ExperimentReportResultDimension[];
+  metricErrors?: Record<string, MetricError>;
 }
 
 export type ReportInterface =


### PR DESCRIPTION
### Features and Changes

A metric whose query failed simply vanished from the results. Nothing distinguished "this metric has no data" from "this metric's query errored", and nothing said which metric a snapshot-level error belonged to.

- Each analysis now carries `metricErrors`, a `Record<metricId, MetricError>` whose `type` is the stage that failed: `query`, `build`, `dependency`, `analysis`, or `config-drift`.
- `getMetricsAndQueryDataForStatsEngine` builds these from the query pointers, using the ownership metadata to attribute a failed fact-metric group to each metric in it. A failed single-metric query no longer pushes blank rows to gbstats, which would have read as a legitimate empty result. A query that succeeded with zero rows still counts as empty, not failed.
- The map is persisted on experiment snapshot analyses, safe-rollout snapshot analyses, and report results, and rendered inline on the metric's row across the results table, breakdowns, the drilldown modal, and the dashboard blocks.
- Failed metrics stay out of `results[].metrics[]` on purpose. That array is built from ids found in the result rows, and `safeFloat` turns a missing number into `0`, so listing them there would report a genuine zero. A caller reads `metricErrors` to learn a metric is absent and why.
- Public API: `ExperimentResults` gains an optional `metricErrors` (`{metricId, metricName, type, message}[]`), reaching all six endpoints that return results through one mapper.

### Testing

- `pnpm type-check`
- `packages/back-end/test/services/stats.test.ts`, the front-end row-error tests, and `test/api/experiments.test.ts` asserting a failed metric appears in `metricErrors` and not as a zero row
