### PR TITLE
fix(experiments): isolate health step failures from metric results

### DIFF
--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -170,18 +170,28 @@ const experimentSnapshotSchema = new mongoose.Schema({
       power: Number,
       isLowPowered: Boolean,
       additionalDaysNeeded: Number,
-      metricVariationPowerResults: [
-        {
-          _id: false,
-          metricId: String,
-          variation: Number,
-          errorMessage: String,
-          power: Number,
-          isLowPowered: Boolean,
-          effectSize: Number,
-          additionalDaysNeeded: Number,
-        },
-      ],
+      // Why the power calculation itself reported failure (type: "error").
+      errorMessage: String,
+      // Without `default: undefined` Mongoose materializes this array as `[]`
+      // on read, which materializes `health.power` itself — so a snapshot with
+      // no power result reads back as `{metricVariationPowerResults: []}` and
+      // every `power !== undefined` check (PowerCard, decision criteria) is
+      // wrong. Keep the field absent when nothing was stored.
+      metricVariationPowerResults: {
+        type: [
+          {
+            _id: false,
+            metricId: String,
+            variation: Number,
+            errorMessage: String,
+            power: Number,
+            isLowPowered: Boolean,
+            effectSize: Number,
+            additionalDaysNeeded: Number,
+          },
+        ],
+        default: undefined,
+      },
     },
     covariateImbalance: {
       _id: false,
@@ -193,22 +203,34 @@ const experimentSnapshotSchema = new mongoose.Schema({
       numGuardrailMetricsImbalanced: Number,
       numSecondaryMetrics: Number,
       numSecondaryMetricsImbalanced: Number,
-      metricVariationCovariateImbalanceResults: [
-        {
-          _id: false,
-          metricId: String,
-          variation: Number,
-          isImbalanced: Boolean,
-          baselineSampleSize: Number,
-          variationSampleSize: Number,
-          baselineMean: Number,
-          variationMean: Number,
-          baselineStandardError: Number,
-          variationStandardError: Number,
-          pValue: Number,
-          errorMessage: String,
-        },
-      ],
+      // See metricVariationPowerResults above for why `default: undefined` is
+      // required here too.
+      metricVariationCovariateImbalanceResults: {
+        type: [
+          {
+            _id: false,
+            metricId: String,
+            variation: Number,
+            isImbalanced: Boolean,
+            baselineSampleSize: Number,
+            variationSampleSize: Number,
+            baselineMean: Number,
+            variationMean: Number,
+            baselineStandardError: Number,
+            variationStandardError: Number,
+            pValue: Number,
+            errorMessage: String,
+          },
+        ],
+        default: undefined,
+      },
+    },
+    // Why an isolated health step produced no result (the step threw). Keyed by
+    // step name; the matching result field above is absent when set.
+    stepErrors: {
+      _id: false,
+      power: String,
+      covariateImbalance: String,
     },
   },
   hasRawQueries: Boolean,

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -41,10 +41,7 @@ import {
 import { SourceIntegrationInterface } from "back-end/src/types/Integration";
 import { FactTableMap } from "back-end/src/models/FactTableModel";
 import { updateReport } from "back-end/src/models/ReportModel";
-import {
-  analyzeExperimentResults,
-  analyzeExperimentTraffic,
-} from "back-end/src/services/stats";
+import { analyzeExperimentResults } from "back-end/src/services/stats";
 import {
   getExperimentSettingsHashForIncrementalRefresh,
   getMetricSettingsHashForIncrementalRefresh,
@@ -76,6 +73,10 @@ import {
   getMetricQueryOwnership,
 } from "./QueryRunner";
 import { shouldRunHealthTrafficQuery } from "./snapshotQueryHelpers";
+import {
+  runIsolatedAnalysisStep,
+  runTrafficAnalysisStep,
+} from "./analysisSteps";
 import {
   getIncrementalCrossStatisticsQueryName,
   getIncrementalStatisticsQueryName,
@@ -1328,9 +1329,10 @@ export class ExperimentIncrementalRefreshQueryRunner extends QueryRunner<
     if (healthQuery) {
       const rows =
         healthQuery.result as ExperimentAggregateUnitsQueryResponseRows;
-      const trafficHealth = analyzeExperimentTraffic({
-        rows: rows,
-        error: healthQuery.error,
+      const { traffic: trafficHealth } = runTrafficAnalysisStep({
+        modelId: this.model.id,
+        rows,
+        queryError: healthQuery.error,
         variations: this.model.settings.variations,
       });
 
@@ -1377,13 +1379,26 @@ export class ExperimentIncrementalRefreshQueryRunner extends QueryRunner<
       const isEligibleForCovariateImbalanceAnalysis =
         !!analysisForCovariateImbalance;
       if (isEligibleForCovariateImbalanceAnalysis) {
-        result.health.covariateImbalance = tabulateCovariateImbalance(
-          analysisForCovariateImbalance,
-          this.model.settings.goalMetrics,
-          this.model.settings.guardrailMetrics,
-          this.model.settings.secondaryMetrics,
-          this.model.settings.metricSettings,
-        );
+        const covariateStep = runIsolatedAnalysisStep({
+          step: "covariateImbalance",
+          modelId: this.model.id,
+          run: () =>
+            tabulateCovariateImbalance(
+              analysisForCovariateImbalance,
+              this.model.settings.goalMetrics,
+              this.model.settings.guardrailMetrics,
+              this.model.settings.secondaryMetrics,
+              this.model.settings.metricSettings,
+            ),
+        });
+        if (covariateStep.error === null) {
+          result.health.covariateImbalance = covariateStep.value;
+        } else {
+          result.health.stepErrors = {
+            ...result.health.stepErrors,
+            covariateImbalance: covariateStep.error,
+          };
+        }
       }
     }
 

--- a/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
@@ -51,10 +51,7 @@ import {
   getFactMetricGroups,
 } from "back-end/src/services/experimentQueries/experimentQueries";
 import { parseDimension } from "back-end/src/services/experiments";
-import {
-  analyzeExperimentResults,
-  analyzeExperimentTraffic,
-} from "back-end/src/services/stats";
+import { analyzeExperimentResults } from "back-end/src/services/stats";
 import { SourceIntegrationInterface } from "back-end/src/types/Integration";
 import { expandDenominatorMetrics } from "back-end/src/util/sql";
 import { FactTableMap } from "back-end/src/models/FactTableModel";
@@ -70,6 +67,10 @@ import {
   getMetricQueryOwnership,
 } from "./QueryRunner";
 import { shouldRunHealthTrafficQuery } from "./snapshotQueryHelpers";
+import {
+  runIsolatedAnalysisStep,
+  runTrafficAnalysisStep,
+} from "./analysisSteps";
 import { getUnitDimQueryName } from "./unitDimensionQueryNaming";
 export type SnapshotResult = {
   unknownVariations: string[];
@@ -637,16 +638,19 @@ export class ExperimentResultsQueryRunner extends QueryRunner<
       result.multipleExposures = results.multipleExposures ?? 0;
     });
 
-    // Run health checks
+    // Run health checks. Each step below is isolated: its failure is recorded on
+    // its own block so it cannot discard the metric results assembled above.
     const healthQuery = queryMap.get(TRAFFIC_QUERY_NAME);
     if (healthQuery) {
       const rows =
         healthQuery.result as ExperimentAggregateUnitsQueryResponseRows;
-      const trafficHealth = analyzeExperimentTraffic({
-        rows: rows,
-        error: healthQuery.error,
-        variations: this.model.settings.variations,
-      });
+      const { traffic: trafficHealth, error: trafficError } =
+        runTrafficAnalysisStep({
+          modelId: this.model.id,
+          rows,
+          queryError: healthQuery.error,
+          variations: this.model.settings.variations,
+        });
 
       result.health = {
         traffic: trafficHealth,
@@ -660,7 +664,10 @@ export class ExperimentResultsQueryRunner extends QueryRunner<
         relativeAnalysis &&
         this.model.settings.banditSettings === undefined &&
         rows &&
-        rows.length;
+        rows.length &&
+        // Power is computed from the traffic health; skip it rather than derive
+        // power from the zero-filled placeholder above.
+        trafficError === null;
 
       if (isEligibleForMidExperimentPowerAnalysis) {
         const today = new Date();
@@ -676,13 +683,26 @@ export class ExperimentResultsQueryRunner extends QueryRunner<
         );
         const targetDaysRemaining = daysBetween(today, experimentTargetEndDate);
         // NB: This does not run a SQL query, but it is a health check that depends on the trafficHealth
-        result.health.power = analyzeExperimentPower({
-          trafficHealth,
-          targetDaysRemaining,
-          analysis: relativeAnalysis,
-          goalMetrics: this.model.settings.goalMetrics,
-          variationsSettings: this.model.settings.variations,
+        const powerStep = runIsolatedAnalysisStep({
+          step: "power",
+          modelId: this.model.id,
+          run: () =>
+            analyzeExperimentPower({
+              trafficHealth,
+              targetDaysRemaining,
+              analysis: relativeAnalysis,
+              goalMetrics: this.model.settings.goalMetrics,
+              variationsSettings: this.model.settings.variations,
+            }),
         });
+        if (powerStep.error === null) {
+          result.health.power = powerStep.value;
+        } else {
+          result.health.stepErrors = {
+            ...result.health.stepErrors,
+            power: powerStep.error,
+          };
+        }
       }
       const analysisForCovariateImbalance = this.model.analyses.find(
         (a) => a.settings.useCovariateAsResponse === true,
@@ -690,13 +710,26 @@ export class ExperimentResultsQueryRunner extends QueryRunner<
       const isEligibleForCovariateImbalanceAnalysis =
         !!analysisForCovariateImbalance;
       if (isEligibleForCovariateImbalanceAnalysis) {
-        result.health.covariateImbalance = tabulateCovariateImbalance(
-          analysisForCovariateImbalance,
-          this.model.settings.goalMetrics,
-          this.model.settings.guardrailMetrics,
-          this.model.settings.secondaryMetrics,
-          this.model.settings.metricSettings,
-        );
+        const covariateStep = runIsolatedAnalysisStep({
+          step: "covariateImbalance",
+          modelId: this.model.id,
+          run: () =>
+            tabulateCovariateImbalance(
+              analysisForCovariateImbalance,
+              this.model.settings.goalMetrics,
+              this.model.settings.guardrailMetrics,
+              this.model.settings.secondaryMetrics,
+              this.model.settings.metricSettings,
+            ),
+        });
+        if (covariateStep.error === null) {
+          result.health.covariateImbalance = covariateStep.value;
+        } else {
+          result.health.stepErrors = {
+            ...result.health.stepErrors,
+            covariateImbalance: covariateStep.error,
+          };
+        }
       }
     }
     return result;

--- a/packages/back-end/src/queryRunners/SafeRolloutResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/SafeRolloutResultsQueryRunner.ts
@@ -10,12 +10,10 @@ import {
 } from "shared/validators";
 import { FactTableMap } from "back-end/src/models/FactTableModel";
 import { getSnapshotSettingsFromSafeRolloutArgs } from "back-end/src/services/safeRolloutSnapshots";
-import {
-  analyzeExperimentResults,
-  analyzeExperimentTraffic,
-} from "back-end/src/services/stats";
+import { analyzeExperimentResults } from "back-end/src/services/stats";
 import { logger } from "back-end/src/util/logger";
 import { QueryRunner, QueryMap, getMetricQueryOwnership } from "./QueryRunner";
+import { runTrafficAnalysisStep } from "./analysisSteps";
 import {
   ExperimentResultsQueryParams,
   getExperimentResultsQueryStatus,
@@ -141,15 +139,14 @@ export class SafeRolloutResultsQueryRunner extends QueryRunner<
     if (healthQuery) {
       const rows =
         healthQuery.result as ExperimentAggregateUnitsQueryResponseRows;
-      const trafficHealth = analyzeExperimentTraffic({
-        rows: rows,
-        error: healthQuery.error,
+      const { traffic } = runTrafficAnalysisStep({
+        modelId: this.model.id,
+        rows,
+        queryError: healthQuery.error,
         variations: this.model.settings.variations,
       });
 
-      result.health = {
-        traffic: trafficHealth,
-      };
+      result.health = { traffic };
     }
     // TODO: Add functionality to dynamically update coverage here
     return result;

--- a/packages/back-end/src/queryRunners/analysisSteps.ts
+++ b/packages/back-end/src/queryRunners/analysisSteps.ts
@@ -1,0 +1,100 @@
+import { ExperimentAggregateUnitsQueryResponseRows } from "shared/types/integrations";
+import {
+  ExperimentSnapshotTraffic,
+  SnapshotSettingsVariation,
+} from "shared/types/experiment-snapshot";
+import { analyzeExperimentTraffic } from "back-end/src/services/stats";
+import { logger } from "back-end/src/util/logger";
+
+/**
+ * Outcome of one isolated `runAnalysis` step. `error === null` is the success
+ * discriminator, so a step whose own return type includes `undefined` (e.g.
+ * `analyzeExperimentPower`) is still distinguishable from a failure.
+ */
+export type AnalysisStepResult<T> =
+  | { value: T; error: null }
+  | { value: null; error: string };
+
+/**
+ * Run one step of a runner's `runAnalysis` in isolation.
+ *
+ * `runAnalysis` assembles its result from several independent steps (metric
+ * analysis, then traffic/health, power, covariate imbalance). They all used to
+ * run inline, so a throw in a *later* step discarded the result of every earlier
+ * one — a power or covariate-imbalance bug threw away metric results that had
+ * already computed successfully, and failed the whole snapshot with them
+ * (design Q7).
+ *
+ * Wrapping a step here converts its throw into a value the caller records on
+ * that step's own block, leaving the rest of the result intact. The failure is
+ * logged with the model id so it is still diagnosable in ops.
+ *
+ * Deliberately *not* used for the metric-analysis step: if that throws there are
+ * no results to persist, so it stays fatal to the snapshot (see the callers).
+ *
+ * Steps are synchronous CPU work in all three runners, so this is sync too.
+ */
+export function runIsolatedAnalysisStep<T>({
+  step,
+  modelId,
+  run,
+}: {
+  /** Step name, used only for the log line. */
+  step: string;
+  modelId: string;
+  run: () => T;
+}): AnalysisStepResult<T> {
+  try {
+    return { value: run(), error: null };
+  } catch (e) {
+    logger.error(e, `${modelId} runner: "${step}" analysis step failed`);
+    return {
+      value: null,
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+/**
+ * The traffic/health step, isolated. Shared by all three runners because
+ * `ExperimentSnapshotHealth.traffic` is non-optional: on failure the block still
+ * has to exist, so it is re-derived from the step's own error — which produces
+ * exactly the empty-with-error shape `analyzeExperimentTraffic` already returns
+ * for a *failed traffic query*, and which the Health tab already renders.
+ *
+ * `error` is non-null when the step itself threw; callers use it to skip work
+ * derived from the traffic health (power analysis in particular) rather than
+ * computing it from the zero-filled placeholder.
+ */
+export function runTrafficAnalysisStep({
+  modelId,
+  rows,
+  queryError,
+  variations,
+}: {
+  modelId: string;
+  rows: ExperimentAggregateUnitsQueryResponseRows;
+  /** Error of the traffic query itself, which `analyzeExperimentTraffic` folds into its result. */
+  queryError?: string;
+  variations: SnapshotSettingsVariation[];
+}): { traffic: ExperimentSnapshotTraffic; error: string | null } {
+  const step = runIsolatedAnalysisStep({
+    step: "traffic",
+    modelId,
+    run: () =>
+      analyzeExperimentTraffic({ rows, error: queryError, variations }),
+  });
+
+  if (step.error === null) return { traffic: step.value, error: null };
+
+  return {
+    // Safe from re-throwing: given an error, analyzeExperimentTraffic returns
+    // before it looks at `rows` at all.
+    traffic: analyzeExperimentTraffic({
+      rows: [],
+      error: step.error,
+      variations,
+    }),
+    error: step.error,
+  };
+}

--- a/packages/back-end/test/queryRunners/ExperimentResultsQueryRunner.test.ts
+++ b/packages/back-end/test/queryRunners/ExperimentResultsQueryRunner.test.ts
@@ -477,6 +477,68 @@ describe("ExperimentResultsQueryRunner.runAnalysis step isolation", () => {
     });
   });
 
+  it("keeps metric results when the power and covariate steps both throw, recording each error on its own block", async () => {
+    mockedAnalyzeExperimentPower.mockImplementation(() => {
+      throw new Error("Cannot read properties of undefined");
+    });
+    mockedTabulateCovariateImbalance.mockImplementation(() => {
+      throw new Error("covariate tabulation failed");
+    });
+
+    const model = makeSnapshotModel();
+    const result = await makeRunner(model).runAnalysis(makeQueryMap());
+
+    // The metric results (and their per-metric errors) survive both throws.
+    expect(result.analyses[0].results).toEqual([METRIC_DIMENSION]);
+    expect(result.analyses[0].status).toBe("success");
+    expect(result.analyses[0].metricErrors).toEqual({
+      met_2: { type: "query", message: "Query failed: boom" },
+    });
+
+    // Traffic still computed; each failed step is absent but explained.
+    expect(result.health?.traffic).toEqual(TRAFFIC_HEALTH);
+    expect(result.health?.power).toBeUndefined();
+    expect(result.health?.covariateImbalance).toBeUndefined();
+    expect(result.health?.stepErrors).toEqual({
+      power: "Cannot read properties of undefined",
+      covariateImbalance: "covariate tabulation failed",
+    });
+  });
+
+  it("keeps metric results when the traffic step throws, recording the error on the traffic block and skipping power", async () => {
+    mockedAnalyzeExperimentTraffic.mockImplementation(
+      ({ error }: { error?: string }) => {
+        // Mirrors the real function, which returns early when given an error.
+        if (error) return { ...TRAFFIC_HEALTH, error };
+        throw new Error("traffic aggregation failed");
+      },
+    );
+
+    const model = makeSnapshotModel();
+    const result = await makeRunner(model).runAnalysis(makeQueryMap());
+
+    expect(result.analyses[0].results).toEqual([METRIC_DIMENSION]);
+    expect(result.health?.traffic.error).toBe("traffic aggregation failed");
+    // Power is derived from the traffic health, so it is skipped rather than
+    // computed from the placeholder — and it is not reported as its own failure.
+    expect(mockedAnalyzeExperimentPower).not.toHaveBeenCalled();
+    expect(result.health?.power).toBeUndefined();
+    expect(result.health?.stepErrors).toBeUndefined();
+  });
+
+  it("still computes every step when nothing throws", async () => {
+    const model = makeSnapshotModel();
+    const result = await makeRunner(model).runAnalysis(makeQueryMap());
+
+    expect(result.analyses[0].results).toEqual([METRIC_DIMENSION]);
+    expect(result.health?.traffic).toEqual(TRAFFIC_HEALTH);
+    expect(result.health?.power).toMatchObject({ type: "success" });
+    expect(result.health?.covariateImbalance).toMatchObject({
+      isImbalanced: false,
+    });
+    expect(result.health?.stepErrors).toBeUndefined();
+  });
+
   it("still analyzes metrics when recomputing fact-metric group membership throws", async () => {
     mockedGetFactMetricGroups.mockImplementation(() => {
       throw new Error("grouping failed");

--- a/packages/back-end/test/queryRunners/analysisSteps.test.ts
+++ b/packages/back-end/test/queryRunners/analysisSteps.test.ts
@@ -1,0 +1,145 @@
+import { ExperimentAggregateUnitsQueryResponseRows } from "shared/types/integrations";
+import {
+  runIsolatedAnalysisStep,
+  runTrafficAnalysisStep,
+} from "back-end/src/queryRunners/analysisSteps";
+import { analyzeExperimentTraffic } from "back-end/src/services/stats";
+import { logger } from "back-end/src/util/logger";
+
+jest.mock("back-end/src/util/logger", () => ({
+  logger: {
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock("back-end/src/services/stats", () => ({
+  analyzeExperimentTraffic: jest.fn(),
+}));
+
+const mockedLoggerError = logger.error as jest.Mock;
+const mockedAnalyzeExperimentTraffic = analyzeExperimentTraffic as jest.Mock;
+
+describe("runIsolatedAnalysisStep", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns the step's value with a null error on success", () => {
+    const step = runIsolatedAnalysisStep({
+      step: "power",
+      modelId: "snp_1",
+      run: () => ({ power: 0.8 }),
+    });
+
+    expect(step).toEqual({ value: { power: 0.8 }, error: null });
+    expect(mockedLoggerError).not.toHaveBeenCalled();
+  });
+
+  it("treats an undefined return as success, not as a failure", () => {
+    // analyzeExperimentPower legitimately returns undefined when its result
+    // fails validation, so `error === null` (not the value) is the success test.
+    const step = runIsolatedAnalysisStep({
+      step: "power",
+      modelId: "snp_1",
+      run: () => undefined,
+    });
+
+    expect(step.error).toBeNull();
+    expect(step.value).toBeUndefined();
+  });
+
+  it("catches a throw, returns its message, and logs it against the model", () => {
+    const step = runIsolatedAnalysisStep({
+      step: "covariateImbalance",
+      modelId: "snp_1",
+      run: () => {
+        throw new Error("Cannot read properties of undefined");
+      },
+    });
+
+    expect(step).toEqual({
+      value: null,
+      error: "Cannot read properties of undefined",
+    });
+    expect(mockedLoggerError).toHaveBeenCalledTimes(1);
+    expect(mockedLoggerError.mock.calls[0][1]).toBe(
+      'snp_1 runner: "covariateImbalance" analysis step failed',
+    );
+  });
+
+  it("stringifies a non-Error throw", () => {
+    const step = runIsolatedAnalysisStep({
+      step: "traffic",
+      modelId: "snp_1",
+      run: () => {
+        throw "boom";
+      },
+    });
+
+    expect(step.error).toBe("boom");
+    expect(step.value).toBeNull();
+  });
+});
+
+describe("runTrafficAnalysisStep", () => {
+  const rows = [
+    { variation: "0", users: 100 },
+  ] as unknown as ExperimentAggregateUnitsQueryResponseRows;
+  const variations = [
+    { id: "0", weight: 0.5 },
+    { id: "1", weight: 0.5 },
+  ];
+  const traffic = {
+    overall: { name: "All", srm: 1, variationUnits: [100, 100] },
+    dimension: {},
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns the traffic block unchanged when the step succeeds", () => {
+    mockedAnalyzeExperimentTraffic.mockReturnValue(traffic);
+
+    expect(
+      runTrafficAnalysisStep({
+        modelId: "snp_1",
+        rows,
+        queryError: undefined,
+        variations,
+      }),
+    ).toEqual({ traffic, error: null });
+    expect(mockedAnalyzeExperimentTraffic).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-derives an empty traffic block carrying the error when the step throws", () => {
+    mockedAnalyzeExperimentTraffic
+      .mockImplementationOnce(() => {
+        throw new Error("traffic aggregation failed");
+      })
+      .mockImplementationOnce(({ error }: { error?: string }) => ({
+        ...traffic,
+        error,
+      }));
+
+    const result = runTrafficAnalysisStep({
+      modelId: "snp_1",
+      rows,
+      queryError: undefined,
+      variations,
+    });
+
+    // A traffic block always exists, and carries the reason it is empty.
+    expect(result.traffic.error).toBe("traffic aggregation failed");
+    expect(result.error).toBe("traffic aggregation failed");
+    // The fallback must not re-run the analysis over the same rows.
+    expect(mockedAnalyzeExperimentTraffic).toHaveBeenLastCalledWith({
+      rows: [],
+      error: "traffic aggregation failed",
+      variations,
+    });
+  });
+});

--- a/packages/front-end/components/HealthTab/CovariateImbalanceCard.tsx
+++ b/packages/front-end/components/HealthTab/CovariateImbalanceCard.tsx
@@ -31,6 +31,7 @@ export default function CovariateImbalanceCard({
 }: Props) {
   const { metricGroups } = useDefinitions();
   const covariateImbalanceResult = snapshot?.health?.covariateImbalance;
+  const covariateStepError = snapshot?.health?.stepErrors?.covariateImbalance;
 
   const isImbalanced = covariateImbalanceResult?.isImbalanced ?? false;
 
@@ -151,6 +152,10 @@ export default function CovariateImbalanceCard({
                 <i>Only available with CUPED enabled.</i>
               </Text>
             </Box>
+          ) : covariateStepError ? (
+            <Callout status="warning">
+              We could not run the pre-exposure bias check. {covariateStepError}
+            </Callout>
           ) : totalNumMetricsTested === 0 ? (
             <Box mt="2">
               <Text color="text-low">

--- a/packages/front-end/components/HealthTab/PowerCard.tsx
+++ b/packages/front-end/components/HealthTab/PowerCard.tsx
@@ -26,12 +26,23 @@ export function PowerCard({
   const { mutate } = useSWRConfig();
   const { hasCommercialFeature } = useUser();
   const snapshotPower = snapshot.health?.power;
+  // Two ways power can be missing-with-a-reason: the step threw (recorded on
+  // health.stepErrors by the runner) or the calculation itself reported
+  // failure. Both read as "healthy"/"not calculated yet" otherwise.
+  const powerError =
+    snapshot.health?.stepErrors?.power ??
+    (snapshotPower?.type === "error"
+      ? (snapshotPower.errorMessage ?? "")
+      : undefined);
   const hasMidExperimentPowerFeature =
     hasCommercialFeature("decision-framework");
 
   const phase = experiment.phases[snapshot.phase];
-  const hasPowerData = snapshotPower !== undefined;
-  const isLowPowered = snapshotPower?.isLowPowered ?? false;
+  const hasPowerData = snapshotPower !== undefined && powerError === undefined;
+  // A failed calculation's isLowPowered flag is not a finding — don't badge the
+  // experiment unhealthy or offer to mute an alert we can't stand behind.
+  const isLowPowered =
+    snapshotPower?.type === "success" && snapshotPower.isLowPowered;
 
   const canBeMuted = hasMidExperimentPowerFeature && isLowPowered;
   const isMuted = experiment.dismissedWarnings?.includes("low-power") ?? false;
@@ -75,6 +86,13 @@ export function PowerCard({
     <Callout status="info">
       We have not calculated power for this experiment yet. Refresh the Results
       to see the power data.
+    </Callout>
+  );
+
+  const renderPowerError = () => (
+    <Callout status="warning">
+      We could not calculate power for this experiment.
+      {powerError ? ` ${powerError}` : ""}
     </Callout>
   );
 
@@ -127,11 +145,13 @@ export function PowerCard({
 
   const content = !hasMidExperimentPowerFeature
     ? renderUpsell()
-    : !hasPowerData
-      ? renderNoPowerData()
-      : !isLowPowered
-        ? renderHealthyExperiment()
-        : renderLowPowerRecommendations();
+    : powerError !== undefined
+      ? renderPowerError()
+      : !hasPowerData
+        ? renderNoPowerData()
+        : !isLowPowered
+          ? renderHealthyExperiment()
+          : renderLowPowerRecommendations();
 
   return (
     <div id="power-card" style={{ scrollMarginTop: "100px" }}>

--- a/packages/shared/src/enterprise/power.ts
+++ b/packages/shared/src/enterprise/power.ts
@@ -60,6 +60,9 @@ export type MetricVariationPowerResult = z.infer<
 export const MidExperimentPowerCalculationFailureValidator = z.object({
   type: z.literal("error"),
   isLowPowered: z.boolean(),
+  // Why power could not be calculated, so the Health tab can say something
+  // specific instead of falling through to "not calculated yet".
+  errorMessage: z.string().optional(),
   metricVariationPowerResults: z.array(MetricVariationPowerResultValidator),
 });
 export type MidExperimentPowerCalculationFailureResult = z.infer<
@@ -433,6 +436,7 @@ export function calculateMidExperimentPower(
     return {
       type: "error",
       isLowPowered: lowPowerWarning,
+      errorMessage: `Power could not be calculated for ${metricVariationFailure} of ${metricVariationCounter} metric-variation tests.`,
       metricVariationPowerResults: metricVariationPowerArray,
     };
   }

--- a/packages/shared/types/experiment-snapshot.d.ts
+++ b/packages/shared/types/experiment-snapshot.d.ts
@@ -305,10 +305,25 @@ export type SnapshotStatusSummary = Pick<
   | "triggeredBy"
 >;
 
+/**
+ * Steps of the results analysis that run *after* metric analysis and are
+ * isolated from it: each one's failure is recorded on the health block instead
+ * of failing the whole snapshot and discarding the metric results that already
+ * computed. A traffic-step failure is recorded on `traffic.error` (which the
+ * Health tab already renders) rather than here, since a traffic block must
+ * always exist.
+ */
+export type IsolatedAnalysisStep = "power" | "covariateImbalance";
+
 export interface ExperimentSnapshotHealth {
   traffic: ExperimentSnapshotTraffic;
   power?: MidExperimentPowerCalculationResult;
   covariateImbalance?: CovariateImbalanceResult;
+  /**
+   * Why a health step produced no result. Present only for a step that threw;
+   * the corresponding result field above is then absent.
+   */
+  stepErrors?: Partial<Record<IsolatedAnalysisStep, string>>;
 }
 
 export interface ExperimentSnapshotTraffic {


### PR DESCRIPTION
### Features and Changes

`runAnalysis` assembles its result from independent steps: metric analysis, then traffic, power, and covariate imbalance. They all ran inline, so a throw in a later step discarded everything the earlier ones had computed. A bug in power or covariate imbalance failed the whole snapshot and took correct metric results with it.

- `runIsolatedAnalysisStep` wraps a step and turns its throw into a value recorded on that step's own block, leaving the rest of the result intact and logging the failure with the model id. `ExperimentSnapshotHealth.stepErrors` holds the reason, and the Health tab reads it instead of falling through to "not calculated yet".
- Traffic gets its own wrapper, since `health.traffic` is not optional. On failure the block is re-derived into the same empty-with-error shape a failed traffic query already produces, and it tells the caller to skip the power step rather than compute from a zero-filled placeholder.
- Metric analysis is deliberately left unwrapped. If it throws there are no results worth persisting, so it stays fatal.
- A failed power calculation now carries `errorMessage`, so the card can say what went wrong.

`metricVariationPowerResults` and `metricVariationCovariateImbalanceResults` needed `default: undefined` in Mongoose. Without it the array materialized as `[]` on read, which materialized `health.power` itself, so every `power !== undefined` check was wrong and a failed step could not be told from an absent one.

### Testing

- `pnpm type-check`
- `analysisSteps.test.ts` and the step-isolation tests in `ExperimentResultsQueryRunner.test.ts`
