### PR TITLE
docs(experiments): fix three stale comments

### DIFF
--- a/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
@@ -94,8 +94,7 @@ export const TRAFFIC_QUERY_NAME = "traffic";
 
 export const UNITS_TABLE_PREFIX = "growthbook_tmp_units";
 
-// Canonical name of the query that drops the shared units table. The builder and
-// the metric-query classifier below both derive it from here so they can't drift.
+// Canonical name of the query that drops the shared units table.
 export function getDropUnitsTableQueryName(queryParentId: string): string {
   return `drop_${queryParentId}`;
 }
@@ -363,7 +362,7 @@ export const startExperimentResultQueries = async (
 
     // Passing a builder isolates build-time SQL-generation failures to the
     // owning group: a throw becomes a failed-query record for `group_<i>`,
-    // which Phase 1's attribution maps to each constituent metric, while other
+    // which per-metric attribution maps to each constituent metric, while other
     // groups still build and run.
     queries.push(
       await startQuery({

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -470,9 +470,9 @@ export abstract class QueryRunner<
     } else if (queryStatus === "failed") {
       this.experimentUpdateExecutionLogger?.endPhase("runQueries");
       logger.debug(this.model.id + " runner: Query failed immediately");
-      // Queries that failed before ever running (build-time SQL-generation
-      // failures, cached failures) already carry their error on the pointer, so
-      // chain the real root cause instead of a generic message.
+      // A query that failed before ever running (a build-time SQL-generation
+      // failure) already carries its error on the pointer, so chain the real
+      // root cause instead of a generic message.
       error = pickQueryFailureError(queries);
     }
 


### PR DESCRIPTION
### Features and Changes

Comments only, no behavior change. Found while splitting this work into reviewable commits, and kept separate so the five containment commits stay provably byte-identical to the branch they came from.

- `getDropUnitsTableQueryName` claimed a "metric-query classifier below" also derives from it. There is no such consumer; the only caller is the drop query's own `name`.
- The fact-metric group builder comment referenced "Phase 1's attribution". That phase numbering exists nowhere in the code or history.
- `startAnalysis` listed "cached failures" as a case it chains the root cause for. `getRecentQuery` only reuses `succeeded` or `running` queries, so a cached pointer is never failed; a build failure is the only way that branch sees one.

### Testing

- `pnpm type-check` (comments only)
