### PR TITLE
fix(api): attribute API-created reports to the authenticated user

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -31873,6 +31873,15 @@ paths:
                 description:
                   description: Report description
                   type: string
+                owner:
+                  description: >-
+                    The userId or email address of the owner. If an email
+                    address is provided, it will be used to look up the userId
+                    of the matching organization member. If an ID is provided,
+                    it will be validated as existing in the organization. When
+                    omitted, it defaults to the user associated with the
+                    request's Personal Access Token (PAT), if one is being used.
+                  type: string
                 statsEngine:
                   description: Stats engine override
                   type: string
@@ -57566,6 +57575,16 @@ components:
             `public`.
           type: string
         experimentId:
+          type: string
+        owner:
+          description: >-
+            The userId of the report owner. Absent for reports created before
+            owner attribution existed.
+          type: string
+        ownerEmail:
+          description: >-
+            The email address of the owner, when the owner can be resolved to a
+            known user.
           type: string
         snapshotId:
           description: Snapshot ID (experiment-snapshot type only)

--- a/packages/back-end/src/api/reports/getReport.ts
+++ b/packages/back-end/src/api/reports/getReport.ts
@@ -6,6 +6,7 @@ import {
   getMetricMapForExperiment,
   toSnapshotApiInterface,
 } from "back-end/src/services/experiments";
+import { resolveOwnerEmail } from "back-end/src/services/owner";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { toReportApiInterface } from "./toReportApiInterface";
 
@@ -31,7 +32,10 @@ export const getReport = createApiRequestHandler(getReportValidator)(async (
 
   if (report.type === "experiment-snapshot") {
     const snapshot = await findSnapshotById(req.context, report.snapshot);
-    const apiReport = toReportApiInterface(report, snapshot);
+    const apiReport = await resolveOwnerEmail(
+      toReportApiInterface(report, snapshot),
+      req.context,
+    );
 
     if (snapshot?.status === "success" && experiment) {
       const metricsById = await getMetricMapForExperiment(
@@ -45,5 +49,7 @@ export const getReport = createApiRequestHandler(getReportValidator)(async (
     return { report: apiReport };
   }
 
-  return { report: toReportApiInterface(report) };
+  return {
+    report: await resolveOwnerEmail(toReportApiInterface(report), req.context),
+  };
 });

--- a/packages/back-end/src/api/reports/listReports.ts
+++ b/packages/back-end/src/api/reports/listReports.ts
@@ -7,6 +7,7 @@ import {
   getAllExperiments,
   getExperimentById,
 } from "back-end/src/models/ExperimentModel";
+import { resolveOwnerEmails } from "back-end/src/services/owner";
 import {
   createApiRequestHandler,
   applyPagination,
@@ -49,7 +50,10 @@ export const listReports = createApiRequestHandler(listReportsValidator)(async (
   const { filtered, returnFields } = applyPagination(reports, req.query);
 
   return {
-    reports: filtered.map((r) => toReportApiInterface(r)),
+    reports: await resolveOwnerEmails(
+      filtered.map((r) => toReportApiInterface(r)),
+      req.context,
+    ),
     ...returnFields,
   };
 });

--- a/packages/back-end/src/api/reports/postReport.ts
+++ b/packages/back-end/src/api/reports/postReport.ts
@@ -12,6 +12,10 @@ import { getMetricMap } from "back-end/src/models/MetricModel";
 import { getFactTableMap } from "back-end/src/models/FactTableModel";
 import { createReport, updateReport } from "back-end/src/models/ReportModel";
 import { createReportSnapshot } from "back-end/src/services/reports";
+import {
+  resolveOwnerEmail,
+  resolveOwnerToUserId,
+} from "back-end/src/services/owner";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { toReportApiInterface } from "./toReportApiInterface";
 
@@ -24,6 +28,7 @@ export const postReport = createApiRequestHandler(postReportValidator)(async (
     experimentId,
     title,
     description,
+    owner,
     statsEngine,
     goalMetrics,
     secondaryMetrics,
@@ -54,6 +59,13 @@ export const postReport = createApiRequestHandler(postReportValidator)(async (
   if (!req.context.permissions.canCreateReport(experiment)) {
     req.context.permissions.throwPermissionError();
   }
+
+  // Attribute the report to the explicit `owner` from the body, or fall back
+  // to the authenticated user. Report edit/delete permissions are gated on
+  // ownership, so an owner-less report can only be managed by admins.
+  const ownerId =
+    (await resolveOwnerToUserId(owner, req.context, { strict: true })) ??
+    req.context.userId;
 
   const phaseIndex = Math.max(experiment.phases.length - 1, 0);
   const latestSnapshot = await getLatestSuccessfulSnapshot({
@@ -142,6 +154,7 @@ export const postReport = createApiRequestHandler(postReportValidator)(async (
 
   const report = await createReport(org.id, {
     experimentId: experiment.id,
+    ...(ownerId ? { userId: ownerId } : {}),
     title: title || `API Report - ${experiment.name}`,
     description: description || "",
     type: "experiment-snapshot",
@@ -191,9 +204,12 @@ export const postReport = createApiRequestHandler(postReportValidator)(async (
     await updateReport(org.id, report.id, { snapshot: newSnapshot.id });
 
     return {
-      report: toReportApiInterface(
-        { ...report, snapshot: newSnapshot.id },
-        newSnapshot,
+      report: await resolveOwnerEmail(
+        toReportApiInterface(
+          { ...report, snapshot: newSnapshot.id },
+          newSnapshot,
+        ),
+        req.context,
       ),
     };
   } catch (e) {
@@ -203,7 +219,10 @@ export const postReport = createApiRequestHandler(postReportValidator)(async (
     await updateReport(org.id, report.id, { snapshot: "" });
     return {
       report: {
-        ...toReportApiInterface({ ...report, snapshot: "" }),
+        ...(await resolveOwnerEmail(
+          toReportApiInterface({ ...report, snapshot: "" }),
+          req.context,
+        )),
         snapshotStatus: "error" as const,
         snapshotError: (e as Error).message,
       },

--- a/packages/back-end/src/api/reports/postReportRefresh.ts
+++ b/packages/back-end/src/api/reports/postReportRefresh.ts
@@ -6,6 +6,7 @@ import { getMetricMap } from "back-end/src/models/MetricModel";
 import { getFactTableMap } from "back-end/src/models/FactTableModel";
 import { createReportSnapshot } from "back-end/src/services/reports";
 import { toSnapshotApiInterface } from "back-end/src/services/experiments";
+import { resolveOwnerEmail } from "back-end/src/services/owner";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { toReportApiInterface } from "./toReportApiInterface";
 
@@ -64,9 +65,12 @@ export const postReportRefresh = createApiRequestHandler(
       details: JSON.stringify({ report: report.id }),
     });
 
-    const apiReport = toReportApiInterface(
-      { ...report, snapshot: newSnapshot.id },
-      newSnapshot,
+    const apiReport = await resolveOwnerEmail(
+      toReportApiInterface(
+        { ...report, snapshot: newSnapshot.id },
+        newSnapshot,
+      ),
+      req.context,
     );
 
     if (newSnapshot.status === "success" && experiment) {
@@ -82,7 +86,7 @@ export const postReportRefresh = createApiRequestHandler(
   } catch (e) {
     return {
       report: {
-        ...toReportApiInterface(report),
+        ...(await resolveOwnerEmail(toReportApiInterface(report), req.context)),
         snapshotStatus: "error" as const,
         snapshotError: (e as Error).message,
       },

--- a/packages/back-end/src/api/reports/putReportMetadata.ts
+++ b/packages/back-end/src/api/reports/putReportMetadata.ts
@@ -7,6 +7,7 @@ import {
   getMetricMapForExperiment,
   toSnapshotApiInterface,
 } from "back-end/src/services/experiments";
+import { resolveOwnerEmail } from "back-end/src/services/owner";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { toReportApiInterface } from "./toReportApiInterface";
 
@@ -57,7 +58,10 @@ export const putReportMetadata = createApiRequestHandler(
   const snapshot = updatedReport.snapshot
     ? await findSnapshotById(req.context, updatedReport.snapshot)
     : null;
-  const apiReport = toReportApiInterface(updatedReport, snapshot);
+  const apiReport = await resolveOwnerEmail(
+    toReportApiInterface(updatedReport, snapshot),
+    req.context,
+  );
 
   if (snapshot?.status === "success" && experiment) {
     const metricsById = await getMetricMapForExperiment(

--- a/packages/back-end/src/api/reports/putReportSettings.ts
+++ b/packages/back-end/src/api/reports/putReportSettings.ts
@@ -8,6 +8,7 @@ import {
   getMetricMapForExperiment,
   toSnapshotApiInterface,
 } from "back-end/src/services/experiments";
+import { resolveOwnerEmail } from "back-end/src/services/owner";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { toReportApiInterface } from "./toReportApiInterface";
 
@@ -160,7 +161,10 @@ export const putReportSettings = createApiRequestHandler(
   const snapshot = updatedReport.snapshot
     ? await findSnapshotById(req.context, updatedReport.snapshot)
     : null;
-  const apiReport = toReportApiInterface(updatedReport, snapshot);
+  const apiReport = await resolveOwnerEmail(
+    toReportApiInterface(updatedReport, snapshot),
+    req.context,
+  );
 
   if (snapshot?.status === "success" && experiment) {
     const metricsById = await getMetricMapForExperiment(

--- a/packages/back-end/src/api/reports/toReportApiInterface.ts
+++ b/packages/back-end/src/api/reports/toReportApiInterface.ts
@@ -26,6 +26,7 @@ export function toReportApiInterface(
     status: report.status,
     shareLevel,
     experimentId: report.experimentId,
+    owner: report.userId || undefined,
   };
 
   if (

--- a/packages/shared/src/validators/reports.ts
+++ b/packages/shared/src/validators/reports.ts
@@ -7,6 +7,11 @@ import {
   lookbackOverride,
   metricOverride,
 } from "./experiments";
+import {
+  ownerEmailField,
+  ownerField,
+  optionalOwnerInputField,
+} from "./owner-field";
 import { apiPaginationFieldsValidator, paginationQueryFields } from "./shared";
 
 const idParams = z
@@ -111,6 +116,12 @@ export const apiReportValidator = namedSchema(
       )
       .optional(),
     experimentId: z.string().optional(),
+    owner: ownerField
+      .describe(
+        "The userId of the report owner. Absent for reports created before owner attribution existed.",
+      )
+      .optional(),
+    ownerEmail: ownerEmailField,
     snapshotId: z
       .string()
       .describe("Snapshot ID (experiment-snapshot type only)")
@@ -216,6 +227,7 @@ const postReportBody = z
       .describe("Report title (defaults to experiment name)")
       .optional(),
     description: z.string().describe("Report description").optional(),
+    owner: optionalOwnerInputField,
     statsEngine: z
       .enum(["bayesian", "frequentist"])
       .describe("Stats engine override")


### PR DESCRIPTION
## Problem

`POST /api/v1/reports` never stamps the created report's `userId`, while the internal controller does (`controllers/reports.ts` sets `userId: req.userId`). Reports created through the REST API therefore:

- render with no owner in the UI, and
- can only be edited, refreshed-from-the-UI, or deleted by admins — **including by their own creator** — because report permissions are ownership-gated (`report.userId === req.userId`, otherwise the admin-only `canSuperDeleteReport` path).

This bit us with automation that creates reports on users' behalf using user-bound credentials: the reports come out orphaned, and the only recourse is asking an admin to delete them.

Other resources already handle this — experiments fall back to `context.userId` in `postExperiment`, features use `resolveOwnerForCreate`, and BaseModel-backed resources got a blanket fallback in #5412. Reports are a legacy non-BaseModel resource that missed that sweep.

## Fix

Follows the existing owner-field convention:

- **`POST /v1/reports`** accepts an optional `owner` (`optionalOwnerInputField` — userId or email, resolved strictly via `resolveOwnerToUserId`) and otherwise falls back to the authenticated user (`req.context.userId`, populated for Personal Access Tokens). The resolved user is stamped as the report's `userId`.
- Organization secret API keys with no body `owner` still create owner-less reports (there is no user to attribute to) — behavior unchanged.
- **All report API responses** (get / list / create / refresh / put metadata / put settings) now expose `owner` + resolved `ownerEmail` via `resolveOwnerEmail(s)`, per the same convention used by experiments, dimensions, archetypes, etc.
- OpenAPI spec regenerated (`generate-openapi`).

## Verification

Manually verified end-to-end against a local dev server:

- explicit `owner` email in the POST body → resolved to the member's userId, stamped on the Mongo doc, returned as `owner`/`ownerEmail` on POST and GET responses; the creator can subsequently edit/delete the report in the UI
- unknown `owner` email/userId → 400 `"Unable to find user: …"`
- org secret key with no `owner` → owner-less report, same as before

`pnpm --filter shared type-check`, `pnpm --filter back-end type-check`, lint, and the owner-service test suite (20/20) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)