### PR TITLE
fix(ui,experiments): prevent stray results menu dividers

### DIFF
--- a/packages/front-end/components/Experiment/ResultMoreMenu.tsx
+++ b/packages/front-end/components/Experiment/ResultMoreMenu.tsx
@@ -90,16 +90,6 @@ export function canShowReenableIncrementalRefresh({
   });
 }
 
-export function shouldShowResultMenuDivider({
-  hasItemBefore,
-  hasItemAfter,
-}: {
-  hasItemBefore: boolean;
-  hasItemAfter: boolean;
-}): boolean {
-  return hasItemBefore && hasItemAfter;
-}
-
 export default function ResultMoreMenu({
   experiment,
   editMetrics,
@@ -384,32 +374,24 @@ export default function ResultMoreMenu({
     return { queryStrings, error };
   }, [snapshot, latest, legacyQueries, legacyQueryError]);
 
-  const canRefreshMenuItem = canShowRefreshMenuItem({
-    forceRefresh,
-    datasource,
-    canRunExperimentQueries:
-      (datasource && permissionsUtil.canRunExperimentQueries(datasource)) ??
-      false,
-  });
-  const canReenableIncrementalRefreshMenuItem =
-    canShowReenableIncrementalRefresh({
+  const hasMenuItemBeforeInitialDivider =
+    queryStrings.length > 0 ||
+    canShowRefreshMenuItem({
+      forceRefresh,
+      datasource,
+      canRunExperimentQueries:
+        (datasource && permissionsUtil.canRunExperimentQueries(datasource)) ??
+        false,
+    }) ||
+    (canShowReenableIncrementalRefresh({
       datasource,
       experimentId: experiment?.id,
       canUpdateDataSourceSettings:
         (datasource &&
           permissionsUtil.canUpdateDataSourceSettings(datasource)) ??
         false,
-    }) && experimentExcludedFromIncrementalRefresh;
-  const shouldShowInitialDivider = shouldShowResultMenuDivider({
-    hasItemBefore:
-      queryStrings.length > 0 ||
-      canRefreshMenuItem ||
-      canReenableIncrementalRefreshMenuItem,
-    hasItemAfter:
-      Boolean(canEdit && editMetrics && !isBandit) ||
-      Boolean(canDownloadJupyterNotebook) ||
-      Boolean(results),
-  });
+    }) &&
+      experimentExcludedFromIncrementalRefresh);
 
   return (
     <>
@@ -445,7 +427,14 @@ export default function ResultMoreMenu({
               />
             </DropdownMenuItem>
           ) : null}
-          {canRefreshMenuItem && (
+          {canShowRefreshMenuItem({
+            forceRefresh,
+            datasource,
+            canRunExperimentQueries:
+              (datasource &&
+                permissionsUtil.canRunExperimentQueries(datasource)) ??
+              false,
+          }) && (
             <DropdownMenuItem
               onClick={handleForceRefresh}
               confirmation={
@@ -476,12 +465,25 @@ export default function ResultMoreMenu({
               {rerunAllQueriesText}
             </DropdownMenuItem>
           )}
-          {canReenableIncrementalRefreshMenuItem && (
-            <DropdownMenuItem onClick={handleReenableIncrementalRefresh}>
-              Re-enable incremental refresh
-            </DropdownMenuItem>
-          )}
-          {shouldShowInitialDivider ? <DropdownMenuSeparator /> : null}
+          {canShowReenableIncrementalRefresh({
+            datasource,
+            experimentId: experiment?.id,
+            canUpdateDataSourceSettings:
+              (datasource &&
+                permissionsUtil.canUpdateDataSourceSettings(datasource)) ??
+              false,
+          }) &&
+            experimentExcludedFromIncrementalRefresh && (
+              <DropdownMenuItem onClick={handleReenableIncrementalRefresh}>
+                Re-enable incremental refresh
+              </DropdownMenuItem>
+            )}
+          {hasMenuItemBeforeInitialDivider &&
+          ((canEdit && editMetrics && !isBandit) ||
+            canDownloadJupyterNotebook ||
+            results) ? (
+            <DropdownMenuSeparator />
+          ) : null}
           {canEdit && editMetrics && !isBandit && (
             <>
               <DropdownMenuItem

--- a/packages/front-end/components/Experiment/ResultMoreMenu.tsx
+++ b/packages/front-end/components/Experiment/ResultMoreMenu.tsx
@@ -90,6 +90,16 @@ export function canShowReenableIncrementalRefresh({
   });
 }
 
+export function shouldShowResultMenuDivider({
+  hasItemBefore,
+  hasItemAfter,
+}: {
+  hasItemBefore: boolean;
+  hasItemAfter: boolean;
+}): boolean {
+  return hasItemBefore && hasItemAfter;
+}
+
 export default function ResultMoreMenu({
   experiment,
   editMetrics,
@@ -374,6 +384,33 @@ export default function ResultMoreMenu({
     return { queryStrings, error };
   }, [snapshot, latest, legacyQueries, legacyQueryError]);
 
+  const canRefreshMenuItem = canShowRefreshMenuItem({
+    forceRefresh,
+    datasource,
+    canRunExperimentQueries:
+      (datasource && permissionsUtil.canRunExperimentQueries(datasource)) ??
+      false,
+  });
+  const canReenableIncrementalRefreshMenuItem =
+    canShowReenableIncrementalRefresh({
+      datasource,
+      experimentId: experiment?.id,
+      canUpdateDataSourceSettings:
+        (datasource &&
+          permissionsUtil.canUpdateDataSourceSettings(datasource)) ??
+        false,
+    }) && experimentExcludedFromIncrementalRefresh;
+  const shouldShowInitialDivider = shouldShowResultMenuDivider({
+    hasItemBefore:
+      queryStrings.length > 0 ||
+      canRefreshMenuItem ||
+      canReenableIncrementalRefreshMenuItem,
+    hasItemAfter:
+      Boolean(canEdit && editMetrics && !isBandit) ||
+      Boolean(canDownloadJupyterNotebook) ||
+      Boolean(results),
+  });
+
   return (
     <>
       <DropdownMenu
@@ -408,14 +445,7 @@ export default function ResultMoreMenu({
               />
             </DropdownMenuItem>
           ) : null}
-          {canShowRefreshMenuItem({
-            forceRefresh,
-            datasource,
-            canRunExperimentQueries:
-              (datasource &&
-                permissionsUtil.canRunExperimentQueries(datasource)) ??
-              false,
-          }) && (
+          {canRefreshMenuItem && (
             <DropdownMenuItem
               onClick={handleForceRefresh}
               confirmation={
@@ -446,24 +476,12 @@ export default function ResultMoreMenu({
               {rerunAllQueriesText}
             </DropdownMenuItem>
           )}
-          {canShowReenableIncrementalRefresh({
-            datasource,
-            experimentId: experiment?.id,
-            canUpdateDataSourceSettings:
-              (datasource &&
-                permissionsUtil.canUpdateDataSourceSettings(datasource)) ??
-              false,
-          }) &&
-            experimentExcludedFromIncrementalRefresh && (
-              <DropdownMenuItem onClick={handleReenableIncrementalRefresh}>
-                Re-enable incremental refresh
-              </DropdownMenuItem>
-            )}
-          {(canEdit && editMetrics && !isBandit) ||
-          canDownloadJupyterNotebook ||
-          results ? (
-            <DropdownMenuSeparator />
-          ) : null}
+          {canReenableIncrementalRefreshMenuItem && (
+            <DropdownMenuItem onClick={handleReenableIncrementalRefresh}>
+              Re-enable incremental refresh
+            </DropdownMenuItem>
+          )}
+          {shouldShowInitialDivider ? <DropdownMenuSeparator /> : null}
           {canEdit && editMetrics && !isBandit && (
             <>
               <DropdownMenuItem

--- a/packages/front-end/components/Experiment/ResultMoreMenu.tsx
+++ b/packages/front-end/components/Experiment/ResultMoreMenu.tsx
@@ -461,8 +461,7 @@ export default function ResultMoreMenu({
             )}
           {(canEdit && editMetrics && !isBandit) ||
           canDownloadJupyterNotebook ||
-          results ||
-          onAddToDashboard ? (
+          results ? (
             <DropdownMenuSeparator />
           ) : null}
           {canEdit && editMetrics && !isBandit && (
@@ -475,7 +474,7 @@ export default function ResultMoreMenu({
               >
                 Add / remove metrics
               </DropdownMenuItem>
-              {canDownloadJupyterNotebook || results || onAddToDashboard ? (
+              {canDownloadJupyterNotebook || results ? (
                 <DropdownMenuSeparator />
               ) : null}
             </>

--- a/packages/front-end/components/Experiment/ResultMoreMenu.tsx
+++ b/packages/front-end/components/Experiment/ResultMoreMenu.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react";
+import { Fragment, ReactElement, useState, useCallback, useMemo } from "react";
 import { BsThreeDotsVertical } from "react-icons/bs";
 import { Queries } from "shared/types/query";
 import {
@@ -374,24 +374,132 @@ export default function ResultMoreMenu({
     return { queryStrings, error };
   }, [snapshot, latest, legacyQueries, legacyQueryError]);
 
-  const hasMenuItemBeforeInitialDivider =
-    queryStrings.length > 0 ||
-    canShowRefreshMenuItem({
-      forceRefresh,
-      datasource,
-      canRunExperimentQueries:
-        (datasource && permissionsUtil.canRunExperimentQueries(datasource)) ??
-        false,
-    }) ||
-    (canShowReenableIncrementalRefresh({
-      datasource,
-      experimentId: experiment?.id,
-      canUpdateDataSourceSettings:
-        (datasource &&
-          permissionsUtil.canUpdateDataSourceSettings(datasource)) ??
-        false,
-    }) &&
-      experimentExcludedFromIncrementalRefresh);
+  const menuItemGroups = [
+    {
+      key: "queries",
+      items: [
+        queryStrings.length > 0 ? (
+          <DropdownMenuItem key="view-queries" onClick={handleViewQueries}>
+            View queries
+            <Badge
+              variant="soft"
+              radius="full"
+              label={String(queryStrings.length)}
+              ml="2"
+              color={error ? "red" : undefined}
+            />
+          </DropdownMenuItem>
+        ) : null,
+        canShowRefreshMenuItem({
+          forceRefresh,
+          datasource,
+          canRunExperimentQueries:
+            (datasource &&
+              permissionsUtil.canRunExperimentQueries(datasource)) ??
+            false,
+        }) ? (
+          <DropdownMenuItem
+            key="refresh"
+            onClick={handleForceRefresh}
+            confirmation={
+              runsIncrementalRefresh
+                ? {
+                    confirmationTitle: "Full Refresh",
+                    cta: "I understand",
+                    submit: async () => {
+                      if (forceRefresh) {
+                        await forceRefresh();
+                        setDropdownOpen(false);
+                      }
+                    },
+                    getConfirmationContent: async () => (
+                      <>
+                        This experiment has Pipeline Mode enabled.
+                        <br />
+                        <br />
+                        Fully refreshing the experiment will re-scan the data
+                        source from the beginning of the experiment, instead of
+                        scanning only new data.
+                      </>
+                    ),
+                  }
+                : undefined
+            }
+          >
+            {rerunAllQueriesText}
+          </DropdownMenuItem>
+        ) : null,
+        canShowReenableIncrementalRefresh({
+          datasource,
+          experimentId: experiment?.id,
+          canUpdateDataSourceSettings:
+            (datasource &&
+              permissionsUtil.canUpdateDataSourceSettings(datasource)) ??
+            false,
+        }) && experimentExcludedFromIncrementalRefresh ? (
+          <DropdownMenuItem
+            key="reenable-incremental-refresh"
+            onClick={handleReenableIncrementalRefresh}
+          >
+            Re-enable incremental refresh
+          </DropdownMenuItem>
+        ) : null,
+      ],
+    },
+    {
+      key: "metrics",
+      items: [
+        canEdit && editMetrics && !isBandit ? (
+          <DropdownMenuItem
+            key="edit-metrics"
+            onClick={() => {
+              editMetrics();
+              setDropdownOpen(false);
+            }}
+          >
+            Add / remove metrics
+          </DropdownMenuItem>
+        ) : null,
+      ],
+    },
+    {
+      key: "exports",
+      items: [
+        results &&
+        onAddToDashboard &&
+        hasCommercialFeature("dashboards") &&
+        !isHoldout ? (
+          <DropdownMenuItem
+            key="add-to-dashboard"
+            onClick={() => {
+              onAddToDashboard();
+              setDropdownOpen(false);
+            }}
+          >
+            Add to Dashboard...
+          </DropdownMenuItem>
+        ) : null,
+        canDownloadJupyterNotebook ? (
+          <DropdownMenuItem
+            key="download-notebook"
+            onClick={handleDownloadNotebook}
+          >
+            Download notebook
+          </DropdownMenuItem>
+        ) : null,
+        results ? (
+          <DropdownMenuItem key="export-csv" onClick={handleDownloadCSV}>
+            Export CSV
+          </DropdownMenuItem>
+        ) : null,
+      ],
+    },
+  ]
+    .map((group) => ({
+      ...group,
+      items: group.items.filter((item): item is ReactElement => item !== null),
+    }))
+    .filter((group) => group.items.length > 0);
 
   return (
     <>
@@ -415,113 +523,14 @@ export default function ResultMoreMenu({
         variant="soft"
       >
         <DropdownMenuGroup>
-          {queryStrings.length > 0 ? (
-            <DropdownMenuItem onClick={handleViewQueries}>
-              View queries
-              <Badge
-                variant="soft"
-                radius="full"
-                label={String(queryStrings.length)}
-                ml="2"
-                color={error ? "red" : undefined}
-              />
-            </DropdownMenuItem>
-          ) : null}
-          {canShowRefreshMenuItem({
-            forceRefresh,
-            datasource,
-            canRunExperimentQueries:
-              (datasource &&
-                permissionsUtil.canRunExperimentQueries(datasource)) ??
-              false,
-          }) && (
-            <DropdownMenuItem
-              onClick={handleForceRefresh}
-              confirmation={
-                runsIncrementalRefresh
-                  ? {
-                      confirmationTitle: "Full Refresh",
-                      cta: "I understand",
-                      submit: async () => {
-                        if (forceRefresh) {
-                          await forceRefresh();
-                          setDropdownOpen(false);
-                        }
-                      },
-                      getConfirmationContent: async () => (
-                        <>
-                          This experiment has Pipeline Mode enabled.
-                          <br />
-                          <br />
-                          Fully refreshing the experiment will re-scan the data
-                          source from the beginning of the experiment, instead
-                          of scanning only new data.
-                        </>
-                      ),
-                    }
-                  : undefined
-              }
-            >
-              {rerunAllQueriesText}
-            </DropdownMenuItem>
-          )}
-          {canShowReenableIncrementalRefresh({
-            datasource,
-            experimentId: experiment?.id,
-            canUpdateDataSourceSettings:
-              (datasource &&
-                permissionsUtil.canUpdateDataSourceSettings(datasource)) ??
-              false,
-          }) &&
-            experimentExcludedFromIncrementalRefresh && (
-              <DropdownMenuItem onClick={handleReenableIncrementalRefresh}>
-                Re-enable incremental refresh
-              </DropdownMenuItem>
-            )}
-          {hasMenuItemBeforeInitialDivider &&
-          ((canEdit && editMetrics && !isBandit) ||
-            canDownloadJupyterNotebook ||
-            results) ? (
-            <DropdownMenuSeparator />
-          ) : null}
-          {canEdit && editMetrics && !isBandit && (
-            <>
-              <DropdownMenuItem
-                onClick={() => {
-                  editMetrics();
-                  setDropdownOpen(false);
-                }}
-              >
-                Add / remove metrics
-              </DropdownMenuItem>
-              {canDownloadJupyterNotebook || results ? (
+          {menuItemGroups.map((group, index) => (
+            <Fragment key={group.key}>
+              {group.items}
+              {index < menuItemGroups.length - 1 ? (
                 <DropdownMenuSeparator />
               ) : null}
-            </>
-          )}
-          {results &&
-            onAddToDashboard &&
-            hasCommercialFeature("dashboards") &&
-            !isHoldout && (
-              <DropdownMenuItem
-                onClick={() => {
-                  onAddToDashboard();
-                  setDropdownOpen(false);
-                }}
-              >
-                Add to Dashboard...
-              </DropdownMenuItem>
-            )}
-          {canDownloadJupyterNotebook && (
-            <DropdownMenuItem onClick={handleDownloadNotebook}>
-              Download notebook
-            </DropdownMenuItem>
-          )}
-          {results && (
-            <DropdownMenuItem onClick={handleDownloadCSV}>
-              Export CSV
-            </DropdownMenuItem>
-          )}
+            </Fragment>
+          ))}
         </DropdownMenuGroup>
       </DropdownMenu>
       {queriesModalOpen && queryStrings.length > 0 && (

--- a/packages/front-end/test/components/experiment/ResultMoreMenu.test.tsx
+++ b/packages/front-end/test/components/experiment/ResultMoreMenu.test.tsx
@@ -5,6 +5,7 @@ import {
   canShowReenableIncrementalRefresh,
   isExperimentExcludedFromIncrementalRefresh,
   shouldOfferMenuRefresh,
+  shouldShowResultMenuDivider,
 } from "@/components/Experiment/ResultMoreMenu";
 
 const makeDatasource = (
@@ -28,6 +29,22 @@ const makeDatasource = (
   }) as DataSourceInterfaceWithParams;
 
 describe("ResultMoreMenu gating helpers", () => {
+  describe("shouldShowResultMenuDivider", () => {
+    it.each([
+      [false, false, false],
+      [false, false, true],
+      [false, true, false],
+      [true, true, true],
+    ])(
+      "returns %s when items before and after are %s and %s",
+      (expected, hasItemBefore, hasItemAfter) => {
+        expect(
+          shouldShowResultMenuDivider({ hasItemBefore, hasItemAfter }),
+        ).toBe(expected);
+      },
+    );
+  });
+
   describe("canShowRefreshMenuItem", () => {
     it("allows refresh when forceRefresh, datasource, permission true", () => {
       const ds = makeDatasource();

--- a/packages/front-end/test/components/experiment/ResultMoreMenu.test.tsx
+++ b/packages/front-end/test/components/experiment/ResultMoreMenu.test.tsx
@@ -5,7 +5,6 @@ import {
   canShowReenableIncrementalRefresh,
   isExperimentExcludedFromIncrementalRefresh,
   shouldOfferMenuRefresh,
-  shouldShowResultMenuDivider,
 } from "@/components/Experiment/ResultMoreMenu";
 
 const makeDatasource = (
@@ -29,22 +28,6 @@ const makeDatasource = (
   }) as DataSourceInterfaceWithParams;
 
 describe("ResultMoreMenu gating helpers", () => {
-  describe("shouldShowResultMenuDivider", () => {
-    it.each([
-      [false, false, false],
-      [false, false, true],
-      [false, true, false],
-      [true, true, true],
-    ])(
-      "returns %s when items before and after are %s and %s",
-      (expected, hasItemBefore, hasItemAfter) => {
-        expect(
-          shouldShowResultMenuDivider({ hasItemBefore, hasItemAfter }),
-        ).toBe(expected);
-      },
-    );
-  });
-
   describe("canShowRefreshMenuItem", () => {
     it("allows refresh when forceRefresh, datasource, permission true", () => {
       const ds = makeDatasource();


### PR DESCRIPTION
### Features and Changes

- Render a divider only between visible Results menu items, so a menu with just Add / remove metrics has no leading divider.

### Testing

- `pnpm --filter front-end test test/components/experiment/ResultMoreMenu.test.tsx`