### PR TITLE
fix(ui): correct error page heading and button spacing

### DIFF
--- a/packages/front-end/components/ProtectedPage.tsx
+++ b/packages/front-end/components/ProtectedPage.tsx
@@ -32,9 +32,9 @@ const LoggedInPageGuard = ({
               className="appbox p-4"
               style={{ maxWidth: 500, margin: "auto" }}
             >
-              <h3 className="mb-3">Error Signing In</h3>
+              <h3 className="mb-3">Something Went Wrong</h3>
               <Callout status="error">{error}</Callout>
-              <div className="d-flex">
+              <div className="d-flex align-items-center mt-3">
                 <Button
                   className="ml-auto"
                   onClick={async () => {


### PR DESCRIPTION
### Features and Changes

- Rename the error page heading from "Error Signing In" to "Something Went Wrong". This screen renders after the user is already authenticated (their email still shows in the top nav) and the error comes from failing to load `/user` or `/organization`. It is a data-load or network failure, not a sign-in problem, so the old heading was misleading.
- Fix the spacing between the error message and the action buttons. The button row had no top margin and sat flush against the Callout. It now has a top margin and vertically centered items, so "Log Out" and "Reload" line up and no longer crowd the message box.

### Testing

- `pnpm --filter front-end type-check`
