### PR TITLE
feat(experiments,dashboards): rebuild Overall Results once so dimension breakdowns run incrementally

### DIFF
--- a/packages/back-end/src/enterprise/services/dashboards.ts
+++ b/packages/back-end/src/enterprise/services/dashboards.ts
@@ -31,13 +31,18 @@ import { ReqContext } from "back-end/types/request";
 
 import { FactTableMap } from "back-end/src/models/FactTableModel";
 import { ApiReqContext } from "back-end/types/api";
-import { getDataSourcesByIds } from "back-end/src/models/DataSourceModel";
+import {
+  getDataSourcesByIds,
+  getDataSourceById,
+} from "back-end/src/models/DataSourceModel";
 import { executeAndSaveQuery } from "back-end/src/routers/saved-queries/saved-queries.controller";
 import {
   getDefaultExperimentAnalysisSettings,
   createSnapshot,
   getAdditionalExperimentAnalysisSettings,
   determineNextDate,
+  planExperimentSnapshot,
+  rebuildOverallResultsForDimensionBreakdowns,
 } from "back-end/src/services/experiments";
 import { createMetricAnalysis } from "back-end/src/services/metric-analysis";
 import { runProductAnalyticsExploration } from "back-end/src/enterprise/services/product-analytics";
@@ -132,26 +137,42 @@ export async function updateExperimentDashboards({
     previousSnapshots.map((snap) => [snap.id, snap]),
   );
 
-  const snapshotAndAnalysisSettingPairs = blocksNeedingSnapshot.map<
+  const snapshotAndAnalysisSettingPairs = blocksNeedingSnapshot.flatMap<
     [BlockSnapshotSettings, ExperimentSnapshotAnalysisSettings]
   >((block) => {
     const blockSnapshot = previousSnapshotMap.get(block.snapshotId);
-    if (!blockSnapshot)
-      throw new Error(
-        "Error updating dashboard results, could not find snapshot",
+    if (!blockSnapshot) {
+      logger.warn(
+        {
+          experimentId: experiment.id,
+          blockId: block.id,
+          snapshotId: block.snapshotId,
+        },
+        "Skipping dashboard block with missing snapshot",
       );
-    if (!blockSnapshot.analyses[0])
-      throw new Error(
-        "Error updating dashboard results, referenced snapshot missing analysis",
+      return [];
+    }
+    if (!blockSnapshot.analyses[0]) {
+      logger.warn(
+        {
+          experimentId: experiment.id,
+          blockId: block.id,
+          snapshotId: block.snapshotId,
+        },
+        "Skipping dashboard block with missing snapshot analysis",
       );
+      return [];
+    }
     const defaultAnalysis = blockSnapshot.analyses[0];
     return [
-      getBlockSnapshotSettings(block),
-      getBlockAnalysisSettings(
-        block,
-        (getBlockSnapshotAnalysis(blockSnapshot, block) ?? defaultAnalysis)
-          .settings,
-      ),
+      [
+        getBlockSnapshotSettings(block),
+        getBlockAnalysisSettings(
+          block,
+          (getBlockSnapshotAnalysis(blockSnapshot, block) ?? defaultAnalysis)
+            .settings,
+        ),
+      ],
     ];
   });
 
@@ -172,64 +193,130 @@ export async function updateExperimentDashboards({
   });
   const metricGroups = await context.models.metricGroups.getAll();
 
-  for (const snapshotSettings of uniqueSnapshotSettings) {
-    const additionalAnalysisSettings =
-      uniqWith<ExperimentSnapshotAnalysisSettings>(
-        snapshotAndAnalysisSettingPairs
-          .filter(([targetSettings]) =>
-            isEqual(snapshotSettings, targetSettings),
-          )
-          .map(([_, analysisSettings]) => analysisSettings),
-        isEqual,
+  const firstDimensionSettings = uniqueSnapshotSettings.find(
+    (s) => (s.dimensionId ?? "").length > 0,
+  );
+  if (firstDimensionSettings?.dimensionId) {
+    try {
+      const datasource = await getDataSourceById(
+        context,
+        experiment.datasource,
       );
-
-    const analysisSettings = getDefaultExperimentAnalysisSettings({
-      statsEngine,
-      experiment,
-      organization: context.org,
-      regressionAdjustmentEnabled,
-      postStratificationEnabled,
-      dimension: snapshotSettings.dimensionId,
-      pValueThreshold: scopedDashboardSettings.pValueThreshold.value,
-      metricGroups,
-    });
-
-    const queryRunner = await createSnapshot({
-      experiment,
-      context,
-      phaseIndex: experiment.phases.length - 1,
-      defaultAnalysisSettings: analysisSettings,
-      additionalAnalysisSettings: getAdditionalExperimentAnalysisSettings(
-        analysisSettings,
-      ).concat(additionalAnalysisSettings),
-      settingsForSnapshotMetrics: settingsForSnapshotMetrics || [],
-      metricMap,
-      factTableMap,
-      useCache: true,
-      type: "exploratory",
-      triggeredBy: "update-dashboards",
-    });
-    await queryRunner.waitForResults();
+      if (datasource) {
+        const probe = await planExperimentSnapshot({
+          context,
+          experiment,
+          datasource,
+          dimension: firstDimensionSettings.dimensionId,
+          phase: experiment.phases.length - 1,
+          useCache: true,
+          type: "exploratory",
+          triggeredBy: "update-dashboards",
+        });
+        if (probe.overallResultsFullRefreshWouldUnblock) {
+          await rebuildOverallResultsForDimensionBreakdowns({
+            context,
+            experiment,
+            datasource,
+            phase: experiment.phases.length - 1,
+          });
+        }
+      }
+    } catch (e) {
+      logger.warn(
+        {
+          err: e,
+          experimentId: experiment.id,
+          dimensionId: firstDimensionSettings.dimensionId,
+        },
+        "Overall Results probe or rebuild for dimension breakdowns failed; breakdowns will fall back to results this cycle",
+      );
+    }
   }
 
-  await updateDashboardSavedQueries(context, allBlocks);
+  for (const snapshotSettings of uniqueSnapshotSettings) {
+    try {
+      const additionalAnalysisSettings =
+        uniqWith<ExperimentSnapshotAnalysisSettings>(
+          snapshotAndAnalysisSettingPairs
+            .filter(([targetSettings]) =>
+              isEqual(snapshotSettings, targetSettings),
+            )
+            .map(([, analysisSettings]) => analysisSettings),
+          isEqual,
+        );
+
+      const analysisSettings = getDefaultExperimentAnalysisSettings({
+        statsEngine,
+        experiment,
+        organization: context.org,
+        regressionAdjustmentEnabled,
+        postStratificationEnabled,
+        dimension: snapshotSettings.dimensionId,
+        pValueThreshold: scopedDashboardSettings.pValueThreshold.value,
+        metricGroups,
+      });
+
+      const queryRunner = await createSnapshot({
+        experiment,
+        context,
+        phaseIndex: experiment.phases.length - 1,
+        defaultAnalysisSettings: analysisSettings,
+        additionalAnalysisSettings: getAdditionalExperimentAnalysisSettings(
+          analysisSettings,
+        ).concat(additionalAnalysisSettings),
+        settingsForSnapshotMetrics: settingsForSnapshotMetrics || [],
+        metricMap,
+        factTableMap,
+        useCache: true,
+        type: "exploratory",
+        triggeredBy: "update-dashboards",
+      });
+      await queryRunner.waitForResults();
+    } catch (e) {
+      logger.warn(
+        {
+          err: e,
+          experimentId: experiment.id,
+          dimensionId: snapshotSettings.dimensionId ?? null,
+        },
+        "Dashboard snapshot refresh failed; remaining refreshes will continue",
+      );
+    }
+  }
+
+  try {
+    await updateDashboardSavedQueries(context, allBlocks);
+  } catch (e) {
+    logger.warn(
+      { err: e, experimentId: experiment.id, unit: "saved-query-batch" },
+      "Dashboard saved query refresh failed; dashboard updates will continue",
+    );
+  }
   for (const dashboard of associatedDashboards) {
-    const editableBlocks = dashboard.blocks.map((block) =>
-      block.type === "metric-explorer" ? { ...block } : block,
-    );
-    const metricAnalysesUpdated = await updateDashboardMetricAnalyses(
-      context,
-      editableBlocks,
-    );
-    const explorationsUpdated = await updateDashboardExplorations(
-      context,
-      editableBlocks,
-      dashboard,
-    );
-    if (metricAnalysesUpdated || explorationsUpdated) {
-      await context.models.dashboards.dangerousUpdateBypassPermission(
+    try {
+      const editableBlocks = dashboard.blocks.map((block) =>
+        block.type === "metric-explorer" ? { ...block } : block,
+      );
+      const metricAnalysesUpdated = await updateDashboardMetricAnalyses(
+        context,
+        editableBlocks,
+      );
+      const explorationsUpdated = await updateDashboardExplorations(
+        context,
+        editableBlocks,
         dashboard,
-        { blocks: editableBlocks },
+      );
+      if (metricAnalysesUpdated || explorationsUpdated) {
+        await context.models.dashboards.dangerousUpdateBypassPermission(
+          dashboard,
+          { blocks: editableBlocks },
+        );
+      }
+    } catch (e) {
+      logger.warn(
+        { err: e, experimentId: experiment.id, dashboardId: dashboard.id },
+        "Dashboard dependent refresh failed; remaining dashboards will continue",
       );
     }
   }

--- a/packages/back-end/src/enterprise/services/dashboards.ts
+++ b/packages/back-end/src/enterprise/services/dashboards.ts
@@ -32,13 +32,18 @@ import { ReqContext } from "back-end/types/request";
 
 import { FactTableMap } from "back-end/src/models/FactTableModel";
 import { ApiReqContext } from "back-end/types/api";
-import { getDataSourcesByIds } from "back-end/src/models/DataSourceModel";
+import {
+  getDataSourcesByIds,
+  getDataSourceById,
+} from "back-end/src/models/DataSourceModel";
 import { executeAndSaveQuery } from "back-end/src/routers/saved-queries/saved-queries.controller";
 import {
   getDefaultExperimentAnalysisSettings,
   createSnapshot,
   getAdditionalExperimentAnalysisSettings,
   determineNextDate,
+  planExperimentSnapshot,
+  rebuildOverallResultsForDimensionBreakdowns,
 } from "back-end/src/services/experiments";
 import { createMetricAnalysis } from "back-end/src/services/metric-analysis";
 import { runProductAnalyticsExploration } from "back-end/src/enterprise/services/product-analytics";
@@ -133,26 +138,42 @@ export async function updateExperimentDashboards({
     previousSnapshots.map((snap) => [snap.id, snap]),
   );
 
-  const snapshotAndAnalysisSettingPairs = blocksNeedingSnapshot.map<
+  const snapshotAndAnalysisSettingPairs = blocksNeedingSnapshot.flatMap<
     [BlockSnapshotSettings, ExperimentSnapshotAnalysisSettings]
   >((block) => {
     const blockSnapshot = previousSnapshotMap.get(block.snapshotId);
-    if (!blockSnapshot)
-      throw new Error(
-        "Error updating dashboard results, could not find snapshot",
+    if (!blockSnapshot) {
+      logger.warn(
+        {
+          experimentId: experiment.id,
+          blockId: block.id,
+          snapshotId: block.snapshotId,
+        },
+        "Skipping dashboard block with missing snapshot",
       );
-    if (!blockSnapshot.analyses[0])
-      throw new Error(
-        "Error updating dashboard results, referenced snapshot missing analysis",
+      return [];
+    }
+    if (!blockSnapshot.analyses[0]) {
+      logger.warn(
+        {
+          experimentId: experiment.id,
+          blockId: block.id,
+          snapshotId: block.snapshotId,
+        },
+        "Skipping dashboard block with missing snapshot analysis",
       );
+      return [];
+    }
     const defaultAnalysis = blockSnapshot.analyses[0];
     return [
-      getBlockSnapshotSettings(block),
-      getBlockAnalysisSettings(
-        block,
-        (getBlockSnapshotAnalysis(blockSnapshot, block) ?? defaultAnalysis)
-          .settings,
-      ),
+      [
+        getBlockSnapshotSettings(block),
+        getBlockAnalysisSettings(
+          block,
+          (getBlockSnapshotAnalysis(blockSnapshot, block) ?? defaultAnalysis)
+            .settings,
+        ),
+      ],
     ];
   });
 
@@ -173,64 +194,130 @@ export async function updateExperimentDashboards({
   });
   const metricGroups = await context.models.metricGroups.getAll();
 
-  for (const snapshotSettings of uniqueSnapshotSettings) {
-    const additionalAnalysisSettings =
-      uniqWith<ExperimentSnapshotAnalysisSettings>(
-        snapshotAndAnalysisSettingPairs
-          .filter(([targetSettings]) =>
-            isEqual(snapshotSettings, targetSettings),
-          )
-          .map(([_, analysisSettings]) => analysisSettings),
-        isEqual,
+  const firstDimensionSettings = uniqueSnapshotSettings.find(
+    (s) => (s.dimensionId ?? "").length > 0,
+  );
+  if (firstDimensionSettings?.dimensionId) {
+    try {
+      const datasource = await getDataSourceById(
+        context,
+        experiment.datasource,
       );
-
-    const analysisSettings = getDefaultExperimentAnalysisSettings({
-      statsEngine,
-      experiment,
-      organization: context.org,
-      regressionAdjustmentEnabled,
-      postStratificationEnabled,
-      dimension: snapshotSettings.dimensionId,
-      pValueThreshold: scopedDashboardSettings.pValueThreshold.value,
-      metricGroups,
-    });
-
-    const queryRunner = await createSnapshot({
-      experiment,
-      context,
-      phaseIndex: experiment.phases.length - 1,
-      defaultAnalysisSettings: analysisSettings,
-      additionalAnalysisSettings: getAdditionalExperimentAnalysisSettings(
-        analysisSettings,
-      ).concat(additionalAnalysisSettings),
-      settingsForSnapshotMetrics: settingsForSnapshotMetrics || [],
-      metricMap,
-      factTableMap,
-      useCache: true,
-      type: "exploratory",
-      triggeredBy: "update-dashboards",
-    });
-    await queryRunner.waitForResults();
+      if (datasource) {
+        const probe = await planExperimentSnapshot({
+          context,
+          experiment,
+          datasource,
+          dimension: firstDimensionSettings.dimensionId,
+          phase: experiment.phases.length - 1,
+          useCache: true,
+          type: "exploratory",
+          triggeredBy: "update-dashboards",
+        });
+        if (probe.overallResultsFullRefreshWouldUnblock) {
+          await rebuildOverallResultsForDimensionBreakdowns({
+            context,
+            experiment,
+            datasource,
+            phase: experiment.phases.length - 1,
+          });
+        }
+      }
+    } catch (e) {
+      logger.warn(
+        {
+          err: e,
+          experimentId: experiment.id,
+          dimensionId: firstDimensionSettings.dimensionId,
+        },
+        "Overall Results probe or rebuild for dimension breakdowns failed; breakdowns will fall back to results this cycle",
+      );
+    }
   }
 
-  await updateDashboardSavedQueries(context, allBlocks);
+  for (const snapshotSettings of uniqueSnapshotSettings) {
+    try {
+      const additionalAnalysisSettings =
+        uniqWith<ExperimentSnapshotAnalysisSettings>(
+          snapshotAndAnalysisSettingPairs
+            .filter(([targetSettings]) =>
+              isEqual(snapshotSettings, targetSettings),
+            )
+            .map(([, analysisSettings]) => analysisSettings),
+          isEqual,
+        );
+
+      const analysisSettings = getDefaultExperimentAnalysisSettings({
+        statsEngine,
+        experiment,
+        organization: context.org,
+        regressionAdjustmentEnabled,
+        postStratificationEnabled,
+        dimension: snapshotSettings.dimensionId,
+        pValueThreshold: scopedDashboardSettings.pValueThreshold.value,
+        metricGroups,
+      });
+
+      const queryRunner = await createSnapshot({
+        experiment,
+        context,
+        phaseIndex: experiment.phases.length - 1,
+        defaultAnalysisSettings: analysisSettings,
+        additionalAnalysisSettings: getAdditionalExperimentAnalysisSettings(
+          analysisSettings,
+        ).concat(additionalAnalysisSettings),
+        settingsForSnapshotMetrics: settingsForSnapshotMetrics || [],
+        metricMap,
+        factTableMap,
+        useCache: true,
+        type: "exploratory",
+        triggeredBy: "update-dashboards",
+      });
+      await queryRunner.waitForResults();
+    } catch (e) {
+      logger.warn(
+        {
+          err: e,
+          experimentId: experiment.id,
+          dimensionId: snapshotSettings.dimensionId ?? null,
+        },
+        "Dashboard snapshot refresh failed; remaining refreshes will continue",
+      );
+    }
+  }
+
+  try {
+    await updateDashboardSavedQueries(context, allBlocks);
+  } catch (e) {
+    logger.warn(
+      { err: e, experimentId: experiment.id, unit: "saved-query-batch" },
+      "Dashboard saved query refresh failed; dashboard updates will continue",
+    );
+  }
   for (const dashboard of associatedDashboards) {
-    const editableBlocks = dashboard.blocks.map((block) =>
-      block.type === "metric-explorer" ? { ...block } : block,
-    );
-    const metricAnalysesUpdated = await updateDashboardMetricAnalyses(
-      context,
-      editableBlocks,
-    );
-    const explorationsUpdated = await updateDashboardExplorations(
-      context,
-      editableBlocks,
-      dashboard,
-    );
-    if (metricAnalysesUpdated || explorationsUpdated) {
-      await context.models.dashboards.dangerousUpdateBypassPermission(
+    try {
+      const editableBlocks = dashboard.blocks.map((block) =>
+        block.type === "metric-explorer" ? { ...block } : block,
+      );
+      const metricAnalysesUpdated = await updateDashboardMetricAnalyses(
+        context,
+        editableBlocks,
+      );
+      const explorationsUpdated = await updateDashboardExplorations(
+        context,
+        editableBlocks,
         dashboard,
-        { blocks: editableBlocks },
+      );
+      if (metricAnalysesUpdated || explorationsUpdated) {
+        await context.models.dashboards.dangerousUpdateBypassPermission(
+          dashboard,
+          { blocks: editableBlocks },
+        );
+      }
+    } catch (e) {
+      logger.warn(
+        { err: e, experimentId: experiment.id, dashboardId: dashboard.id },
+        "Dashboard dependent refresh failed; remaining dashboards will continue",
       );
     }
   }

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -633,6 +633,9 @@ export async function updateSnapshot({
     experimentSnapshot.status === "success" &&
     // Only use main snapshots or those triggered automatically for dashboards
     experimentSnapshot.triggeredBy !== "manual-dashboard" &&
+    // The dependency rebuild only exists to materialize Overall Results for a
+    // fan-out in progress; it must not become a block's data source.
+    experimentSnapshot.triggeredBy !== "dashboard-dependency" &&
     (experimentSnapshot.triggeredBy === "update-dashboards" ||
       experimentSnapshot.type === "standard")
   ) {

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -642,6 +642,9 @@ export async function updateSnapshot({
     experimentSnapshot.status === "success" &&
     // Only use main snapshots or those triggered automatically for dashboards
     experimentSnapshot.triggeredBy !== "manual-dashboard" &&
+    // The dependency rebuild only exists to materialize Overall Results for a
+    // fan-out in progress; it must not become a block's data source.
+    experimentSnapshot.triggeredBy !== "dashboard-dependency" &&
     (experimentSnapshot.triggeredBy === "update-dashboards" ||
       experimentSnapshot.type === "standard")
   ) {

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -1710,6 +1710,7 @@ function shouldIncrementalThrowErrorInsteadOfFallback(
     case "manual-dashboard":
     case "schedule":
     case "update-dashboards":
+    case "dashboard-dependency":
       return false;
     default: {
       triggeredBy satisfies never;
@@ -2141,28 +2142,43 @@ export async function createSnapshotFromPlan({
     // Whenever the standard snapshot for an experiment is refreshed, also refresh the associated dashboards in the background
     if (
       runningSnapshot.type === "standard" &&
-      runningSnapshot.triggeredBy !== "manual-dashboard"
+      runningSnapshot.triggeredBy !== "manual-dashboard" &&
+      // The dependency rebuild materializes Overall Results for a fan-out already
+      // in progress. Re-driving the fan-out from its completion would loop.
+      runningSnapshot.triggeredBy !== "dashboard-dependency"
     ) {
       const defaultAnalysisSettings = runningSnapshot.analyses[0]?.settings;
       if (!defaultAnalysisSettings) {
         throw new Error("Snapshot is missing its default analysis settings");
       }
 
-      updateExperimentDashboards({
-        context,
-        experiment,
-        mainSnapshot: runningSnapshot,
-        statsEngine: defaultAnalysisSettings.statsEngine,
-        regressionAdjustmentEnabled:
-          defaultAnalysisSettings.regressionAdjusted ??
-          DEFAULT_REGRESSION_ADJUSTMENT_ENABLED,
-        postStratificationEnabled:
-          defaultAnalysisSettings.postStratificationEnabled ??
-          DEFAULT_POST_STRATIFICATION_ENABLED,
-        settingsForSnapshotMetrics: plan.settingsForSnapshotMetrics,
-        metricMap,
-        factTableMap,
-      });
+      // Dimension snapshots share the incremental tables, so wait until the
+      // standard runner has finished and released its lock before starting them.
+      void queryRunner
+        .waitForResults()
+        .then(() =>
+          updateExperimentDashboards({
+            context,
+            experiment,
+            mainSnapshot: runningSnapshot,
+            statsEngine: defaultAnalysisSettings.statsEngine,
+            regressionAdjustmentEnabled:
+              defaultAnalysisSettings.regressionAdjusted ??
+              DEFAULT_REGRESSION_ADJUSTMENT_ENABLED,
+            postStratificationEnabled:
+              defaultAnalysisSettings.postStratificationEnabled ??
+              DEFAULT_POST_STRATIFICATION_ENABLED,
+            settingsForSnapshotMetrics: plan.settingsForSnapshotMetrics,
+            metricMap,
+            factTableMap,
+          }),
+        )
+        .catch((error: unknown) => {
+          context.logger.error(
+            error,
+            `Failed to refresh dashboards for experiment ${experiment.id}`,
+          );
+        });
     }
 
     return queryRunner;
@@ -2361,6 +2377,48 @@ export async function createExperimentSnapshot({
     context,
     experiment,
   });
+}
+
+/**
+ * Rebuilds the Overall Results units table (full refresh) for the given phase so
+ * subsequent dimension breakdowns run incrementally instead of via the full-scan
+ * results runner. Awaits completion. Runs once; callers MUST NOT retry.
+ * useCache:false forces a genuine rebuild, required for the stale-by-hash /
+ * built-without-pipeline cases where the table exists but must be rebuilt, not
+ * appended.
+ */
+export async function rebuildOverallResultsForDimensionBreakdowns({
+  context,
+  experiment,
+  datasource,
+  phase,
+}: {
+  context: ReqContext | ApiReqContext;
+  experiment: ExperimentInterface;
+  datasource: DataSourceInterface;
+  phase: number;
+}): Promise<void> {
+  const { queryRunner } = await createExperimentSnapshot({
+    context,
+    experiment,
+    datasource,
+    dimension: undefined,
+    phase,
+    type: "standard",
+    useCache: false,
+    triggeredBy: "dashboard-dependency",
+  });
+  await queryRunner.waitForResults();
+  const refreshState =
+    await context.models.incrementalRefresh.getByExperimentIdAndPhase(
+      experiment.id,
+      phase,
+    );
+  if ((refreshState?.unitsTableFullName ?? null) === null) {
+    context.logger.warn(
+      `Experiment ${experiment.id}: Overall Results rebuild completed without a units table for phase ${phase}; dimension breakdowns will fall back to non-incremental queries this cycle.`,
+    );
+  }
 }
 
 export async function createExperimentSnapshotFromPlan({

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -1739,6 +1739,7 @@ function shouldIncrementalThrowErrorInsteadOfFallback(
     case "manual-dashboard":
     case "schedule":
     case "update-dashboards":
+    case "dashboard-dependency":
       return false;
     default: {
       triggeredBy satisfies never;
@@ -2168,28 +2169,43 @@ export async function createSnapshotFromPlan({
     // Whenever the standard snapshot for an experiment is refreshed, also refresh the associated dashboards in the background
     if (
       runningSnapshot.type === "standard" &&
-      runningSnapshot.triggeredBy !== "manual-dashboard"
+      runningSnapshot.triggeredBy !== "manual-dashboard" &&
+      // The dependency rebuild materializes Overall Results for a fan-out already
+      // in progress. Re-driving the fan-out from its completion would loop.
+      runningSnapshot.triggeredBy !== "dashboard-dependency"
     ) {
       const defaultAnalysisSettings = runningSnapshot.analyses[0]?.settings;
       if (!defaultAnalysisSettings) {
         throw new Error("Snapshot is missing its default analysis settings");
       }
 
-      updateExperimentDashboards({
-        context,
-        experiment,
-        mainSnapshot: runningSnapshot,
-        statsEngine: defaultAnalysisSettings.statsEngine,
-        regressionAdjustmentEnabled:
-          defaultAnalysisSettings.regressionAdjusted ??
-          DEFAULT_REGRESSION_ADJUSTMENT_ENABLED,
-        postStratificationEnabled:
-          defaultAnalysisSettings.postStratificationEnabled ??
-          DEFAULT_POST_STRATIFICATION_ENABLED,
-        settingsForSnapshotMetrics: plan.settingsForSnapshotMetrics,
-        metricMap,
-        factTableMap,
-      });
+      // Dimension snapshots share the incremental tables, so wait until the
+      // standard runner has finished and released its lock before starting them.
+      void queryRunner
+        .waitForResults()
+        .then(() =>
+          updateExperimentDashboards({
+            context,
+            experiment,
+            mainSnapshot: runningSnapshot,
+            statsEngine: defaultAnalysisSettings.statsEngine,
+            regressionAdjustmentEnabled:
+              defaultAnalysisSettings.regressionAdjusted ??
+              DEFAULT_REGRESSION_ADJUSTMENT_ENABLED,
+            postStratificationEnabled:
+              defaultAnalysisSettings.postStratificationEnabled ??
+              DEFAULT_POST_STRATIFICATION_ENABLED,
+            settingsForSnapshotMetrics: plan.settingsForSnapshotMetrics,
+            metricMap,
+            factTableMap,
+          }),
+        )
+        .catch((error: unknown) => {
+          context.logger.error(
+            error,
+            `Failed to refresh dashboards for experiment ${experiment.id}`,
+          );
+        });
     }
 
     return queryRunner;
@@ -2388,6 +2404,48 @@ export async function createExperimentSnapshot({
     context,
     experiment,
   });
+}
+
+/**
+ * Rebuilds the Overall Results units table (full refresh) for the given phase so
+ * subsequent dimension breakdowns run incrementally instead of via the full-scan
+ * results runner. Awaits completion. Runs once; callers MUST NOT retry.
+ * useCache:false forces a genuine rebuild, required for the stale-by-hash /
+ * built-without-pipeline cases where the table exists but must be rebuilt, not
+ * appended.
+ */
+export async function rebuildOverallResultsForDimensionBreakdowns({
+  context,
+  experiment,
+  datasource,
+  phase,
+}: {
+  context: ReqContext | ApiReqContext;
+  experiment: ExperimentInterface;
+  datasource: DataSourceInterface;
+  phase: number;
+}): Promise<void> {
+  const { queryRunner } = await createExperimentSnapshot({
+    context,
+    experiment,
+    datasource,
+    dimension: undefined,
+    phase,
+    type: "standard",
+    useCache: false,
+    triggeredBy: "dashboard-dependency",
+  });
+  await queryRunner.waitForResults();
+  const refreshState =
+    await context.models.incrementalRefresh.getByExperimentIdAndPhase(
+      experiment.id,
+      phase,
+    );
+  if ((refreshState?.unitsTableFullName ?? null) === null) {
+    context.logger.warn(
+      `Experiment ${experiment.id}: Overall Results rebuild completed without a units table for phase ${phase}; dimension breakdowns will fall back to non-incremental queries this cycle.`,
+    );
+  }
 }
 
 export async function createExperimentSnapshotFromPlan({

--- a/packages/back-end/test/enterprise/dashboards.test.ts
+++ b/packages/back-end/test/enterprise/dashboards.test.ts
@@ -1,0 +1,410 @@
+import { DashboardInterface } from "shared/enterprise";
+import { ExperimentInterface } from "shared/types/experiment";
+import {
+  ExperimentSnapshotAnalysisSettings,
+  ExperimentSnapshotInterface,
+} from "shared/types/experiment-snapshot";
+import { ApiReqContext } from "back-end/types/api";
+import {
+  getDataSourceById,
+  getDataSourcesByIds,
+} from "back-end/src/models/DataSourceModel";
+import { findSnapshotsByIds } from "back-end/src/models/ExperimentSnapshotModel";
+import {
+  createSnapshot,
+  getAdditionalExperimentAnalysisSettings,
+  getDefaultExperimentAnalysisSettings,
+  planExperimentSnapshot,
+  rebuildOverallResultsForDimensionBreakdowns,
+} from "back-end/src/services/experiments";
+import { createMetricAnalysis } from "back-end/src/services/metric-analysis";
+import { updateExperimentDashboards } from "back-end/src/enterprise/services/dashboards";
+import { logger } from "back-end/src/util/logger";
+import { snapshotFactory } from "back-end/test/factories/Snapshot.factory";
+
+jest.mock("shared/settings", () => ({
+  getScopedSettings: jest.fn().mockReturnValue({
+    settings: { pValueThreshold: { value: 0.05 } },
+  }),
+}));
+
+jest.mock("back-end/src/models/DataSourceModel", () => ({
+  getDataSourceById: jest.fn(),
+  getDataSourcesByIds: jest.fn(),
+}));
+
+jest.mock("back-end/src/models/ExperimentSnapshotModel", () => ({
+  findSnapshotsByIds: jest.fn(),
+}));
+
+jest.mock("back-end/src/services/experiments", () => ({
+  createSnapshot: jest.fn(),
+  determineNextDate: jest.fn(),
+  getAdditionalExperimentAnalysisSettings: jest.fn(),
+  getDefaultExperimentAnalysisSettings: jest.fn(),
+  planExperimentSnapshot: jest.fn(),
+  rebuildOverallResultsForDimensionBreakdowns: jest.fn(),
+}));
+
+jest.mock("back-end/src/services/metric-analysis", () => ({
+  createMetricAnalysis: jest.fn(),
+}));
+
+jest.mock(
+  "back-end/src/routers/saved-queries/saved-queries.controller",
+  () => ({
+    executeAndSaveQuery: jest.fn(),
+  }),
+);
+
+jest.mock("back-end/src/enterprise/services/product-analytics", () => ({
+  runProductAnalyticsExploration: jest.fn(),
+}));
+
+jest.mock("back-end/src/util/logger", () => ({
+  logger: { warn: jest.fn() },
+}));
+
+const findSnapshotsByIdsMock = findSnapshotsByIds as jest.MockedFunction<
+  typeof findSnapshotsByIds
+>;
+const getDataSourceByIdMock = getDataSourceById as jest.MockedFunction<
+  typeof getDataSourceById
+>;
+const getDataSourcesByIdsMock = getDataSourcesByIds as jest.MockedFunction<
+  typeof getDataSourcesByIds
+>;
+const createSnapshotMock = createSnapshot as jest.MockedFunction<
+  typeof createSnapshot
+>;
+const getAdditionalExperimentAnalysisSettingsMock =
+  getAdditionalExperimentAnalysisSettings as jest.MockedFunction<
+    typeof getAdditionalExperimentAnalysisSettings
+  >;
+const getDefaultExperimentAnalysisSettingsMock =
+  getDefaultExperimentAnalysisSettings as jest.MockedFunction<
+    typeof getDefaultExperimentAnalysisSettings
+  >;
+const planExperimentSnapshotMock =
+  planExperimentSnapshot as jest.MockedFunction<typeof planExperimentSnapshot>;
+const rebuildOverallResultsForDimensionBreakdownsMock =
+  rebuildOverallResultsForDimensionBreakdowns as jest.MockedFunction<
+    typeof rebuildOverallResultsForDimensionBreakdowns
+  >;
+const createMetricAnalysisMock = createMetricAnalysis as jest.MockedFunction<
+  typeof createMetricAnalysis
+>;
+const loggerWarnMock = logger.warn as jest.MockedFunction<typeof logger.warn>;
+
+const defaultAnalysisSettings = {
+  dimensions: [],
+  differenceType: "relative",
+  baselineVariationIndex: 0,
+} as unknown as ExperimentSnapshotAnalysisSettings;
+
+function makeDimensionBlock({
+  id,
+  dimensionId,
+  snapshotId,
+}: {
+  id: string;
+  dimensionId: string;
+  snapshotId: string;
+}): DashboardInterface["blocks"][number] {
+  return {
+    id,
+    type: "experiment-dimension",
+    experimentId: "exp_123",
+    dimensionId,
+    snapshotId,
+    differenceType: "relative",
+    baselineRow: 0,
+  } as DashboardInterface["blocks"][number];
+}
+
+function makeMetricBlock(id: string): DashboardInterface["blocks"][number] {
+  return {
+    id,
+    type: "metric-explorer",
+    metricAnalysisId: `ma_${id}`,
+    analysisSettings: {
+      userIdType: "user_id",
+      startDate: new Date("2026-07-01T00:00:00.000Z"),
+      endDate: new Date("2026-08-01T00:00:00.000Z"),
+      lookbackDays: 30,
+      populationType: "metric",
+      populationId: null,
+    },
+  } as DashboardInterface["blocks"][number];
+}
+
+function makeDashboard({
+  id,
+  blocks,
+}: {
+  id: string;
+  blocks: DashboardInterface["blocks"];
+}): DashboardInterface {
+  return { id, blocks } as DashboardInterface;
+}
+
+function makePreviousSnapshot({
+  id,
+  dimension,
+}: {
+  id: string;
+  dimension: string;
+}): ExperimentSnapshotInterface {
+  return snapshotFactory.build({
+    id,
+    experiment: "exp_123",
+    dimension,
+    analyses: [
+      {
+        settings: defaultAnalysisSettings,
+        status: "success",
+      } as ExperimentSnapshotInterface["analyses"][number],
+    ],
+  });
+}
+
+type TestContext = ApiReqContext & {
+  models: ApiReqContext["models"] & {
+    dashboards: {
+      findByExperiment: jest.Mock;
+      dangerousUpdateBypassPermission: jest.Mock;
+    };
+    metricAnalysis: { getById: jest.Mock };
+    savedQueries: { getByIds: jest.Mock };
+  };
+};
+
+function makeContext(dashboards: DashboardInterface[]): TestContext {
+  return {
+    org: { id: "org_123", settings: {} },
+    models: {
+      dashboards: {
+        findByExperiment: jest.fn().mockResolvedValue(dashboards),
+        dangerousUpdateBypassPermission: jest.fn().mockResolvedValue(undefined),
+      },
+      projects: { getById: jest.fn().mockResolvedValue(null) },
+      metricGroups: { getAll: jest.fn().mockResolvedValue([]) },
+      metricAnalysis: {
+        getById: jest.fn().mockImplementation(async (id: string) => ({
+          id,
+          metric: `fm_${id}`,
+        })),
+      },
+      factMetrics: { getById: jest.fn().mockResolvedValue({ id: "fm_123" }) },
+      savedQueries: { getByIds: jest.fn().mockResolvedValue([]) },
+    },
+  } as unknown as TestContext;
+}
+
+const experiment = {
+  id: "exp_123",
+  organization: "org_123",
+  datasource: "ds_123",
+  project: "",
+  phases: [{}],
+} as unknown as ExperimentInterface;
+
+const mainSnapshot = snapshotFactory.build({
+  experiment: experiment.id,
+  dimension: null,
+  settings: {
+    dimensions: [],
+    precomputedUnitDimensionIds: [],
+  } as unknown as ExperimentSnapshotInterface["settings"],
+});
+
+async function update(context: ApiReqContext): Promise<void> {
+  await updateExperimentDashboards({
+    context,
+    experiment,
+    mainSnapshot,
+    statsEngine: "bayesian",
+    regressionAdjustmentEnabled: false,
+    postStratificationEnabled: false,
+    settingsForSnapshotMetrics: [],
+    metricMap: new Map(),
+    factTableMap: new Map(),
+  });
+}
+
+describe("updateExperimentDashboards", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getDataSourceByIdMock.mockResolvedValue({ id: "ds_123" } as never);
+    getDataSourcesByIdsMock.mockResolvedValue([]);
+    findSnapshotsByIdsMock.mockResolvedValue([]);
+    getDefaultExperimentAnalysisSettingsMock.mockReturnValue(
+      defaultAnalysisSettings,
+    );
+    getAdditionalExperimentAnalysisSettingsMock.mockReturnValue([]);
+    planExperimentSnapshotMock.mockResolvedValue({
+      overallResultsFullRefreshWouldUnblock: false,
+    } as never);
+    rebuildOverallResultsForDimensionBreakdownsMock.mockResolvedValue(
+      undefined,
+    );
+    createSnapshotMock.mockResolvedValue({
+      waitForResults: jest.fn().mockResolvedValue(undefined),
+    } as never);
+    createMetricAnalysisMock.mockResolvedValue({
+      model: { id: "ma_refreshed" },
+    } as never);
+  });
+
+  it("continues snapshot and dashboard work when the Overall Results probe fails", async () => {
+    const dimensionBlock = makeDimensionBlock({
+      id: "block_dimension",
+      dimensionId: "exp:country",
+      snapshotId: "snp_country",
+    });
+    const context = makeContext([
+      makeDashboard({
+        id: "dash_1",
+        blocks: [dimensionBlock, makeMetricBlock("metric_1")],
+      }),
+    ]);
+    findSnapshotsByIdsMock.mockResolvedValue([
+      makePreviousSnapshot({
+        id: "snp_country",
+        dimension: "exp:country",
+      }),
+    ]);
+    planExperimentSnapshotMock.mockRejectedValue(new Error("probe failed"));
+
+    await update(context);
+
+    expect(createSnapshotMock).toHaveBeenCalledTimes(1);
+    expect(context.models.savedQueries.getByIds).toHaveBeenCalled();
+    expect(createMetricAnalysisMock).toHaveBeenCalledTimes(1);
+    expect(
+      context.models.dashboards.dangerousUpdateBypassPermission,
+    ).toHaveBeenCalledTimes(1);
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        experimentId: experiment.id,
+        dimensionId: "exp:country",
+      }),
+      expect.stringContaining("probe or rebuild"),
+    );
+  });
+
+  it("continues later dimensions and dashboard work when one snapshot runner fails", async () => {
+    const blocks = [
+      makeDimensionBlock({
+        id: "block_country",
+        dimensionId: "exp:country",
+        snapshotId: "snp_country",
+      }),
+      makeDimensionBlock({
+        id: "block_browser",
+        dimensionId: "exp:browser",
+        snapshotId: "snp_browser",
+      }),
+      makeMetricBlock("metric_1"),
+    ];
+    const context = makeContext([makeDashboard({ id: "dash_1", blocks })]);
+    findSnapshotsByIdsMock.mockResolvedValue([
+      makePreviousSnapshot({
+        id: "snp_country",
+        dimension: "exp:country",
+      }),
+      makePreviousSnapshot({
+        id: "snp_browser",
+        dimension: "exp:browser",
+      }),
+    ]);
+    const firstWaitForResults = jest
+      .fn()
+      .mockRejectedValue(new Error("runner failed"));
+    const secondWaitForResults = jest.fn().mockResolvedValue(undefined);
+    createSnapshotMock
+      .mockResolvedValueOnce({ waitForResults: firstWaitForResults } as never)
+      .mockResolvedValueOnce({ waitForResults: secondWaitForResults } as never);
+
+    await update(context);
+
+    expect(createSnapshotMock).toHaveBeenCalledTimes(2);
+    expect(firstWaitForResults).toHaveBeenCalledTimes(1);
+    expect(secondWaitForResults).toHaveBeenCalledTimes(1);
+    expect(context.models.savedQueries.getByIds).toHaveBeenCalled();
+    expect(createMetricAnalysisMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops a stale block and refreshes the remaining block", async () => {
+    const context = makeContext([
+      makeDashboard({
+        id: "dash_1",
+        blocks: [
+          makeDimensionBlock({
+            id: "block_stale",
+            dimensionId: "exp:country",
+            snapshotId: "snp_missing",
+          }),
+          makeDimensionBlock({
+            id: "block_valid",
+            dimensionId: "exp:browser",
+            snapshotId: "snp_browser",
+          }),
+        ],
+      }),
+    ]);
+    findSnapshotsByIdsMock.mockResolvedValue([
+      makePreviousSnapshot({
+        id: "snp_browser",
+        dimension: "exp:browser",
+      }),
+    ]);
+
+    await update(context);
+
+    expect(createSnapshotMock).toHaveBeenCalledTimes(1);
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        experimentId: experiment.id,
+        blockId: "block_stale",
+        snapshotId: "snp_missing",
+      }),
+      expect.stringContaining("missing snapshot"),
+    );
+  });
+
+  it("continues dashboard tails after saved-query and dashboard failures", async () => {
+    const context = makeContext([
+      makeDashboard({ id: "dash_1", blocks: [makeMetricBlock("metric_1")] }),
+      makeDashboard({ id: "dash_2", blocks: [makeMetricBlock("metric_2")] }),
+    ]);
+    context.models.savedQueries.getByIds.mockRejectedValue(
+      new Error("saved queries failed"),
+    );
+    context.models.metricAnalysis.getById
+      .mockRejectedValueOnce(new Error("dashboard failed"))
+      .mockResolvedValueOnce({ id: "ma_metric_2", metric: "fm_metric_2" });
+
+    await update(context);
+
+    expect(context.models.metricAnalysis.getById).toHaveBeenCalledTimes(2);
+    expect(createMetricAnalysisMock).toHaveBeenCalledTimes(1);
+    expect(
+      context.models.dashboards.dangerousUpdateBypassPermission,
+    ).toHaveBeenCalledTimes(1);
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        experimentId: experiment.id,
+        unit: "saved-query-batch",
+      }),
+      expect.stringContaining("saved query refresh failed"),
+    );
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        experimentId: experiment.id,
+        dashboardId: "dash_1",
+      }),
+      expect.stringContaining("dependent refresh failed"),
+    );
+  });
+});

--- a/packages/back-end/test/services/snapshot-lifecycle.test.ts
+++ b/packages/back-end/test/services/snapshot-lifecycle.test.ts
@@ -52,6 +52,7 @@ jest.mock("back-end/src/queryRunners/ExperimentResultsQueryRunner", () => ({
     .mockImplementation((_context, snapshot) => ({
       model: snapshot,
       startAnalysis: jest.fn(),
+      waitForResults: jest.fn().mockResolvedValue(undefined),
       setExperimentUpdateExecutionLogger: jest.fn(),
     })),
 }));
@@ -64,6 +65,7 @@ jest.mock(
       .mockImplementation((_context, snapshot) => ({
         model: snapshot,
         startAnalysis: jest.fn(),
+        waitForResults: jest.fn().mockResolvedValue(undefined),
         setExperimentUpdateExecutionLogger: jest.fn(),
       })),
   }),
@@ -77,6 +79,7 @@ jest.mock(
       .mockImplementation((_context, snapshot) => ({
         model: snapshot,
         startAnalysis: jest.fn(),
+        waitForResults: jest.fn().mockResolvedValue(undefined),
         setExperimentUpdateExecutionLogger: jest.fn(),
       })),
   }),
@@ -298,6 +301,54 @@ describe("snapshot lifecycle", () => {
         queryParentId: plan.snapshot.id,
       }),
     );
+    expect(updateExperimentDashboardsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context,
+        experiment,
+        mainSnapshot: plan.snapshot,
+        metricMap,
+        factTableMap,
+      }),
+    );
+  });
+
+  it("waits for the standard snapshot to finish before refreshing dashboards", async () => {
+    const context = makeContext();
+    const experiment = makeExperiment();
+    const plan = makePlan({
+      runnerKind: "incremental-full",
+      fullRefresh: true,
+    });
+    const metricMap = new Map<string, ExperimentMetricInterface>();
+    const factTableMap = new Map() as FactTableMap;
+    let finishSnapshot: () => void = () => {};
+    const waitForResults = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishSnapshot = resolve;
+        }),
+    );
+    incrementalQueryRunnerMock.mockImplementationOnce((_context, snapshot) => ({
+      model: snapshot,
+      startAnalysis: jest.fn(),
+      waitForResults,
+      setExperimentUpdateExecutionLogger: jest.fn(),
+    }));
+
+    await createSnapshotFromPlan({
+      plan,
+      context,
+      experiment,
+      metricMap,
+      factTableMap,
+    });
+
+    expect(waitForResults).toHaveBeenCalledTimes(1);
+    expect(updateExperimentDashboardsMock).not.toHaveBeenCalled();
+
+    finishSnapshot();
+    await waitForResults.mock.results[0].value;
+
     expect(updateExperimentDashboardsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         context,

--- a/packages/back-end/test/services/snapshot-lifecycle.test.ts
+++ b/packages/back-end/test/services/snapshot-lifecycle.test.ts
@@ -52,6 +52,7 @@ jest.mock("back-end/src/queryRunners/ExperimentResultsQueryRunner", () => ({
     .mockImplementation((_context, snapshot) => ({
       model: snapshot,
       startAnalysis: jest.fn(),
+      waitForResults: jest.fn().mockResolvedValue(undefined),
       setExperimentUpdateExecutionLogger: jest.fn(),
     })),
 }));
@@ -64,6 +65,7 @@ jest.mock(
       .mockImplementation((_context, snapshot) => ({
         model: snapshot,
         startAnalysis: jest.fn(),
+        waitForResults: jest.fn().mockResolvedValue(undefined),
         setExperimentUpdateExecutionLogger: jest.fn(),
       })),
   }),
@@ -77,6 +79,7 @@ jest.mock(
       .mockImplementation((_context, snapshot) => ({
         model: snapshot,
         startAnalysis: jest.fn(),
+        waitForResults: jest.fn().mockResolvedValue(undefined),
         setExperimentUpdateExecutionLogger: jest.fn(),
       })),
   }),
@@ -297,6 +300,54 @@ describe("snapshot lifecycle", () => {
         queryParentId: plan.snapshot.id,
       }),
     );
+    expect(updateExperimentDashboardsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context,
+        experiment,
+        mainSnapshot: plan.snapshot,
+        metricMap,
+        factTableMap,
+      }),
+    );
+  });
+
+  it("waits for the standard snapshot to finish before refreshing dashboards", async () => {
+    const context = makeContext();
+    const experiment = makeExperiment();
+    const plan = makePlan({
+      runnerKind: "incremental-full",
+      fullRefresh: true,
+    });
+    const metricMap = new Map<string, ExperimentMetricInterface>();
+    const factTableMap = new Map() as FactTableMap;
+    let finishSnapshot: () => void = () => {};
+    const waitForResults = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishSnapshot = resolve;
+        }),
+    );
+    incrementalQueryRunnerMock.mockImplementationOnce((_context, snapshot) => ({
+      model: snapshot,
+      startAnalysis: jest.fn(),
+      waitForResults,
+      setExperimentUpdateExecutionLogger: jest.fn(),
+    }));
+
+    await createSnapshotFromPlan({
+      plan,
+      context,
+      experiment,
+      metricMap,
+      factTableMap,
+    });
+
+    expect(waitForResults).toHaveBeenCalledTimes(1);
+    expect(updateExperimentDashboardsMock).not.toHaveBeenCalled();
+
+    finishSnapshot();
+    await waitForResults.mock.results[0].value;
+
     expect(updateExperimentDashboardsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         context,

--- a/packages/shared/types/experiment-snapshot.d.ts
+++ b/packages/shared/types/experiment-snapshot.d.ts
@@ -152,7 +152,8 @@ export type SnapshotTriggeredBy =
   | "schedule"
   | "manual"
   | "manual-dashboard"
-  | "update-dashboards";
+  | "update-dashboards"
+  | "dashboard-dependency";
 
 export interface ExperimentSnapshotAnalysis {
   // Stable per snapshot-analysis key used to identify the chunked row data


### PR DESCRIPTION
### Features and Changes

- When refreshing an experiment's dashboards, probe the planner once and, if a full refresh of Overall Results would unblock incremental breakdowns, rebuild Overall once via a new `dashboard-dependency` trigger so breakdowns run incrementally instead of on the full-scan results runner.
- Exclude the `dashboard-dependency` snapshot from both dashboard re-entry hooks so the fan-out cannot loop, and never adopt it as a block's data source.
- Defer the post-standard-snapshot dashboard refresh until the runner releases its incremental lock.
- Harden `updateExperimentDashboards` so a missing snapshot or a single failed refresh no longer aborts the whole cycle.

### Testing

- `pnpm --filter back-end test test/api/snapshots.test.ts test/services/snapshot-planning.test.ts test/services/snapshot-lifecycle.test.ts test/services/snapshot-query-runner-kind.test.ts test/enterprise/dashboards.test.ts`
