### PR TITLE
fix(experiments): Hide VariationLabel names less aggressively 

### DIFF
--- a/packages/front-end/ui/VariationLabel.stories.tsx
+++ b/packages/front-end/ui/VariationLabel.stories.tsx
@@ -63,23 +63,18 @@ export default function VariationLabelStories() {
           Number-only (very limited space)
         </Text>
         <Flex direction="column" gap="2">
-          {([60, 40] as const).map((width) => (
-            <Flex key={width} gap="2" align="center">
-              <Text size="1" style={{ width: 64, color: "var(--gray-9)" }}>
-                {width}px
-              </Text>
-              <Box
-                width={`${width}px`}
-                p="2"
-                style={{ border: "1px solid var(--gray-6)" }}
-              >
-                <VariationLabel
-                  number={1}
-                  name="A very long variation name that should truncate"
-                />
-              </Box>
-            </Flex>
-          ))}
+          <Flex key="40px" gap="2" align="center">
+            <Text size="1" style={{ width: 64, color: "var(--gray-9)" }}>
+              40px
+            </Text>
+            <Box
+              width="40px"
+              p="2"
+              style={{ border: "1px solid var(--gray-6)" }}
+            >
+              <VariationLabel number={1} name="v1" size="sm" />
+            </Box>
+          </Flex>
         </Flex>
       </Flex>
 

--- a/packages/front-end/ui/VariationLabel.stories.tsx
+++ b/packages/front-end/ui/VariationLabel.stories.tsx
@@ -60,26 +60,36 @@ export default function VariationLabelStories() {
 
       <Flex direction="column" gap="2">
         <Text size="2" weight="bold">
-          Number-only (very limited space)
+          Names hidden when available width is too narrow
         </Text>
         <Flex direction="column" gap="2">
-          {([60, 40] as const).map((width) => (
-            <Flex key={width} gap="2" align="center">
-              <Text size="1" style={{ width: 64, color: "var(--gray-9)" }}>
-                {width}px
-              </Text>
-              <Box
-                width={`${width}px`}
-                p="2"
-                style={{ border: "1px solid var(--gray-6)" }}
-              >
-                <VariationLabel
-                  number={1}
-                  name="A very long variation name that should truncate"
-                />
-              </Box>
-            </Flex>
-          ))}
+          <Flex key="60px" gap="2" align="center">
+            <Text size="1" style={{ width: 64, color: "var(--gray-9)" }}>
+              Name hidden
+            </Text>
+            <Box
+              width="60px"
+              p="2"
+              style={{ border: "1px solid var(--gray-6)" }}
+            >
+              <VariationLabel
+                number={1}
+                name="A very long variation name that should truncate"
+              />
+            </Box>
+          </Flex>
+          <Flex key="60px" gap="2" align="center">
+            <Text size="1" style={{ width: 64, color: "var(--gray-9)" }}>
+              Name shown
+            </Text>
+            <Box
+              width="60px"
+              p="2"
+              style={{ border: "1px solid var(--gray-6)" }}
+            >
+              <VariationLabel number={1} name="v1" />
+            </Box>
+          </Flex>
         </Flex>
       </Flex>
 

--- a/packages/front-end/ui/VariationLabel.stories.tsx
+++ b/packages/front-end/ui/VariationLabel.stories.tsx
@@ -63,18 +63,23 @@ export default function VariationLabelStories() {
           Number-only (very limited space)
         </Text>
         <Flex direction="column" gap="2">
-          <Flex key="40px" gap="2" align="center">
-            <Text size="1" style={{ width: 64, color: "var(--gray-9)" }}>
-              40px
-            </Text>
-            <Box
-              width="40px"
-              p="2"
-              style={{ border: "1px solid var(--gray-6)" }}
-            >
-              <VariationLabel number={1} name="v1" size="sm" />
-            </Box>
-          </Flex>
+          {([60, 40] as const).map((width) => (
+            <Flex key={width} gap="2" align="center">
+              <Text size="1" style={{ width: 64, color: "var(--gray-9)" }}>
+                {width}px
+              </Text>
+              <Box
+                width={`${width}px`}
+                p="2"
+                style={{ border: "1px solid var(--gray-6)" }}
+              >
+                <VariationLabel
+                  number={1}
+                  name="A very long variation name that should truncate"
+                />
+              </Box>
+            </Flex>
+          ))}
         </Flex>
       </Flex>
 

--- a/packages/front-end/ui/VariationLabel.tsx
+++ b/packages/front-end/ui/VariationLabel.tsx
@@ -16,8 +16,8 @@ export interface VariationLabelProps {
   disableTooltip?: boolean;
 }
 
-// Below this name width, hide the name and show only the number (tooltip reveals it).
-const MIN_NAME_WIDTH_PX = 4;
+// Hide truncated names below this width, but keep shorter names that fully fit.
+const MIN_NAME_WIDTH_PX = 24;
 // Matches the Flex `gap="1"` between the number and the name.
 const FLEX_GAP_PX = 4;
 
@@ -43,9 +43,15 @@ export default function VariationLabel({
       const rootWidth = root.clientWidth;
       const numberWidth = numberRef.current?.offsetWidth ?? 0;
       const availableNameWidth = rootWidth - numberWidth - FLEX_GAP_PX;
-      setHideName(rootWidth > 0 && availableNameWidth < MIN_NAME_WIDTH_PX);
-      const text = textRef.current;
-      setIsTruncated(!!text && text.scrollWidth > text.clientWidth);
+      // Hidden text remains mounted so its full width stays measurable.
+      const fullNameWidth = textRef.current?.scrollWidth ?? 0;
+      const fitsEntirely = availableNameWidth >= fullNameWidth;
+      setHideName(
+        rootWidth > 0 &&
+          !fitsEntirely &&
+          availableNameWidth < MIN_NAME_WIDTH_PX,
+      );
+      setIsTruncated(!fitsEntirely);
     };
 
     measure();
@@ -53,26 +59,27 @@ export default function VariationLabel({
     const observer = new ResizeObserver(measure);
     observer.observe(root);
     return () => observer.disconnect();
-  }, [name, size, number, hideName]);
-
-  const variationNumber = <VariationNumber ref={numberRef} number={number} />;
+  }, [name, size, number]);
 
   const content = (
     <Flex align="center" gap="1" minWidth="0">
-      {variationNumber}
-      <Box minWidth="0" flexGrow="1" overflow="hidden">
-        {!hideName ? (
-          <Text
-            ref={textRef}
-            as="div"
-            size={size}
-            weight={size === "lg" ? "medium" : "semibold"}
-            color="text-mid"
-            truncate
-          >
-            {name}
-          </Text>
-        ) : null}
+      <VariationNumber ref={numberRef} number={number} />
+      <Box
+        minWidth="0"
+        flexGrow={hideName ? "0" : "1"}
+        width={hideName ? "0" : undefined}
+        overflow="hidden"
+      >
+        <Text
+          ref={textRef}
+          as="div"
+          size={size}
+          weight={size === "lg" ? "medium" : "semibold"}
+          color="text-mid"
+          truncate
+        >
+          {name}
+        </Text>
       </Box>
     </Flex>
   );
@@ -88,7 +95,7 @@ export default function VariationLabel({
   return (
     <Box ref={rootRef} minWidth="0" maxWidth={maxWidth}>
       <Tooltip content={name} enabled={hideName || isTruncated} side="top">
-        {hideName ? variationNumber : content}
+        {content}
       </Tooltip>
     </Box>
   );

--- a/packages/front-end/ui/VariationLabel.tsx
+++ b/packages/front-end/ui/VariationLabel.tsx
@@ -17,7 +17,7 @@ export interface VariationLabelProps {
 }
 
 // Below this name width, hide the name and show only the number (tooltip reveals it).
-const MIN_NAME_WIDTH_PX = 24;
+const MIN_NAME_WIDTH_PX = 4;
 // Matches the Flex `gap="1"` between the number and the name.
 const FLEX_GAP_PX = 4;
 
@@ -43,6 +43,7 @@ export default function VariationLabel({
       const rootWidth = root.clientWidth;
       const numberWidth = numberRef.current?.offsetWidth ?? 0;
       const nameWidth = rootWidth - numberWidth - FLEX_GAP_PX;
+      console.log("widths", { name, rootWidth, numberWidth, nameWidth });
       setHideName(rootWidth > 0 && nameWidth < MIN_NAME_WIDTH_PX);
       const text = textRef.current;
       setIsTruncated(!!text && text.scrollWidth > text.clientWidth);

--- a/packages/front-end/ui/VariationLabel.tsx
+++ b/packages/front-end/ui/VariationLabel.tsx
@@ -62,7 +62,7 @@ export default function VariationLabel({
   }, [name, size, number]);
 
   const content = (
-    <Flex align="center" gap="1" minWidth="0">
+    <Flex align="center" gap={hideName ? "0" : "1"} minWidth="0">
       <VariationNumber ref={numberRef} number={number} />
       <Box
         minWidth="0"

--- a/packages/front-end/ui/VariationLabel.tsx
+++ b/packages/front-end/ui/VariationLabel.tsx
@@ -42,9 +42,8 @@ export default function VariationLabel({
     const measure = () => {
       const rootWidth = root.clientWidth;
       const numberWidth = numberRef.current?.offsetWidth ?? 0;
-      const nameWidth = rootWidth - numberWidth - FLEX_GAP_PX;
-      console.log("widths", { name, rootWidth, numberWidth, nameWidth });
-      setHideName(rootWidth > 0 && nameWidth < MIN_NAME_WIDTH_PX);
+      const availableNameWidth = rootWidth - numberWidth - FLEX_GAP_PX;
+      setHideName(rootWidth > 0 && availableNameWidth < MIN_NAME_WIDTH_PX);
       const text = textRef.current;
       setIsTruncated(!!text && text.scrollWidth > text.clientWidth);
     };


### PR DESCRIPTION
### Features and Changes

We were hiding VariationLabel names when the available width for the name was below `24px` which works for truncated names with ellipses but not short names. This PR changes the logic to only hide the name when it doesn't fit entirely and is below our minimum width of `24px`.

### Dependencies

n/a

### Testing

- Manual testing in the UI 
- Review design system page

### Screenshots

**Before**
<img width="430" height="227" alt="Screenshot 2026-08-04 at 2 25 55 PM" src="https://github.com/user-attachments/assets/61c3d7a5-64c2-4e27-b7d3-eaad96a90cdb" />

**After**
<img width="440" height="236" alt="Screenshot 2026-08-04 at 1 55 32 PM" src="https://github.com/user-attachments/assets/896946bb-8172-4812-b370-f9dd7894a0b1" />
