### PR TITLE
fix(experiments): Use health traffic for results page SRM warning when available

### DIFF
--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -348,6 +348,7 @@ const CompactResults: FC<{
                 linkToHealthTab
                 setTab={setTab}
                 isBandit={isBandit}
+                snapshot={snapshot}
               />
             )}
             <MultipleExposureWarning

--- a/packages/front-end/components/Experiment/DataQualityWarning.tsx
+++ b/packages/front-end/components/Experiment/DataQualityWarning.tsx
@@ -3,6 +3,13 @@ import {
   ExperimentReportResultDimension,
   ExperimentReportVariation,
 } from "shared/types/report";
+import { ExperimentSnapshotInterface } from "shared/types/experiment-snapshot";
+import { getSRMHealthData } from "shared/health";
+import {
+  DEFAULT_SRM_THRESHOLD,
+  DEFAULT_SRM_MINIMINUM_COUNT_PER_VARIATION,
+} from "shared/constants";
+import { useUser } from "@/services/UserContext";
 import SRMWarning from "./SRMWarning";
 import { ExperimentTab } from "./TabbedPage";
 
@@ -12,7 +19,18 @@ const DataQualityWarning: FC<{
   linkToHealthTab?: boolean;
   setTab?: (tab: ExperimentTab) => void;
   isBandit?: boolean;
-}> = ({ results, variations, linkToHealthTab = false, setTab, isBandit }) => {
+  snapshot?: ExperimentSnapshotInterface;
+}> = ({
+  results,
+  variations,
+  linkToHealthTab = false,
+  setTab,
+  isBandit,
+  snapshot,
+}) => {
+  const { settings } = useUser();
+  const srmThreshold = settings.srmThreshold ?? DEFAULT_SRM_THRESHOLD;
+
   if (!results) return null;
   const variationResults = results?.variations || [];
 
@@ -22,12 +40,34 @@ const DataQualityWarning: FC<{
     return null;
   }
 
-  // SRM check
+  const traffic = snapshot?.health?.traffic;
+  const trafficResults =
+    traffic && !traffic.error && traffic.overall.variationUnits.length
+      ? traffic.overall
+      : null;
+
+  // Use health traffic results when available
+  const srm = trafficResults?.srm ?? results.srm;
+  const users =
+    trafficResults?.variationUnits ?? variationResults.map((r) => r.users);
+
+  if (trafficResults) {
+    const totalUsers = users.reduce((a, b) => a + b, 0);
+    const srmHealth = getSRMHealthData({
+      srm,
+      srmThreshold,
+      numOfVariations: variations.length,
+      totalUsersCount: totalUsers,
+      minUsersPerVariation: DEFAULT_SRM_MINIMINUM_COUNT_PER_VARIATION,
+    });
+    if (srmHealth === "not-enough-traffic") return null;
+  }
+
   return (
     <SRMWarning
-      srm={results.srm}
+      srm={srm}
       variations={variations}
-      users={variationResults.map((r) => r.users)}
+      users={users}
       linkToHealthTab={linkToHealthTab}
       setTab={setTab}
       isBandit={isBandit}


### PR DESCRIPTION
### Features and Changes

Currently legacy metric users may see a discrepancy around SRM between the results page and the health tab because two different queries power the SRM warnings on each tab. This PR uses the health traffic query, when available, on the results tab SRMWarning to prevent misalignment. When using the health traffic query, we're also hiding the SRMWarning when we determine there's not enough traffic to make a call as we do on the health tab.

### Dependencies

N/A

### Testing

- Manual testing

### Screenshots

N/A
