### PR TITLE
fix(experiments): Show edit controls on funnel cards for running experiments

### DIFF
--- a/packages/front-end/components/Experiment/TabbedPage/TrafficAllocationFunnel.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/TrafficAllocationFunnel.tsx
@@ -48,14 +48,12 @@ function FunnelCard({
   inlineSummary,
   onEdit,
   children,
-  disabled = false,
 }: {
   title: string;
   titleColor?: "text-disabled" | "text-high";
   inlineSummary?: ReactNode;
   onEdit?: (() => void) | null;
   children?: ReactNode;
-  disabled?: boolean;
 }) {
   return (
     <Box
@@ -77,7 +75,7 @@ function FunnelCard({
             </Text>
           ) : null}
         </Flex>
-        {onEdit && !disabled ? (
+        {onEdit ? (
           <IconButton
             variant="ghost"
             color="violet"
@@ -249,7 +247,6 @@ export default function TrafficAllocationFunnel({
                     {namespaceName}
                   </Text>
                 }
-                disabled={!safeToEdit}
               />
               <FunnelConnector label={includedLabel} />
             </>
@@ -266,7 +263,6 @@ export default function TrafficAllocationFunnel({
                 </Text>
               )
             }
-            disabled={!safeToEdit}
           >
             <Flex direction="column" gap="4">
               <AssignmentAttribute experiment={experiment} />
@@ -305,11 +301,7 @@ export default function TrafficAllocationFunnel({
 
           <FunnelConnector />
 
-          <FunnelCard
-            title="Traffic"
-            onEdit={editTraffic}
-            disabled={!safeToEdit}
-          >
+          <FunnelCard title="Traffic" onEdit={editTraffic}>
             {!isHoldout ? (
               <Box mb="1">
                 <Text weight="semibold" color="text-high">


### PR DESCRIPTION
### Features and Changes

The Traffic Allocation funnel (introduced in #6093) hides the edit pencil on the **Namespace**, **Targeting**, and **Traffic** cards whenever `!safeToEdit` — i.e., on any running experiment with live linked changes. This leaves users with no way to open the traffic/targeting editor from the Implementation section on a running experiment; the only remaining path is the header's Make Changes button, which isn't discoverable from the funnel.

The modals these handlers open (`EditTrafficModal`, `EditTargetingModal`, `EditNamespaceModal`) already check `safeToEdit` and route to `MakeChanges` / `MakeChangesFlow` when the experiment is live — the same behavior the legacy `TrafficAndTargeting` view relied on. The extra `disabled={!safeToEdit}` gate on the funnel cards is redundant and blocks the entry point entirely.

This removes the `disabled` prop from `FunnelCard` and its three call sites so the pencils always render when the user has permission. The modal layer continues to decide whether to show the direct editor or the Make Changes release-plan flow.

- Regression from #6093

### Dependencies

None

### Testing

1. Open a **running** experiment that has a linked feature flag.
2. Implementation section → Traffic Allocation funnel.
3. **Before:** no pencil on Namespace/Targeting/Traffic cards.
   **After:** pencils appear; clicking opens the Make Changes flow (release-plan wizard), matching legacy behavior.
4. On a draft/stopped experiment: pencils open the direct editors (unchanged).

### Screenshots

_Before — running experiment with linked feature: no edit pencil on Traffic card._
_After — pencil present; opens Make Changes flow._

🤖 Generated with [Claude Code](https://claude.com/claude-code)