### PR TITLE
Vercel get plan by installation endpoint

### DIFF
--- a/packages/back-end/src/routers/vercel-native-integration/vercel-native-integration.controller.ts
+++ b/packages/back-end/src/routers/vercel-native-integration/vercel-native-integration.controller.ts
@@ -68,8 +68,6 @@ const STARTER_BILLING_PLAN: BillingPlan = {
   id: "starter-billing-plan",
   name: "Starter Plan",
   cost: "Free",
-  paymentMethodRequired: false,
-  scope: "installation",
   type: "subscription",
   details: [
     { label: "Feature Flags & Evaluations", value: "Unlimited" },
@@ -86,8 +84,7 @@ function getProBillingPlan(perSeatCost: number): BillingPlan {
     description: "Full featured experimentation and growth platform",
     id,
     name: "Pro Plan",
-    paymentMethodRequired: true,
-    scope: "installation",
+
     type: "subscription",
     cost: `Starting at $${perSeatCost}/month`,
     details: [

--- a/packages/back-end/src/routers/vercel-native-integration/vercel-native-integration.controller.ts
+++ b/packages/back-end/src/routers/vercel-native-integration/vercel-native-integration.controller.ts
@@ -52,6 +52,7 @@ import {
 } from "back-end/src/services/licenseData";
 import { getLicenseByKey } from "back-end/src/enterprise/models/licenseModel";
 import { getEffectiveOrgLimits } from "back-end/src/services/plan-limits";
+import { logger } from "back-end/src/util/logger";
 import {
   userAuthenticationValidator,
   systemAuthenticationValidator,
@@ -67,6 +68,8 @@ const STARTER_BILLING_PLAN: BillingPlan = {
   id: "starter-billing-plan",
   name: "Starter Plan",
   cost: "Free",
+  paymentMethodRequired: false,
+  scope: "installation",
   type: "subscription",
   details: [
     { label: "Feature Flags & Evaluations", value: "Unlimited" },
@@ -83,6 +86,8 @@ function getProBillingPlan(perSeatCost: number): BillingPlan {
     description: "Full featured experimentation and growth platform",
     id,
     name: "Pro Plan",
+    paymentMethodRequired: true,
+    scope: "installation",
     type: "subscription",
     cost: `Starting at $${perSeatCost}/month`,
     details: [
@@ -233,6 +238,10 @@ const getContext = async ({
     try {
       return await getOrgFromInstallationResource(installationId, resourceId);
     } catch (err) {
+      logger.warn(
+        { err, installationId, resourceId },
+        "Failed to load Vercel integration context",
+      );
       return failed(401, err.message);
     }
   })();
@@ -269,6 +278,18 @@ const getContext = async ({
 
 const authContext = async (req: Request, res: Response) => {
   const failed = (status: number, reason?: string) => {
+    logger.warn(
+      {
+        status,
+        reason,
+        installationId: req.params.installation_id,
+        resourceId: req.params.resource_id,
+        authType: req.headers["x-vercel-auth"],
+        hasAuthorizationHeader: Boolean(req.headers.authorization),
+      },
+      "Vercel request authentication failed",
+    );
+
     if (reason) res.status(status).send(reason);
     else res.sendStatus(status);
 
@@ -622,7 +643,7 @@ export async function updateResource(req: Request, res: Response) {
   return res.json(updatedResource);
 }
 
-export async function getInstallationProducts(req: Request, res: Response) {
+export async function getPlans(req: Request, res: Response) {
   const { integration } = await authContext(req, res);
 
   const plans = [...availableBillingPlans];

--- a/packages/back-end/src/routers/vercel-native-integration/vercel-native-integration.router.ts
+++ b/packages/back-end/src/routers/vercel-native-integration/vercel-native-integration.router.ts
@@ -50,6 +50,12 @@ router.get(
   vercelController.getResource,
 );
 
+router.get(
+  "/v1/installations/:installation_id/resources/:resource_id/plans",
+  validateRequestMiddleware({}),
+  vercelController.getPlans,
+);
+
 router.patch(
   "/v1/installations/:installation_id/resources/:resource_id",
   validateRequestMiddleware({ body: updateResourceValidator }),
@@ -59,7 +65,7 @@ router.patch(
 router.get(
   "/v1/installations/:installation_id/plans",
   validateRequestMiddleware({}),
-  vercelController.getInstallationProducts,
+  vercelController.getPlans,
 );
 
 router.delete(

--- a/packages/back-end/src/routers/vercel-native-integration/vercel-native-integration.validators.ts
+++ b/packages/back-end/src/routers/vercel-native-integration/vercel-native-integration.validators.ts
@@ -85,9 +85,9 @@ export const billingPlanValidator = z.object({
   maximumAmountAutoPurchasePerPeriod: z.string().optional(),
   minimumAmount: z.string().optional(),
   name: z.string(),
-  paymentMethodRequired: z.boolean(),
+  paymentMethodRequired: z.boolean().optional(),
   preauthorizationAmount: z.number().optional(),
-  scope: z.union([z.literal("installation"), z.literal("resource")]),
+  scope: z.union([z.literal("installation"), z.literal("resource")]).optional(),
   type: z.union([z.literal("prepayment"), z.literal("subscription")]),
 });
 

--- a/packages/back-end/src/routers/vercel-native-integration/vercel-native-integration.validators.ts
+++ b/packages/back-end/src/routers/vercel-native-integration/vercel-native-integration.validators.ts
@@ -85,9 +85,9 @@ export const billingPlanValidator = z.object({
   maximumAmountAutoPurchasePerPeriod: z.string().optional(),
   minimumAmount: z.string().optional(),
   name: z.string(),
-  paymentMethodRequired: z.boolean().optional(),
+  paymentMethodRequired: z.boolean(),
   preauthorizationAmount: z.number().optional(),
-  scope: z.union([z.literal("installation"), z.literal("resource")]).optional(),
+  scope: z.union([z.literal("installation"), z.literal("resource")]),
   type: z.union([z.literal("prepayment"), z.literal("subscription")]),
 });
 


### PR DESCRIPTION
### Features and Changes

- Add Vercel’s resource-level billing plans endpoint so users can view available plans when updating an existing resource.
- Reuse the installation-level plan logic to include legacy plans when currently selected.
- Require `scope` and `paymentMethodRequired` in billing plan responses to match Vercel’s API contract.
- Add diagnostic logging for Vercel authentication and integration-context failures.

### Dependencies

None.

### Testing

- [x] Request plans for an existing Vercel resource and confirm the available plans are returned.
- [x] Request installation-level plans and confirm existing behavior is unchanged.
- [x] Confirm the currently selected legacy plan remains available.
- [x] Confirm authentication and context failures return an error and produce diagnostic logs.

### Screenshots
<img width="508" height="572" alt="Screenshot 2026-08-05 at 8 46 10 AM" src="https://github.com/user-attachments/assets/372926f9-4dbb-495a-9671-0c41a383043d" />
