### PR TITLE
chore(ui): use Popover instead of DropdownMenu

### DIFF
--- a/packages/front-end/components/Experiment/Public/PublicExperimentAnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Experiment/Public/PublicExperimentAnalysisSettingsBar.tsx
@@ -6,9 +6,9 @@ import {ExperimentInterfaceStringDates} from "shared/types/experiment";
 import { SSRPolyfills } from "@/hooks/useSSRPolyfills";
 import DimensionChooser from "@/components/Dimensions/DimensionChooser";
 import DifferenceTypeChooser from "@/components/Experiment/DifferenceTypeChooser";
-import { DropdownMenu } from "@/ui/DropdownMenu";
 import Metadata from "@/ui/Metadata";
 import Link from "@/ui/Link";
+import { Popover } from "@/ui/Popover";
 
 export default function PublicExperimentAnalysisSettingsBar({
   experiment,
@@ -30,16 +30,16 @@ export default function PublicExperimentAnalysisSettingsBar({
   return (
     <>
       <div className="mb-1 d-flex align-items-center justify-content-end">
-        <DropdownMenu
+        <Popover
           trigger={
             <Link>
               <PiEye className="mr-1" />
               View details
             </Link>
           }
-          menuPlacement="end"
-        >
-          <div style={{ minWidth: 250 }} className="p-2">
+          align="end"
+          content={
+            <div style={{ minWidth: 250 }}>
             <h5>Results computed with:</h5>
             <Metadata
               label="Engine"
@@ -76,8 +76,9 @@ export default function PublicExperimentAnalysisSettingsBar({
                 />
               </div>
             )}
-          </div>
-        </DropdownMenu>
+            </div>
+          }
+        />
       </div>
       <div className="py-1 d-flex mb-2">
         <div className="row align-items-center" style={{ gap: "0.5rem 1rem" }}>

--- a/packages/front-end/components/Report/ReportAnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Report/ReportAnalysisSettingsBar.tsx
@@ -14,9 +14,9 @@ import DifferenceTypeChooser from "@/components/Experiment/DifferenceTypeChooser
 import { useAuth } from "@/services/auth";
 import Callout from "@/ui/Callout";
 import Button from "@/ui/Button";
-import { DropdownMenu } from "@/ui/DropdownMenu";
 import Metadata from "@/ui/Metadata";
 import Link from "@/ui/Link";
+import { Popover } from "@/ui/Popover";
 import { useDefinitions } from "@/services/DefinitionsContext";
 
 const numberFormatter = Intl.NumberFormat();
@@ -101,49 +101,54 @@ export default function ReportAnalysisSettingsBar({
     <>
       <div className="mb-1 d-flex align-items-center justify-content-between">
         <div className="h3 mb-1">Analysis</div>
-        <DropdownMenu
+        <Popover
           trigger={
             <Link>
               <PiEye className="mr-1" />
               View details
             </Link>
           }
-          menuPlacement="end"
-        >
-          <div style={{ minWidth: 250 }} className="p-2">
-            <h5>Results computed with:</h5>
-            <Metadata
-              label="Engine"
-              value={
-                analysis?.settings?.statsEngine === "frequentist"
-                  ? "Frequentist"
-                  : "Bayesian"
-              }
-            />
-            <Metadata
-              label="CUPED"
-              value={
-                analysis?.settings?.regressionAdjusted ? "Enabled" : "Disabled"
-              }
-            />
-            {analysis?.settings?.statsEngine === "frequentist" && (
+          align="end"
+          content={
+            <div style={{ minWidth: 250 }}>
+              <h5>Results computed with:</h5>
               <Metadata
-                label="Sequential"
+                label="Engine"
                 value={
-                  analysis?.settings?.sequentialTesting ? "Enabled" : "Disabled"
+                  analysis?.settings?.statsEngine === "frequentist"
+                    ? "Frequentist"
+                    : "Bayesian"
                 }
               />
-            )}
-            {snapshot.runStarted && (
-              <div className="text-right mt-3">
+              <Metadata
+                label="CUPED"
+                value={
+                  analysis?.settings?.regressionAdjusted
+                    ? "Enabled"
+                    : "Disabled"
+                }
+              />
+              {analysis?.settings?.statsEngine === "frequentist" && (
                 <Metadata
-                  label="Run date"
-                  value={datetime(snapshot.runStarted)}
+                  label="Sequential"
+                  value={
+                    analysis?.settings?.sequentialTesting
+                      ? "Enabled"
+                      : "Disabled"
+                  }
                 />
-              </div>
-            )}
-          </div>
-        </DropdownMenu>
+              )}
+              {snapshot.runStarted && (
+                <div className="text-right mt-3">
+                  <Metadata
+                    label="Run date"
+                    value={datetime(snapshot.runStarted)}
+                  />
+                </div>
+              )}
+            </div>
+          }
+        />
       </div>
       <div className="py-1 d-flex mb-2">
         <div className="row align-items-center" style={{ gap: "0.5rem 1rem" }}>


### PR DESCRIPTION
### Features and Changes

In these 2 items we are using DropdownMenu but the content is not a Menu.
So we change to use `ui/Popover` which is the recommended solution here.

| Before | After |
|--------|--------|
| <img width="1280" height="801" alt="report-view-details-before-popover" src="https://github.com/user-attachments/assets/69b3cbf1-357b-4068-8274-2db371d56f88" /> | <img width="1280" height="801" alt="report-view-details-after" src="https://github.com/user-attachments/assets/d2ad129e-3be6-4960-9b52-6e38804a766b" /> |
