### PR TITLE
fix/shared dimension resolvability

### DIFF
--- a/packages/shared/src/enterprise/index.ts
+++ b/packages/shared/src/enterprise/index.ts
@@ -9,6 +9,7 @@ export * from "./power";
 export * from "./decision-criteria";
 export * from "./dashboards";
 export * from "./product-analytics/sql";
+export * from "./product-analytics/columns";
 export * from "./product-analytics/column-dependencies";
 export * from "./product-analytics/comparison";
 export * from "./product-analytics/utils";

--- a/packages/shared/src/enterprise/product-analytics/columns.ts
+++ b/packages/shared/src/enterprise/product-analytics/columns.ts
@@ -10,11 +10,20 @@ export interface AvailableDimensionColumn {
   name: string;
 }
 
+// Only what this module needs from a fact table — deliberately excludes
+// `sql`, so callers can pass either a full FactTableInterface or the
+// sql-less shape returned by an id-scoped "full columns" fetch (e.g. the
+// front-end's useFullFactTablesByIds), without either satisfying the other.
+export type DimensionFactTable = Pick<
+  FactTableInterface,
+  "columns" | "userIdTypes"
+>;
+
 // Top-level string columns, plus dotted sub-paths for JSON columns whose
 // fields are themselves strings — matches the dotted-path convention
 // `getColumnExpression`/`factTableHasResolvableColumn` resolve at query time.
 function expandFactTableColumns(
-  factTable: Pick<FactTableInterface, "columns">,
+  factTable: DimensionFactTable,
 ): AvailableDimensionColumn[] {
   const result: AvailableDimensionColumn[] = [];
   (factTable.columns || [])
@@ -56,7 +65,7 @@ function expandFactTableColumns(
  */
 export function getAvailableDimensionColumns(
   dataset: ExplorationDataset | null,
-  getFactTableById: (id: string) => FactTableInterface | null,
+  getFactTableById: (id: string) => DimensionFactTable | null,
   getFactMetricById: (id: string) => FactMetricInterface | null,
 ): AvailableDimensionColumn[] {
   if (!dataset) return [];

--- a/packages/shared/src/enterprise/product-analytics/columns.ts
+++ b/packages/shared/src/enterprise/product-analytics/columns.ts
@@ -1,0 +1,125 @@
+import {
+  FactTableInterface,
+  FactMetricInterface,
+} from "shared/types/fact-table";
+import { ExplorationDataset } from "../../validators/product-analytics";
+import { factTableHasResolvableColumn } from "./sql";
+
+export interface AvailableDimensionColumn {
+  column: string;
+  name: string;
+}
+
+// Top-level string columns, plus dotted sub-paths for JSON columns whose
+// fields are themselves strings — matches the dotted-path convention
+// `getColumnExpression`/`factTableHasResolvableColumn` resolve at query time.
+function expandFactTableColumns(
+  factTable: Pick<FactTableInterface, "columns">,
+): AvailableDimensionColumn[] {
+  const result: AvailableDimensionColumn[] = [];
+  (factTable.columns || [])
+    .filter((c) => !c.deleted)
+    .forEach((c) => {
+      if (c.datatype === "string") {
+        result.push({ column: c.column, name: c.name || c.column });
+      }
+      if (c.datatype === "json" && c.jsonFields) {
+        Object.entries(c.jsonFields).forEach(([field, info]) => {
+          if (info.datatype === "string") {
+            result.push({
+              column: `${c.column}.${field}`,
+              name: `${c.name || c.column}.${field}`,
+            });
+          }
+        });
+      }
+    });
+  return result;
+}
+
+/**
+ * Columns (including dotted JSON sub-paths) valid to group by for a given
+ * dataset. Single source of truth shared by the front-end Explorer's column
+ * picker and the AI agent's `getAvailableColumns` tool, so both offer
+ * exactly the columns a group-by query can actually resolve.
+ *
+ * For a ratio metric whose denominator lives on a different fact table than
+ * the numerator, candidates are filtered down to columns (including nested
+ * JSON paths) resolvable on *both* fact tables — `factTableHasResolvableColumn`
+ * checks the full dotted path, not just the base column name, so a JSON
+ * sub-field only offered when the denominator's own JSON column actually has
+ * it too.
+ *
+ * Callers must pass FULL fact table data (real `jsonFields`) — a slim/
+ * definitions-only fact table representation will silently under-report
+ * nested JSON columns.
+ */
+export function getAvailableDimensionColumns(
+  dataset: ExplorationDataset | null,
+  getFactTableById: (id: string) => FactTableInterface | null,
+  getFactMetricById: (id: string) => FactMetricInterface | null,
+): AvailableDimensionColumn[] {
+  if (!dataset) return [];
+  if (dataset.type !== "funnel") {
+    if (!dataset.values || dataset.values.length === 0) return [];
+  } else {
+    if (!dataset.steps || dataset.steps.length === 0) return [];
+  }
+
+  const userIdTypes = new Set<string>();
+  let candidates: AvailableDimensionColumn[] | null = null;
+
+  if (dataset.type === "fact_table") {
+    const ft = getFactTableById(dataset.factTableId || "");
+    ft?.userIdTypes?.forEach((u) => userIdTypes.add(u));
+    candidates = ft ? expandFactTableColumns(ft) : [];
+  } else if (dataset.type === "metric") {
+    for (const value of dataset.values) {
+      const factMetric = getFactMetricById(value.metricId);
+      if (!factMetric) continue;
+      const ft = getFactTableById(factMetric.numerator.factTableId);
+      if (!ft) continue;
+      ft.userIdTypes?.forEach((u) => userIdTypes.add(u));
+
+      let valueCandidates = expandFactTableColumns(ft);
+
+      // A ratio metric's denominator can live on a different fact table —
+      // only offer columns (including nested JSON paths) both sides can
+      // resolve, so a dimension can never be picked that a group-by query
+      // can't evaluate on the denominator.
+      if (factMetric.denominator?.factTableId) {
+        const denominatorFt = getFactTableById(
+          factMetric.denominator.factTableId,
+        );
+        denominatorFt?.userIdTypes?.forEach((u) => userIdTypes.add(u));
+        valueCandidates = denominatorFt
+          ? valueCandidates.filter((c) =>
+              factTableHasResolvableColumn(denominatorFt, c.column),
+            )
+          : [];
+      }
+
+      if (candidates === null) {
+        candidates = valueCandidates;
+      } else {
+        const names = new Set(valueCandidates.map((c) => c.column));
+        candidates = candidates.filter((c) => names.has(c.column));
+      }
+    }
+  } else if (dataset.type === "data_source") {
+    candidates = Object.entries(dataset.columnTypes)
+      .filter(([, datatype]) => datatype === "string")
+      .map(([name]) => ({ column: name, name }));
+  } else if (dataset.type === "funnel") {
+    const initialStep = dataset.steps[0];
+    const ft = initialStep?.factTable
+      ? getFactTableById(initialStep.factTable)
+      : null;
+    ft?.userIdTypes?.forEach((u) => userIdTypes.add(u));
+    candidates = ft ? expandFactTableColumns(ft) : [];
+  }
+
+  return (candidates || [])
+    .filter((c) => !userIdTypes.has(c.column))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/packages/shared/src/enterprise/product-analytics/columns.ts
+++ b/packages/shared/src/enterprise/product-analytics/columns.ts
@@ -121,8 +121,8 @@ export function getAvailableDimensionColumns(
       .map(([name]) => ({ column: name, name }));
   } else if (dataset.type === "funnel") {
     const initialStep = dataset.steps[0];
-    const ft = initialStep?.factTable
-      ? getFactTableById(initialStep.factTable)
+    const ft = initialStep?.factTableId
+      ? getFactTableById(initialStep.factTableId)
       : null;
     ft?.userIdTypes?.forEach((u) => userIdTypes.add(u));
     candidates = ft ? expandFactTableColumns(ft) : [];

--- a/packages/shared/src/enterprise/product-analytics/columns.ts
+++ b/packages/shared/src/enterprise/product-analytics/columns.ts
@@ -86,7 +86,7 @@ export function getAvailableDimensionColumns(
     for (const value of dataset.values) {
       const factMetric = getFactMetricById(value.metricId);
       if (!factMetric) continue;
-      const ft = getFactTableById(factMetric.numerator.factTableId);
+      const ft = getFactTableById(factMetric.numerator?.factTableId || "");
       if (!ft) continue;
       ft.userIdTypes?.forEach((u) => userIdTypes.add(u));
 

--- a/packages/shared/src/enterprise/product-analytics/columns.ts
+++ b/packages/shared/src/enterprise/product-analytics/columns.ts
@@ -2,7 +2,10 @@ import {
   FactTableInterface,
   FactMetricInterface,
 } from "shared/types/fact-table";
-import { ExplorationDataset } from "../../validators/product-analytics";
+import {
+  ExplorationDataset,
+  ProductAnalyticsDimension,
+} from "../../validators/product-analytics";
 import { factTableHasResolvableColumn } from "./sql";
 
 export interface AvailableDimensionColumn {
@@ -10,18 +13,13 @@ export interface AvailableDimensionColumn {
   name: string;
 }
 
-// Only what this module needs from a fact table — deliberately excludes
-// `sql`, so callers can pass either a full FactTableInterface or the
-// sql-less shape returned by an id-scoped "full columns" fetch (e.g. the
-// front-end's useFullFactTablesByIds), without either satisfying the other.
+// Deliberately excludes `sql`, so callers can pass a full FactTableInterface
+// or a sql-less id-scoped fetch.
 export type DimensionFactTable = Pick<
   FactTableInterface,
   "columns" | "userIdTypes"
 >;
 
-// Top-level string columns, plus dotted sub-paths for JSON columns whose
-// fields are themselves strings — matches the dotted-path convention
-// `getColumnExpression`/`factTableHasResolvableColumn` resolve at query time.
 function expandFactTableColumns(
   factTable: DimensionFactTable,
 ): AvailableDimensionColumn[] {
@@ -46,22 +44,64 @@ function expandFactTableColumns(
   return result;
 }
 
+function excludeUserIdTypes(
+  columns: AvailableDimensionColumn[],
+  userIdTypes: Set<string>,
+): AvailableDimensionColumn[] {
+  return columns
+    .filter((c) => !userIdTypes.has(c.column))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Fact table ids whose full column data (including `jsonFields`) is needed
+ * to compute `getAvailableDimensionColumns` for this dataset.
+ */
+export function getRelevantFactTableIds(
+  dataset: ExplorationDataset | null,
+  getFactMetricById: (id: string) => FactMetricInterface | null,
+): string[] {
+  if (!dataset) return [];
+  const ids = new Set<string>();
+
+  switch (dataset.type) {
+    case "fact_table":
+      if (dataset.factTableId) ids.add(dataset.factTableId);
+      break;
+    case "metric":
+      dataset.values.forEach((value) => {
+        const metric = getFactMetricById(value.metricId);
+        if (!metric) return;
+        if (metric.numerator?.factTableId) {
+          ids.add(metric.numerator.factTableId);
+        }
+        if (metric.denominator?.factTableId) {
+          ids.add(metric.denominator.factTableId);
+        }
+      });
+      break;
+    case "funnel": {
+      const initialStepFactTableId = dataset.steps[0]?.factTableId;
+      if (initialStepFactTableId) ids.add(initialStepFactTableId);
+      break;
+    }
+    case "data_source":
+      break;
+    default: {
+      const _exhaustive: never = dataset;
+      return _exhaustive;
+    }
+  }
+
+  return Array.from(ids);
+}
+
 /**
  * Columns (including dotted JSON sub-paths) valid to group by for a given
- * dataset. Single source of truth shared by the front-end Explorer's column
- * picker and the AI agent's `getAvailableColumns` tool, so both offer
- * exactly the columns a group-by query can actually resolve.
- *
- * For a ratio metric whose denominator lives on a different fact table than
- * the numerator, candidates are filtered down to columns (including nested
- * JSON paths) resolvable on *both* fact tables — `factTableHasResolvableColumn`
- * checks the full dotted path, not just the base column name, so a JSON
- * sub-field only offered when the denominator's own JSON column actually has
- * it too.
+ * dataset. Shared by the Explorer picker and agent validation.
  *
  * Callers must pass FULL fact table data (real `jsonFields`) — a slim/
- * definitions-only fact table representation will silently under-report
- * nested JSON columns.
+ * definitions-only fact table silently under-reports nested JSON columns.
  */
 export function getAvailableDimensionColumns(
   dataset: ExplorationDataset | null,
@@ -69,66 +109,96 @@ export function getAvailableDimensionColumns(
   getFactMetricById: (id: string) => FactMetricInterface | null,
 ): AvailableDimensionColumn[] {
   if (!dataset) return [];
-  if (dataset.type !== "funnel") {
-    if (!dataset.values || dataset.values.length === 0) return [];
-  } else {
-    if (!dataset.steps || dataset.steps.length === 0) return [];
-  }
 
   const userIdTypes = new Set<string>();
   let candidates: AvailableDimensionColumn[] | null = null;
 
-  if (dataset.type === "fact_table") {
-    const ft = getFactTableById(dataset.factTableId || "");
-    ft?.userIdTypes?.forEach((u) => userIdTypes.add(u));
-    candidates = ft ? expandFactTableColumns(ft) : [];
-  } else if (dataset.type === "metric") {
-    for (const value of dataset.values) {
-      const factMetric = getFactMetricById(value.metricId);
-      if (!factMetric) continue;
-      const ft = getFactTableById(factMetric.numerator?.factTableId || "");
-      if (!ft) continue;
+  switch (dataset.type) {
+    case "fact_table": {
+      if (!dataset.values.length) return [];
+      const ft = getFactTableById(dataset.factTableId || "");
+      if (!ft) return [];
       ft.userIdTypes?.forEach((u) => userIdTypes.add(u));
-
-      let valueCandidates = expandFactTableColumns(ft);
-
-      // A ratio metric's denominator can live on a different fact table —
-      // only offer columns (including nested JSON paths) both sides can
-      // resolve, so a dimension can never be picked that a group-by query
-      // can't evaluate on the denominator.
-      if (factMetric.denominator?.factTableId) {
-        const denominatorFt = getFactTableById(
-          factMetric.denominator.factTableId,
-        );
-        denominatorFt?.userIdTypes?.forEach((u) => userIdTypes.add(u));
-        valueCandidates = denominatorFt
-          ? valueCandidates.filter((c) =>
-              factTableHasResolvableColumn(denominatorFt, c.column),
-            )
-          : [];
-      }
-
-      if (candidates === null) {
-        candidates = valueCandidates;
-      } else {
-        const names = new Set(valueCandidates.map((c) => c.column));
-        candidates = candidates.filter((c) => names.has(c.column));
-      }
+      candidates = expandFactTableColumns(ft);
+      break;
     }
-  } else if (dataset.type === "data_source") {
-    candidates = Object.entries(dataset.columnTypes)
-      .filter(([, datatype]) => datatype === "string")
-      .map(([name]) => ({ column: name, name }));
-  } else if (dataset.type === "funnel") {
-    const initialStep = dataset.steps[0];
-    const ft = initialStep?.factTableId
-      ? getFactTableById(initialStep.factTableId)
-      : null;
-    ft?.userIdTypes?.forEach((u) => userIdTypes.add(u));
-    candidates = ft ? expandFactTableColumns(ft) : [];
+    case "metric": {
+      if (!dataset.values.length) return [];
+      for (const value of dataset.values) {
+        const factMetric = getFactMetricById(value.metricId);
+        if (!factMetric) continue;
+        const ft = getFactTableById(factMetric.numerator?.factTableId || "");
+        let valueCandidates: AvailableDimensionColumn[] = [];
+        if (ft) {
+          ft.userIdTypes?.forEach((u) => userIdTypes.add(u));
+          valueCandidates = expandFactTableColumns(ft);
+
+          if (factMetric.denominator?.factTableId) {
+            const denominatorFt = getFactTableById(
+              factMetric.denominator.factTableId,
+            );
+            denominatorFt?.userIdTypes?.forEach((u) => userIdTypes.add(u));
+            valueCandidates = denominatorFt
+              ? valueCandidates.filter((c) =>
+                  factTableHasResolvableColumn(denominatorFt, c.column),
+                )
+              : [];
+          }
+        }
+
+        if (candidates === null) {
+          candidates = valueCandidates;
+        } else {
+          const names = new Set(valueCandidates.map((c) => c.column));
+          candidates = candidates.filter((c) => names.has(c.column));
+        }
+      }
+      break;
+    }
+    case "data_source": {
+      if (!dataset.values.length) return [];
+      candidates = Object.entries(dataset.columnTypes)
+        .filter(([, datatype]) => datatype === "string")
+        .map(([name]) => ({ column: name, name }));
+      break;
+    }
+    case "funnel": {
+      if (!dataset.steps.length) return [];
+      const initialStep = dataset.steps[0];
+      const ft = initialStep?.factTableId
+        ? getFactTableById(initialStep.factTableId)
+        : null;
+      if (!ft) return [];
+      ft.userIdTypes?.forEach((u) => userIdTypes.add(u));
+      candidates = expandFactTableColumns(ft);
+      break;
+    }
+    default: {
+      const _exhaustive: never = dataset;
+      return _exhaustive;
+    }
   }
 
-  return (candidates || [])
-    .filter((c) => !userIdTypes.has(c.column))
-    .sort((a, b) => a.name.localeCompare(b.name));
+  return excludeUserIdTypes(candidates || [], userIdTypes);
+}
+
+export function dimensionColumnIsAvailable(
+  dimension: ProductAnalyticsDimension,
+  columns: AvailableDimensionColumn[],
+): boolean {
+  switch (dimension.dimensionType) {
+    case "date":
+    case "slice":
+      return true;
+    case "dynamic":
+    case "static":
+      return (
+        dimension.column === null ||
+        columns.some((c) => c.column === dimension.column)
+      );
+    default: {
+      const _exhaustive: never = dimension;
+      return _exhaustive;
+    }
+  }
 }

--- a/packages/shared/src/enterprise/product-analytics/sql.ts
+++ b/packages/shared/src/enterprise/product-analytics/sql.ts
@@ -483,7 +483,7 @@ function generateRowFilterSQL(
 // rather than injecting a WHERE clause that references a nonexistent
 // column and fails at the warehouse.
 export function factTableHasResolvableColumn(
-  factTable: MinimalFactTable,
+  factTable: Pick<FactTableInterface, "columns">,
   column: string,
 ): boolean {
   const [baseColumn, ...rest] = column.split(".");

--- a/packages/shared/src/enterprise/product-analytics/sql.ts
+++ b/packages/shared/src/enterprise/product-analytics/sql.ts
@@ -482,7 +482,7 @@ function generateRowFilterSQL(
 // dimension's filter to a group whose table can't actually resolve it,
 // rather than injecting a WHERE clause that references a nonexistent
 // column and fails at the warehouse.
-function factTableHasResolvableColumn(
+export function factTableHasResolvableColumn(
   factTable: MinimalFactTable,
   column: string,
 ): boolean {
@@ -1795,22 +1795,34 @@ export function generateProductAnalyticsSQL(
 
   factTableGroups.forEach((factTableGroup, i) => {
     // Recomputed against this group's own fact table — a ratio metric's
-    // denominator can resolve a column differently, or not at all (NULL;
-    // getStaticDimensionFilters excludes such a group's rows entirely).
-    const groupDimensions: DimensionData[] = config.dimensions.map((d, di) => ({
-      alias: `dimension${di}`,
-      valueExpr:
-        d.dimensionType === "static" &&
-        !factTableHasResolvableColumn(factTableGroup.factTable, d.column)
-          ? "NULL"
-          : generateDimensionExpression(
-              d,
-              di,
-              factTableGroup,
-              dialect,
-              dateRange,
-            ),
-    }));
+    // denominator can resolve a column differently, or not at all. Static
+    // dimensions become NULL (getStaticDimensionFilters excludes such a
+    // group's rows entirely, since a pinned filter can't be evaluated at
+    // all). Dynamic dimensions fall into the same 'other' bucket already
+    // used for top-N truncation, since a breakdown should still account for
+    // this group's rows rather than dropping them or emitting an
+    // unresolvable column reference.
+    const groupDimensions: DimensionData[] = config.dimensions.map((d, di) => {
+      if (
+        (d.dimensionType === "static" || d.dimensionType === "dynamic") &&
+        !factTableHasResolvableColumn(factTableGroup.factTable, d.column || "")
+      ) {
+        return {
+          alias: `dimension${di}`,
+          valueExpr: d.dimensionType === "static" ? "NULL" : "'other'",
+        };
+      }
+      return {
+        alias: `dimension${di}`,
+        valueExpr: generateDimensionExpression(
+          d,
+          di,
+          factTableGroup,
+          dialect,
+          dateRange,
+        ),
+      };
+    });
     const staticDimensionFilters = getStaticDimensionFilters(
       config.dimensions,
       factTableGroup.factTable,

--- a/packages/shared/src/enterprise/product-analytics/sql.ts
+++ b/packages/shared/src/enterprise/product-analytics/sql.ts
@@ -1803,10 +1803,13 @@ export function generateProductAnalyticsSQL(
     // this group's rows rather than dropping them or emitting an
     // unresolvable column reference.
     const groupDimensions: DimensionData[] = config.dimensions.map((d, di) => {
-      if (
-        (d.dimensionType === "static" || d.dimensionType === "dynamic") &&
-        !factTableHasResolvableColumn(factTableGroup.factTable, d.column || "")
-      ) {
+      const unresolvable =
+        (d.dimensionType === "static" &&
+          !factTableHasResolvableColumn(factTableGroup.factTable, d.column)) ||
+        (d.dimensionType === "dynamic" &&
+          d.column !== null &&
+          !factTableHasResolvableColumn(factTableGroup.factTable, d.column));
+      if (unresolvable) {
         return {
           alias: `dimension${di}`,
           valueExpr: d.dimensionType === "static" ? "NULL" : "'other'",

--- a/packages/shared/test/product-analytics-columns.test.ts
+++ b/packages/shared/test/product-analytics-columns.test.ts
@@ -327,7 +327,7 @@ describe("getAvailableDimensionColumns", () => {
       {
         type: "funnel",
         unit: "user_id",
-        steps: [{ name: "s1", factTable: "numerator_ft", rowFilters: [] }],
+        steps: [{ name: "s1", factTableId: "numerator_ft", rowFilters: [] }],
       },
       getFactTableById,
       () => null,

--- a/packages/shared/test/product-analytics-columns.test.ts
+++ b/packages/shared/test/product-analytics-columns.test.ts
@@ -1,0 +1,341 @@
+import { getAvailableDimensionColumns } from "shared/enterprise";
+import {
+  ColumnInterface,
+  FactTableInterface,
+  FactMetricInterface,
+} from "shared/types/fact-table";
+
+function makeColumn(overrides: Partial<ColumnInterface>): ColumnInterface {
+  return {
+    dateCreated: new Date(),
+    dateUpdated: new Date(),
+    name: "",
+    description: "",
+    column: "",
+    datatype: "string",
+    numberFormat: "",
+    deleted: false,
+    ...overrides,
+  };
+}
+
+function makeFactTable(
+  overrides: Partial<FactTableInterface> & {
+    id: string;
+    columns: ColumnInterface[];
+  },
+): FactTableInterface {
+  return {
+    datasource: "ds_1",
+    filters: [],
+    name: overrides.id,
+    organization: "org_1",
+    sql: "SELECT * FROM t",
+    userIdTypes: [],
+    dateCreated: new Date(),
+    dateUpdated: new Date(),
+    description: "",
+    eventName: "",
+    owner: "",
+    projects: [],
+    tags: [],
+    ...overrides,
+  } as FactTableInterface;
+}
+
+const numeratorFt = makeFactTable({
+  id: "numerator_ft",
+  userIdTypes: ["user_id"],
+  columns: [
+    makeColumn({ column: "user_id", datatype: "string" }),
+    makeColumn({ column: "country", name: "Country", datatype: "string" }),
+    makeColumn({ column: "amount", datatype: "number" }),
+    makeColumn({ column: "deleted_col", datatype: "string", deleted: true }),
+    makeColumn({
+      column: "props",
+      name: "Props",
+      datatype: "json",
+      jsonFields: {
+        plan: { datatype: "string" },
+        score: { datatype: "number" },
+      },
+    }),
+  ],
+});
+
+function makeMetric(
+  overrides: Partial<FactMetricInterface> & { id: string },
+): FactMetricInterface {
+  return {
+    name: overrides.id,
+    metricType: "mean",
+    numerator: {
+      factTableId: "numerator_ft",
+      column: "amount",
+      aggregation: "sum",
+    },
+    denominator: null,
+    cappingSettings: { type: "", value: 0 },
+    windowSettings: {
+      type: "",
+      delayValue: 0,
+      delayUnit: "days",
+      windowValue: 0,
+      windowUnit: "days",
+    },
+    quantileSettings: null,
+    ...overrides,
+  } as FactMetricInterface;
+}
+
+describe("getAvailableDimensionColumns", () => {
+  it("returns [] for a null dataset", () => {
+    expect(
+      getAvailableDimensionColumns(
+        null,
+        () => null,
+        () => null,
+      ),
+    ).toEqual([]);
+  });
+
+  it("returns [] for a metric dataset with no values", () => {
+    expect(
+      getAvailableDimensionColumns(
+        { type: "metric", values: [] },
+        () => null,
+        () => null,
+      ),
+    ).toEqual([]);
+  });
+
+  it("lists string columns and dotted JSON sub-paths for a fact_table dataset, excluding deleted columns and userIdTypes", () => {
+    const getFactTableById = (id: string) =>
+      id === "numerator_ft" ? numeratorFt : null;
+
+    const result = getAvailableDimensionColumns(
+      {
+        type: "fact_table",
+        factTableId: "numerator_ft",
+        values: [{ name: "v", valueColumn: "amount", rowFilters: [] }],
+      },
+      getFactTableById,
+      () => null,
+    );
+
+    expect(result.map((c) => c.column).sort()).toEqual([
+      "country",
+      "props.plan",
+    ]);
+  });
+
+  it("intersects columns across multiple metric values in a metric dataset", () => {
+    const otherFt = makeFactTable({
+      id: "other_ft",
+      columns: [
+        makeColumn({ column: "country", name: "Country", datatype: "string" }),
+      ],
+    });
+    const getFactTableById = (id: string) =>
+      ({ numerator_ft: numeratorFt, other_ft: otherFt })[id] ?? null;
+    const getFactMetricById = (id: string) =>
+      ({
+        m1: makeMetric({
+          id: "m1",
+          numerator: {
+            factTableId: "numerator_ft",
+            column: "amount",
+            aggregation: "sum",
+          },
+        }),
+        m2: makeMetric({
+          id: "m2",
+          numerator: {
+            factTableId: "other_ft",
+            column: "$$count",
+            aggregation: "sum",
+          },
+        }),
+      })[id] ?? null;
+
+    const result = getAvailableDimensionColumns(
+      {
+        type: "metric",
+        values: [
+          {
+            name: "v1",
+            type: "metric",
+            rowFilters: [],
+            metricId: "m1",
+            unit: null,
+            denominatorUnit: null,
+          },
+          {
+            name: "v2",
+            type: "metric",
+            rowFilters: [],
+            metricId: "m2",
+            unit: null,
+            denominatorUnit: null,
+          },
+        ],
+      },
+      getFactTableById,
+      getFactMetricById,
+    );
+
+    // Only "country" is common to both metrics' fact tables — the numerator-
+    // only "props.plan" is dropped by the cross-metric intersection.
+    expect(result.map((c) => c.column)).toEqual(["country"]);
+  });
+
+  describe("ratio metric denominator resolvability", () => {
+    it("excludes a nested JSON column the denominator's fact table doesn't share", () => {
+      const denominatorFt = makeFactTable({
+        id: "denominator_ft",
+        columns: [
+          makeColumn({
+            column: "country",
+            name: "Country",
+            datatype: "string",
+          }),
+          // No "props" column at all.
+        ],
+      });
+      const getFactTableById = (id: string) =>
+        ({ numerator_ft: numeratorFt, denominator_ft: denominatorFt })[id] ??
+        null;
+      const getFactMetricById = () =>
+        makeMetric({
+          id: "ratio",
+          metricType: "ratio",
+          numerator: {
+            factTableId: "numerator_ft",
+            column: "amount",
+            aggregation: "sum",
+          },
+          denominator: {
+            factTableId: "denominator_ft",
+            column: "$$count",
+            aggregation: "sum",
+          },
+        });
+
+      const result = getAvailableDimensionColumns(
+        {
+          type: "metric",
+          values: [
+            {
+              name: "v",
+              type: "metric",
+              rowFilters: [],
+              metricId: "ratio",
+              unit: null,
+              denominatorUnit: null,
+            },
+          ],
+        },
+        getFactTableById,
+        getFactMetricById,
+      );
+
+      expect(result.map((c) => c.column)).toEqual(["country"]);
+    });
+
+    it("includes a nested JSON column when the denominator's fact table shares the same field", () => {
+      const denominatorFt = makeFactTable({
+        id: "denominator_ft",
+        columns: [
+          makeColumn({
+            column: "country",
+            name: "Country",
+            datatype: "string",
+          }),
+          makeColumn({
+            column: "props",
+            name: "Props",
+            datatype: "json",
+            jsonFields: { plan: { datatype: "string" } },
+          }),
+        ],
+      });
+      const getFactTableById = (id: string) =>
+        ({ numerator_ft: numeratorFt, denominator_ft: denominatorFt })[id] ??
+        null;
+      const getFactMetricById = () =>
+        makeMetric({
+          id: "ratio",
+          metricType: "ratio",
+          numerator: {
+            factTableId: "numerator_ft",
+            column: "amount",
+            aggregation: "sum",
+          },
+          denominator: {
+            factTableId: "denominator_ft",
+            column: "$$count",
+            aggregation: "sum",
+          },
+        });
+
+      const result = getAvailableDimensionColumns(
+        {
+          type: "metric",
+          values: [
+            {
+              name: "v",
+              type: "metric",
+              rowFilters: [],
+              metricId: "ratio",
+              unit: null,
+              denominatorUnit: null,
+            },
+          ],
+        },
+        getFactTableById,
+        getFactMetricById,
+      );
+
+      expect(result.map((c) => c.column).sort()).toEqual([
+        "country",
+        "props.plan",
+      ]);
+    });
+  });
+
+  it("lists only string-typed columns for a data_source dataset", () => {
+    const result = getAvailableDimensionColumns(
+      {
+        type: "data_source",
+        path: "raw_events",
+        timestampColumn: "ts",
+        columnTypes: { country: "string", amount: "number", ts: "date" },
+        values: [{ name: "v", valueColumn: "amount", rowFilters: [] }],
+      },
+      () => null,
+      () => null,
+    );
+
+    expect(result.map((c) => c.column)).toEqual(["country"]);
+  });
+
+  it("uses the initial step's fact table for a funnel dataset", () => {
+    const getFactTableById = (id: string) =>
+      id === "numerator_ft" ? numeratorFt : null;
+
+    const result = getAvailableDimensionColumns(
+      {
+        type: "funnel",
+        unit: "user_id",
+        steps: [{ name: "s1", factTable: "numerator_ft", rowFilters: [] }],
+      },
+      getFactTableById,
+      () => null,
+    );
+
+    expect(result.map((c) => c.column).sort()).toEqual([
+      "country",
+      "props.plan",
+    ]);
+  });
+});

--- a/packages/shared/test/product-analytics-columns.test.ts
+++ b/packages/shared/test/product-analytics-columns.test.ts
@@ -1,4 +1,8 @@
-import { getAvailableDimensionColumns } from "shared/enterprise";
+import {
+  dimensionColumnIsAvailable,
+  getAvailableDimensionColumns,
+  getRelevantFactTableIds,
+} from "shared/enterprise";
 import {
   ColumnInterface,
   FactTableInterface,
@@ -337,5 +341,113 @@ describe("getAvailableDimensionColumns", () => {
       "country",
       "props.plan",
     ]);
+  });
+});
+
+describe("getRelevantFactTableIds", () => {
+  it("returns [] for a null dataset", () => {
+    expect(getRelevantFactTableIds(null, () => null)).toEqual([]);
+  });
+
+  it("returns the fact table id for a fact_table dataset", () => {
+    expect(
+      getRelevantFactTableIds(
+        {
+          type: "fact_table",
+          factTableId: "numerator_ft",
+          values: [{ name: "v", valueColumn: "amount", rowFilters: [] }],
+        },
+        () => null,
+      ),
+    ).toEqual(["numerator_ft"]);
+  });
+
+  it("returns numerator and denominator fact table ids for a ratio metric", () => {
+    const getFactMetricById = (id: string) =>
+      id === "ratio"
+        ? makeMetric({
+            id: "ratio",
+            metricType: "ratio",
+            numerator: {
+              factTableId: "numerator_ft",
+              column: "amount",
+              aggregation: "sum",
+            },
+            denominator: {
+              factTableId: "denominator_ft",
+              column: "$$count",
+              aggregation: "sum",
+            },
+          })
+        : null;
+
+    expect(
+      getRelevantFactTableIds(
+        {
+          type: "metric",
+          values: [
+            {
+              name: "v",
+              type: "metric",
+              rowFilters: [],
+              metricId: "ratio",
+              unit: null,
+              denominatorUnit: null,
+            },
+          ],
+        },
+        getFactMetricById,
+      ).sort(),
+    ).toEqual(["denominator_ft", "numerator_ft"]);
+  });
+
+  it("returns only the initial step's fact table for a funnel dataset", () => {
+    expect(
+      getRelevantFactTableIds(
+        {
+          type: "funnel",
+          unit: "user_id",
+          steps: [
+            { name: "s1", factTableId: "step1_ft", rowFilters: [] },
+            { name: "s2", factTableId: "step2_ft", rowFilters: [] },
+          ],
+        },
+        () => null,
+      ),
+    ).toEqual(["step1_ft"]);
+  });
+});
+
+describe("dimensionColumnIsAvailable", () => {
+  const columns = [{ column: "country", name: "Country" }];
+
+  it("keeps date and slice dimensions regardless of columns", () => {
+    expect(
+      dimensionColumnIsAvailable(
+        { dimensionType: "date", column: null, dateGranularity: "auto" },
+        [],
+      ),
+    ).toBe(true);
+    expect(
+      dimensionColumnIsAvailable({ dimensionType: "slice", slices: [] }, []),
+    ).toBe(true);
+  });
+
+  it("keeps a dynamic dimension with no column yet", () => {
+    expect(
+      dimensionColumnIsAvailable(
+        { dimensionType: "dynamic", column: null, maxValues: 5 },
+        columns,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a static dimension whose column is missing", () => {
+    expect(
+      dimensionColumnIsAvailable(
+        { dimensionType: "static", column: "missing", values: ["US"] },
+        columns,
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/shared/test/product-analytics.test.ts
+++ b/packages/shared/test/product-analytics.test.ts
@@ -687,6 +687,127 @@ describe("productAnalytics", () => {
     expect(matches.length).toBe(2);
   });
 
+  it("falls back to the 'other' bucket for a dynamic dimension unresolvable on a cross-table ratio metric's denominator", () => {
+    // Counterpart to the static-dimension regression tests above, for the
+    // "dynamic" (breakdown) dimension type: unlike a pinned filter, a
+    // breakdown should still account for the denominator's rows rather than
+    // dropping them, so an unresolvable column here degrades into the same
+    // 'other' bucket already used for top-N truncation — not a raw,
+    // unresolvable "props.plan" reference that would fail at the warehouse.
+    const jsonFactTableMap = new Map<string, FactTableInterface>([
+      [
+        "orders",
+        {
+          ...factTableMap.get("orders")!,
+          columns: [
+            ...factTableMap.get("orders")!.columns,
+            {
+              column: "props",
+              datatype: "json",
+              dateCreated: new Date(),
+              dateUpdated: new Date(),
+              name: "props",
+              description: "",
+              numberFormat: "",
+              alwaysInlineFilter: false,
+              deleted: false,
+              autoSlices: [],
+              isAutoSliceColumn: false,
+              jsonFields: { plan: { datatype: "string" } },
+            },
+          ],
+        },
+      ],
+      [
+        // Same base shape as "orders", but with no "props" column at all.
+        "other_ft",
+        {
+          ...factTableMap.get("orders")!,
+          id: "other_ft",
+          sql: "SELECT user_id, timestamp, revenue FROM other_events",
+        },
+      ],
+    ]);
+
+    const crossTableRatioMetricMap = new Map<string, FactMetricInterface>([
+      [
+        "cross_table_ratio",
+        {
+          id: "cross_table_ratio",
+          name: "Cross Table Ratio",
+          metricType: "ratio",
+          numerator: {
+            factTableId: "orders",
+            column: "revenue",
+            aggregation: "sum",
+          },
+          denominator: {
+            factTableId: "other_ft",
+            column: "$$count",
+            aggregation: "sum",
+          },
+          cappingSettings: { type: "", value: 0 },
+          windowSettings: {
+            type: "",
+            delayValue: 0,
+            delayUnit: "days",
+            windowValue: 0,
+            windowUnit: "days",
+          },
+          quantileSettings: null,
+        } as FactMetricInterface,
+      ],
+    ]);
+
+    const config: ExplorationConfig = {
+      type: "metric",
+      datasource: "ds_1",
+      chartType: "bar",
+      dateRange: {
+        predefined: "last7Days",
+        startDate: null,
+        endDate: null,
+        lookbackValue: null,
+        lookbackUnit: null,
+      },
+      dimensions: [
+        { dimensionType: "dynamic", column: "props.plan", maxValues: 5 },
+      ],
+      dataset: {
+        type: "metric",
+        values: [
+          {
+            name: "ratio",
+            type: "metric",
+            rowFilters: [],
+            metricId: "cross_table_ratio",
+            unit: null,
+            denominatorUnit: null,
+          },
+        ],
+      },
+    };
+
+    const { sql } = generateProductAnalyticsSQL(
+      config,
+      jsonFactTableMap,
+      crossTableRatioMetricMap,
+      helpers,
+      datasource,
+    );
+
+    // The numerator's CTE (which has "props" as a JSON column) still buckets
+    // by the top-values CASE expression...
+    expect(sql).toMatch(
+      /WHEN props:'plan'::text IN \(SELECT value FROM _dimension0_top\) THEN props:'plan'::text/,
+    );
+    // ...while the denominator's CTE (whose fact table has no "props" at
+    // all) buckets every row directly into 'other', with no reference to
+    // the unresolvable column.
+    expect(sql).toContain("'other' AS dimension0");
+    expect(sql).not.toContain("props.plan");
+  });
+
   it("generates SQL for fact tables with mix of filtered and unfiltered values", () => {
     const config: ExplorationConfig = {
       type: "fact_table",


### PR DESCRIPTION
### Features and Changes

Fixes two gaps in how the Explorer's dimension picker resolves group-by columns for ratio metrics:

- `getCommonColumns` only compared base column names when checking whether a ratio metric's dimension column resolves on the denominator's fact table, missing nested JSON paths (e.g. `props.plan`) — and the check didn't apply to dynamic (breakdown) dimensions at all.
- Adds a shared, nested-JSON-aware `getAvailableDimensionColumns` (in `packages/shared`) as the single source of truth for both the front-end picker and the AI agent (wired up in #6566 and #6567), and generalizes the SQL-generation guard so an unresolvable dynamic dimension falls into the existing "other" bucket instead of emitting a raw, unresolvable column reference.
- Narrows `factTableHasResolvableColumn` to only require `columns` (`Pick<FactTableInterface, "columns">`) instead of the full `MinimalFactTable` shape, so both a full `FactTableInterface` and a sql-less, id-scoped fact-table fetch (added in #6566) can satisfy the same getter.

### Dependencies

None — this is the bottom of a 3-PR stack: #6565 (this PR) → #6566 → #6567.

### Testing

Added `packages/shared/test/product-analytics-columns.test.ts` covering `getAvailableDimensionColumns` (JSON sub-paths, dynamic dimensions, cross-table ratio-metric denominator resolution, funnel steps) plus updated coverage in `product-analytics.test.ts` and `product-analytics-dimension.test.ts`.

### Screenshots

No UI changes in this PR — see #6566 for the front-end wiring.