### PR TITLE
fix(product-analytics): validate AI-agent dimension columns against the shared resolvability check

### DIFF
--- a/packages/back-end/src/enterprise/services/product-analytics-agent.ts
+++ b/packages/back-end/src/enterprise/services/product-analytics-agent.ts
@@ -781,7 +781,7 @@ async function normalizeConfigForExplorer(
       if (dataset.factTableId) dimensionFactTableIds.add(dataset.factTableId);
     } else if (dataset.type === "metric") {
       referencedMetrics.forEach((m) => {
-        if (m.numerator.factTableId) {
+        if (m.numerator?.factTableId) {
           dimensionFactTableIds.add(m.numerator.factTableId);
         }
         if (m.denominator?.factTableId) {

--- a/packages/back-end/src/enterprise/services/product-analytics-agent.ts
+++ b/packages/back-end/src/enterprise/services/product-analytics-agent.ts
@@ -21,6 +21,7 @@ import {
   getIsRatioByIndex,
   buildExplorationColumns,
   getExplorationCellValue,
+  getAvailableDimensionColumns,
 } from "shared/enterprise";
 import type { ReqContext } from "back-end/types/request";
 import { runProductAnalyticsExploration } from "back-end/src/enterprise/services/product-analytics";
@@ -765,6 +766,63 @@ async function normalizeConfigForExplorer(
   const metricById = new Map(referencedMetrics.map((m) => [m.id, m]));
   const getFactMetricByIdResolver = (id: string) => metricById.get(id) ?? null;
 
+  // Drop any static/dynamic dimension whose column doesn't resolve for this
+  // dataset — a hallucinated column, one deleted since, or (for a ratio
+  // metric) one the denominator's fact table can't share with the numerator.
+  // Uses the same shared resolvability logic as the front-end's dimension
+  // picker, so the agent can never author what a user couldn't have picked.
+  if (
+    dims.some(
+      (d) => d.dimensionType === "static" || d.dimensionType === "dynamic",
+    )
+  ) {
+    const dimensionFactTableIds = new Set<string>();
+    if (dataset.type === "fact_table") {
+      if (dataset.factTableId) dimensionFactTableIds.add(dataset.factTableId);
+    } else if (dataset.type === "metric") {
+      referencedMetrics.forEach((m) => {
+        if (m.numerator.factTableId) {
+          dimensionFactTableIds.add(m.numerator.factTableId);
+        }
+        if (m.denominator?.factTableId) {
+          dimensionFactTableIds.add(m.denominator.factTableId);
+        }
+      });
+    } else if (dataset.type === "funnel") {
+      const initialStepFactTable = dataset.steps[0]?.factTable;
+      if (initialStepFactTable) dimensionFactTableIds.add(initialStepFactTable);
+    }
+
+    const dimensionFactTableIdList = Array.from(dimensionFactTableIds);
+    const dimensionFactTables = await Promise.all(
+      dimensionFactTableIdList.map((id) => getFactTable(ctx, id)),
+    );
+    const dimensionFtById = new Map(
+      dimensionFactTableIdList.map((id, i) => [id, dimensionFactTables[i]]),
+    );
+    const availableDimensionColumns = getAvailableDimensionColumns(
+      dataset,
+      (id) => dimensionFtById.get(id) ?? null,
+      getFactMetricByIdResolver,
+    );
+
+    const invalidDims = dims.filter(
+      (d) =>
+        (d.dimensionType === "static" || d.dimensionType === "dynamic") &&
+        d.column !== null &&
+        !availableDimensionColumns.some((c) => c.column === d.column),
+    );
+    if (invalidDims.length) {
+      const invalidDimSet = new Set(invalidDims);
+      dims = dims.filter((d) => !invalidDimSet.has(d));
+      warnings.push(
+        `Removed ${invalidDims.length} dimension(s) referencing a column that isn't valid for this dataset (unknown, deleted, or — for a ratio metric — not shared between the numerator and denominator fact tables): ${invalidDims
+          .map((d) => `"${"column" in d ? d.column : ""}"`)
+          .join(", ")}.`,
+      );
+    }
+  }
+
   // Backfill missing units for metric values so the SQL layer emits a
   // denominator and per_unit rendering works. The agent often omits `unit`
   // even when it should be set; default to the numerator fact table's primary
@@ -966,7 +1024,6 @@ async function executeGetAvailableColumns(
       const { metricIds } = input;
       if (!metricIds?.length) return "metricIds is required for metric source.";
       const metrics = await ctx.models.factMetrics.getByIds(metricIds);
-      let columns: FactTableInterface["columns"] | null = null;
       let userIdTypes: string[] = [];
       const metricUnitInfo: {
         metricId: string;
@@ -974,17 +1031,23 @@ async function executeGetAvailableColumns(
         needsUnit: boolean;
       }[] = [];
 
+      // Fetch both sides of every metric — a ratio metric's denominator can
+      // live on a different fact table than its numerator, and columns must
+      // resolve on both to be valid group-by candidates.
       const ftIds = [
         ...new Set(
-          metrics
-            .map((m) => m.numerator?.factTableId)
-            .filter((id): id is string => !!id),
+          metrics.flatMap((m) =>
+            [m.numerator?.factTableId, m.denominator?.factTableId].filter(
+              (id): id is string => !!id,
+            ),
+          ),
         ),
       ];
       const factTables = await Promise.all(
         ftIds.map((id) => getFactTable(ctx, id)),
       );
       const ftMap = new Map(ftIds.map((id, i) => [id, factTables[i]] as const));
+      const metricMap = new Map(metrics.map((m) => [m.id, m]));
 
       for (const m of metrics) {
         const needsUnit =
@@ -1005,18 +1068,31 @@ async function executeGetAvailableColumns(
         if (!userIdTypes.length && ft?.userIdTypes?.length) {
           userIdTypes = ft.userIdTypes;
         }
-        const ftCols = (ft?.columns ?? []).filter((c) => !c.deleted);
-        if (columns === null) {
-          columns = ftCols;
-        } else {
-          const nameSet = new Set(ftCols.map((c) => c.column));
-          columns = columns.filter((c) => nameSet.has(c.column));
-        }
       }
 
-      const result = (columns ?? [])
-        .sort((a, b) => (a.name || a.column).localeCompare(b.name || b.column))
-        .map((c) => ({ column: c.column, name: c.name, datatype: c.datatype }));
+      // Single source of truth shared with the front-end Explorer's dimension
+      // picker — only offers columns (including nested JSON paths) resolvable
+      // on every referenced metric's fact table(s), denominator included.
+      const availableColumns = getAvailableDimensionColumns(
+        {
+          type: "metric",
+          values: metricIds.map((metricId) => ({
+            type: "metric" as const,
+            name: metricId,
+            rowFilters: [],
+            metricId,
+            unit: null,
+            denominatorUnit: null,
+          })),
+        },
+        (id) => ftMap.get(id) ?? null,
+        (id) => metricMap.get(id) ?? null,
+      );
+      const result = availableColumns.map((c) => ({
+        column: c.column,
+        name: c.name,
+        datatype: "string" as const,
+      }));
 
       const unitNote = userIdTypes.length
         ? `For metrics where needsUnit=true, set unit to one of userIdTypes (default: "${userIdTypes[0]}"). For others, set unit to null.`

--- a/packages/back-end/src/enterprise/services/product-analytics-agent.ts
+++ b/packages/back-end/src/enterprise/services/product-analytics-agent.ts
@@ -789,7 +789,7 @@ async function normalizeConfigForExplorer(
         }
       });
     } else if (dataset.type === "funnel") {
-      const initialStepFactTable = dataset.steps[0]?.factTable;
+      const initialStepFactTable = dataset.steps[0]?.factTableId;
       if (initialStepFactTable) dimensionFactTableIds.add(initialStepFactTable);
     }
 

--- a/packages/back-end/src/enterprise/services/product-analytics-agent.ts
+++ b/packages/back-end/src/enterprise/services/product-analytics-agent.ts
@@ -22,6 +22,8 @@ import {
   buildExplorationColumns,
   getExplorationCellValue,
   getAvailableDimensionColumns,
+  getRelevantFactTableIds,
+  dimensionColumnIsAvailable,
 } from "shared/enterprise";
 import type { ReqContext } from "back-end/types/request";
 import { runProductAnalyticsExploration } from "back-end/src/enterprise/services/product-analytics";
@@ -766,61 +768,37 @@ async function normalizeConfigForExplorer(
   const metricById = new Map(referencedMetrics.map((m) => [m.id, m]));
   const getFactMetricByIdResolver = (id: string) => metricById.get(id) ?? null;
 
-  // Drop any static/dynamic dimension whose column doesn't resolve for this
-  // dataset — a hallucinated column, one deleted since, or (for a ratio
-  // metric) one the denominator's fact table can't share with the numerator.
-  // Uses the same shared resolvability logic as the front-end's dimension
-  // picker, so the agent can never author what a user couldn't have picked.
-  if (
-    dims.some(
-      (d) => d.dimensionType === "static" || d.dimensionType === "dynamic",
-    )
-  ) {
-    const dimensionFactTableIds = new Set<string>();
-    if (dataset.type === "fact_table") {
-      if (dataset.factTableId) dimensionFactTableIds.add(dataset.factTableId);
-    } else if (dataset.type === "metric") {
-      referencedMetrics.forEach((m) => {
-        if (m.numerator?.factTableId) {
-          dimensionFactTableIds.add(m.numerator.factTableId);
-        }
-        if (m.denominator?.factTableId) {
-          dimensionFactTableIds.add(m.denominator.factTableId);
-        }
-      });
-    } else if (dataset.type === "funnel") {
-      const initialStepFactTable = dataset.steps[0]?.factTableId;
-      if (initialStepFactTable) dimensionFactTableIds.add(initialStepFactTable);
-    }
+  const dimensionFactTableIdList = getRelevantFactTableIds(
+    dataset,
+    getFactMetricByIdResolver,
+  );
+  const dimensionFactTables = dimensionFactTableIdList.length
+    ? await Promise.all(
+        dimensionFactTableIdList.map((id) => getFactTable(ctx, id)),
+      )
+    : [];
+  const dimensionFtById = new Map(
+    dimensionFactTableIdList.map((id, i) => [id, dimensionFactTables[i]]),
+  );
+  const getDimensionFactTableById = (id: string) =>
+    dimensionFtById.get(id) ?? null;
 
-    const dimensionFactTableIdList = Array.from(dimensionFactTableIds);
-    const dimensionFactTables = await Promise.all(
-      dimensionFactTableIdList.map((id) => getFactTable(ctx, id)),
+  const availableDimensionColumns = getAvailableDimensionColumns(
+    dataset,
+    getDimensionFactTableById,
+    getFactMetricByIdResolver,
+  );
+  const invalidDims = dims.filter(
+    (d) => !dimensionColumnIsAvailable(d, availableDimensionColumns),
+  );
+  if (invalidDims.length) {
+    const invalidDimSet = new Set(invalidDims);
+    dims = dims.filter((d) => !invalidDimSet.has(d));
+    warnings.push(
+      `Removed ${invalidDims.length} dimension(s) referencing a column that isn't valid for this dataset (unknown, deleted, or — for a ratio metric — not shared between the numerator and denominator fact tables): ${invalidDims
+        .map((d) => `"${"column" in d ? d.column : ""}"`)
+        .join(", ")}.`,
     );
-    const dimensionFtById = new Map(
-      dimensionFactTableIdList.map((id, i) => [id, dimensionFactTables[i]]),
-    );
-    const availableDimensionColumns = getAvailableDimensionColumns(
-      dataset,
-      (id) => dimensionFtById.get(id) ?? null,
-      getFactMetricByIdResolver,
-    );
-
-    const invalidDims = dims.filter(
-      (d) =>
-        (d.dimensionType === "static" || d.dimensionType === "dynamic") &&
-        d.column !== null &&
-        !availableDimensionColumns.some((c) => c.column === d.column),
-    );
-    if (invalidDims.length) {
-      const invalidDimSet = new Set(invalidDims);
-      dims = dims.filter((d) => !invalidDimSet.has(d));
-      warnings.push(
-        `Removed ${invalidDims.length} dimension(s) referencing a column that isn't valid for this dataset (unknown, deleted, or — for a ratio metric — not shared between the numerator and denominator fact tables): ${invalidDims
-          .map((d) => `"${"column" in d ? d.column : ""}"`)
-          .join(", ")}.`,
-      );
-    }
   }
 
   // Backfill missing units for metric values so the SQL layer emits a
@@ -834,29 +812,12 @@ async function normalizeConfigForExplorer(
     );
 
     if (needsUnit) {
-      const factTableIds = Array.from(
-        new Set(
-          dataset.values
-            .filter((v) => !v.unit && v.metricId)
-            .map((v) => metricById.get(v.metricId!)?.numerator?.factTableId)
-            .filter((id): id is string => !!id),
-        ),
-      );
-      const factTables = await Promise.all(
-        factTableIds.map((id) => getFactTable(ctx, id)),
-      );
-      const factTableById = new Map(
-        factTables
-          .filter((ft): ft is FactTableInterface => !!ft)
-          .map((ft) => [ft.id, ft]),
-      );
-
       let filledCount = 0;
       const newValues = dataset.values.map((v) => {
         if (v.unit || !v.metricId) return v;
         const metric = metricById.get(v.metricId);
         if (!metric) return v;
-        const factTable = factTableById.get(
+        const factTable = getDimensionFactTableById(
           metric.numerator?.factTableId ?? "",
         );
         const defaultUnit = factTable?.userIdTypes?.[0];
@@ -1034,20 +995,26 @@ async function executeGetAvailableColumns(
       // Fetch both sides of every metric — a ratio metric's denominator can
       // live on a different fact table than its numerator, and columns must
       // resolve on both to be valid group-by candidates.
-      const ftIds = [
-        ...new Set(
-          metrics.flatMap((m) =>
-            [m.numerator?.factTableId, m.denominator?.factTableId].filter(
-              (id): id is string => !!id,
-            ),
-          ),
-        ),
-      ];
+      const metricMap = new Map(metrics.map((m) => [m.id, m]));
+      const metricDataset = {
+        type: "metric" as const,
+        values: metricIds.map((metricId) => ({
+          type: "metric" as const,
+          name: metricId,
+          rowFilters: [],
+          metricId,
+          unit: null,
+          denominatorUnit: null,
+        })),
+      };
+      const ftIds = getRelevantFactTableIds(
+        metricDataset,
+        (id) => metricMap.get(id) ?? null,
+      );
       const factTables = await Promise.all(
         ftIds.map((id) => getFactTable(ctx, id)),
       );
       const ftMap = new Map(ftIds.map((id, i) => [id, factTables[i]] as const));
-      const metricMap = new Map(metrics.map((m) => [m.id, m]));
 
       for (const m of metrics) {
         const needsUnit =
@@ -1074,17 +1041,7 @@ async function executeGetAvailableColumns(
       // picker — only offers columns (including nested JSON paths) resolvable
       // on every referenced metric's fact table(s), denominator included.
       const availableColumns = getAvailableDimensionColumns(
-        {
-          type: "metric",
-          values: metricIds.map((metricId) => ({
-            type: "metric" as const,
-            name: metricId,
-            rowFilters: [],
-            metricId,
-            unit: null,
-            denominatorUnit: null,
-          })),
-        },
+        metricDataset,
         (id) => ftMap.get(id) ?? null,
         (id) => metricMap.get(id) ?? null,
       );


### PR DESCRIPTION
### Features and Changes

Routes the AI agent's product-analytics tools through the same shared dimension-resolvability check used by the front-end picker (#6565, #6566), closing a validation gap:

- The AI agent's `getAvailableColumns` tool only ever looked at a metric's numerator fact table when listing group-by candidates, and `normalizeConfigForExplorer` never validated a dimension's column against real fact-table data at all — so an agent-authored config could carry a static or dynamic dimension referencing a hallucinated, deleted, or denominator-incompatible column straight through to execution.
- `getAvailableColumns` now fetches numerator and denominator fact tables for every referenced metric.
- `normalizeConfigForExplorer` now strips any dimension whose column doesn't resolve, surfacing it via the existing warnings mechanism so the agent can correct itself.

### Dependencies

Depends on #6565 and #6566 (base of this branch) for the shared `getAvailableDimensionColumns` resolution logic.

### Testing

Ask the AI agent to build a chart grouped by a column that only exists on a metric's numerator (not its denominator), or by a nonexistent/deleted column — it should no longer be able to slip an unresolvable dimension into the final config, and should see a warning it can act on instead.

### Screenshots

No UI changes — this is agent-tool/validation logic.