### PR TITLE
feat(api): add REST API for creating, reading, and updating Holdouts

### DIFF
--- a/docs/api/Holdout_model.mdx
+++ b/docs/api/Holdout_model.mdx
@@ -1,0 +1,4 @@
+---
+title: "Holdout"
+openapi-schema: "openapi.yaml Holdout"
+---

--- a/docs/api/Holdouts/operation/createHoldout.mdx
+++ b/docs/api/Holdouts/operation/createHoldout.mdx
@@ -1,0 +1,4 @@
+---
+title: "Create a single holdout"
+openapi: "/openapi.yaml POST /v1/holdouts"
+---

--- a/docs/api/Holdouts/operation/getHoldout.mdx
+++ b/docs/api/Holdouts/operation/getHoldout.mdx
@@ -1,0 +1,4 @@
+---
+title: "Get a single holdout"
+openapi: "/openapi.yaml GET /v1/holdouts/{id}"
+---

--- a/docs/api/Holdouts/operation/listHoldouts.mdx
+++ b/docs/api/Holdouts/operation/listHoldouts.mdx
@@ -1,0 +1,4 @@
+---
+title: "Get all holdouts"
+openapi: "/openapi.yaml GET /v1/holdouts"
+---

--- a/docs/api/Holdouts/operation/startHoldout.mdx
+++ b/docs/api/Holdouts/operation/startHoldout.mdx
@@ -1,0 +1,4 @@
+---
+title: "Start the Holdout's Active Period"
+openapi: "/openapi.yaml POST /v1/holdouts/{id}/start"
+---

--- a/docs/api/Holdouts/operation/startHoldoutAnalysis.mdx
+++ b/docs/api/Holdouts/operation/startHoldoutAnalysis.mdx
@@ -1,0 +1,4 @@
+---
+title: "Start the Holdout's Analysis Period"
+openapi: "/openapi.yaml POST /v1/holdouts/{id}/start-analysis"
+---

--- a/docs/api/Holdouts/operation/stopHoldout.mdx
+++ b/docs/api/Holdouts/operation/stopHoldout.mdx
@@ -1,0 +1,4 @@
+---
+title: "Stop a Holdout"
+openapi: "/openapi.yaml POST /v1/holdouts/{id}/stop"
+---

--- a/docs/api/Holdouts/operation/updateHoldout.mdx
+++ b/docs/api/Holdouts/operation/updateHoldout.mdx
@@ -1,0 +1,4 @@
+---
+title: "Update a single holdout"
+openapi: "/openapi.yaml PUT /v1/holdouts/{id}"
+---

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1052,6 +1052,18 @@
                   "api/Learnings/operation/createLearning",
                   "api/Learnings/operation/searchLearnings"
                 ]
+              },
+              {
+                "group": "Holdouts",
+                "pages": [
+                  "api/Holdouts/operation/getHoldout",
+                  "api/Holdouts/operation/updateHoldout",
+                  "api/Holdouts/operation/listHoldouts",
+                  "api/Holdouts/operation/createHoldout",
+                  "api/Holdouts/operation/startHoldout",
+                  "api/Holdouts/operation/startHoldoutAnalysis",
+                  "api/Holdouts/operation/stopHoldout"
+                ]
               }
             ]
           },
@@ -1124,6 +1136,7 @@
               "api/FeatureV2_model",
               "api/FeatureWithRevisionsV1_model",
               "api/FeatureWithRevisionsV2_model",
+              "api/Holdout_model",
               "api/InformationSchema_model",
               "api/InformationSchemaTable_model",
               "api/Learning_model",

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -49510,10 +49510,11 @@ paths:
                   type: boolean
                 holdoutSize:
                   description: >-
-                    Proportion of traffic held out, expressed as a decimal (e.g.
-                    0.05 for 5%). An equally-sized control group is bucketed
-                    alongside it, so the Holdout occupies twice this share of
-                    traffic in total. Must be greater than 0 and at most 0.5.
+                    Proportion of traffic placed in the holdout group (e.g. 0.05
+                    for 5%). An equally sized comparison group is sampled from
+                    the remaining traffic for measurement, so 2× this value
+                    enters the holdout experiment in total. Must be greater than
+                    0 and at most 0.5.
                   type: number
                   exclusiveMinimum: 0
                   maximum: 0.5
@@ -49629,8 +49630,8 @@ paths:
       operationId: createHoldout
       summary: Create a single holdout
       description: >-
-        Creates a Holdout. The Holdout starts in the `draft` stage. Use POST
-        /holdouts/{id}/start to start it.
+        Creates a Holdout. The Holdout starts in the `draft` stage. Use the
+        start endpoint to start it.
       tags:
         - Holdouts
       requestBody:
@@ -49847,7 +49848,7 @@ paths:
       operationId: startHoldout
       summary: Start the Holdout's Active Period
       description: >-
-        Feature Flags and experiments can be added during this period while the
+        Feature Flags and Experiments can be added during this period while the
         Holdout measures their cumulative impact.
       tags:
         - Holdouts
@@ -49903,7 +49904,7 @@ paths:
       summary: Start the Holdout's Analysis Period
       description: >-
         Move the holdout into an analysis phase. New Feature Flags and
-        experiments can no longer be added, but existing traffic splits remain
+        Experiments can no longer be added, but existing traffic splits remain
         active for existing and new traffic. Results exclude data from before
         the analysis period so you can measure the cumulative impact after
         changes are frozen.
@@ -65788,10 +65789,10 @@ components:
           type: boolean
         holdoutSize:
           description: >-
-            Proportion of traffic held out, expressed as a decimal (e.g. 0.05
-            for 5%). An equally-sized control group is bucketed alongside it, so
-            the Holdout occupies twice this share of traffic in total. Must be
-            greater than 0 and at most 0.5.
+            Proportion of traffic placed in the holdout group (e.g. 0.05 for
+            5%). An equally sized comparison group is sampled from the remaining
+            traffic for measurement, so 2× this value enters the holdout
+            experiment in total. Must be greater than 0 and at most 0.5.
           type: number
           exclusiveMinimum: 0
           maximum: 0.5

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -408,6 +408,11 @@ tags:
     description: >-
       Saved learnings captured across experiments, including AI-discovered
       patterns.
+  - name: Holdouts
+    x-displayName: Holdouts
+    description: >-
+      Hold a share of traffic out of all experiments to measure their combined
+      effect.
   - name: AggregatedFactTable_model
     x-displayName: Aggregated Fact Table
     description: <SchemaDefinition schemaRef="#/components/schemas/AggregatedFactTable" />
@@ -636,6 +641,9 @@ tags:
     description: >-
       <SchemaDefinition schemaRef="#/components/schemas/FeatureWithRevisionsV2"
       />
+  - name: Holdout_model
+    x-displayName: Holdout
+    description: <SchemaDefinition schemaRef="#/components/schemas/Holdout" />
   - name: InformationSchema_model
     x-displayName: Information Schema
     description: <SchemaDefinition schemaRef="#/components/schemas/InformationSchema" />
@@ -49418,6 +49426,586 @@ paths:
           source: |-
             curl -X POST 'https://api.growthbook.io/api/v1/learnings/search' \
               -H 'Authorization: Bearer YOUR_API_KEY'
+  /v1/holdouts/{id}:
+    get:
+      operationId: getHoldout
+      summary: Get a single holdout
+      tags:
+        - Holdouts
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ''
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  holdout:
+                    $ref: '#/components/schemas/Holdout'
+                required:
+                  - holdout
+                additionalProperties: false
+      x-codeSamples:
+        - lang: cURL
+          source: |-
+            curl -X GET 'https://api.growthbook.io/api/v1/holdouts/{id}' \
+              -H 'Authorization: Bearer YOUR_API_KEY'
+    put:
+      operationId: updateHoldout
+      summary: Update a single holdout
+      description: >-
+        Updates a Holdout. Use the start, start-analysis, and stop endpoints to
+        move it through its lifecycle.
+      tags:
+        - Holdouts
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ''
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                description:
+                  type: string
+                  maxLength: 10000
+                projects:
+                  type: array
+                  items:
+                    type: string
+                owner:
+                  description: >-
+                    The userId or email address of the owner. If an email
+                    address is provided, it will be used to look up the userId
+                    of the matching organization member. If an ID is provided,
+                    it will be validated as existing in the organization.
+                  type: string
+                tags:
+                  type: array
+                  items:
+                    type: string
+                archived:
+                  type: boolean
+                skipAsDefaultHoldout:
+                  description: >-
+                    When true, this Holdout is not selected automatically when
+                    creating Feature Flags or Experiments in Projects assigned
+                    to the Holdout.
+                  type: boolean
+                holdoutSize:
+                  description: >-
+                    Proportion of traffic held out, expressed as a decimal (e.g.
+                    0.05 for 5%). An equally-sized control group is bucketed
+                    alongside it, so the Holdout occupies twice this share of
+                    traffic in total. Must be greater than 0 and at most 0.5.
+                  type: number
+                  exclusiveMinimum: 0
+                  maximum: 0.5
+                hashAttribute:
+                  type: string
+                targetingCondition:
+                  type: string
+                savedGroupTargeting:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      match:
+                        type: string
+                        enum:
+                          - all
+                          - none
+                          - any
+                      ids:
+                        type: array
+                        items:
+                          type: string
+                    required:
+                      - match
+                      - ids
+                    additionalProperties: false
+                datasourceId:
+                  type: string
+                assignmentQueryId:
+                  type: string
+                goalMetrics:
+                  type: array
+                  items:
+                    type: string
+                secondaryMetrics:
+                  type: array
+                  items:
+                    type: string
+                statsEngine:
+                  description: Statistics engine used to analyze this Holdout.
+                  type: string
+                  enum:
+                    - bayesian
+                    - frequentist
+                environments:
+                  description: >-
+                    Replaces the entire per-environment state. Environments not
+                    listed are disabled.
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties:
+                    type: object
+                    properties:
+                      enabled:
+                        description: Whether the Holdout is active in this environment.
+                        type: boolean
+                    required:
+                      - enabled
+                    additionalProperties: false
+                statusUpdateSchedule:
+                  anyOf:
+                    - description: >-
+                        Automatic stage transitions for the Holdout. Dates must
+                        be consecutive: `startAt` before `startAnalysisPeriodAt`
+                        before `stopAt`. Send `null` to delete the schedule.
+                      type: object
+                      properties:
+                        startAt:
+                          description: >-
+                            ISO datetime to move the Holdout from `draft` to
+                            `running`. Must be in the future while the Holdout
+                            is still a draft.
+                          type: string
+                          format: date-time
+                        startAnalysisPeriodAt:
+                          description: >-
+                            ISO datetime to move the Holdout from `running` to
+                            `analysis-period`. Requires `startAt` while the
+                            Holdout is still a draft.
+                          type: string
+                          format: date-time
+                        stopAt:
+                          description: >-
+                            ISO datetime to stop the Holdout. Requires
+                            `startAnalysisPeriodAt` unless the analysis period
+                            has already begun.
+                          type: string
+                          format: date-time
+                      additionalProperties: false
+                    - type: 'null'
+              additionalProperties: false
+      responses:
+        '200':
+          description: Resource updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  holdout:
+                    $ref: '#/components/schemas/Holdout'
+                required:
+                  - holdout
+                additionalProperties: false
+      x-codeSamples:
+        - lang: cURL
+          source: |-
+            curl -X PUT 'https://api.growthbook.io/api/v1/holdouts/{id}' \
+              -H 'Authorization: Bearer YOUR_API_KEY'
+  /v1/holdouts:
+    post:
+      operationId: createHoldout
+      summary: Create a single holdout
+      description: >-
+        Creates a Holdout. The Holdout starts in the `draft` stage. Use POST
+        /holdouts/{id}/start to start it.
+      tags:
+        - Holdouts
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                description:
+                  type: string
+                  maxLength: 10000
+                projects:
+                  description: >-
+                    Project IDs this Holdout applies to. Omit or send an empty
+                    array for All Projects.
+                  type: array
+                  items:
+                    type: string
+                owner:
+                  description: >-
+                    The userId or email address of the owner. If an email
+                    address is provided, it will be used to look up the userId
+                    of the matching organization member. If an ID is provided,
+                    it will be validated as existing in the organization.
+                  type: string
+                tags:
+                  type: array
+                  items:
+                    type: string
+                skipAsDefaultHoldout:
+                  description: >-
+                    When true, this Holdout is not selected automatically when
+                    creating Feature Flags or Experiments in Projects assigned
+                    to the Holdout.
+                  type: boolean
+                holdoutSize:
+                  description: >-
+                    Proportion of traffic held out, expressed as a decimal (e.g.
+                    0.05 for 5%). An equally-sized control group is bucketed
+                    alongside it. Defaults to 0.05. Maximum 0.5.
+                  type: number
+                  exclusiveMinimum: 0
+                  maximum: 0.5
+                hashAttribute:
+                  type: string
+                targetingCondition:
+                  description: Targeting condition as a JSON string.
+                  type: string
+                savedGroupTargeting:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      match:
+                        type: string
+                        enum:
+                          - all
+                          - none
+                          - any
+                      ids:
+                        type: array
+                        items:
+                          type: string
+                    required:
+                      - match
+                      - ids
+                    additionalProperties: false
+                datasourceId:
+                  type: string
+                assignmentQueryId:
+                  type: string
+                goalMetrics:
+                  type: array
+                  items:
+                    type: string
+                secondaryMetrics:
+                  type: array
+                  items:
+                    type: string
+                statsEngine:
+                  description: Statistics engine used to analyze this Holdout.
+                  type: string
+                  enum:
+                    - bayesian
+                    - frequentist
+                environments:
+                  description: >-
+                    Per-environment state, keyed by environment ID. Environments
+                    not listed are disabled.
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties:
+                    type: object
+                    properties:
+                      enabled:
+                        description: Whether the Holdout is active in this environment.
+                        type: boolean
+                    required:
+                      - enabled
+                    additionalProperties: false
+                statusUpdateSchedule:
+                  description: >-
+                    Automatic stage transitions for the Holdout. Dates must be
+                    consecutive: `startAt` before `startAnalysisPeriodAt` before
+                    `stopAt`. Send `null` to delete the schedule.
+                  type: object
+                  properties:
+                    startAt:
+                      description: >-
+                        ISO datetime to move the Holdout from `draft` to
+                        `running`. Must be in the future while the Holdout is
+                        still a draft.
+                      type: string
+                      format: date-time
+                    startAnalysisPeriodAt:
+                      description: >-
+                        ISO datetime to move the Holdout from `running` to
+                        `analysis-period`. Requires `startAt` while the Holdout
+                        is still a draft.
+                      type: string
+                      format: date-time
+                    stopAt:
+                      description: >-
+                        ISO datetime to stop the Holdout. Requires
+                        `startAnalysisPeriodAt` unless the analysis period has
+                        already begun.
+                      type: string
+                      format: date-time
+                  additionalProperties: false
+              required:
+                - name
+              additionalProperties: false
+      responses:
+        '200':
+          description: Resource created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  holdout:
+                    $ref: '#/components/schemas/Holdout'
+                required:
+                  - holdout
+                additionalProperties: false
+      x-codeSamples:
+        - lang: cURL
+          source: |-
+            curl -X POST 'https://api.growthbook.io/api/v1/holdouts' \
+              -H 'Authorization: Bearer YOUR_API_KEY'
+    get:
+      operationId: listHoldouts
+      summary: Get all holdouts
+      tags:
+        - Holdouts
+      parameters:
+        - name: projectId
+          in: query
+          description: ''
+          schema:
+            type: string
+        - name: datasourceId
+          in: query
+          description: ''
+          schema:
+            type: string
+        - $ref: '#/components/parameters/stage'
+        - name: archived
+          in: query
+          description: >-
+            Filter by archived state. Omit to return both archived and
+            unarchived Holdouts.
+          schema:
+            description: >-
+              Filter by archived state. Omit to return both archived and
+              unarchived Holdouts.
+            anyOf:
+              - type: string
+                const: 'true'
+              - type: string
+                const: 'false'
+              - type: string
+                const: '0'
+              - type: string
+                const: '1'
+              - type: boolean
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  holdouts:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Holdout'
+                required:
+                  - holdouts
+                additionalProperties: false
+      x-codeSamples:
+        - lang: cURL
+          source: |-
+            curl -X GET 'https://api.growthbook.io/api/v1/holdouts' \
+              -H 'Authorization: Bearer YOUR_API_KEY'
+  /v1/holdouts/{id}/start:
+    post:
+      operationId: startHoldout
+      summary: Start the Holdout's Active Period
+      description: >-
+        Feature Flags and experiments can be added during this period while the
+        Holdout measures their cumulative impact.
+      tags:
+        - Holdouts
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ''
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Resource created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  holdout:
+                    $ref: '#/components/schemas/Holdout'
+                required:
+                  - holdout
+                additionalProperties: false
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Resource is not in a valid status for this operation
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                    enum:
+                      - invalid_status
+                  details:
+                    $ref: '#/components/schemas/ApiErrorInvalidStatusDetails'
+                required:
+                  - message
+                  - code
+                  - details
+      x-codeSamples:
+        - lang: cURL
+          source: >-
+            curl -X POST 'https://api.growthbook.io/api/v1/holdouts/{id}/start'
+            \
+              -H 'Authorization: Bearer YOUR_API_KEY'
+  /v1/holdouts/{id}/start-analysis:
+    post:
+      operationId: startHoldoutAnalysis
+      summary: Start the Holdout's Analysis Period
+      description: >-
+        Move the holdout into an analysis phase. New Feature Flags and
+        experiments can no longer be added, but existing traffic splits remain
+        active for existing and new traffic. Results exclude data from before
+        the analysis period so you can measure the cumulative impact after
+        changes are frozen.
+      tags:
+        - Holdouts
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ''
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Resource created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  holdout:
+                    $ref: '#/components/schemas/Holdout'
+                required:
+                  - holdout
+                additionalProperties: false
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Resource is not in a valid status for this operation
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                    enum:
+                      - invalid_status
+                  details:
+                    $ref: '#/components/schemas/ApiErrorInvalidStatusDetails'
+                required:
+                  - message
+                  - code
+                  - details
+      x-codeSamples:
+        - lang: cURL
+          source: >-
+            curl -X POST
+            'https://api.growthbook.io/api/v1/holdouts/{id}/start-analysis' \
+              -H 'Authorization: Bearer YOUR_API_KEY'
+  /v1/holdouts/{id}/stop:
+    post:
+      operationId: stopHoldout
+      summary: Stop a Holdout
+      tags:
+        - Holdouts
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ''
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Resource created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  holdout:
+                    $ref: '#/components/schemas/Holdout'
+                required:
+                  - holdout
+                additionalProperties: false
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Resource is not in a valid status for this operation
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                    enum:
+                      - invalid_status
+                  details:
+                    $ref: '#/components/schemas/ApiErrorInvalidStatusDetails'
+                required:
+                  - message
+                  - code
+                  - details
+      x-codeSamples:
+        - lang: cURL
+          source: |-
+            curl -X POST 'https://api.growthbook.io/api/v1/holdouts/{id}/stop' \
+              -H 'Authorization: Bearer YOUR_API_KEY'
 components:
   parameters:
     limit:
@@ -50163,6 +50751,17 @@ components:
           - preferred
           - required
           - never
+    stage:
+      name: stage
+      in: query
+      description: ''
+      schema:
+        type: string
+        enum:
+          - draft
+          - running
+          - analysis-period
+          - stopped
   schemas:
     FeatureV1:
       type: object
@@ -65127,6 +65726,272 @@ components:
         - status
         - source
       additionalProperties: false
+    Holdout:
+      type: object
+      properties:
+        id:
+          type: string
+        dateCreated:
+          type: string
+          format: date-time
+        dateUpdated:
+          type: string
+          format: date-time
+        name:
+          type: string
+        description:
+          type: string
+          maxLength: 10000
+        projects:
+          description: >-
+            Project IDs this Holdout applies to. An empty array means All
+            Projects.
+          type: array
+          items:
+            type: string
+        owner:
+          description: The userId of the owner (or raw owner name/email for legacy records)
+          type: string
+        ownerEmail:
+          description: >-
+            The email address of the owner, when the owner can be resolved to a
+            known user.
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        archived:
+          type: boolean
+        stage:
+          description: >-
+            Lifecycle stage of the Holdout. Use the start, start-analysis, and
+            stop endpoints to move through the lifecycle.
+          type: string
+          enum:
+            - draft
+            - running
+            - analysis-period
+            - stopped
+        trackingKey:
+          type: string
+        experimentId:
+          description: >-
+            ID of the companion experiment that stores this Holdout's analysis.
+            Use it with the experiment results endpoints (e.g. GET
+            /experiments/{experimentId}/results).
+          type: string
+        skipAsDefaultHoldout:
+          description: >-
+            When true, this Holdout is not selected automatically when creating
+            Feature Flags or experiments in Projects assigned to the Holdout.
+          type: boolean
+        holdoutSize:
+          description: >-
+            Proportion of traffic held out, expressed as a decimal (e.g. 0.05
+            for 5%). An equally-sized control group is bucketed alongside it, so
+            the Holdout occupies twice this share of traffic in total. Must be
+            greater than 0 and at most 0.5.
+          type: number
+          exclusiveMinimum: 0
+          maximum: 0.5
+        hashAttribute:
+          description: Attribute used to assign users to the Holdout.
+          type: string
+        targetingCondition:
+          description: Targeting condition as a JSON string.
+          type: string
+        savedGroupTargeting:
+          type: array
+          items:
+            type: object
+            properties:
+              match:
+                type: string
+                enum:
+                  - all
+                  - none
+                  - any
+              ids:
+                type: array
+                items:
+                  type: string
+            required:
+              - match
+              - ids
+            additionalProperties: false
+        datasourceId:
+          type: string
+        assignmentQueryId:
+          type: string
+        goalMetrics:
+          type: array
+          items:
+            type: string
+        secondaryMetrics:
+          type: array
+          items:
+            type: string
+        statsEngine:
+          description: Statistics engine used to analyze this Holdout.
+          type: string
+          enum:
+            - bayesian
+            - frequentist
+        variations:
+          type: array
+          items:
+            type: object
+            properties:
+              variationId:
+                type: string
+              key:
+                type: string
+              name:
+                type: string
+              description:
+                type: string
+                maxLength: 10000
+            required:
+              - variationId
+              - key
+              - name
+            additionalProperties: false
+        environments:
+          description: >-
+            Per-environment state, keyed by environment ID. Environments not
+            present are disabled.
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties:
+            type: object
+            properties:
+              enabled:
+                description: Whether the Holdout is active in this environment.
+                type: boolean
+            required:
+              - enabled
+            additionalProperties: false
+        linkedFeatures:
+          description: >-
+            Feature Flags held out by this Holdout. Manage these through the
+            Feature Flag endpoints.
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              dateAdded:
+                type: string
+                format: date-time
+            required:
+              - id
+              - dateAdded
+            additionalProperties: false
+        linkedExperiments:
+          description: >-
+            Experiments held out by this Holdout. Manage these through the
+            experiment endpoints.
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              dateAdded:
+                type: string
+                format: date-time
+            required:
+              - id
+              - dateAdded
+            additionalProperties: false
+        dateStarted:
+          type: string
+          format: date-time
+        analysisStartDate:
+          description: When the Holdout entered its analysis period.
+          type: string
+          format: date-time
+        dateStopped:
+          type: string
+          format: date-time
+        statusUpdateSchedule:
+          anyOf:
+            - description: >-
+                Automatic stage transitions for the Holdout. Dates must be
+                consecutive: `startAt` before `startAnalysisPeriodAt` before
+                `stopAt`. Send `null` to delete the schedule.
+              type: object
+              properties:
+                startAt:
+                  description: >-
+                    ISO datetime to move the Holdout from `draft` to `running`.
+                    Must be in the future while the Holdout is still a draft.
+                  type: string
+                  format: date-time
+                startAnalysisPeriodAt:
+                  description: >-
+                    ISO datetime to move the Holdout from `running` to
+                    `analysis-period`. Requires `startAt` while the Holdout is
+                    still a draft.
+                  type: string
+                  format: date-time
+                stopAt:
+                  description: >-
+                    ISO datetime to stop the Holdout. Requires
+                    `startAnalysisPeriodAt` unless the analysis period has
+                    already begun.
+                  type: string
+                  format: date-time
+              additionalProperties: false
+            - type: 'null'
+        nextScheduledStatusUpdate:
+          anyOf:
+            - description: The next stage transition that will run automatically.
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - start
+                    - startAnalysisPeriod
+                    - stop
+                date:
+                  type: string
+                  format: date-time
+              required:
+                - type
+                - date
+              additionalProperties: false
+            - type: 'null'
+      required:
+        - id
+        - dateCreated
+        - dateUpdated
+        - name
+        - description
+        - projects
+        - owner
+        - tags
+        - archived
+        - stage
+        - trackingKey
+        - experimentId
+        - skipAsDefaultHoldout
+        - holdoutSize
+        - hashAttribute
+        - targetingCondition
+        - datasourceId
+        - assignmentQueryId
+        - goalMetrics
+        - secondaryMetrics
+        - variations
+        - environments
+        - linkedFeatures
+        - linkedExperiments
+      additionalProperties: false
     ExperimentSnapshot:
       type: object
       properties:
@@ -69352,6 +70217,7 @@ x-tagGroups:
       - AnalyticsExplorations
       - RampScheduleTemplates
       - Learnings
+      - Holdouts
   - name: Models
     tags:
       - AggregatedFactTable_model
@@ -69420,6 +70286,7 @@ x-tagGroups:
       - FeatureV2_model
       - FeatureWithRevisionsV1_model
       - FeatureWithRevisionsV2_model
+      - Holdout_model
       - InformationSchema_model
       - InformationSchemaTable_model
       - Learning_model

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -65780,7 +65780,9 @@ components:
           description: >-
             ID of the companion experiment that stores this Holdout's analysis.
             Use it with the experiment results endpoints (e.g. GET
-            /experiments/{experimentId}/results).
+            /experiments/{experimentId}/results). Pass phase=0 for results
+            across the whole Holdout period, or phase=1 for results limited to
+            the analysis period.
           type: string
         skipAsDefaultHoldout:
           description: >-

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -49503,6 +49503,10 @@ paths:
                 archived:
                   type: boolean
                 skipAsDefaultHoldout:
+                  description: >-
+                    When true, this Holdout is not selected automatically when
+                    creating Feature Flags or Experiments in Projects assigned
+                    to the Holdout.
                   type: boolean
                 holdoutSize:
                   description: >-
@@ -49661,6 +49665,10 @@ paths:
                   items:
                     type: string
                 skipAsDefaultHoldout:
+                  description: >-
+                    When true, this Holdout is not selected automatically when
+                    creating Feature Flags or Experiments in Projects assigned
+                    to the Holdout.
                   type: boolean
                 holdoutSize:
                   description: >-
@@ -65768,8 +65776,8 @@ components:
           type: string
         skipAsDefaultHoldout:
           description: >-
-            When true, this Holdout is not pre-selected for new Feature Flags
-            and experiments in its Projects.
+            When true, this Holdout is not selected automatically when creating
+            Feature Flags or experiments in Projects assigned to the Holdout.
           type: boolean
         holdoutSize:
           description: >-

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -49510,10 +49510,11 @@ paths:
                   type: boolean
                 holdoutSize:
                   description: >-
-                    Proportion of traffic held out, expressed as a decimal (e.g.
-                    0.05 for 5%). An equally-sized control group is bucketed
-                    alongside it, so the Holdout occupies twice this share of
-                    traffic in total. Must be greater than 0 and at most 0.5.
+                    Proportion of traffic placed in the holdout group (e.g. 0.05
+                    for 5%). An equally sized comparison group is sampled from
+                    the remaining traffic for measurement, so 2× this value
+                    enters the holdout experiment in total. Must be greater than
+                    0 and at most 0.5.
                   type: number
                   exclusiveMinimum: 0
                   maximum: 0.5
@@ -49629,8 +49630,8 @@ paths:
       operationId: createHoldout
       summary: Create a single holdout
       description: >-
-        Creates a Holdout. The Holdout starts in the `draft` stage. Use POST
-        /holdouts/{id}/start to start it.
+        Creates a Holdout. The Holdout starts in the `draft` stage. Use the
+        start endpoint to start it.
       tags:
         - Holdouts
       requestBody:
@@ -49847,7 +49848,7 @@ paths:
       operationId: startHoldout
       summary: Start the Holdout's Active Period
       description: >-
-        Feature Flags and experiments can be added during this period while the
+        Feature Flags and Experiments can be added during this period while the
         Holdout measures their cumulative impact.
       tags:
         - Holdouts
@@ -49903,7 +49904,7 @@ paths:
       summary: Start the Holdout's Analysis Period
       description: >-
         Move the holdout into an analysis phase. New Feature Flags and
-        experiments can no longer be added, but existing traffic splits remain
+        Experiments can no longer be added, but existing traffic splits remain
         active for existing and new traffic. Results exclude data from before
         the analysis period so you can measure the cumulative impact after
         changes are frozen.
@@ -65788,10 +65789,10 @@ components:
           type: boolean
         holdoutSize:
           description: >-
-            Proportion of traffic held out, expressed as a decimal (e.g. 0.05
-            for 5%). An equally-sized control group is bucketed alongside it, so
-            the Holdout occupies twice this share of traffic in total. Must be
-            greater than 0 and at most 0.5.
+            Proportion of traffic placed in the holdout group (e.g. 0.05 for
+            5%). An equally sized comparison group is sampled from the remaining
+            traffic for measurement, so 2× this value enters the holdout
+            experiment in total. Must be greater than 0 and at most 0.5.
           type: number
           exclusiveMinimum: 0
           maximum: 0.5

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -49902,10 +49902,11 @@ paths:
       operationId: startHoldoutAnalysis
       summary: Start the Holdout's Analysis Period
       description: >-
-        New Feature Flags and experiments can no longer be added, but existing
-        traffic splits remain active. Results exclude data from before the
-        analysis period so you can measure the cumulative impact after changes
-        are frozen.
+        Move the holdout into an analysis phase. New Feature Flags and
+        experiments can no longer be added, but existing traffic splits remain
+        active for existing and new traffic. Results exclude data from before
+        the analysis period so you can measure the cumulative impact after
+        changes are frozen.
       tags:
         - Holdouts
       parameters:
@@ -65774,6 +65775,12 @@ components:
             - stopped
         trackingKey:
           type: string
+        experimentId:
+          description: >-
+            ID of the companion experiment that stores this Holdout's analysis.
+            Use it with the experiment results endpoints (e.g. GET
+            /experiments/{experimentId}/results).
+          type: string
         skipAsDefaultHoldout:
           description: >-
             When true, this Holdout is not selected automatically when creating
@@ -65971,6 +65978,7 @@ components:
         - archived
         - stage
         - trackingKey
+        - experimentId
         - skipAsDefaultHoldout
         - holdoutSize
         - hashAttribute

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -408,6 +408,11 @@ tags:
     description: >-
       Saved learnings captured across experiments, including AI-discovered
       patterns.
+  - name: Holdouts
+    x-displayName: Holdouts
+    description: >-
+      Hold a share of traffic out of all experiments to measure their combined
+      effect.
   - name: AggregatedFactTable_model
     x-displayName: Aggregated Fact Table
     description: <SchemaDefinition schemaRef="#/components/schemas/AggregatedFactTable" />
@@ -636,6 +641,9 @@ tags:
     description: >-
       <SchemaDefinition schemaRef="#/components/schemas/FeatureWithRevisionsV2"
       />
+  - name: Holdout_model
+    x-displayName: Holdout
+    description: <SchemaDefinition schemaRef="#/components/schemas/Holdout" />
   - name: InformationSchema_model
     x-displayName: Information Schema
     description: <SchemaDefinition schemaRef="#/components/schemas/InformationSchema" />
@@ -49418,6 +49426,481 @@ paths:
           source: |-
             curl -X POST 'https://api.growthbook.io/api/v1/learnings/search' \
               -H 'Authorization: Bearer YOUR_API_KEY'
+  /v1/holdouts/{id}:
+    get:
+      operationId: getHoldout
+      summary: Get a single holdout
+      tags:
+        - Holdouts
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ''
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  holdout:
+                    $ref: '#/components/schemas/Holdout'
+                required:
+                  - holdout
+                additionalProperties: false
+      x-codeSamples:
+        - lang: cURL
+          source: |-
+            curl -X GET 'https://api.growthbook.io/api/v1/holdouts/{id}' \
+              -H 'Authorization: Bearer YOUR_API_KEY'
+    put:
+      operationId: updateHoldout
+      summary: Update a single holdout
+      description: >-
+        Updates a Holdout. Fields are written to the Holdout and its companion
+        experiment as needed, so callers do not need to know where each field is
+        stored. Use POST /holdouts/{id}/stage to change the stage.
+      tags:
+        - Holdouts
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ''
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                  maxLength: 10000
+                projects:
+                  type: array
+                  items:
+                    type: string
+                owner:
+                  description: >-
+                    The userId or email address of the owner. If an email
+                    address is provided, it will be used to look up the userId
+                    of the matching organization member. If an ID is provided,
+                    it will be validated as existing in the organization.
+                  type: string
+                tags:
+                  type: array
+                  items:
+                    type: string
+                archived:
+                  type: boolean
+                skipAsDefaultHoldout:
+                  type: boolean
+                holdoutSize:
+                  description: >-
+                    Proportion of traffic held out, expressed as a decimal (e.g.
+                    0.05 for 5%). An equally-sized control group is bucketed
+                    alongside it, so the Holdout occupies twice this share of
+                    traffic in total. Maximum 0.5.
+                  type: number
+                  minimum: 0
+                  maximum: 0.5
+                hashAttribute:
+                  type: string
+                targetingCondition:
+                  type: string
+                savedGroups:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      match:
+                        type: string
+                        enum:
+                          - all
+                          - none
+                          - any
+                      ids:
+                        type: array
+                        items:
+                          type: string
+                    required:
+                      - match
+                      - ids
+                    additionalProperties: false
+                datasourceId:
+                  type: string
+                assignmentQueryId:
+                  type: string
+                goalMetrics:
+                  type: array
+                  items:
+                    type: string
+                secondaryMetrics:
+                  type: array
+                  items:
+                    type: string
+                guardrailMetrics:
+                  type: array
+                  items:
+                    type: string
+                activationMetric:
+                  type: string
+                variations:
+                  description: >-
+                    Rename a Holdout's variations. A Holdout always has exactly
+                    two variations, so they cannot be added or removed.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      variationId:
+                        type: string
+                      name:
+                        type: string
+                      description:
+                        type: string
+                        maxLength: 10000
+                    required:
+                      - variationId
+                    additionalProperties: false
+                environments:
+                  description: >-
+                    Replaces the entire per-environment state. Environments not
+                    listed are disabled.
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties:
+                    type: object
+                    properties:
+                      enabled:
+                        description: Whether the Holdout is active in this environment.
+                        type: boolean
+                    required:
+                      - enabled
+                    additionalProperties: false
+                statusUpdateSchedule:
+                  anyOf:
+                    - description: >-
+                        Automatic stage transitions for the Holdout. Dates must
+                        be consecutive: `startAt` before `startAnalysisPeriodAt`
+                        before `stopAt`. Send `null` to delete the schedule.
+                      type: object
+                      properties:
+                        startAt:
+                          description: >-
+                            ISO datetime to move the Holdout from `draft` to
+                            `running`. Must be in the future while the Holdout
+                            is still a draft.
+                          type: string
+                          format: date-time
+                        startAnalysisPeriodAt:
+                          description: >-
+                            ISO datetime to move the Holdout from `running` to
+                            `analysis-period`. Requires `startAt` while the
+                            Holdout is still a draft.
+                          type: string
+                          format: date-time
+                        stopAt:
+                          description: >-
+                            ISO datetime to stop the Holdout. Requires
+                            `startAnalysisPeriodAt` unless the analysis period
+                            has already begun.
+                          type: string
+                          format: date-time
+                      additionalProperties: false
+                    - type: 'null'
+              additionalProperties: false
+      responses:
+        '200':
+          description: Resource updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  holdout:
+                    $ref: '#/components/schemas/Holdout'
+                required:
+                  - holdout
+                additionalProperties: false
+      x-codeSamples:
+        - lang: cURL
+          source: |-
+            curl -X PUT 'https://api.growthbook.io/api/v1/holdouts/{id}' \
+              -H 'Authorization: Bearer YOUR_API_KEY'
+  /v1/holdouts:
+    post:
+      operationId: createHoldout
+      summary: Create a single holdout
+      description: >-
+        Creates a Holdout along with its companion experiment. The Holdout
+        starts in the `draft` stage — use POST /holdouts/{id}/stage to start it.
+      tags:
+        - Holdouts
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                  maxLength: 10000
+                projects:
+                  description: >-
+                    Project IDs this Holdout applies to. Omit or send an empty
+                    array for All Projects.
+                  type: array
+                  items:
+                    type: string
+                owner:
+                  description: >-
+                    The userId or email address of the owner. If an email
+                    address is provided, it will be used to look up the userId
+                    of the matching organization member. If an ID is provided,
+                    it will be validated as existing in the organization.
+                  type: string
+                tags:
+                  type: array
+                  items:
+                    type: string
+                skipAsDefaultHoldout:
+                  type: boolean
+                holdoutSize:
+                  description: >-
+                    Proportion of traffic held out, expressed as a decimal (e.g.
+                    0.05 for 5%). An equally-sized control group is bucketed
+                    alongside it. Defaults to 0.05. Maximum 0.5.
+                  type: number
+                  minimum: 0
+                  maximum: 0.5
+                hashAttribute:
+                  type: string
+                targetingCondition:
+                  description: Targeting condition as a JSON string.
+                  type: string
+                savedGroups:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      match:
+                        type: string
+                        enum:
+                          - all
+                          - none
+                          - any
+                      ids:
+                        type: array
+                        items:
+                          type: string
+                    required:
+                      - match
+                      - ids
+                    additionalProperties: false
+                datasourceId:
+                  type: string
+                assignmentQueryId:
+                  type: string
+                goalMetrics:
+                  type: array
+                  items:
+                    type: string
+                secondaryMetrics:
+                  type: array
+                  items:
+                    type: string
+                guardrailMetrics:
+                  type: array
+                  items:
+                    type: string
+                activationMetric:
+                  type: string
+                environments:
+                  description: >-
+                    Per-environment state, keyed by environment ID. Environments
+                    not listed are disabled.
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties:
+                    type: object
+                    properties:
+                      enabled:
+                        description: Whether the Holdout is active in this environment.
+                        type: boolean
+                    required:
+                      - enabled
+                    additionalProperties: false
+                statusUpdateSchedule:
+                  description: >-
+                    Automatic stage transitions for the Holdout. Dates must be
+                    consecutive: `startAt` before `startAnalysisPeriodAt` before
+                    `stopAt`. Send `null` to delete the schedule.
+                  type: object
+                  properties:
+                    startAt:
+                      description: >-
+                        ISO datetime to move the Holdout from `draft` to
+                        `running`. Must be in the future while the Holdout is
+                        still a draft.
+                      type: string
+                      format: date-time
+                    startAnalysisPeriodAt:
+                      description: >-
+                        ISO datetime to move the Holdout from `running` to
+                        `analysis-period`. Requires `startAt` while the Holdout
+                        is still a draft.
+                      type: string
+                      format: date-time
+                    stopAt:
+                      description: >-
+                        ISO datetime to stop the Holdout. Requires
+                        `startAnalysisPeriodAt` unless the analysis period has
+                        already begun.
+                      type: string
+                      format: date-time
+                  additionalProperties: false
+              required:
+                - name
+              additionalProperties: false
+      responses:
+        '200':
+          description: Resource created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  holdout:
+                    $ref: '#/components/schemas/Holdout'
+                required:
+                  - holdout
+                additionalProperties: false
+      x-codeSamples:
+        - lang: cURL
+          source: |-
+            curl -X POST 'https://api.growthbook.io/api/v1/holdouts' \
+              -H 'Authorization: Bearer YOUR_API_KEY'
+    get:
+      operationId: listHoldouts
+      summary: Get all holdouts
+      tags:
+        - Holdouts
+      parameters:
+        - name: projectId
+          in: query
+          description: ''
+          schema:
+            type: string
+        - name: datasourceId
+          in: query
+          description: ''
+          schema:
+            type: string
+        - $ref: '#/components/parameters/stage'
+        - name: archived
+          in: query
+          description: >-
+            Filter by archived state. Omit to return both archived and
+            unarchived Holdouts.
+          schema:
+            description: >-
+              Filter by archived state. Omit to return both archived and
+              unarchived Holdouts.
+            anyOf:
+              - type: string
+                const: 'true'
+              - type: string
+                const: 'false'
+              - type: string
+                const: '0'
+              - type: string
+                const: '1'
+              - type: boolean
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  holdouts:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Holdout'
+                required:
+                  - holdouts
+                additionalProperties: false
+      x-codeSamples:
+        - lang: cURL
+          source: |-
+            curl -X GET 'https://api.growthbook.io/api/v1/holdouts' \
+              -H 'Authorization: Bearer YOUR_API_KEY'
+  /v1/holdouts/{id}/stage:
+    post:
+      operationId: setHoldoutStage
+      summary: Move a Holdout to a different stage
+      tags:
+        - Holdouts
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ''
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                stage:
+                  description: The stage to move the Holdout to.
+                  type: string
+                  enum:
+                    - draft
+                    - running
+                    - analysis-period
+                    - stopped
+              required:
+                - stage
+              additionalProperties: false
+      responses:
+        '200':
+          description: Resource created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  holdout:
+                    $ref: '#/components/schemas/Holdout'
+                required:
+                  - holdout
+                additionalProperties: false
+      x-codeSamples:
+        - lang: cURL
+          source: >-
+            curl -X POST 'https://api.growthbook.io/api/v1/holdouts/{id}/stage'
+            \
+              -H 'Authorization: Bearer YOUR_API_KEY'
 components:
   parameters:
     limit:
@@ -50163,6 +50646,17 @@ components:
           - preferred
           - required
           - never
+    stage:
+      name: stage
+      in: query
+      description: ''
+      schema:
+        type: string
+        enum:
+          - draft
+          - running
+          - analysis-period
+          - stopped
   schemas:
     FeatureV1:
       type: object
@@ -65127,6 +65621,272 @@ components:
         - status
         - source
       additionalProperties: false
+    Holdout:
+      type: object
+      properties:
+        id:
+          type: string
+        dateCreated:
+          type: string
+          format: date-time
+        dateUpdated:
+          type: string
+          format: date-time
+        name:
+          type: string
+        description:
+          type: string
+          maxLength: 10000
+        projects:
+          description: >-
+            Project IDs this Holdout applies to. An empty array means All
+            Projects.
+          type: array
+          items:
+            type: string
+        owner:
+          description: The userId of the owner (or raw owner name/email for legacy records)
+          type: string
+        ownerEmail:
+          description: >-
+            The email address of the owner, when the owner can be resolved to a
+            known user.
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        archived:
+          type: boolean
+        stage:
+          description: >-
+            Lifecycle stage of the Holdout. Change it with POST
+            /holdouts/{id}/stage.
+          type: string
+          enum:
+            - draft
+            - running
+            - analysis-period
+            - stopped
+        experimentId:
+          description: >-
+            ID of the companion experiment that stores this Holdout's analysis
+            settings and results.
+          type: string
+        trackingKey:
+          type: string
+        skipAsDefaultHoldout:
+          description: >-
+            When true, this Holdout is not pre-selected for new Feature Flags
+            and experiments in its Projects.
+          type: boolean
+        holdoutSize:
+          description: >-
+            Proportion of traffic held out, expressed as a decimal (e.g. 0.05
+            for 5%). An equally-sized control group is bucketed alongside it, so
+            the Holdout occupies twice this share of traffic in total. Maximum
+            0.5.
+          type: number
+          minimum: 0
+          maximum: 0.5
+        hashAttribute:
+          description: Attribute used to assign users to the Holdout.
+          type: string
+        targetingCondition:
+          description: Targeting condition as a JSON string.
+          type: string
+        savedGroups:
+          type: array
+          items:
+            type: object
+            properties:
+              match:
+                type: string
+                enum:
+                  - all
+                  - none
+                  - any
+              ids:
+                type: array
+                items:
+                  type: string
+            required:
+              - match
+              - ids
+            additionalProperties: false
+        datasourceId:
+          type: string
+        assignmentQueryId:
+          type: string
+        goalMetrics:
+          type: array
+          items:
+            type: string
+        secondaryMetrics:
+          type: array
+          items:
+            type: string
+        guardrailMetrics:
+          type: array
+          items:
+            type: string
+        activationMetric:
+          type: string
+        variations:
+          type: array
+          items:
+            type: object
+            properties:
+              variationId:
+                type: string
+              key:
+                type: string
+              name:
+                type: string
+              description:
+                type: string
+                maxLength: 10000
+            required:
+              - variationId
+              - key
+              - name
+            additionalProperties: false
+        environments:
+          description: >-
+            Per-environment state, keyed by environment ID. Environments not
+            present are disabled.
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties:
+            type: object
+            properties:
+              enabled:
+                description: Whether the Holdout is active in this environment.
+                type: boolean
+            required:
+              - enabled
+            additionalProperties: false
+        linkedFeatures:
+          description: >-
+            Feature Flags held out by this Holdout. Manage these through the
+            Feature Flag endpoints.
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              dateAdded:
+                type: string
+                format: date-time
+            required:
+              - id
+              - dateAdded
+            additionalProperties: false
+        linkedExperiments:
+          description: >-
+            Experiments held out by this Holdout. Manage these through the
+            experiment endpoints.
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              dateAdded:
+                type: string
+                format: date-time
+            required:
+              - id
+              - dateAdded
+            additionalProperties: false
+        dateStarted:
+          type: string
+          format: date-time
+        analysisStartDate:
+          description: When the Holdout entered its analysis period.
+          type: string
+          format: date-time
+        dateStopped:
+          type: string
+          format: date-time
+        statusUpdateSchedule:
+          anyOf:
+            - description: >-
+                Automatic stage transitions for the Holdout. Dates must be
+                consecutive: `startAt` before `startAnalysisPeriodAt` before
+                `stopAt`. Send `null` to delete the schedule.
+              type: object
+              properties:
+                startAt:
+                  description: >-
+                    ISO datetime to move the Holdout from `draft` to `running`.
+                    Must be in the future while the Holdout is still a draft.
+                  type: string
+                  format: date-time
+                startAnalysisPeriodAt:
+                  description: >-
+                    ISO datetime to move the Holdout from `running` to
+                    `analysis-period`. Requires `startAt` while the Holdout is
+                    still a draft.
+                  type: string
+                  format: date-time
+                stopAt:
+                  description: >-
+                    ISO datetime to stop the Holdout. Requires
+                    `startAnalysisPeriodAt` unless the analysis period has
+                    already begun.
+                  type: string
+                  format: date-time
+              additionalProperties: false
+            - type: 'null'
+        nextScheduledStatusUpdate:
+          anyOf:
+            - description: The next stage transition that will run automatically.
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - start
+                    - startAnalysisPeriod
+                    - stop
+                date:
+                  type: string
+                  format: date-time
+              required:
+                - type
+                - date
+              additionalProperties: false
+            - type: 'null'
+      required:
+        - id
+        - dateCreated
+        - dateUpdated
+        - name
+        - description
+        - projects
+        - owner
+        - tags
+        - archived
+        - stage
+        - experimentId
+        - trackingKey
+        - skipAsDefaultHoldout
+        - holdoutSize
+        - hashAttribute
+        - targetingCondition
+        - datasourceId
+        - assignmentQueryId
+        - goalMetrics
+        - secondaryMetrics
+        - guardrailMetrics
+        - variations
+        - environments
+        - linkedFeatures
+        - linkedExperiments
+      additionalProperties: false
     ExperimentSnapshot:
       type: object
       properties:
@@ -69352,6 +70112,7 @@ x-tagGroups:
       - AnalyticsExplorations
       - RampScheduleTemplates
       - Learnings
+      - Holdouts
   - name: Models
     tags:
       - AggregatedFactTable_model
@@ -69420,6 +70181,7 @@ x-tagGroups:
       - FeatureV2_model
       - FeatureWithRevisionsV1_model
       - FeatureWithRevisionsV2_model
+      - Holdout_model
       - InformationSchema_model
       - InformationSchemaTable_model
       - Learning_model

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -49509,9 +49509,9 @@ paths:
                     Proportion of traffic held out, expressed as a decimal (e.g.
                     0.05 for 5%). An equally-sized control group is bucketed
                     alongside it, so the Holdout occupies twice this share of
-                    traffic in total. Maximum 0.5.
+                    traffic in total. Must be greater than 0 and at most 0.5.
                   type: number
-                  minimum: 0
+                  exclusiveMinimum: 0
                   maximum: 0.5
                 hashAttribute:
                   type: string
@@ -49668,7 +49668,7 @@ paths:
                     0.05 for 5%). An equally-sized control group is bucketed
                     alongside it. Defaults to 0.05. Maximum 0.5.
                   type: number
-                  minimum: 0
+                  exclusiveMinimum: 0
                   maximum: 0.5
                 hashAttribute:
                   type: string
@@ -65775,10 +65775,10 @@ components:
           description: >-
             Proportion of traffic held out, expressed as a decimal (e.g. 0.05
             for 5%). An equally-sized control group is bucketed alongside it, so
-            the Holdout occupies twice this share of traffic in total. Maximum
-            0.5.
+            the Holdout occupies twice this share of traffic in total. Must be
+            greater than 0 and at most 0.5.
           type: number
-          minimum: 0
+          exclusiveMinimum: 0
           maximum: 0.5
         hashAttribute:
           description: Attribute used to assign users to the Holdout.

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -49514,7 +49514,7 @@ paths:
                   type: string
                 targetingCondition:
                   type: string
-                savedGroups:
+                savedGroupTargeting:
                   type: array
                   items:
                     type: object
@@ -49545,24 +49545,12 @@ paths:
                   type: array
                   items:
                     type: string
-                variations:
-                  description: >-
-                    Rename a Holdout's variations. A Holdout always has exactly
-                    two variations, so they cannot be added or removed.
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      variationId:
-                        type: string
-                      name:
-                        type: string
-                      description:
-                        type: string
-                        maxLength: 10000
-                    required:
-                      - variationId
-                    additionalProperties: false
+                statsEngine:
+                  description: Statistics engine used to analyze this Holdout.
+                  type: string
+                  enum:
+                    - bayesian
+                    - frequentist
                 environments:
                   description: >-
                     Replaces the entire per-environment state. Environments not
@@ -49683,7 +49671,7 @@ paths:
                 targetingCondition:
                   description: Targeting condition as a JSON string.
                   type: string
-                savedGroups:
+                savedGroupTargeting:
                   type: array
                   items:
                     type: object
@@ -49714,6 +49702,12 @@ paths:
                   type: array
                   items:
                     type: string
+                statsEngine:
+                  description: Statistics engine used to analyze this Holdout.
+                  type: string
+                  enum:
+                    - bayesian
+                    - frequentist
                 environments:
                   description: >-
                     Per-environment state, keyed by environment ID. Environments
@@ -65680,7 +65674,7 @@ components:
         targetingCondition:
           description: Targeting condition as a JSON string.
           type: string
-        savedGroups:
+        savedGroupTargeting:
           type: array
           items:
             type: object

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -65756,11 +65756,6 @@ components:
             - running
             - analysis-period
             - stopped
-        experimentId:
-          description: >-
-            ID of the companion experiment that stores this Holdout's analysis
-            settings and results.
-          type: string
         trackingKey:
           type: string
         skipAsDefaultHoldout:
@@ -65953,7 +65948,6 @@ components:
         - tags
         - archived
         - stage
-        - experimentId
         - trackingKey
         - skipAsDefaultHoldout
         - holdoutSize

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -65825,6 +65825,12 @@ components:
           type: array
           items:
             type: string
+        statsEngine:
+          description: Statistics engine used to analyze this Holdout.
+          type: string
+          enum:
+            - bayesian
+            - frequentist
         variations:
           type: array
           items:

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -49460,10 +49460,7 @@ paths:
     put:
       operationId: updateHoldout
       summary: Update a single holdout
-      description: >-
-        Updates a Holdout. Fields are written to the Holdout and its companion
-        experiment as needed, so callers do not need to know where each field is
-        stored. Use POST /holdouts/{id}/stage to change the stage.
+      description: Updates a Holdout. Use POST /holdouts/{id}/stage to change the stage.
       tags:
         - Holdouts
       parameters:
@@ -49548,12 +49545,6 @@ paths:
                   type: array
                   items:
                     type: string
-                guardrailMetrics:
-                  type: array
-                  items:
-                    type: string
-                activationMetric:
-                  type: string
                 variations:
                   description: >-
                     Rename a Holdout's variations. A Holdout always has exactly
@@ -49643,8 +49634,8 @@ paths:
       operationId: createHoldout
       summary: Create a single holdout
       description: >-
-        Creates a Holdout along with its companion experiment. The Holdout
-        starts in the `draft` stage — use POST /holdouts/{id}/stage to start it.
+        Creates a Holdout. The Holdout starts in the `draft` stage — use POST
+        /holdouts/{id}/stage to start it.
       tags:
         - Holdouts
       requestBody:
@@ -49723,12 +49714,6 @@ paths:
                   type: array
                   items:
                     type: string
-                guardrailMetrics:
-                  type: array
-                  items:
-                    type: string
-                activationMetric:
-                  type: string
                 environments:
                   description: >-
                     Per-environment state, keyed by environment ID. Environments
@@ -65726,12 +65711,6 @@ components:
           type: array
           items:
             type: string
-        guardrailMetrics:
-          type: array
-          items:
-            type: string
-        activationMetric:
-          type: string
         variations:
           type: array
           items:
@@ -65881,7 +65860,6 @@ components:
         - assignmentQueryId
         - goalMetrics
         - secondaryMetrics
-        - guardrailMetrics
         - variations
         - environments
         - linkedFeatures

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -49481,6 +49481,7 @@ paths:
               properties:
                 name:
                   type: string
+                  minLength: 1
                 description:
                   type: string
                   maxLength: 10000
@@ -49637,6 +49638,7 @@ paths:
               properties:
                 name:
                   type: string
+                  minLength: 1
                 description:
                   type: string
                   maxLength: 10000

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -65780,7 +65780,9 @@ components:
           description: >-
             ID of the companion experiment that stores this Holdout's analysis.
             Use it with the experiment results endpoints (e.g. GET
-            /experiments/{experimentId}/results).
+            /experiments/{experimentId}/results). Pass phase=0 for results
+            across the whole Holdout period, or phase=1 for results limited to
+            the analysis period.
           type: string
         skipAsDefaultHoldout:
           description: >-

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -49460,7 +49460,9 @@ paths:
     put:
       operationId: updateHoldout
       summary: Update a single holdout
-      description: Updates a Holdout. Use POST /holdouts/{id}/stage to change the stage.
+      description: >-
+        Updates a Holdout. Use the start, start-analysis, and stop endpoints to
+        move it through its lifecycle.
       tags:
         - Holdouts
       parameters:
@@ -49622,8 +49624,8 @@ paths:
       operationId: createHoldout
       summary: Create a single holdout
       description: >-
-        Creates a Holdout. The Holdout starts in the `draft` stage — use POST
-        /holdouts/{id}/stage to start it.
+        Creates a Holdout. The Holdout starts in the `draft` stage. Use POST
+        /holdouts/{id}/start to start it.
       tags:
         - Holdouts
       requestBody:
@@ -49830,10 +49832,10 @@ paths:
           source: |-
             curl -X GET 'https://api.growthbook.io/api/v1/holdouts' \
               -H 'Authorization: Bearer YOUR_API_KEY'
-  /v1/holdouts/{id}/stage:
+  /v1/holdouts/{id}/start:
     post:
-      operationId: setHoldoutStage
-      summary: Move a Holdout to a different stage
+      operationId: startHoldout
+      summary: Start a Holdout
       tags:
         - Holdouts
       parameters:
@@ -49843,24 +49845,6 @@ paths:
           description: ''
           schema:
             type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                stage:
-                  description: The stage to move the Holdout to.
-                  type: string
-                  enum:
-                    - draft
-                    - running
-                    - analysis-period
-                    - stopped
-              required:
-                - stage
-              additionalProperties: false
       responses:
         '200':
           description: Resource created
@@ -49874,11 +49858,134 @@ paths:
                 required:
                   - holdout
                 additionalProperties: false
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Resource is not in a valid status for this operation
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                    enum:
+                      - invalid_status
+                  details:
+                    $ref: '#/components/schemas/ApiErrorInvalidStatusDetails'
+                required:
+                  - message
+                  - code
+                  - details
       x-codeSamples:
         - lang: cURL
           source: >-
-            curl -X POST 'https://api.growthbook.io/api/v1/holdouts/{id}/stage'
+            curl -X POST 'https://api.growthbook.io/api/v1/holdouts/{id}/start'
             \
+              -H 'Authorization: Bearer YOUR_API_KEY'
+  /v1/holdouts/{id}/start-analysis:
+    post:
+      operationId: startHoldoutAnalysis
+      summary: Start a Holdout analysis period
+      tags:
+        - Holdouts
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ''
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Resource created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  holdout:
+                    $ref: '#/components/schemas/Holdout'
+                required:
+                  - holdout
+                additionalProperties: false
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Resource is not in a valid status for this operation
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                    enum:
+                      - invalid_status
+                  details:
+                    $ref: '#/components/schemas/ApiErrorInvalidStatusDetails'
+                required:
+                  - message
+                  - code
+                  - details
+      x-codeSamples:
+        - lang: cURL
+          source: >-
+            curl -X POST
+            'https://api.growthbook.io/api/v1/holdouts/{id}/start-analysis' \
+              -H 'Authorization: Bearer YOUR_API_KEY'
+  /v1/holdouts/{id}/stop:
+    post:
+      operationId: stopHoldout
+      summary: Stop a Holdout
+      tags:
+        - Holdouts
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ''
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Resource created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  holdout:
+                    $ref: '#/components/schemas/Holdout'
+                required:
+                  - holdout
+                additionalProperties: false
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Resource is not in a valid status for this operation
+                properties:
+                  message:
+                    type: string
+                  code:
+                    type: string
+                    enum:
+                      - invalid_status
+                  details:
+                    $ref: '#/components/schemas/ApiErrorInvalidStatusDetails'
+                required:
+                  - message
+                  - code
+                  - details
+      x-codeSamples:
+        - lang: cURL
+          source: |-
+            curl -X POST 'https://api.growthbook.io/api/v1/holdouts/{id}/stop' \
               -H 'Authorization: Bearer YOUR_API_KEY'
 components:
   parameters:
@@ -65639,8 +65746,8 @@ components:
           type: boolean
         stage:
           description: >-
-            Lifecycle stage of the Holdout. Change it with POST
-            /holdouts/{id}/stage.
+            Lifecycle stage of the Holdout. Use the start, start-analysis, and
+            stop endpoints to move through the lifecycle.
           type: string
           enum:
             - draft

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -49837,7 +49837,10 @@ paths:
   /v1/holdouts/{id}/start:
     post:
       operationId: startHoldout
-      summary: Start a Holdout
+      summary: Start the Holdout's Active Period
+      description: >-
+        Feature Flags and experiments can be added during this period while the
+        Holdout measures their cumulative impact.
       tags:
         - Holdouts
       parameters:
@@ -49889,7 +49892,12 @@ paths:
   /v1/holdouts/{id}/start-analysis:
     post:
       operationId: startHoldoutAnalysis
-      summary: Start a Holdout analysis period
+      summary: Start the Holdout's Analysis Period
+      description: >-
+        New Feature Flags and experiments can no longer be added, but existing
+        traffic splits remain active. Results exclude data from before the
+        analysis period so you can measure the cumulative impact after changes
+        are frozen.
       tags:
         - Holdouts
       parameters:

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -408,6 +408,11 @@ tags:
     description: >-
       Saved learnings captured across experiments, including AI-discovered
       patterns.
+  - name: Holdouts
+    x-displayName: Holdouts
+    description: >-
+      Hold a share of traffic out of all experiments to measure their combined
+      effect.
   - name: AggregatedFactTable_model
     x-displayName: Aggregated Fact Table
     description: <SchemaDefinition schemaRef="#/components/schemas/AggregatedFactTable" />
@@ -636,6 +641,9 @@ tags:
     description: >-
       <SchemaDefinition schemaRef="#/components/schemas/FeatureWithRevisionsV2"
       />
+  - name: Holdout_model
+    x-displayName: Holdout
+    description: <SchemaDefinition schemaRef="#/components/schemas/Holdout" />
   - name: InformationSchema_model
     x-displayName: Information Schema
     description: <SchemaDefinition schemaRef="#/components/schemas/InformationSchema" />
@@ -48307,6 +48315,481 @@ paths:
           source: |-
             curl -X POST 'https://api.growthbook.io/api/v1/learnings/search' \
               -H 'Authorization: Bearer YOUR_API_KEY'
+  /v1/holdouts/{id}:
+    get:
+      operationId: getHoldout
+      summary: Get a single holdout
+      tags:
+        - Holdouts
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ''
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  holdout:
+                    $ref: '#/components/schemas/Holdout'
+                required:
+                  - holdout
+                additionalProperties: false
+      x-codeSamples:
+        - lang: cURL
+          source: |-
+            curl -X GET 'https://api.growthbook.io/api/v1/holdouts/{id}' \
+              -H 'Authorization: Bearer YOUR_API_KEY'
+    put:
+      operationId: updateHoldout
+      summary: Update a single holdout
+      description: >-
+        Updates a Holdout. Fields are written to the Holdout and its companion
+        experiment as needed, so callers do not need to know where each field is
+        stored. Use POST /holdouts/{id}/stage to change the stage.
+      tags:
+        - Holdouts
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ''
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                  maxLength: 10000
+                projects:
+                  type: array
+                  items:
+                    type: string
+                owner:
+                  description: >-
+                    The userId or email address of the owner. If an email
+                    address is provided, it will be used to look up the userId
+                    of the matching organization member. If an ID is provided,
+                    it will be validated as existing in the organization.
+                  type: string
+                tags:
+                  type: array
+                  items:
+                    type: string
+                archived:
+                  type: boolean
+                skipAsDefaultHoldout:
+                  type: boolean
+                holdoutSize:
+                  description: >-
+                    Proportion of traffic held out, expressed as a decimal (e.g.
+                    0.05 for 5%). An equally-sized control group is bucketed
+                    alongside it, so the Holdout occupies twice this share of
+                    traffic in total. Maximum 0.5.
+                  type: number
+                  minimum: 0
+                  maximum: 0.5
+                hashAttribute:
+                  type: string
+                targetingCondition:
+                  type: string
+                savedGroups:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      match:
+                        type: string
+                        enum:
+                          - all
+                          - none
+                          - any
+                      ids:
+                        type: array
+                        items:
+                          type: string
+                    required:
+                      - match
+                      - ids
+                    additionalProperties: false
+                datasourceId:
+                  type: string
+                assignmentQueryId:
+                  type: string
+                goalMetrics:
+                  type: array
+                  items:
+                    type: string
+                secondaryMetrics:
+                  type: array
+                  items:
+                    type: string
+                guardrailMetrics:
+                  type: array
+                  items:
+                    type: string
+                activationMetric:
+                  type: string
+                variations:
+                  description: >-
+                    Rename a Holdout's variations. A Holdout always has exactly
+                    two variations, so they cannot be added or removed.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      variationId:
+                        type: string
+                      name:
+                        type: string
+                      description:
+                        type: string
+                        maxLength: 10000
+                    required:
+                      - variationId
+                    additionalProperties: false
+                environments:
+                  description: >-
+                    Replaces the entire per-environment state. Environments not
+                    listed are disabled.
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties:
+                    type: object
+                    properties:
+                      enabled:
+                        description: Whether the Holdout is active in this environment.
+                        type: boolean
+                    required:
+                      - enabled
+                    additionalProperties: false
+                statusUpdateSchedule:
+                  anyOf:
+                    - description: >-
+                        Automatic stage transitions for the Holdout. Dates must
+                        be consecutive: `startAt` before `startAnalysisPeriodAt`
+                        before `stopAt`. Send `null` to delete the schedule.
+                      type: object
+                      properties:
+                        startAt:
+                          description: >-
+                            ISO datetime to move the Holdout from `draft` to
+                            `running`. Must be in the future while the Holdout
+                            is still a draft.
+                          type: string
+                          format: date-time
+                        startAnalysisPeriodAt:
+                          description: >-
+                            ISO datetime to move the Holdout from `running` to
+                            `analysis-period`. Requires `startAt` while the
+                            Holdout is still a draft.
+                          type: string
+                          format: date-time
+                        stopAt:
+                          description: >-
+                            ISO datetime to stop the Holdout. Requires
+                            `startAnalysisPeriodAt` unless the analysis period
+                            has already begun.
+                          type: string
+                          format: date-time
+                      additionalProperties: false
+                    - type: 'null'
+              additionalProperties: false
+      responses:
+        '200':
+          description: Resource updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  holdout:
+                    $ref: '#/components/schemas/Holdout'
+                required:
+                  - holdout
+                additionalProperties: false
+      x-codeSamples:
+        - lang: cURL
+          source: |-
+            curl -X PUT 'https://api.growthbook.io/api/v1/holdouts/{id}' \
+              -H 'Authorization: Bearer YOUR_API_KEY'
+  /v1/holdouts:
+    post:
+      operationId: createHoldout
+      summary: Create a single holdout
+      description: >-
+        Creates a Holdout along with its companion experiment. The Holdout
+        starts in the `draft` stage — use POST /holdouts/{id}/stage to start it.
+      tags:
+        - Holdouts
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                  maxLength: 10000
+                projects:
+                  description: >-
+                    Project IDs this Holdout applies to. Omit or send an empty
+                    array for All Projects.
+                  type: array
+                  items:
+                    type: string
+                owner:
+                  description: >-
+                    The userId or email address of the owner. If an email
+                    address is provided, it will be used to look up the userId
+                    of the matching organization member. If an ID is provided,
+                    it will be validated as existing in the organization.
+                  type: string
+                tags:
+                  type: array
+                  items:
+                    type: string
+                skipAsDefaultHoldout:
+                  type: boolean
+                holdoutSize:
+                  description: >-
+                    Proportion of traffic held out, expressed as a decimal (e.g.
+                    0.05 for 5%). An equally-sized control group is bucketed
+                    alongside it. Defaults to 0.05. Maximum 0.5.
+                  type: number
+                  minimum: 0
+                  maximum: 0.5
+                hashAttribute:
+                  type: string
+                targetingCondition:
+                  description: Targeting condition as a JSON string.
+                  type: string
+                savedGroups:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      match:
+                        type: string
+                        enum:
+                          - all
+                          - none
+                          - any
+                      ids:
+                        type: array
+                        items:
+                          type: string
+                    required:
+                      - match
+                      - ids
+                    additionalProperties: false
+                datasourceId:
+                  type: string
+                assignmentQueryId:
+                  type: string
+                goalMetrics:
+                  type: array
+                  items:
+                    type: string
+                secondaryMetrics:
+                  type: array
+                  items:
+                    type: string
+                guardrailMetrics:
+                  type: array
+                  items:
+                    type: string
+                activationMetric:
+                  type: string
+                environments:
+                  description: >-
+                    Per-environment state, keyed by environment ID. Environments
+                    not listed are disabled.
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties:
+                    type: object
+                    properties:
+                      enabled:
+                        description: Whether the Holdout is active in this environment.
+                        type: boolean
+                    required:
+                      - enabled
+                    additionalProperties: false
+                statusUpdateSchedule:
+                  description: >-
+                    Automatic stage transitions for the Holdout. Dates must be
+                    consecutive: `startAt` before `startAnalysisPeriodAt` before
+                    `stopAt`. Send `null` to delete the schedule.
+                  type: object
+                  properties:
+                    startAt:
+                      description: >-
+                        ISO datetime to move the Holdout from `draft` to
+                        `running`. Must be in the future while the Holdout is
+                        still a draft.
+                      type: string
+                      format: date-time
+                    startAnalysisPeriodAt:
+                      description: >-
+                        ISO datetime to move the Holdout from `running` to
+                        `analysis-period`. Requires `startAt` while the Holdout
+                        is still a draft.
+                      type: string
+                      format: date-time
+                    stopAt:
+                      description: >-
+                        ISO datetime to stop the Holdout. Requires
+                        `startAnalysisPeriodAt` unless the analysis period has
+                        already begun.
+                      type: string
+                      format: date-time
+                  additionalProperties: false
+              required:
+                - name
+              additionalProperties: false
+      responses:
+        '200':
+          description: Resource created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  holdout:
+                    $ref: '#/components/schemas/Holdout'
+                required:
+                  - holdout
+                additionalProperties: false
+      x-codeSamples:
+        - lang: cURL
+          source: |-
+            curl -X POST 'https://api.growthbook.io/api/v1/holdouts' \
+              -H 'Authorization: Bearer YOUR_API_KEY'
+    get:
+      operationId: listHoldouts
+      summary: Get all holdouts
+      tags:
+        - Holdouts
+      parameters:
+        - name: projectId
+          in: query
+          description: ''
+          schema:
+            type: string
+        - name: datasourceId
+          in: query
+          description: ''
+          schema:
+            type: string
+        - $ref: '#/components/parameters/stage'
+        - name: archived
+          in: query
+          description: >-
+            Filter by archived state. Omit to return both archived and
+            unarchived Holdouts.
+          schema:
+            description: >-
+              Filter by archived state. Omit to return both archived and
+              unarchived Holdouts.
+            anyOf:
+              - type: string
+                const: 'true'
+              - type: string
+                const: 'false'
+              - type: string
+                const: '0'
+              - type: string
+                const: '1'
+              - type: boolean
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  holdouts:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Holdout'
+                required:
+                  - holdouts
+                additionalProperties: false
+      x-codeSamples:
+        - lang: cURL
+          source: |-
+            curl -X GET 'https://api.growthbook.io/api/v1/holdouts' \
+              -H 'Authorization: Bearer YOUR_API_KEY'
+  /v1/holdouts/{id}/stage:
+    post:
+      operationId: setHoldoutStage
+      summary: Move a Holdout to a different stage
+      tags:
+        - Holdouts
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ''
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                stage:
+                  description: The stage to move the Holdout to.
+                  type: string
+                  enum:
+                    - draft
+                    - running
+                    - analysis-period
+                    - stopped
+              required:
+                - stage
+              additionalProperties: false
+      responses:
+        '200':
+          description: Resource created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  holdout:
+                    $ref: '#/components/schemas/Holdout'
+                required:
+                  - holdout
+                additionalProperties: false
+      x-codeSamples:
+        - lang: cURL
+          source: >-
+            curl -X POST 'https://api.growthbook.io/api/v1/holdouts/{id}/stage'
+            \
+              -H 'Authorization: Bearer YOUR_API_KEY'
 components:
   parameters:
     limit:
@@ -49052,6 +49535,17 @@ components:
           - preferred
           - required
           - never
+    stage:
+      name: stage
+      in: query
+      description: ''
+      schema:
+        type: string
+        enum:
+          - draft
+          - running
+          - analysis-period
+          - stopped
   schemas:
     FeatureV1:
       type: object
@@ -63772,6 +64266,272 @@ components:
         - status
         - source
       additionalProperties: false
+    Holdout:
+      type: object
+      properties:
+        id:
+          type: string
+        dateCreated:
+          type: string
+          format: date-time
+        dateUpdated:
+          type: string
+          format: date-time
+        name:
+          type: string
+        description:
+          type: string
+          maxLength: 10000
+        projects:
+          description: >-
+            Project IDs this Holdout applies to. An empty array means All
+            Projects.
+          type: array
+          items:
+            type: string
+        owner:
+          description: The userId of the owner (or raw owner name/email for legacy records)
+          type: string
+        ownerEmail:
+          description: >-
+            The email address of the owner, when the owner can be resolved to a
+            known user.
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        archived:
+          type: boolean
+        stage:
+          description: >-
+            Lifecycle stage of the Holdout. Change it with POST
+            /holdouts/{id}/stage.
+          type: string
+          enum:
+            - draft
+            - running
+            - analysis-period
+            - stopped
+        experimentId:
+          description: >-
+            ID of the companion experiment that stores this Holdout's analysis
+            settings and results.
+          type: string
+        trackingKey:
+          type: string
+        skipAsDefaultHoldout:
+          description: >-
+            When true, this Holdout is not pre-selected for new Feature Flags
+            and experiments in its Projects.
+          type: boolean
+        holdoutSize:
+          description: >-
+            Proportion of traffic held out, expressed as a decimal (e.g. 0.05
+            for 5%). An equally-sized control group is bucketed alongside it, so
+            the Holdout occupies twice this share of traffic in total. Maximum
+            0.5.
+          type: number
+          minimum: 0
+          maximum: 0.5
+        hashAttribute:
+          description: Attribute used to assign users to the Holdout.
+          type: string
+        targetingCondition:
+          description: Targeting condition as a JSON string.
+          type: string
+        savedGroups:
+          type: array
+          items:
+            type: object
+            properties:
+              match:
+                type: string
+                enum:
+                  - all
+                  - none
+                  - any
+              ids:
+                type: array
+                items:
+                  type: string
+            required:
+              - match
+              - ids
+            additionalProperties: false
+        datasourceId:
+          type: string
+        assignmentQueryId:
+          type: string
+        goalMetrics:
+          type: array
+          items:
+            type: string
+        secondaryMetrics:
+          type: array
+          items:
+            type: string
+        guardrailMetrics:
+          type: array
+          items:
+            type: string
+        activationMetric:
+          type: string
+        variations:
+          type: array
+          items:
+            type: object
+            properties:
+              variationId:
+                type: string
+              key:
+                type: string
+              name:
+                type: string
+              description:
+                type: string
+                maxLength: 10000
+            required:
+              - variationId
+              - key
+              - name
+            additionalProperties: false
+        environments:
+          description: >-
+            Per-environment state, keyed by environment ID. Environments not
+            present are disabled.
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties:
+            type: object
+            properties:
+              enabled:
+                description: Whether the Holdout is active in this environment.
+                type: boolean
+            required:
+              - enabled
+            additionalProperties: false
+        linkedFeatures:
+          description: >-
+            Feature Flags held out by this Holdout. Manage these through the
+            Feature Flag endpoints.
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              dateAdded:
+                type: string
+                format: date-time
+            required:
+              - id
+              - dateAdded
+            additionalProperties: false
+        linkedExperiments:
+          description: >-
+            Experiments held out by this Holdout. Manage these through the
+            experiment endpoints.
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              dateAdded:
+                type: string
+                format: date-time
+            required:
+              - id
+              - dateAdded
+            additionalProperties: false
+        dateStarted:
+          type: string
+          format: date-time
+        analysisStartDate:
+          description: When the Holdout entered its analysis period.
+          type: string
+          format: date-time
+        dateStopped:
+          type: string
+          format: date-time
+        statusUpdateSchedule:
+          anyOf:
+            - description: >-
+                Automatic stage transitions for the Holdout. Dates must be
+                consecutive: `startAt` before `startAnalysisPeriodAt` before
+                `stopAt`. Send `null` to delete the schedule.
+              type: object
+              properties:
+                startAt:
+                  description: >-
+                    ISO datetime to move the Holdout from `draft` to `running`.
+                    Must be in the future while the Holdout is still a draft.
+                  type: string
+                  format: date-time
+                startAnalysisPeriodAt:
+                  description: >-
+                    ISO datetime to move the Holdout from `running` to
+                    `analysis-period`. Requires `startAt` while the Holdout is
+                    still a draft.
+                  type: string
+                  format: date-time
+                stopAt:
+                  description: >-
+                    ISO datetime to stop the Holdout. Requires
+                    `startAnalysisPeriodAt` unless the analysis period has
+                    already begun.
+                  type: string
+                  format: date-time
+              additionalProperties: false
+            - type: 'null'
+        nextScheduledStatusUpdate:
+          anyOf:
+            - description: The next stage transition that will run automatically.
+              type: object
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - start
+                    - startAnalysisPeriod
+                    - stop
+                date:
+                  type: string
+                  format: date-time
+              required:
+                - type
+                - date
+              additionalProperties: false
+            - type: 'null'
+      required:
+        - id
+        - dateCreated
+        - dateUpdated
+        - name
+        - description
+        - projects
+        - owner
+        - tags
+        - archived
+        - stage
+        - experimentId
+        - trackingKey
+        - skipAsDefaultHoldout
+        - holdoutSize
+        - hashAttribute
+        - targetingCondition
+        - datasourceId
+        - assignmentQueryId
+        - goalMetrics
+        - secondaryMetrics
+        - guardrailMetrics
+        - variations
+        - environments
+        - linkedFeatures
+        - linkedExperiments
+      additionalProperties: false
     ExperimentSnapshot:
       type: object
       properties:
@@ -67900,6 +68660,7 @@ x-tagGroups:
       - AnalyticsExplorations
       - RampScheduleTemplates
       - Learnings
+      - Holdouts
   - name: Models
     tags:
       - AggregatedFactTable_model
@@ -67968,6 +68729,7 @@ x-tagGroups:
       - FeatureV2_model
       - FeatureWithRevisionsV1_model
       - FeatureWithRevisionsV2_model
+      - Holdout_model
       - InformationSchema_model
       - InformationSchemaTable_model
       - Learning_model

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -48349,10 +48349,7 @@ paths:
     put:
       operationId: updateHoldout
       summary: Update a single holdout
-      description: >-
-        Updates a Holdout. Fields are written to the Holdout and its companion
-        experiment as needed, so callers do not need to know where each field is
-        stored. Use POST /holdouts/{id}/stage to change the stage.
+      description: Updates a Holdout. Use POST /holdouts/{id}/stage to change the stage.
       tags:
         - Holdouts
       parameters:
@@ -48437,12 +48434,6 @@ paths:
                   type: array
                   items:
                     type: string
-                guardrailMetrics:
-                  type: array
-                  items:
-                    type: string
-                activationMetric:
-                  type: string
                 variations:
                   description: >-
                     Rename a Holdout's variations. A Holdout always has exactly
@@ -48532,8 +48523,8 @@ paths:
       operationId: createHoldout
       summary: Create a single holdout
       description: >-
-        Creates a Holdout along with its companion experiment. The Holdout
-        starts in the `draft` stage — use POST /holdouts/{id}/stage to start it.
+        Creates a Holdout. The Holdout starts in the `draft` stage — use POST
+        /holdouts/{id}/stage to start it.
       tags:
         - Holdouts
       requestBody:
@@ -48612,12 +48603,6 @@ paths:
                   type: array
                   items:
                     type: string
-                guardrailMetrics:
-                  type: array
-                  items:
-                    type: string
-                activationMetric:
-                  type: string
                 environments:
                   description: >-
                     Per-environment state, keyed by environment ID. Environments
@@ -64371,12 +64356,6 @@ components:
           type: array
           items:
             type: string
-        guardrailMetrics:
-          type: array
-          items:
-            type: string
-        activationMetric:
-          type: string
         variations:
           type: array
           items:
@@ -64526,7 +64505,6 @@ components:
         - assignmentQueryId
         - goalMetrics
         - secondaryMetrics
-        - guardrailMetrics
         - variations
         - environments
         - linkedFeatures

--- a/packages/back-end/src/api/ApiModel.ts
+++ b/packages/back-end/src/api/ApiModel.ts
@@ -95,6 +95,7 @@ export type OpenApiEndpointSpec = {
   validator: RequestSchemas<z.ZodTypeAny, z.ZodTypeAny, z.ZodTypeAny>;
   zodReturnObject: z.ZodTypeAny;
   summary: string;
+  description?: string;
   /** Error codes this endpoint may throw, used to generate OpenAPI error response schemas. */
   possibleErrors?: readonly ApiErrorCode[];
 };
@@ -297,6 +298,7 @@ export function getOpenApiRoutesForApiConfig(
       verb,
       operationId,
       summary,
+      description,
       zodReturnObject,
       possibleErrors,
     }) => {
@@ -306,6 +308,7 @@ export function getOpenApiRoutesForApiConfig(
         path: getFullPath(apiConfig.openApiSpec.pathBase, pathFragment),
         operationId,
         summary,
+        description,
         tags: [tag],
         responseSchema: zodReturnObject,
         possibleErrors,

--- a/packages/back-end/src/api/api.router.ts
+++ b/packages/back-end/src/api/api.router.ts
@@ -17,6 +17,7 @@ import { AnalyticsExplorationModel } from "back-end/src/models/AnalyticsExplorat
 import { RampScheduleTemplateModel } from "back-end/src/models/RampScheduleTemplateModel";
 import { RampScheduleModel } from "back-end/src/models/RampScheduleModel";
 import { LearningModel } from "back-end/src/models/LearningModel";
+import { HoldoutModel } from "back-end/src/models/HoldoutModel";
 import { ModelClass } from "back-end/src/services/context";
 import { getBuild } from "back-end/src/util/build";
 import { ApiRequestLocals } from "back-end/types/api";
@@ -72,6 +73,7 @@ const API_MODELS: ModelClass[] = [
   RampScheduleTemplateModel,
   RampScheduleModel,
   LearningModel,
+  HoldoutModel,
 ];
 
 const router = Router();

--- a/packages/back-end/src/api/apiModelHandlers.ts
+++ b/packages/back-end/src/api/apiModelHandlers.ts
@@ -34,6 +34,7 @@ export type CustomApiHandler<
   validator: RequestSchemas<ParamsSchema, BodySchema, QuerySchema>;
   zodReturnObject: ReturnShape;
   summary: string; // For generating docs, e.g. "Get all dashboards for an experiment"
+  description?: string;
   /** Error codes this endpoint may throw, used to generate OpenAPI error response schemas. */
   possibleErrors?: readonly ApiErrorCode[];
   reqHandler: (

--- a/packages/back-end/src/api/experiments/deleteVariationScreenshot.ts
+++ b/packages/back-end/src/api/experiments/deleteVariationScreenshot.ts
@@ -50,6 +50,10 @@ export const deleteVariationScreenshot = createApiRequestHandler(
     throw new Error("Experiment not found");
   }
 
+  if (experiment.type === "holdout") {
+    throw new Error("Holdouts are not supported via this API");
+  }
+
   if (experiment.organization !== context.org.id) {
     throw new Error("You do not have access to this experiment");
   }

--- a/packages/back-end/src/api/experiments/postVariationImageUpload.ts
+++ b/packages/back-end/src/api/experiments/postVariationImageUpload.ts
@@ -85,6 +85,10 @@ export const postVariationImageUpload = createApiRequestHandler(
     throw new Error("Experiment not found");
   }
 
+  if (experiment.type === "holdout") {
+    throw new Error("Holdouts are not supported via this API");
+  }
+
   if (experiment.organization !== context.org.id) {
     throw new Error("You do not have access to this experiment");
   }

--- a/packages/back-end/src/api/specs/holdout.spec.ts
+++ b/packages/back-end/src/api/specs/holdout.spec.ts
@@ -28,8 +28,6 @@ export const holdoutApiSpec = {
     createBody: apiCreateHoldoutBody,
     updateBody: apiUpdateHoldoutBody,
   },
-  // Deleting a Holdout cascades into its companion experiment and unlinks every
-  // held-out Feature Flag and experiment, so it stays UI-only for now.
   crudActions: ["get", "create", "list", "update"],
   crudValidatorOverrides: {
     list: apiListHoldoutsValidator,
@@ -37,9 +35,9 @@ export const holdoutApiSpec = {
   customEndpoints: [holdoutStageEndpoint],
   crudDescriptions: {
     create:
-      "Creates a Holdout along with its companion experiment. The Holdout starts in the `draft` stage — use POST /holdouts/{id}/stage to start it.",
+      "Creates a Holdout. The Holdout starts in the `draft` stage — use POST /holdouts/{id}/stage to start it.",
     update:
-      "Updates a Holdout. Fields are written to the Holdout and its companion experiment as needed, so callers do not need to know where each field is stored. Use POST /holdouts/{id}/stage to change the stage.",
+      "Updates a Holdout. Use POST /holdouts/{id}/stage to change the stage.",
   },
   navDescription:
     "Hold a share of traffic out of all experiments to measure their combined effect.",

--- a/packages/back-end/src/api/specs/holdout.spec.ts
+++ b/packages/back-end/src/api/specs/holdout.spec.ts
@@ -1,7 +1,7 @@
 import {
   apiCreateHoldoutBody,
-  apiHoldoutStageReturn,
-  apiHoldoutStageValidator,
+  apiHoldoutActionReturn,
+  apiHoldoutActionValidator,
   apiHoldoutValidator,
   apiListHoldoutsValidator,
   apiUpdateHoldoutBody,
@@ -10,13 +10,34 @@ import { OpenApiModelSpec } from "back-end/src/api/ApiModel";
 
 /** REST API surface for Holdouts under `/api/v1/holdouts/*`. */
 
-export const holdoutStageEndpoint = {
-  pathFragment: "/:id/stage",
+export const holdoutStartEndpoint = {
+  pathFragment: "/:id/start",
   verb: "post" as const,
-  operationId: "setHoldoutStage",
-  validator: apiHoldoutStageValidator,
-  zodReturnObject: apiHoldoutStageReturn,
-  summary: "Move a Holdout to a different stage",
+  operationId: "startHoldout",
+  validator: apiHoldoutActionValidator,
+  zodReturnObject: apiHoldoutActionReturn,
+  summary: "Start a Holdout",
+  possibleErrors: ["invalid_status"] as const,
+};
+
+export const holdoutStartAnalysisEndpoint = {
+  pathFragment: "/:id/start-analysis",
+  verb: "post" as const,
+  operationId: "startHoldoutAnalysis",
+  validator: apiHoldoutActionValidator,
+  zodReturnObject: apiHoldoutActionReturn,
+  summary: "Start a Holdout analysis period",
+  possibleErrors: ["invalid_status"] as const,
+};
+
+export const holdoutStopEndpoint = {
+  pathFragment: "/:id/stop",
+  verb: "post" as const,
+  operationId: "stopHoldout",
+  validator: apiHoldoutActionValidator,
+  zodReturnObject: apiHoldoutActionReturn,
+  summary: "Stop a Holdout",
+  possibleErrors: ["invalid_status"] as const,
 };
 
 export const holdoutApiSpec = {
@@ -32,12 +53,16 @@ export const holdoutApiSpec = {
   crudValidatorOverrides: {
     list: apiListHoldoutsValidator,
   },
-  customEndpoints: [holdoutStageEndpoint],
+  customEndpoints: [
+    holdoutStartEndpoint,
+    holdoutStartAnalysisEndpoint,
+    holdoutStopEndpoint,
+  ],
   crudDescriptions: {
     create:
-      "Creates a Holdout. The Holdout starts in the `draft` stage — use POST /holdouts/{id}/stage to start it.",
+      "Creates a Holdout. The Holdout starts in the `draft` stage. Use POST /holdouts/{id}/start to start it.",
     update:
-      "Updates a Holdout. Use POST /holdouts/{id}/stage to change the stage.",
+      "Updates a Holdout. Use the start, start-analysis, and stop endpoints to move it through its lifecycle.",
   },
   navDescription:
     "Hold a share of traffic out of all experiments to measure their combined effect.",

--- a/packages/back-end/src/api/specs/holdout.spec.ts
+++ b/packages/back-end/src/api/specs/holdout.spec.ts
@@ -30,7 +30,7 @@ export const holdoutStartAnalysisEndpoint = {
   zodReturnObject: apiHoldoutActionReturn,
   summary: "Start the Holdout's Analysis Period",
   description:
-    "New Feature Flags and experiments can no longer be added, but existing traffic splits remain active. Results exclude data from before the analysis period so you can measure the cumulative impact after changes are frozen.",
+    "Move the holdout into an analysis phase. New Feature Flags and experiments can no longer be added, but existing traffic splits remain active for existing and new traffic. Results exclude data from before the analysis period so you can measure the cumulative impact after changes are frozen.",
   possibleErrors: ["invalid_status"] as const,
 };
 

--- a/packages/back-end/src/api/specs/holdout.spec.ts
+++ b/packages/back-end/src/api/specs/holdout.spec.ts
@@ -18,7 +18,7 @@ export const holdoutStartEndpoint = {
   zodReturnObject: apiHoldoutActionReturn,
   summary: "Start the Holdout's Active Period",
   description:
-    "Feature Flags and experiments can be added during this period while the Holdout measures their cumulative impact.",
+    "Feature Flags and Experiments can be added during this period while the Holdout measures their cumulative impact.",
   possibleErrors: ["invalid_status"] as const,
 };
 
@@ -30,7 +30,7 @@ export const holdoutStartAnalysisEndpoint = {
   zodReturnObject: apiHoldoutActionReturn,
   summary: "Start the Holdout's Analysis Period",
   description:
-    "Move the holdout into an analysis phase. New Feature Flags and experiments can no longer be added, but existing traffic splits remain active for existing and new traffic. Results exclude data from before the analysis period so you can measure the cumulative impact after changes are frozen.",
+    "Move the holdout into an analysis phase. New Feature Flags and Experiments can no longer be added, but existing traffic splits remain active for existing and new traffic. Results exclude data from before the analysis period so you can measure the cumulative impact after changes are frozen.",
   possibleErrors: ["invalid_status"] as const,
 };
 
@@ -64,7 +64,7 @@ export const holdoutApiSpec = {
   ],
   crudDescriptions: {
     create:
-      "Creates a Holdout. The Holdout starts in the `draft` stage. Use POST /holdouts/{id}/start to start it.",
+      "Creates a Holdout. The Holdout starts in the `draft` stage. Use the start endpoint to start it.",
     update:
       "Updates a Holdout. Use the start, start-analysis, and stop endpoints to move it through its lifecycle.",
   },

--- a/packages/back-end/src/api/specs/holdout.spec.ts
+++ b/packages/back-end/src/api/specs/holdout.spec.ts
@@ -16,7 +16,9 @@ export const holdoutStartEndpoint = {
   operationId: "startHoldout",
   validator: apiHoldoutActionValidator,
   zodReturnObject: apiHoldoutActionReturn,
-  summary: "Start a Holdout",
+  summary: "Start the Holdout's Active Period",
+  description:
+    "Feature Flags and experiments can be added during this period while the Holdout measures their cumulative impact.",
   possibleErrors: ["invalid_status"] as const,
 };
 
@@ -26,7 +28,9 @@ export const holdoutStartAnalysisEndpoint = {
   operationId: "startHoldoutAnalysis",
   validator: apiHoldoutActionValidator,
   zodReturnObject: apiHoldoutActionReturn,
-  summary: "Start a Holdout analysis period",
+  summary: "Start the Holdout's Analysis Period",
+  description:
+    "New Feature Flags and experiments can no longer be added, but existing traffic splits remain active. Results exclude data from before the analysis period so you can measure the cumulative impact after changes are frozen.",
   possibleErrors: ["invalid_status"] as const,
 };
 

--- a/packages/back-end/src/api/specs/holdout.spec.ts
+++ b/packages/back-end/src/api/specs/holdout.spec.ts
@@ -1,0 +1,48 @@
+import {
+  apiCreateHoldoutBody,
+  apiHoldoutStageReturn,
+  apiHoldoutStageValidator,
+  apiHoldoutValidator,
+  apiListHoldoutsValidator,
+  apiUpdateHoldoutBody,
+} from "shared/validators";
+import { OpenApiModelSpec } from "back-end/src/api/ApiModel";
+
+/** REST API surface for Holdouts under `/api/v1/holdouts/*`. */
+
+export const holdoutStageEndpoint = {
+  pathFragment: "/:id/stage",
+  verb: "post" as const,
+  operationId: "setHoldoutStage",
+  validator: apiHoldoutStageValidator,
+  zodReturnObject: apiHoldoutStageReturn,
+  summary: "Move a Holdout to a different stage",
+};
+
+export const holdoutApiSpec = {
+  modelSingular: "holdout",
+  modelPlural: "holdouts",
+  pathBase: "/holdouts",
+  apiInterface: apiHoldoutValidator,
+  schemas: {
+    createBody: apiCreateHoldoutBody,
+    updateBody: apiUpdateHoldoutBody,
+  },
+  // Deleting a Holdout cascades into its companion experiment and unlinks every
+  // held-out Feature Flag and experiment, so it stays UI-only for now.
+  crudActions: ["get", "create", "list", "update"],
+  crudValidatorOverrides: {
+    list: apiListHoldoutsValidator,
+  },
+  customEndpoints: [holdoutStageEndpoint],
+  crudDescriptions: {
+    create:
+      "Creates a Holdout along with its companion experiment. The Holdout starts in the `draft` stage — use POST /holdouts/{id}/stage to start it.",
+    update:
+      "Updates a Holdout. Fields are written to the Holdout and its companion experiment as needed, so callers do not need to know where each field is stored. Use POST /holdouts/{id}/stage to change the stage.",
+  },
+  navDescription:
+    "Hold a share of traffic out of all experiments to measure their combined effect.",
+  navAfterTag: "experiments",
+} satisfies OpenApiModelSpec;
+export default holdoutApiSpec;

--- a/packages/back-end/src/api/visual-changesets/postVisualChangesets.ts
+++ b/packages/back-end/src/api/visual-changesets/postVisualChangesets.ts
@@ -15,6 +15,10 @@ export const postVisualChangesets = createApiRequestHandler(
     return req.context.throwNotFoundError("Could not find experiment");
   }
 
+  if (experiment.type === "holdout") {
+    throw new Error("Holdouts are not supported via this API");
+  }
+
   if (!req.context.permissions.canUpdateVisualChange(experiment)) {
     req.context.permissions.throwPermissionError();
   }

--- a/packages/back-end/src/jobs/updateHoldoutStatus.ts
+++ b/packages/back-end/src/jobs/updateHoldoutStatus.ts
@@ -48,10 +48,7 @@ export function isScheduledTransitionApplicable(
 ): boolean {
   const currentStage = getHoldoutStage(holdout, experiment);
   const targetStage = scheduledTypeToStage(scheduledType);
-  return (
-    currentStage !== targetStage &&
-    isHoldoutStageTransitionAllowed(currentStage, targetStage)
-  );
+  return isHoldoutStageTransitionAllowed(currentStage, targetStage);
 }
 
 const QUEUE_HOLDOUT_UPDATES = "queueScheduledHoldoutUpdates";

--- a/packages/back-end/src/jobs/updateHoldoutStatus.ts
+++ b/packages/back-end/src/jobs/updateHoldoutStatus.ts
@@ -1,5 +1,9 @@
 import Agenda, { Job } from "agenda";
-import { getHoldoutStage, HoldoutStage } from "shared/util";
+import {
+  getHoldoutStage,
+  HoldoutStage,
+  isHoldoutStageTransitionAllowed,
+} from "shared/util";
 import {
   HoldoutInterface,
   HoldoutNextScheduledStatusUpdate,
@@ -43,18 +47,11 @@ export function isScheduledTransitionApplicable(
   holdout: Pick<HoldoutInterface, "analysisStartDate">,
 ): boolean {
   const currentStage = getHoldoutStage(holdout, experiment);
-
-  switch (scheduledType) {
-    case "start":
-      return currentStage === "draft";
-    case "startAnalysisPeriod":
-      return currentStage === "running";
-    case "stop":
-      return currentStage !== "stopped";
-    default:
-      scheduledType satisfies never;
-      return false;
-  }
+  const targetStage = scheduledTypeToStage(scheduledType);
+  return (
+    currentStage !== targetStage &&
+    isHoldoutStageTransitionAllowed(currentStage, targetStage)
+  );
 }
 
 const QUEUE_HOLDOUT_UPDATES = "queueScheduledHoldoutUpdates";

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -26,7 +26,6 @@ import {
 } from "back-end/src/api/specs/holdout.spec";
 import { defineCustomApiHandler } from "back-end/src/api/apiModelHandlers";
 import {
-  applyHoldoutTargetingChanges,
   createHoldoutWithExperiment,
   normalizeHoldoutScheduleUpdates,
   setHoldoutStage,
@@ -411,18 +410,33 @@ export class HoldoutModel extends BaseClass {
       }
     }
 
-    // 1. Phase-level targeting and sizing, through the same path the internal
-    //    targeting endpoint uses so phases and the SDK payload stay correct.
+    // 1. Phase-level targeting and sizing.
     if (isTargetingChange) {
-      experiment = await applyHoldoutTargetingChanges(this.context, {
-        experiment,
+      const phases = [...experiment.phases];
+      if (!phases.length) {
+        throw new Error("Holdout does not have a phase to target");
+      }
+
+      const current = phases[phases.length - 1];
+      phases[phases.length - 1] = {
+        ...current,
+        condition: body.targetingCondition ?? current.condition,
+        savedGroups: body.savedGroups ?? current.savedGroups,
         coverage:
           body.holdoutSize === undefined
-            ? undefined
+            ? current.coverage
             : holdoutSizeToCoverage(body.holdoutSize),
-        condition: body.targetingCondition,
-        savedGroups: body.savedGroups,
-        hashAttribute: body.hashAttribute,
+      };
+
+      experiment = await updateExperiment({
+        context: this.context,
+        experiment,
+        changes: {
+          phases,
+          ...(body.hashAttribute !== undefined && {
+            hashAttribute: body.hashAttribute,
+          }),
+        },
       });
     }
 

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -480,6 +480,7 @@ export class HoldoutModel extends BaseClass {
         (field) => body[field] !== undefined,
       ),
       isScheduleChange: (body.statusUpdateSchedule ?? null) !== null,
+      isRunning: experiment.status === "running",
     });
 
     const { holdout: updated, experiment: updatedExperiment } =

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -433,15 +433,28 @@ export class HoldoutModel extends BaseClass {
       this.context.permissions.throwPermissionError();
     }
 
-    // Targeting and sizing changes reach live SDK payloads, so they additionally
-    // require run permission on the Holdout's environments — the same bar the
-    // internal targeting endpoint applies.
+    // Targeting, sizing, and environment changes reach live SDK payloads, so
+    // they additionally require run permission on the Holdout's environments —
+    // the same bar the internal targeting endpoint applies. The environment map
+    // is replaced wholesale by the write below, so authorize the union of the
+    // currently enabled environments and the ones this request would enable;
+    // otherwise a request could deploy targeting to an environment the caller
+    // lacks run permission on.
     const isTargetingChange = HOLDOUT_API_TARGETING_UPDATE_FIELDS.some(
       (field) => body[field] !== undefined,
     );
-    if (isTargetingChange) {
-      const envs = Object.keys(holdout.environmentSettings).filter(
-        (env) => holdout.environmentSettings[env]?.enabled,
+    const isEnvironmentChange = body.environments !== undefined;
+    if (isTargetingChange || isEnvironmentChange) {
+      const currentlyEnabledEnvs = Object.keys(
+        holdout.environmentSettings,
+      ).filter((env) => holdout.environmentSettings[env]?.enabled);
+      const requestedEnabledEnvs = body.environments
+        ? Object.keys(body.environments).filter(
+            (env) => body.environments?.[env]?.enabled,
+          )
+        : [];
+      const envs = Array.from(
+        new Set([...currentlyEnabledEnvs, ...requestedEnabledEnvs]),
       );
       if (
         envs.length > 0 &&

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -22,11 +22,7 @@ import {
 import { UpdateProps } from "shared/types/base-model";
 import { ExperimentInterface } from "shared/types/experiment";
 import { getCollection } from "back-end/src/util/mongo.util";
-import {
-  BadRequestError,
-  InvalidStatusError,
-  NotFoundError,
-} from "back-end/src/util/errors";
+import { InvalidStatusError, NotFoundError } from "back-end/src/util/errors";
 import {
   holdoutApiSpec,
   holdoutStartAnalysisEndpoint,
@@ -38,6 +34,7 @@ import { ApiRequest } from "back-end/src/util/handler";
 import {
   assertCanRunHoldoutEnvironments,
   assertCanUpdateHoldout,
+  assertValidHoldoutSchedule,
   createHoldoutWithExperiment,
   normalizeHoldoutScheduleUpdates,
   setHoldoutStage,
@@ -82,8 +79,7 @@ async function handleHoldoutStageTransition(
   if (!req.context.permissions.canUpdateHoldout(holdout, holdout)) {
     req.context.permissions.throwPermissionError();
   }
-  // Lifecycle transitions change what live SDKs serve, so gate on run permission
-  // for the holdout's enabled environments (matches the internal edit-status path).
+  // Lifecycle transitions change what live SDKs serve (matches editStatus).
   assertCanRunHoldoutEnvironments(req.context, {
     enabledEnvironments: getEnabledHoldoutEnvironments(
       holdout.environmentSettings,
@@ -185,10 +181,8 @@ const BaseClass = MakeModelClass({
 const LINKAGE_FIELDS = ["linkedFeatures", "linkedExperiments"] as const;
 
 /**
- * Merges a holdout and its companion experiment into the public API shape.
- *
- * A holdout is invalid without its companion experiment, so callers must resolve
- * it before serializing.
+ * A holdout is invalid without its companion experiment, so callers resolve it
+ * before serializing.
  */
 export function toApiHoldout(
   holdout: HoldoutInterface,
@@ -247,8 +241,7 @@ export function toApiHoldout(
       dateAdded: e.dateAdded.toISOString(),
     })),
 
-    // The phase carries a dateStarted from creation, but it is only meaningful
-    // once the Holdout has left draft.
+    // The phase gets a dateStarted at creation, meaningless until it leaves draft.
     dateStarted:
       stage === "draft" ? undefined : firstPhase?.dateStarted?.toISOString(),
     analysisStartDate: holdout.analysisStartDate?.toISOString(),
@@ -300,15 +293,12 @@ export class HoldoutModel extends BaseClass {
   /***************
    * REST API handlers
    *
-   * All four are overridden because the default implementations assume a single
-   * document: `toApiInterface` is synchronous and per-doc, so it cannot fetch
-   * the companion experiment that supplies most of the API shape.
+   * All four are overridden: the defaults route through `toApiInterface`, which
+   * is synchronous and so cannot fetch the companion experiment that supplies
+   * most of the API shape.
    ***************/
 
   protected toApiInterface(): ApiHoldoutInterface {
-    // No correct sync implementation exists: the API shape needs the companion
-    // experiment, which is an async fetch. Callers must resolve it and
-    // use `toApiHoldout` instead.
     throw new Error(
       "Use handleApi* handlers to serialize a Holdout; toApiInterface cannot resolve its experiment.",
     );
@@ -350,7 +340,6 @@ export class HoldoutModel extends BaseClass {
         )
       : holdouts;
 
-    // Batch the experiment lookup rather than one query per holdout.
     const experiments = await getExperimentsByIds(
       this.context,
       filteredByProject.map((h) => h.experimentId),
@@ -384,8 +373,8 @@ export class HoldoutModel extends BaseClass {
   ): Promise<ApiHoldoutInterface> {
     const body = apiCreateHoldoutBody.parse(req.body);
 
-    // Gate before creating the companion experiment; createExperiment enforces
-    // no permissions, so an unauthorized create would otherwise orphan one.
+    // createExperiment enforces no permissions, so gate before it runs or an
+    // unauthorized create orphans an experiment.
     if (!this.hasPremiumFeature()) {
       throw new Error(
         "Your organization does not have access to this feature.",
@@ -403,6 +392,12 @@ export class HoldoutModel extends BaseClass {
       assertCanRunHoldoutEnvironments(this.context, {
         enabledEnvironments: getEnabledHoldoutEnvironments(body.environments),
         projects: body.projects ?? [],
+      });
+      // Stored by a follow-up update below, which has nothing to roll back to if
+      // rejected. Every new Holdout starts in draft.
+      assertValidHoldoutSchedule({
+        schedule: body.statusUpdateSchedule,
+        currentStage: "draft",
       });
     }
 
@@ -518,65 +513,11 @@ export class HoldoutModel extends BaseClass {
       throw new NotFoundError("Holdout experiment not found");
     }
 
-    const { startAt, startAnalysisPeriodAt, stopAt } =
-      updates.statusUpdateSchedule ?? {};
-
-    const now = new Date();
-    const currentStage = getHoldoutStage(existing, holdoutExperiment);
-
-    // Check if one of the scheduled dates is in the past
-    if (startAt && currentStage === "draft" && new Date(startAt) < now) {
-      throw new BadRequestError("Scheduled start date cannot be in the past");
-    }
-    if (
-      startAnalysisPeriodAt &&
-      currentStage === "running" &&
-      new Date(startAnalysisPeriodAt) < now
-    ) {
-      throw new BadRequestError(
-        "Scheduled analysis start date cannot be in the past",
-      );
-    }
-    if (stopAt && currentStage !== "stopped" && new Date(stopAt) < now) {
-      throw new BadRequestError("Scheduled stop date cannot be in the past");
-    }
-
-    // Check date dependencies
-    if (
-      currentStage === "draft" &&
-      stopAt &&
-      (!startAt || !startAnalysisPeriodAt)
-    ) {
-      throw new BadRequestError(
-        "To set a stop date, you must also set a start date and an analysis start date",
-      );
-    }
-    if (currentStage === "draft" && startAnalysisPeriodAt && !startAt) {
-      throw new BadRequestError(
-        "To set an analysis start date, you must first set a start date",
-      );
-    }
-
-    if (currentStage === "running" && stopAt && !startAnalysisPeriodAt) {
-      throw new BadRequestError(
-        "To set a stop date, you must first set an analysis start date",
-      );
-    }
-
-    // Check if the dates are consecutive
-    const dateError =
-      (startAt &&
-        startAnalysisPeriodAt &&
-        currentStage === "draft" &&
-        startAt > startAnalysisPeriodAt) ||
-      (startAt && stopAt && currentStage === "draft" && startAt > stopAt) ||
-      (startAnalysisPeriodAt &&
-        stopAt &&
-        !existing.analysisStartDate &&
-        startAnalysisPeriodAt > stopAt);
-    if (dateError) {
-      throw new BadRequestError("Scheduled dates must be consecutive");
-    }
+    assertValidHoldoutSchedule({
+      schedule: updates.statusUpdateSchedule,
+      currentStage: getHoldoutStage(existing, holdoutExperiment),
+      analysisStartDate: existing.analysisStartDate,
+    });
   }
 
   public static async getAllHoldoutsToUpdate(): Promise<

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -141,7 +141,7 @@ const BaseClass = MakeModelClass({
           handleHoldoutStageTransition(req, {
             targetStage: "running",
             invalidStatusMessage:
-              "Holdout must be in the draft stage before it can start.",
+              "Holdout must be in the draft stage to start.",
           }),
       }),
       defineCustomApiHandler({
@@ -150,7 +150,7 @@ const BaseClass = MakeModelClass({
           handleHoldoutStageTransition(req, {
             targetStage: "analysis-period",
             invalidStatusMessage:
-              "Holdout must be running before its analysis period can start.",
+              "Holdout must be running to start its analysis period.",
           }),
       }),
       defineCustomApiHandler({
@@ -159,7 +159,7 @@ const BaseClass = MakeModelClass({
           handleHoldoutStageTransition(req, {
             targetStage: "stopped",
             invalidStatusMessage:
-              "Holdout must be running or in its analysis period before it can stop.",
+              "Holdout must be running or in its analysis period to stop.",
           }),
       }),
     ],

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -187,6 +187,7 @@ export function toApiHoldout(
 ): ApiHoldoutInterface {
   const phase = experiment.phases[experiment.phases.length - 1];
   const firstPhase = experiment.phases[0];
+  const stage = getHoldoutStage(holdout, experiment);
 
   return {
     id: holdout.id,
@@ -198,7 +199,7 @@ export function toApiHoldout(
     owner: experiment.owner,
     tags: experiment.tags,
     archived: experiment.archived,
-    stage: getHoldoutStage(holdout, experiment),
+    stage,
     trackingKey: experiment.trackingKey,
     skipAsDefaultHoldout: holdout.skipAsDefaultHoldout ?? false,
 
@@ -211,6 +212,7 @@ export function toApiHoldout(
     assignmentQueryId: experiment.exposureQueryId,
     goalMetrics: experiment.goalMetrics,
     secondaryMetrics: experiment.secondaryMetrics,
+    statsEngine: experiment.statsEngine,
     variations: experiment.variations.map((v) => ({
       variationId: v.id,
       key: v.key,
@@ -234,7 +236,10 @@ export function toApiHoldout(
       dateAdded: e.dateAdded.toISOString(),
     })),
 
-    dateStarted: firstPhase?.dateStarted?.toISOString(),
+    // The phase carries a dateStarted from creation, but it is only meaningful
+    // once the Holdout has left draft.
+    dateStarted:
+      stage === "draft" ? undefined : firstPhase?.dateStarted?.toISOString(),
     analysisStartDate: holdout.analysisStartDate?.toISOString(),
     dateStopped:
       experiment.status === "stopped"
@@ -327,8 +332,11 @@ export class HoldoutModel extends BaseClass {
     const { projectId, datasourceId, stage, archived } = req.query;
 
     const holdouts = await this.getAll();
+
     const filteredByProject = projectId
-      ? holdouts.filter((h) => h.projects.includes(projectId))
+      ? holdouts.filter(
+          (h) => h.projects.length === 0 || h.projects.includes(projectId),
+        )
       : holdouts;
 
     // Batch the experiment lookup rather than one query per holdout.

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -196,7 +196,6 @@ export function toApiHoldout(
     tags: experiment.tags,
     archived: experiment.archived,
     stage: getHoldoutStage(holdout, experiment),
-    experimentId: holdout.experimentId,
     trackingKey: experiment.trackingKey,
     skipAsDefaultHoldout: holdout.skipAsDefaultHoldout ?? false,
 

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -21,14 +21,14 @@ import {
 } from "shared/validators";
 import { UpdateProps } from "shared/types/base-model";
 import { ExperimentInterface } from "shared/types/experiment";
-import { getCollection } from "back-end/src/util/mongo.util";
-import { InvalidStatusError, NotFoundError } from "back-end/src/util/errors";
 import {
   holdoutApiSpec,
   holdoutStartAnalysisEndpoint,
   holdoutStartEndpoint,
   holdoutStopEndpoint,
 } from "back-end/src/api/specs/holdout.spec";
+import { getCollection } from "back-end/src/util/mongo.util";
+import { InvalidStatusError, NotFoundError } from "back-end/src/util/errors";
 import { defineCustomApiHandler } from "back-end/src/api/apiModelHandlers";
 import { ApiRequest } from "back-end/src/util/handler";
 import {
@@ -478,6 +478,7 @@ export class HoldoutModel extends BaseClass {
         (field) => body[field] !== undefined,
       ),
       isScheduleChange: (body.statusUpdateSchedule ?? null) !== null,
+      isArchiveChange: body.archived !== undefined,
       isRunning: experiment.status === "running",
     });
 

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -295,9 +295,9 @@ export class HoldoutModel extends BaseClass {
    ***************/
 
   protected toApiInterface(): ApiHoldoutInterface {
-    // A holdout needs its companion experiment to serialize, and fetching it is
-    // async. Every handler below resolves the experiment and calls `toApiHoldout`
-    // directly, so this default is never the right path.
+    // No correct sync implementation exists: the API shape needs the companion
+    // experiment, which is an async fetch. Callers must resolve it and
+    // use `toApiHoldout` instead.
     throw new Error(
       "Use handleApi* handlers to serialize a Holdout; toApiInterface cannot resolve its experiment.",
     );

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -170,8 +170,6 @@ export function toApiHoldout(
     assignmentQueryId: experiment?.exposureQueryId ?? "",
     goalMetrics: experiment?.goalMetrics ?? [],
     secondaryMetrics: experiment?.secondaryMetrics ?? [],
-    guardrailMetrics: experiment?.guardrailMetrics ?? [],
-    activationMetric: experiment?.activationMetric || undefined,
     variations: (experiment?.variations ?? []).map((v) => ({
       variationId: v.id,
       key: v.key,
@@ -350,8 +348,6 @@ export class HoldoutModel extends BaseClass {
         savedGroups: body.savedGroups,
         goalMetrics: body.goalMetrics,
         secondaryMetrics: body.secondaryMetrics,
-        guardrailMetrics: body.guardrailMetrics,
-        activationMetric: body.activationMetric,
         environmentSettings: body.environments
           ? Object.fromEntries(
               Object.entries(body.environments).map(([id, settings]) => [

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -1,11 +1,49 @@
-import { HoldoutInterface, holdoutValidator } from "shared/validators";
+import { z } from "zod";
+import {
+  coverageToHoldoutSize,
+  getHoldoutStage,
+  holdoutSizeToCoverage,
+  stringToBoolean,
+} from "shared/util";
+import {
+  ApiHoldoutInterface,
+  apiCreateHoldoutBody,
+  apiHoldoutStageReturn,
+  apiUpdateHoldoutBody,
+  HOLDOUT_API_EXPERIMENT_UPDATE_FIELDS,
+  HOLDOUT_API_TARGETING_UPDATE_FIELDS,
+  HOLDOUT_API_UPDATE_FIELDS,
+  HoldoutInterface,
+  holdoutValidator,
+} from "shared/validators";
 import { UpdateProps } from "shared/types/base-model";
 import { ExperimentInterface } from "shared/types/experiment";
-import { getHoldoutStage } from "shared/util";
 import { getCollection } from "back-end/src/util/mongo.util";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
+import {
+  holdoutApiSpec,
+  holdoutStageEndpoint,
+} from "back-end/src/api/specs/holdout.spec";
+import { defineCustomApiHandler } from "back-end/src/api/apiModelHandlers";
+import {
+  applyHoldoutTargetingChanges,
+  createHoldoutWithExperiment,
+  normalizeHoldoutScheduleUpdates,
+  setHoldoutStage,
+} from "back-end/src/services/holdouts";
+import {
+  resolveOwnerEmail,
+  resolveOwnerEmails,
+  resolveOwnerForCreate,
+  resolveOwnerToUserId,
+} from "back-end/src/services/owner";
+import { getEnvironmentIdsFromOrg } from "back-end/src/services/organizations";
 import { MakeModelClass } from "./BaseModel";
-import { getExperimentById } from "./ExperimentModel";
+import {
+  getExperimentById,
+  getExperimentsByIds,
+  updateExperiment,
+} from "./ExperimentModel";
 
 const COLLECTION_NAME = "holdouts";
 
@@ -28,6 +66,62 @@ const BaseClass = MakeModelClass({
       fields: { "nextScheduledStatusUpdate.date": 1 },
     },
   ],
+  apiConfig: {
+    modelKey: "holdout",
+    openApiSpec: holdoutApiSpec,
+    customHandlers: [
+      defineCustomApiHandler({
+        ...holdoutStageEndpoint,
+        reqHandler: async (
+          req,
+        ): Promise<z.infer<typeof apiHoldoutStageReturn>> => {
+          const holdout = await req.context.models.holdout.getById(
+            req.params.id,
+          );
+          if (!holdout) {
+            return req.context.throwNotFoundError();
+          }
+          const experiment = await getExperimentById(
+            req.context,
+            holdout.experimentId,
+          );
+          if (!experiment) {
+            return req.context.throwNotFoundError(
+              "Holdout experiment not found",
+            );
+          }
+
+          const envs = getEnvironmentIdsFromOrg(req.context.org);
+          if (!req.context.permissions.canRunHoldout(holdout, envs)) {
+            req.context.permissions.throwPermissionError();
+          }
+
+          await setHoldoutStage(req.context, {
+            holdout,
+            experiment,
+            stage: req.body.stage,
+          });
+
+          // Re-read both documents: the stage change rewrote the experiment's
+          // status and phases and the holdout's analysis/schedule fields.
+          const [updatedHoldout, updatedExperiment] = await Promise.all([
+            req.context.models.holdout.getById(holdout.id),
+            getExperimentById(req.context, holdout.experimentId),
+          ]);
+          if (!updatedHoldout || !updatedExperiment) {
+            return req.context.throwNotFoundError();
+          }
+
+          return {
+            holdout: await resolveOwnerEmail(
+              toApiHoldout(updatedHoldout, updatedExperiment),
+              req.context,
+            ),
+          };
+        },
+      }),
+    ],
+  },
 });
 
 // Guarded on BOTH maps by every linkage write, even one that touches only one of
@@ -35,6 +129,95 @@ const BaseClass = MakeModelClass({
 // experiments, compensate a publish) that guarding half would let the other half
 // be clobbered by a writer this one never saw.
 const LINKAGE_FIELDS = ["linkedFeatures", "linkedExperiments"] as const;
+
+/**
+ * Merges a holdout and its companion experiment into the public API shape.
+ *
+ * The experiment is nullable because a holdout can outlive a deleted experiment;
+ * in that case the experiment-derived fields fall back to empty values rather
+ * than failing the whole response.
+ */
+export function toApiHoldout(
+  holdout: HoldoutInterface,
+  experiment: ExperimentInterface | null,
+): ApiHoldoutInterface {
+  const phase = experiment?.phases?.[experiment.phases.length - 1];
+  const firstPhase = experiment?.phases?.[0];
+
+  return {
+    id: holdout.id,
+    dateCreated: holdout.dateCreated.toISOString(),
+    dateUpdated: holdout.dateUpdated.toISOString(),
+    name: holdout.name,
+    description: experiment?.description ?? "",
+    projects: holdout.projects,
+    owner: experiment?.owner ?? "",
+    tags: experiment?.tags ?? [],
+    archived: experiment?.archived ?? false,
+    stage: experiment
+      ? getHoldoutStage(holdout, experiment)
+      : /* No experiment left to derive from. */ "stopped",
+    experimentId: holdout.experimentId,
+    trackingKey: experiment?.trackingKey ?? "",
+    skipAsDefaultHoldout: holdout.skipAsDefaultHoldout ?? false,
+
+    holdoutSize: coverageToHoldoutSize(phase?.coverage ?? 0),
+    hashAttribute: experiment?.hashAttribute ?? "",
+    targetingCondition: phase?.condition ?? "",
+    savedGroups: phase?.savedGroups,
+
+    datasourceId: experiment?.datasource ?? "",
+    assignmentQueryId: experiment?.exposureQueryId ?? "",
+    goalMetrics: experiment?.goalMetrics ?? [],
+    secondaryMetrics: experiment?.secondaryMetrics ?? [],
+    guardrailMetrics: experiment?.guardrailMetrics ?? [],
+    activationMetric: experiment?.activationMetric || undefined,
+    variations: (experiment?.variations ?? []).map((v) => ({
+      variationId: v.id,
+      key: v.key,
+      name: v.name,
+      description: v.description,
+    })),
+
+    environments: Object.fromEntries(
+      Object.entries(holdout.environmentSettings).map(([id, settings]) => [
+        id,
+        { enabled: settings.enabled },
+      ]),
+    ),
+
+    linkedFeatures: Object.values(holdout.linkedFeatures).map((f) => ({
+      id: f.id,
+      dateAdded: f.dateAdded.toISOString(),
+    })),
+    linkedExperiments: Object.values(holdout.linkedExperiments).map((e) => ({
+      id: e.id,
+      dateAdded: e.dateAdded.toISOString(),
+    })),
+
+    dateStarted: firstPhase?.dateStarted?.toISOString(),
+    analysisStartDate: holdout.analysisStartDate?.toISOString(),
+    dateStopped:
+      experiment?.status === "stopped"
+        ? phase?.dateEnded?.toISOString()
+        : undefined,
+
+    statusUpdateSchedule: holdout.statusUpdateSchedule
+      ? {
+          startAt: holdout.statusUpdateSchedule.startAt?.toISOString(),
+          startAnalysisPeriodAt:
+            holdout.statusUpdateSchedule.startAnalysisPeriodAt?.toISOString(),
+          stopAt: holdout.statusUpdateSchedule.stopAt?.toISOString(),
+        }
+      : holdout.statusUpdateSchedule,
+    nextScheduledStatusUpdate: holdout.nextScheduledStatusUpdate
+      ? {
+          type: holdout.nextScheduledStatusUpdate.type,
+          date: holdout.nextScheduledStatusUpdate.date.toISOString(),
+        }
+      : holdout.nextScheduledStatusUpdate,
+  };
+}
 
 export class HoldoutModel extends BaseClass {
   // CRUD permission checks
@@ -57,6 +240,280 @@ export class HoldoutModel extends BaseClass {
 
   protected hasPremiumFeature(): boolean {
     return this.context.hasPremiumFeature("holdouts");
+  }
+
+  /***************
+   * REST API handlers
+   *
+   * All four are overridden because the default implementations assume a single
+   * document: `toApiInterface` is synchronous and per-doc, so it cannot fetch
+   * the companion experiment that supplies most of the API shape.
+   ***************/
+
+  protected toApiInterface(doc: HoldoutInterface): ApiHoldoutInterface {
+    // Only reached if a caller bypasses the overrides below. Returning the
+    // holdout half alone is better than throwing, and every handler here
+    // resolves the experiment properly.
+    return toApiHoldout(doc, null);
+  }
+
+  private async getExperimentOrThrow(
+    holdout: HoldoutInterface,
+  ): Promise<ExperimentInterface> {
+    const experiment = await getExperimentById(
+      this.context,
+      holdout.experimentId,
+    );
+    if (!experiment) {
+      // A 404 rather than a 500: the Holdout exists but is missing its other half.
+      this.context.throwNotFoundError("Holdout experiment not found");
+    }
+    return experiment;
+  }
+
+  public override async handleApiGet(
+    req: Parameters<InstanceType<typeof BaseClass>["handleApiGet"]>[0],
+  ): Promise<ApiHoldoutInterface> {
+    const holdout = await this.getById(req.params.id);
+    if (!holdout) req.context.throwNotFoundError();
+    const experiment = await this.getExperimentOrThrow(holdout);
+    return resolveOwnerEmail(toApiHoldout(holdout, experiment), this.context);
+  }
+
+  public override async handleApiList(
+    req: Parameters<InstanceType<typeof BaseClass>["handleApiList"]>[0],
+  ): Promise<ApiHoldoutInterface[]> {
+    const { projectId, datasourceId, stage, archived } = req.query;
+
+    const holdouts = await this.getAll();
+    const filteredByProject = projectId
+      ? holdouts.filter((h) => h.projects.includes(projectId))
+      : holdouts;
+
+    // Batch the experiment lookup rather than one query per holdout.
+    const experiments = await getExperimentsByIds(
+      this.context,
+      filteredByProject.map((h) => h.experimentId),
+    );
+    const experimentsById = new Map(experiments.map((e) => [e.id, e]));
+
+    const wantArchived =
+      archived === undefined ? undefined : stringToBoolean(archived.toString());
+
+    const results: ApiHoldoutInterface[] = [];
+    for (const holdout of filteredByProject) {
+      const experiment = experimentsById.get(holdout.experimentId);
+      // A holdout whose experiment was deleted cannot be filtered on
+      // experiment-derived fields, so drop it from filtered listings.
+      if (!experiment) {
+        if (datasourceId || stage || wantArchived !== undefined) continue;
+        results.push(toApiHoldout(holdout, null));
+        continue;
+      }
+      if (datasourceId && experiment.datasource !== datasourceId) continue;
+      if (stage && getHoldoutStage(holdout, experiment) !== stage) continue;
+      if (
+        wantArchived !== undefined &&
+        !!experiment.archived !== wantArchived
+      ) {
+        continue;
+      }
+      results.push(toApiHoldout(holdout, experiment));
+    }
+
+    return resolveOwnerEmails(results, this.context);
+  }
+
+  public override async handleApiCreate(
+    req: Parameters<InstanceType<typeof BaseClass>["handleApiCreate"]>[0],
+  ): Promise<ApiHoldoutInterface> {
+    const body = apiCreateHoldoutBody.parse(req.body);
+
+    const owner = await resolveOwnerForCreate(body.owner, this.context);
+
+    const { holdout, experiment } = await createHoldoutWithExperiment(
+      this.context,
+      {
+        name: body.name,
+        description: body.description,
+        projects: body.projects,
+        owner,
+        tags: body.tags,
+        skipAsDefaultHoldout: body.skipAsDefaultHoldout,
+        datasourceId: body.datasourceId,
+        assignmentQueryId: body.assignmentQueryId,
+        // An empty hash attribute would leave the Holdout unable to bucket
+        // anyone, so fall back to the conventional default.
+        hashAttribute: body.hashAttribute || "id",
+        holdoutSize: body.holdoutSize,
+        targetingCondition: body.targetingCondition,
+        savedGroups: body.savedGroups,
+        goalMetrics: body.goalMetrics,
+        secondaryMetrics: body.secondaryMetrics,
+        guardrailMetrics: body.guardrailMetrics,
+        activationMetric: body.activationMetric,
+        environmentSettings: body.environments
+          ? Object.fromEntries(
+              Object.entries(body.environments).map(([id, settings]) => [
+                id,
+                { enabled: settings.enabled },
+              ]),
+            )
+          : undefined,
+      },
+    );
+
+    // Applied after creation so it is validated against the real stored stage.
+    if (body.statusUpdateSchedule) {
+      const withSchedule = await this.update(
+        holdout,
+        normalizeHoldoutScheduleUpdates({
+          holdout,
+          experiment,
+          scheduleInput: body.statusUpdateSchedule,
+        }),
+      );
+      return resolveOwnerEmail(
+        toApiHoldout(withSchedule, experiment),
+        this.context,
+      );
+    }
+
+    return resolveOwnerEmail(toApiHoldout(holdout, experiment), this.context);
+  }
+
+  public override async handleApiUpdate(
+    req: Parameters<InstanceType<typeof BaseClass>["handleApiUpdate"]>[0],
+  ): Promise<ApiHoldoutInterface> {
+    const body = apiUpdateHoldoutBody.parse(req.body);
+
+    const holdout = await this.getById(req.params.id);
+    if (!holdout) req.context.throwNotFoundError();
+    let experiment = await this.getExperimentOrThrow(holdout);
+
+    // Gate every path explicitly. Writes to the companion experiment go through
+    // `updateExperiment`, which does no permission checking of its own, and a
+    // body touching only experiment-side fields never reaches `this.update`.
+    if (
+      !this.context.permissions.canUpdateHoldout(holdout, {
+        projects: body.projects ?? holdout.projects,
+      })
+    ) {
+      this.context.permissions.throwPermissionError();
+    }
+
+    const isTargetingChange = HOLDOUT_API_TARGETING_UPDATE_FIELDS.some(
+      (field) => body[field] !== undefined,
+    );
+
+    // Targeting and sizing changes reach live SDK payloads, so they additionally
+    // require run permission on the Holdout's environments — the same bar the
+    // internal targeting endpoint applies.
+    if (isTargetingChange) {
+      const envs = Object.keys(holdout.environmentSettings).filter(
+        (env) => holdout.environmentSettings[env]?.enabled,
+      );
+      if (
+        envs.length > 0 &&
+        !this.context.permissions.canRunHoldout(holdout, envs)
+      ) {
+        this.context.permissions.throwPermissionError();
+      }
+    }
+
+    // 1. Phase-level targeting and sizing, through the same path the internal
+    //    targeting endpoint uses so phases and the SDK payload stay correct.
+    if (isTargetingChange) {
+      experiment = await applyHoldoutTargetingChanges(this.context, {
+        experiment,
+        coverage:
+          body.holdoutSize === undefined
+            ? undefined
+            : holdoutSizeToCoverage(body.holdoutSize),
+        condition: body.targetingCondition,
+        savedGroups: body.savedGroups,
+        hashAttribute: body.hashAttribute,
+      });
+    }
+
+    // 2. Metadata and analysis settings on the companion experiment.
+    const experimentChanges: Partial<ExperimentInterface> = {};
+    for (const field of HOLDOUT_API_EXPERIMENT_UPDATE_FIELDS) {
+      if (body[field] !== undefined) {
+        (experimentChanges as Record<string, unknown>)[field] = body[field];
+      }
+    }
+    if (body.owner !== undefined) {
+      experimentChanges.owner = await resolveOwnerToUserId(
+        body.owner,
+        this.context,
+      );
+    }
+    if (body.datasourceId !== undefined) {
+      experimentChanges.datasource = body.datasourceId;
+    }
+    if (body.assignmentQueryId !== undefined) {
+      experimentChanges.exposureQueryId = body.assignmentQueryId;
+    }
+    // A holdout's two variations are fixed, so only their labels can change.
+    if (body.variations) {
+      const renames = new Map(body.variations.map((v) => [v.variationId, v]));
+      experimentChanges.variations = experiment.variations.map((v) => {
+        const rename = renames.get(v.id);
+        if (!rename) return v;
+        return {
+          ...v,
+          name: rename.name ?? v.name,
+          description: rename.description ?? v.description,
+        };
+      });
+    }
+    // The name is stored on both documents and must not drift.
+    if (body.name !== undefined) {
+      experimentChanges.name = body.name;
+    }
+    if (Object.keys(experimentChanges).length) {
+      experiment = await updateExperiment({
+        context: this.context,
+        experiment,
+        changes: experimentChanges,
+      });
+    }
+
+    // 3. Fields on the holdout document itself.
+    const holdoutUpdates: UpdateProps<HoldoutInterface> = {};
+    for (const field of HOLDOUT_API_UPDATE_FIELDS) {
+      if (body[field] !== undefined) {
+        (holdoutUpdates as Record<string, unknown>)[field] = body[field];
+      }
+    }
+    if (body.name !== undefined) {
+      holdoutUpdates.name = body.name;
+    }
+    if (body.environments !== undefined) {
+      holdoutUpdates.environmentSettings = Object.fromEntries(
+        Object.entries(body.environments).map(([id, settings]) => [
+          id,
+          { enabled: settings.enabled },
+        ]),
+      );
+    }
+    if (body.statusUpdateSchedule !== undefined) {
+      Object.assign(
+        holdoutUpdates,
+        normalizeHoldoutScheduleUpdates({
+          holdout,
+          experiment,
+          scheduleInput: body.statusUpdateSchedule,
+        }),
+      );
+    }
+
+    const updated = Object.keys(holdoutUpdates).length
+      ? await this.update(holdout, holdoutUpdates)
+      : holdout;
+
+    return resolveOwnerEmail(toApiHoldout(updated, experiment), this.context);
   }
 
   protected async beforeUpdate(

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -47,7 +47,6 @@ import {
   resolveOwnerEmails,
   resolveOwnerForCreate,
 } from "back-end/src/services/owner";
-import { getEnvironmentIdsFromOrg } from "back-end/src/services/organizations";
 import { MakeModelClass } from "./BaseModel";
 import { getExperimentById, getExperimentsByIds } from "./ExperimentModel";
 
@@ -79,10 +78,17 @@ async function handleHoldoutStageTransition(
     return req.context.throwNotFoundError("Holdout experiment not found");
   }
 
-  const envs = getEnvironmentIdsFromOrg(req.context.org);
-  if (!req.context.permissions.canRunHoldout(holdout, envs)) {
+  if (!req.context.permissions.canUpdateHoldout(holdout, holdout)) {
     req.context.permissions.throwPermissionError();
   }
+  // Lifecycle transitions change what live SDKs serve, so gate on run permission
+  // for the holdout's enabled environments (matches the internal edit-status path).
+  assertCanRunHoldoutEnvironments(req.context, {
+    enabledEnvironments: getEnabledHoldoutEnvironments(
+      holdout.environmentSettings,
+    ),
+    projects: holdout.projects,
+  });
 
   const currentStage = getHoldoutStage(holdout, experiment);
   if (!isHoldoutStageTransitionAllowed(currentStage, targetStage)) {
@@ -126,6 +132,8 @@ const BaseClass = MakeModelClass({
     deleteEvent: "holdout.delete",
   },
   globallyUniquePrimaryKeys: false,
+  // The companion experiment is bound at creation and never reassigned.
+  readonlyFields: ["experimentId"],
   defaultValues: {
     skipAsDefaultHoldout: false,
   } as Partial<HoldoutInterface>,

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -209,6 +209,7 @@ export function toApiHoldout(
     archived: experiment.archived,
     stage,
     trackingKey: experiment.trackingKey,
+    experimentId: holdout.experimentId,
     skipAsDefaultHoldout: holdout.skipAsDefaultHoldout ?? false,
 
     holdoutSize: coverageToHoldoutSize(phase?.coverage ?? 0),

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -8,6 +8,7 @@ import {
   isHoldoutStageTransitionAllowed,
   stringToBoolean,
 } from "shared/util";
+import { getActivePhase } from "shared/experiments";
 import {
   ApiHoldoutInterface,
   apiCreateHoldoutBody,
@@ -193,7 +194,8 @@ export function toApiHoldout(
   holdout: HoldoutInterface,
   experiment: ExperimentInterface,
 ): ApiHoldoutInterface {
-  const phase = experiment.phases[experiment.phases.length - 1];
+  const activePhase = getActivePhase(experiment);
+  const lastPhase = experiment.phases[experiment.phases.length - 1];
   const firstPhase = experiment.phases[0];
   const stage = getHoldoutStage(holdout, experiment);
 
@@ -212,10 +214,10 @@ export function toApiHoldout(
     experimentId: holdout.experimentId,
     skipAsDefaultHoldout: holdout.skipAsDefaultHoldout ?? false,
 
-    holdoutSize: coverageToHoldoutSize(phase?.coverage ?? 0),
+    holdoutSize: coverageToHoldoutSize(activePhase?.coverage ?? 0),
     hashAttribute: experiment.hashAttribute,
-    targetingCondition: phase?.condition ?? "",
-    savedGroupTargeting: phase?.savedGroups,
+    targetingCondition: activePhase?.condition ?? "",
+    savedGroupTargeting: activePhase?.savedGroups,
 
     datasourceId: experiment.datasource,
     assignmentQueryId: experiment.exposureQueryId,
@@ -252,7 +254,7 @@ export function toApiHoldout(
     analysisStartDate: holdout.analysisStartDate?.toISOString(),
     dateStopped:
       experiment.status === "stopped"
-        ? phase?.dateEnded?.toISOString()
+        ? lastPhase?.dateEnded?.toISOString()
         : undefined,
 
     statusUpdateSchedule: holdout.statusUpdateSchedule

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 import {
   coverageToHoldoutSize,
   getHoldoutStage,
-  holdoutSizeToCoverage,
   stringToBoolean,
 } from "shared/util";
 import {
@@ -10,9 +9,7 @@ import {
   apiCreateHoldoutBody,
   apiHoldoutStageReturn,
   apiUpdateHoldoutBody,
-  HOLDOUT_API_EXPERIMENT_UPDATE_FIELDS,
   HOLDOUT_API_TARGETING_UPDATE_FIELDS,
-  HOLDOUT_API_UPDATE_FIELDS,
   HoldoutInterface,
   holdoutValidator,
 } from "shared/validators";
@@ -29,20 +26,16 @@ import {
   createHoldoutWithExperiment,
   normalizeHoldoutScheduleUpdates,
   setHoldoutStage,
+  updateHoldoutWithExperiment,
 } from "back-end/src/services/holdouts";
 import {
   resolveOwnerEmail,
   resolveOwnerEmails,
   resolveOwnerForCreate,
-  resolveOwnerToUserId,
 } from "back-end/src/services/owner";
 import { getEnvironmentIdsFromOrg } from "back-end/src/services/organizations";
 import { MakeModelClass } from "./BaseModel";
-import {
-  getExperimentById,
-  getExperimentsByIds,
-  updateExperiment,
-} from "./ExperimentModel";
+import { getExperimentById, getExperimentsByIds } from "./ExperimentModel";
 
 const COLLECTION_NAME = "holdouts";
 
@@ -160,7 +153,7 @@ export function toApiHoldout(
     holdoutSize: coverageToHoldoutSize(phase?.coverage ?? 0),
     hashAttribute: experiment.hashAttribute,
     targetingCondition: phase?.condition ?? "",
-    savedGroups: phase?.savedGroups,
+    savedGroupTargeting: phase?.savedGroups,
 
     datasourceId: experiment.datasource,
     assignmentQueryId: experiment.exposureQueryId,
@@ -333,14 +326,13 @@ export class HoldoutModel extends BaseClass {
         skipAsDefaultHoldout: body.skipAsDefaultHoldout,
         datasourceId: body.datasourceId,
         assignmentQueryId: body.assignmentQueryId,
-        // An empty hash attribute would leave the Holdout unable to bucket
-        // anyone, so fall back to the conventional default.
         hashAttribute: body.hashAttribute || "id",
         holdoutSize: body.holdoutSize,
         targetingCondition: body.targetingCondition,
-        savedGroups: body.savedGroups,
+        savedGroups: body.savedGroupTargeting,
         goalMetrics: body.goalMetrics,
         secondaryMetrics: body.secondaryMetrics,
+        statsEngine: body.statsEngine,
         environmentSettings: body.environments
           ? Object.fromEntries(
               Object.entries(body.environments).map(([id, settings]) => [
@@ -378,7 +370,7 @@ export class HoldoutModel extends BaseClass {
 
     const holdout = await this.getById(req.params.id);
     if (!holdout) req.context.throwNotFoundError();
-    let experiment = await this.getExperimentOrThrow(holdout);
+    const experiment = await this.getExperimentOrThrow(holdout);
 
     // Gate every path explicitly. Writes to the companion experiment go through
     // `updateExperiment`, which does no permission checking of its own, and a
@@ -391,13 +383,12 @@ export class HoldoutModel extends BaseClass {
       this.context.permissions.throwPermissionError();
     }
 
-    const isTargetingChange = HOLDOUT_API_TARGETING_UPDATE_FIELDS.some(
-      (field) => body[field] !== undefined,
-    );
-
     // Targeting and sizing changes reach live SDK payloads, so they additionally
     // require run permission on the Holdout's environments — the same bar the
     // internal targeting endpoint applies.
+    const isTargetingChange = HOLDOUT_API_TARGETING_UPDATE_FIELDS.some(
+      (field) => body[field] !== undefined,
+    );
     if (isTargetingChange) {
       const envs = Object.keys(holdout.environmentSettings).filter(
         (env) => holdout.environmentSettings[env]?.enabled,
@@ -410,114 +401,17 @@ export class HoldoutModel extends BaseClass {
       }
     }
 
-    // 1. Phase-level targeting and sizing.
-    if (isTargetingChange) {
-      const phases = [...experiment.phases];
-      if (!phases.length) {
-        throw new Error("Holdout does not have a phase to target");
-      }
-
-      const current = phases[phases.length - 1];
-      phases[phases.length - 1] = {
-        ...current,
-        condition: body.targetingCondition ?? current.condition,
-        savedGroups: body.savedGroups ?? current.savedGroups,
-        coverage:
-          body.holdoutSize === undefined
-            ? current.coverage
-            : holdoutSizeToCoverage(body.holdoutSize),
-      };
-
-      experiment = await updateExperiment({
-        context: this.context,
+    const { holdout: updated, experiment: updatedExperiment } =
+      await updateHoldoutWithExperiment(this.context, {
+        holdout,
         experiment,
-        changes: {
-          phases,
-          ...(body.hashAttribute !== undefined && {
-            hashAttribute: body.hashAttribute,
-          }),
-        },
+        body,
       });
-    }
 
-    // 2. Metadata and analysis settings on the companion experiment.
-    const experimentChanges: Partial<ExperimentInterface> = {};
-    for (const field of HOLDOUT_API_EXPERIMENT_UPDATE_FIELDS) {
-      if (body[field] !== undefined) {
-        (experimentChanges as Record<string, unknown>)[field] = body[field];
-      }
-    }
-    if (body.owner !== undefined) {
-      experimentChanges.owner = await resolveOwnerToUserId(
-        body.owner,
-        this.context,
-      );
-    }
-    if (body.datasourceId !== undefined) {
-      experimentChanges.datasource = body.datasourceId;
-    }
-    if (body.assignmentQueryId !== undefined) {
-      experimentChanges.exposureQueryId = body.assignmentQueryId;
-    }
-    // A holdout's two variations are fixed, so only their labels can change.
-    if (body.variations) {
-      const renames = new Map(body.variations.map((v) => [v.variationId, v]));
-      experimentChanges.variations = experiment.variations.map((v) => {
-        const rename = renames.get(v.id);
-        if (!rename) return v;
-        return {
-          ...v,
-          name: rename.name ?? v.name,
-          description: rename.description ?? v.description,
-        };
-      });
-    }
-    // The name is stored on both documents and must not drift.
-    if (body.name !== undefined) {
-      experimentChanges.name = body.name;
-    }
-    if (Object.keys(experimentChanges).length) {
-      experiment = await updateExperiment({
-        context: this.context,
-        experiment,
-        changes: experimentChanges,
-      });
-    }
-
-    // 3. Fields on the holdout document itself.
-    const holdoutUpdates: UpdateProps<HoldoutInterface> = {};
-    for (const field of HOLDOUT_API_UPDATE_FIELDS) {
-      if (body[field] !== undefined) {
-        (holdoutUpdates as Record<string, unknown>)[field] = body[field];
-      }
-    }
-    if (body.name !== undefined) {
-      holdoutUpdates.name = body.name;
-    }
-    if (body.environments !== undefined) {
-      holdoutUpdates.environmentSettings = Object.fromEntries(
-        Object.entries(body.environments).map(([id, settings]) => [
-          id,
-          { enabled: settings.enabled },
-        ]),
-      );
-    }
-    if (body.statusUpdateSchedule !== undefined) {
-      Object.assign(
-        holdoutUpdates,
-        normalizeHoldoutScheduleUpdates({
-          holdout,
-          experiment,
-          scheduleInput: body.statusUpdateSchedule,
-        }),
-      );
-    }
-
-    const updated = Object.keys(holdoutUpdates).length
-      ? await this.update(holdout, holdoutUpdates)
-      : holdout;
-
-    return resolveOwnerEmail(toApiHoldout(updated, experiment), this.context);
+    return resolveOwnerEmail(
+      toApiHoldout(updated, updatedExperiment),
+      this.context,
+    );
   }
 
   protected async beforeUpdate(

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -456,9 +456,20 @@ export class HoldoutModel extends BaseClass {
       const envs = Array.from(
         new Set([...currentlyEnabledEnvs, ...requestedEnabledEnvs]),
       );
+      // Authorize against the current project scope and, when the request moves
+      // the Holdout, the destination scope too — otherwise a request could
+      // deploy targeting under a project the caller lacks run permission on.
+      // Each scope is checked separately because an empty projects array means
+      // global scope, which merging into one array would silently drop.
+      const projectScopes = [holdout.projects];
+      if (body.projects !== undefined) {
+        projectScopes.push(body.projects);
+      }
       if (
         envs.length > 0 &&
-        !this.context.permissions.canRunHoldout(holdout, envs)
+        !projectScopes.every((projects) =>
+          this.context.permissions.canRunHoldout({ projects }, envs),
+        )
       ) {
         this.context.permissions.throwPermissionError();
       }

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -1,13 +1,17 @@
 import { z } from "zod";
 import {
   coverageToHoldoutSize,
+  getAllowedHoldoutStageSources,
   getHoldoutStage,
+  HoldoutStage,
+  isHoldoutStageTransitionAllowed,
   stringToBoolean,
 } from "shared/util";
 import {
   ApiHoldoutInterface,
   apiCreateHoldoutBody,
-  apiHoldoutStageReturn,
+  apiHoldoutActionReturn,
+  apiHoldoutActionValidator,
   apiUpdateHoldoutBody,
   HOLDOUT_API_TARGETING_UPDATE_FIELDS,
   HoldoutInterface,
@@ -16,12 +20,19 @@ import {
 import { UpdateProps } from "shared/types/base-model";
 import { ExperimentInterface } from "shared/types/experiment";
 import { getCollection } from "back-end/src/util/mongo.util";
-import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
+import {
+  BadRequestError,
+  InvalidStatusError,
+  NotFoundError,
+} from "back-end/src/util/errors";
 import {
   holdoutApiSpec,
-  holdoutStageEndpoint,
+  holdoutStartAnalysisEndpoint,
+  holdoutStartEndpoint,
+  holdoutStopEndpoint,
 } from "back-end/src/api/specs/holdout.spec";
 import { defineCustomApiHandler } from "back-end/src/api/apiModelHandlers";
+import { ApiRequest } from "back-end/src/util/handler";
 import {
   createHoldoutWithExperiment,
   normalizeHoldoutScheduleUpdates,
@@ -38,6 +49,68 @@ import { MakeModelClass } from "./BaseModel";
 import { getExperimentById, getExperimentsByIds } from "./ExperimentModel";
 
 const COLLECTION_NAME = "holdouts";
+
+type HoldoutActionRequest = ApiRequest<
+  z.infer<typeof apiHoldoutActionReturn>,
+  typeof apiHoldoutActionValidator.paramsSchema,
+  typeof apiHoldoutActionValidator.bodySchema,
+  typeof apiHoldoutActionValidator.querySchema
+>;
+
+async function handleHoldoutStageTransition(
+  req: HoldoutActionRequest,
+  {
+    targetStage,
+    invalidStatusMessage,
+  }: {
+    targetStage: HoldoutStage;
+    invalidStatusMessage: string;
+  },
+): Promise<z.infer<typeof apiHoldoutActionReturn>> {
+  const holdout = await req.context.models.holdout.getById(req.params.id);
+  if (!holdout) {
+    return req.context.throwNotFoundError();
+  }
+  const experiment = await getExperimentById(req.context, holdout.experimentId);
+  if (!experiment) {
+    return req.context.throwNotFoundError("Holdout experiment not found");
+  }
+
+  const envs = getEnvironmentIdsFromOrg(req.context.org);
+  if (!req.context.permissions.canRunHoldout(holdout, envs)) {
+    req.context.permissions.throwPermissionError();
+  }
+
+  const currentStage = getHoldoutStage(holdout, experiment);
+  if (!isHoldoutStageTransitionAllowed(currentStage, targetStage)) {
+    throw new InvalidStatusError(
+      invalidStatusMessage,
+      currentStage,
+      getAllowedHoldoutStageSources(targetStage),
+    );
+  }
+
+  await setHoldoutStage(req.context, {
+    holdout,
+    experiment,
+    stage: targetStage,
+  });
+
+  const [updatedHoldout, updatedExperiment] = await Promise.all([
+    req.context.models.holdout.getById(holdout.id),
+    getExperimentById(req.context, holdout.experimentId),
+  ]);
+  if (!updatedHoldout || !updatedExperiment) {
+    return req.context.throwNotFoundError();
+  }
+
+  return {
+    holdout: await resolveOwnerEmail(
+      toApiHoldout(updatedHoldout, updatedExperiment),
+      req.context,
+    ),
+  };
+}
 
 const BaseClass = MakeModelClass({
   schema: holdoutValidator,
@@ -63,54 +136,31 @@ const BaseClass = MakeModelClass({
     openApiSpec: holdoutApiSpec,
     customHandlers: [
       defineCustomApiHandler({
-        ...holdoutStageEndpoint,
-        reqHandler: async (
-          req,
-        ): Promise<z.infer<typeof apiHoldoutStageReturn>> => {
-          const holdout = await req.context.models.holdout.getById(
-            req.params.id,
-          );
-          if (!holdout) {
-            return req.context.throwNotFoundError();
-          }
-          const experiment = await getExperimentById(
-            req.context,
-            holdout.experimentId,
-          );
-          if (!experiment) {
-            return req.context.throwNotFoundError(
-              "Holdout experiment not found",
-            );
-          }
-
-          const envs = getEnvironmentIdsFromOrg(req.context.org);
-          if (!req.context.permissions.canRunHoldout(holdout, envs)) {
-            req.context.permissions.throwPermissionError();
-          }
-
-          await setHoldoutStage(req.context, {
-            holdout,
-            experiment,
-            stage: req.body.stage,
-          });
-
-          // Re-read both documents: the stage change rewrote the experiment's
-          // status and phases and the holdout's analysis/schedule fields.
-          const [updatedHoldout, updatedExperiment] = await Promise.all([
-            req.context.models.holdout.getById(holdout.id),
-            getExperimentById(req.context, holdout.experimentId),
-          ]);
-          if (!updatedHoldout || !updatedExperiment) {
-            return req.context.throwNotFoundError();
-          }
-
-          return {
-            holdout: await resolveOwnerEmail(
-              toApiHoldout(updatedHoldout, updatedExperiment),
-              req.context,
-            ),
-          };
-        },
+        ...holdoutStartEndpoint,
+        reqHandler: (req) =>
+          handleHoldoutStageTransition(req, {
+            targetStage: "running",
+            invalidStatusMessage:
+              "Holdout must be in the draft stage before it can start.",
+          }),
+      }),
+      defineCustomApiHandler({
+        ...holdoutStartAnalysisEndpoint,
+        reqHandler: (req) =>
+          handleHoldoutStageTransition(req, {
+            targetStage: "analysis-period",
+            invalidStatusMessage:
+              "Holdout must be running before its analysis period can start.",
+          }),
+      }),
+      defineCustomApiHandler({
+        ...holdoutStopEndpoint,
+        reqHandler: (req) =>
+          handleHoldoutStageTransition(req, {
+            targetStage: "stopped",
+            invalidStatusMessage:
+              "Holdout must be running or in its analysis period before it can stop.",
+          }),
       }),
     ],
   },

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -365,6 +365,21 @@ export class HoldoutModel extends BaseClass {
   ): Promise<ApiHoldoutInterface> {
     const body = apiCreateHoldoutBody.parse(req.body);
 
+    // Gate before creating the companion experiment; createExperiment enforces
+    // no permissions, so an unauthorized create would otherwise orphan one.
+    if (!this.hasPremiumFeature()) {
+      throw new Error(
+        "Your organization does not have access to this feature.",
+      );
+    }
+    if (
+      !this.context.permissions.canCreateHoldout({
+        projects: body.projects ?? [],
+      })
+    ) {
+      this.context.permissions.throwPermissionError();
+    }
+
     if (body.statusUpdateSchedule !== undefined) {
       assertCanRunHoldoutEnvironments(this.context, {
         enabledEnvironments: getEnabledHoldoutEnvironments(body.environments),
@@ -430,6 +445,14 @@ export class HoldoutModel extends BaseClass {
     const holdout = await this.getById(req.params.id);
     if (!holdout) req.context.throwNotFoundError();
     const experiment = await this.getExperimentOrThrow(holdout);
+
+    // Experiment-only updates never reach holdout.update, which is where the
+    // premium gate lives, so enforce it here too.
+    if (!this.hasPremiumFeature()) {
+      throw new Error(
+        "Your organization does not have access to this feature.",
+      );
+    }
 
     assertCanUpdateHoldout(this.context, {
       holdout,

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import {
   coverageToHoldoutSize,
   getAllowedHoldoutStageSources,
+  getEnabledHoldoutEnvironments,
   getHoldoutStage,
   HoldoutStage,
   isHoldoutStageTransitionAllowed,
@@ -34,6 +35,8 @@ import {
 import { defineCustomApiHandler } from "back-end/src/api/apiModelHandlers";
 import { ApiRequest } from "back-end/src/util/handler";
 import {
+  assertCanRunHoldoutEnvironments,
+  assertCanUpdateHoldout,
   createHoldoutWithExperiment,
   normalizeHoldoutScheduleUpdates,
   setHoldoutStage,
@@ -362,6 +365,13 @@ export class HoldoutModel extends BaseClass {
   ): Promise<ApiHoldoutInterface> {
     const body = apiCreateHoldoutBody.parse(req.body);
 
+    if (body.statusUpdateSchedule !== undefined) {
+      assertCanRunHoldoutEnvironments(this.context, {
+        enabledEnvironments: getEnabledHoldoutEnvironments(body.environments),
+        projects: body.projects ?? [],
+      });
+    }
+
     const owner = await resolveOwnerForCreate(body.owner, this.context);
 
     const { holdout, experiment } = await createHoldoutWithExperiment(
@@ -421,58 +431,17 @@ export class HoldoutModel extends BaseClass {
     if (!holdout) req.context.throwNotFoundError();
     const experiment = await this.getExperimentOrThrow(holdout);
 
-    // Gate every path explicitly. Writes to the companion experiment go through
-    // `updateExperiment`, which does no permission checking of its own, and a
-    // body touching only experiment-side fields never reaches `this.update`.
-    if (
-      !this.context.permissions.canUpdateHoldout(holdout, {
-        projects: body.projects ?? holdout.projects,
-      })
-    ) {
-      this.context.permissions.throwPermissionError();
-    }
-
-    // Targeting, sizing, and environment changes reach live SDK payloads, so
-    // they additionally require run permission on the Holdout's environments —
-    // the same bar the internal targeting endpoint applies. The environment map
-    // is replaced wholesale by the write below, so authorize the union of the
-    // currently enabled environments and the ones this request would enable;
-    // otherwise a request could deploy targeting to an environment the caller
-    // lacks run permission on.
-    const isTargetingChange = HOLDOUT_API_TARGETING_UPDATE_FIELDS.some(
-      (field) => body[field] !== undefined,
-    );
-    const isEnvironmentChange = body.environments !== undefined;
-    if (isTargetingChange || isEnvironmentChange) {
-      const currentlyEnabledEnvs = Object.keys(
-        holdout.environmentSettings,
-      ).filter((env) => holdout.environmentSettings[env]?.enabled);
-      const requestedEnabledEnvs = body.environments
-        ? Object.keys(body.environments).filter(
-            (env) => body.environments?.[env]?.enabled,
-          )
-        : [];
-      const envs = Array.from(
-        new Set([...currentlyEnabledEnvs, ...requestedEnabledEnvs]),
-      );
-      // Authorize against the current project scope and, when the request moves
-      // the Holdout, the destination scope too — otherwise a request could
-      // deploy targeting under a project the caller lacks run permission on.
-      // Each scope is checked separately because an empty projects array means
-      // global scope, which merging into one array would silently drop.
-      const projectScopes = [holdout.projects];
-      if (body.projects !== undefined) {
-        projectScopes.push(body.projects);
-      }
-      if (
-        envs.length > 0 &&
-        !projectScopes.every((projects) =>
-          this.context.permissions.canRunHoldout({ projects }, envs),
-        )
-      ) {
-        this.context.permissions.throwPermissionError();
-      }
-    }
+    assertCanUpdateHoldout(this.context, {
+      holdout,
+      updatedProjects: body.projects,
+      requestedEnabledEnvironments: body.environments
+        ? getEnabledHoldoutEnvironments(body.environments)
+        : undefined,
+      isTargetingChange: HOLDOUT_API_TARGETING_UPDATE_FIELDS.some(
+        (field) => body[field] !== undefined,
+      ),
+      isScheduleChange: (body.statusUpdateSchedule ?? null) !== null,
+    });
 
     const { holdout: updated, experiment: updatedExperiment } =
       await updateHoldoutWithExperiment(this.context, {

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -133,44 +133,41 @@ const LINKAGE_FIELDS = ["linkedFeatures", "linkedExperiments"] as const;
 /**
  * Merges a holdout and its companion experiment into the public API shape.
  *
- * The experiment is nullable because a holdout can outlive a deleted experiment;
- * in that case the experiment-derived fields fall back to empty values rather
- * than failing the whole response.
+ * A holdout is invalid without its companion experiment, so callers must resolve
+ * it before serializing.
  */
 export function toApiHoldout(
   holdout: HoldoutInterface,
-  experiment: ExperimentInterface | null,
+  experiment: ExperimentInterface,
 ): ApiHoldoutInterface {
-  const phase = experiment?.phases?.[experiment.phases.length - 1];
-  const firstPhase = experiment?.phases?.[0];
+  const phase = experiment.phases[experiment.phases.length - 1];
+  const firstPhase = experiment.phases[0];
 
   return {
     id: holdout.id,
     dateCreated: holdout.dateCreated.toISOString(),
     dateUpdated: holdout.dateUpdated.toISOString(),
     name: holdout.name,
-    description: experiment?.description ?? "",
+    description: experiment.description ?? "",
     projects: holdout.projects,
-    owner: experiment?.owner ?? "",
-    tags: experiment?.tags ?? [],
-    archived: experiment?.archived ?? false,
-    stage: experiment
-      ? getHoldoutStage(holdout, experiment)
-      : /* No experiment left to derive from. */ "stopped",
+    owner: experiment.owner,
+    tags: experiment.tags,
+    archived: experiment.archived,
+    stage: getHoldoutStage(holdout, experiment),
     experimentId: holdout.experimentId,
-    trackingKey: experiment?.trackingKey ?? "",
+    trackingKey: experiment.trackingKey,
     skipAsDefaultHoldout: holdout.skipAsDefaultHoldout ?? false,
 
     holdoutSize: coverageToHoldoutSize(phase?.coverage ?? 0),
-    hashAttribute: experiment?.hashAttribute ?? "",
+    hashAttribute: experiment.hashAttribute,
     targetingCondition: phase?.condition ?? "",
     savedGroups: phase?.savedGroups,
 
-    datasourceId: experiment?.datasource ?? "",
-    assignmentQueryId: experiment?.exposureQueryId ?? "",
-    goalMetrics: experiment?.goalMetrics ?? [],
-    secondaryMetrics: experiment?.secondaryMetrics ?? [],
-    variations: (experiment?.variations ?? []).map((v) => ({
+    datasourceId: experiment.datasource,
+    assignmentQueryId: experiment.exposureQueryId,
+    goalMetrics: experiment.goalMetrics,
+    secondaryMetrics: experiment.secondaryMetrics,
+    variations: experiment.variations.map((v) => ({
       variationId: v.id,
       key: v.key,
       name: v.name,
@@ -196,7 +193,7 @@ export function toApiHoldout(
     dateStarted: firstPhase?.dateStarted?.toISOString(),
     analysisStartDate: holdout.analysisStartDate?.toISOString(),
     dateStopped:
-      experiment?.status === "stopped"
+      experiment.status === "stopped"
         ? phase?.dateEnded?.toISOString()
         : undefined,
 
@@ -248,11 +245,13 @@ export class HoldoutModel extends BaseClass {
    * the companion experiment that supplies most of the API shape.
    ***************/
 
-  protected toApiInterface(doc: HoldoutInterface): ApiHoldoutInterface {
-    // Only reached if a caller bypasses the overrides below. Returning the
-    // holdout half alone is better than throwing, and every handler here
-    // resolves the experiment properly.
-    return toApiHoldout(doc, null);
+  protected toApiInterface(): ApiHoldoutInterface {
+    // A holdout needs its companion experiment to serialize, and fetching it is
+    // async. Every handler below resolves the experiment and calls `toApiHoldout`
+    // directly, so this default is never the right path.
+    throw new Error(
+      "Use handleApi* handlers to serialize a Holdout; toApiInterface cannot resolve its experiment.",
+    );
   }
 
   private async getExperimentOrThrow(
@@ -301,13 +300,8 @@ export class HoldoutModel extends BaseClass {
     const results: ApiHoldoutInterface[] = [];
     for (const holdout of filteredByProject) {
       const experiment = experimentsById.get(holdout.experimentId);
-      // A holdout whose experiment was deleted cannot be filtered on
-      // experiment-derived fields, so drop it from filtered listings.
-      if (!experiment) {
-        if (datasourceId || stage || wantArchived !== undefined) continue;
-        results.push(toApiHoldout(holdout, null));
-        continue;
-      }
+      // A holdout without its companion experiment is invalid, so drop it.
+      if (!experiment) continue;
       if (datasourceId && experiment.datasource !== datasourceId) continue;
       if (stage && getHoldoutStage(holdout, experiment) !== stage) continue;
       if (

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -1,10 +1,47 @@
-import { HoldoutInterface, holdoutValidator } from "shared/validators";
+import { z } from "zod";
+import { getHoldoutStage, stringToBoolean } from "shared/util";
+import {
+  ApiHoldoutInterface,
+  apiCreateHoldoutBody,
+  apiHoldoutStageReturn,
+  apiUpdateHoldoutBody,
+  coverageToHoldoutSize,
+  DEFAULT_HOLDOUT_SIZE,
+  holdoutSizeToCoverage,
+  HOLDOUT_API_EXPERIMENT_UPDATE_FIELDS,
+  HOLDOUT_API_TARGETING_UPDATE_FIELDS,
+  HOLDOUT_API_UPDATE_FIELDS,
+  HoldoutInterface,
+  holdoutValidator,
+} from "shared/validators";
 import { UpdateProps } from "shared/types/base-model";
 import { ExperimentInterface } from "shared/types/experiment";
 import { getCollection } from "back-end/src/util/mongo.util";
 import { BadRequestError, NotFoundError } from "back-end/src/util/errors";
+import {
+  holdoutApiSpec,
+  holdoutStageEndpoint,
+} from "back-end/src/api/specs/holdout.spec";
+import { defineCustomApiHandler } from "back-end/src/api/apiModelHandlers";
+import {
+  advanceHoldoutStage,
+  applyHoldoutTargetingChanges,
+  createHoldoutWithExperiment,
+  normalizeHoldoutScheduleUpdates,
+} from "back-end/src/services/holdouts";
+import {
+  resolveOwnerEmail,
+  resolveOwnerEmails,
+  resolveOwnerForCreate,
+  resolveOwnerToUserId,
+} from "back-end/src/services/owner";
+import { getEnvironmentIdsFromOrg } from "back-end/src/services/organizations";
 import { MakeModelClass } from "./BaseModel";
-import { getExperimentById } from "./ExperimentModel";
+import {
+  getExperimentById,
+  getExperimentsByIds,
+  updateExperiment,
+} from "./ExperimentModel";
 
 const COLLECTION_NAME = "holdouts";
 
@@ -27,6 +64,62 @@ const BaseClass = MakeModelClass({
       fields: { "nextScheduledStatusUpdate.date": 1 },
     },
   ],
+  apiConfig: {
+    modelKey: "holdout",
+    openApiSpec: holdoutApiSpec,
+    customHandlers: [
+      defineCustomApiHandler({
+        ...holdoutStageEndpoint,
+        reqHandler: async (
+          req,
+        ): Promise<z.infer<typeof apiHoldoutStageReturn>> => {
+          const holdout = await req.context.models.holdout.getById(
+            req.params.id,
+          );
+          if (!holdout) {
+            return req.context.throwNotFoundError();
+          }
+          const experiment = await getExperimentById(
+            req.context,
+            holdout.experimentId,
+          );
+          if (!experiment) {
+            return req.context.throwNotFoundError(
+              "Holdout experiment not found",
+            );
+          }
+
+          const envs = getEnvironmentIdsFromOrg(req.context.org);
+          if (!req.context.permissions.canRunHoldout(holdout, envs)) {
+            req.context.permissions.throwPermissionError();
+          }
+
+          await advanceHoldoutStage(req.context, {
+            holdout,
+            experiment,
+            stage: req.body.stage,
+          });
+
+          // Re-read both documents: the stage change rewrote the experiment's
+          // status and phases and the holdout's analysis/schedule fields.
+          const [updatedHoldout, updatedExperiment] = await Promise.all([
+            req.context.models.holdout.getById(holdout.id),
+            getExperimentById(req.context, holdout.experimentId),
+          ]);
+          if (!updatedHoldout || !updatedExperiment) {
+            return req.context.throwNotFoundError();
+          }
+
+          return {
+            holdout: await resolveOwnerEmail(
+              toApiHoldout(updatedHoldout, updatedExperiment),
+              req.context,
+            ),
+          };
+        },
+      }),
+    ],
+  },
 });
 
 // Guarded on BOTH maps by every linkage write, even one that touches only one of
@@ -34,6 +127,95 @@ const BaseClass = MakeModelClass({
 // experiments, compensate a publish) that guarding half would let the other half
 // be clobbered by a writer this one never saw.
 const LINKAGE_FIELDS = ["linkedFeatures", "linkedExperiments"] as const;
+
+/**
+ * Merges a holdout and its companion experiment into the public API shape.
+ *
+ * The experiment is nullable because a holdout can outlive a deleted experiment;
+ * in that case the experiment-derived fields fall back to empty values rather
+ * than failing the whole response.
+ */
+export function toApiHoldout(
+  holdout: HoldoutInterface,
+  experiment: ExperimentInterface | null,
+): ApiHoldoutInterface {
+  const phase = experiment?.phases?.[experiment.phases.length - 1];
+  const firstPhase = experiment?.phases?.[0];
+
+  return {
+    id: holdout.id,
+    dateCreated: holdout.dateCreated.toISOString(),
+    dateUpdated: holdout.dateUpdated.toISOString(),
+    name: holdout.name,
+    description: experiment?.description ?? "",
+    projects: holdout.projects,
+    owner: experiment?.owner ?? "",
+    tags: experiment?.tags ?? [],
+    archived: experiment?.archived ?? false,
+    stage: experiment
+      ? getHoldoutStage(holdout, experiment)
+      : /* No experiment left to derive from. */ "stopped",
+    experimentId: holdout.experimentId,
+    trackingKey: experiment?.trackingKey ?? "",
+    skipAsDefaultHoldout: holdout.skipAsDefaultHoldout ?? false,
+
+    holdoutSize: coverageToHoldoutSize(phase?.coverage ?? 0),
+    hashAttribute: experiment?.hashAttribute ?? "",
+    targetingCondition: phase?.condition ?? "",
+    savedGroups: phase?.savedGroups,
+
+    datasourceId: experiment?.datasource ?? "",
+    assignmentQueryId: experiment?.exposureQueryId ?? "",
+    goalMetrics: experiment?.goalMetrics ?? [],
+    secondaryMetrics: experiment?.secondaryMetrics ?? [],
+    guardrailMetrics: experiment?.guardrailMetrics ?? [],
+    activationMetric: experiment?.activationMetric || undefined,
+    variations: (experiment?.variations ?? []).map((v) => ({
+      variationId: v.id,
+      key: v.key,
+      name: v.name,
+      description: v.description,
+    })),
+
+    environments: Object.fromEntries(
+      Object.entries(holdout.environmentSettings).map(([id, settings]) => [
+        id,
+        { enabled: settings.enabled },
+      ]),
+    ),
+
+    linkedFeatures: Object.values(holdout.linkedFeatures).map((f) => ({
+      id: f.id,
+      dateAdded: f.dateAdded.toISOString(),
+    })),
+    linkedExperiments: Object.values(holdout.linkedExperiments).map((e) => ({
+      id: e.id,
+      dateAdded: e.dateAdded.toISOString(),
+    })),
+
+    dateStarted: firstPhase?.dateStarted?.toISOString(),
+    analysisStartDate: holdout.analysisStartDate?.toISOString(),
+    dateStopped:
+      experiment?.status === "stopped"
+        ? phase?.dateEnded?.toISOString()
+        : undefined,
+
+    statusUpdateSchedule: holdout.statusUpdateSchedule
+      ? {
+          startAt: holdout.statusUpdateSchedule.startAt?.toISOString(),
+          startAnalysisPeriodAt:
+            holdout.statusUpdateSchedule.startAnalysisPeriodAt?.toISOString(),
+          stopAt: holdout.statusUpdateSchedule.stopAt?.toISOString(),
+        }
+      : holdout.statusUpdateSchedule,
+    nextScheduledStatusUpdate: holdout.nextScheduledStatusUpdate
+      ? {
+          type: holdout.nextScheduledStatusUpdate.type,
+          date: holdout.nextScheduledStatusUpdate.date.toISOString(),
+        }
+      : holdout.nextScheduledStatusUpdate,
+  };
+}
 
 export class HoldoutModel extends BaseClass {
   // CRUD permission checks
@@ -56,6 +238,292 @@ export class HoldoutModel extends BaseClass {
 
   protected hasPremiumFeature(): boolean {
     return this.context.hasPremiumFeature("holdouts");
+  }
+
+  /***************
+   * REST API handlers
+   *
+   * All four are overridden because the default implementations assume a single
+   * document: `toApiInterface` is synchronous and per-doc, so it cannot fetch
+   * the companion experiment that supplies most of the API shape.
+   ***************/
+
+  protected toApiInterface(doc: HoldoutInterface): ApiHoldoutInterface {
+    // Only reached if a caller bypasses the overrides below. Returning the
+    // holdout half alone is better than throwing, and every handler here
+    // resolves the experiment properly.
+    return toApiHoldout(doc, null);
+  }
+
+  private async getExperimentOrThrow(
+    holdout: HoldoutInterface,
+  ): Promise<ExperimentInterface> {
+    const experiment = await getExperimentById(
+      this.context,
+      holdout.experimentId,
+    );
+    if (!experiment) {
+      // A 404 rather than a 500: the Holdout exists but is missing its other half.
+      this.context.throwNotFoundError("Holdout experiment not found");
+    }
+    return experiment;
+  }
+
+  public override async handleApiGet(
+    req: Parameters<InstanceType<typeof BaseClass>["handleApiGet"]>[0],
+  ): Promise<ApiHoldoutInterface> {
+    const holdout = await this.getById(req.params.id);
+    if (!holdout) req.context.throwNotFoundError();
+    const experiment = await this.getExperimentOrThrow(holdout);
+    return resolveOwnerEmail(toApiHoldout(holdout, experiment), this.context);
+  }
+
+  public override async handleApiList(
+    req: Parameters<InstanceType<typeof BaseClass>["handleApiList"]>[0],
+  ): Promise<ApiHoldoutInterface[]> {
+    const { projectId, datasourceId, stage, archived } = req.query;
+
+    const holdouts = await this.getAll();
+    const filteredByProject = projectId
+      ? holdouts.filter((h) => h.projects.includes(projectId))
+      : holdouts;
+
+    // Batch the experiment lookup rather than one query per holdout.
+    const experiments = await getExperimentsByIds(
+      this.context,
+      filteredByProject.map((h) => h.experimentId),
+    );
+    const experimentsById = new Map(experiments.map((e) => [e.id, e]));
+
+    const wantArchived =
+      archived === undefined ? undefined : stringToBoolean(archived.toString());
+
+    const results: ApiHoldoutInterface[] = [];
+    for (const holdout of filteredByProject) {
+      const experiment = experimentsById.get(holdout.experimentId);
+      // A holdout whose experiment was deleted cannot be filtered on
+      // experiment-derived fields, so drop it from filtered listings.
+      if (!experiment) {
+        if (datasourceId || stage || wantArchived !== undefined) continue;
+        results.push(toApiHoldout(holdout, null));
+        continue;
+      }
+      if (datasourceId && experiment.datasource !== datasourceId) continue;
+      if (stage && getHoldoutStage(holdout, experiment) !== stage) continue;
+      if (
+        wantArchived !== undefined &&
+        !!experiment.archived !== wantArchived
+      ) {
+        continue;
+      }
+      results.push(toApiHoldout(holdout, experiment));
+    }
+
+    return resolveOwnerEmails(results, this.context);
+  }
+
+  public override async handleApiCreate(
+    req: Parameters<InstanceType<typeof BaseClass>["handleApiCreate"]>[0],
+  ): Promise<ApiHoldoutInterface> {
+    const body = apiCreateHoldoutBody.parse(req.body);
+
+    const owner = await resolveOwnerForCreate(body.owner, this.context);
+
+    const { holdout, experiment } = await createHoldoutWithExperiment(
+      this.context,
+      {
+        name: body.name,
+        description: body.description,
+        projects: body.projects,
+        owner,
+        tags: body.tags,
+        skipAsDefaultHoldout: body.skipAsDefaultHoldout,
+        datasource: body.datasourceId,
+        exposureQueryId: body.assignmentQueryId,
+        // An empty hash attribute would leave the Holdout unable to bucket
+        // anyone, so fall back to the conventional default.
+        hashAttribute: body.hashAttribute || "id",
+        goalMetrics: body.goalMetrics,
+        secondaryMetrics: body.secondaryMetrics,
+        guardrailMetrics: body.guardrailMetrics,
+        activationMetric: body.activationMetric,
+        environmentSettings: body.environments
+          ? Object.fromEntries(
+              Object.entries(body.environments).map(([id, settings]) => [
+                id,
+                { enabled: settings.enabled },
+              ]),
+            )
+          : undefined,
+        // A new holdout gets a single phase holding its targeting and sizing.
+        phases: [
+          {
+            name: "Holdout",
+            reason: "",
+            dateStarted: new Date().toISOString(),
+            coverage: holdoutSizeToCoverage(
+              body.holdoutSize ?? DEFAULT_HOLDOUT_SIZE,
+            ),
+            condition: body.targetingCondition ?? "",
+            savedGroups: body.savedGroups,
+            variationWeights: [0.5, 0.5],
+            variations: [],
+          },
+        ],
+      },
+    );
+
+    // Applied after creation so it is validated against the real stored stage.
+    if (body.statusUpdateSchedule) {
+      const withSchedule = await this.update(
+        holdout,
+        normalizeHoldoutScheduleUpdates({
+          holdout,
+          experiment,
+          scheduleInput: body.statusUpdateSchedule,
+        }),
+      );
+      return resolveOwnerEmail(
+        toApiHoldout(withSchedule, experiment),
+        this.context,
+      );
+    }
+
+    return resolveOwnerEmail(toApiHoldout(holdout, experiment), this.context);
+  }
+
+  public override async handleApiUpdate(
+    req: Parameters<InstanceType<typeof BaseClass>["handleApiUpdate"]>[0],
+  ): Promise<ApiHoldoutInterface> {
+    const body = apiUpdateHoldoutBody.parse(req.body);
+
+    const holdout = await this.getById(req.params.id);
+    if (!holdout) req.context.throwNotFoundError();
+    let experiment = await this.getExperimentOrThrow(holdout);
+
+    // Gate every path explicitly. Writes to the companion experiment go through
+    // `updateExperiment`, which does no permission checking of its own, and a
+    // body touching only experiment-side fields never reaches `this.update`.
+    if (
+      !this.context.permissions.canUpdateHoldout(holdout, {
+        projects: body.projects ?? holdout.projects,
+      })
+    ) {
+      this.context.permissions.throwPermissionError();
+    }
+
+    const isTargetingChange = HOLDOUT_API_TARGETING_UPDATE_FIELDS.some(
+      (field) => body[field] !== undefined,
+    );
+
+    // Targeting and sizing changes reach live SDK payloads, so they additionally
+    // require run permission on the Holdout's environments — the same bar the
+    // internal targeting endpoint applies.
+    if (isTargetingChange) {
+      const envs = Object.keys(holdout.environmentSettings).filter(
+        (env) => holdout.environmentSettings[env]?.enabled,
+      );
+      if (
+        envs.length > 0 &&
+        !this.context.permissions.canRunHoldout(holdout, envs)
+      ) {
+        this.context.permissions.throwPermissionError();
+      }
+    }
+
+    // 1. Phase-level targeting and sizing, through the same path the internal
+    //    targeting endpoint uses so phases and the SDK payload stay correct.
+    if (isTargetingChange) {
+      experiment = await applyHoldoutTargetingChanges(this.context, {
+        experiment,
+        coverage:
+          body.holdoutSize === undefined
+            ? undefined
+            : holdoutSizeToCoverage(body.holdoutSize),
+        condition: body.targetingCondition,
+        savedGroups: body.savedGroups,
+        hashAttribute: body.hashAttribute,
+      });
+    }
+
+    // 2. Metadata and analysis settings on the companion experiment.
+    const experimentChanges: Partial<ExperimentInterface> = {};
+    for (const field of HOLDOUT_API_EXPERIMENT_UPDATE_FIELDS) {
+      if (body[field] !== undefined) {
+        (experimentChanges as Record<string, unknown>)[field] = body[field];
+      }
+    }
+    if (body.owner !== undefined) {
+      experimentChanges.owner = await resolveOwnerToUserId(
+        body.owner,
+        this.context,
+      );
+    }
+    if (body.datasourceId !== undefined) {
+      experimentChanges.datasource = body.datasourceId;
+    }
+    if (body.assignmentQueryId !== undefined) {
+      experimentChanges.exposureQueryId = body.assignmentQueryId;
+    }
+    // A holdout's two variations are fixed, so only their labels can change.
+    if (body.variations) {
+      const renames = new Map(body.variations.map((v) => [v.variationId, v]));
+      experimentChanges.variations = experiment.variations.map((v) => {
+        const rename = renames.get(v.id);
+        if (!rename) return v;
+        return {
+          ...v,
+          name: rename.name ?? v.name,
+          description: rename.description ?? v.description,
+        };
+      });
+    }
+    // The name is stored on both documents and must not drift.
+    if (body.name !== undefined) {
+      experimentChanges.name = body.name;
+    }
+    if (Object.keys(experimentChanges).length) {
+      experiment = await updateExperiment({
+        context: this.context,
+        experiment,
+        changes: experimentChanges,
+      });
+    }
+
+    // 3. Fields on the holdout document itself.
+    const holdoutUpdates: UpdateProps<HoldoutInterface> = {};
+    for (const field of HOLDOUT_API_UPDATE_FIELDS) {
+      if (body[field] !== undefined) {
+        (holdoutUpdates as Record<string, unknown>)[field] = body[field];
+      }
+    }
+    if (body.name !== undefined) {
+      holdoutUpdates.name = body.name;
+    }
+    if (body.environments !== undefined) {
+      holdoutUpdates.environmentSettings = Object.fromEntries(
+        Object.entries(body.environments).map(([id, settings]) => [
+          id,
+          { enabled: settings.enabled },
+        ]),
+      );
+    }
+    if (body.statusUpdateSchedule !== undefined) {
+      Object.assign(
+        holdoutUpdates,
+        normalizeHoldoutScheduleUpdates({
+          holdout,
+          experiment,
+          scheduleInput: body.statusUpdateSchedule,
+        }),
+      );
+    }
+
+    const updated = Object.keys(holdoutUpdates).length
+      ? await this.update(holdout, holdoutUpdates)
+      : holdout;
+
+    return resolveOwnerEmail(toApiHoldout(updated, experiment), this.context);
   }
 
   protected async beforeUpdate(

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -134,44 +134,41 @@ const LINKAGE_FIELDS = ["linkedFeatures", "linkedExperiments"] as const;
 /**
  * Merges a holdout and its companion experiment into the public API shape.
  *
- * The experiment is nullable because a holdout can outlive a deleted experiment;
- * in that case the experiment-derived fields fall back to empty values rather
- * than failing the whole response.
+ * A holdout is invalid without its companion experiment, so callers must resolve
+ * it before serializing.
  */
 export function toApiHoldout(
   holdout: HoldoutInterface,
-  experiment: ExperimentInterface | null,
+  experiment: ExperimentInterface,
 ): ApiHoldoutInterface {
-  const phase = experiment?.phases?.[experiment.phases.length - 1];
-  const firstPhase = experiment?.phases?.[0];
+  const phase = experiment.phases[experiment.phases.length - 1];
+  const firstPhase = experiment.phases[0];
 
   return {
     id: holdout.id,
     dateCreated: holdout.dateCreated.toISOString(),
     dateUpdated: holdout.dateUpdated.toISOString(),
     name: holdout.name,
-    description: experiment?.description ?? "",
+    description: experiment.description ?? "",
     projects: holdout.projects,
-    owner: experiment?.owner ?? "",
-    tags: experiment?.tags ?? [],
-    archived: experiment?.archived ?? false,
-    stage: experiment
-      ? getHoldoutStage(holdout, experiment)
-      : /* No experiment left to derive from. */ "stopped",
+    owner: experiment.owner,
+    tags: experiment.tags,
+    archived: experiment.archived,
+    stage: getHoldoutStage(holdout, experiment),
     experimentId: holdout.experimentId,
-    trackingKey: experiment?.trackingKey ?? "",
+    trackingKey: experiment.trackingKey,
     skipAsDefaultHoldout: holdout.skipAsDefaultHoldout ?? false,
 
     holdoutSize: coverageToHoldoutSize(phase?.coverage ?? 0),
-    hashAttribute: experiment?.hashAttribute ?? "",
+    hashAttribute: experiment.hashAttribute,
     targetingCondition: phase?.condition ?? "",
     savedGroups: phase?.savedGroups,
 
-    datasourceId: experiment?.datasource ?? "",
-    assignmentQueryId: experiment?.exposureQueryId ?? "",
-    goalMetrics: experiment?.goalMetrics ?? [],
-    secondaryMetrics: experiment?.secondaryMetrics ?? [],
-    variations: (experiment?.variations ?? []).map((v) => ({
+    datasourceId: experiment.datasource,
+    assignmentQueryId: experiment.exposureQueryId,
+    goalMetrics: experiment.goalMetrics,
+    secondaryMetrics: experiment.secondaryMetrics,
+    variations: experiment.variations.map((v) => ({
       variationId: v.id,
       key: v.key,
       name: v.name,
@@ -197,7 +194,7 @@ export function toApiHoldout(
     dateStarted: firstPhase?.dateStarted?.toISOString(),
     analysisStartDate: holdout.analysisStartDate?.toISOString(),
     dateStopped:
-      experiment?.status === "stopped"
+      experiment.status === "stopped"
         ? phase?.dateEnded?.toISOString()
         : undefined,
 
@@ -249,11 +246,13 @@ export class HoldoutModel extends BaseClass {
    * the companion experiment that supplies most of the API shape.
    ***************/
 
-  protected toApiInterface(doc: HoldoutInterface): ApiHoldoutInterface {
-    // Only reached if a caller bypasses the overrides below. Returning the
-    // holdout half alone is better than throwing, and every handler here
-    // resolves the experiment properly.
-    return toApiHoldout(doc, null);
+  protected toApiInterface(): ApiHoldoutInterface {
+    // A holdout needs its companion experiment to serialize, and fetching it is
+    // async. Every handler below resolves the experiment and calls `toApiHoldout`
+    // directly, so this default is never the right path.
+    throw new Error(
+      "Use handleApi* handlers to serialize a Holdout; toApiInterface cannot resolve its experiment.",
+    );
   }
 
   private async getExperimentOrThrow(
@@ -302,13 +301,8 @@ export class HoldoutModel extends BaseClass {
     const results: ApiHoldoutInterface[] = [];
     for (const holdout of filteredByProject) {
       const experiment = experimentsById.get(holdout.experimentId);
-      // A holdout whose experiment was deleted cannot be filtered on
-      // experiment-derived fields, so drop it from filtered listings.
-      if (!experiment) {
-        if (datasourceId || stage || wantArchived !== undefined) continue;
-        results.push(toApiHoldout(holdout, null));
-        continue;
-      }
+      // A holdout without its companion experiment is invalid, so drop it.
+      if (!experiment) continue;
       if (datasourceId && experiment.datasource !== datasourceId) continue;
       if (stage && getHoldoutStage(holdout, experiment) !== stage) continue;
       if (

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -1,13 +1,16 @@
 import { z } from "zod";
-import { getHoldoutStage, stringToBoolean } from "shared/util";
+import {
+  coverageToHoldoutSize,
+  getHoldoutStage,
+  holdoutSizeToCoverage,
+  stringToBoolean,
+} from "shared/util";
 import {
   ApiHoldoutInterface,
   apiCreateHoldoutBody,
   apiHoldoutStageReturn,
   apiUpdateHoldoutBody,
-  coverageToHoldoutSize,
   DEFAULT_HOLDOUT_SIZE,
-  holdoutSizeToCoverage,
   HOLDOUT_API_EXPERIMENT_UPDATE_FIELDS,
   HOLDOUT_API_TARGETING_UPDATE_FIELDS,
   HOLDOUT_API_UPDATE_FIELDS,
@@ -24,10 +27,10 @@ import {
 } from "back-end/src/api/specs/holdout.spec";
 import { defineCustomApiHandler } from "back-end/src/api/apiModelHandlers";
 import {
-  advanceHoldoutStage,
   applyHoldoutTargetingChanges,
   createHoldoutWithExperiment,
   normalizeHoldoutScheduleUpdates,
+  setHoldoutStage,
 } from "back-end/src/services/holdouts";
 import {
   resolveOwnerEmail,
@@ -94,7 +97,7 @@ const BaseClass = MakeModelClass({
             req.context.permissions.throwPermissionError();
           }
 
-          await advanceHoldoutStage(req.context, {
+          await setHoldoutStage(req.context, {
             holdout,
             experiment,
             stage: req.body.stage,
@@ -168,8 +171,6 @@ export function toApiHoldout(
     assignmentQueryId: experiment?.exposureQueryId ?? "",
     goalMetrics: experiment?.goalMetrics ?? [],
     secondaryMetrics: experiment?.secondaryMetrics ?? [],
-    guardrailMetrics: experiment?.guardrailMetrics ?? [],
-    activationMetric: experiment?.activationMetric || undefined,
     variations: (experiment?.variations ?? []).map((v) => ({
       variationId: v.id,
       key: v.key,
@@ -345,8 +346,6 @@ export class HoldoutModel extends BaseClass {
         hashAttribute: body.hashAttribute || "id",
         goalMetrics: body.goalMetrics,
         secondaryMetrics: body.secondaryMetrics,
-        guardrailMetrics: body.guardrailMetrics,
-        activationMetric: body.activationMetric,
         environmentSettings: body.environments
           ? Object.fromEntries(
               Object.entries(body.environments).map(([id, settings]) => [

--- a/packages/back-end/src/routers/holdout/holdout.controller.ts
+++ b/packages/back-end/src/routers/holdout/holdout.controller.ts
@@ -26,11 +26,14 @@ import {
 } from "back-end/src/models/ExperimentModel";
 import {
   setHoldoutStage,
+  assertCanRunHoldoutEnvironments,
   assertCanUpdateHoldout,
   assertHoldoutScopeCoversLinked,
+  assertValidHoldoutEnvironments,
   createHoldoutWithExperiment,
   deleteHoldoutAndExperiment,
   normalizeHoldoutScheduleUpdates,
+  refreshHoldoutPayload,
 } from "back-end/src/services/holdouts";
 import {
   assertNoLinkedHoldoutExperiments,
@@ -255,15 +258,32 @@ export const updateHoldout = async (
     });
   }
 
-  const updates = { ...req.body };
+  // Whitelist the client-settable holdout fields. experimentId, the linkage
+  // maps, analysisStartDate, and the computed schedule pointer are server-managed
+  // and must never be written straight from the request body.
+  const { name, projects, skipAsDefaultHoldout, environmentSettings } =
+    req.body;
+  const scheduleInput = req.body.statusUpdateSchedule;
 
-  if (updates.statusUpdateSchedule !== undefined) {
+  const updates: UpdateProps<HoldoutInterface> = {};
+  if (name !== undefined) updates.name = name;
+  if (projects !== undefined) updates.projects = projects;
+  if (skipAsDefaultHoldout !== undefined) {
+    updates.skipAsDefaultHoldout = skipAsDefaultHoldout;
+  }
+  if (environmentSettings !== undefined) {
+    updates.environmentSettings = environmentSettings;
+  }
+
+  assertValidHoldoutEnvironments(
+    context,
+    environmentSettings,
+    holdout.environmentSettings,
+  );
+
+  if (scheduleInput !== undefined) {
     const { statusUpdateSchedule, nextScheduledStatusUpdate } =
-      normalizeHoldoutScheduleUpdates({
-        holdout,
-        experiment,
-        scheduleInput: updates.statusUpdateSchedule,
-      });
+      normalizeHoldoutScheduleUpdates({ holdout, experiment, scheduleInput });
     updates.statusUpdateSchedule = statusUpdateSchedule;
     updates.nextScheduledStatusUpdate = nextScheduledStatusUpdate;
   }
@@ -278,7 +298,7 @@ export const updateHoldout = async (
       ? getEnabledHoldoutEnvironments(updates.environmentSettings)
       : undefined,
     isTargetingChange: false,
-    isScheduleChange: (req.body.statusUpdateSchedule ?? null) !== null,
+    isScheduleChange: (scheduleInput ?? null) !== null,
   });
 
   // Only when the scope actually changes, so a Holdout already holding a
@@ -288,6 +308,20 @@ export const updateHoldout = async (
   }
 
   const updatedHoldout = await context.models.holdout.update(holdout, updates);
+
+  // Environment changes move a running holdout's SDK payload footprint, so
+  // refresh (mirrors the REST update path). Targeting never comes through here.
+  if (
+    experiment.status === "running" &&
+    updates.environmentSettings !== undefined
+  ) {
+    refreshHoldoutPayload(context, {
+      holdout: updatedHoldout,
+      previousHoldout: holdout,
+      event: "Holdout updated",
+    });
+  }
+
   return res.status(200).json({ status: 200, holdout: updatedHoldout });
 };
 
@@ -335,19 +369,14 @@ export const editStatus = async (
     stage = req.body.holdoutRunningStatus ?? "running";
   }
 
-  // Starting the holdout (draft -> running) publishes to its enabled
-  // environments, so it needs run permission, mirroring the REST start path.
-  if (stage === "running" && experiment.status === "draft") {
-    const enabledEnvs = getEnabledHoldoutEnvironments(
+  // Lifecycle transitions change what live SDKs serve, so gate on run permission
+  // for the holdout's enabled environments
+  assertCanRunHoldoutEnvironments(context, {
+    enabledEnvironments: getEnabledHoldoutEnvironments(
       holdout.environmentSettings,
-    );
-    if (
-      enabledEnvs.length > 0 &&
-      !context.permissions.canRunHoldout(holdout, enabledEnvs)
-    ) {
-      context.permissions.throwPermissionError();
-    }
-  }
+    ),
+    projects: holdout.projects,
+  });
 
   await setHoldoutStage(context, { holdout, experiment, stage });
 
@@ -373,7 +402,7 @@ export const deleteHoldout = async (
   const experiment = await getExperimentById(context, holdout.experimentId);
 
   if (!experiment) {
-    res.status(403).json({
+    res.status(404).json({
       status: 404,
       message: "Holdout experiment not found",
     });

--- a/packages/back-end/src/routers/holdout/holdout.controller.ts
+++ b/packages/back-end/src/routers/holdout/holdout.controller.ts
@@ -258,9 +258,8 @@ export const updateHoldout = async (
     });
   }
 
-  // Whitelist the client-settable holdout fields. experimentId, the linkage
-  // maps, analysisStartDate, and the computed schedule pointer are server-managed
-  // and must never be written straight from the request body.
+  // Whitelist: experimentId, the linkage maps, analysisStartDate and the computed
+  // schedule pointer are server-managed and must never come from the body.
   const { name, projects, skipAsDefaultHoldout, environmentSettings } =
     req.body;
   const scheduleInput = req.body.statusUpdateSchedule;
@@ -288,9 +287,8 @@ export const updateHoldout = async (
     updates.nextScheduledStatusUpdate = nextScheduledStatusUpdate;
   }
 
-  // Shared with the REST update handler. The UI never sends targeting through
-  // this path (it lives on the companion experiment), but the gate still takes
-  // the flag so both callers stay identical.
+  // Shared with the REST update handler. Targeting lives on the companion
+  // experiment and never comes through here, but the gate still takes the flag.
   assertCanUpdateHoldout(context, {
     holdout,
     updatedProjects: updates.projects,
@@ -310,11 +308,12 @@ export const updateHoldout = async (
 
   const updatedHoldout = await context.models.holdout.update(holdout, updates);
 
-  // Environment changes move a running holdout's SDK payload footprint, so
-  // refresh (mirrors the REST update path). Targeting never comes through here.
+  // Projects and environments move a running holdout's payload footprint
+  // (mirrors the REST update path).
   if (
     experiment.status === "running" &&
-    updates.environmentSettings !== undefined
+    (updates.environmentSettings !== undefined ||
+      updates.projects !== undefined)
   ) {
     refreshHoldoutPayload(context, {
       holdout: updatedHoldout,
@@ -370,8 +369,7 @@ export const editStatus = async (
     stage = req.body.holdoutRunningStatus ?? "running";
   }
 
-  // Lifecycle transitions change what live SDKs serve, so gate on run permission
-  // for the holdout's enabled environments
+  // Lifecycle transitions change what live SDKs serve.
   assertCanRunHoldoutEnvironments(context, {
     enabledEnvironments: getEnabledHoldoutEnvironments(
       holdout.environmentSettings,

--- a/packages/back-end/src/routers/holdout/holdout.controller.ts
+++ b/packages/back-end/src/routers/holdout/holdout.controller.ts
@@ -8,6 +8,7 @@ import { FeatureInterface } from "shared/types/feature";
 import { EventUserForResponseLocals } from "shared/types/events/event-types";
 import {
   getApplicableEnvIds,
+  getEnabledHoldoutEnvironments,
   HoldoutStage,
   PermissionError,
 } from "shared/util";
@@ -25,6 +26,7 @@ import {
 } from "back-end/src/models/ExperimentModel";
 import {
   setHoldoutStage,
+  assertCanUpdateHoldout,
   assertHoldoutScopeCoversLinked,
   createHoldoutWithExperiment,
   deleteHoldoutAndExperiment,
@@ -98,9 +100,7 @@ export const getHoldout = async (
     experiment: holdoutExperiment,
     linkedFeatures,
     linkedExperiments,
-    envs: Object.keys(holdout.environmentSettings).filter(
-      (e) => holdout.environmentSettings[e].enabled,
-    ),
+    envs: getEnabledHoldoutEnvironments(holdout.environmentSettings),
   });
 };
 
@@ -268,8 +268,21 @@ export const updateHoldout = async (
     updates.nextScheduledStatusUpdate = nextScheduledStatusUpdate;
   }
 
-  // Only when the scope actually changes — a Holdout already holding a stranded
-  // link (created before this guard existed) must stay editable so it can be fixed.
+  // Shared with the REST update handler. The UI never sends targeting through
+  // this path (it lives on the companion experiment), but the gate still takes
+  // the flag so both callers stay identical.
+  assertCanUpdateHoldout(context, {
+    holdout,
+    updatedProjects: updates.projects,
+    requestedEnabledEnvironments: updates.environmentSettings
+      ? getEnabledHoldoutEnvironments(updates.environmentSettings)
+      : undefined,
+    isTargetingChange: false,
+    isScheduleChange: (req.body.statusUpdateSchedule ?? null) !== null,
+  });
+
+  // Only when the scope actually changes, so a Holdout already holding a
+  // stranded link stays editable to be fixed.
   if (updates.projects && !isEqual(updates.projects, holdout.projects)) {
     await assertHoldoutScopeCoversLinked(context, holdout, updates.projects);
   }
@@ -320,6 +333,20 @@ export const editStatus = async (
     stage = "running";
   } else {
     stage = req.body.holdoutRunningStatus ?? "running";
+  }
+
+  // Starting the holdout (draft -> running) publishes to its enabled
+  // environments, so it needs run permission, mirroring the REST start path.
+  if (stage === "running" && experiment.status === "draft") {
+    const enabledEnvs = getEnabledHoldoutEnvironments(
+      holdout.environmentSettings,
+    );
+    if (
+      enabledEnvs.length > 0 &&
+      !context.permissions.canRunHoldout(holdout, enabledEnvs)
+    ) {
+      context.permissions.throwPermissionError();
+    }
   }
 
   await setHoldoutStage(context, { holdout, experiment, stage });

--- a/packages/back-end/src/routers/holdout/holdout.controller.ts
+++ b/packages/back-end/src/routers/holdout/holdout.controller.ts
@@ -299,6 +299,7 @@ export const updateHoldout = async (
       : undefined,
     isTargetingChange: false,
     isScheduleChange: (scheduleInput ?? null) !== null,
+    isRunning: experiment.status === "running",
   });
 
   // Only when the scope actually changes, so a Holdout already holding a

--- a/packages/back-end/src/routers/holdout/holdout.controller.ts
+++ b/packages/back-end/src/routers/holdout/holdout.controller.ts
@@ -297,12 +297,16 @@ export const updateHoldout = async (
       : undefined,
     isTargetingChange: false,
     isScheduleChange: (scheduleInput ?? null) !== null,
+    isArchiveChange: false,
     isRunning: experiment.status === "running",
   });
 
   // Only when the scope actually changes, so a Holdout already holding a
   // stranded link stays editable to be fixed.
   if (updates.projects && !isEqual(updates.projects, holdout.projects)) {
+    if (updates.projects.length) {
+      await context.models.projects.ensureProjectsExist(updates.projects);
+    }
     await assertHoldoutScopeCoversLinked(context, holdout, updates.projects);
   }
 

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -1,9 +1,11 @@
 import { v4 as uuidv4 } from "uuid";
+import isEqual from "lodash/isEqual";
 import { getValidDate } from "shared/dates";
 import { DEFAULT_SEQUENTIAL_TESTING_TUNING_PARAMETER } from "shared/constants";
 import {
   DEFAULT_HOLDOUT_SIZE,
   generateVariationId,
+  getEnabledHoldoutEnvironments,
   getHoldoutStage,
   holdoutSizeToCoverage,
   HoldoutStage,
@@ -52,6 +54,69 @@ import {
   validateExperimentData,
   validateVariationIds,
 } from "back-end/src/services/experiments";
+
+export function assertCanRunHoldoutEnvironments(
+  context: ReqContext | ApiReqContext,
+  {
+    enabledEnvironments,
+    projects,
+  }: {
+    enabledEnvironments: string[];
+    projects: string[];
+  },
+): void {
+  if (enabledEnvironments.length === 0) return;
+  if (!context.permissions.canRunHoldout({ projects }, enabledEnvironments)) {
+    context.permissions.throwPermissionError();
+  }
+}
+
+/**
+ * Update authorization shared by the REST API (`handleApiUpdate`) and the UI
+ * endpoint (`updateHoldout`) so the two cannot drift. Update permission is
+ * always required (on the current and, when moving the Holdout, destination
+ * scope). Targeting/sizing and schedule changes reach live SDK payloads, so
+ * they additionally require run permission on the union of current and
+ * newly-requested environments; environment-only changes and clearing the
+ * schedule do not. The UI never sends targeting here but still passes the flag.
+ */
+export function assertCanUpdateHoldout(
+  context: ReqContext | ApiReqContext,
+  {
+    holdout,
+    updatedProjects,
+    requestedEnabledEnvironments,
+    isTargetingChange,
+    isScheduleChange,
+  }: {
+    holdout: HoldoutInterface;
+    updatedProjects?: string[];
+    requestedEnabledEnvironments?: string[];
+    isTargetingChange: boolean;
+    isScheduleChange: boolean;
+  },
+): void {
+  if (
+    !context.permissions.canUpdateHoldout(holdout, {
+      projects: updatedProjects ?? holdout.projects,
+    })
+  ) {
+    context.permissions.throwPermissionError();
+  }
+
+  if (!isTargetingChange && !isScheduleChange) return;
+
+  const enabledEnvironments = Array.from(
+    new Set([
+      ...getEnabledHoldoutEnvironments(holdout.environmentSettings),
+      ...(requestedEnabledEnvironments ?? []),
+    ]),
+  );
+  assertCanRunHoldoutEnvironments(context, {
+    enabledEnvironments,
+    projects: updatedProjects ?? holdout.projects,
+  });
+}
 
 export async function canLinkExperimentToHoldoutFromFeatures(
   context: ReqContext | ApiReqContext,
@@ -368,6 +433,16 @@ export async function updateHoldoutWithExperiment(
     body: ApiUpdateHoldoutBody;
   },
 ): Promise<{ holdout: HoldoutInterface; experiment: ExperimentInterface }> {
+  // Narrowing the scope must not strand linked entities (matches the internal
+  // update endpoint). Only when it actually changes, so a Holdout already
+  // holding a stranded link stays editable to be fixed.
+  if (
+    body.projects !== undefined &&
+    !isEqual(body.projects, holdout.projects)
+  ) {
+    await assertHoldoutScopeCoversLinked(context, holdout, body.projects);
+  }
+
   const experimentChanges: Partial<ExperimentInterface> = {};
 
   // 1. Phase-level targeting and sizing.

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -39,6 +39,7 @@ import {
   getFeaturesByIds,
   removeHoldoutFromFeature,
 } from "back-end/src/models/FeatureModel";
+import { CasConflictError } from "back-end/src/models/BaseModel";
 import { getEnvironmentIdsFromOrg } from "back-end/src/services/organizations";
 import { getEnabledEnvironments } from "back-end/src/util/features";
 import { isHoldoutAvailableForProject } from "back-end/src/services/holdout-availability";
@@ -308,8 +309,14 @@ export async function createHoldoutWithExperiment(
 /**
  * Roll an experiment back to a prior snapshot after its companion holdout write
  * failed (the two documents share no transaction). Returns whether the restore
- * succeeded so callers can gate follow-up work; on failure we log for manual
- * reconciliation rather than masking the caller's original error.
+ * succeeded so callers can gate follow-up work.
+ *
+ * The restore is guarded on the experiment's `dateUpdated`, which callers pass
+ * from the value our own write persisted. If another request has since written
+ * the experiment, the guard no longer matches and we intentionally skip the
+ * rollback rather than clobbering that request's changes with stale values. On
+ * any other failure we log for manual reconciliation rather than masking the
+ * caller's original error.
  */
 async function rollbackExperimentAfterHoldoutFailure(
   context: ReqContext | ApiReqContext,
@@ -318,9 +325,20 @@ async function rollbackExperimentAfterHoldoutFailure(
   logContext: string,
 ): Promise<boolean> {
   try {
-    await updateExperiment({ context, experiment, changes: revertChanges });
+    await updateExperiment({
+      context,
+      experiment,
+      changes: revertChanges,
+      guard: { dateUpdated: experiment.dateUpdated },
+    });
     return true;
   } catch (revertError) {
+    if (revertError instanceof CasConflictError) {
+      logger.warn(
+        `Skipped rolling back experiment "${experiment.id}" ${logContext}; it was modified concurrently, so the other write is left intact and no reconciliation is needed`,
+      );
+      return false;
+    }
     logger.error(
       revertError,
       `Failed to roll back experiment "${experiment.id}" ${logContext}; the holdout and experiment are now inconsistent and need reconciling by hand`,

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -44,7 +44,8 @@ import { getEnabledEnvironments } from "back-end/src/util/features";
 import { isHoldoutAvailableForProject } from "back-end/src/services/holdout-availability";
 import { getAffectedSDKPayloadKeys } from "back-end/src/util/holdouts";
 import { queueSDKPayloadRefresh } from "back-end/src/services/features";
-import { BadRequestError, InternalServerError } from "back-end/src/util/errors";
+import { BadRequestError } from "back-end/src/util/errors";
+import { logger } from "back-end/src/util/logger";
 import {
   getChangesToStartExperiment,
   validateExperimentData,
@@ -301,11 +302,31 @@ export async function createHoldoutWithExperiment(
     linkedExperiments: {},
   });
 
-  if (!holdout) {
-    throw new InternalServerError("Failed to create holdout");
-  }
-
   return { holdout, experiment, datasource, metricIds };
+}
+
+/**
+ * Roll an experiment back to a prior snapshot after its companion holdout write
+ * failed (the two documents share no transaction). Returns whether the restore
+ * succeeded so callers can gate follow-up work; on failure we log for manual
+ * reconciliation rather than masking the caller's original error.
+ */
+async function rollbackExperimentAfterHoldoutFailure(
+  context: ReqContext | ApiReqContext,
+  experiment: ExperimentInterface,
+  revertChanges: Partial<ExperimentInterface>,
+  logContext: string,
+): Promise<boolean> {
+  try {
+    await updateExperiment({ context, experiment, changes: revertChanges });
+    return true;
+  } catch (revertError) {
+    logger.error(
+      revertError,
+      `Failed to roll back experiment "${experiment.id}" ${logContext}; the holdout and experiment are now inconsistent and need reconciling by hand`,
+    );
+    return false;
+  }
 }
 
 /**
@@ -376,12 +397,9 @@ export async function updateHoldoutWithExperiment(
   if (body.owner !== undefined) {
     experimentChanges.owner = await resolveOwnerToUserId(body.owner, context);
   }
-  // Validate analysis settings as a whole against the *effective* post-update
-  // values: the datasource exists, the goal/secondary metrics belong to it,
-  // and the assignment query is one of its exposure queries. Otherwise a bad
-  // id — including an old exposure query or metric left behind when only the
-  // datasource changes — slips through to snapshot/query time and fails there
-  // with a confusing error.
+  // Validate analysis settings against the effective post-update values so a
+  // stale metric or exposure query (e.g. left behind when only the datasource
+  // changes) is rejected here rather than failing later at query time.
   if (
     body.datasourceId !== undefined ||
     body.assignmentQueryId !== undefined ||
@@ -440,20 +458,19 @@ export async function updateHoldoutWithExperiment(
     );
   }
 
-  // Persist the holdout document before touching the companion experiment. The
-  // holdout write runs its own validation (`beforeUpdate` rejects bad schedule
-  // dates) but has no side effects, while `updateExperiment` commits and
-  // triggers an SDK payload refresh. Writing the holdout first means a
-  // validation failure aborts the request before any experiment change or
-  // refresh lands, so the two documents can't diverge (e.g. a mirrored `name`)
-  // on rejected input. Experiment-side changes are already fully validated
-  // above, so the trailing write only fails on infrastructure errors.
-  const updatedHoldout = Object.keys(holdoutUpdates).length
-    ? await context.models.holdout.update(holdout, holdoutUpdates)
-    : holdout;
+  // Persist the experiment first, then the holdout. With no cross-document
+  // transaction, a holdout failure after the experiment write is committed
+  // would leave the pair inconsistent, so snapshot the changed experiment
+  // fields and roll them back on failure (mirrors `setHoldoutStage`).
+  const originalExperimentValues: Partial<ExperimentInterface> = {};
+  for (const key of Object.keys(experimentChanges)) {
+    (originalExperimentValues as Record<string, unknown>)[key] = (
+      experiment as Record<string, unknown>
+    )[key];
+  }
 
-  // Single write to the companion experiment.
-  if (Object.keys(experimentChanges).length) {
+  const experimentChanged = Object.keys(experimentChanges).length > 0;
+  if (experimentChanged) {
     experiment = await updateExperiment({
       context,
       experiment,
@@ -461,7 +478,27 @@ export async function updateHoldoutWithExperiment(
     });
   }
 
-  return { holdout: updatedHoldout, experiment };
+  if (!Object.keys(holdoutUpdates).length) {
+    return { holdout, experiment };
+  }
+
+  try {
+    const updatedHoldout = await context.models.holdout.update(
+      holdout,
+      holdoutUpdates,
+    );
+    return { holdout: updatedHoldout, experiment };
+  } catch (e) {
+    if (experimentChanged) {
+      await rollbackExperimentAfterHoldoutFailure(
+        context,
+        experiment,
+        originalExperimentValues,
+        "after holdout update failed",
+      );
+    }
+    throw e;
+  }
 }
 
 export function normalizeHoldoutScheduleUpdates({
@@ -605,6 +642,12 @@ export async function setHoldoutStage(
   let phases = [...experiment.phases] as ExperimentPhase[];
   const changes: Changeset = {};
 
+  // Snapshot the only experiment fields any branch below mutates, before those
+  // mutations run, so a failed holdout write can be compensated by restoring
+  // them (see `commitTransition`).
+  const originalStatus = experiment.status;
+  const originalPhases = structuredClone(experiment.phases);
+
   const refreshPayload = (event: string) =>
     queueSDKPayloadRefresh({
       context,
@@ -619,6 +662,37 @@ export async function setHoldoutStage(
       },
     });
 
+  // Commit a stage transition across both documents. With no cross-document
+  // transaction, a holdout failure after the experiment write is committed
+  // rolls the experiment back to its pre-transition status and phases and
+  // rethrows, leaving the schedule pointer untouched so a retry re-selects the
+  // still-due holdout.
+  const commitTransition = async (
+    event: string,
+    holdoutChanges: UpdateProps<HoldoutInterface>,
+  ) => {
+    const updatedExperiment = await updateExperiment({
+      context,
+      experiment,
+      changes,
+    });
+    refreshPayload(event);
+    try {
+      await context.models.holdout.update(holdout, holdoutChanges);
+    } catch (e) {
+      const reverted = await rollbackExperimentAfterHoldoutFailure(
+        context,
+        updatedExperiment,
+        { status: originalStatus, phases: originalPhases },
+        `after holdout update failed during "${event}"`,
+      );
+      if (reverted) {
+        refreshPayload(`Reverted: ${event}`);
+      }
+      throw e;
+    }
+  };
+
   switch (stage) {
     case "stopped": {
       if (phases[0]) {
@@ -628,9 +702,7 @@ export async function setHoldoutStage(
         phases[1].dateEnded = new Date();
       }
       Object.assign(changes, { phases, status: "stopped" });
-      await updateExperiment({ context, experiment, changes });
-      refreshPayload("Status changed to stopped");
-      await context.models.holdout.update(holdout, {
+      await commitTransition("Status changed to stopped", {
         nextScheduledStatusUpdate: getNextScheduledStatusUpdateForStage(
           holdout.statusUpdateSchedule,
           "stopped",
@@ -645,9 +717,7 @@ export async function setHoldoutStage(
       }
       phases[0].dateEnded = undefined;
       Object.assign(changes, { phases: [phases[0]], status: "draft" });
-      await updateExperiment({ context, experiment, changes });
-      refreshPayload("Status changed to draft");
-      await context.models.holdout.update(holdout, {
+      await commitTransition("Status changed to draft", {
         analysisStartDate: undefined,
       });
       return;
@@ -663,9 +733,7 @@ export async function setHoldoutStage(
           changes,
           await getChangesToStartExperiment(context, experiment),
         );
-        await updateExperiment({ context, experiment, changes });
-        refreshPayload("Status changed to running");
-        await context.models.holdout.update(holdout, {
+        await commitTransition("Status changed to running", {
           analysisStartDate: undefined,
           nextScheduledStatusUpdate: getNextScheduledStatusUpdateForStage(
             holdout.statusUpdateSchedule,
@@ -680,9 +748,7 @@ export async function setHoldoutStage(
         phases = [phases[0]];
       }
       Object.assign(changes, { phases, status: "running" });
-      await updateExperiment({ context, experiment, changes });
-      refreshPayload("Status changed to running");
-      await context.models.holdout.update(holdout, {
+      await commitTransition("Status changed to running", {
         analysisStartDate: undefined,
       });
       return;
@@ -705,9 +771,7 @@ export async function setHoldoutStage(
         name: "Analysis",
       };
       Object.assign(changes, { phases, status: "running" });
-      await updateExperiment({ context, experiment, changes });
-      refreshPayload("Status changed to analysis period");
-      await context.models.holdout.update(holdout, {
+      await commitTransition("Status changed to analysis period", {
         analysisStartDate,
         nextScheduledStatusUpdate: getNextScheduledStatusUpdateForStage(
           holdout.statusUpdateSchedule,

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -411,15 +411,6 @@ export async function updateHoldoutWithExperiment(
     experimentChanges.name = body.name;
   }
 
-  // Single write to the companion experiment.
-  if (Object.keys(experimentChanges).length) {
-    experiment = await updateExperiment({
-      context,
-      experiment,
-      changes: experimentChanges,
-    });
-  }
-
   // 3. Fields on the holdout document itself.
   const holdoutUpdates: UpdateProps<HoldoutInterface> = {};
   for (const field of HOLDOUT_API_UPDATE_FIELDS) {
@@ -449,9 +440,26 @@ export async function updateHoldoutWithExperiment(
     );
   }
 
+  // Persist the holdout document before touching the companion experiment. The
+  // holdout write runs its own validation (`beforeUpdate` rejects bad schedule
+  // dates) but has no side effects, while `updateExperiment` commits and
+  // triggers an SDK payload refresh. Writing the holdout first means a
+  // validation failure aborts the request before any experiment change or
+  // refresh lands, so the two documents can't diverge (e.g. a mirrored `name`)
+  // on rejected input. Experiment-side changes are already fully validated
+  // above, so the trailing write only fails on infrastructure errors.
   const updatedHoldout = Object.keys(holdoutUpdates).length
     ? await context.models.holdout.update(holdout, holdoutUpdates)
     : holdout;
+
+  // Single write to the companion experiment.
+  if (Object.keys(experimentChanges).length) {
+    experiment = await updateExperiment({
+      context,
+      experiment,
+      changes: experimentChanges,
+    });
+  }
 
   return { holdout: updatedHoldout, experiment };
 }

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -311,16 +311,18 @@ export async function createHoldoutWithExperiment(
  * failed (the two documents share no transaction). Returns whether the restore
  * succeeded so callers can gate follow-up work.
  *
- * The restore is guarded on the experiment's `dateUpdated`, which callers pass
- * from the value our own write persisted. If another request has since written
- * the experiment, the guard no longer matches and we intentionally skip the
- * rollback rather than clobbering that request's changes with stale values. On
- * any other failure we log for manual reconciliation rather than masking the
- * caller's original error.
+ * The restore is guarded on the exact field values this operation wrote, not the
+ * whole-document `dateUpdated`. An unrelated edit to some other experiment field
+ * therefore no longer blocks compensation, while a concurrent write to one of the
+ * fields we set fails the guard — in that case we skip the rollback rather than
+ * clobber the newer value with our stale revert, and warn that the pair may need
+ * reconciling. On any other failure we log for manual reconciliation rather than
+ * masking the caller's original error.
  */
 async function rollbackExperimentAfterHoldoutFailure(
   context: ReqContext | ApiReqContext,
   experiment: ExperimentInterface,
+  writtenChanges: Partial<ExperimentInterface>,
   revertChanges: Partial<ExperimentInterface>,
   logContext: string,
 ): Promise<boolean> {
@@ -329,13 +331,13 @@ async function rollbackExperimentAfterHoldoutFailure(
       context,
       experiment,
       changes: revertChanges,
-      guard: { dateUpdated: experiment.dateUpdated },
+      guard: writtenChanges,
     });
     return true;
   } catch (revertError) {
     if (revertError instanceof CasConflictError) {
       logger.warn(
-        `Skipped rolling back experiment "${experiment.id}" ${logContext}; it was modified concurrently, so the other write is left intact and no reconciliation is needed`,
+        `Skipped rolling back experiment "${experiment.id}" ${logContext}; one of the fields it wrote was modified concurrently, so the other write is left intact and the holdout and experiment may need reconciling by hand`,
       );
       return false;
     }
@@ -511,6 +513,7 @@ export async function updateHoldoutWithExperiment(
       await rollbackExperimentAfterHoldoutFailure(
         context,
         experiment,
+        experimentChanges,
         originalExperimentValues,
         "after holdout update failed",
       );
@@ -701,6 +704,7 @@ export async function setHoldoutStage(
       const reverted = await rollbackExperimentAfterHoldoutFailure(
         context,
         updatedExperiment,
+        changes,
         { status: originalStatus, phases: originalPhases },
         `after holdout update failed during "${event}"`,
       );

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -13,6 +13,7 @@ import {
   CreateHoldoutInput,
   HoldoutInterface,
   HoldoutNextScheduledStatusUpdate,
+  SavedGroupTargeting,
 } from "shared/validators";
 import {
   Changeset,
@@ -44,6 +45,7 @@ import {
   validateExperimentData,
   validateVariationIds,
 } from "back-end/src/services/experiments";
+import { validateExperimentChange } from "./experimentChanges/changeExperimentStatus";
 
 export async function canLinkExperimentToHoldoutFromFeatures(
   context: ReqContext | ApiReqContext,
@@ -252,8 +254,8 @@ export async function createHoldoutWithExperiment(
     hypothesis: "",
     goalMetrics: data.goalMetrics || [],
     secondaryMetrics: data.secondaryMetrics || [],
-    guardrailMetrics: [],
-    activationMetric: "",
+    guardrailMetrics: data.guardrailMetrics || [],
+    activationMetric: data.activationMetric || "",
     metricOverrides: [],
     segment: "",
     queryFilter: "",
@@ -560,10 +562,57 @@ export async function setHoldoutStage(
   }
 }
 
-// Delete a holdout along with its underlying experiment, unlink it from its
-// linked features and experiments, and refresh affected SDK payloads. Callers
-// are responsible for experiment-level permission checks; deleting the holdout
-// itself enforces canDeleteHoldout.
+/**
+ * Applies phase-level targeting and sizing changes to a holdout's companion
+ * experiment through the same validate/update path the internal targeting
+ * endpoint uses, so the stored phases and the SDK payload stay correct.
+ * Only the fields that are provided are changed. Callers are responsible for
+ * the `canRunHoldout` permission check.
+ */
+export async function applyHoldoutTargetingChanges(
+  context: ReqContext | ApiReqContext,
+  {
+    experiment,
+    coverage,
+    condition,
+    savedGroups,
+    hashAttribute,
+  }: {
+    experiment: ExperimentInterface;
+    coverage?: number;
+    condition?: string;
+    savedGroups?: SavedGroupTargeting[];
+    hashAttribute?: string;
+  },
+): Promise<ExperimentInterface> {
+  const phases = [...experiment.phases];
+  if (!phases.length) {
+    throw new Error("Holdout does not have a phase to target");
+  }
+
+  const current = phases[phases.length - 1];
+  phases[phases.length - 1] = {
+    ...current,
+    condition: condition ?? current.condition,
+    savedGroups: savedGroups ?? current.savedGroups,
+    coverage: coverage ?? current.coverage,
+  };
+
+  const changes: Changeset = { phases };
+  if (hashAttribute !== undefined) {
+    changes.hashAttribute = hashAttribute;
+  }
+
+  await validateExperimentChange({ context, experiment, changes });
+  return updateExperiment({ context, experiment, changes });
+}
+
+/**
+ * Delete a holdout along with its underlying experiment, unlink it from its
+ * linked features and experiments, and refresh affected SDK payloads. Callers
+ * are responsible for experiment-level permission checks; deleting the holdout
+ * itself enforces canDeleteHoldout.
+ */
 export async function deleteHoldoutAndExperiment(
   context: ReqContext,
   holdout: HoldoutInterface,

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 import isEqual from "lodash/isEqual";
 import { getValidDate } from "shared/dates";
+import { getActivePhase } from "shared/experiments";
 import { DEFAULT_SEQUENTIAL_TESTING_TUNING_PARAMETER } from "shared/constants";
 import {
   DEFAULT_HOLDOUT_SIZE,
@@ -53,6 +54,7 @@ import {
   validateExperimentData,
   validateVariationIds,
 } from "back-end/src/services/experiments";
+import { assertRegisteredAttributes } from "back-end/src/services/attributes";
 
 export function assertCanRunHoldoutEnvironments(
   context: ReqContext | ApiReqContext,
@@ -106,8 +108,8 @@ export function assertValidHoldoutEnvironments(
  * permission is always required, on the destination scope when the Holdout is
  * moving. A change additionally needs run permission when it authorizes a
  * deployment: schedule changes at any stage, since they hand the agenda job
- * authority to transition the Holdout later; targeting and environment changes
- * only while it is running, since that is when they reach live SDK payloads.
+ * authority to transition the Holdout later; targeting, environment and archive
+ * changes only while it is running, since that is when they reach the payload.
  */
 export function assertCanUpdateHoldout(
   context: ReqContext | ApiReqContext,
@@ -117,6 +119,7 @@ export function assertCanUpdateHoldout(
     requestedEnabledEnvironments,
     isTargetingChange,
     isScheduleChange,
+    isArchiveChange,
     isRunning,
   }: {
     holdout: HoldoutInterface;
@@ -124,6 +127,7 @@ export function assertCanUpdateHoldout(
     requestedEnabledEnvironments?: string[];
     isTargetingChange: boolean;
     isScheduleChange: boolean;
+    isArchiveChange: boolean;
     isRunning: boolean;
   },
 ): void {
@@ -138,7 +142,8 @@ export function assertCanUpdateHoldout(
   const isEnvironmentChange = requestedEnabledEnvironments !== undefined;
   const requiresRunPermission =
     isScheduleChange ||
-    (isRunning && (isTargetingChange || isEnvironmentChange));
+    (isRunning &&
+      (isTargetingChange || isEnvironmentChange || isArchiveChange));
   if (!requiresRunPermission) return;
 
   const enabledEnvironments = Array.from(
@@ -387,6 +392,14 @@ export async function createHoldoutWithExperiment(
     await context.models.projects.ensureProjectsExist(data.projects);
   }
 
+  assertRegisteredAttributes(
+    context,
+    { hashAttribute: data.hashAttribute, condition: data.targetingCondition },
+    "holdout",
+    undefined,
+    data.projects ?? [],
+  );
+
   assertValidHoldoutEnvironments(context, data.environmentSettings);
 
   const variations = [
@@ -571,11 +584,14 @@ export async function updateHoldoutWithExperiment(
     holdout.environmentSettings,
   );
 
-  // Narrowing the project scope must not strand linked entities
   if (
     body.projects !== undefined &&
     !isEqual(body.projects, holdout.projects)
   ) {
+    if (body.projects.length) {
+      await context.models.projects.ensureProjectsExist(body.projects);
+    }
+    // Narrowing the project scope must not strand linked entities
     await assertHoldoutScopeCoversLinked(context, holdout, body.projects);
   }
 
@@ -600,6 +616,23 @@ export async function updateHoldoutWithExperiment(
         );
       }
     }
+
+    // Passing the persisted values as `existingParts` limits this to attributes
+    // the request actually changes, so a Holdout that predates the org's
+    // registration setting stays editable.
+    assertRegisteredAttributes(
+      context,
+      {
+        hashAttribute: body.hashAttribute,
+        condition: body.targetingCondition,
+      },
+      "holdout",
+      {
+        hashAttribute: experiment.hashAttribute || "id",
+        condition: getActivePhase(experiment)?.condition,
+      },
+      body.projects ?? holdout.projects,
+    );
 
     // The analysis-period phase must carry the same targeting as the payload
     // phase, so mirror the change across every phase, not just the last.

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -41,7 +41,6 @@ import {
   getFeaturesByIds,
   removeHoldoutFromFeature,
 } from "back-end/src/models/FeatureModel";
-import { CasConflictError } from "back-end/src/models/BaseModel";
 import { getEnvironmentIdsFromOrg } from "back-end/src/services/organizations";
 import { getEnabledEnvironments } from "back-end/src/util/features";
 import { isHoldoutAvailableForProject } from "back-end/src/services/holdout-availability";
@@ -416,22 +415,14 @@ export async function createHoldoutWithExperiment(
 }
 
 /**
- * Roll an experiment back to a prior snapshot after its companion holdout write
- * failed (the two documents share no transaction). Returns whether the restore
- * succeeded so callers can gate follow-up work.
- *
- * The restore is guarded on the exact field values this operation wrote, not the
- * whole-document `dateUpdated`. An unrelated edit to some other experiment field
- * therefore no longer blocks compensation, while a concurrent write to one of the
- * fields we set fails the guard — in that case we skip the rollback rather than
- * clobber the newer value with our stale revert, and warn that the pair may need
- * reconciling. On any other failure we log for manual reconciliation rather than
- * masking the caller's original error.
+ * Roll an experiment back after its companion holdout write failed (the two
+ * documents share no transaction). Returns whether the restore succeeded so
+ * callers can gate follow-up work; on failure it logs for manual reconciliation
+ * rather than masking the caller's original error.
  */
 async function rollbackExperimentAfterHoldoutFailure(
   context: ReqContext | ApiReqContext,
   experiment: ExperimentInterface,
-  writtenChanges: Partial<ExperimentInterface>,
   revertChanges: Partial<ExperimentInterface>,
   logContext: string,
 ): Promise<boolean> {
@@ -440,16 +431,9 @@ async function rollbackExperimentAfterHoldoutFailure(
       context,
       experiment,
       changes: revertChanges,
-      guard: writtenChanges,
     });
     return true;
   } catch (revertError) {
-    if (revertError instanceof CasConflictError) {
-      logger.warn(
-        `Skipped rolling back experiment "${experiment.id}" ${logContext}; one of the fields it wrote was modified concurrently, so the other write is left intact and the holdout and experiment may need reconciling by hand`,
-      );
-      return false;
-    }
     logger.error(
       revertError,
       `Failed to roll back experiment "${experiment.id}" ${logContext}; the holdout and experiment are now inconsistent and need reconciling by hand`,
@@ -691,7 +675,6 @@ export async function updateHoldoutWithExperiment(
       await rollbackExperimentAfterHoldoutFailure(
         context,
         experiment,
-        experimentChanges,
         originalExperimentValues,
         "after holdout update failed",
       );
@@ -870,7 +853,6 @@ export async function setHoldoutStage(
       const reverted = await rollbackExperimentAfterHoldoutFailure(
         context,
         updatedExperiment,
-        changes,
         { status: originalStatus, phases: originalPhases },
         `after holdout update failed during "${event}"`,
       );

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -479,10 +479,8 @@ export function refreshHoldoutPayload(
 
 /**
  * Applies a validated REST update body to a Holdout and its companion
- * experiment. Splits the work across the three storage locations a Holdout
- * spans — the current experiment phase (targeting/sizing), the experiment
- * document (metadata and analysis settings), and the holdout document itself —
- * and returns the refreshed pair. Permission gating is the caller's job.
+ * experiment and returns the refreshed pair. Permission gating is the
+ * caller's job.
  */
 export async function updateHoldoutWithExperiment(
   context: ReqContext | ApiReqContext,
@@ -502,9 +500,7 @@ export async function updateHoldoutWithExperiment(
     holdout.environmentSettings,
   );
 
-  // Narrowing the scope must not strand linked entities (matches the internal
-  // update endpoint). Only when it actually changes, so a Holdout already
-  // holding a stranded link stays editable to be fixed.
+  // Narrowing the project scope must not strand linked entities
   if (
     body.projects !== undefined &&
     !isEqual(body.projects, holdout.projects)

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -697,7 +697,6 @@ export async function setHoldoutStage(
       experiment,
       changes,
     });
-    refreshPayload(event);
     try {
       await context.models.holdout.update(holdout, holdoutChanges);
     } catch (e) {
@@ -713,6 +712,7 @@ export async function setHoldoutStage(
       }
       throw e;
     }
+    refreshPayload(event);
   };
 
   switch (stage) {

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -767,12 +767,15 @@ export async function updateHoldoutWithExperiment(
     return { holdout: updatedHoldout, experiment };
   } catch (e) {
     if (experimentChanged) {
-      await rollbackExperimentAfterHoldoutFailure(
+      const reverted = await rollbackExperimentAfterHoldoutFailure(
         context,
         experiment,
         originalExperimentValues,
         "after holdout update failed",
       );
+      // See `commitTransition`: a failed revert leaves the experiment changed,
+      // so the cache needs rebuilding even though the write as a whole failed.
+      if (!reverted) refreshPayload(holdout);
     }
     throw e;
   }
@@ -948,9 +951,12 @@ export async function setHoldoutStage(
         { status: originalStatus, phases: originalPhases },
         `after holdout update failed during "${event}"`,
       );
-      if (reverted) {
-        refreshPayload(`Reverted: ${event}`);
-      }
+      // Refresh either way. A landed revert rebuilds to what the cache already
+      // has, but a failed one leaves the experiment write standing — and payload
+      // eligibility reads experiment.status, so the cache is then wrong.
+      refreshPayload(
+        reverted ? `Reverted: ${event}` : `Rollback failed: ${event}`,
+      );
       throw e;
     }
     refreshPayload(event);

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -551,18 +551,20 @@ export async function updateHoldoutWithExperiment(
       }
     }
 
-    const current = phases[phases.length - 1];
-    phases[phases.length - 1] = {
-      ...current,
-      condition: body.targetingCondition ?? current.condition,
-      savedGroups: body.savedGroupTargeting ?? current.savedGroups,
-      coverage:
-        body.holdoutSize === undefined
-          ? current.coverage
-          : holdoutSizeToCoverage(body.holdoutSize),
-    };
+    // A holdout in its analysis period has two phases ("Holdout" and
+    // "Analysis") that must carry identical targeting, so mirror the change
+    // across every phase rather than only the last one.
+    const targetingCoverage =
+      body.holdoutSize === undefined
+        ? undefined
+        : holdoutSizeToCoverage(body.holdoutSize);
 
-    experimentChanges.phases = phases;
+    experimentChanges.phases = phases.map((phase) => ({
+      ...phase,
+      condition: body.targetingCondition ?? phase.condition,
+      savedGroups: body.savedGroupTargeting ?? phase.savedGroups,
+      coverage: targetingCoverage ?? phase.coverage,
+    }));
     if (body.hashAttribute !== undefined) {
       experimentChanges.hashAttribute = body.hashAttribute;
     }

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -10,10 +10,15 @@ import {
   validateCondition,
 } from "shared/util";
 import {
+  ApiUpdateHoldoutBody,
   CreateHoldoutInput,
   HoldoutInterface,
   HoldoutNextScheduledStatusUpdate,
+  HOLDOUT_API_EXPERIMENT_UPDATE_FIELDS,
+  HOLDOUT_API_TARGETING_UPDATE_FIELDS,
+  HOLDOUT_API_UPDATE_FIELDS,
 } from "shared/validators";
+import { UpdateProps } from "shared/types/base-model";
 import {
   Changeset,
   ExperimentInterface,
@@ -21,6 +26,7 @@ import {
 } from "shared/types/experiment";
 import { FeatureInterface } from "shared/types/feature";
 import { DataSourceInterface } from "shared/types/datasource";
+import { resolveOwnerToUserId } from "back-end/src/services/owner";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import {
@@ -252,8 +258,8 @@ export async function createHoldoutWithExperiment(
     hypothesis: "",
     goalMetrics: data.goalMetrics || [],
     secondaryMetrics: data.secondaryMetrics || [],
-    guardrailMetrics: data.guardrailMetrics || [],
-    activationMetric: data.activationMetric || "",
+    guardrailMetrics: [],
+    activationMetric: "",
     metricOverrides: [],
     segment: "",
     queryFilter: "",
@@ -300,6 +306,154 @@ export async function createHoldoutWithExperiment(
   }
 
   return { holdout, experiment, datasource, metricIds };
+}
+
+/**
+ * Applies a validated REST update body to a Holdout and its companion
+ * experiment. Splits the work across the three storage locations a Holdout
+ * spans — the current experiment phase (targeting/sizing), the experiment
+ * document (metadata and analysis settings), and the holdout document itself —
+ * and returns the refreshed pair. Permission gating is the caller's job.
+ */
+export async function updateHoldoutWithExperiment(
+  context: ReqContext | ApiReqContext,
+  {
+    holdout,
+    experiment,
+    body,
+  }: {
+    holdout: HoldoutInterface;
+    experiment: ExperimentInterface;
+    body: ApiUpdateHoldoutBody;
+  },
+): Promise<{ holdout: HoldoutInterface; experiment: ExperimentInterface }> {
+  const experimentChanges: Partial<ExperimentInterface> = {};
+
+  // 1. Phase-level targeting and sizing.
+  const isTargetingChange = HOLDOUT_API_TARGETING_UPDATE_FIELDS.some(
+    (field) => body[field] !== undefined,
+  );
+  if (isTargetingChange) {
+    const phases = [...experiment.phases];
+    if (!phases.length) {
+      throw new Error("Holdout does not have a phase to target");
+    }
+
+    // Reject a malformed targeting condition up front rather than letting it
+    // break bucketing later. validateCondition treats undefined/"{}" as valid.
+    if (body.targetingCondition !== undefined) {
+      const conditionResult = validateCondition(body.targetingCondition);
+      if (!conditionResult.success) {
+        throw new Error(
+          `Invalid targeting condition: ${conditionResult.error}`,
+        );
+      }
+    }
+
+    const current = phases[phases.length - 1];
+    phases[phases.length - 1] = {
+      ...current,
+      condition: body.targetingCondition ?? current.condition,
+      savedGroups: body.savedGroupTargeting ?? current.savedGroups,
+      coverage:
+        body.holdoutSize === undefined
+          ? current.coverage
+          : holdoutSizeToCoverage(body.holdoutSize),
+    };
+
+    experimentChanges.phases = phases;
+    if (body.hashAttribute !== undefined) {
+      experimentChanges.hashAttribute = body.hashAttribute;
+    }
+  }
+
+  // 2. Metadata and analysis settings on the companion experiment.
+  for (const field of HOLDOUT_API_EXPERIMENT_UPDATE_FIELDS) {
+    if (body[field] !== undefined) {
+      (experimentChanges as Record<string, unknown>)[field] = body[field];
+    }
+  }
+  if (body.owner !== undefined) {
+    experimentChanges.owner = await resolveOwnerToUserId(body.owner, context);
+  }
+  // Validate analysis settings as a whole against the *effective* post-update
+  // values: the datasource exists, the goal/secondary metrics belong to it,
+  // and the assignment query is one of its exposure queries. Otherwise a bad
+  // id — including an old exposure query or metric left behind when only the
+  // datasource changes — slips through to snapshot/query time and fails there
+  // with a confusing error.
+  if (
+    body.datasourceId !== undefined ||
+    body.assignmentQueryId !== undefined ||
+    body.goalMetrics !== undefined ||
+    body.secondaryMetrics !== undefined
+  ) {
+    const { datasource } = await validateExperimentData(context, {
+      datasource: body.datasourceId ?? experiment.datasource,
+      goalMetrics: body.goalMetrics ?? experiment.goalMetrics,
+      secondaryMetrics: body.secondaryMetrics ?? experiment.secondaryMetrics,
+    });
+
+    assertValidAssignmentQuery(
+      datasource,
+      body.assignmentQueryId ?? experiment.exposureQueryId,
+    );
+
+    if (body.datasourceId !== undefined) {
+      experimentChanges.datasource = body.datasourceId;
+    }
+    if (body.assignmentQueryId !== undefined) {
+      experimentChanges.exposureQueryId = body.assignmentQueryId;
+    }
+  }
+  // The name is stored on both documents and must not drift.
+  if (body.name !== undefined) {
+    experimentChanges.name = body.name;
+  }
+
+  // Single write to the companion experiment.
+  if (Object.keys(experimentChanges).length) {
+    experiment = await updateExperiment({
+      context,
+      experiment,
+      changes: experimentChanges,
+    });
+  }
+
+  // 3. Fields on the holdout document itself.
+  const holdoutUpdates: UpdateProps<HoldoutInterface> = {};
+  for (const field of HOLDOUT_API_UPDATE_FIELDS) {
+    if (body[field] !== undefined) {
+      (holdoutUpdates as Record<string, unknown>)[field] = body[field];
+    }
+  }
+  if (body.name !== undefined) {
+    holdoutUpdates.name = body.name;
+  }
+  if (body.environments !== undefined) {
+    holdoutUpdates.environmentSettings = Object.fromEntries(
+      Object.entries(body.environments).map(([id, settings]) => [
+        id,
+        { enabled: settings.enabled },
+      ]),
+    );
+  }
+  if (body.statusUpdateSchedule !== undefined) {
+    Object.assign(
+      holdoutUpdates,
+      normalizeHoldoutScheduleUpdates({
+        holdout,
+        experiment,
+        scheduleInput: body.statusUpdateSchedule,
+      }),
+    );
+  }
+
+  const updatedHoldout = Object.keys(holdoutUpdates).length
+    ? await context.models.holdout.update(holdout, holdoutUpdates)
+    : holdout;
+
+  return { holdout: updatedHoldout, experiment };
 }
 
 export function normalizeHoldoutScheduleUpdates({

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -564,6 +564,33 @@ export async function updateHoldoutWithExperiment(
     )[key];
   }
 
+  // Targeting/sizing (experiment phase) and environment changes both feed the
+  // SDK payload, so refresh it once the writes land (mirrors `setHoldoutStage`).
+  const affectsPayload = isTargetingChange || body.environments !== undefined;
+  const refreshPayload = (finalHoldout: HoldoutInterface) => {
+    if (!affectsPayload) return;
+    const orgEnvs = getEnvironmentIdsFromOrg(context.org);
+    const seen = new Set<string>();
+    const payloadKeys = [
+      ...getAffectedSDKPayloadKeys(holdout, orgEnvs),
+      ...getAffectedSDKPayloadKeys(finalHoldout, orgEnvs),
+    ].filter((key) => {
+      const s = JSON.stringify(key);
+      if (seen.has(s)) return false;
+      seen.add(s);
+      return true;
+    });
+    queueSDKPayloadRefresh({
+      context,
+      payloadKeys,
+      auditContext: {
+        event: "Holdout updated",
+        model: "holdout",
+        id: holdout.id,
+      },
+    });
+  };
+
   const experimentChanged = Object.keys(experimentChanges).length > 0;
   if (experimentChanged) {
     experiment = await updateExperiment({
@@ -574,6 +601,7 @@ export async function updateHoldoutWithExperiment(
   }
 
   if (!Object.keys(holdoutUpdates).length) {
+    refreshPayload(holdout);
     return { holdout, experiment };
   }
 
@@ -582,6 +610,7 @@ export async function updateHoldoutWithExperiment(
       holdout,
       holdoutUpdates,
     );
+    refreshPayload(updatedHoldout);
     return { holdout: updatedHoldout, experiment };
   } catch (e) {
     if (experimentChanged) {

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -13,7 +13,6 @@ import {
   CreateHoldoutInput,
   HoldoutInterface,
   HoldoutNextScheduledStatusUpdate,
-  SavedGroupTargeting,
 } from "shared/validators";
 import {
   Changeset,
@@ -45,7 +44,6 @@ import {
   validateExperimentData,
   validateVariationIds,
 } from "back-end/src/services/experiments";
-import { validateExperimentChange } from "./experimentChanges/changeExperimentStatus";
 
 export async function canLinkExperimentToHoldoutFromFeatures(
   context: ReqContext | ApiReqContext,
@@ -560,51 +558,6 @@ export async function setHoldoutStage(
       stage satisfies never;
     }
   }
-}
-
-/**
- * Applies phase-level targeting and sizing changes to a holdout's companion
- * experiment through the same validate/update path the internal targeting
- * endpoint uses, so the stored phases and the SDK payload stay correct.
- * Only the fields that are provided are changed. Callers are responsible for
- * the `canRunHoldout` permission check.
- */
-export async function applyHoldoutTargetingChanges(
-  context: ReqContext | ApiReqContext,
-  {
-    experiment,
-    coverage,
-    condition,
-    savedGroups,
-    hashAttribute,
-  }: {
-    experiment: ExperimentInterface;
-    coverage?: number;
-    condition?: string;
-    savedGroups?: SavedGroupTargeting[];
-    hashAttribute?: string;
-  },
-): Promise<ExperimentInterface> {
-  const phases = [...experiment.phases];
-  if (!phases.length) {
-    throw new Error("Holdout does not have a phase to target");
-  }
-
-  const current = phases[phases.length - 1];
-  phases[phases.length - 1] = {
-    ...current,
-    condition: condition ?? current.condition,
-    savedGroups: savedGroups ?? current.savedGroups,
-    coverage: coverage ?? current.coverage,
-  };
-
-  const changes: Changeset = { phases };
-  if (hashAttribute !== undefined) {
-    changes.hashAttribute = hashAttribute;
-  }
-
-  await validateExperimentChange({ context, experiment, changes });
-  return updateExperiment({ context, experiment, changes });
 }
 
 /**

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -65,9 +65,41 @@ export function assertCanRunHoldoutEnvironments(
     projects: string[];
   },
 ): void {
-  if (enabledEnvironments.length === 0) return;
-  if (!context.permissions.canRunHoldout({ projects }, enabledEnvironments)) {
+  // Ignore envs that no longer exist in the org: the holdout can't serve there,
+  // so requiring run permission on them would be a spurious denial.
+  const orgEnvs = new Set(getEnvironmentIdsFromOrg(context.org));
+  const envs = enabledEnvironments.filter((env) => orgEnvs.has(env));
+  if (envs.length === 0) return;
+  if (!context.permissions.canRunHoldout({ projects }, envs)) {
     context.permissions.throwPermissionError();
+  }
+}
+
+/**
+ * Reject env ids that don't exist in the org. On update, ids already stored on
+ * the holdout are tolerated (pass `existingEnvironments`) so a client echoing
+ * settings that predate an environment deletion isn't blocked — only newly
+ * referenced ids are checked.
+ */
+export function assertValidHoldoutEnvironments(
+  context: ReqContext | ApiReqContext,
+  environments: Record<string, unknown> | undefined | null,
+  existingEnvironments?: Record<string, unknown>,
+): void {
+  if (!environments) return;
+  const orgEnvs = new Set(getEnvironmentIdsFromOrg(context.org));
+  const existing = new Set(
+    existingEnvironments ? Object.keys(existingEnvironments) : [],
+  );
+  const invalid = Object.keys(environments).filter(
+    (env) => !orgEnvs.has(env) && !existing.has(env),
+  );
+  if (invalid.length) {
+    throw new BadRequestError(
+      `Invalid environment${invalid.length > 1 ? "s" : ""}: ${invalid.join(
+        ", ",
+      )}`,
+    );
   }
 }
 
@@ -269,6 +301,8 @@ export async function createHoldoutWithExperiment(
     await context.models.projects.ensureProjectsExist(data.projects);
   }
 
+  assertValidHoldoutEnvironments(context, data.environmentSettings);
+
   const variations = [
     {
       name: "Holdout",
@@ -415,6 +449,41 @@ async function rollbackExperimentAfterHoldoutFailure(
 }
 
 /**
+ * Queue an SDK payload refresh for a holdout. When a write moves the holdout's
+ * environment or project footprint, pass its prior snapshot as `previousHoldout`
+ * too so keys for both the old and new footprint are invalidated. Callers decide
+ * when a change actually reaches the payload — only running holdouts are served.
+ */
+export function refreshHoldoutPayload(
+  context: ReqContext | ApiReqContext,
+  {
+    holdout,
+    previousHoldout,
+    event,
+  }: {
+    holdout: HoldoutInterface;
+    previousHoldout?: HoldoutInterface;
+    event: string;
+  },
+): void {
+  const orgEnvs = getEnvironmentIdsFromOrg(context.org);
+  const seen = new Set<string>();
+  const payloadKeys = [holdout, ...(previousHoldout ? [previousHoldout] : [])]
+    .flatMap((h) => getAffectedSDKPayloadKeys(h, orgEnvs))
+    .filter((key) => {
+      const s = JSON.stringify(key);
+      if (seen.has(s)) return false;
+      seen.add(s);
+      return true;
+    });
+  queueSDKPayloadRefresh({
+    context,
+    payloadKeys,
+    auditContext: { event, model: "holdout", id: holdout.id },
+  });
+}
+
+/**
  * Applies a validated REST update body to a Holdout and its companion
  * experiment. Splits the work across the three storage locations a Holdout
  * spans — the current experiment phase (targeting/sizing), the experiment
@@ -433,6 +502,12 @@ export async function updateHoldoutWithExperiment(
     body: ApiUpdateHoldoutBody;
   },
 ): Promise<{ holdout: HoldoutInterface; experiment: ExperimentInterface }> {
+  assertValidHoldoutEnvironments(
+    context,
+    body.environments,
+    holdout.environmentSettings,
+  );
+
   // Narrowing the scope must not strand linked entities (matches the internal
   // update endpoint). Only when it actually changes, so a Holdout already
   // holding a stranded link stays editable to be fixed.
@@ -564,30 +639,17 @@ export async function updateHoldoutWithExperiment(
     )[key];
   }
 
-  // Targeting/sizing (experiment phase) and environment changes both feed the
-  // SDK payload, so refresh it once the writes land (mirrors `setHoldoutStage`).
-  const affectsPayload = isTargetingChange || body.environments !== undefined;
+  const affectsPayload =
+    experiment.status === "running" &&
+    (isTargetingChange ||
+      body.environments !== undefined ||
+      body.archived !== undefined);
   const refreshPayload = (finalHoldout: HoldoutInterface) => {
     if (!affectsPayload) return;
-    const orgEnvs = getEnvironmentIdsFromOrg(context.org);
-    const seen = new Set<string>();
-    const payloadKeys = [
-      ...getAffectedSDKPayloadKeys(holdout, orgEnvs),
-      ...getAffectedSDKPayloadKeys(finalHoldout, orgEnvs),
-    ].filter((key) => {
-      const s = JSON.stringify(key);
-      if (seen.has(s)) return false;
-      seen.add(s);
-      return true;
-    });
-    queueSDKPayloadRefresh({
-      context,
-      payloadKeys,
-      auditContext: {
-        event: "Holdout updated",
-        model: "holdout",
-        id: holdout.id,
-      },
+    refreshHoldoutPayload(context, {
+      holdout: finalHoldout,
+      previousHoldout: holdout,
+      event: "Holdout updated",
     });
   };
 
@@ -774,18 +836,7 @@ export async function setHoldoutStage(
   const originalPhases = structuredClone(experiment.phases);
 
   const refreshPayload = (event: string) =>
-    queueSDKPayloadRefresh({
-      context,
-      payloadKeys: getAffectedSDKPayloadKeys(
-        holdout,
-        getEnvironmentIdsFromOrg(context.org),
-      ),
-      auditContext: {
-        event,
-        model: "holdout",
-        id: holdout.id,
-      },
-    });
+    refreshHoldoutPayload(context, { holdout, event });
 
   // Commit a stage transition across both documents. With no cross-document
   // transaction, a holdout failure after the experiment write is committed
@@ -951,18 +1002,7 @@ export async function deleteHoldoutAndExperiment(
 
   await context.models.holdout.delete(holdout);
 
-  queueSDKPayloadRefresh({
-    context,
-    payloadKeys: getAffectedSDKPayloadKeys(
-      holdout,
-      getEnvironmentIdsFromOrg(context.org),
-    ),
-    auditContext: {
-      event: "deleted",
-      model: "holdout",
-      id: holdout.id,
-    },
-  });
+  refreshHoldoutPayload(context, { holdout, event: "deleted" });
 }
 
 // Mirror of `getHoldoutAvailableForProject`, applied from the Holdout side:

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -64,8 +64,8 @@ export function assertCanRunHoldoutEnvironments(
     projects: string[];
   },
 ): void {
-  // Ignore envs that no longer exist in the org: the holdout can't serve there,
-  // so requiring run permission on them would be a spurious denial.
+  // Envs the org no longer has can't serve the holdout, so demanding run
+  // permission on them would be a spurious denial.
   const orgEnvs = new Set(getEnvironmentIdsFromOrg(context.org));
   const envs = enabledEnvironments.filter((env) => orgEnvs.has(env));
   if (envs.length === 0) return;
@@ -75,10 +75,9 @@ export function assertCanRunHoldoutEnvironments(
 }
 
 /**
- * Reject env ids that don't exist in the org. On update, ids already stored on
- * the holdout are tolerated (pass `existingEnvironments`) so a client echoing
- * settings that predate an environment deletion isn't blocked — only newly
- * referenced ids are checked.
+ * Reject env ids the org doesn't have. Ids already stored on the holdout (pass
+ * `existingEnvironments`) are tolerated, so a client echoing back settings that
+ * predate an environment deletion isn't blocked.
  */
 export function assertValidHoldoutEnvironments(
   context: ReqContext | ApiReqContext,
@@ -103,17 +102,12 @@ export function assertValidHoldoutEnvironments(
 }
 
 /**
- * Update authorization shared by the REST API (`handleApiUpdate`) and the UI
- * endpoint (`updateHoldout`) so the two cannot drift. Update permission is
- * always required (on the current and, when moving the Holdout, destination
- * scope). Beyond that, a change needs run permission on the union of current and
- * newly-requested environments when it authorizes a deployment:
- *   - Schedule changes hand the agenda job authority to transition the Holdout's
- *     status later (e.g. auto-start it), so they require it whatever the stage.
- *   - Targeting/sizing and environment changes only reach live SDK payloads
- *     while the Holdout is running, so they require it only then.
- * Metadata-only changes and clearing the schedule do not. The UI never sends
- * targeting here but still passes the flag.
+ * Shared by the REST and UI update paths so the two cannot drift. Update
+ * permission is always required, on the destination scope when the Holdout is
+ * moving. A change additionally needs run permission when it authorizes a
+ * deployment: schedule changes at any stage, since they hand the agenda job
+ * authority to transition the Holdout later; targeting and environment changes
+ * only while it is running, since that is when they reach live SDK payloads.
  */
 export function assertCanUpdateHoldout(
   context: ReqContext | ApiReqContext,
@@ -157,6 +151,89 @@ export function assertCanUpdateHoldout(
     enabledEnvironments,
     projects: updatedProjects ?? holdout.projects,
   });
+}
+
+/**
+ * Shared by the model's `beforeUpdate` hook and the REST create handler, which
+ * runs it before writing so a rejected schedule can't leave a half-created
+ * Holdout behind.
+ */
+export function assertValidHoldoutSchedule({
+  schedule,
+  currentStage,
+  analysisStartDate,
+}: {
+  schedule:
+    | {
+        startAt?: string | Date | null;
+        startAnalysisPeriodAt?: string | Date | null;
+        stopAt?: string | Date | null;
+      }
+    | null
+    | undefined;
+  currentStage: HoldoutStage;
+  analysisStartDate?: Date | null;
+}): void {
+  if (!schedule) return;
+
+  const startAt = schedule.startAt ? getValidDate(schedule.startAt) : undefined;
+  const startAnalysisPeriodAt = schedule.startAnalysisPeriodAt
+    ? getValidDate(schedule.startAnalysisPeriodAt)
+    : undefined;
+  const stopAt = schedule.stopAt ? getValidDate(schedule.stopAt) : undefined;
+
+  const now = new Date();
+
+  if (startAt && currentStage === "draft" && startAt < now) {
+    throw new BadRequestError("Scheduled start date cannot be in the past");
+  }
+  if (
+    startAnalysisPeriodAt &&
+    currentStage === "running" &&
+    startAnalysisPeriodAt < now
+  ) {
+    throw new BadRequestError(
+      "Scheduled analysis start date cannot be in the past",
+    );
+  }
+  if (stopAt && currentStage !== "stopped" && stopAt < now) {
+    throw new BadRequestError("Scheduled stop date cannot be in the past");
+  }
+
+  if (
+    currentStage === "draft" &&
+    stopAt &&
+    (!startAt || !startAnalysisPeriodAt)
+  ) {
+    throw new BadRequestError(
+      "To set a stop date, you must also set a start date and an analysis start date",
+    );
+  }
+  if (currentStage === "draft" && startAnalysisPeriodAt && !startAt) {
+    throw new BadRequestError(
+      "To set an analysis start date, you must first set a start date",
+    );
+  }
+
+  if (currentStage === "running" && stopAt && !startAnalysisPeriodAt) {
+    throw new BadRequestError(
+      "To set a stop date, you must first set an analysis start date",
+    );
+  }
+
+  const dateError =
+    (startAt &&
+      startAnalysisPeriodAt &&
+      currentStage === "draft" &&
+      startAt > startAnalysisPeriodAt) ||
+    (startAt && stopAt && currentStage === "draft" && startAt > stopAt) ||
+    (startAnalysisPeriodAt &&
+      stopAt &&
+      !analysisStartDate &&
+      startAnalysisPeriodAt > stopAt);
+  if (dateError) {
+    throw new BadRequestError("Scheduled dates must be consecutive");
+  }
 }
 
 export async function canLinkExperimentToHoldoutFromFeatures(
@@ -415,10 +492,9 @@ export async function createHoldoutWithExperiment(
 }
 
 /**
- * Roll an experiment back after its companion holdout write failed (the two
- * documents share no transaction). Returns whether the restore succeeded so
- * callers can gate follow-up work; on failure it logs for manual reconciliation
- * rather than masking the caller's original error.
+ * The two documents share no transaction, so a failed holdout write leaves the
+ * experiment ahead of it. Returns whether the restore landed; a failure is
+ * logged for manual reconciliation rather than masking the caller's error.
  */
 async function rollbackExperimentAfterHoldoutFailure(
   context: ReqContext | ApiReqContext,
@@ -443,10 +519,9 @@ async function rollbackExperimentAfterHoldoutFailure(
 }
 
 /**
- * Queue an SDK payload refresh for a holdout. When a write moves the holdout's
- * environment or project footprint, pass its prior snapshot as `previousHoldout`
- * too so keys for both the old and new footprint are invalidated. Callers decide
- * when a change actually reaches the payload — only running holdouts are served.
+ * Pass `previousHoldout` when a write moves the holdout's environment or project
+ * footprint, so keys for both the old and the new one are invalidated. Callers
+ * decide whether a change reaches the payload at all — only running holdouts serve.
  */
 export function refreshHoldoutPayload(
   context: ReqContext | ApiReqContext,
@@ -477,11 +552,7 @@ export function refreshHoldoutPayload(
   });
 }
 
-/**
- * Applies a validated REST update body to a Holdout and its companion
- * experiment and returns the refreshed pair. Permission gating is the
- * caller's job.
- */
+/** Applies a REST update body across both documents. Callers gate permissions. */
 export async function updateHoldoutWithExperiment(
   context: ReqContext | ApiReqContext,
   {
@@ -510,7 +581,6 @@ export async function updateHoldoutWithExperiment(
 
   const experimentChanges: Partial<ExperimentInterface> = {};
 
-  // 1. Phase-level targeting and sizing.
   const isTargetingChange = HOLDOUT_API_TARGETING_UPDATE_FIELDS.some(
     (field) => body[field] !== undefined,
   );
@@ -520,8 +590,8 @@ export async function updateHoldoutWithExperiment(
       throw new Error("Holdout does not have a phase to target");
     }
 
-    // Reject a malformed targeting condition up front rather than letting it
-    // break bucketing later. validateCondition treats undefined/"{}" as valid.
+    // Catch a malformed condition here rather than at bucketing time.
+    // validateCondition treats undefined and "{}" as valid.
     if (body.targetingCondition !== undefined) {
       const conditionResult = validateCondition(body.targetingCondition);
       if (!conditionResult.success) {
@@ -531,9 +601,8 @@ export async function updateHoldoutWithExperiment(
       }
     }
 
-    // A holdout in its analysis period has two phases ("Holdout" and
-    // "Analysis") that must carry identical targeting, so mirror the change
-    // across every phase rather than only the last one.
+    // The analysis-period phase must carry the same targeting as the payload
+    // phase, so mirror the change across every phase, not just the last.
     const targetingCoverage =
       body.holdoutSize === undefined
         ? undefined
@@ -550,7 +619,6 @@ export async function updateHoldoutWithExperiment(
     }
   }
 
-  // 2. Metadata and analysis settings on the companion experiment.
   for (const field of HOLDOUT_API_EXPERIMENT_UPDATE_FIELDS) {
     if (body[field] !== undefined) {
       (experimentChanges as Record<string, unknown>)[field] = body[field];
@@ -559,9 +627,8 @@ export async function updateHoldoutWithExperiment(
   if (body.owner !== undefined) {
     experimentChanges.owner = await resolveOwnerToUserId(body.owner, context);
   }
-  // Validate analysis settings against the effective post-update values so a
-  // stale metric or exposure query (e.g. left behind when only the datasource
-  // changes) is rejected here rather than failing later at query time.
+  // Validate against the post-update values, so a metric or exposure query left
+  // stale by a datasource-only change is rejected here, not at query time.
   if (
     body.datasourceId !== undefined ||
     body.assignmentQueryId !== undefined ||
@@ -591,7 +658,6 @@ export async function updateHoldoutWithExperiment(
     experimentChanges.name = body.name;
   }
 
-  // 3. Fields on the holdout document itself.
   const holdoutUpdates: UpdateProps<HoldoutInterface> = {};
   for (const field of HOLDOUT_API_UPDATE_FIELDS) {
     if (body[field] !== undefined) {
@@ -620,10 +686,9 @@ export async function updateHoldoutWithExperiment(
     );
   }
 
-  // Persist the experiment first, then the holdout. With no cross-document
-  // transaction, a holdout failure after the experiment write is committed
-  // would leave the pair inconsistent, so snapshot the changed experiment
-  // fields and roll them back on failure (mirrors `setHoldoutStage`).
+  // The experiment is written first and there is no cross-document transaction,
+  // so snapshot what changed and roll it back if the holdout write fails
+  // (mirrors `setHoldoutStage`).
   const originalExperimentValues: Partial<ExperimentInterface> = {};
   for (const key of Object.keys(experimentChanges)) {
     (originalExperimentValues as Record<string, unknown>)[key] = (
@@ -635,6 +700,7 @@ export async function updateHoldoutWithExperiment(
     experiment.status === "running" &&
     (isTargetingChange ||
       body.environments !== undefined ||
+      body.projects !== undefined ||
       body.archived !== undefined);
   const refreshPayload = (finalHoldout: HoldoutInterface) => {
     if (!affectsPayload) return;
@@ -820,20 +886,17 @@ export async function setHoldoutStage(
   let phases = [...experiment.phases] as ExperimentPhase[];
   const changes: Changeset = {};
 
-  // Snapshot the only experiment fields any branch below mutates, before those
-  // mutations run, so a failed holdout write can be compensated by restoring
-  // them (see `commitTransition`).
+  // Snapshot before any branch below mutates them; `commitTransition` restores
+  // these if the holdout write fails.
   const originalStatus = experiment.status;
   const originalPhases = structuredClone(experiment.phases);
 
   const refreshPayload = (event: string) =>
     refreshHoldoutPayload(context, { holdout, event });
 
-  // Commit a stage transition across both documents. With no cross-document
-  // transaction, a holdout failure after the experiment write is committed
-  // rolls the experiment back to its pre-transition status and phases and
-  // rethrows, leaving the schedule pointer untouched so a retry re-selects the
-  // still-due holdout.
+  // Commits across both documents. A holdout failure rolls the experiment back
+  // and rethrows, leaving the schedule pointer untouched so a retry re-selects
+  // the still-due holdout.
   const commitTransition = async (
     event: string,
     holdoutChanges: UpdateProps<HoldoutInterface>,
@@ -954,10 +1017,8 @@ export async function setHoldoutStage(
 }
 
 /**
- * Delete a holdout along with its underlying experiment, unlink it from its
- * linked features and experiments, and refresh affected SDK payloads. Callers
- * are responsible for experiment-level permission checks; deleting the holdout
- * itself enforces canDeleteHoldout.
+ * Callers are responsible for experiment-level permission checks; deleting the
+ * holdout itself enforces canDeleteHoldout.
  */
 export async function deleteHoldoutAndExperiment(
   context: ReqContext,

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -107,10 +107,14 @@ export function assertValidHoldoutEnvironments(
  * Update authorization shared by the REST API (`handleApiUpdate`) and the UI
  * endpoint (`updateHoldout`) so the two cannot drift. Update permission is
  * always required (on the current and, when moving the Holdout, destination
- * scope). Targeting/sizing and schedule changes reach live SDK payloads, so
- * they additionally require run permission on the union of current and
- * newly-requested environments; environment-only changes and clearing the
- * schedule do not. The UI never sends targeting here but still passes the flag.
+ * scope). Beyond that, a change needs run permission on the union of current and
+ * newly-requested environments when it authorizes a deployment:
+ *   - Schedule changes hand the agenda job authority to transition the Holdout's
+ *     status later (e.g. auto-start it), so they require it whatever the stage.
+ *   - Targeting/sizing and environment changes only reach live SDK payloads
+ *     while the Holdout is running, so they require it only then.
+ * Metadata-only changes and clearing the schedule do not. The UI never sends
+ * targeting here but still passes the flag.
  */
 export function assertCanUpdateHoldout(
   context: ReqContext | ApiReqContext,
@@ -120,12 +124,14 @@ export function assertCanUpdateHoldout(
     requestedEnabledEnvironments,
     isTargetingChange,
     isScheduleChange,
+    isRunning,
   }: {
     holdout: HoldoutInterface;
     updatedProjects?: string[];
     requestedEnabledEnvironments?: string[];
     isTargetingChange: boolean;
     isScheduleChange: boolean;
+    isRunning: boolean;
   },
 ): void {
   if (
@@ -136,7 +142,11 @@ export function assertCanUpdateHoldout(
     context.permissions.throwPermissionError();
   }
 
-  if (!isTargetingChange && !isScheduleChange) return;
+  const isEnvironmentChange = requestedEnabledEnvironments !== undefined;
+  const requiresRunPermission =
+    isScheduleChange ||
+    (isRunning && (isTargetingChange || isEnvironmentChange));
+  if (!requiresRunPermission) return;
 
   const enabledEnvironments = Array.from(
     new Set([

--- a/packages/back-end/src/services/holdouts.ts
+++ b/packages/back-end/src/services/holdouts.ts
@@ -9,6 +9,7 @@ import {
 import {
   HoldoutInterface,
   HoldoutNextScheduledStatusUpdate,
+  SavedGroupTargeting,
 } from "shared/validators";
 import {
   Changeset,
@@ -41,6 +42,7 @@ import {
   validateExperimentData,
   validateVariationIds,
 } from "back-end/src/services/experiments";
+import { validateExperimentChange } from "./experimentChanges/changeExperimentStatus";
 
 export async function canLinkExperimentToHoldoutFromFeatures(
   context: ReqContext | ApiReqContext,
@@ -520,6 +522,51 @@ export async function setHoldoutStage(
       stage satisfies never;
     }
   }
+}
+
+/**
+ * Applies phase-level targeting and sizing changes to a holdout's companion
+ * experiment through the same validate/update path the internal targeting
+ * endpoint uses, so the stored phases and the SDK payload stay correct.
+ * Only the fields that are provided are changed. Callers are responsible for
+ * the `canRunHoldout` permission check.
+ */
+export async function applyHoldoutTargetingChanges(
+  context: ReqContext | ApiReqContext,
+  {
+    experiment,
+    coverage,
+    condition,
+    savedGroups,
+    hashAttribute,
+  }: {
+    experiment: ExperimentInterface;
+    coverage?: number;
+    condition?: string;
+    savedGroups?: SavedGroupTargeting[];
+    hashAttribute?: string;
+  },
+): Promise<ExperimentInterface> {
+  const phases = [...experiment.phases];
+  if (!phases.length) {
+    throw new Error("Holdout does not have a phase to target");
+  }
+
+  const current = phases[phases.length - 1];
+  phases[phases.length - 1] = {
+    ...current,
+    condition: condition ?? current.condition,
+    savedGroups: savedGroups ?? current.savedGroups,
+    coverage: coverage ?? current.coverage,
+  };
+
+  const changes: Changeset = { phases };
+  if (hashAttribute !== undefined) {
+    changes.hashAttribute = hashAttribute;
+  }
+
+  await validateExperimentChange({ context, experiment, changes });
+  return updateExperiment({ context, experiment, changes });
 }
 
 /**

--- a/packages/back-end/src/util/holdouts.ts
+++ b/packages/back-end/src/util/holdouts.ts
@@ -1,22 +1,7 @@
+import { getEnabledHoldoutEnvironments } from "shared/util";
 import { HoldoutInterface } from "shared/validators";
 import { SDKPayloadKey } from "back-end/types/sdk-payload";
 import { getSDKPayloadKeys } from "./features";
-
-export function getEnabledEnvironments(
-  holdout: HoldoutInterface,
-  allowedEnvs: string[],
-): Set<string> {
-  const environments = new Set<string>();
-
-  const settings = holdout.environmentSettings || {};
-
-  Object.keys(settings)
-    .filter((e) => allowedEnvs.includes(e))
-    .filter((e) => settings[e].enabled)
-    .forEach((e) => environments.add(e));
-
-  return environments;
-}
 
 export function getAffectedSDKPayloadKeys(
   holdout: HoldoutInterface,
@@ -24,7 +9,9 @@ export function getAffectedSDKPayloadKeys(
 ): SDKPayloadKey[] {
   const keys: SDKPayloadKey[] = [];
 
-  const environments = getEnabledEnvironments(holdout, allowedEnvs);
+  const environments = new Set(
+    getEnabledHoldoutEnvironments(holdout.environmentSettings, allowedEnvs),
+  );
 
   const projects = new Set(
     holdout.projects.length > 0 ? holdout.projects : [""],

--- a/packages/back-end/test/jobs/updateHoldoutStatus.test.ts
+++ b/packages/back-end/test/jobs/updateHoldoutStatus.test.ts
@@ -52,9 +52,19 @@ describe("isScheduledTransitionApplicable", () => {
     ).toBe(false);
   });
 
-  it("stops any holdout that is not already stopped", () => {
+  it("stops a running holdout before or during analysis", () => {
     expect(isScheduledTransitionApplicable("stop", running, holdout())).toBe(
       true,
+    );
+    expect(
+      isScheduledTransitionApplicable(
+        "stop",
+        running,
+        holdout({ analysisStartDate: PAST }),
+      ),
+    ).toBe(true);
+    expect(isScheduledTransitionApplicable("stop", draft, holdout())).toBe(
+      false,
     );
     expect(isScheduledTransitionApplicable("stop", stopped, holdout())).toBe(
       false,

--- a/packages/back-end/test/services/holdouts.test.ts
+++ b/packages/back-end/test/services/holdouts.test.ts
@@ -1,10 +1,28 @@
-import { ExperimentInterface } from "shared/types/experiment";
+import type { ExperimentInterface } from "shared/types/experiment";
+import type { HoldoutInterface, ApiUpdateHoldoutBody } from "shared/validators";
+import { updateExperiment } from "back-end/src/models/ExperimentModel";
+import { CasConflictError } from "back-end/src/models/BaseModel";
+import { logger } from "back-end/src/util/logger";
+import type { ReqContext } from "back-end/types/request";
 import {
   getHoldoutLivePayloadChanges,
   getNextScheduledStatusUpdateForStage,
   isHoldoutExperiment,
   normalizeHoldoutScheduleUpdates,
+  setHoldoutStage,
+  updateHoldoutWithExperiment,
 } from "back-end/src/services/holdouts";
+
+jest.mock("back-end/src/models/ExperimentModel", () => ({
+  updateExperiment: jest.fn(),
+  createExperiment: jest.fn(),
+  deleteExperimentByIdForOrganization: jest.fn(),
+  getExperimentsByIds: jest.fn(),
+}));
+
+jest.mock("back-end/src/services/features", () => ({
+  queueSDKPayloadRefresh: jest.fn(),
+}));
 
 function makeExperiment(
   overrides: Partial<ExperimentInterface> = {},
@@ -16,7 +34,7 @@ function makeExperiment(
   } as unknown as ExperimentInterface;
 }
 
-function makeHoldout(
+function makeHoldoutExperiment(
   phases: { coverage: number }[],
 ): ExperimentInterface & { type: "holdout" } {
   return makeExperiment({
@@ -47,7 +65,7 @@ describe("isHoldoutExperiment", () => {
 });
 
 describe("getHoldoutLivePayloadChanges", () => {
-  const experiment = makeHoldout([{ coverage: 0.1 }]);
+  const experiment = makeHoldoutExperiment([{ coverage: 0.1 }]);
 
   it("reports a change when coverage differs from phase 0", () => {
     expect(getHoldoutLivePayloadChanges(experiment, 0.2)).toEqual({
@@ -71,7 +89,10 @@ describe("getHoldoutLivePayloadChanges", () => {
   });
 
   it("uses phase 0 as the payload phase, ignoring later phases", () => {
-    const multiPhase = makeHoldout([{ coverage: 0.1 }, { coverage: 0.9 }]);
+    const multiPhase = makeHoldoutExperiment([
+      { coverage: 0.1 },
+      { coverage: 0.9 },
+    ]);
     // Matches phase 0 (0.1) -> no change, even though phase 1 differs.
     expect(
       getHoldoutLivePayloadChanges(multiPhase, 0.1).changesLivePayload,
@@ -331,5 +352,121 @@ describe("getNextScheduledStatusUpdateForStage", () => {
     expect(
       getNextScheduledStatusUpdateForStage({ startAt: SOON }, "draft"),
     ).toBeNull();
+  });
+});
+
+describe("rollbackExperimentAfterHoldoutFailure guard", () => {
+  const mockUpdateExperiment = updateExperiment as jest.Mock;
+
+  const makeRollbackExperiment = (
+    overrides: Partial<ExperimentInterface> = {},
+  ): ExperimentInterface =>
+    ({
+      id: "exp_1",
+      organization: "org",
+      name: "Old",
+      status: "running",
+      phases: [{ dateEnded: undefined }],
+      dateUpdated: new Date("2026-07-28T12:00:00.000Z"),
+      ...overrides,
+    }) as unknown as ExperimentInterface;
+
+  const makeRollbackHoldout = (
+    overrides: Partial<HoldoutInterface> = {},
+  ): HoldoutInterface =>
+    ({
+      id: "hld_1",
+      organization: "org",
+      name: "Old",
+      projects: [],
+      environmentSettings: {},
+      statusUpdateSchedule: null,
+      nextScheduledStatusUpdate: null,
+      analysisStartDate: undefined,
+      ...overrides,
+    }) as unknown as HoldoutInterface;
+
+  const makeContext = (holdoutUpdate: jest.Mock): ReqContext =>
+    ({
+      org: { id: "org", settings: {} },
+      models: { holdout: { update: holdoutUpdate } },
+    }) as unknown as ReqContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("metadata updates", () => {
+    it("guards the rollback on the fields the update wrote, not dateUpdated", async () => {
+      const experiment = makeRollbackExperiment();
+      mockUpdateExperiment
+        .mockResolvedValueOnce(makeRollbackExperiment({ name: "New" }))
+        .mockResolvedValueOnce(makeRollbackExperiment({ name: "Old" }));
+      const holdoutUpdate = jest
+        .fn()
+        .mockRejectedValue(new Error("holdout down"));
+
+      await expect(
+        updateHoldoutWithExperiment(makeContext(holdoutUpdate), {
+          holdout: makeRollbackHoldout(),
+          experiment,
+          body: { name: "New" } as ApiUpdateHoldoutBody,
+        }),
+      ).rejects.toThrow("holdout down");
+
+      expect(mockUpdateExperiment).toHaveBeenCalledTimes(2);
+      const rollbackCall = mockUpdateExperiment.mock.calls[1][0];
+      expect(rollbackCall.guard).toEqual({ name: "New" });
+      expect(rollbackCall.changes).toEqual({ name: "Old" });
+    });
+
+    it("skips the rollback and warns when a written field changed concurrently", async () => {
+      mockUpdateExperiment
+        .mockResolvedValueOnce(makeRollbackExperiment({ name: "New" }))
+        .mockRejectedValueOnce(new CasConflictError());
+      const holdoutUpdate = jest
+        .fn()
+        .mockRejectedValue(new Error("holdout down"));
+      const warn = jest.spyOn(logger, "warn").mockImplementation();
+
+      await expect(
+        updateHoldoutWithExperiment(makeContext(holdoutUpdate), {
+          holdout: makeRollbackHoldout(),
+          experiment: makeRollbackExperiment(),
+          body: { name: "New" } as ApiUpdateHoldoutBody,
+        }),
+      ).rejects.toThrow("holdout down");
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toContain("may need reconciling");
+    });
+  });
+
+  describe("lifecycle transitions", () => {
+    it("guards the rollback on the status and phases it wrote", async () => {
+      const experiment = makeRollbackExperiment({ status: "running" });
+      mockUpdateExperiment
+        .mockResolvedValueOnce(makeRollbackExperiment({ status: "stopped" }))
+        .mockResolvedValueOnce(makeRollbackExperiment({ status: "running" }));
+      const holdoutUpdate = jest
+        .fn()
+        .mockRejectedValue(new Error("holdout down"));
+
+      await expect(
+        setHoldoutStage(makeContext(holdoutUpdate), {
+          holdout: makeRollbackHoldout(),
+          experiment,
+          stage: "stopped",
+        }),
+      ).rejects.toThrow("holdout down");
+
+      expect(mockUpdateExperiment).toHaveBeenCalledTimes(2);
+      const forwardChanges = mockUpdateExperiment.mock.calls[0][0].changes;
+      const rollbackCall = mockUpdateExperiment.mock.calls[1][0];
+      // The guard is exactly the changeset the forward write applied.
+      expect(rollbackCall.guard).toBe(forwardChanges);
+      expect(rollbackCall.guard.status).toBe("stopped");
+      expect(rollbackCall.changes.status).toBe("running");
+    });
   });
 });

--- a/packages/back-end/test/services/holdouts.test.ts
+++ b/packages/back-end/test/services/holdouts.test.ts
@@ -1,5 +1,6 @@
 import type { ExperimentInterface } from "shared/types/experiment";
 import type { HoldoutInterface, ApiUpdateHoldoutBody } from "shared/validators";
+import { holdoutSizeToCoverage } from "shared/util";
 import { updateExperiment } from "back-end/src/models/ExperimentModel";
 import { CasConflictError } from "back-end/src/models/BaseModel";
 import { queueSDKPayloadRefresh } from "back-end/src/services/features";
@@ -442,6 +443,53 @@ describe("rollbackExperimentAfterHoldoutFailure guard", () => {
 
       expect(warn).toHaveBeenCalledTimes(1);
       expect(warn.mock.calls[0][0]).toContain("may need reconciling");
+    });
+  });
+
+  describe("targeting updates", () => {
+    it("mirrors targeting changes across every phase", async () => {
+      const experiment = makeExperiment({
+        phases: [
+          {
+            name: "Holdout",
+            condition: "{}",
+            savedGroups: [],
+            coverage: 0.5,
+          },
+          {
+            name: "Analysis",
+            condition: "{}",
+            savedGroups: [],
+            coverage: 0.5,
+          },
+        ] as unknown as ExperimentInterface["phases"],
+      });
+      mockUpdateExperiment.mockResolvedValueOnce(experiment);
+      const holdoutUpdate = jest.fn();
+
+      const savedGroupTargeting = [{ match: "all" as const, ids: ["grp_1"] }];
+      await updateHoldoutWithExperiment(makeContext(holdoutUpdate), {
+        holdout: makeHoldout(),
+        experiment,
+        body: {
+          targetingCondition: '{"country":"US"}',
+          savedGroupTargeting,
+          holdoutSize: 0.2,
+        } as ApiUpdateHoldoutBody,
+      });
+
+      expect(mockUpdateExperiment).toHaveBeenCalledTimes(1);
+      const { changes } = mockUpdateExperiment.mock.calls[0][0];
+      const expectedCoverage = holdoutSizeToCoverage(0.2);
+      expect(changes.phases).toHaveLength(2);
+      for (const phase of changes.phases) {
+        expect(phase.condition).toBe('{"country":"US"}');
+        expect(phase.savedGroups).toEqual(savedGroupTargeting);
+        expect(phase.coverage).toBe(expectedCoverage);
+      }
+      // Non-targeting fields on each phase are preserved.
+      expect(changes.phases[0].name).toBe("Holdout");
+      expect(changes.phases[1].name).toBe("Analysis");
     });
   });
 

--- a/packages/back-end/test/services/holdouts.test.ts
+++ b/packages/back-end/test/services/holdouts.test.ts
@@ -8,6 +8,7 @@ import type { ReqContext } from "back-end/types/request";
 import {
   getHoldoutLivePayloadChanges,
   assertValidHoldoutEnvironments,
+  assertValidHoldoutSchedule,
   getNextScheduledStatusUpdateForStage,
   isHoldoutExperiment,
   normalizeHoldoutScheduleUpdates,
@@ -492,6 +493,72 @@ describe("rollbackExperimentAfterHoldoutFailure", () => {
     });
   });
 
+  describe("payload refresh", () => {
+    const makePayloadContext = (holdoutUpdate: jest.Mock): ReqContext =>
+      ({
+        org: { id: "org", settings: { environments: [{ id: "production" }] } },
+        models: { holdout: { update: holdoutUpdate } },
+      }) as unknown as ReqContext;
+
+    const withProjects = (projects: string[]) =>
+      makeRollbackHoldout({
+        projects,
+        environmentSettings: { production: { enabled: true } },
+      } as unknown as Partial<HoldoutInterface>);
+
+    it("invalidates the old and the new keys when a running holdout moves projects", async () => {
+      const holdoutUpdate = jest
+        .fn()
+        .mockResolvedValue(withProjects(["prj_2"]));
+
+      await updateHoldoutWithExperiment(makePayloadContext(holdoutUpdate), {
+        holdout: withProjects(["prj_1"]),
+        experiment: makeExperiment({ status: "running" }),
+        body: { projects: ["prj_2"] } as ApiUpdateHoldoutBody,
+      });
+
+      expect(mockQueueSDKPayloadRefresh).toHaveBeenCalledTimes(1);
+      const { payloadKeys } = mockQueueSDKPayloadRefresh.mock.calls[0][0];
+      expect(payloadKeys).toEqual(
+        expect.arrayContaining([
+          { environment: "production", project: "prj_2" },
+          { environment: "production", project: "prj_1" },
+        ]),
+      );
+    });
+
+    it("skips the refresh when the holdout is not running", async () => {
+      const holdoutUpdate = jest
+        .fn()
+        .mockResolvedValue(withProjects(["prj_2"]));
+
+      await updateHoldoutWithExperiment(makePayloadContext(holdoutUpdate), {
+        holdout: withProjects(["prj_1"]),
+        experiment: makeExperiment({ status: "draft" }),
+        body: { projects: ["prj_2"] } as ApiUpdateHoldoutBody,
+      });
+
+      expect(mockQueueSDKPayloadRefresh).not.toHaveBeenCalled();
+    });
+
+    it("skips the refresh for a metadata-only change", async () => {
+      const holdoutUpdate = jest
+        .fn()
+        .mockResolvedValue(withProjects(["prj_1"]));
+      mockUpdateExperiment.mockResolvedValueOnce(
+        makeExperiment({ status: "running" }),
+      );
+
+      await updateHoldoutWithExperiment(makePayloadContext(holdoutUpdate), {
+        holdout: withProjects(["prj_1"]),
+        experiment: makeExperiment({ status: "running" }),
+        body: { description: "new" } as ApiUpdateHoldoutBody,
+      });
+
+      expect(mockQueueSDKPayloadRefresh).not.toHaveBeenCalled();
+    });
+  });
+
   describe("lifecycle transitions", () => {
     it("rolls back to the status and phases it wrote", async () => {
       const experiment = makeRollbackExperiment({ status: "running" });
@@ -595,5 +662,112 @@ describe("assertValidHoldoutEnvironments", () => {
         { deleted: { enabled: true } },
       ),
     ).toThrow(/Invalid environment: made_up/);
+  });
+});
+
+describe("assertValidHoldoutSchedule", () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("is a no-op for an absent schedule", () => {
+    expect(() =>
+      assertValidHoldoutSchedule({ schedule: null, currentStage: "draft" }),
+    ).not.toThrow();
+    expect(() =>
+      assertValidHoldoutSchedule({
+        schedule: undefined,
+        currentStage: "draft",
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts consecutive future dates on a draft", () => {
+    expect(() =>
+      assertValidHoldoutSchedule({
+        schedule: {
+          startAt: SOON,
+          startAnalysisPeriodAt: LATER,
+          stopAt: LATEST,
+        },
+        currentStage: "draft",
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects dates in the past for the stage they apply to", () => {
+    expect(() =>
+      assertValidHoldoutSchedule({
+        schedule: { startAt: PAST },
+        currentStage: "draft",
+      }),
+    ).toThrow(/start date cannot be in the past/);
+    expect(() =>
+      assertValidHoldoutSchedule({
+        schedule: { startAnalysisPeriodAt: PAST },
+        currentStage: "running",
+      }),
+    ).toThrow(/analysis start date cannot be in the past/);
+  });
+
+  it("rejects a stop date that is missing the dates leading up to it", () => {
+    expect(() =>
+      assertValidHoldoutSchedule({
+        schedule: { startAt: SOON, stopAt: LATEST },
+        currentStage: "draft",
+      }),
+    ).toThrow(/you must also set a start date and an analysis start date/);
+    expect(() =>
+      assertValidHoldoutSchedule({
+        schedule: { stopAt: LATEST },
+        currentStage: "running",
+      }),
+    ).toThrow(/you must first set an analysis start date/);
+  });
+
+  it("rejects out-of-order dates", () => {
+    expect(() =>
+      assertValidHoldoutSchedule({
+        schedule: {
+          startAt: LATER,
+          startAnalysisPeriodAt: SOON,
+          stopAt: LATEST,
+        },
+        currentStage: "draft",
+      }),
+    ).toThrow(/must be consecutive/);
+  });
+
+  it("accepts ISO strings, as the REST API sends them", () => {
+    expect(() =>
+      assertValidHoldoutSchedule({
+        schedule: {
+          startAt: SOON.toISOString(),
+          startAnalysisPeriodAt: LATER.toISOString(),
+          stopAt: LATEST.toISOString(),
+        },
+        currentStage: "draft",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertValidHoldoutSchedule({
+        schedule: { startAt: PAST.toISOString() },
+        currentStage: "draft",
+      }),
+    ).toThrow(/start date cannot be in the past/);
+  });
+
+  it("allows an analysis period that already started to stop at any future date", () => {
+    expect(() =>
+      assertValidHoldoutSchedule({
+        schedule: { startAnalysisPeriodAt: LATEST, stopAt: LATER },
+        currentStage: "analysis-period",
+        analysisStartDate: PAST,
+      }),
+    ).not.toThrow();
   });
 });

--- a/packages/back-end/test/services/holdouts.test.ts
+++ b/packages/back-end/test/services/holdouts.test.ts
@@ -641,6 +641,31 @@ describe("rollbackExperimentAfterHoldoutFailure", () => {
       expect(rollbackCall.changes.status).toBe("running");
     });
 
+    it("refreshes anyway when the rollback itself fails", async () => {
+      // The experiment write stands, and payload eligibility reads its status,
+      // so the cache no longer matches the database.
+      const experiment = makeExperiment({ status: "running" });
+      mockUpdateExperiment
+        .mockResolvedValueOnce(makeExperiment({ status: "stopped" }))
+        .mockRejectedValueOnce(new Error("experiment down"));
+      const holdoutUpdate = jest
+        .fn()
+        .mockRejectedValue(new Error("holdout down"));
+
+      await expect(
+        setHoldoutStage(makeContext(holdoutUpdate), {
+          holdout: makeRollbackHoldout(),
+          experiment,
+          stage: "stopped",
+        }),
+      ).rejects.toThrow("holdout down");
+
+      const events = mockQueueSDKPayloadRefresh.mock.calls.map(
+        ([arg]) => arg.auditContext.event,
+      );
+      expect(events).toEqual(["Rollback failed: Status changed to stopped"]);
+    });
+
     it("never queues the forward refresh when the holdout write is rolled back", async () => {
       const experiment = makeExperiment({ status: "running" });
       mockUpdateExperiment

--- a/packages/back-end/test/services/holdouts.test.ts
+++ b/packages/back-end/test/services/holdouts.test.ts
@@ -7,6 +7,7 @@ import { logger } from "back-end/src/util/logger";
 import type { ReqContext } from "back-end/types/request";
 import {
   getHoldoutLivePayloadChanges,
+  assertCanUpdateHoldout,
   assertValidHoldoutEnvironments,
   assertValidHoldoutSchedule,
   getNextScheduledStatusUpdateForStage,
@@ -493,11 +494,68 @@ describe("rollbackExperimentAfterHoldoutFailure", () => {
     });
   });
 
+  describe("registered attributes", () => {
+    const makeStrictContext = (): ReqContext =>
+      ({
+        org: {
+          id: "org",
+          settings: {
+            environments: [{ id: "production" }],
+            requireRegisteredAttributes: { isOn: true },
+            attributeSchema: [{ property: "id", datatype: "string" }],
+          },
+        },
+        models: {
+          holdout: { update: jest.fn() },
+          projects: { ensureProjectsExist: jest.fn() },
+        },
+      }) as unknown as ReqContext;
+
+    const experiment = () =>
+      makeExperiment({
+        status: "running",
+        hashAttribute: "id",
+        phases: [
+          { condition: '{"country":"US"}', coverage: 0.1 },
+        ] as unknown as ExperimentInterface["phases"],
+      });
+
+    it("rejects a condition that introduces an unregistered attribute", async () => {
+      await expect(
+        updateHoldoutWithExperiment(makeStrictContext(), {
+          holdout: makeRollbackHoldout(),
+          experiment: experiment(),
+          body: {
+            targetingCondition: '{"made_up":"x"}',
+          } as ApiUpdateHoldoutBody,
+        }),
+      ).rejects.toThrow(/made_up/);
+    });
+
+    it("allows a change that leaves the stored attributes alone", async () => {
+      mockUpdateExperiment.mockResolvedValueOnce(experiment());
+      // Echoes back the stored condition, which is already unregistered.
+      await expect(
+        updateHoldoutWithExperiment(makeStrictContext(), {
+          holdout: makeRollbackHoldout(),
+          experiment: experiment(),
+          body: {
+            targetingCondition: '{"country":"US"}',
+            holdoutSize: 0.2,
+          } as ApiUpdateHoldoutBody,
+        }),
+      ).resolves.toBeDefined();
+    });
+  });
+
   describe("payload refresh", () => {
     const makePayloadContext = (holdoutUpdate: jest.Mock): ReqContext =>
       ({
         org: { id: "org", settings: { environments: [{ id: "production" }] } },
-        models: { holdout: { update: holdoutUpdate } },
+        models: {
+          holdout: { update: holdoutUpdate },
+          projects: { ensureProjectsExist: jest.fn() },
+        },
       }) as unknown as ReqContext;
 
     const withProjects = (projects: string[]) =>
@@ -769,5 +827,78 @@ describe("assertValidHoldoutSchedule", () => {
         analysisStartDate: PAST,
       }),
     ).not.toThrow();
+  });
+});
+
+describe("assertCanUpdateHoldout", () => {
+  const makeContext = (canRun: boolean) =>
+    ({
+      org: { id: "org", settings: { environments: [{ id: "production" }] } },
+      permissions: {
+        canUpdateHoldout: () => true,
+        canRunHoldout: () => canRun,
+        throwPermissionError: () => {
+          throw new Error("permission denied");
+        },
+      },
+    }) as unknown as ReqContext;
+
+  const base = {
+    holdout: {
+      projects: [],
+      environmentSettings: { production: { enabled: true } },
+    } as unknown as HoldoutInterface,
+    isTargetingChange: false,
+    isScheduleChange: false,
+    isArchiveChange: false,
+    isRunning: true,
+  };
+
+  it("requires run permission to archive a running holdout", () => {
+    // Archiving pulls it out of the live payload, same as disabling every env.
+    expect(() =>
+      assertCanUpdateHoldout(makeContext(false), {
+        ...base,
+        isArchiveChange: true,
+      }),
+    ).toThrow("permission denied");
+    expect(() =>
+      assertCanUpdateHoldout(makeContext(true), {
+        ...base,
+        isArchiveChange: true,
+      }),
+    ).not.toThrow();
+  });
+
+  it("does not require run permission to archive a holdout that is not running", () => {
+    expect(() =>
+      assertCanUpdateHoldout(makeContext(false), {
+        ...base,
+        isArchiveChange: true,
+        isRunning: false,
+      }),
+    ).not.toThrow();
+  });
+
+  it("does not require run permission for a metadata-only change", () => {
+    expect(() =>
+      assertCanUpdateHoldout(makeContext(false), base),
+    ).not.toThrow();
+  });
+
+  it("requires run permission for targeting and schedule changes", () => {
+    expect(() =>
+      assertCanUpdateHoldout(makeContext(false), {
+        ...base,
+        isTargetingChange: true,
+      }),
+    ).toThrow("permission denied");
+    expect(() =>
+      assertCanUpdateHoldout(makeContext(false), {
+        ...base,
+        isScheduleChange: true,
+        isRunning: false,
+      }),
+    ).toThrow("permission denied");
   });
 });

--- a/packages/back-end/test/services/holdouts.test.ts
+++ b/packages/back-end/test/services/holdouts.test.ts
@@ -2,6 +2,7 @@ import type { ExperimentInterface } from "shared/types/experiment";
 import type { HoldoutInterface, ApiUpdateHoldoutBody } from "shared/validators";
 import { updateExperiment } from "back-end/src/models/ExperimentModel";
 import { CasConflictError } from "back-end/src/models/BaseModel";
+import { queueSDKPayloadRefresh } from "back-end/src/services/features";
 import { logger } from "back-end/src/util/logger";
 import type { ReqContext } from "back-end/types/request";
 import {
@@ -357,6 +358,7 @@ describe("getNextScheduledStatusUpdateForStage", () => {
 
 describe("rollbackExperimentAfterHoldoutFailure guard", () => {
   const mockUpdateExperiment = updateExperiment as jest.Mock;
+  const mockQueueSDKPayloadRefresh = queueSDKPayloadRefresh as jest.Mock;
 
   const makeRollbackExperiment = (
     overrides: Partial<ExperimentInterface> = {},
@@ -467,6 +469,31 @@ describe("rollbackExperimentAfterHoldoutFailure guard", () => {
       expect(rollbackCall.guard).toBe(forwardChanges);
       expect(rollbackCall.guard.status).toBe("stopped");
       expect(rollbackCall.changes.status).toBe("running");
+    });
+
+    it("never queues the forward refresh when the holdout write is rolled back", async () => {
+      const experiment = makeExperiment({ status: "running" });
+      mockUpdateExperiment
+        .mockResolvedValueOnce(makeExperiment({ status: "stopped" }))
+        .mockResolvedValueOnce(makeExperiment({ status: "running" }));
+      const holdoutUpdate = jest
+        .fn()
+        .mockRejectedValue(new Error("holdout down"));
+
+      await expect(
+        setHoldoutStage(makeContext(holdoutUpdate), {
+          holdout: makeHoldout(),
+          experiment,
+          stage: "stopped",
+        }),
+      ).rejects.toThrow("holdout down");
+
+      const events = mockQueueSDKPayloadRefresh.mock.calls.map(
+        ([arg]) => arg.auditContext.event,
+      );
+      // The forward lifecycle refresh must not run once the transition rolls
+      // back; only the reverted-state refresh should reach the SDK caches.
+      expect(events).toEqual(["Reverted: Status changed to stopped"]);
     });
   });
 });

--- a/packages/back-end/test/services/holdouts.test.ts
+++ b/packages/back-end/test/services/holdouts.test.ts
@@ -2,7 +2,6 @@ import type { ExperimentInterface } from "shared/types/experiment";
 import type { HoldoutInterface, ApiUpdateHoldoutBody } from "shared/validators";
 import { holdoutSizeToCoverage } from "shared/util";
 import { updateExperiment } from "back-end/src/models/ExperimentModel";
-import { CasConflictError } from "back-end/src/models/BaseModel";
 import { queueSDKPayloadRefresh } from "back-end/src/services/features";
 import { logger } from "back-end/src/util/logger";
 import type { ReqContext } from "back-end/types/request";
@@ -358,7 +357,7 @@ describe("getNextScheduledStatusUpdateForStage", () => {
   });
 });
 
-describe("rollbackExperimentAfterHoldoutFailure guard", () => {
+describe("rollbackExperimentAfterHoldoutFailure", () => {
   const mockUpdateExperiment = updateExperiment as jest.Mock;
   const mockQueueSDKPayloadRefresh = queueSDKPayloadRefresh as jest.Mock;
 
@@ -401,7 +400,7 @@ describe("rollbackExperimentAfterHoldoutFailure guard", () => {
   });
 
   describe("metadata updates", () => {
-    it("guards the rollback on the fields the update wrote, not dateUpdated", async () => {
+    it("rolls the experiment back to the fields it wrote", async () => {
       const experiment = makeRollbackExperiment();
       mockUpdateExperiment
         .mockResolvedValueOnce(makeRollbackExperiment({ name: "New" }))
@@ -420,18 +419,18 @@ describe("rollbackExperimentAfterHoldoutFailure guard", () => {
 
       expect(mockUpdateExperiment).toHaveBeenCalledTimes(2);
       const rollbackCall = mockUpdateExperiment.mock.calls[1][0];
-      expect(rollbackCall.guard).toEqual({ name: "New" });
+      expect(rollbackCall.guard).toBeUndefined();
       expect(rollbackCall.changes).toEqual({ name: "Old" });
     });
 
-    it("skips the rollback and warns when a written field changed concurrently", async () => {
+    it("logs for manual reconciliation when the rollback write fails", async () => {
       mockUpdateExperiment
         .mockResolvedValueOnce(makeRollbackExperiment({ name: "New" }))
-        .mockRejectedValueOnce(new CasConflictError());
+        .mockRejectedValueOnce(new Error("revert down"));
       const holdoutUpdate = jest
         .fn()
         .mockRejectedValue(new Error("holdout down"));
-      const warn = jest.spyOn(logger, "warn").mockImplementation();
+      const error = jest.spyOn(logger, "error").mockImplementation();
 
       await expect(
         updateHoldoutWithExperiment(makeContext(holdoutUpdate), {
@@ -441,8 +440,8 @@ describe("rollbackExperimentAfterHoldoutFailure guard", () => {
         }),
       ).rejects.toThrow("holdout down");
 
-      expect(warn).toHaveBeenCalledTimes(1);
-      expect(warn.mock.calls[0][0]).toContain("may need reconciling");
+      expect(error).toHaveBeenCalledTimes(1);
+      expect(error.mock.calls[0][1]).toContain("need reconciling by hand");
     });
   });
 
@@ -469,7 +468,7 @@ describe("rollbackExperimentAfterHoldoutFailure guard", () => {
 
       const savedGroupTargeting = [{ match: "all" as const, ids: ["grp_1"] }];
       await updateHoldoutWithExperiment(makeContext(holdoutUpdate), {
-        holdout: makeHoldout(),
+        holdout: makeRollbackHoldout(),
         experiment,
         body: {
           targetingCondition: '{"country":"US"}',
@@ -487,14 +486,14 @@ describe("rollbackExperimentAfterHoldoutFailure guard", () => {
         expect(phase.savedGroups).toEqual(savedGroupTargeting);
         expect(phase.coverage).toBe(expectedCoverage);
       }
-      // Non-targeting fields on each phase are preserved.
+      // Non-targeting fields are preserved.
       expect(changes.phases[0].name).toBe("Holdout");
       expect(changes.phases[1].name).toBe("Analysis");
     });
   });
 
   describe("lifecycle transitions", () => {
-    it("guards the rollback on the status and phases it wrote", async () => {
+    it("rolls back to the status and phases it wrote", async () => {
       const experiment = makeRollbackExperiment({ status: "running" });
       mockUpdateExperiment
         .mockResolvedValueOnce(makeRollbackExperiment({ status: "stopped" }))
@@ -512,11 +511,8 @@ describe("rollbackExperimentAfterHoldoutFailure guard", () => {
       ).rejects.toThrow("holdout down");
 
       expect(mockUpdateExperiment).toHaveBeenCalledTimes(2);
-      const forwardChanges = mockUpdateExperiment.mock.calls[0][0].changes;
       const rollbackCall = mockUpdateExperiment.mock.calls[1][0];
-      // The guard is exactly the changeset the forward write applied.
-      expect(rollbackCall.guard).toBe(forwardChanges);
-      expect(rollbackCall.guard.status).toBe("stopped");
+      expect(rollbackCall.guard).toBeUndefined();
       expect(rollbackCall.changes.status).toBe("running");
     });
 
@@ -531,7 +527,7 @@ describe("rollbackExperimentAfterHoldoutFailure guard", () => {
 
       await expect(
         setHoldoutStage(makeContext(holdoutUpdate), {
-          holdout: makeHoldout(),
+          holdout: makeRollbackHoldout(),
           experiment,
           stage: "stopped",
         }),
@@ -540,8 +536,7 @@ describe("rollbackExperimentAfterHoldoutFailure guard", () => {
       const events = mockQueueSDKPayloadRefresh.mock.calls.map(
         ([arg]) => arg.auditContext.event,
       );
-      // The forward lifecycle refresh must not run once the transition rolls
-      // back; only the reverted-state refresh should reach the SDK caches.
+      // Only the reverted-state refresh runs, not the forward one.
       expect(events).toEqual(["Reverted: Status changed to stopped"]);
     });
   });

--- a/packages/back-end/test/services/holdouts.test.ts
+++ b/packages/back-end/test/services/holdouts.test.ts
@@ -7,6 +7,7 @@ import { logger } from "back-end/src/util/logger";
 import type { ReqContext } from "back-end/types/request";
 import {
   getHoldoutLivePayloadChanges,
+  assertValidHoldoutEnvironments,
   getNextScheduledStatusUpdateForStage,
   isHoldoutExperiment,
   normalizeHoldoutScheduleUpdates,
@@ -495,5 +496,61 @@ describe("rollbackExperimentAfterHoldoutFailure guard", () => {
       // back; only the reverted-state refresh should reach the SDK caches.
       expect(events).toEqual(["Reverted: Status changed to stopped"]);
     });
+  });
+});
+
+describe("assertValidHoldoutEnvironments", () => {
+  const context = {
+    org: {
+      id: "org",
+      settings: {
+        environments: [{ id: "production" }, { id: "staging" }],
+      },
+    },
+  } as unknown as ReqContext;
+
+  it("passes when every id exists in the org", () => {
+    expect(() =>
+      assertValidHoldoutEnvironments(context, {
+        production: { enabled: true },
+        staging: { enabled: false },
+      }),
+    ).not.toThrow();
+  });
+
+  it("throws when an id does not exist in the org", () => {
+    expect(() =>
+      assertValidHoldoutEnvironments(context, {
+        production: { enabled: true },
+        made_up: { enabled: true },
+      }),
+    ).toThrow(/Invalid environment: made_up/);
+  });
+
+  it("is a no-op for undefined or null", () => {
+    expect(() =>
+      assertValidHoldoutEnvironments(context, undefined),
+    ).not.toThrow();
+    expect(() => assertValidHoldoutEnvironments(context, null)).not.toThrow();
+  });
+
+  it("tolerates ids already stored on the holdout", () => {
+    expect(() =>
+      assertValidHoldoutEnvironments(
+        context,
+        { deleted: { enabled: false } },
+        { deleted: { enabled: true } },
+      ),
+    ).not.toThrow();
+  });
+
+  it("still rejects newly introduced ids on update", () => {
+    expect(() =>
+      assertValidHoldoutEnvironments(
+        context,
+        { deleted: { enabled: false }, made_up: { enabled: true } },
+        { deleted: { enabled: true } },
+      ),
+    ).toThrow(/Invalid environment: made_up/);
   });
 });

--- a/packages/front-end/components/Experiment/TabbedPage/HoldoutEnvironments.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/HoldoutEnvironments.tsx
@@ -1,4 +1,5 @@
 import { FeatureEnvironment } from "shared/types/feature";
+import { getEnabledHoldoutEnvironments } from "shared/util";
 import Link from "@/ui/Link";
 import Text from "@/ui/Text";
 import Frame from "@/ui/Frame";
@@ -22,11 +23,7 @@ export default function HoldoutEnvironments({
           <Text weight="semibold">Edit</Text>
         </Link>
       </div>
-      <div>
-        {Object.keys(environments)
-          .filter((e) => environments[e].enabled)
-          .join(", ")}
-      </div>
+      <div>{getEnabledHoldoutEnvironments(environments).join(", ")}</div>
     </Frame>
   );
 }

--- a/packages/front-end/components/Features/HoldoutRule.tsx
+++ b/packages/front-end/components/Features/HoldoutRule.tsx
@@ -6,7 +6,10 @@ import { ExperimentInterfaceStringDates } from "shared/types/experiment";
 import { MinimalFeatureRevisionInterface } from "shared/types/feature-revision";
 import { PiArrowBendRightDown } from "react-icons/pi";
 import { BsThreeDotsVertical } from "react-icons/bs";
-import { filterEnvironmentsByFeature } from "shared/util";
+import {
+  filterEnvironmentsByFeature,
+  getEnabledHoldoutEnvironments,
+} from "shared/util";
 import { hasTargetingConfigured } from "shared/experiments";
 import Link from "@/ui/Link";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
@@ -86,11 +89,9 @@ export const HoldoutRule = forwardRef<HTMLDivElement, Props>(
 
     // Holdout env scope lives on the holdout itself (not the feature link).
     // Show envs where the holdout is enabled as active, the rest as inactive.
-    const activeHoldoutEnvIds = Object.entries(
-      holdout.environmentSettings ?? {},
-    )
-      .filter(([, s]) => s?.enabled)
-      .map(([id]) => id);
+    const activeHoldoutEnvIds = getEnabledHoldoutEnvironments(
+      holdout.environmentSettings,
+    );
 
     const hasCondition = hasTargetingConfigured(holdoutExperiment.phases[0]);
 

--- a/packages/shared/src/util/holdouts.ts
+++ b/packages/shared/src/util/holdouts.ts
@@ -12,17 +12,21 @@ export const DEFAULT_HOLDOUT_SIZE = 0.05;
 /**
  * Enabled environment ids from a holdout-style environment map. Accepts both the
  * internal `environmentSettings` shape and the REST `environments` shape since
- * both expose `enabled`.
+ * both expose `enabled`. Pass `allowedEnvs` to drop ids that no longer exist in
+ * the org (e.g. a deleted environment still lingering in stored settings).
  */
 export function getEnabledHoldoutEnvironments(
   environmentSettings:
     | Record<string, { enabled?: boolean } | undefined>
     | undefined
     | null,
+  allowedEnvs?: string[],
 ): string[] {
   if (!environmentSettings) return [];
+  const allowed = allowedEnvs ? new Set(allowedEnvs) : null;
   return Object.keys(environmentSettings).filter(
-    (env) => environmentSettings[env]?.enabled,
+    (env) =>
+      environmentSettings[env]?.enabled && (!allowed || allowed.has(env)),
   );
 }
 

--- a/packages/shared/src/util/holdouts.ts
+++ b/packages/shared/src/util/holdouts.ts
@@ -60,8 +60,5 @@ export function isHoldoutStageTransitionAllowed(
   currentStage: HoldoutStage,
   targetStage: HoldoutStage,
 ): boolean {
-  return (
-    currentStage === targetStage ||
-    getAllowedHoldoutStageSources(targetStage).includes(currentStage)
-  );
+  return getAllowedHoldoutStageSources(targetStage).includes(currentStage);
 }

--- a/packages/shared/src/util/holdouts.ts
+++ b/packages/shared/src/util/holdouts.ts
@@ -37,3 +37,31 @@ export function getHoldoutStage(
   if (exp.status === "stopped") return "stopped";
   return holdout.analysisStartDate ? "analysis-period" : "running";
 }
+
+export function getAllowedHoldoutStageSources(
+  targetStage: HoldoutStage,
+): HoldoutStage[] {
+  switch (targetStage) {
+    case "draft":
+      return [];
+    case "running":
+      return ["draft"];
+    case "analysis-period":
+      return ["running"];
+    case "stopped":
+      return ["running", "analysis-period"];
+    default:
+      targetStage satisfies never;
+      return [];
+  }
+}
+
+export function isHoldoutStageTransitionAllowed(
+  currentStage: HoldoutStage,
+  targetStage: HoldoutStage,
+): boolean {
+  return (
+    currentStage === targetStage ||
+    getAllowedHoldoutStageSources(targetStage).includes(currentStage)
+  );
+}

--- a/packages/shared/src/util/holdouts.ts
+++ b/packages/shared/src/util/holdouts.ts
@@ -9,6 +9,23 @@ export const MAX_HOLDOUT_SIZE = 0.5;
 
 export const DEFAULT_HOLDOUT_SIZE = 0.05;
 
+/**
+ * Enabled environment ids from a holdout-style environment map. Accepts both the
+ * internal `environmentSettings` shape and the REST `environments` shape since
+ * both expose `enabled`.
+ */
+export function getEnabledHoldoutEnvironments(
+  environmentSettings:
+    | Record<string, { enabled?: boolean } | undefined>
+    | undefined
+    | null,
+): string[] {
+  if (!environmentSettings) return [];
+  return Object.keys(environmentSettings).filter(
+    (env) => environmentSettings[env]?.enabled,
+  );
+}
+
 export function holdoutSizeToCoverage(holdoutSize: number): number {
   return holdoutSize * 2;
 }

--- a/packages/shared/src/validators/holdout.ts
+++ b/packages/shared/src/validators/holdout.ts
@@ -218,7 +218,7 @@ export const apiHoldoutValidator = namedSchema(
     skipAsDefaultHoldout: z
       .boolean()
       .describe(
-        "When true, this Holdout is not pre-selected for new Feature Flags and experiments in its Projects.",
+        "When true, this Holdout is not selected automatically when creating Feature Flags or experiments in Projects assigned to the Holdout.",
       ),
 
     // Targeting and sizing
@@ -300,7 +300,12 @@ export const apiCreateHoldoutBody = z.strictObject({
     .optional(),
   owner: ownerInputField.optional(),
   tags: z.array(z.string()).optional(),
-  skipAsDefaultHoldout: z.boolean().optional(),
+  skipAsDefaultHoldout: z
+    .boolean()
+    .describe(
+      "When true, this Holdout is not selected automatically when creating Feature Flags or Experiments in Projects assigned to the Holdout.",
+    )
+    .optional(),
 
   holdoutSize: holdoutSizeField
     .describe(
@@ -342,7 +347,12 @@ export const apiUpdateHoldoutBody = z.strictObject({
   owner: ownerInputField.optional(),
   tags: z.array(z.string()).optional(),
   archived: z.boolean().optional(),
-  skipAsDefaultHoldout: z.boolean().optional(),
+  skipAsDefaultHoldout: z
+    .boolean()
+    .describe(
+      "When true, this Holdout is not selected automatically when creating Feature Flags or Experiments in Projects assigned to the Holdout.",
+    )
+    .optional(),
 
   holdoutSize: holdoutSizeField.optional(),
   hashAttribute: z.string().optional(),

--- a/packages/shared/src/validators/holdout.ts
+++ b/packages/shared/src/validators/holdout.ts
@@ -295,7 +295,7 @@ export const apiListHoldoutsValidator = {
 };
 
 export const apiCreateHoldoutBody = z.strictObject({
-  name: z.string(),
+  name: z.string().min(1, "Holdout name cannot be empty"),
   description: z.string().max(MAX_DESCRIPTION_LENGTH).optional(),
   projects: z
     .array(z.string())
@@ -341,7 +341,7 @@ export const apiCreateHoldoutBody = z.strictObject({
 export type ApiCreateHoldoutBody = z.infer<typeof apiCreateHoldoutBody>;
 
 export const apiUpdateHoldoutBody = z.strictObject({
-  name: z.string().optional(),
+  name: z.string().min(1, "Holdout name cannot be empty").optional(),
   description: z.string().max(MAX_DESCRIPTION_LENGTH).optional(),
   projects: z.array(z.string()).optional(),
   owner: ownerInputField.optional(),

--- a/packages/shared/src/validators/holdout.ts
+++ b/packages/shared/src/validators/holdout.ts
@@ -159,10 +159,10 @@ const apiHoldoutLinkedItem = z.object({
  */
 const holdoutSizeField = z
   .number()
-  .min(0)
+  .positive("Holdout size must be greater than 0")
   .max(MAX_HOLDOUT_SIZE)
   .describe(
-    "Proportion of traffic held out, expressed as a decimal (e.g. 0.05 for 5%). An equally-sized control group is bucketed alongside it, so the Holdout occupies twice this share of traffic in total. Maximum 0.5.",
+    "Proportion of traffic held out, expressed as a decimal (e.g. 0.05 for 5%). An equally-sized control group is bucketed alongside it, so the Holdout occupies twice this share of traffic in total. Must be greater than 0 and at most 0.5.",
   );
 
 const apiHoldoutStatusUpdateSchedule = z

--- a/packages/shared/src/validators/holdout.ts
+++ b/packages/shared/src/validators/holdout.ts
@@ -236,6 +236,10 @@ export const apiHoldoutValidator = namedSchema(
     assignmentQueryId: z.string(),
     goalMetrics: z.array(z.string()),
     secondaryMetrics: z.array(z.string()),
+    statsEngine: z
+      .enum(statsEngines)
+      .describe("Statistics engine used to analyze this Holdout.")
+      .optional(),
     variations: z.array(apiHoldoutVariation),
 
     environments: z

--- a/packages/shared/src/validators/holdout.ts
+++ b/packages/shared/src/validators/holdout.ts
@@ -214,11 +214,6 @@ export const apiHoldoutValidator = namedSchema(
       .describe(
         "Lifecycle stage of the Holdout. Use the start, start-analysis, and stop endpoints to move through the lifecycle.",
       ),
-    experimentId: z
-      .string()
-      .describe(
-        "ID of the companion experiment that stores this Holdout's analysis settings and results.",
-      ),
     trackingKey: z.string(),
     skipAsDefaultHoldout: z
       .boolean()

--- a/packages/shared/src/validators/holdout.ts
+++ b/packages/shared/src/validators/holdout.ts
@@ -212,7 +212,7 @@ export const apiHoldoutValidator = namedSchema(
     stage: z
       .enum(holdoutStage)
       .describe(
-        "Lifecycle stage of the Holdout. Change it with POST /holdouts/{id}/stage.",
+        "Lifecycle stage of the Holdout. Use the start, start-analysis, and stop endpoints to move through the lifecycle.",
       ),
     experimentId: z
       .string()
@@ -407,14 +407,12 @@ export const HOLDOUT_API_TARGETING_UPDATE_FIELDS = [
   "savedGroupTargeting",
 ] as const satisfies readonly (keyof ApiUpdateHoldoutBody)[];
 
-export const apiHoldoutStageValidator = {
+export const apiHoldoutActionValidator = {
   paramsSchema: z.strictObject({ id: z.string() }),
-  bodySchema: z.strictObject({
-    stage: z.enum(holdoutStage).describe("The stage to move the Holdout to."),
-  }),
+  bodySchema: z.never(),
   querySchema: z.never(),
 };
 
-export const apiHoldoutStageReturn = z.object({
+export const apiHoldoutActionReturn = z.object({
   holdout: apiHoldoutValidator,
 });

--- a/packages/shared/src/validators/holdout.ts
+++ b/packages/shared/src/validators/holdout.ts
@@ -215,6 +215,11 @@ export const apiHoldoutValidator = namedSchema(
         "Lifecycle stage of the Holdout. Use the start, start-analysis, and stop endpoints to move through the lifecycle.",
       ),
     trackingKey: z.string(),
+    experimentId: z
+      .string()
+      .describe(
+        "ID of the companion experiment that stores this Holdout's analysis. Use it with the experiment results endpoints (e.g. GET /experiments/{experimentId}/results).",
+      ),
     skipAsDefaultHoldout: z
       .boolean()
       .describe(

--- a/packages/shared/src/validators/holdout.ts
+++ b/packages/shared/src/validators/holdout.ts
@@ -412,9 +412,7 @@ export const HOLDOUT_API_EXPERIMENT_UPDATE_FIELDS = [
 ] as const satisfies readonly (keyof ApiUpdateHoldoutBody)[];
 
 /**
- * Update fields applied to the holdout experiment's current phase. These follow
- * the same path as the internal targeting endpoint rather than a plain update,
- * so the SDK payload and phase history stay correct.
+ * Update fields applied to the holdout's companion experiment.
  */
 export const HOLDOUT_API_TARGETING_UPDATE_FIELDS = [
   "holdoutSize",

--- a/packages/shared/src/validators/holdout.ts
+++ b/packages/shared/src/validators/holdout.ts
@@ -1,9 +1,16 @@
 import { z } from "zod";
 import { statsEngines, MAX_DESCRIPTION_LENGTH } from "shared/constants";
-import { MAX_HOLDOUT_SIZE } from "../util/holdouts";
+import { holdoutStage, MAX_HOLDOUT_SIZE } from "shared/util";
+import { apiBaseSchema } from "./base-model";
 import { featureEnvironment } from "./features";
-import { savedGroupTargeting } from "./shared";
-import { optionalOwnerInputField } from "./owner-field";
+import { namedSchema } from "./openapi-helpers";
+import {
+  optionalOwnerInputField,
+  ownerEmailField,
+  ownerField,
+  ownerInputField,
+} from "./owner-field";
+import { booleanQueryField, savedGroupTargeting } from "./shared";
 
 export const holdoutLinkedItemValidator = z.object({
   dateAdded: z.date(),
@@ -114,6 +121,8 @@ export const createHoldoutInputValidator = z.object({
   assignmentQueryId: z.string().optional(),
   goalMetrics: z.array(z.string()).optional(),
   secondaryMetrics: z.array(z.string()).optional(),
+  guardrailMetrics: z.array(z.string()).optional(),
+  activationMetric: z.string().optional(),
 
   environmentSettings: z.record(z.string(), featureEnvironment).optional(),
   statsEngine: z.enum(statsEngines).optional(),
@@ -121,3 +130,304 @@ export const createHoldoutInputValidator = z.object({
 });
 
 export type CreateHoldoutInput = z.infer<typeof createHoldoutInputValidator>;
+
+// ---------------------------------------------------------------------------
+// API validators
+// ---------------------------------------------------------------------------
+
+const apiHoldoutVariation = z.object({
+  variationId: z.string(),
+  key: z.string(),
+  name: z.string(),
+  description: z.string().max(MAX_DESCRIPTION_LENGTH).optional(),
+});
+
+const apiHoldoutEnvironment = z.object({
+  enabled: z
+    .boolean()
+    .describe("Whether the Holdout is active in this environment."),
+});
+
+const apiHoldoutLinkedItem = z.object({
+  id: z.string(),
+  dateAdded: z.iso.datetime(),
+});
+
+/**
+ * The share of traffic held out, as a proportion.
+ *
+ * Stored internally as the experiment phase's `coverage`, which is twice this
+ * value: a `holdoutSize` of 0.05 corresponds to a `coverage` of 0.1.
+ */
+const holdoutSizeField = z
+  .number()
+  .min(0)
+  .max(MAX_HOLDOUT_SIZE)
+  .describe(
+    "Proportion of traffic held out, expressed as a decimal (e.g. 0.05 for 5%). An equally-sized control group is bucketed alongside it, so the Holdout occupies twice this share of traffic in total. Maximum 0.5.",
+  );
+
+const apiHoldoutStatusUpdateSchedule = z
+  .object({
+    startAt: z.iso
+      .datetime()
+      .describe(
+        "ISO datetime to move the Holdout from `draft` to `running`. Must be in the future while the Holdout is still a draft.",
+      )
+      .optional(),
+    startAnalysisPeriodAt: z.iso
+      .datetime()
+      .describe(
+        "ISO datetime to move the Holdout from `running` to `analysis-period`. Requires `startAt` while the Holdout is still a draft.",
+      )
+      .optional(),
+    stopAt: z.iso
+      .datetime()
+      .describe(
+        "ISO datetime to stop the Holdout. Requires `startAnalysisPeriodAt` unless the analysis period has already begun.",
+      )
+      .optional(),
+  })
+  .describe(
+    "Automatic stage transitions for the Holdout. Dates must be consecutive: `startAt` before `startAnalysisPeriodAt` before `stopAt`. Send `null` to delete the schedule.",
+  );
+
+/**
+ * Read shape for a Holdout. A Holdout is stored as two documents — the holdout
+ * itself and a companion experiment of type `holdout` — and this schema merges
+ * both so callers never have to know which half a field lives on.
+ */
+export const apiHoldoutValidator = namedSchema(
+  "Holdout",
+  apiBaseSchema.safeExtend({
+    name: z.string(),
+    description: z.string().max(MAX_DESCRIPTION_LENGTH),
+    projects: z
+      .array(z.string())
+      .describe(
+        "Project IDs this Holdout applies to. An empty array means All Projects.",
+      ),
+    owner: ownerField,
+    ownerEmail: ownerEmailField,
+    tags: z.array(z.string()),
+    archived: z.boolean(),
+    stage: z
+      .enum(holdoutStage)
+      .describe(
+        "Lifecycle stage of the Holdout. Change it with POST /holdouts/{id}/stage.",
+      ),
+    experimentId: z
+      .string()
+      .describe(
+        "ID of the companion experiment that stores this Holdout's analysis settings and results.",
+      ),
+    trackingKey: z.string(),
+    skipAsDefaultHoldout: z
+      .boolean()
+      .describe(
+        "When true, this Holdout is not pre-selected for new Feature Flags and experiments in its Projects.",
+      ),
+
+    // Targeting and sizing
+    holdoutSize: holdoutSizeField,
+    hashAttribute: z
+      .string()
+      .describe("Attribute used to assign users to the Holdout."),
+    targetingCondition: z
+      .string()
+      .describe("Targeting condition as a JSON string."),
+    savedGroups: z.array(savedGroupTargeting).optional(),
+
+    // Analysis settings
+    datasourceId: z.string(),
+    assignmentQueryId: z.string(),
+    goalMetrics: z.array(z.string()),
+    secondaryMetrics: z.array(z.string()),
+    guardrailMetrics: z.array(z.string()),
+    activationMetric: z.string().optional(),
+    variations: z.array(apiHoldoutVariation),
+
+    environments: z
+      .record(z.string(), apiHoldoutEnvironment)
+      .describe(
+        "Per-environment state, keyed by environment ID. Environments not present are disabled.",
+      ),
+
+    linkedFeatures: z
+      .array(apiHoldoutLinkedItem)
+      .describe(
+        "Feature Flags held out by this Holdout. Manage these through the Feature Flag endpoints.",
+      ),
+    linkedExperiments: z
+      .array(apiHoldoutLinkedItem)
+      .describe(
+        "Experiments held out by this Holdout. Manage these through the experiment endpoints.",
+      ),
+
+    dateStarted: z.iso.datetime().optional(),
+    analysisStartDate: z.iso
+      .datetime()
+      .describe("When the Holdout entered its analysis period.")
+      .optional(),
+    dateStopped: z.iso.datetime().optional(),
+
+    statusUpdateSchedule: apiHoldoutStatusUpdateSchedule.nullable().optional(),
+    nextScheduledStatusUpdate: z
+      .object({
+        type: z.enum(["start", "startAnalysisPeriod", "stop"]),
+        date: z.iso.datetime(),
+      })
+      .describe("The next stage transition that will run automatically.")
+      .nullable()
+      .optional(),
+  }),
+);
+
+export type ApiHoldoutInterface = z.infer<typeof apiHoldoutValidator>;
+
+export const apiListHoldoutsValidator = {
+  bodySchema: z.never(),
+  querySchema: z.strictObject({
+    projectId: z.string().optional(),
+    datasourceId: z.string().optional(),
+    stage: z.enum(holdoutStage).optional(),
+    archived: booleanQueryField.describe(
+      "Filter by archived state. Omit to return both archived and unarchived Holdouts.",
+    ),
+  }),
+  paramsSchema: z.never(),
+};
+
+export const apiCreateHoldoutBody = z.strictObject({
+  name: z.string(),
+  description: z.string().max(MAX_DESCRIPTION_LENGTH).optional(),
+  projects: z
+    .array(z.string())
+    .describe(
+      "Project IDs this Holdout applies to. Omit or send an empty array for All Projects.",
+    )
+    .optional(),
+  owner: ownerInputField.optional(),
+  tags: z.array(z.string()).optional(),
+  skipAsDefaultHoldout: z.boolean().optional(),
+
+  holdoutSize: holdoutSizeField
+    .describe(
+      "Proportion of traffic held out, expressed as a decimal (e.g. 0.05 for 5%). An equally-sized control group is bucketed alongside it. Defaults to 0.05. Maximum 0.5.",
+    )
+    .optional(),
+  hashAttribute: z.string().optional(),
+  targetingCondition: z
+    .string()
+    .describe("Targeting condition as a JSON string.")
+    .optional(),
+  savedGroups: z.array(savedGroupTargeting).optional(),
+
+  datasourceId: z.string().optional(),
+  assignmentQueryId: z.string().optional(),
+  goalMetrics: z.array(z.string()).optional(),
+  secondaryMetrics: z.array(z.string()).optional(),
+  guardrailMetrics: z.array(z.string()).optional(),
+  activationMetric: z.string().optional(),
+
+  environments: z
+    .record(z.string(), apiHoldoutEnvironment)
+    .describe(
+      "Per-environment state, keyed by environment ID. Environments not listed are disabled.",
+    )
+    .optional(),
+
+  statusUpdateSchedule: apiHoldoutStatusUpdateSchedule.optional(),
+});
+
+export type ApiCreateHoldoutBody = z.infer<typeof apiCreateHoldoutBody>;
+
+export const apiUpdateHoldoutBody = z.strictObject({
+  name: z.string().optional(),
+  description: z.string().max(MAX_DESCRIPTION_LENGTH).optional(),
+  projects: z.array(z.string()).optional(),
+  owner: ownerInputField.optional(),
+  tags: z.array(z.string()).optional(),
+  archived: z.boolean().optional(),
+  skipAsDefaultHoldout: z.boolean().optional(),
+
+  holdoutSize: holdoutSizeField.optional(),
+  hashAttribute: z.string().optional(),
+  targetingCondition: z.string().optional(),
+  savedGroups: z.array(savedGroupTargeting).optional(),
+
+  datasourceId: z.string().optional(),
+  assignmentQueryId: z.string().optional(),
+  goalMetrics: z.array(z.string()).optional(),
+  secondaryMetrics: z.array(z.string()).optional(),
+  guardrailMetrics: z.array(z.string()).optional(),
+  activationMetric: z.string().optional(),
+  variations: z
+    .array(
+      z.object({
+        variationId: z.string(),
+        name: z.string().optional(),
+        description: z.string().max(MAX_DESCRIPTION_LENGTH).optional(),
+      }),
+    )
+    .describe(
+      "Rename a Holdout's variations. A Holdout always has exactly two variations, so they cannot be added or removed.",
+    )
+    .optional(),
+
+  environments: z
+    .record(z.string(), apiHoldoutEnvironment)
+    .describe(
+      "Replaces the entire per-environment state. Environments not listed are disabled.",
+    )
+    .optional(),
+
+  statusUpdateSchedule: apiHoldoutStatusUpdateSchedule.nullable().optional(),
+});
+
+export type ApiUpdateHoldoutBody = z.infer<typeof apiUpdateHoldoutBody>;
+
+/**
+ * Update fields stored on the holdout document itself. `name` is deliberately
+ * absent — it lives on both documents and is mirrored explicitly.
+ */
+export const HOLDOUT_API_UPDATE_FIELDS = [
+  "projects",
+  "skipAsDefaultHoldout",
+] as const satisfies readonly (keyof ApiUpdateHoldoutBody)[];
+
+/** Update fields stored on the companion experiment document. */
+export const HOLDOUT_API_EXPERIMENT_UPDATE_FIELDS = [
+  "description",
+  "owner",
+  "tags",
+  "archived",
+  "goalMetrics",
+  "secondaryMetrics",
+  "guardrailMetrics",
+  "activationMetric",
+] as const satisfies readonly (keyof ApiUpdateHoldoutBody)[];
+
+/**
+ * Update fields applied to the holdout experiment's current phase. These follow
+ * the same path as the internal targeting endpoint rather than a plain update,
+ * so the SDK payload and phase history stay correct.
+ */
+export const HOLDOUT_API_TARGETING_UPDATE_FIELDS = [
+  "holdoutSize",
+  "hashAttribute",
+  "targetingCondition",
+  "savedGroups",
+] as const satisfies readonly (keyof ApiUpdateHoldoutBody)[];
+
+export const apiHoldoutStageValidator = {
+  paramsSchema: z.strictObject({ id: z.string() }),
+  bodySchema: z.strictObject({
+    stage: z.enum(holdoutStage).describe("The stage to move the Holdout to."),
+  }),
+  querySchema: z.never(),
+};
+
+export const apiHoldoutStageReturn = z.object({
+  holdout: apiHoldoutValidator,
+});

--- a/packages/shared/src/validators/holdout.ts
+++ b/packages/shared/src/validators/holdout.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { statsEngines, MAX_DESCRIPTION_LENGTH } from "shared/constants";
-import { holdoutStage, MAX_HOLDOUT_SIZE } from "shared/util";
+import { MAX_HOLDOUT_SIZE, holdoutStage } from "../util/holdouts";
 import { apiBaseSchema } from "./base-model";
 import { featureEnvironment } from "./features";
 import { namedSchema } from "./openapi-helpers";

--- a/packages/shared/src/validators/holdout.ts
+++ b/packages/shared/src/validators/holdout.ts
@@ -121,8 +121,6 @@ export const createHoldoutInputValidator = z.object({
   assignmentQueryId: z.string().optional(),
   goalMetrics: z.array(z.string()).optional(),
   secondaryMetrics: z.array(z.string()).optional(),
-  guardrailMetrics: z.array(z.string()).optional(),
-  activationMetric: z.string().optional(),
 
   environmentSettings: z.record(z.string(), featureEnvironment).optional(),
   statsEngine: z.enum(statsEngines).optional(),
@@ -236,7 +234,7 @@ export const apiHoldoutValidator = namedSchema(
     targetingCondition: z
       .string()
       .describe("Targeting condition as a JSON string."),
-    savedGroups: z.array(savedGroupTargeting).optional(),
+    savedGroupTargeting: z.array(savedGroupTargeting).optional(),
 
     // Analysis settings
     datasourceId: z.string(),
@@ -319,12 +317,16 @@ export const apiCreateHoldoutBody = z.strictObject({
     .string()
     .describe("Targeting condition as a JSON string.")
     .optional(),
-  savedGroups: z.array(savedGroupTargeting).optional(),
+  savedGroupTargeting: z.array(savedGroupTargeting).optional(),
 
   datasourceId: z.string().optional(),
   assignmentQueryId: z.string().optional(),
   goalMetrics: z.array(z.string()).optional(),
   secondaryMetrics: z.array(z.string()).optional(),
+  statsEngine: z
+    .enum(statsEngines)
+    .describe("Statistics engine used to analyze this Holdout.")
+    .optional(),
 
   environments: z
     .record(z.string(), apiHoldoutEnvironment)
@@ -350,23 +352,15 @@ export const apiUpdateHoldoutBody = z.strictObject({
   holdoutSize: holdoutSizeField.optional(),
   hashAttribute: z.string().optional(),
   targetingCondition: z.string().optional(),
-  savedGroups: z.array(savedGroupTargeting).optional(),
+  savedGroupTargeting: z.array(savedGroupTargeting).optional(),
 
   datasourceId: z.string().optional(),
   assignmentQueryId: z.string().optional(),
   goalMetrics: z.array(z.string()).optional(),
   secondaryMetrics: z.array(z.string()).optional(),
-  variations: z
-    .array(
-      z.object({
-        variationId: z.string(),
-        name: z.string().optional(),
-        description: z.string().max(MAX_DESCRIPTION_LENGTH).optional(),
-      }),
-    )
-    .describe(
-      "Rename a Holdout's variations. A Holdout always has exactly two variations, so they cannot be added or removed.",
-    )
+  statsEngine: z
+    .enum(statsEngines)
+    .describe("Statistics engine used to analyze this Holdout.")
     .optional(),
 
   environments: z
@@ -398,6 +392,7 @@ export const HOLDOUT_API_EXPERIMENT_UPDATE_FIELDS = [
   "archived",
   "goalMetrics",
   "secondaryMetrics",
+  "statsEngine",
 ] as const satisfies readonly (keyof ApiUpdateHoldoutBody)[];
 
 /**
@@ -409,7 +404,7 @@ export const HOLDOUT_API_TARGETING_UPDATE_FIELDS = [
   "holdoutSize",
   "hashAttribute",
   "targetingCondition",
-  "savedGroups",
+  "savedGroupTargeting",
 ] as const satisfies readonly (keyof ApiUpdateHoldoutBody)[];
 
 export const apiHoldoutStageValidator = {

--- a/packages/shared/src/validators/holdout.ts
+++ b/packages/shared/src/validators/holdout.ts
@@ -243,8 +243,6 @@ export const apiHoldoutValidator = namedSchema(
     assignmentQueryId: z.string(),
     goalMetrics: z.array(z.string()),
     secondaryMetrics: z.array(z.string()),
-    guardrailMetrics: z.array(z.string()),
-    activationMetric: z.string().optional(),
     variations: z.array(apiHoldoutVariation),
 
     environments: z
@@ -327,8 +325,6 @@ export const apiCreateHoldoutBody = z.strictObject({
   assignmentQueryId: z.string().optional(),
   goalMetrics: z.array(z.string()).optional(),
   secondaryMetrics: z.array(z.string()).optional(),
-  guardrailMetrics: z.array(z.string()).optional(),
-  activationMetric: z.string().optional(),
 
   environments: z
     .record(z.string(), apiHoldoutEnvironment)
@@ -360,8 +356,6 @@ export const apiUpdateHoldoutBody = z.strictObject({
   assignmentQueryId: z.string().optional(),
   goalMetrics: z.array(z.string()).optional(),
   secondaryMetrics: z.array(z.string()).optional(),
-  guardrailMetrics: z.array(z.string()).optional(),
-  activationMetric: z.string().optional(),
   variations: z
     .array(
       z.object({
@@ -404,8 +398,6 @@ export const HOLDOUT_API_EXPERIMENT_UPDATE_FIELDS = [
   "archived",
   "goalMetrics",
   "secondaryMetrics",
-  "guardrailMetrics",
-  "activationMetric",
 ] as const satisfies readonly (keyof ApiUpdateHoldoutBody)[];
 
 /**

--- a/packages/shared/src/validators/holdout.ts
+++ b/packages/shared/src/validators/holdout.ts
@@ -393,10 +393,12 @@ export const HOLDOUT_API_UPDATE_FIELDS = [
   "skipAsDefaultHoldout",
 ] as const satisfies readonly (keyof ApiUpdateHoldoutBody)[];
 
-/** Update fields stored on the companion experiment document. */
+/**
+ * Update fields stored on the companion experiment document. `owner` is absent
+ * because it must be resolved to a user id first, so it is handled separately.
+ */
 export const HOLDOUT_API_EXPERIMENT_UPDATE_FIELDS = [
   "description",
-  "owner",
   "tags",
   "archived",
   "goalMetrics",

--- a/packages/shared/src/validators/holdout.ts
+++ b/packages/shared/src/validators/holdout.ts
@@ -162,7 +162,7 @@ const holdoutSizeField = z
   .positive("Holdout size must be greater than 0")
   .max(MAX_HOLDOUT_SIZE)
   .describe(
-    "Proportion of traffic held out, expressed as a decimal (e.g. 0.05 for 5%). An equally-sized control group is bucketed alongside it, so the Holdout occupies twice this share of traffic in total. Must be greater than 0 and at most 0.5.",
+    "Proportion of traffic placed in the holdout group (e.g. 0.05 for 5%). An equally sized comparison group is sampled from the remaining traffic for measurement, so 2× this value enters the holdout experiment in total. Must be greater than 0 and at most 0.5.",
   );
 
 const apiHoldoutStatusUpdateSchedule = z

--- a/packages/shared/src/validators/holdout.ts
+++ b/packages/shared/src/validators/holdout.ts
@@ -218,7 +218,7 @@ export const apiHoldoutValidator = namedSchema(
     experimentId: z
       .string()
       .describe(
-        "ID of the companion experiment that stores this Holdout's analysis. Use it with the experiment results endpoints (e.g. GET /experiments/{experimentId}/results).",
+        "ID of the companion experiment that stores this Holdout's analysis. Use it with the experiment results endpoints (e.g. GET /experiments/{experimentId}/results). Pass phase=0 for results across the whole Holdout period, or phase=1 for results limited to the analysis period.",
       ),
     skipAsDefaultHoldout: z
       .boolean()

--- a/packages/shared/src/validators/holdout.ts
+++ b/packages/shared/src/validators/holdout.ts
@@ -214,8 +214,6 @@ export const apiHoldoutValidator = namedSchema(
     assignmentQueryId: z.string(),
     goalMetrics: z.array(z.string()),
     secondaryMetrics: z.array(z.string()),
-    guardrailMetrics: z.array(z.string()),
-    activationMetric: z.string().optional(),
     variations: z.array(apiHoldoutVariation),
 
     environments: z
@@ -298,8 +296,6 @@ export const apiCreateHoldoutBody = z.strictObject({
   assignmentQueryId: z.string().optional(),
   goalMetrics: z.array(z.string()).optional(),
   secondaryMetrics: z.array(z.string()).optional(),
-  guardrailMetrics: z.array(z.string()).optional(),
-  activationMetric: z.string().optional(),
 
   environments: z
     .record(z.string(), apiHoldoutEnvironment)
@@ -331,8 +327,6 @@ export const apiUpdateHoldoutBody = z.strictObject({
   assignmentQueryId: z.string().optional(),
   goalMetrics: z.array(z.string()).optional(),
   secondaryMetrics: z.array(z.string()).optional(),
-  guardrailMetrics: z.array(z.string()).optional(),
-  activationMetric: z.string().optional(),
   variations: z
     .array(
       z.object({
@@ -375,8 +369,6 @@ export const HOLDOUT_API_EXPERIMENT_UPDATE_FIELDS = [
   "archived",
   "goalMetrics",
   "secondaryMetrics",
-  "guardrailMetrics",
-  "activationMetric",
 ] as const satisfies readonly (keyof ApiUpdateHoldoutBody)[];
 
 /**

--- a/packages/shared/src/validators/holdout.ts
+++ b/packages/shared/src/validators/holdout.ts
@@ -1,5 +1,11 @@
 import { z } from "zod";
+import { MAX_HOLDOUT_SIZE, holdoutStage } from "shared/util";
+import { MAX_DESCRIPTION_LENGTH } from "../constants";
+import { apiBaseSchema } from "./base-model";
 import { featureEnvironment } from "./features";
+import { namedSchema } from "./openapi-helpers";
+import { ownerEmailField, ownerField, ownerInputField } from "./owner-field";
+import { booleanQueryField, savedGroupTargeting } from "./shared";
 
 export const holdoutLinkedItemValidator = z.object({
   dateAdded: z.date(),
@@ -92,3 +98,307 @@ export type HoldoutInterface = z.infer<typeof holdoutValidator>;
 export type HoldoutInterfaceStringDates = z.infer<
   typeof _holdoutStringDatesValidator
 >;
+
+// ---------------------------------------------------------------------------
+// API validators
+// ---------------------------------------------------------------------------
+
+const apiHoldoutVariation = z.object({
+  variationId: z.string(),
+  key: z.string(),
+  name: z.string(),
+  description: z.string().max(MAX_DESCRIPTION_LENGTH).optional(),
+});
+
+const apiHoldoutEnvironment = z.object({
+  enabled: z
+    .boolean()
+    .describe("Whether the Holdout is active in this environment."),
+});
+
+const apiHoldoutLinkedItem = z.object({
+  id: z.string(),
+  dateAdded: z.iso.datetime(),
+});
+
+/** Default share of traffic held out when none is specified. */
+export const DEFAULT_HOLDOUT_SIZE = 0.05;
+
+/**
+ * The share of traffic held out, as a proportion.
+ *
+ * Stored internally as the experiment phase's `coverage`, which is twice this
+ * value: a `holdoutSize` of 0.05 corresponds to a `coverage` of 0.1.
+ */
+const holdoutSizeField = z
+  .number()
+  .min(0)
+  .max(MAX_HOLDOUT_SIZE)
+  .describe(
+    "Proportion of traffic held out, expressed as a decimal (e.g. 0.05 for 5%). An equally-sized control group is bucketed alongside it, so the Holdout occupies twice this share of traffic in total. Maximum 0.5.",
+  );
+
+const apiHoldoutStatusUpdateSchedule = z
+  .object({
+    startAt: z.iso
+      .datetime()
+      .describe(
+        "ISO datetime to move the Holdout from `draft` to `running`. Must be in the future while the Holdout is still a draft.",
+      )
+      .optional(),
+    startAnalysisPeriodAt: z.iso
+      .datetime()
+      .describe(
+        "ISO datetime to move the Holdout from `running` to `analysis-period`. Requires `startAt` while the Holdout is still a draft.",
+      )
+      .optional(),
+    stopAt: z.iso
+      .datetime()
+      .describe(
+        "ISO datetime to stop the Holdout. Requires `startAnalysisPeriodAt` unless the analysis period has already begun.",
+      )
+      .optional(),
+  })
+  .describe(
+    "Automatic stage transitions for the Holdout. Dates must be consecutive: `startAt` before `startAnalysisPeriodAt` before `stopAt`. Send `null` to delete the schedule.",
+  );
+
+/**
+ * Read shape for a Holdout. A Holdout is stored as two documents — the holdout
+ * itself and a companion experiment of type `holdout` — and this schema merges
+ * both so callers never have to know which half a field lives on.
+ */
+export const apiHoldoutValidator = namedSchema(
+  "Holdout",
+  apiBaseSchema.safeExtend({
+    name: z.string(),
+    description: z.string().max(MAX_DESCRIPTION_LENGTH),
+    projects: z
+      .array(z.string())
+      .describe(
+        "Project IDs this Holdout applies to. An empty array means All Projects.",
+      ),
+    owner: ownerField,
+    ownerEmail: ownerEmailField,
+    tags: z.array(z.string()),
+    archived: z.boolean(),
+    stage: z
+      .enum(holdoutStage)
+      .describe(
+        "Lifecycle stage of the Holdout. Change it with POST /holdouts/{id}/stage.",
+      ),
+    experimentId: z
+      .string()
+      .describe(
+        "ID of the companion experiment that stores this Holdout's analysis settings and results.",
+      ),
+    trackingKey: z.string(),
+    skipAsDefaultHoldout: z
+      .boolean()
+      .describe(
+        "When true, this Holdout is not pre-selected for new Feature Flags and experiments in its Projects.",
+      ),
+
+    // Targeting and sizing
+    holdoutSize: holdoutSizeField,
+    hashAttribute: z
+      .string()
+      .describe("Attribute used to assign users to the Holdout."),
+    targetingCondition: z
+      .string()
+      .describe("Targeting condition as a JSON string."),
+    savedGroups: z.array(savedGroupTargeting).optional(),
+
+    // Analysis settings
+    datasourceId: z.string(),
+    assignmentQueryId: z.string(),
+    goalMetrics: z.array(z.string()),
+    secondaryMetrics: z.array(z.string()),
+    guardrailMetrics: z.array(z.string()),
+    activationMetric: z.string().optional(),
+    variations: z.array(apiHoldoutVariation),
+
+    environments: z
+      .record(z.string(), apiHoldoutEnvironment)
+      .describe(
+        "Per-environment state, keyed by environment ID. Environments not present are disabled.",
+      ),
+
+    linkedFeatures: z
+      .array(apiHoldoutLinkedItem)
+      .describe(
+        "Feature Flags held out by this Holdout. Manage these through the Feature Flag endpoints.",
+      ),
+    linkedExperiments: z
+      .array(apiHoldoutLinkedItem)
+      .describe(
+        "Experiments held out by this Holdout. Manage these through the experiment endpoints.",
+      ),
+
+    dateStarted: z.iso.datetime().optional(),
+    analysisStartDate: z.iso
+      .datetime()
+      .describe("When the Holdout entered its analysis period.")
+      .optional(),
+    dateStopped: z.iso.datetime().optional(),
+
+    statusUpdateSchedule: apiHoldoutStatusUpdateSchedule.nullable().optional(),
+    nextScheduledStatusUpdate: z
+      .object({
+        type: z.enum(["start", "startAnalysisPeriod", "stop"]),
+        date: z.iso.datetime(),
+      })
+      .describe("The next stage transition that will run automatically.")
+      .nullable()
+      .optional(),
+  }),
+);
+
+export type ApiHoldoutInterface = z.infer<typeof apiHoldoutValidator>;
+
+export const apiListHoldoutsValidator = {
+  bodySchema: z.never(),
+  querySchema: z.strictObject({
+    projectId: z.string().optional(),
+    datasourceId: z.string().optional(),
+    stage: z.enum(holdoutStage).optional(),
+    archived: booleanQueryField.describe(
+      "Filter by archived state. Omit to return both archived and unarchived Holdouts.",
+    ),
+  }),
+  paramsSchema: z.never(),
+};
+
+export const apiCreateHoldoutBody = z.strictObject({
+  name: z.string(),
+  description: z.string().max(MAX_DESCRIPTION_LENGTH).optional(),
+  projects: z
+    .array(z.string())
+    .describe(
+      "Project IDs this Holdout applies to. Omit or send an empty array for All Projects.",
+    )
+    .optional(),
+  owner: ownerInputField.optional(),
+  tags: z.array(z.string()).optional(),
+  skipAsDefaultHoldout: z.boolean().optional(),
+
+  holdoutSize: holdoutSizeField
+    .describe(
+      "Proportion of traffic held out, expressed as a decimal (e.g. 0.05 for 5%). An equally-sized control group is bucketed alongside it. Defaults to 0.05. Maximum 0.5.",
+    )
+    .optional(),
+  hashAttribute: z.string().optional(),
+  targetingCondition: z
+    .string()
+    .describe("Targeting condition as a JSON string.")
+    .optional(),
+  savedGroups: z.array(savedGroupTargeting).optional(),
+
+  datasourceId: z.string().optional(),
+  assignmentQueryId: z.string().optional(),
+  goalMetrics: z.array(z.string()).optional(),
+  secondaryMetrics: z.array(z.string()).optional(),
+  guardrailMetrics: z.array(z.string()).optional(),
+  activationMetric: z.string().optional(),
+
+  environments: z
+    .record(z.string(), apiHoldoutEnvironment)
+    .describe(
+      "Per-environment state, keyed by environment ID. Environments not listed are disabled.",
+    )
+    .optional(),
+
+  statusUpdateSchedule: apiHoldoutStatusUpdateSchedule.optional(),
+});
+
+export type ApiCreateHoldoutBody = z.infer<typeof apiCreateHoldoutBody>;
+
+export const apiUpdateHoldoutBody = z.strictObject({
+  name: z.string().optional(),
+  description: z.string().max(MAX_DESCRIPTION_LENGTH).optional(),
+  projects: z.array(z.string()).optional(),
+  owner: ownerInputField.optional(),
+  tags: z.array(z.string()).optional(),
+  archived: z.boolean().optional(),
+  skipAsDefaultHoldout: z.boolean().optional(),
+
+  holdoutSize: holdoutSizeField.optional(),
+  hashAttribute: z.string().optional(),
+  targetingCondition: z.string().optional(),
+  savedGroups: z.array(savedGroupTargeting).optional(),
+
+  datasourceId: z.string().optional(),
+  assignmentQueryId: z.string().optional(),
+  goalMetrics: z.array(z.string()).optional(),
+  secondaryMetrics: z.array(z.string()).optional(),
+  guardrailMetrics: z.array(z.string()).optional(),
+  activationMetric: z.string().optional(),
+  variations: z
+    .array(
+      z.object({
+        variationId: z.string(),
+        name: z.string().optional(),
+        description: z.string().max(MAX_DESCRIPTION_LENGTH).optional(),
+      }),
+    )
+    .describe(
+      "Rename a Holdout's variations. A Holdout always has exactly two variations, so they cannot be added or removed.",
+    )
+    .optional(),
+
+  environments: z
+    .record(z.string(), apiHoldoutEnvironment)
+    .describe(
+      "Replaces the entire per-environment state. Environments not listed are disabled.",
+    )
+    .optional(),
+
+  statusUpdateSchedule: apiHoldoutStatusUpdateSchedule.nullable().optional(),
+});
+
+export type ApiUpdateHoldoutBody = z.infer<typeof apiUpdateHoldoutBody>;
+
+/**
+ * Update fields stored on the holdout document itself. `name` is deliberately
+ * absent — it lives on both documents and is mirrored explicitly.
+ */
+export const HOLDOUT_API_UPDATE_FIELDS = [
+  "projects",
+  "skipAsDefaultHoldout",
+] as const satisfies readonly (keyof ApiUpdateHoldoutBody)[];
+
+/** Update fields stored on the companion experiment document. */
+export const HOLDOUT_API_EXPERIMENT_UPDATE_FIELDS = [
+  "description",
+  "owner",
+  "tags",
+  "archived",
+  "goalMetrics",
+  "secondaryMetrics",
+  "guardrailMetrics",
+  "activationMetric",
+] as const satisfies readonly (keyof ApiUpdateHoldoutBody)[];
+
+/**
+ * Update fields applied to the holdout experiment's current phase. These follow
+ * the same path as the internal targeting endpoint rather than a plain update,
+ * so the SDK payload and phase history stay correct.
+ */
+export const HOLDOUT_API_TARGETING_UPDATE_FIELDS = [
+  "holdoutSize",
+  "hashAttribute",
+  "targetingCondition",
+  "savedGroups",
+] as const satisfies readonly (keyof ApiUpdateHoldoutBody)[];
+
+export const apiHoldoutStageValidator = {
+  paramsSchema: z.strictObject({ id: z.string() }),
+  bodySchema: z.strictObject({
+    stage: z.enum(holdoutStage).describe("The stage to move the Holdout to."),
+  }),
+  querySchema: z.never(),
+};
+
+export const apiHoldoutStageReturn = z.object({
+  holdout: apiHoldoutValidator,
+});

--- a/packages/shared/test/holdout-api.test.ts
+++ b/packages/shared/test/holdout-api.test.ts
@@ -1,0 +1,26 @@
+import {
+  apiCreateHoldoutBody,
+  MAX_HOLDOUT_SIZE,
+} from "../src/validators/holdout";
+
+describe("apiCreateHoldoutBody holdoutSize bounds", () => {
+  const parse = (holdoutSize: number) =>
+    apiCreateHoldoutBody.safeParse({ name: "Holdout", holdoutSize });
+
+  it("accepts sizes up to the maximum", () => {
+    expect(parse(0).success).toBe(true);
+    expect(parse(0.05).success).toBe(true);
+    expect(parse(MAX_HOLDOUT_SIZE).success).toBe(true);
+  });
+
+  it("rejects a size above the maximum", () => {
+    // Previously reachable through the UI, which clamped the entered percent
+    // at 100 and then doubled it into a coverage of 2.
+    expect(parse(0.51).success).toBe(false);
+    expect(parse(1).success).toBe(false);
+  });
+
+  it("rejects a negative size", () => {
+    expect(parse(-0.01).success).toBe(false);
+  });
+});

--- a/packages/shared/test/util/holdouts.test.ts
+++ b/packages/shared/test/util/holdouts.test.ts
@@ -1,6 +1,7 @@
 import {
   coverageToHoldoutSize,
   getAllowedHoldoutStageSources,
+  getEnabledHoldoutEnvironments,
   getHoldoutStage,
   holdoutSizeToCoverage,
   isHoldoutStageTransitionAllowed,
@@ -79,6 +80,46 @@ describe("getHoldoutStage", () => {
         getHoldoutStage({ analysisStartDate: "" }, { status: "running" }),
       ).toBe("running");
     });
+  });
+});
+
+describe("getEnabledHoldoutEnvironments", () => {
+  it("returns only the enabled environment ids", () => {
+    expect(
+      getEnabledHoldoutEnvironments({
+        production: { enabled: true },
+        staging: { enabled: false },
+        dev: { enabled: true },
+      }),
+    ).toEqual(["production", "dev"]);
+  });
+
+  it("returns an empty array when nothing is enabled", () => {
+    expect(
+      getEnabledHoldoutEnvironments({
+        production: { enabled: false },
+        staging: { enabled: false },
+      }),
+    ).toEqual([]);
+  });
+
+  it("returns an empty array for an empty map", () => {
+    expect(getEnabledHoldoutEnvironments({})).toEqual([]);
+  });
+
+  it("returns an empty array for undefined or null", () => {
+    expect(getEnabledHoldoutEnvironments(undefined)).toEqual([]);
+    expect(getEnabledHoldoutEnvironments(null)).toEqual([]);
+  });
+
+  it("treats missing or undefined enabled as disabled", () => {
+    expect(
+      getEnabledHoldoutEnvironments({
+        production: {},
+        staging: { enabled: undefined },
+        dev: { enabled: true },
+      }),
+    ).toEqual(["dev"]);
   });
 });
 

--- a/packages/shared/test/util/holdouts.test.ts
+++ b/packages/shared/test/util/holdouts.test.ts
@@ -1,7 +1,9 @@
 import {
   coverageToHoldoutSize,
+  getAllowedHoldoutStageSources,
   getHoldoutStage,
   holdoutSizeToCoverage,
+  isHoldoutStageTransitionAllowed,
   MAX_HOLDOUT_SIZE,
 } from "../../src/util/holdouts";
 
@@ -77,5 +79,34 @@ describe("getHoldoutStage", () => {
         getHoldoutStage({ analysisStartDate: "" }, { status: "running" }),
       ).toBe("running");
     });
+  });
+});
+
+describe("holdout stage transitions", () => {
+  it("allows forward lifecycle transitions and retries", () => {
+    expect(isHoldoutStageTransitionAllowed("draft", "running")).toBe(true);
+    expect(isHoldoutStageTransitionAllowed("running", "analysis-period")).toBe(
+      true,
+    );
+    expect(isHoldoutStageTransitionAllowed("running", "stopped")).toBe(true);
+    expect(isHoldoutStageTransitionAllowed("analysis-period", "stopped")).toBe(
+      true,
+    );
+    expect(isHoldoutStageTransitionAllowed("running", "running")).toBe(true);
+  });
+
+  it("rejects skipped and backward transitions", () => {
+    expect(isHoldoutStageTransitionAllowed("draft", "stopped")).toBe(false);
+    expect(isHoldoutStageTransitionAllowed("draft", "analysis-period")).toBe(
+      false,
+    );
+    expect(isHoldoutStageTransitionAllowed("stopped", "running")).toBe(false);
+  });
+
+  it("lists the valid sources for stopping", () => {
+    expect(getAllowedHoldoutStageSources("stopped")).toEqual([
+      "running",
+      "analysis-period",
+    ]);
   });
 });

--- a/packages/shared/test/util/holdouts.test.ts
+++ b/packages/shared/test/util/holdouts.test.ts
@@ -83,7 +83,7 @@ describe("getHoldoutStage", () => {
 });
 
 describe("holdout stage transitions", () => {
-  it("allows forward lifecycle transitions and retries", () => {
+  it("allows forward lifecycle transitions", () => {
     expect(isHoldoutStageTransitionAllowed("draft", "running")).toBe(true);
     expect(isHoldoutStageTransitionAllowed("running", "analysis-period")).toBe(
       true,
@@ -92,10 +92,14 @@ describe("holdout stage transitions", () => {
     expect(isHoldoutStageTransitionAllowed("analysis-period", "stopped")).toBe(
       true,
     );
-    expect(isHoldoutStageTransitionAllowed("running", "running")).toBe(true);
   });
 
-  it("rejects skipped and backward transitions", () => {
+  it("rejects repeated, skipped, and backward transitions", () => {
+    expect(isHoldoutStageTransitionAllowed("running", "running")).toBe(false);
+    expect(
+      isHoldoutStageTransitionAllowed("analysis-period", "analysis-period"),
+    ).toBe(false);
+    expect(isHoldoutStageTransitionAllowed("stopped", "stopped")).toBe(false);
     expect(isHoldoutStageTransitionAllowed("draft", "stopped")).toBe(false);
     expect(isHoldoutStageTransitionAllowed("draft", "analysis-period")).toBe(
       false,

--- a/packages/shared/test/util/holdouts.test.ts
+++ b/packages/shared/test/util/holdouts.test.ts
@@ -121,6 +121,36 @@ describe("getEnabledHoldoutEnvironments", () => {
       }),
     ).toEqual(["dev"]);
   });
+
+  it("drops enabled ids missing from allowedEnvs", () => {
+    expect(
+      getEnabledHoldoutEnvironments(
+        {
+          production: { enabled: true },
+          staging: { enabled: true },
+          deleted: { enabled: true },
+        },
+        ["production", "staging"],
+      ),
+    ).toEqual(["production", "staging"]);
+  });
+
+  it("returns all enabled ids when allowedEnvs is omitted", () => {
+    expect(
+      getEnabledHoldoutEnvironments({
+        production: { enabled: true },
+        deleted: { enabled: true },
+      }),
+    ).toEqual(["production", "deleted"]);
+  });
+
+  it("returns an empty array when allowedEnvs excludes every enabled id", () => {
+    expect(
+      getEnabledHoldoutEnvironments({ deleted: { enabled: true } }, [
+        "production",
+      ]),
+    ).toEqual([]);
+  });
 });
 
 describe("holdout stage transitions", () => {

--- a/packages/shared/test/validators/holdout.test.ts
+++ b/packages/shared/test/validators/holdout.test.ts
@@ -1,14 +1,11 @@
-import {
-  apiCreateHoldoutBody,
-  MAX_HOLDOUT_SIZE,
-} from "../../src/validators/holdout";
+import { MAX_HOLDOUT_SIZE } from "../../src/util/holdouts";
+import { apiCreateHoldoutBody } from "../../src/validators/holdout";
 
 describe("apiCreateHoldoutBody holdoutSize bounds", () => {
   const parse = (holdoutSize: number) =>
     apiCreateHoldoutBody.safeParse({ name: "Holdout", holdoutSize });
 
   it("accepts sizes up to the maximum", () => {
-    expect(parse(0).success).toBe(true);
     expect(parse(0.05).success).toBe(true);
     expect(parse(MAX_HOLDOUT_SIZE).success).toBe(true);
   });
@@ -18,7 +15,8 @@ describe("apiCreateHoldoutBody holdoutSize bounds", () => {
     expect(parse(1).success).toBe(false);
   });
 
-  it("rejects a negative size", () => {
+  it("rejects zero and negative sizes", () => {
+    expect(parse(0).success).toBe(false);
     expect(parse(-0.01).success).toBe(false);
   });
 });

--- a/packages/shared/test/validators/holdout.test.ts
+++ b/packages/shared/test/validators/holdout.test.ts
@@ -1,7 +1,7 @@
 import {
   apiCreateHoldoutBody,
   MAX_HOLDOUT_SIZE,
-} from "../src/validators/holdout";
+} from "../../src/validators/holdout";
 
 describe("apiCreateHoldoutBody holdoutSize bounds", () => {
   const parse = (holdoutSize: number) =>
@@ -14,8 +14,6 @@ describe("apiCreateHoldoutBody holdoutSize bounds", () => {
   });
 
   it("rejects a size above the maximum", () => {
-    // Previously reachable through the UI, which clamped the entered percent
-    // at 100 and then doubled it into a coverage of 2.
     expect(parse(0.51).success).toBe(false);
     expect(parse(1).success).toBe(false);
   });


### PR DESCRIPTION
### Features and Changes

Adds a REST API for Holdouts:
- **`GET /holdouts/{id}`** — read a single Holdout
- **`GET /holdouts`** — list Holdouts, with optional `projectId`, `datasourceId`, `stage`, and `archived` filters
- **`POST /holdouts`** — create a Holdout (starts in the `draft` stage)
- **`PUT /holdouts/{id}`** — update a Holdout
- **`POST /holdouts/{id}/start`**, **`/start-analysis`**, and **`/stop`** — dedicated lifecycle endpoints for moving through the Holdout's stages

The public API merges each Holdout with its required companion experiment, hiding the internal two-document implementation from consumers. Writes are coordinated across both documents with permission checks, lifecycle validation, rollback protection for partial failures (the two documents share no transaction), and DK payload refreshes.
Permission and validation logic is factored into shared util/service functions so the REST API and the internal app API can't drift apart.

**Not included:** Holdout deletion. That endpoint is more involved given the cleanup required on linked Features and Experiments, so I'll tackle it in a follow-up PR.

**Internal API Changes**
- The internal `updateHoldout` handler now whitelists client-settable fields instead of spreading `req.body`, so server-managed fields (`experimentId`, linkage maps, `analysisStartDate`, computed schedule pointer) can no longer be written from the request body.
- The internal create endpoint now takes `CreateHoldoutInput` rather than a partial experiment/holdout body; `NewHoldoutForm` is updated to match.
- Experiment custom hooks are now skipped for `type === "holdout"`. We should add separate custom hooks for holdouts given that they're composed of two documents.

### Dependencies

Stacked on #6570 (and #6569).

### Testing

- Unit tests for the new shared Holdout utilities (stage derivation, allowed transitions, size/coverage conversion, enabled-environment resolution).
- Unit tests for the Holdout service functions covering create/update coordination, schedule normalization, stage transitions, and experiment rollback on partial failure.
- Manual Tests
- [Claude API Test Suite](https://claude.ai/code/artifact/858bc2a0-3ade-4f9f-904f-7d5aa5c75caf)

### Screenshots

N/A