### PR TITLE
fix(docker): disable unused Next.js image optimizer instead of granting it write access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -227,8 +227,8 @@ ENV LD_LIBRARY_PATH="/opt/python/lib:/opt/pydeps:/opt/krb5deps:/usr/lib/x86_64-l
 # Read-only-rootfs friendly defaults: don't write venv .pyc into the read-only
 # /opt/venv, skip Next's telemetry write, and point PM2_HOME at /tmp (pm2 writes
 # its pid/socket/log files there; the default $HOME/.pm2 isn't writable under a
-# read-only rootfs). The remaining writable paths (/tmp, .next/cache, uploads)
-# are declared as mounts by the deployer (emptyDir or PVC in k8s — see the chart).
+# read-only rootfs). The remaining writable paths (/tmp, uploads) are declared
+# as mounts by the deployer (emptyDir or PVC in k8s — see the chart).
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV PM2_HOME=/tmp/.pm2

--- a/charts/growthbook/values.yaml
+++ b/charts/growthbook/values.yaml
@@ -35,18 +35,14 @@ frontend:
   # runs just this pod's app.
   command: [/usr/local/bin/node, node_modules/pm2/bin/pm2-runtime, start, ecosystem.config.js, --only, front-end]
   args: []
-  # readOnlyRootFilesystem requires writable mounts for the paths the front-end
-  # writes at runtime: /tmp and Next.js's on-disk cache.
+  # readOnlyRootFilesystem requires a writable mount for the one path the
+  # front-end writes at runtime: /tmp.
   volumes:
     - name: tmp
-      emptyDir: {}
-    - name: next-cache
       emptyDir: {}
   volumeMounts:
     - name: tmp
       mountPath: /tmp
-    - name: next-cache
-      mountPath: /usr/local/src/app/packages/front-end/.next/cache
   env:
     - name: API_HOST
       # full URL of your backend, e.g. https://gb-api.example.com

--- a/packages/front-end/next.config.js
+++ b/packages/front-end/next.config.js
@@ -10,6 +10,13 @@ const cspHeader = `
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // The app doesn't use next/image anywhere, so the /_next/image optimizer is
+  // unused product surface — only a public, unauthenticated endpoint for SSRF/
+  // path-traversal probing and (via its uncapped disk cache) disk-fill risk.
+  // Disabling it closes the route entirely (404) instead of serving it.
+  images: {
+    unoptimized: true,
+  },
   turbopack: {
     root: path.join(__dirname, "../.."),
     // Ace workers: load as raw text so we can create Blob URLs. Turbopack doesn't support


### PR DESCRIPTION
### Features and Changes

Fixes an `EACCES: permission denied, mkdir '.../packages/front-end/.next/cache'` error that started after the Docker Hardened Image switch (#6176). That PR made the runtime image non-root (uid 1000) with a root-owned app tree; Next.js's on-demand image optimizer (`/_next/image`) tries to write its disk cache there at request time, which now fails.

Investigated rather than just patching around it, since the fix depends on *why* the write happens:
- No first-party code uses `next/image` anywhere in `packages/front-end` — the endpoint serves no product traffic.
- Prod logs show `/_next/image` getting hit with external URLs and POSTs — this is generic internet scanning for the well-known Next.js image-optimizer SSRF pattern. Verified against the actual installed `next@16.2.6` + `sharp`: external URLs and path-traversal attempts already get rejected with `400` by Next's own default-deny allowlist (no `images.domains`/`remotePatterns` configured), so none of this was exploitable — but it did trip the `EACCES` on every attempt.
- The bigger concern: `images.maximumDiskCacheSize` defaults to `undefined`, which Next's disk-LRU cache resolves to **50% of available disk space**. Granting write access there to fix the permissions error would have turned an already-scanned, unauthenticated endpoint into a disk-fill vector.

Given zero legitimate use, disabling the optimizer is safer than making the cache dir writable:
- `packages/front-end/next.config.js`: `images.unoptimized = true`. Verified empirically that this makes `/_next/image` return a flat `404` — no `sharp` call, no disk write attempted.
- `Dockerfile`: no changes needed once the optimizer is disabled — reverted an earlier attempt at `--chown`-ing the cache dir.
- `charts/growthbook/values.yaml`: dropped the now-unnecessary `next-cache` emptyDir/mount.

### Dependencies

None.

### Testing

- Reproduced the exact `EACCES` mechanism with a minimal `next@16.2.6` + `sharp@0.34.5` container running as non-root uid 1000 against a root-owned app dir, hitting `/_next/image?url=/favicon.ico&w=64&q=75` — confirmed the same error signature as prod logs.
- Confirmed `images.unoptimized: true` returns `404` for that same request with no disk-cache write attempted (checked container-side; no `.next/cache` write occurs).
- Confirmed Next's default domain allowlist already rejects external URLs (`400 "url" parameter is not allowed`) and path traversal (`400 "url" parameter is invalid`) with no `images` config set, so this change closes an unused/risky endpoint rather than papering over a live vulnerability.
- Could not build/run the actual `dhi.io`-based production Dockerfile locally (no DHI registry credentials in this environment), so the reproduction used equivalent stock `node:24-slim` images with the same non-root/ownership pattern instead of the real hardened base.

### Screenshots

N/A — no UI changes.
