### PR TITLE
docs(visual-editor): remove beta messaging, link Chrome Web Store, and clean up from old extension

### DIFF
--- a/docs/docs/integrations/shopify.mdx
+++ b/docs/docs/integrations/shopify.mdx
@@ -34,15 +34,9 @@ When a user views an experiment, this script will fire an event that tracks whic
 
 Once added, click "Save" and navigate back to GrowthBook.
 
-### Step 3: Install the GrowthBook DevTools Browser Extension
+### Step 3: Install the GrowthBook Visual Editor
 
-The GrowthBook DevTools browser extension enables you to use the Visual Editor to update your Shopify website content. Install it from the [Chrome Web Store](https://chromewebstore.google.com/detail/growthbook-devtools/opemhndcehfgipokneipaafbglcecjia) (Chrome) or from [addons.mozilla.org](https://addons.mozilla.org/en-US/firefox/addon/growthbook-devtools/) (Firefox).
-
-Next, open the DevTools extension by clicking the extension icon.
-
-- Find and click on the cog icon ⚙️.
-- Enter your Personal Access Token (available in GrowthBook from the **main dropdown menu** → **Personal Access Tokens**).
-- Click "Save". The GrowthBook browser extension is all set up!
+Install the [GrowthBook Visual Editor](https://chromewebstore.google.com/detail/growthbook-visual-editor/nbomejknbpkcpjdagefhichaajpoempk) from the Chrome Web Store, then open the side panel and click **Connect with GrowthBook**. See [Install and connect](/app/visual/install-and-connect) for the full setup.
 
 ### Step 4: Create a GrowthBook Visual Editor Experiment
 

--- a/docs/docs/integrations/webflow.mdx
+++ b/docs/docs/integrations/webflow.mdx
@@ -34,15 +34,9 @@ When a user views an experiment, the code above will fire an event that tracks w
 
 Once added, save and publish the changes and navigate back to GrowthBook.
 
-### Step 3: Install the GrowthBook DevTools Browser Extension
+### Step 3: Install the GrowthBook Visual Editor
 
-The GrowthBook DevTools browser extension enables you to use the Visual Editor to update your Shopify website content. Install it from the [Chrome Web Store](https://chromewebstore.google.com/detail/growthbook-devtools/opemhndcehfgipokneipaafbglcecjia) (Chrome) or from [addons.mozilla.org](https://addons.mozilla.org/en-US/firefox/addon/growthbook-devtools/) (Firefox).
-
-Next, open the DevTools extension by clicking the extension icon.
-
-- Find and click on the cog icon ⚙️.
-- Enter your Personal Access Token (available in GrowthBook from the **main dropdown menu** → **Personal Access Tokens**).
-- Click "Save". The GrowthBook browser extension is all set up!
+Install the [GrowthBook Visual Editor](https://chromewebstore.google.com/detail/growthbook-visual-editor/nbomejknbpkcpjdagefhichaajpoempk) from the Chrome Web Store, then open the side panel and click **Connect with GrowthBook**. See [Install and connect](/app/visual/install-and-connect) for the full setup.
 
 ### Step 4: Create a GrowthBook Visual Editor Experiment
 

--- a/docs/docs/integrations/wordpress.mdx
+++ b/docs/docs/integrations/wordpress.mdx
@@ -45,15 +45,9 @@ When a user views an experiment, this script will fire an event that tracks whic
 
 Once added, navigate back to GrowthBook.
 
-### Step 3: Install the GrowthBook DevTools Browser Extension
+### Step 3: Install the GrowthBook Visual Editor
 
-The GrowthBook DevTools browser extension enables you to use the Visual Editor to update your Shopify website content. Install it from the [Chrome Web Store](https://chromewebstore.google.com/detail/growthbook-devtools/opemhndcehfgipokneipaafbglcecjia) (Chrome) or from [addons.mozilla.org](https://addons.mozilla.org/en-US/firefox/addon/growthbook-devtools/) (Firefox).
-
-Next, open the DevTools extension by clicking the extension icon.
-
-- Find and click on the cog icon ⚙️.
-- Enter your Personal Access Token (available in GrowthBook from the **main dropdown menu** → **Personal Access Tokens**).
-- Click "Save". The GrowthBook browser extension is all set up!
+Install the [GrowthBook Visual Editor](https://chromewebstore.google.com/detail/growthbook-visual-editor/nbomejknbpkcpjdagefhichaajpoempk) from the Chrome Web Store, then open the side panel and click **Connect with GrowthBook**. See [Install and connect](/app/visual/install-and-connect) for the full setup.
 
 ### Step 4: Create a GrowthBook Visual Editor Experiment
 

--- a/docs/docs/kb/glossary.mdx
+++ b/docs/docs/kb/glossary.mdx
@@ -106,7 +106,7 @@ hide_table_of_contents: true
 
 [Global SDK Webhooks](/app/webhooks/global-sdk-webhooks): Global SDK Webhooks in GrowthBook are notifications that fire for all SDK Connection changes, not limited to a single SDK Connection, and are particularly useful for larger organizations with multi-org installations of GrowthBook.
 
-[GrowthBook DevTools Browser Extension](/tools/chrome-extension): The GrowthBook DevTools Browser Extension (Chrome and Firefox) integrates with the JavaScript SDKs, allowing you to QA and debug feature flags and experiments from GrowthBook's JavaScript SDKs directly in your browser. The extension also includes the Visual Editor, our no-code experiment designer.
+[GrowthBook DevTools Browser Extension](/tools/chrome-extension): The GrowthBook DevTools Browser Extension (Chrome and Firefox) integrates with the JavaScript SDKs, allowing you to QA and debug feature flags and experiments from GrowthBook's JavaScript SDKs directly in your browser.
 
 [GrowthBook Proxy](/self-host/proxy): The GrowthBook Proxy is a server that sits between your application and GrowthBook, providing speed, scalability, security, and real-time feature rollouts by caching feature lookups and streaming updates in real-time.
 
@@ -250,4 +250,4 @@ hide_table_of_contents: true
 
 [Variation](/using/fundamentals#variations): A Variation in GrowthBook is a version of a feature or product that is being tested in an experiment, with users being assigned to different variations to compare their performance and impact on key metrics.
 
-[Visual Editor](/app/visual): The Visual Editor in GrowthBook is a tool that allows you to design A/B tests directly in your browser without writing a single line of code, enabling you to run experiments on your site and analyze results in real-time.
+[Visual Editor](/app/visual): The GrowthBook Visual Editor is a Chrome side-panel extension for designing A/B tests without writing code. Install it from the [Chrome Web Store](https://chromewebstore.google.com/detail/growthbook-visual-editor/nbomejknbpkcpjdagefhichaajpoempk).

--- a/docs/docs/tools/chrome-extension.mdx
+++ b/docs/docs/tools/chrome-extension.mdx
@@ -195,4 +195,4 @@ See the Node.js [DevTools for back-end](/lib/node#devtools-for-back-end) guide f
 
 ## Visual Editor
 
-GrowthBook DevTools also powers our Visual Editor, which enables designing A/B tests without writing code. The Visual Editor requires the Access Token mentioned in the previous section. See the docs [on the Visual Editor.](https://docs.growthbook.io/app/visual)
+The [GrowthBook Visual Editor](https://chromewebstore.google.com/detail/growthbook-visual-editor/nbomejknbpkcpjdagefhichaajpoempk) is a separate Chrome extension for designing A/B tests without writing code. See the [Visual Editor docs](/app/visual) to install, connect, and get started.

--- a/docs/docs/using/experimenting.mdx
+++ b/docs/docs/using/experimenting.mdx
@@ -7,7 +7,7 @@ Before analyzing results, you need to actually run the experiment. This can be d
 
 - Feature Flags (most common)
 - Running an inline experiment directly with our SDKs
-- Our Visual Editor (beta)
+- Our [Visual Editor](/app/visual)
 - Your own custom variation assignment / bucketing system
 
 When you go to add an experiment in GrowthBook, it will first look in your data source for any new

--- a/docs/docs/visual-editor.mdx
+++ b/docs/docs/visual-editor.mdx
@@ -13,8 +13,8 @@ import CommercialFeature from '@site/src/components/CommercialFeature';
 
 GrowthBook's AI-based Visual Editor is a no-code way to build and launch experiments on your website. Describe the change you want in natural language, review what the editor proposes, and ship a real A/B test without writing code or waiting on a deploy.
 
-:::tip Early Beta Access
-The Visual Editor is currently in beta and available through our early access program. Interested in trying it? 👉 [Sign up here](https://www.growthbook.io/events/early-access-ai-visual-editor).
+:::tip Install the extension
+Get the [GrowthBook Visual Editor](https://chromewebstore.google.com/detail/growthbook-visual-editor/nbomejknbpkcpjdagefhichaajpoempk) from the Chrome Web Store, then [connect it to your account](/app/visual/install-and-connect).
 :::
 
 <img
@@ -27,7 +27,7 @@ The Visual Editor is a **Chrome side-panel extension**. You open it next to your
 
 - **[AI mode](/app/visual/ai-mode)** — describe the change in plain language ("make the hero headline shorter and the CTA green") and the editor proposes the edits for you to preview and accept.
 - **[Manual mode](/app/visual/manual-mode)** — point and click to select any element and edit its content, typography, layout, background, classes, and more with structured controls.
-- **[Figma & image import](/app/visual/design-import)** _(beta)_ — turn a Figma frame or a mockup image into a high-fidelity, testable component the editor builds and places on the page for you.
+- **[Figma & image import](/app/visual/design-import)** — turn a Figma frame or a mockup image into a high-fidelity, testable component the editor builds and places on the page for you.
 
 To actually render your variations on your live site, a developer integrates one of GrowthBook's front-end SDKs — the [Script Tag](/lib/script-tag), [JavaScript](/lib/js), or [ReactJS](/lib/react) SDK — or renders them on a CDN with an [Edge SDK](/lib/edge/cloudflare). See [Running on your site](/app/visual/running-on-your-site).
 
@@ -46,7 +46,7 @@ The Visual Editor is now a Chrome side panel. If you're using an older version o
 
 :::info Join the Visual Editor community on Slack
 
-Connect with the GrowthBook team and other beta users for help, feedback, and early updates. [Join the Visual Editor beta channel on Slack](https://growthbookusers.slack.com/archives/C0BBMTLJUUT).
+Connect with the GrowthBook team and other users. [Join the Visual Editor channel on Slack](https://growthbookusers.slack.com/archives/C0BBMTLJUUT).
 
 :::
 

--- a/docs/docs/visual-editor/design-import.mdx
+++ b/docs/docs/visual-editor/design-import.mdx
@@ -1,5 +1,5 @@
 ---
-title: Import from Figma or an Image — Design to Variant (Beta)
+title: Import from Figma or an Image — Design to Variant
 description: Turn a Figma frame or a mockup image into a high-fidelity, testable A/B variation. GrowthBook's AI rebuilds the design as a scoped component and injects it into the page.
 sidebar_label: Figma & image import
 slug: /app/visual/design-import
@@ -10,9 +10,9 @@ import CommercialFeature from '@site/src/components/CommercialFeature';
 
 <CommercialFeature feature="visual-editor" />
 
-:::info Beta
+:::info Review generated variations
 
-**Design → Variant** is in beta. Generated results can vary, so always review the variation before you save it. It also needs an up-to-date GrowthBook server and a configured vision-capable AI model — if your instance hasn't enabled it yet, the panel will say so and you can fall back to a mockup image (or ask an admin to update the server).
+Generated results can vary, so always review the variation before you save it. Design → Variant also needs an up-to-date GrowthBook server and a configured vision-capable AI model. If your instance hasn't enabled it yet, the panel will say so and you can fall back to a mockup image (or ask an admin to update the server).
 
 :::
 
@@ -65,7 +65,7 @@ The AI builds the component and previews it live on the page. Review it, then **
 
 :::tip Review before you save
 
-This is the beta caveat in practice: the AI reproduces the design as faithfully as it can, but fonts, spacing, and imagery can differ from the source. Treat the output as a strong first draft, eyeball it on the real page, and tweak with [Manual mode](/app/visual/manual-mode) or [global CSS](/app/visual/manual-mode) if needed before saving.
+The AI reproduces the design as faithfully as it can, but fonts, spacing, and imagery can differ from the source. Treat the output as a strong first draft, eyeball it on the real page, and tweak with [Manual mode](/app/visual/manual-mode) or [global CSS](/app/visual/manual-mode) if needed before saving.
 
 :::
 
@@ -87,7 +87,7 @@ The AI reproduces **layout, typography, spacing, and color** from the design. Fo
 
 - **One component per generation.** Design → Variant produces a single scoped component, not a multi-section page.
 - **Too-large designs are declined.** If the frame is a full page or a large multi-section layout, the AI returns a message explaining it's too large instead of producing a partial result. Target a smaller container.
-- **Results vary (beta).** Always preview and adjust before saving.
+- **Results vary.** Always preview and adjust before saving.
 - **Needs a vision-capable AI model.** Your org must have a vision-capable model configured in [AI Settings](/integrations/ai) (e.g. Gemini, GPT-4o/5, or Claude). Admins can set the model used for the Visual Editor there.
 
 ## Next steps

--- a/docs/docs/visual-editor/install-and-connect.mdx
+++ b/docs/docs/visual-editor/install-and-connect.mdx
@@ -1,6 +1,6 @@
 ---
 title: Install and Connect the GrowthBook Visual Editor
-description: Install the GrowthBook DevTools Chrome extension and connect it to your GrowthBook account with a single click. No copying API tokens by hand.
+description: Install the GrowthBook Visual Editor from the Chrome Web Store and connect it to your GrowthBook account with a single click.
 sidebar_label: Install and connect
 slug: /app/visual/install-and-connect
 ---
@@ -14,9 +14,7 @@ The GrowthBook Visual Editor is a standalone Chrome extension. Setup is two clic
 
 ## 1. Install the extension
 
-Install **GrowthBook Visual Editor** from the Chrome Web Store (Chrome, Edge, Brave, Dia, and most Chromium browsers).
-
-During beta, the link is emailed after you [sign up for early access](https://www.growthbook.io/events/early-access-ai-visual-editor).
+Install **[GrowthBook Visual Editor](https://chromewebstore.google.com/detail/growthbook-visual-editor/nbomejknbpkcpjdagefhichaajpoempk)** from the Chrome Web Store (Chrome, Edge, Brave, Dia, and most Chromium browsers).
 
 {/* Is firefox support coming soon? */}
 {/* Firefox support coming soon. */}

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -372,7 +372,7 @@ export default {
             {
               type: "category",
               label: "Visual Editor",
-              className: "beta",
+              className: "pill-new",
               link: {
                 type: "doc",
                 id: "visual-editor",


### PR DESCRIPTION
### Features and Changes

- Remove Visual Editor “beta” / early-access messaging from docs
- Point installs at the public [Chrome Web Store](https://chromewebstore.google.com/detail/growthbook-visual-editor/nbomejknbpkcpjdagefhichaajpoempk) listing instead of the early-access signup flow
- Replace the sidebar beta pill with new (pill-new)
- Update DevTools, Shopify, WordPress, Webflow, and glossary docs so they no longer say DevTools powers the Visual Editor in these 5 places

1. docs/docs/tools/chrome-extension.mdx — Visual Editor section used to say DevTools powers it and needed an access token. Now says it’s a separate extension and links the Web Store.
2. docs/docs/integrations/shopify.mdx — Step 3 was “Install the GrowthBook DevTools Browser Extension” with PAT setup. Now “Install the GrowthBook Visual Editor” with Connect with GrowthBook.
3. docs/docs/integrations/wordpress.mdx — Same Step 3 rewrite as Shopify.
4. docs/docs/integrations/webflow.mdx — Same Step 3 rewrite as Shopify.
5. docs/docs/kb/glossary.mdx — DevTools entry no longer says it includes the Visual Editor; Visual Editor entry now describes the standalone extension and links the Web Store.

### Dependencies

None

### Testing

- Open the docs site locally and confirm Visual Editor install/connect pages link to the Chrome Web Store
- Confirm the Visual Editor sidebar item shows a green new tag (not beta)
- Spot-check Shopify / WordPress / Webflow / DevTools pages for the updated install steps

### Screenshots
`new` tag instead of `beta`:

<img width="432" height="448" alt="image" src="https://github.com/user-attachments/assets/291a7784-a10c-45a6-bf61-816347278d9c" />

