### PR TITLE
Fix retry banner disappearing after a dimension/filter round trip

### DIFF
--- a/packages/front-end/enterprise/components/ProductAnalytics/ExplorerContext.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/ExplorerContext.tsx
@@ -466,11 +466,6 @@ export function ExplorerProvider({
       hasEverFetchedRef.current = true;
       const requestId = ++submitRequestIdRef.current;
 
-      setExplorerState((prev) => ({
-        ...prev,
-        error: null,
-      }));
-
       const startTime = Date.now();
       const {
         data: fetchResult,

--- a/packages/front-end/enterprise/components/ProductAnalytics/ExplorerContext.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/ExplorerContext.tsx
@@ -40,12 +40,18 @@ import {
   getCommonColumns,
   getInitialInlineFilters,
   hasUnsatisfiedInlineFilters,
-  getQueryTimeoutErrorMessage,
   isSubmittableConfig,
   stripExplorerDraftFields,
   toFetchKey,
   validateDimensions,
 } from "@/enterprise/components/ProductAnalytics/util";
+import {
+  getExplorerQueryPhase,
+  getQueryTimeoutErrorMessage,
+  resolveExplorerQueryErrorKind,
+  type ExplorerQueryErrorKind,
+  type ExplorerQueryPhase,
+} from "@/enterprise/components/ProductAnalytics/explorerQueryPhase";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import track from "@/services/track";
 import { useDefinitions } from "@/services/DefinitionsContext";
@@ -65,6 +71,7 @@ export interface ExplorerContextValue {
   query: QueryInterface | null;
   loading: boolean;
   error: string | null;
+  queryPhase: ExplorerQueryPhase;
   commonColumns: Pick<ColumnInterface, "column" | "name">[];
   isStale: boolean;
   needsFetch: boolean;
@@ -166,6 +173,7 @@ export function ExplorerProvider({
     submittedState: ExplorerDraftConfig | null;
     exploration: ProductAnalyticsExploration | null;
     error: string | null;
+    errorKind: ExplorerQueryErrorKind | null;
     query: QueryInterface | null;
   }>(() => {
     const withUnits = fillMissingUnits(
@@ -192,6 +200,7 @@ export function ExplorerProvider({
       submittedState: hasExistingResults ? normalizedSubmitted : null,
       exploration: null,
       error: null,
+      errorKind: null,
       query: null,
     };
   });
@@ -308,6 +317,7 @@ export function ExplorerProvider({
 
   const data = explorerState.exploration;
   const error = explorerState.error;
+  const errorKind = explorerState.errorKind;
   const submittedExploreState = explorerState.submittedState;
   const query = explorerState.query;
 
@@ -423,6 +433,29 @@ export function ExplorerProvider({
     );
   }, [cleanedDraftExploreState, draftExploreState, getFactTableById]);
 
+  const queryPhase = useMemo(
+    () =>
+      getExplorerQueryPhase({
+        loading: loading || polling,
+        isStale,
+        needsFetch,
+        needsUpdate,
+        errorKind,
+        error,
+        submittedExploreState,
+      }),
+    [
+      loading,
+      polling,
+      isStale,
+      needsFetch,
+      needsUpdate,
+      errorKind,
+      error,
+      submittedExploreState,
+    ],
+  );
+
   const doSubmit = useCallback(
     async (options?: { cache?: CacheOption; config?: ExplorerDraftConfig }) => {
       const sourceConfig = options?.config ?? draftExploreState;
@@ -466,11 +499,6 @@ export function ExplorerProvider({
       hasEverFetchedRef.current = true;
       const requestId = ++submitRequestIdRef.current;
 
-      setExplorerState((prev) => ({
-        ...prev,
-        error: null,
-      }));
-
       const startTime = Date.now();
       const {
         data: fetchResult,
@@ -490,7 +518,9 @@ export function ExplorerProvider({
       // Ignore out-of-order responses from older in-flight requests.
       if (requestId !== submitRequestIdRef.current) return;
 
-      // Cache miss when cache=required
+      // Required-cache miss is not a completed attempt: keep the last
+      // exploration/error and mark the draft stale so reverting the draft
+      // restores the previous outcome instead of a blank banner.
       if (cache === "required" && fetchResult === null && !fetchError) {
         setIsStale(true);
         return;
@@ -523,6 +553,7 @@ export function ExplorerProvider({
               previousPeriod: comparison.previousPeriod,
             }
           : null,
+        timeout: boolean = false,
       ) => {
         if (requestId !== submitRequestIdRef.current) return;
         setPolling(false);
@@ -530,11 +561,17 @@ export function ExplorerProvider({
           setSubmittedExploreState(submittedConfig);
           setIsStale(false);
         }
+        const nextError = resultError || result?.error || null;
         setExplorerState((prev) => ({
           ...prev,
           exploration: result,
           query: resultQuery,
-          error: resultError || result?.error || null,
+          error: nextError,
+          errorKind: resolveExplorerQueryErrorKind({
+            result,
+            resultError: nextError,
+            timeout,
+          }),
         }));
         setComparisonExploration(resultComparison);
         setComparisonQuery(resultComparisonQuery);
@@ -602,6 +639,7 @@ export function ExplorerProvider({
           exploration: primaryIsRunning ? null : fetchResult,
           query: primaryIsRunning ? null : query,
           error: null,
+          errorKind: null,
         }));
         setComparisonExploration(comparisonIsRunning ? null : comparisonResult);
         setComparisonQuery(
@@ -665,6 +703,7 @@ export function ExplorerProvider({
                   null,
                   latestComparisonQuery,
                   null,
+                  true,
                 );
               } else {
                 finalize(
@@ -1047,6 +1086,7 @@ export function ExplorerProvider({
           submittedState: null,
           exploration: null,
           error: null,
+          errorKind: null,
           query: null,
         };
       });
@@ -1070,6 +1110,7 @@ export function ExplorerProvider({
       exploration: data,
       loading: loading || polling,
       error,
+      queryPhase,
       commonColumns,
       setDraftExploreState,
       handleSubmit,
@@ -1116,6 +1157,7 @@ export function ExplorerProvider({
       deleteValueFromDataset,
       draftExploreState,
       error,
+      queryPhase,
       handleSubmit,
       isStale,
       isSubmittable,

--- a/packages/front-end/enterprise/components/ProductAnalytics/MainSection/ExplorerDataTable.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/MainSection/ExplorerDataTable.tsx
@@ -18,7 +18,7 @@ export default function ExplorerDataTable({
   submittedExploreState,
   loading,
   hasChart = false,
-  isStale = false,
+  padForFloatingCallout = false,
   query = null,
   compareEnabled = false,
   comparisonExploration = null,
@@ -30,7 +30,7 @@ export default function ExplorerDataTable({
   submittedExploreState: ExplorationConfig | null;
   loading: boolean;
   hasChart?: boolean;
-  isStale?: boolean;
+  padForFloatingCallout?: boolean;
   query?: QueryInterface | null;
   compareEnabled?: boolean;
   comparisonExploration?: ProductAnalyticsExploration | null;
@@ -126,7 +126,7 @@ export default function ExplorerDataTable({
       csvColumnKeys={csvColumnKeys}
       csvColumnLabels={csvColumnLabels}
       renderCell={renderCell}
-      paddingTop={(isStale || loading) && !hasChart ? 35 : 0}
+      paddingTop={padForFloatingCallout || (loading && !hasChart) ? 35 : 0}
     />
   );
 }

--- a/packages/front-end/enterprise/components/ProductAnalytics/MainSection/ExplorerMainSection.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/MainSection/ExplorerMainSection.tsx
@@ -22,6 +22,8 @@ export default function ExplorerMainSection() {
     loading,
     error,
     isStale,
+    needsFetch,
+    needsUpdate,
     query,
     draftExploreState,
     handleSubmit,
@@ -47,7 +49,15 @@ export default function ExplorerMainSection() {
     !hasSubmittablePayload(submittedExploreState);
 
   const suppressStaleFloatingCallout = funnelMainEmpty && isStale && !loading;
-  const isTimeoutError = !loading && isQueryTimeoutError(error);
+  // Draft matches submitted but has no result: the last attempt for this
+  // exact config failed. Derived from `exploration` (always set on any
+  // completed attempt) rather than `error`, which can be cleared elsewhere.
+  const isUnresolved =
+    !loading &&
+    !needsFetch &&
+    !needsUpdate &&
+    exploration === null &&
+    hasSubmittablePayload(submittedExploreState);
   const retryDisabled =
     !hasSubmittablePayload(draftExploreState) || !isSubmittable;
 
@@ -196,13 +206,13 @@ export default function ExplorerMainSection() {
             )}
           </Flex>
         )}
-        {(isStale || loading || isTimeoutError) &&
+        {(isStale || loading || isUnresolved) &&
           !suppressStaleFloatingCallout && (
             <Box
               style={{
                 position: "absolute",
                 zIndex: 1000,
-                top: isTimeoutError ? 63 : 12,
+                top: isUnresolved ? 63 : 12,
                 right: 15,
                 width: "auto",
                 backgroundColor: "var(--color-panel-solid)",
@@ -210,7 +220,7 @@ export default function ExplorerMainSection() {
               }}
             >
               <Callout
-                status={isTimeoutError ? "error" : "info"}
+                status={isUnresolved ? "error" : "info"}
                 size="sm"
                 align="center"
                 wrap="nowrap"
@@ -229,22 +239,24 @@ export default function ExplorerMainSection() {
                       onClick={() => handleSubmit({ force: true })}
                       icon={<PiArrowsClockwise />}
                     >
-                      {isTimeoutError ? "Retry" : "Refresh"}
+                      {isUnresolved ? "Retry" : "Refresh"}
                     </Button>
                   ) : undefined
                 }
               >
                 <Text
                   title={
-                    !loading && !isTimeoutError
+                    !loading && !isUnresolved
                       ? "Some configuration changes require running a new SQL query against your data source"
                       : undefined
                   }
                 >
                   {loading
                     ? "Loading..."
-                    : isTimeoutError
-                      ? "Query timed out"
+                    : isUnresolved
+                      ? isQueryTimeoutError(error)
+                        ? "Query timed out"
+                        : "Query failed"
                       : "Latest changes not applied"}
                 </Text>
               </Callout>

--- a/packages/front-end/enterprise/components/ProductAnalytics/MainSection/ExplorerMainSection.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/MainSection/ExplorerMainSection.tsx
@@ -6,9 +6,9 @@ import Text from "@/ui/Text";
 import Button from "@/ui/Button";
 import {
   hasSubmittablePayload,
-  isQueryTimeoutError,
   shouldChartSectionShow,
 } from "@/enterprise/components/ProductAnalytics/util";
+import { getExplorerFloatingCallout } from "@/enterprise/components/ProductAnalytics/explorerQueryPhase";
 import Callout from "@/ui/Callout";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import ExplorerChart from "./ExplorerChart";
@@ -21,7 +21,7 @@ export default function ExplorerMainSection() {
     submittedExploreState,
     loading,
     error,
-    isStale,
+    queryPhase,
     query,
     draftExploreState,
     handleSubmit,
@@ -46,8 +46,10 @@ export default function ExplorerMainSection() {
     draftExploreState.dataset?.type === "funnel" &&
     !hasSubmittablePayload(submittedExploreState);
 
-  const suppressStaleFloatingCallout = funnelMainEmpty && isStale && !loading;
-  const isTimeoutError = !loading && isQueryTimeoutError(error);
+  const floatingCallout =
+    queryPhase.type === "stale" && funnelMainEmpty
+      ? null
+      : getExplorerFloatingCallout(queryPhase);
   const retryDisabled =
     !hasSubmittablePayload(draftExploreState) || !isSubmittable;
 
@@ -136,7 +138,9 @@ export default function ExplorerMainSection() {
                 submittedExploreState={submittedExploreState}
                 loading={loading}
                 hasChart={showChartSection}
-                isStale={isStale}
+                padForFloatingCallout={
+                  floatingCallout !== null && !showChartSection
+                }
                 query={query}
                 compareEnabled={compareEnabled}
                 comparisonExploration={comparisonExploration}
@@ -196,60 +200,47 @@ export default function ExplorerMainSection() {
             )}
           </Flex>
         )}
-        {(isStale || loading || isTimeoutError) &&
-          !suppressStaleFloatingCallout && (
-            <Box
-              style={{
-                position: "absolute",
-                zIndex: 1000,
-                top: isTimeoutError ? 63 : 12,
-                right: 15,
-                width: "auto",
-                backgroundColor: "var(--color-panel-solid)",
-                borderRadius: "var(--radius-3)",
-              }}
+        {floatingCallout ? (
+          <Box
+            style={{
+              position: "absolute",
+              zIndex: 1000,
+              top: 12,
+              right: 15,
+              width: "auto",
+              backgroundColor: "var(--color-panel-solid)",
+              borderRadius: "var(--radius-3)",
+            }}
+          >
+            <Callout
+              status={floatingCallout.status}
+              size="sm"
+              align="center"
+              wrap="nowrap"
+              icon={
+                floatingCallout.action === null ? (
+                  <LoadingSpinner style={{ width: "12px", height: "12px" }} />
+                ) : undefined
+              }
+              action={
+                floatingCallout.action !== null ? (
+                  <Button
+                    color="inherit"
+                    size="sm"
+                    variant="solid"
+                    disabled={retryDisabled}
+                    onClick={() => handleSubmit({ force: true })}
+                    icon={<PiArrowsClockwise />}
+                  >
+                    {floatingCallout.action === "retry" ? "Retry" : "Refresh"}
+                  </Button>
+                ) : undefined
+              }
             >
-              <Callout
-                status={isTimeoutError ? "error" : "info"}
-                size="sm"
-                align="center"
-                wrap="nowrap"
-                icon={
-                  loading ? (
-                    <LoadingSpinner style={{ width: "12px", height: "12px" }} />
-                  ) : undefined
-                }
-                action={
-                  !loading ? (
-                    <Button
-                      color="inherit"
-                      size="sm"
-                      variant="solid"
-                      disabled={retryDisabled}
-                      onClick={() => handleSubmit({ force: true })}
-                      icon={<PiArrowsClockwise />}
-                    >
-                      {isTimeoutError ? "Retry" : "Refresh"}
-                    </Button>
-                  ) : undefined
-                }
-              >
-                <Text
-                  title={
-                    !loading && !isTimeoutError
-                      ? "Some configuration changes require running a new SQL query against your data source"
-                      : undefined
-                  }
-                >
-                  {loading
-                    ? "Loading..."
-                    : isTimeoutError
-                      ? "Query timed out"
-                      : "Latest changes not applied"}
-                </Text>
-              </Callout>
-            </Box>
-          )}
+              <Text title={floatingCallout.title}>{floatingCallout.text}</Text>
+            </Callout>
+          </Box>
+        ) : null}
       </Flex>
     </Flex>
   );

--- a/packages/front-end/enterprise/components/ProductAnalytics/explorerQueryPhase.ts
+++ b/packages/front-end/enterprise/components/ProductAnalytics/explorerQueryPhase.ts
@@ -1,0 +1,110 @@
+import type { ProductAnalyticsExploration } from "shared/validators";
+import {
+  hasSubmittablePayload,
+  type ExplorerDraftConfig,
+} from "@/enterprise/components/ProductAnalytics/util";
+
+export type ExplorerQueryErrorKind = "timeout" | "query";
+
+export type ExplorerQueryPhase =
+  | { type: "idle" }
+  | { type: "loading" }
+  | { type: "stale" }
+  | { type: "success" }
+  | { type: "error"; kind: ExplorerQueryErrorKind; message: string };
+
+export type ExplorerFloatingCalloutModel = {
+  status: "info" | "error";
+  text: string;
+  action: "retry" | "refresh" | null;
+  title?: string;
+};
+
+export function getQueryTimeoutErrorMessage(isFunnel: boolean): string {
+  return isFunnel
+    ? "This query is taking longer than expected. Try a shorter date range or fewer steps, then run again."
+    : "This query is taking longer than expected. Try a shorter date range, then run again.";
+}
+
+export function resolveExplorerQueryErrorKind({
+  result,
+  resultError,
+  timeout = false,
+}: {
+  result: ProductAnalyticsExploration | null;
+  resultError: string | null;
+  timeout?: boolean;
+}): ExplorerQueryErrorKind | null {
+  if (timeout) return "timeout";
+  if (
+    resultError !== null ||
+    result?.status === "error" ||
+    Boolean(result?.error)
+  ) {
+    return "query";
+  }
+  return null;
+}
+
+export function getExplorerQueryPhase({
+  loading,
+  isStale,
+  needsFetch,
+  needsUpdate,
+  errorKind,
+  error,
+  submittedExploreState,
+}: {
+  loading: boolean;
+  isStale: boolean;
+  needsFetch: boolean;
+  needsUpdate: boolean;
+  errorKind: ExplorerQueryErrorKind | null;
+  error: string | null;
+  submittedExploreState: ExplorerDraftConfig | null;
+}): ExplorerQueryPhase {
+  if (loading) return { type: "loading" };
+  if (!hasSubmittablePayload(submittedExploreState)) return { type: "idle" };
+
+  // Cache-miss auto-submits keep errorKind and set needsFetch, so they count as stale.
+  const lastAttemptApplies = !needsFetch && !needsUpdate;
+  if (lastAttemptApplies && errorKind !== null) {
+    return {
+      type: "error",
+      kind: errorKind,
+      message: error ?? "",
+    };
+  }
+  if (isStale || needsFetch) return { type: "stale" };
+  return { type: "success" };
+}
+
+export function getExplorerFloatingCallout(
+  phase: ExplorerQueryPhase,
+): ExplorerFloatingCalloutModel | null {
+  switch (phase.type) {
+    case "loading":
+      return { status: "info", text: "Loading...", action: null };
+    case "stale":
+      return {
+        status: "info",
+        text: "Latest changes not applied",
+        action: "refresh",
+        title:
+          "Some configuration changes require running a new SQL query against your data source",
+      };
+    case "error":
+      return {
+        status: "error",
+        text: phase.kind === "timeout" ? "Query timed out" : "Query failed",
+        action: "retry",
+      };
+    case "idle":
+    case "success":
+      return null;
+    default: {
+      const _exhaustive: never = phase;
+      return _exhaustive;
+    }
+  }
+}

--- a/packages/front-end/enterprise/components/ProductAnalytics/util.ts
+++ b/packages/front-end/enterprise/components/ProductAnalytics/util.ts
@@ -122,21 +122,6 @@ export function explorationPollDelayMs(elapsedSec: number): number {
   return 0;
 }
 
-// Shared between ExplorerContext (where it's raised) and ExplorerMainSection
-// (where it's matched to offer a retry), so the two stay in sync.
-const QUERY_TIMEOUT_ERROR_PREFIX =
-  "This query is taking longer than expected. Try a shorter date range";
-
-export function getQueryTimeoutErrorMessage(isFunnel: boolean): string {
-  return isFunnel
-    ? `${QUERY_TIMEOUT_ERROR_PREFIX} or fewer steps, then run again.`
-    : `${QUERY_TIMEOUT_ERROR_PREFIX}, then run again.`;
-}
-
-export function isQueryTimeoutError(error: string | null): boolean {
-  return error != null && error.startsWith(QUERY_TIMEOUT_ERROR_PREFIX);
-}
-
 export const VALUE_TYPE_OPTIONS: {
   value: "unit_count" | "count" | "sum";
   label: string;

--- a/packages/front-end/test/enterprise/components/ProductAnalytics/explorerQueryPhase.test.ts
+++ b/packages/front-end/test/enterprise/components/ProductAnalytics/explorerQueryPhase.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import type { ProductAnalyticsExploration } from "shared/validators";
+import type { ExplorerDraftConfig } from "@/enterprise/components/ProductAnalytics/util";
+import {
+  getExplorerFloatingCallout,
+  getExplorerQueryPhase,
+  getQueryTimeoutErrorMessage,
+  resolveExplorerQueryErrorKind,
+  type ExplorerQueryErrorKind,
+} from "@/enterprise/components/ProductAnalytics/explorerQueryPhase";
+
+const submitted: ExplorerDraftConfig = {
+  type: "fact_table",
+  datasource: "ds_1",
+  chartType: "bar",
+  dimensions: [],
+  dateRange: { predefined: "last7Days" },
+  dataset: {
+    type: "fact_table",
+    factTableId: "ft_1",
+    values: [
+      {
+        type: "fact_table",
+        name: "value",
+        rowFilters: [],
+        valueType: "count",
+        valueColumn: null,
+        unit: null,
+      },
+    ],
+  },
+};
+
+const settled = {
+  loading: false,
+  isStale: false,
+  needsFetch: false,
+  needsUpdate: false,
+  error: null as string | null,
+  errorKind: null as ExplorerQueryErrorKind | null,
+  submittedExploreState: submitted,
+};
+
+describe("getQueryTimeoutErrorMessage", () => {
+  it("mentions fewer steps only for funnels", () => {
+    expect(getQueryTimeoutErrorMessage(true)).toContain("or fewer steps");
+    expect(getQueryTimeoutErrorMessage(false)).not.toContain("or fewer steps");
+  });
+});
+
+describe("resolveExplorerQueryErrorKind", () => {
+  it("records an explicit timeout even when there is no exploration", () => {
+    expect(
+      resolveExplorerQueryErrorKind({
+        result: null,
+        resultError: getQueryTimeoutErrorMessage(false),
+        timeout: true,
+      }),
+    ).toBe("timeout");
+  });
+
+  it("treats a warehouse error exploration as a query failure", () => {
+    const result = {
+      status: "error",
+      error: "permission denied",
+    } as ProductAnalyticsExploration;
+    expect(resolveExplorerQueryErrorKind({ result, resultError: null })).toBe(
+      "query",
+    );
+  });
+
+  it("treats a fetch error string as a query failure", () => {
+    expect(
+      resolveExplorerQueryErrorKind({
+        result: null,
+        resultError: "connection reset",
+      }),
+    ).toBe("query");
+  });
+
+  it("returns null on success", () => {
+    const result = { status: "success" } as ProductAnalyticsExploration;
+    expect(resolveExplorerQueryErrorKind({ result, resultError: null })).toBe(
+      null,
+    );
+  });
+});
+
+describe("getExplorerQueryPhase", () => {
+  it("prefers loading over a leftover error", () => {
+    expect(
+      getExplorerQueryPhase({
+        ...settled,
+        loading: true,
+        errorKind: "timeout",
+        error: getQueryTimeoutErrorMessage(false),
+      }),
+    ).toEqual({ type: "loading" });
+  });
+
+  it("is idle until a submittable config has been submitted", () => {
+    expect(
+      getExplorerQueryPhase({
+        ...settled,
+        submittedExploreState: null,
+      }),
+    ).toEqual({ type: "idle" });
+  });
+
+  it("surfaces the last timeout while the draft still matches submitted", () => {
+    expect(
+      getExplorerQueryPhase({
+        ...settled,
+        errorKind: "timeout",
+        error: getQueryTimeoutErrorMessage(false),
+      }),
+    ).toEqual({
+      type: "error",
+      kind: "timeout",
+      message: getQueryTimeoutErrorMessage(false),
+    });
+  });
+
+  it("surfaces a warehouse failure without matching error copy", () => {
+    expect(
+      getExplorerQueryPhase({
+        ...settled,
+        errorKind: "query",
+        error: "permission denied",
+      }),
+    ).toEqual({
+      type: "error",
+      kind: "query",
+      message: "permission denied",
+    });
+  });
+
+  it("treats a required-cache miss after a failed submit as stale, not a new failure", () => {
+    expect(
+      getExplorerQueryPhase({
+        ...settled,
+        isStale: true,
+        needsFetch: true,
+        errorKind: "timeout",
+        error: getQueryTimeoutErrorMessage(false),
+      }),
+    ).toEqual({ type: "stale" });
+  });
+
+  it("restores the failed outcome when the draft is dialed back to submitted", () => {
+    expect(
+      getExplorerQueryPhase({
+        ...settled,
+        errorKind: "timeout",
+        error: getQueryTimeoutErrorMessage(false),
+      }).type,
+    ).toBe("error");
+  });
+
+  it("is stale when the draft needs a fetch and the last run succeeded", () => {
+    expect(
+      getExplorerQueryPhase({
+        ...settled,
+        isStale: true,
+        needsFetch: true,
+      }),
+    ).toEqual({ type: "stale" });
+  });
+
+  it("is success when the last run applies and did not fail", () => {
+    expect(getExplorerQueryPhase(settled)).toEqual({ type: "success" });
+  });
+});
+
+describe("getExplorerFloatingCallout", () => {
+  it("returns null for idle and success", () => {
+    expect(getExplorerFloatingCallout({ type: "idle" })).toBe(null);
+    expect(getExplorerFloatingCallout({ type: "success" })).toBe(null);
+  });
+
+  it("maps loading, stale, timeout, and query failure onto one banner model", () => {
+    expect(getExplorerFloatingCallout({ type: "loading" })).toEqual({
+      status: "info",
+      text: "Loading...",
+      action: null,
+    });
+    expect(getExplorerFloatingCallout({ type: "stale" })).toMatchObject({
+      status: "info",
+      text: "Latest changes not applied",
+      action: "refresh",
+    });
+    expect(
+      getExplorerFloatingCallout({
+        type: "error",
+        kind: "timeout",
+        message: "ignored",
+      }),
+    ).toEqual({
+      status: "error",
+      text: "Query timed out",
+      action: "retry",
+    });
+    expect(
+      getExplorerFloatingCallout({
+        type: "error",
+        kind: "query",
+        message: "ignored",
+      }),
+    ).toEqual({
+      status: "error",
+      text: "Query failed",
+      action: "retry",
+    });
+  });
+});


### PR DESCRIPTION
### Features and Changes

Stacked on #6572. That PR made the "Query timed out" banner show a **Retry** button, but the retry opportunity could still silently disappear:

If a query for config A timed out, then the user changed a dimension or filter to config B (an auto-triggered fetch using the required-cache policy), and that fetch missed cache, `doSubmit` cleared `error` to `null` without updating `submittedState`/`exploration`. Dialing the draft back to A then showed no banner and no data.

This PR keeps that retry visible by giving Explorer a single query outcome instead of reconstructing failure in the view:

- Stops clearing `error` at the start of `doSubmit`. A required-cache miss is not a completed attempt: the last exploration/error stands, and the draft is marked stale. Reverting the draft restores Retry.
- Records `errorKind` (`timeout` | `query`) in context so timeout is not detected by matching user-facing copy.
- Exposes a derived `queryPhase` (`idle` | `loading` | `stale` | `success` | `error`). `ExplorerMainSection` renders `getExplorerFloatingCallout(queryPhase)` instead of `isTimeoutError` / `isUnresolved` ternaries.
- Warehouse failures (`exploration.status === "error"`) share the same error phase, so Retry is not timeout-only.

- Closes **(add link to issue here)**

### Dependencies

Depends on #6572 (base branch for this PR).

### Testing

1. Set the warehouse query timeout low, run Explorer until it times out, confirm the floating banner says "Query timed out" with Retry.
2. Change a dimension or filter (cache miss), then change it back to the timed-out config — Retry should still be there.
3. Trigger a warehouse query failure (not a timeout) and confirm the banner says "Query failed" with Retry.

### Screenshots
<img width="1488" height="862" alt="Screenshot 2026-08-06 at 2 52 59 PM" src="https://github.com/user-attachments/assets/aec99995-fdb5-4414-b29e-082acc2b63b9" />
<img width="1486" height="862" alt="Screenshot 2026-08-06 at 2 53 08 PM" src="https://github.com/user-attachments/assets/d501d161-7ce4-4d37-ba3c-a794948b4712" />
<img width="1492" height="864" alt="Screenshot 2026-08-06 at 2 53 15 PM" src="https://github.com/user-attachments/assets/c8db4f4d-ed5c-42d7-9a14e045489a" />