### PR TITLE
fix(funnels): use one shared WITHIN GROUP ordering for Redshift step arrays

### DIFF
--- a/packages/back-end/src/integrations/dialects/redshift.ts
+++ b/packages/back-end/src/integrations/dialects/redshift.ts
@@ -40,9 +40,10 @@ export const redshiftDialect: SqlDialect = {
   },
   // Redshift rejects a SELECT whose WITHIN GROUP (ORDER BY) clauses differ
   // across aggregates ("within group ORDER BY clauses for aggregate functions
-  // must be the same"), so honor the shared `orderBy` when provided.
-  arrayAggSorted: (col: string, orderBy?: string) =>
-    `SPLIT_TO_ARRAY(LISTAGG(CAST(${col} AS VARCHAR), '||~gb~||') WITHIN GROUP (ORDER BY ${orderBy ?? col}), '||~gb~||')`,
+  // must be the same"), so honor the shared alias when provided. See the
+  // SqlDialect docs: the alias must equal `col` wherever `col` is non-null.
+  arrayAggSorted: (col: string, orderByColAlias?: string) =>
+    `SPLIT_TO_ARRAY(LISTAGG(CAST(${col} AS VARCHAR), '||~gb~||') WITHIN GROUP (ORDER BY ${orderByColAlias ?? col}), '||~gb~||')`,
   argMinByTimestamp: (valueCol: string, tsCol: string) =>
     `SPLIT_PART(MIN(CAST(${tsCol} AS VARCHAR) || '||~gb~||' || CAST(${valueCol} AS VARCHAR)), '||~gb~||', 2)`,
   arrayMinInRange: (col, lowerBound, upperBound) => {

--- a/packages/back-end/src/integrations/dialects/redshift.ts
+++ b/packages/back-end/src/integrations/dialects/redshift.ts
@@ -38,8 +38,11 @@ export const redshiftDialect: SqlDialect = {
       .join(", ")}, TRUE)`;
     return isNumeric ? redshiftDialect.castToFloat(raw) : raw;
   },
-  arrayAggSorted: (col: string) =>
-    `SPLIT_TO_ARRAY(LISTAGG(CAST(${col} AS VARCHAR), '||~gb~||') WITHIN GROUP (ORDER BY ${col}), '||~gb~||')`,
+  // Redshift rejects a SELECT whose WITHIN GROUP (ORDER BY) clauses differ
+  // across aggregates ("within group ORDER BY clauses for aggregate functions
+  // must be the same"), so honor the shared `orderBy` when provided.
+  arrayAggSorted: (col: string, orderBy?: string) =>
+    `SPLIT_TO_ARRAY(LISTAGG(CAST(${col} AS VARCHAR), '||~gb~||') WITHIN GROUP (ORDER BY ${orderBy ?? col}), '||~gb~||')`,
   argMinByTimestamp: (valueCol: string, tsCol: string) =>
     `SPLIT_PART(MIN(CAST(${tsCol} AS VARCHAR) || '||~gb~||' || CAST(${valueCol} AS VARCHAR)), '||~gb~||', 2)`,
   arrayMinInRange: (col, lowerBound, upperBound) => {

--- a/packages/back-end/test/integrations/dialects/funnel-sql.test.ts
+++ b/packages/back-end/test/integrations/dialects/funnel-sql.test.ts
@@ -161,6 +161,12 @@ describe("SqlDialect funnel array helpers", () => {
     expect(redshiftDialect.arrayAggSorted("value")).toContain(
       "SPLIT_TO_ARRAY(LISTAGG(",
     );
+    // A shared order expression must replace the per-column default so that
+    // multiple aggregates in one SELECT can use identical WITHIN GROUP
+    // clauses (a hard Redshift requirement).
+    expect(redshiftDialect.arrayAggSorted("value", "ts")).toContain(
+      "WITHIN GROUP (ORDER BY ts)",
+    );
     expect(redshiftDialect.argMinByTimestamp("value", "timestamp")).toContain(
       "SPLIT_PART(MIN(",
     );
@@ -382,6 +388,25 @@ describe("buildFunnelSql — launch subset (real dialects)", () => {
     expect(sql).not.toMatch(/EXTRACT\(\s*EPOCH/i);
     expect(sql).not.toMatch(/unnest\(/i);
     expect(sql).not.toMatch(/ARRAY_AGG\(/i);
+  });
+
+  it("Redshift uses one identical WITHIN GROUP ordering for all step arrays", () => {
+    // Redshift rejects a SELECT whose WITHIN GROUP (ORDER BY) clauses differ
+    // across aggregates. A 3-step funnel aggregates two step arrays in the
+    // same SELECT, so they must share a single order expression.
+    const { sql, stepCount } = buildFunnelSql(
+      config,
+      factTableMap,
+      redshiftDialect,
+    );
+    expect(stepCount).toBe(3);
+    const orderings = [
+      ...sql.matchAll(/WITHIN GROUP\s*\(\s*ORDER BY\s+([^)]+?)\s*\)/gi),
+    ]
+      .map((m) => m[1].replace(/\s+/g, " "))
+      .sort();
+    expect(orderings.length).toBeGreaterThanOrEqual(2);
+    expect(new Set(orderings).size).toBe(1);
   });
 
   it("multi-fact-table funnel with a breakdown types the dimension NULL for the UNION", () => {

--- a/packages/shared/src/enterprise/product-analytics/sql.ts
+++ b/packages/shared/src/enterprise/product-analytics/sql.ts
@@ -1455,8 +1455,12 @@ export function buildFunnelSql(
   userAggregateCols.push(`MIN(step1_ts) AS step1_resolved_ts`);
   for (let i = 1; i < steps.length; i++) {
     const stepN = i + 1;
+    // Order every array by the shared raw event timestamp instead of the
+    // step's own column: each stepN_ts is a CASE-gated copy of `ts`, so the
+    // resulting order is identical, and using one shared expression keeps
+    // Redshift happy (all WITHIN GROUP ORDER BYs in a SELECT must match).
     userAggregateCols.push(
-      `${dialect.arrayAggSorted(`step${stepN}_ts`)} AS step${stepN}_arr`,
+      `${dialect.arrayAggSorted(`step${stepN}_ts`, "ts")} AS step${stepN}_arr`,
     );
   }
   const userAggregatesCte: CTE = {

--- a/packages/shared/types/sql.d.ts
+++ b/packages/shared/types/sql.d.ts
@@ -120,15 +120,13 @@ export interface SqlDialect {
    * the chained step-resolution CTEs then look up matching timestamps via
    * `arrayMinInRange` instead of self-joining the full event log.
    *
-   * `orderBy` is an optional shared sort expression (defaults to `col`).
-   * Redshift requires every WITHIN GROUP (ORDER BY ...) aggregate in a
-   * SELECT to use an identical ORDER BY clause, so when a query aggregates
-   * several columns, callers must pass the same `orderBy` to each call.
-   * This is only sound when each `col` equals `orderBy` on every row where
-   * `col` is non-null — true for funnel step timestamps, which are
-   * CASE-gated copies of the row's event timestamp.
+   * `orderByColAlias` is NOT a free-form sort expression: it MUST equal
+   * `col` on every row where `col` is non-null (funnel step timestamps
+   * satisfy this — each is a CASE-gated copy of the row's event timestamp).
+   * Passing the same alias to every call lets all aggregates in a SELECT
+   * share an identical WITHIN GROUP ordering, which Redshift requires.
    */
-  arrayAggSorted: (col: string, orderBy?: string) => string;
+  arrayAggSorted: (col: string, orderByColAlias?: string) => string;
   /**
    * Aggregate value: returns `valueCol` from the row where `tsCol` is the
    * minimum non-null timestamp in the group. Used by funnel SQL to capture

--- a/packages/shared/types/sql.d.ts
+++ b/packages/shared/types/sql.d.ts
@@ -119,8 +119,16 @@ export interface SqlDialect {
    * sorted timestamp array per user per step in a single GROUP BY pass —
    * the chained step-resolution CTEs then look up matching timestamps via
    * `arrayMinInRange` instead of self-joining the full event log.
+   *
+   * `orderBy` is an optional shared sort expression (defaults to `col`).
+   * Redshift requires every WITHIN GROUP (ORDER BY ...) aggregate in a
+   * SELECT to use an identical ORDER BY clause, so when a query aggregates
+   * several columns, callers must pass the same `orderBy` to each call.
+   * This is only sound when each `col` equals `orderBy` on every row where
+   * `col` is non-null — true for funnel step timestamps, which are
+   * CASE-gated copies of the row's event timestamp.
    */
-  arrayAggSorted: (col: string) => string;
+  arrayAggSorted: (col: string, orderBy?: string) => string;
   /**
    * Aggregate value: returns `valueCol` from the row where `tsCol` is the
    * minimum non-null timestamp in the group. Used by funnel SQL to capture


### PR DESCRIPTION
## Fix Redshift funnel error: `within group ORDER BY clauses for aggregate functions must be the same`

Funnels with 3+ steps failed on Redshift because each step's sorted timestamp array used its own column in `WITHIN GROUP (ORDER BY ...)`, and Redshift requires every such clause in a SELECT to be identical.

`arrayAggSorted` now accepts an optional shared `orderByColAlias ` expression, and the funnel builder passes the raw event timestamp (`ts`) for every step array. This is functionally equivalent, since the `stepX_ts` items are always just the `timestamp` from the previous step anyways. This argument to `arrayAggSorted` is a bit risky since now if `orderByColAlias` is not the same as `col` then this logic somewhat breaks down, but for funnels this isn't a problem and I note it in the argument name and in the docs for that argument.

**Before**

```sql
-- __funnel_ft0_events
SELECT
  user_id,
  timestamp AS ts,
  CASE WHEN (event_name = 'add_to_cart') THEN timestamp END AS step2_ts,
  CASE WHEN (event_name = 'purchase')    THEN timestamp END AS step3_ts
FROM ...

-- __funnel_user_aggregates
SELECT
  user_id,
  MIN(step1_ts) AS step1_resolved_ts,
  LISTAGG(CAST(step2_ts AS VARCHAR), '||~gb~||') WITHIN GROUP (ORDER BY step2_ts) ...,
  LISTAGG(CAST(step3_ts AS VARCHAR), '||~gb~||') WITHIN GROUP (ORDER BY step3_ts) ... --
FROM __funnel_ft0_events
GROUP BY user_id
```

This errors because the ORDER BY statement is different in this GROUP BY.

**After**

```sql
-- __funnel_ft0_events (same as above)
SELECT
  user_id,
  timestamp AS ts,
  CASE WHEN (event_name = 'add_to_cart') THEN timestamp END AS step2_ts,
  CASE WHEN (event_name = 'purchase')    THEN timestamp END AS step3_ts
FROM ...

-- __funnel_user_aggregates
SELECT
  user_id,
  MIN(step1_ts) AS step1_resolved_ts,
  LISTAGG(CAST(step2_ts AS VARCHAR), '||~gb~||') WITHIN GROUP (ORDER BY ts) ...,
  LISTAGG(CAST(step3_ts AS VARCHAR), '||~gb~||') WITHIN GROUP (ORDER BY ts) ...
FROM __funnel_ft0_events
GROUP BY user_id
```
This works because you can see how `step2_ts` and `step3_ts` are just `timestamp` or NULL, so when we use `ts` in `__funnel_user_aggregates`, the order still works.

Other dialects are unaffected (only Redshift uses the parameter). 


## Testing

Manual testing, PA redshift funnel with 3 steps now works, counts seem correct.