### PR TITLE
agentic-bugfix/environment-orphaned-project-cleanup

### DIFF
--- a/packages/back-end/src/models/OrganizationModel.ts
+++ b/packages/back-end/src/models/OrganizationModel.ts
@@ -547,6 +547,32 @@ export async function removeProjectFromProjectRoles(
   }
 }
 
+export async function removeProjectFromEnvironments(
+  project: string,
+  org: OrganizationInterface,
+) {
+  if (!org) return;
+
+  const environments = cloneDeep(org.settings?.environments || []);
+  let changed = false;
+
+  environments.forEach((env) => {
+    if (!env.projects?.length) return;
+    const filtered = env.projects.filter((p) => p !== project);
+    if (filtered.length !== env.projects.length) {
+      env.projects = filtered;
+      changed = true;
+    }
+  });
+
+  if (changed) {
+    await OrganizationModel.updateOne(
+      { id: org.id },
+      { $set: { "settings.environments": environments } },
+    );
+  }
+}
+
 export async function findOrganizationsByDomain(domain: string) {
   const docs = await OrganizationModel.find({
     verifiedDomain: domain,

--- a/packages/back-end/src/services/projects.ts
+++ b/packages/back-end/src/services/projects.ts
@@ -4,7 +4,10 @@ import { removeProjectFromMetrics } from "back-end/src/models/MetricModel";
 import { removeProjectFromFeatures } from "back-end/src/models/FeatureModel";
 import { removeProjectFromExperiments } from "back-end/src/models/ExperimentModel";
 import { removeProjectFromSlackIntegration } from "back-end/src/models/SlackIntegrationModel";
-import { removeProjectFromProjectRoles } from "back-end/src/models/OrganizationModel";
+import {
+  removeProjectFromProjectRoles,
+  removeProjectFromEnvironments,
+} from "back-end/src/models/OrganizationModel";
 
 /**
  * Remove all references to a project from multi-project resources and
@@ -50,6 +53,10 @@ export async function cleanupProjectReferences(
     [
       "project roles",
       () => removeProjectFromProjectRoles(projectId, context.org),
+    ],
+    [
+      "environments",
+      () => removeProjectFromEnvironments(projectId, context.org),
     ],
     [
       "saved groups",


### PR DESCRIPTION
### Features and Changes
Deleting a project scrubbed the project ID from data sources, metrics, features, experiments, Slack integrations, project roles, saved groups, constants, and configs — but never from environments. An environment scoped to a deleted project kept the dangling ID in its `projects` array indefinitely, which blocks it from being cleanly managed or deleted afterward since it references a project that no longer exists. Added `removeProjectFromEnvironments` (mirroring the existing `removeProjectFromProjectRoles` pattern) and registered it as a step in `cleanupProjectReferences`, so deleting a project now also strips it from any environment's `projects` array, falling back to "all projects" the same way features and experiments already do:
- Environment scoped only to the deleted project → `projects: []` (all projects)
- Environment scoped to the deleted project plus others → deleted ID removed, other project IDs retained
- Environment not scoped to the deleted project → unchanged

### Testing
Create an environment scoped to a project, delete that project, and confirm the environment's `projects` array no longer contains the deleted project ID (and the environment can be edited/deleted normally afterward). Repeat with an environment scoped to multiple projects to confirm only the deleted ID is removed. Confirm an environment scoped to an unrelated project is unaffected.