### PR TITLE
chore(test): limit workers on non-CI to avoid OOM

### DIFF
--- a/packages/back-end/jest.config.js
+++ b/packages/back-end/jest.config.js
@@ -12,12 +12,10 @@ module.exports = {
       "<rootDir>/../../node_modules/.pnpm/@typespec+ts-http-runtime@0.3.1/node_modules/@typespec/ts-http-runtime/dist/commonjs/$1/internal.js",
   },
   setupFilesAfterEnv: ["<rootDir>/test/jest.setup.ts"],
-  // Cap parallelism only where a `pnpm dev` stack competes for the same box
-  // (local laptop or cloud dev agent). CI has a dedicated runner and runs the
-  // workspaces sequentially, so it keeps Jest's default worker count. Jest
-  // retains each file's module graph for the worker's lifetime (~140MB/file),
-  // so the idle-memory recycle keeps a long-lived worker from creeping toward
-  // the heap ceiling and OOMing.
+  // Off CI, tests share the box with a running `pnpm dev` stack, so cap
+  // workers.
   ...(process.env.CI ? {} : { maxWorkers: 2 }),
-  workerIdleMemoryLimit: "768MB",
+  // Each file's module graph stays resident (~140MB/file); recycle workers
+  // before the heap fills. Tighter off CI, where memory is shared.
+  workerIdleMemoryLimit: process.env.CI ? "2GB" : "768MB",
 };

--- a/packages/back-end/jest.config.js
+++ b/packages/back-end/jest.config.js
@@ -12,11 +12,10 @@ module.exports = {
       "<rootDir>/../../node_modules/.pnpm/@typespec+ts-http-runtime@0.3.1/node_modules/@typespec/ts-http-runtime/dist/commonjs/$1/internal.js",
   },
   setupFilesAfterEnv: ["<rootDir>/test/jest.setup.ts"],
-  // Jest retains each test file's compiled module graph for the worker's
-  // lifetime, so a worker's heap grows ~140MB per file and a worker that
-  // handles enough files creeps toward the 8GB --max-old-space-size ceiling and
-  // crashes with "JavaScript heap out of memory" (intermittently, depending on
-  // how files get distributed). Recycle a worker once its RSS passes 2GB so
-  // heap usage stays well under the ceiling regardless of file distribution.
-  workerIdleMemoryLimit: "2GB",
+  // Prefer a longer run over exhausting a 16GB cloud-agent VM (or a laptop
+  // that also has `pnpm dev` up). Jest retains each file's module graph for
+  // the worker's lifetime (~140MB/file), so without recycling workers creep
+  // toward the Node heap ceiling and OOM.
+  maxWorkers: 2,
+  workerIdleMemoryLimit: "768MB",
 };

--- a/packages/back-end/jest.config.js
+++ b/packages/back-end/jest.config.js
@@ -12,10 +12,12 @@ module.exports = {
       "<rootDir>/../../node_modules/.pnpm/@typespec+ts-http-runtime@0.3.1/node_modules/@typespec/ts-http-runtime/dist/commonjs/$1/internal.js",
   },
   setupFilesAfterEnv: ["<rootDir>/test/jest.setup.ts"],
-  // Prefer a longer run over exhausting a 16GB cloud-agent VM (or a laptop
-  // that also has `pnpm dev` up). Jest retains each file's module graph for
-  // the worker's lifetime (~140MB/file), so without recycling workers creep
-  // toward the Node heap ceiling and OOM.
-  maxWorkers: 2,
+  // Cap parallelism only where a `pnpm dev` stack competes for the same box
+  // (local laptop or cloud dev agent). CI has a dedicated runner and runs the
+  // workspaces sequentially, so it keeps Jest's default worker count. Jest
+  // retains each file's module graph for the worker's lifetime (~140MB/file),
+  // so the idle-memory recycle keeps a long-lived worker from creeping toward
+  // the heap ceiling and OOMing.
+  ...(process.env.CI ? {} : { maxWorkers: 2 }),
   workerIdleMemoryLimit: "768MB",
 };

--- a/packages/back-end/jest.config.js
+++ b/packages/back-end/jest.config.js
@@ -12,10 +12,9 @@ module.exports = {
       "<rootDir>/../../node_modules/.pnpm/@typespec+ts-http-runtime@0.3.1/node_modules/@typespec/ts-http-runtime/dist/commonjs/$1/internal.js",
   },
   setupFilesAfterEnv: ["<rootDir>/test/jest.setup.ts"],
-  // Off CI, tests share the box with a running `pnpm dev` stack, so cap
-  // workers.
-  ...(process.env.CI ? {} : { maxWorkers: 2 }),
+  // For non-CI, lets make sure to cap the workers
+  ...(process.env.CI ? {} : { maxWorkers: "50%" }),
   // Each file's module graph stays resident (~140MB/file); recycle workers
-  // before the heap fills. Tighter off CI, where memory is shared.
-  workerIdleMemoryLimit: process.env.CI ? "2GB" : "768MB",
+  // before the heap fills.
+  workerIdleMemoryLimit: process.env.CI ? "2GB" : "1GB",
 };

--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -17,7 +17,7 @@
     "start:with-tracing": "node --require ./dist/tracing.opentelemetry.js dist/server.js",
     "start:with-datadog": "node --require ./dist/tracing.datadog.js dist/server.js",
     "repl": "node --require ts-node/register/transpile-only --experimental-repl-await repl",
-    "test": "DISABLE_PYTHON_MONITOR=true GB_STATS_ENGINE_MIN_POOL_SIZE=0 NODE_OPTIONS='--no-node-snapshot --max-old-space-size=3072' jest",
+    "test": "DISABLE_PYTHON_MONITOR=true GB_STATS_ENGINE_MIN_POOL_SIZE=0 NODE_OPTIONS='--no-node-snapshot --max-old-space-size=8192' jest",
     "type-check": "tsgo --pretty --noEmit",
     "unused-export-check": "npx ts-unused-exports tsconfig.json --findCompletelyUnusedFiles --allowUnusedTypes --showLineNumber",
     "generate-dummy-data": "ts-node ./test/data-generator/new-generator.ts",

--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -17,7 +17,7 @@
     "start:with-tracing": "node --require ./dist/tracing.opentelemetry.js dist/server.js",
     "start:with-datadog": "node --require ./dist/tracing.datadog.js dist/server.js",
     "repl": "node --require ts-node/register/transpile-only --experimental-repl-await repl",
-    "test": "DISABLE_PYTHON_MONITOR=true GB_STATS_ENGINE_MIN_POOL_SIZE=0 NODE_OPTIONS='--no-node-snapshot --max-old-space-size=8192' jest",
+    "test": "DISABLE_PYTHON_MONITOR=true GB_STATS_ENGINE_MIN_POOL_SIZE=0 NODE_OPTIONS='--no-node-snapshot --max-old-space-size=3072' jest",
     "type-check": "tsgo --pretty --noEmit",
     "unused-export-check": "npx ts-unused-exports tsconfig.json --findCompletelyUnusedFiles --allowUnusedTypes --showLineNumber",
     "generate-dummy-data": "ts-node ./test/data-generator/new-generator.ts",

--- a/packages/front-end/vitest.config.js
+++ b/packages/front-end/vitest.config.js
@@ -6,9 +6,10 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./test/setup.ts"],
-    // Cap parallelism so front-end tests stay within a 16GB cloud-agent VM
-    // (or a laptop that also has `pnpm dev` running).
-    maxWorkers: 2,
+    // Cap parallelism only where a `pnpm dev` stack competes for the same box
+    // (local laptop or cloud dev agent). CI has a dedicated runner, so it keeps
+    // Vitest's default worker count.
+    ...(process.env.CI ? {} : { maxWorkers: 2 }),
     coverage: {
       provider: "v8",
     },

--- a/packages/front-end/vitest.config.js
+++ b/packages/front-end/vitest.config.js
@@ -6,9 +6,8 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./test/setup.ts"],
-    // Cap parallelism only where a `pnpm dev` stack competes for the same box
-    // (local laptop or cloud dev agent). CI has a dedicated runner, so it keeps
-    // Vitest's default worker count.
+    // Off CI, tests share the box with a running `pnpm dev` stack, so cap
+    // workers.
     ...(process.env.CI ? {} : { maxWorkers: 2 }),
     coverage: {
       provider: "v8",

--- a/packages/front-end/vitest.config.js
+++ b/packages/front-end/vitest.config.js
@@ -6,6 +6,9 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./test/setup.ts"],
+    // Cap parallelism so front-end tests stay within a 16GB cloud-agent VM
+    // (or a laptop that also has `pnpm dev` running).
+    maxWorkers: 2,
     coverage: {
       provider: "v8",
     },


### PR DESCRIPTION
### Features and Changes

I noticed in my local env (and also Cursor cloud agents) that sometimes running `pnpm test` would take up a lot of my memory, making things crash sometimes if we had 2 `test` processes running at the same time with dev server, etc.

So we are keeping the `CI` configuration as-is but limiting the workers for dev machines, and also recycling the `jest` workers sooner.

From my testing this should improve this situation without a lot of additional drawback.