### PR TITLE
fix(ui): truncate long breadcrumbs and wrap long page titles

### DIFF
--- a/packages/front-end/components/ContextualBandit/ContextualBanditDetailPage.tsx
+++ b/packages/front-end/components/ContextualBandit/ContextualBanditDetailPage.tsx
@@ -258,24 +258,22 @@ export default function ContextualBanditDetailPage({
   return (
     <Box>
       <Flex direction="row" align="start" justify="between" gap="5">
-        <Box>
-          <h1
-            className="mb-0"
-            style={{ display: "inline", verticalAlign: "middle" }}
+        <Flex align="center" gap="2">
+          <Heading
+            as="h1"
+            size="xl"
+            weight="semibold"
+            overflowWrap="anywhere"
+            mb="0"
           >
             {cb.name}
-          </h1>
-          <Box
-            ml="2"
-            mt="1"
-            display="inline-block"
-            style={{ userSelect: "none" }}
-          >
+          </Heading>
+          <Box style={{ userSelect: "none" }}>
             <ExperimentStatusIndicator
               experimentData={contextualBanditStatusIndicatorData(cb)}
             />
           </Box>
-        </Box>
+        </Flex>
 
         <Flex direction="row" align="center" gap="2" flexShrink="0">
           {canRun && cb.status === "draft" ? (

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -823,7 +823,13 @@ export default function ExperimentHeader({
       >
         <Flex direction="row" align="start" justify="between" gap="5">
           <Flex align="center" gap="2">
-            <Heading as="h1" size="2xl" color="text-high" weight="medium">
+            <Heading
+              as="h1"
+              size="2xl"
+              color="text-high"
+              overflowWrap="anywhere"
+              weight="medium"
+            >
               {experiment.name}
             </Heading>
             <Box style={{ userSelect: "none" }}>

--- a/packages/front-end/components/Features/FeaturesHeader.tsx
+++ b/packages/front-end/components/Features/FeaturesHeader.tsx
@@ -412,7 +412,7 @@ export default function FeaturesHeader({
         <Box>
           <Flex align="start" justify="between" gap="2">
             <Flex align="center" mb="2" gap="3" style={{ marginTop: "-4px" }}>
-              <Heading size="xl" as="h1" mb="0">
+              <Heading size="xl" as="h1" overflowWrap="anywhere" mb="0">
                 {feature.id}
               </Heading>
               <FeatureStatusBadge

--- a/packages/front-end/components/Report/ReportMetaInfo.tsx
+++ b/packages/front-end/components/Report/ReportMetaInfo.tsx
@@ -30,6 +30,7 @@ import ConditionalWrapper from "@/components/ConditionalWrapper";
 import track from "@/services/track";
 import Owner from "@/components/Avatar/Owner";
 import Metadata from "@/ui/Metadata";
+import Heading from "@/ui/Heading";
 import ShareStatusBadge from "@/components/Report/ShareStatusBadge";
 
 type ShareLevel = "public" | "organization" | "private";
@@ -265,23 +266,30 @@ export default function ReportMetaInfo({
       <div className="mb-3">
         <div className="d-flex">
           <div className="flex-1">
-            <h1 className="mt-1 mb-3 mr-2">
+            <Heading
+              as="h1"
+              size="xl"
+              weight="semibold"
+              color="text-high"
+              overflowWrap="anywhere"
+              mt="1"
+              mb="4"
+              mr="2"
+            >
               {report.title}
               {showEditControls && (
-                <>
-                  <div
-                    className="d-inline-block ml-2 position-relative"
-                    style={{ top: -2 }}
-                  >
-                    <ShareStatusBadge
-                      shareLevel={report.shareLevel}
-                      editLevel={report.editLevel}
-                      isOwner={isOwner}
-                    />
-                  </div>
-                </>
+                <div
+                  className="d-inline-block ml-2 position-relative"
+                  style={{ top: -2 }}
+                >
+                  <ShareStatusBadge
+                    shareLevel={report.shareLevel}
+                    editLevel={report.editLevel}
+                    isOwner={isOwner}
+                  />
+                </div>
               )}
-            </h1>
+            </Heading>
 
             <Flex gap="3" mt="2" mb="1">
               {showEditControls && (

--- a/packages/front-end/pages/attributes/[property].tsx
+++ b/packages/front-end/pages/attributes/[property].tsx
@@ -266,7 +266,7 @@ export default function AttributeDetailPage() {
       />
       <div className="p-3 container-fluid pagecontents">
         <Flex align="center" justify="between" mb="4">
-          <Heading as="h1" size="xl">
+          <Heading as="h1" size="xl" overflowWrap="anywhere">
             {attribute.property}
           </Heading>
           {canEdit && (

--- a/packages/front-end/pages/configs/[cfgid].tsx
+++ b/packages/front-end/pages/configs/[cfgid].tsx
@@ -1462,7 +1462,7 @@ export default function ConfigDetailPage(): React.ReactElement {
             <Flex align="start" justify="between" gap="2" mb="2">
               <Box style={{ marginTop: "-4px" }}>
                 <Flex align="center" gap="3">
-                  <Heading size="xl" as="h1" mb="0">
+                  <Heading size="xl" as="h1" overflowWrap="anywhere" mb="0">
                     {displayedConfig.name}
                   </Heading>
                   {displayedConfig.archived && (

--- a/packages/front-end/pages/constants/[cid].tsx
+++ b/packages/front-end/pages/constants/[cid].tsx
@@ -330,7 +330,7 @@ export default function ConstantDetailPage(): React.ReactElement {
       <div className="container-fluid pagecontents">
         <Flex align="start" justify="between" gap="2" mb="2">
           <Flex align="center" gap="3" style={{ marginTop: "-4px" }}>
-            <Heading size="2xl" as="h1" mb="0">
+            <Heading size="2xl" as="h1" overflowWrap="anywhere" mb="0">
               {displayedConstant.name}
             </Heading>
             {displayedConstant.archived && (

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -217,7 +217,7 @@ const DataSourcePage: FC = () => {
       )}
       <Flex align="center" justify="between">
         <Flex align="center" gap="3">
-          <Heading as="h1" size="xl" mb="0">
+          <Heading as="h1" size="xl" overflowWrap="anywhere" mb="0">
             {d.name}
           </Heading>
           <Badge

--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -534,7 +534,7 @@ export default function FactMetricPage() {
       )}
       <Flex align="start" justify="between" gap="2" mb="2">
         <Flex align="center" gap="3" style={{ marginTop: "-4px" }}>
-          <Heading size="xl" as="h1" mb="0">
+          <Heading size="xl" as="h1" overflowWrap="anywhere" mb="0">
             <MetricName id={factMetric.id} officialBadgePosition="right" />
           </Heading>
         </Flex>

--- a/packages/front-end/pages/fact-tables/[ftid].tsx
+++ b/packages/front-end/pages/fact-tables/[ftid].tsx
@@ -283,7 +283,7 @@ export default function FactTablePage() {
       )}
       <Flex align="start" justify="between" gap="2" mb="2">
         <Flex align="center" gap="3" style={{ marginTop: "-4px" }}>
-          <Heading size="xl" as="h1" mb="0">
+          <Heading size="xl" as="h1" overflowWrap="anywhere" mb="0">
             {factTable.name}
             <OfficialBadge
               ml="2"

--- a/packages/front-end/pages/metric/[mid].tsx
+++ b/packages/front-end/pages/metric/[mid].tsx
@@ -430,7 +430,7 @@ const MetricPage: FC = () => {
 
       <Flex align="start" justify="between" gap="2" mb="2">
         <Flex align="center" gap="3" style={{ marginTop: "-4px" }}>
-          <Heading size="xl" as="h1" mb="0">
+          <Heading size="xl" as="h1" overflowWrap="anywhere" mb="0">
             <MetricName id={metric.id} />
           </Heading>
         </Flex>

--- a/packages/front-end/pages/project/[pid].tsx
+++ b/packages/front-end/pages/project/[pid].tsx
@@ -178,7 +178,7 @@ const ProjectPage: FC = () => {
         ) : null}
         <Flex align="center" justify="between" width="100%">
           <Flex align="start" direction="column">
-            <Heading size="xl" as="h1">
+            <Heading size="xl" as="h1" overflowWrap="anywhere">
               {p.name}
             </Heading>
             <Flex gap="6" mb="4">

--- a/packages/front-end/pages/saved-groups/[sgid].tsx
+++ b/packages/front-end/pages/saved-groups/[sgid].tsx
@@ -892,7 +892,7 @@ export default function EditSavedGroupPage() {
       <div className="container-fluid pagecontents">
         <Flex align="start" justify="between" gap="2">
           <Flex align="center" mb="2" gap="3" style={{ marginTop: "-4px" }}>
-            <Heading size="2xl" as="h1" mb="0">
+            <Heading size="2xl" as="h1" overflowWrap="anywhere" mb="0">
               {displayedSavedGroup?.groupName || savedGroup.groupName}
             </Heading>
             {displayedSavedGroup?.archived && (

--- a/packages/front-end/pages/sdks/[sdkid].tsx
+++ b/packages/front-end/pages/sdks/[sdkid].tsx
@@ -122,7 +122,7 @@ export default function SDKConnectionPage() {
 
       <Flex align="start" justify="between" gap="2" mb="2">
         <Flex align="center" gap="3" style={{ marginTop: "-4px" }}>
-          <Heading size="xl" as="h1" mb="0">
+          <Heading size="xl" as="h1" overflowWrap="anywhere" mb="0">
             {connection.name}
           </Heading>
         </Flex>

--- a/packages/front-end/ui/Breadcrumbs.module.scss
+++ b/packages/front-end/ui/Breadcrumbs.module.scss
@@ -21,3 +21,26 @@
     align-items: center;
   }
 }
+
+.current {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+
+  > span {
+    display: block;
+    min-width: 0;
+    max-width: 100%;
+  }
+}
+
+// Cap each ancestor crumb's width so a long ancestor name (e.g. the experiment
+// name in a report's "Experiments > <experiment> > <report>" trail) can't eat
+// the whole bar and push the current page's crumb off-screen. 22ch is a width
+// budget: wide enough to keep most names readable, narrow enough that a couple
+// of ancestors plus the current crumb still fit on one line. Overflow past the
+// cap is ellipsized by the Link's `truncate` (full name stays in the `title`).
+.crumbLink {
+  max-width: 22ch;
+  overflow: hidden;
+}

--- a/packages/front-end/ui/Breadcrumbs.tsx
+++ b/packages/front-end/ui/Breadcrumbs.tsx
@@ -29,10 +29,12 @@ export default function Breadcrumbs({ items }: { items: BreadcrumbItem[] }) {
               )}
               <span
                 title={item.display}
-                className={!isLast ? styles.ancestor : undefined}
+                className={isLast ? styles.current : styles.ancestor}
               >
                 {item.href ? (
                   <Link
+                    className={!isLast ? styles.crumbLink : undefined}
+                    truncate
                     href={item.href}
                     size="md"
                     weight="bold"
@@ -41,8 +43,16 @@ export default function Breadcrumbs({ items }: { items: BreadcrumbItem[] }) {
                     {item.display}
                   </Link>
                 ) : (
-                  <span aria-current={isLast ? "page" : undefined}>
-                    <Text size="md" weight="semibold" color="text-high">
+                  <span
+                    aria-current={isLast ? "page" : undefined}
+                    className={!isLast ? styles.crumbLink : undefined}
+                  >
+                    <Text
+                      size="md"
+                      weight="semibold"
+                      color="text-high"
+                      truncate
+                    >
                       {item.display}
                     </Text>
                   </span>

--- a/packages/front-end/ui/Heading.tsx
+++ b/packages/front-end/ui/Heading.tsx
@@ -12,6 +12,7 @@ type HeadingWhiteSpace =
   | "pre-wrap"
   | "pre-line"
   | "break-spaces";
+type HeadingOverflowWrap = "normal" | "anywhere" | "break-word";
 // NB: We might need to expand this to support RadixHeadingProps["color"], but being conservative for now.
 type HeadingColors = "text-high" | "text-mid" | "text-low";
 
@@ -40,6 +41,7 @@ export interface HeadingProps {
   align?: HeadingAlign;
   title?: string;
   whiteSpace?: HeadingWhiteSpace;
+  overflowWrap?: HeadingOverflowWrap;
   textTransform?: "uppercase" | "lowercase" | "capitalize";
 
   // Margin props
@@ -61,6 +63,7 @@ export default function Heading({
   align = "left",
   title,
   whiteSpace,
+  overflowWrap = "normal",
   textTransform,
   m,
   mx,
@@ -70,7 +73,7 @@ export default function Heading({
   mb,
   ml,
 }: HeadingProps) {
-  const style: React.CSSProperties = {};
+  const style: React.CSSProperties = { overflowWrap };
   if (whiteSpace) style.whiteSpace = whiteSpace;
   if (textTransform) style.textTransform = textTransform;
 


### PR DESCRIPTION
### Features and Changes

During the refactor of Breadcrumbs #5742 I broke the truncating functionality, which meant that the layout for resources with long text was not rendering as expected.

So this PR:
- Fixes the Breadcrumb truncation
- Fixes page titles to also break in case of single words with no spaces (use `anywhere` for `overflowWrap`)

### Screenshots

| Before | After |
|--------|--------|
| <img width="1440" height="900" alt="7-report" src="https://github.com/user-attachments/assets/51d3a754-75ef-401f-84d7-c9e2186eedae" /> | <img width="1440" height="900" alt="7-report" src="https://github.com/user-attachments/assets/fb0f658b-bf5f-46ef-9b89-6f2dc8065628" /> | 

### Testing

- Visual tests
