### PR TITLE
Add namespace info to Start Experiment modal summary (#6594)

### DIFF
--- a/packages/front-end/components/Experiment/TabbedPage/StartExperimentModal.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/StartExperimentModal.tsx
@@ -31,6 +31,8 @@ import {
 } from "@/services/utils";
 import ConditionDisplay from "@/components/Features/ConditionDisplay";
 import SavedGroupTargetingDisplay from "@/components/Features/SavedGroupTargetingDisplay";
+import { getNamespaceDisplayData } from "@/components/Features/NamespaceSelectorUtils";
+import useOrgSettings from "@/hooks/useOrgSettings";
 import {
   ICON_PROPERTIES,
   LINKED_CHANGE_CONTAINER_PROPERTIES,
@@ -72,6 +74,11 @@ const PENDING_DRAFT_FAILURE_LABELS: Record<
   "needs-approval": "Awaiting approval",
   "publish-error": "Publish failed unexpectedly",
 };
+
+const percentFormatter = new Intl.NumberFormat(undefined, {
+  style: "percent",
+  maximumFractionDigits: 2,
+});
 
 function SubmitButton({ cta, disabled }: { cta: string; disabled: boolean }) {
   const { loading } = useModalForm();
@@ -184,6 +191,11 @@ export default function StartExperimentModal({
   const hasAttributeTargeting = hasAttributeCondition(latestPhase?.condition);
   const hasSavedGroupTargeting = !!latestPhase?.savedGroups?.length;
   const hasPrerequisites = !!latestPhase?.prerequisites?.length && !isHoldout;
+  const { namespaces } = useOrgSettings();
+  const hasNamespace =
+    !!latestPhase?.namespace && latestPhase.namespace.enabled;
+  const { coverage: namespaceCoverage, name: namespaceName } =
+    getNamespaceDisplayData(latestPhase?.namespace, namespaces);
   const hasLinkedChanges =
     linkedFeatures.length > 0 ||
     visualChangesets.length > 0 ||
@@ -504,6 +516,14 @@ export default function StartExperimentModal({
                       </Text>
                     )}
                   </SummaryRow>
+                  {hasNamespace && (
+                    <SummaryRow label="Namespace">
+                      <Text>
+                        {namespaceName} (
+                        {percentFormatter.format(namespaceCoverage)})
+                      </Text>
+                    </SummaryRow>
+                  )}
                   {hasAttributeTargeting && (
                     <SummaryRow label="Attribute Targeting">
                       <ConditionDisplay condition={latestPhase.condition} />


### PR DESCRIPTION
### Features and Changes

Adds namespace information to the "Summary" section of the **Start Experiment** confirmation modal (`packages/front-end/components/Experiment/TabbedPage/StartExperimentModal.tsx`).

Previously, this Summary only showed Traffic, Attribute Targeting, Saved Group Targeting, and Prerequisites (each conditionally rendered based on whether they're configured), but never mentioned namespace, even when the experiment was scoped to one. This meant a user could review the pre-launch summary, see nothing about namespace targeting, and be surprised later that their experiment traffic was actually restricted to a namespace range they'd configured earlier.

**What changed:**
- Added `hasNamespace`, `namespaceName`, and `namespaceCoverage` derived from the experiment's latest phase, using the existing `getNamespaceDisplayData` helper (`@/components/Features/NamespaceSelectorUtils`) and `useOrgSettings()` hook, the same pattern already used in `TrafficAllocationFunnel.tsx` to display namespace info elsewhere in the app, so this stays consistent with the existing convention rather than introducing a new one.
- Added a new conditional `SummaryRow` for "Namespace," rendered only when `hasNamespace` is true (i.e., "if relevant," per the issue), positioned directly after the existing "Traffic" row.
- No backend or schema changes, this is a pure front-end display fix. Namespace data already existed on the experiment phase; it just wasn't being surfaced in this specific modal.

- Closes **#6594**

### Dependencies

None

### Testing

Manually tested both branches of the conditional against a local dev instance (`pnpm dev`):
- ✅ Experiment **with** a namespace configured (enabled, 57% coverage) → Start Experiment modal Summary now correctly shows `Namespace: test-adding-namespace (57%)` beneath Traffic
- ✅ Experiment **without** a namespace configured → Summary correctly shows only `Traffic:` with no Namespace row, confirming the "if relevant" conditional works in both directions
- ✅ `pnpm --filter front-end type-check` passes with no errors
- ✅ `npx eslint` on the changed file passes with no errors
- ✅ `npx prettier --check` on the changed file passes

### Screenshots

This is the screenshot of summary of experiment with the namespace configured:
<img width="1553" height="905" alt="Screenshot from 2026-08-09 02-28-15" src="https://github.com/user-attachments/assets/c840eea7-452e-4ceb-b43f-4274b5f53db9" />


Below is the screenshot of summary of experiment without the namespace configured:
<img width="1553" height="905" alt="Screenshot from 2026-08-09 02-37-01" src="https://github.com/user-attachments/assets/1e99a1e3-a9d7-4ee9-9c88-511cd673512a" />
