### PR TITLE
docs: clarify Node backgroundSync vs streaming vs cache refresh

### DIFF
--- a/docs/docs/lib/node.mdx
+++ b/docs/docs/lib/node.mdx
@@ -218,10 +218,20 @@ const gbClient = new GrowthBookClient().initSync({
 
 By default, the GrowthBookClient will only fetch features once during initialization. This works great for short-running processes (e.g. serverless functions).
 
-For long-running Node.js processes, there are 2 main approaches to keeping feature defintiions up-to-date.
+For long-running Node.js processes, there are 2 main approaches to keeping feature definitions up-to-date.
 
 1. Streaming
 2. Polling
+
+:::note Streaming vs cache refresh vs `backgroundSync`
+These are easy to mix up:
+
+- **Streaming** — GrowthBook (Cloud or Proxy) pushes a notification when features change. On Node you must opt in with `init({ streaming: true })` and an `EventSource` polyfill (below).
+- **Cache refresh** — the SDK refetches the features payload (for example by calling `refreshFeatures()`). Cache settings like `staleTTL` only apply when a fetch already runs; they do **not** start fetches on their own.
+- **`backgroundSync`** — only controls whether a streaming connection is **allowed** (default `true`). Setting `cacheSettings: { backgroundSync: true }` alone does **not** enable auto-refresh on Node.
+
+A long-running process that never enables streaming and never calls `refreshFeatures()` (directly or on a timer) will keep the payload from `init` until restart.
+:::
 
 ### Streaming Updates
 
@@ -255,6 +265,8 @@ This will make an initial network request to download the features payload from 
 
 Every call to evaluate feature flags will use the latest available payload.
 
+To disable streaming even when it would otherwise start, set `backgroundSync: false` on the client (or via `configureCache`). That option does not turn streaming on by itself.
+
 ### Polling Updates
 
 If your environment doesn't support streaming updates or you want a simpler option, you can use a polling approach:
@@ -272,6 +284,8 @@ The JavaScript SDK has 2 caching layers:
 
 1. In-memory cache (enabled by default)
 2. Persistent localStorage cache (disabled by default, requires configuration)
+
+Caching controls how a features payload is stored and reused **when the SDK fetches**. It is not a substitute for [streaming or polling](#refreshing-features) in long-running Node processes.
 
 ### Configuring Local Storage
 
@@ -307,6 +321,9 @@ configureCache({
   maxAge: 1000 * 60 * 60 * 24,
   // Set to `true` to completely disable both in-memory and persistent caching
   disableCache: false,
+  // When false, do not open an SSE streaming connection (default true).
+  // This does not enable auto-refresh by itself — see Refreshing Features.
+  backgroundSync: true,
 })
 ```
 

--- a/docs/docs/lib/node.mdx
+++ b/docs/docs/lib/node.mdx
@@ -226,7 +226,7 @@ For long-running Node.js processes, there are 2 main approaches to keeping featu
 :::note Streaming vs cache refresh vs `backgroundSync`
 These are easy to mix up:
 
-- **Streaming** — GrowthBook (Cloud or Proxy) pushes a notification when features change. On Node you must opt in with `init({ streaming: true })` and an `EventSource` polyfill (below).
+- **Streaming** — GrowthBook (Cloud or Proxy) pushes a notification when features change. On Node, set up an `EventSource` polyfill and use `init({ streaming: true })` so this client subscribes to those updates (below).
 - **Cache refresh** — the SDK refetches the features payload (for example by calling `refreshFeatures()`). Cache settings like `staleTTL` only apply when a fetch already runs; they do **not** start fetches on their own.
 - **`backgroundSync`** — only controls whether a streaming connection is **allowed** (default `true`). Setting `cacheSettings: { backgroundSync: true }` alone does **not** enable auto-refresh on Node.
 

--- a/docs/docs/lib/node.mdx
+++ b/docs/docs/lib/node.mdx
@@ -265,7 +265,7 @@ This will make an initial network request to download the features payload from 
 
 Every call to evaluate feature flags will use the latest available payload.
 
-To disable streaming even when it would otherwise start, set `backgroundSync: false` on the client (or via `configureCache`). That option does not turn streaming on by itself.
+To block streaming connections, call `configureCache({ backgroundSync: false })`. `GrowthBookClient` does not take a `backgroundSync` constructor option — that setting only lives on the cache config. `backgroundSync: true` (the default) does not turn streaming on by itself.
 
 ### Polling Updates
 


### PR DESCRIPTION
## Summary
- Clarifies on the Node SDK docs what **streaming**, **cache refresh**, and **`backgroundSync`** each actually mean, so people stop treating `cacheSettings.backgroundSync: true` as auto-refresh.
- Callout under Refreshing Features, plus short notes in Streaming and Caching (and document `backgroundSync` in the cache settings example).
- Fixes a small typo (`defintiions` → `definitions`).

Closes / relates to: https://github.com/growthbook/growthbook/issues/4889

## Investigation

I dug into #4889. In a long-running Node process, feature values stay on whatever loaded at startup until you restart or call refreshFeatures() by hand. People were using init({ cacheSettings: { backgroundSync: true } }) thinking that meant auto-refresh. The original reporter hit this, irsooti confirmed it later, and Slack shows up in the issue too.

### What I tested
I reproduced the reported setup locally with a mock `/api/features/...` server and `GrowthBookClient` using the same init as the issue:

1. Init → feature off  
2. Flip the API payload and wait → still off  
3. `refreshFeatures({ skipCache: true })` → updates  

The observed issue is real with that config.

### What that showed
The assumption in the issue is that `backgroundSync: true` means “keep refreshing in the background.”

From the SDK code (`startStreaming` only runs when `streaming: true`; `backgroundSync` only *allows* SSE; Node has no `EventSource` unless you polyfill) and the existing Node docs, that’s not what it does. Auto-updates need **streaming** (`streaming: true` + `eventsource`) or **polling** (`refreshFeatures` on a timer). Cache / `staleTTL` only matter when a fetch already runs — they don’t wake a sitting process.

### Other bugs around the same topic
Same class of pain shows up under other titles, not only #4889:

- https://github.com/growthbook/growthbook/issues/4031 — flags don’t update unless restart / streaming not working  
- https://github.com/growthbook/growthbook/issues/960 — autoRefresh not working as expected (Node)  
- Related streaming/proxy timing: https://github.com/growthbook/growthbook/issues/1457, https://github.com/growthbook/growthbook/issues/1965  

### How I learned what `backgroundSync` does
- Code path: `startStreaming` / `startAutoRefresh` / `refreshFeatures`  
- Changelog / README: `backgroundSync: false` disables opening a streaming connection; it isn’t “start syncing”  
- Node docs already say default is fetch-once, then streaming or polling — but Caching / the name `backgroundSync` make it easy to grab the wrong knob  

**Streaming** = get told features changed (push), which often leads to a refetch.  
**Cache refresh** = refetch the payload when something asks (`refreshFeatures`, poller, etc.).  
Related end state, different jobs.

### Why docs only
With the config in #4889, staying stale is expected behavior, not a proven broken refresh engine. I didn’t show that correctly configured streaming still fails. The failure mode is confusion about which settings turn auto-update on — so clarifying the Node docs is the smallest fix that matches what I found.

Made with [Cursor](https://cursor.com)