### PR TITLE
feat(agent): add a learnings skill and route experiment skills to it

### DIFF
--- a/packages/back-end/src/agent/general-agent.ts
+++ b/packages/back-end/src/agent/general-agent.ts
@@ -206,6 +206,11 @@ const EXPLORATION_PATH_RE =
 const COLUMN_VALUES_PATH_RE =
   /^\/api\/v[12]\/product-analytics\/column-values\/?$/;
 
+/** Read-only POST that ranks saved Learnings against a natural-language query.
+ * It's a POST only because the query goes in the body; it changes nothing, and
+ * the learnings skill treats it as the preferred way to search. */
+const LEARNINGS_SEARCH_PATH_RE = /^\/api\/v[12]\/learnings\/search\/?$/;
+
 function isExplorationPath(path: string): boolean {
   // Normalize first so we match the canonical `/api/v1/...` form the
   // dispatcher routes to, regardless of the prefix shape the LLM sent
@@ -217,8 +222,8 @@ function isExplorationPath(path: string): boolean {
  * Deterministic mutation gate. Any non-GET call mutates configuration and is
  * parked for explicit user confirmation, except a small allowlist of
  * read-only POSTs (experiment snapshot refreshes, product-analytics
- * explorations, and column-value lookups) that compute or read data without
- * changing configuration.
+ * explorations, column-value lookups, and Learnings search) that compute or
+ * read data without changing configuration.
  *
  * The path is normalized first (via the dispatcher's `normalizePath`) so the
  * allowlist matches regardless of whether the LLM sends `/api/v1/...`,
@@ -234,6 +239,9 @@ function requiresMutationConfirmation(input: DispatchInput): boolean {
     return false;
   }
   if (COLUMN_VALUES_PATH_RE.test(path)) {
+    return false;
+  }
+  if (LEARNINGS_SEARCH_PATH_RE.test(path)) {
     return false;
   }
   return true;

--- a/packages/back-end/src/agent/skills/experiments/SKILL.md
+++ b/packages/back-end/src/agent/skills/experiments/SKILL.md
@@ -14,6 +14,9 @@ sub-skill below → follow that leaf's workflow.
 For **product analytics charts** (metric/fact-table explorations), call
 `loadSkill('product-analytics')` instead — not covered here.
 
+For **what the team has already concluded** across past experiments ("have we
+tested this before", "what do we know about X"), call `loadSkill('learnings')`.
+
 ## Sub-skills
 
 | Skill                   | Use when                                      |

--- a/packages/back-end/src/agent/skills/experiments/experiment-analyze.md
+++ b/packages/back-end/src/agent/skills/experiments/experiment-analyze.md
@@ -198,6 +198,9 @@ Use the `callApi` tool for every REST request. This skill is read-only — it ne
 
 ## Handoffs
 
+- `loadSkill('learnings')` — when the result generalizes beyond this one test
+  (a tactic, audience, or product behaviour that has now shown up more than
+  once), offer to record it as a Learning so it outlives the experiment.
 - `loadSkill('experiment-stop')` — when the user is ready to act on a conclusive result.
 - `loadSkill('flag-targeting')` — after stopping with a winner, the linked flag (if any) needs its `experiment-ref` rule updated or removed.
 - `loadSkill('experiment-brainstorm')` — to ground ideas for the next test in results from past experiments.

--- a/packages/back-end/src/agent/skills/experiments/experiment-design.md
+++ b/packages/back-end/src/agent/skills/experiments/experiment-design.md
@@ -104,6 +104,9 @@ Use the `callApi` tool for every REST request. This skill is read-only — it pr
 
 ## Handoffs
 
+- `loadSkill('learnings')` — search what the team already concluded before
+  designing. If a Learning already settles the question, or contradicts the
+  hypothesis, surface it rather than designing a test that re-litigates it.
 - `loadSkill('experiment-launch')` — consumes the spec and creates the draft experiment in GrowthBook.
 - Manual metric creation — if the primary metric doesn't exist yet, the user needs to create it in the GrowthBook UI at `/metrics` (or `/fact-tables` for fact metrics) before launching. No skill for that yet.
 - `loadSkill('experiment-brainstorm')` — if the user came in without a specific hypothesis, route back here to ground a new idea in past results.

--- a/packages/back-end/src/agent/skills/experiments/experiment-design.md
+++ b/packages/back-end/src/agent/skills/experiments/experiment-design.md
@@ -107,6 +107,9 @@ Use the `callApi` tool for every REST request. This skill is read-only — it pr
 - `loadSkill('learnings')` — search what the team already concluded before
   designing. If a Learning already settles the question, or contradicts the
   hypothesis, surface it rather than designing a test that re-litigates it.
+  Most orgs have no Learnings yet; an empty result means nothing has been
+  recorded, not that there's no relevant history — fall through to
+  `experiment-brainstorm` for the experiment record itself.
 - `loadSkill('experiment-launch')` — consumes the spec and creates the draft experiment in GrowthBook.
 - Manual metric creation — if the primary metric doesn't exist yet, the user needs to create it in the GrowthBook UI at `/metrics` (or `/fact-tables` for fact metrics) before launching. No skill for that yet.
 - `loadSkill('experiment-brainstorm')` — if the user came in without a specific hypothesis, route back here to ground a new idea in past results.

--- a/packages/back-end/src/agent/skills/learnings.md
+++ b/packages/back-end/src/agent/skills/learnings.md
@@ -1,0 +1,106 @@
+---
+name: learnings
+description: Search, read, and record Learnings — the durable conclusions a team has drawn across multiple experiments. Use when the user asks "what have we learned about X", "do we already know whether Y works", "have we tested this before", "record this as a learning", or when a finished experiment produces a conclusion worth keeping. Consult before designing a new experiment so you don't re-test something already settled.
+---
+
+# Learnings
+
+A Learning is a durable conclusion that spans **multiple** experiments — "urgency
+messaging lifts checkout on mobile" — not a summary of a single test. Each one
+cites the experiments that support it and the ones that contradict it, so it
+carries its own evidence.
+
+Call the GrowthBook REST API through the `callApi` tool. All paths below are
+relative to the GrowthBook server.
+
+<when_to_use>
+Reach for this skill in three situations:
+
+1. **Before designing an experiment.** Search first — the team may have already
+   settled the question, or have contrary evidence worth knowing. This is the
+   highest-value use.
+2. **When the user asks what's known** about an area, tactic, or audience.
+3. **After analyzing a finished experiment**, when the result generalizes beyond
+   that one test — offer to record it.
+   </when_to_use>
+
+<workflow>
+**Finding what's already known** — prefer search over list:
+
+1. `POST /api/v1/learnings/search` with `{"query": "checkout friction"}` ranks
+   Learnings by meaning, not keyword. Use this whenever the user's question is
+   conceptual. Optional `limit` (max 50) and `projectId`.
+2. `GET /api/v1/learnings` when you want a filtered slice rather than a ranked
+   one — supports `projectId`, `experimentId`, `tag`, and `status`.
+   `experimentId` returns Learnings that cite that experiment in **either**
+   direction, supporting or contradicting.
+3. `GET /api/v1/learnings/{id}` for one Learning in full.
+
+**Recording a new Learning:**
+
+1. Search first (step 1 above) and read anything close. If one already covers
+   the conclusion, update it rather than creating a near-duplicate — add the new
+   experiment to `supportingExperimentIds` via
+   `PUT /api/v1/learnings/{id}`.
+2. Otherwise `POST /api/v1/learnings`:
+
+   ```json
+   {
+     "title": "Urgency messaging lifts add-to-cart on mobile",
+     "text": "Two tests moved add-to-cart with countdown copy...",
+     "tags": ["urgency", "mobile"],
+     "supportingExperimentIds": ["exp_abc", "exp_def"],
+     "contradictingExperimentIds": [],
+     "projects": ["prj_123"]
+   }
+   ```
+
+   Only `title` is required. `status` takes the id of a status configured under
+   Settings → General → Experiment Settings; omit it or pass `""` for none —
+   an unknown id is rejected.
+   </workflow>
+
+<quality_bar>
+A Learning is only worth recording if it clears this bar. Be strict — a corpus
+full of restated single results is worse than a small one.
+
+- **Two or more experiments.** One result is an experiment outcome, not a
+  Learning. If only one test supports it, say so and suggest waiting.
+- **Cite the evidence.** Always populate `supportingExperimentIds`, and
+  `contradictingExperimentIds` when results disagree. Contrary evidence makes a
+  Learning more trustworthy, not less — never omit it to make one look cleaner.
+- **Significance, not direction.** Only treat a result as evidence when the
+  metric actually moved significantly. An inconclusive test is "no result",
+  which is not the same as evidence of no effect.
+- **Watch metric direction.** For inverse metrics (bounce rate, unsubscribes,
+  latency) a positive lift is a regression. Check which way is good before
+  calling something a win.
+- **Generalize.** State the transferable pattern and what to do about it, not a
+  recap of what happened.
+  </quality_bar>
+
+<conventions>
+- **Confirm before writing.** Creating and updating are mutations — show the
+  user the title and text and get agreement first. Never record a Learning as a
+  side effect of an analysis the user asked for.
+- **Attribution.** Learnings created through the API are marked `source: "api"`,
+  which distinguishes them from AI-discovered and hand-written ones. You do not
+  set this.
+- **Enterprise-gated.** Creating, updating, and searching require a plan that
+  includes Learnings; search additionally needs AI enabled. A 403 means the
+  org isn't entitled — report it plainly rather than retrying.
+- **Not available over the API:** the AI "find Learnings across experiments"
+  and "refresh a Learning" flows are app-only. If the user wants those, point
+  them at the Learnings page rather than attempting an API call.
+</conventions>
+
+<page_context>
+When the user message starts with `[Page context: <path>]`:
+
+- `/learnings` → the Learnings list; treat a bare question as being about the
+  whole corpus.
+- `/learnings/<id>` → that Learning (`GET /api/v1/learnings/<id>`).
+- `/experiment/<id>` → scope to that experiment with
+  `GET /api/v1/learnings?experimentId=<id>` before answering "what have we
+  learned here".
+  </page_context>

--- a/packages/back-end/src/agent/skills/learnings.md
+++ b/packages/back-end/src/agent/skills/learnings.md
@@ -53,7 +53,9 @@ When a search returns nothing:
 
 1. `POST /api/v1/learnings/search` with `{"query": "checkout friction"}` ranks
    Learnings by meaning, not keyword. Use this whenever the user's question is
-   conceptual. Optional `limit` (max 50) and `projectId`.
+   conceptual. Optional `limit` (max 50) and `projectId`. It's a POST only
+   because the query goes in the body — it reads, so it is not gated and runs
+   immediately.
 2. `GET /api/v1/learnings` when you want a filtered slice rather than a ranked
    one — supports `projectId`, `experimentId`, `tag`, and `status`.
    `experimentId` returns Learnings that cite that experiment in **either**

--- a/packages/back-end/src/agent/skills/learnings.md
+++ b/packages/back-end/src/agent/skills/learnings.md
@@ -1,6 +1,6 @@
 ---
 name: learnings
-description: Search, read, and record Learnings — the durable conclusions a team has drawn across multiple experiments. Use when the user asks "what have we learned about X", "do we already know whether Y works", "have we tested this before", "record this as a learning", or when a finished experiment produces a conclusion worth keeping. Consult before designing a new experiment so you don't re-test something already settled.
+description: Search, read, and record Learnings — the durable conclusions a team has drawn across multiple experiments. Use when the user asks "what have we learned about X", "do we already know whether Y works", "have we tested this before", "record this as a learning", or when a finished experiment produces a conclusion worth keeping. Consult before designing a new experiment so you don't re-test something already settled. Most orgs have no Learnings yet — an empty result means none are recorded, not that there's no history, so fall through to experiment-brainstorm. For a single experiment's results, use experiment-analyze.
 ---
 
 # Learnings
@@ -9,6 +9,12 @@ A Learning is a durable conclusion that spans **multiple** experiments — "urge
 messaging lifts checkout on mobile" — not a summary of a single test. Each one
 cites the experiments that support it and the ones that contradict it, so it
 carries its own evidence.
+
+Learnings are a **curated layer on top of** the experiment record, never a
+replacement for it. A Learning is what someone concluded; the experiments are
+the evidence. Most teams have far more experiment history than Learnings, so
+reading Learnings is a shortcut when one exists — not a substitute for looking
+at past experiments.
 
 Call the GrowthBook REST API through the `callApi` tool. All paths below are
 relative to the GrowthBook server.
@@ -23,6 +29,24 @@ Reach for this skill in three situations:
 3. **After analyzing a finished experiment**, when the result generalizes beyond
    that one test — offer to record it.
    </when_to_use>
+
+<empty_corpus>
+**An empty Learnings corpus is the normal starting state**, not a finding.
+Learnings only exist once someone has saved one, so most orgs have none at
+first — including orgs with years of experiment history.
+
+When a search returns nothing:
+
+- Say plainly that no Learnings have been recorded yet. Do **not** report it as
+  "the team has no prior knowledge about this" — that conflates an empty
+  curated layer with an empty experiment history.
+- Fall back to the experiment record: `loadSkill('experiment-brainstorm')`
+  grounds ideas in past stopped experiments, and `loadSkill('experiment-analyze')`
+  reads a specific experiment's results. An empty Learnings search must never
+  stop you from checking those.
+- If the user's question was answered by past experiments, that is a good moment
+  to offer to record the conclusion as the team's first Learning.
+  </empty_corpus>
 
 <workflow>
 **Finding what's already known** — prefer search over list:

--- a/packages/back-end/test/agent/general-agent.test.ts
+++ b/packages/back-end/test/agent/general-agent.test.ts
@@ -154,6 +154,44 @@ describe("requiresMutationConfirmation (deterministic mutation gate)", () => {
     ).toBe(false);
   });
 
+  it("allows Learnings search without confirmation", () => {
+    // POST only because the query goes in the body — it reads, it doesn't write.
+    expect(
+      _requiresMutationConfirmation({
+        method: "POST",
+        path: "/api/v1/learnings/search",
+      }),
+    ).toBe(false);
+    // Prefix-agnostic, like the other allowlist entries.
+    expect(
+      _requiresMutationConfirmation({
+        method: "POST",
+        path: "/learnings/search",
+      }),
+    ).toBe(false);
+  });
+
+  it("still gates Learnings writes", () => {
+    expect(
+      _requiresMutationConfirmation({
+        method: "POST",
+        path: "/api/v1/learnings",
+      }),
+    ).toBe(true);
+    expect(
+      _requiresMutationConfirmation({
+        method: "PUT",
+        path: "/api/v1/learnings/lrn_123",
+      }),
+    ).toBe(true);
+    expect(
+      _requiresMutationConfirmation({
+        method: "DELETE",
+        path: "/api/v1/learnings/lrn_123",
+      }),
+    ).toBe(true);
+  });
+
   it("ignores query strings when matching the allowlist", () => {
     expect(
       _requiresMutationConfirmation({


### PR DESCRIPTION
Agents could analyze an experiment but had no idea the Learnings corpus existed — they couldn't check what the team already concluded, and nothing was ever recorded back into it.

Adds a flat `learnings` skill (matching the product-analytics precedent; the surface is small enough that a domain router with leaves would be scaffolding for its own sake) covering search, list, read, and record.

Cross-references where they actually matter: experiment-design consults prior Learnings before designing so a settled question isn't re-tested, and experiment-analyze offers to record a result that generalizes.

Documents only what /api/v1 actually exposes — CRUD plus semantic search. The AI find and refresh flows are internal routes, so the skill tells the agent to point users at the app rather than attempt a call that would 404.
