### PR TITLE
Fix type-check failure blocking deploy: factTable -> factTableId

### DIFF
--- a/packages/front-end/enterprise/components/ProductAnalytics/util.ts
+++ b/packages/front-end/enterprise/components/ProductAnalytics/util.ts
@@ -587,8 +587,8 @@ export function getColumnTopValues(
   }
   if (dataset.type === "funnel") {
     const initialStep = dataset.steps[0];
-    const ft = initialStep?.factTable
-      ? getFactTableById(initialStep.factTable)
+    const ft = initialStep?.factTableId
+      ? getFactTableById(initialStep.factTableId)
       : null;
     return ft ? getColumnInfo(ft, column).topValues : [];
   }

--- a/packages/shared/test/sql.funnel.test.ts
+++ b/packages/shared/test/sql.funnel.test.ts
@@ -222,9 +222,9 @@ describe("buildFunnelSql", () => {
   it("filters out non-qualifying users before the per-step CTEs, not just in the final SELECT", () => {
     const config = baseFunnelConfig(
       [
-        { name: "Step 1", factTable: "orders" },
-        { name: "Step 2", factTable: "orders" },
-        { name: "Step 3", factTable: "orders" },
+        { name: "Step 1", factTableId: "orders" },
+        { name: "Step 2", factTableId: "orders" },
+        { name: "Step 3", factTableId: "orders" },
       ],
       {
         dimensions: [
@@ -257,8 +257,8 @@ describe("buildFunnelSql", () => {
   it("filters to pinned values via a WHERE clause for a static dimension", () => {
     const config = baseFunnelConfig(
       [
-        { name: "Step 1", factTable: "orders" },
-        { name: "Step 2", factTable: "orders" },
+        { name: "Step 1", factTableId: "orders" },
+        { name: "Step 2", factTableId: "orders" },
       ],
       {
         dimensions: [
@@ -284,8 +284,8 @@ describe("buildFunnelSql", () => {
     // editor's 1-20 cap), so this must not emit a malformed `IN ()`.
     const config = baseFunnelConfig(
       [
-        { name: "Step 1", factTable: "orders" },
-        { name: "Step 2", factTable: "orders" },
+        { name: "Step 1", factTableId: "orders" },
+        { name: "Step 2", factTableId: "orders" },
       ],
       {
         dimensions: [


### PR DESCRIPTION
## Summary
- `main` (commit fca885de8, #6475) is currently failing the production build/deploy because of a type error in `enterprise/components/ProductAnalytics/util.ts`.
- The funnel-step field was renamed from `factTable` to `factTableId` in #6583, but one usage in `getColumnTopValues` was missed, so it still referenced `initialStep.factTable`, which no longer exists on the type.
- This fixes the two leftover references to use `factTableId`, restoring a passing type-check/build.

## Test plan
- [x] `pnpm --filter front-end type-check` passes