### PR TITLE
fix(product-analytics; funnels): skip optional steps when computing sequential/conversion window logic

### DIFF
--- a/packages/shared/src/enterprise/product-analytics/sql.ts
+++ b/packages/shared/src/enterprise/product-analytics/sql.ts
@@ -1286,28 +1286,25 @@ function conversionWindowToSeconds(window: ConversionWindow): number {
 }
 
 /**
- * Build the chained `COALESCE(stepN_resolved_ts, stepN-1_resolved_ts, ...)`
- * expression we use as the "previous resolved timestamp" for step `index`.
- * Walks backward from `index - 1` and prefers required steps (an optional
- * step that the user skipped falls through to its predecessor).
+ * The "previous resolved timestamp" that step `index` measures its window and
+ * concurrency against: the nearest preceding required step.
+ *
+ * Optional steps are skipped rather than chained through. An optional step can
+ * land *after* the step that follows it, and anchoring on it would then push
+ * that already-completed conversion outside the window and drop it.
  */
 function buildPrevResolvedExpr(
   steps: FunnelStep[],
   index: number,
   alias: string = "",
 ): string {
-  // Walk back from the immediate predecessor. Optional steps that the user
-  // skipped will be NULL, so chaining COALESCE through them lets the next
-  // step's window/concurrency be measured against the most recent step the
-  // user actually completed.
   const prefix = alias ? `${alias}.` : "";
-  const parts: string[] = [];
   for (let i = index - 1; i >= 0; i--) {
-    parts.push(`${prefix}step${i + 1}_resolved_ts`);
-    if (!steps[i].optional) break;
+    if (!steps[i].optional) return `${prefix}step${i + 1}_resolved_ts`;
   }
-  if (parts.length === 1) return parts[0];
-  return `COALESCE(${parts.join(", ")})`;
+  // Every preceding step is optional, so anchor on step 1, which
+  // __funnel_qualifying_users already guarantees is non-null.
+  return `${prefix}step1_resolved_ts`;
 }
 
 interface FunnelFactTableGroup {

--- a/packages/shared/test/sql.funnel.test.ts
+++ b/packages/shared/test/sql.funnel.test.ts
@@ -375,10 +375,11 @@ describe("buildFunnelSql", () => {
 
     const { sql } = buildFunnelSql(config, factTableMap, helpers);
     // Optional step 2 can land after step 3, so step 3 measures from required
-    // step 1 rather than chaining through whichever step resolved last.
-    expect(sql).toMatch(/FROM unnest\(r\.step3_arr\) AS t/);
-    expect(sql).toMatch(/r\.step1_resolved_ts/);
-    expect(sql).not.toMatch(/COALESCE\(r\.step2_resolved_ts/);
+    // step 1 rather than chaining through whichever step resolved last. The
+    // anchor has to be asserted inside step 3's own range predicate.
+    expect(sql).toMatch(
+      /FROM unnest\(r\.step3_arr\) AS t WHERE t >= r\.step1_resolved_ts/,
+    );
   });
 
   it("anchors on step 1 when every preceding step is optional", () => {

--- a/packages/shared/test/sql.funnel.test.ts
+++ b/packages/shared/test/sql.funnel.test.ts
@@ -364,7 +364,7 @@ describe("buildFunnelSql", () => {
     expect(sql).toMatch(/step\d+_resolved_ts - INTERVAL '5 seconds'/);
   });
 
-  it("chains COALESCE through optional skipped steps", () => {
+  it("anchors past an optional step on the nearest required step", () => {
     const config = baseFunnelConfig([
       { name: "Step 1", factTableId: "orders" },
       { name: "Step 2", factTableId: "orders" },
@@ -374,11 +374,27 @@ describe("buildFunnelSql", () => {
     config.dataset.steps[1].optional = true;
 
     const { sql } = buildFunnelSql(config, factTableMap, helpers);
-    // Step 3's previous-resolved expression should fall through step 2
-    // (optional) to step 1 via COALESCE.
-    expect(sql).toMatch(
-      /COALESCE\(r\.step2_resolved_ts, r\.step1_resolved_ts\)/,
-    );
+    // Optional step 2 can land after step 3, so step 3 measures from required
+    // step 1 rather than chaining through whichever step resolved last.
+    expect(sql).toMatch(/FROM unnest\(r\.step3_arr\) AS t/);
+    expect(sql).toMatch(/r\.step1_resolved_ts/);
+    expect(sql).not.toMatch(/COALESCE\(r\.step2_resolved_ts/);
+  });
+
+  it("anchors on step 1 when every preceding step is optional", () => {
+    const config = baseFunnelConfig([
+      { name: "Step 1", factTableId: "orders" },
+      { name: "Step 2", factTableId: "orders" },
+    ]);
+    if (config.dataset.type !== "funnel") throw new Error("never");
+    // Step 1 is guaranteed non-null by __funnel_qualifying_users, so it stays
+    // the anchor and no NULL bound reaches the window comparison.
+    config.dataset.steps[0].optional = true;
+    config.dataset.steps[1].conversionWindow = { unit: "minutes", value: 30 };
+
+    const { sql } = buildFunnelSql(config, factTableMap, helpers);
+    expect(sql).toContain("r.step1_resolved_ts + INTERVAL '1800 seconds'");
+    expect(sql).not.toMatch(/NULL \+ INTERVAL/);
   });
 
   it("rejects funnels without a unit", () => {


### PR DESCRIPTION
Previously, if you had the following sequence of events for a user, 1 -> 3 -> 2, but step 2 was optional, our coalesce would see the step 3 event and check the step 2 timestamp if and only if it existed. Because step 2 did exist and is in the future for step 3, this would mean step 3 would say "I didn't happen in order" and the user in this case would show as not converted on step 3.

This PR changes this behavior to enshrine the belief that "optional" steps should have no impact on any other step. Later steps instead look backwards recursively for the last non-optional step and use that to check for sequential behavior or conversion windows.

Tested manually.