### PR TITLE
Prefer us-east-1 alias

### DIFF
--- a/docs/docs/experimentation-analysis/event-forwarder.mdx
+++ b/docs/docs/experimentation-analysis/event-forwarder.mdx
@@ -217,7 +217,7 @@ You can also send events directly to our ingestion API. Pass an array of event o
 - **event_name**: The name of the event (e.g., "Purchase", "Button Click")
 - **properties**: Optional key-value pairs with properties of the event itself
 - **attributes**: Optional key-value pairs with attributes of the user or context at the time of the event
-- YOUR_WAREHOUSE_REGION: either us1 or eu-west-1 depending on what you selected when creating your datasource
+- YOUR_WAREHOUSE_REGION: either us-east-1 or eu-west-1 depending on what you selected when creating your datasource
 - YOUR_CLIENT_KEY: The key from your sdk connection. Go to https://app.growthbook.io/sdks/ click on your connection or make a new one. Copy the text from the "Client Key"
 
 ```bash

--- a/docs/docs/experimentation-analysis/event-forwarder.mdx
+++ b/docs/docs/experimentation-analysis/event-forwarder.mdx
@@ -197,7 +197,7 @@ req.growthbook.logEvent("Sign Up", {
 
 #### Sending events to the right region
 
-The tracking plugin sends events to `https://us1.gb-ingest.com` by default. If you selected **eu-west-1** as your Event Forwarder's Data Region, override the ingestor host so events reach the right Kafka/Confluent resources instead of being dropped:
+The tracking plugin sends events to `https://us-east-1.gb-ingest.com` by default. If you selected **eu-west-1** as your Event Forwarder's Data Region, override the ingestor host so events reach the right Kafka/Confluent resources instead of being dropped:
 
 - **HTML Script Tag**: add `data-event-ingestor-host="https://eu-west-1.gb-ingest.com"` to the script tag.
 - **JavaScript / React / Node.js**: pass `ingestorHost` to `growthbookTrackingPlugin()`:

--- a/docs/docs/experimentation-analysis/managed-warehouse.mdx
+++ b/docs/docs/experimentation-analysis/managed-warehouse.mdx
@@ -280,7 +280,7 @@ req.growthbook.logEvent("Sign Up", {
 
 #### Sending events to the right region
 
-The tracking plugin sends events to `https://us1.gb-ingest.com` by default. If you selected **eu-west-1** as your Data Region when creating your Managed Warehouse, override the ingestor host so events reach the right ClickHouse cluster instead of being dropped:
+The tracking plugin sends events to `https://us-east-1.gb-ingest.com` by default. If you selected **eu-west-1** as your Data Region when creating your Managed Warehouse, override the ingestor host so events reach the right ClickHouse cluster instead of being dropped:
 
 - **HTML Script Tag**: add `data-event-ingestor-host="https://eu-west-1.gb-ingest.com"` to the script tag.
 - **JavaScript / React / Node.js**: pass `ingestorHost` to `growthbookTrackingPlugin()`:
@@ -297,7 +297,7 @@ You can find your datasource's configured region on its settings page.
 
 You can also send events directly to our ingestion API. The host depends on the **Data Region** you chose when creating your Managed Warehouse datasource:
 
-- `us-east-1` → `https://us1.gb-ingest.com`
+- `us-east-1` → `https://us-east-1.gb-ingest.com`
 - `eu-west-1` → `https://eu-west-1.gb-ingest.com`
 
 Sending events to the wrong region's host means they won't reach the ClickHouse cluster your data warehouse actually lives in — always match the host to the region shown on your datasource's settings page.
@@ -340,7 +340,7 @@ Prefer the explicit `user_id` and `device_id` keys, and use each key for one kin
 By default, events are timestamped with the time they are received by the ingestion API. If you batch events before sending, you can preserve each event's original timing by adding a per-event `timestamp` along with a top-level `sentAt` field:
 
 ```bash
-curl -X POST "https://us1.gb-ingest.com/track?client_key=YOUR_CLIENT_KEY" \
+curl -X POST "https://YOUR_WAREHOUSE_REGION.gb-ingest.com/track?client_key=YOUR_CLIENT_KEY" \
 -H "Content-Type: application/json" \
 -d '{
   "sentAt": "2025-06-01T12:00:05.000Z",

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -62,7 +62,7 @@ export function isGrowthBookTelemetryDebug(): boolean {
 }
 
 export function getIngestorHost(): string {
-  return INGESTOR_HOST || "https://us1.gb-ingest.com";
+  return INGESTOR_HOST || "https://us-east-1.gb-ingest.com";
 }
 
 // Default to true

--- a/packages/front-end/services/env.ts
+++ b/packages/front-end/services/env.ts
@@ -117,7 +117,7 @@ export function getSuperadminDefaultRole() {
   return env.superadminDefaultRole;
 }
 export function getIngestorHost() {
-  return env.ingestorOverride || "https://us1.gb-ingest.com";
+  return env.ingestorOverride || "https://us-east-1.gb-ingest.com";
 }
 
 export function getStripePublishableKey() {

--- a/packages/sdk-js/src/plugins/growthbook-tracking.ts
+++ b/packages/sdk-js/src/plugins/growthbook-tracking.ts
@@ -142,7 +142,7 @@ async function track({
   if (!events.length) return;
 
   const endpoint = `${
-    ingestorHost || "https://us1.gb-ingest.com"
+    ingestorHost || "https://us-east-1.gb-ingest.com"
   }/track?client_key=${clientKey}`;
   const body = JSON.stringify(events);
 

--- a/packages/sdk-js/test/plugins/growthbook-tracking.test.ts
+++ b/packages/sdk-js/test/plugins/growthbook-tracking.test.ts
@@ -50,7 +50,7 @@ describe("growthbookTrackingPlugin", () => {
     await sleep(75);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://us1.gb-ingest.com/track?client_key=test`,
+      `https://us-east-1.gb-ingest.com/track?client_key=test`,
       {
         method: "POST",
         headers: {
@@ -303,7 +303,7 @@ describe("growthbookTrackingPlugin", () => {
     await sleep(150);
 
     expect(fetchMock.mock.calls[2][0]).toBe(
-      "https://us1.gb-ingest.com/track?client_key=test2",
+      "https://us-east-1.gb-ingest.com/track?client_key=test2",
     );
     const body3 = JSON.parse(fetchMock.mock.calls[2][1].body);
     expect(body3.length).toBe(1);
@@ -424,7 +424,7 @@ describe("growthbookTrackingPlugin", () => {
 
       expect(sendBeaconMock).toHaveBeenCalledTimes(1);
       const [url, blob] = sendBeaconMock.mock.calls[0];
-      expect(url).toBe("https://us1.gb-ingest.com/track?client_key=test");
+      expect(url).toBe("https://us-east-1.gb-ingest.com/track?client_key=test");
       // jsdom's Blob has no .text() - read via FileReader
       const text = await new Promise<string>((resolve, reject) => {
         const reader = new FileReader();


### PR DESCRIPTION
### Features and Changes
Swaps `us1.gb-ingest.com` with  `us-east-1.gb-ingest.com` as the default ingestor url. Now that we have eu-west-1.gb-ingest.com, it standardizes the url format.  It also makes it clear the exact region.  If we add other ingestors it will make it clearer where the ingestor is located.

### Dependencies
https://github.com/growthbook/terraform/pull/218 needs to land first!
