### PR TITLE
Show managed warehouse region on datasource page

### DIFF
--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -13,6 +13,10 @@ import { useFeatureIsOn, useFeatureValue } from "@growthbook/growthbook-react";
 import ManagedWarehouseNoEventsCallout from "@/components/ManagedWarehouse/ManagedWarehouseNoEventsCallout";
 import Link from "@/ui/Link";
 import { useAuth } from "@/services/auth";
+import {
+  getDataRegionLabel,
+  DEFAULT_DATA_REGION,
+} from "@/services/dataRegions";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { hasFileConfig } from "@/services/env";
 import { DocLink, DocSection } from "@/components/DocLink";
@@ -364,6 +368,12 @@ const DataSourcePage: FC = () => {
           <Text weight="medium">Type:</Text>{" "}
           {d.type === "growthbook_clickhouse" ? "managed" : d.type}
         </Text>
+        {d.type === "growthbook_clickhouse" && (
+          <Text color="text-mid">
+            <Text weight="medium">Region:</Text>{" "}
+            {getDataRegionLabel(d.settings.region ?? DEFAULT_DATA_REGION)}
+          </Text>
+        )}
         <Box>
           <Text color="text-mid" weight="medium">
             Fact Tables:


### PR DESCRIPTION
### Features and Changes

Shows the AWS region a GrowthBook-managed warehouse is provisioned in, next to the existing `Type:` field on the datasource detail page. Uses `getDataRegionLabel` from `@/services/dataRegions`, the same helper already used in the admin provisioning UI, so the label stays consistent.

### Testing

- [x] Open a `growthbook_clickhouse` datasource's detail page -> "Region:" shows next to "Type:" (defaults to `AWS us-east-1` when `settings.region` is unset)
- [x] Open any other datasource type -> no Region field shown

### Screenshot
<img width="1064" height="283" alt="Screenshot 2026-08-11 at 2 52 14 PM" src="https://github.com/user-attachments/assets/daaab1b8-b58e-4a39-bce5-4e8cd1950377" />
