### PR TITLE
fix: Hide Start Time field in Analysis Settings for draft experiments

### DIFF
--- a/packages/front-end/components/Experiment/AnalysisForm.tsx
+++ b/packages/front-end/components/Experiment/AnalysisForm.tsx
@@ -761,36 +761,40 @@ const AnalysisForm: FC<{
             </small>
           </div>
         )}
-        {!!phaseObj && editDates && !isBandit && !isHoldout && (
-          <div className="row">
-            <div className="col">
-              <DatePicker
-                label="Start Time (UTC)"
-                helpText="Only include users who entered the experiment on or after this date"
-                date={form.watch("dateStarted")}
-                setDate={(v) => {
-                  form.setValue("dateStarted", v ? datetime(v) : "");
-                }}
-                scheduleEndDate={form.watch("dateEnded")}
-                disableAfter={form.watch("dateEnded") || undefined}
-              />
-            </div>
-            {experiment.status === "stopped" && (
+        {!!phaseObj &&
+          editDates &&
+          !isBandit &&
+          !isHoldout &&
+          experiment.status !== "draft" && (
+            <div className="row">
               <div className="col">
                 <DatePicker
-                  label="End Time (UTC)"
-                  helpText="Only include users who entered the experiment on or before this date"
-                  date={form.watch("dateEnded")}
+                  label="Start Time (UTC)"
+                  helpText="Only include users who entered the experiment on or after this date"
+                  date={form.watch("dateStarted")}
                   setDate={(v) => {
-                    form.setValue("dateEnded", v ? datetime(v) : "");
+                    form.setValue("dateStarted", v ? datetime(v) : "");
                   }}
-                  scheduleStartDate={form.watch("dateStarted")}
-                  disableBefore={form.watch("dateStarted") || undefined}
+                  scheduleEndDate={form.watch("dateEnded")}
+                  disableAfter={form.watch("dateEnded") || undefined}
                 />
               </div>
-            )}
-          </div>
-        )}
+              {experiment.status === "stopped" && (
+                <div className="col">
+                  <DatePicker
+                    label="End Time (UTC)"
+                    helpText="Only include users who entered the experiment on or before this date"
+                    date={form.watch("dateEnded")}
+                    setDate={(v) => {
+                      form.setValue("dateEnded", v ? datetime(v) : "");
+                    }}
+                    scheduleStartDate={form.watch("dateStarted")}
+                    disableBefore={form.watch("dateStarted") || undefined}
+                  />
+                </div>
+              )}
+            </div>
+          )}
         <Flex gap="3" align="start" wrap="wrap">
           <Box style={{ flex: "1 1 200px", minWidth: 200 }}>
             <StatsEngineSelect


### PR DESCRIPTION
### Features and Changes

Hides the Start Time field in the Analysis Settings modal when an experiment is in draft status. This field was incorrectly displayed for draft experiments even though it has no effect until the experiment starts running, it also I think wasn't saving on back-end validation.

### Testing

Manually confirmed.

**Before in draft exp**
<img width="1157" height="394" alt="Screenshot 2026-08-11 at 11 27 26 AM" src="https://github.com/user-attachments/assets/357e3033-80db-4e20-8609-a3a3a22e7331" />

**After in same draft exp**
<img width="1110" height="404" alt="Screenshot 2026-08-11 at 11 27 52 AM" src="https://github.com/user-attachments/assets/aa5afa9a-ccf6-457b-aef8-9fef3fef5210" />
