### PR TITLE
feat(funnel-metrics): show steps breakdown for dimensions

### DIFF
--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -38,6 +38,7 @@ import ResultsTable, {
 } from "@/components/Experiment/ResultsTable";
 import { QueryStatusData } from "@/components/Queries/RunQueriesButton";
 import { getRenderLabelColumn } from "@/components/Experiment/CompactResults";
+import FunnelStepLabel from "@/components/Experiment/FunnelStepLabel";
 import RadixTooltip from "@/ui/Tooltip";
 import { SSRPolyfills } from "@/hooks/useSSRPolyfills";
 import { useExperimentDimensionRows } from "@/hooks/useExperimentDimensionRows";
@@ -321,32 +322,7 @@ const BreakDownResults: FC<{
               setDifferenceType={setDifferenceType}
               renderLabelColumn={({ label, row }) => {
                 if (row?.childRowType === "funnelStep") {
-                  return (
-                    <div className="pl-4" style={{ position: "relative" }}>
-                      <div
-                        className="ml-2 font-weight-bold"
-                        style={{
-                          display: "-webkit-box",
-                          WebkitLineClamp: 1,
-                          WebkitBoxOrient: "vertical",
-                          overflow: "hidden",
-                          color: "var(--color-text-high)",
-                        }}
-                      >
-                        {row.label ?? label}
-                      </div>
-                      <div
-                        className="ml-2"
-                        style={{
-                          fontSize: "0.75rem",
-                          color: "var(--color-text-low)",
-                        }}
-                      >
-                        Step {(row.funnelStepIndex ?? 0) + 1}
-                        {row.funnelStepOptional ? " (optional)" : ""}
-                      </div>
-                    </div>
-                  );
+                  return <FunnelStepLabel label={label} row={row} />;
                 }
 
                 const hasSteps = !!row?.numChildren;
@@ -378,6 +354,11 @@ const BreakDownResults: FC<{
                             size="1"
                             variant="ghost"
                             radius="full"
+                            aria-label={
+                              isExpanded
+                                ? "Collapse funnel steps"
+                                : "Expand funnel steps"
+                            }
                             onClick={() => toggleExpandedRow(parentRowId)}
                           >
                             {isExpanded ? (

--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -332,7 +332,6 @@ const BreakDownResults: FC<{
                   <div
                     className="pl-3 font-weight-bold"
                     style={{
-                      position: "relative",
                       display: "-webkit-box",
                       WebkitLineClamp: 1,
                       WebkitBoxOrient: "vertical",
@@ -341,7 +340,16 @@ const BreakDownResults: FC<{
                     }}
                   >
                     {hasSteps ? (
-                      <span style={{ position: "absolute", left: 7, top: 1 }}>
+                      <span
+                        style={{
+                          position: "absolute",
+                          left: 7,
+                          top: 0,
+                          bottom: 0,
+                          display: "flex",
+                          alignItems: "center",
+                        }}
+                      >
                         <RadixTooltip
                           content={
                             isExpanded

--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -1,4 +1,6 @@
-import { FC, Fragment } from "react";
+import { FC, Fragment, useState } from "react";
+import { IconButton } from "@radix-ui/themes";
+import { PiCaretCircleRight, PiCaretCircleDown } from "react-icons/pi";
 import {
   ExperimentReportResultDimension,
   ExperimentReportVariation,
@@ -36,6 +38,7 @@ import ResultsTable, {
 } from "@/components/Experiment/ResultsTable";
 import { QueryStatusData } from "@/components/Queries/RunQueriesButton";
 import { getRenderLabelColumn } from "@/components/Experiment/CompactResults";
+import RadixTooltip from "@/ui/Tooltip";
 import { SSRPolyfills } from "@/hooks/useSSRPolyfills";
 import { useExperimentDimensionRows } from "@/hooks/useExperimentDimensionRows";
 import useOrgSettings from "@/hooks/useOrgSettings";
@@ -166,6 +169,14 @@ const BreakDownResults: FC<{
   // Detect drilldown context for automatic row click handling
   const drilldownContext = useMetricDrilldownContext();
 
+  // Funnel step child rows nest under their dimension-value parent and stay
+  // collapsed until the parent's chevron is toggled. The key matches the
+  // `parentRowId` (`metricId:dimensionValue`) each child row carries.
+  const [expandedRows, setExpandedRows] = useState<Record<string, boolean>>({});
+  const toggleExpandedRow = (parentRowId: string) => {
+    setExpandedRows((prev) => ({ ...prev, [parentRowId]: !prev[parentRowId] }));
+  };
+
   const dimension =
     ssrPolyfills?.getDimensionById?.(dimensionId)?.name ||
     getDimensionById(dimensionId)?.name ||
@@ -247,6 +258,13 @@ const BreakDownResults: FC<{
       </div>
 
       {tables.map((table, i) => {
+        // Hide funnel step child rows whose dimension-value parent is collapsed.
+        const visibleRows = table.rows.filter(
+          (row) =>
+            !row.isChildRow ||
+            !row.parentRowId ||
+            !!expandedRows[row.parentRowId],
+        );
         return (
           <Fragment key={table.metric.id + "_" + i}>
             <h4
@@ -277,7 +295,7 @@ const BreakDownResults: FC<{
               setVariationFilter={setVariationFilter}
               baselineRow={baselineRow}
               columnsFilter={columnsFilter}
-              rows={table.rows}
+              rows={visibleRows}
               onRowClick={handleRowClick}
               dimension={dimension}
               id={(idPrefix ? `${idPrefix}_` : "") + table.metric.id}
@@ -301,28 +319,90 @@ const BreakDownResults: FC<{
               pValueCorrection={pValueCorrection}
               differenceType={differenceType}
               setDifferenceType={setDifferenceType}
-              renderLabelColumn={({ label }) => (
-                <div
-                  className="pl-3 font-weight-bold"
-                  style={{
-                    display: "-webkit-box",
-                    WebkitLineClamp: 1,
-                    WebkitBoxOrient: "vertical",
-                    overflow: "hidden",
-                    color: "var(--color-text-mid)",
-                  }}
-                >
-                  {label ? (
-                    label === NULL_DIMENSION_VALUE ? (
-                      <em>{formatDimensionValueForDisplay(label)}</em>
-                    ) : (
-                      label
-                    )
-                  ) : (
-                    <em>unknown</em>
-                  )}
-                </div>
-              )}
+              renderLabelColumn={({ label, row }) => {
+                if (row?.childRowType === "funnelStep") {
+                  return (
+                    <div className="pl-4" style={{ position: "relative" }}>
+                      <div
+                        className="ml-2 font-weight-bold"
+                        style={{
+                          display: "-webkit-box",
+                          WebkitLineClamp: 1,
+                          WebkitBoxOrient: "vertical",
+                          overflow: "hidden",
+                          color: "var(--color-text-high)",
+                        }}
+                      >
+                        {row.label ?? label}
+                      </div>
+                      <div
+                        className="ml-2"
+                        style={{
+                          fontSize: "0.75rem",
+                          color: "var(--color-text-low)",
+                        }}
+                      >
+                        Step {(row.funnelStepIndex ?? 0) + 1}
+                        {row.funnelStepOptional ? " (optional)" : ""}
+                      </div>
+                    </div>
+                  );
+                }
+
+                const hasSteps = !!row?.numChildren;
+                const parentRowId = `${row?.metric?.id}:${row?.label ?? ""}`;
+                const isExpanded = !!expandedRows[parentRowId];
+                return (
+                  <div
+                    className="pl-3 font-weight-bold"
+                    style={{
+                      position: "relative",
+                      display: "-webkit-box",
+                      WebkitLineClamp: 1,
+                      WebkitBoxOrient: "vertical",
+                      overflow: "hidden",
+                      color: "var(--color-text-mid)",
+                    }}
+                  >
+                    {hasSteps ? (
+                      <span style={{ position: "absolute", left: 7, top: 1 }}>
+                        <RadixTooltip
+                          content={
+                            isExpanded
+                              ? "Collapse funnel steps"
+                              : "Expand funnel steps"
+                          }
+                          side="top"
+                        >
+                          <IconButton
+                            size="1"
+                            variant="ghost"
+                            radius="full"
+                            onClick={() => toggleExpandedRow(parentRowId)}
+                          >
+                            {isExpanded ? (
+                              <PiCaretCircleDown size={16} />
+                            ) : (
+                              <PiCaretCircleRight size={16} />
+                            )}
+                          </IconButton>
+                        </RadixTooltip>
+                      </span>
+                    ) : null}
+                    <span className={hasSteps ? "ml-2" : undefined}>
+                      {label ? (
+                        label === NULL_DIMENSION_VALUE ? (
+                          <em>{formatDimensionValueForDisplay(label)}</em>
+                        ) : (
+                          label
+                        )
+                      ) : (
+                        <em>unknown</em>
+                      )}
+                    </span>
+                  </div>
+                );
+              }}
               isTabActive={true}
               isBandit={isBandit}
               ssrPolyfills={ssrPolyfills}

--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -704,7 +704,16 @@ export function getRenderLabelColumn({
             }
           >
             {shouldShowExpandButton ? (
-              <div style={{ position: "absolute", left: 7, marginTop: 3 }}>
+              <div
+                style={{
+                  position: "absolute",
+                  left: 7,
+                  top: 0,
+                  bottom: 0,
+                  display: "flex",
+                  alignItems: "center",
+                }}
+              >
                 <RadixTooltip
                   content={
                     isFactFunnelMetric(metric)

--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -40,6 +40,7 @@ import Link from "@/ui/Link";
 import { useExperimentTableRows } from "@/hooks/useExperimentTableRows";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { ExperimentTableRow } from "@/services/experiments";
+import FunnelStepLabel from "@/components/Experiment/FunnelStepLabel";
 import { QueryStatusData } from "@/components/Queries/RunQueriesButton";
 import RadixTooltip from "@/ui/Tooltip";
 import { SSRPolyfills } from "@/hooks/useSSRPolyfills";
@@ -583,29 +584,7 @@ export function getRenderLabelColumn({
 
     // Funnel step row
     if (isFunnelStepRow) {
-      return (
-        <div className="pl-4" style={{ position: "relative" }}>
-          <div
-            className="ml-2 font-weight-bold"
-            style={{
-              display: "-webkit-box",
-              WebkitLineClamp: 1,
-              WebkitBoxOrient: "vertical",
-              overflow: "hidden",
-              color: "var(--color-text-high)",
-            }}
-          >
-            {row?.label ?? label}
-          </div>
-          <div
-            className="ml-2"
-            style={{ fontSize: "0.75rem", color: "var(--color-text-low)" }}
-          >
-            Step {(row?.funnelStepIndex ?? 0) + 1}
-            {row?.funnelStepOptional ? " (optional)" : ""}
-          </div>
-        </div>
-      );
+      return <FunnelStepLabel label={label} row={row} />;
     }
 
     // Slice row
@@ -742,6 +721,15 @@ export function getRenderLabelColumn({
                     size="1"
                     variant="ghost"
                     radius="full"
+                    aria-label={
+                      isFactFunnelMetric(metric)
+                        ? isExpanded
+                          ? "Collapse funnel steps"
+                          : "Expand funnel steps"
+                        : isExpanded
+                          ? "Collapse metric slices"
+                          : "Expand metric slices"
+                    }
                     onClick={
                       row?.labelOnly || sliceTagsFilter?.includes("overall")
                         ? undefined

--- a/packages/front-end/components/Experiment/FunnelStepLabel.tsx
+++ b/packages/front-end/components/Experiment/FunnelStepLabel.tsx
@@ -1,0 +1,34 @@
+import { ReactElement } from "react";
+import { ExperimentTableRow } from "@/services/experiments";
+
+export default function FunnelStepLabel({
+  label,
+  row,
+}: {
+  label: string | ReactElement;
+  row: ExperimentTableRow;
+}) {
+  return (
+    <div className="pl-4" style={{ position: "relative" }}>
+      <div
+        className="ml-2 font-weight-bold"
+        style={{
+          display: "-webkit-box",
+          WebkitLineClamp: 1,
+          WebkitBoxOrient: "vertical",
+          overflow: "hidden",
+          color: "var(--color-text-high)",
+        }}
+      >
+        {row?.label ?? label}
+      </div>
+      <div
+        className="ml-2"
+        style={{ fontSize: "0.75rem", color: "var(--color-text-low)" }}
+      >
+        Step {(row?.funnelStepIndex ?? 0) + 1}
+        {row?.funnelStepOptional ? " (optional)" : ""}
+      </div>
+    </div>
+  );
+}

--- a/packages/front-end/hooks/useExperimentDimensionRows.ts
+++ b/packages/front-end/hooks/useExperimentDimensionRows.ts
@@ -13,6 +13,8 @@ import {
   setAdjustedCIs,
   setAdjustedPValuesOnResults,
   isMetricGroupId,
+  isFactFunnelMetric,
+  funnelStepMetricId,
 } from "shared/experiments";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import {
@@ -390,10 +392,19 @@ export function useExperimentDimensionRows({
         sortDirection: sortDirection || "desc",
       };
 
-      return tables.map((table) => ({
-        ...table,
-        rows: [...table.rows].sort((a, b) => compareRows(a, b, sortOptions)),
-      }));
+      // A funnel table's rows are dimension-value groups with per-step child
+      // rows beneath each; a flat sort would tear that grouping apart, so leave
+      // funnel tables in their emitted order.
+      return tables.map((table) =>
+        isFactFunnelMetric(table.metric)
+          ? table
+          : {
+              ...table,
+              rows: [...table.rows].sort((a, b) =>
+                compareRows(a, b, sortOptions),
+              ),
+            },
+      );
     }
 
     return tables;
@@ -470,30 +481,60 @@ export function generateDimensionRowsForMetric({
 }): ExperimentTableRow[] {
   const filteredResults = includeVariation(results, dimensionValuesFilter);
 
+  const funnelSteps = isFactFunnelMetric(newMetric)
+    ? newMetric.funnelSettings.steps
+    : [];
+
+  const noData = () => ({ users: 0, value: 0, cr: 0, errorMessage: "No data" });
+
   const rows: ExperimentTableRow[] = [];
 
-  // Create a row for each dimension result
+  // One row per dimension result. For a funnel metric the dimension value is
+  // the parent (whole-funnel completion) and each step follows as a child row,
+  // mirroring the overall table's nesting one level deeper.
   filteredResults.forEach((dimensionResult) => {
-    const row: ExperimentTableRow = {
+    const parentRow: ExperimentTableRow = {
       label: dimensionResult.name,
       metric: newMetric,
       metricOverrideFields: overrideFields,
       rowClass: newMetric?.inverse ? "inverse" : "",
-      variations: dimensionResult.variations.map((v) => {
-        return (
-          v.metrics?.[metricId] || {
-            users: 0,
-            value: 0,
-            cr: 0,
-            errorMessage: "No data",
-          }
-        );
-      }),
+      variations: dimensionResult.variations.map(
+        (v) => v.metrics?.[metricId] || noData(),
+      ),
       metricSnapshotSettings,
       resultGroup,
     };
 
-    rows.push(row);
+    if (!funnelSteps.length) {
+      rows.push(parentRow);
+      return;
+    }
+
+    const parentRowId = `${metricId}:${dimensionResult.name}`;
+    parentRow.numChildren = funnelSteps.length;
+    rows.push(parentRow);
+
+    funnelSteps.forEach((step, stepIndex) => {
+      const stepMetricId = funnelStepMetricId(metricId, stepIndex);
+      rows.push({
+        label: step.name,
+        metric: newMetric,
+        metricOverrideFields: overrideFields,
+        rowClass: newMetric?.inverse ? "inverse" : "",
+        variations: dimensionResult.variations.map(
+          (v) => v.metrics?.[stepMetricId] || noData(),
+        ),
+        metricSnapshotSettings,
+        resultGroup,
+        numChildren: 0,
+        isChildRow: true,
+        childRowType: "funnelStep",
+        funnelStepIndex: stepIndex,
+        funnelStepOptional: step.optional,
+        parentRowId,
+        isHiddenByFilter: false,
+      });
+    });
   });
 
   return rows;

--- a/packages/front-end/hooks/useExperimentDimensionRows.ts
+++ b/packages/front-end/hooks/useExperimentDimensionRows.ts
@@ -392,12 +392,15 @@ export function useExperimentDimensionRows({
         sortDirection: sortDirection || "desc",
       };
 
-      // A funnel table's rows are dimension-value groups with per-step child
-      // rows beneath each; a flat sort would tear that grouping apart, so leave
-      // funnel tables in their emitted order.
+      // A funnel table's rows are dimension-value parents with per-step child
+      // rows beneath each. Sort the parents but keep each parent's steps
+      // attached in step order; a flat sort would tear that grouping apart.
       return tables.map((table) =>
         isFactFunnelMetric(table.metric)
-          ? table
+          ? {
+              ...table,
+              rows: sortFunnelDimensionRows(table.rows, sortOptions),
+            }
           : {
               ...table,
               rows: [...table.rows].sort((a, b) =>
@@ -538,4 +541,37 @@ export function generateDimensionRowsForMetric({
   });
 
   return rows;
+}
+
+export interface FunnelDimensionRowGroup {
+  parent: ExperimentTableRow;
+  children: ExperimentTableRow[];
+}
+
+// A funnel dimension table is a flat list of dimension-value parent rows, each
+// followed by its step child rows. Group them so a parent can move without
+// detaching its steps.
+export function groupFunnelDimensionRows(
+  rows: ExperimentTableRow[],
+): FunnelDimensionRowGroup[] {
+  const groups: FunnelDimensionRowGroup[] = [];
+  for (const row of rows) {
+    if (row.isChildRow && groups.length > 0) {
+      groups[groups.length - 1].children.push(row);
+    } else {
+      groups.push({ parent: row, children: [] });
+    }
+  }
+  return groups;
+}
+
+// Sort the parent dimension rows by significance/change while keeping each
+// parent's step children beneath it in their original step order.
+export function sortFunnelDimensionRows(
+  rows: ExperimentTableRow[],
+  sortOptions: Parameters<typeof compareRows>[2],
+): ExperimentTableRow[] {
+  return groupFunnelDimensionRows(rows)
+    .sort((a, b) => compareRows(a.parent, b.parent, sortOptions))
+    .flatMap((group) => [group.parent, ...group.children]);
 }

--- a/packages/front-end/test/funnel-dimension-rows.test.ts
+++ b/packages/front-end/test/funnel-dimension-rows.test.ts
@@ -2,7 +2,12 @@ import { funnelStepMetricId } from "shared/experiments";
 import { FunnelFactMetricInterface } from "shared/types/fact-table";
 import { ExperimentReportResultDimension } from "shared/types/report";
 import { SnapshotVariation } from "shared/types/experiment-snapshot";
-import { generateDimensionRowsForMetric } from "@/hooks/useExperimentDimensionRows";
+import {
+  generateDimensionRowsForMetric,
+  groupFunnelDimensionRows,
+  sortFunnelDimensionRows,
+} from "@/hooks/useExperimentDimensionRows";
+import { ExperimentTableRow } from "@/services/experiments";
 
 const FUNNEL_METRIC_ID = "fact__funnel";
 const STEP_NAMES = ["Viewed landing page", "Signed up", "Completed onboarding"];
@@ -90,6 +95,86 @@ describe("generateDimensionRowsForMetric funnel", () => {
         });
       });
     });
+  });
+});
+
+function makeParent(
+  label: string,
+  variations: ExperimentTableRow["variations"],
+): ExperimentTableRow {
+  return {
+    label,
+    metric: funnelMetric,
+    variations,
+    resultGroup: "goal",
+    numChildren: NUM_STEPS,
+  } as unknown as ExperimentTableRow;
+}
+
+function makeStep(parentLabel: string, stepIndex: number): ExperimentTableRow {
+  return {
+    label: `${parentLabel} step ${stepIndex}`,
+    metric: funnelMetric,
+    variations: [],
+    resultGroup: "goal",
+    isChildRow: true,
+    childRowType: "funnelStep",
+    funnelStepIndex: stepIndex,
+    numChildren: 0,
+    parentRowId: `${FUNNEL_METRIC_ID}:${parentLabel}`,
+  } as unknown as ExperimentTableRow;
+}
+
+describe("groupFunnelDimensionRows", () => {
+  it("groups each parent with the step rows that follow it, in order", () => {
+    const flat = [
+      makeParent("US", []),
+      makeStep("US", 0),
+      makeStep("US", 1),
+      makeParent("UK", []),
+      makeStep("UK", 0),
+    ];
+
+    const groups = groupFunnelDimensionRows(flat);
+
+    expect(groups.map((g) => g.parent.label)).toEqual(["US", "UK"]);
+    expect(groups[0].children.map((c) => c.funnelStepIndex)).toEqual([0, 1]);
+    expect(groups[1].children.map((c) => c.funnelStepIndex)).toEqual([0]);
+  });
+});
+
+describe("sortFunnelDimensionRows", () => {
+  it("reorders parents by significance while keeping steps attached in order", () => {
+    // A no-data parent sorts after one with data (compareRows early-return),
+    // which is deterministic without depending on the significance math.
+    const withData = [
+      { users: 100, value: 50, cr: 0.5 },
+      { users: 100, value: 50, cr: 0.5, expected: 0.1 },
+    ];
+    const flat = [
+      makeParent("US", []),
+      makeStep("US", 0),
+      makeStep("US", 1),
+      makeParent("UK", withData as ExperimentTableRow["variations"]),
+      makeStep("UK", 0),
+      makeStep("UK", 1),
+    ];
+
+    const sorted = sortFunnelDimensionRows(flat, {
+      sortBy: "change",
+      variationFilter: [],
+      metricDefaults: {},
+      sortDirection: "desc",
+    } as unknown as Parameters<typeof sortFunnelDimensionRows>[1]);
+
+    expect(sorted.map((r) => r.label)).toEqual([
+      "UK",
+      "UK step 0",
+      "UK step 1",
+      "US",
+      "US step 0",
+      "US step 1",
+    ]);
   });
 });
 

--- a/packages/front-end/test/funnel-dimension-rows.test.ts
+++ b/packages/front-end/test/funnel-dimension-rows.test.ts
@@ -1,0 +1,116 @@
+import { funnelStepMetricId } from "shared/experiments";
+import { FunnelFactMetricInterface } from "shared/types/fact-table";
+import { ExperimentReportResultDimension } from "shared/types/report";
+import { SnapshotVariation } from "shared/types/experiment-snapshot";
+import { generateDimensionRowsForMetric } from "@/hooks/useExperimentDimensionRows";
+
+const FUNNEL_METRIC_ID = "fact__funnel";
+const STEP_NAMES = ["Viewed landing page", "Signed up", "Completed onboarding"];
+const DIMENSION_VALUES = ["US", "UK"];
+
+const funnelMetric = {
+  id: FUNNEL_METRIC_ID,
+  name: "Signup Funnel",
+  metricType: "funnel",
+  numerator: null,
+  denominator: null,
+  funnelSettings: {
+    steps: STEP_NAMES.map((name) => ({
+      name,
+      factTableId: "ft",
+      rowFilters: [],
+      optional: false,
+    })),
+  },
+} as unknown as FunnelFactMetricInterface;
+
+const NUM_STEPS = STEP_NAMES.length;
+
+function buildVariation(seed: number): SnapshotVariation {
+  const metrics: SnapshotVariation["metrics"] = {
+    [FUNNEL_METRIC_ID]: { users: 10000 + seed, value: 5000 + seed, cr: 0.5 },
+  };
+  STEP_NAMES.forEach((_, i) => {
+    metrics[funnelStepMetricId(FUNNEL_METRIC_ID, i)] = {
+      users: 1000 * (i + 1) + seed,
+      value: 100 * (i + 1) + seed,
+      cr: (i + 1) / 10,
+    };
+  });
+  return { users: 10000 + seed, metrics };
+}
+
+const results: ExperimentReportResultDimension[] = DIMENSION_VALUES.map(
+  (name, dimIndex) => ({
+    name,
+    srm: 1,
+    variations: [
+      buildVariation(dimIndex * 10),
+      buildVariation(dimIndex * 10 + 1),
+    ],
+  }),
+);
+
+const rows = generateDimensionRowsForMetric({
+  metricId: FUNNEL_METRIC_ID,
+  resultGroup: "goal",
+  results,
+  overrideFields: [],
+  metricSnapshotSettings: undefined,
+  newMetric: funnelMetric,
+});
+
+describe("generateDimensionRowsForMetric funnel", () => {
+  it("emits a parent row plus per-step child rows for each dimension value", () => {
+    expect(rows).toHaveLength(DIMENSION_VALUES.length * (1 + NUM_STEPS));
+
+    DIMENSION_VALUES.forEach((value, dimIndex) => {
+      const start = dimIndex * (1 + NUM_STEPS);
+      const parent = rows[start];
+      const steps = rows.slice(start + 1, start + 1 + NUM_STEPS);
+
+      expect(parent.label).toBe(value);
+      expect(parent.isChildRow).toBeFalsy();
+      expect(parent.numChildren).toBe(NUM_STEPS);
+      results[dimIndex].variations.forEach((v, j) => {
+        expect(parent.variations[j]).toEqual(v.metrics[FUNNEL_METRIC_ID]);
+      });
+
+      expect(steps).toHaveLength(NUM_STEPS);
+      steps.forEach((row, i) => {
+        expect(row.isChildRow).toBe(true);
+        expect(row.childRowType).toBe("funnelStep");
+        expect(row.funnelStepIndex).toBe(i);
+        expect(row.label).toBe(STEP_NAMES[i]);
+        expect(row.parentRowId).toBe(`${FUNNEL_METRIC_ID}:${value}`);
+        results[dimIndex].variations.forEach((v, j) => {
+          expect(row.variations[j]).toEqual(
+            v.metrics[funnelStepMetricId(FUNNEL_METRIC_ID, i)],
+          );
+        });
+      });
+    });
+  });
+});
+
+describe("generateDimensionRowsForMetric non-funnel", () => {
+  it("emits a single flat row per dimension value", () => {
+    const metric = {
+      ...funnelMetric,
+      metricType: "proportion",
+    } as unknown as FunnelFactMetricInterface;
+    const flatRows = generateDimensionRowsForMetric({
+      metricId: FUNNEL_METRIC_ID,
+      resultGroup: "goal",
+      results,
+      overrideFields: [],
+      metricSnapshotSettings: undefined,
+      newMetric: metric,
+    });
+    expect(flatRows).toHaveLength(DIMENSION_VALUES.length);
+    flatRows.forEach((row) => {
+      expect(row.isChildRow).toBeFalsy();
+      expect(row.childRowType).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
### Features and Changes

Fast-follow for the new metric type `funnel`.

Now we are also showing the steps breakdown for funnel metrics inside the dimension breakdown.

### Testing

- Unit tests
- Manual test
  - Go to the experiment results page, select a Dimension in the `Unit Dimension` toggle
  - Observe how you can expand and see results per-step for a funnel metric

### Screenshots

| Before | After |
|--------|--------|
| <img width="1083" height="628" alt="image" src="https://github.com/user-attachments/assets/d486aef4-2e63-4316-88a3-433261d768f2" /> | <img width="1080" height="635" alt="image" src="https://github.com/user-attachments/assets/32a3cbe7-9485-45d6-b42c-ff10a76efa5b" /> <img width="1078" height="771" alt="image" src="https://github.com/user-attachments/assets/0a94e2d2-decd-4bd4-b36a-eab164568d58" /> | 