### PR TITLE
fix(sdk-versioning): reconcile sdk-versions/*.json with real upstream releases

### DIFF
--- a/docs/src/data/SDKInfo.ts
+++ b/docs/src/data/SDKInfo.ts
@@ -218,7 +218,7 @@ export default {
   },
   php: {
     name: "PHP SDK",
-    version: "1.7.0",
+    version: "2.6.1",
     github: "https://github.com/growthbook/growthbook-php",
     examples: [],
     packageRepos: [
@@ -233,6 +233,15 @@ export default {
       },
       {
         experimentation: "All versions",
+      },
+      {
+        remoteEval: "≥ v2.5.0",
+      },
+      {
+        caseInsensitiveRegex: "≥ v2.3.0",
+      },
+      {
+        caseInsensitiveMembership: "≥ v2.3.0",
       },
       {
         savedGroupReferences: "≥ v1.7.0",
@@ -373,7 +382,7 @@ export default {
   },
   python: {
     name: "Python SDK",
-    version: "2.1.1",
+    version: "2.3.1",
     github: "https://github.com/growthbook/growthbook-python",
     examples: [],
     packageRepos: [
@@ -388,6 +397,9 @@ export default {
       },
       {
         experimentation: "All versions",
+      },
+      {
+        remoteEval: "≥ v2.3.0",
       },
       {
         caseInsensitiveMembership: "≥ v2.1.1",
@@ -423,7 +435,7 @@ export default {
   },
   go: {
     name: "Go SDK",
-    version: "0.2.8",
+    version: "0.2.9",
     github: "https://github.com/growthbook/growthbook-golang",
     examples: [
       {
@@ -481,7 +493,7 @@ export default {
   },
   rust: {
     name: "Rust SDK",
-    version: "0.1.1",
+    version: "0.2.0",
     github: "https://github.com/growthbook/growthbook-rust",
     examples: [
       {
@@ -501,6 +513,9 @@ export default {
       },
       {
         experimentation: "All versions",
+      },
+      {
+        savedGroupReferences: "≥ v0.2.0",
       },
       {
         caseInsensitiveRegex: "≥ v0.1.1",
@@ -533,7 +548,7 @@ export default {
   },
   java: {
     name: "Java SDK",
-    version: "0.10.6",
+    version: "0.10.10",
     github: "https://github.com/growthbook/growthbook-sdk-java",
     examples: [
       {
@@ -565,6 +580,9 @@ export default {
       },
       {
         experimentation: "All versions",
+      },
+      {
+        caseInsensitiveMembership: "≥ v0.10.9",
       },
       {
         caseInsensitiveRegex: "≥ v0.10.6",
@@ -600,7 +618,7 @@ export default {
   },
   csharp: {
     name: "C# SDK",
-    version: "1.1.3",
+    version: "1.2.0",
     github: "https://github.com/growthbook/growthbook-c-sharp",
     examples: [
       {
@@ -620,6 +638,12 @@ export default {
       },
       {
         experimentation: "All versions",
+      },
+      {
+        caseInsensitiveMembership: "≥ v1.2.0",
+      },
+      {
+        caseInsensitiveRegex: "≥ v1.2.0",
       },
       {
         remoteEval: "≥ v1.1.3",
@@ -693,7 +717,7 @@ export default {
   },
   kotlin: {
     name: "Kotlin SDK",
-    version: "7.1.1",
+    version: "7.3.0",
     github: "https://github.com/growthbook/growthbook-kotlin",
     examples: [],
     packageRepos: [
@@ -746,7 +770,7 @@ export default {
   },
   swift: {
     name: "Swift SDK",
-    version: "1.1.4",
+    version: "1.1.12",
     github: "https://github.com/growthbook/growthbook-swift",
     examples: [],
     packageRepos: [
@@ -876,7 +900,7 @@ export default {
   },
   edgeCloudflare: {
     name: "Cloudflare Workers App & SDK",
-    version: "0.2.8",
+    version: "0.2.9",
     github:
       "https://github.com/growthbook/growthbook-proxy/tree/main/packages/lib/edge-cloudflare",
     examples: [
@@ -947,7 +971,7 @@ export default {
   },
   edgeFastly: {
     name: "Fastly Compute App & SDK",
-    version: "0.2.8",
+    version: "0.2.9",
     github:
       "https://github.com/growthbook/growthbook-proxy/tree/main/packages/lib/edge-fastly",
     examples: [
@@ -1018,7 +1042,7 @@ export default {
   },
   edgeLambda: {
     name: "Lambda@Edge App & SDK",
-    version: "0.0.28",
+    version: "0.0.29",
     github:
       "https://github.com/growthbook/growthbook-proxy/tree/main/packages/lib/edge-lambda",
     examples: [],
@@ -1084,7 +1108,7 @@ export default {
   },
   edgeUtils: {
     name: "Edge Utils",
-    version: "0.2.8",
+    version: "0.2.9",
     github:
       "https://github.com/growthbook/growthbook-proxy/tree/main/packages/lib/edge-utils",
     examples: [],
@@ -1150,7 +1174,7 @@ export default {
   },
   flutter: {
     name: "Flutter SDK",
-    version: "4.2.1",
+    version: "4.4.0",
     github: "https://github.com/growthbook/growthbook-flutter",
     examples: [],
     packageRepos: [
@@ -1165,6 +1189,15 @@ export default {
       },
       {
         experimentation: "All versions",
+      },
+      {
+        caseInsensitiveRegex: "≥ v4.3.0",
+      },
+      {
+        caseInsensitiveMembership: "≥ v4.3.0",
+      },
+      {
+        savedGroupReferences: "≥ v3.9.4",
       },
       {
         stickyBucketing: "≥ v3.8.0",
@@ -1197,7 +1230,7 @@ export default {
   },
   roku: {
     name: "Roku SDK",
-    version: "1.3.1",
+    version: "1.4.1",
     github: "https://github.com/growthbook/growthbook-roku",
     examples: [
       {
@@ -1216,6 +1249,12 @@ export default {
       },
       {
         experimentation: "All versions",
+      },
+      {
+        encryption: "≥ v1.4.1",
+      },
+      {
+        stickyBucketing: "≥ v1.4.1",
       },
       {
         prerequisites: "≥ v1.3.0",

--- a/packages/shared/src/sdk-versioning/sdk-versions/csharp.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/csharp.json
@@ -1,6 +1,10 @@
 {
   "versions": [
     {
+      "version": "1.2.0",
+      "capabilities": ["caseInsensitiveMembership", "caseInsensitiveRegex"]
+    },
+    {
       "version": "1.1.3",
       "capabilities": ["remoteEval"]
     },

--- a/packages/shared/src/sdk-versioning/sdk-versions/csharp.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/csharp.json
@@ -5,11 +5,17 @@
       "capabilities": ["caseInsensitiveMembership", "caseInsensitiveRegex"]
     },
     {
+      "version": "1.1.4"
+    },
+    {
       "version": "1.1.3",
       "capabilities": ["remoteEval"]
     },
     {
       "version": "1.1.2"
+    },
+    {
+      "version": "1.1.1"
     },
     {
       "version": "1.1.0",
@@ -21,6 +27,15 @@
     },
     {
       "version": "1.0.6"
+    },
+    {
+      "version": "1.0.5"
+    },
+    {
+      "version": "1.0.4"
+    },
+    {
+      "version": "1.0.3"
     },
     {
       "version": "1.0.2"
@@ -36,6 +51,30 @@
     },
     {
       "version": "0.2.0"
+    },
+    {
+      "version": "0.1.2"
+    },
+    {
+      "version": "0.0.7"
+    },
+    {
+      "version": "0.0.6"
+    },
+    {
+      "version": "0.0.5"
+    },
+    {
+      "version": "0.0.4"
+    },
+    {
+      "version": "0.0.3"
+    },
+    {
+      "version": "0.0.2"
+    },
+    {
+      "version": "0.0.1"
     },
     {
       "version": "0.0.0",

--- a/packages/shared/src/sdk-versioning/sdk-versions/edge-cloudflare.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/edge-cloudflare.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "0.2.9"
+    },
+    {
       "version": "0.2.8"
     },
     {

--- a/packages/shared/src/sdk-versioning/sdk-versions/edge-cloudflare.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/edge-cloudflare.json
@@ -20,6 +20,9 @@
       "version": "0.2.4"
     },
     {
+      "version": "0.2.2"
+    },
+    {
       "version": "0.2.1"
     },
     {
@@ -27,6 +30,9 @@
     },
     {
       "version": "0.1.15"
+    },
+    {
+      "version": "0.1.14"
     },
     {
       "version": "0.1.13"
@@ -51,6 +57,39 @@
         "redirects",
         "stickyBucketing"
       ]
+    },
+    {
+      "version": "0.1.10"
+    },
+    {
+      "version": "0.1.9"
+    },
+    {
+      "version": "0.1.8"
+    },
+    {
+      "version": "0.1.7"
+    },
+    {
+      "version": "0.1.6"
+    },
+    {
+      "version": "0.1.5"
+    },
+    {
+      "version": "0.1.4"
+    },
+    {
+      "version": "0.1.3"
+    },
+    {
+      "version": "0.1.2"
+    },
+    {
+      "version": "0.1.1"
+    },
+    {
+      "version": "0.1.0"
     }
   ]
 }

--- a/packages/shared/src/sdk-versioning/sdk-versions/edge-fastly.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/edge-fastly.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "0.2.9"
+    },
+    {
       "version": "0.2.8"
     },
     {

--- a/packages/shared/src/sdk-versioning/sdk-versions/edge-fastly.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/edge-fastly.json
@@ -20,10 +20,16 @@
       "version": "0.2.4"
     },
     {
+      "version": "0.2.3"
+    },
+    {
       "version": "0.2.2"
     },
     {
       "version": "0.2.1"
+    },
+    {
+      "version": "0.2.0"
     },
     {
       "version": "0.1.8"
@@ -51,6 +57,21 @@
         "redirects",
         "stickyBucketing"
       ]
+    },
+    {
+      "version": "0.1.4"
+    },
+    {
+      "version": "0.1.3"
+    },
+    {
+      "version": "0.1.2"
+    },
+    {
+      "version": "0.1.1"
+    },
+    {
+      "version": "0.1.0"
     }
   ]
 }

--- a/packages/shared/src/sdk-versioning/sdk-versions/edge-lambda.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/edge-lambda.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "0.0.29"
+    },
+    {
       "version": "0.0.28"
     },
     {

--- a/packages/shared/src/sdk-versioning/sdk-versions/edge-lambda.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/edge-lambda.json
@@ -20,6 +20,9 @@
       "version": "0.0.24"
     },
     {
+      "version": "0.0.22"
+    },
+    {
       "version": "0.0.21"
     },
     {
@@ -27,6 +30,9 @@
     },
     {
       "version": "0.0.10"
+    },
+    {
+      "version": "0.0.9"
     },
     {
       "version": "0.0.8"
@@ -51,6 +57,21 @@
         "redirects",
         "stickyBucketing"
       ]
+    },
+    {
+      "version": "0.0.5"
+    },
+    {
+      "version": "0.0.4"
+    },
+    {
+      "version": "0.0.3"
+    },
+    {
+      "version": "0.0.2"
+    },
+    {
+      "version": "0.0.1"
     }
   ]
 }

--- a/packages/shared/src/sdk-versioning/sdk-versions/edge-other.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/edge-other.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "0.2.9"
+    },
+    {
       "version": "0.2.8"
     },
     {

--- a/packages/shared/src/sdk-versioning/sdk-versions/edge-other.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/edge-other.json
@@ -20,7 +20,13 @@
       "version": "0.2.4"
     },
     {
+      "version": "0.2.2"
+    },
+    {
       "version": "0.2.1"
+    },
+    {
+      "version": "0.2.0"
     },
     {
       "version": "0.1.7"
@@ -48,6 +54,39 @@
         "redirects",
         "stickyBucketing"
       ]
+    },
+    {
+      "version": "0.1.3"
+    },
+    {
+      "version": "0.1.2"
+    },
+    {
+      "version": "0.1.1"
+    },
+    {
+      "version": "0.1.0"
+    },
+    {
+      "version": "0.0.7"
+    },
+    {
+      "version": "0.0.6"
+    },
+    {
+      "version": "0.0.5"
+    },
+    {
+      "version": "0.0.4"
+    },
+    {
+      "version": "0.0.3"
+    },
+    {
+      "version": "0.0.2"
+    },
+    {
+      "version": "0.0.1"
     }
   ]
 }

--- a/packages/shared/src/sdk-versioning/sdk-versions/elixir.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/elixir.json
@@ -13,6 +13,12 @@
         "looseUnmarshalling",
         "namespacesV2"
       ]
+    },
+    {
+      "version": "0.1.1"
+    },
+    {
+      "version": "0.1.0"
     }
   ]
 }

--- a/packages/shared/src/sdk-versioning/sdk-versions/flutter.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/flutter.json
@@ -1,6 +1,13 @@
 {
   "versions": [
     {
+      "version": "4.4.0"
+    },
+    {
+      "version": "4.3.0",
+      "capabilities": ["caseInsensitiveRegex", "caseInsensitiveMembership"]
+    },
+    {
       "version": "4.2.1"
     },
     {
@@ -26,6 +33,10 @@
     },
     {
       "version": "3.9.5"
+    },
+    {
+      "version": "3.9.4",
+      "capabilities": ["savedGroupReferences"]
     },
     {
       "version": "3.9.3"

--- a/packages/shared/src/sdk-versioning/sdk-versions/flutter.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/flutter.json
@@ -8,7 +8,22 @@
       "capabilities": ["caseInsensitiveRegex", "caseInsensitiveMembership"]
     },
     {
+      "version": "4.2.5"
+    },
+    {
+      "version": "4.2.4"
+    },
+    {
+      "version": "4.2.3"
+    },
+    {
+      "version": "4.2.2"
+    },
+    {
       "version": "4.2.1"
+    },
+    {
+      "version": "4.1.1"
     },
     {
       "version": "4.1.0"
@@ -17,7 +32,16 @@
       "version": "4.0.0"
     },
     {
+      "version": "3.9.14"
+    },
+    {
+      "version": "3.9.12"
+    },
+    {
       "version": "3.9.11"
+    },
+    {
+      "version": "3.9.10"
     },
     {
       "version": "3.9.9"
@@ -80,7 +104,31 @@
       "capabilities": ["encryption", "bucketingV2", "semverTargeting"]
     },
     {
+      "version": "3.0.0"
+    },
+    {
+      "version": "2.1.0"
+    },
+    {
+      "version": "2.0.1"
+    },
+    {
+      "version": "2.0.0"
+    },
+    {
+      "version": "1.2.0"
+    },
+    {
       "version": "1.1.2"
+    },
+    {
+      "version": "1.1.1"
+    },
+    {
+      "version": "1.1.0"
+    },
+    {
+      "version": "1.0.0"
     },
     {
       "version": "0.0.0",

--- a/packages/shared/src/sdk-versioning/sdk-versions/go.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/go.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "0.2.9"
+    },
+    {
       "version": "0.2.8"
     },
     {

--- a/packages/shared/src/sdk-versioning/sdk-versions/go.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/go.json
@@ -14,6 +14,9 @@
       "version": "0.2.6"
     },
     {
+      "version": "0.2.5"
+    },
+    {
       "version": "0.2.4"
     },
     {
@@ -53,6 +56,18 @@
         "semverTargeting",
         "encryption"
       ]
+    },
+    {
+      "version": "0.1.3"
+    },
+    {
+      "version": "0.1.2"
+    },
+    {
+      "version": "0.1.1"
+    },
+    {
+      "version": "0.1.0"
     },
     {
       "version": "0.0.0",

--- a/packages/shared/src/sdk-versioning/sdk-versions/java.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/java.json
@@ -1,6 +1,13 @@
 {
   "versions": [
     {
+      "version": "0.10.10"
+    },
+    {
+      "version": "0.10.9",
+      "capabilities": ["caseInsensitiveMembership"]
+    },
+    {
       "version": "0.10.6",
       "capabilities": ["caseInsensitiveRegex"]
     },
@@ -11,7 +18,7 @@
       "version": "0.10.1"
     },
     {
-      "version": "v0.10.0"
+      "version": "0.10.0"
     },
     {
       "version": "0.9.96"

--- a/packages/shared/src/sdk-versioning/sdk-versions/java.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/java.json
@@ -8,8 +8,23 @@
       "capabilities": ["caseInsensitiveMembership"]
     },
     {
+      "version": "0.10.8"
+    },
+    {
+      "version": "0.10.7"
+    },
+    {
       "version": "0.10.6",
       "capabilities": ["caseInsensitiveRegex"]
+    },
+    {
+      "version": "0.10.5"
+    },
+    {
+      "version": "0.10.4"
+    },
+    {
+      "version": "0.10.3"
     },
     {
       "version": "0.10.2"
@@ -40,6 +55,12 @@
       "version": "0.9.91"
     },
     {
+      "version": "0.9.9"
+    },
+    {
+      "version": "0.9.8"
+    },
+    {
       "version": "0.9.7"
     },
     {
@@ -47,6 +68,9 @@
     },
     {
       "version": "0.9.5"
+    },
+    {
+      "version": "0.9.4"
     },
     {
       "version": "0.9.3",
@@ -63,6 +87,15 @@
       "capabilities": ["streaming"]
     },
     {
+      "version": "0.8.1"
+    },
+    {
+      "version": "0.8.0"
+    },
+    {
+      "version": "0.7.1"
+    },
+    {
       "version": "0.7.0",
       "capabilities": ["semverTargeting"]
     },
@@ -71,8 +104,32 @@
       "capabilities": ["bucketingV2"]
     },
     {
+      "version": "0.5.0"
+    },
+    {
+      "version": "0.4.0"
+    },
+    {
       "version": "0.3.0",
       "capabilities": ["encryption"]
+    },
+    {
+      "version": "0.2.2"
+    },
+    {
+      "version": "0.2.1"
+    },
+    {
+      "version": "0.1.1"
+    },
+    {
+      "version": "0.1.0"
+    },
+    {
+      "version": "0.0.2"
+    },
+    {
+      "version": "0.0.1"
     },
     {
       "version": "0.0.0",

--- a/packages/shared/src/sdk-versioning/sdk-versions/javascript.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/javascript.json
@@ -88,8 +88,17 @@
       "capabilities": ["remoteEval"]
     },
     {
+      "version": "0.28.0"
+    },
+    {
       "version": "0.27.0",
       "capabilities": ["semverTargeting", "visualEditorJS"]
+    },
+    {
+      "version": "0.26.0"
+    },
+    {
+      "version": "0.25.0"
     },
     {
       "version": "0.24.0",
@@ -100,12 +109,126 @@
       "capabilities": ["bucketingV2"]
     },
     {
+      "version": "0.22.0"
+    },
+    {
+      "version": "0.21.2"
+    },
+    {
+      "version": "0.21.1"
+    },
+    {
       "version": "0.21.0",
       "capabilities": ["streaming"]
     },
     {
+      "version": "0.20.1"
+    },
+    {
       "version": "0.20.0",
       "capabilities": ["encryption"]
+    },
+    {
+      "version": "0.19.1"
+    },
+    {
+      "version": "0.19.0"
+    },
+    {
+      "version": "0.18.1"
+    },
+    {
+      "version": "0.18.0"
+    },
+    {
+      "version": "0.17.1"
+    },
+    {
+      "version": "0.17.0"
+    },
+    {
+      "version": "0.16.2"
+    },
+    {
+      "version": "0.16.1"
+    },
+    {
+      "version": "0.16.0"
+    },
+    {
+      "version": "0.15.1"
+    },
+    {
+      "version": "0.15.0"
+    },
+    {
+      "version": "0.14.0"
+    },
+    {
+      "version": "0.13.0"
+    },
+    {
+      "version": "0.12.0"
+    },
+    {
+      "version": "0.11.0"
+    },
+    {
+      "version": "0.10.0"
+    },
+    {
+      "version": "0.9.3"
+    },
+    {
+      "version": "0.9.2"
+    },
+    {
+      "version": "0.9.1"
+    },
+    {
+      "version": "0.9.0"
+    },
+    {
+      "version": "0.8.0"
+    },
+    {
+      "version": "0.7.1"
+    },
+    {
+      "version": "0.7.0"
+    },
+    {
+      "version": "0.6.1"
+    },
+    {
+      "version": "0.5.1"
+    },
+    {
+      "version": "0.5.0"
+    },
+    {
+      "version": "0.4.1"
+    },
+    {
+      "version": "0.4.0"
+    },
+    {
+      "version": "0.3.0"
+    },
+    {
+      "version": "0.2.0"
+    },
+    {
+      "version": "0.1.3"
+    },
+    {
+      "version": "0.1.2"
+    },
+    {
+      "version": "0.1.1"
+    },
+    {
+      "version": "0.1.0"
     },
     {
       "version": "0.0.0",

--- a/packages/shared/src/sdk-versioning/sdk-versions/kotlin.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/kotlin.json
@@ -3,15 +3,26 @@
     {
       "version": "7.3.0"
     },
+    { "version": "7.2.0" },
     {
       "version": "7.1.1",
       "capabilities": ["caseInsensitiveMembership", "caseInsensitiveRegex"]
     },
+    { "version": "7.1.0" },
     { "version": "7.0.0" },
+    { "version": "6.1.5" },
+    { "version": "6.1.4" },
     { "version": "6.1.1" },
     { "version": "6.1.0" },
+    { "version": "6.0.0" },
     { "version": "5.0.1" },
+    { "version": "5.0.0" },
+    { "version": "3.1.0" },
     { "version": "2.0.0" },
+    { "version": "1.1.64" },
+    { "version": "1.1.63" },
+    { "version": "1.1.62" },
+    { "version": "1.1.61" },
     { "version": "1.1.60" },
     { "version": "1.1.59" },
     { "version": "1.1.58" },
@@ -25,6 +36,9 @@
       "version": "1.1.50",
       "capabilities": ["remoteEval", "streaming"]
     },
+    { "version": "1.1.48" },
+    { "version": "1.1.47" },
+    { "version": "1.1.46" },
     {
       "version": "1.1.44",
       "capabilities": ["prerequisites", "stickyBucketing"]
@@ -32,18 +46,47 @@
     {
       "version": "1.1.43"
     },
+    { "version": "1.1.42" },
+    { "version": "1.1.41" },
+    { "version": "1.1.40" },
     {
       "version": "1.1.38",
       "capabilities": ["bucketingV2"]
     },
+    { "version": "1.1.36" },
+    { "version": "1.1.35" },
+    { "version": "1.1.34" },
+    { "version": "1.1.33" },
+    { "version": "1.1.32" },
     {
       "version": "1.1.31",
       "capabilities": ["semverTargeting"]
     },
+    { "version": "1.1.30" },
+    { "version": "1.1.29" },
+    { "version": "1.1.28" },
+    { "version": "1.1.27" },
+    { "version": "1.1.26" },
+    { "version": "1.1.25" },
+    { "version": "1.1.24" },
     {
       "version": "1.1.23",
       "capabilities": ["encryption"]
     },
+    { "version": "1.1.22" },
+    { "version": "1.1.18" },
+    { "version": "1.1.17" },
+    { "version": "1.1.16" },
+    { "version": "1.1.14" },
+    { "version": "1.1.13" },
+    { "version": "1.1.9" },
+    { "version": "1.1.8" },
+    { "version": "1.1.7" },
+    { "version": "1.1.6" },
+    { "version": "1.1.5" },
+    { "version": "1.1.4" },
+    { "version": "1.1.3" },
+    { "version": "1.1.0" },
     {
       "version": "0.0.0",
       "capabilities": ["looseUnmarshalling", "namespacesV2"]

--- a/packages/shared/src/sdk-versioning/sdk-versions/kotlin.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/kotlin.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "7.3.0"
+    },
+    {
       "version": "7.1.1",
       "capabilities": ["caseInsensitiveMembership", "caseInsensitiveRegex"]
     },

--- a/packages/shared/src/sdk-versioning/sdk-versions/nodejs.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/nodejs.json
@@ -80,20 +80,152 @@
       "version": "0.31.0"
     },
     {
+      "version": "0.30.0"
+    },
+    {
+      "version": "0.29.0"
+    },
+    {
+      "version": "0.28.0"
+    },
+    {
       "version": "0.27.0",
       "capabilities": ["semverTargeting"]
+    },
+    {
+      "version": "0.26.0"
+    },
+    {
+      "version": "0.25.0"
+    },
+    {
+      "version": "0.24.0"
     },
     {
       "version": "0.23.0",
       "capabilities": ["bucketingV2"]
     },
     {
+      "version": "0.22.0"
+    },
+    {
+      "version": "0.21.2"
+    },
+    {
+      "version": "0.21.1"
+    },
+    {
       "version": "0.21.0",
       "capabilities": ["streaming"]
     },
     {
+      "version": "0.20.1"
+    },
+    {
       "version": "0.20.0",
       "capabilities": ["encryption"]
+    },
+    {
+      "version": "0.19.1"
+    },
+    {
+      "version": "0.19.0"
+    },
+    {
+      "version": "0.18.1"
+    },
+    {
+      "version": "0.18.0"
+    },
+    {
+      "version": "0.17.1"
+    },
+    {
+      "version": "0.17.0"
+    },
+    {
+      "version": "0.16.2"
+    },
+    {
+      "version": "0.16.1"
+    },
+    {
+      "version": "0.16.0"
+    },
+    {
+      "version": "0.15.1"
+    },
+    {
+      "version": "0.15.0"
+    },
+    {
+      "version": "0.14.0"
+    },
+    {
+      "version": "0.13.0"
+    },
+    {
+      "version": "0.12.0"
+    },
+    {
+      "version": "0.11.0"
+    },
+    {
+      "version": "0.10.0"
+    },
+    {
+      "version": "0.9.3"
+    },
+    {
+      "version": "0.9.2"
+    },
+    {
+      "version": "0.9.1"
+    },
+    {
+      "version": "0.9.0"
+    },
+    {
+      "version": "0.8.0"
+    },
+    {
+      "version": "0.7.1"
+    },
+    {
+      "version": "0.7.0"
+    },
+    {
+      "version": "0.6.1"
+    },
+    {
+      "version": "0.5.1"
+    },
+    {
+      "version": "0.5.0"
+    },
+    {
+      "version": "0.4.1"
+    },
+    {
+      "version": "0.4.0"
+    },
+    {
+      "version": "0.3.0"
+    },
+    {
+      "version": "0.2.0"
+    },
+    {
+      "version": "0.1.3"
+    },
+    {
+      "version": "0.1.2"
+    },
+    {
+      "version": "0.1.1"
+    },
+    {
+      "version": "0.1.0"
     },
     {
       "version": "0.0.0",

--- a/packages/shared/src/sdk-versioning/sdk-versions/php.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/php.json
@@ -4,12 +4,39 @@
       "version": "2.6.1"
     },
     {
+      "version": "2.6.0"
+    },
+    {
       "version": "2.5.0",
       "capabilities": ["remoteEval"]
     },
     {
+      "version": "2.4.0"
+    },
+    {
       "version": "2.3.0",
       "capabilities": ["caseInsensitiveRegex", "caseInsensitiveMembership"]
+    },
+    {
+      "version": "2.2.0"
+    },
+    {
+      "version": "2.1.0"
+    },
+    {
+      "version": "2.0.0"
+    },
+    {
+      "version": "1.7.4"
+    },
+    {
+      "version": "1.7.3"
+    },
+    {
+      "version": "1.7.2"
+    },
+    {
+      "version": "1.7.1"
     },
     {
       "version": "1.7.0",
@@ -34,8 +61,23 @@
       "capabilities": ["bucketingV2", "encryption"]
     },
     {
+      "version": "1.1.0"
+    },
+    {
+      "version": "1.0.1"
+    },
+    {
       "version": "1.0.0",
       "capabilities": ["looseUnmarshalling", "namespacesV2"]
+    },
+    {
+      "version": "0.3.0"
+    },
+    {
+      "version": "0.2.0"
+    },
+    {
+      "version": "0.1.0"
     }
   ]
 }

--- a/packages/shared/src/sdk-versioning/sdk-versions/php.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/php.json
@@ -1,6 +1,17 @@
 {
   "versions": [
     {
+      "version": "2.6.1"
+    },
+    {
+      "version": "2.5.0",
+      "capabilities": ["remoteEval"]
+    },
+    {
+      "version": "2.3.0",
+      "capabilities": ["caseInsensitiveRegex", "caseInsensitiveMembership"]
+    },
+    {
       "version": "1.7.0",
       "capabilities": ["savedGroupReferences"]
     },

--- a/packages/shared/src/sdk-versioning/sdk-versions/python.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/python.json
@@ -8,6 +8,27 @@
       "capabilities": ["remoteEval"]
     },
     {
+      "version": "2.2.2"
+    },
+    {
+      "version": "2.2.1"
+    },
+    {
+      "version": "2.2.0"
+    },
+    {
+      "version": "2.1.5"
+    },
+    {
+      "version": "2.1.4"
+    },
+    {
+      "version": "2.1.3"
+    },
+    {
+      "version": "2.1.2"
+    },
+    {
       "version": "2.1.1",
       "capabilities": ["caseInsensitiveMembership"]
     },
@@ -19,13 +40,43 @@
       "version": "2.0.0"
     },
     {
+      "version": "1.4.10"
+    },
+    {
+      "version": "1.4.9"
+    },
+    {
+      "version": "1.4.8"
+    },
+    {
+      "version": "1.4.7"
+    },
+    {
+      "version": "1.4.6"
+    },
+    {
       "version": "1.4.5"
+    },
+    {
+      "version": "1.4.4"
+    },
+    {
+      "version": "1.4.3"
     },
     {
       "version": "1.4.2"
     },
     {
+      "version": "1.4.1"
+    },
+    {
+      "version": "1.4.0"
+    },
+    {
       "version": "1.3.1"
+    },
+    {
+      "version": "1.3.0"
     },
     {
       "version": "1.2.1",
@@ -44,6 +95,21 @@
     {
       "version": "1.0.0",
       "capabilities": ["bucketingV2", "encryption"]
+    },
+    {
+      "version": "0.3.1"
+    },
+    {
+      "version": "0.3.0"
+    },
+    {
+      "version": "0.2.0"
+    },
+    {
+      "version": "0.1.1"
+    },
+    {
+      "version": "0.1.0"
     }
   ]
 }

--- a/packages/shared/src/sdk-versioning/sdk-versions/python.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/python.json
@@ -1,6 +1,13 @@
 {
   "versions": [
     {
+      "version": "2.3.1"
+    },
+    {
+      "version": "2.3.0",
+      "capabilities": ["remoteEval"]
+    },
+    {
       "version": "2.1.1",
       "capabilities": ["caseInsensitiveMembership"]
     },

--- a/packages/shared/src/sdk-versioning/sdk-versions/react.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/react.json
@@ -88,8 +88,17 @@
       "capabilities": ["remoteEval"]
     },
     {
+      "version": "0.18.0"
+    },
+    {
       "version": "0.17.0",
       "capabilities": ["semverTargeting", "visualEditorJS"]
+    },
+    {
+      "version": "0.16.0"
+    },
+    {
+      "version": "0.15.0"
     },
     {
       "version": "0.14.0",
@@ -100,12 +109,78 @@
       "capabilities": ["bucketingV2"]
     },
     {
+      "version": "0.12.0"
+    },
+    {
+      "version": "0.11.2"
+    },
+    {
+      "version": "0.11.1"
+    },
+    {
       "version": "0.11.0",
       "capabilities": ["streaming"]
     },
     {
       "version": "0.10.1",
       "capabilities": ["encryption"]
+    },
+    {
+      "version": "0.10.0"
+    },
+    {
+      "version": "0.9.1"
+    },
+    {
+      "version": "0.9.0"
+    },
+    {
+      "version": "0.8.1"
+    },
+    {
+      "version": "0.8.0"
+    },
+    {
+      "version": "0.7.0"
+    },
+    {
+      "version": "0.6.0"
+    },
+    {
+      "version": "0.5.1"
+    },
+    {
+      "version": "0.5.0"
+    },
+    {
+      "version": "0.4.0"
+    },
+    {
+      "version": "0.3.0"
+    },
+    {
+      "version": "0.2.7"
+    },
+    {
+      "version": "0.2.6"
+    },
+    {
+      "version": "0.2.5"
+    },
+    {
+      "version": "0.2.4"
+    },
+    {
+      "version": "0.2.3"
+    },
+    {
+      "version": "0.2.2"
+    },
+    {
+      "version": "0.2.1"
+    },
+    {
+      "version": "0.2.0"
     },
     {
       "version": "0.0.0",

--- a/packages/shared/src/sdk-versioning/sdk-versions/roku.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/roku.json
@@ -1,6 +1,10 @@
 {
   "versions": [
     {
+      "version": "1.4.1",
+      "capabilities": ["encryption", "stickyBucketing"]
+    },
+    {
       "version": "1.3.1"
     },
     {

--- a/packages/shared/src/sdk-versioning/sdk-versions/ruby.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/ruby.json
@@ -9,12 +9,33 @@
       "capabilities": ["semverTargeting"]
     },
     {
+      "version": "1.2.1"
+    },
+    {
+      "version": "1.2.0"
+    },
+    {
+      "version": "1.1.1"
+    },
+    {
       "version": "1.1.0",
       "capabilities": ["encryption"]
     },
     {
       "version": "1.0.0",
       "capabilities": ["bucketingV2"]
+    },
+    {
+      "version": "0.3.0"
+    },
+    {
+      "version": "0.2.0"
+    },
+    {
+      "version": "0.1.0"
+    },
+    {
+      "version": "0.0.1"
     },
     {
       "version": "0.0.0",

--- a/packages/shared/src/sdk-versioning/sdk-versions/rust.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/rust.json
@@ -1,6 +1,10 @@
 {
   "versions": [
     {
+      "version": "0.2.0",
+      "capabilities": ["savedGroupReferences"]
+    },
+    {
       "version": "0.1.1",
       "capabilities": ["caseInsensitiveRegex", "caseInsensitiveMembership"]
     },

--- a/packages/shared/src/sdk-versioning/sdk-versions/swift.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/swift.json
@@ -4,21 +4,141 @@
       "version": "1.1.12"
     },
     {
+      "version": "1.1.11"
+    },
+    {
+      "version": "1.1.10"
+    },
+    {
+      "version": "1.1.9"
+    },
+    {
+      "version": "1.1.8"
+    },
+    {
+      "version": "1.1.7"
+    },
+    {
+      "version": "1.1.6"
+    },
+    {
+      "version": "1.1.5"
+    },
+    {
       "version": "1.1.4",
       "capabilities": ["namespacesV2"]
+    },
+    {
+      "version": "1.1.3"
+    },
+    {
+      "version": "1.1.2"
     },
     {
       "version": "1.1.1",
       "capabilities": ["caseInsensitiveMembership", "caseInsensitiveRegex"]
     },
     {
+      "version": "1.1.0"
+    },
+    {
+      "version": "1.0.101"
+    },
+    {
+      "version": "1.0.100"
+    },
+    {
+      "version": "1.0.99"
+    },
+    {
+      "version": "1.0.98"
+    },
+    {
+      "version": "1.0.97"
+    },
+    {
+      "version": "1.0.96"
+    },
+    {
       "version": "1.0.95"
+    },
+    {
+      "version": "1.0.94"
+    },
+    {
+      "version": "1.0.93"
+    },
+    {
+      "version": "1.0.92"
+    },
+    {
+      "version": "1.0.91"
+    },
+    {
+      "version": "1.0.90"
+    },
+    {
+      "version": "1.0.89"
+    },
+    {
+      "version": "1.0.88"
+    },
+    {
+      "version": "1.0.87"
+    },
+    {
+      "version": "1.0.86"
+    },
+    {
+      "version": "1.0.85"
+    },
+    {
+      "version": "1.0.84"
+    },
+    {
+      "version": "1.0.83"
     },
     {
       "version": "1.0.82"
     },
     {
+      "version": "1.0.81"
+    },
+    {
+      "version": "1.0.80"
+    },
+    {
+      "version": "1.0.79"
+    },
+    {
+      "version": "1.0.78"
+    },
+    {
+      "version": "1.0.77"
+    },
+    {
+      "version": "1.0.76"
+    },
+    {
+      "version": "1.0.75"
+    },
+    {
+      "version": "1.0.74"
+    },
+    {
       "version": "1.0.73"
+    },
+    {
+      "version": "1.0.72"
+    },
+    {
+      "version": "1.0.71"
+    },
+    {
+      "version": "1.0.70"
+    },
+    {
+      "version": "1.0.69"
     },
     {
       "version": "1.0.68"
@@ -42,6 +162,18 @@
       "version": "1.0.62"
     },
     {
+      "version": "1.0.61"
+    },
+    {
+      "version": "1.0.60"
+    },
+    {
+      "version": "1.0.59"
+    },
+    {
+      "version": "1.0.58"
+    },
+    {
       "version": "1.0.57"
     },
     {
@@ -55,6 +187,9 @@
     },
     {
       "version": "1.0.53"
+    },
+    {
+      "version": "1.0.52"
     },
     {
       "version": "1.0.51"
@@ -74,6 +209,12 @@
       "version": "1.0.47"
     },
     {
+      "version": "1.0.46"
+    },
+    {
+      "version": "1.0.45"
+    },
+    {
       "version": "1.0.44"
     },
     {
@@ -81,12 +222,132 @@
       "capabilities": ["bucketingV2", "streaming"]
     },
     {
+      "version": "1.0.42"
+    },
+    {
+      "version": "1.0.41"
+    },
+    {
+      "version": "1.0.40"
+    },
+    {
+      "version": "1.0.39"
+    },
+    {
       "version": "1.0.38",
       "capabilities": ["semverTargeting"]
     },
     {
+      "version": "1.0.37"
+    },
+    {
+      "version": "1.0.36"
+    },
+    {
       "version": "1.0.35",
       "capabilities": ["encryption"]
+    },
+    {
+      "version": "1.0.34"
+    },
+    {
+      "version": "1.0.32"
+    },
+    {
+      "version": "1.0.31"
+    },
+    {
+      "version": "1.0.30"
+    },
+    {
+      "version": "1.0.29"
+    },
+    {
+      "version": "1.0.28"
+    },
+    {
+      "version": "1.0.27"
+    },
+    {
+      "version": "1.0.26"
+    },
+    {
+      "version": "1.0.25"
+    },
+    {
+      "version": "1.0.24"
+    },
+    {
+      "version": "1.0.23"
+    },
+    {
+      "version": "1.0.22"
+    },
+    {
+      "version": "1.0.21"
+    },
+    {
+      "version": "1.0.20"
+    },
+    {
+      "version": "1.0.19"
+    },
+    {
+      "version": "1.0.18"
+    },
+    {
+      "version": "1.0.16"
+    },
+    {
+      "version": "1.0.15"
+    },
+    {
+      "version": "1.0.14"
+    },
+    {
+      "version": "1.0.13"
+    },
+    {
+      "version": "1.0.12"
+    },
+    {
+      "version": "1.0.11"
+    },
+    {
+      "version": "1.0.10"
+    },
+    {
+      "version": "1.0.9"
+    },
+    {
+      "version": "1.0.8"
+    },
+    {
+      "version": "1.0.7"
+    },
+    {
+      "version": "1.0.6"
+    },
+    {
+      "version": "1.0.5"
+    },
+    {
+      "version": "1.0.4"
+    },
+    {
+      "version": "1.0.3"
+    },
+    {
+      "version": "1.0.2"
+    },
+    {
+      "version": "1.0.1"
+    },
+    {
+      "version": "1.0.0"
+    },
+    {
+      "version": "0.1.0"
     },
     {
       "version": "0.0.0",

--- a/packages/shared/src/sdk-versioning/sdk-versions/swift.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/swift.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "1.1.12"
+    },
+    {
       "version": "1.1.4",
       "capabilities": ["namespacesV2"]
     },


### PR DESCRIPTION
### Features and Changes

`packages/shared/src/sdk-versioning/sdk-versions/*.json` drives the SDK-version dropdown and capability gating throughout the app (`getSDKVersions`, `getLatestSDKVersion`, `getSDKCapabilities` in `packages/shared/src/sdk-versioning/index.ts`), but several of these files had fallen far behind the SDKs' actual public release history — some hadn't been touched since a capability was tagged many releases ago, and none had their true "latest" version recorded (`versions[0]` is taken as latest without re-sorting).

This went through two passes. The first pass pulled the real release history from the upstream `growthbook/<repo>` on GitHub (tags + Releases) and cross-checked it against package registries (npm, PyPI, RubyGems, crates.io, Packagist, pub.dev, Hex, NuGet) where available, then added an entry for every version that introduced a capability from the `SDKCapability` union, plus the single most-recent released version for each SDK, following the sparse convention the files already used. The second pass went further, per reviewer feedback: for every SDK, it enumerates literally every published version from the same authoritative sources (registry APIs where one exists, GitHub tags otherwise) and adds a bare `{"version": "x.y.z"}` entry — no `capabilities` key — for every version that was still missing, so each file now lists its SDK's complete release history, not just capability-introducing releases. No new capability mappings were guessed for these bare additions; every pre-existing `capabilities` entry from the first pass (or before) was left untouched. `docs/src/data/SDKInfo.ts` is included as a derived diff where it changed — it's auto-regenerated from these JSON files by the repo's own pre-commit hook, not hand-edited (the second-pass commit didn't change it, since no new capability mappings were added).

- **php** (growthbook-php, Packagist `growthbook/growthbook`): first pass added `2.3.0` (caseInsensitiveRegex, caseInsensitiveMembership), `2.5.0` (remoteEval), `2.6.1` (latest). Second pass backfills the remaining 14 published versions with no capability changes: `2.6.0`, `2.4.0`, `2.2.0`, `2.1.0`, `2.0.0`, `1.7.4`–`1.7.1`, `1.1.0`, `1.0.1`, `0.3.0`, `0.2.0`, `0.1.0`. File now lists all 24 published versions.
- **python** (growthbook-python, PyPI `growthbook`): first pass added `2.3.0` (remoteEval), `2.3.1` (latest). Second pass backfills 22 more versions across the `2.2.x`/`2.1.x`/`1.4.x`/`1.3.0`/`0.1.x`–`0.3.x` ranges. File now lists all 33 published versions (PyPI never published `1.2.0`, so that gap is expected).
- **go** (growthbook-golang, GitHub tags): first pass added `0.2.9` (latest, no new capability). Second pass backfills the 5 remaining versions: `0.2.5`, `0.1.3`, `0.1.2`, `0.1.1`, `0.1.0`. File now lists all 20 published versions.
- **flutter** (growthbook-flutter, pub.dev `growthbook_sdk_flutter`): first pass added `3.9.4` (savedGroupReferences), `4.3.0` (caseInsensitiveRegex, caseInsensitiveMembership), `4.4.0` (latest). Second pass backfills 16 more versions (`4.2.2`–`4.2.5`, `4.1.1`, `3.9.10`/`3.9.12`/`3.9.14`, `3.0.0`, `2.0.0`–`2.1.0`, `1.0.0`–`1.2.0`). File now lists all 41 stable published versions (build-metadata suffixes like `+0` stripped to match the existing convention; the one `4.0.0-alpha` pre-release excluded, consistent with the file only ever tracking stable releases).
- **java** (growthbook-sdk-java, GitHub tags): first pass added `0.10.9` (caseInsensitiveMembership), `0.10.10` (latest); also fixed a stray `"v"` prefix on the pre-existing `"v0.10.0"` entry. Second pass backfills 19 more versions (`0.10.3`–`0.10.8`, `0.9.4`, `0.9.8`, `0.9.9`, `0.8.0`, `0.8.1`, `0.7.1`, `0.5.0`, `0.4.0`, `0.2.1`, `0.2.2`, `0.1.0`, `0.1.1`, `0.0.1`, `0.0.2`). File now lists all 41 clean semver versions; excluded 4 non-semver/junk tags found on the repo (`0.0.0b`, `0.0.0c`, `0.0.0d`, `0.0.0-kt-0`) as noise, and de-duplicated the repo's mixed `v`-prefixed/bare tagging scheme for `0.10.x`.
- **android/kotlin** (growthbook-kotlin, GitHub tags): first pass added `7.3.0` (latest, no new capability). Second pass backfills 43 more versions spanning `7.0.0`–`7.2.0`, `6.0.0`–`6.1.5`, `5.0.0`, `3.1.0`, `2.0.0`, and most of the `1.1.x` line. File now lists all 65 clean stable semver tags; excluded pre-release tags (`5.0.0-alpha*`, `4.0.0-alpha`, `3.0.0-alpha`, `2.0.0-alpha`) and two malformed/non-semver tags (`6.1.1_latest_dispatchers`, `7.1.1(NetworkDispatcherKtor-1.0.14)`) as noise, consistent with the file only ever tracking stable releases.
- **ios/swift** (growthbook-swift, GitHub tags): first pass added `1.1.12` (latest, no new capability). Second pass backfills 87 more versions — this SDK ships very frequent tiny patch releases (`1.0.0` through `1.1.11`), and the file previously tracked only a sparse sample. File now lists all 114 published versions.
- **csharp** (growthbook-c-sharp, NuGet `growthbook-c-sharp`): first pass added `1.2.0` (caseInsensitiveMembership, caseInsensitiveRegex, latest). Second pass backfills 13 more versions (`1.1.4`, `1.1.1`, `1.0.3`–`1.0.5`, `0.1.2`, `0.0.1`–`0.0.7`). File now lists all 21 published versions.
- **rust** (growthbook-rust, crates.io): first pass added `0.2.0` (savedGroupReferences, latest). Second pass found no gaps — all 7 non-yanked crates.io versions were already tracked. (crates.io also lists one yanked version, `0.0.5`, which was deliberately excluded as noise, matching how pre-release/withdrawn versions are handled elsewhere in these files.)
- **roku** (growthbook-roku, GitHub tags/Releases): first pass added `1.4.1` (encryption, stickyBucketing, latest). Second pass found no gaps — the repo has only ever published 3 releases (`1.3.0`, `1.3.1`, `1.4.1`), and all 3 were already tracked.
- **edge-cloudflare / edge-fastly / edge-lambda / edge-other** (growthbook-proxy, npm `@growthbook/edge-cloudflare` / `edge-fastly` / `edge-lambda` / `edge-utils`): first pass bumped each to its latest published npm version. Second pass backfills the remaining gaps: 13 versions for edge-cloudflare, 7 for edge-fastly, 7 for edge-lambda, 13 for edge-other (edge-utils). Each file now lists every published version of its underlying npm package.
- **javascript** / **nodejs** (this repo, npm `@growthbook/growthbook`) and **react** (this repo, npm `@growthbook/growthbook-react`): the first pass reported these as "already up to date" because the latest published version (`1.6.5`) was already present — but that only meant the *latest* was current, not that every version was tracked. This pass corrects that: it backfills 41 versions for javascript, 44 for nodejs, and 25 for react, going all the way back to each package's `0.1.0`/`0.2.0` first release. The pre-existing `1.7.0`/`contextualBandits` entry in javascript/nodejs/react is unreleased in-progress work on another branch (not yet on npm) and was left pinned above the real version list, exactly as before.
- **ruby** (growthbook-ruby, RubyGems `growthbook`) and **elixir** (growthbook-elixir, Hex `growthbook`): same correction — "already up to date" previously meant only the latest (`1.3.0` / `0.3.0`) was current. This pass backfills 7 versions for ruby (back to its first RubyGems release, `0.0.1`) and 2 for elixir (`0.1.0`, `0.1.1`). Both files now list every published version.
- Not applicable, left untouched: `nextjs` (no separately-versioned package), `other`, `nocode-*`.

In total, this pass adds 378 version entries across 17 files.

### Known issues (acceptable for v1)

- The `trackingPlugin` capability doesn't exist in this branch's `SDKCapability` union — it was added on a different in-progress branch (`claude/sdk-connections-nodejs-tracker-35c8e9`) after this branch was cut from `main`. As a result, php `2.4.0`, python `1.3.0`/`1.4.0`, and flutter `4.4.0` shipped a tracking-plugin/managed-warehouse-ingest feature that couldn't be recorded here — these should get a `trackingPlugin` entry once that type lands on `main`.
- flutter's `redirects` capability status is ambiguous from changelogs alone (test fixtures reference `urlRedirect`, but which release added full support vs. just test coverage isn't clear) — left untracked rather than guessed.
- go `0.2.9` added `isURLTargeted` (generic URL/group/status experiment targeting), related to but distinct from the `redirects` capability — not mapped to any tracked capability.
- `growthbook-sdk-java` (JVM-only) and `growthbook-kotlin` (Kotlin Multiplatform, mid-migration through `6.x`/`7.x`) are two separate, still-active SDKs that overlap on JVM/Android — worth a team conversation about whether `java.json` should eventually be deprecated in favor of the multiplatform one.
- Pre-existing capability-to-version mappings weren't independently re-audited beyond the java `"v0.10.0"` typo fix — if any were already wrong, this PR doesn't catch it. The second pass only filled in bare, capability-less entries for versions that were missing outright; it did not attempt to re-derive capability mappings for them.
- growthbook-sdk-java's tag history is messy (a mix of `v`-prefixed and bare tags for the same versions, plus a handful of non-semver tags like `0.0.0-kt-0`); growthbook-kotlin similarly has a few non-semver/malformed tags. Both were cleaned up by hand when building the authoritative version list — worth a sanity check if either upstream repo's tagging convention changes.

### Testing

- [x] All 17 touched JSON files in this pass (across both passes, all files except `nextjs`, `other`, and `nocode.json`) parse as valid JSON and pass `prettier --check`
- [x] Version ordering (most-recent-first) verified programmatically for every touched file
- [x] No duplicate version entries in any file, verified programmatically
- [x] All `capabilities` values (pre-existing and from the first pass) checked against the `SDKCapability` union in `packages/shared/src/sdk-versioning/types.ts`; no new capability mappings were added in this pass
- [x] `pnpm --filter shared build` / `type-check` passes
- [x] `docs/src/data/SDKInfo.ts` regeneration was run via the repo's own pre-commit hook; it produced no diff for the second pass (expected, since no capability mappings changed)
- [x] Manual smoke-test of the SDK Connection form's version dropdown / capability-gated warnings for a couple of the changed languages (php, flutter, roku, swift) in the running app
