### PR TITLE
fix(contextual-bandits): limit contextual bandits to only using the first exposure

### DIFF
--- a/packages/shared/src/util/units-query-settings.ts
+++ b/packages/shared/src/util/units-query-settings.ts
@@ -41,6 +41,9 @@ export function buildUnitsQuerySettingsFromCb(
     metricSettings: [],
     banditSettings: {
       contextualBandit: true,
+      // Always attribute each user to their first exposure in the lookback
+      // window; never bucket multi-variation users as '__multiple__'
+      useFirstExposure: true,
       targetingAttributeColumns: cbSettings.contextualAttributes,
       reweight: cbSettings.reweight,
       decisionMetric,


### PR DESCRIPTION
In the first version of contextual bandits, we rely on users to manage repeated visits via a new identifier type, and instead just use the first exposure for each experiment unit for the sake of collecting data.

Later we could allow folks to opt-in to different measurement strategies.