### PR TITLE
fix(experiments): Swap legacy tooltips in FeatureVariationsInput with ui/Tooltip to ensure they render

### DIFF
--- a/packages/front-end/components/Features/FeatureVariationsInput.tsx
+++ b/packages/front-end/components/Features/FeatureVariationsInput.tsx
@@ -388,7 +388,7 @@ export default function FeatureVariationsInput({
                         !editingSplits &&
                         !onlySafeToEditVariationMetadata && (
                           <Tooltip
-                            body="Customize split"
+                            body="Click to unlock split…"
                             usePortal={true}
                             tipPosition="top"
                           >

--- a/packages/front-end/components/Features/FeatureVariationsInput.tsx
+++ b/packages/front-end/components/Features/FeatureVariationsInput.tsx
@@ -202,7 +202,12 @@ export default function FeatureVariationsInput({
               <label className="mb-0">
                 {coverageLabel}{" "}
                 <Tooltip content={coverageTooltip} side="top">
-                  <Box display="inline-block">
+                  <Box
+                    as="span"
+                    display="inline-block"
+                    tabIndex={0}
+                    aria-label={`More information about ${coverageLabel}`}
+                  >
                     <GBInfo />
                   </Box>
                 </Tooltip>
@@ -288,7 +293,12 @@ export default function FeatureVariationsInput({
               <label className="mb-0">
                 {coverageLabel}{" "}
                 <Tooltip content={coverageTooltip} side="top">
-                  <Box display="inline-block">
+                  <Box
+                    as="span"
+                    display="inline-block"
+                    tabIndex={0}
+                    aria-label={`More information about ${coverageLabel}`}
+                  >
                     <GBInfo />
                   </Box>
                 </Tooltip>

--- a/packages/front-end/components/Features/FeatureVariationsInput.tsx
+++ b/packages/front-end/components/Features/FeatureVariationsInput.tsx
@@ -386,45 +386,49 @@ export default function FeatureVariationsInput({
                   {showDescriptions && <th>Description</th>}
                   {!hideSplits && (
                     <th>
-                      Split
-                      {!disableVariations &&
-                        !disableCustomSplit &&
-                        !editingSplits &&
-                        !onlySafeToEditVariationMetadata && (
-                          <Tooltip content="Customize split" side="top">
-                            <Link
-                              onClick={(e) => {
-                                e.preventDefault();
-                                setEditingSplits(true);
-                              }}
-                              ml="1"
-                              aria-label="Customize split"
+                      <Flex align="center" gap="1">
+                        <span>Split</span>
+                        {!disableVariations &&
+                          !disableCustomSplit &&
+                          !editingSplits &&
+                          !onlySafeToEditVariationMetadata && (
+                            <Tooltip content="Customize split" side="top">
+                              <Link
+                                onClick={(e) => {
+                                  e.preventDefault();
+                                  setEditingSplits(true);
+                                }}
+                                aria-label="Customize split"
+                              >
+                                <PiLockSimpleFill size={15} />
+                              </Link>
+                            </Tooltip>
+                          )}
+                        {editingSplits &&
+                          !isEqualWeights &&
+                          !disableCustomSplit &&
+                          !hideSplits && (
+                            <Tooltip
+                              content="Assign equal weights to all variations"
+                              side="top"
                             >
-                              <PiLockSimpleFill size={15} />
-                            </Link>
-                          </Tooltip>
-                        )}
-                      {editingSplits &&
-                        !isEqualWeights &&
-                        !disableCustomSplit &&
-                        !hideSplits && (
-                          <Tooltip
-                            content="Assign equal weights to all variations"
-                            side="top"
-                          >
-                            <a
-                              role="button"
-                              className="ml-2 link-purple small"
-                              onClick={(e) => {
-                                e.preventDefault();
-                                setEqualWeights();
-                              }}
-                            >
-                              <PiArrowsClockwise className="mr-1" size={12} />
-                              set equal
-                            </a>
-                          </Tooltip>
-                        )}
+                              <Link
+                                onClick={(e) => {
+                                  e.preventDefault();
+                                  setEqualWeights();
+                                }}
+                                aria-label="Set equal weights"
+                              >
+                                <Flex align="center" gap="1">
+                                  <PiArrowsClockwise size={12} />
+                                  <Box as="span" style={{ fontSize: "11px" }}>
+                                    set equal
+                                  </Box>
+                                </Flex>
+                              </Link>
+                            </Tooltip>
+                          )}
+                      </Flex>
                     </th>
                   )}
                 </tr>

--- a/packages/front-end/components/Features/FeatureVariationsInput.tsx
+++ b/packages/front-end/components/Features/FeatureVariationsInput.tsx
@@ -24,6 +24,7 @@ import Tooltip from "@/components/Tooltip/Tooltip";
 import Field from "@/components/Forms/Field";
 import Link from "@/ui/Link";
 import Text from "@/ui/Text";
+import UiTooltip from "@/ui/Tooltip";
 import styles from "./VariationsInput.module.scss";
 import ExperimentSplitVisual from "./ExperimentSplitVisual";
 import {
@@ -387,11 +388,7 @@ export default function FeatureVariationsInput({
                         !disableCustomSplit &&
                         !editingSplits &&
                         !onlySafeToEditVariationMetadata && (
-                          <Tooltip
-                            body="Click to unlock split…"
-                            usePortal={true}
-                            tipPosition="top"
-                          >
+                          <UiTooltip content="Click to unlock split…" side="top">
                             <a
                               role="button"
                               className="ml-1 mb-0"
@@ -404,7 +401,7 @@ export default function FeatureVariationsInput({
                                 size={15}
                               />
                             </a>
-                          </Tooltip>
+                          </UiTooltip>
                         )}
                       {editingSplits &&
                         !isEqualWeights &&

--- a/packages/front-end/components/Features/FeatureVariationsInput.tsx
+++ b/packages/front-end/components/Features/FeatureVariationsInput.tsx
@@ -1,12 +1,6 @@
 import { FeatureInterface, FeatureValueType } from "shared/types/feature";
 import { Box, Flex, Slider } from "@radix-ui/themes";
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getEqualWeights } from "shared/experiments";
 import { PiArrowsClockwise, PiLockSimpleFill } from "react-icons/pi";
 import {
@@ -19,12 +13,11 @@ import {
   generateVariationId,
   getDefaultVariationValue,
 } from "@/services/features";
-import { GBAddCircle } from "@/components/Icons";
-import Tooltip from "@/components/Tooltip/Tooltip";
+import { GBAddCircle, GBInfo } from "@/components/Icons";
 import Field from "@/components/Forms/Field";
 import Link from "@/ui/Link";
 import Text from "@/ui/Text";
-import UiTooltip from "@/ui/Tooltip";
+import Tooltip from "@/ui/Tooltip";
 import styles from "./VariationsInput.module.scss";
 import ExperimentSplitVisual from "./ExperimentSplitVisual";
 import {
@@ -207,7 +200,12 @@ export default function FeatureVariationsInput({
           {!hideCoverage ? (
             <div className="px-3 pt-3 bg-highlight rounded mb-3">
               <label className="mb-0">
-                {coverageLabel} <Tooltip body={coverageTooltip} />
+                {coverageLabel}{" "}
+                <Tooltip content={coverageTooltip} side="top">
+                  <Box display="inline-block">
+                    <GBInfo />
+                  </Box>
+                </Tooltip>
               </label>
               <div className="row align-items-center pb-3 mx-1">
                 <div className="col pl-0">
@@ -288,7 +286,12 @@ export default function FeatureVariationsInput({
           {!hideCoverage ? (
             <div className="px-3 pt-3 bg-highlight rounded mb-3">
               <label className="mb-0">
-                {coverageLabel} <Tooltip body={coverageTooltip} />
+                {coverageLabel}{" "}
+                <Tooltip content={coverageTooltip} side="top">
+                  <Box display="inline-block">
+                    <GBInfo />
+                  </Box>
+                </Tooltip>
               </label>
               <div className="row align-items-center pb-3 mx-1">
                 <div className="col pl-0">
@@ -388,29 +391,26 @@ export default function FeatureVariationsInput({
                         !disableCustomSplit &&
                         !editingSplits &&
                         !onlySafeToEditVariationMetadata && (
-                          <UiTooltip content="Click to unlock split…" side="top">
-                            <a
-                              role="button"
-                              className="ml-1 mb-0"
-                              onClick={() => {
+                          <Tooltip content="Customize split" side="top">
+                            <Link
+                              onClick={(e) => {
+                                e.preventDefault();
                                 setEditingSplits(true);
                               }}
+                              ml="1"
+                              aria-label="Customize split"
                             >
-                              <PiLockSimpleFill
-                                className="text-purple"
-                                size={15}
-                              />
-                            </a>
-                          </UiTooltip>
+                              <PiLockSimpleFill size={15} />
+                            </Link>
+                          </Tooltip>
                         )}
                       {editingSplits &&
                         !isEqualWeights &&
                         !disableCustomSplit &&
                         !hideSplits && (
                           <Tooltip
-                            body="Assign equal weights to all variations"
-                            usePortal={true}
-                            tipPosition="top"
+                            content="Assign equal weights to all variations"
+                            side="top"
                           >
                             <a
                               role="button"
@@ -494,7 +494,10 @@ export default function FeatureVariationsInput({
                           )}
                           {valueType === "boolean" && (
                             <>
-                              <Tooltip body="Boolean features can only have two variations. Use a different feature type to add multiple variations.">
+                              <Tooltip
+                                content="Boolean features can only have two variations. Use a different feature type to add multiple variations."
+                                side="top"
+                              >
                                 <Link
                                   style={{
                                     cursor: "not-allowed",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

Fixes the hover tooltip on the Split lock icon in `FeatureVariationsInput` so users can tell the control is interactive. The legacy `Tooltip` component we were using was not rendering within the new `Modal` component so now we're using `ui/Tooltip`

### Dependencies

None

### Testing

1. Open any experiment or feature flow that shows `FeatureVariationsInput` with the Split column (for example, creating a new experiment).
2. Hover the purple lock icon next to **Split**.
3. Confirm a tooltip is rendered
4. Click the lock and confirm custom split editing still unlocks as before.

### Screenshots

<img width="261" height="134" alt="Screenshot 2026-08-12 at 10 34 54 AM" src="https://github.com/user-attachments/assets/db0f7294-8f37-45d0-b596-ad96c6c185ba" />
