### PR TITLE
Document tracking callback user context across JS SDKs

### DIFF
--- a/docs/docs/lib/js.mdx
+++ b/docs/docs/lib/js.mdx
@@ -385,7 +385,7 @@ const gb = new GrowthBook({
 });
 ```
 
-Starting in version 1.7.0, the callback receives a third `user` argument: a `TrackingUserContext` containing the `attributes` and optional `url` used when the experiment was evaluated. We recommend tracking attributes from this argument instead of reading them from the current GrowthBook instance or application state, since those may have changed since the evaluation.
+Starting in version 1.7.0, the callback receives a third `user` argument: a `TrackingUserContext` containing the `attributes` and optional `url` used when the experiment was evaluated. We recommend recording attributes from this argument so exposure events consistently reflect the attributes GrowthBook used for targeting and assignment.
 
 This same tracking callback is used for both feature flag experiments and Visual Editor experiments.
 
@@ -465,11 +465,13 @@ Sometimes, your analytics tracker is loaded after GrowthBook. In that case, you 
 
 There are some scenarios where you need to queue up tracking calls in one GrowthBook instance and fire them in another. For example, if your analytics tracker is only available on the front-end, but you are running experiments in Node.js.
 
-Export the queued tracking calls with the `getDeferredTrackingCalls()` method. The result is a serializable JSON object containing the experiment, result, and user context from evaluation time:
+Export the queued tracking calls with the `getDeferredTrackingCalls()` method. The result is a serializable JSON object containing the experiment, result, and `user` context captured during evaluation:
 
 ```ts
 const tracks = gb.getDeferredTrackingCalls();
 ```
+
+When these calls are serialized and sent between a server and client, the captured `user` context is passed as the third argument to the tracking callback. Deferred calls created by SDK versions earlier than 1.7.0 may not include `user`.
 
 Then, import with `setDeferredTrackingCalls`. This does not fire them automatically. You must call `fireDeferredTrackingCalls` after.
 

--- a/docs/docs/lib/js.mdx
+++ b/docs/docs/lib/js.mdx
@@ -42,10 +42,11 @@ const gb = new GrowthBook({
   },
   // Only required for A/B testing
   // Called every time a user is put into an experiment
-  trackingCallback: (experiment, result) => {
+  trackingCallback: (experiment, result, user) => {
     console.log("Experiment Viewed", {
       experimentId: experiment.key,
       variationId: result.key,
+      attributes: user?.attributes,
     });
   },
 });
@@ -373,15 +374,18 @@ In order to run A/B tests, you need to set up a tracking callback function. This
 const gb = new GrowthBook({
   apiHost: "https://cdn.growthbook.io",
   clientKey: "sdk-abc123",
-  trackingCallback: (experiment, result) => {
+  trackingCallback: (experiment, result, user) => {
     // Example using Segment
     analytics.track("Experiment Viewed", {
       experimentId: experiment.key,
       variationId: result.key,
+      attributes: user?.attributes,
     });
   },
 });
 ```
+
+Starting in version 1.7.0, the callback receives a third `user` argument: a `TrackingUserContext` containing the `attributes` and optional `url` used when the experiment was evaluated. We recommend tracking attributes from this argument instead of reading them from the current GrowthBook instance or application state, since those may have changed since the evaluation.
 
 This same tracking callback is used for both feature flag experiments and Visual Editor experiments.
 
@@ -461,7 +465,7 @@ Sometimes, your analytics tracker is loaded after GrowthBook. In that case, you 
 
 There are some scenarios where you need to queue up tracking calls in one GrowthBook instance and fire them in another. For example, if your analytics tracker is only available on the front-end, but you are running experiments in Node.js.
 
-Export the queue tracking calls with the `getDeferredTrackingCalls()` method. The result is a serializable JSON object:
+Export the queued tracking calls with the `getDeferredTrackingCalls()` method. The result is a serializable JSON object containing the experiment, result, and user context from evaluation time:
 
 ```ts
 const tracks = gb.getDeferredTrackingCalls();

--- a/docs/docs/lib/node.mdx
+++ b/docs/docs/lib/node.mdx
@@ -322,7 +322,7 @@ You can specify this globally in your GrowthBookClient class and/or per-request 
 
 We recommend using a global callback if you plan to track events directly from Node and using a user context callback if you plan to send events to the front-end to fire.
 
-When specified globally, the callbacks will receive an additional argument with the user context that triggered the event.
+Starting in version 1.7.0, tracking callbacks receive a third `userContext` argument: a `TrackingUserContext` containing the `attributes` and optional `url` used when the experiment was evaluated. We recommend tracking attributes from this argument instead of reading them from the request or other application state, since those may differ from the attributes GrowthBook used for the evaluation.
 
 ```js
 // Callback configured globally
@@ -332,7 +332,8 @@ const gbClient = new GrowthBookClient({
 
     console.log("Viewed Experiment", userId, {
       experimentId: experiment.key,
-      variationId: result.key
+      variationId: result.key,
+      attributes: userContext.attributes,
     });
   }
 });
@@ -342,10 +343,11 @@ const userContext = {
   attributes: {
     id: req.user.id
   },
-  trackingCallback: (experiment, result) => {
-    console.log("Viewed Experiment", req.user.id, {
+  trackingCallback: (experiment, result, userContext) => {
+    console.log("Viewed Experiment", userContext.attributes.id, {
       experimentId: experiment.key,
-      variationId: result.key
+      variationId: result.key,
+      attributes: userContext.attributes,
     });
   }
 }
@@ -376,8 +378,8 @@ app.use((req, res, next) => {
   req.trackingData = [];
   const userContext = {
     attributes: {id: "123"},
-    trackingCallback: (experiment, result) => {
-      req.trackingData.push({experiment, result});
+    trackingCallback: (experiment, result, userContext) => {
+      req.trackingData.push({experiment, result, user: userContext});
     }
   }
   req.growthbook = gbClient.createScopedInstance(userContext);
@@ -392,11 +394,12 @@ app.get("/", (req, res) => {
       (function() {
         const data = ${JSON.stringify(req.trackingData)};
 
-        data.forEach(({experiment, result}) => {
+        data.forEach(({experiment, result, user}) => {
           // Example using Segment.io
           analytics.track("Experiment Viewed", {
             experimentId: experiment.key,
             variationId: result.key,
+            attributes: user.attributes,
           });
         })
       })();

--- a/docs/docs/lib/node.mdx
+++ b/docs/docs/lib/node.mdx
@@ -322,7 +322,7 @@ You can specify this globally in your GrowthBookClient class and/or per-request 
 
 We recommend using a global callback if you plan to track events directly from Node and using a user context callback if you plan to send events to the front-end to fire.
 
-Starting in version 1.7.0, tracking callbacks receive a third `userContext` argument: a `TrackingUserContext` containing the `attributes` and optional `url` used when the experiment was evaluated. We recommend tracking attributes from this argument instead of reading them from the request or other application state, since those may differ from the attributes GrowthBook used for the evaluation.
+Starting in version 1.7.0, tracking callbacks receive a third `userContext` argument: a `TrackingUserContext` containing the `attributes` and optional `url` used when the experiment was evaluated. We recommend recording attributes from this argument so exposure events consistently reflect the attributes GrowthBook used for targeting and assignment.
 
 ```js
 // Callback configured globally

--- a/docs/docs/lib/quickstart.mdx
+++ b/docs/docs/lib/quickstart.mdx
@@ -194,7 +194,8 @@ const gbClient = new GrowthBookClient({
     // TODO: Replace with your own tracking implementation
     console.log("Viewed Experiment", userId, {
       experimentId: experiment.key,
-      variationId: result.key
+      variationId: result.key,
+      attributes: userContext.attributes,
     });
   }
 });

--- a/docs/docs/lib/react-native.mdx
+++ b/docs/docs/lib/react-native.mdx
@@ -360,7 +360,7 @@ const gb = new GrowthBook({
 });
 ```
 
-Starting in version 1.7.0, the callback receives a third `user` argument: a `TrackingUserContext` containing the `attributes` and optional `url` used when the experiment was evaluated. We recommend tracking attributes from this argument instead of reading them from the current GrowthBook instance or application state, since those may have changed since the evaluation.
+Starting in version 1.7.0, the callback receives a third `user` argument: a `TrackingUserContext` containing the `attributes` and optional `url` used when the experiment was evaluated. We recommend recording attributes from this argument so exposure events consistently reflect the attributes GrowthBook used for targeting and assignment.
 
 This same tracking callback is used for both feature flag experiments and Visual Editor experiments.
 

--- a/docs/docs/lib/react-native.mdx
+++ b/docs/docs/lib/react-native.mdx
@@ -37,10 +37,11 @@ const gb = new GrowthBook({
   clientKey: "sdk-abc123",
   // Only required for A/B testing
   // Called every time a user is put into an experiment
-  trackingCallback: (experiment, result) => {
+  trackingCallback: (experiment, result, user) => {
     console.log("Experiment Viewed", {
       experimentId: experiment.key,
       variationId: result.key,
+      attributes: user?.attributes,
     });
   },
 });
@@ -348,15 +349,18 @@ In order to run A/B tests, you need to set up a tracking callback function. This
 const gb = new GrowthBook({
   apiHost: "https://cdn.growthbook.io",
   clientKey: "sdk-abc123",
-  trackingCallback: (experiment, result) => {
+  trackingCallback: (experiment, result, user) => {
     // Example using Segment
     analytics.track("Experiment Viewed", {
       experimentId: experiment.key,
       variationId: result.key,
+      attributes: user?.attributes,
     });
   },
 });
 ```
+
+Starting in version 1.7.0, the callback receives a third `user` argument: a `TrackingUserContext` containing the `attributes` and optional `url` used when the experiment was evaluated. We recommend tracking attributes from this argument instead of reading them from the current GrowthBook instance or application state, since those may have changed since the evaluation.
 
 This same tracking callback is used for both feature flag experiments and Visual Editor experiments.
 

--- a/docs/docs/lib/react.mdx
+++ b/docs/docs/lib/react.mdx
@@ -43,10 +43,11 @@ const gb = new GrowthBook({
   enableDevMode: true,
   // Only required for A/B testing
   // Called every time a user is put into an experiment
-  trackingCallback: (experiment, result) => {
+  trackingCallback: (experiment, result, user) => {
     console.log("Experiment Viewed", {
       experimentId: experiment.key,
       variationId: result.key,
+      attributes: user?.attributes,
     });
   },
 });
@@ -478,15 +479,18 @@ In order to run A/B tests, you need to set up a tracking callback function. This
 const gb = new GrowthBook({
   apiHost: "https://cdn.growthbook.io",
   clientKey: "sdk-abc123",
-  trackingCallback: (experiment, result) => {
+  trackingCallback: (experiment, result, user) => {
     // Example using Segment
     analytics.track("Experiment Viewed", {
       experimentId: experiment.key,
       variationId: result.key,
+      attributes: user?.attributes,
     });
   },
 });
 ```
+
+Starting in version 1.7.0, the callback receives a third `user` argument: a `TrackingUserContext` containing the `attributes` and optional `url` used when the experiment was evaluated. We recommend tracking attributes from this argument instead of reading them from the current GrowthBook instance or application state, since those may have changed since the evaluation.
 
 This same tracking callback is used for both feature flag experiments and Visual Editor experiments.
 
@@ -689,10 +693,11 @@ export default function GrowthBookWrapper({
         apiHost: process.env.NEXT_PUBLIC_GROWTHBOOK_API_HOST,
         clientKey: process.env.NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY,
         decryptionKey: process.env.NEXT_PUBLIC_GROWTHBOOK_DECRYPTION_KEY,
-        trackingCallback: (experiment, result) => {
+        trackingCallback: (experiment, result, user) => {
           console.log("Viewed Experiment", {
             experimentId: experiment.key,
-            variationId: result.key
+            variationId: result.key,
+            attributes: user?.attributes,
           });
         },
         // Targeting attributes
@@ -874,10 +879,11 @@ export default function MyPage({ payload }) {
         apiHost: process.env.NEXT_PUBLIC_GROWTHBOOK_API_HOST,
         clientKey: process.env.NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY,
         decryptionKey: process.env.NEXT_PUBLIC_GROWTHBOOK_DECRYPTION_KEY,
-        trackingCallback: (experiment, result) => {
+        trackingCallback: (experiment, result, user) => {
           console.log("Viewed Experiment", {
             experimentId: experiment.key,
-            variationId: result.key
+            variationId: result.key,
+            attributes: user?.attributes,
           });
         },
         attributes: {

--- a/docs/docs/lib/react.mdx
+++ b/docs/docs/lib/react.mdx
@@ -490,7 +490,7 @@ const gb = new GrowthBook({
 });
 ```
 
-Starting in version 1.7.0, the callback receives a third `user` argument: a `TrackingUserContext` containing the `attributes` and optional `url` used when the experiment was evaluated. We recommend tracking attributes from this argument instead of reading them from the current GrowthBook instance or application state, since those may have changed since the evaluation.
+Starting in version 1.7.0, the callback receives a third `user` argument: a `TrackingUserContext` containing the `attributes` and optional `url` used when the experiment was evaluated. We recommend recording attributes from this argument so exposure events consistently reflect the attributes GrowthBook used for targeting and assignment.
 
 This same tracking callback is used for both feature flag experiments and Visual Editor experiments.
 

--- a/docs/docs/lib/script-tag.mdx
+++ b/docs/docs/lib/script-tag.mdx
@@ -177,10 +177,11 @@ mixpanel.init("[YOUR PROJECT TOKEN]", {
    })
   },
 });
-window.growthbook_config.trackingCallback = (experiment, result) => {
+window.growthbook_config.trackingCallback = (experiment, result, user) => {
     mixpanel.track("$experiment_started", {
       "Experiment name": experiment.key,
       "Variant name": result.variationId,
+      "GrowthBook attributes": user?.attributes,
       $source: "growthbook",
     });
 </script>
@@ -195,13 +196,16 @@ window.growthbook_config.trackingCallback = (experiment, result) => {
 
 For any other event tracking system (or if the built-in ones above do not meet your requirements), you can define your own custom tracking callback function. This must be defined _BEFORE_ loading the main GrowthBook snippet on the page.
 
+Starting in version 1.7.0, the callback receives a third `user` argument containing the `attributes` and optional `url` used when the experiment was evaluated. We recommend tracking attributes from this argument instead of reading them from the current GrowthBook instance or application state, since those may have changed since the evaluation.
+
 ```html
 <script>
 window.growthbook_config = window.growthbook_config || {};
-window.growthbook_config.trackingCallback = (experiment, result) => {
+window.growthbook_config.trackingCallback = (experiment, result, user) => {
   customEventTracker("Viewed Experiment", {
     experiment_id: experiment.key,
-    variation_id: result.key
+    variation_id: result.key,
+    attributes: user?.attributes
   })
 };
 </script>

--- a/docs/docs/lib/script-tag.mdx
+++ b/docs/docs/lib/script-tag.mdx
@@ -196,7 +196,7 @@ window.growthbook_config.trackingCallback = (experiment, result, user) => {
 
 For any other event tracking system (or if the built-in ones above do not meet your requirements), you can define your own custom tracking callback function. This must be defined _BEFORE_ loading the main GrowthBook snippet on the page.
 
-Starting in version 1.7.0, the callback receives a third `user` argument containing the `attributes` and optional `url` used when the experiment was evaluated. We recommend tracking attributes from this argument instead of reading them from the current GrowthBook instance or application state, since those may have changed since the evaluation.
+Starting in version 1.7.0, the callback receives a third `user` argument containing the `attributes` and optional `url` used when the experiment was evaluated. We recommend recording attributes from this argument so exposure events consistently reflect the attributes GrowthBook used for targeting and assignment.
 
 ```html
 <script>

--- a/packages/sdk-js/README.md
+++ b/packages/sdk-js/README.md
@@ -318,7 +318,7 @@ const gb = new GrowthBook({
 });
 ```
 
-Starting in version 1.7.0, the callback receives a third `user` argument: a `TrackingUserContext` containing the `attributes` and optional `url` used when the experiment was evaluated. We recommend tracking attributes from this argument instead of reading them from the current GrowthBook instance or application state, since those may have changed since the evaluation.
+Starting in version 1.7.0, the callback receives a third `user` argument: a `TrackingUserContext` containing the `attributes` and optional `url` used when the experiment was evaluated. We recommend recording attributes from this argument so exposure events consistently reflect the attributes GrowthBook used for targeting and assignment.
 
 This same tracking callback is used for both feature flag experiments and Visual Editor experiments.
 

--- a/packages/sdk-js/README.md
+++ b/packages/sdk-js/README.md
@@ -58,10 +58,11 @@ const gb = new GrowthBook({
   },
   // Only required for A/B testing
   // Called every time a user is put into an experiment
-  trackingCallback: (experiment, result) => {
+  trackingCallback: (experiment, result, user) => {
     console.log("Experiment Viewed", {
       experimentId: experiment.key,
       variationId: result.key,
+      attributes: user?.attributes,
     });
   },
 });
@@ -198,6 +199,7 @@ const gb = new GrowthBookClient({
     console.log("Experiment Viewed", user.attributes.id, {
       experimentId: experiment.key,
       variationId: result.key,
+      attributes: user?.attributes,
     });
   },
 });
@@ -210,10 +212,11 @@ const userContext = {
   attributes: {
     id: req.user.id,
   },
-  trackingCallback: (experiment, result) => {
-    console.log("Experiment Viewed", req.user.id, {
+  trackingCallback: (experiment, result, user) => {
+    console.log("Experiment Viewed", user?.attributes.id, {
       experimentId: experiment.key,
       variationId: result.key,
+      attributes: user?.attributes,
     });
   },
 };
@@ -304,15 +307,18 @@ In order to run A/B tests, you need to set up a tracking callback function. This
 const gb = new GrowthBook({
   apiHost: "https://cdn.growthbook.io",
   clientKey: "sdk-abc123",
-  trackingCallback: (experiment, result) => {
+  trackingCallback: (experiment, result, user) => {
     // Example using Segment
     analytics.track("Experiment Viewed", {
       experimentId: experiment.key,
       variationId: result.key,
+      attributes: user?.attributes,
     });
   },
 });
 ```
+
+Starting in version 1.7.0, the callback receives a third `user` argument: a `TrackingUserContext` containing the `attributes` and optional `url` used when the experiment was evaluated. We recommend tracking attributes from this argument instead of reading them from the current GrowthBook instance or application state, since those may have changed since the evaluation.
 
 This same tracking callback is used for both feature flag experiments and Visual Editor experiments.
 

--- a/packages/sdk-react/README.md
+++ b/packages/sdk-react/README.md
@@ -51,10 +51,11 @@ const gb = new GrowthBook({
   subscribeToChanges: true,
   // Only required for A/B testing
   // Called every time a user is put into an experiment
-  trackingCallback: (experiment, result) => {
+  trackingCallback: (experiment, result, user) => {
     console.log("Experiment Viewed", {
       experimentId: experiment.key,
       variationId: result.key,
+      attributes: user?.attributes,
     });
   },
 });
@@ -242,15 +243,18 @@ In order to run A/B tests, you need to set up a tracking callback function. This
 const gb = new GrowthBook({
   apiHost: "https://cdn.growthbook.io",
   clientKey: "sdk-abc123",
-  trackingCallback: (experiment, result) => {
+  trackingCallback: (experiment, result, user) => {
     // Example using Segment
     analytics.track("Experiment Viewed", {
       experimentId: experiment.key,
       variationId: result.key,
+      attributes: user?.attributes,
     });
   },
 });
 ```
+
+Starting in version 1.7.0, the callback receives a third `user` argument: a `TrackingUserContext` containing the `attributes` and optional `url` used when the experiment was evaluated. We recommend tracking attributes from this argument instead of reading them from the current GrowthBook instance or application state, since those may have changed since the evaluation.
 
 This same tracking callback is used for both feature flag experiments and Visual Editor experiments.
 

--- a/packages/sdk-react/README.md
+++ b/packages/sdk-react/README.md
@@ -254,7 +254,7 @@ const gb = new GrowthBook({
 });
 ```
 
-Starting in version 1.7.0, the callback receives a third `user` argument: a `TrackingUserContext` containing the `attributes` and optional `url` used when the experiment was evaluated. We recommend tracking attributes from this argument instead of reading them from the current GrowthBook instance or application state, since those may have changed since the evaluation.
+Starting in version 1.7.0, the callback receives a third `user` argument: a `TrackingUserContext` containing the `attributes` and optional `url` used when the experiment was evaluated. We recommend recording attributes from this argument so exposure events consistently reflect the attributes GrowthBook used for targeting and assignment.
 
 This same tracking callback is used for both feature flag experiments and Visual Editor experiments.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

- Document the third `trackingCallback` argument added in JS/React SDK 1.7.0.
- Recommend recording attributes from the callback context so exposure events reflect the attributes GrowthBook used for targeting and assignment.
- Clarify that deferred tracking snapshots and serializes the `user` context, then supplies it as the third callback argument when fired.
- Update JavaScript, React, React Native, Node.js, Script Tag, quickstart, and package README examples.
- Leave Vercel Flags and Edge SDK docs unchanged because they do not yet support this callback argument.

### Dependencies

None.

### Testing

- `pnpm --filter @growthbook/growthbook test contextual-bandit.test.ts --runInBand` (18 tests passed, including deferred context preservation)
- `pnpm exec prettier --check` on all changed documentation files
- `pnpm build` in `docs/` (successful static production build; existing unrelated broken-anchor and Sass deprecation warnings remain)
- Manually verified the revised recommendation and Deferred Tracking section

### Walkthrough

[js_sdk_callback_context_correction_demo.mp4](https://cursor.com/agents/bc-c65e33ba-e419-517d-b6bb-23d0e90488bb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjs_sdk_callback_context_correction_demo.mp4)

### Screenshots

Not applicable; content-only documentation changes.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C0A9B5W8LMN/p1786548588200149?thread_ts=1786548588.200149&cid=C0A9B5W8LMN)

<div><a href="https://cursor.com/agents/bc-c65e33ba-e419-517d-b6bb-23d0e90488bb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c65e33ba-e419-517d-b6bb-23d0e90488bb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

