### PR TITLE
Automate sdk-versions: dispatch receiver + capabilities + verify

### DIFF
--- a/.github/scripts/apply-sdk-capabilities.sh
+++ b/.github/scripts/apply-sdk-capabilities.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Validate a comma-separated capability list against the SDKCapability union in
+# packages/shared/src/sdk-versioning/types.ts and set it on a specific version
+# entry in that SDK's sdk-versions JSON.
+#
+# Usage: apply-sdk-capabilities.sh <repo_root> <sdk> <version> <capabilities_csv>
+#
+# Exit codes:
+#   0  capabilities applied (edited the JSON)
+#   2  empty capability list -> nothing to do (version-only)
+#   3  one or more capabilities are not in types.ts (no changes made)
+#   1  usage / structural error
+#
+# On success (0) and no-op (2) it prints "applied=<csv>" so the caller can echo
+# it back. On rejection (3) it prints "invalid=<csv>".
+set -euo pipefail
+
+ROOT="${1:?repo_root}"
+SDK="${2:?sdk}"
+VERSION="${3:?version}"
+CSV="${4-}"
+
+TYPES="$ROOT/packages/shared/src/sdk-versioning/types.ts"
+[ -f "$TYPES" ] || { echo "types.ts not found at $TYPES" >&2; exit 1; }
+
+# SDK key -> filename (a few keys don't map 1:1 to their file).
+case "$SDK" in
+  android)  FILE_STEM=kotlin ;;
+  ios)      FILE_STEM=swift ;;
+  nocode-*) FILE_STEM=nocode ;;
+  *)        FILE_STEM="$SDK" ;;
+esac
+FILE="$ROOT/packages/shared/src/sdk-versioning/sdk-versions/$FILE_STEM.json"
+[ -f "$FILE" ] || { echo "no sdk-versions file for '$SDK' ($FILE)" >&2; exit 1; }
+
+# The version entry the PR added must exist.
+if ! jq -e --arg v "$VERSION" '.versions[] | select(.version == $v)' "$FILE" >/dev/null; then
+  echo "version $VERSION not present in $FILE" >&2; exit 1
+fi
+
+# The single source of truth for valid capabilities: the SDKCapability union.
+VALID="$(sed -n '/export type SDKCapability =/,/;/p' "$TYPES" | grep -oE '"[A-Za-z0-9]+"' | tr -d '"')"
+
+# Parse + trim the CSV. Empty -> no-op (version-only).
+CLEANED="$(echo "$CSV" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | grep -v '^$' || true)"
+if [ -z "$CLEANED" ]; then
+  echo "applied="
+  exit 2
+fi
+
+invalid=""
+while IFS= read -r cap; do
+  grep -qx "$cap" <<< "$VALID" || invalid="${invalid:+$invalid, }$cap"
+done <<< "$CLEANED"
+
+if [ -n "$invalid" ]; then
+  echo "invalid=$invalid"
+  exit 3
+fi
+
+# Build a JSON array from the validated, de-duplicated (order-preserving) list.
+CAPS_JSON="$(echo "$CLEANED" | awk '!seen[$0]++' | jq -R . | jq -sc .)"
+
+# Set capabilities on exactly the target version entry. `(...) |= ` mutates in place.
+tmp="$(mktemp)"
+jq --arg v "$VERSION" --argjson caps "$CAPS_JSON" \
+  '(.versions[] | select(.version == $v)).capabilities = $caps' "$FILE" > "$tmp"
+mv "$tmp" "$FILE"
+
+echo "applied=$(echo "$CLEANED" | awk '!seen[$0]++' | paste -sd ',' -)"
+exit 0

--- a/.github/workflows/sdk-version-capabilities.yml
+++ b/.github/workflows/sdk-version-capabilities.yml
@@ -5,31 +5,64 @@ name: SDK version capabilities
 #
 #     /capabilities streaming, redirects
 #
-# and this workflow validates each token against the SDKCapability union in
-# types.ts, sets them on that version entry, regenerates the SDK docs, and
-# commits everything back to the PR branch. An empty `/capabilities` records
-# the release as version-only. Unknown capabilities are rejected with a comment
-# and nothing is changed (so gen-sdk-resources can never be fed a bad value).
+# It validates each token against the SDKCapability union in types.ts, sets them
+# on that version entry, regenerates SDKInfo.ts (the same generator the pre-commit
+# hook runs on any sdk-versioning change), and commits back to the PR branch. An
+# empty `/capabilities` records the release as version-only. Unknown capabilities
+# are rejected with a comment and nothing changes.
 #
-# NOTE: issue_comment workflows only run from the copy on the default branch,
-# so this takes effect once merged to main.
+# Security model (this command has write access and commits/pushes, and it runs
+# the checked-out branch's build/generators):
+#   - authorize job: the commenter must be OWNER/MEMBER/COLLABORATOR
+#     (author_association is set by GitHub and cannot be spoofed).
+#   - same-repo only: cross-repository (fork) PRs are skipped, so fork-controlled
+#     code is never executed with the write token. Same-repo `sdk-version/*`
+#     branches can only be pushed by write-access users (the release bot), so the
+#     residual is limited to repo insiders, which the ChatOps model already trusts.
 #
-# The commit is pushed with SDK_VERSION_BOT_TOKEN (a PAT) when available so the
-# verify-sdk-versions check re-runs on the new commit; it falls back to
-# GITHUB_TOKEN (push works, but the required check won't re-trigger).
+# NOTE: issue_comment workflows only run from the copy on the default branch, so
+# this takes effect once merged to main.
 
 on:
   issue_comment:
     types: [created]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
-  capabilities:
+  authorize:
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/capabilities') }}
     runs-on: ubuntu-latest
+    outputs:
+      ok: ${{ steps.check.outputs.ok }}
+    steps:
+      - name: Require trusted commenter + same-repo PR
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.issue.number }}
+          ASSOC: ${{ github.event.comment.author_association }}
+        run: |
+          set -euo pipefail
+          cross="$(gh pr view "$PR" -R "$REPO" --json isCrossRepository --jq '.isCrossRepository')"
+          echo "author_association=$ASSOC cross_repo=$cross"
+          ok=false
+          case "$ASSOC" in
+            OWNER|MEMBER|COLLABORATOR) [[ "$cross" == "false" ]] && ok=true ;;
+          esac
+          echo "ok=$ok" >> "$GITHUB_OUTPUT"
+          [[ "$ok" == "true" ]] || echo "Not authorized ($ASSOC, cross_repo=$cross) — skipping."
+
+  capabilities:
+    needs: authorize
+    if: ${{ needs.authorize.outputs.ok == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v5
         with:
@@ -65,8 +98,8 @@ jobs:
           set -uo pipefail
           # Strip the command word from the first line; the rest is the CSV.
           CSV="$(printf '%s\n' "$COMMENT" | head -n1 | sed -E 's#^/capabilities##')"
-          # GitHub runs steps with `bash -e`; the apply script exits 2/3 by design,
-          # so guard with `|| code=$?` to capture the code instead of aborting.
+          # GitHub runs steps with `bash -e`; the apply script exits 1/2/3 by
+          # design, so guard with `|| code=$?` to capture the code, not abort.
           code=0
           out="$(bash .github/scripts/apply-sdk-capabilities.sh "$PWD" "$SDK" "$VERSION" "$CSV")" || code=$?
           echo "$out"
@@ -74,7 +107,6 @@ jobs:
             echo "result=$out"
             echo "code=$code"
           } >> "$GITHUB_OUTPUT"
-          exit 0
 
       - name: Reject unknown capabilities
         if: ${{ steps.apply.outputs.code == '3' }}
@@ -84,6 +116,15 @@ jobs:
           RESULT: ${{ steps.apply.outputs.result }}
         run: |
           gh pr comment "$PR" --body "❌ Unknown capabilities: **${RESULT#invalid=}**. Valid values come from \`packages/shared/src/sdk-versioning/types.ts\`. No changes made."
+
+      - name: Fail on structural error
+        if: ${{ steps.pr.outputs.skip != 'true' && steps.apply.outputs.code != '0' && steps.apply.outputs.code != '2' && steps.apply.outputs.code != '3' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+          CODE: ${{ steps.apply.outputs.code }}
+        run: |
+          gh pr comment "$PR" --body "⚠️ \`/capabilities\` could not run (internal error, exit \`$CODE\`). No changes made — please check the workflow logs."
           exit 1
 
       - name: Acknowledge version-only
@@ -91,7 +132,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.issue.number }}
-        run: gh pr comment "$PR" --body "No capabilities given — recording this release as version-only. Ready to merge."
+        run: |
+          gh pr comment "$PR" --body "No capabilities given — recording this release as version-only. Ready to merge."
 
       - name: Set up pnpm
         if: ${{ steps.apply.outputs.code == '0' }}
@@ -116,10 +158,10 @@ jobs:
           set -euo pipefail
           caps="${RESULT#applied=}"
           pnpm install
-          # This mirrors the repo's pre-commit hook, which runs
-          # `gen-sdk-resources-for-docs` on any sdk-versioning change to regenerate
-          # docs/src/data/SDKInfo.ts. That generator needs the JS SDK built first.
-          # CAPABILITIES.md is intentionally not regenerated (not in the hook).
+          # Mirrors the pre-commit hook, which runs gen-sdk-resources-for-docs on
+          # any sdk-versioning change to regenerate docs/src/data/SDKInfo.ts. That
+          # generator needs the JS SDK built first. CAPABILITIES.md is intentionally
+          # not regenerated (it is not part of the hook).
           pnpm --filter @growthbook/growthbook run build
           pnpm exec prettier --write "packages/shared/src/sdk-versioning/sdk-versions/$SDK.json"
           pnpm --filter shared gen-sdk-resources-for-docs

--- a/.github/workflows/sdk-version-capabilities.yml
+++ b/.github/workflows/sdk-version-capabilities.yml
@@ -1,0 +1,123 @@
+name: SDK version capabilities
+
+# ChatOps for the auto-generated sdk-versions PRs. On a PR whose branch is
+# `sdk-version/<sdk>-<x.y.z>`, a maintainer comments:
+#
+#     /capabilities streaming, redirects
+#
+# and this workflow validates each token against the SDKCapability union in
+# types.ts, sets them on that version entry, regenerates the SDK docs, and
+# commits everything back to the PR branch. An empty `/capabilities` records
+# the release as version-only. Unknown capabilities are rejected with a comment
+# and nothing is changed (so gen-sdk-resources can never be fed a bad value).
+#
+# NOTE: issue_comment workflows only run from the copy on the default branch,
+# so this takes effect once merged to main.
+#
+# The commit is pushed with SDK_VERSION_BOT_TOKEN (a PAT) when available so the
+# verify-sdk-versions check re-runs on the new commit; it falls back to
+# GITHUB_TOKEN (push works, but the required check won't re-trigger).
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  capabilities:
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/capabilities') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.SDK_VERSION_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Check out the PR branch and parse sdk/version
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.SDK_VERSION_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          gh pr checkout "$PR"
+          head="$(git rev-parse --abbrev-ref HEAD)"
+          if [[ ! "$head" =~ ^sdk-version/(.+)-([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "PR branch '$head' is not sdk-version/<sdk>-<x.y.z>; ignoring."
+            echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          {
+            echo "sdk=${BASH_REMATCH[1]}"
+            echo "version=${BASH_REMATCH[2]}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate + apply capabilities to the JSON
+        if: ${{ steps.pr.outputs.skip != 'true' }}
+        id: apply
+        env:
+          COMMENT: ${{ github.event.comment.body }}
+          SDK: ${{ steps.pr.outputs.sdk }}
+          VERSION: ${{ steps.pr.outputs.version }}
+        run: |
+          set -uo pipefail
+          # Strip the command word from the first line; the rest is the CSV.
+          CSV="$(printf '%s\n' "$COMMENT" | head -n1 | sed -E 's#^/capabilities##')"
+          out="$(bash .github/scripts/apply-sdk-capabilities.sh "$PWD" "$SDK" "$VERSION" "$CSV")"; code=$?
+          echo "$out"
+          echo "result=$out" >> "$GITHUB_OUTPUT"
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Reject unknown capabilities
+        if: ${{ steps.apply.outputs.code == '3' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+          RESULT: ${{ steps.apply.outputs.result }}
+        run: |
+          gh pr comment "$PR" --body "❌ Unknown capabilities: **${RESULT#invalid=}**. Valid values come from \`packages/shared/src/sdk-versioning/types.ts\`. No changes made."
+          exit 1
+
+      - name: Acknowledge version-only
+        if: ${{ steps.apply.outputs.code == '2' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+        run: gh pr comment "$PR" --body "No capabilities given — recording this release as version-only. Ready to merge."
+
+      - name: Set up pnpm
+        if: ${{ steps.apply.outputs.code == '0' }}
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node
+        if: ${{ steps.apply.outputs.code == '0' }}
+        uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Regenerate docs, commit, and comment
+        if: ${{ steps.apply.outputs.code == '0' }}
+        env:
+          GH_TOKEN: ${{ secrets.SDK_VERSION_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+          SDK: ${{ steps.pr.outputs.sdk }}
+          VERSION: ${{ steps.pr.outputs.version }}
+          RESULT: ${{ steps.apply.outputs.result }}
+        run: |
+          set -euo pipefail
+          caps="${RESULT#applied=}"
+          pnpm install
+          pnpm exec prettier --write "packages/shared/src/sdk-versioning/sdk-versions/$SDK.json" || \
+            pnpm exec prettier --write "packages/shared/src/sdk-versioning/sdk-versions/"*.json
+          pnpm --filter shared generate-sdk-report
+          pnpm --filter shared gen-sdk-resources-for-docs
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add packages/shared/src/sdk-versioning docs/src/data/SDKInfo.ts
+          git commit -m "chore(sdk-versions): $SDK $VERSION capabilities [$caps]"
+          git push
+          gh pr comment "$PR" --body "✅ Set capabilities **[$caps]** on \`$SDK\` $VERSION and regenerated SDK docs (\`CAPABILITIES.md\`, \`SDKInfo.ts\`)."

--- a/.github/workflows/sdk-version-capabilities.yml
+++ b/.github/workflows/sdk-version-capabilities.yml
@@ -99,7 +99,7 @@ jobs:
           node-version: "24"
           cache: "pnpm"
 
-      - name: Regenerate docs, commit, and comment
+      - name: Regenerate SDKInfo.ts, commit, and comment
         if: ${{ steps.apply.outputs.code == '0' }}
         env:
           GH_TOKEN: ${{ secrets.SDK_VERSION_BOT_TOKEN || secrets.GITHUB_TOKEN }}
@@ -111,13 +111,16 @@ jobs:
           set -euo pipefail
           caps="${RESULT#applied=}"
           pnpm install
-          pnpm exec prettier --write "packages/shared/src/sdk-versioning/sdk-versions/$SDK.json" || \
-            pnpm exec prettier --write "packages/shared/src/sdk-versioning/sdk-versions/"*.json
-          pnpm --filter shared generate-sdk-report
+          # This mirrors the repo's pre-commit hook, which runs
+          # `gen-sdk-resources-for-docs` on any sdk-versioning change to regenerate
+          # docs/src/data/SDKInfo.ts. That generator needs the JS SDK built first.
+          # CAPABILITIES.md is intentionally not regenerated (not in the hook).
+          pnpm --filter @growthbook/growthbook run build
+          pnpm exec prettier --write "packages/shared/src/sdk-versioning/sdk-versions/$SDK.json"
           pnpm --filter shared gen-sdk-resources-for-docs
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add packages/shared/src/sdk-versioning docs/src/data/SDKInfo.ts
+          git add packages/shared/src/sdk-versioning docs
           git commit -m "chore(sdk-versions): $SDK $VERSION capabilities [$caps]"
           git push
-          gh pr comment "$PR" --body "✅ Set capabilities **[$caps]** on \`$SDK\` $VERSION and regenerated SDK docs (\`CAPABILITIES.md\`, \`SDKInfo.ts\`)."
+          gh pr comment "$PR" --body "✅ Set capabilities **[$caps]** on \`$SDK\` $VERSION and regenerated \`SDKInfo.ts\`."

--- a/.github/workflows/sdk-version-capabilities.yml
+++ b/.github/workflows/sdk-version-capabilities.yml
@@ -65,10 +65,15 @@ jobs:
           set -uo pipefail
           # Strip the command word from the first line; the rest is the CSV.
           CSV="$(printf '%s\n' "$COMMENT" | head -n1 | sed -E 's#^/capabilities##')"
-          out="$(bash .github/scripts/apply-sdk-capabilities.sh "$PWD" "$SDK" "$VERSION" "$CSV")"; code=$?
+          # GitHub runs steps with `bash -e`; the apply script exits 2/3 by design,
+          # so guard with `|| code=$?` to capture the code instead of aborting.
+          code=0
+          out="$(bash .github/scripts/apply-sdk-capabilities.sh "$PWD" "$SDK" "$VERSION" "$CSV")" || code=$?
           echo "$out"
-          echo "result=$out" >> "$GITHUB_OUTPUT"
-          echo "code=$code" >> "$GITHUB_OUTPUT"
+          {
+            echo "result=$out"
+            echo "code=$code"
+          } >> "$GITHUB_OUTPUT"
           exit 0
 
       - name: Reject unknown capabilities

--- a/.github/workflows/sync-sdk-version.yml
+++ b/.github/workflows/sync-sdk-version.yml
@@ -1,0 +1,125 @@
+name: Sync SDK version
+
+# Receiver for SDK release notifications. An SDK repo (via the
+# growthbook/sdk-version-sync action) fires a repository_dispatch
+# (event_type: update-sdk-version) after it publishes. This workflow prepends the
+# new version to packages/shared/src/sdk-versioning/sdk-versions/<sdk>.json,
+# regenerates docs/src/data/SDKInfo.ts (the same generator the pre-commit hook
+# runs on any sdk-versioning change), and opens a PR. Generic over `sdk`.
+#
+# Trigger it two ways:
+#   - repository_dispatch: from an SDK release (or a manual `gh api ... /dispatches`).
+#   - workflow_dispatch: run by hand with sdk + version inputs.
+
+on:
+  repository_dispatch:
+    types: [update-sdk-version]
+  workflow_dispatch:
+    inputs:
+      sdk:
+        required: true
+        description: "SDK key, e.g. rust"
+      version:
+        required: true
+        description: "Released version, e.g. 0.2.1"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Prepend version (idempotent; no-op if not newer)
+        id: bump
+        env:
+          SDK: ${{ github.event.client_payload.sdk || inputs.sdk }}
+          VERSION: ${{ github.event.client_payload.version || inputs.version }}
+        run: |
+          set -euo pipefail
+          # Validate untrusted dispatch inputs: sdk becomes a filename, so keep
+          # it to a strict slug (no path traversal); version must be plain x.y.z.
+          if ! echo "$SDK" | grep -qE '^[a-z0-9-]+$'; then
+            echo "SDK '$SDK' is not a valid slug"; exit 1
+          fi
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Version '$VERSION' is not x.y.z"; exit 1
+          fi
+          # SDK key -> filename (a few keys don't map 1:1 to their file).
+          case "$SDK" in
+            android)  F=kotlin ;;
+            ios)      F=swift ;;
+            nocode-*) F=nocode ;;
+            *)        F="$SDK" ;;
+          esac
+          FILE="packages/shared/src/sdk-versioning/sdk-versions/$F.json"
+          if [ ! -f "$FILE" ]; then
+            echo "No sdk-versions file for '$SDK' ($FILE)"; exit 1
+          fi
+          CURRENT=$(jq -r '.versions[0].version' "$FILE")
+          # No-op if the version is already listed, or is not strictly newer than
+          # the current top entry (sort -V is version-aware: 0.2.10 > 0.2.9).
+          if jq -e --arg v "$VERSION" '.versions[] | select(.version == $v)' "$FILE" >/dev/null \
+             || [ "$(printf '%s\n%s\n' "$CURRENT" "$VERSION" | sort -V | tail -1)" != "$VERSION" ]; then
+            echo "$FILE already up to date ($VERSION <= $CURRENT); nothing to do."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Prepend a version-only entry. Capabilities (if any) are added later
+          # via the /capabilities comment — they can't be derived from a version.
+          jq --arg v "$VERSION" '.versions |= ([{version: $v}] + .)' "$FILE" > "$FILE.tmp"
+          mv "$FILE.tmp" "$FILE"
+          {
+            echo "changed=true"
+            echo "sdk=$SDK"
+            echo "version=$VERSION"
+            echo "file=$FILE"
+          } >> "$GITHUB_OUTPUT"
+          echo "Prepended $VERSION to $FILE (was $CURRENT)."
+
+      - name: Set up pnpm
+        if: steps.bump.outputs.changed == 'true'
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node
+        if: steps.bump.outputs.changed == 'true'
+        uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Format JSON + regenerate SDKInfo.ts
+        if: steps.bump.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          pnpm install
+          pnpm exec prettier --write "${{ steps.bump.outputs.file }}"
+          # Mirrors the pre-commit hook: regenerate docs/src/data/SDKInfo.ts on the
+          # sdk-versioning change. The generator needs the JS SDK built first.
+          pnpm --filter @growthbook/growthbook run build
+          pnpm --filter shared gen-sdk-resources-for-docs
+
+      - name: Open PR
+        if: steps.bump.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: sdk-version/${{ steps.bump.outputs.sdk }}-${{ steps.bump.outputs.version }}
+          commit-message: "chore(sdk-versions): ${{ steps.bump.outputs.sdk }} ${{ steps.bump.outputs.version }}"
+          title: "chore(sdk-versions): ${{ steps.bump.outputs.sdk }} ${{ steps.bump.outputs.version }}"
+          labels: sdk-versions, automated
+          body: |
+            Automated version sync for the **${{ steps.bump.outputs.sdk }}** SDK - **${{ steps.bump.outputs.version }}** release — adds it to
+            `${{ steps.bump.outputs.file }}` and regenerates the derived docs.
+
+            #### Did this release add a gated capability?
+
+            Comment on this PR and the bot does the rest (validates each value against `types.ts`):
+
+            ```
+            /capabilities streaming, redirects
+            ```
+
+            **Otherwise, just merge** — recording the version is all that's needed.

--- a/.github/workflows/verify-sdk-versions.yml
+++ b/.github/workflows/verify-sdk-versions.yml
@@ -1,0 +1,65 @@
+name: Verify sdk-versions
+
+# Required check for any change under sdk-versioning. Two guarantees:
+#   1. Every capability listed in a sdk-versions/*.json is a real SDKCapability
+#      (from types.ts) — a typo can't silently reach gen-sdk-resources.
+#   2. The generated SDK docs (CAPABILITIES.md, SDKInfo.ts) are regenerated and
+#      committed — so a capability change can't merge with stale docs.
+#
+# Make this a required status check on the sdk-version/* PRs (branch protection)
+# to enforce point 2 at merge time.
+
+on:
+  pull_request:
+    paths:
+      - "packages/shared/src/sdk-versioning/**"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Validate capabilities against types.ts
+        run: |
+          set -euo pipefail
+          VALID="$(sed -n '/export type SDKCapability =/,/;/p' \
+            packages/shared/src/sdk-versioning/types.ts | grep -oE '"[A-Za-z0-9]+"' | tr -d '"')"
+          bad=""
+          for f in packages/shared/src/sdk-versioning/sdk-versions/*.json; do
+            while IFS= read -r cap; do
+              [ -z "$cap" ] && continue
+              grep -qx "$cap" <<< "$VALID" || bad="${bad}"$'\n'"  $f -> $cap"
+            done < <(jq -r '.versions[].capabilities // [] | .[]' "$f")
+          done
+          if [ -n "$bad" ]; then
+            echo "::error::Unknown capabilities (not in types.ts):$bad"
+            exit 1
+          fi
+          echo "All capabilities are valid SDKCapability values."
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Regenerate SDK docs and check they are committed
+        run: |
+          set -euo pipefail
+          pnpm install
+          pnpm --filter shared generate-sdk-report
+          pnpm --filter shared gen-sdk-resources-for-docs
+          if ! git diff --quiet -- \
+              packages/shared/src/sdk-versioning/CAPABILITIES.md \
+              docs/src/data/SDKInfo.ts; then
+            echo "::error::SDK docs are stale. Regenerate and commit: pnpm --filter shared generate-sdk-report && pnpm --filter shared gen-sdk-resources-for-docs"
+            git --no-pager diff -- \
+              packages/shared/src/sdk-versioning/CAPABILITIES.md \
+              docs/src/data/SDKInfo.ts | head -100
+            exit 1
+          fi
+          echo "SDK docs are up to date."

--- a/.github/workflows/verify-sdk-versions.yml
+++ b/.github/workflows/verify-sdk-versions.yml
@@ -1,13 +1,13 @@
 name: Verify sdk-versions
 
-# Required check for any change under sdk-versioning. Two guarantees:
-#   1. Every capability listed in a sdk-versions/*.json is a real SDKCapability
-#      (from types.ts) — a typo can't silently reach gen-sdk-resources.
-#   2. The generated SDK docs (CAPABILITIES.md, SDKInfo.ts) are regenerated and
-#      committed — so a capability change can't merge with stale docs.
+# Required check for any change under sdk-versioning: every capability listed in
+# a sdk-versions/*.json must be a real SDKCapability (from types.ts). This is the
+# guard that keeps a typo'd capability from ever reaching gen-sdk-resources.
 #
-# Make this a required status check on the sdk-version/* PRs (branch protection)
-# to enforce point 2 at merge time.
+# Note: SDKInfo.ts freshness is NOT gated here. The repo's pre-commit hook
+# regenerates SDKInfo.ts on any sdk-versioning change, and the automation commits
+# it, so it stays in sync without a (build-heavy) CI diff gate. CAPABILITIES.md is
+# intentionally out of scope (it is not part of the pre-commit flow).
 
 on:
   pull_request:
@@ -18,12 +18,12 @@ permissions:
   contents: read
 
 jobs:
-  verify:
+  validate-capabilities:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 
-      - name: Validate capabilities against types.ts
+      - name: Every capability must exist in types.ts
         run: |
           set -euo pipefail
           VALID="$(sed -n '/export type SDKCapability =/,/;/p' \
@@ -40,26 +40,3 @@ jobs:
             exit 1
           fi
           echo "All capabilities are valid SDKCapability values."
-
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v5
-        with:
-          node-version: "24"
-          cache: "pnpm"
-
-      - name: Regenerate SDK docs and check they are committed
-        run: |
-          set -euo pipefail
-          pnpm install
-          pnpm --filter shared generate-sdk-report
-          pnpm --filter shared gen-sdk-resources-for-docs
-          if ! git diff --quiet -- \
-              packages/shared/src/sdk-versioning/CAPABILITIES.md \
-              docs/src/data/SDKInfo.ts; then
-            echo "::error::SDK docs are stale. Regenerate and commit: pnpm --filter shared generate-sdk-report && pnpm --filter shared gen-sdk-resources-for-docs"
-            git --no-pager diff -- \
-              packages/shared/src/sdk-versioning/CAPABILITIES.md \
-              docs/src/data/SDKInfo.ts | head -100
-            exit 1
-          fi
-          echo "SDK docs are up to date."


### PR DESCRIPTION
## Summary

Fallback to dispatcher event model to automate version sync. 

  -  Sender: Each SDK (**growthbook/sdk-version-sync** action) on a successful release.
  - Receiver: upon event dispatch, opens a PR for that SDK, regenerates sdk info and docs.

## Notes
- **`SDKInfo.ts` is regenerated** — via the pre-commit hook. `CAPABILITIES.md` is intentionally untouched (not in the hook; already drifted, so gating on it would false-fail every PR).
- **Security** (comment-command has write): `authorize` job requires the commenter be OWNER/MEMBER/COLLABORATOR (`author_association`) and the PR be same-repo, so fork code never runs with the write token. Least-privilege token; only the write job gets `contents: write`.
- **Capabilities can't be derived** automatically — Comment `/capabilities streaming, redirects` on the PR to manage them.

## What's included
- **`.github/workflows/sync-sdk-version.yml`** — receiver. On `repository_dispatch` (`update-sdk-version`) or manual `workflow_dispatch`, prepends a version-only entry to `sdk-versions/<sdk>.json` (idempotent; no-op if not newer), regenerates `SDKInfo.ts` via `gen-sdk-resources-for-docs` (the same command the pre-commit hook runs), and opens a `sdk-version/<sdk>-<x.y.z>` PR.
- **`.github/workflows/sdk-version-capabilities.yml`** — ChatOps. Comment `/capabilities streaming, redirects` → validates each token against the `SDKCapability` union in `types.ts` (unknown → rejected, no change), sets them on the entry, regenerates `SDKInfo.ts`, commits back. Empty → version-only.
- **`.github/workflows/verify-sdk-versions.yml`** — required check: every capability in every `sdk-versions/*.json` is a real `SDKCapability`.
- **`.github/scripts/apply-sdk-capabilities.sh`** — the validate-and-edit logic (unit-tested).

## Validation
The whole flow — receiver, all `/capabilities` cases (empty / unknown / valid), the authz gate, and idempotency — was proven end-to-end in **growthbook/examples** with a stubbed generator. The only piece not exercisable there is the real `gen-sdk-resources-for-docs` build, whose generators were verified locally.