### PR TITLE
[SCRATCH - do not merge] test verify-sdk-versions gate

### DIFF
--- a/.github/scripts/apply-sdk-capabilities.sh
+++ b/.github/scripts/apply-sdk-capabilities.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Validate a comma-separated capability list against the SDKCapability union in
+# packages/shared/src/sdk-versioning/types.ts and set it on a specific version
+# entry in that SDK's sdk-versions JSON.
+#
+# Usage: apply-sdk-capabilities.sh <repo_root> <sdk> <version> <capabilities_csv>
+#
+# Exit codes:
+#   0  capabilities applied (edited the JSON)
+#   2  empty capability list -> nothing to do (version-only)
+#   3  one or more capabilities are not in types.ts (no changes made)
+#   1  usage / structural error
+#
+# On success (0) and no-op (2) it prints "applied=<csv>" so the caller can echo
+# it back. On rejection (3) it prints "invalid=<csv>".
+set -euo pipefail
+
+ROOT="${1:?repo_root}"
+SDK="${2:?sdk}"
+VERSION="${3:?version}"
+CSV="${4-}"
+
+TYPES="$ROOT/packages/shared/src/sdk-versioning/types.ts"
+[ -f "$TYPES" ] || { echo "types.ts not found at $TYPES" >&2; exit 1; }
+
+# SDK key -> filename (a few keys don't map 1:1 to their file).
+case "$SDK" in
+  android)  FILE_STEM=kotlin ;;
+  ios)      FILE_STEM=swift ;;
+  nocode-*) FILE_STEM=nocode ;;
+  *)        FILE_STEM="$SDK" ;;
+esac
+FILE="$ROOT/packages/shared/src/sdk-versioning/sdk-versions/$FILE_STEM.json"
+[ -f "$FILE" ] || { echo "no sdk-versions file for '$SDK' ($FILE)" >&2; exit 1; }
+
+# The version entry the PR added must exist.
+if ! jq -e --arg v "$VERSION" '.versions[] | select(.version == $v)' "$FILE" >/dev/null; then
+  echo "version $VERSION not present in $FILE" >&2; exit 1
+fi
+
+# The single source of truth for valid capabilities: the SDKCapability union.
+VALID="$(sed -n '/export type SDKCapability =/,/;/p' "$TYPES" | grep -oE '"[A-Za-z0-9]+"' | tr -d '"')"
+
+# Parse + trim the CSV. Empty -> no-op (version-only).
+CLEANED="$(echo "$CSV" | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | grep -v '^$' || true)"
+if [ -z "$CLEANED" ]; then
+  echo "applied="
+  exit 2
+fi
+
+invalid=""
+while IFS= read -r cap; do
+  grep -qx "$cap" <<< "$VALID" || invalid="${invalid:+$invalid, }$cap"
+done <<< "$CLEANED"
+
+if [ -n "$invalid" ]; then
+  echo "invalid=$invalid"
+  exit 3
+fi
+
+# Build a JSON array from the validated, de-duplicated (order-preserving) list.
+CAPS_JSON="$(echo "$CLEANED" | awk '!seen[$0]++' | jq -R . | jq -sc .)"
+
+# Set capabilities on exactly the target version entry. `(...) |= ` mutates in place.
+tmp="$(mktemp)"
+jq --arg v "$VERSION" --argjson caps "$CAPS_JSON" \
+  '(.versions[] | select(.version == $v)).capabilities = $caps' "$FILE" > "$tmp"
+mv "$tmp" "$FILE"
+
+echo "applied=$(echo "$CLEANED" | awk '!seen[$0]++' | paste -sd ',' -)"
+exit 0

--- a/.github/workflows/sdk-version-capabilities.yml
+++ b/.github/workflows/sdk-version-capabilities.yml
@@ -1,0 +1,123 @@
+name: SDK version capabilities
+
+# ChatOps for the auto-generated sdk-versions PRs. On a PR whose branch is
+# `sdk-version/<sdk>-<x.y.z>`, a maintainer comments:
+#
+#     /capabilities streaming, redirects
+#
+# and this workflow validates each token against the SDKCapability union in
+# types.ts, sets them on that version entry, regenerates the SDK docs, and
+# commits everything back to the PR branch. An empty `/capabilities` records
+# the release as version-only. Unknown capabilities are rejected with a comment
+# and nothing is changed (so gen-sdk-resources can never be fed a bad value).
+#
+# NOTE: issue_comment workflows only run from the copy on the default branch,
+# so this takes effect once merged to main.
+#
+# The commit is pushed with SDK_VERSION_BOT_TOKEN (a PAT) when available so the
+# verify-sdk-versions check re-runs on the new commit; it falls back to
+# GITHUB_TOKEN (push works, but the required check won't re-trigger).
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  capabilities:
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/capabilities') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.SDK_VERSION_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Check out the PR branch and parse sdk/version
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.SDK_VERSION_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          gh pr checkout "$PR"
+          head="$(git rev-parse --abbrev-ref HEAD)"
+          if [[ ! "$head" =~ ^sdk-version/(.+)-([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "PR branch '$head' is not sdk-version/<sdk>-<x.y.z>; ignoring."
+            echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          {
+            echo "sdk=${BASH_REMATCH[1]}"
+            echo "version=${BASH_REMATCH[2]}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate + apply capabilities to the JSON
+        if: ${{ steps.pr.outputs.skip != 'true' }}
+        id: apply
+        env:
+          COMMENT: ${{ github.event.comment.body }}
+          SDK: ${{ steps.pr.outputs.sdk }}
+          VERSION: ${{ steps.pr.outputs.version }}
+        run: |
+          set -uo pipefail
+          # Strip the command word from the first line; the rest is the CSV.
+          CSV="$(printf '%s\n' "$COMMENT" | head -n1 | sed -E 's#^/capabilities##')"
+          out="$(bash .github/scripts/apply-sdk-capabilities.sh "$PWD" "$SDK" "$VERSION" "$CSV")"; code=$?
+          echo "$out"
+          echo "result=$out" >> "$GITHUB_OUTPUT"
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Reject unknown capabilities
+        if: ${{ steps.apply.outputs.code == '3' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+          RESULT: ${{ steps.apply.outputs.result }}
+        run: |
+          gh pr comment "$PR" --body "❌ Unknown capabilities: **${RESULT#invalid=}**. Valid values come from \`packages/shared/src/sdk-versioning/types.ts\`. No changes made."
+          exit 1
+
+      - name: Acknowledge version-only
+        if: ${{ steps.apply.outputs.code == '2' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+        run: gh pr comment "$PR" --body "No capabilities given — recording this release as version-only. Ready to merge."
+
+      - name: Set up pnpm
+        if: ${{ steps.apply.outputs.code == '0' }}
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node
+        if: ${{ steps.apply.outputs.code == '0' }}
+        uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Regenerate docs, commit, and comment
+        if: ${{ steps.apply.outputs.code == '0' }}
+        env:
+          GH_TOKEN: ${{ secrets.SDK_VERSION_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+          SDK: ${{ steps.pr.outputs.sdk }}
+          VERSION: ${{ steps.pr.outputs.version }}
+          RESULT: ${{ steps.apply.outputs.result }}
+        run: |
+          set -euo pipefail
+          caps="${RESULT#applied=}"
+          pnpm install
+          pnpm exec prettier --write "packages/shared/src/sdk-versioning/sdk-versions/$SDK.json" || \
+            pnpm exec prettier --write "packages/shared/src/sdk-versioning/sdk-versions/"*.json
+          pnpm --filter shared generate-sdk-report
+          pnpm --filter shared gen-sdk-resources-for-docs
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add packages/shared/src/sdk-versioning docs/src/data/SDKInfo.ts
+          git commit -m "chore(sdk-versions): $SDK $VERSION capabilities [$caps]"
+          git push
+          gh pr comment "$PR" --body "✅ Set capabilities **[$caps]** on \`$SDK\` $VERSION and regenerated SDK docs (\`CAPABILITIES.md\`, \`SDKInfo.ts\`)."

--- a/.github/workflows/verify-sdk-versions.yml
+++ b/.github/workflows/verify-sdk-versions.yml
@@ -1,0 +1,65 @@
+name: Verify sdk-versions
+
+# Required check for any change under sdk-versioning. Two guarantees:
+#   1. Every capability listed in a sdk-versions/*.json is a real SDKCapability
+#      (from types.ts) — a typo can't silently reach gen-sdk-resources.
+#   2. The generated SDK docs (CAPABILITIES.md, SDKInfo.ts) are regenerated and
+#      committed — so a capability change can't merge with stale docs.
+#
+# Make this a required status check on the sdk-version/* PRs (branch protection)
+# to enforce point 2 at merge time.
+
+on:
+  pull_request:
+    paths:
+      - "packages/shared/src/sdk-versioning/**"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Validate capabilities against types.ts
+        run: |
+          set -euo pipefail
+          VALID="$(sed -n '/export type SDKCapability =/,/;/p' \
+            packages/shared/src/sdk-versioning/types.ts | grep -oE '"[A-Za-z0-9]+"' | tr -d '"')"
+          bad=""
+          for f in packages/shared/src/sdk-versioning/sdk-versions/*.json; do
+            while IFS= read -r cap; do
+              [ -z "$cap" ] && continue
+              grep -qx "$cap" <<< "$VALID" || bad="${bad}"$'\n'"  $f -> $cap"
+            done < <(jq -r '.versions[].capabilities // [] | .[]' "$f")
+          done
+          if [ -n "$bad" ]; then
+            echo "::error::Unknown capabilities (not in types.ts):$bad"
+            exit 1
+          fi
+          echo "All capabilities are valid SDKCapability values."
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Regenerate SDK docs and check they are committed
+        run: |
+          set -euo pipefail
+          pnpm install
+          pnpm --filter shared generate-sdk-report
+          pnpm --filter shared gen-sdk-resources-for-docs
+          if ! git diff --quiet -- \
+              packages/shared/src/sdk-versioning/CAPABILITIES.md \
+              docs/src/data/SDKInfo.ts; then
+            echo "::error::SDK docs are stale. Regenerate and commit: pnpm --filter shared generate-sdk-report && pnpm --filter shared gen-sdk-resources-for-docs"
+            git --no-pager diff -- \
+              packages/shared/src/sdk-versioning/CAPABILITIES.md \
+              docs/src/data/SDKInfo.ts | head -100
+            exit 1
+          fi
+          echo "SDK docs are up to date."

--- a/packages/shared/src/sdk-versioning/sdk-versions/rust.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/rust.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "0.2.1"
+    },
+    {
       "version": "0.2.0",
       "capabilities": ["savedGroupReferences"]
     },


### PR DESCRIPTION
Throwaway PR to exercise `verify-sdk-versions` on a version-only `rust.json` bump. Expected: the check PASSES (no capability change → docs stay in sync). Will close after validating.