### PR TITLE
Fix for trailing characters on invite email addresses

### DIFF
--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -889,17 +889,11 @@ export async function inviteUser({
 } & MemberRoleWithProjects) {
   organization.invites = organization.invites || [];
 
-  // Strip stray leading/trailing separators (e.g. a trailing ";" from a pasted
-  // Outlook-style list). Mail servers ignore these separators when sending, so
-  // stripping them stores the address the invite email is actually delivered to.
   email = email
     .toLowerCase()
     .replace(/^[\s;,]+/, "")
     .replace(/[\s;,]+$/, "");
 
-  // Reject addresses that are still malformed. Storing one would break
-  // acceptance later: the stored email would never match the recipient's
-  // real address, so they'd get "sent to a different email address" errors.
   if (!z.string().email().safeParse(email).success) {
     throw new Error(`Invalid email address: ${email}`);
   }

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "crypto";
+import { z } from "zod";
 import { freeEmailDomains } from "free-email-domains-typescript";
 import { cloneDeep } from "lodash";
 import { Request } from "express";
@@ -888,7 +889,15 @@ export async function inviteUser({
 } & MemberRoleWithProjects) {
   organization.invites = organization.invites || [];
 
-  email = email.toLowerCase();
+  email = email.trim().toLowerCase();
+
+  // Reject malformed addresses (e.g. a stray trailing ";" from a pasted
+  // Outlook-style list). Mail servers silently strip such separators, so the
+  // email would be delivered, but accepting the invite would then fail because
+  // the stored email would never match the recipient's real address.
+  if (!z.string().email().safeParse(email).success) {
+    throw new Error(`Invalid email address: ${email}`);
+  }
 
   // User is already invited (legacy invites may have been stored with
   // mixed case, so compare case-insensitively).

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -889,12 +889,17 @@ export async function inviteUser({
 } & MemberRoleWithProjects) {
   organization.invites = organization.invites || [];
 
-  email = email.trim().toLowerCase();
+  // Strip stray leading/trailing separators (e.g. a trailing ";" from a pasted
+  // Outlook-style list). Mail servers ignore these separators when sending, so
+  // stripping them stores the address the invite email is actually delivered to.
+  email = email
+    .toLowerCase()
+    .replace(/^[\s;,]+/, "")
+    .replace(/[\s;,]+$/, "");
 
-  // Reject malformed addresses (e.g. a stray trailing ";" from a pasted
-  // Outlook-style list). Mail servers silently strip such separators, so the
-  // email would be delivered, but accepting the invite would then fail because
-  // the stored email would never match the recipient's real address.
+  // Reject addresses that are still malformed. Storing one would break
+  // acceptance later: the stored email would never match the recipient's
+  // real address, so they'd get "sent to a different email address" errors.
   if (!z.string().email().safeParse(email).success) {
     throw new Error(`Invalid email address: ${email}`);
   }

--- a/packages/back-end/test/services/organizationInvites.test.ts
+++ b/packages/back-end/test/services/organizationInvites.test.ts
@@ -93,14 +93,28 @@ describe("inviteUser email validation", () => {
     );
   });
 
-  it("rejects an email with a trailing semicolon", async () => {
+  it("strips a stray trailing semicolon before storing the invite", async () => {
     const organization = makeOrganization();
 
-    await expect(sendInvite(organization, "gsj@brolo.me;")).rejects.toThrow(
-      "Invalid email address: gsj@brolo.me;",
-    );
+    await sendInvite(organization, "gsj@brolo.me;");
 
-    expect(mockedAddOrganizationInviteIfSeatAvailable).not.toHaveBeenCalled();
+    expect(mockedAddOrganizationInviteIfSeatAvailable).toHaveBeenCalledWith(
+      organization.id,
+      expect.objectContaining({ email: "gsj@brolo.me" }),
+      null,
+    );
+  });
+
+  it("strips leading and trailing separators and whitespace", async () => {
+    const organization = makeOrganization();
+
+    await sendInvite(organization, " ;User@Example.com,; ");
+
+    expect(mockedAddOrganizationInviteIfSeatAvailable).toHaveBeenCalledWith(
+      organization.id,
+      expect.objectContaining({ email: "user@example.com" }),
+      null,
+    );
   });
 
   it("rejects a clearly malformed email", async () => {
@@ -109,6 +123,16 @@ describe("inviteUser email validation", () => {
     await expect(sendInvite(organization, "not-an-email")).rejects.toThrow(
       "Invalid email address: not-an-email",
     );
+
+    expect(mockedAddOrganizationInviteIfSeatAvailable).not.toHaveBeenCalled();
+  });
+
+  it("rejects multiple addresses joined by a separator", async () => {
+    const organization = makeOrganization();
+
+    await expect(
+      sendInvite(organization, "a@example.com;b@example.com"),
+    ).rejects.toThrow("Invalid email address: a@example.com;b@example.com");
 
     expect(mockedAddOrganizationInviteIfSeatAvailable).not.toHaveBeenCalled();
   });

--- a/packages/back-end/test/services/organizationInvites.test.ts
+++ b/packages/back-end/test/services/organizationInvites.test.ts
@@ -1,0 +1,148 @@
+import { OrganizationInterface } from "shared/types/organization";
+import {
+  getAccountPlan,
+  getLicense,
+  licenseInit,
+} from "back-end/src/enterprise";
+import { addOrganizationInviteIfSeatAvailable } from "back-end/src/models/OrganizationModel";
+import { inviteUser } from "back-end/src/services/organizations";
+
+jest.mock("back-end/src/enterprise", () => ({
+  ...jest.requireActual("back-end/src/enterprise"),
+  getAccountPlan: jest.fn(),
+  getLicense: jest.fn(),
+  licenseInit: jest.fn(),
+}));
+
+jest.mock("back-end/src/models/OrganizationModel", () => ({
+  acceptOrganizationInvite: jest.fn(),
+  addOrganizationInviteIfSeatAvailable: jest.fn(),
+  addOrganizationMemberIfSeatAvailable: jest.fn(),
+  createOrganization: jest.fn(),
+  findAllOrganizations: jest.fn(),
+  findOrganizationById: jest.fn(),
+  findOrganizationByInviteKey: jest.fn(),
+  findOrganizationsByDomain: jest.fn(),
+  updateOrganization: jest.fn(),
+}));
+
+jest.mock("back-end/src/services/email", () => ({
+  isEmailEnabled: jest.fn(() => false),
+  sendInviteEmail: jest.fn(),
+  sendNewMemberEmail: jest.fn(),
+  sendPendingMemberEmail: jest.fn(),
+}));
+
+jest.mock("back-end/src/services/plan-limits", () => ({
+  getEffectiveOrgLimits: jest.fn(() => ({
+    orgSupportsRoles: () => true,
+  })),
+}));
+
+jest.mock("back-end/src/util/secrets", () => ({
+  ...jest.requireActual("back-end/src/util/secrets"),
+  IS_CLOUD: true,
+}));
+
+const mockedGetAccountPlan = jest.mocked(getAccountPlan);
+const mockedGetLicense = jest.mocked(getLicense);
+const mockedLicenseInit = jest.mocked(licenseInit);
+const mockedAddOrganizationInviteIfSeatAvailable = jest.mocked(
+  addOrganizationInviteIfSeatAvailable,
+);
+
+function makeOrganization(
+  overrides: Partial<OrganizationInterface> = {},
+): OrganizationInterface {
+  return {
+    id: "org_1",
+    url: "acme",
+    dateCreated: new Date(),
+    name: "Acme",
+    ownerEmail: "owner@example.com",
+    members: [],
+    invites: [],
+    ...overrides,
+  } as OrganizationInterface;
+}
+
+function sendInvite(organization: OrganizationInterface, email: string) {
+  return inviteUser({
+    organization,
+    email,
+    role: "admin",
+    limitAccessByEnvironment: false,
+    environments: [],
+    projectRoles: [],
+    invitedBy: "owner@example.com",
+  });
+}
+
+describe("inviteUser email validation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetAccountPlan.mockReturnValue("enterprise");
+    mockedGetLicense.mockReturnValue(null);
+    mockedLicenseInit.mockResolvedValue(undefined);
+    mockedAddOrganizationInviteIfSeatAvailable.mockImplementation(
+      async (id, invite) =>
+        ({
+          ...makeOrganization(),
+          invites: [invite],
+        }) as OrganizationInterface,
+    );
+  });
+
+  it("rejects an email with a trailing semicolon", async () => {
+    const organization = makeOrganization();
+
+    await expect(sendInvite(organization, "gsj@brolo.me;")).rejects.toThrow(
+      "Invalid email address: gsj@brolo.me;",
+    );
+
+    expect(mockedAddOrganizationInviteIfSeatAvailable).not.toHaveBeenCalled();
+  });
+
+  it("rejects a clearly malformed email", async () => {
+    const organization = makeOrganization();
+
+    await expect(sendInvite(organization, "not-an-email")).rejects.toThrow(
+      "Invalid email address: not-an-email",
+    );
+
+    expect(mockedAddOrganizationInviteIfSeatAvailable).not.toHaveBeenCalled();
+  });
+
+  it("trims whitespace and lowercases before storing the invite", async () => {
+    const organization = makeOrganization();
+
+    await sendInvite(organization, "  User@Example.com ");
+
+    expect(mockedAddOrganizationInviteIfSeatAvailable).toHaveBeenCalledWith(
+      organization.id,
+      expect.objectContaining({ email: "user@example.com" }),
+      null,
+    );
+  });
+
+  it("matches an existing invite after normalization", async () => {
+    const organization = makeOrganization({
+      invites: [
+        {
+          email: "invited@example.com",
+          key: "invite_key",
+          role: "admin",
+          limitAccessByEnvironment: false,
+          environments: [],
+          dateCreated: new Date(),
+        },
+      ],
+    });
+
+    await expect(
+      sendInvite(organization, " Invited@Example.com "),
+    ).resolves.toMatchObject({ emailSent: true });
+
+    expect(mockedAddOrganizationInviteIfSeatAvailable).not.toHaveBeenCalled();
+  });
+});

--- a/packages/front-end/components/Settings/Team/InviteModal.tsx
+++ b/packages/front-end/components/Settings/Team/InviteModal.tsx
@@ -250,7 +250,10 @@ const InviteModal = ({ mutate, close, defaultRole }: Props) => {
               const parsedEmails: string[] = [];
               emails.forEach((em) => {
                 parsedEmails.push(
-                  ...em.split(/[\s,]/g).filter((e) => e.trim().length > 0),
+                  ...em
+                    .split(/[\s,;]/g)
+                    .map((e) => e.trim())
+                    .filter((e) => e.length > 0),
                 );
               });
               // dedup:


### PR DESCRIPTION
Inviting users via outlook in particular, can be semicolon separated. This additional character will correctly send an email, but cause the invite to be not join-able as it will never match the email. This fixes this edge case.