### PR TITLE
fix: omit phaseStartDate when editDates is false to avoid runExperiments permission

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1996,29 +1996,45 @@ export async function postExperiment(
   }
 
   // If changing phase start/end dates (from "Configure Analysis" modal)
+  // Only update phases if the dates have actually changed to avoid requiring
+  // runExperiments permission for pure analysis-setting changes
   if (
     experiment.status !== "draft" &&
     currentPhase !== undefined &&
     experiment.phases?.[currentPhase] &&
     (phaseStartDate || phaseEndDate)
   ) {
+    const existingPhase = experiment.phases[currentPhase];
     const phases = [...experiment.phases];
     const phaseClone = { ...phases[currentPhase] };
     phases[Math.floor(currentPhase * 1)] = phaseClone;
     const firstPhaseClone = { ...phases[0] };
 
+    let phasesChanged = false;
+
     if (phaseStartDate) {
-      phaseClone.dateStarted = getValidDate(phaseStartDate + ":00Z");
-    }
-    if (experiment.status === "stopped" && phaseEndDate) {
-      phaseClone.dateEnded = getValidDate(phaseEndDate + ":00Z");
-      // update both phases when stopped
-      if (experiment.type === "holdout") {
-        firstPhaseClone.dateEnded = getValidDate(phaseEndDate + ":00Z");
-        phases[0] = firstPhaseClone; // update the first phase to the same date ended
+      const newStartDate = getValidDate(phaseStartDate + ":00Z");
+      if (newStartDate.getTime() !== existingPhase.dateStarted.getTime()) {
+        phaseClone.dateStarted = newStartDate;
+        phasesChanged = true;
       }
     }
-    changes.phases = phases;
+    if (experiment.status === "stopped" && phaseEndDate) {
+      const newEndDate = getValidDate(phaseEndDate + ":00Z");
+      if (newEndDate.getTime() !== existingPhase.dateEnded?.getTime()) {
+        phaseClone.dateEnded = newEndDate;
+        phasesChanged = true;
+        // update both phases when stopped
+        if (experiment.type === "holdout") {
+          firstPhaseClone.dateEnded = newEndDate;
+          phases[0] = firstPhaseClone; // update the first phase to the same date ended
+        }
+      }
+    }
+
+    if (phasesChanged) {
+      changes.phases = phases;
+    }
   }
 
   // Clean up some vars for bandits, but only if safe to do so...

--- a/packages/front-end/components/Experiment/AnalysisForm.tsx
+++ b/packages/front-end/components/Experiment/AnalysisForm.tsx
@@ -432,20 +432,24 @@ const AnalysisForm: FC<{
         const { dateStarted, dateEnded, skipPartialData, ...values } = value;
 
         const body: Partial<ExperimentInterfaceStringDates> & {
-          phaseStartDate: string;
+          phaseStartDate?: string;
           phaseEndDate?: string;
           currentPhase?: number;
         } = {
           ...values,
           currentPhase: phase,
-          phaseStartDate: dateStarted,
           skipPartialData: skipPartialData === "strict",
         };
 
         fixMetricOverridesBeforeSaving(body.metricOverrides || []);
 
-        if (experiment.status === "stopped") {
-          body.phaseEndDate = dateEnded;
+        // Only include phase dates when editDates is true to avoid triggering
+        // runExperiments permission for pure analysis-setting changes
+        if (editDates) {
+          body.phaseStartDate = dateStarted;
+          if (experiment.status === "stopped") {
+            body.phaseEndDate = dateEnded;
+          }
         }
         // Include lookbackOverride; use undefined to clear when user selects "None"
         if (value.lookbackOverride !== undefined) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

Fixes a permissions issue with the "Edit Settings" modal on experiments where pure analysis-setting edits incorrectly required `runExperiments` permission instead of just `createAnalyses`.

**Root cause:** The `AnalysisForm` component always included `phaseStartDate` in the request body, even when `editDates={false}` (e.g., when opening "Edit Settings" from the Results tab). The backend interpreted this as a `phases` update, which triggered the `runExperiments` permission check for running experiments.

**Fix (two layers of defense):**

1. **Frontend (`AnalysisForm.tsx`):** Only include `phaseStartDate` and `phaseEndDate` in the request body when `editDates={true}`. This prevents unnecessary date submission for pure analysis-setting changes.

2. **Backend (`experiments.ts`):** Added a delta check so that even if dates are submitted, we only add `phases` to the changes object if the dates have actually changed. This provides defense-in-depth and handles edge cases where dates might be submitted but unchanged.

### Dependencies

None

### Testing

1. Create an experiment with a user who has `createAnalyses` permission but not `runExperiments` permission
2. Navigate to the Results tab and click "Edit Settings"
3. Make a change to any analysis setting (e.g., stats engine, CUPED, etc.)
4. Click Save - should now succeed without a permissions error

Previously, step 4 would fail with a permissions modal requiring `runExperiments` permission.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C0A9B5W8LMN/p1786575682570519?thread_ts=1786575682.570519&cid=C0A9B5W8LMN)

<div><a href="https://cursor.com/agents/bc-8c2bdbcc-564c-5019-8fd0-e2875e4df931?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c2bdbcc-564c-5019-8fd0-e2875e4df931&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

