### PR TITLE
fix(fe): stop the simple condition editor rewriting boolean $ne conditions

### DIFF
--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -1425,17 +1425,17 @@ export function jsonToConds(
             value: "",
           });
         }
-        if (operator === "$eq" && (v === true || v === false)) {
+        if (v === true || v === false) {
+          // Only `$eq` round-trips through `$true` / `$false`. Anything else
+          // (e.g. `{$ne: true}`, which also matches an unset attribute) has no
+          // simple-editor equivalent and would be rewritten on save.
+          if (operator !== "$eq") {
+            valid = false;
+            return;
+          }
           return conds.push({
             field,
             operator: v ? "$true" : "$false",
-            value: "",
-          });
-        }
-        if (operator === "$ne" && (v === true || v === false)) {
-          return conds.push({
-            field,
-            operator: v ? "$false" : "$true",
             value: "",
           });
         }

--- a/packages/front-end/test/features.test.ts
+++ b/packages/front-end/test/features.test.ts
@@ -237,6 +237,32 @@ describe("json <-> conds", () => {
     expect(jsonToConds(json, attributeMap)).toEqual(conds);
     expect(condToJson(conds, attributeMap)).toEqual(simplifiedJson);
   });
+  // A boolean literal under any operator other than $eq has no simple-editor
+  // equivalent, so the simple editor must opt out rather than rewrite it.
+  it("bool - $ne true requires advanced mode", () => {
+    const json = stringify({ bool: { $ne: true } });
+    expect(jsonToConds(json, attributeMap)).toEqual(null);
+  });
+  it("bool - $ne false requires advanced mode", () => {
+    const json = stringify({ bool: { $ne: false } });
+    expect(jsonToConds(json, attributeMap)).toEqual(null);
+  });
+  it("$ne boolean on a non-boolean attribute requires advanced mode", () => {
+    const json = stringify({ str: { $ne: true } });
+    expect(jsonToConds(json, attributeMap)).toEqual(null);
+  });
+  it("$ne boolean inside $or requires advanced mode", () => {
+    const json = stringify({ $or: [{ bool: { $ne: true } }, { str: "a" }] });
+    expect(jsonToConds(json, attributeMap)).toEqual(null);
+  });
+  it("boolean literal under a comparison operator requires advanced mode", () => {
+    expect(
+      jsonToConds(stringify({ num: { $lt: true } }), attributeMap),
+    ).toEqual(null);
+    expect(
+      jsonToConds(stringify({ str: { $gt: false } }), attributeMap),
+    ).toEqual(null);
+  });
 
   // Array operators
   it("str_arr - $includes", () => {


### PR DESCRIPTION
### Features and Changes

The simple (dropdown) condition editor maps `{"attr": {"$ne": true}}` onto its "is false" operator, and `{"$ne": false}` onto "is true". Those get serialized back as `{"attr": false}` / `{"attr": true}`, which are not equivalent: `$ne: true` also matches when the attribute is not set at all (the SDK resolves a missing attribute to `null`, and `null !== true`), whereas a bare `false` does not.

Because `ConditionInput` parses into simple mode and re-serializes on mount, a rule with such a condition is rewritten as soon as it is opened in the rule modal — the user doesn't need to touch the targeting section. Changing a rollout percentage is enough to turn "everyone without `beta_user` set" into "everyone with `beta_user` explicitly `false`", which usually matches nobody.

Simple mode has no operator that can represent this, so this PR treats a boolean literal under any operator other than `$eq` as advanced-only, the same way `jsonToConds` already bails out for `$in` values containing commas, `$nor`, `$type`, etc. Effects:

- Such conditions now open in the JSON editor and are preserved verbatim.
- `ConditionDisplay` renders them as JSON instead of the previous "is false" text, which was describing the wrong semantics.
- `$eq: true/false` and bare booleans are unchanged.
- Rules produced by the LaunchDarkly importer for negated boolean clauses fall into this category too; they're preserved rather than displayed/edited incorrectly.

No issue filed for this; happy to open one if you'd prefer to track it.

### Dependencies

None

### Testing

- New unit tests in `test/features.test.ts` cover `$ne: true`, `$ne: false`, `$ne` on a non-boolean attribute, `$ne` nested in `$or`, and a boolean under a comparison operator; all fail on `main` and pass here.
- Mounted `ConditionInput` with `{"attr": {"$ne": true}}`: on `main` `onChange` fires with the original and then immediately with `{"attr": false}`; with this change it fires only with the original. `{"$eq": true}` still takes the simple path.
- Existing `ConditionInput` component tests pass.

### Screenshots

N/A — affected conditions now open in the existing JSON editor; no new UI.