### PR TITLE
fix(experiments): funnel step time-series graphs and metric drilldown

### DIFF
--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -216,7 +216,9 @@ const BreakDownResults: FC<{
   // Wrap drilldown to include dimension info
   const handleRowClick = drilldownContext
     ? (row: ExperimentTableRow) => {
-        const rawValue = typeof row.label === "string" ? row.label : "";
+        const rawValue =
+          row.dimensionValue ??
+          (typeof row.label === "string" ? row.label : "");
         const value = formatDimensionValueForDisplay(rawValue);
         drilldownContext.openDrilldown(row, {
           dimensionInfo: { id: dimensionId, name: dimension, value, rawValue },

--- a/packages/front-end/components/Experiment/ExperimentMetricTimeSeriesGraphWrapper.tsx
+++ b/packages/front-end/components/Experiment/ExperimentMetricTimeSeriesGraphWrapper.tsx
@@ -130,6 +130,7 @@ interface ExperimentMetricTimeSeriesGraphWrapperProps {
   pValueAdjustmentEnabled: boolean;
   firstDateToRender: Date;
   sliceId?: string;
+  funnelStepId?: string;
   baselineRow?: number;
   unavailableMessage?: string;
   preloadedTimeSeries?: MetricTimeSeries;
@@ -167,6 +168,7 @@ function ExperimentMetricTimeSeriesGraphWrapper({
   pValueAdjustmentEnabled,
   firstDateToRender,
   sliceId,
+  funnelStepId,
   baselineRow = 0,
   unavailableMessage,
   preloadedTimeSeries,
@@ -183,7 +185,7 @@ function ExperimentMetricTimeSeriesGraphWrapper({
     getFactTableById,
   );
 
-  const metricId = sliceId ?? metric.id;
+  const metricId = funnelStepId ?? sliceId ?? metric.id;
   const dimensionQuery =
     dimensionId && dimensionValue !== undefined
       ? `&dimensions[0][id]=${encodeURIComponent(

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -33,6 +33,7 @@ import {
   ExperimentMetricDefinition,
   ExperimentSortBy,
   SetExperimentSortBy,
+  funnelStepMetricId,
   isFactMetric,
 } from "shared/experiments";
 import { PiPencilSimpleFill } from "react-icons/pi";
@@ -779,6 +780,12 @@ export default function ResultsTable({
                     ? `${id}-${row.metric.id}-${row.sliceId}`
                     : `${id}-${row.metric.id}-${i}`;
 
+                  const funnelStepId =
+                    row.childRowType === "funnelStep" &&
+                    row.funnelStepIndex !== undefined
+                      ? funnelStepMetricId(row.metric.id, row.funnelStepIndex)
+                      : undefined;
+
                   const timeSeriesButton = showTimeSeriesButton ? (
                     <TimeSeriesButton
                       onClick={() => toggleVisibleTimeSeriesRowId(rowId)}
@@ -1320,6 +1327,7 @@ export default function ResultsTable({
                                             startDate,
                                           )}
                                           sliceId={row.sliceId}
+                                          funnelStepId={funnelStepId}
                                           baselineRow={baselineRow}
                                           unavailableMessage={timeSeriesMessage}
                                           preloadedTimeSeries={

--- a/packages/front-end/components/MetricDrilldown/MetricDrilldownContext.tsx
+++ b/packages/front-end/components/MetricDrilldown/MetricDrilldownContext.tsx
@@ -169,6 +169,13 @@ export const MetricDrilldownProvider: FC<MetricDrilldownProviderProps> = ({
             (typeof row.label === "string" ? row.label : ""),
           dimensionInfo: resolvedDimensionInfo,
         });
+      } else if (row.childRowType === "funnelStep") {
+        setOpenModalInfo({
+          metricRow: row,
+          initialResults,
+          initialTab: options?.initialTab ?? "funnel",
+          dimensionInfo: resolvedDimensionInfo,
+        });
       } else {
         setOpenModalInfo({
           metricRow: row,

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentTimeSeriesBlock.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentTimeSeriesBlock.tsx
@@ -4,7 +4,10 @@ import { MetricSnapshotSettings } from "shared/types/report";
 import { DEFAULT_PROPER_PRIOR_STDDEV } from "shared/constants";
 import { groupBy } from "lodash";
 import { getValidDate } from "shared/dates";
-import { getLatestPhaseVariations } from "shared/experiments";
+import {
+  funnelStepMetricId,
+  getLatestPhaseVariations,
+} from "shared/experiments";
 import ExperimentMetricTimeSeriesGraphWrapper from "@/components/Experiment/ExperimentMetricTimeSeriesGraphWrapper";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import usePValueThreshold from "@/hooks/usePValueThreshold";
@@ -208,6 +211,12 @@ export default function ExperimentTimeSeriesBlock({
                         pValueAdjustmentEnabled={!!appliedPValueCorrection}
                         firstDateToRender={phaseStartDate}
                         sliceId={row.sliceId}
+                        funnelStepId={
+                          row.childRowType === "funnelStep" &&
+                          row.funnelStepIndex !== undefined
+                            ? funnelStepMetricId(metric.id, row.funnelStepIndex)
+                            : undefined
+                        }
                       />
                     )}
                   </div>

--- a/packages/front-end/hooks/useExperimentDimensionRows.ts
+++ b/packages/front-end/hooks/useExperimentDimensionRows.ts
@@ -498,6 +498,7 @@ export function generateDimensionRowsForMetric({
   filteredResults.forEach((dimensionResult) => {
     const parentRow: ExperimentTableRow = {
       label: dimensionResult.name,
+      dimensionValue: dimensionResult.name,
       metric: newMetric,
       metricOverrideFields: overrideFields,
       rowClass: newMetric?.inverse ? "inverse" : "",
@@ -521,6 +522,7 @@ export function generateDimensionRowsForMetric({
       const stepMetricId = funnelStepMetricId(metricId, stepIndex);
       rows.push({
         label: step.name,
+        dimensionValue: dimensionResult.name,
         metric: newMetric,
         metricOverrideFields: overrideFields,
         rowClass: newMetric?.inverse ? "inverse" : "",

--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -213,6 +213,10 @@ export type ExperimentTableRow = {
   // Funnel step row properties
   funnelStepIndex?: number;
   funnelStepOptional?: boolean;
+  // Dimension-table rows: the raw dimension value this row belongs to. On a
+  // parent row this equals its label; child rows (e.g. funnel steps) carry it
+  // because their label is the step name, not the dimension value.
+  dimensionValue?: string;
   isHiddenByFilter?: boolean;
   labelOnly?: boolean;
 };


### PR DESCRIPTION
### Features and Changes

Two fixes for funnel metrics on the experiment results and dashboards.

- In a time series dashboard block, you can expand the metric to see timeseries per step. Before this fix, we would render one graph per step, but the values inside were always from the 'overall row'. Now we properly use the data from each step.
- And clicking on a funnel step in a dimension breakdown row was not working. Now it works, opening the metric drilldown modal in the 'funnel' tab.

### Testing

- Manual testing
- Unit tests
