### PR TITLE
fix: don't analyze derived metrics whose parent metric are not included

### DIFF
--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -221,7 +221,9 @@ export function getSnapshotSettingsFromReportArgs(
       exp: args,
       expandedMetricMap: metricMap,
       includeActivationMetric: true,
-      metricGroups: [],
+      // Must match the groups used to expand the map above, otherwise group
+      // members (and now their derived metrics) are left out.
+      metricGroups,
     })
       .map((m) =>
         getMetricForSnapshot({
@@ -730,8 +732,15 @@ export function getReportSnapshotSettings({
           }
         : undefined;
 
+  // Use the scrubbed lists so metricSettings lines up with the goal/secondary/
+  // guardrail lists returned below (a scrubbed metric must not be queried).
   const metricSettings = getAllExpandedMetricIdsFromExperiment({
-    exp: report.experimentAnalysisSettings,
+    exp: {
+      goalMetrics,
+      secondaryMetrics,
+      guardrailMetrics,
+      activationMetric: report.experimentAnalysisSettings.activationMetric,
+    },
     expandedMetricMap: metricMap,
     includeActivationMetric: true,
     metricGroups,

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -205,6 +205,13 @@ export function getSnapshotSettingsFromReportArgs(
     stddev: DEFAULT_PROPER_PRIOR_STDDEV,
   };
 
+  const expandedArgs: LegacyExperimentReportArgs = {
+    ...args,
+    goalMetrics: expandMetricGroups(args.goalMetrics, metricGroups),
+    secondaryMetrics: expandMetricGroups(args.secondaryMetrics, metricGroups),
+    guardrailMetrics: expandMetricGroups(args.guardrailMetrics, metricGroups),
+  };
+
   // Expand derived metrics if factTableMap is provided
   if (factTableMap) {
     // Expand all derived metrics (slices and funnel steps) into the metricMap
@@ -218,12 +225,9 @@ export function getSnapshotSettingsFromReportArgs(
 
   const snapshotSettings: ExperimentSnapshotSettings = {
     metricSettings: getAllExpandedMetricIdsFromExperiment({
-      exp: args,
+      exp: expandedArgs,
       expandedMetricMap: metricMap,
       includeActivationMetric: true,
-      // Must match the groups used to expand the map above, otherwise group
-      // members (and now their derived metrics) are left out.
-      metricGroups,
     })
       .map((m) =>
         getMetricForSnapshot({
@@ -255,9 +259,9 @@ export function getSnapshotSettingsFromReportArgs(
     skipPartialData: !!args.skipPartialData,
     defaultMetricPriorSettings: defaultMetricPriorSettings,
     regressionAdjustmentEnabled: !!args.regressionAdjustmentEnabled,
-    goalMetrics: args.goalMetrics,
-    secondaryMetrics: args.secondaryMetrics,
-    guardrailMetrics: args.guardrailMetrics,
+    goalMetrics: expandedArgs.goalMetrics,
+    secondaryMetrics: expandedArgs.secondaryMetrics,
+    guardrailMetrics: expandedArgs.guardrailMetrics,
     dimensions: args.dimension ? [{ id: args.dimension }] : [],
     variations: args.variations.map((v) => ({
       id: v.id,
@@ -265,7 +269,7 @@ export function getSnapshotSettingsFromReportArgs(
     })),
     coverage: args.coverage,
   };
-  const analysisSettings = getAnalysisSettingsFromReportArgs(args);
+  const analysisSettings = getAnalysisSettingsFromReportArgs(expandedArgs);
 
   return { snapshotSettings, analysisSettings };
 }

--- a/packages/back-end/test/services/snapshot-planning.test.ts
+++ b/packages/back-end/test/services/snapshot-planning.test.ts
@@ -1,14 +1,19 @@
 import {
   ExperimentMetricInterface,
+  expandDerivedMetricsInMap,
   getMetricSnapshotSettings,
 } from "shared/experiments";
 import { ExperimentInterface } from "shared/types/experiment";
 import { DataSourceInterface } from "shared/types/datasource";
 import {
   ExperimentSnapshotAnalysisSettings,
+  ExperimentSnapshotSettings,
   MetricForSnapshot,
 } from "shared/types/experiment-snapshot";
-import { MetricSnapshotSettings } from "shared/types/report";
+import {
+  ExperimentSnapshotReportInterface,
+  MetricSnapshotSettings,
+} from "shared/types/report";
 import { ApiReqContext } from "back-end/types/api";
 import {
   assertIncrementalRefreshPrerequisites,
@@ -25,6 +30,8 @@ import {
   planSnapshot,
 } from "back-end/src/services/experiments";
 import { planMetricFanOut } from "back-end/src/services/experimentQueries/planMetricFanOut";
+import { getQueryableMetricsFromSnapshotSettings } from "back-end/src/services/experimentQueries/experimentQueries";
+import { getReportSnapshotSettings } from "back-end/src/services/reports";
 import { updateExperiment } from "back-end/src/models/ExperimentModel";
 import { getMetricMap } from "back-end/src/models/MetricModel";
 import {
@@ -329,6 +336,188 @@ describe("snapshot planning", () => {
     expect(createExperimentSnapshotModelMock).not.toHaveBeenCalled();
     expect(updateExperimentMock).not.toHaveBeenCalled();
     expect(updateExperimentDashboardsMock).not.toHaveBeenCalled();
+  });
+
+  // Exposure query identifies units by user_id; ft_joinable shares that id
+  // type, ft_orphan does not and the datasource has no identity join for it.
+  // Both metrics carry auto slices, so each expands into derived metrics.
+  function makeJoinabilityFixture() {
+    const datasource = makeDatasource({
+      settings: {
+        queries: {
+          exposure: [
+            {
+              id: "exposure_user",
+              name: "Users",
+              userIdType: "user_id",
+              query: "SELECT * FROM exposures",
+              dimensions: [],
+            },
+          ],
+        },
+      } as unknown as DataSourceInterface["settings"],
+    });
+    const sliceColumn = {
+      column: "country",
+      datatype: "string" as const,
+      name: "country",
+      description: "",
+      dateCreated: new Date(),
+      dateUpdated: new Date(),
+      numberFormat: "" as const,
+      deleted: false,
+      isAutoSliceColumn: true,
+      autoSlices: ["us", "ca"],
+    };
+    const joinableTable = factTableFactory.build({
+      id: "ft_joinable",
+      userIdTypes: ["user_id"],
+      columns: [sliceColumn],
+    });
+    const orphanTable = factTableFactory.build({
+      id: "ft_orphan",
+      userIdTypes: ["device_id"],
+      columns: [sliceColumn],
+    });
+    const factTableMap = new Map([
+      [joinableTable.id, joinableTable],
+      [orphanTable.id, orphanTable],
+    ]) as FactTableMap;
+    const joinableMetric = factMetricFactory.build({
+      id: "m_joinable",
+      numerator: { factTableId: "ft_joinable", column: "$$count" },
+      metricAutoSlices: ["country"],
+    });
+    const orphanMetric = factMetricFactory.build({
+      id: "m_orphan",
+      numerator: { factTableId: "ft_orphan", column: "$$count" },
+      metricAutoSlices: ["country"],
+    });
+    const metricMap = new Map<string, ExperimentMetricInterface>([
+      [joinableMetric.id, joinableMetric],
+      [orphanMetric.id, orphanMetric],
+    ]);
+    const settingsForSnapshotMetrics = [joinableMetric, orphanMetric].map(
+      (metric) =>
+        getMetricSnapshotSettings({
+          metric,
+          denominatorMetrics: [],
+          experimentRegressionAdjustmentEnabled: false,
+        }).metricSnapshotSettings,
+    );
+    return { datasource, factTableMap, metricMap, settingsForSnapshotMetrics };
+  }
+
+  function expectOnlyJoinableMetricsAnalyzed(
+    snapshotSettings: ExperimentSnapshotSettings,
+    metricMap: Map<string, ExperimentMetricInterface>,
+  ) {
+    const analyzedIds = snapshotSettings.metricSettings.map((m) => m.id);
+    expect(snapshotSettings.goalMetrics).toEqual(["m_joinable"]);
+    expect(analyzedIds).toContain("m_joinable");
+    expect(analyzedIds.some((id) => id.startsWith("m_joinable?dim:"))).toBe(
+      true,
+    );
+    expect(analyzedIds.filter((id) => id.startsWith("m_orphan"))).toEqual([]);
+
+    // The query runner selects metrics to query from these settings; the
+    // orphan's slices would otherwise reach the SQL builder, which has no way
+    // to join ft_orphan to the exposure units and fails the whole snapshot.
+    const queried = getQueryableMetricsFromSnapshotSettings(
+      snapshotSettings,
+      metricMap,
+    ).map((m) => m.id);
+    expect(queried.some((id) => id.startsWith("m_joinable?dim:"))).toBe(true);
+    expect(queried.filter((id) => id.startsWith("m_orphan"))).toEqual([]);
+  }
+
+  // Callers reach getSnapshotSettings both with a fresh metricMap and with one
+  // that was already expanded from the full experiment (e.g. the map built in
+  // createExperimentSnapshotFromPlan is reused for dashboard snapshots), so
+  // scrubbing must hold either way.
+  describe.each([
+    ["a fresh metricMap", false],
+    ["a metricMap already expanded from the unscrubbed experiment", true],
+  ])("snapshot settings with %s", (_label, preExpand) => {
+    it("do not analyze unjoinable metrics or their slices", () => {
+      const {
+        datasource,
+        factTableMap,
+        metricMap,
+        settingsForSnapshotMetrics,
+      } = makeJoinabilityFixture();
+      const experiment = makeExperiment({
+        exposureQueryId: "exposure_user",
+        goalMetrics: ["m_joinable", "m_orphan"],
+        metricOverrides: [],
+      });
+      if (preExpand) {
+        expandDerivedMetricsInMap({
+          metricMap,
+          factTableMap,
+          experiment,
+          metricGroups: [],
+        });
+      }
+
+      const snapshotSettings = getSnapshotSettings({
+        experiment,
+        phaseIndex: 0,
+        snapshotType: "standard",
+        dimension: null,
+        regressionAdjustmentEnabled: false,
+        orgPriorSettings: undefined,
+        orgDisabledPrecomputedDimensions: true,
+        settingsForSnapshotMetrics,
+        metricMap,
+        factTableMap,
+        metricGroups: [],
+        incrementalRefreshModel: null,
+        datasource,
+      });
+
+      expectOnlyJoinableMetricsAnalyzed(snapshotSettings, metricMap);
+    });
+  });
+
+  it("report settings drop unjoinable metrics and their slices", () => {
+    const { datasource, factTableMap, metricMap, settingsForSnapshotMetrics } =
+      makeJoinabilityFixture();
+    const experimentAnalysisSettings = {
+      exposureQueryId: "exposure_user",
+      goalMetrics: ["m_joinable", "m_orphan"],
+      secondaryMetrics: [],
+      guardrailMetrics: [],
+      metricOverrides: [],
+    };
+    // Report generation expands derived metrics from the unscrubbed report
+    // settings before building the snapshot settings.
+    expandDerivedMetricsInMap({
+      metricMap,
+      factTableMap,
+      experiment: experimentAnalysisSettings,
+      metricGroups: [],
+    });
+
+    const snapshotSettings = getReportSnapshotSettings({
+      report: {
+        experimentAnalysisSettings,
+        experimentMetadata: {
+          phases: [{ variationWeights: [0.5, 0.5] }],
+          variations: [{ key: "0" }, { key: "1" }],
+        },
+      } as unknown as ExperimentSnapshotReportInterface,
+      analysisSettings: makeAnalysisSettings(),
+      phaseIndex: 0,
+      orgPriorSettings: undefined,
+      settingsForSnapshotMetrics,
+      metricMap,
+      factTableMap,
+      metricGroups: [],
+      datasource,
+    });
+
+    expectOnlyJoinableMetricsAnalyzed(snapshotSettings, metricMap);
   });
 
   it("rejects a snapshot for an experiment with no metrics without persisting a record", async () => {

--- a/packages/back-end/test/services/snapshot-planning.test.ts
+++ b/packages/back-end/test/services/snapshot-planning.test.ts
@@ -12,8 +12,10 @@ import {
 } from "shared/types/experiment-snapshot";
 import {
   ExperimentSnapshotReportInterface,
+  LegacyExperimentReportArgs,
   MetricSnapshotSettings,
 } from "shared/types/report";
+import { MetricGroupInterface } from "shared/types/metric-groups";
 import { ApiReqContext } from "back-end/types/api";
 import {
   assertIncrementalRefreshPrerequisites,
@@ -31,7 +33,10 @@ import {
 } from "back-end/src/services/experiments";
 import { planMetricFanOut } from "back-end/src/services/experimentQueries/planMetricFanOut";
 import { getQueryableMetricsFromSnapshotSettings } from "back-end/src/services/experimentQueries/experimentQueries";
-import { getReportSnapshotSettings } from "back-end/src/services/reports";
+import {
+  getReportSnapshotSettings,
+  getSnapshotSettingsFromReportArgs,
+} from "back-end/src/services/reports";
 import { updateExperiment } from "back-end/src/models/ExperimentModel";
 import { getMetricMap } from "back-end/src/models/MetricModel";
 import {
@@ -518,6 +523,74 @@ describe("snapshot planning", () => {
     });
 
     expectOnlyJoinableMetricsAnalyzed(snapshotSettings, metricMap);
+  });
+
+  it("expands legacy report metric groups consistently", () => {
+    const metricGroups = [
+      { id: "mg_goal", metrics: ["m_goal_a", "m_goal_b"] },
+      { id: "mg_secondary", metrics: ["m_secondary"] },
+      { id: "mg_guardrail", metrics: ["m_guardrail_a", "m_guardrail_b"] },
+    ].map(
+      ({ id, metrics }): MetricGroupInterface => ({
+        id,
+        organization: "org_123",
+        dateCreated: new Date(),
+        dateUpdated: new Date(),
+        owner: "",
+        name: id,
+        description: "",
+        tags: [],
+        projects: [],
+        metrics,
+        datasource: "ds_123",
+        archived: false,
+      }),
+    );
+    const metrics = metricGroups
+      .flatMap((group) => group.metrics)
+      .map((id) => factMetricFactory.build({ id }));
+    const metricMap = new Map<string, ExperimentMetricInterface>(
+      metrics.map((metric) => [metric.id, metric]),
+    );
+    const args: LegacyExperimentReportArgs = {
+      trackingKey: "experiment",
+      datasource: "ds_123",
+      exposureQueryId: "exposure",
+      startDate: new Date(),
+      variations: [
+        { id: "0", index: 0, name: "Control", weight: 0.5 },
+        { id: "1", index: 1, name: "Treatment", weight: 0.5 },
+      ],
+      goalMetrics: ["mg_goal"],
+      secondaryMetrics: ["mg_secondary"],
+      guardrailMetrics: ["mg_guardrail"],
+      decisionFrameworkSettings: {},
+    };
+
+    const { snapshotSettings, analysisSettings } =
+      getSnapshotSettingsFromReportArgs(
+        args,
+        metricMap,
+        undefined,
+        undefined,
+        metricGroups,
+      );
+
+    expect(snapshotSettings.metricSettings.map((metric) => metric.id)).toEqual([
+      "m_goal_a",
+      "m_goal_b",
+      "m_secondary",
+      "m_guardrail_a",
+      "m_guardrail_b",
+    ]);
+    expect(snapshotSettings.goalMetrics).toEqual(["m_goal_a", "m_goal_b"]);
+    expect(snapshotSettings.secondaryMetrics).toEqual(["m_secondary"]);
+    expect(snapshotSettings.guardrailMetrics).toEqual([
+      "m_guardrail_a",
+      "m_guardrail_b",
+    ]);
+    expect(analysisSettings.numGoalMetrics).toBe(2);
+    expect(analysisSettings.numGuardrailMetrics).toBe(2);
   });
 
   it("rejects a snapshot for an experiment with no metrics without persisting a record", async () => {

--- a/packages/shared/src/experiments/experiments.ts
+++ b/packages/shared/src/experiments/experiments.ts
@@ -2152,12 +2152,16 @@ export function getAllExpandedMetricIdsFromExperiment({
 
   // Scoop up expanded metric ids that only exist in the map, not in the base
   // experiment: slice metrics (dim:, standard and custom) and funnel step
-  // metrics (step=).
+  // metrics (step=). The map is often expanded from a wider set of metrics than
+  // `exp` (e.g. before unjoinable metrics were scrubbed), so only take derived
+  // metrics whose parent is actually being analyzed.
   expandedMetricMap.forEach((_, metricId) => {
-    if (
-      /[?&]dim:/.test(metricId) ||
-      parseFunnelStepMetricId(metricId).isFunnelStepMetric
-    ) {
+    const step = parseFunnelStepMetricId(metricId);
+    if (!step.isFunnelStepMetric && !/[?&]dim:/.test(metricId)) return;
+    const parentId = step.isFunnelStepMetric
+      ? step.baseMetricId
+      : parseSliceMetricId(metricId).baseMetricId;
+    if (expandedMetricIds.has(parentId)) {
       expandedMetricIds.add(metricId);
     }
   });

--- a/packages/shared/test/experiments.test.ts
+++ b/packages/shared/test/experiments.test.ts
@@ -5,6 +5,7 @@ import {
   FactFilterInterface,
 } from "shared/types/fact-table";
 import { IndexedPValue } from "shared/types/stats";
+import { MetricGroupInterface } from "shared/types/metric-groups";
 import {
   getColumnRefWhereClause,
   canInlineFilterColumn,
@@ -22,6 +23,8 @@ import {
   getRowFilterSQL,
   getEffectiveLookbackOverride,
   getIntersectionBaseMetricIds,
+  getAllExpandedMetricIdsFromExperiment,
+  ExperimentMetricInterface,
 } from "../src/experiments";
 import { createLikeStringMatchFn } from "../src/sql";
 import { LookbackOverride } from "../src/validators/experiments";
@@ -2299,6 +2302,64 @@ describe("getIntersectionBaseMetricIds", () => {
         ["m_b", "m_a?dim:x=y", "m_a"],
       ),
     ).toEqual(["m_b", "m_a"]);
+  });
+});
+
+describe("getAllExpandedMetricIdsFromExperiment", () => {
+  // The collector only inspects ids, so the map values can be placeholders.
+  const mapOf = (...ids: string[]) =>
+    new Map(
+      ids.map((id) => [id, { id } as unknown as ExperimentMetricInterface]),
+    );
+
+  it("includes derived metrics of the metrics being analyzed", () => {
+    const ids = getAllExpandedMetricIdsFromExperiment({
+      exp: { goalMetrics: ["m_a"], guardrailMetrics: ["f_b"] },
+      expandedMetricMap: mapOf(
+        "m_a",
+        "m_a?dim:country=us",
+        "m_a?dim:country=",
+        "m_a?dim:a=1&dim:b=2",
+        "f_b",
+        "f_b?step=0",
+      ),
+    });
+    expect(ids.sort()).toEqual(
+      [
+        "m_a",
+        "m_a?dim:country=us",
+        "m_a?dim:country=",
+        "m_a?dim:a=1&dim:b=2",
+        "f_b",
+        "f_b?step=0",
+      ].sort(),
+    );
+  });
+
+  it("ignores derived metrics whose parent is not being analyzed", () => {
+    // e.g. the map was expanded before an unjoinable metric was scrubbed
+    const ids = getAllExpandedMetricIdsFromExperiment({
+      exp: { goalMetrics: ["m_a"] },
+      expandedMetricMap: mapOf(
+        "m_a",
+        "m_a?dim:country=us",
+        "m_orphan",
+        "m_orphan?dim:country=us",
+        "f_orphan?step=0",
+      ),
+    });
+    expect(ids.sort()).toEqual(["m_a", "m_a?dim:country=us"].sort());
+  });
+
+  it("resolves parents through metric groups", () => {
+    const ids = getAllExpandedMetricIdsFromExperiment({
+      exp: { goalMetrics: ["mg_1"] },
+      expandedMetricMap: mapOf("m_a", "m_a?dim:x=1"),
+      metricGroups: [
+        { id: "mg_1", metrics: ["m_a"] } as unknown as MetricGroupInterface,
+      ],
+    });
+    expect(ids.sort()).toEqual(["m_a", "m_a?dim:x=1"].sort());
   });
 });
 


### PR DESCRIPTION
### Features and Changes

When an experiment's metric can't be joined to the exposure query (its fact table shares no identifier type with the exposure query and the datasource has no identity join between them), `getSnapshotSettings` scrubs it from the goal/secondary/guardrail lists. But the metric's derived metrics — auto slices, custom slices, funnel steps — were still analyzed: `getAllExpandedMetricIdsFromExperiment` collected every derived id present in the metric map, and the map is routinely expanded from the full experiment (before scrubbing, or by a caller further up such as `createExperimentSnapshotFromPlan`, whose map is reused for dashboard snapshots).

The first orphaned slice then fails SQL generation with `Missing identifier join table for 'a' and 'b'`, which fails the entire refresh. Net effect: adding auto slices to a metric that isn't joinable for a given experiment makes that experiment permanently un-refreshable, even though the metric itself is (correctly) skipped.

Changes:

- `getAllExpandedMetricIdsFromExperiment` only collects derived metrics whose parent is one of the metrics being analyzed. This fixes experiment snapshots (including the pre-expanded-map path) and the experiment time series, which would otherwise record empty data points for orphaned slices.
- `getReportSnapshotSettings` built `metricSettings` from the unscrubbed report settings, so for reports even the base unjoinable metrics were queried; it now uses the scrubbed lists.
- `getSnapshotSettingsFromReportArgs` (legacy reports/notebooks) expanded the map with the real metric groups but collected with `metricGroups: []`; with the parent check that would have dropped group members' derived metrics, so it now collects with the same groups. Side effect: group members are now included as base metrics there too, which the expansion step already assumed.

Other callers of the collector (`experimentTimeSeries`, `AnalysisSettingsSummary`, funnels tests) expand and collect from the same lists, so their output is unchanged.

Not changed, but related: `getSafeRolloutSnapshotSettings` has the same mismatch for guardrails (scrubbed `guardrailMetrics`, unscrubbed `metricSettings`), so an unjoinable guardrail currently fails the safe rollout snapshot outright. Building `metricSettings` from the scrubbed list would instead silently stop monitoring that guardrail, which seemed like a product decision rather than a bug fix, so I've left it as-is and am just flagging it.

- Closes N/A (no issue filed; happy to open one)

### Dependencies

None

### Testing

- `shared/test/experiments.test.ts`: collector keeps derived ids for analyzed parents (slices, multi-column slices, funnel steps, parents reached via metric groups) and ignores derived ids whose parent isn't analyzed — the latter fails on `main`.
- `back-end/test/services/snapshot-planning.test.ts`: an experiment with a joinable and a non-joinable auto-sliced metric, run both with a fresh metric map and with a map pre-expanded from the full experiment; asserts the non-joinable metric and its slices are absent from `metricSettings` and from `getQueryableMetricsFromSnapshotSettings` (what the query runner selects). Plus a report-path variant. Both fail on `main`.
- Manually drove the same fixture (pre-expanded map) through `getFactMetricGroups` and the Postgres integration's `getExperimentFactMetricsQuery`: on `main` each orphaned slice throws `Missing identifier join table for 'user_id' and 'device_id'`; with this change only the joinable metric and its slices are selected and every query builds.

### Screenshots

N/A (back-end only)