### PR TITLE
docs: update Statsig migration tutorial video

### DIFF
--- a/docs/docs/guide/migrate-from-statsig.mdx
+++ b/docs/docs/guide/migrate-from-statsig.mdx
@@ -9,7 +9,7 @@ import MaxWidthImage from "@site/src/components/MaxWidthImage";
 
 This guide walks through migrating feature flags, experiments, and SDKs from Statsig to GrowthBook.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/6bYVm-px-As" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen style={{
+<iframe width="560" height="315" src="https://www.youtube.com/embed/X8RDc_klHBQ" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen style={{
   aspectRatio: "16/9",
   width: "100%",
   height: "auto",


### PR DESCRIPTION
### Features and Changes

Replaces the outdated YouTube embed on the Statsig migration tutorial with the current video.

- Updates `docs/docs/guide/migrate-from-statsig.mdx` to embed https://www.youtube.com/watch?v=X8RDc_klHBQ

### Dependencies

None

### Testing

- [ ] Open [Migrate from Statsig](https://docs.growthbook.io/guide/migrate-from-statsig) after deploy
- [ ] Confirm the embedded video is https://www.youtube.com/watch?v=X8RDc_klHBQ and plays correctly

### Screenshots

N/A (embed URL swap only)

Made with [Cursor](https://cursor.com)