### PR TITLE
feat(dashboards): add standalone read-only DashboardView component

### DIFF
--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardCanvas.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardCanvas.tsx
@@ -1,0 +1,84 @@
+import {
+  DashboardBlockInterface,
+  DashboardBlockInterfaceOrData,
+  DashboardInterface,
+} from "shared/enterprise";
+import { Flex } from "@radix-ui/themes";
+import Heading from "@/ui/Heading";
+import Text from "@/ui/Text";
+import { DashboardChartsProvider } from "@/enterprise/components/Dashboards/DashboardChartsContext";
+import DashboardBlock from "./DashboardBlock";
+import DashboardGrid from "./DashboardGrid";
+
+export default function DashboardCanvas({
+  blocks,
+  globalControls,
+  dashboardComparison,
+  isGeneralDashboard = true,
+  mutate,
+}: {
+  blocks: DashboardBlockInterfaceOrData<DashboardBlockInterface>[];
+  globalControls?: DashboardInterface["globalControls"];
+  dashboardComparison?: DashboardInterface["comparison"];
+  isGeneralDashboard?: boolean;
+  mutate?: () => void;
+}) {
+  if (blocks.length === 0) {
+    return (
+      <Flex
+        direction="column"
+        align="center"
+        justify="center"
+        px="80px"
+        pt="60px"
+        pb="70px"
+        className="appbox"
+        gap="5"
+      >
+        <Flex direction="column">
+          <Heading as="h1" size="lg" weight="medium" align="center">
+            No Blocks Yet
+          </Heading>
+          <Text align="center">This dashboard has no blocks yet.</Text>
+        </Flex>
+      </Flex>
+    );
+  }
+
+  return (
+    <DashboardChartsProvider>
+      <DashboardGrid
+        blocks={blocks}
+        isEditing={false}
+        editSidebarDirty={false}
+        stagedBlockIndex={undefined}
+        isAddingBlock={false}
+        updateLayout={undefined}
+        addBlockType={undefined}
+        isGeneralDashboard={isGeneralDashboard}
+        renderBlock={(block, i) => (
+          <DashboardBlock
+            isTabActive
+            block={block}
+            dashboardGlobalControls={globalControls}
+            dashboardComparison={dashboardComparison}
+            blockIndex={i}
+            isEditing={false}
+            isFocused={false}
+            editingBlock={false}
+            canMoveBlock={false}
+            disableBlock="none"
+            scrollAreaRef={null}
+            setBlock={undefined}
+            editBlock={() => undefined}
+            duplicateBlock={() => undefined}
+            deleteBlock={() => undefined}
+            isGeneralDashboard={isGeneralDashboard}
+            mutate={mutate ?? (() => undefined)}
+            canEdit={false}
+          />
+        )}
+      />
+    </DashboardChartsProvider>
+  );
+}

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardGrid.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardGrid.tsx
@@ -1,0 +1,253 @@
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  DashboardBlockInterface,
+  DashboardBlockInterfaceOrData,
+  DashboardBlockType,
+  DASHBOARD_GRID_COLS,
+  DASHBOARD_GRID_ROW_HEIGHT_DEFAULT,
+} from "shared/enterprise";
+import { isDefined } from "shared/util";
+import clsx from "clsx";
+import {
+  LayoutItem,
+  ResponsiveGridLayout,
+  useContainerWidth,
+  verticalCompactor,
+} from "react-grid-layout";
+import Button from "@/ui/Button";
+import Tooltip from "@/components/Tooltip/Tooltip";
+import { AddBlockDropdown } from "./DashboardBlockTypeMenu";
+import { getAvailableBlockTypes } from "./dashboardBlockTypes";
+import {
+  AddBlockOptions,
+  blockFitsGap,
+  buildRGLLayout,
+  DASHBOARD_GRID_MARGIN,
+  getGridKeyForBlock,
+  getHorizontalGridGaps,
+  gridRectToPixels,
+} from "./dashboardLayout";
+
+const RGL_BREAKPOINTS = { lg: 1200, md: 996, sm: 768, xs: 0 } as const;
+const RGL_COLS = {
+  lg: DASHBOARD_GRID_COLS,
+  md: DASHBOARD_GRID_COLS,
+  sm: DASHBOARD_GRID_COLS,
+  xs: DASHBOARD_GRID_COLS,
+} as const;
+const RGL_CANONICAL_BREAKPOINT: keyof typeof RGL_BREAKPOINTS = "lg";
+
+const CANONICAL_COL_BREAKPOINTS: ReadonlyArray<keyof typeof RGL_BREAKPOINTS> = (
+  Object.keys(RGL_COLS) as Array<keyof typeof RGL_COLS>
+).filter((bp) => RGL_COLS[bp] === RGL_COLS[RGL_CANONICAL_BREAKPOINT]);
+
+export interface DashboardGridProps {
+  blocks: DashboardBlockInterfaceOrData<DashboardBlockInterface>[];
+  isEditing: boolean;
+  editSidebarDirty: boolean;
+  stagedBlockIndex: number | undefined;
+  isAddingBlock: boolean;
+  updateLayout: ((layout: readonly LayoutItem[]) => void) | undefined;
+  addBlockType:
+    | ((blockType: DashboardBlockType, options?: AddBlockOptions) => void)
+    | undefined;
+  isGeneralDashboard: boolean;
+  renderBlock: (
+    block: DashboardBlockInterfaceOrData<DashboardBlockInterface>,
+    index: number,
+  ) => React.ReactNode;
+}
+
+export default function DashboardGrid({
+  blocks,
+  isEditing,
+  editSidebarDirty,
+  stagedBlockIndex,
+  isAddingBlock,
+  updateLayout,
+  addBlockType,
+  isGeneralDashboard,
+  renderBlock,
+}: DashboardGridProps) {
+  const { width, containerRef, mounted } = useContainerWidth({
+    initialWidth: 1280,
+  });
+  const [openGapKey, setOpenGapKey] = useState<string | null>(null);
+  const [isGridInteracting, setIsGridInteracting] = useState(false);
+
+  const layout = useMemo(() => {
+    const nextLayout = buildRGLLayout(
+      blocks,
+      RGL_COLS[RGL_CANONICAL_BREAKPOINT],
+    );
+    if (!isDefined(stagedBlockIndex) || isAddingBlock) return nextLayout;
+    return nextLayout.map((item, index) => ({
+      ...item,
+      static: index !== stagedBlockIndex,
+    }));
+  }, [blocks, isAddingBlock, stagedBlockIndex]);
+  const gaps = useMemo(() => {
+    if (
+      !isEditing ||
+      !addBlockType ||
+      editSidebarDirty ||
+      isGridInteracting ||
+      blocks.some((block) => !block.layout) ||
+      isDefined(stagedBlockIndex)
+    ) {
+      return [];
+    }
+    const allowedBlockTypes = getAvailableBlockTypes(isGeneralDashboard);
+    return getHorizontalGridGaps(layout).filter((gap) =>
+      allowedBlockTypes.some((blockType) => blockFitsGap(blockType, gap)),
+    );
+  }, [
+    addBlockType,
+    blocks,
+    editSidebarDirty,
+    isEditing,
+    isGeneralDashboard,
+    isGridInteracting,
+    layout,
+    stagedBlockIndex,
+  ]);
+  const layouts = useMemo(() => {
+    return Object.fromEntries(
+      CANONICAL_COL_BREAKPOINTS.map((bp) => [bp, layout]),
+    ) as Partial<Record<keyof typeof RGL_BREAKPOINTS, LayoutItem[]>>;
+  }, [layout]);
+
+  const persistLayout = useCallback(
+    (next: readonly LayoutItem[]) => {
+      if (!updateLayout) return;
+      updateLayout(next);
+    },
+    [updateLayout],
+  );
+
+  const isInteractive = isEditing && !isAddingBlock;
+  const showDisabledResizeOverlay = isEditing && !isInteractive;
+
+  return (
+    <div
+      ref={containerRef as unknown as React.RefObject<HTMLDivElement>}
+      className={clsx("dashboard-grid-container", { "is-editing": isEditing })}
+    >
+      {mounted && (
+        <ResponsiveGridLayout
+          width={width}
+          className={clsx("dashboard-grid", {
+            "is-editing": isEditing,
+            "is-resize-disabled": showDisabledResizeOverlay,
+          })}
+          layouts={layouts}
+          breakpoints={RGL_BREAKPOINTS}
+          cols={RGL_COLS}
+          rowHeight={DASHBOARD_GRID_ROW_HEIGHT_DEFAULT}
+          margin={[DASHBOARD_GRID_MARGIN, DASHBOARD_GRID_MARGIN]}
+          containerPadding={[0, 0]}
+          dragConfig={{
+            enabled: isInteractive,
+            handle: ".dashboard-block-drag-handle",
+            bounded: false,
+            threshold: 3,
+          }}
+          resizeConfig={{
+            enabled: isInteractive,
+            handles: ["se", "sw"],
+          }}
+          compactor={verticalCompactor}
+          onDragStart={() => {
+            setOpenGapKey(null);
+            setIsGridInteracting(true);
+          }}
+          onDragStop={(curr) => {
+            persistLayout(curr);
+            setIsGridInteracting(false);
+          }}
+          onResizeStart={() => {
+            setOpenGapKey(null);
+            setIsGridInteracting(true);
+          }}
+          onResizeStop={(curr) => {
+            persistLayout(curr);
+            setIsGridInteracting(false);
+          }}
+        >
+          {blocks.map((block, i) => {
+            const key = getGridKeyForBlock(block, i);
+            return (
+              <div
+                key={key}
+                className={clsx("dashboard-grid-item", {
+                  "is-grid-interaction-disabled":
+                    isDefined(stagedBlockIndex) && i !== stagedBlockIndex,
+                })}
+              >
+                {renderBlock(block, i)}
+                {showDisabledResizeOverlay && (
+                  <Tooltip
+                    body="Close the edit panel to resize this block"
+                    tipPosition="top"
+                    className="dashboard-resize-handle-disabled-overlay"
+                    usePortal
+                  >
+                    <span aria-hidden />
+                  </Tooltip>
+                )}
+              </div>
+            );
+          })}
+        </ResponsiveGridLayout>
+      )}
+      {mounted &&
+        addBlockType &&
+        gaps.map((gap) => {
+          const gapKey = `${gap.x}-${gap.y}-${gap.w}-${gap.h}`;
+          const gapStyle = gridRectToPixels({
+            rect: gap,
+            containerWidth: width,
+            rowHeight: DASHBOARD_GRID_ROW_HEIGHT_DEFAULT,
+          });
+
+          return (
+            <div
+              key={gapKey}
+              className={clsx("dashboard-grid-add-block-gap", {
+                "is-open": openGapKey === gapKey,
+              })}
+              style={gapStyle}
+            >
+              <AddBlockDropdown
+                isGeneralDashboard={isGeneralDashboard}
+                filterBlockType={(blockType) => blockFitsGap(blockType, gap)}
+                onDropdownOpen={() => setOpenGapKey(gapKey)}
+                onDropdownClose={() =>
+                  setOpenGapKey((currentKey) =>
+                    currentKey === gapKey ? null : currentKey,
+                  )
+                }
+                addBlockType={(blockType) => {
+                  addBlockType(blockType, {
+                    index: gap.insertIndex,
+                    placement: "gap",
+                    initialLayout: {
+                      x: gap.x,
+                      y: gap.y,
+                      w: gap.w,
+                      h: gap.h,
+                    },
+                  });
+                }}
+                trigger={
+                  <Button size="sm" variant="outline">
+                    Add block
+                  </Button>
+                }
+              />
+            </div>
+          );
+        })}
+    </div>
+  );
+}

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/dashboardLayout.ts
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/dashboardLayout.ts
@@ -3,6 +3,7 @@ import {
   DashboardBlockInterface,
   DashboardBlockInterfaceOrData,
   DashboardBlockType,
+  dashboardBlockHasIds,
   getBlockSizeBounds,
 } from "shared/enterprise";
 import { LayoutItem } from "react-grid-layout";
@@ -323,4 +324,81 @@ export function gridRectToPixels({
     width: rect.w * columnWidth + (rect.w - 1) * DASHBOARD_GRID_MARGIN,
     height: rect.h * rowHeight + (rect.h - 1) * DASHBOARD_GRID_MARGIN,
   };
+}
+
+export function getGridKeyForBlock(
+  block: DashboardBlockInterfaceOrData<DashboardBlockInterface>,
+  index: number,
+): string {
+  return dashboardBlockHasIds(block) ? block.id : `__staged_block_${index}__`;
+}
+
+export function buildRGLLayout(
+  blocks: DashboardBlockInterfaceOrData<DashboardBlockInterface>[],
+  cols: number = DASHBOARD_GRID_COLS,
+): LayoutItem[] {
+  let nextY = 0;
+  blocks.forEach((b) => {
+    if (b.layout) {
+      nextY = Math.max(nextY, b.layout.y + b.layout.h);
+    }
+  });
+  return blocks.map((block, index) => {
+    const i = getGridKeyForBlock(block, index);
+    const bounds = getBlockSizeBounds(block.type);
+    const maxW = cols;
+    if (block.layout) {
+      const item: LayoutItem = {
+        i,
+        x: block.layout.x,
+        y: block.layout.y,
+        w: Math.min(block.layout.w, maxW),
+        h: Math.max(1, block.layout.h),
+        minW: bounds.minW,
+        minH: bounds.minH,
+        maxW,
+      };
+      if (block.layout.static) item.static = true;
+      return item;
+    }
+    const w = Math.min(bounds.w, maxW);
+    const h = Math.max(1, bounds.h);
+    const layout: LayoutItem = {
+      i,
+      x: 0,
+      y: nextY,
+      w,
+      h,
+      minW: bounds.minW,
+      minH: bounds.minH,
+      maxW,
+    };
+    nextY += h;
+    return layout;
+  });
+}
+
+export function getPreviewBlocks<
+  T extends DashboardBlockInterfaceOrData<DashboardBlockInterface>,
+>(blocks: T[], maxBlocks?: number): T[] {
+  if (maxBlocks === undefined) return blocks;
+
+  const sorted = [...blocks].sort((a, b) => {
+    const ay = a.layout?.y ?? Number.POSITIVE_INFINITY;
+    const by = b.layout?.y ?? Number.POSITIVE_INFINITY;
+    if (ay !== by) return ay - by;
+    return (a.layout?.x ?? 0) - (b.layout?.x ?? 0);
+  });
+  const visible = sorted.slice(0, maxBlocks);
+  const minY = visible.reduce(
+    (min, block) => Math.min(min, block.layout?.y ?? 0),
+    Number.POSITIVE_INFINITY,
+  );
+  if (!Number.isFinite(minY) || minY === 0) return visible;
+
+  return visible.map((block) =>
+    block.layout
+      ? { ...block, layout: { ...block.layout, y: block.layout.y - minY } }
+      : block,
+  );
 }

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/index.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/index.tsx
@@ -640,12 +640,16 @@ function DashboardEditor({
           >
             <Flex direction="column">
               <Heading as="h1" size="lg" weight="medium" align="center">
-                Add Content Blocks
+                {addBlockType || (canEdit && setIsEditing)
+                  ? "Add Content Blocks"
+                  : "No Blocks Yet"}
               </Heading>
               <Text align="center">
                 {addBlockType
                   ? "Choose a block type to get started."
-                  : "Add some blocks to get started"}
+                  : canEdit && setIsEditing
+                    ? "Add some blocks to get started"
+                    : "This dashboard has no blocks yet."}
               </Text>
             </Flex>
             {addBlockType ? (

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/index.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/index.tsx
@@ -1,30 +1,21 @@
-import React, { useCallback, useContext, useMemo, useState } from "react";
+import React, { useContext, useMemo, useState } from "react";
 import { PiCaretDownFill, PiPencilSimpleFill } from "react-icons/pi";
 import { BsThreeDotsVertical } from "react-icons/bs";
 import {
   DashboardBlockInterfaceOrData,
   DashboardBlockInterface,
   DashboardBlockType,
-  dashboardBlockHasIds,
   getBlockData,
   DashboardEditLevel,
   DashboardInterface,
   DashboardShareLevel,
   DashboardUpdateSchedule,
-  DASHBOARD_GRID_COLS,
-  DASHBOARD_GRID_ROW_HEIGHT_DEFAULT,
-  getBlockSizeBounds,
 } from "shared/enterprise";
 import { isDefined } from "shared/util";
 import { Box, Flex, IconButton } from "@radix-ui/themes";
 import clsx from "clsx";
 import { withErrorBoundary } from "@sentry/nextjs";
-import {
-  LayoutItem,
-  ResponsiveGridLayout,
-  useContainerWidth,
-  verticalCompactor,
-} from "react-grid-layout";
+import { LayoutItem } from "react-grid-layout";
 import Heading from "@/ui/Heading";
 import Text from "@/ui/Text";
 import Button from "@/ui/Button";
@@ -52,93 +43,10 @@ import DashboardUpdateDisplay from "./DashboardUpdateDisplay";
 import DashboardBlock from "./DashboardBlock";
 import DashboardGlobalControlsBar from "./DashboardGlobalControlsBar";
 import { AddBlockDropdown } from "./DashboardBlockTypeMenu";
-import { getAvailableBlockTypes } from "./dashboardBlockTypes";
-import {
-  AddBlockOptions,
-  blockFitsGap,
-  DASHBOARD_GRID_MARGIN,
-  getHorizontalGridGaps,
-  gridRectToPixels,
-} from "./dashboardLayout";
+import { AddBlockOptions } from "./dashboardLayout";
+import DashboardGrid from "./DashboardGrid";
 
 export const DASHBOARD_TOPBAR_HEIGHT = "40px";
-// Stable RGL key for a block (uses block id when persisted, else a synthetic
-// key for the at-most-one staged add block).
-export function getGridKeyForBlock(
-  block: DashboardBlockInterfaceOrData<DashboardBlockInterface>,
-  index: number,
-): string {
-  return dashboardBlockHasIds(block) ? block.id : `__staged_block_${index}__`;
-}
-
-// Build the RGL LayoutItem[] from blocks. Blocks without an existing layout
-// get stacked full-width below the highest occupied y so they don't collide.
-// minW/minH come from the shared per-type defaults; maxW is the absolute grid
-// cap. Height is intentionally uncapped. None of these constraints are
-// persisted.
-export function buildRGLLayout(
-  blocks: DashboardBlockInterfaceOrData<DashboardBlockInterface>[],
-  cols: number = DASHBOARD_GRID_COLS,
-): LayoutItem[] {
-  let nextY = 0;
-  blocks.forEach((b) => {
-    if (b.layout) {
-      nextY = Math.max(nextY, b.layout.y + b.layout.h);
-    }
-  });
-  return blocks.map((block, index) => {
-    const i = getGridKeyForBlock(block, index);
-    const bounds = getBlockSizeBounds(block.type);
-    const maxW = cols;
-    if (block.layout) {
-      const item: LayoutItem = {
-        i,
-        x: block.layout.x,
-        y: block.layout.y,
-        w: Math.min(block.layout.w, maxW),
-        h: Math.max(1, block.layout.h),
-        minW: bounds.minW,
-        minH: bounds.minH,
-        maxW,
-      };
-      if (block.layout.static) item.static = true;
-      return item;
-    }
-    const w = Math.min(bounds.w, maxW);
-    const h = Math.max(1, bounds.h);
-    const layout: LayoutItem = {
-      i,
-      x: 0,
-      y: nextY,
-      w,
-      h,
-      minW: bounds.minW,
-      minH: bounds.minH,
-      maxW,
-    };
-    nextY += h;
-    return layout;
-  });
-}
-
-// Every breakpoint uses the same canonical column count. We intentionally do
-// NOT degrade to fewer cols at narrower widths because RGL's auto-derived
-// layout for a smaller-col breakpoint compacts in *array order*, silently
-// reordering the user's saved x positions. Keeping cols constant means cells
-// just shrink proportionally and the canonical layout is always honored,
-// regardless of the container width (e.g. when the editing drawer opens).
-const RGL_BREAKPOINTS = { lg: 1200, md: 996, sm: 768, xs: 0 } as const;
-const RGL_COLS = {
-  lg: DASHBOARD_GRID_COLS,
-  md: DASHBOARD_GRID_COLS,
-  sm: DASHBOARD_GRID_COLS,
-  xs: DASHBOARD_GRID_COLS,
-} as const;
-const RGL_CANONICAL_BREAKPOINT: keyof typeof RGL_BREAKPOINTS = "lg";
-
-const CANONICAL_COL_BREAKPOINTS: ReadonlyArray<keyof typeof RGL_BREAKPOINTS> = (
-  Object.keys(RGL_COLS) as Array<keyof typeof RGL_COLS>
-).filter((bp) => RGL_COLS[bp] === RGL_COLS[RGL_CANONICAL_BREAKPOINT]);
 
 interface EditBlockProps {
   scrollAreaRef: null | React.MutableRefObject<HTMLDivElement | null>;
@@ -640,16 +548,12 @@ function DashboardEditor({
           >
             <Flex direction="column">
               <Heading as="h1" size="lg" weight="medium" align="center">
-                {addBlockType || (canEdit && setIsEditing)
-                  ? "Add Content Blocks"
-                  : "No Blocks Yet"}
+                Add Content Blocks
               </Heading>
               <Text align="center">
                 {addBlockType
                   ? "Choose a block type to get started."
-                  : canEdit && setIsEditing
-                    ? "Add some blocks to get started"
-                    : "This dashboard has no blocks yet."}
+                  : "Add some blocks to get started"}
               </Text>
             </Flex>
             {addBlockType ? (
@@ -721,245 +625,6 @@ function DashboardEditor({
         {isEditing && <div style={{ height: 350 }} />}
       </div>
     </DashboardChartsProvider>
-  );
-}
-
-interface DashboardGridProps {
-  blocks: DashboardBlockInterfaceOrData<DashboardBlockInterface>[];
-  isEditing: boolean;
-  editSidebarDirty: boolean;
-  stagedBlockIndex: number | undefined;
-  isAddingBlock: boolean;
-  updateLayout: ((layout: readonly LayoutItem[]) => void) | undefined;
-  addBlockType:
-    | ((blockType: DashboardBlockType, options?: AddBlockOptions) => void)
-    | undefined;
-  isGeneralDashboard: boolean;
-  renderBlock: (
-    block: DashboardBlockInterfaceOrData<DashboardBlockInterface>,
-    index: number,
-  ) => React.ReactNode;
-}
-
-// Wraps blocks in react-grid-layout so users can drag, drop, and resize.
-// Drag/resize are disabled outside edit mode and while a new block is being
-// added. We only persist layout changes from the canonical (lg)
-// breakpoint; smaller breakpoints are auto-derived for responsive viewing only.
-function DashboardGrid({
-  blocks,
-  isEditing,
-  editSidebarDirty,
-  stagedBlockIndex,
-  isAddingBlock,
-  updateLayout,
-  addBlockType,
-  isGeneralDashboard,
-  renderBlock,
-}: DashboardGridProps) {
-  const { width, containerRef, mounted } = useContainerWidth({
-    initialWidth: 1280,
-  });
-  const [openGapKey, setOpenGapKey] = useState<string | null>(null);
-  const [isGridInteracting, setIsGridInteracting] = useState(false);
-
-  const layout = useMemo(() => {
-    const nextLayout = buildRGLLayout(
-      blocks,
-      RGL_COLS[RGL_CANONICAL_BREAKPOINT],
-    );
-    if (!isDefined(stagedBlockIndex) || isAddingBlock) return nextLayout;
-    return nextLayout.map((item, index) => ({
-      ...item,
-      static: index !== stagedBlockIndex,
-    }));
-  }, [blocks, isAddingBlock, stagedBlockIndex]);
-  const gaps = useMemo(() => {
-    if (
-      !isEditing ||
-      !addBlockType ||
-      editSidebarDirty ||
-      isGridInteracting ||
-      blocks.some((block) => !block.layout) ||
-      isDefined(stagedBlockIndex)
-    ) {
-      return [];
-    }
-    const allowedBlockTypes = getAvailableBlockTypes(isGeneralDashboard);
-    return getHorizontalGridGaps(layout).filter((gap) =>
-      allowedBlockTypes.some((blockType) => blockFitsGap(blockType, gap)),
-    );
-  }, [
-    addBlockType,
-    blocks,
-    editSidebarDirty,
-    isEditing,
-    isGeneralDashboard,
-    isGridInteracting,
-    layout,
-    stagedBlockIndex,
-  ]);
-  // Every breakpoint shares the same canonical column count, so we hand RGL
-  // the same layout for all of them. This is what makes side-by-side blocks
-  // keep their x positions when the editing drawer narrows the container.
-  const layouts = useMemo(() => {
-    return Object.fromEntries(
-      CANONICAL_COL_BREAKPOINTS.map((bp) => [bp, layout]),
-    ) as Partial<Record<keyof typeof RGL_BREAKPOINTS, LayoutItem[]>>;
-  }, [layout]);
-
-  // We only persist on onDragStop / onResizeStop - both are terminal,
-  // user-initiated, and ship the final layout. onLayoutChange is deliberately
-  // NOT a save trigger because RGL also fires it on mount (after running its
-  // compactor), which would silently rewrite the user's saved positions when
-  // simply opening the dashboard.
-  const persistLayout = useCallback(
-    (next: readonly LayoutItem[]) => {
-      if (!updateLayout) return;
-      updateLayout(next);
-    },
-    [updateLayout],
-  );
-
-  const isInteractive = isEditing && !isAddingBlock;
-  // When we're in edit mode but interaction is disabled (because the edit
-  // drawer is open), keep the resize handle visible-but-dimmed and surface a
-  // tooltip explaining why it doesn't respond. Outside of edit mode the
-  // handle is hidden entirely, so no overlay is needed.
-  const showDisabledResizeOverlay = isEditing && !isInteractive;
-
-  return (
-    <div
-      // useContainerWidth gives back React 19's `RefObject<T | null>` but the
-      // codebase is still on React 18 types - cast to satisfy the older
-      // LegacyRef signature without changing runtime behaviour.
-      ref={containerRef as unknown as React.RefObject<HTMLDivElement>}
-      className={clsx("dashboard-grid-container", { "is-editing": isEditing })}
-    >
-      {mounted && (
-        <ResponsiveGridLayout
-          width={width}
-          className={clsx("dashboard-grid", {
-            "is-editing": isEditing,
-            "is-resize-disabled": showDisabledResizeOverlay,
-          })}
-          layouts={layouts}
-          breakpoints={RGL_BREAKPOINTS}
-          cols={RGL_COLS}
-          rowHeight={DASHBOARD_GRID_ROW_HEIGHT_DEFAULT}
-          margin={[DASHBOARD_GRID_MARGIN, DASHBOARD_GRID_MARGIN]}
-          containerPadding={[0, 0]}
-          dragConfig={{
-            enabled: isInteractive,
-            handle: ".dashboard-block-drag-handle",
-            bounded: false,
-            threshold: 3,
-          }}
-          resizeConfig={{
-            enabled: isInteractive,
-            handles: ["se", "sw"],
-          }}
-          compactor={verticalCompactor}
-          onDragStart={() => {
-            setOpenGapKey(null);
-            setIsGridInteracting(true);
-          }}
-          onDragStop={(curr) => {
-            persistLayout(curr);
-            setIsGridInteracting(false);
-          }}
-          onResizeStart={() => {
-            setOpenGapKey(null);
-            setIsGridInteracting(true);
-          }}
-          onResizeStop={(curr) => {
-            persistLayout(curr);
-            setIsGridInteracting(false);
-          }}
-        >
-          {blocks.map((block, i) => {
-            const key = getGridKeyForBlock(block, i);
-            return (
-              <div
-                key={key}
-                className={clsx("dashboard-grid-item", {
-                  "is-grid-interaction-disabled":
-                    isDefined(stagedBlockIndex) && i !== stagedBlockIndex,
-                })}
-              >
-                {renderBlock(block, i)}
-                {showDisabledResizeOverlay && (
-                  // Tooltip wraps its children in an inline <span> and anchors
-                  // its popper to that span. We put the overlay styles on the
-                  // span itself (via className) so Popper measures the corner
-                  // hit target instead of a collapsed zero-size box. The inner
-                  // child is a placeholder to suppress Tooltip's GBInfo
-                  // fallback when no children are provided.
-                  <Tooltip
-                    body="Close the edit panel to resize this block"
-                    tipPosition="top"
-                    className="dashboard-resize-handle-disabled-overlay"
-                    // Render through a portal so the popper escapes the grid's
-                    // stacking context - otherwise the edit drawer (which has
-                    // its own stacking context above the grid) clips it.
-                    usePortal
-                  >
-                    <span aria-hidden />
-                  </Tooltip>
-                )}
-              </div>
-            );
-          })}
-        </ResponsiveGridLayout>
-      )}
-      {mounted &&
-        addBlockType &&
-        gaps.map((gap) => {
-          const gapKey = `${gap.x}-${gap.y}-${gap.w}-${gap.h}`;
-          const gapStyle = gridRectToPixels({
-            rect: gap,
-            containerWidth: width,
-            rowHeight: DASHBOARD_GRID_ROW_HEIGHT_DEFAULT,
-          });
-
-          return (
-            <div
-              key={gapKey}
-              className={clsx("dashboard-grid-add-block-gap", {
-                "is-open": openGapKey === gapKey,
-              })}
-              style={gapStyle}
-            >
-              <AddBlockDropdown
-                isGeneralDashboard={isGeneralDashboard}
-                filterBlockType={(blockType) => blockFitsGap(blockType, gap)}
-                onDropdownOpen={() => setOpenGapKey(gapKey)}
-                onDropdownClose={() =>
-                  setOpenGapKey((currentKey) =>
-                    currentKey === gapKey ? null : currentKey,
-                  )
-                }
-                addBlockType={(blockType) => {
-                  addBlockType(blockType, {
-                    index: gap.insertIndex,
-                    placement: "gap",
-                    initialLayout: {
-                      x: gap.x,
-                      y: gap.y,
-                      w: gap.w,
-                      h: gap.h,
-                    },
-                  });
-                }}
-                trigger={
-                  <Button size="sm" variant="outline">
-                    Add block
-                  </Button>
-                }
-              />
-            </div>
-          );
-        })}
-    </div>
   );
 }
 

--- a/packages/front-end/enterprise/components/Dashboards/DashboardView.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardView.tsx
@@ -1,0 +1,60 @@
+import { DashboardInterface } from "shared/enterprise";
+import useApi from "@/hooks/useApi";
+import LoadingOverlay from "@/components/LoadingOverlay";
+import Callout from "@/ui/Callout";
+import DashboardEditor from "@/enterprise/components/Dashboards/DashboardEditor";
+import DashboardSnapshotProvider from "@/enterprise/components/Dashboards/DashboardSnapshotProvider";
+
+// Read-only embed: renders a dashboard's blocks without any editing affordances.
+// DashboardEditor only shows its edit entry points when setIsEditing/setBlock
+// are provided, so omitting them here is enough to make this view-only.
+export default function DashboardView({
+  dashboardId,
+}: {
+  dashboardId: string;
+}) {
+  const { data, isLoading, error, mutate } = useApi<{
+    dashboard: DashboardInterface;
+  }>(`/dashboards/${dashboardId}`, {
+    shouldRun: () => Boolean(dashboardId),
+  });
+  const dashboard = data?.dashboard;
+
+  if (isLoading) {
+    return <LoadingOverlay />;
+  }
+
+  if (error) {
+    return <Callout status="error">An error occurred: {error.message}</Callout>;
+  }
+
+  if (!dashboard) {
+    return null;
+  }
+
+  return (
+    <DashboardSnapshotProvider dashboard={dashboard} mutateDefinitions={mutate}>
+      <DashboardEditor
+        isTabActive
+        id={dashboard.id}
+        initialEditLevel={dashboard.editLevel}
+        ownerId={dashboard.userId}
+        initialShareLevel={dashboard.shareLevel}
+        dashboardOwnerId={dashboard.userId}
+        isGeneralDashboard={true}
+        isEditing={false}
+        title={dashboard.title}
+        blocks={dashboard.blocks}
+        globalControls={dashboard.globalControls}
+        enableAutoUpdates={dashboard.enableAutoUpdates}
+        setBlock={undefined}
+        projects={dashboard.projects ? dashboard.projects : []}
+        mutate={mutate}
+        updateSchedule={dashboard.updateSchedule || undefined}
+        nextUpdate={dashboard.nextUpdate}
+        dashboardLastUpdated={dashboard.lastUpdated}
+        dashboardComparison={dashboard.comparison}
+      />
+    </DashboardSnapshotProvider>
+  );
+}

--- a/packages/front-end/enterprise/components/Dashboards/DashboardView.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardView.tsx
@@ -21,7 +21,7 @@ export default function DashboardView({
   const dashboard = data?.dashboard;
 
   if (isLoading) {
-    return <LoadingOverlay />;
+    return <LoadingOverlay relativePosition />;
   }
 
   if (error) {
@@ -29,7 +29,7 @@ export default function DashboardView({
   }
 
   if (!dashboard) {
-    return null;
+    return <Callout status="error">Dashboard not found</Callout>;
   }
 
   return (

--- a/packages/front-end/enterprise/components/Dashboards/DashboardView.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardView.tsx
@@ -1,60 +1,46 @@
 import { DashboardInterface } from "shared/enterprise";
-import useApi from "@/hooks/useApi";
-import LoadingOverlay from "@/components/LoadingOverlay";
-import Callout from "@/ui/Callout";
-import DashboardEditor from "@/enterprise/components/Dashboards/DashboardEditor";
+import { Flex } from "@radix-ui/themes";
+import { PiArrowRight } from "react-icons/pi";
+import Link from "@/ui/Link";
 import DashboardSnapshotProvider from "@/enterprise/components/Dashboards/DashboardSnapshotProvider";
+import DashboardCanvas from "@/enterprise/components/Dashboards/DashboardEditor/DashboardCanvas";
+import { getPreviewBlocks } from "@/enterprise/components/Dashboards/DashboardEditor/dashboardLayout";
 
-// Read-only embed: renders a dashboard's blocks without any editing affordances.
-// DashboardEditor only shows its edit entry points when setIsEditing/setBlock
-// are provided, so omitting them here is enough to make this view-only.
 export default function DashboardView({
-  dashboardId,
+  dashboard,
+  maxBlocks,
+  mutate,
 }: {
-  dashboardId: string;
+  dashboard: DashboardInterface;
+  maxBlocks?: number;
+  mutate?: () => void;
 }) {
-  const { data, isLoading, error, mutate } = useApi<{
-    dashboard: DashboardInterface;
-  }>(`/dashboards/${dashboardId}`, {
-    shouldRun: () => Boolean(dashboardId),
-  });
-  const dashboard = data?.dashboard;
-
-  if (isLoading) {
-    return <LoadingOverlay relativePosition />;
-  }
-
-  if (error) {
-    return <Callout status="error">An error occurred: {error.message}</Callout>;
-  }
-
-  if (!dashboard) {
-    return <Callout status="error">Dashboard not found</Callout>;
-  }
+  const visibleBlocks = getPreviewBlocks(dashboard.blocks, maxBlocks);
+  const hasHiddenBlocks = visibleBlocks.length < dashboard.blocks.length;
+  const previewDashboard =
+    visibleBlocks === dashboard.blocks
+      ? dashboard
+      : { ...dashboard, blocks: visibleBlocks };
 
   return (
-    <DashboardSnapshotProvider dashboard={dashboard} mutateDefinitions={mutate}>
-      <DashboardEditor
-        isTabActive
-        id={dashboard.id}
-        initialEditLevel={dashboard.editLevel}
-        ownerId={dashboard.userId}
-        initialShareLevel={dashboard.shareLevel}
-        dashboardOwnerId={dashboard.userId}
-        isGeneralDashboard={true}
-        isEditing={false}
-        title={dashboard.title}
-        blocks={dashboard.blocks}
+    <DashboardSnapshotProvider
+      dashboard={previewDashboard}
+      mutateDefinitions={mutate ?? (() => undefined)}
+    >
+      <DashboardCanvas
+        blocks={visibleBlocks}
         globalControls={dashboard.globalControls}
-        enableAutoUpdates={dashboard.enableAutoUpdates}
-        setBlock={undefined}
-        projects={dashboard.projects ? dashboard.projects : []}
-        mutate={mutate}
-        updateSchedule={dashboard.updateSchedule || undefined}
-        nextUpdate={dashboard.nextUpdate}
-        dashboardLastUpdated={dashboard.lastUpdated}
         dashboardComparison={dashboard.comparison}
+        isGeneralDashboard
+        mutate={mutate}
       />
+      {hasHiddenBlocks && (
+        <Flex justify="end" mt="2">
+          <Link href={`/product-analytics/dashboards/${dashboard.id}`}>
+            View full dashboard <PiArrowRight />
+          </Link>
+        </Flex>
+      )}
     </DashboardSnapshotProvider>
   );
 }

--- a/packages/front-end/enterprise/components/Dashboards/DashboardWorkspace.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardWorkspace.tsx
@@ -41,15 +41,13 @@ import Tooltip from "@/components/Tooltip/Tooltip";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import { useExploreData } from "@/enterprise/components/ProductAnalytics/useExploreData";
-import DashboardEditor, {
-  DASHBOARD_TOPBAR_HEIGHT,
-  getGridKeyForBlock,
-} from "./DashboardEditor";
+import DashboardEditor, { DASHBOARD_TOPBAR_HEIGHT } from "./DashboardEditor";
 import { SubmitDashboard, UpdateDashboardArgs } from "./DashboardsTab";
 import DashboardEditorSidebar from "./DashboardEditor/DashboardEditorSidebar";
 import { isBlockTypeAllowed } from "./DashboardEditor/dashboardBlockTypes";
 import {
   AddBlockOptions,
+  getGridKeyForBlock,
   insertBlockAtIndex,
 } from "./DashboardEditor/dashboardLayout";
 import DashboardModal from "./DashboardModal";

--- a/packages/front-end/test/enterprise/dashboardLayout.test.ts
+++ b/packages/front-end/test/enterprise/dashboardLayout.test.ts
@@ -1,0 +1,52 @@
+import {
+  DashboardBlockInterface,
+  DashboardBlockInterfaceOrData,
+} from "shared/enterprise";
+import { getPreviewBlocks } from "@/enterprise/components/Dashboards/DashboardEditor/dashboardLayout";
+
+function block({
+  id,
+  x,
+  y,
+}: {
+  id: string;
+  x?: number;
+  y?: number;
+}): DashboardBlockInterfaceOrData<DashboardBlockInterface> {
+  return {
+    id,
+    type: "markdown",
+    title: id,
+    content: id,
+    ...(x !== undefined && y !== undefined
+      ? { layout: { x, y, w: 6, h: 4 } }
+      : {}),
+  } as DashboardBlockInterfaceOrData<DashboardBlockInterface>;
+}
+
+describe("getPreviewBlocks", () => {
+  it("returns the original array when maxBlocks is omitted", () => {
+    const blocks = [block({ id: "a" }), block({ id: "b" })];
+    expect(getPreviewBlocks(blocks)).toBe(blocks);
+  });
+
+  it("sorts by layout y then x instead of array order", () => {
+    const blocks = [
+      block({ id: "bottom", x: 0, y: 8 }),
+      block({ id: "top-right", x: 6, y: 0 }),
+      block({ id: "top-left", x: 0, y: 0 }),
+    ];
+    const preview = getPreviewBlocks(blocks, 2);
+    expect(preview.map((b) => b.title)).toEqual(["top-left", "top-right"]);
+  });
+
+  it("rebases y so the first visible row starts at 0", () => {
+    const blocks = [
+      block({ id: "a", x: 0, y: 10 }),
+      block({ id: "b", x: 0, y: 14 }),
+    ];
+    const preview = getPreviewBlocks(blocks, 2);
+    expect(preview[0]?.layout?.y).toBe(0);
+    expect(preview[1]?.layout?.y).toBe(4);
+  });
+});


### PR DESCRIPTION
### Features and Changes

Extracts the `DashboardSnapshotProvider` + `DashboardEditor` composition (currently duplicated between the single-dashboard page and the experiment-embedded dashboards tab) into a new standalone `DashboardView` component that takes just a `dashboardId`.

It renders read-only by omitting `setBlock`/`onGlobalControlsChange`/`onDashboardComparisonChange`/`setIsEditing`/`enterEditModeForBlock` — `DashboardEditor` already hides its edit entry points whenever those aren't provided, so no new `readOnly` prop was needed on it.

This PR is additive only: nothing consumes `DashboardView` yet (that starts in #6651 later in this stack), and no existing page's behavior changes.

### Dependencies

None — base of the stack.

### Testing

- `pnpm --filter front-end type-check`
- No existing pages import this component yet; it's exercised end-to-end starting with the home-page PR later in the stack.

### Screenshots

_(added separately)_