### PR TITLE
feat(projects): add defaultDashboardId to project settings

### DIFF
--- a/packages/back-end/src/routers/project/project.router.ts
+++ b/packages/back-end/src/routers/project/project.router.ts
@@ -62,6 +62,7 @@ router.put(
           statsEngine: z.string().optional(),
           confidenceLevel: z.number().min(0.5).max(1).optional(),
           pValueThreshold: z.number().gt(0).max(0.5).optional(),
+          defaultDashboardId: z.string().optional(),
         }),
       })
       .strict(),

--- a/packages/back-end/src/routers/project/project.router.ts
+++ b/packages/back-end/src/routers/project/project.router.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import { z } from "zod";
+import { projectSettingsValidator } from "shared/validators";
 import { wrapController } from "back-end/src/routers/wrapController";
 import { validateRequestMiddleware } from "back-end/src/routers/utils/validateRequestMiddleware";
 import * as rawProjectController from "./project.controller";
@@ -56,14 +57,14 @@ router.delete(
 router.put(
   "/:id/settings",
   validateRequestMiddleware({
+    params: z
+      .object({
+        id: z.string(),
+      })
+      .strict(),
     body: z
       .object({
-        settings: z.object({
-          statsEngine: z.string().optional(),
-          confidenceLevel: z.number().min(0.5).max(1).optional(),
-          pValueThreshold: z.number().gt(0).max(0.5).optional(),
-          defaultDashboardId: z.string().optional(),
-        }),
+        settings: projectSettingsValidator,
       })
       .strict(),
   }),

--- a/packages/shared/src/validators/projects.ts
+++ b/packages/shared/src/validators/projects.ts
@@ -12,6 +12,7 @@ export const projectSettingsValidator = z.object({
   statsEngine: statsEnginesValidator.optional(),
   confidenceLevel: z.number().min(0.5).max(1).optional(),
   pValueThreshold: z.number().gt(0).max(0.5).optional(),
+  defaultDashboardId: z.string().optional(),
 });
 
 export const projectValidator = baseSchema

--- a/packages/shared/src/validators/projects.ts
+++ b/packages/shared/src/validators/projects.ts
@@ -12,7 +12,7 @@ export const projectSettingsValidator = z.object({
   statsEngine: statsEnginesValidator.optional(),
   confidenceLevel: z.number().min(0.5).max(1).optional(),
   pValueThreshold: z.number().gt(0).max(0.5).optional(),
-  defaultDashboardId: z.string().optional(),
+  defaultDashboardId: z.string().min(1).optional(),
 });
 
 export const projectValidator = baseSchema


### PR DESCRIPTION
### Features and Changes

Adds an optional `defaultDashboardId` field to `ProjectSettings` (`packages/shared/src/validators/projects.ts`) so a project can pin a general (non-experiment) Product Analytics dashboard as its default.

Also updates the `PUT /projects/:id/settings` router's separately-duplicated `.strict()` Zod body schema to accept the new field — without this the internal API would silently reject any request that includes it.

No controller changes needed: `putProjectSettings` already forwards the `settings` object straight to `ProjectModel.update()`, so the new optional field passes through for free.

### Dependencies

Stacked on #6648 (ordering only, no functional dependency).

### Testing

- `pnpm --filter shared type-check`, `pnpm --filter back-end type-check`
- Manually verified `PUT /projects/:id/settings` with `{"settings": {"defaultDashboardId": "dash_xxx"}}` is accepted and persisted (previously would 400).

### Screenshots

N/A — back-end only.