### PR TITLE
feat(projects): let admins set a project's default dashboard

### DIFF
--- a/packages/front-end/enterprise/components/Dashboards/DashboardSelector.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardSelector.tsx
@@ -5,6 +5,10 @@ import { DashboardInterface } from "shared/enterprise";
 import { Select, SelectItem, SelectSeparator } from "@/ui/Select";
 import OverflowText from "@/components/Experiment/TabbedPage/OverflowText";
 
+// Radix Select forbids an empty-string item value, so a "no selection"
+// option needs its own sentinel that gets translated back to "" here.
+const CLEAR_VALUE = "__clear__";
+
 export interface DashboardSelectorProps {
   dashboards: DashboardInterface[];
   defaultDashboard?: DashboardInterface;
@@ -15,6 +19,9 @@ export interface DashboardSelectorProps {
   style?: React.CSSProperties;
   showIcon?: boolean;
   disabled?: boolean;
+  // Adds a "no selection" option that calls setValue("") when chosen.
+  allowClear?: boolean;
+  clearLabel?: string;
 }
 
 export default function DashboardSelector({
@@ -27,6 +34,8 @@ export default function DashboardSelector({
   style,
   showIcon = true,
   disabled = false,
+  allowClear = false,
+  clearLabel = "None",
 }: DashboardSelectorProps) {
   return (
     <Select
@@ -34,16 +43,28 @@ export default function DashboardSelector({
         minWidth: "200px",
         ...style,
       }}
-      value={value}
+      value={allowClear && !value ? CLEAR_VALUE : value}
       setValue={(newValue) => {
         if (newValue === "__create__") {
           onCreateNew?.();
+          return;
+        }
+        if (newValue === CLEAR_VALUE) {
+          setValue("");
           return;
         }
         setValue(newValue);
       }}
       disabled={disabled}
     >
+      {allowClear && (
+        <>
+          <SelectItem value={CLEAR_VALUE}>
+            <Text color="gray">{clearLabel}</Text>
+          </SelectItem>
+          <SelectSeparator />
+        </>
+      )}
       {defaultDashboard && (
         <>
           <SelectItem value={defaultDashboard.id}>

--- a/packages/front-end/hooks/useDashboards.ts
+++ b/packages/front-end/hooks/useDashboards.ts
@@ -44,10 +44,15 @@ export function useExperimentDashboards(experimentId: string) {
   };
 }
 
-export function useDashboards(includeExperimentDashboards: boolean) {
+export function useDashboards(
+  includeExperimentDashboards: boolean,
+  shouldRun?: () => boolean,
+) {
   const { data, error, mutate } = useApi<{
     dashboards: DashboardInterface[];
-  }>(`/dashboards?includeExperimentDashboards=${includeExperimentDashboards}`);
+  }>(`/dashboards?includeExperimentDashboards=${includeExperimentDashboards}`, {
+    shouldRun,
+  });
 
   const dashboards = useMemo(() => data?.dashboards || [], [data]);
 

--- a/packages/front-end/pages/project/[pid].tsx
+++ b/packages/front-end/pages/project/[pid].tsx
@@ -87,12 +87,17 @@ const ProjectPage: FC = () => {
   const checklist = data?.checklist;
 
   const canViewDashboards = hasCommercialFeature("dashboards");
-  const { dashboards } = useDashboards(false, () => canViewDashboards);
+  const { dashboards, loading: dashboardsLoading } = useDashboards(
+    false,
+    () => canViewDashboards,
+  );
   const projectDashboards = useMemo(
     () =>
       dashboards.filter((d) => !d.projects?.length || d.projects.includes(pid)),
     [dashboards, pid],
   );
+  const noProjectDashboards =
+    !dashboardsLoading && projectDashboards.length === 0;
 
   useEffect(() => {
     if (settings) {
@@ -421,7 +426,7 @@ const ProjectPage: FC = () => {
                             home page by default. They can still pick a
                             different one for themselves.
                           </Text>
-                          {projectDashboards.length === 0 ? (
+                          {dashboardsLoading ? null : noProjectDashboards ? (
                             <Callout status="info">
                               No dashboards are available for this Project yet.{" "}
                               <Link href="/product-analytics/dashboards/new">

--- a/packages/front-end/pages/project/[pid].tsx
+++ b/packages/front-end/pages/project/[pid].tsx
@@ -416,21 +416,34 @@ const ProjectPage: FC = () => {
                           <Heading as="h5" size="sm">
                             Default Dashboard
                           </Heading>
-                          <p className="pt-2">
+                          <Text as="p" mt="2">
                             Members of this project see this dashboard on their
                             home page by default. They can still pick a
                             different one for themselves.
-                          </p>
-                          <DashboardSelector
-                            dashboards={projectDashboards}
-                            value={form.watch("defaultDashboardId") || ""}
-                            setValue={(v) =>
-                              form.setValue(
-                                "defaultDashboardId",
-                                v || undefined,
-                              )
-                            }
-                          />
+                          </Text>
+                          {projectDashboards.length === 0 ? (
+                            <Callout status="info">
+                              No dashboards are available for this Project yet.{" "}
+                              <Link href="/product-analytics/dashboards/new">
+                                Create a dashboard
+                              </Link>{" "}
+                              scoped to this Project (or with no Project
+                              restriction) to set a default.
+                            </Callout>
+                          ) : (
+                            <DashboardSelector
+                              dashboards={projectDashboards}
+                              value={form.watch("defaultDashboardId") || ""}
+                              setValue={(v) =>
+                                form.setValue(
+                                  "defaultDashboardId",
+                                  v || undefined,
+                                )
+                              }
+                              allowClear
+                              clearLabel="No default"
+                            />
+                          )}
                         </Box>
                       </Flex>
                     </Flex>

--- a/packages/front-end/pages/project/[pid].tsx
+++ b/packages/front-end/pages/project/[pid].tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from "react";
+import React, { FC, useEffect, useMemo, useState } from "react";
 import router from "next/router";
 import NextLink from "next/link";
 import { useForm } from "react-hook-form";
@@ -36,6 +36,8 @@ import Metadata from "@/ui/Metadata";
 import ChanceToWinThresholdField from "@/components/GeneralSettings/ExperimentSettings/ChanceToWinThresholdField";
 import PValueThresholdField from "@/components/GeneralSettings/ExperimentSettings/PValueThresholdField";
 import Callout from "@/ui/Callout";
+import { useDashboards } from "@/hooks/useDashboards";
+import DashboardSelector from "@/enterprise/components/Dashboards/DashboardSelector";
 
 function emptyStringToUndefined(v: unknown): number | undefined {
   if (v === "" || v === null || v === undefined) return undefined;
@@ -83,6 +85,13 @@ const ProjectPage: FC = () => {
   }>(`/experiments/launch-checklist?projectId=${pid}`);
 
   const checklist = data?.checklist;
+
+  const { dashboards } = useDashboards(false);
+  const projectDashboards = useMemo(
+    () =>
+      dashboards.filter((d) => !d.projects?.length || d.projects.includes(pid)),
+    [dashboards, pid],
+  );
 
   useEffect(() => {
     if (settings) {
@@ -389,6 +398,34 @@ const ProjectPage: FC = () => {
                             }}
                           />
                         ) : null}
+                      </Box>
+                    </Flex>
+                  </Flex>
+                </Frame>
+                <Frame>
+                  <Flex gap="4" mb="4">
+                    <Box width="220px" flexShrink="0">
+                      <Heading as="h4" size="md">
+                        Home Page Dashboard
+                      </Heading>
+                    </Box>
+                    <Flex align="start" direction="column" flexGrow="1">
+                      <Box mb="3" width="100%">
+                        <Heading as="h5" size="sm">
+                          Default Dashboard
+                        </Heading>
+                        <p className="pt-2">
+                          Members of this project see this dashboard on their
+                          home page by default. They can still pick a different
+                          one for themselves.
+                        </p>
+                        <DashboardSelector
+                          dashboards={projectDashboards}
+                          value={form.watch("defaultDashboardId") || ""}
+                          setValue={(v) =>
+                            form.setValue("defaultDashboardId", v || undefined)
+                          }
+                        />
                       </Box>
                     </Flex>
                   </Flex>

--- a/packages/front-end/pages/project/[pid].tsx
+++ b/packages/front-end/pages/project/[pid].tsx
@@ -86,7 +86,8 @@ const ProjectPage: FC = () => {
 
   const checklist = data?.checklist;
 
-  const { dashboards } = useDashboards(false);
+  const canViewDashboards = hasCommercialFeature("dashboards");
+  const { dashboards } = useDashboards(false, () => canViewDashboards);
   const projectDashboards = useMemo(
     () =>
       dashboards.filter((d) => !d.projects?.length || d.projects.includes(pid)),
@@ -402,34 +403,39 @@ const ProjectPage: FC = () => {
                     </Flex>
                   </Flex>
                 </Frame>
-                <Frame>
-                  <Flex gap="4" mb="4">
-                    <Box width="220px" flexShrink="0">
-                      <Heading as="h4" size="md">
-                        Home Page Dashboard
-                      </Heading>
-                    </Box>
-                    <Flex align="start" direction="column" flexGrow="1">
-                      <Box mb="3" width="100%">
-                        <Heading as="h5" size="sm">
-                          Default Dashboard
+                {canViewDashboards && (
+                  <Frame>
+                    <Flex gap="4" mb="4">
+                      <Box width="220px" flexShrink="0">
+                        <Heading as="h4" size="md">
+                          Home Page Dashboard
                         </Heading>
-                        <p className="pt-2">
-                          Members of this project see this dashboard on their
-                          home page by default. They can still pick a different
-                          one for themselves.
-                        </p>
-                        <DashboardSelector
-                          dashboards={projectDashboards}
-                          value={form.watch("defaultDashboardId") || ""}
-                          setValue={(v) =>
-                            form.setValue("defaultDashboardId", v || undefined)
-                          }
-                        />
                       </Box>
+                      <Flex align="start" direction="column" flexGrow="1">
+                        <Box mb="3" width="100%">
+                          <Heading as="h5" size="sm">
+                            Default Dashboard
+                          </Heading>
+                          <p className="pt-2">
+                            Members of this project see this dashboard on their
+                            home page by default. They can still pick a
+                            different one for themselves.
+                          </p>
+                          <DashboardSelector
+                            dashboards={projectDashboards}
+                            value={form.watch("defaultDashboardId") || ""}
+                            setValue={(v) =>
+                              form.setValue(
+                                "defaultDashboardId",
+                                v || undefined,
+                              )
+                            }
+                          />
+                        </Box>
+                      </Flex>
                     </Flex>
-                  </Flex>
-                </Frame>
+                  </Frame>
+                )}
                 <div className="w-100 py-3" style={{ bottom: 0, height: 70 }}>
                   <div className="container-fluid pagecontents d-flex">
                     <div className="flex-grow-1 mr-4">

--- a/packages/front-end/pages/project/[pid].tsx
+++ b/packages/front-end/pages/project/[pid].tsx
@@ -6,6 +6,7 @@ import isEqual from "lodash/isEqual";
 import { ProjectInterface, ProjectSettings } from "shared/types/project";
 import { getScopedSettings } from "shared/settings";
 import { DEFAULT_CONFIDENCE_LEVEL } from "shared/constants";
+import { isProjectListValidForProject } from "shared/util";
 import { Box, Flex } from "@radix-ui/themes";
 import { ExperimentLaunchChecklistInterface } from "shared/types/experimentLaunchChecklist";
 import Link from "@/ui/Link";
@@ -93,7 +94,7 @@ const ProjectPage: FC = () => {
   );
   const projectDashboards = useMemo(
     () =>
-      dashboards.filter((d) => !d.projects?.length || d.projects.includes(pid)),
+      dashboards.filter((d) => isProjectListValidForProject(d.projects, pid)),
     [dashboards, pid],
   );
   const noProjectDashboards =
@@ -120,6 +121,9 @@ const ProjectPage: FC = () => {
     const payload: ProjectSettings = { ...value };
     if (typeof payload.confidenceLevel === "number") {
       payload.confidenceLevel = payload.confidenceLevel / 100;
+    }
+    if (!payload.defaultDashboardId) {
+      delete payload.defaultDashboardId;
     }
     await apiCall(`/projects/${pid}/settings`, {
       method: "PUT",


### PR DESCRIPTION
### Features and Changes

Adds a "Home Page Dashboard" section to the project settings page (`/project/:id`) with a "Default Dashboard" picker, reusing the existing `DashboardSelector` component. Options are scoped to general dashboards that are either global or already assigned to this project.

Wired into the page's existing `useForm<ProjectSettings>()` / `saveSettings` flow — no new save button or API call, it's just another field alongside `statsEngine`/`confidenceLevel`/`pValueThreshold`.

Gated by the same project-settings-edit permission that already protects this page; no new permission introduced.

### Dependencies

Requires #6649 (the `defaultDashboardId` field/API).

### Testing

- `pnpm --filter front-end type-check`
- Manually set a project's default dashboard and confirmed it persists across page reloads.

### Screenshots
<img width="1335" height="271" alt="Screenshot 2026-08-18 at 11 27 48 AM" src="https://github.com/user-attachments/assets/fe37e149-cdce-4959-99c1-bea11aefceec" />
<img width="1326" height="271" alt="Screenshot 2026-08-18 at 11 28 20 AM" src="https://github.com/user-attachments/assets/5c5a4638-11fd-4638-9663-525be882db86" />
