### PR TITLE
feat(home): show a project's default dashboard on the home page

### DIFF
--- a/packages/back-end/src/routers/project/project.router.ts
+++ b/packages/back-end/src/routers/project/project.router.ts
@@ -62,6 +62,7 @@ router.put(
           statsEngine: z.string().optional(),
           confidenceLevel: z.number().min(0.5).max(1).optional(),
           pValueThreshold: z.number().gt(0).max(0.5).optional(),
+          defaultDashboardId: z.string().optional(),
         }),
       })
       .strict(),

--- a/packages/front-end/components/GetStarted/DashboardCard.tsx
+++ b/packages/front-end/components/GetStarted/DashboardCard.tsx
@@ -11,7 +11,10 @@ import { useDashboards } from "@/hooks/useDashboards";
 import DashboardSelector from "@/enterprise/components/Dashboards/DashboardSelector";
 import DashboardView from "@/enterprise/components/Dashboards/DashboardView";
 
-const PREVIEW_HEIGHT = "280px";
+// Cap the number of blocks shown, rather than shrinking/scrolling a full
+// dashboard, so everything visible fits at its native (author-configured)
+// size. See DashboardView for the "View full dashboard" link this implies.
+const PREVIEW_MAX_BLOCKS = 2;
 
 // Resolution order: the user's own localStorage pick, then the project's
 // admin-configured default, then nothing selected. The selector itself always
@@ -75,13 +78,14 @@ export default function DashboardCard() {
           pb="4"
           px="4"
           style={{
-            maxHeight: PREVIEW_HEIGHT,
-            overflow: "auto",
             border: "1px solid var(--slate-a4)",
             borderRadius: "var(--radius-3)",
           }}
         >
-          <DashboardView dashboardId={resolvedDashboardId} />
+          <DashboardView
+            dashboardId={resolvedDashboardId}
+            maxBlocks={PREVIEW_MAX_BLOCKS}
+          />
         </Box>
       ) : (
         <Text color="text-mid">

--- a/packages/front-end/components/GetStarted/DashboardCard.tsx
+++ b/packages/front-end/components/GetStarted/DashboardCard.tsx
@@ -1,0 +1,72 @@
+import { useMemo } from "react";
+import { Box, Flex } from "@radix-ui/themes";
+import Heading from "@/ui/Heading";
+import {
+  useDefinitions,
+  LOCALSTORAGE_DASHBOARD_KEY,
+} from "@/services/DefinitionsContext";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
+import { useDashboards } from "@/hooks/useDashboards";
+import DashboardSelector from "@/enterprise/components/Dashboards/DashboardSelector";
+import DashboardView from "@/enterprise/components/Dashboards/DashboardView";
+
+// Resolution order: the user's own localStorage pick, then the project's
+// admin-configured default, then nothing (no dashboard shown).
+export default function DashboardCard() {
+  const { project, getProjectById } = useDefinitions();
+  const { dashboards, loading } = useDashboards(false);
+  const [selectedDashboardId, setSelectedDashboardId] = useLocalStorage(
+    LOCALSTORAGE_DASHBOARD_KEY,
+    "",
+  );
+
+  const projectDashboards = useMemo(
+    () =>
+      dashboards.filter(
+        (d) => !d.projects?.length || d.projects.includes(project),
+      ),
+    [dashboards, project],
+  );
+
+  const projectDefaultDashboardId =
+    getProjectById(project)?.settings?.defaultDashboardId;
+
+  const resolvedDashboardId = useMemo(() => {
+    if (
+      selectedDashboardId &&
+      projectDashboards.some((d) => d.id === selectedDashboardId)
+    ) {
+      return selectedDashboardId;
+    }
+    if (
+      projectDefaultDashboardId &&
+      projectDashboards.some((d) => d.id === projectDefaultDashboardId)
+    ) {
+      return projectDefaultDashboardId;
+    }
+    return "";
+  }, [selectedDashboardId, projectDefaultDashboardId, projectDashboards]);
+
+  if (loading || projectDashboards.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box mb="6">
+      <Flex align="center" justify="between" mb="3">
+        <Heading as="h4" size="sm">
+          Dashboard
+        </Heading>
+        <DashboardSelector
+          dashboards={projectDashboards}
+          value={resolvedDashboardId}
+          setValue={setSelectedDashboardId}
+          style={{ minWidth: "240px" }}
+        />
+      </Flex>
+      {resolvedDashboardId ? (
+        <DashboardView dashboardId={resolvedDashboardId} />
+      ) : null}
+    </Box>
+  );
+}

--- a/packages/front-end/components/GetStarted/DashboardCard.tsx
+++ b/packages/front-end/components/GetStarted/DashboardCard.tsx
@@ -86,6 +86,7 @@ export default function DashboardCard() {
           <DashboardView
             dashboardId={resolvedDashboardId}
             maxBlocks={PREVIEW_MAX_BLOCKS}
+            showHeader={false}
           />
         </Frame>
       ) : (

--- a/packages/front-end/components/GetStarted/DashboardCard.tsx
+++ b/packages/front-end/components/GetStarted/DashboardCard.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { Box, Flex } from "@radix-ui/themes";
 import Heading from "@/ui/Heading";
 import Text from "@/ui/Text";
+import Frame from "@/ui/Frame";
 import {
   useDefinitions,
   LOCALSTORAGE_DASHBOARD_KEY,
@@ -70,23 +71,23 @@ export default function DashboardCard() {
           value={resolvedDashboardId}
           setValue={setSelectedDashboardId}
           style={{ minWidth: "240px" }}
+          placeholder="Select a dashboard"
         />
       </Flex>
       {resolvedDashboardId ? (
-        <Box
+        <Frame
+          position="relative"
           pt="1"
           pb="4"
           px="4"
-          style={{
-            border: "1px solid var(--slate-a4)",
-            borderRadius: "var(--radius-3)",
-          }}
+          mb="0"
+          style={{ minHeight: "160px" }}
         >
           <DashboardView
             dashboardId={resolvedDashboardId}
             maxBlocks={PREVIEW_MAX_BLOCKS}
           />
-        </Box>
+        </Frame>
       ) : (
         <Text color="text-mid">
           Select a dashboard above to preview it here.

--- a/packages/front-end/components/GetStarted/DashboardCard.tsx
+++ b/packages/front-end/components/GetStarted/DashboardCard.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { Box, Flex } from "@radix-ui/themes";
 import Heading from "@/ui/Heading";
+import Text from "@/ui/Text";
 import {
   useDefinitions,
   LOCALSTORAGE_DASHBOARD_KEY,
@@ -10,8 +11,12 @@ import { useDashboards } from "@/hooks/useDashboards";
 import DashboardSelector from "@/enterprise/components/Dashboards/DashboardSelector";
 import DashboardView from "@/enterprise/components/Dashboards/DashboardView";
 
+const PREVIEW_HEIGHT = "420px";
+
 // Resolution order: the user's own localStorage pick, then the project's
-// admin-configured default, then nothing (no dashboard shown).
+// admin-configured default, then nothing selected. The selector itself always
+// shows (as long as candidate dashboards exist) so a project without a
+// default yet is still discoverable/pickable from the home page.
 export default function DashboardCard() {
   const { project, getProjectById } = useDefinitions();
   const { dashboards, loading } = useDashboards(false);
@@ -52,7 +57,7 @@ export default function DashboardCard() {
   }
 
   return (
-    <Box mb="6">
+    <Box mb="5">
       <Flex align="center" justify="between" mb="3">
         <Heading as="h4" size="sm">
           Dashboard
@@ -65,8 +70,21 @@ export default function DashboardCard() {
         />
       </Flex>
       {resolvedDashboardId ? (
-        <DashboardView dashboardId={resolvedDashboardId} />
-      ) : null}
+        <Box
+          style={{
+            maxHeight: PREVIEW_HEIGHT,
+            overflow: "auto",
+            border: "1px solid var(--slate-a4)",
+            borderRadius: "var(--radius-3)",
+          }}
+        >
+          <DashboardView dashboardId={resolvedDashboardId} />
+        </Box>
+      ) : (
+        <Text color="text-mid">
+          Select a dashboard above to preview it here.
+        </Text>
+      )}
     </Box>
   );
 }

--- a/packages/front-end/components/GetStarted/DashboardCard.tsx
+++ b/packages/front-end/components/GetStarted/DashboardCard.tsx
@@ -11,7 +11,7 @@ import { useDashboards } from "@/hooks/useDashboards";
 import DashboardSelector from "@/enterprise/components/Dashboards/DashboardSelector";
 import DashboardView from "@/enterprise/components/Dashboards/DashboardView";
 
-const PREVIEW_HEIGHT = "420px";
+const PREVIEW_HEIGHT = "280px";
 
 // Resolution order: the user's own localStorage pick, then the project's
 // admin-configured default, then nothing selected. The selector itself always
@@ -57,7 +57,7 @@ export default function DashboardCard() {
   }
 
   return (
-    <Box mb="5">
+    <Box mt="5" mb="5">
       <Flex align="center" justify="between" mb="3">
         <Heading as="h4" size="sm">
           Dashboard
@@ -71,6 +71,7 @@ export default function DashboardCard() {
       </Flex>
       {resolvedDashboardId ? (
         <Box
+          p="4"
           style={{
             maxHeight: PREVIEW_HEIGHT,
             overflow: "auto",

--- a/packages/front-end/components/GetStarted/DashboardCard.tsx
+++ b/packages/front-end/components/GetStarted/DashboardCard.tsx
@@ -71,7 +71,9 @@ export default function DashboardCard() {
       </Flex>
       {resolvedDashboardId ? (
         <Box
-          p="4"
+          pt="1"
+          pb="4"
+          px="4"
           style={{
             maxHeight: PREVIEW_HEIGHT,
             overflow: "auto",

--- a/packages/front-end/components/GetStarted/index.tsx
+++ b/packages/front-end/components/GetStarted/index.tsx
@@ -279,8 +279,6 @@ const GetStartedAndHomePage = ({
           )}
         </Grid>
 
-        <DashboardCard />
-
         {!orgIsUsingFeatureOrExperiment && (
           <Text size="4" weight="medium" mb="3" as="div">
             Get Started
@@ -300,6 +298,7 @@ const GetStartedAndHomePage = ({
               {orgIsUsingFeatureOrExperiment && (
                 <Box>
                   <NeedingAttention />
+                  <DashboardCard />
                   <Box mt="6" mb="2">
                     <Box mb="3">
                       <Text

--- a/packages/front-end/components/GetStarted/index.tsx
+++ b/packages/front-end/components/GetStarted/index.tsx
@@ -298,26 +298,25 @@ const GetStartedAndHomePage = ({
               {orgIsUsingFeatureOrExperiment && (
                 <Box>
                   <NeedingAttention />
-                  <DashboardCard />
-                  <Box mt="6" mb="2">
-                    <Box mb="3">
-                      <Text
-                        size="1"
-                        weight="medium"
-                        style={{ color: "var(--color-text-mid)" }}
-                      >
-                        EXPLORE ADVANCED FEATURES
-                      </Text>
-                    </Box>
-                    <Flex direction={{ initial: "column", sm: "row" }} gap="4">
-                      {advancedFeatures.map((feature) => (
-                        <AdvancedFeaturesCard
-                          key={feature.title}
-                          {...feature}
-                        />
-                      ))}
-                    </Flex>
+                </Box>
+              )}
+              <DashboardCard />
+              {orgIsUsingFeatureOrExperiment && (
+                <Box mt="6" mb="2">
+                  <Box mb="3">
+                    <Text
+                      size="1"
+                      weight="medium"
+                      style={{ color: "var(--color-text-mid)" }}
+                    >
+                      EXPLORE ADVANCED FEATURES
+                    </Text>
                   </Box>
+                  <Flex direction={{ initial: "column", sm: "row" }} gap="4">
+                    {advancedFeatures.map((feature) => (
+                      <AdvancedFeaturesCard key={feature.title} {...feature} />
+                    ))}
+                  </Flex>
                 </Box>
               )}
 

--- a/packages/front-end/components/GetStarted/index.tsx
+++ b/packages/front-end/components/GetStarted/index.tsx
@@ -32,6 +32,7 @@ import Callout from "@/ui/Callout";
 import Link from "@/ui/Link";
 import useSDKConnections from "@/hooks/useSDKConnections";
 import NeedingAttention from "@/components/GetStarted/NeedingAttention";
+import DashboardCard from "@/components/GetStarted/DashboardCard";
 import { DropdownMenu, DropdownMenuItem } from "@/ui/DropdownMenu";
 import Button from "@/ui/Button";
 import { useUser } from "@/services/UserContext";
@@ -277,6 +278,8 @@ const GetStartedAndHomePage = ({
             </Flex>
           )}
         </Grid>
+
+        <DashboardCard />
 
         {!orgIsUsingFeatureOrExperiment && (
           <Text size="4" weight="medium" mb="3" as="div">

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/index.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/index.tsx
@@ -197,6 +197,11 @@ interface Props {
   setIsEditing?: (v: boolean) => void;
   enterEditModeForBlock?: (blockIndex: number) => void;
   editBlockProps?: EditBlockProps;
+  // Hides the title/share badge, update display, edit/share/menu actions,
+  // and Projects/Owner row — for read-only skim previews (e.g. the home
+  // page dashboard card) where that identity/management chrome would just
+  // duplicate context already shown by the embedding surface.
+  showHeader?: boolean;
 }
 
 function DashboardEditor({
@@ -227,6 +232,7 @@ function DashboardEditor({
   setIsEditing,
   enterEditModeForBlock,
   editBlockProps,
+  showHeader = true,
 }: Props) {
   const {
     editSidebarDirty,
@@ -436,156 +442,171 @@ function DashboardEditor({
         isGeneralDashboard={isGeneralDashboard}
         dashboardId={id}
       />
-      <Box mt={isEditing ? "1" : undefined} mb="3">
-        <Flex align="center" height={DASHBOARD_TOPBAR_HEIGHT} gap="1">
-          {switchToExperimentView ? (
-            <Button variant="ghost" size="sm" onClick={switchToExperimentView}>
-              View Regular Experiment View
-            </Button>
-          ) : (
-            <Flex align="center" gap="2" flexGrow="1" minWidth="0">
-              <Text truncate={true} size="xl">
-                {title}
-              </Text>
-              <ShareStatusBadge
-                shareLevel={
-                  initialShareLevel === "published" ? "organization" : "private"
-                }
-                editLevel={
-                  initialEditLevel === "private" ? "private" : "organization"
-                }
-                isOwner={dashboardOwnerId === userId}
-              />
-            </Flex>
-          )}
-          <DashboardUpdateDisplay
-            dashboardId={id}
-            enableAutoUpdates={enableAutoUpdates}
-            nextUpdate={nextUpdate}
-            dashboardLastUpdated={dashboardLastUpdated}
-            disabled={!!editSidebarDirty}
-            isEditing={isEditing}
-            needsUpdate={needsUpdate}
-            updateTemporaryDashboardResults={updateTemporaryDashboardResults}
-            onUpdated={() => setNeedsUpdate(false)}
-          />
-          {isGeneralDashboard && setIsEditing && !isEditing ? (
-            <Flex align="center" gap="4" ml="4" flexShrink="0">
-              {canManageSharingAndEditLevels && (
-                <Button
-                  variant="outline"
-                  size="md"
-                  onClick={() => setShareModalOpen(true)}
-                >
-                  Share...
-                </Button>
-              )}
+      <Box
+        mt={isEditing ? "1" : undefined}
+        mb={
+          showHeader || (isGeneralDashboard && onGlobalControlsChange)
+            ? "3"
+            : undefined
+        }
+      >
+        {showHeader && (
+          <Flex align="center" height={DASHBOARD_TOPBAR_HEIGHT} gap="1">
+            {switchToExperimentView ? (
               <Button
-                variant="solid"
-                size="md"
-                disabled={!canEdit}
-                onClick={() => setIsEditing(true)}
+                variant="ghost"
+                size="sm"
+                onClick={switchToExperimentView}
               >
-                <PiPencilSimpleFill className="mr-2" />
-                Edit Blocks
+                View Regular Experiment View
               </Button>
-
-              <DropdownMenu
-                trigger={
-                  <IconButton
-                    variant="ghost"
-                    color="gray"
-                    radius="full"
-                    size="3"
-                    highContrast
+            ) : (
+              <Flex align="center" gap="2" flexGrow="1" minWidth="0">
+                <Text truncate={true} size="xl">
+                  {title}
+                </Text>
+                <ShareStatusBadge
+                  shareLevel={
+                    initialShareLevel === "published"
+                      ? "organization"
+                      : "private"
+                  }
+                  editLevel={
+                    initialEditLevel === "private" ? "private" : "organization"
+                  }
+                  isOwner={dashboardOwnerId === userId}
+                />
+              </Flex>
+            )}
+            <DashboardUpdateDisplay
+              dashboardId={id}
+              enableAutoUpdates={enableAutoUpdates}
+              nextUpdate={nextUpdate}
+              dashboardLastUpdated={dashboardLastUpdated}
+              disabled={!!editSidebarDirty}
+              isEditing={isEditing}
+              needsUpdate={needsUpdate}
+              updateTemporaryDashboardResults={updateTemporaryDashboardResults}
+              onUpdated={() => setNeedsUpdate(false)}
+            />
+            {isGeneralDashboard && setIsEditing && !isEditing ? (
+              <Flex align="center" gap="4" ml="4" flexShrink="0">
+                {canManageSharingAndEditLevels && (
+                  <Button
+                    variant="outline"
+                    size="md"
+                    onClick={() => setShareModalOpen(true)}
                   >
-                    <BsThreeDotsVertical size={18} />
-                  </IconButton>
-                }
-                open={dropdownOpen}
-                onOpenChange={(o) => {
-                  setDropdownOpen(!!o);
-                }}
-                menuPlacement="end"
-                variant="soft"
-              >
-                <DropdownMenuGroup>
-                  {canEdit && (
-                    <DropdownMenuItem
-                      onClick={() => {
-                        setEditDashboard(true);
-                        setDropdownOpen(false);
-                      }}
+                    Share...
+                  </Button>
+                )}
+                <Button
+                  variant="solid"
+                  size="md"
+                  disabled={!canEdit}
+                  onClick={() => setIsEditing(true)}
+                >
+                  <PiPencilSimpleFill className="mr-2" />
+                  Edit Blocks
+                </Button>
+
+                <DropdownMenu
+                  trigger={
+                    <IconButton
+                      variant="ghost"
+                      color="gray"
+                      radius="full"
+                      size="3"
+                      highContrast
                     >
-                      Edit Dashboard Settings
-                    </DropdownMenuItem>
-                  )}
-                  {canDuplicate && (
-                    <DropdownMenuItem
-                      onClick={() => {
-                        setDuplicateDashboard(true);
-                        setDropdownOpen(false);
-                      }}
-                    >
-                      Duplicate
-                    </DropdownMenuItem>
-                  )}
-                  {queryStrings.length > 0 || savedQueryIds.length > 0 ? (
-                    <>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem onClick={handleViewQueries}>
-                        View queries
-                        <Badge
-                          variant="soft"
-                          radius="full"
-                          label={String(count)}
-                          ml="2"
-                          color={error ? "red" : undefined}
-                        />
-                      </DropdownMenuItem>
-                    </>
-                  ) : null}
-                  {canDelete && (
-                    <>
-                      <DropdownMenuSeparator />
+                      <BsThreeDotsVertical size={18} />
+                    </IconButton>
+                  }
+                  open={dropdownOpen}
+                  onOpenChange={(o) => {
+                    setDropdownOpen(!!o);
+                  }}
+                  menuPlacement="end"
+                  variant="soft"
+                >
+                  <DropdownMenuGroup>
+                    {canEdit && (
                       <DropdownMenuItem
-                        color="red"
-                        confirmation={{
-                          confirmationTitle: "Delete Dashboard?",
-                          cta: "Delete",
-                          submit: async () => {
-                            await apiCall(`/dashboards/${id}`, {
-                              method: "DELETE",
-                            });
-                            if (typeof window !== "undefined") {
-                              window.location.href =
-                                "/product-analytics/dashboards";
-                            }
-                          },
-                          closeDropdown: () => {
-                            setDropdownOpen(false);
-                          },
+                        onClick={() => {
+                          setEditDashboard(true);
+                          setDropdownOpen(false);
                         }}
                       >
-                        Delete
+                        Edit Dashboard Settings
                       </DropdownMenuItem>
-                    </>
+                    )}
+                    {canDuplicate && (
+                      <DropdownMenuItem
+                        onClick={() => {
+                          setDuplicateDashboard(true);
+                          setDropdownOpen(false);
+                        }}
+                      >
+                        Duplicate
+                      </DropdownMenuItem>
+                    )}
+                    {queryStrings.length > 0 || savedQueryIds.length > 0 ? (
+                      <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem onClick={handleViewQueries}>
+                          View queries
+                          <Badge
+                            variant="soft"
+                            radius="full"
+                            label={String(count)}
+                            ml="2"
+                            color={error ? "red" : undefined}
+                          />
+                        </DropdownMenuItem>
+                      </>
+                    ) : null}
+                    {canDelete && (
+                      <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          color="red"
+                          confirmation={{
+                            confirmationTitle: "Delete Dashboard?",
+                            cta: "Delete",
+                            submit: async () => {
+                              await apiCall(`/dashboards/${id}`, {
+                                method: "DELETE",
+                              });
+                              if (typeof window !== "undefined") {
+                                window.location.href =
+                                  "/product-analytics/dashboards";
+                              }
+                            },
+                            closeDropdown: () => {
+                              setDropdownOpen(false);
+                            },
+                          }}
+                        >
+                          Delete
+                        </DropdownMenuItem>
+                      </>
+                    )}
+                  </DropdownMenuGroup>
+                </DropdownMenu>
+                {queriesModalOpen &&
+                  (queryStrings.length > 0 || savedQueryIds.length > 0) && (
+                    <AsyncQueriesModal
+                      close={() => setQueriesModalOpen(false)}
+                      queries={queryStrings}
+                      savedQueries={savedQueryIds}
+                      error={error}
+                    />
                   )}
-                </DropdownMenuGroup>
-              </DropdownMenu>
-              {queriesModalOpen &&
-                (queryStrings.length > 0 || savedQueryIds.length > 0) && (
-                  <AsyncQueriesModal
-                    close={() => setQueriesModalOpen(false)}
-                    queries={queryStrings}
-                    savedQueries={savedQueryIds}
-                    error={error}
-                  />
-                )}
-            </Flex>
-          ) : null}
-        </Flex>
-        {!isEditing && (
+              </Flex>
+            ) : null}
+          </Flex>
+        )}
+        {showHeader && !isEditing && (
           <Flex align="center" gap="3">
             <Flex align="center" gap="1">
               <Text weight="medium">Projects:</Text>

--- a/packages/front-end/enterprise/components/Dashboards/DashboardSelector.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardSelector.tsx
@@ -5,6 +5,10 @@ import { DashboardInterface } from "shared/enterprise";
 import { Select, SelectItem, SelectSeparator } from "@/ui/Select";
 import OverflowText from "@/components/Experiment/TabbedPage/OverflowText";
 
+// Radix Select forbids an empty-string item value, so a "no selection"
+// option needs its own sentinel that gets translated back to "" here.
+const CLEAR_VALUE = "__clear__";
+
 export interface DashboardSelectorProps {
   dashboards: DashboardInterface[];
   defaultDashboard?: DashboardInterface;
@@ -15,6 +19,9 @@ export interface DashboardSelectorProps {
   style?: React.CSSProperties;
   showIcon?: boolean;
   disabled?: boolean;
+  // Adds a "no selection" option that calls setValue("") when chosen.
+  allowClear?: boolean;
+  clearLabel?: string;
 }
 
 export default function DashboardSelector({
@@ -27,6 +34,8 @@ export default function DashboardSelector({
   style,
   showIcon = true,
   disabled = false,
+  allowClear = false,
+  clearLabel = "None",
 }: DashboardSelectorProps) {
   return (
     <Select
@@ -34,16 +43,28 @@ export default function DashboardSelector({
         minWidth: "200px",
         ...style,
       }}
-      value={value}
+      value={allowClear && !value ? CLEAR_VALUE : value}
       setValue={(newValue) => {
         if (newValue === "__create__") {
           onCreateNew?.();
+          return;
+        }
+        if (newValue === CLEAR_VALUE) {
+          setValue("");
           return;
         }
         setValue(newValue);
       }}
       disabled={disabled}
     >
+      {allowClear && (
+        <>
+          <SelectItem value={CLEAR_VALUE}>
+            <Text color="gray">{clearLabel}</Text>
+          </SelectItem>
+          <SelectSeparator />
+        </>
+      )}
       {defaultDashboard && (
         <>
           <SelectItem value={defaultDashboard.id}>

--- a/packages/front-end/enterprise/components/Dashboards/DashboardSelector.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardSelector.tsx
@@ -22,6 +22,7 @@ export interface DashboardSelectorProps {
   // Adds a "no selection" option that calls setValue("") when chosen.
   allowClear?: boolean;
   clearLabel?: string;
+  placeholder?: string;
 }
 
 export default function DashboardSelector({
@@ -36,6 +37,7 @@ export default function DashboardSelector({
   disabled = false,
   allowClear = false,
   clearLabel = "None",
+  placeholder,
 }: DashboardSelectorProps) {
   return (
     <Select
@@ -43,6 +45,7 @@ export default function DashboardSelector({
         minWidth: "200px",
         ...style,
       }}
+      placeholder={placeholder}
       value={allowClear && !value ? CLEAR_VALUE : value}
       setValue={(newValue) => {
         if (newValue === "__create__") {

--- a/packages/front-end/enterprise/components/Dashboards/DashboardView.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardView.tsx
@@ -1,7 +1,9 @@
 import { DashboardInterface } from "shared/enterprise";
+import { Flex } from "@radix-ui/themes";
 import useApi from "@/hooks/useApi";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import Callout from "@/ui/Callout";
+import Link from "@/ui/Link";
 import DashboardEditor from "@/enterprise/components/Dashboards/DashboardEditor";
 import DashboardSnapshotProvider from "@/enterprise/components/Dashboards/DashboardSnapshotProvider";
 
@@ -10,8 +12,13 @@ import DashboardSnapshotProvider from "@/enterprise/components/Dashboards/Dashbo
 // are provided, so omitting them here is enough to make this view-only.
 export default function DashboardView({
   dashboardId,
+  maxBlocks,
 }: {
   dashboardId: string;
+  // When set, only the first N blocks render (in the dashboard's own saved
+  // order/sizing) instead of shrinking or reflowing everything to fit a
+  // smaller space. A "View full dashboard" link covers the rest.
+  maxBlocks?: number;
 }) {
   const { data, isLoading, error, mutate } = useApi<{
     dashboard: DashboardInterface;
@@ -32,6 +39,11 @@ export default function DashboardView({
     return <Callout status="error">Dashboard not found</Callout>;
   }
 
+  const visibleBlocks = maxBlocks
+    ? dashboard.blocks.slice(0, maxBlocks)
+    : dashboard.blocks;
+  const hasHiddenBlocks = visibleBlocks.length < dashboard.blocks.length;
+
   return (
     <DashboardSnapshotProvider dashboard={dashboard} mutateDefinitions={mutate}>
       <DashboardEditor
@@ -44,7 +56,7 @@ export default function DashboardView({
         isGeneralDashboard={true}
         isEditing={false}
         title={dashboard.title}
-        blocks={dashboard.blocks}
+        blocks={visibleBlocks}
         globalControls={dashboard.globalControls}
         enableAutoUpdates={dashboard.enableAutoUpdates}
         setBlock={undefined}
@@ -55,6 +67,13 @@ export default function DashboardView({
         dashboardLastUpdated={dashboard.lastUpdated}
         dashboardComparison={dashboard.comparison}
       />
+      {hasHiddenBlocks && (
+        <Flex justify="end" mt="2">
+          <Link href={`/product-analytics/dashboards/${dashboard.id}`}>
+            View full dashboard →
+          </Link>
+        </Flex>
+      )}
     </DashboardSnapshotProvider>
   );
 }

--- a/packages/front-end/enterprise/components/Dashboards/DashboardView.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardView.tsx
@@ -14,12 +14,16 @@ import DashboardSnapshotProvider from "@/enterprise/components/Dashboards/Dashbo
 export default function DashboardView({
   dashboardId,
   maxBlocks,
+  showHeader = true,
 }: {
   dashboardId: string;
   // When set, only the first N blocks render (in the dashboard's own saved
   // order/sizing) instead of shrinking or reflowing everything to fit a
   // smaller space. A "View full dashboard" link covers the rest.
   maxBlocks?: number;
+  // Independent of maxBlocks — a caller may want a capped block count with
+  // the header still shown, or a full-block embed without it.
+  showHeader?: boolean;
 }) {
   const { data, isLoading, error, mutate } = useApi<{
     dashboard: DashboardInterface;
@@ -67,14 +71,13 @@ export default function DashboardView({
         nextUpdate={dashboard.nextUpdate}
         dashboardLastUpdated={dashboard.lastUpdated}
         dashboardComparison={dashboard.comparison}
-        showHeader={!maxBlocks}
+        showHeader={showHeader}
       />
       {hasHiddenBlocks && (
-        <Flex justify="end" align="center" gap="1" mt="2">
+        <Flex justify="end" mt="2">
           <Link href={`/product-analytics/dashboards/${dashboard.id}`}>
-            View full dashboard
+            View full dashboard <PiArrowRight />
           </Link>
-          <PiArrowRight />
         </Flex>
       )}
     </DashboardSnapshotProvider>

--- a/packages/front-end/enterprise/components/Dashboards/DashboardView.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardView.tsx
@@ -1,5 +1,6 @@
 import { DashboardInterface } from "shared/enterprise";
 import { Flex } from "@radix-ui/themes";
+import { PiArrowRight } from "react-icons/pi";
 import useApi from "@/hooks/useApi";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import Callout from "@/ui/Callout";
@@ -66,12 +67,14 @@ export default function DashboardView({
         nextUpdate={dashboard.nextUpdate}
         dashboardLastUpdated={dashboard.lastUpdated}
         dashboardComparison={dashboard.comparison}
+        showHeader={!maxBlocks}
       />
       {hasHiddenBlocks && (
-        <Flex justify="end" mt="2">
+        <Flex justify="end" align="center" gap="1" mt="2">
           <Link href={`/product-analytics/dashboards/${dashboard.id}`}>
-            View full dashboard →
+            View full dashboard
           </Link>
+          <PiArrowRight />
         </Flex>
       )}
     </DashboardSnapshotProvider>

--- a/packages/front-end/enterprise/components/Dashboards/DashboardView.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardView.tsx
@@ -1,7 +1,9 @@
 import { DashboardInterface } from "shared/enterprise";
+import { Flex } from "@radix-ui/themes";
 import useApi from "@/hooks/useApi";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import Callout from "@/ui/Callout";
+import Link from "@/ui/Link";
 import DashboardEditor from "@/enterprise/components/Dashboards/DashboardEditor";
 import DashboardSnapshotProvider from "@/enterprise/components/Dashboards/DashboardSnapshotProvider";
 
@@ -10,8 +12,13 @@ import DashboardSnapshotProvider from "@/enterprise/components/Dashboards/Dashbo
 // are provided, so omitting them here is enough to make this view-only.
 export default function DashboardView({
   dashboardId,
+  maxBlocks,
 }: {
   dashboardId: string;
+  // When set, only the first N blocks render (in the dashboard's own saved
+  // order/sizing) instead of shrinking or reflowing everything to fit a
+  // smaller space. A "View full dashboard" link covers the rest.
+  maxBlocks?: number;
 }) {
   const { data, isLoading, error, mutate } = useApi<{
     dashboard: DashboardInterface;
@@ -32,6 +39,11 @@ export default function DashboardView({
     return null;
   }
 
+  const visibleBlocks = maxBlocks
+    ? dashboard.blocks.slice(0, maxBlocks)
+    : dashboard.blocks;
+  const hasHiddenBlocks = visibleBlocks.length < dashboard.blocks.length;
+
   return (
     <DashboardSnapshotProvider dashboard={dashboard} mutateDefinitions={mutate}>
       <DashboardEditor
@@ -44,7 +56,7 @@ export default function DashboardView({
         isGeneralDashboard={true}
         isEditing={false}
         title={dashboard.title}
-        blocks={dashboard.blocks}
+        blocks={visibleBlocks}
         globalControls={dashboard.globalControls}
         enableAutoUpdates={dashboard.enableAutoUpdates}
         setBlock={undefined}
@@ -55,6 +67,13 @@ export default function DashboardView({
         dashboardLastUpdated={dashboard.lastUpdated}
         dashboardComparison={dashboard.comparison}
       />
+      {hasHiddenBlocks && (
+        <Flex justify="end" mt="2">
+          <Link href={`/product-analytics/dashboards/${dashboard.id}`}>
+            View full dashboard →
+          </Link>
+        </Flex>
+      )}
     </DashboardSnapshotProvider>
   );
 }

--- a/packages/front-end/hooks/useDashboards.ts
+++ b/packages/front-end/hooks/useDashboards.ts
@@ -44,10 +44,15 @@ export function useExperimentDashboards(experimentId: string) {
   };
 }
 
-export function useDashboards(includeExperimentDashboards: boolean) {
+export function useDashboards(
+  includeExperimentDashboards: boolean,
+  shouldRun?: () => boolean,
+) {
   const { data, error, mutate } = useApi<{
     dashboards: DashboardInterface[];
-  }>(`/dashboards?includeExperimentDashboards=${includeExperimentDashboards}`);
+  }>(`/dashboards?includeExperimentDashboards=${includeExperimentDashboards}`, {
+    shouldRun,
+  });
 
   const dashboards = useMemo(() => data?.dashboards || [], [data]);
 

--- a/packages/front-end/pages/project/[pid].tsx
+++ b/packages/front-end/pages/project/[pid].tsx
@@ -87,12 +87,17 @@ const ProjectPage: FC = () => {
   const checklist = data?.checklist;
 
   const canViewDashboards = hasCommercialFeature("dashboards");
-  const { dashboards } = useDashboards(false, () => canViewDashboards);
+  const { dashboards, loading: dashboardsLoading } = useDashboards(
+    false,
+    () => canViewDashboards,
+  );
   const projectDashboards = useMemo(
     () =>
       dashboards.filter((d) => !d.projects?.length || d.projects.includes(pid)),
     [dashboards, pid],
   );
+  const noProjectDashboards =
+    !dashboardsLoading && projectDashboards.length === 0;
 
   useEffect(() => {
     if (settings) {
@@ -421,7 +426,7 @@ const ProjectPage: FC = () => {
                             home page by default. They can still pick a
                             different one for themselves.
                           </Text>
-                          {projectDashboards.length === 0 ? (
+                          {dashboardsLoading ? null : noProjectDashboards ? (
                             <Callout status="info">
                               No dashboards are available for this Project yet.{" "}
                               <Link href="/product-analytics/dashboards/new">

--- a/packages/front-end/pages/project/[pid].tsx
+++ b/packages/front-end/pages/project/[pid].tsx
@@ -416,21 +416,34 @@ const ProjectPage: FC = () => {
                           <Heading as="h5" size="sm">
                             Default Dashboard
                           </Heading>
-                          <p className="pt-2">
+                          <Text as="p" mt="2">
                             Members of this project see this dashboard on their
                             home page by default. They can still pick a
                             different one for themselves.
-                          </p>
-                          <DashboardSelector
-                            dashboards={projectDashboards}
-                            value={form.watch("defaultDashboardId") || ""}
-                            setValue={(v) =>
-                              form.setValue(
-                                "defaultDashboardId",
-                                v || undefined,
-                              )
-                            }
-                          />
+                          </Text>
+                          {projectDashboards.length === 0 ? (
+                            <Callout status="info">
+                              No dashboards are available for this Project yet.{" "}
+                              <Link href="/product-analytics/dashboards/new">
+                                Create a dashboard
+                              </Link>{" "}
+                              scoped to this Project (or with no Project
+                              restriction) to set a default.
+                            </Callout>
+                          ) : (
+                            <DashboardSelector
+                              dashboards={projectDashboards}
+                              value={form.watch("defaultDashboardId") || ""}
+                              setValue={(v) =>
+                                form.setValue(
+                                  "defaultDashboardId",
+                                  v || undefined,
+                                )
+                              }
+                              allowClear
+                              clearLabel="No default"
+                            />
+                          )}
                         </Box>
                       </Flex>
                     </Flex>

--- a/packages/front-end/pages/project/[pid].tsx
+++ b/packages/front-end/pages/project/[pid].tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from "react";
+import React, { FC, useEffect, useMemo, useState } from "react";
 import router from "next/router";
 import NextLink from "next/link";
 import { useForm } from "react-hook-form";
@@ -36,6 +36,8 @@ import Metadata from "@/ui/Metadata";
 import ChanceToWinThresholdField from "@/components/GeneralSettings/ExperimentSettings/ChanceToWinThresholdField";
 import PValueThresholdField from "@/components/GeneralSettings/ExperimentSettings/PValueThresholdField";
 import Callout from "@/ui/Callout";
+import { useDashboards } from "@/hooks/useDashboards";
+import DashboardSelector from "@/enterprise/components/Dashboards/DashboardSelector";
 
 function emptyStringToUndefined(v: unknown): number | undefined {
   if (v === "" || v === null || v === undefined) return undefined;
@@ -83,6 +85,13 @@ const ProjectPage: FC = () => {
   }>(`/experiments/launch-checklist?projectId=${pid}`);
 
   const checklist = data?.checklist;
+
+  const { dashboards } = useDashboards(false);
+  const projectDashboards = useMemo(
+    () =>
+      dashboards.filter((d) => !d.projects?.length || d.projects.includes(pid)),
+    [dashboards, pid],
+  );
 
   useEffect(() => {
     if (settings) {
@@ -389,6 +398,34 @@ const ProjectPage: FC = () => {
                             }}
                           />
                         ) : null}
+                      </Box>
+                    </Flex>
+                  </Flex>
+                </Frame>
+                <Frame>
+                  <Flex gap="4" mb="4">
+                    <Box width="220px" flexShrink="0">
+                      <Heading as="h4" size="md">
+                        Home Page Dashboard
+                      </Heading>
+                    </Box>
+                    <Flex align="start" direction="column" flexGrow="1">
+                      <Box mb="3" width="100%">
+                        <Heading as="h5" size="sm">
+                          Default Dashboard
+                        </Heading>
+                        <p className="pt-2">
+                          Members of this project see this dashboard on their
+                          home page by default. They can still pick a different
+                          one for themselves.
+                        </p>
+                        <DashboardSelector
+                          dashboards={projectDashboards}
+                          value={form.watch("defaultDashboardId") || ""}
+                          setValue={(v) =>
+                            form.setValue("defaultDashboardId", v || undefined)
+                          }
+                        />
                       </Box>
                     </Flex>
                   </Flex>

--- a/packages/front-end/pages/project/[pid].tsx
+++ b/packages/front-end/pages/project/[pid].tsx
@@ -86,7 +86,8 @@ const ProjectPage: FC = () => {
 
   const checklist = data?.checklist;
 
-  const { dashboards } = useDashboards(false);
+  const canViewDashboards = hasCommercialFeature("dashboards");
+  const { dashboards } = useDashboards(false, () => canViewDashboards);
   const projectDashboards = useMemo(
     () =>
       dashboards.filter((d) => !d.projects?.length || d.projects.includes(pid)),
@@ -402,34 +403,39 @@ const ProjectPage: FC = () => {
                     </Flex>
                   </Flex>
                 </Frame>
-                <Frame>
-                  <Flex gap="4" mb="4">
-                    <Box width="220px" flexShrink="0">
-                      <Heading as="h4" size="md">
-                        Home Page Dashboard
-                      </Heading>
-                    </Box>
-                    <Flex align="start" direction="column" flexGrow="1">
-                      <Box mb="3" width="100%">
-                        <Heading as="h5" size="sm">
-                          Default Dashboard
+                {canViewDashboards && (
+                  <Frame>
+                    <Flex gap="4" mb="4">
+                      <Box width="220px" flexShrink="0">
+                        <Heading as="h4" size="md">
+                          Home Page Dashboard
                         </Heading>
-                        <p className="pt-2">
-                          Members of this project see this dashboard on their
-                          home page by default. They can still pick a different
-                          one for themselves.
-                        </p>
-                        <DashboardSelector
-                          dashboards={projectDashboards}
-                          value={form.watch("defaultDashboardId") || ""}
-                          setValue={(v) =>
-                            form.setValue("defaultDashboardId", v || undefined)
-                          }
-                        />
                       </Box>
+                      <Flex align="start" direction="column" flexGrow="1">
+                        <Box mb="3" width="100%">
+                          <Heading as="h5" size="sm">
+                            Default Dashboard
+                          </Heading>
+                          <p className="pt-2">
+                            Members of this project see this dashboard on their
+                            home page by default. They can still pick a
+                            different one for themselves.
+                          </p>
+                          <DashboardSelector
+                            dashboards={projectDashboards}
+                            value={form.watch("defaultDashboardId") || ""}
+                            setValue={(v) =>
+                              form.setValue(
+                                "defaultDashboardId",
+                                v || undefined,
+                              )
+                            }
+                          />
+                        </Box>
+                      </Flex>
                     </Flex>
-                  </Flex>
-                </Frame>
+                  </Frame>
+                )}
                 <div className="w-100 py-3" style={{ bottom: 0, height: 70 }}>
                   <div className="container-fluid pagecontents d-flex">
                     <div className="flex-grow-1 mr-4">

--- a/packages/front-end/services/DefinitionsContext.tsx
+++ b/packages/front-end/services/DefinitionsContext.tsx
@@ -161,6 +161,7 @@ export function useDefinitions() {
 }
 
 export const LOCALSTORAGE_PROJECT_KEY = "gb_current_project" as const;
+export const LOCALSTORAGE_DASHBOARD_KEY = "gb_selected_dashboard" as const;
 
 // Applies user's team(s) default project constraint once per browser session
 let teamConstraintApplied = false;

--- a/packages/front-end/services/DefinitionsContext.tsx
+++ b/packages/front-end/services/DefinitionsContext.tsx
@@ -159,6 +159,7 @@ export function useDefinitions() {
 }
 
 export const LOCALSTORAGE_PROJECT_KEY = "gb_current_project" as const;
+export const LOCALSTORAGE_DASHBOARD_KEY = "gb_selected_dashboard" as const;
 
 // Applies user's team(s) default project constraint once per browser session
 let teamConstraintApplied = false;

--- a/packages/shared/src/validators/projects.ts
+++ b/packages/shared/src/validators/projects.ts
@@ -12,6 +12,7 @@ export const projectSettingsValidator = z.object({
   statsEngine: statsEnginesValidator.optional(),
   confidenceLevel: z.number().min(0.5).max(1).optional(),
   pValueThreshold: z.number().gt(0).max(0.5).optional(),
+  defaultDashboardId: z.string().optional(),
 });
 
 export const projectValidator = baseSchema


### PR DESCRIPTION
### Features and Changes

Adds a "Dashboard" card to the home page (under the "Needing Attention" section) that resolves and renders a dashboard preview:

- **Resolution order:** the user's own pick (stored in `localStorage` under `gb_selected_dashboard`) → the current project's admin-configured `defaultDashboardId` (from #6650) → nothing selected.
- The dashboard selector itself (reusing `DashboardSelector`) always shows as long as candidate dashboards exist for the project, even before any default has been configured — so it's discoverable without depending on an admin having set one up first.
- Renders via the read-only `DashboardView` from #6648, capped to the first 2 blocks (in the dashboard's own saved order/sizing) with a "View full dashboard →" link when more exist. This avoids two worse options: shrinking/scaling the whole grid (which just forces scrolling and defeats the point of a quick-glance preview), or reflowing blocks into a fixed layout (which would override the dashboard author's deliberate sizing choices).
- A few spacing/padding/height iterations based on visual review feedback (top margin, inner padding, preview block count/height).

### Dependencies

Requires #6650 so a project default can actually resolve, though the card also works purely from the localStorage selection with no admin default configured.

### Testing

- `pnpm --filter front-end type-check`
- Manually verified: card shows/hides correctly depending on dashboard availability, the inline selector's pick persists across reloads and takes precedence over the project default, and the dashboard's own "Update" button remains usable (permission-gated, not tied to edit mode) inside the read-only embed.

### Screenshots
<img width="1320" height="838" alt="Screenshot 2026-08-14 at 4 30 37 PM" src="https://github.com/user-attachments/assets/f34d5bf2-bd79-469a-8ccd-4a22dd7d4409" />
<img width="919" height="806" alt="Screenshot 2026-08-14 at 4 30 47 PM" src="https://github.com/user-attachments/assets/e6376077-a729-499b-9e7b-9186ae3e0f40" />
<img width="894" height="862" alt="Screenshot 2026-08-14 at 4 30 51 PM" src="https://github.com/user-attachments/assets/bea3dfe0-f835-43ad-911c-56386b7b5e58" />
<img width="907" height="843" alt="Screenshot 2026-08-14 at 4 30 56 PM" src="https://github.com/user-attachments/assets/2ce3ec39-4bcb-4168-924f-c20e2712963c" />

