### PR TITLE
feat(dashboards): set a project's default dashboard from the Dashboards list

### DIFF
--- a/packages/back-end/src/routers/project/project.controller.ts
+++ b/packages/back-end/src/routers/project/project.controller.ts
@@ -344,7 +344,7 @@ export const deleteProject = async (
 // endregion DELETE /projects/:id
 
 type PutProjectSettingsRequest = AuthRequest<
-  { settings: ProjectSettings },
+  { settings: Partial<ProjectSettings> },
   { id: string }
 >;
 type PutProjectSettingsResponse = {
@@ -372,7 +372,7 @@ export const putProjectSettings = async (
     return;
   }
 
-  const { settings } = req.body;
+  const settings = { ...project.settings, ...req.body.settings };
 
   await context.models.projects.update(project, { settings });
 

--- a/packages/front-end/pages/product-analytics/dashboards/index.tsx
+++ b/packages/front-end/pages/product-analytics/dashboards/index.tsx
@@ -386,6 +386,10 @@ export default function DashboardsPage() {
                           const isDefaultForSingleProject =
                             singleEligibleProjectForDefault?.settings
                               ?.defaultDashboardId === d.id;
+                          const isDefaultForAnyEligibleProject =
+                            eligibleProjectsForDefault.some(
+                              (p) => p.settings?.defaultDashboardId === d.id,
+                            );
 
                           // If the dashboard is private, and the currentUser isn't the owner, they don't have edit/delete rights, regardless of their permissions
                           if (
@@ -522,7 +526,13 @@ export default function DashboardsPage() {
                                         </Tooltip>
                                       ) : eligibleProjectsForDefault.length >
                                         1 ? (
-                                        <DropdownSubMenu trigger="Set as Default Dashboard">
+                                        <DropdownSubMenu
+                                          trigger={
+                                            isDefaultForAnyEligibleProject
+                                              ? "Manage Default Dashboard"
+                                              : "Set as Default Dashboard"
+                                          }
+                                        >
                                           {eligibleProjectsForDefault.map(
                                             (p) => {
                                               const isCurrentDefault =
@@ -548,7 +558,7 @@ export default function DashboardsPage() {
                                                     }
                                                   >
                                                     {isCurrentDefault
-                                                      ? `Remove as Default (${p.name})`
+                                                      ? `Remove as Default for ${p.name}`
                                                       : p.name}
                                                   </DropdownMenuItem>
                                                 </Tooltip>

--- a/packages/front-end/pages/product-analytics/dashboards/index.tsx
+++ b/packages/front-end/pages/product-analytics/dashboards/index.tsx
@@ -498,44 +498,62 @@ export default function DashboardsPage() {
                                       </DropdownMenuItem>
 
                                       {singleEligibleProjectForDefault ? (
-                                        <DropdownMenuItem
-                                          disabled={isDefaultForSingleProject}
-                                          onClick={() =>
-                                            setDefaultDashboard(
-                                              singleEligibleProjectForDefault.id,
-                                              d.id,
-                                            )
+                                        <Tooltip
+                                          body={
+                                            isDefaultForSingleProject
+                                              ? `Remove this dashboard as the default. Members of the ${singleEligibleProjectForDefault.name} Project currently see it on their home page by default.`
+                                              : `Members of the ${singleEligibleProjectForDefault.name} Project will see this dashboard on their home page by default. They can still pick a different one for themselves.`
                                           }
                                         >
-                                          {isDefaultForSingleProject
-                                            ? `Default for ${singleEligibleProjectForDefault.name}`
-                                            : `Set as Default for ${singleEligibleProjectForDefault.name}`}
-                                        </DropdownMenuItem>
+                                          <DropdownMenuItem
+                                            onClick={() =>
+                                              setDefaultDashboard(
+                                                singleEligibleProjectForDefault.id,
+                                                isDefaultForSingleProject
+                                                  ? ""
+                                                  : d.id,
+                                              )
+                                            }
+                                          >
+                                            {isDefaultForSingleProject
+                                              ? `Remove as Default for ${singleEligibleProjectForDefault.name}`
+                                              : `Set as Default for ${singleEligibleProjectForDefault.name}`}
+                                          </DropdownMenuItem>
+                                        </Tooltip>
                                       ) : eligibleProjectsForDefault.length >
                                         1 ? (
                                         <DropdownSubMenu trigger="Set as Default Dashboard">
                                           {eligibleProjectsForDefault.map(
-                                            (p) => (
-                                              <DropdownMenuItem
-                                                key={p.id}
-                                                disabled={
-                                                  p.settings
-                                                    ?.defaultDashboardId ===
-                                                  d.id
-                                                }
-                                                onClick={() =>
-                                                  setDefaultDashboard(
-                                                    p.id,
-                                                    d.id,
-                                                  )
-                                                }
-                                              >
-                                                {p.settings
-                                                  ?.defaultDashboardId === d.id
-                                                  ? `${p.name} (current default)`
-                                                  : p.name}
-                                              </DropdownMenuItem>
-                                            ),
+                                            (p) => {
+                                              const isCurrentDefault =
+                                                p.settings
+                                                  ?.defaultDashboardId === d.id;
+                                              return (
+                                                <Tooltip
+                                                  key={p.id}
+                                                  body={
+                                                    isCurrentDefault
+                                                      ? `Remove this dashboard as the default. Members of the ${p.name} Project currently see it on their home page by default.`
+                                                      : `Members of the ${p.name} Project will see this dashboard on their home page by default. They can still pick a different one for themselves.`
+                                                  }
+                                                >
+                                                  <DropdownMenuItem
+                                                    onClick={() =>
+                                                      setDefaultDashboard(
+                                                        p.id,
+                                                        isCurrentDefault
+                                                          ? ""
+                                                          : d.id,
+                                                      )
+                                                    }
+                                                  >
+                                                    {isCurrentDefault
+                                                      ? `Remove as Default (${p.name})`
+                                                      : p.name}
+                                                  </DropdownMenuItem>
+                                                </Tooltip>
+                                              );
+                                            },
                                           )}
                                         </DropdownSubMenu>
                                       ) : null}

--- a/packages/front-end/pages/product-analytics/dashboards/index.tsx
+++ b/packages/front-end/pages/product-analytics/dashboards/index.tsx
@@ -559,7 +559,7 @@ export default function DashboardsPage() {
                                                   >
                                                     {isCurrentDefault
                                                       ? `Remove as Default for ${p.name}`
-                                                      : p.name}
+                                                      : `Set as Default for ${p.name}`}
                                                   </DropdownMenuItem>
                                                 </Tooltip>
                                               );

--- a/packages/front-end/pages/product-analytics/dashboards/index.tsx
+++ b/packages/front-end/pages/product-analytics/dashboards/index.tsx
@@ -379,6 +379,15 @@ export default function DashboardsPage() {
                             permissionsUtil.canCreateGeneralDashboards(d);
                           const canManageSharingAndEditLevels =
                             canEdit && (isOwner || isAdmin);
+                          const eligibleProjectsForDefault =
+                            getEligibleProjectsForDefault(d);
+                          const singleEligibleProjectForDefault =
+                            eligibleProjectsForDefault.length === 1
+                              ? eligibleProjectsForDefault[0]
+                              : undefined;
+                          const isDefaultForSingleProject =
+                            singleEligibleProjectForDefault?.settings
+                              ?.defaultDashboardId === d.id;
 
                           // If the dashboard is private, and the currentUser isn't the owner, they don't have edit/delete rights, regardless of their permissions
                           if (
@@ -490,56 +499,48 @@ export default function DashboardsPage() {
                                         Share...
                                       </DropdownMenuItem>
 
-                                      {(() => {
-                                        const eligibleProjects =
-                                          getEligibleProjectsForDefault(d);
-                                        if (!eligibleProjects.length) {
-                                          return null;
-                                        }
-                                        if (eligibleProjects.length === 1) {
-                                          const p = eligibleProjects[0];
-                                          const isDefault =
-                                            p.settings?.defaultDashboardId ===
-                                            d.id;
-                                          return (
-                                            <DropdownMenuItem
-                                              disabled={isDefault}
-                                              onClick={() =>
-                                                setDefaultDashboard(p.id, d.id)
-                                              }
-                                            >
-                                              {isDefault
-                                                ? `Default for ${p.name}`
-                                                : `Set as Default for ${p.name}`}
-                                            </DropdownMenuItem>
-                                          );
-                                        }
-                                        return (
-                                          <DropdownSubMenu trigger="Set as Default Dashboard">
-                                            {eligibleProjects.map((p) => {
-                                              const isDefault =
-                                                p.settings
-                                                  ?.defaultDashboardId === d.id;
-                                              return (
-                                                <DropdownMenuItem
-                                                  key={p.id}
-                                                  disabled={isDefault}
-                                                  onClick={() =>
-                                                    setDefaultDashboard(
-                                                      p.id,
-                                                      d.id,
-                                                    )
-                                                  }
-                                                >
-                                                  {isDefault
-                                                    ? `${p.name} (current default)`
-                                                    : p.name}
-                                                </DropdownMenuItem>
-                                              );
-                                            })}
-                                          </DropdownSubMenu>
-                                        );
-                                      })()}
+                                      {singleEligibleProjectForDefault ? (
+                                        <DropdownMenuItem
+                                          disabled={isDefaultForSingleProject}
+                                          onClick={() =>
+                                            setDefaultDashboard(
+                                              singleEligibleProjectForDefault.id,
+                                              d.id,
+                                            )
+                                          }
+                                        >
+                                          {isDefaultForSingleProject
+                                            ? `Default for ${singleEligibleProjectForDefault.name}`
+                                            : `Set as Default for ${singleEligibleProjectForDefault.name}`}
+                                        </DropdownMenuItem>
+                                      ) : eligibleProjectsForDefault.length >
+                                        1 ? (
+                                        <DropdownSubMenu trigger="Set as Default Dashboard">
+                                          {eligibleProjectsForDefault.map(
+                                            (p) => (
+                                              <DropdownMenuItem
+                                                key={p.id}
+                                                disabled={
+                                                  p.settings
+                                                    ?.defaultDashboardId ===
+                                                  d.id
+                                                }
+                                                onClick={() =>
+                                                  setDefaultDashboard(
+                                                    p.id,
+                                                    d.id,
+                                                  )
+                                                }
+                                              >
+                                                {p.settings
+                                                  ?.defaultDashboardId === d.id
+                                                  ? `${p.name} (current default)`
+                                                  : p.name}
+                                              </DropdownMenuItem>
+                                            ),
+                                          )}
+                                        </DropdownSubMenu>
+                                      ) : null}
 
                                       {canDelete && (
                                         <>

--- a/packages/front-end/pages/product-analytics/dashboards/index.tsx
+++ b/packages/front-end/pages/product-analytics/dashboards/index.tsx
@@ -48,8 +48,7 @@ import LinkButton from "@/ui/LinkButton";
 export default function DashboardsPage() {
   const permissionsUtil = usePermissionsUtil();
   const { hasCommercialFeature, userId } = useUser();
-  const { project, projects, getProjectById, mutateDefinitions } =
-    useDefinitions();
+  const { project, projects, mutateDefinitions } = useDefinitions();
   const { apiCall } = useAuth();
   const [saving, setSaving] = useState(false);
   const router = useRouter();
@@ -165,14 +164,13 @@ export default function DashboardsPage() {
   };
 
   const setDefaultDashboard = async (projectId: string, dashId: string) => {
-    const p = getProjectById(projectId);
+    // The server merges this into the project's existing settings, so only
+    // the changed field needs to be sent (avoids clobbering concurrent
+    // changes to statsEngine/confidenceLevel/etc. from a stale snapshot).
     await apiCall(`/projects/${projectId}/settings`, {
       method: "PUT",
       body: JSON.stringify({
-        // `settings` is a single field server-side (replaced wholesale, not
-        // merged), so the rest of the project's settings must be spread back
-        // in or this would silently clear statsEngine/confidenceLevel/etc.
-        settings: { ...p?.settings, defaultDashboardId: dashId },
+        settings: { defaultDashboardId: dashId },
       }),
     });
     mutateDefinitions();

--- a/packages/front-end/pages/product-analytics/dashboards/index.tsx
+++ b/packages/front-end/pages/product-analytics/dashboards/index.tsx
@@ -38,6 +38,7 @@ import {
   DropdownMenu,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownSubMenu,
 } from "@/ui/DropdownMenu";
 import PremiumEmptyState from "@/components/PremiumEmptyState";
 import Tooltip from "@/components/Tooltip/Tooltip";
@@ -47,7 +48,8 @@ import LinkButton from "@/ui/LinkButton";
 export default function DashboardsPage() {
   const permissionsUtil = usePermissionsUtil();
   const { hasCommercialFeature, userId } = useUser();
-  const { project } = useDefinitions();
+  const { project, projects, getProjectById, mutateDefinitions } =
+    useDefinitions();
   const { apiCall } = useAuth();
   const [saving, setSaving] = useState(false);
   const router = useRouter();
@@ -150,6 +152,31 @@ export default function DashboardsPage() {
     },
     [apiCall, mutateDashboards],
   );
+
+  // A dashboard scoped to specific projects can only be set as the default
+  // for one of those; a global dashboard (no projects) is eligible for any
+  // project. Either way, setting a project's default requires permission on
+  // that project specifically, not on the dashboard.
+  const getEligibleProjectsForDefault = (d: DashboardInterface) => {
+    const candidates = d.projects?.length
+      ? projects.filter((p) => d.projects?.includes(p.id))
+      : projects;
+    return candidates.filter((p) => permissionsUtil.canUpdateProject(p.id));
+  };
+
+  const setDefaultDashboard = async (projectId: string, dashId: string) => {
+    const p = getProjectById(projectId);
+    await apiCall(`/projects/${projectId}/settings`, {
+      method: "PUT",
+      body: JSON.stringify({
+        // `settings` is a single field server-side (replaced wholesale, not
+        // merged), so the rest of the project's settings must be spread back
+        // in or this would silently clear statsEngine/confidenceLevel/etc.
+        settings: { ...p?.settings, defaultDashboardId: dashId },
+      }),
+    });
+    mutateDefinitions();
+  };
 
   if (loading || saving) return <LoadingOverlay />;
 
@@ -462,6 +489,57 @@ export default function DashboardsPage() {
                                       >
                                         Share...
                                       </DropdownMenuItem>
+
+                                      {(() => {
+                                        const eligibleProjects =
+                                          getEligibleProjectsForDefault(d);
+                                        if (!eligibleProjects.length) {
+                                          return null;
+                                        }
+                                        if (eligibleProjects.length === 1) {
+                                          const p = eligibleProjects[0];
+                                          const isDefault =
+                                            p.settings?.defaultDashboardId ===
+                                            d.id;
+                                          return (
+                                            <DropdownMenuItem
+                                              disabled={isDefault}
+                                              onClick={() =>
+                                                setDefaultDashboard(p.id, d.id)
+                                              }
+                                            >
+                                              {isDefault
+                                                ? `Default for ${p.name}`
+                                                : `Set as Default for ${p.name}`}
+                                            </DropdownMenuItem>
+                                          );
+                                        }
+                                        return (
+                                          <DropdownSubMenu trigger="Set as Default Dashboard">
+                                            {eligibleProjects.map((p) => {
+                                              const isDefault =
+                                                p.settings
+                                                  ?.defaultDashboardId === d.id;
+                                              return (
+                                                <DropdownMenuItem
+                                                  key={p.id}
+                                                  disabled={isDefault}
+                                                  onClick={() =>
+                                                    setDefaultDashboard(
+                                                      p.id,
+                                                      d.id,
+                                                    )
+                                                  }
+                                                >
+                                                  {isDefault
+                                                    ? `${p.name} (current default)`
+                                                    : p.name}
+                                                </DropdownMenuItem>
+                                              );
+                                            })}
+                                          </DropdownSubMenu>
+                                        );
+                                      })()}
 
                                       {canDelete && (
                                         <>


### PR DESCRIPTION
### Features and Changes

Adds a "Set as Default Dashboard" action to each row's `⋮` menu on the Product Analytics Dashboards list page (`/product-analytics/dashboards`), so setting a default doesn't require a separate trip to project settings:

- Eligible projects are the dashboard's own scoped projects, or all projects if it's a global (unscoped) dashboard — filtered down to the ones the current user can manage (`canUpdateProject`).
- A single eligible project renders a direct "Set as Default for [Project]" menu item; multiple eligible projects render a submenu with one item per project, marking whichever is currently the default.
- The write correctly merges with each project's existing settings before saving — `settings` is a single top-level field server-side (replaced wholesale, not deep-merged), so sending just `{defaultDashboardId}` would have silently cleared out `statsEngine`/`confidenceLevel`/`pValueThreshold`.
- Per-row eligibility/state is computed once alongside the existing `canEdit`/`canDelete` permission checks, rather than via a function invoked during render.

### Dependencies

Requires #6650 (the `defaultDashboardId` field/API). Stacked on #6651 for ordering; functionally independent of the home-page card itself.

### Testing

- `pnpm --filter front-end type-check`
- Manually verified: single- and multiple-eligible-project cases, permission gating (no action shown when the user can't manage any relevant project), and that setting a default from this page doesn't clobber the project's other settings.

### Screenshots

<img width="1382" height="527" alt="Screenshot 2026-08-14 at 4 30 24 PM" src="https://github.com/user-attachments/assets/68ce404d-73d2-4be2-8f98-8eb5f3d5cca4" />