### PR TITLE
Adds a derived, always-present revision.tags to GrowthBook's validate…

### DIFF
--- a/docs/docs/features/custom-hooks.mdx
+++ b/docs/docs/features/custom-hooks.mdx
@@ -140,7 +140,34 @@ if (feature.valueType === "json" && feature.defaultValue === "{}") {
 
 ### validateFeatureRevision
 
-Called whenever a feature revision is about to be created or updated. Receives the full feature and the revision as inputs.
+Called whenever a feature revision is about to be created or updated. Receives:
+
+- `feature` — the **live** feature, i.e. the state before this revision publishes. Use it as the "before" side when checking what a revision changes.
+- `revision` — the revision being validated: `version`, `baseVersion`, `status`, `comment`, `title`, `defaultValue`, `rules`, `createdBy`, `contributors`, and `reviews`. Metadata staged by the revision lives on `revision.metadata` (`tags`, `description`, `owner`, `project`, `customFields`, `jsonSchema`, and more), which is **sparse** — a key is present only when this revision changed it, so an absent key means "unchanged" rather than "cleared". `revision.tags` is derived from that envelope and is always present: it holds the effective tag list this revision will publish (the staged value when tags were changed, otherwise the feature's current tags). Compare it against `feature.tags` to detect additions and removals.
+
+Example: Restrict who can add a sensitive tag. `createdBy` is a union — check `type` before reading `email`, since API key and system actors may not have one.
+
+```js
+const added = revision.tags.filter(
+  (t) => !(feature.tags || []).includes(t)
+);
+if (added.includes("pii")) {
+  const actor = revision.createdBy;
+  const isSteward =
+    actor?.type === "dashboard" && actor.email === "steward@example.com";
+  if (!isSteward) {
+    throw new Error("The 'pii' tag must be applied by a data steward.");
+  }
+}
+```
+
+Example: Require at least one tag before publishing.
+
+```js
+if (revision.status === "published" && revision.tags.length === 0) {
+  addWarning("This feature has no tags.");
+}
+```
 
 Example: Require a comment before publishing a draft.
 

--- a/packages/back-end/src/enterprise/sandbox/sandbox-eval.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-eval.ts
@@ -7,6 +7,7 @@ import {
   getConfigAncestorKeys,
   getConfigBaseKeys,
   getConfigSubtree,
+  getEffectiveRevisionTags,
   withConfigExtends,
 } from "shared/util";
 import { CONSTANT_EXTENDS_KEY } from "shared/constants";
@@ -54,6 +55,24 @@ export async function runValidateFeatureHooks({
   );
 }
 
+// The revision as hooks see it: the stored doc plus fields derived from the
+// staged metadata envelope. `feature` is the pre-merge live feature, so these
+// are the only way a hook can read what the revision will actually publish.
+type FeatureRevisionHookInput = FeatureRevisionInterface & {
+  tags: string[];
+};
+
+// `metadata` is sparse — an absent key means "unchanged", so fall back to live.
+function toFeatureRevisionHookInput(
+  feature: FeatureInterface,
+  revision: FeatureRevisionInterface,
+): FeatureRevisionHookInput {
+  return {
+    ...revision,
+    tags: getEffectiveRevisionTags(feature, revision),
+  };
+}
+
 export async function runValidateFeatureRevisionHooks({
   context,
   feature,
@@ -68,12 +87,12 @@ export async function runValidateFeatureRevisionHooks({
   return _runCustomHooks(
     context,
     "validateFeatureRevision",
-    { feature, revision },
+    { feature, revision: toFeatureRevisionHookInput(feature, revision) },
     feature.project,
     feature.id,
     {
       feature,
-      revision: original,
+      revision: toFeatureRevisionHookInput(feature, original),
     },
   );
 }
@@ -115,12 +134,12 @@ export async function collectValidateFeatureRevisionHookResults({
   return collectCustomHookResults(
     context,
     "validateFeatureRevision",
-    { feature, revision },
+    { feature, revision: toFeatureRevisionHookInput(feature, revision) },
     feature.project,
     feature.id,
     {
       feature,
-      revision: original,
+      revision: toFeatureRevisionHookInput(feature, original),
     },
   );
 }

--- a/packages/back-end/test/enterprise/featureRevisionHookInput.test.ts
+++ b/packages/back-end/test/enterprise/featureRevisionHookInput.test.ts
@@ -1,0 +1,96 @@
+import type { FeatureInterface } from "shared/types/feature";
+import type { FeatureRevisionInterface } from "shared/types/feature-revision";
+import type { Context } from "back-end/src/models/BaseModel";
+import { runInSandbox } from "back-end/src/enterprise/sandbox/sandbox-pool";
+import { getContextForAgendaJobByOrgObject } from "back-end/src/services/organizations";
+import {
+  collectValidateFeatureRevisionHookResults,
+  runValidateFeatureRevisionHooks,
+} from "back-end/src/enterprise/sandbox/sandbox-eval";
+
+// The derivation formula is covered in shared/test/util/features.test.ts; this
+// only confirms the hook runner wires it in at every call site.
+jest.mock("back-end/src/enterprise/sandbox/sandbox-pool", () => ({
+  runInSandbox: jest.fn(),
+}));
+jest.mock("back-end/src/services/organizations", () => ({
+  getContextForAgendaJobByOrgObject: jest.fn(),
+}));
+
+const mockRunInSandbox = runInSandbox as jest.MockedFunction<
+  typeof runInSandbox
+>;
+const mockAgendaContext =
+  getContextForAgendaJobByOrgObject as jest.MockedFunction<
+    typeof getContextForAgendaJobByOrgObject
+  >;
+
+const feature = { id: "feat_test", tags: ["live"] } as FeatureInterface;
+const withTags = (tags: string[]) =>
+  ({ metadata: { tags } }) as FeatureRevisionInterface;
+
+const context = {
+  hasPremiumFeature: () => true,
+  canSkipHooksFor: () => false,
+  ignoreWarnings: false,
+  models: {
+    customHooks: {
+      getByHook: jest.fn(async () => [
+        { hook: "validateFeatureRevision", incrementalChangesOnly: true },
+      ]),
+      logSuccess: jest.fn(),
+      logFailure: jest.fn(),
+    },
+  },
+} as unknown as Context;
+
+function tagsArg(call: number) {
+  return (mockRunInSandbox.mock.calls[call][1].revision as { tags: string[] })
+    .tags;
+}
+
+describe("validateFeatureRevision hook input", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAgendaContext.mockReturnValue(context);
+    // Both calls fail identically, so incrementalChangesOnly's re-run against
+    // `original` happens without throwing — letting both args be inspected.
+    mockRunInSandbox.mockResolvedValue({ ok: false, error: "x", warnings: [] });
+  });
+
+  it("derives tags for both the staged and original revision args", async () => {
+    await runValidateFeatureRevisionHooks({
+      context,
+      feature,
+      revision: withTags(["staged"]),
+      original: withTags(["base"]),
+    });
+
+    expect(tagsArg(0)).toEqual(["staged"]);
+    expect(tagsArg(1)).toEqual(["base"]);
+  });
+
+  it("does the same for the non-throwing publish-gate variant", async () => {
+    await collectValidateFeatureRevisionHookResults({
+      context,
+      feature,
+      revision: withTags(["staged"]),
+      original: withTags(["base"]),
+    });
+
+    expect(tagsArg(0)).toEqual(["staged"]);
+    expect(tagsArg(1)).toEqual(["base"]);
+  });
+
+  it("does not mutate the revision object, which gets persisted after this call", async () => {
+    const revision = withTags(["staged"]);
+    await runValidateFeatureRevisionHooks({
+      context,
+      feature,
+      revision,
+      original: withTags(["base"]),
+    });
+
+    expect(revision).not.toHaveProperty("tags");
+  });
+});

--- a/packages/front-end/components/CustomHooks/CustomHookModal.tsx
+++ b/packages/front-end/components/CustomHooks/CustomHookModal.tsx
@@ -14,6 +14,8 @@ import {
   ExperimentInterface,
   ExperimentInterfaceStringDates,
 } from "shared/types/experiment";
+import { getEffectiveRevisionTags } from "shared/util";
+import { buildHookTestFunctionArgs } from "@/components/CustomHooks/customHookTestArgs";
 import { useAuth } from "@/services/auth";
 import Modal from "@/components/Modal";
 import Field from "@/components/Forms/Field";
@@ -59,7 +61,7 @@ const dummyFeature: FeatureInterface = {
   prerequisites: [],
   customFields: {},
 };
-const dummyRevision: FeatureRevisionInterface = {
+const dummyRevision: FeatureRevisionInterface & { tags: string[] } = {
   organization: "org_abc123",
   featureId: "new-feature",
   dateCreated: new Date(),
@@ -97,6 +99,9 @@ const dummyRevision: FeatureRevisionInterface = {
       timestamp: new Date(),
     },
   ],
+  metadata: { tags: ["checkout"] },
+  // Derived by the server from metadata; not part of the stored document.
+  tags: ["checkout"],
 };
 const dummyExperiment: ExperimentInterface = {
   id: "exp_abc123",
@@ -277,11 +282,12 @@ export const hookTypes: Record<
         testValue: stringify(dummyFeature),
       },
       revision: {
-        description: "The feature revision being validated",
+        description:
+          "The feature revision being validated. `revision.tags` is the effective tag list this revision will publish (staged value, or the feature's current tags when untouched); `feature.tags` is still the live value, so compare the two to detect added or removed tags.",
         testValue: stringify(dummyRevision),
       },
     },
-    example: `\n// Block the save (hard error):\nif (!revision.rules.production || revision.rules.production.length === 0) {\n  throw new Error("At least one production rule is required");\n}\n\n// Or raise a soft warning the user can acknowledge:\nif (!revision.comment) {\n  addWarning("Consider adding a comment describing this change");\n}`,
+    example: `\n// Block the save (hard error):\nif (!revision.rules.production || revision.rules.production.length === 0) {\n  throw new Error("At least one production rule is required");\n}\n\n// Gate on tags being added:\nconst added = revision.tags.filter(t => !(feature.tags || []).includes(t));\nif (added.includes("pii")) {\n  throw new Error("The 'pii' tag must be applied by a data steward");\n}\n\n// Or raise a soft warning the user can acknowledge:\nif (!revision.comment) {\n  addWarning("Consider adding a comment describing this change");\n}`,
   },
   validateExperiment: {
     label: "Validate Experiment",
@@ -382,7 +388,12 @@ export default function CustomHookModal({
           : experiment && k === "experiment"
             ? stringify(experiment)
             : revision && k === "revision"
-              ? stringify(revision)
+              ? // Mirror the runtime shape: `tags` is derived from the sparse
+                // metadata envelope, so the stored doc lacks it.
+                stringify({
+                  ...revision,
+                  tags: getEffectiveRevisionTags(feature ?? {}, revision),
+                })
               : config && k === "config"
                 ? // Mirror the runtime shape: parsed value + this config as the
                   // hook's pinned target (a hook created here scopes to it).
@@ -419,14 +430,10 @@ export default function CustomHookModal({
         method: "POST",
         body: JSON.stringify({
           functionBody: form.getValues("code"),
-          functionArgs: Object.fromEntries(
-            Object.entries(testValues).map(([k, v]) => {
-              try {
-                return [k, JSON.parse(v)];
-              } catch (e) {
-                return [k, v];
-              }
-            }),
+          functionArgs: buildHookTestFunctionArgs(
+            testValues,
+            hookType,
+            feature,
           ),
           ...(feature
             ? { entityType: "feature" as const, entityId: feature.id }

--- a/packages/front-end/components/CustomHooks/customHookTestArgs.ts
+++ b/packages/front-end/components/CustomHooks/customHookTestArgs.ts
@@ -1,0 +1,49 @@
+import { FeatureInterface } from "shared/types/feature";
+import { FeatureRevisionInterface } from "shared/types/feature-revision";
+import { getEffectiveRevisionTags } from "shared/util";
+import { CustomHookType } from "shared/validators";
+
+// Builds the functionArgs sent to POST /custom-hooks/test from the Test
+// panel's editable JSON textareas.
+//
+// The server always derives `revision.tags` fresh from `revision.metadata`
+// (see getEffectiveRevisionTags) — it never trusts a submitted `tags` field.
+// Recompute it here too, at submit time, so an edit to `metadata.tags` in the
+// textarea can't leave a stale sibling `tags` value that disagrees with what
+// the hook would actually see on a real save.
+export function buildHookTestFunctionArgs(
+  testValues: Record<string, string>,
+  hookType: CustomHookType,
+  feature: Pick<FeatureInterface, "tags"> | undefined,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(testValues).map(([key, rawValue]) => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(rawValue);
+      } catch {
+        return [key, rawValue];
+      }
+
+      if (
+        key === "revision" &&
+        hookType === "validateFeatureRevision" &&
+        parsed !== null &&
+        typeof parsed === "object"
+      ) {
+        return [
+          key,
+          {
+            ...parsed,
+            tags: getEffectiveRevisionTags(
+              feature ?? {},
+              parsed as Pick<FeatureRevisionInterface, "metadata">,
+            ),
+          },
+        ];
+      }
+
+      return [key, parsed];
+    }),
+  );
+}

--- a/packages/front-end/test/components/CustomHooks/customHookTestArgs.test.ts
+++ b/packages/front-end/test/components/CustomHooks/customHookTestArgs.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import type { FeatureInterface } from "shared/types/feature";
+import { buildHookTestFunctionArgs } from "@/components/CustomHooks/customHookTestArgs";
+
+const FEATURE = { tags: ["live"] } as Pick<FeatureInterface, "tags">;
+
+describe("buildHookTestFunctionArgs", () => {
+  it("recomputes tags on every call, overriding a stale sibling tags field", () => {
+    // Simulates editing `metadata.tags` in the textarea without also updating
+    // the `tags` field baked in when the panel first opened.
+    const args = buildHookTestFunctionArgs(
+      {
+        revision: JSON.stringify({
+          metadata: { tags: ["edited"] },
+          tags: ["stale"],
+        }),
+      },
+      "validateFeatureRevision",
+      FEATURE,
+    );
+
+    expect(args.revision).toMatchObject({ tags: ["edited"] });
+  });
+
+  it("falls back to the feature's tags when metadata does not touch tags", () => {
+    const args = buildHookTestFunctionArgs(
+      { revision: JSON.stringify({ metadata: { description: "x" } }) },
+      "validateFeatureRevision",
+      FEATURE,
+    );
+
+    expect(args.revision).toMatchObject({ tags: ["live"] });
+  });
+
+  it("does not touch the revision arg for other hook types (e.g. validateConfigRevision)", () => {
+    const configRevision = { version: 2, status: "approved" };
+    const args = buildHookTestFunctionArgs(
+      { revision: JSON.stringify(configRevision) },
+      "validateConfigRevision",
+      undefined,
+    );
+
+    expect(args.revision).toEqual(configRevision);
+  });
+
+  it("does not touch non-revision keys", () => {
+    const args = buildHookTestFunctionArgs(
+      { feature: JSON.stringify({ tags: ["a"] }) },
+      "validateFeatureRevision",
+      FEATURE,
+    );
+
+    expect(args.feature).toEqual({ tags: ["a"] });
+  });
+
+  it("passes through a value that fails to parse as JSON unchanged", () => {
+    const args = buildHookTestFunctionArgs(
+      { revision: "not json" },
+      "validateFeatureRevision",
+      FEATURE,
+    );
+
+    expect(args.revision).toBe("not json");
+  });
+});

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -154,6 +154,16 @@ export function toV2FeatureSnapshot<T extends Partial<FeatureInterface>>(
   } as T;
 }
 
+// A revision's `metadata` envelope is sparse — a key is present only when this
+// revision changed it — so an absent `tags` means "unchanged", not "cleared".
+// Shared so the hook runtime and the hook Test panel derive it identically.
+export function getEffectiveRevisionTags(
+  feature: Pick<FeatureInterface, "tags">,
+  revision: Pick<FeatureRevisionInterface, "metadata">,
+): string[] {
+  return revision.metadata?.tags ?? feature.tags ?? [];
+}
+
 export function mergeRevision(
   feature: FeatureInterface,
   revision: FeatureRevisionInterface,

--- a/packages/shared/test/util/features.test.ts
+++ b/packages/shared/test/util/features.test.ts
@@ -10,6 +10,7 @@ import {
   validateFeatureValue,
   assertSchemaMatchesValueType,
   getValidation,
+  getEffectiveRevisionTags,
   validateJSONFeatureValue,
   autoMerge,
   getLiveChangesSinceBase,
@@ -4741,5 +4742,49 @@ describe("draftHasChangesOutsideTargetRef", () => {
       prerequisites: [{ id: "feat_x", condition: '{"value": true}' }],
     });
     expect(draftHasChangesOutsideTargetRef(draft, live, isTarget)).toBe(true);
+  });
+});
+
+describe("getEffectiveRevisionTags", () => {
+  const feature = (tags?: string[]) =>
+    ({ ...(tags === undefined ? {} : { tags }) }) as Pick<
+      FeatureInterface,
+      "tags"
+    >;
+  const revision = (metadata?: { tags?: string[]; description?: string }) =>
+    ({ ...(metadata === undefined ? {} : { metadata }) }) as Pick<
+      FeatureRevisionInterface,
+      "metadata"
+    >;
+
+  it("uses the staged tags when the revision changes them", () => {
+    expect(
+      getEffectiveRevisionTags(feature(["old"]), revision({ tags: ["new"] })),
+    ).toEqual(["new"]);
+  });
+
+  it("falls back to the feature's tags when the revision leaves them untouched", () => {
+    expect(getEffectiveRevisionTags(feature(["live"]), revision())).toEqual([
+      "live",
+    ]);
+  });
+
+  it("falls back when metadata exists but does not touch tags", () => {
+    expect(
+      getEffectiveRevisionTags(
+        feature(["live"]),
+        revision({ description: "changed" }),
+      ),
+    ).toEqual(["live"]);
+  });
+
+  it("treats tags cleared to an empty list as distinct from untouched", () => {
+    expect(
+      getEffectiveRevisionTags(feature(["live"]), revision({ tags: [] })),
+    ).toEqual([]);
+  });
+
+  it("defaults to an empty array when neither side has tags", () => {
+    expect(getEffectiveRevisionTags(feature(), revision())).toEqual([]);
   });
 });


### PR DESCRIPTION
### Features and Changes
The validateFeatureRevision custom hook received the raw revision document alongside the pre-merge live feature, so a hook could not cleanly read the tags a revision would publish. Tags were reachable at revision.metadata.tags, but that envelope is sparse — an absent key means "unchanged", indistinguishable from "cleared" without manually comparing against feature.tags — and it was absent from both the docs and the in-app Test fixture. Add a derived revision.tags holding the effective tag list, mirroring the enrichment config hooks already get via ConfigHookInput. feature.tags still carries the live value, so hooks can diff the two to detect additions:
* tags staged by this revision → revision.tags is the staged value
* tags untouched → revision.tags falls back to the feature's current tags
* tags cleared → revision.tags is [], distinct from untouched
Derived on the original args too, so incrementalChangesOnly suppression keeps matching.

### Testing
Create a validateFeatureRevision hook that throws when revision.tags includes a restricted tag. Confirm it blocks a draft save that adds the tag, allows saves that leave tags untouched, and that the Test panel's prefilled revision now exercises the tag branch. New unit suite covers the derivation, the original-args path, and the publish-gate collector.
