### PR TITLE
fix(stats): keep the sign of relative lift when the baseline mean is negative

### DIFF
--- a/packages/front-end/components/Experiment/DateResults.tsx
+++ b/packages/front-end/components/Experiment/DateResults.tsx
@@ -212,7 +212,7 @@ const DateResults: FC<{
               if (differenceType === "absolute") {
                 up = crB - crA;
               } else {
-                up = crA ? (crB - crA) / crA : 0;
+                up = crA ? (crB - crA) / Math.abs(crA) : 0;
               }
             }
 

--- a/packages/front-end/components/Experiment/TabbedPage/CovariateImbalanceTable.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/CovariateImbalanceTable.tsx
@@ -257,7 +257,7 @@ function CovariateImbalanceTableSection({
                     row.baselineMean !== 0 ? (
                       percentageFormatter.format(
                         (row.variationMean - row.baselineMean) /
-                          row.baselineMean,
+                          Math.abs(row.baselineMean),
                       )
                     ) : (
                       "-"

--- a/packages/stats/gbstats/models/tests.py
+++ b/packages/stats/gbstats/models/tests.py
@@ -79,7 +79,10 @@ def frequentist_variance_relative_cuped_ratio(
 ) -> float:
     if stat_a.unadjusted_mean == 0 or stat_a.d_statistic_post.mean == 0:
         return 0  # avoid division by zero
-    g_abs = stat_b.mean - stat_a.mean
+    # The estimate is (mean_b - mean_a) / abs(unadjusted_mean), so its gradient
+    # in the control post-period terms carries the sign of the baseline; folding
+    # it into g_abs keeps the variance correct when the baseline mean is negative.
+    g_abs = (stat_b.mean - stat_a.mean) * np.sign(stat_a.unadjusted_mean)
     g_rel_den = np.abs(stat_a.unadjusted_mean)
     nabla_ctrl_0_num = -(g_rel_den + g_abs) / stat_a.d_statistic_post.mean
     nabla_ctrl_0_den = g_rel_den**2
@@ -1156,7 +1159,7 @@ class PostStratificationSummary:
             if self.mean[0] == 0:
                 return 0
             else:
-                return self.mean[1] / self.mean[0]
+                return self.mean[1] / abs(self.mean[0])
         else:
             return self.mean[1]
 
@@ -1329,11 +1332,12 @@ class PostStratificationSummaryRatio(PostStratificationSummary):
             if self.point_estimate_rel_denominator == 0:
                 return 0
             else:
-                return (
+                relative_estimate = (
                     self.point_estimate_rel_numerator
                     / self.point_estimate_rel_denominator
                     - 1
                 )
+                return relative_estimate * np.sign(self.unadjusted_baseline_mean)
         else:
             mn_trt_num = self.mean[0] + self.mean[1]
             mn_trt_den = self.mean[2] + self.mean[3]

--- a/packages/stats/gbstats/utils.py
+++ b/packages/stats/gbstats/utils.py
@@ -23,12 +23,6 @@ def frequentist_diff(mean_a, mean_b, relative, mean_a_unadjusted=None) -> float:
     if not mean_a_unadjusted:
         mean_a_unadjusted = mean_a
     if relative:
-        # Scale by the magnitude of the baseline so the sign of the relative
-        # difference always matches the sign of the absolute difference. Dividing
-        # by a negative baseline would flip it, so an improvement on a metric
-        # with a negative control mean would show as a loss (and vice versa).
-        # Matches the abs() scaling already used for the relative variance and
-        # prior conversions elsewhere in the engine.
         return (mean_b - mean_a) / abs(mean_a_unadjusted)
     else:
         return mean_b - mean_a

--- a/packages/stats/gbstats/utils.py
+++ b/packages/stats/gbstats/utils.py
@@ -23,7 +23,13 @@ def frequentist_diff(mean_a, mean_b, relative, mean_a_unadjusted=None) -> float:
     if not mean_a_unadjusted:
         mean_a_unadjusted = mean_a
     if relative:
-        return (mean_b - mean_a) / mean_a_unadjusted
+        # Scale by the magnitude of the baseline so the sign of the relative
+        # difference always matches the sign of the absolute difference. Dividing
+        # by a negative baseline would flip it, so an improvement on a metric
+        # with a negative control mean would show as a loss (and vice versa).
+        # Matches the abs() scaling already used for the relative variance and
+        # prior conversions elsewhere in the engine.
+        return (mean_b - mean_a) / abs(mean_a_unadjusted)
     else:
         return mean_b - mean_a
 

--- a/packages/stats/tests/frequentist/test_post_strat.py
+++ b/packages/stats/tests/frequentist/test_post_strat.py
@@ -892,6 +892,51 @@ class TestPostStratification(TestCase):
             (self.revenue_us_firefox_a, self.revenue_us_firefox_b),
         ]
 
+    def test_count_relative_point_estimate_uses_negative_baseline_magnitude(self):
+        def sample_mean(mean: float, n: int = 1000) -> SampleMeanStatistic:
+            return SampleMeanStatistic(n=n, sum=mean * n, sum_squares=(mean**2 + 4) * n)
+
+        for variation_mean, expected_relative_lift in [
+            (-5, 0.5),
+            (-15, -0.5),
+            (5, 1.5),
+        ]:
+            with self.subTest(variation_mean=variation_mean):
+                stats = [
+                    (sample_mean(-10), sample_mean(variation_mean)) for _ in range(2)
+                ]
+                result = EffectMomentsPostStratification(
+                    stats, self.moments_config_rel  # type: ignore
+                ).compute_result()
+
+                self.assertTrue(result.post_stratification_applied)
+                self.assertAlmostEqual(result.point_estimate, expected_relative_lift)
+
+    def test_ratio_relative_point_estimate_uses_negative_baseline_magnitude(self):
+        def ratio(mean: float, n: int = 1000) -> RatioStatistic:
+            return RatioStatistic(
+                n=n,
+                m_statistic=SampleMeanStatistic(
+                    n=n, sum=mean * n, sum_squares=(mean**2 + 4) * n
+                ),
+                d_statistic=SampleMeanStatistic(n=n, sum=n, sum_squares=n),
+                m_d_sum_of_products=mean * n,
+            )
+
+        for variation_mean, expected_relative_lift in [
+            (-5, 0.5),
+            (-15, -0.5),
+            (5, 1.5),
+        ]:
+            with self.subTest(variation_mean=variation_mean):
+                stats = [(ratio(-10), ratio(variation_mean)) for _ in range(2)]
+                result = EffectMomentsPostStratification(
+                    stats, self.moments_config_rel  # type: ignore
+                ).compute_result()
+
+                self.assertTrue(result.post_stratification_applied)
+                self.assertAlmostEqual(result.point_estimate, expected_relative_lift)
+
     def test_zero_negative_variance(self):
         stats_count_strata = [
             (

--- a/packages/stats/tests/test_shared_models.py
+++ b/packages/stats/tests/test_shared_models.py
@@ -3,7 +3,6 @@
 2. Demonstrating equivalence to numpy methods that take raw data"""
 
 from unittest import TestCase, main as unittest_main
-import copy
 import numpy as np
 from dataclasses import asdict
 from typing import Literal
@@ -12,6 +11,7 @@ from gbstats.messages import ZERO_NEGATIVE_VARIANCE_MESSAGE
 from gbstats.models.statistics import (
     ProportionStatistic,
     RatioStatistic,
+    RegressionAdjustedRatioStatistic,
     RegressionAdjustedStatistic,
     SampleMeanStatistic,
     QuantileStatistic,
@@ -372,6 +372,84 @@ class TestEffectMomentsNegativeBaseline(TestCase):
         relative = self._moments(-10, -5, "relative")
         self.assertAlmostEqual(relative.point_estimate, 0.5)
         self.assertGreater(relative.standard_error, 0)
+
+
+class TestEffectMomentsCupedRatioNegativeBaseline(TestCase):
+    """Negating the metric negates the relative lift exactly, so the standard
+    error must be identical for the positive- and negative-baseline versions
+    of the same data. The negation pair alone cannot catch a variance error
+    that is itself sign-symmetric, so the golden standard errors (validated
+    against a finite-difference delta-method computation) pin the magnitude."""
+
+    @staticmethod
+    def _stat(
+        m_post: np.ndarray, d_post: np.ndarray, m_pre: np.ndarray, d_pre: np.ndarray
+    ) -> RegressionAdjustedRatioStatistic:
+        n = len(m_post)
+        return RegressionAdjustedRatioStatistic(
+            n=n,
+            m_statistic_post=SampleMeanStatistic(
+                n=n, sum=float(np.sum(m_post)), sum_squares=float(np.sum(m_post**2))
+            ),
+            d_statistic_post=SampleMeanStatistic(
+                n=n, sum=float(np.sum(d_post)), sum_squares=float(np.sum(d_post**2))
+            ),
+            m_statistic_pre=SampleMeanStatistic(
+                n=n, sum=float(np.sum(m_pre)), sum_squares=float(np.sum(m_pre**2))
+            ),
+            d_statistic_pre=SampleMeanStatistic(
+                n=n, sum=float(np.sum(d_pre)), sum_squares=float(np.sum(d_pre**2))
+            ),
+            m_post_m_pre_sum_of_products=float(np.sum(m_post * m_pre)),
+            d_post_d_pre_sum_of_products=float(np.sum(d_post * d_pre)),
+            m_pre_d_pre_sum_of_products=float(np.sum(m_pre * d_pre)),
+            m_post_d_post_sum_of_products=float(np.sum(m_post * d_post)),
+            m_post_d_pre_sum_of_products=float(np.sum(m_post * d_pre)),
+            m_pre_d_post_sum_of_products=float(np.sum(m_pre * d_post)),
+            theta=0.5,
+        )
+
+    # Treatment numerators roughly 11x and 9x the denominators, versus 10x for
+    # control, so the two datasets give an improving and a declining lift. Both
+    # directions matter: they exercise all four sign combinations of the
+    # baseline mean and the mean difference in the variance gradient.
+    M_POST_B_IMPROVING = np.array([17.0, 12.0, 23.0, 28.0, 12.0, 22.0, 29.0, 16.0])
+    M_POST_B_DECLINING = np.array([14.0, 9.0, 17.0, 23.0, 9.0, 18.0, 22.0, 13.0])
+
+    def _moments(self, sign: int, m_post_b: np.ndarray):
+        d_post_a = np.array([1.0, 2.0, 1.5, 2.5, 2.0, 1.0, 1.5, 2.5])
+        d_pre_a = np.array([1.5, 1.0, 2.0, 2.0, 2.5, 1.0, 1.0, 2.0])
+        m_post_a = sign * np.array([12.0, 19.0, 16.0, 24.0, 21.0, 9.0, 14.0, 26.0])
+        m_pre_a = sign * np.array([16.0, 11.0, 21.0, 19.0, 26.0, 11.0, 9.0, 21.0])
+        d_post_b = np.array([1.5, 1.0, 2.0, 2.5, 1.0, 2.0, 2.5, 1.5])
+        d_pre_b = np.array([1.0, 1.5, 2.0, 2.5, 1.0, 2.5, 2.0, 1.5])
+        m_pre_b = sign * np.array([11.0, 17.0, 22.0, 27.0, 10.0, 27.0, 21.0, 16.0])
+        return EffectMoments(
+            [
+                (
+                    self._stat(m_post_a, d_post_a, m_pre_a, d_pre_a),
+                    self._stat(sign * m_post_b, d_post_b, m_pre_b, d_pre_b),
+                )
+            ],
+            config=EffectMomentsConfig(difference_type="relative"),
+        ).compute_result()
+
+    def test_negating_the_metric_negates_lift_and_keeps_standard_error(self):
+        for label, m_post_b, expected_lift, expected_se in [
+            ("improving", self.M_POST_B_IMPROVING, 0.1039280, 0.0286196),
+            ("declining", self.M_POST_B_DECLINING, -0.1372068, 0.0223934),
+        ]:
+            with self.subTest(treatment=label):
+                positive = self._moments(1, m_post_b)
+                negative = self._moments(-1, m_post_b)
+                self.assertIsNone(positive.error_message)
+                self.assertIsNone(negative.error_message)
+                self.assertAlmostEqual(positive.point_estimate, expected_lift)
+                self.assertAlmostEqual(positive.standard_error, expected_se)
+                self.assertAlmostEqual(
+                    negative.point_estimate, -positive.point_estimate
+                )
+                self.assertAlmostEqual(negative.standard_error, positive.standard_error)
 
 
 if __name__ == "__main__":

--- a/packages/stats/tests/test_shared_models.py
+++ b/packages/stats/tests/test_shared_models.py
@@ -6,6 +6,8 @@ from unittest import TestCase, main as unittest_main
 import copy
 import numpy as np
 from dataclasses import asdict
+from typing import Literal
+
 from gbstats.messages import ZERO_NEGATIVE_VARIANCE_MESSAGE
 from gbstats.models.statistics import (
     ProportionStatistic,
@@ -332,6 +334,44 @@ class TestEffectMomentsResult(TestCase):
         self.assertEqual(
             moments.compute_result().error_message, ZERO_NEGATIVE_VARIANCE_MESSAGE
         )
+
+
+class TestEffectMomentsNegativeBaseline(TestCase):
+    def _moments(
+        self,
+        mean_a: float,
+        mean_b: float,
+        difference_type: Literal["relative", "absolute"],
+    ):
+        n = 1000
+        # Same spread either side so the only thing that differs is the mean.
+        stat_a = SampleMeanStatistic(
+            n=n, sum=mean_a * n, sum_squares=(mean_a**2 + 4) * n
+        )
+        stat_b = SampleMeanStatistic(
+            n=n, sum=mean_b * n, sum_squares=(mean_b**2 + 4) * n
+        )
+        return EffectMoments(
+            [(stat_a, stat_b)],
+            config=EffectMomentsConfig(difference_type=difference_type),
+        ).compute_result()
+
+    def test_relative_sign_matches_absolute_sign(self):
+        for mean_a, mean_b in [(-10, -5), (-10, -15), (-2, 3), (10, 15), (10, 5)]:
+            absolute = self._moments(mean_a, mean_b, "absolute")
+            relative = self._moments(mean_a, mean_b, "relative")
+            self.assertIsNone(absolute.error_message)
+            self.assertIsNone(relative.error_message)
+            self.assertEqual(
+                np.sign(relative.point_estimate),
+                np.sign(absolute.point_estimate),
+                msg=f"sign mismatch for baseline {mean_a} -> {mean_b}",
+            )
+
+    def test_relative_magnitude_scaled_by_baseline_magnitude(self):
+        relative = self._moments(-10, -5, "relative")
+        self.assertAlmostEqual(relative.point_estimate, 0.5)
+        self.assertGreater(relative.standard_error, 0)
 
 
 if __name__ == "__main__":

--- a/packages/stats/tests/test_utils.py
+++ b/packages/stats/tests/test_utils.py
@@ -6,11 +6,39 @@ import numpy as np
 from scipy.stats import norm
 import copy
 
-from gbstats.utils import multinomial_covariance, truncated_normal_mean
+from gbstats.utils import (
+    frequentist_diff,
+    multinomial_covariance,
+    truncated_normal_mean,
+)
 from scipy.stats import truncnorm
 
 DECIMALS = 5
 round_ = partial(np.round, decimals=DECIMALS)
+
+
+class TestFrequentistDiff(TestCase):
+    def test_absolute_is_plain_difference(self):
+        self.assertEqual(frequentist_diff(-10, -5, relative=False), 5)
+        self.assertEqual(frequentist_diff(10, 15, relative=False), 5)
+
+    def test_relative_positive_baseline(self):
+        self.assertAlmostEqual(frequentist_diff(10, 15, relative=True), 0.5)
+        self.assertAlmostEqual(frequentist_diff(10, 5, relative=True), -0.5)
+
+    def test_relative_negative_baseline_keeps_direction(self):
+        # -10 -> -5 is an increase; the relative difference must be positive
+        self.assertAlmostEqual(frequentist_diff(-10, -5, relative=True), 0.5)
+        # -10 -> -15 is a decrease
+        self.assertAlmostEqual(frequentist_diff(-10, -15, relative=True), -0.5)
+        # crossing zero
+        self.assertAlmostEqual(frequentist_diff(-2, 3, relative=True), 2.5)
+
+    def test_relative_uses_unadjusted_baseline_magnitude(self):
+        # CUPED-adjusted means with an unadjusted (negative) baseline
+        self.assertAlmostEqual(
+            frequentist_diff(-9, -4, relative=True, mean_a_unadjusted=-10), 0.5
+        )
 
 
 class TestTruncatedNormalMean(TestCase):


### PR DESCRIPTION
### Features and Changes

`gbstats.utils.frequentist_diff` computes the relative difference as `(mean_b - mean_a) / mean_a`. When the control mean is negative, the division flips the sign of the result:

| control → variation | absolute | relative (before) | relative (after) |
|---|---|---|---|
| −10 → −5 (up) | +5 | −50% | +50% |
| −10 → −15 (down) | −5 | +50% | −50% |
| −2 → +3 (crosses zero) | +5 | −250% | +250% |

The relative point estimate is what `EffectMoments` hands to both the frequentist and Bayesian tests, so it isn't just the displayed number: the CI, p-value / chance to win, and the win/lose colouring all invert. Driving `analyze_metric_df` with a control mean of −10 and a variation mean of −5 gives `expected = −0.5, chanceToWin = 0.000` in relative mode on both engines, while absolute mode correctly reports `+5, 1.000`.

This PR divides by `abs(mean_a_unadjusted)` instead, so the sign of the relative lift always matches the sign of the absolute difference. That's the convention already used elsewhere in the engine — `frequentist_variance_relative_cuped_ratio` scales by `np.abs(stat_a.unadjusted_mean)`, and the Bayesian prior conversion between relative and absolute uses `abs(stat_a.unadjusted_mean)` — so this brings the point estimate in line with them. The relative variance is a squared quantity and was already sign-agnostic. Absolute mode is unchanged.

Behavior change to be aware of: any existing metric with a negative control mean will show its relative lift (and win/lose colouring) with the opposite sign after upgrading — that's the corrected sign, but a re-refresh will look like the result flipped. Absolute-mode results are unaffected.

Not addressed here: whether "relative lift" is a meaningful summary at all when the baseline is near or crosses zero (the −250% row). That's a presentation question rather than a sign bug; absolute mode remains the better view for such metrics.

- Related: #401

### Dependencies

None

### Testing

- `tests/test_utils.py`: `frequentist_diff` unit tests — absolute unchanged, positive baseline unchanged, negative baseline keeps direction (incl. crossing zero), and the CUPED `mean_a_unadjusted` path.
- `tests/test_shared_models.py`: `EffectMoments` end-to-end with `SampleMeanStatistic`s — for each of five baseline/variation pairs, the sign of the relative point estimate equals the sign of the absolute one; magnitude check for −10 → −5.
- The four new tests fail on `main` and pass here; the full gbstats suite passes (110). black / flake8 / pyright clean.

### Screenshots

N/A