### PR TITLE
Add org setting to disable personal access tokens

### DIFF
--- a/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
+++ b/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
@@ -17,6 +17,7 @@ import {
 import { getCustomLogProps } from "back-end/src/util/logger";
 import {
   isApiKeyForUserInOrganization,
+  isUserAccessToken,
   dangerousLookupOrganizationByApiKey,
 } from "back-end/src/util/api-key.util";
 import {
@@ -266,6 +267,17 @@ function authenticateWithApiKey(
         }
       }
       req.organization = org;
+
+      // Turning the org setting on revokes every existing PAT (and OAuth
+      // access token) immediately, without touching the stored docs.
+      if (
+        org.settings?.disablePersonalAccessTokens &&
+        isUserAccessToken(apiKeyDoc)
+      ) {
+        throw new Error(
+          "Personal access tokens are disabled for this organization",
+        );
+      }
 
       if (org.suspended && !req.user?.superAdmin) {
         return res.status(403).json({

--- a/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
+++ b/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
@@ -17,7 +17,6 @@ import {
 import { getCustomLogProps } from "back-end/src/util/logger";
 import {
   isApiKeyForUserInOrganization,
-  isUserAccessToken,
   dangerousLookupOrganizationByApiKey,
 } from "back-end/src/util/api-key.util";
 import {
@@ -268,12 +267,9 @@ function authenticateWithApiKey(
       }
       req.organization = org;
 
-      // Turning the org setting on revokes every existing PAT (and OAuth
-      // access token) immediately, without touching the stored docs.
-      if (
-        org.settings?.disablePersonalAccessTokens &&
-        isUserAccessToken(apiKeyDoc)
-      ) {
+      // Turning the org setting on revokes every user-attributed token
+      // immediately, without touching the stored docs.
+      if (userId && org.settings?.disablePersonalAccessTokens) {
         throw new Error(
           "Personal access tokens are disabled for this organization",
         );

--- a/packages/back-end/src/models/ApiKeyModel.ts
+++ b/packages/back-end/src/models/ApiKeyModel.ts
@@ -4,7 +4,6 @@ import { getRoleById } from "shared/permissions";
 import {
   generateEncryptionKey,
   generateSigningKey,
-  isUserAccessToken,
   migrateApiKey,
 } from "back-end/src/util/api-key.util";
 import { getEnvironmentIdsFromOrg } from "back-end/src/services/organizations";
@@ -116,8 +115,7 @@ export class ApiKeyModel extends BaseClass {
       // and users must still be able to disable or delete the ones they have.
       if (
         !previousDoc &&
-        this.context.org.settings?.disablePersonalAccessTokens &&
-        isUserAccessToken(doc)
+        this.context.org.settings?.disablePersonalAccessTokens
       ) {
         this.context.throwBadRequestError(
           "Personal access tokens are disabled for this organization.",

--- a/packages/back-end/src/models/ApiKeyModel.ts
+++ b/packages/back-end/src/models/ApiKeyModel.ts
@@ -4,6 +4,7 @@ import { getRoleById } from "shared/permissions";
 import {
   generateEncryptionKey,
   generateSigningKey,
+  isUserAccessToken,
   migrateApiKey,
 } from "back-end/src/util/api-key.util";
 import { getEnvironmentIdsFromOrg } from "back-end/src/services/organizations";
@@ -111,6 +112,17 @@ export class ApiKeyModel extends BaseClass {
     previousDoc?: ApiKeyInterface,
   ) {
     if (doc.userId) {
+      // Creation only — existing tokens are already rejected at authentication,
+      // and users must still be able to disable or delete the ones they have.
+      if (
+        !previousDoc &&
+        this.context.org.settings?.disablePersonalAccessTokens &&
+        isUserAccessToken(doc)
+      ) {
+        this.context.throwBadRequestError(
+          "Personal access tokens are disabled for this organization.",
+        );
+      }
       // PATs inherit permissions from their user — scoping fields must not be set
       if (doc.limitAccessByEnvironment) {
         this.context.throwBadRequestError(

--- a/packages/back-end/src/util/api-key.util.ts
+++ b/packages/back-end/src/util/api-key.util.ts
@@ -35,6 +35,21 @@ export const isApiKeyForUserInOrganization = (
   return !!organization.members.find((m) => m.id === userId);
 };
 
+// Keys GrowthBook issues to itself on the user's behalf, rather than tokens a
+// person deliberately minted. Their role survives `migrateApiKey` so they can
+// be told apart from PATs after a read.
+export const APP_ISSUED_KEY_ROLES = ["visualEditor"];
+
+/**
+ * A token that acts as a specific user and was minted on purpose — a Personal
+ * Access Token or an OAuth-issued access token. Excludes app-issued keys (the
+ * Visual Editor), which users don't create and can't manage.
+ */
+export const isUserAccessToken = (
+  apiKey: Pick<ApiKeyInterface, "userId" | "role">,
+): boolean =>
+  !!apiKey.userId && !APP_ISSUED_KEY_ROLES.includes(apiKey.role || "");
+
 export const roleForApiKey = (
   apiKey: Pick<ApiKeyInterface, "role" | "userId" | "secret">,
 ): string | null => {
@@ -75,7 +90,12 @@ export function migrateApiKey(legacyDoc: unknown) {
   const obj = legacyDoc as ApiKeyInterface;
   return {
     ...obj,
-    role: roleForApiKey(obj) || undefined,
+    // `roleForApiKey` nulls the role on user-attributed keys because their
+    // permissions come from the member, not the key. App-issued roles keep
+    // theirs so callers can still identify the key's origin.
+    role: APP_ISSUED_KEY_ROLES.includes(obj.role || "")
+      ? obj.role
+      : roleForApiKey(obj) || undefined,
     dateUpdated: obj.dateUpdated ?? obj.dateCreated,
     limitAccessByEnvironment: obj.limitAccessByEnvironment ?? false,
     environments: obj.environments ?? [],

--- a/packages/back-end/src/util/api-key.util.ts
+++ b/packages/back-end/src/util/api-key.util.ts
@@ -35,21 +35,6 @@ export const isApiKeyForUserInOrganization = (
   return !!organization.members.find((m) => m.id === userId);
 };
 
-// Keys GrowthBook issues to itself on the user's behalf, rather than tokens a
-// person deliberately minted. Their role survives `migrateApiKey` so they can
-// be told apart from PATs after a read.
-export const APP_ISSUED_KEY_ROLES = ["visualEditor"];
-
-/**
- * A token that acts as a specific user and was minted on purpose — a Personal
- * Access Token or an OAuth-issued access token. Excludes app-issued keys (the
- * Visual Editor), which users don't create and can't manage.
- */
-export const isUserAccessToken = (
-  apiKey: Pick<ApiKeyInterface, "userId" | "role">,
-): boolean =>
-  !!apiKey.userId && !APP_ISSUED_KEY_ROLES.includes(apiKey.role || "");
-
 export const roleForApiKey = (
   apiKey: Pick<ApiKeyInterface, "role" | "userId" | "secret">,
 ): string | null => {
@@ -90,12 +75,7 @@ export function migrateApiKey(legacyDoc: unknown) {
   const obj = legacyDoc as ApiKeyInterface;
   return {
     ...obj,
-    // `roleForApiKey` nulls the role on user-attributed keys because their
-    // permissions come from the member, not the key. App-issued roles keep
-    // theirs so callers can still identify the key's origin.
-    role: APP_ISSUED_KEY_ROLES.includes(obj.role || "")
-      ? obj.role
-      : roleForApiKey(obj) || undefined,
+    role: roleForApiKey(obj) || undefined,
     dateUpdated: obj.dateUpdated ?? obj.dateCreated,
     limitAccessByEnvironment: obj.limitAccessByEnvironment ?? false,
     environments: obj.environments ?? [],

--- a/packages/back-end/test/util/api-key.util.test.ts
+++ b/packages/back-end/test/util/api-key.util.test.ts
@@ -2,7 +2,6 @@ import { ApiKeyInterface } from "shared/types/apikey";
 import { OrganizationInterface } from "shared/types/organization";
 import {
   isApiKeyForUserInOrganization,
-  isUserAccessToken,
   migrateApiKey,
   roleForApiKey,
 } from "back-end/src/util/api-key.util";
@@ -135,53 +134,18 @@ describe("api key utils", () => {
     });
   });
 
-  describe("isUserAccessToken", () => {
-    it("should return true for a personal access token", () => {
-      expect(isUserAccessToken({ userId: "user-abc123", role: "user" })).toBe(
-        true,
-      );
-    });
-
-    it("should return true for a PAT whose role was stripped on read", () => {
-      expect(
-        isUserAccessToken({ userId: "user-abc123", role: undefined }),
-      ).toBe(true);
-    });
-
-    it("should return false for an app-issued Visual Editor key", () => {
-      expect(
-        isUserAccessToken({ userId: "user-abc123", role: "visualEditor" }),
-      ).toBe(false);
-    });
-
-    it("should return false for an org API key", () => {
-      expect(isUserAccessToken({ userId: undefined, role: "admin" })).toBe(
-        false,
-      );
-    });
-  });
-
   describe("migrateApiKey", () => {
-    it("should strip the role from a personal access token", () => {
-      const migrated = migrateApiKey({
-        userId: "user-abc123",
-        role: "user",
-        secret: true,
-        dateCreated: new Date(),
-      });
+    it("should strip the role from every user-attributed key", () => {
+      for (const role of ["user", "visualEditor"]) {
+        const migrated = migrateApiKey({
+          userId: "user-abc123",
+          role,
+          secret: true,
+          dateCreated: new Date(),
+        });
 
-      expect(migrated.role).toBeUndefined();
-    });
-
-    it("should keep the role on an app-issued Visual Editor key", () => {
-      const migrated = migrateApiKey({
-        userId: "user-abc123",
-        role: "visualEditor",
-        secret: true,
-        dateCreated: new Date(),
-      });
-
-      expect(migrated.role).toEqual("visualEditor");
+        expect(migrated.role).toBeUndefined();
+      }
     });
 
     it("should still default a roleless org secret key to admin", () => {

--- a/packages/back-end/test/util/api-key.util.test.ts
+++ b/packages/back-end/test/util/api-key.util.test.ts
@@ -2,6 +2,8 @@ import { ApiKeyInterface } from "shared/types/apikey";
 import { OrganizationInterface } from "shared/types/organization";
 import {
   isApiKeyForUserInOrganization,
+  isUserAccessToken,
+  migrateApiKey,
   roleForApiKey,
 } from "back-end/src/util/api-key.util";
 
@@ -130,6 +132,66 @@ describe("api key utils", () => {
       };
 
       expect(roleForApiKey(input)).toEqual("readonly");
+    });
+  });
+
+  describe("isUserAccessToken", () => {
+    it("should return true for a personal access token", () => {
+      expect(isUserAccessToken({ userId: "user-abc123", role: "user" })).toBe(
+        true,
+      );
+    });
+
+    it("should return true for a PAT whose role was stripped on read", () => {
+      expect(
+        isUserAccessToken({ userId: "user-abc123", role: undefined }),
+      ).toBe(true);
+    });
+
+    it("should return false for an app-issued Visual Editor key", () => {
+      expect(
+        isUserAccessToken({ userId: "user-abc123", role: "visualEditor" }),
+      ).toBe(false);
+    });
+
+    it("should return false for an org API key", () => {
+      expect(isUserAccessToken({ userId: undefined, role: "admin" })).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("migrateApiKey", () => {
+    it("should strip the role from a personal access token", () => {
+      const migrated = migrateApiKey({
+        userId: "user-abc123",
+        role: "user",
+        secret: true,
+        dateCreated: new Date(),
+      });
+
+      expect(migrated.role).toBeUndefined();
+    });
+
+    it("should keep the role on an app-issued Visual Editor key", () => {
+      const migrated = migrateApiKey({
+        userId: "user-abc123",
+        role: "visualEditor",
+        secret: true,
+        dateCreated: new Date(),
+      });
+
+      expect(migrated.role).toEqual("visualEditor");
+    });
+
+    it("should still default a roleless org secret key to admin", () => {
+      const migrated = migrateApiKey({
+        role: undefined,
+        secret: true,
+        dateCreated: new Date(),
+      });
+
+      expect(migrated.role).toEqual("admin");
     });
   });
 });

--- a/packages/front-end/components/PersonalAccessTokens/PersonalAccessTokens.tsx
+++ b/packages/front-end/components/PersonalAccessTokens/PersonalAccessTokens.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "@/services/auth";
 import { groupApiKeysByType } from "@/services/secret-api-keys.utils";
 import useApi from "@/hooks/useApi";
 import Callout from "@/ui/Callout";
+import { useUser } from "@/services/UserContext";
 
 type PersonalAccessTokensProps = {
   accessTokens: ApiKeyInterface[];
@@ -28,6 +29,8 @@ export const PersonalAccessTokens: FC<PersonalAccessTokensProps> = ({
   onCreate,
 }) => {
   const [open, setOpen] = useState(false);
+  const { settings } = useUser();
+  const tokensDisabled = !!settings?.disablePersonalAccessTokens;
 
   return (
     <div>
@@ -56,15 +59,23 @@ export const PersonalAccessTokens: FC<PersonalAccessTokensProps> = ({
             onToggleDisabled={onToggleDisabled}
           />
         )}
-        <button
-          className="btn btn-primary"
-          onClick={(e) => {
-            e.preventDefault();
-            setOpen(true);
-          }}
-        >
-          <FaKey /> Create New Personal Access Token
-        </button>
+        {tokensDisabled ? (
+          <Callout status="warning">
+            Personal access tokens are disabled for your organization. Existing
+            tokens no longer work and new ones can&apos;t be created. Contact an
+            admin if you need API access.
+          </Callout>
+        ) : (
+          <button
+            className="btn btn-primary"
+            onClick={(e) => {
+              e.preventDefault();
+              setOpen(true);
+            }}
+          >
+            <FaKey /> Create New Personal Access Token
+          </button>
+        )}
       </div>
 
       <div className="mb-5">

--- a/packages/front-end/components/Settings/ApiKeys.tsx
+++ b/packages/front-end/components/Settings/ApiKeys.tsx
@@ -2,6 +2,7 @@ import React, { FC } from "react";
 import { ApiKeyInterface } from "shared/types/apikey";
 import Link from "@/ui/Link";
 import Callout from "@/ui/Callout";
+import { useUser } from "@/services/UserContext";
 import useApi from "@/hooks/useApi";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import SecretApiKeys from "./SecretApiKeys";
@@ -9,6 +10,7 @@ import PersonalAccessTokenSettings from "./PersonalAccessTokenSettings";
 
 const ApiKeys: FC = () => {
   const { data, error, mutate } = useApi<{ keys: ApiKeyInterface[] }>("/keys");
+  const { settings } = useUser();
 
   if (error) {
     return <Callout status="error">{error.message}</Callout>;
@@ -23,13 +25,15 @@ const ApiKeys: FC = () => {
 
       <PersonalAccessTokenSettings />
 
-      <Callout status="info" mb="4">
-        You can also create{" "}
-        <Link href="/account/personal-access-tokens">
-          Personal Access Tokens
-        </Link>{" "}
-        for your user account
-      </Callout>
+      {!settings?.disablePersonalAccessTokens && (
+        <Callout status="info" mb="4">
+          You can also create{" "}
+          <Link href="/account/personal-access-tokens">
+            Personal Access Tokens
+          </Link>{" "}
+          for your user account
+        </Callout>
+      )}
     </>
   );
 };

--- a/packages/front-end/components/Settings/ApiKeys.tsx
+++ b/packages/front-end/components/Settings/ApiKeys.tsx
@@ -5,6 +5,7 @@ import Callout from "@/ui/Callout";
 import useApi from "@/hooks/useApi";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import SecretApiKeys from "./SecretApiKeys";
+import PersonalAccessTokenSettings from "./PersonalAccessTokenSettings";
 
 const ApiKeys: FC = () => {
   const { data, error, mutate } = useApi<{ keys: ApiKeyInterface[] }>("/keys");
@@ -19,6 +20,8 @@ const ApiKeys: FC = () => {
   return (
     <>
       <SecretApiKeys keys={data.keys} mutate={mutate} />
+
+      <PersonalAccessTokenSettings />
 
       <Callout status="info" mb="4">
         You can also create{" "}

--- a/packages/front-end/components/Settings/PersonalAccessTokenSettings.tsx
+++ b/packages/front-end/components/Settings/PersonalAccessTokenSettings.tsx
@@ -1,0 +1,81 @@
+import React, { FC, useState } from "react";
+import Heading from "@/ui/Heading";
+import { useAuth } from "@/services/auth";
+import { hasFileConfig } from "@/services/env";
+import { useUser } from "@/services/UserContext";
+import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import Checkbox from "@/ui/Checkbox";
+import ConfirmDialog from "@/ui/ConfirmDialog";
+import Frame from "@/ui/Frame";
+import HelperText from "@/ui/HelperText";
+
+// Org-wide kill switch for user-minted API tokens. Enabling it blocks creation
+// AND rejects existing tokens at authentication, so there is no separate
+// "revoke everything" action to run.
+const PersonalAccessTokenSettings: FC = () => {
+  const { apiCall } = useAuth();
+  const { settings, refreshOrganization } = useUser();
+  const canManageOrgSettings = usePermissionsUtil().canManageOrgSettings();
+  const [confirming, setConfirming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const tokensDisabled = !!settings?.disablePersonalAccessTokens;
+
+  const save = async (disablePersonalAccessTokens: boolean) => {
+    setError(null);
+    try {
+      await apiCall("/organization", {
+        method: "PUT",
+        body: JSON.stringify({ settings: { disablePersonalAccessTokens } }),
+      });
+      await refreshOrganization();
+    } catch (e) {
+      setError(e.message);
+    }
+  };
+
+  return (
+    <Frame mb="4">
+      <Heading as="h3" size="md" mb="3">
+        Personal Access Tokens
+      </Heading>
+      <Checkbox
+        label="Disable personal access tokens"
+        description="Members can't create personal access tokens, and existing tokens stop working immediately. Also blocks OAuth access tokens used by MCP and agent integrations. The Visual Editor is unaffected."
+        value={tokensDisabled}
+        disabled={!canManageOrgSettings || hasFileConfig()}
+        disabledMessage={
+          hasFileConfig()
+            ? "Organization settings are managed by your config.yml file"
+            : "Only admins can change this setting"
+        }
+        setValue={(value) => {
+          if (value) {
+            setConfirming(true);
+          } else {
+            void save(false);
+          }
+        }}
+      />
+      {error && (
+        <HelperText status="error" mt="2">
+          {error}
+        </HelperText>
+      )}
+      {confirming && (
+        <ConfirmDialog
+          title="Disable personal access tokens?"
+          content="Every existing personal access token and OAuth access token in this organization will stop working immediately, and members won't be able to create new ones. Turning this setting back off restores them."
+          yesText="Disable tokens"
+          onConfirm={async () => {
+            await save(true);
+            setConfirming(false);
+          }}
+          onCancel={() => setConfirming(false)}
+        />
+      )}
+    </Frame>
+  );
+};
+
+export default PersonalAccessTokenSettings;

--- a/packages/front-end/components/Settings/PersonalAccessTokenSettings.tsx
+++ b/packages/front-end/components/Settings/PersonalAccessTokenSettings.tsx
@@ -41,7 +41,7 @@ const PersonalAccessTokenSettings: FC = () => {
       </Heading>
       <Checkbox
         label="Disable personal access tokens"
-        description="Members can't create personal access tokens, and existing tokens stop working immediately. This covers every token that acts as a user — also OAuth access tokens used by MCP and agent integrations, and the key the Visual Editor needs, so the Visual Editor stops working too."
+        description="Blocks new personal access tokens and stops existing ones working — including OAuth tokens and the Visual Editor."
         value={tokensDisabled}
         disabled={!canManageOrgSettings || hasFileConfig()}
         disabledMessage={

--- a/packages/front-end/components/Settings/PersonalAccessTokenSettings.tsx
+++ b/packages/front-end/components/Settings/PersonalAccessTokenSettings.tsx
@@ -41,7 +41,7 @@ const PersonalAccessTokenSettings: FC = () => {
       </Heading>
       <Checkbox
         label="Disable personal access tokens"
-        description="Members can't create personal access tokens, and existing tokens stop working immediately. Also blocks OAuth access tokens used by MCP and agent integrations. The Visual Editor is unaffected."
+        description="Members can't create personal access tokens, and existing tokens stop working immediately. This covers every token that acts as a user — also OAuth access tokens used by MCP and agent integrations, and the key the Visual Editor needs, so the Visual Editor stops working too."
         value={tokensDisabled}
         disabled={!canManageOrgSettings || hasFileConfig()}
         disabledMessage={
@@ -65,7 +65,7 @@ const PersonalAccessTokenSettings: FC = () => {
       {confirming && (
         <ConfirmDialog
           title="Disable personal access tokens?"
-          content="Every existing personal access token and OAuth access token in this organization will stop working immediately, and members won't be able to create new ones. Turning this setting back off restores them."
+          content="Every token that acts as a user stops working immediately — personal access tokens, OAuth access tokens, and the Visual Editor. Members won't be able to create new ones. Turning this setting back off restores them."
           yesText="Disable tokens"
           onConfirm={async () => {
             await save(true);

--- a/packages/shared/types/organization.d.ts
+++ b/packages/shared/types/organization.d.ts
@@ -382,6 +382,10 @@ export interface OrganizationSettings {
   postStratificationEnabled?: boolean;
   approvalFlows?: ApprovalFlowConfigurations;
   learningStatuses?: LearningStatus[];
+  // When true, members can't create user-attributed API tokens and existing
+  // ones are rejected at authentication. Covers Personal Access Tokens and
+  // OAuth-issued access tokens; app-issued Visual Editor keys are unaffected.
+  disablePersonalAccessTokens?: boolean;
 }
 
 export type LearningStatusColor =


### PR DESCRIPTION
### Features and Changes

Adds `disablePersonalAccessTokens` to `OrganizationSettings`, an org-wide switch for user-attributed API tokens. Enforced on creation in `ApiKeyModel.customValidation` and on authentication in `authenticateApiRequestMiddleware`, so enabling it also revokes tokens that already exist. No token docs are written, so turning it back off restores access. Creation is gated on `!previousDoc` so users can still disable and delete the tokens they already have.

:warning: This covers **every** token that acts as a user — personal access tokens, OAuth access tokens (MCP and agent integrations), and the key the in-app Visual Editor and Chrome extension depend on. Enabling it stops the Visual Editor working.

An earlier revision exempted Visual Editor keys as "system managed". That was a full bypass, not a carve-out: `verifyApiKeyPermission` branches on `apiKey.userId` first, and `doesUserHavePermission` resolves from `getUserPermissions({ id: userId })`, so the key's role is never consulted. A non-superAdmin member (`experimenter`) used a self-minted Visual Editor key to create a feature flag — that needs `FlagsFullAccess`, and the `visualEditor` role is only `ReadData` + `VisualEditorFullAccess`. Minting is self-service through an authenticated `GET /visual-editor/key`, which returns the raw key.

The admin toggle is on Settings > API Keys, gated on `canManageOrgSettings` and disabled under `hasFileConfig()`. The member-facing page swaps the create button for a callout. Self-hosted orgs wanting this immutable can pin it in `config.yml`, which overrides the stored value.

### Known issues

- A key labelled `visualEditor` carries the member's full permissions rather than the role's. Pre-existing, unchanged by this PR, tracked separately.
- With the setting on, opening the Visual Editor surfaces "Personal access tokens are disabled for this organization" — accurate, but worded for the PAT case.

### Testing

- [x] PAT -> `/api/v1/features` with the setting on -> 401
- [x] Visual Editor key with the setting on -> 401
- [x] Org secret API key with the setting on -> 200, unaffected
- [x] `POST /keys` with `type: "user"` and the setting on -> 400
- [x] `GET /visual-editor/key` with the setting on -> 400, so no replacement can be minted
- [x] Disable and delete an existing token with the setting on -> 200
- [x] Turn the setting off -> both the PAT and the Visual Editor key authenticate again

### Screenshots

<img width="1440" height="900" alt="pat-tokens-enabled" src="https://github.com/user-attachments/assets/3f2be08e-d2ba-4918-b752-bf681f5e4eb5" />

<img width="1440" height="900" alt="pat-tokens-disabled" src="https://github.com/user-attachments/assets/fc281d8e-fc49-4bc0-aea7-b576b8c81fb8" />
