### PR TITLE
Keep product analytics AI streams alive

### DIFF
--- a/packages/back-end/src/enterprise/services/agent-handler.ts
+++ b/packages/back-end/src/enterprise/services/agent-handler.ts
@@ -7,6 +7,7 @@ import { stringifyToolResultForStorage } from "shared/ai-chat";
 import type { AIAgentPendingAction } from "shared/validators";
 import type { ReqContext } from "back-end/types/request";
 import type { AuthRequest } from "back-end/src/types/AuthRequest";
+import type { AIConversationModel } from "back-end/src/models/AIConversationModel";
 import {
   dispatchInternal,
   type DispatchInput,
@@ -154,6 +155,64 @@ type ErrorPart = Extract<AgentStreamPart, { type: "error" }>;
 
 const activeStreamControllers = new Map<string, AbortController>();
 
+const SSE_KEEPALIVE_MS = 15_000;
+// Keep this below the client's 60-second stale-stream threshold.
+const DB_HEARTBEAT_MS = 30_000;
+
+// SSE pings keep the connection open; Mongo updates support reloads and
+// cancellation handled by another server instance.
+function startStreamHeartbeats({
+  conversations,
+  conversationId,
+  emit,
+  onCancelled,
+}: {
+  conversations: AIConversationModel;
+  conversationId: string;
+  emit: AgentEmit;
+  onCancelled: () => void;
+}) {
+  const sseKeepalive = setInterval(
+    () => emit("keepalive", {}),
+    SSE_KEEPALIVE_MS,
+  );
+
+  let bumpInFlight = false;
+  const dbHeartbeat = setInterval(() => {
+    if (bumpInFlight) return;
+    bumpInFlight = true;
+    void conversations
+      .touchStreamedAt(conversationId)
+      .then((doc) => {
+        if (doc && !doc.isStreaming) {
+          stopSseKeepalive();
+          stopDbHeartbeat();
+          onCancelled();
+        }
+      })
+      .catch((err) => {
+        logger.debug(
+          `Keepalive bump failed for conversation ${conversationId}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      })
+      .finally(() => {
+        bumpInFlight = false;
+      });
+  }, DB_HEARTBEAT_MS);
+
+  const stopSseKeepalive = (): void => {
+    clearInterval(sseKeepalive);
+  };
+
+  const stopDbHeartbeat = (): void => {
+    clearInterval(dbHeartbeat);
+  };
+
+  return { stopSseKeepalive, stopDbHeartbeat };
+}
+
 /**
  * Abort the active LLM stream for a conversation. Called from the cancel
  * endpoint — returns true if there was a stream to abort.
@@ -298,16 +357,30 @@ export function createAgentHandler<TParams>(config: AgentConfig<TParams>) {
     activeStreamControllers.set(conversationId, abortController);
     let cancelledExternally = false;
 
+    const markCancelledExternally = (): void => {
+      cancelledExternally = true;
+      abortController.abort();
+    };
+
     const checkCancellation = async (): Promise<boolean> => {
       if (cancelledExternally) return true;
       const doc = await context.models.aiConversations.getById(conversationId);
       if (doc && !doc.isStreaming) {
-        cancelledExternally = true;
-        abortController.abort();
+        markCancelledExternally();
         return true;
       }
       return false;
     };
+
+    const heartbeats = startStreamHeartbeats({
+      conversations: context.models.aiConversations,
+      conversationId,
+      emit,
+      onCancelled: markCancelledExternally,
+    });
+
+    // Continue the DB heartbeat so the result survives a disconnected client.
+    res.on("close", heartbeats.stopSseKeepalive);
 
     try {
       const stream = await streamingChatCompletion({
@@ -360,6 +433,8 @@ export function createAgentHandler<TParams>(config: AgentConfig<TParams>) {
 
       await titlePromise;
     } finally {
+      heartbeats.stopSseKeepalive();
+      heartbeats.stopDbHeartbeat();
       activeStreamControllers.delete(conversationId);
 
       try {

--- a/packages/back-end/src/enterprise/services/product-analytics-agent.ts
+++ b/packages/back-end/src/enterprise/services/product-analytics-agent.ts
@@ -1,3 +1,4 @@
+import { setTimeout as delay } from "timers/promises";
 import { z } from "zod";
 import {
   tryParseToolResultJson,
@@ -8,6 +9,7 @@ import {
   dateRangePredefined,
   ExplorationConfig,
   explorationConfigValidator,
+  ProductAnalyticsExploration,
   ProductAnalyticsResultRow,
 } from "shared/validators";
 import {
@@ -839,8 +841,40 @@ async function normalizeConfigForExplorer(
   };
 }
 
-// Max wait time for the warehouse query to complete.
-const RUN_EXPLORATION_WAIT_MS = 10 * 60 * 1000;
+// Match the frontend's polling cadence and ~10-minute cutoff.
+function explorationPollDelayMs(elapsedMs: number): number {
+  if (elapsedMs < 10_000) return 2_000;
+  if (elapsedMs < 30_000) return 3_000;
+  if (elapsedMs < 60_000) return 5_000;
+  if (elapsedMs < 300_000) return 10_000;
+  if (elapsedMs < 600_000) return 20_000;
+  return 0;
+}
+
+async function pollExplorationUntilFinished(
+  ctx: ReqContext,
+  exploration: ProductAnalyticsExploration,
+  startedAt: number,
+  abortSignal?: AbortSignal,
+): Promise<ProductAnalyticsExploration> {
+  let latest = exploration;
+  while (latest.status === "running") {
+    const pollDelay = explorationPollDelayMs(Date.now() - startedAt);
+    if (pollDelay === 0) break;
+
+    await delay(pollDelay, undefined, {
+      signal: abortSignal,
+      ref: false,
+    });
+
+    const polled = await ctx.models.analyticsExplorations.getById(latest.id);
+    if (!polled) {
+      throw new Error("Product analytics exploration not found");
+    }
+    latest = polled;
+  }
+  return latest;
+}
 
 async function executeRunExploration(
   ctx: ReqContext,
@@ -852,12 +886,23 @@ async function executeRunExploration(
     const { config, warnings, getFactMetricById } =
       await normalizeConfigForExplorer(ctx, rawConfig);
 
-    const exploration = await runProductAnalyticsExploration(
+    const startedAt = Date.now();
+    const initialExploration = await runProductAnalyticsExploration(
       ctx,
       config,
-      { cache: "preferred" },
-      { waitMs: RUN_EXPLORATION_WAIT_MS, abortSignal },
+      {
+        cache: "preferred",
+      },
     );
+    const exploration =
+      initialExploration?.status === "running"
+        ? await pollExplorationUntilFinished(
+            ctx,
+            initialExploration,
+            startedAt,
+            abortSignal,
+          )
+        : initialExploration;
 
     if (exploration?.status === "error") {
       return {

--- a/packages/back-end/src/enterprise/services/product-analytics-agent.ts
+++ b/packages/back-end/src/enterprise/services/product-analytics-agent.ts
@@ -839,22 +839,38 @@ async function normalizeConfigForExplorer(
   };
 }
 
+// Max wait time for the warehouse query to complete.
+const RUN_EXPLORATION_WAIT_MS = 10 * 60 * 1000;
+
 async function executeRunExploration(
   ctx: ReqContext,
   buffer: ConversationBuffer,
   rawConfig: ExplorationConfig,
+  abortSignal?: AbortSignal,
 ): Promise<RunExplorationToolResult> {
   try {
     const { config, warnings, getFactMetricById } =
       await normalizeConfigForExplorer(ctx, rawConfig);
-    const exploration = await runProductAnalyticsExploration(ctx, config, {
-      cache: "preferred",
-    });
+
+    const exploration = await runProductAnalyticsExploration(
+      ctx,
+      config,
+      { cache: "preferred" },
+      { waitMs: RUN_EXPLORATION_WAIT_MS, abortSignal },
+    );
 
     if (exploration?.status === "error") {
       return {
         status: "error",
         message: exploration.error ?? "The query failed with an unknown error",
+      };
+    }
+
+    if (exploration?.status === "running") {
+      return {
+        status: "error",
+        message:
+          "The warehouse query is still running after waiting. Do NOT assume there is no data or that the fact table, filters, or date range are wrong. Tell the user the query is taking longer than expected and they can retry shortly.",
       };
     }
 
@@ -1271,6 +1287,7 @@ const GET_COLUMN_VALUES_DESCRIPTION =
 const RUN_EXPLORATION_DESCRIPTION =
   "Execute a product analytics exploration with the given config. " +
   "Use this when the user asks to build, change, or rerun a chart. " +
+  "Waits for the warehouse query to finish before returning. " +
   "The chart will be automatically displayed to the user after execution. " +
   "Returns config (the normalized config used), resultCsv (CSV of the results for analysis), rowCount, snapshotId, and summary. " +
   "Use config and resultCsv for analysis and follow-up modifications. Ignore the exploration field (internal use). " +
@@ -1338,7 +1355,8 @@ const productAnalyticsAgentConfig: AgentConfig<PAParams> = {
       runExploration: aiTool({
         description: RUN_EXPLORATION_DESCRIPTION,
         inputSchema: runExplorationInputSchema,
-        execute: ({ config }) => executeRunExploration(ctx, buffer, config),
+        execute: ({ config }, { abortSignal }) =>
+          executeRunExploration(ctx, buffer, config, abortSignal),
       }),
 
       getSnapshot: aiTool({

--- a/packages/back-end/src/enterprise/services/product-analytics.ts
+++ b/packages/back-end/src/enterprise/services/product-analytics.ts
@@ -1,4 +1,3 @@
-import { setTimeout as delay } from "timers/promises";
 import {
   ExplorationConfig,
   explorationConfigValidator,
@@ -46,7 +45,7 @@ function withRequestedDisplayConfig(
   };
 }
 
-// Default time to wait synchronously for an exploration's queries before
+// Max time to wait synchronously for an exploration's queries before
 // returning the in-progress model and letting the frontend poll for the
 // result. Bounds request latency for heavy funnel/metric queries over large
 // event tables.
@@ -56,7 +55,6 @@ export async function runProductAnalyticsExploration(
   context: ReqContext | ApiReqContext,
   config: ExplorationConfig,
   options: ExplorationCacheQuery,
-  waitOptions?: { waitMs: number; abortSignal?: AbortSignal },
 ): Promise<ProductAnalyticsExploration | null> {
   config = explorationConfigValidator.parse(config);
 
@@ -232,35 +230,33 @@ export async function runProductAnalyticsExploration(
     true,
   );
 
-  const waitMs = waitOptions?.waitMs ?? PRODUCT_ANALYTICS_SYNC_TIMEOUT_MS;
-  const waitController = new AbortController();
-  const abortWait = (): void => waitController.abort();
-  if (waitOptions?.abortSignal?.aborted) {
-    abortWait();
-  } else {
-    waitOptions?.abortSignal?.addEventListener("abort", abortWait, {
-      once: true,
-    });
-  }
-
+  let syncTimer: ReturnType<typeof setTimeout> | undefined;
   try {
     await queryRunner.startAnalysis({
       factTableMap,
       factMetricMap: metricMap,
     });
-    // The query continues in the background when the wait ends.
+    // If results aren't ready within the sync budget, return the in-progress
+    // exploration (status "running") instead of blocking the request. The
+    // warehouse query is NOT cancelled — the QueryRunner keeps driving it and
+    // persists status updates via its own background timers, so the frontend
+    // shows a loading state and polls getExplorationById for the result.
+    // This bounds request latency (no UI hang) without re-running the query.
+    const timeout = new Promise<void>((resolve) => {
+      syncTimer = setTimeout(resolve, PRODUCT_ANALYTICS_SYNC_TIMEOUT_MS);
+    });
     await Promise.race([
+      // Swallow a late resolve/reject so it can't surface as an unhandled
+      // rejection after the timeout wins; errors are persisted to the model
+      // and surfaced to the client via polling.
       queryRunner.waitForResults().catch(() => {}),
-      delay(waitMs, undefined, {
-        signal: waitController.signal,
-        ref: false,
-      }).catch(() => {}),
+      timeout,
     ]);
   } catch (e) {
     // Ignore errors here, still return the model
   } finally {
-    waitController.abort();
-    waitOptions?.abortSignal?.removeEventListener("abort", abortWait);
+    // Clear the timer so the fast path doesn't leave a dangling timeout.
+    if (syncTimer) clearTimeout(syncTimer);
   }
 
   return queryRunner.model;

--- a/packages/back-end/src/enterprise/services/product-analytics.ts
+++ b/packages/back-end/src/enterprise/services/product-analytics.ts
@@ -1,3 +1,4 @@
+import { setTimeout as delay } from "timers/promises";
 import {
   ExplorationConfig,
   explorationConfigValidator,
@@ -45,7 +46,7 @@ function withRequestedDisplayConfig(
   };
 }
 
-// Max time to wait synchronously for an exploration's queries before
+// Default time to wait synchronously for an exploration's queries before
 // returning the in-progress model and letting the frontend poll for the
 // result. Bounds request latency for heavy funnel/metric queries over large
 // event tables.
@@ -55,6 +56,7 @@ export async function runProductAnalyticsExploration(
   context: ReqContext | ApiReqContext,
   config: ExplorationConfig,
   options: ExplorationCacheQuery,
+  waitOptions?: { waitMs: number; abortSignal?: AbortSignal },
 ): Promise<ProductAnalyticsExploration | null> {
   config = explorationConfigValidator.parse(config);
 
@@ -230,33 +232,35 @@ export async function runProductAnalyticsExploration(
     true,
   );
 
-  let syncTimer: ReturnType<typeof setTimeout> | undefined;
+  const waitMs = waitOptions?.waitMs ?? PRODUCT_ANALYTICS_SYNC_TIMEOUT_MS;
+  const waitController = new AbortController();
+  const abortWait = (): void => waitController.abort();
+  if (waitOptions?.abortSignal?.aborted) {
+    abortWait();
+  } else {
+    waitOptions?.abortSignal?.addEventListener("abort", abortWait, {
+      once: true,
+    });
+  }
+
   try {
     await queryRunner.startAnalysis({
       factTableMap,
       factMetricMap: metricMap,
     });
-    // If results aren't ready within the sync budget, return the in-progress
-    // exploration (status "running") instead of blocking the request. The
-    // warehouse query is NOT cancelled — the QueryRunner keeps driving it and
-    // persists status updates via its own background timers, so the frontend
-    // shows a loading state and polls getExplorationById for the result.
-    // This bounds request latency (no UI hang) without re-running the query.
-    const timeout = new Promise<void>((resolve) => {
-      syncTimer = setTimeout(resolve, PRODUCT_ANALYTICS_SYNC_TIMEOUT_MS);
-    });
+    // The query continues in the background when the wait ends.
     await Promise.race([
-      // Swallow a late resolve/reject so it can't surface as an unhandled
-      // rejection after the timeout wins; errors are persisted to the model
-      // and surfaced to the client via polling.
       queryRunner.waitForResults().catch(() => {}),
-      timeout,
+      delay(waitMs, undefined, {
+        signal: waitController.signal,
+        ref: false,
+      }).catch(() => {}),
     ]);
   } catch (e) {
     // Ignore errors here, still return the model
   } finally {
-    // Clear the timer so the fast path doesn't leave a dangling timeout.
-    if (syncTimer) clearTimeout(syncTimer);
+    waitController.abort();
+    waitOptions?.abortSignal?.removeEventListener("abort", abortWait);
   }
 
   return queryRunner.model;

--- a/packages/back-end/src/models/AIConversationModel.ts
+++ b/packages/back-end/src/models/AIConversationModel.ts
@@ -41,6 +41,21 @@ export class AIConversationModel extends BaseClass {
     return existing.userId === this.context.userId;
   }
 
+  // Avoid loading the embedded messages for this periodic update.
+  public async touchStreamedAt(
+    id: string,
+  ): Promise<{ isStreaming: boolean } | null> {
+    const now = new Date();
+    const { value } = await this._dangerousGetCollection().findOneAndUpdate(
+      { organization: this.context.org.id, id, userId: this.context.userId },
+      { $set: { lastStreamedAt: now, dateUpdated: now } },
+      { returnDocument: "after", projection: { isStreaming: 1 } },
+    );
+    if (!value) return null;
+
+    return { isStreaming: !!value.isStreaming };
+  }
+
   /**
    * Returns all non-empty conversations for the current user, sorted
    * newest-first, without loading the messages array.


### PR DESCRIPTION
## Summary
- Fixes a bug where product analytics agents would see long running queries return after 5 seconds and tell the user there are 0 rows. The agent should instead wait for the query to properly finish and then report back to the user. 
- Keep Product Analytics AI streams active during long warehouse queries with SSE keepalives and persisted conversation heartbeats, including across page reloads and backend instances.
- Poll persisted exploration status using the same backoff as the frontend, stopping on completion, cancellation, or the ten-minute cutoff.

## Test plan
- `pnpm --filter back-end type-check`
- Manually verified the polling path with a slow, uncached warehouse query.