### PR TITLE
Custom hook Test panel: simulate incremental suppression and prefill from a Feature Flag

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -26182,6 +26182,15 @@ paths:
                   propertyNames:
                     type: string
                   additionalProperties: {}
+                originalFunctionArgs:
+                  description: >-
+                    State before the change. When supplied, the hook also runs
+                    against it and Incremental Changes Only suppression is
+                    applied to the result.
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties: {}
                 entityType:
                   type: string
                   enum:
@@ -26215,6 +26224,8 @@ paths:
                   log:
                     description: Captured console output
                     type: string
+                  suppressed:
+                    $ref: '#/components/schemas/suppressed'
                 required:
                   - success
                 additionalProperties: false
@@ -67741,6 +67752,19 @@ components:
         - override
         - requiresPermission
         - resolution
+      additionalProperties: false
+    suppressed:
+      description: >-
+        Outcomes the previous state produced too, which Incremental Changes Only
+        would hide on a real save
+      type: object
+      properties:
+        error:
+          type: string
+        warnings:
+          type: array
+          items:
+            type: string
       additionalProperties: false
     versions:
       type: object

--- a/packages/back-end/src/api/custom-hooks/testCustomHook.ts
+++ b/packages/back-end/src/api/custom-hooks/testCustomHook.ts
@@ -1,6 +1,6 @@
 import { testCustomHookValidator } from "shared/validators";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { runInSandbox } from "back-end/src/enterprise/sandbox/sandbox-pool";
+import { runCustomHookTest } from "back-end/src/enterprise/sandbox/sandbox-eval";
 import { getFeature } from "back-end/src/models/FeatureModel";
 import { assertCustomHooksAvailable } from "./validations";
 
@@ -8,7 +8,13 @@ export const testCustomHook = createApiRequestHandler(testCustomHookValidator)(
   async (req) => {
     assertCustomHooksAvailable(req.context);
 
-    const { functionBody, functionArgs, entityType, entityId } = req.body;
+    const {
+      functionBody,
+      functionArgs,
+      originalFunctionArgs,
+      entityType,
+      entityId,
+    } = req.body;
 
     // Feature-scoped tests are authorized against the target feature instead
     // of the org-level manageCustomHooks permission (mirrors the internal
@@ -25,24 +31,10 @@ export const testCustomHook = createApiRequestHandler(testCustomHookValidator)(
       req.context.permissions.throwPermissionError();
     }
 
-    const result = await runInSandbox(functionBody, functionArgs ?? {});
-
-    if (!result.ok) {
-      return {
-        success: false,
-        error: result.error || "Unknown error",
-        warnings: result.warnings,
-        log: result.log,
-      };
-    }
-
-    return {
-      success: true,
-      returnVal: result.returnVal
-        ? JSON.stringify(result.returnVal, null, 2)
-        : undefined,
-      warnings: result.warnings,
-      log: result.log,
-    };
+    return runCustomHookTest(
+      functionBody,
+      functionArgs ?? {},
+      originalFunctionArgs,
+    );
   },
 );

--- a/packages/back-end/src/enterprise/sandbox/sandbox-eval.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-eval.ts
@@ -27,6 +27,7 @@ import {
   configToResolvable,
   ResolvableValue,
 } from "back-end/src/services/resolvableValues";
+import type { SandboxEvalResult } from "./sandbox-core";
 import { runInSandbox } from "./sandbox-pool";
 
 // Custom hook orchestration; sandboxed JS runs in the child-process pool (sandbox-pool.ts).
@@ -600,6 +601,30 @@ async function _runCustomHooks(
   }
 }
 
+// The incrementalChangesOnly rule: an outcome the previous state already
+// produced isn't this change's fault. Errors must match verbatim, so a message
+// carrying changing state never suppresses. Exported so the hook Test panel
+// applies the same rule instead of approximating it.
+export async function applyIncrementalSuppression(
+  code: string,
+  res: SandboxEvalResult,
+  originalFunctionArgs: Record<string, unknown>,
+): Promise<{ errorSuppressed: boolean; warnings: string[] }> {
+  const originalRes = await runInSandbox(code, originalFunctionArgs);
+  if (!res.ok) {
+    return {
+      errorSuppressed: !originalRes.ok && originalRes.error === res.error,
+      warnings: [],
+    };
+  }
+  return {
+    errorSuppressed: false,
+    warnings: originalRes.ok
+      ? res.warnings.filter((w) => !originalRes.warnings.includes(w))
+      : res.warnings,
+  };
+}
+
 async function _runCustomHook(
   context: Context,
   hook: CustomHookInterface,
@@ -614,14 +639,18 @@ async function _runCustomHook(
     context.models.customHooks.logFailure(hook);
   }
 
+  // Only worth a second sandbox run when there's an outcome to suppress.
+  const checkPrior = !!originalFunctionArgs && !!hook.incrementalChangesOnly;
+
   // A thrown error is a hard block and always wins over any warnings.
   if (!res.ok) {
-    // Incremental: ignore the hook if this same error already existed before the change.
-    if (originalFunctionArgs && hook.incrementalChangesOnly) {
-      const originalRes = await runInSandbox(hook.code, originalFunctionArgs);
-      if (!originalRes.ok && originalRes.error === res.error) {
-        return { warnings: [] };
-      }
+    if (checkPrior) {
+      const { errorSuppressed } = await applyIncrementalSuppression(
+        hook.code,
+        res,
+        originalFunctionArgs!,
+      );
+      if (errorSuppressed) return { warnings: [] };
     }
 
     const error =
@@ -631,12 +660,12 @@ async function _runCustomHook(
 
   let warnings = res.warnings;
 
-  // Incremental: drop warnings that were already present before this change.
-  if (warnings.length && originalFunctionArgs && hook.incrementalChangesOnly) {
-    const originalRes = await runInSandbox(hook.code, originalFunctionArgs);
-    if (originalRes.ok) {
-      warnings = warnings.filter((w) => !originalRes.warnings.includes(w));
-    }
+  if (warnings.length && checkPrior) {
+    ({ warnings } = await applyIncrementalSuppression(
+      hook.code,
+      res,
+      originalFunctionArgs!,
+    ));
   }
 
   return { warnings };

--- a/packages/back-end/src/enterprise/sandbox/sandbox-eval.ts
+++ b/packages/back-end/src/enterprise/sandbox/sandbox-eval.ts
@@ -605,11 +605,16 @@ async function _runCustomHooks(
 // produced isn't this change's fault. Errors must match verbatim, so a message
 // carrying changing state never suppresses. Exported so the hook Test panel
 // applies the same rule instead of approximating it.
+export type IncrementalSuppression = {
+  errorSuppressed: boolean;
+  warnings: string[];
+};
+
 export async function applyIncrementalSuppression(
   code: string,
   res: SandboxEvalResult,
   originalFunctionArgs: Record<string, unknown>,
-): Promise<{ errorSuppressed: boolean; warnings: string[] }> {
+): Promise<IncrementalSuppression> {
   const originalRes = await runInSandbox(code, originalFunctionArgs);
   if (!res.ok) {
     return {
@@ -623,6 +628,75 @@ export async function applyIncrementalSuppression(
       ? res.warnings.filter((w) => !originalRes.warnings.includes(w))
       : res.warnings,
   };
+}
+
+// Warnings are only compared on a successful proposed run. A throw returns
+// warnings: [] (error wins); treating that as a comparison would mark every
+// proposed warning as suppressed.
+export function formatCustomHookTestResult(
+  result: SandboxEvalResult,
+  incremental: IncrementalSuppression | null,
+): {
+  success: boolean;
+  returnVal?: string;
+  error?: string;
+  warnings: string[];
+  log?: string;
+  suppressed?: { error?: string; warnings?: string[] };
+} {
+  const suppressedWarnings =
+    incremental && result.ok
+      ? result.warnings.filter((w) => !incremental.warnings.includes(w))
+      : [];
+  const suppressed =
+    incremental?.errorSuppressed || suppressedWarnings.length
+      ? {
+          ...(incremental?.errorSuppressed ? { error: result.error } : {}),
+          ...(suppressedWarnings.length
+            ? { warnings: suppressedWarnings }
+            : {}),
+        }
+      : undefined;
+
+  if (result.ok || incremental?.errorSuppressed) {
+    return {
+      success: true,
+      returnVal: result.returnVal
+        ? JSON.stringify(result.returnVal, null, 2)
+        : undefined,
+      warnings: incremental ? incremental.warnings : result.warnings,
+      log: result.log,
+      suppressed,
+    };
+  }
+
+  return {
+    success: false,
+    error: result.error || "Unknown error",
+    warnings: result.warnings,
+    log: result.log,
+    suppressed,
+  };
+}
+
+// Dry-run used by both the internal Test panel and the REST /custom-hooks/test
+// handler. Second sandbox run only happens when there is an outcome to hide,
+// matching _runCustomHook.
+export async function runCustomHookTest(
+  functionBody: string,
+  functionArgs: Record<string, unknown>,
+  originalFunctionArgs?: Record<string, unknown>,
+) {
+  const result = await runInSandbox(functionBody, functionArgs);
+  const incremental =
+    originalFunctionArgs && (!result.ok || result.warnings.length)
+      ? await applyIncrementalSuppression(
+          functionBody,
+          result,
+          originalFunctionArgs,
+        )
+      : null;
+  return formatCustomHookTestResult(result, incremental);
 }
 
 async function _runCustomHook(

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -133,7 +133,8 @@ const featureRevisionSchema = new mongoose.Schema({
   revertedFromVersion: Number,
   defaultValue: String,
   rules: {},
-  // Revision envelopes — only present when explicitly changed
+  // Only present when explicitly changed, except `metadata`, which
+  // prepareFeatureRevision always writes as a complete snapshot.
   environmentsEnabled: {},
   prerequisites: [{}],
   archived: Boolean,

--- a/packages/back-end/src/routers/custom-hooks/custom-hooks.controller.ts
+++ b/packages/back-end/src/routers/custom-hooks/custom-hooks.controller.ts
@@ -4,8 +4,7 @@ import { CustomHookEntityType, CustomHookInterface } from "shared/validators";
 import { AuthRequest } from "back-end/src/types/AuthRequest";
 import { getContextFromReq } from "back-end/src/services/organizations";
 import { IS_CLOUD } from "back-end/src/util/secrets";
-import { runInSandbox } from "back-end/src/enterprise/sandbox/sandbox-pool";
-import { applyIncrementalSuppression } from "back-end/src/enterprise/sandbox/sandbox-eval";
+import { runCustomHookTest } from "back-end/src/enterprise/sandbox/sandbox-eval";
 import { getFeature } from "back-end/src/models/FeatureModel";
 import { revertCustomHookToVersion } from "back-end/src/services/customHookHistory";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
@@ -183,49 +182,14 @@ export const testCustomHook = async (
   }
 
   const { functionBody, functionArgs, originalFunctionArgs } = req.body;
-  const result = await runInSandbox(functionBody, functionArgs);
+  const result = await runCustomHookTest(
+    functionBody,
+    functionArgs,
+    originalFunctionArgs,
+  );
 
-  // With a previous state supplied, mirror what a real save would do: run the
-  // hook against it too and report which outcomes suppression would hide.
-  const incremental = originalFunctionArgs
-    ? await applyIncrementalSuppression(
-        functionBody,
-        result,
-        originalFunctionArgs,
-      )
-    : null;
-  const suppressedWarnings = incremental
-    ? result.warnings.filter((w) => !incremental.warnings.includes(w))
-    : [];
-  const suppressed =
-    incremental?.errorSuppressed || suppressedWarnings.length
-      ? {
-          ...(incremental?.errorSuppressed ? { error: result.error } : {}),
-          ...(suppressedWarnings.length
-            ? { warnings: suppressedWarnings }
-            : {}),
-        }
-      : undefined;
-
-  if (result.ok || incremental?.errorSuppressed) {
-    res.status(200).json({
-      status: 200,
-      success: true,
-      returnVal: result.returnVal
-        ? JSON.stringify(result.returnVal, null, 2)
-        : undefined,
-      warnings: incremental ? incremental.warnings : result.warnings,
-      log: result.log,
-      suppressed,
-    });
-  } else {
-    res.status(200).json({
-      status: 200,
-      success: false,
-      error: result.error || "Unknown error",
-      warnings: result.warnings,
-      log: result.log,
-      suppressed,
-    });
-  }
+  res.status(200).json({
+    status: 200,
+    ...result,
+  });
 };

--- a/packages/back-end/src/routers/custom-hooks/custom-hooks.controller.ts
+++ b/packages/back-end/src/routers/custom-hooks/custom-hooks.controller.ts
@@ -5,6 +5,7 @@ import { AuthRequest } from "back-end/src/types/AuthRequest";
 import { getContextFromReq } from "back-end/src/services/organizations";
 import { IS_CLOUD } from "back-end/src/util/secrets";
 import { runInSandbox } from "back-end/src/enterprise/sandbox/sandbox-pool";
+import { applyIncrementalSuppression } from "back-end/src/enterprise/sandbox/sandbox-eval";
 import { getFeature } from "back-end/src/models/FeatureModel";
 import { revertCustomHookToVersion } from "back-end/src/services/customHookHistory";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
@@ -138,6 +139,7 @@ export const testCustomHook = async (
     {
       functionBody: string;
       functionArgs: Record<string, unknown>;
+      originalFunctionArgs?: Record<string, unknown>;
       entityType?: CustomHookEntityType;
       entityId?: string;
     },
@@ -150,6 +152,7 @@ export const testCustomHook = async (
     error?: string;
     warnings?: string[];
     log?: string;
+    suppressed?: { error?: string; warnings?: string[] };
   }>,
 ) => {
   const context = getContextFromReq(req);
@@ -179,20 +182,41 @@ export const testCustomHook = async (
     context.permissions.throwPermissionError();
   }
 
-  const result = await runInSandbox(
-    req.body.functionBody,
-    req.body.functionArgs,
-  );
+  const { functionBody, functionArgs, originalFunctionArgs } = req.body;
+  const result = await runInSandbox(functionBody, functionArgs);
 
-  if (result.ok) {
+  // With a previous state supplied, mirror what a real save would do: run the
+  // hook against it too and report which outcomes suppression would hide.
+  const incremental = originalFunctionArgs
+    ? await applyIncrementalSuppression(
+        functionBody,
+        result,
+        originalFunctionArgs,
+      )
+    : null;
+  const suppressedWarnings = incremental
+    ? result.warnings.filter((w) => !incremental.warnings.includes(w))
+    : [];
+  const suppressed =
+    incremental?.errorSuppressed || suppressedWarnings.length
+      ? {
+          ...(incremental?.errorSuppressed ? { error: result.error } : {}),
+          ...(suppressedWarnings.length
+            ? { warnings: suppressedWarnings }
+            : {}),
+        }
+      : undefined;
+
+  if (result.ok || incremental?.errorSuppressed) {
     res.status(200).json({
       status: 200,
       success: true,
       returnVal: result.returnVal
         ? JSON.stringify(result.returnVal, null, 2)
         : undefined,
-      warnings: result.warnings,
+      warnings: incremental ? incremental.warnings : result.warnings,
       log: result.log,
+      suppressed,
     });
   } else {
     res.status(200).json({
@@ -201,6 +225,7 @@ export const testCustomHook = async (
       error: result.error || "Unknown error",
       warnings: result.warnings,
       log: result.log,
+      suppressed,
     });
   }
 };

--- a/packages/back-end/test/enterprise/incrementalSuppression.test.ts
+++ b/packages/back-end/test/enterprise/incrementalSuppression.test.ts
@@ -1,0 +1,163 @@
+import { runInSandbox } from "back-end/src/enterprise/sandbox/sandbox-pool";
+import {
+  applyIncrementalSuppression,
+  formatCustomHookTestResult,
+  runCustomHookTest,
+} from "back-end/src/enterprise/sandbox/sandbox-eval";
+import type { SandboxEvalResult } from "back-end/src/enterprise/sandbox/sandbox-core";
+
+jest.mock("back-end/src/enterprise/sandbox/sandbox-pool", () => ({
+  runInSandbox: jest.fn(),
+}));
+
+const mockRunInSandbox = runInSandbox as jest.MockedFunction<
+  typeof runInSandbox
+>;
+
+function ok(warnings: string[] = [], extras: Partial<SandboxEvalResult> = {}) {
+  return { ok: true, warnings, log: "", ...extras };
+}
+
+function fail(
+  error: string,
+  warnings: string[] = [],
+  extras: Partial<SandboxEvalResult> = {},
+) {
+  return { ok: false, error, warnings, log: "", ...extras };
+}
+
+describe("formatCustomHookTestResult", () => {
+  it("does not classify proposed warnings as suppressed when the hook threw", () => {
+    const result = formatCustomHookTestResult(
+      fail("blocked", ["pre-existing"]),
+      {
+        errorSuppressed: false,
+        warnings: [],
+      },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.warnings).toEqual(["pre-existing"]);
+    expect(result.suppressed).toBeUndefined();
+  });
+
+  it("reports a suppressed error without also listing its discarded warnings", () => {
+    const result = formatCustomHookTestResult(
+      fail("blocked", ["pre-existing"]),
+      {
+        errorSuppressed: true,
+        warnings: [],
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toEqual([]);
+    expect(result.suppressed).toEqual({ error: "blocked" });
+  });
+
+  it("reports warnings that Incremental Changes Only would hide on a successful run", () => {
+    const result = formatCustomHookTestResult(ok(["old", "new"]), {
+      errorSuppressed: false,
+      warnings: ["new"],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toEqual(["new"]);
+    expect(result.suppressed).toEqual({ warnings: ["old"] });
+  });
+
+  it("leaves a clean successful run unchanged when there is no prior state", () => {
+    const result = formatCustomHookTestResult(ok(), null);
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toEqual([]);
+    expect(result.suppressed).toBeUndefined();
+  });
+});
+
+describe("applyIncrementalSuppression", () => {
+  beforeEach(() => {
+    mockRunInSandbox.mockReset();
+  });
+
+  it("suppresses an error only when the prior state produced the same message", async () => {
+    mockRunInSandbox.mockResolvedValueOnce(fail("blocked"));
+
+    await expect(
+      applyIncrementalSuppression("code", fail("blocked"), { feature: {} }),
+    ).resolves.toEqual({ errorSuppressed: true, warnings: [] });
+  });
+
+  it("does not suppress an error that the prior state did not produce", async () => {
+    mockRunInSandbox.mockResolvedValueOnce(fail("different"));
+
+    await expect(
+      applyIncrementalSuppression("code", fail("blocked"), { feature: {} }),
+    ).resolves.toEqual({ errorSuppressed: false, warnings: [] });
+  });
+
+  it("returns no compared warnings on the error path", async () => {
+    mockRunInSandbox.mockResolvedValueOnce(fail("blocked", ["old"]));
+
+    await expect(
+      applyIncrementalSuppression("code", fail("blocked", ["old"]), {
+        feature: {},
+      }),
+    ).resolves.toEqual({ errorSuppressed: true, warnings: [] });
+  });
+
+  it("drops warnings the prior state already produced", async () => {
+    mockRunInSandbox.mockResolvedValueOnce(ok(["old"]));
+
+    await expect(
+      applyIncrementalSuppression("code", ok(["old", "new"]), { feature: {} }),
+    ).resolves.toEqual({ errorSuppressed: false, warnings: ["new"] });
+  });
+});
+
+describe("runCustomHookTest", () => {
+  beforeEach(() => {
+    mockRunInSandbox.mockReset();
+  });
+
+  it("does not rerun the sandbox for a clean successful test", async () => {
+    mockRunInSandbox.mockResolvedValueOnce(ok());
+
+    const result = await runCustomHookTest(
+      "code",
+      { feature: { id: "a" } },
+      { feature: { id: "b" } },
+    );
+
+    expect(mockRunInSandbox).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+    expect(result.suppressed).toBeUndefined();
+  });
+
+  it("reruns against the prior state when the proposed run has an error", async () => {
+    mockRunInSandbox
+      .mockResolvedValueOnce(fail("blocked"))
+      .mockResolvedValueOnce(fail("blocked"));
+
+    const result = await runCustomHookTest(
+      "code",
+      { feature: { id: "a" } },
+      { feature: { id: "b" } },
+    );
+
+    expect(mockRunInSandbox).toHaveBeenCalledTimes(2);
+    expect(result.success).toBe(true);
+    expect(result.suppressed).toEqual({ error: "blocked" });
+  });
+
+  it("leaves the response unchanged when no prior state is supplied", async () => {
+    mockRunInSandbox.mockResolvedValueOnce(fail("blocked"));
+
+    const result = await runCustomHookTest("code", { feature: { id: "a" } });
+
+    expect(mockRunInSandbox).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("blocked");
+    expect(result.suppressed).toBeUndefined();
+  });
+});

--- a/packages/front-end/components/CustomHooks/CustomHookModal.tsx
+++ b/packages/front-end/components/CustomHooks/CustomHookModal.tsx
@@ -545,6 +545,7 @@ export default function CustomHookModal({
               form.setValue("hook", value as CustomHookType);
               setTestValues(initialTestValues(value as CustomHookType));
               setPriorTestValues(initialTestValues(value as CustomHookType));
+              setPrefillFeatureId("");
             }}
           />
           {!scope && (

--- a/packages/front-end/components/CustomHooks/CustomHookModal.tsx
+++ b/packages/front-end/components/CustomHooks/CustomHookModal.tsx
@@ -6,7 +6,7 @@ import {
   hookEntityType,
 } from "shared/validators";
 import { CreateProps } from "shared/types/base-model";
-import { Flex, Kbd, Separator } from "@radix-ui/themes";
+import { Box, Flex, Kbd, Separator } from "@radix-ui/themes";
 import stringify from "json-stringify-pretty-compact";
 import { FeatureInterface } from "shared/types/feature";
 import { FeatureRevisionInterface } from "shared/types/feature-revision";
@@ -16,7 +16,6 @@ import {
 } from "shared/types/experiment";
 import { useAuth } from "@/services/auth";
 import { useFeaturesList } from "@/services/features";
-import { Select, SelectItem } from "@/ui/Select";
 import Modal from "@/components/Modal";
 import Field from "@/components/Forms/Field";
 import SelectField from "@/components/Forms/SelectField";
@@ -423,11 +422,14 @@ export default function CustomHookModal({
   const showFeaturePicker =
     !feature && "feature" in (hookTypeData?.availableArguments ?? {});
 
+  // An empty id is the "use the sample values" option, which puts the generic
+  // fixture back so the picker isn't a one-way door.
   const prefillFromFeature = (id: string) => {
     setPrefillFeatureId(id);
     const picked = featuresList.find((f) => f.id === id);
-    if (!picked) return;
-    const json = stringify(picked);
+    const json = picked
+      ? stringify(picked)
+      : hookTypeData.availableArguments.feature.testValue;
     setTestValues((v) => ({ ...v, feature: json }));
     setPriorTestValues((v) => ({ ...v, feature: json }));
   };
@@ -623,19 +625,13 @@ export default function CustomHookModal({
         <div style={{ width: "50%" }}>
           <h3>Test Your Hook</h3>
           {showFeaturePicker && (
-            <Select
+            <SelectField
               label="Prefill from a Feature Flag"
-              placeholder="Use the sample values"
+              initialOption="Use the sample values"
               value={prefillFeatureId}
-              setValue={prefillFromFeature}
-              mb="3"
-            >
-              {featuresList.map((f) => (
-                <SelectItem key={f.id} value={f.id}>
-                  {f.id}
-                </SelectItem>
-              ))}
-            </Select>
+              onChange={prefillFromFeature}
+              options={featuresList.map((f) => ({ label: f.id, value: f.id }))}
+            />
           )}
           {Object.keys(hookTypeData?.availableArguments).map((arg) => (
             <CodeTextArea
@@ -716,7 +712,7 @@ export default function CustomHookModal({
             </div>
           )}
           {testResult.suppressed && (
-            <div className="mt-3">
+            <Box mt="3">
               <strong>Suppressed by Incremental Changes Only:</strong>
               {[
                 ...(testResult.suppressed.error
@@ -728,7 +724,7 @@ export default function CustomHookModal({
                   {m}
                 </Callout>
               ))}
-            </div>
+            </Box>
           )}
           {testResult.returnVal && (
             <div className="mt-3">

--- a/packages/front-end/components/CustomHooks/CustomHookModal.tsx
+++ b/packages/front-end/components/CustomHooks/CustomHookModal.tsx
@@ -22,7 +22,7 @@ import SelectField from "@/components/Forms/SelectField";
 import useProjectOptions from "@/hooks/useProjectOptions";
 import MultiSelectField from "@/ui/MultiSelectField";
 import CodeTextArea from "@/components/Forms/CodeTextArea";
-import Checkbox from "@/ui/Checkbox";
+import Switch from "@/ui/Switch";
 import Button from "@/ui/Button";
 import Callout from "@/ui/Callout";
 import Text from "@/ui/Text";
@@ -615,10 +615,10 @@ export default function CustomHookModal({
             .
           </Text>
 
-          <Checkbox
+          <Switch
             label="Incremental Changes Only"
             value={form.watch("incrementalChangesOnly") ?? true}
-            setValue={(value) => form.setValue("incrementalChangesOnly", value)}
+            onChange={(value) => form.setValue("incrementalChangesOnly", value)}
             description="Ignore this hook if the same error was already present before attempting to save."
           />
         </div>
@@ -660,11 +660,14 @@ export default function CustomHookModal({
                 change; anything this hook reports for both states is suppressed
                 on a real save.
               </Text>
+              <Text as="div" weight="medium" mb="2">
+                Before the change
+              </Text>
               {Object.keys(hookTypeData?.availableArguments).map((arg) => (
                 <CodeTextArea
                   language="json"
                   key={`prior-${arg}`}
-                  label={`${arg} (before the change)`}
+                  label={arg}
                   required
                   value={priorTestValues[arg] || ""}
                   setValue={(value) =>

--- a/packages/front-end/components/CustomHooks/CustomHookModal.tsx
+++ b/packages/front-end/components/CustomHooks/CustomHookModal.tsx
@@ -15,6 +15,8 @@ import {
   ExperimentInterfaceStringDates,
 } from "shared/types/experiment";
 import { useAuth } from "@/services/auth";
+import { useFeaturesList } from "@/services/features";
+import { Select, SelectItem } from "@/ui/Select";
 import Modal from "@/components/Modal";
 import Field from "@/components/Forms/Field";
 import SelectField from "@/components/Forms/SelectField";
@@ -363,6 +365,7 @@ export default function CustomHookModal({
   const projectOptions = useProjectOptions(() => true, current?.projects || []);
 
   const hookType = form.watch("hook");
+  const incrementalChangesOnly = form.watch("incrementalChangesOnly") ?? true;
   const hookTypeData = hookTypes[hookType];
   const exampleDocSection = EXAMPLE_DOC_SECTIONS[hookType];
 
@@ -399,13 +402,46 @@ export default function CustomHookModal({
   const [testValues, setTestValues] = useState<Record<string, string>>(
     initialTestValues(defaultHook),
   );
+  // The "before" side of an Incremental Changes Only run. Seeded identically to
+  // the proposed state so an author starts from a no-op and edits one side.
+  const [priorTestValues, setPriorTestValues] = useState<
+    Record<string, string>
+  >(initialTestValues(defaultHook));
   const [testResult, setTestResult] = useState<{
     status: "" | "success" | "error";
     returnVal?: string;
     error?: string;
     warnings?: string[];
     log?: string;
+    suppressed?: { error?: string; warnings?: string[] };
   }>({ status: "" });
+
+  // A hook created from Settings has no entity in context, so its fixtures are
+  // generic samples. Let the author swap in a real one.
+  const { features: featuresList } = useFeaturesList();
+  const [prefillFeatureId, setPrefillFeatureId] = useState("");
+  const showFeaturePicker =
+    !feature && "feature" in (hookTypeData?.availableArguments ?? {});
+
+  const prefillFromFeature = (id: string) => {
+    setPrefillFeatureId(id);
+    const picked = featuresList.find((f) => f.id === id);
+    if (!picked) return;
+    const json = stringify(picked);
+    setTestValues((v) => ({ ...v, feature: json }));
+    setPriorTestValues((v) => ({ ...v, feature: json }));
+  };
+
+  const parseArgs = (values: Record<string, string>) =>
+    Object.fromEntries(
+      Object.entries(values).map(([k, v]) => {
+        try {
+          return [k, JSON.parse(v)];
+        } catch (e) {
+          return [k, v];
+        }
+      }),
+    );
 
   const runTest = async () => {
     try {
@@ -415,19 +451,15 @@ export default function CustomHookModal({
         error?: string;
         warnings?: string[];
         log?: string;
+        suppressed?: { error?: string; warnings?: string[] };
       }>("/custom-hooks/test", {
         method: "POST",
         body: JSON.stringify({
           functionBody: form.getValues("code"),
-          functionArgs: Object.fromEntries(
-            Object.entries(testValues).map(([k, v]) => {
-              try {
-                return [k, JSON.parse(v)];
-              } catch (e) {
-                return [k, v];
-              }
-            }),
-          ),
+          functionArgs: parseArgs(testValues),
+          ...(incrementalChangesOnly
+            ? { originalFunctionArgs: parseArgs(priorTestValues) }
+            : {}),
           ...(feature
             ? { entityType: "feature" as const, entityId: feature.id }
             : experiment
@@ -443,6 +475,7 @@ export default function CustomHookModal({
         error: res.error,
         warnings: res.warnings,
         log: res.log,
+        suppressed: res.suppressed,
       });
     } catch (e) {
       setTestResult({ status: "error", error: e.message });
@@ -511,6 +544,7 @@ export default function CustomHookModal({
             onChange={(value) => {
               form.setValue("hook", value as CustomHookType);
               setTestValues(initialTestValues(value as CustomHookType));
+              setPriorTestValues(initialTestValues(value as CustomHookType));
             }}
           />
           {!scope && (
@@ -587,6 +621,21 @@ export default function CustomHookModal({
         </div>
         <div style={{ width: "50%" }}>
           <h3>Test Your Hook</h3>
+          {showFeaturePicker && (
+            <Select
+              label="Prefill from a Feature Flag"
+              placeholder="Use the sample values"
+              value={prefillFeatureId}
+              setValue={prefillFromFeature}
+              mb="3"
+            >
+              {featuresList.map((f) => (
+                <SelectItem key={f.id} value={f.id}>
+                  {f.id}
+                </SelectItem>
+              ))}
+            </Select>
+          )}
           {Object.keys(hookTypeData?.availableArguments).map((arg) => (
             <CodeTextArea
               language="json"
@@ -606,6 +655,35 @@ export default function CustomHookModal({
               showFullscreenButton
             />
           ))}
+          {incrementalChangesOnly && (
+            <>
+              <Text as="div" size="sm" color="text-low" mb="2">
+                Incremental Changes Only also runs the hook against the state
+                before the change. Edit the values above to represent the
+                change; anything this hook reports for both states is suppressed
+                on a real save.
+              </Text>
+              {Object.keys(hookTypeData?.availableArguments).map((arg) => (
+                <CodeTextArea
+                  language="json"
+                  key={`prior-${arg}`}
+                  label={`${arg} (before the change)`}
+                  required
+                  value={priorTestValues[arg] || ""}
+                  setValue={(value) =>
+                    setPriorTestValues((existing) => ({
+                      ...existing,
+                      [arg]: value,
+                    }))
+                  }
+                  onCtrlEnter={runTest}
+                  maxLines={8}
+                  showCopyButton
+                  showFullscreenButton
+                />
+              ))}
+            </>
+          )}
           <Button
             onClick={runTest}
             disabled={!form.watch("code")}
@@ -632,6 +710,21 @@ export default function CustomHookModal({
               {testResult.warnings.map((w, i) => (
                 <Callout key={i} status="warning" mt="2">
                   {w}
+                </Callout>
+              ))}
+            </div>
+          )}
+          {testResult.suppressed && (
+            <div className="mt-3">
+              <strong>Suppressed by Incremental Changes Only:</strong>
+              {[
+                ...(testResult.suppressed.error
+                  ? [testResult.suppressed.error]
+                  : []),
+                ...(testResult.suppressed.warnings ?? []),
+              ].map((m, i) => (
+                <Callout key={i} status="info" mt="2">
+                  {m}
                 </Callout>
               ))}
             </div>

--- a/packages/front-end/components/CustomHooks/CustomHookModal.tsx
+++ b/packages/front-end/components/CustomHooks/CustomHookModal.tsx
@@ -22,7 +22,7 @@ import SelectField from "@/components/Forms/SelectField";
 import useProjectOptions from "@/hooks/useProjectOptions";
 import MultiSelectField from "@/ui/MultiSelectField";
 import CodeTextArea from "@/components/Forms/CodeTextArea";
-import Switch from "@/ui/Switch";
+import Checkbox from "@/ui/Checkbox";
 import Button from "@/ui/Button";
 import Callout from "@/ui/Callout";
 import Text from "@/ui/Text";
@@ -615,10 +615,10 @@ export default function CustomHookModal({
             .
           </Text>
 
-          <Switch
+          <Checkbox
             label="Incremental Changes Only"
             value={form.watch("incrementalChangesOnly") ?? true}
-            onChange={(value) => form.setValue("incrementalChangesOnly", value)}
+            setValue={(value) => form.setValue("incrementalChangesOnly", value)}
             description="Ignore this hook if the same error was already present before attempting to save."
           />
         </div>
@@ -660,14 +660,11 @@ export default function CustomHookModal({
                 change; anything this hook reports for both states is suppressed
                 on a real save.
               </Text>
-              <Text as="div" weight="medium" mb="2">
-                Before the change
-              </Text>
               {Object.keys(hookTypeData?.availableArguments).map((arg) => (
                 <CodeTextArea
                   language="json"
                   key={`prior-${arg}`}
-                  label={arg}
+                  label={`${arg} (before the change)`}
                   required
                   value={priorTestValues[arg] || ""}
                   setValue={(value) =>

--- a/packages/shared/src/validators/custom-hooks.ts
+++ b/packages/shared/src/validators/custom-hooks.ts
@@ -298,6 +298,12 @@ export const testCustomHookValidator = {
           "Arguments exposed to the function as named globals (e.g. `feature`, `config`, `revision`)",
         )
         .optional(),
+      originalFunctionArgs: z
+        .record(z.string(), z.unknown())
+        .describe(
+          "State before the change. When supplied, the hook also runs against it and Incremental Changes Only suppression is applied to the result.",
+        )
+        .optional(),
       // Authorization scope only — a feature-scoped test is authorized against
       // that feature instead of the org-level manageCustomHooks permission.
       entityType: z.enum(customHookEntityTypes).optional(),
@@ -316,6 +322,15 @@ export const testCustomHookValidator = {
       error: z.string().optional(),
       warnings: z.array(z.string()).optional(),
       log: z.string().describe("Captured console output").optional(),
+      suppressed: z
+        .object({
+          error: z.string().optional(),
+          warnings: z.array(z.string()).optional(),
+        })
+        .describe(
+          "Outcomes the previous state produced too, which Incremental Changes Only would hide on a real save",
+        )
+        .optional(),
     })
     .strict(),
   summary: "Dry-run hook code in the sandbox",


### PR DESCRIPTION
### Features and Changes

Two gaps that made Custom Hooks hard to author, both surfaced by a support escalation where the correct hook looked broken in the Test panel.

The panel could not exercise **Incremental Changes Only**. It ran the hook once with no prior state, so a hook that correctly throws in the panel and correctly does not block on save looked wrong. `/custom-hooks/test` now accepts an optional `originalFunctionArgs` and applies the real suppression rule via `applyIncrementalSuppression`, extracted from `_runCustomHook` so the panel cannot drift from runtime. The response reports what suppression hid — "nothing happened" is the confusing outcome, so the panel names it.

Fixtures created from Settings were always generic samples with no way to point at real data. The panel now offers a picker that seeds both the proposed and prior state from an existing Feature Flag.

`_runCustomHook` keeps its call pattern: the second sandbox run still only happens when there is an error or warning to suppress, so successful hooks don't pay for an extra run.

Also corrects the `FeatureRevisionModel` schema comment, which claimed every revision envelope is present only when explicitly changed. True of its neighbours, but not of `metadata`, which `prepareFeatureRevision` always writes as a complete snapshot. Reading it as a sparse diff is what sent #6656 down the wrong path.

### Testing

Endpoint, against a local stack:

- [x] Same error before and after -> `success: true`, error reported under `suppressed`
- [x] Error only in the proposed state -> `success: false`, nothing suppressed
- [x] Same warning before and after -> dropped from `warnings`, reported under `suppressed`
- [x] No `originalFunctionArgs` -> unchanged response, no `suppressed` key

Runtime path, to confirm the extraction didn't change behavior:

- [x] Adding a blocked tag with Incremental Changes Only on -> still blocked
- [x] Unrelated edit on a Feature Flag that already has it -> still passes
- [x] `experimentCustomHooks` and `publishImmediateCustomHooks` suites pass

### Screenshots

With incremental changes checked (default)
<img width="1600" height="1100" alt="hookmodal" src="https://github.com/user-attachments/assets/61ede56d-a55e-457d-8c4d-a3b2adf99838" />

With incremental changes unchecked
<img width="1600" height="1100" alt="hookmodal-no-incremental" src="https://github.com/user-attachments/assets/c20b442a-c4b4-43d4-89e1-b2055e94fd6d" />

Prefilled from a feature
<img width="1600" height="1100" alt="hookmodal-prefilled" src="https://github.com/user-attachments/assets/6f4544a0-ab1a-4f9c-84fb-9b3027e7422b" />

