### PR TITLE
Fix for experiment analysis prompt size

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -45,6 +45,7 @@ import { EventUserForResponseLocals } from "shared/types/events/event-types";
 import { CreateURLRedirectProps } from "shared/types/url-redirect";
 import isEqual from "lodash/isEqual";
 import { getMetricMap } from "back-end/src/models/MetricModel";
+import { summarizeExperimentForAI } from "back-end/src/util/ai-prompt.util";
 import {
   AuthRequest,
   ResponseWithStatusAndError,
@@ -286,18 +287,28 @@ export async function postAIExperimentAnalysis(
     allVariations.find((v) => v.id === releasedVariationId)?.name || "";
 
   const allMetricGroups = await context.models.metricGroups.getAll();
-  const experimentMetricIds = expandMetricGroups(
-    getAllMetricIdsFromExperiment(experiment, false, allMetricGroups),
-    allMetricGroups,
-  );
   const allOrgMetrics = await getMetricMap(context);
-  const experimentMetrics = experimentMetricIds
-    .map((id) => allOrgMetrics.get(id))
-    .filter(isDefined);
+  const expandIds = (ids: string[] | undefined) =>
+    expandMetricGroups(ids || [], allMetricGroups);
+
+  const segmentId = snapshot?.settings?.segment;
+  const segmentName = segmentId
+    ? (await context.models.segments.getById(segmentId))?.name
+    : null;
+
+  const summary = summarizeExperimentForAI({
+    experiment,
+    snapshot,
+    metricMap: allOrgMetrics,
+    goalMetricIds: expandIds(experiment.goalMetrics),
+    secondaryMetricIds: expandIds(experiment.secondaryMetrics),
+    guardrailMetricIds: expandIds(experiment.guardrailMetrics),
+    segmentName,
+  });
 
   const instructions =
-    "\nYou are an expert data analyst whose colleague has chosen a particular outcome for an A/B test. " +
-    "\nYou are fully aware of the experiment framework consisting of:" +
+    "\nYou are an expert data analyst whose colleague has chosen a particular outcome for an A/B test." +
+    "\nYou will be given a JSON summary of the experiment and its latest results." +
     // Arguments
     "\nThe chosen outcome can be 'dnf' which means 'did not finish', 'won' which means the experiment was successful, 'lost' which means none of the variations were as successful as the control, or 'inconclusive' which means no statistically significant result was detected." +
     "\nIf the chosen outcome is 'dnf', 'inconclusive', or 'lost' then we stick with the control." +
@@ -305,98 +316,58 @@ export async function postAIExperimentAnalysis(
     "\nUsually the releasedVariationId is the same as the winning variation, but not always perhaps because the difference is not big enough to warrant the cost of maintaining the winning variant, or other external factors not measured by the metrics" +
     // General context
     "\nExperiments are A/B tests that evaluate the performance of different variations of a feature or product." +
-    "\nSnapshots are periodic summaries of experiment results, including metrics and statistical analyses." +
+    "\nSnapshots are periodic summaries of experiment results, including metrics and statistical analyses. You are given a summary of the latest one rather than the raw snapshot." +
+    // Summary structure
+    "\nThe summary contains the following fields:" +
     // Experiment structure
-    "\nAn Experiment object contains the following key fields:" +
-    "\n- id: A unique identifier for the experiment." +
-    "\n- name: The name of the experiment." +
-    "\n- status: The current status of the experiment (e.g., 'running', 'stopped')." +
-    "\n- variations: An array of variations being tested in the experiment. Each variation has an id, name, and description." +
-    "\n- phases: An array of phases, where each phase represents a time period during which the experiment was run with specific settings." +
-    "\n- results: A summary of the experiment's outcome (e.g., 'won', 'lost', 'inconclusive')." +
-    "\n- winner: The index of the winning variation, if applicable." +
-    "\n- releasedVariationId: The id of the variation that was released as a result of the experiment." +
-    "\n- analysis: A textual summary of the experiment's results and conclusions that you will come up with." +
-    "\n- metrics: Metrics are used to evaluate the performance of variations. These include goal metrics, guardrail metrics, and secondary metrics." +
-    "\n- linkedFeatures: A list of feature flags or features associated with the experiment." +
-    // Snapshot structure
-    "\nA Snapshot object contains the following key fields:" +
-    "\n- id: A unique identifier for the snapshot." +
-    "\n- experiment: The id of the experiment this snapshot belongs to." +
-    "\n- phase: The phase index of the experiment this snapshot corresponds to." +
-    "\n- status: The status of the snapshot (e.g., 'success', 'running', 'error')." +
-    "\n- results: An array of results for each variation in the experiment. Each result includes:" +
-    "\n  - name: The name of the variation." +
-    "\n  - srm: Sample Ratio Mismatch, a measure of whether traffic was evenly split." +
-    "\n  - variations: An array of metrics for each variation. Each metric includes:" +
-    "\n    - users: The number of users exposed to the variation." +
-    "\n    - metrics: A map of metric ids to their statistical results, including:" +
-    "\n      - value: The observed value of the metric." +
-    "\n      - cr: Conversion rate for the metric. For metrics with 'revenue' type this is in the local currency, for count it is a number, for duration it is a time, and for binomial it is a percent" +
-    "\n      - ci: Confidence interval for the metric." +
-    "\n      - uplift: The uplift in performance compared to the baseline." +
-    "\n      - chanceToWin: The probability that this variation is better than others." +
-    "\n- health: Information about the health of the experiment, including traffic and statistical power." +
+    "\n- experiment: id, name, status, hypothesis, description, and priorAnalysis (analysis text a colleague already wrote, if any). Long free-text fields may be truncated with a trailing ellipsis." +
+    "\n- experiment.variations: the variations being tested, in order. The first one is the baseline (control). Each has a name, a description, and weight, which is its share of experiment traffic." +
+    "\n- experiment.startDate and experiment.endDate: the period the latest phase ran for. experiment.coverage is the fraction of eligible traffic that phase included." +
+    "\n- experiment.priorPhases: earlier phases, if the experiment ran in more than one, each with the reason it ended. The results below cover only the latest phase, so treat these as background rather than as results." +
+    // Results structure
+    "\n- results: the overall analysis from the latest successful snapshot. It is omitted entirely when there are no results, which usually means the experiment never started." +
+    "\n- results.statsEngine: 'bayesian' or 'frequentist'." +
+    "\n- results.differenceType: 'relative', 'absolute', or 'scaled'. This is how each lift below is expressed." +
+    "\n- results.pValueThreshold, results.pValueCorrection, results.sequentialTesting, results.regressionAdjusted: the analysis settings the results were computed with." +
+    // Health and validity checks
+    "\n- results.srmPValue: the Sample Ratio Mismatch p-value. A value below 0.001 means traffic was not split as configured and the results should not be trusted." +
+    "\n- results.multipleExposures: how many users saw more than one variation." +
+    "\n- results.unknownVariations: variation ids found in the data that the experiment does not define. Anything listed here means the exposure data is suspect." +
+    "\n- results.segment and results.queryFilter: when either is present the analysis covered only a subset of users, not everyone in the experiment. Say so whenever you state a result, so the numbers are not read as applying to all users." +
+    "\n- results.health, when present, reports validity checks beyond SRM:" +
+    "\n  - isLowPowered and power: whether the experiment collected enough data to detect the effect it was looking for. When a result is inconclusive and the experiment was underpowered, say so, since that is a different conclusion from the variation having no effect." +
+    "\n  - additionalDaysNeeded: how much longer it would have needed to run to reach adequate power." +
+    "\n  - covariateImbalance: true means the variation groups already differed before the experiment started, which undermines the comparison." +
+    "\n  - trafficError: set when traffic data could not be loaded, so exposure counts may be unreliable." +
+    "\n- results.droppedMetrics: if present, how many metrics of each role were left out of the summary to keep it small. Say so in your analysis when metrics were dropped, since the summary is then incomplete for that role." +
     // Metrics and statistical concepts
-    "\nMetrics are used to evaluate the performance of variations in an experiment. They include:" +
-    "\n- Goal metrics: Metrics that measure the primary objectives of the experiment." +
-    "\n- Guardrail metrics: Metrics that ensure the experiment does not negatively impact critical areas." +
-    "\n- Secondary metrics: Additional metrics that provide context or insights." +
-    "\nStatistical concepts used in experiments include:" +
-    "\n- Confidence intervals: A range of values that likely contains the true effect size." +
-    "\n- Statistical power: The probability of detecting a true effect." +
-    "\n- Sample Ratio Mismatch (SRM): Indicates whether traffic was evenly split among variations." +
-    "\n- Chance to Win (bayesian only): The probability that a variation is better than others." +
-    "\n- P-Value (frequentist only): The probability that the null hypothesis is true." +
+    "\n- results.metrics: one entry per metric, each containing:" +
+    "\n  - metric: the metric name." +
+    "\n  - role: 'goal' for metrics measuring the primary objective, which determine success or failure; 'guardrail' for metrics that must not regress; 'secondary' for metrics that add context only." +
     // Metric types
-    "\nMetrics can be of the following types:" +
-    "\n- Binomial/Proportion Metrics: Represent yes/no outcomes (e.g., conversion rates). The value is the proportion of users who converted (e.g., 10% means 10 out of 100 users converted)." +
-    "\n- Count/Mean Metrics: Represent the total count of events per user (e.g., pages viewed per user). The value is the average count per user." +
-    "\n- Duration/Mean Metrics: Represent the total time spent per user (e.g., time on site). The value is the average duration per user, typically in seconds or minutes." +
-    "\n- Revenue/Mean Metrics: Represent the total revenue generated per user. The value is in the local currency, and not a percent.  (e.g. For instance 6.58 means the average revenue per user was $6.58 on average)." +
-    "\n- Ratio Metrics: Represent the ratio of two numeric values among experiment users." +
-    // Statistical results
-    "\n- Statistical results for metrics include: Conversion Rate (CR)" +
-    "\n- Statistical results for metrics include: Value: Represents the total value of the metric across all users who saw the variation." +
-    "\n- Statistical results for metrics include: Confidence Interval (CI): Represents the range within which the true metric value is likely to fall." +
-    "\n- Statistical results for metrics include: Uplift: Represents the difference in metric performance between variations (e.g., the increase in average revenue per user for a variation compared to the baseline)." +
-    "\n- Statistical results for metrics include: Chance to Win: Represents the probability that a variation is better than others for this metric." +
+    "\n  - metricType: proportion (also called binomial), mean, count, duration, revenue, ratio, quantile, or retention." +
+    "\n  - betterDirection: 'higher' or 'lower'. For 'lower' metrics such as bounce rate or latency, a positive lift is a regression, not a win." +
+    "\n  - variations: one entry per variation, in the same order as experiment.variations, so the first entry is the baseline." +
+    "\n    - users: the number of users exposed to the variation." +
+    "\n    - value: the total value of the metric across those users." +
     // Metric interpretation
-    "\n- For binomial metrics, the CR represents the proportion of users who achieved the outcome (e.g., 6.58% means 6.58 out of 100 users converted)." +
-    "\n- For count metrics, the CR represents the average number of events per user (e.g., 6.58 means each user performed 6.58 actions on average)." +
-    "\n- For duration metrics, the CR represents the average time spent per user (e.g., 6.58 means each user spent 6.58 seconds or minutes on average, depending on the unit)." +
-    "\n- For revenue metrics, the CR represents the average revenue per user (e.g., $6.58 means each user generated $6.58 in revenue on average)." +
+    "\n    - cr: the per-user value of the metric. What it means depends on metricType:" +
+    "\n      - proportion, also called binomial, and retention: the share of users who converted or returned, as a rate and not a percentage. 0.0658 means 6.58% of users, or 6.58 out of every 100." +
+    "\n      - revenue: the average revenue per user in the local currency. 6.58 means each user generated $6.58 on average, not 6.58%." +
+    "\n      - count and mean: the average number of events per user. 6.58 means each user performed the action 6.58 times on average." +
+    "\n      - duration: the average time per user, in whatever unit the metric is configured with, which may be seconds, minutes, or hours. Do not assume a unit; refer to it as time unless you are told the unit." +
+    "\n      - ratio: the ratio of two aggregated values across experiment users, such as revenue divided by orders." +
+    "\n      - quantile: the value at the metric's configured percentile rather than an average." +
+    // Statistical results
+    "\n    - lift: the difference compared to the baseline, expressed according to differenceType. Absent on the baseline itself." +
+    "\n    - ci: the confidence interval for that lift, which is the range the true effect is likely to fall in." +
+    "\n    - chanceToWin (bayesian only): the probability this variation beats the baseline for this metric." +
+    "\n    - pValue (frequentist only): the probability of seeing a difference at least this large if the variation truly had no effect. Lower means stronger evidence; compare it against pValueThreshold to judge statistical significance." +
     // Metric aggregation
-    "\nMetrics are aggregated at the user level before being averaged across all users in a variation." +
-    "\nFor example, in revenue metrics, the total revenue for all users in a variation is divided by the total number of users in that variation to calculate the average revenue per user." +
-    // Relationships between experiments and snapshots
-    "\nEach experiment can have multiple snapshots, one for each phase or analysis." +
-    "\nSnapshots summarize the results of an experiment at a specific point in time." +
-    "\nThe 'results' field in a snapshot provides detailed metrics and statistical analyses for each variation." +
-    // Relationships between experiments and metrics
-    "\nExperiments are evaluated using metrics, which are categorized into three types:" +
-    "\n- Goal metrics: These measure the primary objectives of the experiment and are used to determine success or failure." +
-    "\n- Guardrail metrics: These ensure that the experiment does not negatively impact critical areas of the product or business." +
-    "\n- Secondary metrics: These provide additional insights or context but are not the primary focus of the experiment." +
-    "\nEach metric is identified by a unique ID, which is referenced in the experiment's `goalMetrics`, `guardrailMetrics`, and `secondaryMetrics` fields." +
-    "\nThe `experimentMetrics` object is a map where the keys are metric IDs and the values are detailed metric objects. These objects include statistical results and metadata about the metrics." +
-    "\nTo evaluate the experiment, the metric IDs in the `goalMetrics`, `guardrailMetrics`, and `secondaryMetrics` fields should be matched to their corresponding metric objects in the `experimentMetrics` map." +
-    "\nEach metric object in the `experimentMetrics` map contains the following key fields:" +
-    "\n- `value`: The observed value of the metric." +
-    "\n- `cr`: The conversion rate for the metric." +
-    "\n- `ci`: The confidence interval for the metric." +
-    "\n- `uplift`: The uplift in performance compared to the baseline." +
-    "\n- `chanceToWin`: The probability that the variation is better than others for this metric." +
-    "\n- `pValue`: The p-value for the metric, indicating statistical significance." +
-    "\nThe `experimentMetrics` map provides the detailed results for each metric, which are used to analyze the performance of the variations in the experiment." +
-    "\nThe keys in the `experimentMetrics` map refer to the ids mentioned in the `goalMetrics`, `guardrailMetrics`, and `secondaryMetrics` fields of the experiment." +
-    "\nIf the snapshot is undefined then the experiment probably never started." +
-    "\n- the experiment data is: " +
-    JSON.stringify(experiment) +
-    "\n- the latest snapshot is: " +
-    JSON.stringify(snapshot) +
-    "\n- the experiment metrics are: " +
-    JSON.stringify(experimentMetrics) +
+    "\nMetrics are aggregated at the user level before being averaged across all users in a variation. For revenue, the total revenue for a variation is divided by the number of users in it." +
+    "\nA result is only worth acting on when it is both statistically significant and large enough to matter in practice." +
+    "\n- the experiment summary is: " +
+    JSON.stringify(summary) +
     "\n- Your colleague has chosen the following outcome for the experiment:" +
     results +
     (results === "won"

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -19,7 +19,10 @@ import {
   getAllVariations,
 } from "shared/experiments";
 import { getScopedSettings } from "shared/settings";
-import { isExperimentIncrementalEnabled } from "shared/enterprise";
+import {
+  getHealthSettings,
+  isExperimentIncrementalEnabled,
+} from "shared/enterprise";
 import { v4 as uuidv4 } from "uuid";
 import { IdeaInterface } from "shared/types/idea";
 import { VisualChangesetInterface } from "shared/types/visual-changeset";
@@ -45,7 +48,7 @@ import { EventUserForResponseLocals } from "shared/types/events/event-types";
 import { CreateURLRedirectProps } from "shared/types/url-redirect";
 import isEqual from "lodash/isEqual";
 import { getMetricMap } from "back-end/src/models/MetricModel";
-import { summarizeExperimentForAI } from "back-end/src/util/ai-prompt.util";
+import { summarizeExperimentAnalysisForAI } from "back-end/src/util/ai-prompt.util";
 import {
   AuthRequest,
   ResponseWithStatusAndError,
@@ -295,8 +298,9 @@ export async function postAIExperimentAnalysis(
   const segmentName = segmentId
     ? (await context.models.segments.getById(segmentId))?.name
     : null;
+  const { srmThreshold } = getHealthSettings(context.org.settings);
 
-  const summary = summarizeExperimentForAI({
+  const summary = summarizeExperimentAnalysisForAI({
     experiment,
     snapshot,
     metricMap: allOrgMetrics,
@@ -304,6 +308,7 @@ export async function postAIExperimentAnalysis(
     secondaryMetricIds: expandIds(experiment.secondaryMetrics),
     guardrailMetricIds: expandIds(experiment.guardrailMetrics),
     segmentName,
+    srmThreshold,
   });
 
   const instructions =
@@ -330,7 +335,8 @@ export async function postAIExperimentAnalysis(
     "\n- results.differenceType: 'relative', 'absolute', or 'scaled'. This is how each lift below is expressed." +
     "\n- results.pValueThreshold, results.pValueCorrection, results.sequentialTesting, results.regressionAdjusted: the analysis settings the results were computed with." +
     // Health and validity checks
-    "\n- results.srmPValue: the Sample Ratio Mismatch p-value. A value below 0.001 means traffic was not split as configured and the results should not be trusted." +
+    "\n- results.srmPValue: the Sample Ratio Mismatch p-value. A value below results.srmThreshold means traffic was not split as configured and the results should not be trusted." +
+    "\n- results.srmThreshold: this org's configured significance threshold for the SRM check above." +
     "\n- results.multipleExposures: how many users saw more than one variation." +
     "\n- results.unknownVariations: variation ids found in the data that the experiment does not define. Anything listed here means the exposure data is suspect." +
     "\n- results.segment and results.queryFilter: when either is present the analysis covered only a subset of users, not everyone in the experiment. Say so whenever you state a result, so the numbers are not read as applying to all users." +
@@ -345,7 +351,7 @@ export async function postAIExperimentAnalysis(
     "\n  - metric: the metric name." +
     "\n  - role: 'goal' for metrics measuring the primary objective, which determine success or failure; 'guardrail' for metrics that must not regress; 'secondary' for metrics that add context only." +
     // Metric types
-    "\n  - metricType: proportion (also called binomial), mean, count, duration, revenue, ratio, quantile, or retention." +
+    "\n  - metricType: proportion (also called binomial), mean, count, duration, revenue, ratio, quantile, retention, or dailyParticipation." +
     "\n  - betterDirection: 'higher' or 'lower'. For 'lower' metrics such as bounce rate or latency, a positive lift is a regression, not a win." +
     "\n  - variations: one entry per variation, in the same order as experiment.variations, so the first entry is the baseline." +
     "\n    - users: the number of users exposed to the variation." +
@@ -358,6 +364,7 @@ export async function postAIExperimentAnalysis(
     "\n      - duration: the average time per user, in whatever unit the metric is configured with, which may be seconds, minutes, or hours. Do not assume a unit; refer to it as time unless you are told the unit." +
     "\n      - ratio: the ratio of two aggregated values across experiment users, such as revenue divided by orders." +
     "\n      - quantile: the value at the metric's configured percentile rather than an average." +
+    "\n      - dailyParticipation: the average share of days in the metric's window that each user was active, as a rate and not a percentage." +
     // Statistical results
     "\n    - lift: the difference compared to the baseline, expressed according to differenceType. Absent on the baseline itself." +
     "\n    - ci: the confidence interval for that lift, which is the range the true effect is likely to fall in." +

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -299,6 +299,10 @@ export async function postAIExperimentAnalysis(
     ? (await context.models.segments.getById(segmentId))?.name
     : null;
   const { srmThreshold } = getHealthSettings(context.org.settings);
+  const { settings: scopedSettings } = getScopedSettings({
+    organization: context.org,
+    experiment,
+  });
 
   const summary = summarizeExperimentAnalysisForAI({
     experiment,
@@ -309,6 +313,7 @@ export async function postAIExperimentAnalysis(
     guardrailMetricIds: expandIds(experiment.guardrailMetrics),
     segmentName,
     srmThreshold,
+    statsEngine: experiment.statsEngine || scopedSettings.statsEngine.value,
   });
 
   const instructions =
@@ -355,7 +360,6 @@ export async function postAIExperimentAnalysis(
     "\n  - betterDirection: 'higher' or 'lower'. For 'lower' metrics such as bounce rate or latency, a positive lift is a regression, not a win." +
     "\n  - variations: one entry per variation, in the same order as experiment.variations, so the first entry is the baseline." +
     "\n    - users: the number of users exposed to the variation." +
-    "\n    - value: the total value of the metric across those users." +
     // Metric interpretation
     "\n    - cr: the per-user value of the metric. What it means depends on metricType:" +
     "\n      - proportion, also called binomial, and retention: the share of users who converted or returned, as a rate and not a percentage. 0.0658 means 6.58% of users, or 6.58 out of every 100." +

--- a/packages/back-end/src/routers/learnings/learnings.controller.ts
+++ b/packages/back-end/src/routers/learnings/learnings.controller.ts
@@ -27,6 +27,14 @@ import { getLatestSnapshotMultipleExperiments } from "back-end/src/models/Experi
 import { getMetricMap } from "back-end/src/models/MetricModel";
 import { getAllTags } from "back-end/src/models/TagModel";
 import { logger } from "back-end/src/util/logger";
+import {
+  MAX_ANALYSIS_CHARS,
+  MAX_DESCRIPTION_CHARS,
+  MAX_HYPOTHESIS_CHARS,
+  MAX_VARIATION_DESCRIPTION_CHARS,
+  roundForAI,
+  truncateForAI,
+} from "back-end/src/util/ai-prompt.util";
 
 type LearningWithCanManage = LearningInterface & { canManage: boolean };
 
@@ -227,11 +235,6 @@ const MAX_EXPERIMENTS_FOR_AI = 150;
 const METRIC_RESULTS_CHAR_ALLOWANCE = 2000;
 const MAX_SAVED_LEARNINGS_IN_PROMPT = 100;
 const MAX_ORG_TAGS_IN_PROMPT = 100;
-// Per-field character caps for the experiment summaries sent to the AI
-const MAX_HYPOTHESIS_CHARS = 600;
-const MAX_DESCRIPTION_CHARS = 1500;
-const MAX_ANALYSIS_CHARS = 2000;
-const MAX_VARIATION_DESCRIPTION_CHARS = 300;
 const MAX_SAVED_LEARNING_TEXT_CHARS = 600;
 // Candidates at or above this cosine similarity to a saved learning are
 // dropped as duplicates (prompt-level dedup is soft; this is the hard check)
@@ -239,15 +242,6 @@ const SIMILARITY_DEDUP_THRESHOLD = 0.85;
 // Saved learnings normally get embeddings via LearningModel hooks; backfill at
 // most this many missing ones inline per request
 const MAX_SAVED_VECTOR_BACKFILL = 50;
-
-function truncateForAI(s: string | undefined, maxChars: number): string {
-  if (!s) return "";
-  return s.length > maxChars ? s.slice(0, maxChars) + "…" : s;
-}
-
-function roundForAI(n: number): number {
-  return Math.round(n * 10000) / 10000;
-}
 
 // When stopped, an experiment's last phase end date is the best "recency"
 // signal; fall back to dateUpdated for anything without phases.

--- a/packages/back-end/src/util/ai-prompt.util.ts
+++ b/packages/back-end/src/util/ai-prompt.util.ts
@@ -3,7 +3,11 @@ import {
   ExperimentSnapshotAnalysis,
   ExperimentSnapshotInterface,
 } from "shared/types/experiment-snapshot";
-import { ExperimentMetricInterface, isFactMetric } from "shared/experiments";
+import {
+  ExperimentMetricInterface,
+  getLatestPhaseVariations,
+  isFactMetric,
+} from "shared/experiments";
 import { getSnapshotAnalysis } from "shared/util";
 
 export const MAX_HYPOTHESIS_CHARS = 600;
@@ -274,6 +278,9 @@ export function summarizeExperimentForAI({
 }): AIExperimentSummary {
   const phases = experiment.phases || [];
   const lastPhase = phases[phases.length - 1];
+  // Snapshot results are indexed against the latest phase's variation list,
+  // which can reorder or omit entries relative to experiment.variations.
+  const phaseVariations = getLatestPhaseVariations(experiment);
   // Results only describe the last phase, so earlier ones are listed as
   // context rather than mixed in with the numbers.
   const priorPhases: AIPhaseSummary[] = phases.slice(0, -1).map((phase) => ({
@@ -282,7 +289,7 @@ export function summarizeExperimentForAI({
     startDate: toISODate(phase.dateStarted),
     endDate: toISODate(phase.dateEnded),
   }));
-  const variationNames = (experiment.variations || []).map(
+  const variationNames = phaseVariations.map(
     (v, i) => v.name || `Variation ${i}`,
   );
 
@@ -294,7 +301,7 @@ export function summarizeExperimentForAI({
       hypothesis: truncateForAI(experiment.hypothesis, MAX_HYPOTHESIS_CHARS),
       description: truncateForAI(experiment.description, MAX_DESCRIPTION_CHARS),
       priorAnalysis: truncateForAI(experiment.analysis, MAX_ANALYSIS_CHARS),
-      variations: (experiment.variations || []).map((v, i) => ({
+      variations: phaseVariations.map((v, i) => ({
         name: variationNames[i],
         description: truncateForAI(
           v.description,

--- a/packages/back-end/src/util/ai-prompt.util.ts
+++ b/packages/back-end/src/util/ai-prompt.util.ts
@@ -3,6 +3,7 @@ import {
   ExperimentSnapshotAnalysis,
   ExperimentSnapshotInterface,
 } from "shared/types/experiment-snapshot";
+import { StatsEngine } from "shared/types/stats";
 import {
   ExperimentMetricInterface,
   getLatestPhaseVariations,
@@ -54,7 +55,6 @@ function roundPairForAI(pair: [number, number]): [number, number] {
 export type AIMetricVariationResult = {
   variation: string;
   users: number;
-  value?: number;
   cr?: number;
   lift?: number;
   ci?: [number, number];
@@ -144,6 +144,24 @@ function allocateMetricBudget(
   return allocated;
 }
 
+// analyses[0] is whichever analysis was written first, which may be a
+// dimension analysis — whose results[0] is one slice rather than the whole
+// experiment — or one using a stats engine the team does not read. Prefer an
+// overall analysis, and among those the configured engine.
+function selectAnalysis(
+  snapshot: ExperimentSnapshotInterface,
+  statsEngine?: StatsEngine,
+): ExperimentSnapshotAnalysis | null {
+  const overall = (snapshot.analyses || []).filter(
+    (a) => !a.settings.dimensions?.length && a.results?.length,
+  );
+  return (
+    overall.find((a) => a.settings.statsEngine === statsEngine) ||
+    overall[0] ||
+    getSnapshotAnalysis(snapshot)
+  );
+}
+
 function summarizeMetricResults({
   analysis,
   metricMap,
@@ -194,7 +212,6 @@ function summarizeMetricResults({
           variation: variationNames[i] || `Variation ${i}`,
           users: m.users ?? variation.users,
         };
-        if (typeof m.value === "number") row.value = roundForAI(m.value);
         if (typeof m.cr === "number") row.cr = roundForAI(m.cr);
         if (typeof m.expected === "number") row.lift = roundForAI(m.expected);
         const ci = m.ciAdjusted ?? m.ci;
@@ -269,6 +286,7 @@ export function summarizeExperimentAnalysisForAI({
   guardrailMetricIds,
   segmentName,
   srmThreshold,
+  statsEngine,
 }: {
   experiment: ExperimentInterface;
   snapshot: ExperimentSnapshotInterface | undefined;
@@ -278,6 +296,7 @@ export function summarizeExperimentAnalysisForAI({
   guardrailMetricIds: string[];
   segmentName?: string | null;
   srmThreshold: number;
+  statsEngine?: StatsEngine;
 }): AIExperimentSummary {
   const phases = experiment.phases || [];
   const lastPhase = phases[phases.length - 1];
@@ -321,7 +340,7 @@ export function summarizeExperimentAnalysisForAI({
 
   if (!snapshot) return summary;
 
-  const analysis = getSnapshotAnalysis(snapshot);
+  const analysis = selectAnalysis(snapshot, statsEngine);
   if (!analysis) return summary;
 
   const metricResults = summarizeMetricResults({

--- a/packages/back-end/src/util/ai-prompt.util.ts
+++ b/packages/back-end/src/util/ai-prompt.util.ts
@@ -109,6 +109,7 @@ export type AIExperimentSummary = {
     sequentialTesting?: boolean;
     regressionAdjusted?: boolean;
     srmPValue: number;
+    srmThreshold: number;
     multipleExposures: number;
     metrics: AIMetricResult[];
     droppedMetrics?: Partial<Record<AIMetricRole, number>>;
@@ -259,7 +260,7 @@ function summarizeHealth(
   return Object.keys(health).length ? health : undefined;
 }
 
-export function summarizeExperimentForAI({
+export function summarizeExperimentAnalysisForAI({
   experiment,
   snapshot,
   metricMap,
@@ -267,6 +268,7 @@ export function summarizeExperimentForAI({
   secondaryMetricIds,
   guardrailMetricIds,
   segmentName,
+  srmThreshold,
 }: {
   experiment: ExperimentInterface;
   snapshot: ExperimentSnapshotInterface | undefined;
@@ -275,6 +277,7 @@ export function summarizeExperimentForAI({
   secondaryMetricIds: string[];
   guardrailMetricIds: string[];
   segmentName?: string | null;
+  srmThreshold: number;
 }): AIExperimentSummary {
   const phases = experiment.phases || [];
   const lastPhase = phases[phases.length - 1];
@@ -341,6 +344,7 @@ export function summarizeExperimentForAI({
     sequentialTesting: analysis.settings.sequentialTesting,
     regressionAdjusted: analysis.settings.regressionAdjusted,
     srmPValue: roundForAI(analysis.results[0].srm),
+    srmThreshold,
     multipleExposures: snapshot.multipleExposures,
     metrics: metricResults.metrics,
     ...(Object.keys(metricResults.droppedMetrics).length

--- a/packages/back-end/src/util/ai-prompt.util.ts
+++ b/packages/back-end/src/util/ai-prompt.util.ts
@@ -1,0 +1,362 @@
+import { ExperimentInterface } from "shared/types/experiment";
+import {
+  ExperimentSnapshotAnalysis,
+  ExperimentSnapshotInterface,
+} from "shared/types/experiment-snapshot";
+import { ExperimentMetricInterface, isFactMetric } from "shared/experiments";
+import { getSnapshotAnalysis } from "shared/util";
+
+export const MAX_HYPOTHESIS_CHARS = 600;
+export const MAX_DESCRIPTION_CHARS = 1500;
+export const MAX_ANALYSIS_CHARS = 2000;
+export const MAX_VARIATION_DESCRIPTION_CHARS = 300;
+export const MAX_QUERY_FILTER_CHARS = 300;
+// A snapshot can hold results for hundreds of metrics; past this many the
+// prompt costs more than the extra metrics are worth to the analysis. Size
+// scales with metrics x variations: at this cap a 2-variation experiment is
+// ~40k tokens and an 8-variation one ~140k, so the worst case still fits the
+// smallest default model's window (Haiku 4.5 at 200k), but not by much.
+export const MAX_METRICS_FOR_AI = 400;
+
+// Each role is guaranteed a share of the cap so a long list of goal metrics
+// can never push every guardrail out of the summary. Unclaimed budget is
+// handed back out in this same order, so a role is only capped when the
+// others actually need their share.
+export const METRIC_ROLE_RESERVATIONS: Record<AIMetricRole, number> = {
+  goal: 240,
+  guardrail: 120,
+  secondary: 40,
+};
+
+export function truncateForAI(s: string | undefined, maxChars: number): string {
+  if (!s) return "";
+  return s.length > maxChars ? s.slice(0, maxChars) + "…" : s;
+}
+
+export function roundForAI(n: number): number {
+  return Math.round(n * 10000) / 10000;
+}
+
+function toISODate(d: Date | undefined): string | undefined {
+  if (!d) return undefined;
+  const date = new Date(d);
+  return isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function roundPairForAI(pair: [number, number]): [number, number] {
+  return [roundForAI(pair[0]), roundForAI(pair[1])];
+}
+
+export type AIMetricVariationResult = {
+  variation: string;
+  users: number;
+  value?: number;
+  cr?: number;
+  lift?: number;
+  ci?: [number, number];
+  chanceToWin?: number;
+  pValue?: number;
+};
+
+export type AIMetricRole = "goal" | "guardrail" | "secondary";
+
+export type AIMetricResult = {
+  metric: string;
+  role: AIMetricRole;
+  metricType: string;
+  betterDirection: "higher" | "lower";
+  variations: AIMetricVariationResult[];
+};
+
+export type AIPhaseSummary = {
+  name: string;
+  reason: string;
+  startDate?: string;
+  endDate?: string;
+};
+
+export type AIHealthSummary = {
+  power?: number;
+  isLowPowered?: boolean;
+  additionalDaysNeeded?: number;
+  covariateImbalance?: boolean;
+  trafficError?: string;
+};
+
+export type AIExperimentSummary = {
+  experiment: {
+    id: string;
+    name: string;
+    status: string;
+    hypothesis: string;
+    description: string;
+    priorAnalysis: string;
+    variations: { name: string; description: string; weight?: number }[];
+    startDate?: string;
+    endDate?: string;
+    coverage?: number;
+    priorPhases?: AIPhaseSummary[];
+  };
+  results?: {
+    statsEngine: string;
+    differenceType: string;
+    pValueThreshold?: number;
+    pValueCorrection?: string;
+    sequentialTesting?: boolean;
+    regressionAdjusted?: boolean;
+    srmPValue: number;
+    multipleExposures: number;
+    metrics: AIMetricResult[];
+    droppedMetrics?: Partial<Record<AIMetricRole, number>>;
+    health?: AIHealthSummary;
+    segment?: string;
+    queryFilter?: string;
+    unknownVariations?: string[];
+  };
+};
+
+function allocateMetricBudget(
+  counts: Record<AIMetricRole, number>,
+): Record<AIMetricRole, number> {
+  const order: AIMetricRole[] = ["goal", "guardrail", "secondary"];
+  const allocated: Record<AIMetricRole, number> = {
+    goal: 0,
+    guardrail: 0,
+    secondary: 0,
+  };
+
+  let remaining = MAX_METRICS_FOR_AI;
+  for (const role of order) {
+    allocated[role] = Math.min(counts[role], METRIC_ROLE_RESERVATIONS[role]);
+    remaining -= allocated[role];
+  }
+  for (const role of order) {
+    const extra = Math.min(counts[role] - allocated[role], remaining);
+    allocated[role] += extra;
+    remaining -= extra;
+  }
+
+  return allocated;
+}
+
+function summarizeMetricResults({
+  analysis,
+  metricMap,
+  variationNames,
+  goalMetricIds,
+  secondaryMetricIds,
+  guardrailMetricIds,
+}: {
+  analysis: ExperimentSnapshotAnalysis;
+  metricMap: Map<string, ExperimentMetricInterface>;
+  variationNames: string[];
+  goalMetricIds: string[];
+  secondaryMetricIds: string[];
+  guardrailMetricIds: string[];
+}): {
+  metrics: AIMetricResult[];
+  droppedMetrics: Partial<Record<AIMetricRole, number>>;
+} | null {
+  const overall = analysis.results?.[0];
+  if (!overall) return null;
+
+  const roleOrder: [AIMetricRole, string[]][] = [
+    ["goal", goalMetricIds],
+    ["guardrail", guardrailMetricIds],
+    ["secondary", secondaryMetricIds],
+  ];
+
+  const byRole: Record<AIMetricRole, AIMetricResult[]> = {
+    goal: [],
+    guardrail: [],
+    secondary: [],
+  };
+  const seen = new Set<string>();
+
+  for (const [role, metricIds] of roleOrder) {
+    for (const metricId of metricIds) {
+      if (seen.has(metricId)) continue;
+      seen.add(metricId);
+
+      const metric = metricMap.get(metricId);
+      if (!metric) continue;
+
+      const variations: AIMetricVariationResult[] = [];
+      overall.variations.forEach((variation, i) => {
+        const m = variation.metrics?.[metricId];
+        if (!m) return;
+        const row: AIMetricVariationResult = {
+          variation: variationNames[i] || `Variation ${i}`,
+          users: m.users ?? variation.users,
+        };
+        if (typeof m.value === "number") row.value = roundForAI(m.value);
+        if (typeof m.cr === "number") row.cr = roundForAI(m.cr);
+        if (typeof m.expected === "number") row.lift = roundForAI(m.expected);
+        const ci = m.ciAdjusted ?? m.ci;
+        if (ci) row.ci = roundPairForAI(ci);
+        if (typeof m.chanceToWin === "number") {
+          row.chanceToWin = roundForAI(m.chanceToWin);
+        }
+        const pValue = m.pValueAdjusted ?? m.pValue;
+        if (typeof pValue === "number") row.pValue = roundForAI(pValue);
+        variations.push(row);
+      });
+
+      if (!variations.length) continue;
+
+      byRole[role].push({
+        metric: metric.name || metricId,
+        role,
+        metricType: isFactMetric(metric) ? metric.metricType : metric.type,
+        betterDirection: metric.inverse ? "lower" : "higher",
+        variations,
+      });
+    }
+  }
+
+  const budget = allocateMetricBudget({
+    goal: byRole.goal.length,
+    guardrail: byRole.guardrail.length,
+    secondary: byRole.secondary.length,
+  });
+
+  const metrics: AIMetricResult[] = [];
+  const droppedMetrics: Partial<Record<AIMetricRole, number>> = {};
+  for (const [role] of roleOrder) {
+    metrics.push(...byRole[role].slice(0, budget[role]));
+    const dropped = byRole[role].length - budget[role];
+    if (dropped > 0) droppedMetrics[role] = dropped;
+  }
+
+  return { metrics, droppedMetrics };
+}
+
+// health.traffic is a per-day, per-dimension time series and health.power
+// carries a row per metric and variation; only the top-level verdicts are
+// worth prompt space.
+function summarizeHealth(
+  snapshot: ExperimentSnapshotInterface,
+): AIHealthSummary | undefined {
+  const { power, covariateImbalance, traffic } = snapshot.health || {};
+
+  const health: AIHealthSummary = {};
+  if (power) {
+    health.isLowPowered = power.isLowPowered;
+    if (power.type === "success") {
+      health.power = roundForAI(power.power);
+      health.additionalDaysNeeded = power.additionalDaysNeeded;
+    }
+  }
+  if (covariateImbalance) {
+    health.covariateImbalance = covariateImbalance.isImbalanced;
+  }
+  if (traffic?.error) health.trafficError = traffic.error;
+
+  return Object.keys(health).length ? health : undefined;
+}
+
+export function summarizeExperimentForAI({
+  experiment,
+  snapshot,
+  metricMap,
+  goalMetricIds,
+  secondaryMetricIds,
+  guardrailMetricIds,
+  segmentName,
+}: {
+  experiment: ExperimentInterface;
+  snapshot: ExperimentSnapshotInterface | undefined;
+  metricMap: Map<string, ExperimentMetricInterface>;
+  goalMetricIds: string[];
+  secondaryMetricIds: string[];
+  guardrailMetricIds: string[];
+  segmentName?: string | null;
+}): AIExperimentSummary {
+  const phases = experiment.phases || [];
+  const lastPhase = phases[phases.length - 1];
+  // Results only describe the last phase, so earlier ones are listed as
+  // context rather than mixed in with the numbers.
+  const priorPhases: AIPhaseSummary[] = phases.slice(0, -1).map((phase) => ({
+    name: phase.name,
+    reason: phase.reason,
+    startDate: toISODate(phase.dateStarted),
+    endDate: toISODate(phase.dateEnded),
+  }));
+  const variationNames = (experiment.variations || []).map(
+    (v, i) => v.name || `Variation ${i}`,
+  );
+
+  const summary: AIExperimentSummary = {
+    experiment: {
+      id: experiment.id,
+      name: experiment.name,
+      status: experiment.status,
+      hypothesis: truncateForAI(experiment.hypothesis, MAX_HYPOTHESIS_CHARS),
+      description: truncateForAI(experiment.description, MAX_DESCRIPTION_CHARS),
+      priorAnalysis: truncateForAI(experiment.analysis, MAX_ANALYSIS_CHARS),
+      variations: (experiment.variations || []).map((v, i) => ({
+        name: variationNames[i],
+        description: truncateForAI(
+          v.description,
+          MAX_VARIATION_DESCRIPTION_CHARS,
+        ),
+        weight: lastPhase?.variationWeights?.[i],
+      })),
+      startDate: toISODate(lastPhase?.dateStarted),
+      endDate: toISODate(lastPhase?.dateEnded),
+      coverage: lastPhase?.coverage,
+      ...(priorPhases.length ? { priorPhases } : {}),
+    },
+  };
+
+  if (!snapshot) return summary;
+
+  const analysis = getSnapshotAnalysis(snapshot);
+  if (!analysis) return summary;
+
+  const metricResults = summarizeMetricResults({
+    analysis,
+    metricMap,
+    variationNames,
+    goalMetricIds,
+    secondaryMetricIds,
+    guardrailMetricIds,
+  });
+  if (!metricResults) return summary;
+
+  const health = summarizeHealth(snapshot);
+
+  summary.results = {
+    statsEngine: analysis.settings.statsEngine,
+    differenceType: analysis.settings.differenceType,
+    pValueThreshold: analysis.settings.pValueThreshold,
+    pValueCorrection: analysis.settings.pValueCorrection ?? undefined,
+    sequentialTesting: analysis.settings.sequentialTesting,
+    regressionAdjusted: analysis.settings.regressionAdjusted,
+    srmPValue: roundForAI(analysis.results[0].srm),
+    multipleExposures: snapshot.multipleExposures,
+    metrics: metricResults.metrics,
+    ...(Object.keys(metricResults.droppedMetrics).length
+      ? { droppedMetrics: metricResults.droppedMetrics }
+      : {}),
+    ...(health ? { health } : {}),
+    // Both scope the analysis to a subset of users, so a summary that omits
+    // them reads as if it covered everyone.
+    ...(snapshot.settings?.segment
+      ? { segment: segmentName || snapshot.settings.segment }
+      : {}),
+    ...(snapshot.settings?.queryFilter
+      ? {
+          queryFilter: truncateForAI(
+            snapshot.settings.queryFilter,
+            MAX_QUERY_FILTER_CHARS,
+          ),
+        }
+      : {}),
+    ...(snapshot.unknownVariations?.length
+      ? { unknownVariations: snapshot.unknownVariations }
+      : {}),
+  };
+
+  return summary;
+}

--- a/packages/back-end/test/ai-prompt.util.test.ts
+++ b/packages/back-end/test/ai-prompt.util.test.ts
@@ -211,11 +211,10 @@ describe("summarizeExperimentAnalysisForAI", () => {
     expect(purchases?.metricType).toBe("binomial");
     expect(purchases?.betterDirection).toBe("higher");
     expect(purchases?.variations).toEqual([
-      { variation: "Control", users: 1000, value: 100, cr: 0.1 },
+      { variation: "Control", users: 1000, cr: 0.1 },
       {
         variation: "Two-step",
         users: 1010,
-        value: 121,
         cr: 0.1198,
         lift: 0.198,
         ci: [0.0512, 0.3512],
@@ -559,17 +558,108 @@ describe("summarizeExperimentAnalysisForAI", () => {
     // resultVariations[1] holds the lift, so it must be labelled with the
     // phase's second variation, not the experiment's.
     expect(summary.results?.metrics[0].variations).toEqual([
-      { variation: "Two-step", users: 1000, value: 100, cr: 0.1 },
+      { variation: "Two-step", users: 1000, cr: 0.1 },
       {
         variation: "Control",
         users: 1010,
-        value: 121,
         cr: 0.1198,
         lift: 0.198,
         ci: [0.0512, 0.3512],
         pValue: 0.0123,
       },
     ]);
+  });
+
+  it("leaves out the raw summed value, which cr and users already carry", () => {
+    const summary = summarizeExperimentAnalysisForAI({
+      experiment,
+      snapshot: makeSnapshot(resultVariations),
+      metricMap,
+      goalMetricIds: ["met_purchases"],
+      secondaryMetricIds: [],
+      guardrailMetricIds: [],
+      srmThreshold: 0.001,
+    });
+
+    const serialized = JSON.stringify(summary.results?.metrics);
+    expect(serialized).not.toContain("value");
+  });
+
+  it("prefers the overall analysis using the configured stats engine", () => {
+    const snapshot = makeSnapshot(resultVariations);
+    const [frequentist] = snapshot.analyses;
+    snapshot.analyses = [
+      {
+        ...frequentist,
+        analysisKey: "bayesian",
+        settings: { ...frequentist.settings, statsEngine: "bayesian" },
+      },
+      frequentist,
+    ];
+
+    const summary = summarizeExperimentAnalysisForAI({
+      experiment,
+      snapshot,
+      metricMap,
+      goalMetricIds: ["met_purchases"],
+      secondaryMetricIds: [],
+      guardrailMetricIds: [],
+      srmThreshold: 0.001,
+      statsEngine: "frequentist",
+    });
+
+    expect(summary.results?.statsEngine).toBe("frequentist");
+  });
+
+  it("skips a dimension analysis, whose first row is one slice", () => {
+    const snapshot = makeSnapshot(resultVariations);
+    const [overall] = snapshot.analyses;
+    snapshot.analyses = [
+      {
+        ...overall,
+        analysisKey: "by-country",
+        settings: { ...overall.settings, dimensions: ["exp:country"] },
+        // A distinct srm makes it detectable if this analysis is the one used.
+        results: [{ name: "US", srm: 0.1234, variations: resultVariations }],
+      },
+      overall,
+    ];
+
+    const summary = summarizeExperimentAnalysisForAI({
+      experiment,
+      snapshot,
+      metricMap,
+      goalMetricIds: ["met_purchases"],
+      secondaryMetricIds: [],
+      guardrailMetricIds: [],
+      srmThreshold: 0.001,
+    });
+
+    expect(summary.results?.srmPValue).toBe(0.6324);
+    expect(summary.results?.metrics).toHaveLength(1);
+  });
+
+  it("falls back to the first analysis when none is dimensionless", () => {
+    const snapshot = makeSnapshot(resultVariations);
+    const [overall] = snapshot.analyses;
+    snapshot.analyses = [
+      {
+        ...overall,
+        settings: { ...overall.settings, dimensions: ["exp:country"] },
+      },
+    ];
+
+    const summary = summarizeExperimentAnalysisForAI({
+      experiment,
+      snapshot,
+      metricMap,
+      goalMetricIds: ["met_purchases"],
+      secondaryMetricIds: [],
+      guardrailMetricIds: [],
+      srmThreshold: 0.001,
+    });
+
+    expect(summary.results?.metrics).toHaveLength(1);
   });
 
   it("keeps warehouse queries and health time series out of the prompt", () => {

--- a/packages/back-end/test/ai-prompt.util.test.ts
+++ b/packages/back-end/test/ai-prompt.util.test.ts
@@ -542,13 +542,14 @@ describe("summarizeExperimentAnalysisForAI", () => {
       ],
     } as ExperimentInterface;
 
-    const summary = summarizeExperimentForAI({
+    const summary = summarizeExperimentAnalysisForAI({
       experiment: reorderedExperiment,
       snapshot: makeSnapshot(resultVariations),
       metricMap,
       goalMetricIds: ["met_purchases"],
       secondaryMetricIds: [],
       guardrailMetricIds: [],
+      srmThreshold,
     });
 
     expect(summary.experiment.variations).toEqual([

--- a/packages/back-end/test/ai-prompt.util.test.ts
+++ b/packages/back-end/test/ai-prompt.util.test.ts
@@ -507,6 +507,52 @@ describe("summarizeExperimentForAI", () => {
     expect(summary.results?.unknownVariations).toBeUndefined();
   });
 
+  it("labels result rows using the latest phase's variation order", () => {
+    // Snapshot rows follow the phase's list, which here is reversed relative
+    // to experiment.variations.
+    const reorderedExperiment = {
+      ...experiment,
+      phases: [
+        {
+          ...experiment.phases[1],
+          variations: [
+            { id: "var_1", status: "active" },
+            { id: "var_0", status: "active" },
+          ],
+          variationWeights: [0.7, 0.3],
+        },
+      ],
+    } as ExperimentInterface;
+
+    const summary = summarizeExperimentForAI({
+      experiment: reorderedExperiment,
+      snapshot: makeSnapshot(resultVariations),
+      metricMap,
+      goalMetricIds: ["met_purchases"],
+      secondaryMetricIds: [],
+      guardrailMetricIds: [],
+    });
+
+    expect(summary.experiment.variations).toEqual([
+      { name: "Two-step", description: "Shorter flow", weight: 0.7 },
+      { name: "Control", description: "Current flow", weight: 0.3 },
+    ]);
+    // resultVariations[1] holds the lift, so it must be labelled with the
+    // phase's second variation, not the experiment's.
+    expect(summary.results?.metrics[0].variations).toEqual([
+      { variation: "Two-step", users: 1000, value: 100, cr: 0.1 },
+      {
+        variation: "Control",
+        users: 1010,
+        value: 121,
+        cr: 0.1198,
+        lift: 0.198,
+        ci: [0.0512, 0.3512],
+        pValue: 0.0123,
+      },
+    ]);
+  });
+
   it("keeps warehouse queries and health time series out of the prompt", () => {
     const snapshot: ExperimentSnapshotInterface = {
       ...makeSnapshot(resultVariations),

--- a/packages/back-end/test/ai-prompt.util.test.ts
+++ b/packages/back-end/test/ai-prompt.util.test.ts
@@ -9,7 +9,7 @@ import {
   MAX_METRICS_FOR_AI,
   MAX_QUERY_FILTER_CHARS,
   METRIC_ROLE_RESERVATIONS,
-  summarizeExperimentForAI,
+  summarizeExperimentAnalysisForAI,
 } from "back-end/src/util/ai-prompt.util";
 import { snapshotFactory } from "back-end/test/factories/Snapshot.factory";
 
@@ -46,6 +46,8 @@ const experiment = {
   secondaryMetrics: ["met_revenue"],
   guardrailMetrics: ["met_errors"],
 } as ExperimentInterface;
+
+const srmThreshold = 0.001;
 
 const metricMap = new Map<string, ExperimentMetricInterface>([
   [
@@ -118,15 +120,16 @@ const resultVariations: SnapshotVariation[] = [
   },
 ];
 
-describe("summarizeExperimentForAI", () => {
+describe("summarizeExperimentAnalysisForAI", () => {
   it("summarizes the experiment when there is no snapshot", () => {
-    const summary = summarizeExperimentForAI({
+    const summary = summarizeExperimentAnalysisForAI({
       experiment,
       snapshot: undefined,
       metricMap,
       goalMetricIds: ["met_purchases"],
       secondaryMetricIds: ["met_revenue"],
       guardrailMetricIds: ["met_errors"],
+      srmThreshold,
     });
 
     expect(summary.results).toBeUndefined();
@@ -156,7 +159,7 @@ describe("summarizeExperimentForAI", () => {
   });
 
   it("truncates long free-text fields", () => {
-    const summary = summarizeExperimentForAI({
+    const summary = summarizeExperimentAnalysisForAI({
       experiment: {
         ...experiment,
         hypothesis: "x".repeat(1000),
@@ -169,6 +172,7 @@ describe("summarizeExperimentForAI", () => {
       goalMetricIds: [],
       secondaryMetricIds: [],
       guardrailMetricIds: [],
+      srmThreshold,
     });
 
     expect(summary.experiment.hypothesis).toBe("x".repeat(600) + "…");
@@ -178,13 +182,14 @@ describe("summarizeExperimentForAI", () => {
   });
 
   it("groups results by metric, ordered goal then guardrail then secondary", () => {
-    const summary = summarizeExperimentForAI({
+    const summary = summarizeExperimentAnalysisForAI({
       experiment,
       snapshot: makeSnapshot(resultVariations),
       metricMap,
       goalMetricIds: ["met_purchases"],
       secondaryMetricIds: ["met_revenue"],
       guardrailMetricIds: ["met_errors"],
+      srmThreshold,
     });
 
     expect(summary.results?.statsEngine).toBe("frequentist");
@@ -192,6 +197,7 @@ describe("summarizeExperimentForAI", () => {
     expect(summary.results?.pValueThreshold).toBe(0.05);
     expect(summary.results?.sequentialTesting).toBe(true);
     expect(summary.results?.srmPValue).toBe(0.6324);
+    expect(summary.results?.srmThreshold).toBe(0.001);
     expect(summary.results?.multipleExposures).toBe(3);
     expect(summary.results?.droppedMetrics).toBeUndefined();
 
@@ -219,13 +225,14 @@ describe("summarizeExperimentForAI", () => {
   });
 
   it("marks inverse metrics as better when lower and prefers adjusted stats", () => {
-    const summary = summarizeExperimentForAI({
+    const summary = summarizeExperimentAnalysisForAI({
       experiment,
       snapshot: makeSnapshot(resultVariations),
       metricMap,
       goalMetricIds: ["met_purchases"],
       secondaryMetricIds: ["met_revenue"],
       guardrailMetricIds: ["met_errors"],
+      srmThreshold,
     });
 
     const errors = summary.results?.metrics.find((m) => m.metric === "Errors");
@@ -235,13 +242,14 @@ describe("summarizeExperimentForAI", () => {
   });
 
   it("omits metrics with no results and metrics missing from the metric map", () => {
-    const summary = summarizeExperimentForAI({
+    const summary = summarizeExperimentAnalysisForAI({
       experiment,
       snapshot: makeSnapshot(resultVariations),
       metricMap,
       goalMetricIds: ["met_purchases", "met_deleted"],
       secondaryMetricIds: [],
       guardrailMetricIds: ["met_no_results"],
+      srmThreshold,
     });
 
     expect(summary.results?.metrics.map((m) => m.metric)).toEqual([
@@ -283,17 +291,20 @@ describe("summarizeExperimentForAI", () => {
       },
     ];
 
-    return summarizeExperimentForAI({
+    return summarizeExperimentAnalysisForAI({
       experiment,
       snapshot: makeSnapshot(bigVariations),
       metricMap: bigMetricMap,
       goalMetricIds: goalIds,
       secondaryMetricIds: secondaryIds,
       guardrailMetricIds: guardrailIds,
+      srmThreshold,
     });
   }
 
-  function countByRole(summary: ReturnType<typeof summarizeExperimentForAI>) {
+  function countByRole(
+    summary: ReturnType<typeof summarizeExperimentAnalysisForAI>,
+  ) {
     return (summary.results?.metrics || []).reduce<Record<string, number>>(
       (acc, m) => ({ ...acc, [m.role]: (acc[m.role] || 0) + 1 }),
       {},
@@ -379,13 +390,14 @@ describe("summarizeExperimentForAI", () => {
       },
     } as ExperimentSnapshotInterface["health"];
 
-    const summary = summarizeExperimentForAI({
+    const summary = summarizeExperimentAnalysisForAI({
       experiment,
       snapshot,
       metricMap,
       goalMetricIds: ["met_purchases"],
       secondaryMetricIds: [],
       guardrailMetricIds: [],
+      srmThreshold,
     });
 
     expect(summary.results?.health).toEqual({
@@ -411,26 +423,28 @@ describe("summarizeExperimentForAI", () => {
       },
     } as ExperimentSnapshotInterface["health"];
 
-    const summary = summarizeExperimentForAI({
+    const summary = summarizeExperimentAnalysisForAI({
       experiment,
       snapshot,
       metricMap,
       goalMetricIds: ["met_purchases"],
       secondaryMetricIds: [],
       guardrailMetricIds: [],
+      srmThreshold,
     });
 
     expect(summary.results?.health).toEqual({ isLowPowered: true });
   });
 
   it("omits health entirely when the snapshot has none", () => {
-    const summary = summarizeExperimentForAI({
+    const summary = summarizeExperimentAnalysisForAI({
       experiment,
       snapshot: makeSnapshot(resultVariations),
       metricMap,
       goalMetricIds: ["met_purchases"],
       secondaryMetricIds: [],
       guardrailMetricIds: [],
+      srmThreshold,
     });
 
     expect(summary.results?.health).toBeUndefined();
@@ -442,7 +456,7 @@ describe("summarizeExperimentForAI", () => {
     snapshot.settings.queryFilter = "country = 'US'";
     snapshot.unknownVariations = ["3", "4"];
 
-    const summary = summarizeExperimentForAI({
+    const summary = summarizeExperimentAnalysisForAI({
       experiment,
       snapshot,
       metricMap,
@@ -450,6 +464,7 @@ describe("summarizeExperimentForAI", () => {
       secondaryMetricIds: [],
       guardrailMetricIds: [],
       segmentName: "Logged-in mobile users",
+      srmThreshold,
     });
 
     expect(summary.results?.segment).toBe("Logged-in mobile users");
@@ -461,7 +476,7 @@ describe("summarizeExperimentForAI", () => {
     const snapshot = makeSnapshot(resultVariations);
     snapshot.settings.segment = "seg_123";
 
-    const summary = summarizeExperimentForAI({
+    const summary = summarizeExperimentAnalysisForAI({
       experiment,
       snapshot,
       metricMap,
@@ -469,6 +484,7 @@ describe("summarizeExperimentForAI", () => {
       secondaryMetricIds: [],
       guardrailMetricIds: [],
       segmentName: null,
+      srmThreshold,
     });
 
     expect(summary.results?.segment).toBe("seg_123");
@@ -478,13 +494,14 @@ describe("summarizeExperimentForAI", () => {
     const snapshot = makeSnapshot(resultVariations);
     snapshot.settings.queryFilter = "a".repeat(1000);
 
-    const summary = summarizeExperimentForAI({
+    const summary = summarizeExperimentAnalysisForAI({
       experiment,
       snapshot,
       metricMap,
       goalMetricIds: ["met_purchases"],
       secondaryMetricIds: [],
       guardrailMetricIds: [],
+      srmThreshold,
     });
 
     expect(summary.results?.queryFilter).toBe(
@@ -493,13 +510,14 @@ describe("summarizeExperimentForAI", () => {
   });
 
   it("omits scoping fields when the analysis covered everyone", () => {
-    const summary = summarizeExperimentForAI({
+    const summary = summarizeExperimentAnalysisForAI({
       experiment,
       snapshot: makeSnapshot(resultVariations),
       metricMap,
       goalMetricIds: ["met_purchases"],
       secondaryMetricIds: [],
       guardrailMetricIds: [],
+      srmThreshold,
     });
 
     expect(summary.results?.segment).toBeUndefined();
@@ -569,13 +587,14 @@ describe("summarizeExperimentForAI", () => {
     };
 
     const serialized = JSON.stringify(
-      summarizeExperimentForAI({
+      summarizeExperimentAnalysisForAI({
         experiment,
         snapshot,
         metricMap,
         goalMetricIds: ["met_purchases"],
         secondaryMetricIds: ["met_revenue"],
         guardrailMetricIds: ["met_errors"],
+        srmThreshold,
       }),
     );
 

--- a/packages/back-end/test/ai-prompt.util.test.ts
+++ b/packages/back-end/test/ai-prompt.util.test.ts
@@ -1,0 +1,540 @@
+import { ExperimentInterface } from "shared/types/experiment";
+import {
+  ExperimentSnapshotAnalysis,
+  ExperimentSnapshotInterface,
+  SnapshotVariation,
+} from "shared/types/experiment-snapshot";
+import { ExperimentMetricInterface } from "shared/experiments";
+import {
+  MAX_METRICS_FOR_AI,
+  MAX_QUERY_FILTER_CHARS,
+  METRIC_ROLE_RESERVATIONS,
+  summarizeExperimentForAI,
+} from "back-end/src/util/ai-prompt.util";
+import { snapshotFactory } from "back-end/test/factories/Snapshot.factory";
+
+const experiment = {
+  id: "exp_1",
+  name: "Checkout redesign",
+  status: "stopped",
+  hypothesis: "A shorter checkout converts better",
+  description: "Two-step checkout vs the current four-step flow",
+  analysis: "Looks like a win",
+  variations: [
+    { id: "var_0", key: "0", name: "Control", description: "Current flow" },
+    { id: "var_1", key: "1", name: "Two-step", description: "Shorter flow" },
+  ],
+  phases: [
+    {
+      name: "Ramp",
+      reason: "Ramping up traffic",
+      coverage: 0.1,
+      dateStarted: new Date("2025-12-01T00:00:00Z"),
+      dateEnded: new Date("2026-01-01T00:00:00Z"),
+      variationWeights: [0.5, 0.5],
+    },
+    {
+      name: "Main",
+      reason: "",
+      coverage: 1,
+      dateStarted: new Date("2026-01-01T00:00:00Z"),
+      dateEnded: new Date("2026-02-01T00:00:00Z"),
+      variationWeights: [0.5, 0.5],
+    },
+  ],
+  goalMetrics: ["met_purchases"],
+  secondaryMetrics: ["met_revenue"],
+  guardrailMetrics: ["met_errors"],
+} as ExperimentInterface;
+
+const metricMap = new Map<string, ExperimentMetricInterface>([
+  [
+    "met_purchases",
+    { id: "met_purchases", name: "Purchases", type: "binomial" },
+  ],
+  ["met_revenue", { id: "met_revenue", name: "Revenue", type: "revenue" }],
+  [
+    "met_errors",
+    { id: "met_errors", name: "Errors", type: "count", inverse: true },
+  ],
+] as [string, ExperimentMetricInterface][]);
+
+function makeSnapshot(variations: SnapshotVariation[], srm = 0.63241234) {
+  return snapshotFactory.build({
+    multipleExposures: 3,
+    analyses: [
+      {
+        analysisKey: "default",
+        dateCreated: new Date(),
+        status: "success",
+        settings: {
+          dimensions: [],
+          statsEngine: "frequentist",
+          differenceType: "relative",
+          pValueThreshold: 0.05,
+          sequentialTesting: true,
+          regressionAdjusted: false,
+          numGoalMetrics: 1,
+          numGuardrailMetrics: 1,
+        },
+        results: [{ name: "All", srm, variations }],
+      } as ExperimentSnapshotAnalysis,
+    ],
+  });
+}
+
+const resultVariations: SnapshotVariation[] = [
+  {
+    users: 1000,
+    metrics: {
+      met_purchases: { value: 100, cr: 0.1, users: 1000 },
+      met_revenue: { value: 5000, cr: 5, users: 1000 },
+      met_errors: { value: 20, cr: 0.02, users: 1000 },
+    },
+  },
+  {
+    users: 1010,
+    metrics: {
+      met_purchases: {
+        value: 121,
+        cr: 0.119801980198,
+        users: 1010,
+        expected: 0.198019801980198,
+        ci: [0.0512345678, 0.3512345678],
+        pValue: 0.012345678,
+      },
+      met_revenue: { value: 5600, cr: 5.544554455, users: 1010 },
+      met_errors: {
+        value: 30,
+        cr: 0.0297029703,
+        users: 1010,
+        expected: 0.485148514,
+        ci: [-0.1, 1.1],
+        ciAdjusted: [-0.25, 1.25],
+        pValue: 0.04,
+        pValueAdjusted: 0.09,
+      },
+    },
+  },
+];
+
+describe("summarizeExperimentForAI", () => {
+  it("summarizes the experiment when there is no snapshot", () => {
+    const summary = summarizeExperimentForAI({
+      experiment,
+      snapshot: undefined,
+      metricMap,
+      goalMetricIds: ["met_purchases"],
+      secondaryMetricIds: ["met_revenue"],
+      guardrailMetricIds: ["met_errors"],
+    });
+
+    expect(summary.results).toBeUndefined();
+    expect(summary.experiment).toEqual({
+      id: "exp_1",
+      name: "Checkout redesign",
+      status: "stopped",
+      hypothesis: "A shorter checkout converts better",
+      description: "Two-step checkout vs the current four-step flow",
+      priorAnalysis: "Looks like a win",
+      variations: [
+        { name: "Control", description: "Current flow", weight: 0.5 },
+        { name: "Two-step", description: "Shorter flow", weight: 0.5 },
+      ],
+      startDate: "2026-01-01T00:00:00.000Z",
+      endDate: "2026-02-01T00:00:00.000Z",
+      coverage: 1,
+      priorPhases: [
+        {
+          name: "Ramp",
+          reason: "Ramping up traffic",
+          startDate: "2025-12-01T00:00:00.000Z",
+          endDate: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("truncates long free-text fields", () => {
+    const summary = summarizeExperimentForAI({
+      experiment: {
+        ...experiment,
+        hypothesis: "x".repeat(1000),
+        variations: [
+          { ...experiment.variations[0], description: "y".repeat(1000) },
+        ],
+      },
+      snapshot: undefined,
+      metricMap,
+      goalMetricIds: [],
+      secondaryMetricIds: [],
+      guardrailMetricIds: [],
+    });
+
+    expect(summary.experiment.hypothesis).toBe("x".repeat(600) + "…");
+    expect(summary.experiment.variations[0].description).toBe(
+      "y".repeat(300) + "…",
+    );
+  });
+
+  it("groups results by metric, ordered goal then guardrail then secondary", () => {
+    const summary = summarizeExperimentForAI({
+      experiment,
+      snapshot: makeSnapshot(resultVariations),
+      metricMap,
+      goalMetricIds: ["met_purchases"],
+      secondaryMetricIds: ["met_revenue"],
+      guardrailMetricIds: ["met_errors"],
+    });
+
+    expect(summary.results?.statsEngine).toBe("frequentist");
+    expect(summary.results?.differenceType).toBe("relative");
+    expect(summary.results?.pValueThreshold).toBe(0.05);
+    expect(summary.results?.sequentialTesting).toBe(true);
+    expect(summary.results?.srmPValue).toBe(0.6324);
+    expect(summary.results?.multipleExposures).toBe(3);
+    expect(summary.results?.droppedMetrics).toBeUndefined();
+
+    expect(summary.results?.metrics.map((m) => [m.metric, m.role])).toEqual([
+      ["Purchases", "goal"],
+      ["Errors", "guardrail"],
+      ["Revenue", "secondary"],
+    ]);
+
+    const purchases = summary.results?.metrics[0];
+    expect(purchases?.metricType).toBe("binomial");
+    expect(purchases?.betterDirection).toBe("higher");
+    expect(purchases?.variations).toEqual([
+      { variation: "Control", users: 1000, value: 100, cr: 0.1 },
+      {
+        variation: "Two-step",
+        users: 1010,
+        value: 121,
+        cr: 0.1198,
+        lift: 0.198,
+        ci: [0.0512, 0.3512],
+        pValue: 0.0123,
+      },
+    ]);
+  });
+
+  it("marks inverse metrics as better when lower and prefers adjusted stats", () => {
+    const summary = summarizeExperimentForAI({
+      experiment,
+      snapshot: makeSnapshot(resultVariations),
+      metricMap,
+      goalMetricIds: ["met_purchases"],
+      secondaryMetricIds: ["met_revenue"],
+      guardrailMetricIds: ["met_errors"],
+    });
+
+    const errors = summary.results?.metrics.find((m) => m.metric === "Errors");
+    expect(errors?.betterDirection).toBe("lower");
+    expect(errors?.variations[1].ci).toEqual([-0.25, 1.25]);
+    expect(errors?.variations[1].pValue).toBe(0.09);
+  });
+
+  it("omits metrics with no results and metrics missing from the metric map", () => {
+    const summary = summarizeExperimentForAI({
+      experiment,
+      snapshot: makeSnapshot(resultVariations),
+      metricMap,
+      goalMetricIds: ["met_purchases", "met_deleted"],
+      secondaryMetricIds: [],
+      guardrailMetricIds: ["met_no_results"],
+    });
+
+    expect(summary.results?.metrics.map((m) => m.metric)).toEqual([
+      "Purchases",
+    ]);
+    expect(summary.results?.droppedMetrics).toBeUndefined();
+  });
+
+  function manyMetrics(prefix: string, count: number) {
+    return Array.from({ length: count }, (_, i) => `${prefix}_${i}`);
+  }
+
+  function summarizeManyMetrics({
+    goal,
+    guardrail,
+    secondary,
+  }: {
+    goal: number;
+    guardrail: number;
+    secondary: number;
+  }) {
+    const goalIds = manyMetrics("goal", goal);
+    const guardrailIds = manyMetrics("guardrail", guardrail);
+    const secondaryIds = manyMetrics("secondary", secondary);
+    const allIds = [...goalIds, ...guardrailIds, ...secondaryIds];
+
+    const bigMetricMap = new Map<string, ExperimentMetricInterface>(
+      allIds.map((id) => [
+        id,
+        { id, name: id, type: "binomial" } as ExperimentMetricInterface,
+      ]),
+    );
+    const bigVariations: SnapshotVariation[] = [
+      {
+        users: 100,
+        metrics: Object.fromEntries(
+          allIds.map((id) => [id, { value: 10, cr: 0.1, users: 100 }]),
+        ),
+      },
+    ];
+
+    return summarizeExperimentForAI({
+      experiment,
+      snapshot: makeSnapshot(bigVariations),
+      metricMap: bigMetricMap,
+      goalMetricIds: goalIds,
+      secondaryMetricIds: secondaryIds,
+      guardrailMetricIds: guardrailIds,
+    });
+  }
+
+  function countByRole(summary: ReturnType<typeof summarizeExperimentForAI>) {
+    return (summary.results?.metrics || []).reduce<Record<string, number>>(
+      (acc, m) => ({ ...acc, [m.role]: (acc[m.role] || 0) + 1 }),
+      {},
+    );
+  }
+
+  it("never drops a metric while the cap has room", () => {
+    const summary = summarizeManyMetrics({
+      goal: MAX_METRICS_FOR_AI - 10,
+      guardrail: 5,
+      secondary: 5,
+    });
+
+    expect(summary.results?.metrics).toHaveLength(MAX_METRICS_FOR_AI);
+    expect(summary.results?.droppedMetrics).toBeUndefined();
+  });
+
+  it("lets one role use the whole cap when the others need none", () => {
+    const summary = summarizeManyMetrics({
+      goal: MAX_METRICS_FOR_AI + 50,
+      guardrail: 0,
+      secondary: 0,
+    });
+
+    expect(countByRole(summary)).toEqual({ goal: MAX_METRICS_FOR_AI });
+    expect(summary.results?.droppedMetrics).toEqual({ goal: 50 });
+  });
+
+  it("keeps guardrails when goal metrics would otherwise fill the cap", () => {
+    const goal = MAX_METRICS_FOR_AI + 100;
+    const guardrail = 60;
+    const summary = summarizeManyMetrics({ goal, guardrail, secondary: 0 });
+
+    expect(countByRole(summary)).toEqual({
+      goal: MAX_METRICS_FOR_AI - guardrail,
+      guardrail,
+    });
+    expect(summary.results?.droppedMetrics).toEqual({
+      goal: goal - (MAX_METRICS_FOR_AI - guardrail),
+    });
+  });
+
+  it("falls back to each role's reservation when every role is oversubscribed", () => {
+    const summary = summarizeManyMetrics({
+      goal: 1000,
+      guardrail: 1000,
+      secondary: 1000,
+    });
+
+    expect(countByRole(summary)).toEqual(METRIC_ROLE_RESERVATIONS);
+    expect(summary.results?.droppedMetrics).toEqual({
+      goal: 1000 - METRIC_ROLE_RESERVATIONS.goal,
+      guardrail: 1000 - METRIC_ROLE_RESERVATIONS.guardrail,
+      secondary: 1000 - METRIC_ROLE_RESERVATIONS.secondary,
+    });
+  });
+
+  it("reduces snapshot health to its top-level verdicts", () => {
+    const snapshot = makeSnapshot(resultVariations);
+    snapshot.health = {
+      traffic: {
+        overall: { dimension: "All", variationUnits: [1000, 1010] },
+        dimension: {},
+        error: "TOO_MANY_ROWS",
+      },
+      power: {
+        type: "success",
+        power: 0.42123456,
+        isLowPowered: true,
+        additionalDaysNeeded: 9,
+        metricVariationPowerResults: [],
+      },
+      covariateImbalance: {
+        isImbalanced: false,
+        pValueThreshold: 0.05,
+        numGoalMetrics: 1,
+        numGoalMetricsImbalanced: 0,
+        numGuardrailMetrics: 1,
+        numGuardrailMetricsImbalanced: 0,
+        numSecondaryMetrics: 1,
+        numSecondaryMetricsImbalanced: 0,
+        metricVariationCovariateImbalanceResults: [],
+      },
+    } as ExperimentSnapshotInterface["health"];
+
+    const summary = summarizeExperimentForAI({
+      experiment,
+      snapshot,
+      metricMap,
+      goalMetricIds: ["met_purchases"],
+      secondaryMetricIds: [],
+      guardrailMetricIds: [],
+    });
+
+    expect(summary.results?.health).toEqual({
+      power: 0.4212,
+      isLowPowered: true,
+      additionalDaysNeeded: 9,
+      covariateImbalance: false,
+      trafficError: "TOO_MANY_ROWS",
+    });
+  });
+
+  it("reports low power without a power estimate when the calculation failed", () => {
+    const snapshot = makeSnapshot(resultVariations);
+    snapshot.health = {
+      traffic: {
+        overall: { dimension: "All", variationUnits: [] },
+        dimension: {},
+      },
+      power: {
+        type: "error",
+        isLowPowered: true,
+        metricVariationPowerResults: [],
+      },
+    } as ExperimentSnapshotInterface["health"];
+
+    const summary = summarizeExperimentForAI({
+      experiment,
+      snapshot,
+      metricMap,
+      goalMetricIds: ["met_purchases"],
+      secondaryMetricIds: [],
+      guardrailMetricIds: [],
+    });
+
+    expect(summary.results?.health).toEqual({ isLowPowered: true });
+  });
+
+  it("omits health entirely when the snapshot has none", () => {
+    const summary = summarizeExperimentForAI({
+      experiment,
+      snapshot: makeSnapshot(resultVariations),
+      metricMap,
+      goalMetricIds: ["met_purchases"],
+      secondaryMetricIds: [],
+      guardrailMetricIds: [],
+    });
+
+    expect(summary.results?.health).toBeUndefined();
+  });
+
+  it("reports the segment and query filter that scoped the analysis", () => {
+    const snapshot = makeSnapshot(resultVariations);
+    snapshot.settings.segment = "seg_123";
+    snapshot.settings.queryFilter = "country = 'US'";
+    snapshot.unknownVariations = ["3", "4"];
+
+    const summary = summarizeExperimentForAI({
+      experiment,
+      snapshot,
+      metricMap,
+      goalMetricIds: ["met_purchases"],
+      secondaryMetricIds: [],
+      guardrailMetricIds: [],
+      segmentName: "Logged-in mobile users",
+    });
+
+    expect(summary.results?.segment).toBe("Logged-in mobile users");
+    expect(summary.results?.queryFilter).toBe("country = 'US'");
+    expect(summary.results?.unknownVariations).toEqual(["3", "4"]);
+  });
+
+  it("falls back to the segment id when the segment name is unavailable", () => {
+    const snapshot = makeSnapshot(resultVariations);
+    snapshot.settings.segment = "seg_123";
+
+    const summary = summarizeExperimentForAI({
+      experiment,
+      snapshot,
+      metricMap,
+      goalMetricIds: ["met_purchases"],
+      secondaryMetricIds: [],
+      guardrailMetricIds: [],
+      segmentName: null,
+    });
+
+    expect(summary.results?.segment).toBe("seg_123");
+  });
+
+  it("truncates a long query filter", () => {
+    const snapshot = makeSnapshot(resultVariations);
+    snapshot.settings.queryFilter = "a".repeat(1000);
+
+    const summary = summarizeExperimentForAI({
+      experiment,
+      snapshot,
+      metricMap,
+      goalMetricIds: ["met_purchases"],
+      secondaryMetricIds: [],
+      guardrailMetricIds: [],
+    });
+
+    expect(summary.results?.queryFilter).toBe(
+      "a".repeat(MAX_QUERY_FILTER_CHARS) + "…",
+    );
+  });
+
+  it("omits scoping fields when the analysis covered everyone", () => {
+    const summary = summarizeExperimentForAI({
+      experiment,
+      snapshot: makeSnapshot(resultVariations),
+      metricMap,
+      goalMetricIds: ["met_purchases"],
+      secondaryMetricIds: [],
+      guardrailMetricIds: [],
+    });
+
+    expect(summary.results?.segment).toBeUndefined();
+    expect(summary.results?.queryFilter).toBeUndefined();
+    expect(summary.results?.unknownVariations).toBeUndefined();
+  });
+
+  it("keeps warehouse queries and health time series out of the prompt", () => {
+    const snapshot: ExperimentSnapshotInterface = {
+      ...makeSnapshot(resultVariations),
+      queries: [
+        {
+          query: "SELECT secret_column FROM warehouse",
+          status: "succeeded",
+          name: "results",
+        },
+      ] as unknown as ExperimentSnapshotInterface["queries"],
+      health: {
+        traffic: { overall: { dimension: "All", variationUnits: [1, 2] } },
+      } as unknown as ExperimentSnapshotInterface["health"],
+    };
+
+    const serialized = JSON.stringify(
+      summarizeExperimentForAI({
+        experiment,
+        snapshot,
+        metricMap,
+        goalMetricIds: ["met_purchases"],
+        secondaryMetricIds: ["met_revenue"],
+        guardrailMetricIds: ["met_errors"],
+      }),
+    );
+
+    expect(serialized).not.toContain("secret_column");
+    expect(serialized).not.toContain("variationUnits");
+    expect(serialized.length).toBeLessThan(JSON.stringify(snapshot).length);
+  });
+});


### PR DESCRIPTION
As we pass a lot of information to the experiment results generator, it's easy to go over the token limits. This fix summarizes the experiments more efficiently to not only reduce the chance of hitting the token limits, but also increase the max number of metrics we can analyze. 