### PR TITLE
ci(preview): skip workflow for external PRs

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,7 +14,9 @@ on:
 
 jobs:
   preview:
-    if: ${{ github.repository == 'growthbook/growthbook' }}
+    if: >-
+      github.repository == 'growthbook/growthbook' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
### Features and Changes

- Skip the `preview` job for pull requests opened from forks.

For (very good) security reasons, Action secrets are not included in PRs from forks, so the `preview` job has been failing as it is unable to authenticate with Fly.io.

So we now skip it instead of failing.

In the future we might explore how to have external PRs with automatic preview environment, but it is a bigger lift with additional security considerations.