### PR TITLE
Enforce cookies only contain string values

### DIFF
--- a/packages/back-end/src/controllers/auth.ts
+++ b/packages/back-end/src/controllers/auth.ts
@@ -374,10 +374,17 @@ export async function getResetPassword(
   });
 }
 
-export async function getSSOConnectionFromDomain(req: Request, res: Response) {
+export async function getSSOConnectionFromDomain(
+  // eslint-disable-next-line
+  req: Request<any, any, { domain: unknown }>,
+  res: Response,
+) {
   const { domain } = req.body;
+  if (!domain || typeof domain !== "string") {
+    throw new Error("Invalid domain");
+  }
 
-  const sso = await _dangerousGetSSOConnectionByEmailDomain(domain as string);
+  const sso = await _dangerousGetSSOConnectionByEmailDomain(domain);
 
   if (!sso?.id) {
     throw new Error(`Unknown SSO Connection for *@${domain}`);

--- a/packages/back-end/src/models/AuthRefreshModel.ts
+++ b/packages/back-end/src/models/AuthRefreshModel.ts
@@ -55,7 +55,8 @@ export async function getUserIdFromAuthRefreshToken(
   token: string,
 ): Promise<string> {
   const doc = await AuthRefreshModel.findOne({
-    token,
+    // $eq + String() so a non-string token can never act as a Mongo operator
+    token: { $eq: String(token) },
   });
 
   if (doc) {

--- a/packages/back-end/src/models/ForgotPasswordModel.ts
+++ b/packages/back-end/src/models/ForgotPasswordModel.ts
@@ -72,7 +72,7 @@ export async function getUserIdFromForgotPasswordToken(
   token: string,
 ): Promise<string> {
   const doc = await ForgotPasswordModel.findOne({
-    token,
+    token: { $eq: String(token) },
   });
 
   if (!doc) return "";
@@ -88,6 +88,6 @@ export async function getUserIdFromForgotPasswordToken(
 
 export async function deleteForgotPasswordToken(token: string) {
   return ForgotPasswordModel.deleteOne({
-    token,
+    token: { $eq: String(token) },
   });
 }

--- a/packages/back-end/src/models/SSOConnectionModel.ts
+++ b/packages/back-end/src/models/SSOConnectionModel.ts
@@ -42,7 +42,7 @@ export async function _dangerousGetSSOConnectionById(
   id: string,
 ): Promise<null | SSOConnectionInterface> {
   if (!id) return null;
-  const doc = await SSOConnectionModel.findOne({ id });
+  const doc = await SSOConnectionModel.findOne({ id: { $eq: String(id) } });
 
   return doc ? toInterface(doc) : null;
 }
@@ -59,7 +59,7 @@ export async function _dangerousGetSSOConnectionByEmailDomain(
 ): Promise<null | SSOConnectionInterface> {
   if (!emailDomain) return null;
   const doc = await SSOConnectionModel.findOne({
-    emailDomains: emailDomain,
+    emailDomains: { $eq: String(emailDomain) },
   });
 
   return doc ? toInterface(doc) : null;

--- a/packages/back-end/src/services/auth/LocalAuthConnection.ts
+++ b/packages/back-end/src/services/auth/LocalAuthConnection.ts
@@ -78,7 +78,7 @@ export class LocalAuthConnection implements AuthConnection {
     const refreshToken = RefreshTokenCookie.getValue(req);
     if (refreshToken) {
       await AuthRefreshModel.deleteOne({
-        token: refreshToken,
+        token: { $eq: String(refreshToken) },
       });
     }
     return "";

--- a/packages/back-end/src/util/cookie.ts
+++ b/packages/back-end/src/util/cookie.ts
@@ -43,8 +43,13 @@ class Cookie {
     req.cookies[this.key] = value;
   }
 
-  getValue(req: Request) {
-    return req.cookies[this.key] || "";
+  // cookie-parser JSON-decodes any cookie whose value starts with `j:`, so
+  // req.cookies can hold arbitrary attacker-controlled objects. Never hand one
+  // to a caller — an object reaching a Mongo filter turns into an operator
+  // injection (e.g. `j:{"$ne":""}` matching any refresh token).
+  getValue(req: Request): string {
+    const value = req.cookies[this.key];
+    return typeof value === "string" ? value : "";
   }
 }
 

--- a/packages/back-end/test/util/cookie.test.ts
+++ b/packages/back-end/test/util/cookie.test.ts
@@ -1,6 +1,11 @@
 import jwt from "jsonwebtoken";
 import { Request, Response } from "express";
-import { isIdTokenExpired, setIdTokenCookie } from "back-end/src/util/cookie";
+import {
+  IdTokenCookie,
+  RefreshTokenCookie,
+  isIdTokenExpired,
+  setIdTokenCookie,
+} from "back-end/src/util/cookie";
 
 function makeReqRes() {
   const cookieCalls: {
@@ -69,6 +74,43 @@ describe("setIdTokenCookie", () => {
 
     expect(cookieCalls).toHaveLength(0);
     expect(clearCalls.some((c) => c.name === "AUTH_ID_TOKEN")).toBe(true);
+  });
+});
+
+describe("Cookie.getValue", () => {
+  function reqWithCookies(cookies: Record<string, unknown>) {
+    return { cookies } as unknown as Request;
+  }
+
+  it("returns the value for a normal string cookie", () => {
+    const req = reqWithCookies({ AUTH_REFRESH_TOKEN: "abc123" });
+    expect(RefreshTokenCookie.getValue(req)).toBe("abc123");
+  });
+
+  it("returns an empty string when the cookie is missing", () => {
+    expect(RefreshTokenCookie.getValue(reqWithCookies({}))).toBe("");
+  });
+
+  // cookie-parser turns `AUTH_REFRESH_TOKEN=j:{"$ne":""}` into an object. If it
+  // reached the Mongo filter it would match any refresh token, so it must be
+  // dropped here.
+  it("drops a JSON-decoded object instead of passing it through", () => {
+    const req = reqWithCookies({ AUTH_REFRESH_TOKEN: { $ne: "" } });
+    expect(RefreshTokenCookie.getValue(req)).toBe("");
+  });
+
+  it("drops JSON-decoded arrays and numbers", () => {
+    expect(
+      RefreshTokenCookie.getValue(reqWithCookies({ AUTH_REFRESH_TOKEN: [1] })),
+    ).toBe("");
+    expect(
+      RefreshTokenCookie.getValue(reqWithCookies({ AUTH_REFRESH_TOKEN: 42 })),
+    ).toBe("");
+  });
+
+  it("applies to every cookie, not just the refresh token", () => {
+    const req = reqWithCookies({ AUTH_ID_TOKEN: { $ne: "" } });
+    expect(IdTokenCookie.getValue(req)).toBe("");
   });
 });
 


### PR DESCRIPTION
Enforce that cookie value are always strings to harden against potential security vulnerabilities.