### PR TITLE
fix(experiments): invalidate incremental refresh cache when metric group queries fail

### DIFF
--- a/packages/back-end/src/models/IncrementalRefreshModel.ts
+++ b/packages/back-end/src/models/IncrementalRefreshModel.ts
@@ -2,6 +2,8 @@ import uniqid from "uniqid";
 import { UpdateProps } from "shared/types/base-model";
 import {
   IncrementalRefreshInterface,
+  IncrementalRefreshMetricSourceInterface,
+  IncrementalRefreshMetricCovariateSourceInterface,
   incrementalRefreshValidator,
 } from "shared/validators";
 import { isDuplicateKeyError } from "back-end/src/util/mongo.util";
@@ -253,6 +255,94 @@ export class IncrementalRefreshModel extends BaseClass {
       { $set: { ...data, dateUpdated: new Date() } },
     );
     return result.matchedCount > 0;
+  }
+
+  public async invalidateMetricSourceGroup(
+    experimentId: string,
+    executionId: string,
+    groupId: string,
+  ): Promise<boolean> {
+    const result = await this._dangerousGetCollection().updateOne(
+      {
+        organization: this.context.org.id,
+        experimentId,
+        currentExecutionSnapshotId: executionId,
+      },
+      {
+        $pull: {
+          metricSources: { groupId },
+          metricCovariateSources: { groupId },
+        },
+        $set: { dateUpdated: new Date() },
+      },
+    );
+    return result.matchedCount > 0;
+  }
+
+  /**
+   * MongoDB rejects `$pull` and `$push` on one path, while DocumentDB and
+   * Cosmos reject pipeline updates. The conditional push prevents concurrent
+   * same-group writes from creating duplicates.
+   */
+  private async _upsertSourceGroupEntry(
+    field: "metricSources" | "metricCovariateSources",
+    experimentId: string,
+    executionId: string,
+    entry: { groupId: string },
+  ): Promise<boolean> {
+    const filter = {
+      organization: this.context.org.id,
+      experimentId,
+      currentExecutionSnapshotId: executionId,
+    };
+
+    const collection = this._dangerousGetCollection();
+
+    await collection.updateOne(filter, {
+      $pull: { [field]: { groupId: entry.groupId } },
+    });
+
+    const result = await collection.updateOne(
+      {
+        ...filter,
+        [`${field}.groupId`]: { $ne: entry.groupId },
+      },
+      {
+        $push: { [field]: entry },
+        $set: { dateUpdated: new Date() },
+      },
+    );
+    if (result.matchedCount > 0) return true;
+
+    return (
+      (await collection.findOne(filter, { projection: { _id: 1 } })) !== null
+    );
+  }
+
+  public async upsertMetricSource(
+    experimentId: string,
+    executionId: string,
+    source: IncrementalRefreshMetricSourceInterface,
+  ): Promise<boolean> {
+    return this._upsertSourceGroupEntry(
+      "metricSources",
+      experimentId,
+      executionId,
+      source,
+    );
+  }
+
+  public async upsertMetricCovariateSource(
+    experimentId: string,
+    executionId: string,
+    source: IncrementalRefreshMetricCovariateSourceInterface,
+  ): Promise<boolean> {
+    return this._upsertSourceGroupEntry(
+      "metricCovariateSources",
+      experimentId,
+      executionId,
+      source,
+    );
   }
 
   public async deleteByExperimentIdAndPhase(

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -227,6 +227,7 @@ const startExperimentIncrementalRefreshQueries = async (
     params: StartQueryParams<RowsType, ProcessedRowsType>,
   ) => Promise<QueryPointer>,
   experimentUpdateExecutionLogger: ExperimentUpdateExecutionLogger | null,
+  recordFailedMetricSourceGroup: (groupId: string) => void,
 ): Promise<Queries> => {
   const { snapshotSettings, queryParentId, experimentId, metricMap } = params;
 
@@ -582,8 +583,6 @@ const startExperimentIncrementalRefreshQueries = async (
     integration,
     snapshotSettings,
   });
-  let runningSourceData = existingSources ?? [];
-  let runningCovariateSourceData = existingCovariateSources ?? [];
 
   // Track per-group state we need from the per-FT pass for the cross-FT
   // pair pass below: each pipeline's cache table name (so the stats query
@@ -610,6 +609,10 @@ const startExperimentIncrementalRefreshQueries = async (
     const existingCovariateSource = existingCovariateSources?.find(
       (s) => s.groupId === group.groupId,
     );
+
+    const recordSourceGroupFailure = () => {
+      recordFailedMetricSourceGroup(group.groupId);
+    };
 
     const metricSourceTableFullName: string | undefined =
       existingSource?.tableFullName ??
@@ -666,6 +669,7 @@ const startExperimentIncrementalRefreshQueries = async (
             queryMetadata,
           ),
         ),
+        onFailure: recordSourceGroupFailure,
         queryType: "experimentIncrementalRefreshCreateMetricsSourceTable",
       });
       queries.push(createMetricsSourceQuery);
@@ -697,6 +701,7 @@ const startExperimentIncrementalRefreshQueries = async (
           setExternalId,
           queryMetadata,
         ),
+      onFailure: recordSourceGroupFailure,
       queryType: "experimentIncrementalRefreshInsertMetricsSourceData",
     });
     queries.push(insertMetricsSourceDataQuery);
@@ -747,6 +752,7 @@ const startExperimentIncrementalRefreshQueries = async (
           run: fenced((query, setExternalId, queryMetadata) =>
             integration.runDropTableQuery(query, setExternalId, queryMetadata),
           ),
+          onFailure: recordSourceGroupFailure,
           queryType: "experimentIncrementalRefreshDropMetricsCovariateTable",
         });
         queries.push(dropMetricCovariateTableQuery);
@@ -769,6 +775,7 @@ const startExperimentIncrementalRefreshQueries = async (
               queryMetadata,
             ),
           ),
+          onFailure: recordSourceGroupFailure,
           queryType: "experimentIncrementalRefreshCreateMetricsCovariateTable",
         });
         queries.push(createMetricCovariateTableQuery);
@@ -815,6 +822,7 @@ const startExperimentIncrementalRefreshQueries = async (
             setExternalId,
             queryMetadata,
           ),
+        onFailure: recordSourceGroupFailure,
         onSuccess: async () => {
           const incrementalRefresh =
             await context.models.incrementalRefresh.getLockedBySnapshotId(
@@ -834,22 +842,11 @@ const startExperimentIncrementalRefreshQueries = async (
                   lastSuccessfulMaxTimestamp,
                   tableFullName: metricSourceCovariateTableFullName,
                 };
-          if (!existingCovariateSource) {
-            runningCovariateSourceData = runningCovariateSourceData.concat(
-              updatedCovariateSource,
-            );
-          } else {
-            runningCovariateSourceData = runningCovariateSourceData.map((s) =>
-              s.groupId === group.groupId ? updatedCovariateSource : s,
-            );
-          }
           const lockHeld =
-            await context.models.incrementalRefresh.updateByExperimentIdIfCurrentExecution(
+            await context.models.incrementalRefresh.upsertMetricCovariateSource(
               experimentId,
               executionId,
-              {
-                metricCovariateSources: runningCovariateSourceData,
-              },
+              updatedCovariateSource,
             );
           if (lockHeld !== true) {
             context.logger.warn(
@@ -914,24 +911,7 @@ const startExperimentIncrementalRefreshQueries = async (
       dependencies: [insertMetricsSourceDataQuery.query],
       run: (query, setExternalId, queryMetadata) =>
         integration.runMaxTimestampQuery(query, setExternalId, queryMetadata),
-      onFailure: async () => {
-        // Remove the source from the running data if max timestamp fails
-        runningSourceData = runningSourceData.filter(
-          (s) => s.groupId !== group.groupId,
-        );
-        // Note: onFailure is not awaited by QueryRunner, so we must catch
-        // errors here to avoid unhandled promise rejections.
-        context.models.incrementalRefresh
-          .updateByExperimentIdIfCurrentExecution(experimentId, executionId, {
-            metricSources: runningSourceData,
-          })
-          .catch((e) =>
-            context.logger.error(
-              e,
-              "Failed to update metric sources on query failure",
-            ),
-          );
-      },
+      onFailure: recordSourceGroupFailure,
       onSuccess: async (rows) => {
         const maxTimestamp = new Date(rows[0].max_timestamp as string);
         if (maxTimestamp) {
@@ -959,20 +939,11 @@ const startExperimentIncrementalRefreshQueries = async (
                   })),
                   tableFullName: metricSourceTableFullName,
                 };
-          if (!existingSource) {
-            runningSourceData = runningSourceData.concat(updatedSource);
-          } else {
-            runningSourceData = runningSourceData.map((s) =>
-              s.groupId === group.groupId ? updatedSource : s,
-            );
-          }
           const lockHeld =
-            await context.models.incrementalRefresh.updateByExperimentIdIfCurrentExecution(
+            await context.models.incrementalRefresh.upsertMetricSource(
               experimentId,
               executionId,
-              {
-                metricSources: runningSourceData,
-              },
+              updatedSource,
             );
           if (lockHeld !== true) {
             context.logger.warn(
@@ -1175,6 +1146,7 @@ export class ExperimentIncrementalRefreshQueryRunner extends QueryRunner<
 > {
   private variationNames: string[] = [];
   private metricMap: Map<string, ExperimentMetricInterface> = new Map();
+  private failedMetricSourceGroupIds = new Set<string>();
 
   checkPermissions(): boolean {
     return this.context.permissions.canRunExperimentQueries(
@@ -1191,6 +1163,29 @@ export class ExperimentIncrementalRefreshQueryRunner extends QueryRunner<
           "Failed to refresh incremental refresh lock heartbeat",
         ),
       );
+  }
+
+  protected recordFailedMetricSourceGroup(groupId: string): void {
+    this.failedMetricSourceGroupIds.add(groupId);
+  }
+
+  private async invalidateFailedMetricSourceGroups(): Promise<void> {
+    const results = await Promise.all(
+      [...this.failedMetricSourceGroupIds].map((groupId) =>
+        this.context.models.incrementalRefresh.invalidateMetricSourceGroup(
+          this.model.experiment,
+          this.model.id,
+          groupId,
+        ),
+      ),
+    );
+    if (results.some((lockHeld) => !lockHeld)) {
+      this.context.logger.warn(
+        "Incremental refresh execution lock lost for experiment: " +
+          this.model.experiment,
+      );
+    }
+    this.failedMetricSourceGroupIds.clear();
   }
 
   async startQueries(
@@ -1244,6 +1239,7 @@ export class ExperimentIncrementalRefreshQueryRunner extends QueryRunner<
       this.integration,
       this.startQuery.bind(this),
       this.experimentUpdateExecutionLogger,
+      (groupId) => this.recordFailedMetricSourceGroup(groupId),
     );
   }
 
@@ -1397,6 +1393,8 @@ export class ExperimentIncrementalRefreshQueryRunner extends QueryRunner<
     // Release the incremental refresh lock on any terminal status
     // TODO: Properly handle partially-succeeded status that also becomes terminal??
     if (snapshotStatus !== "running") {
+      await this.invalidateFailedMetricSourceGroups();
+
       if (snapshotStatus === "success") {
         await this.context.models.incrementalRefresh
           .updateByExperimentIdIfCurrentExecution(

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -69,7 +69,7 @@ export type StartQueryParams<Rows, ProcessedRows> = {
   /** @deprecated */
   process?: (rows: Rows) => ProcessedRows;
   onSuccess?: (rows: Rows) => void | Promise<void>;
-  onFailure?: () => void;
+  onFailure?: () => void | Promise<void>;
   queryType: QueryType;
   runAtEnd?: boolean;
 };
@@ -150,7 +150,7 @@ export abstract class QueryRunner<
       ) => Promise<QueryResponse<RowsType>>;
       process?: (rows: RowsType) => ProcessedRowsType;
       onSuccess?: (rows: RowsType) => void | Promise<void>;
-      onFailure: () => void;
+      onFailure: () => void | Promise<void>;
     };
   } = {};
   // Prevent early query completions from refreshing against a partial DAG.
@@ -159,6 +159,7 @@ export abstract class QueryRunner<
   private pendingTimers: Record<string, NodeJS.Timeout> = {};
   private lockHeartbeatTimer: null | NodeJS.Timeout = null;
   private finishedQueryMapCache: QueryMap = new Map();
+  private inFlightTerminalHandlers = new Set<Promise<void>>();
   protected experimentUpdateExecutionLogger: ExperimentUpdateExecutionLogger | null =
     null;
 
@@ -215,6 +216,16 @@ export abstract class QueryRunner<
 
   private hasTimer(id: string): boolean {
     return this.pendingTimers[id] !== undefined;
+  }
+
+  private registerTerminalHandler(handler: () => Promise<void>): void {
+    const terminalHandler = Promise.resolve()
+      .then(handler)
+      .catch((error) => logger.error(error))
+      .finally(() => {
+        this.inFlightTerminalHandlers.delete(terminalHandler);
+      });
+    this.inFlightTerminalHandlers.add(terminalHandler);
   }
 
   // Called periodically while the runner is active. Override to refresh an
@@ -575,6 +586,9 @@ export abstract class QueryRunner<
     );
 
     if (!hasChanges) return queryMap;
+    if (newStatus !== "running") {
+      await Promise.all([...this.inFlightTerminalHandlers]);
+    }
 
     let error: string | undefined = undefined;
     let result: Result | undefined = undefined;
@@ -800,7 +814,7 @@ export abstract class QueryRunner<
         queryMetadata: RunQueryMetadata,
       ) => Promise<QueryResponse<Rows>>;
       process?: (rows: Rows) => ProcessedRows;
-      onFailure: () => void;
+      onFailure: () => void | Promise<void>;
       onSuccess?: (rows: Rows) => void | Promise<void>;
     },
   ): Promise<void> {
@@ -842,10 +856,42 @@ export abstract class QueryRunner<
       });
     };
 
-    run(doc.query, setExternalId, { queryType: doc.queryType || "unknown" })
-      .then(async ({ rows, statistics }) => {
-        clearInterval(timer);
-        logger.debug("Query succeeded: " + doc.id);
+    const finishQuery = async () => {
+      try {
+        await this.onQueryFinish();
+      } catch (error) {
+        logger.error(error);
+      }
+    };
+    const handleFailure = async (error: unknown) => {
+      clearInterval(timer);
+      const message = error instanceof Error ? error.message : String(error);
+      logger.debug("Query failed: " + message);
+      try {
+        const updated = await updateQueryIfRunning(this.context, doc, {
+          finishedAt: new Date(),
+          status: "failed",
+          error: message,
+        });
+        if (!updated) {
+          logger.debug(
+            `Query ${doc.id} failure not written: already terminal (e.g. user cancel)`,
+          );
+        }
+      } catch (updateError) {
+        logger.error(updateError);
+      }
+      try {
+        await onFailure();
+      } catch (failureError) {
+        logger.error(failureError);
+      }
+      await finishQuery();
+    };
+    const handleSuccess = async ({ rows, statistics }: QueryResponse<Rows>) => {
+      clearInterval(timer);
+      logger.debug("Query succeeded: " + doc.id);
+      try {
         await updateQuery(this.context, doc, {
           finishedAt: new Date(),
           status: "succeeded",
@@ -856,28 +902,20 @@ export abstract class QueryRunner<
         if (onSuccess) {
           await onSuccess(rows);
         }
-        this.onQueryFinish();
-      })
-      .catch(async (e) => {
-        clearInterval(timer);
-        logger.debug("Query failed: " + e.message);
-        try {
-          const updated = await updateQueryIfRunning(this.context, doc, {
-            finishedAt: new Date(),
-            status: "failed",
-            error: e.message,
-          });
-          if (!updated) {
-            logger.debug(
-              `Query ${doc.id} failure not written: already terminal (e.g. user cancel)`,
-            );
-          }
-          onFailure();
-          this.onQueryFinish();
-        } catch (err) {
-          logger.error(err);
-        }
-      });
+      } catch (error) {
+        await handleFailure(error);
+        return;
+      }
+      await finishQuery();
+    };
+
+    run(doc.query, setExternalId, {
+      queryType: doc.queryType || "unknown",
+    }).then(
+      (response) => this.registerTerminalHandler(() => handleSuccess(response)),
+      (error: unknown) =>
+        this.registerTerminalHandler(() => handleFailure(error)),
+    );
   }
 
   public async startQuery<

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -503,6 +503,14 @@ export abstract class QueryRunner<
             (q) => q.query,
           )}`,
         });
+        const runCallbacks = this.runCallbacks[query.id];
+        if (runCallbacks?.onFailure) {
+          try {
+            await runCallbacks.onFailure();
+          } catch (failureError) {
+            logger.error(failureError);
+          }
+        }
         this.onQueryFinish();
         continue;
       }

--- a/packages/back-end/test/models/IncrementalRefreshModel.test.ts
+++ b/packages/back-end/test/models/IncrementalRefreshModel.test.ts
@@ -1,5 +1,9 @@
 import mongoose from "mongoose";
 import { MongoMemoryServer } from "mongodb-memory-server";
+import type {
+  IncrementalRefreshMetricCovariateSourceInterface,
+  IncrementalRefreshMetricSourceInterface,
+} from "shared/validators";
 import {
   IncrementalRefreshModel,
   COLLECTION_NAME,
@@ -13,9 +17,23 @@ const context = {
   models: {},
 } as unknown as Context;
 
+const createDeferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+};
+
+class TestIncrementalRefreshModel extends IncrementalRefreshModel {
+  public getCollection() {
+    return this._dangerousGetCollection();
+  }
+}
+
 describe("IncrementalRefreshModel", () => {
   let mongod: MongoMemoryServer;
-  let model: IncrementalRefreshModel;
+  let model: TestIncrementalRefreshModel;
 
   const collection = () => mongoose.connection.db!.collection(COLLECTION_NAME);
 
@@ -68,7 +86,7 @@ describe("IncrementalRefreshModel", () => {
   });
 
   beforeEach(async () => {
-    model = new IncrementalRefreshModel(context);
+    model = new TestIncrementalRefreshModel(context);
     await waitForIndexes();
   });
 
@@ -325,5 +343,147 @@ describe("IncrementalRefreshModel", () => {
 
     const found = await model.getByExperimentIdAndPhase("exp_1", 0);
     expect(found?.experimentId).toBe("exp_1");
+  });
+
+  const source = (
+    groupId: string,
+    tableFullName: string,
+  ): IncrementalRefreshMetricSourceInterface => ({
+    groupId,
+    factTableId: `ft_${groupId}`,
+    metrics: [{ id: `m_${groupId}`, settingsHash: `hash_${groupId}` }],
+    maxTimestamp: null,
+    tableFullName,
+  });
+
+  const covariate = (
+    groupId: string,
+    tableFullName: string,
+  ): IncrementalRefreshMetricCovariateSourceInterface => ({
+    groupId,
+    tableFullName,
+    lastSuccessfulMaxTimestamp: null,
+  });
+
+  const sourcesByGroup = async (snapshotId: string) => {
+    const doc = await model.getLockedBySnapshotId("exp_1", snapshotId);
+    return Object.fromEntries(
+      (doc?.metricSources ?? []).map((s) => [s.groupId, s.tableFullName]),
+    );
+  };
+
+  it("appends a new source group and replaces an existing one, keyed by group", async () => {
+    await acquireLock("exp_1", 0, "snap_0");
+
+    expect(
+      await model.upsertMetricSource("exp_1", "snap_0", source("a", "tbl_a")),
+    ).toBe(true);
+    await model.upsertMetricSource("exp_1", "snap_0", source("b", "tbl_b"));
+    await model.upsertMetricSource("exp_1", "snap_0", source("a", "tbl_a_v2"));
+
+    expect(await sourcesByGroup("snap_0")).toEqual({
+      a: "tbl_a_v2",
+      b: "tbl_b",
+    });
+  });
+
+  it("allows only one conditional push after concurrent same-group pulls", async () => {
+    await acquireLock("exp_1", 0, "snap_0");
+    const mongoCollection = model.getCollection();
+    const updateOne = mongoCollection.updateOne.bind(mongoCollection);
+    const bothPullsFinished = createDeferred();
+    const releasePulls = createDeferred();
+    let completedUpdates = 0;
+    const updateOneSpy = jest
+      .spyOn(mongoCollection, "updateOne")
+      .mockImplementation(async (filter, update, options) => {
+        const result = await updateOne(filter, update, options);
+        completedUpdates += 1;
+        if (completedUpdates <= 2) {
+          if (completedUpdates === 2) bothPullsFinished.resolve();
+          await releasePulls.promise;
+        }
+        return result;
+      });
+
+    try {
+      const first = model.upsertMetricSource(
+        "exp_1",
+        "snap_0",
+        source("a", "tbl_a"),
+      );
+      const second = model.upsertMetricSource(
+        "exp_1",
+        "snap_0",
+        source("a", "tbl_a_v2"),
+      );
+      await bothPullsFinished.promise;
+      releasePulls.resolve();
+      expect(await Promise.all([first, second])).toEqual([true, true]);
+    } finally {
+      releasePulls.resolve();
+      updateOneSpy.mockRestore();
+    }
+
+    const doc = await model.getLockedBySnapshotId("exp_1", "snap_0");
+    expect(doc?.metricSources).toHaveLength(1);
+    expect(doc?.metricSources[0]?.groupId).toBe("a");
+  });
+
+  it("keeps a pulled source group gone when a sibling is upserted", async () => {
+    await acquireLock("exp_1", 0, "snap_0");
+    await model.upsertMetricSource("exp_1", "snap_0", source("a", "tbl_a"));
+    await model.upsertMetricSource("exp_1", "snap_0", source("b", "tbl_b"));
+
+    await model.invalidateMetricSourceGroup("exp_1", "snap_0", "a");
+    await model.upsertMetricSource("exp_1", "snap_0", source("b", "tbl_b_v2"));
+
+    expect(await sourcesByGroup("snap_0")).toEqual({ b: "tbl_b_v2" });
+  });
+
+  it("refuses a source upsert from a non-current execution", async () => {
+    await acquireLock("exp_1", 0, "snap_0");
+    await model.upsertMetricSource("exp_1", "snap_0", source("a", "tbl_a"));
+
+    expect(
+      await model.upsertMetricSource(
+        "exp_1",
+        "snap_stale",
+        source("b", "tbl_b"),
+      ),
+    ).toBe(false);
+    expect(await sourcesByGroup("snap_0")).toEqual({ a: "tbl_a" });
+  });
+
+  it("appends, replaces, and lock-guards covariate sources keyed by group", async () => {
+    await acquireLock("exp_1", 0, "snap_0");
+
+    await model.upsertMetricCovariateSource(
+      "exp_1",
+      "snap_0",
+      covariate("a", "cov_a"),
+    );
+    await model.upsertMetricCovariateSource(
+      "exp_1",
+      "snap_0",
+      covariate("a", "cov_a_v2"),
+    );
+    expect(
+      await model.upsertMetricCovariateSource(
+        "exp_1",
+        "snap_stale",
+        covariate("b", "cov_b"),
+      ),
+    ).toBe(false);
+
+    const doc = await model.getLockedBySnapshotId("exp_1", "snap_0");
+    expect(
+      Object.fromEntries(
+        (doc?.metricCovariateSources ?? []).map((s) => [
+          s.groupId,
+          s.tableFullName,
+        ]),
+      ),
+    ).toEqual({ a: "cov_a_v2" });
   });
 });

--- a/packages/back-end/test/queryRunners/QueryRunner.test.ts
+++ b/packages/back-end/test/queryRunners/QueryRunner.test.ts
@@ -430,6 +430,39 @@ describe("QueryRunner", () => {
       );
     });
 
+    it("invokes onFailure when a query is failed by a failed dependency", async () => {
+      const depFailed = createMockQuery("qry_dep_failed", "failed", []);
+      const queryA = createMockQuery("qry_A", "queued", ["qry_dep_failed"]);
+
+      const model: InterfaceWithQueries = {
+        id: "test-model",
+        organization: "test-org",
+        queries: [
+          { name: "dep_failed", query: "qry_dep_failed", status: "failed" },
+          { name: "A", query: "qry_A", status: "queued" },
+        ],
+        runStarted: new Date(),
+      };
+
+      const runner = new TestQueryRunner(mockContext, model, mockIntegration);
+
+      const onFailure = jest.fn();
+      runner.runCallbacks["qry_A"] = {
+        run: jest.fn().mockResolvedValue({ rows: [], statistics: {} }),
+        process: jest.fn((rows) => rows),
+        onFailure,
+      };
+
+      const queryMap: QueryMap = new Map([
+        ["dep_failed", depFailed],
+        ["A", queryA],
+      ]);
+
+      await runner.startReadyQueries(queryMap);
+
+      expect(onFailure).toHaveBeenCalledTimes(1);
+    });
+
     it("should execute queries when all dependencies succeed", async () => {
       const depSucceeded = createMockQuery("qry_dep_ok", "succeeded", []);
       const queryA = createMockQuery("qry_A", "queued", ["qry_dep_ok"]);

--- a/packages/back-end/test/queryRunners/QueryRunner.test.ts
+++ b/packages/back-end/test/queryRunners/QueryRunner.test.ts
@@ -7,7 +7,12 @@ import {
   getQueryFailureError,
 } from "back-end/src/queryRunners/QueryRunner";
 import { SourceIntegrationInterface } from "back-end/src/types/Integration";
-import { getQueriesByIds, updateQuery } from "back-end/src/models/QueryModel";
+import {
+  getQueriesByIds,
+  updateQuery,
+  updateQueryIfPending,
+  updateQueryIfRunning,
+} from "back-end/src/models/QueryModel";
 
 jest.mock("back-end/src/models/QueryModel");
 
@@ -62,6 +67,54 @@ class TestQueryRunner extends QueryRunner<
     return Promise.resolve();
   }
 }
+
+class ExecutionTestQueryRunner extends QueryRunner<
+  InterfaceWithQueries,
+  object,
+  { success: boolean }
+> {
+  public updateModelSpy = jest.fn();
+  public onQueryFinishSpy = jest.fn();
+
+  checkPermissions() {
+    return true;
+  }
+
+  async startQueries() {
+    return [];
+  }
+
+  async runAnalysis() {
+    return { success: true };
+  }
+
+  async getLatestModel() {
+    return this.model;
+  }
+
+  async updateModel(params: {
+    status: QueryStatus;
+    queries: Queries;
+    runStarted?: Date;
+    result?: { success: boolean };
+    error?: string;
+  }) {
+    this.updateModelSpy(params);
+    return { ...this.model, queries: params.queries };
+  }
+
+  async onQueryFinish() {
+    this.onQueryFinishSpy();
+  }
+}
+
+const createDeferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+};
 
 const createMockQuery = (
   id: string,
@@ -517,6 +570,104 @@ describe("QueryRunner", () => {
           onFailure: expect.any(Function),
         }),
       );
+    });
+  });
+
+  describe("executeQuery", () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("blocks a terminal refresh until asynchronous failure cleanup settles", async () => {
+      const model: InterfaceWithQueries = {
+        id: "test-model",
+        organization: "test-org",
+        queries: [{ name: "failure", query: "qry_failure", status: "running" }],
+        runStarted: new Date(),
+      };
+      const runner = new ExecutionTestQueryRunner(
+        createMockContext(),
+        model,
+        createMockIntegration(),
+      );
+      const cleanupStarted = createDeferred();
+      const allowCleanupToFinish = createDeferred();
+      const statusSnapshotRead = createDeferred();
+      runner.status = "running";
+      (updateQueryIfPending as jest.Mock).mockResolvedValue(true);
+      (updateQueryIfRunning as jest.Mock).mockResolvedValue(true);
+      (getQueriesByIds as jest.Mock).mockImplementation(async () => {
+        statusSnapshotRead.resolve();
+        return [createMockQuery("qry_failure", "failed")];
+      });
+
+      void runner.executeQuery(createMockQuery("qry_failure", "queued"), {
+        run: jest.fn().mockRejectedValue(new Error("warehouse failed")),
+        onFailure: async () => {
+          cleanupStarted.resolve();
+          await allowCleanupToFinish.promise;
+        },
+      });
+
+      await cleanupStarted.promise;
+      const refresh = runner.refreshQueryStatuses();
+      await statusSnapshotRead.promise;
+      await Promise.resolve();
+      expect(runner.model.queries[0]?.status).toBe("failed");
+      expect(runner.updateModelSpy).not.toHaveBeenCalled();
+
+      allowCleanupToFinish.resolve();
+      await refresh;
+      expect(runner.updateModelSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "failed" }),
+      );
+      expect(runner.onQueryFinishSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("blocks a terminal refresh until asynchronous success processing settles", async () => {
+      const model: InterfaceWithQueries = {
+        id: "test-model",
+        organization: "test-org",
+        queries: [{ name: "success", query: "qry_success", status: "running" }],
+        runStarted: new Date(),
+      };
+      const runner = new ExecutionTestQueryRunner(
+        createMockContext(),
+        model,
+        createMockIntegration(),
+      );
+      const processingStarted = createDeferred();
+      const allowProcessingToFinish = createDeferred();
+      const statusSnapshotRead = createDeferred();
+      runner.status = "running";
+      (updateQueryIfPending as jest.Mock).mockResolvedValue(true);
+      (getQueriesByIds as jest.Mock).mockImplementation(async () => {
+        statusSnapshotRead.resolve();
+        return [createMockQuery("qry_success", "succeeded")];
+      });
+
+      void runner.executeQuery(createMockQuery("qry_success", "queued"), {
+        run: jest.fn().mockResolvedValue({ rows: [], statistics: {} }),
+        onFailure: jest.fn(),
+        onSuccess: async () => {
+          processingStarted.resolve();
+          await allowProcessingToFinish.promise;
+        },
+      });
+
+      await processingStarted.promise;
+      const refresh = runner.refreshQueryStatuses();
+      await statusSnapshotRead.promise;
+      await Promise.resolve();
+      expect(runner.model.queries[0]?.status).toBe("succeeded");
+      expect(runner.updateModelSpy).not.toHaveBeenCalled();
+
+      allowProcessingToFinish.resolve();
+      await refresh;
+      expect(runner.updateModelSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "succeeded" }),
+      );
+      expect(runner.onQueryFinishSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/back-end/test/queryRunners/incrementalRefreshMetricSources.test.ts
+++ b/packages/back-end/test/queryRunners/incrementalRefreshMetricSources.test.ts
@@ -1,9 +1,19 @@
 import type { ExperimentSnapshotSettings } from "shared/types/experiment-snapshot";
+import type { ApiReqContext } from "back-end/types/api";
+import type { SourceIntegrationInterface } from "back-end/src/types/Integration";
+import { updateSnapshot } from "back-end/src/models/ExperimentSnapshotModel";
 import {
+  ExperimentIncrementalRefreshQueryRunner,
   getIncrementalRefreshMetricSources,
   MetricSourceGroups,
 } from "back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner";
 import { factMetricFactory } from "../factories/FactMetric.factory";
+import { snapshotFactory } from "../factories/Snapshot.factory";
+
+jest.mock("back-end/src/models/ExperimentSnapshotModel", () => ({
+  findSnapshotById: jest.fn(),
+  updateSnapshot: jest.fn(),
+}));
 
 // `getIncrementalRefreshMetricSources` only reaches into the integration for
 // `getSourceProperties().maxColumns` (used by the chunker). The rest of the
@@ -174,5 +184,99 @@ describe("getIncrementalRefreshMetricSources fan-out", () => {
     // exists and that orientation is recoverable from the metric.
     expect(numGroup).toBeDefined();
     expect(numGroup!.metrics[0].numerator.factTableId).toBe("ft_num");
+  });
+});
+
+const createDeferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+};
+
+class TestableIncrementalRefreshQueryRunner extends ExperimentIncrementalRefreshQueryRunner {
+  public recordFailedGroup(groupId: string): void {
+    this.recordFailedMetricSourceGroup(groupId);
+  }
+}
+
+describe("ExperimentIncrementalRefreshQueryRunner terminal invalidation", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("invalidates recorded groups before materialization and lock release", async () => {
+    const events: string[] = [];
+    const invalidationStarted = createDeferred();
+    const finishInvalidation = createDeferred();
+    const invalidateMetricSourceGroup = jest.fn(async () => {
+      events.push("invalidate-started");
+      invalidationStarted.resolve();
+      await finishInvalidation.promise;
+      events.push("invalidated");
+      return true;
+    });
+    const updateByExperimentIdIfCurrentExecution = jest.fn(async () => {
+      events.push("materialized");
+      return true;
+    });
+    const releaseLock = jest.fn(async () => {
+      events.push("released");
+    });
+    const context = {
+      org: { id: "org_1" },
+      permissions: { canRunExperimentQueries: () => true },
+      logger: { warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+      models: {
+        incrementalRefresh: {
+          invalidateMetricSourceGroup,
+          updateByExperimentIdIfCurrentExecution,
+          releaseLock,
+        },
+      },
+    } as unknown as ApiReqContext;
+    const integration = {
+      datasource: { id: "ds_1", type: "postgres", settings: {} },
+      context: { org: { id: "org_1" } },
+    } as unknown as SourceIntegrationInterface;
+    const snapshot = snapshotFactory.build({
+      id: "snap_1",
+      experiment: "exp_1",
+      status: "running",
+    });
+    const runner = new TestableIncrementalRefreshQueryRunner(
+      context,
+      snapshot,
+      integration,
+    );
+    runner.recordFailedGroup("group_a");
+    (updateSnapshot as jest.Mock).mockImplementation(async () => {
+      events.push("snapshot-updated");
+    });
+
+    const terminalUpdate = runner.updateModel({
+      status: "partially-succeeded",
+      queries: [],
+    });
+    await invalidationStarted.promise;
+    expect(updateByExperimentIdIfCurrentExecution).not.toHaveBeenCalled();
+    expect(releaseLock).not.toHaveBeenCalled();
+
+    finishInvalidation.resolve();
+    await terminalUpdate;
+    expect(events).toEqual([
+      "snapshot-updated",
+      "invalidate-started",
+      "invalidated",
+      "materialized",
+      "released",
+    ]);
+
+    await runner.updateModel({
+      status: "partially-succeeded",
+      queries: [],
+    });
+    expect(invalidateMetricSourceGroup).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
### Features and Changes

For incremental pipeline, we have a lot of different queries that maintain the pipeline cache tables.

This improves how we are handling the invalidation of said caches when query failures happen, so we rebuild the table pipeline (not all tables, just the failed ones) when that happens.

- When any of the metric group query fails during incremental update, invalidate that metric source and covariate source, so next run rebuild it from scratch
- `QueryRunner` now awaits in-flight per-query success/failure handlers before finalizing a terminal snapshot status, so invalidation writes land before the refresh is marked done

### Testing

- Unit tests
