### PR TITLE
Include referenced experiments in project-scoped SDK payloads

### DIFF
--- a/packages/back-end/src/api/features/listFeatures.ts
+++ b/packages/back-end/src/api/features/listFeatures.ts
@@ -14,6 +14,7 @@ import {
 } from "back-end/src/services/features";
 import { resolveOwnerEmails } from "back-end/src/services/owner";
 import { getFeatureDefinitionsWithCache } from "back-end/src/controllers/features";
+import { referencedExperimentIds } from "back-end/src/util/features";
 import {
   applyPagination,
   createApiRequestHandler,
@@ -106,10 +107,7 @@ export async function loadFeaturesPage(
   }
 
   const experimentScope = projectId ? [projectId] : (projectIds ?? undefined);
-  const [groupMap, experimentMap] = await Promise.all([
-    getSavedGroupMap(context),
-    getAllPayloadExperiments(context, experimentScope),
-  ]);
+  const groupMap = await getSavedGroupMap(context);
 
   let filtered: Awaited<ReturnType<typeof getFeaturesPage>>;
   let total: number;
@@ -198,6 +196,13 @@ export async function loadFeaturesPage(
   );
   const safeRolloutMap =
     await context.models.safeRollout.getAllPayloadSafeRollouts();
+
+  // Loaded after the page resolves so the experiments it references come too.
+  const experimentMap = await getAllPayloadExperiments(
+    context,
+    experimentScope,
+    referencedExperimentIds(filtered),
+  );
 
   const hasMore = skipPagination ? false : offset + limit < total;
   const nextOffset = hasMore ? offset + limit : null;

--- a/packages/back-end/src/api/features/listFeatures.ts
+++ b/packages/back-end/src/api/features/listFeatures.ts
@@ -14,7 +14,7 @@ import {
 } from "back-end/src/services/features";
 import { resolveOwnerEmails } from "back-end/src/services/owner";
 import { getFeatureDefinitionsWithCache } from "back-end/src/controllers/features";
-import { referencedRefIds } from "back-end/src/util/features";
+import { getReferenceIdsInFeatures } from "back-end/src/util/features";
 import {
   applyPagination,
   createApiRequestHandler,
@@ -201,7 +201,7 @@ export async function loadFeaturesPage(
   const experimentMap = await getAllPayloadExperiments(
     context,
     experimentScope,
-    referencedRefIds(filtered, "experiment-ref"),
+    getReferenceIdsInFeatures(filtered, "experiment-ref"),
   );
 
   const hasMore = skipPagination ? false : offset + limit < total;

--- a/packages/back-end/src/api/features/listFeatures.ts
+++ b/packages/back-end/src/api/features/listFeatures.ts
@@ -14,7 +14,7 @@ import {
 } from "back-end/src/services/features";
 import { resolveOwnerEmails } from "back-end/src/services/owner";
 import { getFeatureDefinitionsWithCache } from "back-end/src/controllers/features";
-import { referencedExperimentIds } from "back-end/src/util/features";
+import { referencedRefIds } from "back-end/src/util/features";
 import {
   applyPagination,
   createApiRequestHandler,
@@ -201,7 +201,7 @@ export async function loadFeaturesPage(
   const experimentMap = await getAllPayloadExperiments(
     context,
     experimentScope,
-    referencedExperimentIds(filtered),
+    referencedRefIds(filtered, "experiment-ref"),
   );
 
   const hasMore = skipPagination ? false : offset + limit < total;

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -1883,17 +1883,25 @@ export async function getExperimentMapForFeature(
 export async function getAllPayloadExperiments(
   context: ReqContext | ApiReqContext,
   projects?: string[],
+  // Experiments a delivered feature references, wanted whatever project they are in.
+  alsoIncludeIds: string[] = [],
 ): Promise<Map<string, ExperimentInterface>> {
-  const projectFilter =
+  const scoped =
     !projects || !projects.length
-      ? {}
+      ? undefined
       : projects.length === 1
         ? { project: projects[0] }
         : { project: { $in: projects } };
 
+  const scopeFilter = !scoped
+    ? {}
+    : alsoIncludeIds.length
+      ? { $and: [{ $or: [scoped, { id: { $in: alsoIncludeIds } }] }] }
+      : scoped;
+
   const experiments = await findExperiments(context, {
     organization: context.org.id,
-    ...projectFilter,
+    ...scopeFilter,
     archived: { $ne: true },
     $or: [
       {

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -103,6 +103,7 @@ import {
   buildInheritedChildrenByAncestor,
   expandRuleEnvsForInheritance,
   getAffectedSDKPayloadKeys,
+  experimentRefIds,
   getSDKPayloadKeysByDiff,
 } from "back-end/src/util/features";
 import {
@@ -4335,15 +4336,12 @@ export async function createAndPublishRevision({
 function getLinkedExperiments(feature: FeatureInterface) {
   // Keep existing links even when a rule is removed — past revisions need
   // them to render correctly.
-  const expIds: Set<string> = new Set(feature.linkedExperiments || []);
-
-  (feature.rules ?? []).forEach((rule) => {
-    if (rule?.type === "experiment-ref") {
-      expIds.add(rule.experimentId);
-    }
-  });
-
-  return [...expIds];
+  return [
+    ...new Set([
+      ...(feature.linkedExperiments || []),
+      ...experimentRefIds(feature.rules),
+    ]),
+  ];
 }
 
 export async function toggleNeverStale(

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -103,7 +103,7 @@ import {
   buildInheritedChildrenByAncestor,
   expandRuleEnvsForInheritance,
   getAffectedSDKPayloadKeys,
-  ruleRefIds,
+  getReferenceIdsInRules,
   getSDKPayloadKeysByDiff,
 } from "back-end/src/util/features";
 import {
@@ -4339,7 +4339,7 @@ function getLinkedExperiments(feature: FeatureInterface) {
   return [
     ...new Set([
       ...(feature.linkedExperiments || []),
-      ...ruleRefIds(feature.rules, "experiment-ref"),
+      ...getReferenceIdsInRules(feature.rules, "experiment-ref"),
     ]),
   ];
 }

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -103,7 +103,7 @@ import {
   buildInheritedChildrenByAncestor,
   expandRuleEnvsForInheritance,
   getAffectedSDKPayloadKeys,
-  experimentRefIds,
+  ruleRefIds,
   getSDKPayloadKeysByDiff,
 } from "back-end/src/util/features";
 import {
@@ -4339,7 +4339,7 @@ function getLinkedExperiments(feature: FeatureInterface) {
   return [
     ...new Set([
       ...(feature.linkedExperiments || []),
-      ...experimentRefIds(feature.rules),
+      ...ruleRefIds(feature.rules, "experiment-ref"),
     ]),
   ];
 }

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -134,7 +134,7 @@ import {
   getParsedCondition,
   pairedWeightsToPositional,
   experimentMapForFeatures,
-  referencedRefIds,
+  getReferenceIdsInFeatures,
 } from "back-end/src/util/features";
 import { getApplicableEnvIds } from "back-end/src/util/flattenRules";
 import { bucketRulesByEnv } from "back-end/src/util/toLegacy";
@@ -1466,7 +1466,10 @@ export async function buildSDKPayloadForConnection(
   }
 
   let cbMap: Map<string, ContextualBanditInterface> | undefined;
-  const cbIds = referencedRefIds(filteredFeatures, "contextual-bandit-ref");
+  const cbIds = getReferenceIdsInFeatures(
+    filteredFeatures,
+    "contextual-bandit-ref",
+  );
   if (cbIds.length > 0) {
     const cbDocs = await Promise.all(
       cbIds.map((id) => context.models.contextualBandits.getById(id)),
@@ -1614,7 +1617,7 @@ export async function getFeatureDefinitions(
   const experimentMap = await getAllPayloadExperiments(
     context,
     projectFilter,
-    referencedRefIds(allFeatures, "experiment-ref"),
+    getReferenceIdsInFeatures(allFeatures, "experiment-ref"),
   );
   const safeRolloutMap =
     await context.models.safeRollout.getAllPayloadSafeRollouts();

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -133,6 +133,8 @@ import {
   getHoldoutFeatureDefId,
   getParsedCondition,
   pairedWeightsToPositional,
+  experimentMapForFeatures,
+  referencedExperimentIds,
 } from "back-end/src/util/features";
 import { getApplicableEnvIds } from "back-end/src/util/flattenRules";
 import { bucketRulesByEnv } from "back-end/src/util/toLegacy";
@@ -1425,6 +1427,12 @@ export async function buildSDKPayloadForConnection(
         )
       : data.experimentMap;
 
+  const featureExperimentMap = experimentMapForFeatures(
+    data.experimentMap,
+    filteredFeatures,
+    projectList,
+  );
+
   // Fresh cache per connection (one env per connection); keyed by prereq id only
   const prereqStateCache: Record<string, PrerequisiteStateResult> = {};
 
@@ -1485,7 +1493,7 @@ export async function buildSDKPayloadForConnection(
     groupMap: data.groupMap,
     constants: data.constants,
     constantMap: data.constantMap,
-    experimentMap: filteredExperimentMap,
+    experimentMap: featureExperimentMap,
     prereqStateCache,
     safeRolloutMap: data.safeRolloutMap,
     holdoutsMap: holdoutsMapForConnection,
@@ -1612,7 +1620,11 @@ export async function getFeatureDefinitions(
     projects: projectFilter,
   });
   const groupMap = await getSavedGroupMap(context, allSavedGroups);
-  const experimentMap = await getAllPayloadExperiments(context, projectFilter);
+  const experimentMap = await getAllPayloadExperiments(
+    context,
+    projectFilter,
+    referencedExperimentIds(allFeatures),
+  );
   const safeRolloutMap =
     await context.models.safeRollout.getAllPayloadSafeRollouts();
   const holdoutsMap =

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -134,7 +134,7 @@ import {
   getParsedCondition,
   pairedWeightsToPositional,
   experimentMapForFeatures,
-  referencedExperimentIds,
+  referencedRefIds,
 } from "back-end/src/util/features";
 import { getApplicableEnvIds } from "back-end/src/util/flattenRules";
 import { bucketRulesByEnv } from "back-end/src/util/toLegacy";
@@ -1466,16 +1466,7 @@ export async function buildSDKPayloadForConnection(
   }
 
   let cbMap: Map<string, ContextualBanditInterface> | undefined;
-  const cbIdsFromRules: string[] = [];
-  for (const feature of filteredFeatures) {
-    const rules = feature.rules ?? [];
-    for (const rule of rules) {
-      if (rule.type === "contextual-bandit-ref" && rule.contextualBanditId) {
-        cbIdsFromRules.push(rule.contextualBanditId);
-      }
-    }
-  }
-  const cbIds = Array.from(new Set(cbIdsFromRules));
+  const cbIds = referencedRefIds(filteredFeatures, "contextual-bandit-ref");
   if (cbIds.length > 0) {
     const cbDocs = await Promise.all(
       cbIds.map((id) => context.models.contextualBandits.getById(id)),
@@ -1623,7 +1614,7 @@ export async function getFeatureDefinitions(
   const experimentMap = await getAllPayloadExperiments(
     context,
     projectFilter,
-    referencedExperimentIds(allFeatures),
+    referencedRefIds(allFeatures, "experiment-ref"),
   );
   const safeRolloutMap =
     await context.models.safeRollout.getAllPayloadSafeRollouts();

--- a/packages/back-end/src/util/features.ts
+++ b/packages/back-end/src/util/features.ts
@@ -592,6 +592,36 @@ export function getSDKPayloadKeysByDiff(
   return getSDKPayloadKeys(environments, projects);
 }
 
+export function referencedExperimentIds(
+  features: FeatureInterface[],
+): string[] {
+  const ids = new Set<string>();
+  features.forEach((feature) => {
+    (feature.rules ?? []).forEach((rule) => {
+      if (rule.type === "experiment-ref" && rule.enabled !== false) {
+        ids.add(rule.experimentId);
+      }
+    });
+  });
+  return [...ids];
+}
+
+// An experiment a delivered feature references belongs in that feature's payload
+// even when the experiment itself lives in another project.
+export function experimentMapForFeatures(
+  experimentMap: Map<string, ExperimentInterface>,
+  features: FeatureInterface[],
+  projects: string[],
+): Map<string, ExperimentInterface> {
+  if (!projects.length) return experimentMap;
+  const referenced = new Set(referencedExperimentIds(features));
+  return new Map(
+    [...experimentMap.entries()].filter(
+      ([id, exp]) => projects.includes(exp.project || "") || referenced.has(id),
+    ),
+  );
+}
+
 export function getAffectedSDKPayloadKeys(
   features: FeatureInterface[],
   allowedEnvs: string[],

--- a/packages/back-end/src/util/features.ts
+++ b/packages/back-end/src/util/features.ts
@@ -592,26 +592,38 @@ export function getSDKPayloadKeysByDiff(
   return getSDKPayloadKeys(environments, projects);
 }
 
-export function experimentRefIds(
+type RefRuleType = "experiment-ref" | "contextual-bandit-ref";
+
+const REF_ID: Record<RefRuleType, (rule: FeatureRule) => string | undefined> = {
+  "experiment-ref": (r) =>
+    r?.type === "experiment-ref" ? r.experimentId : undefined,
+  "contextual-bandit-ref": (r) =>
+    r?.type === "contextual-bandit-ref" ? r.contextualBanditId : undefined,
+};
+
+export function ruleRefIds(
   rules: FeatureRule[] | undefined,
+  type: RefRuleType,
   { skipDisabled = false }: { skipDisabled?: boolean } = {},
 ): string[] {
   const ids = new Set<string>();
   (rules ?? []).forEach((rule) => {
-    if (rule?.type !== "experiment-ref") return;
-    if (skipDisabled && rule.enabled === false) return;
-    ids.add(rule.experimentId);
+    if (skipDisabled && rule?.enabled === false) return;
+    const id = REF_ID[type](rule);
+    if (id) ids.add(id);
   });
   return [...ids];
 }
 
-export function referencedExperimentIds(
+// Disabled rules never render, so what they reference is not needed.
+export function referencedRefIds(
   features: FeatureInterface[],
+  type: RefRuleType,
 ): string[] {
   return [
     ...new Set(
       features.flatMap((f) =>
-        experimentRefIds(f.rules, { skipDisabled: true }),
+        ruleRefIds(f.rules, type, { skipDisabled: true }),
       ),
     ),
   ];
@@ -625,7 +637,7 @@ export function experimentMapForFeatures(
   projects: string[],
 ): Map<string, ExperimentInterface> {
   if (!projects.length) return experimentMap;
-  const referenced = new Set(referencedExperimentIds(features));
+  const referenced = new Set(referencedRefIds(features, "experiment-ref"));
   return new Map(
     [...experimentMap.entries()].filter(
       ([id, exp]) => projects.includes(exp.project || "") || referenced.has(id),

--- a/packages/back-end/src/util/features.ts
+++ b/packages/back-end/src/util/features.ts
@@ -592,18 +592,29 @@ export function getSDKPayloadKeysByDiff(
   return getSDKPayloadKeys(environments, projects);
 }
 
+export function experimentRefIds(
+  rules: FeatureRule[] | undefined,
+  { skipDisabled = false }: { skipDisabled?: boolean } = {},
+): string[] {
+  const ids = new Set<string>();
+  (rules ?? []).forEach((rule) => {
+    if (rule?.type !== "experiment-ref") return;
+    if (skipDisabled && rule.enabled === false) return;
+    ids.add(rule.experimentId);
+  });
+  return [...ids];
+}
+
 export function referencedExperimentIds(
   features: FeatureInterface[],
 ): string[] {
-  const ids = new Set<string>();
-  features.forEach((feature) => {
-    (feature.rules ?? []).forEach((rule) => {
-      if (rule.type === "experiment-ref" && rule.enabled !== false) {
-        ids.add(rule.experimentId);
-      }
-    });
-  });
-  return [...ids];
+  return [
+    ...new Set(
+      features.flatMap((f) =>
+        experimentRefIds(f.rules, { skipDisabled: true }),
+      ),
+    ),
+  ];
 }
 
 // An experiment a delivered feature references belongs in that feature's payload

--- a/packages/back-end/src/util/features.ts
+++ b/packages/back-end/src/util/features.ts
@@ -601,7 +601,7 @@ const REF_ID: Record<RefRuleType, (rule: FeatureRule) => string | undefined> = {
     r?.type === "contextual-bandit-ref" ? r.contextualBanditId : undefined,
 };
 
-export function ruleRefIds(
+export function getReferenceIdsInRules(
   rules: FeatureRule[] | undefined,
   type: RefRuleType,
   { skipDisabled = false }: { skipDisabled?: boolean } = {},
@@ -616,14 +616,14 @@ export function ruleRefIds(
 }
 
 // Disabled rules never render, so what they reference is not needed.
-export function referencedRefIds(
+export function getReferenceIdsInFeatures(
   features: FeatureInterface[],
   type: RefRuleType,
 ): string[] {
   return [
     ...new Set(
       features.flatMap((f) =>
-        ruleRefIds(f.rules, type, { skipDisabled: true }),
+        getReferenceIdsInRules(f.rules, type, { skipDisabled: true }),
       ),
     ),
   ];
@@ -637,7 +637,9 @@ export function experimentMapForFeatures(
   projects: string[],
 ): Map<string, ExperimentInterface> {
   if (!projects.length) return experimentMap;
-  const referenced = new Set(referencedRefIds(features, "experiment-ref"));
+  const referenced = new Set(
+    getReferenceIdsInFeatures(features, "experiment-ref"),
+  );
   return new Map(
     [...experimentMap.entries()].filter(
       ([id, exp]) => projects.includes(exp.project || "") || referenced.has(id),

--- a/packages/back-end/test/crossProjectExperimentRefs.test.ts
+++ b/packages/back-end/test/crossProjectExperimentRefs.test.ts
@@ -1,0 +1,103 @@
+import type { FeatureInterface } from "shared/types/feature";
+import type { ExperimentInterface } from "back-end/types/experiment";
+import {
+  experimentMapForFeatures,
+  referencedExperimentIds,
+} from "back-end/src/util/features";
+
+const feature = (
+  id: string,
+  project: string,
+  rules: { experimentId: string; enabled?: boolean }[],
+): FeatureInterface =>
+  ({
+    id,
+    project,
+    rules: rules.map((r, i) => ({
+      id: `rule-${i}`,
+      type: "experiment-ref",
+      experimentId: r.experimentId,
+      allEnvironments: true,
+      ...(r.enabled === false ? { enabled: false } : {}),
+    })),
+    environmentSettings: { production: { enabled: true } },
+  }) as unknown as FeatureInterface;
+
+const experiment = (id: string, project: string): ExperimentInterface =>
+  ({ id, project }) as unknown as ExperimentInterface;
+
+describe("referencedExperimentIds", () => {
+  it("collects experiment ids from experiment-ref rules", () => {
+    const features = [
+      feature("f1", "prj_b", [{ experimentId: "exp_a" }]),
+      feature("f2", "prj_b", [{ experimentId: "exp_c" }]),
+    ];
+
+    expect(referencedExperimentIds(features).sort()).toEqual([
+      "exp_a",
+      "exp_c",
+    ]);
+  });
+
+  it("skips disabled rules, which never render", () => {
+    const features = [
+      feature("f1", "prj_b", [{ experimentId: "exp_a", enabled: false }]),
+    ];
+
+    expect(referencedExperimentIds(features)).toEqual([]);
+  });
+
+  it("dedupes an experiment referenced by several features", () => {
+    const features = [
+      feature("f1", "prj_b", [{ experimentId: "exp_a" }]),
+      feature("f2", "prj_b", [{ experimentId: "exp_a" }]),
+    ];
+
+    expect(referencedExperimentIds(features)).toEqual(["exp_a"]);
+  });
+
+  it("ignores features with no rules", () => {
+    expect(referencedExperimentIds([feature("f1", "prj_b", [])])).toEqual([]);
+  });
+});
+
+describe("experimentMapForFeatures", () => {
+  const inProject = experiment("exp_b", "prj_b");
+  const elsewhere = experiment("exp_a", "prj_a");
+  const unrelated = experiment("exp_z", "prj_a");
+  const map = new Map([
+    [inProject.id, inProject],
+    [elsewhere.id, elsewhere],
+    [unrelated.id, unrelated],
+  ]);
+
+  // The point of the change: a delivered feature's experiment travels with it.
+  it("keeps an experiment from another project when a feature references it", () => {
+    const features = [feature("f1", "prj_b", [{ experimentId: "exp_a" }])];
+    const result = experimentMapForFeatures(map, features, ["prj_b"]);
+
+    expect([...result.keys()].sort()).toEqual(["exp_a", "exp_b"]);
+  });
+
+  it("still drops experiments nothing delivered references", () => {
+    const features = [feature("f1", "prj_b", [{ experimentId: "exp_a" }])];
+    const result = experimentMapForFeatures(map, features, ["prj_b"]);
+
+    expect(result.has("exp_z")).toBe(false);
+  });
+
+  it("keeps everything when the connection is not project scoped", () => {
+    const result = experimentMapForFeatures(map, [], []);
+
+    expect(result).toBe(map);
+  });
+
+  it("does not resurrect an experiment referenced only by a disabled rule", () => {
+    const features = [
+      feature("f1", "prj_b", [{ experimentId: "exp_a", enabled: false }]),
+    ];
+    const result = experimentMapForFeatures(map, features, ["prj_b"]);
+
+    expect(result.has("exp_a")).toBe(false);
+  });
+});

--- a/packages/back-end/test/crossProjectExperimentRefs.test.ts
+++ b/packages/back-end/test/crossProjectExperimentRefs.test.ts
@@ -2,7 +2,7 @@ import type { FeatureInterface } from "shared/types/feature";
 import type { ExperimentInterface } from "back-end/types/experiment";
 import {
   experimentMapForFeatures,
-  referencedExperimentIds,
+  referencedRefIds,
 } from "back-end/src/util/features";
 
 const feature = (
@@ -26,14 +26,14 @@ const feature = (
 const experiment = (id: string, project: string): ExperimentInterface =>
   ({ id, project }) as unknown as ExperimentInterface;
 
-describe("referencedExperimentIds", () => {
+describe("referencedRefIds", () => {
   it("collects experiment ids from experiment-ref rules", () => {
     const features = [
       feature("f1", "prj_b", [{ experimentId: "exp_a" }]),
       feature("f2", "prj_b", [{ experimentId: "exp_c" }]),
     ];
 
-    expect(referencedExperimentIds(features).sort()).toEqual([
+    expect(referencedRefIds(features, "experiment-ref").sort()).toEqual([
       "exp_a",
       "exp_c",
     ]);
@@ -44,7 +44,7 @@ describe("referencedExperimentIds", () => {
       feature("f1", "prj_b", [{ experimentId: "exp_a", enabled: false }]),
     ];
 
-    expect(referencedExperimentIds(features)).toEqual([]);
+    expect(referencedRefIds(features, "experiment-ref")).toEqual([]);
   });
 
   it("dedupes an experiment referenced by several features", () => {
@@ -53,11 +53,13 @@ describe("referencedExperimentIds", () => {
       feature("f2", "prj_b", [{ experimentId: "exp_a" }]),
     ];
 
-    expect(referencedExperimentIds(features)).toEqual(["exp_a"]);
+    expect(referencedRefIds(features, "experiment-ref")).toEqual(["exp_a"]);
   });
 
   it("ignores features with no rules", () => {
-    expect(referencedExperimentIds([feature("f1", "prj_b", [])])).toEqual([]);
+    expect(
+      referencedRefIds([feature("f1", "prj_b", [])], "experiment-ref"),
+    ).toEqual([]);
   });
 });
 
@@ -99,5 +101,53 @@ describe("experimentMapForFeatures", () => {
     const result = experimentMapForFeatures(map, features, ["prj_b"]);
 
     expect(result.has("exp_a")).toBe(false);
+  });
+});
+
+describe("referencedRefIds for contextual bandits", () => {
+  const cbFeature = (
+    id: string,
+    rules: { contextualBanditId?: string; enabled?: boolean }[],
+  ): FeatureInterface =>
+    ({
+      id,
+      project: "prj_b",
+      rules: rules.map((r, i) => ({
+        id: `rule-${i}`,
+        type: "contextual-bandit-ref",
+        contextualBanditId: r.contextualBanditId,
+        allEnvironments: true,
+        ...(r.enabled === false ? { enabled: false } : {}),
+      })),
+    }) as unknown as FeatureInterface;
+
+  it("collects contextual bandit ids from the same walk", () => {
+    const features = [
+      cbFeature("f1", [{ contextualBanditId: "cb_1" }]),
+      cbFeature("f2", [{ contextualBanditId: "cb_2" }]),
+    ];
+
+    expect(referencedRefIds(features, "contextual-bandit-ref").sort()).toEqual([
+      "cb_1",
+      "cb_2",
+    ]);
+  });
+
+  it("keeps the two rule types apart", () => {
+    const features = [
+      feature("f1", "prj_b", [{ experimentId: "exp_a" }]),
+      cbFeature("f2", [{ contextualBanditId: "cb_1" }]),
+    ];
+
+    expect(referencedRefIds(features, "experiment-ref")).toEqual(["exp_a"]);
+    expect(referencedRefIds(features, "contextual-bandit-ref")).toEqual([
+      "cb_1",
+    ]);
+  });
+
+  it("ignores a rule with no bandit id", () => {
+    expect(
+      referencedRefIds([cbFeature("f1", [{}])], "contextual-bandit-ref"),
+    ).toEqual([]);
   });
 });

--- a/packages/back-end/test/crossProjectExperimentRefs.test.ts
+++ b/packages/back-end/test/crossProjectExperimentRefs.test.ts
@@ -2,7 +2,7 @@ import type { FeatureInterface } from "shared/types/feature";
 import type { ExperimentInterface } from "back-end/types/experiment";
 import {
   experimentMapForFeatures,
-  referencedRefIds,
+  getReferenceIdsInFeatures,
 } from "back-end/src/util/features";
 
 const feature = (
@@ -26,17 +26,16 @@ const feature = (
 const experiment = (id: string, project: string): ExperimentInterface =>
   ({ id, project }) as unknown as ExperimentInterface;
 
-describe("referencedRefIds", () => {
+describe("getReferenceIdsInFeatures", () => {
   it("collects experiment ids from experiment-ref rules", () => {
     const features = [
       feature("f1", "prj_b", [{ experimentId: "exp_a" }]),
       feature("f2", "prj_b", [{ experimentId: "exp_c" }]),
     ];
 
-    expect(referencedRefIds(features, "experiment-ref").sort()).toEqual([
-      "exp_a",
-      "exp_c",
-    ]);
+    expect(
+      getReferenceIdsInFeatures(features, "experiment-ref").sort(),
+    ).toEqual(["exp_a", "exp_c"]);
   });
 
   it("skips disabled rules, which never render", () => {
@@ -44,7 +43,7 @@ describe("referencedRefIds", () => {
       feature("f1", "prj_b", [{ experimentId: "exp_a", enabled: false }]),
     ];
 
-    expect(referencedRefIds(features, "experiment-ref")).toEqual([]);
+    expect(getReferenceIdsInFeatures(features, "experiment-ref")).toEqual([]);
   });
 
   it("dedupes an experiment referenced by several features", () => {
@@ -53,12 +52,14 @@ describe("referencedRefIds", () => {
       feature("f2", "prj_b", [{ experimentId: "exp_a" }]),
     ];
 
-    expect(referencedRefIds(features, "experiment-ref")).toEqual(["exp_a"]);
+    expect(getReferenceIdsInFeatures(features, "experiment-ref")).toEqual([
+      "exp_a",
+    ]);
   });
 
   it("ignores features with no rules", () => {
     expect(
-      referencedRefIds([feature("f1", "prj_b", [])], "experiment-ref"),
+      getReferenceIdsInFeatures([feature("f1", "prj_b", [])], "experiment-ref"),
     ).toEqual([]);
   });
 });
@@ -104,7 +105,7 @@ describe("experimentMapForFeatures", () => {
   });
 });
 
-describe("referencedRefIds for contextual bandits", () => {
+describe("getReferenceIdsInFeatures for contextual bandits", () => {
   const cbFeature = (
     id: string,
     rules: { contextualBanditId?: string; enabled?: boolean }[],
@@ -127,10 +128,9 @@ describe("referencedRefIds for contextual bandits", () => {
       cbFeature("f2", [{ contextualBanditId: "cb_2" }]),
     ];
 
-    expect(referencedRefIds(features, "contextual-bandit-ref").sort()).toEqual([
-      "cb_1",
-      "cb_2",
-    ]);
+    expect(
+      getReferenceIdsInFeatures(features, "contextual-bandit-ref").sort(),
+    ).toEqual(["cb_1", "cb_2"]);
   });
 
   it("keeps the two rule types apart", () => {
@@ -139,15 +139,20 @@ describe("referencedRefIds for contextual bandits", () => {
       cbFeature("f2", [{ contextualBanditId: "cb_1" }]),
     ];
 
-    expect(referencedRefIds(features, "experiment-ref")).toEqual(["exp_a"]);
-    expect(referencedRefIds(features, "contextual-bandit-ref")).toEqual([
-      "cb_1",
+    expect(getReferenceIdsInFeatures(features, "experiment-ref")).toEqual([
+      "exp_a",
     ]);
+    expect(
+      getReferenceIdsInFeatures(features, "contextual-bandit-ref"),
+    ).toEqual(["cb_1"]);
   });
 
   it("ignores a rule with no bandit id", () => {
     expect(
-      referencedRefIds([cbFeature("f1", [{}])], "contextual-bandit-ref"),
+      getReferenceIdsInFeatures(
+        [cbFeature("f1", [{}])],
+        "contextual-bandit-ref",
+      ),
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
Previously `experiment-ref` rules were dropped from the SDK Payload if the underlying experiment was in a different project than the feature (features in All Projects were unaffected). Fixes by always including referenced experiments irrespective of project alignment. Especially important now that we have targeting projects. Note: this fix also works for `contextual-bandit-ref` rules.