### PR TITLE
refactor(product-analytics): move timestampColumn from FactTableInterface

### DIFF
--- a/packages/shared/src/enterprise/product-analytics/sql.ts
+++ b/packages/shared/src/enterprise/product-analytics/sql.ts
@@ -45,8 +45,8 @@ import {
 // Internal Type definitions
 type MinimalFactTable = Pick<
   FactTableInterface,
-  "sql" | "columns" | "filters" | "userIdTypes" | "timestampColumn"
->;
+  "sql" | "columns" | "filters" | "userIdTypes"
+> & { timestampColumn?: string };
 // Funnel fact metrics are excluded: product-analytics explorations describe
 // their own funnels through the funnel dataset, and a funnel fact metric has no
 // numerator column to roll up.

--- a/packages/shared/types/fact-table.d.ts
+++ b/packages/shared/types/fact-table.d.ts
@@ -100,7 +100,6 @@ export interface FactTableInterface {
   columnRefreshPending?: boolean;
   filters: FactFilterInterface[];
   archived?: boolean;
-  timestampColumn?: string;
   autoSliceUpdatesEnabled?: boolean;
   // Null/undefined means the pipeline is disabled for this fact table.
   aggregatedFactTableSettings?: z.infer<


### PR DESCRIPTION
### Features and Changes

`FactTableInterface` has `timestampColumn?` for Product Analytics, but this value is not persisted for all Fact Tables at all.

Given this is a Product Analytics-only field, we are moving it into the PA-specific type and removing from the overall FactTableInterface to avoid confusion.

### Testing

- type-check passes
- unit tests
