### PR TITLE
fix(results): Separate mouse enter from mouse move in DrilldownTooltip

### DIFF
--- a/packages/front-end/components/Experiment/DrilldownTooltip.tsx
+++ b/packages/front-end/components/Experiment/DrilldownTooltip.tsx
@@ -32,7 +32,7 @@ interface DrilldownTooltipProps {
  */
 export function DrilldownTooltip({ enabled, children }: DrilldownTooltipProps) {
   const { triggerProps, close, renderTooltip } = useHoverTooltip({
-    delayMs: 1500,
+    delayMs: 1250,
     enabled,
     positioning: "cursor",
   });

--- a/packages/front-end/components/Experiment/DrilldownTooltip.tsx
+++ b/packages/front-end/components/Experiment/DrilldownTooltip.tsx
@@ -15,6 +15,7 @@ export function isInteractiveElement(target: HTMLElement): boolean {
 }
 
 interface DrilldownTooltipHandlers {
+  onMouseEnter: (e: React.MouseEvent) => void;
   onMouseMove: (e: React.MouseEvent) => void;
   onMouseLeave: () => void;
   onClick: () => void;
@@ -36,6 +37,18 @@ export function DrilldownTooltip({ enabled, children }: DrilldownTooltipProps) {
     positioning: "cursor",
   });
 
+  const onMouseEnter = useCallback(
+    (e: React.MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (isInteractiveElement(target)) {
+        return;
+      }
+
+      triggerProps.onMouseEnter(e);
+    },
+    [triggerProps],
+  );
+
   const onMouseMove = useCallback(
     (e: React.MouseEvent) => {
       const target = e.target as HTMLElement;
@@ -44,7 +57,6 @@ export function DrilldownTooltip({ enabled, children }: DrilldownTooltipProps) {
         return;
       }
 
-      triggerProps.onMouseEnter(e);
       triggerProps.onMouseMove(e);
     },
     [triggerProps, close],
@@ -53,6 +65,7 @@ export function DrilldownTooltip({ enabled, children }: DrilldownTooltipProps) {
   return (
     <>
       {children({
+        onMouseEnter,
         onMouseMove,
         onMouseLeave: close,
         onClick: close,

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -540,6 +540,7 @@ export default function ResultsTable({
   return (
     <DrilldownTooltip enabled={drilldownEnabled}>
       {({
+        onMouseEnter: onRowMouseEnter,
         onMouseMove: onRowMouseMove,
         onMouseLeave: onRowMouseLeave,
         onClick: onRowClick_,
@@ -827,6 +828,7 @@ export default function ResultsTable({
                                   }
                                 : undefined
                             }
+                            onMouseEnter={onRowMouseEnter}
                             onMouseMove={onRowMouseMove}
                             onMouseLeave={onRowMouseLeave}
                           >

--- a/packages/front-end/hooks/useHoverTooltip.tsx
+++ b/packages/front-end/hooks/useHoverTooltip.tsx
@@ -347,9 +347,13 @@ export function useHoverTooltip({
         }
 
         // Reset the show timer - tooltip only appears after mouse is still
-        if (state === "waiting") {
+        // Also handle idle state so tooltip can re-appear after being dismissed
+        if (state === "waiting" || state === "idle") {
           if (showTimerRef.current) {
             clearTimeout(showTimerRef.current);
+          }
+          if (state === "idle") {
+            setState("waiting");
           }
           showTimerRef.current = setTimeout(() => {
             const success = openTooltip(id);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

The "Click Anywhere in Row" tooltip on the results page was appearing too aggressively because `DrilldownTooltip` was calling `triggerProps.onMouseEnter` on every mouse movement event, causing the hover state to constantly reset.

This fix:
1. **Separates concerns**: `onMouseEnter` is called once when mouse first enters, `onMouseMove` handles subsequent movements
2. **Reduces delay**: Changed from 1500ms to 1250ms (1.25 seconds) as requested
3. **Fixes re-appearance**: Tooltip now correctly re-appears after being dismissed by movement within the same row (by handling "idle" state in cursor mode's `onMouseMove`)

This ensures the tooltip only appears after the user has been hovering still for 1.25 seconds, disappears on movement, and can re-appear after another period of stillness.

### Dependencies

None

### Testing

1. Navigate to an experiment results page with metrics
2. Move your mouse over the results table
3. Verify the "Click anywhere in a row to open the Metric Drilldown" tooltip only appears after holding the mouse still for ~1.25 seconds
4. Move the mouse within the same row - the tooltip should disappear
5. Keep the mouse still again within the same row - tooltip should re-appear after 1.25 seconds
6. Verify the tooltip does NOT appear when quickly moving across the table

### Screenshots

UI behavior change - the tooltip will now only appear after a prolonged hover (1.25s of no mouse movement) and will re-appear after being dismissed if you keep the mouse still again.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C07NK4F016Z/p1787165907542389?thread_ts=1787165907.542389&cid=C07NK4F016Z)

<div><a href="https://cursor.com/agents/bc-54848133-51f7-5b44-963f-7e10b1fac1d9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54848133-51f7-5b44-963f-7e10b1fac1d9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

