### PR TITLE
fix(permissions): check feature publish against serving environments

### DIFF
--- a/.agents/guides/flag-family-authority.md
+++ b/.agents/guides/flag-family-authority.md
@@ -81,8 +81,10 @@ atom that carried the source side:
 
 The footprint is the set of environments a change actually reaches:
 
-- A Feature Flag revision: the environments whose rules or enabled state change,
-  plus any the change re-enables.
+- A Feature Flag revision: the serving environments whose rules change, plus any
+  the change enables or disables. A rule change in a disabled environment reaches
+  no payload, so it needs no authority there. This is the same rule as archive
+  below.
 - A Constant or Config: the per-environment overrides that differ.
 - A Saved Group: none — it is not partitioned by environment.
 - A **revert**: the environments where the _restored_ state differs from

--- a/packages/front-end/test/footprintParity.test.ts
+++ b/packages/front-end/test/footprintParity.test.ts
@@ -70,7 +70,11 @@ const feature = {
 const applicableIds = serveFootprint(environments, feature);
 
 describe("control footprint === endpoint footprint", () => {
-  it("feature publish, rules-only draft: the environments whose rules differ", () => {
+  // staging's rule differs too, but staging is disabled, so dropping its rule
+  // reaches no payload and needs no authority there. A disabled environment enters
+  // the footprint only via a toggle, never via a rule change, the same as qa above
+  // and a feature archive.
+  it("feature publish, rules-only draft: the serving environments whose rules differ", () => {
     expect(
       [
         ...getRevisionPublishEnvs({
@@ -80,7 +84,7 @@ describe("control footprint === endpoint footprint", () => {
           holdoutsMap: new Map(),
         }),
       ].sort(),
-    ).toEqual(["production", "staging"]);
+    ).toEqual(["production"]);
   });
 
   it("feature publish, a global change: everywhere it serves", () => {

--- a/packages/shared/src/permissions/publishFootprint.ts
+++ b/packages/shared/src/permissions/publishFootprint.ts
@@ -114,17 +114,24 @@ export function featurePublishFootprint({
   // `serving` — an `allEnvironments` rule otherwise demands authority over disabled
   // environments it can never reach. An env this draft ENABLES stays covered by the
   // unnarrowed `environmentsEnabled` contribution below.
-  const changedRuleEnvs =
+  const changedRuleEnvsAll =
     changedRules === undefined
       ? []
       : environmentIds.filter(
           (env) =>
-            serving.includes(env) &&
             !isEqual(
               getRulesForEnvironment(liveRules, env),
               getRulesForEnvironment(changedRules, env),
             ),
         );
+  const servingRuleEnvs = changedRuleEnvsAll.filter((env) =>
+    serving.includes(env),
+  );
+  // Never let the narrowing empty the set: the fallback below would then claim
+  // everything the flag serves, which a disabled-env-only edit never touched.
+  const changedRuleEnvs = servingRuleEnvs.length
+    ? servingRuleEnvs
+    : changedRuleEnvsAll;
 
   const envScoped = new Set([
     ...changedRuleEnvs,

--- a/packages/shared/src/permissions/publishFootprint.ts
+++ b/packages/shared/src/permissions/publishFootprint.ts
@@ -110,11 +110,16 @@ export function featurePublishFootprint({
   if (holdoutEnvs === HOLDOUT_ENVS_UNRESOLVED) return [...environmentIds];
 
   const changedRules = changes.rules;
+  // A rule change is only observable where the flag serves, so intersect with
+  // `serving` — an `allEnvironments` rule otherwise demands authority over disabled
+  // environments it can never reach. An env this draft ENABLES stays covered by the
+  // unnarrowed `environmentsEnabled` contribution below.
   const changedRuleEnvs =
     changedRules === undefined
       ? []
       : environmentIds.filter(
           (env) =>
+            serving.includes(env) &&
             !isEqual(
               getRulesForEnvironment(liveRules, env),
               getRulesForEnvironment(changedRules, env),

--- a/packages/shared/test/permissions/publishFootprint.test.ts
+++ b/packages/shared/test/permissions/publishFootprint.test.ts
@@ -111,6 +111,35 @@ describe("featurePublishFootprint", () => {
     ]);
   });
 
+  // Every changed env is disabled, so the narrowing above would empty the set and
+  // fall through to the whole serving list — demanding authority in dev/staging,
+  // which this draft never touched. It stays the environment that was edited.
+  it("keeps the edited environment when the narrowing would empty the set", () => {
+    expect(footprint({ rules: [rule("r1", "production")] })).toEqual([
+      "production",
+    ]);
+  });
+
+  // The `environmentsEnabled` contribution is deliberately not narrowed, so an env
+  // this same draft switches on stays in the footprint.
+  it("counts an environment the draft enables while editing its rules", () => {
+    expect(
+      footprint({
+        rules: [rule("r1", "production")],
+        environmentsEnabled: { production: true },
+      }),
+    ).toEqual(["production"]);
+  });
+
+  it("unions an enabled environment with the serving envs whose rules changed", () => {
+    expect(
+      footprint({
+        rules: [rule("r2", "dev")],
+        environmentsEnabled: { production: true },
+      }),
+    ).toEqual(["dev", "production"]);
+  });
+
   // A global field is felt everywhere, so the footprint is everything the change
   // REACHES — including an environment this same draft switches on. Returning
   // only the already-serving set let a draft that enabled production and edited

--- a/packages/shared/test/permissions/publishFootprint.test.ts
+++ b/packages/shared/test/permissions/publishFootprint.test.ts
@@ -96,6 +96,21 @@ describe("featurePublishFootprint", () => {
     ]);
   });
 
+  // A rule marked `allEnvironments` structurally touches every applicable
+  // environment, including ones the flag is disabled in. The footprint must stay
+  // the serving set — demanding authority over a disabled environment the change
+  // can never reach blocked a feature owner from publishing their own draft.
+  it("counts an allEnvironments rule only where the flag actually serves", () => {
+    const allEnvRule = {
+      ...rule("r1"),
+      allEnvironments: true,
+    } as unknown as FeatureRule;
+    expect(footprint({ rules: [allEnvRule] }, { liveRules: [] })).toEqual([
+      "dev",
+      "staging",
+    ]);
+  });
+
   // A global field is felt everywhere, so the footprint is everything the change
   // REACHES — including an environment this same draft switches on. Returning
   // only the already-serving set let a draft that enabled production and edited


### PR DESCRIPTION
### Features and Changes

A feature draft with an "apply to all environments" rule was requiring permission to all environments, even the ones it is disabled in.

Now they check only against the environment that it'll impact.

### Testing

- Unit test
