### PR TITLE
Prep the attributes table for column customization

### DIFF
--- a/packages/back-end/src/routers/attributes/attributes.router.ts
+++ b/packages/back-end/src/routers/attributes/attributes.router.ts
@@ -21,7 +21,7 @@ router.post(
   "/",
   validateRequestMiddleware({
     body: z.strictObject({
-      property: z.string(),
+      property: z.string().min(1, "Attribute property cannot be empty"),
       description: z.string().optional(),
       datatype: z.enum(attributeDataTypes),
       projects: z.array(z.string()),
@@ -39,7 +39,7 @@ router.put(
   "/",
   validateRequestMiddleware({
     body: z.strictObject({
-      property: z.string(),
+      property: z.string().min(1, "Attribute property cannot be empty"),
       description: z.string().optional(),
       datatype: z.enum(attributeDataTypes),
       projects: z.array(z.string()).optional(),

--- a/packages/front-end/components/Features/AttributeRowMenu.tsx
+++ b/packages/front-end/components/Features/AttributeRowMenu.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useState } from "react";
 import { IconButton } from "@radix-ui/themes";
-import { BsThreeDotsVertical } from "react-icons/bs";
+import { PiDotsThreeVertical } from "react-icons/pi";
 import { SDKAttribute } from "shared/types/organization";
 import {
   DropdownMenu,
@@ -31,13 +31,15 @@ const AttributeRowMenu: FC<{
           radius="full"
           size="2"
           highContrast
+          aria-label={`Actions for attribute ${attribute.property}`}
         >
-          <BsThreeDotsVertical size={18} />
+          <PiDotsThreeVertical size={18} />
         </IconButton>
       }
       open={menuOpen}
       onOpenChange={setMenuOpen}
       menuPlacement="end"
+      variant="soft"
     >
       {!attribute.archived && (
         <DropdownMenuItem
@@ -84,8 +86,7 @@ const AttributeRowMenu: FC<{
             <>
               Are you sure you want to delete the{" "}
               {attribute.hashAttribute ? "identifier " : ""}
-              {attribute.datatype} attribute:{" "}
-              <code className="font-weight-bold">{attribute.property}</code>?
+              {attribute.datatype} attribute: <code>{attribute.property}</code>?
               <br />
               This action cannot be undone.
             </>

--- a/packages/front-end/components/Features/AttributeRowMenu.tsx
+++ b/packages/front-end/components/Features/AttributeRowMenu.tsx
@@ -1,0 +1,101 @@
+import React, { FC, useState } from "react";
+import { IconButton } from "@radix-ui/themes";
+import { BsThreeDotsVertical } from "react-icons/bs";
+import { SDKAttribute } from "shared/types/organization";
+import {
+  DropdownMenu,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/ui/DropdownMenu";
+import { useAuth } from "@/services/auth";
+import { useUser } from "@/services/UserContext";
+import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+
+const AttributeRowMenu: FC<{
+  attribute: SDKAttribute;
+  onEdit: () => void;
+}> = ({ attribute, onEdit }) => {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const { apiCall } = useAuth();
+  const { refreshOrganization } = useUser();
+  const permissionsUtil = usePermissionsUtil();
+
+  if (!permissionsUtil.canCreateAttribute(attribute)) return null;
+
+  return (
+    <DropdownMenu
+      trigger={
+        <IconButton
+          variant="ghost"
+          color="gray"
+          radius="full"
+          size="2"
+          highContrast
+        >
+          <BsThreeDotsVertical size={18} />
+        </IconButton>
+      }
+      open={menuOpen}
+      onOpenChange={setMenuOpen}
+      menuPlacement="end"
+    >
+      {!attribute.archived && (
+        <DropdownMenuItem
+          onClick={() => {
+            onEdit();
+            setMenuOpen(false);
+          }}
+        >
+          Edit
+        </DropdownMenuItem>
+      )}
+      <DropdownMenuItem
+        onClick={async () => {
+          const updatedAttribute: SDKAttribute = {
+            property: attribute.property,
+            datatype: attribute.datatype,
+            archived: !attribute.archived,
+          };
+          await apiCall<{ res: number }>("/attribute", {
+            method: "PUT",
+            body: JSON.stringify(updatedAttribute),
+          });
+          refreshOrganization();
+          setMenuOpen(false);
+        }}
+      >
+        {attribute.archived ? "Unarchive" : "Archive"}
+      </DropdownMenuItem>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem
+        color="red"
+        confirmation={{
+          submit: async () => {
+            await apiCall<{ status: number }>("/attribute/", {
+              method: "DELETE",
+              body: JSON.stringify({ id: attribute.property }),
+            });
+            refreshOrganization();
+          },
+          confirmationTitle: "Delete Attribute",
+          cta: "Delete",
+          ctaColor: "red",
+          getConfirmationContent: async () => (
+            <>
+              Are you sure you want to delete the{" "}
+              {attribute.hashAttribute ? "identifier " : ""}
+              {attribute.datatype} attribute:{" "}
+              <code className="font-weight-bold">{attribute.property}</code>?
+              <br />
+              This action cannot be undone.
+            </>
+          ),
+        }}
+      >
+        Delete
+      </DropdownMenuItem>
+    </DropdownMenu>
+  );
+};
+
+export default AttributeRowMenu;

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -118,9 +118,10 @@ const FeatureAttributesPage = (): React.ReactElement => {
   const [referencesProperty, setReferencesProperty] = useState<string | null>(
     null,
   );
-  const referencesAttribute = referencesProperty
-    ? attributeSchema.find((a) => a.property === referencesProperty)
-    : undefined;
+  const referencesAttribute =
+    referencesProperty !== null
+      ? attributeSchema.find((a) => a.property === referencesProperty)
+      : undefined;
 
   const drawRow = (v: SDKAttribute) => {
     const refs = references?.[v.property];

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -1,24 +1,17 @@
 import React, { useMemo, useState } from "react";
 import { PiInfo } from "react-icons/pi";
-import { Box, Flex, IconButton } from "@radix-ui/themes";
+import { Box, Flex } from "@radix-ui/themes";
 import { BiShow } from "react-icons/bi";
-import { BsThreeDotsVertical } from "react-icons/bs";
 import { SDKAttribute } from "shared/types/organization";
 import Text from "@/ui/Text";
 import Tooltip from "@/components/Tooltip/Tooltip";
-import {
-  DropdownMenu,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-} from "@/ui/DropdownMenu";
 import Modal from "@/components/Modal";
-import { useAuth } from "@/services/auth";
 import { useAttributeSchema } from "@/services/features";
 import AttributeModal from "@/components/Features/AttributeModal";
+import AttributeRowMenu from "@/components/Features/AttributeRowMenu";
 import AttributeReferencesList from "@/components/Features/AttributeReferencesList";
 import ProjectBadges from "@/components/ProjectBadges";
 import { useDefinitions } from "@/services/DefinitionsContext";
-import { useUser } from "@/services/UserContext";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import Button from "@/ui/Button";
 import { useAddComputedFields, useSearch } from "@/services/search";
@@ -86,15 +79,6 @@ const FeatureAttributesPage = (): React.ReactElement => {
 
   const hasArchived = attributeSchema.some((a) => a.archived);
 
-  const attributesWithIndex = useMemo(
-    () =>
-      attributesWithComputedFields.map((a, i) => ({
-        ...a,
-        originalIndex: i,
-      })),
-    [attributesWithComputedFields],
-  );
-
   const {
     items: filteredAttributes,
     searchInputProps,
@@ -102,10 +86,12 @@ const FeatureAttributesPage = (): React.ReactElement => {
     syntaxFilters,
     isFiltered,
     SortableTableColumnHeader,
+    pagination,
   } = useSearch({
-    items: attributesWithIndex,
+    items: attributesWithComputedFields,
     localStorageKey: "attributes",
     defaultSortField: "property",
+    pageSize: 50,
     searchFields: [
       "property^3",
       "description",
@@ -129,97 +115,12 @@ const FeatureAttributesPage = (): React.ReactElement => {
     },
   });
 
-  const [showReferencesModal, setShowReferencesModal] = useState<number | null>(
+  const [referencesProperty, setReferencesProperty] = useState<string | null>(
     null,
   );
-
-  function AttributeRowMenu({
-    v,
-    onEdit,
-  }: {
-    v: SDKAttribute;
-    onEdit: () => void;
-  }) {
-    const [menuOpen, setMenuOpen] = useState(false);
-    const { apiCall: rowApiCall } = useAuth();
-    const { refreshOrganization: rowRefresh } = useUser();
-    const rowPermissions = usePermissionsUtil();
-    if (!rowPermissions.canCreateAttribute(v)) return null;
-    return (
-      <DropdownMenu
-        trigger={
-          <IconButton
-            variant="ghost"
-            color="gray"
-            radius="full"
-            size="2"
-            highContrast
-          >
-            <BsThreeDotsVertical size={18} />
-          </IconButton>
-        }
-        open={menuOpen}
-        onOpenChange={setMenuOpen}
-        menuPlacement="end"
-      >
-        {!v.archived && (
-          <DropdownMenuItem
-            onClick={() => {
-              onEdit();
-              setMenuOpen(false);
-            }}
-          >
-            Edit
-          </DropdownMenuItem>
-        )}
-        <DropdownMenuItem
-          onClick={async () => {
-            const updatedAttribute: SDKAttribute = {
-              property: v.property,
-              datatype: v.datatype,
-              archived: !v.archived,
-            };
-            await rowApiCall<{ res: number }>("/attribute", {
-              method: "PUT",
-              body: JSON.stringify(updatedAttribute),
-            });
-            rowRefresh();
-            setMenuOpen(false);
-          }}
-        >
-          {v.archived ? "Unarchive" : "Archive"}
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem
-          color="red"
-          confirmation={{
-            submit: async () => {
-              await rowApiCall<{ status: number }>("/attribute/", {
-                method: "DELETE",
-                body: JSON.stringify({ id: v.property }),
-              });
-              rowRefresh();
-            },
-            confirmationTitle: "Delete Attribute",
-            cta: "Delete",
-            ctaColor: "red",
-            getConfirmationContent: async () => (
-              <>
-                Are you sure you want to delete the{" "}
-                {v.hashAttribute ? "identifier " : ""}
-                {v.datatype} attribute:{" "}
-                <code className="font-weight-bold">{v.property}</code>?
-                <br />
-                This action cannot be undone.
-              </>
-            ),
-          }}
-        >
-          Delete
-        </DropdownMenuItem>
-      </DropdownMenu>
-    );
-  }
+  const referencesAttribute = referencesProperty
+    ? attributeSchema.find((a) => a.property === referencesProperty)
+    : undefined;
 
   const drawRow = (v: SDKAttribute) => {
     const refs = references?.[v.property];
@@ -301,12 +202,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
         <TableCell className="text-gray">
           {numReferences > 0 ? (
             <Link
-              onClick={() => {
-                const schemaIndex = attributeSchema.findIndex(
-                  (a) => a.property === v.property,
-                );
-                if (schemaIndex >= 0) setShowReferencesModal(schemaIndex);
-              }}
+              onClick={() => setReferencesProperty(v.property)}
               style={{ whiteSpace: "nowrap" }}
             >
               <BiShow /> {numReferences} reference
@@ -330,7 +226,10 @@ const FeatureAttributesPage = (): React.ReactElement => {
           <Flex justify="center">{v.hashAttribute && <>yes</>}</Flex>
         </TableCell>
         <TableCell>
-          <AttributeRowMenu v={v} onEdit={() => setModalData(v.property)} />
+          <AttributeRowMenu
+            attribute={v}
+            onEdit={() => setModalData(v.property)}
+          />
         </TableCell>
       </TableRow>
     );
@@ -367,7 +266,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
                   />
                 </Box>
                 <AttributeSearchFilters
-                  attributes={attributesWithIndex}
+                  attributes={attributesWithComputedFields}
                   searchInputProps={searchInputProps}
                   setSearchValue={setSearchValue}
                   syntaxFilters={syntaxFilters}
@@ -439,37 +338,34 @@ const FeatureAttributesPage = (): React.ReactElement => {
               )}
             </TableBody>
           </Table>
+          {pagination}
         </Box>
       </Box>
-      {showReferencesModal !== null &&
-        attributeSchema?.[showReferencesModal] && (
-          <Modal
-            header={`'${attributeSchema[showReferencesModal].property}' References`}
-            trackingEventModalType="show-attribute-references"
-            close={() => setShowReferencesModal(null)}
-            open={true}
-            closeCta="Close"
-          >
-            <Text as="p" mb="3">
-              This attribute is referenced by the following features,
-              experiments, and condition groups.
-            </Text>
-            <AttributeReferencesList
-              features={
-                references?.[attributeSchema[showReferencesModal].property]
-                  ?.features ?? []
-              }
-              experiments={
-                references?.[attributeSchema[showReferencesModal].property]
-                  ?.experiments ?? []
-              }
-              conditionGroups={
-                references?.[attributeSchema[showReferencesModal].property]
-                  ?.savedGroups ?? []
-              }
-            />
-          </Modal>
-        )}
+      {referencesAttribute && (
+        <Modal
+          header={`'${referencesAttribute.property}' References`}
+          trackingEventModalType="show-attribute-references"
+          close={() => setReferencesProperty(null)}
+          open={true}
+          closeCta="Close"
+        >
+          <Text as="p" mb="3">
+            This attribute is referenced by the following features, experiments,
+            and condition groups.
+          </Text>
+          <AttributeReferencesList
+            features={
+              references?.[referencesAttribute.property]?.features ?? []
+            }
+            experiments={
+              references?.[referencesAttribute.property]?.experiments ?? []
+            }
+            conditionGroups={
+              references?.[referencesAttribute.property]?.savedGroups ?? []
+            }
+          />
+        </Modal>
+      )}
       {modalData !== null && (
         <AttributeModal
           close={() => setModalData(null)}


### PR DESCRIPTION
### Features and Changes

Groundwork for #6713 and #6716, split out so those read cleanly.

`AttributeRowMenu` moves out of the page component so re-renders stop remounting it and losing its open state, and the references modal is keyed by property rather than an array index. The internal `POST`/`PUT /attribute` now require `property` to be at least one character, as the REST API already does.

### Testing

- [x] Open a row's kebab menu, let references load -> menu stays open
- [x] Click "N references" on several rows -> modal shows that row's attribute
- [x] `PUT /attribute` with `property: ""` -> 400
