### PR TITLE
Let users show, hide and reorder Attributes table columns

### DIFF
--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardEditorSidebar/MetricExperimentsSettings.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardEditorSidebar/MetricExperimentsSettings.tsx
@@ -26,7 +26,7 @@ import SelectField from "@/components/Forms/SelectField";
 import MultiSelectField from "@/ui/MultiSelectField";
 import { resolveMetricExperimentColumns } from "@/components/MetricExperiments/MetricExperiments";
 import { DATE_RANGE_PREDEFINED_LABELS } from "@/enterprise/components/ProductAnalytics/dateRangeLabels";
-import MetricExperimentsColumnSettings from "./MetricExperimentsColumnSettings";
+import ColumnSettings from "@/ui/ColumnSettings";
 import BlockDateRangePicker from "./BlockDateRangePicker";
 import SidebarSettingField from "./SidebarSettingField";
 import DashboardFilterInheritTag from "./DashboardFilterInheritTag";
@@ -315,7 +315,7 @@ export default function MetricExperimentsSettings({
                       column is always shown.
                     </Text>
                   </Box>
-                  <MetricExperimentsColumnSettings
+                  <ColumnSettings
                     columns={resolvedColumns.map((c) => ({
                       id: c.id,
                       label: c.label,

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardEditorSidebar/MetricExperimentsSettings.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardEditorSidebar/MetricExperimentsSettings.tsx
@@ -9,12 +9,11 @@ import {
   withBlockGlobalFilterFollowing,
 } from "shared/enterprise";
 import { ExplorationDateRange } from "shared/validators";
-import React, { useState } from "react";
+import React from "react";
 import { Box, Flex } from "@radix-ui/themes";
 import { PiSlidersHorizontal } from "react-icons/pi";
 import Text from "@/ui/Text";
 import Link from "@/ui/Link";
-import { Popover } from "@/ui/Popover";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useExperiments } from "@/hooks/useExperiments";
 import SidebarExperimentFilters, {
@@ -26,7 +25,7 @@ import SelectField from "@/components/Forms/SelectField";
 import MultiSelectField from "@/ui/MultiSelectField";
 import { resolveMetricExperimentColumns } from "@/components/MetricExperiments/MetricExperiments";
 import { DATE_RANGE_PREDEFINED_LABELS } from "@/enterprise/components/ProductAnalytics/dateRangeLabels";
-import ColumnSettings from "@/ui/ColumnSettings";
+import ColumnSettingsButton from "@/ui/ColumnSettingsButton";
 import BlockDateRangePicker from "./BlockDateRangePicker";
 import SidebarSettingField from "./SidebarSettingField";
 import DashboardFilterInheritTag from "./DashboardFilterInheritTag";
@@ -66,7 +65,6 @@ export default function MetricExperimentsSettings({
 }: Props) {
   const { projects: allProjects } = useDefinitions();
   const { experiments } = useExperiments();
-  const [columnsOpen, setColumnsOpen] = useState(false);
 
   // A field inherits only if the block opted in AND the dashboard has a value.
   const projectsSet = globalFilterIsSet(dashboardGlobalControls, "projects");
@@ -295,10 +293,16 @@ export default function MetricExperimentsSettings({
             </Text>
           </Box>
           <Box style={{ flexShrink: 0 }}>
-            <Popover
-              open={columnsOpen}
-              onOpenChange={setColumnsOpen}
-              align="end"
+            {/* The hidden count is already in the summary to the left, and this
+                sidebar row wants a Link rather than the toolbar trigger. */}
+            <ColumnSettingsButton
+              columns={resolvedColumns.map((c) => ({
+                id: c.id,
+                label: c.label,
+                visible: c.visible,
+              }))}
+              onChange={(columns) => setBlock({ ...block, columns })}
+              note="The Experiment column is always shown."
               trigger={
                 <Link size="sm" style={{ whiteSpace: "nowrap" }}>
                   <Flex align="center" gap="1">
@@ -306,24 +310,6 @@ export default function MetricExperimentsSettings({
                     Edit
                   </Flex>
                 </Link>
-              }
-              content={
-                <Box style={{ width: 260 }}>
-                  <Box mb="2">
-                    <Text size="sm" color="text-low">
-                      Drag to reorder or toggle visibility. The Experiment
-                      column is always shown.
-                    </Text>
-                  </Box>
-                  <ColumnSettings
-                    columns={resolvedColumns.map((c) => ({
-                      id: c.id,
-                      label: c.label,
-                      visible: c.visible,
-                    }))}
-                    onChange={(columns) => setBlock({ ...block, columns })}
-                  />
-                </Box>
               }
             />
           </Box>

--- a/packages/front-end/hooks/useTableColumns.ts
+++ b/packages/front-end/hooks/useTableColumns.ts
@@ -1,0 +1,105 @@
+import { useCallback, useMemo, useRef } from "react";
+import {
+  isLayoutCustomized,
+  mergeLayoutForWrite,
+  resolveTableColumns,
+  ResolvedTableColumn,
+  TableColumnDef,
+  TableColumnLayout,
+} from "@/services/tableColumns";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
+
+export interface UseTableColumnsReturn<TRow> {
+  /** All columns in their effective order, hidden ones included. */
+  columns: ResolvedTableColumn<TRow>[];
+  visibleColumns: ResolvedTableColumn<TRow>[];
+  colSpan: number;
+  hiddenCount: number;
+  isCustomized: boolean;
+  /** Apply order and visibility in a single write. */
+  applySettings: (ordered: { id: string; visible: boolean }[]) => void;
+  setWidth: (id: string, width: number | undefined) => void;
+  reset: () => void;
+  /** Live `<col>` nodes, keyed by column id, for imperative width writes. */
+  colRefs: React.MutableRefObject<Map<string, HTMLTableColElement | null>>;
+}
+
+/**
+ * Column order, visibility and width for a table, persisted per browser.
+ *
+ * The storage key mirrors useSearch's `${localStorageKey}:sort-dir` convention,
+ * so a page's persisted table state reads as one family.
+ */
+export function useTableColumns<TRow>({
+  storageKey,
+  columns: defs,
+}: {
+  storageKey: string;
+  columns: TableColumnDef<TRow>[];
+}): UseTableColumnsReturn<TRow> {
+  const [layout, setLayout] = useLocalStorage<TableColumnLayout | null>(
+    `${storageKey}:columns`,
+    null,
+  );
+
+  const colRefs = useRef<Map<string, HTMLTableColElement | null>>(new Map());
+
+  const columns = useMemo(
+    () => resolveTableColumns(defs, layout),
+    [defs, layout],
+  );
+
+  const visibleColumns = useMemo(
+    () => columns.filter((col) => col.visible),
+    [columns],
+  );
+
+  const write = useCallback(
+    (next: ResolvedTableColumn<TRow>[]) => {
+      setLayout((prev) => mergeLayoutForWrite(next, prev));
+    },
+    [setLayout],
+  );
+
+  const applySettings = useCallback(
+    (ordered: { id: string; visible: boolean }[]) => {
+      const byId = new Map(columns.map((col) => [col.id, col]));
+      const next = ordered
+        .map(({ id, visible }) => {
+          const col = byId.get(id);
+          return col ? { ...col, visible } : undefined;
+        })
+        .filter((col): col is ResolvedTableColumn<TRow> => !!col);
+      // Columns the caller didn't mention keep their relative position rather
+      // than being dropped.
+      columns.forEach((col, i) => {
+        if (!ordered.some((o) => o.id === col.id)) next.splice(i, 0, col);
+      });
+      write(next);
+    },
+    [columns, write],
+  );
+
+  const setWidth = useCallback(
+    (id: string, width: number | undefined) => {
+      write(columns.map((col) => (col.id === id ? { ...col, width } : col)));
+    },
+    [columns, write],
+  );
+
+  // Writing null rather than a defaults blob, so later changes to the code
+  // defaults still reach users who have reset.
+  const reset = useCallback(() => setLayout(null), [setLayout]);
+
+  return {
+    columns,
+    visibleColumns,
+    colSpan: visibleColumns.length,
+    hiddenCount: columns.length - visibleColumns.length,
+    isCustomized: isLayoutCustomized(defs, columns),
+    applySettings,
+    setWidth,
+    reset,
+    colRefs,
+  };
+}

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -282,7 +282,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
         locked: true,
         resizable: false,
         render: (v) => (
-          <Flex justify="end">
+          <Flex justify="center">
             <AttributeRowMenu
               attribute={v}
               onEdit={() => setModalData(v.property)}
@@ -307,7 +307,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
   // Lives in the empty row-actions header rather than the filter toolbar, which
   // is for data filters.
   const columnSettings = (
-    <Flex justify="end">
+    <Flex justify="center">
       <ColumnSettingsButton
         columns={columns
           // Locked columns can't be hidden or moved, so listing them is noise.

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -2,7 +2,6 @@ import React, { useMemo, useState } from "react";
 import { PiInfo } from "react-icons/pi";
 import { Box, Flex } from "@radix-ui/themes";
 import { BiShow } from "react-icons/bi";
-import { SDKAttribute } from "shared/types/organization";
 import Text from "@/ui/Text";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import Modal from "@/components/Modal";
@@ -30,6 +29,9 @@ import Table, {
   TableCell,
 } from "@/ui/Table";
 import Heading from "@/ui/Heading";
+import ColumnSettingsButton from "@/ui/ColumnSettingsButton";
+import { useTableColumns } from "@/hooks/useTableColumns";
+import { TableColumnDef } from "@/services/tableColumns";
 
 const ATTRIBUTE_NAME_COLUMN_MAX_WIDTH = 200;
 const TAGS_COLUMN_MAX_WIDTH = 160;
@@ -123,74 +125,92 @@ const FeatureAttributesPage = (): React.ReactElement => {
       ? attributeSchema.find((a) => a.property === referencesProperty)
       : undefined;
 
-  const drawRow = (v: SDKAttribute) => {
-    const refs = references?.[v.property];
-    const numReferences =
-      (refs?.features.length ?? 0) +
-      (refs?.experiments.length ?? 0) +
-      (refs?.savedGroups.length ?? 0);
+  type AttributeRow = (typeof attributesWithComputedFields)[number];
 
-    return (
-      <TableRow
-        className={v.archived ? "disabled" : ""}
-        key={"attr-row-" + v.property}
-      >
-        <TableCell
-          className="text-gray font-weight-bold"
-          style={{ maxWidth: ATTRIBUTE_NAME_COLUMN_MAX_WIDTH }}
-        >
-          <Link
-            href={`/attributes/${encodeURIComponent(v.property)}`}
-            style={{ color: "var(--gray-12)" }}
-          >
-            <TruncateMiddleWithTooltip
-              text={v.property}
-              maxChars={23}
-              maxWidth={ATTRIBUTE_NAME_COLUMN_MAX_WIDTH}
-            />
-          </Link>{" "}
-          {v.archived && (
-            <span className="badge badge-secondary" style={{ marginLeft: 8 }}>
-              archived
-            </span>
-          )}
-        </TableCell>
-        <TableCell
-          className="text-gray"
-          style={{ maxWidth: 200, overflow: "hidden" }}
-        >
-          {v.description ? (
+  const columnDefs = useMemo<TableColumnDef<AttributeRow>[]>(
+    () => [
+      {
+        id: "property",
+        label: "Attribute",
+        sortField: "property",
+        locked: true,
+        defaultWidth: ATTRIBUTE_NAME_COLUMN_MAX_WIDTH,
+        cellProps: () => ({ className: "text-gray font-weight-bold" }),
+        render: (v) => (
+          <>
+            <Link
+              href={`/attributes/${encodeURIComponent(v.property)}`}
+              style={{ color: "var(--gray-12)" }}
+            >
+              <TruncateMiddleWithTooltip
+                text={v.property}
+                maxChars={23}
+                maxWidth={ATTRIBUTE_NAME_COLUMN_MAX_WIDTH}
+              />
+            </Link>{" "}
+            {v.archived && (
+              <span className="badge badge-secondary" style={{ marginLeft: 8 }}>
+                archived
+              </span>
+            )}
+          </>
+        ),
+      },
+      {
+        id: "description",
+        label: "Description",
+        sortField: "description",
+        defaultWidth: 200,
+        cellProps: () => ({
+          className: "text-gray",
+          style: { overflow: "hidden" },
+        }),
+        render: (v) =>
+          v.description ? (
             <Markdown className="mb-0">{v.description}</Markdown>
-          ) : null}
-        </TableCell>
-        <TableCell className="text-gray" style={{ wordWrap: "break-word" }}>
-          {v.datatype}
-          {v.datatype === "enum" && <>: ({v.enum})</>}
-          {v.format && (
-            <p className="my-0">
-              <small>(format: {v.format})</small>
-            </p>
-          )}
-        </TableCell>
-        <TableCell style={{ paddingRight: "1rem" }}>
+          ) : null,
+      },
+      {
+        id: "datatype",
+        label: "Data Type",
+        sortField: "datatype",
+        cellProps: () => ({
+          className: "text-gray",
+          style: { wordWrap: "break-word" },
+        }),
+        render: (v) => (
+          <>
+            {v.datatype}
+            {v.datatype === "enum" && <>: ({v.enum})</>}
+            {v.format && (
+              <p className="my-0">
+                <small>(format: {v.format})</small>
+              </p>
+            )}
+          </>
+        ),
+      },
+      {
+        id: "projects",
+        label: "Projects",
+        headerProps: { style: { paddingRight: "1rem" } },
+        cellProps: () => ({ style: { paddingRight: "1rem" } }),
+        render: (v) => (
           <ProjectBadges
             resourceType="attribute"
             projectIds={(v.projects || []).length > 0 ? v.projects : undefined}
           />
-        </TableCell>
-        <TableCell
-          style={{
-            maxWidth: TAGS_COLUMN_MAX_WIDTH,
-            overflow: "hidden",
-          }}
-        >
+        ),
+      },
+      {
+        id: "tags",
+        label: "Tags",
+        defaultWidth: TAGS_COLUMN_MAX_WIDTH,
+        cellProps: () => ({ style: { overflow: "hidden" } }),
+        render: (v) => (
           <div
             className="tags-cell-content"
-            style={{
-              minWidth: 0,
-              maxWidth: "100%",
-              overflow: "hidden",
-            }}
+            style={{ minWidth: 0, maxWidth: "100%", overflow: "hidden" }}
           >
             <SortedTags
               tags={v.tags || []}
@@ -199,9 +219,20 @@ const FeatureAttributesPage = (): React.ReactElement => {
               truncateTagChars={15}
             />
           </div>
-        </TableCell>
-        <TableCell className="text-gray">
-          {numReferences > 0 ? (
+        ),
+      },
+      {
+        id: "references",
+        label: "References",
+        cellProps: () => ({ className: "text-gray" }),
+        render: (v) => {
+          const refs = references?.[v.property];
+          const numReferences =
+            (refs?.features.length ?? 0) +
+            (refs?.experiments.length ?? 0) +
+            (refs?.savedGroups.length ?? 0);
+
+          return numReferences > 0 ? (
             <Link
               onClick={() => setReferencesProperty(v.property)}
               style={{ whiteSpace: "nowrap" }}
@@ -221,20 +252,56 @@ const FeatureAttributesPage = (): React.ReactElement => {
                 <BiShow /> 0 references
               </span>
             </Tooltip>
-          )}
-        </TableCell>
-        <TableCell className="text-gray">
+          );
+        },
+      },
+      {
+        id: "hashAttribute",
+        label: "Identifier",
+        header: (
+          <>
+            Identifier{" "}
+            <Tooltip
+              body="Any attribute that uniquely identifies a user, account, device, or similar."
+              popperStyle={{ textAlign: "left" }}
+            >
+              <PiInfo style={{ position: "relative", top: "-1px" }} />
+            </Tooltip>
+          </>
+        ),
+        align: "center",
+        cellProps: () => ({ className: "text-gray" }),
+        render: (v) => (
           <Flex justify="center">{v.hashAttribute && <>yes</>}</Flex>
-        </TableCell>
-        <TableCell>
+        ),
+      },
+      {
+        id: "actions",
+        label: "Row actions",
+        header: null,
+        locked: true,
+        resizable: false,
+        headerProps: { className: "text-center" },
+        render: (v) => (
           <AttributeRowMenu
             attribute={v}
             onEdit={() => setModalData(v.property)}
           />
-        </TableCell>
-      </TableRow>
-    );
-  };
+        ),
+      },
+    ],
+    [references],
+  );
+
+  const {
+    columns,
+    visibleColumns,
+    colSpan,
+    hiddenCount,
+    isCustomized,
+    applySettings,
+    reset,
+  } = useTableColumns({ storageKey: "attributes", columns: columnDefs });
 
   return (
     <>
@@ -266,13 +333,32 @@ const FeatureAttributesPage = (): React.ReactElement => {
                     {...searchInputProps}
                   />
                 </Box>
-                <AttributeSearchFilters
-                  attributes={attributesWithComputedFields}
-                  searchInputProps={searchInputProps}
-                  setSearchValue={setSearchValue}
-                  syntaxFilters={syntaxFilters}
-                  hasArchived={hasArchived}
-                />
+                <Flex gap="5" align="center">
+                  <AttributeSearchFilters
+                    attributes={attributesWithComputedFields}
+                    searchInputProps={searchInputProps}
+                    setSearchValue={setSearchValue}
+                    syntaxFilters={syntaxFilters}
+                    hasArchived={hasArchived}
+                  />
+                  <ColumnSettingsButton
+                    columns={columns
+                      // The row-actions column has no header and can't be
+                      // hidden or moved, so listing it is pure noise.
+                      .filter((c) => c.header !== null)
+                      .map((c) => ({
+                        id: c.id,
+                        label: c.label,
+                        visible: c.visible,
+                        locked: c.locked,
+                      }))}
+                    hiddenCount={hiddenCount}
+                    canReset={isCustomized}
+                    onReset={reset}
+                    onChange={applySettings}
+                    lockedNote="The Attribute column is always shown."
+                  />
+                </Flex>
               </Flex>
             </Box>
           )}
@@ -284,47 +370,64 @@ const FeatureAttributesPage = (): React.ReactElement => {
           >
             <TableHeader>
               <TableRow>
-                <SortableTableColumnHeader
-                  field="property"
-                  style={{ maxWidth: ATTRIBUTE_NAME_COLUMN_MAX_WIDTH }}
-                >
-                  Attribute
-                </SortableTableColumnHeader>
-                <SortableTableColumnHeader
-                  field="description"
-                  style={{ maxWidth: 200 }}
-                >
-                  Description
-                </SortableTableColumnHeader>
-                <SortableTableColumnHeader field="datatype">
-                  Data Type
-                </SortableTableColumnHeader>
-                <TableColumnHeader style={{ paddingRight: "1rem" }}>
-                  Projects
-                </TableColumnHeader>
-                <TableColumnHeader style={{ maxWidth: TAGS_COLUMN_MAX_WIDTH }}>
-                  Tags
-                </TableColumnHeader>
-                <TableColumnHeader>References</TableColumnHeader>
-                <TableColumnHeader style={{ textAlign: "center" }}>
-                  Identifier{" "}
-                  <Tooltip
-                    body="Any attribute that uniquely identifies a user, account, device, or similar."
-                    popperStyle={{ textAlign: "left" }}
-                  >
-                    <PiInfo style={{ position: "relative", top: "-1px" }} />
-                  </Tooltip>
-                </TableColumnHeader>
-                <TableColumnHeader className="text-center" />
+                {visibleColumns.map((col) =>
+                  col.sortField ? (
+                    <SortableTableColumnHeader
+                      key={col.id}
+                      field={col.sortField}
+                      className={col.headerProps?.className}
+                      style={{
+                        maxWidth: col.width,
+                        textAlign: col.align,
+                        ...col.headerProps?.style,
+                      }}
+                    >
+                      {col.header !== undefined ? col.header : col.label}
+                    </SortableTableColumnHeader>
+                  ) : (
+                    <TableColumnHeader
+                      key={col.id}
+                      className={col.headerProps?.className}
+                      style={{
+                        maxWidth: col.width,
+                        textAlign: col.align,
+                        ...col.headerProps?.style,
+                      }}
+                    >
+                      {col.header !== undefined ? col.header : col.label}
+                    </TableColumnHeader>
+                  ),
+                )}
               </TableRow>
             </TableHeader>
             <TableBody>
               {attributeSchema?.length > 0 ? (
                 <>
-                  {filteredAttributes.map((v) => drawRow(v))}
+                  {filteredAttributes.map((v) => (
+                    <TableRow
+                      className={v.archived ? "disabled" : ""}
+                      key={"attr-row-" + v.property}
+                    >
+                      {visibleColumns.map((col) => {
+                        const { className, style } = col.cellProps?.(v) ?? {};
+                        return (
+                          <TableCell
+                            key={col.id}
+                            className={className}
+                            style={{ maxWidth: col.width, ...style }}
+                          >
+                            {col.render(v)}
+                          </TableCell>
+                        );
+                      })}
+                    </TableRow>
+                  ))}
                   {!filteredAttributes.length && isFiltered && (
                     <TableRow>
-                      <TableCell colSpan={8} className="text-center text-gray">
+                      <TableCell
+                        colSpan={colSpan}
+                        className="text-center text-gray"
+                      >
                         No matching attributes found.
                       </TableCell>
                     </TableRow>
@@ -332,7 +435,10 @@ const FeatureAttributesPage = (): React.ReactElement => {
                 </>
               ) : (
                 <TableRow>
-                  <TableCell colSpan={8} className="text-center text-gray">
+                  <TableCell
+                    colSpan={colSpan}
+                    className="text-center text-gray"
+                  >
                     <em>No attributes defined.</em>
                   </TableCell>
                 </TableRow>

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -133,7 +133,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
         id: "property",
         label: "Attribute",
         sortField: "property",
-        locked: true,
+        hideable: false,
         defaultWidth: ATTRIBUTE_NAME_COLUMN_MAX_WIDTH,
         cellProps: () => ({ className: "text-gray font-weight-bold" }),
         render: (v) => (
@@ -350,7 +350,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
                         id: c.id,
                         label: c.label,
                         visible: c.visible,
-                        locked: c.locked,
+                        alwaysVisible: c.locked || c.hideable === false,
                       }))}
                     hiddenCount={hiddenCount}
                     canReset={isCustomized}

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -31,7 +31,7 @@ import Table, {
 import Heading from "@/ui/Heading";
 import ColumnSettingsButton from "@/ui/ColumnSettingsButton";
 import { useTableColumns } from "@/hooks/useTableColumns";
-import { TableColumnDef } from "@/services/tableColumns";
+import { ResolvedTableColumn, TableColumnDef } from "@/services/tableColumns";
 
 const ATTRIBUTE_NAME_COLUMN_MAX_WIDTH = 200;
 const TAGS_COLUMN_MAX_WIDTH = 160;
@@ -281,12 +281,13 @@ const FeatureAttributesPage = (): React.ReactElement => {
         header: null,
         locked: true,
         resizable: false,
-        headerProps: { className: "text-center" },
         render: (v) => (
-          <AttributeRowMenu
-            attribute={v}
-            onEdit={() => setModalData(v.property)}
-          />
+          <Flex justify="end">
+            <AttributeRowMenu
+              attribute={v}
+              onEdit={() => setModalData(v.property)}
+            />
+          </Flex>
         ),
       },
     ],
@@ -302,6 +303,36 @@ const FeatureAttributesPage = (): React.ReactElement => {
     applySettings,
     reset,
   } = useTableColumns({ storageKey: "attributes", columns: columnDefs });
+
+  // Lives in the empty row-actions header rather than the filter toolbar, which
+  // is for data filters.
+  const columnSettings = (
+    <Flex justify="end">
+      <ColumnSettingsButton
+        columns={columns
+          // Locked columns can't be hidden or moved, so listing them is noise.
+          .filter((c) => !c.locked)
+          .map((c) => ({
+            id: c.id,
+            label: c.label,
+            visible: c.visible,
+            alwaysVisible: c.hideable === false,
+          }))}
+        hiddenCount={hiddenCount}
+        canReset={isCustomized}
+        onReset={reset}
+        onChange={applySettings}
+        note="The Attribute column is always shown."
+      />
+    </Flex>
+  );
+
+  const renderHeader = (col: ResolvedTableColumn<AttributeRow>) =>
+    col.id === "actions"
+      ? columnSettings
+      : col.header !== undefined
+        ? col.header
+        : col.label;
 
   return (
     <>
@@ -333,32 +364,13 @@ const FeatureAttributesPage = (): React.ReactElement => {
                     {...searchInputProps}
                   />
                 </Box>
-                <Flex gap="5" align="center">
-                  <AttributeSearchFilters
-                    attributes={attributesWithComputedFields}
-                    searchInputProps={searchInputProps}
-                    setSearchValue={setSearchValue}
-                    syntaxFilters={syntaxFilters}
-                    hasArchived={hasArchived}
-                  />
-                  <ColumnSettingsButton
-                    columns={columns
-                      // The row-actions column has no header and can't be
-                      // hidden or moved, so listing it is pure noise.
-                      .filter((c) => c.header !== null)
-                      .map((c) => ({
-                        id: c.id,
-                        label: c.label,
-                        visible: c.visible,
-                        alwaysVisible: c.locked || c.hideable === false,
-                      }))}
-                    hiddenCount={hiddenCount}
-                    canReset={isCustomized}
-                    onReset={reset}
-                    onChange={applySettings}
-                    note="The Attribute column is always shown."
-                  />
-                </Flex>
+                <AttributeSearchFilters
+                  attributes={attributesWithComputedFields}
+                  searchInputProps={searchInputProps}
+                  setSearchValue={setSearchValue}
+                  syntaxFilters={syntaxFilters}
+                  hasArchived={hasArchived}
+                />
               </Flex>
             </Box>
           )}
@@ -382,7 +394,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
                         ...col.headerProps?.style,
                       }}
                     >
-                      {col.header !== undefined ? col.header : col.label}
+                      {renderHeader(col)}
                     </SortableTableColumnHeader>
                   ) : (
                     <TableColumnHeader
@@ -394,7 +406,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
                         ...col.headerProps?.style,
                       }}
                     >
-                      {col.header !== undefined ? col.header : col.label}
+                      {renderHeader(col)}
                     </TableColumnHeader>
                   ),
                 )}

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -356,7 +356,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
                     canReset={isCustomized}
                     onReset={reset}
                     onChange={applySettings}
-                    lockedNote="The Attribute column is always shown."
+                    note="The Attribute column is always shown."
                   />
                 </Flex>
               </Flex>

--- a/packages/front-end/pages/design-system/index.tsx
+++ b/packages/front-end/pages/design-system/index.tsx
@@ -11,6 +11,8 @@ import BadgeStories from "@/ui/Badge.stories";
 import BreadcrumbsStories from "@/ui/Breadcrumbs.stories";
 import ButtonStories from "@/ui/Button.stories";
 import CalloutStories from "@/ui/Callout.stories";
+import ColumnSettingsStories from "@/ui/ColumnSettings.stories";
+import ColumnSettingsButtonStories from "@/ui/ColumnSettingsButton.stories";
 import CheckboxStories from "@/ui/Checkbox.stories";
 import DataListStories from "@/ui/DataList.stories";
 import DatePickerStories from "@/ui/DatePicker.stories";
@@ -75,6 +77,11 @@ export default function DesignSystemPage() {
     { name: "Breadcrumbs", Stories: BreadcrumbsStories },
     { name: "Button", Stories: ButtonStories },
     { name: "Callout", Stories: CalloutStories },
+    { name: "ColumnSettings", Stories: ColumnSettingsStories },
+    {
+      name: "ColumnSettingsButton",
+      Stories: ColumnSettingsButtonStories,
+    },
     { name: "Checkbox", Stories: CheckboxStories },
     { name: "DataList", Stories: DataListStories },
     { name: "DatePicker", Stories: DatePickerStories },

--- a/packages/front-end/services/tableColumns.ts
+++ b/packages/front-end/services/tableColumns.ts
@@ -1,0 +1,192 @@
+import type { CSSProperties, ReactNode } from "react";
+
+const MIN_TABLE_COLUMN_WIDTH = 64;
+const MAX_TABLE_COLUMN_WIDTH = 800;
+// Floor applied even when a column declares a smaller minWidth.
+const HARD_MIN_TABLE_COLUMN_WIDTH = 40;
+
+const TABLE_COLUMN_LAYOUT_VERSION = 1;
+
+export interface TableColumnDef<TRow> {
+  /** Stable persisted identity. Never reuse an id for a different column. */
+  id: string;
+  /** Plain text — used in the settings list and aria labels. */
+  label: string;
+  /** Rich header content (e.g. label plus an info tooltip). Defaults to `label`. */
+  header?: ReactNode;
+  /** When set, the header renders as a sortable header for this field. */
+  sortField?: keyof TRow & string;
+  /**
+   * px. Under a fixed table layout, exactly one visible column should omit this
+   * and absorb the remaining horizontal slack.
+   */
+  defaultWidth?: number;
+  minWidth?: number;
+  maxWidth?: number;
+  /** Cannot be hidden and cannot be moved — pinned to its position in code. */
+  locked?: boolean;
+  hideable?: boolean;
+  resizable?: boolean;
+  /** Starts hidden until the user opts in. */
+  defaultHidden?: boolean;
+  align?: "left" | "center" | "right";
+  headerProps?: { className?: string; style?: CSSProperties };
+  cellProps?: (row: TRow) => { className?: string; style?: CSSProperties };
+  render: (row: TRow) => ReactNode;
+}
+
+export interface TableColumnLayoutEntry {
+  id: string;
+  visible: boolean;
+  width?: number;
+}
+
+/** Versioned so a future server-side store can accept the blob verbatim. */
+export interface TableColumnLayout {
+  v: number;
+  columns: TableColumnLayoutEntry[];
+}
+
+export type ResolvedTableColumn<TRow> = TableColumnDef<TRow> & {
+  visible: boolean;
+  width?: number;
+};
+
+function isHideable<TRow>(def: TableColumnDef<TRow>): boolean {
+  return !def.locked && def.hideable !== false;
+}
+
+function clampWidth<TRow>(
+  def: TableColumnDef<TRow>,
+  width: number | undefined,
+): number | undefined {
+  if (width === undefined || !Number.isFinite(width) || width <= 0) {
+    return undefined;
+  }
+  const min = Math.max(
+    def.minWidth ?? MIN_TABLE_COLUMN_WIDTH,
+    HARD_MIN_TABLE_COLUMN_WIDTH,
+  );
+  const max = def.maxWidth ?? MAX_TABLE_COLUMN_WIDTH;
+  return Math.min(Math.max(width, min), Math.max(min, max));
+}
+
+function defaultsFor<TRow>(
+  defs: TableColumnDef<TRow>[],
+): ResolvedTableColumn<TRow>[] {
+  return defs.map((def) => ({
+    ...def,
+    visible: isHideable(def) ? !def.defaultHidden : true,
+    width: clampWidth(def, def.defaultWidth),
+  }));
+}
+
+/**
+ * Resolve the effective ordered column list from a stored layout.
+ *
+ * Stored ids are applied in their saved order. Ids that no longer exist in code
+ * are dropped. Columns missing from the layout are spliced in next to their
+ * neighbour in code rather than appended, so a newly added column doesn't land
+ * after the row-actions column. Locked columns are forced visible and forced to
+ * their position in code, so a stale layout can never strand them.
+ */
+export function resolveTableColumns<TRow>(
+  defs: TableColumnDef<TRow>[],
+  stored: TableColumnLayout | null | undefined,
+): ResolvedTableColumn<TRow>[] {
+  if (!stored || stored.v !== TABLE_COLUMN_LAYOUT_VERSION) {
+    return defaultsFor(defs);
+  }
+
+  const byId = new Map(defs.map((def) => [def.id, def]));
+  const entryById = new Map<string, TableColumnLayoutEntry>();
+  const order: string[] = [];
+  stored.columns.forEach((entry) => {
+    if (!byId.has(entry.id) || entryById.has(entry.id)) return;
+    entryById.set(entry.id, entry);
+    order.push(entry.id);
+  });
+
+  if (!order.length) return defaultsFor(defs);
+
+  // Splice each unsaved column in after its nearest preceding saved neighbour.
+  defs.forEach((def, index) => {
+    if (entryById.has(def.id)) return;
+    let insertAt = 0;
+    for (let i = index - 1; i >= 0; i--) {
+      const position = order.indexOf(defs[i].id);
+      if (position >= 0) {
+        insertAt = position + 1;
+        break;
+      }
+    }
+    order.splice(insertAt, 0, def.id);
+  });
+
+  const resolved: ResolvedTableColumn<TRow>[] = order.map((id) => {
+    const def = byId.get(id) as TableColumnDef<TRow>;
+    const entry = entryById.get(id);
+    const visible = isHideable(def)
+      ? (entry?.visible ?? !def.defaultHidden)
+      : true;
+    return {
+      ...def,
+      visible,
+      width: clampWidth(def, entry?.width ?? def.defaultWidth),
+    };
+  });
+
+  // Locked columns ignore the stored order and sit where code puts them.
+  const locked = defs
+    .map((def, index) => ({ def, index }))
+    .filter(({ def }) => def.locked);
+  if (locked.length) {
+    const unlocked = resolved.filter((col) => !col.locked);
+    const byIdResolved = new Map(resolved.map((col) => [col.id, col]));
+    locked.forEach(({ def, index }) => {
+      const col = byIdResolved.get(def.id);
+      if (col) unlocked.splice(index, 0, col);
+    });
+    return unlocked;
+  }
+
+  return resolved;
+}
+
+/**
+ * Build the blob to persist. Entries for columns that no longer exist in code
+ * are carried through, so a rollback or a stale tab doesn't destroy a layout.
+ */
+export function mergeLayoutForWrite<TRow>(
+  resolved: ResolvedTableColumn<TRow>[],
+  stored: TableColumnLayout | null | undefined,
+): TableColumnLayout {
+  const knownIds = new Set(resolved.map((col) => col.id));
+  const orphans = (
+    stored?.v === TABLE_COLUMN_LAYOUT_VERSION ? stored.columns : []
+  ).filter((entry) => !knownIds.has(entry.id));
+  return {
+    v: TABLE_COLUMN_LAYOUT_VERSION,
+    columns: [
+      ...resolved.map(({ id, visible, width }) => ({ id, visible, width })),
+      ...orphans,
+    ],
+  };
+}
+
+/** True when the resolved layout differs from what the code defaults would give. */
+export function isLayoutCustomized<TRow>(
+  defs: TableColumnDef<TRow>[],
+  resolved: ResolvedTableColumn<TRow>[],
+): boolean {
+  const defaults = defaultsFor(defs);
+  if (defaults.length !== resolved.length) return true;
+  return defaults.some((def, i) => {
+    const col = resolved[i];
+    return (
+      def.id !== col.id ||
+      def.visible !== col.visible ||
+      def.width !== col.width
+    );
+  });
+}

--- a/packages/front-end/services/tableColumns.ts
+++ b/packages/front-end/services/tableColumns.ts
@@ -94,7 +94,13 @@ export function resolveTableColumns<TRow>(
   defs: TableColumnDef<TRow>[],
   stored: TableColumnLayout | null | undefined,
 ): ResolvedTableColumn<TRow>[] {
-  if (!stored || stored.v !== TABLE_COLUMN_LAYOUT_VERSION) {
+  // The stored value is untrusted: it comes from localStorage, so it can be
+  // hand-edited or left behind by a different shape of this schema.
+  if (
+    !stored ||
+    stored.v !== TABLE_COLUMN_LAYOUT_VERSION ||
+    !Array.isArray(stored.columns)
+  ) {
     return defaultsFor(defs);
   }
 
@@ -102,6 +108,7 @@ export function resolveTableColumns<TRow>(
   const entryById = new Map<string, TableColumnLayoutEntry>();
   const order: string[] = [];
   stored.columns.forEach((entry) => {
+    if (!entry || typeof entry.id !== "string") return;
     if (!byId.has(entry.id) || entryById.has(entry.id)) return;
     entryById.set(entry.id, entry);
     order.push(entry.id);
@@ -163,8 +170,12 @@ export function mergeLayoutForWrite<TRow>(
 ): TableColumnLayout {
   const knownIds = new Set(resolved.map((col) => col.id));
   const orphans = (
-    stored?.v === TABLE_COLUMN_LAYOUT_VERSION ? stored.columns : []
-  ).filter((entry) => !knownIds.has(entry.id));
+    stored?.v === TABLE_COLUMN_LAYOUT_VERSION && Array.isArray(stored.columns)
+      ? stored.columns
+      : []
+  ).filter(
+    (entry) => entry && typeof entry.id === "string" && !knownIds.has(entry.id),
+  );
   return {
     v: TABLE_COLUMN_LAYOUT_VERSION,
     columns: [

--- a/packages/front-end/test/services/tableColumns.test.ts
+++ b/packages/front-end/test/services/tableColumns.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from "vitest";
+import {
+  isLayoutCustomized,
+  mergeLayoutForWrite,
+  resolveTableColumns,
+  TableColumnDef,
+  TableColumnLayout,
+} from "@/services/tableColumns";
+
+type Row = { id: string };
+
+function col(
+  id: string,
+  extra: Partial<TableColumnDef<Row>> = {},
+): TableColumnDef<Row> {
+  return { id, label: id.toUpperCase(), render: () => null, ...extra };
+}
+
+const layout = (
+  columns: TableColumnLayout["columns"],
+  v = 1,
+): TableColumnLayout => ({ v, columns });
+
+describe("resolveTableColumns", () => {
+  it("returns code defaults when there is no stored layout", () => {
+    const defs = [col("a"), col("b", { defaultHidden: true })];
+    const resolved = resolveTableColumns(defs, null);
+    expect(resolved.map((c) => [c.id, c.visible])).toEqual([
+      ["a", true],
+      ["b", false],
+    ]);
+  });
+
+  it("honours the stored order and visibility", () => {
+    const defs = [col("a"), col("b"), col("c")];
+    const resolved = resolveTableColumns(
+      defs,
+      layout([
+        { id: "c", visible: true },
+        { id: "a", visible: false },
+        { id: "b", visible: true },
+      ]),
+    );
+    expect(resolved.map((c) => c.id)).toEqual(["c", "a", "b"]);
+    expect(resolved.find((c) => c.id === "a")?.visible).toBe(false);
+  });
+
+  it("drops stored ids that no longer exist in code", () => {
+    const defs = [col("a"), col("b")];
+    const resolved = resolveTableColumns(
+      defs,
+      layout([
+        { id: "gone", visible: true },
+        { id: "b", visible: true },
+        { id: "a", visible: true },
+      ]),
+    );
+    expect(resolved.map((c) => c.id)).toEqual(["b", "a"]);
+  });
+
+  it("splices a newly added column after its predecessor in code, not at the end", () => {
+    // "owner" is added in code between b and actions; the stored layout predates it.
+    const defs = [col("a"), col("b"), col("owner"), col("actions")];
+    const resolved = resolveTableColumns(
+      defs,
+      layout([
+        { id: "b", visible: true },
+        { id: "a", visible: true },
+        { id: "actions", visible: true },
+      ]),
+    );
+    // Follows "b", the column it comes after in code — and crucially lands
+    // before the trailing row-actions column rather than after it.
+    expect(resolved.map((c) => c.id)).toEqual(["b", "owner", "a", "actions"]);
+  });
+
+  it("keeps a newly added trailing column ahead of the row-actions column", () => {
+    // The shape #6702 produces: a custom-field column added just before actions.
+    const defs = [col("a"), col("b"), col("custom:team"), col("actions")];
+    const resolved = resolveTableColumns(
+      defs,
+      layout([
+        { id: "a", visible: true },
+        { id: "b", visible: true },
+        { id: "actions", visible: true },
+      ]),
+    );
+    expect(resolved.map((c) => c.id)).toEqual([
+      "a",
+      "b",
+      "custom:team",
+      "actions",
+    ]);
+  });
+
+  it("respects defaultHidden for a newly added column", () => {
+    const defs = [col("a"), col("new", { defaultHidden: true })];
+    const resolved = resolveTableColumns(
+      defs,
+      layout([{ id: "a", visible: true }]),
+    );
+    expect(resolved.find((c) => c.id === "new")?.visible).toBe(false);
+  });
+
+  it("forces locked columns visible and back to their position in code", () => {
+    const defs = [
+      col("name", { locked: true }),
+      col("b"),
+      col("actions", { locked: true }),
+    ];
+    const resolved = resolveTableColumns(
+      defs,
+      layout([
+        { id: "actions", visible: false },
+        { id: "b", visible: true },
+        { id: "name", visible: false },
+      ]),
+    );
+    expect(resolved.map((c) => c.id)).toEqual(["name", "b", "actions"]);
+    expect(resolved.every((c) => c.visible)).toBe(true);
+  });
+
+  it("cannot hide a column marked hideable: false", () => {
+    const defs = [col("a", { hideable: false })];
+    const resolved = resolveTableColumns(
+      defs,
+      layout([{ id: "a", visible: false }]),
+    );
+    expect(resolved[0].visible).toBe(true);
+  });
+
+  it("clamps a stored width up to a raised minWidth", () => {
+    const defs = [col("a", { minWidth: 150 })];
+    const resolved = resolveTableColumns(
+      defs,
+      layout([{ id: "a", visible: true, width: 80 }]),
+    );
+    expect(resolved[0].width).toBe(150);
+  });
+
+  it("clamps a stored width down to maxWidth", () => {
+    const defs = [col("a", { maxWidth: 300 })];
+    const resolved = resolveTableColumns(
+      defs,
+      layout([{ id: "a", visible: true, width: 5000 }]),
+    );
+    expect(resolved[0].width).toBe(300);
+  });
+
+  it("drops non-finite and non-positive stored widths", () => {
+    const defs = [col("a"), col("b")];
+    const resolved = resolveTableColumns(
+      defs,
+      layout([
+        { id: "a", visible: true, width: Number.NaN },
+        { id: "b", visible: true, width: -10 },
+      ]),
+    );
+    expect(resolved[0].width).toBeUndefined();
+    expect(resolved[1].width).toBeUndefined();
+  });
+
+  it("falls back to defaults on a version mismatch", () => {
+    const defs = [col("a"), col("b")];
+    const resolved = resolveTableColumns(
+      defs,
+      layout([{ id: "b", visible: false }], 99),
+    );
+    expect(resolved.map((c) => [c.id, c.visible])).toEqual([
+      ["a", true],
+      ["b", true],
+    ]);
+  });
+
+  it("falls back to defaults when no stored id is recognised", () => {
+    const defs = [col("a"), col("b")];
+    const resolved = resolveTableColumns(
+      defs,
+      layout([{ id: "gone", visible: false }]),
+    );
+    expect(resolved.map((c) => c.id)).toEqual(["a", "b"]);
+  });
+
+  it("ignores duplicate stored entries", () => {
+    const defs = [col("a"), col("b")];
+    const resolved = resolveTableColumns(
+      defs,
+      layout([
+        { id: "a", visible: true },
+        { id: "a", visible: false },
+        { id: "b", visible: true },
+      ]),
+    );
+    expect(resolved.map((c) => c.id)).toEqual(["a", "b"]);
+    expect(resolved[0].visible).toBe(true);
+  });
+});
+
+describe("mergeLayoutForWrite", () => {
+  it("preserves stored entries for columns that no longer exist in code", () => {
+    const defs = [col("a")];
+    const stored = layout([
+      { id: "a", visible: true },
+      { id: "removed-in-this-deploy", visible: false, width: 120 },
+    ]);
+    const resolved = resolveTableColumns(defs, stored);
+    const merged = mergeLayoutForWrite(resolved, stored);
+    expect(merged.columns.map((c) => c.id)).toEqual([
+      "a",
+      "removed-in-this-deploy",
+    ]);
+  });
+
+  it("writes the current version", () => {
+    const defs = [col("a")];
+    const merged = mergeLayoutForWrite(resolveTableColumns(defs, null), null);
+    expect(merged.v).toBe(1);
+  });
+
+  it("does not carry orphans across a version mismatch", () => {
+    const defs = [col("a")];
+    const stored = layout([{ id: "old", visible: true }], 99);
+    const merged = mergeLayoutForWrite(
+      resolveTableColumns(defs, stored),
+      stored,
+    );
+    expect(merged.columns.map((c) => c.id)).toEqual(["a"]);
+  });
+});
+
+describe("isLayoutCustomized", () => {
+  it("is false for the code defaults", () => {
+    const defs = [col("a", { defaultWidth: 100 }), col("b")];
+    expect(isLayoutCustomized(defs, resolveTableColumns(defs, null))).toBe(
+      false,
+    );
+  });
+
+  it("is true when the order differs", () => {
+    const defs = [col("a"), col("b")];
+    const resolved = resolveTableColumns(
+      defs,
+      layout([
+        { id: "b", visible: true },
+        { id: "a", visible: true },
+      ]),
+    );
+    expect(isLayoutCustomized(defs, resolved)).toBe(true);
+  });
+
+  it("is true when a column is hidden", () => {
+    const defs = [col("a"), col("b")];
+    const resolved = resolveTableColumns(
+      defs,
+      layout([
+        { id: "a", visible: true },
+        { id: "b", visible: false },
+      ]),
+    );
+    expect(isLayoutCustomized(defs, resolved)).toBe(true);
+  });
+
+  it("is true when a width differs from the default", () => {
+    const defs = [col("a", { defaultWidth: 100 })];
+    const resolved = resolveTableColumns(
+      defs,
+      layout([{ id: "a", visible: true, width: 240 }]),
+    );
+    expect(isLayoutCustomized(defs, resolved)).toBe(true);
+  });
+});

--- a/packages/front-end/test/services/tableColumns.test.ts
+++ b/packages/front-end/test/services/tableColumns.test.ts
@@ -129,6 +129,22 @@ describe("resolveTableColumns", () => {
     expect(resolved[0].visible).toBe(true);
   });
 
+  it("still honours the stored position of a hideable: false column", () => {
+    // hideable: false means "always visible", not "pinned" — unlike `locked`,
+    // which is what the row-actions column uses.
+    const defs = [col("name", { hideable: false }), col("b"), col("c")];
+    const resolved = resolveTableColumns(
+      defs,
+      layout([
+        { id: "b", visible: true },
+        { id: "name", visible: true },
+        { id: "c", visible: true },
+      ]),
+    );
+    expect(resolved.map((c) => c.id)).toEqual(["b", "name", "c"]);
+    expect(resolved.every((c) => c.visible)).toBe(true);
+  });
+
   it("clamps a stored width up to a raised minWidth", () => {
     const defs = [col("a", { minWidth: 150 })];
     const resolved = resolveTableColumns(

--- a/packages/front-end/test/services/tableColumns.test.ts
+++ b/packages/front-end/test/services/tableColumns.test.ts
@@ -188,6 +188,43 @@ describe("resolveTableColumns", () => {
     ]);
   });
 
+  // The stored value comes from localStorage, so it can be hand-edited or left
+  // behind by a different shape of this schema. None of these may throw — the
+  // page would white-screen with no way to recover from the UI.
+  it.each([
+    ["columns missing", { v: 1 }],
+    ["columns null", { v: 1, columns: null }],
+    ["columns a non-array object", { v: 1, columns: { a: true } }],
+    ["columns a string", { v: 1, columns: "nope" }],
+    ["a null entry", { v: 1, columns: [null, { id: "a", visible: true }] }],
+    ["an entry with no id", { v: 1, columns: [{ visible: true }] }],
+    ["an entry with a non-string id", { v: 1, columns: [{ id: 7 }] }],
+    ["the whole value a string", "garbage"],
+    ["the whole value an array", []],
+  ])("survives a malformed stored layout: %s", (_label, stored) => {
+    const defs = [col("a"), col("b")];
+    expect(() =>
+      resolveTableColumns(defs, stored as unknown as TableColumnLayout),
+    ).not.toThrow();
+    const resolved = resolveTableColumns(
+      defs,
+      stored as unknown as TableColumnLayout,
+    );
+    expect(resolved.map((c) => c.id)).toEqual(["a", "b"]);
+    expect(resolved.every((c) => c.visible)).toBe(true);
+  });
+
+  it("keeps the usable entries when only some are malformed", () => {
+    const defs = [col("a"), col("b")];
+    const resolved = resolveTableColumns(defs, {
+      v: 1,
+      columns: [null, { id: "b", visible: false }],
+    } as unknown as TableColumnLayout);
+    // "a" wasn't in the layout and has no saved predecessor, so it leads.
+    expect(resolved.map((c) => c.id)).toEqual(["a", "b"]);
+    expect(resolved.find((c) => c.id === "b")?.visible).toBe(false);
+  });
+
   it("falls back to defaults when no stored id is recognised", () => {
     const defs = [col("a"), col("b")];
     const resolved = resolveTableColumns(
@@ -231,6 +268,23 @@ describe("mergeLayoutForWrite", () => {
     const defs = [col("a")];
     const merged = mergeLayoutForWrite(resolveTableColumns(defs, null), null);
     expect(merged.v).toBe(1);
+  });
+
+  it("ignores a malformed stored value instead of throwing", () => {
+    const defs = [col("a")];
+    const stored = {
+      v: 1,
+      columns: [null, "x"],
+    } as unknown as TableColumnLayout;
+    expect(() =>
+      mergeLayoutForWrite(resolveTableColumns(defs, stored), stored),
+    ).not.toThrow();
+    expect(
+      mergeLayoutForWrite(
+        resolveTableColumns(defs, stored),
+        stored,
+      ).columns.map((c) => c.id),
+    ).toEqual(["a"]);
   });
 
   it("does not carry orphans across a version mismatch", () => {

--- a/packages/front-end/ui/ColumnSettings.stories.tsx
+++ b/packages/front-end/ui/ColumnSettings.stories.tsx
@@ -48,8 +48,8 @@ export default function ColumnSettingsStories() {
         </Box>
         <Box className="mt-2">
           <Text size="1" color="gray">
-            The Attribute row shows a lock rather than an eye — it can be
-            reordered but not hidden. Everything else toggles.
+            The Attribute row is checked and disabled — it can be reordered but
+            not hidden. Everything else toggles.
           </Text>
         </Box>
       </Box>

--- a/packages/front-end/ui/ColumnSettings.stories.tsx
+++ b/packages/front-end/ui/ColumnSettings.stories.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from "react";
+import { Box, Flex, Text } from "@radix-ui/themes";
+import ColumnSettings, { ManagedColumn } from "./ColumnSettings";
+
+const INITIAL: ManagedColumn[] = [
+  { id: "name", label: "Attribute", visible: true, alwaysVisible: true },
+  { id: "description", label: "Description", visible: true },
+  { id: "datatype", label: "Data Type", visible: true },
+  { id: "projects", label: "Projects", visible: true },
+  { id: "tags", label: "Tags", visible: false },
+  { id: "references", label: "References", visible: true },
+];
+
+export default function ColumnSettingsStories() {
+  const [columns, setColumns] = useState<ManagedColumn[]>(INITIAL);
+  const [plain, setPlain] = useState<ManagedColumn[]>(
+    INITIAL.filter((c) => !c.alwaysVisible),
+  );
+
+  const apply =
+    (setter: React.Dispatch<React.SetStateAction<ManagedColumn[]>>) =>
+    (next: { id: string; visible: boolean }[]) =>
+      setter((prev) =>
+        next.map(({ id, visible }) => ({
+          ...(prev.find((c) => c.id === id) as ManagedColumn),
+          visible,
+        })),
+      );
+
+  const isCustomized =
+    JSON.stringify(columns) !== JSON.stringify(INITIAL) || false;
+
+  return (
+    <Flex direction="column" gap="6">
+      <Box>
+        <Box className="mb-2">
+          <Text weight="medium">
+            With an always-visible column, and reset available
+          </Text>
+        </Box>
+        <Box style={{ width: 260 }}>
+          <ColumnSettings
+            columns={columns}
+            onChange={apply(setColumns)}
+            onReset={() => setColumns(INITIAL)}
+            canReset={isCustomized}
+          />
+        </Box>
+        <Box className="mt-2">
+          <Text size="1" color="gray">
+            The Attribute row shows a lock rather than an eye — it can be
+            reordered but not hidden. Everything else toggles.
+          </Text>
+        </Box>
+      </Box>
+
+      <Box>
+        <Box className="mb-2">
+          <Text weight="medium">All columns toggleable, no reset link</Text>
+        </Box>
+        <Box style={{ width: 260 }}>
+          <ColumnSettings columns={plain} onChange={apply(setPlain)} />
+        </Box>
+      </Box>
+
+      <Box>
+        <Box className="mb-2">
+          <Text weight="medium">Single column</Text>
+        </Box>
+        <Box style={{ width: 260 }}>
+          <ColumnSettings
+            columns={[{ id: "only", label: "Only column", visible: true }]}
+            onChange={() => {
+              /* noop */
+            }}
+          />
+        </Box>
+      </Box>
+    </Flex>
+  );
+}

--- a/packages/front-end/ui/ColumnSettings.tsx
+++ b/packages/front-end/ui/ColumnSettings.tsx
@@ -16,7 +16,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { Box, Flex, IconButton } from "@radix-ui/themes";
-import { PiDotsSixVertical, PiEye, PiEyeSlash } from "react-icons/pi";
+import { PiDotsSixVertical, PiEye, PiEyeSlash, PiLock } from "react-icons/pi";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import Text from "@/ui/Text";
 import Link from "@/ui/Link";
@@ -25,8 +25,8 @@ export interface ManagedColumn {
   id: string;
   label: string;
   visible: boolean;
-  /** Rendered without a drag handle and with the visibility toggle disabled. */
-  locked?: boolean;
+  /** Can still be reordered, but shows a lock instead of a visibility toggle. */
+  alwaysVisible?: boolean;
 }
 
 function SortableColumnRow({
@@ -43,7 +43,7 @@ function SortableColumnRow({
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: column.id, disabled: column.locked });
+  } = useSortable({ id: column.id });
 
   return (
     <Flex
@@ -62,18 +62,14 @@ function SortableColumnRow({
         boxShadow: isDragging ? "var(--shadow-4)" : undefined,
       }}
     >
-      {column.locked ? (
-        <span style={{ display: "flex", width: 14 }} />
-      ) : (
-        <span
-          {...attributes}
-          {...listeners}
-          aria-label={`Drag to reorder ${column.label}`}
-          style={{ cursor: "grab", display: "flex", color: "var(--gray-8)" }}
-        >
-          <PiDotsSixVertical />
-        </span>
-      )}
+      <span
+        {...attributes}
+        {...listeners}
+        aria-label={`Drag to reorder ${column.label}`}
+        style={{ cursor: "grab", display: "flex", color: "var(--gray-8)" }}
+      >
+        <PiDotsSixVertical />
+      </span>
       <Box style={{ flex: 1, minWidth: 0 }}>
         <Text
           as="div"
@@ -84,19 +80,19 @@ function SortableColumnRow({
           {column.label}
         </Text>
       </Box>
-      {column.locked ? (
+      {column.alwaysVisible ? (
         <Tooltip body="This column is always shown">
-          {/* Not a disabled button: Radix dims those, which reads as hidden. */}
+          {/* A lock, not an eye: an eye here reads as a toggle you can click. */}
           <span
             role="img"
             aria-label={`${column.label} column is always shown`}
             style={{
               display: "flex",
               padding: "0 var(--space-1)",
-              color: "var(--accent-11)",
+              color: "var(--gray-9)",
             }}
           >
-            <PiEye size={16} />
+            <PiLock size={16} />
           </span>
         </Tooltip>
       ) : (
@@ -143,7 +139,6 @@ export default function ColumnSettings({
     const oldIndex = ids.indexOf(String(active.id));
     const newIndex = ids.indexOf(String(over.id));
     if (oldIndex === -1 || newIndex === -1) return;
-    if (columns[oldIndex].locked || columns[newIndex].locked) return;
     const reordered = arrayMove(columns, oldIndex, newIndex);
     onChange(reordered.map((c) => ({ id: c.id, visible: c.visible })));
   };

--- a/packages/front-end/ui/ColumnSettings.tsx
+++ b/packages/front-end/ui/ColumnSettings.tsx
@@ -132,7 +132,14 @@ export default function ColumnSettings({
         onDragEnd={handleDragEnd}
       >
         <SortableContext items={ids} strategy={verticalListSortingStrategy}>
-          <Flex direction="column" gap="2">
+          {/* Only the list scrolls, so the reset link stays reachable. pr is
+              for the scrollbar, which would otherwise sit on the row borders. */}
+          <Flex
+            direction="column"
+            gap="2"
+            pr="1"
+            style={{ maxHeight: "min(50vh, 360px)", overflowY: "auto" }}
+          >
             {columns.map((c) => (
               <SortableColumnRow
                 key={c.id}

--- a/packages/front-end/ui/ColumnSettings.tsx
+++ b/packages/front-end/ui/ColumnSettings.tsx
@@ -84,26 +84,34 @@ function SortableColumnRow({
           {column.label}
         </Text>
       </Box>
-      <Tooltip
-        body={
-          column.locked
-            ? "This column is always shown"
-            : column.visible
-              ? "Hide column"
-              : "Show column"
-        }
-      >
-        <IconButton
-          size="1"
-          variant="ghost"
-          color={column.visible ? "violet" : "gray"}
-          disabled={column.locked}
-          aria-label={column.visible ? "Hide column" : "Show column"}
-          onClick={() => onToggle(!column.visible)}
-        >
-          {column.visible ? <PiEye size={16} /> : <PiEyeSlash size={16} />}
-        </IconButton>
-      </Tooltip>
+      {column.locked ? (
+        <Tooltip body="This column is always shown">
+          {/* Not a disabled button: Radix dims those, which reads as hidden. */}
+          <span
+            role="img"
+            aria-label={`${column.label} column is always shown`}
+            style={{
+              display: "flex",
+              padding: "0 var(--space-1)",
+              color: "var(--accent-11)",
+            }}
+          >
+            <PiEye size={16} />
+          </span>
+        </Tooltip>
+      ) : (
+        <Tooltip body={column.visible ? "Hide column" : "Show column"}>
+          <IconButton
+            size="1"
+            variant="ghost"
+            color={column.visible ? "violet" : "gray"}
+            aria-label={column.visible ? "Hide column" : "Show column"}
+            onClick={() => onToggle(!column.visible)}
+          >
+            {column.visible ? <PiEye size={16} /> : <PiEyeSlash size={16} />}
+          </IconButton>
+        </Tooltip>
+      )}
     </Flex>
   );
 }

--- a/packages/front-end/ui/ColumnSettings.tsx
+++ b/packages/front-end/ui/ColumnSettings.tsx
@@ -17,7 +17,7 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import { Box, Flex, IconButton } from "@radix-ui/themes";
 import { PiDotsSixVertical, PiEye, PiEyeSlash, PiLock } from "react-icons/pi";
-import Tooltip from "@/components/Tooltip/Tooltip";
+import Tooltip from "@/ui/Tooltip";
 import Text from "@/ui/Text";
 import Link from "@/ui/Link";
 
@@ -81,7 +81,7 @@ function SortableColumnRow({
         </Text>
       </Box>
       {column.alwaysVisible ? (
-        <Tooltip body="This column is always shown">
+        <Tooltip content="This column is always shown">
           {/* A lock, not an eye: an eye here reads as a toggle you can click.
               asChild borrows IconButton's box so it lines up with the toggles —
               the ghost variant's negative margin can't be matched by hand. */}
@@ -95,7 +95,7 @@ function SortableColumnRow({
           </IconButton>
         </Tooltip>
       ) : (
-        <Tooltip body={column.visible ? "Hide column" : "Show column"}>
+        <Tooltip content={column.visible ? "Hide column" : "Show column"}>
           <IconButton
             size="1"
             variant="ghost"

--- a/packages/front-end/ui/ColumnSettings.tsx
+++ b/packages/front-end/ui/ColumnSettings.tsx
@@ -2,6 +2,7 @@ import {
   closestCenter,
   DndContext,
   DragEndEvent,
+  KeyboardSensor,
   PointerSensor,
   useSensor,
   useSensors,
@@ -9,6 +10,7 @@ import {
 import {
   arrayMove,
   SortableContext,
+  sortableKeyboardCoordinates,
   useSortable,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
@@ -17,11 +19,14 @@ import { Box, Flex, IconButton } from "@radix-ui/themes";
 import { PiDotsSixVertical, PiEye, PiEyeSlash } from "react-icons/pi";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import Text from "@/ui/Text";
+import Link from "@/ui/Link";
 
 export interface ManagedColumn {
   id: string;
   label: string;
   visible: boolean;
+  /** Rendered without a drag handle and with the visibility toggle disabled. */
+  locked?: boolean;
 }
 
 function SortableColumnRow({
@@ -38,7 +43,7 @@ function SortableColumnRow({
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: column.id });
+  } = useSortable({ id: column.id, disabled: column.locked });
 
   return (
     <Flex
@@ -57,14 +62,18 @@ function SortableColumnRow({
         boxShadow: isDragging ? "var(--shadow-4)" : undefined,
       }}
     >
-      <span
-        {...attributes}
-        {...listeners}
-        aria-label="Drag to reorder"
-        style={{ cursor: "grab", display: "flex", color: "var(--gray-8)" }}
-      >
-        <PiDotsSixVertical />
-      </span>
+      {column.locked ? (
+        <span style={{ display: "flex", width: 14 }} />
+      ) : (
+        <span
+          {...attributes}
+          {...listeners}
+          aria-label={`Drag to reorder ${column.label}`}
+          style={{ cursor: "grab", display: "flex", color: "var(--gray-8)" }}
+        >
+          <PiDotsSixVertical />
+        </span>
+      )}
       <Box style={{ flex: 1, minWidth: 0 }}>
         <Text
           as="div"
@@ -75,11 +84,20 @@ function SortableColumnRow({
           {column.label}
         </Text>
       </Box>
-      <Tooltip body={column.visible ? "Hide column" : "Show column"}>
+      <Tooltip
+        body={
+          column.locked
+            ? "This column is always shown"
+            : column.visible
+              ? "Hide column"
+              : "Show column"
+        }
+      >
         <IconButton
           size="1"
           variant="ghost"
           color={column.visible ? "violet" : "gray"}
+          disabled={column.locked}
           aria-label={column.visible ? "Hide column" : "Show column"}
           onClick={() => onToggle(!column.visible)}
         >
@@ -90,16 +108,25 @@ function SortableColumnRow({
   );
 }
 
-interface Props {
+export interface ColumnSettingsProps {
   columns: ManagedColumn[];
   onChange: (columns: { id: string; visible: boolean }[]) => void;
+  onReset?: () => void;
+  canReset?: boolean;
 }
 
-export default function MetricExperimentsColumnSettings({
+export default function ColumnSettings({
   columns,
   onChange,
-}: Props) {
-  const sensors = useSensors(useSensor(PointerSensor));
+  onReset,
+  canReset,
+}: ColumnSettingsProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
   const ids = columns.map((c) => c.id);
 
   const handleDragEnd = (event: DragEndEvent) => {
@@ -108,6 +135,7 @@ export default function MetricExperimentsColumnSettings({
     const oldIndex = ids.indexOf(String(active.id));
     const newIndex = ids.indexOf(String(over.id));
     if (oldIndex === -1 || newIndex === -1) return;
+    if (columns[oldIndex].locked || columns[newIndex].locked) return;
     const reordered = arrayMove(columns, oldIndex, newIndex);
     onChange(reordered.map((c) => ({ id: c.id, visible: c.visible })));
   };
@@ -122,22 +150,31 @@ export default function MetricExperimentsColumnSettings({
   };
 
   return (
-    <DndContext
-      sensors={sensors}
-      collisionDetection={closestCenter}
-      onDragEnd={handleDragEnd}
-    >
-      <SortableContext items={ids} strategy={verticalListSortingStrategy}>
-        <Flex direction="column" gap="2">
-          {columns.map((c) => (
-            <SortableColumnRow
-              key={c.id}
-              column={c}
-              onToggle={(v) => toggle(c.id, v)}
-            />
-          ))}
+    <>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+          <Flex direction="column" gap="2">
+            {columns.map((c) => (
+              <SortableColumnRow
+                key={c.id}
+                column={c}
+                onToggle={(v) => toggle(c.id, v)}
+              />
+            ))}
+          </Flex>
+        </SortableContext>
+      </DndContext>
+      {onReset && canReset && (
+        <Flex justify="end" mt="3">
+          <Link onClick={onReset}>
+            <Text size="sm">Reset to default</Text>
+          </Link>
         </Flex>
-      </SortableContext>
-    </DndContext>
+      )}
+    </>
   );
 }

--- a/packages/front-end/ui/ColumnSettings.tsx
+++ b/packages/front-end/ui/ColumnSettings.tsx
@@ -25,7 +25,8 @@ export interface ManagedColumn {
   id: string;
   label: string;
   visible: boolean;
-  /** Can still be reordered, but its checkbox is checked and disabled. */
+  /** Can still be reordered, but its checkbox is checked and disabled. The
+   * popover's helper copy is where that gets explained. */
   alwaysVisible?: boolean;
 }
 
@@ -78,7 +79,6 @@ function SortableColumnRow({
         value={column.visible}
         setValue={onToggle}
         disabled={column.alwaysVisible}
-        disabledMessage="This column is always shown"
       />
     </Flex>
   );

--- a/packages/front-end/ui/ColumnSettings.tsx
+++ b/packages/front-end/ui/ColumnSettings.tsx
@@ -82,18 +82,17 @@ function SortableColumnRow({
       </Box>
       {column.alwaysVisible ? (
         <Tooltip body="This column is always shown">
-          {/* A lock, not an eye: an eye here reads as a toggle you can click. */}
-          <span
-            role="img"
-            aria-label={`${column.label} column is always shown`}
-            style={{
-              display: "flex",
-              padding: "0 var(--space-1)",
-              color: "var(--gray-9)",
-            }}
-          >
-            <PiLock size={16} />
-          </span>
+          {/* A lock, not an eye: an eye here reads as a toggle you can click.
+              asChild borrows IconButton's box so it lines up with the toggles —
+              the ghost variant's negative margin can't be matched by hand. */}
+          <IconButton asChild size="1" variant="ghost" color="gray">
+            <span
+              role="img"
+              aria-label={`${column.label} column is always shown`}
+            >
+              <PiLock size={16} />
+            </span>
+          </IconButton>
         </Tooltip>
       ) : (
         <Tooltip body={column.visible ? "Hide column" : "Show column"}>

--- a/packages/front-end/ui/ColumnSettings.tsx
+++ b/packages/front-end/ui/ColumnSettings.tsx
@@ -82,17 +82,19 @@ function SortableColumnRow({
       </Box>
       {column.alwaysVisible ? (
         <Tooltip content="This column is always shown">
-          {/* A lock, not an eye: an eye here reads as a toggle you can click.
-              asChild borrows IconButton's box so it lines up with the toggles —
-              the ghost variant's negative margin can't be matched by hand. */}
-          <IconButton asChild size="1" variant="ghost" color="gray">
-            <span
-              role="img"
-              aria-label={`${column.label} column is always shown`}
-            >
-              <PiLock size={16} />
-            </span>
-          </IconButton>
+          {/* Not a button: a ghost IconButton shows hover/press states for something inert. 16px is the toggle's layout box. */}
+          <span
+            role="img"
+            aria-label={`${column.label} column is always shown`}
+            style={{
+              display: "inline-flex",
+              width: 16,
+              height: 16,
+              color: "var(--gray-a11)",
+            }}
+          >
+            <PiLock size={16} />
+          </span>
         </Tooltip>
       ) : (
         <Tooltip content={column.visible ? "Hide column" : "Show column"}>

--- a/packages/front-end/ui/ColumnSettings.tsx
+++ b/packages/front-end/ui/ColumnSettings.tsx
@@ -15,9 +15,9 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { Box, Flex, IconButton } from "@radix-ui/themes";
-import { PiDotsSixVertical, PiEye, PiEyeSlash, PiLock } from "react-icons/pi";
-import Tooltip from "@/ui/Tooltip";
+import { Flex } from "@radix-ui/themes";
+import { PiDotsSixVertical } from "react-icons/pi";
+import Checkbox from "@/ui/Checkbox";
 import Text from "@/ui/Text";
 import Link from "@/ui/Link";
 
@@ -25,7 +25,7 @@ export interface ManagedColumn {
   id: string;
   label: string;
   visible: boolean;
-  /** Can still be reordered, but shows a lock instead of a visibility toggle. */
+  /** Can still be reordered, but its checkbox is checked and disabled. */
   alwaysVisible?: boolean;
 }
 
@@ -70,45 +70,16 @@ function SortableColumnRow({
       >
         <PiDotsSixVertical />
       </span>
-      <Box style={{ flex: 1, minWidth: 0 }}>
-        <Text
-          as="div"
-          size="sm"
-          color={column.visible ? "text-high" : "text-low"}
-          truncate
-        >
-          {column.label}
-        </Text>
-      </Box>
-      {column.alwaysVisible ? (
-        <Tooltip content="This column is always shown">
-          {/* Not a button: a ghost IconButton shows hover/press states for something inert. 16px is the toggle's layout box. */}
-          <span
-            role="img"
-            aria-label={`${column.label} column is always shown`}
-            style={{
-              display: "inline-flex",
-              width: 16,
-              height: 16,
-              color: "var(--gray-a11)",
-            }}
-          >
-            <PiLock size={16} />
-          </span>
-        </Tooltip>
-      ) : (
-        <Tooltip content={column.visible ? "Hide column" : "Show column"}>
-          <IconButton
-            size="1"
-            variant="ghost"
-            color={column.visible ? "violet" : "gray"}
-            aria-label={column.visible ? "Hide column" : "Show column"}
-            onClick={() => onToggle(!column.visible)}
-          >
-            {column.visible ? <PiEye size={16} /> : <PiEyeSlash size={16} />}
-          </IconButton>
-        </Tooltip>
-      )}
+      <Checkbox
+        size="sm"
+        labelSize="sm"
+        weight="regular"
+        label={column.label}
+        value={column.visible}
+        setValue={onToggle}
+        disabled={column.alwaysVisible}
+        disabledMessage="This column is always shown"
+      />
     </Flex>
   );
 }

--- a/packages/front-end/ui/ColumnSettingsButton.stories.tsx
+++ b/packages/front-end/ui/ColumnSettingsButton.stories.tsx
@@ -30,9 +30,7 @@ export default function ColumnSettingsButtonStories() {
     <Flex direction="column" gap="6">
       <Box>
         <Box className="mb-2">
-          <Text weight="medium">
-            Default toolbar trigger, with a hidden-column count
-          </Text>
+          <Text weight="medium">Default trigger</Text>
         </Box>
         <ColumnSettingsButton
           columns={columns}
@@ -44,8 +42,9 @@ export default function ColumnSettingsButtonStories() {
         />
         <Box className="mt-2">
           <Text size="1" color="gray">
-            Trigger weight matches `FilterHeading`, so it sits alongside search
-            filters in a toolbar row.
+            Icon only, sized to match a row-action kebab — it lives in a
+            table&apos;s row-actions header cell. The hidden-column count goes
+            to the accessible name, since there is no room to show it.
           </Text>
         </Box>
       </Box>

--- a/packages/front-end/ui/ColumnSettingsButton.stories.tsx
+++ b/packages/front-end/ui/ColumnSettingsButton.stories.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from "react";
+import { Box, Flex, Text } from "@radix-ui/themes";
+import { PiSlidersHorizontal } from "react-icons/pi";
+import Link from "@/ui/Link";
+import ColumnSettingsButton from "./ColumnSettingsButton";
+import { ManagedColumn } from "./ColumnSettings";
+
+const INITIAL: ManagedColumn[] = [
+  { id: "name", label: "Attribute", visible: true, alwaysVisible: true },
+  { id: "description", label: "Description", visible: true },
+  { id: "datatype", label: "Data Type", visible: true },
+  { id: "tags", label: "Tags", visible: false },
+  { id: "references", label: "References", visible: false },
+];
+
+export default function ColumnSettingsButtonStories() {
+  const [columns, setColumns] = useState<ManagedColumn[]>(INITIAL);
+
+  const onChange = (next: { id: string; visible: boolean }[]) =>
+    setColumns((prev) =>
+      next.map(({ id, visible }) => ({
+        ...(prev.find((c) => c.id === id) as ManagedColumn),
+        visible,
+      })),
+    );
+
+  const hiddenCount = columns.filter((c) => !c.visible).length;
+
+  return (
+    <Flex direction="column" gap="6">
+      <Box>
+        <Box className="mb-2">
+          <Text weight="medium">
+            Default toolbar trigger, with a hidden-column count
+          </Text>
+        </Box>
+        <ColumnSettingsButton
+          columns={columns}
+          hiddenCount={hiddenCount}
+          onChange={onChange}
+          onReset={() => setColumns(INITIAL)}
+          canReset={hiddenCount !== 2}
+          note="The Attribute column is always shown."
+        />
+        <Box className="mt-2">
+          <Text size="1" color="gray">
+            Trigger weight matches `FilterHeading`, so it sits alongside search
+            filters in a toolbar row.
+          </Text>
+        </Box>
+      </Box>
+
+      <Box>
+        <Box className="mb-2">
+          <Text weight="medium">Custom trigger</Text>
+        </Box>
+        <ColumnSettingsButton
+          columns={columns}
+          onChange={onChange}
+          note="The Experiment column is always shown."
+          trigger={
+            <Link size="sm" style={{ whiteSpace: "nowrap" }}>
+              <Flex align="center" gap="1">
+                <PiSlidersHorizontal />
+                Edit
+              </Flex>
+            </Link>
+          }
+        />
+        <Box className="mt-2">
+          <Text size="1" color="gray">
+            What the dashboard sidebar uses — it surfaces the hidden count in
+            its own summary line, so the trigger omits it.
+          </Text>
+        </Box>
+      </Box>
+
+      <Box>
+        <Box className="mb-2">
+          <Text weight="medium">Nothing hidden</Text>
+        </Box>
+        <ColumnSettingsButton
+          columns={INITIAL.map((c) => ({ ...c, visible: true }))}
+          onChange={() => {
+            /* noop */
+          }}
+        />
+      </Box>
+    </Flex>
+  );
+}

--- a/packages/front-end/ui/ColumnSettingsButton.tsx
+++ b/packages/front-end/ui/ColumnSettingsButton.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useState } from "react";
-import { Box, Flex, IconButton } from "@radix-ui/themes";
-import { PiCaretDown, PiCaretUp, PiSlidersHorizontal } from "react-icons/pi";
+import { Box, IconButton } from "@radix-ui/themes";
+import { PiSlidersHorizontal } from "react-icons/pi";
 import { Popover } from "@/ui/Popover";
 import Text from "@/ui/Text";
 import ColumnSettings, { ManagedColumn } from "@/ui/ColumnSettings";
@@ -15,14 +15,14 @@ export default function ColumnSettingsButton({
   trigger,
 }: {
   columns: ManagedColumn[];
-  /** Shown on the default trigger. Omit when the caller surfaces it itself. */
+  /** Announced on the default trigger, which has no room to show it. */
   hiddenCount?: number;
   onChange: (columns: { id: string; visible: boolean }[]) => void;
   onReset?: () => void;
   canReset?: boolean;
   /** Appended to the popover's helper copy, e.g. which column is pinned. */
   note?: string;
-  /** Overrides the default toolbar trigger, for hosts that need another weight. */
+  /** Overrides the default trigger, for hosts that need another weight. */
   trigger?: ReactNode;
 }) {
   const [open, setOpen] = useState(false);
@@ -34,32 +34,18 @@ export default function ColumnSettingsButton({
       align="end"
       trigger={
         trigger ?? (
-          // Matches FilterHeading in components/Search/SearchFilters.tsx so the
-          // control reads as part of the same toolbar family.
           <IconButton
             variant="ghost"
             color="gray"
             radius="small"
-            size="3"
+            // Matches the row-action kebab below it, so the two line up.
+            size="2"
             highContrast
-            // Derived rather than static: a fixed label would override the name
-            // computed from the children and drop the hidden count.
             aria-label={
               hiddenCount > 0 ? `Columns, ${hiddenCount} hidden` : "Columns"
             }
           >
-            <Flex gap="2" align="center">
-              <Flex gap="1" align="center">
-                <PiSlidersHorizontal />
-                Columns
-                {hiddenCount > 0 && (
-                  <Text as="span" color="text-low">
-                    · {hiddenCount} hidden
-                  </Text>
-                )}
-              </Flex>
-              {open ? <PiCaretUp /> : <PiCaretDown />}
-            </Flex>
+            <PiSlidersHorizontal size={18} />
           </IconButton>
         )
       }

--- a/packages/front-end/ui/ColumnSettingsButton.tsx
+++ b/packages/front-end/ui/ColumnSettingsButton.tsx
@@ -1,25 +1,29 @@
-import { useState } from "react";
-import { Box, Flex } from "@radix-ui/themes";
-import { PiSlidersHorizontal } from "react-icons/pi";
+import { ReactNode, useState } from "react";
+import { Box, Flex, IconButton } from "@radix-ui/themes";
+import { PiCaretDown, PiCaretUp, PiSlidersHorizontal } from "react-icons/pi";
 import { Popover } from "@/ui/Popover";
-import Link from "@/ui/Link";
 import Text from "@/ui/Text";
 import ColumnSettings, { ManagedColumn } from "@/ui/ColumnSettings";
 
 export default function ColumnSettingsButton({
   columns,
-  hiddenCount,
+  hiddenCount = 0,
   onChange,
   onReset,
   canReset,
-  lockedNote,
+  note,
+  trigger,
 }: {
   columns: ManagedColumn[];
-  hiddenCount: number;
+  /** Shown on the default trigger. Omit when the caller surfaces it itself. */
+  hiddenCount?: number;
   onChange: (columns: { id: string; visible: boolean }[]) => void;
   onReset?: () => void;
   canReset?: boolean;
-  lockedNote?: string;
+  /** Appended to the popover's helper copy, e.g. which column is pinned. */
+  note?: string;
+  /** Overrides the default toolbar trigger, for hosts that need another weight. */
+  trigger?: ReactNode;
 }) {
   const [open, setOpen] = useState(false);
 
@@ -29,24 +33,38 @@ export default function ColumnSettingsButton({
       onOpenChange={setOpen}
       align="end"
       trigger={
-        <Link size="sm" style={{ whiteSpace: "nowrap" }}>
-          <Flex align="center" gap="1">
-            <PiSlidersHorizontal />
-            Columns
-            {hiddenCount > 0 && (
-              <Text as="span" color="text-low">
-                · {hiddenCount} hidden
-              </Text>
-            )}
-          </Flex>
-        </Link>
+        trigger ?? (
+          // Matches FilterHeading in components/Search/SearchFilters.tsx so the
+          // control reads as part of the same toolbar family.
+          <IconButton
+            variant="ghost"
+            color="gray"
+            radius="small"
+            size="3"
+            highContrast
+            aria-label="Column settings"
+          >
+            <Flex gap="2" align="center">
+              <Flex gap="1" align="center">
+                <PiSlidersHorizontal />
+                Columns
+                {hiddenCount > 0 && (
+                  <Text as="span" color="text-low">
+                    · {hiddenCount} hidden
+                  </Text>
+                )}
+              </Flex>
+              {open ? <PiCaretUp /> : <PiCaretDown />}
+            </Flex>
+          </IconButton>
+        )
       }
       content={
         <Box style={{ width: 260 }}>
           <Box mb="2">
             <Text size="sm" color="text-low">
               Drag to reorder or toggle visibility.
-              {lockedNote ? ` ${lockedNote}` : ""}
+              {note ? ` ${note}` : ""}
             </Text>
           </Box>
           <ColumnSettings

--- a/packages/front-end/ui/ColumnSettingsButton.tsx
+++ b/packages/front-end/ui/ColumnSettingsButton.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useState } from "react";
 import { Box, IconButton } from "@radix-ui/themes";
-import { PiSlidersHorizontal } from "react-icons/pi";
+import { PiTextColumns } from "react-icons/pi";
 import { Popover } from "@/ui/Popover";
 import Text from "@/ui/Text";
 import ColumnSettings, { ManagedColumn } from "@/ui/ColumnSettings";
@@ -15,7 +15,7 @@ export default function ColumnSettingsButton({
   trigger,
 }: {
   columns: ManagedColumn[];
-  /** Announced on the default trigger, which has no room to show it. */
+  /** Named on the default trigger, which has no room to show it. */
   hiddenCount?: number;
   onChange: (columns: { id: string; visible: boolean }[]) => void;
   onReset?: () => void;
@@ -26,6 +26,8 @@ export default function ColumnSettingsButton({
   trigger?: ReactNode;
 }) {
   const [open, setOpen] = useState(false);
+
+  const label = hiddenCount > 0 ? `Columns, ${hiddenCount} hidden` : "Columns";
 
   return (
     <Popover
@@ -41,11 +43,10 @@ export default function ColumnSettingsButton({
             // Matches the row-action kebab below it, so the two line up.
             size="2"
             highContrast
-            aria-label={
-              hiddenCount > 0 ? `Columns, ${hiddenCount} hidden` : "Columns"
-            }
+            aria-label={label}
+            title={label}
           >
-            <PiSlidersHorizontal size={18} />
+            <PiTextColumns size={18} />
           </IconButton>
         )
       }

--- a/packages/front-end/ui/ColumnSettingsButton.tsx
+++ b/packages/front-end/ui/ColumnSettingsButton.tsx
@@ -42,7 +42,11 @@ export default function ColumnSettingsButton({
             radius="small"
             size="3"
             highContrast
-            aria-label="Column settings"
+            // Derived rather than static: a fixed label would override the name
+            // computed from the children and drop the hidden count.
+            aria-label={
+              hiddenCount > 0 ? `Columns, ${hiddenCount} hidden` : "Columns"
+            }
           >
             <Flex gap="2" align="center">
               <Flex gap="1" align="center">

--- a/packages/front-end/ui/ColumnSettingsButton.tsx
+++ b/packages/front-end/ui/ColumnSettingsButton.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+import { Box, Flex } from "@radix-ui/themes";
+import { PiSlidersHorizontal } from "react-icons/pi";
+import { Popover } from "@/ui/Popover";
+import Link from "@/ui/Link";
+import Text from "@/ui/Text";
+import ColumnSettings, { ManagedColumn } from "@/ui/ColumnSettings";
+
+export default function ColumnSettingsButton({
+  columns,
+  hiddenCount,
+  onChange,
+  onReset,
+  canReset,
+  lockedNote,
+}: {
+  columns: ManagedColumn[];
+  hiddenCount: number;
+  onChange: (columns: { id: string; visible: boolean }[]) => void;
+  onReset?: () => void;
+  canReset?: boolean;
+  lockedNote?: string;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={setOpen}
+      align="end"
+      trigger={
+        <Link size="sm" style={{ whiteSpace: "nowrap" }}>
+          <Flex align="center" gap="1">
+            <PiSlidersHorizontal />
+            Columns
+            {hiddenCount > 0 && (
+              <Text as="span" color="text-low">
+                · {hiddenCount} hidden
+              </Text>
+            )}
+          </Flex>
+        </Link>
+      }
+      content={
+        <Box style={{ width: 260 }}>
+          <Box mb="2">
+            <Text size="sm" color="text-low">
+              Drag to reorder or toggle visibility.
+              {lockedNote ? ` ${lockedNote}` : ""}
+            </Text>
+          </Box>
+          <ColumnSettings
+            columns={columns}
+            onChange={onChange}
+            onReset={onReset}
+            canReset={canReset}
+          />
+        </Box>
+      }
+    />
+  );
+}

--- a/packages/front-end/ui/ColumnSettingsButton.tsx
+++ b/packages/front-end/ui/ColumnSettingsButton.tsx
@@ -54,8 +54,8 @@ export default function ColumnSettingsButton({
         <Box style={{ width: 260 }}>
           <Box mb="2">
             <Text size="sm" color="text-low">
-              Drag to reorder or toggle visibility.
-              {note ? ` ${note}` : ""}
+              Drag to reorder; check to show or hide. Saved in this browser
+              only, not shared with your team.{note ? ` ${note}` : ""}
             </Text>
           </Box>
           <ColumnSettings


### PR DESCRIPTION
### Features and Changes

First half of #6701: the Attributes table gets show/hide and drag-to-reorder columns, persisted per browser under `attributes:columns`.

It's a resolver plus a hook rather than a new table component, since `useSearch` already owns sort state and hands back a bound header; `@/ui/Table` is unchanged. `services/tableColumns.ts` holds the compatibility rules and their tests: stored ids apply in their saved order, ids no longer in code are dropped on read but kept on write, and a column that's new to the code is spliced in next to its neighbour rather than appended. The Attribute column can be reordered but not hidden, and the row-actions column stays last.

We also lift the dashboard's `MetricExperimentsColumnSettings` into `@/ui/ColumnSettings`, so both surfaces share one component and keyboard drag comes along.

### Testing

- [x] Hide and reorder columns, reload -> layout persists; trigger reads "Columns · N hidden"
- [x] Reset to default -> stored key removed, code defaults return
- [x] Hand-edit the stored blob (unknown id, bumped `v`, null entry) -> table still renders
- [x] Dashboard "Metric Experiments" block column settings still reorder and toggle

### Screenshots

<img width="1440" height="900" alt="6713-columns-final" src="https://github.com/user-attachments/assets/018a6768-dc73-448f-aded-7ae87e2a88cb" />
