### PR TITLE
Make attribute column widths authoritative with a fixed table layout

### DIFF
--- a/packages/front-end/hooks/useTableColumns.tsx
+++ b/packages/front-end/hooks/useTableColumns.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from "react";
+import React, { useCallback, useMemo, useRef } from "react";
 import {
   isLayoutCustomized,
   mergeLayoutForWrite,
@@ -22,6 +22,11 @@ export interface UseTableColumnsReturn<TRow> {
   reset: () => void;
   /** Live `<col>` nodes, keyed by column id, for imperative width writes. */
   colRefs: React.MutableRefObject<Map<string, HTMLTableColElement | null>>;
+  /**
+   * Renders the `<colgroup>`. Pass as the first child of `<Table>` — under a
+   * fixed layout these widths are what make column sizes authoritative.
+   */
+  ColGroup: React.FC;
 }
 
 /**
@@ -91,6 +96,23 @@ export function useTableColumns<TRow>({
   // defaults still reach users who have reset.
   const reset = useCallback(() => setLayout(null), [setLayout]);
 
+  const ColGroup = useMemo<React.FC>(() => {
+    const Group = () => (
+      <colgroup>
+        {visibleColumns.map((col) => (
+          <col
+            key={col.id}
+            ref={(el) => {
+              colRefs.current.set(col.id, el);
+            }}
+            style={col.width ? { width: col.width } : undefined}
+          />
+        ))}
+      </colgroup>
+    );
+    return Group;
+  }, [visibleColumns]);
+
   return {
     columns,
     visibleColumns,
@@ -101,5 +123,6 @@ export function useTableColumns<TRow>({
     setWidth,
     reset,
     colRefs,
+    ColGroup,
   };
 }

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -363,7 +363,12 @@ const FeatureAttributesPage = (): React.ReactElement => {
         header: null,
         locked: true,
         resizable: false,
-        defaultWidth: 56,
+        // Sized to the control it holds rather than to the shared padding,
+        // which would otherwise take more room than the icon itself.
+        defaultWidth: 40,
+        minWidth: 40,
+        headerProps: { style: { paddingLeft: 4, paddingRight: 4 } },
+        cellProps: () => ({ style: { paddingLeft: 4, paddingRight: 4 } }),
         render: (v) => (
           <Flex justify="center">
             <AttributeRowMenu

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -256,9 +256,11 @@ const FeatureAttributesPage = (): React.ReactElement => {
               </Text>
               {detail && (
                 <ClampedCell tooltip={detail}>
-                  {/* Inline, so the clamp's text-overflow ellipsis applies —
-                      it doesn't act on an overflowing block child. */}
-                  <Text as="span" size="sm">
+                  {/* Inline, so the clamp's text-overflow ellipsis applies — it
+                      doesn't act on an overflowing block child. whiteSpace is
+                      explicit because Text otherwise sets `normal` inline,
+                      which beats the clamp's nowrap and lets the text wrap. */}
+                  <Text as="span" size="sm" whiteSpace="nowrap">
                     {detail}
                   </Text>
                 </ClampedCell>

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -1,9 +1,10 @@
-import React, { useMemo, useState } from "react";
+import React, { FC, ReactNode, useEffect, useMemo, useState } from "react";
 import { PiInfo } from "react-icons/pi";
 import { Box, Flex } from "@radix-ui/themes";
 import { BiShow } from "react-icons/bi";
 import Text from "@/ui/Text";
 import Tooltip from "@/components/Tooltip/Tooltip";
+import RadixTooltip from "@/ui/Tooltip";
 import Modal from "@/components/Modal";
 import { useAttributeSchema } from "@/services/features";
 import AttributeModal from "@/components/Features/AttributeModal";
@@ -38,6 +39,64 @@ import { ResolvedTableColumn, TableColumnDef } from "@/services/tableColumns";
 function truncateCharsForWidth(width: number | undefined) {
   return Math.max(12, Math.floor((width ?? 220) / 8));
 }
+
+/**
+ * Clamped content plus a tooltip that only appears once the text is actually
+ * clipped. Measured rather than guessed from a character count: these columns
+ * are resizable and one of them absorbs the table's slack, so the same string
+ * clips at one width and fits at another.
+ */
+const ClampedCell: FC<{
+  tooltip: string;
+  clampLines?: number;
+  children: ReactNode;
+}> = ({ tooltip, clampLines = 1, children }) => {
+  // A callback ref, not useRef: toggling `enabled` swaps a fragment for the
+  // tooltip trigger, which remounts this node. A held ref would keep measuring
+  // the detached one, read 0, and flip the tooltip straight back off.
+  const [node, setNode] = useState<HTMLDivElement | null>(null);
+  const [overflowing, setOverflowing] = useState(false);
+
+  useEffect(() => {
+    if (!node) return;
+    const measure = () =>
+      setOverflowing(
+        node.scrollHeight > node.clientHeight + 1 ||
+          node.scrollWidth > node.clientWidth + 1,
+      );
+    measure();
+    const observer = new ResizeObserver(measure);
+    // The cell too: a line-clamped box keeps the same height whatever its
+    // content, so watching only this node would never re-fire on resize.
+    if (node.parentElement) observer.observe(node.parentElement);
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [node, tooltip, clampLines]);
+
+  return (
+    <RadixTooltip content={tooltip} enabled={overflowing}>
+      <div
+        ref={setNode}
+        style={
+          clampLines > 1
+            ? {
+                display: "-webkit-box",
+                WebkitLineClamp: clampLines,
+                WebkitBoxOrient: "vertical",
+                overflow: "hidden",
+              }
+            : {
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }
+        }
+      >
+        {children}
+      </div>
+    </RadixTooltip>
+  );
+};
 
 const FeatureAttributesPage = (): React.ReactElement => {
   const permissionsUtil = usePermissionsUtil();
@@ -168,21 +227,11 @@ const FeatureAttributesPage = (): React.ReactElement => {
         cellProps: () => ({ className: "text-gray" }),
         render: (v) =>
           v.description ? (
-            <Tooltip
-              body={v.description}
-              shouldDisplay={v.description.length > 80}
-            >
-              <div
-                style={{
-                  display: "-webkit-box",
-                  WebkitLineClamp: 2,
-                  WebkitBoxOrient: "vertical",
-                  overflow: "hidden",
-                }}
-              >
-                <Markdown className="mb-0">{v.description}</Markdown>
-              </div>
-            </Tooltip>
+            // Plain text in the tooltip: Radix wraps content in a <p>, so
+            // rendered Markdown would nest block elements inside it.
+            <ClampedCell tooltip={v.description} clampLines={2}>
+              <Markdown className="mb-0">{v.description}</Markdown>
+            </ClampedCell>
           ) : null,
       },
       {
@@ -202,13 +251,17 @@ const FeatureAttributesPage = (): React.ReactElement => {
                 : "";
           return (
             <>
-              <div className="text-truncate">{v.datatype}</div>
+              <Text as="div" truncate>
+                {v.datatype}
+              </Text>
               {detail && (
-                <Tooltip body={detail}>
-                  <div className="text-truncate">
-                    <small>{detail}</small>
-                  </div>
-                </Tooltip>
+                <ClampedCell tooltip={detail}>
+                  {/* Inline, so the clamp's text-overflow ellipsis applies —
+                      it doesn't act on an overflowing block child. */}
+                  <Text as="span" size="sm">
+                    {detail}
+                  </Text>
+                </ClampedCell>
               )}
             </>
           );

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -33,8 +33,11 @@ import ColumnSettingsButton from "@/ui/ColumnSettingsButton";
 import { useTableColumns } from "@/hooks/useTableColumns";
 import { ResolvedTableColumn, TableColumnDef } from "@/services/tableColumns";
 
-const ATTRIBUTE_NAME_COLUMN_MAX_WIDTH = 200;
-const TAGS_COLUMN_MAX_WIDTH = 160;
+// Rough char budget for a column of `width` px. Only settles after a resize
+// commits, which is why it takes the committed width rather than a live one.
+function truncateCharsForWidth(width: number | undefined) {
+  return Math.max(12, Math.floor((width ?? 220) / 8));
+}
 
 const FeatureAttributesPage = (): React.ReactElement => {
   const permissionsUtil = usePermissionsUtil();
@@ -134,9 +137,10 @@ const FeatureAttributesPage = (): React.ReactElement => {
         label: "Attribute",
         sortField: "property",
         hideable: false,
-        defaultWidth: ATTRIBUTE_NAME_COLUMN_MAX_WIDTH,
+        defaultWidth: 220,
+        minWidth: 120,
         cellProps: () => ({ className: "text-gray font-weight-bold" }),
-        render: (v) => (
+        render: (v, width) => (
           <>
             <Link
               href={`/attributes/${encodeURIComponent(v.property)}`}
@@ -144,8 +148,8 @@ const FeatureAttributesPage = (): React.ReactElement => {
             >
               <TruncateMiddleWithTooltip
                 text={v.property}
-                maxChars={23}
-                maxWidth={ATTRIBUTE_NAME_COLUMN_MAX_WIDTH}
+                maxChars={truncateCharsForWidth(width)}
+                maxWidth="100%"
               />
             </Link>{" "}
             {v.archived && (
@@ -157,44 +161,63 @@ const FeatureAttributesPage = (): React.ReactElement => {
         ),
       },
       {
+        // The slack absorber: no defaultWidth, so it takes the remaining space.
         id: "description",
         label: "Description",
         sortField: "description",
-        defaultWidth: 200,
-        cellProps: () => ({
-          className: "text-gray",
-          style: { overflow: "hidden" },
-        }),
+        cellProps: () => ({ className: "text-gray" }),
         render: (v) =>
           v.description ? (
-            <Markdown className="mb-0">{v.description}</Markdown>
+            <Tooltip
+              body={v.description}
+              shouldDisplay={v.description.length > 80}
+            >
+              <div
+                style={{
+                  display: "-webkit-box",
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: "vertical",
+                  overflow: "hidden",
+                }}
+              >
+                <Markdown className="mb-0">{v.description}</Markdown>
+              </div>
+            </Tooltip>
           ) : null,
       },
       {
         id: "datatype",
         label: "Data Type",
         sortField: "datatype",
-        cellProps: () => ({
-          className: "text-gray",
-          style: { wordWrap: "break-word" },
-        }),
-        render: (v) => (
-          <>
-            {v.datatype}
-            {v.datatype === "enum" && <>: ({v.enum})</>}
-            {v.format && (
-              <p className="my-0">
-                <small>(format: {v.format})</small>
-              </p>
-            )}
-          </>
-        ),
+        defaultWidth: 170,
+        cellProps: () => ({ className: "text-gray" }),
+        render: (v) => {
+          // Enum lists are unbounded, so the detail line gets one line plus a
+          // tooltip rather than wrapping and making every row taller.
+          const detail =
+            v.datatype === "enum" && v.enum
+              ? `(${v.enum})`
+              : v.format
+                ? `(format: ${v.format})`
+                : "";
+          return (
+            <>
+              <div className="text-truncate">{v.datatype}</div>
+              {detail && (
+                <Tooltip body={detail}>
+                  <div className="text-truncate">
+                    <small>{detail}</small>
+                  </div>
+                </Tooltip>
+              )}
+            </>
+          );
+        },
       },
       {
         id: "projects",
         label: "Projects",
-        headerProps: { style: { paddingRight: "1rem" } },
-        cellProps: () => ({ style: { paddingRight: "1rem" } }),
+        defaultWidth: 150,
         render: (v) => (
           <ProjectBadges
             resourceType="attribute"
@@ -205,9 +228,11 @@ const FeatureAttributesPage = (): React.ReactElement => {
       {
         id: "tags",
         label: "Tags",
-        defaultWidth: TAGS_COLUMN_MAX_WIDTH,
-        cellProps: () => ({ style: { overflow: "hidden" } }),
+        defaultWidth: 150,
         render: (v) => (
+          // The inner div is the flex min-width: 0 fix for SortedTags useFlex;
+          // overflow must not go on the <td> (list cells stay visible so
+          // in-cell poppers aren't clipped).
           <div
             className="tags-cell-content"
             style={{ minWidth: 0, maxWidth: "100%", overflow: "hidden" }}
@@ -224,6 +249,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
       {
         id: "references",
         label: "References",
+        defaultWidth: 130,
         cellProps: () => ({ className: "text-gray" }),
         render: (v) => {
           const refs = references?.[v.property];
@@ -270,6 +296,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
           </>
         ),
         align: "center",
+        defaultWidth: 90,
         cellProps: () => ({ className: "text-gray" }),
         render: (v) => (
           <Flex justify="center">{v.hashAttribute && <>yes</>}</Flex>
@@ -281,6 +308,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
         header: null,
         locked: true,
         resizable: false,
+        defaultWidth: 56,
         render: (v) => (
           <Flex justify="center">
             <AttributeRowMenu
@@ -302,6 +330,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
     isCustomized,
     applySettings,
     reset,
+    ColGroup,
   } = useTableColumns({ storageKey: "attributes", columns: columnDefs });
 
   // Lives in the empty row-actions header rather than the filter toolbar, which
@@ -374,12 +403,8 @@ const FeatureAttributesPage = (): React.ReactElement => {
               </Flex>
             </Box>
           )}
-          <Table
-            variant="list"
-            stickyHeader
-            roundedCorners
-            style={{ tableLayout: "auto" }}
-          >
+          <Table variant="list" stickyHeader roundedCorners layout="fixed">
+            <ColGroup />
             <TableHeader>
               <TableRow>
                 {visibleColumns.map((col) =>
@@ -389,7 +414,6 @@ const FeatureAttributesPage = (): React.ReactElement => {
                       field={col.sortField}
                       className={col.headerProps?.className}
                       style={{
-                        maxWidth: col.width,
                         textAlign: col.align,
                         ...col.headerProps?.style,
                       }}
@@ -401,7 +425,6 @@ const FeatureAttributesPage = (): React.ReactElement => {
                       key={col.id}
                       className={col.headerProps?.className}
                       style={{
-                        maxWidth: col.width,
                         textAlign: col.align,
                         ...col.headerProps?.style,
                       }}
@@ -426,9 +449,9 @@ const FeatureAttributesPage = (): React.ReactElement => {
                           <TableCell
                             key={col.id}
                             className={className}
-                            style={{ maxWidth: col.width, ...style }}
+                            style={style}
                           >
-                            {col.render(v)}
+                            {col.render(v, col.width)}
                           </TableCell>
                         );
                       })}

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -196,7 +196,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
         label: "Attribute",
         sortField: "property",
         hideable: false,
-        defaultWidth: 220,
+        defaultWidth: 200,
         minWidth: 120,
         cellProps: () => ({ className: "text-gray font-weight-bold" }),
         render: (v, width) => (
@@ -272,7 +272,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
       {
         id: "projects",
         label: "Projects",
-        defaultWidth: 150,
+        defaultWidth: 130,
         render: (v) => (
           <ProjectBadges
             resourceType="attribute"
@@ -283,7 +283,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
       {
         id: "tags",
         label: "Tags",
-        defaultWidth: 150,
+        defaultWidth: 130,
         render: (v) => (
           // The inner div is the flex min-width: 0 fix for SortedTags useFlex;
           // overflow must not go on the <td> (list cells stay visible so

--- a/packages/front-end/services/tableColumns.ts
+++ b/packages/front-end/services/tableColumns.ts
@@ -32,7 +32,8 @@ export interface TableColumnDef<TRow> {
   align?: "left" | "center" | "right";
   headerProps?: { className?: string; style?: CSSProperties };
   cellProps?: (row: TRow) => { className?: string; style?: CSSProperties };
-  render: (row: TRow) => ReactNode;
+  /** `width` is the column's resolved width, for content that must size to it. */
+  render: (row: TRow, width: number | undefined) => ReactNode;
 }
 
 export interface TableColumnLayoutEntry {

--- a/packages/front-end/services/tableColumns.ts
+++ b/packages/front-end/services/tableColumns.ts
@@ -140,7 +140,14 @@ export function resolveTableColumns<TRow>(
     return {
       ...def,
       visible,
-      width: clampWidth(def, entry?.width ?? def.defaultWidth),
+      // A column the user can't resize has no stored width worth honouring —
+      // it is a stale copy of a past default, and it would shadow the current
+      // one forever for anyone who has already saved a layout.
+      width: clampWidth(
+        def,
+        (def.resizable === false ? undefined : entry?.width) ??
+          def.defaultWidth,
+      ),
     };
   });
 

--- a/packages/front-end/test/services/tableColumns.test.ts
+++ b/packages/front-end/test/services/tableColumns.test.ts
@@ -154,6 +154,19 @@ describe("resolveTableColumns", () => {
     expect(resolved[0].width).toBe(150);
   });
 
+  it("ignores a stored width for a column the user cannot resize", () => {
+    // The bug this guards: the row-actions column narrowed in code, but anyone
+    // with a saved layout kept the old width, which they could never undo.
+    const defs = [
+      col("actions", { resizable: false, defaultWidth: 40, minWidth: 40 }),
+    ];
+    const resolved = resolveTableColumns(
+      defs,
+      layout([{ id: "actions", visible: true, width: 56 }]),
+    );
+    expect(resolved[0].width).toBe(40);
+  });
+
   it("clamps a stored width down to maxWidth", () => {
     const defs = [col("a", { maxWidth: 300 })];
     const resolved = resolveTableColumns(


### PR DESCRIPTION
### Features and Changes

Replaces the hardcoded `maxWidth` truncation with a real width model: a `<colgroup>` plus `table-layout: fixed`, with widths declared per column and carried by #6713's persisted layout. It lands ahead of drag-to-resize so widths are authoritative before they become draggable.

Long descriptions get a two-line clamp and the enum/format detail under Data Type gets one, so row heights are uniform. Both show a tooltip only once the text is actually clipped, measured rather than inferred from a character count.

### Testing

- [x] Long attribute key -> middle-truncates with a tooltip
- [x] Long description -> two lines with a tooltip; short description -> no tooltip
- [x] `enum` with a long value list -> one line with an ellipsis, row height matches its neighbours

### Screenshots

<img width="1440" height="900" alt="6714-fixed-layout-v2" src="https://github.com/user-attachments/assets/3a1556ec-a97e-4dd8-ae85-b5e39bb149b3" />

<img width="1170" height="109" alt="6714-truncation-v2" src="https://github.com/user-attachments/assets/1db793ef-bb23-4234-84ce-6128107951ec" />

<img width="1440" height="900" alt="6714-enum-tooltip" src="https://github.com/user-attachments/assets/47f52cda-347a-4e30-9777-b64fe70bfd2f" />
