### PR TITLE
Add drag-to-resize columns and horizontal scroll to the Attributes table

### DIFF
--- a/packages/front-end/hooks/useTableColumns.tsx
+++ b/packages/front-end/hooks/useTableColumns.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useRef } from "react";
 import {
   isLayoutCustomized,
   mergeLayoutForWrite,
+  minTableWidth,
   resolveTableColumns,
   ResolvedTableColumn,
   TableColumnDef,
@@ -16,6 +17,8 @@ export interface UseTableColumnsReturn<TRow> {
   colSpan: number;
   hiddenCount: number;
   isCustomized: boolean;
+  /** Pass to `<Table minTableWidth>` so a slack column can't starve to zero. */
+  minTableWidth: number;
   /** Apply order and visibility in a single write. */
   applySettings: (ordered: { id: string; visible: boolean }[]) => void;
   setWidth: (id: string, width: number | undefined) => void;
@@ -119,6 +122,7 @@ export function useTableColumns<TRow>({
     colSpan: visibleColumns.length,
     hiddenCount: columns.length - visibleColumns.length,
     isCustomized: isLayoutCustomized(defs, columns),
+    minTableWidth: minTableWidth(columns),
     applySettings,
     setWidth,
     reset,

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -48,8 +48,7 @@ function truncateCharsForWidth(width: number | undefined) {
 /**
  * Clamped content plus a tooltip that only appears once the text is actually
  * clipped. Measured rather than guessed from a character count: these columns
- * are resizable and one of them absorbs the table's slack, so the same string
- * clips at one width and fits at another.
+ * are resizable, so the same string clips at one width and fits at another.
  */
 const ClampedCell: FC<{
   tooltip: string;
@@ -225,10 +224,10 @@ const FeatureAttributesPage = (): React.ReactElement => {
         ),
       },
       {
-        // The slack absorber: no defaultWidth, so it takes the remaining space.
         id: "description",
         label: "Description",
         sortField: "description",
+        defaultWidth: 240,
         cellProps: () => ({ className: "text-gray" }),
         render: (v) =>
           v.description ? (
@@ -368,9 +367,9 @@ const FeatureAttributesPage = (): React.ReactElement => {
         header: null,
         locked: true,
         resizable: false,
-        // Sized to the control it holds rather than to the shared padding,
-        // which would otherwise take more room than the icon itself.
-        defaultWidth: 40,
+        // No defaultWidth: the one column that absorbs leftover width, so a
+        // resize elsewhere only moves the columns to its right. The kebab hugs
+        // the table's right edge whatever the leftover is.
         minWidth: 40,
         headerProps: { style: { paddingLeft: 4, paddingRight: 4 } },
         cellProps: () => ({ style: { paddingLeft: 4, paddingRight: 4 } }),

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -441,7 +441,15 @@ const FeatureAttributesPage = (): React.ReactElement => {
         onCommit={(w) => setWidth(col.id, w)}
         setLiveWidth={(w) => {
           const el = colRefs.current.get(col.id);
-          if (el) el.style.width = `${w}px`;
+          if (!el) return;
+          el.style.width = `${w}px`;
+          // Move the floor with the drag, or the auto column squeezes mid-drag
+          // and snaps back to its minimum on release.
+          const committed = col.width ?? columnWidthBounds(col).min;
+          el.closest<HTMLElement>("[data-table-list]")?.style.setProperty(
+            "--table-min-width",
+            `${minTableWidth - committed + w}px`,
+          );
         }}
       />
     );

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -32,7 +32,12 @@ import Table, {
 import Heading from "@/ui/Heading";
 import ColumnSettingsButton from "@/ui/ColumnSettingsButton";
 import { useTableColumns } from "@/hooks/useTableColumns";
-import { ResolvedTableColumn, TableColumnDef } from "@/services/tableColumns";
+import {
+  columnWidthBounds,
+  ResolvedTableColumn,
+  TableColumnDef,
+} from "@/services/tableColumns";
+import ColumnResizeHandle from "@/ui/ColumnResizeHandle";
 
 // Rough char budget for a column of `width` px. Only settles after a resize
 // commits, which is why it takes the committed width rather than a live one.
@@ -389,7 +394,9 @@ const FeatureAttributesPage = (): React.ReactElement => {
     hiddenCount,
     isCustomized,
     applySettings,
+    setWidth,
     reset,
+    colRefs,
     ColGroup,
   } = useTableColumns({ storageKey: "attributes", columns: columnDefs });
 
@@ -422,6 +429,23 @@ const FeatureAttributesPage = (): React.ReactElement => {
       : col.header !== undefined
         ? col.header
         : col.label;
+  const renderResizeHandle = (col: ResolvedTableColumn<AttributeRow>) => {
+    if (col.resizable === false) return null;
+    const { min, max } = columnWidthBounds(col);
+    return (
+      <ColumnResizeHandle
+        label={col.label}
+        width={col.width}
+        minWidth={min}
+        maxWidth={max}
+        onCommit={(w) => setWidth(col.id, w)}
+        setLiveWidth={(w) => {
+          const el = colRefs.current.get(col.id);
+          if (el) el.style.width = `${w}px`;
+        }}
+      />
+    );
+  };
 
   return (
     <>
@@ -463,7 +487,13 @@ const FeatureAttributesPage = (): React.ReactElement => {
               </Flex>
             </Box>
           )}
-          <Table variant="list" stickyHeader roundedCorners layout="fixed">
+          <Table
+            variant="list"
+            stickyHeader
+            roundedCorners
+            layout="fixed"
+            scrollX
+          >
             <ColGroup />
             <TableHeader>
               <TableRow>
@@ -477,6 +507,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
                         textAlign: col.align,
                         ...col.headerProps?.style,
                       }}
+                      endAdornment={renderResizeHandle(col)}
                     >
                       {renderHeader(col)}
                     </SortableTableColumnHeader>
@@ -490,6 +521,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
                       }}
                     >
                       {renderHeader(col)}
+                      {renderResizeHandle(col)}
                     </TableColumnHeader>
                   ),
                 )}

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -396,6 +396,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
     setWidth,
     reset,
     colRefs,
+    minTableWidth,
     ColGroup,
   } = useTableColumns({ storageKey: "attributes", columns: columnDefs });
 
@@ -492,6 +493,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
             roundedCorners
             layout="fixed"
             scrollX
+            minTableWidth={minTableWidth}
           >
             <ColGroup />
             <TableHeader>

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -362,14 +362,24 @@ const FeatureAttributesPage = (): React.ReactElement => {
         ),
       },
       {
+        // The one column that absorbs leftover width, so a resize elsewhere
+        // only moves the columns to its right. Renders nothing.
+        id: "spacer",
+        label: "",
+        header: null,
+        locked: true,
+        resizable: false,
+        minWidth: 0,
+        render: () => null,
+      },
+      {
         id: "actions",
         label: "Row actions",
         header: null,
         locked: true,
         resizable: false,
-        // No defaultWidth: the one column that absorbs leftover width, so a
-        // resize elsewhere only moves the columns to its right. The kebab hugs
-        // the table's right edge whatever the leftover is.
+        // Fixed, so the pinned column can't grow over the data it covers.
+        defaultWidth: 40,
         minWidth: 40,
         headerProps: { style: { paddingLeft: 4, paddingRight: 4 } },
         cellProps: () => ({ style: { paddingLeft: 4, paddingRight: 4 } }),
@@ -501,6 +511,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
             roundedCorners
             layout="fixed"
             scrollX
+            stickyLastColumn
             minTableWidth={minTableWidth}
           >
             <ColGroup />

--- a/packages/front-end/pages/design-system/index.tsx
+++ b/packages/front-end/pages/design-system/index.tsx
@@ -11,6 +11,7 @@ import BadgeStories from "@/ui/Badge.stories";
 import BreadcrumbsStories from "@/ui/Breadcrumbs.stories";
 import ButtonStories from "@/ui/Button.stories";
 import CalloutStories from "@/ui/Callout.stories";
+import ColumnResizeHandleStories from "@/ui/ColumnResizeHandle.stories";
 import ColumnSettingsStories from "@/ui/ColumnSettings.stories";
 import ColumnSettingsButtonStories from "@/ui/ColumnSettingsButton.stories";
 import CheckboxStories from "@/ui/Checkbox.stories";
@@ -77,6 +78,7 @@ export default function DesignSystemPage() {
     { name: "Breadcrumbs", Stories: BreadcrumbsStories },
     { name: "Button", Stories: ButtonStories },
     { name: "Callout", Stories: CalloutStories },
+    { name: "ColumnResizeHandle", Stories: ColumnResizeHandleStories },
     { name: "ColumnSettings", Stories: ColumnSettingsStories },
     {
       name: "ColumnSettingsButton",

--- a/packages/front-end/services/search.tsx
+++ b/packages/front-end/services/search.tsx
@@ -200,6 +200,8 @@ export interface SearchReturn<T> {
     className?: string;
     children: ReactNode;
     style?: React.CSSProperties;
+    /** Rendered as a sibling of the sort target, e.g. a resize handle. */
+    endAdornment?: ReactNode;
   }>;
   page: number;
   resetPage: () => void;
@@ -490,7 +492,9 @@ export function useSearch<T extends { id: string }>({
       className?: string;
       children: ReactNode;
       style?: React.CSSProperties;
-    }> = ({ children, field, className, style }) => {
+      /** Rendered as a sibling of the sort target, e.g. a resize handle. */
+      endAdornment?: ReactNode;
+    }> = ({ children, field, className, style, endAdornment }) => {
       const showSortDirection = !isRelevanceSortActive && sort.field === field;
 
       return (
@@ -522,6 +526,7 @@ export function useSearch<T extends { id: string }>({
               )}
             </a>
           </span>
+          {endAdornment}
         </TableColumnHeader>
       );
     };

--- a/packages/front-end/services/tableColumns.ts
+++ b/packages/front-end/services/tableColumns.ts
@@ -57,6 +57,18 @@ function isHideable<TRow>(def: TableColumnDef<TRow>): boolean {
   return !def.locked && def.hideable !== false;
 }
 
+/** The effective resize bounds for a column, applying the shared defaults. */
+export function columnWidthBounds<TRow>(def: TableColumnDef<TRow>): {
+  min: number;
+  max: number;
+} {
+  const min = Math.max(
+    def.minWidth ?? MIN_TABLE_COLUMN_WIDTH,
+    HARD_MIN_TABLE_COLUMN_WIDTH,
+  );
+  return { min, max: Math.max(min, def.maxWidth ?? MAX_TABLE_COLUMN_WIDTH) };
+}
+
 function clampWidth<TRow>(
   def: TableColumnDef<TRow>,
   width: number | undefined,
@@ -64,12 +76,8 @@ function clampWidth<TRow>(
   if (width === undefined || !Number.isFinite(width) || width <= 0) {
     return undefined;
   }
-  const min = Math.max(
-    def.minWidth ?? MIN_TABLE_COLUMN_WIDTH,
-    HARD_MIN_TABLE_COLUMN_WIDTH,
-  );
-  const max = def.maxWidth ?? MAX_TABLE_COLUMN_WIDTH;
-  return Math.min(Math.max(width, min), Math.max(min, max));
+  const { min, max } = columnWidthBounds(def);
+  return Math.min(Math.max(width, min), max);
 }
 
 function defaultsFor<TRow>(

--- a/packages/front-end/services/tableColumns.ts
+++ b/packages/front-end/services/tableColumns.ts
@@ -69,6 +69,23 @@ export function columnWidthBounds<TRow>(def: TableColumnDef<TRow>): {
   return { min, max: Math.max(min, def.maxWidth ?? MAX_TABLE_COLUMN_WIDTH) };
 }
 
+/**
+ * Narrowest the table can get before a slack column starves.
+ *
+ * A `table-layout: fixed` column with no width takes only what the specified
+ * widths leave over, so once they exceed the container it collapses to zero and
+ * its content becomes unreachable. Flooring the table instead keeps the slack
+ * column absorbing spare space when there is any, and pushes the table into
+ * horizontal scroll when there isn't.
+ */
+export function minTableWidth<TRow>(
+  resolved: ResolvedTableColumn<TRow>[],
+): number {
+  return resolved
+    .filter((col) => col.visible)
+    .reduce((sum, col) => sum + (col.width ?? columnWidthBounds(col).min), 0);
+}
+
 function clampWidth<TRow>(
   def: TableColumnDef<TRow>,
   width: number | undefined,

--- a/packages/front-end/services/tableColumns.ts
+++ b/packages/front-end/services/tableColumns.ts
@@ -62,10 +62,14 @@ export function columnWidthBounds<TRow>(def: TableColumnDef<TRow>): {
   min: number;
   max: number;
 } {
-  const min = Math.max(
-    def.minWidth ?? MIN_TABLE_COLUMN_WIDTH,
-    HARD_MIN_TABLE_COLUMN_WIDTH,
-  );
+  // An explicit 0 is honoured: a spacer column has no content to protect.
+  const min =
+    def.minWidth === 0
+      ? 0
+      : Math.max(
+          def.minWidth ?? MIN_TABLE_COLUMN_WIDTH,
+          HARD_MIN_TABLE_COLUMN_WIDTH,
+        );
   return { min, max: Math.max(min, def.maxWidth ?? MAX_TABLE_COLUMN_WIDTH) };
 }
 

--- a/packages/front-end/test/services/tableColumns.test.ts
+++ b/packages/front-end/test/services/tableColumns.test.ts
@@ -353,6 +353,14 @@ describe("minTableWidth", () => {
     expect(minTableWidth(resolveTableColumns(defs, null))).toBe(164);
   });
 
+  it("lets a spacer column opt out of the floor with minWidth 0", () => {
+    const defs = [
+      col("a", { defaultWidth: 100 }),
+      col("spacer", { minWidth: 0 }),
+    ];
+    expect(minTableWidth(resolveTableColumns(defs, null))).toBe(100);
+  });
+
   it("counts a resized slack column at its committed width", () => {
     const defs = [
       col("a", { defaultWidth: 100 }),

--- a/packages/front-end/test/services/tableColumns.test.ts
+++ b/packages/front-end/test/services/tableColumns.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   isLayoutCustomized,
   mergeLayoutForWrite,
+  minTableWidth,
   resolveTableColumns,
   TableColumnDef,
   TableColumnLayout,
@@ -308,6 +309,63 @@ describe("mergeLayoutForWrite", () => {
       stored,
     );
     expect(merged.columns.map((c) => c.id)).toEqual(["a"]);
+  });
+});
+
+describe("minTableWidth", () => {
+  it("sums the widths of visible columns", () => {
+    const defs = [
+      col("a", { defaultWidth: 100 }),
+      col("b", { defaultWidth: 80 }),
+    ];
+    expect(minTableWidth(resolveTableColumns(defs, null))).toBe(180);
+  });
+
+  it("sums the clamped width, not the declared one", () => {
+    // 50 is below the shared minimum, so the column really occupies 64.
+    const defs = [
+      col("a", { defaultWidth: 100 }),
+      col("b", { defaultWidth: 50 }),
+    ];
+    expect(minTableWidth(resolveTableColumns(defs, null))).toBe(164);
+  });
+
+  it("ignores hidden columns", () => {
+    const defs = [
+      col("a", { defaultWidth: 100 }),
+      col("b", { defaultWidth: 50, defaultHidden: true }),
+    ];
+    expect(minTableWidth(resolveTableColumns(defs, null))).toBe(100);
+  });
+
+  it("floors a slack column at its minWidth rather than counting it as zero", () => {
+    // The bug this guards: a fixed-layout column with no width takes only the
+    // leftover space, so without a floor it collapses once the others fill up.
+    const defs = [
+      col("a", { defaultWidth: 100 }),
+      col("slack", { minWidth: 160 }),
+    ];
+    expect(minTableWidth(resolveTableColumns(defs, null))).toBe(260);
+  });
+
+  it("uses the shared minimum for a slack column that declares no minWidth", () => {
+    const defs = [col("a", { defaultWidth: 100 }), col("slack")];
+    expect(minTableWidth(resolveTableColumns(defs, null))).toBe(164);
+  });
+
+  it("counts a resized slack column at its committed width", () => {
+    const defs = [
+      col("a", { defaultWidth: 100 }),
+      col("slack", { minWidth: 160 }),
+    ];
+    const resolved = resolveTableColumns(
+      defs,
+      layout([
+        { id: "a", visible: true, width: 100 },
+        { id: "slack", visible: true, width: 400 },
+      ]),
+    );
+    expect(minTableWidth(resolved)).toBe(500);
   });
 });
 

--- a/packages/front-end/ui/ColumnResizeHandle.stories.tsx
+++ b/packages/front-end/ui/ColumnResizeHandle.stories.tsx
@@ -1,0 +1,131 @@
+import { useRef, useState } from "react";
+import { Flex } from "@radix-ui/themes";
+import Text from "@/ui/Text";
+import Table, {
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableColumnHeader,
+  TableCell,
+} from "./Table";
+import ColumnResizeHandle from "./ColumnResizeHandle";
+
+const COLUMNS = [
+  { id: "name", label: "Name", defaultWidth: 200 },
+  // No default width: absorbs the remaining slack, like Description on
+  // the Attributes table.
+  { id: "description", label: "Description", defaultWidth: undefined },
+  { id: "status", label: "Status", defaultWidth: 140 },
+  { id: "date", label: "Date", defaultWidth: 160 },
+];
+
+const ROWS = [
+  {
+    name: "Item One",
+    description: "The first item",
+    status: "Active",
+    date: "Jan 15",
+  },
+  {
+    name: "Item Two",
+    description: "The second item",
+    status: "Draft",
+    date: "Jan 14",
+  },
+  {
+    name: "Item Three",
+    description: "The third item",
+    status: "Active",
+    date: "Jan 13",
+  },
+];
+
+function ResizableTable({ scrollX }: { scrollX?: boolean }) {
+  const [widths, setWidths] = useState<Record<string, number | undefined>>(() =>
+    Object.fromEntries(COLUMNS.map((c) => [c.id, c.defaultWidth])),
+  );
+  const colRefs = useRef<Map<string, HTMLTableColElement | null>>(new Map());
+
+  return (
+    <Table
+      variant="list"
+      stickyHeader
+      roundedCorners
+      layout="fixed"
+      scrollX={scrollX}
+    >
+      <colgroup>
+        {COLUMNS.map((col) => (
+          <col
+            key={col.id}
+            ref={(el) => {
+              colRefs.current.set(col.id, el);
+            }}
+            style={widths[col.id] ? { width: widths[col.id] } : undefined}
+          />
+        ))}
+      </colgroup>
+      <TableHeader>
+        <TableRow>
+          {COLUMNS.map((col) => (
+            <TableColumnHeader key={col.id}>
+              {col.label}
+              <ColumnResizeHandle
+                label={col.label}
+                width={widths[col.id]}
+                minWidth={64}
+                maxWidth={800}
+                onCommit={(w) =>
+                  setWidths((prev) => ({ ...prev, [col.id]: w }))
+                }
+                setLiveWidth={(w) => {
+                  const el = colRefs.current.get(col.id);
+                  if (el) el.style.width = `${w}px`;
+                }}
+              />
+            </TableColumnHeader>
+          ))}
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {ROWS.map((row) => (
+          <TableRow key={row.name}>
+            {COLUMNS.map((col) => (
+              <TableCell key={col.id}>
+                {row[col.id as keyof typeof row]}
+              </TableCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+export default function ColumnResizeHandleStories() {
+  return (
+    <Flex direction="column" gap="6">
+      <Flex direction="column" gap="2">
+        <Text weight="medium">Drag, double-click and keyboard resize</Text>
+        <Text size="sm" color="text-low">
+          The handle sits in the right 8px of each header cell and is invisible
+          until you hover it. Drag to resize; double-click to reset one column;
+          or focus a handle and use Left/Right (Shift for a larger step, Home to
+          reset). A fixed layout and a <code>&lt;colgroup&gt;</code> are what
+          make the widths authoritative — Description declares no width, so it
+          absorbs the slack.
+        </Text>
+        <ResizableTable />
+      </Flex>
+      <Flex direction="column" gap="2">
+        <Text weight="medium">Inside a scrollX region</Text>
+        <Text size="sm" color="text-low">
+          Widen the columns past the container to scroll horizontally. The
+          header sticks to the top of the scroll region rather than the
+          viewport.
+        </Text>
+        <ResizableTable scrollX />
+      </Flex>
+    </Flex>
+  );
+}

--- a/packages/front-end/ui/ColumnResizeHandle.stories.tsx
+++ b/packages/front-end/ui/ColumnResizeHandle.stories.tsx
@@ -12,11 +12,12 @@ import ColumnResizeHandle from "./ColumnResizeHandle";
 
 const COLUMNS = [
   { id: "name", label: "Name", defaultWidth: 200 },
-  // No default width: absorbs the remaining slack, like Description on
-  // the Attributes table.
-  { id: "description", label: "Description", defaultWidth: undefined },
+  { id: "description", label: "Description", defaultWidth: 240 },
   { id: "status", label: "Status", defaultWidth: 140 },
   { id: "date", label: "Date", defaultWidth: 160 },
+  // No default width: absorbs the leftover, like the row-actions column on the
+  // Attributes table, so a resize only ever moves the columns to its right.
+  { id: "actions", label: "", defaultWidth: undefined },
 ];
 
 const ROWS = [
@@ -70,19 +71,21 @@ function ResizableTable({ scrollX }: { scrollX?: boolean }) {
           {COLUMNS.map((col) => (
             <TableColumnHeader key={col.id}>
               {col.label}
-              <ColumnResizeHandle
-                label={col.label}
-                width={widths[col.id]}
-                minWidth={64}
-                maxWidth={800}
-                onCommit={(w) =>
-                  setWidths((prev) => ({ ...prev, [col.id]: w }))
-                }
-                setLiveWidth={(w) => {
-                  const el = colRefs.current.get(col.id);
-                  if (el) el.style.width = `${w}px`;
-                }}
-              />
+              {col.defaultWidth !== undefined && (
+                <ColumnResizeHandle
+                  label={col.label}
+                  width={widths[col.id]}
+                  minWidth={64}
+                  maxWidth={800}
+                  onCommit={(w) =>
+                    setWidths((prev) => ({ ...prev, [col.id]: w }))
+                  }
+                  setLiveWidth={(w) => {
+                    const el = colRefs.current.get(col.id);
+                    if (el) el.style.width = `${w}px`;
+                  }}
+                />
+              )}
             </TableColumnHeader>
           ))}
         </TableRow>
@@ -108,12 +111,13 @@ export default function ColumnResizeHandleStories() {
       <Flex direction="column" gap="2">
         <Text weight="medium">Drag, double-click and keyboard resize</Text>
         <Text size="sm" color="text-low">
-          The handle sits in the right 8px of each header cell and is invisible
-          until you hover it. Drag to resize; double-click to reset one column;
-          or focus a handle and use Left/Right (Shift for a larger step, Home to
-          reset). A fixed layout and a <code>&lt;colgroup&gt;</code> are what
-          make the widths authoritative — Description declares no width, so it
-          absorbs the slack.
+          The handle is the faint line in the right 8px of each header cell.
+          Drag to resize; double-click to fit a column to its content; or focus
+          a handle and use Left/Right (Shift for a larger step, Home to reset).
+          A fixed layout and a <code>&lt;colgroup&gt;</code> are what make the
+          widths authoritative. Every data column has a width, so a resize only
+          moves the columns to its right; the trailing column absorbs whatever
+          is left over.
         </Text>
         <ResizableTable />
       </Flex>

--- a/packages/front-end/ui/ColumnResizeHandle.stories.tsx
+++ b/packages/front-end/ui/ColumnResizeHandle.stories.tsx
@@ -11,13 +11,19 @@ import Table, {
 import ColumnResizeHandle from "./ColumnResizeHandle";
 
 const COLUMNS = [
-  { id: "name", label: "Name", defaultWidth: 200 },
-  { id: "description", label: "Description", defaultWidth: 240 },
-  { id: "status", label: "Status", defaultWidth: 140 },
-  { id: "date", label: "Date", defaultWidth: 160 },
-  // No default width: absorbs the leftover, like the row-actions column on the
-  // Attributes table, so a resize only ever moves the columns to its right.
-  { id: "actions", label: "", defaultWidth: undefined },
+  { id: "name", label: "Name", defaultWidth: 200, resizable: true },
+  {
+    id: "description",
+    label: "Description",
+    defaultWidth: 240,
+    resizable: true,
+  },
+  { id: "status", label: "Status", defaultWidth: 140, resizable: true },
+  { id: "date", label: "Date", defaultWidth: 160, resizable: true },
+  // No default width: absorbs the leftover, so a resize only ever moves the
+  // columns to its right.
+  { id: "spacer", label: "", defaultWidth: undefined, resizable: false },
+  { id: "actions", label: "", defaultWidth: 56, resizable: false },
 ];
 
 const ROWS = [
@@ -54,6 +60,7 @@ function ResizableTable({ scrollX }: { scrollX?: boolean }) {
       roundedCorners
       layout="fixed"
       scrollX={scrollX}
+      stickyLastColumn={scrollX}
     >
       <colgroup>
         {COLUMNS.map((col) => (
@@ -71,7 +78,7 @@ function ResizableTable({ scrollX }: { scrollX?: boolean }) {
           {COLUMNS.map((col) => (
             <TableColumnHeader key={col.id}>
               {col.label}
-              {col.defaultWidth !== undefined && (
+              {col.resizable && (
                 <ColumnResizeHandle
                   label={col.label}
                   width={widths[col.id]}
@@ -116,8 +123,8 @@ export default function ColumnResizeHandleStories() {
           a handle and use Left/Right (Shift for a larger step, Home to reset).
           A fixed layout and a <code>&lt;colgroup&gt;</code> are what make the
           widths authoritative. Every data column has a width, so a resize only
-          moves the columns to its right; the trailing column absorbs whatever
-          is left over.
+          moves the columns to its right; a trailing spacer column absorbs
+          whatever is left over.
         </Text>
         <ResizableTable />
       </Flex>
@@ -126,7 +133,7 @@ export default function ColumnResizeHandleStories() {
         <Text size="sm" color="text-low">
           Widen the columns past the container to scroll horizontally. The
           header sticks to the top of the scroll region rather than the
-          viewport.
+          viewport, and the last column pins to the right edge.
         </Text>
         <ResizableTable scrollX />
       </Flex>

--- a/packages/front-end/ui/ColumnResizeHandle.tsx
+++ b/packages/front-end/ui/ColumnResizeHandle.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import styles from "./Table.module.scss";
 
 const KEYBOARD_STEP = 16;
@@ -27,7 +27,11 @@ export default function ColumnResizeHandle({
     startWidth: number;
     pending: number;
     raf: number | null;
+    moved: boolean;
   } | null>(null);
+  // Only the slack column has no width to report. Measured on focus, which is
+  // when a screen reader announces the value.
+  const [focusWidth, setFocusWidth] = useState<number | undefined>();
 
   // Measured from the header cell, so it's truthful even for an auto-sized
   // column that has no width of its own.
@@ -54,6 +58,7 @@ export default function ColumnResizeHandle({
       startWidth,
       pending: clamp(startWidth),
       raf: null,
+      moved: false,
     };
     e.currentTarget.setPointerCapture(e.pointerId);
     e.currentTarget.dataset.active = "true";
@@ -64,6 +69,7 @@ export default function ColumnResizeHandle({
   const onPointerMove = (e: React.PointerEvent<HTMLButtonElement>) => {
     const state = drag.current;
     if (!state) return;
+    state.moved = true;
     state.pending = clamp(state.startWidth + (e.clientX - state.startX));
     if (state.raf === null) state.raf = requestAnimationFrame(flush);
   };
@@ -72,13 +78,15 @@ export default function ColumnResizeHandle({
     const state = drag.current;
     if (!state) return;
     if (state.raf !== null) cancelAnimationFrame(state.raf);
-    flush();
+    if (state.moved) flush();
     drag.current = null;
     delete e.currentTarget.dataset.active;
     e.currentTarget
       .closest("[data-table-list]")
       ?.removeAttribute("data-resizing");
-    onCommit(state.pending);
+    // A click that never moved must not pin the column: committing there would
+    // freeze the slack column and mark the layout customized.
+    if (state.moved) onCommit(state.pending);
   };
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
@@ -101,9 +109,10 @@ export default function ColumnResizeHandle({
       role="separator"
       aria-orientation="vertical"
       aria-label={`Resize ${label} column`}
-      aria-valuenow={width}
+      aria-valuenow={width ?? focusWidth}
       aria-valuemin={minWidth}
       aria-valuemax={maxWidth}
+      onFocus={() => setFocusWidth(Math.round(measure()) || undefined)}
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
       onPointerUp={endDrag}

--- a/packages/front-end/ui/ColumnResizeHandle.tsx
+++ b/packages/front-end/ui/ColumnResizeHandle.tsx
@@ -4,6 +4,41 @@ import styles from "./Table.module.scss";
 const KEYBOARD_STEP = 16;
 const KEYBOARD_STEP_LARGE = 64;
 
+/**
+ * Width of a cell's laid-out content. Text is measured through Ranges and only
+ * inline-level boxes count, so a block wrapper that fills the cell (a clamp, a
+ * flex row) doesn't report the cell's own width back as "content".
+ */
+function contentWidth(cell: Element, skip: Element | null): number {
+  let left = Infinity;
+  let right = -Infinity;
+  const include = ({ left: l, right: r, width }: DOMRect) => {
+    if (width <= 0) return;
+    left = Math.min(left, l);
+    right = Math.max(right, r);
+  };
+  const walker = document.createTreeWalker(
+    cell,
+    NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT,
+    {
+      acceptNode: (node) =>
+        node === skip ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT,
+    },
+  );
+  for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+    if (node instanceof Element) {
+      if (getComputedStyle(node).display.startsWith("inline")) {
+        include(node.getBoundingClientRect());
+      }
+    } else {
+      const range = document.createRange();
+      range.selectNodeContents(node);
+      include(range.getBoundingClientRect());
+    }
+  }
+  return right > left ? right - left : 0;
+}
+
 export default function ColumnResizeHandle({
   label,
   width,
@@ -89,6 +124,24 @@ export default function ColumnResizeHandle({
     if (state.moved) onCommit(state.pending);
   };
 
+  // Spreadsheet semantics: size the column to its widest header or cell content.
+  const fitToContent = () => {
+    const th = ref.current?.closest("th");
+    const table = th?.closest("table");
+    if (!th || !table) return;
+    const index = Array.from(th.parentElement?.children ?? []).indexOf(th);
+    const cells = Array.from(table.querySelectorAll("tbody tr"))
+      .map((row) => row.children[index])
+      .filter((cell): cell is Element => !!cell);
+    const style = getComputedStyle(th);
+    const padding =
+      parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
+    const widest = Math.max(
+      ...[th, ...cells].map((cell) => contentWidth(cell, ref.current)),
+    );
+    onCommit(clamp(Math.ceil(widest + padding)));
+  };
+
   const onKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
     const step = e.shiftKey ? KEYBOARD_STEP_LARGE : KEYBOARD_STEP;
     if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
@@ -120,7 +173,7 @@ export default function ColumnResizeHandle({
       onKeyDown={onKeyDown}
       onDoubleClick={(e) => {
         e.stopPropagation();
-        onCommit(undefined);
+        fitToContent();
       }}
       onClick={(e) => e.stopPropagation()}
     />

--- a/packages/front-end/ui/ColumnResizeHandle.tsx
+++ b/packages/front-end/ui/ColumnResizeHandle.tsx
@@ -1,0 +1,119 @@
+import React, { useRef } from "react";
+import styles from "./Table.module.scss";
+
+const KEYBOARD_STEP = 16;
+const KEYBOARD_STEP_LARGE = 64;
+
+export default function ColumnResizeHandle({
+  label,
+  width,
+  minWidth,
+  maxWidth,
+  onCommit,
+  setLiveWidth,
+}: {
+  label: string;
+  /** Committed width, or undefined when the column is auto-sized. */
+  width: number | undefined;
+  minWidth: number;
+  maxWidth: number;
+  onCommit: (width: number | undefined) => void;
+  /** Written imperatively during the drag; no React render per frame. */
+  setLiveWidth: (width: number) => void;
+}) {
+  const ref = useRef<HTMLButtonElement>(null);
+  const drag = useRef<{
+    startX: number;
+    startWidth: number;
+    pending: number;
+    raf: number | null;
+  } | null>(null);
+
+  // Measured from the header cell, so it's truthful even for an auto-sized
+  // column that has no width of its own.
+  const measure = () =>
+    ref.current?.closest("th")?.getBoundingClientRect().width ?? 0;
+
+  const clamp = (w: number) => Math.min(Math.max(w, minWidth), maxWidth);
+
+  const flush = () => {
+    const state = drag.current;
+    if (!state) return;
+    state.raf = null;
+    setLiveWidth(state.pending);
+  };
+
+  const onPointerDown = (e: React.PointerEvent<HTMLButtonElement>) => {
+    // The sort handler lives on an inner span of the same <th>, but stop
+    // propagation anyway so a drag can never register as a sort click.
+    e.preventDefault();
+    e.stopPropagation();
+    const startWidth = measure();
+    drag.current = {
+      startX: e.clientX,
+      startWidth,
+      pending: clamp(startWidth),
+      raf: null,
+    };
+    e.currentTarget.setPointerCapture(e.pointerId);
+    e.currentTarget.dataset.active = "true";
+    const wrapper = e.currentTarget.closest("[data-table-list]");
+    wrapper?.setAttribute("data-resizing", "true");
+  };
+
+  const onPointerMove = (e: React.PointerEvent<HTMLButtonElement>) => {
+    const state = drag.current;
+    if (!state) return;
+    state.pending = clamp(state.startWidth + (e.clientX - state.startX));
+    if (state.raf === null) state.raf = requestAnimationFrame(flush);
+  };
+
+  const endDrag = (e: React.PointerEvent<HTMLButtonElement>) => {
+    const state = drag.current;
+    if (!state) return;
+    if (state.raf !== null) cancelAnimationFrame(state.raf);
+    flush();
+    drag.current = null;
+    delete e.currentTarget.dataset.active;
+    e.currentTarget
+      .closest("[data-table-list]")
+      ?.removeAttribute("data-resizing");
+    onCommit(state.pending);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    const step = e.shiftKey ? KEYBOARD_STEP_LARGE : KEYBOARD_STEP;
+    if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
+      e.preventDefault();
+      const from = width ?? measure();
+      onCommit(clamp(from + (e.key === "ArrowRight" ? step : -step)));
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      onCommit(undefined);
+    }
+  };
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      className={styles.resizeHandle}
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={`Resize ${label} column`}
+      aria-valuenow={width}
+      aria-valuemin={minWidth}
+      aria-valuemax={maxWidth}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      onKeyDown={onKeyDown}
+      onDoubleClick={(e) => {
+        e.stopPropagation();
+        onCommit(undefined);
+      }}
+      onClick={(e) => e.stopPropagation()}
+    />
+  );
+}

--- a/packages/front-end/ui/Table.module.scss
+++ b/packages/front-end/ui/Table.module.scss
@@ -222,20 +222,36 @@
       z-index: 2;
     }
 
-    // accent-a2 is translucent, so the opaque background has to stay under it.
+    // The row-hover rule sets a translucent background-color on every cell and
+    // outranks the opaque one above, so restate it here and layer the tint on
+    // top as an image. Otherwise scrolled content shows through the hovered row.
     :global(
       .rt-TableBody
         .rt-TableRow:not([data-no-hover]):hover
         > *:last-child:not([colspan])
     ) {
+      background-color: var(--color-panel-solid);
       background-image: linear-gradient(var(--accent-a2), var(--accent-a2));
     }
 
-    // Only once something is actually hidden behind it. box-sizing is
-    // border-box here, so this costs no layout width.
+    // Only once something is actually hidden behind it. A soft shadow rather
+    // than a rule: the neighbouring column's resize handle is already a crisp
+    // line, and two of those side by side read as a double border.
     &[data-overflow-x="true"]
-      :global(.rt-TableRow > *:last-child:not([colspan])) {
-      border-left: 1px solid var(--slate-a5, rgba(0, 9, 50, 0.12));
+      :global(.rt-TableRow > *:last-child:not([colspan]))::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      // Narrow: the peak sets how dark the edge is, the width how much tint is
+      // laid down overall — too wide and it reads as a wash, not a shadow.
+      width: 6px;
+      transform: translateX(-100%);
+      pointer-events: none;
+      // The same slate-alpha family as the table's own borders: it inverts for
+      // dark mode, where black leaves no cue and neutral grey doesn't blend.
+      background: linear-gradient(to right, transparent, var(--slate-a3));
     }
   }
 

--- a/packages/front-end/ui/Table.module.scss
+++ b/packages/front-end/ui/Table.module.scss
@@ -230,6 +230,7 @@
   border: none;
   padding: 0;
 
+  // Faint at rest so the affordance is discoverable; accent while in use.
   &::after {
     content: "";
     position: absolute;
@@ -238,7 +239,7 @@
     width: 2px;
     height: 60%;
     border-radius: 1px;
-    background-color: transparent;
+    background-color: var(--gray-a5);
   }
 
   &:hover::after,

--- a/packages/front-end/ui/Table.module.scss
+++ b/packages/front-end/ui/Table.module.scss
@@ -184,4 +184,69 @@
     ) {
     border-top-right-radius: 0;
   }
+
+  // Opt-in bounded scroll region for wide tables. overflow-x can't scroll
+  // without overflow-y doing the same, so the header sticks to this region
+  // rather than to the viewport.
+  &[data-scroll-x="true"] {
+    overflow: auto;
+    max-height: calc(100vh - var(--table-sticky-top, 56px) - 24px);
+    border: 1px solid var(--slate-a5, rgba(0, 9, 50, 0.12));
+    border-radius: var(--radius-4);
+
+    :global(.rt-TableRootTable) {
+      border: none;
+      border-radius: 0;
+    }
+
+    &[data-sticky-header="true"] :global(.rt-TableHeader) {
+      top: 0;
+    }
+  }
+
+  // Anchor for the absolutely positioned resize handle.
+  :global(.rt-TableHeader .rt-TableRow .rt-TableColumnHeaderCell) {
+    position: relative;
+  }
+
+  &[data-resizing="true"] {
+    user-select: none;
+  }
+}
+
+.resizeHandle {
+  position: absolute;
+  // Kept fully inside the cell: the first and last header cells carry a
+  // border-radius, so a handle straddling the border can clip on edge columns.
+  top: 0;
+  right: 0;
+  width: 8px;
+  height: 100%;
+  cursor: col-resize;
+  touch-action: none;
+  z-index: 1;
+  background: none;
+  border: none;
+  padding: 0;
+
+  &::after {
+    content: "";
+    position: absolute;
+    top: 20%;
+    right: 2px;
+    width: 2px;
+    height: 60%;
+    border-radius: 1px;
+    background-color: transparent;
+  }
+
+  &:hover::after,
+  &:focus-visible::after,
+  &[data-active="true"]::after {
+    background-color: var(--accent-9);
+  }
+
+  &:focus-visible {
+    outline: none;
+  }
 }

--- a/packages/front-end/ui/Table.module.scss
+++ b/packages/front-end/ui/Table.module.scss
@@ -191,8 +191,11 @@
   &[data-scroll-x="true"] {
     overflow: auto;
     max-height: calc(100vh - var(--table-sticky-top, 56px) - 24px);
-    // Matches the header's rounded top corners, so scrolled content is clipped
-    // to the same shape. No border: the wrapper's is `none !important` above.
+    // The frame moves onto the scroll container, so it stays put while the
+    // content scrolls under it. No top edge: the header draws its own, as in
+    // the unbounded case.
+    border: 1px solid var(--slate-a5, rgba(0, 9, 50, 0.12)) !important;
+    border-top: none !important;
     border-radius: var(--radius-4);
 
     :global(.rt-TableRootTable) {
@@ -202,6 +205,37 @@
 
     &[data-sticky-header="true"] :global(.rt-TableHeader) {
       top: 0;
+    }
+  }
+
+  // Pins the row-actions column while the rest scrolls under it. The colspan
+  // guard spares full-width rows such as the empty state.
+  &[data-sticky-last-column="true"] {
+    :global(.rt-TableRow > *:last-child:not([colspan])) {
+      position: sticky;
+      right: 0;
+      z-index: 1;
+      background-color: var(--color-panel-solid);
+    }
+
+    :global(.rt-TableHeader .rt-TableRow > *:last-child) {
+      z-index: 2;
+    }
+
+    // accent-a2 is translucent, so the opaque background has to stay under it.
+    :global(
+      .rt-TableBody
+        .rt-TableRow:not([data-no-hover]):hover
+        > *:last-child:not([colspan])
+    ) {
+      background-image: linear-gradient(var(--accent-a2), var(--accent-a2));
+    }
+
+    // Only once something is actually hidden behind it. box-sizing is
+    // border-box here, so this costs no layout width.
+    &[data-overflow-x="true"]
+      :global(.rt-TableRow > *:last-child:not([colspan])) {
+      border-left: 1px solid var(--slate-a5, rgba(0, 9, 50, 0.12));
     }
   }
 

--- a/packages/front-end/ui/Table.module.scss
+++ b/packages/front-end/ui/Table.module.scss
@@ -27,6 +27,12 @@
     overflow: visible !important;
   }
 
+  // Radix still measures the viewport it can no longer scroll and renders a
+  // scrollbar for it, which drags but moves nothing.
+  :global(.rt-ScrollAreaScrollbar) {
+    display: none;
+  }
+
   :global(.rt-TableBody .rt-TableRow .rt-TableCell) {
     box-sizing: border-box;
     overflow: visible;

--- a/packages/front-end/ui/Table.module.scss
+++ b/packages/front-end/ui/Table.module.scss
@@ -191,7 +191,8 @@
   &[data-scroll-x="true"] {
     overflow: auto;
     max-height: calc(100vh - var(--table-sticky-top, 56px) - 24px);
-    border: 1px solid var(--slate-a5, rgba(0, 9, 50, 0.12));
+    // Matches the header's rounded top corners, so scrolled content is clipped
+    // to the same shape. No border: the wrapper's is `none !important` above.
     border-radius: var(--radius-4);
 
     :global(.rt-TableRootTable) {

--- a/packages/front-end/ui/Table.module.scss
+++ b/packages/front-end/ui/Table.module.scss
@@ -205,6 +205,12 @@
     }
   }
 
+  // No-op until a caller sets the var. Applied to the table rather than the
+  // slack <col>, whose min-width the CSS Tables spec doesn't honour.
+  :global(.rt-TableRootTable) {
+    min-width: var(--table-min-width, 0);
+  }
+
   // Anchor for the absolutely positioned resize handle.
   :global(.rt-TableHeader .rt-TableRow .rt-TableColumnHeaderCell) {
     position: relative;

--- a/packages/front-end/ui/Table.stories.tsx
+++ b/packages/front-end/ui/Table.stories.tsx
@@ -13,6 +13,16 @@ const sampleRows = [
   { name: "Item Three", status: "Active", date: "Jan 13, 2025" },
 ];
 
+const wideColumns = [
+  "Name",
+  "Owner",
+  "Environment",
+  "Data Source",
+  "Last Updated",
+  "Tags",
+  "Projects",
+];
+
 export default function TableStories() {
   return (
     <Flex direction="column" gap="6">
@@ -34,6 +44,39 @@ export default function TableStories() {
                 <TableCell>{row.name}</TableCell>
                 <TableCell>{row.status}</TableCell>
                 <TableCell>{row.date}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Flex>
+      <Flex direction="column" gap="2">
+        <span style={{ fontWeight: 600 }}>
+          List variant with scrollX (bounded scroll region)
+        </span>
+        <span>
+          Wide content scrolls horizontally inside the table instead of the
+          page. The header then sticks to the top of this region rather than to
+          the viewport, because overflow-x cannot scroll without overflow-y
+          doing the same.
+        </span>
+        <Table variant="list" stickyHeader roundedCorners scrollX>
+          <TableHeader>
+            <TableRow>
+              {wideColumns.map((c) => (
+                <TableColumnHeader key={c} style={{ minWidth: 180 }}>
+                  {c}
+                </TableColumnHeader>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {sampleRows.map((row, i) => (
+              <TableRow key={i}>
+                {wideColumns.map((c) => (
+                  <TableCell key={c} style={{ minWidth: 180 }}>
+                    {c === "Name" ? row.name : `${c} value ${i + 1}`}
+                  </TableCell>
+                ))}
               </TableRow>
             ))}
           </TableBody>

--- a/packages/front-end/ui/Table.tsx
+++ b/packages/front-end/ui/Table.tsx
@@ -20,6 +20,13 @@ export type TableProps = Omit<
   stickyTopOffset?: number;
   /** When true (or when variant="list"), first header row gets rounded top corners */
   roundedCorners?: boolean;
+  /**
+   * Opt in to a bounded scroll region so wide tables scroll horizontally. The
+   * header then sticks to that region instead of the viewport — the list variant
+   * neutralises Radix's own scroll area to get viewport-sticky headers, and
+   * overflow-x can't scroll without overflow-y doing the same.
+   */
+  scrollX?: boolean;
 };
 
 export default function Table({
@@ -29,6 +36,7 @@ export default function Table({
   stickyHeader,
   stickyTopOffset = DEFAULT_STICKY_TOP_OFFSET_PX,
   roundedCorners,
+  scrollX,
   className,
   ...props
 }: TableProps) {
@@ -43,6 +51,12 @@ export default function Table({
     if (!isListVariant || !useStickyHeader) return;
     const wrapper = wrapperRef.current;
     if (!wrapper) return;
+    // In a scroll region the header is always stuck to the region's top, so
+    // there is no unstuck state to detect.
+    if (scrollX) {
+      wrapper.setAttribute("data-sticky-active", "true");
+      return;
+    }
     const header = wrapper.querySelector(".rt-TableHeader");
     if (!header) return;
 
@@ -59,7 +73,7 @@ export default function Table({
     check();
     window.addEventListener("scroll", check, { passive: true });
     return () => window.removeEventListener("scroll", check);
-  }, [isListVariant, useStickyHeader, stickyTopOffset]);
+  }, [isListVariant, useStickyHeader, stickyTopOffset, scrollX]);
 
   const radixVariant = variant === "list" ? "surface" : variant;
 
@@ -91,6 +105,7 @@ export default function Table({
       }
       data-table-list
       data-sticky-header={useStickyHeader ? "true" : "false"}
+      data-scroll-x={scrollX ? "true" : undefined}
     >
       {tableElement}
     </div>

--- a/packages/front-end/ui/Table.tsx
+++ b/packages/front-end/ui/Table.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useEffect, useRef } from "react";
+import React, { forwardRef, useEffect, useRef, useState } from "react";
 import { Table as RadixTable } from "@radix-ui/themes";
 import clsx from "clsx";
 import { radixSize, Size } from "@/ui/sizes";
@@ -27,6 +27,8 @@ export type TableProps = Omit<
    * overflow-x can't scroll without overflow-y doing the same.
    */
   scrollX?: boolean;
+  /** Pins the last column to the right edge while the rest scrolls under it. */
+  stickyLastColumn?: boolean;
   /**
    * px floor for the table itself. Under a fixed layout a column with no width
    * takes only the leftover space, so without a floor it collapses to zero once
@@ -43,6 +45,7 @@ export default function Table({
   stickyTopOffset = DEFAULT_STICKY_TOP_OFFSET_PX,
   roundedCorners,
   scrollX,
+  stickyLastColumn,
   minTableWidth,
   className,
   ...props
@@ -53,6 +56,23 @@ export default function Table({
     (variant === "list" && stickyHeader !== false) || stickyHeader === true;
 
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const [overflowX, setOverflowX] = useState(false);
+
+  // A pinned column only earns its divider once there is something behind it.
+  useEffect(() => {
+    const wrapper = wrapperRef.current;
+    if (!scrollX || !stickyLastColumn || !wrapper) return;
+    const check = () =>
+      setOverflowX(wrapper.scrollWidth > wrapper.clientWidth + 1);
+    check();
+    const observer = new ResizeObserver(check);
+    observer.observe(wrapper);
+    // The table too: a drag-resize changes its width without changing the
+    // wrapper's.
+    const table = wrapper.querySelector("table");
+    if (table) observer.observe(table);
+    return () => observer.disconnect();
+  }, [scrollX, stickyLastColumn]);
 
   useEffect(() => {
     if (!isListVariant || !useStickyHeader) return;
@@ -114,6 +134,8 @@ export default function Table({
       data-table-list
       data-sticky-header={useStickyHeader ? "true" : "false"}
       data-scroll-x={scrollX ? "true" : undefined}
+      data-sticky-last-column={scrollX && stickyLastColumn ? "true" : undefined}
+      data-overflow-x={overflowX ? "true" : undefined}
     >
       {tableElement}
     </div>

--- a/packages/front-end/ui/Table.tsx
+++ b/packages/front-end/ui/Table.tsx
@@ -27,6 +27,12 @@ export type TableProps = Omit<
    * overflow-x can't scroll without overflow-y doing the same.
    */
   scrollX?: boolean;
+  /**
+   * px floor for the table itself. Under a fixed layout a column with no width
+   * takes only the leftover space, so without a floor it collapses to zero once
+   * the specified widths fill the container. `useTableColumns` computes this.
+   */
+  minTableWidth?: number;
 };
 
 export default function Table({
@@ -37,6 +43,7 @@ export default function Table({
   stickyTopOffset = DEFAULT_STICKY_TOP_OFFSET_PX,
   roundedCorners,
   scrollX,
+  minTableWidth,
   className,
   ...props
 }: TableProps) {
@@ -97,11 +104,12 @@ export default function Table({
       ref={wrapperRef}
       className={styles.wrapper}
       style={
-        useStickyHeader
-          ? ({
-              "--table-sticky-top": `${stickyTopOffset}px`,
-            } as React.CSSProperties)
-          : undefined
+        {
+          ...(useStickyHeader && {
+            "--table-sticky-top": `${stickyTopOffset}px`,
+          }),
+          ...(minTableWidth && { "--table-min-width": `${minTableWidth}px` }),
+        } as React.CSSProperties
       }
       data-table-list
       data-sticky-header={useStickyHeader ? "true" : "false"}


### PR DESCRIPTION
### Features and Changes

Completes #6701: columns can be dragged to resize, and the table gets an opt-in scroll region (`scrollX` on `@/ui/Table`) so it can grow wider than the viewport.

Every data column has a width and the row-actions column is the only auto column, so a drag only moves the columns to its right and the kebab stays at the table's right edge. Once the widths exceed the container the table scrolls horizontally rather than squeezing anything. The drag writes straight to the `<col>` node and commits once on release; double-click fits a column to its content, and Left/Right/Home work from the keyboard. The handle is the faint line at the right of each header cell.

### Known issues

- The Attribute column scrolls out of view horizontally rather than pinning; sticky-left cells are a follow-up.

### Testing

- [x] Drag a column 140px -> it changes by 140px and only the columns to its right move; reload keeps it
- [x] Widen past the container -> the region scrolls horizontally, the page body never does, and the header stays pinned while scrolling vertically
- [x] Double-click the handle on an empty Tags column -> it fits to its header
- [x] Other `variant="list"` pages (`/features`, `/metrics`, `/environments`, `/saved-groups`) -> unchanged

### Screenshots


<img width="1600" height="1000" alt="6715-default" src="https://github.com/user-attachments/assets/e67a542b-7fff-455a-9159-ca5c68813a4f" />

<img width="1600" height="1000" alt="6715-resized-scroll" src="https://github.com/user-attachments/assets/ecdecee7-e5ad-419e-9a4c-e87b694cf281" />


