### PR TITLE
Perf: drop redundant indexes on the revisions collection

### DIFF
--- a/packages/back-end/src/models/RevisionModel.ts
+++ b/packages/back-end/src/models/RevisionModel.ts
@@ -142,17 +142,15 @@ const BaseClass = MakeModelClass({
     "scheduledPublishGaveUpAt",
     "armAcknowledgments",
   ],
+  // Both were superseded by longer indexes that start with the same fields, so
+  // Mongo can never pick them; they only cost write throughput.
+  indexesToRemove: [
+    "organization_1_target.type_1_target.id_1_status_1",
+    "organization_1_status_1",
+  ],
   additionalIndexes: [
-    {
-      fields: {
-        organization: 1,
-        "target.type": 1,
-        "target.id": 1,
-        status: 1,
-      },
-    },
-    // Merge order, read on every landing. Extends the equality prefix above with
-    // the sort keys so the read is a one-row indexed walk, not an in-memory sort.
+    // Merge order, read on every landing. The equality filter plus both sort keys,
+    // so the read is a one-row indexed walk, not an in-memory sort.
     {
       fields: {
         organization: 1,
@@ -878,7 +876,10 @@ export class RevisionModel extends BaseClass {
         status: "merged",
       } as Record<string, unknown>,
       {
-        sort: { "resolution.dateCreated": -1, version: -1, id: -1 },
+        // No `id` tiebreaker: `version` is unique per target, so the pair is
+        // already deterministic, and omitting it keeps the whole sort inside
+        // the target/status/resolution index instead of blocking in memory.
+        sort: { "resolution.dateCreated": -1, version: -1 },
         limit: 1,
         // NOT read-filtered: a consistency query, not a user-facing read. A
         // snapshot-basis null here reads to `assertLandingBaseline` as "no

--- a/packages/back-end/src/models/RevisionModel.ts
+++ b/packages/back-end/src/models/RevisionModel.ts
@@ -142,8 +142,7 @@ const BaseClass = MakeModelClass({
     "scheduledPublishGaveUpAt",
     "armAcknowledgments",
   ],
-  // Both were superseded by longer indexes that start with the same fields, so
-  // Mongo can never pick them; they only cost write throughput.
+  // Superseded by longer indexes starting with the same fields, so never picked.
   indexesToRemove: [
     "organization_1_target.type_1_target.id_1_status_1",
     "organization_1_status_1",
@@ -876,9 +875,6 @@ export class RevisionModel extends BaseClass {
         status: "merged",
       } as Record<string, unknown>,
       {
-        // No `id` tiebreaker: `version` is unique per target, so the pair is
-        // already deterministic, and omitting it keeps the whole sort inside
-        // the target/status/resolution index instead of blocking in memory.
         sort: { "resolution.dateCreated": -1, version: -1 },
         limit: 1,
         // NOT read-filtered: a consistency query, not a user-facing read. A

--- a/packages/back-end/src/models/RevisionModel.ts
+++ b/packages/back-end/src/models/RevisionModel.ts
@@ -142,10 +142,13 @@ const BaseClass = MakeModelClass({
     "scheduledPublishGaveUpAt",
     "armAcknowledgments",
   ],
-  // Superseded by longer indexes starting with the same fields, so never picked.
+  // The first two are prefixes of longer indexes below, which give identical
+  // bounds — no query needs them. Nothing filters `authorId` without also
+  // constraining `target.type`, so the third can never be the selective choice.
   indexesToRemove: [
     "organization_1_target.type_1_target.id_1_status_1",
     "organization_1_status_1",
+    "organization_1_authorId_1",
   ],
   additionalIndexes: [
     // Merge order, read on every landing. The equality filter plus both sort keys,
@@ -159,9 +162,6 @@ const BaseClass = MakeModelClass({
         "resolution.dateCreated": 1,
         version: 1,
       },
-    },
-    {
-      fields: { organization: 1, authorId: 1 },
     },
     // The listing sort `{dateCreated: -1, id: -1}` on the filter's prefix, so
     // paginated reads don't block-sort the whole match.


### PR DESCRIPTION
### Features and Changes

Atlas flagged a suggested index on `revisions`; the real fix was a dead sort key.

`getLatestMergedByTarget` in `packages/back-end/src/models/RevisionModel.ts` sorted by `{resolution.dateCreated: -1, version: -1, id: -1}`. Mongo only serves a multi-key sort from an index when the entire sort spec is an index prefix, and no index carried `id` — so despite `limit: 1` the query loaded every merged revision for the target and block-sorted it in memory, on every landing (it's called from `assertLandingStillOwned`, `assertLandingBaseline`, the stranded-merge recovery in `revisionActions`, and `resolveConfigLockTarget`). `{organization, target.type, target.id, version}` is a unique index, so `version` alone already breaks every tie and the `id` key was dead weight. Dropping it makes the sort a prefix of the existing `{organization, target.type, target.id, status, resolution.dateCreated, version}` index — a one-row indexed walk, no new index required.

Two indexes also go via `indexesToRemove`, both unpickable because a longer index starts with the same fields: `organization_1_target.type_1_target.id_1_status_1` (declared in `additionalIndexes` directly above the resolution index that supersedes it) and `organization_1_status_1`, which a past commit replaced with `{organization, status, dateCreated: -1, id: -1}` without ever dropping the original. That takes the collection from 13 indexes to 11.

Note: `indexesToRemove` fires from `updateIndexes` on first model touch per process and `dropIndex` swallows `IndexNotFound`, so this is a no-op on fresh installs and self-hosted instances that never had the stale index.

### Testing

- [x] `pnpm --filter back-end type-check` — clean
- [x] `pnpm --filter back-end test test/revisions` — 442 tests, 40 suites pass
- [x] `test/api/landing-fence-gaps.test.ts` — passes; the one integration test that exercises this query's real ordering, whose rival-merge fixture wins on `resolution.dateCreated`, never on `id`
- [x] Verified in production Atlas that `organization_1_target.type_1_target.id_1_version_1`
      is `unique: true`, so `version` is a total order per target and the removed `id`
      tiebreaker could never have broken a tie
- [x] Verified that two of the dropped indicies MongoDB Atlas complains are unused in https://cloud.mongodb.com/v2/5ed168263dde1050674a9be7#/metrics/replicaSet/6149ef567106b147fad1bf5e/advisor/dropIndexes
- [x] Verified that the third index dropped organization_1_status_1 is a subset of a longer index and it will probably not slow down anything.  We are not creating it for new orgs, so it is better that we have the same indices as them.  