### PR TITLE
Docs: document the docker login dhi.io needed to build the image from source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ mongosh -u root
 
 ### Building the Docker image
 
-Day-to-day development uses `pnpm dev`, so you don't normally need to build the image. If you do change the `Dockerfile` and want to build it locally, run `docker login dhi.io` first: the hardened base images come from Docker's `dhi.io` registry, which rejects unauthenticated requests (including metadata reads) with a `401`. Any free Docker account works — see [Building from source](https://docs.growthbook.io/self-host#building-from-source) for details. CI does not build the image, so a PR won't fail for want of these credentials.
+Day-to-day development uses `pnpm dev`, so you don't normally need to build the image. If you do change the `Dockerfile` and want to build it locally, run `docker login dhi.io` first: the hardened base images come from Docker's `dhi.io` registry, which rejects unauthenticated requests (including metadata reads) with a `401`. Any free Docker account works — see [Building from source](https://docs.growthbook.io/self-host#building-from-source) for details. You don't need your own credentials for CI: the preview workflow builds `Dockerfile` changes for pull requests from a branch on this repo, using the repo's own credentials, and skips the build entirely for pull requests from forks.
 
 ### Working on docs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,10 @@ mongosh -u root
 - `show collections` should show you the collections for the database you are using. This will throw an error if you are not logged in as the correct user.
 - `db` is available and you should be able to run queries against it, e.g. `db.users.find()`
 
+### Building the Docker image
+
+Day-to-day development uses `pnpm dev`, so you don't normally need to build the image. If you do change the `Dockerfile` and want to build it locally, run `docker login dhi.io` first: the hardened base images come from Docker's `dhi.io` registry, which rejects unauthenticated requests (including metadata reads) with a `401`. Any free Docker account works — see [Building from source](https://docs.growthbook.io/self-host#building-from-source) for details. CI does not build the image, so a PR won't fail for want of these credentials.
+
 ### Working on docs
 
 To start the docs site, first `cd docs` and then run `pnpm install` to install and `pnpm dev` to run the docs server. You can view the site at http://localhost:3200

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,11 @@
 # Pinned to debian-12 (bookworm) to match the glibc of node:24-slim, keeping the
 # gbstats venv and the kerberos native addon ABI-compatible. Do NOT move to
 # debian-13 without re-validating both.
+#
+# Building this file requires `docker login dhi.io` — that registry rejects
+# unauthenticated requests (even metadata reads) with a 401 that doesn't name
+# DHI. Any free Docker account works; see docs.growthbook.io/self-host#building-from-source.
+# Pulling the published growthbook/growthbook image needs no credentials.
 # ============================================================================
 
 ARG PYTHON_MAJOR=3.11

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ docker compose up -d
 
 Then visit http://localhost:3000. View the full [Self-Hosting Instructions](https://docs.growthbook.io/self-host) for more details.
 
+This pulls our prebuilt public Docker image and needs no registry credentials. If you instead build the image from the `Dockerfile` in this repo, its hardened base images come from Docker's `dhi.io` registry, which requires a one-time `docker login dhi.io` with any free Docker account — see [Building from source](https://docs.growthbook.io/self-host#building-from-source).
+
 [![GrowthBook Screenshot](/features-screenshot.png)](https://www.growthbook.io)
 
 ## Our Philosophy

--- a/docs/docs/self-host/index.mdx
+++ b/docs/docs/self-host/index.mdx
@@ -101,16 +101,7 @@ docker run --rm -it --pid=container:<container-name> --cap-add=SYS_PTRACE busybo
 
 ### Building from source requires `docker login dhi.io` {#building-from-source}
 
-Most deployments should use the published `growthbook/growthbook` image — it's the same image we run on GrowthBook Cloud, and it needs no DHI account. But if you build the `Dockerfile` yourself (a fork, an internal CI pipeline, an air-gapped rebuild), two build stages pull hardened base images from Docker's `dhi.io` registry:
-
-| Stage                           | Base image repository |
-| ------------------------------- | --------------------- |
-| `pybuild` (Python stats engine) | `dhi.io/python`       |
-| final runtime stage             | `dhi.io/node`         |
-
-(The exact tags are pinned in the `Dockerfile` via the `PYTHON_MAJOR` and `NODE_MAJOR` build args.)
-
-`dhi.io` requires authentication on **every** request, including image metadata reads, so an unauthenticated `docker build` fails at the manifest fetch:
+Most deployments should use the published `growthbook/growthbook` image — it's the same image we run on GrowthBook Cloud, and it needs no DHI account. But if you build the `Dockerfile` yourself (a fork, an internal CI pipeline, an air-gapped rebuild), you will need to log in to `dhi.io` to avoid the following error:
 
 ```
 failed to authorize: failed to fetch anonymous token: unexpected status from GET

--- a/docs/docs/self-host/index.mdx
+++ b/docs/docs/self-host/index.mdx
@@ -69,7 +69,9 @@ Lastly, if you need to reference the image for a specific git commit for any rea
 
 ## Hardened (non-root, shell-less) image
 
-The GrowthBook runtime image is a distroless [Docker Hardened Image](https://www.docker.com/products/hardened-images): it runs as a **non-root user (uid 1000)** and contains **no shell or package manager**. This removes a recurring class of OS-package CVEs. If you pull the image directly (`docker run`, Docker Compose, or a pinned `latest`/git-sha tag), there are two things to know.
+The GrowthBook runtime image is a distroless [Docker Hardened Image](https://www.docker.com/products/hardened-images) (DHI): it runs as a **non-root user (uid 1000)** and contains **no shell or package manager**. This removes a recurring class of OS-package CVEs.
+
+The published `growthbook/growthbook` image is an ordinary public image — `docker pull` needs no special credentials. The notes below cover the operational differences when you run it, plus the one extra step needed if you build the image from source yourself.
 
 ### Local file uploads must be writable by uid 1000
 
@@ -95,4 +97,52 @@ docker run --rm -it --pid=container:<container-name> --cap-add=SYS_PTRACE busybo
 #   ls /proc/1/root/usr/local/src/app
 ```
 
-`--cap-add=SYS_PTRACE` is required to read the target process's filesystem. Any image with a shell works (`busybox`, `debian`); the matching `dhi.io/node:<version>-debian12-dev` image gives you the same libraries for running the app's own binaries. On Kubernetes, use `kubectl debug -it <pod> --image=busybox --target=<container>`. One-off admin scripts (e.g. encryption-key migration) are run via `node` directly — see [Environment Variables](/self-host/env).
+`--cap-add=SYS_PTRACE` is required to read the target process's filesystem. Any image with a shell works (`busybox`, `debian`); the matching `dhi.io/node:<version>-debian12-dev` image gives you the same libraries for running the app's own binaries, though pulling that one needs the login described below. On Kubernetes, use `kubectl debug -it <pod> --image=busybox --target=<container>`. One-off admin scripts (e.g. encryption-key migration) are run via `node` directly — see [Environment Variables](/self-host/env).
+
+### Building from source requires `docker login dhi.io` {#building-from-source}
+
+Most deployments should use the published `growthbook/growthbook` image — it's the same image we run on GrowthBook Cloud, and it needs no DHI account. But if you build the `Dockerfile` yourself (a fork, an internal CI pipeline, an air-gapped rebuild), two build stages pull hardened base images from Docker's `dhi.io` registry:
+
+| Stage                           | Base image repository |
+| ------------------------------- | --------------------- |
+| `pybuild` (Python stats engine) | `dhi.io/python`       |
+| final runtime stage             | `dhi.io/node`         |
+
+(The exact tags are pinned in the `Dockerfile` via the `PYTHON_MAJOR` and `NODE_MAJOR` build args.)
+
+`dhi.io` requires authentication on **every** request, including image metadata reads, so an unauthenticated `docker build` fails at the manifest fetch:
+
+```
+failed to authorize: failed to fetch anonymous token: unexpected status from GET
+https://dhi.io/token?scope=repository:node:pull...: 401 Unauthorized
+```
+
+Any free Docker account fixes this — the [DHI Community catalog](https://docs.docker.com/dhi/) is free under Apache 2.0, with no paid subscription or separate entitlement to provision:
+
+```bash
+docker login dhi.io   # Docker ID + password or personal access token
+docker build -t growthbook .
+```
+
+In CI, add a login step before the build. With GitHub Actions:
+
+```yaml
+- uses: docker/login-action@v4
+  with:
+    registry: dhi.io
+    username: ${{ secrets.DOCKER_HUB_USERNAME }}
+    password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+```
+
+:::caution Registry mirrors and egress allowlists
+`dhi.io` is a distinct registry from `docker.io`. A pull-through mirror (Artifactory, Harbor, Nexus) configured for Docker Hub does **not** cover it, and neither does a firewall rule that only permits `docker.io` / `registry-1.docker.io`. Add `dhi.io` as its own upstream remote or allowlisted host.
+:::
+
+If you only build from source in order to layer something on top — a CA certificate, an internal config file — extend the published image instead. This needs no DHI access at all:
+
+```dockerfile
+FROM growthbook/growthbook:latest
+COPY my-ca.crt /usr/local/share/ca-certificates/
+```
+
+Substituting public bases (`python:3.11-slim`, `node:24-slim`) is possible, but it isn't a one-line swap: the final stage is built around the hardened layout — the stats engine venv is compiled against the DHI interpreter at `/opt/python`, there is no shell for `RUN` steps, and the process is non-root. A fork taking that route has to carry those adjustments itself, and we don't test that configuration. If `dhi.io` is a hard blocker in your environment, [open an issue](https://github.com/growthbook/growthbook/issues) or find us in [Slack](https://slack.growthbook.io) — we'd like to hear about it.

--- a/docs/docs/self-host/index.mdx
+++ b/docs/docs/self-host/index.mdx
@@ -142,7 +142,10 @@ If you only build from source in order to layer something on top — a CA certif
 
 ```dockerfile
 FROM growthbook/growthbook:latest
-COPY my-ca.crt /usr/local/share/ca-certificates/
+COPY my-ca.crt /opt/certs/my-ca.crt
+ENV NODE_EXTRA_CA_CERTS=/opt/certs/my-ca.crt
 ```
 
-Substituting public bases (`python:3.11-slim`, `node:24-slim`) is possible, but it isn't a one-line swap: the final stage is built around the hardened layout — the stats engine venv is compiled against the DHI interpreter at `/opt/python`, there is no shell for `RUN` steps, and the process is non-root. A fork taking that route has to carry those adjustments itself, and we don't test that configuration. If `dhi.io` is a hard blocker in your environment, [open an issue](https://github.com/growthbook/growthbook/issues) or find us in [Slack](https://slack.growthbook.io) — we'd like to hear about it.
+Point `NODE_EXTRA_CA_CERTS` at the certificate rather than dropping it in `/usr/local/share/ca-certificates/`: the usual `update-ca-certificates` step needs a shell, which this image doesn't have, and Node wouldn't read the system bundle anyway. Node picks the variable up at startup, so it covers the back-end and front-end processes where GrowthBook makes its outbound connections.
+
+If `dhi.io` is a hard blocker in your environment, [open an issue](https://github.com/growthbook/growthbook/issues) or find us in [Slack](https://slack.growthbook.io) — we'd like to hear about it.


### PR DESCRIPTION
### Features and Changes

Building the image from source pulls hardened base images from `dhi.io`, which rejects unauthenticated requests — including metadata reads — so `docker build` fails with a 401 before any layer runs. A self-hosted user upgrading to 5.0.0 hit this; the fix is `docker login dhi.io` with any free Docker account, and it wasn't documented anywhere.

Adds a "Building from source" section to the self-hosting docs: the login, a CI login step, the registry-mirror caveat (`dhi.io` is a separate registry from `docker.io`, so a Docker Hub pull-through mirror or egress allowlist won't cover it), and extending the published image as an alternative to forking the `Dockerfile`. Pointers from the README and `CONTRIBUTING.md`, plus a note in the `Dockerfile` header since the 401 itself doesn't name DHI. The docs now also state up front that pulling `growthbook/growthbook` needs no credentials — the DHI requirement is build-time only. No build changes.

### Testing

- [x] `pnpm build` in `docs/` succeeds and `#building-from-source` renders as an anchor
- [x] README and `CONTRIBUTING.md` links resolve to that anchor
