### PR TITLE
fix(ui): improve callout action wrapping

### DIFF
--- a/packages/front-end/ui/Callout.module.scss
+++ b/packages/front-end/ui/Callout.module.scss
@@ -14,5 +14,10 @@
 
 .body {
   flex: 1 1 0%;
-  min-width: min(100%, 16rem);
+}
+
+.bodyWithAction {
+  flex-basis: 16rem;
+  min-width: 0;
+  max-width: max-content;
 }

--- a/packages/front-end/ui/Callout.tsx
+++ b/packages/front-end/ui/Callout.tsx
@@ -9,6 +9,7 @@ import {
 import React, { forwardRef, ReactNode } from "react";
 import { MarginProps } from "@radix-ui/themes/dist/esm/props/margin.props.js";
 import { PiX } from "react-icons/pi";
+import clsx from "clsx";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { radixSize } from "@/ui/sizes";
 import { RadixStatusIcon, Status, getRadixColor, Size } from "./HelperText";
@@ -103,13 +104,18 @@ export default forwardRef<
         wrap="wrap"
         align="start"
         gapX="3"
-        gapY="2"
+        gapY="3"
         flexGrow="1"
         minWidth="0"
+        justify={action ? "between" : undefined}
       >
         {/* Rendered as a div (not the default <p>) so block-level children
             and nested layout don't produce invalid <div>-inside-<p> nesting. */}
-        <Text as="div" size={radixSize(size)} className={styles.body}>
+        <Text
+          as="div"
+          size={radixSize(size)}
+          className={clsx(styles.body, action && styles.bodyWithAction)}
+        >
           {children}
         </Text>
         {action ? <Box className={styles.firstLineSlot}>{action}</Box> : null}


### PR DESCRIPTION
### Features and Changes

Fix a scenario where a Callout with short text + short action was wrapping into a new line when it shouldn't.

### Screenshots

| Before | After |
|--------|--------|
| <img width="1800" height="2200" alt="callout-final-before" src="https://github.com/user-attachments/assets/db84bae9-c0cb-45a3-a300-8fe87e6bb1fb" /> | <img width="1800" height="2200" alt="callout-final-after" src="https://github.com/user-attachments/assets/51aafb7e-1985-4124-80bb-cd3b4db4780c" /> |

