### PR TITLE
fix(features): stop env-settings writes from wiping rules on v1-shaped docs

### DIFF
--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -1323,40 +1323,68 @@ export async function updateFeature(
   // change: the merge reports no rule diff, so `computeRevisionMergeChanges`
   // omits `changes.rules` while still writing `environmentSettings`, and
   // enabling a feature in a new environment silently drops the rest.
-  // `feature.rules` is the migrated live state the reader already sees, so
-  // persisting it is a no-op on v2 docs and a repair on v1 ones.
-  if (allUpdates.environmentSettings && allUpdates.rules === undefined) {
-    allUpdates.rules = feature.rules ?? [];
-  }
+  // `feature.rules` is the migrated live state the reader already sees.
+  //
+  // Only docs that still need it get the backfill: rewriting a v2 doc's rules
+  // from the pre-image would revert whatever a concurrent publish landed in
+  // between (unguarded callers pass no `casOnDateUpdated`). So it rides a
+  // second attempt, reached only when the first — which claims v2-shaped docs
+  // alone — matches nothing. Exactly one of the two writes ever lands.
+  const rulesBackfill =
+    allUpdates.environmentSettings && allUpdates.rules === undefined
+      ? (feature.rules ?? [])
+      : null;
 
-  const normalizedUpdates = buildFeatureUpdate(allUpdates);
+  const mutation = (payload: typeof allUpdates) => {
+    const normalizedUpdates = buildFeatureUpdate(payload);
 
-  if (Array.isArray(normalizedUpdates.rules)) {
-    const { rules: dedupedRules, collisions } = ensureUniqueRuleIds(
-      normalizedUpdates.rules as FeatureRule[],
-    );
-    if (collisions.length > 0) {
-      logger.warn(
-        { featureId: feature.id, collisions },
-        "Duplicate rule ids auto-suffixed on feature update",
+    if (Array.isArray(normalizedUpdates.rules)) {
+      const { rules: dedupedRules, collisions } = ensureUniqueRuleIds(
+        normalizedUpdates.rules as FeatureRule[],
       );
-      normalizedUpdates.rules = dedupedRules;
+      if (collisions.length > 0) {
+        logger.warn(
+          { featureId: feature.id, collisions },
+          "Duplicate rule ids auto-suffixed on feature update",
+        );
+        normalizedUpdates.rules = dedupedRules;
+      }
     }
-  }
 
-  const writeResult = await FeatureModel.updateOne(
-    {
-      organization: feature.organization,
-      id: feature.id,
-      ...(options?.casOnDateUpdated
-        ? { dateUpdated: options.casOnDateUpdated }
-        : {}),
-    },
-    {
+    return {
       $set: normalizedUpdates,
       ...(options?.unsetHoldout ? { $unset: { holdout: "" } } : {}),
-    },
+    };
+  };
+
+  const filter = {
+    organization: feature.organization,
+    id: feature.id,
+    ...(options?.casOnDateUpdated
+      ? { dateUpdated: options.casOnDateUpdated }
+      : {}),
+  };
+
+  let writeResult = await FeatureModel.updateOne(
+    rulesBackfill
+      ? {
+          ...filter,
+          // Mirrors `topLevelRulesAreV2Shaped` on the read side: every rule we
+          // write carries `allEnvironments` or `environments`.
+          $or: [
+            { "rules.allEnvironments": { $exists: true } },
+            { "rules.environments": { $exists: true } },
+          ],
+        }
+      : filter,
+    mutation(allUpdates),
   );
+  if (rulesBackfill && writeResult.matchedCount === 0) {
+    writeResult = await FeatureModel.updateOne(
+      filter,
+      mutation({ ...allUpdates, rules: rulesBackfill }),
+    );
+  }
   if (options?.casOnDateUpdated && writeResult.matchedCount === 0) {
     throw new CasConflictError();
   }

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -1293,6 +1293,11 @@ export async function updateFeature(
     });
   }
 
+  // `buildFeatureUpdate` below scrubs `environmentSettings.{env}.rules` from
+  // any update that carries `environmentSettings`, on the invariant that the
+  // top-level v2 `rules` array is the only place rules live on disk. Neither
+  // half of that invariant holds on its own, so both are backfilled here.
+
   // Hygiene: when persisting a new top-level v2 `rules` array, also force-scrub
   // any legacy `environmentSettings.{env}.rules` from the doc. The JIT read
   // migration trusts top-level v2 rules over env.rules now (so this is no
@@ -1307,6 +1312,21 @@ export async function updateFeature(
     feature.environmentSettings
   ) {
     allUpdates.environmentSettings = { ...feature.environmentSettings };
+  }
+
+  // The mirror, and load-bearing for correctness: an update carrying
+  // `environmentSettings` but no `rules` triggers the same scrub with nothing
+  // to replace it. On a still-v1-shaped doc those env rules ARE the live rules
+  // — the top-level array is empty on disk and only filled JIT on read by
+  // `migrateRawFeatureToV2` — so the scrub erases every rule the feature had.
+  // Publishing a revision hits this whenever the rules themselves didn't
+  // change: the merge reports no rule diff, so `computeRevisionMergeChanges`
+  // omits `changes.rules` while still writing `environmentSettings`, and
+  // enabling a feature in a new environment silently drops the rest.
+  // `feature.rules` is the migrated live state the reader already sees, so
+  // persisting it is a no-op on v2 docs and a repair on v1 ones.
+  if (allUpdates.environmentSettings && allUpdates.rules === undefined) {
+    allUpdates.rules = feature.rules ?? [];
   }
 
   const normalizedUpdates = buildFeatureUpdate(allUpdates);

--- a/packages/back-end/test/models/featureV1RulePreservation.test.ts
+++ b/packages/back-end/test/models/featureV1RulePreservation.test.ts
@@ -149,6 +149,43 @@ describe("updateFeature rule preservation on env-settings writes", () => {
     ]);
   });
 
+  it("does not revert a concurrent rules write on a v2 doc", async () => {
+    const v2Rule = {
+      ...devRule,
+      allEnvironments: false,
+      environments: ["dev"],
+    };
+    await seed({
+      id: "race-flag",
+      rules: [v2Rule],
+      environmentSettings: {
+        dev: { enabled: true },
+        production: { enabled: true },
+      },
+    });
+
+    const preImage = await load("race-flag");
+
+    // A publish lands new rules after the pre-image was read. The env-settings
+    // write below carries no `rules`, so it must leave them alone rather than
+    // backfilling the stale pre-image over them.
+    await mongoose.connection
+      .collection("features")
+      .updateOne(
+        { organization: ORG_ID, id: "race-flag" },
+        { $set: { rules: [{ ...v2Rule, id: "fr_published" }] } },
+      );
+
+    await updateFeature(context, preImage, {
+      environmentSettings: {
+        ...preImage.environmentSettings,
+        "self-hosted": { enabled: true },
+      },
+    });
+
+    expect(await rawRules("race-flag")).toMatchObject([{ id: "fr_published" }]);
+  });
+
   it("still lets a caller replace the rules outright", async () => {
     await seed({
       id: "replace-flag",

--- a/packages/back-end/test/models/featureV1RulePreservation.test.ts
+++ b/packages/back-end/test/models/featureV1RulePreservation.test.ts
@@ -1,0 +1,204 @@
+import mongoose from "mongoose";
+import type { Request } from "express";
+import type { OrganizationInterface } from "shared/types/organization";
+import { ReqContextClass } from "back-end/src/services/context";
+import { getFeature, updateFeature } from "back-end/src/models/FeatureModel";
+import { setupApp } from "../api/api.setup";
+
+/**
+ * Where rules live on disk after a write to a v1-shaped doc, against real Mongo.
+ *
+ * A v1 doc keeps its rules in `environmentSettings.<env>.rules` with an empty
+ * top-level `rules` array; they're flattened JIT on read. `updateFeature`
+ * holds the invariant that after any write the top-level array is the only
+ * copy on disk, and backfills it from both directions:
+ *
+ *   - a write carrying `environmentSettings` but no `rules` must still land
+ *     the rules (this half was missing — enabling a feature in a new
+ *     environment silently deleted every rule it had);
+ *   - a write carrying `rules` but no `environmentSettings` must still scrub
+ *     the legacy env copy, so nothing is left to shadow the new array.
+ */
+
+const ORG_ID = "org_v1_rule_preservation";
+
+const org = {
+  id: ORG_ID,
+  name: "V1 Rule Preservation",
+  ownerEmail: "test@test.com",
+  url: "",
+  dateCreated: new Date(),
+  members: [],
+  settings: {
+    environments: [
+      { id: "dev", description: "" },
+      { id: "production", description: "" },
+      { id: "self-hosted", description: "" },
+    ],
+  },
+} as unknown as OrganizationInterface;
+
+const devRule = {
+  type: "force",
+  id: "fr_keepme",
+  description: "Employee dev instances",
+  value: "true",
+  enabled: true,
+  condition: '{"admin": true}',
+  savedGroups: [],
+};
+
+describe("updateFeature rule preservation on env-settings writes", () => {
+  setupApp();
+  let context: ReqContextClass;
+
+  beforeEach(async () => {
+    context = new ReqContextClass({
+      org,
+      auditUser: { type: "api_key", apiKey: "key_test" },
+      role: "admin",
+      req: { query: {}, headers: {} } as unknown as Request,
+    });
+    await mongoose.connection
+      .collection("features")
+      .deleteMany({ organization: ORG_ID });
+  });
+
+  async function seed(doc: Record<string, unknown>) {
+    await mongoose.connection.collection("features").insertOne({
+      organization: ORG_ID,
+      valueType: "boolean",
+      defaultValue: "false",
+      version: 1,
+      dateCreated: new Date(Date.now() - 60_000),
+      dateUpdated: new Date(Date.now() - 60_000),
+      ...doc,
+    });
+  }
+
+  async function load(id: string) {
+    const feature = await getFeature(context, id);
+    if (!feature) throw new Error("seed missing");
+    return feature;
+  }
+
+  const rawDoc = async (id: string) =>
+    await mongoose.connection
+      .collection("features")
+      .findOne({ organization: ORG_ID, id });
+
+  const rawRules = async (id: string) => (await rawDoc(id))?.rules ?? [];
+
+  it("keeps a v1 doc's env rules when a write only enables another environment", async () => {
+    await seed({
+      id: "v1-flag",
+      rules: [],
+      environmentSettings: {
+        dev: { enabled: true, rules: [devRule] },
+        production: { enabled: true, rules: [] },
+      },
+    });
+
+    const preImage = await load("v1-flag");
+    // Read flattens the legacy env rules, so the pre-image already sees them.
+    expect(preImage.rules).toHaveLength(1);
+
+    // Mirrors what publishing an enablement-only revision sends: the whole
+    // env-settings map (rules already scrubbed in memory) and no `rules` key.
+    await updateFeature(context, preImage, {
+      environmentSettings: {
+        ...preImage.environmentSettings,
+        "self-hosted": { enabled: true },
+      },
+    });
+
+    // Materialized onto the doc rather than dropped with the legacy copy.
+    expect(await rawRules("v1-flag")).toMatchObject([
+      { id: "fr_keepme", environments: ["dev"] },
+    ]);
+    const after = await load("v1-flag");
+    expect(after.rules).toMatchObject([{ id: "fr_keepme" }]);
+    expect(after.environmentSettings["self-hosted"].enabled).toBe(true);
+  });
+
+  it("leaves a v2 doc's existing flat rules untouched", async () => {
+    const v2Rule = {
+      ...devRule,
+      allEnvironments: false,
+      environments: ["dev"],
+    };
+    await seed({
+      id: "v2-flag",
+      rules: [v2Rule],
+      environmentSettings: {
+        dev: { enabled: true },
+        production: { enabled: true },
+      },
+    });
+
+    const preImage = await load("v2-flag");
+    await updateFeature(context, preImage, {
+      environmentSettings: {
+        ...preImage.environmentSettings,
+        "self-hosted": { enabled: true },
+      },
+    });
+
+    expect(await rawRules("v2-flag")).toMatchObject([
+      { id: "fr_keepme", environments: ["dev"] },
+    ]);
+  });
+
+  it("still lets a caller replace the rules outright", async () => {
+    await seed({
+      id: "replace-flag",
+      rules: [],
+      environmentSettings: {
+        dev: { enabled: true, rules: [devRule] },
+        production: { enabled: true, rules: [] },
+      },
+    });
+
+    const preImage = await load("replace-flag");
+    await updateFeature(context, preImage, {
+      environmentSettings: {
+        ...preImage.environmentSettings,
+        "self-hosted": { enabled: true },
+      },
+      rules: [],
+    });
+
+    // An explicit `rules: []` is intent, not an omission — don't resurrect.
+    expect(await rawRules("replace-flag")).toHaveLength(0);
+  });
+
+  it("scrubs a v1 doc's legacy env rules when a write carries only rules", async () => {
+    await seed({
+      id: "scrub-flag",
+      rules: [],
+      environmentSettings: {
+        dev: { enabled: true, rules: [devRule] },
+        production: { enabled: true, rules: [] },
+      },
+    });
+
+    const preImage = await load("scrub-flag");
+    await updateFeature(context, preImage, {
+      rules: [
+        { ...devRule, id: "fr_replacement", environments: ["dev"] },
+      ] as never,
+    });
+
+    const doc = await rawDoc("scrub-flag");
+    expect(doc?.rules).toMatchObject([{ id: "fr_replacement" }]);
+    // The legacy copy must not survive alongside the new array: left behind,
+    // it re-classifies the doc as v1 on the next read and shadows the write.
+    expect(doc?.environmentSettings.dev).not.toHaveProperty("rules");
+    expect(doc?.environmentSettings.production).not.toHaveProperty("rules");
+    // ...and the env's own non-rule state is untouched by that scrub.
+    expect(doc?.environmentSettings.dev.enabled).toBe(true);
+
+    const after = await load("scrub-flag");
+    expect(after.rules).toMatchObject([{ id: "fr_replacement" }]);
+  });
+});


### PR DESCRIPTION
### Features and Changes

Publishing a feature revision that changed **only** environment enablement silently deleted every rule on features still stored in the v1 shape. The write returned 200 and the SDK payload simply stopped serving those rules.

A v1-shaped doc keeps its rules in `environmentSettings.<env>.rules`, with an empty top-level `rules: []`. `migrateRawFeatureToV2` flattens them JIT on read, so the feature looks completely healthy everywhere you'd normally look.

On write, `buildFeatureUpdate` strips the legacy `env.rules` key from any update carrying `environmentSettings`, on the invariant that the top-level array is the only place rules live on disk. When the update doesn't also carry `rules`, nothing takes their place.

Publishing a revision hits exactly that case whenever the rules themselves didn't change: the merge reports no rule diff, so `computeRevisionMergeChanges` omits `changes.rules` while still writing `environmentSettings`. Enabling a feature in a new environment was enough to drop the rules of every other environment. The revision document was written correctly — only the feature doc, which the read path actually uses, was emptied, which is why nothing surfaced until a payload was fetched.

`updateFeature` already held one half of this invariant, ~55 lines below the fix: an update carrying `rules` but no `environmentSettings` injects a scrubbed env-settings payload so the legacy copy can't shadow the new array. The fix adds the missing mirror, immediately beneath it under a shared comment, so the two halves read as one invariant:

```ts
if (allUpdates.environmentSettings && allUpdates.rules === undefined) {
  allUpdates.rules = feature.rules ?? [];
}
```

`feature.rules` is the migrated live state the reader already sees, so persisting it is a no-op on v2 docs and a repair on v1 ones.

Found while migrating a clone of the production org: 53 of its 142 features are in the v1 shape, and a script performing 115 env-enablement writes stripped rules across a large fraction of them.

- Closes **(add link to issue here)**

### Dependencies

None.

### Testing

`packages/back-end/test/models/featureV1RulePreservation.test.ts` — real-Mongo coverage of the invariant in both directions, modelled on `updateFeatureGuard.test.ts`:

- env-settings write with no `rules` → rules still land (the regression)
- rules write with no `environmentSettings` → legacy env copy still scrubbed (the pre-existing mirror guard, previously untested)
- a v2 doc's flat rules are left untouched (the backfill must be a no-op)
- an explicit `rules: []` stays intent rather than an omission to backfill

Each guard was verified to be load-bearing by removing it and confirming the matching test fails.

Also verified end-to-end against a clone of the production org: payload corruption from a full project/environment restructure went from **14 features per SDK connection to 0**, with every one of the 9 connections' payloads byte-identical to `cdn.growthbook.io` beforehand.

```bash
pnpm --filter back-end test -- test/models/featureV1RulePreservation.test.ts
```

Related suites green: `featureV1RulePreservation`, `FeatureModel`, `updateFeatureGuard`, `computeRevisionMergeChanges` (84 tests), plus `test/features.test.ts`, `test/revisions`, `test/models`, `test/migrations.test.ts` (1070 tests).

### Screenshots

N/A — back-end only.
