### PR TITLE
Add a `replaces` field to fact metrics

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -28494,6 +28494,18 @@ paths:
                   type: array
                   items:
                     type: string
+                replaces:
+                  description: >-
+                    Ids of older metrics (legacy or fact) that this metric
+                    supersedes, for example the legacy metric it was migrated
+                    from. Cannot include this metric's own id. Informational
+                    only - GrowthBook uses it to link the old and new
+                    definitions in the UI and to keep showing results from a
+                    snapshot that was created before an experiment switched to
+                    this metric. This field can only be set through the API.
+                  type: array
+                  items:
+                    type: string
               required:
                 - name
                 - metricType
@@ -29159,6 +29171,18 @@ paths:
                   description: >-
                     Array of slice column names that will be automatically
                     included in metric analysis. This is an enterprise feature.
+                  type: array
+                  items:
+                    type: string
+                replaces:
+                  description: >-
+                    Ids of older metrics (legacy or fact) that this metric
+                    supersedes, for example the legacy metric it was migrated
+                    from. Cannot include this metric's own id. Informational
+                    only - GrowthBook uses it to link the old and new
+                    definitions in the UI and to keep showing results from a
+                    snapshot that was created before an experiment switched to
+                    this metric. This field can only be set through the API.
                   type: array
                   items:
                     type: string
@@ -30150,6 +30174,20 @@ paths:
                               Array of slice column names that will be
                               automatically included in metric analysis. This is
                               an enterprise feature.
+                            type: array
+                            items:
+                              type: string
+                          replaces:
+                            description: >-
+                              Ids of older metrics (legacy or fact) that this
+                              metric supersedes, for example the legacy metric
+                              it was migrated from. Cannot include this metric's
+                              own id. Informational only - GrowthBook uses it to
+                              link the old and new definitions in the UI and to
+                              keep showing results from a snapshot that was
+                              created before an experiment switched to this
+                              metric. This field can only be set through the
+                              API.
                             type: array
                             items:
                               type: string
@@ -60022,6 +60060,16 @@ components:
           description: >-
             Array of slice column names that will be automatically included in
             metric analysis. This is an enterprise feature.
+          type: array
+          items:
+            type: string
+        replaces:
+          description: >-
+            Ids of older metrics (legacy or fact) that this metric supersedes,
+            for example the legacy metric it was migrated from. Informational
+            only - GrowthBook uses it to link the old and new definitions in the
+            UI and to keep showing results from a snapshot that was created
+            before an experiment switched to this metric.
           type: array
           items:
             type: string

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -28494,6 +28494,18 @@ paths:
                   type: array
                   items:
                     type: string
+                replaces:
+                  description: >-
+                    Ids of older metrics (legacy or fact) that this metric
+                    supersedes, for example the legacy metric it was migrated
+                    from. Cannot include this metric's own id. Informational
+                    only - GrowthBook uses it to link the old and new
+                    definitions in the UI and to keep showing results from a
+                    snapshot that was created before an experiment switched to
+                    this metric. This field can only be set through the API.
+                  type: array
+                  items:
+                    type: string
               required:
                 - name
                 - metricType
@@ -29159,6 +29171,18 @@ paths:
                   description: >-
                     Array of slice column names that will be automatically
                     included in metric analysis. This is an enterprise feature.
+                  type: array
+                  items:
+                    type: string
+                replaces:
+                  description: >-
+                    Ids of older metrics (legacy or fact) that this metric
+                    supersedes, for example the legacy metric it was migrated
+                    from. Cannot include this metric's own id. Informational
+                    only - GrowthBook uses it to link the old and new
+                    definitions in the UI and to keep showing results from a
+                    snapshot that was created before an experiment switched to
+                    this metric. This field can only be set through the API.
                   type: array
                   items:
                     type: string
@@ -30150,6 +30174,20 @@ paths:
                               Array of slice column names that will be
                               automatically included in metric analysis. This is
                               an enterprise feature.
+                            type: array
+                            items:
+                              type: string
+                          replaces:
+                            description: >-
+                              Ids of older metrics (legacy or fact) that this
+                              metric supersedes, for example the legacy metric
+                              it was migrated from. Cannot include this metric's
+                              own id. Informational only - GrowthBook uses it to
+                              link the old and new definitions in the UI and to
+                              keep showing results from a snapshot that was
+                              created before an experiment switched to this
+                              metric. This field can only be set through the
+                              API.
                             type: array
                             items:
                               type: string
@@ -60022,6 +60060,16 @@ components:
           description: >-
             Array of slice column names that will be automatically included in
             metric analysis. This is an enterprise feature.
+          type: array
+          items:
+            type: string
+        replaces:
+          description: >-
+            Ids of older metrics (legacy or fact) that this metric supersedes,
+            for example the legacy metric it was migrated from. Informational
+            only - GrowthBook uses it to link the old and new definitions in the
+            UI and to keep showing results from a snapshot that was created
+            before an experiment switched to this metric.
           type: array
           items:
             type: string

--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -116,6 +116,16 @@ function validateUserFilter({
   }
 }
 
+// Existence is not checked: the replaced metric is often deleted later, and
+// failing validation then would make the surviving metric un-editable.
+function validateReplaces({ id, replaces }: FactMetricInterface): void {
+  if (!replaces?.length) return;
+
+  if (replaces.includes(id)) {
+    throw new Error("A metric cannot replace itself");
+  }
+}
+
 function denominatorRequiredByMetricType(metricType: FactMetricType): boolean {
   switch (metricType) {
     case "mean":
@@ -449,6 +459,8 @@ export class FactMetricModel extends BaseClass {
         `maxPercentChange (${data.maxPercentChange}) must be greater than minPercentChange (${data.minPercentChange})`,
       );
     }
+
+    validateReplaces(data);
   }
 
   protected async customValidation(

--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -46,6 +46,7 @@ import RadixTooltip from "@/ui/Tooltip";
 import { SSRPolyfills } from "@/hooks/useSSRPolyfills";
 import ResultsTable from "@/components/Experiment/ResultsTable";
 import { OfficialBadge } from "@/components/Metrics/MetricName";
+import { ReplacedMetricWarning } from "@/components/Metrics/MetricReplacement";
 import styles from "./CompactResults.module.scss";
 import { ExperimentTab } from "./TabbedPage";
 import MultipleExposureWarning from "./MultipleExposureWarning";
@@ -819,6 +820,9 @@ export function getRenderLabelColumn({
                   </Link>
                 )}
               </Text>
+              {row?.replacedByMetricName ? (
+                <ReplacedMetricWarning name={row.replacedByMetricName} />
+              ) : null}
             </span>
           </span>
         </div>

--- a/packages/front-end/components/Metrics/MetricReplacement.tsx
+++ b/packages/front-end/components/Metrics/MetricReplacement.tsx
@@ -1,4 +1,5 @@
 import { Fragment } from "react";
+import { Box } from "@radix-ui/themes";
 import { getMetricLink } from "shared/experiments";
 import { PiWarningFill } from "react-icons/pi";
 import Callout from "@/ui/Callout";
@@ -17,17 +18,14 @@ export function ReplacedByCallout({ metricId }: { metricId: string }) {
 
   return (
     <Callout status="info" mb="2">
-      <strong>
-        This metric has been replaced by{" "}
-        {replacements.map((m, i) => (
-          <Fragment key={m.id}>
-            {i > 0 ? ", " : ""}
-            <Link href={getMetricLink(m.id)}>{m.name}</Link>
-          </Fragment>
-        ))}
-        .
-      </strong>{" "}
-      Prefer the newer metric in new experiments.
+      <strong>This metric has been replaced.</strong> Prefer{" "}
+      {replacements.map((m, i) => (
+        <Fragment key={m.id}>
+          {i > 0 ? ", " : ""}
+          <Link href={getMetricLink(m.id)}>{m.name}</Link>
+        </Fragment>
+      ))}{" "}
+      in new experiments.
     </Callout>
   );
 }
@@ -62,18 +60,22 @@ export function ReplacesMetadata({ replaces }: { replaces?: string[] }) {
 }
 
 export function ReplacedMetricWarning({ name }: { name: string }) {
+  const label = `Replaced by “${name}”. Showing the previous metric’s results until results are refreshed.`;
   return (
-    <Tooltip
-      content={`Replaced by “${name}”. Showing the previous metric’s results until results are refreshed.`}
-    >
-      <PiWarningFill
-        size={14}
-        style={{
-          color: "var(--amber-11)",
-          marginLeft: 4,
-          verticalAlign: "-0.15em",
-        }}
-      />
+    <Tooltip content={label}>
+      <Box
+        as="span"
+        display="inline-block"
+        ml="1"
+        tabIndex={0}
+        aria-label={label}
+      >
+        <PiWarningFill
+          size={14}
+          aria-hidden
+          style={{ color: "var(--amber-11)", verticalAlign: "-0.15em" }}
+        />
+      </Box>
     </Tooltip>
   );
 }

--- a/packages/front-end/components/Metrics/MetricReplacement.tsx
+++ b/packages/front-end/components/Metrics/MetricReplacement.tsx
@@ -1,0 +1,79 @@
+import { Fragment } from "react";
+import { getMetricLink } from "shared/experiments";
+import { PiWarningFill } from "react-icons/pi";
+import Callout from "@/ui/Callout";
+import Link from "@/ui/Link";
+import Metadata from "@/ui/Metadata";
+import Tooltip from "@/ui/Tooltip";
+import { useDefinitions } from "@/services/DefinitionsContext";
+
+export function ReplacedByCallout({ metricId }: { metricId: string }) {
+  const { _factMetricsIncludingArchived } = useDefinitions();
+
+  const replacements = _factMetricsIncludingArchived.filter((m) =>
+    m.replaces?.includes(metricId),
+  );
+  if (!replacements.length) return null;
+
+  return (
+    <Callout status="info" mb="2">
+      <strong>
+        This metric has been replaced by{" "}
+        {replacements.map((m, i) => (
+          <Fragment key={m.id}>
+            {i > 0 ? ", " : ""}
+            <Link href={getMetricLink(m.id)}>{m.name}</Link>
+          </Fragment>
+        ))}
+        .
+      </strong>{" "}
+      Prefer the newer metric in new experiments.
+    </Callout>
+  );
+}
+
+export function ReplacesMetadata({ replaces }: { replaces?: string[] }) {
+  const { getExperimentMetricById } = useDefinitions();
+
+  if (!replaces?.length) return null;
+
+  return (
+    <Metadata
+      label="Replaces"
+      value={
+        <>
+          {replaces.map((id, i) => {
+            const metric = getExperimentMetricById(id);
+            return (
+              <Fragment key={id}>
+                {i > 0 ? <span>,&nbsp;</span> : null}
+                {metric ? (
+                  <Link href={getMetricLink(id)}>{metric.name}</Link>
+                ) : (
+                  <em>{id}</em>
+                )}
+              </Fragment>
+            );
+          })}
+        </>
+      }
+    />
+  );
+}
+
+export function ReplacedMetricWarning({ name }: { name: string }) {
+  return (
+    <Tooltip
+      content={`Replaced by “${name}”. Showing the previous metric’s results until results are refreshed.`}
+    >
+      <PiWarningFill
+        size={14}
+        style={{
+          color: "var(--amber-11)",
+          marginLeft: 4,
+          verticalAlign: "-0.15em",
+        }}
+      />
+    </Tooltip>
+  );
+}

--- a/packages/front-end/hooks/useExperimentDimensionRows.ts
+++ b/packages/front-end/hooks/useExperimentDimensionRows.ts
@@ -15,6 +15,8 @@ import {
   isMetricGroupId,
   isFactFunnelMetric,
   funnelStepMetricId,
+  resolveMetricsForSnapshot,
+  resolveSnapshotMetricIds,
 } from "shared/experiments";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import {
@@ -278,12 +280,24 @@ export function useExperimentDimensionRows({
     ]);
 
   const tables = useMemo(() => {
+    const getMetricById = (id: string) =>
+      ssrPolyfills?.getExperimentMetricById?.(id) ||
+      getExperimentMetricById(id);
+
     if (!results.length || (!ready && !ssrPolyfills)) {
       return [];
     }
 
     if (pValueCorrection && statsEngine === "frequentist") {
-      setAdjustedPValuesOnResults(results, expandedGoals, pValueCorrection);
+      setAdjustedPValuesOnResults(
+        results,
+        resolveSnapshotMetricIds({
+          metricIds: expandedGoals,
+          getExperimentMetricById: getMetricById,
+          results,
+        }),
+        pValueCorrection,
+      );
       setAdjustedCIs(results, pValueThreshold);
     }
 
@@ -294,11 +308,7 @@ export function useExperimentDimensionRows({
     ) {
       // Get metric definitions
       const metricDefs = metricIds
-        .map(
-          (metricId) =>
-            ssrPolyfills?.getExperimentMetricById?.(metricId) ||
-            getExperimentMetricById(metricId),
-        )
+        .map(getMetricById)
         .filter((m): m is ExperimentMetricDefinition => !!m);
 
       // Apply tag filtering first (independent of sorting)
@@ -325,71 +335,73 @@ export function useExperimentDimensionRows({
               )
             : filteredMetricIds;
 
-      return sortedMetricIds
-        .map((metricId) => {
-          const metric =
-            ssrPolyfills?.getExperimentMetricById?.(metricId) ||
-            getExperimentMetricById(metricId);
-          if (!metric) return null;
+      const buildTable = (
+        metric: ExperimentMetricDefinition,
+        replacedByMetricName: string | undefined,
+      ) => {
+        const { newMetric, overrideFields } = applyMetricOverrides(
+          metric,
+          metricOverrides,
+        );
+        const metricSnapshotSettings = settingsForSnapshotMetrics?.find(
+          (s) => s.metric === metric.id,
+        );
 
-          // Apply filtering first (independent of sorting)
-          const filteredMetrics = filterMetricsByTags(
-            [metric],
-            metricTagFilter,
-          );
-          if (filteredMetrics.length === 0) return null;
+        // Handle quantile metric errors
+        if (showErrorsOnQuantileMetrics && quantileMetricType(newMetric)) {
+          return {
+            metric: newMetric,
+            isGuardrail: resultGroup === "guardrail",
+            rows: [
+              {
+                label: "",
+                metric: newMetric,
+                variations: [],
+                metricSnapshotSettings,
+                resultGroup,
+                metricOverrideFields: overrideFields,
+                error: RowError.QUANTILE_AGGREGATION_ERROR,
+                replacedByMetricName,
+              },
+            ],
+          };
+        }
 
-          const { newMetric, overrideFields } = applyMetricOverrides(
-            metric,
-            metricOverrides,
-          );
-          let _metricSnapshotSettings: MetricSnapshotSettings | undefined;
-          if (settingsForSnapshotMetrics) {
-            _metricSnapshotSettings = settingsForSnapshotMetrics.find(
-              (s) => s.metric === metricId,
-            );
-          }
-
-          // Handle quantile metric errors
-          if (showErrorsOnQuantileMetrics && quantileMetricType(newMetric)) {
-            return {
-              metric: newMetric,
-              isGuardrail: resultGroup === "guardrail",
-              rows: [
-                {
-                  label: "",
-                  metric: newMetric,
-                  variations: [],
-                  metricSnapshotSettings: _metricSnapshotSettings,
-                  resultGroup,
-                  metricOverrideFields: overrideFields,
-                  error: RowError.QUANTILE_AGGREGATION_ERROR,
-                },
-              ],
-            };
-          }
-
-          const rows = generateDimensionRowsForMetric({
-            metricId,
+        return {
+          metric: newMetric,
+          isGuardrail: resultGroup === "guardrail",
+          rows: generateDimensionRowsForMetric({
+            metricId: metric.id,
             resultGroup,
             results,
             dimensionValuesFilter,
             overrideFields,
-            metricSnapshotSettings: _metricSnapshotSettings,
+            metricSnapshotSettings,
             newMetric,
-          });
+            replacedByMetricName,
+          }),
+        };
+      };
 
-          return {
-            metric: newMetric,
-            isGuardrail: resultGroup === "guardrail",
-            rows,
-          };
+      const seenMetricIds = new Set<string>();
+      return sortedMetricIds
+        .flatMap((metricId) => {
+          const experimentMetric = getMetricById(metricId);
+          if (!experimentMetric) return [];
+          const { metrics, replacedByMetricName } = resolveMetricsForSnapshot({
+            metric: experimentMetric,
+            getExperimentMetricById: getMetricById,
+            results,
+          });
+          return metrics.map((metric) =>
+            buildTable(metric, replacedByMetricName),
+          );
         })
-        .filter((table) => table?.metric) as Array<{
-        metric: ExperimentMetricDefinition;
-        isGuardrail: boolean;
-        rows: ExperimentTableRow[];
-      }>;
+        .filter(
+          (table) =>
+            !seenMetricIds.has(table.metric.id) &&
+            !!seenMetricIds.add(table.metric.id),
+        );
     }
 
     const tables = [
@@ -488,6 +500,7 @@ export function generateDimensionRowsForMetric({
   overrideFields,
   metricSnapshotSettings,
   newMetric,
+  replacedByMetricName,
 }: {
   metricId: string;
   resultGroup: "goal" | "secondary" | "guardrail";
@@ -496,6 +509,7 @@ export function generateDimensionRowsForMetric({
   overrideFields: string[];
   metricSnapshotSettings: MetricSnapshotSettings | undefined;
   newMetric: ExperimentMetricDefinition;
+  replacedByMetricName?: string;
 }): ExperimentTableRow[] {
   const filteredResults = includeVariation(results, dimensionValuesFilter);
 
@@ -527,6 +541,7 @@ export function generateDimensionRowsForMetric({
       ),
       metricSnapshotSettings,
       resultGroup,
+      replacedByMetricName,
     };
 
     if (!funnelSteps.length) {
@@ -551,6 +566,7 @@ export function generateDimensionRowsForMetric({
         ),
         metricSnapshotSettings,
         resultGroup,
+        replacedByMetricName,
         numChildren: 0,
         isChildRow: true,
         childRowType: "funnelStep",

--- a/packages/front-end/hooks/useExperimentTableRows.ts
+++ b/packages/front-end/hooks/useExperimentTableRows.ts
@@ -25,6 +25,8 @@ import {
   generateSliceString,
   generateSelectAllSliceString,
   isMetricGroupId,
+  resolveMetricsForSnapshot,
+  resolveSnapshotMetricIds,
 } from "shared/experiments";
 import { MetricGroupInterface } from "shared/types/metric-groups";
 import { isDefined } from "shared/util";
@@ -298,12 +300,12 @@ export function useExperimentTableRows({
     ]);
 
   const unsortedRows = useMemo<ExperimentTableRow[]>(() => {
-    function getRowsForMetric(
-      metricId: string,
+    function getRowsForMetricGroup(
+      metricIds: string[],
       resultGroup: "goal" | "secondary" | "guardrail",
     ): ExperimentTableRow[] {
-      return generateRowsForMetric({
-        metricId,
+      return generateRowsForMetricGroup({
+        metricIds,
         resultGroup,
         results,
         metricOverrides,
@@ -320,7 +322,15 @@ export function useExperimentTableRows({
     if (!results || !results.variations || (!ready && !ssrPolyfills)) return [];
     if (pValueCorrection && statsEngine === "frequentist") {
       // Only include goals in calculation, not secondary or guardrails
-      setAdjustedPValuesOnResults([results], expandedGoals, pValueCorrection);
+      setAdjustedPValuesOnResults(
+        [results],
+        resolveSnapshotMetricIds({
+          metricIds: expandedGoals,
+          getExperimentMetricById,
+          results: [results],
+        }),
+        pValueCorrection,
+      );
       setAdjustedCIs([results], pValueThreshold);
     }
 
@@ -417,17 +427,11 @@ export function useExperimentTableRows({
             )
           : filteredGuardrails;
 
-    const retMetrics = sortedFilteredMetrics.flatMap((metricId) =>
-      getRowsForMetric(metricId, "goal"),
-    );
-    const retSecondary = sortedFilteredSecondary.flatMap((metricId) =>
-      getRowsForMetric(metricId, "secondary"),
-    );
-    const retGuardrails = sortedFilteredGuardrails.flatMap((metricId) =>
-      getRowsForMetric(metricId, "guardrail"),
-    );
-
-    return [...retMetrics, ...retSecondary, ...retGuardrails];
+    return [
+      ...getRowsForMetricGroup(sortedFilteredMetrics, "goal"),
+      ...getRowsForMetricGroup(sortedFilteredSecondary, "secondary"),
+      ...getRowsForMetricGroup(sortedFilteredGuardrails, "guardrail"),
+    ];
   }, [
     results,
     metricGroups,
@@ -471,6 +475,39 @@ export function useExperimentTableRows({
     rows,
     getChildRowCounts,
   };
+}
+
+/**
+ * Rows for one result group, substituting the metrics a newer metric replaces
+ * when the snapshot only has the older ones. Ids in a group are already
+ * deduped, but substitution can reintroduce collisions - two new metrics can
+ * each replace the same older one - so keep the first occurrence.
+ */
+export function generateRowsForMetricGroup({
+  metricIds,
+  ...params
+}: Omit<Parameters<typeof generateRowsForMetric>[0], "metricId"> & {
+  metricIds: string[];
+}): ExperimentTableRow[] {
+  const { results, getExperimentMetricById } = params;
+  const seen = new Set<string>();
+  return metricIds.flatMap((metricId) => {
+    const metric = getExperimentMetricById(metricId);
+    if (!metric) return [];
+    const { metrics, replacedByMetricName } = resolveMetricsForSnapshot({
+      metric,
+      getExperimentMetricById,
+      results: Array.isArray(results) ? results : [results],
+    });
+    return metrics.flatMap((m) => {
+      if (seen.has(m.id)) return [];
+      seen.add(m.id);
+      const rows = generateRowsForMetric({ ...params, metricId: m.id });
+      return replacedByMetricName
+        ? rows.map((row) => ({ ...row, replacedByMetricName }))
+        : rows;
+    });
+  });
 }
 
 export function generateRowsForMetric({

--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -80,6 +80,10 @@ import {
   isMergeAggregationMetric,
   REST_API_ONLY_EDIT_MESSAGE,
 } from "@/services/factMetrics";
+import {
+  ReplacedByCallout,
+  ReplacesMetadata,
+} from "@/components/Metrics/MetricReplacement";
 
 function FactTableLink({ id }: { id?: string }) {
   const { getFactTableById } = useDefinitions();
@@ -632,6 +636,7 @@ export default function FactMetricPage() {
           experiments.
         </Callout>
       )}
+      <ReplacedByCallout metricId={factMetric.id} />
       <Flex align="start" justify="between" gap="2" mb="2">
         <Flex align="center" gap="3" style={{ marginTop: "-4px" }}>
           <Heading size="xl" as="h1" overflowWrap="anywhere" mb="0">
@@ -805,6 +810,7 @@ export default function FactMetricPage() {
             </Link>
           }
         />
+        <ReplacesMetadata replaces={factMetric.replaces} />
       </Flex>
       <Box mt="3" mb="3">
         <Flex align="center" gap="1">

--- a/packages/front-end/pages/metric/[mid].tsx
+++ b/packages/front-end/pages/metric/[mid].tsx
@@ -60,6 +60,7 @@ import Tooltip from "@/components/Tooltip/Tooltip";
 import { useCurrency } from "@/hooks/useCurrency";
 import { useUser } from "@/services/UserContext";
 import PageHead from "@/components/Layout/PageHead";
+import { ReplacedByCallout } from "@/components/Metrics/MetricReplacement";
 import { capitalizeFirstLetter } from "@/services/utils";
 import MetricName from "@/components/Metrics/MetricName";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
@@ -427,6 +428,7 @@ const MetricPage: FC = () => {
           experiments.
         </Callout>
       )}
+      <ReplacedByCallout metricId={metric.id} />
 
       <Flex align="start" justify="between" gap="2" mb="2">
         <Flex align="center" gap="3" style={{ marginTop: "-4px" }}>

--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -222,6 +222,7 @@ export type ExperimentTableRow = {
   // Funnel step row properties
   funnelStepIndex?: number;
   funnelStepOptional?: boolean;
+  replacedByMetricName?: string;
   // Dimension-table rows: the raw dimension value this row belongs to. On a
   // parent row this equals its label; child rows (e.g. funnel steps) carry it
   // because their label is the step name, not the dimension value.

--- a/packages/front-end/test/replaced-metric-rows.test.ts
+++ b/packages/front-end/test/replaced-metric-rows.test.ts
@@ -1,0 +1,121 @@
+import { ExperimentMetricDefinition } from "shared/experiments";
+import { FactMetricInterface } from "shared/types/fact-table";
+import { ExperimentReportResultDimension } from "shared/types/report";
+import { generateRowsForMetricGroup } from "@/hooks/useExperimentTableRows";
+
+const NEW_ID = "fact__new";
+const OLD_ID = "met_old";
+
+const newMetric = {
+  id: NEW_ID,
+  name: "Revenue (v2)",
+  metricType: "mean",
+  numerator: { factTableId: "ft", column: "amount", rowFilters: [] },
+  denominator: null,
+  replaces: [OLD_ID],
+} as unknown as FactMetricInterface;
+
+const oldMetric = {
+  id: OLD_ID,
+  name: "Revenue",
+} as unknown as ExperimentMetricDefinition;
+
+const metricsById: Record<string, ExperimentMetricDefinition> = {
+  [NEW_ID]: newMetric,
+  [OLD_ID]: oldMetric,
+};
+
+function resultsFor(...metricIds: string[]): ExperimentReportResultDimension {
+  return {
+    name: "",
+    srm: 1,
+    variations: [0, 1].map((i) => ({
+      users: 1000 + i,
+      metrics: Object.fromEntries(
+        metricIds.map((metricId) => [
+          metricId,
+          { users: 1000 + i, value: 100 + i, cr: 0.1 },
+        ]),
+      ),
+    })),
+  };
+}
+
+function rowsFor(
+  results: ExperimentReportResultDimension,
+  ...metricIds: string[]
+) {
+  return generateRowsForMetricGroup({
+    metricIds: metricIds.length ? metricIds : [NEW_ID],
+    resultGroup: "goal",
+    results,
+    metricOverrides: [],
+    shouldShowMetricSlices: false,
+    getExperimentMetricById: (id) => metricsById[id] ?? null,
+    getFactTableById: () => null,
+  });
+}
+
+describe("generateRowsForMetricGroup with a replaced metric", () => {
+  it("falls back to the replaced metric's results when the snapshot predates the swap", () => {
+    const results = resultsFor(OLD_ID);
+    const [row] = rowsFor(results);
+
+    expect(row.metric.id).toBe(OLD_ID);
+    expect(row.replacedByMetricName).toBe("Revenue (v2)");
+    results.variations.forEach((v, i) => {
+      expect(row.variations[i]).toEqual(v.metrics[OLD_ID]);
+    });
+  });
+
+  it("uses the metric's own results when the snapshot has them", () => {
+    const results = resultsFor(NEW_ID);
+    const [row] = rowsFor(results);
+
+    expect(row.metric.id).toBe(NEW_ID);
+    expect(row.replacedByMetricName).toBeUndefined();
+  });
+
+  it("renders a row per replaced metric when one metric consolidates several", () => {
+    const oldIds = ["met_a", "met_b", "met_c"];
+    oldIds.forEach((id) => {
+      metricsById[id] = { id, name: id } as ExperimentMetricDefinition;
+    });
+    const consolidatedId = "fact__consolidated";
+    metricsById[consolidatedId] = {
+      ...newMetric,
+      id: consolidatedId,
+      name: "Consolidated",
+      replaces: oldIds,
+    } as unknown as FactMetricInterface;
+
+    const rows = rowsFor(resultsFor(...oldIds), consolidatedId);
+
+    expect(rows.map((r) => r.metric.id)).toEqual(oldIds);
+    rows.forEach((row) => {
+      expect(row.replacedByMetricName).toBe("Consolidated");
+    });
+  });
+
+  it("renders a replaced metric once when two metrics both replace it", () => {
+    const otherId = "fact__other";
+    metricsById[otherId] = {
+      ...newMetric,
+      id: otherId,
+      name: "Revenue (v3)",
+    } as unknown as FactMetricInterface;
+
+    const rows = rowsFor(resultsFor(OLD_ID), NEW_ID, otherId);
+
+    expect(rows.map((r) => r.metric.id)).toEqual([OLD_ID]);
+    expect(rows[0].replacedByMetricName).toBe("Revenue (v2)");
+  });
+
+  it("does not substitute in reverse when only the replacement is in the snapshot", () => {
+    const [row] = rowsFor(resultsFor(NEW_ID), OLD_ID);
+
+    expect(row.metric.id).toBe(OLD_ID);
+    expect(row.replacedByMetricName).toBeUndefined();
+    expect(row.variations[0].errorMessage).toBe("No data");
+  });
+});

--- a/packages/shared/src/experiments/index.ts
+++ b/packages/shared/src/experiments/index.ts
@@ -1,4 +1,5 @@
 export * from "./experiments";
+export * from "./metric-replacement";
 export * from "./outdated-reasons";
 export * from "./phases";
 export * from "./targeting";

--- a/packages/shared/src/experiments/metric-replacement.ts
+++ b/packages/shared/src/experiments/metric-replacement.ts
@@ -53,13 +53,17 @@ export function resolveSnapshotMetricIds({
   getExperimentMetricById: (id: string) => ExperimentMetricDefinition | null;
   results: ExperimentReportResultDimension[];
 }): string[] {
-  return metricIds.flatMap((metricId) => {
-    const metric = getExperimentMetricById(metricId);
-    if (!metric) return [metricId];
-    return resolveMetricsForSnapshot({
-      metric,
-      getExperimentMetricById,
-      results,
-    }).metrics.map((m) => m.id);
-  });
+  return [
+    ...new Set(
+      metricIds.flatMap((metricId) => {
+        const metric = getExperimentMetricById(metricId);
+        if (!metric) return [metricId];
+        return resolveMetricsForSnapshot({
+          metric,
+          getExperimentMetricById,
+          results,
+        }).metrics.map((m) => m.id);
+      }),
+    ),
+  ];
 }

--- a/packages/shared/src/experiments/metric-replacement.ts
+++ b/packages/shared/src/experiments/metric-replacement.ts
@@ -1,0 +1,65 @@
+import { ExperimentReportResultDimension } from "shared/types/report";
+import { ExperimentMetricDefinition, isFactMetric } from "./experiments";
+
+function snapshotHasMetric(
+  results: ExperimentReportResultDimension[],
+  metricId: string,
+): boolean {
+  return results.some((result) =>
+    result.variations.some((v) => v.metrics?.[metricId] !== undefined),
+  );
+}
+
+// Older metrics are substituted only when the snapshot has their results and
+// not this metric's.
+export function resolveMetricsForSnapshot({
+  metric,
+  getExperimentMetricById,
+  results,
+}: {
+  metric: ExperimentMetricDefinition;
+  getExperimentMetricById: (id: string) => ExperimentMetricDefinition | null;
+  results: ExperimentReportResultDimension[];
+}): {
+  metrics: ExperimentMetricDefinition[];
+  replacedByMetricName?: string;
+} {
+  if (
+    !isFactMetric(metric) ||
+    !metric.replaces?.length ||
+    snapshotHasMetric(results, metric.id)
+  ) {
+    return { metrics: [metric] };
+  }
+
+  const metrics: ExperimentMetricDefinition[] = [];
+  for (const replacedId of metric.replaces) {
+    if (!snapshotHasMetric(results, replacedId)) continue;
+    const replacedMetric = getExperimentMetricById(replacedId);
+    if (replacedMetric) metrics.push(replacedMetric);
+  }
+
+  if (!metrics.length) return { metrics: [metric] };
+
+  return { metrics, replacedByMetricName: metric.name };
+}
+
+export function resolveSnapshotMetricIds({
+  metricIds,
+  getExperimentMetricById,
+  results,
+}: {
+  metricIds: string[];
+  getExperimentMetricById: (id: string) => ExperimentMetricDefinition | null;
+  results: ExperimentReportResultDimension[];
+}): string[] {
+  return metricIds.flatMap((metricId) => {
+    const metric = getExperimentMetricById(metricId);
+    if (!metric) return [metricId];
+    return resolveMetricsForSnapshot({
+      metric,
+      getExperimentMetricById,
+      results,
+    }).metrics.map((m) => m.id);
+  });
+}

--- a/packages/shared/src/validators/fact-metrics.ts
+++ b/packages/shared/src/validators/fact-metrics.ts
@@ -359,6 +359,12 @@ export const apiFactMetricValidator = namedSchema(
           "Array of slice column names that will be automatically included in metric analysis. This is an enterprise feature.",
         )
         .optional(),
+      replaces: z
+        .array(z.string())
+        .describe(
+          "Ids of older metrics (legacy or fact) that this metric supersedes, for example the legacy metric it was migrated from. Informational only - GrowthBook uses it to link the old and new definitions in the UI and to keep showing results from a snapshot that was created before an experiment switched to this metric.",
+        )
+        .optional(),
     })
     .strict(),
 );
@@ -674,6 +680,12 @@ export const postFactMetricBodyFields = z.object({
     .array(z.string())
     .describe(
       "Array of slice column names that will be automatically included in metric analysis. This is an enterprise feature.",
+    )
+    .optional(),
+  replaces: z
+    .array(z.string())
+    .describe(
+      "Ids of older metrics (legacy or fact) that this metric supersedes, for example the legacy metric it was migrated from. Cannot include this metric's own id. Informational only - GrowthBook uses it to link the old and new definitions in the UI and to keep showing results from a snapshot that was created before an experiment switched to this metric. This field can only be set through the API.",
     )
     .optional(),
 });

--- a/packages/shared/src/validators/fact-table.ts
+++ b/packages/shared/src/validators/fact-table.ts
@@ -404,6 +404,9 @@ const factMetricObjectValidator = z
     inverse: z.boolean(),
     archived: z.boolean().optional(),
 
+    // Older metrics this one supersedes. API-only; existence is not enforced.
+    replaces: z.array(z.string()).optional(),
+
     metricType: metricTypeValidator,
     // Null only for funnel metrics, which describe their events through
     // funnelSettings.steps instead. Cross-field rules live in

--- a/packages/shared/test/metric-replacement.test.ts
+++ b/packages/shared/test/metric-replacement.test.ts
@@ -153,4 +153,16 @@ describe("resolveSnapshotMetricIds", () => {
       }),
     ).toEqual(["missing"]);
   });
+
+  it("counts a metric two goals both replace as one hypothesis", () => {
+    const otherId = "fact__other";
+    metricsById[otherId] = factMetric(otherId, [OLD_ID]);
+    expect(
+      resolveSnapshotMetricIds({
+        metricIds: [NEW_ID, otherId],
+        getExperimentMetricById,
+        results: resultsWith([OLD_ID]),
+      }),
+    ).toEqual([OLD_ID]);
+  });
 });

--- a/packages/shared/test/metric-replacement.test.ts
+++ b/packages/shared/test/metric-replacement.test.ts
@@ -1,0 +1,156 @@
+import {
+  ExperimentMetricDefinition,
+  resolveMetricsForSnapshot,
+  resolveSnapshotMetricIds,
+} from "shared/experiments";
+import { FactMetricInterface } from "shared/types/fact-table";
+import { ExperimentReportResultDimension } from "shared/types/report";
+
+function factMetric(
+  id: string,
+  replaces?: string[],
+): ExperimentMetricDefinition {
+  return {
+    id,
+    name: id,
+    metricType: "proportion",
+    replaces,
+  } as unknown as FactMetricInterface;
+}
+
+function legacyMetric(id: string): ExperimentMetricDefinition {
+  return { id, name: id } as unknown as ExperimentMetricDefinition;
+}
+
+function resultsWith(
+  ...metricIdsByVariation: string[][]
+): ExperimentReportResultDimension[] {
+  return [
+    {
+      name: "",
+      srm: 1,
+      variations: metricIdsByVariation.map((metricIds) => ({
+        users: 100,
+        metrics: Object.fromEntries(
+          metricIds.map((id) => [id, { users: 100, value: 10, cr: 0.1 }]),
+        ),
+      })),
+    },
+  ];
+}
+
+const NEW_ID = "fact__new";
+const OLD_ID = "met_old";
+
+const metricsById: Record<string, ExperimentMetricDefinition> = {
+  [NEW_ID]: factMetric(NEW_ID, [OLD_ID]),
+  [OLD_ID]: legacyMetric(OLD_ID),
+};
+const getExperimentMetricById = (id: string) => metricsById[id] ?? null;
+
+function resolve(
+  metric: ExperimentMetricDefinition,
+  snapshotMetricIds: string[],
+) {
+  return resolveMetricsForSnapshot({
+    metric,
+    getExperimentMetricById,
+    results: resultsWith(snapshotMetricIds),
+  });
+}
+
+describe("resolveMetricsForSnapshot", () => {
+  it("substitutes the replaced metric when only its results are in the snapshot", () => {
+    const { metrics, replacedByMetricName } = resolve(metricsById[NEW_ID], [
+      OLD_ID,
+    ]);
+    expect(metrics.map((m) => m.id)).toEqual([OLD_ID]);
+    expect(replacedByMetricName).toBe(NEW_ID);
+  });
+
+  it("substitutes when only some variations have the replaced metric's stats", () => {
+    const { metrics } = resolveMetricsForSnapshot({
+      metric: metricsById[NEW_ID],
+      getExperimentMetricById,
+      results: resultsWith([OLD_ID], []),
+    });
+    expect(metrics.map((m) => m.id)).toEqual([OLD_ID]);
+  });
+
+  it("substitutes every replaced metric a consolidating metric still has results for", () => {
+    const oldIds = ["met_a", "met_b", "met_c"];
+    oldIds.forEach((id) => {
+      metricsById[id] = legacyMetric(id);
+    });
+    const consolidated = factMetric("fact__consolidated", oldIds);
+
+    // In `replaces` order, regardless of the order the snapshot lists them in
+    expect(
+      resolve(consolidated, [...oldIds].reverse()).metrics.map((m) => m.id),
+    ).toEqual(oldIds);
+    // Only the ones the snapshot actually has results for
+    expect(
+      resolve(consolidated, ["met_c", "met_a"]).metrics.map((m) => m.id),
+    ).toEqual(["met_a", "met_c"]);
+  });
+
+  it("does not substitute when the metric's own results are in the snapshot", () => {
+    const { metrics, replacedByMetricName } = resolve(metricsById[NEW_ID], [
+      NEW_ID,
+      OLD_ID,
+    ]);
+    expect(metrics.map((m) => m.id)).toEqual([NEW_ID]);
+    expect(replacedByMetricName).toBeUndefined();
+  });
+
+  it("does not substitute when no replaced metric is in the snapshot", () => {
+    const { metrics, replacedByMetricName } = resolve(metricsById[NEW_ID], [
+      "fact__unrelated",
+    ]);
+    expect(metrics.map((m) => m.id)).toEqual([NEW_ID]);
+    expect(replacedByMetricName).toBeUndefined();
+  });
+
+  it("skips replaced metrics whose definition no longer exists", () => {
+    const deletedId = "met_deleted";
+    const metric = factMetric(NEW_ID, [deletedId, OLD_ID]);
+    expect(
+      resolve(metric, [deletedId, OLD_ID]).metrics.map((m) => m.id),
+    ).toEqual([OLD_ID]);
+  });
+
+  it("leaves legacy metrics and fact metrics that replace nothing unchanged", () => {
+    expect(resolve(legacyMetric(OLD_ID), []).metrics.map((m) => m.id)).toEqual([
+      OLD_ID,
+    ]);
+    expect(resolve(factMetric(NEW_ID), []).metrics.map((m) => m.id)).toEqual([
+      NEW_ID,
+    ]);
+  });
+});
+
+describe("resolveSnapshotMetricIds", () => {
+  it("maps each goal onto the metric ids the snapshot actually has stats for", () => {
+    expect(
+      resolveSnapshotMetricIds({
+        metricIds: [NEW_ID],
+        getExperimentMetricById,
+        results: resultsWith([OLD_ID]),
+      }),
+    ).toEqual([OLD_ID]);
+    expect(
+      resolveSnapshotMetricIds({
+        metricIds: [NEW_ID],
+        getExperimentMetricById,
+        results: resultsWith([NEW_ID]),
+      }),
+    ).toEqual([NEW_ID]);
+    expect(
+      resolveSnapshotMetricIds({
+        metricIds: ["missing"],
+        getExperimentMetricById,
+        results: resultsWith([]),
+      }),
+    ).toEqual(["missing"]);
+  });
+});


### PR DESCRIPTION
Stacked on #6704 — review that one first.

### Features and Changes

A fact metric can now declare the older metrics it supersedes via a `replaces` array of metric ids (legacy or fact). It's set through the API only — the intended use is a legacy-to-fact-table migration that records which metric each new one came from.

The field is informational; GrowthBook uses it in two places:

- **Metric pages** — the old metric links forward to its replacement, the new metric lists what it replaces.
- **Experiment results** — when a snapshot predates the switch to the new metric, the row falls back to the replaced metric's results with a warning icon, instead of showing "No data". Refreshing results moves the row back to the new metric on its own.

Existence of the replaced metric is not validated: it's often deleted after the migration, and failing validation then would make the surviving metric un-editable. A metric cannot list its own id.

### Notes

- Substitution only happens when the snapshot has the old metric's results and not the new one's — never in reverse.
- P-value correction runs over the substituted ids, so adjusted values match the rows actually shown.