### PR TITLE
Add support for factTable.timestampColumn in generated SQL

### DIFF
--- a/packages/back-end/src/enterprise/services/data-pipeline.ts
+++ b/packages/back-end/src/enterprise/services/data-pipeline.ts
@@ -3,6 +3,7 @@ import {
   ExperimentMetricInterface,
   getAutoSliceMetrics,
   getFactMetricPrimaryFactTableId,
+  getFactTableTimestampColumn,
   isSliceMetric,
 } from "shared/experiments";
 import {
@@ -359,8 +360,14 @@ export function getMetricSettingsHashForAggregatedFactTable({
 export function getFactTableSettingsHashForAggregatedFactTable(
   factTable: FactTableInterface,
 ): string {
+  const timestampColumn = getFactTableTimestampColumn(factTable);
   return hashObject({
     sql: factTable.sql,
+    // Omitted when it resolves to the default (JSON.stringify drops undefined),
+    // so hashes stored before this field existed stay byte-identical and a fact
+    // table that spells out "timestamp" doesn't force a restate either.
+    timestampColumn:
+      timestampColumn === "timestamp" ? undefined : timestampColumn,
     eventName: factTable.eventName,
     filters: (factTable.filters ?? [])
       .map((f) => ({ id: f.id, value: f.value }))

--- a/packages/back-end/src/enterprise/services/product-analytics-agent.ts
+++ b/packages/back-end/src/enterprise/services/product-analytics-agent.ts
@@ -1111,6 +1111,7 @@ async function executeGetColumnValues(
   type RawCol = { column: string; datatype: string };
   let factTableSql: string;
   let factTableEventName: string;
+  let factTableTimestampColumn: string | undefined;
   let datasourceId: string;
   let availableColumns: RawCol[];
 
@@ -1122,6 +1123,7 @@ async function executeGetColumnValues(
       if (!ft) return `Fact table "${factTableId}" not found.`;
       factTableSql = ft.sql;
       factTableEventName = ft.eventName ?? "";
+      factTableTimestampColumn = ft.timestampColumn;
       datasourceId = ft.datasource;
       availableColumns = (ft.columns ?? [])
         .filter((c) => !c.deleted)
@@ -1141,6 +1143,7 @@ async function executeGetColumnValues(
       if (!ft) return `Fact table not found.`;
       factTableSql = ft.sql;
       factTableEventName = ft.eventName ?? "";
+      factTableTimestampColumn = ft.timestampColumn;
       datasourceId = ft.datasource;
       availableColumns = (ft.columns ?? [])
         .filter((c) => !c.deleted)
@@ -1196,7 +1199,11 @@ async function executeGetColumnValues(
     rawValues = await runColumnsTopValuesQuery(
       ctx,
       datasource,
-      { sql: factTableSql, eventName: factTableEventName },
+      {
+        sql: factTableSql,
+        eventName: factTableEventName,
+        timestampColumn: factTableTimestampColumn,
+      },
       colsToQuery,
     );
   } catch (err) {

--- a/packages/back-end/src/integrations/sql/columns/fact-metric-column.ts
+++ b/packages/back-end/src/integrations/sql/columns/fact-metric-column.ts
@@ -1,6 +1,7 @@
 import {
   getAggregateFilters,
   getColumnExpression,
+  getFactTableTimestampColumn,
   isBinomialMetric,
 } from "shared/experiments";
 import type {
@@ -28,7 +29,7 @@ export function getFactMetricColumn(
     ? columnRef?.aggregateFilterColumn
     : columnRef?.column;
 
-  const timestampColumn = `${alias}.timestamp`;
+  const timestampColumn = `${alias}.${getFactTableTimestampColumn(factTable)}`;
 
   const value =
     (!hasAggregateFilter && isBinomialMetric(metric)) ||

--- a/packages/back-end/src/integrations/sql/columns/metric-columns.ts
+++ b/packages/back-end/src/integrations/sql/columns/metric-columns.ts
@@ -2,6 +2,7 @@ import {
   ExperimentMetricInterface,
   getAggregateFilters,
   getColumnExpression,
+  getFactTableTimestampColumn,
   getUserIdTypes,
   isBinomialMetric,
   isFactMetric,
@@ -64,7 +65,7 @@ export function getMetricColumns(
 
     return {
       userIds,
-      timestamp: `${alias}.timestamp`,
+      timestamp: `${alias}.${getFactTableTimestampColumn(factTable)}`,
       value,
     };
   }

--- a/packages/back-end/src/integrations/sql/ctes/fact-metric-cte.ts
+++ b/packages/back-end/src/integrations/sql/ctes/fact-metric-cte.ts
@@ -1,6 +1,7 @@
 import {
   getColumnRefWhereClause,
   getFactTableTemplateVariables,
+  getFactTableTimestampColumn,
   isFactFunnelMetric,
   isRatioMetric,
   parseSliceMetricId,
@@ -69,8 +70,12 @@ export function getFactMetricCTE(
     }
   }
 
+  // The fact table's timestamp column, aliased to `timestamp` on the way out so
+  // downstream SQL never has to know its real name.
+  const timestampColumn = `m.${getFactTableTimestampColumn(factTable)}`;
+
   // BQ datetime cast for SELECT statements (do not use for where)
-  const timestampDateTimeColumn = dialect.castUserDateCol("m.timestamp");
+  const timestampDateTimeColumn = dialect.castUserDateCol(timestampColumn);
 
   const sql = factTable.sql;
   const where: string[] = [];
@@ -82,7 +87,7 @@ export function getFactMetricCTE(
     const timestampFn = exclusiveStartDateFilter
       ? toTimestampWithMs
       : dialect.toTimestamp.bind(dialect);
-    where.push(`m.timestamp ${operator} ${timestampFn(startDate)}`);
+    where.push(`${timestampColumn} ${operator} ${timestampFn(startDate)}`);
   }
   if (endDate) {
     // If exclusive, we need to be more precise with the timestamp
@@ -90,7 +95,7 @@ export function getFactMetricCTE(
     const timestampFn = exclusiveEndDateFilter
       ? toTimestampWithMs
       : dialect.toTimestamp.bind(dialect);
-    where.push(`m.timestamp ${operator} ${timestampFn(endDate)}`);
+    where.push(`${timestampColumn} ${operator} ${timestampFn(endDate)}`);
   }
 
   const metricCols: string[] = [];

--- a/packages/back-end/src/integrations/sql/ctes/fact-segment-cte.ts
+++ b/packages/back-end/src/integrations/sql/ctes/fact-segment-cte.ts
@@ -1,3 +1,4 @@
+import { getFactTableTimestampColumn } from "shared/experiments";
 import { FactTableInterface } from "shared/types/fact-table";
 import type { SQLVars, SqlDialect } from "shared/types/sql";
 import { compileSqlTemplate } from "back-end/src/util/sql";
@@ -38,7 +39,9 @@ export function getFactSegmentCTE(
   }
 
   // BQ datetime cast for SELECT statements (do not use for where)
-  const timestampDateTimeColumn = dialect.castUserDateCol("m.timestamp");
+  const timestampDateTimeColumn = dialect.castUserDateCol(
+    `m.${getFactTableTimestampColumn(factTable)}`,
+  );
 
   const sql = factTable.sql;
 

--- a/packages/back-end/src/integrations/sql/ctes/power-population-source-cte.ts
+++ b/packages/back-end/src/integrations/sql/ctes/power-population-source-cte.ts
@@ -1,3 +1,4 @@
+import { getFactTableTimestampColumn } from "shared/experiments";
 import type { PopulationDataQuerySettings } from "shared/types/query";
 import { SegmentInterface } from "shared/types/segment";
 import type { SqlDialect } from "shared/types/sql";
@@ -50,7 +51,7 @@ export function getPowerPopulationSourceCTE(
           __source AS (
             SELECT
               ${settings.userIdType}
-              , timestamp
+              , ${getFactTableTimestampColumn(factTable)} AS timestamp
             FROM (
               ${sql}
             ) ft

--- a/packages/back-end/src/integrations/sql/queries/columns-top-values-query.ts
+++ b/packages/back-end/src/integrations/sql/queries/columns-top-values-query.ts
@@ -1,3 +1,4 @@
+import { getFactTableTimestampColumn } from "shared/experiments";
 import { format } from "shared/sql";
 import type { ColumnTopValuesParams } from "shared/types/integrations";
 import type { SqlDialect } from "shared/types/sql";
@@ -28,6 +29,8 @@ export function getColumnsTopValuesQuery(
   const start = new Date();
   start.setDate(start.getDate() - lookbackDays);
 
+  const timestampColumn = getFactTableTimestampColumn(factTable);
+
   return format(
     `
 WITH
@@ -44,7 +47,13 @@ __factTable AS (
   )}
 ),
 __topValues AS (
-  ${getTopValuesCTEBody(dialect, { columns, start, limit, maxValueLength })}
+  ${getTopValuesCTEBody(dialect, {
+    columns,
+    start,
+    limit,
+    maxValueLength,
+    timestampColumn,
+  })}
 )
 SELECT column_name, value FROM __topValues
 ORDER BY column_name, count DESC
@@ -58,11 +67,18 @@ type TopValuesCTEBodyParams = {
   start: Date;
   limit: number;
   maxValueLength?: number;
+  timestampColumn: string;
 };
 
 function getTopValuesCTEBody(
   dialect: SqlDialect,
-  { columns, start, limit, maxValueLength }: TopValuesCTEBodyParams,
+  {
+    columns,
+    start,
+    limit,
+    maxValueLength,
+    timestampColumn,
+  }: TopValuesCTEBodyParams,
 ): string {
   const pairs = columns.map((c) => ({
     keyLiteral: c.column.replace(/'/g, "''"),
@@ -75,7 +91,7 @@ function getTopValuesCTEBody(
     return dialect.approxTopValuesCTEBody({
       pairs,
       fromTable: "__factTable",
-      whereClause: `timestamp >= ${dialect.toTimestamp(start)}`,
+      whereClause: `${timestampColumn} >= ${dialect.toTimestamp(start)}`,
       limit,
       maxValueLength,
     });
@@ -98,7 +114,7 @@ function getTopValuesCTEBody(
         SELECT ${u.keyExpr} AS column_name, ${u.valueExpr} AS value
         FROM __factTable
         ${u.fromContinuation}
-        WHERE timestamp >= ${dialect.toTimestamp(start)}
+        WHERE ${timestampColumn} >= ${dialect.toTimestamp(start)}
       ) __unpivot
       WHERE value IS NOT NULL
         ${lengthFilter}

--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -63,6 +63,7 @@ const factTableSchema = new mongoose.Schema({
   datasource: String,
   userIdTypes: [String],
   sql: String,
+  timestampColumn: String,
   eventName: String,
   columns: [
     {

--- a/packages/back-end/src/routers/fact-table/fact-table.controller.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.controller.ts
@@ -2,6 +2,7 @@ import type { Response } from "express";
 import {
   canInlineFilterColumn,
   expandVirtualColumnsInSql,
+  getFactTableTimestampColumn,
 } from "shared/experiments";
 import { DEFAULT_MAX_METRIC_SLICE_LEVELS } from "shared/settings";
 import { cloneDeep } from "lodash";
@@ -120,7 +121,7 @@ async function testFilterQuery(
     throw new Error("Testing not supported on this data source");
   }
 
-  const timestampColumn = "timestamp";
+  const timestampColumn = getFactTableTimestampColumn(factTable);
 
   const sql = integration.getTestQuery({
     // Must have a newline after factTable sql in case it ends with a comment.
@@ -178,7 +179,7 @@ async function testVirtualColumnQuery(
     throw new Error("Testing not supported on this data source");
   }
 
-  const timestampColumn = "timestamp";
+  const timestampColumn = getFactTableTimestampColumn(factTable);
 
   // Alias the computed expression with the real column id (sanitized to a safe
   // SQL identifier) so the preview matches what the saved column will be named.
@@ -300,7 +301,7 @@ export async function refreshColumns(
   datasource: DataSourceInterface,
   factTable: Pick<
     FactTableInterface,
-    "sql" | "eventName" | "columns" | "userIdTypes"
+    "sql" | "eventName" | "columns" | "userIdTypes" | "timestampColumn"
   >,
   forceColumnRefresh?: boolean,
 ): Promise<RefreshColumnsResult> {
@@ -319,7 +320,7 @@ export async function refreshColumns(
     !forceColumnRefresh &&
     integration.supportsLimitZeroColumnValidation?.()
   ) {
-    const timestampColumn = "timestamp";
+    const timestampColumn = getFactTableTimestampColumn(factTable);
 
     // Fast path: LIMIT 0 query
     const sql = integration.getTestQuery({

--- a/packages/back-end/src/services/factMetricRowFilterValidation.ts
+++ b/packages/back-end/src/services/factMetricRowFilterValidation.ts
@@ -1,9 +1,10 @@
+import { getFactTableTimestampColumn } from "shared/experiments";
 import { FactTableInterface, RowFilter } from "shared/types/fact-table";
 import { SourceIntegrationInterface } from "back-end/src/types/Integration";
 
 type FactTableForRowFilterValidation = Pick<
   FactTableInterface,
-  "sql" | "eventName"
+  "sql" | "eventName" | "timestampColumn"
 >;
 
 function getNormalizedSqlExpr(rowFilter: RowFilter): string | null {
@@ -84,7 +85,9 @@ export async function validateFactMetricRowFilterSql({
     return;
   }
 
-  const query = `SELECT timestamp FROM (
+  const timestampColumn = getFactTableTimestampColumn(factTable);
+
+  const query = `SELECT ${timestampColumn} FROM (
   ${factTable.sql}
 ) f
 WHERE ${riskyFilterExpressions.join(" AND ")}`;
@@ -95,7 +98,7 @@ WHERE ${riskyFilterExpressions.join(" AND ")}`;
     {
       eventName: factTable.eventName,
     },
-    "timestamp",
+    timestampColumn,
   );
 
   try {

--- a/packages/back-end/src/services/factTableColumns.ts
+++ b/packages/back-end/src/services/factTableColumns.ts
@@ -1,5 +1,8 @@
 import chunk from "lodash/chunk";
-import { canInlineFilterColumn } from "shared/experiments";
+import {
+  canInlineFilterColumn,
+  getFactTableTimestampColumn,
+} from "shared/experiments";
 import {
   DEFAULT_MAX_METRIC_SLICE_LEVELS,
   DEFAULT_TOP_VALUES_LOOKBACK_VALUE,
@@ -89,7 +92,7 @@ export function selectColumnsForTopValues({
 export async function runColumnsTopValuesQuery(
   context: ReqContext,
   datasource: DataSourceInterface,
-  factTable: Pick<FactTableInterface, "sql" | "eventName">,
+  factTable: Pick<FactTableInterface, "sql" | "eventName" | "timestampColumn">,
   columns: ColumnInterface[],
 ): Promise<Record<string, string[]>> {
   if (!context.permissions.canRunFactQueries(datasource)) {
@@ -215,7 +218,7 @@ export async function runColumnDetectionQuery(
   datasource: DataSourceInterface,
   factTable: Pick<
     FactTableInterface,
-    "sql" | "eventName" | "columns" | "userIdTypes"
+    "sql" | "eventName" | "columns" | "userIdTypes" | "timestampColumn"
   >,
 ): Promise<ColumnInterface[]> {
   if (!context.permissions.canRunFactQueries(datasource)) {
@@ -228,7 +231,7 @@ export async function runColumnDetectionQuery(
     throw new Error("Testing not supported on this data source");
   }
 
-  const timestampColumn = "timestamp";
+  const timestampColumn = getFactTableTimestampColumn(factTable);
 
   const sql = integration.getTestQuery({
     query: factTable.sql,
@@ -383,7 +386,10 @@ export async function runColumnDetectionQuery(
 export async function refreshColumnTopValues(
   context: ReqContext,
   datasource: DataSourceInterface,
-  factTable: Pick<FactTableInterface, "sql" | "eventName" | "userIdTypes">,
+  factTable: Pick<
+    FactTableInterface,
+    "sql" | "eventName" | "userIdTypes" | "timestampColumn"
+  >,
   columns: ColumnInterface[],
 ): Promise<ColumnInterface[]> {
   const refreshedColumns: ColumnInterface[] = [];

--- a/packages/back-end/test/sqlintegration.test.ts
+++ b/packages/back-end/test/sqlintegration.test.ts
@@ -481,6 +481,36 @@ describe("bigquery integration", () => {
     );
   });
 
+  it("uses the fact table's timestamp column and aliases it to timestamp", () => {
+    const factTable = factTableFactory.build({
+      sql: "SELECT user_id, anonymous_id, event_time, value FROM events",
+      timestampColumn: "event_time",
+    });
+    const factMetric = factMetricFactory.build({
+      metricType: "mean",
+      numerator: {
+        factTableId: factTable.id,
+        column: "value",
+        aggregation: "sum",
+      },
+    });
+
+    const result = getFactMetricCTE(bigQueryDialect, {
+      metricsWithIndices: [{ metric: factMetric, index: 0 }],
+      factTable,
+      baseIdType: "user_id",
+      idJoinMap: {},
+      startDate: new Date("2023-01-01"),
+      endDate: new Date("2023-01-31"),
+    });
+
+    expect(result).toContain("CAST(m.event_time as DATETIME) as timestamp");
+    expect(result).toContain(
+      "WHERE m.event_time >= '2023-01-01 00:00:00' AND m.event_time <= '2023-01-31 00:00:00'",
+    );
+    expect(result).not.toContain("m.timestamp");
+  });
+
   it("substitutes {{experimentId}} in fact table SQL when experimentId is provided", () => {
     const factTable = factTableFactory.build({
       sql: "SELECT user_id, timestamp, value FROM events WHERE sample_type = CONCAT('experiment:', '{{experimentId}}')",

--- a/packages/shared/src/enterprise/product-analytics/sql.ts
+++ b/packages/shared/src/enterprise/product-analytics/sql.ts
@@ -45,8 +45,8 @@ import {
 // Internal Type definitions
 type MinimalFactTable = Pick<
   FactTableInterface,
-  "sql" | "columns" | "filters" | "userIdTypes"
-> & { timestampColumn?: string };
+  "sql" | "columns" | "filters" | "userIdTypes" | "timestampColumn"
+>;
 // Funnel fact metrics are excluded: product-analytics explorations describe
 // their own funnels through the funnel dataset, and a funnel fact metric has no
 // numerator column to roll up.

--- a/packages/shared/src/experiments/experiments.ts
+++ b/packages/shared/src/experiments/experiments.ts
@@ -1094,6 +1094,15 @@ export function getFactTableTemplateVariables(
   };
 }
 
+// The timestamp column in a fact table's SQL is configurable, defaulting to
+// `timestamp`. Query generation aliases it to `timestamp` when it first selects
+// from the fact table, so nothing downstream has to know the real name.
+export function getFactTableTimestampColumn(
+  factTable: Pick<FactTableInterface, "timestampColumn"> | undefined | null,
+): string {
+  return factTable?.timestampColumn || "timestamp";
+}
+
 // TODO(sql): refactor to remove factTableMap
 export function getMetricTemplateVariables(
   m: ExperimentMetricInterface,

--- a/packages/shared/types/fact-table.d.ts
+++ b/packages/shared/types/fact-table.d.ts
@@ -94,6 +94,10 @@ export interface FactTableInterface {
   datasource: string;
   userIdTypes: string[];
   sql: string;
+  // Column in the fact table SQL holding the event timestamp. Empty/undefined
+  // means "timestamp". SQL generation aliases it to `timestamp` in the first CTE
+  // that selects from the fact table, so everything downstream is unchanged.
+  timestampColumn?: string;
   eventName: string;
   columns: ColumnInterface[];
   columnsError?: string | null;

--- a/packages/shared/types/integrations.d.ts
+++ b/packages/shared/types/integrations.d.ts
@@ -299,7 +299,7 @@ export type TestQueryParams = {
 };
 
 export type ColumnTopValuesParams = {
-  factTable: Pick<FactTableInterface, "sql" | "eventName">;
+  factTable: Pick<FactTableInterface, "sql" | "eventName" | "timestampColumn">;
   columns: ColumnInterface[];
   limit?: number;
   lookbackDays: number;


### PR DESCRIPTION
### Features and Changes

We want `select * from my_table` to be a valid fact table definition.  No aliases just to satisfy GrowthBook.

First step of this is `timestamp`.  Now, fact tables can specify a `timestampColumn`. When set, it will be used instead of assuming the column is called `timestamp`.

The real column is aliased to `timestamp` in the very first CTE, so the vast majority of SQL generation code remains untouched.  Only a handful of places needed updating.

**Note**: This PR only adds support in the data model / SQL generation.  The new field is NOT exposed in the UI or API yet, so this change should be a complete no-op on merge.

There will be a follow-up PR in this stack doing the same thing for identifier columns.