### PR TITLE
Support pinning the Helm chart image by digest

### DIFF
--- a/charts/growthbook/charts/server/templates/_helpers.tpl
+++ b/charts/growthbook/charts/server/templates/_helpers.tpl
@@ -52,6 +52,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Image reference. A digest pins the exact image and wins over tag when both are set.
+*/}}
+{{- define "server.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "server.serviceAccountName" -}}

--- a/charts/growthbook/charts/server/templates/deployment.yaml
+++ b/charts/growthbook/charts/server/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "server.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.command }}
           command: 

--- a/charts/growthbook/charts/server/values.yaml
+++ b/charts/growthbook/charts/server/values.yaml
@@ -15,6 +15,9 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+  # Pin an immutable digest ("sha256:..."), e.g. when mirroring into a private
+  # registry. Takes precedence over tag.
+  digest: ""
 
 command:
 args:

--- a/docs/self-host/kubernetes.mdx
+++ b/docs/self-host/kubernetes.mdx
@@ -484,6 +484,42 @@ ingress:
   </Tab>
 </Tabs>
 
+## Private Registry Mirrors
+
+If your cluster is only allowed to pull from an internal registry, mirror the published image into it rather than building from source. A source build additionally requires the [`docker login dhi.io` step](/self-host#building-from-source) and has to be maintained across upgrades.
+
+Copy the image registry-to-registry so the multi-arch index and its provenance attestation survive. A `docker pull` followed by a `docker push` round-trips through a local daemon, which collapses the index to a single architecture and drops the attestation:
+
+```bash
+# Azure Container Registry
+az acr import --name myregistry \
+  --source docker.io/growthbook/growthbook:5.0.1 \
+  --image growthbook/growthbook:5.0.1
+
+# Any registry — crane, oras and skopeo all preserve the index
+crane copy growthbook/growthbook:5.0.1 myregistry.example.com/growthbook/growthbook:5.0.1
+```
+
+Then point the chart at your mirror. Both the `frontend` and `backend` deployments run this image, so set it in both places. Use `image.digest` to pin an exact image — it takes precedence over `image.tag`:
+
+```yaml
+frontend:
+  image:
+    repository: myregistry.example.com/growthbook/growthbook
+    digest: "sha256:f53ead646b5f29a302d0526f02847e9e648445e66c5c1af039eac76ebc164b78"
+  imagePullSecrets:
+    - name: my-registry-credentials
+
+backend:
+  image:
+    repository: myregistry.example.com/growthbook/growthbook
+    digest: "sha256:f53ead646b5f29a302d0526f02847e9e648445e66c5c1af039eac76ebc164b78"
+  imagePullSecrets:
+    - name: my-registry-credentials
+```
+
+Read the digest of a published tag with `docker buildx imagetools inspect growthbook/growthbook:5.0.1`.
+
 ## Accessing GrowthBook
 
 After deploying with Helm, access GrowthBook using the Ingress hostnames you configured in your values file:


### PR DESCRIPTION
### Features and Changes

Adds an `image.digest` value to the `server` subchart so deployments can pin an immutable digest. The deployment template rendered `repository:tag` with a hardcoded colon, so pinning previously meant setting `repository` to `<registry>/growthbook@sha256` and putting the bare hex in `tag`. A new `server.image` helper emits `repository@digest` when a digest is set and falls back to `repository:tag` otherwise; digest wins when both are set.

Also documents mirroring the published image into a private registry on the Kubernetes self-host page, including that a `docker pull` + `docker push` round-trip collapses the multi-arch index to one architecture and drops the provenance attestation.

### Testing

`helm lint --strict --with-subcharts` passes. `helm template` renders the expected ref in all four cases: neither value set (unchanged `growthbook/growthbook:5.0.1`), tag only, digest only, and both.
