### PR TITLE
[docs] Fix event forwarder docs to not mention self-hosted as an option

### DIFF
--- a/docs/app/event-forwarder.mdx
+++ b/docs/app/event-forwarder.mdx
@@ -13,7 +13,6 @@ GrowthBook offers a fully managed event ingestion pipeline. Use our SDKs to trac
 - **Seamless Integration**: Built-in tracking in our SDKs.
 - **Near Real-Time**: Events are available in your warehouse typically within a few seconds.
 - **Broad Support**: Works with BigQuery and Snowflake today, with more warehouses coming soon.
-- **Works with Self-Hosting** - Use with either GrowthBook Cloud or your self-hosted GrowthBook instance.
 
 ## How it Works
 


### PR DESCRIPTION
Event Forwarder only works with GrowthBook Cloud. Docs were incorrect.
