### PR TITLE
Clean up Sentry error logging

### DIFF
--- a/packages/back-end/src/instrumentation.ts
+++ b/packages/back-end/src/instrumentation.ts
@@ -1,5 +1,6 @@
 // Warning: Careful importing other modules, as they and any dependencies they import won't be instrumented.
 import * as Sentry from "@sentry/node";
+import { scrubSentryEvent } from "shared/sentry";
 import { getBuild } from "./util/build";
 
 const SENTRY_DSN = process.env.SENTRY_DSN;
@@ -10,6 +11,15 @@ if (SENTRY_DSN) {
     sendDefaultPii: true,
     environment: process.env.NODE_ENV || "development",
     release: buildInfo.sha,
+    integrations: [
+      // Request bodies carry data source credentials, private keys, and passwords
+      Sentry.httpIntegration({ maxIncomingRequestBodySize: "none" }),
+      // `data` and `cookies` both default to true, independent of `sendDefaultPii`
+      Sentry.requestDataIntegration({
+        include: { data: false, cookies: false },
+      }),
+    ],
+    beforeSend: (event) => scrubSentryEvent(event),
   });
   const buildDate = buildInfo.date;
   if (buildDate) {

--- a/packages/back-end/src/util/logger.ts
+++ b/packages/back-end/src/util/logger.ts
@@ -14,6 +14,9 @@ import { ENVIRONMENT, IS_CLOUD, LOG_LEVEL } from "./secrets";
 
 const redactPaths = [
   "req.headers.authorization",
+  'req.headers["proxy-authorization"]',
+  'req.headers["x-api-key"]',
+  'req.headers["x-vercel-auth"]',
   'req.headers["upgrade-insecure-requests"]',
   "req.headers.cookie",
   "req.headers.connection",

--- a/packages/front-end/instrumentation.ts
+++ b/packages/front-end/instrumentation.ts
@@ -1,3 +1,5 @@
+import { scrubSentryEvent } from "shared/sentry";
+
 export async function register() {
   // NB: Sentry for client-side is setup in initEnv
   if (
@@ -13,6 +15,13 @@ export async function register() {
         sendDefaultPii: true,
         environment: process.env.NODE_ENV || "development",
         release: process.env.DD_VERSION || undefined,
+        integrations: [
+          // `data` (the body) and `cookies` default to true, independent of `sendDefaultPii`
+          Sentry.requestDataIntegration({
+            include: { data: false, cookies: false },
+          }),
+        ],
+        beforeSend: (event) => scrubSentryEvent(event),
       });
     }
   }

--- a/packages/front-end/services/env.ts
+++ b/packages/front-end/services/env.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
+import { scrubSentryEvent } from "shared/sentry";
 import { EnvironmentInitValue } from "@/./pages/api/init";
 
 const env: EnvironmentInitValue = {
@@ -44,6 +45,7 @@ export async function initEnv() {
       sendDefaultPii: true,
       environment: env.environment,
       release: env.build?.sha,
+      beforeSend: (event) => scrubSentryEvent(event),
     });
   }
 }

--- a/packages/shared/sentry.d.ts
+++ b/packages/shared/sentry.d.ts
@@ -1,0 +1,1 @@
+export * from "./src/sentry";

--- a/packages/shared/sentry.js
+++ b/packages/shared/sentry.js
@@ -1,0 +1,1 @@
+module.exports = require("./dist/sentry");

--- a/packages/shared/src/sentry.ts
+++ b/packages/shared/src/sentry.ts
@@ -1,0 +1,52 @@
+const REDACTED_HEADERS = new Set([
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+  "set-cookie",
+  "x-api-key",
+  "x-vercel-auth",
+]);
+
+const REDACTED_URL_PATTERNS = [
+  /(\/auth\/reset\/)[^/?#]+/gi,
+  /(\/invite\/)[^/?#]+/gi,
+  /([?&](?:token|key)=)[^&#]+/gi,
+];
+
+const REDACTED = "[Redacted]";
+
+function redactUrl(url: string): string {
+  return REDACTED_URL_PATTERNS.reduce(
+    (acc, pattern) => acc.replace(pattern, `$1${REDACTED}`),
+    url,
+  );
+}
+
+// Structural subset of Sentry's `Event`, so this works for node, edge, and browser alike
+type SentryEventLike = {
+  request?: { url?: string; headers?: Record<string, string> };
+  transaction?: string;
+};
+
+// Strip credentials from a Sentry event. Wire in via `Sentry.init({ beforeSend })`.
+export function scrubSentryEvent<T extends SentryEventLike>(event: T): T {
+  const headers = event.request?.headers;
+  if (headers) {
+    Object.keys(headers).forEach((name) => {
+      if (REDACTED_HEADERS.has(name.toLowerCase())) {
+        headers[name] = REDACTED;
+      }
+    });
+  }
+
+  if (event.request?.url) {
+    event.request.url = redactUrl(event.request.url);
+  }
+
+  // Without tracing there's no `expressIntegration`, so the transaction name is the raw URL
+  if (event.transaction) {
+    event.transaction = redactUrl(event.transaction);
+  }
+
+  return event;
+}

--- a/packages/shared/src/sentry.ts
+++ b/packages/shared/src/sentry.ts
@@ -35,7 +35,9 @@ type SentryEventLike = {
 
 // Strip credentials from a Sentry event. Wire in via `Sentry.init({ beforeSend })`.
 export function scrubSentryEvent<T extends SentryEventLike>(event: T): T {
-  const headers = event.request?.headers;
+  const { request } = event;
+
+  const headers = request?.headers;
   if (headers) {
     Object.keys(headers).forEach((name) => {
       if (REDACTED_HEADERS.has(name.toLowerCase())) {
@@ -44,12 +46,16 @@ export function scrubSentryEvent<T extends SentryEventLike>(event: T): T {
     });
   }
 
-  if (event.request?.url) {
-    event.request.url = redactUrl(event.request.url);
-  }
-
-  if (typeof event.request?.query_string === "string") {
-    event.request.query_string = redactUrl(event.request.query_string);
+  if (request) {
+    if (request.url) {
+      request.url = redactUrl(request.url);
+    }
+    if (typeof request.query_string === "string") {
+      request.query_string = redactUrl(request.query_string);
+    } else if (request.query_string) {
+      // The protocol allows parsed forms too; no JS SDK emits one, so fail closed
+      request.query_string = REDACTED;
+    }
   }
 
   // Without tracing there's no `expressIntegration`, so the transaction name is the raw URL

--- a/packages/shared/src/sentry.ts
+++ b/packages/shared/src/sentry.ts
@@ -10,7 +10,8 @@ const REDACTED_HEADERS = new Set([
 const REDACTED_URL_PATTERNS = [
   /(\/auth\/reset\/)[^/?#]+/gi,
   /(\/invite\/)[^/?#]+/gi,
-  /([?&](?:token|key)=)[^&#]+/gi,
+  // `^` for `query_string`, which Sentry stores without the leading `?`
+  /((?:[?&#]|^)(?:id_token|access_token|refresh_token|token|code|key)=)[^&#]*/gi,
 ];
 
 const REDACTED = "[Redacted]";
@@ -24,7 +25,11 @@ function redactUrl(url: string): string {
 
 // Structural subset of Sentry's `Event`, so this works for node, edge, and browser alike
 type SentryEventLike = {
-  request?: { url?: string; headers?: Record<string, string> };
+  request?: {
+    url?: string;
+    query_string?: unknown;
+    headers?: Record<string, string>;
+  };
   transaction?: string;
 };
 
@@ -41,6 +46,10 @@ export function scrubSentryEvent<T extends SentryEventLike>(event: T): T {
 
   if (event.request?.url) {
     event.request.url = redactUrl(event.request.url);
+  }
+
+  if (typeof event.request?.query_string === "string") {
+    event.request.query_string = redactUrl(event.request.query_string);
   }
 
   // Without tracing there's no `expressIntegration`, so the transaction name is the raw URL

--- a/packages/shared/test/sentry.test.ts
+++ b/packages/shared/test/sentry.test.ts
@@ -1,0 +1,55 @@
+import { scrubSentryEvent } from "../src/sentry";
+
+describe("scrubSentryEvent", () => {
+  it("redacts credential headers and keeps the rest", () => {
+    const event = scrubSentryEvent({
+      request: {
+        headers: {
+          Authorization: "Bearer secret-api-key",
+          cookie: "AUTH_REFRESH_TOKEN=abc123",
+          "x-vercel-auth": "vercel-secret",
+          "user-agent": "Mozilla/5.0",
+          "content-type": "application/json",
+        },
+      },
+    });
+
+    expect(event.request?.headers).toEqual({
+      Authorization: "[Redacted]",
+      cookie: "[Redacted]",
+      "x-vercel-auth": "[Redacted]",
+      "user-agent": "Mozilla/5.0",
+      "content-type": "application/json",
+    });
+  });
+
+  it("redacts tokens in URL paths and query strings", () => {
+    expect(
+      scrubSentryEvent({
+        request: { url: "https://api.growthbook.io/auth/reset/rt_abc123" },
+      }).request?.url,
+    ).toBe("https://api.growthbook.io/auth/reset/[Redacted]");
+
+    expect(
+      scrubSentryEvent({ request: { url: "/invite/inv_abc123/role" } }).request
+        ?.url,
+    ).toBe("/invite/[Redacted]/role");
+
+    expect(
+      scrubSentryEvent({
+        request: { url: "/reset-password?foo=1&token=rt_abc123#x" },
+      }).request?.url,
+    ).toBe("/reset-password?foo=1&token=[Redacted]#x");
+  });
+
+  it("redacts the transaction name, which is the raw URL without tracing", () => {
+    expect(
+      scrubSentryEvent({ transaction: "POST /auth/reset/rt_abc123" })
+        .transaction,
+    ).toBe("POST /auth/reset/[Redacted]");
+  });
+
+  it("leaves events without request data alone", () => {
+    expect(scrubSentryEvent({})).toEqual({});
+  });
+});

--- a/packages/shared/test/sentry.test.ts
+++ b/packages/shared/test/sentry.test.ts
@@ -42,6 +42,36 @@ describe("scrubSentryEvent", () => {
     ).toBe("/reset-password?foo=1&token=[Redacted]#x");
   });
 
+  it("redacts OAuth codes and tokens, including in the fragment", () => {
+    expect(
+      scrubSentryEvent({
+        request: { url: "/auth/callback?code=oauth_abc&state=xyz" },
+      }).request?.url,
+    ).toBe("/auth/callback?code=[Redacted]&state=xyz");
+
+    expect(
+      scrubSentryEvent({
+        request: { url: "/oauth/callback#id_token=eyJhbG&access_token=at_abc" },
+      }).request?.url,
+    ).toBe("/oauth/callback#id_token=[Redacted]&access_token=[Redacted]");
+  });
+
+  it("redacts query_string, which Sentry stores without a leading `?`", () => {
+    expect(
+      scrubSentryEvent({
+        request: { query_string: "code=oauth_abc&state=xyz" },
+      }).request?.query_string,
+    ).toBe("code=[Redacted]&state=xyz");
+  });
+
+  it("leaves a non-string query_string alone", () => {
+    const parsed = { code: "oauth_abc" };
+    expect(
+      scrubSentryEvent({ request: { query_string: parsed } }).request
+        ?.query_string,
+    ).toBe(parsed);
+  });
+
   it("redacts the transaction name, which is the raw URL without tracing", () => {
     expect(
       scrubSentryEvent({ transaction: "POST /auth/reset/rt_abc123" })

--- a/packages/shared/test/sentry.test.ts
+++ b/packages/shared/test/sentry.test.ts
@@ -64,12 +64,16 @@ describe("scrubSentryEvent", () => {
     ).toBe("code=[Redacted]&state=xyz");
   });
 
-  it("leaves a non-string query_string alone", () => {
-    const parsed = { code: "oauth_abc" };
+  it("redacts a parsed query_string wholesale", () => {
     expect(
-      scrubSentryEvent({ request: { query_string: parsed } }).request
-        ?.query_string,
-    ).toBe(parsed);
+      scrubSentryEvent({ request: { query_string: { code: "oauth_abc" } } })
+        .request?.query_string,
+    ).toBe("[Redacted]");
+
+    expect(
+      scrubSentryEvent({ request: { query_string: [["code", "oauth_abc"]] } })
+        .request?.query_string,
+    ).toBe("[Redacted]");
   });
 
   it("redacts the transaction name, which is the raw URL without tracing", () => {


### PR DESCRIPTION
### Features and Changes

As an extra layer of security, instead of relying on app settings within Sentry to redact sensitive info, make this redaction explicit in the code.  Also, cleans up some other inconsistencies with error logging code.