### PR TITLE
Fix saved-group conflict resolution follow-ups

### DIFF
--- a/packages/back-end/src/routers/saved-group/saved-group.controller.ts
+++ b/packages/back-end/src/routers/saved-group/saved-group.controller.ts
@@ -499,6 +499,9 @@ type PutSavedGroupRequest = AuthRequest<
   }
 >;
 
+// Cap on a single conflict value shipped back for display in a 409.
+const MAX_CONFLICT_VALUE_BYTES = 20_000;
+
 type PutSavedGroupResponse =
   | {
       status: 200;
@@ -601,6 +604,9 @@ export const putSavedGroup = async (
   let targetRevision: Revision | null = null;
   let comparisonBase: SavedGroupInterface = savedGroup;
 
+  // Set when comparing against a draft; tells the client a fork keeps both versions.
+  let draftComparisonVersion: number | undefined;
+
   if (revisionId) {
     targetRevision = await context.models.revisions.getByIdReadable(revisionId);
     // Writing `archived` into a PINNED revision is a write into someone else's
@@ -628,6 +634,7 @@ export const putSavedGroup = async (
         normalizeProposedChanges(targetRevision.target.proposedChanges),
       );
       comparisonBase = { ...savedGroup, ...patchedSnapshot };
+      draftComparisonVersion = targetRevision.version ?? 0;
     }
   }
 
@@ -651,16 +658,26 @@ export const putSavedGroup = async (
       );
     });
     if (contested.length) {
+      const current: Record<string, unknown> = Object.fromEntries(
+        Object.keys(baseline).map((k) => [k, base[k]]),
+      );
+      // Withhold huge lists; the client offers reload instead of merge choices.
+      const omittedFields = Object.keys(current).filter(
+        (k) =>
+          Array.isArray(current[k]) &&
+          JSON.stringify(current[k]).length > MAX_CONFLICT_VALUE_BYTES,
+      );
+      for (const k of omittedFields) delete current[k];
       return res.status(409).json({
         status: 409,
         message:
           "This saved group was changed by someone else after you loaded it. Review their version before saving.",
         conflict: {
           entityId: savedGroup.id,
-          current: Object.fromEntries(
-            Object.keys(baseline).map((k) => [k, base[k]]),
-          ),
+          current,
           liveVersion: 0,
+          draftVersion: draftComparisonVersion,
+          omittedFields: omittedFields.length ? omittedFields : undefined,
           merge: {
             contested: contested.map((k) => ({ key: k, fields: [k] })),
             theirFields: [],

--- a/packages/back-end/src/routers/saved-group/saved-group.controller.ts
+++ b/packages/back-end/src/routers/saved-group/saved-group.controller.ts
@@ -648,13 +648,15 @@ export const putSavedGroup = async (
       projects,
     };
     const base = comparisonBase as unknown as Record<string, unknown>;
+    // An empty array and an absent field mean the same thing to the editor.
+    const norm = (v: unknown) =>
+      Array.isArray(v) && v.length === 0 ? null : (v ?? null);
     const contested = Object.keys(baseline).filter((k) => {
       const loaded = (baseline as Record<string, unknown>)[k];
-      if (isEqual(loaded ?? null, base[k] ?? null)) return false;
+      if (isEqual(norm(loaded), norm(base[k]))) return false;
       // Someone else changed it; only a differing submission is contested.
       return (
-        incoming[k] !== undefined &&
-        !isEqual(incoming[k] ?? null, base[k] ?? null)
+        incoming[k] !== undefined && !isEqual(norm(incoming[k]), norm(base[k]))
       );
     });
     if (contested.length) {

--- a/packages/front-end/components/DraftConflicts/ConflictContext.tsx
+++ b/packages/front-end/components/DraftConflicts/ConflictContext.tsx
@@ -25,6 +25,9 @@ type ConflictContextValue = {
   claimed: Set<string>;
   claim: (key: string) => void;
   release: (key: string) => void;
+  // Fields whose current value was too large to ship; reload replaces merging.
+  omitted?: string[];
+  reload?: () => void;
 };
 
 const ConflictContext = createContext<ConflictContextValue | null>(null);
@@ -38,6 +41,8 @@ export function ConflictProvider({
   claimed,
   claim,
   release,
+  omitted,
+  reload,
   children,
 }: ConflictContextValue & { children: ReactNode }) {
   const value = useMemo(
@@ -50,6 +55,8 @@ export function ConflictProvider({
       claimed,
       claim,
       release,
+      omitted,
+      reload,
     }),
     [
       contested,
@@ -60,6 +67,8 @@ export function ConflictProvider({
       claimed,
       claim,
       release,
+      omitted,
+      reload,
     ],
   );
 
@@ -79,9 +88,24 @@ export function useContestedChunk(field: string): ContestedChunk | undefined {
   return ctx?.contested.find((c) => c.fields.includes(field));
 }
 
+function chunkOmitted(
+  ctx: ConflictContextValue | null,
+  chunk: ContestedChunk,
+): boolean {
+  return chunk.fields.some((f) => ctx?.omitted?.includes(f));
+}
+
 function ConflictButtons({ chunk }: { chunk: ContestedChunk }) {
   const ctx = useConflict();
   if (!ctx) return null;
+  // Without their value there is nothing to merge; reload is the only move.
+  if (chunkOmitted(ctx, chunk)) {
+    return ctx.reload ? (
+      <Button size="sm" variant="outline" onClick={() => ctx.reload?.()}>
+        Reload
+      </Button>
+    ) : null;
+  }
   const resolution = ctx.resolutions.get(chunk.key);
   const choice = (side: ConflictResolution, label: string) => {
     const active = resolution === side;
@@ -113,6 +137,14 @@ export function ConflictMessage({
 }) {
   const ctx = useConflict();
   if (!ctx) return null;
+  if (chunkOmitted(ctx, chunk)) {
+    return (
+      <Text>
+        <Text weight="semibold">{ctx.labelFor?.(chunk) ?? chunk.key}</Text> was
+        modified while you were editing.
+      </Text>
+    );
+  }
   return (
     <Text>
       <Text weight="semibold">{ctx.labelFor?.(chunk) ?? chunk.key}</Text> was

--- a/packages/front-end/components/DraftConflicts/conflictValues.ts
+++ b/packages/front-end/components/DraftConflicts/conflictValues.ts
@@ -10,8 +10,12 @@ export function formatConflictValue(v: unknown): string {
 }
 
 function formatList(list: unknown[]): string {
-  const s = `[${list.map((v) => JSON.stringify(v)).join(", ")}]`;
-  return s.length > MAX_VALUE_CHARS ? `${s.slice(0, MAX_VALUE_CHARS)}…` : s;
+  // Bounded up front so a huge list never stringifies in full.
+  const bounded = list.slice(0, 120);
+  const s = `[${bounded.map((v) => JSON.stringify(v)).join(", ")}]`;
+  return s.length > MAX_VALUE_CHARS || bounded.length < list.length
+    ? `${s.slice(0, MAX_VALUE_CHARS)}…`
+    : s;
 }
 
 // The fixed scope label the flag stands for: allEnvironments and

--- a/packages/front-end/components/DraftConflicts/useDraftConflict.tsx
+++ b/packages/front-end/components/DraftConflicts/useDraftConflict.tsx
@@ -29,6 +29,7 @@ export function useDraftConflict<T extends object>({
   applyField,
   isNewDraft,
   entityNoun,
+  onReload,
 }: {
   initial: T;
   labels?: Record<string, string>;
@@ -38,6 +39,8 @@ export function useDraftConflict<T extends object>({
   applyField?: (field: string, value: unknown) => void;
   isNewDraft: boolean;
   entityNoun: string;
+  // Offered in place of merge choices when a contested value was too large to ship.
+  onReload?: () => void;
 }) {
   const [baseline, setBaseline] = useState<T>(initial);
   const [conflict, setConflict] = useState<Conflict<T> | null>(null);
@@ -135,7 +138,9 @@ export function useDraftConflict<T extends object>({
   /** Per-submit: the baseline to send, and the 409 handler. */
   const guard = useCallback(
     (attempted: T) => ({
-      baseline,
+      // A fork compares against live, which only the pre-conflict baseline describes.
+      baseline:
+        newDraftAvoidsConflict && conflict ? conflict.baseAtConflict : baseline,
       onError: (responseData: { status?: number; conflict?: unknown }) => {
         if (responseData?.status !== 409 || !responseData?.conflict) return;
         signaledRef.current = true;
@@ -151,7 +156,7 @@ export function useDraftConflict<T extends object>({
         if (payload.current) setBaseline(payload.current);
       },
     }),
-    [baseline, setField],
+    [baseline, setField, conflict, newDraftAvoidsConflict],
   );
 
   // The conflict renders its own banner, so a handled 409 must not also surface
@@ -169,7 +174,18 @@ export function useDraftConflict<T extends object>({
     }
   }, []);
 
-  const clear = useCallback(() => setConflict(null), []);
+  const onReloadRef = useRef(onReload);
+  onReloadRef.current = onReload;
+  const reload = useCallback(() => {
+    setConflict(null);
+    onReloadRef.current?.();
+  }, []);
+
+  // Page-mounted hooks re-pin at modal open; the initial baseline predates it.
+  const clear = useCallback((fresh?: T) => {
+    setConflict(null);
+    if (fresh) setBaseline(fresh);
+  }, []);
 
   const alert = conflict ? (
     <HelperText status="warning" icon={null}>
@@ -220,6 +236,7 @@ export function useDraftConflict<T extends object>({
     alertActive: !resolved,
     callouts,
     hasConflict: !!conflict,
+    conflictFromDraft: conflict?.draftVersion !== undefined,
     providerProps: {
       contested: newDraftAvoidsConflict ? [] : contested,
       resolutions,
@@ -229,6 +246,8 @@ export function useDraftConflict<T extends object>({
       claimed,
       claim,
       release,
+      omitted: conflict?.omittedFields,
+      reload: onReload ? reload : undefined,
     },
   };
 }

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -1697,7 +1697,18 @@ export default function RuleModal({
               body: JSON.stringify({
                 rule: values,
                 ruleId,
-                ...(baselineRule ? { baseline: { rule: baselineRule } } : {}),
+                // A fork compares against live, which only the
+                // pre-conflict baseline describes.
+                ...(baselineRule
+                  ? {
+                      baseline: {
+                        rule:
+                          newDraftAvoidsConflict && conflict
+                            ? (conflict.baseAtConflict ?? baselineRule)
+                            : baselineRule,
+                      },
+                    }
+                  : {}),
                 ...(rampScheduleInline
                   ? { rampSchedule: rampScheduleInline }
                   : {}),

--- a/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
+++ b/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
@@ -1,5 +1,5 @@
 import { NO_ENVIRONMENT_BINDING } from "shared/permissions";
-import { FC, useEffect, useMemo, useState } from "react";
+import { FC, useEffect, useMemo, useRef, useState } from "react";
 import {
   CreateSavedGroupProps,
   UpdateSavedGroupProps,
@@ -251,8 +251,13 @@ const SavedGroupForm: FC<{
     (c) => c.key === "description",
   );
 
-  // Update form values when selected revision changes OR when current prop updates
+  // Reseed only when the backing revision changes: a same-revision SWR refresh
+  // must not clobber unsaved edits — the stale baseline 409s instead.
+  const seedKey = currentRevision ? currentRevision.id : "__live__";
+  const seededKeyRef = useRef<string | null>(null);
   useEffect(() => {
+    if (seededKeyRef.current === seedKey) return;
+    seededKeyRef.current = seedKey;
     let baseData: Partial<SavedGroupInterface>;
 
     if (currentRevision) {
@@ -294,7 +299,16 @@ const SavedGroupForm: FC<{
     if (baseData.description) {
       setShowDescription(true);
     }
-  }, [currentRevision, liveVersion, type, project, orgId, form, current]);
+  }, [
+    seedKey,
+    currentRevision,
+    liveVersion,
+    type,
+    project,
+    orgId,
+    form,
+    current,
+  ]);
 
   const selectedProjects = form.watch("projects") || [];
 

--- a/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
+++ b/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
@@ -251,6 +251,12 @@ const SavedGroupForm: FC<{
     (c) => c.key === "description",
   );
 
+  // Live state pinned at open. Publish/new-draft submits compare against live,
+  // which the hook baseline only describes when the conflict came from live.
+  const [livePin] = useState<SavedGroupInterface | undefined>(
+    () => liveVersion,
+  );
+
   // Reseed only when the backing revision changes: a same-revision SWR refresh
   // must not clobber unsaved edits — the stale baseline 409s instead.
   const seedKey = currentRevision ? currentRevision.id : "__live__";
@@ -480,8 +486,11 @@ const SavedGroupForm: FC<{
         if (current.id) {
           const baseline = (k: keyof SavedGroupInterface) =>
             (current as Partial<SavedGroupInterface>)[k];
+          // An empty array and an absent field mean the same thing here.
+          const norm = (v: unknown) =>
+            Array.isArray(v) && v.length === 0 ? null : (v ?? null);
           const fieldChanged = (k: keyof SavedGroupFormValues) =>
-            !isEqual(value[k] ?? null, baseline(k) ?? null);
+            !isEqual(norm(value[k]), norm(baseline(k)));
           let payload: UpdateSavedGroupProps;
           if (editInfoOnly) {
             payload = {
@@ -540,6 +549,17 @@ const SavedGroupForm: FC<{
           const guard = conflict.guard(
             payload as unknown as Record<string, unknown>,
           );
+          const submitBaseline =
+            livePin &&
+            draftMode !== "existing" &&
+            (!conflict.hasConflict || conflict.conflictFromDraft)
+              ? Object.fromEntries(
+                  Object.keys(payload).map((k) => [
+                    k,
+                    (livePin as unknown as Record<string, unknown>)[k],
+                  ]),
+                )
+              : guard.baseline;
           const res = await conflict.guarded(() =>
             apiCall<{
               status: number;
@@ -549,7 +569,7 @@ const SavedGroupForm: FC<{
               url,
               {
                 method: "PUT",
-                body: JSON.stringify({ ...payload, baseline: guard.baseline }),
+                body: JSON.stringify({ ...payload, baseline: submitBaseline }),
               },
               guard.onError,
             ),

--- a/packages/front-end/pages/saved-groups/[sgid].tsx
+++ b/packages/front-end/pages/saved-groups/[sgid].tsx
@@ -141,6 +141,9 @@ export default function EditSavedGroupPage() {
   const [addItemsDraftSelectedId, setAddItemsDraftSelectedId] = useState<
     string | null
   >(null);
+  // Live list pinned at modal open; the SWR value revalidates mid-edit, so a
+  // submit-time read would vouch for changes the user never saw.
+  const [liveListPin, setLiveListPin] = useState<string[] | null>(null);
   const [deleteItemsModal, setDeleteItemsModal] = useState(false);
   const [deleteItemsDraftMode, setDeleteItemsDraftMode] =
     useState<DraftMode>("new");
@@ -325,7 +328,7 @@ export default function EditSavedGroupPage() {
     hook: { hasConflict: boolean; conflictFromDraft: boolean },
   ) =>
     mode !== "existing" && (!hook.hasConflict || hook.conflictFromDraft)
-      ? { values: savedGroup?.values }
+      ? { values: liveListPin ?? savedGroup?.values }
       : guardBaseline;
 
   const filteredValues = displayedValues.filter((v) => v.match(filter));
@@ -1507,6 +1510,7 @@ export default function EditSavedGroupPage() {
                             setDeleteItemsDraftSelectedId(
                               userOpenRevision?.id ?? null,
                             );
+                            setLiveListPin(savedGroup.values ?? []);
                             deleteConflict.clear({ values: displayedValues });
                             setDeleteItemsModal(true);
                           }}
@@ -1546,6 +1550,7 @@ export default function EditSavedGroupPage() {
                           setAddItemsDraftSelectedId(
                             userOpenRevision?.id ?? null,
                           );
+                          setLiveListPin(savedGroup.values ?? []);
                           addConflict.clear({ values: displayedValues });
                           setAddItems(true);
                         }}
@@ -1584,6 +1589,7 @@ export default function EditSavedGroupPage() {
                           setAddItemsDraftSelectedId(
                             userOpenRevision?.id ?? null,
                           );
+                          setLiveListPin(savedGroup.values ?? []);
                           addConflict.clear({ values: displayedValues });
                           setAddItems(true);
                         }}

--- a/packages/front-end/pages/saved-groups/[sgid].tsx
+++ b/packages/front-end/pages/saved-groups/[sgid].tsx
@@ -21,11 +21,7 @@ import {
   getApprovalFlowSettings,
 } from "shared/enterprise";
 import { REVIEW_REQUESTED_STATUSES } from "shared/validators";
-import {
-  PiArrowsDownUp,
-  PiPencilSimpleFill,
-  PiPlusCircleBold,
-} from "react-icons/pi";
+import { PiArrowsDownUp, PiPencilSimpleFill, PiPlusBold } from "react-icons/pi";
 import { BsThreeDotsVertical } from "react-icons/bs";
 import { isIdListSupportedAttribute, restoredProjectScope } from "shared/util";
 import { Box, Flex, IconButton } from "@radix-ui/themes";
@@ -1572,7 +1568,7 @@ export default function EditSavedGroupPage() {
                       <Button
                         variant="outline"
                         disabled={!canDraft || !!(isMerged || isDiscarded)}
-                        icon={<PiPlusCircleBold />}
+                        icon={<PiPlusBold />}
                         onClick={() => {
                           // When viewing live, switch to/create draft first
                           if (!selectedRevision && userOpenRevision) {

--- a/packages/front-end/pages/saved-groups/[sgid].tsx
+++ b/packages/front-end/pages/saved-groups/[sgid].tsx
@@ -141,9 +141,6 @@ export default function EditSavedGroupPage() {
   const [addItemsDraftSelectedId, setAddItemsDraftSelectedId] = useState<
     string | null
   >(null);
-  // Pinned when a list modal opens. `displayedValues` tracks revalidation, so
-  // reading it at submit time would compare the current list against itself.
-  const [listBaseline, setListBaseline] = useState<string[] | null>(null);
   const [deleteItemsModal, setDeleteItemsModal] = useState(false);
   const [deleteItemsDraftMode, setDeleteItemsDraftMode] =
     useState<DraftMode>("new");
@@ -294,12 +291,10 @@ export default function EditSavedGroupPage() {
     [displayedSavedGroup],
   );
 
-  const pinnedList = listBaseline ?? displayedValues;
-
   // A list can't merge item-by-item, so a contested one is flagged, not merged.
   // One instance per modal, so an add conflict can't gate a later removal.
   const addConflict = useDraftConflict<Record<string, unknown>>({
-    initial: { values: pinnedList },
+    initial: { values: displayedValues },
     labels: { values: "List items" },
     applyField: (_field, value) => {
       setImportOperation("replace");
@@ -307,15 +302,31 @@ export default function EditSavedGroupPage() {
     },
     isNewDraft: addItemsDraftMode === "new",
     entityNoun: "saved group",
+    onReload: async () => {
+      await mutate();
+      setAddItems(false);
+      setItemsToAdd([]);
+    },
   });
   // Removing by selection has nowhere to apply their list, so this one only
   // reports the conflict and offers a reload.
   const deleteConflict = useDraftConflict<Record<string, unknown>>({
-    initial: { values: pinnedList },
+    initial: { values: displayedValues },
     labels: { values: "List items" },
     isNewDraft: deleteItemsDraftMode === "new",
     entityNoun: "saved group",
   });
+
+  // Publish/new-draft submits compare against live, which the hook baseline
+  // only describes when the conflict itself came from live.
+  const submitBaseline = (
+    mode: DraftMode,
+    guardBaseline: Record<string, unknown> | undefined,
+    hook: { hasConflict: boolean; conflictFromDraft: boolean },
+  ) =>
+    mode !== "existing" && (!hook.hasConflict || hook.conflictFromDraft)
+      ? { values: savedGroup?.values }
+      : guardBaseline;
 
   const filteredValues = displayedValues.filter((v) => v.match(filter));
   const sortedValues = sortNewestFirst
@@ -559,6 +570,11 @@ export default function EditSavedGroupPage() {
             }
 
             const guard = deleteConflict.guard({ values: newValues });
+            const baseline = submitBaseline(
+              deleteItemsDraftMode,
+              guard.baseline,
+              deleteConflict,
+            );
             const res = await deleteConflict.guarded(() =>
               apiCall<{
                 status: number;
@@ -569,7 +585,7 @@ export default function EditSavedGroupPage() {
                   method: "PUT",
                   body: JSON.stringify({
                     values: newValues,
-                    baseline: { values: pinnedList },
+                    baseline,
                   }),
                 },
                 guard.onError,
@@ -683,6 +699,11 @@ export default function EditSavedGroupPage() {
             }
 
             const guard = addConflict.guard({ values: newValues });
+            const baseline = submitBaseline(
+              addItemsDraftMode,
+              guard.baseline,
+              addConflict,
+            );
             const res = await addConflict.guarded(() =>
               apiCall<{
                 status: number;
@@ -694,7 +715,7 @@ export default function EditSavedGroupPage() {
                   method: "PUT",
                   body: JSON.stringify({
                     values: newValues,
-                    baseline: { values: pinnedList },
+                    baseline,
                   }),
                 },
                 guard.onError,
@@ -1350,7 +1371,7 @@ export default function EditSavedGroupPage() {
             )}
             {savedGroup.type === "list" &&
               !isIdListSupportedAttribute(attr) && (
-                <Callout status="error" mt="3">
+                <Callout status="error" my="3">
                   The attribute for this Saved Group has an unsupported
                   datatype. It cannot be edited and it may produce unexpected
                   behavior when used in SDKs. Try using a{" "}
@@ -1486,8 +1507,7 @@ export default function EditSavedGroupPage() {
                             setDeleteItemsDraftSelectedId(
                               userOpenRevision?.id ?? null,
                             );
-                            setListBaseline(displayedValues);
-                            deleteConflict.clear();
+                            deleteConflict.clear({ values: displayedValues });
                             setDeleteItemsModal(true);
                           }}
                         >
@@ -1526,8 +1546,7 @@ export default function EditSavedGroupPage() {
                           setAddItemsDraftSelectedId(
                             userOpenRevision?.id ?? null,
                           );
-                          setListBaseline(displayedValues);
-                          addConflict.clear();
+                          addConflict.clear({ values: displayedValues });
                           setAddItems(true);
                         }}
                       >
@@ -1565,8 +1584,7 @@ export default function EditSavedGroupPage() {
                           setAddItemsDraftSelectedId(
                             userOpenRevision?.id ?? null,
                           );
-                          setListBaseline(displayedValues);
-                          addConflict.clear();
+                          addConflict.clear({ values: displayedValues });
                           setAddItems(true);
                         }}
                       >

--- a/packages/shared/src/util/threeWayMerge.ts
+++ b/packages/shared/src/util/threeWayMerge.ts
@@ -61,9 +61,17 @@ export function threeWayMerge<T extends object>(
     units.push({ key: fields[0], fields });
   }
 
-  // An empty array and an absent key mean the same thing to the editor.
-  const canon = (v: unknown) =>
-    Array.isArray(v) && v.length === 0 ? null : (v ?? null);
+  // An empty array equals an absent key, and primitive arrays are set-typed
+  // (tags, projects), so reorders are not changes. Object arrays keep order.
+  const canon = (v: unknown) => {
+    if (Array.isArray(v)) {
+      if (v.length === 0) return null;
+      if (v.every((x) => typeof x !== "object" || x === null)) {
+        return [...v].sort();
+      }
+    }
+    return v ?? null;
+  };
   const pick = (obj: Record<string, unknown>, fields: string[]) =>
     JSON.stringify(fields.map((f) => canon(obj[f])));
 

--- a/packages/shared/test/threeWayMerge.test.ts
+++ b/packages/shared/test/threeWayMerge.test.ts
@@ -1,0 +1,57 @@
+import { threeWayMerge } from "../src/util/threeWayMerge";
+
+type Entity = {
+  tags?: string[];
+  owner?: string;
+  variations?: Array<{ id: string; value: string }>;
+};
+
+describe("threeWayMerge array canonicalization", () => {
+  it("treats a reordered primitive array as unchanged", () => {
+    const base: Entity = { tags: ["a", "b"], owner: "x" };
+    const theirs: Entity = { tags: ["b", "a"], owner: "x" };
+    const yours: Entity = { tags: ["a", "b"], owner: "y" };
+    const result = threeWayMerge(base, theirs, yours);
+    expect(result.contested).toEqual([]);
+    expect(result.theirFields).toEqual([]);
+    expect(result.yourFields).toEqual(["owner"]);
+    expect(result.merged).toEqual(yours);
+  });
+
+  it("does not contest when both sides hold the same set in different orders", () => {
+    const base: Entity = { tags: ["a"] };
+    const theirs: Entity = { tags: ["b", "a"] };
+    const yours: Entity = { tags: ["a", "b"] };
+    const result = threeWayMerge(base, theirs, yours);
+    expect(result.contested).toEqual([]);
+  });
+
+  it("still contests when the sets genuinely differ", () => {
+    const base: Entity = { tags: ["a"] };
+    const theirs: Entity = { tags: ["a", "b"] };
+    const yours: Entity = { tags: ["a", "c"] };
+    const result = threeWayMerge(base, theirs, yours);
+    expect(result.contested).toEqual([{ key: "tags", fields: ["tags"] }]);
+  });
+
+  it("keeps order significant for object arrays", () => {
+    const v1 = { id: "1", value: "x" };
+    const v2 = { id: "2", value: "y" };
+    const base: Entity = { variations: [v1, v2] };
+    const theirs: Entity = { variations: [v2, v1] };
+    const yours: Entity = { variations: [{ ...v1, value: "z" }, v2] };
+    const result = threeWayMerge(base, theirs, yours);
+    expect(result.contested).toEqual([
+      { key: "variations", fields: ["variations"] },
+    ]);
+  });
+
+  it("still equates an empty array with an absent key", () => {
+    const base: Entity = { tags: [] };
+    const theirs: Entity = {};
+    const yours: Entity = { owner: "y" };
+    const result = threeWayMerge(base, theirs, yours);
+    expect(result.contested).toEqual([]);
+    expect(result.theirFields).toEqual([]);
+  });
+});

--- a/packages/shared/types/draft-conflict.d.ts
+++ b/packages/shared/types/draft-conflict.d.ts
@@ -2,6 +2,8 @@
 export type DraftConflict<T> = {
   entityId: string;
   current: T | null;
+  // Contested fields whose current value was too large to ship.
+  omittedFields?: string[];
   liveVersion: number;
   draftVersion?: number;
   merge?: {


### PR DESCRIPTION
Fixes two bugs from the concurrent-edit guard: clicking "keep mine" on a saved-group list conflict no longer re-warns when you save again, choosing "create a new draft" now clears the conflict and saves, and huge ID lists are no longer shipped back in conflict responses (you get a Reload button instead).