### PR TITLE
Add pr feedback for ef update

### DIFF
--- a/packages/front-end/components/DeleteButton/DeleteButton.tsx
+++ b/packages/front-end/components/DeleteButton/DeleteButton.tsx
@@ -108,6 +108,7 @@ const DeleteButton: FC<{
           variant="ghost"
           color="red"
           title={title}
+          disabled={disabled}
           stopPropagation={stopPropagation}
         >
           {text}

--- a/packages/front-end/components/Metrics/MetricName.tsx
+++ b/packages/front-end/components/Metrics/MetricName.tsx
@@ -38,6 +38,8 @@ export function OfficialBadge({
   type,
   managedBy,
   disableTooltip,
+  tooltip,
+  usePortal,
   showOfficialLabel,
   color,
   leftGap,
@@ -46,6 +48,10 @@ export function OfficialBadge({
   type: string;
   managedBy?: "" | "config" | "api" | "admin";
   disableTooltip?: boolean;
+  // Replaces the default "managed by the API" copy.
+  tooltip?: React.ReactNode;
+  // Needed when the badge sits inside a container that clips overflow.
+  usePortal?: boolean;
   showOfficialLabel?: boolean;
   color?: string;
   leftGap?: boolean;
@@ -66,9 +72,12 @@ export function OfficialBadge({
   return (
     <Box display="inline" className="text-purple mr-1" {...marginProps}>
       <Tooltip
+        usePortal={usePortal}
         body={
           disableTooltip ? (
             ""
+          ) : tooltip ? (
+            tooltip
           ) : (
             <>
               <h4 className="pb-1">

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/DataSourceInlineEditIdentifierTypes.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/DataSourceInlineEditIdentifierTypes.tsx
@@ -7,7 +7,11 @@ import {
 import { isEventForwarderManaged } from "shared/util";
 import { PiPlus } from "react-icons/pi";
 import { Box, Card, Flex } from "@radix-ui/themes";
-import { OfficialBadge } from "@/components/Metrics/MetricName";
+import Tooltip from "@/components/Tooltip/Tooltip";
+import {
+  EVENT_FORWARDER_MANAGED_TOOLTIP,
+  EventForwarderManagedBadge,
+} from "@/components/Settings/EditDataSource/EventForwarderManaged";
 import { DataSourceQueryEditingModalBaseProps } from "@/components/Settings/EditDataSource/types";
 import { EditIdentifierType } from "@/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/EditIdentifierType";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
@@ -140,11 +144,7 @@ export const DataSourceInlineEditIdentifierTypes: FC<
                 <Heading size="sm" as="h3" mb="1">
                   {userIdType}
                   {isManaged && (
-                    <OfficialBadge
-                      type="identifier type"
-                      managedBy="api"
-                      ml="1"
-                    />
+                    <EventForwarderManagedBadge type="identifier type" />
                   )}
                 </Heading>
                 <Box mb="2">
@@ -158,23 +158,31 @@ export const DataSourceInlineEditIdentifierTypes: FC<
                 </Text>
               </Box>
 
-              {canEdit && !isManaged && (
-                <Flex gap="2">
-                  <Button
-                    variant="ghost"
-                    onClick={handleActionEditClicked(idx)}
-                  >
-                    Edit
-                  </Button>
-                  <DeleteButton
-                    onClick={handleActionDeleteClicked(idx)}
-                    useIcon={false}
-                    displayName={userIdType}
-                    deleteMessage={`Are you sure you want to delete identifier type ${userIdType}?`}
-                    title="Delete"
-                    text="Delete"
-                  />
-                </Flex>
+              {canEdit && (
+                <Tooltip
+                  body={EVENT_FORWARDER_MANAGED_TOOLTIP}
+                  shouldDisplay={isManaged}
+                  usePortal
+                >
+                  <Flex gap="2">
+                    <Button
+                      variant="ghost"
+                      disabled={isManaged}
+                      onClick={handleActionEditClicked(idx)}
+                    >
+                      Edit
+                    </Button>
+                    <DeleteButton
+                      onClick={handleActionDeleteClicked(idx)}
+                      useIcon={false}
+                      disabled={isManaged}
+                      displayName={userIdType}
+                      deleteMessage={`Are you sure you want to delete identifier type ${userIdType}?`}
+                      title="Delete"
+                      text="Delete"
+                    />
+                  </Flex>
+                </Tooltip>
               )}
             </Flex>
           </Card>

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/DataSourceInlineEditIdentifierTypes.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/DataSourceInlineEditIdentifierTypes.tsx
@@ -7,6 +7,7 @@ import {
 import { isEventForwarderManaged } from "shared/util";
 import { PiPlus } from "react-icons/pi";
 import { Box, Card, Flex } from "@radix-ui/themes";
+import { OfficialBadge } from "@/components/Metrics/MetricName";
 import { DataSourceQueryEditingModalBaseProps } from "@/components/Settings/EditDataSource/types";
 import { EditIdentifierType } from "@/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/EditIdentifierType";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
@@ -138,6 +139,13 @@ export const DataSourceInlineEditIdentifierTypes: FC<
               <Box>
                 <Heading size="sm" as="h3" mb="1">
                   {userIdType}
+                  {isManaged && (
+                    <OfficialBadge
+                      type="identifier type"
+                      managedBy="api"
+                      ml="1"
+                    />
+                  )}
                 </Heading>
                 <Box mb="2">
                   <Metadata

--- a/packages/front-end/components/Settings/EditDataSource/EventForwarderManaged.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EventForwarderManaged.tsx
@@ -1,15 +1,16 @@
 import { OfficialBadge } from "@/components/Metrics/MetricName";
-import Tooltip from "@/components/Tooltip/Tooltip";
 
 export const EVENT_FORWARDER_MANAGED_TOOLTIP =
-  "Managed by the Event Forwarder. It is read-only and cannot be edited or deleted from within GrowthBook.";
+  "Managed by Event Forwarder. It is read-only and cannot be edited or deleted from within GrowthBook.";
 
-// These badges sit inside Cards that clip overflow, so the tooltip has to
-// portal out or it gets cut off.
 export function EventForwarderManagedBadge({ type }: { type: string }) {
   return (
-    <Tooltip body={EVENT_FORWARDER_MANAGED_TOOLTIP} usePortal>
-      <OfficialBadge type={type} managedBy="api" disableTooltip ml="1" />
-    </Tooltip>
+    <OfficialBadge
+      type={type}
+      managedBy="api"
+      tooltip={EVENT_FORWARDER_MANAGED_TOOLTIP}
+      usePortal
+      ml="1"
+    />
   );
 }

--- a/packages/front-end/components/Settings/EditDataSource/EventForwarderManaged.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EventForwarderManaged.tsx
@@ -1,0 +1,15 @@
+import { OfficialBadge } from "@/components/Metrics/MetricName";
+import Tooltip from "@/components/Tooltip/Tooltip";
+
+export const EVENT_FORWARDER_MANAGED_TOOLTIP =
+  "Managed by the Event Forwarder. It is read-only and cannot be edited or deleted from within GrowthBook.";
+
+// These badges sit inside Cards that clip overflow, so the tooltip has to
+// portal out or it gets cut off.
+export function EventForwarderManagedBadge({ type }: { type: string }) {
+  return (
+    <Tooltip body={EVENT_FORWARDER_MANAGED_TOOLTIP} usePortal>
+      <OfficialBadge type={type} managedBy="api" disableTooltip ml="1" />
+    </Tooltip>
+  );
+}

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
@@ -8,7 +8,10 @@ import { PiCaretRight, PiDotsThreeVertical, PiPlus } from "react-icons/pi";
 import { Box, Card, Flex, Heading, IconButton } from "@radix-ui/themes";
 import { DimensionSlicesInterface } from "shared/types/dimension";
 import { isEventForwarderManaged } from "shared/util";
-import { OfficialBadge } from "@/components/Metrics/MetricName";
+import {
+  EVENT_FORWARDER_MANAGED_TOOLTIP,
+  EventForwarderManagedBadge,
+} from "@/components/Settings/EditDataSource/EventForwarderManaged";
 import { DataSourceQueryEditingModalBaseProps } from "@/components/Settings/EditDataSource/types";
 import Code from "@/components/SyntaxHighlighting/Code";
 import { AddEditExperimentAssignmentQueryModal } from "@/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal";
@@ -151,6 +154,9 @@ export const ExperimentAssignmentQueries: FC<
       {experimentExposureQueries.map((query, idx) => {
         const isOpen = openIndexes[idx] || false;
         const isManaged = isEventForwarderManaged(query);
+        const managedTooltip = isManaged
+          ? EVENT_FORWARDER_MANAGED_TOOLTIP
+          : undefined;
 
         return (
           <Card mt="3" key={query.id}>
@@ -160,11 +166,7 @@ export const ExperimentAssignmentQueries: FC<
                 <Heading as="h4" size="3" mb="0">
                   {query.name}
                   {isManaged && (
-                    <OfficialBadge
-                      type="assignment query"
-                      managedBy="api"
-                      ml="1"
-                    />
+                    <EventForwarderManagedBadge type="assignment query" />
                   )}
                 </Heading>
                 {query.description && (
@@ -228,7 +230,7 @@ export const ExperimentAssignmentQueries: FC<
               {/* region Actions*/}
 
               <Flex align="center">
-                {canEdit && !isManaged && (
+                {canEdit && (
                   <DropdownMenu
                     trigger={
                       <IconButton
@@ -247,18 +249,24 @@ export const ExperimentAssignmentQueries: FC<
                   >
                     <DropdownMenuItem
                       onClick={handleActionClicked(idx, "edit")}
+                      disabled={isManaged}
+                      tooltip={managedTooltip}
                     >
                       Edit Query
                     </DropdownMenuItem>
                     {query.dimensions.length > 0 ? (
                       <DropdownMenuItem
                         onClick={handleActionClicked(idx, "dimension")}
+                        disabled={isManaged}
+                        tooltip={managedTooltip}
                       >
                         Edit Dimensions
                       </DropdownMenuItem>
                     ) : null}
                     <DropdownMenuItem
                       color="red"
+                      disabled={isManaged}
+                      tooltip={managedTooltip}
                       confirmation={{
                         submit: handleActionDeleteClicked(idx),
                         confirmationTitle: `Delete ${query.name}`,

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
@@ -8,6 +8,7 @@ import { PiCaretRight, PiDotsThreeVertical, PiPlus } from "react-icons/pi";
 import { Box, Card, Flex, Heading, IconButton } from "@radix-ui/themes";
 import { DimensionSlicesInterface } from "shared/types/dimension";
 import { isEventForwarderManaged } from "shared/util";
+import { OfficialBadge } from "@/components/Metrics/MetricName";
 import { DataSourceQueryEditingModalBaseProps } from "@/components/Settings/EditDataSource/types";
 import Code from "@/components/SyntaxHighlighting/Code";
 import { AddEditExperimentAssignmentQueryModal } from "@/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal";
@@ -158,6 +159,13 @@ export const ExperimentAssignmentQueries: FC<
               <Box width="100%">
                 <Heading as="h4" size="3" mb="0">
                   {query.name}
+                  {isManaged && (
+                    <OfficialBadge
+                      type="assignment query"
+                      managedBy="api"
+                      ml="1"
+                    />
+                  )}
                 </Heading>
                 {query.description && (
                   <p className="text-muted mb-0 mt-1">{query.description}</p>

--- a/packages/front-end/components/Settings/EditDataSource/FeatureEvaluationQueries/FeatureEvaluationQueries.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/FeatureEvaluationQueries/FeatureEvaluationQueries.tsx
@@ -10,6 +10,7 @@ import {
   isEventForwarderManaged,
 } from "shared/util";
 import { Box, Flex, Heading, IconButton } from "@radix-ui/themes";
+import { OfficialBadge } from "@/components/Metrics/MetricName";
 import { DataSourceQueryEditingModalBaseProps } from "@/components/Settings/EditDataSource/types";
 import Code from "@/components/SyntaxHighlighting/Code";
 import Button from "@/ui/Button";
@@ -107,6 +108,13 @@ export const FeatureEvaluationQueries: FC<FeatureEvaluationQueriesProps> = ({
           <Flex align="center" gap="3" mb="0">
             <Heading as="h3" size="4" mb="0">
               Feature Usage Query
+              {isManaged && (
+                <OfficialBadge
+                  type="feature usage query"
+                  managedBy="api"
+                  ml="1"
+                />
+              )}
             </Heading>
           </Flex>
         </Box>

--- a/packages/front-end/components/Settings/EditDataSource/FeatureEvaluationQueries/FeatureEvaluationQueries.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/FeatureEvaluationQueries/FeatureEvaluationQueries.tsx
@@ -10,7 +10,10 @@ import {
   isEventForwarderManaged,
 } from "shared/util";
 import { Box, Flex, Heading, IconButton } from "@radix-ui/themes";
-import { OfficialBadge } from "@/components/Metrics/MetricName";
+import {
+  EVENT_FORWARDER_MANAGED_TOOLTIP,
+  EventForwarderManagedBadge,
+} from "@/components/Settings/EditDataSource/EventForwarderManaged";
 import { DataSourceQueryEditingModalBaseProps } from "@/components/Settings/EditDataSource/types";
 import Code from "@/components/SyntaxHighlighting/Code";
 import Button from "@/ui/Button";
@@ -100,6 +103,9 @@ export const FeatureEvaluationQueries: FC<FeatureEvaluationQueriesProps> = ({
 
   const isManaged =
     !!featureUsageQuery && isEventForwarderManaged(featureUsageQuery);
+  const managedTooltip = isManaged
+    ? EVENT_FORWARDER_MANAGED_TOOLTIP
+    : undefined;
 
   return (
     <Box>
@@ -109,11 +115,7 @@ export const FeatureEvaluationQueries: FC<FeatureEvaluationQueriesProps> = ({
             <Heading as="h3" size="4" mb="0">
               Feature Usage Query
               {isManaged && (
-                <OfficialBadge
-                  type="feature usage query"
-                  managedBy="api"
-                  ml="1"
-                />
+                <EventForwarderManagedBadge type="feature usage query" />
               )}
             </Heading>
           </Flex>
@@ -126,7 +128,7 @@ export const FeatureEvaluationQueries: FC<FeatureEvaluationQueriesProps> = ({
                 Add
               </Button>
             )}
-            {featureUsageQuery && !isManaged && (
+            {featureUsageQuery && (
               <DropdownMenu
                 trigger={
                   <IconButton
@@ -143,12 +145,18 @@ export const FeatureEvaluationQueries: FC<FeatureEvaluationQueriesProps> = ({
                 menuPlacement="end"
                 variant="soft"
               >
-                <DropdownMenuItem onClick={() => setUiMode("edit")}>
+                <DropdownMenuItem
+                  onClick={() => setUiMode("edit")}
+                  disabled={isManaged}
+                  tooltip={managedTooltip}
+                >
                   Edit Query
                 </DropdownMenuItem>
 
                 <DropdownMenuItem
                   color="red"
+                  disabled={isManaged}
+                  tooltip={managedTooltip}
                   confirmation={{
                     submit: handleActionDeleteClicked(),
                     confirmationTitle: "Delete Feature Usage Query",

--- a/packages/front-end/components/Settings/SnowflakeForm.tsx
+++ b/packages/front-end/components/Settings/SnowflakeForm.tsx
@@ -16,8 +16,8 @@ const SnowflakeForm: FC<{
   onManualParamChange: (name: string, value: string) => void;
 }> = ({ params, existing, onParamChange, onManualParamChange }) => {
   const [useAccessUrl, setUseAccessUrl] = useState(!!params.accessUrl);
-  // Convenience variable for the auth method to handle undefined
-  const authMethod = params.authMethod ?? "password";
+  // Saved connections without authMethod used password; new ones default to key-pair.
+  const authMethod = params.authMethod ?? (existing ? "password" : "key-pair");
   const canKeepExistingCredentials = useCanKeepExistingCredentials(
     existing,
     authMethod,
@@ -55,11 +55,11 @@ const SnowflakeForm: FC<{
           className="form-control"
           autoComplete="off"
           name="authMethod"
-          value={params.authMethod ?? "password"}
+          value={authMethod}
           onChange={(e) => onManualParamChange("authMethod", e.target.value)}
         >
-          <option value="password">Password</option>
           <option value="key-pair">Key Pair</option>
+          <option value="password">Password</option>
         </select>
       </div>
 

--- a/packages/front-end/services/eventSchema.tsx
+++ b/packages/front-end/services/eventSchema.tsx
@@ -353,6 +353,7 @@ export const dataSourceConnections: {
       account: "",
       username: "",
       password: "",
+      authMethod: "key-pair",
     },
   },
   {

--- a/packages/front-end/ui/DropdownMenu.tsx
+++ b/packages/front-end/ui/DropdownMenu.tsx
@@ -213,6 +213,7 @@ type DropdownItemProps = {
   color?: "red" | "default";
   shortcut?: RadixDropdownMenu.ItemProps["shortcut"];
   tooltip?: string;
+  tooltipStyle?: React.CSSProperties;
   confirmation?: {
     submit: () => Promise<void> | void;
     getConfirmationContent?: () => Promise<string | ReactElement | null>;
@@ -234,6 +235,7 @@ export function DropdownMenuItem({
   onClick,
   confirmation,
   tooltip,
+  tooltipStyle = { width: "max-content" },
   ...props
 }: DropdownItemProps) {
   if (color === "default") {
@@ -340,7 +342,13 @@ export function DropdownMenuItem({
           {confirmationContent ?? "Are you sure? This action cannot be undone."}
         </ModalStandard>
       )}
-      {tooltip ? <Tooltip body={tooltip}>{menuItem}</Tooltip> : menuItem}
+      {tooltip ? (
+        <Tooltip body={tooltip} popperStyle={tooltipStyle}>
+          {menuItem}
+        </Tooltip>
+      ) : (
+        menuItem
+      )}
     </>
   );
 }

--- a/packages/shared/src/util/event-forwarder-datasource.ts
+++ b/packages/shared/src/util/event-forwarder-datasource.ts
@@ -1,4 +1,5 @@
 import isEqual from "lodash/isEqual";
+import omit from "lodash/omit";
 import {
   DataSourceParams,
   DataSourceType,
@@ -134,7 +135,10 @@ export function findEventForwarderManagedViolation<
     if (!updated) {
       return `Cannot delete ${label} ${identify(record)} because it is managed by Event Forwarder`;
     }
-    if (!isEqual(record, updated)) {
+    // `error` is stamped by query validation on the way through, so it is the
+    // one field a managed record must be free to change — otherwise a broken
+    // managed query can never persist its error and the UI shows nothing.
+    if (!isEqual(omit(record, "error"), omit(updated, "error"))) {
       return `Cannot edit ${label} ${identify(record)} because it is managed by Event Forwarder`;
     }
   }

--- a/packages/shared/test/util/event-forwarder-datasource.test.ts
+++ b/packages/shared/test/util/event-forwarder-datasource.test.ts
@@ -453,6 +453,25 @@ describe("findEventForwarderManagedViolation", () => {
     );
   });
 
+  it("allows validation to stamp an error on a managed record", () => {
+    expect(
+      findEventForwarderManagedViolation({
+        before,
+        after: [{ ...before[0], error: "bad query" }, before[1]],
+        identify,
+        label,
+      }),
+    ).toBe(null);
+    expect(
+      findEventForwarderManagedViolation({
+        before: [{ ...before[0], error: "bad query" }],
+        after: [{ ...before[0], error: undefined }],
+        identify,
+        label,
+      }),
+    ).toBe(null);
+  });
+
   it("allows anything when nothing was managed", () => {
     expect(
       findEventForwarderManagedViolation({


### PR DESCRIPTION
### Features and Changes
- Address the last bit of feedback https://github.com/growthbook/growthbook/pull/6519#pullrequestreview-4996907517
- Added tooltips, indicator and CTA (disabled) for Event forwarder managed resources: Identifier Types, Experiment Queries and Feature Query
- Changed the Snowflake form to show Keypair as the default Authentication method instead of Password.

### Dependencies
N/A

### Testing
- [x] Add an Event Forwarder to a datasource
- [x] Verify all EF managed resources are read-only
- [x] Verify the buttons are there but not clickable with appropriate tooltips

### Screenshots
<img width="1944" height="695" alt="Screenshot 2026-08-24 at 11 33 46" src="https://github.com/user-attachments/assets/eec3c675-6131-4543-977b-f75a79e316cb" />
<img width="1858" height="668" alt="Screenshot 2026-08-24 at 11 33 55" src="https://github.com/user-attachments/assets/dc0bd050-a355-470f-bb44-509117fc346a" />
<img width="1862" height="1102" alt="Screenshot 2026-08-24 at 11 34 05" src="https://github.com/user-attachments/assets/30393f45-4238-4985-b451-c9b3057d1e50" />
<img width="1710" height="465" alt="Screenshot 2026-08-24 at 11 34 18" src="https://github.com/user-attachments/assets/b20d959d-4c5f-42b7-ab29-1e73ec363d77" />

