### PR TITLE
Fix draft experiment-ref rules never reaching the SDK payload

### DIFF
--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -1918,8 +1918,7 @@ export async function getAllPayloadExperiments(
 
   return new Map(
     experiments
-      // Keep feature-only drafts: connections with includeDraftExperimentRefs
-      // need them, and getFeatureDefinition drops drafts for everyone else.
+      // Keep drafts; getFeatureDefinition filters them per connection
       .filter((e) => includeExperimentInPayload(e, [], { includeDrafts: true }))
       .map((e) => [e.id, e]),
   );
@@ -2093,9 +2092,8 @@ export function getPayloadKeys(
   // Every org project id — only consulted for linked features that target all projects.
   allProjectIds: string[] = [],
 ): SDKPayloadKey[] {
-  // If experiment is not included in the SDK payload. Feature-only drafts
-  // count: connections with includeDraftExperimentRefs serve them, so edits
-  // must refresh the payloads their published ref rules live in.
+  // If experiment is not included in the SDK payload. Drafts count so their
+  // edits refresh the payloads serving includeDraftExperimentRefs connections.
   if (
     !includeExperimentInPayload(experiment, linkedFeatures, {
       includeDrafts: true,

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -1918,7 +1918,9 @@ export async function getAllPayloadExperiments(
 
   return new Map(
     experiments
-      .filter((e) => includeExperimentInPayload(e))
+      // Keep feature-only drafts: connections with includeDraftExperimentRefs
+      // need them, and getFeatureDefinition drops drafts for everyone else.
+      .filter((e) => includeExperimentInPayload(e, [], { includeDrafts: true }))
       .map((e) => [e.id, e]),
   );
 }
@@ -2091,8 +2093,14 @@ export function getPayloadKeys(
   // Every org project id — only consulted for linked features that target all projects.
   allProjectIds: string[] = [],
 ): SDKPayloadKey[] {
-  // If experiment is not included in the SDK payload
-  if (!includeExperimentInPayload(experiment, linkedFeatures)) {
+  // If experiment is not included in the SDK payload. Feature-only drafts
+  // count: connections with includeDraftExperimentRefs serve them, so edits
+  // must refresh the payloads their published ref rules live in.
+  if (
+    !includeExperimentInPayload(experiment, linkedFeatures, {
+      includeDrafts: true,
+    })
+  ) {
     return [];
   }
 
@@ -2166,8 +2174,8 @@ const hasChangesForSDKPayloadRefresh = (
 ): boolean => {
   // Skip experiments that don't have linked changes
   if (
-    !includeExperimentInPayload(oldExperiment) &&
-    !includeExperimentInPayload(newExperiment)
+    !includeExperimentInPayload(oldExperiment, [], { includeDrafts: true }) &&
+    !includeExperimentInPayload(newExperiment, [], { includeDrafts: true })
   ) {
     return false;
   }

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -1641,6 +1641,7 @@ export async function getFeatureDefinitions(
       encryptionKey: args.encryptionKey,
       includeVisualExperiments: args.includeVisualExperiments,
       includeDraftExperiments: args.includeDraftExperiments,
+      includeDraftExperimentRefs: args.includeDraftExperimentRefs,
       includeExperimentNames: args.includeExperimentNames,
       includeRedirectExperiments: args.includeRedirectExperiments,
       includeRuleIds: args.includeRuleIds,

--- a/packages/back-end/src/util/features.ts
+++ b/packages/back-end/src/util/features.ts
@@ -1051,9 +1051,14 @@ export function getFeatureDefinition({
           const exp = experimentMap.get(r.experimentId);
           if (!exp) return null;
 
-          if (!includeExperimentInPayload(exp)) return null;
-
           if (exp.status === "draft" && !includeDraftExperimentRefs)
+            return null;
+
+          if (
+            !includeExperimentInPayload(exp, [], {
+              includeDrafts: includeDraftExperimentRefs,
+            })
+          )
             return null;
 
           // Get current experiment phase and use it to set rule properties

--- a/packages/back-end/test/services/sdk-payload-generation.test.ts
+++ b/packages/back-end/test/services/sdk-payload-generation.test.ts
@@ -1599,8 +1599,7 @@ describe("SDK payload generation (scenario-specific)", () => {
   });
 
   describe("includeDraftExperimentRefs", () => {
-    // Draft experiment linked ONLY via a feature flag (no visual changesets or
-    // URL redirects) — the case the connection setting exists for.
+    // Draft experiment linked only via a feature flag (no visual changesets or redirects)
     function draftRefData(): SDKPayloadRawData {
       const exp: ExperimentInterface = {
         id: "exp-draft-ref",

--- a/packages/back-end/test/services/sdk-payload-generation.test.ts
+++ b/packages/back-end/test/services/sdk-payload-generation.test.ts
@@ -1598,6 +1598,104 @@ describe("SDK payload generation (scenario-specific)", () => {
     expect(outIncluded.experiments?.length).toBe(1);
   });
 
+  describe("includeDraftExperimentRefs", () => {
+    // Draft experiment linked ONLY via a feature flag (no visual changesets or
+    // URL redirects) — the case the connection setting exists for.
+    function draftRefData(): SDKPayloadRawData {
+      const exp: ExperimentInterface = {
+        id: "exp-draft-ref",
+        organization: "org-1",
+        project: "",
+        name: "Draft Ref Exp",
+        hypothesis: "",
+        status: "draft",
+        hashVersion: 2,
+        archived: false,
+        hasVisualChangesets: false,
+        hasURLRedirects: false,
+        linkedFeatures: ["fd"],
+        trackingKey: "tk-draft",
+        phases: [
+          {
+            phase: "main",
+            coverage: 1,
+            variationWeights: [0.5, 0.5],
+            seed: "draft-ref-seed",
+          },
+        ],
+        variations: [
+          { id: "v0", key: "0", name: "Control" },
+          { id: "v1", key: "1", name: "Treatment" },
+        ],
+        dateCreated: new Date(),
+        dateUpdated: new Date(),
+      } as ExperimentInterface;
+      const feature: FeatureInterface = {
+        id: "fd",
+        project: "",
+        dateCreated: new Date(),
+        dateUpdated: new Date(),
+        defaultValue: "false",
+        organization: "org-1",
+        owner: "",
+        valueType: "boolean",
+        archived: false,
+        description: "",
+        version: 1,
+        environmentSettings: {
+          production: {
+            enabled: true,
+            rules: [
+              {
+                type: "experiment-ref",
+                id: "rule-draft-ref",
+                enabled: true,
+                experimentId: "exp-draft-ref",
+                variations: [
+                  { variationId: "v0", value: "false" },
+                  { variationId: "v1", value: "true" },
+                ],
+              },
+            ],
+          },
+        },
+      } as FeatureInterface;
+      return minimalRawData({
+        features: [feature],
+        experimentMap: new Map([[exp.id, exp]]),
+      });
+    }
+
+    it("excludes feature-only draft experiment-ref rules by default", async () => {
+      const out = await buildSDKPayloadForConnection({
+        context: minimalContext(),
+        connection: {
+          capabilities: [],
+          environment: "production",
+          projects: [],
+        },
+        data: draftRefData(),
+      });
+      expect(out.features["fd"]?.rules ?? []).toEqual([]);
+    });
+
+    it("includes feature-only draft experiment-ref rules when enabled", async () => {
+      const out = await buildSDKPayloadForConnection({
+        context: minimalContext(),
+        connection: {
+          capabilities: [],
+          environment: "production",
+          projects: [],
+          includeDraftExperimentRefs: true,
+        },
+        data: draftRefData(),
+      });
+      const rules = out.features["fd"]?.rules ?? [];
+      expect(rules.length).toBe(1);
+      expect(rules[0].variations).toEqual([false, true]);
+    });
+  });
+
   describe("contextual bandits gated by SDK version", () => {
     const cbDoc = {
       id: "cb1",

--- a/packages/shared/src/util/index.ts
+++ b/packages/shared/src/util/index.ts
@@ -200,9 +200,7 @@ export function includeExperimentInPayload(
   exp: ExperimentInterface | ExperimentInterfaceStringDates,
   linkedFeatures: FeatureInterface[] = [],
   options?: {
-    // SDK connections can opt into draft experiment-ref rules
-    // (includeDraftExperimentRefs), so payload-building and payload-refresh
-    // paths must keep feature-only drafts in scope.
+    // Keep feature-only drafts (SDK connections with includeDraftExperimentRefs)
     includeDrafts?: boolean;
   },
 ): boolean {

--- a/packages/shared/src/util/index.ts
+++ b/packages/shared/src/util/index.ts
@@ -199,14 +199,22 @@ export function experimentHasLiveLinkedChanges(
 export function includeExperimentInPayload(
   exp: ExperimentInterface | ExperimentInterfaceStringDates,
   linkedFeatures: FeatureInterface[] = [],
+  options?: {
+    // SDK connections can opt into draft experiment-ref rules
+    // (includeDraftExperimentRefs), so payload-building and payload-refresh
+    // paths must keep feature-only drafts in scope.
+    includeDrafts?: boolean;
+  },
 ): boolean {
   // Archived experiments are always excluded
   if (exp.archived) return false;
 
   if (!experimentHasLinkedChanges(exp)) return false;
 
-  // Exclude if experiment is a draft and there are no visual changes or redirects (feature flags always ignore draft experiment rules)
+  // Exclude if experiment is a draft and there are no visual changes or redirects
+  // (feature flags ignore draft experiment rules unless includeDrafts is set)
   if (
+    !options?.includeDrafts &&
     !exp.hasVisualChangesets &&
     !exp.hasURLRedirects &&
     exp.status === "draft"


### PR DESCRIPTION
The SDK connection setting "Include draft Experiment rules in feature definitions" was not plumbed properly and was effectively a no-op. Fixed in this PR.

Drafts still only appear where the experiment-ref rule itself is published and enabled.