### PR TITLE
fix(fact-metrics): handle partial aggregate filters

### DIFF
--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -289,6 +289,13 @@ export class FactMetricModel extends BaseClass {
       delete newColumnRef.aggregation;
     }
 
+    // A user filter needs both fields; a half-set pair (from the same null
+    // storage) fails the "both or neither" check and blocks unrelated edits
+    if (!newColumnRef.aggregateFilter || !newColumnRef.aggregateFilterColumn) {
+      delete newColumnRef.aggregateFilter;
+      delete newColumnRef.aggregateFilterColumn;
+    }
+
     // If row filters are already defined, do nothing
     if (newColumnRef.rowFilters !== undefined) {
       return newColumnRef;

--- a/packages/back-end/test/migrations.test.ts
+++ b/packages/back-end/test/migrations.test.ts
@@ -372,6 +372,54 @@ describe("Fact Metric Migration", () => {
         rowFilters: [],
       });
     });
+    it("keeps a complete aggregate filter", () => {
+      expect(
+        FactMetricModel.migrateColumnRef({
+          factTableId: "ft_123",
+          column: "event_name",
+          rowFilters: [],
+          aggregateFilterColumn: "$$count",
+          aggregateFilter: ">= 1",
+        }),
+      ).toEqual({
+        factTableId: "ft_123",
+        column: "event_name",
+        rowFilters: [],
+        aggregateFilterColumn: "$$count",
+        aggregateFilter: ">= 1",
+      });
+    });
+    it("drops an aggregate filter column with no filter", () => {
+      expect(
+        FactMetricModel.migrateColumnRef({
+          factTableId: "ft_123",
+          column: "event_name",
+          rowFilters: [],
+          aggregateFilterColumn: "$$count",
+        }),
+      ).toEqual({
+        factTableId: "ft_123",
+        column: "event_name",
+        rowFilters: [],
+      });
+    });
+    it("drops an aggregate filter with a null column", () => {
+      expect(
+        FactMetricModel.migrateColumnRef({
+          factTableId: "ft_123",
+          column: "event_name",
+          rowFilters: [],
+          aggregateFilter: ">= 1",
+          // Mongo stores an explicit `undefined` as null
+          aggregateFilterColumn: null as unknown as string,
+        }),
+      ).toEqual({
+        factTableId: "ft_123",
+        column: "event_name",
+        rowFilters: [],
+      });
+    });
+
     it("Can unmigrate filters for API responses", () => {
       const original: LegacyColumnRef = {
         factTableId: "ft_123",

--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -1854,6 +1854,7 @@ function StandardFactMetricModal({
         ) {
           if (values.numerator.column !== "$$distinctUsers") {
             values.numerator.aggregateFilterColumn = "";
+            values.numerator.aggregateFilter = undefined;
           } else {
             if (values.cappingSettings?.type) {
               throw new Error(


### PR DESCRIPTION
### Features and Changes

We observed some errors in JS when fields were not in the shape we expected. So to fix it, we are doing additional clean ups.

- Clear partial aggregate-filter fields during fact metric migration so stale Mongo `null` values do not block unrelated edits.
- Clear the aggregate filter when the modal resets its aggregate filter column.

### Testing

- Unit tests