### PR TITLE
feat(nps): let staff bypass sampling and tenure

### DIFF
--- a/packages/front-end/components/NPSSurvey/NPSSurvey.tsx
+++ b/packages/front-end/components/NPSSurvey/NPSSurvey.tsx
@@ -145,9 +145,18 @@ export default function NPSSurvey() {
   const suppressed = withinCooldown(npsSurveyAt);
   // Tenure is the account's own age, so a new hire at an established org isn't
   // asked on their first day.
+  //
+  // Staff skip sampling and tenure. At a 5% rate with a staggered start day only
+  // about 1 in 23 eligible users sees the card on a given day, which makes the
+  // live path impractical to exercise on demand. Everything else still applies —
+  // the webhook must be configured, the cooldown still suppresses, and the
+  // response is recorded and forwarded normally rather than as a `?show-nps`
+  // preview. A rate of 0 turns the survey off for staff too.
   const eligible =
-    meetsMinimumTenure(accountCreatedAt, minTenureDays) &&
-    inSampledCohort(userId, sampleRate);
+    sampleRate > 0 &&
+    (isStaff ||
+      (meetsMinimumTenure(accountCreatedAt, minTenureDays) &&
+        inSampledCohort(userId, sampleRate)));
   // Latched, not derived: `?show-nps` disappears on client-side navigation,
   // which would flip a staff preview into a real response mid-card.
   const [forceShow, setForceShow] = useState(false);


### PR DESCRIPTION
Follow-up to #6184.

## Why

At the current `rate: 5` with a staggered start day, only about **1 in 23** eligible users sees the card on a given day (day 79 of the 90-day cycle, measured against the real sampling function). There was no practical way to exercise the live path on demand.

`?show-nps` bypasses the gates, but marks the response as a **preview**: the server skips `updateUser` and the Slack message is labelled, so it does not exercise the real path either.

## What changes

superAdmins skip sampling and tenure on the normal path:

```ts
const eligible =
  sampleRate > 0 &&
  (isStaff ||
    (meetsMinimumTenure(accountCreatedAt, minTenureDays) &&
      inSampledCohort(userId, sampleRate)));
```

Everything else is unchanged: the webhook must still be configured, the 90-day cooldown still suppresses, and the response is recorded and forwarded like any other.

**`rate: 0` still turns the survey off for everyone, staff included** — the kill switch is intact.

## Tradeoff

Staff responses land in the NPS data as real responses. Since superAdmins are GrowthBook staff rather than customers, that is arguably noise worth filtering at analysis time. The cooldown caps it at one per person per 90 days.

If you would rather staff never pollute the data, the alternative is to keep this preview-only via `?show-nps` and accept that the live path can only be observed by waiting for real traffic.

## Verification

Type-check, eslint and `pretty:check` clean; 1089 front-end tests pass.