### PR TITLE
Rebuild SDK payloads from a fresh org after an environment's projects change

### DIFF
--- a/packages/back-end/src/api/environments/putEnvironment.ts
+++ b/packages/back-end/src/api/environments/putEnvironment.ts
@@ -6,6 +6,7 @@ import { updateOrganization } from "back-end/src/models/OrganizationModel";
 import { auditDetailsUpdate } from "back-end/src/services/audit";
 import { findSDKConnectionsByOrganization } from "back-end/src/models/SdkConnectionModel";
 import { queueSDKPayloadRefresh } from "back-end/src/services/features";
+import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizations";
 import { validatePayload } from "./validations";
 
 export const putEnvironment = createApiRequestHandler(putEnvironmentValidator)(
@@ -62,8 +63,9 @@ export const putEnvironment = createApiRequestHandler(putEnvironmentValidator)(
           (c) => c.environment === id,
         );
 
+        // Re-read the org: req.context still holds the pre-update environments, which would rebuild payloads against the old project list
         queueSDKPayloadRefresh({
-          context: req.context,
+          context: await getContextForAgendaJobByOrgId(org.id),
           payloadKeys: [],
           sdkConnections: affectedConnections,
           auditContext: {

--- a/packages/back-end/src/routers/environment/environment.controller.ts
+++ b/packages/back-end/src/routers/environment/environment.controller.ts
@@ -23,6 +23,7 @@ import { PrivateApiErrorResponse } from "back-end/types/api";
 import {
   getEnvironments,
   getContextFromReq,
+  getContextForAgendaJobByOrgId,
 } from "back-end/src/services/organizations";
 import { addEnvironmentToOrganizationEnvironments } from "back-end/src/util/environments";
 import { updateOrganization } from "back-end/src/models/OrganizationModel";
@@ -208,10 +209,16 @@ export const putEnvironment = async (
           (c) => c.environment === id,
         );
 
+        // Re-read the org: the request context still holds the pre-update environments, which would rebuild payloads against the old project list
         queueSDKPayloadRefresh({
-          context,
+          context: await getContextForAgendaJobByOrgId(org.id),
           payloadKeys: [],
           sdkConnections: affectedConnections,
+          auditContext: {
+            event: "projects changed",
+            model: "environment",
+            id,
+          },
         });
       }
     }

--- a/packages/back-end/test/api/environments.test.ts
+++ b/packages/back-end/test/api/environments.test.ts
@@ -1,8 +1,12 @@
 import request from "supertest";
-import { updateOrganization } from "back-end/src/models/OrganizationModel";
+import {
+  findOrganizationById,
+  updateOrganization,
+} from "back-end/src/models/OrganizationModel";
 import { setupApp } from "./api.setup";
 
 jest.mock("back-end/src/models/OrganizationModel", () => ({
+  findOrganizationById: jest.fn(),
   updateOrganization: jest.fn(),
 }));
 
@@ -181,29 +185,32 @@ describe("environements API", () => {
   });
 
   it("can update environments", async () => {
+    const org = {
+      id: "org1",
+      settings: {
+        environments: [
+          {
+            id: "env1",
+            description: "env1",
+            toggleOnList: true,
+            defaultState: true,
+            projects: ["bla"],
+          },
+          {
+            id: "env2",
+          },
+        ],
+      },
+    };
+    // The payload refresh re-reads the org by id after the write
+    jest.mocked(findOrganizationById).mockResolvedValue(org as never);
     setReqContext({
       models: {
         projects: {
           getAll: () => [{ id: "proj1" }, { id: "proj2" }, { id: "proj3" }],
         },
       },
-      org: {
-        id: "org1",
-        settings: {
-          environments: [
-            {
-              id: "env1",
-              description: "env1",
-              toggleOnList: true,
-              defaultState: true,
-              projects: ["bla"],
-            },
-            {
-              id: "env2",
-            },
-          ],
-        },
-      },
+      org,
       permissions: {
         canUpdateEnvironment: () => true,
       },


### PR DESCRIPTION
### Features and Changes

Both `PUT /environment/:id` handlers (internal and REST) queue an SDK payload refresh after `updateOrganization()`, but pass the request context whose `org` was loaded before the write. `refreshSDKPayloadCache` then filters each connection's projects against the environment's *previous* project list, so every rebuild lags one save behind. Editing the list twice (remove a project, add it back) leaves the DB correct while connections in that project are cached as `{features: {}, experiments: [], savedGroups: {}}` until an unrelated refresh touches them.
The refresh context is now re-read by id via `getContextForAgendaJobByOrgId`, and the internal path tags the refresh with an `auditContext` so `sdkcache.audit` attributes the rebuild to the environment edit.

### Testing

- [x] Project-scoped connection in `production`; set the env's projects to its project -> payload unchanged
- [x] Set the env's projects to a different project -> payload empty (before: stayed populated)
- [x] Set the env's projects back to its project -> payload populated (before: `features: {}`)
- [x] `sdkcache.audit` for the connection shows `event: "projects changed", model: "environment"`
