### PR TITLE
Fix OAuth login failures with many open tabs and return to the original page

### DIFF
--- a/packages/back-end/src/services/auth/OpenIdAuthConnection.ts
+++ b/packages/back-end/src/services/auth/OpenIdAuthConnection.ts
@@ -20,7 +20,9 @@ import {
 import { AuthRequest } from "back-end/src/types/AuthRequest";
 import { MemoryCache } from "back-end/src/services/cache";
 import {
-  AuthChecksCookie,
+  clearPendingAuthChecks,
+  getPendingAuthChecks,
+  setPendingAuthChecks,
   SSOConnectionIdCookie,
 } from "back-end/src/util/cookie";
 import { APP_ORIGIN, IS_CLOUD, USE_PROXY } from "back-end/src/util/secrets";
@@ -41,9 +43,6 @@ type AuthChecks = {
   state: string;
   code_verifier: string;
 };
-
-// The cookie holds one entry per in-flight login so concurrent tabs don't clobber each other
-const MAX_PENDING_AUTH_CHECKS = 10;
 
 if (USE_PROXY) {
   custom.setHttpOptionsDefaults(getHttpOptions());
@@ -133,23 +132,19 @@ export class OpenIdAuthConnection implements AuthConnection {
 
     const params = client.callbackParams(req.originalUrl);
 
-    // Consume only this flow's entry; other tabs' pending logins stay valid
-    const pending = this.getAuthChecks(req);
-    const checks = pending.find((c) => c.state === params.state);
-    const remaining = pending.filter((c) => c !== checks);
-    AuthChecksCookie.setValue(
-      remaining.length ? JSON.stringify(remaining) : "",
-      req,
-      res,
-    );
+    // Consume only this flow's cookie; other tabs' pending logins stay valid
+    const pending = getPendingAuthChecks(req);
+    const raw = params.state ? pending[params.state] : undefined;
+    if (raw) clearPendingAuthChecks(req, res, params.state);
 
-    if (!checks) {
+    if (!raw) {
       throw new Error(
-        pending.length
+        Object.keys(pending).length
           ? "No pending auth checks match the returned state"
           : "Missing auth checks in session",
       );
     }
+    const checks: AuthChecks = JSON.parse(raw);
     if (checks.connection_id !== (connection.id || "")) {
       throw new Error("Invalid auth checks in session");
     }
@@ -262,11 +257,7 @@ export class OpenIdAuthConnection implements AuthConnection {
   }
 
   private getAuthChecks(req: Request): AuthChecks[] {
-    const checks = AuthChecksCookie.getValue(req);
-    if (!checks) return [];
-    const parsed: AuthChecks | AuthChecks[] = JSON.parse(checks);
-    // Cookies written before the list format held a single object
-    return Array.isArray(parsed) ? parsed : [parsed];
+    return Object.values(getPendingAuthChecks(req)).map((v) => JSON.parse(v));
   }
   private getMaxAge(tokenSet: TokenSet) {
     if (tokenSet.expires_in) {
@@ -302,8 +293,7 @@ export class OpenIdAuthConnection implements AuthConnection {
       state,
     };
 
-    const pending = this.getAuthChecks(req).slice(1 - MAX_PENDING_AUTH_CHECKS);
-    AuthChecksCookie.setValue(JSON.stringify([...pending, checks]), req, res);
+    setPendingAuthChecks(state, JSON.stringify(checks), req, res);
 
     let url = client.authorizationUrl({
       scope: `openid email profile ${

--- a/packages/back-end/src/services/auth/OpenIdAuthConnection.ts
+++ b/packages/back-end/src/services/auth/OpenIdAuthConnection.ts
@@ -36,7 +36,12 @@ import {
   VERCEL_CLIENT_SECRET,
 } from "back-end/src/services/vercel-native-integration.service";
 import { AuthConnection, TokensResponse } from "./AuthConnection";
-import { deriveAuthChecks, nonceFromState } from "./authChecks";
+import {
+  createNonce,
+  deriveAuthChecks,
+  isNonceExpired,
+  nonceFromState,
+} from "./authChecks";
 
 if (USE_PROXY) {
   custom.setHttpOptionsDefaults(getHttpOptions());
@@ -132,12 +137,13 @@ export class OpenIdAuthConnection implements AuthConnection {
       throw new Error("Missing auth secret cookie");
     }
 
+    const nonce = nonceFromState(params.state);
+    if (isNonceExpired(nonce)) {
+      throw new Error("Login attempt expired");
+    }
+
     // A wrong connection or forged state fails the HMAC comparison inside callback()
-    const checks = deriveAuthChecks(
-      secret,
-      connection.id || "",
-      nonceFromState(params.state),
-    );
+    const checks = deriveAuthChecks(secret, connection.id || "", nonce);
     const tokenSet = await client.callback(
       `${APP_ORIGIN}/oauth/callback`,
       params,
@@ -275,7 +281,7 @@ export class OpenIdAuthConnection implements AuthConnection {
     const { state, code_verifier } = deriveAuthChecks(
       this.getAuthSecret(req, res),
       ssoConnection.id || "",
-      generators.random(),
+      createNonce(),
     );
     const code_challenge = generators.codeChallenge(code_verifier);
 

--- a/packages/back-end/src/services/auth/OpenIdAuthConnection.ts
+++ b/packages/back-end/src/services/auth/OpenIdAuthConnection.ts
@@ -20,9 +20,8 @@ import {
 import { AuthRequest } from "back-end/src/types/AuthRequest";
 import { MemoryCache } from "back-end/src/services/cache";
 import {
-  clearPendingAuthChecks,
-  getPendingAuthChecks,
-  setPendingAuthChecks,
+  AuthSecretCookie,
+  PendingSSOConnectionCookie,
   SSOConnectionIdCookie,
 } from "back-end/src/util/cookie";
 import { APP_ORIGIN, IS_CLOUD, USE_PROXY } from "back-end/src/util/secrets";
@@ -37,12 +36,7 @@ import {
   VERCEL_CLIENT_SECRET,
 } from "back-end/src/services/vercel-native-integration.service";
 import { AuthConnection, TokensResponse } from "./AuthConnection";
-
-type AuthChecks = {
-  connection_id: string;
-  state: string;
-  code_verifier: string;
-};
+import { deriveAuthChecks, nonceFromState } from "./authChecks";
 
 if (USE_PROXY) {
   custom.setHttpOptionsDefaults(getHttpOptions());
@@ -114,13 +108,14 @@ export class OpenIdAuthConnection implements AuthConnection {
     res: Response,
   ): Promise<UnauthenticatedResponse> {
     const { connection, client } = await getConnectionFromRequest(req, res);
-    const redirectURI = this.getRedirectURI(connection, client, req, res);
 
     // If there's an existing incomplete auth session for this Cloud SSO provider,
     // confirm with the user to give them a chance to cancel and reset to the default auth
     const confirm =
       !!connection.id &&
-      this.getAuthChecks(req).some((c) => c.connection_id === connection.id);
+      PendingSSOConnectionCookie.getValue(req) === connection.id;
+
+    const redirectURI = this.getRedirectURI(connection, client, req, res);
 
     return {
       redirectURI,
@@ -132,31 +127,23 @@ export class OpenIdAuthConnection implements AuthConnection {
 
     const params = client.callbackParams(req.originalUrl);
 
-    // Consume only this flow's cookie; other tabs' pending logins stay valid
-    const pending = getPendingAuthChecks(req);
-    const raw = params.state ? pending[params.state] : undefined;
-    if (raw) clearPendingAuthChecks(req, res, params.state);
-
-    if (!raw) {
-      throw new Error(
-        Object.keys(pending).length
-          ? "No pending auth checks match the returned state"
-          : "Missing auth checks in session",
-      );
-    }
-    const checks: AuthChecks = JSON.parse(raw);
-    if (checks.connection_id !== (connection.id || "")) {
-      throw new Error("Invalid auth checks in session");
+    const secret = AuthSecretCookie.getValue(req);
+    if (!secret) {
+      throw new Error("Missing auth secret cookie");
     }
 
+    // A wrong connection or forged state fails the HMAC comparison inside callback()
+    const checks = deriveAuthChecks(
+      secret,
+      connection.id || "",
+      nonceFromState(params.state),
+    );
     const tokenSet = await client.callback(
       `${APP_ORIGIN}/oauth/callback`,
       params,
-      {
-        code_verifier: checks.code_verifier,
-        state: checks.state,
-      },
+      checks,
     );
+    PendingSSOConnectionCookie.setValue("", req, res);
 
     const email = tokenSet.claims().email;
     if (email) {
@@ -256,8 +243,11 @@ export class OpenIdAuthConnection implements AuthConnection {
     }
   }
 
-  private getAuthChecks(req: Request): AuthChecks[] {
-    return Object.values(getPendingAuthChecks(req)).map((v) => JSON.parse(v));
+  // Re-set on every use so the TTL slides for active browsers
+  private getAuthSecret(req: Request, res: Response): string {
+    const secret = AuthSecretCookie.getValue(req) || generators.random();
+    AuthSecretCookie.setValue(secret, req, res);
+    return secret;
   }
   private getMaxAge(tokenSet: TokenSet) {
     if (tokenSet.expires_in) {
@@ -282,18 +272,16 @@ export class OpenIdAuthConnection implements AuthConnection {
       }/${installationId}`;
     }
 
-    const code_verifier = generators.codeVerifier();
+    const { state, code_verifier } = deriveAuthChecks(
+      this.getAuthSecret(req, res),
+      ssoConnection.id || "",
+      generators.random(),
+    );
     const code_challenge = generators.codeChallenge(code_verifier);
 
-    const state = generators.state();
-
-    const checks: AuthChecks = {
-      connection_id: ssoConnection.id || "",
-      code_verifier,
-      state,
-    };
-
-    setPendingAuthChecks(state, JSON.stringify(checks), req, res);
+    if (ssoConnection.id) {
+      PendingSSOConnectionCookie.setValue(ssoConnection.id, req, res);
+    }
 
     let url = client.authorizationUrl({
       scope: `openid email profile ${

--- a/packages/back-end/src/services/auth/OpenIdAuthConnection.ts
+++ b/packages/back-end/src/services/auth/OpenIdAuthConnection.ts
@@ -42,6 +42,9 @@ type AuthChecks = {
   code_verifier: string;
 };
 
+// The cookie holds one entry per in-flight login so concurrent tabs don't clobber each other
+const MAX_PENDING_AUTH_CHECKS = 10;
+
 if (USE_PROXY) {
   custom.setHttpOptionsDefaults(getHttpOptions());
 }
@@ -116,8 +119,9 @@ export class OpenIdAuthConnection implements AuthConnection {
 
     // If there's an existing incomplete auth session for this Cloud SSO provider,
     // confirm with the user to give them a chance to cancel and reset to the default auth
-    const checks = this.getAuthChecks(req);
-    const confirm = !!connection.id && checks?.connection_id === connection.id;
+    const confirm =
+      !!connection.id &&
+      this.getAuthChecks(req).some((c) => c.connection_id === connection.id);
 
     return {
       redirectURI,
@@ -127,18 +131,29 @@ export class OpenIdAuthConnection implements AuthConnection {
   async processCallback(req: Request, res: Response): Promise<TokensResponse> {
     const { connection, client } = await getConnectionFromRequest(req, res);
 
-    // Get rid of temporary codeVerifier cookie
-    const checks = this.getAuthChecks(req);
-    AuthChecksCookie.setValue("", req, res);
+    const params = client.callbackParams(req.originalUrl);
+
+    // Consume only this flow's entry; other tabs' pending logins stay valid
+    const pending = this.getAuthChecks(req);
+    const checks = pending.find((c) => c.state === params.state);
+    const remaining = pending.filter((c) => c !== checks);
+    AuthChecksCookie.setValue(
+      remaining.length ? JSON.stringify(remaining) : "",
+      req,
+      res,
+    );
 
     if (!checks) {
-      throw new Error("Missing auth checks in session");
+      throw new Error(
+        pending.length
+          ? "No pending auth checks match the returned state"
+          : "Missing auth checks in session",
+      );
     }
     if (checks.connection_id !== (connection.id || "")) {
       throw new Error("Invalid auth checks in session");
     }
 
-    const params = client.callbackParams(req.originalUrl);
     const tokenSet = await client.callback(
       `${APP_ORIGIN}/oauth/callback`,
       params,
@@ -246,11 +261,12 @@ export class OpenIdAuthConnection implements AuthConnection {
     }
   }
 
-  private getAuthChecks(req: Request) {
+  private getAuthChecks(req: Request): AuthChecks[] {
     const checks = AuthChecksCookie.getValue(req);
-    if (!checks) return null;
-    const parsed: AuthChecks = JSON.parse(checks);
-    return parsed;
+    if (!checks) return [];
+    const parsed: AuthChecks | AuthChecks[] = JSON.parse(checks);
+    // Cookies written before the list format held a single object
+    return Array.isArray(parsed) ? parsed : [parsed];
   }
   private getMaxAge(tokenSet: TokenSet) {
     if (tokenSet.expires_in) {
@@ -286,7 +302,8 @@ export class OpenIdAuthConnection implements AuthConnection {
       state,
     };
 
-    AuthChecksCookie.setValue(JSON.stringify(checks), req, res);
+    const pending = this.getAuthChecks(req).slice(1 - MAX_PENDING_AUTH_CHECKS);
+    AuthChecksCookie.setValue(JSON.stringify([...pending, checks]), req, res);
 
     let url = client.authorizationUrl({
       scope: `openid email profile ${

--- a/packages/back-end/src/services/auth/authChecks.ts
+++ b/packages/back-end/src/services/auth/authChecks.ts
@@ -1,0 +1,22 @@
+import crypto from "crypto";
+
+// Everything a callback needs is recomputed from the browser secret and the nonce carried in `state`
+export function deriveAuthChecks(
+  secret: string,
+  connectionId: string,
+  nonce: string,
+) {
+  const hmac = (label: string) =>
+    crypto
+      .createHmac("sha256", secret)
+      .update(`${label}:${connectionId}:${nonce}`)
+      .digest("base64url");
+  return {
+    state: `${nonce}.${hmac("state")}`,
+    code_verifier: hmac("verifier"),
+  };
+}
+
+export function nonceFromState(state: string | undefined): string {
+  return state?.split(".")[0] ?? "";
+}

--- a/packages/back-end/src/services/auth/authChecks.ts
+++ b/packages/back-end/src/services/auth/authChecks.ts
@@ -1,5 +1,19 @@
 import crypto from "crypto";
 
+// AUTH_SECRET lives ~1 year, so the nonce embeds its mint time to keep callbacks from validating indefinitely
+const NONCE_TTL_MS = 60 * 60 * 1000;
+
+export function createNonce(): string {
+  return `${Date.now().toString(36)}.${crypto
+    .randomBytes(32)
+    .toString("base64url")}`;
+}
+
+export function isNonceExpired(nonce: string): boolean {
+  const ts = parseInt(nonce.split(".")[0], 36);
+  return !Number.isFinite(ts) || Math.abs(Date.now() - ts) > NONCE_TTL_MS;
+}
+
 // Everything a callback needs is recomputed from the browser secret and the nonce carried in `state`
 export function deriveAuthChecks(
   secret: string,
@@ -18,5 +32,7 @@ export function deriveAuthChecks(
 }
 
 export function nonceFromState(state: string | undefined): string {
-  return state?.split(".")[0] ?? "";
+  if (!state) return "";
+  const i = state.lastIndexOf(".");
+  return i > 0 ? state.slice(0, i) : "";
 }

--- a/packages/back-end/src/services/auth/index.ts
+++ b/packages/back-end/src/services/auth/index.ts
@@ -27,7 +27,8 @@ import {
 } from "back-end/src/models/OrganizationModel";
 import {
   IdTokenCookie,
-  clearPendingAuthChecks,
+  AuthSecretCookie,
+  PendingSSOConnectionCookie,
   RefreshTokenCookie,
   SSOConnectionIdCookie,
 } from "back-end/src/util/cookie";
@@ -388,7 +389,8 @@ export function deleteAuthCookies(req: Request, res: Response) {
   RefreshTokenCookie.setValue("", req, res);
   IdTokenCookie.setValue("", req, res);
   SSOConnectionIdCookie.setValue("", req, res);
-  clearPendingAuthChecks(req, res);
+  AuthSecretCookie.setValue("", req, res);
+  PendingSSOConnectionCookie.setValue("", req, res);
 }
 
 export function validatePasswordFormat(password?: string): string {

--- a/packages/back-end/src/services/auth/index.ts
+++ b/packages/back-end/src/services/auth/index.ts
@@ -27,7 +27,7 @@ import {
 } from "back-end/src/models/OrganizationModel";
 import {
   IdTokenCookie,
-  AuthChecksCookie,
+  clearPendingAuthChecks,
   RefreshTokenCookie,
   SSOConnectionIdCookie,
 } from "back-end/src/util/cookie";
@@ -388,7 +388,7 @@ export function deleteAuthCookies(req: Request, res: Response) {
   RefreshTokenCookie.setValue("", req, res);
   IdTokenCookie.setValue("", req, res);
   SSOConnectionIdCookie.setValue("", req, res);
-  AuthChecksCookie.setValue("", req, res);
+  clearPendingAuthChecks(req, res);
 }
 
 export function validatePasswordFormat(password?: string): string {

--- a/packages/back-end/src/util/cookie.ts
+++ b/packages/back-end/src/util/cookie.ts
@@ -67,79 +67,13 @@ export const RefreshTokenCookie = new Cookie(
 );
 export const IdTokenCookie = new Cookie("AUTH_ID_TOKEN", minutes(15));
 
-// One cookie per in-flight login so concurrent tabs can't overwrite each other's state
-const AUTH_CHECKS_PREFIX = "AUTH_CHECKS_";
-// Long enough to sit on the IdP's login page for a while before coming back
-const AUTH_CHECKS_TTL = minutes(60);
-const MAX_PENDING_AUTH_CHECKS = 10;
-
-// Creation time is stored alongside the value so the cap can evict oldest-first
-type PendingAuthChecks = { t: number; v: string };
-
-function authChecksCookie(state: string) {
-  return new Cookie(AUTH_CHECKS_PREFIX + state, AUTH_CHECKS_TTL);
-}
-
-function readPendingAuthChecks(
-  req: Request,
-): Record<string, PendingAuthChecks> {
-  const pending: Record<string, PendingAuthChecks> = {};
-  for (const [name, value] of Object.entries(req.cookies)) {
-    if (!name.startsWith(AUTH_CHECKS_PREFIX) || typeof value !== "string") {
-      continue;
-    }
-    try {
-      const parsed = JSON.parse(value) as Partial<PendingAuthChecks> | null;
-      if (typeof parsed?.t === "number" && typeof parsed?.v === "string") {
-        pending[name.slice(AUTH_CHECKS_PREFIX.length)] = {
-          t: parsed.t,
-          v: parsed.v,
-        };
-      }
-    } catch (e) {
-      // ignore malformed cookies
-    }
-  }
-  return pending;
-}
-
-export function getPendingAuthChecks(req: Request): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(readPendingAuthChecks(req)).map(([s, c]) => [s, c.v]),
-  );
-}
-
-export function setPendingAuthChecks(
-  state: string,
-  value: string,
-  req: Request,
-  res: Response,
-) {
-  // Abandoned flows expire on their own; past the cap, evict the oldest
-  const oldestFirst = Object.entries(readPendingAuthChecks(req)).sort(
-    (a, b) => a[1].t - b[1].t,
-  );
-  const excess = oldestFirst.length + 1 - MAX_PENDING_AUTH_CHECKS;
-  for (const [s] of oldestFirst.slice(0, Math.max(0, excess))) {
-    clearPendingAuthChecks(req, res, s);
-  }
-  authChecksCookie(state).setValue(
-    JSON.stringify({ t: Date.now(), v: value }),
-    req,
-    res,
-  );
-}
-
-export function clearPendingAuthChecks(
-  req: Request,
-  res: Response,
-  state?: string,
-) {
-  const states = state ? [state] : Object.keys(readPendingAuthChecks(req));
-  for (const s of states) {
-    authChecksCookie(s).setValue("", req, res);
-  }
-}
+// Per-browser key that OAuth state/PKCE values derive from, so no per-flow storage is needed
+export const AuthSecretCookie = new Cookie("AUTH_SECRET", days(365));
+// Hint that this browser was recently sent to an enterprise IdP, for the confirm prompt
+export const PendingSSOConnectionCookie = new Cookie(
+  "AUTH_PENDING_SSO",
+  minutes(10),
+);
 
 // Read the JWT's `exp` claim without verifying the signature — we only trust
 // the cookie value once a downstream middleware has verified it.

--- a/packages/back-end/src/util/cookie.ts
+++ b/packages/back-end/src/util/cookie.ts
@@ -66,7 +66,8 @@ export const RefreshTokenCookie = new Cookie(
   "/auth",
 );
 export const IdTokenCookie = new Cookie("AUTH_ID_TOKEN", minutes(15));
-export const AuthChecksCookie = new Cookie("AUTH_CHECKS", minutes(10));
+// Long enough to sit on the IdP's login page for a while before coming back
+export const AuthChecksCookie = new Cookie("AUTH_CHECKS", minutes(60));
 
 // Read the JWT's `exp` claim without verifying the signature — we only trust
 // the cookie value once a downstream middleware has verified it.

--- a/packages/back-end/src/util/cookie.ts
+++ b/packages/back-end/src/util/cookie.ts
@@ -73,18 +73,40 @@ const AUTH_CHECKS_PREFIX = "AUTH_CHECKS_";
 const AUTH_CHECKS_TTL = minutes(60);
 const MAX_PENDING_AUTH_CHECKS = 10;
 
-export function getPendingAuthChecks(req: Request): Record<string, string> {
-  const pending: Record<string, string> = {};
+// Creation time is stored alongside the value so the cap can evict oldest-first
+type PendingAuthChecks = { t: number; v: string };
+
+function authChecksCookie(state: string) {
+  return new Cookie(AUTH_CHECKS_PREFIX + state, AUTH_CHECKS_TTL);
+}
+
+function readPendingAuthChecks(
+  req: Request,
+): Record<string, PendingAuthChecks> {
+  const pending: Record<string, PendingAuthChecks> = {};
   for (const [name, value] of Object.entries(req.cookies)) {
-    if (
-      name.startsWith(AUTH_CHECKS_PREFIX) &&
-      typeof value === "string" &&
-      value
-    ) {
-      pending[name.slice(AUTH_CHECKS_PREFIX.length)] = value;
+    if (!name.startsWith(AUTH_CHECKS_PREFIX) || typeof value !== "string") {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(value) as Partial<PendingAuthChecks> | null;
+      if (typeof parsed?.t === "number" && typeof parsed?.v === "string") {
+        pending[name.slice(AUTH_CHECKS_PREFIX.length)] = {
+          t: parsed.t,
+          v: parsed.v,
+        };
+      }
+    } catch (e) {
+      // ignore malformed cookies
     }
   }
   return pending;
+}
+
+export function getPendingAuthChecks(req: Request): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(readPendingAuthChecks(req)).map(([s, c]) => [s, c.v]),
+  );
 }
 
 export function setPendingAuthChecks(
@@ -93,14 +115,16 @@ export function setPendingAuthChecks(
   req: Request,
   res: Response,
 ) {
-  // Abandoned flows expire on their own; only sweep when they pile up
-  if (
-    Object.keys(getPendingAuthChecks(req)).length >= MAX_PENDING_AUTH_CHECKS
-  ) {
-    clearPendingAuthChecks(req, res);
+  // Abandoned flows expire on their own; past the cap, evict the oldest
+  const oldestFirst = Object.entries(readPendingAuthChecks(req)).sort(
+    (a, b) => a[1].t - b[1].t,
+  );
+  const excess = oldestFirst.length + 1 - MAX_PENDING_AUTH_CHECKS;
+  for (const [s] of oldestFirst.slice(0, Math.max(0, excess))) {
+    clearPendingAuthChecks(req, res, s);
   }
-  new Cookie(AUTH_CHECKS_PREFIX + state, AUTH_CHECKS_TTL).setValue(
-    value,
+  authChecksCookie(state).setValue(
+    JSON.stringify({ t: Date.now(), v: value }),
     req,
     res,
   );
@@ -111,9 +135,9 @@ export function clearPendingAuthChecks(
   res: Response,
   state?: string,
 ) {
-  const states = state ? [state] : Object.keys(getPendingAuthChecks(req));
+  const states = state ? [state] : Object.keys(readPendingAuthChecks(req));
   for (const s of states) {
-    new Cookie(AUTH_CHECKS_PREFIX + s, AUTH_CHECKS_TTL).setValue("", req, res);
+    authChecksCookie(s).setValue("", req, res);
   }
 }
 

--- a/packages/back-end/src/util/cookie.ts
+++ b/packages/back-end/src/util/cookie.ts
@@ -66,8 +66,56 @@ export const RefreshTokenCookie = new Cookie(
   "/auth",
 );
 export const IdTokenCookie = new Cookie("AUTH_ID_TOKEN", minutes(15));
+
+// One cookie per in-flight login so concurrent tabs can't overwrite each other's state
+const AUTH_CHECKS_PREFIX = "AUTH_CHECKS_";
 // Long enough to sit on the IdP's login page for a while before coming back
-export const AuthChecksCookie = new Cookie("AUTH_CHECKS", minutes(60));
+const AUTH_CHECKS_TTL = minutes(60);
+const MAX_PENDING_AUTH_CHECKS = 10;
+
+export function getPendingAuthChecks(req: Request): Record<string, string> {
+  const pending: Record<string, string> = {};
+  for (const [name, value] of Object.entries(req.cookies)) {
+    if (
+      name.startsWith(AUTH_CHECKS_PREFIX) &&
+      typeof value === "string" &&
+      value
+    ) {
+      pending[name.slice(AUTH_CHECKS_PREFIX.length)] = value;
+    }
+  }
+  return pending;
+}
+
+export function setPendingAuthChecks(
+  state: string,
+  value: string,
+  req: Request,
+  res: Response,
+) {
+  // Abandoned flows expire on their own; only sweep when they pile up
+  if (
+    Object.keys(getPendingAuthChecks(req)).length >= MAX_PENDING_AUTH_CHECKS
+  ) {
+    clearPendingAuthChecks(req, res);
+  }
+  new Cookie(AUTH_CHECKS_PREFIX + state, AUTH_CHECKS_TTL).setValue(
+    value,
+    req,
+    res,
+  );
+}
+
+export function clearPendingAuthChecks(
+  req: Request,
+  res: Response,
+  state?: string,
+) {
+  const states = state ? [state] : Object.keys(getPendingAuthChecks(req));
+  for (const s of states) {
+    new Cookie(AUTH_CHECKS_PREFIX + s, AUTH_CHECKS_TTL).setValue("", req, res);
+  }
+}
 
 // Read the JWT's `exp` claim without verifying the signature — we only trust
 // the cookie value once a downstream middleware has verified it.

--- a/packages/back-end/test/services/authChecks.test.ts
+++ b/packages/back-end/test/services/authChecks.test.ts
@@ -1,0 +1,38 @@
+import {
+  deriveAuthChecks,
+  nonceFromState,
+} from "back-end/src/services/auth/authChecks";
+
+describe("deriveAuthChecks", () => {
+  const secret = "browser-secret";
+
+  it("is deterministic, so a callback can recompute what the redirect used", () => {
+    const a = deriveAuthChecks(secret, "sso_1", "nonce");
+    const b = deriveAuthChecks(secret, "sso_1", "nonce");
+    expect(a).toEqual(b);
+  });
+
+  it("round-trips the nonce through state", () => {
+    const { state } = deriveAuthChecks(secret, "", "abc123");
+    expect(nonceFromState(state)).toBe("abc123");
+    expect(nonceFromState(undefined)).toBe("");
+  });
+
+  it("changes both values with the nonce, connection, and secret", () => {
+    const base = deriveAuthChecks(secret, "sso_1", "n1");
+    for (const other of [
+      deriveAuthChecks(secret, "sso_1", "n2"),
+      deriveAuthChecks(secret, "sso_2", "n1"),
+      deriveAuthChecks("other-secret", "sso_1", "n1"),
+    ]) {
+      expect(other.state).not.toBe(base.state);
+      expect(other.code_verifier).not.toBe(base.code_verifier);
+    }
+  });
+
+  it("produces a PKCE-valid code_verifier", () => {
+    const { code_verifier } = deriveAuthChecks(secret, "", "n");
+    // RFC 7636: 43-128 chars from the unreserved set
+    expect(code_verifier).toMatch(/^[A-Za-z0-9\-._~]{43,128}$/);
+  });
+});

--- a/packages/back-end/test/services/authChecks.test.ts
+++ b/packages/back-end/test/services/authChecks.test.ts
@@ -1,5 +1,7 @@
 import {
+  createNonce,
   deriveAuthChecks,
+  isNonceExpired,
   nonceFromState,
 } from "back-end/src/services/auth/authChecks";
 
@@ -16,6 +18,25 @@ describe("deriveAuthChecks", () => {
     const { state } = deriveAuthChecks(secret, "", "abc123");
     expect(nonceFromState(state)).toBe("abc123");
     expect(nonceFromState(undefined)).toBe("");
+  });
+
+  it("round-trips a created nonce, which itself contains a dot", () => {
+    const nonce = createNonce();
+    const { state } = deriveAuthChecks(secret, "sso_1", nonce);
+    expect(nonceFromState(state)).toBe(nonce);
+    expect(isNonceExpired(nonce)).toBe(false);
+  });
+
+  it("expires stale, future, and malformed nonces", () => {
+    const twoHours = 2 * 60 * 60 * 1000;
+    expect(isNonceExpired(`${(Date.now() - twoHours).toString(36)}.x`)).toBe(
+      true,
+    );
+    expect(isNonceExpired(`${(Date.now() + twoHours).toString(36)}.x`)).toBe(
+      true,
+    );
+    expect(isNonceExpired("")).toBe(true);
+    expect(isNonceExpired(".x")).toBe(true);
   });
 
   it("changes both values with the nonce, connection, and secret", () => {

--- a/packages/back-end/test/util/cookie.test.ts
+++ b/packages/back-end/test/util/cookie.test.ts
@@ -3,8 +3,11 @@ import { Request, Response } from "express";
 import {
   IdTokenCookie,
   RefreshTokenCookie,
+  clearPendingAuthChecks,
+  getPendingAuthChecks,
   isIdTokenExpired,
   setIdTokenCookie,
+  setPendingAuthChecks,
 } from "back-end/src/util/cookie";
 
 function makeReqRes() {
@@ -111,6 +114,58 @@ describe("Cookie.getValue", () => {
   it("applies to every cookie, not just the refresh token", () => {
     const req = reqWithCookies({ AUTH_ID_TOKEN: { $ne: "" } });
     expect(IdTokenCookie.getValue(req)).toBe("");
+  });
+});
+
+describe("pending auth checks", () => {
+  it("keeps one cookie per flow so concurrent logins don't overwrite each other", () => {
+    const { req, res, cookieCalls } = makeReqRes();
+
+    setPendingAuthChecks("s1", "a", req, res);
+    setPendingAuthChecks("s2", "b", req, res);
+
+    expect(cookieCalls.map((c) => c.name)).toEqual([
+      "AUTH_CHECKS_s1",
+      "AUTH_CHECKS_s2",
+    ]);
+    expect(getPendingAuthChecks(req)).toEqual({ s1: "a", s2: "b" });
+  });
+
+  it("clears only the consumed flow", () => {
+    const { req, res, clearCalls } = makeReqRes();
+    setPendingAuthChecks("s1", "a", req, res);
+    setPendingAuthChecks("s2", "b", req, res);
+
+    clearPendingAuthChecks(req, res, "s1");
+
+    expect(clearCalls).toEqual([{ name: "AUTH_CHECKS_s1" }]);
+    expect(getPendingAuthChecks(req)).toEqual({ s2: "b" });
+  });
+
+  it("sweeps every pending flow once too many pile up", () => {
+    const { req, res, clearCalls } = makeReqRes();
+    for (let i = 0; i < 10; i++) {
+      setPendingAuthChecks(`s${i}`, "x", req, res);
+    }
+    expect(clearCalls).toHaveLength(0);
+
+    setPendingAuthChecks("s10", "y", req, res);
+
+    expect(clearCalls).toHaveLength(10);
+    expect(getPendingAuthChecks(req)).toEqual({ s10: "y" });
+  });
+
+  it("ignores unrelated, empty, and JSON-decoded object cookies", () => {
+    const req = {
+      cookies: {
+        AUTH_CHECKS_a: "ok",
+        AUTH_CHECKS_b: "",
+        AUTH_CHECKS_c: { $ne: "" },
+        AUTH_REFRESH_TOKEN: "abc",
+      },
+    } as unknown as Request;
+
+    expect(getPendingAuthChecks(req)).toEqual({ a: "ok" });
   });
 });
 

--- a/packages/back-end/test/util/cookie.test.ts
+++ b/packages/back-end/test/util/cookie.test.ts
@@ -3,11 +3,8 @@ import { Request, Response } from "express";
 import {
   IdTokenCookie,
   RefreshTokenCookie,
-  clearPendingAuthChecks,
-  getPendingAuthChecks,
   isIdTokenExpired,
   setIdTokenCookie,
-  setPendingAuthChecks,
 } from "back-end/src/util/cookie";
 
 function makeReqRes() {
@@ -114,67 +111,6 @@ describe("Cookie.getValue", () => {
   it("applies to every cookie, not just the refresh token", () => {
     const req = reqWithCookies({ AUTH_ID_TOKEN: { $ne: "" } });
     expect(IdTokenCookie.getValue(req)).toBe("");
-  });
-});
-
-describe("pending auth checks", () => {
-  it("keeps one cookie per flow so concurrent logins don't overwrite each other", () => {
-    const { req, res, cookieCalls } = makeReqRes();
-
-    setPendingAuthChecks("s1", "a", req, res);
-    setPendingAuthChecks("s2", "b", req, res);
-
-    expect(cookieCalls.map((c) => c.name)).toEqual([
-      "AUTH_CHECKS_s1",
-      "AUTH_CHECKS_s2",
-    ]);
-    expect(getPendingAuthChecks(req)).toEqual({ s1: "a", s2: "b" });
-  });
-
-  it("clears only the consumed flow", () => {
-    const { req, res, clearCalls } = makeReqRes();
-    setPendingAuthChecks("s1", "a", req, res);
-    setPendingAuthChecks("s2", "b", req, res);
-
-    clearPendingAuthChecks(req, res, "s1");
-
-    expect(clearCalls).toEqual([{ name: "AUTH_CHECKS_s1" }]);
-    expect(getPendingAuthChecks(req)).toEqual({ s2: "b" });
-  });
-
-  it("evicts only the oldest pending flow once too many pile up", () => {
-    const { req, res, clearCalls } = makeReqRes();
-    const now = jest.spyOn(Date, "now");
-    // Insert out of chronological order so eviction can't just follow insertion
-    for (const [i, t] of [5, 3, 9, 1, 7, 2, 8, 4, 6, 10].entries()) {
-      now.mockReturnValue(t);
-      setPendingAuthChecks(`s${i}`, "x", req, res);
-    }
-    expect(clearCalls).toHaveLength(0);
-
-    now.mockReturnValue(11);
-    setPendingAuthChecks("s10", "y", req, res);
-    now.mockRestore();
-
-    expect(clearCalls).toEqual([{ name: "AUTH_CHECKS_s3" }]);
-    expect(Object.keys(getPendingAuthChecks(req))).toHaveLength(10);
-    expect(getPendingAuthChecks(req)).not.toHaveProperty("s3");
-    expect(getPendingAuthChecks(req)).toHaveProperty("s10", "y");
-  });
-
-  it("ignores unrelated, empty, malformed, and JSON-decoded object cookies", () => {
-    const req = {
-      cookies: {
-        AUTH_CHECKS_a: JSON.stringify({ t: 1, v: "ok" }),
-        AUTH_CHECKS_b: "",
-        AUTH_CHECKS_c: { $ne: "" },
-        AUTH_CHECKS_d: "not json",
-        AUTH_CHECKS_e: JSON.stringify({ v: "no timestamp" }),
-        AUTH_REFRESH_TOKEN: "abc",
-      },
-    } as unknown as Request;
-
-    expect(getPendingAuthChecks(req)).toEqual({ a: "ok" });
   });
 });
 

--- a/packages/back-end/test/util/cookie.test.ts
+++ b/packages/back-end/test/util/cookie.test.ts
@@ -142,25 +142,34 @@ describe("pending auth checks", () => {
     expect(getPendingAuthChecks(req)).toEqual({ s2: "b" });
   });
 
-  it("sweeps every pending flow once too many pile up", () => {
+  it("evicts only the oldest pending flow once too many pile up", () => {
     const { req, res, clearCalls } = makeReqRes();
-    for (let i = 0; i < 10; i++) {
+    const now = jest.spyOn(Date, "now");
+    // Insert out of chronological order so eviction can't just follow insertion
+    for (const [i, t] of [5, 3, 9, 1, 7, 2, 8, 4, 6, 10].entries()) {
+      now.mockReturnValue(t);
       setPendingAuthChecks(`s${i}`, "x", req, res);
     }
     expect(clearCalls).toHaveLength(0);
 
+    now.mockReturnValue(11);
     setPendingAuthChecks("s10", "y", req, res);
+    now.mockRestore();
 
-    expect(clearCalls).toHaveLength(10);
-    expect(getPendingAuthChecks(req)).toEqual({ s10: "y" });
+    expect(clearCalls).toEqual([{ name: "AUTH_CHECKS_s3" }]);
+    expect(Object.keys(getPendingAuthChecks(req))).toHaveLength(10);
+    expect(getPendingAuthChecks(req)).not.toHaveProperty("s3");
+    expect(getPendingAuthChecks(req)).toHaveProperty("s10", "y");
   });
 
-  it("ignores unrelated, empty, and JSON-decoded object cookies", () => {
+  it("ignores unrelated, empty, malformed, and JSON-decoded object cookies", () => {
     const req = {
       cookies: {
-        AUTH_CHECKS_a: "ok",
+        AUTH_CHECKS_a: JSON.stringify({ t: 1, v: "ok" }),
         AUTH_CHECKS_b: "",
         AUTH_CHECKS_c: { $ne: "" },
+        AUTH_CHECKS_d: "not json",
+        AUTH_CHECKS_e: JSON.stringify({ v: "no timestamp" }),
         AUTH_REFRESH_TOKEN: "abc",
       },
     } as unknown as Request;

--- a/packages/front-end/components/OAuthError.tsx
+++ b/packages/front-end/components/OAuthError.tsx
@@ -1,5 +1,9 @@
 import Button from "@/components/Button";
-import { redirectWithTimeout, safeLogout } from "@/services/auth";
+import {
+  getPostAuthRedirectPath,
+  redirectWithTimeout,
+  safeLogout,
+} from "@/services/auth";
 import Callout from "@/ui/Callout";
 
 export const OAuthError = ({ error }: { error: string }) => (
@@ -12,7 +16,7 @@ export const OAuthError = ({ error }: { error: string }) => (
         <Button
           color="primary"
           onClick={async () => {
-            await redirectWithTimeout(window.location.origin);
+            await redirectWithTimeout(getPostAuthRedirectPath());
           }}
         >
           Retry

--- a/packages/front-end/pages/oauth/callback.tsx
+++ b/packages/front-end/pages/oauth/callback.tsx
@@ -23,12 +23,12 @@ export default function OAuthCallbackPage() {
     post(`/auth/callback${qs}`)
       .then(async (json) => {
         if (json?.status === 200) {
-          return router.replace(getPostAuthRedirectPath());
+          return router.replace(getPostAuthRedirectPath({ consume: true }));
         }
         // Another tab may have already finished logging in, making this failure moot
         const refresh = await post("/auth/refresh").catch(() => null);
         if (refresh?.token) {
-          return router.replace(getPostAuthRedirectPath());
+          return router.replace(getPostAuthRedirectPath({ consume: true }));
         }
         setError(json?.message || "An unknown error occurred");
       })

--- a/packages/front-end/pages/oauth/callback.tsx
+++ b/packages/front-end/pages/oauth/callback.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import { OAuthError } from "@/components/OAuthError";
 import { getApiHost } from "@/services/env";
+import { getPostAuthRedirectPath } from "@/services/auth";
 
 export default function OAuthCallbackPage() {
   const router = useRouter();
@@ -14,29 +15,22 @@ export default function OAuthCallbackPage() {
         ? window.location.search
         : "?" + window.location.hash.substring(1);
 
-    window
-      .fetch(getApiHost() + `/auth/callback${qs}`, {
-        method: "POST",
-        credentials: "include",
-      })
-      .then((res) => res.json())
-      .then((json) => {
-        if (json?.status !== 200) {
-          setError(json?.message || "An unknown error occurred");
-        } else {
-          try {
-            let redirect =
-              window.sessionStorage.getItem("postAuthRedirectPath") ?? "/";
-            // make sure the redirect path is relative (starts with a / followed by a string or nothing)
-            if (!/^\/\w*/.test(redirect)) {
-              redirect = "/";
-            }
-            router.replace(redirect);
-          } catch (e) {
-            // just redirect to the home page if there's an error
-            router.replace("/");
-          }
+    const post = (path: string) =>
+      window
+        .fetch(getApiHost() + path, { method: "POST", credentials: "include" })
+        .then((res) => res.json());
+
+    post(`/auth/callback${qs}`)
+      .then(async (json) => {
+        if (json?.status === 200) {
+          return router.replace(getPostAuthRedirectPath());
         }
+        // Another tab may have already finished logging in, making this failure moot
+        const refresh = await post("/auth/refresh").catch(() => null);
+        if (refresh?.token) {
+          return router.replace(getPostAuthRedirectPath());
+        }
+        setError(json?.message || "An unknown error occurred");
       })
       .catch((e) => {
         setError(e.message);

--- a/packages/front-end/pages/oauth/vercel-integration.tsx
+++ b/packages/front-end/pages/oauth/vercel-integration.tsx
@@ -47,12 +47,14 @@ const VercelPage = () => {
         // Vercel deep links win; otherwise return to wherever the session expired
         const baseUrl = experimentationItemId?.match(urlRegex)
           ? "/" + experimentationItemId.replace(urlRegex, "/$1/")
-          : getPostAuthRedirectPath();
+          : getPostAuthRedirectPath({ consume: true });
 
         if (projectId) setProject(projectId);
-        router.push(
-          `${baseUrl}${baseUrl.includes("?") ? "&" : "?"}org=${organizationId}`,
-        );
+        // set() replaces any stale org= carried in the saved path
+        const [path, query] = baseUrl.split("?");
+        const searchParams = new URLSearchParams(query);
+        searchParams.set("org", organizationId);
+        router.push(`${path}?${searchParams}`);
       } catch (err) {
         setError(String(err));
       }

--- a/packages/front-end/pages/oauth/vercel-integration.tsx
+++ b/packages/front-end/pages/oauth/vercel-integration.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import { getApiHost } from "@/services/env";
 import { useProject } from "@/services/DefinitionsContext";
 import { OAuthError } from "@/components/OAuthError";
+import { getPostAuthRedirectPath } from "@/services/auth";
 
 type QueryParams = {
   code?: string;
@@ -43,14 +44,15 @@ const VercelPage = () => {
 
         const urlRegex = /^(features|experiment):/;
 
-        const baseUrl =
-          "/" +
-          (experimentationItemId?.match(urlRegex)
-            ? experimentationItemId.replace(urlRegex, "/$1/")
-            : "");
+        // Vercel deep links win; otherwise return to wherever the session expired
+        const baseUrl = experimentationItemId?.match(urlRegex)
+          ? "/" + experimentationItemId.replace(urlRegex, "/$1/")
+          : getPostAuthRedirectPath();
 
         if (projectId) setProject(projectId);
-        router.push(`${baseUrl}?org=${organizationId}`);
+        router.push(
+          `${baseUrl}${baseUrl.includes("?") ? "&" : "?"}org=${organizationId}`,
+        );
       } catch (err) {
         setError(String(err));
       }

--- a/packages/front-end/services/auth.tsx
+++ b/packages/front-end/services/auth.tsx
@@ -211,12 +211,27 @@ export async function safeLogout() {
 }
 
 // Where to land once login completes; only a same-origin relative path is trusted
-export function getPostAuthRedirectPath(): string {
+export function getPostAuthRedirectPath({ consume = false } = {}): string {
   try {
     const path = window.sessionStorage.getItem("postAuthRedirectPath") ?? "/";
-    return /^\/(?!\/)/.test(path) ? path : "/";
+    if (consume) {
+      window.sessionStorage.removeItem("postAuthRedirectPath");
+    }
+    // Reject protocol-relative (//host) and backslash (/\host) escapes
+    return /^\/(?![/\\])/.test(path) ? path : "/";
   } catch (e) {
     return "/";
+  }
+}
+
+export function savePostAuthRedirectPath() {
+  try {
+    window.sessionStorage.setItem(
+      "postAuthRedirectPath",
+      window.location.pathname + (window.location.search || ""),
+    );
+  } catch (e) {
+    // ignore
   }
 }
 
@@ -294,6 +309,7 @@ export const AuthProvider: React.FC<{
             trackingEventModalType=""
             open={true}
             submit={async () => {
+              savePostAuthRedirectPath();
               await redirectWithTimeout(resp.redirectURI);
             }}
             close={async () => {
@@ -309,16 +325,7 @@ export const AuthProvider: React.FC<{
           </Modal>,
         );
       } else {
-        try {
-          const redirectAddress =
-            window.location.pathname + (window.location.search || "");
-          window.sessionStorage.setItem(
-            "postAuthRedirectPath",
-            redirectAddress,
-          );
-        } catch (e) {
-          // ignore
-        }
+        savePostAuthRedirectPath();
 
         // Don't need to confirm, just redirect immediately
         if (isUnregisteredCloudUser()) {
@@ -453,16 +460,7 @@ export const AuthProvider: React.FC<{
               init.headers["Authorization"] = `Bearer ${resp.token}`;
               return fetch(getApiHost() + url, init);
             } else if ("redirectURI" in resp) {
-              try {
-                const redirectAddress =
-                  window.location.pathname + (window.location.search || "");
-                window.sessionStorage.setItem(
-                  "postAuthRedirectPath",
-                  redirectAddress,
-                );
-              } catch (e) {
-                // ignore
-              }
+              savePostAuthRedirectPath();
               await redirectWithTimeout(resp.redirectURI);
             }
             setSessionError(true);
@@ -527,16 +525,7 @@ export const AuthProvider: React.FC<{
             }
             return responseData;
           } else if ("redirectURI" in resp) {
-            try {
-              const redirectAddress =
-                window.location.pathname + (window.location.search || "");
-              window.sessionStorage.setItem(
-                "postAuthRedirectPath",
-                redirectAddress,
-              );
-            } catch (e) {
-              // ignore
-            }
+            savePostAuthRedirectPath();
             // Don't need to confirm, just redirect immediately
             await redirectWithTimeout(resp.redirectURI);
           }

--- a/packages/front-end/services/auth.tsx
+++ b/packages/front-end/services/auth.tsx
@@ -210,6 +210,16 @@ export async function safeLogout() {
   await redirectWithTimeout(json?.redirectURI || window.location.origin);
 }
 
+// Where to land once login completes; only a same-origin relative path is trusted
+export function getPostAuthRedirectPath(): string {
+  try {
+    const path = window.sessionStorage.getItem("postAuthRedirectPath") ?? "/";
+    return /^\/(?!\/)/.test(path) ? path : "/";
+  } catch (e) {
+    return "/";
+  }
+}
+
 export async function redirectWithTimeout(url: string, timeout: number = 5000) {
   // If the URL is the same as the current one, do a reload instead
   // This is the only way to force the page to refresh if the URL contains a hash


### PR DESCRIPTION
### Features and Changes

Fixes the `OAuth Error: Error Signing In` that shows up when several GrowthBook tabs re-authenticate at once, and the redirect to the home page after pressing Retry. About **10%** of prod `/auth/callback` requests currently fail this way.

The root cause is that `AUTH_CHECKS` held a single pending `state`/PKCE verifier per browser, so concurrent logins overwrote each other. We now derive those values per flow from one long-lived `AUTH_SECRET` cookie instead of storing them, so there's nothing for tabs to race on. Since `state` is no longer single-use, each one embeds its mint time and callbacks older than an hour are rejected.

Design note: we considered the more common per-flow transaction cookie (single-use `state`, the Auth.js/Auth0 SDK pattern) and opted for the smaller stateless surface instead, since expiry plus PKCE and the single-use authorization code cover replay. Happy to swap to per-flow cookies if reviewers think strict single-use matters here.

Enterprise SSO visits also change visibly: main computed the "Sign In Required" confirm *after* writing the checks cookie, so the modal appeared on every unauthenticated visit and dropped the deep link. It now only appears when a login started in the last 10 minutes was left unfinished; first visits redirect straight to the IdP.

On the front-end, a failed callback now checks whether another tab already logged in and continues instead of erroring. Retry and the Vercel SSO return page go back to the saved page instead of home; the saved path is consumed on use and any stale `org` param in it is replaced.

### Known issues

A brand-new browser (no `AUTH_SECRET` yet) starting several flows in the same instant keeps only the last secret; those tabs fail once and recover via the refresh fallback.

### Testing

Verified on a dev stack pointed at a real Auth0/Google `SSO_CONFIG`:

- [x] Sign in end to end -> the derived state/PKCE values round-trip a real IdP
- [x] Two tabs with expired sessions -> both succeed, each lands on its own experiment
- [x] Deep link while logged out -> returns there after sign-in, not home

Still needs Cloud:

- [ ] Retry on the error page -> returns to the page the session expired on
- [ ] Vercel SSO re-auth from an experiment page -> returns to that experiment
- [ ] Enterprise SSO: abandon a login, revisit within 10 minutes -> confirm modal; complete it -> lands on the saved page
- [ ] Post-deploy: "Error signing in" in the prod API logs drops from ~2.9k/week
