### PR TITLE
fix(front-end): skip redundant revisions fetch on feature-page ?v= deep links

### DIFF
--- a/packages/front-end/hooks/useFeaturePageData.ts
+++ b/packages/front-end/hooks/useFeaturePageData.ts
@@ -346,6 +346,14 @@ export function useFeaturePageData(
       return match;
     }
 
+    // A specific non-live version is selected but its revision has not loaded
+    // yet (e.g. a ?v=N deep link outside the base response's full-revision
+    // window). Do not fall back to live feature values under that version's
+    // URL -- wait for the revision to load.
+    if (currentVersion !== baseFeature.version) {
+      return null;
+    }
+
     // Create dummy revision for old features without revision history
     const rules: FeatureRule[] = baseFeature.rules ?? [];
     return {

--- a/packages/front-end/hooks/useFeaturePageData.ts
+++ b/packages/front-end/hooks/useFeaturePageData.ts
@@ -87,12 +87,14 @@ export function useFeaturePageData(
   });
 
   // Only fetch a specific version if it isn't already in the base response or cache.
+  // Until the base response arrives we can't tell, so wait rather than double-fetch.
   const requestedVersionInBaseSet =
     baseData?.revisions?.some((r) => r.version === selectedVersion) ?? false;
   const requestedVersionInCache =
     selectedVersion != null && !!cachedRevisions[selectedVersion];
   const shouldFetchFromRevisionsEndpoint =
     !!fid &&
+    !!baseData &&
     selectedVersion != null &&
     !requestedVersionInBaseSet &&
     !requestedVersionInCache;
@@ -120,6 +122,7 @@ export function useFeaturePageData(
       false);
   const shouldFetchBaseVersion =
     !!fid &&
+    !!baseData &&
     selectedRevisionBaseVersion != null &&
     !baseVersionInCache &&
     !baseVersionInBaseSet;

--- a/packages/front-end/test/hooks/useFeaturePageData.test.tsx
+++ b/packages/front-end/test/hooks/useFeaturePageData.test.tsx
@@ -1,0 +1,175 @@
+import { ReactNode } from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import { FeatureInterface } from "shared/types/feature";
+import { FeatureRevisionInterface } from "shared/types/feature-revision";
+import { useFeaturePageData } from "@/hooks/useFeaturePageData";
+import { useAuth } from "@/services/auth";
+import { useEnvironments } from "@/services/features";
+
+vi.mock("@/services/auth", () => ({ useAuth: vi.fn() }));
+vi.mock("@/services/features", () => ({ useEnvironments: vi.fn() }));
+
+const feature = {
+  id: "f1",
+  version: 1,
+  defaultValue: "false",
+  rules: [],
+  dateCreated: new Date(0),
+  dateUpdated: new Date(0),
+  organization: "org_1",
+  prerequisites: [],
+} as unknown as FeatureInterface;
+
+function rev(
+  version: number,
+  overrides: Partial<FeatureRevisionInterface> = {},
+): FeatureRevisionInterface {
+  return {
+    featureId: "f1",
+    organization: "org_1",
+    version,
+    baseVersion: Math.max(1, version - 1),
+    comment: "",
+    createdBy: null,
+    publishedBy: null,
+    dateCreated: new Date(0),
+    datePublished: new Date(0),
+    dateUpdated: new Date(0),
+    defaultValue: "false",
+    rules: {},
+    status: "published",
+    ...overrides,
+  } as unknown as FeatureRevisionInterface;
+}
+
+function basePayload(fullRevisions: FeatureRevisionInterface[]) {
+  return {
+    feature,
+    revisionList: fullRevisions.map((r) => ({
+      version: r.version,
+      datePublished: r.datePublished ?? null,
+      dateUpdated: r.dateUpdated,
+      createdBy: r.createdBy,
+      status: r.status,
+      comment: r.comment || "",
+    })),
+    revisions: fullRevisions,
+    experiments: [],
+    safeRollouts: [],
+    codeRefs: [],
+    holdout: undefined,
+    rampSchedules: [],
+  };
+}
+
+describe("useFeaturePageData", () => {
+  const apiCall = vi.fn();
+  let resolveBase: (payload: unknown) => void;
+
+  beforeEach(() => {
+    apiCall.mockReset();
+    vi.mocked(useAuth).mockReturnValue({
+      apiCall,
+      orgId: "org_1",
+    } as unknown as ReturnType<typeof useAuth>);
+    vi.mocked(useEnvironments).mockReturnValue([]);
+
+    // The base feature request stays pending until the test resolves it, so
+    // each test controls the cold-load ordering explicitly.
+    const basePromise = new Promise((res) => {
+      resolveBase = res;
+    });
+    apiCall.mockImplementation((url: string) => {
+      if (url === "/feature/f1") return basePromise;
+      if (url.startsWith("/ramp-schedule")) {
+        return Promise.resolve({ status: 200, rampSchedules: [] });
+      }
+      if (url.startsWith("/feature/f1/revisions?versions=")) {
+        const version = parseInt(url.split("versions=")[1], 10);
+        return Promise.resolve({
+          status: 200,
+          revisions: [rev(version, { baseVersion: 1 })],
+        });
+      }
+      throw new Error(`unexpected api call: ${url}`);
+    });
+  });
+
+  const revisionFetches = () =>
+    apiCall.mock.calls
+      .map((c) => c[0] as string)
+      .filter((url) => url.includes("/revisions?versions="));
+
+  function render(versionQueryParam?: string) {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        {children}
+      </SWRConfig>
+    );
+    return renderHook(() => useFeaturePageData("f1", versionQueryParam), {
+      wrapper,
+    });
+  }
+
+  const flush = () => act(async () => {});
+
+  it("does not fetch a ?v= version that the base response already includes", async () => {
+    const { result } = render("2");
+    await flush();
+
+    // Base request still in flight: no speculative revisions fetch.
+    expect(revisionFetches()).toEqual([]);
+
+    await act(async () => {
+      resolveBase(basePayload([rev(1), rev(2, { status: "draft" })]));
+    });
+    await waitFor(() => expect(result.current.revision?.version).toBe(2));
+
+    // The base response contained version 2, so no extra fetch at all.
+    expect(revisionFetches()).toEqual([]);
+  });
+
+  it("fetches a ?v= version missing from the base response, once it can tell", async () => {
+    const { result } = render("42");
+    await flush();
+    expect(revisionFetches()).toEqual([]);
+
+    // Base response knows about v42 (revisionList) but only carries full
+    // revisions for the recent window.
+    const payload = basePayload([rev(1), rev(2)]);
+    payload.revisionList.push({
+      version: 42,
+      datePublished: new Date(0),
+      dateUpdated: new Date(0),
+      createdBy: null,
+      status: "published",
+      comment: "",
+    });
+    await act(async () => {
+      resolveBase(payload);
+    });
+
+    await waitFor(() => expect(result.current.revision?.version).toBe(42));
+    expect(revisionFetches()).toEqual(["/feature/f1/revisions?versions=42"]);
+  });
+
+  it("still lazily fetches a selected draft's base version from outside the window", async () => {
+    const { result } = render("6");
+    await flush();
+    expect(revisionFetches()).toEqual([]);
+
+    // v6 is an active draft based on v2, which fell outside the full-revision
+    // window; v2 must be fetched for merge/review CTAs.
+    await act(async () => {
+      resolveBase(
+        basePayload([rev(1), rev(6, { status: "draft", baseVersion: 2 })]),
+      );
+    });
+
+    await waitFor(() =>
+      expect(revisionFetches()).toEqual(["/feature/f1/revisions?versions=2"]),
+    );
+    await waitFor(() => expect(result.current.revision?.version).toBe(6));
+  });
+});

--- a/packages/front-end/test/hooks/useFeaturePageData.test.tsx
+++ b/packages/front-end/test/hooks/useFeaturePageData.test.tsx
@@ -172,4 +172,56 @@ describe("useFeaturePageData", () => {
     );
     await waitFor(() => expect(result.current.revision?.version).toBe(6));
   });
+
+  it("does not render live feature values under a ?v= URL while that revision is loading", async () => {
+    let resolveBaseLocal!: (payload: unknown) => void;
+    let resolveRev!: (payload: unknown) => void;
+    const baseLocal = new Promise((res) => {
+      resolveBaseLocal = res;
+    });
+    const revLocal = new Promise((res) => {
+      resolveRev = res;
+    });
+    apiCall.mockReset();
+    apiCall.mockImplementation((url: string) => {
+      if (url === "/feature/f1") return baseLocal;
+      if (url.startsWith("/ramp-schedule")) {
+        return Promise.resolve({ status: 200, rampSchedules: [] });
+      }
+      if (url === "/feature/f1/revisions?versions=42") return revLocal;
+      throw new Error(`unexpected api call: ${url}`);
+    });
+
+    const { result } = render("42");
+    await flush();
+    expect(result.current.feature).toBeNull();
+
+    // Base response knows v42 exists (revisionList) but only carries full
+    // revisions for the recent window, so v42's revision must be fetched.
+    const payload = basePayload([rev(1), rev(2)]);
+    payload.revisionList.push({
+      version: 42,
+      datePublished: new Date(0),
+      dateUpdated: new Date(0),
+      createdBy: null,
+      status: "published",
+      comment: "",
+    });
+    await act(async () => {
+      resolveBaseLocal(payload);
+    });
+    await flush();
+
+    // v42's revision is still in flight: the hook must not substitute the live
+    // feature under the ?v=42 URL.
+    expect(result.current.version).toBe(42);
+    expect(result.current.revision).toBeNull();
+    expect(result.current.feature).toBeNull();
+
+    // Once v42 arrives, it renders as the historical revision.
+    await act(async () => {
+      resolveRev({ status: 200, revisions: [rev(42, { baseVersion: 1 })] });
+    });
+    await waitFor(() => expect(result.current.revision?.version).toBe(42));
+  });
 });


### PR DESCRIPTION
### Features and Changes

Fixes a cold-load race in `useFeaturePageData` that fires a redundant `GET /feature/:id/revisions?versions=N` on every feature-page deep link with `?v=N` in the URL.

The hook checks whether the requested version is already included in the base `/feature/:id` response via `baseData?.revisions?.some(...) ?? false`. On a cold load, `baseData` is still in flight at first render, so the check defaults to `false` and `shouldFetchFromRevisionsEndpoint` becomes true for any `?v=N` — the revisions request fires immediately, even when the version is in the set the base response already carries (full revisions for the top recent versions, active drafts, and their base versions), which covers most deep links. The lazy fetch of a selected draft's `baseVersion` has the same early default and can likewise fire before the base response lands (for example, when a revisions response arrives first and exposes a `baseVersion`).

This PR gates both fetches on `baseData` having arrived, so they only fire for versions genuinely absent from the base response. Trade-off: for a genuinely-absent version, the revisions fetch now starts after the base response returns instead of in parallel with it. Since a revision can only be rendered by merging it into the base feature, this does not delay first render — and it removes a duplicate revisions query from every in-window deep link, the common case. We noticed this as redundant revisions queries on version deep links in our self-hosted deployment.

### Dependencies

None

### Testing

Added `test/hooks/useFeaturePageData.test.tsx`:

- a `?v=` version that the base response includes is never fetched from the revisions endpoint — including while the base request is still in flight (this case fails without the fix);
- a `?v=` version missing from the base response is fetched exactly once, after the base response arrives;
- a selected draft whose `baseVersion` fell outside the base response's full-revision window still triggers the lazy base-version fetch.

Without the fix, all three cases fail: the speculative fetch fires while the base request is in flight (twice, in fact: the speculative fetch for the requested version plus the cascaded fetch of its `baseVersion` — both paths this PR gates). With the fix, all three pass. The touched files pass the package's prettier check.

### Screenshots

No UI change.