### PR TITLE
Re-generate OpenAPI spec to pick up missing funnel fields

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -39928,6 +39928,7 @@ paths:
                                           - type: string
                                           - type: 'null'
                                       steps:
+                                        maxItems: 20
                                         type: array
                                         items:
                                           type: object
@@ -40021,6 +40022,10 @@ paths:
                                   - type
                                   - dataset
                                 additionalProperties: false
+                              linkedFunnelMetricId:
+                                anyOf:
+                                  - type: string
+                                  - type: 'null'
                             required:
                               - organization
                               - id
@@ -47295,6 +47300,7 @@ paths:
                         - type: string
                         - type: 'null'
                     steps:
+                      maxItems: 20
                       type: array
                       items:
                         type: object
@@ -47676,6 +47682,7 @@ paths:
                                       - type: string
                                       - type: 'null'
                                   steps:
+                                    maxItems: 20
                                     type: array
                                     items:
                                       type: object
@@ -63849,6 +63856,7 @@ components:
                               - type: string
                               - type: 'null'
                           steps:
+                            maxItems: 20
                             type: array
                             items:
                               type: object
@@ -63942,6 +63950,10 @@ components:
                       - type
                       - dataset
                     additionalProperties: false
+                  linkedFunnelMetricId:
+                    anyOf:
+                      - type: string
+                      - type: 'null'
                 required:
                   - organization
                   - id
@@ -64194,6 +64206,7 @@ components:
         - variations
         - datasource
         - contextualBanditQueryId
+        - seed
         - currentLeafWeights
         - banditVersion
         - contextualAttributes
@@ -66705,6 +66718,7 @@ components:
                         - type: string
                         - type: 'null'
                     steps:
+                      maxItems: 20
                       type: array
                       items:
                         type: object


### PR DESCRIPTION
With #6747 , a pre-commit hook and CI step was added to validate that API docs were properly re-generated.  #6691 appears to have merged without pulling in those commits and introduced an inconsistency in the docs.  This was likely just a temporary transition issue.  This PR adds the missing fields to the API docs and gets everything back to a working state.