### PR TITLE
Skip no-op migration drift in the concurrent-edit guard

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -5594,9 +5594,9 @@ export async function putFeature(
       incoming: pick((k) => (updates as unknown as Record<string, unknown>)[k]),
       liveVersion: feature.version,
       ...(targetDraft ? { draftVersion: targetDraft.version } : {}),
-      // Mutually exclusive, so merging them apart would target all projects and
-      // carry a list at the same time. Older docs lack the migration-added
-      // flag; absent reads as false.
+      // Mutually exclusive, so merging them apart would target all projects
+      // and carry a list at the same time; on older docs the flag is absent,
+      // which reads as false.
       config: {
         chunks: [["targetingAllProjects", "targetingProjects"]],
         absentDefaults: { targetingAllProjects: false },

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -5595,8 +5595,12 @@ export async function putFeature(
       liveVersion: feature.version,
       ...(targetDraft ? { draftVersion: targetDraft.version } : {}),
       // Mutually exclusive, so merging them apart would target all projects and
-      // carry a list at the same time.
-      config: { chunks: [["targetingAllProjects", "targetingProjects"]] },
+      // carry a list at the same time. Older docs lack the migration-added
+      // flag; absent reads as false.
+      config: {
+        chunks: [["targetingAllProjects", "targetingProjects"]],
+        absentDefaults: { targetingAllProjects: false },
+      },
     });
     if (!resolution.ok) {
       return res.status(409).json({

--- a/packages/back-end/src/routers/saved-group/saved-group.controller.ts
+++ b/packages/back-end/src/routers/saved-group/saved-group.controller.ts
@@ -2,6 +2,7 @@ import { NO_ENVIRONMENT_BINDING } from "shared/permissions";
 import type { Response } from "express";
 import { isEqual } from "lodash";
 import {
+  draftValuesEqual,
   formatByteSizeString,
   SAVED_GROUP_SIZE_LIMIT_BYTES,
   ID_LIST_DATATYPES,
@@ -648,15 +649,12 @@ export const putSavedGroup = async (
       projects,
     };
     const base = comparisonBase as unknown as Record<string, unknown>;
-    // An empty array and an absent field mean the same thing to the editor.
-    const norm = (v: unknown) =>
-      Array.isArray(v) && v.length === 0 ? null : (v ?? null);
     const contested = Object.keys(baseline).filter((k) => {
       const loaded = (baseline as Record<string, unknown>)[k];
-      if (isEqual(norm(loaded), norm(base[k]))) return false;
+      if (draftValuesEqual(loaded, base[k])) return false;
       // Someone else changed it; only a differing submission is contested.
       return (
-        incoming[k] !== undefined && !isEqual(norm(incoming[k]), norm(base[k]))
+        incoming[k] !== undefined && !draftValuesEqual(incoming[k], base[k])
       );
     });
     if (contested.length) {

--- a/packages/front-end/components/DraftConflicts/conflictValues.ts
+++ b/packages/front-end/components/DraftConflicts/conflictValues.ts
@@ -9,13 +9,23 @@ export function formatConflictValue(v: unknown): string {
   return s.length > MAX_VALUE_CHARS ? `${s.slice(0, MAX_VALUE_CHARS)}…` : s;
 }
 
-function formatList(list: unknown[]): string {
+export function formatList(list: unknown[]): string {
   // Bounded up front so a huge list never stringifies in full.
   const bounded = list.slice(0, 120);
   const s = `[${bounded.map((v) => JSON.stringify(v)).join(", ")}]`;
   return s.length > MAX_VALUE_CHARS || bounded.length < list.length
     ? `${s.slice(0, MAX_VALUE_CHARS)}…`
     : s;
+}
+
+// Renders a project-id list by name, for conflict rows over project fields.
+export function namedProjectsFormatter(
+  getProjectById: (id: string) => { name: string } | null,
+): (value: unknown) => string {
+  return (v) =>
+    formatList(
+      ((v as string[]) ?? []).map((id) => getProjectById(id)?.name ?? id),
+    );
 }
 
 // The fixed scope label the flag stands for: allEnvironments and
@@ -35,15 +45,19 @@ function scopeLabel(flagField: string): string {
 function formatFlaggedList(
   entity: Record<string, unknown>,
   fields: string[],
+  formatters?: Record<string, (value: unknown) => string>,
 ): string | null {
   if (fields.length !== 2) return null;
   const flagField = fields.find((f) => typeof entity[f] === "boolean");
   if (!flagField) return null;
   // The list is often absent when the flag is on, so it can't be required here.
-  const list = entity[fields.find((f) => f !== flagField) as string];
+  const listField = fields.find((f) => f !== flagField) as string;
+  const list = entity[listField];
   if (list !== undefined && !Array.isArray(list)) return null;
-  return entity[flagField]
-    ? scopeLabel(flagField)
+  if (entity[flagField]) return scopeLabel(flagField);
+  const format = formatters?.[listField];
+  return format
+    ? format((list as unknown[]) ?? [])
     : formatList((list as unknown[]) ?? []);
 }
 
@@ -60,7 +74,7 @@ export function formatChunkValue(
     if (format && only !== undefined) return format(only);
     return Array.isArray(only) ? formatList(only) : formatConflictValue(only);
   }
-  const flagged = formatFlaggedList(entity, fields);
+  const flagged = formatFlaggedList(entity, fields, formatters);
   if (flagged !== null) return flagged;
   return formatConflictValue(
     Object.fromEntries(

--- a/packages/front-end/components/DraftConflicts/useDraftConflict.tsx
+++ b/packages/front-end/components/DraftConflicts/useDraftConflict.tsx
@@ -25,6 +25,7 @@ type Conflict<T> = DraftConflict<T> & {
 export function useDraftConflict<T extends object>({
   initial,
   labels,
+  formatters,
   form,
   applyField,
   isNewDraft,
@@ -33,6 +34,8 @@ export function useDraftConflict<T extends object>({
 }: {
   initial: T;
   labels?: Record<string, string>;
+  // Per-field display, for values the control shows differently (names, %).
+  formatters?: Record<string, (value: unknown) => string>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   form?: UseFormReturn<any>;
   // For editors that aren't react-hook-form backed (e.g. a set of toggles).
@@ -108,8 +111,9 @@ export function useDraftConflict<T extends object>({
           unknown
         > | null,
         chunk.fields,
+        formatters,
       ),
-    [conflict],
+    [conflict, formatters],
   );
 
   const labelFor = useCallback(

--- a/packages/front-end/components/Features/EditFeatureInfoModal.tsx
+++ b/packages/front-end/components/Features/EditFeatureInfoModal.tsx
@@ -11,6 +11,8 @@ import SelectOwner from "@/components/Owner/SelectOwner";
 import useProjectOptions from "@/hooks/useProjectOptions";
 import SelectField from "@/components/Forms/SelectField";
 import TargetingProjectsField from "@/components/TargetingProjectsField";
+import { namedProjectsFormatter } from "@/components/DraftConflicts/conflictValues";
+import { useDefinitions } from "@/services/DefinitionsContext";
 import Callout from "@/ui/Callout";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import { getMetadataEditEnvs, useEnvironments } from "@/services/features";
@@ -64,6 +66,8 @@ const EditFeatureInfoModal: FC<{
     if (!reviewSetting?.requireReviewOn) return false;
     return reviewSetting.featureRequireMetadataReview !== false;
   })();
+
+  const { getProjectById } = useDefinitions();
 
   const form = useForm({
     defaultValues: {
@@ -123,6 +127,11 @@ const EditFeatureInfoModal: FC<{
       targetingAllProjects: "Targeting Projects",
       targetingProjects: "Targeting Projects",
       description: "Description",
+    },
+    formatters: {
+      project: (v) =>
+        v ? (getProjectById(String(v))?.name ?? String(v)) : "None",
+      targetingProjects: namedProjectsFormatter(getProjectById),
     },
     form,
     isNewDraft: mode === "new",

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -83,6 +83,7 @@ import {
 import { decimalToPercent } from "@/services/utils";
 import {
   formatChunkValue,
+  namedProjectsFormatter,
   projectFormValues,
 } from "@/components/DraftConflicts/conflictValues";
 import StandardRuleFields, {
@@ -405,7 +406,11 @@ export default function RuleModal({
       return defaultRampSectionState(ruleRampSchedule);
     },
   );
-  const { datasources, project: currentProject } = useDefinitions();
+  const {
+    datasources,
+    project: currentProject,
+    getProjectById,
+  } = useDefinitions();
   const { experimentsMap, mutateExperiments } = useExperiments();
   const { templates: allTemplates } = useTemplates();
   const allEnvironments = useEnvironments();
@@ -1960,9 +1965,12 @@ export default function RuleModal({
           ? (conflict?.current ?? null)
           : (conflict?.attempted ?? null),
         chunk.fields,
-        RULE_VALUE_FORMATTERS,
+        {
+          ...RULE_VALUE_FORMATTERS,
+          projects: namedProjectsFormatter(getProjectById),
+        },
       ),
-    [conflict],
+    [conflict, getProjectById],
   );
 
   const conflictCallouts = conflict ? (

--- a/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
+++ b/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
@@ -14,8 +14,8 @@ import {
   getApprovalFlowSettings,
 } from "shared/enterprise";
 import { useForm } from "react-hook-form";
-import { isEqual } from "lodash";
 import {
+  draftValuesEqual,
   isIdListSupportedAttribute,
   validateAndFixCondition,
 } from "shared/util";
@@ -46,6 +46,7 @@ import ConflictCallout, {
   ConflictProvider,
 } from "@/components/DraftConflicts/ConflictContext";
 import { useDraftConflict } from "@/components/DraftConflicts/useDraftConflict";
+import { namedProjectsFormatter } from "@/components/DraftConflicts/conflictValues";
 import SavedGroupDraftSelectorForChanges, {
   DraftMode,
 } from "@/components/SavedGroups/SavedGroupDraftSelectorForChanges";
@@ -181,7 +182,7 @@ const SavedGroupForm: FC<{
     (currentRevision?.status === "discarded" ||
       currentRevision?.status === "merged");
 
-  const { mutateDefinitions, project } = useDefinitions();
+  const { mutateDefinitions, project, getProjectById } = useDefinitions();
 
   const { data: savedGroupsData } = useApi<{
     savedGroups: SavedGroupWithoutValues[];
@@ -241,6 +242,9 @@ const SavedGroupForm: FC<{
       projects: "Projects",
       condition: "Condition",
       values: "IDs",
+    },
+    formatters: {
+      projects: namedProjectsFormatter(getProjectById),
     },
     form,
     isNewDraft: draftMode === "new",
@@ -486,11 +490,8 @@ const SavedGroupForm: FC<{
         if (current.id) {
           const baseline = (k: keyof SavedGroupInterface) =>
             (current as Partial<SavedGroupInterface>)[k];
-          // An empty array and an absent field mean the same thing here.
-          const norm = (v: unknown) =>
-            Array.isArray(v) && v.length === 0 ? null : (v ?? null);
           const fieldChanged = (k: keyof SavedGroupFormValues) =>
-            !isEqual(norm(value[k]), norm(baseline(k)));
+            !draftValuesEqual(value[k], baseline(k));
           let payload: UpdateSavedGroupProps;
           if (editInfoOnly) {
             payload = {

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -1699,9 +1699,8 @@ export function featureRuleMergeConfig(
     ruleTypeFamily(yours.type) === "force-rollout";
   return {
     chunks: RULE_MERGE_CHUNKS,
-    // What an absent field means on legacy rules, matching the editor's seeds
-    // so materialized defaults never read as drift. allEnvironments is omitted:
-    // its absent meaning depends on whether an environments list is present.
+    // What absent means on legacy rules. allEnvironments is omitted: its
+    // absent meaning depends on whether an environments list is present.
     absentDefaults: {
       enabled: true,
       allProjects: true,

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -1699,6 +1699,16 @@ export function featureRuleMergeConfig(
     ruleTypeFamily(yours.type) === "force-rollout";
   return {
     chunks: RULE_MERGE_CHUNKS,
+    // What an absent field means on legacy rules, matching the editor's seeds
+    // so materialized defaults never read as drift. allEnvironments is omitted:
+    // its absent meaning depends on whether an environments list is present.
+    absentDefaults: {
+      enabled: true,
+      allProjects: true,
+      coverage: 1,
+      hashAttribute: "id",
+      hashVersion: 1,
+    },
     family: (r) => ruleTypeFamily(r.type),
     ignoreFields: () => (derivesTypeFromCoverage ? ["id", "type"] : ["id"]),
     derive: derivesTypeFromCoverage

--- a/packages/shared/src/util/threeWayMerge.ts
+++ b/packages/shared/src/util/threeWayMerge.ts
@@ -11,8 +11,8 @@ export type ThreeWayMergeResult<T> = {
 export type ThreeWayMergeConfig<T> = {
   // Mutually-exclusive pairs; merged independently they can contradict.
   chunks?: string[][];
-  // What an absent field reads as (migration-added fields older docs lack),
-  // so materialized defaults never register as drift.
+  // What an absent field reads as, so migration-added fields older docs lack
+  // never register as drift.
   absentDefaults?: Record<string, unknown>;
   ignoreFields?: (entity: T) => string[];
   // Differing families skip the field merge entirely.
@@ -37,10 +37,8 @@ function canonicalize(v: unknown, absentDefault?: unknown): unknown {
   return v;
 }
 
-/**
- * The draft-guard notion of "same value". Guards that can't use threeWayMerge
- * (sparse-update endpoints) share it so the representation rules live once.
- */
+// The draft-guard notion of "same value"; guards that can't use threeWayMerge
+// (sparse-update endpoints) share it so the representation rules live once.
 export function draftValuesEqual(
   a: unknown,
   b: unknown,

--- a/packages/shared/src/util/threeWayMerge.ts
+++ b/packages/shared/src/util/threeWayMerge.ts
@@ -11,11 +11,46 @@ export type ThreeWayMergeResult<T> = {
 export type ThreeWayMergeConfig<T> = {
   // Mutually-exclusive pairs; merged independently they can contradict.
   chunks?: string[][];
+  // What an absent field reads as (migration-added fields older docs lack),
+  // so materialized defaults never register as drift.
+  absentDefaults?: Record<string, unknown>;
   ignoreFields?: (entity: T) => string[];
   // Differing families skip the field merge entirely.
   family?: (entity: T) => string;
   derive?: (merged: Record<string, unknown>) => void;
 };
+
+// An empty array or string equals an absent key, and primitive arrays are
+// set-typed (tags, projects), so reorders are not changes. Object arrays keep
+// order.
+function canonicalize(v: unknown, absentDefault?: unknown): unknown {
+  if (v === undefined || v === null) {
+    v = absentDefault ?? null;
+  }
+  if (Array.isArray(v)) {
+    if (v.length === 0) return null;
+    if (v.every((x) => typeof x !== "object" || x === null)) {
+      return [...v].sort();
+    }
+  }
+  if (v === "") return null;
+  return v;
+}
+
+/**
+ * The draft-guard notion of "same value". Guards that can't use threeWayMerge
+ * (sparse-update endpoints) share it so the representation rules live once.
+ */
+export function draftValuesEqual(
+  a: unknown,
+  b: unknown,
+  absentDefault?: unknown,
+): boolean {
+  return (
+    JSON.stringify(canonicalize(a, absentDefault)) ===
+    JSON.stringify(canonicalize(b, absentDefault))
+  );
+}
 
 // One side's change wins automatically; chunks both sides changed differently
 // are contested, with your value retained in `merged`.
@@ -61,19 +96,10 @@ export function threeWayMerge<T extends object>(
     units.push({ key: fields[0], fields });
   }
 
-  // An empty array equals an absent key, and primitive arrays are set-typed
-  // (tags, projects), so reorders are not changes. Object arrays keep order.
-  const canon = (v: unknown) => {
-    if (Array.isArray(v)) {
-      if (v.length === 0) return null;
-      if (v.every((x) => typeof x !== "object" || x === null)) {
-        return [...v].sort();
-      }
-    }
-    return v ?? null;
-  };
   const pick = (obj: Record<string, unknown>, fields: string[]) =>
-    JSON.stringify(fields.map((f) => canon(obj[f])));
+    JSON.stringify(
+      fields.map((f) => canonicalize(obj[f], config.absentDefaults?.[f])),
+    );
 
   const result = { ...empty, merged: { ...yours } };
   for (const unit of units) {

--- a/packages/shared/test/threeWayMerge.test.ts
+++ b/packages/shared/test/threeWayMerge.test.ts
@@ -54,4 +54,48 @@ describe("threeWayMerge array canonicalization", () => {
     expect(result.contested).toEqual([]);
     expect(result.theirFields).toEqual([]);
   });
+
+  it("equates an empty string with an absent key", () => {
+    const base = { description: "" } as Record<string, unknown>;
+    const theirs = {} as Record<string, unknown>;
+    const yours = { description: "mine" } as Record<string, unknown>;
+    const result = threeWayMerge(base, theirs, yours);
+    expect(result.contested).toEqual([]);
+    expect(result.merged).toEqual({ description: "mine" });
+  });
+
+  it("reads an absent field as its declared default", () => {
+    // A migration-added flag: old docs lack it, clients baseline it as false.
+    const base = {
+      targetingAllProjects: false,
+      targetingProjects: [],
+    } as Record<string, unknown>;
+    const theirs = { targetingProjects: [] } as Record<string, unknown>;
+    const yours = {
+      targetingAllProjects: false,
+      targetingProjects: ["prj_1"],
+    } as Record<string, unknown>;
+    const result = threeWayMerge(base, theirs, yours, {
+      chunks: [["targetingAllProjects", "targetingProjects"]],
+      absentDefaults: { targetingAllProjects: false },
+    });
+    expect(result.contested).toEqual([]);
+    expect(result.merged).toEqual(yours);
+  });
+
+  it("still contests the flag chunk without a declared default", () => {
+    const base = {
+      targetingAllProjects: false,
+      targetingProjects: [],
+    } as Record<string, unknown>;
+    const theirs = { targetingProjects: [] } as Record<string, unknown>;
+    const yours = {
+      targetingAllProjects: false,
+      targetingProjects: ["prj_1"],
+    } as Record<string, unknown>;
+    const result = threeWayMerge(base, theirs, yours, {
+      chunks: [["targetingAllProjects", "targetingProjects"]],
+    });
+    expect(result.contested).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
Fields added by migrations (like targeting projects) no longer trigger false "modified while you were editing" warnings, and conflict rows now show project names instead of ids.

Previous spurious bug:
<img width="1538" height="512" alt="image" src="https://github.com/user-attachments/assets/4080b9e7-4cb8-4e15-9106-27a1b3d67498" />
