### PR TITLE
fix(get-started): ensure we render a row per feature version

### DIFF
--- a/packages/front-end/components/GetStarted/NeedingAttention.tsx
+++ b/packages/front-end/components/GetStarted/NeedingAttention.tsx
@@ -532,10 +532,10 @@ const NeedingAttention = (): React.ReactElement | null => {
             </thead>
             <tbody>
               {paginatedFeatureFlags.map((item) => (
-                <tr key={item.featureId} className="hover-highlight">
+                <tr key={item.id} className="hover-highlight">
                   <td className={styles.nameTd}>
                     <Link
-                      href={`/features/${item.featureId}`}
+                      href={`/features/${item.featureId}?v=${item.version}`}
                       style={{
                         textDecoration: "none",
                         color: "inherit",


### PR DESCRIPTION
### Features and Changes

In the "Feature flags requiring attention" table on the home page, we use `featureId` as the key but a single feature can have several revisions that need attention.

- Using the same `key` leads to duplicated rows as React does not clean them up
- We collide versions into a single row with no differentiator

While we are not changing the UI, we are fixing the `key` and also deep linking to the revision that needs attention, instead of dropping you in the live version.

### Testing

https://github.com/user-attachments/assets/445bdd2a-2f79-4403-bcd9-f14a0d28c68c

