### PR TITLE
Keep review controls available on approved revisions

### DIFF
--- a/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
+++ b/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
@@ -39,6 +39,7 @@ import {
   isScheduledPublishPending,
   isScheduledPublishLockActive,
   findPublishLockingScheduledRevision,
+  isInReviewCycle,
 } from "shared/enterprise";
 import {
   EventUserLoggedIn,
@@ -800,9 +801,6 @@ export default function ReviewAndPublish({
   );
   const featureLockedBySchedule = !!lockingScheduledSibling;
 
-  const isPendingReview =
-    revision?.status === "pending-review" ||
-    revision?.status === "changes-requested";
   const createdBy = revision?.createdBy as
     | EventUserLoggedIn
     | EventUserApiKey
@@ -814,8 +812,11 @@ export default function ReviewAndPublish({
   const isBlockedContributor =
     reviewSetting?.blockSelfApproval &&
     (revision?.contributors ?? []).some((id) => id === user?.id);
+  // The whole review cycle accepts verdicts, "approved" included (matching the
+  // server): an approval that doesn't satisfy coverage or a required team must
+  // not lock out the one that would.
   const canReview =
-    !!isPendingReview &&
+    isInReviewCycle(revision?.status) &&
     createdBy?.id !== user?.id &&
     permissionsUtil.canReviewFeatureDrafts(feature, reviewFootprint);
   // Advancing a draft takes draft authority, or revert/delete authority over a
@@ -2656,7 +2657,7 @@ export default function ReviewAndPublish({
             ))}
 
           {/* Submit review — reviewer action, opens the comment/decision popover */}
-          {canReview && isPendingReview && !approved && (
+          {canReview && !adminPublish && (
             <Flex direction="column" gap="3">
               <ReviewCommentPopover
                 submitUrl={`/feature/${feature.id}/${revision.version}/submit-review`}
@@ -2687,6 +2688,15 @@ export default function ReviewAndPublish({
                 }}
                 trigger={
                   <Button
+                    // Outline once publishing is live or armed on a schedule —
+                    // either way review is no longer the primary action.
+                    variant={
+                      state.submitAction === "publish" &&
+                      state.ctaEnabled &&
+                      canDoPrimary
+                        ? "outline"
+                        : undefined
+                    }
                     style={{ width: "100%" }}
                     icon={<PiCaretDownBold />}
                     iconPosition="right"

--- a/packages/front-end/components/Revision/ReviewAndPublishTab.tsx
+++ b/packages/front-end/components/Revision/ReviewAndPublishTab.tsx
@@ -20,6 +20,7 @@ import {
   findPublishLockingScheduledRevision,
   entityPublishFootprint,
   entityReviewFootprint,
+  isInReviewCycle,
 } from "shared/enterprise";
 import { serveFootprint } from "shared/permissions";
 import type { RevisionStatus } from "shared/validators";
@@ -613,9 +614,6 @@ function ReviewAndPublishRevision<T>({
     ) && hasCommercialFeature("require-approvals");
   const revisionAutoPublishArmed = !!revision.autoPublishOnApproval;
 
-  const isPendingReview =
-    revision.status === "pending-review" ||
-    revision.status === "changes-requested";
   const canReviewOrEdit = canReviewEntity ?? canEditEntity;
   const canDraftOrEdit = canManageDraftsEntity ?? canEditEntity;
   const hasRevertAuthority = canRevertEntity ?? canEditEntity;
@@ -677,8 +675,11 @@ function ReviewAndPublishRevision<T>({
   // the no-permission notice. Each individual action gates on its own atom.
   const hasAnyAuthority =
     canDraftOrEdit || canReviewOrEdit || canRevertOrEdit || canPublishOrEdit;
-  const canReview = isPendingReview && !isAuthor && canReviewOrEdit;
-  const approved = revision.status === "approved" || adminPublish;
+  // The whole review cycle accepts verdicts, "approved" included (matching the
+  // server): an approval that doesn't satisfy coverage or a required team must
+  // not lock out the one that would.
+  const canReview =
+    isInReviewCycle(revision.status) && !isAuthor && canReviewOrEdit;
 
   // ── Comments: posted as `comment`-decision reviews on the generic
   // revision endpoint; diff-ref blocks in the markdown resolve to gutter
@@ -1398,7 +1399,7 @@ function ReviewAndPublishRevision<T>({
         <Box mt="6">
           {/* Submit review — reviewer action, opens the comment/decision
               popover */}
-          {canReview && requiresApproval && !approved && (
+          {canReview && requiresApproval && !adminPublish && (
             <Flex direction="column" gap="3" mb="4">
               <ReviewCommentPopover
                 onSubmit={submitReviewDecision}
@@ -1417,6 +1418,15 @@ function ReviewAndPublishRevision<T>({
                 onSuccess={() => {}}
                 trigger={
                   <Button
+                    // Outline once publishing is live or armed on a schedule —
+                    // either way review is no longer the primary action.
+                    variant={
+                      state.submitAction === "publish" &&
+                      state.ctaEnabled &&
+                      canPublishOrEdit
+                        ? "outline"
+                        : undefined
+                    }
                     style={{ width: "100%" }}
                     icon={<PiCaretDownBold />}
                     iconPosition="right"

--- a/packages/front-end/pages/approval-requests.tsx
+++ b/packages/front-end/pages/approval-requests.tsx
@@ -4,7 +4,12 @@ import { FC, useCallback, useEffect, useMemo, useState } from "react";
 import { Box, Flex, TextField } from "@radix-ui/themes";
 import { useRouter } from "next/router";
 import { datetime } from "shared/dates";
-import { Revision, RevisionStatus, getRevisionKey } from "shared/enterprise";
+import {
+  Revision,
+  RevisionStatus,
+  getRevisionKey,
+  isInReviewCycle,
+} from "shared/enterprise";
 import { FeatureRevisionInterface } from "shared/types/feature-revision";
 import { FeatureMetaInfo } from "shared/types/feature";
 import Link from "next/link";
@@ -399,7 +404,8 @@ const ApprovalRequests: FC = () => {
 
   // Scope-level filter applied on top of the status/search filtering.
   // - "needs-my-review": rows I'm allowed to review, that I didn't author,
-  //   and that are in an actionable state (pending-review, changes-requested).
+  //   and that still accept a verdict — "approved" included, since an approval
+  //   that doesn't cover the change still needs one that does.
   // - "my-requests": rows I authored (any status).
   // - "all": no additional filtering.
   const effectiveItems = useMemo(() => {
@@ -412,8 +418,7 @@ const ApprovalRequests: FC = () => {
     // scope === "needs-my-review"
     return statusFilteredItems.filter(
       (row) =>
-        (row.status === "pending-review" ||
-          row.status === "changes-requested") &&
+        isInReviewCycle(row.status) &&
         row.authorId !== userId &&
         canReviewRow(row),
     );

--- a/packages/shared/src/enterprise/reviewCycle.ts
+++ b/packages/shared/src/enterprise/reviewCycle.ts
@@ -4,7 +4,12 @@ export const REVIEW_CYCLE_STATUSES = [
   "approved",
 ] as const;
 
-/** Revisions predating the field read as cycle 0, so legacy rows still match. */
+// Whether a revision's status still accepts reviewer verdicts.
+export function isInReviewCycle(status: string | undefined): boolean {
+  return (REVIEW_CYCLE_STATUSES as readonly string[]).includes(status ?? "");
+}
+
+// Revisions predating the field read as cycle 0, so legacy rows still match.
 export function reviewCycleOf(revision: { reviewCycle?: number }): number {
   return revision.reviewCycle ?? 0;
 }
@@ -22,7 +27,7 @@ export function reviewCycleSupersededMessage(
   return `This review request was superseded — the draft was recalled and resubmitted while your ${what} was in flight. Reload and review the current request.`;
 }
 
-/** Changes requested outrank approvals; callers choose the no-verdict fallback. */
+// Changes requested outrank approvals; callers choose the no-verdict fallback.
 export function statusFromStandingVerdicts<TFallback extends string>(
   verdicts: readonly ("approved" | "changes-requested")[],
   fallback: TFallback,


### PR DESCRIPTION
An approval from someone outside the required approver teams (or without review access in the changed environments) flipped a revision to Approved. This "insufficient" approval hid the review controls from everyone; the approval that would actually satisfy the gate couldn't be given. Fixed by allowing multiple reviews and not blocking the UI, which is what we originally intended anyhow.