### PR TITLE
feat(api): add effect SE to api results

### DIFF
--- a/docs/app/experiment-bulk-results-api.mdx
+++ b/docs/app/experiment-bulk-results-api.mdx
@@ -103,6 +103,7 @@ The query is strict: an unrecognized param is a `400`. Other failures are `400` 
                       "mean": 0.089,
                       "stddev": 0.284,
                       "effect": null,
+                      "effectStandardError": null,
                       "ciLow": null,
                       "ciHigh": null,
                       "chanceToBeatControl": null
@@ -145,7 +146,9 @@ Each metric role entry is `{ metricId, effectiveSettings? }`, where `effectiveSe
 
 ### Variation analyses
 
-Each variation carries `variationIndex` and `variationKey` — the authoritative join keys, taken from the snapshot's stored variation array — plus its `users` count and an `analyses` array holding one entry per stored difference type: `engine`, `differenceType` (`relative`, `absolute`, `scaled`), `numerator`, `denominator`, `mean`, `stddev`, `effect`, `ciLow`, `ciHigh`, `pValue`, and `chanceToBeatControl`. Every statistic is `null` when it is missing or non-finite, and `effect` is expressed according to `differenceType`.
+Each variation carries `variationIndex` and `variationKey` — the authoritative join keys, taken from the snapshot's stored variation array — plus its `users` count and an `analyses` array holding one entry per stored difference type: `engine`, `differenceType` (`relative`, `absolute`, `scaled`), `numerator`, `denominator`, `mean`, `stddev`, `effect`, `effectStandardError`, `ciLow`, `ciHigh`, `pValue`, and `chanceToBeatControl`. Every statistic is `null` when it is missing or non-finite.
+
+`effect` is expressed according to `differenceType`, and `effectStandardError` is its standard error on the same scale — the frequentist standard error of the estimate, or the posterior standard deviation under the Bayesian engine. Note that `stddev` is unrelated: it is the within-variation standard deviation of the metric itself.
 
 ## Semantics
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -54832,6 +54832,11 @@ components:
                                   type: number
                                 percentChange:
                                   type: number
+                                effectStandardError:
+                                  description: >-
+                                    Standard error of the estimated effect
+                                    (`percentChange`).
+                                  type: number
                                 ciLow:
                                   type: number
                                 ciHigh:
@@ -54851,6 +54856,7 @@ components:
                                 - mean
                                 - stddev
                                 - percentChange
+                                - effectStandardError
                                 - ciLow
                                 - ciHigh
                               additionalProperties: false
@@ -68234,6 +68240,9 @@ components:
                 type: number
               lift:
                 description: Relative uplift mean for this variation, if available
+                type: number
+              effectStandardError:
+                description: Standard error of `lift`, if available
                 type: number
               ci:
                 description: Confidence interval [lower, upper]

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -54832,6 +54832,11 @@ components:
                                   type: number
                                 percentChange:
                                   type: number
+                                effectStandardError:
+                                  description: >-
+                                    Standard error of the estimated effect
+                                    (`percentChange`).
+                                  type: number
                                 ciLow:
                                   type: number
                                 ciHigh:
@@ -54851,6 +54856,7 @@ components:
                                 - mean
                                 - stddev
                                 - percentChange
+                                - effectStandardError
                                 - ciLow
                                 - ciHigh
                               additionalProperties: false
@@ -68234,6 +68240,9 @@ components:
                 type: number
               lift:
                 description: Relative uplift mean for this variation, if available
+                type: number
+              effectStandardError:
+                description: Standard error of `lift`, if available
                 type: number
               ci:
                 description: Confidence interval [lower, upper]

--- a/packages/back-end/src/api/experiments/bulkResultSerialization.ts
+++ b/packages/back-end/src/api/experiments/bulkResultSerialization.ts
@@ -173,6 +173,7 @@ export function toApiResultAnalysis(
     mean: safeFloatOrNull(data?.stats?.mean),
     stddev: safeFloatOrNull(data?.stats?.stddev),
     effect: safeFloatOrNull(data?.expected),
+    effectStandardError: safeFloatOrNull(data?.uplift?.stddev),
     ciLow: safeFloatOrNull(data?.ci?.[0]),
     ciHigh: safeFloatOrNull(data?.ci?.[1]),
     pValue: safeFloatOrNull(data?.pValue),

--- a/packages/back-end/src/api/metrics/listMetricExperiments.ts
+++ b/packages/back-end/src/api/metrics/listMetricExperiments.ts
@@ -91,6 +91,7 @@ export const listMetricExperiments = createApiRequestHandler(
         value: metricResult?.value,
         mean: metricResult?.cr,
         lift: metricResult?.uplift?.mean,
+        effectStandardError: metricResult?.uplift?.stddev,
         ci: metricResult?.ci,
         pValue: metricResult?.pValue,
         chanceToWin: metricResult?.chanceToWin,

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -3315,6 +3315,7 @@ export function toSnapshotApiInterface(
                     mean: safeFloat(data?.stats?.mean),
                     stddev: safeFloat(data?.stats?.stddev),
                     percentChange: safeFloat(data?.expected),
+                    effectStandardError: safeFloat(data?.uplift?.stddev),
                     ciLow: safeFloat(data?.ci?.[0]),
                     ciHigh: safeFloat(data?.ci?.[1]),
                     pValue: safeFloat(data?.pValue),

--- a/packages/back-end/test/services/experimentSnapshotAnalyses.test.ts
+++ b/packages/back-end/test/services/experimentSnapshotAnalyses.test.ts
@@ -252,6 +252,16 @@ describe("toApiResultAnalysis", () => {
     expect(result.effect).toBeNull();
     expect(result.pValue).toBeNull();
     expect(result.mean).toBeNull();
+    expect(result.effectStandardError).toBeNull();
+  });
+
+  it("maps the uplift stddev to effectStandardError", () => {
+    expect(
+      toApiResultAnalysis("frequentist", "relative", {
+        ...data,
+        uplift: { dist: "normal", mean: 0.25, stddev: 0.04 },
+      }).effectStandardError,
+    ).toBe(0.04);
   });
 
   it("passes the stored denominator through unchanged", () => {
@@ -334,6 +344,33 @@ describe("toSnapshotApiInterface (legacy contract)", () => {
 
     expect(analysis.percentChange).toBe(0);
     expect(analysis.pValue).toBe(0);
+    expect(analysis.effectStandardError).toBe(0);
+  });
+
+  it("returns the effect standard error from the stored uplift distribution", () => {
+    const snapshot = makeSnapshot();
+    snapshot.analyses = [
+      makeSuccessAnalysis(
+        makeAnalysisSettings({ dimensions: [""] }),
+        makeOverallResult("met_1", [
+          makeSnapshotMetricData(),
+          makeSnapshotMetricData({
+            uplift: { dist: "normal", mean: 0.1, stddev: 0.02 },
+          }),
+        ]),
+      ),
+    ];
+
+    const result = toSnapshotApiInterface(
+      makeExperiment(),
+      snapshot,
+      new Map(),
+    );
+
+    expect(
+      result.results[0].metrics[0].variations[1].analyses[0]
+        .effectStandardError,
+    ).toBe(0.02);
   });
 });
 

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -1076,6 +1076,11 @@ export const apiExperimentResultsValidator = namedSchema(
                       mean: z.coerce.number(),
                       stddev: z.coerce.number(),
                       percentChange: z.coerce.number(),
+                      effectStandardError: z.coerce
+                        .number()
+                        .describe(
+                          "Standard error of the estimated effect (`percentChange`).",
+                        ),
                       ciLow: z.coerce.number(),
                       ciHigh: z.coerce.number(),
                       pValue: z.coerce.number().optional(),
@@ -1181,6 +1186,10 @@ const apiBulkResultVariation = z.object({
       stddev: z.number().nullable(),
       // Estimated effect expressed according to differenceType.
       effect: z.number().nullable(),
+      effectStandardError: z
+        .number()
+        .nullable()
+        .describe("Standard error of `effect`, on the same scale."),
       ciLow: z.number().nullable(),
       ciHigh: z.number().nullable(),
       pValue: z.number().nullable().optional(),

--- a/packages/shared/src/validators/metrics.ts
+++ b/packages/shared/src/validators/metrics.ts
@@ -779,6 +779,10 @@ const apiMetricExperimentVariationResultValidator = z.object({
     .number()
     .describe("Relative uplift mean for this variation, if available")
     .optional(),
+  effectStandardError: z
+    .number()
+    .describe("Standard error of `lift`, if available")
+    .optional(),
   ci: z
     .tuple([z.number(), z.number()])
     .describe("Confidence interval [lower, upper]")


### PR DESCRIPTION
Add the effect standard error (technically the posterior std dev of the effect for the bayesian engine) to the results API endpoints.