### PR TITLE
Perf: speed up local test runs

### DIFF
--- a/packages/back-end/jest.config.js
+++ b/packages/back-end/jest.config.js
@@ -1,3 +1,46 @@
+// Packages no test exercises, stubbed to keep their init cost out of 300+ fresh
+// module registries. The googleapis barrel alone eagerly requires 472 modules.
+const STUBBED_DRIVERS = [
+  "googleapis",
+  "@sentry/node",
+  "stripe",
+  "openid-client",
+  "jwks-rsa",
+  "ai",
+  "openai",
+  "@ai-sdk/anthropic",
+  "@ai-sdk/google",
+  "@ai-sdk/mistral",
+  "@ai-sdk/openai",
+  "@ai-sdk/xai",
+  "@dqbd/tiktoken",
+  "tiktoken",
+  "proxy-agent",
+  "kerberos",
+  "@google-cloud/bigquery",
+  "@google-cloud/storage",
+  "@aws-sdk/client-athena",
+  "@aws-sdk/client-sts",
+  "@aws-sdk/client-s3",
+  "@aws-sdk/client-cloudwatch",
+  "@aws-sdk/credential-providers",
+  "@aws-sdk/s3-request-presigner",
+  "@aws-sdk/s3-presigned-post",
+  "@databricks/sql",
+  "@clickhouse/client",
+  "presto-client",
+  "mysql2",
+  "mysql2/promise",
+  "mssql",
+];
+
+const driverStubs = Object.fromEntries(
+  STUBBED_DRIVERS.map((m) => [
+    `^${m}$`,
+    "<rootDir>/test/stubs/heavy-module.js",
+  ]),
+);
+
 module.exports = {
   moduleFileExtensions: ["ts", "js", "node", "json"],
   transform: {
@@ -9,14 +52,16 @@ module.exports = {
   // Pinned rather than left in the OS temp dir so CI can cache it between runs.
   cacheDirectory: "<rootDir>/.jest-cache",
   moduleNameMapper: {
+    ...driverStubs,
     "^axios$": "axios/dist/axios.js",
     "^@typespec/ts-http-runtime/internal/(.*)$":
       "<rootDir>/../../node_modules/.pnpm/@typespec+ts-http-runtime@0.3.1/node_modules/@typespec/ts-http-runtime/dist/commonjs/$1/internal.js",
   },
+  globalSetup: "<rootDir>/test/globalSetup.ts",
+  globalTeardown: "<rootDir>/test/globalTeardown.ts",
   setupFilesAfterEnv: ["<rootDir>/test/jest.setup.ts"],
   // For non-CI, lets make sure to cap the workers
   ...(process.env.CI ? {} : { maxWorkers: "50%" }),
-  // Each file's module graph stays resident (~140MB/file); recycle workers
-  // before the heap fills.
-  workerIdleMemoryLimit: process.env.CI ? "2GB" : "1GB",
+  // Recycle workers before the heap fills; 1GB cost more in restarts than it saved.
+  workerIdleMemoryLimit: "2GB",
 };

--- a/packages/back-end/test/api/api.setup.ts
+++ b/packages/back-end/test/api/api.setup.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "crypto";
 import mongoose from "mongoose";
-import { MongoMemoryServer } from "mongodb-memory-server";
 import merge from "lodash/merge";
 import { getAuthConnection } from "back-end/src/services/auth";
 import authenticateApiRequestMiddleware from "back-end/src/middleware/authenticateApiRequestMiddleware";
@@ -10,6 +9,7 @@ import { queueInit } from "back-end/src/init/queue";
 import { getAgendaInstance } from "back-end/src/services/queueing";
 import { waitForIndexes } from "back-end/src/models/BaseModel";
 import { ReqContextClass } from "back-end/src/services/context";
+import { testMongoUri } from "back-end/test/mongo";
 
 jest.mock("back-end/src/util/secrets", () => ({
   ...jest.requireActual("back-end/src/util/secrets"),
@@ -46,15 +46,12 @@ export const setupApp = () => {
   // spec each run.
   jest.setTimeout(20000);
 
-  let mongodb;
   let reqContext;
   const auditMock = jest.fn();
   const OLD_ENV = process.env;
   const isReady = new Promise((resolve) => {
     beforeAll(async () => {
-      mongodb = await MongoMemoryServer.create();
-      const uri = mongodb.getUri();
-      process.env.MONGO_URL = uri;
+      process.env.MONGO_URL = testMongoUri();
       getAuthConnection().middleware.mockImplementation((req, res, next) => {
         next();
       });
@@ -109,7 +106,6 @@ export const setupApp = () => {
     afterAll(async () => {
       await getAgendaInstance().stop();
       await mongoose.connection.close();
-      await mongodb.stop();
       process.env = OLD_ENV;
     });
 

--- a/packages/back-end/test/globalSetup.ts
+++ b/packages/back-end/test/globalSetup.ts
@@ -1,0 +1,8 @@
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { setMongod } from "./mongo";
+
+export default async function globalSetup() {
+  const mongod = await MongoMemoryServer.create();
+  setMongod(mongod);
+  process.env.MONGO_TEST_BASE_URI = mongod.getUri();
+}

--- a/packages/back-end/test/globalTeardown.ts
+++ b/packages/back-end/test/globalTeardown.ts
@@ -1,0 +1,5 @@
+import { getMongod } from "./mongo";
+
+export default async function globalTeardown() {
+  await getMongod()?.stop();
+}

--- a/packages/back-end/test/mongo.ts
+++ b/packages/back-end/test/mongo.ts
@@ -1,0 +1,17 @@
+import { MongoMemoryServer } from "mongodb-memory-server";
+
+type MongoGlobal = typeof globalThis & { __TEST_MONGOD__?: MongoMemoryServer };
+
+export const setMongod = (m: MongoMemoryServer) => {
+  (globalThis as MongoGlobal).__TEST_MONGOD__ = m;
+};
+
+export const getMongod = () => (globalThis as MongoGlobal).__TEST_MONGOD__;
+
+// One mongod serves the whole run. Each worker gets its own database, and files
+// sharing a worker reuse it so collection indexes are built once, not per file.
+export const testMongoUri = () => {
+  const base = process.env.MONGO_TEST_BASE_URI;
+  if (!base) throw new Error("globalSetup did not start the test mongod");
+  return `${base.replace(/\/$/, "")}/gb_test_${process.env.JEST_WORKER_ID ?? "1"}`;
+};

--- a/packages/back-end/test/stubs/heavy-module.js
+++ b/packages/back-end/test/stubs/heavy-module.js
@@ -1,0 +1,20 @@
+// Stand-in for heavy packages no test exercises. Callable, constructible, and
+// every property yields another stub, so any usage shape resolves.
+const handler = {
+  get: (target, prop) => {
+    // Symbols stay undefined so coercion behaves like a plain object, and a
+    // stub must not look thenable or `await` would resolve to the wrong value.
+    if (typeof prop === "symbol" || prop === "then") return undefined;
+    if (prop === "__esModule") return true;
+    if (!(prop in target)) target[prop] = makeStub();
+    return target[prop];
+  },
+  apply: () => makeStub(),
+  construct: () => makeStub(),
+};
+
+function makeStub() {
+  return new Proxy(function stub() {}, handler);
+}
+
+module.exports = makeStub();

--- a/packages/front-end/vitest.config.js
+++ b/packages/front-end/vitest.config.js
@@ -6,9 +6,9 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./test/setup.ts"],
-    // Off CI, tests share the box with a running `pnpm dev` stack, so cap
-    // workers.
-    ...(process.env.CI ? {} : { maxWorkers: 2 }),
+    // Off CI, tests share the box with a running `pnpm dev` stack, so leave it
+    // half the cores. CI sets its own worker count from the runner size.
+    ...(process.env.CI ? {} : { maxWorkers: "50%" }),
     coverage: {
       provider: "v8",
     },


### PR DESCRIPTION
### Features and Changes

#6754 sped up CI by ~3x, but didn't affect local runs of the test suite. Almost all of back-end's time turns out to be module init being re-run for all 309 test files, rather than the tests themselves.

Four wins:
* Stub the packages no test exercises. `googleapis` is the worst, eagerly requiring 472 modules covering every Google API. **-42s**
* Reuse one `mongod` for the whole run instead of the 53 that `api.setup.ts` was spawning per file. **-4s**
* Raise `workerIdleMemoryLimit` to 2GB to prevent excessive worker restarts **-4s**
* Let Vitest's `maxWorkers` scale to machine size **74s -> 32s** (for my 8 core/16 thread laptop)

Back-end **158s -> 106s**, front-end **74s -> 32s**

### Testing

Two runs per step, and test counts are identical before and after so nothing got silently skipped:

- [x] Back-end: 309 suites, 8249 tests, 2254 snapshots pass
- [x] Front-end: 69 files, 1110 tests pass
- [x] Single-file runs unaffected by the shared mongod, 3.47s -> 3.50s
- [x] `pnpm lint:ci` and `pnpm pretty:check` clean
