### PR TITLE
Fix approval requirements leaking from switched-off rules

### DIFF
--- a/packages/front-end/AGENTS.md
+++ b/packages/front-end/AGENTS.md
@@ -18,13 +18,3 @@ Permission controls must:
 - Use independent, discriminating fixtures rather than deriving expected values through the implementation under test.
 
 See `.agents/guides/flag-family-authority.md` for the authority rules.
-
-<!-- BEGIN:nextjs-agent-rules -->
-
-# This is NOT the Next.js you know
-
-This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
-
-This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
-
-<!-- END:nextjs-agent-rules -->

--- a/packages/front-end/AGENTS.md
+++ b/packages/front-end/AGENTS.md
@@ -18,3 +18,13 @@ Permission controls must:
 - Use independent, discriminating fixtures rather than deriving expected values through the implementation under test.
 
 See `.agents/guides/flag-family-authority.md` for the authority rules.
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/packages/front-end/components/Settings/Team/RoleRulesSummary.tsx
+++ b/packages/front-end/components/Settings/Team/RoleRulesSummary.tsx
@@ -7,7 +7,13 @@ import Text from "@/ui/Text";
 import Badge from "@/ui/Badge";
 import { useUser } from "@/services/UserContext";
 
-export function RoleRulesSummary({ value }: { value: MemberRoleWithProjects }) {
+export function RoleRulesSummary({
+  value,
+  size = "sm",
+}: {
+  value: MemberRoleWithProjects;
+  size?: "sm" | "md";
+}) {
   const { organization } = useUser();
 
   const extraRules =
@@ -21,7 +27,7 @@ export function RoleRulesSummary({ value }: { value: MemberRoleWithProjects }) {
 
   return (
     <Flex align="center" gap="2" wrap="wrap">
-      <Text size="sm" weight="medium">
+      <Text size={size} weight="medium">
         {getRoleDisplayName(value.role, organization)} in {environments}
       </Text>
       {extraRules > 0 && (

--- a/packages/front-end/pages/settings/team/[tid].tsx
+++ b/packages/front-end/pages/settings/team/[tid].tsx
@@ -2,12 +2,14 @@ import router from "next/router";
 import React, { FC, useState } from "react";
 import { date, datetime } from "shared/dates";
 import { BsThreeDotsVertical } from "react-icons/bs";
-import { Flex, IconButton } from "@radix-ui/themes";
+import { Flex, IconButton, Separator } from "@radix-ui/themes";
 import { reviewScopesRequiringTeam } from "shared/util";
 import { useAuth } from "@/services/auth";
 import TeamModal from "@/components/Teams/TeamModal";
 import { AddMembersModal } from "@/components/Teams/AddMembersModal";
 import { PermissionsModal } from "@/components/Settings/Teams/PermissionModal";
+import { RoleRulesSummary } from "@/components/Settings/Team/RoleRulesSummary";
+import Frame from "@/ui/Frame";
 import { useUser } from "@/services/UserContext";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import Badge from "@/ui/Badge";
@@ -123,12 +125,6 @@ const TeamPage: FC = () => {
             )}
           </Flex>
           <Flex align="center" gap="4" flexShrink="0">
-            <Button
-              variant="outline"
-              onClick={() => setPermissionModalOpen(true)}
-            >
-              Edit permissions
-            </Button>
             {isEditable && canManageTeam && (
               <DropdownMenu
                 trigger={
@@ -176,36 +172,66 @@ const TeamPage: FC = () => {
           )}
         </Flex>
 
-        {approvalScopes.length > 0 && (
-          <Flex direction="column" gap="1" mb="5">
-            <Text weight="semibold">Required approver for:</Text>
-            {approvalScopes.map((scope) => (
-              <Flex
-                key={scope.project ?? "all"}
-                align="center"
-                gap="2"
-                wrap="wrap"
-              >
-                {scope.project ? (
-                  <Link href={`/project/${scope.project}`}>
-                    {getProjectById(scope.project)?.name || scope.project}
-                  </Link>
-                ) : (
-                  <Text>
-                    {approvalScopes.length > 1
-                      ? "All other projects"
-                      : "All projects"}
-                  </Text>
-                )}
-                {scope.environments.length > 0 && (
-                  <Text color="text-low">
-                    · {scope.environments.join(", ")}
-                  </Text>
-                )}
-              </Flex>
-            ))}
+        <Frame px="4" py="4" mb="5">
+          <Flex align="start" justify="between" gap="3">
+            <Flex direction="column" gap="2">
+              <Heading as="h2" size="md" mb="0">
+                Permissions
+              </Heading>
+              <RoleRulesSummary
+                size="md"
+                value={{
+                  role: team.role,
+                  limitAccessByEnvironment: team.limitAccessByEnvironment,
+                  environments: team.environments,
+                  additionalRoles: team.additionalRoles,
+                  projectRoles: team.projectRoles,
+                }}
+              />
+            </Flex>
+            <Button
+              variant="outline"
+              onClick={() => setPermissionModalOpen(true)}
+            >
+              Edit Team Permissions
+            </Button>
           </Flex>
-        )}
+          {approvalScopes.length > 0 && (
+            <>
+              <Separator size="4" my="4" />
+              <Flex direction="column" gap="2">
+                <Heading as="h2" size="md" mb="0">
+                  Required approver for
+                </Heading>
+                {approvalScopes.map((scope) => (
+                  <Flex
+                    key={scope.project ?? "all"}
+                    align="center"
+                    gap="2"
+                    wrap="wrap"
+                  >
+                    {scope.project ? (
+                      <Link href={`/project/${scope.project}`}>
+                        {getProjectById(scope.project)?.name || scope.project}
+                      </Link>
+                    ) : (
+                      <Text>
+                        {approvalScopes.length > 1
+                          ? "All other projects"
+                          : "All projects"}
+                      </Text>
+                    )}
+                    {scope.environments.length > 0 && (
+                      <Text color="text-low">
+                        · {scope.environments.join(", ")}
+                      </Text>
+                    )}
+                  </Flex>
+                ))}
+              </Flex>
+            </>
+          )}
+        </Frame>
 
         <Flex align="center" justify="between" gap="3" mb="2">
           <Heading as="h2" size="md" mb="0">

--- a/packages/front-end/pages/settings/team/[tid].tsx
+++ b/packages/front-end/pages/settings/team/[tid].tsx
@@ -107,7 +107,7 @@ const TeamPage: FC = () => {
             This team is managed by an idP. To make changes to the{" "}
             <b>team name</b> or <b>team membership</b> please access your idP
             and edit the corresponding group. Team permissions must be edited
-            via the <b>Edit permissions</b> button.
+            via the <b>Edit team permissions</b> button.
           </Callout>
         )}
 
@@ -193,7 +193,7 @@ const TeamPage: FC = () => {
               variant="outline"
               onClick={() => setPermissionModalOpen(true)}
             >
-              Edit Team Permissions
+              Edit team permissions
             </Button>
           </Flex>
           {approvalScopes.length > 0 && (
@@ -201,7 +201,7 @@ const TeamPage: FC = () => {
               <Separator size="4" my="4" />
               <Flex direction="column" gap="2">
                 <Heading as="h2" size="md" mb="0">
-                  Required approver for
+                  Required Approver
                 </Heading>
                 {approvalScopes.map((scope) => (
                   <Flex

--- a/packages/front-end/pages/settings/team/[tid].tsx
+++ b/packages/front-end/pages/settings/team/[tid].tsx
@@ -217,8 +217,8 @@ const TeamPage: FC = () => {
                     ) : (
                       <Text>
                         {approvalScopes.length > 1
-                          ? "All other projects"
-                          : "All projects"}
+                          ? "All other Projects"
+                          : "All Projects"}
                       </Text>
                     )}
                     {scope.environments.length > 0 && (

--- a/packages/shared/src/util/projectScopedRules.ts
+++ b/packages/shared/src/util/projectScopedRules.ts
@@ -65,9 +65,8 @@ export function resolveProjectScopedRule<T extends ProjectScopedRule>(
   // A base winner is already the bottom layer; only a specific one inherits.
   if (!specificWinner || !baseWinner) return winner;
   // A switched-off rule gates nothing, so it takes no part in inheritance: it
-  // neither borrows fields from the layer beneath nor donates its stored (but
-  // dormant) fields — e.g. approver teams left behind by a disabled base rule
-  // must not leak into an active override that never named any.
+  // neither borrows fields from the layer beneath nor donates its own dormant
+  // ones.
   const active = (rule: T) => !isActive || isActive(rule);
   if (!active(winner)) return winner;
   const layers = [specificWinner, baseWinner].filter(active);
@@ -95,10 +94,9 @@ function dropUnsetFields<T extends object>(rule: T): T {
   ) as T;
 }
 
-// The UI hides a disabled rule's fields, so a team association it still stores
-// is invisible — and would silently re-arm if the rule is ever re-enabled.
-// Scraped on the way in; the resolver also refuses to read them, so rows
-// written before this stay inert.
+// The UI hides a disabled rule's fields, so a stored team association is
+// invisible and would silently re-arm on re-enable. Scraped on write; the
+// resolver also ignores them on read, so pre-existing rows stay inert.
 function dropDormantTeams<T extends { requiredApproverTeams?: string[] }>(
   rule: T,
   active: boolean,

--- a/packages/shared/src/util/projectScopedRules.ts
+++ b/packages/shared/src/util/projectScopedRules.ts
@@ -95,21 +95,49 @@ function dropUnsetFields<T extends object>(rule: T): T {
   ) as T;
 }
 
+// The UI hides a disabled rule's fields, so a team association it still stores
+// is invisible — and would silently re-arm if the rule is ever re-enabled.
+// Scraped on the way in; the resolver also refuses to read them, so rows
+// written before this stay inert.
+function dropDormantTeams<T extends { requiredApproverTeams?: string[] }>(
+  rule: T,
+  active: boolean,
+): T {
+  if (active || rule.requiredApproverTeams === undefined) return rule;
+  const next = { ...rule };
+  delete next.requiredApproverTeams;
+  return next;
+}
+
 // Applied on the way in, so both rule families store clears the same way.
 export function normalizeApprovalRuleSettings<
   T extends {
-    requireReviews?: boolean | ProjectScopedRule[];
-    approvalFlows?: { savedGroups?: ProjectScopedRule[] };
+    requireReviews?:
+      | boolean
+      | (ProjectScopedRule & {
+          requireReviewOn?: boolean;
+          requiredApproverTeams?: string[];
+        })[];
+    approvalFlows?: {
+      savedGroups?: (ProjectScopedRule & {
+        required?: boolean;
+        requiredApproverTeams?: string[];
+      })[];
+    };
   },
 >(settings: T): T {
   const next: T = { ...settings };
   if (Array.isArray(next.requireReviews)) {
-    next.requireReviews = next.requireReviews.map(dropUnsetFields);
+    next.requireReviews = next.requireReviews.map((rule) =>
+      dropDormantTeams(dropUnsetFields(rule), !!rule.requireReviewOn),
+    );
   }
   if (next.approvalFlows?.savedGroups) {
     next.approvalFlows = {
       ...next.approvalFlows,
-      savedGroups: next.approvalFlows.savedGroups.map(dropUnsetFields),
+      savedGroups: next.approvalFlows.savedGroups.map((rule) =>
+        dropDormantTeams(dropUnsetFields(rule), !!rule.required),
+      ),
     };
   }
   return next;

--- a/packages/shared/src/util/projectScopedRules.ts
+++ b/packages/shared/src/util/projectScopedRules.ts
@@ -64,7 +64,13 @@ export function resolveProjectScopedRule<T extends ProjectScopedRule>(
   if (!winner) return undefined;
   // A base winner is already the bottom layer; only a specific one inherits.
   if (!specificWinner || !baseWinner) return winner;
-  const layers = [specificWinner, baseWinner];
+  // A switched-off rule gates nothing, so it takes no part in inheritance: it
+  // neither borrows fields from the layer beneath nor donates its stored (but
+  // dormant) fields — e.g. approver teams left behind by a disabled base rule
+  // must not leak into an active override that never named any.
+  const active = (rule: T) => !isActive || isActive(rule);
+  if (!active(winner)) return winner;
+  const layers = [specificWinner, baseWinner].filter(active);
 
   const merged: T = { ...winner };
   for (const field of inheritable) {

--- a/packages/shared/test/inheritedRuleFields.test.ts
+++ b/packages/shared/test/inheritedRuleFields.test.ts
@@ -58,9 +58,8 @@ describe("an absent field inherits", () => {
   });
 });
 
-// A switched-off rule gates nothing, so it takes no part in inheritance. The
-// UI hides a disabled rule's fields, so anything it still stores is invisible;
-// letting it donate would enforce requirements no settings screen shows.
+// Letting a disabled rule donate its (UI-hidden) fields would enforce
+// requirements no settings screen shows.
 describe("a switched-off rule takes no part in inheritance", () => {
   it("does not donate teams left behind on a disabled base rule", () => {
     const resolved = getReviewSetting(
@@ -146,8 +145,6 @@ describe("normalizeApprovalRuleSettings", () => {
     expect(normalized.requireReviews).toBe(true);
   });
 
-  // The UI hides a disabled rule's fields, so teams it still stores are
-  // invisible and would silently re-arm on re-enable.
   it("scrapes team associations off switched-off rules in both families", () => {
     const normalized = normalizeApprovalRuleSettings({
       requireReviews: [

--- a/packages/shared/test/inheritedRuleFields.test.ts
+++ b/packages/shared/test/inheritedRuleFields.test.ts
@@ -145,6 +145,39 @@ describe("normalizeApprovalRuleSettings", () => {
     const normalized = normalizeApprovalRuleSettings({ requireReviews: true });
     expect(normalized.requireReviews).toBe(true);
   });
+
+  // The UI hides a disabled rule's fields, so teams it still stores are
+  // invisible and would silently re-arm on re-enable.
+  it("scrapes team associations off switched-off rules in both families", () => {
+    const normalized = normalizeApprovalRuleSettings({
+      requireReviews: [
+        {
+          requireReviewOn: false,
+          projects: [],
+          requiredApproverTeams: ["t_stale"],
+        },
+        {
+          requireReviewOn: true,
+          projects: ["prj_a"],
+          requiredApproverTeams: ["t_live"],
+        },
+      ],
+      approvalFlows: {
+        savedGroups: [
+          { required: false, projects: [], requiredApproverTeams: ["t_stale"] },
+        ],
+      },
+    });
+
+    const [off, on] = normalized.requireReviews as Record<string, unknown>[];
+    expect("requiredApproverTeams" in off).toBe(false);
+    expect(on.requiredApproverTeams).toEqual(["t_live"]);
+    const sgRule = normalized.approvalFlows?.savedGroups?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect("requiredApproverTeams" in sgRule).toBe(false);
+  });
 });
 
 describe("pruneApprovalRuleReferences", () => {

--- a/packages/shared/test/inheritedRuleFields.test.ts
+++ b/packages/shared/test/inheritedRuleFields.test.ts
@@ -58,6 +58,59 @@ describe("an absent field inherits", () => {
   });
 });
 
+// A switched-off rule gates nothing, so it takes no part in inheritance. The
+// UI hides a disabled rule's fields, so anything it still stores is invisible;
+// letting it donate would enforce requirements no settings screen shows.
+describe("a switched-off rule takes no part in inheritance", () => {
+  it("does not donate teams left behind on a disabled base rule", () => {
+    const resolved = getReviewSetting(
+      [
+        rule({ requireReviewOn: false }),
+        {
+          requireReviewOn: true,
+          projects: ["prj_a"],
+          environments: ["production"],
+        },
+      ],
+      { project: "prj_a" },
+    );
+
+    expect(resolved?.requireReviewOn).toBe(true);
+    expect(resolved?.requiredApproverTeams).toBeUndefined();
+  });
+
+  it("does not donate any other dormant field either", () => {
+    const override = rule({ projects: ["prj_a"] });
+    delete override.blockSelfApproval;
+
+    const resolved = getReviewSetting(
+      [rule({ requireReviewOn: false }), override],
+      { project: "prj_a" },
+    );
+
+    expect(resolved?.blockSelfApproval).toBeUndefined();
+  });
+
+  it("still lets an enabled base rule donate", () => {
+    const override = rule({ projects: ["prj_a"] });
+    delete override.requiredApproverTeams;
+
+    const resolved = getReviewSetting([rule(), override], { project: "prj_a" });
+
+    expect(resolved?.requiredApproverTeams).toEqual(["t_sec"]);
+  });
+
+  it("returns a switched-off override as-is, borrowing nothing beneath it", () => {
+    const override = rule({ projects: ["prj_a"], requireReviewOn: false });
+    delete override.requiredApproverTeams;
+
+    const resolved = getReviewSetting([rule(), override], { project: "prj_a" });
+
+    expect(resolved?.requireReviewOn).toBe(false);
+    expect(resolved?.requiredApproverTeams).toBeUndefined();
+  });
+});
+
 // Absence is the only unset form, so a null from an older client is dropped on
 // the way in rather than stored as a second way to say the same thing.
 describe("normalizeApprovalRuleSettings", () => {


### PR DESCRIPTION
A disabled approval rule's stored approver teams were still being inherited by active project overrides, enforcing a requirement that no settings screen showed (reported by a customer). Switched-off rules now take no part in field inheritance, and dormant team associations are scraped off disabled rules on save.

Also adds a permissions summary card to the team page, including which projects/environments the team is a required approver for.

<img width="1355" height="446" alt="image" src="https://github.com/user-attachments/assets/94700701-6ba2-4527-a5cc-72061a20e96c" />
