### PR TITLE
Contextual Bandit Attributes Sync

### DIFF
--- a/packages/back-end/src/enterprise/models/ContextualBanditModel.ts
+++ b/packages/back-end/src/enterprise/models/ContextualBanditModel.ts
@@ -281,9 +281,7 @@ export class ContextualBanditModel extends BaseClass {
       }
     }
 
-    const targetingAttributeColumns =
-      doc.targetingAttributeColumns ?? doc.contextualAttributes;
-    if ((targetingAttributeColumns?.length ?? 0) === 0) {
+    if ((doc.contextualAttributes?.length ?? 0) === 0) {
       throw new Error(
         "A contextual bandit must declare at least one contextual attribute.",
       );
@@ -294,7 +292,7 @@ export class ContextualBanditModel extends BaseClass {
         {
           id: doc.id,
           name: doc.name,
-          targetingAttributeColumns,
+          targetingAttributeColumns: doc.contextualAttributes,
         },
       ],
     );
@@ -342,7 +340,6 @@ export class ContextualBanditModel extends BaseClass {
         id: generateVariationId(),
         screenshots: [],
       })),
-      targetingAttributeColumns: body.contextualAttributes,
       contextualAttributes: body.contextualAttributes,
       status: "draft" as const,
       currentLeafWeights: [],
@@ -358,9 +355,6 @@ export class ContextualBanditModel extends BaseClass {
       if (body[field] !== undefined) {
         (out as Record<string, unknown>)[field] = body[field];
       }
-    }
-    if (body.contextualAttributes !== undefined) {
-      out.targetingAttributeColumns = body.contextualAttributes;
     }
     return out as Parameters<typeof this.updateById>[1];
   }

--- a/packages/back-end/src/enterprise/models/ContextualBanditModel.ts
+++ b/packages/back-end/src/enterprise/models/ContextualBanditModel.ts
@@ -8,7 +8,7 @@ import {
   apiCreateContextualBanditBody,
   apiUpdateContextualBanditBody,
   ApiContextualBanditInterface,
-  assertExposureQueriesTargetingAttributeColumnsValid,
+  assertContextualAttributesValid,
   CONTEXTUAL_BANDIT_API_UPDATE_FIELDS,
   ContextualBanditInterface,
   contextualBanditValidator,
@@ -281,21 +281,20 @@ export class ContextualBanditModel extends BaseClass {
       }
     }
 
-    if ((doc.contextualAttributes?.length ?? 0) === 0) {
-      throw new Error(
-        "A contextual bandit must declare at least one contextual attribute.",
+    if (
+      !previousDoc ||
+      !isEqual(doc.contextualAttributes, previousDoc.contextualAttributes)
+    ) {
+      if ((doc.contextualAttributes?.length ?? 0) === 0) {
+        throw new Error(
+          "A contextual bandit must declare at least one contextual attribute.",
+        );
+      }
+      assertContextualAttributesValid(
+        this.context.org.settings?.attributeSchema,
+        doc,
       );
     }
-    assertExposureQueriesTargetingAttributeColumnsValid(
-      this.context.org.settings?.attributeSchema,
-      [
-        {
-          id: doc.id,
-          name: doc.name,
-          targetingAttributeColumns: doc.contextualAttributes,
-        },
-      ],
-    );
   }
 
   public override async handleApiList(

--- a/packages/back-end/src/enterprise/queryRunners/ContextualBanditResultsQueryRunner.ts
+++ b/packages/back-end/src/enterprise/queryRunners/ContextualBanditResultsQueryRunner.ts
@@ -219,6 +219,7 @@ export class ContextualBanditResultsQueryRunner extends QueryRunner<
     const statsSettings = getContextualBanditSettingsForStatsEngine(
       cb,
       this.snapshotSettings.variations.map((v) => v.id),
+      this.snapshotSettings.contextualAttributes,
     );
 
     const expSnapshotSettings = buildSnapshotSettingsForCb(

--- a/packages/back-end/src/enterprise/services/contextualBandits.ts
+++ b/packages/back-end/src/enterprise/services/contextualBandits.ts
@@ -19,10 +19,11 @@ import {
   ContextualBanditQueryInterface,
   ContextualBanditSnapshotInterface,
   ContextualBanditSnapshotSettings,
-  getAllowedTargetingAttributePropertyNames,
+  getEffectiveContextualAttributes,
   LeafWeight,
   RevisionRampAction,
 } from "shared/validators";
+import type { SDKAttributeSchema } from "shared/types/organization";
 import {
   autoMerge,
   reconcileMergeBaselines,
@@ -867,14 +868,46 @@ export async function runContextualBanditSnapshot(
     scheduleChanges,
   );
 
-  const allowedGlobalAttributes = getAllowedTargetingAttributePropertyNames(
-    context.org.settings?.attributeSchema,
-  );
+  const previousSnapshot =
+    await context.models.contextualBanditSnapshots.getLatestForContextualBandit(
+      updatedCb.id,
+    );
   const snapshotSettings = buildContextualBanditSnapshotSettings(
     updatedCb,
     cbQuery,
-    allowedGlobalAttributes,
+    context.org.settings?.attributeSchema,
   );
+
+  const droppedContextualAttributes = updatedCb.contextualAttributes.filter(
+    (a) => !snapshotSettings.contextualAttributes.includes(a),
+  );
+  if (
+    droppedContextualAttributes.length > 0 &&
+    !isEqual(
+      previousSnapshot?.frozenSettings?.contextualAttributes,
+      snapshotSettings.contextualAttributes,
+    )
+  ) {
+    try {
+      await context.auditLog({
+        event: "contextualBandit.update",
+        entity: {
+          object: "contextualBandit",
+          id: updatedCb.id,
+        },
+        details: auditDetailsUpdate(
+          { contextualAttributes: updatedCb.contextualAttributes },
+          { contextualAttributes: snapshotSettings.contextualAttributes },
+          { droppedContextualAttributes, triggeredBy: opts.triggeredBy },
+        ),
+      });
+    } catch (e) {
+      context.logger.error(
+        e,
+        `Error creating audit log for dropped contextual attributes (${updatedCb.id})`,
+      );
+    }
+  }
 
   const cbs = await context.models.contextualBanditSnapshots.create({
     contextualBandit: updatedCb.id,
@@ -1114,14 +1147,15 @@ export async function persistContextualBanditEvent(
 export function buildContextualBanditSnapshotSettings(
   cb: ContextualBanditInterface,
   cbQuery: ContextualBanditQueryInterface,
-  allowedGlobalAttributes: Set<string>,
+  attributeSchema: SDKAttributeSchema | undefined,
 ): ContextualBanditSnapshotSettings {
   const numVariations = cb.variations?.length || 1;
 
-  const selectedAttributes = new Set(cb.contextualAttributes);
-  const effectiveContextualAttributes = (
-    cbQuery.targetingAttributeColumns ?? []
-  ).filter((a) => selectedAttributes.has(a) && allowedGlobalAttributes.has(a));
+  const effectiveContextualAttributes = getEffectiveContextualAttributes(
+    cb.contextualAttributes,
+    cbQuery.targetingAttributeColumns,
+    attributeSchema,
+  );
   if (effectiveContextualAttributes.length === 0) {
     throw new Error(
       `Contextual bandit ${cb.id} has no usable contextual attributes: none of its selected attributes are on both the query and the attribute schema.`,

--- a/packages/back-end/src/enterprise/services/contextualBandits.ts
+++ b/packages/back-end/src/enterprise/services/contextualBandits.ts
@@ -868,10 +868,6 @@ export async function runContextualBanditSnapshot(
     scheduleChanges,
   );
 
-  const previousSnapshot =
-    await context.models.contextualBanditSnapshots.getLatestForContextualBandit(
-      updatedCb.id,
-    );
   const snapshotSettings = buildContextualBanditSnapshotSettings(
     updatedCb,
     cbQuery,
@@ -881,31 +877,36 @@ export async function runContextualBanditSnapshot(
   const droppedContextualAttributes = updatedCb.contextualAttributes.filter(
     (a) => !snapshotSettings.contextualAttributes.includes(a),
   );
-  if (
-    droppedContextualAttributes.length > 0 &&
-    !isEqual(
-      previousSnapshot?.frozenSettings?.contextualAttributes,
-      snapshotSettings.contextualAttributes,
-    )
-  ) {
-    try {
-      await context.auditLog({
-        event: "contextualBandit.update",
-        entity: {
-          object: "contextualBandit",
-          id: updatedCb.id,
-        },
-        details: auditDetailsUpdate(
-          { contextualAttributes: updatedCb.contextualAttributes },
-          { contextualAttributes: snapshotSettings.contextualAttributes },
-          { droppedContextualAttributes, triggeredBy: opts.triggeredBy },
-        ),
-      });
-    } catch (e) {
-      context.logger.error(
-        e,
-        `Error creating audit log for dropped contextual attributes (${updatedCb.id})`,
+  if (droppedContextualAttributes.length > 0) {
+    const previousSnapshot =
+      await context.models.contextualBanditSnapshots.getLatestForContextualBandit(
+        updatedCb.id,
       );
+    if (
+      !isEqual(
+        previousSnapshot?.frozenSettings?.contextualAttributes,
+        snapshotSettings.contextualAttributes,
+      )
+    ) {
+      try {
+        await context.auditLog({
+          event: "contextualBandit.update",
+          entity: {
+            object: "contextualBandit",
+            id: updatedCb.id,
+          },
+          details: auditDetailsUpdate(
+            { contextualAttributes: updatedCb.contextualAttributes },
+            { contextualAttributes: snapshotSettings.contextualAttributes },
+            { droppedContextualAttributes, triggeredBy: opts.triggeredBy },
+          ),
+        });
+      } catch (e) {
+        context.logger.error(
+          e,
+          `Error creating audit log for dropped contextual attributes (${updatedCb.id})`,
+        );
+      }
     }
   }
 

--- a/packages/back-end/src/enterprise/services/contextualBandits.ts
+++ b/packages/back-end/src/enterprise/services/contextualBandits.ts
@@ -19,6 +19,7 @@ import {
   ContextualBanditQueryInterface,
   ContextualBanditSnapshotInterface,
   ContextualBanditSnapshotSettings,
+  getAllowedTargetingAttributePropertyNames,
   LeafWeight,
   RevisionRampAction,
 } from "shared/validators";
@@ -866,9 +867,13 @@ export async function runContextualBanditSnapshot(
     scheduleChanges,
   );
 
+  const allowedGlobalAttributes = getAllowedTargetingAttributePropertyNames(
+    context.org.settings?.attributeSchema,
+  );
   const snapshotSettings = buildContextualBanditSnapshotSettings(
     updatedCb,
     cbQuery,
+    allowedGlobalAttributes,
   );
 
   const cbs = await context.models.contextualBanditSnapshots.create({
@@ -1109,8 +1114,19 @@ export async function persistContextualBanditEvent(
 export function buildContextualBanditSnapshotSettings(
   cb: ContextualBanditInterface,
   cbQuery: ContextualBanditQueryInterface,
+  allowedGlobalAttributes: Set<string>,
 ): ContextualBanditSnapshotSettings {
   const numVariations = cb.variations?.length || 1;
+
+  const selectedAttributes = new Set(cb.contextualAttributes);
+  const effectiveContextualAttributes = (
+    cbQuery.targetingAttributeColumns ?? []
+  ).filter((a) => selectedAttributes.has(a) && allowedGlobalAttributes.has(a));
+  if (effectiveContextualAttributes.length === 0) {
+    throw new Error(
+      `Contextual bandit ${cb.id} has no usable contextual attributes: none of its selected attributes are on both the query and the attribute schema.`,
+    );
+  }
 
   const banditStart = cb.dateStarted ?? new Date();
   const effectiveEnd = cb.dateStopped ?? new Date();
@@ -1130,8 +1146,7 @@ export function buildContextualBanditSnapshotSettings(
     contextualBanditQueryId: cb.contextualBanditQueryId,
     query: cbQuery.query,
     userIdType: cbQuery.userIdType,
-    contextualAttributes:
-      cbQuery.targetingAttributeColumns ?? cb.contextualAttributes,
+    contextualAttributes: effectiveContextualAttributes,
 
     decisionMetric: cb.decisionMetric ?? "",
     metricSettings: {},
@@ -1201,10 +1216,11 @@ export function buildSnapshotSettingsForCb(
 export function getContextualBanditSettingsForStatsEngine(
   cb: ContextualBanditInterface,
   variationIds: string[],
+  contextualAttributes: string[],
 ): ContextualBanditStatsSettings {
   return {
     varIds: variationIds,
-    contextualAttributes: cb.contextualAttributes,
+    contextualAttributes,
     maxLeaves: cb.maxLeaves,
     minUsersPerLeaf: cb.minUsersPerLeaf,
   };

--- a/packages/back-end/test/services/contextualBandits.test.ts
+++ b/packages/back-end/test/services/contextualBandits.test.ts
@@ -191,7 +191,11 @@ describe("buildContextualBanditSnapshotSettings", () => {
     const cb = makeCb();
     const eaq = makeExposureQuery();
 
-    const settings = buildContextualBanditSnapshotSettings(cb, eaq);
+    const settings = buildContextualBanditSnapshotSettings(
+      cb,
+      eaq,
+      new Set(["country", "device"]),
+    );
 
     expect(settings).not.toHaveProperty("activationMetric");
     expect(settings).not.toHaveProperty("phase");
@@ -215,6 +219,7 @@ describe("buildContextualBanditSnapshotSettings", () => {
     const settings = buildContextualBanditSnapshotSettings(
       makeCb({ trackingKey: "first_contextual_bandit" }),
       makeExposureQuery(),
+      new Set(["country", "device"]),
     );
 
     expect(settings.experimentId).toBe("cb_1");
@@ -225,6 +230,7 @@ describe("buildContextualBanditSnapshotSettings", () => {
     const cbSettings = buildContextualBanditSnapshotSettings(
       makeCb({ trackingKey: "first_contextual_bandit" }),
       makeExposureQuery(),
+      new Set(["country", "device"]),
     );
 
     expect(buildSnapshotSettingsForCb(cbSettings).experimentId).toBe(
@@ -232,13 +238,75 @@ describe("buildContextualBanditSnapshotSettings", () => {
     );
   });
 
-  it("falls back to CB.contextualAttributes when EAQ has no targeting columns", () => {
-    const cb = makeCb({ contextualAttributes: ["plan_tier"] });
-    const eaq = makeExposureQuery({ targetingAttributeColumns: undefined });
+  it("intersects CB, query, and global attributes and preserves query order", () => {
+    const cb = makeCb({ contextualAttributes: ["device", "country"] });
+    const eaq = makeExposureQuery({
+      targetingAttributeColumns: ["country", "device", "plan_tier"],
+    });
 
-    const settings = buildContextualBanditSnapshotSettings(cb, eaq);
+    const settings = buildContextualBanditSnapshotSettings(
+      cb,
+      eaq,
+      new Set(["country", "device", "plan_tier"]),
+    );
 
-    expect(settings.contextualAttributes).toEqual(["plan_tier"]);
+    expect(settings.contextualAttributes).toEqual(["country", "device"]);
+  });
+
+  it("drops an attribute the query no longer exposes", () => {
+    const cb = makeCb({ contextualAttributes: ["country", "device"] });
+    const eaq = makeExposureQuery({ targetingAttributeColumns: ["country"] });
+
+    const settings = buildContextualBanditSnapshotSettings(
+      cb,
+      eaq,
+      new Set(["country", "device"]),
+    );
+
+    expect(settings.contextualAttributes).toEqual(["country"]);
+  });
+
+  it("drops an attribute removed from the global attribute schema", () => {
+    const cb = makeCb({ contextualAttributes: ["country", "device"] });
+    const eaq = makeExposureQuery({
+      targetingAttributeColumns: ["country", "device"],
+    });
+
+    const settings = buildContextualBanditSnapshotSettings(
+      cb,
+      eaq,
+      new Set(["country"]),
+    );
+
+    expect(settings.contextualAttributes).toEqual(["country"]);
+  });
+
+  it("does not include a query attribute the CB did not select", () => {
+    const cb = makeCb({ contextualAttributes: ["country"] });
+    const eaq = makeExposureQuery({
+      targetingAttributeColumns: ["country", "device"],
+    });
+
+    const settings = buildContextualBanditSnapshotSettings(
+      cb,
+      eaq,
+      new Set(["country", "device"]),
+    );
+
+    expect(settings.contextualAttributes).toEqual(["country"]);
+  });
+
+  it("throws when the intersection is empty", () => {
+    const cb = makeCb({ contextualAttributes: ["country"] });
+    const eaq = makeExposureQuery({ targetingAttributeColumns: ["device"] });
+
+    expect(() =>
+      buildContextualBanditSnapshotSettings(
+        cb,
+        eaq,
+        new Set(["country", "device"]),
+      ),
+    ).toThrow(/no usable contextual attributes/);
   });
 
   it("defaults variation weights to uniform when the CB has none set", () => {
@@ -255,6 +323,7 @@ describe("buildContextualBanditSnapshotSettings", () => {
     const settings = buildContextualBanditSnapshotSettings(
       cb,
       makeExposureQuery(),
+      new Set(["country", "device"]),
     );
 
     expect(settings.variations).toEqual([
@@ -292,6 +361,11 @@ describe("runContextualBanditSnapshot", () => {
       overrides.update ?? jest.fn().mockImplementation((cb) => cb);
     return {
       hasPremiumFeature: jest.fn().mockReturnValue(true),
+      org: {
+        settings: {
+          attributeSchema: [{ property: "country" }, { property: "device" }],
+        },
+      },
       models: {
         contextualBandits: { update: updateMock },
         contextualBanditQueries: {

--- a/packages/back-end/test/services/contextualBandits.test.ts
+++ b/packages/back-end/test/services/contextualBandits.test.ts
@@ -1,9 +1,13 @@
 import { ExposureQuery } from "shared/types/datasource";
+import type { SDKAttributeSchema } from "shared/types/organization";
 import {
   ContextualBanditInterface,
   ContextualBanditSnapshotInterface,
   contextualBanditSnapshotSettingsValidator,
 } from "shared/validators";
+
+const schema = (...properties: string[]): SDKAttributeSchema =>
+  properties.map((property) => ({ property })) as SDKAttributeSchema;
 import { ApiReqContext, ReqContext } from "back-end/types/api";
 import {
   buildContextualBanditSnapshotSettings,
@@ -194,7 +198,7 @@ describe("buildContextualBanditSnapshotSettings", () => {
     const settings = buildContextualBanditSnapshotSettings(
       cb,
       eaq,
-      new Set(["country", "device"]),
+      schema("country", "device"),
     );
 
     expect(settings).not.toHaveProperty("activationMetric");
@@ -219,7 +223,7 @@ describe("buildContextualBanditSnapshotSettings", () => {
     const settings = buildContextualBanditSnapshotSettings(
       makeCb({ trackingKey: "first_contextual_bandit" }),
       makeExposureQuery(),
-      new Set(["country", "device"]),
+      schema("country", "device"),
     );
 
     expect(settings.experimentId).toBe("cb_1");
@@ -230,7 +234,7 @@ describe("buildContextualBanditSnapshotSettings", () => {
     const cbSettings = buildContextualBanditSnapshotSettings(
       makeCb({ trackingKey: "first_contextual_bandit" }),
       makeExposureQuery(),
-      new Set(["country", "device"]),
+      schema("country", "device"),
     );
 
     expect(buildSnapshotSettingsForCb(cbSettings).experimentId).toBe(
@@ -247,7 +251,7 @@ describe("buildContextualBanditSnapshotSettings", () => {
     const settings = buildContextualBanditSnapshotSettings(
       cb,
       eaq,
-      new Set(["country", "device", "plan_tier"]),
+      schema("country", "device", "plan_tier"),
     );
 
     expect(settings.contextualAttributes).toEqual(["country", "device"]);
@@ -260,7 +264,7 @@ describe("buildContextualBanditSnapshotSettings", () => {
     const settings = buildContextualBanditSnapshotSettings(
       cb,
       eaq,
-      new Set(["country", "device"]),
+      schema("country", "device"),
     );
 
     expect(settings.contextualAttributes).toEqual(["country"]);
@@ -275,7 +279,7 @@ describe("buildContextualBanditSnapshotSettings", () => {
     const settings = buildContextualBanditSnapshotSettings(
       cb,
       eaq,
-      new Set(["country"]),
+      schema("country"),
     );
 
     expect(settings.contextualAttributes).toEqual(["country"]);
@@ -290,7 +294,7 @@ describe("buildContextualBanditSnapshotSettings", () => {
     const settings = buildContextualBanditSnapshotSettings(
       cb,
       eaq,
-      new Set(["country", "device"]),
+      schema("country", "device"),
     );
 
     expect(settings.contextualAttributes).toEqual(["country"]);
@@ -304,7 +308,7 @@ describe("buildContextualBanditSnapshotSettings", () => {
       buildContextualBanditSnapshotSettings(
         cb,
         eaq,
-        new Set(["country", "device"]),
+        schema("country", "device"),
       ),
     ).toThrow(/no usable contextual attributes/);
   });
@@ -323,7 +327,7 @@ describe("buildContextualBanditSnapshotSettings", () => {
     const settings = buildContextualBanditSnapshotSettings(
       cb,
       makeExposureQuery(),
-      new Set(["country", "device"]),
+      schema("country", "device"),
     );
 
     expect(settings.variations).toEqual([

--- a/packages/back-end/test/services/contextualBandits.test.ts
+++ b/packages/back-end/test/services/contextualBandits.test.ts
@@ -365,6 +365,8 @@ describe("runContextualBanditSnapshot", () => {
       overrides.update ?? jest.fn().mockImplementation((cb) => cb);
     return {
       hasPremiumFeature: jest.fn().mockReturnValue(true),
+      auditLog: jest.fn().mockResolvedValue(undefined),
+      logger: { error: jest.fn() },
       org: {
         settings: {
           attributeSchema: [{ property: "country" }, { property: "device" }],
@@ -384,6 +386,7 @@ describe("runContextualBanditSnapshot", () => {
           create: jest
             .fn()
             .mockResolvedValue({ id: overrides.cbeSnapshotId ?? "cbs_1" }),
+          getLatestForContextualBandit: jest.fn().mockResolvedValue(null),
         },
       },
     } as unknown as ApiReqContext;

--- a/packages/front-end/components/ContextualBandit/ContextualBanditAnalysisFields.tsx
+++ b/packages/front-end/components/ContextualBandit/ContextualBanditAnalysisFields.tsx
@@ -1,10 +1,12 @@
 import { useFormContext } from "react-hook-form";
-import { useEffect, useMemo, useState } from "react";
-import { isEqual } from "lodash";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { getEligibleContextualAttributes } from "shared/validators";
 import { Box, Separator } from "@radix-ui/themes";
 import SelectField from "@/components/Forms/SelectField";
 import MultiSelectField from "@/ui/MultiSelectField";
+import HelperText from "@/ui/HelperText";
 import { useDefinitions } from "@/services/DefinitionsContext";
+import { useAttributeSchema } from "@/services/features";
 import { useContextualBanditQueries } from "@/hooks/useContextualBanditQueries";
 import AddEditContextualBanditQueryModal from "@/components/ContextualBandit/AddEditContextualBanditQueryModal";
 import ContextualBanditDecisionMetricSettings from "@/components/ContextualBandit/ContextualBanditDecisionMetricSettings";
@@ -53,9 +55,14 @@ export default function ContextualBanditAnalysisFields({
     }
   }, [cbQueries, exposureQueryId, form]);
 
-  const queryAttributeColumns = useMemo(
-    () => selectedCbQuery?.targetingAttributeColumns ?? [],
-    [selectedCbQuery],
+  const attributeSchema = useAttributeSchema(false);
+  const eligibleAttributes = useMemo(
+    () =>
+      getEligibleContextualAttributes(
+        selectedCbQuery?.targetingAttributeColumns,
+        attributeSchema,
+      ),
+    [selectedCbQuery, attributeSchema],
   );
   const watchedContextualAttributes = form.watch("contextualAttributes");
   const selectedContextualAttributes = useMemo(
@@ -63,21 +70,13 @@ export default function ContextualBanditAnalysisFields({
     [watchedContextualAttributes],
   );
 
+  const seededQueryIdRef = useRef<string | undefined>(undefined);
   useEffect(() => {
     if (!selectedCbQuery) return;
-    const valid = selectedContextualAttributes.filter((a) =>
-      queryAttributeColumns.includes(a),
-    );
-    const next = valid.length > 0 ? valid : queryAttributeColumns;
-    if (!isEqual(next, selectedContextualAttributes)) {
-      form.setValue("contextualAttributes", next);
-    }
-  }, [
-    selectedCbQuery,
-    queryAttributeColumns,
-    selectedContextualAttributes,
-    form,
-  ]);
+    if (seededQueryIdRef.current === exposureQueryId) return;
+    seededQueryIdRef.current = exposureQueryId;
+    form.setValue("contextualAttributes", eligibleAttributes);
+  }, [selectedCbQuery, exposureQueryId, eligibleAttributes, form]);
 
   const settings = useOrgSettings();
 
@@ -170,21 +169,24 @@ export default function ContextualBanditAnalysisFields({
             )}
             {selectedCbQuery ? (
               <Box mt="3">
-                <MultiSelectField
-                  label="Contextual Attributes"
-                  value={selectedContextualAttributes}
-                  onChange={(v) => form.setValue("contextualAttributes", v)}
-                  options={queryAttributeColumns.map((a) => ({
-                    label: a,
-                    value: a,
-                  }))}
-                  placeholder="Select contextual attributes…"
-                  helpText="Attributes this Bandit uses as context. Defaults to all query attributes; select a subset to narrow it."
-                />
-                {queryAttributeColumns.length === 0 && (
-                  <em className="text-muted">
-                    The selected query has no targeting attribute columns.
-                  </em>
+                {eligibleAttributes.length > 0 ? (
+                  <MultiSelectField
+                    label="Contextual Attributes"
+                    value={selectedContextualAttributes}
+                    onChange={(v) => form.setValue("contextualAttributes", v)}
+                    options={eligibleAttributes.map((a) => ({
+                      label: a,
+                      value: a,
+                    }))}
+                    placeholder="Select contextual attributes…"
+                    legacyLabelFormatting={false}
+                    helpText="Attributes this Bandit uses as context. Defaults to all query attributes; select a subset to narrow it."
+                  />
+                ) : (
+                  <HelperText status="warning">
+                    The selected query has no targeting attribute columns that
+                    are still valid organization attributes.
+                  </HelperText>
                 )}
               </Box>
             ) : null}

--- a/packages/front-end/components/ContextualBandit/ContextualBanditAnalysisFields.tsx
+++ b/packages/front-end/components/ContextualBandit/ContextualBanditAnalysisFields.tsx
@@ -5,6 +5,7 @@ import { Box, Separator } from "@radix-ui/themes";
 import SelectField from "@/components/Forms/SelectField";
 import MultiSelectField from "@/ui/MultiSelectField";
 import HelperText from "@/ui/HelperText";
+import Text from "@/ui/Text";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useAttributeSchema } from "@/services/features";
 import { useContextualBanditQueries } from "@/hooks/useContextualBanditQueries";
@@ -183,10 +184,15 @@ export default function ContextualBanditAnalysisFields({
                     helpText="Attributes this Bandit uses as context. Defaults to all query attributes; select a subset to narrow it."
                   />
                 ) : (
-                  <HelperText status="warning">
-                    The selected query has no targeting attribute columns that
-                    are still valid organization attributes.
-                  </HelperText>
+                  <>
+                    <Text weight="semibold" size="md">
+                      Contextual Attributes
+                    </Text>
+                    <HelperText status="warning">
+                      The selected query has no targeting attribute columns that
+                      are still valid organization attributes.
+                    </HelperText>
+                  </>
                 )}
               </Box>
             ) : null}

--- a/packages/front-end/components/ContextualBandit/ContextualBanditAnalysisFields.tsx
+++ b/packages/front-end/components/ContextualBandit/ContextualBanditAnalysisFields.tsx
@@ -1,7 +1,9 @@
 import { useFormContext } from "react-hook-form";
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { isEqual } from "lodash";
 import { Box, Separator } from "@radix-ui/themes";
 import SelectField from "@/components/Forms/SelectField";
+import MultiSelectField from "@/ui/MultiSelectField";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useContextualBanditQueries } from "@/hooks/useContextualBanditQueries";
 import AddEditContextualBanditQueryModal from "@/components/ContextualBandit/AddEditContextualBanditQueryModal";
@@ -50,6 +52,32 @@ export default function ContextualBanditAnalysisFields({
       form.setValue("exposureQueryId", cbQueries[0]?.id ?? "");
     }
   }, [cbQueries, exposureQueryId, form]);
+
+  const queryAttributeColumns = useMemo(
+    () => selectedCbQuery?.targetingAttributeColumns ?? [],
+    [selectedCbQuery],
+  );
+  const watchedContextualAttributes = form.watch("contextualAttributes");
+  const selectedContextualAttributes = useMemo(
+    () => (watchedContextualAttributes ?? []) as string[],
+    [watchedContextualAttributes],
+  );
+
+  useEffect(() => {
+    if (!selectedCbQuery) return;
+    const valid = selectedContextualAttributes.filter((a) =>
+      queryAttributeColumns.includes(a),
+    );
+    const next = valid.length > 0 ? valid : queryAttributeColumns;
+    if (!isEqual(next, selectedContextualAttributes)) {
+      form.setValue("contextualAttributes", next);
+    }
+  }, [
+    selectedCbQuery,
+    queryAttributeColumns,
+    selectedContextualAttributes,
+    form,
+  ]);
 
   const settings = useOrgSettings();
 
@@ -141,20 +169,22 @@ export default function ContextualBanditAnalysisFields({
               />
             )}
             {selectedCbQuery ? (
-              <Box mt="2">
-                <strong className="font-weight-semibold">
-                  Targeting Attributes:{" "}
-                </strong>
-                {(selectedCbQuery.targetingAttributeColumns ?? []).map(
-                  (d, i) => (
-                    <Fragment key={d}>
-                      {i ? ", " : ""}
-                      <code>{d}</code>
-                    </Fragment>
-                  ),
-                )}
-                {!(selectedCbQuery.targetingAttributeColumns ?? []).length && (
-                  <em className="text-muted">none</em>
+              <Box mt="3">
+                <MultiSelectField
+                  label="Contextual Attributes"
+                  value={selectedContextualAttributes}
+                  onChange={(v) => form.setValue("contextualAttributes", v)}
+                  options={queryAttributeColumns.map((a) => ({
+                    label: a,
+                    value: a,
+                  }))}
+                  placeholder="Select contextual attributes…"
+                  helpText="Attributes this Bandit uses as context. Defaults to all query attributes; select a subset to narrow it."
+                />
+                {queryAttributeColumns.length === 0 && (
+                  <em className="text-muted">
+                    The selected query has no targeting attribute columns.
+                  </em>
                 )}
               </Box>
             ) : null}

--- a/packages/front-end/components/ContextualBandit/ContextualBanditAnalysisMetricsModal.tsx
+++ b/packages/front-end/components/ContextualBandit/ContextualBanditAnalysisMetricsModal.tsx
@@ -274,14 +274,19 @@ export default function ContextualBanditAnalysisMetricsModal({
                 helpText="Attributes this Bandit uses as context. Defaults to all query attributes; select a subset to narrow it."
               />
             ) : (
-              <HelperText status="warning">
-                The selected query has no targeting attribute columns that are
-                still valid organization attributes.
-              </HelperText>
+              <Box mb="3">
+                <Text weight="semibold" size="md">
+                  Contextual Attributes
+                </Text>
+                <HelperText status="warning">
+                  The selected query has no targeting attribute columns that are
+                  still valid organization attributes.
+                </HelperText>
+              </Box>
             )
           ) : (
             <Box mb="3">
-              <Text weight="semibold" size="m">
+              <Text weight="semibold" size="md">
                 Contextual Attributes
               </Text>
               <Box mt="1">

--- a/packages/front-end/components/ContextualBandit/ContextualBanditAnalysisMetricsModal.tsx
+++ b/packages/front-end/components/ContextualBandit/ContextualBanditAnalysisMetricsModal.tsx
@@ -174,7 +174,6 @@ export default function ContextualBanditAnalysisMetricsModal({
           const query = contextualBanditQueries.find(
             (q) => q.id === data.exposureQueryId,
           );
-          const queryAttrs = query?.targetingAttributeColumns ?? [];
           const eligible = getEligibleContextualAttributes(
             query?.targetingAttributeColumns,
             attributeSchema,
@@ -192,7 +191,7 @@ export default function ContextualBanditAnalysisMetricsModal({
           if (
             !isDraft &&
             queryChanged &&
-            !contextualAttributes.some((a) => queryAttrs.includes(a))
+            !contextualAttributes.some((a) => eligible.includes(a))
           ) {
             throw new Error(
               `The selected query has no attributes in common with this Bandit's contextual attributes (${contextualAttributes.join(

--- a/packages/front-end/components/ContextualBandit/ContextualBanditAnalysisMetricsModal.tsx
+++ b/packages/front-end/components/ContextualBandit/ContextualBanditAnalysisMetricsModal.tsx
@@ -177,6 +177,19 @@ export default function ContextualBanditAnalysisMetricsModal({
               "Select at least one contextual attribute for this Contextual Bandit.",
             );
           }
+          const queryChanged =
+            data.exposureQueryId !== cb.contextualBanditQueryId;
+          if (
+            !isDraft &&
+            queryChanged &&
+            !contextualAttributes.some((a) => queryAttrs.includes(a))
+          ) {
+            throw new Error(
+              `The selected query has no attributes in common with this Bandit's contextual attributes (${contextualAttributes.join(
+                ", ",
+              )}). Choose a query that includes at least one of them.`,
+            );
+          }
 
           const includeConversionWindow =
             !disableBanditConversionWindow &&

--- a/packages/front-end/components/ContextualBandit/ContextualBanditAnalysisMetricsModal.tsx
+++ b/packages/front-end/components/ContextualBandit/ContextualBanditAnalysisMetricsModal.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useEffect, useMemo, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
+import { isEqual } from "lodash";
 import { ApiContextualBanditInterface } from "shared/validators";
 import { getScopedSettings } from "shared/settings";
 import { Box } from "@radix-ui/themes";
@@ -10,6 +11,7 @@ import useOrgSettings from "@/hooks/useOrgSettings";
 import { useContextualBanditQueries } from "@/hooks/useContextualBanditQueries";
 import ModalStandard from "@/ui/Modal/Patterns/ModalStandard";
 import SelectField from "@/components/Forms/SelectField";
+import MultiSelectField from "@/ui/MultiSelectField";
 import BanditSettings from "@/components/GeneralSettings/BanditSettings";
 import ContextualBanditDecisionMetricSettings, {
   conversionWindowFormValuesFromMetricWindow,
@@ -19,6 +21,7 @@ import ContextualBanditDecisionMetricSettings, {
 type FormValues = {
   datasource: string;
   exposureQueryId: string;
+  contextualAttributes: string[];
   decisionMetric: string;
   banditScheduleValue: number;
   banditScheduleUnit: "hours" | "days";
@@ -84,6 +87,7 @@ export default function ContextualBanditAnalysisMetricsModal({
     defaultValues: {
       datasource: cb.datasource ?? "",
       exposureQueryId: cb.contextualBanditQueryId ?? "",
+      contextualAttributes: cb.contextualAttributes ?? [],
       decisionMetric: cb.decisionMetric ?? "",
       banditScheduleValue:
         cb.scheduleValue ?? scopedSettings.banditScheduleValue.value,
@@ -113,8 +117,19 @@ export default function ContextualBanditAnalysisMetricsModal({
     [contextualBanditQueries, watchedQueryId],
   );
 
-  const derivedContextualAttributes =
-    selectedQuery?.targetingAttributeColumns ?? [];
+  const isDraft = cb.status === "draft";
+  const queryAttributeColumns = useMemo(
+    () => selectedQuery?.targetingAttributeColumns ?? [],
+    [selectedQuery],
+  );
+  const watchedContextualAttributes = form.watch("contextualAttributes");
+  const selectedContextualAttributes = useMemo(
+    () => watchedContextualAttributes ?? [],
+    [watchedContextualAttributes],
+  );
+  const effectiveContextualAttributes = selectedContextualAttributes.filter(
+    (a) => queryAttributeColumns.includes(a),
+  );
 
   useEffect(() => {
     if (!contextualBanditQueries.length) return;
@@ -122,6 +137,23 @@ export default function ContextualBanditAnalysisMetricsModal({
       form.setValue("exposureQueryId", contextualBanditQueries[0]?.id ?? "");
     }
   }, [contextualBanditQueries, watchedQueryId, form]);
+
+  useEffect(() => {
+    if (!isDraft || !selectedQuery) return;
+    const valid = selectedContextualAttributes.filter((a) =>
+      queryAttributeColumns.includes(a),
+    );
+    const next = valid.length > 0 ? valid : queryAttributeColumns;
+    if (!isEqual(next, selectedContextualAttributes)) {
+      form.setValue("contextualAttributes", next);
+    }
+  }, [
+    isDraft,
+    selectedQuery,
+    queryAttributeColumns,
+    selectedContextualAttributes,
+    form,
+  ]);
 
   return (
     <FormProvider {...form}>
@@ -136,8 +168,15 @@ export default function ContextualBanditAnalysisMetricsModal({
           const query = contextualBanditQueries.find(
             (q) => q.id === data.exposureQueryId,
           );
-          const contextualAttributes =
-            query?.targetingAttributeColumns ?? cb.contextualAttributes;
+          const queryAttrs = query?.targetingAttributeColumns ?? [];
+          const contextualAttributes = isDraft
+            ? data.contextualAttributes.filter((a) => queryAttrs.includes(a))
+            : cb.contextualAttributes;
+          if (isDraft && contextualAttributes.length === 0) {
+            throw new Error(
+              "Select at least one contextual attribute for this Contextual Bandit.",
+            );
+          }
 
           const includeConversionWindow =
             !disableBanditConversionWindow &&
@@ -198,26 +237,39 @@ export default function ContextualBanditAnalysisMetricsModal({
         ) : null}
 
         {selectedQuery ? (
-          <div className="form-group">
-            <label className="font-weight-bold">Contextual Attributes</label>
-            <div>
-              {derivedContextualAttributes.length > 0 ? (
-                derivedContextualAttributes.map((attr, i) => (
-                  <Fragment key={attr}>
-                    {i > 0 ? ", " : ""}
-                    <code>{attr}</code>
-                  </Fragment>
-                ))
-              ) : (
-                <em className="text-muted">
-                  None — add targeting attribute columns to the selected query.
-                </em>
-              )}
+          isDraft ? (
+            <MultiSelectField
+              label="Contextual Attributes"
+              value={selectedContextualAttributes}
+              onChange={(v) => form.setValue("contextualAttributes", v)}
+              options={queryAttributeColumns.map((a) => ({
+                label: a,
+                value: a,
+              }))}
+              placeholder="Select contextual attributes…"
+              helpText="Attributes this Bandit uses as context. Defaults to all query attributes; select a subset to narrow it."
+            />
+          ) : (
+            <div className="form-group">
+              <label className="font-weight-bold">Contextual Attributes</label>
+              <div>
+                {effectiveContextualAttributes.length > 0 ? (
+                  effectiveContextualAttributes.map((attr, i) => (
+                    <Fragment key={attr}>
+                      {i > 0 ? ", " : ""}
+                      <code>{attr}</code>
+                    </Fragment>
+                  ))
+                ) : (
+                  <em className="text-muted">None</em>
+                )}
+              </div>
+              <small className="form-text text-muted">
+                Contextual attributes can only be changed while the Bandit is a
+                draft.
+              </small>
             </div>
-            <small className="form-text text-muted">
-              Derived from the selected Contextual Bandit query.
-            </small>
-          </div>
+          )
         ) : null}
 
         <hr className="my-4" />

--- a/packages/front-end/components/ContextualBandit/ContextualBanditAnalysisMetricsModal.tsx
+++ b/packages/front-end/components/ContextualBandit/ContextualBanditAnalysisMetricsModal.tsx
@@ -281,7 +281,7 @@ export default function ContextualBanditAnalysisMetricsModal({
             )
           ) : (
             <Box mb="3">
-              <Text weight="semibold" size="sm">
+              <Text weight="semibold" size="m">
                 Contextual Attributes
               </Text>
               <Box mt="1">

--- a/packages/front-end/components/ContextualBandit/ContextualBanditAnalysisMetricsModal.tsx
+++ b/packages/front-end/components/ContextualBandit/ContextualBanditAnalysisMetricsModal.tsx
@@ -1,17 +1,23 @@
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
-import { isEqual } from "lodash";
-import { ApiContextualBanditInterface } from "shared/validators";
+import {
+  ApiContextualBanditInterface,
+  getEffectiveContextualAttributes,
+  getEligibleContextualAttributes,
+} from "shared/validators";
 import { getScopedSettings } from "shared/settings";
 import { Box } from "@radix-ui/themes";
 import { useAuth } from "@/services/auth";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useUser } from "@/services/UserContext";
 import useOrgSettings from "@/hooks/useOrgSettings";
+import { useAttributeSchema } from "@/services/features";
 import { useContextualBanditQueries } from "@/hooks/useContextualBanditQueries";
 import ModalStandard from "@/ui/Modal/Patterns/ModalStandard";
 import SelectField from "@/components/Forms/SelectField";
 import MultiSelectField from "@/ui/MultiSelectField";
+import HelperText from "@/ui/HelperText";
+import Text from "@/ui/Text";
 import BanditSettings from "@/components/GeneralSettings/BanditSettings";
 import ContextualBanditDecisionMetricSettings, {
   conversionWindowFormValuesFromMetricWindow,
@@ -118,17 +124,24 @@ export default function ContextualBanditAnalysisMetricsModal({
   );
 
   const isDraft = cb.status === "draft";
-  const queryAttributeColumns = useMemo(
-    () => selectedQuery?.targetingAttributeColumns ?? [],
-    [selectedQuery],
+  const attributeSchema = useAttributeSchema(false);
+  const eligibleAttributes = useMemo(
+    () =>
+      getEligibleContextualAttributes(
+        selectedQuery?.targetingAttributeColumns,
+        attributeSchema,
+      ),
+    [selectedQuery, attributeSchema],
   );
   const watchedContextualAttributes = form.watch("contextualAttributes");
   const selectedContextualAttributes = useMemo(
     () => watchedContextualAttributes ?? [],
     [watchedContextualAttributes],
   );
-  const effectiveContextualAttributes = selectedContextualAttributes.filter(
-    (a) => queryAttributeColumns.includes(a),
+  const effectiveContextualAttributes = getEffectiveContextualAttributes(
+    selectedContextualAttributes,
+    selectedQuery?.targetingAttributeColumns,
+    attributeSchema,
   );
 
   useEffect(() => {
@@ -138,22 +151,15 @@ export default function ContextualBanditAnalysisMetricsModal({
     }
   }, [contextualBanditQueries, watchedQueryId, form]);
 
+  const seededQueryIdRef = useRef<string | undefined>(
+    cb.contextualBanditQueryId,
+  );
   useEffect(() => {
     if (!isDraft || !selectedQuery) return;
-    const valid = selectedContextualAttributes.filter((a) =>
-      queryAttributeColumns.includes(a),
-    );
-    const next = valid.length > 0 ? valid : queryAttributeColumns;
-    if (!isEqual(next, selectedContextualAttributes)) {
-      form.setValue("contextualAttributes", next);
-    }
-  }, [
-    isDraft,
-    selectedQuery,
-    queryAttributeColumns,
-    selectedContextualAttributes,
-    form,
-  ]);
+    if (seededQueryIdRef.current === watchedQueryId) return;
+    seededQueryIdRef.current = watchedQueryId;
+    form.setValue("contextualAttributes", eligibleAttributes);
+  }, [isDraft, selectedQuery, watchedQueryId, eligibleAttributes, form]);
 
   return (
     <FormProvider {...form}>
@@ -169,8 +175,12 @@ export default function ContextualBanditAnalysisMetricsModal({
             (q) => q.id === data.exposureQueryId,
           );
           const queryAttrs = query?.targetingAttributeColumns ?? [];
+          const eligible = getEligibleContextualAttributes(
+            query?.targetingAttributeColumns,
+            attributeSchema,
+          );
           const contextualAttributes = isDraft
-            ? data.contextualAttributes.filter((a) => queryAttrs.includes(a))
+            ? data.contextualAttributes.filter((a) => eligible.includes(a))
             : cb.contextualAttributes;
           if (isDraft && contextualAttributes.length === 0) {
             throw new Error(
@@ -251,21 +261,31 @@ export default function ContextualBanditAnalysisMetricsModal({
 
         {selectedQuery ? (
           isDraft ? (
-            <MultiSelectField
-              label="Contextual Attributes"
-              value={selectedContextualAttributes}
-              onChange={(v) => form.setValue("contextualAttributes", v)}
-              options={queryAttributeColumns.map((a) => ({
-                label: a,
-                value: a,
-              }))}
-              placeholder="Select contextual attributes…"
-              helpText="Attributes this Bandit uses as context. Defaults to all query attributes; select a subset to narrow it."
-            />
+            eligibleAttributes.length > 0 ? (
+              <MultiSelectField
+                label="Contextual Attributes"
+                value={selectedContextualAttributes}
+                onChange={(v) => form.setValue("contextualAttributes", v)}
+                options={eligibleAttributes.map((a) => ({
+                  label: a,
+                  value: a,
+                }))}
+                placeholder="Select contextual attributes…"
+                legacyLabelFormatting={false}
+                helpText="Attributes this Bandit uses as context. Defaults to all query attributes; select a subset to narrow it."
+              />
+            ) : (
+              <HelperText status="warning">
+                The selected query has no targeting attribute columns that are
+                still valid organization attributes.
+              </HelperText>
+            )
           ) : (
-            <div className="form-group">
-              <label className="font-weight-bold">Contextual Attributes</label>
-              <div>
+            <Box mb="3">
+              <Text weight="semibold" size="sm">
+                Contextual Attributes
+              </Text>
+              <Box mt="1">
                 {effectiveContextualAttributes.length > 0 ? (
                   effectiveContextualAttributes.map((attr, i) => (
                     <Fragment key={attr}>
@@ -274,14 +294,14 @@ export default function ContextualBanditAnalysisMetricsModal({
                     </Fragment>
                   ))
                 ) : (
-                  <em className="text-muted">None</em>
+                  <Text color="text-low">None</Text>
                 )}
-              </div>
-              <small className="form-text text-muted">
+              </Box>
+              <HelperText status="info">
                 Contextual attributes can only be changed while the Bandit is a
                 draft.
-              </small>
-            </div>
+              </HelperText>
+            </Box>
           )
         ) : null}
 

--- a/packages/front-end/components/ContextualBandit/ContextualBanditDetailPage.tsx
+++ b/packages/front-end/components/ContextualBandit/ContextualBanditDetailPage.tsx
@@ -198,7 +198,7 @@ export default function ContextualBanditDetailPage({
     return globalAttributes.filter((a) => contextual.has(a));
   }, [cb.condition, cb.contextualAttributes, attributeMap]);
 
-  const globalAttributeSchema = useAttributeSchema(false, cb.project);
+  const globalAttributeSchema = useAttributeSchema(false);
   const { effectiveContextualAttributes, droppedContextualAttributes } =
     useMemo(() => {
       const queryAttrs =

--- a/packages/front-end/components/ContextualBandit/ContextualBanditDetailPage.tsx
+++ b/packages/front-end/components/ContextualBandit/ContextualBanditDetailPage.tsx
@@ -1,9 +1,13 @@
-import { ReactNode, useMemo, useState } from "react";
+import { Fragment, ReactNode, useMemo, useState } from "react";
 import { Box, Flex, Grid, IconButton } from "@radix-ui/themes";
 import { BsThreeDotsVertical } from "react-icons/bs";
 import { date } from "shared/dates";
 import { getMetricLink } from "shared/experiments";
-import { ApiContextualBanditInterface } from "shared/validators";
+import {
+  ApiContextualBanditInterface,
+  getDroppedContextualAttributes,
+  getEffectiveContextualAttributes,
+} from "shared/validators";
 import {
   ExperimentInterfaceStringDates,
   LinkedFeatureInfo,
@@ -201,17 +205,19 @@ export default function ContextualBanditDetailPage({
   const globalAttributeSchema = useAttributeSchema(false);
   const { effectiveContextualAttributes, droppedContextualAttributes } =
     useMemo(() => {
-      const queryAttrs =
-        contextualBanditQueriesMap.get(cb.contextualBanditQueryId)
-          ?.targetingAttributeColumns ?? [];
-      const querySet = new Set(queryAttrs);
-      const globalSet = new Set(globalAttributeSchema.map((a) => a.property));
+      const queryAttrs = contextualBanditQueriesMap.get(
+        cb.contextualBanditQueryId,
+      )?.targetingAttributeColumns;
       return {
-        effectiveContextualAttributes: cb.contextualAttributes.filter(
-          (a) => querySet.has(a) && globalSet.has(a),
+        effectiveContextualAttributes: getEffectiveContextualAttributes(
+          cb.contextualAttributes,
+          queryAttrs,
+          globalAttributeSchema,
         ),
-        droppedContextualAttributes: cb.contextualAttributes.filter(
-          (a) => !querySet.has(a) || !globalSet.has(a),
+        droppedContextualAttributes: getDroppedContextualAttributes(
+          cb.contextualAttributes,
+          queryAttrs,
+          globalAttributeSchema,
         ),
       };
     }, [
@@ -622,7 +628,12 @@ export default function ContextualBanditDetailPage({
                 </DetailSectionColumn>
                 <DetailSectionColumn label="Contextual Attributes">
                   {effectiveContextualAttributes.length
-                    ? effectiveContextualAttributes.join(", ")
+                    ? effectiveContextualAttributes.map((a, i) => (
+                        <Fragment key={a}>
+                          {i ? ", " : ""}
+                          <code>{a}</code>
+                        </Fragment>
+                      ))
                     : "—"}
                 </DetailSectionColumn>
               </Grid>

--- a/packages/front-end/components/ContextualBandit/ContextualBanditDetailPage.tsx
+++ b/packages/front-end/components/ContextualBandit/ContextualBanditDetailPage.tsx
@@ -12,7 +12,11 @@ import {
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useAuth } from "@/services/auth";
 import { contextualBanditStatusIndicatorData } from "@/services/contextualBandits";
-import { jsonToConds, useAttributeMap } from "@/services/features";
+import {
+  jsonToConds,
+  useAttributeMap,
+  useAttributeSchema,
+} from "@/services/features";
 import ExperimentStatusIndicator from "@/components/Experiment/TabbedPage/ExperimentStatusIndicator";
 import Frame from "@/ui/Frame";
 import Heading from "@/ui/Heading";
@@ -193,6 +197,29 @@ export default function ContextualBanditDetailPage({
 
     return globalAttributes.filter((a) => contextual.has(a));
   }, [cb.condition, cb.contextualAttributes, attributeMap]);
+
+  const globalAttributeSchema = useAttributeSchema(false, cb.project);
+  const { effectiveContextualAttributes, droppedContextualAttributes } =
+    useMemo(() => {
+      const queryAttrs =
+        contextualBanditQueriesMap.get(cb.contextualBanditQueryId)
+          ?.targetingAttributeColumns ?? [];
+      const querySet = new Set(queryAttrs);
+      const globalSet = new Set(globalAttributeSchema.map((a) => a.property));
+      return {
+        effectiveContextualAttributes: cb.contextualAttributes.filter(
+          (a) => querySet.has(a) && globalSet.has(a),
+        ),
+        droppedContextualAttributes: cb.contextualAttributes.filter(
+          (a) => !querySet.has(a) || !globalSet.has(a),
+        ),
+      };
+    }, [
+      cb.contextualAttributes,
+      cb.contextualBanditQueryId,
+      contextualBanditQueriesMap,
+      globalAttributeSchema,
+    ]);
 
   const formatExploratoryStage = (
     value?: number,
@@ -594,8 +621,8 @@ export default function ContextualBanditDetailPage({
                   {exposureQueryName || <em>none</em>}
                 </DetailSectionColumn>
                 <DetailSectionColumn label="Contextual Attributes">
-                  {cb.contextualAttributes.length
-                    ? cb.contextualAttributes.join(", ")
+                  {effectiveContextualAttributes.length
+                    ? effectiveContextualAttributes.join(", ")
                     : "—"}
                 </DetailSectionColumn>
               </Grid>
@@ -629,6 +656,22 @@ export default function ContextualBanditDetailPage({
                   {formatUpdateCadence(cb.scheduleValue, cb.scheduleUnit)}
                 </DetailSectionColumn>
               </Grid>
+              {droppedContextualAttributes.length > 0 && (
+                <Callout status="warning" mt="4">
+                  <Flex direction="column" gap="2">
+                    <Text as="span">
+                      These attributes were removed from the Contextual Bandit
+                      query or your organization&apos;s attributes and are no
+                      longer used. Edit the analysis settings to update them.
+                    </Text>
+                    <Flex align="center" gap="1" wrap="wrap">
+                      {droppedContextualAttributes.map((a) => (
+                        <AttributeBadge key={a} attributeId={a} />
+                      ))}
+                    </Flex>
+                  </Flex>
+                </Callout>
+              )}
             </OverviewSection>
           </Box>
         </TabsContent>

--- a/packages/front-end/enterprise/components/ContextualBandit/ContextualBanditForm.tsx
+++ b/packages/front-end/enterprise/components/ContextualBandit/ContextualBanditForm.tsx
@@ -70,6 +70,7 @@ type ContextualBanditFormValues = Partial<ExperimentInterfaceStringDates> &
     >
   > & {
     decisionMetric?: string;
+    contextualAttributes?: string[];
   };
 
 export type ContextualBanditFormProps = {
@@ -159,6 +160,7 @@ const ContextualBanditForm: FC<ContextualBanditFormProps> = ({
       name: initialValue?.name || "",
       hashAttribute: initialHashAttribute,
       decisionMetric: initialValue?.decisionMetric ?? "",
+      contextualAttributes: initialValue?.contextualAttributes ?? [],
       tags: initialValue?.tags || [],
       targetURLRegex: initialValue?.targetURLRegex || "",
       description: initialValue?.description || "",
@@ -393,9 +395,19 @@ const ContextualBanditForm: FC<ContextualBanditFormProps> = ({
       }
     }
 
-    const submitContextualAttributes =
-      cbQueries.find((q) => q.id === data.exposureQueryId)
-        ?.targetingAttributeColumns ?? [];
+    const queryAttributeColumns =
+      selectedCbQuery.targetingAttributeColumns ?? [];
+    const submitContextualAttributes = (
+      data.contextualAttributes?.length
+        ? data.contextualAttributes
+        : queryAttributeColumns
+    ).filter((a) => queryAttributeColumns.includes(a));
+    if (submitContextualAttributes.length === 0) {
+      setStep(1);
+      throw new Error(
+        "Select at least one contextual attribute for this Contextual Bandit.",
+      );
+    }
 
     const banditConversionWindowValue =
       shouldIncludeConversionWindow && data.banditConversionWindowValue

--- a/packages/front-end/enterprise/components/ContextualBandit/ContextualBanditForm.tsx
+++ b/packages/front-end/enterprise/components/ContextualBandit/ContextualBanditForm.tsx
@@ -9,6 +9,7 @@ import {
 import {
   ApiContextualBanditInterface,
   ApiCreateContextualBanditBody,
+  getEligibleContextualAttributes,
 } from "shared/validators";
 import { useRouter } from "next/router";
 import { datetime, getValidDate } from "shared/dates";
@@ -395,13 +396,13 @@ const ContextualBanditForm: FC<ContextualBanditFormProps> = ({
       }
     }
 
-    const queryAttributeColumns =
-      selectedCbQuery.targetingAttributeColumns ?? [];
-    const submitContextualAttributes = (
-      data.contextualAttributes?.length
-        ? data.contextualAttributes
-        : queryAttributeColumns
-    ).filter((a) => queryAttributeColumns.includes(a));
+    const eligibleAttributes = getEligibleContextualAttributes(
+      selectedCbQuery.targetingAttributeColumns,
+      allAttributesSchema,
+    );
+    const submitContextualAttributes = (data.contextualAttributes ?? []).filter(
+      (a) => eligibleAttributes.includes(a),
+    );
     if (submitContextualAttributes.length === 0) {
       setStep(1);
       throw new Error(

--- a/packages/shared/src/validators/contextual-bandit.ts
+++ b/packages/shared/src/validators/contextual-bandit.ts
@@ -60,7 +60,6 @@ export const contextualBanditValidator = baseSchema
     banditVersion: z.number().int().nonnegative(),
 
     contextualAttributes: z.array(z.string()),
-    targetingAttributeColumns: z.array(z.string()).optional(),
 
     decisionMetric: z.string().optional(),
     minUsersPerLeaf: z.number().int().positive(),

--- a/packages/shared/src/validators/exposure-query-targeting-attribute-columns.ts
+++ b/packages/shared/src/validators/exposure-query-targeting-attribute-columns.ts
@@ -150,3 +150,47 @@ export function assertExposureQueriesTargetingAttributeColumnsValid(
     ),
   );
 }
+
+export function getEligibleContextualAttributes(
+  queryAttributeColumns: string[] | undefined,
+  attributeSchema: SDKAttributeSchema | undefined,
+): string[] {
+  const allowed = getAllowedTargetingAttributePropertyNames(attributeSchema);
+  return (queryAttributeColumns ?? []).filter((a) => allowed.has(a));
+}
+
+export function getEffectiveContextualAttributes(
+  selectedAttributes: string[] | undefined,
+  queryAttributeColumns: string[] | undefined,
+  attributeSchema: SDKAttributeSchema | undefined,
+): string[] {
+  const selected = new Set(selectedAttributes ?? []);
+  return getEligibleContextualAttributes(
+    queryAttributeColumns,
+    attributeSchema,
+  ).filter((a) => selected.has(a));
+}
+
+export function getDroppedContextualAttributes(
+  selectedAttributes: string[] | undefined,
+  queryAttributeColumns: string[] | undefined,
+  attributeSchema: SDKAttributeSchema | undefined,
+): string[] {
+  const eligible = new Set(
+    getEligibleContextualAttributes(queryAttributeColumns, attributeSchema),
+  );
+  return (selectedAttributes ?? []).filter((a) => !eligible.has(a));
+}
+
+export function assertContextualAttributesValid(
+  attributeSchema: SDKAttributeSchema | undefined,
+  cb: { id: string; name: string; contextualAttributes: string[] },
+): void {
+  assertExposureQueriesTargetingAttributeColumnsValid(attributeSchema, [
+    {
+      id: cb.id,
+      name: cb.name,
+      targetingAttributeColumns: cb.contextualAttributes,
+    },
+  ]);
+}


### PR DESCRIPTION
### Problem:
- We have an inconsistent use of the targeting attributes for contextual bandits

4 Spots:
- CBAQ -> columns in the sql query
- CBAQ -> targeting attribute columns (selected under query)
    - an invariant keeps the CBAQ columns and targetingAttribute consistent, so this represent what the "live" attributes are 
- CB -> contextual attributes
- CB -> targetingAttributeColumns

Currently, the snapshot builder (what we input in the stats engine) - uses `cbQuery.targetingAttributeColumns` and the CB detail page uses `cb.contextualAttributes` - therefore, modifying the CBAQ modifies what the stats engine outputs whilst the CB detail page remains the same.

### Changes:
**Backend:**
    - The snapshots uses an intersection of the `CB.contextualAttributes`, `CBAQ.targetingAttributeColumns` and global org attributes
        - deleting an attribute from the query will drop it from the intersection
        - if no attributes are in the intersection, then the snapshot will throw an error and fail
    - Removed redundant `targetingAttributeColumns` from the CB model, `contextualAttributes` becomes the single source of truth
**Frontend:**
    - Added multi-select (default all) on CB creation 
    
<img width="803" height="736" alt="image" src="https://github.com/user-attachments/assets/f140c0e2-9556-4a6a-820b-e5862cec66e7" />

    - When CB is in draft mode, users can edit the attribute subset, but it's blocked once the CB is running 
    
<img width="810" height="718" alt="image" src="https://github.com/user-attachments/assets/7af0e2c7-4dac-46ab-8090-7a6e7a4a0dc7" />

    - Warning message when an attribute was removed from the query or global schema after the CB started running 
<img width="787" height="703" alt="image" src="https://github.com/user-attachments/assets/f613c332-6d2d-4232-a7ec-9f43cfd972e1" />

### Testing

1. Create a CBAQ with several targeting attribute columns (e.g. `country`, `device`, `plan_tier`).
2. Create a Contextual Bandit on that query and confirm the new **Contextual Attributes** multi-select defaults to all query attributes; narrow it to a subset (e.g. `country`, `device`) and save.
3. Start the bandit and run a snapshot; confirm the analysis uses only the selected subset.
4. Edit the CBAQ and remove one of the selected attributes (e.g. `device`). On the CB detail page, confirm the **Contextual Attributes** value shows only the still-valid attributes and a warning callout lists the dropped one. Confirm the next snapshot uses the reduced set.
5. Delete a still-selected attribute from Settings → Attributes and confirm the same drift callout behavior.
6. Open "Edit Analysis & Metrics" on a **draft** CB and confirm attributes are editable; open it on a **running** CB and confirm they are read-only and unchanged on save.

### Screenshots

<!-- Create form multi-select, detail-page drift callout + effective set, and the draft vs. running edit modal. -->