### PR TITLE
contextual model selection

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -16081,6 +16081,9 @@ paths:
                           sse_trajectory:
                             type: array
                             items: {}
+                          bic_trajectory:
+                            type: array
+                            items: {}
                         required:
                           - attributes
                           - responses

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -16081,6 +16081,9 @@ paths:
                           sse_trajectory:
                             type: array
                             items: {}
+                          bic_trajectory:
+                            type: array
+                            items: {}
                         required:
                           - attributes
                           - responses

--- a/packages/back-end/src/api/contextual-bandits/getResults.ts
+++ b/packages/back-end/src/api/contextual-bandits/getResults.ts
@@ -42,6 +42,7 @@ export const getContextualBanditResults = createApiRequestHandler(
           leaf_map: contextualBanditSnapshot.leaf_map,
           leaf_stats: contextualBanditSnapshot.leaf_stats,
           sse_trajectory: contextualBanditSnapshot.sse_trajectory,
+          bic_trajectory: contextualBanditSnapshot.bic_trajectory,
         }
       : null,
     overallWeights,

--- a/packages/back-end/src/enterprise/services/contextualBandits.ts
+++ b/packages/back-end/src/enterprise/services/contextualBandits.ts
@@ -818,6 +818,7 @@ export async function getContextualBanditResultsForUi(
         leaf_map: latestEvent.leaf_map,
         leaf_stats: latestEvent.leaf_stats,
         sse_trajectory: latestEvent.sse_trajectory,
+        bic_trajectory: latestEvent.bic_trajectory,
       }
     : null;
 
@@ -1063,6 +1064,7 @@ export async function persistContextualBanditEvent(
     leaf_map: result.leaf_map,
     leaf_stats: result.leaf_stats,
     sse_trajectory: result.sse_trajectory,
+    bic_trajectory: result.bic_trajectory,
     weightsWereUpdated,
     ...(result.srm ? { degreesOfFreedom: result.srm.degreesOfFreedom } : {}),
     // Store the seed for historical tracking

--- a/packages/shared/src/validators/contextual-bandit-event.ts
+++ b/packages/shared/src/validators/contextual-bandit-event.ts
@@ -33,9 +33,22 @@ export type ContextualLeafStatsEntryInterface = z.infer<
 export const contextualSseTrajectoryEntryValidator = z.object({
   numSplits: z.number().int().nonnegative(),
   totalSse: z.number(),
+  /** Per-variation SSE at this stage; sums to `totalSse`. */
+  ssePerVariation: z.array(z.number()),
 });
 export type ContextualSseTrajectoryEntryInterface = z.infer<
   typeof contextualSseTrajectoryEntryValidator
+>;
+
+/** BIC model-selection statistic for one greedy tree split (observability only). */
+export const contextualBicTrajectoryEntryValidator = z.object({
+  numSplits: z.number().int().nonnegative(),
+  logLikelihoodRatio: z.number(),
+  penalty: z.number(),
+  deltaBic: z.number(),
+});
+export type ContextualBicTrajectoryEntryInterface = z.infer<
+  typeof contextualBicTrajectoryEntryValidator
 >;
 
 /** Mirrors gbstats `ContextualBanditResponse`. */
@@ -67,6 +80,7 @@ export const contextualBanditEventValidator = baseSchema
     leaf_map: z.array(contextualLeafMapEntryValidator).optional(),
     leaf_stats: z.array(contextualLeafStatsEntryValidator).optional(),
     sse_trajectory: z.array(contextualSseTrajectoryEntryValidator).optional(),
+    bic_trajectory: z.array(contextualBicTrajectoryEntryValidator).optional(),
     weightsWereUpdated: z.boolean(),
     degreesOfFreedom: z.number().int().nonnegative().optional(),
     // The seed that was applied to the CB when this event was persisted.

--- a/packages/shared/src/validators/contextual-bandit-event.ts
+++ b/packages/shared/src/validators/contextual-bandit-event.ts
@@ -33,8 +33,7 @@ export type ContextualLeafStatsEntryInterface = z.infer<
 export const contextualSseTrajectoryEntryValidator = z.object({
   numSplits: z.number().int().nonnegative(),
   totalSse: z.number(),
-  /** Per-variation SSE at this stage; sums to `totalSse`. */
-  ssePerVariation: z.array(z.number()),
+  ssePerVariation: z.array(z.number()).optional(),
 });
 export type ContextualSseTrajectoryEntryInterface = z.infer<
   typeof contextualSseTrajectoryEntryValidator

--- a/packages/shared/src/validators/contextual-bandit.ts
+++ b/packages/shared/src/validators/contextual-bandit.ts
@@ -482,6 +482,7 @@ export const getContextualBanditResultsValidator = {
           leaf_map: z.array(z.unknown()).optional(),
           leaf_stats: z.array(z.unknown()).optional(),
           sse_trajectory: z.array(z.unknown()).optional(),
+          bic_trajectory: z.array(z.unknown()).optional(),
         })
         .nullable(),
       overallWeights: z

--- a/packages/shared/test/contextual-bandit-results.test.ts
+++ b/packages/shared/test/contextual-bandit-results.test.ts
@@ -68,8 +68,8 @@ const snapshot: ContextualBanditSnapshot = {
     },
   ],
   sse_trajectory: [
-    { numSplits: 0, totalSse: 200 },
-    { numSplits: 1, totalSse: 150 },
+    { numSplits: 0, totalSse: 200, ssePerVariation: [120, 80] },
+    { numSplits: 1, totalSse: 150, ssePerVariation: [90, 60] },
   ],
 };
 

--- a/packages/shared/types/stats.d.ts
+++ b/packages/shared/types/stats.d.ts
@@ -231,10 +231,9 @@ export type ContextualSseTrajectoryEntry = {
   /** Total SSE summed across every leaf of the tree at this stage. */
   totalSse: number;
   /**
-   * Per-variation SSE at this stage (positional by variation), summing to
-   * `totalSse`.
+   * Per-variation SSE at this stage, summing to `totalSse`.
    */
-  ssePerVariation: number[];
+  ssePerVariation?: number[];
 };
 
 /**

--- a/packages/shared/types/stats.d.ts
+++ b/packages/shared/types/stats.d.ts
@@ -230,6 +230,29 @@ export type ContextualSseTrajectoryEntry = {
   numSplits: number;
   /** Total SSE summed across every leaf of the tree at this stage. */
   totalSse: number;
+  /**
+   * Per-variation SSE at this stage (positional by variation), summing to
+   * `totalSse`.
+   */
+  ssePerVariation: number[];
+};
+
+/**
+ * BIC model-selection statistic for one greedy regression-tree split, derived
+ * from the per-(split, variation) SSE trajectory.
+ */
+export type ContextualBicTrajectoryEntry = {
+  /** Number of splits after applying this split (its resulting stage; >= 1). */
+  numSplits: number;
+  /**
+   * Likelihood-ratio statistic for the split:
+   * `sum_v N_v * ln(SSE_before_v / SSE_after_v)`.
+   */
+  logLikelihoodRatio: number;
+  /** BIC complexity penalty `K * ln(N)` for the split's K new parameters. */
+  penalty: number;
+  /** `penalty - logLikelihoodRatio`; a negative value favors keeping the split. */
+  deltaBic: number;
 };
 
 /** Full contextual bandit output for a decision-metric run (mirrors gbstats `ContextualBanditResult`). */
@@ -239,6 +262,7 @@ export type ContextualBanditSnapshot = {
   leaf_map?: ContextualLeafMapEntry[];
   leaf_stats?: ContextualLeafStatsEntry[];
   sse_trajectory?: ContextualSseTrajectoryEntry[];
+  bic_trajectory?: ContextualBicTrajectoryEntry[];
 };
 
 export type MultipleExperimentMetricAnalysis = {

--- a/packages/shared/types/stats.d.ts
+++ b/packages/shared/types/stats.d.ts
@@ -222,8 +222,8 @@ export type ContextualLeafStatsEntry = {
 
 /**
  * Total within-tree SSE captured at each stage of greedy regression-tree
- * growth: index 0 is the root (before the first split), the next entry is the
- * total SSE after the first split, then after the second split, etc.
+ * growth: index 0 is the root (before the first split), the next entry is
+ * total SSE after the first split, etc.
  */
 export type ContextualSseTrajectoryEntry = {
   /** Number of splits applied so far. 0 = root, before the first split. */
@@ -242,14 +242,9 @@ export type ContextualSseTrajectoryEntry = {
  * from the per-(split, variation) SSE trajectory.
  */
 export type ContextualBicTrajectoryEntry = {
-  /** Number of splits after applying this split (its resulting stage; >= 1). */
+  /** Number of splits after applying this split (>= 1). */
   numSplits: number;
-  /**
-   * Likelihood-ratio statistic for the split:
-   * `sum_v N_v * ln(SSE_before_v / SSE_after_v)`.
-   */
   logLikelihoodRatio: number;
-  /** BIC complexity penalty `K * ln(N)` for the split's K new parameters. */
   penalty: number;
   /** `penalty - logLikelihoodRatio`; a negative value favors keeping the split. */
   deltaBic: number;

--- a/packages/stats-ts/src/banditWeights.ts
+++ b/packages/stats-ts/src/banditWeights.ts
@@ -5,6 +5,8 @@ const BANDIT_PRIOR_VARIANCE = 1e4;
 const BANDIT_PRIOR_PRECISION = 1 / BANDIT_PRIOR_VARIANCE;
 const MIN_VARIATION_WEIGHT = 0.01;
 const MIN_UNITS_PER_VARIATION = 100;
+// Minimum variance for a bandit variation.
+const BANDIT_MIN_VARIANCE = 1e-9;
 
 export type BanditArmStatistic = {
   n: number;
@@ -198,8 +200,8 @@ export function updateVariationWeights(
     };
   }
 
-  const dataPrecision = stats.map((s) =>
-    s.variance > 0 ? s.n / s.variance : 0,
+  const dataPrecision = stats.map(
+    (s) => s.n / Math.max(s.variance, BANDIT_MIN_VARIANCE),
   );
   const posteriorVariance = dataPrecision.map(
     (dp) => 1 / (BANDIT_PRIOR_PRECISION + dp),

--- a/packages/stats-ts/src/contextualBanditWeights.ts
+++ b/packages/stats-ts/src/contextualBanditWeights.ts
@@ -318,9 +318,12 @@ export function armSseDirect(
   return sumSquares - (sum * sum) / n;
 }
 
-/** Pooled within-group SSE over compact category stats (sums the direct formula). */
-function compactGroupSse(cats: CompactCat[], numVariations: number): number {
-  let sse = 0;
+/** Per-variation pooled within-group SSE over compact category stats. */
+function compactGroupSsePerVariation(
+  cats: CompactCat[],
+  numVariations: number,
+): number[] {
+  const sse = new Array<number>(numVariations).fill(0);
   for (let v = 0; v < numVariations; v++) {
     const base = v * 3;
     let n = 0;
@@ -331,9 +334,17 @@ function compactGroupSse(cats: CompactCat[], numVariations: number): number {
       sum += cat[base + CAT_SUM];
       sumSquares += cat[base + CAT_SUM_SQUARES];
     }
-    sse += armSseDirect(n, sum, sumSquares);
+    sse[v] = armSseDirect(n, sum, sumSquares);
   }
   return sse;
+}
+
+/** Pooled within-group SSE over compact category stats (sums the per-variation values). */
+function compactGroupSse(cats: CompactCat[], numVariations: number): number {
+  return compactGroupSsePerVariation(cats, numVariations).reduce(
+    (a, b) => a + b,
+    0,
+  );
 }
 
 /**
@@ -680,6 +691,7 @@ type BuildTreeResult = {
    * SSE by (stage, variation).  stage = 0 is the root (before the first split)
    */
   sseTrajectory: number[][];
+  bicTrajectory: ContextualBicTrajectoryEntry[];
 };
 
 /** A leaf's best candidate split, cached across growth iterations. */
@@ -694,6 +706,16 @@ type LeafSplit = {
   splitSse: number;
   /** SSE reduction from the split (`sseCurrent - splitSse`). */
   gain: number;
+  /**
+   * Per-variation SSE of the leaf before splitting (parent). Sums to
+   * `sseCurrent`;
+   */
+  parentSsePerVariation: number[];
+  /**
+   * Per-variation SSE of the two child sides combined (after splitting). Sums
+   * to `splitSse`;
+   */
+  childrenSsePerVariation: number[];
 };
 
 /**
@@ -737,7 +759,7 @@ function buildTree(
     [0, new Set<number>()],
   ]);
   if (contexts.length === 0) {
-    return { leafInfo: new Map(), sseTrajectory: [] };
+    return { leafInfo: new Map(), sseTrajectory: [], bicTrajectory: [] };
   }
 
   const isBinomial = metric.main_metric_type === "binomial";
@@ -835,12 +857,25 @@ function buildTree(
       const candidateSseSplit = km.sse;
       const gain = sseCurrent - candidateSseSplit;
       if (best === null || gain > best.gain) {
+        const movingSse = compactGroupSsePerVariation(
+          cats.filter((_, i) => labels[i] === 1),
+          numVariations,
+        );
+        const stayingSse = compactGroupSsePerVariation(
+          cats.filter((_, i) => labels[i] === 0),
+          numVariations,
+        );
         best = {
           attrIndex,
           group,
           sseCurrent,
           splitSse: candidateSseSplit,
           gain,
+          parentSsePerVariation: compactGroupSsePerVariation(
+            cats,
+            numVariations,
+          ),
+          childrenSsePerVariation: movingSse.map((m, v) => m + stayingSse[v]),
         };
       }
     }
@@ -848,6 +883,9 @@ function buildTree(
   };
 
   const sseTrajectory: number[][] = [totalSsePerVariation()];
+  // BIC statistic per accepted split, accumulated as the tree grows (the root
+  // has no split, so this stays one shorter than `sseTrajectory`).
+  const bicTrajectory: ContextualBicTrajectoryEntry[] = [];
 
   // Per-variation total sample size across all contexts, and the BIC
   // complexity penalty K*ln(N). Used to gate each split by whether it lowers
@@ -872,64 +910,37 @@ function buildTree(
     }
     dirtyLeaves = new Set<number>();
 
-    let bestGain = -Infinity;
-    let bestAttr = -1;
     let bestLeaf = -1;
-    let bestGroup: Set<string> = new Set();
+    let bestSplit: LeafSplit | null = null;
     // Visit leaves in ascending id order so gain ties resolve to the earliest
     // leaf (and, within a leaf, the earliest attribute), matching the original
     // single-pass selection.
     for (const leafId of [...new Set(currentLeaf)].sort((a, b) => a - b)) {
       const candidate = splitCache.get(leafId);
       if (!candidate) continue;
-      if (candidate.gain > bestGain) {
-        bestGain = candidate.gain;
-        bestAttr = candidate.attrIndex;
+      if (bestSplit === null || candidate.gain > bestSplit.gain) {
         bestLeaf = leafId;
-        bestGroup = candidate.group;
+        bestSplit = candidate;
       }
     }
 
     // Stop when no leaf admits a further valid split, or the best available
     // split does not strictly reduce total SSE (e.g. identical categories).
-    if (bestAttr < 0 || bestGain <= 0) {
+    if (bestSplit === null || bestSplit.gain <= 0) {
       break;
     }
+    const bestAttr = bestSplit.attrIndex;
+    const bestGroup = bestSplit.group;
+    const parentSsePerVariation = bestSplit.parentSsePerVariation;
+    const childrenSsePerVariation = bestSplit.childrenSsePerVariation;
 
     // BIC stopping gate: the chosen split maximizes SSE reduction, but split
-    // only if it lowers BIC.
+    // only if it lowers BIC. Only `bestLeaf` changes.
     const beforePerVariation = sseTrajectory[sseTrajectory.length - 1];
-    const parentEntries: ContextEntry[] = [];
-    const movingEntries: ContextEntry[] = [];
-    const stayingEntries: ContextEntry[] = [];
-    for (let c = 0; c < contexts.length; c++) {
-      if (currentLeaf[c] !== bestLeaf) continue;
-      parentEntries.push(contexts[c]);
-      if (bestGroup.has(contexts[c].tuple[bestAttr])) {
-        movingEntries.push(contexts[c]);
-      } else {
-        stayingEntries.push(contexts[c]);
-      }
-    }
-    const parentSse = sumOfSquaredErrorsPerVariation(
-      parentEntries,
-      metric,
-      numVariations,
-    );
-    const movingSse = sumOfSquaredErrorsPerVariation(
-      movingEntries,
-      metric,
-      numVariations,
-    );
-    const stayingSse = sumOfSquaredErrorsPerVariation(
-      stayingEntries,
-      metric,
-      numVariations,
-    );
     const afterPerVariation = beforePerVariation.map(
-      (sse, v) => sse - parentSse[v] + movingSse[v] + stayingSse[v],
+      (sse, v) => sse - parentSsePerVariation[v] + childrenSsePerVariation[v],
     );
-    const { deltaBic } = bicDeltaForSplit(
+    const { logLikelihoodRatio, deltaBic } = bicDeltaForSplit(
       beforePerVariation,
       afterPerVariation,
       armTotalSampleSizes,
@@ -960,6 +971,14 @@ function buildTree(
       }
     }
     sseTrajectory.push(totalSsePerVariation());
+    // Record the BIC for the split we just applied. `numSplits` is the resulting
+    // stage index (the newly pushed `sseTrajectory` entry).
+    bicTrajectory.push({
+      numSplits: sseTrajectory.length - 1,
+      logLikelihoodRatio,
+      penalty: bicPenaltyValue,
+      deltaBic,
+    });
 
     // Only the split leaf and its new child changed; re-evaluate just those two
     // next iteration and reuse every other leaf's cached best split.
@@ -977,7 +996,7 @@ function buildTree(
     leafInfo.get(currentLeaf[c])?.memberContexts.push(c);
   }
 
-  return { leafInfo, sseTrajectory };
+  return { leafInfo, sseTrajectory, bicTrajectory };
 }
 
 function bicPenalty(numVariations: number, totalSampleSize: number): number {
@@ -1009,33 +1028,6 @@ function bicDeltaForSplit(
       armTotalSampleSizes[v] * (Math.log(before) - Math.log(after));
   }
   return { logLikelihoodRatio, deltaBic: penalty - logLikelihoodRatio };
-}
-
-/**
- * BIC model-selection statistic for each greedy split, derived from the
- * per-(split, variation) SSE trajectory.
- *
- */
-function computeBicTrajectory(
-  sseTrajectory: number[][],
-  armTotalSampleSizes: number[],
-): ContextualBicTrajectoryEntry[] {
-  const penalty = bicPenalty(
-    armTotalSampleSizes.length,
-    armTotalSampleSizes.reduce((a, b) => a + b, 0),
-  );
-
-  const trajectory: ContextualBicTrajectoryEntry[] = [];
-  for (let s = 1; s < sseTrajectory.length; s++) {
-    const { logLikelihoodRatio, deltaBic } = bicDeltaForSplit(
-      sseTrajectory[s - 1],
-      sseTrajectory[s],
-      armTotalSampleSizes,
-      penalty,
-    );
-    trajectory.push({ numSplits: s, logLikelihoodRatio, penalty, deltaBic });
-  }
-  return trajectory;
 }
 
 export function computeContextualBanditWeights(
@@ -1072,7 +1064,7 @@ export function computeContextualBanditWeights(
     return { attributes, responses: [], leaf_map: [] };
   }
 
-  const { leafInfo, sseTrajectory } = buildTree(
+  const { leafInfo, sseTrajectory, bicTrajectory } = buildTree(
     contexts,
     attributes,
     metricSettings,
@@ -1132,17 +1124,6 @@ export function computeContextualBanditWeights(
     }),
   );
 
-  const armTotalSampleSizes = new Array<number>(numVariations).fill(0);
-  for (const ctx of contexts) {
-    for (let v = 0; v < numVariations; v++) {
-      armTotalSampleSizes[v] += ctx.arms[v].n;
-    }
-  }
-  const bic_trajectory = computeBicTrajectory(
-    sseTrajectory,
-    armTotalSampleSizes,
-  );
-
   const responses: ContextualBanditResponseSnapshot[] = [];
 
   for (let c = 0; c < contexts.length; c++) {
@@ -1173,6 +1154,6 @@ export function computeContextualBanditWeights(
     leaf_map: buildLeafConditionMap(contexts, attributes, leafInfo),
     leaf_stats,
     sse_trajectory,
-    bic_trajectory,
+    bic_trajectory: bicTrajectory,
   };
 }

--- a/packages/stats-ts/src/contextualBanditWeights.ts
+++ b/packages/stats-ts/src/contextualBanditWeights.ts
@@ -1,6 +1,7 @@
 import type {
   ContextualBanditResponseSnapshot,
   ContextualBanditSnapshot,
+  ContextualBicTrajectoryEntry,
   ContextualLeafMapEntry,
   ContextualLeafStatsEntry,
   ContextualSseTrajectoryEntry,
@@ -247,15 +248,17 @@ function partitionByContext(
 }
 
 /**
- * Within-group SSE from each member's per-variation arm statistics: pool the
- * arms per variation, then sum `(n - 1) * variance` across variations.
+ * Per-variation within-group SSE from each member's arm statistics: for each
+ * variation, pool the arms across members and return `(n - 1) * variance`. The
+ * total within-group SSE (the objective the tree greedily reduces) is the sum
+ * of the returned array across variations.
  */
-function sumOfSquaredErrorsFromArms(
+function sumOfSquaredErrorsPerVariationFromArms(
   armsPerMember: ContextualBanditArm[][],
   metric: MetricSettingsForStatsEngine,
   numVariations: number,
-): number {
-  let sse = 0;
+): number[] {
+  const sse = new Array<number>(numVariations).fill(0);
   for (let v = 0; v < numVariations; v++) {
     let n = 0;
     let main_sum = 0;
@@ -270,17 +273,18 @@ function sumOfSquaredErrorsFromArms(
       { ...emptyArm(), n, main_sum, main_sum_squares },
       metric,
     );
-    sse += (stat.n - 1) * stat.variance;
+    sse[v] = (stat.n - 1) * stat.variance;
   }
   return sse;
 }
 
-function sumOfSquaredErrors(
+/** Per-variation within-group SSE over a set of contexts (pools their arms). */
+function sumOfSquaredErrorsPerVariation(
   contexts: ContextEntry[],
   metric: MetricSettingsForStatsEngine,
   numVariations: number,
-): number {
-  return sumOfSquaredErrorsFromArms(
+): number[] {
+  return sumOfSquaredErrorsPerVariationFromArms(
     contexts.map((ctx) => ctx.arms),
     metric,
     numVariations,
@@ -677,11 +681,12 @@ type BuildTreeResult = {
   /** One entry per tree leaf, keyed by leaf id. */
   leafInfo: Map<number, LeafInfo>;
   /**
-   * Total within-tree SSE at each stage of greedy growth, in order:
+   * Per-variation within-tree SSE at each stage of greedy growth, in order:
    * index 0 is the root (before the first split), index 1 is after the first
-   * split, etc.
+   * split, etc. Each stage is a per-variation array whose sum is that stage's
+   * total within-tree SSE.
    */
-  sseTrajectory: number[];
+  sseTrajectory: number[][];
 };
 
 /** A leaf's best candidate split, cached across growth iterations. */
@@ -744,14 +749,19 @@ function buildTree(
 
   const isBinomial = metric.main_metric_type === "binomial";
 
-  const totalSse = (): number => {
-    let total = 0;
+  const totalSsePerVariation = (): number[] => {
+    const total = new Array<number>(numVariations).fill(0);
     for (const leafId of new Set(currentLeaf)) {
       const inLeaf: ContextEntry[] = [];
       for (let c = 0; c < contexts.length; c++) {
         if (currentLeaf[c] === leafId) inLeaf.push(contexts[c]);
       }
-      total += sumOfSquaredErrors(inLeaf, metric, numVariations);
+      const leafSse = sumOfSquaredErrorsPerVariation(
+        inLeaf,
+        metric,
+        numVariations,
+      );
+      for (let v = 0; v < numVariations; v++) total[v] += leafSse[v];
     }
     return total;
   };
@@ -844,7 +854,7 @@ function buildTree(
     return best;
   };
 
-  const sseTrajectory: number[] = [totalSse()];
+  const sseTrajectory: number[][] = [totalSsePerVariation()];
 
   const splitCache = new Map<number, LeafSplit | null>();
   let dirtyLeaves = new Set<number>(currentLeaf);
@@ -897,7 +907,7 @@ function buildTree(
         currentLeaf[c] = newLeaf;
       }
     }
-    sseTrajectory.push(totalSse());
+    sseTrajectory.push(totalSsePerVariation());
 
     // Only the split leaf and its new child changed; re-evaluate just those two
     // next iteration and reuse every other leaf's cached best split.
@@ -916,6 +926,60 @@ function buildTree(
   }
 
   return { leafInfo, sseTrajectory };
+}
+
+/**
+ * BIC model-selection statistic for each greedy split, derived from the
+ * per-(split, variation) SSE trajectory.
+ *
+ * Comparing the tree before and after a split under a Gaussian model whose
+ * per-variation variance is pooled across leaves, a split adds K
+ * (= `numVariations`) parameters — one new per-variation mean for the new leaf.
+ * The likelihood-ratio statistic for the split that takes the tree from
+ * `sseTrajectory[s - 1]` to `sseTrajectory[s]` is
+ *
+ *   Lambda_s = sum_v N_v * ln(SSE_before_v / SSE_after_v)
+ *
+ * where `N_v` is variation `v`'s total sample size and `SSE_*_v` is the
+ * total-tree SSE for variation `v` before/after the split. BIC charges a
+ * complexity penalty of `K * ln(N)` with `N = sum_v N_v` the total sample size,
+ * so `deltaBic = penalty - Lambda`; a negative `deltaBic` favors keeping the
+ * split.
+ *
+ * A variation whose SSE is zero on either side of a split has an undefined
+ * log-ratio and contributes nothing to the statistic, keeping it finite.
+ *
+ * NOTE: recorded for observability only; it does not yet influence when
+ * `buildTree` stops growing the tree.
+ */
+function computeBicTrajectory(
+  sseTrajectory: number[][],
+  armTotalSampleSizes: number[],
+): ContextualBicTrajectoryEntry[] {
+  const numVariations = armTotalSampleSizes.length;
+  const totalSampleSize = armTotalSampleSizes.reduce((a, b) => a + b, 0);
+  const penalty =
+    totalSampleSize > 0 ? numVariations * Math.log(totalSampleSize) : 0;
+
+  const trajectory: ContextualBicTrajectoryEntry[] = [];
+  for (let s = 1; s < sseTrajectory.length; s++) {
+    const before = sseTrajectory[s - 1];
+    const after = sseTrajectory[s];
+    let logLikelihoodRatio = 0;
+    for (let v = 0; v < numVariations; v++) {
+      if (before[v] > 0 && after[v] > 0) {
+        logLikelihoodRatio +=
+          armTotalSampleSizes[v] * Math.log(before[v] / after[v]);
+      }
+    }
+    trajectory.push({
+      numSplits: s,
+      logLikelihoodRatio,
+      penalty,
+      deltaBic: penalty - logLikelihoodRatio,
+    });
+  }
+  return trajectory;
 }
 
 export function computeContextualBanditWeights(
@@ -1005,7 +1069,24 @@ export function computeContextualBanditWeights(
   );
 
   const sse_trajectory: ContextualSseTrajectoryEntry[] = sseTrajectory.map(
-    (totalSse, numSplits) => ({ numSplits, totalSse }),
+    (ssePerVariation, numSplits) => ({
+      numSplits,
+      totalSse: ssePerVariation.reduce((total, sse) => total + sse, 0),
+      ssePerVariation,
+    }),
+  );
+
+  // Per-variation total sample size across every context; feeds the BIC
+  // likelihood ratio and complexity penalty computed from the SSE trajectory.
+  const armTotalSampleSizes = new Array<number>(numVariations).fill(0);
+  for (const ctx of contexts) {
+    for (let v = 0; v < numVariations; v++) {
+      armTotalSampleSizes[v] += ctx.arms[v].n;
+    }
+  }
+  const bic_trajectory = computeBicTrajectory(
+    sseTrajectory,
+    armTotalSampleSizes,
   );
 
   const responses: ContextualBanditResponseSnapshot[] = [];
@@ -1038,5 +1119,6 @@ export function computeContextualBanditWeights(
     leaf_map: buildLeafConditionMap(contexts, attributes, leafInfo),
     leaf_stats,
     sse_trajectory,
+    bic_trajectory,
   };
 }

--- a/packages/stats-ts/src/contextualBanditWeights.ts
+++ b/packages/stats-ts/src/contextualBanditWeights.ts
@@ -856,6 +856,20 @@ function buildTree(
 
   const sseTrajectory: number[][] = [totalSsePerVariation()];
 
+  // Per-variation total sample size across all contexts, and the constant BIC
+  // complexity penalty K*ln(N). Used to gate each split by whether it lowers
+  // BIC (deltaBic < 0).
+  const armTotalSampleSizes = new Array<number>(numVariations).fill(0);
+  for (const ctx of contexts) {
+    for (let v = 0; v < numVariations; v++) {
+      armTotalSampleSizes[v] += ctx.arms[v].n;
+    }
+  }
+  const bicPenaltyValue = bicPenalty(
+    numVariations,
+    armTotalSampleSizes.reduce((a, b) => a + b, 0),
+  );
+
   const splitCache = new Map<number, LeafSplit | null>();
   let dirtyLeaves = new Set<number>(currentLeaf);
 
@@ -885,7 +899,52 @@ function buildTree(
 
     // Stop when no leaf admits a further valid split, or the best available
     // split does not strictly reduce total SSE (e.g. identical categories).
-    if (bestAttr < 0 || bestGain <= 0) break;
+    if (bestAttr < 0 || bestGain <= 0) {
+      break;
+    }
+
+    // BIC stopping gate: the chosen split maximizes SSE reduction, but only
+    // apply it if it lowers BIC.
+    const beforePerVariation = sseTrajectory[sseTrajectory.length - 1];
+    const parentEntries: ContextEntry[] = [];
+    const movingEntries: ContextEntry[] = [];
+    const stayingEntries: ContextEntry[] = [];
+    for (let c = 0; c < contexts.length; c++) {
+      if (currentLeaf[c] !== bestLeaf) continue;
+      parentEntries.push(contexts[c]);
+      if (bestGroup.has(contexts[c].tuple[bestAttr])) {
+        movingEntries.push(contexts[c]);
+      } else {
+        stayingEntries.push(contexts[c]);
+      }
+    }
+    const parentSse = sumOfSquaredErrorsPerVariation(
+      parentEntries,
+      metric,
+      numVariations,
+    );
+    const movingSse = sumOfSquaredErrorsPerVariation(
+      movingEntries,
+      metric,
+      numVariations,
+    );
+    const stayingSse = sumOfSquaredErrorsPerVariation(
+      stayingEntries,
+      metric,
+      numVariations,
+    );
+    const afterPerVariation = beforePerVariation.map(
+      (sse, v) => sse - parentSse[v] + movingSse[v] + stayingSse[v],
+    );
+    const { deltaBic } = bicDeltaForSplit(
+      beforePerVariation,
+      afterPerVariation,
+      armTotalSampleSizes,
+      bicPenaltyValue,
+    );
+    if (deltaBic >= 0) {
+      break;
+    }
 
     const newLeaf = iteration + 1;
     // Both sides of the split now constrain `bestAttr` along their paths: the
@@ -929,55 +988,58 @@ function buildTree(
 }
 
 /**
+ * BIC complexity penalty for a single split: the split adds one new leaf, i.e.
+ * `numVariations` new per-variation means, charged `K * ln(N)` with `N` the
+ * total sample size (0 when there are no units).
+ */
+function bicPenalty(numVariations: number, totalSampleSize: number): number {
+  return totalSampleSize > 0 ? numVariations * Math.log(totalSampleSize) : 0;
+}
+
+/**
+ * BIC change for a single split given the total-tree per-variation SSE before
+ * and after it. lower deltaBIC is better.
+ */
+function bicDeltaForSplit(
+  beforePerVariation: number[],
+  afterPerVariation: number[],
+  armTotalSampleSizes: number[],
+  penalty: number,
+): { logLikelihoodRatio: number; deltaBic: number } {
+  let logLikelihoodRatio = 0;
+  for (let v = 0; v < armTotalSampleSizes.length; v++) {
+    if (beforePerVariation[v] > 0 && afterPerVariation[v] > 0) {
+      logLikelihoodRatio +=
+        armTotalSampleSizes[v] *
+        Math.log(beforePerVariation[v] / afterPerVariation[v]);
+    }
+  }
+  return { logLikelihoodRatio, deltaBic: penalty - logLikelihoodRatio };
+}
+
+/**
  * BIC model-selection statistic for each greedy split, derived from the
  * per-(split, variation) SSE trajectory.
  *
- * Comparing the tree before and after a split under a Gaussian model whose
- * per-variation variance is pooled across leaves, a split adds K
- * (= `numVariations`) parameters — one new per-variation mean for the new leaf.
- * The likelihood-ratio statistic for the split that takes the tree from
- * `sseTrajectory[s - 1]` to `sseTrajectory[s]` is
- *
- *   Lambda_s = sum_v N_v * ln(SSE_before_v / SSE_after_v)
- *
- * where `N_v` is variation `v`'s total sample size and `SSE_*_v` is the
- * total-tree SSE for variation `v` before/after the split. BIC charges a
- * complexity penalty of `K * ln(N)` with `N = sum_v N_v` the total sample size,
- * so `deltaBic = penalty - Lambda`; a negative `deltaBic` favors keeping the
- * split.
- *
- * A variation whose SSE is zero on either side of a split has an undefined
- * log-ratio and contributes nothing to the statistic, keeping it finite.
- *
- * NOTE: recorded for observability only; it does not yet influence when
- * `buildTree` stops growing the tree.
  */
 function computeBicTrajectory(
   sseTrajectory: number[][],
   armTotalSampleSizes: number[],
 ): ContextualBicTrajectoryEntry[] {
-  const numVariations = armTotalSampleSizes.length;
-  const totalSampleSize = armTotalSampleSizes.reduce((a, b) => a + b, 0);
-  const penalty =
-    totalSampleSize > 0 ? numVariations * Math.log(totalSampleSize) : 0;
+  const penalty = bicPenalty(
+    armTotalSampleSizes.length,
+    armTotalSampleSizes.reduce((a, b) => a + b, 0),
+  );
 
   const trajectory: ContextualBicTrajectoryEntry[] = [];
   for (let s = 1; s < sseTrajectory.length; s++) {
-    const before = sseTrajectory[s - 1];
-    const after = sseTrajectory[s];
-    let logLikelihoodRatio = 0;
-    for (let v = 0; v < numVariations; v++) {
-      if (before[v] > 0 && after[v] > 0) {
-        logLikelihoodRatio +=
-          armTotalSampleSizes[v] * Math.log(before[v] / after[v]);
-      }
-    }
-    trajectory.push({
-      numSplits: s,
-      logLikelihoodRatio,
+    const { logLikelihoodRatio, deltaBic } = bicDeltaForSplit(
+      sseTrajectory[s - 1],
+      sseTrajectory[s],
+      armTotalSampleSizes,
       penalty,
-      deltaBic: penalty - logLikelihoodRatio,
-    });
+    );
+    trajectory.push({ numSplits: s, logLikelihoodRatio, penalty, deltaBic });
   }
   return trajectory;
 }

--- a/packages/stats-ts/src/contextualBanditWeights.ts
+++ b/packages/stats-ts/src/contextualBanditWeights.ts
@@ -970,7 +970,7 @@ function buildTree(
         currentLeaf[c] = newLeaf;
       }
     }
-    sseTrajectory.push(totalSsePerVariation());
+    sseTrajectory.push(afterPerVariation);
     // Record the BIC for the split we just applied. `numSplits` is the resulting
     // stage index (the newly pushed `sseTrajectory` entry).
     bicTrajectory.push({

--- a/packages/stats-ts/src/contextualBanditWeights.ts
+++ b/packages/stats-ts/src/contextualBanditWeights.ts
@@ -248,10 +248,7 @@ function partitionByContext(
 }
 
 /**
- * Per-variation within-group SSE from each member's arm statistics: for each
- * variation, pool the arms across members and return `(n - 1) * variance`. The
- * total within-group SSE (the objective the tree greedily reduces) is the sum
- * of the returned array across variations.
+ * Per-variation within-group SSE.
  */
 function sumOfSquaredErrorsPerVariationFromArms(
   armsPerMember: ContextualBanditArm[][],
@@ -278,7 +275,6 @@ function sumOfSquaredErrorsPerVariationFromArms(
   return sse;
 }
 
-/** Per-variation within-group SSE over a set of contexts (pools their arms). */
 function sumOfSquaredErrorsPerVariation(
   contexts: ContextEntry[],
   metric: MetricSettingsForStatsEngine,
@@ -681,10 +677,7 @@ type BuildTreeResult = {
   /** One entry per tree leaf, keyed by leaf id. */
   leafInfo: Map<number, LeafInfo>;
   /**
-   * Per-variation within-tree SSE at each stage of greedy growth, in order:
-   * index 0 is the root (before the first split), index 1 is after the first
-   * split, etc. Each stage is a per-variation array whose sum is that stage's
-   * total within-tree SSE.
+   * SSE by (stage, variation).  stage = 0 is the root (before the first split)
    */
   sseTrajectory: number[][];
 };
@@ -856,7 +849,7 @@ function buildTree(
 
   const sseTrajectory: number[][] = [totalSsePerVariation()];
 
-  // Per-variation total sample size across all contexts, and the constant BIC
+  // Per-variation total sample size across all contexts, and the BIC
   // complexity penalty K*ln(N). Used to gate each split by whether it lowers
   // BIC (deltaBic < 0).
   const armTotalSampleSizes = new Array<number>(numVariations).fill(0);
@@ -903,8 +896,8 @@ function buildTree(
       break;
     }
 
-    // BIC stopping gate: the chosen split maximizes SSE reduction, but only
-    // apply it if it lowers BIC.
+    // BIC stopping gate: the chosen split maximizes SSE reduction, but split
+    // only if it lowers BIC.
     const beforePerVariation = sseTrajectory[sseTrajectory.length - 1];
     const parentEntries: ContextEntry[] = [];
     const movingEntries: ContextEntry[] = [];
@@ -987,18 +980,18 @@ function buildTree(
   return { leafInfo, sseTrajectory };
 }
 
-/**
- * BIC complexity penalty for a single split: the split adds one new leaf, i.e.
- * `numVariations` new per-variation means, charged `K * ln(N)` with `N` the
- * total sample size (0 when there are no units).
- */
 function bicPenalty(numVariations: number, totalSampleSize: number): number {
   return totalSampleSize > 0 ? numVariations * Math.log(totalSampleSize) : 0;
 }
 
+// Relative floor applied to a variation's post-split pooled SSE when it drops to
+// (near) zero, so the likelihood ratio stays finite and scale-invariant. Caps a
+// single variation's per-split contribution at armTotalSampleSize * ln(1/floor).
+const SSE_RATIO_FLOOR = 1e-6;
+
 /**
  * BIC change for a single split given the total-tree per-variation SSE before
- * and after it. lower deltaBIC is better.
+ * and after it.
  */
 function bicDeltaForSplit(
   beforePerVariation: number[],
@@ -1008,11 +1001,12 @@ function bicDeltaForSplit(
 ): { logLikelihoodRatio: number; deltaBic: number } {
   let logLikelihoodRatio = 0;
   for (let v = 0; v < armTotalSampleSizes.length; v++) {
-    if (beforePerVariation[v] > 0 && afterPerVariation[v] > 0) {
-      logLikelihoodRatio +=
-        armTotalSampleSizes[v] *
-        Math.log(beforePerVariation[v] / afterPerVariation[v]);
-    }
+    const before = beforePerVariation[v];
+    // No baseline variance => no improvement to measure (ln(0/0) is undefined).
+    if (before <= 0) continue;
+    const after = Math.max(afterPerVariation[v], before * SSE_RATIO_FLOOR);
+    logLikelihoodRatio +=
+      armTotalSampleSizes[v] * (Math.log(before) - Math.log(after));
   }
   return { logLikelihoodRatio, deltaBic: penalty - logLikelihoodRatio };
 }
@@ -1138,8 +1132,6 @@ export function computeContextualBanditWeights(
     }),
   );
 
-  // Per-variation total sample size across every context; feeds the BIC
-  // likelihood ratio and complexity penalty computed from the SSE trajectory.
   const armTotalSampleSizes = new Array<number>(numVariations).fill(0);
   for (const ctx of contexts) {
     for (let v = 0; v < numVariations; v++) {

--- a/packages/stats-ts/test/contextualBanditWeights.test.ts
+++ b/packages/stats-ts/test/contextualBanditWeights.test.ts
@@ -291,6 +291,56 @@ describe("computeContextualBanditWeights", () => {
     expect(result.sse_trajectory![0].totalSse).toBeCloseTo(398, 6);
   });
 
+  it("records per-variation SSE that sums to the total SSE at each stage", () => {
+    const data = [
+      countryObs("US", 0, 200, 1),
+      countryObs("US", 1, 200, 2),
+      countryObs("CA", 0, 200, 2),
+      countryObs("CA", 1, 200, 1),
+    ];
+
+    const result = computeContextualBanditWeights(input(data));
+
+    expect(result.sse_trajectory!.length).toBeGreaterThan(0);
+    for (const step of result.sse_trajectory!) {
+      expect(step.ssePerVariation).toBeDefined();
+      expect(step.ssePerVariation!).toHaveLength(2);
+      const sum = step.ssePerVariation!.reduce((a, b) => a + b, 0);
+      expect(sum).toBeCloseTo(step.totalSse, 6);
+    }
+  });
+
+  it("computes a BIC statistic per split from the per-variation SSE trajectory", () => {
+    const data = [
+      countryObs("US", 0, 200, 1),
+      countryObs("US", 1, 200, 2),
+      countryObs("CA", 0, 200, 2),
+      countryObs("CA", 1, 200, 1),
+    ];
+
+    const result = computeContextualBanditWeights(input(data));
+
+    // One BIC entry per split (the transition between consecutive stages),
+    // aligned to the resulting stage's numSplits.
+    expect(result.bic_trajectory).toBeDefined();
+    expect(result.bic_trajectory!.map((b) => b.numSplits)).toEqual([1]);
+
+    const bic = result.bic_trajectory![0];
+    // The split reduces SSE, so the likelihood ratio is positive.
+    expect(bic.logLikelihoodRatio).toBeGreaterThan(0);
+    // K = 2 variations, N = 800 total users => penalty = 2 * ln(800).
+    expect(bic.penalty).toBeCloseTo(2 * Math.log(800), 6);
+    expect(bic.deltaBic).toBeCloseTo(bic.penalty - bic.logLikelihoodRatio, 6);
+  });
+
+  it("produces no BIC entries when the tree does not split", () => {
+    const data = [countryObs("US", 0, 200, 1), countryObs("US", 1, 200, 2)];
+
+    const result = computeContextualBanditWeights(input(data));
+
+    expect(result.bic_trajectory).toEqual([]);
+  });
+
   it("keeps identical contexts in a single leaf", () => {
     const data = [
       countryObs("US", 0, 200, 1),


### PR DESCRIPTION
### Features and Changes

GrowthBook's contextual bandits model uses a tree to group users with the same attribute values with other collections of users.   These groups of users are called "leaves".  Creating leaves helps avoid overfitting and makes manageable the size of the SDK payload.  

Currently this number of leaves is fixed at 12 (if there at least 12 user collections to begin with).  In many instances 12 is too big.  For example, if two different user groups have the same variation dominating, then they can be grouped in the same leaf with no loss of reward.  

This PR uses Bayesian Information Criterion (BIC) to determine how many leaves should be used.  
