### PR TITLE
CI and test fixes: job timeout, worker memory limit, remote-eval flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,8 @@ jobs:
   # A 4-vCPU runner gives Jest only 3 workers for 300+ files, so shard instead.
   test-back-end:
     runs-on: ubuntu-latest
+    # A silently killed Jest worker leaves the parent waiting on the 6h default.
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/packages/back-end/jest.config.js
+++ b/packages/back-end/jest.config.js
@@ -60,6 +60,6 @@ module.exports = {
   setupFilesAfterEnv: ["<rootDir>/test/jest.setup.ts"],
   // For non-CI, lets make sure to cap the workers
   ...(process.env.CI ? {} : { maxWorkers: "50%" }),
-  // Recycle workers before the heap fills; 1GB cost more in restarts than it saved.
-  workerIdleMemoryLimit: "2GB",
+  // Recycle workers before the heap fills; non-CI stays lower for cloud agents running a dev server alongside.
+  workerIdleMemoryLimit: process.env.CI ? "2GB" : "1GB",
 };

--- a/packages/sdk-js/test/remote-eval.test.ts
+++ b/packages/sdk-js/test/remote-eval.test.ts
@@ -34,6 +34,33 @@ async function sleep(ms: number) {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// Fake Date only, so cache staleness follows explicit clock moves rather than how
+// long SDK init happens to take on a loaded machine.
+function useFrozenClock() {
+  jest.useFakeTimers({
+    doNotFake: [
+      "hrtime",
+      "nextTick",
+      "performance",
+      "queueMicrotask",
+      "requestAnimationFrame",
+      "cancelAnimationFrame",
+      "requestIdleCallback",
+      "cancelIdleCallback",
+      "setImmediate",
+      "clearImmediate",
+      "setInterval",
+      "clearInterval",
+      "setTimeout",
+      "clearTimeout",
+    ],
+  });
+}
+
+function advanceClock(ms: number) {
+  jest.setSystemTime(Date.now() + ms);
+}
+
 function mockApi(
   data: FeatureApiResponse | null,
   supportSSE: boolean = false,
@@ -164,6 +191,10 @@ const sdkPayloadUpdated = {
 };
 
 describe("remote-eval", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it("debounces network requests for same clientKey and cacheKeyAttributes", async () => {
     await clearCache();
     const [f, cleanup] = mockApi(sdkPayload);
@@ -466,6 +497,7 @@ describe("remote-eval", () => {
   });
 
   it("uses localStorage cache", async () => {
+    useFrozenClock();
     await clearCache();
     await seedLocalStorage();
 
@@ -502,7 +534,7 @@ describe("remote-eval", () => {
     expect(f.mock.calls.length).toEqual(0);
 
     // Wait for localStorage entry to expire and refresh features
-    await sleep(120);
+    advanceClock(120);
     await growthbook.refreshFeatures();
     expect(f.mock.calls.length).toEqual(1);
     expect(growthbook.evalFeature("foo").value).toEqual("api");
@@ -514,7 +546,7 @@ describe("remote-eval", () => {
 
     // Wait for localStorage entry to expire again
     // Since the payload didn't change, make sure it updates localStorage staleAt flag
-    await sleep(120);
+    advanceClock(120);
     await growthbook.refreshFeatures();
     expect(f.mock.calls.length).toEqual(2);
     expect(growthbook.evalFeature("foo").value).toEqual("api");
@@ -528,7 +560,7 @@ describe("remote-eval", () => {
     // If api has a new version, refreshFeatures should pick it up
     data.features.foo.defaultValue = "new";
     data.dateUpdated = "2020-02-01T00:00:00Z";
-    await sleep(120);
+    advanceClock(120);
     await growthbook.refreshFeatures();
     expect(f.mock.calls.length).toEqual(3);
     expect(growthbook.evalFeature("foo").value).toEqual("new");


### PR DESCRIPTION
### Features and Changes

Three CI and test fixes:

- `test-back-end` gets `timeout-minutes: 15`. A killed Jest worker leaves the parent
waiting with no timeout of its own, so a stalled shard runs to the 6h default.
- `workerIdleMemoryLimit` goes back to `process.env.CI ? "2GB" : "1GB"`, as it was
before #6773.
- `remote-eval`'s "uses localStorage cache" fakes `Date` and moves the clock explicitly,
instead of seeding a 50ms staleness window that SDK init has to finish inside.

### Testing

- [x] 200ms stall injected into the test -> fails before, passes after
- [x] sdk-js suite -> 18 files / 793 tests pass
