### PR TITLE
feat: show CBAQ section on managed warehouse datasource page

### DIFF
--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -515,6 +515,16 @@ mixpanel.init('YOUR PROJECT TOKEN', {
                       }}
                     />
                   </Frame>
+
+                  {contextualBanditsEnabled &&
+                    hasCommercialFeature("contextual-bandits") && (
+                      <Frame id={CBAQ_ANCHOR_ID}>
+                        <ContextualBanditAssignmentQueries
+                          dataSource={d}
+                          canEdit={canUpdateDataSourceSettings}
+                        />
+                      </Frame>
+                    )}
                 </>
               )
             ) : (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Allows users with managed warehouse data connections to view and edit their Contextual Bandit Assignment Queries (CBAQ) directly from the managed warehouse datasource page.

## Changes

- Added the `ContextualBanditAssignmentQueries` component to the managed warehouse section of the datasource page
- The CBAQ section is now visible for both managed warehouses and non-managed warehouses (previously it was only shown for non-managed warehouses)
- Same feature flag (`contextual-bandits`) and commercial feature checks (`contextual-bandits`) apply

## Context

A user was able to create a CBAQ for their managed warehouse data connection but couldn't see or edit it because the CBAQ section was only rendered in the non-managed-warehouse branch of the datasource page UI.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C0ASQ7U39B6/p1787939387416589?thread_ts=1787939387.416589&cid=C0ASQ7U39B6)

<div><a href="https://cursor.com/agents/bc-8c6eadc8-9da4-5c33-bd63-1af872bce467?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c6eadc8-9da4-5c33-bd63-1af872bce467&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

