### PR TITLE
Pre-download and cache the mongod binary in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,9 @@ jobs:
     runs-on: depot-ubuntu-24.04-4
     # A silently killed Jest worker leaves the parent waiting on the 6h default.
     timeout-minutes: 15
+    env:
+      # mongodb-memory-server's own default, pinned so the cache key is exact.
+      MONGOMS_VERSION: 6.0.14
     strategy:
       fail-fast: false
       matrix:
@@ -170,6 +173,19 @@ jobs:
             ${{ runner.os }}-jest-back-end-${{ matrix.shard }}-${{ hashFiles('pnpm-lock.yaml') }}-
             ${{ runner.os }}-jest-back-end-${{ matrix.shard }}-
             ${{ runner.os }}-jest-back-end-
+
+      # Otherwise Jest workers race for the same mongod and die on its lockfile.
+      - name: Cache mongod binary
+        id: cache-mongod
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: ${{ runner.os }}-mongod-${{ env.MONGOMS_VERSION }}
+
+      - name: Download mongod binary
+        if: steps.cache-mongod.outputs.cache-hit != 'true'
+        # The hook defaults to node_modules/.cache; the tests read ~/.cache.
+        run: MONGOMS_PREFER_GLOBAL_PATH=true node packages/back-end/node_modules/mongodb-memory-server/postinstall.js
 
       - name: Test
         run: pnpm --filter back-end test --shard=${{ matrix.shard }}/4


### PR DESCRIPTION
### Features and Changes

Nothing puts a mongod on a CI box before Jest starts, so a back-end shard's three workers race to download the same 70MB binary and whichever one loses the fight over mongodb-memory-server's lockfile takes its suite down with it. That's what failed a shard on #6789. Now we fetch the binary once up front and cache it, so the workers just find it.

`MONGOMS_VERSION` pins the version the cache key names, so it needs bumping whenever mongodb-memory-server's default moves.

### Testing

- [x] `test-back-end` shards no longer log `Downloading MongoDB` during the `Test` step
