### PR TITLE
Run the back-end tests unsharded on one 16-vCPU runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,19 +145,15 @@ jobs:
         env:
           CI: true
 
-  # A 4-vCPU runner gives Jest only 3 workers for 300+ files, so shard instead.
-  # The 2 vCPU base runner drops each shard to one worker, so pay for 4 here.
+  # One box for 300+ files: Jest gets 15 workers instead of 3 per shard, and the
+  # ~20s of workspace setup is paid once rather than four times.
   test-back-end:
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: depot-ubuntu-24.04-16
     # A silently killed Jest worker leaves the parent waiting on the 6h default.
     timeout-minutes: 15
     env:
       # mongodb-memory-server's own default, pinned so the cache key is exact.
       MONGOMS_VERSION: 6.0.14
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3, 4]
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -168,10 +164,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: packages/back-end/.jest-cache
-          key: ${{ runner.os }}-jest-back-end-${{ matrix.shard }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.run_id }}
+          key: ${{ runner.os }}-jest-back-end-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-jest-back-end-${{ matrix.shard }}-${{ hashFiles('pnpm-lock.yaml') }}-
-            ${{ runner.os }}-jest-back-end-${{ matrix.shard }}-
+            ${{ runner.os }}-jest-back-end-${{ hashFiles('pnpm-lock.yaml') }}-
             ${{ runner.os }}-jest-back-end-
 
       # Otherwise Jest workers race for the same mongod and die on its lockfile.
@@ -188,7 +183,7 @@ jobs:
         run: MONGOMS_PREFER_GLOBAL_PATH=true node packages/back-end/node_modules/mongodb-memory-server/postinstall.js
 
       - name: Test
-        run: pnpm --filter back-end test --shard=${{ matrix.shard }}/4
+        run: pnpm --filter back-end test
         env:
           CI: true
 


### PR DESCRIPTION
### Features and Changes

jdorn's suggestion on #6793: one `depot-ubuntu-24.04-16` instead of four 4-vCPU shards. Jest takes `cores - 1` in CI, so 15 workers rather than 3 per shard, and the workspace setup is paid once instead of four times.

### Dependencies

Based on #6793 — 15 workers contend for that one mongod download instead of 3.

### Testing

Two attempts per side. Cost is job seconds x vCPU, since Depot bills in proportion to runner size.

| | sharded (4 x 4 vCPU) | unsharded (1 x 16 vCPU) |
| --- | --- | --- |
| `Test` step | 49 / 37 / 31 / 32s | **45s**, **40s** |
| job wall clock | 69s (slowest shard) | **67s**, **60s** |
| cost | **15.7** vCPU-min | **17.9**, **16.0** vCPU-min |

Break-even is 59s of job time, so the two attempts land either side of it. 15 workers cleared ~447 worker-seconds of tests in 40-45s, about 10 workers' worth of throughput.

No run-level speedup either way — `lint` is the critical path at 77s.
