### PR TITLE
Add option to disable SDK feature usage events

### DIFF
--- a/docs/app/event-forwarder.mdx
+++ b/docs/app/event-forwarder.mdx
@@ -145,6 +145,15 @@ gb.logEvent("Button Click", {
 });
 ```
 
+Feature usage events are enabled by default. Disable them without affecting
+experiment view or custom events:
+
+```js
+growthbookTrackingPlugin({
+  enableFeatureUsageEvents: false,
+});
+```
+
 #### Event Delivery on Page Navigation
 
 Events are batched and sent with `fetch` using `keepalive`, and when the page

--- a/docs/app/managed-warehouse.mdx
+++ b/docs/app/managed-warehouse.mdx
@@ -252,6 +252,15 @@ gb.logEvent("Button Click", {
 });
 ```
 
+Feature usage events are enabled by default. Disable them without affecting
+experiment view or custom events:
+
+```js
+growthbookTrackingPlugin({
+  enableFeatureUsageEvents: false,
+});
+```
+
 #### Node.js
 
 Use the `growthbookTrackingPlugin` to enable tracking:

--- a/packages/sdk-js/CHANGELOG.md
+++ b/packages/sdk-js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## **1.7.1** - Unreleased
+
+- Add an option to disable feature usage events in the GrowthBook tracking plugin
+
 ## **1.7.0** - Aug 7, 2026
 
 - Add Contextual Bandit support
@@ -8,7 +12,6 @@
 - Fix event forwarder tracking for `GrowthBookClient`
 - Add internal subscription streams for feature usage and custom events (used by plugins)
 - Fix redirect experiment SRM issues: subdomain-stable UUID generation and unload-safe event delivery
-- Add an option to disable feature usage events in the GrowthBook tracking plugin
 
 ## **1.6.5** - Feb 18, 2026
 

--- a/packages/sdk-js/CHANGELOG.md
+++ b/packages/sdk-js/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix event forwarder tracking for `GrowthBookClient`
 - Add internal subscription streams for feature usage and custom events (used by plugins)
 - Fix redirect experiment SRM issues: subdomain-stable UUID generation and unload-safe event delivery
+- Add an option to disable feature usage events in the GrowthBook tracking plugin
 
 ## **1.6.5** - Feb 18, 2026
 

--- a/packages/sdk-js/src/plugins/growthbook-tracking.ts
+++ b/packages/sdk-js/src/plugins/growthbook-tracking.ts
@@ -187,6 +187,7 @@ export function growthbookTrackingPlugin({
   queueFlushInterval = 100,
   ingestorHost,
   enable = true,
+  enableFeatureUsageEvents = true,
   debug,
   dedupeCacheSize = 1000,
   dedupeKeyAttributes = [],
@@ -197,6 +198,7 @@ export function growthbookTrackingPlugin({
   queueFlushInterval?: number;
   ingestorHost?: string;
   enable?: boolean;
+  enableFeatureUsageEvents?: boolean;
   debug?: boolean;
   dedupeCacheSize?: number;
   dedupeKeyAttributes?: string[];
@@ -252,6 +254,13 @@ export function growthbookTrackingPlugin({
           attributes: userContext.attributes || {},
           url: userContext.url || "",
         };
+
+        if (
+          !enableFeatureUsageEvents &&
+          eventName === EVENT_FEATURE_EVALUATED
+        ) {
+          return;
+        }
 
         // Skip logging if the event is being filtered
         if (eventFilter && !eventFilter(data)) {

--- a/packages/sdk-js/test/plugins/growthbook-tracking.test.ts
+++ b/packages/sdk-js/test/plugins/growthbook-tracking.test.ts
@@ -161,6 +161,45 @@ describe("growthbookTrackingPlugin", () => {
     gb.destroy();
   });
 
+  it("can disable feature usage events independently", async () => {
+    const eventFilter = jest.fn(() => true);
+    const gb = new GrowthBookClient({
+      clientKey: "test",
+      plugins: [
+        growthbookTrackingPlugin({
+          enableFeatureUsageEvents: false,
+          eventFilter,
+        }),
+      ],
+    });
+    gb.initSync({
+      payload: {
+        features: {
+          feature: { defaultValue: true },
+        },
+      },
+    });
+
+    const user = gb.createScopedInstance({ attributes: { user_id: "1" } });
+    user.evalFeature("feature");
+    user.runInlineExperiment({
+      key: "my-experiment",
+      variations: [false, true],
+      hashAttribute: "user_id",
+      hashVersion: 2,
+    });
+    user.logEvent("Custom Event");
+
+    await sleep(150);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(
+      body.map((event: { event_name: string }) => event.event_name),
+    ).toEqual([EVENT_EXPERIMENT_VIEWED, "Custom Event"]);
+    expect(eventFilter).toHaveBeenCalledTimes(2);
+
+    gb.destroy();
+  });
+
   it("Skips logging duplicate Feature Evaluted events", async () => {
     const plugin = growthbookTrackingPlugin();
 


### PR DESCRIPTION
## Summary
- add an `enableFeatureUsageEvents` tracking-plugin option that defaults to enabled
- suppress feature evaluation events independently of experiment views and custom events
- document the option and cover it with an SDK test

## Test plan
- [x] Run the tracking plugin Jest suite
- [x] Type-check and build the JavaScript SDK
- [x] Run the standalone manual comparison with the option enabled and disabled
- [x] Check formatting, docs frontmatter, and lint diagnostics

Made with [Cursor](https://cursor.com)