### PR TITLE
Readable error and one-shot reload when an auth proxy intercepts API calls

### DIFF
--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -40,6 +40,7 @@ import { getValidDate } from "shared/dates";
 import sha256 from "crypto-js/sha256";
 import { AgreementType } from "shared/validators";
 import { AIProvider } from "shared/ai";
+import { NonJsonResponseError } from "shared/util";
 import { getOwnerDisplay as getOwnerDisplayName } from "@/services/owners";
 import {
   getGrowthBookBuild,
@@ -51,11 +52,7 @@ import {
   usingSSO,
 } from "@/services/env";
 import useApi from "@/hooks/useApi";
-import {
-  NonJsonResponseError,
-  useAuth,
-  UserOrganizations,
-} from "@/services/auth";
+import { useAuth, UserOrganizations } from "@/services/auth";
 import { getJitsuClient, trackPageView } from "@/services/track";
 import { getOrGeneratePageId, growthbook } from "@/services/utils";
 
@@ -244,8 +241,8 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
     shouldRun: () => !!orgId,
   });
 
-  // An auth proxy (e.g. Google IAP) with an expired session answers API calls in plain text; only a top-level navigation lets it re-authenticate, so reload once
-  const AUTH_PROXY_RELOAD_FLAG = "gb-auth-proxy-reloaded";
+  // An expired auth proxy session (e.g. Google IAP) answers API calls in plain text; only a top-level navigation can re-authenticate it, so reload, at most once a minute
+  const AUTH_PROXY_RELOAD_KEY = "gb-auth-proxy-reload";
   const proxyAuthError = [error, orgLoadingError].some(
     (e) =>
       e instanceof NonJsonResponseError &&
@@ -254,22 +251,18 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!proxyAuthError) return;
     try {
-      if (window.sessionStorage.getItem(AUTH_PROXY_RELOAD_FLAG)) return;
-      window.sessionStorage.setItem(AUTH_PROXY_RELOAD_FLAG, "1");
+      const lastReload = parseInt(
+        window.sessionStorage.getItem(AUTH_PROXY_RELOAD_KEY) || "0",
+        10,
+      );
+      if (Date.now() - lastReload < 60_000) return;
+      window.sessionStorage.setItem(AUTH_PROXY_RELOAD_KEY, `${Date.now()}`);
     } catch (e) {
       // no guard available; don't risk a reload loop
       return;
     }
     window.location.reload();
   }, [proxyAuthError]);
-  useEffect(() => {
-    if (!data) return;
-    try {
-      window.sessionStorage.removeItem(AUTH_PROXY_RELOAD_FLAG);
-    } catch (e) {
-      // ignore
-    }
-  }, [data]);
 
   const refreshOrganization = useCallback(
     async (options?: RefreshOrganizationOptions) => {

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -51,7 +51,11 @@ import {
   usingSSO,
 } from "@/services/env";
 import useApi from "@/hooks/useApi";
-import { useAuth, UserOrganizations } from "@/services/auth";
+import {
+  NonJsonResponseError,
+  useAuth,
+  UserOrganizations,
+} from "@/services/auth";
 import { getJitsuClient, trackPageView } from "@/services/track";
 import { getOrGeneratePageId, growthbook } from "@/services/utils";
 
@@ -239,6 +243,33 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
   } = useApi<GetOrganizationResponse>(`/organization`, {
     shouldRun: () => !!orgId,
   });
+
+  // An auth proxy (e.g. Google IAP) with an expired session answers API calls in plain text; only a top-level navigation lets it re-authenticate, so reload once
+  const AUTH_PROXY_RELOAD_FLAG = "gb-auth-proxy-reloaded";
+  const proxyAuthError = [error, orgLoadingError].some(
+    (e) =>
+      e instanceof NonJsonResponseError &&
+      (e.status === 401 || e.status === 403),
+  );
+  useEffect(() => {
+    if (!proxyAuthError) return;
+    try {
+      if (window.sessionStorage.getItem(AUTH_PROXY_RELOAD_FLAG)) return;
+      window.sessionStorage.setItem(AUTH_PROXY_RELOAD_FLAG, "1");
+    } catch (e) {
+      // no guard available; don't risk a reload loop
+      return;
+    }
+    window.location.reload();
+  }, [proxyAuthError]);
+  useEffect(() => {
+    if (!data) return;
+    try {
+      window.sessionStorage.removeItem(AUTH_PROXY_RELOAD_FLAG);
+    } catch (e) {
+      // ignore
+    }
+  }, [data]);
 
   const refreshOrganization = useCallback(
     async (options?: RefreshOrganizationOptions) => {

--- a/packages/front-end/services/auth.tsx
+++ b/packages/front-end/services/auth.tsx
@@ -9,6 +9,7 @@ import React, {
 } from "react";
 import { useRouter } from "next/router";
 import { OrganizationInterface } from "shared/types/organization";
+import { NonJsonResponseError } from "shared/util";
 import {
   IdTokenResponse,
   UnauthenticatedResponse,
@@ -42,19 +43,6 @@ export function appendIgnoreWarnings(url: string): string {
 
 export function isExternalApiPath(url: string): boolean {
   return /^\/api\/v\d/.test(url);
-}
-
-// Thrown when the API answers with something other than JSON, e.g. an auth proxy (Google IAP) responding in plain text after its session expired
-export class NonJsonResponseError extends Error {
-  status: number;
-  constructor(status: number) {
-    super(
-      status === 401 || status === 403
-        ? "Your network sign-in session has expired. Reload the page to continue."
-        : `The API returned an invalid response (HTTP ${status})`,
-    );
-    this.status = status;
-  }
 }
 
 export interface AuthContextValue {

--- a/packages/front-end/services/auth.tsx
+++ b/packages/front-end/services/auth.tsx
@@ -44,6 +44,19 @@ export function isExternalApiPath(url: string): boolean {
   return /^\/api\/v\d/.test(url);
 }
 
+// Thrown when the API answers with something other than JSON, e.g. an auth proxy (Google IAP) responding in plain text after its session expired
+export class NonJsonResponseError extends Error {
+  status: number;
+  constructor(status: number) {
+    super(
+      status === 401 || status === 403
+        ? "Your network sign-in session has expired. Reload the page to continue."
+        : `The API returned an invalid response (HTTP ${status})`,
+    );
+    this.status = status;
+  }
+}
+
 export interface AuthContextValue {
   isAuthenticated: boolean;
   loading: boolean;
@@ -403,7 +416,11 @@ export const AuthProvider: React.FC<{
       if (contentType && contentType.startsWith("image/")) {
         responseData = await response.blob();
       } else {
-        responseData = await response.json();
+        try {
+          responseData = await response.json();
+        } catch (e) {
+          throw new NonJsonResponseError(response.status);
+        }
         if (
           !response.ok &&
           responseData &&

--- a/packages/shared/src/util/errors.ts
+++ b/packages/shared/src/util/errors.ts
@@ -17,3 +17,17 @@ export class PermissionError extends Error {
     this.name = "PermissionError";
   }
 }
+
+// Thrown when the API answers with something other than JSON, e.g. an auth proxy (Google IAP) responding in plain text after its session expired
+export class NonJsonResponseError extends Error {
+  status: number;
+  constructor(status: number) {
+    super(
+      status === 401 || status === 403
+        ? "Your network sign-in session has expired. Reload the page to continue."
+        : `The API returned an invalid response (HTTP ${status})`,
+    );
+    this.name = "NonJsonResponseError";
+    this.status = status;
+  }
+}


### PR DESCRIPTION
### Features and Changes

An enterprise customer behind Google IAP reported `Unexpected token 'I', "Invalid IA"... is not valid JSON` whenever they reopened an old tab: the proxy session had expired, so every API call got IAP's plain-text 401 and we parsed it as JSON.

Non-JSON API responses now throw a typed error with a readable message. When the user-loading path hits one with a 401/403, we reload the page, at most once a minute (last-reload timestamp in sessionStorage) so a broken proxy can't loop; the top-level navigation is what lets the proxy re-authenticate, so the tab recovers on its own. Failed writes behind an expired proxy now show the readable message instead of the parse error, with no reload, so form state isn't lost.

### Testing

Verified against a local IAP-spoof proxy in front of the API (plain-text 401s on everything except `/auth/*`, with toggleable status and path scope), driving headless Chrome through each scenario:

- [x] Expired proxy session -> one automatic reload, then the friendly message, no reload loop
- [x] Proxy restored -> reload recovers the app
- [x] Non-auth failure (plain-text HTTP 500) -> "The API returned an invalid response (HTTP 500)", no reload
- [x] Split failure (`/organization` only) -> one reload, then the friendly message, no loop
