### PR TITLE
Delete shared feature rule from one environment only (narrow, not global)

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -5418,17 +5418,23 @@ export async function deleteFeatureRule(
         : (rule.environments ?? []);
   }
 
-  // Strip any pending ramp actions for the deleted rule so publish doesn't
-  // create a schedule doc that would be immediately cleaned up as orphaned.
-  // Mirrors the REST handler's behavior.
+  // Pending ramp actions target a rule by id (environment is deprecated); a
+  // ramp applies to every environment the rule serves at publish time. So only
+  // strip them when the rule is fully removed (its last applicable env was
+  // deleted). An env-scoped delete that merely narrows a shared rule — where it
+  // survives in other envs — must keep the ramp so the surviving env's schedule
+  // isn't lost. Mirrors the REST handler's `fullyDeleted` behavior.
   const changes: { rules: FeatureRule[]; rampActions?: RevisionRampAction[] } =
     { rules: nextRules };
-  const existingRampActions = revision.rampActions ?? [];
-  const filteredRampActions = existingRampActions.filter(
-    (a) => a.ruleId !== ruleId,
-  );
-  if (filteredRampActions.length !== existingRampActions.length) {
-    changes.rampActions = filteredRampActions;
+  const ruleFullyRemoved = !nextRules.some((r) => r.id === ruleId);
+  if (ruleFullyRemoved) {
+    const existingRampActions = revision.rampActions ?? [];
+    const filteredRampActions = existingRampActions.filter(
+      (a) => a.ruleId !== ruleId,
+    );
+    if (filteredRampActions.length !== existingRampActions.length) {
+      changes.rampActions = filteredRampActions;
+    }
   }
 
   const resetReview = resetReviewOnChange({

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -179,6 +179,8 @@ import {
   stampRuleForEnvs,
   updateRuleById,
   removeRuleById,
+  projectRulesForEnv,
+  removeRuleAtEnvIndex,
 } from "back-end/src/util/revisionRuleOps";
 import {
   getSDKPayloadCacheLocation,
@@ -5351,13 +5353,16 @@ export async function getDraftandReviewRevisions(
 }
 
 export async function deleteFeatureRule(
-  req: AuthRequest<{ ruleId: string }, { id: string; version: string }>,
+  req: AuthRequest<
+    { ruleId: string; environment?: string },
+    { id: string; version: string }
+  >,
   res: Response<{ status: 200; version: number }, EventUserForResponseLocals>,
 ) {
   const context = getContextFromReq(req);
   const { org } = context;
   const { id, version } = req.params;
-  const { ruleId } = req.body;
+  const { ruleId, environment } = req.body;
 
   if (!ruleId) {
     throw new Error("Must provide ruleId to identify the rule");
@@ -5379,14 +5384,39 @@ export async function deleteFeatureRule(
   const revision = await getDraftRevision(context, feature, parseInt(version));
   const existingRules = cloneDeep(revision.rules ?? []);
 
-  const { rules: nextRules, removed: rule } = removeRuleById(
-    existingRules,
-    ruleId,
-  );
-  const ruleChangedEnvs: string[] =
-    rule.allEnvironments || rule.environments === undefined
-      ? environmentIds
-      : (rule.environments ?? []);
+  let nextRules: FeatureRule[];
+  let rule: FeatureRule;
+  let ruleChangedEnvs: string[];
+
+  if (environment) {
+    // Env-scoped delete (from the per-environment UI). A shared rule is
+    // narrowed to its remaining applicable envs rather than deleted from
+    // every environment at once (fixes #6663).
+    const ruleIndex = projectRulesForEnv(
+      existingRules,
+      environment,
+    ).envRules.findIndex((r) => r.id === ruleId);
+    if (ruleIndex === -1) {
+      throw new Error("Unknown rule");
+    }
+    const result = removeRuleAtEnvIndex(
+      existingRules,
+      environment,
+      ruleIndex,
+      environmentIds,
+    );
+    nextRules = result.rules;
+    rule = result.removed;
+    ruleChangedEnvs = [environment];
+  } else {
+    const result = removeRuleById(existingRules, ruleId);
+    nextRules = result.rules;
+    rule = result.removed;
+    ruleChangedEnvs =
+      rule.allEnvironments || rule.environments === undefined
+        ? environmentIds
+        : (rule.environments ?? []);
+  }
 
   // Strip any pending ramp actions for the deleted rule so publish doesn't
   // create a schedule doc that would be immediately cleaned up as orphaned.

--- a/packages/back-end/test/api/features/deleteFeatureRule.environment.test.ts
+++ b/packages/back-end/test/api/features/deleteFeatureRule.environment.test.ts
@@ -58,6 +58,19 @@ const sharedRule = {
   enabled: true,
 };
 
+// A pending ramp create action targeting the shared rule by id. Ramp actions
+// are keyed to a rule (environment is deprecated), so they apply to every env
+// the rule serves. It must survive an env-scoped delete as long as the rule
+// does, and be stripped when the rule's last env is removed.
+const pendingRampAction = {
+  mode: "create",
+  ruleId: RULE_ID,
+  name: "ramp shared",
+  startActions: [],
+  steps: [{ interval: 86400, actions: [] }],
+  endActions: [],
+};
+
 function makeReq(environment: string): AuthRequest {
   const req = {
     params: { id: FEATURE_ID, version: "2" },
@@ -91,7 +104,10 @@ function makeRes() {
   } as never;
 }
 
-async function seedFeatureAndDraft(rules: Array<Record<string, unknown>>) {
+async function seedFeatureAndDraft(
+  rules: Array<Record<string, unknown>>,
+  rampActions?: Array<Record<string, unknown>>,
+) {
   await mongoose.connection.collection("features").insertOne({
     id: FEATURE_ID,
     organization: ORG_ID,
@@ -131,6 +147,7 @@ async function seedFeatureAndDraft(rules: Array<Record<string, unknown>>) {
     defaultValue: "off",
     valueType: "string",
     rules,
+    ...(rampActions !== undefined && { rampActions }),
     environmentsEnabled: { production: true, staging: true },
     log: [],
   });
@@ -141,6 +158,13 @@ async function getDraftRules() {
     .collection("featurerevisions")
     .findOne({ organization: ORG_ID, featureId: FEATURE_ID, version: 2 });
   return (doc?.rules as Array<{ id: string; environments?: string[] }>) ?? [];
+}
+
+async function getDraftRampActions() {
+  const doc = await mongoose.connection
+    .collection("featurerevisions")
+    .findOne({ organization: ORG_ID, featureId: FEATURE_ID, version: 2 });
+  return (doc?.rampActions as Array<{ ruleId?: string }>) ?? [];
 }
 
 describe("deleteFeatureRule env-scoped delete (#6663)", () => {
@@ -173,5 +197,41 @@ describe("deleteFeatureRule env-scoped delete (#6663)", () => {
 
     const rules = await getDraftRules();
     expect(rules).toEqual([]);
+  });
+
+  it("preserves the pending ramp action when a shared rule is narrowed to a surviving env", async () => {
+    await seedFeatureAndDraft([sharedRule], [pendingRampAction]);
+
+    // Delete the shared rule only from production; it survives for staging.
+    await deleteFeatureRule(makeReq("production"), makeRes());
+
+    const rules = await getDraftRules();
+    expect(rules).toHaveLength(1);
+    expect(rules[0].id).toBe(RULE_ID);
+    expect(rules[0].environments).toEqual(["staging"]);
+
+    // The ramp targets the rule by id and applies wherever it serves — it must
+    // NOT be stripped, or staging would silently lose its pending schedule.
+    const rampActions = await getDraftRampActions();
+    expect(rampActions).toHaveLength(1);
+    expect(rampActions[0].ruleId).toBe(RULE_ID);
+  });
+
+  it("strips the pending ramp action when the rule's last applicable env is deleted", async () => {
+    await seedFeatureAndDraft(
+      [{ ...sharedRule, environments: ["production"] }],
+      [pendingRampAction],
+    );
+
+    // Deleting the only env fully removes the rule — its ramp must go too,
+    // otherwise publish would create a schedule for a rule that no longer
+    // exists.
+    await deleteFeatureRule(makeReq("production"), makeRes());
+
+    const rules = await getDraftRules();
+    expect(rules).toEqual([]);
+
+    const rampActions = await getDraftRampActions();
+    expect(rampActions).toEqual([]);
   });
 });

--- a/packages/back-end/test/api/features/deleteFeatureRule.environment.test.ts
+++ b/packages/back-end/test/api/features/deleteFeatureRule.environment.test.ts
@@ -1,0 +1,177 @@
+import mongoose from "mongoose";
+import type { Request } from "express";
+import type { OrganizationInterface } from "shared/types/organization";
+import type { AuthRequest } from "back-end/src/types/AuthRequest";
+import * as featuresController from "back-end/src/controllers/features";
+import { setupApp } from "../api.setup";
+
+const { deleteFeatureRule } = featuresController;
+
+// Regression for #6663: "Deleting a rule from one environment deletes it in all
+// environments". The UI's per-environment delete sends `{ ruleId, environment }`
+// to `deleteFeatureRule` (the controller behind `DELETE /feature/:id/:version/rule`).
+// A shared rule (production + staging) must be narrowed to its remaining
+// applicable envs, not removed from every environment at once.
+//
+// This drives the actual controller against real in-memory Mongo with real model
+// functions (getFeature / getDraftRevision / updateRevision). The request carries
+// real auth fields (organization/userId/email) so `getContextFromReq` builds a
+// real ReqContextClass, keeping the whole rule-mutation decision path real. The
+// test fails against the old implementation that used `removeRuleById` (global
+// delete) and passes with the env-scoped narrowing.
+
+const FEATURE_ID = "feat_rule_del_env";
+const RULE_ID = "fr_shared";
+const ORG_ID = "org_rule_del_env";
+const USER_ID = "u_ruledel";
+
+const ORG = {
+  id: ORG_ID,
+  name: "Rule Delete Env",
+  ownerEmail: "ruledel@test.com",
+  url: "",
+  dateCreated: new Date(),
+  members: [
+    {
+      id: USER_ID,
+      role: "admin",
+      limitAccessByEnvironment: false,
+      environments: [],
+    },
+  ],
+  settings: {
+    environments: [
+      { id: "production", description: "" },
+      { id: "staging", description: "" },
+    ],
+  },
+} as unknown as OrganizationInterface;
+
+const sharedRule = {
+  id: RULE_ID,
+  allEnvironments: false,
+  environments: ["production", "staging"],
+  type: "force",
+  description: "",
+  value: "on",
+  condition: "{}",
+  enabled: true,
+};
+
+function makeReq(environment: string): AuthRequest {
+  const req = {
+    params: { id: FEATURE_ID, version: "2" },
+    body: { ruleId: RULE_ID, environment },
+    organization: ORG,
+    userId: USER_ID,
+    email: "ruledel@test.com",
+    name: "Test",
+    superAdmin: false,
+    teams: [],
+    headers: {},
+    query: {},
+    log: { child: () => ({}) },
+    currentUser: { id: USER_ID, email: "ruledel@test.com", superAdmin: false },
+  } as unknown as Request;
+  return req as AuthRequest;
+}
+
+function makeRes() {
+  return {
+    locals: {
+      eventAudit: {
+        type: "dashboard",
+        id: USER_ID,
+        email: "ruledel@test.com",
+        name: "Test",
+      },
+    },
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  } as never;
+}
+
+async function seedFeatureAndDraft(rules: Array<Record<string, unknown>>) {
+  await mongoose.connection.collection("features").insertOne({
+    id: FEATURE_ID,
+    organization: ORG_ID,
+    version: 1,
+    defaultValue: "off",
+    valueType: "string",
+    owner: "",
+    description: "",
+    project: "",
+    tags: [],
+    dateCreated: new Date(),
+    dateUpdated: new Date(),
+    rules: [],
+    environmentSettings: {
+      production: { enabled: true },
+      staging: { enabled: true },
+    },
+    archived: false,
+  });
+
+  const now = new Date();
+  await mongoose.connection.collection("featurerevisions").insertOne({
+    organization: ORG_ID,
+    featureId: FEATURE_ID,
+    version: 2,
+    dateCreated: now,
+    dateUpdated: now,
+    createdBy: {
+      type: "dashboard",
+      id: USER_ID,
+      email: "ruledel@test.com",
+      name: "T",
+    },
+    baseVersion: 1,
+    status: "draft",
+    comment: "",
+    defaultValue: "off",
+    valueType: "string",
+    rules,
+    environmentsEnabled: { production: true, staging: true },
+    log: [],
+  });
+}
+
+async function getDraftRules() {
+  const doc = await mongoose.connection
+    .collection("featurerevisions")
+    .findOne({ organization: ORG_ID, featureId: FEATURE_ID, version: 2 });
+  return (doc?.rules as Array<{ id: string; environments?: string[] }>) ?? [];
+}
+
+describe("deleteFeatureRule env-scoped delete (#6663)", () => {
+  const { isReady } = setupApp();
+
+  beforeAll(async () => {
+    await isReady;
+    await mongoose.connection.collection("organizations").insertOne(ORG);
+  });
+
+  it("narrows a shared rule to remaining envs instead of deleting it globally", async () => {
+    await seedFeatureAndDraft([sharedRule]);
+
+    await deleteFeatureRule(makeReq("production"), makeRes());
+
+    // The shared rule must survive narrowed to staging: removed only from
+    // production, not from every environment at once.
+    const rules = await getDraftRules();
+    expect(rules).toHaveLength(1);
+    expect(rules[0].id).toBe(RULE_ID);
+    expect(rules[0].environments).toEqual(["staging"]);
+  });
+
+  it("removes the rule entirely when deleting its last applicable env", async () => {
+    await seedFeatureAndDraft([
+      { ...sharedRule, environments: ["production"] },
+    ]);
+
+    await deleteFeatureRule(makeReq("production"), makeRes());
+
+    const rules = await getDraftRules();
+    expect(rules).toEqual([]);
+  });
+});

--- a/packages/back-end/test/util/revisionRuleOps.test.ts
+++ b/packages/back-end/test/util/revisionRuleOps.test.ts
@@ -120,6 +120,30 @@ describe("removeRuleAtEnvIndex", () => {
     expect(next[0].allEnvironments).toBe(false);
   });
 
+  it("narrows a shared allEnvironments rule to remaining applicable envs instead of deleting globally (#6663)", () => {
+    const shared = allEnvRule("shared");
+    const prod1 = envRule("prod1", "prod");
+    const rules = [shared, prod1];
+
+    // Env-scoped delete from "dev": the shared rule must survive narrowed to
+    // every OTHER applicable env, not vanish from all environments at once.
+    const applicable = ["dev", "staging", "prod"];
+    const { rules: next } = removeRuleAtEnvIndex(rules, "dev", 0, applicable);
+    expect(next).toHaveLength(2);
+    expect(next[0].id).toBe("shared");
+    expect(next[0].allEnvironments).toBe(false);
+    expect(next[0].environments).toEqual(["staging", "prod"]);
+    expect(next[1].id).toBe("prod1");
+  });
+
+  it("deletes a shared rule globally when removing its last applicable env", () => {
+    const shared = allEnvRule("shared");
+    const rules = [shared];
+
+    const { rules: next } = removeRuleAtEnvIndex(rules, "dev", 0, ["dev"]);
+    expect(next).toEqual([]);
+  });
+
   it("throws on bad index", () => {
     const rules = [envRule("a", "dev")];
     expect(() => removeRuleAtEnvIndex(rules, "dev", 5)).toThrow(

--- a/packages/front-end/components/Features/Rule.tsx
+++ b/packages/front-end/components/Features/Rule.tsx
@@ -806,7 +806,10 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
                 `/feature/${feature.id}/${targetVersion}/rule`,
                 {
                   method: "DELETE",
-                  body: JSON.stringify({ ruleId: rule.id }),
+                  body: JSON.stringify({
+                    ruleId: rule.id,
+                    ...(!isAllEnvsView && environment ? { environment } : {}),
+                  }),
                 },
               );
               await mutate();


### PR DESCRIPTION
## Summary
Fixes #6663 — deleting a shared feature rule from one environment via the UI deleted it from every environment at once.

## Root cause
The UI per-environment delete hit `DELETE /feature/:id/:version/rule`, which only sent `{ ruleId }`. The backend `deleteFeatureRule` controller then called `removeRuleById()` — a global delete that splices the rule out of the flat revision rules array, removing it from all environments.

## Change
- **front-end**: Rule delete now sends `environment` in the DELETE body (except in the all-environments view, where there is no real env).
- **back-end**: `deleteFeatureRule` now, when `environment` is supplied, narrows the shared rule to its remaining applicable envs via `projectRulesForEnv` + `removeRuleAtEnvIndex(...)` instead of deleting it globally. No-env behavior (all-envs view / external callers) is unchanged.

## Regression test
Adds a controller-level test (`deleteFeatureRule`) exercising the actual bug path: a rule in `production` + `staging` deleted with `{ ruleId, environment: "production" }` survives as `["staging"]`. The test fails on the old `removeRuleById` implementation and passes with the fix.

## Testing
- New regression test + existing feature/helper suites: 135 passing