### PR TITLE
Pricing phase 1: Pro tier limits

### DIFF
--- a/docs/account/user-permissions.mdx
+++ b/docs/account/user-permissions.mdx
@@ -13,7 +13,7 @@ GrowthBook's user permissions system allows organizations to define the level of
 <Note>
 **Plan availability**
 
-On the Free plan, members can only be assigned the `Admin` role — assigning any other role (including custom roles) requires a Pro or Enterprise account. Organizations created before this limit was introduced are unaffected, and existing role assignments always keep working.
+On the Free plan, members can only be assigned the `Admin` role — assigning any other role (including custom roles) requires a Pro or Enterprise account. Pro and Enterprise organizations have full access to role management. Organizations created before this limit was introduced are unaffected, and existing role assignments always keep working.
 
 </Note>
 

--- a/docs/features/environments.mdx
+++ b/docs/features/environments.mdx
@@ -13,7 +13,7 @@ GrowthBook comes with one environment by default (**production**), but you can a
 <Note>
 **Plan availability**
 
-Free organizations can use the built-in environments (`production`, `dev`, `staging`, and `test`). Creating custom environments beyond these requires a Pro or Enterprise plan. Organizations created before this limit was introduced are unaffected.
+Free and Pro organizations can use the built-in environments (`production`, `dev`, `staging`, and `test`). Creating custom environments beyond these requires an Enterprise plan. Organizations created before this limit was introduced are unaffected.
 
 </Note>
 
@@ -44,7 +44,7 @@ Environments and projects are both ways to organize feature flags, but they serv
 
 **Environments** represent _where_ your code runs — such as development, staging, and production. A single feature flag exists across all environments, but can be enabled, disabled, or configured differently in each one. Environments map to SDK connections: each SDK key is tied to one environment, so your production app only receives production rules.
 
-**Projects** represent _what_ you're working on — such as a product area, team, or application. Projects scope which flags, experiments, metrics, and data sources are visible to a given team. Items in GrowthBook can belong to multiple projects, and items with no project assigned are available globally. Projects also let you customize permissions and even statistical settings per team. Manage projects under **Settings → Projects**. Free organizations include one project; creating additional projects requires a Pro or Enterprise plan (organizations created before this limit was introduced are unaffected).
+**Projects** represent _what_ you're working on — such as a product area, team, or application. Projects scope which flags, experiments, metrics, and data sources are visible to a given team. Items in GrowthBook can belong to multiple projects, and items with no project assigned are available globally. Projects also let you customize permissions and even statistical settings per team. Manage projects under **Settings → Projects**. Free organizations include one project and Pro organizations include three; the sample data project doesn't count toward either. Creating more requires an Enterprise plan (organizations created before this limit was introduced are unaffected).
 
 In practice, you use both together: a feature flag in the "Mobile App" project might be enabled in the dev environment for testing but disabled in production until launch.
 

--- a/packages/back-end/src/enterprise/licenseUtil.ts
+++ b/packages/back-end/src/enterprise/licenseUtil.ts
@@ -1064,8 +1064,7 @@ export function getEffectiveAccountPlan(org: MinimalOrganization): AccountPlan {
 }
 
 // Raw plan limits only — does NOT honor the pricing-limits flag's kill switch.
-// Enforcement paths must use getEffectiveOrgLimits (services/plan-limits.ts),
-// which passes the flag-resolved config as `planLimitsOverride`.
+// Enforcement paths must use getEffectiveOrgLimits (services/plan-limits.ts).
 export function getOrgLimits(
   org: MinimalOrganization & Pick<OrganizationInterface, "limits">,
   planLimitsOverride?: OrgLimits,

--- a/packages/back-end/src/enterprise/licenseUtil.ts
+++ b/packages/back-end/src/enterprise/licenseUtil.ts
@@ -17,7 +17,10 @@ import {
   LicenseMetaData,
   LicenseUserCodes,
   makeOrgLimits,
+  DEFAULT_ORG_LIMITS,
+  OrgLimits,
   OrgLimitsAccessor,
+  planTierFor,
   SubscriptionInfo,
 } from "shared/enterprise";
 import { StripeAddress, TaxIdType } from "shared/types/subscriptions";
@@ -1061,15 +1064,21 @@ export function getEffectiveAccountPlan(org: MinimalOrganization): AccountPlan {
 }
 
 // Raw plan limits only — does NOT honor the pricing-limits flag's kill switch.
-// Enforcement paths must use getEffectiveOrgLimits (services/plan-limits.ts).
+// Enforcement paths must use getEffectiveOrgLimits (services/plan-limits.ts),
+// which passes the flag-resolved config as `planLimitsOverride`.
 export function getOrgLimits(
   org: MinimalOrganization & Pick<OrganizationInterface, "limits">,
+  planLimitsOverride?: OrgLimits,
 ): OrgLimitsAccessor {
+  const effectivePlan = getEffectiveAccountPlan(org);
+  const tier = planTierFor(effectivePlan);
   return makeOrgLimits({
-    effectivePlan: getEffectiveAccountPlan(org),
+    effectivePlan,
     orgLimits: org.limits,
     licenseLimits: getLicense(org.licenseKey || process.env.LICENSE_KEY)
       ?.limits,
+    planLimits:
+      planLimitsOverride ?? (tier ? DEFAULT_ORG_LIMITS[tier] : undefined),
   });
 }
 

--- a/packages/back-end/src/models/ApiKeyModel.ts
+++ b/packages/back-end/src/models/ApiKeyModel.ts
@@ -147,7 +147,7 @@ export class ApiKeyModel extends BaseClass {
         doc.role !== "admin" &&
         !this.context.limits.orgSupportsRoles()
       ) {
-        this.context.throwBadRequestError(
+        this.context.throwPaymentRequiredError(
           "Your plan only supports the admin role. Upgrade your plan to assign other roles.",
         );
       }

--- a/packages/back-end/src/routers/vercel-native-integration/vercel-native-integration.controller.ts
+++ b/packages/back-end/src/routers/vercel-native-integration/vercel-native-integration.controller.ts
@@ -6,7 +6,6 @@ import { v4 as uuidv4 } from "uuid";
 import { ManagedBy } from "shared/validators";
 import { isDemoDatasourceProject } from "shared/demo-datasource";
 import { OrganizationInterface } from "shared/types/organization";
-import { FREE_ORG_LIMITS, PRO_ORG_LIMITS, OrgLimits } from "shared/enterprise";
 import {
   findVercelInstallationByInstallationId,
   VercelNativeIntegrationModel,
@@ -64,12 +63,6 @@ import {
   BillingPlan,
 } from "./vercel-native-integration.validators";
 
-// Vercel installations always create a brand new org, so the plan's limits
-// always apply — no grandfathering to account for here.
-function projectLimitLabel({ maxProjects }: OrgLimits): string {
-  return maxProjects == null ? "Unlimited" : `Limit ${maxProjects}`;
-}
-
 const STARTER_BILLING_PLAN: BillingPlan = {
   description: "Basic flags and experiments for solo devs and small teams",
   id: "starter-billing-plan",
@@ -81,7 +74,7 @@ const STARTER_BILLING_PLAN: BillingPlan = {
   details: [
     { label: "Feature Flags & Evaluations", value: "Unlimited" },
     { label: "Experiments", value: "Unlimited" },
-    { label: "Projects", value: projectLimitLabel(FREE_ORG_LIMITS) },
+    { label: "Projects", value: "Limit 1" },
     { label: "Seats", value: "Up to 3" },
   ],
 };
@@ -100,7 +93,7 @@ function getProBillingPlan(perSeatCost: number): BillingPlan {
     details: [
       { label: "Feature Flags & Evaluations", value: "Unlimited" },
       { label: "Experiments", value: "Unlimited" },
-      { label: "Projects", value: projectLimitLabel(PRO_ORG_LIMITS) },
+      { label: "Projects", value: "Limit 3" },
       { label: "Seats", value: `$${perSeatCost}/seat/month` },
       {
         label: "Advanced Flags",

--- a/packages/back-end/src/routers/vercel-native-integration/vercel-native-integration.controller.ts
+++ b/packages/back-end/src/routers/vercel-native-integration/vercel-native-integration.controller.ts
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from "uuid";
 import { ManagedBy } from "shared/validators";
 import { isDemoDatasourceProject } from "shared/demo-datasource";
 import { OrganizationInterface } from "shared/types/organization";
+import { FREE_ORG_LIMITS, PRO_ORG_LIMITS, OrgLimits } from "shared/enterprise";
 import {
   findVercelInstallationByInstallationId,
   VercelNativeIntegrationModel,
@@ -63,6 +64,12 @@ import {
   BillingPlan,
 } from "./vercel-native-integration.validators";
 
+// Vercel installations always create a brand new org, so the plan's limits
+// always apply — no grandfathering to account for here.
+function projectLimitLabel({ maxProjects }: OrgLimits): string {
+  return maxProjects == null ? "Unlimited" : `Limit ${maxProjects}`;
+}
+
 const STARTER_BILLING_PLAN: BillingPlan = {
   description: "Basic flags and experiments for solo devs and small teams",
   id: "starter-billing-plan",
@@ -74,7 +81,7 @@ const STARTER_BILLING_PLAN: BillingPlan = {
   details: [
     { label: "Feature Flags & Evaluations", value: "Unlimited" },
     { label: "Experiments", value: "Unlimited" },
-    { label: "Projects", value: "Limit 1" },
+    { label: "Projects", value: projectLimitLabel(FREE_ORG_LIMITS) },
     { label: "Seats", value: "Up to 3" },
   ],
 };
@@ -93,7 +100,7 @@ function getProBillingPlan(perSeatCost: number): BillingPlan {
     details: [
       { label: "Feature Flags & Evaluations", value: "Unlimited" },
       { label: "Experiments", value: "Unlimited" },
-      { label: "Projects", value: "Unlimited" },
+      { label: "Projects", value: projectLimitLabel(PRO_ORG_LIMITS) },
       { label: "Seats", value: `$${perSeatCost}/seat/month` },
       {
         label: "Advanced Flags",

--- a/packages/back-end/src/services/plan-limits.ts
+++ b/packages/back-end/src/services/plan-limits.ts
@@ -19,9 +19,8 @@ import {
 import { IS_CLOUD } from "back-end/src/util/secrets";
 
 // Limits stamped onto a newly created org. Cloud reads the flag; self-hosted
-// always uses the hardcoded defaults. New orgs always start on the free tier,
-// so the stamp holds free values — its presence is also what marks the org as
-// subject to plan limits at all (missing = grandfathered, on every plan).
+// always uses the hardcoded defaults. Every org is created free, so the stamp
+// holds free values; its presence is what marks the org as non-grandfathered.
 export async function getStampedOrgLimits(): Promise<OrgLimits> {
   if (!IS_CLOUD) return { ...FREE_ORG_LIMITS };
 
@@ -34,9 +33,8 @@ export async function getStampedOrgLimits(): Promise<OrgLimits> {
   return resolveOrgLimitsConfig(raw);
 }
 
-// The flag evaluated for this org, with trusted server-derived attributes only
-// (no request context, so the SDK's query-string override cannot influence
-// enforcement). Self-hosted never reads the CDN for limits.
+// Trusted server-derived attributes only — no request context, so the SDK's
+// query-string override cannot influence enforcement.
 function evalLimitsFlagForOrg(org: OrganizationInterface): unknown {
   if (!IS_CLOUD) return undefined;
   return getGrowthBookClient()?.evalFeature(PRICING_PHASE_1_FLAG_KEY, {
@@ -44,25 +42,22 @@ function evalLimitsFlagForOrg(org: OrganizationInterface): unknown {
   }).value;
 }
 
-// getOrgLimits, plus the two enforcement-time jobs of the pricing flag:
-//   - `enabled: false` (base value or a per-org targeting rule) lifts all
-//     limits for the evaluated org.
-//   - the served limit fields are the org's live per-plan config. Paid tiers
-//     need this because the stamp is frozen at creation time (always free), so
-//     an org that upgraded to Pro resolves its limits against its current plan
-//     via an accountPlan targeting rule.
+// getOrgLimits, plus the flag's on/off switch: `enabled: false` (base value or
+// a per-org targeting rule) lifts all limits for the evaluated org. The served
+// limit fields are the org's live per-plan config, which paid tiers need
+// because their stamp is frozen at creation time on the free tier.
 export function getEffectiveOrgLimits(
   org: OrganizationInterface,
 ): OrgLimitsAccessor {
+  const effectivePlan = getEffectiveAccountPlan(org);
   const raw = evalLimitsFlagForOrg(org);
 
   if (isLimitsFlagDisabled(raw)) {
-    return makeOrgLimits({ effectivePlan: getEffectiveAccountPlan(org) });
+    return makeOrgLimits({ effectivePlan });
   }
 
-  // Free limits come from the stamp, not the flag, so only paid tiers need an
-  // override here. Self-hosted falls through to getOrgLimits' tier defaults.
-  const tier = planTierFor(getEffectiveAccountPlan(org));
+  // Free limits come from the stamp, so only paid tiers read the flag here.
+  const tier = planTierFor(effectivePlan);
   const planLimitsOverride =
     IS_CLOUD && tier && tier !== "free"
       ? resolveOrgLimitsConfig(raw, DEFAULT_ORG_LIMITS[tier])

--- a/packages/back-end/src/services/plan-limits.ts
+++ b/packages/back-end/src/services/plan-limits.ts
@@ -19,8 +19,7 @@ import {
 import { IS_CLOUD } from "back-end/src/util/secrets";
 
 // Limits stamped onto a newly created org. Cloud reads the flag; self-hosted
-// always uses the hardcoded defaults. Every org is created free, so the stamp
-// holds free values; its presence is what marks the org as non-grandfathered.
+// always uses the hardcoded defaults.
 export async function getStampedOrgLimits(): Promise<OrgLimits> {
   if (!IS_CLOUD) return { ...FREE_ORG_LIMITS };
 
@@ -33,8 +32,6 @@ export async function getStampedOrgLimits(): Promise<OrgLimits> {
   return resolveOrgLimitsConfig(raw);
 }
 
-// Trusted server-derived attributes only — no request context, so the SDK's
-// query-string override cannot influence enforcement.
 function evalLimitsFlagForOrg(org: OrganizationInterface): unknown {
   if (!IS_CLOUD) return undefined;
   return getGrowthBookClient()?.evalFeature(PRICING_PHASE_1_FLAG_KEY, {
@@ -43,9 +40,7 @@ function evalLimitsFlagForOrg(org: OrganizationInterface): unknown {
 }
 
 // getOrgLimits, plus the flag's on/off switch: `enabled: false` (base value or
-// a per-org targeting rule) lifts all limits for the evaluated org. The served
-// limit fields are the org's live per-plan config, which paid tiers need
-// because their stamp is frozen at creation time on the free tier.
+// a per-org targeting rule) lifts all limits for the evaluated org.
 export function getEffectiveOrgLimits(
   org: OrganizationInterface,
 ): OrgLimitsAccessor {
@@ -56,7 +51,6 @@ export function getEffectiveOrgLimits(
     return makeOrgLimits({ effectivePlan });
   }
 
-  // Free limits come from the stamp, so only paid tiers read the flag here.
   const tier = planTierFor(effectivePlan);
   const planLimitsOverride =
     IS_CLOUD && tier && tier !== "free"

--- a/packages/back-end/src/services/plan-limits.ts
+++ b/packages/back-end/src/services/plan-limits.ts
@@ -1,10 +1,12 @@
 import {
+  DEFAULT_ORG_LIMITS,
   FREE_ORG_LIMITS,
   OrgLimits,
   OrgLimitsAccessor,
   PRICING_PHASE_1_FLAG_KEY,
   isLimitsFlagDisabled,
   makeOrgLimits,
+  planTierFor,
   resolveOrgLimitsConfig,
 } from "shared/enterprise";
 import { OrganizationInterface } from "shared/types/organization";
@@ -17,7 +19,9 @@ import {
 import { IS_CLOUD } from "back-end/src/util/secrets";
 
 // Limits stamped onto a newly created org. Cloud reads the flag; self-hosted
-// always uses the hardcoded defaults.
+// always uses the hardcoded defaults. New orgs always start on the free tier,
+// so the stamp holds free values — its presence is also what marks the org as
+// subject to plan limits at all (missing = grandfathered, on every plan).
 export async function getStampedOrgLimits(): Promise<OrgLimits> {
   if (!IS_CLOUD) return { ...FREE_ORG_LIMITS };
 
@@ -30,22 +34,39 @@ export async function getStampedOrgLimits(): Promise<OrgLimits> {
   return resolveOrgLimitsConfig(raw);
 }
 
-function isPricingLimitsDisabledForOrg(org: OrganizationInterface): boolean {
-  if (!IS_CLOUD) return false;
-
-  const raw = getGrowthBookClient()?.evalFeature(PRICING_PHASE_1_FLAG_KEY, {
+// The flag evaluated for this org, with trusted server-derived attributes only
+// (no request context, so the SDK's query-string override cannot influence
+// enforcement). Self-hosted never reads the CDN for limits.
+function evalLimitsFlagForOrg(org: OrganizationInterface): unknown {
+  if (!IS_CLOUD) return undefined;
+  return getGrowthBookClient()?.evalFeature(PRICING_PHASE_1_FLAG_KEY, {
     attributes: getTrustedOrgAttributes(org),
   }).value;
-  return isLimitsFlagDisabled(raw);
 }
 
-// getOrgLimits, plus the flag's on/off switch: `enabled: false` (base value or
-// a per-org targeting rule) lifts all limits for the evaluated org.
+// getOrgLimits, plus the two enforcement-time jobs of the pricing flag:
+//   - `enabled: false` (base value or a per-org targeting rule) lifts all
+//     limits for the evaluated org.
+//   - the served limit fields are the org's live per-plan config. Paid tiers
+//     need this because the stamp is frozen at creation time (always free), so
+//     an org that upgraded to Pro resolves its limits against its current plan
+//     via an accountPlan targeting rule.
 export function getEffectiveOrgLimits(
   org: OrganizationInterface,
 ): OrgLimitsAccessor {
-  if (isPricingLimitsDisabledForOrg(org)) {
+  const raw = evalLimitsFlagForOrg(org);
+
+  if (isLimitsFlagDisabled(raw)) {
     return makeOrgLimits({ effectivePlan: getEffectiveAccountPlan(org) });
   }
-  return getOrgLimits(org);
+
+  // Free limits come from the stamp, not the flag, so only paid tiers need an
+  // override here. Self-hosted falls through to getOrgLimits' tier defaults.
+  const tier = planTierFor(getEffectiveAccountPlan(org));
+  const planLimitsOverride =
+    IS_CLOUD && tier && tier !== "free"
+      ? resolveOrgLimitsConfig(raw, DEFAULT_ORG_LIMITS[tier])
+      : undefined;
+
+  return getOrgLimits(org, planLimitsOverride);
 }

--- a/packages/front-end/AGENTS.md
+++ b/packages/front-end/AGENTS.md
@@ -18,13 +18,3 @@ Permission controls must:
 - Use independent, discriminating fixtures rather than deriving expected values through the implementation under test.
 
 See `.agents/guides/flag-family-authority.md` for the authority rules.
-
-<!-- BEGIN:nextjs-agent-rules -->
-
-# This is NOT the Next.js you know
-
-This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
-
-This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
-
-<!-- END:nextjs-agent-rules -->

--- a/packages/front-end/AGENTS.md
+++ b/packages/front-end/AGENTS.md
@@ -18,3 +18,13 @@ Permission controls must:
 - Use independent, discriminating fixtures rather than deriving expected values through the implementation under test.
 
 See `.agents/guides/flag-family-authority.md` for the authority rules.
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/packages/front-end/components/Settings/EnvironmentModal.tsx
+++ b/packages/front-end/components/Settings/EnvironmentModal.tsx
@@ -84,7 +84,7 @@ export default function EnvironmentModal({
       <UpgradeModal
         close={close}
         source="environment limit"
-        commercialFeature={null}
+        commercialFeature="custom-environments"
       />
     );
   }
@@ -193,7 +193,7 @@ export default function EnvironmentModal({
       )}
       {!existing.id && !customEnvironmentsAllowed && (
         <PremiumCallout
-          commercialFeature="advanced-permissions"
+          commercialFeature="custom-environments"
           id="environment-plan-limit"
           mb="3"
         >

--- a/packages/front-end/components/Settings/UpgradeModal/index.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/index.tsx
@@ -284,6 +284,11 @@ export default function UpgradeModal({
       "Create product analytics dashboards and control who can view and edit them.",
     "metric-groups": "Simplify experiment analysis with Metric Groups",
     "advanced-permissions": "Manage advanced user permissions",
+    "role-management":
+      "Assign roles to teammates instead of making everyone an admin",
+    "unlimited-projects": "Create as many projects as you need",
+    "custom-environments":
+      "Create custom environments beyond production, dev, staging, and test",
     "encrypt-features-endpoint": "SDK endpoint encryption",
     "schedule-feature-flag": "Schedule feature flag rollouts",
     "override-metrics": "Override metric definitions on a per-experiment basis",

--- a/packages/front-end/hooks/useOrgLimits.ts
+++ b/packages/front-end/hooks/useOrgLimits.ts
@@ -15,32 +15,36 @@ import { isCloud } from "@/services/env";
 export default function useOrgLimits(): OrgLimitsAccessor {
   const { organization, license, effectiveAccountPlan } = useUser();
 
-  // Display-side mirror of the server's flag read (cloud only). The SDK is
-  // seeded with the org's accountPlan, so per-plan targeting resolves the same
-  // way it does server-side.
+  // Display-side mirror of the server's flag read (cloud only).
   const flagValue = useFeatureValue(PRICING_PHASE_1_FLAG_KEY, null);
+  const limitsDisabled = isCloud() && isLimitsFlagDisabled(flagValue);
 
   return useMemo(() => {
-    const plan = effectiveAccountPlan || "oss";
-
-    if (isCloud() && isLimitsFlagDisabled(flagValue)) {
-      return makeOrgLimits({ effectivePlan: plan });
+    if (limitsDisabled) {
+      return makeOrgLimits({ effectivePlan: effectiveAccountPlan || "oss" });
     }
 
     // Free limits come from the org's stamp; paid tiers resolve live.
-    const tier = planTierFor(plan);
+    const tier = planTierFor(effectiveAccountPlan || "oss");
     const planLimits =
       tier && tier !== "free"
-        ? isCloud()
-          ? resolveOrgLimitsConfig(flagValue, DEFAULT_ORG_LIMITS[tier])
-          : DEFAULT_ORG_LIMITS[tier]
+        ? resolveOrgLimitsConfig(
+            isCloud() ? flagValue : null,
+            DEFAULT_ORG_LIMITS[tier],
+          )
         : undefined;
 
     return makeOrgLimits({
-      effectivePlan: plan,
+      effectivePlan: effectiveAccountPlan || "oss",
       orgLimits: organization?.limits,
       licenseLimits: license?.limits,
       planLimits,
     });
-  }, [effectiveAccountPlan, organization?.limits, license?.limits, flagValue]);
+  }, [
+    effectiveAccountPlan,
+    organization?.limits,
+    license?.limits,
+    limitsDisabled,
+    flagValue,
+  ]);
 }

--- a/packages/front-end/hooks/useOrgLimits.ts
+++ b/packages/front-end/hooks/useOrgLimits.ts
@@ -1,9 +1,12 @@
 import { useMemo } from "react";
 import { useFeatureValue } from "@growthbook/growthbook-react";
 import {
+  DEFAULT_ORG_LIMITS,
   PRICING_PHASE_1_FLAG_KEY,
   isLimitsFlagDisabled,
   makeOrgLimits,
+  planTierFor,
+  resolveOrgLimitsConfig,
   OrgLimitsAccessor,
 } from "shared/enterprise";
 import { useUser } from "@/services/UserContext";
@@ -12,23 +15,32 @@ import { isCloud } from "@/services/env";
 export default function useOrgLimits(): OrgLimitsAccessor {
   const { organization, license, effectiveAccountPlan } = useUser();
 
-  // Display-side mirror of the server's flag on/off check (cloud only).
+  // Display-side mirror of the server's flag read (cloud only). The SDK is
+  // seeded with the org's accountPlan, so per-plan targeting resolves the same
+  // way it does server-side.
   const flagValue = useFeatureValue(PRICING_PHASE_1_FLAG_KEY, null);
-  const limitsDisabled = isCloud() && isLimitsFlagDisabled(flagValue);
 
   return useMemo(() => {
-    if (limitsDisabled) {
-      return makeOrgLimits({ effectivePlan: effectiveAccountPlan || "oss" });
+    const plan = effectiveAccountPlan || "oss";
+
+    if (isCloud() && isLimitsFlagDisabled(flagValue)) {
+      return makeOrgLimits({ effectivePlan: plan });
     }
+
+    // Free limits come from the org's stamp; paid tiers resolve live.
+    const tier = planTierFor(plan);
+    const planLimits =
+      tier && tier !== "free"
+        ? isCloud()
+          ? resolveOrgLimitsConfig(flagValue, DEFAULT_ORG_LIMITS[tier])
+          : DEFAULT_ORG_LIMITS[tier]
+        : undefined;
+
     return makeOrgLimits({
-      effectivePlan: effectiveAccountPlan || "oss",
+      effectivePlan: plan,
       orgLimits: organization?.limits,
       licenseLimits: license?.limits,
+      planLimits,
     });
-  }, [
-    effectiveAccountPlan,
-    organization?.limits,
-    license?.limits,
-    limitsDisabled,
-  ]);
+  }, [effectiveAccountPlan, organization?.limits, license?.limits, flagValue]);
 }

--- a/packages/front-end/hooks/useOrgLimits.ts
+++ b/packages/front-end/hooks/useOrgLimits.ts
@@ -15,7 +15,7 @@ import { isCloud } from "@/services/env";
 export default function useOrgLimits(): OrgLimitsAccessor {
   const { organization, license, effectiveAccountPlan } = useUser();
 
-  // Display-side mirror of the server's flag read (cloud only).
+  // Display-side mirror of the server's flag on/off check (cloud only).
   const flagValue = useFeatureValue(PRICING_PHASE_1_FLAG_KEY, null);
   const limitsDisabled = isCloud() && isLimitsFlagDisabled(flagValue);
 
@@ -24,7 +24,6 @@ export default function useOrgLimits(): OrgLimitsAccessor {
       return makeOrgLimits({ effectivePlan: effectiveAccountPlan || "oss" });
     }
 
-    // Free limits come from the org's stamp; paid tiers resolve live.
     const tier = planTierFor(effectiveAccountPlan || "oss");
     const planLimits =
       tier && tier !== "free"

--- a/packages/shared/src/enterprise/entitlements.ts
+++ b/packages/shared/src/enterprise/entitlements.ts
@@ -37,7 +37,6 @@ type LimitsInput = {
   // Stamped at org creation. Its absence means the org is grandfathered.
   orgLimits?: OrgLimits;
   licenseLimits?: OrgLimits;
-  // Live per-plan config, for tiers whose limits can't be stamped at creation.
   planLimits?: OrgLimits;
 };
 
@@ -62,14 +61,12 @@ function resolve({
 
   if (licenseLimits) return licenseLimits;
 
-  // Never stamped, so never limited on any plan.
   if (!orgLimits) return null;
 
   const tier = planTierFor(effectivePlan);
   if (!tier) return null;
 
-  // The stamp holds free values, so an org that upgraded reads its new tier's
-  // limits instead of the ones frozen at creation.
+  // The stamp holds free values, so an upgraded org reads its new tier's.
   return planLimits ?? DEFAULT_ORG_LIMITS[tier];
 }
 

--- a/packages/shared/src/enterprise/entitlements.ts
+++ b/packages/shared/src/enterprise/entitlements.ts
@@ -1,5 +1,10 @@
 import { DEFAULT_ENVIRONMENT_IDS } from "../util";
-import { AccountPlan, OrgLimits } from "./license-consts";
+import {
+  AccountPlan,
+  CommercialFeature,
+  OrgLimits,
+  accountFeatures,
+} from "./license-consts";
 
 export const FREE_ORG_LIMITS: OrgLimits = {
   maxProjects: 1,
@@ -7,29 +12,78 @@ export const FREE_ORG_LIMITS: OrgLimits = {
   roleManagement: false,
 };
 
-type LimitsInput = {
-  effectivePlan: AccountPlan;
-  orgLimits?: OrgLimits;
-  licenseLimits?: OrgLimits;
+export const PRO_ORG_LIMITS: OrgLimits = {
+  maxProjects: 3,
+  customEnvironments: false,
+  roleManagement: true,
 };
 
-// Free plans read the org's own snapshot; paid plans read the license's.
+// The tiers that carry plan limits. Enterprise is absent on purpose: it is
+// never subject to them (see planTierFor).
+export type LimitedPlanTier = "free" | "pro";
+
+export const DEFAULT_ORG_LIMITS: Record<LimitedPlanTier, OrgLimits> = {
+  free: FREE_ORG_LIMITS,
+  pro: PRO_ORG_LIMITS,
+};
+
+export function planTierFor(plan: AccountPlan): LimitedPlanTier | null {
+  if (plan === "oss" || plan === "starter") return "free";
+  if (plan === "pro" || plan === "pro_sso") return "pro";
+  return null;
+}
+
+type LimitsInput = {
+  effectivePlan: AccountPlan;
+  // Stamped at org creation. Its absence is the grandfathering signal: orgs
+  // created before pricing limits shipped have no stamp and stay unlimited.
+  orgLimits?: OrgLimits;
+  licenseLimits?: OrgLimits;
+  // Live per-plan config (flag-resolved) for tiers whose limits can't be
+  // stamped at creation because the plan is bought later. Falls back to
+  // DEFAULT_ORG_LIMITS.
+  planLimits?: OrgLimits;
+};
+
+function planAllows(
+  { effectivePlan }: LimitsInput,
+  feature: CommercialFeature,
+): boolean {
+  return accountFeatures[effectivePlan]?.has(feature) ?? false;
+}
+
 function resolve({
   effectivePlan,
   orgLimits,
   licenseLimits,
+  planLimits,
 }: LimitsInput): OrgLimits | null {
+  // Free plans read their own snapshot; it is both the stamp and the limit.
   if (effectivePlan === "oss" || effectivePlan === "starter") {
     return orgLimits ?? null;
   }
-  return licenseLimits ?? null;
+
+  // A license that carries an explicit snapshot always wins on paid plans.
+  if (licenseLimits) return licenseLimits;
+
+  // Grandfathered: never stamped, so never limited on any plan.
+  if (!orgLimits) return null;
+
+  const tier = planTierFor(effectivePlan);
+  if (!tier) return null;
+
+  // The stamp holds free-tier values, so a stamped org that upgraded reads its
+  // new tier's limits rather than the ones frozen at creation.
+  return planLimits ?? DEFAULT_ORG_LIMITS[tier];
 }
 
 function getMaxProjects(input: LimitsInput): number | null {
+  if (planAllows(input, "unlimited-projects")) return null;
   return resolve(input)?.maxProjects ?? null;
 }
 
 function supportsCustomEnvironments(input: LimitsInput): boolean {
+  if (planAllows(input, "custom-environments")) return true;
   const limits = resolve(input);
   if (!limits) return true;
   return limits.customEnvironments !== false;
@@ -41,6 +95,7 @@ function isEnvironmentIdAllowed(input: LimitsInput, envId: string): boolean {
 }
 
 function orgSupportsRoles(input: LimitsInput): boolean {
+  if (planAllows(input, "role-management")) return true;
   const limits = resolve(input);
   if (!limits) return true;
   return limits.roleManagement !== false;

--- a/packages/shared/src/enterprise/entitlements.ts
+++ b/packages/shared/src/enterprise/entitlements.ts
@@ -18,8 +18,7 @@ export const PRO_ORG_LIMITS: OrgLimits = {
   roleManagement: true,
 };
 
-// The tiers that carry plan limits. Enterprise is absent on purpose: it is
-// never subject to them (see planTierFor).
+// Enterprise is absent on purpose — it is never subject to plan limits.
 export type LimitedPlanTier = "free" | "pro";
 
 export const DEFAULT_ORG_LIMITS: Record<LimitedPlanTier, OrgLimits> = {
@@ -35,13 +34,10 @@ export function planTierFor(plan: AccountPlan): LimitedPlanTier | null {
 
 type LimitsInput = {
   effectivePlan: AccountPlan;
-  // Stamped at org creation. Its absence is the grandfathering signal: orgs
-  // created before pricing limits shipped have no stamp and stay unlimited.
+  // Stamped at org creation. Its absence means the org is grandfathered.
   orgLimits?: OrgLimits;
   licenseLimits?: OrgLimits;
-  // Live per-plan config (flag-resolved) for tiers whose limits can't be
-  // stamped at creation because the plan is bought later. Falls back to
-  // DEFAULT_ORG_LIMITS.
+  // Live per-plan config, for tiers whose limits can't be stamped at creation.
   planLimits?: OrgLimits;
 };
 
@@ -49,31 +45,31 @@ function planAllows(
   { effectivePlan }: LimitsInput,
   feature: CommercialFeature,
 ): boolean {
-  return accountFeatures[effectivePlan]?.has(feature) ?? false;
+  return accountFeatures[effectivePlan].has(feature);
 }
 
+// Free plans read the org's own snapshot; paid plans read the license's, then
+// their tier's.
 function resolve({
   effectivePlan,
   orgLimits,
   licenseLimits,
   planLimits,
 }: LimitsInput): OrgLimits | null {
-  // Free plans read their own snapshot; it is both the stamp and the limit.
   if (effectivePlan === "oss" || effectivePlan === "starter") {
     return orgLimits ?? null;
   }
 
-  // A license that carries an explicit snapshot always wins on paid plans.
   if (licenseLimits) return licenseLimits;
 
-  // Grandfathered: never stamped, so never limited on any plan.
+  // Never stamped, so never limited on any plan.
   if (!orgLimits) return null;
 
   const tier = planTierFor(effectivePlan);
   if (!tier) return null;
 
-  // The stamp holds free-tier values, so a stamped org that upgraded reads its
-  // new tier's limits rather than the ones frozen at creation.
+  // The stamp holds free values, so an org that upgraded reads its new tier's
+  // limits instead of the ones frozen at creation.
   return planLimits ?? DEFAULT_ORG_LIMITS[tier];
 }
 

--- a/packages/shared/src/enterprise/license-consts.ts
+++ b/packages/shared/src/enterprise/license-consts.ts
@@ -16,6 +16,9 @@ export type CommercialFeature =
   | "scim"
   | "sso"
   | "advanced-permissions"
+  | "role-management"
+  | "unlimited-projects"
+  | "custom-environments"
   | "encrypt-features-endpoint"
   | "schedule-feature-flag"
   | "events-forwarder"
@@ -207,6 +210,7 @@ export type LicenseData = {
 
 const commercialFeaturesPro: CommercialFeature[] = [
   "advanced-permissions",
+  "role-management",
   "encrypt-features-endpoint",
   "schedule-feature-flag",
   "events-forwarder",
@@ -247,6 +251,8 @@ const commercialFeaturesProSso: CommercialFeature[] = [
 
 const commercialFeaturesEnterpriseOnly: CommercialFeature[] = [
   "ai-suggestions",
+  "unlimited-projects",
+  "custom-environments",
   "ai-byok",
   "scim",
   "audit-logging",

--- a/packages/shared/src/enterprise/pricing-limits.ts
+++ b/packages/shared/src/enterprise/pricing-limits.ts
@@ -2,9 +2,8 @@ import { z } from "zod";
 import { OrgLimits } from "./license-consts";
 import { FREE_ORG_LIMITS } from "./entitlements";
 
-// Value shape: { "enabled": true, ...OrgLimits }. The base value holds the free
-// tier's limits; per-plan values are served with targeting rules on the
-// accountPlan attribute.
+// Value shape: { "enabled": true, ...OrgLimits }. Per-plan values are served
+// with targeting rules on the accountPlan attribute.
 export const PRICING_PHASE_1_FLAG_KEY = "pricing-phase-1-limits";
 
 export function isLimitsFlagDisabled(raw: unknown): boolean {

--- a/packages/shared/src/enterprise/pricing-limits.ts
+++ b/packages/shared/src/enterprise/pricing-limits.ts
@@ -2,10 +2,9 @@ import { z } from "zod";
 import { OrgLimits } from "./license-consts";
 import { FREE_ORG_LIMITS } from "./entitlements";
 
-// Value shape: { "enabled": true, ...OrgLimits }. Per-plan values are served
-// with targeting rules on the accountPlan attribute: the base value holds the
-// free tier's limits (also used for the creation-time stamp), and a rule
-// matching accountPlan in [pro, pro_sso] serves the pro tier's.
+// Value shape: { "enabled": true, ...OrgLimits }. The base value holds the free
+// tier's limits; per-plan values are served with targeting rules on the
+// accountPlan attribute.
 export const PRICING_PHASE_1_FLAG_KEY = "pricing-phase-1-limits";
 
 export function isLimitsFlagDisabled(raw: unknown): boolean {
@@ -20,41 +19,36 @@ export function isLimitsFlagDisabled(raw: unknown): boolean {
 const maxProjectsSchema = z.number().int().nonnegative().nullable();
 const flagBoolSchema = z.boolean();
 
-// Per-field fallback so the resolved config is always complete. Pass the tier's
-// defaults as `fallback` when reading limits for a plan other than free.
+// Per-field fallback to the tier's defaults so the config is always complete.
 export function resolveOrgLimitsConfig(
   raw: unknown,
-  fallback: OrgLimits = FREE_ORG_LIMITS,
+  defaults: OrgLimits = FREE_ORG_LIMITS,
 ): OrgLimits {
   const obj =
     raw && typeof raw === "object" && !Array.isArray(raw)
       ? (raw as Record<string, unknown>)
       : {};
 
-  const pick = <T>(
-    schema: z.ZodType<T>,
-    value: unknown,
-    defaultValue: T,
-  ): T => {
+  const pick = <T>(schema: z.ZodType<T>, value: unknown, fallback: T): T => {
     const parsed = schema.safeParse(value);
-    return parsed.success ? parsed.data : defaultValue;
+    return parsed.success ? parsed.data : fallback;
   };
 
   return {
     maxProjects: pick(
       maxProjectsSchema,
       obj.maxProjects,
-      fallback.maxProjects ?? null,
+      defaults.maxProjects ?? null,
     ),
     customEnvironments: pick(
       flagBoolSchema,
       obj.customEnvironments,
-      fallback.customEnvironments ?? false,
+      defaults.customEnvironments ?? false,
     ),
     roleManagement: pick(
       flagBoolSchema,
       obj.roleManagement,
-      fallback.roleManagement ?? false,
+      defaults.roleManagement ?? false,
     ),
   };
 }

--- a/packages/shared/src/enterprise/pricing-limits.ts
+++ b/packages/shared/src/enterprise/pricing-limits.ts
@@ -2,8 +2,10 @@ import { z } from "zod";
 import { OrgLimits } from "./license-consts";
 import { FREE_ORG_LIMITS } from "./entitlements";
 
-// Value shape: { "enabled": true, ...OrgLimits }. Per-plan values can be
-// served later with targeting rules on the accountPlan attribute.
+// Value shape: { "enabled": true, ...OrgLimits }. Per-plan values are served
+// with targeting rules on the accountPlan attribute: the base value holds the
+// free tier's limits (also used for the creation-time stamp), and a rule
+// matching accountPlan in [pro, pro_sso] serves the pro tier's.
 export const PRICING_PHASE_1_FLAG_KEY = "pricing-phase-1-limits";
 
 export function isLimitsFlagDisabled(raw: unknown): boolean {
@@ -18,33 +20,41 @@ export function isLimitsFlagDisabled(raw: unknown): boolean {
 const maxProjectsSchema = z.number().int().nonnegative().nullable();
 const flagBoolSchema = z.boolean();
 
-// Per-field fallback to FREE_ORG_LIMITS so the stamp is always complete.
-export function resolveOrgLimitsConfig(raw: unknown): OrgLimits {
+// Per-field fallback so the resolved config is always complete. Pass the tier's
+// defaults as `fallback` when reading limits for a plan other than free.
+export function resolveOrgLimitsConfig(
+  raw: unknown,
+  fallback: OrgLimits = FREE_ORG_LIMITS,
+): OrgLimits {
   const obj =
     raw && typeof raw === "object" && !Array.isArray(raw)
       ? (raw as Record<string, unknown>)
       : {};
 
-  const pick = <T>(schema: z.ZodType<T>, value: unknown, fallback: T): T => {
+  const pick = <T>(
+    schema: z.ZodType<T>,
+    value: unknown,
+    defaultValue: T,
+  ): T => {
     const parsed = schema.safeParse(value);
-    return parsed.success ? parsed.data : fallback;
+    return parsed.success ? parsed.data : defaultValue;
   };
 
   return {
     maxProjects: pick(
       maxProjectsSchema,
       obj.maxProjects,
-      FREE_ORG_LIMITS.maxProjects ?? null,
+      fallback.maxProjects ?? null,
     ),
     customEnvironments: pick(
       flagBoolSchema,
       obj.customEnvironments,
-      FREE_ORG_LIMITS.customEnvironments ?? false,
+      fallback.customEnvironments ?? false,
     ),
     roleManagement: pick(
       flagBoolSchema,
       obj.roleManagement,
-      FREE_ORG_LIMITS.roleManagement ?? false,
+      fallback.roleManagement ?? false,
     ),
   };
 }

--- a/packages/shared/test/enterprise/entitlements.test.ts
+++ b/packages/shared/test/enterprise/entitlements.test.ts
@@ -92,8 +92,6 @@ describe("makeOrgLimits", () => {
     it.each<AccountPlan>(["pro", "pro_sso"])(
       "upgrades a stamped org to the pro tier's limits on plan=%s",
       (effectivePlan) => {
-        // The stamp holds free values (every org is created free), so a pro org
-        // must not be held to maxProjects: 1.
         const limits = accessorFor({ effectivePlan, orgLimits: FREE_LIMITS });
         expect(limits.getMaxProjects()).toBe(3);
         expect(limits.isEnvironmentIdAllowed("production")).toBe(true);
@@ -123,8 +121,6 @@ describe("makeOrgLimits", () => {
     });
 
     it("keeps role management even if a license snapshot revokes it", () => {
-      // Pro has the role-management commercial feature, so roles are never
-      // gated by a limits snapshot on that plan.
       const limits = accessorFor({
         effectivePlan: "pro",
         orgLimits: FREE_LIMITS,

--- a/packages/shared/test/enterprise/entitlements.test.ts
+++ b/packages/shared/test/enterprise/entitlements.test.ts
@@ -1,10 +1,15 @@
-import { makeOrgLimits, FREE_ORG_LIMITS } from "shared/enterprise";
+import {
+  makeOrgLimits,
+  planTierFor,
+  FREE_ORG_LIMITS,
+  PRO_ORG_LIMITS,
+} from "shared/enterprise";
 import type { AccountPlan, OrgLimits } from "shared/enterprise";
 
 const FREE_LIMITS: OrgLimits = FREE_ORG_LIMITS;
 
-const PAID_LIMITS: OrgLimits = {
-  maxProjects: 3,
+const LICENSE_LIMITS: OrgLimits = {
+  maxProjects: 7,
   customEnvironments: false,
   roleManagement: false,
 };
@@ -13,13 +18,36 @@ function accessorFor({
   effectivePlan,
   orgLimits,
   licenseLimits,
+  planLimits,
 }: {
   effectivePlan: AccountPlan;
   orgLimits?: OrgLimits;
   licenseLimits?: OrgLimits;
+  planLimits?: OrgLimits;
 }) {
-  return makeOrgLimits({ effectivePlan, orgLimits, licenseLimits });
+  return makeOrgLimits({
+    effectivePlan,
+    orgLimits,
+    licenseLimits,
+    planLimits,
+  });
 }
+
+describe("planTierFor", () => {
+  it("maps free plans to the free tier", () => {
+    expect(planTierFor("oss")).toBe("free");
+    expect(planTierFor("starter")).toBe("free");
+  });
+
+  it("maps pro plans to the pro tier", () => {
+    expect(planTierFor("pro")).toBe("pro");
+    expect(planTierFor("pro_sso")).toBe("pro");
+  });
+
+  it("leaves enterprise untiered so it is never limited", () => {
+    expect(planTierFor("enterprise")).toBeNull();
+  });
+});
 
 describe("makeOrgLimits", () => {
   describe("grandfathered orgs (no stored limits)", () => {
@@ -32,6 +60,14 @@ describe("makeOrgLimits", () => {
         expect(limits.orgSupportsRoles()).toBe(true);
       },
     );
+
+    it("stays unrestricted on pro even when pro limits are configured", () => {
+      const limits = accessorFor({
+        effectivePlan: "pro",
+        planLimits: PRO_ORG_LIMITS,
+      });
+      expect(limits.getMaxProjects()).toBeNull();
+    });
   });
 
   describe("free plans (oss/starter) read org limits, ignore license limits", () => {
@@ -42,6 +78,7 @@ describe("makeOrgLimits", () => {
           effectivePlan,
           orgLimits: FREE_LIMITS,
           licenseLimits: { maxProjects: 999 }, // should be ignored on free plans
+          planLimits: PRO_ORG_LIMITS, // free never reads the live per-plan config
         });
         expect(limits.getMaxProjects()).toBe(1);
         expect(limits.isEnvironmentIdAllowed("production")).toBe(true);
@@ -51,26 +88,68 @@ describe("makeOrgLimits", () => {
     );
   });
 
-  describe("active paid plans read license limits, ignore org limits", () => {
-    it.each<AccountPlan>(["pro", "pro_sso", "enterprise"])(
-      "enforces license.limits on plan=%s",
+  describe("pro plans", () => {
+    it.each<AccountPlan>(["pro", "pro_sso"])(
+      "upgrades a stamped org to the pro tier's limits on plan=%s",
       (effectivePlan) => {
-        const limits = accessorFor({
-          effectivePlan,
-          orgLimits: FREE_LIMITS, // should be ignored on paid plans
-          licenseLimits: PAID_LIMITS,
-        });
+        // The stamp holds free values (every org is created free), so a pro org
+        // must not be held to maxProjects: 1.
+        const limits = accessorFor({ effectivePlan, orgLimits: FREE_LIMITS });
         expect(limits.getMaxProjects()).toBe(3);
+        expect(limits.isEnvironmentIdAllowed("production")).toBe(true);
         expect(limits.isEnvironmentIdAllowed("custom-env")).toBe(false);
-        expect(limits.orgSupportsRoles()).toBe(false);
+        expect(limits.orgSupportsRoles()).toBe(true);
       },
     );
 
-    it("resolves to unlimited when the license has no limits snapshot", () => {
+    it("prefers the live per-plan config over the hardcoded pro defaults", () => {
+      const limits = accessorFor({
+        effectivePlan: "pro",
+        orgLimits: FREE_LIMITS,
+        planLimits: { ...PRO_ORG_LIMITS, maxProjects: 10 },
+      });
+      expect(limits.getMaxProjects()).toBe(10);
+    });
+
+    it("lets an explicit license snapshot win over the tier defaults", () => {
+      const limits = accessorFor({
+        effectivePlan: "pro",
+        orgLimits: FREE_LIMITS,
+        licenseLimits: LICENSE_LIMITS,
+        planLimits: PRO_ORG_LIMITS,
+      });
+      expect(limits.getMaxProjects()).toBe(7);
+      expect(limits.isEnvironmentIdAllowed("custom-env")).toBe(false);
+    });
+
+    it("keeps role management even if a license snapshot revokes it", () => {
+      // Pro has the role-management commercial feature, so roles are never
+      // gated by a limits snapshot on that plan.
+      const limits = accessorFor({
+        effectivePlan: "pro",
+        orgLimits: FREE_LIMITS,
+        licenseLimits: LICENSE_LIMITS,
+      });
+      expect(limits.orgSupportsRoles()).toBe(true);
+    });
+  });
+
+  describe("enterprise is never affected by plan limits", () => {
+    it("ignores a stamped org snapshot", () => {
       const limits = accessorFor({
         effectivePlan: "enterprise",
         orgLimits: FREE_LIMITS,
-        licenseLimits: undefined,
+      });
+      expect(limits.getMaxProjects()).toBeNull();
+      expect(limits.isEnvironmentIdAllowed("custom-env")).toBe(true);
+      expect(limits.orgSupportsRoles()).toBe(true);
+    });
+
+    it("ignores a license snapshot", () => {
+      const limits = accessorFor({
+        effectivePlan: "enterprise",
+        orgLimits: FREE_LIMITS,
+        licenseLimits: LICENSE_LIMITS,
       });
       expect(limits.getMaxProjects()).toBeNull();
       expect(limits.isEnvironmentIdAllowed("custom-env")).toBe(true);

--- a/packages/shared/test/pricing-limits.test.ts
+++ b/packages/shared/test/pricing-limits.test.ts
@@ -1,5 +1,6 @@
 import {
   FREE_ORG_LIMITS,
+  PRO_ORG_LIMITS,
   OrgLimits,
   isLimitsFlagDisabled,
   resolveOrgLimitsConfig,
@@ -66,6 +67,30 @@ describe("resolveOrgLimitsConfig", () => {
       maxProjects: 2,
       customEnvironments: FREE_ORG_LIMITS.customEnvironments,
       roleManagement: FREE_ORG_LIMITS.roleManagement,
+    });
+  });
+
+  describe("per-tier fallback", () => {
+    it("falls back to the supplied tier defaults instead of free", () => {
+      expect(resolveOrgLimitsConfig({}, PRO_ORG_LIMITS)).toEqual({
+        maxProjects: PRO_ORG_LIMITS.maxProjects,
+        customEnvironments: PRO_ORG_LIMITS.customEnvironments,
+        roleManagement: PRO_ORG_LIMITS.roleManagement,
+      });
+    });
+
+    it("still lets the flag override individual tier fields", () => {
+      const result = resolveOrgLimitsConfig({ maxProjects: 5 }, PRO_ORG_LIMITS);
+      expect(result.maxProjects).toBe(5);
+      expect(result.roleManagement).toBe(PRO_ORG_LIMITS.roleManagement);
+    });
+
+    it("falls back per-field when the flag serves an invalid value", () => {
+      const result = resolveOrgLimitsConfig(
+        { maxProjects: "three" },
+        PRO_ORG_LIMITS,
+      );
+      expect(result.maxProjects).toBe(PRO_ORG_LIMITS.maxProjects);
     });
   });
 });


### PR DESCRIPTION
### Features and Changes

Builds the **Pro** tier on the same stamp + `pricing-phase-1-limits` flag system that shipped for Free in #6325.

| | Free | Pro | Enterprise |
|---|---|---|---|
| Projects | 1 | **3** | Unlimited |
| Custom environments | ✗ | **✗** | ✓ |
| Role management | ✗ | **✓** | ✓ |

Sample data projects still don't count toward the project cap, and grandfathering is unchanged: orgs created before limits shipped carry no stamp and stay unlimited on every plan.

**Keeping Enterprise clear**, via three new commercial features:

- `role-management` — Pro and above
- `unlimited-projects` — Enterprise only
- `custom-environments` — Enterprise only

These short-circuit the limit checks, so a plan that owns the feature can never be restricted by a stamp or a license snapshot. They also give the upsell UI the correct plan badge and CTA for free — the environment upsells now point at `custom-environments`, so they route to Enterprise rather than Pro.

Two drive-by fixes that were wrong under the new pricing: the Vercel Pro billing plan advertised unlimited projects (now derived from the constants), and the plan-availability notes in the docs.


### Dependencies

The `pricing-phase-1-limits` flag needs a targeting rule serving Pro's values to `accountPlan` in `[pro, pro_sso]`. Without it Pro orgs fall back to the hardcoded `PRO_ORG_LIMITS`, which already match the spec, so this can ship in either order.

### Testing

- `packages/shared/test/enterprise/entitlements.test.ts` — rewritten around plan tiers: Pro upgrades a stamped org off the frozen free values, license snapshots vs. tier defaults, Pro keeps roles, Enterprise ignores both stamp and license snapshot, grandfathering on every plan.
- `packages/shared/test/pricing-limits.test.ts` — per-tier fallback on the flag resolver.
- Full `shared` (2750), `back-end` (8324) and `front-end` (1115) suites pass. Two back-end suites failed only under parallel workers (SIGSEGV / socket hang up) and pass in isolation.

Three assertions in the old entitlements test changed on purpose: Pro now keeps role management even if a license snapshot revokes it, and Enterprise is no longer limited by a license snapshot.

### Screenshots
