### PR TITLE
fix(experiments): count fact-funnel step windows without a conversion envelope

### DIFF
--- a/packages/back-end/src/integrations/sql/dates/max-hours-to-convert.ts
+++ b/packages/back-end/src/integrations/sql/dates/max-hours-to-convert.ts
@@ -37,25 +37,32 @@ export function getMaxHoursToConvert(
   // has selected `skipPartialData`)
   let neededHoursForConversion = 0;
   metricAndDenominatorMetrics.forEach((m) => {
+    const funnelHours = getFunnelCompletionHours(m);
+    const delayHours = getDelayWindowHours(m.windowSettings);
+
+    // Step windows are hours-after-exposure even when the metric-level
+    // type is none/lookback.
+    let metricHours: number | null = null;
     if (m.windowSettings.type === "conversion") {
-      // The metric conversion window is a hard envelope on every event.
-      // When every funnel step also has a window, the funnel is settled
-      // earlier — at the sum of those step windows — so skipPartialData
-      // can use the tighter of the two. Otherwise the envelope alone
-      // bounds conversion.
       const windowHours = getMetricWindowHours(m.windowSettings);
-      const funnelHours = getFunnelCompletionHours(m);
-      const metricHours =
-        getDelayWindowHours(m.windowSettings) +
+      metricHours =
+        delayHours +
         (funnelHours === null
           ? windowHours
           : Math.min(windowHours, funnelHours));
-      if (funnelMetric) {
-        // funnel metric windows can cascade, so sum each metric hours to get max
-        neededHoursForConversion += metricHours;
-      } else if (metricHours > neededHoursForConversion) {
-        neededHoursForConversion = metricHours;
-      }
+    } else if (funnelHours !== null) {
+      metricHours = delayHours + funnelHours;
+    }
+
+    if (metricHours === null) {
+      return;
+    }
+
+    if (funnelMetric) {
+      // funnel metric windows can cascade, so sum each metric hours to get max
+      neededHoursForConversion += metricHours;
+    } else if (metricHours > neededHoursForConversion) {
+      neededHoursForConversion = metricHours;
     }
   });
   // activation metrics windows always cascade

--- a/packages/back-end/test/maxHoursToConvert.test.ts
+++ b/packages/back-end/test/maxHoursToConvert.test.ts
@@ -20,10 +20,12 @@ function buildStep(
 }
 
 function buildFunnelMetric({
+  windowType = "conversion",
   windowValueHours,
   delayValueHours = 0,
   steps,
 }: {
+  windowType?: FunnelFactMetricInterface["windowSettings"]["type"];
   windowValueHours: number;
   delayValueHours?: number;
   steps: MetricFunnelStep[];
@@ -32,7 +34,7 @@ function buildFunnelMetric({
     ...factMetricFactory.build({
       id: "fact__funnel",
       windowSettings: {
-        type: "conversion",
+        type: windowType,
         windowUnit: "hours",
         windowValue: windowValueHours,
         delayUnit: "hours",
@@ -100,5 +102,44 @@ describe("getMaxHoursToConvert for fact funnel metrics", () => {
       ],
     });
     expect(getMaxHoursToConvert(false, [metric], null)).toEqual(6);
+  });
+
+  it("uses the step-window sum when the metric has no conversion envelope", () => {
+    const metric = buildFunnelMetric({
+      windowType: "",
+      windowValueHours: 72,
+      steps: [
+        buildStep("View", { value: 1, unit: "hours" }),
+        buildStep("Cart", { value: 30, unit: "minutes" }),
+        buildStep("Purchase", { value: 30, unit: "minutes" }),
+      ],
+    });
+    expect(getMaxHoursToConvert(false, [metric], null)).toEqual(2);
+  });
+
+  it("uses the step-window sum when the metric window is lookback", () => {
+    const metric = buildFunnelMetric({
+      windowType: "lookback",
+      windowValueHours: 7 * 24,
+      delayValueHours: 1,
+      steps: [
+        buildStep("View", { value: 1, unit: "hours" }),
+        buildStep("Purchase", { value: 1, unit: "hours" }),
+      ],
+    });
+    expect(getMaxHoursToConvert(false, [metric], null)).toEqual(3);
+  });
+
+  it("has no bound when the metric has no conversion envelope and a step is unwindowed", () => {
+    const metric = buildFunnelMetric({
+      windowType: "",
+      windowValueHours: 72,
+      steps: [
+        buildStep("View", { value: 1, unit: "hours" }),
+        buildStep("Cart"),
+        buildStep("Purchase", { value: 1, unit: "hours" }),
+      ],
+    });
+    expect(getMaxHoursToConvert(false, [metric], null)).toEqual(0);
   });
 });


### PR DESCRIPTION
## Summary
- `getMaxHoursToConvert` only applied skipPartialData when the metric-level window type was `conversion`.
- Fact funnel step windows are still hours-after-exposure when the metric window is none or lookback. If every step has a conversion window, that sum is a valid bound (plus delay).
- A missing step window still yields no bound unless the metric itself has a conversion envelope.

## Test plan
- [x] `pnpm --filter back-end test test/maxHoursToConvert.test.ts`
- [ ] Confirm a funnel with no metric conversion window and fully windowed steps excludes recent exposures when skipPartialData is on
- [ ] Confirm an unwindowed step on a none/lookback funnel still includes in-progress units


Made with [Cursor](https://cursor.com)