### PR TITLE
Add persist + flat element catalog to the visual editor AI edit endpoint

### DIFF
--- a/packages/back-end/src/api/visual-editor-ai/aiTools/generateImage.ts
+++ b/packages/back-end/src/api/visual-editor-ai/aiTools/generateImage.ts
@@ -46,6 +46,16 @@ const inputSchema = z.object({
     ),
 });
 
+// `gen/` has a 7-day TTL; the extension promotes out of it when the user
+// accepts. A persisting caller has no accept step, so it writes permanent.
+export function imageFilePath(
+  orgId: string,
+  ext: string,
+  quarantine: boolean,
+): string {
+  return `${quarantine ? "gen/" : ""}${orgId}/visual-editor/img_${uuidv4()}.${ext}`;
+}
+
 export function generateImageTool(toolCtx: GenerateImageToolContext) {
   return aiTool({
     description:
@@ -141,10 +151,11 @@ export function generateImageTool(toolCtx: GenerateImageToolContext) {
 
         const img = generated[0];
         const optimized = await optimizeAIImage(img);
-        // `gen/` has a 7-day TTL; the extension promotes out of it on accept.
-        const filePath = `${toolCtx.quarantine ? "gen/" : ""}${
-          org.id
-        }/visual-editor/img_${uuidv4()}.${optimized.ext}`;
+        const filePath = imageFilePath(
+          org.id,
+          optimized.ext,
+          toolCtx.quarantine,
+        );
         const url = await uploadFile(
           filePath,
           optimized.contentType,

--- a/packages/back-end/src/api/visual-editor-ai/aiTools/generateImage.ts
+++ b/packages/back-end/src/api/visual-editor-ai/aiTools/generateImage.ts
@@ -16,12 +16,27 @@ import type { ApiReqContext } from "back-end/types/api";
 // constant in postAIImageGen.ts — both paths bill the same way.
 const IMAGE_GEN_TOKEN_COST_PER_IMAGE = 1290;
 
+// Shared across every generateImage call in a single chat turn. `count`/`max`
+// stop the AI burning through credits in a loop; `generated` and `warnings`
+// give the handler a machine-readable record of what the tool did, since a
+// failed generation is returned to the model as a tool result rather than
+// thrown (the turn still finishes with its text edits) and would otherwise
+// survive only as prose in the model's `explanation`. The toolset factory
+// creates one of these per request.
+export interface ImageTurnState {
+  count: number;
+  max: number;
+  generated: { url: string; width: number; height: number }[];
+  warnings: string[];
+}
+
 export interface GenerateImageToolContext {
   context: ApiReqContext;
-  // Counter shared across every generateImage call in a single chat
-  // turn so the AI can't burn through credits in a loop. The toolset
-  // factory creates one of these per request.
-  turnCounter: { count: number; max: number };
+  turnCounter: ImageTurnState;
+  // False when the caller has already committed to saving the result (the
+  // `persist` flag on /ai/edit), so there is no reject step for the quarantine
+  // prefix to protect against. See the filePath note below.
+  quarantine: boolean;
 }
 
 const inputSchema = z.object({
@@ -49,10 +64,9 @@ export function generateImageTool(toolCtx: GenerateImageToolContext) {
         // Surfaced back to the model as the tool result; it will see this
         // and stop trying. Easier than throwing — exceptions inside a
         // tool can abort the whole turn depending on the SDK version.
-        return {
-          ok: false,
-          error: `Image-generation budget exhausted for this turn (max ${toolCtx.turnCounter.max} images). Wrap up with the images you've already generated.`,
-        } as const;
+        const error = `Image-generation budget exhausted for this turn (max ${toolCtx.turnCounter.max} images). Wrap up with the images you've already generated.`;
+        toolCtx.turnCounter.warnings.push(error);
+        return { ok: false, error } as const;
       }
 
       const { context } = toolCtx;
@@ -73,11 +87,10 @@ export function generateImageTool(toolCtx: GenerateImageToolContext) {
       if (
         await secondsUntilAICanBeUsedAgainForProvider(context, imageProvider)
       ) {
-        return {
-          ok: false,
-          error:
-            "Daily AI usage limit reached — no more images can be generated today. Continue without generating images.",
-        } as const;
+        const error =
+          "Daily AI usage limit reached — no more images can be generated today. Continue without generating images.";
+        toolCtx.turnCounter.warnings.push(error);
+        return { ok: false, error } as const;
       }
 
       // Defensive single-image constraint. Even with the tool
@@ -101,10 +114,9 @@ export function generateImageTool(toolCtx: GenerateImageToolContext) {
         });
 
         if (generated.length === 0) {
-          return {
-            ok: false,
-            error: "Image generation returned no images.",
-          } as const;
+          const error = "Image generation returned no images.";
+          toolCtx.turnCounter.warnings.push(error);
+          return { ok: false, error } as const;
         }
 
         // Reported for every org whichever key paid — see postAIImageGen.ts.
@@ -137,7 +149,13 @@ export function generateImageTool(toolCtx: GenerateImageToolContext) {
 
         const img = generated[0];
         const optimized = await optimizeAIImage(img);
-        const filePath = `gen/${org.id}/visual-editor/img_${uuidv4()}.${optimized.ext}`;
+        // `gen/` is the AI quarantine prefix (7-day bucket TTL); the extension
+        // promotes a file out of it when the user accepts the proposed change.
+        // A persisting caller has no accept step, so writing there would leave
+        // the saved mutation pointing at a URL that 404s in a week.
+        const filePath = `${toolCtx.quarantine ? "gen/" : ""}${
+          org.id
+        }/visual-editor/img_${uuidv4()}.${optimized.ext}`;
         const url = await uploadFile(
           filePath,
           optimized.contentType,
@@ -146,6 +164,11 @@ export function generateImageTool(toolCtx: GenerateImageToolContext) {
         );
 
         toolCtx.turnCounter.count += 1;
+        toolCtx.turnCounter.generated.push({
+          url,
+          width: optimized.width,
+          height: optimized.height,
+        });
         return {
           ok: true,
           url,
@@ -159,6 +182,7 @@ export function generateImageTool(toolCtx: GenerateImageToolContext) {
           { err: e, orgId: org.id },
           "[ai-tool/generate-image] gen failed",
         );
+        toolCtx.turnCounter.warnings.push(`Image generation failed: ${msg}`);
         return { ok: false, error: msg } as const;
       }
     },

--- a/packages/back-end/src/api/visual-editor-ai/aiTools/generateImage.ts
+++ b/packages/back-end/src/api/visual-editor-ai/aiTools/generateImage.ts
@@ -16,13 +16,8 @@ import type { ApiReqContext } from "back-end/types/api";
 // constant in postAIImageGen.ts — both paths bill the same way.
 const IMAGE_GEN_TOKEN_COST_PER_IMAGE = 1290;
 
-// Shared across every generateImage call in a single chat turn. `count`/`max`
-// stop the AI burning through credits in a loop; `generated` and `warnings`
-// give the handler a machine-readable record of what the tool did, since a
-// failed generation is returned to the model as a tool result rather than
-// thrown (the turn still finishes with its text edits) and would otherwise
-// survive only as prose in the model's `explanation`. The toolset factory
-// creates one of these per request.
+// A failed generation returns a tool result rather than throwing, so `warnings`
+// is the only machine-readable trace of it.
 export interface ImageTurnState {
   count: number;
   max: number;
@@ -33,9 +28,6 @@ export interface ImageTurnState {
 export interface GenerateImageToolContext {
   context: ApiReqContext;
   turnCounter: ImageTurnState;
-  // False when the caller has already committed to saving the result (the
-  // `persist` flag on /ai/edit), so there is no reject step for the quarantine
-  // prefix to protect against. See the filePath note below.
   quarantine: boolean;
 }
 
@@ -149,10 +141,7 @@ export function generateImageTool(toolCtx: GenerateImageToolContext) {
 
         const img = generated[0];
         const optimized = await optimizeAIImage(img);
-        // `gen/` is the AI quarantine prefix (7-day bucket TTL); the extension
-        // promotes a file out of it when the user accepts the proposed change.
-        // A persisting caller has no accept step, so writing there would leave
-        // the saved mutation pointing at a URL that 404s in a week.
+        // `gen/` has a 7-day TTL; the extension promotes out of it on accept.
         const filePath = `${toolCtx.quarantine ? "gen/" : ""}${
           org.id
         }/visual-editor/img_${uuidv4()}.${optimized.ext}`;

--- a/packages/back-end/src/api/visual-editor-ai/aiTools/index.ts
+++ b/packages/back-end/src/api/visual-editor-ai/aiTools/index.ts
@@ -1,6 +1,6 @@
 import type { ToolSet } from "ai";
 import type { ApiReqContext } from "back-end/types/api";
-import { generateImageTool } from "./generateImage";
+import { generateImageTool, type ImageTurnState } from "./generateImage";
 import { searchImageLibraryTool } from "./searchImageLibrary";
 import { getDesignTokensTool } from "./getDesignTokens";
 import { searchPastExperimentsTool } from "./searchPastExperiments";
@@ -34,6 +34,23 @@ export interface VisualEditorToolsetOptions {
   pageStructure?: PageStructureNode[];
   // Set to true to suppress tools entirely.
   disabled?: boolean;
+  // Per-request image record. Pass one in to read back what `generateImage`
+  // did (URLs produced, soft failures); omit it and the tool still works, the
+  // outcomes just aren't observable.
+  imageState?: ImageTurnState;
+  // False when the caller has already committed to saving the result, so
+  // generated images skip the quarantine prefix. Defaults to true — the
+  // extension previews before accepting.
+  quarantineImages?: boolean;
+}
+
+export function newImageTurnState(): ImageTurnState {
+  return {
+    count: 0,
+    max: IMAGE_GEN_PER_TURN_MAX,
+    generated: [],
+    warnings: [],
+  };
 }
 
 export function buildVisualEditorTools({
@@ -41,12 +58,18 @@ export function buildVisualEditorTools({
   job,
   pageStructure,
   disabled = false,
+  imageState,
+  quarantineImages = true,
 }: VisualEditorToolsetOptions): ToolSet | undefined {
   if (disabled) return undefined;
-  const turnCounter = { count: 0, max: IMAGE_GEN_PER_TURN_MAX };
+  const turnCounter = imageState ?? newImageTurnState();
   const hasStructure = !!pageStructure && pageStructure.length > 0;
   const serverTools = {
-    generateImage: generateImageTool({ context, turnCounter }),
+    generateImage: generateImageTool({
+      context,
+      turnCounter,
+      quarantine: quarantineImages,
+    }),
     searchImageLibrary: searchImageLibraryTool(context),
     getDesignTokens: getDesignTokensTool(context),
     searchPastExperiments: searchPastExperimentsTool(context),

--- a/packages/back-end/src/api/visual-editor-ai/aiTools/index.ts
+++ b/packages/back-end/src/api/visual-editor-ai/aiTools/index.ts
@@ -34,13 +34,7 @@ export interface VisualEditorToolsetOptions {
   pageStructure?: PageStructureNode[];
   // Set to true to suppress tools entirely.
   disabled?: boolean;
-  // Per-request image record. Pass one in to read back what `generateImage`
-  // did (URLs produced, soft failures); omit it and the tool still works, the
-  // outcomes just aren't observable.
   imageState?: ImageTurnState;
-  // False when the caller has already committed to saving the result, so
-  // generated images skip the quarantine prefix. Defaults to true — the
-  // extension previews before accepting.
   quarantineImages?: boolean;
 }
 

--- a/packages/back-end/src/api/visual-editor-ai/postCreateExperiment.ts
+++ b/packages/back-end/src/api/visual-editor-ai/postCreateExperiment.ts
@@ -45,10 +45,7 @@ const bodySchema = z
     // Standard A/B experiment (default) or a multi-armed bandit. Bandits
     // require the "multi-armed-bandits" premium feature (enforced below).
     type: z.enum(["standard", "multi-armed-bandit"]).default("standard"),
-    // Declared so the 422 SoftWarningError retry hint ("re-send with
-    // `ignoreWarnings: true` in the request body") actually works — the flag
-    // is read off the body by context.ignoreWarnings, but this .strict()
-    // schema rejected it before the handler ever ran.
+    // Declared so the 422 retry hint's body form isn't rejected by .strict().
     ignoreWarnings: ignoreWarningsBodyField,
   })
   .strict();

--- a/packages/back-end/src/api/visual-editor-ai/postCreateExperiment.ts
+++ b/packages/back-end/src/api/visual-editor-ai/postCreateExperiment.ts
@@ -5,6 +5,7 @@ import type {
   ExperimentInterface,
   ExperimentInterfaceExcludingHoldouts,
 } from "shared/validators";
+import { ignoreWarningsBodyField } from "shared/validators";
 import { createExperiment } from "back-end/src/models/ExperimentModel";
 import { SoftWarningError } from "back-end/src/util/errors";
 import {
@@ -44,6 +45,11 @@ const bodySchema = z
     // Standard A/B experiment (default) or a multi-armed bandit. Bandits
     // require the "multi-armed-bandits" premium feature (enforced below).
     type: z.enum(["standard", "multi-armed-bandit"]).default("standard"),
+    // Declared so the 422 SoftWarningError retry hint ("re-send with
+    // `ignoreWarnings: true` in the request body") actually works — the flag
+    // is read off the body by context.ignoreWarnings, but this .strict()
+    // schema rejected it before the handler ever ran.
+    ignoreWarnings: ignoreWarningsBodyField,
   })
   .strict();
 

--- a/packages/back-end/src/enterprise/api/visual-editor-ai/postAIEdit.ts
+++ b/packages/back-end/src/enterprise/api/visual-editor-ai/postAIEdit.ts
@@ -135,14 +135,7 @@ const domDigestSchema = z.object({
   // On-demand container map for the `findElements` tool — not rendered into
   // the prompt (formatDigest ignores it).
   pageStructure: z.array(structureNodeSchema).max(400).optional(),
-  // Untyped catalog for clients that don't classify elements the way the
-  // content script does. The six arrays above each have their own field
-  // names, which means any client building a digest from raw HTML has to
-  // bucket every element before it can serialize it; this accepts the same
-  // information as one flat list. Rendered alongside the typed sections (both
-  // may be populated) and, more importantly, counted as grounded selectors —
-  // without that, the self-correct pass is skipped and hallucinated selectors
-  // go through unchecked.
+  // Flat alternative to the typed arrays above; both may be populated.
   elements: z
     .array(
       z.object({
@@ -192,12 +185,7 @@ const bodySchema = z
     // When omitted/false, the response is the original unwrapped shape
     // and only server-side tools (generateImage, etc.) are available.
     streamingMode: z.boolean().optional(),
-    // Save the generated changes onto the variation's visual change instead of
-    // returning them for the caller to persist. For non-interactive clients
-    // (CLI/agent) that have no accept/reject step: it keeps the
-    // append-mutations / replace-css-js asymmetry in one place, and lets
-    // generated images skip the quarantine prefix. Mutually exclusive with
-    // streamingMode, whose final output is assembled in postAIEditResume.
+    // Save the result rather than returning it for the caller to persist.
     persist: z.boolean().optional(),
   })
   .strict();
@@ -633,9 +621,7 @@ export const postAIEdit = createApiRequestHandler(validation)(async (req) => {
   const context = req.context;
   requireUserAuth(context);
 
-  // The streaming tool loop finalizes in postAIEditResume, so a persisting
-  // streaming request would need the save duplicated there. Reject the
-  // combination rather than maintaining two write paths.
+  // Streaming finalizes in postAIEditResume; one write path, not two.
   if (persist && req.body.streamingMode) {
     context.throwBadRequestError(
       "`persist` cannot be combined with `streamingMode`.",
@@ -654,11 +640,7 @@ export const postAIEdit = createApiRequestHandler(validation)(async (req) => {
   if (!context.permissions.canUpdateVisualChange(experiment)) {
     context.permissions.throwPermissionError();
   }
-  // Only when persisting, and deliberately before the generation: the save
-  // would be rejected by the same check anyway, and failing here means a
-  // non-draft experiment doesn't burn AI quota to produce changes that can't
-  // be stored. Generate-only requests stay unrestricted — the extension
-  // previews against running experiments.
+  // Before the generation, so a doomed save doesn't burn AI quota first.
   if (persist) requireDraftExperiment(context, experiment);
 
   // Gated on the model this request will actually run: an org on its own key
@@ -725,6 +707,11 @@ export const postAIEdit = createApiRequestHandler(validation)(async (req) => {
   let effectiveInstructions = visualEditorAIContext
     ? `${instructions}\n\nAdditional brand guidelines / context provided by the organization (these MUST be respected unless they conflict with the JSON output schema):\n${visualEditorAIContext}`
     : instructions;
+
+  // No chooser without a preview, so alternatives cost a paid call and are binned.
+  if (persist) {
+    effectiveInstructions = `${effectiveInstructions}\n\nThis request is saved directly, with no preview and no way for the user to pick between alternatives:\n- NEVER populate \`options\`. Return your single best \`value\`, even if the user asked for a few choices — say in the \`explanation\` that you picked one, and that they can ask again for a different take.\n- Call \`generateImage\` at most once per element you are changing. Never generate variants of the same image to choose from.`;
+  }
 
   if (locale && !locale.toLowerCase().startsWith("en")) {
     effectiveInstructions = `${effectiveInstructions}\n\nLanguage:\n- The user's interface is set to locale "${locale}". Write the \`explanation\` field in that language (the natural language the user reads on screen).\n- Keep the JSON keys, selectors, attribute names, mutation actions ("set"/"append"/"remove"), CSS, JS, and any code identifiers in English — only the explanation prose is localized.`;
@@ -926,7 +913,7 @@ export const postAIEdit = createApiRequestHandler(validation)(async (req) => {
         // chooser of one. Dedupe defensively (the model occasionally
         // repeats its top pick).
         const opts =
-          !isPosition && m.options
+          !isPosition && !persist && m.options
             ? Array.from(new Set(m.options.filter((o) => o && o.length > 0)))
             : [];
         return {
@@ -986,8 +973,6 @@ export const postAIEdit = createApiRequestHandler(validation)(async (req) => {
     job: useToolLoop ? job : undefined,
     pageStructure,
     imageState,
-    // A persisting caller has no accept/reject step, so a generated image is
-    // accepted by definition and skips the quarantine prefix.
     quarantineImages: !persist,
   });
   // Cast through unknown — the job store is invariant in TFinal for
@@ -1083,19 +1068,14 @@ export const postAIEdit = createApiRequestHandler(validation)(async (req) => {
   aiEditJobStore.delete(job.id);
 
   if (persist) {
-    // `currentChange` is non-null here: the handler fails fast above on a
-    // variationId that isn't part of this changeset.
+    // Non-null: the handler fails fast above on a variationId not in the changeset.
     const change = currentChange as NonNullable<typeof currentChange>;
     await updateVisualChange({
       changesetId: visualChangesetId,
       visualChangeId: change.id,
       organization: req.organization.id,
       payload: {
-        // Mutations are additive — the model is prompted with the existing
-        // ones and told not to duplicate them, so it returns only what's new.
-        // css/js are the opposite: it's told to re-emit them in full, and
-        // finalizeOutput omits them entirely when unchanged. updateVisualChange
-        // replaces any array it's handed, so the concat has to happen here.
+        // The model returns only new mutations, but complete css/js.
         domMutations: [
           ...(change.domMutations ?? []),
           ...(finalized.mutations as typeof change.domMutations),

--- a/packages/back-end/src/enterprise/api/visual-editor-ai/postAIEdit.ts
+++ b/packages/back-end/src/enterprise/api/visual-editor-ai/postAIEdit.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { findVisualChangesetById } from "back-end/src/models/VisualChangesetModel";
+import {
+  findVisualChangesetById,
+  updateVisualChange,
+} from "back-end/src/models/VisualChangesetModel";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
 import {
   parsePrompt,
@@ -12,8 +15,10 @@ import { IS_CLOUD } from "back-end/src/util/secrets";
 import { requireUserAuth } from "back-end/src/api/visual-editor-ai/requireUserAuth";
 import {
   buildVisualEditorTools,
+  newImageTurnState,
   VISUAL_EDITOR_MAX_STEPS,
 } from "back-end/src/api/visual-editor-ai/aiTools";
+import { requireDraftExperiment } from "back-end/src/api/visual-editor-ai/requireDraftExperiment";
 import { aiEditJobStore } from "back-end/src/api/visual-editor-ai/aiTools/clientJob";
 import {
   buildInsertJs,
@@ -130,6 +135,28 @@ const domDigestSchema = z.object({
   // On-demand container map for the `findElements` tool — not rendered into
   // the prompt (formatDigest ignores it).
   pageStructure: z.array(structureNodeSchema).max(400).optional(),
+  // Untyped catalog for clients that don't classify elements the way the
+  // content script does. The six arrays above each have their own field
+  // names, which means any client building a digest from raw HTML has to
+  // bucket every element before it can serialize it; this accepts the same
+  // information as one flat list. Rendered alongside the typed sections (both
+  // may be populated) and, more importantly, counted as grounded selectors —
+  // without that, the self-correct pass is skipped and hallucinated selectors
+  // go through unchecked.
+  elements: z
+    .array(
+      z.object({
+        selector: z.string(),
+        tag: z.string(),
+        text: z.string().optional(),
+        href: z.string().optional(),
+        src: z.string().optional(),
+        alt: z.string().optional(),
+        placeholder: z.string().optional(),
+      }),
+    )
+    .max(300)
+    .optional(),
 });
 
 // Capped at 12 turns + 4000 chars/turn to bound prompt size.
@@ -165,6 +192,13 @@ const bodySchema = z
     // When omitted/false, the response is the original unwrapped shape
     // and only server-side tools (generateImage, etc.) are available.
     streamingMode: z.boolean().optional(),
+    // Save the generated changes onto the variation's visual change instead of
+    // returning them for the caller to persist. For non-interactive clients
+    // (CLI/agent) that have no accept/reject step: it keeps the
+    // append-mutations / replace-css-js asymmetry in one place, and lets
+    // generated images skip the quarantine prefix. Mutually exclusive with
+    // streamingMode, whose final output is assembled in postAIEditResume.
+    persist: z.boolean().optional(),
   })
   .strict();
 
@@ -468,6 +502,22 @@ const formatDigest = (digest: z.infer<typeof domDigestSchema>): string => {
         `\`${img.selector}\`${img.alt ? ` alt="${img.alt}"` : ""} src=${img.src}`,
     ),
   );
+  section(
+    "Other elements",
+    (digest.elements ?? []).map((el) => {
+      const meta = [
+        el.href ? `→ ${el.href}` : "",
+        el.src ? `src=${el.src}` : "",
+        el.alt ? `alt="${el.alt}"` : "",
+        el.placeholder ? `placeholder="${el.placeholder}"` : "",
+      ]
+        .filter(Boolean)
+        .join(" ");
+      return `\`${el.selector}\` <${el.tag}>${
+        el.text ? ` "${el.text}"` : ""
+      }${meta ? ` ${meta}` : ""}`;
+    }),
+  );
   if (lines.length === 0) {
     return "\n(No editable elements were detected on the page.)\n";
   }
@@ -486,6 +536,7 @@ const allDigestSelectors = (
   for (const l of digest.links) out.add(l.selector);
   for (const i of digest.inputs) out.add(i.selector);
   for (const img of digest.images) out.add(img.selector);
+  for (const el of digest.elements ?? []) out.add(el.selector);
   // html/body always resolve, even without a content-script digest.
   out.add("html");
   out.add("body");
@@ -572,6 +623,7 @@ export const postAIEdit = createApiRequestHandler(validation)(async (req) => {
     domDigest,
     conversationHistory,
     locale,
+    persist,
   } = req.body;
 
   // Carried inside domDigest (sent in the body, kept out of the prompt) and
@@ -580,6 +632,15 @@ export const postAIEdit = createApiRequestHandler(validation)(async (req) => {
 
   const context = req.context;
   requireUserAuth(context);
+
+  // The streaming tool loop finalizes in postAIEditResume, so a persisting
+  // streaming request would need the save duplicated there. Reject the
+  // combination rather than maintaining two write paths.
+  if (persist && req.body.streamingMode) {
+    context.throwBadRequestError(
+      "`persist` cannot be combined with `streamingMode`.",
+    );
+  }
 
   const changeset = await findVisualChangesetById(
     visualChangesetId,
@@ -593,6 +654,12 @@ export const postAIEdit = createApiRequestHandler(validation)(async (req) => {
   if (!context.permissions.canUpdateVisualChange(experiment)) {
     context.permissions.throwPermissionError();
   }
+  // Only when persisting, and deliberately before the generation: the save
+  // would be rejected by the same check anyway, and failing here means a
+  // non-draft experiment doesn't burn AI quota to produce changes that can't
+  // be stored. Generate-only requests stay unrestricted — the extension
+  // previews against running experiments.
+  if (persist) requireDraftExperiment(context, experiment);
 
   // Gated on the model this request will actually run: an org on its own key
   // for that provider pays its own bill, so the managed cap doesn't apply.
@@ -913,10 +980,15 @@ export const postAIEdit = createApiRequestHandler(validation)(async (req) => {
   // extension's handling is unchanged.
   const useToolLoop = streamingMode && !IS_CLOUD;
   const job = aiEditJobStore.create();
+  const imageState = newImageTurnState();
   const tools = buildVisualEditorTools({
     context,
     job: useToolLoop ? job : undefined,
     pageStructure,
+    imageState,
+    // A persisting caller has no accept/reject step, so a generated image is
+    // accepted by definition and skips the quarantine prefix.
+    quarantineImages: !persist,
   });
   // Cast through unknown — the job store is invariant in TFinal for
   // type-erasure reasons but each job is used with one schema only.
@@ -1009,6 +1081,38 @@ export const postAIEdit = createApiRequestHandler(validation)(async (req) => {
   // outcome.kind === "final"
   const finalized = await finalizeOutput(outcome.payload);
   aiEditJobStore.delete(job.id);
+
+  if (persist) {
+    // `currentChange` is non-null here: the handler fails fast above on a
+    // variationId that isn't part of this changeset.
+    const change = currentChange as NonNullable<typeof currentChange>;
+    await updateVisualChange({
+      changesetId: visualChangesetId,
+      visualChangeId: change.id,
+      organization: req.organization.id,
+      payload: {
+        // Mutations are additive — the model is prompted with the existing
+        // ones and told not to duplicate them, so it returns only what's new.
+        // css/js are the opposite: it's told to re-emit them in full, and
+        // finalizeOutput omits them entirely when unchanged. updateVisualChange
+        // replaces any array it's handed, so the concat has to happen here.
+        domMutations: [
+          ...(change.domMutations ?? []),
+          ...(finalized.mutations as typeof change.domMutations),
+        ],
+        ...(finalized.css !== undefined ? { css: finalized.css } : {}),
+        ...(finalized.js !== undefined ? { js: finalized.js } : {}),
+      },
+    });
+    return {
+      ...finalized,
+      saved: true as const,
+      visualChangeId: change.id,
+      images: imageState.generated,
+      warnings: imageState.warnings,
+    };
+  }
+
   return streamingMode
     ? { kind: "final" as const, payload: finalized }
     : finalized;

--- a/packages/back-end/test/api/visual-editor-ai-persist.test.ts
+++ b/packages/back-end/test/api/visual-editor-ai-persist.test.ts
@@ -2,24 +2,15 @@ import request from "supertest";
 import { VisualChangesetModel } from "back-end/src/models/VisualChangesetModel";
 import { setupApp } from "./api.setup";
 
-// Coverage for the `persist` flag on POST /api/v1/visual-editor/ai/edit.
-// The LLM is mocked; the changeset round-trips through the real model against
-// in-memory Mongo, because the thing worth testing is the merge itself —
-// mutations append, css/js replace, and an omitted field must not clobber.
+// The LLM is mocked; the changeset round-trips through the real model.
 
-// These three modules sit in import cycles with the model layer, so spreading
-// `requireActual` at factory time throws "cannot access before initialization".
-// A lazy Proxy defers it to first property access — same trick as
-// release-publish-revisions-failure.test.ts. Factories are hoisted above every
-// declaration here, so each Proxy is inlined and may only close over
-// `mock`-prefixed variables.
+// Import cycles: a lazy Proxy defers requireActual to first property access.
 const mockParsePrompt = jest.fn();
 const mockGetExperimentById = jest.fn();
 
 jest.mock("back-end/src/enterprise/services/ai", () => {
   const overrides: Record<string, unknown> = {
     parsePrompt: (...args: unknown[]) => mockParsePrompt(...args),
-    secondsUntilAICanBeUsedAgainForModel: async () => 0,
   };
   return new Proxy(
     {},
@@ -28,24 +19,6 @@ jest.mock("back-end/src/enterprise/services/ai", () => {
         prop in overrides
           ? overrides[prop]
           : jest.requireActual("back-end/src/enterprise/services/ai")[prop],
-    },
-  );
-});
-
-jest.mock("back-end/src/services/organizations", () => {
-  const overrides: Record<string, unknown> = {
-    getAISettingsForOrg: async () => ({
-      visualEditorAIModel: "gpt-4o",
-      keySource: {},
-    }),
-  };
-  return new Proxy(
-    {},
-    {
-      get: (_t, prop: string) =>
-        prop in overrides
-          ? overrides[prop]
-          : jest.requireActual("back-end/src/services/organizations")[prop],
     },
   );
 });
@@ -189,24 +162,6 @@ describe("visual editor AI edit — persist", () => {
     expect((await readVisualChange()).css).toBe("h1 { color: red; }");
   });
 
-  it("replaces css wholesale when the model returns new css", async () => {
-    await seedChangeset({ css: "h1 { color: red; }" });
-    mockParsePrompt.mockResolvedValue({
-      mutations: [],
-      css: "h1 { color: blue; }",
-      js: null,
-      insert: [],
-      explanation: "Recoloured.",
-    });
-
-    await request(app)
-      .post("/api/v1/visual-editor/ai/edit")
-      .send(editBody())
-      .expect(200);
-
-    expect((await readVisualChange()).css).toBe("h1 { color: blue; }");
-  });
-
   it("rejects a non-draft experiment before calling the model", async () => {
     await seedChangeset();
     mockGetExperimentById.mockResolvedValue({
@@ -219,41 +174,18 @@ describe("visual editor AI edit — persist", () => {
       .send(editBody());
 
     expect(res.status).toBe(400);
-    // The point of the early gate: no AI quota burned on a change that
-    // could never have been saved.
+    // The point of the early gate: no AI quota burned on an unsavable change.
     expect(mockParsePrompt).not.toHaveBeenCalled();
   });
 
-  it("still generates without persist against a non-draft experiment", async () => {
+  // A selector from the flat `elements` catalog must count as grounded, or the
+  // self-correct pass burns a second call "fixing" a valid one.
+  it("treats a selector from domDigest.elements as grounded", async () => {
     await seedChangeset();
-    mockGetExperimentById.mockResolvedValue({
-      ...draftExperiment,
-      status: "running",
-    });
-
-    const res = await request(app)
-      .post("/api/v1/visual-editor/ai/edit")
-      .send(editBody({ persist: undefined }));
-
-    expect(res.status).toBe(200);
-    expect(res.body.saved).toBeUndefined();
-    expect((await readVisualChange()).domMutations).toHaveLength(0);
-  });
-
-  // The flat `elements` catalog only earns its keep if its selectors count as
-  // grounded — otherwise the self-correct pass treats every one of them as a
-  // hallucination and burns a second LLM call "fixing" a valid selector.
-  describe("flat domDigest.elements", () => {
-    const digestWith = (selector: string) => ({
-      url: "https://example.com/pricing",
-      title: "Pricing",
-      elements: [{ selector, tag: "div", text: "Promo" }],
-    });
-
-    const mutateOn = (selector: string) => ({
+    mockParsePrompt.mockResolvedValue({
       mutations: [
         {
-          selector,
+          selector: ".promo",
           action: "set",
           attribute: "html",
           value: "New",
@@ -268,42 +200,20 @@ describe("visual editor AI edit — persist", () => {
       explanation: "Done.",
     });
 
-    it("treats a selector from elements as grounded (no self-correct retry)", async () => {
-      await seedChangeset();
-      mockParsePrompt.mockResolvedValue(mutateOn(".promo"));
-
-      await request(app)
-        .post("/api/v1/visual-editor/ai/edit")
-        .send(editBody({ domDigest: digestWith(".promo") }))
-        .expect(200);
-
-      expect(mockParsePrompt).toHaveBeenCalledTimes(1);
-      expect((await readVisualChange()).domMutations[0].selector).toBe(
-        ".promo",
-      );
-    });
-
-    it("still retries on a selector that is in no catalog", async () => {
-      await seedChangeset();
-      mockParsePrompt.mockResolvedValue(mutateOn(".invented"));
-
-      await request(app)
-        .post("/api/v1/visual-editor/ai/edit")
-        .send(editBody({ domDigest: digestWith(".promo") }))
-        .expect(200);
-
-      expect(mockParsePrompt).toHaveBeenCalledTimes(2);
-    });
-  });
-
-  it("rejects persist combined with streamingMode", async () => {
-    await seedChangeset();
-
-    const res = await request(app)
+    await request(app)
       .post("/api/v1/visual-editor/ai/edit")
-      .send(editBody({ streamingMode: true }));
+      .send(
+        editBody({
+          domDigest: {
+            url: "https://example.com/pricing",
+            title: "Pricing",
+            elements: [{ selector: ".promo", tag: "div", text: "Promo" }],
+          },
+        }),
+      )
+      .expect(200);
 
-    expect(res.status).toBe(400);
-    expect(mockParsePrompt).not.toHaveBeenCalled();
+    expect(mockParsePrompt).toHaveBeenCalledTimes(1);
+    expect((await readVisualChange()).domMutations[0].selector).toBe(".promo");
   });
 });

--- a/packages/back-end/test/api/visual-editor-ai-persist.test.ts
+++ b/packages/back-end/test/api/visual-editor-ai-persist.test.ts
@@ -1,0 +1,309 @@
+import request from "supertest";
+import { VisualChangesetModel } from "back-end/src/models/VisualChangesetModel";
+import { setupApp } from "./api.setup";
+
+// Coverage for the `persist` flag on POST /api/v1/visual-editor/ai/edit.
+// The LLM is mocked; the changeset round-trips through the real model against
+// in-memory Mongo, because the thing worth testing is the merge itself —
+// mutations append, css/js replace, and an omitted field must not clobber.
+
+// These three modules sit in import cycles with the model layer, so spreading
+// `requireActual` at factory time throws "cannot access before initialization".
+// A lazy Proxy defers it to first property access — same trick as
+// release-publish-revisions-failure.test.ts. Factories are hoisted above every
+// declaration here, so each Proxy is inlined and may only close over
+// `mock`-prefixed variables.
+const mockParsePrompt = jest.fn();
+const mockGetExperimentById = jest.fn();
+
+jest.mock("back-end/src/enterprise/services/ai", () => {
+  const overrides: Record<string, unknown> = {
+    parsePrompt: (...args: unknown[]) => mockParsePrompt(...args),
+    secondsUntilAICanBeUsedAgainForModel: async () => 0,
+  };
+  return new Proxy(
+    {},
+    {
+      get: (_t, prop: string) =>
+        prop in overrides
+          ? overrides[prop]
+          : jest.requireActual("back-end/src/enterprise/services/ai")[prop],
+    },
+  );
+});
+
+jest.mock("back-end/src/services/organizations", () => {
+  const overrides: Record<string, unknown> = {
+    getAISettingsForOrg: async () => ({
+      visualEditorAIModel: "gpt-4o",
+      keySource: {},
+    }),
+  };
+  return new Proxy(
+    {},
+    {
+      get: (_t, prop: string) =>
+        prop in overrides
+          ? overrides[prop]
+          : jest.requireActual("back-end/src/services/organizations")[prop],
+    },
+  );
+});
+
+jest.mock("back-end/src/models/ExperimentModel", () => {
+  const overrides: Record<string, unknown> = {
+    getExperimentById: (...args: unknown[]) => mockGetExperimentById(...args),
+  };
+  return new Proxy(
+    {},
+    {
+      get: (_t, prop: string) =>
+        prop in overrides
+          ? overrides[prop]
+          : jest.requireActual("back-end/src/models/ExperimentModel")[prop],
+    },
+  );
+});
+
+describe("visual editor AI edit — persist", () => {
+  const { app, setReqContext } = setupApp();
+  const org = { id: "org_1", settings: {}, members: [] };
+
+  const CHANGESET_ID = "vcs_1";
+  const VISUAL_CHANGE_ID = "vc_1";
+  const VARIATION_ID = "var_treatment";
+
+  const draftExperiment = {
+    id: "exp_1",
+    organization: "org_1",
+    status: "draft",
+    archived: false,
+    variations: [{ id: "var_control" }, { id: VARIATION_ID }],
+  };
+
+  const seedChangeset = async (visualChange: Record<string, unknown> = {}) =>
+    VisualChangesetModel.create({
+      id: CHANGESET_ID,
+      organization: org.id,
+      experiment: draftExperiment.id,
+      editorUrl: "https://example.com/pricing",
+      urlPatterns: [
+        {
+          include: true,
+          type: "simple",
+          pattern: "https://example.com/pricing",
+        },
+      ],
+      visualChanges: [
+        {
+          id: VISUAL_CHANGE_ID,
+          variation: VARIATION_ID,
+          description: "",
+          css: "",
+          domMutations: [],
+          ...visualChange,
+        },
+      ],
+    });
+
+  const readVisualChange = async () => {
+    const doc = await VisualChangesetModel.findOne({ id: CHANGESET_ID });
+    return doc?.toJSON().visualChanges[0];
+  };
+
+  const editBody = (overrides: Record<string, unknown> = {}) => ({
+    prompt: "make the headline shorter",
+    variationId: VARIATION_ID,
+    visualChangesetId: CHANGESET_ID,
+    persist: true,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    setReqContext({
+      org,
+      organization: org,
+      userId: "u_1",
+      permissions: {
+        canUpdateVisualChange: () => true,
+        throwPermissionError: () => {
+          throw new Error("permission error");
+        },
+      },
+      hasPremiumFeature: () => true,
+    });
+    mockGetExperimentById.mockResolvedValue(draftExperiment);
+    mockParsePrompt.mockResolvedValue({
+      mutations: [
+        {
+          selector: "h1",
+          action: "set",
+          attribute: "html",
+          value: "Shorter",
+          parentSelector: null,
+          insertBeforeSelector: null,
+          options: null,
+        },
+      ],
+      css: null,
+      js: null,
+      insert: [],
+      explanation: "Shortened the headline.",
+    });
+  });
+
+  it("appends new mutations onto the existing ones", async () => {
+    const existing = {
+      selector: ".sub",
+      action: "set",
+      attribute: "html",
+      value: "Existing",
+    };
+    await seedChangeset({ domMutations: [existing] });
+
+    const res = await request(app)
+      .post("/api/v1/visual-editor/ai/edit")
+      .send(editBody());
+
+    expect(res.status).toBe(200);
+    expect(res.body.saved).toBe(true);
+    expect(res.body.visualChangeId).toBe(VISUAL_CHANGE_ID);
+
+    const saved = await readVisualChange();
+    expect(saved.domMutations).toHaveLength(2);
+    expect(saved.domMutations[0]).toMatchObject(existing);
+    expect(saved.domMutations[1]).toMatchObject({
+      selector: "h1",
+      value: "Shorter",
+    });
+  });
+
+  it("leaves existing css untouched when the model returns none", async () => {
+    await seedChangeset({ css: "h1 { color: red; }" });
+
+    await request(app)
+      .post("/api/v1/visual-editor/ai/edit")
+      .send(editBody())
+      .expect(200);
+
+    expect((await readVisualChange()).css).toBe("h1 { color: red; }");
+  });
+
+  it("replaces css wholesale when the model returns new css", async () => {
+    await seedChangeset({ css: "h1 { color: red; }" });
+    mockParsePrompt.mockResolvedValue({
+      mutations: [],
+      css: "h1 { color: blue; }",
+      js: null,
+      insert: [],
+      explanation: "Recoloured.",
+    });
+
+    await request(app)
+      .post("/api/v1/visual-editor/ai/edit")
+      .send(editBody())
+      .expect(200);
+
+    expect((await readVisualChange()).css).toBe("h1 { color: blue; }");
+  });
+
+  it("rejects a non-draft experiment before calling the model", async () => {
+    await seedChangeset();
+    mockGetExperimentById.mockResolvedValue({
+      ...draftExperiment,
+      status: "running",
+    });
+
+    const res = await request(app)
+      .post("/api/v1/visual-editor/ai/edit")
+      .send(editBody());
+
+    expect(res.status).toBe(400);
+    // The point of the early gate: no AI quota burned on a change that
+    // could never have been saved.
+    expect(mockParsePrompt).not.toHaveBeenCalled();
+  });
+
+  it("still generates without persist against a non-draft experiment", async () => {
+    await seedChangeset();
+    mockGetExperimentById.mockResolvedValue({
+      ...draftExperiment,
+      status: "running",
+    });
+
+    const res = await request(app)
+      .post("/api/v1/visual-editor/ai/edit")
+      .send(editBody({ persist: undefined }));
+
+    expect(res.status).toBe(200);
+    expect(res.body.saved).toBeUndefined();
+    expect((await readVisualChange()).domMutations).toHaveLength(0);
+  });
+
+  // The flat `elements` catalog only earns its keep if its selectors count as
+  // grounded — otherwise the self-correct pass treats every one of them as a
+  // hallucination and burns a second LLM call "fixing" a valid selector.
+  describe("flat domDigest.elements", () => {
+    const digestWith = (selector: string) => ({
+      url: "https://example.com/pricing",
+      title: "Pricing",
+      elements: [{ selector, tag: "div", text: "Promo" }],
+    });
+
+    const mutateOn = (selector: string) => ({
+      mutations: [
+        {
+          selector,
+          action: "set",
+          attribute: "html",
+          value: "New",
+          parentSelector: null,
+          insertBeforeSelector: null,
+          options: null,
+        },
+      ],
+      css: null,
+      js: null,
+      insert: [],
+      explanation: "Done.",
+    });
+
+    it("treats a selector from elements as grounded (no self-correct retry)", async () => {
+      await seedChangeset();
+      mockParsePrompt.mockResolvedValue(mutateOn(".promo"));
+
+      await request(app)
+        .post("/api/v1/visual-editor/ai/edit")
+        .send(editBody({ domDigest: digestWith(".promo") }))
+        .expect(200);
+
+      expect(mockParsePrompt).toHaveBeenCalledTimes(1);
+      expect((await readVisualChange()).domMutations[0].selector).toBe(
+        ".promo",
+      );
+    });
+
+    it("still retries on a selector that is in no catalog", async () => {
+      await seedChangeset();
+      mockParsePrompt.mockResolvedValue(mutateOn(".invented"));
+
+      await request(app)
+        .post("/api/v1/visual-editor/ai/edit")
+        .send(editBody({ domDigest: digestWith(".promo") }))
+        .expect(200);
+
+      expect(mockParsePrompt).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("rejects persist combined with streamingMode", async () => {
+    await seedChangeset();
+
+    const res = await request(app)
+      .post("/api/v1/visual-editor/ai/edit")
+      .send(editBody({ streamingMode: true }));
+
+    expect(res.status).toBe(400);
+    expect(mockParsePrompt).not.toHaveBeenCalled();
+  });
+});

--- a/packages/back-end/test/visual-editor-ai-image-tool.test.ts
+++ b/packages/back-end/test/visual-editor-ai-image-tool.test.ts
@@ -1,77 +1,12 @@
-import { generateImageTool } from "back-end/src/api/visual-editor-ai/aiTools/generateImage";
-import { uploadFile } from "back-end/src/services/files";
-import type { ApiReqContext } from "back-end/types/api";
+import { imageFilePath } from "back-end/src/api/visual-editor-ai/aiTools/generateImage";
 
-// Inverting `quarantine` fails silently — the experiment renders and the image
-// 404s a week later when the gen/ prefix expires — so assert it both ways.
-
-// jest.config stubs `ai` globally; here `tool()` must pass its definition through.
-jest.mock("ai", () => ({ tool: (definition: unknown) => definition }));
-jest.mock("back-end/src/services/files", () => ({
-  uploadFile: jest.fn(async (p: string) => `https://cdn.test/${p}`),
-}));
-jest.mock("back-end/src/services/imageGeneration", () => ({
-  generateImages: jest.fn(async () => [{ base64: "x" }]),
-}));
-jest.mock("back-end/src/services/imageOptimization", () => ({
-  optimizeAIImage: jest.fn(async () => ({
-    buffer: Buffer.from("x"),
-    contentType: "image/webp",
-    ext: "webp",
-    width: 1600,
-    height: 900,
-  })),
-}));
-jest.mock("back-end/src/services/organizations", () => ({
-  getAISettingsForOrg: jest.fn(async () => ({
-    visualEditorImageModel: "test-image-model",
-    visualEditorAIContext: "",
-    keySource: {},
-  })),
-}));
-jest.mock("back-end/src/enterprise/services/ai", () => ({
-  secondsUntilAICanBeUsedAgainForProvider: jest.fn(async () => 0),
-}));
-jest.mock("back-end/src/models/AITokenUsageModel", () => ({
-  updateTokenUsage: jest.fn(),
-}));
-jest.mock("back-end/src/services/growthbook", () => ({
-  trackAIUsage: jest.fn(),
-}));
-jest.mock("shared/ai", () => {
-  const overrides: Record<string, unknown> = {
-    getImageModelMeta: () => ({ provider: "openai" }),
-  };
-  return new Proxy(
-    {},
-    {
-      get: (_t, prop: string) =>
-        prop in overrides
-          ? overrides[prop]
-          : jest.requireActual("shared/ai")[prop],
-    },
-  );
-});
-
-it("only writes under gen/ when quarantining", async () => {
-  const uploadedPath = async (quarantine: boolean) => {
-    (uploadFile as jest.Mock).mockClear();
-    const tool = generateImageTool({
-      context: {
-        org: { id: "org_1" },
-        userId: "u_1",
-      } as unknown as ApiReqContext,
-      turnCounter: { count: 0, max: 3, generated: [], warnings: [] },
-      quarantine,
-    });
-    await tool.execute!({ prompt: "a dog", aspectRatio: "16:9" }, {} as never);
-    return (uploadFile as jest.Mock).mock.calls[0][0];
-  };
-
-  expect(await uploadedPath(true)).toMatch(
+// Inverting `quarantine` fails silently: the experiment renders, then its
+// image 404s a week later when the gen/ prefix expires.
+it("only writes under gen/ when quarantining", () => {
+  expect(imageFilePath("org_1", "webp", true)).toMatch(
     /^gen\/org_1\/visual-editor\/img_.+\.webp$/,
   );
-  expect(await uploadedPath(false)).toMatch(
+  expect(imageFilePath("org_1", "webp", false)).toMatch(
     /^org_1\/visual-editor\/img_.+\.webp$/,
   );
 });

--- a/packages/back-end/test/visual-editor-ai-image-tool.test.ts
+++ b/packages/back-end/test/visual-editor-ai-image-tool.test.ts
@@ -1,0 +1,136 @@
+import { generateImageTool } from "back-end/src/api/visual-editor-ai/aiTools/generateImage";
+import { uploadFile } from "back-end/src/services/files";
+import { generateImages } from "back-end/src/services/imageGeneration";
+import type { ImageTurnState } from "back-end/src/api/visual-editor-ai/aiTools/generateImage";
+import type { ApiReqContext } from "back-end/types/api";
+
+// The `quarantine` flag decides whether a generated image lands under the
+// `gen/` prefix (7-day bucket TTL, promoted when the extension user accepts)
+// or straight into permanent storage (a persisting caller has no accept step).
+// Getting it backwards fails silently — the experiment renders fine and the
+// image 404s a week later — so the prefix is asserted both ways.
+
+// jest.config stubs the whole `ai` package for import cost ("no test exercises
+// these"). This one does: `tool()` must return its definition intact or the
+// execute closure under test is swallowed by the stub.
+jest.mock("ai", () => ({
+  tool: (definition: unknown) => definition,
+}));
+
+jest.mock("back-end/src/services/files", () => ({
+  uploadFile: jest.fn(
+    async (filePath: string) => `https://cdn.test/${filePath}`,
+  ),
+}));
+jest.mock("back-end/src/services/imageGeneration", () => ({
+  generateImages: jest.fn(),
+}));
+jest.mock("back-end/src/services/imageOptimization", () => ({
+  optimizeAIImage: jest.fn(async () => ({
+    buffer: Buffer.from("x"),
+    contentType: "image/webp",
+    ext: "webp",
+    width: 1600,
+    height: 900,
+  })),
+}));
+jest.mock("back-end/src/services/organizations", () => ({
+  getAISettingsForOrg: jest.fn(async () => ({
+    visualEditorImageModel: "test-image-model",
+    visualEditorAIContext: "",
+    keySource: {},
+  })),
+}));
+jest.mock("back-end/src/enterprise/services/ai", () => ({
+  secondsUntilAICanBeUsedAgainForProvider: jest.fn(async () => 0),
+}));
+jest.mock("back-end/src/models/AITokenUsageModel", () => ({
+  updateTokenUsage: jest.fn(),
+}));
+jest.mock("back-end/src/services/growthbook", () => ({
+  trackAIUsage: jest.fn(),
+}));
+jest.mock("shared/ai", () => {
+  const overrides: Record<string, unknown> = {
+    getImageModelMeta: () => ({ provider: "openai" }),
+  };
+  return new Proxy(
+    {},
+    {
+      get: (_t, prop: string) =>
+        prop in overrides
+          ? overrides[prop]
+          : jest.requireActual("shared/ai")[prop],
+    },
+  );
+});
+
+const context = {
+  org: { id: "org_1" },
+  userId: "u_1",
+} as unknown as ApiReqContext;
+
+const newTurnState = (): ImageTurnState => ({
+  count: 0,
+  max: 3,
+  generated: [],
+  warnings: [],
+});
+
+const run = async (quarantine: boolean) => {
+  const turnCounter = newTurnState();
+  const tool = generateImageTool({ context, turnCounter, quarantine });
+  const result = await tool.execute!(
+    { prompt: "a dog", aspectRatio: "16:9" },
+    // The AI SDK passes call metadata the tool doesn't read.
+    {} as never,
+  );
+  return { result, turnCounter };
+};
+
+describe("generateImage quarantine prefix", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (generateImages as jest.Mock).mockResolvedValue([{ base64: "x" }]);
+  });
+
+  it("writes under gen/ when quarantining (the extension's preview flow)", async () => {
+    const { result, turnCounter } = await run(true);
+    const [filePath] = (uploadFile as jest.Mock).mock.calls[0];
+    expect(filePath).toMatch(/^gen\/org_1\/visual-editor\/img_.+\.webp$/);
+    expect(result).toMatchObject({ ok: true });
+    expect(turnCounter.generated).toHaveLength(1);
+  });
+
+  it("writes straight to permanent storage when not quarantining", async () => {
+    const { result, turnCounter } = await run(false);
+    const [filePath] = (uploadFile as jest.Mock).mock.calls[0];
+    expect(filePath).toMatch(/^org_1\/visual-editor\/img_.+\.webp$/);
+    expect(filePath.startsWith("gen/")).toBe(false);
+    expect(result).toMatchObject({ ok: true });
+    expect(turnCounter.generated[0].url).toBe(`https://cdn.test/${filePath}`);
+  });
+
+  it("records a soft failure as a warning instead of throwing", async () => {
+    (generateImages as jest.Mock).mockRejectedValue(new Error("provider down"));
+    const { result, turnCounter } = await run(false);
+    expect(result).toMatchObject({ ok: false });
+    expect(turnCounter.warnings).toEqual([
+      "Image generation failed: provider down",
+    ]);
+    expect(turnCounter.generated).toHaveLength(0);
+  });
+
+  it("stops at the per-turn budget and says so", async () => {
+    const turnCounter = newTurnState();
+    turnCounter.count = turnCounter.max;
+    const tool = generateImageTool({ context, turnCounter, quarantine: false });
+    const result = await tool.execute!(
+      { prompt: "a dog", aspectRatio: "16:9" },
+      {} as never,
+    );
+    expect(result).toMatchObject({ ok: false });
+    expect(uploadFile).not.toHaveBeenCalled();
+    expect(turnCounter.warnings[0]).toContain("budget exhausted");
+  });
+});

--- a/packages/back-end/test/visual-editor-ai-image-tool.test.ts
+++ b/packages/back-end/test/visual-editor-ai-image-tool.test.ts
@@ -1,29 +1,17 @@
 import { generateImageTool } from "back-end/src/api/visual-editor-ai/aiTools/generateImage";
 import { uploadFile } from "back-end/src/services/files";
-import { generateImages } from "back-end/src/services/imageGeneration";
-import type { ImageTurnState } from "back-end/src/api/visual-editor-ai/aiTools/generateImage";
 import type { ApiReqContext } from "back-end/types/api";
 
-// The `quarantine` flag decides whether a generated image lands under the
-// `gen/` prefix (7-day bucket TTL, promoted when the extension user accepts)
-// or straight into permanent storage (a persisting caller has no accept step).
-// Getting it backwards fails silently — the experiment renders fine and the
-// image 404s a week later — so the prefix is asserted both ways.
+// Inverting `quarantine` fails silently — the experiment renders and the image
+// 404s a week later when the gen/ prefix expires — so assert it both ways.
 
-// jest.config stubs the whole `ai` package for import cost ("no test exercises
-// these"). This one does: `tool()` must return its definition intact or the
-// execute closure under test is swallowed by the stub.
-jest.mock("ai", () => ({
-  tool: (definition: unknown) => definition,
-}));
-
+// jest.config stubs `ai` globally; here `tool()` must pass its definition through.
+jest.mock("ai", () => ({ tool: (definition: unknown) => definition }));
 jest.mock("back-end/src/services/files", () => ({
-  uploadFile: jest.fn(
-    async (filePath: string) => `https://cdn.test/${filePath}`,
-  ),
+  uploadFile: jest.fn(async (p: string) => `https://cdn.test/${p}`),
 }));
 jest.mock("back-end/src/services/imageGeneration", () => ({
-  generateImages: jest.fn(),
+  generateImages: jest.fn(async () => [{ base64: "x" }]),
 }));
 jest.mock("back-end/src/services/imageOptimization", () => ({
   optimizeAIImage: jest.fn(async () => ({
@@ -65,72 +53,25 @@ jest.mock("shared/ai", () => {
   );
 });
 
-const context = {
-  org: { id: "org_1" },
-  userId: "u_1",
-} as unknown as ApiReqContext;
+it("only writes under gen/ when quarantining", async () => {
+  const uploadedPath = async (quarantine: boolean) => {
+    (uploadFile as jest.Mock).mockClear();
+    const tool = generateImageTool({
+      context: {
+        org: { id: "org_1" },
+        userId: "u_1",
+      } as unknown as ApiReqContext,
+      turnCounter: { count: 0, max: 3, generated: [], warnings: [] },
+      quarantine,
+    });
+    await tool.execute!({ prompt: "a dog", aspectRatio: "16:9" }, {} as never);
+    return (uploadFile as jest.Mock).mock.calls[0][0];
+  };
 
-const newTurnState = (): ImageTurnState => ({
-  count: 0,
-  max: 3,
-  generated: [],
-  warnings: [],
-});
-
-const run = async (quarantine: boolean) => {
-  const turnCounter = newTurnState();
-  const tool = generateImageTool({ context, turnCounter, quarantine });
-  const result = await tool.execute!(
-    { prompt: "a dog", aspectRatio: "16:9" },
-    // The AI SDK passes call metadata the tool doesn't read.
-    {} as never,
+  expect(await uploadedPath(true)).toMatch(
+    /^gen\/org_1\/visual-editor\/img_.+\.webp$/,
   );
-  return { result, turnCounter };
-};
-
-describe("generateImage quarantine prefix", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    (generateImages as jest.Mock).mockResolvedValue([{ base64: "x" }]);
-  });
-
-  it("writes under gen/ when quarantining (the extension's preview flow)", async () => {
-    const { result, turnCounter } = await run(true);
-    const [filePath] = (uploadFile as jest.Mock).mock.calls[0];
-    expect(filePath).toMatch(/^gen\/org_1\/visual-editor\/img_.+\.webp$/);
-    expect(result).toMatchObject({ ok: true });
-    expect(turnCounter.generated).toHaveLength(1);
-  });
-
-  it("writes straight to permanent storage when not quarantining", async () => {
-    const { result, turnCounter } = await run(false);
-    const [filePath] = (uploadFile as jest.Mock).mock.calls[0];
-    expect(filePath).toMatch(/^org_1\/visual-editor\/img_.+\.webp$/);
-    expect(filePath.startsWith("gen/")).toBe(false);
-    expect(result).toMatchObject({ ok: true });
-    expect(turnCounter.generated[0].url).toBe(`https://cdn.test/${filePath}`);
-  });
-
-  it("records a soft failure as a warning instead of throwing", async () => {
-    (generateImages as jest.Mock).mockRejectedValue(new Error("provider down"));
-    const { result, turnCounter } = await run(false);
-    expect(result).toMatchObject({ ok: false });
-    expect(turnCounter.warnings).toEqual([
-      "Image generation failed: provider down",
-    ]);
-    expect(turnCounter.generated).toHaveLength(0);
-  });
-
-  it("stops at the per-turn budget and says so", async () => {
-    const turnCounter = newTurnState();
-    turnCounter.count = turnCounter.max;
-    const tool = generateImageTool({ context, turnCounter, quarantine: false });
-    const result = await tool.execute!(
-      { prompt: "a dog", aspectRatio: "16:9" },
-      {} as never,
-    );
-    expect(result).toMatchObject({ ok: false });
-    expect(uploadFile).not.toHaveBeenCalled();
-    expect(turnCounter.warnings[0]).toContain("budget exhausted");
-  });
+  expect(await uploadedPath(false)).toMatch(
+    /^org_1\/visual-editor\/img_.+\.webp$/,
+  );
 });


### PR DESCRIPTION
Non-browser clients (CLI, agents, the MCP server) can drive the visual editor's prompt endpoint today, but they have to reimplement three things the extension does after the response comes back, and each has a quiet failure mode:

- Saving. `updateVisualChange` replaces any array it's handed, while the model returns only NEW mutations (it's prompted with the existing ones and told not to duplicate them) and complete css/js. Merge it the wrong way and you either duplicate mutations or wipe the variation's stylesheet.
- Images. `generateImage` writes to the `gen/` quarantine prefix, which has a 7-day bucket TTL. A client that saves the response verbatim gets an experiment whose hero image 404s mid-test.
- The page catalog. domDigest's six arrays each have their own field names, so a client building one from raw HTML must classify every element first.

`persist: true` handles the first: it runs the draft check up front (so a non-draft experiment fails before burning AI quota rather than after) and does the append-mutations / replace-css-js merge server-side. It's rejected alongside streamingMode, whose final output is assembled in a different handler — one write path, not two.

For images, when `persist: true` is set, it skips the quarantine, generates just a single image and saves it immediately.

`domDigest.elements` accepts the same catalog as one flat list, and counts toward the trusted-selector set — without that the self-correct pass treats every entry as a hallucination.

Also declares `ignoreWarnings` on create-experiment's body schema. The SoftWarningError 422 tells callers to retry with it in the body, and context.ignoreWarnings does read it there, but the .strict() schema rejected the request before the handler ran.

These changes are all backwards compatible and no updates are needed to the Chrome extension.