### PR TITLE
fix(api): don't 400 the experiments list on a phase with no start date

### DIFF
--- a/packages/back-end/src/controllers/metrics.ts
+++ b/packages/back-end/src/controllers/metrics.ts
@@ -607,7 +607,7 @@ export const getMetricExperimentResults = async (
     dateUpdated: e.dateUpdated.toISOString(),
     phases: e.phases.map((p) => ({
       ...p,
-      dateStarted: p.dateStarted ? p.dateStarted.toISOString() : "",
+      dateStarted: p.dateStarted?.toISOString(),
       dateEnded: p.dateEnded?.toISOString(),
     })),
     nextScheduledStatusUpdate: e.nextScheduledStatusUpdate
@@ -707,7 +707,7 @@ export const getMetricNorthstarData = async (
     dateUpdated: e.dateUpdated.toISOString(),
     phases: e.phases.map((p) => ({
       ...p,
-      dateStarted: p.dateStarted ? p.dateStarted.toISOString() : "",
+      dateStarted: p.dateStarted?.toISOString(),
       dateEnded: p.dateEnded?.toISOString(),
     })),
     nextScheduledStatusUpdate: e.nextScheduledStatusUpdate

--- a/packages/back-end/src/controllers/metrics.ts
+++ b/packages/back-end/src/controllers/metrics.ts
@@ -607,7 +607,7 @@ export const getMetricExperimentResults = async (
     dateUpdated: e.dateUpdated.toISOString(),
     phases: e.phases.map((p) => ({
       ...p,
-      dateStarted: p.dateStarted.toISOString(),
+      dateStarted: p.dateStarted ? p.dateStarted.toISOString() : "",
       dateEnded: p.dateEnded?.toISOString(),
     })),
     nextScheduledStatusUpdate: e.nextScheduledStatusUpdate
@@ -707,7 +707,7 @@ export const getMetricNorthstarData = async (
     dateUpdated: e.dateUpdated.toISOString(),
     phases: e.phases.map((p) => ({
       ...p,
-      dateStarted: p.dateStarted.toISOString(),
+      dateStarted: p.dateStarted ? p.dateStarted.toISOString() : "",
       dateEnded: p.dateEnded?.toISOString(),
     })),
     nextScheduledStatusUpdate: e.nextScheduledStatusUpdate

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -3034,10 +3034,9 @@ export async function toExperimentApiInterface(
     ),
     phases: experiment.phases.map((p) => ({
       name: p.name,
-      // Legacy phases can be stored without a start date; one of them used to
-      // throw and take down the whole page of GET /api/v1/experiments.
-      dateStarted: p.dateStarted ? p.dateStarted.toISOString() : "",
-      dateEnded: p.dateEnded ? p.dateEnded.toISOString() : "",
+      // dateStarted is required by the API but some legacy phases might not have one
+      dateStarted: p.dateStarted?.toISOString() ?? "",
+      dateEnded: p.dateEnded?.toISOString() ?? "",
       reasonForStopping: p.reason || "",
       seed: p.seed || experiment.trackingKey,
       coverage: p.coverage,

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -3034,7 +3034,9 @@ export async function toExperimentApiInterface(
     ),
     phases: experiment.phases.map((p) => ({
       name: p.name,
-      dateStarted: p.dateStarted.toISOString(),
+      // Legacy phases can be stored without a start date; one of them used to
+      // throw and take down the whole page of GET /api/v1/experiments.
+      dateStarted: p.dateStarted ? p.dateStarted.toISOString() : "",
       dateEnded: p.dateEnded ? p.dateEnded.toISOString() : "",
       reasonForStopping: p.reason || "",
       seed: p.seed || experiment.trackingKey,

--- a/packages/back-end/test/experimentApiPhaseDates.test.ts
+++ b/packages/back-end/test/experimentApiPhaseDates.test.ts
@@ -1,0 +1,70 @@
+import { ExperimentInterface } from "shared/validators";
+import { ReqContext } from "back-end/types/organization";
+import { toExperimentApiInterface } from "back-end/src/services/experiments";
+
+// Legacy experiment docs can carry a phase with no dateStarted. The serializer
+// must not throw on them: one bad phase used to 400 an entire page of
+// GET /api/v1/experiments (issue #3841).
+const context = {
+  org: { id: "org_1", settings: {} },
+  models: { projects: { getById: async () => null } },
+} as unknown as ReqContext;
+
+function experimentWithPhaseDate(
+  dateStarted: Date | null,
+): ExperimentInterface {
+  return {
+    id: "exp_1",
+    organization: "org_1",
+    trackingKey: "my-experiment",
+    name: "My Experiment",
+    project: "",
+    owner: "u_1",
+    dateCreated: new Date("2024-01-01"),
+    dateUpdated: new Date("2024-01-02"),
+    tags: [],
+    variations: [
+      { id: "v0", key: "0", name: "Control", screenshots: [] },
+      { id: "v1", key: "1", name: "Variation 1", screenshots: [] },
+    ],
+    archived: false,
+    status: "running",
+    hashAttribute: "id",
+    hashVersion: 2,
+    autoSnapshots: false,
+    releasedVariationId: "",
+    goalMetrics: [],
+    secondaryMetrics: [],
+    guardrailMetrics: [],
+    phases: [
+      {
+        name: "Main",
+        dateStarted,
+        reason: "",
+        coverage: 1,
+        condition: "",
+        variationWeights: [0.5, 0.5],
+        variations: [],
+      },
+    ],
+  } as unknown as ExperimentInterface;
+}
+
+describe("toExperimentApiInterface phase dates", () => {
+  it("serializes a phase that has a start date", async () => {
+    const api = await toExperimentApiInterface(
+      context,
+      experimentWithPhaseDate(new Date("2024-03-01T00:00:00.000Z")),
+    );
+    expect(api.phases[0].dateStarted).toBe("2024-03-01T00:00:00.000Z");
+  });
+
+  it("serializes a phase with a missing start date instead of throwing", async () => {
+    const api = await toExperimentApiInterface(
+      context,
+      experimentWithPhaseDate(null),
+    );
+    expect(api.phases[0].dateStarted).toBe("");
+    expect(api.phases[0].dateEnded).toBe("");
+  });
+});


### PR DESCRIPTION
### Features and Changes

`toExperimentApiInterface` calls `p.dateStarted.toISOString()` on every phase with no null check, while the `dateEnded` line directly below it already guards. an experiment whose phase has no stored `dateStarted` throws a `TypeError` there, and `app.ts` turns any error without a status into a 400 carrying the raw message, so the caller gets `{"message": "Cannot read properties of null (reading 'toISOString')"}` and it reads as a client error.

serialization runs per page, so one such experiment breaks whichever page it lands on and there is no way to page past it. that is why #3841 saw it on specific offset/limit pairs like `offset=233, limit=1`.

this guards `dateStarted` the same way `dateEnded` already is, so a missing date serializes as `""`. `controllers/metrics.ts` builds the same phase shape for the experiments-using-this-metric views and had the same unguarded call twice, so those are guarded too.

not touching the 400 vs 500 part of the report. that default lives in the shared error handler and applies to every endpoint, so it belongs in its own PR.

- Closes #3841

### Dependencies

none

### Testing

added `packages/back-end/test/experimentApiPhaseDates.test.ts`, one phase with a start date and one with a null start date. the null case fails on main with `TypeError: Cannot read properties of null (reading 'toISOString')` and passes with the guard.

also ran the experiment and metric back-end suites, 32 suites and 545 tests, all green.

### Screenshots

none, no UI change.
