### PR TITLE
Allow custom values on enum and multiselect custom fields

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -43873,6 +43873,11 @@ paths:
                     - datetime
                 values:
                   type: string
+                creatable:
+                  description: >-
+                    For enum and multiselect fields, allow users to enter values
+                    beyond the predefined list
+                  type: boolean
                 required:
                   type: boolean
                 projects:
@@ -44060,6 +44065,11 @@ paths:
                           ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))$
                 values:
                   type: string
+                creatable:
+                  description: >-
+                    For enum and multiselect fields, allow users to enter values
+                    beyond the predefined list
+                  type: boolean
                 required:
                   type: boolean
                 projects:
@@ -65335,6 +65345,8 @@ components:
             - datetime
         values:
           type: string
+        creatable:
+          type: boolean
         required:
           type: boolean
         creator:

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -43873,6 +43873,11 @@ paths:
                     - datetime
                 values:
                   type: string
+                creatable:
+                  description: >-
+                    For enum and multiselect fields, allow users to enter values
+                    beyond the predefined list
+                  type: boolean
                 required:
                   type: boolean
                 projects:
@@ -44060,6 +44065,11 @@ paths:
                           ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))$
                 values:
                   type: string
+                creatable:
+                  description: >-
+                    For enum and multiselect fields, allow users to enter values
+                    beyond the predefined list
+                  type: boolean
                 required:
                   type: boolean
                 projects:
@@ -65335,6 +65345,8 @@ components:
             - datetime
         values:
           type: string
+        creatable:
+          type: boolean
         required:
           type: boolean
         creator:

--- a/packages/back-end/src/api/experiments/updateExperiment.ts
+++ b/packages/back-end/src/api/experiments/updateExperiment.ts
@@ -144,6 +144,9 @@ export const updateExperiment = createApiRequestHandler(
       req.body.customFields ?? experiment.customFields,
       req.context,
       req.body.project ?? experiment.project,
+      // A project change must re-validate all values against the new
+      // project's fields, so only grandfather unchanged values in place
+      projectChanged ? undefined : experiment.customFields,
     );
   }
 

--- a/packages/back-end/src/api/experiments/validations.ts
+++ b/packages/back-end/src/api/experiments/validations.ts
@@ -7,9 +7,11 @@ export const validateCustomFields = async (
   customFieldValues: Record<string, unknown> | undefined,
   context: ApiReqContext,
   project?: string,
+  existingCustomFieldValues?: Record<string, unknown>,
 ) => {
   await validateCustomFieldsForSection({
     customFieldValues,
+    existingCustomFieldValues,
     customFieldsModel: context.models.customFields,
     section: "experiment",
     project,

--- a/packages/back-end/src/api/features/updateFeature.ts
+++ b/packages/back-end/src/api/features/updateFeature.ts
@@ -140,6 +140,9 @@ export const updateFeature = createApiRequestHandler(updateFeatureValidator)(
         customFields ?? feature.customFields,
         req.context,
         effectiveProject,
+        // A project change must re-validate all values against the new
+        // project's fields, so only grandfather unchanged values in place
+        projectChanged ? undefined : feature.customFields,
       );
     }
 

--- a/packages/back-end/src/api/features/updateFeatureV2.ts
+++ b/packages/back-end/src/api/features/updateFeatureV2.ts
@@ -141,6 +141,9 @@ export const updateFeatureV2 = createApiRequestHandler(
       customFields ?? feature.customFields,
       req.context,
       effectiveProject,
+      // A project change must re-validate all values against the new
+      // project's fields, so only grandfather unchanged values in place
+      projectChanged ? undefined : feature.customFields,
     );
   }
 

--- a/packages/back-end/src/api/features/validations.ts
+++ b/packages/back-end/src/api/features/validations.ts
@@ -187,9 +187,11 @@ export const validateCustomFields = async (
   customFieldValues: Record<string, unknown> | undefined,
   context: ApiReqContext,
   project?: string,
+  existingCustomFieldValues?: Record<string, unknown>,
 ) => {
   await validateCustomFieldsForSection({
     customFieldValues,
+    existingCustomFieldValues,
     customFieldsModel: context.models.customFields,
     section: "feature",
     project,

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1606,6 +1606,7 @@ export async function postExperiment(
   ) {
     await validateCustomFieldsForSection({
       customFieldValues: data.customFields,
+      existingCustomFieldValues: experiment.customFields,
       customFieldsModel: context.models.customFields,
       section: "experiment",
       project: "project" in data ? data.project : experiment.project,

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -5577,6 +5577,7 @@ export async function putFeature(
   ) {
     await validateCustomFieldsForSection({
       customFieldValues: updates.customFields,
+      existingCustomFieldValues: feature.customFields,
       customFieldsModel: context.models.customFields,
       section: "feature",
       project: "project" in updates ? updates.project : feature.project,

--- a/packages/back-end/src/routers/custom-fields/custom-fields.controller.ts
+++ b/packages/back-end/src/routers/custom-fields/custom-fields.controller.ts
@@ -40,6 +40,7 @@ export const postCustomField = async (
     defaultValue,
     type,
     values,
+    creatable,
     required,
     projects,
     sections,
@@ -62,6 +63,7 @@ export const postCustomField = async (
     defaultValue,
     type,
     values,
+    creatable,
     required,
     projects,
     sections: sections?.length ? sections : [...ALL_SECTIONS],
@@ -149,6 +151,7 @@ type PutCustomFieldRequest = AuthRequest<
     placeholder: string;
     defaultValue?: boolean | string;
     values?: string;
+    creatable?: boolean;
     required: boolean;
     projects?: string[];
     sections?: CustomFieldSection[];
@@ -179,6 +182,7 @@ export const putCustomField = async (
     placeholder,
     defaultValue,
     values,
+    creatable,
     required,
     projects,
     sections,
@@ -209,6 +213,7 @@ export const putCustomField = async (
       placeholder,
       defaultValue,
       values,
+      ...(creatable !== undefined && { creatable }),
       required,
       projects,
       sections: sections ?? existingField.sections ?? [...ALL_SECTIONS],

--- a/packages/back-end/src/util/custom-fields.ts
+++ b/packages/back-end/src/util/custom-fields.ts
@@ -87,6 +87,11 @@ function validateSingleCustomFieldValue(
         `Invalid enum value for custom field ${customField.id} (${toStringValue(value)}). Only one value is allowed for enum fields.`,
       );
     }
+    // Creatable fields accept values beyond the predefined list
+    if (customField.creatable) {
+      return;
+    }
+
     const possibleValues = customField.values
       ? customField.values
           .split(",")

--- a/packages/back-end/src/util/custom-fields.ts
+++ b/packages/back-end/src/util/custom-fields.ts
@@ -87,7 +87,6 @@ function validateSingleCustomFieldValue(
         `Invalid enum value for custom field ${customField.id} (${toStringValue(value)}). Only one value is allowed for enum fields.`,
       );
     }
-    // Creatable fields accept values beyond the predefined list
     if (customField.creatable) {
       return;
     }

--- a/packages/back-end/src/util/custom-fields.ts
+++ b/packages/back-end/src/util/custom-fields.ts
@@ -141,9 +141,20 @@ function validateSingleCustomFieldValue(
 export function validateCustomFieldValues(
   customFields: CustomField[],
   customFieldValues: Record<string, unknown>,
+  existingCustomFieldValues?: Record<string, unknown>,
 ): void {
+  // Untouched values are grandfathered in, so stale values (entered before an
+  // option was removed, creatable turned off, or a field deleted) don't block
+  // saves of unrelated changes
+  const isUnchanged = (key: string) =>
+    existingCustomFieldValues !== undefined &&
+    isEqual(customFieldValues[key], existingCustomFieldValues[key]);
+
   if (customFields.length === 0) {
-    if (customFieldValues && Object.keys(customFieldValues).length > 0) {
+    const changedKeys = Object.keys(customFieldValues ?? {}).filter(
+      (key) => !isUnchanged(key),
+    );
+    if (changedKeys.length > 0) {
       throw new Error(`No custom fields are available to be defined.`);
     }
 
@@ -154,7 +165,7 @@ export function validateCustomFieldValues(
   // Ensure all custom fields being passed in, are valid keys
   const validKeys = new Set(customFields.map((v) => v.id));
   for (const key of Object.keys(customFieldValues)) {
-    if (!validKeys.has(key)) {
+    if (!validKeys.has(key) && !isUnchanged(key)) {
       throw new Error(
         `Invalid custom field: ${key}. This custom field does not exist.`,
       );
@@ -162,6 +173,10 @@ export function validateCustomFieldValues(
   }
 
   for (const customField of customFields) {
+    if (isUnchanged(customField.id)) {
+      continue;
+    }
+
     if (!(customField.id in customFieldValues)) {
       if (customField.required) {
         throw new Error(`Custom field "${customField.name}" is required.`);
@@ -195,11 +210,13 @@ export function shouldValidateCustomFieldsOnUpdate({
 // Helper that fetches the required customfields to validate against
 export async function validateCustomFieldsForSection({
   customFieldValues,
+  existingCustomFieldValues,
   project,
   section,
   customFieldsModel,
 }: {
   customFieldValues: Record<string, unknown> | undefined;
+  existingCustomFieldValues?: Record<string, unknown>;
   project: string | undefined;
   section: CustomFieldSection;
   customFieldsModel: CustomFieldModel;
@@ -210,5 +227,9 @@ export async function validateCustomFieldsForSection({
       project,
     })) ?? [];
 
-  validateCustomFieldValues(applicableCustomFields, customFieldValues ?? {});
+  validateCustomFieldValues(
+    applicableCustomFields,
+    customFieldValues ?? {},
+    existingCustomFieldValues,
+  );
 }

--- a/packages/back-end/test/util/custom-fields.test.ts
+++ b/packages/back-end/test/util/custom-fields.test.ts
@@ -26,14 +26,17 @@ describe("custom fields validation", () => {
     const validate = async ({
       fields,
       values,
+      existingValues,
       section = "feature",
     }: {
       fields: CustomField[];
       values?: Record<string, unknown>;
+      existingValues?: Record<string, unknown>;
       section?: "feature" | "experiment";
     }) => {
       return validateCustomFieldsForSection({
         customFieldValues: values,
+        existingCustomFieldValues: existingValues,
         customFieldsModel: buildCustomFieldsModel(fields),
         section,
       });
@@ -382,6 +385,93 @@ describe("custom fields validation", () => {
           section: "experiment",
         }),
       ).rejects.toThrow("Only one value is allowed for enum fields");
+    });
+
+    describe("grandfathering unchanged values on update", () => {
+      const owners = buildCustomField({
+        id: "cfd_owners",
+        name: "Owners",
+        type: "multiselect",
+        required: true,
+        values: "team-a,team-b",
+        sections: ["experiment"],
+      });
+      const tier = buildCustomField({
+        id: "cfd_tier",
+        name: "Tier",
+        type: "enum",
+        required: false,
+        values: "tier-a,tier-b",
+        sections: ["experiment"],
+      });
+
+      it("allows an unchanged out-of-list value when another field changes", async () => {
+        await expect(
+          validate({
+            values: { cfd_owners: '["team-c"]', cfd_tier: "tier-b" },
+            existingValues: { cfd_owners: '["team-c"]', cfd_tier: "tier-a" },
+            fields: [owners, tier],
+            section: "experiment",
+          }),
+        ).resolves.toBeUndefined();
+      });
+
+      it("still rejects a changed out-of-list value", async () => {
+        await expect(
+          validate({
+            values: { cfd_owners: '["team-c","team-d"]' },
+            existingValues: { cfd_owners: '["team-c"]' },
+            fields: [owners],
+            section: "experiment",
+          }),
+        ).rejects.toThrow(
+          "Invalid multiselect value for custom field cfd_owners",
+        );
+      });
+
+      it("allows an unchanged value for a field that no longer exists", async () => {
+        await expect(
+          validate({
+            values: { cfd_removed: "stale", cfd_tier: "tier-a" },
+            existingValues: { cfd_removed: "stale" },
+            fields: [tier],
+            section: "experiment",
+          }),
+        ).resolves.toBeUndefined();
+      });
+
+      it("allows a required field to stay absent when it was already absent", async () => {
+        await expect(
+          validate({
+            values: { cfd_tier: "tier-a" },
+            existingValues: {},
+            fields: [owners, tier],
+            section: "experiment",
+          }),
+        ).resolves.toBeUndefined();
+      });
+
+      it("still requires a required field that is being removed", async () => {
+        await expect(
+          validate({
+            values: { cfd_tier: "tier-a" },
+            existingValues: { cfd_owners: '["team-a"]', cfd_tier: "tier-a" },
+            fields: [owners, tier],
+            section: "experiment",
+          }),
+        ).rejects.toThrow('Custom field "Owners" is required.');
+      });
+
+      it("allows unchanged values when no custom fields are configured anymore", async () => {
+        await expect(
+          validate({
+            values: { cfd_removed: "stale" },
+            existingValues: { cfd_removed: "stale" },
+            fields: [],
+            section: "experiment",
+          }),
+        ).resolves.toBeUndefined();
+      });
     });
 
     it("treats numeric zero as a valid required number value", async () => {

--- a/packages/back-end/test/util/custom-fields.test.ts
+++ b/packages/back-end/test/util/custom-fields.test.ts
@@ -324,6 +324,66 @@ describe("custom fields validation", () => {
       );
     });
 
+    it("accepts values outside the allowed options for creatable multiselect fields", async () => {
+      await expect(
+        validate({
+          values: { cfd_owners: '["team-c","team-a"]' },
+          fields: [
+            buildCustomField({
+              id: "cfd_owners",
+              name: "Owners",
+              type: "multiselect",
+              required: true,
+              values: "team-a,team-b",
+              creatable: true,
+              sections: ["experiment"],
+            }),
+          ],
+          section: "experiment",
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("accepts values outside the allowed options for creatable enum fields", async () => {
+      await expect(
+        validate({
+          values: { cfd_tier: "tier-c" },
+          fields: [
+            buildCustomField({
+              id: "cfd_tier",
+              name: "Tier",
+              type: "enum",
+              required: true,
+              values: "tier-a,tier-b",
+              creatable: true,
+              sections: ["experiment"],
+            }),
+          ],
+          section: "experiment",
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("still rejects multiple values for creatable enum fields", async () => {
+      await expect(
+        validate({
+          values: { cfd_tier: '["tier-a","tier-c"]' },
+          fields: [
+            buildCustomField({
+              id: "cfd_tier",
+              name: "Tier",
+              type: "enum",
+              required: true,
+              values: "tier-a,tier-b",
+              creatable: true,
+              sections: ["experiment"],
+            }),
+          ],
+          section: "experiment",
+        }),
+      ).rejects.toThrow("Only one value is allowed for enum fields");
+    });
+
     it("treats numeric zero as a valid required number value", async () => {
       await expect(
         validate({

--- a/packages/front-end/components/CustomFields/CustomFieldInput.tsx
+++ b/packages/front-end/components/CustomFields/CustomFieldInput.tsx
@@ -34,6 +34,20 @@ const CustomFieldInput: FC<{
     return raw;
   };
 
+  // Include stored values in the options so custom values entered while a
+  // field was creatable still render after creatable is turned off
+  const getSelectOptions = (field: CustomField, currentValues: string[]) => {
+    const defined = field.values
+      ? field.values
+          .split(",")
+          .map((k) => k.trim())
+          .filter(Boolean)
+      : [];
+    return [...new Set([...defined, ...currentValues.filter(Boolean)])].map(
+      (j) => ({ value: j, label: j }),
+    );
+  };
+
   return (
     <Flex direction="column" gap="4" mt="4" className={className}>
       {!fields.length ? (
@@ -71,14 +85,9 @@ const CustomFieldInput: FC<{
                       </>
                     }
                     value={value[v.id] ?? v.defaultValue ?? ""}
-                    options={
-                      v.values
-                        ? v.values
-                            .split(",")
-                            .map((k) => k.trim())
-                            .map((j) => ({ value: j, label: j }))
-                        : []
-                    }
+                    options={getSelectOptions(v, [
+                      String(value[v.id] ?? v.defaultValue ?? ""),
+                    ])}
                     onChange={(s) => {
                       updateCustomField(v.id, s);
                     }}
@@ -99,14 +108,10 @@ const CustomFieldInput: FC<{
                       </>
                     }
                     value={value[v.id] ? getMultiSelectValue(value[v.id]) : []}
-                    options={
-                      v.values
-                        ? v.values
-                            .split(",")
-                            .map((k) => k.trim())
-                            .map((j) => ({ value: j, label: j }))
-                        : []
-                    }
+                    options={getSelectOptions(
+                      v,
+                      value[v.id] ? getMultiSelectValue(value[v.id]) : [],
+                    )}
                     onChange={(values) => {
                       updateCustomField(v.id, JSON.stringify(values));
                     }}

--- a/packages/front-end/components/CustomFields/CustomFieldInput.tsx
+++ b/packages/front-end/components/CustomFields/CustomFieldInput.tsx
@@ -61,6 +61,7 @@ const CustomFieldInput: FC<{
                 ) : v.type === "enum" ? (
                   <SelectField
                     size="legacy"
+                    createable={!!v.creatable}
                     label={
                       <>
                         {v.name}
@@ -88,6 +89,7 @@ const CustomFieldInput: FC<{
                 ) : v.type === "multiselect" ? (
                   <MultiSelectField
                     legacyHeight
+                    creatable={!!v.creatable}
                     label={
                       <>
                         {v.name}

--- a/packages/front-end/components/CustomFields/CustomFieldModal.tsx
+++ b/packages/front-end/components/CustomFields/CustomFieldModal.tsx
@@ -53,6 +53,7 @@ export default function CustomFieldModal({
       name: existing.name || "",
       description: existing.description || "",
       values: existing.values || "",
+      creatable: existing.creatable ?? false,
       type: existing.type || "text",
       placeholder: existing.placeholder || "",
       defaultValue: existing.defaultValue
@@ -134,6 +135,10 @@ export default function CustomFieldModal({
           value.placeholder = "";
         }
 
+        if (value.type !== "multiselect" && value.type !== "enum") {
+          value.creatable = false;
+        }
+
         if (
           (value.type === "multiselect" || value.type === "enum") &&
           value.defaultValue
@@ -144,7 +149,7 @@ export default function CustomFieldModal({
             ? value.values.split(",").map((k) => k.trim())
             : [];
           // check the array of values to see if the default value exists as one of the options:
-          if (!possibleValues.includes(defaultValue)) {
+          if (!value.creatable && !possibleValues.includes(defaultValue)) {
             throw new Error("Default value must be one of the options");
           }
           // unset any placeholder value, as this is not applicable to boolean fields
@@ -156,6 +161,7 @@ export default function CustomFieldModal({
           edit.name = value?.name ?? "";
           edit.required = value?.required ?? false;
           edit.values = value.values;
+          edit.creatable = value.creatable;
           edit.defaultValue = value.defaultValue;
           edit.description = value?.description ?? "";
           edit.placeholder = value?.placeholder ?? "";
@@ -175,6 +181,7 @@ export default function CustomFieldModal({
             id: value.id ?? "",
             name: value.name ?? "",
             values: value.values,
+            creatable: value.creatable,
             description: value.description ?? "",
             placeholder: value.placeholder ?? "",
             defaultValue: value.defaultValue,
@@ -333,7 +340,11 @@ export default function CustomFieldModal({
                   .filter(Boolean) || []
               }
               onChange={(values) => form.setValue("values", values.join(","))}
-              helpText="List of possible values"
+              helpText={
+                form.watch("creatable")
+                  ? "List of suggested values"
+                  : "List of possible values"
+              }
               placeholder="Add value..."
               containerClassName="mb-0"
             />
@@ -342,6 +353,16 @@ export default function CustomFieldModal({
                 {optionsChangeInfo}
               </Callout>
             )}
+            <Box mt="3">
+              <Checkbox
+                id="creatable"
+                label="Allow custom values"
+                value={!!form.watch("creatable")}
+                setValue={(value) => {
+                  form.setValue("creatable", value);
+                }}
+              />
+            </Box>
           </Box>
         )}
         {form.watch("type") !== "boolean" ? (
@@ -364,6 +385,8 @@ export default function CustomFieldModal({
               <SelectField
                 size="legacy"
                 label="Default value"
+                sort={false}
+                createable={!!form.watch("creatable")}
                 value={(form.watch("defaultValue") as string) || ""}
                 onChange={(v) => form.setValue("defaultValue", v)}
                 options={

--- a/packages/front-end/components/CustomFields/CustomFieldModal.tsx
+++ b/packages/front-end/components/CustomFields/CustomFieldModal.tsx
@@ -357,6 +357,11 @@ export default function CustomFieldModal({
               <Checkbox
                 id="creatable"
                 label="Allow custom values"
+                description={
+                  existing.creatable && !form.watch("creatable")
+                    ? "Custom values already entered on Feature Flags and experiments are kept."
+                    : undefined
+                }
                 value={!!form.watch("creatable")}
                 setValue={(value) => {
                   form.setValue("creatable", value);

--- a/packages/front-end/components/CustomFields/CustomFields.tsx
+++ b/packages/front-end/components/CustomFields/CustomFields.tsx
@@ -35,6 +35,8 @@ import CustomFieldModal from "@/components/CustomFields/CustomFieldModal";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import Button from "@/ui/Button";
+import Link from "@/ui/Link";
+import Text from "@/ui/Text";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/ui/Tabs";
 import useURLHash from "@/hooks/useURLHash";
 
@@ -130,21 +132,15 @@ function CustomFieldsTable({
           </SortableContext>
         ) : (
           <TableRow>
-            <TableCell colSpan={colSpan} className="text-center text-gray">
-              <em>
-                No custom fields in this view.{" "}
-                {canManage ? (
-                  <a
-                    href="#"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      openAddModal();
-                    }}
-                  >
-                    Add custom field
-                  </a>
-                ) : null}
-              </em>
+            <TableCell colSpan={colSpan}>
+              <Text as="div" align="center" color="text-low">
+                <em>
+                  No custom fields in this view.{" "}
+                  {canManage ? (
+                    <Link onClick={openAddModal}>Add custom field</Link>
+                  ) : null}
+                </em>
+              </Text>
             </TableCell>
           </TableRow>
         )}

--- a/packages/front-end/components/CustomFields/CustomFields.tsx
+++ b/packages/front-end/components/CustomFields/CustomFields.tsx
@@ -20,7 +20,7 @@ import { Box } from "@radix-ui/themes";
 import { useAuth } from "@/services/auth";
 import track from "@/services/track";
 import {
-  CUSTOM_FIELD_TABLE_WIDTHS,
+  CustomFieldColGroup,
   SortableCustomFieldRow,
   StaticCustomFieldRow,
 } from "@/components/CustomFields/SortableCustomField";
@@ -60,7 +60,6 @@ function CustomFieldsTable({
   handleMoveDown: (moveId: string, belowId: string) => void;
   canManage: boolean;
 }) {
-  const W = CUSTOM_FIELD_TABLE_WIDTHS;
   const colSpan = 7 + 1 + (showRequired ? 1 : 0); // +1 for menu
 
   const filteredItems = useMemo(() => {
@@ -75,20 +74,10 @@ function CustomFieldsTable({
 
   return (
     <table
-      className="table gbtable table-valign-top"
+      className="table gbtable gbtable-sortable table-valign-top"
       style={{ tableLayout: "fixed", width: "100%" }}
     >
-      <colgroup>
-        <col style={{ width: W.dragHandle }} />
-        <col style={{ width: W.name }} />
-        <col style={{ width: W.key }} />
-        <col style={{ width: W.description }} />
-        <col style={{ width: W.appliesTo }} />
-        <col style={{ width: W.valueType }} />
-        <col style={{ width: W.projects }} />
-        {showRequired && <col style={{ width: W.required }} />}
-        <col style={{ width: W.menu }} />
-      </colgroup>
+      <CustomFieldColGroup showRequired={showRequired} />
       <thead>
         <tr>
           <th style={{ padding: "0.5rem 0", textAlign: "center" }} />
@@ -358,7 +347,11 @@ const CustomFields: FC = () => {
           </Tabs>
           <DragOverlay>
             {activeId && selectedRow ? (
-              <table style={{ width: "100%" }} className="table gbtable">
+              <table
+                style={{ tableLayout: "fixed", width: "100%" }}
+                className="table gbtable gbtable-sortable table-valign-top"
+              >
+                <CustomFieldColGroup showRequired={true} />
                 <tbody>
                   <StaticCustomFieldRow
                     customField={selectedRow}

--- a/packages/front-end/components/CustomFields/CustomFields.tsx
+++ b/packages/front-end/components/CustomFields/CustomFields.tsx
@@ -24,6 +24,13 @@ import {
   SortableCustomFieldRow,
   StaticCustomFieldRow,
 } from "@/components/CustomFields/SortableCustomField";
+import Table, {
+  TableBody,
+  TableCell,
+  TableColumnHeader,
+  TableHeader,
+  TableRow,
+} from "@/ui/Table";
 import CustomFieldModal from "@/components/CustomFields/CustomFieldModal";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
@@ -73,25 +80,28 @@ function CustomFieldsTable({
     );
 
   return (
-    <table
-      className="table gbtable gbtable-sortable table-valign-top"
-      style={{ tableLayout: "fixed", width: "100%" }}
+    <Table
+      variant="list"
+      stickyHeader={false}
+      roundedCorners
+      layout="fixed"
+      className="appbox"
     >
       <CustomFieldColGroup showRequired={showRequired} />
-      <thead>
-        <tr>
-          <th style={{ padding: "0.5rem 0", textAlign: "center" }} />
-          <th>Field Name</th>
-          <th>Field Key</th>
-          <th>Description</th>
-          <th>Applies To</th>
-          <th>Value Type</th>
-          <th>Projects</th>
-          {showRequired && <th>Required</th>}
-          <th style={{ padding: "0.5rem 0", textAlign: "center" }} />
-        </tr>
-      </thead>
-      <tbody>
+      <TableHeader>
+        <TableRow>
+          <TableColumnHeader />
+          <TableColumnHeader>Field Name</TableColumnHeader>
+          <TableColumnHeader>Field Key</TableColumnHeader>
+          <TableColumnHeader>Description</TableColumnHeader>
+          <TableColumnHeader>Applies To</TableColumnHeader>
+          <TableColumnHeader>Value Type</TableColumnHeader>
+          <TableColumnHeader>Projects</TableColumnHeader>
+          {showRequired && <TableColumnHeader>Required</TableColumnHeader>}
+          <TableColumnHeader />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
         {filteredItems.length > 0 ? (
           <SortableContext
             items={filteredItems}
@@ -119,8 +129,8 @@ function CustomFieldsTable({
             ))}
           </SortableContext>
         ) : (
-          <tr>
-            <td colSpan={colSpan} className="text-center text-gray">
+          <TableRow>
+            <TableCell colSpan={colSpan} className="text-center text-gray">
               <em>
                 No custom fields in this view.{" "}
                 {canManage ? (
@@ -135,11 +145,11 @@ function CustomFieldsTable({
                   </a>
                 ) : null}
               </em>
-            </td>
-          </tr>
+            </TableCell>
+          </TableRow>
         )}
-      </tbody>
-    </table>
+      </TableBody>
+    </Table>
   );
 }
 
@@ -297,68 +307,64 @@ const CustomFields: FC = () => {
               </TabsList>
             </Box>
             <TabsContent value="all">
-              <Box className="appbox">
-                <CustomFieldsTable
-                  filter="all"
-                  items={items}
-                  duplicateIds={duplicateIds}
-                  showRequired={true}
-                  deleteCustomField={deleteCustomField}
-                  toggleCustomField={toggleCustomField}
-                  setModalOpen={setModalOpen}
-                  handleMoveUp={handleMoveUp}
-                  handleMoveDown={handleMoveDown}
-                  canManage={canManage}
-                />
-              </Box>
+              <CustomFieldsTable
+                filter="all"
+                items={items}
+                duplicateIds={duplicateIds}
+                showRequired={true}
+                deleteCustomField={deleteCustomField}
+                toggleCustomField={toggleCustomField}
+                setModalOpen={setModalOpen}
+                handleMoveUp={handleMoveUp}
+                handleMoveDown={handleMoveDown}
+                canManage={canManage}
+              />
             </TabsContent>
             <TabsContent value="feature">
-              <Box className="appbox">
-                <CustomFieldsTable
-                  filter="feature"
-                  items={items}
-                  duplicateIds={duplicateIds}
-                  showRequired={true}
-                  deleteCustomField={deleteCustomField}
-                  toggleCustomField={toggleCustomField}
-                  setModalOpen={setModalOpen}
-                  handleMoveUp={handleMoveUp}
-                  handleMoveDown={handleMoveDown}
-                  canManage={canManage}
-                />
-              </Box>
+              <CustomFieldsTable
+                filter="feature"
+                items={items}
+                duplicateIds={duplicateIds}
+                showRequired={true}
+                deleteCustomField={deleteCustomField}
+                toggleCustomField={toggleCustomField}
+                setModalOpen={setModalOpen}
+                handleMoveUp={handleMoveUp}
+                handleMoveDown={handleMoveDown}
+                canManage={canManage}
+              />
             </TabsContent>
             <TabsContent value="experiment">
-              <Box className="appbox">
-                <CustomFieldsTable
-                  filter="experiment"
-                  items={items}
-                  duplicateIds={duplicateIds}
-                  showRequired={true}
-                  deleteCustomField={deleteCustomField}
-                  toggleCustomField={toggleCustomField}
-                  setModalOpen={setModalOpen}
-                  handleMoveUp={handleMoveUp}
-                  handleMoveDown={handleMoveDown}
-                  canManage={canManage}
-                />
-              </Box>
+              <CustomFieldsTable
+                filter="experiment"
+                items={items}
+                duplicateIds={duplicateIds}
+                showRequired={true}
+                deleteCustomField={deleteCustomField}
+                toggleCustomField={toggleCustomField}
+                setModalOpen={setModalOpen}
+                handleMoveUp={handleMoveUp}
+                handleMoveDown={handleMoveDown}
+                canManage={canManage}
+              />
             </TabsContent>
           </Tabs>
           <DragOverlay>
             {activeId && selectedRow ? (
-              <table
-                style={{ tableLayout: "fixed", width: "100%" }}
-                className="table gbtable gbtable-sortable table-valign-top"
+              <Table
+                variant="list"
+                stickyHeader={false}
+                layout="fixed"
+                style={{ width: "100%" }}
               >
                 <CustomFieldColGroup showRequired={true} />
-                <tbody>
+                <TableBody>
                   <StaticCustomFieldRow
                     customField={selectedRow}
                     showRequired={true}
                   />
-                </tbody>
-              </table>
+                </TableBody>
+              </Table>
             ) : null}
           </DragOverlay>
         </DndContext>

--- a/packages/front-end/components/CustomFields/SortableCustomField.tsx
+++ b/packages/front-end/components/CustomFields/SortableCustomField.tsx
@@ -76,6 +76,27 @@ export const CUSTOM_FIELD_TABLE_WIDTHS = {
   required: "7%",
 } as const;
 
+export function CustomFieldColGroup({
+  showRequired,
+}: {
+  showRequired: boolean;
+}) {
+  const W = CUSTOM_FIELD_TABLE_WIDTHS;
+  return (
+    <colgroup>
+      <col style={{ width: W.dragHandle }} />
+      <col style={{ width: W.name }} />
+      <col style={{ width: W.key }} />
+      <col style={{ width: W.description }} />
+      <col style={{ width: W.appliesTo }} />
+      <col style={{ width: W.valueType }} />
+      <col style={{ width: W.projects }} />
+      {showRequired && <col style={{ width: W.required }} />}
+      <col style={{ width: W.menu }} />
+    </colgroup>
+  );
+}
+
 interface SortableProps {
   customField: CustomFieldWithArrayIndex;
   setEditModal: (cf: CustomField) => void;

--- a/packages/front-end/components/CustomFields/SortableCustomField.tsx
+++ b/packages/front-end/components/CustomFields/SortableCustomField.tsx
@@ -11,6 +11,7 @@ import CustomFieldRowMenu from "@/components/CustomFields/CustomFieldRowMenu";
 import ProjectBadges from "@/components/ProjectBadges";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import Badge from "@/ui/Badge";
+import { TableCell, TableRow } from "@/ui/Table";
 import Text from "@/ui/Text";
 
 const MULTI_VALUE_LIMIT = 3;
@@ -123,20 +124,19 @@ function RowCells({
   showRequired: boolean;
   isDuplicateId?: boolean;
 }) {
-  const WIDTHS = CUSTOM_FIELD_TABLE_WIDTHS;
   const isDisabled = customField.active === false;
 
   return (
     <>
-      <td style={{ ...tdStyle, width: WIDTHS.name }}>
+      <TableCell style={tdStyle}>
         <Flex wrap="wrap" align="center" gap="2">
           <Text weight="semibold" color={isDisabled ? "text-low" : "text-mid"}>
             {customField.name}
           </Text>
           {isDisabled && <Badge label="disabled" color="gray" variant="soft" />}
         </Flex>
-      </td>
-      <td style={{ ...tdStyle, width: WIDTHS.key }}>
+      </TableCell>
+      <TableCell style={tdStyle}>
         <Flex align="center">
           {isDuplicateId && (
             <Tooltip
@@ -162,20 +162,20 @@ function RowCells({
             {customField.id}
           </code>
         </Flex>
-      </td>
-      <td style={{ ...tdStyle, width: WIDTHS.description }}>
+      </TableCell>
+      <TableCell style={tdStyle}>
         <Text color="text-mid">
           {customField.description && customField.description.length > 80
             ? customField.description.substring(0, 80).trim() + "..."
             : (customField.description ?? "")}
         </Text>
-      </td>
-      <td style={{ ...tdStyle, width: WIDTHS.appliesTo }}>
+      </TableCell>
+      <TableCell style={tdStyle}>
         <Text color="text-mid">
           {formatSectionsLabel(customField.sections)}
         </Text>
-      </td>
-      <td style={{ ...tdStyle, width: WIDTHS.valueType }}>
+      </TableCell>
+      <TableCell style={tdStyle}>
         <Text color="text-mid">
           {customField.type}
           {(customField.type === "enum" ||
@@ -183,19 +183,19 @@ function RowCells({
             <EnumValuesDisplay valuesStr={customField.values} />
           )}
         </Text>
-      </td>
-      <td style={{ ...tdStyle, width: WIDTHS.projects }}>
+      </TableCell>
+      <TableCell style={tdStyle}>
         <ProjectBadges
           resourceType="custom field"
           projectIds={
             customField.projects?.length ? customField.projects : undefined
           }
         />
-      </td>
+      </TableCell>
       {showRequired && (
-        <td style={{ ...tdStyle, width: WIDTHS.required }}>
+        <TableCell style={tdStyle}>
           <Text color="text-mid">{customField.required ? "yes" : ""}</Text>
-        </td>
+        </TableCell>
       )}
     </>
   );
@@ -213,7 +213,6 @@ export function SortableCustomFieldRow(props: SortableProps) {
   const customField = props.customField;
   const { showRequired, isDuplicateId } = props;
   const isDisabled = customField.active === false;
-  const WIDTHS = CUSTOM_FIELD_TABLE_WIDTHS;
   const style: React.CSSProperties = {
     transition,
     ...(isDragging
@@ -222,12 +221,10 @@ export function SortableCustomFieldRow(props: SortableProps) {
   };
 
   return (
-    <tr ref={setNodeRef} style={style}>
-      <td
+    <TableRow ref={setNodeRef} style={style}>
+      <TableCell
         style={{
           ...tdStyle,
-          width: WIDTHS.dragHandle,
-          minWidth: WIDTHS.dragHandle,
           padding: "0.65rem 0",
           textAlign: "center",
         }}
@@ -245,17 +242,15 @@ export function SortableCustomFieldRow(props: SortableProps) {
             <RiDraggable size={16} />
           </div>
         </Flex>
-      </td>
+      </TableCell>
       <RowCells
         customField={customField}
         showRequired={showRequired}
         isDuplicateId={isDuplicateId}
       />
-      <td
+      <TableCell
         style={{
           ...tdStyle,
-          width: WIDTHS.menu,
-          minWidth: WIDTHS.menu,
           padding: "0.5rem 0",
           textAlign: "center",
         }}
@@ -272,8 +267,8 @@ export function SortableCustomFieldRow(props: SortableProps) {
           onMoveDown={props.onMoveDown}
           onToggleActive={() => props.toggleCustomField(customField)}
         />
-      </td>
-    </tr>
+      </TableCell>
+    </TableRow>
   );
 }
 
@@ -284,15 +279,11 @@ export function StaticCustomFieldRow({
   customField: CustomField;
   showRequired?: boolean;
 }) {
-  const WIDTHS = CUSTOM_FIELD_TABLE_WIDTHS;
-
   return (
-    <tr style={{ opacity: 0.6, borderBottom: "1px solid var(--gray-a5)" }}>
-      <td
+    <TableRow style={{ opacity: 0.6 }}>
+      <TableCell
         style={{
           ...tdStyle,
-          width: WIDTHS.dragHandle,
-          minWidth: WIDTHS.dragHandle,
           padding: "0.5rem 0",
           textAlign: "center",
         }}
@@ -308,17 +299,15 @@ export function StaticCustomFieldRow({
             <RiDraggable size={16} />
           </div>
         </Flex>
-      </td>
+      </TableCell>
       <RowCells customField={customField} showRequired={showRequired} />
-      <td
+      <TableCell
         style={{
           ...tdStyle,
-          width: WIDTHS.menu,
-          minWidth: WIDTHS.menu,
           padding: "1rem 0.5rem",
           textAlign: "center",
         }}
       />
-    </tr>
+    </TableRow>
   );
 }

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -1088,15 +1088,6 @@ main.main {
     }
   }
 
-  // Collapsed borders repaint inconsistently when drag-and-drop translates a <tr>
-  &.gbtable-sortable {
-    border-collapse: separate;
-    border-spacing: 0;
-    thead th {
-      border-bottom: 0;
-    }
-  }
-
   .dark-theme &.decision-criteria-table {
     tbody {
       tr {

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -1088,6 +1088,18 @@ main.main {
     }
   }
 
+  // Collapsed borders are shared between adjacent rows, so they repaint at
+  // inconsistent positions when drag-and-drop translates a <tr>. Separate
+  // borders move rigidly with their row; the header's own border is dropped
+  // so the divider stays 1px (the first body row's border-top provides it).
+  &.gbtable-sortable {
+    border-collapse: separate;
+    border-spacing: 0;
+    thead th {
+      border-bottom: 0;
+    }
+  }
+
   .dark-theme &.decision-criteria-table {
     tbody {
       tr {

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -1088,10 +1088,7 @@ main.main {
     }
   }
 
-  // Collapsed borders are shared between adjacent rows, so they repaint at
-  // inconsistent positions when drag-and-drop translates a <tr>. Separate
-  // borders move rigidly with their row; the header's own border is dropped
-  // so the divider stays 1px (the first body row's border-top provides it).
+  // Collapsed borders repaint inconsistently when drag-and-drop translates a <tr>
   &.gbtable-sortable {
     border-collapse: separate;
     border-spacing: 0;

--- a/packages/front-end/ui/Checkbox.tsx
+++ b/packages/front-end/ui/Checkbox.tsx
@@ -89,7 +89,7 @@ export default forwardRef<HTMLLabelElement, Props>(function Checkbox(
         <Flex direction="column" gap="1">
           <Text weight={weight}>{label}</Text>
           {description && (
-            <Text style={{ color: "var(--color-text-mid)" }}>
+            <Text weight="regular" style={{ color: "var(--color-text-mid)" }}>
               {description}
             </Text>
           )}

--- a/packages/shared/src/validators/custom-fields.ts
+++ b/packages/shared/src/validators/custom-fields.ts
@@ -29,6 +29,8 @@ export const customFieldsPropsValidator = z.object({
   defaultValue: z.any().optional(),
   type: customFieldTypes,
   values: z.string().optional(),
+  // Enum and multiselect only: allow users to enter values beyond the predefined list
+  creatable: z.boolean().optional(),
   required: z.boolean(),
   creator: z.string().optional(),
   projects: z.array(z.string()).optional(),
@@ -91,6 +93,7 @@ export const apiCustomFieldInterface = namedSchema(
     defaultValue: apiDefaultValueTypes.optional(),
     type: customFieldTypes,
     values: z.string().optional(),
+    creatable: z.boolean().optional(),
     required: z.boolean(),
     creator: z.string().optional(),
     projects: z.array(z.string()).optional(),
@@ -111,6 +114,12 @@ export const apiCreateCustomFieldBody = z.strictObject({
     "The type of value this custom field will take",
   ),
   values: z.string().optional(),
+  creatable: z
+    .boolean()
+    .optional()
+    .describe(
+      "For enum and multiselect fields, allow users to enter values beyond the predefined list",
+    ),
   required: z.boolean(),
   projects: z.array(z.string()).optional(),
   sections: z

--- a/packages/shared/src/validators/custom-fields.ts
+++ b/packages/shared/src/validators/custom-fields.ts
@@ -29,7 +29,6 @@ export const customFieldsPropsValidator = z.object({
   defaultValue: z.any().optional(),
   type: customFieldTypes,
   values: z.string().optional(),
-  // Enum and multiselect only: allow users to enter values beyond the predefined list
   creatable: z.boolean().optional(),
   required: z.boolean(),
   creator: z.string().optional(),


### PR DESCRIPTION
Adds an "Allow custom values" option to enum and multiselect custom fields, letting users type in values beyond the predefined list - in the UI and via the REST API.

<img width="561" height="807" alt="image" src="https://github.com/user-attachments/assets/6aeffe37-0c99-4a0b-bd90-a5878edf6623" />
