### PR TITLE
Update docs to recommend Azure DocumentDB instead of Cosmos

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -112,6 +112,10 @@ GrowthBook only deals with aggregate data and the bulk of the processing is offl
 
 If you are using feature flags, **we strongly recommend** adding a caching layer between the GrowthBook API and your application in production. This will also help you stay within the limits of our [Fair Use Policy](https://www.growthbook.io/fair-use). Some of our [code examples](https://github.com/growthbook/examples) implement caching. We offer a pre-built [GrowthBook Proxy server](/self-host/proxy) you can run that handles caching and invalidation automatically. You can also setup [your own CDN](/self-host/cdn) or distributed cache like Redis.
 
+### Can I use Azure CosmosDB instead of Mongo?
+
+No. Azure Cosmos DB is not fully supported as a MongoDB replacement for GrowthBook. If you're running on Azure, use [Azure DocumentDB](https://azure.microsoft.com/en-us/products/documentdb) instead. See the [production self-hosting guide](/self-host/production) for other managed MongoDB options.
+
 ### I can't upload to S3/getting 400 error when uploading to S3?
 
 - Make sure you've correctly set the `S3_BUCKET` and `S3_REGION` environment variables

--- a/docs/self-host.mdx
+++ b/docs/self-host.mdx
@@ -51,7 +51,7 @@ Then, just run `docker compose up -d` to start everything and view the app at [h
 **Use of mongo image**
 
 The use of the mongo image within the docker-compose.yml is meant to quickly get a dev or staging environment up and running.
-For production you may want to use a more scalable and stable solution (ie. AWS DocumentDB, Google Cloud MongoDB Atlas, Azure Cosmos DB for Mongo, etc.)
+For production you may want to use a more scalable and stable solution (ie. AWS DocumentDB, Google Cloud MongoDB Atlas, Azure DocumentDB, etc.)
 
 </Warning>
 

--- a/docs/self-host/production.mdx
+++ b/docs/self-host/production.mdx
@@ -118,7 +118,7 @@ The easiest option in production is to use a managed service:
 - [MongoDB Atlas](https://www.mongodb.com/) (recommended)
 - AWS DocumentDB
 - [FerretDB](/self-host/ferretdb)
-- Azure CosmosDB
+- [Azure DocumentDB](https://azure.microsoft.com/en-us/products/documentdb)
 
 If you prefer to run MongoDB yourself, we recommend running a replica set configuration with 3 nodes. This will ensure that your data is always available even if one of your MongoDB instances goes down.
 


### PR DESCRIPTION
### Features and Changes

Azure CosmosDB is not fully compatible with Mongo, especially when it comes to how indexes are handled. Luckily, Azure has a replacement called Azure DocumentDB with much better Mongo compatibility.  Update the docs to link there instead.
