### PR TITLE
Re-sync every SDK key mapping to the license server daily

### DIFF
--- a/packages/back-end/src/init/queue.ts
+++ b/packages/back-end/src/init/queue.ts
@@ -28,6 +28,7 @@ import updateAggregatedFactTablesJob from "back-end/src/jobs/updateAggregatedFac
 import addRampScheduleJob from "back-end/src/jobs/updateRampSchedules";
 import addScheduledPublishJob from "back-end/src/jobs/updateScheduledPublishes";
 import addSyncManagedWarehouseJsonErgonomicsJob from "back-end/src/jobs/syncManagedWarehouseJsonErgonomics";
+import addSyncSdkKeyMappingsJob from "back-end/src/jobs/syncSdkKeyMappings";
 import { initRampScheduleHooks } from "back-end/src/services/rampSchedule";
 
 export async function queueInit() {
@@ -57,6 +58,7 @@ export async function queueInit() {
   addRampScheduleJob(agenda);
   addScheduledPublishJob(agenda);
   await addSyncManagedWarehouseJsonErgonomicsJob(agenda);
+  await addSyncSdkKeyMappingsJob(agenda);
   initRampScheduleHooks();
   // Make sure we have index needed to delete efficiently
   agenda._collection

--- a/packages/back-end/src/jobs/syncSdkKeyMappings.ts
+++ b/packages/back-end/src/jobs/syncSdkKeyMappings.ts
@@ -1,0 +1,59 @@
+import Agenda from "agenda";
+import { IS_CLOUD } from "back-end/src/util/secrets";
+import { getCollection } from "back-end/src/util/mongo.util";
+import { syncCloudSDKMappings } from "back-end/src/services/licenseServerManagedClickhouse";
+import { logger } from "back-end/src/util/logger";
+
+const JOB_NAME = "syncSdkKeyMappings";
+export const BATCH_SIZE = 500;
+
+type MappingDoc = { key?: string; organization?: string };
+
+/**
+ * Re-post every SDK connection's key -> org pair to the license server so
+ * usage.sdk_key_mapping heals from any create-time insert that failed.
+ */
+export async function syncSdkKeyMappings(
+  source: AsyncIterable<MappingDoc> = getCollection<MappingDoc>(
+    "sdkconnections",
+  ).find({}, { projection: { key: 1, organization: 1, _id: 0 } }),
+) {
+  if (!IS_CLOUD) return;
+
+  const start = Date.now();
+  let batch: { key: string; organization: string }[] = [];
+  let sent = 0;
+  let failedBatches = 0;
+
+  const flush = async () => {
+    if (!batch.length) return;
+    try {
+      await syncCloudSDKMappings(batch);
+      sent += batch.length;
+    } catch (e) {
+      failedBatches++;
+      logger.error(e, `${JOB_NAME}: batch of ${batch.length} mappings failed`);
+    }
+    batch = [];
+  };
+
+  for await (const doc of source) {
+    if (!doc.key || !doc.organization) continue;
+    batch.push({ key: doc.key, organization: doc.organization });
+    if (batch.length >= BATCH_SIZE) await flush();
+  }
+  await flush();
+
+  logger.info(
+    `${JOB_NAME}: synced ${sent} SDK key mappings (${failedBatches} failed batches) in ${Date.now() - start}ms`,
+  );
+}
+
+export default async function (agenda: Agenda) {
+  agenda.define(JOB_NAME, () => syncSdkKeyMappings());
+
+  const job = agenda.create(JOB_NAME, {});
+  job.unique({});
+  job.repeatEvery("24 hours");
+  await job.save();
+}

--- a/packages/back-end/src/services/licenseServerManagedClickhouse.ts
+++ b/packages/back-end/src/services/licenseServerManagedClickhouse.ts
@@ -188,6 +188,13 @@ export async function addCloudSDKMapping(
   });
 }
 
+/** Batch form of addCloudSDKMapping; the license server upserts, so re-sending is safe. */
+export async function syncCloudSDKMappings(
+  mappings: { key: string; organization: string }[],
+): Promise<void> {
+  await postManagedClickhouse("sdk-key-mapping", { mappings });
+}
+
 export async function migrateOverageEventsForOrgId(
   orgId: string,
 ): Promise<void> {

--- a/packages/back-end/test/jobs/syncSdkKeyMappings.test.ts
+++ b/packages/back-end/test/jobs/syncSdkKeyMappings.test.ts
@@ -1,0 +1,62 @@
+import {
+  BATCH_SIZE,
+  syncSdkKeyMappings,
+} from "back-end/src/jobs/syncSdkKeyMappings";
+import { syncCloudSDKMappings } from "back-end/src/services/licenseServerManagedClickhouse";
+
+jest.mock("back-end/src/util/secrets", () => ({ IS_CLOUD: true }));
+jest.mock("back-end/src/util/mongo.util", () => ({ getCollection: jest.fn() }));
+jest.mock("back-end/src/services/licenseServerManagedClickhouse", () => ({
+  syncCloudSDKMappings: jest.fn(),
+}));
+jest.mock("back-end/src/util/logger", () => ({
+  logger: { info: jest.fn(), error: jest.fn() },
+}));
+
+const mockSync = syncCloudSDKMappings as jest.Mock;
+
+async function* docs(n: number, offset = 0) {
+  for (let i = offset; i < offset + n; i++) {
+    yield { key: `sdk-${i}`, organization: `org_${i % 3}` };
+  }
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("syncSdkKeyMappings", () => {
+  it("posts in batches of BATCH_SIZE and flushes the remainder", async () => {
+    mockSync.mockResolvedValue(undefined);
+    await syncSdkKeyMappings(docs(BATCH_SIZE * 2 + 7));
+    const sizes = mockSync.mock.calls.map(([batch]) => batch.length);
+    expect(sizes).toEqual([BATCH_SIZE, BATCH_SIZE, 7]);
+    expect(mockSync.mock.calls[0][0][0]).toEqual({
+      key: "sdk-0",
+      organization: "org_0",
+    });
+  });
+
+  it("skips documents missing a key or organization", async () => {
+    mockSync.mockResolvedValue(undefined);
+    async function* mixed() {
+      yield { key: "sdk-a", organization: "org_1" };
+      yield { key: "", organization: "org_1" };
+      yield { organization: "org_1" };
+      yield { key: "sdk-b" };
+      yield { key: "sdk-c", organization: "org_2" };
+    }
+    await syncSdkKeyMappings(mixed());
+    expect(mockSync).toHaveBeenCalledTimes(1);
+    expect(mockSync.mock.calls[0][0]).toEqual([
+      { key: "sdk-a", organization: "org_1" },
+      { key: "sdk-c", organization: "org_2" },
+    ]);
+  });
+
+  it("keeps going when one batch fails", async () => {
+    mockSync
+      .mockRejectedValueOnce(new Error("license server down"))
+      .mockResolvedValue(undefined);
+    await syncSdkKeyMappings(docs(BATCH_SIZE + 1));
+    expect(mockSync).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
### Features and Changes

The only write to the license server's `sdk_key_mapping` table happens at SDK connection create, inside a try/catch that just logs, so a failed call leaves that connection's CDN traffic attributed to no org and never billed.

`syncSdkKeyMappings` runs every 24 hours on Cloud, streams `key` and `organization` from `sdkconnections`, and posts batches of 500 to `sdk-key-mapping`, which now takes `{mappings: [...]}`. A failed batch is logged and the sweep continues. The create-time call stays for freshness; running the job once is the backfill.

### Dependencies

central-license-server#183 (the batch body) has to be deployed first, or every batch 400s.

### Testing

- [x] connections without `key` or `organization` -> skipped
- [x] one batch rejected by the license server -> logged, remaining batches still sent
- [ ] Run the job once against a dev license server -> every `sdkconnections` key present in `usage.sdk_key_mapping`
