### PR TITLE
Add Slack channel management UI

### DIFF
--- a/packages/back-end/src/routers/slack-integration/slack-integration.controller.ts
+++ b/packages/back-end/src/routers/slack-integration/slack-integration.controller.ts
@@ -128,7 +128,7 @@ type PutSlackOAuthConnectionRequest = AuthRequest<
 
 export const putSlackOAuthConnection = async (
   req: PutSlackOAuthConnectionRequest,
-  res: Response<PostSlackOAuthCallbackResponse | ApiErrorResponse>,
+  res: Response<GetSlackOAuthConnectionResponse | ApiErrorResponse>,
 ) => {
   const context = getContextFromReq(req);
 

--- a/packages/back-end/src/routers/slack-integration/slack-integration.controller.ts
+++ b/packages/back-end/src/routers/slack-integration/slack-integration.controller.ts
@@ -21,6 +21,7 @@ import {
   listSlackOAuthConnections,
   listSlackWorkspaceChannels,
   type SlackChannelOption,
+  updateSlackOAuthIntegration,
 } from "back-end/src/services/slackIntegration";
 
 // region GET /integrations/slack
@@ -106,6 +107,39 @@ export const getSlackOAuthConnection = async (
   const slackIntegration = await getSlackOAuthIntegrationById({
     context,
     id: req.params.id,
+  });
+  if (!slackIntegration) {
+    return res.status(404).json({ message: "Not found" });
+  }
+
+  return res.json({ slackIntegration });
+};
+
+type PutSlackOAuthConnectionRequest = AuthRequest<
+  {
+    enabled: boolean;
+    events: string[];
+    projects: string[];
+    environments: string[];
+    tags: string[];
+  },
+  { id: string }
+>;
+
+export const putSlackOAuthConnection = async (
+  req: PutSlackOAuthConnectionRequest,
+  res: Response<PostSlackOAuthCallbackResponse | ApiErrorResponse>,
+) => {
+  const context = getContextFromReq(req);
+
+  if (!context.permissions.canManageIntegrations()) {
+    context.permissions.throwPermissionError();
+  }
+
+  const slackIntegration = await updateSlackOAuthIntegration({
+    context,
+    id: req.params.id,
+    updates: req.body,
   });
   if (!slackIntegration) {
     return res.status(404).json({ message: "Not found" });

--- a/packages/back-end/src/routers/slack-integration/slack-integration.controller.ts
+++ b/packages/back-end/src/routers/slack-integration/slack-integration.controller.ts
@@ -151,7 +151,7 @@ export const putSlackOAuthConnection = async (
 // region POST /integrations/slack/connect
 
 type PostSlackOAuthConnectRequest = AuthRequest<
-  Record<string, never>,
+  { teamId?: string },
   Record<string, never>,
   Record<string, never>
 >;
@@ -171,7 +171,7 @@ export const postSlackOAuthConnect = async (
   }
 
   return res.json({
-    url: getSlackOAuthAuthorizeUrl(context),
+    url: getSlackOAuthAuthorizeUrl(context, req.body.teamId),
   });
 };
 

--- a/packages/back-end/src/routers/slack-integration/slack-integration.router.ts
+++ b/packages/back-end/src/routers/slack-integration/slack-integration.router.ts
@@ -1,6 +1,9 @@
 import express from "express";
 import { z } from "zod";
-import { zodNotificationEventNamesEnum } from "shared/validators";
+import {
+  isEventWebhookWildcard,
+  zodNotificationEventNamesEnum,
+} from "shared/validators";
 import { wrapController } from "back-end/src/routers/wrapController";
 import { validateRequestMiddleware } from "back-end/src/routers/utils/validateRequestMiddleware";
 import * as rawSlackIntegrationController from "./slack-integration.controller";
@@ -10,6 +13,15 @@ const router = express.Router();
 const slackIntegrationController = wrapController(
   rawSlackIntegrationController,
 );
+
+const eventNameOrWildcard = z
+  .string()
+  .refine(
+    (value) =>
+      zodNotificationEventNamesEnum.includes(value as never) ||
+      isEventWebhookWildcard(value),
+    { message: "Must be a valid event name or wildcard pattern" },
+  );
 
 router.get("/", slackIntegrationController.getSlackIntegrations);
 
@@ -21,6 +33,23 @@ router.get(
     params: z.object({ id: z.string() }).strict(),
   }),
   slackIntegrationController.getSlackOAuthConnection,
+);
+
+router.put(
+  "/oauth/:id",
+  validateRequestMiddleware({
+    params: z.object({ id: z.string() }).strict(),
+    body: z
+      .object({
+        enabled: z.boolean(),
+        events: z.array(eventNameOrWildcard).min(1),
+        projects: z.array(z.string()),
+        environments: z.array(z.string()),
+        tags: z.array(z.string()),
+      })
+      .strict(),
+  }),
+  slackIntegrationController.putSlackOAuthConnection,
 );
 
 router.post(

--- a/packages/back-end/src/routers/slack-integration/slack-integration.router.ts
+++ b/packages/back-end/src/routers/slack-integration/slack-integration.router.ts
@@ -54,7 +54,9 @@ router.put(
 
 router.post(
   "/connect",
-  validateRequestMiddleware({}),
+  validateRequestMiddleware({
+    body: z.object({ teamId: z.string().optional() }).strict(),
+  }),
   slackIntegrationController.postSlackOAuthConnect,
 );
 

--- a/packages/back-end/src/services/slackIntegration.ts
+++ b/packages/back-end/src/services/slackIntegration.ts
@@ -25,6 +25,7 @@ import {
   getAllEventWebHooks,
   getEventWebHookById,
   reconnectSlackEventWebhook,
+  updateEventWebHook,
   updateSlackChannelName,
 } from "back-end/src/models/EventWebhookModel";
 import {
@@ -400,7 +401,8 @@ export const listSlackOAuthConnections = async (
     .filter(
       (eventWebHook) =>
         eventWebHook.payloadType === "slack" &&
-        (eventWebHook.slack?.channelId || !eventWebHook.slack?.teamId),
+        !!eventWebHook.slack?.teamId &&
+        !!eventWebHook.slack.channelId,
     )
     .map(slackEventWebhookToIntegration);
   const connectionsByTeamId = new Map(
@@ -460,9 +462,35 @@ export const getSlackOAuthIntegrationById = async ({
   id: string;
 }): Promise<SlackOAuthIntegrationInterface | null> => {
   const eventWebHook = await getEventWebHookById(id, context.org.id);
-  return eventWebHook?.payloadType === "slack"
+  return eventWebHook?.payloadType === "slack" && eventWebHook.slack?.teamId
     ? slackEventWebhookToIntegration(eventWebHook)
     : null;
+};
+
+export const updateSlackOAuthIntegration = async ({
+  context,
+  id,
+  updates,
+}: {
+  context: ReqContext;
+  id: string;
+  updates: Pick<
+    EventWebHookInterface,
+    "enabled" | "events" | "projects" | "environments" | "tags"
+  >;
+}): Promise<SlackOAuthIntegrationInterface | null> => {
+  const eventWebHook = await getEventWebHookById(id, context.org.id);
+  if (eventWebHook?.payloadType !== "slack" || !eventWebHook.slack?.teamId) {
+    return null;
+  }
+
+  await updateEventWebHook(
+    { eventWebHookId: id, organizationId: context.org.id },
+    updates,
+  );
+
+  const updated = await getEventWebHookById(id, context.org.id);
+  return updated ? slackEventWebhookToIntegration(updated) : null;
 };
 
 /**

--- a/packages/back-end/src/services/slackIntegration.ts
+++ b/packages/back-end/src/services/slackIntegration.ts
@@ -52,6 +52,7 @@ const slackOAuthStateSchema = z
   .object({
     orgId: z.string(),
     userId: z.string(),
+    teamId: z.string().optional(),
     nonce: z.string(),
     createdAt: z.number(),
   })
@@ -127,14 +128,17 @@ const signSlackOAuthState = (payload: string) =>
 const encodeSlackOAuthState = ({
   orgId,
   userId,
+  teamId,
 }: {
   orgId: string;
   userId: string;
+  teamId?: string;
 }) => {
   const payload = Buffer.from(
     JSON.stringify({
       orgId,
       userId,
+      teamId,
       nonce: randomBytes(16).toString("base64url"),
       createdAt: Date.now(),
     }),
@@ -190,9 +194,14 @@ const assertSlackOAuthState = ({
   ) {
     throw new Error("Slack OAuth state does not match the current user");
   }
+
+  return parsed.data;
 };
 
-export const getSlackOAuthAuthorizeUrl = (context: ReqContext) => {
+export const getSlackOAuthAuthorizeUrl = (
+  context: ReqContext,
+  teamId?: string,
+) => {
   if (!isSlackOAuthConfigured()) {
     throw new Error("Slack OAuth is not configured");
   }
@@ -201,11 +210,13 @@ export const getSlackOAuthAuthorizeUrl = (context: ReqContext) => {
   url.searchParams.set("client_id", SLACK_CLIENT_ID);
   url.searchParams.set("scope", SLACK_OAUTH_SCOPE);
   url.searchParams.set("redirect_uri", getSlackOAuthRedirectUri());
+  if (teamId) url.searchParams.set("team", teamId);
   url.searchParams.set(
     "state",
     encodeSlackOAuthState({
       orgId: context.org.id,
       userId: context.userId,
+      teamId,
     }),
   );
 
@@ -480,7 +491,11 @@ export const updateSlackOAuthIntegration = async ({
   >;
 }): Promise<SlackOAuthIntegrationInterface | null> => {
   const eventWebHook = await getEventWebHookById(id, context.org.id);
-  if (eventWebHook?.payloadType !== "slack" || !eventWebHook.slack?.teamId) {
+  if (
+    eventWebHook?.payloadType !== "slack" ||
+    !eventWebHook.slack?.teamId ||
+    !eventWebHook.slack.channelId
+  ) {
     return null;
   }
 
@@ -507,9 +522,11 @@ export type SlackOAuthConnectionResult = {
 const attachSlackOAuthCode = async ({
   context,
   code,
+  expectedTeamId,
 }: {
   context: ReqContext;
   code: string;
+  expectedTeamId?: string;
 }): Promise<SlackOAuthConnectionResult> => {
   const slackOAuthResponse = await exchangeSlackOAuthCode(code);
   const teamId = slackOAuthResponse.team?.id;
@@ -517,6 +534,9 @@ const attachSlackOAuthCode = async ({
     throw new Error(
       "Slack did not return a workspace id. Install the GrowthBook app into a specific workspace (org-wide enterprise installs are not supported).",
     );
+  }
+  if (expectedTeamId && teamId !== expectedTeamId) {
+    throw new Error("Slack connected a different workspace than expected");
   }
   const connection = await upsertSlackWorkspaceConnection({
     context,
@@ -614,8 +634,12 @@ export const connectSlackOAuthIntegration = async ({
   code: string;
   state: string;
 }) => {
-  assertSlackOAuthState({ state, context });
-  return attachSlackOAuthCode({ context, code });
+  const oauthState = assertSlackOAuthState({ state, context });
+  return attachSlackOAuthCode({
+    context,
+    code,
+    expectedTeamId: oauthState.teamId,
+  });
 };
 
 /**

--- a/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
@@ -22,6 +22,7 @@ import { useDefinitions } from "@/services/DefinitionsContext";
 import Button from "@/ui/Button";
 import Callout from "@/ui/Callout";
 import Badge from "@/ui/Badge";
+import LinkButton from "@/ui/LinkButton";
 import {
   DropdownMenu,
   DropdownMenuGroup,
@@ -143,6 +144,12 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
   if (!payloadType) return null;
 
   const loading = state?.type === "loading";
+  const slackSettingsUrl =
+    payloadType === "slack" && eventWebHook.slack?.teamId
+      ? eventWebHook.slack.channelId
+        ? `/integrations/slack?channel=${encodeURIComponent(eventWebHook.id)}`
+        : "/integrations/slack"
+      : null;
 
   return (
     <Box>
@@ -167,9 +174,15 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
         </Flex>
 
         <Flex align="center" gap="4">
-          <Button icon={<PiPencilSimpleFill />} onClick={onEditModalOpen}>
-            Edit
-          </Button>
+          {slackSettingsUrl ? (
+            <LinkButton href={slackSettingsUrl} icon={<PiPencilSimpleFill />}>
+              Edit Slack settings
+            </LinkButton>
+          ) : (
+            <Button icon={<PiPencilSimpleFill />} onClick={onEditModalOpen}>
+              Edit
+            </Button>
+          )}
 
           <DropdownMenu
             trigger={
@@ -349,7 +362,7 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
         </div>
       </Box>
 
-      {isModalOpen ? (
+      {isModalOpen && !slackSettingsUrl ? (
         <EventWebHookAddEditModal
           isOpen={isModalOpen}
           onClose={onModalClose}

--- a/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
@@ -11,6 +11,7 @@ import Text from "@/ui/Text";
 import { useAuth } from "@/services/auth";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { useEventWebhookLogs } from "@/hooks/useEventWebhookLogs";
+import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import {
   EventWebHookEditParams,
   useIconForState,
@@ -58,6 +59,7 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
   editError,
 }) => {
   const { getProjectById } = useDefinitions();
+  const permissionsUtils = usePermissionsUtil();
   const [dropdownOpen, setDropdownOpen] = useState(false);
 
   const {
@@ -145,10 +147,14 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
 
   const loading = state?.type === "loading";
   const slackSettingsUrl =
-    payloadType === "slack" && eventWebHook.slack?.teamId
+    payloadType === "slack" &&
+    eventWebHook.slack?.teamId &&
+    permissionsUtils.canManageIntegrations()
       ? eventWebHook.slack.channelId
         ? `/integrations/slack?channel=${encodeURIComponent(eventWebHook.id)}`
-        : "/integrations/slack"
+        : `/integrations/slack?workspace=${encodeURIComponent(
+            eventWebHook.slack.teamId,
+          )}`
       : null;
 
   return (

--- a/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookList.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookList.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "@/services/auth";
 import { EventWebHookEditParams } from "@/components/EventWebHooks/utils";
 import { EventWebHookAddEditModal } from "@/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal";
 import { docUrl, DocLink } from "@/components/DocLink";
+import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import Button from "@/ui/Button";
 import Callout from "@/ui/Callout";
 import { EventWebHookListItem } from "./EventWebHookListItem/EventWebHookListItem";
@@ -28,6 +29,9 @@ export const EventWebHookList: FC<EventWebHookListProps> = ({
   errorMessage,
   createError,
 }) => {
+  const permissionsUtils = usePermissionsUtil();
+  const canManageSlack = permissionsUtils.canManageIntegrations();
+
   return (
     <div>
       {isModalOpen ? (
@@ -96,13 +100,16 @@ export const EventWebHookList: FC<EventWebHookListProps> = ({
           {eventWebHooks.map((eventWebHook) => {
             const managedInSlack =
               eventWebHook.payloadType === "slack" &&
-              !!eventWebHook.slack?.teamId;
+              !!eventWebHook.slack?.teamId &&
+              canManageSlack;
             const href = managedInSlack
               ? eventWebHook.slack?.channelId
                 ? `/integrations/slack?channel=${encodeURIComponent(
                     eventWebHook.id,
                   )}`
-                : "/integrations/slack"
+                : `/integrations/slack?workspace=${encodeURIComponent(
+                    eventWebHook.slack?.teamId || "",
+                  )}`
               : `/settings/webhooks/event/${eventWebHook.id}`;
 
             return (

--- a/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookList.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookList.tsx
@@ -93,14 +93,24 @@ export const EventWebHookList: FC<EventWebHookListProps> = ({
       {eventWebHooks.length > 0 && (
         <div>
           {/* List view */}
-          {eventWebHooks.map((eventWebHook) => (
-            <div key={eventWebHook.id} className="mb-3">
-              <EventWebHookListItem
-                href={`/settings/webhooks/event/${eventWebHook.id}`}
-                eventWebHook={eventWebHook}
-              />
-            </div>
-          ))}
+          {eventWebHooks.map((eventWebHook) => {
+            const managedInSlack =
+              eventWebHook.payloadType === "slack" &&
+              !!eventWebHook.slack?.teamId;
+            const href = managedInSlack
+              ? eventWebHook.slack?.channelId
+                ? `/integrations/slack?channel=${encodeURIComponent(
+                    eventWebHook.id,
+                  )}`
+                : "/integrations/slack"
+              : `/settings/webhooks/event/${eventWebHook.id}`;
+
+            return (
+              <div key={eventWebHook.id} className="mb-3">
+                <EventWebHookListItem href={href} eventWebHook={eventWebHook} />
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookListItem/EventWebHookListItem.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookListItem/EventWebHookListItem.tsx
@@ -46,11 +46,7 @@ export const EventWebHookListItem: FC<EventWebHookListItemProps> = ({
           <div className="d-flex">
             <h3 className="link-purple text-truncate">{name}</h3>
             {enabled && (
-              <div>
-                <span className="badge badge-gray text-uppercase ml-2">
-                  Enabled
-                </span>
-              </div>
+              <Badge label="Enabled" color="gray" variant="soft" ml="2" />
             )}
             {managedInSlack && (
               <Badge

--- a/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookListItem/EventWebHookListItem.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookListItem/EventWebHookListItem.tsx
@@ -7,6 +7,7 @@ import {
   useIconForState,
   displayedEvents,
 } from "@/components/EventWebHooks/utils";
+import Badge from "@/ui/Badge";
 
 type EventWebHookListItemProps = {
   href: string;
@@ -27,6 +28,8 @@ export const EventWebHookListItem: FC<EventWebHookListItemProps> = ({
   if (!payloadType) return null;
 
   const detailedWebhook = ["raw", "json"].includes(payloadType);
+  const managedInSlack =
+    payloadType === "slack" && !!eventWebHook.slack?.teamId;
 
   return (
     <Link href={href} style={{ textDecoration: "none" }} className="card p-3">
@@ -48,6 +51,14 @@ export const EventWebHookListItem: FC<EventWebHookListItemProps> = ({
                   Enabled
                 </span>
               </div>
+            )}
+            {managedInSlack && (
+              <Badge
+                label="Managed in Slack settings"
+                color="purple"
+                variant="soft"
+                ml="2"
+              />
             )}
           </div>
           <div className="d-flex">

--- a/packages/front-end/components/SlackIntegrations/SlackChannelSettings.tsx
+++ b/packages/front-end/components/SlackIntegrations/SlackChannelSettings.tsx
@@ -1,0 +1,284 @@
+import { useMemo, useState } from "react";
+import { SlackOAuthIntegrationInterface } from "shared/types/slack-integration";
+import { Box, Flex, Grid } from "@radix-ui/themes";
+import { PiTrash } from "react-icons/pi";
+import {
+  eventWebHookEventOptions,
+  formatWebhookEventOptionLabel,
+} from "@/components/EventWebHooks/utils";
+import TagsInput from "@/components/Tags/TagsInput";
+import { useDefinitions } from "@/services/DefinitionsContext";
+import { useAuth } from "@/services/auth";
+import { useEnvironments } from "@/services/features";
+import Button from "@/ui/Button";
+import Callout from "@/ui/Callout";
+import Checkbox from "@/ui/Checkbox";
+import ConfirmDialog from "@/ui/ConfirmDialog";
+import Heading from "@/ui/Heading";
+import MultiSelectField from "@/ui/MultiSelectField";
+import Text from "@/ui/Text";
+
+const REQUIRED_SCOPES = [
+  "chat:write",
+  "channels:read",
+  "groups:read",
+  "channels:join",
+];
+
+export const getSlackChannelLabel = (
+  integration: SlackOAuthIntegrationInterface,
+) => {
+  const channelName = integration.slack?.channelName;
+  if (channelName) {
+    return channelName.startsWith("#") ? channelName : `#${channelName}`;
+  }
+  return integration.slack?.channelId || integration.name;
+};
+
+export const getSlackWorkspaceLabel = (
+  integration: SlackOAuthIntegrationInterface,
+) =>
+  integration.slack?.teamName ||
+  integration.slack?.teamId ||
+  integration.slack?.enterpriseName ||
+  integration.slack?.enterpriseId ||
+  "Unknown workspace";
+
+export default function SlackChannelSettings({
+  integration,
+  onSaved,
+  onDeleted,
+}: {
+  integration: SlackOAuthIntegrationInterface;
+  onSaved: () => Promise<void>;
+  onDeleted: () => Promise<void>;
+}) {
+  const { apiCall } = useAuth();
+  const { projects, tags } = useDefinitions();
+  const environments = useEnvironments();
+  const [enabled, setEnabled] = useState(integration.enabled);
+  const [events, setEvents] = useState(integration.events);
+  const [filterProjects, setFilterProjects] = useState(
+    integration.projects || [],
+  );
+  const [filterEnvironments, setFilterEnvironments] = useState(
+    integration.environments || [],
+  );
+  const [filterTags, setFilterTags] = useState(integration.tags || []);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+  const [reconnecting, setReconnecting] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  const grantedScopes = useMemo(
+    () =>
+      new Set(
+        (integration.slack?.scope || "")
+          .split(",")
+          .map((scope) => scope.trim())
+          .filter(Boolean),
+      ),
+    [integration.slack?.scope],
+  );
+  const needsReconnect = REQUIRED_SCOPES.some(
+    (scope) => !grantedScopes.has(scope),
+  );
+
+  const save = async () => {
+    setSaving(true);
+    setSaveError(null);
+    setSaved(false);
+    try {
+      await apiCall(`/integrations/slack/oauth/${integration.id}`, {
+        method: "PUT",
+        body: JSON.stringify({
+          enabled,
+          events,
+          projects: filterProjects,
+          environments: filterEnvironments,
+          tags: filterTags,
+        }),
+      });
+      await onSaved();
+      setSaved(true);
+    } catch (error) {
+      setSaveError(
+        error instanceof Error ? error.message : "Failed to save settings.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const reconnect = async () => {
+    setReconnecting(true);
+    setSaveError(null);
+    try {
+      const response = await apiCall<{ url: string }>(
+        "/integrations/slack/connect",
+        { method: "POST" },
+      );
+      window.location.assign(response.url);
+    } catch (error) {
+      setSaveError(
+        error instanceof Error ? error.message : "Failed to start reconnect.",
+      );
+      setReconnecting(false);
+    }
+  };
+
+  const deleteChannel = async () => {
+    await apiCall(`/integrations/slack/${integration.id}`, {
+      method: "DELETE",
+    });
+    await onDeleted();
+  };
+
+  return (
+    <>
+      {confirmingDelete && (
+        <ConfirmDialog
+          title="Delete Slack channel connection?"
+          content={`${getSlackChannelLabel(
+            integration,
+          )} will stop receiving GrowthBook notifications.`}
+          yesText="Delete"
+          onConfirm={deleteChannel}
+          onCancel={() => setConfirmingDelete(false)}
+        />
+      )}
+
+      <Flex direction="column" gap="5">
+        <Flex justify="between" align="start" gap="4" wrap="wrap">
+          <Box>
+            <Heading as="h2" size="md" mb="1">
+              {getSlackChannelLabel(integration)}
+            </Heading>
+            <Text color="text-mid">{getSlackWorkspaceLabel(integration)}</Text>
+          </Box>
+          <Flex align="center" gap="4">
+            <Checkbox
+              label="Enabled"
+              value={enabled}
+              setValue={(value) => {
+                setEnabled(value);
+                setSaved(false);
+              }}
+              weight="medium"
+            />
+            <Button
+              variant="outline"
+              color="red"
+              icon={<PiTrash />}
+              onClick={() => setConfirmingDelete(true)}
+            >
+              Delete
+            </Button>
+          </Flex>
+        </Flex>
+
+        {needsReconnect && (
+          <Callout status="warning">
+            <Flex justify="between" align="center" gap="3" wrap="wrap">
+              <Text>
+                Reconnect this workspace to grant the Slack permissions needed
+                for channel management and notifications.
+              </Text>
+              <Button onClick={reconnect} loading={reconnecting}>
+                Reconnect
+              </Button>
+            </Flex>
+          </Callout>
+        )}
+
+        <Box>
+          <Heading as="h3" size="sm" mb="1">
+            Events
+          </Heading>
+          <Text as="p" color="text-mid" mb="3">
+            Choose the existing GrowthBook events sent to this channel.
+          </Text>
+          <MultiSelectField
+            label="Events"
+            value={events}
+            placeholder="Choose events"
+            sort={false}
+            size="lg"
+            options={eventWebHookEventOptions}
+            formatOptionLabel={(option, meta) =>
+              formatWebhookEventOptionLabel(option, meta)
+            }
+            onChange={(value) => {
+              setEvents(value);
+              setSaved(false);
+            }}
+          />
+        </Box>
+
+        <Box pt="5" style={{ borderTop: "1px solid var(--gray-a4)" }}>
+          <Heading as="h3" size="sm" mb="1">
+            Filters
+          </Heading>
+          <Text as="p" color="text-mid" mb="3">
+            Leave a filter empty to include everything.
+          </Text>
+          <Grid columns={{ initial: "1", sm: "2" }} gap="4">
+            <MultiSelectField
+              label="Projects"
+              placeholder="All Projects"
+              value={filterProjects}
+              size="lg"
+              options={projects.map(({ id, name }) => ({
+                label: name,
+                value: id,
+              }))}
+              onChange={(value) => {
+                setFilterProjects(value);
+                setSaved(false);
+              }}
+            />
+            <MultiSelectField
+              label="Environments"
+              placeholder="All Environments"
+              value={filterEnvironments}
+              size="lg"
+              options={environments.map(({ id }) => ({
+                label: id,
+                value: id,
+              }))}
+              onChange={(value) => {
+                setFilterEnvironments(value);
+                setSaved(false);
+              }}
+            />
+            <Box>
+              <Text as="label" size="md" weight="semibold">
+                Tags
+              </Text>
+              <TagsInput
+                tagOptions={tags}
+                value={filterTags}
+                onChange={(value) => {
+                  setFilterTags(value);
+                  setSaved(false);
+                }}
+                autoFocus={false}
+                prompt="All tags"
+                creatable={false}
+              />
+            </Box>
+          </Grid>
+        </Box>
+
+        <Flex align="center" gap="3">
+          <Button onClick={save} loading={saving}>
+            Save settings
+          </Button>
+          {saved && <Text color="text-mid">Saved.</Text>}
+          {saveError && <Text color="text-mid">{saveError}</Text>}
+        </Flex>
+      </Flex>
+    </>
+  );
+}

--- a/packages/front-end/components/SlackIntegrations/SlackChannelSettings.tsx
+++ b/packages/front-end/components/SlackIntegrations/SlackChannelSettings.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { SlackOAuthIntegrationInterface } from "shared/types/slack-integration";
+import { SlackWorkspaceConnectionFrontEndInterface } from "shared/validators";
 import { Box, Flex, Grid } from "@radix-ui/themes";
 import { PiTrash } from "react-icons/pi";
 import {
@@ -36,21 +37,23 @@ export const getSlackChannelLabel = (
   return integration.slack?.channelId || integration.name;
 };
 
-export const getSlackWorkspaceLabel = (
-  integration: SlackOAuthIntegrationInterface,
+const getSlackWorkspaceLabel = (
+  workspace: SlackWorkspaceConnectionFrontEndInterface,
 ) =>
-  integration.slack?.teamName ||
-  integration.slack?.teamId ||
-  integration.slack?.enterpriseName ||
-  integration.slack?.enterpriseId ||
+  workspace.teamName ||
+  workspace.teamId ||
+  workspace.enterpriseName ||
+  workspace.enterpriseId ||
   "Unknown workspace";
 
 export default function SlackChannelSettings({
   integration,
+  workspace,
   onSaved,
   onDeleted,
 }: {
   integration: SlackOAuthIntegrationInterface;
+  workspace: SlackWorkspaceConnectionFrontEndInterface;
   onSaved: () => Promise<void>;
   onDeleted: () => Promise<void>;
 }) {
@@ -76,12 +79,12 @@ export default function SlackChannelSettings({
   const grantedScopes = useMemo(
     () =>
       new Set(
-        (integration.slack?.scope || "")
+        (workspace.scope || "")
           .split(",")
           .map((scope) => scope.trim())
           .filter(Boolean),
       ),
-    [integration.slack?.scope],
+    [workspace.scope],
   );
   const needsReconnect = REQUIRED_SCOPES.some(
     (scope) => !grantedScopes.has(scope),
@@ -123,7 +126,10 @@ export default function SlackChannelSettings({
     try {
       const response = await apiCall<{ url: string }>(
         "/integrations/slack/connect",
-        { method: "POST" },
+        {
+          method: "POST",
+          body: JSON.stringify({ teamId: workspace.teamId }),
+        },
       );
       window.location.assign(response.url);
     } catch (error) {
@@ -161,7 +167,7 @@ export default function SlackChannelSettings({
             <Heading as="h2" size="md" mb="1">
               {getSlackChannelLabel(integration)}
             </Heading>
-            <Text color="text-mid">{getSlackWorkspaceLabel(integration)}</Text>
+            <Text color="text-mid">{getSlackWorkspaceLabel(workspace)}</Text>
           </Box>
           <Flex align="center" gap="4">
             <Checkbox

--- a/packages/front-end/components/SlackIntegrations/SlackChannelSettings.tsx
+++ b/packages/front-end/components/SlackIntegrations/SlackChannelSettings.tsx
@@ -15,6 +15,7 @@ import Callout from "@/ui/Callout";
 import Checkbox from "@/ui/Checkbox";
 import ConfirmDialog from "@/ui/ConfirmDialog";
 import Heading from "@/ui/Heading";
+import HelperText from "@/ui/HelperText";
 import MultiSelectField from "@/ui/MultiSelectField";
 import Text from "@/ui/Text";
 
@@ -69,6 +70,7 @@ export default function SlackChannelSettings({
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
   const [reconnecting, setReconnecting] = useState(false);
+  const [reconnectError, setReconnectError] = useState<string | null>(null);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
 
   const grantedScopes = useMemo(
@@ -117,7 +119,7 @@ export default function SlackChannelSettings({
 
   const reconnect = async () => {
     setReconnecting(true);
-    setSaveError(null);
+    setReconnectError(null);
     try {
       const response = await apiCall<{ url: string }>(
         "/integrations/slack/connect",
@@ -125,7 +127,7 @@ export default function SlackChannelSettings({
       );
       window.location.assign(response.url);
     } catch (error) {
-      setSaveError(
+      setReconnectError(
         error instanceof Error ? error.message : "Failed to start reconnect.",
       );
       setReconnecting(false);
@@ -143,7 +145,7 @@ export default function SlackChannelSettings({
     <>
       {confirmingDelete && (
         <ConfirmDialog
-          title="Delete Slack channel connection?"
+          title="Delete Slack Channel Connection?"
           content={`${getSlackChannelLabel(
             integration,
           )} will stop receiving GrowthBook notifications.`}
@@ -183,17 +185,22 @@ export default function SlackChannelSettings({
         </Flex>
 
         {needsReconnect && (
-          <Callout status="warning">
-            <Flex justify="between" align="center" gap="3" wrap="wrap">
-              <Text>
-                Reconnect this workspace to grant the Slack permissions needed
-                for channel management and notifications.
-              </Text>
-              <Button onClick={reconnect} loading={reconnecting}>
-                Reconnect
-              </Button>
-            </Flex>
-          </Callout>
+          <Flex direction="column" gap="2">
+            <Callout
+              status="warning"
+              action={
+                <Button onClick={reconnect} loading={reconnecting}>
+                  Reconnect
+                </Button>
+              }
+            >
+              Reconnect this workspace to grant the Slack permissions needed for
+              channel management and notifications.
+            </Callout>
+            {reconnectError && (
+              <HelperText status="error">{reconnectError}</HelperText>
+            )}
+          </Flex>
         )}
 
         <Box>
@@ -204,7 +211,6 @@ export default function SlackChannelSettings({
             Choose the existing GrowthBook events sent to this channel.
           </Text>
           <MultiSelectField
-            label="Events"
             value={events}
             placeholder="Choose events"
             sort={false}
@@ -288,8 +294,8 @@ export default function SlackChannelSettings({
           >
             Save settings
           </Button>
-          {saved && <Text color="text-mid">Saved.</Text>}
-          {saveError && <Text color="text-mid">{saveError}</Text>}
+          {saved && <HelperText status="success">Saved.</HelperText>}
+          {saveError && <HelperText status="error">{saveError}</HelperText>}
         </Flex>
       </Flex>
     </>

--- a/packages/front-end/components/SlackIntegrations/SlackChannelSettings.tsx
+++ b/packages/front-end/components/SlackIntegrations/SlackChannelSettings.tsx
@@ -86,6 +86,10 @@ export default function SlackChannelSettings({
   );
 
   const save = async () => {
+    if (events.length === 0) {
+      setSaveError("Select at least one event.");
+      return;
+    }
     setSaving(true);
     setSaveError(null);
     setSaved(false);
@@ -214,6 +218,11 @@ export default function SlackChannelSettings({
               setSaved(false);
             }}
           />
+          {events.length === 0 && (
+            <Callout status="warning" mt="3">
+              Select at least one event before saving.
+            </Callout>
+          )}
         </Box>
 
         <Box pt="5" style={{ borderTop: "1px solid var(--gray-a4)" }}>
@@ -272,7 +281,11 @@ export default function SlackChannelSettings({
         </Box>
 
         <Flex align="center" gap="3">
-          <Button onClick={save} loading={saving}>
+          <Button
+            onClick={save}
+            loading={saving}
+            disabled={events.length === 0}
+          >
             Save settings
           </Button>
           {saved && <Text color="text-mid">Saved.</Text>}

--- a/packages/front-end/components/SlackIntegrations/SlackIntegrationsListView/SlackIntegrationsListView.tsx
+++ b/packages/front-end/components/SlackIntegrations/SlackIntegrationsListView/SlackIntegrationsListView.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from "react";
 import pick from "lodash/pick";
+import { Box } from "@radix-ui/themes";
 import { SlackIntegrationInterface } from "shared/types/slack-integration";
 import { TagInterface } from "shared/types/tag";
 import {
@@ -20,8 +21,11 @@ import { useEnvironments } from "@/services/features";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import Button from "@/ui/Button";
 import Callout from "@/ui/Callout";
+import Heading from "@/ui/Heading";
+import Text from "@/ui/Text";
 
 type SlackIntegrationsListViewProps = {
+  legacyOnly?: boolean;
   onEditModalOpen: (id: string, data: SlackIntegrationEditParams) => void;
   onCreateModalOpen: () => void;
   onModalClose: () => void;
@@ -41,6 +45,7 @@ type SlackIntegrationsListViewProps = {
 };
 
 export const SlackIntegrationsListView: FC<SlackIntegrationsListViewProps> = ({
+  legacyOnly = false,
   onCreate,
   onUpdate,
   onDelete,
@@ -79,21 +84,34 @@ export const SlackIntegrationsListView: FC<SlackIntegrationsListViewProps> = ({
         />
       ) : null}
 
-      {/* Heading w/ beta messaging */}
-      <div className="mb-4">
-        <div className="d-flex justify-space-between align-items-center">
-          <span className="badge badge-purple text-uppercase mr-2">Beta</span>
-          <h1>Slack Integrations</h1>
+      {legacyOnly ? (
+        <Box mb="4">
+          <Heading as="h2" size="md" mb="2">
+            Legacy Slack Integrations
+          </Heading>
+          <Text as="p" color="text-mid">
+            These connections continue to send notifications. You can edit or
+            delete them here while you move to workspace connections. After
+            verifying a new connection, delete the old connection to avoid
+            duplicate notifications.
+          </Text>
+        </Box>
+      ) : (
+        <div className="mb-4">
+          <div className="d-flex justify-space-between align-items-center">
+            <span className="badge badge-purple text-uppercase mr-2">Beta</span>
+            <h1>Slack Integrations</h1>
+          </div>
+          <p>Get alerts in Slack when your GrowthBook data is updated.</p>
+          <div className="alert alert-premium">
+            <h4>Free while in Beta</h4>
+            <p className="mb-0">
+              This feature will be free while we build it out and work out the
+              bugs.
+            </p>
+          </div>
         </div>
-        <p>Get alerts in Slack when your GrowthBook data is updated.</p>
-        <div className="alert alert-premium">
-          <h4>Free while in Beta</h4>
-          <p className="mb-0">
-            This feature will be free while we build it out and work out the
-            bugs.
-          </p>
-        </div>
-      </div>
+      )}
 
       {/* Feedback messages */}
       {errorMessage && (
@@ -104,9 +122,11 @@ export const SlackIntegrationsListView: FC<SlackIntegrationsListViewProps> = ({
 
       {/* Empty state */}
       {slackIntegrations.length === 0 ? (
-        <SlackIntegrationsEmptyState>
-          <Button onClick={onCreateModalOpen}>New Slack integration</Button>
-        </SlackIntegrationsEmptyState>
+        legacyOnly ? null : (
+          <SlackIntegrationsEmptyState>
+            <Button onClick={onCreateModalOpen}>New Slack integration</Button>
+          </SlackIntegrationsEmptyState>
+        )
       ) : (
         <div>
           {/* List View */}
@@ -123,9 +143,11 @@ export const SlackIntegrationsListView: FC<SlackIntegrationsListViewProps> = ({
             </div>
           ))}
 
-          <div className="mt-4 mb-5">
-            <Button onClick={onCreateModalOpen}>New Slack integration</Button>
-          </div>
+          {!legacyOnly && (
+            <Box mt="4" mb="5">
+              <Button onClick={onCreateModalOpen}>New Slack integration</Button>
+            </Box>
+          )}
         </div>
       )}
     </div>
@@ -143,11 +165,16 @@ const SlackIntegrationsEmptyState: FC<PropsWithChildren> = ({ children }) => (
   </div>
 );
 
-export const SlackIntegrationsListViewContainer = () => {
+export const SlackIntegrationsListViewContainer = ({
+  legacyOnly = false,
+}: {
+  legacyOnly?: boolean;
+}) => {
   const { apiCall } = useAuth();
 
-  const [modalMode, setModalMode] =
-    useState<SlackIntegrationModalMode | null>();
+  const [modalMode, setModalMode] = useState<SlackIntegrationModalMode | null>(
+    null,
+  );
 
   const handleOnEditModalOpen = useCallback(
     (id: string, data: SlackIntegrationEditParams) => {
@@ -273,10 +300,12 @@ export const SlackIntegrationsListViewContainer = () => {
 
   const { projects, tags } = useDefinitions();
 
+  if (legacyOnly && !loadError && slackIntegrations.length === 0) return null;
+
   return (
     <SlackIntegrationsListView
+      legacyOnly={legacyOnly}
       slackIntegrations={slackIntegrations}
-      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'SlackIntegrationModalMode | null | undefined... Remove this comment to see the full error message
       modalMode={modalMode}
       onDelete={handleDelete}
       modalError={addEditError}

--- a/packages/front-end/pages/integrations/slack/index.tsx
+++ b/packages/front-end/pages/integrations/slack/index.tsx
@@ -8,12 +8,12 @@ import React, {
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import { SlackOAuthIntegrationInterface } from "shared/types/slack-integration";
+import { SlackWorkspaceConnectionFrontEndInterface } from "shared/validators";
 import { Box, Flex } from "@radix-ui/themes";
 import { FaSlack } from "react-icons/fa";
 import { PiPlus, PiPlugs } from "react-icons/pi";
 import SlackChannelSettings, {
   getSlackChannelLabel,
-  getSlackWorkspaceLabel,
 } from "@/components/SlackIntegrations/SlackChannelSettings";
 import SelectField from "@/components/Forms/SelectField";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
@@ -31,8 +31,14 @@ import { Select, SelectItem } from "@/ui/Select";
 import Text from "@/ui/Text";
 
 type SlackConnectionsResponse = {
+  slackConnections: SlackWorkspaceConnectionFrontEndInterface[];
   slackIntegrations: SlackOAuthIntegrationInterface[];
   oauthConfigured: boolean;
+};
+
+type SlackOAuthConnectionResponse = {
+  slackConnection: SlackWorkspaceConnectionFrontEndInterface;
+  slackIntegration: SlackOAuthIntegrationInterface | null;
 };
 
 type SlackChannelOption = {
@@ -45,7 +51,7 @@ type SlackChannelOption = {
 
 type WorkspaceGroup = {
   teamId: string;
-  workspace: SlackOAuthIntegrationInterface;
+  workspace: SlackWorkspaceConnectionFrontEndInterface;
   channels: SlackOAuthIntegrationInterface[];
 };
 
@@ -65,16 +71,25 @@ const getSlackAuthorizationError = (error: string) =>
     : "Slack authorization failed. Try again.";
 
 const workspaceNeedsReconnect = (
-  integration: SlackOAuthIntegrationInterface,
+  connection: SlackWorkspaceConnectionFrontEndInterface,
 ) => {
   const scopes = new Set(
-    (integration.slack?.scope || "")
+    (connection.scope || "")
       .split(",")
       .map((scope) => scope.trim())
       .filter(Boolean),
   );
   return REQUIRED_SCOPES.some((scope) => !scopes.has(scope));
 };
+
+const getSlackWorkspaceLabel = (
+  connection: SlackWorkspaceConnectionFrontEndInterface,
+) =>
+  connection.teamName ||
+  connection.teamId ||
+  connection.enterpriseName ||
+  connection.enterpriseId ||
+  "Unknown workspace";
 
 function AddChannelModal({
   teamId,
@@ -235,29 +250,26 @@ const SlackIntegrationsPage: NextPage = () => {
     () => data?.slackIntegrations || [],
     [data?.slackIntegrations],
   );
+  const connections = useMemo(
+    () => data?.slackConnections || [],
+    [data?.slackConnections],
+  );
 
-  const workspaceGroups = useMemo(() => {
-    const groups = new Map<string, WorkspaceGroup>();
-    integrations.forEach((integration) => {
-      const teamId = integration.slack?.teamId;
-      if (!teamId) return;
-      const existing = groups.get(teamId);
-      if (!existing) {
-        groups.set(teamId, {
-          teamId,
-          workspace: integration,
-          channels: integration.slack?.channelId ? [integration] : [],
-        });
-        return;
-      }
-      if (integration.slack?.channelId) {
-        existing.channels.push(integration);
-      } else {
-        existing.workspace = integration;
-      }
-    });
-    return [...groups.values()];
-  }, [integrations]);
+  const workspaceGroups = useMemo(
+    () =>
+      connections.map(
+        (workspace): WorkspaceGroup => ({
+          teamId: workspace.teamId,
+          workspace,
+          channels: integrations.filter(
+            (integration) =>
+              integration.slack?.teamId === workspace.teamId &&
+              !!integration.slack.channelId,
+          ),
+        }),
+      ),
+    [connections, integrations],
+  );
 
   const selectedChannelId = getQueryStringValue(router.query.channel);
   const selectedWorkspaceId = getQueryStringValue(router.query.workspace);
@@ -275,6 +287,13 @@ const SlackIntegrationsPage: NextPage = () => {
       workspaceChannels[0]
     );
   }, [selectedChannelId, selectedWorkspaceGroup, workspaceGroups]);
+  const selectedChannelWorkspace = useMemo(
+    () =>
+      workspaceGroups.find(
+        (group) => group.teamId === selectedChannel?.slack?.teamId,
+      )?.workspace || null,
+    [selectedChannel, workspaceGroups],
+  );
 
   const selectChannel = useCallback(
     async (channelId: string | null) => {
@@ -315,19 +334,18 @@ const SlackIntegrationsPage: NextPage = () => {
 
     setConnecting(true);
     setConnectError(null);
-    apiCall<{ slackIntegration: SlackOAuthIntegrationInterface }>(
+    apiCall<SlackOAuthConnectionResponse>(
       "/integrations/slack/oauth-callback",
       {
         method: "POST",
         body: JSON.stringify({ code, state }),
       },
     )
-      .then(async ({ slackIntegration }) => {
+      .then(async ({ slackConnection, slackIntegration }) => {
         await mutate();
         setConnectedMessage("Slack workspace connected successfully.");
-        const teamId = slackIntegration.slack?.teamId;
-        if (teamId && !slackIntegration.slack?.channelId) {
-          setAddChannelTeamId(teamId);
+        if (!slackIntegration) {
+          setAddChannelTeamId(slackConnection.teamId);
         }
       })
       .catch((error: unknown) => {
@@ -387,18 +405,19 @@ const SlackIntegrationsPage: NextPage = () => {
     setInstalling(true);
     setConnectError(null);
     try {
-      const { slackIntegration } = await apiCall<{
-        slackIntegration: SlackOAuthIntegrationInterface;
-      }>("/integrations/slack/oauth-install", {
-        method: "POST",
-        body: JSON.stringify({ code: installCode }),
-      });
+      const { slackConnection, slackIntegration } =
+        await apiCall<SlackOAuthConnectionResponse>(
+          "/integrations/slack/oauth-install",
+          {
+            method: "POST",
+            body: JSON.stringify({ code: installCode }),
+          },
+        );
       await mutate();
       setInstallCode(null);
       setConnectedMessage("Slack workspace connected successfully.");
-      const teamId = slackIntegration.slack?.teamId;
-      if (teamId && !slackIntegration.slack?.channelId) {
-        setAddChannelTeamId(teamId);
+      if (!slackIntegration) {
+        setAddChannelTeamId(slackConnection.teamId);
       }
     } catch (error) {
       setConnectError(
@@ -598,7 +617,11 @@ const SlackIntegrationsPage: NextPage = () => {
                 notify.
               </Text>
               {data?.oauthConfigured && (
-                <Button icon={<FaSlack />} onClick={() => connectToSlack()}>
+                <Button
+                  icon={<FaSlack />}
+                  onClick={() => connectToSlack()}
+                  loading={connecting}
+                >
                   Connect to Slack
                 </Button>
               )}
@@ -724,10 +747,11 @@ const SlackIntegrationsPage: NextPage = () => {
               </Flex>
 
               <Box p="5" style={{ flex: 1, minWidth: 0 }}>
-                {selectedChannel ? (
+                {selectedChannel && selectedChannelWorkspace ? (
                   <SlackChannelSettings
                     key={selectedChannel.id}
                     integration={selectedChannel}
+                    workspace={selectedChannelWorkspace}
                     onSaved={async () => {
                       await mutate();
                     }}

--- a/packages/front-end/pages/integrations/slack/index.tsx
+++ b/packages/front-end/pages/integrations/slack/index.tsx
@@ -10,7 +10,7 @@ import { useRouter } from "next/router";
 import { SlackOAuthIntegrationInterface } from "shared/types/slack-integration";
 import { Box, Flex } from "@radix-ui/themes";
 import { FaSlack } from "react-icons/fa";
-import { PiPlus, PiPlugsConnected } from "react-icons/pi";
+import { PiPlus, PiPlugs } from "react-icons/pi";
 import SlackChannelSettings, {
   getSlackChannelLabel,
   getSlackWorkspaceLabel,
@@ -25,7 +25,7 @@ import Callout from "@/ui/Callout";
 import ConfirmDialog from "@/ui/ConfirmDialog";
 import Frame from "@/ui/Frame";
 import Heading from "@/ui/Heading";
-import HelperText from "@/ui/HelperText";
+import Link from "@/ui/Link";
 import ModalStandard from "@/ui/Modal/Patterns/ModalStandard";
 import { Select, SelectItem } from "@/ui/Select";
 import Text from "@/ui/Text";
@@ -140,7 +140,7 @@ function AddChannelModal({
     <ModalStandard
       trackingEventModalType="slack-add-channel"
       open={true}
-      header="Add a Slack channel"
+      header="Add a Slack Channel"
       cta="Add channel"
       ctaEnabled={!!selected && !connectedIds.has(selected)}
       submit={async () => {
@@ -342,24 +342,30 @@ const SlackIntegrationsPage: NextPage = () => {
       });
   }, [apiCall, mutate, router]);
 
-  const connectToSlack = useCallback(async () => {
-    setConnecting(true);
-    setConnectError(null);
-    try {
-      const response = await apiCall<{ url: string }>(
-        "/integrations/slack/connect",
-        { method: "POST" },
-      );
-      window.location.assign(response.url);
-    } catch (error) {
-      setConnectError(
-        error instanceof Error
-          ? error.message
-          : "Failed to start the Slack connection.",
-      );
-      setConnecting(false);
-    }
-  }, [apiCall]);
+  const connectToSlack = useCallback(
+    async (teamId?: string) => {
+      setConnecting(true);
+      setConnectError(null);
+      try {
+        const response = await apiCall<{ url: string }>(
+          "/integrations/slack/connect",
+          {
+            method: "POST",
+            body: JSON.stringify(teamId ? { teamId } : {}),
+          },
+        );
+        window.location.assign(response.url);
+      } catch (error) {
+        setConnectError(
+          error instanceof Error
+            ? error.message
+            : "Failed to start the Slack connection.",
+        );
+        setConnecting(false);
+      }
+    },
+    [apiCall],
+  );
 
   const organizationOptions = useMemo(
     () =>
@@ -522,7 +528,7 @@ const SlackIntegrationsPage: NextPage = () => {
       )}
       {disconnectTeamId && (
         <ConfirmDialog
-          title="Disconnect Slack workspace?"
+          title="Disconnect Slack Workspace?"
           content="This removes the workspace and all of its channel connections from GrowthBook."
           yesText="Disconnect"
           onConfirm={disconnectWorkspace}
@@ -546,16 +552,14 @@ const SlackIntegrationsPage: NextPage = () => {
               channel receives.
             </Text>
           </Box>
-          {data?.oauthConfigured && (
+          {data?.oauthConfigured && workspaceGroups.length > 0 && (
             <Button
               icon={<FaSlack />}
-              onClick={connectToSlack}
+              onClick={() => connectToSlack()}
               loading={connecting}
-              variant={workspaceGroups.length ? "outline" : "solid"}
+              variant="outline"
             >
-              {workspaceGroups.length
-                ? "Connect another workspace"
-                : "Connect to Slack"}
+              Connect another workspace
             </Button>
           )}
         </Flex>
@@ -587,14 +591,14 @@ const SlackIntegrationsPage: NextPage = () => {
           <Frame>
             <Flex direction="column" align="center" gap="3" p="5">
               <Heading as="h2" size="sm" mb="0">
-                No Slack workspace connected
+                No Slack Workspace Connected
               </Heading>
               <Text color="text-mid" align="center">
                 Connect a workspace, then add the channels GrowthBook should
                 notify.
               </Text>
               {data?.oauthConfigured && (
-                <Button icon={<FaSlack />} onClick={connectToSlack}>
+                <Button icon={<FaSlack />} onClick={() => connectToSlack()}>
                   Connect to Slack
                 </Button>
               )}
@@ -640,10 +644,10 @@ const SlackIntegrationsPage: NextPage = () => {
                         <Button
                           variant="ghost"
                           size="sm"
-                          aria-label="Add channel"
+                          icon={<PiPlus />}
                           onClick={() => setAddChannelTeamId(group.teamId)}
                         >
-                          <PiPlus />
+                          Add channel
                         </Button>
                       </Flex>
                     </Flex>
@@ -651,7 +655,7 @@ const SlackIntegrationsPage: NextPage = () => {
                       <Button
                         variant="outline"
                         size="sm"
-                        onClick={connectToSlack}
+                        onClick={() => connectToSlack(group.teamId)}
                         loading={connecting}
                       >
                         Reconnect
@@ -660,7 +664,7 @@ const SlackIntegrationsPage: NextPage = () => {
                         variant="outline"
                         color="red"
                         size="sm"
-                        icon={<PiPlugsConnected />}
+                        icon={<PiPlugs />}
                         onClick={() => setDisconnectTeamId(group.teamId)}
                       >
                         Disconnect
@@ -670,21 +674,19 @@ const SlackIntegrationsPage: NextPage = () => {
                       {group.channels.map((channel) => {
                         const selected = channel.id === selectedChannel?.id;
                         return (
-                          <Box
+                          <Link
                             key={channel.id}
-                            role="button"
-                            tabIndex={0}
-                            px="3"
-                            py="2"
-                            onClick={() => selectChannel(channel.id)}
-                            onKeyDown={(event) => {
-                              if (event.key === "Enter" || event.key === " ") {
-                                selectChannel(channel.id);
-                              }
-                            }}
+                            href={`/integrations/slack?channel=${encodeURIComponent(
+                              channel.id,
+                            )}`}
+                            shallow
+                            underline="none"
+                            color="dark"
+                            aria-current={selected ? "page" : undefined}
                             style={{
+                              display: "block",
+                              padding: "var(--space-2) var(--space-3)",
                               borderRadius: 8,
-                              cursor: "pointer",
                               background: selected
                                 ? "var(--violet-a3)"
                                 : undefined,
@@ -708,7 +710,7 @@ const SlackIntegrationsPage: NextPage = () => {
                                 </Box>
                               )}
                             </Flex>
-                          </Box>
+                          </Link>
                         );
                       })}
                       {group.channels.length === 0 && (
@@ -737,7 +739,7 @@ const SlackIntegrationsPage: NextPage = () => {
                 ) : (
                   <Flex direction="column" align="start" gap="3">
                     <Heading as="h2" size="sm" mb="0">
-                      Add a channel
+                      Add a Channel
                     </Heading>
                     <Text color="text-mid">
                       Choose a workspace and add the first channel to start
@@ -760,12 +762,6 @@ const SlackIntegrationsPage: NextPage = () => {
               </Box>
             </Flex>
           </Frame>
-        )}
-
-        {workspaceGroups.length > 0 && (
-          <HelperText status="info">
-            Slack connections created here are managed on this page.
-          </HelperText>
         )}
       </Flex>
     </Box>

--- a/packages/front-end/pages/integrations/slack/index.tsx
+++ b/packages/front-end/pages/integrations/slack/index.tsx
@@ -49,6 +49,13 @@ type WorkspaceGroup = {
   channels: SlackOAuthIntegrationInterface[];
 };
 
+const REQUIRED_SCOPES = [
+  "chat:write",
+  "channels:read",
+  "groups:read",
+  "channels:join",
+];
+
 const getQueryStringValue = (value: string | string[] | undefined) =>
   Array.isArray(value) ? value[0] : value;
 
@@ -56,6 +63,18 @@ const getSlackAuthorizationError = (error: string) =>
   error === "access_denied"
     ? "Slack authorization was canceled."
     : "Slack authorization failed. Try again.";
+
+const workspaceNeedsReconnect = (
+  integration: SlackOAuthIntegrationInterface,
+) => {
+  const scopes = new Set(
+    (integration.slack?.scope || "")
+      .split(",")
+      .map((scope) => scope.trim())
+      .filter(Boolean),
+  );
+  return REQUIRED_SCOPES.some((scope) => !scopes.has(scope));
+};
 
 function AddChannelModal({
   teamId,
@@ -241,13 +260,21 @@ const SlackIntegrationsPage: NextPage = () => {
   }, [integrations]);
 
   const selectedChannelId = getQueryStringValue(router.query.channel);
+  const selectedWorkspaceId = getQueryStringValue(router.query.workspace);
+  const selectedWorkspaceGroup = useMemo(
+    () =>
+      workspaceGroups.find((group) => group.teamId === selectedWorkspaceId) ||
+      null,
+    [selectedWorkspaceId, workspaceGroups],
+  );
   const selectedChannel = useMemo(() => {
     const channels = workspaceGroups.flatMap((group) => group.channels);
+    const workspaceChannels = selectedWorkspaceGroup?.channels || channels;
     return (
       channels.find((channel) => channel.id === selectedChannelId) ||
-      channels[0]
+      workspaceChannels[0]
     );
-  }, [selectedChannelId, workspaceGroups]);
+  }, [selectedChannelId, selectedWorkspaceGroup, workspaceGroups]);
 
   const selectChannel = useCallback(
     async (channelId: string | null) => {
@@ -279,10 +306,10 @@ const SlackIntegrationsPage: NextPage = () => {
     if (!code) return;
     const state = getQueryStringValue(router.query.state);
     callbackProcessed.current = true;
+    router.replace("/integrations/slack", undefined, { shallow: true });
 
     if (!state) {
       setInstallCode(code);
-      router.replace("/integrations/slack", undefined, { shallow: true });
       return;
     }
 
@@ -312,7 +339,6 @@ const SlackIntegrationsPage: NextPage = () => {
       })
       .finally(() => {
         setConnecting(false);
-        router.replace("/integrations/slack", undefined, { shallow: true });
       });
   }, [apiCall, mutate, router]);
 
@@ -545,8 +571,11 @@ const SlackIntegrationsPage: NextPage = () => {
         )}
         {data && !data.oauthConfigured && (
           <Callout status="warning">
-            Slack OAuth is not configured. Set the Slack client ID and client
-            secret on the GrowthBook API server.
+            Slack OAuth is not configured. Set <code>SLACK_CLIENT_ID</code> and{" "}
+            <code>SLACK_CLIENT_SECRET</code> for an app with the{" "}
+            <code>chat:write</code>, <code>channels:read</code>,{" "}
+            <code>groups:read</code>, and <code>channels:join</code> bot scopes.
+            A Slack signing secret is not required for outgoing notifications.
           </Callout>
         )}
 
@@ -587,9 +616,26 @@ const SlackIntegrationsPage: NextPage = () => {
                 {workspaceGroups.map((group) => (
                   <Box key={group.teamId}>
                     <Flex justify="between" align="center" gap="2" mb="2">
-                      <Text size="sm" weight="semibold" truncate>
-                        {getSlackWorkspaceLabel(group.workspace)}
-                      </Text>
+                      <Box style={{ minWidth: 0 }}>
+                        <Text size="sm" weight="semibold" truncate>
+                          {getSlackWorkspaceLabel(group.workspace)}
+                        </Text>
+                        <Box mt="1">
+                          <Badge
+                            label={
+                              workspaceNeedsReconnect(group.workspace)
+                                ? "Reconnect needed"
+                                : "Connected"
+                            }
+                            color={
+                              workspaceNeedsReconnect(group.workspace)
+                                ? "amber"
+                                : "green"
+                            }
+                            variant="soft"
+                          />
+                        </Box>
+                      </Box>
                       <Flex gap="1">
                         <Button
                           variant="ghost"
@@ -599,16 +645,26 @@ const SlackIntegrationsPage: NextPage = () => {
                         >
                           <PiPlus />
                         </Button>
-                        <Button
-                          variant="ghost"
-                          color="red"
-                          size="sm"
-                          aria-label="Disconnect workspace"
-                          onClick={() => setDisconnectTeamId(group.teamId)}
-                        >
-                          <PiPlugsConnected />
-                        </Button>
                       </Flex>
+                    </Flex>
+                    <Flex gap="2" mb="3">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={connectToSlack}
+                        loading={connecting}
+                      >
+                        Reconnect
+                      </Button>
+                      <Button
+                        variant="outline"
+                        color="red"
+                        size="sm"
+                        icon={<PiPlugsConnected />}
+                        onClick={() => setDisconnectTeamId(group.teamId)}
+                      >
+                        Disconnect
+                      </Button>
                     </Flex>
                     <Flex direction="column" gap="1">
                       {group.channels.map((channel) => {
@@ -690,7 +746,11 @@ const SlackIntegrationsPage: NextPage = () => {
                     <Button
                       icon={<PiPlus />}
                       onClick={() =>
-                        setAddChannelTeamId(workspaceGroups[0]?.teamId || null)
+                        setAddChannelTeamId(
+                          selectedWorkspaceGroup?.teamId ||
+                            workspaceGroups[0]?.teamId ||
+                            null,
+                        )
                       }
                     >
                       Add channel

--- a/packages/front-end/pages/integrations/slack/index.tsx
+++ b/packages/front-end/pages/integrations/slack/index.tsx
@@ -1,11 +1,53 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { NextPage } from "next";
 import { useRouter } from "next/router";
-import { SlackIntegrationsListViewContainer } from "@/components/SlackIntegrations/SlackIntegrationsListView/SlackIntegrationsListView";
+import { SlackOAuthIntegrationInterface } from "shared/types/slack-integration";
+import { Box, Flex } from "@radix-ui/themes";
+import { FaSlack } from "react-icons/fa";
+import { PiPlus, PiPlugsConnected } from "react-icons/pi";
+import SlackChannelSettings, {
+  getSlackChannelLabel,
+  getSlackWorkspaceLabel,
+} from "@/components/SlackIntegrations/SlackChannelSettings";
+import SelectField from "@/components/Forms/SelectField";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import useApi from "@/hooks/useApi";
 import { useAuth } from "@/services/auth";
-import Callout from "@/ui/Callout";
+import Badge from "@/ui/Badge";
 import Button from "@/ui/Button";
+import Callout from "@/ui/Callout";
+import ConfirmDialog from "@/ui/ConfirmDialog";
+import Frame from "@/ui/Frame";
+import Heading from "@/ui/Heading";
+import HelperText from "@/ui/HelperText";
+import ModalStandard from "@/ui/Modal/Patterns/ModalStandard";
+import { Select, SelectItem } from "@/ui/Select";
+import Text from "@/ui/Text";
+
+type SlackConnectionsResponse = {
+  slackIntegrations: SlackOAuthIntegrationInterface[];
+  oauthConfigured: boolean;
+};
+
+type SlackChannelOption = {
+  id: string;
+  name: string;
+  isPrivate: boolean;
+  isMember: boolean;
+  alreadyConnected: boolean;
+};
+
+type WorkspaceGroup = {
+  teamId: string;
+  workspace: SlackOAuthIntegrationInterface;
+  channels: SlackOAuthIntegrationInterface[];
+};
 
 const getQueryStringValue = (value: string | string[] | undefined) =>
   Array.isArray(value) ? value[0] : value;
@@ -15,17 +57,215 @@ const getSlackAuthorizationError = (error: string) =>
     ? "Slack authorization was canceled."
     : "Slack authorization failed. Try again.";
 
-const SlackIntegrationsPage: NextPage = () => {
-  const permissionsUtils = usePermissionsUtil();
-  const router = useRouter();
+function AddChannelModal({
+  teamId,
+  onClose,
+  onAdded,
+}: {
+  teamId: string;
+  onClose: () => void;
+  onAdded: (integration: SlackOAuthIntegrationInterface) => Promise<void>;
+}) {
   const { apiCall } = useAuth();
-  const callbackProcessed = useRef(false);
-  const [connecting, setConnecting] = useState(false);
-  const [connectError, setConnectError] = useState<string | null>(null);
-  const [connected, setConnected] = useState(false);
+  const [channels, setChannels] = useState<SlackChannelOption[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [selected, setSelected] = useState("");
+
+  const fetchChannels = useCallback(
+    async (cursor?: string) => {
+      setLoading(true);
+      setLoadError(null);
+      try {
+        const response = await apiCall<{
+          channels: SlackChannelOption[];
+          nextCursor: string | null;
+        }>(
+          `/integrations/slack/channels?teamId=${encodeURIComponent(teamId)}${
+            cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""
+          }`,
+        );
+        setChannels((current) =>
+          cursor ? [...current, ...response.channels] : response.channels,
+        );
+        setNextCursor(response.nextCursor);
+      } catch (error) {
+        setLoadError(
+          error instanceof Error
+            ? error.message
+            : "Failed to load Slack channels.",
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    [apiCall, teamId],
+  );
 
   useEffect(() => {
-    if (!router.isReady || callbackProcessed.current) return;
+    fetchChannels();
+  }, [fetchChannels]);
+
+  const connectedIds = useMemo(
+    () =>
+      new Set(
+        channels
+          .filter((channel) => channel.alreadyConnected)
+          .map((channel) => channel.id),
+      ),
+    [channels],
+  );
+
+  return (
+    <ModalStandard
+      trackingEventModalType="slack-add-channel"
+      open={true}
+      header="Add a Slack channel"
+      cta="Add channel"
+      ctaEnabled={!!selected && !connectedIds.has(selected)}
+      submit={async () => {
+        const response = await apiCall<{
+          slackIntegration: SlackOAuthIntegrationInterface;
+        }>("/integrations/slack/channels", {
+          method: "POST",
+          body: JSON.stringify({ teamId, channelId: selected }),
+        });
+        await onAdded(response.slackIntegration);
+      }}
+      close={onClose}
+    >
+      <Text as="p" color="text-mid" mb="3">
+        GrowthBook will join the channel and send the notifications you
+        configure.
+      </Text>
+      {loadError && (
+        <Callout status="error" mb="3">
+          {loadError}
+        </Callout>
+      )}
+      <SelectField
+        label="Channel"
+        placeholder={loading ? "Loading channels…" : "Search for a channel…"}
+        value={selected}
+        options={channels.map((channel) => ({
+          label: `#${channel.name}${channel.isPrivate ? " (private)" : ""}${
+            channel.alreadyConnected ? " — already connected" : ""
+          }`,
+          value: channel.id,
+        }))}
+        onChange={setSelected}
+        isSearchable
+        isOptionDisabled={(option) =>
+          "value" in option && connectedIds.has(option.value)
+        }
+        disabled={loading && channels.length === 0}
+      />
+      <Flex gap="3" align="center" mt="3">
+        <Button
+          variant="ghost"
+          size="sm"
+          loading={loading}
+          onClick={() => fetchChannels()}
+        >
+          Refresh
+        </Button>
+        {nextCursor && (
+          <Button
+            variant="ghost"
+            size="sm"
+            loading={loading}
+            onClick={() => fetchChannels(nextCursor)}
+          >
+            Load more
+          </Button>
+        )}
+      </Flex>
+      <Text as="p" size="sm" color="text-mid" mt="3" mb="0">
+        For a private channel, invite the GrowthBook app in Slack before
+        refreshing this list.
+      </Text>
+    </ModalStandard>
+  );
+}
+
+const SlackIntegrationsPage: NextPage = () => {
+  const permissionsUtils = usePermissionsUtil();
+  const canManageIntegrations = permissionsUtils.canManageIntegrations();
+  const router = useRouter();
+  const { apiCall, orgId, organizations, setOrgId } = useAuth();
+  const callbackProcessed = useRef(false);
+  const installInFlight = useRef(false);
+  const [connecting, setConnecting] = useState(false);
+  const [connectError, setConnectError] = useState<string | null>(null);
+  const [connectedMessage, setConnectedMessage] = useState<string | null>(null);
+  const [installCode, setInstallCode] = useState<string | null>(null);
+  const [installing, setInstalling] = useState(false);
+  const [addChannelTeamId, setAddChannelTeamId] = useState<string | null>(null);
+  const [disconnectTeamId, setDisconnectTeamId] = useState<string | null>(null);
+
+  const {
+    data,
+    error: loadError,
+    mutate,
+  } = useApi<SlackConnectionsResponse>("/integrations/slack/oauth", {
+    shouldRun: () => canManageIntegrations,
+  });
+
+  const integrations = useMemo(
+    () => data?.slackIntegrations || [],
+    [data?.slackIntegrations],
+  );
+
+  const workspaceGroups = useMemo(() => {
+    const groups = new Map<string, WorkspaceGroup>();
+    integrations.forEach((integration) => {
+      const teamId = integration.slack?.teamId;
+      if (!teamId) return;
+      const existing = groups.get(teamId);
+      if (!existing) {
+        groups.set(teamId, {
+          teamId,
+          workspace: integration,
+          channels: integration.slack?.channelId ? [integration] : [],
+        });
+        return;
+      }
+      if (integration.slack?.channelId) {
+        existing.channels.push(integration);
+      } else {
+        existing.workspace = integration;
+      }
+    });
+    return [...groups.values()];
+  }, [integrations]);
+
+  const selectedChannelId = getQueryStringValue(router.query.channel);
+  const selectedChannel = useMemo(() => {
+    const channels = workspaceGroups.flatMap((group) => group.channels);
+    return (
+      channels.find((channel) => channel.id === selectedChannelId) ||
+      channels[0]
+    );
+  }, [selectedChannelId, workspaceGroups]);
+
+  const selectChannel = useCallback(
+    async (channelId: string | null) => {
+      await router.replace(
+        channelId
+          ? `/integrations/slack?channel=${encodeURIComponent(channelId)}`
+          : "/integrations/slack",
+        undefined,
+        { shallow: true },
+      );
+    },
+    [router],
+  );
+
+  useEffect(() => {
+    if (!router.isReady || callbackProcessed.current) {
+      return;
+    }
 
     const slackError = getQueryStringValue(router.query.error);
     if (slackError) {
@@ -37,25 +277,31 @@ const SlackIntegrationsPage: NextPage = () => {
 
     const code = getQueryStringValue(router.query.code);
     if (!code) return;
-
     const state = getQueryStringValue(router.query.state);
     callbackProcessed.current = true;
+
     if (!state) {
-      setConnectError(
-        "This Slack install was not started from GrowthBook. Start the connection from this page.",
-      );
+      setInstallCode(code);
       router.replace("/integrations/slack", undefined, { shallow: true });
       return;
     }
 
     setConnecting(true);
     setConnectError(null);
-    apiCall("/integrations/slack/oauth-callback", {
-      method: "POST",
-      body: JSON.stringify({ code, state }),
-    })
-      .then(() => {
-        setConnected(true);
+    apiCall<{ slackIntegration: SlackOAuthIntegrationInterface }>(
+      "/integrations/slack/oauth-callback",
+      {
+        method: "POST",
+        body: JSON.stringify({ code, state }),
+      },
+    )
+      .then(async ({ slackIntegration }) => {
+        await mutate();
+        setConnectedMessage("Slack workspace connected successfully.");
+        const teamId = slackIntegration.slack?.teamId;
+        if (teamId && !slackIntegration.slack?.channelId) {
+          setAddChannelTeamId(teamId);
+        }
       })
       .catch((error: unknown) => {
         setConnectError(
@@ -68,7 +314,7 @@ const SlackIntegrationsPage: NextPage = () => {
         setConnecting(false);
         router.replace("/integrations/slack", undefined, { shallow: true });
       });
-  }, [apiCall, router]);
+  }, [apiCall, mutate, router]);
 
   const connectToSlack = useCallback(async () => {
     setConnecting(true);
@@ -89,32 +335,380 @@ const SlackIntegrationsPage: NextPage = () => {
     }
   }, [apiCall]);
 
-  if (!permissionsUtils.canManageIntegrations()) {
+  const organizationOptions = useMemo(
+    () =>
+      (organizations || []).map((organization) => ({
+        value: organization.id,
+        label: organization.name || organization.id,
+      })),
+    [organizations],
+  );
+  const currentOrganizationName =
+    organizationOptions.find((organization) => organization.value === orgId)
+      ?.label ||
+    orgId ||
+    "this organization";
+
+  const confirmAppDirectoryInstall = useCallback(async () => {
+    if (!installCode || installInFlight.current) return;
+    installInFlight.current = true;
+    setInstalling(true);
+    setConnectError(null);
+    try {
+      const { slackIntegration } = await apiCall<{
+        slackIntegration: SlackOAuthIntegrationInterface;
+      }>("/integrations/slack/oauth-install", {
+        method: "POST",
+        body: JSON.stringify({ code: installCode }),
+      });
+      await mutate();
+      setInstallCode(null);
+      setConnectedMessage("Slack workspace connected successfully.");
+      const teamId = slackIntegration.slack?.teamId;
+      if (teamId && !slackIntegration.slack?.channelId) {
+        setAddChannelTeamId(teamId);
+      }
+    } catch (error) {
+      setConnectError(
+        error instanceof Error
+          ? error.message
+          : "Failed to connect the Slack workspace.",
+      );
+    } finally {
+      installInFlight.current = false;
+      setInstalling(false);
+    }
+  }, [apiCall, installCode, mutate]);
+
+  const switchInstallOrganization = useCallback(
+    (nextOrgId: string) => {
+      if (!setOrgId || !nextOrgId || nextOrgId === orgId) return;
+      setOrgId(nextOrgId);
+      setConnectError(null);
+      try {
+        localStorage.setItem("gb-last-picked-org", JSON.stringify(nextOrgId));
+      } catch {
+        // Persisting the selection is best-effort.
+      }
+    },
+    [orgId, setOrgId],
+  );
+
+  const disconnectWorkspace = useCallback(async () => {
+    if (!disconnectTeamId) return;
+    await apiCall("/integrations/slack/disconnect", {
+      method: "POST",
+      body: JSON.stringify({ teamId: disconnectTeamId }),
+    });
+    setDisconnectTeamId(null);
+    await selectChannel(null);
+    await mutate();
+  }, [apiCall, disconnectTeamId, mutate, selectChannel]);
+
+  if (installCode) {
     return (
-      <div className="container-fluid pagecontents">
+      <Flex align="center" justify="center" p="5" style={{ minHeight: "60vh" }}>
+        <Frame style={{ maxWidth: 520, width: "100%" }}>
+          <Flex direction="column" gap="4">
+            <Box>
+              <Heading as="h1" size="lg" mb="2">
+                Connect Slack to GrowthBook
+              </Heading>
+              <Text as="p" color="text-mid" mb="0">
+                Confirm which GrowthBook organization should own this Slack
+                workspace.
+              </Text>
+            </Box>
+            <Box>
+              <Heading as="h2" size="sm" mb="2">
+                {currentOrganizationName}
+              </Heading>
+              {organizationOptions.length > 1 && (
+                <Select
+                  label="Organization"
+                  value={orgId || ""}
+                  setValue={switchInstallOrganization}
+                >
+                  {organizationOptions.map((organization) => (
+                    <SelectItem
+                      key={organization.value}
+                      value={organization.value}
+                    >
+                      {organization.label}
+                    </SelectItem>
+                  ))}
+                </Select>
+              )}
+            </Box>
+            {!canManageIntegrations && (
+              <Callout status="warning">
+                You cannot manage integrations for this organization. Choose
+                another organization or ask an administrator for access.
+              </Callout>
+            )}
+            {connectError && <Callout status="error">{connectError}</Callout>}
+            <Flex gap="3">
+              <Button
+                onClick={confirmAppDirectoryInstall}
+                loading={installing}
+                disabled={!orgId || !canManageIntegrations}
+              >
+                Connect to {currentOrganizationName}
+              </Button>
+              <Button
+                variant="ghost"
+                onClick={() => {
+                  setInstallCode(null);
+                  setConnectError(null);
+                }}
+              >
+                Cancel
+              </Button>
+            </Flex>
+          </Flex>
+        </Frame>
+      </Flex>
+    );
+  }
+
+  if (!canManageIntegrations) {
+    return (
+      <Box p="5">
         <Callout status="error">
           You do not have access to view this page.
         </Callout>
-      </div>
+      </Box>
     );
   }
+
   return (
-    <div className="container-fluid pagecontents">
-      {connectError && (
-        <Callout status="error" mb="4">
-          {connectError}
-        </Callout>
+    <Box p="5">
+      {addChannelTeamId && (
+        <AddChannelModal
+          teamId={addChannelTeamId}
+          onClose={() => setAddChannelTeamId(null)}
+          onAdded={async (integration) => {
+            setAddChannelTeamId(null);
+            await mutate();
+            await selectChannel(integration.id);
+          }}
+        />
       )}
-      {connected && (
-        <Callout status="success" mb="4">
-          Slack workspace connected successfully.
-        </Callout>
+      {disconnectTeamId && (
+        <ConfirmDialog
+          title="Disconnect Slack workspace?"
+          content="This removes the workspace and all of its channel connections from GrowthBook."
+          yesText="Disconnect"
+          onConfirm={disconnectWorkspace}
+          onCancel={() => setDisconnectTeamId(null)}
+        />
       )}
-      <Button onClick={connectToSlack} loading={connecting} mb="4">
-        Connect Slack workspace
-      </Button>
-      <SlackIntegrationsListViewContainer />
-    </div>
+
+      <Flex direction="column" gap="4">
+        <Flex
+          direction={{ initial: "column", sm: "row" }}
+          justify="between"
+          align="start"
+          gap="4"
+        >
+          <Box>
+            <Heading as="h1" size="lg" mb="2">
+              Slack
+            </Heading>
+            <Text as="p" color="text-mid" mb="0">
+              Connect Slack channels and choose which GrowthBook events each
+              channel receives.
+            </Text>
+          </Box>
+          {data?.oauthConfigured && (
+            <Button
+              icon={<FaSlack />}
+              onClick={connectToSlack}
+              loading={connecting}
+              variant={workspaceGroups.length ? "outline" : "solid"}
+            >
+              {workspaceGroups.length
+                ? "Connect another workspace"
+                : "Connect to Slack"}
+            </Button>
+          )}
+        </Flex>
+
+        {connectedMessage && (
+          <Callout status="success">{connectedMessage}</Callout>
+        )}
+        {connectError && <Callout status="error">{connectError}</Callout>}
+        {loadError && (
+          <Callout status="error">
+            Failed to load Slack connections: {loadError.message}
+          </Callout>
+        )}
+        {data && !data.oauthConfigured && (
+          <Callout status="warning">
+            Slack OAuth is not configured. Set the Slack client ID and client
+            secret on the GrowthBook API server.
+          </Callout>
+        )}
+
+        {!data && !loadError ? (
+          <Frame>
+            <Text color="text-mid">Loading Slack connections…</Text>
+          </Frame>
+        ) : workspaceGroups.length === 0 ? (
+          <Frame>
+            <Flex direction="column" align="center" gap="3" p="5">
+              <Heading as="h2" size="sm" mb="0">
+                No Slack workspace connected
+              </Heading>
+              <Text color="text-mid" align="center">
+                Connect a workspace, then add the channels GrowthBook should
+                notify.
+              </Text>
+              {data?.oauthConfigured && (
+                <Button icon={<FaSlack />} onClick={connectToSlack}>
+                  Connect to Slack
+                </Button>
+              )}
+            </Flex>
+          </Frame>
+        ) : (
+          <Frame>
+            <Flex align="stretch">
+              <Flex
+                direction="column"
+                gap="4"
+                p="3"
+                style={{
+                  width: 280,
+                  flex: "none",
+                  borderRight: "1px solid var(--gray-a4)",
+                }}
+              >
+                {workspaceGroups.map((group) => (
+                  <Box key={group.teamId}>
+                    <Flex justify="between" align="center" gap="2" mb="2">
+                      <Text size="sm" weight="semibold" truncate>
+                        {getSlackWorkspaceLabel(group.workspace)}
+                      </Text>
+                      <Flex gap="1">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          aria-label="Add channel"
+                          onClick={() => setAddChannelTeamId(group.teamId)}
+                        >
+                          <PiPlus />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          color="red"
+                          size="sm"
+                          aria-label="Disconnect workspace"
+                          onClick={() => setDisconnectTeamId(group.teamId)}
+                        >
+                          <PiPlugsConnected />
+                        </Button>
+                      </Flex>
+                    </Flex>
+                    <Flex direction="column" gap="1">
+                      {group.channels.map((channel) => {
+                        const selected = channel.id === selectedChannel?.id;
+                        return (
+                          <Box
+                            key={channel.id}
+                            role="button"
+                            tabIndex={0}
+                            px="3"
+                            py="2"
+                            onClick={() => selectChannel(channel.id)}
+                            onKeyDown={(event) => {
+                              if (event.key === "Enter" || event.key === " ") {
+                                selectChannel(channel.id);
+                              }
+                            }}
+                            style={{
+                              borderRadius: 8,
+                              cursor: "pointer",
+                              background: selected
+                                ? "var(--violet-a3)"
+                                : undefined,
+                            }}
+                          >
+                            <Flex align="center" gap="2">
+                              <Text
+                                size="md"
+                                weight={selected ? "semibold" : "medium"}
+                                truncate
+                              >
+                                {getSlackChannelLabel(channel)}
+                              </Text>
+                              {!channel.enabled && (
+                                <Box ml="auto">
+                                  <Badge
+                                    label="Disabled"
+                                    color="gray"
+                                    variant="soft"
+                                  />
+                                </Box>
+                              )}
+                            </Flex>
+                          </Box>
+                        );
+                      })}
+                      {group.channels.length === 0 && (
+                        <Text size="sm" color="text-mid">
+                          No channels yet
+                        </Text>
+                      )}
+                    </Flex>
+                  </Box>
+                ))}
+              </Flex>
+
+              <Box p="5" style={{ flex: 1, minWidth: 0 }}>
+                {selectedChannel ? (
+                  <SlackChannelSettings
+                    key={selectedChannel.id}
+                    integration={selectedChannel}
+                    onSaved={async () => {
+                      await mutate();
+                    }}
+                    onDeleted={async () => {
+                      await selectChannel(null);
+                      await mutate();
+                    }}
+                  />
+                ) : (
+                  <Flex direction="column" align="start" gap="3">
+                    <Heading as="h2" size="sm" mb="0">
+                      Add a channel
+                    </Heading>
+                    <Text color="text-mid">
+                      Choose a workspace and add the first channel to start
+                      receiving notifications.
+                    </Text>
+                    <Button
+                      icon={<PiPlus />}
+                      onClick={() =>
+                        setAddChannelTeamId(workspaceGroups[0]?.teamId || null)
+                      }
+                    >
+                      Add channel
+                    </Button>
+                  </Flex>
+                )}
+              </Box>
+            </Flex>
+          </Frame>
+        )}
+
+        {workspaceGroups.length > 0 && (
+          <HelperText status="info">
+            Slack connections created here are managed on this page.
+          </HelperText>
+        )}
+      </Flex>
+    </Box>
   );
 };
 

--- a/packages/front-end/pages/integrations/slack/index.tsx
+++ b/packages/front-end/pages/integrations/slack/index.tsx
@@ -326,13 +326,15 @@ const SlackIntegrationsPage: NextPage = () => {
     if (!code) return;
     const state = getQueryStringValue(router.query.state);
     callbackProcessed.current = true;
-    router.replace("/integrations/slack", undefined, { shallow: true });
 
     if (!state) {
+      // Keep the code in the callback URL until confirmed or canceled.
+      // Switching organizations remounts this page and clears local state.
       setInstallCode(code);
       return;
     }
 
+    router.replace("/integrations/slack", undefined, { shallow: true });
     setConnecting(true);
     setConnectError(null);
     apiCall<SlackOAuthConnectionResponse>(
@@ -414,8 +416,9 @@ const SlackIntegrationsPage: NextPage = () => {
             body: JSON.stringify({ code: installCode }),
           },
         );
-      await mutate();
       setInstallCode(null);
+      await router.replace("/integrations/slack", undefined, { shallow: true });
+      await mutate();
       setConnectedMessage("Slack workspace connected successfully.");
       if (!slackIntegration) {
         setAddChannelTeamId(slackConnection.teamId);
@@ -430,7 +433,7 @@ const SlackIntegrationsPage: NextPage = () => {
       installInFlight.current = false;
       setInstalling(false);
     }
-  }, [apiCall, installCode, mutate]);
+  }, [apiCall, installCode, mutate, router]);
 
   const switchInstallOrganization = useCallback(
     (nextOrgId: string) => {
@@ -480,6 +483,7 @@ const SlackIntegrationsPage: NextPage = () => {
                   label="Organization"
                   value={orgId || ""}
                   setValue={switchInstallOrganization}
+                  disabled={installing}
                 >
                   {organizationOptions.map((organization) => (
                     <SelectItem
@@ -509,7 +513,11 @@ const SlackIntegrationsPage: NextPage = () => {
               </Button>
               <Button
                 variant="ghost"
-                onClick={() => {
+                disabled={installing}
+                onClick={async () => {
+                  await router.replace("/integrations/slack", undefined, {
+                    shallow: true,
+                  });
                   setInstallCode(null);
                   setConnectError(null);
                 }}

--- a/packages/front-end/pages/integrations/slack/index.tsx
+++ b/packages/front-end/pages/integrations/slack/index.tsx
@@ -15,6 +15,7 @@ import { PiPlus, PiPlugs } from "react-icons/pi";
 import SlackChannelSettings, {
   getSlackChannelLabel,
 } from "@/components/SlackIntegrations/SlackChannelSettings";
+import { SlackIntegrationsListViewContainer } from "@/components/SlackIntegrations/SlackIntegrationsListView/SlackIntegrationsListView";
 import SelectField from "@/components/Forms/SelectField";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import useApi from "@/hooks/useApi";
@@ -787,6 +788,7 @@ const SlackIntegrationsPage: NextPage = () => {
             </Flex>
           </Frame>
         )}
+        <SlackIntegrationsListViewContainer key={orgId} legacyOnly />
       </Flex>
     </Box>
   );


### PR DESCRIPTION
## Summary
- add complete Slack workspace and channel management
- complete GrowthBook-initiated and App Directory OAuth callbacks, including explicit organization confirmation
- add channel event settings and route OAuth-managed Event Webhooks to the Slack settings page

Depends on #6839.

When the new UI is enabled, existing legacy connections continue sending notifications and retain edit/delete controls in a Legacy Slack Integrations section. This section appears only for organizations with legacy records (or a load error); legacy creation controls are hidden in this UI. Users can verify replacement workspace connections before deleting old ones to avoid duplicate notifications.

Rich notification cards, digests, coalescing, previews, and expanded event production remain deferred to focused follow-up PRs.

## Test plan
- [x] Run back-end and front-end type checks
- [x] Run ESLint and Prettier checks for changed files
- [x] Run 36 focused OAuth, channel connection, token rotation, and legacy delivery tests
- [x] Run the full front-end test suite (74 files, 1,147 tests)
- [ ] Verify workspace OAuth and channel management in the PR preview

Made with [Cursor](https://cursor.com)

## Feature-flag rollout

All new Slack UI is gated by the boolean `slack-workspace-ui` feature flag. An absent or false flag keeps the legacy Slack page, including create/edit/delete, and the existing Event Webhook links and edit controls. The OAuth page and its API effects are not mounted while the flag is off.

Enable the flag only for internal test organizations initially. Flag-on users see the workspace UI from #6841 and retain edit/delete access for existing legacy connections. The flag does not stop notification delivery or migrate/delete existing records; switching it off restores the legacy UI.

Validation: the legacy page matches current main apart from its component name; the legacy Slack model and delivery handlers are unchanged. Frontend type checks, lint/format hooks, and 26 focused Slack tests passed. Live workspace testing remains required before expanding rollout.
