### PR TITLE
fix(incremental): treat absent startDate as unchanged in full-refresh check

### DIFF
--- a/packages/shared/src/enterprise/pipeline.ts
+++ b/packages/shared/src/enterprise/pipeline.ts
@@ -44,7 +44,10 @@ export function normalizeIncrementalFullRefreshField(
   settings: IncrementalFullRefreshComparable,
 ): string | number | boolean | null {
   if (field === "startDate") {
-    return getValidDate(settings.startDate).getTime();
+    // Use a stable epoch fallback so absent/invalid startDates normalize
+    // deterministically; the default `getValidDate` fallback is `new Date()`,
+    // which makes two absent values compare unequal across separate calls.
+    return getValidDate(settings.startDate, new Date(0)).getTime();
   }
   if (field === "attributionModel") {
     return settings.attributionModel || "firstExposure";


### PR DESCRIPTION
## Summary

`getIncrementalFullRefreshReasons` compares two snapshot settings field-by-field to decide whether an incremental update requires a full refresh. For `startDate`, `normalizeIncrementalFullRefreshField` normalized via:

```ts
return getValidDate(settings.startDate).getTime();
```

When `startDate` is absent, `getValidDate` falls back to `new Date()` (the current time). Because `current` and `baseline` are normalized in two separate calls, two snapshots that **both** lack a `startDate` produce two `new Date().getTime()` values a few milliseconds apart. Whenever a millisecond boundary falls between the two calls, they compare as unequal and the check reports a spurious `"Analysis start date changed"`, triggering an unnecessary full refresh.

This also made the unit test `treats both-absent startDate as equal` **flaky** — it passes when both `new Date()` calls land in the same millisecond and fails otherwise.

## Fix

Pass a stable epoch fallback so absent (and invalid) start dates normalize deterministically:

```ts
return getValidDate(settings.startDate, new Date(0)).getTime();
```

- both-absent → `0 === 0` → unchanged
- same moment (Date vs ISO string) → still equal
- differing moments / present-vs-absent → still flagged as changed

## Test plan

- [x] `pnpm --filter shared test pipeline` — all 67 tests pass, including `treats both-absent startDate as equal`
- [x] ESLint + Prettier clean (ran via pre-commit lint-staged)

Made with [Cursor](https://cursor.com)