### PR TITLE
fix: compute Multiple Exposures Check correctly when dimensions configured

### DIFF
--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -1333,6 +1333,13 @@ export class ExperimentIncrementalRefreshQueryRunner extends QueryRunner<
         traffic: trafficHealth,
       };
 
+      // Use the traffic query's multiple exposures count when available, as it
+      // correctly aggregates across dimension slices. The metric query's count
+      // can be incorrect when dimensions are configured.
+      if (trafficHealth.multipleExposures !== undefined) {
+        result.multipleExposures = trafficHealth.multipleExposures;
+      }
+
       // TODO(incremental-refresh): ensure power calculations work
       // const _relativeAnalysis = this.model.analyses.find(
       //   (a) => a.settings.differenceType === "relative",

--- a/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
@@ -577,6 +577,13 @@ export class ExperimentResultsQueryRunner extends QueryRunner<
         traffic: trafficHealth,
       };
 
+      // Use the traffic query's multiple exposures count when available, as it
+      // correctly aggregates across dimension slices. The metric query's count
+      // can be incorrect when dimensions are configured.
+      if (trafficHealth.multipleExposures !== undefined) {
+        result.multipleExposures = trafficHealth.multipleExposures;
+      }
+
       const relativeAnalysis = this.model.analyses.find(
         (a) => a.settings.differenceType === "relative",
       );

--- a/packages/back-end/src/queryRunners/SafeRolloutResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/SafeRolloutResultsQueryRunner.ts
@@ -132,6 +132,13 @@ export class SafeRolloutResultsQueryRunner extends QueryRunner<
       result.health = {
         traffic: trafficHealth,
       };
+
+      // Use the traffic query's multiple exposures count when available, as it
+      // correctly aggregates across dimension slices. The metric query's count
+      // can be incorrect when dimensions are configured.
+      if (trafficHealth.multipleExposures !== undefined) {
+        result.multipleExposures = trafficHealth.multipleExposures;
+      }
     }
     // TODO: Add functionality to dynamically update coverage here
     return result;

--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -855,15 +855,31 @@ export function analyzeExperimentTraffic({
     dimension: {},
   };
 
+  // Track multiple exposures per dimension. Each dimension should have the
+  // same total (since the same users appear in each dimension). We sum within
+  // each dimension and take the max across dimensions to handle cases where
+  // some dimensions might not have all slices reported.
+  const multipleExposuresPerDimension: Map<string, number> = new Map();
+
   let banditSrmSet = false;
   rows.forEach((r) => {
     if (r.dimension_name === BANDIT_SRM_DIMENSION_NAME) {
       trafficResults.overall.srm = chi2pvalue(r.units, variations.length - 1);
       banditSrmSet = true;
     }
+
+    // Track __multiple__ rows separately to compute total multiple exposures
+    if (r.variation === "__multiple__") {
+      const currentTotal =
+        multipleExposuresPerDimension.get(r.dimension_name) ?? 0;
+      multipleExposuresPerDimension.set(
+        r.dimension_name,
+        currentTotal + r.units,
+      );
+      return;
+    }
+
     const variationIndex = variationIdMap[r.variation];
-    // skip if variation is not found (this happens if variation is __multiple__)
-    if (variationIndex === undefined) return;
     const dimTraffic: Map<string, ExperimentSnapshotTrafficDimension> =
       dimTrafficResults.get(r.dimension_name) ?? new Map();
     const dimValueTraffic: ExperimentSnapshotTrafficDimension = dimTraffic.get(
@@ -906,5 +922,15 @@ export function analyzeExperimentTraffic({
       }
     }
   }
+
+  // Set multiple exposures as the max across dimensions. All dimensions should
+  // have the same total since the same users appear in each, but we take max
+  // to be safe in case some dimensions have incomplete data.
+  if (multipleExposuresPerDimension.size > 0) {
+    trafficResults.multipleExposures = Math.max(
+      ...multipleExposuresPerDimension.values(),
+    );
+  }
+
   return trafficResults;
 }

--- a/packages/back-end/test/services/stats.test.ts
+++ b/packages/back-end/test/services/stats.test.ts
@@ -2,8 +2,12 @@ import type {
   ExperimentSnapshotAnalysisSettings,
   SnapshotSettingsVariation,
 } from "shared/types/experiment-snapshot";
+import type { ExperimentAggregateUnitsQueryResponseRows } from "shared/types/integrations";
 import type { ExperimentMetricAnalysis } from "shared/types/stats";
-import { parseStatsEngineResult } from "back-end/src/services/stats";
+import {
+  parseStatsEngineResult,
+  analyzeExperimentTraffic,
+} from "back-end/src/services/stats";
 
 const analysisSettings: ExperimentSnapshotAnalysisSettings = {
   dimensions: [""],
@@ -236,5 +240,133 @@ describe("parseStatsEngineResult", () => {
         variations: [],
       },
     ]);
+  });
+});
+
+describe("analyzeExperimentTraffic", () => {
+  it("computes multiple exposures from traffic query rows", () => {
+    const rows: ExperimentAggregateUnitsQueryResponseRows = [
+      {
+        variation: "control",
+        dimension_name: "dim_exposure_date",
+        dimension_value: "2026-08-29",
+        units: 25360,
+      },
+      {
+        variation: "treatment",
+        dimension_name: "dim_exposure_date",
+        dimension_value: "2026-08-29",
+        units: 25398,
+      },
+      {
+        variation: "__multiple__",
+        dimension_name: "dim_exposure_date",
+        dimension_value: "2026-08-29",
+        units: 198,
+      },
+      {
+        variation: "__multiple__",
+        dimension_name: "dim_exposure_date",
+        dimension_value: "2026-08-30",
+        units: 84,
+      },
+      {
+        variation: "__multiple__",
+        dimension_name: "dim_exposure_date",
+        dimension_value: "2026-08-31",
+        units: 40,
+      },
+      {
+        variation: "__multiple__",
+        dimension_name: "dim_exposure_date",
+        dimension_value: "2026-09-01",
+        units: 30,
+      },
+      {
+        variation: "__multiple__",
+        dimension_name: "dim_exposure_date",
+        dimension_value: "2026-08-28",
+        units: 1,
+      },
+    ];
+
+    const result = analyzeExperimentTraffic({
+      rows,
+      variations,
+    });
+
+    expect(result.multipleExposures).toBe(353);
+  });
+
+  it("uses max across dimensions when multiple dimensions have __multiple__ rows", () => {
+    const rows: ExperimentAggregateUnitsQueryResponseRows = [
+      {
+        variation: "control",
+        dimension_name: "dim_exposure_date",
+        dimension_value: "2026-08-29",
+        units: 100,
+      },
+      {
+        variation: "__multiple__",
+        dimension_name: "dim_app_platform",
+        dimension_value: "iOS",
+        units: 353,
+      },
+      {
+        variation: "__multiple__",
+        dimension_name: "dim_app_theme",
+        dimension_value: "Light",
+        units: 189,
+      },
+      {
+        variation: "__multiple__",
+        dimension_name: "dim_app_theme",
+        dimension_value: "Black",
+        units: 145,
+      },
+      {
+        variation: "__multiple__",
+        dimension_name: "dim_app_theme",
+        dimension_value: "Dark",
+        units: 13,
+      },
+      {
+        variation: "__multiple__",
+        dimension_name: "dim_app_theme",
+        dimension_value: "Sepia",
+        units: 6,
+      },
+    ];
+
+    const result = analyzeExperimentTraffic({
+      rows,
+      variations,
+    });
+
+    expect(result.multipleExposures).toBe(353);
+  });
+
+  it("returns undefined multipleExposures when no __multiple__ rows exist", () => {
+    const rows: ExperimentAggregateUnitsQueryResponseRows = [
+      {
+        variation: "control",
+        dimension_name: "dim_exposure_date",
+        dimension_value: "2026-08-29",
+        units: 100,
+      },
+      {
+        variation: "treatment",
+        dimension_name: "dim_exposure_date",
+        dimension_value: "2026-08-29",
+        units: 100,
+      },
+    ];
+
+    const result = analyzeExperimentTraffic({
+      rows,
+      variations,
+    });
+
+    expect(result.multipleExposures).toBeUndefined();
   });
 });

--- a/packages/shared/types/experiment-snapshot.d.ts
+++ b/packages/shared/types/experiment-snapshot.d.ts
@@ -295,6 +295,7 @@ export interface ExperimentSnapshotTraffic {
     [dimension: string]: ExperimentSnapshotTrafficDimension[];
   };
   error?: "NO_ROWS_IN_UNIT_QUERY" | "TOO_MANY_ROWS" | string;
+  multipleExposures?: number;
 }
 export interface ExperimentSnapshotTrafficDimension {
   name: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

Fixes a bug where the Multiple Exposures Check on the Health tab shows a count from a single dimension slice instead of the experiment total when dimensions are configured.

**Root cause:** The code in `parseStatsEngineResult` (stats.ts) used `q.rows.filter()[0]` which only grabbed the first `__multiple__` row instead of aggregating across all dimension slices.

**Example from the bug report:**
- Expected: 353 multiple exposures
- Observed: 6 multiple exposures (which matched the Sepia slice of `dim_exp_app_theme`)

**The fix:** Compute multiple exposures from the traffic query instead of metric queries. The `analyzeExperimentTraffic` function now:
1. Tracks `__multiple__` rows separately
2. Sums them per dimension
3. Takes the max across dimensions (all dimensions should have the same total since they represent the same users with different dimension attributes)

**Changes:**
- Added `multipleExposures?: number` to `ExperimentSnapshotTraffic` type
- Modified `analyzeExperimentTraffic()` to compute and return multiple exposures
- Updated `ExperimentResultsQueryRunner`, `SafeRolloutResultsQueryRunner`, and `ExperimentIncrementalRefreshQueryRunner` to use the traffic query's value when available
- Added unit tests for the multiple exposures calculation

- Closes N/A (reported via Slack by a self-hosted v4.4 customer)

### Dependencies

None

### Testing

- All 8399 existing tests pass
- Added 3 new unit tests specifically for multiple exposures calculation:
  1. `computes multiple exposures from traffic query rows` - verifies summing across dimension slices
  2. `uses max across dimensions when multiple dimensions have __multiple__ rows` - verifies taking max across dimensions
  3. `returns undefined multipleExposures when no __multiple__ rows exist` - verifies the undefined case

### Screenshots

N/A - this is a back-end calculation fix. The UI component (`MultipleExposuresCard.tsx`) remains unchanged and will display the corrected value.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C046L8DQD6F/p1788393471738539?thread_ts=1788393471.738539&cid=C046L8DQD6F)

<div><a href="https://cursor.com/agents/bc-50271f7d-b267-52bb-8e47-e0be5c9703fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50271f7d-b267-52bb-8e47-e0be5c9703fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

