### PR TITLE
fix(datasources): ensure we close connections on every exit path

### DIFF
--- a/packages/back-end/src/integrations/ClickHouse.ts
+++ b/packages/back-end/src/integrations/ClickHouse.ts
@@ -117,23 +117,31 @@ export default class ClickHouse extends SqlIntegration {
           : {}),
       },
     });
-    const results = await client.query({ query: sql, format: "JSON" });
-    // eslint-disable-next-line
-    const data: ResponseJSON<Record<string, any>[]> = await results.json();
-    const rows = data.data ? data.data : [];
-    if (isManagedWarehouse(this.datasource)) {
-      normalizeManagedWarehouseDatetimes(rows, data.meta);
+    try {
+      const results = await client.query({ query: sql, format: "JSON" });
+      // eslint-disable-next-line
+      const data: ResponseJSON<Record<string, any>[]> = await results.json();
+      const rows = data.data ? data.data : [];
+      if (isManagedWarehouse(this.datasource)) {
+        normalizeManagedWarehouseDatetimes(rows, data.meta);
+      }
+      return {
+        rows,
+        statistics: data.statistics
+          ? {
+              executionDurationMs: data.statistics.elapsed,
+              rowsProcessed: data.statistics.rows_read,
+              bytesProcessed: data.statistics.bytes_read,
+            }
+          : undefined,
+      };
+    } finally {
+      try {
+        await client.close();
+      } catch (e) {
+        logger.warn(e, "Failed to close ClickHouse client");
+      }
     }
-    return {
-      rows,
-      statistics: data.statistics
-        ? {
-            executionDurationMs: data.statistics.elapsed,
-            rowsProcessed: data.statistics.rows_read,
-            bytesProcessed: data.statistics.bytes_read,
-          }
-        : undefined,
-    };
   }
 
   getInformationSchemaWhereClause(): string {

--- a/packages/back-end/src/integrations/Mysql.ts
+++ b/packages/back-end/src/integrations/Mysql.ts
@@ -4,6 +4,7 @@ import { SqlDialect } from "shared/types/sql";
 import { QueryResponse } from "shared/types/integrations";
 import { MysqlConnectionParams } from "shared/types/integrations/mysql";
 import { decryptDataSourceParams } from "back-end/src/services/datasource";
+import { logger } from "back-end/src/util/logger";
 import SqlIntegration from "./SqlIntegration";
 import { mysqlDialect } from "./dialects/mysql";
 
@@ -34,10 +35,16 @@ export default class Mysql extends SqlIntegration {
       };
     }
     const conn = await mysql.createConnection(config);
-
-    const [rows] = await conn.query(sql);
-    conn.end();
-    return { rows: rows as RowDataPacket[] };
+    try {
+      const [rows] = await conn.query(sql);
+      return { rows: rows as RowDataPacket[] };
+    } finally {
+      try {
+        await conn.end();
+      } catch (e) {
+        logger.warn(e, "Failed to close MySQL connection");
+      }
+    }
   }
   hasQuantileTesting(): boolean {
     return false;

--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -33,6 +33,7 @@ import {
   getConfigDatasources,
 } from "back-end/src/init/config";
 import { upgradeDatasourceObject } from "back-end/src/util/migrations";
+import { closeMssqlPool } from "back-end/src/util/mssqlPoolManager";
 import { queueCreateInformationSchema } from "back-end/src/jobs/createInformationSchema";
 import { IS_CLOUD } from "back-end/src/util/secrets";
 import { ReqContext } from "back-end/types/request";
@@ -294,6 +295,8 @@ export async function deleteDatasource(
     id: datasource.id,
     organization: context.org.id,
   });
+
+  await closeMssqlPool(datasource.id);
 
   await audit.logDelete(context, datasource);
   await touchDefinitionsVersion(

--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -346,6 +346,10 @@ export async function deleteAllDataSourcesForAProject({
     organization: organizationId,
     projects: [projectId],
   });
+
+  for (const doc of docs) {
+    await closeMssqlPool(doc.id);
+  }
   // Only datasources whose sole project is projectId are deleted here, so only
   // that project's readers are affected.
   await touchDefinitionsVersion(organizationId, definitionsScope([projectId]));

--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -296,7 +296,9 @@ export async function deleteDatasource(
     organization: context.org.id,
   });
 
-  await closeMssqlPool(datasource.id);
+  // Eviction is synchronous; socket teardown can take up to the driver's
+  // connect timeout, so don't make the request wait on it
+  void closeMssqlPool(datasource.id);
 
   await audit.logDelete(context, datasource);
   await touchDefinitionsVersion(
@@ -348,7 +350,7 @@ export async function deleteAllDataSourcesForAProject({
   });
 
   for (const doc of docs) {
-    await closeMssqlPool(doc.id);
+    void closeMssqlPool(doc.id);
   }
   // Only datasources whose sole project is projectId are deleted here, so only
   // that project's readers are affected.

--- a/packages/back-end/src/services/databricks.ts
+++ b/packages/back-end/src/services/databricks.ts
@@ -41,29 +41,29 @@ export function buildDatabricksConnectionOptions(
   };
 }
 
-export async function runDatabricksQuery<T>(
+export async function runDatabricksQuery(
   conn: DatabricksConnectionParams,
   sql: string,
-): Promise<QueryResponse<T[]>> {
+): Promise<QueryResponse> {
   // Because of how Databrick's SDK is written, it may reject or resolve multiple times
   // So we have a quick boolean check to make sure we only do it the first time
   let finished = false;
 
+  const client = new DBSQLClient({
+    logger: {
+      log(level, message) {
+        if (ENVIRONMENT !== "production") {
+          logger.info({ db: "Databricks", level }, message);
+        }
+      },
+    },
+  });
+
   // Annoyingly, the `client.connect` method is async, but if there's an error,
   // it just hangs and never rejects. Instead, it emits an "error" event.
   // So we have to wrap everything in a `new Promise()` and handle errors manually
-
   try {
-    const result = await new Promise<T[]>((resolve, reject) => {
-      const client = new DBSQLClient({
-        logger: {
-          log(level, message) {
-            if (ENVIRONMENT !== "production") {
-              logger.info({ db: "Databricks", level }, message);
-            }
-          },
-        },
-      });
+    const rows = await new Promise<QueryResponse["rows"]>((resolve, reject) => {
       client
         .on("error", (error) => {
           if (!finished) {
@@ -79,20 +79,14 @@ export async function runDatabricksQuery<T>(
             // This is required to have the results returned immediately
             maxRows: 1000,
           });
-          const result = (await queryOperation.fetchAll({
+          const rows = (await queryOperation.fetchAll({
             progress: false,
-          })) as unknown as Promise<T[]>;
+          })) as QueryResponse["rows"];
 
-          // As soon as we have the reuslt, return it
           if (!finished) {
             finished = true;
-            resolve(result);
+            resolve(rows);
           }
-
-          // Do cleanup in the background and ignore errors
-          await queryOperation.close();
-          await session.close();
-          await client.close();
         })
         .catch((e) => {
           if (!finished) {
@@ -101,11 +95,17 @@ export async function runDatabricksQuery<T>(
           }
         });
     });
-    return { rows: result };
+    return { rows };
   } catch (e) {
     if (e.response?.displayMessage) {
       throw new Error(e.response.displayMessage);
     }
     throw new Error(e.message);
+  } finally {
+    try {
+      await client.close();
+    } catch (e) {
+      logger.warn(e, "Failed to close Databricks connection");
+    }
   }
 }

--- a/packages/back-end/src/services/postgres.ts
+++ b/packages/back-end/src/services/postgres.ts
@@ -3,53 +3,53 @@ import { QueryResponse } from "shared/types/integrations";
 import { PostgresConnectionParams } from "shared/types/integrations/postgres";
 import { logger } from "back-end/src/util/logger";
 
-export function runPostgresQuery(
+export async function runPostgresQuery(
   conn: PostgresConnectionParams,
   sql: string,
   values: string[] = [],
 ): Promise<QueryResponse> {
-  return new Promise<QueryResponse>((resolve, reject) => {
-    let ssl: false | ClientConfig["ssl"] = false;
-    if (conn.ssl === true || conn.ssl === "true") {
-      ssl = {
-        rejectUnauthorized: false,
-      };
-
-      if (conn.caCert) {
-        ssl.ca = conn.caCert;
-      }
-      if (conn.clientCert) {
-        ssl.cert = conn.clientCert;
-      }
-      if (conn.clientKey) {
-        ssl.key = conn.clientKey;
-      }
-    }
-
-    const settings: ClientConfig = {
-      ...conn,
-      ssl,
-      // Give it 10 seconds to connect
-      connectionTimeoutMillis: 10000,
+  let ssl: false | ClientConfig["ssl"] = false;
+  if (conn.ssl === true || conn.ssl === "true") {
+    ssl = {
+      rejectUnauthorized: false,
     };
 
-    const client = new Client(settings);
-    client
-      .on("error", (err) => {
-        reject(err);
-      })
-      .connect()
-      .then(() => client.query(sql, values))
-      .then(async (res) => {
-        try {
-          await client.end();
-        } catch (e) {
-          logger.warn(e, "Postgres query failed");
-        }
-        resolve({ rows: res.rows });
-      })
-      .catch((e) => {
-        reject(e);
-      });
+    if (conn.caCert) {
+      ssl.ca = conn.caCert;
+    }
+    if (conn.clientCert) {
+      ssl.cert = conn.clientCert;
+    }
+    if (conn.clientKey) {
+      ssl.key = conn.clientKey;
+    }
+  }
+
+  const settings: ClientConfig = {
+    ...conn,
+    ssl,
+    // Give it 10 seconds to connect
+    connectionTimeoutMillis: 10000,
+  };
+
+  const client = new Client(settings);
+
+  // Unhandled pg "error" events crash the process; race them into a rejection
+  const socketError = new Promise<never>((_, reject) => {
+    client.on("error", reject);
   });
+
+  try {
+    const res = await Promise.race([
+      client.connect().then(() => client.query(sql, values)),
+      socketError,
+    ]);
+    return { rows: res.rows };
+  } finally {
+    try {
+      await client.end();
+    } catch (e) {
+      logger.warn(e, "Failed to close Postgres connection");
+    }
+  }
 }

--- a/packages/back-end/src/util/mssqlPoolManager.ts
+++ b/packages/back-end/src/util/mssqlPoolManager.ts
@@ -1,20 +1,56 @@
+import { createHash } from "crypto";
 import mssql from "mssql";
 import { MssqlConnectionParams } from "shared/types/integrations/mssql";
-const pools = new Map();
+import { logger } from "back-end/src/util/logger";
+
+type PoolEntry = {
+  configKey: string;
+  pool: mssql.ConnectionPool;
+  connected: Promise<mssql.ConnectionPool>;
+};
+
+const pools = new Map<string, PoolEntry>();
 
 export function findOrCreateConnection(
-  name: string,
+  datasourceId: string,
   config: MssqlConnectionParams,
-) {
-  if (!pools.has(name)) {
-    const pool: mssql.ConnectionPool = new mssql.ConnectionPool(config);
-    // automatically remove the pool from the cache if `pool.close()` is called
-    const close = pool.close.bind(pool);
-    pool.close = () => {
-      pools.delete(name);
-      return close();
-    };
-    pools.set(name, pool.connect());
+): Promise<mssql.ConnectionPool> {
+  const existing = pools.get(datasourceId);
+
+  const configKey = createHash("sha256")
+    .update(JSON.stringify(config))
+    .digest("hex");
+  if (existing?.configKey === configKey) {
+    return existing.connected;
   }
-  return pools.get(name);
+
+  // Config changed: replace the stale pool
+  if (existing) {
+    void closeMssqlPool(datasourceId);
+  }
+
+  const pool = new mssql.ConnectionPool(config);
+  pool.on("error", (err) => {
+    logger.warn(err, `MSSQL pool error for datasource ${datasourceId}`);
+  });
+  const connected = pool.connect().catch((e) => {
+    // Evict so the next query retries instead of replaying this rejection
+    if (pools.get(datasourceId)?.pool === pool) {
+      pools.delete(datasourceId);
+    }
+    throw e;
+  });
+  pools.set(datasourceId, { configKey, pool, connected });
+  return connected;
+}
+
+export async function closeMssqlPool(datasourceId: string): Promise<void> {
+  const entry = pools.get(datasourceId);
+  if (!entry) return;
+  pools.delete(datasourceId);
+  // mssql rejects close() while connecting, so wait for connect to settle
+  await entry.connected.catch(() => undefined);
+  await entry.pool.close().catch((e) => {
+    logger.warn(e, `Failed to close MSSQL pool for datasource ${datasourceId}`);
+  });
 }

--- a/packages/back-end/test/util/mssqlPoolManager.test.ts
+++ b/packages/back-end/test/util/mssqlPoolManager.test.ts
@@ -1,0 +1,140 @@
+import { EventEmitter } from "events";
+import { MssqlConnectionParams } from "shared/types/integrations/mssql";
+import {
+  closeMssqlPool,
+  findOrCreateConnection,
+} from "back-end/src/util/mssqlPoolManager";
+
+type MockPool = EventEmitter & { closeCalls: number };
+
+const created: MockPool[] = [];
+let connectBehavior: () => Promise<void> = async () => undefined;
+
+jest.mock("mssql", () => {
+  class ConnectionPool extends EventEmitter {
+    closeCalls = 0;
+    constructor() {
+      super();
+      created.push(this);
+    }
+    connect() {
+      return connectBehavior().then(() => this);
+    }
+    async close() {
+      this.closeCalls++;
+    }
+  }
+  return { __esModule: true, default: { ConnectionPool } };
+});
+
+const config: MssqlConnectionParams = {
+  server: "db.example.com",
+  port: 1433,
+  user: "gb",
+  password: "secret",
+  database: "analytics",
+};
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+beforeEach(() => {
+  created.length = 0;
+  connectBehavior = async () => undefined;
+});
+
+describe("findOrCreateConnection", () => {
+  it("reuses the pool while the config is unchanged", async () => {
+    const first = await findOrCreateConnection("ds-reuse", config);
+    const second = await findOrCreateConnection("ds-reuse", { ...config });
+    expect(second).toBe(first);
+    expect(created).toHaveLength(1);
+  });
+
+  it("replaces and closes the pool when the config changes", async () => {
+    const stale = await findOrCreateConnection("ds-rotate", config);
+    const fresh = await findOrCreateConnection("ds-rotate", {
+      ...config,
+      password: "rotated",
+    });
+    await flush();
+    expect(fresh).not.toBe(stale);
+    expect(created).toHaveLength(2);
+    expect(created[0].closeCalls).toBe(1);
+    expect(created[1].closeCalls).toBe(0);
+  });
+
+  it("evicts a rejected connect so the next call retries", async () => {
+    connectBehavior = async () => {
+      throw new Error("login failed");
+    };
+    await expect(findOrCreateConnection("ds-retry", config)).rejects.toThrow(
+      "login failed",
+    );
+
+    connectBehavior = async () => undefined;
+    const pool = await findOrCreateConnection("ds-retry", config);
+    expect(created).toHaveLength(2);
+    expect(pool).toBe(created[1]);
+  });
+
+  it("does not let a slow rejection evict a newer replacement pool", async () => {
+    let rejectSlow: (e: Error) => void = () => undefined;
+    connectBehavior = () =>
+      new Promise((_, reject) => {
+        rejectSlow = reject;
+      });
+    const slow = findOrCreateConnection("ds-race", config);
+
+    connectBehavior = async () => undefined;
+    const replacement = await findOrCreateConnection("ds-race", {
+      ...config,
+      password: "rotated",
+    });
+
+    rejectSlow(new Error("too late"));
+    await expect(slow).rejects.toThrow("too late");
+
+    const again = await findOrCreateConnection("ds-race", {
+      ...config,
+      password: "rotated",
+    });
+    expect(again).toBe(replacement);
+    expect(created).toHaveLength(2);
+  });
+
+  it("attaches an error listener so pool errors do not throw", async () => {
+    const pool = await findOrCreateConnection("ds-error", config);
+    expect(() => pool.emit("error", new Error("tedious"))).not.toThrow();
+  });
+});
+
+describe("closeMssqlPool", () => {
+  it("closes and forgets the pool, and is a no-op afterwards", async () => {
+    await findOrCreateConnection("ds-close", config);
+    await closeMssqlPool("ds-close");
+    expect(created[0].closeCalls).toBe(1);
+
+    await closeMssqlPool("ds-close");
+    expect(created[0].closeCalls).toBe(1);
+
+    await findOrCreateConnection("ds-close", config);
+    expect(created).toHaveLength(2);
+  });
+
+  it("waits for a pending connect before closing", async () => {
+    let finishConnect: () => void = () => undefined;
+    connectBehavior = () =>
+      new Promise((resolve) => {
+        finishConnect = resolve;
+      });
+    const connecting = findOrCreateConnection("ds-pending", config);
+    const closing = closeMssqlPool("ds-pending");
+    await flush();
+    expect(created[0].closeCalls).toBe(0);
+
+    finishConnect();
+    await connecting;
+    await closing;
+    expect(created[0].closeCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
### Features and Changes

Doing some clean up for warehouses where we keep a connection open, ensuring we close all resources when they are not needed anymore.

**MSSQL pool cache**

- Pools are keyed by datasource id plus a hash of the connection config, so a rotated password or changed host replaces the stale pool instead of being ignored until restart.
- A rejected `connect()` evicts its cache entry, so the next query retries instead of replaying the original error.

### Testing

- Unit tests
- Manual testing forcing errors