### PR TITLE
Revert "fix(incremental): treat absent startDate as unchanged in full-refresh check"

### DIFF
--- a/packages/shared/src/enterprise/pipeline.ts
+++ b/packages/shared/src/enterprise/pipeline.ts
@@ -44,10 +44,7 @@ export function normalizeIncrementalFullRefreshField(
   settings: IncrementalFullRefreshComparable,
 ): string | number | boolean | null {
   if (field === "startDate") {
-    // Use a stable epoch fallback so absent/invalid startDates normalize
-    // deterministically; the default `getValidDate` fallback is `new Date()`,
-    // which makes two absent values compare unequal across separate calls.
-    return getValidDate(settings.startDate, new Date(0)).getTime();
+    return getValidDate(settings.startDate).getTime();
   }
   if (field === "attributionModel") {
     return settings.attributionModel || "firstExposure";


### PR DESCRIPTION
Reverts growthbook/growthbook#6844

need to address Greptile feedback