### PR TITLE
fixing undefined start date

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -615,6 +615,13 @@ export function getSnapshotSettings({
   if (!phase) {
     throw new Error("Invalid snapshot phase");
   }
+  // upgradeExperimentDoc backfills a missing phase start date.
+  // If the backfill fails, throw an error.
+  if (!phase.dateStarted) {
+    throw new Error(
+      "This experiment phase has no start date, so results can't be analyzed. Set a start date for the phase and try again.",
+    );
+  }
 
   const defaultPriorSettings = orgPriorSettings ?? {
     override: false,

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -619,7 +619,7 @@ export function getSnapshotSettings({
   // If the backfill fails, throw an error.
   if (!phase.dateStarted) {
     throw new Error(
-      "This experiment phase has no start date, so results can't be analyzed. Set a start date for the phase and try again.",
+      "This experiment phase has no start date, so results cannot be analyzed. Set a start date for the phase and try again.",
     );
   }
 

--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -680,14 +680,15 @@ export function upgradeExperimentDoc(
     experiment.secondaryMetrics = [];
   }
 
-  // Backfill a missing creation date (a required field that legacy/corrupt docs
-  // may lack).
+  // Backfill a missing creation date.
   if (!experiment.dateCreated) {
     const earliestPhaseStart = (experiment.phases ?? [])
       .map((p) => p.dateStarted)
       .filter((d): d is Date => !!d)
       .sort((a, b) => +new Date(a) - +new Date(b))[0];
-    experiment.dateCreated = earliestPhaseStart ?? experiment.dateUpdated;
+    if (earliestPhaseStart) {
+      experiment.dateCreated = earliestPhaseStart;
+    }
   }
 
   // Populate phase names and targeting properties

--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -680,17 +680,6 @@ export function upgradeExperimentDoc(
     experiment.secondaryMetrics = [];
   }
 
-  // Backfill a missing creation date.
-  if (!experiment.dateCreated) {
-    const earliestPhaseStart = (experiment.phases ?? [])
-      .map((p) => p.dateStarted)
-      .filter((d): d is Date => !!d)
-      .sort((a, b) => +new Date(a) - +new Date(b))[0];
-    if (earliestPhaseStart) {
-      experiment.dateCreated = earliestPhaseStart;
-    }
-  }
-
   // Populate phase names and targeting properties
   if (experiment.phases) {
     experiment.phases.forEach((phase, i) => {
@@ -699,13 +688,14 @@ export function upgradeExperimentDoc(
         phase.name = p.substring(0, 1).toUpperCase() + p.substring(1);
       }
 
-      // Backfill a missing start date on legacy phases.
-      // Use the prior phase's `dateEnded`; for the first phase,
-      // fall back to the experiment's creation date.
+      // Backfill a missing start date on a legacy phase from the prior phase's
+      // end date.
       if (!phase.dateStarted) {
         const prevPhaseEnded =
           i > 0 ? experiment.phases[i - 1].dateEnded : undefined;
-        phase.dateStarted = prevPhaseEnded ?? experiment.dateCreated;
+        if (prevPhaseEnded) {
+          phase.dateStarted = prevPhaseEnded;
+        }
       }
 
       phase.coverage = phase.coverage ?? 1;

--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -680,6 +680,16 @@ export function upgradeExperimentDoc(
     experiment.secondaryMetrics = [];
   }
 
+  // Backfill a missing creation date (a required field that legacy/corrupt docs
+  // may lack).
+  if (!experiment.dateCreated) {
+    const earliestPhaseStart = (experiment.phases ?? [])
+      .map((p) => p.dateStarted)
+      .filter((d): d is Date => !!d)
+      .sort((a, b) => +new Date(a) - +new Date(b))[0];
+    experiment.dateCreated = earliestPhaseStart ?? experiment.dateUpdated;
+  }
+
   // Populate phase names and targeting properties
   if (experiment.phases) {
     experiment.phases.forEach((phase, i) => {

--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -682,10 +682,19 @@ export function upgradeExperimentDoc(
 
   // Populate phase names and targeting properties
   if (experiment.phases) {
-    experiment.phases.forEach((phase) => {
+    experiment.phases.forEach((phase, i) => {
       if (!phase.name) {
         const p = phase.phase || "main";
         phase.name = p.substring(0, 1).toUpperCase() + p.substring(1);
+      }
+
+      // Backfill a missing start date on legacy phases.
+      // Use the prior phase's `dateEnded`; for the first phase,
+      // fall back to the experiment's creation date.
+      if (!phase.dateStarted) {
+        const prevPhaseEnded =
+          i > 0 ? experiment.phases[i - 1].dateEnded : undefined;
+        phase.dateStarted = prevPhaseEnded ?? experiment.dateCreated;
       }
 
       phase.coverage = phase.coverage ?? 1;

--- a/packages/back-end/test/migrations.test.ts
+++ b/packages/back-end/test/migrations.test.ts
@@ -1919,14 +1919,17 @@ describe("Experiment Migration", () => {
     expect(result.dateCreated).toEqual(early);
   });
 
-  it("falls back to dateUpdated for dateCreated when no phase has a start", () => {
+  it("leaves dateCreated unset when no phase has a start (no dateUpdated fallback)", () => {
+    // "Last modified" is a poor proxy for creation, so dateUpdated is not used.
+    // Leaving dateCreated (and the phase start) absent lets the analysis guard
+    // fire rather than analyzing against a fabricated window.
     const dateUpdated = new Date("2024-05-01T00:00:00.000Z");
     const result = upgradeExperimentDoc({
       ...exp,
       dateCreated: undefined,
       dateUpdated,
     });
-    expect(result.dateCreated).toEqual(dateUpdated);
+    expect(result.dateCreated).toBeUndefined();
   });
 
   it("derives dateCreated from a phase start, which then resolves that phase's dateStarted", () => {

--- a/packages/back-end/test/migrations.test.ts
+++ b/packages/back-end/test/migrations.test.ts
@@ -1864,6 +1864,46 @@ describe("Experiment Migration", () => {
   it("upgrades experiment objects", () => {
     expect(upgradeExperimentDoc(exp)).toEqual(upgraded);
   });
+
+  it("backfills a first phase's missing start date from the experiment's dateCreated", () => {
+    const dateCreated = new Date("2024-01-01T00:00:00.000Z");
+    const result = upgradeExperimentDoc({ ...exp, dateCreated });
+    expect(result.phases[0].dateStarted).toEqual(dateCreated);
+  });
+
+  it("backfills a later phase's missing start date from the previous phase's dateEnded", () => {
+    const dateCreated = new Date("2024-01-01T00:00:00.000Z");
+    const phase0End = new Date("2024-02-01T00:00:00.000Z");
+    const result = upgradeExperimentDoc({
+      ...exp,
+      dateCreated,
+      phases: [
+        { ...exp.phases[0], dateEnded: phase0End },
+        { ...exp.phases[1] },
+      ],
+    });
+    expect(result.phases[1].dateStarted).toEqual(phase0End);
+  });
+
+  it("leaves a first phase's start date unset when there is no dateCreated to fall back to", () => {
+    // The exact case the analysis guard in getSnapshotSettings blocks on.
+    const result = upgradeExperimentDoc({ ...exp });
+    expect(result.phases[0].dateStarted).toBeUndefined();
+  });
+
+  it("does not overwrite an existing phase start date", () => {
+    const existing = new Date("2023-06-01T00:00:00.000Z");
+    const dateCreated = new Date("2024-01-01T00:00:00.000Z");
+    const result = upgradeExperimentDoc({
+      ...exp,
+      dateCreated,
+      phases: [
+        { ...exp.phases[0], dateStarted: existing },
+        { ...exp.phases[1] },
+      ],
+    });
+    expect(result.phases[0].dateStarted).toEqual(existing);
+  });
   it("upgrades stopped experiments with results", () => {
     expect(
       upgradeExperimentDoc({

--- a/packages/back-end/test/migrations.test.ts
+++ b/packages/back-end/test/migrations.test.ts
@@ -1904,6 +1904,55 @@ describe("Experiment Migration", () => {
     });
     expect(result.phases[0].dateStarted).toEqual(existing);
   });
+
+  it("backfills a missing dateCreated from the earliest phase start", () => {
+    const early = new Date("2024-01-01T00:00:00.000Z");
+    const late = new Date("2024-03-01T00:00:00.000Z");
+    const result = upgradeExperimentDoc({
+      ...exp,
+      dateCreated: undefined,
+      phases: [
+        { ...exp.phases[0], dateStarted: late },
+        { ...exp.phases[1], dateStarted: early },
+      ],
+    });
+    expect(result.dateCreated).toEqual(early);
+  });
+
+  it("falls back to dateUpdated for dateCreated when no phase has a start", () => {
+    const dateUpdated = new Date("2024-05-01T00:00:00.000Z");
+    const result = upgradeExperimentDoc({
+      ...exp,
+      dateCreated: undefined,
+      dateUpdated,
+    });
+    expect(result.dateCreated).toEqual(dateUpdated);
+  });
+
+  it("derives dateCreated from a phase start, which then resolves that phase's dateStarted", () => {
+    // Mirrors the heal path: a user sets the phase start on a doc missing
+    // dateCreated; on the next read dateCreated derives from it and analysis
+    // (which needs dateCreated) can proceed.
+    const phaseStart = new Date("2024-02-01T00:00:00.000Z");
+    const result = upgradeExperimentDoc({
+      ...exp,
+      dateCreated: undefined,
+      phases: [{ ...exp.phases[0], dateStarted: phaseStart }],
+    });
+    expect(result.dateCreated).toEqual(phaseStart);
+    expect(result.phases[0].dateStarted).toEqual(phaseStart);
+  });
+
+  it("does not overwrite an existing dateCreated", () => {
+    const dateCreated = new Date("2022-01-01T00:00:00.000Z");
+    const phaseStart = new Date("2024-02-01T00:00:00.000Z");
+    const result = upgradeExperimentDoc({
+      ...exp,
+      dateCreated,
+      phases: [{ ...exp.phases[0], dateStarted: phaseStart }],
+    });
+    expect(result.dateCreated).toEqual(dateCreated);
+  });
   it("upgrades stopped experiments with results", () => {
     expect(
       upgradeExperimentDoc({

--- a/packages/back-end/test/migrations.test.ts
+++ b/packages/back-end/test/migrations.test.ts
@@ -1865,10 +1865,13 @@ describe("Experiment Migration", () => {
     expect(upgradeExperimentDoc(exp)).toEqual(upgraded);
   });
 
-  it("backfills a first phase's missing start date from the experiment's dateCreated", () => {
+  it("does not backfill a first phase's missing start date, even when dateCreated exists", () => {
+    // A first phase has no reliable start to derive, so we intentionally do not
+    // fall back to dateCreated. Leaving it unset makes the analysis guard in
+    // getSnapshotSettings block and prompt the user to set the phase dates.
     const dateCreated = new Date("2024-01-01T00:00:00.000Z");
     const result = upgradeExperimentDoc({ ...exp, dateCreated });
-    expect(result.phases[0].dateStarted).toEqual(dateCreated);
+    expect(result.phases[0].dateStarted).toBeUndefined();
   });
 
   it("backfills a later phase's missing start date from the previous phase's dateEnded", () => {
@@ -1885,7 +1888,7 @@ describe("Experiment Migration", () => {
     expect(result.phases[1].dateStarted).toEqual(phase0End);
   });
 
-  it("leaves a first phase's start date unset when there is no dateCreated to fall back to", () => {
+  it("leaves a first phase's start date unset when it has no dateStarted", () => {
     // The exact case the analysis guard in getSnapshotSettings blocks on.
     const result = upgradeExperimentDoc({ ...exp });
     expect(result.phases[0].dateStarted).toBeUndefined();
@@ -1905,57 +1908,6 @@ describe("Experiment Migration", () => {
     expect(result.phases[0].dateStarted).toEqual(existing);
   });
 
-  it("backfills a missing dateCreated from the earliest phase start", () => {
-    const early = new Date("2024-01-01T00:00:00.000Z");
-    const late = new Date("2024-03-01T00:00:00.000Z");
-    const result = upgradeExperimentDoc({
-      ...exp,
-      dateCreated: undefined,
-      phases: [
-        { ...exp.phases[0], dateStarted: late },
-        { ...exp.phases[1], dateStarted: early },
-      ],
-    });
-    expect(result.dateCreated).toEqual(early);
-  });
-
-  it("leaves dateCreated unset when no phase has a start (no dateUpdated fallback)", () => {
-    // "Last modified" is a poor proxy for creation, so dateUpdated is not used.
-    // Leaving dateCreated (and the phase start) absent lets the analysis guard
-    // fire rather than analyzing against a fabricated window.
-    const dateUpdated = new Date("2024-05-01T00:00:00.000Z");
-    const result = upgradeExperimentDoc({
-      ...exp,
-      dateCreated: undefined,
-      dateUpdated,
-    });
-    expect(result.dateCreated).toBeUndefined();
-  });
-
-  it("derives dateCreated from a phase start, which then resolves that phase's dateStarted", () => {
-    // Mirrors the heal path: a user sets the phase start on a doc missing
-    // dateCreated; on the next read dateCreated derives from it and analysis
-    // (which needs dateCreated) can proceed.
-    const phaseStart = new Date("2024-02-01T00:00:00.000Z");
-    const result = upgradeExperimentDoc({
-      ...exp,
-      dateCreated: undefined,
-      phases: [{ ...exp.phases[0], dateStarted: phaseStart }],
-    });
-    expect(result.dateCreated).toEqual(phaseStart);
-    expect(result.phases[0].dateStarted).toEqual(phaseStart);
-  });
-
-  it("does not overwrite an existing dateCreated", () => {
-    const dateCreated = new Date("2022-01-01T00:00:00.000Z");
-    const phaseStart = new Date("2024-02-01T00:00:00.000Z");
-    const result = upgradeExperimentDoc({
-      ...exp,
-      dateCreated,
-      phases: [{ ...exp.phases[0], dateStarted: phaseStart }],
-    });
-    expect(result.dateCreated).toEqual(dateCreated);
-  });
   it("upgrades stopped experiments with results", () => {
     expect(
       upgradeExperimentDoc({

--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
@@ -311,9 +311,13 @@ export default function AnalysisSettingsSummary({
         ? !!experiment.regressionAdjustmentEnabled
         : false,
       experimentId: experiment.id,
+      // Leave absent when there's no started phase so it stays symmetric with an
+      // absent baseline; fabricating `new Date()` here would spuriously flag a change.
       startDate: phaseStart
         ? new Date(phaseStart)
-        : getValidDate(experiment.phases?.[0]?.dateStarted ?? ""),
+        : experiment.phases?.[0]?.dateStarted
+          ? new Date(experiment.phases[0].dateStarted)
+          : undefined,
     };
     const baselineComparable: IncrementalFullRefreshComparable = {
       activationMetric: dimensionless.settings.activationMetric,

--- a/packages/shared/src/enterprise/pipeline.ts
+++ b/packages/shared/src/enterprise/pipeline.ts
@@ -33,10 +33,17 @@ export const INCREMENTAL_FULL_REFRESH_SETTINGS_FIELDS = [
   "experimentId",
 ] as const satisfies readonly (keyof ExperimentSnapshotSettings)[];
 
-export type IncrementalFullRefreshComparable = Pick<
-  ExperimentSnapshotSettings,
-  (typeof INCREMENTAL_FULL_REFRESH_SETTINGS_FIELDS)[number]
->;
+export type IncrementalFullRefreshComparable = Omit<
+  Pick<
+    ExperimentSnapshotSettings,
+    (typeof INCREMENTAL_FULL_REFRESH_SETTINGS_FIELDS)[number]
+  >,
+  "startDate"
+> & {
+  // Legacy snapshots (and experiments without a started phase) may lack a
+  // start date, so treat it as optional even though the snapshot type requires it.
+  startDate?: ExperimentSnapshotSettings["startDate"];
+};
 
 // Keep this aligned with snapshotSettings so UI labels match backend hash checks.
 export function normalizeIncrementalFullRefreshField(
@@ -44,7 +51,14 @@ export function normalizeIncrementalFullRefreshField(
   settings: IncrementalFullRefreshComparable,
 ): string | number | boolean | null {
   if (field === "startDate") {
-    return getValidDate(settings.startDate).getTime();
+    // getValidDate() falls
+    // back to a fresh `new Date()` on every call, so two absent dates would
+    // resolve to different wall-clock timestamps and never compare equal,
+    // deterministically reporting "Analysis start date changed" even when
+    // neither side has a start date.
+    return settings.startDate
+      ? getValidDate(settings.startDate).getTime()
+      : null;
   }
   if (field === "attributionModel") {
     return settings.attributionModel || "firstExposure";

--- a/packages/shared/test/enterprise/pipeline.test.ts
+++ b/packages/shared/test/enterprise/pipeline.test.ts
@@ -755,6 +755,15 @@ describe("getIncrementalFullRefreshReasons", () => {
     ).toEqual([]);
   });
 
+  it("flags startDate when only one side is absent", () => {
+    expect(
+      getIncrementalFullRefreshReasons(
+        makeComparable({ startDate: new Date("2024-01-01T00:00:00.000Z") }),
+        makeComparable({ startDate: undefined }),
+      ),
+    ).toEqual(["Analysis start date changed"]);
+  });
+
   it("flags queryFilter 'a' vs 'b' as changed", () => {
     expect(
       getIncrementalFullRefreshReasons(


### PR DESCRIPTION
Fix spurious "Analysis start date changed" and guard analysis when a phase has no start date.  Behavior stays unchanged for normally-configured experiments; the guard only trips for legacy/corrupt data with no resolvable phase start.

Problem
When an experiment phase has no start date, the incremental full-refresh comparison normalizes absent dates via getValidDate(), which returns a fresh new Date() on each call. Two absent dates therefore resolve to different timestamps, deterministically (and incorrectly) reporting Analysis start date changed.

Changes
shared/enterprise/pipeline.ts: Normalize an absent startDate to a stable null sentinel instead of a fabricated timestamp; make startDate optional on IncrementalFullRefreshComparable to reflect that legacy snapshots may lack it.
front-end/.../AnalysisSettingsSummary.tsx: Stop fabricating new Date() for the current-side start when there's no started phase, so it stays symmetric with an absent baseline.
back-end/util/migrations.ts: In upgradeExperimentDoc, backfill a missing phase dateStarted from the previous phase's dateEnded (or the experiment's dateCreated for the first phase). Runs on every read.
back-end/services/experiments.ts: In getSnapshotSettings, throw a clear, user-facing error when a phase still has no resolvable start date (first phase with no dateCreated) — blocking analysis rather than producing a fabricated window. Surfaces on-screen when the user clicks Update Results.
Tests: Add coverage for the absent/one-sided startDate comparison and the migration backfill (both-absent, first-phase fallback, prior-phase fallback, and no-op when already set).

Example error state when phase start date cannot be resolved. 

<img width="1728" height="1117" alt="Screenshot 2026-09-03 at 1 49 51 PM" src="https://github.com/user-attachments/assets/86799cdc-0e83-45c4-8681-47798709a657" />

