### PR TITLE
Include referenced prerequisites in project-scoped SDK payloads

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -18979,8 +18979,9 @@ paths:
                   type: boolean
                 includeReferencedPrerequisites:
                   description: >-
-                    Carry prerequisite features into this payload even when they
-                    target other projects. Defaults to true for new connections.
+                    Carry prerequisite Feature Flags into this payload even when
+                    they target other Projects. Defaults to true for new
+                    connections.
                   type: boolean
               required:
                 - name
@@ -19099,8 +19100,9 @@ paths:
                   type: boolean
                 includeReferencedPrerequisites:
                   description: >-
-                    Carry prerequisite features into this payload even when they
-                    target other projects. Defaults to true for new connections.
+                    Carry prerequisite Feature Flags into this payload even when
+                    they target other Projects. Defaults to true for new
+                    connections.
                   type: boolean
               additionalProperties: false
       responses:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -18977,6 +18977,11 @@ paths:
                   type: boolean
                 savedGroupReferencesEnabled:
                   type: boolean
+                includeReferencedPrerequisites:
+                  description: >-
+                    Carry prerequisite features into this payload even when they
+                    target other projects. Defaults to true for new connections.
+                  type: boolean
               required:
                 - name
                 - language
@@ -19091,6 +19096,11 @@ paths:
                 remoteEvalEnabled:
                   type: boolean
                 savedGroupReferencesEnabled:
+                  type: boolean
+                includeReferencedPrerequisites:
+                  description: >-
+                    Carry prerequisite features into this payload even when they
+                    target other projects. Defaults to true for new connections.
                   type: boolean
               additionalProperties: false
       responses:
@@ -56925,6 +56935,8 @@ components:
         remoteEvalEnabled:
           type: boolean
         savedGroupReferencesEnabled:
+          type: boolean
+        includeReferencedPrerequisites:
           type: boolean
       required:
         - id

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -18979,8 +18979,9 @@ paths:
                   type: boolean
                 includeReferencedPrerequisites:
                   description: >-
-                    Carry prerequisite features into this payload even when they
-                    target other projects. Defaults to true for new connections.
+                    Carry prerequisite Feature Flags into this payload even when
+                    they target other Projects. Defaults to true for new
+                    connections.
                   type: boolean
               required:
                 - name
@@ -19099,8 +19100,9 @@ paths:
                   type: boolean
                 includeReferencedPrerequisites:
                   description: >-
-                    Carry prerequisite features into this payload even when they
-                    target other projects. Defaults to true for new connections.
+                    Carry prerequisite Feature Flags into this payload even when
+                    they target other Projects. Defaults to true for new
+                    connections.
                   type: boolean
               additionalProperties: false
       responses:

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -18977,6 +18977,11 @@ paths:
                   type: boolean
                 savedGroupReferencesEnabled:
                   type: boolean
+                includeReferencedPrerequisites:
+                  description: >-
+                    Carry prerequisite features into this payload even when they
+                    target other projects. Defaults to true for new connections.
+                  type: boolean
               required:
                 - name
                 - language
@@ -19091,6 +19096,11 @@ paths:
                 remoteEvalEnabled:
                   type: boolean
                 savedGroupReferencesEnabled:
+                  type: boolean
+                includeReferencedPrerequisites:
+                  description: >-
+                    Carry prerequisite features into this payload even when they
+                    target other projects. Defaults to true for new connections.
                   type: boolean
               additionalProperties: false
       responses:
@@ -56925,6 +56935,8 @@ components:
         remoteEvalEnabled:
           type: boolean
         savedGroupReferencesEnabled:
+          type: boolean
+        includeReferencedPrerequisites:
           type: boolean
       required:
         - id

--- a/packages/back-end/src/api/sdk-connections/validations.ts
+++ b/packages/back-end/src/api/sdk-connections/validations.ts
@@ -62,6 +62,7 @@ interface CreateSdkConnectionRequestBody
   includeCustomFieldsInMetadata?: boolean;
   allowedCustomFieldsInMetadata?: string[];
   includeTagsInMetadata?: boolean;
+  includeReferencedPrerequisites?: boolean;
   proxyHost?: string;
   hashSecureAttributes?: boolean;
 }

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -422,6 +422,7 @@ export type SDKPayloadParams = Pick<
   | "includeCustomFieldsInMetadata"
   | "allowedCustomFieldsInMetadata"
   | "includeTagsInMetadata"
+  | "includeReferencedPrerequisites"
 > &
   Partial<Pick<SDKConnectionInterface, "organization">> & {
     // Extend languages to allow "legacy" for old API keys
@@ -468,6 +469,7 @@ export async function getPayloadParamsFromApiKey(
       hashSecureAttributes: connection.hashSecureAttributes,
       remoteEvalEnabled: connection.remoteEvalEnabled,
       savedGroupReferencesEnabled: connection.savedGroupReferencesEnabled,
+      includeReferencedPrerequisites: connection.includeReferencedPrerequisites,
       languages: connection.languages,
       sdkVersion: connection.sdkVersion,
     };
@@ -588,6 +590,7 @@ export async function getFeatureDefinitionsWithCache({
           ? params.savedGroupReferencesEnabled &&
             capabilities.includes("savedGroupReferences")
           : undefined,
+      includeReferencedPrerequisites: params.includeReferencedPrerequisites,
     });
 
     // Write back to cache to populate it for future reads (fire and forget)

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -515,11 +515,17 @@ export async function getAllFeatures(
   context: ReqContext | ApiReqContext,
   {
     projects,
+    ids,
     includeArchived = false,
-  }: { projects?: string[]; includeArchived?: boolean } = {},
+  }: { projects?: string[]; ids?: string[]; includeArchived?: boolean } = {},
 ): Promise<FeatureInterface[]> {
   const q: FilterQuery<FeatureDocument> = { organization: context.org.id };
-  if (projects && projects.length) {
+  // An explicit id list is its own scope — used to pull in prerequisites that a
+  // project filter would otherwise hide (see loadMissingPrerequisites).
+  if (ids) {
+    if (!ids.length) return [];
+    q.id = { $in: ids };
+  } else if (projects && projects.length) {
     Object.assign(q, targetingScopedProjectClause(projects));
   }
 

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -520,8 +520,7 @@ export async function getAllFeatures(
   }: { projects?: string[]; ids?: string[]; includeArchived?: boolean } = {},
 ): Promise<FeatureInterface[]> {
   const q: FilterQuery<FeatureDocument> = { organization: context.org.id };
-  // An explicit id list is its own scope — used to pull in prerequisites that a
-  // project filter would otherwise hide (see loadMissingPrerequisites).
+  // An explicit id list is its own scope, ignoring `projects`.
   if (ids) {
     if (!ids.length) return [];
     q.id = { $in: ids };

--- a/packages/back-end/src/models/SdkConnectionModel.ts
+++ b/packages/back-end/src/models/SdkConnectionModel.ts
@@ -231,16 +231,20 @@ export async function createSDKConnection(
   context: ReqContext | ApiReqContext,
   params: CreateSDKConnectionParams,
 ) {
-  const { proxyEnabled, proxyHost, languages, ...otherParams } =
-    createSDKConnectionValidator.parse(params);
+  const {
+    proxyEnabled,
+    proxyHost,
+    languages,
+    // Written explicitly so "absent" keeps one meaning: off, for the
+    // connections that predate the setting.
+    includeReferencedPrerequisites = true,
+    ...otherParams
+  } = createSDKConnectionValidator.parse(params);
 
   // TODO: if using a proxy, try to validate the connection
   const connection: SDKConnectionInterface = {
     ...otherParams,
-    // Written explicitly so "absent" keeps one meaning: off, for the connections
-    // that predate the setting.
-    includeReferencedPrerequisites:
-      otherParams.includeReferencedPrerequisites ?? true,
+    includeReferencedPrerequisites,
     organization: context.org.id,
     languages: languages as SDKLanguage[],
     id: uniqid("sdk_"),

--- a/packages/back-end/src/models/SdkConnectionModel.ts
+++ b/packages/back-end/src/models/SdkConnectionModel.ts
@@ -237,9 +237,8 @@ export async function createSDKConnection(
   // TODO: if using a proxy, try to validate the connection
   const connection: SDKConnectionInterface = {
     ...otherParams,
-    // Written explicitly rather than left absent, so "absent" keeps a single
-    // meaning (off, every connection predating the setting) instead of one that
-    // depends on when the connection was created.
+    // Written explicitly so "absent" keeps one meaning: off, for the connections
+    // that predate the setting.
     includeReferencedPrerequisites:
       otherParams.includeReferencedPrerequisites ?? true,
     organization: context.org.id,

--- a/packages/back-end/src/models/SdkConnectionModel.ts
+++ b/packages/back-end/src/models/SdkConnectionModel.ts
@@ -73,6 +73,7 @@ const sdkConnectionSchema = new mongoose.Schema({
   allowedCustomFieldsInMetadata: [String],
   includeTagsInMetadata: Boolean,
   includeExperimentScheduleInMetadata: Boolean,
+  includeReferencedPrerequisites: Boolean,
   connected: Boolean,
   remoteEvalEnabled: Boolean,
   savedGroupReferencesEnabled: Boolean,
@@ -215,6 +216,7 @@ export const createSDKConnectionValidator = z
     proxyHost: z.string().optional(),
     remoteEvalEnabled: z.boolean().optional(),
     savedGroupReferencesEnabled: z.boolean().optional(),
+    includeReferencedPrerequisites: z.boolean().optional(),
     managedBy: managedByValidator.optional(),
   })
   .strict();
@@ -235,6 +237,11 @@ export async function createSDKConnection(
   // TODO: if using a proxy, try to validate the connection
   const connection: SDKConnectionInterface = {
     ...otherParams,
+    // Written explicitly rather than left absent, so "absent" keeps a single
+    // meaning (off, every connection predating the setting) instead of one that
+    // depends on when the connection was created.
+    includeReferencedPrerequisites:
+      otherParams.includeReferencedPrerequisites ?? true,
     organization: context.org.id,
     languages: languages as SDKLanguage[],
     id: uniqid("sdk_"),
@@ -323,6 +330,7 @@ export const editSDKConnectionValidator = z
     includeExperimentScheduleInMetadata: z.boolean().optional(),
     remoteEvalEnabled: z.boolean().optional(),
     savedGroupReferencesEnabled: z.boolean().optional(),
+    includeReferencedPrerequisites: z.boolean().optional(),
     eventTracker: z.string().optional(),
   })
   .strict();
@@ -394,6 +402,7 @@ export async function editSDKConnection(
     "includeTagsInMetadata",
     "includeExperimentScheduleInMetadata",
     "savedGroupReferencesEnabled",
+    "includeReferencedPrerequisites",
   ] as const;
   keysRequiringProxyUpdate.forEach((key) => {
     if (key in otherChanges && !isEqual(otherChanges[key], connection[key])) {
@@ -656,5 +665,6 @@ export function toApiSDKConnectionInterface(
     proxySigningKey: connection.proxy.signingKey,
     remoteEvalEnabled: connection.remoteEvalEnabled,
     savedGroupReferencesEnabled: connection.savedGroupReferencesEnabled,
+    includeReferencedPrerequisites: connection.includeReferencedPrerequisites,
   };
 }

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -234,9 +234,8 @@ export function generateFeaturesPayload({
   includeDraftExperimentRefs?: boolean;
   rampMonitoredRuleMap?: Map<string, RampMonitoredRuleInfo>;
   payloadProjects?: string[];
-  // Features pulled in by prerequisite closure. They are delivered outside their
-  // own targeting, so the connection's project set would filter away every rule
-  // they have; they are built against their own delivery scope instead.
+  // Carried by prerequisite closure: built against their own delivery scope,
+  // since the connection's projects would filter away every rule they have.
   carriedPrerequisiteIds?: Set<string>;
 }): Record<string, FeatureDefinition> {
   const defs: Record<string, FeatureDefinition> = {};
@@ -942,13 +941,17 @@ export async function refreshSDKPayloadCache({
     getAllURLRedirectExperiments(context, experimentMap),
   ]);
 
-  // Prerequisite closure delivers a feature into payloads its own projects don't
-  // name, so a change to it produces keys that miss them. Widen before matching
-  // connections. Costs nothing when no prerequisite crosses a project boundary.
+  // Widen before matching connections; a no-op when no prerequisite crosses a
+  // project boundary. Re-applies the skip, which reach can otherwise undo.
   payloadKeys = expandPayloadKeysForPrerequisites(
     payloadKeys,
     buildPrerequisiteProjectReach(allFeatures),
   );
+  if (skipRefreshForProject) {
+    payloadKeys = payloadKeys.filter(
+      (k) => k.project !== skipRefreshForProject,
+    );
+  }
 
   const rawData: Omit<SDKPayloadRawData, "holdoutsMap"> = {
     features: allFeatures,
@@ -1374,9 +1377,8 @@ export type SDKPayloadRawData = {
   // holdoutsMapByEnv) instead of re-parsing every JSON constant for every
   // connection. When omitted, generateFeaturesPayload builds it from `constants`.
   constantMap?: ConstantValueMap | null;
-  // Pre-built id -> feature lookup over `features`. Hoisted for the same reason
-  // as `constantMap`: prerequisite closure needs it per connection, and the bulk
-  // refresh would otherwise rebuild it for every one. Built here when omitted.
+  // Hoisted for the same reason as `constantMap`: prerequisite closure needs it
+  // per connection. Built in generateFeaturesPayload when omitted.
   featuresMap?: Map<string, FeatureInterface>;
 };
 
@@ -1469,10 +1471,8 @@ export async function buildSDKPayloadForConnection(
         )
       : data.features;
 
-  // Prerequisites a delivered feature gates on ride along even when they target
-  // other projects. Skipped when the connection can't evaluate prerequisites at
-  // all (those features are folded or excluded downstream, so carrying parents
-  // would be waste), and when nothing was filtered out to begin with.
+  // Skipped when the connection can't evaluate prerequisites at all — those
+  // features are folded or excluded downstream, so carrying parents is waste.
   const canEvaluatePrerequisites =
     capabilities === undefined || capabilities.includes("prerequisites");
   const { features: filteredFeatures, carried: carriedPrerequisiteIds } =
@@ -1673,14 +1673,12 @@ export type FeatureDefinitionSDKPayload = {
   encryptedContextualBandits?: string;
 };
 
-// Chains are shallow in practice; the bound only stops a pathological one from
-// issuing a query per hop forever.
+// Bounds a pathological chain issuing a query per hop.
 const MAX_PREREQUISITE_LOAD_ROUNDS = 10;
 
-// Project-filtered loads can't see a prerequisite that targets other projects, so
-// closure at payload-build time would find nothing to carry. Pull the missing
-// parents in, then their parents, until the graph closes. Costs no extra query
-// when nothing crosses a project boundary.
+// A project-filtered load can't see a prerequisite targeting other projects, so
+// closure would find nothing to carry. Costs no extra query when nothing crosses
+// a project boundary.
 async function loadMissingPrerequisites(
   context: ReqContext | ApiReqContext,
   features: FeatureInterface[],
@@ -1725,18 +1723,32 @@ export async function getFeatureDefinitions(
     allFeatures = await loadMissingPrerequisites(context, allFeatures);
   }
   const groupMap = await getSavedGroupMap(context, allSavedGroups);
-  const experimentMap = await getAllPayloadExperiments(
+  let experimentMap = await getAllPayloadExperiments(
     context,
     projectFilter,
     getReferenceIdsInFeatures(allFeatures, "experiment-ref"),
   );
-  // Experiment phase gates are only visible once the experiments are loaded.
+  // Phase gates are only visible once the experiments are loaded.
   if (projectFilter && args.includeReferencedPrerequisites) {
-    allFeatures = await loadMissingPrerequisites(
+    const expanded = await loadMissingPrerequisites(
       context,
       allFeatures,
       getPrerequisiteIdsInFeatures(allFeatures, experimentMap),
     );
+    if (expanded.length !== allFeatures.length) {
+      allFeatures = expanded;
+      const referenced = getReferenceIdsInFeatures(
+        allFeatures,
+        "experiment-ref",
+      );
+      if (referenced.some((id) => !experimentMap.has(id))) {
+        experimentMap = await getAllPayloadExperiments(
+          context,
+          projectFilter,
+          referenced,
+        );
+      }
+    }
   }
   const safeRolloutMap =
     await context.models.safeRollout.getAllPayloadSafeRollouts();

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -941,11 +941,12 @@ export async function refreshSDKPayloadCache({
     getAllURLRedirectExperiments(context, experimentMap),
   ]);
 
-  // Widen before matching connections; a no-op when no prerequisite crosses a
-  // project boundary. Re-applies the skip, which reach can otherwise undo.
-  // Only an all-projects dependent needs the full project list, and this context
-  // is fresh, so its cache is cold — don't pay for the query otherwise.
+  // Only an all-projects dependent needs the project list, and this context is
+  // fresh, so its cache is cold — don't pay for the query otherwise.
   const hasAllProjectsFeature = allFeatures.some((f) => f.targetingAllProjects);
+
+  // Widen before matching connections; a no-op when no prerequisite crosses a
+  // project boundary.
   payloadKeys = expandPayloadKeysForPrerequisites(
     payloadKeys,
     buildPrerequisiteProjectReach(
@@ -954,6 +955,8 @@ export async function refreshSDKPayloadCache({
       experimentMap,
     ),
   );
+
+  // Widening can reintroduce a project the caller asked to skip.
   if (skipRefreshForProject) {
     payloadKeys = payloadKeys.filter(
       (k) => k.project !== skipRefreshForProject,
@@ -1385,7 +1388,7 @@ export type SDKPayloadRawData = {
   // connection. When omitted, generateFeaturesPayload builds it from `constants`.
   constantMap?: ConstantValueMap | null;
   // Hoisted for the same reason as `constantMap`: prerequisite closure needs it
-  // per connection. Built in generateFeaturesPayload when omitted.
+  // per connection. Built in buildSDKPayloadForConnection when omitted.
   featuresMap?: Map<string, FeatureInterface>;
 };
 

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -28,6 +28,7 @@ import {
   getDependentFeatures,
   getSavedGroupsValuesFromGroupMap,
   getSavedGroupsValuesFromInterfaces,
+  getTargetingProjectIds,
   isDefined,
   namespacesToMap,
   recursiveWalk,
@@ -141,7 +142,11 @@ import {
   getHoldoutFeatureDefId,
   getParsedCondition,
   pairedWeightsToPositional,
+  buildPrerequisiteProjectReach,
+  expandPayloadKeysForPrerequisites,
   experimentMapForFeatures,
+  featuresWithPrerequisiteClosure,
+  getPrerequisiteIdsInFeatures,
   getReferenceIdsInFeatures,
 } from "back-end/src/util/features";
 import { bucketRulesByEnv } from "back-end/src/util/toLegacy";
@@ -197,6 +202,7 @@ export function generateFeaturesPayload({
   includeDraftExperimentRefs,
   rampMonitoredRuleMap,
   payloadProjects,
+  carriedPrerequisiteIds,
 }: {
   features: FeatureInterface[];
   experimentMap: Map<string, ExperimentInterface>;
@@ -228,6 +234,10 @@ export function generateFeaturesPayload({
   includeDraftExperimentRefs?: boolean;
   rampMonitoredRuleMap?: Map<string, RampMonitoredRuleInfo>;
   payloadProjects?: string[];
+  // Features pulled in by prerequisite closure. They are delivered outside their
+  // own targeting, so the connection's project set would filter away every rule
+  // they have; they are built against their own delivery scope instead.
+  carriedPrerequisiteIds?: Set<string>;
 }): Record<string, FeatureDefinition> {
   const defs: Record<string, FeatureDefinition> = {};
   const newFeatures = reduceFeaturesWithPrerequisites(
@@ -272,7 +282,9 @@ export function generateFeaturesPayload({
         includeExperimentScheduleInMetadata,
       },
       projectsMap,
-      payloadProjects,
+      payloadProjects: carriedPrerequisiteIds?.has(feature.id)
+        ? (getTargetingProjectIds(feature) ?? [])
+        : payloadProjects,
       cbMap,
       constantMap: constantMap ?? undefined,
       onConstantCycle: (key) => {
@@ -930,8 +942,17 @@ export async function refreshSDKPayloadCache({
     getAllURLRedirectExperiments(context, experimentMap),
   ]);
 
+  // Prerequisite closure delivers a feature into payloads its own projects don't
+  // name, so a change to it produces keys that miss them. Widen before matching
+  // connections. Costs nothing when no prerequisite crosses a project boundary.
+  payloadKeys = expandPayloadKeysForPrerequisites(
+    payloadKeys,
+    buildPrerequisiteProjectReach(allFeatures),
+  );
+
   const rawData: Omit<SDKPayloadRawData, "holdoutsMap"> = {
     features: allFeatures,
+    featuresMap: new Map(allFeatures.map((f) => [f.id, f])),
     experimentMap,
     groupMap,
     safeRolloutMap,
@@ -1020,6 +1041,8 @@ export async function refreshSDKPayloadCache({
             capabilities,
             environment: env,
             projects: filteredProjects,
+            includeReferencedPrerequisites:
+              connection.includeReferencedPrerequisites,
             encryptPayload: connection.encryptPayload,
             encryptionKey: connection.encryptionKey,
             includeVisualExperiments: connection.includeVisualExperiments,
@@ -1327,6 +1350,7 @@ export type FeatureDefinitionArgs = {
   includeExperimentScheduleInMetadata?: boolean;
   hashSecureAttributes?: boolean;
   savedGroupReferencesEnabled?: boolean;
+  includeReferencedPrerequisites?: boolean;
 };
 
 // Pre-fetched data to build one connection's payload. Bulk refresh shares this and adds holdoutsMap per env; may include visualExperiments/urlRedirectExperiments to avoid repeated DB queries.
@@ -1350,6 +1374,10 @@ export type SDKPayloadRawData = {
   // holdoutsMapByEnv) instead of re-parsing every JSON constant for every
   // connection. When omitted, generateFeaturesPayload builds it from `constants`.
   constantMap?: ConstantValueMap | null;
+  // Pre-built id -> feature lookup over `features`. Hoisted for the same reason
+  // as `constantMap`: prerequisite closure needs it per connection, and the bulk
+  // refresh would otherwise rebuild it for every one. Built here when omitted.
+  featuresMap?: Map<string, FeatureInterface>;
 };
 
 // Payload-relevant subset of SDK connection (plus derived capabilities). Pass through encryptPayload + encryptionKey; effective key is derived inside buildSDKPayloadForConnection.
@@ -1357,6 +1385,7 @@ export type ConnectionPayloadOptions = {
   capabilities: SDKCapability[];
   environment: string;
   projects: string[] | null;
+  includeReferencedPrerequisites?: boolean;
   encryptPayload?: boolean;
   encryptionKey?: string;
   includeVisualExperiments?: boolean;
@@ -1406,6 +1435,7 @@ export async function buildSDKPayloadForConnection(
     capabilities,
     environment = "production",
     projects,
+    includeReferencedPrerequisites,
     encryptPayload,
     encryptionKey,
     includeVisualExperiments,
@@ -1432,12 +1462,29 @@ export async function buildSDKPayloadForConnection(
   }
 
   const projectList = projects && projects.length > 0 ? projects : [];
-  const filteredFeatures =
+  const scopedFeatures =
     projectList.length > 0
       ? data.features.filter((f) =>
           projectList.some((p) => entityTargetsProject(f, p)),
         )
       : data.features;
+
+  // Prerequisites a delivered feature gates on ride along even when they target
+  // other projects. Skipped when the connection can't evaluate prerequisites at
+  // all (those features are folded or excluded downstream, so carrying parents
+  // would be waste), and when nothing was filtered out to begin with.
+  const canEvaluatePrerequisites =
+    capabilities === undefined || capabilities.includes("prerequisites");
+  const { features: filteredFeatures, carried: carriedPrerequisiteIds } =
+    includeReferencedPrerequisites &&
+    canEvaluatePrerequisites &&
+    projectList.length > 0
+      ? featuresWithPrerequisiteClosure(
+          scopedFeatures,
+          data.featuresMap ?? new Map(data.features.map((f) => [f.id, f])),
+          data.experimentMap,
+        )
+      : { features: scopedFeatures, carried: new Set<string>() };
   const filteredExperimentMap =
     projectList.length > 0
       ? new Map(
@@ -1527,6 +1574,7 @@ export async function buildSDKPayloadForConnection(
     includeExperimentScheduleInMetadata,
     projectsMap,
     payloadProjects: projectList,
+    carriedPrerequisiteIds,
     cbMap,
     rampMonitoredRuleMap: data.rampMonitoredRuleMap,
   });
@@ -1625,21 +1673,71 @@ export type FeatureDefinitionSDKPayload = {
   encryptedContextualBandits?: string;
 };
 
+// Chains are shallow in practice; the bound only stops a pathological one from
+// issuing a query per hop forever.
+const MAX_PREREQUISITE_LOAD_ROUNDS = 10;
+
+// Project-filtered loads can't see a prerequisite that targets other projects, so
+// closure at payload-build time would find nothing to carry. Pull the missing
+// parents in, then their parents, until the graph closes. Costs no extra query
+// when nothing crosses a project boundary.
+async function loadMissingPrerequisites(
+  context: ReqContext | ApiReqContext,
+  features: FeatureInterface[],
+  seedIds: string[] = [],
+): Promise<FeatureInterface[]> {
+  const present = new Set(features.map((f) => f.id));
+  const out = [...features];
+
+  let wanted = [
+    ...new Set([...getPrerequisiteIdsInFeatures(features), ...seedIds]),
+  ].filter((id) => !present.has(id));
+
+  for (
+    let round = 0;
+    wanted.length && round < MAX_PREREQUISITE_LOAD_ROUNDS;
+    round++
+  ) {
+    const loaded = await getAllFeatures(context, { ids: wanted });
+    if (!loaded.length) break;
+    loaded.forEach((f) => {
+      present.add(f.id);
+      out.push(f);
+    });
+    wanted = getPrerequisiteIdsInFeatures(loaded).filter(
+      (id) => !present.has(id),
+    );
+  }
+
+  return out;
+}
+
 export async function getFeatureDefinitions(
   args: FeatureDefinitionArgs,
 ): Promise<FeatureDefinitionSDKPayload> {
   const { context, environment = "production", projects } = args;
   const projectFilter = projects && projects.length > 0 ? projects : undefined;
   const allSavedGroups = await context.models.savedGroups.getAll();
-  const allFeatures = await getAllFeatures(context, {
+  let allFeatures = await getAllFeatures(context, {
     projects: projectFilter,
   });
+  if (projectFilter && args.includeReferencedPrerequisites) {
+    allFeatures = await loadMissingPrerequisites(context, allFeatures);
+  }
   const groupMap = await getSavedGroupMap(context, allSavedGroups);
   const experimentMap = await getAllPayloadExperiments(
     context,
     projectFilter,
     getReferenceIdsInFeatures(allFeatures, "experiment-ref"),
   );
+  // Experiment phase gates are only visible once the experiments are loaded.
+  if (projectFilter && args.includeReferencedPrerequisites) {
+    allFeatures = await loadMissingPrerequisites(
+      context,
+      allFeatures,
+      getPrerequisiteIdsInFeatures(allFeatures, experimentMap),
+    );
+  }
   const safeRolloutMap =
     await context.models.safeRollout.getAllPayloadSafeRollouts();
   const holdoutsMap =
@@ -1653,6 +1751,7 @@ export async function getFeatureDefinitions(
       capabilities: args.capabilities,
       environment,
       projects: projects ?? null,
+      includeReferencedPrerequisites: args.includeReferencedPrerequisites,
       encryptPayload: args.encryptPayload,
       encryptionKey: args.encryptionKey,
       includeVisualExperiments: args.includeVisualExperiments,

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -943,9 +943,16 @@ export async function refreshSDKPayloadCache({
 
   // Widen before matching connections; a no-op when no prerequisite crosses a
   // project boundary. Re-applies the skip, which reach can otherwise undo.
+  // Only an all-projects dependent needs the full project list, and this context
+  // is fresh, so its cache is cold — don't pay for the query otherwise.
+  const hasAllProjectsFeature = allFeatures.some((f) => f.targetingAllProjects);
   payloadKeys = expandPayloadKeysForPrerequisites(
     payloadKeys,
-    buildPrerequisiteProjectReach(allFeatures),
+    buildPrerequisiteProjectReach(
+      allFeatures,
+      hasAllProjectsFeature ? await context.getAllProjectIds() : [],
+      experimentMap,
+    ),
   );
   if (skipRefreshForProject) {
     payloadKeys = payloadKeys.filter(

--- a/packages/back-end/src/util/features.ts
+++ b/packages/back-end/src/util/features.ts
@@ -647,10 +647,8 @@ export function experimentMapForFeatures(
   );
 }
 
-// Prerequisite feature ids a set of features gates on: top-level gates, gates on
-// an enabled rule, and the phase gates of any experiment those rules reference.
-// All three become `parentConditions` in the payload, so all three need the
-// parent present for the gate to be evaluable.
+// Gates live in three places — the feature, its rules, and the phases of any
+// experiment those rules reference — and all three become `parentConditions`.
 export function getPrerequisiteIdsInFeatures(
   features: FeatureInterface[],
   experimentMap?: Map<string, ExperimentInterface>,
@@ -662,7 +660,6 @@ export function getPrerequisiteIdsInFeatures(
 
     (feature.rules ?? []).forEach((rule) => {
       if (!rule || typeof rule !== "object") return;
-      // Disabled rules never render, so what they gate on is not needed.
       if (rule.enabled === false) return;
 
       (rule.prerequisites ?? []).forEach((p) => p?.id && ids.add(p.id));
@@ -678,14 +675,8 @@ export function getPrerequisiteIdsInFeatures(
   return [...ids];
 }
 
-// A prerequisite a delivered feature gates on belongs in that feature's payload
-// even when the parent targets other projects. Without it the gate resolves
-// against a missing feature, which can never pass, and the dependent silently
-// fails closed. Transitive: a parent's own prerequisites come too.
-//
-// `carried` is the set of ids pulled in this way. They are delivered outside
-// their own targeting, so their rules must be built against their own delivery
-// scope rather than the connection's — see `getFeatureDefinition`.
+// A gate whose parent is absent from the payload can never pass, so a delivered
+// feature's prerequisites travel with it even when they target other projects.
 export function featuresWithPrerequisiteClosure(
   features: FeatureInterface[],
   featuresMap: Map<string, FeatureInterface>,
@@ -700,7 +691,6 @@ export function featuresWithPrerequisiteClosure(
     for (const id of getPrerequisiteIdsInFeatures(frontier, experimentMap)) {
       if (present.has(id)) continue;
       const parent = featuresMap.get(id);
-      // A missing parent is a dangling reference, not something to carry.
       if (!parent) continue;
       present.add(id);
       carried.add(id);
@@ -717,15 +707,10 @@ export function featuresWithPrerequisiteClosure(
   };
 }
 
-// Feature A gating on prerequisite B means every payload that delivers A also
-// carries B (see featuresWithPrerequisiteClosure). A change to B only produces
-// payload keys for B's own projects, so those payloads would go stale. This maps
-// a project to the projects whose payloads may carry a feature from it, so the
-// affected keys can be widened.
-//
-// Project-level rather than feature-level so it can be built once per refresh
-// and applied without knowing which feature changed. Orgs with no cross-project
-// prerequisites get an empty map and no extra work.
+// Closure delivers a parent into payloads its own projects don't name, and a
+// change to it only produces keys for those projects. Maps a project to the
+// projects whose payloads may carry a feature from it, so the keys can be
+// widened without knowing which feature changed.
 export function buildPrerequisiteProjectReach(
   features: FeatureInterface[],
 ): Map<string, Set<string>> {
@@ -740,8 +725,7 @@ export function buildPrerequisiteProjectReach(
   };
 
   for (const dependent of features) {
-    // A dependent that targets all projects is in every payload already; the
-    // parent still needs to reach those payloads, so leave it to the "" key.
+    // All-projects entities are served by the "" key already.
     const dependentProjects = getTargetingProjectIds(dependent);
     if (dependentProjects === null) continue;
 
@@ -756,8 +740,7 @@ export function buildPrerequisiteProjectReach(
     }
   }
 
-  // Chains: a grandparent reaches wherever its parent reaches. The project graph
-  // is small, so a simple fixpoint is cheaper than tracking the feature graph.
+  // A grandparent reaches wherever its parent reaches.
   let changed = true;
   while (changed) {
     changed = false;
@@ -776,8 +759,6 @@ export function buildPrerequisiteProjectReach(
   return reach;
 }
 
-// Widen payload keys so a change to a feature that something gates on also
-// refreshes the payloads carrying it as a prerequisite.
 export function expandPayloadKeysForPrerequisites(
   payloadKeys: SDKPayloadKey[],
   reach: Map<string, Set<string>>,

--- a/packages/back-end/src/util/features.ts
+++ b/packages/back-end/src/util/features.ts
@@ -647,6 +647,159 @@ export function experimentMapForFeatures(
   );
 }
 
+// Prerequisite feature ids a set of features gates on: top-level gates, gates on
+// an enabled rule, and the phase gates of any experiment those rules reference.
+// All three become `parentConditions` in the payload, so all three need the
+// parent present for the gate to be evaluable.
+export function getPrerequisiteIdsInFeatures(
+  features: FeatureInterface[],
+  experimentMap?: Map<string, ExperimentInterface>,
+): string[] {
+  const ids = new Set<string>();
+
+  features.forEach((feature) => {
+    (feature.prerequisites ?? []).forEach((p) => p?.id && ids.add(p.id));
+
+    (feature.rules ?? []).forEach((rule) => {
+      if (!rule || typeof rule !== "object") return;
+      // Disabled rules never render, so what they gate on is not needed.
+      if (rule.enabled === false) return;
+
+      (rule.prerequisites ?? []).forEach((p) => p?.id && ids.add(p.id));
+
+      if (!experimentMap || rule.type !== "experiment-ref") return;
+      const phase = experimentMap
+        .get(rule.experimentId)
+        ?.phases?.slice(-1)?.[0];
+      (phase?.prerequisites ?? []).forEach((p) => p?.id && ids.add(p.id));
+    });
+  });
+
+  return [...ids];
+}
+
+// A prerequisite a delivered feature gates on belongs in that feature's payload
+// even when the parent targets other projects. Without it the gate resolves
+// against a missing feature, which can never pass, and the dependent silently
+// fails closed. Transitive: a parent's own prerequisites come too.
+//
+// `carried` is the set of ids pulled in this way. They are delivered outside
+// their own targeting, so their rules must be built against their own delivery
+// scope rather than the connection's — see `getFeatureDefinition`.
+export function featuresWithPrerequisiteClosure(
+  features: FeatureInterface[],
+  featuresMap: Map<string, FeatureInterface>,
+  experimentMap?: Map<string, ExperimentInterface>,
+): { features: FeatureInterface[]; carried: Set<string> } {
+  const carried = new Set<string>();
+  const present = new Set(features.map((f) => f.id));
+
+  let frontier = features;
+  while (frontier.length) {
+    const next: FeatureInterface[] = [];
+    for (const id of getPrerequisiteIdsInFeatures(frontier, experimentMap)) {
+      if (present.has(id)) continue;
+      const parent = featuresMap.get(id);
+      // A missing parent is a dangling reference, not something to carry.
+      if (!parent) continue;
+      present.add(id);
+      carried.add(id);
+      next.push(parent);
+    }
+    frontier = next;
+  }
+
+  return {
+    features: carried.size
+      ? [...features, ...[...carried].map((id) => featuresMap.get(id)!)]
+      : features,
+    carried,
+  };
+}
+
+// Feature A gating on prerequisite B means every payload that delivers A also
+// carries B (see featuresWithPrerequisiteClosure). A change to B only produces
+// payload keys for B's own projects, so those payloads would go stale. This maps
+// a project to the projects whose payloads may carry a feature from it, so the
+// affected keys can be widened.
+//
+// Project-level rather than feature-level so it can be built once per refresh
+// and applied without knowing which feature changed. Orgs with no cross-project
+// prerequisites get an empty map and no extra work.
+export function buildPrerequisiteProjectReach(
+  features: FeatureInterface[],
+): Map<string, Set<string>> {
+  const featuresMap = new Map(features.map((f) => [f.id, f]));
+  const reach = new Map<string, Set<string>>();
+
+  const link = (from: string, to: string) => {
+    if (!from || !to || from === to) return;
+    const set = reach.get(from) ?? new Set<string>();
+    set.add(to);
+    reach.set(from, set);
+  };
+
+  for (const dependent of features) {
+    // A dependent that targets all projects is in every payload already; the
+    // parent still needs to reach those payloads, so leave it to the "" key.
+    const dependentProjects = getTargetingProjectIds(dependent);
+    if (dependentProjects === null) continue;
+
+    for (const parentId of getPrerequisiteIdsInFeatures([dependent])) {
+      const parent = featuresMap.get(parentId);
+      if (!parent) continue;
+      const parentProjects = getTargetingProjectIds(parent);
+      if (parentProjects === null) continue;
+      parentProjects.forEach((from) =>
+        dependentProjects.forEach((to) => link(from, to)),
+      );
+    }
+  }
+
+  // Chains: a grandparent reaches wherever its parent reaches. The project graph
+  // is small, so a simple fixpoint is cheaper than tracking the feature graph.
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const [from, tos] of reach) {
+      for (const to of [...tos]) {
+        for (const onward of reach.get(to) ?? []) {
+          if (onward !== from && !tos.has(onward)) {
+            tos.add(onward);
+            changed = true;
+          }
+        }
+      }
+    }
+  }
+
+  return reach;
+}
+
+// Widen payload keys so a change to a feature that something gates on also
+// refreshes the payloads carrying it as a prerequisite.
+export function expandPayloadKeysForPrerequisites(
+  payloadKeys: SDKPayloadKey[],
+  reach: Map<string, Set<string>>,
+): SDKPayloadKey[] {
+  if (!reach.size) return payloadKeys;
+
+  const out = [...payloadKeys];
+  const seen = new Set(payloadKeys.map((k) => JSON.stringify(k)));
+
+  payloadKeys.forEach(({ environment, project }) => {
+    (reach.get(project) ?? []).forEach((p) => {
+      const key = { environment, project: p };
+      const s = JSON.stringify(key);
+      if (seen.has(s)) return;
+      seen.add(s);
+      out.push(key);
+    });
+  });
+
+  return out;
+}
+
 export function getAffectedSDKPayloadKeys(
   features: FeatureInterface[],
   allowedEnvs: string[],

--- a/packages/back-end/src/util/features.ts
+++ b/packages/back-end/src/util/features.ts
@@ -713,6 +713,8 @@ export function featuresWithPrerequisiteClosure(
 // widened without knowing which feature changed.
 export function buildPrerequisiteProjectReach(
   features: FeatureInterface[],
+  allProjectIds: string[] = [],
+  experimentMap?: Map<string, ExperimentInterface>,
 ): Map<string, Set<string>> {
   const featuresMap = new Map(features.map((f) => [f.id, f]));
   const reach = new Map<string, Set<string>>();
@@ -725,11 +727,16 @@ export function buildPrerequisiteProjectReach(
   };
 
   for (const dependent of features) {
-    // All-projects entities are served by the "" key already.
-    const dependentProjects = getTargetingProjectIds(dependent);
-    if (dependentProjects === null) continue;
+    // An all-projects dependent is delivered everywhere, so its prerequisites
+    // are carried everywhere. The "" key doesn't cover that: it only reaches
+    // connections with no project filter unless treatEmptyProjectAsGlobal.
+    const dependentProjects =
+      getTargetingProjectIds(dependent) ?? allProjectIds;
 
-    for (const parentId of getPrerequisiteIdsInFeatures([dependent])) {
+    for (const parentId of getPrerequisiteIdsInFeatures(
+      [dependent],
+      experimentMap,
+    )) {
       const parent = featuresMap.get(parentId);
       if (!parent) continue;
       const parentProjects = getTargetingProjectIds(parent);

--- a/packages/back-end/src/util/features.ts
+++ b/packages/back-end/src/util/features.ts
@@ -707,10 +707,10 @@ export function featuresWithPrerequisiteClosure(
   };
 }
 
-// Closure delivers a parent into payloads its own projects don't name, and a
-// change to it only produces keys for those projects. Maps a project to the
-// projects whose payloads may carry a feature from it, so the keys can be
-// widened without knowing which feature changed.
+// Closure delivers a parent into payloads its own projects don't name, so a
+// change to it produces keys that miss them. Maps a project to the projects
+// whose payloads may carry a feature from it, so keys can be widened without
+// knowing which feature changed.
 export function buildPrerequisiteProjectReach(
   features: FeatureInterface[],
   allProjectIds: string[] = [],
@@ -727,9 +727,9 @@ export function buildPrerequisiteProjectReach(
   };
 
   for (const dependent of features) {
-    // An all-projects dependent is delivered everywhere, so its prerequisites
-    // are carried everywhere. The "" key doesn't cover that: it only reaches
-    // connections with no project filter unless treatEmptyProjectAsGlobal.
+    // An all-projects dependent carries its prerequisites everywhere. The ""
+    // key doesn't cover that — it only reaches connections with no project
+    // filter unless treatEmptyProjectAsGlobal.
     const dependentProjects =
       getTargetingProjectIds(dependent) ?? allProjectIds;
 

--- a/packages/back-end/test/crossProjectPrerequisites.test.ts
+++ b/packages/back-end/test/crossProjectPrerequisites.test.ts
@@ -215,6 +215,39 @@ describe("buildPrerequisiteProjectReach", () => {
     expect([...(reach.get("prj_a") ?? [])].sort()).toEqual(["prj_b", "prj_c"]);
   });
 
+  it("reaches every project when the dependent targets all projects", () => {
+    const child = feature("child", "prj_b", {
+      prerequisites: ["root"],
+      targetingAllProjects: true,
+    });
+    const root = feature("root", "prj_a");
+
+    const reach = buildPrerequisiteProjectReach(
+      [child, root],
+      ["prj_a", "prj_b", "prj_c"],
+    );
+
+    expect([...(reach.get("prj_a") ?? [])].sort()).toEqual(["prj_b", "prj_c"]);
+  });
+
+  it("follows gates on the phase of a referenced experiment", () => {
+    const child = feature("child", "prj_b", {
+      rules: [{ experimentId: "exp_a" }],
+    });
+    const root = feature("root", "prj_a");
+    const experimentMap = new Map([
+      ["exp_a", experimentWithPhasePrereq("exp_a", "root")],
+    ]);
+
+    const reach = buildPrerequisiteProjectReach(
+      [child, root],
+      [],
+      experimentMap,
+    );
+
+    expect([...(reach.get("prj_a") ?? [])]).toEqual(["prj_b"]);
+  });
+
   it("is empty when no prerequisite crosses a project boundary", () => {
     const child = feature("child", "prj_a", { prerequisites: ["root"] });
     const root = feature("root", "prj_a");

--- a/packages/back-end/test/crossProjectPrerequisites.test.ts
+++ b/packages/back-end/test/crossProjectPrerequisites.test.ts
@@ -1,0 +1,271 @@
+import type { FeatureInterface } from "shared/types/feature";
+import type { ExperimentInterface } from "back-end/types/experiment";
+import {
+  buildPrerequisiteProjectReach,
+  expandPayloadKeysForPrerequisites,
+  featuresWithPrerequisiteClosure,
+  getPrerequisiteIdsInFeatures,
+} from "back-end/src/util/features";
+
+type RuleSpec = {
+  prerequisites?: string[];
+  experimentId?: string;
+  enabled?: boolean;
+};
+
+const feature = (
+  id: string,
+  project: string,
+  {
+    prerequisites = [],
+    rules = [],
+    targetingProjects,
+    targetingAllProjects,
+  }: {
+    prerequisites?: string[];
+    rules?: RuleSpec[];
+    targetingProjects?: string[];
+    targetingAllProjects?: boolean;
+  } = {},
+): FeatureInterface =>
+  ({
+    id,
+    project,
+    ...(targetingProjects ? { targetingProjects } : {}),
+    ...(targetingAllProjects ? { targetingAllProjects } : {}),
+    prerequisites: prerequisites.map((p) => ({ id: p, condition: "{}" })),
+    rules: rules.map((r, i) => ({
+      id: `rule-${i}`,
+      type: r.experimentId ? "experiment-ref" : "force",
+      ...(r.experimentId ? { experimentId: r.experimentId } : {}),
+      allEnvironments: true,
+      ...(r.enabled === false ? { enabled: false } : {}),
+      ...(r.prerequisites
+        ? {
+            prerequisites: r.prerequisites.map((p) => ({
+              id: p,
+              condition: "{}",
+            })),
+          }
+        : {}),
+    })),
+    environmentSettings: { production: { enabled: true } },
+  }) as unknown as FeatureInterface;
+
+const experimentWithPhasePrereq = (
+  id: string,
+  prereqId: string,
+): ExperimentInterface =>
+  ({
+    id,
+    phases: [{ prerequisites: [{ id: prereqId, condition: "{}" }] }],
+  }) as unknown as ExperimentInterface;
+
+const mapOf = (features: FeatureInterface[]) =>
+  new Map(features.map((f) => [f.id, f]));
+
+describe("getPrerequisiteIdsInFeatures", () => {
+  it("collects top-level prerequisites", () => {
+    expect(
+      getPrerequisiteIdsInFeatures([
+        feature("child", "prj_b", { prerequisites: ["root"] }),
+      ]),
+    ).toEqual(["root"]);
+  });
+
+  it("collects rule-level prerequisites", () => {
+    expect(
+      getPrerequisiteIdsInFeatures([
+        feature("child", "prj_b", { rules: [{ prerequisites: ["root"] }] }),
+      ]),
+    ).toEqual(["root"]);
+  });
+
+  it("collects prerequisites from the phase of a referenced experiment", () => {
+    const features = [
+      feature("child", "prj_b", { rules: [{ experimentId: "exp_a" }] }),
+    ];
+    const experimentMap = new Map([
+      ["exp_a", experimentWithPhasePrereq("exp_a", "root")],
+    ]);
+
+    expect(getPrerequisiteIdsInFeatures(features, experimentMap)).toEqual([
+      "root",
+    ]);
+  });
+
+  it("skips disabled rules, which never render", () => {
+    expect(
+      getPrerequisiteIdsInFeatures([
+        feature("child", "prj_b", {
+          rules: [{ prerequisites: ["root"], enabled: false }],
+        }),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("dedupes a prerequisite reached more than one way", () => {
+    expect(
+      getPrerequisiteIdsInFeatures([
+        feature("child", "prj_b", {
+          prerequisites: ["root"],
+          rules: [{ prerequisites: ["root"] }],
+        }),
+        feature("other", "prj_b", { prerequisites: ["root"] }),
+      ]),
+    ).toEqual(["root"]);
+  });
+});
+
+describe("featuresWithPrerequisiteClosure", () => {
+  // The point of the change: without the parent the gate can never pass.
+  it("carries a prerequisite that targets another project", () => {
+    const child = feature("child", "prj_b", { prerequisites: ["root"] });
+    const root = feature("root", "prj_a");
+
+    const result = featuresWithPrerequisiteClosure(
+      [child],
+      mapOf([child, root]),
+    );
+
+    expect(result.features.map((f) => f.id).sort()).toEqual(["child", "root"]);
+    expect([...result.carried]).toEqual(["root"]);
+  });
+
+  it("is transitive", () => {
+    const child = feature("child", "prj_b", { prerequisites: ["parent"] });
+    const parent = feature("parent", "prj_a", { prerequisites: ["grandpa"] });
+    const grandpa = feature("grandpa", "prj_a");
+
+    const result = featuresWithPrerequisiteClosure(
+      [child],
+      mapOf([child, parent, grandpa]),
+    );
+
+    expect(result.features.map((f) => f.id).sort()).toEqual([
+      "child",
+      "grandpa",
+      "parent",
+    ]);
+    expect([...result.carried].sort()).toEqual(["grandpa", "parent"]);
+  });
+
+  it("does not re-carry a prerequisite already delivered", () => {
+    const child = feature("child", "prj_b", { prerequisites: ["root"] });
+    const root = feature("root", "prj_b");
+
+    const result = featuresWithPrerequisiteClosure(
+      [child, root],
+      mapOf([child, root]),
+    );
+
+    expect(result.carried.size).toBe(0);
+    expect(result.features).toHaveLength(2);
+  });
+
+  it("ignores a dangling prerequisite", () => {
+    const child = feature("child", "prj_b", { prerequisites: ["gone"] });
+
+    const result = featuresWithPrerequisiteClosure([child], mapOf([child]));
+
+    expect(result.carried.size).toBe(0);
+    expect(result.features.map((f) => f.id)).toEqual(["child"]);
+  });
+
+  it("terminates on a prerequisite cycle", () => {
+    const a = feature("a", "prj_b", { prerequisites: ["b"] });
+    const b = feature("b", "prj_a", { prerequisites: ["a"] });
+
+    const result = featuresWithPrerequisiteClosure([a], mapOf([a, b]));
+
+    expect(result.features.map((f) => f.id).sort()).toEqual(["a", "b"]);
+    expect([...result.carried]).toEqual(["b"]);
+  });
+});
+
+describe("buildPrerequisiteProjectReach", () => {
+  it("maps a parent's project to the projects that carry it", () => {
+    const child = feature("child", "prj_b", { prerequisites: ["root"] });
+    const root = feature("root", "prj_a");
+
+    const reach = buildPrerequisiteProjectReach([child, root]);
+
+    expect([...(reach.get("prj_a") ?? [])]).toEqual(["prj_b"]);
+  });
+
+  it("follows the targeting projects of the dependent", () => {
+    const child = feature("child", "prj_b", {
+      prerequisites: ["root"],
+      targetingProjects: ["prj_c"],
+    });
+    const root = feature("root", "prj_a");
+
+    const reach = buildPrerequisiteProjectReach([child, root]);
+
+    expect([...(reach.get("prj_a") ?? [])].sort()).toEqual(["prj_b", "prj_c"]);
+  });
+
+  it("closes over chains", () => {
+    const child = feature("child", "prj_c", { prerequisites: ["parent"] });
+    const parent = feature("parent", "prj_b", { prerequisites: ["grandpa"] });
+    const grandpa = feature("grandpa", "prj_a");
+
+    const reach = buildPrerequisiteProjectReach([child, parent, grandpa]);
+
+    expect([...(reach.get("prj_a") ?? [])].sort()).toEqual(["prj_b", "prj_c"]);
+  });
+
+  it("is empty when no prerequisite crosses a project boundary", () => {
+    const child = feature("child", "prj_a", { prerequisites: ["root"] });
+    const root = feature("root", "prj_a");
+
+    expect(buildPrerequisiteProjectReach([child, root]).size).toBe(0);
+  });
+});
+
+describe("expandPayloadKeysForPrerequisites", () => {
+  it("adds the projects that carry the changed feature", () => {
+    const reach = new Map([["prj_a", new Set(["prj_b"])]]);
+
+    expect(
+      expandPayloadKeysForPrerequisites(
+        [{ environment: "production", project: "prj_a" }],
+        reach,
+      ),
+    ).toEqual([
+      { environment: "production", project: "prj_a" },
+      { environment: "production", project: "prj_b" },
+    ]);
+  });
+
+  it("keeps the environment of the original key", () => {
+    const reach = new Map([["prj_a", new Set(["prj_b"])]]);
+
+    expect(
+      expandPayloadKeysForPrerequisites(
+        [{ environment: "staging", project: "prj_a" }],
+        reach,
+      ),
+    ).toContainEqual({ environment: "staging", project: "prj_b" });
+  });
+
+  it("does not duplicate a key already present", () => {
+    const reach = new Map([["prj_a", new Set(["prj_b"])]]);
+
+    expect(
+      expandPayloadKeysForPrerequisites(
+        [
+          { environment: "production", project: "prj_a" },
+          { environment: "production", project: "prj_b" },
+        ],
+        reach,
+      ),
+    ).toHaveLength(2);
+  });
+
+  it("returns the keys untouched when nothing reaches", () => {
+    const keys = [{ environment: "production", project: "prj_a" }];
+
+    expect(expandPayloadKeysForPrerequisites(keys, new Map())).toBe(keys);
+  });
+});

--- a/packages/back-end/test/services/sdk-payload-lifecycle.test.ts
+++ b/packages/back-end/test/services/sdk-payload-lifecycle.test.ts
@@ -88,6 +88,7 @@ function minimalContext(overrides?: Partial<ApiReqContext>): ApiReqContext {
       settings: { environments: [{ id: "production", projects: [] }] },
     },
     models: {} as ApiReqContext["models"],
+    getAllProjectIds: async () => [],
     userId: "u1",
     email: "e@e.com",
     userName: "User",

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -191,8 +191,7 @@ export default function SDKConnectionForm({
         false,
       includeExperimentScheduleInMetadata:
         initialValue.includeExperimentScheduleInMetadata ?? false,
-      // Absent means off — connections created before the setting existed keep
-      // their behavior. New ones are created with it on.
+      // Absent = off, so existing connections keep their behavior.
       includeReferencedPrerequisites:
         initialValue.includeReferencedPrerequisites ?? !edit,
     },
@@ -668,6 +667,33 @@ export default function SDKConnectionForm({
             project being removed from the selected environment.
           </div>
         )}
+        <Box mt="3">
+          <Checkbox
+            weight="regular"
+            value={!!form.watch("includeReferencedPrerequisites")}
+            setValue={(val) =>
+              form.setValue("includeReferencedPrerequisites", val)
+            }
+            label={
+              <>
+                Include referenced prerequisite features{" "}
+                <Tooltip
+                  body={
+                    <p className="mb-0">
+                      When a feature in this payload is gated on a prerequisite
+                      that targets other projects, deliver that prerequisite
+                      too. Without it the gate can never pass, so the feature it
+                      gates is silently off. Turn this off to keep the payload
+                      strictly limited to the projects selected above.
+                    </p>
+                  }
+                >
+                  <PiInfo />
+                </Tooltip>
+              </>
+            }
+          />
+        </Box>
       </div>
 
       {shouldShowPayloadSecurity(languageType, languages) && (
@@ -1340,34 +1366,6 @@ export default function SDKConnectionForm({
               label="Include feature rule IDs in payload"
               value={!!form.watch("includeRuleIds")}
               setValue={(val) => form.setValue("includeRuleIds", val)}
-            />
-          </Box>
-          <Box>
-            <Checkbox
-              weight="regular"
-              value={!!form.watch("includeReferencedPrerequisites")}
-              setValue={(val) =>
-                form.setValue("includeReferencedPrerequisites", val)
-              }
-              label={
-                <>
-                  Include referenced prerequisite features{" "}
-                  <Tooltip
-                    body={
-                      <p className="mb-0">
-                        When a feature in this payload is gated on a
-                        prerequisite that targets other projects, include that
-                        prerequisite too. Without it the gate can never pass and
-                        the feature it gates is silently off. Turn this off to
-                        keep the payload strictly limited to this
-                        connection&apos;s projects.
-                      </p>
-                    }
-                  >
-                    <PiInfo />
-                  </Tooltip>
-                </>
-              }
             />
           </Box>
           <Box>

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -670,15 +670,6 @@ export default function SDKConnectionForm({
         <Box mt="3">
           <Checkbox
             weight="regular"
-            // A no-op on an unfiltered payload, which already carries every
-            // prerequisite. An empty selection still filters when the
-            // environment is scoped to Projects, so check both. Disabled
-            // rather than hidden: the value is still submitted.
-            disabled={
-              (form.watch("projects") || []).length === 0 &&
-              !environmentHasProjects
-            }
-            disabledMessage="Only applies when the payload is filtered by Project."
             value={!!form.watch("includeReferencedPrerequisites")}
             setValue={(val) =>
               form.setValue("includeReferencedPrerequisites", val)
@@ -691,7 +682,8 @@ export default function SDKConnectionForm({
                     <p className="mb-0">
                       Deliver prerequisite Feature Flags that target other
                       Projects. Without them, the Feature Flags they gate are
-                      always off.
+                      always off. Only applies when this connection filters by
+                      Project.
                     </p>
                   }
                 >

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -667,31 +667,37 @@ export default function SDKConnectionForm({
             project being removed from the selected environment.
           </div>
         )}
-        <Box mt="3">
-          <Checkbox
-            weight="regular"
-            value={!!form.watch("includeReferencedPrerequisites")}
-            setValue={(val) =>
-              form.setValue("includeReferencedPrerequisites", val)
-            }
-            label={
-              <>
-                Always include prerequisite Feature Flags{" "}
-                <Tooltip
-                  body={
-                    <p className="mb-0">
-                      Deliver prerequisite Feature Flags that target other
-                      Projects. Without them, the Feature Flags they gate are
-                      always off.
-                    </p>
-                  }
-                >
-                  <PiInfo />
-                </Tooltip>
-              </>
-            }
-          />
-        </Box>
+        {/* Only meaningful when the payload is actually project-filtered. An
+        empty selection still filters when the environment is scoped to
+        Projects, so both have to be empty before this becomes a no-op. */}
+        {((form.watch("projects") || []).length > 0 ||
+          environmentHasProjects) && (
+          <Box mt="3">
+            <Checkbox
+              weight="regular"
+              value={!!form.watch("includeReferencedPrerequisites")}
+              setValue={(val) =>
+                form.setValue("includeReferencedPrerequisites", val)
+              }
+              label={
+                <>
+                  Always include prerequisite Feature Flags{" "}
+                  <Tooltip
+                    body={
+                      <p className="mb-0">
+                        Deliver prerequisite Feature Flags that target other
+                        Projects. Without them, the Feature Flags they gate are
+                        always off.
+                      </p>
+                    }
+                  >
+                    <PiInfo />
+                  </Tooltip>
+                </>
+              }
+            />
+          </Box>
+        )}
       </div>
 
       {shouldShowPayloadSecurity(languageType, languages) && (

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -676,12 +676,13 @@ export default function SDKConnectionForm({
             }
             label={
               <>
-                Always include prerequisite features{" "}
+                Always include prerequisite Feature Flags{" "}
                 <Tooltip
                   body={
                     <p className="mb-0">
-                      Deliver prerequisite features that target other projects.
-                      Without them, the features they gate are always off.
+                      Deliver prerequisite Feature Flags that target other
+                      Projects. Without them, the Feature Flags they gate are
+                      always off.
                     </p>
                   }
                 >

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -667,37 +667,40 @@ export default function SDKConnectionForm({
             project being removed from the selected environment.
           </div>
         )}
-        {/* Only meaningful when the payload is actually project-filtered. An
-        empty selection still filters when the environment is scoped to
-        Projects, so both have to be empty before this becomes a no-op. */}
-        {((form.watch("projects") || []).length > 0 ||
-          environmentHasProjects) && (
-          <Box mt="3">
-            <Checkbox
-              weight="regular"
-              value={!!form.watch("includeReferencedPrerequisites")}
-              setValue={(val) =>
-                form.setValue("includeReferencedPrerequisites", val)
-              }
-              label={
-                <>
-                  Always include prerequisite Feature Flags{" "}
-                  <Tooltip
-                    body={
-                      <p className="mb-0">
-                        Deliver prerequisite Feature Flags that target other
-                        Projects. Without them, the Feature Flags they gate are
-                        always off.
-                      </p>
-                    }
-                  >
-                    <PiInfo />
-                  </Tooltip>
-                </>
-              }
-            />
-          </Box>
-        )}
+        <Box mt="3">
+          <Checkbox
+            weight="regular"
+            // A no-op on an unfiltered payload, which already carries every
+            // prerequisite. An empty selection still filters when the
+            // environment is scoped to Projects, so check both. Disabled
+            // rather than hidden: the value is still submitted.
+            disabled={
+              (form.watch("projects") || []).length === 0 &&
+              !environmentHasProjects
+            }
+            disabledMessage="Only applies when the payload is filtered by Project."
+            value={!!form.watch("includeReferencedPrerequisites")}
+            setValue={(val) =>
+              form.setValue("includeReferencedPrerequisites", val)
+            }
+            label={
+              <>
+                Always include prerequisite Feature Flags{" "}
+                <Tooltip
+                  body={
+                    <p className="mb-0">
+                      Deliver prerequisite Feature Flags that target other
+                      Projects. Without them, the Feature Flags they gate are
+                      always off.
+                    </p>
+                  }
+                >
+                  <PiInfo />
+                </Tooltip>
+              </>
+            }
+          />
+        </Box>
       </div>
 
       {shouldShowPayloadSecurity(languageType, languages) && (

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -676,7 +676,7 @@ export default function SDKConnectionForm({
             }
             label={
               <>
-                Include referenced prerequisite features{" "}
+                Always include prerequisite features{" "}
                 <Tooltip
                   body={
                     <p className="mb-0">

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -680,11 +680,8 @@ export default function SDKConnectionForm({
                 <Tooltip
                   body={
                     <p className="mb-0">
-                      When a feature in this payload is gated on a prerequisite
-                      that targets other projects, deliver that prerequisite
-                      too. Without it the gate can never pass, so the feature it
-                      gates is silently off. Turn this off to keep the payload
-                      strictly limited to the projects selected above.
+                      Deliver prerequisite features that target other projects.
+                      Without them, the features they gate are always off.
                     </p>
                   }
                 >

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -191,6 +191,10 @@ export default function SDKConnectionForm({
         false,
       includeExperimentScheduleInMetadata:
         initialValue.includeExperimentScheduleInMetadata ?? false,
+      // Absent means off — connections created before the setting existed keep
+      // their behavior. New ones are created with it on.
+      includeReferencedPrerequisites:
+        initialValue.includeReferencedPrerequisites ?? !edit,
     },
   });
 
@@ -1336,6 +1340,34 @@ export default function SDKConnectionForm({
               label="Include feature rule IDs in payload"
               value={!!form.watch("includeRuleIds")}
               setValue={(val) => form.setValue("includeRuleIds", val)}
+            />
+          </Box>
+          <Box>
+            <Checkbox
+              weight="regular"
+              value={!!form.watch("includeReferencedPrerequisites")}
+              setValue={(val) =>
+                form.setValue("includeReferencedPrerequisites", val)
+              }
+              label={
+                <>
+                  Include referenced prerequisite features{" "}
+                  <Tooltip
+                    body={
+                      <p className="mb-0">
+                        When a feature in this payload is gated on a
+                        prerequisite that targets other projects, include that
+                        prerequisite too. Without it the gate can never pass and
+                        the feature it gates is silently off. Turn this off to
+                        keep the payload strictly limited to this
+                        connection&apos;s projects.
+                      </p>
+                    }
+                  >
+                    <PiInfo />
+                  </Tooltip>
+                </>
+              }
             />
           </Box>
           <Box>

--- a/packages/shared/src/validators/sdk-connections.ts
+++ b/packages/shared/src/validators/sdk-connections.ts
@@ -48,6 +48,7 @@ export const apiSdkConnectionValidator = namedSchema(
       hashSecureAttributes: z.boolean().optional(),
       remoteEvalEnabled: z.boolean().optional(),
       savedGroupReferencesEnabled: z.boolean().optional(),
+      includeReferencedPrerequisites: z.boolean().optional(),
     })
     .strict(),
 );
@@ -84,6 +85,12 @@ const postSdkConnectionBody = z
     hashSecureAttributes: z.boolean().optional(),
     remoteEvalEnabled: z.boolean().optional(),
     savedGroupReferencesEnabled: z.boolean().optional(),
+    includeReferencedPrerequisites: z
+      .boolean()
+      .optional()
+      .describe(
+        "Carry prerequisite features into this payload even when they target other projects. Defaults to true for new connections.",
+      ),
   })
   .strict();
 

--- a/packages/shared/src/validators/sdk-connections.ts
+++ b/packages/shared/src/validators/sdk-connections.ts
@@ -89,7 +89,7 @@ const postSdkConnectionBody = z
       .boolean()
       .optional()
       .describe(
-        "Carry prerequisite features into this payload even when they target other projects. Defaults to true for new connections.",
+        "Carry prerequisite Feature Flags into this payload even when they target other Projects. Defaults to true for new connections.",
       ),
   })
   .strict();

--- a/packages/shared/types/sdk-connection.d.ts
+++ b/packages/shared/types/sdk-connection.d.ts
@@ -97,6 +97,11 @@ export interface SDKConnectionInterface {
   allowedCustomFieldsInMetadata?: string[];
   includeTagsInMetadata?: boolean;
   includeExperimentScheduleInMetadata?: boolean;
+  // Carry prerequisite features into this payload even when they target other
+  // projects. Without them the gate they back can never pass, so the dependent
+  // silently fails closed. Absent = off, which is every connection that predates
+  // the setting; new connections are created with it on.
+  includeReferencedPrerequisites?: boolean;
 
   // URL slug for fetching features from the API
   key: string;

--- a/packages/shared/types/sdk-connection.d.ts
+++ b/packages/shared/types/sdk-connection.d.ts
@@ -98,9 +98,7 @@ export interface SDKConnectionInterface {
   includeTagsInMetadata?: boolean;
   includeExperimentScheduleInMetadata?: boolean;
   // Carry prerequisite features into this payload even when they target other
-  // projects. Without them the gate they back can never pass, so the dependent
-  // silently fails closed. Absent = off, which is every connection that predates
-  // the setting; new connections are created with it on.
+  // projects. Absent = off; new connections are created with it on.
   includeReferencedPrerequisites?: boolean;
 
   // URL slug for fetching features from the API


### PR DESCRIPTION
A feature gated on a prerequisite that targets other projects now receives that prerequisite in its SDK payload, so the gate can evaluate instead of silently failing closed.

Controlled by a new SDK Connection setting — on by default for new connections, off for existing ones.

<img width="837" height="592" alt="image" src="https://github.com/user-attachments/assets/5a8fb9e2-793c-4ee7-8c2a-bc4ab7e5f6b0" />

