### PR TITLE
Require approved status, not just coverage, in the app publish endpoint

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -2182,7 +2182,15 @@ export async function postFeaturePublish(
       base,
     });
 
-  if (!adminOverride && requiresReview && !hasCoveringApproval) {
+  // Status AND coverage: `status` aggregates every standing verdict (one
+  // reviewer's changes-requested outranks another's approval), so a covering
+  // approval alone must not publish over an open objection. Same condition as
+  // the REST publish handler.
+  if (
+    !adminOverride &&
+    requiresReview &&
+    !(revision.status === "approved" && hasCoveringApproval)
+  ) {
     throw new Error(
       revision.status === "approved"
         ? "This draft now changes environments its approvers cannot approve. It needs approval from someone with review rights across everything it changes."

--- a/packages/back-end/test/services/assessRevisionApproval.test.ts
+++ b/packages/back-end/test/services/assessRevisionApproval.test.ts
@@ -137,6 +137,27 @@ describe("assessRevisionApproval", () => {
     expect(result.satisfied).toBe(true);
   });
 
+  // One verdict stands per reviewer and changes-requested outranks approved, so
+  // a covering approval can coexist with an open objection. Coverage alone is
+  // not the publish condition — callers must gate on status too (`satisfied`).
+  it("is unsatisfied while another reviewer's changes-requested stands over a covering approval", async () => {
+    const result = await assess(
+      makeContext({}),
+      revision({
+        rules: [rule("production")],
+        status: "changes-requested",
+        reviews: [
+          { userId: "u_rev", status: "approved" },
+          { userId: "u_other", status: "changes-requested" },
+        ],
+      } as Partial<FeatureRevisionInterface>),
+    );
+
+    expect(result.requiresReview).toBe(true);
+    expect(result.hasCoveringApproval).toBe(true);
+    expect(result.satisfied).toBe(false);
+  });
+
   // The case the branch exists for: approved, but not by anyone who could
   // publish what the draft now changes.
   it("refuses an approval that does not cover the changed environment", async () => {


### PR DESCRIPTION
### Features and Changes

Restores the `status === "approved"` half of the approval gate in `postFeaturePublish` (the app's `POST /feature/:id/:version/publish`).

#6699 changed that gate from `requiresReview && revision.status !== "approved"` to `requiresReview && !hasCoveringApproval`. `hasCoveringApproval` is derived only from `reviews[]` entries whose `status === "approved"`, and the later `reviewStatuses` check admits `changes-requested` / `pending-review`. Since one verdict is kept per reviewer and `statusFromStandingVerdicts` ranks changes-requested above approved, the sequence "A approves, then B requests changes" leaves the draft at `changes-requested` with A's approval still standing — and that draft passed the gate. Anyone with publish rights could publish it via the normal request body (no `adminOverride`). The UI hides the button in that state, so this needs a crafted request, and it still needs one genuine covering approval, but it lets a publisher override another reviewer's open objection.

This looks like an oversight rather than intent: every sibling path kept the status check — the REST handler (`postFeatureRevisionPublish.ts`, `revision.status === "approved" && plan.hasCoveringApproval`), `revisionActions.ts`, `governanceGates.ts`, and experiment auto-publish via `assessRevisionApproval().satisfied`. This PR makes the app endpoint use the same conjunction as the REST handler and keeps the distinct "approvers can no longer cover the footprint" message.

An alternative would be to gate on `satisfied` from `assessRevisionApproval()` directly (it already folds in status, coverage and required approver teams); happy to switch to that if you prefer — you know this code better than we do.

Observation, not changed here: `postFeatureApproveAndPublish` commits the approval and then calls `postFeaturePublish`. If another reviewer's changes-requested is standing, the aggregate status stays `changes-requested`, so with this fix the approval lands and the publish is refused with "needs review before publishing" (same as before #6699). That seems right, but the preflight in that handler doesn't anticipate it.

### Dependencies

None

### Testing

Unit: `test/services/assessRevisionApproval.test.ts` gains a case for `{approved (covering), changes-requested}` → `hasCoveringApproval: true`, `satisfied: false`. This passes on `main` too (the helper was already right; the controller just wasn't reading status) — it pins the invariant the gate relies on.

End-to-end against a local back-end (org with `requireReviews` on for all environments; three admins A, B, C):

1. A edits a flag's default value (draft v2) and requests review.
2. B submits `Approved`; C submits `Requested Changes`. Revision is now `{"status":"changes-requested","reviews":[{"status":"approved"},{"status":"changes-requested"}]}`.
3. A calls `POST /feature/<id>/2/publish` with a valid `mergeResultSerialized` and no `adminOverride`.

| build | response | flag after |
|---|---|---|
| `main` | `{"status":200}` | `{"liveVersion":2,"liveDefault":"true"}` — published over C's objection |
| this PR | `{"status":400,"message":"needs review before publishing"}` | `{"liveVersion":1,"liveDefault":"false"}` |

Also checked on this PR's build: B approves with no objection → publishes (200); `pending-review` with no verdicts → refused; C retracts via `undo-review` → status returns to `approved` → publishes; `adminOverride: true` from a user with bypass rights still publishes the objected draft.

### Screenshots

N/A (back-end only)
