### PR TITLE
Add compound indexes for audit history queries

### DIFF
--- a/packages/back-end/src/models/AuditModel.ts
+++ b/packages/back-end/src/models/AuditModel.ts
@@ -39,6 +39,23 @@ const auditSchema = new mongoose.Schema({
   dateCreated: Date,
 });
 
+// The history queries below filter on organization + entity (or parent, or
+// user) and sort by dateCreated; without these they scan every audit in the
+// organization and sort in memory.
+auditSchema.index({
+  organization: 1,
+  "entity.object": 1,
+  "entity.id": 1,
+  dateCreated: 1,
+});
+auditSchema.index({
+  organization: 1,
+  "parent.object": 1,
+  "parent.id": 1,
+  dateCreated: 1,
+});
+auditSchema.index({ organization: 1, "user.id": 1, dateCreated: 1 });
+
 type AuditDocument = mongoose.Document & AuditInterface;
 
 const AuditModel = mongoose.model<AuditInterface>("Audit", auditSchema);


### PR DESCRIPTION
### Features and Changes

Adds three compound indexes to the `audits` collection:

```
{ organization: 1, "entity.object": 1, "entity.id": 1, dateCreated: 1 }
{ organization: 1, "parent.object": 1, "parent.id": 1, dateCreated: 1 }
{ organization: 1, "user.id": 1, dateCreated: 1 }
```

`auditSchema` currently indexes only `id` and `organization`, so the history queries in `AuditModel.ts` — `/user/history` on the home page, the feature/experiment History tab, and the Activity page — scan the whole organization's audit log and sort by `dateCreated` in memory. This becomes a noticeable problem at scale for larger organizations.

### Dependencies

None.

### Testing

Ran the back-end locally on `main` and on this branch and compared `explain()` for the filters/sorts `AuditModel.ts` issues: the user, entity, and parent history queries go from `SORT <- FETCH <- IXSCAN[organization_1]` to `LIMIT <- FETCH <- IXSCAN[<new compound index>]`. `GET /user/history` and `GET /history/feature/:id` return the same payloads on both builds. Also confirmed a pre-existing identical index is reused without error.
