### PR TITLE
Perf: index the audit history queries

### DIFF
--- a/packages/back-end/src/models/AuditModel.ts
+++ b/packages/back-end/src/models/AuditModel.ts
@@ -39,6 +39,24 @@ const auditSchema = new mongoose.Schema({
   dateCreated: Date,
 });
 
+// History queries otherwise scan the org's entire audit log and sort in memory.
+auditSchema.index({
+  organization: 1,
+  "entity.object": 1,
+  "entity.id": 1,
+  dateCreated: -1,
+});
+auditSchema.index({
+  organization: 1,
+  "parent.object": 1,
+  "parent.id": 1,
+  dateCreated: -1,
+});
+auditSchema.index({ organization: 1, "user.id": 1, dateCreated: -1 });
+// Activity page filters by type alone, so the indexes above can't sort it.
+auditSchema.index({ organization: 1, "entity.object": 1, dateCreated: -1 });
+auditSchema.index({ organization: 1, "parent.object": 1, dateCreated: -1 });
+
 type AuditDocument = mongoose.Document & AuditInterface;
 
 const AuditModel = mongoose.model<AuditInterface>("Audit", auditSchema);


### PR DESCRIPTION
### Features and Changes

`auditSchema` only indexed `id` and `organization`, so queries were fetching every audit document in the org including the `details` blob, and sorting them in memory. This PR replaces #6861 as it adds two more indexes to speed up the Activity page. (The Activity page filters on `entity.object` alone, which leaves `entity.id` unbounded ahead of the sort key, so it needs its own three-key index instead of reusing the four-key ones.)

### Testing

`explain()` against 3M synthetic audits with 90% of rows in one org:

```
                       before                    after
History tab     2,698,971 docs / 3278ms     4 keys / 1ms
Activity page   2,698,971 docs / 3564ms    50 keys / 1ms
/user/history   2,698,971 docs / 2453ms    10 keys / 0ms
```

- [x] The history queries go from `SORT <- FETCH <- IXSCAN[organization_1]` to `LIMIT <- FETCH <- IXSCAN`, and `countAuditByEntity` to a `COUNT_SCAN`
- [x] With both the four-key and three-key indexes present, the planner still picks the four-key one for the History tab
- [x] Building all five under a concurrent insert loop doesn't block writes (p50 1ms, p99 4ms), since 4.2+ only takes the exclusive lock at start and commit

Index cost is 72.5 B/doc, or **1.35GB on a 20M-document collection**, which builds in 2.8 min.

