### PR TITLE
fix(fact-tables): avoid mutating columns during detection

### DIFF
--- a/packages/back-end/src/services/factTableColumns.ts
+++ b/packages/back-end/src/services/factTableColumns.ts
@@ -1,4 +1,5 @@
 import chunk from "lodash/chunk";
+import cloneDeep from "lodash/cloneDeep";
 import {
   canInlineFilterColumn,
   getFactTableTimestampColumn,
@@ -300,7 +301,7 @@ export async function runColumnDetectionQuery(
     }
   });
 
-  const columns = factTable.columns || [];
+  const columns = cloneDeep(factTable.columns || []);
 
   // Update existing column
   columns.forEach((col) => {

--- a/packages/back-end/test/services/factTableColumns.test.ts
+++ b/packages/back-end/test/services/factTableColumns.test.ts
@@ -524,4 +524,20 @@ describe("runColumnDetectionQuery", () => {
       dataTypeFromWarehouse: "string",
     });
   });
+
+  it("does not mutate the input columns", async () => {
+    const column = makeCol("missing");
+    const originalDateUpdated = column.dateUpdated;
+
+    await refreshColumns({
+      column,
+      result: {
+        results: [],
+        duration: 1,
+      },
+    });
+
+    expect(column.deleted).toBe(false);
+    expect(column.dateUpdated).toBe(originalDateUpdated);
+  });
 });


### PR DESCRIPTION
### Features and Changes

- Reconcile detected columns against a copy so the input Fact Table remains unchanged.

### What this fixes

`runColumnDetectionQuery` mutated `factTable.columns` in place and returned the same array. Both callers (`refreshFactTableColumns` job and `putFactTable`) then used the same `factTable` in `updateFactTableColumns` as the "before" state, so every before/after comparison saw no difference.

The Mongo write itself was correct; only the change-driven side effects were lost.

### Testing

- Added regression coverage for input mutation.