### PR TITLE
fix(models): check permissions for no-op updates

### DIFF
--- a/packages/back-end/src/enterprise/services/contextualBandits.ts
+++ b/packages/back-end/src/enterprise/services/contextualBandits.ts
@@ -840,10 +840,13 @@ export async function runContextualBanditSnapshot(
   // Compute bandit stage before running the update, in case this
   // update moves bandits from explore to exploit.
   const scheduleChanges = computeContextualBanditStageAndSchedule(cb);
-  const updatedCb = await context.models.contextualBandits.update(
-    cb,
-    scheduleChanges,
-  );
+  // Authority was established by canRunContextualBandit at the route; the
+  // stage/schedule write is a consequence of the run, not a separate edit.
+  const updatedCb =
+    await context.models.contextualBandits.dangerousUpdateBypassPermission(
+      cb,
+      scheduleChanges,
+    );
 
   const snapshotSettings = buildContextualBanditSnapshotSettings(
     updatedCb,

--- a/packages/back-end/src/models/BaseModel.ts
+++ b/packages/back-end/src/models/BaseModel.ts
@@ -1271,14 +1271,6 @@ export abstract class BaseModel<
       .map(([k]) => k) as (keyof z.infer<T>)[];
     updates = pick(updates, updatedFields);
 
-    // If no updates are needed, return immediately — UNLESS the write is
-    // guarded. A guarded write is a CAS fence as much as a mutation: skipping
-    // it would confirm "the doc I read is still current" without checking it
-    // or advancing the token. The fence writes only the advanced stamp.
-    if (!updatedFields.length && !options?.guard) {
-      return doc;
-    }
-
     // Make sure the updates don't include any fields that shouldn't be updated
     if (
       ["id", "uid", "organization", "dateCreated", "dateUpdated"].some(
@@ -1328,6 +1320,11 @@ export abstract class BaseModel<
       throw new PermissionError(
         "You do not have access to update this resource",
       );
+    }
+
+    // A guarded write is a CAS fence even when no fields changed.
+    if (!updatedFields.length && !options?.guard) {
+      return doc;
     }
 
     await this.validateProjectFields(updates as Partial<z.infer<T>>);

--- a/packages/back-end/src/models/BaseModel.ts
+++ b/packages/back-end/src/models/BaseModel.ts
@@ -1266,6 +1266,7 @@ export abstract class BaseModel<
     );
 
     // Only consider updates that actually change the value
+    const requested = updates;
     const updatedFields = Object.entries(updates)
       .filter(([k, v]) => !isEqual(doc[k as keyof z.infer<T>], v))
       .map(([k]) => k) as (keyof z.infer<T>)[];
@@ -1316,7 +1317,13 @@ export abstract class BaseModel<
 
     await this.populateForeignRefs([newDoc]);
 
-    if (!options?.forceCanUpdate && !this.canUpdate(doc, updates, newDoc)) {
+    // A no-op is gated on the payload as submitted: "may you write what you
+    // asked for", not "may you write nothing" — which key-aware canUpdate
+    // implementations (e.g. ApiKeyModel's `disabled`-only allowlist) reject.
+    if (
+      !options?.forceCanUpdate &&
+      !this.canUpdate(doc, updatedFields.length ? updates : requested, newDoc)
+    ) {
       throw new PermissionError(
         "You do not have access to update this resource",
       );

--- a/packages/back-end/src/services/rampScheduleEvaluator.ts
+++ b/packages/back-end/src/services/rampScheduleEvaluator.ts
@@ -31,6 +31,7 @@ import {
   RampAdvanceLockBusyError,
 } from "back-end/src/util/errors";
 import { logger } from "back-end/src/util/logger";
+import { getContextForAgendaJobByOrgObject } from "back-end/src/services/organizations";
 
 export type EvalDecision =
   | { action: "advance" }
@@ -534,12 +535,9 @@ export async function applyRampEvaluationDecision(
       nextSnapshotAt: schedule.nextSnapshotAt,
       cutoffDate: schedule.cutoffDate,
     });
-    // Scheduler bookkeeping, not a user edit: the snapshot that triggered this
-    // may run under a member who cannot edit or publish the feature.
-    return ctx.models.rampSchedules.dangerousUpdateByIdBypassPermission(
-      schedule.id,
-      { nextProcessAt },
-    );
+    return ctx.models.rampSchedules.updateById(schedule.id, {
+      nextProcessAt,
+    });
   }
 
   // Fold the verified advance and any due backlog into a single jump publish.
@@ -554,12 +552,16 @@ export async function applyRampEvaluationDecision(
 }
 
 export async function evaluateRampScheduleAfterSafeRolloutSnapshot(
-  ctx: ReqContext,
+  requestCtx: ReqContext,
   safeRollout: SafeRolloutInterface,
   now: Date = new Date(),
 ): Promise<void> {
   if (!safeRollout.rampScheduleId) return;
   const rampScheduleId = safeRollout.rampScheduleId;
+
+  // A scheduler decision, so it runs on the same authority as the cron tick:
+  // the member whose snapshot completed may not be able to publish the feature.
+  const ctx = getContextForAgendaJobByOrgObject(requestCtx.org);
 
   // Pre-lock screen: don't pay lock writes for no-op snapshot completions.
   // Re-screened inside the lock.

--- a/packages/back-end/src/services/rampScheduleEvaluator.ts
+++ b/packages/back-end/src/services/rampScheduleEvaluator.ts
@@ -534,9 +534,12 @@ export async function applyRampEvaluationDecision(
       nextSnapshotAt: schedule.nextSnapshotAt,
       cutoffDate: schedule.cutoffDate,
     });
-    return ctx.models.rampSchedules.updateById(schedule.id, {
-      nextProcessAt,
-    });
+    // Scheduler bookkeeping, not a user edit: the snapshot that triggered this
+    // may run under a member who cannot edit or publish the feature.
+    return ctx.models.rampSchedules.dangerousUpdateByIdBypassPermission(
+      schedule.id,
+      { nextProcessAt },
+    );
   }
 
   // Fold the verified advance and any due backlog into a single jump publish.

--- a/packages/back-end/test/api/noop-update-permissions.test.ts
+++ b/packages/back-end/test/api/noop-update-permissions.test.ts
@@ -1,0 +1,86 @@
+import mongoose from "mongoose";
+import request from "supertest";
+import { ApiKeyInterface } from "shared/types/apikey";
+import { OrganizationInterface } from "shared/types/organization";
+import { ReqContextClass } from "back-end/src/services/context";
+import { factMetricFactory } from "back-end/test/factories/FactMetric.factory";
+import { setupApp } from "./api.setup";
+
+const organization: OrganizationInterface = {
+  id: "org_noop_update_permissions",
+  name: "No-op update permissions",
+  ownerEmail: "owner@example.com",
+  url: "",
+  dateCreated: new Date("2026-01-01"),
+  invites: [],
+  members: [],
+  settings: { environments: [] },
+};
+
+const datasource = {
+  id: "ds_noop_update_permissions",
+  organization: organization.id,
+  name: "No-op update data source",
+  description: "",
+  type: "postgres",
+  params: "",
+  projects: [],
+  settings: {},
+  dateCreated: new Date("2026-01-01"),
+  dateUpdated: new Date("2026-01-01"),
+};
+
+const factMetric = factMetricFactory.build({
+  id: "fact__noop_update",
+  organization: organization.id,
+  datasource: datasource.id,
+  owner: "",
+  managedBy: "",
+  name: "No-op metric",
+  funnelSettings: null,
+});
+
+const { app, setReqContext } = setupApp();
+
+beforeEach(async () => {
+  const apiKeyData: ApiKeyInterface = {
+    id: "key_readonly",
+    key: "test-key",
+    organization: organization.id,
+    dateCreated: new Date("2026-01-01"),
+    dateUpdated: new Date("2026-01-01"),
+    secret: true,
+    role: "readonly",
+    limitAccessByEnvironment: false,
+    environments: [],
+  };
+  setReqContext(
+    new ReqContextClass({
+      org: organization,
+      auditUser: { type: "api_key", apiKey: "test-key" },
+      role: "readonly",
+      apiKey: "test-key",
+      apiKeyData,
+    }),
+  );
+  await mongoose.connection
+    .db!.collection("datasources")
+    .insertOne(structuredClone(datasource));
+  await mongoose.connection
+    .db!.collection("factmetrics")
+    .insertOne(structuredClone(factMetric));
+});
+
+it("checks update permissions for no-op payloads", async () => {
+  for (const body of [{}, { name: factMetric.name }]) {
+    const response = await request(app)
+      .post(`/api/v1/fact-metrics/${factMetric.id}`)
+      .send(body)
+      .set("Authorization", "Bearer test-key");
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toBe(
+      "You do not have access to update this resource",
+    );
+  }
+});

--- a/packages/back-end/test/models/BaseModel.test.ts
+++ b/packages/back-end/test/models/BaseModel.test.ts
@@ -788,6 +788,57 @@ describe("BaseModel", () => {
     );
   });
 
+  it("checks update access even when the update is a no-op", async () => {
+    const model = new TestModel(defaultContext);
+    model.canUpdateMock.mockReturnValue(false);
+    const updateOneMock = jest.fn();
+    model.dangerousGetCollectionMock.mockReturnValue({
+      updateOne: updateOneMock,
+    });
+    const existing = {
+      name: "foo",
+      id: "aabb",
+      organization: "a",
+      dateCreated: new Date(),
+      dateUpdated: new Date(),
+    };
+
+    await expect(model.update(existing, { name: "foo" })).rejects.toEqual(
+      new Error("You do not have access to update this resource"),
+    );
+    expect(updateOneMock).not.toHaveBeenCalled();
+  });
+
+  it("gates a no-op update on the payload as submitted, not on {}", async () => {
+    const model = new TestModel(defaultContext);
+    // Key-aware canUpdate, like ApiKeyModel's `disabled`-only allowlist.
+    model.canUpdateMock.mockImplementation(
+      (_existing, updates) =>
+        Object.keys(updates).length === 1 && "name" in updates,
+    );
+    const updateOneMock = jest.fn();
+    model.dangerousGetCollectionMock.mockReturnValue({
+      updateOne: updateOneMock,
+    });
+    const existing = {
+      name: "foo",
+      id: "aabb",
+      organization: "a",
+      dateCreated: new Date(),
+      dateUpdated: new Date(),
+    };
+
+    await expect(model.update(existing, { name: "foo" })).resolves.toEqual(
+      existing,
+    );
+    expect(model.canUpdateMock).toHaveBeenCalledWith(
+      existing,
+      { name: "foo" },
+      expect.objectContaining({ name: "foo" }),
+    );
+    expect(updateOneMock).not.toHaveBeenCalled();
+  });
+
   it("raises an error when attempting to update a read-only field", () => {
     const model = new TestModel(defaultContext);
     model.canUpdateMock.mockReturnValue(true);

--- a/packages/back-end/test/services/contextualBandits.test.ts
+++ b/packages/back-end/test/services/contextualBandits.test.ts
@@ -373,7 +373,7 @@ describe("runContextualBanditSnapshot", () => {
         },
       },
       models: {
-        contextualBandits: { update: updateMock },
+        contextualBandits: { dangerousUpdateBypassPermission: updateMock },
         contextualBanditQueries: {
           getById: jest.fn().mockResolvedValue({
             id: "cbq_1",

--- a/packages/back-end/test/services/rampScheduleEvaluator.test.ts
+++ b/packages/back-end/test/services/rampScheduleEvaluator.test.ts
@@ -29,6 +29,13 @@ jest.mock("back-end/src/util/logger", () => ({
   },
 }));
 
+// The post-snapshot evaluator swaps to the org's job context; hand it the
+// test's own mocked context so assertions keep seeing the same models.
+let mockLastContext: unknown;
+jest.mock("back-end/src/services/organizations", () => ({
+  getContextForAgendaJobByOrgObject: jest.fn(() => mockLastContext),
+}));
+
 const mockCreateSafeRolloutSnapshot =
   createSafeRolloutSnapshot as jest.MockedFunction<
     typeof createSafeRolloutSnapshot
@@ -129,12 +136,12 @@ function makeContext({
   snapshotAnalysis?: SafeRolloutSnapshotAnalysis;
   schedule?: RampScheduleInterface;
 }) {
-  return {
+  const context = {
     org: { id: "org_1", settings: {} },
     models: {
       rampSchedules: {
         getById: jest.fn().mockResolvedValue(schedule ?? null),
-        dangerousUpdateByIdBypassPermission: jest
+        updateById: jest
           .fn()
           .mockImplementation(
             (_id: string, updates: Partial<RampScheduleInterface>) => ({
@@ -163,6 +170,8 @@ function makeContext({
       },
     },
   };
+  mockLastContext = context;
+  return context;
 }
 
 describe("evaluateCurrentStep: 0-step simple schedules", () => {
@@ -456,11 +465,12 @@ describe("rampScheduleEvaluator monitored SafeRollout integration", () => {
     );
 
     expect(context.models.rampSchedules.getById).toHaveBeenCalledWith("rs_1");
-    expect(
-      context.models.rampSchedules.dangerousUpdateByIdBypassPermission,
-    ).toHaveBeenCalledWith("rs_1", {
-      nextProcessAt: null,
-    });
+    expect(context.models.rampSchedules.updateById).toHaveBeenCalledWith(
+      "rs_1",
+      {
+        nextProcessAt: null,
+      },
+    );
     expect(mockCreateSafeRolloutSnapshot).not.toHaveBeenCalled();
   });
 
@@ -918,9 +928,7 @@ describe("rampScheduleEvaluator monitored SafeRollout integration", () => {
         expect(context.models.rampSchedules.getById).toHaveBeenCalledWith(
           "rs_1",
         );
-        expect(
-          context.models.rampSchedules.dangerousUpdateByIdBypassPermission,
-        ).not.toHaveBeenCalled();
+        expect(context.models.rampSchedules.updateById).not.toHaveBeenCalled();
       });
     }
 
@@ -941,9 +949,7 @@ describe("rampScheduleEvaluator monitored SafeRollout integration", () => {
       );
 
       expect(context.models.rampSchedules.getById).toHaveBeenCalledWith("rs_1");
-      expect(
-        context.models.rampSchedules.dangerousUpdateByIdBypassPermission,
-      ).not.toHaveBeenCalled();
+      expect(context.models.rampSchedules.updateById).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/back-end/test/services/rampScheduleEvaluator.test.ts
+++ b/packages/back-end/test/services/rampScheduleEvaluator.test.ts
@@ -134,7 +134,7 @@ function makeContext({
     models: {
       rampSchedules: {
         getById: jest.fn().mockResolvedValue(schedule ?? null),
-        updateById: jest
+        dangerousUpdateByIdBypassPermission: jest
           .fn()
           .mockImplementation(
             (_id: string, updates: Partial<RampScheduleInterface>) => ({
@@ -456,12 +456,11 @@ describe("rampScheduleEvaluator monitored SafeRollout integration", () => {
     );
 
     expect(context.models.rampSchedules.getById).toHaveBeenCalledWith("rs_1");
-    expect(context.models.rampSchedules.updateById).toHaveBeenCalledWith(
-      "rs_1",
-      {
-        nextProcessAt: null,
-      },
-    );
+    expect(
+      context.models.rampSchedules.dangerousUpdateByIdBypassPermission,
+    ).toHaveBeenCalledWith("rs_1", {
+      nextProcessAt: null,
+    });
     expect(mockCreateSafeRolloutSnapshot).not.toHaveBeenCalled();
   });
 
@@ -919,7 +918,9 @@ describe("rampScheduleEvaluator monitored SafeRollout integration", () => {
         expect(context.models.rampSchedules.getById).toHaveBeenCalledWith(
           "rs_1",
         );
-        expect(context.models.rampSchedules.updateById).not.toHaveBeenCalled();
+        expect(
+          context.models.rampSchedules.dangerousUpdateByIdBypassPermission,
+        ).not.toHaveBeenCalled();
       });
     }
 
@@ -940,7 +941,9 @@ describe("rampScheduleEvaluator monitored SafeRollout integration", () => {
       );
 
       expect(context.models.rampSchedules.getById).toHaveBeenCalledWith("rs_1");
-      expect(context.models.rampSchedules.updateById).not.toHaveBeenCalled();
+      expect(
+        context.models.rampSchedules.dangerousUpdateByIdBypassPermission,
+      ).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
### Features and Changes

- Run update permission checks before returning from no-op updates.

### Testing

- Added API coverage for empty and identical update payloads.