### PR TITLE
fix(fact-tables): preflight and guard auto-slice cleanup

### DIFF
--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -11,6 +11,7 @@ import {
 } from "shared/experiments";
 import { getFunnelRuleViolations } from "shared/funnels";
 import { UpdateProps } from "shared/types/base-model";
+import { PermissionError } from "shared/util";
 import { factMetricValidator, ApiFactMetric } from "shared/validators";
 import {
   ColumnRef,
@@ -181,11 +182,7 @@ export class FactMetricModel extends BaseClass {
   }
 
   // Every fact metric in the org, ignoring the caller's read permissions. Only
-  // for authoritative dependency scans (e.g. blocking deletion of a fact table
-  // column a metric still references), where missing a metric in a project the
-  // caller cannot read would let the delete through and leave that metric
-  // generating SQL for a column that no longer exists. Never return these to
-  // the caller.
+  // use for dependency scans and cleanup preflights; never return these rows.
   public async dangerousGetAllForDependencyScan(): Promise<
     FactMetricInterface[]
   > {
@@ -369,13 +366,29 @@ export class FactMetricModel extends BaseClass {
     }
   }
 
-  protected async beforeUpdate(existing: FactMetricInterface) {
-    // Check the admin permission here?
+  public preflightAutoSliceCleanup(
+    existing: FactMetricInterface,
+    metricAutoSlices: string[],
+  ): void {
+    const updates: UpdateProps<FactMetricInterface> = { metricAutoSlices };
+    if (!this.canUpdate(existing, updates)) {
+      throw new PermissionError(
+        "You do not have access to update this resource",
+      );
+    }
+    this.assertUpdateChannel(existing);
+  }
+
+  private assertUpdateChannel(existing: FactMetricInterface): void {
     if (existing.managedBy === "api" && !this.context.isApiRequest) {
       throw new Error(
         "Cannot update fact metric managed by API if the request isn't from the API.",
       );
     }
+  }
+
+  protected async beforeUpdate(existing: FactMetricInterface) {
+    this.assertUpdateChannel(existing);
   }
 
   protected async beforeDelete(existing: FactMetricInterface) {

--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -41,6 +41,7 @@ import {
   normalizeJSONFieldsInput,
   normalizePersistedColumn,
 } from "back-end/src/util/factTable";
+import { logger } from "back-end/src/util/logger";
 
 const audit = createModelAuditLogger({
   entity: "factTable",
@@ -620,10 +621,39 @@ async function applyMetricAutoSliceCleanup(
   context: ReqContext | ApiReqContext,
   cleanup: MetricAutoSliceCleanup[],
 ): Promise<void> {
-  for (const { metric, metricAutoSlices } of cleanup) {
-    await context.models.factMetrics.updateIfUnchanged(metric, {
-      metricAutoSlices,
-    });
+  const applied: {
+    before: FactMetricInterface;
+    written: FactMetricInterface;
+  }[] = [];
+
+  try {
+    for (const { metric, metricAutoSlices } of cleanup) {
+      await context.models.factMetrics.updateIfUnchanged(
+        metric,
+        { metricAutoSlices },
+        undefined,
+        {
+          // Capture the write before audit/hooks so later failures can undo it.
+          onWritten: (written) => {
+            applied.push({ before: metric, written });
+          },
+        },
+      );
+    }
+  } catch (error) {
+    for (const { before, written } of applied.reverse()) {
+      try {
+        await context.models.factMetrics.updateIfUnchanged(written, {
+          metricAutoSlices: before.metricAutoSlices ?? [],
+        });
+      } catch (rollbackError) {
+        logger.error(
+          rollbackError,
+          `Failed to restore Fact Metric ${before.id} after auto-slice cleanup failed`,
+        );
+      }
+    }
+    throw error;
   }
 }
 

--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -13,6 +13,7 @@ import {
   CreateFactTableProps,
   ColumnRef,
   FactFilterInterface,
+  FactMetricInterface,
   FactTableDefinition,
   FactTableInterface,
   UpdateFactFilterProps,
@@ -398,21 +399,15 @@ export async function updateFactTable(
   );
   if (!changed) return;
 
-  // Clean up auto slices from metrics if columns were deleted or modified
-  if (changes.columns) {
-    const removedColumns = detectRemovedColumns(
-      factTable.columns || [],
-      changes.columns,
-    );
+  const autoSliceCleanup = await prepareMetricAutoSliceCleanup({
+    context,
+    factTableId: factTable.id,
+    removedColumns: changes.columns
+      ? detectRemovedColumns(factTable.columns || [], changes.columns)
+      : [],
+  });
 
-    if (removedColumns.length > 0) {
-      await cleanupMetricAutoSlices({
-        context,
-        factTableId: factTable.id,
-        removedColumns,
-      });
-    }
-  }
+  await applyMetricAutoSliceCleanup(context, autoSliceCleanup);
 
   await FactTableModel.updateOne(
     {
@@ -462,6 +457,14 @@ export async function updateFactTableColumns(
     ),
   );
 
+  const autoSliceCleanup = await prepareMetricAutoSliceCleanup({
+    context,
+    factTableId: factTable.id,
+    removedColumns: changes.columns
+      ? detectRemovedColumns(factTable.columns || [], changes.columns)
+      : [],
+  });
+
   await FactTableModel.updateOne(
     {
       id: factTable.id,
@@ -485,21 +488,7 @@ export async function updateFactTableColumns(
     );
   }
 
-  // Clean up auto slices from metrics if columns were refreshed and some were deleted
-  if (changes.columns) {
-    const removedColumns = detectRemovedColumns(
-      factTable.columns || [],
-      changes.columns,
-    );
-
-    if (removedColumns.length > 0) {
-      await cleanupMetricAutoSlices({
-        context,
-        factTableId: factTable.id,
-        removedColumns,
-      });
-    }
-  }
+  await applyMetricAutoSliceCleanup(context, autoSliceCleanup);
 }
 
 // System-driven update of the managed-warehouse events fact table (managedBy "api").
@@ -521,19 +510,15 @@ export async function dangerouslySyncManagedWarehouseFactTable(
     return;
   }
 
-  if (changes.columns) {
-    const removedColumns = detectRemovedColumns(
-      factTable.columns || [],
-      changes.columns,
-    );
-    if (removedColumns.length > 0) {
-      await cleanupMetricAutoSlices({
-        context,
-        factTableId: factTable.id,
-        removedColumns,
-      });
-    }
-  }
+  const autoSliceCleanup = await prepareMetricAutoSliceCleanup({
+    context,
+    factTableId: factTable.id,
+    removedColumns: changes.columns
+      ? detectRemovedColumns(factTable.columns || [], changes.columns)
+      : [],
+  });
+
+  await applyMetricAutoSliceCleanup(context, autoSliceCleanup);
 
   await FactTableModel.updateOne(
     {
@@ -589,8 +574,12 @@ export function detectRemovedColumns(
   return [...deletedColumns, ...disabledAutoSliceColumns];
 }
 
-// Clean up auto slices from fact metrics when columns are "deleted" or dropped
-export async function cleanupMetricAutoSlices({
+type MetricAutoSliceCleanup = {
+  metric: FactMetricInterface;
+  metricAutoSlices: string[];
+};
+
+async function prepareMetricAutoSliceCleanup({
   context,
   factTableId,
   removedColumns,
@@ -598,28 +587,43 @@ export async function cleanupMetricAutoSlices({
   context: ReqContext | ApiReqContext;
   factTableId: string;
   removedColumns: string[];
-}) {
-  // Get all fact metrics that use this fact table
-  const allFactMetrics = await context.models.factMetrics.getAll();
-  const affectedMetrics = allFactMetrics.filter(
-    (metric) => metric.numerator?.factTableId === factTableId,
-  );
+}): Promise<MetricAutoSliceCleanup[]> {
+  if (removedColumns.length === 0) return [];
 
-  // For each affected metric, remove auto slices that reference removed columns
-  for (const metric of affectedMetrics) {
-    if (!metric.metricAutoSlices?.length) continue;
-
-    const originalAutoSlices = [...metric.metricAutoSlices];
-    const cleanedAutoSlices = metric.metricAutoSlices.filter(
+  const allFactMetrics =
+    await context.models.factMetrics.dangerousGetAllForDependencyScan();
+  const cleanup = allFactMetrics.flatMap((metric) => {
+    if (
+      metric.numerator?.factTableId !== factTableId ||
+      !metric.metricAutoSlices?.length
+    ) {
+      return [];
+    }
+    const metricAutoSlices = metric.metricAutoSlices.filter(
       (sliceColumn) => !removedColumns.includes(sliceColumn),
     );
+    return metricAutoSlices.length === metric.metricAutoSlices.length
+      ? []
+      : [{ metric, metricAutoSlices }];
+  });
 
-    // Only update if there were changes
-    if (cleanedAutoSlices.length !== originalAutoSlices.length) {
-      await context.models.factMetrics.update(metric, {
-        metricAutoSlices: cleanedAutoSlices,
-      });
-    }
+  for (const { metric, metricAutoSlices } of cleanup) {
+    context.models.factMetrics.preflightAutoSliceCleanup(
+      metric,
+      metricAutoSlices,
+    );
+  }
+  return cleanup;
+}
+
+async function applyMetricAutoSliceCleanup(
+  context: ReqContext | ApiReqContext,
+  cleanup: MetricAutoSliceCleanup[],
+): Promise<void> {
+  for (const { metric, metricAutoSlices } of cleanup) {
+    await context.models.factMetrics.updateIfUnchanged(metric, {
+      metricAutoSlices,
+    });
   }
 }
 
@@ -656,7 +660,20 @@ export async function updateColumn({
     dateUpdated: new Date(),
   });
 
-  factTable.columns[columnIndex] = updatedColumn;
+  const nextColumns = factTable.columns.map((existingColumn, index) =>
+    index === columnIndex ? updatedColumn : existingColumn,
+  );
+  const autoSliceCleanup = context
+    ? await prepareMetricAutoSliceCleanup({
+        context,
+        factTableId: factTable.id,
+        removedColumns:
+          updatedColumn.deleted ||
+          (!updatedColumn.isAutoSliceColumn && originalColumn.isAutoSliceColumn)
+            ? [column]
+            : [],
+      })
+    : [];
 
   await FactTableModel.updateOne(
     {
@@ -666,26 +683,18 @@ export async function updateColumn({
     {
       $set: {
         dateUpdated: new Date(),
-        columns: factTable.columns,
+        columns: nextColumns,
       },
     },
   );
+  factTable.columns = nextColumns;
   await touchDefinitionsVersion(
     factTable.organization,
     definitionsScope(factTable.projects),
   );
 
-  // Clean up auto slices from metrics if column was deleted or isAutoSliceColumn was disabled
-  if (
-    context &&
-    (updatedColumn.deleted ||
-      (!updatedColumn.isAutoSliceColumn && originalColumn.isAutoSliceColumn))
-  ) {
-    await cleanupMetricAutoSlices({
-      context,
-      factTableId: factTable.id,
-      removedColumns: [column],
-    });
+  if (context) {
+    await applyMetricAutoSliceCleanup(context, autoSliceCleanup);
   }
 }
 
@@ -932,6 +941,11 @@ export async function deleteColumn(
   }
 
   const columns = factTable.columns.filter((c) => c.column !== columnName);
+  const autoSliceCleanup = await prepareMetricAutoSliceCleanup({
+    context,
+    factTableId: factTable.id,
+    removedColumns: [columnName],
+  });
 
   await FactTableModel.updateOne(
     {
@@ -946,12 +960,7 @@ export async function deleteColumn(
     },
   );
 
-  // A virtual column may be referenced by metric auto-slices; remove those.
-  await cleanupMetricAutoSlices({
-    context,
-    factTableId: factTable.id,
-    removedColumns: [columnName],
-  });
+  await applyMetricAutoSliceCleanup(context, autoSliceCleanup);
 }
 
 export function mergeUpsertColumns(
@@ -1025,8 +1034,13 @@ export async function upsertColumns({
     factTable.columns,
     columns,
   );
-
-  factTable.columns = nextColumns;
+  const autoSliceCleanup = context
+    ? await prepareMetricAutoSliceCleanup({
+        context,
+        factTableId: factTable.id,
+        removedColumns: removedAutoSliceColumns,
+      })
+    : [];
 
   await FactTableModel.updateOne(
     {
@@ -1040,18 +1054,15 @@ export async function upsertColumns({
       },
     },
   );
+  factTable.columns = nextColumns;
 
   await touchDefinitionsVersion(
     factTable.organization,
     definitionsScope(factTable.projects),
   );
 
-  if (context && removedAutoSliceColumns.length > 0) {
-    await cleanupMetricAutoSlices({
-      context,
-      factTableId: factTable.id,
-      removedColumns: removedAutoSliceColumns,
-    });
+  if (context) {
+    await applyMetricAutoSliceCleanup(context, autoSliceCleanup);
   }
 }
 

--- a/packages/back-end/test/api/fact-table-auto-slice-cleanup.test.ts
+++ b/packages/back-end/test/api/fact-table-auto-slice-cleanup.test.ts
@@ -156,17 +156,18 @@ it("checks every affected metric before writing cleanup changes", async () => {
   });
 });
 
-it("does not overwrite a concurrent metric update during cleanup", async () => {
+it("restores earlier cleanup when a later metric changes concurrently", async () => {
+  const firstMetric = makeMetric("fact__a_first_cleanup");
   const metric = makeMetric("fact__concurrent_update");
-  await seed([metric]);
+  await seed([firstMetric, metric]);
   const context = useContext();
   const factMetrics = context.models.factMetrics;
   const updateIfUnchanged = factMetrics.updateIfUnchanged.bind(factMetrics);
 
   jest
     .spyOn(factMetrics, "updateIfUnchanged")
-    .mockImplementationOnce(
-      async (existing, updates, writeOptions, options) => {
+    .mockImplementation(async (existing, updates, writeOptions, options) => {
+      if (existing.id === metric.id) {
         await mongoose.connection.db!.collection("factmetrics").updateOne(
           { id: metric.id, organization: organization.id },
           {
@@ -177,13 +178,20 @@ it("does not overwrite a concurrent metric update during cleanup", async () => {
             },
           },
         );
-        return updateIfUnchanged(existing, updates, writeOptions, options);
-      },
-    );
+      }
+      return updateIfUnchanged(existing, updates, writeOptions, options);
+    });
 
   const response = await updateColumns();
 
   expect(response.status).toBe(409);
+  expect(
+    await mongoose.connection
+      .db!.collection("factmetrics")
+      .findOne({ id: firstMetric.id }),
+  ).toMatchObject({
+    metricAutoSlices: ["country"],
+  });
   expect(
     await mongoose.connection
       .db!.collection("factmetrics")

--- a/packages/back-end/test/api/fact-table-auto-slice-cleanup.test.ts
+++ b/packages/back-end/test/api/fact-table-auto-slice-cleanup.test.ts
@@ -1,0 +1,195 @@
+import mongoose from "mongoose";
+import request from "supertest";
+import { ApiKeyInterface } from "shared/types/apikey";
+import {
+  ColumnInterface,
+  FactMetricInterface,
+  FactTableInterface,
+} from "shared/types/fact-table";
+import { OrganizationInterface } from "shared/types/organization";
+import { ReqContextClass } from "back-end/src/services/context";
+import { factMetricFactory } from "back-end/test/factories/FactMetric.factory";
+import { setupApp } from "./api.setup";
+
+const organization: OrganizationInterface = {
+  id: "org_auto_slice_cleanup",
+  name: "Auto-slice cleanup",
+  ownerEmail: "owner@example.com",
+  url: "",
+  dateCreated: new Date("2026-01-01"),
+  invites: [],
+  members: [],
+  settings: { environments: [] },
+};
+
+const columns: ColumnInterface[] = [
+  {
+    column: "amount",
+    name: "Amount",
+    description: "",
+    numberFormat: "",
+    datatype: "number",
+    dateCreated: new Date("2026-01-01"),
+    dateUpdated: new Date("2026-01-01"),
+    deleted: false,
+  },
+  {
+    column: "country",
+    name: "Country",
+    description: "",
+    numberFormat: "",
+    datatype: "string",
+    dateCreated: new Date("2026-01-01"),
+    dateUpdated: new Date("2026-01-01"),
+    deleted: false,
+    isAutoSliceColumn: true,
+  },
+];
+
+const factTable: FactTableInterface = {
+  organization: organization.id,
+  id: "ftb_auto_slice_cleanup",
+  managedBy: "",
+  dateCreated: new Date("2026-01-01"),
+  dateUpdated: new Date("2026-01-01"),
+  name: "Fact Table",
+  description: "",
+  owner: "",
+  projects: [],
+  tags: [],
+  datasource: "ds_auto_slice_cleanup",
+  userIdTypes: [],
+  sql: "SELECT amount, country FROM events",
+  eventName: "",
+  columns,
+  filters: [],
+  columnRefreshPending: false,
+};
+
+function makeMetric(id: string): FactMetricInterface {
+  return factMetricFactory.build({
+    id,
+    organization: organization.id,
+    datasource: factTable.datasource,
+    owner: "",
+    managedBy: "",
+    name: id,
+    numerator: {
+      factTableId: factTable.id,
+      column: "amount",
+      aggregation: "sum",
+      rowFilters: [],
+    },
+    metricAutoSlices: ["country"],
+    loseRisk: 0.5,
+  });
+}
+
+const { app, setReqContext } = setupApp();
+
+function useContext() {
+  const apiKeyData: ApiKeyInterface = {
+    id: "key_admin",
+    key: "test-key",
+    organization: organization.id,
+    dateCreated: new Date("2026-01-01"),
+    dateUpdated: new Date("2026-01-01"),
+    secret: true,
+    role: "admin",
+    limitAccessByEnvironment: false,
+    environments: [],
+  };
+  const context = new ReqContextClass({
+    org: organization,
+    auditUser: { type: "api_key", apiKey: "test-key" },
+    role: "admin",
+    apiKey: "test-key",
+    apiKeyData,
+  });
+  setReqContext(context);
+  return context;
+}
+
+async function seed(metrics: FactMetricInterface[]) {
+  await mongoose.connection.db!.collection("facttables").insertOne({
+    ...factTable,
+    columns: factTable.columns.map((column) => ({ ...column })),
+  });
+  await mongoose.connection.db!.collection("factmetrics").insertMany(metrics);
+}
+
+async function updateColumns() {
+  return request(app)
+    .post(`/api/v1/fact-tables/${factTable.id}`)
+    .send({ columns: [{ column: "country", isAutoSliceColumn: false }] })
+    .set("Authorization", "Bearer test-key");
+}
+
+it("checks every affected metric before writing cleanup changes", async () => {
+  const allowed = makeMetric("fact__a_allowed");
+  const denied = makeMetric("fact__z_denied");
+  await seed([allowed, denied]);
+  const context = useContext();
+  context.permissions.canUpdateFactMetric = (metric) => metric.id !== denied.id;
+
+  const response = await updateColumns();
+
+  expect(response.status).toBe(403);
+  const storedMetrics = await mongoose.connection
+    .db!.collection("factmetrics")
+    .find({ organization: organization.id })
+    .sort({ id: 1 })
+    .toArray();
+  expect(storedMetrics.map((metric) => metric.metricAutoSlices)).toEqual([
+    ["country"],
+    ["country"],
+  ]);
+  expect(
+    await mongoose.connection
+      .db!.collection("facttables")
+      .findOne({ id: factTable.id }),
+  ).toMatchObject({
+    columns: [
+      { column: "amount" },
+      { column: "country", isAutoSliceColumn: true },
+    ],
+  });
+});
+
+it("does not overwrite a concurrent metric update during cleanup", async () => {
+  const metric = makeMetric("fact__concurrent_update");
+  await seed([metric]);
+  const context = useContext();
+  const factMetrics = context.models.factMetrics;
+  const updateIfUnchanged = factMetrics.updateIfUnchanged.bind(factMetrics);
+
+  jest
+    .spyOn(factMetrics, "updateIfUnchanged")
+    .mockImplementationOnce(
+      async (existing, updates, writeOptions, options) => {
+        await mongoose.connection.db!.collection("factmetrics").updateOne(
+          { id: metric.id, organization: organization.id },
+          {
+            $set: {
+              name: "Concurrent update",
+              metricAutoSlices: ["country", "device"],
+              dateUpdated: new Date(metric.dateUpdated.getTime() + 1_000),
+            },
+          },
+        );
+        return updateIfUnchanged(existing, updates, writeOptions, options);
+      },
+    );
+
+  const response = await updateColumns();
+
+  expect(response.status).toBe(409);
+  expect(
+    await mongoose.connection
+      .db!.collection("factmetrics")
+      .findOne({ id: metric.id }),
+  ).toMatchObject({
+    name: "Concurrent update",
+    metricAutoSlices: ["country", "device"],
+  });
+});


### PR DESCRIPTION
### Features and Changes

- Preflight all auto-slice cleanup updates before writing.
- Use compare-and-swap updates to preserve concurrent Fact Metric changes.

### Testing

- Added API coverage for permission failures and concurrent updates.