### PR TITLE
BigQuery/Trino: improve/fix exact watermark comparison

### DIFF
--- a/packages/back-end/src/integrations/dialects/bigquery.ts
+++ b/packages/back-end/src/integrations/dialects/bigquery.ts
@@ -128,6 +128,14 @@ export const bigQueryDialect: SqlDialect = {
   // TIMESTAMP holds microseconds; %E6S prints all six, in UTC.
   formatTimestampExact: (col: string) =>
     `format_timestamp("%F %H:%M:%E6S", ${col})`,
+  // A fact table's timestamp column may be TIMESTAMP or DATETIME here (see
+  // castUserDateCol), and BigQuery has no implicit coercion between the two:
+  // `datetime_col > CAST('…' AS TIMESTAMP)` is a type error. A bare string
+  // literal instead coerces to whichever type the column has, at microsecond
+  // precision, like every other date bound this dialect renders (toTimestamp).
+  // The watermark is CAST(MAX(col) AS TIMESTAMP) printed in UTC, which for a
+  // DATETIME column is its own wall-clock value, so it round-trips exactly.
+  exactTimestampLiteral: (quoted: string) => quoted,
   castToString: (col: string) => `cast(${col} as string)`,
   stringMatch: createLikeStringMatchFn({
     escapeStringLiteral: bigQueryEscapeStringLiteral,

--- a/packages/back-end/src/integrations/dialects/bigquery.ts
+++ b/packages/back-end/src/integrations/dialects/bigquery.ts
@@ -128,10 +128,10 @@ export const bigQueryDialect: SqlDialect = {
   // TIMESTAMP holds microseconds; %E6S prints all six, in UTC.
   formatTimestampExact: (col: string) =>
     `format_timestamp("%F %H:%M:%E6S", ${col})`,
-  // A fact table's timestamp column may be TIMESTAMP or DATETIME here (see
-  // castUserDateCol), and BigQuery has no implicit coercion between the two:
-  // `datetime_col > CAST('…' AS TIMESTAMP)` is a type error. A bare string
-  // literal instead coerces to whichever type the column has, at microsecond
+  // A fact table's timestamp column may be TIMESTAMP or DATETIME and BigQuery
+  // has no implicit coercion between the two: `datetime_col > CAST('…' AS TIMESTAMP)`
+  // is a type error.
+  // A bare string literal instead coerces to whichever type the column has, at microsecond
   // precision, like every other date bound this dialect renders (toTimestamp).
   // The watermark is CAST(MAX(col) AS TIMESTAMP) printed in UTC, which for a
   // DATETIME column is its own wall-clock value, so it round-trips exactly.

--- a/packages/back-end/src/integrations/dialects/presto.ts
+++ b/packages/back-end/src/integrations/dialects/presto.ts
@@ -24,7 +24,7 @@ export const prestoDialect: SqlDialect = {
   // A typed literal takes its precision from the string, so a timestamp(6)
   // watermark compares exactly with a timestamp(6) column. `CAST(... AS
   // TIMESTAMP)` is timestamp(3) on Trino and rounds the value first. A bare
-  // string is a type error against a timestamp on both Presto and Trino.
+  // string is a type error against a timestamp on Trino/Presto.
   exactTimestampLiteral: (quoted: string) => `TIMESTAMP ${quoted}`,
   dateDiff: (startCol: string, endCol: string) =>
     `date_diff('day', ${startCol}, ${endCol})`,

--- a/packages/back-end/src/integrations/dialects/presto.ts
+++ b/packages/back-end/src/integrations/dialects/presto.ts
@@ -21,6 +21,11 @@ export const prestoDialect: SqlDialect = {
   formatDateTimeString: (col: string) => `to_iso8601(${col})`,
   // Casting preserves the precision of TIMESTAMP(p); date_format truncates it.
   formatTimestampExact: (col: string) => prestoDialect.castToString(col),
+  // A typed literal takes its precision from the string, so a timestamp(6)
+  // watermark compares exactly with a timestamp(6) column. `CAST(... AS
+  // TIMESTAMP)` is timestamp(3) on Trino and rounds the value first. A bare
+  // string is a type error against a timestamp on both Presto and Trino.
+  exactTimestampLiteral: (quoted: string) => `TIMESTAMP ${quoted}`,
   dateDiff: (startCol: string, endCol: string) =>
     `date_diff('day', ${startCol}, ${endCol})`,
   castToFloat: (col: string) => `CAST(${col} AS DOUBLE)`,

--- a/packages/back-end/src/integrations/sql/primitives/watermark.ts
+++ b/packages/back-end/src/integrations/sql/primitives/watermark.ts
@@ -36,7 +36,8 @@ export function rawWatermark(date: Date | null, value: unknown): string | null {
 
 // Predicate selecting rows strictly after a persisted watermark.
 //
-// With the exact `raw` value this is a plain `>`. Without it we only have the
+// With the exact `raw` value this is a plain `>` against that value, written
+// back as the dialect's exactTimestampLiteral. Without it we only have the
 // millisecond-truncated Date, and a strict `> date` would re-match every row
 // inside the watermark's last millisecond on the next refresh (rows at
 // 12:00:00.999999 vs a stored 12:00:00.999), so the append-only caches would
@@ -45,13 +46,17 @@ export function rawWatermark(date: Date | null, value: unknown): string | null {
 // sub-millisecond remainder, which the serial-arrival assumption already
 // tolerates for anything at or before the watermark.
 export function afterWatermark(
-  dialect: Pick<SqlDialect, "castToTimestamp">,
+  dialect: Pick<SqlDialect, "castToTimestamp" | "exactTimestampLiteral">,
   column: string,
   watermark: Date,
   raw?: string | null,
 ): string {
   if (raw && RAW_WATERMARK.test(raw)) {
-    return `${column} > ${dialect.castToTimestamp(`'${raw}'`)}`;
+    const quoted = `'${raw}'`;
+    const literal = dialect.exactTimestampLiteral
+      ? dialect.exactTimestampLiteral(quoted)
+      : dialect.castToTimestamp(quoted);
+    return `${column} > ${literal}`;
   }
   const nextMillisecond = new Date(watermark.getTime() + 1);
   return `${column} >= ${toTimestampWithMs(nextMillisecond)}`;

--- a/packages/back-end/test/integrations/incrementalRefreshWatermark.test.ts
+++ b/packages/back-end/test/integrations/incrementalRefreshWatermark.test.ts
@@ -26,7 +26,10 @@ import { factMetricFactory } from "../factories/FactMetric.factory";
 const watermark = new Date("2024-01-10T12:00:00.999Z");
 const NEXT_MS = "'2024-01-10 12:00:01.000'";
 const RAW = "2024-01-10 12:00:00.999999";
-const AFTER_RAW = `> CAST('${RAW}' AS TIMESTAMP)`;
+// BigQuery writes the exact value back as a bare literal, which coerces to
+// the column's own type (TIMESTAMP or DATETIME); the generic form is a CAST.
+const AFTER_RAW = `> '${RAW}'`;
+const AFTER_RAW_CAST = `> CAST('${RAW}' AS TIMESTAMP)`;
 
 const factTable = factTableFactory.build({
   id: "ft_events",
@@ -155,6 +158,20 @@ describe("afterWatermark", () => {
     expect(afterWatermark(bigQueryDialect, "m.timestamp", watermark, RAW)).toBe(
       `m.timestamp ${AFTER_RAW}`,
     );
+  });
+
+  it("writes the exact value back as a TIMESTAMP cast unless the dialect says otherwise", () => {
+    // A TIMESTAMP-typed bound is the default. BigQuery opts out because its
+    // fact-table timestamp columns may be DATETIME, which does not compare
+    // with TIMESTAMP, while a bare literal coerces to either type.
+    for (const dialect of [baseDialect, snowflakeDialect, prestoDialect]) {
+      expect(afterWatermark(dialect, "m.timestamp", watermark, RAW)).toBe(
+        `m.timestamp ${AFTER_RAW_CAST}`,
+      );
+    }
+    expect(
+      afterWatermark(bigQueryDialect, "m.timestamp", watermark, RAW),
+    ).not.toContain("CAST(");
   });
 
   it("starts from the millisecond after the watermark otherwise", () => {

--- a/packages/back-end/test/integrations/incrementalRefreshWatermark.test.ts
+++ b/packages/back-end/test/integrations/incrementalRefreshWatermark.test.ts
@@ -27,9 +27,8 @@ const watermark = new Date("2024-01-10T12:00:00.999Z");
 const NEXT_MS = "'2024-01-10 12:00:01.000'";
 const RAW = "2024-01-10 12:00:00.999999";
 // BigQuery writes the exact value back as a bare literal, which coerces to
-// the column's own type (TIMESTAMP or DATETIME); the generic form is a CAST.
+// the column's own type (TIMESTAMP or DATETIME).
 const AFTER_RAW = `> '${RAW}'`;
-const AFTER_RAW_CAST = `> CAST('${RAW}' AS TIMESTAMP)`;
 
 const factTable = factTableFactory.build({
   id: "ft_events",
@@ -160,18 +159,22 @@ describe("afterWatermark", () => {
     );
   });
 
-  it("writes the exact value back as a TIMESTAMP cast unless the dialect says otherwise", () => {
-    // A TIMESTAMP-typed bound is the default. BigQuery opts out because its
-    // fact-table timestamp columns may be DATETIME, which does not compare
-    // with TIMESTAMP, while a bare literal coerces to either type.
-    for (const dialect of [baseDialect, snowflakeDialect, prestoDialect]) {
+  it("writes the exact value back in the dialect's literal form", () => {
+    // A TIMESTAMP cast is the default. BigQuery's fact-table timestamp columns
+    // may be DATETIME, which does not compare with TIMESTAMP, so it uses a bare
+    // literal that coerces to either type. Presto's CAST is timestamp(3) and
+    // would round a finer watermark, so it uses a typed literal.
+    for (const dialect of [baseDialect, snowflakeDialect]) {
       expect(afterWatermark(dialect, "m.timestamp", watermark, RAW)).toBe(
-        `m.timestamp ${AFTER_RAW_CAST}`,
+        `m.timestamp > CAST('${RAW}' AS TIMESTAMP)`,
       );
     }
-    expect(
-      afterWatermark(bigQueryDialect, "m.timestamp", watermark, RAW),
-    ).not.toContain("CAST(");
+    expect(afterWatermark(prestoDialect, "m.timestamp", watermark, RAW)).toBe(
+      `m.timestamp > TIMESTAMP '${RAW}'`,
+    );
+    expect(afterWatermark(bigQueryDialect, "m.timestamp", watermark, RAW)).toBe(
+      `m.timestamp ${AFTER_RAW}`,
+    );
   });
 
   it("starts from the millisecond after the watermark otherwise", () => {

--- a/packages/shared/types/sql.d.ts
+++ b/packages/shared/types/sql.d.ts
@@ -170,6 +170,13 @@ export interface SqlDialect {
   // parse back to the identical instant. Used to persist exact incremental
   // refresh watermarks. Dialects without a known-lossless format return NULL.
   formatTimestampExact: (column: string) => string;
+  // Writes a value printed by formatTimestampExact back into an incremental
+  // refresh filter (`<timestamp column> > <this>`). `quoted` is the value as
+  // a quoted SQL string literal. Defaults to castToTimestamp (an explicitly
+  // TIMESTAMP-typed bound); a dialect whose user timestamp columns may be of
+  // several temporal types that don't compare with TIMESTAMP overrides it with
+  // a form the engine coerces to the column's own type.
+  exactTimestampLiteral?: (quoted: string) => string;
   selectStarLimit: (
     from: string,
     limit: number,

--- a/packages/shared/types/sql.d.ts
+++ b/packages/shared/types/sql.d.ts
@@ -170,12 +170,14 @@ export interface SqlDialect {
   // parse back to the identical instant. Used to persist exact incremental
   // refresh watermarks. Dialects without a known-lossless format return NULL.
   formatTimestampExact: (column: string) => string;
-  // Writes a value printed by formatTimestampExact back into an incremental
-  // refresh filter (`<timestamp column> > <this>`). `quoted` is the value as
-  // a quoted SQL string literal. Defaults to castToTimestamp (an explicitly
-  // TIMESTAMP-typed bound); a dialect whose user timestamp columns may be of
-  // several temporal types that don't compare with TIMESTAMP overrides it with
-  // a form the engine coerces to the column's own type.
+  // Renders a quoted 'YYYY-MM-DD HH:MM:SS.fff…' string (the shape
+  // formatTimestampExact prints) as a temporal literal that compares with a
+  // user timestamp column at the string's full precision. Absent,
+  // castToTimestamp is used. Override where that cast can't do the job:
+  // BigQuery returns the bare literal, which coerces to DATETIME or TIMESTAMP
+  // alike; Presto returns a typed literal, whose precision follows the string
+  // where CAST would round it. Used e.g. by incremental refresh filters
+  // (`<column> > <literal>`).
   exactTimestampLiteral?: (quoted: string) => string;
   selectStarLimit: (
     from: string,


### PR DESCRIPTION
### Features and Changes

#6777 made incremental refreshes persist each watermark at full precision (`max_timestamp_raw`) and write it back into the next refresh's filter as `<col> > castToTimestamp('<raw>')`, i.e.

```sql
WHERE m.timestamp > CAST('2024-01-10 12:00:00.999999' AS TIMESTAMP)
```

On BigQuery a fact table's timestamp column is allowed to be `DATETIME` as well as `TIMESTAMP` (that is what `castUserDateCol` exists for), and BigQuery has no implicit coercion between the two types. So for any fact table whose timestamp column is `DATETIME`, the first refresh after upgrading still works (no raw watermark stored yet → the `>= '<watermark + 1ms>'` fallback), but every refresh after that fails with:

```
No matching signature for operator > for argument types: DATETIME, TIMESTAMP
```

and the experiment's results silently stop advancing for metrics on that fact table. `TIMESTAMP` columns are unaffected.

Every other date-range bound the SQL builder renders against a user timestamp column on BigQuery is a bare string literal (`toTimestamp`, `toTimestampWithMs`, and #6777's own +1 ms fallback one line below), which BigQuery coerces to the column's own type — see the "BQ datetime cast for SELECT statements (do not use for where)" note in `fact-metric-cte.ts`. The exact-watermark branch was the one place a TIMESTAMP-typed bound met the raw column.

This PR:

- adds an optional `SqlDialect.exactTimestampLiteral(quoted)` hook for how the exact watermark value is written back into the filter; `afterWatermark` uses it when a dialect defines it and otherwise keeps `castToTimestamp`, so **Snowflake, Presto and every other dialect render byte-identical SQL**;
- implements it for BigQuery as the bare literal, so BigQuery now renders

  ```sql
  WHERE m.timestamp > '2024-01-10 12:00:00.999999'
  ```

  which is valid against both `TIMESTAMP` and `DATETIME` columns (fact-metric CTE, incremental units query, and the two covariate inserts all go through `afterWatermark`).

What does **not** change: the strict `>`, microsecond precision (BigQuery parses `'YYYY-MM-DD HH:MM:SS.ffffff'` to the same microsecond bare or via `CAST`; the equality edge was checked both ways), the UTC interpretation (a bare literal compared with a `TIMESTAMP` column is read in the session time zone exactly as `CAST(... AS TIMESTAMP)` is, and the stored value is `CAST(MAX(col) AS TIMESTAMP)` printed by `format_timestamp` in that same zone — for a `DATETIME` column that is its own wall-clock value, so it round-trips exactly for both types), the `RAW_WATERMARK` guard on the interpolated value (the hook only ever receives the regex-validated, quoted value), `rawWatermark`, the +1 ms fallback, and the scan-end clamp.

Alternatives considered and why not:

- `CAST(col AS TIMESTAMP) > CAST('…' AS TIMESTAMP)` — also type-correct on BigQuery, but a dry run shows the column-side cast defeats partition pruning when the column is a `DATETIME` partitioning column (the bare literal keeps it; on `TIMESTAMP` partition columns both forms prune identically), and in shared code it would change semantics elsewhere (e.g. Snowflake's `TIMESTAMP` is `TIMESTAMP_NTZ`).
- Rendering by column type — fact-table column metadata records `datatype: "date"` for `TIMESTAMP`, `DATETIME` and `DATE` alike, so the type isn't known when the SQL is built.
- A bare literal for every dialect — several dialects deliberately avoid bare date literals (`from_iso8601_timestamp`, `TIMESTAMP'…'`, `toDateTime`), so the explicit cast stays the default and only BigQuery, whose convention already is bare literals, opts out.

Observation, out of scope for this PR: a fact table whose timestamp column is `DATE` does not work on BigQuery before or after this change, because the ordinary inclusive start filter `date_col >= 'YYYY-MM-DD HH:MM:SS'` is already rejected ("Could not cast literal … to type DATE").

- Closes: n/a (regression from #6777; no issue filed)

### Dependencies

None.

### Testing

- `packages/back-end/test/integrations/incrementalRefreshWatermark.test.ts`: the BigQuery-integration expectations for the units, metric-source, covariate and aggregated-fact-table queries now assert the bare literal; a new case pins the `CAST('…' AS TIMESTAMP)` form for the base, Snowflake and Presto dialects and asserts BigQuery's form contains no `CAST(`. The existing injection case (`"1' OR '1'='1"` → fallback) is unchanged and still passes.
- Against a real BigQuery project (dry runs of the metric-source query shape `SELECT … FROM (<fact table sql>) m WHERE <bound> AND m.timestamp <= '…'`):
  - fact table with a `DATETIME` timestamp (`DATETIME_ADD(CAST(date_col AS DATETIME), INTERVAL 1 DAY) AS timestamp`): before → `No matching signature for operator > for argument types: DATETIME, TIMESTAMP`; after → valid, same bytes scanned as the +1 ms fallback form;
  - fact table with a `TIMESTAMP` timestamp: before and after both valid with identical bytes scanned (partition pruning unchanged);
  - zero-byte literal checks: `DATETIME '…12:00:00.500000' > '…12:00:00.499999'` → true, `DATETIME '…499999' > '…499999'` → false; `TIMESTAMP '…499999+00' > '…499999'` → false and `=` → true; `format_timestamp('%F %H:%M:%E6S', CAST(DATETIME '2024-01-10 12:00:00.123456' AS TIMESTAMP))` → `'2024-01-10 12:00:00.123456'`; with `SET @@time_zone` to a non-UTC zone the bare literal and the `CAST` still agree with each other and with `format_timestamp`'s output.
- `prettier --check` on the touched files.

### Screenshots

n/a (SQL generation only)
