### PR TITLE
Show the user's local timezone on schedule date pickers

### DIFF
--- a/packages/front-end/components/DatePicker/index.tsx
+++ b/packages/front-end/components/DatePicker/index.tsx
@@ -10,7 +10,11 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { getValidDate, getValidDateOffsetByUTC } from "shared/dates";
+import {
+  getValidDate,
+  getValidDateOffsetByUTC,
+  timezoneShortLabel,
+} from "shared/dates";
 import { Flex } from "@radix-ui/themes";
 import clsx from "clsx";
 import { debounce } from "lodash";
@@ -30,6 +34,12 @@ type Props = {
   /** When using a range (`setDate2`), shown if `label` is omitted. */
   label2?: ReactNode;
   helpText?: ReactNode;
+  /**
+   * Note under the field that the time is interpreted in the viewer's local
+   * timezone. Use on datetime pickers that schedule a future action, where a
+   * viewer might otherwise assume UTC or a fixed server timezone.
+   */
+  showTimezone?: boolean;
   inputWidth?: number;
   precision?: "datetime" | "date";
   disableBefore?: Date | string;
@@ -104,6 +114,7 @@ export default function DatePicker({
   label,
   label2,
   helpText,
+  showTimezone,
   inputWidth,
   precision = "datetime",
   disableBefore,
@@ -578,6 +589,12 @@ export default function DatePicker({
         </Popover.Portal>
       </Popover.Root>
       {helpText && <small className="form-text text-muted">{helpText}</small>}
+      {showTimezone && (
+        <small className="form-text text-muted">
+          Time is in your local timezone (
+          {timezoneShortLabel(date ? parseDateInput(date) : new Date())})
+        </small>
+      )}
     </div>
   );
 }

--- a/packages/front-end/components/Experiment/EditScheduleModal.tsx
+++ b/packages/front-end/components/Experiment/EditScheduleModal.tsx
@@ -2,7 +2,11 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { ExperimentInterfaceStringDates } from "shared/types/experiment";
 import { DEFAULT_DECISION_FRAMEWORK_ENABLED } from "shared/constants";
-import { getValidDate, resolveScheduleStopAfter } from "shared/dates";
+import {
+  getValidDate,
+  resolveScheduleStopAfter,
+  timezoneShortLabel,
+} from "shared/dates";
 import { PiArrowSquareOut } from "react-icons/pi";
 import { Box, Flex, Separator } from "@radix-ui/themes";
 import Tooltip from "@/ui/Tooltip";
@@ -409,17 +413,22 @@ export default function EditScheduleModal({
                 disabled={experiment.status !== "draft"}
               />
               {startAt && (
-                <DatePicker
-                  label=""
-                  date={startAt || undefined}
-                  setDate={(d) =>
-                    form.setValue("startAt", d ? d.toISOString() : "")
-                  }
-                  precision="datetime"
-                  scheduleEndDate={stopAt || undefined}
-                  disableBefore={now}
-                  disabled={experiment.status !== "draft"}
-                />
+                <>
+                  <DatePicker
+                    label=""
+                    date={startAt || undefined}
+                    setDate={(d) =>
+                      form.setValue("startAt", d ? d.toISOString() : "")
+                    }
+                    precision="datetime"
+                    scheduleEndDate={stopAt || undefined}
+                    disableBefore={now}
+                    disabled={experiment.status !== "draft"}
+                  />
+                  <Text size="sm" color="text-low">
+                    ({timezoneShortLabel(startAt)})
+                  </Text>
+                </>
               )}
             </ScheduleRow>
 
@@ -452,16 +461,21 @@ export default function EditScheduleModal({
                 containerStyle={{ width: 150 }}
               />
               {endMode === "on-date" && (
-                <DatePicker
-                  label=""
-                  date={stopAt || undefined}
-                  setDate={(d) =>
-                    form.setValue("stopAt", d ? d.toISOString() : "")
-                  }
-                  precision="datetime"
-                  scheduleStartDate={startAt || undefined}
-                  disableBefore={startAt ? new Date(startAt) : now}
-                />
+                <>
+                  <DatePicker
+                    label=""
+                    date={stopAt || undefined}
+                    setDate={(d) =>
+                      form.setValue("stopAt", d ? d.toISOString() : "")
+                    }
+                    precision="datetime"
+                    scheduleStartDate={startAt || undefined}
+                    disableBefore={startAt ? new Date(startAt) : now}
+                  />
+                  <Text size="sm" color="text-low">
+                    ({timezoneShortLabel(stopAt || new Date())})
+                  </Text>
+                </>
               )}
               {endMode === "after" && (
                 <Flex align="center" gap="3">

--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -22,7 +22,7 @@ import {
   PiProhibit,
   PiClockFill,
 } from "react-icons/pi";
-import { ago, datetime } from "shared/dates";
+import { ago, datetime, timezoneShortLabel } from "shared/dates";
 import { filterEnvironmentsByFeature, getReviewSetting } from "shared/util";
 import {
   isScheduledPublishPending,
@@ -669,7 +669,11 @@ export default function FeaturesOverview({
                         <>
                           This <strong>draft</strong> is scheduled to publish on{" "}
                           <strong>
-                            {datetime(revision.scheduledPublishAt as Date)}
+                            {datetime(revision.scheduledPublishAt as Date)} (
+                            {timezoneShortLabel(
+                              revision.scheduledPublishAt as Date,
+                            )}
+                            )
                           </strong>
                           {awaitingApproval ? " once approved" : ""}
                           {lockClauses.length

--- a/packages/front-end/components/Features/RuleModal/RampScheduleSection.tsx
+++ b/packages/front-end/components/Features/RuleModal/RampScheduleSection.tsx
@@ -51,7 +51,7 @@ import {
   resolveStartApproval,
   DEFAULT_NO_TRAFFIC_GRACE_PERIOD_HOURS,
 } from "shared/validators";
-import { date as formatDate } from "shared/dates";
+import { date as formatDate, timezoneShortLabel } from "shared/dates";
 import { parsePlainJSONObject } from "shared/util";
 import { BsThreeDotsVertical } from "react-icons/bs";
 import { HiBadgeCheck } from "react-icons/hi";
@@ -3683,6 +3683,9 @@ export default function RampScheduleSection({
         precision="datetime"
         disableBefore={new Date().toISOString()}
       />
+      <Text size="sm" color="text-low">
+        ({timezoneShortLabel(state.cutoffDate || new Date())})
+      </Text>
       <IconButton
         variant="ghost"
         color="gray"
@@ -3797,11 +3800,16 @@ export default function RampScheduleSection({
         containerStyle={{ width: 150 }}
       />
       {state.startDate && (
-        <DatePicker
-          date={state.startDate || undefined}
-          setDate={(d) => patchState({ startDate: d ? d.toISOString() : "" })}
-          precision="datetime"
-        />
+        <>
+          <DatePicker
+            date={state.startDate || undefined}
+            setDate={(d) => patchState({ startDate: d ? d.toISOString() : "" })}
+            precision="datetime"
+          />
+          <Text size="sm" color="text-low">
+            ({timezoneShortLabel(state.startDate)})
+          </Text>
+        </>
       )}
     </Flex>
   ) : null;

--- a/packages/front-end/components/Features/RuleModal/ScheduleInputs.tsx
+++ b/packages/front-end/components/Features/RuleModal/ScheduleInputs.tsx
@@ -4,7 +4,9 @@
 // identical to the ramp schedule path.
 
 import { Flex } from "@radix-ui/themes";
+import { timezoneShortLabel } from "shared/dates";
 import Heading from "@/ui/Heading";
+import Text from "@/ui/Text";
 import SelectField from "@/components/Forms/SelectField";
 import DatePicker from "@/components/DatePicker";
 import ScheduleRow from "@/components/Schedule/ScheduleRow";
@@ -178,6 +180,16 @@ export default function ScheduleInputs({
           />
         )}
       </ScheduleRow>
+
+      {(state.startDate || endTriggerValue === "specific-time") && (
+        <Text size="sm" color="text-low">
+          Times are in your local timezone (
+          {timezoneShortLabel(
+            state.startDate || state.endScheduleAt || new Date(),
+          )}
+          )
+        </Text>
+      )}
     </Flex>
   );
 }

--- a/packages/front-end/components/Features/RuleModal/ScheduleInputs.tsx
+++ b/packages/front-end/components/Features/RuleModal/ScheduleInputs.tsx
@@ -140,14 +140,21 @@ export default function ScheduleInputs({
           formatOptionLabel={formatOptionLabel}
         />
         {state.startDate && (
-          <DatePicker
-            date={state.startDate || undefined}
-            setDate={(d) => patchState({ startDate: d ? d.toISOString() : "" })}
-            precision="datetime"
-            containerClassName="mb-0"
-            scheduleEndDate={state.endScheduleAt || undefined}
-            disabled={startDisabled}
-          />
+          <>
+            <DatePicker
+              date={state.startDate || undefined}
+              setDate={(d) =>
+                patchState({ startDate: d ? d.toISOString() : "" })
+              }
+              precision="datetime"
+              containerClassName="mb-0"
+              scheduleEndDate={state.endScheduleAt || undefined}
+              disabled={startDisabled}
+            />
+            <Text size="sm" color="text-low">
+              ({timezoneShortLabel(state.startDate)})
+            </Text>
+          </>
         )}
       </ScheduleRow>
 
@@ -165,29 +172,30 @@ export default function ScheduleInputs({
           formatOptionLabel={formatOptionLabel}
         />
         {endTriggerValue === "specific-time" && (
-          <DatePicker
-            date={state.endScheduleAt || undefined}
-            setDate={(d) =>
-              patchState({ endScheduleAt: d ? d.toISOString() : "" })
-            }
-            precision="datetime"
-            containerClassName="mb-0"
-            scheduleStartDate={state.startDate || undefined}
-            disableBefore={
-              state.startDate ? new Date(state.startDate) : new Date()
-            }
-            disabled={disabled}
-          />
+          <>
+            <DatePicker
+              date={state.endScheduleAt || undefined}
+              setDate={(d) =>
+                patchState({ endScheduleAt: d ? d.toISOString() : "" })
+              }
+              precision="datetime"
+              containerClassName="mb-0"
+              scheduleStartDate={state.startDate || undefined}
+              disableBefore={
+                state.startDate ? new Date(state.startDate) : new Date()
+              }
+              disabled={disabled}
+            />
+            <Text size="sm" color="text-low">
+              ({timezoneShortLabel(state.endScheduleAt || new Date())})
+            </Text>
+          </>
         )}
       </ScheduleRow>
 
       {(state.startDate || endTriggerValue === "specific-time") && (
         <Text size="sm" color="text-low">
-          Times are in your local timezone (
-          {timezoneShortLabel(
-            state.startDate || state.endScheduleAt || new Date(),
-          )}
-          )
+          Times are in your local timezone
         </Text>
       )}
     </Flex>

--- a/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
+++ b/packages/front-end/components/Reviews/Feature/ReviewAndPublish.tsx
@@ -57,6 +57,7 @@ import {
 import { BsThreeDotsVertical } from "react-icons/bs";
 import { Box, Flex, IconButton } from "@radix-ui/themes";
 import { format } from "date-fns";
+import { timezoneShortLabel } from "shared/dates";
 import EventUser from "@/components/Avatar/EventUser";
 import { getCurrentUser, useUser } from "@/services/UserContext";
 import { useAuth } from "@/services/auth";
@@ -971,7 +972,8 @@ export default function ReviewAndPublish({
         title="Scheduled to publish"
         body={
           <>
-            {format(new Date(revision.scheduledPublishAt as Date), "PPp")}
+            {format(new Date(revision.scheduledPublishAt as Date), "PPp")} (
+            {timezoneShortLabel(new Date(revision.scheduledPublishAt as Date))})
             {lockActive ? "" : " · pending approval"}
           </>
         }
@@ -2890,6 +2892,7 @@ export default function ReviewAndPublish({
                             }
                             precision="datetime"
                             disableBefore={new Date().toISOString()}
+                            showTimezone
                           />
                           <Flex align="center" gap="1" mt="2">
                             <Checkbox

--- a/packages/front-end/components/Reviews/ScheduledPublishControl.tsx
+++ b/packages/front-end/components/Reviews/ScheduledPublishControl.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useEffect, useState } from "react";
 import { Box, Flex } from "@radix-ui/themes";
 import { format } from "date-fns";
+import { timezoneShortLabel } from "shared/dates";
 import { PiClockFill, PiLock } from "react-icons/pi";
 import { useUser } from "@/services/UserContext";
 import { useAuth } from "@/services/auth";
@@ -439,7 +440,8 @@ export default function ScheduledPublishControl({
           title="Scheduled to publish"
           body={
             <>
-              {format(new Date(scheduledAtIso), "PPp")}
+              {format(new Date(scheduledAtIso), "PPp")} (
+              {timezoneShortLabel(scheduledAtIso)})
               {pending && !lockActive ? " · pending approval" : ""}
             </>
           }
@@ -592,6 +594,7 @@ export default function ScheduledPublishControl({
                 setDate={(d) => onDateChange(d ? d.toISOString() : "")}
                 precision="datetime"
                 disableBefore={new Date().toISOString()}
+                showTimezone
               />
               <Flex align="center" gap="1" mt="2">
                 <Checkbox

--- a/packages/front-end/components/Revision/RevisionSummaryCard.tsx
+++ b/packages/front-end/components/Revision/RevisionSummaryCard.tsx
@@ -12,7 +12,7 @@ import {
   isScheduledPublishPending,
   isScheduledPublishLockActive,
 } from "shared/enterprise";
-import { datetime, ago } from "shared/dates";
+import { datetime, ago, timezoneShortLabel } from "shared/dates";
 import { Box, Flex, IconButton, Separator } from "@radix-ui/themes";
 import {
   PiPencil,
@@ -233,7 +233,11 @@ export default function RevisionSummaryCard({
               <>
                 This <strong>draft</strong> is scheduled to publish on{" "}
                 <strong>
-                  {datetime(selectedRevision.scheduledPublishAt as Date)}
+                  {datetime(selectedRevision.scheduledPublishAt as Date)} (
+                  {timezoneShortLabel(
+                    selectedRevision.scheduledPublishAt as Date,
+                  )}
+                  )
                 </strong>
                 {awaitingApproval ? " once approved" : ""}
                 {lockClauses.length ? ` — ${lockClauses.join(" and ")}` : ""}

--- a/packages/shared/src/dates.ts
+++ b/packages/shared/src/dates.ts
@@ -55,6 +55,19 @@ export function timestamp(date: string | Date, inTimezone?: string): string {
     ? formatInTimeZone(d, inTimezone, formatStr)
     : format(d, formatStr);
 }
+/**
+ * Short label for the timezone a date renders in, e.g. "PST" or "GMT+2".
+ * Evaluated at the given date, not now — across a DST boundary the offset in
+ * effect at the scheduled time is the one that matters.
+ */
+export function timezoneShortLabel(
+  date: string | Date = new Date(),
+  inTimezone?: string,
+): string {
+  const zone = inTimezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+  return formatInTimeZone(getValidDate(date), zone, "zzz");
+}
+
 export function relativeDate(date: string | Date): string {
   if (!date) return "";
   return formatRelative(getValidDate(date), new Date());

--- a/packages/shared/test/dates.test.ts
+++ b/packages/shared/test/dates.test.ts
@@ -3,6 +3,7 @@ import {
   getValidDate,
   resolveScheduleStopAfter,
   resolveScheduledStop,
+  timezoneShortLabel,
 } from "../src/dates";
 
 describe("getValidDate", () => {
@@ -156,5 +157,25 @@ describe("resolveScheduledStop", () => {
     expect(r.stopAt).toBeNull();
     expect(r.stopAfter).toBeNull();
     expect(r.stagedStop).toBeNull();
+  });
+});
+
+describe("timezoneShortLabel", () => {
+  it("evaluates the label at the given date, so DST resolves correctly", () => {
+    expect(timezoneShortLabel("2026-01-15T12:00:00Z", "America/New_York")).toBe(
+      "EST",
+    );
+    expect(timezoneShortLabel("2026-07-15T12:00:00Z", "America/New_York")).toBe(
+      "EDT",
+    );
+  });
+
+  it("falls back to a GMT offset for zones without an abbreviation", () => {
+    expect(timezoneShortLabel("2026-07-15T12:00:00Z", "Europe/Berlin")).toBe(
+      "GMT+2",
+    );
+    expect(timezoneShortLabel("2026-01-15T12:00:00Z", "Europe/Berlin")).toBe(
+      "GMT+1",
+    );
   });
 });


### PR DESCRIPTION
When setting up an auto-publish schedule (or any other future-dated automation), the datetime input is interpreted in the viewer's **browser local timezone**, stored as UTC, and fired at that absolute instant. However, nothing in the UI said so, and users don't know what time zone is used. This change shows the timezone to the user to remove doubt.

<img width="370" height="377" alt="Screenshot 2026-09-05 at 3 34 54 PM" src="https://github.com/user-attachments/assets/7ed2adee-e253-4ed2-913b-065d1074c915" />
<img width="579" height="199" alt="Screenshot 2026-09-05 at 3 33 18 PM" src="https://github.com/user-attachments/assets/9d38a627-0c3a-48ec-9720-6b4d56791591" />

