### PR TITLE
docs: document sticky bucket cookie WAF false positives

### DIFF
--- a/docs/app/sticky-bucketing.mdx
+++ b/docs/app/sticky-bucketing.mdx
@@ -126,6 +126,8 @@ Suppose your website integrates GrowthBook on the front end only. You would like
 
 In our JavaScript and React SDKs, we provide 2 different Sticky Bucket Services that make sense in this scenario: `LocalStorageStickyBucketService` and `BrowserCookieStickyBucketService`. You can instantiate either of these services and plug them into the GrowthBook SDK.
 
+If you use `BrowserCookieStickyBucketService` behind a Web Application Firewall, see [Sticky Bucket Cookies and WAF False Positives](/kb/sdks/sticky-bucket-cookie-encoding) — the cookie's default encoding can trigger generic SQL injection rules.
+
 ### Front-end and Back-end (Node.js)
 
 Let's expand the "front-end only" example above so that our back-end controllers also integrate with GrowthBook and can reference the same experiments. In this scenario, we would like both the front-end and back-end to perform bucketing and persist a sticky bucket that reliably crosses the front-end / back-end divide.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -347,6 +347,10 @@
                     "group": "Metrics",
                     "pages": ["kb/metrics/fact-metric-optimization"]
                   },
+                  {
+                    "group": "SDKs",
+                    "pages": ["kb/sdks/sticky-bucket-cookie-encoding"]
+                  },
                   "kb/glossary"
                 ]
               },

--- a/docs/kb/sdks/sticky-bucket-cookie-encoding.mdx
+++ b/docs/kb/sdks/sticky-bucket-cookie-encoding.mdx
@@ -1,0 +1,111 @@
+---
+title: Sticky Bucket Cookies and WAF False Positives
+description: Why the browser sticky bucket cookie is only partially percent-encoded, how that can trigger a WAF SQL injection rule, and how to fix it.
+sidebarTitle: Sticky Bucket Cookies and WAFs
+slug: sticky-bucket-cookie-encoding
+---
+
+`BrowserCookieStickyBucketService` writes cookies that are only partially percent-encoded. `{`, `}` and `:` stay literal in the cookie value, and `|` stays literal in the cookie name.
+
+This is valid per [RFC 6265](https://datatracker.ietf.org/doc/html/rfc6265), and every GrowthBook SDK reads it correctly. But generic Web Application Firewall (WAF) rulesets — including Cloudflare's OWASP Core Ruleset — pattern-match those characters and may score the cookie as an SQL injection attempt. The WAF then acts on the **request**, and because the cookie is sent on every request once set, you can end up challenging or blocking every legitimate user.
+
+## Symptoms
+
+- Users get a Managed Challenge, CAPTCHA, or block page on a site with no bot problem.
+- It persists across page loads and stops only when the sticky bucket cookie is cleared.
+- WAF logs show an SQL injection or OWASP anomaly-score rule firing on a cookie or the `Cookie` header.
+- The cookie name starts with `gbStickyBuckets__`.
+
+A cookie written by the browser service looks like this:
+
+```
+gbStickyBuckets__id||e49b8ce1-c7ec-47c7-af50-e059b561a54e={%22attributeName%22:%22id%22%2C%22assignments%22:{%22pro...
+```
+
+`"` and `,` are encoded as `%22` and `%2C`, but `{`, `}` and `:` are not — and the name contains a literal `||`.
+
+## Start with your WAF logs
+
+Find the rule ID that fired and the field it matched on. That detail decides which fix below will work: the first one changes the cookie **value** only, and cannot help if the rule is matching the **name**.
+
+## Fixes
+
+### 1. Pass a custom `js-cookie` converter
+
+The best option in most cases. Give `js-cookie` a write converter that doesn't revert any characters:
+
+```js
+import Cookies from "js-cookie";
+import { BrowserCookieStickyBucketService } from "@growthbook/growthbook";
+
+const stickyBucketService = new BrowserCookieStickyBucketService({
+  jsCookie: Cookies.withConverter({
+    write: (value) => encodeURIComponent(value),
+  }),
+});
+```
+
+The value is now fully encoded, with `{`, `}` and `:` written as `%7B`, `%7D` and `%3A`.
+
+This is safe to roll out. `decodeURIComponent` handles the old and new forms identically, so cookies already in users' browsers keep working, edge and server-side readers need no change, and no sticky bucket assignments need migrating.
+
+<Warning>
+  `withConverter({ write })` replaces the *value* converter only. `js-cookie` encodes the cookie name on a separate internal path, so the `||` is still written literally. If your rule matches on the cookie name — or on `||` anywhere in the `Cookie` header — this won't clear the block.
+</Warning>
+
+### 2. Scope a WAF exception
+
+Skip the Managed Challenge (or the specific OWASP rule ID) for this cookie, as narrowly as you can:
+
+- Match `gbStickyBuckets__*`, not all cookies.
+- Restrict the rule to the path or host serving your app.
+- Skip the one rule ID that is firing, not the whole ruleset.
+
+### 3. Switch to `localStorage`
+
+`LocalStorageStickyBucketService` removes the cookie entirely, so the WAF has nothing to match on.
+
+This only works if nothing outside the browser reads the sticky bucket. A CDN edge worker that evaluates features server-side — for example a [Cloudflare Worker](/lib/edge/cloudflare) — needs that cookie.
+
+## Why it happens
+
+Two things combine.
+
+**GrowthBook builds the cookie name with pipes.** `StickyBucketService.getKey()` returns `` `${prefix}${attributeName}||${attributeValue}` ``.
+
+**`js-cookie` leaves some characters literal on purpose.** Its default write converter runs `encodeURIComponent` over the value, then reverts these characters — all permitted by RFC 6265 — for readability:
+
+```
+# $ & + / : < = > ? @ [ ] ^ ` { | }
+```
+
+The cookie **name** goes through a separate hardcoded path that reverts a shorter list, which is why the pipes survive:
+
+```
+# $ & + ^ ` |
+```
+
+`BrowserCookieStickyBucketService` passes its `JSON.stringify` output straight to `jsCookie.set()`, leaving all encoding to `js-cookie`. Neither piece is a bug on its own; the problem is the combination meeting a generic ruleset.
+
+<Note>
+  `ExpressCookieStickyBucketService` encodes both name and value in full, so the same document written server-side looks different on the wire:
+
+```
+gbStickyBuckets__id%7C%7Cabc-123=%7B%22attributeName%22%3A%22id%22%2C...
+```
+
+  Both forms decode identically, so interop is unaffected — but a rule matching a literal `||` fires on the client-written cookie only.
+</Note>
+
+Verified against `@growthbook/growthbook` 1.7.x with `js-cookie` v3.
+
+## Reporting to support
+
+If you still need help, include:
+
+1. The SDK, its version, and which sticky bucket service you use.
+2. Where the cookie is written — client-side, server-side, or a proxy/CDN.
+3. The raw `Set-Cookie` response header, not the devtools cookie panel view.
+4. **The WAF rule ID that fired, and the field it matched on.**
+
+Item 4 is the one that determines which fix will actually work.

--- a/docs/lib/js.mdx
+++ b/docs/lib/js.mdx
@@ -486,7 +486,7 @@ Sticky bucketing ensures that users see the same experiment variant, even when u
 - `LocalStorageStickyBucketService` —
   For simple bucket persistence using the browser's LocalStorage (can be polyfilled for other environments).
 
-- `BrowserCookieStickyBucketService` — For simple bucket persistence using browser cookies, which are transportable to the back end. Assumes `js-cookie` is implemented (can be polyfilled). Cookie attributes can also be configured. The default cookie expiry is 180 days; override by passing `expires: {days}` into the constructor's `cookieAttributes`.
+- `BrowserCookieStickyBucketService` — For simple bucket persistence using browser cookies, which are transportable to the back end. Assumes `js-cookie` is implemented (can be polyfilled). Cookie attributes can also be configured. The default cookie expiry is 180 days; override by passing `expires: {days}` into the constructor's `cookieAttributes`. If your site sits behind a Web Application Firewall, see [Sticky Bucket Cookies and WAF False Positives](/kb/sdks/sticky-bucket-cookie-encoding).
 
 - Build your own — Implement the abstract `StickyBucketService` class and connect to your own data store, or custom wrap multiple service implementations (ex: read/write to both cookies and Redis).
 

--- a/docs/lib/react.mdx
+++ b/docs/lib/react.mdx
@@ -569,7 +569,7 @@ Sticky bucketing ensures that users see the same experiment variant, even when u
 - `LocalStorageStickyBucketService` —
   For simple bucket persistence using the browser's LocalStorage (can be polyfilled for other environments).
 
-- `BrowserCookieStickyBucketService` — For simple bucket persistence using browser cookies, which are transportable to the back end. Assumes `js-cookie` is implemented (can be polyfilled). Cookie attributes can also be configured. The default cookie expiry is 180 days; override by passing `expires: {days}` into the constructor's `cookieAttributes`.
+- `BrowserCookieStickyBucketService` — For simple bucket persistence using browser cookies, which are transportable to the back end. Assumes `js-cookie` is implemented (can be polyfilled). Cookie attributes can also be configured. The default cookie expiry is 180 days; override by passing `expires: {days}` into the constructor's `cookieAttributes`. If your site sits behind a Web Application Firewall, see [Sticky Bucket Cookies and WAF False Positives](/kb/sdks/sticky-bucket-cookie-encoding).
 
 - Build your own — Implement the abstract `StickyBucketService` class and connect to your own data store, or custom wrap multiple service implementations (ex: read/write to both cookies and Redis).
 


### PR DESCRIPTION
# docs: add KB article on sticky bucket cookie encoding and WAF false positives

## What

New Knowledge Base article on why `BrowserCookieStickyBucketService` writes partially percent-encoded cookies, how that trips generic WAF SQL injection rules (e.g. Cloudflare's OWASP Core Ruleset), and three fixes.

Page: `docs/kb/sdks/sticky-bucket-cookie-encoding.mdx` → `/kb/sdks/sticky-bucket-cookie-encoding`

## Why here

It's a diagnosis-plus-fix article, which is what the KB is for (cf. `kb/experiments/troubleshooting-experiments`, `kb/google-analytics/*-troubleshooting`). The alternatives fit worse: `app/sticky-bucketing.mdx` is the conceptual setup page and this would bury the instructions; `lib/js.mdx` and `lib/react.mdx` are API reference and would need duplicate copies; `faq.mdx` entries run a few paragraphs, not a root cause plus three scoped fixes.

Adds an **SDKs** group under Knowledge Base, matching the existing Experiments / Google Analytics / Metrics grouping. One page for now, but SDK troubleshooting has no home today.

## Changes

- `docs/kb/sdks/sticky-bucket-cookie-encoding.mdx` — new article
- `docs/docs.json` — new "SDKs" group under Knowledge Base
- `docs/app/sticky-bucketing.mdx` — cross-link from the front-end-only example
- `docs/lib/js.mdx`, `docs/lib/react.mdx` — one-line cross-link on the `BrowserCookieStickyBucketService` bullet

## Verification

Claims were checked against `packages/sdk-js/src/sticky-bucket-service.ts` and `js-cookie` 3.0.7, then reproduced by writing real cookies with `@growthbook/growthbook@1.7.0` in jsdom. Confirmed:

- `getKey()` builds `${prefix}${attributeName}||${attributeValue}`; default prefix `gbStickyBuckets__`.
- `saveAssignmentsSync()` passes the `JSON.stringify` output to `jsCookie.set()` unencoded on every branch, including the newer domain-scoped one.
- The default write produces exactly the mixed encoding shown in the article.
- `Cookies.withConverter({ write })` fully encodes the value but leaves the name's `||` literal, so the warning in the article is real rather than theoretical.
- `withConverter` merges into the default converter, so `read` is untouched. A converter-configured instance reads old cookies and a default instance reads new ones — the "safe to roll out" claim holds in both directions.
- `ExpressCookieStickyBucketService` encodes name and value in full: `gbStickyBuckets__id%7C%7Cabc-123=%7B%22attributeName%22%3A...`.

Two corrections to the source material along the way:

1. The `js-cookie` value revert list was missing `/`. The regex `%(2[346BF]|3[AC-F]|40|5[BDE]|60|7[BCD])` reverts eighteen characters, and the article now lists all of them.
2. A code excerpt of `saveAssignmentsSync` was out of date — the method has since gained domain scoping and a host-only fallback. Rather than reproduce the current code and risk the same drift, the article describes the behaviour in prose.

## Notes for reviewers

- Documents current behaviour; proposes no code change. If we later change the default write path, "Why it happens" and the roll-out claim in fix 1 need revisiting — full encoding is read-compatible with existing cookies, changing the `||` separator in `getKey()` is not.
- The article pins the behaviour to `@growthbook/growthbook` 1.7.x + `js-cookie` v3. Worth a look if the SDK ever moves to js-cookie v4.
- No redirects needed; new path.