### PR TITLE
Silently restart stale OAuth login attempts and stretch the state TTL to 24h

### DIFF
--- a/packages/back-end/src/controllers/auth.ts
+++ b/packages/back-end/src/controllers/auth.ts
@@ -40,6 +40,7 @@ import {
   getUserById,
 } from "back-end/src/models/UserModel";
 import { AuthRefreshModel } from "back-end/src/models/AuthRefreshModel";
+import { RetriableAuthError } from "back-end/src/services/auth/authChecks";
 import { reissueAttributionCookie } from "back-end/src/util/signup-attribution";
 
 export async function getHasOrganizations(req: Request, res: Response) {
@@ -142,6 +143,8 @@ export async function postOAuthCallback(req: Request, res: Response) {
     return res.status(400).json({
       status: 400,
       message: "Error Signing In",
+      // The front-end silently restarts the login for failures a fresh flow fixes
+      ...(e instanceof RetriableAuthError && { code: "stale_login_attempt" }),
     });
   }
 }

--- a/packages/back-end/src/services/auth/OpenIdAuthConnection.ts
+++ b/packages/back-end/src/services/auth/OpenIdAuthConnection.ts
@@ -38,6 +38,7 @@ import {
 import { AuthConnection, TokensResponse } from "./AuthConnection";
 import {
   createNonce,
+  RetriableAuthError,
   deriveAuthChecks,
   isNonceExpired,
   nonceFromState,
@@ -134,12 +135,12 @@ export class OpenIdAuthConnection implements AuthConnection {
 
     const secret = AuthSecretCookie.getValue(req);
     if (!secret) {
-      throw new Error("Missing auth secret cookie");
+      throw new RetriableAuthError("Missing auth secret cookie");
     }
 
     const nonce = nonceFromState(params.state);
     if (isNonceExpired(nonce)) {
-      throw new Error("Login attempt expired");
+      throw new RetriableAuthError("Login attempt expired");
     }
 
     // A wrong connection or forged state fails the HMAC comparison inside callback()

--- a/packages/back-end/src/services/auth/authChecks.ts
+++ b/packages/back-end/src/services/auth/authChecks.ts
@@ -1,7 +1,11 @@
 import crypto from "crypto";
 
-// AUTH_SECRET lives ~1 year, so the nonce embeds its mint time to keep callbacks from validating indefinitely
-const NONCE_TTL_MS = 60 * 60 * 1000;
+// AUTH_SECRET lives ~1 year, so the nonce embeds its mint time to keep callbacks from validating indefinitely.
+// 24h covers tabs parked on the IdP overnight; anything staler restarts silently client-side.
+const NONCE_TTL_MS = 24 * 60 * 60 * 1000;
+
+// A failure the browser can fix by silently starting a fresh login flow
+export class RetriableAuthError extends Error {}
 
 export function createNonce(): string {
   return `${Date.now().toString(36)}.${crypto

--- a/packages/back-end/test/services/authChecks.test.ts
+++ b/packages/back-end/test/services/authChecks.test.ts
@@ -28,13 +28,13 @@ describe("deriveAuthChecks", () => {
   });
 
   it("expires stale, future, and malformed nonces", () => {
-    const twoHours = 2 * 60 * 60 * 1000;
-    expect(isNonceExpired(`${(Date.now() - twoHours).toString(36)}.x`)).toBe(
-      true,
-    );
-    expect(isNonceExpired(`${(Date.now() + twoHours).toString(36)}.x`)).toBe(
-      true,
-    );
+    const twentyFiveHours = 25 * 60 * 60 * 1000;
+    expect(
+      isNonceExpired(`${(Date.now() - twentyFiveHours).toString(36)}.x`),
+    ).toBe(true);
+    expect(
+      isNonceExpired(`${(Date.now() + twentyFiveHours).toString(36)}.x`),
+    ).toBe(true);
     expect(isNonceExpired("")).toBe(true);
     expect(isNonceExpired(".x")).toBe(true);
   });

--- a/packages/back-end/test/services/authChecks.test.ts
+++ b/packages/back-end/test/services/authChecks.test.ts
@@ -28,7 +28,11 @@ describe("deriveAuthChecks", () => {
   });
 
   it("expires stale, future, and malformed nonces", () => {
+    const twentyThreeHours = 23 * 60 * 60 * 1000;
     const twentyFiveHours = 25 * 60 * 60 * 1000;
+    expect(
+      isNonceExpired(`${(Date.now() - twentyThreeHours).toString(36)}.x`),
+    ).toBe(false);
     expect(
       isNonceExpired(`${(Date.now() - twentyFiveHours).toString(36)}.x`),
     ).toBe(true);

--- a/packages/front-end/pages/oauth/callback.tsx
+++ b/packages/front-end/pages/oauth/callback.tsx
@@ -3,7 +3,22 @@ import { useEffect, useState } from "react";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import { OAuthError } from "@/components/OAuthError";
 import { getApiHost } from "@/services/env";
-import { getPostAuthRedirectPath } from "@/services/auth";
+import { getPostAuthRedirectPath, redirectWithTimeout } from "@/services/auth";
+
+// At most one silent restart a minute, so a persistent failure still surfaces the error page
+const canAutoRestart = () => {
+  try {
+    const last = parseInt(
+      window.sessionStorage.getItem("gb-login-restart") || "0",
+      10,
+    );
+    if (Date.now() - last < 60_000) return false;
+    window.sessionStorage.setItem("gb-login-restart", `${Date.now()}`);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
 
 export default function OAuthCallbackPage() {
   const router = useRouter();
@@ -29,6 +44,14 @@ export default function OAuthCallbackPage() {
         const refresh = await post("/auth/refresh").catch(() => null);
         if (refresh?.token) {
           return router.replace(getPostAuthRedirectPath({ consume: true }));
+        }
+        // A stale attempt (e.g. a tab parked on the IdP overnight) is fixed by a fresh flow
+        if (
+          json?.code === "stale_login_attempt" &&
+          refresh?.redirectURI &&
+          canAutoRestart()
+        ) {
+          return redirectWithTimeout(refresh.redirectURI);
         }
         setError(json?.message || "An unknown error occurred");
       })

--- a/packages/front-end/pages/oauth/callback.tsx
+++ b/packages/front-end/pages/oauth/callback.tsx
@@ -15,7 +15,7 @@ const canAutoRestart = () => {
     if (Date.now() - last < 60_000) return false;
     window.sessionStorage.setItem("gb-login-restart", `${Date.now()}`);
     return true;
-  } catch (e) {
+  } catch {
     return false;
   }
 };


### PR DESCRIPTION
### Features and Changes

#6753 halved OAuth sign-in failures, but there's still one main type we can fix in the prod logs. `Login attempt expired` happens when a tab waiting on the IdP goes past the TTL, so completing it later fails.

Two fixes for this:
1. The nonce TTL goes from 1 hour to 24, covering old tabs overnight but still bounding replay of a leaked auth URL. 
2. Expired or secret-less callbacks are now marked retriable, so the callback page handles it instead of showing the error. Restarts are limited to one a minute per tab, so a persistent failure still surfaces the error page. The deep link isn't consumed until a callback succeeds, so the restarted flow still lands on the original page.

### Testing

- [x] Unit tests cover the new TTL bounds
- [x] Real back-end: a generic callback failure carries no retriable code
- [x] Headless Chrome against the dev stack with mocked callback/refresh responses: a stale attempt silently restarts to the fresh flow's redirect; the follow-up success lands on the original deep link; a second stale attempt within a minute shows the error page instead; the logged-in-elsewhere fallback still wins; a non-retriable failure never restarts
- [ ] Post-deploy: `Login attempt expired` in the prod API logs drops from 50–210/day

🤖 Generated with [Claude Code](https://claude.com/claude-code)
