### PR TITLE
Fix: remove 24h limit to report canceling

### DIFF
--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -626,10 +626,10 @@ export async function cancelReport(
   }
 
   if (report.type === "experiment-snapshot") {
-    const snapshot = report.snapshot
-      ? (await findLatestRunningSnapshotByReportId(context, report.id)) ||
-        undefined
-      : undefined;
+    const snapshot = await findLatestRunningSnapshotByReportId(
+      context,
+      report.id,
+    );
     if (!snapshot) {
       return res.status(400).json({
         status: 400,

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -1045,18 +1045,17 @@ export async function findLatestRunningSnapshotByReportId(
   context: Context,
   report: string,
 ) {
-  // Only look for match in the past 24 hours to make the query more efficient
-  // Older snapshots should not still be running anyway
-  const earliestDate = new Date();
-  earliestDate.setDate(earliestDate.getDate() - 1);
-
-  const doc = await ExperimentSnapshotModel.findOne({
-    organization: context.org.id,
-    report,
-    status: "running",
-    dateCreated: { $gt: earliestDate },
-    queries: { $elemMatch: { status: "running" } },
-  });
+  // Scoped to one report + org; do not date-bound — jobs can still be in flight after 24h.
+  const doc = await ExperimentSnapshotModel.findOne(
+    {
+      organization: context.org.id,
+      report,
+      status: "running",
+      queries: { $elemMatch: { status: { $in: ["running", "queued"] } } },
+    },
+    null,
+    { sort: { dateCreated: -1 } },
+  );
 
   return doc ? toInterface(doc) : null;
 }


### PR DESCRIPTION
Fix cancellation of stalled reports older than 24 hours by removing the snapshot lookup’s age cutoff. Include queued queries and select the latest running snapshot.

Willing to accept slightly slower mongo queries for this fairly low-usage endpoint where instead we should prioritize reliability.