### PR TITLE
docs: add native GTM integration in docs.json

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1199,6 +1199,11 @@
       "href": "https://app.growthbook.io/"
     }
   },
+  "integrations": {
+    "gtm": {
+      "tagId": "GTM-MF7GKV4V"
+    }
+  },
   "footer": {
     "socials": {
       "x": "https://twitter.com/growth_book",


### PR DESCRIPTION
## Summary
- Add Mintlify's native Google Tag Manager integration (`GTM-MF7GKV4V`) to `docs.json` so the GTM script is injected on all docs pages.
- No existing `ga4` block was present, so nothing was removed. Tracking GA4 only through GTM avoids duplicate pageviews.
