### PR TITLE
fix(query-runner): heartbeat queued query docs

### DIFF
--- a/packages/back-end/src/jobs/expireOldQueries.ts
+++ b/packages/back-end/src/jobs/expireOldQueries.ts
@@ -1,5 +1,5 @@
 import Agenda from "agenda";
-import { Queries } from "shared/types/query";
+import { Queries, QueryInterface } from "shared/types/query";
 import {
   AggregatedFactTableInterface,
   AggregatedFactTableRunInterface,
@@ -43,7 +43,18 @@ const JOB_NAME = "expireOldQueries";
 const STALLED_SNAPSHOT_THRESHOLD_MS = 60 * 60 * 1000;
 // The allowable time between the last query finishing and the snapshot being finalized
 const STALLED_FINALIZE_GRACE_MS = 10 * 60 * 1000;
-const STALLED_SNAPSHOT_REAP_LIMIT = 50;
+// The runner beats every queued query doc it owns every 30 seconds, so ten
+// missed beats is enough to conclude the DAG.
+const QUEUED_HEARTBEAT_STALE_MS = 5 * 60 * 1000;
+// createNewQuery stamps createdAt and heartbeat from two separate `new Date()`
+// calls, so a never-heartbeated doc can show a gap of a millisecond. A real
+// beat is at least one 30s tick later. This is what keeps docs owned by
+// pre-deploy processes on the 1 hour rule during rollout.
+const HEARTBEAT_ADVANCE_MIN_MS = 1000;
+// With a 5 minute candidate window every long-running live snapshot is a
+// candidate on every tick, so a page that filled up with live waiters would
+// starve newer dead ones.
+const STALLED_SNAPSHOT_REAP_LIMIT = 200;
 
 // Accessed via raw collections (not context-scoped BaseModel) so this cross-org reaper needs no per-run org context.
 const AGGREGATED_FACT_TABLE_RUN_COLLECTION = "aggregatedfacttableruns";
@@ -232,12 +243,75 @@ const expireOldQueries = async () => {
   }
 };
 
+export type StalledQueryStatus = Pick<
+  QueryInterface,
+  "id" | "status" | "finishedAt" | "heartbeat" | "createdAt"
+>;
+
+export type StalledSnapshotVerdict =
+  | "active" // leave alone this tick
+  | "stalled-terminal" // every query terminal, snapshot never finalized
+  | "orphaned-dead" // nothing running, queued docs were heartbeated and all beats are stale
+  | "orphaned-unknown"; // nothing running, queued docs never heartbeated
+
+export function classifyStalledSnapshot({
+  statuses,
+  snapshotDateCreated,
+  now,
+}: {
+  statuses: StalledQueryStatus[];
+  snapshotDateCreated: Date;
+  now: number;
+}): StalledSnapshotVerdict {
+  const running = statuses.filter((q) => q.status === "running");
+  const queued = statuses.filter((q) => q.status === "queued");
+
+  const age = now - snapshotDateCreated.getTime();
+  const latestFinishedAt = Math.max(
+    0,
+    ...statuses.map((s) => s.finishedAt?.getTime() ?? 0),
+  );
+  // Orphaned DAGs may have no finished queries, so fall back to snapshot age.
+  const lastActivityAt =
+    latestFinishedAt > 0 ? latestFinishedAt : snapshotDateCreated.getTime();
+  const withinLegacyRule =
+    age >= STALLED_SNAPSHOT_THRESHOLD_MS &&
+    now - lastActivityAt >= STALLED_FINALIZE_GRACE_MS;
+
+  if (running.length > 0) return "active";
+  if (queued.length === 0) {
+    return withinLegacyRule ? "stalled-terminal" : "active";
+  }
+
+  const heartbeated = queued.filter(
+    (q) =>
+      q.heartbeat &&
+      q.createdAt &&
+      q.heartbeat.getTime() - q.createdAt.getTime() >= HEARTBEAT_ADVANCE_MIN_MS,
+  );
+  if (heartbeated.length === 0) {
+    return withinLegacyRule ? "orphaned-unknown" : "active";
+  }
+
+  // The newest beat decides: a runner beats all of its queued docs in one
+  // updateMany, so any fresh beat means the owner is still alive.
+  const newestBeat = Math.max(...heartbeated.map((q) => q.heartbeat.getTime()));
+  return now - newestBeat >= QUEUED_HEARTBEAT_STALE_MS
+    ? "orphaned-dead"
+    : "active";
+}
+
 async function reapStalledSnapshots() {
-  const stalledBefore = new Date(Date.now() - STALLED_SNAPSHOT_THRESHOLD_MS);
+  const now = Date.now();
   const candidates = await dangerousFindStalledRunningSnapshotsFromAllOrgs(
-    stalledBefore,
+    new Date(now - QUEUED_HEARTBEAT_STALE_MS),
     STALLED_SNAPSHOT_REAP_LIMIT,
   );
+  if (candidates.length >= STALLED_SNAPSHOT_REAP_LIMIT) {
+    logger.warn(
+      `Stalled-snapshot reaper candidate page is full (${STALLED_SNAPSHOT_REAP_LIMIT}); newer stalled snapshots may be delayed`,
+    );
+  }
 
   for (const snapshot of candidates) {
     const queryIds = [...new Set(snapshot.queries.map((q) => q.query))];
@@ -249,26 +323,15 @@ async function reapStalledSnapshots() {
     );
     if (statuses.length !== queryIds.length) continue;
 
-    const running = statuses.filter((q) => q.status === "running");
     const queued = statuses.filter((q) => q.status === "queued");
-    const allTerminal = statuses.every(
-      (q) => q.status === "succeeded" || q.status === "failed",
-    );
-
-    // Queued queries have no heartbeat. If the in-memory runner disappears
-    // before starting them, the normal stale-query path will never see them.
-    const orphanedDag = running.length === 0 && queued.length > 0;
-
-    if (!allTerminal && !orphanedDag) continue;
-
-    const latestFinishedAt = Math.max(
-      0,
-      ...statuses.map((s) => s.finishedAt?.getTime() ?? 0),
-    );
-    // Orphaned DAGs may have no finished queries, so fall back to snapshot age.
-    const lastActivityAt =
-      latestFinishedAt > 0 ? latestFinishedAt : snapshot.dateCreated.getTime();
-    if (Date.now() - lastActivityAt < STALLED_FINALIZE_GRACE_MS) continue;
+    const verdict = classifyStalledSnapshot({
+      statuses,
+      snapshotDateCreated: snapshot.dateCreated,
+      now,
+    });
+    if (verdict === "active") continue;
+    const orphanedDag =
+      verdict === "orphaned-dead" || verdict === "orphaned-unknown";
 
     const statusById = new Map(statuses.map((s) => [s.id, s.status]));
     snapshot.queries.forEach((q) => {

--- a/packages/back-end/src/jobs/expireOldQueries.ts
+++ b/packages/back-end/src/jobs/expireOldQueries.ts
@@ -44,7 +44,7 @@ const STALLED_SNAPSHOT_THRESHOLD_MS = 60 * 60 * 1000;
 // The allowable time between the last query finishing and the snapshot being finalized
 const STALLED_FINALIZE_GRACE_MS = 10 * 60 * 1000;
 // The runner beats every queued query doc it owns every 30 seconds; 5 minutes
-// without a beat is ten missed beats, enough to conclude consider it stalled
+// without a beat is ten missed beats, enough to consider it stalled
 const QUEUED_HEARTBEAT_STALE_MS = 5 * 60 * 1000;
 // createNewQuery stamps createdAt and heartbeat from two separate `new Date()`
 // calls, so a never-heartbeated doc shows a gap of about a millisecond. A real

--- a/packages/back-end/src/jobs/expireOldQueries.ts
+++ b/packages/back-end/src/jobs/expireOldQueries.ts
@@ -52,9 +52,11 @@ const QUEUED_HEARTBEAT_STALE_MS = 5 * 60 * 1000;
 // This ensures we don't consider just created docs as stalled.
 const HEARTBEAT_MIN_GAP_MS = 1000;
 // With a 5 minute candidate window every long-running live snapshot is a
-// candidate on every tick. If the page ever fills with live waiters, newer
-// dead ones wait until older candidates resolve; the warn below surfaces it.
+// candidate on every tick, so the snapshot reaper pages past live waiters
+// instead of stopping at the first page. This caps the work one tick can do;
+// the warn below surfaces it.
 const STALLED_SNAPSHOT_REAP_LIMIT = 50;
+const STALLED_SNAPSHOT_REAP_MAX_PER_TICK = 500;
 
 // Accessed via raw collections (not context-scoped BaseModel) so this cross-org reaper needs no per-run org context.
 const AGGREGATED_FACT_TABLE_RUN_COLLECTION = "aggregatedfacttableruns";
@@ -301,19 +303,36 @@ export function classifyStalledSnapshot({
     : "active";
 }
 
+// Oldest-first pages of running snapshots older than the heartbeat window,
+// excluding ids already yielded so a page of live waiters can't hide newer
+// dead snapshots behind it.
+async function* stalledSnapshotCandidates(stalledBefore: Date) {
+  const seen: string[] = [];
+  while (seen.length < STALLED_SNAPSHOT_REAP_MAX_PER_TICK) {
+    const page = await dangerousFindStalledRunningSnapshotsFromAllOrgs(
+      stalledBefore,
+      Math.min(
+        STALLED_SNAPSHOT_REAP_LIMIT,
+        STALLED_SNAPSHOT_REAP_MAX_PER_TICK - seen.length,
+      ),
+      seen,
+    );
+    if (!page.length) return;
+    for (const snapshot of page) {
+      seen.push(snapshot.id);
+      yield snapshot;
+    }
+  }
+  logger.warn(
+    `Stalled-snapshot reaper examined ${STALLED_SNAPSHOT_REAP_MAX_PER_TICK} candidates this tick; newer stalled snapshots may be delayed`,
+  );
+}
+
 async function reapStalledSnapshots() {
   const now = Date.now();
-  const candidates = await dangerousFindStalledRunningSnapshotsFromAllOrgs(
-    new Date(now - QUEUED_HEARTBEAT_STALE_MS),
-    STALLED_SNAPSHOT_REAP_LIMIT,
-  );
-  if (candidates.length >= STALLED_SNAPSHOT_REAP_LIMIT) {
-    logger.warn(
-      `Stalled-snapshot reaper candidate page is full (${STALLED_SNAPSHOT_REAP_LIMIT}); newer stalled snapshots may be delayed`,
-    );
-  }
+  const stalledBefore = new Date(now - QUEUED_HEARTBEAT_STALE_MS);
 
-  for (const snapshot of candidates) {
+  for await (const snapshot of stalledSnapshotCandidates(stalledBefore)) {
     const queryIds = [...new Set(snapshot.queries.map((q) => q.query))];
     if (!queryIds.length) continue;
 

--- a/packages/back-end/src/jobs/expireOldQueries.ts
+++ b/packages/back-end/src/jobs/expireOldQueries.ts
@@ -43,18 +43,18 @@ const JOB_NAME = "expireOldQueries";
 const STALLED_SNAPSHOT_THRESHOLD_MS = 60 * 60 * 1000;
 // The allowable time between the last query finishing and the snapshot being finalized
 const STALLED_FINALIZE_GRACE_MS = 10 * 60 * 1000;
-// The runner beats every queued query doc it owns every 30 seconds, so ten
-// missed beats is enough to conclude the DAG.
+// The runner beats every queued query doc it owns every 30 seconds; 5 minutes
+// without a beat is ten missed beats, enough to conclude consider it stalled
 const QUEUED_HEARTBEAT_STALE_MS = 5 * 60 * 1000;
 // createNewQuery stamps createdAt and heartbeat from two separate `new Date()`
-// calls, so a never-heartbeated doc can show a gap of a millisecond. A real
-// beat is at least one 30s tick later. This is what keeps docs owned by
-// pre-deploy processes on the 1 hour rule during rollout.
-const HEARTBEAT_ADVANCE_MIN_MS = 1000;
+// calls, so a never-heartbeated doc shows a gap of about a millisecond. A real
+// beat lands at least one 30s tick later, so a 1s gap separates the two.
+// This ensures we don't consider just created docs as stalled.
+const HEARTBEAT_MIN_GAP_MS = 1000;
 // With a 5 minute candidate window every long-running live snapshot is a
-// candidate on every tick, so a page that filled up with live waiters would
-// starve newer dead ones.
-const STALLED_SNAPSHOT_REAP_LIMIT = 200;
+// candidate on every tick. If the page ever fills with live waiters, newer
+// dead ones wait until older candidates resolve; the warn below surfaces it.
+const STALLED_SNAPSHOT_REAP_LIMIT = 50;
 
 // Accessed via raw collections (not context-scoped BaseModel) so this cross-org reaper needs no per-run org context.
 const AGGREGATED_FACT_TABLE_RUN_COLLECTION = "aggregatedfacttableruns";
@@ -255,21 +255,21 @@ export type StalledSnapshotVerdict =
   | "orphaned-unknown"; // nothing running, queued docs never heartbeated
 
 export function classifyStalledSnapshot({
-  statuses,
+  queryStatuses,
   snapshotDateCreated,
   now,
 }: {
-  statuses: StalledQueryStatus[];
+  queryStatuses: StalledQueryStatus[];
   snapshotDateCreated: Date;
   now: number;
 }): StalledSnapshotVerdict {
-  const running = statuses.filter((q) => q.status === "running");
-  const queued = statuses.filter((q) => q.status === "queued");
+  const running = queryStatuses.filter((q) => q.status === "running");
+  const queued = queryStatuses.filter((q) => q.status === "queued");
 
   const age = now - snapshotDateCreated.getTime();
   const latestFinishedAt = Math.max(
     0,
-    ...statuses.map((s) => s.finishedAt?.getTime() ?? 0),
+    ...queryStatuses.map((s) => s.finishedAt?.getTime() ?? 0),
   );
   // Orphaned DAGs may have no finished queries, so fall back to snapshot age.
   const lastActivityAt =
@@ -287,7 +287,7 @@ export function classifyStalledSnapshot({
     (q) =>
       q.heartbeat &&
       q.createdAt &&
-      q.heartbeat.getTime() - q.createdAt.getTime() >= HEARTBEAT_ADVANCE_MIN_MS,
+      q.heartbeat.getTime() - q.createdAt.getTime() >= HEARTBEAT_MIN_GAP_MS,
   );
   if (heartbeated.length === 0) {
     return withinLegacyRule ? "orphaned-unknown" : "active";
@@ -317,34 +317,34 @@ async function reapStalledSnapshots() {
     const queryIds = [...new Set(snapshot.queries.map((q) => q.query))];
     if (!queryIds.length) continue;
 
-    const statuses = await getQueryStatusesByIds(
+    const queryStatuses = await getQueryStatusesByIds(
       snapshot.organization,
       queryIds,
     );
-    if (statuses.length !== queryIds.length) continue;
+    if (queryStatuses.length !== queryIds.length) continue;
 
-    const queued = statuses.filter((q) => q.status === "queued");
+    const queued = queryStatuses.filter((q) => q.status === "queued");
     const verdict = classifyStalledSnapshot({
-      statuses,
+      queryStatuses,
       snapshotDateCreated: snapshot.dateCreated,
       now,
     });
     if (verdict === "active") continue;
-    const orphanedDag =
+    const isOrphanedDag =
       verdict === "orphaned-dead" || verdict === "orphaned-unknown";
 
-    const statusById = new Map(statuses.map((s) => [s.id, s.status]));
+    const statusById = new Map(queryStatuses.map((s) => [s.id, s.status]));
     snapshot.queries.forEach((q) => {
       q.status = statusById.get(q.query) ?? q.status;
     });
 
     const shouldScheduleSnapshotRetry =
-      orphanedDag &&
+      isOrphanedDag &&
       !snapshot.report &&
       snapshot.type === "standard" &&
       snapshot.triggeredBy === "schedule";
 
-    const error = orphanedDag
+    const error = isOrphanedDag
       ? shouldScheduleSnapshotRetry
         ? "Snapshot stalled: queries were never started. This can happen when the server restarts mid-refresh. A retry has been scheduled."
         : "Snapshot stalled: queries were never started. This can happen when the server restarts mid-refresh. Please try updating results again."
@@ -358,12 +358,12 @@ async function reapStalledSnapshots() {
     if (!reaped) continue;
 
     logger.info(
-      orphanedDag
+      isOrphanedDag
         ? `Reaped orphaned snapshot ${snapshot.id} (experiment ${snapshot.experiment}): ${queued.length} of ${queryIds.length} queries stuck in "queued" with nothing running`
         : `Reaped stalled snapshot ${snapshot.id} (experiment ${snapshot.experiment}): all ${queryIds.length} queries terminal but status still running`,
     );
 
-    if (orphanedDag) {
+    if (isOrphanedDag) {
       await markPendingQueriesAsFailed(
         context,
         queued.map((q) => q.id),

--- a/packages/back-end/src/jobs/expireOldQueries.ts
+++ b/packages/back-end/src/jobs/expireOldQueries.ts
@@ -265,10 +265,13 @@ export function classifyStalledSnapshot({
   snapshotDateCreated: Date;
   now: number;
 }): StalledSnapshotVerdict {
-  const running = queryStatuses.filter((q) => q.status === "running");
+  if (queryStatuses.some((q) => q.status === "running")) {
+    return "active";
+  }
+
   const queued = queryStatuses.filter((q) => q.status === "queued");
 
-  const age = now - snapshotDateCreated.getTime();
+  const snapshotAge = now - snapshotDateCreated.getTime();
   const latestFinishedAt = Math.max(
     0,
     ...queryStatuses.map((s) => s.finishedAt?.getTime() ?? 0),
@@ -276,13 +279,14 @@ export function classifyStalledSnapshot({
   // Orphaned DAGs may have no finished queries, so fall back to snapshot age.
   const lastActivityAt =
     latestFinishedAt > 0 ? latestFinishedAt : snapshotDateCreated.getTime();
-  const withinLegacyRule =
-    age >= STALLED_SNAPSHOT_THRESHOLD_MS &&
+  // Before heartbeats for queued queries, snapshots were considered stalled if they
+  // were at least 60 minutes old, with no running queries and none finishing in the last 10 minutes.
+  const meetsFallbackLegacyCriteria =
+    snapshotAge >= STALLED_SNAPSHOT_THRESHOLD_MS &&
     now - lastActivityAt >= STALLED_FINALIZE_GRACE_MS;
 
-  if (running.length > 0) return "active";
   if (queued.length === 0) {
-    return withinLegacyRule ? "stalled-terminal" : "active";
+    return meetsFallbackLegacyCriteria ? "stalled-terminal" : "active";
   }
 
   const heartbeated = queued.filter(
@@ -292,7 +296,7 @@ export function classifyStalledSnapshot({
       q.heartbeat.getTime() - q.createdAt.getTime() >= HEARTBEAT_MIN_GAP_MS,
   );
   if (heartbeated.length === 0) {
-    return withinLegacyRule ? "orphaned-unknown" : "active";
+    return meetsFallbackLegacyCriteria ? "orphaned-unknown" : "active";
   }
 
   // The newest beat decides: a runner beats all of its queued docs in one

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -1033,6 +1033,7 @@ export async function errorSnapshotIfStillRunning(
 export async function dangerousFindStalledRunningSnapshotsFromAllOrgs(
   stalledBefore: Date,
   limit: number,
+  excludeIds: string[] = [],
 ) {
   // Only look back 24 hours to keep the scan bounded
   const earliestDate = new Date();
@@ -1041,6 +1042,7 @@ export async function dangerousFindStalledRunningSnapshotsFromAllOrgs(
   const docs = await ExperimentSnapshotModel.find({
     status: "running",
     dateCreated: { $gt: earliestDate, $lt: stalledBefore },
+    ...(excludeIds.length ? { id: { $nin: excludeIds } } : {}),
   })
     .sort({ dateCreated: 1 })
     .limit(limit);

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -248,6 +248,11 @@ experimentSnapshotSchema.index({
   status: 1,
   dateCreated: -1,
 });
+// Backs the cross-org stalled-snapshot reaper scan, which runs every minute.
+experimentSnapshotSchema.index({
+  status: 1,
+  dateCreated: -1,
+});
 
 export type ExperimentSnapshotDocument = mongoose.Document &
   LegacyExperimentSnapshotInterface;
@@ -1036,7 +1041,9 @@ export async function dangerousFindStalledRunningSnapshotsFromAllOrgs(
   const docs = await ExperimentSnapshotModel.find({
     status: "running",
     dateCreated: { $gt: earliestDate, $lt: stalledBefore },
-  }).limit(limit);
+  })
+    .sort({ dateCreated: 1 })
+    .limit(limit);
 
   return docs.map((doc) => toInterface(doc));
 }

--- a/packages/back-end/src/models/QueryModel.ts
+++ b/packages/back-end/src/models/QueryModel.ts
@@ -274,9 +274,7 @@ export async function touchQueuedQueriesHeartbeat(
   ids: string[],
 ): Promise<number> {
   if (!ids.length) return 0;
-  // Filtered on "queued" in Mongo, not on the caller's pointer status, which
-  // lags: a doc already promoted to running must not get a queued-style beat,
-  // and a never-resolved cache-copy doc would otherwise stay alive forever.
+
   const result = await QueryModel.updateMany(
     {
       organization: context.org.id,

--- a/packages/back-end/src/models/QueryModel.ts
+++ b/packages/back-end/src/models/QueryModel.ts
@@ -84,16 +84,23 @@ export async function getQueriesByIds(
 export async function getQueryStatusesByIds(
   organization: string,
   ids: string[],
-): Promise<Pick<QueryInterface, "id" | "status" | "finishedAt">[]> {
+): Promise<
+  Pick<
+    QueryInterface,
+    "id" | "status" | "finishedAt" | "heartbeat" | "createdAt"
+  >[]
+> {
   if (!ids.length) return [];
   const docs = await QueryModel.find(
     { organization, id: { $in: ids } },
-    { id: 1, status: 1, finishedAt: 1, _id: 0 },
+    { id: 1, status: 1, finishedAt: 1, heartbeat: 1, createdAt: 1, _id: 0 },
   );
   return docs.map((d) => ({
     id: d.id,
     status: d.status,
     finishedAt: d.finishedAt,
+    heartbeat: d.heartbeat,
+    createdAt: d.createdAt,
   }));
 }
 

--- a/packages/back-end/src/models/QueryModel.ts
+++ b/packages/back-end/src/models/QueryModel.ts
@@ -258,6 +258,29 @@ export async function markPendingQueriesAsFailed(
   return result.modifiedCount;
 }
 
+/**
+ * Prove the owning runner is still alive for queries it hasn't started yet.
+ * Returns the number affected.
+ */
+export async function touchQueuedQueriesHeartbeat(
+  context: ReqContext | ApiReqContext,
+  ids: string[],
+): Promise<number> {
+  if (!ids.length) return 0;
+  // Filtered on "queued" in Mongo, not on the caller's pointer status, which
+  // lags: a doc already promoted to running must not get a queued-style beat,
+  // and a never-resolved cache-copy doc would otherwise stay alive forever.
+  const result = await QueryModel.updateMany(
+    {
+      organization: context.org.id,
+      id: { $in: ids },
+      status: "queued",
+    },
+    { $set: { heartbeat: new Date() } },
+  );
+  return result.modifiedCount;
+}
+
 export async function getRecentQuery(
   organization: string,
   datasource: string,

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -16,6 +16,7 @@ import {
   getQueriesByIds,
   getRecentQuery,
   markPendingQueriesAsFailed,
+  touchQueuedQueriesHeartbeat,
   updateQuery,
   updateQueryIfPending,
   updateQueryIfRunning,
@@ -310,7 +311,24 @@ export abstract class QueryRunner<
     if (this.lockHeartbeatTimer) return;
     this.lockHeartbeatTimer = setInterval(() => {
       this.onHeartbeat();
+      this.heartbeatQueuedQueries();
     }, 30000);
+  }
+
+  /**
+   * Lets the stalled-snapshot reaper tell a live runner whose queries are
+   * waiting on the concurrency cap from a runner whose process died.
+   */
+  private heartbeatQueuedQueries(): void {
+    // "running" pointers are included because pointer status lags Mongo; the
+    // model's own "queued" filter decides which docs get the beat.
+    const ids = this.model.queries
+      .filter((q) => q.status === "queued" || q.status === "running")
+      .map((q) => q.query);
+    if (!ids.length) return;
+    touchQueuedQueriesHeartbeat(this.context, ids).catch((e) =>
+      logger.warn(e, `Failed to heartbeat queued queries for ${this.model.id}`),
+    );
   }
 
   private stopLockHeartbeat(): void {

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -223,7 +223,7 @@ export abstract class QueryRunner<
   private dagPersisted = false;
   private useCache: boolean;
   private pendingTimers: Record<string, NodeJS.Timeout> = {};
-  private lockHeartbeatTimer: null | NodeJS.Timeout = null;
+  private heartbeatTimer: null | NodeJS.Timeout = null;
   private refreshWatchdogTimer: null | NodeJS.Timeout = null;
   /** Non-null while a refresh pass is in flight; watchdog skips re-arm then. */
   private refreshStartedAt: number | null = null;
@@ -307,34 +307,31 @@ export abstract class QueryRunner<
    */
   protected onHeartbeat(): void {}
 
-  private startLockHeartbeat(): void {
-    if (this.lockHeartbeatTimer) return;
-    this.lockHeartbeatTimer = setInterval(() => {
+  private startHeartbeat(): void {
+    if (this.heartbeatTimer) return;
+    this.heartbeatTimer = setInterval(() => {
       this.onHeartbeat();
       this.heartbeatQueuedQueries();
     }, 30000);
   }
 
   /**
-   * Lets the stalled-snapshot reaper tell a live runner whose queries are
-   * waiting on the concurrency cap from a runner whose process died.
+   * While the query is queued, update the heartbeat to show that this
+   * runner is still alive and monitoring the dependencies and will start
+   * the query when ready.
    */
   private heartbeatQueuedQueries(): void {
-    // "running" pointers are included because pointer status lags Mongo; the
-    // model's own "queued" filter decides which docs get the beat.
-    const ids = this.model.queries
-      .filter((q) => q.status === "queued" || q.status === "running")
-      .map((q) => q.query);
+    const ids = this.model.queries.map((q) => q.query);
     if (!ids.length) return;
     touchQueuedQueriesHeartbeat(this.context, ids).catch((e) =>
       logger.warn(e, `Failed to heartbeat queued queries for ${this.model.id}`),
     );
   }
 
-  private stopLockHeartbeat(): void {
-    if (this.lockHeartbeatTimer) {
-      clearInterval(this.lockHeartbeatTimer);
-      this.lockHeartbeatTimer = null;
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
     }
   }
 
@@ -665,12 +662,12 @@ export abstract class QueryRunner<
     this.result = result;
 
     if (this.status === "running") {
-      this.startLockHeartbeat();
+      this.startHeartbeat();
       this.startRefreshWatchdog();
     }
 
     if (this.status === "finished") {
-      this.stopLockHeartbeat();
+      this.stopHeartbeat();
       this.stopRefreshWatchdog();
       this.emitter.emit(FINISH_EVENT);
     }

--- a/packages/back-end/test/jobs/expireOldQueries.test.ts
+++ b/packages/back-end/test/jobs/expireOldQueries.test.ts
@@ -125,13 +125,13 @@ describe("classifyStalledSnapshot", () => {
   const cases: {
     name: string;
     ageMs: number;
-    statuses: StalledQueryStatus[];
+    queryStatuses: StalledQueryStatus[];
     expected: StalledSnapshotVerdict;
   }[] = [
     {
       name: "something is still running",
       ageMs: 3 * HOUR,
-      statuses: [
+      queryStatuses: [
         row("qry_1", "running", { createdAgoMs: 3 * HOUR }),
         row("qry_2", "queued", {
           createdAgoMs: 3 * HOUR,
@@ -144,7 +144,7 @@ describe("classifyStalledSnapshot", () => {
     {
       name: "never-heartbeated queued queries on a young snapshot",
       ageMs: 10 * MIN,
-      statuses: [
+      queryStatuses: [
         row("qry_1", "queued", { createdAgoMs: 10 * MIN }),
         row("qry_2", "queued", { createdAgoMs: 10 * MIN }),
       ],
@@ -153,7 +153,7 @@ describe("classifyStalledSnapshot", () => {
     {
       name: "never-heartbeated queued queries past the legacy threshold",
       ageMs: 71 * MIN,
-      statuses: [
+      queryStatuses: [
         row("qry_1", "queued", { createdAgoMs: 71 * MIN }),
         row("qry_2", "queued", { createdAgoMs: 71 * MIN }),
       ],
@@ -162,7 +162,7 @@ describe("classifyStalledSnapshot", () => {
     {
       name: "fresh beats on an hours-old snapshot",
       ageMs: 3 * HOUR,
-      statuses: [
+      queryStatuses: [
         row("qry_1", "queued", {
           createdAgoMs: 3 * HOUR,
           heartbeatAgoMs: 2 * MIN,
@@ -177,7 +177,7 @@ describe("classifyStalledSnapshot", () => {
     {
       name: "stale beats minutes after the runner died",
       ageMs: 12 * MIN,
-      statuses: [
+      queryStatuses: [
         row("qry_1", "queued", {
           createdAgoMs: 12 * MIN,
           heartbeatAgoMs: 6 * MIN,
@@ -192,7 +192,7 @@ describe("classifyStalledSnapshot", () => {
     {
       name: "one fresh beat alongside a never-heartbeated query",
       ageMs: 3 * HOUR,
-      statuses: [
+      queryStatuses: [
         row("qry_1", "queued", {
           createdAgoMs: 3 * HOUR,
           heartbeatAgoMs: 1 * MIN,
@@ -204,7 +204,7 @@ describe("classifyStalledSnapshot", () => {
     {
       name: "stale beat with one query already succeeded",
       ageMs: 12 * MIN,
-      statuses: [
+      queryStatuses: [
         row("qry_1", "succeeded", {
           createdAgoMs: 30 * MIN,
           finishedAgoMs: 20 * MIN,
@@ -219,7 +219,7 @@ describe("classifyStalledSnapshot", () => {
     {
       name: "heartbeat only a millisecond past createdAt is not a real beat",
       ageMs: 3 * HOUR,
-      statuses: [
+      queryStatuses: [
         row("qry_1", "queued", {
           createdAgoMs: 3 * HOUR,
           heartbeatAgoMs: 3 * HOUR - 1,
@@ -234,7 +234,7 @@ describe("classifyStalledSnapshot", () => {
     {
       name: "all succeeded on a young snapshot",
       ageMs: 30 * MIN,
-      statuses: [
+      queryStatuses: [
         row("qry_1", "succeeded", {
           createdAgoMs: 30 * MIN,
           finishedAgoMs: 25 * MIN,
@@ -249,7 +249,7 @@ describe("classifyStalledSnapshot", () => {
     {
       name: "all succeeded but still inside the finalize grace window",
       ageMs: 2 * HOUR,
-      statuses: [
+      queryStatuses: [
         row("qry_1", "succeeded", {
           createdAgoMs: 2 * HOUR,
           finishedAgoMs: 30 * MIN,
@@ -264,7 +264,7 @@ describe("classifyStalledSnapshot", () => {
     {
       name: "all succeeded and past the finalize grace window",
       ageMs: 2 * HOUR,
-      statuses: [
+      queryStatuses: [
         row("qry_1", "succeeded", {
           createdAgoMs: 2 * HOUR,
           finishedAgoMs: 30 * MIN,
@@ -279,7 +279,7 @@ describe("classifyStalledSnapshot", () => {
     {
       name: "succeeded plus failed, past the finalize grace window",
       ageMs: 2 * HOUR,
-      statuses: [
+      queryStatuses: [
         row("qry_1", "succeeded", {
           createdAgoMs: 2 * HOUR,
           finishedAgoMs: 20 * MIN,
@@ -293,10 +293,10 @@ describe("classifyStalledSnapshot", () => {
     },
   ];
 
-  it.each(cases)("$name -> $expected", ({ ageMs, statuses, expected }) => {
+  it.each(cases)("$name -> $expected", ({ ageMs, queryStatuses, expected }) => {
     expect(
       classifyStalledSnapshot({
-        statuses,
+        queryStatuses,
         snapshotDateCreated: new Date(NOW - ageMs),
         now: NOW,
       }),

--- a/packages/back-end/test/jobs/expireOldQueries.test.ts
+++ b/packages/back-end/test/jobs/expireOldQueries.test.ts
@@ -1,5 +1,6 @@
 import type Agenda from "agenda";
 import type {
+  ExperimentSnapshotInterface,
   SnapshotTriggeredBy,
   SnapshotType,
 } from "shared/types/experiment-snapshot";
@@ -314,12 +315,21 @@ describe("expireOldQueries stalled snapshot reaper", () => {
     },
   };
 
+  // Serve pages from a fixed candidate list the way the real query does:
+  // oldest-first, honoring the caller's limit and exclusion list.
+  function mockCandidates(candidates: ExperimentSnapshotInterface[]) {
+    (
+      dangerousFindStalledRunningSnapshotsFromAllOrgs as jest.Mock
+    ).mockImplementation(
+      async (_stalledBefore: Date, limit: number, excludeIds: string[] = []) =>
+        candidates.filter((c) => !excludeIds.includes(c.id)).slice(0, limit),
+    );
+  }
+
   beforeEach(() => {
     jest.clearAllMocks();
     (getStaleQueries as jest.Mock).mockResolvedValue([]);
-    (
-      dangerousFindStalledRunningSnapshotsFromAllOrgs as jest.Mock
-    ).mockResolvedValue([]);
+    mockCandidates([]);
     (getQueryStatusesByIds as jest.Mock).mockResolvedValue([]);
     (errorSnapshotIfStillRunning as jest.Mock).mockResolvedValue(true);
     (markPendingQueriesAsFailed as jest.Mock).mockResolvedValue(1);
@@ -348,6 +358,38 @@ describe("expireOldQueries stalled snapshot reaper", () => {
     await definitions.expireOldQueries();
   }
 
+  function runningSnapshot(
+    id: string,
+    snapshot: {
+      type?: SnapshotType;
+      triggeredBy?: SnapshotTriggeredBy;
+      report?: string;
+      ageMs?: number;
+    },
+  ): ExperimentSnapshotInterface {
+    const dateCreated = new Date(
+      Date.now() - (snapshot.ageMs ?? 2 * 60 * 60 * 1000),
+    );
+    return {
+      id,
+      organization: "org_1",
+      experiment: "exp_1",
+      phase: 0,
+      dimension: null,
+      type: snapshot.type,
+      triggeredBy: snapshot.triggeredBy,
+      report: snapshot.report,
+      dateCreated,
+      runStarted: dateCreated,
+      status: "running",
+      settings: {},
+      queries: [{ name: "main", query: `qry_${id}`, status: "queued" }],
+      unknownVariations: [],
+      multipleExposures: 0,
+      analyses: [],
+    } as unknown as ExperimentSnapshotInterface;
+  }
+
   function mockOrphanedSnapshot(snapshot: {
     type?: SnapshotType;
     triggeredBy?: SnapshotTriggeredBy;
@@ -355,31 +397,9 @@ describe("expireOldQueries stalled snapshot reaper", () => {
     ageMs?: number;
     statuses?: StalledQueryStatus[];
   }) {
-    const dateCreated = new Date(
-      Date.now() - (snapshot.ageMs ?? 2 * 60 * 60 * 1000),
-    );
-    (
-      dangerousFindStalledRunningSnapshotsFromAllOrgs as jest.Mock
-    ).mockResolvedValue([
-      {
-        id: "snp_1",
-        organization: "org_1",
-        experiment: "exp_1",
-        phase: 0,
-        dimension: null,
-        type: snapshot.type,
-        triggeredBy: snapshot.triggeredBy,
-        report: snapshot.report,
-        dateCreated,
-        runStarted: dateCreated,
-        status: "running",
-        settings: {},
-        queries: [{ name: "main", query: "qry_1", status: "queued" }],
-        unknownVariations: [],
-        multipleExposures: 0,
-        analyses: [],
-      },
-    ]);
+    const candidate = runningSnapshot("snp_1", snapshot);
+    candidate.queries = [{ name: "main", query: "qry_1", status: "queued" }];
+    mockCandidates([candidate]);
     (getQueryStatusesByIds as jest.Mock).mockResolvedValue(
       snapshot.statuses ?? [{ id: "qry_1", status: "queued" }],
     );
@@ -462,6 +482,46 @@ describe("expireOldQueries stalled snapshot reaper", () => {
       expect.any(String),
     );
     expect(updateExperiment).not.toHaveBeenCalled();
+  });
+
+  it("pages past a full page of live snapshots to reach a newer dead one", async () => {
+    const now = Date.now();
+    // 50 healthy long-running snapshots fill the first page; the orphaned
+    // one is newer and only reachable on the second page.
+    const live = Array.from({ length: 50 }, (_, i) =>
+      runningSnapshot(`live_${i}`, { ageMs: (60 + i) * 60 * 1000 }),
+    );
+    const dead = runningSnapshot("dead", {
+      type: "standard",
+      triggeredBy: "manual",
+      ageMs: 12 * 60 * 1000,
+    });
+    mockCandidates([...live, dead]);
+    (getQueryStatusesByIds as jest.Mock).mockImplementation(
+      async (_org: string, ids: string[]) =>
+        ids.map((id) => ({
+          id,
+          status: "queued",
+          createdAt: new Date(now - 60 * 60 * 1000),
+          heartbeat: new Date(
+            now - (id === "qry_dead" ? 6 * 60 * 1000 : 30 * 1000),
+          ),
+        })),
+    );
+
+    await runJob();
+
+    expect(
+      dangerousFindStalledRunningSnapshotsFromAllOrgs,
+    ).toHaveBeenCalledTimes(3);
+    expect(errorSnapshotIfStillRunning).toHaveBeenCalledTimes(1);
+    expect(errorSnapshotIfStillRunning).toHaveBeenCalledWith(
+      context,
+      "dead",
+      expect.objectContaining({
+        error: expect.stringContaining("queries were never started"),
+      }),
+    );
   });
 
   it("leaves an orphaned DAG alone while its queued heartbeats are fresh, however old the snapshot is", async () => {

--- a/packages/back-end/test/jobs/expireOldQueries.test.ts
+++ b/packages/back-end/test/jobs/expireOldQueries.test.ts
@@ -3,7 +3,12 @@ import type {
   SnapshotTriggeredBy,
   SnapshotType,
 } from "shared/types/experiment-snapshot";
-import expireOldQueries from "back-end/src/jobs/expireOldQueries";
+import type { QueryStatus } from "shared/types/query";
+import expireOldQueries, {
+  classifyStalledSnapshot,
+  StalledQueryStatus,
+  StalledSnapshotVerdict,
+} from "back-end/src/jobs/expireOldQueries";
 import {
   dangerousFindStalledRunningSnapshotsFromAllOrgs,
   errorSnapshotIfStillRunning,
@@ -84,6 +89,221 @@ jest.mock("back-end/src/util/logger", () => ({
   },
 }));
 
+describe("classifyStalledSnapshot", () => {
+  const NOW = Date.UTC(2026, 0, 15, 12, 0, 0);
+  const MIN = 60 * 1000;
+  const HOUR = 60 * MIN;
+
+  function row(
+    id: string,
+    status: QueryStatus,
+    {
+      createdAgoMs,
+      heartbeatAgoMs,
+      finishedAgoMs,
+    }: {
+      createdAgoMs: number;
+      heartbeatAgoMs?: number;
+      finishedAgoMs?: number;
+    },
+  ): StalledQueryStatus {
+    const createdAt = new Date(NOW - createdAgoMs);
+    return {
+      id,
+      status,
+      createdAt,
+      heartbeat:
+        heartbeatAgoMs === undefined
+          ? createdAt
+          : new Date(NOW - heartbeatAgoMs),
+      ...(finishedAgoMs === undefined
+        ? {}
+        : { finishedAt: new Date(NOW - finishedAgoMs) }),
+    };
+  }
+
+  const cases: {
+    name: string;
+    ageMs: number;
+    statuses: StalledQueryStatus[];
+    expected: StalledSnapshotVerdict;
+  }[] = [
+    {
+      name: "something is still running",
+      ageMs: 3 * HOUR,
+      statuses: [
+        row("qry_1", "running", { createdAgoMs: 3 * HOUR }),
+        row("qry_2", "queued", {
+          createdAgoMs: 3 * HOUR,
+          heartbeatAgoMs: 6 * MIN,
+        }),
+        row("qry_3", "queued", { createdAgoMs: 3 * HOUR }),
+      ],
+      expected: "active",
+    },
+    {
+      name: "never-heartbeated queued queries on a young snapshot",
+      ageMs: 10 * MIN,
+      statuses: [
+        row("qry_1", "queued", { createdAgoMs: 10 * MIN }),
+        row("qry_2", "queued", { createdAgoMs: 10 * MIN }),
+      ],
+      expected: "active",
+    },
+    {
+      name: "never-heartbeated queued queries past the legacy threshold",
+      ageMs: 71 * MIN,
+      statuses: [
+        row("qry_1", "queued", { createdAgoMs: 71 * MIN }),
+        row("qry_2", "queued", { createdAgoMs: 71 * MIN }),
+      ],
+      expected: "orphaned-unknown",
+    },
+    {
+      name: "fresh beats on an hours-old snapshot",
+      ageMs: 3 * HOUR,
+      statuses: [
+        row("qry_1", "queued", {
+          createdAgoMs: 3 * HOUR,
+          heartbeatAgoMs: 2 * MIN,
+        }),
+        row("qry_2", "queued", {
+          createdAgoMs: 3 * HOUR,
+          heartbeatAgoMs: 3 * MIN,
+        }),
+      ],
+      expected: "active",
+    },
+    {
+      name: "stale beats minutes after the runner died",
+      ageMs: 12 * MIN,
+      statuses: [
+        row("qry_1", "queued", {
+          createdAgoMs: 12 * MIN,
+          heartbeatAgoMs: 6 * MIN,
+        }),
+        row("qry_2", "queued", {
+          createdAgoMs: 12 * MIN,
+          heartbeatAgoMs: 7 * MIN,
+        }),
+      ],
+      expected: "orphaned-dead",
+    },
+    {
+      name: "one fresh beat alongside a never-heartbeated query",
+      ageMs: 3 * HOUR,
+      statuses: [
+        row("qry_1", "queued", {
+          createdAgoMs: 3 * HOUR,
+          heartbeatAgoMs: 1 * MIN,
+        }),
+        row("qry_2", "queued", { createdAgoMs: 3 * HOUR }),
+      ],
+      expected: "active",
+    },
+    {
+      name: "stale beat with one query already succeeded",
+      ageMs: 12 * MIN,
+      statuses: [
+        row("qry_1", "succeeded", {
+          createdAgoMs: 30 * MIN,
+          finishedAgoMs: 20 * MIN,
+        }),
+        row("qry_2", "queued", {
+          createdAgoMs: 12 * MIN,
+          heartbeatAgoMs: 6 * MIN,
+        }),
+      ],
+      expected: "orphaned-dead",
+    },
+    {
+      name: "heartbeat only a millisecond past createdAt is not a real beat",
+      ageMs: 3 * HOUR,
+      statuses: [
+        row("qry_1", "queued", {
+          createdAgoMs: 3 * HOUR,
+          heartbeatAgoMs: 3 * HOUR - 1,
+        }),
+        row("qry_2", "queued", {
+          createdAgoMs: 3 * HOUR,
+          heartbeatAgoMs: 3 * HOUR - 1,
+        }),
+      ],
+      expected: "orphaned-unknown",
+    },
+    {
+      name: "all succeeded on a young snapshot",
+      ageMs: 30 * MIN,
+      statuses: [
+        row("qry_1", "succeeded", {
+          createdAgoMs: 30 * MIN,
+          finishedAgoMs: 25 * MIN,
+        }),
+        row("qry_2", "succeeded", {
+          createdAgoMs: 30 * MIN,
+          finishedAgoMs: 20 * MIN,
+        }),
+      ],
+      expected: "active",
+    },
+    {
+      name: "all succeeded but still inside the finalize grace window",
+      ageMs: 2 * HOUR,
+      statuses: [
+        row("qry_1", "succeeded", {
+          createdAgoMs: 2 * HOUR,
+          finishedAgoMs: 30 * MIN,
+        }),
+        row("qry_2", "succeeded", {
+          createdAgoMs: 2 * HOUR,
+          finishedAgoMs: 3 * MIN,
+        }),
+      ],
+      expected: "active",
+    },
+    {
+      name: "all succeeded and past the finalize grace window",
+      ageMs: 2 * HOUR,
+      statuses: [
+        row("qry_1", "succeeded", {
+          createdAgoMs: 2 * HOUR,
+          finishedAgoMs: 30 * MIN,
+        }),
+        row("qry_2", "succeeded", {
+          createdAgoMs: 2 * HOUR,
+          finishedAgoMs: 20 * MIN,
+        }),
+      ],
+      expected: "stalled-terminal",
+    },
+    {
+      name: "succeeded plus failed, past the finalize grace window",
+      ageMs: 2 * HOUR,
+      statuses: [
+        row("qry_1", "succeeded", {
+          createdAgoMs: 2 * HOUR,
+          finishedAgoMs: 20 * MIN,
+        }),
+        row("qry_2", "failed", {
+          createdAgoMs: 2 * HOUR,
+          finishedAgoMs: 20 * MIN,
+        }),
+      ],
+      expected: "stalled-terminal",
+    },
+  ];
+
+  it.each(cases)("$name -> $expected", ({ ageMs, statuses, expected }) => {
+    expect(
+      classifyStalledSnapshot({
+        statuses,
+        snapshotDateCreated: new Date(NOW - ageMs),
+        now: NOW,
+      }),
+    ).toBe(expected);
+  });
+});
+
 describe("expireOldQueries stalled snapshot reaper", () => {
   const releaseLock = jest.fn().mockResolvedValue(undefined);
   const context = {
@@ -132,8 +352,12 @@ describe("expireOldQueries stalled snapshot reaper", () => {
     type?: SnapshotType;
     triggeredBy?: SnapshotTriggeredBy;
     report?: string;
+    ageMs?: number;
+    statuses?: StalledQueryStatus[];
   }) {
-    const dateCreated = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    const dateCreated = new Date(
+      Date.now() - (snapshot.ageMs ?? 2 * 60 * 60 * 1000),
+    );
     (
       dangerousFindStalledRunningSnapshotsFromAllOrgs as jest.Mock
     ).mockResolvedValue([
@@ -156,9 +380,9 @@ describe("expireOldQueries stalled snapshot reaper", () => {
         analyses: [],
       },
     ]);
-    (getQueryStatusesByIds as jest.Mock).mockResolvedValue([
-      { id: "qry_1", status: "queued" },
-    ]);
+    (getQueryStatusesByIds as jest.Mock).mockResolvedValue(
+      snapshot.statuses ?? [{ id: "qry_1", status: "queued" }],
+    );
   }
 
   it("schedules a retry for orphaned scheduled standard snapshots", async () => {
@@ -205,5 +429,60 @@ describe("expireOldQueries stalled snapshot reaper", () => {
     await runJob();
 
     expect(updateExperiment).not.toHaveBeenCalled();
+  });
+
+  it("concludes an orphaned DAG whose queued heartbeats went stale, minutes after death", async () => {
+    const now = Date.now();
+    mockOrphanedSnapshot({
+      type: "standard",
+      triggeredBy: "manual",
+      ageMs: 12 * 60 * 1000,
+      statuses: [
+        {
+          id: "qry_1",
+          status: "queued",
+          createdAt: new Date(now - 12 * 60 * 1000),
+          heartbeat: new Date(now - 6 * 60 * 1000),
+        },
+      ],
+    });
+
+    await runJob();
+
+    expect(errorSnapshotIfStillRunning).toHaveBeenCalledWith(
+      context,
+      "snp_1",
+      expect.objectContaining({
+        error: expect.stringContaining("queries were never started"),
+      }),
+    );
+    expect(markPendingQueriesAsFailed).toHaveBeenCalledWith(
+      context,
+      ["qry_1"],
+      expect.any(String),
+    );
+    expect(updateExperiment).not.toHaveBeenCalled();
+  });
+
+  it("leaves an orphaned DAG alone while its queued heartbeats are fresh, however old the snapshot is", async () => {
+    const now = Date.now();
+    mockOrphanedSnapshot({
+      type: "standard",
+      triggeredBy: "manual",
+      ageMs: 3 * 60 * 60 * 1000,
+      statuses: [
+        {
+          id: "qry_1",
+          status: "queued",
+          createdAt: new Date(now - 3 * 60 * 60 * 1000),
+          heartbeat: new Date(now - 60 * 1000),
+        },
+      ],
+    });
+
+    await runJob();
+
+    expect(errorSnapshotIfStillRunning).not.toHaveBeenCalled();
+    expect(markPendingQueriesAsFailed).not.toHaveBeenCalled();
   });
 });

--- a/packages/back-end/test/queryRunners/QueryRunner.test.ts
+++ b/packages/back-end/test/queryRunners/QueryRunner.test.ts
@@ -15,9 +15,16 @@ import {
   updateQuery,
   updateQueryIfPending,
   updateQueryIfRunning,
+  touchQueuedQueriesHeartbeat,
 } from "back-end/src/models/QueryModel";
 
 jest.mock("back-end/src/models/QueryModel");
+
+// The automocked heartbeat resolves nowhere by default, and the runner calls
+// `.catch` on it inside a timer callback.
+beforeEach(() => {
+  jest.mocked(touchQueuedQueriesHeartbeat).mockResolvedValue(0);
+});
 
 class TestQueryRunner extends QueryRunner<
   InterfaceWithQueries,
@@ -932,6 +939,38 @@ describe("QueryRunner", () => {
         // Interval must be cleared — no further beats no matter how long we wait.
         jest.advanceTimersByTime(120000);
         expect(runner.onHeartbeatSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+      }
+    });
+
+    it("heartbeats its queued query docs on every beat, and stops when finished", async () => {
+      jest.useFakeTimers();
+      try {
+        const runner = new HeartbeatTestQueryRunner(
+          mockContext,
+          {
+            id: "test-model",
+            organization: "test-org",
+            queries: [],
+            runStarted: new Date(),
+          },
+          mockIntegration,
+        );
+
+        await runner.startAnalysis({ pointers: runningPointers });
+
+        jest.advanceTimersByTime(30000);
+        expect(touchQueuedQueriesHeartbeat).toHaveBeenCalledTimes(1);
+        expect(touchQueuedQueriesHeartbeat).toHaveBeenCalledWith(mockContext, [
+          "qry_drop",
+          "qry_create",
+        ]);
+
+        await runner.cancelQueries();
+        jest.advanceTimersByTime(120000);
+        expect(touchQueuedQueriesHeartbeat).toHaveBeenCalledTimes(1);
       } finally {
         jest.clearAllTimers();
         jest.useRealTimers();


### PR DESCRIPTION
### Features and Changes

The `expireOldQueries` job sees which queries were never finished (for whatever reason), then figures out who owns it, if they are still owning it and is just a long-running query (or sets of queries), and finally registers the failures in the appropriate documents.

One gap is that `queued` queries have no signal to show if a queryRunner is monitoring this query and will start it when ready, or if the process is dead and this query is now stuck in a `queued` state.

Queries stay in the `queued` state for longer periods when they are either waiting on a parent query to finish that they depend on, or if the datasource has a `maxConcurrentQueries` limit that forces us to wait for a slot to run the query.

The QueryRunner is already responsible for keeping the `heartbeat` for `running` queries, so this PR extends it to also include `queued` queries.

This also allows us to detect dead processes and failures much sooner, instead of having to have a big window to account for long-running queries or saturated warehouses.

#### Changes

- A live `QueryRunner` now heartbeats every `queued` query doc it owns from its existing 30s timer (one `updateMany`, filtered on `status: "queued"` in Mongo)
- Updated how `expireOldQueries` job determines the status of the queryRunner. A queryRunner whose queued docs have a fresh heartbeat is left alone however old the snapshot is. If the queued docs were heartbeated at least once and have all been stale for 5 minutes, we consider is stalled and finalize it immediately. Docs that were never heartbeated keep today's logic, so this behavior is net new and safe to rollout.

### Testing

- Unit tests
- Manual testing
