### PR TITLE
Notify feature-squad Slack channel on sdk-versions-sync PR activity

### DIFF
--- a/.github/workflows/notify-sdk-version-sync.yml
+++ b/.github/workflows/notify-sdk-version-sync.yml
@@ -1,0 +1,23 @@
+name: Notify feature-squad on SDK version sync
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+# Secrets are not available in job-level `if`, so expose presence via env
+env:
+  HAS_WEBHOOK: ${{ secrets.SLACK_FEATURE_SQUAD_WEBHOOK_URL != '' }}
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    if: startsWith(github.head_ref, 'sdk-versions-sync/')
+    steps:
+      - name: Post to Slack
+        if: env.HAS_WEBHOOK == 'true'
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_FEATURE_SQUAD_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "SDK version sync PR ${{ github.event.action == 'opened' && 'opened' || 'updated' }}, review/approval needed: <${{ github.event.pull_request.html_url }}|growthbook#${{ github.event.pull_request.number }}>"


### PR DESCRIPTION
## Summary
Posts a Slack notification to #feature-squad whenever the daily SDK version-sync routine opens a sync PR or pushes updates to one, nudging for review/approval.

## How it helps
- Fires on `pull_request` `opened`/`reopened`/`synchronize` for head branches matching `sdk-versions-sync/*` — covers both a new sync PR and follow-up commits appended to an open one.
- Notification lives in CI rather than in the sync routine itself: the routine's sandbox has no Slack access and its egress policy blocks some hosts, so a webhook call from there could fail silently. This also fires when a human pushes to the sync branch.
- Reuses the existing `slackapi/slack-github-action` pattern from `notify-on-failure.yml`.
- No-ops cleanly (no failed check) until the webhook secret is configured.

## Setup required before this takes effect
- [ ] Create a Slack incoming webhook targeting #feature-squad
- [ ] Add it as repo secret `SLACK_FEATURE_SQUAD_WEBHOOK_URL` (the existing `SLACK_WEBHOOK_URL` targets the CI-failure Slack workflow, so it is not reused)

## Test plan
- [ ] `prettier --check` and YAML parse pass on the workflow file
- [ ] After merge + secret setup: next `sdk-versions-sync/*` PR event posts to #feature-squad
- [ ] Before secret setup: workflow run on a sync PR skips the Slack step without failing