### PR TITLE
Check update permissions on no-op updates

### DIFF
--- a/packages/back-end/src/enterprise/services/contextualBandits.ts
+++ b/packages/back-end/src/enterprise/services/contextualBandits.ts
@@ -840,10 +840,13 @@ export async function runContextualBanditSnapshot(
   // Compute bandit stage before running the update, in case this
   // update moves bandits from explore to exploit.
   const scheduleChanges = computeContextualBanditStageAndSchedule(cb);
-  const updatedCb = await context.models.contextualBandits.update(
-    cb,
-    scheduleChanges,
-  );
+  // Authority was established by canRunContextualBandit at the route; the
+  // stage/schedule write is a consequence of the run, not a separate edit.
+  const updatedCb =
+    await context.models.contextualBandits.dangerousUpdateBypassPermission(
+      cb,
+      scheduleChanges,
+    );
 
   const snapshotSettings = buildContextualBanditSnapshotSettings(
     updatedCb,

--- a/packages/back-end/src/models/BaseModel.ts
+++ b/packages/back-end/src/models/BaseModel.ts
@@ -1271,14 +1271,6 @@ export abstract class BaseModel<
       .map(([k]) => k) as (keyof z.infer<T>)[];
     updates = pick(updates, updatedFields);
 
-    // If no updates are needed, return immediately — UNLESS the write is
-    // guarded. A guarded write is a CAS fence as much as a mutation: skipping
-    // it would confirm "the doc I read is still current" without checking it
-    // or advancing the token. The fence writes only the advanced stamp.
-    if (!updatedFields.length && !options?.guard) {
-      return doc;
-    }
-
     // Make sure the updates don't include any fields that shouldn't be updated
     if (
       ["id", "uid", "organization", "dateCreated", "dateUpdated"].some(
@@ -1328,6 +1320,11 @@ export abstract class BaseModel<
       throw new PermissionError(
         "You do not have access to update this resource",
       );
+    }
+
+    // A guarded write is a CAS fence even when no fields changed.
+    if (!updatedFields.length && !options?.guard) {
+      return doc;
     }
 
     await this.validateProjectFields(updates as Partial<z.infer<T>>);

--- a/packages/back-end/src/models/BaseModel.ts
+++ b/packages/back-end/src/models/BaseModel.ts
@@ -1266,6 +1266,7 @@ export abstract class BaseModel<
     );
 
     // Only consider updates that actually change the value
+    const requested = updates;
     const updatedFields = Object.entries(updates)
       .filter(([k, v]) => !isEqual(doc[k as keyof z.infer<T>], v))
       .map(([k]) => k) as (keyof z.infer<T>)[];
@@ -1316,7 +1317,13 @@ export abstract class BaseModel<
 
     await this.populateForeignRefs([newDoc]);
 
-    if (!options?.forceCanUpdate && !this.canUpdate(doc, updates, newDoc)) {
+    // A no-op is gated on the payload as submitted: "may you write what you
+    // asked for", not "may you write nothing" — which key-aware canUpdate
+    // implementations (e.g. ApiKeyModel's `disabled`-only allowlist) reject.
+    if (
+      !options?.forceCanUpdate &&
+      !this.canUpdate(doc, updatedFields.length ? updates : requested, newDoc)
+    ) {
       throw new PermissionError(
         "You do not have access to update this resource",
       );

--- a/packages/back-end/src/services/rampScheduleEvaluator.ts
+++ b/packages/back-end/src/services/rampScheduleEvaluator.ts
@@ -534,9 +534,12 @@ export async function applyRampEvaluationDecision(
       nextSnapshotAt: schedule.nextSnapshotAt,
       cutoffDate: schedule.cutoffDate,
     });
-    return ctx.models.rampSchedules.updateById(schedule.id, {
-      nextProcessAt,
-    });
+    // Scheduler bookkeeping, not a user edit: the snapshot that triggered this
+    // may run under a member who cannot edit or publish the feature.
+    return ctx.models.rampSchedules.dangerousUpdateByIdBypassPermission(
+      schedule.id,
+      { nextProcessAt },
+    );
   }
 
   // Fold the verified advance and any due backlog into a single jump publish.

--- a/packages/back-end/test/api/noop-update-permissions.test.ts
+++ b/packages/back-end/test/api/noop-update-permissions.test.ts
@@ -1,0 +1,86 @@
+import mongoose from "mongoose";
+import request from "supertest";
+import { ApiKeyInterface } from "shared/types/apikey";
+import { OrganizationInterface } from "shared/types/organization";
+import { ReqContextClass } from "back-end/src/services/context";
+import { factMetricFactory } from "back-end/test/factories/FactMetric.factory";
+import { setupApp } from "./api.setup";
+
+const organization: OrganizationInterface = {
+  id: "org_noop_update_permissions",
+  name: "No-op update permissions",
+  ownerEmail: "owner@example.com",
+  url: "",
+  dateCreated: new Date("2026-01-01"),
+  invites: [],
+  members: [],
+  settings: { environments: [] },
+};
+
+const datasource = {
+  id: "ds_noop_update_permissions",
+  organization: organization.id,
+  name: "No-op update data source",
+  description: "",
+  type: "postgres",
+  params: "",
+  projects: [],
+  settings: {},
+  dateCreated: new Date("2026-01-01"),
+  dateUpdated: new Date("2026-01-01"),
+};
+
+const factMetric = factMetricFactory.build({
+  id: "fact__noop_update",
+  organization: organization.id,
+  datasource: datasource.id,
+  owner: "",
+  managedBy: "",
+  name: "No-op metric",
+  funnelSettings: null,
+});
+
+const { app, setReqContext } = setupApp();
+
+beforeEach(async () => {
+  const apiKeyData: ApiKeyInterface = {
+    id: "key_readonly",
+    key: "test-key",
+    organization: organization.id,
+    dateCreated: new Date("2026-01-01"),
+    dateUpdated: new Date("2026-01-01"),
+    secret: true,
+    role: "readonly",
+    limitAccessByEnvironment: false,
+    environments: [],
+  };
+  setReqContext(
+    new ReqContextClass({
+      org: organization,
+      auditUser: { type: "api_key", apiKey: "test-key" },
+      role: "readonly",
+      apiKey: "test-key",
+      apiKeyData,
+    }),
+  );
+  await mongoose.connection
+    .db!.collection("datasources")
+    .insertOne(structuredClone(datasource));
+  await mongoose.connection
+    .db!.collection("factmetrics")
+    .insertOne(structuredClone(factMetric));
+});
+
+it("checks update permissions for no-op payloads", async () => {
+  for (const body of [{}, { name: factMetric.name }]) {
+    const response = await request(app)
+      .post(`/api/v1/fact-metrics/${factMetric.id}`)
+      .send(body)
+      .set("Authorization", "Bearer test-key");
+
+    expect(response.status).toBe(403);
+    expect(response.body.message).toBe(
+      "You do not have access to update this resource",
+    );
+  }
+});

--- a/packages/back-end/test/models/BaseModel.test.ts
+++ b/packages/back-end/test/models/BaseModel.test.ts
@@ -788,6 +788,57 @@ describe("BaseModel", () => {
     );
   });
 
+  it("checks update access even when the update is a no-op", async () => {
+    const model = new TestModel(defaultContext);
+    model.canUpdateMock.mockReturnValue(false);
+    const updateOneMock = jest.fn();
+    model.dangerousGetCollectionMock.mockReturnValue({
+      updateOne: updateOneMock,
+    });
+    const existing = {
+      name: "foo",
+      id: "aabb",
+      organization: "a",
+      dateCreated: new Date(),
+      dateUpdated: new Date(),
+    };
+
+    await expect(model.update(existing, { name: "foo" })).rejects.toEqual(
+      new Error("You do not have access to update this resource"),
+    );
+    expect(updateOneMock).not.toHaveBeenCalled();
+  });
+
+  it("gates a no-op update on the payload as submitted, not on {}", async () => {
+    const model = new TestModel(defaultContext);
+    // Key-aware canUpdate, like ApiKeyModel's `disabled`-only allowlist.
+    model.canUpdateMock.mockImplementation(
+      (_existing, updates) =>
+        Object.keys(updates).length === 1 && "name" in updates,
+    );
+    const updateOneMock = jest.fn();
+    model.dangerousGetCollectionMock.mockReturnValue({
+      updateOne: updateOneMock,
+    });
+    const existing = {
+      name: "foo",
+      id: "aabb",
+      organization: "a",
+      dateCreated: new Date(),
+      dateUpdated: new Date(),
+    };
+
+    await expect(model.update(existing, { name: "foo" })).resolves.toEqual(
+      existing,
+    );
+    expect(model.canUpdateMock).toHaveBeenCalledWith(
+      existing,
+      { name: "foo" },
+      expect.objectContaining({ name: "foo" }),
+    );
+    expect(updateOneMock).not.toHaveBeenCalled();
+  });
+
   it("raises an error when attempting to update a read-only field", () => {
     const model = new TestModel(defaultContext);
     model.canUpdateMock.mockReturnValue(true);


### PR DESCRIPTION
### Features and Changes

`BaseModel.update()` returned early on a no-op payload before checking `canUpdate`, so a readonly caller re-sending a resource's current values got a 200. The check now runs first, and it's asked about the payload as submitted rather than an empty object, so key-aware checks like `ApiKeyModel`'s `disabled`-only allowlist still pass an idempotent toggle.

Two cascades that re-save usually-unchanged values under the requesting user's context move to the permission bypass, since their authority comes from the parent action: the ramp-schedule hold bookkeeping after a safe-rollout snapshot, and the bandit stage recompute after a run.

### Testing

- [x] Readonly member re-sends a fact metric's current `name` via `PUT /fact-metrics/:id` -> 403
- [x] PAT owner re-disables an already-disabled key via `PUT /keys/:id/disabled` -> 200, doc unchanged
- [x] Same two calls on `main` -> 200 / 200
