### PR TITLE
Treat metric auto-slice cleanup as a cascade of the fact-table write

### DIFF
--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -164,7 +164,8 @@ function validateSavedFilterIds({
 }
 
 type WriteOptions = {
-  // Set by fact-table column cascades; see removeAutoSlices.
+  // Set by removeAutoSlices: a metricAutoSlices-only write that maintains
+  // derived state and is exempt from the API-managed channel guard.
   autoSliceCascade?: boolean;
 };
 
@@ -414,12 +415,17 @@ export class FactMetricModel extends BaseClass<WriteOptions> {
     newDoc: FactMetricInterface,
     writeOptions?: WriteOptions,
   ) {
-    // Check the admin permission here?
+    // A fact-table column cascade only maintains derived state, so that write
+    // is exempt from the channel guard below. See removeAutoSlices.
     if (
-      existing.managedBy === "api" &&
-      !this.context.isApiRequest &&
-      !writeOptions?.autoSliceCascade
+      writeOptions?.autoSliceCascade &&
+      Object.keys(updates).every((k) => k === "metricAutoSlices")
     ) {
+      return;
+    }
+    // API-managed metrics are only editable through the API so their
+    // definition can't drift from the caller's source of truth.
+    if (existing.managedBy === "api" && !this.context.isApiRequest) {
       throw new Error(
         "Cannot update fact metric managed by API if the request isn't from the API.",
       );

--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -33,7 +33,7 @@ import {
 import { projectFilterQuery } from "back-end/src/util/mongo.util";
 import { validateAggregationSpecification } from "back-end/src/services/factMetricAggregationValidation";
 import { healPriorSettings } from "back-end/src/util/priors";
-import { Context, MakeModelClass } from "./BaseModel";
+import { CasConflictError, Context, MakeModelClass } from "./BaseModel";
 import { getDataSourceById } from "./DataSourceModel";
 import { getFactTableMap } from "./FactTableModel";
 
@@ -163,7 +163,12 @@ function validateSavedFilterIds({
   }
 }
 
-export class FactMetricModel extends BaseClass {
+type WriteOptions = {
+  // Set by fact-table column cascades; see removeAutoSlices.
+  autoSliceCascade?: boolean;
+};
+
+export class FactMetricModel extends BaseClass<WriteOptions> {
   protected canRead(doc: FactMetricInterface): boolean {
     return this.context.hasPermission("readData", doc.projects || []);
   }
@@ -190,6 +195,40 @@ export class FactMetricModel extends BaseClass {
     FactMetricInterface[]
   > {
     return this._find({}, { bypassReadPermissionChecks: true });
+  }
+
+  // Cascade from a fact-table column change. Authority is the fact-table write,
+  // so this bypasses canUpdate; the guarded write plus re-read means a
+  // concurrent edit to the metric is retried against, never clobbered.
+  public async removeAutoSlices(
+    metricId: string,
+    removedColumns: string[],
+  ): Promise<void> {
+    const maxAttempts = 3;
+    for (let attempt = 1; ; attempt++) {
+      const [metric] = await this._find(
+        { id: metricId },
+        { bypassReadPermissionChecks: true },
+      );
+      if (!metric?.metricAutoSlices?.length) return;
+      const metricAutoSlices = metric.metricAutoSlices.filter(
+        (c) => !removedColumns.includes(c),
+      );
+      if (metricAutoSlices.length === metric.metricAutoSlices.length) return;
+      try {
+        await this.updateIfUnchanged(
+          metric,
+          { metricAutoSlices },
+          { autoSliceCascade: true },
+          { dangerouslyBypassCanUpdate: true },
+        );
+        return;
+      } catch (e) {
+        if (!(e instanceof CasConflictError) || attempt >= maxAttempts) {
+          throw e;
+        }
+      }
+    }
   }
 
   /**
@@ -369,9 +408,18 @@ export class FactMetricModel extends BaseClass {
     }
   }
 
-  protected async beforeUpdate(existing: FactMetricInterface) {
+  protected async beforeUpdate(
+    existing: FactMetricInterface,
+    updates: UpdateProps<FactMetricInterface>,
+    newDoc: FactMetricInterface,
+    writeOptions?: WriteOptions,
+  ) {
     // Check the admin permission here?
-    if (existing.managedBy === "api" && !this.context.isApiRequest) {
+    if (
+      existing.managedBy === "api" &&
+      !this.context.isApiRequest &&
+      !writeOptions?.autoSliceCascade
+    ) {
       throw new Error(
         "Cannot update fact metric managed by API if the request isn't from the API.",
       );

--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -2,6 +2,7 @@ import mongoose, { FilterQuery } from "mongoose";
 import uniqid from "uniqid";
 import {
   getFactMetricColumnRefs,
+  getFactMetricPrimaryFactTableId,
   sqlReferencesColumn,
 } from "shared/experiments";
 import { explorationConfigReferencesColumn } from "shared/enterprise";
@@ -40,6 +41,7 @@ import {
   normalizeJSONFieldsInput,
   normalizePersistedColumn,
 } from "back-end/src/util/factTable";
+import { logger } from "back-end/src/util/logger";
 
 const audit = createModelAuditLogger({
   entity: "factTable",
@@ -398,22 +400,6 @@ export async function updateFactTable(
   );
   if (!changed) return;
 
-  // Clean up auto slices from metrics if columns were deleted or modified
-  if (changes.columns) {
-    const removedColumns = detectRemovedColumns(
-      factTable.columns || [],
-      changes.columns,
-    );
-
-    if (removedColumns.length > 0) {
-      await cleanupMetricAutoSlices({
-        context,
-        factTableId: factTable.id,
-        removedColumns,
-      });
-    }
-  }
-
   await FactTableModel.updateOne(
     {
       id: factTable.id,
@@ -436,6 +422,17 @@ export async function updateFactTable(
       changes.projects ?? factTable.projects,
     ),
   );
+
+  if (changes.columns) {
+    await cleanupMetricAutoSlices({
+      context,
+      factTableId: factTable.id,
+      removedColumns: detectRemovedColumns(
+        factTable.columns || [],
+        changes.columns,
+      ),
+    });
+  }
 }
 
 const ALLOWED_COLUMN_UPDATE_FIELDS = [
@@ -521,20 +518,6 @@ export async function dangerouslySyncManagedWarehouseFactTable(
     return;
   }
 
-  if (changes.columns) {
-    const removedColumns = detectRemovedColumns(
-      factTable.columns || [],
-      changes.columns,
-    );
-    if (removedColumns.length > 0) {
-      await cleanupMetricAutoSlices({
-        context,
-        factTableId: factTable.id,
-        removedColumns,
-      });
-    }
-  }
-
   await FactTableModel.updateOne(
     {
       id: factTable.id,
@@ -551,6 +534,17 @@ export async function dangerouslySyncManagedWarehouseFactTable(
     factTable.organization,
     definitionsScope(factTable.projects),
   );
+
+  if (changes.columns) {
+    await cleanupMetricAutoSlices({
+      context,
+      factTableId: factTable.id,
+      removedColumns: detectRemovedColumns(
+        factTable.columns || [],
+        changes.columns,
+      ),
+    });
+  }
 }
 
 // Detect columns that were removed or had auto slice disabled
@@ -589,7 +583,10 @@ export function detectRemovedColumns(
   return [...deletedColumns, ...disabledAutoSliceColumns];
 }
 
-// Clean up auto slices from fact metrics when columns are "deleted" or dropped
+// Cascade from a fact-table column change: drop metric auto slices that
+// reference removed or disabled columns. The fact table is the source of truth
+// and every reader intersects against it, so this is best-effort — it spans
+// metrics the caller can't read and never fails the fact-table write.
 export async function cleanupMetricAutoSlices({
   context,
   factTableId,
@@ -599,26 +596,25 @@ export async function cleanupMetricAutoSlices({
   factTableId: string;
   removedColumns: string[];
 }) {
-  // Get all fact metrics that use this fact table
-  const allFactMetrics = await context.models.factMetrics.getAll();
-  const affectedMetrics = allFactMetrics.filter(
-    (metric) => metric.numerator?.factTableId === factTableId,
-  );
+  if (!removedColumns.length) return;
 
-  // For each affected metric, remove auto slices that reference removed columns
-  for (const metric of affectedMetrics) {
-    if (!metric.metricAutoSlices?.length) continue;
-
-    const originalAutoSlices = [...metric.metricAutoSlices];
-    const cleanedAutoSlices = metric.metricAutoSlices.filter(
-      (sliceColumn) => !removedColumns.includes(sliceColumn),
-    );
-
-    // Only update if there were changes
-    if (cleanedAutoSlices.length !== originalAutoSlices.length) {
-      await context.models.factMetrics.update(metric, {
-        metricAutoSlices: cleanedAutoSlices,
-      });
+  const allFactMetrics =
+    await context.models.factMetrics.dangerousGetAllForDependencyScan();
+  for (const metric of allFactMetrics) {
+    if (getFactMetricPrimaryFactTableId(metric) !== factTableId) continue;
+    if (!metric.metricAutoSlices?.some((c) => removedColumns.includes(c))) {
+      continue;
+    }
+    try {
+      await context.models.factMetrics.removeAutoSlices(
+        metric.id,
+        removedColumns,
+      );
+    } catch (e) {
+      logger.error(
+        e,
+        `Failed to remove auto slices from fact metric ${metric.id}`,
+      );
     }
   }
 }

--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -14,6 +14,7 @@ import {
   CreateFactTableProps,
   ColumnRef,
   FactFilterInterface,
+  FactMetricInterface,
   FactTableDefinition,
   FactTableInterface,
   UpdateFactFilterProps,
@@ -598,8 +599,17 @@ export async function cleanupMetricAutoSlices({
 }) {
   if (!removedColumns.length) return;
 
-  const allFactMetrics =
-    await context.models.factMetrics.dangerousGetAllForDependencyScan();
+  let allFactMetrics: FactMetricInterface[];
+  try {
+    allFactMetrics =
+      await context.models.factMetrics.dangerousGetAllForDependencyScan();
+  } catch (e) {
+    logger.error(
+      e,
+      `Failed to scan fact metrics for auto-slice cleanup of ${factTableId}`,
+    );
+    return;
+  }
   for (const metric of allFactMetrics) {
     if (getFactMetricPrimaryFactTableId(metric) !== factTableId) continue;
     if (!metric.metricAutoSlices?.some((c) => removedColumns.includes(c))) {

--- a/packages/back-end/test/api/fact-table-auto-slice-cleanup.test.ts
+++ b/packages/back-end/test/api/fact-table-auto-slice-cleanup.test.ts
@@ -1,0 +1,240 @@
+import mongoose from "mongoose";
+import request from "supertest";
+import { ApiKeyInterface } from "shared/types/apikey";
+import {
+  ColumnInterface,
+  FactMetricInterface,
+  FactTableInterface,
+} from "shared/types/fact-table";
+import { OrganizationInterface } from "shared/types/organization";
+import { ReqContextClass } from "back-end/src/services/context";
+import { updateFactTableColumns } from "back-end/src/models/FactTableModel";
+import { factMetricFactory } from "back-end/test/factories/FactMetric.factory";
+import { setupApp } from "./api.setup";
+
+const organization: OrganizationInterface = {
+  id: "org_auto_slice_cleanup",
+  name: "Auto-slice cleanup",
+  ownerEmail: "owner@example.com",
+  url: "",
+  dateCreated: new Date("2026-01-01"),
+  invites: [],
+  members: [],
+  settings: { environments: [] },
+};
+
+const columns: ColumnInterface[] = [
+  {
+    column: "amount",
+    name: "Amount",
+    description: "",
+    numberFormat: "",
+    datatype: "number",
+    dateCreated: new Date("2026-01-01"),
+    dateUpdated: new Date("2026-01-01"),
+    deleted: false,
+  },
+  {
+    column: "country",
+    name: "Country",
+    description: "",
+    numberFormat: "",
+    datatype: "string",
+    dateCreated: new Date("2026-01-01"),
+    dateUpdated: new Date("2026-01-01"),
+    deleted: false,
+    isAutoSliceColumn: true,
+  },
+];
+
+const factTable: FactTableInterface = {
+  organization: organization.id,
+  id: "ftb_auto_slice_cleanup",
+  managedBy: "",
+  dateCreated: new Date("2026-01-01"),
+  dateUpdated: new Date("2026-01-01"),
+  name: "Fact Table",
+  description: "",
+  owner: "",
+  projects: [],
+  tags: [],
+  datasource: "ds_auto_slice_cleanup",
+  userIdTypes: [],
+  sql: "SELECT amount, country FROM events",
+  eventName: "",
+  columns,
+  filters: [],
+  columnRefreshPending: false,
+};
+
+function makeMetric(
+  id: string,
+  overrides: Partial<FactMetricInterface> = {},
+): FactMetricInterface {
+  return {
+    ...factMetricFactory.build({
+      id,
+      organization: organization.id,
+      datasource: factTable.datasource,
+      owner: "",
+      managedBy: "",
+      name: id,
+      numerator: {
+        factTableId: factTable.id,
+        column: "amount",
+        aggregation: "sum",
+        rowFilters: [],
+      },
+      metricAutoSlices: ["country", "device"],
+      loseRisk: 0.5,
+    }),
+    ...overrides,
+  } as FactMetricInterface;
+}
+
+const { app, setReqContext } = setupApp();
+
+// factmetrics is not a mongoose-registered collection, so the shared afterEach
+// leaves it alone.
+afterEach(async () => {
+  await mongoose.connection
+    .db!.collection("factmetrics")
+    .deleteMany({ organization: organization.id });
+});
+
+function makeContext(auth: { role: string; auditUser: unknown }) {
+  const apiKeyData: ApiKeyInterface = {
+    id: "key_test",
+    key: "test-key",
+    organization: organization.id,
+    dateCreated: new Date("2026-01-01"),
+    dateUpdated: new Date("2026-01-01"),
+    secret: true,
+    role: auth.role,
+    limitAccessByEnvironment: false,
+    environments: [],
+  };
+  const context = new ReqContextClass({
+    org: organization,
+    auditUser: auth.auditUser as ReqContextClass["auditUser"],
+    role: auth.role,
+    apiKey: "test-key",
+    apiKeyData,
+  });
+  setReqContext(context);
+  return context;
+}
+
+const apiKeyContext = () =>
+  makeContext({
+    role: "admin",
+    auditUser: { type: "api_key", apiKey: "test-key" },
+  });
+
+async function seed(metrics: FactMetricInterface[]) {
+  await mongoose.connection.db!.collection("facttables").insertOne({
+    ...factTable,
+    columns: factTable.columns.map((column) => ({ ...column })),
+  });
+  await mongoose.connection.db!.collection("factmetrics").insertMany(metrics);
+}
+
+async function storedMetric(id: string) {
+  return mongoose.connection.db!.collection("factmetrics").findOne({ id });
+}
+
+async function disableCountrySlices() {
+  return request(app)
+    .post(`/api/v1/fact-tables/${factTable.id}`)
+    .send({ columns: [{ column: "country", isAutoSliceColumn: false }] })
+    .set("Authorization", "Bearer test-key");
+}
+
+it("cleans metrics the caller is not allowed to update", async () => {
+  const metric = makeMetric("fact__not_updatable");
+  await seed([metric]);
+  const context = apiKeyContext();
+  context.permissions.canUpdateFactMetric = () => false;
+
+  const response = await disableCountrySlices();
+
+  expect(response.status).toBe(200);
+  expect(await storedMetric(metric.id)).toMatchObject({
+    metricAutoSlices: ["device"],
+  });
+  expect(
+    await mongoose.connection
+      .db!.collection("facttables")
+      .findOne({ id: factTable.id }),
+  ).toMatchObject({
+    columns: [
+      { column: "amount" },
+      { column: "country", isAutoSliceColumn: false },
+    ],
+  });
+});
+
+it("preserves a concurrent metric edit and still removes the slice", async () => {
+  const metric = makeMetric("fact__concurrent_edit");
+  await seed([metric]);
+  const context = apiKeyContext();
+  const factMetrics = context.models.factMetrics;
+  const updateIfUnchanged = factMetrics.updateIfUnchanged.bind(factMetrics);
+
+  // Slip a concurrent write in between the cascade's read and its CAS write.
+  let injected = false;
+  jest
+    .spyOn(factMetrics, "updateIfUnchanged")
+    .mockImplementation(async (existing, updates, writeOptions, options) => {
+      if (!injected) {
+        injected = true;
+        await mongoose.connection.db!.collection("factmetrics").updateOne(
+          { id: metric.id, organization: organization.id },
+          {
+            $set: {
+              name: "Concurrent update",
+              dateUpdated: new Date(metric.dateUpdated.getTime() + 1_000),
+            },
+          },
+        );
+      }
+      return updateIfUnchanged(existing, updates, writeOptions, options);
+    });
+
+  const response = await disableCountrySlices();
+
+  expect(response.status).toBe(200);
+  expect(await storedMetric(metric.id)).toMatchObject({
+    name: "Concurrent update",
+    metricAutoSlices: ["device"],
+  });
+});
+
+it("background column refresh cleans API-managed metrics and still lands", async () => {
+  const metric = makeMetric("fact__api_managed", { managedBy: "api" });
+  await seed([metric]);
+  // Mirrors getContextForAgendaJobByOrgObject: admin role, no audit user.
+  const context = makeContext({ role: "admin", auditUser: null });
+
+  await updateFactTableColumns(
+    { ...factTable, columns: factTable.columns.map((c) => ({ ...c })) },
+    {
+      columns: [columns[0], { ...columns[1], deleted: true }],
+      columnsError: null,
+      columnRefreshPending: false,
+    },
+    context,
+  );
+
+  expect(
+    await mongoose.connection
+      .db!.collection("facttables")
+      .findOne({ id: factTable.id }),
+  ).toMatchObject({
+    columnRefreshPending: false,
+    columns: [{ column: "amount" }, { column: "country", deleted: true }],
+  });
+  expect(await storedMetric(metric.id)).toMatchObject({
+    metricAutoSlices: ["device"],
+  });
+});


### PR DESCRIPTION
### Features and Changes

Supersedes #6867 with a different approach to that bug, thanks @itsgrimetime for kickstarting these fixes.

When a fact-table column is deleted or loses `isAutoSliceColumn`, dependent metrics have that column dropped from `metricAutoSlices`. That list is derived state: every reader intersects it with the fact table's current auto-slice columns, so the fact table is the source of truth and the cleanup is bookkeeping. Today it runs as a user edit on each metric, so a metric the caller can't manage, or an API-managed metric touched from the UI or the cron column refresh, fails the request after the column was already written.

The cleanup now runs after the fact-table write as a cascade: it spans every metric in the org, writes with the permission bypass, skips the API-managed channel guard for this one field, and retries on a CAS conflict instead of clobbering a concurrent metric edit. A metric that fails its own validation is logged and skipped rather than failing the fact-table write.

### Testing

- [x] Experimenter disables an auto-slice column via `PUT /fact-tables/:id/column/:column` with an API-managed dependent metric -> 200, both dependent metrics cleaned
- [x] Same call on `main` -> 403, column already disabled, metrics untouched
- [x] Concurrent edit to a dependent metric during the cascade -> edit preserved, slice still removed
- [x] Background column refresh dropping the column with an API-managed dependent -> columns land, `columnRefreshPending` cleared, metric cleaned
