### PR TITLE
fix(features): Stop persisting sticky bucketing on non-experiment rules

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -66,6 +66,7 @@ import {
   RevisionRampDetachAction,
   RevisionRampUpdateAction,
   RampStepAction,
+  stripUnknownRuleFields,
 } from "shared/validators";
 import { FeatureUsageLookback } from "shared/types/integrations";
 import {
@@ -3246,11 +3247,12 @@ export async function postFeatureRule(
   const { id, version } = req.params;
   const {
     environments: selectedEnvironments = [],
-    rule,
+    rule: ruleInput,
     safeRolloutFields,
     rampSchedule: rampSchedulePayload,
     insertBeforeRuleId,
   } = req.body;
+  let rule = ruleInput;
 
   const feature = await getFeature(context, id);
   if (!feature) {
@@ -3344,6 +3346,7 @@ export async function postFeatureRule(
   }
 
   // Stamp id + rollout seed via the shared chokepoint (safe-rollout seed set above).
+  rule = stripUnknownRuleFields(rule);
   addIdsToFlatRules([rule], feature.id);
   let rampActionsUpdate:
     | RevisionRampCreateAction
@@ -4554,7 +4557,7 @@ export async function putFeatureRule(
     }
   }
 
-  let effectiveRule = rule;
+  let effectiveRule = stripUnknownRuleFields(rule);
   let autoMergedTheirFields: string[] = [];
   if (baseline) {
     const liveRule = (feature.rules ?? []).find((r) => r.id === ruleId) ?? null;

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -532,9 +532,14 @@ export default function RuleModal({
     // has a value. getDefaultRuleValue only sets it for ruleType === "rollout";
     // other rule types ignore it at save time via their Zod validators.
     hashVersion: (hasSDKWithNoBucketingV2 ? 1 : 2) as 1 | 2,
-    // Seed sticky bucketing from the org default for new experiment rules. An
-    // existing rule's value overrides this via the convertRuleToFormValues spread.
-    disableStickyBucketing: !settings.stickyBucketingOnByDefault,
+    ...(defaultType === "experiment" ||
+    defaultType === "experiment-ref" ||
+    defaultType === "experiment-ref-new"
+      ? {
+          // Seed sticky bucketing from the org default for experiment rules only.
+          disableStickyBucketing: !settings.stickyBucketingOnByDefault,
+        }
+      : {}),
   };
 
   const convertRuleToFormValues = (rule: FeatureRule | undefined) => {
@@ -997,8 +1002,14 @@ export default function RuleModal({
     if (existingSeed) {
       (newVal as Record<string, unknown>).seed = existingSeed;
     }
-    (newVal as Record<string, unknown>).disableStickyBucketing =
-      !settings.stickyBucketingOnByDefault;
+    if (
+      v === "experiment" ||
+      v === "experiment-ref" ||
+      v === "experiment-ref-new"
+    ) {
+      (newVal as Record<string, unknown>).disableStickyBucketing =
+        !settings.stickyBucketingOnByDefault;
+    }
     // Org opt-in: new JSON rules start in sparse mode with a clean-slate value
     // (strip keys equal to the default) so the editor isn't pre-filled with the
     // whole default object. Only for eligible JSON features; new rules only.

--- a/packages/front-end/hooks/useFeatureRevisionDiff.ts
+++ b/packages/front-end/hooks/useFeatureRevisionDiff.ts
@@ -2,7 +2,7 @@ import { useMemo, ReactNode } from "react";
 import isEqual from "lodash/isEqual";
 import { FeatureInterface } from "shared/types/feature";
 import { FeatureRevisionInterface } from "shared/types/feature-revision";
-import { RevisionMetadata } from "shared/validators";
+import { RevisionMetadata, stripUnknownRuleFields } from "shared/validators";
 import type { MergeResultChanges } from "shared/util";
 import {
   renderFeatureDefaultValue,
@@ -401,8 +401,12 @@ export function useFeatureRevisionDiff({
     // footprint is empty (`environments: []`, pending) or universal
     // (`allEnvironments: true`) — all of which were invisible in the old
     // per-env projection layout.
-    const draftRulesArr = Array.isArray(draft.rules) ? draft.rules : [];
-    const currentRulesArr = Array.isArray(current.rules) ? current.rules : [];
+    const draftRulesArr = (Array.isArray(draft.rules) ? draft.rules : []).map(
+      stripUnknownRuleFields,
+    );
+    const currentRulesArr = (
+      Array.isArray(current.rules) ? current.rules : []
+    ).map(stripUnknownRuleFields);
     const draftRampActions = draft.rampActions ?? undefined;
     // Force the Rules section to render when an unchanged rule has a pending
     // ramp create action queued — without this, a draft whose only change is

--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -45,6 +45,7 @@ import {
   HoldoutInterface,
   RevisionRampAction,
   SafeRolloutRule,
+  stripUnknownRuleFields,
 } from "shared/validators";
 import {
   featurePublishFootprint,
@@ -742,7 +743,7 @@ export function validateFeatureRule(
   existingRule?: FeatureRule,
 ): null | FeatureRule {
   let hasChanges = false;
-  const ruleCopy = cloneDeep(rule);
+  const ruleCopy = cloneDeep(stripUnknownRuleFields(rule));
 
   validateSavedGroupTargeting(rule.savedGroups);
 

--- a/packages/front-end/test/hooks/useFeatureRevisionDiff.test.ts
+++ b/packages/front-end/test/hooks/useFeatureRevisionDiff.test.ts
@@ -209,6 +209,36 @@ describe("useFeatureRevisionDiff", () => {
     expect(html).not.toContain('["production","dev"]');
   });
 
+  it("ignores rule fields the rule type does not declare", () => {
+    const rule = {
+      type: "experiment-ref",
+      id: "r1",
+      description: "",
+      enabled: true,
+      allEnvironments: true,
+      condition: "",
+      scheduleRules: [],
+      experimentId: "exp_1",
+      variations: [{ variationId: "v0", value: "a" }],
+    };
+    const current: FeatureRevisionDiffInput = {
+      defaultValue: "a",
+      rules: [rule] as never,
+    };
+    const draft: FeatureRevisionDiffInput = {
+      defaultValue: "a",
+      rules: [
+        { ...rule, hashVersion: 2, disableStickyBucketing: false },
+      ] as never,
+    };
+
+    const { result } = renderHook(() =>
+      useFeatureRevisionDiff({ current, draft }),
+    );
+
+    expect(result.current.filter((d) => d.key === "rules")).toHaveLength(0);
+  });
+
   it("emits an env-toggle diff only for envs that actually changed", () => {
     const current: FeatureRevisionDiffInput = {
       defaultValue: "false",

--- a/packages/shared/src/validators/features.ts
+++ b/packages/shared/src/validators/features.ts
@@ -272,6 +272,24 @@ export const featureRule = z.union([
 
 export type FeatureRule = z.infer<typeof featureRule>;
 
+// Keys each rule type actually stores. The rule form carries widget-only
+// fields (hashVersion, sticky bucketing, coverage) for every type; union
+// members are `.strict()` so nothing strips them on the way in unless we do.
+export function stripUnknownRuleFields<T extends { type?: string }>(
+  rule: T,
+): T {
+  const schema = featureRule.options.find((o) =>
+    o.shape.type._def.values.includes(rule.type as never),
+  );
+  if (!schema) return rule;
+  const allowed = new Set(Object.keys(schema.shape));
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(rule)) {
+    if (allowed.has(k)) out[k] = v;
+  }
+  return out as T;
+}
+
 // Env-level settings only (kill switch + prerequisites). Rules live on
 // `featureInterface.rules`.
 export const featureEnvironment = z

--- a/packages/shared/test/strip-unknown-rule-fields.test.ts
+++ b/packages/shared/test/strip-unknown-rule-fields.test.ts
@@ -1,0 +1,69 @@
+import { stripUnknownRuleFields } from "../src/validators/features";
+
+describe("stripUnknownRuleFields", () => {
+  it("drops fields a force rule does not store", () => {
+    const out = stripUnknownRuleFields({
+      type: "force",
+      id: "r1",
+      description: "",
+      enabled: true,
+      allEnvironments: true,
+      condition: "",
+      scheduleRules: [],
+      value: "true",
+      disableStickyBucketing: true,
+      hashVersion: 2,
+      hashAttribute: "id",
+    } as never) as Record<string, unknown>;
+    expect(out.disableStickyBucketing).toBeUndefined();
+    expect(out.hashVersion).toBeUndefined();
+    expect(out.hashAttribute).toBeUndefined();
+    expect(out.value).toBe("true");
+  });
+
+  it("drops fields an experiment-ref rule does not store", () => {
+    const out = stripUnknownRuleFields({
+      type: "experiment-ref",
+      id: "r1",
+      description: "",
+      enabled: true,
+      allEnvironments: true,
+      condition: "",
+      scheduleRules: [],
+      experimentId: "exp_1",
+      variations: [],
+      hashVersion: 2,
+      disableStickyBucketing: false,
+      coverage: 1,
+    } as never) as Record<string, unknown>;
+    expect(out.hashVersion).toBeUndefined();
+    expect(out.disableStickyBucketing).toBeUndefined();
+    expect(out.coverage).toBeUndefined();
+    expect(out.experimentId).toBe("exp_1");
+    expect(out.allEnvironments).toBe(true);
+  });
+
+  it("keeps fields the type does store", () => {
+    const out = stripUnknownRuleFields({
+      type: "rollout",
+      id: "r2",
+      description: "",
+      enabled: true,
+      allEnvironments: true,
+      condition: "",
+      scheduleRules: [],
+      value: "a",
+      coverage: 0.5,
+      hashAttribute: "id",
+      hashVersion: 2,
+    } as never) as Record<string, unknown>;
+    expect(out.coverage).toBe(0.5);
+    expect(out.hashVersion).toBe(2);
+    expect(out.disableStickyBucketing).toBeUndefined();
+  });
+
+  it("leaves an unrecognised type alone", () => {
+    const rule = { type: "nope", weird: 1 } as never;
+    expect(stripUnknownRuleFields(rule)).toBe(rule);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

After the sticky bucketing opt-in work (#6799), the rule form seeded `disableStickyBucketing` on every rule type. Force, rollout, and experiment-ref rules don't declare that field in their Zod schemas, but the internal revision save path persisted it anyway — so creating or editing any rule in a draft could attach sticky-bucketing metadata that doesn't belong on that rule type.

This fix:

- Adds `stripUnknownRuleFields()` in shared, which drops any keys not declared on the rule type's schema
- Strips widget-only fields in `validateFeatureRule` before rules are submitted from the UI
- Sanitizes rules on the back-end in `postFeatureRule` / `putFeatureRule`
- Limits the sticky bucketing form default to experiment rule types only
- Normalizes rules through their schema in revision diffs so drafts written before this fix don't keep showing phantom changes

### Testing

- `pnpm --filter shared test strip-unknown-rule-fields.test.ts` (4/4 passing)
- `pnpm --filter front-end test test/hooks/useFeatureRevisionDiff.test.ts` (7/7 passing)
- `pnpm --filter shared type-check`
- `pnpm --filter front-end type-check`
- `pnpm --filter back-end type-check`

<a href="/opt/cursor/artifacts/sticky_bucketing_rule_field_strip_tests.txt">Test output</a>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/D0ANTLUD22J/p1774465571901549?thread_ts=1774465571.901549&cid=D0ANTLUD22J)

<div><a href="https://cursor.com/agents/bc-02c05ed9-9a12-56df-8912-e8c5403bc446?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02c05ed9-9a12-56df-8912-e8c5403bc446&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

