### PR TITLE
docs: re-apply experiment section nav restructure

### DIFF
--- a/docs/app/experiment-configuration.mdx
+++ b/docs/app/experiment-configuration.mdx
@@ -12,7 +12,7 @@ The Experiments section in GrowthBook is where you create experiments, configure
 
 Before [analyzing results](/app/experiment-results), you need to run the experiment. GrowthBook supports several ways to do this:
 
-- [Feature Flags](/feature-flag-experiments) (most common)
+- [Feature Flags](/features/feature-flag-experiments) (most common)
 - Running an inline experiment directly with our [SDKs](/lib)
 - [URL Redirects](/app/url-redirects)
 - Our [Visual Editor](/app/visual)
@@ -46,7 +46,7 @@ After creation, the draft experiment's Overview tab includes a pre-launch checkl
 
 - Selecting a data source and experiment assignment table
 - Adding at least one goal metric
-- Adding a linked [Feature Flag](/feature-flag-experiments), [Visual Editor](/app/visual) change, or [URL Redirect](/app/url-redirects)
+- Adding a linked [Feature Flag](/features/feature-flag-experiments), [Visual Editor](/app/visual) change, or [URL Redirect](/app/url-redirects)
 
 The pre-launch checklist can be configured by Enterprise customers, [read more here](/app/pre-launch-checklist).
 

--- a/docs/app/managed-warehouse.mdx
+++ b/docs/app/managed-warehouse.mdx
@@ -138,7 +138,7 @@ With events flowing and metrics defined, you're ready to experiment:
 2. Add an **Experiment** rule to it.
 3. Start the experiment and watch results flow in on the **Results** tab.
 
-For a detailed walkthrough, see our [guide to running Feature Flag Experiments](/feature-flag-experiments).
+For a detailed walkthrough, see our [guide to running Feature Flag Experiments](/features/feature-flag-experiments).
 
 ---
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -78,7 +78,8 @@
                       "features/targeting",
                       "features/safe-rollouts",
                       "features/ramp-schedules",
-                      "features/prerequisites"
+                      "features/prerequisites",
+                      "features/feature-flag-experiments"
                     ]
                   },
                   {
@@ -162,55 +163,54 @@
                 "group": "Experimentation",
                 "root": "experiments",
                 "pages": [
-                  "feature-flag-experiments",
                   {
-                    "group": "Visual Editor",
-                    "root": "app/visual",
+                    "group": "Creating Experiments",
+                    "expanded": true,
                     "pages": [
-                      "app/visual/install-and-connect",
-                      "app/visual/ai-mode",
-                      "app/visual/manual-mode",
-                      "app/visual/images",
-                      "app/visual/design-import",
-                      "app/visual/running-on-your-site",
-                      "app/visual/preview-and-qa",
-                      "app/visual/troubleshooting",
-                      "app/visual/legacy"
+                      "app/experiment-configuration",
+                      "running-experiments/experiment-templates",
+                      "app/pre-launch-checklist",
+                      "statistics/power",
+                      "app/importing-experiments"
                     ]
                   },
-                  "app/url-redirects",
-                  "app/experiment-configuration",
-                  "running-experiments/experiment-templates",
-                  "app/experiment-results",
-                  "app/experiment-time-series",
-                  "app/experiment-decisions",
-                  "app/making-experiment-changes",
                   {
-                    "group": "Bandits",
+                    "group": "Delivery Methods",
+                    "expanded": true,
                     "pages": [
-                      "bandits/overview",
-                      "bandits/config",
-                      "bandits/results",
+                      "features/feature-flag-experiments",
                       {
-                        "group": "Contextual Bandits",
-                        "tag": "BETA",
+                        "group": "Visual Editor",
+                        "root": "app/visual",
                         "pages": [
-                          "bandits/contextual",
-                          "bandits/contextual-config",
-                          "bandits/contextual-via-api"
+                          "app/visual/install-and-connect",
+                          "app/visual/ai-mode",
+                          "app/visual/manual-mode",
+                          "app/visual/images",
+                          "app/visual/design-import",
+                          "app/visual/running-on-your-site",
+                          "app/visual/preview-and-qa",
+                          "app/visual/troubleshooting",
+                          "app/visual/legacy"
                         ]
-                      }
+                      },
+                      "app/url-redirects"
                     ]
                   },
-                  "app/holdouts",
-                  "app/sticky-bucketing",
-                  "experimentation-analysis/cluster-experiments",
-                  "app/dimensions",
-                  "app/pre-launch-checklist",
-                  "app/experiment-dashboards",
-                  "app/importing-experiments",
                   {
-                    "group": "Statistics",
+                    "group": "Analysis & Decisions",
+                    "expanded": true,
+                    "pages": [
+                      "app/making-experiment-changes",
+                      "app/experiment-results",
+                      "app/experiment-time-series",
+                      "app/experiment-decisions",
+                      "app/experiment-dashboards",
+                      "app/dimensions"
+                    ]
+                  },
+                  {
+                    "group": "Advanced & Statistics",
                     "pages": [
                       "statistics/overview",
                       "statistics/details",
@@ -219,10 +219,29 @@
                       "statistics/sequential",
                       "statistics/multiple-corrections",
                       "statistics/aggregation",
-                      "statistics/power",
-                      "statistics/contextual-bandit-technical"
+                      "statistics/contextual-bandit-technical",
+                      "app/sticky-bucketing",
+                      "experimentation-analysis/cluster-experiments"
                     ]
-                  }
+                  },
+                  {
+                    "group": "Bandits",
+                    "pages": [
+                      "bandits/overview",
+                      "bandits/config",
+                      "bandits/results"
+                    ]
+                  },
+                  {
+                    "group": "Contextual Bandits",
+                    "tag": "BETA",
+                    "pages": [
+                      "bandits/contextual",
+                      "bandits/contextual-config",
+                      "bandits/contextual-via-api"
+                    ]
+                  },
+                  "app/holdouts"
                 ]
               },
               "insights",
@@ -1257,8 +1276,8 @@
       "destination": "/static/open-guide-to-ab-testing.v1.0.pdf"
     },
     {
-      "source": "/features/feature-flag-experiments",
-      "destination": "/feature-flag-experiments"
+      "source": "/feature-flag-experiments",
+      "destination": "/features/feature-flag-experiments"
     },
     {
       "source": "/app/experiments",

--- a/docs/experiments.mdx
+++ b/docs/experiments.mdx
@@ -24,7 +24,7 @@ logic ([rules](/features/rules)) which controls how a feature should be shown, a
 of an experiment. GrowthBook also lets you target any feature or rule based on the
 [targeting attributes](/features/targeting) you define. With GrowthBook, you can add an experiment rule to a feature that will
 randomly assign the users based on some hashing attribute into one of your experiment variations. You can read more about
-feature flag [experiment rules](/features/rules), or more details on running an [experiment with feature flags](/feature-flag-experiments).
+feature flag [experiment rules](/features/rules), or more details on running an [experiment with feature flags](/features/feature-flag-experiments).
 
 ### Inline Experiments
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -60,7 +60,7 @@ So that means if you do 50 orders per week and that's the metric you are trying 
 
 Yes! In fact, we recommend running many experiments in parallel in your application. Most A/B tests fail, so the more shots-on-goal you take, the more likely you are to get a winner. Running tests in parallel is a great way to increase your velocity.
 
-Now it's possible your experiments might have interaction effects, but these are actually pretty rare in practice. One example is if one test is changing the text color on a page and another test is changing the background color. Some users might end up seeing black text on a black background, which is obviously not ideal. For these rare cases, you can use [Namespaces](/feature-flag-experiments#namespaces) to run mutually exclusive experiments. Make sure all experiments within the same Namespace are using the same hash attribute (assignment attribute).
+Now it's possible your experiments might have interaction effects, but these are actually pretty rare in practice. One example is if one test is changing the text color on a page and another test is changing the background color. Some users might end up seeing black text on a black background, which is obviously not ideal. For these rare cases, you can use [Namespaces](/features/feature-flag-experiments#namespaces) to run mutually exclusive experiments. Make sure all experiments within the same Namespace are using the same hash attribute (assignment attribute).
 
 As long as you apply a little common sense to avoid situations like the above, running multiple experiments has low risk and really high reward.
 

--- a/docs/features/feature-flag-experiments.mdx
+++ b/docs/features/feature-flag-experiments.mdx
@@ -2,7 +2,7 @@
 title: Feature Flag Experiments
 description: Attach an experiment-ref rule to a feature flag so GrowthBook assigns variations and analyzes the test.
 sidebarTitle: Feature Flag Experiments
-slug: /feature-flag-experiments
+slug: /features/feature-flag-experiments
 ---
 
 GrowthBook allows you to run experiments using feature flags. This method of running experiments allows any feature to be

--- a/docs/features/rules.mdx
+++ b/docs/features/rules.mdx
@@ -75,7 +75,7 @@ Experiment rules randomly split users into variations, assign each variation a v
 
 You control both the percentage of users included and the split between variations. For example, including 50% of users with a 40/60 split means 20% of all users see variation A, 30% see variation B, and the remaining 50% fall through to the next rule.
 
-→ [Full experimentation documentation](/feature-flag-experiments)
+→ [Full experimentation documentation](/features/feature-flag-experiments)
 
 ### Bandit
 

--- a/docs/guide/express-js.mdx
+++ b/docs/guide/express-js.mdx
@@ -188,6 +188,6 @@ In this tutorial, you learned how to use a simple feature flag in an Express app
 Here are a few next steps you can take:
 
 - Use more [advanced targeting](/features/targeting)
-- Run [A/B tests](/feature-flag-experiments)
+- Run [A/B tests](/features/feature-flag-experiments)
 
 View the [full Node.js docs](/lib/node) for more information on all of the options available in the GrowthBook SDK, including streaming updates, persistent caching, and more.

--- a/docs/guide/google-tag-manager-and-growthbook.mdx
+++ b/docs/guide/google-tag-manager-and-growthbook.mdx
@@ -63,7 +63,7 @@ Be sure to click **Submit** and **Publish** to make your changes live. GrowthBoo
 It's possible to use GrowthBook in your GTM setup. This allows you to control feature flags and experiments without needing to modify your website code.
 
 <Tip>
-If you're planning to use the [Visual Editor](/app/visual), [URL redirects](/app/url-redirects), or to [run experiments in code](/feature-flag-experiments), skip ahead to the next section ⏭️
+If you're planning to use the [Visual Editor](/app/visual), [URL redirects](/app/url-redirects), or to [run experiments in code](/features/feature-flag-experiments), skip ahead to the next section ⏭️
 </Tip>
 
 Create a new boolean feature flag with an A/B test. For this tutorial, we'll use a feature flag called `show-discount` to run an A/B test to show and hide an item's discount. New to feature flags in GrowthBook? Learn more about [creating them and A/B tests](/features/basics).

--- a/docs/kb/glossary.mdx
+++ b/docs/kb/glossary.mdx
@@ -146,7 +146,7 @@ hide_table_of_contents: true
 
 **N**
 
-[Namespace](/feature-flag-experiments#namespaces): A Namespace in GrowthBook is a feature that allows you to make multiple experiments mutually exclusive, ensuring that users are only part of one experiment within the same namespace at a time, useful for avoiding conflicts between experiments.
+[Namespace](/features/feature-flag-experiments#namespaces): A Namespace in GrowthBook is a feature that allows you to make multiple experiments mutually exclusive, ensuring that users are only part of one experiment within the same namespace at a time, useful for avoiding conflicts between experiments.
 
 [No Access Role](/account/user-permissions#how-does-the-no-access-role-work): A base role with zero permissions (not even read access). Combine with project-scoped roles for fine-grained access control.
 

--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -54,7 +54,7 @@ Press `Cmd+K` (Mac) or `Ctrl+K` (Windows and Linux) anywhere in GrowthBook to op
 
     It really is that simple to get started! For next steps, we recommend reading our [Feature Flag Basics](/features/basics) page, which goes into more depth.
 
-    Feature flags are the foundation for powerful experimentation. In the next section, we show you how to use them to run no-code experimentation using our Visual Editor. Need more advanced options? Dive into our [complete guide for code-based experimentation](/feature-flag-experiments).
+    Feature flags are the foundation for powerful experimentation. In the next section, we show you how to use them to run no-code experimentation using our Visual Editor. Need more advanced options? Dive into our [complete guide for code-based experimentation](/features/feature-flag-experiments).
 
   </Step>
 </Steps>

--- a/docs/using/experimentation-best-practices.mdx
+++ b/docs/using/experimentation-best-practices.mdx
@@ -45,7 +45,7 @@ two tests will meaningfully interact, and many will run the tests in serial in a
 However, meaningful interactions are actually quite rare, and keeping a higher rate of experimentation
 is usually more beneficial. You can run analysis after the experiments to see if there were any
 interaction effects which would change your conclusions (GrowthBook is working on an integrated solution for
-this). If you need to run mutually exclusive tests, you can use GrowthBook’s [namespace](/feature-flag-experiments#namespaces) feature.
+this). If you need to run mutually exclusive tests, you can use GrowthBook’s [namespace](/features/feature-flag-experiments#namespaces) feature.
 
 ### Experimentation Frequency
 


### PR DESCRIPTION
Re-applies the left nav restructure from #6422 that was lost in the Docusaurus to Mintlify migration (#6446):

- Group the Experimentation nav into Creating Experiments, Delivery Methods, Analysis & Decisions, and Advanced & Statistics
- Split Bandits and Contextual Bandits into sibling groups
- Move Feature Flag Experiments back to /features/feature-flag-experiments, list it under Feature Flags > Targeting & Rules, flip the redirect, and update internal links