### PR TITLE
fix(features): Strip disableStickyBucketing from non-legacy experiment rules after experiment creation

### DIFF
--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -1461,6 +1461,11 @@ export default function RuleModal({
         delete values.scheduleRules;
       }
 
+      // Only needed for experiment & bandit creation. Not stored on rules
+      // so we strip it here after the experiment is created.
+      delete (values as { disableStickyBucketing?: boolean })
+        .disableStickyBucketing;
+
       const correctedRule = validateFeatureRule(
         values as FeatureRule,
         feature,

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -1461,10 +1461,12 @@ export default function RuleModal({
         delete values.scheduleRules;
       }
 
-      // Only needed for experiment & bandit creation. Not stored on rules
-      // so we strip it here after the experiment is created.
-      delete (values as { disableStickyBucketing?: boolean })
-        .disableStickyBucketing;
+      // Only inline experiment rules store disableStickyBucketing; on every
+      // other type it's a stray form default
+      if (values.type !== "experiment") {
+        delete (values as { disableStickyBucketing?: boolean })
+          .disableStickyBucketing;
+      }
 
       const correctedRule = validateFeatureRule(
         values as FeatureRule,


### PR DESCRIPTION
### Features and Changes

We're currently setting a default for all rule types for `disableStickyBucketing` to support seeding the default based on the org's setting for whether or not sticky bucketing is opt in or opt our for experiments. Because we share a form for all rule types, we set the default before knowing the type. The submit handler was missing a line to remove `disableStickyBucketing` from the rule so this PR adds that for non legacy experiment rules after we persist the value for new experiments/bandits. This had no impact on the SDK for rule types that don't support sticky bucketing so this is mainly a correctness fix.

### Testing

- [x] Add a non experiment-ref rule and verify in the review and publish tab that we aren't adding `disableStickyBucketing` to the rule
- [x] Edit a non experiment-ref rule and verify that we aren't adding `disableStickyBucketing` to the rule
- [x] New experiment-ref rules are correctly seeded based on org settings

### Screenshots

**Before**
<img width="424" height="442" alt="Screenshot 2026-09-09 at 11 40 50 AM" src="https://github.com/user-attachments/assets/9921d516-074b-4490-8575-3d19a238e578" />

**After**
<img width="434" height="391" alt="Screenshot 2026-09-09 at 11 42 33 AM" src="https://github.com/user-attachments/assets/3c2cc579-0d58-4a4d-a2a6-1f4e3bad865d" />
