### PR TITLE
fix(queries): cancel warehouse jobs when external IDs arrive late

### DIFF
--- a/packages/back-end/src/models/QueryModel.ts
+++ b/packages/back-end/src/models/QueryModel.ts
@@ -139,6 +139,29 @@ export async function countRunningQueries(
   }).count();
 }
 
+export async function setQueryExternalId(
+  context: ReqContext,
+  query: QueryInterface,
+  externalId: string,
+  metadata?: QueryInterface["externalIdMetadata"],
+): Promise<QueryInterface["status"] | null> {
+  if (query.organization !== context.org.id) {
+    throw new Error("Cannot update query from different organization");
+  }
+
+  const doc = await QueryModel.findOneAndUpdate(
+    { organization: context.org.id, id: query.id },
+    {
+      $set: {
+        externalId,
+        ...(metadata ? { externalIdMetadata: metadata } : {}),
+      },
+    },
+    { new: true, projection: { status: 1 } },
+  );
+  return doc?.status ?? null;
+}
+
 export async function updateQuery(
   context: ReqContext,
   query: QueryInterface,

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -14,9 +14,9 @@ import {
   createNewQuery,
   createNewQueryFromCached,
   getQueriesByIds,
-  getQueryStatusesByIds,
   getRecentQuery,
   markPendingQueriesAsFailed,
+  setQueryExternalId,
   touchQueuedQueriesHeartbeat,
   updateQuery,
   updateQueryIfPending,
@@ -1130,27 +1130,12 @@ export abstract class QueryRunner<
       id: string,
       metadata?: Record<string, string>,
     ) => {
-      await updateQuery(this.context, doc, {
-        externalId: id,
-        ...(metadata ? { externalIdMetadata: metadata } : {}),
-      });
+      const status = await setQueryExternalId(this.context, doc, id, metadata);
       if (!this.integration.cancelQuery) return;
 
       // In case the query was cancelled before externalId was set, detect that and cancel
       // the external job here
-      const statuses = await getQueryStatusesByIds(this.context.org.id, [
-        doc.id,
-      ]).catch((err: unknown) => {
-        logger.warn(
-          { err, queryId: doc.id, externalId: id },
-          "Could not check query status after storing external ID; continuing to collect results",
-        );
-        return null;
-      });
-      if (statuses === null) return;
-
-      const [current] = statuses;
-      if (!current || current.status === "failed") {
+      if (status === null || status === "failed") {
         await cancelQueryAndConfirm(
           this.integration,
           { externalId: id, metadata },

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -14,6 +14,7 @@ import {
   createNewQuery,
   createNewQueryFromCached,
   getQueriesByIds,
+  getQueryStatusesByIds,
   getRecentQuery,
   markPendingQueriesAsFailed,
   touchQueuedQueriesHeartbeat,
@@ -1133,6 +1134,24 @@ export abstract class QueryRunner<
         externalId: id,
         ...(metadata ? { externalIdMetadata: metadata } : {}),
       });
+      if (!this.integration.cancelQuery) return;
+
+      // In case the query was cancelled before externalId was set, detect that and cancel
+      // the external job here
+      const [current] = await getQueryStatusesByIds(this.context.org.id, [
+        doc.id,
+      ]);
+      if (!current || current.status === "failed") {
+        await cancelQueryAndConfirm(
+          this.integration,
+          { externalId: id, metadata },
+          {
+            datasourceId: this.integration.datasource.id,
+            modelId: this.model.id,
+            queryId: doc.id,
+          },
+        );
+      }
     };
 
     run(doc.query, setExternalId, { queryType: doc.queryType || "unknown" })

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -1138,9 +1138,18 @@ export abstract class QueryRunner<
 
       // In case the query was cancelled before externalId was set, detect that and cancel
       // the external job here
-      const [current] = await getQueryStatusesByIds(this.context.org.id, [
+      const statuses = await getQueryStatusesByIds(this.context.org.id, [
         doc.id,
-      ]);
+      ]).catch((err: unknown) => {
+        logger.warn(
+          { err, queryId: doc.id, externalId: id },
+          "Could not check query status after storing external ID; continuing to collect results",
+        );
+        return null;
+      });
+      if (statuses === null) return;
+
+      const [current] = statuses;
       if (!current || current.status === "failed") {
         await cancelQueryAndConfirm(
           this.integration,

--- a/packages/back-end/test/queryRunners/QueryRunner.test.ts
+++ b/packages/back-end/test/queryRunners/QueryRunner.test.ts
@@ -10,6 +10,7 @@ import {
   getQueryFailureError,
 } from "back-end/src/queryRunners/QueryRunner";
 import { SourceIntegrationInterface } from "back-end/src/types/Integration";
+import { logger } from "back-end/src/util/logger";
 import {
   countRunningQueries,
   getQueriesByIds,
@@ -842,6 +843,56 @@ describe("QueryRunner", () => {
         }
       },
     );
+
+    it("continues collecting results when the cancellation status lookup fails", async () => {
+      jest.useFakeTimers();
+      const query = createMockQuery("qry_status_lookup", "running");
+      const runner = new CascadeFailureQueryRunner(
+        mockContext,
+        {
+          id: "test-model",
+          organization: "test-org",
+          queries: [{ name: "a", query: query.id, status: "running" }],
+          runStarted: new Date(),
+        },
+        mockIntegration,
+      );
+      const lookupError = new Error("MongoDB temporarily unavailable");
+      const warn = jest.spyOn(logger, "warn").mockImplementation(() => {});
+      const onSuccess = jest.fn();
+      const onFailure = jest.fn();
+      mockIntegration.cancelQuery = jest.fn().mockResolvedValue(undefined);
+      jest.mocked(updateQueryIfPending).mockResolvedValue(true);
+      jest.mocked(updateQuery).mockResolvedValue(query);
+      jest.mocked(getQueryStatusesByIds).mockRejectedValue(lookupError);
+
+      try {
+        await runner.executeQuery(query, {
+          run: async (sql, setExternalId) => {
+            expect(sql).toBe(query.query);
+            await setExternalId("job_status_lookup", { location: "EU" });
+            return { rows: [] };
+          },
+          onSuccess,
+          onFailure,
+        });
+        await jest.advanceTimersByTimeAsync(0);
+
+        expect(onSuccess).toHaveBeenCalledWith([]);
+        expect(onFailure).not.toHaveBeenCalled();
+        expect(mockIntegration.cancelQuery).not.toHaveBeenCalled();
+        expect(warn).toHaveBeenCalledWith(
+          expect.objectContaining({ err: lookupError, queryId: query.id }),
+          expect.any(String),
+        );
+      } finally {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+        warn.mockRestore();
+        jest.mocked(updateQuery).mockReset();
+        jest.mocked(getQueryStatusesByIds).mockReset();
+      }
+    });
 
     // Reproduces the swallowed-error bug in the aggregated fact table pipeline.
     // A multi-query DAG (insert + a dependent coverage query) fails when the

--- a/packages/back-end/test/queryRunners/QueryRunner.test.ts
+++ b/packages/back-end/test/queryRunners/QueryRunner.test.ts
@@ -10,12 +10,12 @@ import {
   getQueryFailureError,
 } from "back-end/src/queryRunners/QueryRunner";
 import { SourceIntegrationInterface } from "back-end/src/types/Integration";
-import { logger } from "back-end/src/util/logger";
 import {
   countRunningQueries,
   getQueriesByIds,
   getQueryStatusesByIds,
   markPendingQueriesAsFailed,
+  setQueryExternalId,
   updateQuery,
   updateQueryIfPending,
   updateQueryIfRunning,
@@ -789,19 +789,25 @@ describe("QueryRunner", () => {
         mockIntegration.cancelQuery = cancelQuery;
         jest.mocked(updateQueryIfPending).mockResolvedValue(true);
         jest
-          .mocked(updateQuery)
-          .mockImplementation(async (context, doc, changes) => {
+          .mocked(setQueryExternalId)
+          .mockImplementation(async (context, doc, externalId, metadata) => {
             expect(context).toBe(mockContext);
             expect(doc.id).toBe(query.id);
-            storedQuery = { ...storedQuery, ...changes };
-            return storedQuery;
+            storedQuery = {
+              ...storedQuery,
+              externalId,
+              externalIdMetadata: metadata,
+            };
+            return storedQuery.status;
           });
         jest
           .mocked(getQueriesByIds)
           .mockImplementation(async () => [storedQuery]);
         jest
           .mocked(getQueryStatusesByIds)
-          .mockImplementation(async () => [storedQuery]);
+          .mockRejectedValue(
+            new Error("Status lookup temporarily unavailable"),
+          );
         jest.mocked(markPendingQueriesAsFailed).mockImplementation(async () => {
           storedQuery = { ...storedQuery, status: "failed" };
           return 1;
@@ -837,14 +843,14 @@ describe("QueryRunner", () => {
         } finally {
           jest.clearAllTimers();
           jest.useRealTimers();
-          jest.mocked(updateQuery).mockReset();
+          jest.mocked(setQueryExternalId).mockReset();
           jest.mocked(markPendingQueriesAsFailed).mockReset();
           jest.mocked(getQueryStatusesByIds).mockReset();
         }
       },
     );
 
-    it("continues collecting results when the cancellation status lookup fails", async () => {
+    it("collects results while the query remains running", async () => {
       jest.useFakeTimers();
       const query = createMockQuery("qry_status_lookup", "running");
       const runner = new CascadeFailureQueryRunner(
@@ -857,14 +863,12 @@ describe("QueryRunner", () => {
         },
         mockIntegration,
       );
-      const lookupError = new Error("MongoDB temporarily unavailable");
-      const warn = jest.spyOn(logger, "warn").mockImplementation(() => {});
       const onSuccess = jest.fn();
       const onFailure = jest.fn();
       mockIntegration.cancelQuery = jest.fn().mockResolvedValue(undefined);
       jest.mocked(updateQueryIfPending).mockResolvedValue(true);
       jest.mocked(updateQuery).mockResolvedValue(query);
-      jest.mocked(getQueryStatusesByIds).mockRejectedValue(lookupError);
+      jest.mocked(setQueryExternalId).mockResolvedValue("running");
 
       try {
         await runner.executeQuery(query, {
@@ -881,16 +885,11 @@ describe("QueryRunner", () => {
         expect(onSuccess).toHaveBeenCalledWith([]);
         expect(onFailure).not.toHaveBeenCalled();
         expect(mockIntegration.cancelQuery).not.toHaveBeenCalled();
-        expect(warn).toHaveBeenCalledWith(
-          expect.objectContaining({ err: lookupError, queryId: query.id }),
-          expect.any(String),
-        );
       } finally {
         jest.clearAllTimers();
         jest.useRealTimers();
-        warn.mockRestore();
         jest.mocked(updateQuery).mockReset();
-        jest.mocked(getQueryStatusesByIds).mockReset();
+        jest.mocked(setQueryExternalId).mockReset();
       }
     });
 

--- a/packages/back-end/test/queryRunners/QueryRunner.test.ts
+++ b/packages/back-end/test/queryRunners/QueryRunner.test.ts
@@ -1,4 +1,5 @@
 import { Queries, QueryInterface, QueryStatus } from "shared/types/query";
+import { ExternalIdCallback } from "shared/types/integrations";
 import { ReqContext } from "back-end/types/request";
 import {
   QueryRunner,
@@ -12,6 +13,8 @@ import { SourceIntegrationInterface } from "back-end/src/types/Integration";
 import {
   countRunningQueries,
   getQueriesByIds,
+  getQueryStatusesByIds,
+  markPendingQueriesAsFailed,
   updateQuery,
   updateQueryIfPending,
   updateQueryIfRunning,
@@ -758,6 +761,87 @@ describe("QueryRunner", () => {
     class CascadeFailureQueryRunner extends RaceTestQueryRunner {
       async onQueryFinish() {}
     }
+
+    it.each([true, false])(
+      "cancels the warehouse job when cancellation precedes external ID persistence: %s",
+      async (cancelBeforeExternalId) => {
+        jest.useFakeTimers();
+        const query = createMockQuery("qry_late_id", "running");
+        let storedQuery = { ...query };
+        const model: InterfaceWithQueries = {
+          id: "test-model",
+          organization: "test-org",
+          queries: [{ name: "a", query: query.id, status: "running" }],
+          runStarted: new Date(),
+        };
+        const runner = new CascadeFailureQueryRunner(
+          mockContext,
+          model,
+          mockIntegration,
+        );
+        const cancellingRunner = new CascadeFailureQueryRunner(
+          mockContext,
+          model,
+          mockIntegration,
+        );
+        const cancelQuery = jest.fn().mockResolvedValue(undefined);
+        mockIntegration.cancelQuery = cancelQuery;
+        jest.mocked(updateQueryIfPending).mockResolvedValue(true);
+        jest
+          .mocked(updateQuery)
+          .mockImplementation(async (context, doc, changes) => {
+            expect(context).toBe(mockContext);
+            expect(doc.id).toBe(query.id);
+            storedQuery = { ...storedQuery, ...changes };
+            return storedQuery;
+          });
+        jest
+          .mocked(getQueriesByIds)
+          .mockImplementation(async () => [storedQuery]);
+        jest
+          .mocked(getQueryStatusesByIds)
+          .mockImplementation(async () => [storedQuery]);
+        jest.mocked(markPendingQueriesAsFailed).mockImplementation(async () => {
+          storedQuery = { ...storedQuery, status: "failed" };
+          return 1;
+        });
+        const run = jest.fn(
+          (sql: string, setExternalId: ExternalIdCallback) => {
+            expect(sql).toBe(query.query);
+            expect(setExternalId).toEqual(expect.any(Function));
+            return new Promise<{ rows: [] }>(() => {});
+          },
+        );
+
+        try {
+          await runner.executeQuery(query, { run, onFailure: jest.fn() });
+          const setExternalId = run.mock.calls[0][1];
+          const metadata = { location: "europe-west2" };
+          if (cancelBeforeExternalId) {
+            await cancellingRunner.cancelQueries();
+            expect(cancelQuery).not.toHaveBeenCalled();
+            await setExternalId("job_late_id", metadata);
+          } else {
+            await setExternalId("job_late_id", metadata);
+            expect(cancelQuery).not.toHaveBeenCalled();
+            await cancellingRunner.cancelQueries();
+          }
+          expect(cancelQuery).toHaveBeenCalledTimes(1);
+          expect(cancelQuery).toHaveBeenCalledWith("job_late_id", metadata);
+          expect(storedQuery).toMatchObject({
+            status: "failed",
+            externalId: "job_late_id",
+            externalIdMetadata: metadata,
+          });
+        } finally {
+          jest.clearAllTimers();
+          jest.useRealTimers();
+          jest.mocked(updateQuery).mockReset();
+          jest.mocked(markPendingQueriesAsFailed).mockReset();
+          jest.mocked(getQueryStatusesByIds).mockReset();
+        }
+      },
+    );
 
     // Reproduces the swallowed-error bug in the aggregated fact table pipeline.
     // A multi-query DAG (insert + a dependent coverage query) fails when the


### PR DESCRIPTION
### Features and Changes

For a query that is cancelled on our side before we store the `externalId`, before we would just ignore this information and let the query keep running on the external warehouse -- now we check for this scenario and cancel it immediately after.

Closes a race during job creation.

### Testing

- Unit tests
