### PR TITLE
perf(sdk-payload): skip building SDK payloads that are neither cached nor sent

### DIFF
--- a/packages/back-end/src/jobs/sdkWebhooks.ts
+++ b/packages/back-end/src/jobs/sdkWebhooks.ts
@@ -357,7 +357,9 @@ export async function fireGlobalSdkWebhooks(
   context: ReqContext | ApiReqContext,
   connections: SDKConnectionInterface[],
 ) {
-  if (!connections.length) return;
+  // With no global webhooks configured (the WEBHOOKS env var) there is nobody
+  // to send to; don't generate a full SDK payload per connection just to drop it.
+  if (!connections.length || !WEBHOOKS.length) return;
 
   for (const connection of connections) {
     const payload = await getFeatureDefinitionsWithCache({

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -926,20 +926,23 @@ export async function refreshSDKPayloadCache({
     logger.warn(e, "Failed to delete legacy cache entries");
   }
 
-  const experimentMap = await getAllPayloadExperiments(context);
-  const safeRolloutMap =
-    await context.models.safeRollout.getAllPayloadSafeRollouts();
-  const savedGroups = await context.models.savedGroups.getAll();
-  const groupMap = await getSavedGroupMap(context, savedGroups);
-  const allFeatures = await getAllFeatures(context);
-  const constants = await getResolvableValues(context);
-  const rampMonitoredRuleMap =
-    await context.models.rampSchedules.getPayloadRampMonitoredRuleMap();
+  // With no payload cache configured there is nowhere to store a pre-built
+  // payload: the cache upsert at the end of this function is the only consumer
+  // of the built contents, and every reader (SDK endpoint, webhooks, proxy)
+  // generates the payload itself on a cache miss. In that case this function
+  // only has to work out WHICH connections are affected and notify them.
+  const storesPayloads = storageLocation !== "none";
 
-  const [allVisualExperiments, allURLRedirectExperiments] = await Promise.all([
-    getAllVisualExperiments(context, experimentMap),
-    getAllURLRedirectExperiments(context, experimentMap),
-  ]);
+  // First load only what deciding the affected connections needs: the payload
+  // experiments (phase prerequisites) and the features (prerequisite edges and
+  // projects). Building payloads needs the full feature documents; the decision
+  // alone can use the lean loader getFeaturesDependingOnAsPrerequisite also
+  // uses (same JIT migration and permission filter, editor-only fields
+  // projected out, no Mongoose hydration).
+  const experimentMap = await getAllPayloadExperiments(context);
+  const allFeatures = storesPayloads
+    ? await getAllFeatures(context)
+    : await getAllFeaturesWithoutEditorFields(context);
 
   // Only an all-projects dependent needs the project list, and this context is
   // fresh, so its cache is cold — don't pay for the query otherwise.
@@ -963,6 +966,86 @@ export async function refreshSDKPayloadCache({
     );
   }
 
+  // Everything that decides which connections are affected (the widening above
+  // and this match) must stay above the early returns below.
+  const sdkConnections = payloadKeys.length
+    ? await findSDKConnectionsByOrganization(context)
+    : sdkConnectionsToUpdate;
+
+  const connectionsUpdated = sdkConnections.filter(
+    (connection) =>
+      sdkConnectionsToUpdate.some((c) => c.key === connection.key) ||
+      payloadKeys.some((k) =>
+        isSDKConnectionAffectedByPayloadKey(
+          connection,
+          k,
+          treatEmptyProjectAsGlobal,
+        ),
+      ),
+  );
+
+  // If there are no changes, we don't need to do anything
+  if (!connectionsUpdated.length) {
+    const durationMs = Math.round(performance.now() - refreshStartedAt);
+    recordSdkPayloadRefreshMetrics(durationMs);
+    logger.info(
+      {
+        orgId: context.org.id,
+        payloadKeys,
+        auditContext: initialAuditContext,
+        durationMs,
+      },
+      "[sdk-payload] refresh skipped — no matching SDK connections",
+    );
+    return;
+  }
+
+  // Shared epilogue: record metrics and notify webhooks/proxies/CDN for the
+  // affected connections. These consumers take connection identities (and the
+  // widened payload keys) and fetch payloads themselves, so on the cached path
+  // this must run after the upserts below.
+  const finish = () => {
+    const durationMs = Math.round(performance.now() - refreshStartedAt);
+    recordSdkPayloadRefreshMetrics(durationMs);
+    logger.info(
+      {
+        orgId: context.org.id,
+        connectionKeys: connectionsUpdated.map((c) => c.key),
+        connectionCount: connectionsUpdated.length,
+        payloadKeys,
+        cacheLocation: storageLocation,
+        auditContext: initialAuditContext,
+        durationMs,
+      },
+      "[sdk-payload] refresh completed",
+    );
+
+    triggerWebhookJobs(context, payloadKeys, connectionsUpdated, true).catch(
+      (e) => {
+        logger.error(e, "Error triggering webhook jobs");
+      },
+    );
+  };
+
+  if (!storesPayloads) {
+    finish();
+    return;
+  }
+
+  const safeRolloutMap =
+    await context.models.safeRollout.getAllPayloadSafeRollouts();
+  const savedGroups = await context.models.savedGroups.getAll();
+  const groupMap = await getSavedGroupMap(context, savedGroups);
+  const constants = await getResolvableValues(context);
+  const rampMonitoredRuleMap =
+    await context.models.rampSchedules.getPayloadRampMonitoredRuleMap();
+
+  const [allVisualExperiments, allURLRedirectExperiments] = await Promise.all([
+    getAllVisualExperiments(context, experimentMap),
+    getAllURLRedirectExperiments(context, experimentMap),
+  ]);
+
+  // Only reached when payloads are built, i.e. allFeatures holds full documents.
   const rawData: Omit<SDKPayloadRawData, "holdoutsMap"> = {
     features: allFeatures,
     featuresMap: new Map(allFeatures.map((f) => [f.id, f])),
@@ -976,12 +1059,8 @@ export async function refreshSDKPayloadCache({
     constants,
   };
 
-  const payloadKeyEnvironments = new Set(payloadKeys.map((k) => k.environment));
   const allEnvironmentsToUpdate = Array.from(
-    new Set([
-      ...payloadKeyEnvironments,
-      ...sdkConnectionsToUpdate.map((c) => c.environment),
-    ]),
+    new Set(connectionsUpdated.map((c) => c.environment)),
   );
 
   const holdoutsMapByEnv: Record<
@@ -1003,40 +1082,16 @@ export async function refreshSDKPayloadCache({
       : null;
   }
 
-  const sdkConnections = payloadKeys.length
-    ? await findSDKConnectionsByOrganization(context)
-    : sdkConnectionsToUpdate;
-
   if (sdkConnections.some((c) => c.includeProjectIdInMetadata)) {
     const allProjects = await context.models.projects.getAll();
     rawData.projectsMap = new Map(allProjects.map((p) => [p.id, p]));
   }
 
-  const connectionsUpdated: SDKConnectionInterface[] = [];
-  const promises: (() => Promise<void>)[] = [];
-
-  sdkConnections.forEach((connection) => {
-    if (
-      !sdkConnectionsToUpdate.some((c) => c.key === connection.key) &&
-      !payloadKeys.some((k) =>
-        isSDKConnectionAffectedByPayloadKey(
-          connection,
-          k,
-          treatEmptyProjectAsGlobal,
-        ),
-      )
-    ) {
-      return;
-    }
-
+  const promises = connectionsUpdated.map((connection) => {
     const env = connection.environment;
     const holdoutsMap = holdoutsMapByEnv[env];
-    if (!holdoutsMap) {
-      return;
-    }
-    connectionsUpdated.push(connection);
 
-    promises.push(async () => {
+    return async () => {
       try {
         const capabilities = getConnectionSDKCapabilities(connection);
         const environmentDoc = context.org?.settings?.environments?.find(
@@ -1092,59 +1147,22 @@ export async function refreshSDKPayloadCache({
               }
             : undefined;
 
-        if (storageLocation !== "none") {
-          await context.models.sdkConnectionCache.upsert(
-            connection.key,
-            JSON.stringify(contents),
-            auditContext,
-          );
-        }
+        await context.models.sdkConnectionCache.upsert(
+          connection.key,
+          JSON.stringify(contents),
+          auditContext,
+        );
       } catch (e) {
         logger.error(e, "Error updating SDK connection cache");
       }
-    });
+    };
   });
-
-  // If there are no changes, we don't need to do anything
-  if (!promises.length) {
-    const durationMs = Math.round(performance.now() - refreshStartedAt);
-    recordSdkPayloadRefreshMetrics(durationMs);
-    logger.info(
-      {
-        orgId: context.org.id,
-        payloadKeys,
-        auditContext: initialAuditContext,
-        durationMs,
-      },
-      "[sdk-payload] refresh skipped — no matching SDK connections",
-    );
-    return;
-  }
 
   // There may be many SDK connection caches to update
   // Batch the promises in chunks of 4 at a time to avoid overloading Mongo
   await promiseAllChunks(promises, 4);
 
-  const durationMs = Math.round(performance.now() - refreshStartedAt);
-  recordSdkPayloadRefreshMetrics(durationMs);
-  logger.info(
-    {
-      orgId: context.org.id,
-      connectionKeys: connectionsUpdated.map((c) => c.key),
-      connectionCount: connectionsUpdated.length,
-      payloadKeys,
-      cacheLocation: storageLocation,
-      auditContext: initialAuditContext,
-      durationMs,
-    },
-    "[sdk-payload] refresh completed",
-  );
-
-  triggerWebhookJobs(context, payloadKeys, connectionsUpdated, true).catch(
-    (e) => {
-      logger.error(e, "Error triggering webhook jobs");
-    },
-  );
+  finish();
 }
 
 export type FeatureDefinitionsResponseArgs = {

--- a/packages/back-end/test/jobs/sdkWebhooks.test.ts
+++ b/packages/back-end/test/jobs/sdkWebhooks.test.ts
@@ -1,0 +1,54 @@
+import { SDKConnectionInterface } from "shared/types/sdk-connection";
+import { ReqContext } from "back-end/types/request";
+import { fireGlobalSdkWebhooks } from "back-end/src/jobs/sdkWebhooks";
+import { getFeatureDefinitionsWithCache } from "back-end/src/controllers/features";
+
+jest.mock("back-end/src/util/secrets", () => ({
+  ...jest.requireActual("back-end/src/util/secrets"),
+  // No global webhooks configured (the WEBHOOKS env var is unset)
+  WEBHOOKS: [],
+}));
+jest.mock("back-end/src/controllers/features", () => ({
+  getFeatureDefinitionsWithCache: jest.fn().mockResolvedValue({
+    features: {},
+    dateUpdated: null,
+  }),
+}));
+jest.mock("back-end/src/util/http.util", () => ({
+  ...jest.requireActual("back-end/src/util/http.util"),
+  cancellableFetch: jest.fn(),
+}));
+
+describe("fireGlobalSdkWebhooks", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not generate SDK payloads when no global webhooks are configured", async () => {
+    const connections = [
+      {
+        id: "sdk_1",
+        key: "sdk-key-1",
+        organization: "org-1",
+        environment: "production",
+        projects: [],
+        languages: ["javascript"],
+      },
+      {
+        id: "sdk_2",
+        key: "sdk-key-2",
+        organization: "org-1",
+        environment: "production",
+        projects: ["p1"],
+        languages: ["javascript"],
+      },
+    ] as unknown as SDKConnectionInterface[];
+
+    await fireGlobalSdkWebhooks(
+      { org: { id: "org-1" } } as unknown as ReqContext,
+      connections,
+    );
+
+    expect(getFeatureDefinitionsWithCache).not.toHaveBeenCalled();
+  });
+});

--- a/packages/back-end/test/services/sdk-payload-lifecycle.test.ts
+++ b/packages/back-end/test/services/sdk-payload-lifecycle.test.ts
@@ -41,6 +41,7 @@ jest.mock("back-end/src/models/SdkConnectionCacheModel", () => ({
 }));
 jest.mock("back-end/src/models/FeatureModel", () => ({
   getAllFeatures: jest.fn().mockResolvedValue([]),
+  getAllFeaturesWithoutEditorFields: jest.fn().mockResolvedValue([]),
 }));
 jest.mock("back-end/src/models/ExperimentModel", () => ({
   getAllPayloadExperiments: jest.fn().mockResolvedValue(new Map()),
@@ -52,6 +53,11 @@ jest.mock("back-end/src/services/organizations", () => ({
     org,
     models: (global as unknown as { __mockContextModels: unknown })
       .__mockContextModels,
+    getAllProjectIds: jest.fn(
+      async () =>
+        (global as unknown as { __mockAllProjectIds?: string[] })
+          .__mockAllProjectIds ?? [],
+    ),
     userId: "u",
     email: "e@e.com",
     userName: "U",
@@ -74,6 +80,14 @@ const findSDKConnectionsByOrganization = jest.requireMock(
 ).findSDKConnectionsByOrganization as jest.Mock;
 const triggerWebhookJobs = jest.requireMock("back-end/src/jobs/updateAllJobs")
   .triggerWebhookJobs as jest.Mock;
+const getContextForAgendaJobByOrgObject = jest.requireMock(
+  "back-end/src/services/organizations",
+).getContextForAgendaJobByOrgObject as jest.Mock;
+// The background context refreshSDKPayloadCache created for its last call.
+const agendaContext = () =>
+  getContextForAgendaJobByOrgObject.mock.results.slice(-1)[0].value as {
+    getAllProjectIds: jest.Mock;
+  };
 
 function minimalContext(overrides?: Partial<ApiReqContext>): ApiReqContext {
   return {
@@ -117,6 +131,9 @@ describe("SDK payload lifecycle (comprehensive)", () => {
     (
       global as unknown as { __mockContextModels: unknown }
     ).__mockContextModels = undefined;
+    (
+      global as unknown as { __mockAllProjectIds?: string[] }
+    ).__mockAllProjectIds = undefined;
   });
 
   describe("isSDKConnectionAffectedByPayloadKey", () => {
@@ -259,6 +276,391 @@ describe("SDK payload lifecycle (comprehensive)", () => {
       );
       expect(triggerWebhookJobs).toHaveBeenCalled();
     });
+
+    // Models touched only when payloads are actually built and stored. Kept
+    // separate so tests can assert the early paths never reach them.
+    function payloadBuildModels() {
+      return {
+        safeRollout: {
+          getAllPayloadSafeRollouts: jest.fn().mockResolvedValue(new Map()),
+        },
+        savedGroups: { getAll: jest.fn().mockResolvedValue([]) },
+        constants: { getAll: jest.fn().mockResolvedValue([]) },
+        configs: { getAll: jest.fn().mockResolvedValue([]) },
+        holdout: {
+          getAllPayloadHoldouts: jest.fn().mockResolvedValue(new Map()),
+        },
+        rampSchedules: {
+          getPayloadRampMonitoredRuleMap: jest
+            .fn()
+            .mockResolvedValue(new Map()),
+        },
+        projects: { getAll: jest.fn().mockResolvedValue([]) },
+      };
+    }
+    function expectNoPayloadBuildLoads(
+      models: ReturnType<typeof payloadBuildModels>,
+    ) {
+      expect(models.savedGroups.getAll).not.toHaveBeenCalled();
+      expect(
+        models.safeRollout.getAllPayloadSafeRollouts,
+      ).not.toHaveBeenCalled();
+      expect(models.constants.getAll).not.toHaveBeenCalled();
+      expect(
+        models.rampSchedules.getPayloadRampMonitoredRuleMap,
+      ).not.toHaveBeenCalled();
+      expect(models.holdout.getAllPayloadHoldouts).not.toHaveBeenCalled();
+      expect(models.projects.getAll).not.toHaveBeenCalled();
+      expect(ExperimentModel.getAllVisualExperiments).not.toHaveBeenCalled();
+      expect(
+        ExperimentModel.getAllURLRedirectExperiments,
+      ).not.toHaveBeenCalled();
+    }
+    const twoEnvOrg = {
+      ...minimalContext().org,
+      settings: {
+        environments: [
+          { id: "production", projects: [] },
+          { id: "dev", projects: [] },
+        ],
+      },
+    };
+    const sdkConn = (
+      key: string,
+      projects: string[],
+      environment = "production",
+    ) =>
+      ({
+        key,
+        organization: "org-1",
+        environment,
+        projects,
+      }) as SDKConnectionInterface;
+
+    it.each(["none", "mongo"] as const)(
+      "storage %s: triggerWebhookJobs receives exactly the affected connections; with no cache only the loads that decide that set run",
+      async (storage) => {
+        getSDKPayloadCacheLocationMock.mockReturnValue(storage);
+        const deleteAllLegacy = jest.fn().mockResolvedValue(undefined);
+        const upsert = jest.fn().mockResolvedValue(undefined);
+        const affectedGlobal = sdkConn("sdk-global-prod", []);
+        const affectedProject = sdkConn("sdk-p1-prod", ["p1"]);
+        const otherProject = sdkConn("sdk-p2-prod", ["p2"]);
+        const otherEnv = sdkConn("sdk-global-dev", [], "dev");
+        findSDKConnectionsByOrganization.mockResolvedValue([
+          affectedGlobal,
+          otherProject,
+          affectedProject,
+          otherEnv,
+        ]);
+
+        const mockModels = {
+          sdkConnectionCache: {
+            deleteAllLegacyCacheEntries: deleteAllLegacy,
+            upsert,
+          },
+          ...payloadBuildModels(),
+        };
+        (
+          global as unknown as { __mockContextModels: unknown }
+        ).__mockContextModels = mockModels;
+
+        const payloadKeys = [{ environment: "production", project: "p1" }];
+        await refreshSDKPayloadCache({
+          context: minimalContext({
+            org: twoEnvOrg,
+            models: mockModels as unknown as ReqContext["models"],
+          }) as ReqContext,
+          payloadKeys,
+          sdkConnections: [],
+        });
+
+        // Same side effects and notification fan-out regardless of cache location
+        expect(deleteAllLegacy).toHaveBeenCalledTimes(1);
+        expect(ExperimentModel.getAllPayloadExperiments).toHaveBeenCalledTimes(
+          1,
+        );
+        expect(findSDKConnectionsByOrganization).toHaveBeenCalledTimes(1);
+        expect(triggerWebhookJobs).toHaveBeenCalledTimes(1);
+        expect(triggerWebhookJobs).toHaveBeenCalledWith(
+          expect.objectContaining({
+            org: expect.objectContaining({ id: "org-1" }),
+          }),
+          payloadKeys,
+          [affectedGlobal, affectedProject],
+          true,
+        );
+
+        if (storage === "none") {
+          // Nothing persists a pre-built payload: only the lean feature load and
+          // the experiments (both needed to widen the keys) are read; nothing is
+          // built or upserted.
+          expect(
+            FeatureModel.getAllFeaturesWithoutEditorFields,
+          ).toHaveBeenCalledTimes(1);
+          expect(FeatureModel.getAllFeatures).not.toHaveBeenCalled();
+          expectNoPayloadBuildLoads(mockModels);
+          expect(upsert).not.toHaveBeenCalled();
+        } else {
+          expect(FeatureModel.getAllFeatures).toHaveBeenCalledTimes(1);
+          expect(
+            FeatureModel.getAllFeaturesWithoutEditorFields,
+          ).not.toHaveBeenCalled();
+          expect(mockModels.savedGroups.getAll).toHaveBeenCalledTimes(1);
+          // Holdouts only for environments that have an affected connection
+          expect(
+            mockModels.holdout.getAllPayloadHoldouts,
+          ).toHaveBeenCalledTimes(1);
+          expect(mockModels.holdout.getAllPayloadHoldouts).toHaveBeenCalledWith(
+            "production",
+          );
+          expect(upsert).toHaveBeenCalledTimes(2);
+          expect(upsert).toHaveBeenCalledWith(
+            "sdk-global-prod",
+            expect.any(String),
+            undefined,
+          );
+          expect(upsert).toHaveBeenCalledWith(
+            "sdk-p1-prod",
+            expect.any(String),
+            undefined,
+          );
+          // Consumers fetch the payload from the cache, so every upsert must
+          // have happened before they are notified.
+          const notifiedAt = triggerWebhookJobs.mock.invocationCallOrder[0];
+          upsert.mock.invocationCallOrder.forEach((order) =>
+            expect(order).toBeLessThan(notifiedAt),
+          );
+        }
+      },
+    );
+
+    it.each(["none", "mongo"] as const)(
+      "storage %s: no matching connections returns after the feature/experiment loads and before everything else, without notifying",
+      async (storage) => {
+        getSDKPayloadCacheLocationMock.mockReturnValue(storage);
+        const deleteAllLegacy = jest.fn().mockResolvedValue(undefined);
+        const upsert = jest.fn().mockResolvedValue(undefined);
+        findSDKConnectionsByOrganization.mockResolvedValue([
+          sdkConn("sdk-dev", [], "dev"),
+        ]);
+        const mockModels = {
+          sdkConnectionCache: {
+            deleteAllLegacyCacheEntries: deleteAllLegacy,
+            upsert,
+          },
+          ...payloadBuildModels(),
+        };
+        (
+          global as unknown as { __mockContextModels: unknown }
+        ).__mockContextModels = mockModels;
+
+        await refreshSDKPayloadCache({
+          context: minimalContext({
+            org: twoEnvOrg,
+            models: mockModels as unknown as ReqContext["models"],
+          }) as ReqContext,
+          payloadKeys: [{ environment: "production", project: "p1" }],
+          sdkConnections: [],
+        });
+
+        expect(deleteAllLegacy).toHaveBeenCalledTimes(1);
+        expect(ExperimentModel.getAllPayloadExperiments).toHaveBeenCalledTimes(
+          1,
+        );
+        if (storage === "none") {
+          expect(
+            FeatureModel.getAllFeaturesWithoutEditorFields,
+          ).toHaveBeenCalledTimes(1);
+        } else {
+          expect(FeatureModel.getAllFeatures).toHaveBeenCalledTimes(1);
+        }
+        expectNoPayloadBuildLoads(mockModels);
+        expect(upsert).not.toHaveBeenCalled();
+        expect(triggerWebhookJobs).not.toHaveBeenCalled();
+      },
+    );
+
+    // Cross-project prerequisites (#6858): a change to a project-A feature that
+    // a project-B feature lists as a prerequisite must also reach connections
+    // scoped to project B, on both cache paths.
+    describe.each(["none", "mongo"] as const)(
+      "storage %s: cross-project prerequisite widening happens before connections are matched",
+      (storage) => {
+        const parent = {
+          id: "parent-flag",
+          organization: "org-1",
+          project: "prj-a",
+          valueType: "boolean",
+          defaultValue: "true",
+          environmentSettings: { production: { enabled: true } },
+          rules: [],
+          prerequisites: [],
+        } as unknown as FeatureInterface;
+        const dependent = {
+          id: "dependent-flag",
+          organization: "org-1",
+          project: "prj-b",
+          valueType: "boolean",
+          defaultValue: "false",
+          environmentSettings: { production: { enabled: true } },
+          rules: [],
+          prerequisites: [{ id: "parent-flag", condition: "{}" }],
+        } as unknown as FeatureInterface;
+        const connA = sdkConn("sdk-a", ["prj-a"]);
+        const connB = sdkConn("sdk-b", ["prj-b"]);
+        const connC = sdkConn("sdk-c", ["prj-c"]);
+        const changedParentKeys = [
+          { environment: "production", project: "prj-a" },
+        ];
+
+        let upsert: jest.Mock;
+        let mockModels: ReturnType<typeof payloadBuildModels> & {
+          sdkConnectionCache: {
+            deleteAllLegacyCacheEntries: jest.Mock;
+            upsert: jest.Mock;
+          };
+        };
+        beforeEach(() => {
+          // These module mocks keep their resolved value across tests
+          // (clearAllMocks only clears calls), so start each case from empty.
+          (FeatureModel.getAllFeatures as jest.Mock).mockResolvedValue([]);
+          (
+            FeatureModel.getAllFeaturesWithoutEditorFields as jest.Mock
+          ).mockResolvedValue([]);
+          (
+            ExperimentModel.getAllPayloadExperiments as jest.Mock
+          ).mockResolvedValue(new Map());
+          getSDKPayloadCacheLocationMock.mockReturnValue(storage);
+          upsert = jest.fn().mockResolvedValue(undefined);
+          mockModels = {
+            sdkConnectionCache: {
+              deleteAllLegacyCacheEntries: jest
+                .fn()
+                .mockResolvedValue(undefined),
+              upsert,
+            },
+            ...payloadBuildModels(),
+          };
+          (
+            global as unknown as { __mockContextModels: unknown }
+          ).__mockContextModels = mockModels;
+          findSDKConnectionsByOrganization.mockResolvedValue([
+            connA,
+            connB,
+            connC,
+          ]);
+        });
+        function useFeatures(features: FeatureInterface[]) {
+          (FeatureModel.getAllFeatures as jest.Mock).mockResolvedValue(
+            features,
+          );
+          (
+            FeatureModel.getAllFeaturesWithoutEditorFields as jest.Mock
+          ).mockResolvedValue(features);
+        }
+        async function refresh(
+          extra: Partial<Parameters<typeof refreshSDKPayloadCache>[0]> = {},
+        ) {
+          await refreshSDKPayloadCache({
+            context: minimalContext({
+              models: mockModels as unknown as ReqContext["models"],
+            }) as ReqContext,
+            payloadKeys: changedParentKeys,
+            sdkConnections: [],
+            ...extra,
+          });
+        }
+        function expectNotified(
+          connections: SDKConnectionInterface[],
+          projects: string[],
+        ) {
+          expect(triggerWebhookJobs).toHaveBeenCalledTimes(1);
+          const [, keys, notified] = triggerWebhookJobs.mock.calls[0];
+          expect(notified).toEqual(connections);
+          expect(
+            (keys as { environment: string; project: string }[])
+              .map((k) => k.project)
+              .sort(),
+          ).toEqual([...projects].sort());
+          if (storage === "none") {
+            expect(upsert).not.toHaveBeenCalled();
+          } else {
+            expect(upsert.mock.calls.map((c) => c[0]).sort()).toEqual(
+              connections.map((c) => c.key).sort(),
+            );
+            // Every cache write lands before anyone is notified.
+            const notifiedAt = triggerWebhookJobs.mock.invocationCallOrder[0];
+            upsert.mock.invocationCallOrder.forEach((order) =>
+              expect(order).toBeLessThan(notifiedAt),
+            );
+          }
+        }
+
+        it("top-level prerequisite in another project: the dependent's connection is notified too", async () => {
+          useFeatures([parent, dependent]);
+          await refresh();
+          expectNotified([connA, connB], ["prj-a", "prj-b"]);
+          // No all-projects dependent: the project list is not consulted.
+          expect(agendaContext().getAllProjectIds).not.toHaveBeenCalled();
+        });
+
+        it("prerequisite on the phase of an experiment referenced by an experiment-ref rule", async () => {
+          const viaExperiment = {
+            ...dependent,
+            prerequisites: [],
+            rules: [
+              {
+                type: "experiment-ref",
+                id: "fr_1",
+                enabled: true,
+                experimentId: "exp-x",
+                variations: [],
+              },
+            ],
+          } as unknown as FeatureInterface;
+          (
+            ExperimentModel.getAllPayloadExperiments as jest.Mock
+          ).mockResolvedValue(
+            new Map([
+              [
+                "exp-x",
+                {
+                  id: "exp-x",
+                  phases: [
+                    { prerequisites: [{ id: "parent-flag", condition: "{}" }] },
+                  ],
+                },
+              ],
+            ]),
+          );
+          useFeatures([parent, viaExperiment]);
+          await refresh();
+          expectNotified([connA, connB], ["prj-a", "prj-b"]);
+        });
+
+        it("all-projects dependent: every project's connection is notified and the project list is consulted", async () => {
+          const everywhere = {
+            ...dependent,
+            project: "",
+            targetingAllProjects: true,
+          } as unknown as FeatureInterface;
+          (
+            global as unknown as { __mockAllProjectIds?: string[] }
+          ).__mockAllProjectIds = ["prj-a", "prj-b", "prj-c"];
+          useFeatures([parent, everywhere]);
+          await refresh();
+          expectNotified([connA, connB, connC], ["prj-a", "prj-b", "prj-c"]);
+          expect(agendaContext().getAllProjectIds).toHaveBeenCalledTimes(1);
+        });
+
+        it("skipRefreshForProject still wins over a project the widening reintroduces", async () => {
+          useFeatures([parent, dependent]);
+          await refresh({ skipRefreshForProject: "prj-b" });
+          expectNotified([connA], ["prj-a"]);
+        });
+      },
+    );
 
     it("targeted path: uses sdkConnectionsToUpdate, does not call findSDKConnectionsByOrganization", async () => {
       getSDKPayloadCacheLocationMock.mockReturnValue("mongo");


### PR DESCRIPTION
### Features and Changes

Two small changes for self-hosted deployments that run with `SDK_PAYLOAD_CACHE=none` and/or without global `WEBHOOKS`; for deployments that use a payload cache and have global webhooks configured the only difference is that a refresh which turns out to affect no SDK connection now returns before loading payload data rather than after. Two commits, glad to split.

**1. `refreshSDKPayloadCache` with `SDK_PAYLOAD_CACHE=none`.** After every feature, experiment or saved-group write it loads every feature (hydrated), every payload experiment, every saved group, safe rollouts, constants, ramp schedules, visual changesets and redirects, holdouts per environment and sometimes projects, builds a full SDK payload per affected connection, and then, with the cache location set to `none`, skips the upsert and drops the payloads. The function's only other output, `triggerWebhookJobs(context, payloadKeys, connectionsUpdated, isProxyEnabled)`, takes connection identities and payload keys, and every consumer it notifies (SDK webhooks, global webhooks, legacy webhooks, proxy updates) fetches its payload through `getFeatureDefinitionsWithCache`, which generates on the fly when there is no cache. So nothing reads the discarded payloads, and on a large organization building them costs seconds of CPU on the request-serving process after each write.

   Since #6858 the affected-connection set depends on the prerequisite graph (payload keys are widened to the projects whose payloads carry a changed feature as a cross-project prerequisite, "before matching connections"), and that widening needs the features and the payload experiments. So rather than short-circuiting, the change reorders the function: `deleteAllLegacyCacheEntries` first as today; then load the payload experiments and the features (the same `getAllFeatures` when payloads will be built; `getAllFeaturesWithoutEditorFields` when they will not: it runs the same query, JIT migration and permission filter as `getAllFeatures`, skips Mongoose hydration (for a legacy document stored with an empty `environmentSettings` object this routes the migration through a different branch, but the two branches differ only in rule environment scoping, which the reach does not read), and omits only `description`, `jsonSchema`, `customFields` and `draft` (plus the `legacyDraft` derived from it), none of which the reach computation reads (it reads ids, projects, prerequisites and rules), and its bulk-publish scan overlay is not set on the background context this function creates, so the widened key set is identical on both paths; it is also the loader #6858's own dependents scan, `getFeaturesDependingOnAsPrerequisite`, uses); widen and re-apply `skipRefreshForProject` exactly as today; fetch the SDK connections and compute the affected set with the same predicate as today. From there: no affected connection → the existing "refresh skipped" return (metrics + log, no `triggerWebhookJobs`, unchanged) now happens before the remaining loads instead of after them; cache location `none` → metrics, the "refresh completed" log and `triggerWebhookJobs` with the widened keys and the affected connections, skipping saved groups, safe rollouts, constants, ramp schedules, visual changesets, redirects, holdouts, projects and every per-connection build; otherwise → the remaining loads, builds and upserts exactly as before, and the same epilogue after the upserts as before. There is a single place that decides which connections are affected and it sits above both early returns, with a comment saying it must stay there.

   Behavior notes for reviewers: `connectionsUpdated` is computed with the same inputs and predicate as before; the old per-connection `if (!holdoutsMap) return` guard could never fire (`getAllPayloadHoldouts` always returns a Map, for every environment an affected connection can have), so dropping it does not change the set; holdouts are now loaded only for the environments of the affected connections (the only ones ever read). With cache `none`, webhook/proxy jobs are queued right after the two loads instead of after the discarded build; they read current database state either way. `sdk_payload.refresh_duration_ms` records the real (smaller) duration on the `none` and no-match paths.

   A question rather than a change: cross-project parents are only ever delivered to connections that have `includeReferencedPrerequisites` set and a project filter, so when no connection in the organization has both, the widening cannot change any payload and the two loads could be skipped as well on the `none` path. That would, however, also stop notifying project-scoped connections without the flag about a parent change in another project (today they are notified although their payload cannot change), so we left it out; tell us if you would like it.

**2. `fireGlobalSdkWebhooks` without global webhooks.** It generated a complete payload per affected connection with `getFeatureDefinitionsWithCache` and only then iterated the `WEBHOOKS` list from the environment; with no global webhooks configured (the default) the loop has no other effect, so those payloads were built and dropped too (and with cache `none` each one is a full on-the-fly generation). It now returns early when the list is empty. No change when `WEBHOOKS` is configured.

If you would rather restructure `refreshSDKPayloadCache` differently (for example the affected-connection computation as its own helper), say so and we will follow.

### Dependencies

None.

### Testing

- `test/services/sdk-payload-lifecycle.test.ts`, each case for cache location `none` and `mongo`: `triggerWebhookJobs` receives exactly the affected connections and, with `none`, only the experiments, the (lean) features and the connections are loaded and nothing is built or upserted; the no-match path returns after those loads, before the others, without notifying; and four cross-project prerequisite cases (a top-level prerequisite in another project; a prerequisite on the phase of an experiment reached through an experiment-ref rule; an all-projects dependent; `skipRefreshForProject` winning over a project the widening reintroduces) asserting that the dependent projects' connections are notified with the widened keys and, on the cached path, that every cache upsert happens before anyone is notified. Run against current `main` the cross-project cases pass and only the load-shape assertions differ; run against a version of commit 1 that returns before the widening (what a naive port of our pre-#6858 patch would do), three of the four cross-project cases fail in both cache modes (the `skipRefreshForProject` case holds either way, since nothing is reintroduced when nothing is widened). `test/jobs/sdkWebhooks.test.ts` (new): no payload generation when `WEBHOOKS` is empty. The existing sdk-payload, prerequisites and cross-project-prerequisites suites pass.
- Before-numbers, measured in August 2026 on `main` as of mid-August (before #6858), local single-process back-end with `SDK_PAYLOAD_CACHE=none`, no global webhooks, and a synthetic organization with well over ten thousand features and many SDK connections: toggling one environment of one feature, then issuing a cheap authenticated GET every 250 ms for 20-30 s, the refresh logged ~6.5-9 s for one affected connection, the process burned ~26 CPU-seconds in the 30 s after the write, and the cheap GET saw stalls of 1.3-4.8 s; the global-webhook path (commit 2) accounted for two further stalls of ~1-1.6 s. Re-measured on current `main` with the same probe (toggle, then a cheap authenticated GET every 250 ms for 30 s), local single-process back-ends built from the same commit with and without this branch (and one with commit 1 only), same data set, interleaved runs after a warm-up each (5 parent, 3 commit-1-only, 5 both). One thing differs from the August run and matters here: features in this data set list prerequisites that live in other projects, so since #6858 that one toggle widens to a few dozen project-scoped SDK connections instead of one. `refreshSDKPayloadCache`'s own logged duration: 3.6-3.9 s on the parent, 1.7-2.0 s with commit 1 (the experiments query, the lean feature load and the reach pass are what remains; the same with both commits). Back-end CPU burned in the 30 s after the write, net of the probe's own ~6 CPU-seconds: ~17 CPU-seconds on the parent, still ~17 with commit 1 alone (the global-webhook path then generates one payload per affected connection, which is exactly what commit 2 removes), and within the probe's own noise (0-2 CPU-seconds) with both. Longest stall seen by the cheap GET: 1.8-2.2 s on the parent (plus a second one of 0.7-0.9 s), 0.7-1.0 s with commit 1 alone, 0.15-0.55 s with both; its p90 over the window 160-220 ms, 140-210 ms and 42-44 ms respectively, against ~30 ms when idle. Same-machine ratios; absolute numbers will differ on your hardware.
- Driven end to end on a local single-process back-end (`SDK_PAYLOAD_CACHE=none`, no `WEBHOOKS`) with one unscoped and three project-scoped SDK connections (projects A, B, C) and a flag in project B that lists a project-A flag as a prerequisite. Toggling the project-A flag logs the same `connectionKeys` (unscoped, A and B, not C) and the same widened `payloadKeys` on `main` and on this branch, and the served `/api/features/<key>` payloads are identical afterwards (B's payload drops the dependent flag when its cross-project parent goes off, on both). With the MongoDB profiler on for the write, `main` reads `holdouts`, `rampschedules`, `saferollout`, `savedgroups`, `urlredirects`, `visualchangesets` and `constants` (once for the refresh and once more per affected connection for the global-webhook pass, although no global webhook is configured); this branch reads none of them. Toggling in an environment no connection uses logs "refresh skipped" before those reads. With a `WEBHOOKS` entry configured, the per-connection generation for global webhooks still runs as before.
- `tsc --noEmit`, eslint and prettier clean on the changed files.
- Toolchain note: our checks ran with TypeScript 5.7.3 `tsc` rather than the repo's `tsgo` type-check script, and with lockfile versions except a few nearby dev-tool versions (the jest transform and supertest among them); your CI is the first exact-toolchain run and we will fix anything it finds.

### Screenshots

N/A.
