### PR TITLE
Block the ramp-up save behind a traffic-impact banner with acknowledge

### DIFF
--- a/packages/front-end/components/Admin/EditOrganization.tsx
+++ b/packages/front-end/components/Admin/EditOrganization.tsx
@@ -190,7 +190,6 @@ const EditOrganization: FC<{
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       submit={handleSubmit}
       open={true}

--- a/packages/front-end/components/Archetype/ArchetypeAttributesModal.tsx
+++ b/packages/front-end/components/Archetype/ArchetypeAttributesModal.tsx
@@ -67,7 +67,6 @@ const ArchetypeAttributesModal: FC<{
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType="add-edit-archetype"
       trackingEventModalSource={source}
       open={true}

--- a/packages/front-end/components/Archetype/AssignmentTester.tsx
+++ b/packages/front-end/components/Archetype/AssignmentTester.tsx
@@ -469,7 +469,6 @@ export default function AssignmentTester({
             />
           ) : (
             <Modal
-              useRadixButton={false}
               trackingEventModalType=""
               open={true}
               close={() => setOpenArchetypeModal(null)}

--- a/packages/front-end/components/AuditHistoryExplorer/AuditHistoryExplorerModal.tsx
+++ b/packages/front-end/components/AuditHistoryExplorer/AuditHistoryExplorerModal.tsx
@@ -279,7 +279,6 @@ export default function AuditHistoryExplorerModal<T>({
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType="audit-history-explorer"
       open={true}
       header={`${entityName} Audit History`}

--- a/packages/front-end/components/Auth/ChangePasswordModal.tsx
+++ b/packages/front-end/components/Auth/ChangePasswordModal.tsx
@@ -17,7 +17,6 @@ const ChangePasswordModal: FC<{
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       header="Change Password"
       open={true}

--- a/packages/front-end/components/CustomHooks/CustomHookModal.tsx
+++ b/packages/front-end/components/CustomHooks/CustomHookModal.tsx
@@ -531,7 +531,6 @@ export default function CustomHookModal({
 
   return (
     <Modal
-      useRadixButton={false}
       header={current?.id ? "Edit Custom Hook" : "Add Custom Hook"}
       close={close}
       open={true}

--- a/packages/front-end/components/DecisionCriteria/DecisionCriteriaModal.tsx
+++ b/packages/front-end/components/DecisionCriteria/DecisionCriteriaModal.tsx
@@ -26,7 +26,6 @@ const DecisionCriteriaModal: FC<DecisionCriteriaModalProps> = ({
 
   return (
     <Modal
-      useRadixButton={false}
       open={true}
       header={editable ? "Modify Decision Criteria" : "View Decision Criteria"}
       subHeader="Define rules for automatic decision making based on experiment results"

--- a/packages/front-end/components/Dimensions/DimensionForm.tsx
+++ b/packages/front-end/components/Dimensions/DimensionForm.tsx
@@ -72,7 +72,6 @@ const DimensionForm: FC<{
         />
       )}
       <Modal
-        useRadixButton={false}
         trackingEventModalType=""
         close={close}
         open={true}

--- a/packages/front-end/components/EventWebHooks/WebhookSecretModal.tsx
+++ b/packages/front-end/components/EventWebHooks/WebhookSecretModal.tsx
@@ -37,7 +37,6 @@ export default function WebhookSecretModal({
 
   return (
     <Modal
-      useRadixButton={false}
       open={true}
       close={close}
       increasedElevation={increasedElevation}

--- a/packages/front-end/components/Experiment/EditDOMMutationsModal.tsx
+++ b/packages/front-end/components/Experiment/EditDOMMutationsModal.tsx
@@ -337,7 +337,6 @@ const EditDOMMutationsModal: FC<{
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open
       close={close}

--- a/packages/front-end/components/Experiment/ExperimentCarouselModal.tsx
+++ b/packages/front-end/components/Experiment/ExperimentCarouselModal.tsx
@@ -173,7 +173,6 @@ const ExperimentCarouselModal: FC<{
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={true}
       header={null}

--- a/packages/front-end/components/Experiment/ImportExperimentList.tsx
+++ b/packages/front-end/components/Experiment/ImportExperimentList.tsx
@@ -255,7 +255,6 @@ const ImportExperimentList: FC<{
                 }}
               >
                 <RunQueriesButton
-                  useRadixButton={false}
                   cta={
                     data.experiments.latestData ? "Get New Data" : "Run Query"
                   }

--- a/packages/front-end/components/Experiment/ImportExperimentModal.tsx
+++ b/packages/front-end/components/Experiment/ImportExperimentModal.tsx
@@ -92,7 +92,6 @@ const ImportExperimentModal: FC<{
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType="import-experiment"
       header="Import Experiment"
       open={true}

--- a/packages/front-end/components/Experiment/MakeChangesFlow.tsx
+++ b/packages/front-end/components/Experiment/MakeChangesFlow.tsx
@@ -6,7 +6,7 @@ import {
 import omit from "lodash/omit";
 import isEqual from "lodash/isEqual";
 import { useEffect, useState } from "react";
-import { Flex, Box } from "@radix-ui/themes";
+import { Box } from "@radix-ui/themes";
 import ReleaseChangesForm from "@/components/Experiment/ReleaseChangesForm";
 import PagedModal from "@/components/Modal/PagedModal";
 import Page from "@/components/Modal/Page";
@@ -14,8 +14,8 @@ import TargetingInfo from "@/components/Experiment/TabbedPage/TargetingInfo";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import track from "@/services/track";
 import RadioGroup, { RadioOptions } from "@/ui/RadioGroup";
-import Callout from "@/ui/Callout";
-import Text from "@/ui/Text";
+import Checkbox from "@/ui/Checkbox";
+import ModalWarningBanner from "@/components/Modal/ModalWarningBanner";
 import TargetingForm from "./TargetingForm";
 
 export type ChangeType =
@@ -154,38 +154,24 @@ export default function MakeChangesFlow({
           setStep(i);
         }
       }}
-      secondaryCTA={
+      aboveFooterContent={
         step === lastStepNumber ? (
-          <Box style={{ minWidth: 520 }}>
-            <Callout status="warning">
-              <Flex align="center" justify="between" gap="3">
-                <Text>
-                  <Text weight="semibold">Warning:</Text> Changes made will
-                  apply to linked Feature Flags, Visual Changes, and URL
-                  Redirects immediately upon publishing
-                </Text>
-                <Box>
-                  <label
-                    htmlFor="confirm-changes"
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: "8px",
-                      cursor: "pointer",
-                    }}
-                  >
-                    <Text weight="semibold">Confirm</Text>
-                    <input
-                      id="confirm-changes"
-                      type="checkbox"
-                      checked={changesConfirmed}
-                      onChange={(e) => setChangesConfirmed(e.target.checked)}
-                    />
-                  </label>
-                </Box>
-              </Flex>
-            </Callout>
-          </Box>
+          <ModalWarningBanner
+            controls={
+              <Box style={{ color: "var(--violet-11)" }}>
+                <Checkbox
+                  value={changesConfirmed}
+                  setValue={setChangesConfirmed}
+                  label="Confirm"
+                  weight="medium"
+                  align="center"
+                />
+              </Box>
+            }
+          >
+            Changes made will apply to linked Feature Flags, Visual Changes, and
+            URL Redirects immediately upon publishing.
+          </ModalWarningBanner>
         ) : undefined
       }
     >

--- a/packages/front-end/components/Experiment/MakeChangesFlow.tsx
+++ b/packages/front-end/components/Experiment/MakeChangesFlow.tsx
@@ -116,6 +116,7 @@ export default function MakeChangesFlow({
 
   let cta = "Publish changes";
   let ctaEnabled = true;
+  let disabledMessage: string | undefined;
   let blockSteps: number[] = [];
   if (!changeType) {
     cta = "Select a change type";
@@ -134,6 +135,8 @@ export default function MakeChangesFlow({
       ctaEnabled = false;
     }
     if (step === lastStepNumber && !changesConfirmed) {
+      // Only name the confirm gate when it's the sole remaining blocker.
+      if (ctaEnabled) disabledMessage = 'Check "Confirm" to publish';
       ctaEnabled = false;
     }
   }
@@ -146,6 +149,7 @@ export default function MakeChangesFlow({
       submit={submit}
       cta={cta}
       ctaEnabled={ctaEnabled && canSubmit}
+      disabledMessage={disabledMessage}
       forceCtaText={!ctaEnabled}
       size="lg"
       step={step}

--- a/packages/front-end/components/Experiment/MakeChangesFlow.tsx
+++ b/packages/front-end/components/Experiment/MakeChangesFlow.tsx
@@ -140,7 +140,6 @@ export default function MakeChangesFlow({
 
   return (
     <PagedModal
-      useRadixButton={false}
       trackingEventModalType="make-changes"
       close={close}
       header={`Make ${isBandit ? "Bandit" : "Experiment"} Changes`}

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -851,7 +851,6 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
   return (
     <FormProvider {...form}>
       <PagedModal
-        useRadixButton={false}
         trackingEventModalType={trackingEventModalType}
         trackingEventModalSource={source}
         header={header}

--- a/packages/front-end/components/Experiment/NewPhaseForm.tsx
+++ b/packages/front-end/components/Experiment/NewPhaseForm.tsx
@@ -141,7 +141,6 @@ const NewPhaseForm: FC<{
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType="new-phase-form"
       trackingEventModalSource={source}
       header={firstPhase ? "Start Experiment" : "New Experiment Phase"}

--- a/packages/front-end/components/Experiment/QueryModal.tsx
+++ b/packages/front-end/components/Experiment/QueryModal.tsx
@@ -10,7 +10,6 @@ const QueryModal: FC<{
 }> = ({ queries, language, close }) => {
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       close={close}
       header="View Query"

--- a/packages/front-end/components/Experiment/RefreshSnapshotButton.tsx
+++ b/packages/front-end/components/Experiment/RefreshSnapshotButton.tsx
@@ -1,10 +1,8 @@
 import { FC } from "react";
-import { BsArrowRepeat } from "react-icons/bs";
 import { ExperimentInterfaceStringDates } from "shared/types/experiment";
 import { Text } from "@radix-ui/themes";
 import { PiArrowClockwise } from "react-icons/pi";
 import { useDefinitions } from "@/services/DefinitionsContext";
-import Button from "@/components/Button";
 import RadixButton from "@/ui/Button";
 import {
   type SnapshotRefreshBlocker,
@@ -17,7 +15,6 @@ const RefreshSnapshotButton: FC<{
   experiment: ExperimentInterfaceStringDates;
   phase: number;
   dimension?: string;
-  useRadixButton?: boolean;
   radixVariant?: "outline" | "solid" | "soft";
   setError: (e: string | undefined) => void;
   // Return false to abort the refresh
@@ -36,7 +33,6 @@ const RefreshSnapshotButton: FC<{
   experiment,
   phase,
   dimension,
-  useRadixButton = true,
   radixVariant = "outline",
   setError,
   customValidation,
@@ -75,44 +71,24 @@ const RefreshSnapshotButton: FC<{
   return (
     <>
       <FullRefreshRequiredDialog controller={fullRefreshConfirm} />
-      {useRadixButton ? (
-        <>
-          {loading && longResult && (
-            <Text size="1" color="gray" mr="3">
-              this may take several minutes
-            </Text>
-          )}
-          <RadixButton
-            variant={radixVariant}
-            size="md"
-            disabled={loading || disabled}
-            setError={(error) => setError(error ?? undefined)}
-            onClick={handleClick}
-            style={{
-              minWidth: 110,
-            }}
-            icon={<PiArrowClockwise />}
-          >
-            {label}
-          </RadixButton>
-        </>
-      ) : (
-        <>
-          {loading && longResult && (
-            <small className="text-muted mr-3">
-              this may take several minutes
-            </small>
-          )}
-          <Button
-            color="outline-primary"
-            setErrorText={setError}
-            onClick={handleClick}
-            disabled={loading || disabled}
-          >
-            <BsArrowRepeat /> {label}
-          </Button>
-        </>
+      {loading && longResult && (
+        <Text size="1" color="gray" mr="3">
+          this may take several minutes
+        </Text>
       )}
+      <RadixButton
+        variant={radixVariant}
+        size="md"
+        disabled={loading || disabled}
+        setError={(error) => setError(error ?? undefined)}
+        onClick={handleClick}
+        style={{
+          minWidth: 110,
+        }}
+        icon={<PiArrowClockwise />}
+      >
+        {label}
+      </RadixButton>
     </>
   );
 };

--- a/packages/front-end/components/Experiment/SRMWarning.tsx
+++ b/packages/front-end/components/Experiment/SRMWarning.tsx
@@ -94,7 +94,6 @@ const SRMWarning: FC<{
     <>
       {type === "with_modal" && (
         <Modal
-          useRadixButton={false}
           trackingEventModalType="srm-warning"
           close={() => setOpen(false)}
           open={open}

--- a/packages/front-end/components/Experiment/TabbedPage/EditHoldoutInfoModal.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/EditHoldoutInfoModal.tsx
@@ -45,7 +45,6 @@ export default function EditHoldoutInfoModal({
 
   return (
     <Modal
-      useRadixButton={false}
       open={true}
       close={() => setShowEditInfoModal(false)}
       trackingEventModalType="edit-experiment-info"

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -529,7 +529,6 @@ export default function ExperimentHeader({
       )}
       {showBanditModal ? (
         <Modal
-          useRadixButton={false}
           open={true}
           close={() => setShowBanditModal(false)}
           trackingEventModalType=""

--- a/packages/front-end/components/Experiment/TabbedPage/HealthTabOnboardingModal.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/HealthTabOnboardingModal.tsx
@@ -194,7 +194,6 @@ export const HealthTabOnboardingModal: FC<HealthTabOnboardingModalProps> = ({
   if (step === -1) {
     return (
       <Modal
-        useRadixButton={false}
         trackingEventModalType=""
         open={open}
         submit={close}
@@ -364,7 +363,6 @@ export const HealthTabOnboardingModal: FC<HealthTabOnboardingModalProps> = ({
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={open}
       close={() => {

--- a/packages/front-end/components/Experiment/TabbedPage/index.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/index.tsx
@@ -449,7 +449,6 @@ export default function TabbedPage({
       )}
       {watchersModal && (
         <Modal
-          useRadixButton={false}
           trackingEventModalType=""
           open={true}
           header="Experiment Watchers"

--- a/packages/front-end/components/Experiment/Templates/TemplateForm.tsx
+++ b/packages/front-end/components/Experiment/Templates/TemplateForm.tsx
@@ -233,7 +233,6 @@ const TemplateForm: FC<Props> = ({
   return (
     <FormProvider {...form}>
       <PagedModal
-        useRadixButton={false}
         trackingEventModalType={trackingEventModalType}
         trackingEventModalSource={source}
         header={header}

--- a/packages/front-end/components/FactTables/ColumnModal.tsx
+++ b/packages/front-end/components/FactTables/ColumnModal.tsx
@@ -265,7 +265,6 @@ export default function ColumnModal({ existing, factTable, close }: Props) {
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={true}
       close={close}

--- a/packages/front-end/components/FactTables/FactFilterModal.tsx
+++ b/packages/front-end/components/FactTables/FactFilterModal.tsx
@@ -98,7 +98,6 @@ export default function FactFilterModal({ existing, factTable, close }: Props) {
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={true}
       close={close}

--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -1262,7 +1262,6 @@ function FieldMappingModal({
 
   return (
     <Modal
-      useRadixButton={false}
       close={close}
       header="Create Fact Metric From Template"
       trackingEventModalType=""
@@ -1669,7 +1668,6 @@ function StandardFactMetricModal({
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={true}
       header={!isNew ? "Edit Metric" : "Create Fact Table Metric"}

--- a/packages/front-end/components/FactTables/FactTableModal.tsx
+++ b/packages/front-end/components/FactTables/FactTableModal.tsx
@@ -147,7 +147,6 @@ export default function FactTableModal({
         />
       )}
       <Modal
-        useRadixButton={false}
         trackingEventModalType=""
         open={true}
         close={close}

--- a/packages/front-end/components/FactTables/RecommendedFactMetricsModal.tsx
+++ b/packages/front-end/components/FactTables/RecommendedFactMetricsModal.tsx
@@ -165,7 +165,6 @@ export default function RecommendedFactMetricsModal({
 
   return (
     <Modal
-      useRadixButton={false}
       open
       header="Review Recommended Metrics"
       cta={`Create ${checked.size} Selected Metric${

--- a/packages/front-end/components/Features/AttributeModal.tsx
+++ b/packages/front-end/components/Features/AttributeModal.tsx
@@ -148,7 +148,6 @@ export default function AttributeModal({ close, attribute }: Props) {
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={true}
       close={close}

--- a/packages/front-end/components/Features/CodeSnippetModal.tsx
+++ b/packages/front-end/components/Features/CodeSnippetModal.tsx
@@ -199,7 +199,6 @@ export default function CodeSnippetModal({
         />
       )}
       <Modal
-        useRadixButton={false}
         trackingEventModalType=""
         close={close}
         secondaryCTA={secondaryCTA}

--- a/packages/front-end/components/Features/FeatureImplementationModal.tsx
+++ b/packages/front-end/components/Features/FeatureImplementationModal.tsx
@@ -52,7 +52,6 @@ export default function FeatureImplementationModal({
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={true}
       close={close}

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -307,7 +307,6 @@ export default function FeatureModal({
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open
       size="lg"

--- a/packages/front-end/components/Features/FeatureUsageGraph.tsx
+++ b/packages/front-end/components/Features/FeatureUsageGraph.tsx
@@ -1295,7 +1295,6 @@ export function FeatureUsageSparkline({
       </Tooltip>
       {modalOpen && (
         <Modal
-          useRadixButton={false}
           trackingEventModalType="feature-usage-sparkline"
           open={true}
           close={() => setModalOpen(false)}

--- a/packages/front-end/components/Features/FeatureValueField.tsx
+++ b/packages/front-end/components/Features/FeatureValueField.tsx
@@ -1318,7 +1318,6 @@ function SimpleSchemaEditor({
       <>
         {open ? (
           <Modal
-            useRadixButton={false}
             trackingEventModalType=""
             open={true}
             header="Edit Value"

--- a/packages/front-end/components/Features/FeaturesHeader.tsx
+++ b/packages/front-end/components/Features/FeaturesHeader.tsx
@@ -667,7 +667,6 @@ export default function FeaturesHeader({
       )}
       {watchersModal && (
         <Modal
-          useRadixButton={false}
           trackingEventModalType=""
           open={true}
           header="Feature Watchers"

--- a/packages/front-end/components/Features/HoldoutValueModal.tsx
+++ b/packages/front-end/components/Features/HoldoutValueModal.tsx
@@ -114,7 +114,6 @@ const HoldoutValueModal = ({
 
   return (
     <Modal
-      useRadixButton={false}
       header="Change Holdout Value"
       open={true}
       close={close}

--- a/packages/front-end/components/Features/PrerequisiteModal.tsx
+++ b/packages/front-end/components/Features/PrerequisiteModal.tsx
@@ -262,7 +262,6 @@ export default function PrerequisiteModal({
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={true}
       close={close}

--- a/packages/front-end/components/Features/PrerequisiteStatusRow.tsx
+++ b/packages/front-end/components/Features/PrerequisiteStatusRow.tsx
@@ -114,7 +114,6 @@ export default function PrerequisiteStatusRow({
 
   const deleteModal = showDeleteModal && (
     <Modal
-      useRadixButton={false}
       trackingEventModalType="delete-prerequisite"
       header="Delete Prerequisite"
       size="lg"

--- a/packages/front-end/components/Features/RuleModal/RampScheduleSection.tsx
+++ b/packages/front-end/components/Features/RuleModal/RampScheduleSection.tsx
@@ -30,7 +30,6 @@ import {
 } from "react-icons/pi";
 import type {
   FeatureInterface,
-  FeatureRule,
   SavedGroupTargeting,
   FeaturePrerequisite,
 } from "shared/types/feature";
@@ -102,10 +101,6 @@ import PaidFeatureBadge from "@/components/GetStarted/PaidFeatureBadge";
 import { formatRemainingDuration } from "@/components/Features/Rule";
 import { Popover } from "@/ui/Popover";
 import { getExposureQuery } from "@/services/datasources";
-import {
-  countRampFallthroughRules,
-  getRampStartImpact,
-} from "@/components/Features/RuleModal/rampStartImpact";
 import styles from "./RampScheduleSection.module.scss";
 
 export type IntervalUnit = "minutes" | "hours" | "days";
@@ -899,11 +894,6 @@ interface Props {
   // Whether the parent rule is a sparse patch. The ramp's value edits inherit
   // this — sparse interpretation belongs to the rule, not the schedule.
   sparse?: boolean;
-  // Published version of the target rule; unset when nothing is live.
-  liveRule?: FeatureRule;
-  // Escape hatch offered by the traffic-drop warning: switch to the
-  // "Ramp to new value" flow instead of ramping the live rule itself.
-  onRampToNewValue?: () => void;
 }
 
 export default function RampScheduleSection({
@@ -931,8 +921,6 @@ export default function RampScheduleSection({
   ruleId,
   featureId,
   sparse = false,
-  liveRule,
-  onRampToNewValue,
 }: Props) {
   const [open, setOpen] = useState(embedded || state.mode !== "off");
   const [seedOpen, setSeedOpen] = useState(
@@ -4018,77 +4006,8 @@ export default function RampScheduleSection({
       </HelperText>
     ) : null;
 
-  // Warn when starting this ramp would take traffic away from an already-live
-  // rule. Only meaningful before the ramp has started.
-  const rampNotYetStarted =
-    !ruleRampSchedule || ["pending", "ready"].includes(ruleRampSchedule.status);
-  const rampStartImpact = rampNotYetStarted
-    ? getRampStartImpact({
-        liveRule,
-        firstStepCoveragePct: state.steps.find(
-          (s) => s.patch.coverage !== undefined,
-        )?.patch.coverage,
-        hasDelayedStart:
-          (!!state.startDate && new Date(state.startDate) > new Date()) ||
-          state.requiresStartApproval,
-      })
-    : null;
-  const fallthroughPhrase =
-    countRampFallthroughRules(feature, ruleId) > 0
-      ? "the next matching rule, or the default value"
-      : "the default value";
-
-  const rampImpactCallout =
-    !rampStartImpact ||
-    hideTemplateSave ||
-    isReadOnlyView ||
-    state.mode === "off" ? null : (
-      <Callout status="warning" size="sm" mb="4">
-        <Flex align="center" gap="8">
-          <Box flexGrow="1">
-            <Text as="div">
-              {rampStartImpact.kind === "coverage-drop" ? (
-                <>
-                  This ramp-up drops this rule from {rampStartImpact.fromPct}%
-                  to {rampStartImpact.toPct}% of traffic.
-                </>
-              ) : (
-                <>
-                  This rule (live at {rampStartImpact.liveCoveragePct}%) will be
-                  disabled until the ramp-up starts.
-                </>
-              )}
-            </Text>
-            <Text as="div" size="sm" mt="1">
-              {rampStartImpact.kind === "coverage-drop" ? (
-                <>Unenrolled users will fall through to {fallthroughPhrase}.</>
-              ) : (
-                <>
-                  Until then, all traffic will fall through to{" "}
-                  {fallthroughPhrase}.
-                </>
-              )}
-              {onRampToNewValue && (
-                <>
-                  {" "}
-                  To ramp to a new value instead, insert a ramp-up rule above
-                  this one.
-                </>
-              )}
-            </Text>
-          </Box>
-          {onRampToNewValue && (
-            <Button variant="solid" size="sm" onClick={onRampToNewValue}>
-              Ramp to new value
-            </Button>
-          )}
-        </Flex>
-      </Callout>
-    );
-
   const createContent = (
     <>
-      {rampImpactCallout}
       {hasRampSchedulesFeature && !hideTemplateSave && (
         <>
           <Text as="div" weight="semibold" mb="1">

--- a/packages/front-end/components/Features/RuleModal/RampScheduleSection.tsx
+++ b/packages/front-end/components/Features/RuleModal/RampScheduleSection.tsx
@@ -2478,7 +2478,8 @@ export default function RampScheduleSection({
                 </Flex>
 
                 {!isReadOnlyView &&
-                  (step.holdConditions?.requiresApproval ||
+                  ((step.triggerType !== "approval" &&
+                    step.holdConditions?.requiresApproval) ||
                     (step.monitored &&
                       (step.holdConditions?.minSampleSize ?? null) !==
                         null)) && (

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -1005,7 +1005,7 @@ export default function RuleModal({
   const rampImpactKey = rampStartImpact
     ? rampStartImpact.kind === "coverage-drop"
       ? `drop:${rampStartImpact.fromPct}:${rampStartImpact.toPct}`
-      : `delayed:${rampStartImpact.liveCoveragePct}`
+      : `delayed:${rampStartImpact.liveCoveragePct}:${rampSectionState.startDate}:${rampSectionState.requiresStartApproval}`
     : "";
   const [rampAcknowledgedKey, setRampAcknowledgedKey] = useState(() =>
     ruleRampSchedule || pendingCreateActionTyped ? rampImpactKey : "",

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -19,7 +19,12 @@ import {
   parsePlainJSONObject,
   stripDefaultsForSparse,
 } from "shared/util";
-import { PiCaretDown, PiCaretRight } from "react-icons/pi";
+import {
+  PiCaretDown,
+  PiCaretRight,
+  PiCheckBold,
+  PiWarningFill,
+} from "react-icons/pi";
 import { DEFAULT_SEQUENTIAL_TESTING_TUNING_PARAMETER } from "shared/constants";
 import { getScopedSettings } from "shared/settings";
 import { getAllVariations, getLatestPhaseVariations } from "shared/experiments";
@@ -71,8 +76,14 @@ import { getNewExperimentDatasourceDefaults } from "@/components/Experiment/NewE
 import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
 import { useUser } from "@/services/UserContext";
 import RadioCards from "@/ui/RadioCards";
+import {
+  countRampFallthroughRules,
+  getRampStartImpact,
+  type RampStartImpact,
+} from "@/components/Features/RuleModal/rampStartImpact";
 import RadioGroup from "@/ui/RadioGroup";
 import Callout from "@/ui/Callout";
+import Tooltip from "@/components/Tooltip/Tooltip";
 import HelperText from "@/ui/HelperText";
 import PagedModal from "@/components/Modal/PagedModal";
 import {
@@ -193,6 +204,100 @@ export const RAMP_TO_NEW_VALUE_CARRIED_FIELDS = [
 export interface RampToNewValueSeed {
   rule: Record<(typeof RAMP_TO_NEW_VALUE_CARRIED_FIELDS)[number], unknown>;
   ramp: RampSectionState;
+}
+
+// Full-bleed amber strip above the modal CTAs: warns that saving this ramp
+// takes traffic away from an already-published rule, and gates Save behind an
+// explicit acknowledgment.
+function RampImpactBanner({
+  impact,
+  fallthroughPhrase,
+  acknowledged,
+  onToggleAcknowledged,
+  onRampToNewValue,
+}: {
+  impact: NonNullable<RampStartImpact>;
+  fallthroughPhrase: string;
+  acknowledged: boolean;
+  onToggleAcknowledged: () => void;
+  onRampToNewValue?: () => void;
+}) {
+  return (
+    <Flex
+      align="center"
+      justify="between"
+      gap="4"
+      px="4"
+      py="2"
+      style={{
+        background: "var(--amber-a3)",
+        borderTop: "1px solid var(--amber-a5)",
+        color: "var(--amber-11)",
+      }}
+    >
+      <Flex align="center" gap="2">
+        <PiWarningFill size={15} style={{ flexShrink: 0 }} />
+        <Text as="div">
+          This ramp-up will override an already-published rule.{" "}
+          {impact.kind === "coverage-drop" ? (
+            <>
+              Unenrolled users ({100 - impact.toPct}%) will fall through to{" "}
+              {fallthroughPhrase}.
+            </>
+          ) : (
+            <>
+              This rule will be disabled until the ramp-up starts; until then,
+              all traffic will fall through to {fallthroughPhrase}.
+            </>
+          )}
+        </Text>
+      </Flex>
+      <Flex align="center" gap="3" flexShrink="0">
+        {onRampToNewValue && (
+          <Tooltip
+            body="Inserts a ramp-up rule above this one, keeping unenrolled users on the current value."
+            tipPosition="top"
+          >
+            <Button variant="outline" size="md" onClick={onRampToNewValue}>
+              Ramp to new value
+            </Button>
+          </Tooltip>
+        )}
+        <Button
+          variant="ghost"
+          size="md"
+          color="inherit"
+          aria-pressed={acknowledged}
+          onClick={onToggleAcknowledged}
+        >
+          <Flex align="center" gap="2">
+            {/* Checkbox lookalike (a real one nests a button inside this
+                button); the button is the control. */}
+            <Flex
+              align="center"
+              justify="center"
+              flexShrink="0"
+              style={{
+                width: 16,
+                height: 16,
+                borderRadius: "var(--radius-1)",
+                boxShadow: acknowledged
+                  ? "none"
+                  : "inset 0 0 0 1px var(--gray-a7)",
+                background: acknowledged
+                  ? "var(--violet-9)"
+                  : "var(--color-surface)",
+                color: "var(--white-a12)",
+              }}
+            >
+              {acknowledged && <PiCheckBold size={12} />}
+            </Flex>
+            {acknowledged ? "Acknowledged" : "Acknowledge"}
+          </Flex>
+        </Button>
+      </Flex>
+    </Flex>
+  );
 }
 
 export interface Props {
@@ -872,8 +977,61 @@ export default function RuleModal({
   const isRampType = scheduleType === "ramp";
   const hasRampPage =
     isRampType && (ruleType === "force" || ruleType === "rollout");
+  const onRampPage = hasRampPage && step === 1;
   const rampIsEditable =
     !ruleRampSchedule || ruleRampSchedule.status !== "running";
+
+  // Ramping an already-live rule takes traffic away from it: block the ramp
+  // page's submit until that's acknowledged. Moot once the ramp has started.
+  const rampNotYetStarted =
+    !ruleRampSchedule || ["pending", "ready"].includes(ruleRampSchedule.status);
+  const rampStartImpact =
+    hasRampPage && rampNotYetStarted && rampSectionState.mode !== "off"
+      ? getRampStartImpact({
+          liveRule,
+          firstStepCoveragePct: rampSectionState.steps.find(
+            (s) => s.patch.coverage !== undefined,
+          )?.patch.coverage,
+          hasDelayedStart:
+            (!!rampSectionState.startDate &&
+              new Date(rampSectionState.startDate) > new Date()) ||
+            rampSectionState.requiresStartApproval,
+        })
+      : null;
+  // Acknowledgment binds to the impact's signature, so editing the ramp into
+  // a different impact re-arms the gate. A ramp that arrived already saved
+  // (pending schedule or draft action) starts acknowledged — its impact was
+  // accepted when it was first saved.
+  const rampImpactKey = rampStartImpact
+    ? rampStartImpact.kind === "coverage-drop"
+      ? `drop:${rampStartImpact.fromPct}:${rampStartImpact.toPct}`
+      : `delayed:${rampStartImpact.liveCoveragePct}`
+    : "";
+  const [rampAcknowledgedKey, setRampAcknowledgedKey] = useState(() =>
+    ruleRampSchedule || pendingCreateActionTyped ? rampImpactKey : "",
+  );
+  const rampImpactAcknowledged =
+    rampImpactKey !== "" && rampAcknowledgedKey === rampImpactKey;
+  const rampImpactBlocksSubmit = !!rampStartImpact && !rampImpactAcknowledged;
+  const rampFallthroughPhrase =
+    rampStartImpact && countRampFallthroughRules(feature, ruleId) > 0
+      ? "the next matching rule, or the default value"
+      : "the default value";
+  // Hidden when the draft already has a pending ramp — publish would ramp
+  // both the source and the clone.
+  const switchToRampToNewValue =
+    mode === "edit" &&
+    isLiveRule &&
+    !ruleRampSchedule &&
+    !pendingCreateActionTyped &&
+    ruleId &&
+    onSwitchToRampToNewValue
+      ? () =>
+          onSwitchToRampToNewValue(ruleId, {
+            rule: pick(formValues(), RAMP_TO_NEW_VALUE_CARRIED_FIELDS),
+            ramp: rampSectionState,
+          })
+      : undefined;
 
   // Reset to page 1 when the ramp page disappears (user switched away from ramp).
   // Only applies to rollout/force rules — experiment rules have their own valid pages.
@@ -2299,14 +2457,33 @@ export default function RuleModal({
             ? ruleType !== undefined
             : hasRampPage && step === 0
               ? !isCyclic && !prerequisiteTargetingSdkIssues
-              : canSubmit && conflictResolved
+              : canSubmit && conflictResolved && !rampImpactBlocksSubmit
         }
         disabledMessage={
           hasRampPage && step === 0
             ? undefined
             : !conflictResolved
               ? "Resolve the conflicting edits above, or save to a new draft."
-              : (monitoringError ?? undefined)
+              : !canSubmit
+                ? (monitoringError ?? undefined)
+                : rampImpactBlocksSubmit
+                  ? "Acknowledge the traffic warning to save"
+                  : undefined
+        }
+        aboveFooterContent={
+          onRampPage && rampStartImpact ? (
+            <RampImpactBanner
+              impact={rampStartImpact}
+              fallthroughPhrase={rampFallthroughPhrase}
+              acknowledged={rampImpactAcknowledged}
+              onToggleAcknowledged={() =>
+                setRampAcknowledgedKey(
+                  rampImpactAcknowledged ? "" : rampImpactKey,
+                )
+              }
+              onRampToNewValue={switchToRampToNewValue}
+            />
+          ) : undefined
         }
         header={headerText}
         docSection={
@@ -2401,26 +2578,6 @@ export default function RuleModal({
               ruleId={form.watch("id") as string}
               featureId={feature.id}
               sparse={!!form.watch("sparse")}
-              liveRule={liveRule}
-              onRampToNewValue={
-                // Hidden when the draft already has a pending ramp —
-                // publish would ramp both the source and the clone.
-                mode === "edit" &&
-                isLiveRule &&
-                !ruleRampSchedule &&
-                !pendingCreateActionTyped &&
-                ruleId &&
-                onSwitchToRampToNewValue
-                  ? () =>
-                      onSwitchToRampToNewValue(ruleId, {
-                        rule: pick(
-                          formValues(),
-                          RAMP_TO_NEW_VALUE_CARRIED_FIELDS,
-                        ),
-                        ramp: rampSectionState,
-                      })
-                  : undefined
-              }
             />
           </Page>
         )}

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -19,12 +19,7 @@ import {
   parsePlainJSONObject,
   stripDefaultsForSparse,
 } from "shared/util";
-import {
-  PiCaretDown,
-  PiCaretRight,
-  PiCheckBold,
-  PiWarningFill,
-} from "react-icons/pi";
+import { PiCaretDown, PiCaretRight, PiWarningFill } from "react-icons/pi";
 import { DEFAULT_SEQUENTIAL_TESTING_TUNING_PARAMETER } from "shared/constants";
 import { getScopedSettings } from "shared/settings";
 import { getAllVariations, getLatestPhaseVariations } from "shared/experiments";
@@ -83,6 +78,7 @@ import {
 } from "@/components/Features/RuleModal/rampStartImpact";
 import RadioGroup from "@/ui/RadioGroup";
 import Callout from "@/ui/Callout";
+import Checkbox from "@/ui/Checkbox";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import HelperText from "@/ui/HelperText";
 import PagedModal from "@/components/Modal/PagedModal";
@@ -213,13 +209,13 @@ function RampImpactBanner({
   impact,
   fallthroughPhrase,
   acknowledged,
-  onToggleAcknowledged,
+  setAcknowledged,
   onRampToNewValue,
 }: {
   impact: NonNullable<RampStartImpact>;
   fallthroughPhrase: string;
   acknowledged: boolean;
-  onToggleAcknowledged: () => void;
+  setAcknowledged: (value: boolean) => void;
   onRampToNewValue?: () => void;
 }) {
   return (
@@ -252,7 +248,7 @@ function RampImpactBanner({
           )}
         </Text>
       </Flex>
-      <Flex align="center" gap="3" flexShrink="0">
+      <Flex align="center" gap="4" flexShrink="0">
         {onRampToNewValue && (
           <Tooltip
             body="Inserts a ramp-up rule above this one, keeping unenrolled users on the current value."
@@ -263,38 +259,15 @@ function RampImpactBanner({
             </Button>
           </Tooltip>
         )}
-        <Button
-          variant="ghost"
-          size="md"
-          color="inherit"
-          aria-pressed={acknowledged}
-          onClick={onToggleAcknowledged}
-        >
-          <Flex align="center" gap="2">
-            {/* Checkbox lookalike (a real one nests a button inside this
-                button); the button is the control. */}
-            <Flex
-              align="center"
-              justify="center"
-              flexShrink="0"
-              style={{
-                width: 16,
-                height: 16,
-                borderRadius: "var(--radius-1)",
-                boxShadow: acknowledged
-                  ? "none"
-                  : "inset 0 0 0 1px var(--gray-a7)",
-                background: acknowledged
-                  ? "var(--violet-9)"
-                  : "var(--color-surface)",
-                color: "var(--white-a12)",
-              }}
-            >
-              {acknowledged && <PiCheckBold size={12} />}
-            </Flex>
-            {acknowledged ? "Acknowledged" : "Acknowledge"}
-          </Flex>
-        </Button>
+        <Box style={{ color: "var(--violet-11)" }}>
+          <Checkbox
+            value={acknowledged}
+            setValue={setAcknowledged}
+            label="Acknowledge"
+            weight="medium"
+            containerClassName="mb-0"
+          />
+        </Box>
       </Flex>
     </Flex>
   );
@@ -2476,10 +2449,8 @@ export default function RuleModal({
               impact={rampStartImpact}
               fallthroughPhrase={rampFallthroughPhrase}
               acknowledged={rampImpactAcknowledged}
-              onToggleAcknowledged={() =>
-                setRampAcknowledgedKey(
-                  rampImpactAcknowledged ? "" : rampImpactKey,
-                )
+              setAcknowledged={(v) =>
+                setRampAcknowledgedKey(v ? rampImpactKey : "")
               }
               onRampToNewValue={switchToRampToNewValue}
             />

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -19,7 +19,7 @@ import {
   parsePlainJSONObject,
   stripDefaultsForSparse,
 } from "shared/util";
-import { PiCaretDown, PiCaretRight, PiWarningFill } from "react-icons/pi";
+import { PiCaretDown, PiCaretRight } from "react-icons/pi";
 import { DEFAULT_SEQUENTIAL_TESTING_TUNING_PARAMETER } from "shared/constants";
 import { getScopedSettings } from "shared/settings";
 import { getAllVariations, getLatestPhaseVariations } from "shared/experiments";
@@ -79,6 +79,7 @@ import {
 import RadioGroup from "@/ui/RadioGroup";
 import Callout from "@/ui/Callout";
 import Checkbox from "@/ui/Checkbox";
+import ModalWarningBanner from "@/components/Modal/ModalWarningBanner";
 import Tooltip from "@/ui/Tooltip";
 import HelperText from "@/ui/HelperText";
 import PagedModal from "@/components/Modal/PagedModal";
@@ -219,56 +220,44 @@ function RampImpactBanner({
   onRampToNewValue?: () => void;
 }) {
   return (
-    <Flex
-      align="center"
-      justify="between"
-      gap="4"
-      px="4"
-      py="2"
-      style={{
-        background: "var(--amber-a3)",
-        borderTop: "1px solid var(--amber-a5)",
-      }}
-    >
-      <Flex align="center" gap="2" style={{ color: "var(--amber-11)" }}>
-        <PiWarningFill size={15} style={{ flexShrink: 0 }} />
-        <Text as="div">
-          This ramp-up will override an already-published rule.{" "}
-          {impact.kind === "coverage-drop" ? (
-            <>
-              Unenrolled users ({100 - impact.toPct}%) will fall through to{" "}
-              {fallthroughPhrase}.
-            </>
-          ) : (
-            <>
-              This rule will be disabled until the ramp-up starts; until then,
-              all traffic will fall through to {fallthroughPhrase}.
-            </>
+    <ModalWarningBanner
+      controls={
+        <>
+          {onRampToNewValue && (
+            <Tooltip
+              content="Inserts a ramp-up rule above this one, keeping unenrolled users on the current value."
+              side="top"
+            >
+              <Button variant="outline" size="md" onClick={onRampToNewValue}>
+                Ramp to new value
+              </Button>
+            </Tooltip>
           )}
-        </Text>
-      </Flex>
-      <Flex align="center" gap="4" flexShrink="0">
-        {onRampToNewValue && (
-          <Tooltip
-            content="Inserts a ramp-up rule above this one, keeping unenrolled users on the current value."
-            side="top"
-          >
-            <Button variant="outline" size="md" onClick={onRampToNewValue}>
-              Ramp to new value
-            </Button>
-          </Tooltip>
-        )}
-        <Box style={{ color: "var(--violet-11)" }}>
-          <Checkbox
-            value={acknowledged}
-            setValue={setAcknowledged}
-            label="Acknowledge"
-            weight="medium"
-            align="center"
-          />
-        </Box>
-      </Flex>
-    </Flex>
+          <Box style={{ color: "var(--violet-11)" }}>
+            <Checkbox
+              value={acknowledged}
+              setValue={setAcknowledged}
+              label="Acknowledge"
+              weight="medium"
+              align="center"
+            />
+          </Box>
+        </>
+      }
+    >
+      This ramp-up will override an already-published rule.{" "}
+      {impact.kind === "coverage-drop" ? (
+        <>
+          Unenrolled users ({100 - impact.toPct}%) will fall through to{" "}
+          {fallthroughPhrase}.
+        </>
+      ) : (
+        <>
+          This rule will be disabled until the ramp-up starts; until then, all
+          traffic will fall through to {fallthroughPhrase}.
+        </>
+      )}
+    </ModalWarningBanner>
   );
 }
 

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -265,7 +265,6 @@ function RampImpactBanner({
             label="Acknowledge"
             weight="medium"
             align="center"
-            containerClassName="mb-0"
           />
         </Box>
       </Flex>

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -265,6 +265,7 @@ function RampImpactBanner({
             setValue={setAcknowledged}
             label="Acknowledge"
             weight="medium"
+            align="center"
             containerClassName="mb-0"
           />
         </Box>

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -79,7 +79,7 @@ import {
 import RadioGroup from "@/ui/RadioGroup";
 import Callout from "@/ui/Callout";
 import Checkbox from "@/ui/Checkbox";
-import Tooltip from "@/components/Tooltip/Tooltip";
+import Tooltip from "@/ui/Tooltip";
 import HelperText from "@/ui/HelperText";
 import PagedModal from "@/components/Modal/PagedModal";
 import {
@@ -228,10 +228,9 @@ function RampImpactBanner({
       style={{
         background: "var(--amber-a3)",
         borderTop: "1px solid var(--amber-a5)",
-        color: "var(--amber-11)",
       }}
     >
-      <Flex align="center" gap="2">
+      <Flex align="center" gap="2" style={{ color: "var(--amber-11)" }}>
         <PiWarningFill size={15} style={{ flexShrink: 0 }} />
         <Text as="div">
           This ramp-up will override an already-published rule.{" "}
@@ -251,8 +250,8 @@ function RampImpactBanner({
       <Flex align="center" gap="4" flexShrink="0">
         {onRampToNewValue && (
           <Tooltip
-            body="Inserts a ramp-up rule above this one, keeping unenrolled users on the current value."
-            tipPosition="top"
+            content="Inserts a ramp-up rule above this one, keeping unenrolled users on the current value."
+            side="top"
           >
             <Button variant="outline" size="md" onClick={onRampToNewValue}>
               Ramp to new value

--- a/packages/front-end/components/Features/SDKConnections/ProxyTestButton.tsx
+++ b/packages/front-end/components/Features/SDKConnections/ProxyTestButton.tsx
@@ -31,7 +31,6 @@ export default function ProxyTestButton({
     <>
       {proxyTestResult && (
         <Modal
-          useRadixButton={false}
           trackingEventModalType=""
           header="Proxy Status"
           open={true}

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -390,7 +390,6 @@ export default function SDKConnectionForm({
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       header={edit ? "Edit SDK Connection" : "New SDK Connection"}
       size={"lg"}

--- a/packages/front-end/components/Features/SafeRollout/SafeRolloutStatusModal.tsx
+++ b/packages/front-end/components/Features/SafeRollout/SafeRolloutStatusModal.tsx
@@ -140,7 +140,6 @@ export default function SafeRolloutStatusModal({
 
   return (
     <Modal
-      useRadixButton={false}
       open={open}
       close={() => setStatusModalOpen(false)}
       header={`End Safe Rollout`}

--- a/packages/front-end/components/FeedbackModal.tsx
+++ b/packages/front-end/components/FeedbackModal.tsx
@@ -38,7 +38,6 @@ export default function FeedbackModal({
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={open}
       header={header}

--- a/packages/front-end/components/GeneralSettings/ExperimentSettings/DecisionFrameworkSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/ExperimentSettings/DecisionFrameworkSettings.tsx
@@ -65,7 +65,6 @@ const DecisionFrameworkSettings = () => {
 
       {criteriaToDelete && (
         <Modal
-          useRadixButton={false}
           header="Delete Decision Criteria"
           trackingEventModalType="delete-decision-criteria"
           open={true}

--- a/packages/front-end/components/GeneralSettings/RampScheduleTemplates.tsx
+++ b/packages/front-end/components/GeneralSettings/RampScheduleTemplates.tsx
@@ -95,7 +95,6 @@ function EditModal({ template, onClose, onSave }: EditModalProps) {
 
   return (
     <Modal
-      useRadixButton={false}
       open
       trackingEventModalType="ramp-schedule-template-edit"
       close={onClose}

--- a/packages/front-end/components/GuidedGetStarted/CheckSDKConnectionModal.tsx
+++ b/packages/front-end/components/GuidedGetStarted/CheckSDKConnectionModal.tsx
@@ -24,7 +24,6 @@ export default function CheckSDKConnectionModal({
   const canUpdate = permissionsUtil.canUpdateSDKConnection(connection, {});
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={true}
       close={showModalClose ? close : undefined}

--- a/packages/front-end/components/HealthTab/DimensionIssues.tsx
+++ b/packages/front-end/components/HealthTab/DimensionIssues.tsx
@@ -166,7 +166,6 @@ export const DimensionIssues = ({
   return (
     <>
       <Modal
-        useRadixButton={false}
         trackingEventModalType="srm-dimension-issues"
         close={() => setModalOpen(false)}
         open={modalOpen}

--- a/packages/front-end/components/Holdout/EditEnvironmentsModal.tsx
+++ b/packages/front-end/components/Holdout/EditEnvironmentsModal.tsx
@@ -46,7 +46,6 @@ const EditEnvironmentsModal = ({
 
   return (
     <Modal
-      useRadixButton={false}
       open={true}
       trackingEventModalType=""
       header="Edit Included Environments"

--- a/packages/front-end/components/Holdout/EditScheduleModal.tsx
+++ b/packages/front-end/components/Holdout/EditScheduleModal.tsx
@@ -75,7 +75,6 @@ const EditScheduleModal = ({
 
   return (
     <Modal
-      useRadixButton={false}
       open={true}
       ctaEnabled={holdoutStage !== "stopped" && !experiment.archived}
       trackingEventModalType=""

--- a/packages/front-end/components/Holdout/NewHoldoutForm.tsx
+++ b/packages/front-end/components/Holdout/NewHoldoutForm.tsx
@@ -356,7 +356,6 @@ const NewHoldoutForm: FC<NewHoldoutFormProps> = ({
   return (
     <FormProvider {...form}>
       <PagedModal
-        useRadixButton={false}
         trackingEventModalType={trackingEventModalType}
         trackingEventModalSource={source}
         header={header}

--- a/packages/front-end/components/HomePage/NorthStar.tsx
+++ b/packages/front-end/components/HomePage/NorthStar.tsx
@@ -154,7 +154,6 @@ const NorthStar: FC<{
       )}
       {openNorthStarModal && (
         <Modal
-          useRadixButton={false}
           trackingEventModalType=""
           close={() => setOpenNorthStarModal(false)}
           overflowAuto={false}

--- a/packages/front-end/components/HomePage/NorthStarMetricDisplay.tsx
+++ b/packages/front-end/components/HomePage/NorthStarMetricDisplay.tsx
@@ -145,9 +145,19 @@ const NorthStarMetricDisplay = ({
           )}
           {datasource && permissionsUtil.canRunMetricQueries(datasource) ? (
             isFactMetric(metric) ? (
-              <form
-                onSubmit={async (e) => {
-                  e.preventDefault();
+              <RunQueriesButton
+                icon="refresh"
+                cta={analysis ? "Refresh Data" : "Run Analysis"}
+                mutate={mutate}
+                model={
+                  analysis ?? {
+                    queries: [],
+                    runStarted: new Date(),
+                  }
+                }
+                cancelEndpoint={`/metric-analysis/${analysis?.id}/cancel`}
+                position="left"
+                onSubmit={async () => {
                   //setError(null);
                   try {
                     const endOfToday = new Date();
@@ -183,27 +193,21 @@ const NorthStarMetricDisplay = ({
                     //setError(e.message);
                   }
                 }}
-              >
-                <RunQueriesButton
-                  useRadixButton={false}
-                  icon="refresh"
-                  cta={analysis ? "Refresh Data" : "Run Analysis"}
-                  mutate={mutate}
-                  model={
-                    analysis ?? {
-                      queries: [],
-                      runStarted: new Date(),
-                    }
-                  }
-                  cancelEndpoint={`/metric-analysis/${analysis?.id}/cancel`}
-                  color="outline-primary"
-                  position="left"
-                />
-              </form>
+              />
             ) : (
-              <form
-                onSubmit={async (e) => {
-                  e.preventDefault();
+              <RunQueriesButton
+                icon="refresh"
+                cta={analysis ? "Refresh Data" : "Run Analysis"}
+                model={
+                  data.data.metric ?? {
+                    queries: [],
+                    runStarted: new Date(),
+                  }
+                }
+                cancelEndpoint={`/metric/${metric.id}/analysis/cancel`}
+                position="left"
+                mutate={mutate}
+                onSubmit={async () => {
                   try {
                     await apiCall(`/metric/${metric.id}/analysis`, {
                       method: "POST",
@@ -213,23 +217,7 @@ const NorthStarMetricDisplay = ({
                     console.error(e);
                   }
                 }}
-              >
-                <RunQueriesButton
-                  useRadixButton={false}
-                  icon="refresh"
-                  cta={analysis ? "Refresh Data" : "Run Analysis"}
-                  model={
-                    data.data.metric ?? {
-                      queries: [],
-                      runStarted: new Date(),
-                    }
-                  }
-                  cancelEndpoint={`/metric/${metric.id}/analysis/cancel`}
-                  color="outline-primary"
-                  position="left"
-                  mutate={mutate}
-                />
-              </form>
+              />
             )
           ) : null}
         </div>

--- a/packages/front-end/components/Ideas/IdeaForm.tsx
+++ b/packages/front-end/components/Ideas/IdeaForm.tsx
@@ -44,7 +44,6 @@ const IdeaForm: FC<{
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       header={edit ? "Edit Idea" : "New Idea"}
       close={close}

--- a/packages/front-end/components/InitialSetup/ManagedWarehouseModal.tsx
+++ b/packages/front-end/components/InitialSetup/ManagedWarehouseModal.tsx
@@ -99,7 +99,6 @@ export default function ManagedWarehouseModal({
 
   return (
     <Modal
-      useRadixButton={false}
       open={true}
       header={
         <>

--- a/packages/front-end/components/Layout/TopNav.tsx
+++ b/packages/front-end/components/Layout/TopNav.tsx
@@ -419,7 +419,6 @@ const TopNav: FC<{
       </Head>
       {editUserOpen && (
         <Modal
-          useRadixButton={false}
           trackingEventModalType=""
           close={() => setEditUserOpen(false)}
           submit={onSubmitEditProfile}

--- a/packages/front-end/components/MetricAnalysis/MetricAnalysis.tsx
+++ b/packages/front-end/components/MetricAnalysis/MetricAnalysis.tsx
@@ -474,9 +474,18 @@ const MetricAnalysis: FC<MetricAnalysisProps> = ({
               ) : null}
               <div className="col-auto">
                 {canRunMetricQuery && (
-                  <form
-                    onSubmit={async (e) => {
-                      e.preventDefault();
+                  <RunQueriesButton
+                    icon="refresh"
+                    cta={"Run Analysis"}
+                    mutate={mutate}
+                    model={
+                      metricAnalysis ?? {
+                        queries: [],
+                        runStarted: new Date(),
+                      }
+                    }
+                    cancelEndpoint={`/metric-analysis/${metricAnalysis?.id}/cancel`}
+                    onSubmit={async () => {
                       setError(null);
                       const data = getMetricAnalysisProps({
                         id: factMetric.id,
@@ -498,22 +507,7 @@ const MetricAnalysis: FC<MetricAnalysisProps> = ({
                         setError(e.message);
                       }
                     }}
-                  >
-                    <RunQueriesButton
-                      useRadixButton={false}
-                      icon="refresh"
-                      cta={"Run Analysis"}
-                      mutate={mutate}
-                      model={
-                        metricAnalysis ?? {
-                          queries: [],
-                          runStarted: new Date(),
-                        }
-                      }
-                      cancelEndpoint={`/metric-analysis/${metricAnalysis?.id}/cancel`}
-                      color="outline-primary"
-                    />
-                  </form>
+                  />
                 )}
               </div>
               <MetricAnalysisMoreMenu

--- a/packages/front-end/components/MetricDrilldown/MetricDrilldownModal.tsx
+++ b/packages/front-end/components/MetricDrilldown/MetricDrilldownModal.tsx
@@ -579,7 +579,6 @@ const MetricDrilldownModal = ({
       }
     >
       <Modal
-        useRadixButton={false}
         open={true}
         close={close}
         borderlessHeader={true}

--- a/packages/front-end/components/Metrics/MetricForm/index.tsx
+++ b/packages/front-end/components/Metrics/MetricForm/index.tsx
@@ -639,7 +639,6 @@ const MetricForm: FC<MetricFormProps> = ({
         />
       )}
       <PagedModal
-        useRadixButton={false}
         trackingEventModalType={trackingEventModalType}
         inline={inline}
         header={edit ? "Edit Metric" : "New Metric"}

--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -45,7 +45,6 @@ type ModalProps = {
   closeCta?: string | ReactNode;
   includeCloseCta?: boolean;
   onClickCloseCta?: () => Promise<void> | void;
-  closeCtaClassName?: string;
   disabledMessage?: string;
   docSection?: DocSection;
   error?: string;
@@ -75,7 +74,6 @@ type ModalProps = {
   // Full-bleed row rendered between the body and the footer CTA buttons.
   // Not positioned for stickyFooter modals (the fixed footer would cover it).
   aboveFooterContent?: ReactNode;
-  useRadixButton?: boolean;
   borderlessHeader?: boolean;
   backgroundlessHeader?: boolean;
   borderlessFooter?: boolean;
@@ -98,7 +96,6 @@ const Modal: FC<ModalProps> = ({
   ctaEnabled = true,
   closeCta = "Cancel",
   onClickCloseCta,
-  closeCtaClassName = "btn btn-link",
   includeCloseCta = true,
   disabledMessage,
   inline = false,
@@ -127,7 +124,6 @@ const Modal: FC<ModalProps> = ({
   allowlistedTrackingEventProps = {},
   modalUuid: _modalUuid,
   trackOnSubmit = true,
-  useRadixButton = true,
   aboveBodyContent = null,
   aboveFooterContent = null,
   borderlessHeader = false,
@@ -318,33 +314,17 @@ const Modal: FC<ModalProps> = ({
               }
             >
               {close && includeCloseCta ? (
-                <>
-                  {useRadixButton ? (
-                    <div className="mr-1">
-                      <Button
-                        variant="ghost"
-                        onClick={async () => {
-                          await onClickCloseCta?.();
-                          close();
-                        }}
-                      >
-                        {isSuccess && successMessage ? "Close" : closeCta}
-                      </Button>
-                    </div>
-                  ) : (
-                    <button
-                      type="button"
-                      className={closeCtaClassName}
-                      onClick={async (e) => {
-                        e.preventDefault();
-                        await onClickCloseCta?.();
-                        close();
-                      }}
-                    >
-                      {isSuccess && successMessage ? "Close" : closeCta}
-                    </button>
-                  )}
-                </>
+                <div className="mr-1">
+                  <Button
+                    variant="ghost"
+                    onClick={async () => {
+                      await onClickCloseCta?.();
+                      close();
+                    }}
+                  >
+                    {isSuccess && successMessage ? "Close" : closeCta}
+                  </Button>
+                </div>
               ) : null}
               {secondaryCTA}
               {submit && !isSuccess ? (
@@ -353,26 +333,15 @@ const Modal: FC<ModalProps> = ({
                   enabled={!ctaEnabled && !!disabledMessage}
                   side="top"
                 >
-                  {useRadixButton ? (
-                    <Button
-                      type="submit"
-                      disabled={!ctaEnabled}
-                      ml="3"
-                      color={submitColor === "danger" ? "red" : undefined}
-                    >
-                      {cta}
-                    </Button>
-                  ) : (
-                    <button
-                      className={`btn btn-${submitColor} ${
-                        fullWidthSubmit ? "w-100" : ""
-                      } ${stickyFooter ? "ml-auto mr-5" : ""}`}
-                      type="submit"
-                      disabled={!ctaEnabled}
-                    >
-                      {cta}
-                    </button>
-                  )}
+                  <Button
+                    type="submit"
+                    disabled={!ctaEnabled}
+                    ml="3"
+                    color={submitColor === "danger" ? "red" : undefined}
+                    style={fullWidthSubmit ? { width: "100%" } : undefined}
+                  >
+                    {cta}
+                  </Button>
                 </UITooltip>
               ) : null}
               {tertiaryCTA}

--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -71,6 +71,9 @@ type ModalProps = {
   increasedElevation?: boolean;
   stickyFooter?: boolean;
   aboveBodyContent?: ReactNode;
+  // Full-bleed row rendered between the body and the footer CTA buttons.
+  // Not positioned for stickyFooter modals (the fixed footer would cover it).
+  aboveFooterContent?: ReactNode;
   useRadixButton?: boolean;
   borderlessHeader?: boolean;
   backgroundlessHeader?: boolean;
@@ -125,6 +128,7 @@ const Modal: FC<ModalProps> = ({
   trackOnSubmit = true,
   useRadixButton = true,
   aboveBodyContent = null,
+  aboveFooterContent = null,
   borderlessHeader = false,
   backgroundlessHeader = false,
   borderlessFooter = false,
@@ -292,86 +296,89 @@ const Modal: FC<ModalProps> = ({
         tertiaryCTA ||
         backCTA ||
         (close && includeCloseCta)) ? (
-        <div
-          className={clsx("modal-footer", { "sticky-footer": stickyFooter })}
-        >
-          {backCTA ? (
-            <>
-              {backCTA}
-              <div className="flex-1" />
-            </>
-          ) : null}
-          <ConditionalWrapper
-            condition={stickyFooter}
-            wrapper={
-              <div
-                className="container pagecontents mx-auto text-right"
-                style={{ maxWidth: 1100 }}
-              />
-            }
+        <>
+          {aboveFooterContent && !isSuccess ? aboveFooterContent : null}
+          <div
+            className={clsx("modal-footer", { "sticky-footer": stickyFooter })}
           >
-            {close && includeCloseCta ? (
+            {backCTA ? (
               <>
-                {useRadixButton ? (
-                  <div className="mr-1">
-                    <Button
-                      variant="ghost"
-                      onClick={async () => {
+                {backCTA}
+                <div className="flex-1" />
+              </>
+            ) : null}
+            <ConditionalWrapper
+              condition={stickyFooter}
+              wrapper={
+                <div
+                  className="container pagecontents mx-auto text-right"
+                  style={{ maxWidth: 1100 }}
+                />
+              }
+            >
+              {close && includeCloseCta ? (
+                <>
+                  {useRadixButton ? (
+                    <div className="mr-1">
+                      <Button
+                        variant="ghost"
+                        onClick={async () => {
+                          await onClickCloseCta?.();
+                          close();
+                        }}
+                      >
+                        {isSuccess && successMessage ? "Close" : closeCta}
+                      </Button>
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      className={closeCtaClassName}
+                      onClick={async (e) => {
+                        e.preventDefault();
                         await onClickCloseCta?.();
                         close();
                       }}
                     >
                       {isSuccess && successMessage ? "Close" : closeCta}
+                    </button>
+                  )}
+                </>
+              ) : null}
+              {secondaryCTA}
+              {submit && !isSuccess ? (
+                <Tooltip
+                  body={disabledMessage || ""}
+                  shouldDisplay={!ctaEnabled && !!disabledMessage}
+                  tipPosition="top"
+                  className={fullWidthSubmit ? "w-100" : ""}
+                >
+                  {useRadixButton ? (
+                    <Button
+                      type="submit"
+                      disabled={!ctaEnabled}
+                      ml="3"
+                      color={submitColor === "danger" ? "red" : undefined}
+                    >
+                      {cta}
                     </Button>
-                  </div>
-                ) : (
-                  <button
-                    type="button"
-                    className={closeCtaClassName}
-                    onClick={async (e) => {
-                      e.preventDefault();
-                      await onClickCloseCta?.();
-                      close();
-                    }}
-                  >
-                    {isSuccess && successMessage ? "Close" : closeCta}
-                  </button>
-                )}
-              </>
-            ) : null}
-            {secondaryCTA}
-            {submit && !isSuccess ? (
-              <Tooltip
-                body={disabledMessage || ""}
-                shouldDisplay={!ctaEnabled && !!disabledMessage}
-                tipPosition="top"
-                className={fullWidthSubmit ? "w-100" : ""}
-              >
-                {useRadixButton ? (
-                  <Button
-                    type="submit"
-                    disabled={!ctaEnabled}
-                    ml="3"
-                    color={submitColor === "danger" ? "red" : undefined}
-                  >
-                    {cta}
-                  </Button>
-                ) : (
-                  <button
-                    className={`btn btn-${submitColor} ${
-                      fullWidthSubmit ? "w-100" : ""
-                    } ${stickyFooter ? "ml-auto mr-5" : ""}`}
-                    type="submit"
-                    disabled={!ctaEnabled}
-                  >
-                    {cta}
-                  </button>
-                )}
-              </Tooltip>
-            ) : null}
-            {tertiaryCTA}
-          </ConditionalWrapper>
-        </div>
+                  ) : (
+                    <button
+                      className={`btn btn-${submitColor} ${
+                        fullWidthSubmit ? "w-100" : ""
+                      } ${stickyFooter ? "ml-auto mr-5" : ""}`}
+                      type="submit"
+                      disabled={!ctaEnabled}
+                    >
+                      {cta}
+                    </button>
+                  )}
+                </Tooltip>
+              ) : null}
+              {tertiaryCTA}
+            </ConditionalWrapper>
+          </div>
+        </>
       ) : null}
     </div>
   );

--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -296,7 +296,11 @@ const Modal: FC<ModalProps> = ({
         <>
           {aboveFooterContent && !isSuccess ? aboveFooterContent : null}
           <div
-            className={clsx("modal-footer", { "sticky-footer": stickyFooter })}
+            className={clsx("modal-footer", {
+              "sticky-footer": stickyFooter,
+              // The banner draws its own top border; avoid doubling up.
+              "border-top-0": !!aboveFooterContent,
+            })}
           >
             {backCTA ? (
               <>

--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -16,6 +16,7 @@ import ConditionalWrapper from "@/components/ConditionalWrapper";
 import ErrorDisplay from "@/ui/ErrorDisplay";
 import Button from "@/ui/Button";
 import Callout from "@/ui/Callout";
+import UITooltip from "@/ui/Tooltip";
 import LoadingOverlay from "./LoadingOverlay";
 import Portal from "./Modal/Portal";
 import Tooltip from "./Tooltip/Tooltip";
@@ -347,11 +348,10 @@ const Modal: FC<ModalProps> = ({
               ) : null}
               {secondaryCTA}
               {submit && !isSuccess ? (
-                <Tooltip
-                  body={disabledMessage || ""}
-                  shouldDisplay={!ctaEnabled && !!disabledMessage}
-                  tipPosition="top"
-                  className={fullWidthSubmit ? "w-100" : ""}
+                <UITooltip
+                  content={disabledMessage || ""}
+                  enabled={!ctaEnabled && !!disabledMessage}
+                  side="top"
                 >
                   {useRadixButton ? (
                     <Button
@@ -373,7 +373,7 @@ const Modal: FC<ModalProps> = ({
                       {cta}
                     </button>
                   )}
-                </Tooltip>
+                </UITooltip>
               ) : null}
               {tertiaryCTA}
             </ConditionalWrapper>

--- a/packages/front-end/components/Modal/ModalWarningBanner.tsx
+++ b/packages/front-end/components/Modal/ModalWarningBanner.tsx
@@ -23,6 +23,7 @@ export default function ModalWarningBanner({
       style={{
         background: "var(--amber-a3)",
         borderTop: "1px solid var(--amber-a5)",
+        borderBottom: "1px solid var(--amber-a5)",
       }}
     >
       <Flex align="center" gap="2" style={{ color: "var(--amber-11)" }}>

--- a/packages/front-end/components/Modal/ModalWarningBanner.tsx
+++ b/packages/front-end/components/Modal/ModalWarningBanner.tsx
@@ -1,0 +1,39 @@
+import { ReactNode } from "react";
+import { Flex } from "@radix-ui/themes";
+import { PiWarningFill } from "react-icons/pi";
+import Text from "@/ui/Text";
+
+// Full-bleed amber strip for a Modal's `aboveFooterContent` slot: a warning
+// message on the left, optional controls (confirm checkbox, action button) on
+// the right.
+export default function ModalWarningBanner({
+  children,
+  controls,
+}: {
+  children: ReactNode;
+  controls?: ReactNode;
+}) {
+  return (
+    <Flex
+      align="center"
+      justify="between"
+      gap="4"
+      px="4"
+      py="2"
+      style={{
+        background: "var(--amber-a3)",
+        borderTop: "1px solid var(--amber-a5)",
+      }}
+    >
+      <Flex align="center" gap="2" style={{ color: "var(--amber-11)" }}>
+        <PiWarningFill size={15} style={{ flexShrink: 0 }} />
+        <Text as="div">{children}</Text>
+      </Flex>
+      {controls ? (
+        <Flex align="center" gap="4" flexShrink="0">
+          {controls}
+        </Flex>
+      ) : null}
+    </Flex>
+  );
+}

--- a/packages/front-end/components/Modal/PagedModal.tsx
+++ b/packages/front-end/components/Modal/PagedModal.tsx
@@ -60,7 +60,6 @@ type Props = {
   // Currently the allowlist for what event props are valid is controlled outside of the codebase.
   // Make sure you've checked that any props you pass here are in the list!
   allowlistedTrackingEventProps?: TrackEventProps;
-  useRadixButton?: boolean;
 };
 
 const PagedModal: FC<Props> = (props) => {

--- a/packages/front-end/components/Modal/PagedModal.tsx
+++ b/packages/front-end/components/Modal/PagedModal.tsx
@@ -43,6 +43,7 @@ type Props = {
   step: number;
   setStep: (step: number) => void;
   secondaryCTA?: ReactElement;
+  aboveFooterContent?: ReactNode;
   className?: string;
   bodyClassName?: string;
   stickyFooter?: boolean;
@@ -80,6 +81,7 @@ const PagedModal: FC<Props> = (props) => {
     forceCtaText,
     inline,
     secondaryCTA,
+    aboveFooterContent,
     size,
     className,
     bodyClassName,
@@ -348,6 +350,7 @@ const PagedModal: FC<Props> = (props) => {
         )
       }
       ctaEnabled={ctaEnabled}
+      aboveFooterContent={aboveFooterContent}
       trackingEventModalType={trackingEventModalType}
       trackingEventModalSource={trackingEventModalSource}
       allowlistedTrackingEventProps={allowlistedTrackingEventProps}

--- a/packages/front-end/components/OfficialResourceModal.tsx
+++ b/packages/front-end/components/OfficialResourceModal.tsx
@@ -22,7 +22,6 @@ export default function OfficialResourceModal({
 }) {
   return (
     <Modal
-      useRadixButton={false}
       open={true}
       trackingEventModalType={`convert-to-official-${resourceType}`}
       trackingEventModalSource={source}

--- a/packages/front-end/components/OpenVisualEditorLink.tsx
+++ b/packages/front-end/components/OpenVisualEditorLink.tsx
@@ -266,7 +266,6 @@ const OpenVisualEditorLink: FC<{
 
       {showEditorUrlDialog && openSettings && (
         <Modal
-          useRadixButton={false}
           trackingEventModalType=""
           open
           header="Visual Editor Target URL"
@@ -284,7 +283,6 @@ const OpenVisualEditorLink: FC<{
 
       {showExtensionDialog && (
         <Modal
-          useRadixButton={false}
           trackingEventModalType=""
           open
           header="GrowthBook Visual Editor Extension"

--- a/packages/front-end/components/PowerCalculation/PowerCalculationSettingsModal/SelectStep.tsx
+++ b/packages/front-end/components/PowerCalculation/PowerCalculationSettingsModal/SelectStep.tsx
@@ -300,7 +300,6 @@ export const SelectStep = ({
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType="power-calculation-select"
       open
       size="lg"

--- a/packages/front-end/components/PowerCalculation/PowerCalculationSettingsModal/SetParamsStep.tsx
+++ b/packages/front-end/components/PowerCalculation/PowerCalculationSettingsModal/SetParamsStep.tsx
@@ -233,9 +233,22 @@ const PopulationDataQueryInput = ({
         <div style={{ flex: 1 }} />
         <div className="col-auto">
           {canRunPopulationQuery && (
-            <form
-              onSubmit={async (e) => {
-                e.preventDefault();
+            <RunQueriesButton
+              icon="refresh"
+              cta={
+                populationData?.status === "success"
+                  ? "Refresh Data"
+                  : "Get Data"
+              }
+              mutate={mutate}
+              model={
+                populationData ?? {
+                  queries: [],
+                  runStarted: new Date(),
+                }
+              }
+              cancelEndpoint={`/population-data/${populationData?.id}/cancel`}
+              onSubmit={async () => {
                 try {
                   form.setValue("customizedMetrics", false);
                   const res = await postPopulationData({
@@ -253,26 +266,7 @@ const PopulationDataQueryInput = ({
                   setError(e.message);
                 }
               }}
-            >
-              <RunQueriesButton
-                useRadixButton={false}
-                icon="refresh"
-                cta={
-                  populationData?.status === "success"
-                    ? "Refresh Data"
-                    : "Get Data"
-                }
-                mutate={mutate}
-                model={
-                  populationData ?? {
-                    queries: [],
-                    runStarted: new Date(),
-                  }
-                }
-                cancelEndpoint={`/population-data/${populationData?.id}/cancel`}
-                color="outline-primary"
-              />
-            </form>
+            />
           )}
         </div>
         <div className="col-auto pl-0">
@@ -432,7 +426,6 @@ export const SetParamsStep = ({
   }
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType="power-calculation-set-params"
       allowlistedTrackingEventProps={{
         source: form.getValues("metricValuesData.source"),

--- a/packages/front-end/components/PowerCalculation/PowerCalculationStatsEngineSettingsModal.tsx
+++ b/packages/front-end/components/PowerCalculation/PowerCalculationStatsEngineSettingsModal.tsx
@@ -65,7 +65,6 @@ export default function PowerCalculationStatsEngineSettingsModal({
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open
       size="lg"

--- a/packages/front-end/components/Queries/AsyncQueriesModal.tsx
+++ b/packages/front-end/components/Queries/AsyncQueriesModal.tsx
@@ -188,7 +188,6 @@ const AsyncQueriesModal: FC<{
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType="async-queries"
       close={close}
       header="Queries"

--- a/packages/front-end/components/Queries/RunQueriesButton.tsx
+++ b/packages/front-end/components/Queries/RunQueriesButton.tsx
@@ -6,7 +6,6 @@ import {
   useState,
 } from "react";
 import { QueryStatus, Queries } from "shared/types/query";
-import clsx from "clsx";
 import { PiPlay, PiArrowClockwise, PiXBold } from "react-icons/pi";
 import { getValidDate } from "shared/dates";
 import { IconButton, Progress, Text } from "@radix-ui/themes";
@@ -71,14 +70,12 @@ type Props = {
   model: { queries: Queries; runStarted: string | Date | undefined | null };
   mutate: () => Promise<unknown> | unknown;
   icon?: "run" | "refresh";
-  color?: string;
   position?: "left" | "right";
   resetFilters?: () => void | Promise<void>;
   radixVariant?: "outline" | "solid" | "soft";
   size?: "sm" | "md";
   onSubmit?: () => void | Promise<void>;
   disabled?: boolean;
-  useRadixButton?: boolean;
 };
 
 const RunQueriesButton = forwardRef<HTMLButtonElement, Props>(
@@ -90,14 +87,12 @@ const RunQueriesButton = forwardRef<HTMLButtonElement, Props>(
       model,
       mutate,
       icon = "run",
-      color = "primary",
       position = "right",
       resetFilters,
       radixVariant = "outline",
       size = "md",
       onSubmit,
       disabled,
-      useRadixButton = true,
     },
     ref: ForwardedRef<HTMLButtonElement>,
   ) => {
@@ -206,51 +201,29 @@ const RunQueriesButton = forwardRef<HTMLButtonElement, Props>(
             </div>
           )}
           <div className="position-relative">
-            {useRadixButton ? (
-              <Button
-                ref={ref}
-                variant={radixVariant}
-                size={size}
-                disabled={status === "running" || disabled}
-                type="button"
-                onClick={async () => {
-                  await resetFilters?.();
-                  await onSubmit?.();
-                }}
-                icon={buttonIcon}
-                style={{
-                  minWidth: size === "sm" ? 90 : 110,
-                }}
-              >
-                {status === "running" ? (
-                  <Text className="small">
-                    {loadingText} ({getTimeDisplay(elapsed)})
-                  </Text>
-                ) : (
-                  <Text>{cta}</Text>
-                )}
-              </Button>
-            ) : (
-              <button
-                ref={ref}
-                className={clsx("btn font-weight-bold my-0", `btn-${color}`, {
-                  disabled: status === "running",
-                })}
-                disabled={status === "running" || disabled}
-                type="submit"
-                onClick={async () => {
-                  await resetFilters?.();
-                  await onSubmit?.();
-                }}
-              >
-                <span className="h4 pr-2 m-0 d-inline-block align-top">
-                  {buttonIcon}
-                </span>
-                {status === "running"
-                  ? `${loadingText} (${getTimeDisplay(elapsed)})...`
-                  : cta}
-              </button>
-            )}
+            <Button
+              ref={ref}
+              variant={radixVariant}
+              size={size}
+              disabled={status === "running" || disabled}
+              type="button"
+              onClick={async () => {
+                await resetFilters?.();
+                await onSubmit?.();
+              }}
+              icon={buttonIcon}
+              style={{
+                minWidth: size === "sm" ? 90 : 110,
+              }}
+            >
+              {status === "running" ? (
+                <Text className="small">
+                  {loadingText} ({getTimeDisplay(elapsed)})
+                </Text>
+              ) : (
+                <Text>{cta}</Text>
+              )}
+            </Button>
             {status === "running" && numQueries > 1 && (
               <Progress
                 value={Math.floor((100 * numFinished) / numQueries)}

--- a/packages/front-end/components/RampSchedule/SafeRolloutRuleDashboard/MetricSection.tsx
+++ b/packages/front-end/components/RampSchedule/SafeRolloutRuleDashboard/MetricSection.tsx
@@ -411,7 +411,6 @@ function SafeRolloutMetricDrilldownModal({
 
   return (
     <Modal
-      useRadixButton={false}
       open={true}
       header={<MetricName metric={metric} officialBadgePosition="right" />}
       subHeader={

--- a/packages/front-end/components/Report/ConfigureLegacyReport.tsx
+++ b/packages/front-end/components/Report/ConfigureLegacyReport.tsx
@@ -184,7 +184,6 @@ export default function ConfigureLegacyReport({
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       inline={true}
       header=""

--- a/packages/front-end/components/Report/LegacyReportPage.tsx
+++ b/packages/front-end/components/Report/LegacyReportPage.tsx
@@ -366,9 +366,13 @@ export default function LegacyReportPage({
                   </div>
                   <div className="col-auto">
                     {canUpdateReport && (
-                      <form
-                        onSubmit={async (e) => {
-                          e.preventDefault();
+                      <RunQueriesButton
+                        icon="refresh"
+                        cta="Refresh Data"
+                        mutate={mutate}
+                        model={report}
+                        cancelEndpoint={`/report/${report.id}/cancel`}
+                        onSubmit={async () => {
                           try {
                             const res = await apiCall<{
                               report: ReportInterface;
@@ -387,17 +391,7 @@ export default function LegacyReportPage({
                             setRefreshError(e.message);
                           }
                         }}
-                      >
-                        <RunQueriesButton
-                          useRadixButton={false}
-                          icon="refresh"
-                          cta="Refresh Data"
-                          mutate={mutate}
-                          model={report}
-                          cancelEndpoint={`/report/${report.id}/cancel`}
-                          color="outline-primary"
-                        />
-                      </form>
+                      />
                     )}
                   </div>
                   <div className="col-auto">

--- a/packages/front-end/components/Report/ReportAnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Report/ReportAnalysisSettingsBar.tsx
@@ -235,7 +235,6 @@ export default function ReportAnalysisSettingsBar({
                 }}
                 model={snapshot}
                 cancelEndpoint={`/report/${report.id}/cancel`}
-                color="outline-primary"
                 radixVariant="soft"
                 onSubmit={async () => {
                   try {

--- a/packages/front-end/components/Reviews/Feature/CompareRevisionsModal.tsx
+++ b/packages/front-end/components/Reviews/Feature/CompareRevisionsModal.tsx
@@ -1012,7 +1012,6 @@ export default function CompareRevisionsModal({
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType="compare-revisions"
       open={true}
       header="Compare revisions"

--- a/packages/front-end/components/Reviews/Feature/RevertModal.tsx
+++ b/packages/front-end/components/Reviews/Feature/RevertModal.tsx
@@ -226,7 +226,6 @@ export default function RevertModal({
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={true}
       header="Revert"

--- a/packages/front-end/components/Revision/CompareRevisionsModal.tsx
+++ b/packages/front-end/components/Revision/CompareRevisionsModal.tsx
@@ -1055,7 +1055,6 @@ export default function CompareRevisionsModal<
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType="compare-revisions"
       open={true}
       header="Compare revisions"

--- a/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
+++ b/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
@@ -248,22 +248,17 @@ export default function EditSqlModal({
       cta="Confirm Changes"
       closeCta="Back"
       secondaryCTA={
-        <Tooltip
-          body="You do not have permission to run test queries"
-          shouldDisplay={!canRunQueries}
-          tipPosition="top"
-        >
-          <label className="mx-4 mb-0">
-            <input
-              type="checkbox"
-              disabled={!canRunQueries}
-              className="form-check-input"
-              checked={testQueryBeforeSaving}
-              onChange={(e) => setTestQueryBeforeSaving(e.target.checked)}
-            />
-            Test query before confirming
-          </label>
-        </Tooltip>
+        <Box mx="4">
+          <Checkbox
+            value={testQueryBeforeSaving}
+            setValue={setTestQueryBeforeSaving}
+            label="Test query before confirming"
+            weight="medium"
+            align="center"
+            disabled={!canRunQueries}
+            disabledMessage="You do not have permission to run test queries"
+          />
+        </Box>
       }
     >
       <Box p="2" style={{ height: "calc(93vh - 140px)" }}>

--- a/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
+++ b/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { FaPlay, FaExclamationTriangle } from "react-icons/fa";
 import { TestQueryRow } from "shared/types/integrations";
 import { TemplateVariables } from "shared/types/sql";
 import { Flex, Text, Box, IconButton } from "@radix-ui/themes";
 import { BsThreeDotsVertical } from "react-icons/bs";
+import { PiPlayFill, PiWarningFill } from "react-icons/pi";
 import { SQL_ROW_LIMIT } from "shared/sql";
 import { parseIntWithDefault } from "shared/util";
 import { useAuth } from "@/services/auth";
@@ -13,7 +13,6 @@ import { validateSQL } from "@/services/datasources";
 import CodeTextArea from "@/components/Forms/CodeTextArea";
 import Modal from "@/components/Modal";
 import DisplayTestQueryResults from "@/components/Settings/DisplayTestQueryResults";
-import Button from "@/components/Button";
 import RadixButton from "@/ui/Button";
 import {
   usesEventName,
@@ -248,7 +247,7 @@ export default function EditSqlModal({
       cta="Confirm Changes"
       closeCta="Back"
       secondaryCTA={
-        <Box mx="4">
+        <Box style={{ marginLeft: 16, marginRight: 24 }}>
           <Checkbox
             value={testQueryBeforeSaving}
             setValue={setTestQueryBeforeSaving}
@@ -278,7 +277,7 @@ export default function EditSqlModal({
                       <Flex gap="3" align="center">
                         {formatError && (
                           <Tooltip body={formatError}>
-                            <FaExclamationTriangle className="text-danger" />
+                            <PiWarningFill style={{ color: "var(--red-11)" }} />
                           </Tooltip>
                         )}
 
@@ -312,19 +311,16 @@ export default function EditSqlModal({
                           body="You do not have permission to run test queries"
                           shouldDisplay={!canRunQueries}
                         >
-                          <Button
-                            color="primary"
-                            className="btn-sm"
+                          <RadixButton
+                            size="sm"
                             onClick={handleTestQuery}
                             loading={testingQuery}
                             disabled={!canRunQueries}
                             type="button"
+                            icon={<PiPlayFill />}
                           >
-                            <span className="pr-2">
-                              <FaPlay />
-                            </span>
                             Test Query
-                          </Button>
+                          </RadixButton>
                         </Tooltip>
                         <DropdownMenu
                           trigger={

--- a/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
+++ b/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
@@ -207,7 +207,6 @@ export default function EditSqlModal({
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open
       header={

--- a/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
+++ b/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
@@ -312,7 +312,7 @@ export default function EditSqlModal({
                           shouldDisplay={!canRunQueries}
                         >
                           <RadixButton
-                            size="sm"
+                            size="md"
                             onClick={handleTestQuery}
                             loading={testingQuery}
                             disabled={!canRunQueries}

--- a/packages/front-end/components/SchemaBrowser/SaveQueryModal.tsx
+++ b/packages/front-end/components/SchemaBrowser/SaveQueryModal.tsx
@@ -67,7 +67,6 @@ export default function SaveQueryModal({
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType="save-query"
       open
       header="Save Query"

--- a/packages/front-end/components/Segments/SegmentForm.tsx
+++ b/packages/front-end/components/Segments/SegmentForm.tsx
@@ -140,7 +140,6 @@ const SegmentForm: FC<{
         />
       )}
       <Modal
-        useRadixButton={false}
         trackingEventModalType=""
         close={close}
         open={true}

--- a/packages/front-end/components/Settings/DataSourceForm.tsx
+++ b/packages/front-end/components/Settings/DataSourceForm.tsx
@@ -189,7 +189,6 @@ const DataSourceForm: FC<{
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       inline={inline}
       open={true}

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceExperimentProperties/DataSourceEditExperimentEventPropertiesModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceExperimentProperties/DataSourceEditExperimentEventPropertiesModal.tsx
@@ -47,7 +47,6 @@ export const DataSourceEditExperimentEventPropertiesModal: FC<
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={true}
       submit={handleSubmit}

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/AddEditIdentityJoinModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/AddEditIdentityJoinModal.tsx
@@ -117,7 +117,6 @@ export const AddEditIdentityJoinModal: FC<AddEditIdentityJoinModalProps> = ({
         />
       )}
       <Modal
-        useRadixButton={false}
         trackingEventModalType=""
         open={true}
         submit={handleSubmit}

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceJupypterQuery/EditJupyterNotebookQueryRunner.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceJupypterQuery/EditJupyterNotebookQueryRunner.tsx
@@ -30,7 +30,6 @@ export const EditJupyterNotebookQueryRunner: FC<
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={true}
       submit={handleSubmit}

--- a/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/DimensionSlicesRunner.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/DimensionSlicesRunner.tsx
@@ -214,7 +214,6 @@ const RefreshData = ({
           mutate={mutate}
           model={dimensionSlices ?? { queries: [], runStarted: undefined }}
           cancelEndpoint={`/dimension-slices/${dimensionSlices?.id}/cancel`}
-          color={`${dimensionSlices ? "outline-" : ""}primary`}
           onSubmit={async () => {
             try {
               setError("");

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
@@ -233,7 +233,6 @@ export const AddEditExperimentAssignmentQueryModal: FC<
       )}
 
       <Modal
-        useRadixButton={false}
         trackingEventModalType=""
         open={true}
         submit={handleSubmit}

--- a/packages/front-end/components/Settings/EditDataSource/FeatureEvaluationQueries/FeatureEvaluationQueryModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/FeatureEvaluationQueries/FeatureEvaluationQueryModal.tsx
@@ -100,7 +100,6 @@ export const FeatureEvaluationQueryModal: FC<FeatureEvaluationQueryProps> = ({
       )}
 
       <Modal
-        useRadixButton={false}
         trackingEventModalType=""
         open={true}
         submit={handleSubmit}

--- a/packages/front-end/components/Settings/EditLicenseModal.tsx
+++ b/packages/front-end/components/Settings/EditLicenseModal.tsx
@@ -25,7 +25,6 @@ const EditLicenseModal: FC<{
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       header="Enter License Key"
       open={true}

--- a/packages/front-end/components/Settings/EnvironmentModal.tsx
+++ b/packages/front-end/components/Settings/EnvironmentModal.tsx
@@ -96,7 +96,6 @@ export default function EnvironmentModal({
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={true}
       close={close}

--- a/packages/front-end/components/Settings/ExperimentCheckListModal.tsx
+++ b/packages/front-end/components/Settings/ExperimentCheckListModal.tsx
@@ -73,7 +73,6 @@ export default function ExperimentCheckListModal({
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={true}
       close={close}

--- a/packages/front-end/components/Settings/NewDataSourceForm.tsx
+++ b/packages/front-end/components/Settings/NewDataSourceForm.tsx
@@ -756,7 +756,6 @@ const NewDataSourceForm: FC<{
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={true}
       header={"Add Data Source"}

--- a/packages/front-end/components/Settings/RestoreConfigYamlButton.tsx
+++ b/packages/front-end/components/Settings/RestoreConfigYamlButton.tsx
@@ -250,7 +250,6 @@ export default function RestoreConfigYamlButton({
     <div>
       {open && (
         <PagedModal
-          useRadixButton={false}
           trackingEventModalType="import-settings-config-yaml"
           close={() => setOpen(false)}
           header="Import from config.yml"

--- a/packages/front-end/components/Settings/SubscriptionInfo.tsx
+++ b/packages/front-end/components/Settings/SubscriptionInfo.tsx
@@ -239,7 +239,6 @@ export default function SubscriptionInfo() {
       )}
       {showCancellationSurveyModal && (
         <Modal
-          useRadixButton={false}
           open={true}
           header={null}
           trackingEventModalType="cancellation-survey"
@@ -270,7 +269,6 @@ export default function SubscriptionInfo() {
       )}
       {cancelSubscriptionModal && (
         <Modal
-          useRadixButton={false}
           open={true}
           header="Are you sure you want to cancel?"
           trackingEventModalType="cancel-subscription"

--- a/packages/front-end/components/Settings/Team/AddOrphanedUserModal.tsx
+++ b/packages/front-end/components/Settings/Team/AddOrphanedUserModal.tsx
@@ -49,7 +49,6 @@ const AddOrphanedUserModal: FC<{
   ) {
     return (
       <Modal
-        useRadixButton={false}
         trackingEventModalType=""
         open={true}
         close={close}
@@ -70,7 +69,6 @@ const AddOrphanedUserModal: FC<{
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       close={close}
       header="Add User"

--- a/packages/front-end/components/Settings/Team/AdminSetPasswordModal.tsx
+++ b/packages/front-end/components/Settings/Team/AdminSetPasswordModal.tsx
@@ -20,7 +20,6 @@ export default function AdminSetPasswordModal({ member, close }: Props) {
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       close={close}
       header="Change Password"

--- a/packages/front-end/components/Settings/Team/InviteModal.tsx
+++ b/packages/front-end/components/Settings/Team/InviteModal.tsx
@@ -87,7 +87,6 @@ const InviteModal = ({ mutate, close, defaultRole }: Props) => {
   if (showContactSupport) {
     return (
       <Modal
-        useRadixButton={false}
         trackingEventModalType=""
         open={true}
         close={close}
@@ -168,7 +167,6 @@ const InviteModal = ({ mutate, close, defaultRole }: Props) => {
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       close={close}
       header="Invite Member"

--- a/packages/front-end/components/Settings/UpdateOrbSubscriptionModal.tsx
+++ b/packages/front-end/components/Settings/UpdateOrbSubscriptionModal.tsx
@@ -180,7 +180,6 @@ export default function UpdateOrbSubscriptionModal({
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType="update-orb-subscription"
       open={true}
       close={close}

--- a/packages/front-end/components/Settings/UpgradeModal/CloudTrialConfirmationModal.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/CloudTrialConfirmationModal.tsx
@@ -15,7 +15,6 @@ export default function CloudTrialConfirmationModal({
 }: Props) {
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={true}
       close={close}

--- a/packages/front-end/components/Settings/UpgradeModal/LicenseSuccessModal.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/LicenseSuccessModal.tsx
@@ -16,7 +16,6 @@ export default function LicenseSuccessModal({
 }: Props) {
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={true}
       cta="Invite Members"

--- a/packages/front-end/components/Settings/UpgradeModal/PleaseVerifyEmailModal.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/PleaseVerifyEmailModal.tsx
@@ -61,7 +61,6 @@ export default function PleaseVerifyEmailModal({
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={true}
       cta="Close"

--- a/packages/front-end/components/Settings/UpgradeModal/SelfHostedTrialConfirmationModal.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/SelfHostedTrialConfirmationModal.tsx
@@ -25,7 +25,6 @@ export default function SelfHostedTrialConfirmationModal({
   });
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={true}
       includeCloseCta={false}

--- a/packages/front-end/components/Settings/UpgradeModal/VerifyingEmailModal.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/VerifyingEmailModal.tsx
@@ -70,7 +70,6 @@ export default function VerifyingEmailModal() {
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={true}
       cta="Invite Members"

--- a/packages/front-end/components/Settings/UpgradeModal/index.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/index.tsx
@@ -677,7 +677,6 @@ export default function UpgradeModal({
   if (accountPlan === "enterprise") {
     return (
       <Modal
-        useRadixButton={false}
         trackingEventModalType="upgrade-modal"
         allowlistedTrackingEventProps={trackContext}
         open={true}
@@ -769,7 +768,6 @@ export default function UpgradeModal({
         </StripeProvider>
       ) : orgIsManagedByVercel ? (
         <Modal
-          useRadixButton={false}
           trackingEventModalType="upgrade-modal"
           allowlistedTrackingEventProps={trackContext}
           open={true}
@@ -813,7 +811,6 @@ export default function UpgradeModal({
         </Modal>
       ) : (
         <Modal
-          useRadixButton={false}
           trackingEventModalType="upgrade-modal"
           allowlistedTrackingEventProps={trackContext}
           open={true}

--- a/packages/front-end/components/Settings/WebhooksModal.tsx
+++ b/packages/front-end/components/Settings/WebhooksModal.tsx
@@ -219,7 +219,6 @@ export function CreateSDKWebhookModal({
         />
       )}
       <Modal
-        useRadixButton={false}
         trackingEventModalType=""
         close={close}
         header="Create New SDK Webhook"
@@ -616,7 +615,6 @@ const EditSDKWebhooksModal: FC<{
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       close={close}
       header={current.id ? "Update Webhook" : "Create New Webhook"}

--- a/packages/front-end/components/SlackIntegrations/SlackIntegrationAddEditModal/SlackIntegrationAddEditModal.tsx
+++ b/packages/front-end/components/SlackIntegrations/SlackIntegrationAddEditModal/SlackIntegrationAddEditModal.tsx
@@ -110,7 +110,6 @@ export const SlackIntegrationAddEditModal: FC<
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       header={modalTitle}
       cta={buttonText}

--- a/packages/front-end/enterprise/components/AIChat/ChatSearchModal.tsx
+++ b/packages/front-end/enterprise/components/AIChat/ChatSearchModal.tsx
@@ -109,7 +109,6 @@ export default function ChatSearchModal({
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       header="Search chats"
       close={onClose}

--- a/packages/front-end/enterprise/components/AIChat/ConversationSidebar.tsx
+++ b/packages/front-end/enterprise/components/AIChat/ConversationSidebar.tsx
@@ -56,7 +56,6 @@ export default function ConversationSidebar({
 
       {confirmDeleteId && onDelete && (
         <Modal
-          useRadixButton={false}
           trackingEventModalType=""
           header="Delete conversation"
           close={() => setConfirmDeleteId(null)}

--- a/packages/front-end/enterprise/components/Billing/CloudProUpgradeModal.tsx
+++ b/packages/front-end/enterprise/components/Billing/CloudProUpgradeModal.tsx
@@ -242,7 +242,6 @@ export default function CloudProUpgradeModal({ close, closeParent }: Props) {
   if (success) {
     return (
       <Modal
-        useRadixButton={false}
         header={null}
         close={() => {
           close();
@@ -313,7 +312,6 @@ export default function CloudProUpgradeModal({ close, closeParent }: Props) {
 
   return (
     <PagedModal
-      useRadixButton={false}
       trackingEventModalType="upgrade-to-pro"
       trackingEventModalSource="upgrade-modal"
       hideNav={true}

--- a/packages/front-end/enterprise/components/Billing/PaymentInfo.tsx
+++ b/packages/front-end/enterprise/components/Billing/PaymentInfo.tsx
@@ -132,7 +132,6 @@ export default function PaymentInfo() {
       ) : null}
       {defaultPaymentMethod ? (
         <Modal
-          useRadixButton={false}
           header="Update default payment method"
           open={true}
           cta="Set as default payment method"

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardEditorSidebar/EditSingleBlock.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardEditorSidebar/EditSingleBlock.tsx
@@ -814,7 +814,6 @@ export default function EditSingleBlock({
     <>
       {savedQuery && showDeleteSavedQueryConfirmation && (
         <Modal
-          useRadixButton={false}
           trackingEventModalType=""
           header={"Delete Saved Query?"}
           close={() => setShowDeleteSavedQueryConfirmation(false)}

--- a/packages/front-end/enterprise/components/Dashboards/DashboardModal.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardModal.tsx
@@ -191,7 +191,6 @@ export default function DashboardModal({
 
   return (
     <Modal
-      useRadixButton={false}
       open={true}
       size="md"
       trackingEventModalType={`${mode}-dashboard`}

--- a/packages/front-end/pages/admin.tsx
+++ b/packages/front-end/pages/admin.tsx
@@ -163,7 +163,6 @@ function OrganizationRow({
       )}
       {clickhouseModalOpen && (
         <Modal
-          useRadixButton={false}
           open={true}
           header="Create Clickhouse Data Source"
           close={() => setClickhouseModalOpen(false)}
@@ -939,7 +938,6 @@ const EditMember: FC<{
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       submit={handleSubmit}
       open={true}
@@ -1154,7 +1152,6 @@ function EditSSOModal({
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       submit={form.handleSubmit(async (data) => {
         const payload = generateSSOConnection({

--- a/packages/front-end/pages/attributes/[property].tsx
+++ b/packages/front-end/pages/attributes/[property].tsx
@@ -198,7 +198,6 @@ export default function AttributeDetailPage() {
     <>
       {showReferencesModal && (
         <Modal
-          useRadixButton={false}
           open={true}
           header={`References: ${attribute.property}`}
           close={() => setShowReferencesModal(false)}
@@ -223,7 +222,6 @@ export default function AttributeDetailPage() {
       )}
       {showDeleteModal && (
         <Modal
-          useRadixButton={false}
           open={true}
           header="Delete Attribute"
           close={() => setShowDeleteModal(false)}

--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -505,7 +505,6 @@ export default function FactMetricPage() {
     <div className="pagecontents container-fluid">
       {auditModal && (
         <Modal
-          useRadixButton={false}
           trackingEventModalType=""
           open={true}
           header="Audit Log"
@@ -534,7 +533,6 @@ export default function FactMetricPage() {
       )}
       {showDeleteModal && (
         <Modal
-          useRadixButton={false}
           trackingEventModalType=""
           header={`Delete Metric`}
           close={() => setShowDeleteModal(false)}

--- a/packages/front-end/pages/fact-tables/[ftid].tsx
+++ b/packages/front-end/pages/fact-tables/[ftid].tsx
@@ -248,7 +248,6 @@ export default function FactTablePage() {
       )}
       {auditModal && (
         <Modal
-          useRadixButton={false}
           trackingEventModalType=""
           open={true}
           header="Audit Log"

--- a/packages/front-end/pages/metric/[mid].tsx
+++ b/packages/front-end/pages/metric/[mid].tsx
@@ -661,9 +661,13 @@ const MetricPage: FC = () => {
                       <div style={{ flex: 1 }} />
                       <div className="col-auto">
                         {canRunMetricQuery && (
-                          <form
-                            onSubmit={async (e) => {
-                              e.preventDefault();
+                          <RunQueriesButton
+                            icon="refresh"
+                            cta={analysis ? "Refresh Data" : "Run Analysis"}
+                            mutate={mutate}
+                            model={metric}
+                            cancelEndpoint={`/metric/${metric.id}/analysis/cancel`}
+                            onSubmit={async () => {
                               try {
                                 await apiCall(`/metric/${metric.id}/analysis`, {
                                   method: "POST",
@@ -673,17 +677,7 @@ const MetricPage: FC = () => {
                                 console.error(e);
                               }
                             }}
-                          >
-                            <RunQueriesButton
-                              useRadixButton={false}
-                              icon="refresh"
-                              cta={analysis ? "Refresh Data" : "Run Analysis"}
-                              mutate={mutate}
-                              model={metric}
-                              cancelEndpoint={`/metric/${metric.id}/analysis/cancel`}
-                              color="outline-primary"
-                            />
-                          </form>
+                          />
                         )}
                       </div>
                     </div>

--- a/packages/front-end/pages/presentations.tsx
+++ b/packages/front-end/pages/presentations.tsx
@@ -286,7 +286,6 @@ const PresentationPage = (): React.ReactElement => {
       />
       {sharableLinkModal && (
         <Modal
-          useRadixButton={false}
           trackingEventModalType=""
           open={true}
           header={"Sharable link"}

--- a/packages/front-end/pages/reset-password.tsx
+++ b/packages/front-end/pages/reset-password.tsx
@@ -56,7 +56,6 @@ export default function ResetPasswordPage(): ReactElement {
 
   return (
     <Modal
-      useRadixButton={false}
       trackingEventModalType=""
       open={true}
       autoCloseOnSubmit={false}

--- a/packages/front-end/pages/saved-groups/[sgid].tsx
+++ b/packages/front-end/pages/saved-groups/[sgid].tsx
@@ -527,7 +527,6 @@ export default function EditSavedGroupPage() {
       )}
       {deleteItemsModal && (
         <Modal
-          useRadixButton={false}
           trackingEventModalType="delete-saved-group-items"
           close={() => setDeleteItemsModal(false)}
           open={deleteItemsModal}
@@ -647,7 +646,6 @@ export default function EditSavedGroupPage() {
       )}
       {addItems && (
         <Modal
-          useRadixButton={false}
           trackingEventModalType={`edit-saved-group-${importOperation}-items`}
           close={() => {
             setAddItems(false);

--- a/packages/front-end/pages/settings/custom-markdown.tsx
+++ b/packages/front-end/pages/settings/custom-markdown.tsx
@@ -101,7 +101,6 @@ const CustomMarkdown: React.FC = () => {
         </DocLink>
       </p>
       <Modal
-        useRadixButton={false}
         trackingEventModalType=""
         cta={"Save"}
         header={false}

--- a/packages/front-end/pages/setup/index.tsx
+++ b/packages/front-end/pages/setup/index.tsx
@@ -114,7 +114,6 @@ export default function SetupFlow() {
         </h1>
       )}
       <PagedModal
-        useRadixButton={false}
         trackingEventModalType="setup-growthbook"
         header={""}
         submit={async () => {}}

--- a/packages/front-end/services/auth.tsx
+++ b/packages/front-end/services/auth.tsx
@@ -306,7 +306,6 @@ export const AuthProvider: React.FC<{
       if (resp.confirm) {
         setAuthComponent(
           <Modal
-            useRadixButton={false}
             trackingEventModalType=""
             open={true}
             submit={async () => {
@@ -614,7 +613,6 @@ export const AuthProvider: React.FC<{
   if (initError) {
     return (
       <Modal
-        useRadixButton={false}
         trackingEventModalType=""
         header="logo"
         open={true}
@@ -641,7 +639,6 @@ export const AuthProvider: React.FC<{
   if (sessionError) {
     return (
       <Modal
-        useRadixButton={false}
         trackingEventModalType=""
         open={true}
         cta="OK"

--- a/packages/front-end/ui/Checkbox.tsx
+++ b/packages/front-end/ui/Checkbox.tsx
@@ -11,6 +11,9 @@ export type Size = SharedSize<"sm" | "md" | "lg">;
 
 export type Props = {
   label?: string | ReactElement;
+  // Vertical alignment of the box against the label. Defaults to the flex
+  // default (stretch); "center" suits single-line labels in toolbars/banners.
+  align?: "start" | "center";
   labelSize?: SharedSize<"sm" | "md" | "lg">;
   id?: string;
   disabled?: boolean;
@@ -30,6 +33,7 @@ export type Props = {
 export default forwardRef<HTMLLabelElement, Props>(function Checkbox(
   {
     label,
+    align,
     labelSize = "md",
     id,
     disabled,
@@ -78,7 +82,7 @@ export default forwardRef<HTMLLabelElement, Props>(function Checkbox(
       )}
       {...containerProps}
     >
-      <Flex gap="2" align={description || error ? undefined : "center"}>
+      <Flex gap="2" align={align}>
         {checkboxTooltip && !disabled ? (
           <RadixTooltip content={checkboxTooltip} side="top" maxWidth="240px">
             {checkboxEl}

--- a/packages/front-end/ui/Checkbox.tsx
+++ b/packages/front-end/ui/Checkbox.tsx
@@ -78,7 +78,7 @@ export default forwardRef<HTMLLabelElement, Props>(function Checkbox(
       )}
       {...containerProps}
     >
-      <Flex gap="2">
+      <Flex gap="2" align={description || error ? undefined : "center"}>
         {checkboxTooltip && !disabled ? (
           <RadixTooltip content={checkboxTooltip} side="top" maxWidth="240px">
             {checkboxEl}


### PR DESCRIPTION
Replaces the ramp page's traffic-impact callout with a full-bleed warning banner above the modal CTAs, and blocks Save to Draft until it's acknowledged.

- Warns when saving a ramp-up would override an already-published rule, and where unenrolled users will land.
- **Ramp to new value** stays available as an escape hatch on the banner.
- Acknowledgment is bound to the specific impact — editing the ramp into a different impact re-arms the gate. Ramps that were already saved open pre-acknowledged.
- Adds an `aboveFooterContent` slot to Modal/PagedModal.

<img width="835" height="983" alt="image" src="https://github.com/user-attachments/assets/a8e8ebe3-04b7-4a50-8049-74c474cd8679" />

<img width="833" height="1024" alt="image" src="https://github.com/user-attachments/assets/377478bb-c5f8-43f2-9120-cf877bf9efd4" />

