### PR TITLE
fix(front-end): do not fabricate today as the end date for stopped experiments with no phase end date

### DIFF
--- a/packages/front-end/components/Experiment/CompletedExperimentList.tsx
+++ b/packages/front-end/components/Experiment/CompletedExperimentList.tsx
@@ -205,6 +205,7 @@ const CompletedExperimentList = ({
             const moreGoalMetrics = e.goalMetrics.length > 2;
 
             const experimentProjects = e.project ? [e.project] : [];
+            const expEndDate = experimentDate(e);
             return (
               <Box key={e.trackingKey} className="appbox" mb="4" p="6" pt="5">
                 <Flex align="center" mb="4">
@@ -276,9 +277,7 @@ const CompletedExperimentList = ({
                               ? date(e.phases?.[0]?.dateStarted)
                               : "") +
                               " - " +
-                              (experimentDate(e)
-                                ? date(experimentDate(e))
-                                : "")}
+                              (expEndDate ? date(expEndDate) : "")}
                           </Box>
                         </Flex>
                         <Flex gap="2">

--- a/packages/front-end/components/Experiment/ExperimentsListTable.tsx
+++ b/packages/front-end/components/Experiment/ExperimentsListTable.tsx
@@ -209,17 +209,23 @@ const ExperimentsListTable: React.FC<ExperimentsListTableProps> = ({
                 />
               </TableCell>
               <TableCell>{e.ownerName ?? <em>None</em>}</TableCell>
-              <TableCell title={datetime(e.date)}>
-                {e.tab === "running"
-                  ? "started"
-                  : e.tab === "drafts"
-                    ? "created"
-                    : e.tab === "stopped"
-                      ? "ended"
-                      : e.tab === "archived"
-                        ? "updated"
-                        : ""}{" "}
-                {date(e.date)}
+              <TableCell title={e.date ? datetime(e.date) : undefined}>
+                {e.date ? (
+                  <>
+                    {e.tab === "running"
+                      ? "started"
+                      : e.tab === "drafts"
+                        ? "created"
+                        : e.tab === "stopped"
+                          ? "ended"
+                          : e.tab === "archived"
+                            ? "updated"
+                            : ""}{" "}
+                    {date(e.date)}
+                  </>
+                ) : e.tab === "stopped" ? (
+                  <em>no end date</em>
+                ) : null}
               </TableCell>
               {needsStatusColumn ? (
                 <TableCell>

--- a/packages/front-end/components/Experiment/TabbedPage/ProjectTagBar.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ProjectTagBar.tsx
@@ -86,13 +86,15 @@ export default function ProjectTagBar({
       : toUTCDate(lastPhase?.dateStarted ?? "");
     const endDate = lastPhase?.dateEnded
       ? toUTCDate(lastPhase.dateEnded)
-      : "now";
+      : experiment.status === "running"
+        ? "now"
+        : null;
 
     if (!startDate) {
       return "not started";
     }
 
-    return `${startDate} - ${endDate}`;
+    return `${startDate} - ${endDate ?? "unknown"}`;
   };
 
   const renderTotalRuntimeTooltip = (): JSX.Element | string => {

--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -169,16 +169,25 @@ export const compareRows = (
   return sortDirection === "desc" ? -comparisonResult : comparisonResult;
 };
 
-export function experimentDate(exp: ExperimentInterfaceStringDates): string {
-  return (
-    (exp.archived
-      ? exp.dateUpdated
-      : exp.status === "running"
-        ? exp.phases?.[exp.phases?.length - 1]?.dateStarted
-        : exp.status === "stopped"
-          ? exp.phases?.[exp.phases?.length - 1]?.dateEnded
-          : exp.dateCreated) ?? new Date().toISOString() // fallback to now
-  );
+export function experimentDate(
+  exp: ExperimentInterfaceStringDates,
+): string | undefined {
+  if (exp.archived) return exp.dateUpdated;
+  if (exp.status === "running") {
+    // A running experiment with no phase start date effectively just started,
+    // so "now" is an honest fallback (same gating DateGraph uses).
+    return (
+      exp.phases?.[exp.phases?.length - 1]?.dateStarted ??
+      new Date().toISOString()
+    );
+  }
+  if (exp.status === "stopped") {
+    // Several stop paths never close the phase, so dateEnded can be absent.
+    // Returning undefined (no fabricated "now") lets the list show the gap
+    // and sort these rows last instead of as if they ended today.
+    return exp.phases?.[exp.phases?.length - 1]?.dateEnded;
+  }
+  return exp.dateCreated;
 }
 
 /**
@@ -514,6 +523,7 @@ export function useExperimentSearch({
     defaultSortDir,
     updateSearchQueryOnChange: controlledSearchValue === undefined,
     controlledSearchValue,
+    undefinedLast: true,
     searchFields: ["name^3", "trackingKey^2", "hypothesis^2", "description"],
     searchTermFilters: {
       is: (item) => {

--- a/packages/shared/types/experiment.d.ts
+++ b/packages/shared/types/experiment.d.ts
@@ -227,7 +227,7 @@ export type ComputedExperimentInterface = ExperimentInterfaceStringDates & {
   projectName?: string;
   projectIsDeReferenced?: string | boolean;
   tab: string;
-  date: string;
+  date: string | undefined;
   statusSortOrder: number;
   statusIndicator: StatusIndicatorData;
   isWatched?: boolean;


### PR DESCRIPTION
Fixes #6900.

## Root cause (the reporter's, confirmed at main)

@august-growthbook traced this with file:line citations; verified independently:

1. `services/experiments.ts` `experimentDate()`: the `?? new Date().toISOString()` fallback fabricates "now" for a stopped experiment whose last phase has no `dateEnded` (regression from #4342, v4.1.0, which changed `?? ""` to `?? now` to fix Date sort).
2. The fabricated value is both the rendered "ended <today>" (`ExperimentsListTable.tsx`) and the Date sort key (`useExperimentSearch`), which also made the `undefinedLast` branch in `services/search.tsx` unreachable.
3. `ProjectTagBar.tsx` prints a literal "now" for the runtime end regardless of status; `Metrics/DateGraph.tsx` already gates its equivalent on `status === "running"` - this patch mirrors that pattern.

## Fix (5 files, +44/-27) - display only

- `experimentDate()` returns `string | undefined`; the now-fallback is kept only for **running** experiments (honest there: a running experiment with no phase start effectively just started). Stopped experiments return the real `dateEnded` or `undefined`.
- `useExperimentSearch` passes `undefinedLast: true`, so undated rows sort last instead of as-if-ended-today.
- `ExperimentsListTable.tsx`: stopped rows with no date render *no end date* (tooltip guarded).
- `CompletedExperimentList.tsx`: hoisted `experimentDate(e)` to a const for the new TS narrowing; behavior unchanged.
- `ProjectTagBar.tsx`: "now" only when running; stopped-no-date renders `<start> - unknown` (wording choice - happy to take maintainers' preferred phrasing).
- `shared/types/experiment.d.ts`: `ComputedExperimentInterface.date` widened to `string | undefined` (checked-in declaration the front-end imports).

**Scope deliberately display-only**, matching the reporter's own split: the write-side (every stop path closing the phase) plus a backfill is a maintainer call - the diagnosis for it is in the issue comment.

## Verification

Red/green proof, run for real: `experimentDate()` extracted from pristine and patched source (esbuild, node), 6 fixtures - stopped+no-`dateEnded` returns a fabricated "now" pre-patch and `undefined` post-patch; stopped-with-date, running, draft, archived, and stopped-no-phases behave identically pre/post except that stopped-no-phases also stops fabricating. **Not run:** full jest/tsc (monorepo dependency graph) - disclosed; the change is mechanical and every touched API (`undefinedLast` comparator branch in `services/search.tsx`, including the both-undefined fall-through) was verified in source at `main` (e09ce5c).

> Built by breken, your AI support engineer - breken.ai - this one's on us.
