### PR TITLE
fix(sdk-payload): stop infinite recursion on a prerequisite cycle

### DIFF
--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -3592,6 +3592,20 @@ function prerequisiteListsDiffer(
 }
 
 // Only keep features that are "on" or "conditional". For "on" features, remove any top level prerequisites
+const logCyclicPrerequisite = (
+  prereqFeature: FeatureInterface,
+  environment: string,
+) => {
+  logger.warn(
+    {
+      organization: prereqFeature.organization,
+      feature: prereqFeature.id,
+      environment,
+    },
+    "Cyclic prerequisite detected during SDK payload generation; features and rules gated on it are omitted",
+  );
+};
+
 export const reduceFeaturesWithPrerequisites = (
   features: FeatureInterface[],
   environment: string,
@@ -3623,6 +3637,9 @@ export const reduceFeaturesWithPrerequisites = (
             undefined,
             true,
           );
+          if (state.state === "cyclic") {
+            logCyclicPrerequisite(prereqFeature, environment);
+          }
         }
         prereqStateCache[prereq.id] = state;
       }
@@ -3767,6 +3784,9 @@ const getInlinePrerequisitesReductionInfo = (
           undefined,
           true,
         );
+        if (state.state === "cyclic") {
+          logCyclicPrerequisite(prereqFeature, environment);
+        }
       }
       prereqStateCache[pc.id] = state;
     }

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -3591,7 +3591,6 @@ function prerequisiteListsDiffer(
   return false;
 }
 
-// Only keep features that are "on" or "conditional". For "on" features, remove any top level prerequisites
 const logCyclicPrerequisite = (
   prereqFeature: FeatureInterface,
   environment: string,
@@ -3606,6 +3605,7 @@ const logCyclicPrerequisite = (
   );
 };
 
+// Only keep features that are "on" or "conditional". For "on" features, remove any top level prerequisites
 export const reduceFeaturesWithPrerequisites = (
   features: FeatureInterface[],
   environment: string,

--- a/packages/back-end/test/prerequisites.test.ts
+++ b/packages/back-end/test/prerequisites.test.ts
@@ -2,6 +2,7 @@ import cloneDeep from "lodash/cloneDeep";
 import { evaluatePrerequisiteState } from "shared/util";
 import { FeatureInterface, FeatureRule } from "shared/types/feature";
 import { generateFeaturesPayload } from "back-end/src/services/features";
+import { logger } from "back-end/src/util/logger";
 
 // Test-local normalizer: these fixtures were authored in the v1 shape
 // (rules under environmentSettings[env].rules). The production JIT
@@ -159,9 +160,7 @@ describe("Prerequisite reduction in SDK Payload", () => {
       ).state,
     ).toEqual("cyclic");
 
-    // With the "prerequisites" capability a feature whose prerequisite is
-    // merely "conditional" would be kept (with an inline gating rule), so
-    // absence here pins the "cyclic" branch specifically.
+    // Conditional prerequisites would survive with this capability enabled.
     const payload = generateFeaturesPayload({
       features: features.map(normalizeV1Fixture),
       environment: "production",
@@ -200,6 +199,101 @@ describe("Prerequisite reduction in SDK Payload", () => {
       capabilities: ["prerequisites"],
     });
     expect(payload).not.toHaveProperty("parent1");
+  });
+
+  it("Removes a rule gated on a cycle while preserving the default and unrelated rules", () => {
+    const features: FeatureInterface[] = [
+      {
+        ...cloneDeep(childFeature),
+        defaultValue: "false",
+        prerequisites: [],
+        rules: [
+          {
+            type: "force",
+            description: "",
+            enabled: true,
+            allEnvironments: true,
+            value: "true",
+            prerequisites: [{ id: "parent1", condition: '{"value": true}' }],
+          },
+          {
+            type: "force",
+            description: "",
+            enabled: true,
+            allEnvironments: true,
+            value: "true",
+            condition: '{"country": "US"}',
+          },
+        ],
+      },
+      {
+        ...cloneDeep(parentFeature),
+        prerequisites: [{ id: "parent1", condition: '{"value": true}' }],
+      },
+    ];
+
+    const payload = generateFeaturesPayload({
+      features,
+      environment: "production",
+      groupMap: new Map(),
+      experimentMap: new Map(),
+      safeRolloutMap: new Map(),
+      holdoutsMap: new Map(),
+      capabilities: ["prerequisites"],
+    });
+
+    expect(payload).not.toHaveProperty("parent1");
+    expect(payload.child1).toEqual({
+      defaultValue: false,
+      rules: [{ force: true, condition: { country: "US" } }],
+    });
+  });
+
+  it("Warns once per cyclic prerequisite per payload build across features and rules", () => {
+    const warn = jest.spyOn(logger, "warn").mockImplementation(() => {});
+    const features: FeatureInterface[] = [
+      {
+        ...cloneDeep(childFeature),
+        id: "rule-consumer",
+        prerequisites: [],
+        rules: [
+          {
+            type: "force",
+            description: "",
+            enabled: true,
+            allEnvironments: true,
+            value: "true",
+            prerequisites: [{ id: "parent1", condition: '{"value": true}' }],
+          },
+        ],
+      },
+      cloneDeep(childFeature),
+      {
+        ...cloneDeep(parentFeature),
+        prerequisites: [{ id: "parent1", condition: '{"value": true}' }],
+      },
+    ];
+
+    try {
+      for (let build = 1; build <= 2; build++) {
+        generateFeaturesPayload({
+          features,
+          environment: "production",
+          groupMap: new Map(),
+          experimentMap: new Map(),
+          safeRolloutMap: new Map(),
+          holdoutsMap: new Map(),
+          capabilities: ["prerequisites"],
+        });
+        expect(warn).toHaveBeenCalledTimes(build);
+      }
+      expect(warn).toHaveBeenCalledWith(
+        { organization: "123", feature: "parent1", environment: "production" },
+        expect.any(String),
+      );
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("Does not block when top-level prerequisite has conditional state, creates inline gating rule", () => {

--- a/packages/back-end/test/prerequisites.test.ts
+++ b/packages/back-end/test/prerequisites.test.ts
@@ -138,6 +138,70 @@ describe("Prerequisite reduction in SDK Payload", () => {
     expect(payload).not.toHaveProperty("child1");
   });
 
+  it("Blocks features whose top-level prerequisites form a cycle and keeps the rest of the payload", () => {
+    const features: FeatureInterface[] = [
+      cloneDeep(childFeature),
+      {
+        ...cloneDeep(parentFeature),
+        prerequisites: [{ id: "child1", condition: `{"value": true}` }],
+      },
+      { ...cloneDeep(parentFeature), id: "unrelated1" },
+    ];
+
+    const featuresMap = new Map(features.map((f) => [f.id, f]));
+    expect(
+      evaluatePrerequisiteState(
+        features[0],
+        featuresMap,
+        "production",
+        undefined,
+        true,
+      ).state,
+    ).toEqual("cyclic");
+
+    // With the "prerequisites" capability a feature whose prerequisite is
+    // merely "conditional" would be kept (with an inline gating rule), so
+    // absence here pins the "cyclic" branch specifically.
+    const payload = generateFeaturesPayload({
+      features: features.map(normalizeV1Fixture),
+      environment: "production",
+      groupMap: new Map(),
+      experimentMap: new Map(),
+      capabilities: ["prerequisites"],
+    });
+    expect(payload).not.toHaveProperty("parent1");
+    expect(payload).not.toHaveProperty("child1");
+    expect(payload).toHaveProperty("unrelated1");
+  });
+
+  it("Blocks a feature that lists itself as a prerequisite", () => {
+    const features: FeatureInterface[] = [
+      {
+        ...cloneDeep(parentFeature),
+        prerequisites: [{ id: "parent1", condition: `{"value": true}` }],
+      },
+    ];
+    const featuresMap = new Map(features.map((f) => [f.id, f]));
+    expect(
+      evaluatePrerequisiteState(
+        features[0],
+        featuresMap,
+        "production",
+        undefined,
+        true,
+      ).state,
+    ).toEqual("cyclic");
+
+    const payload = generateFeaturesPayload({
+      features: features.map(normalizeV1Fixture),
+      environment: "production",
+      groupMap: new Map(),
+      experimentMap: new Map(),
+      capabilities: ["prerequisites"],
+    });
+    expect(payload).not.toHaveProperty("parent1");
+  });
+
   it("Does not block when top-level prerequisite has conditional state, creates inline gating rule", () => {
     const features: FeatureInterface[] = [
       cloneDeep(childFeature),

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -2538,9 +2538,7 @@ export function evaluatePrerequisiteState(
       return { state: "cyclic", value: null };
   }
 
-  // Features on the current prerequisite path. Callers that pass
-  // `skipCyclicCheck` (the SDK payload builder) rely on this to terminate on
-  // a cycle instead of recursing until the stack overflows.
+  // Guard recursion even when payload generation skips the full cycle check.
   const visiting = new Set<string>();
   const visit = (feature: FeatureInterface): PrerequisiteStateResult => {
     if (visiting.has(feature.id)) return { state: "cyclic", value: null };

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -2538,7 +2538,13 @@ export function evaluatePrerequisiteState(
       return { state: "cyclic", value: null };
   }
 
+  // Features on the current prerequisite path. Callers that pass
+  // `skipCyclicCheck` (the SDK payload builder) rely on this to terminate on
+  // a cycle instead of recursing until the stack overflows.
+  const visiting = new Set<string>();
   const visit = (feature: FeatureInterface): PrerequisiteStateResult => {
+    if (visiting.has(feature.id)) return { state: "cyclic", value: null };
+
     // 1. Current environment toggles take priority
     if (!feature.environmentSettings[env]) {
       return { state: "deterministic", value: null };
@@ -2592,6 +2598,7 @@ export function evaluatePrerequisiteState(
     //  - if any are "conditional", the feature is "conditional"
     isTopLevel = false;
     const prerequisites = feature.prerequisites || [];
+    visiting.add(feature.id);
     for (const prerequisite of prerequisites) {
       const prerequisiteFeature = featuresMap.get(prerequisite.id);
       if (!prerequisiteFeature) {
@@ -2602,6 +2609,9 @@ export function evaluatePrerequisiteState(
       }
       const { state: prerequisiteState, value: prerequisiteValue } =
         visit(prerequisiteFeature);
+      if (prerequisiteState === "cyclic") {
+        return { state: "cyclic", value: null };
+      }
       if (prerequisiteState === "deterministic") {
         const evaled = evalDeterministicPrereqValue(
           prerequisiteValue ?? null,
@@ -2618,6 +2628,7 @@ export function evaluatePrerequisiteState(
         value = undefined;
       }
     }
+    visiting.delete(feature.id);
 
     return { state, value };
   };

--- a/packages/shared/test/util/features.test.ts
+++ b/packages/shared/test/util/features.test.ts
@@ -51,6 +51,7 @@ import {
   stripDefaultsForSparse,
   expandSparseToFull,
   draftHasChangesOutsideTargetRef,
+  evaluatePrerequisiteState,
 } from "../../src/util";
 import type { RampScheduleInterface } from "../../src/validators/ramp-schedule";
 
@@ -4491,6 +4492,88 @@ describe("sparse JSON rule helpers", () => {
         JSON.parse(full),
       );
     });
+  });
+});
+
+describe("evaluatePrerequisiteState", () => {
+  const makeFeature = (
+    id: string,
+    prerequisites: string[] = [],
+    overrides: Partial<FeatureInterface> = {},
+  ): FeatureInterface => ({
+    ...feature,
+    id,
+    environmentSettings: { production: { enabled: true } },
+    rules: [],
+    prerequisites: prerequisites.map((id) => ({
+      id,
+      condition: '{"value": true}',
+    })),
+    ...overrides,
+  });
+
+  const evaluate = (features: FeatureInterface[]) =>
+    evaluatePrerequisiteState(
+      features[0],
+      new Map(features.map((f) => [f.id, f])),
+      "production",
+      false,
+      true,
+    );
+
+  it("allows a prerequisite shared by separate branches", () => {
+    expect(
+      evaluate([
+        makeFeature("a", ["b", "c"]),
+        makeFeature("b", ["d"]),
+        makeFeature("c", ["d"]),
+        makeFeature("d"),
+      ]),
+    ).toEqual({ state: "deterministic", value: true });
+  });
+
+  it("allows repeated references to the same prerequisite", () => {
+    expect(evaluate([makeFeature("a", ["b", "b"]), makeFeature("b")])).toEqual({
+      state: "deterministic",
+      value: true,
+    });
+  });
+
+  it("propagates a cycle to a feature outside the cycle", () => {
+    expect(
+      evaluate([
+        makeFeature("a", ["b"]),
+        makeFeature("b", ["c"]),
+        makeFeature("c", ["b"]),
+      ]),
+    ).toEqual({ state: "cyclic", value: null });
+  });
+
+  it("stops at a disabled prerequisite before following its cycle", () => {
+    expect(
+      evaluate([
+        makeFeature("a", ["b"]),
+        makeFeature("b", ["a"], {
+          environmentSettings: { production: { enabled: false } },
+        }),
+      ]),
+    ).toEqual({ state: "deterministic", value: null });
+  });
+
+  it("stops at a missing prerequisite before following a later cycle", () => {
+    expect(
+      evaluate([makeFeature("a", ["missing", "b"]), makeFeature("b", ["a"])]),
+    ).toEqual({ state: "deterministic", value: null });
+  });
+
+  it("stops at a failed condition before following a later cycle", () => {
+    expect(
+      evaluate([
+        makeFeature("a", ["off", "b"]),
+        makeFeature("off", [], { defaultValue: "false" }),
+        makeFeature("b", ["a"]),
+      ]),
+    ).toEqual({ state: "deterministic", value: null });
   });
 });
 


### PR DESCRIPTION
### Features and Changes

The UI already refuses to create a prerequisite cycle (the prerequisite picker checks for it); this change makes the server tolerate one that arrives through the REST API instead of failing the whole SDK payload.

`evaluatePrerequisiteState` guards against prerequisite cycles with `isFeatureCyclic`, but the SDK payload builder calls it with `skipCyclicCheck = true` (both call sites in `reduceFeaturesWithPrerequisites` / the rule reducer in `packages/back-end/src/services/features.ts`), and the inner `visit()` walk keeps no record of the features already on the current path. If stored data contains a top-level prerequisite cycle (A → B → A, or a feature that lists itself as a prerequisite), the walk recurses until `RangeError: Maximum call stack size exceeded`. That error fails payload generation for every SDK connection whose scope includes the cyclic feature, so `GET /api/features/:key` returns `400 {"error":"Failed to get features"}` for the whole connection (unrelated features included) until the cycle is removed.

The UI's prerequisite picker refuses a cyclic choice, but the REST feature create/update endpoints store `prerequisites` as given, so a cycle can reach stored data through the API.

This change makes `visit()` track the features on the current path and return the existing `"cyclic"` state when it meets one again (and propagate it to the caller). The payload builder already handles `"cyclic"` by dropping the affected feature/rule, so a stored cycle now removes only the features gated on it and the rest of the payload is served normally. Callers that do not pass `skipCyclicCheck` are unaffected: `isFeatureCyclic` still returns first for them.

Because the old failure at least surfaced as an error while the new behaviour is a quiet drop, the two payload-builder call sites now `logger.warn` (organization, feature, environment) the first time they evaluate a cyclic prerequisite in a build, mirroring how `onConstantCycle` reports a cyclic constant reference a few lines above. Glad to drop that if you'd rather keep the diff to the shared helper only.

Deliberately out of scope: validating prerequisites at write time on the REST endpoints (existence / archived / cycle). Happy to follow up on that separately if you'd like it, but it has a few choices in it (which checks, and the cost of a graph walk per write) that felt like yours to make.

### Dependencies

None.

### Testing

- `packages/back-end/test/prerequisites.test.ts`: two new cases (a two-feature cycle, and a self-prerequisite) build a payload through `generateFeaturesPayload` and assert the cyclic features are dropped while an unrelated feature is kept; the first also asserts `evaluatePrerequisiteState(..., skipCyclicCheck=true)` returns `"cyclic"`. Against current `main` both cases fail with `RangeError: Maximum call stack size exceeded`; with this change all 10 cases in the file pass. `packages/shared/test/util/features.test.ts` (265 cases) passes unchanged.
- Driven end to end on a local back-end: created `flag_a`, `flag_b` (prerequisite `flag_a`) and an unrelated `flag_c` via `POST /api/v1/features`, then `POST /api/v1/features/flag_a {"prerequisites":["flag_b"]}` to close the cycle (accepted), plus one SDK connection on that environment. On `main`, `GET /api/features/<client key>` → `HTTP 400 {"status":400,"error":"Failed to get features"}`. With this branch → `HTTP 200` with `features: { flag_c }` (the cyclic pair dropped, the unrelated flag served).
- `test/services/sdk-payload-generation.test.ts` and `test/services/sdk-payload-lifecycle.test.ts` pass unchanged.
- `tsc --noEmit` (shared, back-end), eslint and prettier clean on the changed files.

### Screenshots

N/A (no UI change).
