### PR TITLE
fix(api): require publish access to re-aim an armed ramp schedule via REST

### DIFF
--- a/packages/back-end/src/models/RampScheduleModel.ts
+++ b/packages/back-end/src/models/RampScheduleModel.ts
@@ -19,6 +19,7 @@ import {
 import { rampScheduleApiSpec } from "back-end/src/api/specs/ramp-schedule.spec";
 import {
   appendRampEvent,
+  assertCanEditRampScheduleConfig,
   assertCanUpdateLinkedSafeRolloutMonitoringConfig,
   computeNextProcessAt,
   dispatchRampEvent,
@@ -733,6 +734,10 @@ export class RampScheduleModel extends BaseClass {
         ? updates.startApprovedAt
         : schedule.startApprovedAt) as Date | null | undefined,
     });
+
+    // Same publish-class gate as the dashboard PUT; canUpdate() alone passes
+    // with draft access, which is right for name/monitoring edits only.
+    await assertCanEditRampScheduleConfig(this.context, schedule, updates);
 
     const editedFields = Object.keys(updates).filter(
       (k) => k !== "nextProcessAt" && k !== "eventHistory",

--- a/packages/back-end/src/routers/ramp-schedule/ramp-schedule.controller.ts
+++ b/packages/back-end/src/routers/ramp-schedule/ramp-schedule.controller.ts
@@ -27,6 +27,7 @@ import {
   setRampMonitoringMode,
   startSchedule,
   assertCanControlRampSchedule,
+  assertCanEditRampScheduleConfig,
 } from "back-end/src/services/rampSchedule";
 import { assertCanRefreshRampMonitoring } from "back-end/src/services/rampMonitoringAuthority";
 import { createSafeRolloutSnapshot } from "back-end/src/services/safeRolloutSnapshots";
@@ -214,18 +215,6 @@ export const putRampSchedule = async (
           `Cannot update: schedule changed to "${fresh.status}" while the request was in flight`,
         );
       }
-      // Fields the poller executes — fire times and the actions/steps it will
-      // apply — are publish-class to touch on an ARMABLE schedule, for the same
-      // reason the arm itself is: editing them re-aims a live transition the
-      // /actions endpoints would refuse this caller. Name and monitoring edits
-      // stay draft-class (monitoring carries its own assert below).
-      const touchesExecution =
-        "startDate" in body ||
-        "cutoffDate" in body ||
-        body.startActions !== undefined ||
-        body.steps !== undefined ||
-        body.endActions !== undefined;
-
       const updates: Record<string, unknown> = {};
       if (body.name !== undefined) updates.name = body.name;
       if (body.startActions !== undefined)
@@ -275,24 +264,9 @@ export const putRampSchedule = async (
           : fresh.startApprovedAt) as Date | null | undefined,
       });
 
-      // Armable is `computeNextProcessAt` answering non-null — the same function
-      // the poller keys off, rather than a second reading of what "armed" means.
-      // Checked BOTH before and after: a dateless or approval-gated schedule
-      // fires nothing, so editing its steps is draft-class and demanding publish
-      // refused edits nobody could yet act on; but disarming a schedule that IS
-      // armed re-aims a live transition just as arming one does.
-      if (touchesExecution && (fresh.nextProcessAt || updates.nextProcessAt)) {
-        // Both the PRE-edit and POST-edit aim. Checking `fresh` alone authorized
-        // the schedule as it stands, so a dateless schedule with dev-only steps
-        // (draft-class, gate skipped) could be armed in ONE put that also swapped
-        // in production steps — the edit was judged against the aim it replaced.
-        // The incoming steps are what will fire, so they answer too.
-        await assertCanControlRampSchedule(context, fresh);
-        await assertCanControlRampSchedule(context, {
-          ...fresh,
-          ...updates,
-        } as RampScheduleInterface);
-      }
+      // Publish-class gate for execution-field edits on an armable schedule
+      // (monitoring carries its own assert above).
+      await assertCanEditRampScheduleConfig(context, fresh, updates);
 
       const editedFields = Object.keys(updates).filter(
         (k) => k !== "nextProcessAt" && k !== "eventHistory",

--- a/packages/back-end/src/services/rampSchedule.ts
+++ b/packages/back-end/src/services/rampSchedule.ts
@@ -3179,3 +3179,41 @@ export async function assertCanControlRampSchedule(
     }
   }
 }
+
+// Config-edit gate for PUT-style updates of a not-yet-running schedule, shared
+// by the dashboard PUT /ramp-schedule/:id and the REST PUT /ramp-schedules/:id.
+// Fields the poller executes — fire times and the actions/steps it will apply —
+// are publish-class to touch on an ARMABLE schedule, for the same reason the
+// arm itself is: editing them re-aims a live transition the /actions endpoints
+// would refuse this caller. Name and monitoring edits stay draft-class.
+//
+// Armable is `computeNextProcessAt` answering non-null — the same function the
+// poller keys off. Checked BOTH before (`existing.nextProcessAt`) and after
+// (`updates.nextProcessAt`, which the caller has already recomputed): a
+// dateless or approval-gated schedule fires nothing, so editing its steps is
+// draft-class; but disarming a schedule that IS armed re-aims a live transition
+// just as arming one does. Both the PRE-edit and POST-edit aim are asserted:
+// checking `existing` alone would let a dateless schedule with dev-only steps
+// be armed in ONE put that also swapped in production steps — the incoming
+// steps are what will fire, so they answer too.
+export const RAMP_EXECUTION_FIELDS = [
+  "startDate",
+  "cutoffDate",
+  "startActions",
+  "steps",
+  "endActions",
+] as const;
+export async function assertCanEditRampScheduleConfig(
+  context: ReqContext | ApiReqContext,
+  existing: RampScheduleInterface,
+  updates: Record<string, unknown>,
+): Promise<void> {
+  const touchesExecution = RAMP_EXECUTION_FIELDS.some((k) => k in updates);
+  if (!touchesExecution) return;
+  if (!existing.nextProcessAt && !updates.nextProcessAt) return;
+  await assertCanControlRampSchedule(context, existing);
+  await assertCanControlRampSchedule(context, {
+    ...existing,
+    ...updates,
+  } as RampScheduleInterface);
+}

--- a/packages/back-end/test/services/rampScheduleConfigEditGate.test.ts
+++ b/packages/back-end/test/services/rampScheduleConfigEditGate.test.ts
@@ -1,0 +1,127 @@
+import { PermissionError } from "shared/util";
+import type { RampScheduleInterface } from "shared/validators";
+import type { ApiReqContext } from "back-end/types/api";
+
+jest.mock("back-end/src/services/organizations", () => ({
+  getEnvironmentIdsFromOrg: jest.fn(() => ["dev", "production"]),
+  getContextForAgendaJobByOrgObject: jest.fn(),
+}));
+jest.mock("back-end/src/models/FeatureModel", () => ({
+  getFeature: jest.fn(),
+  getFeatureProjectsByIds: jest.fn(async () => new Map([["feat_1", "prj_1"]])),
+  getFeatureRuleEnvironmentsByIds: jest.fn(async () => new Map()),
+}));
+jest.mock("back-end/src/services/safeRolloutSnapshots", () => ({
+  createSafeRolloutSnapshot: jest.fn(),
+}));
+jest.mock("back-end/src/models/DataSourceModel", () => ({
+  getDataSourceById: jest.fn(),
+}));
+
+import { assertCanEditRampScheduleConfig } from "back-end/src/services/rampSchedule";
+
+// The PUT-style config edit gate shared by the dashboard and REST update
+// handlers: execution-field edits on a schedule that is armed before or after
+// the edit take publish authority; everything else stays draft-class.
+
+const ARMED_AT = new Date("2030-01-01T00:00:00Z");
+
+const schedule = (nextProcessAt: Date | null) =>
+  ({
+    id: "ramp_1",
+    entityType: "feature",
+    entityId: "feat_1",
+    status: "ready",
+    targets: [
+      {
+        id: "t_1",
+        entityType: "feature",
+        entityId: "feat_1",
+        status: "active",
+      },
+    ],
+    steps: [
+      {
+        actions: [{ targetId: "t_1", patch: { environments: ["production"] } }],
+      },
+    ],
+    startActions: [],
+    nextProcessAt,
+  }) as unknown as RampScheduleInterface;
+
+function makeContext(canPublish: boolean) {
+  const canPublishFeature = jest.fn(() => canPublish);
+  const context = {
+    org: { id: "org_1" },
+    permissions: {
+      canPublishFeature,
+      throwPermissionError: () => {
+        throw new PermissionError("permission denied");
+      },
+    },
+    models: {
+      rampSchedules: { publishEnvironments: jest.fn(() => ["production"]) },
+    },
+  } as unknown as ApiReqContext;
+  return { context, canPublishFeature };
+}
+
+describe("assertCanEditRampScheduleConfig", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("does not ask for publish authority on a name-only edit of an armed schedule", async () => {
+    const { context, canPublishFeature } = makeContext(false);
+    await expect(
+      assertCanEditRampScheduleConfig(context, schedule(ARMED_AT), {
+        name: "renamed",
+        nextProcessAt: ARMED_AT,
+      }),
+    ).resolves.toBeUndefined();
+    expect(canPublishFeature).not.toHaveBeenCalled();
+  });
+
+  it("does not ask for publish authority to edit steps of a schedule that is not armed before or after", async () => {
+    const { context, canPublishFeature } = makeContext(false);
+    await expect(
+      assertCanEditRampScheduleConfig(context, schedule(null), {
+        steps: [],
+        nextProcessAt: null,
+      }),
+    ).resolves.toBeUndefined();
+    expect(canPublishFeature).not.toHaveBeenCalled();
+  });
+
+  it("refuses a steps edit on an armed schedule without publish authority", async () => {
+    const { context, canPublishFeature } = makeContext(false);
+    await expect(
+      assertCanEditRampScheduleConfig(context, schedule(ARMED_AT), {
+        steps: [],
+        nextProcessAt: ARMED_AT,
+      }),
+    ).rejects.toThrow(PermissionError);
+    expect(canPublishFeature).toHaveBeenCalledWith({ project: "prj_1" }, [
+      "production",
+    ]);
+  });
+
+  it("refuses arming a dateless schedule (startDate edit) without publish authority", async () => {
+    const { context } = makeContext(false);
+    await expect(
+      assertCanEditRampScheduleConfig(context, schedule(null), {
+        startDate: ARMED_AT,
+        nextProcessAt: ARMED_AT,
+      }),
+    ).rejects.toThrow(PermissionError);
+  });
+
+  it("allows an execution-field edit on an armed schedule with publish authority", async () => {
+    const { context, canPublishFeature } = makeContext(true);
+    await expect(
+      assertCanEditRampScheduleConfig(context, schedule(ARMED_AT), {
+        cutoffDate: null,
+        nextProcessAt: ARMED_AT,
+      }),
+    ).resolves.toBeUndefined();
+    expect(canPublishFeature).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Features and Changes

The dashboard's ramp-schedule update route already treats the fields the poller executes as publish-class on an armed schedule:

```ts
// routers/ramp-schedule/ramp-schedule.controller.ts, putRampSchedule
const touchesExecution = "startDate" in body || "cutoffDate" in body ||
  body.startActions !== undefined || body.steps !== undefined || body.endActions !== undefined;
...
if (touchesExecution && (fresh.nextProcessAt || updates.nextProcessAt)) {
  await assertCanControlRampSchedule(context, fresh);
  await assertCanControlRampSchedule(context, { ...fresh, ...updates });
}
```

The generated REST `PUT /api/v1/ramp-schedules/{id}` (`RampScheduleModel.applyApiUpdateLocked`) accepts the same body but only went through the model's `canUpdate`, which (as its own comment says) is the union of draft-class and publish-class and relies on the handler to gate precisely. The REST handler never did, so an API key that can edit feature drafts but whose publish rights don't cover the targeted rule's environments could replace the steps, start/end actions or start/cutoff date of an **armed** schedule on that rule, and the poller would apply the new plan when it fired.

This moves the dashboard route's gate, unchanged, into `assertCanEditRampScheduleConfig(context, existing, updates)` in `services/rampSchedule.ts` (right next to `assertCanControlRampSchedule`, with the existing explanatory comment), and has both `putRampSchedule` and `applyApiUpdateLocked` call it at the same point in the flow: after `nextProcessAt` is recomputed, before the write. That way the two surfaces share one definition of "which config edits are publish-class" instead of two copies. Everything else is unchanged: name / monitoring / lockdown edits stay draft-class, and so do execution-field edits on a schedule that is not armed before or after the edit (no start date, or held for start approval), on both routes.

The model-level `canUpdate` is deliberately left as the draft-or-publish union, per its comment. If you'd rather have the REST handler carry its own inline copy and leave the controller untouched, that's a two-minute change, say so.

### Dependencies

None.

### Testing

- Driven end to end on a local back-end (Enterprise features enabled): a boolean flag with a force rule in `production`, an armed ramp schedule on that rule created through `POST /api/v1/ramp-schedules` (`startDate` in the future → `status: ready`, `nextProcessAt` set), and an `engineer` API key with `limitAccessByEnvironment: true, environments: ["dev"]`.
  - On `main`, with that dev-only key: `PUT /api/v1/ramp-schedules/{id}` with `{"steps":[{"interval":60,"actions":[{"targetType":"feature-rule","patch":{"ruleId":"<rule>","coverage":1}}]}]}` → `200` (steps replaced), and `{"startDate":"2026-12-01T00:00:00Z"}` → `200` (`nextProcessAt` moved).
  - With this branch, same key: both → `403 "You do not have permission to perform this action"`; `{"name":"renamed"}` → `200`. With an admin key the steps update → `200`.
- `test/services/rampScheduleConfigEditGate.test.ts` (new, same mocking shape as `test/routers/rampScheduleActionGate.test.ts`): name-only edit on an armed schedule and steps edit on an unarmed one never consult `canPublishFeature`; steps edit on an armed schedule and a `startDate` edit that arms a dateless one throw `PermissionError` without publish authority and pass with it. The existing `rampScheduleActionGate` and `services/rampSchedule*` suites (238 cases) pass unchanged; the dashboard `PUT /ramp-schedule/:id` was re-driven locally (steps and name edits → `200` for an admin session) to confirm the extraction is behaviour-preserving there.
- `tsc --noEmit` (back-end), eslint and prettier clean on the changed files.

### Screenshots

N/A (no UI change).
