### PR TITLE
fix(environments): refuse to delete an environment that SDK Connections use

### DIFF
--- a/packages/back-end/src/api/environments/deleteEnvironment.ts
+++ b/packages/back-end/src/api/environments/deleteEnvironment.ts
@@ -3,6 +3,7 @@ import { OrganizationInterface } from "shared/types/organization";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { updateOrganization } from "back-end/src/models/OrganizationModel";
 import { auditDetailsDelete } from "back-end/src/services/audit";
+import { assertEnvironmentDeletable } from "back-end/src/services/environments";
 
 export const deleteEnvironment = createApiRequestHandler(
   deleteEnvironmentValidator,
@@ -18,6 +19,8 @@ export const deleteEnvironment = createApiRequestHandler(
 
   if (!req.context.permissions.canDeleteEnvironment(environment))
     req.context.permissions.throwPermissionError();
+
+  await assertEnvironmentDeletable(req.context, id);
 
   const updates: Partial<OrganizationInterface> = {
     settings: {

--- a/packages/back-end/src/api/environments/deleteEnvironment.ts
+++ b/packages/back-end/src/api/environments/deleteEnvironment.ts
@@ -3,7 +3,10 @@ import { OrganizationInterface } from "shared/types/organization";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { updateOrganization } from "back-end/src/models/OrganizationModel";
 import { auditDetailsDelete } from "back-end/src/services/audit";
-import { assertEnvironmentDeletable } from "back-end/src/services/environments";
+import {
+  assertEnvironmentDeletable,
+  cleanupDeletedEnvironment,
+} from "back-end/src/services/environments";
 
 export const deleteEnvironment = createApiRequestHandler(
   deleteEnvironmentValidator,
@@ -30,6 +33,7 @@ export const deleteEnvironment = createApiRequestHandler(
   };
 
   await updateOrganization(org.id, updates);
+  await cleanupDeletedEnvironment(org.id, id);
 
   await req.audit({
     event: "environment.delete",

--- a/packages/back-end/src/models/SdkConnectionModel.ts
+++ b/packages/back-end/src/models/SdkConnectionModel.ts
@@ -162,6 +162,18 @@ export async function findSDKConnectionsByOrganization(
   );
 }
 
+// Not filtered by the caller's project read access: used as a referential
+// integrity check before an environment is removed.
+export async function countSDKConnectionsByEnvironment(
+  context: ReqContext | ApiReqContext,
+  environment: string,
+) {
+  return await SDKConnectionModel.countDocuments({
+    organization: context.org.id,
+    environment,
+  });
+}
+
 export async function findAllSDKConnectionsAcrossAllOrgs() {
   const docs = await SDKConnectionModel.find();
   return docs.map(toInterface);

--- a/packages/back-end/src/routers/environment/environment.controller.ts
+++ b/packages/back-end/src/routers/environment/environment.controller.ts
@@ -28,6 +28,7 @@ import {
 import { addEnvironmentToOrganizationEnvironments } from "back-end/src/util/environments";
 import { updateOrganization } from "back-end/src/models/OrganizationModel";
 import { queueSDKPayloadRefresh } from "back-end/src/services/features";
+import { assertEnvironmentDeletable } from "back-end/src/services/environments";
 
 type UpdateEnvOrderProps = z.infer<typeof updateEnvOrderValidator>;
 
@@ -342,6 +343,8 @@ export const deleteEnvironment = async (
   if (!context.permissions.canDeleteEnvironment(envToDelete)) {
     context.permissions.throwPermissionError();
   }
+
+  await assertEnvironmentDeletable(context, id);
 
   try {
     await updateOrganization(org.id, {

--- a/packages/back-end/src/routers/environment/environment.controller.ts
+++ b/packages/back-end/src/routers/environment/environment.controller.ts
@@ -17,7 +17,6 @@ import {
   auditDetailsDelete,
   auditDetailsUpdate,
 } from "back-end/src/services/audit";
-import { removeEnvironmentFromSlackIntegration } from "back-end/src/models/SlackIntegrationModel";
 import { AuthRequest } from "back-end/src/types/AuthRequest";
 import { PrivateApiErrorResponse } from "back-end/types/api";
 import {
@@ -28,7 +27,10 @@ import {
 import { addEnvironmentToOrganizationEnvironments } from "back-end/src/util/environments";
 import { updateOrganization } from "back-end/src/models/OrganizationModel";
 import { queueSDKPayloadRefresh } from "back-end/src/services/features";
-import { assertEnvironmentDeletable } from "back-end/src/services/environments";
+import {
+  assertEnvironmentDeletable,
+  cleanupDeletedEnvironment,
+} from "back-end/src/services/environments";
 
 type UpdateEnvOrderProps = z.infer<typeof updateEnvOrderValidator>;
 
@@ -353,6 +355,7 @@ export const deleteEnvironment = async (
         environments: existingEnvs.filter((env) => env.id !== id),
       },
     });
+    await cleanupDeletedEnvironment(org.id, id);
 
     await req.audit({
       event: "environment.delete",
@@ -361,11 +364,6 @@ export const deleteEnvironment = async (
         id,
       },
       details: auditDetailsDelete(id),
-    });
-
-    removeEnvironmentFromSlackIntegration({
-      organizationId: org.id,
-      envId: id,
     });
 
     res.status(200).json({

--- a/packages/back-end/src/services/environments.ts
+++ b/packages/back-end/src/services/environments.ts
@@ -1,6 +1,7 @@
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import { countSDKConnectionsByEnvironment } from "back-end/src/models/SdkConnectionModel";
+import { removeEnvironmentFromSlackIntegration } from "back-end/src/models/SlackIntegrationModel";
 import { BadRequestError } from "back-end/src/util/errors";
 
 // Single source of truth for "may this environment be deleted?", shared by the
@@ -16,4 +17,15 @@ export async function assertEnvironmentDeletable(
   throw new BadRequestError(
     `Cannot delete environment: it is still used by ${count} SDK Connection(s). Remove them or move them to another environment first.`,
   );
+}
+
+// Notification filters are derived config, not a dependency: prune, never block.
+export async function cleanupDeletedEnvironment(
+  organizationId: string,
+  environmentId: string,
+): Promise<void> {
+  await removeEnvironmentFromSlackIntegration({
+    organizationId,
+    envId: environmentId,
+  });
 }

--- a/packages/back-end/src/services/environments.ts
+++ b/packages/back-end/src/services/environments.ts
@@ -1,0 +1,19 @@
+import { ReqContext } from "back-end/types/request";
+import { ApiReqContext } from "back-end/types/api";
+import { countSDKConnectionsByEnvironment } from "back-end/src/models/SdkConnectionModel";
+import { BadRequestError } from "back-end/src/util/errors";
+
+// Single source of truth for "may this environment be deleted?", shared by the
+// dashboard controller and the REST handler. Org-wide, like
+// assertSavedGroupDeletable: an SDK Connection the caller cannot read is still
+// left pointing at a missing environment by the delete.
+export async function assertEnvironmentDeletable(
+  context: ReqContext | ApiReqContext,
+  environmentId: string,
+): Promise<void> {
+  const count = await countSDKConnectionsByEnvironment(context, environmentId);
+  if (count === 0) return;
+  throw new BadRequestError(
+    `Cannot delete environment: it is still used by ${count} SDK Connection(s). Remove them or move them to another environment first.`,
+  );
+}

--- a/packages/back-end/test/api/environments.test.ts
+++ b/packages/back-end/test/api/environments.test.ts
@@ -3,11 +3,17 @@ import {
   findOrganizationById,
   updateOrganization,
 } from "back-end/src/models/OrganizationModel";
+import { countSDKConnectionsByEnvironment } from "back-end/src/models/SdkConnectionModel";
 import { setupApp } from "./api.setup";
 
 jest.mock("back-end/src/models/OrganizationModel", () => ({
   findOrganizationById: jest.fn(),
   updateOrganization: jest.fn(),
+}));
+
+jest.mock("back-end/src/models/SdkConnectionModel", () => ({
+  countSDKConnectionsByEnvironment: jest.fn().mockResolvedValue(0),
+  findSDKConnectionsByOrganization: jest.fn().mockResolvedValue([]),
 }));
 
 describe("environements API", () => {
@@ -146,6 +152,30 @@ describe("environements API", () => {
       entity: { id: "env1", object: "environment" },
       event: "environment.delete",
     });
+  });
+
+  it("refuses to delete an environment that SDK Connections still use", async () => {
+    setReqContext({
+      org: {
+        id: "org1",
+        settings: {
+          environments: [{ id: "env1" }, { id: "env2" }],
+        },
+      },
+      permissions: {
+        canDeleteEnvironment: () => true,
+      },
+    });
+    jest.mocked(countSDKConnectionsByEnvironment).mockResolvedValueOnce(2);
+
+    const response = await request(app)
+      .delete("/api/v1/environments/env1")
+      .set("Authorization", "Bearer foo");
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toMatch(/still used by 2 SDK Connection/);
+    expect(updateOrganization).not.toHaveBeenCalled();
+    expect(auditMock).not.toHaveBeenCalled();
   });
 
   it("checks for permission to delete environments", async () => {

--- a/packages/back-end/test/api/environments.test.ts
+++ b/packages/back-end/test/api/environments.test.ts
@@ -4,6 +4,7 @@ import {
   updateOrganization,
 } from "back-end/src/models/OrganizationModel";
 import { countSDKConnectionsByEnvironment } from "back-end/src/models/SdkConnectionModel";
+import { removeEnvironmentFromSlackIntegration } from "back-end/src/models/SlackIntegrationModel";
 import { setupApp } from "./api.setup";
 
 jest.mock("back-end/src/models/OrganizationModel", () => ({
@@ -14,6 +15,11 @@ jest.mock("back-end/src/models/OrganizationModel", () => ({
 jest.mock("back-end/src/models/SdkConnectionModel", () => ({
   countSDKConnectionsByEnvironment: jest.fn().mockResolvedValue(0),
   findSDKConnectionsByOrganization: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock("back-end/src/models/SlackIntegrationModel", () => ({
+  ...jest.requireActual("back-end/src/models/SlackIntegrationModel"),
+  removeEnvironmentFromSlackIntegration: jest.fn(),
 }));
 
 describe("environements API", () => {
@@ -146,6 +152,10 @@ describe("environements API", () => {
     expect(updateOrganization).toHaveBeenCalledWith("org1", {
       settings: { environments: [{ id: "env2" }] },
     });
+    expect(removeEnvironmentFromSlackIntegration).toHaveBeenCalledWith({
+      organizationId: "org1",
+      envId: "env1",
+    });
     expect(auditMock).toHaveBeenCalledWith({
       details:
         '{"pre":{"id":"env1","description":"env1","toggleOnList":true,"defaultState":true,"projects":["bla"]},"context":{}}',
@@ -175,6 +185,7 @@ describe("environements API", () => {
     expect(response.status).toBe(400);
     expect(response.body.message).toMatch(/still used by 2 SDK Connection/);
     expect(updateOrganization).not.toHaveBeenCalled();
+    expect(removeEnvironmentFromSlackIntegration).not.toHaveBeenCalled();
     expect(auditMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
### Features and Changes

The Environments page disables **Delete** for an environment while any SDK Connection uses it (`pages/environments.tsx`: `deleteBlocked = numConnections > 0`, tooltip "cannot be deleted until they have been removed"). The server did not enforce the same rule on either delete route:

- REST `DELETE /api/v1/environments/:id` (`packages/back-end/src/api/environments/deleteEnvironment.ts`)
- dashboard `DELETE /environment/:id` (`packages/back-end/src/routers/environment/environment.controller.ts`)

Both removed the environment from `organization.settings.environments` without looking at SDK Connections, so an API client (or a direct call to the dashboard route) could leave connections pointing at an environment that no longer exists; those connections keep answering, but with every feature reduced to its default value.

This adds `assertEnvironmentDeletable(context, id)` in a new `services/environments.ts`, following the existing `assertSavedGroupDeletable` / `assertFeatureDeletable` shape (one guard, called from both the REST handler and the controller, throws `BadRequestError`). It uses a small `countSDKConnectionsByEnvironment` helper on `SdkConnectionModel` and refuses with `Cannot delete environment: it is still used by N SDK Connection(s). Remove them or move them to another environment first.`

Like the sibling guards, the count is org-wide rather than filtered by the caller's project read access (which `findSDKConnectionsByOrganization`, used by the environments page, does apply): a connection the caller can't read is still broken by the delete. Happy to switch to the filtered list if you'd rather match the page exactly.

One observation while here, not changed in this PR: `importConfig` (`POST /organization/config/import`) replaces `settings.environments` wholesale and can also drop an environment that connections use; that seemed like a separate conversation since the import round-trip is meant to carry full settings.

### Dependencies

None.

### Testing

- `test/api/environments.test.ts`: new case "refuses to delete an environment that SDK Connections still use" (count mocked to 2 → `400`, `updateOrganization` and audit not called); the existing delete/permission cases pass with the count mocked to 0. Against current `main` the new case fails (`Expected: 400, Received: 200`).
- Driven end to end on a local back-end: created environment `staging` and an SDK Connection on it through the REST API. On `main`, `DELETE /api/v1/environments/staging` → `200 {"deletedId":"staging"}` with the connection still referencing `staging`. With this branch the same call → `400` with the message above; the dashboard `DELETE /environment/staging` → `400` likewise; after deleting the connection, the delete → `200`.
- `tsc --noEmit` (back-end), eslint and prettier clean on the changed files.

### Screenshots

N/A (no UI change; the UI already blocks this).
