### PR TITLE
Load secrets from files via SECRETS_DIR

### DIFF
--- a/docs/self-host/env.mdx
+++ b/docs/self-host/env.mdx
@@ -99,6 +99,25 @@ When using GrowthBook in production, it is important to change the
   node environment and the default <code>JWT_SECRET</code> will throw an error.
 </Info>
 
+### Loading Secrets from Files
+
+If you'd rather not pass sensitive values as plain environment variables, set **SECRETS_DIR** to a directory and GrowthBook will read every file in it at startup, exposing each as an environment variable named after the file. This works with Docker secrets and Kubernetes secret volume mounts, which both write one file per secret. A variable that is already set in the environment takes precedence over the file.
+
+```yml
+services:
+  growthbook:
+    environment:
+      - SECRETS_DIR=/run/secrets
+    secrets:
+      - JWT_SECRET
+      - MONGODB_PASSWORD
+secrets:
+  JWT_SECRET:
+    file: ./secrets/jwt_secret.txt
+  MONGODB_PASSWORD:
+    file: ./secrets/mongodb_password.txt
+```
+
 ## Email SMTP Settings
 
 This is required in order to send experiment alerts, team member invites, and reset password emails.

--- a/packages/back-end/src/init/dotenv.ts
+++ b/packages/back-end/src/init/dotenv.ts
@@ -1,6 +1,18 @@
 import fs from "fs";
+import path from "path";
 import dotenv from "dotenv";
 
 if (fs.existsSync(".env.local")) {
   dotenv.config({ path: ".env.local" });
+}
+
+// Docker/Kubernetes secrets mount as one file per secret; expose each as an env var named after the file.
+const secretsDir = process.env.SECRETS_DIR;
+if (secretsDir) {
+  for (const name of fs.readdirSync(secretsDir)) {
+    if (name.startsWith(".") || process.env[name] !== undefined) continue;
+    const file = path.join(secretsDir, name);
+    if (!fs.statSync(file).isFile()) continue;
+    process.env[name] = fs.readFileSync(file, "utf8").trimEnd();
+  }
 }


### PR DESCRIPTION
### Features and Changes

Docker and Kubernetes secrets mount one file per secret. When `SECRETS_DIR` is set, we read each file at boot into an env var named after it, with an already-set env var taking precedence, so credentials like `JWT_SECRET` and `MONGODB_PASSWORD` no longer have to be passed as plain environment variables. Documented under Production Settings with a compose `secrets:` example. Closes #2625.

### Testing

- [x] Image built from this branch, run with `NODE_ENV=production`, no secret env vars, and `SECRETS_DIR=/run/secrets` holding `MONGODB_URI`, `JWT_SECRET`, `ENCRYPTION_KEY` -> healthcheck 200
- [x] Session JWT signed with the file's `JWT_SECRET` -> passes signature verification; signed with a different value -> 401 invalid signature
- [x] Same image without `SECRETS_DIR` -> fails to boot on missing `MONGODB_URI`
