### PR TITLE
Flag results outdated when variation order changes

### DIFF
--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
@@ -624,7 +624,8 @@ export default function AnalysisSettingsSummary({
     if (!val1 && !val2) return false;
     if (!val1 || !val2) return true;
     if (val1.length !== val2.length) return true;
-    return val1.some((v) => !val2.includes(v));
+    // Order matters: snapshot results are indexed by variation position.
+    return val1.some((v, i) => v !== val2[i]);
   }
 
   function isStringArrayMissingElements(


### PR DESCRIPTION
### Features and Changes

Reordering variations left the results table showing each variation's stats under the other's name until the analysis was re-run: snapshot results are positional, but the "Variations changed" outdated check compared keys as a set, so a pure reorder never flagged the results as stale. We compare positionally now. Closes #2950.

### Testing

- [x] Running experiment with a snapshot, variations `Control, Treatment` -> Outdated tooltip lists only "Analysis dates changed"
- [x] Swap the stored variation order -> Results tab shows Treatment under Control's numbers, and the tooltip now also lists "Variations changed"
