### PR TITLE
New dashboard from exploration inherits exploration date range

### DIFF
--- a/packages/front-end/enterprise/components/ProductAnalytics/SaveToDashboardModal.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SaveToDashboardModal.tsx
@@ -177,7 +177,11 @@ export default function SaveToDashboardModal({
           projects: formValues.projects,
           experimentId: "",
           blocks: [newBlock],
-          globalControls: DEFAULT_DASHBOARD_GLOBAL_CONTROLS,
+          // Seed new dashboard with the exploration's date range.
+          globalControls: {
+            ...DEFAULT_DASHBOARD_GLOBAL_CONTROLS,
+            dateRange: { ...config.dateRange },
+          },
         }),
       });
       if (res.status !== 200) throw new Error("Failed to create dashboard");


### PR DESCRIPTION
### Features and Changes

When a user creates a **new** dashboard from a product analytics exploration, the dashboard date filter now matches the exploration they were looking at instead of always defaulting to the last 30 days.

Previously, building a 12-month chart and choosing “Add to Dashboard” → “New dashboard” showed a different chart on the dashboard because the global date control overrode the block with 30 days. Adding a visualization to an **existing** dashboard is unchanged and still uses that dashboard’s current date filter. Blank dashboards created from the dashboards list still default to 30 days.

- Closes **(add link to issue here)**

### Dependencies

None

### Testing

- [x] From an exploration set to last 12 months, save to a **new** dashboard and confirm the chart and dashboard date control both show last 12 months
- [x] Repeat with last 7 days and a custom date range
- [x] Add the same chart to an **existing** dashboard that is on 30 days and confirm that dashboard’s date filter does not change
- [x] Create a blank dashboard from the dashboards list and confirm it still defaults to last 30 days

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->