### PR TITLE
Add local notification card previews and Slack setup documentation

### DIFF
--- a/docs/integrations/slack.mdx
+++ b/docs/integrations/slack.mdx
@@ -1,14 +1,73 @@
 ---
 title: Slack integration
 toc_max_heading_level: 5
-description: "Receive GrowthBook event alerts in a Slack channel: create an incoming webhook, connect it in GrowthBook, and subscribe to the events you care about."
+description: "Connect Slack workspaces and channels to GrowthBook, choose notification filters and experiment cards, and manage existing incoming webhooks."
 ---
-
-import { ExternalLink } from "/snippets/ExternalLink.jsx";
 
 The GrowthBook Slack integration allows you to receive alerts for the events that you care about in a Slack channel of your choosing.
 
-## Creating and configuring an app in Slack
+## Connect a Slack workspace
+
+When workspace connections are enabled for your GrowthBook instance, open
+**Integrations → Slack**, click **Connect to Slack**, and authorize the app.
+You need permission to manage integrations in GrowthBook. Select the correct
+GrowthBook organization before starting the installation.
+
+Add channels after connecting the workspace. GrowthBook joins public channels
+automatically. For a private channel, invite the GrowthBook bot to the channel
+first, then select it in GrowthBook.
+
+Each channel has its own event, project, environment, and tag filters. Select
+at least one event before saving. You can pause a channel, reconnect its
+workspace to update authorization, or disconnect it from the Slack integrations
+page. These connections use Event Webhooks for delivery and logs.
+
+### Experiment cards
+
+Channel settings offer text-only, compact, and detailed experiment cards.
+Currently, only sample ratio mismatch (SRM) warnings produce cards. Significance
+notifications and other warning types remain text-only. If a card cannot be
+rendered or uploaded, GrowthBook sends the original text notification instead.
+Cards require the Slack app's `files:write` permission; reconnect the workspace
+when prompted to grant updated permissions.
+
+### Existing connections
+
+Existing Slack connections and incoming webhooks continue delivering notifications.
+You do not need to reconnect them just to keep receiving alerts. If you see the
+legacy Slack settings instead of workspace connections, continue managing your
+existing connections there. Incoming webhook setup is documented below.
+
+When migrating a channel to a workspace connection, test the new connection
+before disabling the old one. Leaving both enabled can produce duplicate alerts.
+
+### Self-hosted workspace setup
+
+Create a Slack app for your instance and configure its OAuth redirect URL as
+`https://YOUR_GROWTHBOOK_APP_HOST/integrations/slack`, matching your GrowthBook
+`APP_ORIGIN`. Set `SLACK_CLIENT_ID` and `SLACK_CLIENT_SECRET` on the API server,
+then restart it. Workspace management must also be enabled for your instance
+through the `slack-workspace-ui` feature flag.
+
+The current OAuth flow requests these bot scopes:
+
+- `chat:write`
+- `files:write`
+- `channels:read`
+- `groups:read`
+- `channels:join`
+- `assistant:write`
+- `im:history`
+- `app_mentions:read`
+
+The last three scopes prepare for assistant functionality; granting them does
+not enable a Slack assistant in this release. Notifications do not require an
+inbound events URL. `SLACK_SIGNING_SECRET` is not used by this outbound
+notification flow.
+
+## Legacy incoming webhook setup
+
+### Creating and configuring an app in Slack
 
 ### Create a Slack app
 

--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -29,7 +29,8 @@
     "migrate-encryption-key": "./src/scripts/migrate-encryption-key.sh",
     "generate-openapi": "pnpm --filter shared build && ENABLE_ZOD_SCHEMA_REGISTRATION=1 DISABLE_PYTHON_MONITOR=1 GB_STATS_ENGINE_MIN_POOL_SIZE=0 tsx src/scripts/generate-openapi.ts && tsx src/scripts/generate-openapi-docs.ts",
     "test-rest-api": "ts-node src/scripts/test-rest-api.ts",
-    "diff-features": "tsx src/scripts/diff-features.ts"
+    "diff-features": "tsx src/scripts/diff-features.ts",
+    "preview:notification-cards": "tsx src/scripts/preview-notification-cards.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.0",

--- a/packages/back-end/src/scripts/preview-notification-cards.ts
+++ b/packages/back-end/src/scripts/preview-notification-cards.ts
@@ -1,0 +1,42 @@
+import { mkdtemp, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { pathToFileURL } from "url";
+import { sampleCard } from "back-end/src/services/notificationCards/cardImages";
+import {
+  listCardStyles,
+  renderExperimentCard,
+} from "back-end/src/services/notificationCards/experimentCards";
+
+async function main() {
+  const directory = await mkdtemp(
+    join(tmpdir(), "growthbook-notification-cards-"),
+  );
+  const card = sampleCard("warning");
+  card.event = "warning";
+  const styles = listCardStyles();
+  for (const { id } of styles) {
+    const png = await renderExperimentCard(card, id);
+    await writeFile(join(directory, `${id}.png`), png, { flag: "wx" });
+  }
+  const html = `<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>GrowthBook notification card previews</title>
+<style>body{font:16px system-ui;margin:32px auto;padding:0 24px;max-width:1200px;background:#f5f5f5;color:#222}img{max-width:100%;height:auto}section{margin:32px 0}</style>
+<h1>Notification Card Previews</h1>
+<p>Sample SRM warning data rendered with the production card renderer. These previews do not send notifications or load customer data.</p>
+${styles.map(({ id, label }) => `<section><h2>${label}</h2><a href="${id}.png" download>Download PNG</a><p><img src="${id}.png" alt="${label} sample SRM warning card"></p></section>`).join("\n")}
+</html>`;
+  const index = join(directory, "index.html");
+  await writeFile(index, html, { flag: "wx" });
+  process.stdout.write(`Open ${pathToFileURL(index).href}\n`);
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(
+    `${error instanceof Error ? error.message : String(error)}\n`,
+  );
+  process.exitCode = 1;
+});

--- a/packages/back-end/src/services/notificationCards/README.md
+++ b/packages/back-end/src/services/notificationCards/README.md
@@ -1,0 +1,24 @@
+# Notification card previews
+
+From the repository root, after installing dependencies, build shared packages
+and render the previews:
+
+```sh
+pnpm build:deps
+pnpm --filter back-end preview:notification-cards
+```
+
+Open the printed local HTML file in your browser. It shows compact and detailed
+PNG cards generated from the built-in sample SRM warning data using the same
+renderer as notification delivery. The PNG files are alongside the HTML file
+in a new temporary directory on each run. No Slack credentials, running server,
+database, or customer data are needed, and nothing is sent to Slack.
+
+These samples help check fonts, layout, and renderer changes. They are not an
+end-to-end delivery test and do not imply that every renderer state is currently
+mapped to a notification event. In the initial cards release, only SRM warnings
+produce cards; significance and unsupported warning events remain text-only.
+
+For a delivery test, connect a test Slack channel in GrowthBook and use the
+Event Webhook's Test action. A generic webhook test checks notification delivery;
+it does not necessarily generate an SRM card.


### PR DESCRIPTION
Superseded by #6927 after renaming the source branch to the required `gm/` prefix. No implementation was discarded.

Adds a local preview command for the notification cards introduced in #6870 and documents Slack workspace setup, permissions, text fallback, and legacy-connection migration.

`pnpm --filter back-end preview:notification-cards` renders sample SRM cards in both styles into a temporary HTML gallery. It uses no customer data or Slack credentials and sends no messages.

This PR is based on `gm/generic-notification-cards` (#6870). The original implementation remains preserved in #6787. Admin send endpoints are intentionally not included in this local preview slice.

Validation: backend typecheck; 12 renderer smoke tests; actual PNG rendering and visual inspection; targeted ESLint, Prettier, documentation frontmatter checks and commit hooks.
