### PR TITLE
fix(ci): skip preview rebuild when PR becomes ready

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -10,7 +10,7 @@ on:
       - "pnpm-lock.yaml"
       - "Dockerfile"
       - ".dockerignore"
-    types: [opened, reopened, closed, synchronize, ready_for_review]
+    types: [opened, reopened, closed, synchronize]
 
 jobs:
   preview:


### PR DESCRIPTION
### Features and Changes

We were rebuilding the preview env when the PR went from draft to Ready for review -- but it is not needed as no code was changed in this case.

So now we don't.

- Remove `ready_for_review` from the Preview workflow triggers to avoid rebuilding code already deployed while the PR was a draft
