### PR TITLE
fix(results): ignore benign stats errors in failure rows

### DIFF
--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -63,9 +63,9 @@ import { getDefaultRuleValue, NewExperimentRefRule } from "./features";
 export const NO_DATA_ERROR_MESSAGE = "No data";
 
 export function getComputeErrorMessage(
-  stats?: Pick<SnapshotMetric, "errorMessage"> | null,
+  stats?: Pick<SnapshotMetric, "computeFailed" | "errorMessage"> | null,
 ): string | null {
-  const message = stats?.errorMessage;
+  const message = stats?.computeFailed ? stats.errorMessage : null;
   return message && message !== NO_DATA_ERROR_MESSAGE ? message : null;
 }
 

--- a/packages/front-end/test/experimentComputeErrors.test.ts
+++ b/packages/front-end/test/experimentComputeErrors.test.ts
@@ -1,0 +1,29 @@
+import { getComputeErrorMessage } from "@/services/experiments";
+
+describe("getComputeErrorMessage", () => {
+  it("returns analysis-level compute failures", () => {
+    expect(
+      getComputeErrorMessage({
+        computeFailed: true,
+        errorMessage: "Metric analysis failed",
+      }),
+    ).toBe("Metric analysis failed");
+  });
+
+  it("ignores expected per-variation stats errors", () => {
+    expect(
+      getComputeErrorMessage({
+        errorMessage: "ZERO_NEGATIVE_VARIANCE",
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores no-data placeholders", () => {
+    expect(
+      getComputeErrorMessage({
+        computeFailed: true,
+        errorMessage: "No data",
+      }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
### Features and Changes

- Only show whole-row compute errors for results explicitly marked `computeFailed`.
- Keep per-variation stats errors such as `ZERO_NEGATIVE_VARIANCE` from being misclassified as analysis failures.

### Testing

- `pnpm --filter front-end test test/experimentComputeErrors.test.ts`
- `pnpm --filter front-end type-check`
- ESLint and Prettier for the changed files

### Screenshots

Not included. This restores the normal no-data rendering for zero-user variations and is covered by a regression test.
