### PR TITLE
Add experiment lifecycle alerts and immutable event cards

### DIFF
--- a/docs/snippets/partials/event-webhook/_event-webhook-list.mdx
+++ b/docs/snippets/partials/event-webhook/_event-webhook-list.mdx
@@ -42,6 +42,17 @@
 | **[experiment.decision.ship](#experiment-decision-ship)**                                                     | Triggered when an experiment is ready to ship a variation.                                                                                                                                                                                                                                                                    |
 | **[experiment.decision.rollback](#experiment-decision-rollback)**                                             | Triggered when an experiment should be rolled back to the control.                                                                                                                                                                                                                                                            |
 | **[experiment.decision.review](#experiment-decision-review)**                                                 | Triggered when an experiment has reached the desired power point, but the results may be ambiguous.                                                                                                                                                                                                                           |
+| **[experiment.started](#experiment-started)**                                                                 | Triggered when an experiment starts running.                                                                                                                                                                                                                                                                                  |
+| **[experiment.stopped](#experiment-stopped)**                                                                 | Triggered when an experiment stops, including its result and any temporary rollout.                                                                                                                                                                                                                                           |
+| **[experiment.health.guardrailFailed](#experiment-health-guardrailfailed)**                                   | Triggered when a running experiment has a failing guardrail metric.                                                                                                                                                                                                                                                           |
+| **[experiment.health.queryFailed](#experiment-health-queryfailed)**                                           | Triggered when experiment results fail to update because of a query error.                                                                                                                                                                                                                                                    |
+| **[experiment.status.changed](#experiment-status-changed)**                                                   | Triggered when an experiment status changes.                                                                                                                                                                                                                                                                                  |
+| **[experiment.endingSoon](#experiment-endingsoon)**                                                           | Triggered when a running experiment is nearing its scheduled end date.                                                                                                                                                                                                                                                        |
+| **[experiment.stale](#experiment-stale)**                                                                     | Triggered when a running experiment has been active for a long time without a decision.                                                                                                                                                                                                                                       |
+| **[experiment.metric.regression](#experiment-metric-regression)**                                             | Triggered when a metric regression is detected in an experiment.                                                                                                                                                                                                                                                              |
+| **[experiment.bandit.weightsChanged](#experiment-bandit-weightschanged)**                                     | Triggered when a multi-armed bandit materially changes variation weights.                                                                                                                                                                                                                                                     |
+| **[experiment.holdout.created](#experiment-holdout-created)**                                                 | Triggered when a holdout is created.                                                                                                                                                                                                                                                                                          |
+| **[experiment.holdout.updated](#experiment-holdout-updated)**                                                 | Triggered when a holdout is updated.                                                                                                                                                                                                                                                                                          |
 | **[savedGroup.created](#savedgroup-created)**                                                                 | Triggered when a saved group is created                                                                                                                                                                                                                                                                                       |
 | **[savedGroup.updated](#savedgroup-updated)**                                                                 | Triggered when a saved group is updated                                                                                                                                                                                                                                                                                       |
 | **[savedGroup.deleted](#savedgroup-deleted)**                                                                 | Triggered when a saved group is deleted                                                                                                                                                                                                                                                                                       |
@@ -3115,6 +3126,14 @@ Triggered when a goal or guardrail metric reaches significance in an experiment 
             statsEngine: string;
             criticalValue: number;
             winning: boolean;
+            snapshotId?: string | undefined;
+            differenceType?: string | undefined;
+            metricRole?: ("goal" | "secondary" | "guardrail") | undefined;
+            uplift?: number | undefined;
+            ci?: [
+                number,
+                number
+            ] | undefined;
         };
     };
     user: {
@@ -3300,6 +3319,519 @@ Triggered when an experiment has reached the desired power point, but the result
             experimentId: string;
             decisionDescription?: string | undefined;
             source: "scheduled-end" | "analysis";
+        };
+    };
+    user: {
+        type: "dashboard";
+        id: string;
+        email: string;
+        name: string;
+    } | {
+        type: "api_key";
+        apiKey: string;
+        id?: string | undefined;
+        name?: string | undefined;
+        email?: string | undefined;
+    } | {
+        type: "system";
+        subtype?: string | undefined;
+        id?: string | undefined;
+    } | null;
+    tags: string[];
+    /** The environments affected by the change described by this event. For live-state events (e.g. `feature.updated`) these are the environments whose effective configuration actually changed; for draft lifecycle events (`*.revision.*`) they are the environments the proposed changes would affect. Webhook environment filters match against this field. An empty array means the event has no environment-scoped impact (it will only be delivered to subscriptions without an environment filter). */
+    environments: string[];
+    containsSecrets: boolean;
+}
+```
+
+</Accordion>
+
+### experiment.started
+
+Triggered when an experiment starts running.
+
+<Accordion title="Payload">
+
+```typescript
+{
+    event: "experiment.started";
+    object: "experiment";
+    api_version: string;
+    created: number;
+    data: {
+        object: {
+            type: "started";
+            experimentId: string;
+            experimentName: string;
+            phaseName?: string | undefined;
+            variationCount: number;
+        };
+    };
+    user: {
+        type: "dashboard";
+        id: string;
+        email: string;
+        name: string;
+    } | {
+        type: "api_key";
+        apiKey: string;
+        id?: string | undefined;
+        name?: string | undefined;
+        email?: string | undefined;
+    } | {
+        type: "system";
+        subtype?: string | undefined;
+        id?: string | undefined;
+    } | null;
+    tags: string[];
+    /** The environments affected by the change described by this event. For live-state events (e.g. `feature.updated`) these are the environments whose effective configuration actually changed; for draft lifecycle events (`*.revision.*`) they are the environments the proposed changes would affect. Webhook environment filters match against this field. An empty array means the event has no environment-scoped impact (it will only be delivered to subscriptions without an environment filter). */
+    environments: string[];
+    containsSecrets: boolean;
+}
+```
+
+</Accordion>
+
+### experiment.stopped
+
+Triggered when an experiment stops, including its result and any temporary rollout.
+
+<Accordion title="Payload">
+
+```typescript
+{
+    event: "experiment.stopped";
+    object: "experiment";
+    api_version: string;
+    created: number;
+    data: {
+        object: {
+            type: "stopped";
+            experimentId: string;
+            experimentName: string;
+            results: "dnf" | "won" | "lost" | "inconclusive";
+            releasedVariationName?: string | undefined;
+            enableTemporaryRollout: boolean;
+            reason?: string | undefined;
+        };
+    };
+    user: {
+        type: "dashboard";
+        id: string;
+        email: string;
+        name: string;
+    } | {
+        type: "api_key";
+        apiKey: string;
+        id?: string | undefined;
+        name?: string | undefined;
+        email?: string | undefined;
+    } | {
+        type: "system";
+        subtype?: string | undefined;
+        id?: string | undefined;
+    } | null;
+    tags: string[];
+    /** The environments affected by the change described by this event. For live-state events (e.g. `feature.updated`) these are the environments whose effective configuration actually changed; for draft lifecycle events (`*.revision.*`) they are the environments the proposed changes would affect. Webhook environment filters match against this field. An empty array means the event has no environment-scoped impact (it will only be delivered to subscriptions without an environment filter). */
+    environments: string[];
+    containsSecrets: boolean;
+}
+```
+
+</Accordion>
+
+### experiment.health.guardrailFailed
+
+Triggered when a running experiment has a failing guardrail metric.
+
+<Accordion title="Payload">
+
+```typescript
+{
+    event: "experiment.health.guardrailFailed";
+    object: "experiment";
+    api_version: string;
+    created: number;
+    data: {
+        object: {
+            type: "guardrail-failed";
+            experimentId: string;
+            experimentName: string;
+            failedMetrics: {
+                id: string;
+                name: string;
+                variationName: string;
+            }[];
+        };
+    };
+    user: {
+        type: "dashboard";
+        id: string;
+        email: string;
+        name: string;
+    } | {
+        type: "api_key";
+        apiKey: string;
+        id?: string | undefined;
+        name?: string | undefined;
+        email?: string | undefined;
+    } | {
+        type: "system";
+        subtype?: string | undefined;
+        id?: string | undefined;
+    } | null;
+    tags: string[];
+    /** The environments affected by the change described by this event. For live-state events (e.g. `feature.updated`) these are the environments whose effective configuration actually changed; for draft lifecycle events (`*.revision.*`) they are the environments the proposed changes would affect. Webhook environment filters match against this field. An empty array means the event has no environment-scoped impact (it will only be delivered to subscriptions without an environment filter). */
+    environments: string[];
+    containsSecrets: boolean;
+}
+```
+
+</Accordion>
+
+### experiment.health.queryFailed
+
+Triggered when experiment results fail to update because of a query error.
+
+<Accordion title="Payload">
+
+```typescript
+{
+    event: "experiment.health.queryFailed";
+    object: "experiment";
+    api_version: string;
+    created: number;
+    data: {
+        object: {
+            type: "query-failed";
+            experimentId: string;
+            experimentName: string;
+            errorMessage?: string | undefined;
+        };
+    };
+    user: {
+        type: "dashboard";
+        id: string;
+        email: string;
+        name: string;
+    } | {
+        type: "api_key";
+        apiKey: string;
+        id?: string | undefined;
+        name?: string | undefined;
+        email?: string | undefined;
+    } | {
+        type: "system";
+        subtype?: string | undefined;
+        id?: string | undefined;
+    } | null;
+    tags: string[];
+    /** The environments affected by the change described by this event. For live-state events (e.g. `feature.updated`) these are the environments whose effective configuration actually changed; for draft lifecycle events (`*.revision.*`) they are the environments the proposed changes would affect. Webhook environment filters match against this field. An empty array means the event has no environment-scoped impact (it will only be delivered to subscriptions without an environment filter). */
+    environments: string[];
+    containsSecrets: boolean;
+}
+```
+
+</Accordion>
+
+### experiment.status.changed
+
+Triggered when an experiment status changes.
+
+<Accordion title="Payload">
+
+```typescript
+{
+    event: "experiment.status.changed";
+    object: "experiment";
+    api_version: string;
+    created: number;
+    data: {
+        object: {
+            type: "status-changed";
+            experimentId: string;
+            experimentName: string;
+            previousStatus: string;
+            currentStatus: string;
+        };
+    };
+    user: {
+        type: "dashboard";
+        id: string;
+        email: string;
+        name: string;
+    } | {
+        type: "api_key";
+        apiKey: string;
+        id?: string | undefined;
+        name?: string | undefined;
+        email?: string | undefined;
+    } | {
+        type: "system";
+        subtype?: string | undefined;
+        id?: string | undefined;
+    } | null;
+    tags: string[];
+    /** The environments affected by the change described by this event. For live-state events (e.g. `feature.updated`) these are the environments whose effective configuration actually changed; for draft lifecycle events (`*.revision.*`) they are the environments the proposed changes would affect. Webhook environment filters match against this field. An empty array means the event has no environment-scoped impact (it will only be delivered to subscriptions without an environment filter). */
+    environments: string[];
+    containsSecrets: boolean;
+}
+```
+
+</Accordion>
+
+### experiment.endingSoon
+
+Triggered when a running experiment is nearing its scheduled end date.
+
+<Accordion title="Payload">
+
+```typescript
+{
+    event: "experiment.endingSoon";
+    object: "experiment";
+    api_version: string;
+    created: number;
+    data: {
+        object: {
+            type: "ending-soon";
+            experimentId: string;
+            experimentName: string;
+            endsAt: string;
+            daysRemaining: number;
+        };
+    };
+    user: {
+        type: "dashboard";
+        id: string;
+        email: string;
+        name: string;
+    } | {
+        type: "api_key";
+        apiKey: string;
+        id?: string | undefined;
+        name?: string | undefined;
+        email?: string | undefined;
+    } | {
+        type: "system";
+        subtype?: string | undefined;
+        id?: string | undefined;
+    } | null;
+    tags: string[];
+    /** The environments affected by the change described by this event. For live-state events (e.g. `feature.updated`) these are the environments whose effective configuration actually changed; for draft lifecycle events (`*.revision.*`) they are the environments the proposed changes would affect. Webhook environment filters match against this field. An empty array means the event has no environment-scoped impact (it will only be delivered to subscriptions without an environment filter). */
+    environments: string[];
+    containsSecrets: boolean;
+}
+```
+
+</Accordion>
+
+### experiment.stale
+
+Triggered when a running experiment has been active for a long time without a decision.
+
+<Accordion title="Payload">
+
+```typescript
+{
+    event: "experiment.stale";
+    object: "experiment";
+    api_version: string;
+    created: number;
+    data: {
+        object: {
+            type: "stale";
+            experimentId: string;
+            experimentName: string;
+            daysRunning: number;
+            reason: string;
+        };
+    };
+    user: {
+        type: "dashboard";
+        id: string;
+        email: string;
+        name: string;
+    } | {
+        type: "api_key";
+        apiKey: string;
+        id?: string | undefined;
+        name?: string | undefined;
+        email?: string | undefined;
+    } | {
+        type: "system";
+        subtype?: string | undefined;
+        id?: string | undefined;
+    } | null;
+    tags: string[];
+    /** The environments affected by the change described by this event. For live-state events (e.g. `feature.updated`) these are the environments whose effective configuration actually changed; for draft lifecycle events (`*.revision.*`) they are the environments the proposed changes would affect. Webhook environment filters match against this field. An empty array means the event has no environment-scoped impact (it will only be delivered to subscriptions without an environment filter). */
+    environments: string[];
+    containsSecrets: boolean;
+}
+```
+
+</Accordion>
+
+### experiment.metric.regression
+
+Triggered when a metric regression is detected in an experiment.
+
+<Accordion title="Payload">
+
+```typescript
+{
+    event: "experiment.metric.regression";
+    object: "experiment";
+    api_version: string;
+    created: number;
+    data: {
+        object: {
+            type: "metric-regression";
+            experimentId: string;
+            experimentName: string;
+            metricId: string;
+            metricName: string;
+            variationName: string;
+            metricRole?: ("goal" | "secondary" | "guardrail") | undefined;
+            uplift?: number | undefined;
+            ci?: [
+                number,
+                number
+            ] | undefined;
+        };
+    };
+    user: {
+        type: "dashboard";
+        id: string;
+        email: string;
+        name: string;
+    } | {
+        type: "api_key";
+        apiKey: string;
+        id?: string | undefined;
+        name?: string | undefined;
+        email?: string | undefined;
+    } | {
+        type: "system";
+        subtype?: string | undefined;
+        id?: string | undefined;
+    } | null;
+    tags: string[];
+    /** The environments affected by the change described by this event. For live-state events (e.g. `feature.updated`) these are the environments whose effective configuration actually changed; for draft lifecycle events (`*.revision.*`) they are the environments the proposed changes would affect. Webhook environment filters match against this field. An empty array means the event has no environment-scoped impact (it will only be delivered to subscriptions without an environment filter). */
+    environments: string[];
+    containsSecrets: boolean;
+}
+```
+
+</Accordion>
+
+### experiment.bandit.weightsChanged
+
+Triggered when a multi-armed bandit materially changes variation weights.
+
+<Accordion title="Payload">
+
+```typescript
+{
+    event: "experiment.bandit.weightsChanged";
+    object: "experiment";
+    api_version: string;
+    created: number;
+    data: {
+        object: {
+            type: "bandit-weights-changed";
+            experimentId: string;
+            experimentName: string;
+            currentWeights: number[];
+            updatedWeights: number[];
+        };
+    };
+    user: {
+        type: "dashboard";
+        id: string;
+        email: string;
+        name: string;
+    } | {
+        type: "api_key";
+        apiKey: string;
+        id?: string | undefined;
+        name?: string | undefined;
+        email?: string | undefined;
+    } | {
+        type: "system";
+        subtype?: string | undefined;
+        id?: string | undefined;
+    } | null;
+    tags: string[];
+    /** The environments affected by the change described by this event. For live-state events (e.g. `feature.updated`) these are the environments whose effective configuration actually changed; for draft lifecycle events (`*.revision.*`) they are the environments the proposed changes would affect. Webhook environment filters match against this field. An empty array means the event has no environment-scoped impact (it will only be delivered to subscriptions without an environment filter). */
+    environments: string[];
+    containsSecrets: boolean;
+}
+```
+
+</Accordion>
+
+### experiment.holdout.created
+
+Triggered when a holdout is created.
+
+<Accordion title="Payload">
+
+```typescript
+{
+    event: "experiment.holdout.created";
+    object: "experiment";
+    api_version: string;
+    created: number;
+    data: {
+        object: {
+            type: "holdout-created" | "holdout-updated";
+            experimentId: string;
+            experimentName: string;
+        };
+    };
+    user: {
+        type: "dashboard";
+        id: string;
+        email: string;
+        name: string;
+    } | {
+        type: "api_key";
+        apiKey: string;
+        id?: string | undefined;
+        name?: string | undefined;
+        email?: string | undefined;
+    } | {
+        type: "system";
+        subtype?: string | undefined;
+        id?: string | undefined;
+    } | null;
+    tags: string[];
+    /** The environments affected by the change described by this event. For live-state events (e.g. `feature.updated`) these are the environments whose effective configuration actually changed; for draft lifecycle events (`*.revision.*`) they are the environments the proposed changes would affect. Webhook environment filters match against this field. An empty array means the event has no environment-scoped impact (it will only be delivered to subscriptions without an environment filter). */
+    environments: string[];
+    containsSecrets: boolean;
+}
+```
+
+</Accordion>
+
+### experiment.holdout.updated
+
+Triggered when a holdout is updated.
+
+<Accordion title="Payload">
+
+```typescript
+{
+    event: "experiment.holdout.updated";
+    object: "experiment";
+    api_version: string;
+    created: number;
+    data: {
+        object: {
+            type: "holdout-created" | "holdout-updated";
+            experimentId: string;
+            experimentName: string;
         };
     };
     user: {

--- a/packages/back-end/src/events/handlers/slack/experimentAlerts.ts
+++ b/packages/back-end/src/events/handlers/slack/experimentAlerts.ts
@@ -1,0 +1,84 @@
+import type { NotificationEvent } from "shared/types/events/notification-events";
+import { APP_ORIGIN } from "back-end/src/util/secrets";
+import type { SlackMessage } from "./slack-event-handler-utils";
+
+type AlertName =
+  | "experiment.started"
+  | "experiment.stopped"
+  | "experiment.health.guardrailFailed"
+  | "experiment.health.queryFailed"
+  | "experiment.status.changed"
+  | "experiment.endingSoon"
+  | "experiment.stale"
+  | "experiment.metric.regression"
+  | "experiment.bandit.weightsChanged"
+  | "experiment.holdout.created"
+  | "experiment.holdout.updated";
+
+type AlertEvent = Extract<NotificationEvent, { event: AlertName }>;
+
+export function buildExperimentAlertMessage(event: AlertEvent): SlackMessage {
+  const object = event.data.object;
+  let detail: string;
+  switch (event.event) {
+    case "experiment.started":
+      detail = `Started with ${event.data.object.variationCount} variations.`;
+      break;
+    case "experiment.stopped": {
+      const data = event.data.object;
+      detail = `Stopped. Result: ${data.results}.`;
+      if (data.enableTemporaryRollout && data.releasedVariationName) {
+        detail += ` Temporary rollout: ${data.releasedVariationName}.`;
+      }
+      if (data.reason) detail += ` ${data.reason}`;
+      break;
+    }
+    case "experiment.health.guardrailFailed":
+      detail = `Failing guardrails: ${event.data.object.failedMetrics.map((m) => `${m.name} (${m.variationName})`).join(", ")}.`;
+      break;
+    case "experiment.health.queryFailed":
+      detail = "The results query failed. Open GrowthBook for details.";
+      break;
+    case "experiment.status.changed":
+      detail = `Status changed from ${event.data.object.previousStatus} to ${event.data.object.currentStatus}.`;
+      break;
+    case "experiment.endingSoon":
+      detail = `Scheduled to end at ${event.data.object.endsAt}.`;
+      break;
+    case "experiment.stale":
+      detail = `Running for ${event.data.object.daysRunning} days. Review whether to stop or extend it.`;
+      break;
+    case "experiment.metric.regression":
+      detail = `Regression detected for ${event.data.object.metricName} (${event.data.object.variationName}).`;
+      break;
+    case "experiment.bandit.weightsChanged":
+      detail = `Bandit allocation changed from ${event.data.object.currentWeights.map((w) => `${(w * 100).toFixed(1)}%`).join(" / ")} to ${event.data.object.updatedWeights.map((w) => `${(w * 100).toFixed(1)}%`).join(" / ")}.`;
+      break;
+    case "experiment.holdout.created":
+      detail = "Holdout created.";
+      break;
+    case "experiment.holdout.updated":
+      detail = "Holdout updated.";
+      break;
+  }
+  const text = `${object.experimentName}: ${detail}`;
+  return {
+    text,
+    blocks: [
+      {
+        type: "section",
+        text: { type: "plain_text", text: text.slice(0, 3000), emoji: false },
+      },
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            text: { type: "plain_text", text: "View in GrowthBook" },
+            url: `${APP_ORIGIN}/experiment/${encodeURIComponent(object.experimentId)}`,
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/packages/back-end/src/events/handlers/slack/slack-event-handler-utils.ts
+++ b/packages/back-end/src/events/handlers/slack/slack-event-handler-utils.ts
@@ -34,6 +34,7 @@ import { APP_ORIGIN } from "back-end/src/util/secrets";
 import { getEvent } from "back-end/src/models/EventModel";
 import { cancellableFetch } from "back-end/src/util/http.util";
 import { logger } from "back-end/src/util/logger";
+import { buildExperimentAlertMessage } from "./experimentAlerts";
 
 // region Filtering
 
@@ -99,6 +100,19 @@ export const getSlackMessageForNotificationEvent = async (
         event.data.object,
         eventId,
       );
+
+    case "experiment.started":
+    case "experiment.stopped":
+    case "experiment.health.guardrailFailed":
+    case "experiment.health.queryFailed":
+    case "experiment.status.changed":
+    case "experiment.endingSoon":
+    case "experiment.stale":
+    case "experiment.metric.regression":
+    case "experiment.bandit.weightsChanged":
+    case "experiment.holdout.created":
+    case "experiment.holdout.updated":
+      return buildExperimentAlertMessage(event);
 
     case "experiment.warning":
       return buildSlackMessageForExperimentWarningEvent(event.data.object);

--- a/packages/back-end/src/jobs/updateExperimentResults.ts
+++ b/packages/back-end/src/jobs/updateExperimentResults.ts
@@ -20,7 +20,12 @@ import {
 } from "back-end/src/util/errors";
 import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizations";
 import { getMetricMap } from "back-end/src/models/MetricModel";
-import { notifyAutoUpdate } from "back-end/src/services/experimentNotifications";
+import {
+  notifyAutoUpdate,
+  notifyBanditWeightsChanged,
+  notifyExperimentEndingSoon,
+  notifyExperimentStale,
+} from "back-end/src/services/experimentNotifications";
 import { EXPERIMENT_REFRESH_FREQUENCY } from "back-end/src/util/secrets";
 import { logger } from "back-end/src/util/logger";
 import { getFactTableMap } from "back-end/src/models/FactTableModel";
@@ -111,6 +116,13 @@ const updateSingleExperiment = async (job: UpdateSingleExpJob) => {
 
   const experiment = await getExperimentById(context, experimentId);
   if (!experiment) return;
+
+  try {
+    await notifyExperimentEndingSoon({ context, experiment });
+    await notifyExperimentStale({ context, experiment });
+  } catch (error) {
+    logger.error(error, "Failed to notify experiment schedule alerts");
+  }
 
   let project = null;
   if (experiment.project) {
@@ -215,6 +227,20 @@ const updateSingleExperiment = async (job: UpdateSingleExpJob) => {
         experiment,
         changes,
       });
+      if (
+        currentSnapshot?.banditResult?.weightsWereUpdated &&
+        currentSnapshot.banditResult.currentWeights &&
+        currentSnapshot.banditResult.updatedWeights
+      ) {
+        await notifyBanditWeightsChanged({
+          context,
+          experiment,
+          currentWeights: currentSnapshot.banditResult.currentWeights,
+          updatedWeights: currentSnapshot.banditResult.updatedWeights,
+        }).catch((error: unknown) =>
+          logger.error(error, "Failed to notify bandit allocation change"),
+        );
+      }
     }
   } catch (e) {
     // Lock contention is transient so we don't disable auto-updates

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -21,6 +21,7 @@ import {
   Changeset,
   ExperimentInterface,
   ExperimentType,
+  ExperimentNotification,
   LegacyExperimentInterface,
   Variation,
 } from "shared/types/experiment";
@@ -787,6 +788,26 @@ export function hasActualChanges(
   return changeKeys.some((key) => !isEqual(experiment[key], changes[key]));
 }
 
+export async function setExperimentNotificationState({
+  context,
+  experiment,
+  type,
+  triggered,
+}: {
+  context: ReqContext | ApiReqContext;
+  experiment: ExperimentInterface;
+  type: ExperimentNotification;
+  triggered: boolean;
+}) {
+  // Independent alerts must not overwrite each other's delivery state.
+  await ExperimentModel.updateOne(
+    { id: experiment.id, organization: context.org.id },
+    triggered
+      ? { $addToSet: { pastNotifications: type } }
+      : { $pull: { pastNotifications: type } },
+  );
+}
+
 export async function updateExperiment({
   context,
   experiment,
@@ -1247,7 +1268,28 @@ export const logExperimentCreated = async (
   context: ReqContext | ApiReqContext,
   experiment: ExperimentInterface,
 ) => {
-  if (experiment.type === "holdout") return;
+  if (experiment.type === "holdout") {
+    await createEvent({
+      context,
+      object: "experiment",
+      objectId: experiment.id,
+      event: "holdout.created",
+      data: {
+        object: {
+          type: "holdout-created",
+          experimentId: experiment.id,
+          experimentName: experiment.name,
+        },
+      },
+      projects: experiment.project ? [experiment.project] : [],
+      tags: experiment.tags || [],
+      environments: [],
+      containsSecrets: false,
+    }).catch((error: unknown) =>
+      logger.error(error, "Failed to notify holdout creation"),
+    );
+    return;
+  }
 
   const apiExperiment = await toExperimentApiInterface(
     context,
@@ -1289,7 +1331,52 @@ export const logExperimentUpdated = async ({
   current: ExperimentInterface;
   previous: ExperimentInterface;
 }) => {
-  if (current.type === "holdout") return;
+  if (current.type === "holdout") {
+    await createEvent({
+      context,
+      object: "experiment",
+      objectId: current.id,
+      event: "holdout.updated",
+      data: {
+        object: {
+          type: "holdout-updated",
+          experimentId: current.id,
+          experimentName: current.name,
+        },
+      },
+      projects: current.project ? [current.project] : [],
+      tags: current.tags || [],
+      environments: [],
+      containsSecrets: false,
+    }).catch((error: unknown) =>
+      logger.error(error, "Failed to notify holdout update"),
+    );
+
+    if (previous.status !== current.status) {
+      await createEvent({
+        context,
+        object: "experiment",
+        objectId: current.id,
+        event: "status.changed",
+        data: {
+          object: {
+            type: "status-changed",
+            experimentId: current.id,
+            experimentName: current.name,
+            previousStatus: previous.status,
+            currentStatus: current.status,
+          },
+        },
+        projects: current.project ? [current.project] : [],
+        tags: current.tags || [],
+        environments: [],
+        containsSecrets: false,
+      }).catch((error: unknown) =>
+        logger.error(error, "Failed to notify experiment status change"),
+      );
+    }
+    return;
+  }
 
   const previousApiExperimentPromise = toExperimentApiInterface(
     context,
@@ -1360,6 +1447,34 @@ export const logExperimentUpdated = async ({
     environments: changedEnvs,
     containsSecrets: false,
   });
+
+  if (previous.status !== current.status) {
+    await createEvent({
+      context,
+      object: "experiment",
+      objectId: current.id,
+      event: "status.changed",
+      data: {
+        object: {
+          type: "status-changed",
+          experimentId: current.id,
+          experimentName: current.name,
+          previousStatus: previous.status,
+          currentStatus: current.status,
+        },
+      },
+      projects: Array.from(
+        new Set([previousApiExperiment.project, currentApiExperiment.project]),
+      ),
+      tags: Array.from(
+        new Set([...previousApiExperiment.tags, ...currentApiExperiment.tags]),
+      ),
+      environments: changedEnvs,
+      containsSecrets: false,
+    }).catch((error: unknown) =>
+      logger.error(error, "Failed to notify experiment status change"),
+    );
+  }
 };
 
 /**

--- a/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
@@ -685,6 +685,36 @@ export class ExperimentResultsQueryRunner extends QueryRunner<
       experimentUpdateExecutionLogger: this.experimentUpdateExecutionLogger,
     });
     if (
+      status === "failed" &&
+      this.model.type === "standard" &&
+      !this.model.report
+    ) {
+      try {
+        const { getExperimentById } = await import(
+          "back-end/src/models/ExperimentModel"
+        );
+        const { notifyExperimentQueryFailed } = await import(
+          "back-end/src/services/experimentNotifications"
+        );
+        const experiment = await getExperimentById(
+          this.context,
+          this.model.experiment,
+        );
+        if (experiment)
+          await notifyExperimentQueryFailed({
+            context: this.context,
+            experiment,
+            errorMessage: error,
+          });
+      } catch (notificationError) {
+        const { logger } = await import("back-end/src/util/logger");
+        logger.error(
+          notificationError,
+          "Failed to notify experiment query failure",
+        );
+      }
+    }
+    if (
       this.model.report &&
       ["failed", "partially-succeeded", "succeeded"].includes(status)
     ) {

--- a/packages/back-end/src/services/experimentChanges/changeExperimentStatus.ts
+++ b/packages/back-end/src/services/experimentChanges/changeExperimentStatus.ts
@@ -14,6 +14,7 @@ import {
   getAffectedEnvsForExperiment,
   experimentHasLiveLinkedChanges,
 } from "shared/util";
+import { logger } from "back-end/src/util/logger";
 import { orgHasPremiumFeature } from "back-end/src/enterprise";
 import {
   customHooksActive,
@@ -37,6 +38,10 @@ import {
   PendingDraftPublishResult,
   publishPendingFeatureDraftsForExperiment,
 } from "back-end/src/services/experiment-feature";
+import {
+  notifyExperimentStarted,
+  notifyExperimentStopped,
+} from "back-end/src/services/experimentNotifications";
 import {
   ChecklistIncompleteError,
   InvalidStatusError,
@@ -510,6 +515,15 @@ export async function executeExperimentStart(
     changes: { ...changes, nextScheduledStatusUpdate },
   });
 
+  if (experiment.status === "draft") {
+    await notifyExperimentStarted({
+      context,
+      experiment: updated,
+    }).catch((error: unknown) =>
+      logger.error(error, "Failed to notify experiment start"),
+    );
+  }
+
   trackEventForContext(context, "Experiment Started", {
     source: context.auditUser?.type ?? "agenda-job",
     hasDatasource: !!updated.datasource,
@@ -862,8 +876,26 @@ export async function stopExperiment({
     changes,
   });
 
-  // Only track true stop events; ignore results edits to already-stopped experiments.
   if (isEnding) {
+    const releasedVariationName =
+      variations[releasedVariationIndexFromId]?.name ||
+      variations[winner]?.name ||
+      undefined;
+
+    await notifyExperimentStopped({
+      context,
+      experiment: updated,
+      type: "stopped",
+      results: input.results,
+      enableTemporaryRollout,
+      releasedVariationName,
+      reason: input.reason,
+    }).catch((error: unknown) =>
+      logger.error(error, "Failed to notify experiment stop"),
+    );
+
+    // Only track true stop events; ignore results edits to already-stopped
+    // experiments.
     trackEventForContext(context, "Experiment Stopped", {
       source: context.auditUser?.type ?? "agenda-job",
       result: updated.results,

--- a/packages/back-end/src/services/experimentNotifications.ts
+++ b/packages/back-end/src/services/experimentNotifications.ts
@@ -27,7 +27,7 @@ import { ResourceEvents } from "shared/types/events/base-types";
 import { orgHasPremiumFeature } from "back-end/src/enterprise";
 import { Context } from "back-end/src/models/BaseModel";
 import { createEvent, CreateEventData } from "back-end/src/models/EventModel";
-import { updateExperiment } from "back-end/src/models/ExperimentModel";
+import { setExperimentNotificationState } from "back-end/src/models/ExperimentModel";
 import { logger } from "back-end/src/util/logger";
 import { getLatestSuccessfulSnapshot } from "back-end/src/models/ExperimentSnapshotModel";
 import { getExperimentMetricById } from "back-end/src/services/experiments";
@@ -85,16 +85,11 @@ export const memoizeNotification = async ({
 
   await dispatch();
 
-  const pastNotifications = triggered
-    ? [...(experiment.pastNotifications || []), type]
-    : (experiment.pastNotifications || []).filter((t) => t !== type);
-
-  await updateExperiment({
-    experiment,
+  await setExperimentNotificationState({
     context,
-    changes: {
-      pastNotifications,
-    },
+    experiment,
+    type,
+    triggered,
   });
 };
 
@@ -127,6 +122,66 @@ export const notifyAutoUpdate = ({
         },
       }),
   });
+
+export const notifyExperimentStarted = async ({
+  context,
+  experiment,
+}: {
+  context: Context;
+  experiment: ExperimentInterface;
+}) => {
+  const latestPhase = experiment.phases[experiment.phases.length - 1];
+
+  await dispatchEvent({
+    context,
+    experiment,
+    event: "started",
+    data: {
+      object: {
+        type: "started",
+        experimentId: experiment.id,
+        experimentName: experiment.name,
+        phaseName: latestPhase?.name,
+        variationCount: experiment.variations.length,
+      },
+    },
+  });
+};
+
+export const notifyExperimentStopped = async ({
+  context,
+  experiment,
+  type,
+  results,
+  enableTemporaryRollout,
+  releasedVariationName,
+  reason,
+}: {
+  context: Context;
+  experiment: ExperimentInterface;
+  type: "stopped";
+  results: NonNullable<ExperimentInterface["results"]>;
+  enableTemporaryRollout: boolean;
+  releasedVariationName?: string;
+  reason?: string;
+}) => {
+  await dispatchEvent({
+    context,
+    experiment,
+    event: "stopped",
+    data: {
+      object: {
+        type,
+        experimentId: experiment.id,
+        experimentName: experiment.name,
+        results,
+        releasedVariationName,
+        enableTemporaryRollout,
+        reason,
+      },
+    },
+  });
+};
 
 // Fires on every failed attempt of the scheduled-status-update job (not
 // memoized). Each event carries the attempt count and whether another retry
@@ -166,6 +221,103 @@ export const notifyScheduledStatusUpdateFailed = ({
       },
     },
   });
+
+const getSafeDate = (value: Date | string | undefined): Date | null => {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const daysBetweenDates = (start: Date, end: Date): number =>
+  Math.max(0, Math.ceil((end.getTime() - start.getTime()) / 86400000));
+
+export const notifyExperimentEndingSoon = async ({
+  context,
+  experiment,
+  windowDays = 3,
+}: {
+  context: Context;
+  experiment: ExperimentInterface;
+  windowDays?: number;
+}) => {
+  const endsAt = getSafeDate(experiment.statusUpdateSchedule?.stopAt);
+  const now = new Date();
+  const daysRemaining = endsAt ? daysBetweenDates(now, endsAt) : 0;
+  const triggered =
+    experiment.status === "running" &&
+    !!endsAt &&
+    endsAt.getTime() >= now.getTime() &&
+    daysRemaining <= windowDays;
+
+  await memoizeNotification({
+    context,
+    experiment,
+    type: "ending-soon",
+    triggered,
+    dispatch: async () => {
+      if (!triggered || !endsAt) return;
+      await dispatchEvent({
+        context,
+        experiment,
+        event: "endingSoon",
+        data: {
+          object: {
+            type: "ending-soon",
+            experimentId: experiment.id,
+            experimentName: experiment.name,
+            endsAt: endsAt.toISOString(),
+            daysRemaining,
+          },
+        },
+      });
+    },
+  });
+};
+
+export const notifyExperimentStale = async ({
+  context,
+  experiment,
+  staleAfterDays = 90,
+}: {
+  context: Context;
+  experiment: ExperimentInterface;
+  staleAfterDays?: number;
+}) => {
+  const firstPhase = experiment.phases[0];
+  const startedAt = getSafeDate(firstPhase?.dateStarted);
+  const daysRunning = startedAt
+    ? Math.max(0, Math.floor((Date.now() - startedAt.getTime()) / 86400000))
+    : 0;
+  const triggered =
+    experiment.status === "running" &&
+    !!startedAt &&
+    daysRunning >= staleAfterDays;
+
+  await memoizeNotification({
+    context,
+    experiment,
+    type: "stale",
+    triggered,
+    dispatch: async () => {
+      if (!triggered) return;
+      await dispatchEvent({
+        context,
+        experiment,
+        event: "stale",
+        data: {
+          object: {
+            type: "stale",
+            experimentId: experiment.id,
+            experimentName: experiment.name,
+            daysRunning,
+            reason:
+              "This experiment has been running for a long time. Review whether it should ship, roll back, or be extended.",
+          },
+        },
+      });
+    },
+  });
+};
 
 // Emitted when the scheduled-status-update job applies a start/stop. Not
 // memoized — each scheduled transition fires once. Flows to org webhooks/Slack
@@ -297,6 +449,88 @@ export const notifySrm = async ({
   return triggered && !experiment.pastNotifications?.includes("srm");
 };
 
+const getFailedGuardrailMetrics = async ({
+  context,
+  experiment,
+  analysisSummary,
+}: {
+  context: Context;
+  experiment: ExperimentInterface;
+  analysisSummary?: ExperimentAnalysisSummary;
+}) => {
+  const failedMetrics: {
+    id: string;
+    name: string;
+    variationName: string;
+  }[] = [];
+  const variations = getLatestPhaseVariations(experiment);
+
+  for (const variationStatus of analysisSummary?.resultsStatus?.variations ||
+    []) {
+    for (const [metricId, metricStatus] of Object.entries(
+      variationStatus.guardrailMetrics || {},
+    )) {
+      if (metricStatus.status !== "lost") continue;
+
+      const metric = await getExperimentMetricById(context, metricId);
+      const variation = variations.find(
+        (v) => v.id === variationStatus.variationId,
+      );
+
+      failedMetrics.push({
+        id: metricId,
+        name: metric?.name || metricId,
+        variationName: variation?.name || variationStatus.variationId,
+      });
+    }
+  }
+
+  return failedMetrics;
+};
+
+export const notifyGuardrailFailed = async ({
+  context,
+  experiment,
+}: {
+  context: Context;
+  experiment: ExperimentInterface;
+}) => {
+  const failedMetrics = await getFailedGuardrailMetrics({
+    context,
+    experiment,
+    analysisSummary: experiment.analysisSummary,
+  });
+  const triggered = experiment.status === "running" && failedMetrics.length > 0;
+
+  await memoizeNotification({
+    context,
+    experiment,
+    type: "guardrail-failed",
+    triggered,
+    dispatch: async () => {
+      if (!triggered) return;
+
+      await dispatchEvent({
+        context,
+        experiment,
+        event: "health.guardrailFailed",
+        data: {
+          object: {
+            type: "guardrail-failed",
+            experimentId: experiment.id,
+            experimentName: experiment.name,
+            failedMetrics,
+          },
+        },
+      });
+    },
+  });
+
+  return (
+    triggered && !experiment.pastNotifications?.includes("guardrail-failed")
+  );
+};
+
 export const notifyUnderpowered = async ({
   context,
   experiment,
@@ -378,6 +612,44 @@ export const notifyNoData = async ({
   return triggered && !experiment.pastNotifications?.includes("no-data");
 };
 
+export const notifyExperimentQueryFailed = async ({
+  context,
+  experiment,
+  errorMessage,
+  triggered = true,
+}: {
+  context: Context;
+  experiment: ExperimentInterface;
+  errorMessage?: string;
+  triggered?: boolean;
+}) => {
+  await memoizeNotification({
+    context,
+    experiment,
+    type: "query-failed",
+    triggered: experiment.status === "running" && triggered,
+    dispatch: async () => {
+      if (!triggered || experiment.status !== "running") return;
+
+      await dispatchEvent({
+        context,
+        experiment,
+        event: "health.queryFailed",
+        data: {
+          object: {
+            type: "query-failed",
+            experimentId: experiment.id,
+            experimentName: experiment.name,
+            errorMessage: errorMessage
+              ? "The results query failed. Open GrowthBook for details."
+              : undefined,
+          },
+        },
+      });
+    },
+  });
+};
+
 type ExperimentSignificanceChange = {
   experimentId: string;
   experimentName: string;
@@ -385,9 +657,14 @@ type ExperimentSignificanceChange = {
   variationName: string;
   metricId: string;
   metricName: string;
+  snapshotId?: string;
+  differenceType?: string;
+  metricRole?: "goal" | "secondary" | "guardrail";
   statsEngine: StatsEngine;
   criticalValue: number;
   winning: boolean;
+  uplift?: number;
+  ci?: [number, number];
 };
 
 const sendSignificanceEmail = async (
@@ -466,6 +743,22 @@ export const computeExperimentChanges = async ({
     experiment.goalMetrics,
     metricGroups,
   );
+  const expandedSecondaryMetrics = expandMetricGroups(
+    experiment.secondaryMetrics || [],
+    metricGroups,
+  );
+  const expandedGuardrailMetrics = expandMetricGroups(
+    experiment.guardrailMetrics || [],
+    metricGroups,
+  );
+  const getMetricRole = (
+    metricId: string,
+  ): ExperimentSignificanceChange["metricRole"] => {
+    if (expandedGoalMetrics.includes(metricId)) return "goal";
+    if (expandedGuardrailMetrics.includes(metricId)) return "guardrail";
+    if (expandedSecondaryMetrics.includes(metricId)) return "secondary";
+    return undefined;
+  };
 
   const currentResults = cloneDeep(currentAnalysis.results);
   setAdjustedPValuesOnResults(
@@ -506,7 +799,7 @@ export const computeExperimentChanges = async ({
 
       const criticalValue =
         statsEngine === "frequentist"
-          ? curMetric.pValue
+          ? (curMetric.pValueAdjusted ?? curMetric.pValue)
           : curMetric.chanceToWin;
       if (criticalValue === undefined) continue;
 
@@ -559,9 +852,13 @@ export const computeExperimentChanges = async ({
 
       if (winning === null) continue;
 
-      const { id: variationId, name: variationName } = getLatestPhaseVariations(
-        experiment,
-      )?.[i] || { id: i + "", name: "" };
+      const variationKey = currentSnapshot.settings.variations[i]?.id;
+      const variations = experiment.variations;
+      const variation =
+        variations.find((v) => v.key === variationKey) ??
+        variations.find((v) => v.id === variationKey);
+      if (!variation) continue;
+      const { id: variationId, name: variationName } = variation;
 
       experimentChanges.push({
         experimentId: experiment.id,
@@ -570,9 +867,14 @@ export const computeExperimentChanges = async ({
         variationName,
         metricId: m,
         metricName: metric.name,
+        snapshotId: currentSnapshot.id,
+        differenceType: currentAnalysis.settings.differenceType,
+        metricRole: getMetricRole(m),
         statsEngine,
         criticalValue,
         winning,
+        uplift: curMetric.uplift?.mean,
+        ci: curMetric.ciAdjusted || curMetric.ci,
       });
     }
   }
@@ -609,17 +911,84 @@ export const notifySignificance = async ({
   }
 
   await Promise.all(
-    experimentChanges.map((change) =>
-      dispatchEvent({
-        context,
-        experiment,
-        event: "info.significance",
-        data: {
-          object: change,
-        },
-      }),
-    ),
+    experimentChanges.flatMap((change) => {
+      const events = [
+        dispatchEvent({
+          context,
+          experiment,
+          event: "info.significance",
+          data: {
+            object: change,
+          },
+        }),
+      ];
+
+      if (!change.winning) {
+        events.push(
+          dispatchEvent({
+            context,
+            experiment,
+            event: "metric.regression",
+            data: {
+              object: {
+                type: "metric-regression",
+                experimentId: change.experimentId,
+                experimentName: change.experimentName,
+                metricId: change.metricId,
+                metricName: change.metricName,
+                variationName: change.variationName,
+                metricRole: change.metricRole,
+                uplift: change.uplift,
+                ci: change.ci,
+              },
+            },
+          }),
+        );
+      }
+
+      return events;
+    }),
   );
+};
+
+export const notifyBanditWeightsChanged = async ({
+  context,
+  experiment,
+  currentWeights,
+  updatedWeights,
+}: {
+  context: Context;
+  experiment: ExperimentInterface;
+  currentWeights: number[];
+  updatedWeights: number[];
+}) => {
+  if (
+    !currentWeights.length ||
+    currentWeights.length !== updatedWeights.length ||
+    [...currentWeights, ...updatedWeights].some(
+      (weight) => !Number.isFinite(weight),
+    )
+  )
+    return;
+  const maxDelta = Math.max(
+    ...updatedWeights.map((weight, i) => Math.abs(weight - currentWeights[i])),
+  );
+  if (maxDelta < 0.05) return;
+
+  await dispatchEvent({
+    context,
+    experiment,
+    event: "bandit.weightsChanged",
+    data: {
+      object: {
+        type: "bandit-weights-changed",
+        experimentId: experiment.id,
+        experimentName: experiment.name,
+        currentWeights,
+        updatedWeights,
+      },
+    },
+  });
 };
 
 export const notifyDecision = async ({
@@ -778,6 +1147,12 @@ export const notifyExperimentChange = async ({
     decisionCriteria,
   });
 
+  await notifyExperimentQueryFailed({
+    context,
+    experiment,
+    triggered: false,
+  });
+
   const triggeredNoData = await notifyNoData({
     context,
     experiment,
@@ -805,6 +1180,14 @@ export const notifyExperimentChange = async ({
     });
     if (triggeredSrm) {
       notificationsTriggered.push("srm");
+    }
+
+    const triggeredGuardrailFailure = await notifyGuardrailFailed({
+      context,
+      experiment,
+    });
+    if (triggeredGuardrailFailure) {
+      notificationsTriggered.push("guardrail-failed");
     }
 
     const triggeredUnderpowered = await notifyUnderpowered({

--- a/packages/back-end/src/services/notificationCards/cardImages.ts
+++ b/packages/back-end/src/services/notificationCards/cardImages.ts
@@ -247,6 +247,8 @@ export interface ExperimentCardData {
   ds?: string;
   note?: string;
   rows: CardGoalRow[];
+  summary?: string[];
+  sentiment?: "positive" | "negative";
   secondary?: CardCiMetric[];
   guardrail?: CardCiMetric[];
   // Shown above the conclusion for non-started states; and in the started body.
@@ -595,7 +597,7 @@ function arrowImg(dir: "up" | "down", color: string, size = 9): El {
 // Shared cells / primitives.
 // ---------------------------------------------------------------------------
 
-function badge(state: CardState): El {
+function badge(state: CardState, label = BADGE[state]): El {
   const hue = HUE[state];
   return el(
     "div",
@@ -615,7 +617,7 @@ function badge(state: CardState): El {
         borderRadius: 9999,
         backgroundColor: SOLID[hue],
       }),
-      txt(BADGE[state], { fontSize: 12, fontWeight: 600, color: P.st[hue] }),
+      txt(label, { fontSize: 12, fontWeight: 600, color: P.st[hue] }),
     ],
   );
 }
@@ -915,7 +917,10 @@ function headerEl(exp: ExperimentCardData): El {
             letterSpacing: "-0.01em",
           }),
           txt(exp.key, { fontSize: 12, color: P.subtle }, true),
-          badge(exp.state),
+          badge(
+            exp.state,
+            exp.summary && exp.state === "stopped" ? "Stopped" : undefined,
+          ),
         ],
       ),
       el(
@@ -1270,12 +1275,25 @@ function conclusionEl(exp: ExperimentCardData): El | null {
   );
 }
 
+function eventSummaryBody(lines: string[]): El {
+  return el(
+    "div",
+    { display: "flex", flexDirection: "column", gap: 12, padding: "20px 24px" },
+    lines.map((line) =>
+      txt(plainClamp(line, 240), { fontSize: 17, color: P.text }),
+    ),
+  );
+}
+
 function buildCard(exp: ExperimentCardData): El {
-  const hue = HUE[exp.state];
+  const hue = exp.sentiment === "negative" ? "red" : HUE[exp.state];
   let body: El;
   let footerItems: (string | undefined)[];
 
-  if (exp.state === "started") {
+  if (exp.summary) {
+    body = eventSummaryBody(exp.summary);
+    footerItems = [exp.dates];
+  } else if (exp.state === "started") {
     body = startedBody(exp);
     footerItems = [
       exp.variants.join(" · "),
@@ -1645,6 +1663,7 @@ function compactHero(
   event: CompactEvent,
   hue: Hue,
 ): El {
+  if (exp.summary) return eventSummaryBody(exp.summary);
   const accentText = P.st[hue];
   const r = exp.rows[0];
 
@@ -1897,7 +1916,7 @@ function buildCompactCard(exp: ExperimentCardData): El {
   const ev = COMPACT_EVENT[event];
   const r0 = exp.rows[0];
   // Event hue drives the rail + eyebrow; win/significance tint by direction.
-  let hue = ev.hue;
+  let hue = exp.sentiment === "negative" ? "red" : ev.hue;
   if ((event === "significance" || event === "won") && r0?.dir === "down") {
     hue = "red";
   }

--- a/packages/back-end/src/services/notificationCards/eventSnapshotCard.ts
+++ b/packages/back-end/src/services/notificationCards/eventSnapshotCard.ts
@@ -1,0 +1,91 @@
+import type { NotificationEvent } from "shared/types/events/notification-events";
+import {
+  experimentInfoSignificance,
+  experimentStartedNotificationPayload,
+  experimentStoppedNotificationPayload,
+} from "shared/validators";
+import type { ExperimentCardData } from "./cardImages";
+
+export function buildEventSnapshotCard(
+  event: NotificationEvent,
+): ExperimentCardData | null {
+  if (event.event === "experiment.info.significance") {
+    const parsed = experimentInfoSignificance.safeParse(event.data.object);
+    if (!parsed.success) return null;
+    const data = parsed.data;
+    // Older queued events lack immutable results. Never substitute today's snapshot.
+    if (
+      !["frequentist", "bayesian"].includes(data.statsEngine) ||
+      !data.snapshotId ||
+      data.differenceType !== "relative" ||
+      data.uplift === undefined ||
+      !Number.isFinite(data.uplift)
+    )
+      return null;
+    const summary = [
+      `${data.metricName} · ${data.variationName}`,
+      `Relative change: ${(data.uplift * 100).toFixed(2)}%`,
+      data.statsEngine === "frequentist"
+        ? `p-value: ${data.criticalValue.toPrecision(3)}`
+        : `Chance to beat baseline: ${(data.criticalValue * 100).toFixed(1)}%`,
+      data.winning
+        ? "Statistically significant improvement"
+        : "Statistically significant regression",
+    ];
+    return {
+      sentiment: data.winning ? "positive" : "negative",
+      state: "running",
+      event: "significance",
+      name: data.experimentName,
+      key: data.experimentId,
+      goal: data.metricName,
+      variants: [data.variationName],
+      rows: [],
+      summary,
+    };
+  }
+  if (event.event === "experiment.started") {
+    const parsed = experimentStartedNotificationPayload.safeParse(
+      event.data.object,
+    );
+    if (!parsed.success) return null;
+    const data = parsed.data;
+    return {
+      state: "started",
+      event: "started",
+      name: data.experimentName,
+      key: data.experimentId,
+      goal: "",
+      variants: [],
+      rows: [],
+      summary: [
+        `Started with ${data.variationCount} variations.`,
+        ...(data.phaseName ? [`Phase: ${data.phaseName}`] : []),
+      ],
+    };
+  }
+  if (event.event === "experiment.stopped") {
+    const parsed = experimentStoppedNotificationPayload.safeParse(
+      event.data.object,
+    );
+    if (!parsed.success) return null;
+    const data = parsed.data;
+    return {
+      state: "stopped",
+      event: "stopped",
+      name: data.experimentName,
+      key: data.experimentId,
+      goal: "",
+      variants: [],
+      rows: [],
+      summary: [
+        `Experiment stopped. Result: ${data.results}.`,
+        ...(data.enableTemporaryRollout && data.releasedVariationName
+          ? [`Temporary rollout: ${data.releasedVariationName}`]
+          : []),
+        ...(data.reason ? [data.reason] : []),
+      ],
+    };
+  }
+  return null;
+}

--- a/packages/back-end/src/services/notificationCards/experimentEventCard.ts
+++ b/packages/back-end/src/services/notificationCards/experimentEventCard.ts
@@ -3,6 +3,7 @@ import { experimentCardFormats } from "shared/validators";
 import { logger } from "back-end/src/util/logger";
 import type { CompactEvent } from "back-end/src/services/notificationCards/cardImages";
 import { renderExperimentCard } from "back-end/src/services/notificationCards/experimentCards";
+import { buildEventSnapshotCard } from "./eventSnapshotCard";
 
 const compactEventForNotification = (
   event: NotificationEvent,
@@ -40,7 +41,9 @@ export async function renderExperimentNotificationCard(
   format: ExperimentNotificationCardFormat = "compact",
 ): Promise<RenderedExperimentNotificationCard | null> {
   if (format === "none") return null;
-  const compactEvent = compactEventForNotification(event);
+  const snapshotCard = buildEventSnapshotCard(event);
+  const compactEvent =
+    snapshotCard?.event ?? compactEventForNotification(event);
   if (!compactEvent) return null;
 
   const object = event.data?.object as
@@ -56,11 +59,15 @@ export async function renderExperimentNotificationCard(
     const { buildExperimentCardData } = await import(
       "back-end/src/services/notificationCards/experimentCardData"
     );
-    const context = await getContextForAgendaJobByOrgId(organizationId);
-    const card = await buildExperimentCardData(context, experimentId);
+    const card =
+      snapshotCard ??
+      (await buildExperimentCardData(
+        await getContextForAgendaJobByOrgId(organizationId),
+        experimentId,
+      ));
     // A delayed warning may now load healthy or stopped results. Preserve the
     // event's text instead of presenting a contradictory current-state card.
-    if (!card || card.state !== "warning") return null;
+    if (!card || (!snapshotCard && card.state !== "warning")) return null;
 
     card.event = compactEvent;
     const png = await renderExperimentCard(

--- a/packages/back-end/src/services/slackIntegration.ts
+++ b/packages/back-end/src/services/slackIntegration.ts
@@ -46,7 +46,7 @@ import {
 const SLACK_AUTHORIZE_URL = "https://slack.com/oauth/v2/authorize";
 const SLACK_OAUTH_ACCESS_URL = "https://slack.com/api/oauth.v2.access";
 const SLACK_OAUTH_SCOPE =
-  "chat:write,files:write,channels:read,groups:read,channels:join,assistant:write,im:history,app_mentions:read";
+  "chat:write,files:write,channels:read,groups:read,channels:join,assistant:write,im:history,app_mentions:read,commands,links:read,links:write";
 const SLACK_OAUTH_STATE_MAX_AGE_MS = 10 * 60 * 1000;
 const DEFAULT_SLACK_EVENTS = ["experiment.*", "feature.*"];
 

--- a/packages/back-end/test/services/eventSnapshotCard.fixtures.ts
+++ b/packages/back-end/test/services/eventSnapshotCard.fixtures.ts
@@ -1,0 +1,78 @@
+import type { NotificationEvent } from "shared/types/events/notification-events";
+
+const base = {
+  experimentId: "exp-checkout",
+  experimentName: "Checkout redesign",
+};
+const significance = {
+  ...base,
+  variationId: "v-express",
+  variationName: "Express checkout",
+  metricId: "metric-revenue",
+  metricName: "Revenue per visitor",
+  statsEngine: "frequentist",
+  criticalValue: 0.012,
+  winning: true,
+  snapshotId: "snap-review",
+  differenceType: "relative",
+  uplift: 0.085,
+};
+
+export const eventSnapshotCardSamples: {
+  name: string;
+  event: NotificationEvent;
+}[] = [
+  {
+    name: "started",
+    event: {
+      event: "experiment.started",
+      data: {
+        object: {
+          ...base,
+          type: "started",
+          variationCount: 3,
+          phaseName: "Main phase",
+        },
+      },
+    } as NotificationEvent,
+  },
+  {
+    name: "stopped",
+    event: {
+      event: "experiment.stopped",
+      data: {
+        object: {
+          ...base,
+          type: "stopped",
+          results: "inconclusive",
+          enableTemporaryRollout: true,
+          releasedVariationName: "Original checkout",
+          reason:
+            "Pause while investigating instrumentation. No winner was selected; the original checkout remains active during the investigation.",
+        },
+      },
+    } as NotificationEvent,
+  },
+  {
+    name: "significance",
+    event: {
+      event: "experiment.info.significance",
+      data: { object: significance },
+    } as NotificationEvent,
+  },
+  {
+    name: "inverse-regression",
+    event: {
+      event: "experiment.info.significance",
+      data: {
+        object: {
+          ...significance,
+          metricName: "Checkout error rate (lower is better)",
+          metricId: "metric-errors",
+          winning: false,
+          uplift: 0.08,
+        },
+      },
+    } as NotificationEvent,
+  },
+];

--- a/packages/back-end/test/services/eventSnapshotCard.test.ts
+++ b/packages/back-end/test/services/eventSnapshotCard.test.ts
@@ -1,0 +1,96 @@
+import type { NotificationEvent } from "shared/types/events/notification-events";
+import { buildEventSnapshotCard } from "back-end/src/services/notificationCards/eventSnapshotCard";
+
+const significance = (
+  overrides: Record<string, unknown> = {},
+): NotificationEvent =>
+  ({
+    event: "experiment.info.significance",
+    data: {
+      object: {
+        experimentId: "exp-1",
+        experimentName: "Checkout",
+        variationId: "v-2",
+        variationName: "Express",
+        metricId: "m-2",
+        metricName: "Revenue",
+        statsEngine: "frequentist",
+        criticalValue: 0.012,
+        winning: true,
+        snapshotId: "snap-1",
+        differenceType: "relative",
+        uplift: 0.05,
+        ...overrides,
+      },
+    },
+  }) as NotificationEvent;
+
+describe("immutable event cards", () => {
+  it("uses the event's metric and variation, including frequentist terminology", () => {
+    expect(buildEventSnapshotCard(significance())).toMatchObject({
+      sentiment: "positive",
+      name: "Checkout",
+      goal: "Revenue",
+      variants: ["Express"],
+      rows: [],
+      summary: [
+        "Revenue · Express",
+        "Relative change: 5.00%",
+        "p-value: 0.0120",
+        "Statistically significant improvement",
+      ],
+    });
+  });
+  it("uses Bayesian probability instead of calling it a p-value", () => {
+    expect(
+      buildEventSnapshotCard(
+        significance({
+          statsEngine: "bayesian",
+          criticalValue: 0.02,
+          winning: false,
+          uplift: -0.08,
+        }),
+      )?.summary,
+    ).toContain("Chance to beat baseline: 2.0%");
+  });
+  it("colors an inverse-metric improvement by outcome rather than uplift sign", () => {
+    expect(
+      buildEventSnapshotCard(significance({ winning: true, uplift: -0.08 }))
+        ?.sentiment,
+    ).toBe("positive");
+    expect(
+      buildEventSnapshotCard(significance({ winning: false, uplift: 0.08 }))
+        ?.sentiment,
+    ).toBe("negative");
+  });
+  it.each([
+    { snapshotId: undefined },
+    { uplift: undefined },
+    { uplift: NaN },
+    { differenceType: "absolute" },
+    { differenceType: undefined },
+  ])(
+    "falls back for incomplete or unsupported immutable data %j",
+    (overrides) => {
+      expect(buildEventSnapshotCard(significance(overrides))).toBeNull();
+    },
+  );
+  it("does not call an inconclusive stop a rollback or ship", () => {
+    const event = {
+      event: "experiment.stopped",
+      data: {
+        object: {
+          type: "stopped",
+          experimentId: "exp-1",
+          experimentName: "Checkout",
+          results: "inconclusive",
+          enableTemporaryRollout: false,
+        },
+      },
+    } as NotificationEvent;
+    expect(buildEventSnapshotCard(event)).toMatchObject({
+      event: "stopped",
+      summary: ["Experiment stopped. Result: inconclusive."],
+    });
+  });
+});

--- a/packages/back-end/test/services/experimentAlerts.test.ts
+++ b/packages/back-end/test/services/experimentAlerts.test.ts
@@ -1,0 +1,38 @@
+import type { NotificationEvent } from "shared/types/events/notification-events";
+import { buildExperimentAlertMessage } from "back-end/src/events/handlers/slack/experimentAlerts";
+
+describe("experiment alert messages", () => {
+  it("preserves user text as plain text without enabling Slack mentions", () => {
+    const event = {
+      event: "experiment.started",
+      data: {
+        object: {
+          type: "started",
+          experimentId: "exp-1",
+          experimentName: "<!channel>",
+          variationCount: 3,
+        },
+      },
+    } as Extract<NotificationEvent, { event: "experiment.started" }>;
+    expect(buildExperimentAlertMessage(event).blocks[0]).toMatchObject({
+      text: {
+        type: "plain_text",
+        text: "<!channel>: Started with 3 variations.",
+      },
+    });
+  });
+  it("does not send raw warehouse errors into Slack", () => {
+    const event = {
+      event: "experiment.health.queryFailed",
+      data: {
+        object: {
+          type: "query-failed",
+          experimentId: "exp-1",
+          experimentName: "Checkout",
+          errorMessage: "secret SQL",
+        },
+      },
+    } as Extract<NotificationEvent, { event: "experiment.health.queryFailed" }>;
+    expect(buildExperimentAlertMessage(event).text).not.toContain("secret SQL");
+  });
+});

--- a/packages/back-end/test/services/experimentNotifications.test.ts
+++ b/packages/back-end/test/services/experimentNotifications.test.ts
@@ -1,8 +1,8 @@
 import { memoizeNotification } from "back-end/src/services/experimentNotifications";
-import { updateExperiment } from "back-end/src/models/ExperimentModel";
+import { setExperimentNotificationState } from "back-end/src/models/ExperimentModel";
 
 jest.mock("back-end/src/models/ExperimentModel", () => ({
-  updateExperiment: jest.fn(),
+  setExperimentNotificationState: jest.fn(),
 }));
 
 describe("memoizeNotification", () => {
@@ -17,8 +17,9 @@ describe("memoizeNotification", () => {
     });
 
     expect(dispatch).toHaveBeenCalled();
-    expect(updateExperiment).toHaveBeenCalledWith({
-      changes: { pastNotifications: ["foo"] },
+    expect(setExperimentNotificationState).toHaveBeenCalledWith({
+      type: "foo",
+      triggered: true,
       context: "da-context",
       experiment: { id: "da-experiment" },
     });
@@ -35,7 +36,7 @@ describe("memoizeNotification", () => {
     });
 
     expect(dispatch).not.toHaveBeenCalled();
-    expect(updateExperiment).not.toHaveBeenCalledWith();
+    expect(setExperimentNotificationState).not.toHaveBeenCalledWith();
   });
 
   it("calls the handler when notification is not triggered and it was previously dispatched", async () => {
@@ -49,8 +50,9 @@ describe("memoizeNotification", () => {
     });
 
     expect(dispatch).toHaveBeenCalled();
-    expect(updateExperiment).toHaveBeenCalledWith({
-      changes: { pastNotifications: ["bla"] },
+    expect(setExperimentNotificationState).toHaveBeenCalledWith({
+      type: "foo",
+      triggered: false,
       context: "da-context",
       experiment: { id: "da-experiment", pastNotifications: ["foo", "bla"] },
     });
@@ -67,6 +69,6 @@ describe("memoizeNotification", () => {
     });
 
     expect(dispatch).not.toHaveBeenCalled();
-    expect(updateExperiment).not.toHaveBeenCalledWith();
+    expect(setExperimentNotificationState).not.toHaveBeenCalledWith();
   });
 });

--- a/packages/back-end/test/services/experimentNotifications/experimentAlerts.test.ts
+++ b/packages/back-end/test/services/experimentNotifications/experimentAlerts.test.ts
@@ -1,0 +1,171 @@
+import type { ExperimentInterface } from "shared/types/experiment";
+import type { Context } from "back-end/src/models/BaseModel";
+import { createEvent } from "back-end/src/models/EventModel";
+import { setExperimentNotificationState } from "back-end/src/models/ExperimentModel";
+import {
+  notifyBanditWeightsChanged,
+  notifyExperimentEndingSoon,
+  notifyExperimentQueryFailed,
+  notifyExperimentStale,
+  notifyExperimentStopped,
+} from "back-end/src/services/experimentNotifications";
+
+jest.mock("back-end/src/models/EventModel", () => ({ createEvent: jest.fn() }));
+jest.mock("back-end/src/models/ExperimentModel", () => ({
+  setExperimentNotificationState: jest.fn(),
+}));
+
+const context = { org: { id: "org_test" } } as Context;
+const now = new Date("2026-09-10T12:00:00Z");
+const day = 86400000;
+const experiment = {
+  id: "exp_test",
+  name: "Test experiment",
+  status: "running",
+  type: "standard",
+  phases: [{ dateStarted: new Date(now.getTime() - 90 * day) }],
+  variations: [],
+  tags: [],
+  pastNotifications: [],
+} as unknown as ExperimentInterface;
+
+describe("experiment alert producers", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers().setSystemTime(now);
+  });
+  afterEach(() => jest.useRealTimers());
+
+  it("requires 90 complete days for a stale alert", async () => {
+    await notifyExperimentStale({
+      context,
+      experiment: {
+        ...experiment,
+        phases: [
+          {
+            ...experiment.phases[0],
+            dateStarted: new Date(now.getTime() - 90 * day + 1),
+          },
+        ],
+      },
+    });
+    expect(createEvent).not.toHaveBeenCalled();
+    await notifyExperimentStale({ context, experiment });
+    expect(createEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "stale",
+        data: { object: expect.objectContaining({ daysRunning: 90 }) },
+      }),
+    );
+  });
+
+  it("does not announce an end date outside the window or in the past", async () => {
+    for (const stopAt of [
+      new Date(now.getTime() + 3 * day + 1),
+      new Date(now.getTime() - 1),
+    ]) {
+      await notifyExperimentEndingSoon({
+        context,
+        experiment: {
+          ...experiment,
+          statusUpdateSchedule: { stopAt },
+        } as ExperimentInterface,
+      });
+    }
+    expect(createEvent).not.toHaveBeenCalled();
+  });
+
+  it("updates independent markers when ending and stale alerts fire together", async () => {
+    const scheduled = {
+      ...experiment,
+      statusUpdateSchedule: { stopAt: new Date(now.getTime() + 2 * day + 1) },
+    } as ExperimentInterface;
+    await notifyExperimentEndingSoon({ context, experiment: scheduled });
+    await notifyExperimentStale({ context, experiment: scheduled });
+    expect(createEvent).toHaveBeenCalledTimes(2);
+    expect(createEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "endingSoon",
+        data: { object: expect.objectContaining({ daysRemaining: 3 }) },
+      }),
+    );
+    expect(
+      jest.mocked(setExperimentNotificationState).mock.calls.map(([args]) => ({
+        type: args.type,
+        triggered: args.triggered,
+      })),
+    ).toEqual([
+      { type: "ending-soon", triggered: true },
+      { type: "stale", triggered: true },
+    ]);
+  });
+
+  it("redacts query errors and clears only the query marker on recovery", async () => {
+    await notifyExperimentQueryFailed({
+      context,
+      experiment,
+      errorMessage: "secret-database-password",
+    });
+    expect(JSON.stringify(jest.mocked(createEvent).mock.calls)).not.toContain(
+      "secret-database-password",
+    );
+    jest.mocked(createEvent).mockClear();
+    const failed = {
+      ...experiment,
+      pastNotifications: ["query-failed", "srm"],
+    } as ExperimentInterface;
+    await notifyExperimentQueryFailed({
+      context,
+      experiment: failed,
+      triggered: false,
+    });
+    expect(createEvent).not.toHaveBeenCalled();
+    expect(setExperimentNotificationState).toHaveBeenLastCalledWith({
+      context,
+      experiment: failed,
+      type: "query-failed",
+      triggered: false,
+    });
+  });
+
+  it("ignores insignificant or invalid bandit allocations", async () => {
+    for (const updatedWeights of [[0.51, 0.49], [NaN, 0.5], [0.6]]) {
+      await notifyBanditWeightsChanged({
+        context,
+        experiment,
+        currentWeights: [0.5, 0.5],
+        updatedWeights,
+      });
+    }
+    expect(createEvent).not.toHaveBeenCalled();
+    await notifyBanditWeightsChanged({
+      context,
+      experiment,
+      currentWeights: [0.5, 0.5],
+      updatedWeights: [0.7, 0.3],
+    });
+    expect(createEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains an inconclusive stop without inventing a shipped winner", async () => {
+    await notifyExperimentStopped({
+      context,
+      experiment,
+      type: "stopped",
+      results: "inconclusive",
+      enableTemporaryRollout: false,
+    });
+    expect(createEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "stopped",
+        data: {
+          object: expect.objectContaining({
+            results: "inconclusive",
+            enableTemporaryRollout: false,
+            releasedVariationName: undefined,
+          }),
+        },
+      }),
+    );
+  });
+});

--- a/packages/back-end/test/services/experimentNotifications/experimentSignificance.test.ts
+++ b/packages/back-end/test/services/experimentNotifications/experimentSignificance.test.ts
@@ -121,7 +121,7 @@ describe("Experiment Significance notifications", () => {
   const { isReady, setReqContext } = setupApp();
   const orgId = experiments[0].organization;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     await isReady;
 
     const globalContext = {
@@ -184,5 +184,36 @@ describe("Experiment Significance notifications", () => {
         );
       },
     );
+  });
+  it("resolves variation names by snapshot key after variations are reordered", async () => {
+    getLatestSuccessfulSnapshot.mockReturnValue(undefined);
+    getSignificanceSettingsForProject.mockResolvedValue({
+      ciUpper: 0.95,
+      ciLower: 0.05,
+      pValueThreshold: 0.05,
+      pValueCorrection: null,
+    });
+    getMetricDefaultsForOrg.mockReturnValue([]);
+    const experiment = ensureAndReturn(
+      await ExperimentModel.findOne({ id: snapshots.base.experiment }),
+    ).toObject();
+    const expectedVariation = experiment.variations[1];
+    experiment.variations.reverse();
+    const results = await computeExperimentChanges({
+      context: {
+        org: { id: orgId },
+        permissions: { canReadMultiProjectResource: () => true },
+        models: { metricGroups: { getAll: () => [] } },
+      },
+      experiment,
+      snapshot: snapshots.base,
+    });
+    expect(results).toEqual([
+      expect.objectContaining({
+        variationId: expectedVariation.id,
+        variationName: expectedVariation.name,
+        snapshotId: snapshots.base.id,
+      }),
+    ]);
   });
 });

--- a/packages/back-end/test/services/notification-card-images.smoke.test.ts
+++ b/packages/back-end/test/services/notification-card-images.smoke.test.ts
@@ -1,9 +1,11 @@
+import { buildEventSnapshotCard } from "back-end/src/services/notificationCards/eventSnapshotCard";
 import {
   type CardState,
   type CompactEvent,
   sampleCard,
 } from "back-end/src/services/notificationCards/cardImages";
 import { renderExperimentCard } from "back-end/src/services/notificationCards/experimentCards";
+import { eventSnapshotCardSamples } from "./eventSnapshotCard.fixtures";
 
 const isPng = (png: Buffer) =>
   png.subarray(0, 8).toString("hex") === "89504e470d0a1a0a";
@@ -45,6 +47,26 @@ describe("renderExperimentCard", () => {
       const png = await renderExperimentCard(card, "compact");
       expect(isPng(png)).toBe(true);
       expect(png.length).toBeGreaterThan(2000);
+    },
+    30000,
+  );
+});
+
+describe("immutable event summary rendering", () => {
+  it.each(eventSnapshotCardSamples)(
+    "renders compact and detailed $name cards without result rows",
+    async ({ event }) => {
+      const card = buildEventSnapshotCard(event);
+      expect(card).not.toBeNull();
+      if (!card) throw new Error("Missing event sample card");
+      expect(card.rows).toEqual([]);
+      for (const style of ["compact", "detailed"] as const) {
+        const png = await renderExperimentCard(card, style);
+        expect(isPng(png)).toBe(true);
+        expect(png.readUInt32BE(16)).toBeGreaterThan(500);
+        expect(png.readUInt32BE(20)).toBeGreaterThan(150);
+        expect(png.length).toBeGreaterThan(2000);
+      }
     },
     30000,
   );

--- a/packages/back-end/test/services/slackIntegration.test.ts
+++ b/packages/back-end/test/services/slackIntegration.test.ts
@@ -49,9 +49,12 @@ describe("Slack OAuth validation", () => {
       "channels:join",
       "channels:read",
       "chat:write",
+      "commands",
       "files:write",
       "groups:read",
       "im:history",
+      "links:read",
+      "links:write",
     ]);
     expect(url.searchParams.has("user_scope")).toBe(false);
   });

--- a/packages/front-end/components/SlackIntegrations/SlackChannelSettings.tsx
+++ b/packages/front-end/components/SlackIntegrations/SlackChannelSettings.tsx
@@ -33,6 +33,9 @@ const REQUIRED_SCOPES = [
   "assistant:write",
   "im:history",
   "app_mentions:read",
+  "commands",
+  "links:read",
+  "links:write",
 ];
 
 const CARD_FORMAT_LABELS: Record<

--- a/packages/front-end/pages/integrations/slack/index.tsx
+++ b/packages/front-end/pages/integrations/slack/index.tsx
@@ -67,6 +67,9 @@ const REQUIRED_SCOPES = [
   "assistant:write",
   "im:history",
   "app_mentions:read",
+  "commands",
+  "links:read",
+  "links:write",
 ];
 
 const getQueryStringValue = (value: string | string[] | undefined) =>
@@ -614,9 +617,10 @@ const SlackWorkspacePage: NextPage = () => {
             <code>chat:write</code>, <code>files:write</code>,{" "}
             <code>channels:read</code>, <code>groups:read</code>,{" "}
             <code>channels:join</code>, <code>assistant:write</code>,{" "}
-            <code>im:history</code>, and <code>app_mentions:read</code> bot
-            scopes. A Slack signing secret is not required for outgoing
-            notifications.
+            <code>im:history</code>, <code>app_mentions:read</code>,{" "}
+            <code>commands</code>, <code>links:read</code>, and{" "}
+            <code>links:write</code> bot scopes. A Slack signing secret is not
+            required for outgoing notifications.
           </Callout>
         )}
 

--- a/packages/shared/src/validators/events.ts
+++ b/packages/shared/src/validators/events.ts
@@ -48,6 +48,18 @@ import {
   experimentInfoScheduledStatusUpdate,
 } from "./experiment-info";
 import { experimentDecisionNotificationPayload } from "./experiment-decision";
+import {
+  experimentStartedNotificationPayload,
+  experimentStoppedNotificationPayload,
+  experimentGuardrailFailedNotificationPayload,
+  experimentQueryFailedNotificationPayload,
+  experimentStatusChangedNotificationPayload,
+  experimentEndingSoonNotificationPayload,
+  experimentStaleNotificationPayload,
+  experimentMetricRegressionNotificationPayload,
+  experimentBanditChangedNotificationPayload,
+  experimentHoldoutNotificationPayload,
+} from "./experiment-alerts";
 import { userLoginInterface } from "./users";
 import { apiSavedGroupValidator } from "./saved-group";
 import {
@@ -317,6 +329,57 @@ export const notificationEvents = {
     "decision.review": {
       schema: experimentDecisionNotificationPayload,
       description: `Triggered when an experiment has reached the desired power point, but the results may be ambiguous.`,
+    },
+    started: {
+      schema: experimentStartedNotificationPayload,
+      description: "Triggered when an experiment starts running.",
+    },
+    stopped: {
+      schema: experimentStoppedNotificationPayload,
+      description:
+        "Triggered when an experiment stops, including its result and any temporary rollout.",
+    },
+    "health.guardrailFailed": {
+      schema: experimentGuardrailFailedNotificationPayload,
+      description:
+        "Triggered when a running experiment has a failing guardrail metric.",
+    },
+    "health.queryFailed": {
+      schema: experimentQueryFailedNotificationPayload,
+      description:
+        "Triggered when experiment results fail to update because of a query error.",
+    },
+    "status.changed": {
+      schema: experimentStatusChangedNotificationPayload,
+      description: "Triggered when an experiment status changes.",
+    },
+    endingSoon: {
+      schema: experimentEndingSoonNotificationPayload,
+      description:
+        "Triggered when a running experiment is nearing its scheduled end date.",
+    },
+    stale: {
+      schema: experimentStaleNotificationPayload,
+      description:
+        "Triggered when a running experiment has been active for a long time without a decision.",
+    },
+    "metric.regression": {
+      schema: experimentMetricRegressionNotificationPayload,
+      description:
+        "Triggered when a metric regression is detected in an experiment.",
+    },
+    "bandit.weightsChanged": {
+      schema: experimentBanditChangedNotificationPayload,
+      description:
+        "Triggered when a multi-armed bandit materially changes variation weights.",
+    },
+    "holdout.created": {
+      schema: experimentHoldoutNotificationPayload,
+      description: "Triggered when a holdout is created.",
+    },
+    "holdout.updated": {
+      schema: experimentHoldoutNotificationPayload,
+      description: "Triggered when a holdout is updated.",
     },
   },
   savedGroup: {
@@ -614,7 +677,12 @@ export const notificationEventNames = (
   [] as NotificationEventName[],
 );
 
-/** Non-empty tuple for z.enum that avoids recursive union-to-tuple instantiation. */
+// Only use this for zod validations! Asserted to a non-empty tuple of the union
+// element type rather than `UnionToTuple<NotificationEventName>` — that maps a
+// union to an exact ordered tuple by recursing once per member, and the event
+// union has grown large enough to blow tsc's instantiation-depth limit (TS2589).
+// z.enum only needs `[string, ...string[]]`, and infers the same
+// `NotificationEventName` value type either way, so runtime behavior is identical.
 export const zodNotificationEventNamesEnum = notificationEventNames as [
   NotificationEventName,
   ...NotificationEventName[],

--- a/packages/shared/src/validators/experiment-alerts.ts
+++ b/packages/shared/src/validators/experiment-alerts.ts
@@ -1,0 +1,152 @@
+import { z } from "zod";
+import { experimentResultsType } from "./experiments";
+
+export const experimentStartedNotificationPayload = z
+  .object({
+    type: z.literal("started"),
+    experimentId: z.string(),
+    experimentName: z.string(),
+    phaseName: z.string().optional(),
+    variationCount: z.number(),
+  })
+  .strict();
+
+export const experimentStoppedNotificationPayload = z
+  .object({
+    type: z.literal("stopped"),
+    experimentId: z.string(),
+    experimentName: z.string(),
+    results: z.enum(experimentResultsType),
+    releasedVariationName: z.string().optional(),
+    enableTemporaryRollout: z.boolean(),
+    reason: z.string().optional(),
+  })
+  .strict();
+
+export const experimentGuardrailFailedNotificationPayload = z
+  .object({
+    type: z.literal("guardrail-failed"),
+    experimentId: z.string(),
+    experimentName: z.string(),
+    failedMetrics: z.array(
+      z
+        .object({
+          id: z.string(),
+          name: z.string(),
+          variationName: z.string(),
+        })
+        .strict(),
+    ),
+  })
+  .strict();
+
+export const experimentQueryFailedNotificationPayload = z
+  .object({
+    type: z.literal("query-failed"),
+    experimentId: z.string(),
+    experimentName: z.string(),
+    errorMessage: z.string().optional(),
+  })
+  .strict();
+
+export const experimentStatusChangedNotificationPayload = z
+  .object({
+    type: z.literal("status-changed"),
+    experimentId: z.string(),
+    experimentName: z.string(),
+    previousStatus: z.string(),
+    currentStatus: z.string(),
+  })
+  .strict();
+
+export const experimentEndingSoonNotificationPayload = z
+  .object({
+    type: z.literal("ending-soon"),
+    experimentId: z.string(),
+    experimentName: z.string(),
+    endsAt: z.string(),
+    daysRemaining: z.number(),
+  })
+  .strict();
+
+export const experimentStaleNotificationPayload = z
+  .object({
+    type: z.literal("stale"),
+    experimentId: z.string(),
+    experimentName: z.string(),
+    daysRunning: z.number(),
+    reason: z.string(),
+  })
+  .strict();
+
+export const experimentMetricRegressionNotificationPayload = z
+  .object({
+    type: z.literal("metric-regression"),
+    experimentId: z.string(),
+    experimentName: z.string(),
+    metricId: z.string(),
+    metricName: z.string(),
+    variationName: z.string(),
+    metricRole: z.enum(["goal", "secondary", "guardrail"]).optional(),
+    uplift: z.number().optional(),
+    ci: z.tuple([z.number(), z.number()]).optional(),
+  })
+  .strict();
+
+export const experimentBanditChangedNotificationPayload = z
+  .object({
+    type: z.literal("bandit-weights-changed"),
+    experimentId: z.string(),
+    experimentName: z.string(),
+    currentWeights: z.array(z.number()),
+    updatedWeights: z.array(z.number()),
+  })
+  .strict();
+
+export const experimentHoldoutNotificationPayload = z
+  .object({
+    type: z.union([z.literal("holdout-created"), z.literal("holdout-updated")]),
+    experimentId: z.string(),
+    experimentName: z.string(),
+  })
+  .strict();
+
+export type ExperimentStartedNotificationPayload = z.infer<
+  typeof experimentStartedNotificationPayload
+>;
+
+export type ExperimentStoppedNotificationPayload = z.infer<
+  typeof experimentStoppedNotificationPayload
+>;
+
+export type ExperimentGuardrailFailedNotificationPayload = z.infer<
+  typeof experimentGuardrailFailedNotificationPayload
+>;
+
+export type ExperimentQueryFailedNotificationPayload = z.infer<
+  typeof experimentQueryFailedNotificationPayload
+>;
+
+export type ExperimentStatusChangedNotificationPayload = z.infer<
+  typeof experimentStatusChangedNotificationPayload
+>;
+
+export type ExperimentEndingSoonNotificationPayload = z.infer<
+  typeof experimentEndingSoonNotificationPayload
+>;
+
+export type ExperimentStaleNotificationPayload = z.infer<
+  typeof experimentStaleNotificationPayload
+>;
+
+export type ExperimentMetricRegressionNotificationPayload = z.infer<
+  typeof experimentMetricRegressionNotificationPayload
+>;
+
+export type ExperimentBanditChangedNotificationPayload = z.infer<
+  typeof experimentBanditChangedNotificationPayload
+>;
+
+export type ExperimentHoldoutNotificationPayload = z.infer<
+  typeof experimentHoldoutNotificationPayload
+>;

--- a/packages/shared/src/validators/experiment-info.ts
+++ b/packages/shared/src/validators/experiment-info.ts
@@ -11,6 +11,11 @@ export const experimentInfoSignificance = z
     statsEngine: z.string(),
     criticalValue: z.number(),
     winning: z.boolean(),
+    snapshotId: z.string().optional(),
+    differenceType: z.string().optional(),
+    metricRole: z.enum(["goal", "secondary", "guardrail"]).optional(),
+    uplift: z.number().optional(),
+    ci: z.tuple([z.number(), z.number()]).optional(),
   })
   .strict();
 

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -177,6 +177,10 @@ export const experimentNotification = [
   "srm",
   "no-data",
   "significance",
+  "guardrail-failed",
+  "query-failed",
+  "ending-soon",
+  "stale",
   "underpowered",
 ] as const;
 export type ExperimentNotification = (typeof experimentNotification)[number];

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -95,3 +95,5 @@ export * from "./contextual-bandit-query";
 export * from "./contextual-bandit-snapshot";
 export * from "./contextual-bandit-event";
 export * from "./api-errors";
+
+export * from "./experiment-alerts";


### PR DESCRIPTION
Superseded by #6926 after renaming the source branch to the required `gm/` prefix. No implementation was discarded.

Adds experiment lifecycle and health notifications and renders start, stop, and significance cards from immutable event payloads. A delayed significance notification now preserves the exact metric and variation that triggered it, including after variation reordering. Older or unsupported significance payloads remain text-only.

Based on #6870 (`gm/generic-notification-cards`), which now includes main through 95730a2503. Kept separate from digests because this is a substantial producer/schema change. The original source remains preserved in #6787.

Includes start/stop, status changes, guardrail failure, failed standard result queries, ending-soon/stale reminders, metric regressions, bandit allocation changes, and holdout events. Existing no-data warnings keep their original event name. Stops report their result and any temporary rollout without claiming an undeployed variation shipped. Bandit alerts follow persistence; new notification failures do not fail completed lifecycle mutations. Independent alert markers use atomic updates.

Time-based reminders currently run with scheduled result refreshes. New events may add messages for subscribers selecting all events. No digest/coalescing or AI functionality is included.

Validation: backend and frontend typechecks; 7 focused suites / 49 tests (including actual PNG renders, reordered variations, immutable event data, legacy fallback and alert producers); visual review of eight summary cards; ESLint/Prettier; OpenAPI/event documentation generation and commit hooks.
