### PR TITLE
fix(api): require run-experiments permission for payload-affecting experiment updates

### DIFF
--- a/packages/back-end/src/api/experiments/updateExperiment.ts
+++ b/packages/back-end/src/api/experiments/updateExperiment.ts
@@ -10,6 +10,7 @@ import {
   getExperimentByTrackingKey,
 } from "back-end/src/models/ExperimentModel";
 import {
+  assertCanRunExperimentChanges,
   normalizeStatusUpdateScheduleChanges,
   toExperimentApiInterface,
   getExperimentAttributeScopeProjects,
@@ -340,6 +341,12 @@ export const updateExperiment = createApiRequestHandler(
   );
 
   normalizeStatusUpdateScheduleChanges(experiment, changes);
+
+  // canUpdateExperiment (above) is the analysis-level check. Fields that reach
+  // SDK payloads additionally need run-experiments permission in the
+  // environments the experiment affects — the same rule, on the same fields,
+  // as the dashboard's POST /experiment/:id.
+  await assertCanRunExperimentChanges(req.context, experiment, changes);
 
   // Same validation as PUT /schedule, against the stored schedule and the
   // post-update variations/metrics.

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -53,6 +53,7 @@ import {
 import {
   _getSnapshots,
   applyVariationWeightsToLatestPhase,
+  assertCanRunExperimentChanges,
   createSnapshotAnalyses,
   createSnapshotAnalysis,
   determineNextBanditSchedule,
@@ -2134,50 +2135,7 @@ export async function postExperiment(
     }
   }
 
-  // Only some fields affect production SDK payloads
-  const needsRunExperimentsPermission = (
-    [
-      "phases",
-      "variations",
-      "project",
-      "name",
-      "trackingKey",
-      "archived",
-      "status",
-      "releasedVariationId",
-      "excludeFromPayload",
-      "type",
-      "banditStage",
-      "banditStageDateStarted",
-      "banditScheduleValue",
-      "banditScheduleUnit",
-      "banditBurnInValue",
-      "banditBurnInUnit",
-    ] as (keyof ExperimentInterfaceStringDates)[]
-  ).some((key) => key in changes);
-  if (needsRunExperimentsPermission) {
-    const linkedFeatureIds = experiment.linkedFeatures || [];
-
-    const linkedFeatures = await getFeaturesByIds(context, linkedFeatureIds);
-
-    const envs = getAffectedEnvsForExperiment({
-      experiment,
-      orgEnvironments: context.org.settings?.environments || [],
-      linkedFeatures,
-    });
-    if (envs.length > 0) {
-      const projects = [experiment.project || undefined];
-      if ("project" in changes) {
-        projects.push(changes.project || undefined);
-      }
-      // check user's permission on existing experiment project and the updated project, if changed
-      projects.forEach((project) => {
-        if (!context.permissions.canRunExperiment({ project }, envs)) {
-          context.permissions.throwPermissionError();
-        }
-      });
-    }
-  }
+  await assertCanRunExperimentChanges(context, experiment, changes);
 
   await validateExperimentChange({ context, experiment, changes });
   const updated = await updateExperimentAndSync({

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -25,6 +25,7 @@ import {
   findAnalysisComputeFailure,
   fillRevisionFromFeature,
   generateVariationId,
+  getAffectedEnvsForExperiment,
   getExperimentAttributeScopeProjectIds,
   getFeatureAttributeScopeWithDrafts,
   getMatchingRules,
@@ -2353,6 +2354,61 @@ export function fillEmptyVariationKeys(
       v.key = String(nextKey);
       usedKeys.add(v.key);
       nextKey++;
+    }
+  }
+}
+
+// Only some experiment fields reach SDK payloads. A change that touches any of
+// them needs run-experiments permission in the environments the experiment
+// affects (on both the current project and, if it moves, the new one); other
+// edits need only the update permission the caller has already been checked
+// for. Shared by the dashboard POST /experiment/:id and the REST
+// POST /api/v1/experiments/:id so the two agree on which fields count.
+const PAYLOAD_AFFECTING_EXPERIMENT_FIELDS: (keyof ExperimentInterface)[] = [
+  "phases",
+  "variations",
+  "project",
+  "name",
+  "trackingKey",
+  "archived",
+  "status",
+  "releasedVariationId",
+  "excludeFromPayload",
+  "type",
+  "banditStage",
+  "banditStageDateStarted",
+  "banditScheduleValue",
+  "banditScheduleUnit",
+  "banditBurnInValue",
+  "banditBurnInUnit",
+];
+export async function assertCanRunExperimentChanges(
+  context: ReqContext | ApiReqContext,
+  experiment: ExperimentInterface,
+  changes: Changeset,
+): Promise<void> {
+  const needsRunExperimentsPermission =
+    PAYLOAD_AFFECTING_EXPERIMENT_FIELDS.some((key) => key in changes);
+  if (!needsRunExperimentsPermission) return;
+
+  const linkedFeatureIds = experiment.linkedFeatures || [];
+  const linkedFeatures = await getFeaturesByIds(context, linkedFeatureIds);
+
+  const envs = getAffectedEnvsForExperiment({
+    experiment,
+    orgEnvironments: context.org.settings?.environments || [],
+    linkedFeatures,
+  });
+  if (envs.length > 0) {
+    const projects = [experiment.project || undefined];
+    if ("project" in changes) {
+      projects.push(changes.project || undefined);
+    }
+    // check user's permission on existing experiment project and the updated project, if changed
+    for (const project of projects) {
+      if (!context.permissions.canRunExperiment({ project }, envs)) {
+        context.permissions.throwPermissionError();
+      }
     }
   }
 }

--- a/packages/back-end/test/api/experiments.test.ts
+++ b/packages/back-end/test/api/experiments.test.ts
@@ -1,4 +1,5 @@
 import request from "supertest";
+import { PermissionError } from "shared/util";
 import {
   getExperimentById,
   getExperimentByTrackingKey,
@@ -1209,6 +1210,59 @@ describe("experiments API", () => {
       expect(res.status).toBe(200);
       expect(res.body).toHaveProperty("experiment");
       expect(res.body.experiment.name).toBe("Updated Experiment Name");
+    });
+
+    describe("run-experiments permission for payload-affecting fields", () => {
+      // An experiment that reaches every environment (visual changesets are
+      // not scoped to linked-feature environments), and a caller who may
+      // update the experiment's analysis but may not run experiments.
+      const liveExperiment = { ...experiment, hasVisualChangesets: true };
+      beforeEach(() => {
+        updateReqContext({
+          org: { ...org, settings: { environments: [{ id: "production" }] } },
+          permissions: {
+            canUpdateExperiment: () => true,
+            canRunExperiment: () => false,
+            throwPermissionError: () => {
+              throw new PermissionError("permission denied");
+            },
+          },
+        });
+        (getExperimentById as jest.Mock).mockResolvedValue(liveExperiment);
+        (updateExperiment as jest.Mock).mockImplementation(
+          ({ experiment: exp, changes }) => ({ ...exp, ...changes }),
+        );
+      });
+
+      it("refuses a phases change without run permission", async () => {
+        const res = await request(app)
+          .post("/api/v1/experiments/exp_123")
+          .send({
+            phases: [{ name: "Main", dateStarted: "2026-02-01T00:00:00.000Z" }],
+          })
+          .set("Authorization", "Bearer foo");
+
+        expect(res.status).toBe(403);
+        expect(updateExperiment).not.toHaveBeenCalled();
+      });
+
+      it("allows an analysis-only change without run permission", async () => {
+        const res = await request(app)
+          .post("/api/v1/experiments/exp_123")
+          .send({ description: "Updated description" })
+          .set("Authorization", "Bearer foo");
+
+        expect(res.status).toBe(200);
+      });
+
+      it("asks for run permission whenever a payload field is sent, as the dashboard route does", async () => {
+        const res = await request(app)
+          .post("/api/v1/experiments/exp_123")
+          .send({ name: liveExperiment.name, description: "Updated" })
+          .set("Authorization", "Bearer foo");
+
+        expect(res.status).toBe(403);
+      });
     });
 
     it("allows update when required custom fields are missing and payload omits customFields", async () => {


### PR DESCRIPTION
### Features and Changes

The dashboard's `POST /experiment/:id` (`postExperiment` in `controllers/experiments.ts`) has long required `canRunExperiment` — in the environments the experiment affects, on the current project and the destination project if it moves — whenever a change touches one of the fields that reach SDK payloads:

```
phases, variations, project, name, trackingKey, archived, status, releasedVariationId,
excludeFromPayload, type, banditStage, banditStageDateStarted, banditSchedule*, banditBurnIn*
```

The REST `POST /api/v1/experiments/{id}` (`api/experiments/updateExperiment.ts`) accepts the same fields but only checked `canUpdateExperiment`, which is the analysis-level permission (`createAnalyses`). So an API key whose role can edit analyses but not run experiments (e.g. the built-in `analyst` role) could change a running experiment's coverage, traffic split or targeting, or stop it, through the API, while the dashboard refuses the same user.

This moves that block, unchanged (same field list, same environment/project resolution), into `assertCanRunExperimentChanges(context, experiment, changes)` in `services/experiments.ts`; `postExperiment` calls it exactly where the inline block was, and the REST handler now calls it too, right after the request body is mapped to a changeset. The semantics are deliberately identical to the dashboard's: presence-based, i.e. a request that *includes* one of those fields for an experiment that reaches an environment needs run permission there, even if the value equals what is stored. I first tried exempting unchanged values, but a round-tripped `phases` / `variations` array never compares equal to the stored one after mapping (alias keys such as `trafficSplit` / `targetingCondition` ride along), so the exemption would only have worked for scalars and I preferred one predictable rule over a partial one. If you'd like a normalised "did it really change" comparison I'm happy to add it in the helper so both routes get it.

Behaviour change to be aware of: API keys or tokens whose role can update experiments but not run them (e.g. `analyst`, or an env-limited key outside the experiment's environments) will now get `403` on `POST /api/v1/experiments/{id}` bodies that carry any of the listed fields for a live experiment — including a whole-object echo. Analysis-only bodies are unaffected. One pre-existing quirk carries over from the dashboard: for a *draft* multi-armed bandit the payload mapper injects bandit-stage fields on every update, so those updates ask for run permission too.

Deliberately not in this PR: the REST update still writes `status` / `releasedVariationId` directly rather than through the start/stop services; `PUT /api/v1/experiments/{id}/schedule` can stage a scheduled stop under the same analysis-level permission; and `POST /api/v1/visual-editor/rename-experiment` writes `name` without this check. Those looked like separate conversations; happy to follow up on any of them.

### Dependencies

None.

### Testing

- `test/api/experiments.test.ts`: new cases under "run-experiments permission for payload-affecting fields" with `canRunExperiment: () => false` on an experiment that reaches an environment — a `phases` change → `403` and `updateExperiment` not called; a `description`-only change → `200`; a body that includes `name` (even unchanged) → `403`, matching the dashboard. Against current `main` the `403` cases fail (`Received: 200`). All 90 cases in the file pass.
- Driven end to end on a local back-end: a running experiment (`hasVisualChangesets: true`, two variations, one phase at coverage 1) and an API key with the built-in `analyst` role.
  - On `main`, with the analyst key: `POST /api/v1/experiments/{id}` with `phases:[{..., coverage: 0.05, trafficSplit: [...]}]` → `200`, stored coverage `0.05`; `{"status":"stopped","releasedVariationId":"var_b"}` → `200`, experiment stopped.
  - With this branch, same key: both → `403 "You do not have permission to perform this action"`; `{"description": "..."}` → `200`. With an admin key the phases change → `200`.
- `tsc --noEmit` (back-end), eslint and prettier clean on the changed files.

### Screenshots

N/A (no UI change).
